### PR TITLE
Link enrollment to application in workshop view

### DIFF
--- a/apps/src/code-studio/pd/workshop_dashboard/components/workshop_enrollment_school_info.jsx
+++ b/apps/src/code-studio/pd/workshop_dashboard/components/workshop_enrollment_school_info.jsx
@@ -149,7 +149,7 @@ export class WorkshopEnrollmentSchoolInfo extends React.Component {
 
     // Note: These paths are defined in ApplicationDashboard component
     let path = course === CSD ? 'csd_teachers' : 'csp_teachers';
-    return `https://studio.code.org/pd/application_dashboard/${path}/${application_id}`;
+    return `/pd/application_dashboard/${path}/${application_id}`;
   }
 
   renderSelectCell(enrollment) {
@@ -208,7 +208,7 @@ export class WorkshopEnrollmentSchoolInfo extends React.Component {
             {application_url && (
               <p>
                 <a href={application_url} target="_blank">
-                  Application
+                  View Application
                 </a>
               </p>
             )}

--- a/apps/src/code-studio/pd/workshop_dashboard/components/workshop_enrollment_school_info.jsx
+++ b/apps/src/code-studio/pd/workshop_dashboard/components/workshop_enrollment_school_info.jsx
@@ -187,7 +187,9 @@ export class WorkshopEnrollmentSchoolInfo extends React.Component {
           <td>{i + 1}</td>
           <td>{enrollment.first_name}</td>
           <td>{enrollment.last_name}</td>
-          <td>{enrollment.email}</td>
+          <td>
+            {enrollment.email} {enrollment.application_id}
+          </td>
           <td>{enrollment.district_name}</td>
           <td>{enrollment.school}</td>
           {this.props.workshopCourse === CSF && (

--- a/apps/src/code-studio/pd/workshop_dashboard/components/workshop_enrollment_school_info.jsx
+++ b/apps/src/code-studio/pd/workshop_dashboard/components/workshop_enrollment_school_info.jsx
@@ -1,7 +1,7 @@
 import PropTypes from 'prop-types';
 import React from 'react';
 import {connect} from 'react-redux';
-import {Table} from 'react-bootstrap';
+import {Button, Table} from 'react-bootstrap';
 import ConfirmationDialog from '../../components/confirmation_dialog';
 import {enrollmentShape} from '../types';
 import {workshopEnrollmentStyles as styles} from '../workshop_enrollment_styles';
@@ -207,9 +207,9 @@ export class WorkshopEnrollmentSchoolInfo extends React.Component {
             {enrollment.email}
             {application_url && (
               <p>
-                <a href={application_url} target="_blank">
+                <Button bsSize="xsmall" href={application_url} target="_blank">
                   View Application
-                </a>
+                </Button>
               </p>
             )}
           </td>

--- a/apps/src/code-studio/pd/workshop_dashboard/components/workshop_enrollment_school_info.jsx
+++ b/apps/src/code-studio/pd/workshop_dashboard/components/workshop_enrollment_school_info.jsx
@@ -13,6 +13,7 @@ import {
   SubjectNames,
   CourseKeyMap
 } from '@cdo/apps/generated/pd/sharedWorkshopConstants';
+import {CSD, CSP} from '../../application/ApplicationConstants';
 
 const CSF = 'CS Fundamentals';
 const DEEP_DIVE = SubjectNames.SUBJECT_CSF_201;
@@ -141,6 +142,16 @@ export class WorkshopEnrollmentSchoolInfo extends React.Component {
     }
   }
 
+  getApplicationURL(application_id, course) {
+    if (!application_id || ![CSD, CSP].includes(course)) {
+      return null;
+    }
+
+    // Note: These paths are defined in ApplicationDashboard component
+    let path = course === CSD ? 'csd_teachers' : 'csp_teachers';
+    return `https://studio.code.org/pd/application_dashboard/${path}/${application_id}`;
+  }
+
   renderSelectCell(enrollment) {
     const checkBoxClass =
       this.props.selectedEnrollments.findIndex(e => e.id === enrollment.id) >= 0
@@ -179,6 +190,11 @@ export class WorkshopEnrollmentSchoolInfo extends React.Component {
         );
       }
 
+      let application_url = this.getApplicationURL(
+        enrollment.application_id,
+        this.props.workshopCourse
+      );
+
       return (
         <tr key={i}>
           {deleteCell}
@@ -188,7 +204,14 @@ export class WorkshopEnrollmentSchoolInfo extends React.Component {
           <td>{enrollment.first_name}</td>
           <td>{enrollment.last_name}</td>
           <td>
-            {enrollment.email} {enrollment.application_id}
+            {enrollment.email}
+            {application_url && (
+              <p>
+                <a href={application_url} target="_blank">
+                  Application
+                </a>
+              </p>
+            )}
           </td>
           <td>{enrollment.district_name}</td>
           <td>{enrollment.school}</td>

--- a/dashboard/app/models/pd/enrollment.rb
+++ b/dashboard/app/models/pd/enrollment.rb
@@ -302,6 +302,22 @@ class Pd::Enrollment < ActiveRecord::Base
       FACILITATOR_APPLICATION_CLASS.where(user_id: user_id).first&.status == 'accepted'
   end
 
+  def application_id
+    find_application_id(user_id, pd_workshop_id)
+  end
+
+  # Finds the application an user used for a workshop.
+  # Assumes that at most one application like that exists.
+  # @param [Integer] user_id
+  # @param [Integer] workshop_id
+  # @return [Integer, nil] application id or nil if cannot find any application
+  def find_application_id(user_id, workshop_id)
+    Pd::Application::ApplicationBase.where(user_id: user_id).each do |application|
+      return application.id if application.try(:pd_workshop_id) == workshop_id
+    end
+    nil
+  end
+
   # Removes the name and email information stored within this Pd::Enrollment.
   def clear_data
     write_attribute :name, nil

--- a/dashboard/app/serializers/api/v1/pd/workshop_enrollment_serializer.rb
+++ b/dashboard/app/serializers/api/v1/pd/workshop_enrollment_serializer.rb
@@ -1,5 +1,5 @@
 class Api::V1::Pd::WorkshopEnrollmentSerializer < ActiveModel::Serializer
-  attributes :id, :first_name, :last_name, :email, :district_name, :school, :role,
+  attributes :id, :first_name, :last_name, :email, :application_id, :district_name, :school, :role,
     :grades_teaching, :attended_csf_intro_workshop, :csf_course_experience,
     :csf_courses_planned, :csf_has_physical_curriculum_guide, :user_id, :attended,
     :pre_workshop_survey, :previous_courses, :replace_existing, :attendances,

--- a/dashboard/test/models/pd/enrollment_test.rb
+++ b/dashboard/test/models/pd/enrollment_test.rb
@@ -612,4 +612,18 @@ class Pd::EnrollmentTest < ActiveSupport::TestCase
     # initially creates scholarship info with YES_CDO status
     assert_equal enrollment.scholarship_status, Pd::ScholarshipInfoConstants::YES_CDO
   end
+
+  test 'find matching application for an enrollment' do
+    workshop = create :workshop
+    teacher = create :teacher
+    enrollment = create :pd_enrollment, user: teacher, workshop: workshop
+    application = create :pd_teacher2021_application, user: teacher
+
+    assert_nil enrollment.application_id
+
+    application.update(pd_workshop_id: workshop.id)
+
+    # Can only link an enrollment to an application when the application is assigned to the same workshop
+    assert_equal application.id, enrollment.application_id
+  end
 end

--- a/dashboard/test/serializers/api/v1/pd/workshop_enrollment_serializer_test.rb
+++ b/dashboard/test/serializers/api/v1/pd/workshop_enrollment_serializer_test.rb
@@ -7,7 +7,7 @@ class Api::V1::Pd::WorkshopEnrollmentSerializerTest < ::ActionController::TestCa
   test 'serialized workshop enrollment has expected attributes' do
     enrollment = create :pd_enrollment
     expected_attributes = [
-      :id, :first_name, :last_name, :email, :district_name, :school, :role,
+      :id, :first_name, :last_name, :email, :application_id, :district_name, :school, :role,
       :grades_teaching, :attended_csf_intro_workshop, :csf_course_experience,
       :csf_courses_planned, :csf_has_physical_curriculum_guide, :user_id, :attended,
       :pre_workshop_survey, :previous_courses, :replace_existing, :attendances,


### PR DESCRIPTION
In the workshop view, add links from enrollments to the corresponding applications. This feature only works for CSD and CSP workshops. (CSF workshop doesn't require applications.)

**Before**
<img width="715" alt="Screen Shot 2020-03-13 at 12 11 33 AM" src="https://user-images.githubusercontent.com/46507039/76599434-41e23c00-64c2-11ea-81c6-777918fb3e3d.png">

**After**
<img width="698" alt="Screen Shot 2020-03-13 at 12 40 42 PM" src="https://user-images.githubusercontent.com/46507039/76654299-e9458a00-6527-11ea-8927-fc58746c6c0a.png">



# Links
- [PLC-747](https://codedotorg.atlassian.net/browse/PLC-747)
- [Teacher application spec](https://docs.google.com/document/d/1ywjPNIOmYCitrgap0WUqAY_wiPWzdZKmJ06nAhZ89OU/edit#)

# Testing story
- Unit tested
- Manually tested
  ```ruby
  include FactoryGirl::Syntax::Methods
  csd = create :csd_academic_year_workshop
  csp = create :csp_summer_workshop
  u = create :teacher
  csda = create :pd_teacher2021_application, user: u, pd_workshop_id: csd.id
  cspa = create :pd_teacher1920_application, user: u, pd_workshop_id: csp.id

  csde = create :pd_enrollment, user: u, workshop: csd
  cspe = create :pd_enrollment, user: u, workshop: csp

  # Then go to these pages to verify links show up correctly
  "http://localhost-studio.code.org:3000/pd/workshop_dashboard/workshops/#{csd.id}"
  "http://localhost-studio.code.org:3000/pd/workshop_dashboard/workshops/#{csp.id}"
   ```

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
