### PR TITLE
Standards: Fix bugs when switch between courses

### DIFF
--- a/apps/src/templates/sectionProgress/SectionProgress.jsx
+++ b/apps/src/templates/sectionProgress/SectionProgress.jsx
@@ -85,17 +85,6 @@ class SectionProgress extends Component {
     this.props.loadScript(this.props.scriptId, this.props.section.id);
   }
 
-  componentDidUpdate() {
-    // Check if we are on a script that does NOT have standards associations and
-    // currentView is Standards. If so re-set currentView to Summary since
-    // Standards doesn't apply.
-    const hasStandards =
-      this.props.scriptData && this.props.scriptData.hasStandards;
-    if (this.props.currentView === ViewType.STANDARDS && !hasStandards) {
-      this.props.setCurrentView(ViewType.SUMMARY);
-    }
-  }
-
   onChangeScript = scriptId => {
     this.props.setScriptId(scriptId);
     this.props.loadScript(scriptId, this.props.section.id);
@@ -211,7 +200,8 @@ class SectionProgress extends Component {
           )}
         </div>
 
-        <ProgressViewHeader />
+        {levelDataInitialized && <ProgressViewHeader />}
+
         <div style={{clear: 'both'}}>
           {!levelDataInitialized && (
             <FontAwesome
@@ -231,15 +221,17 @@ class SectionProgress extends Component {
             </div>
           )}
           {levelDataInitialized && this.renderTooltips()}
-          {experiments.isEnabled(experiments.STANDARDS_REPORT) && (
-            <div id="uitest-standards-view" style={standardsStyle}>
-              <StandardsView
-                showStandardsIntroDialog={
-                  currentView === ViewType.STANDARDS && showStandardsIntroDialog
-                }
-              />
-            </div>
-          )}
+          {levelDataInitialized &&
+            experiments.isEnabled(experiments.STANDARDS_REPORT) && (
+              <div id="uitest-standards-view" style={standardsStyle}>
+                <StandardsView
+                  showStandardsIntroDialog={
+                    currentView === ViewType.STANDARDS &&
+                    showStandardsIntroDialog
+                  }
+                />
+              </div>
+            )}
         </div>
       </div>
     );

--- a/apps/src/templates/sectionProgress/sectionProgressRedux.js
+++ b/apps/src/templates/sectionProgress/sectionProgressRedux.js
@@ -372,6 +372,12 @@ export const loadScript = (scriptId, sectionId) => {
           dispatch(fetchStandardsCoveredForScript(scriptId));
           dispatch(fetchStudentLevelScores(scriptId, sectionId));
         }
+        if (
+          state.currentView === ViewType.STANDARDS &&
+          !scriptData.hasStandards
+        ) {
+          dispatch(setCurrentView(ViewType.SUMMARY));
+        }
       });
 
     const numStudents = sectionData.students.length;


### PR DESCRIPTION
Fixes two problems from bug bash.

1. If you switch between two courses that have standards and are in the standards tab you will stay in the standards tab.
2. If you switch away from a course and back to it the standards view would not load standards data. We now always load the data for the standards tab
    - Future work: To save all the standards data in a way that will allow us to to not reload all the data if we already loaded it in the past.

I also just cleaned up the sectionProgressRedux doc a little to match the format we use in other similar files.

## Links

<!--
  Any relevant links to external resources; ie, specification documents, jira
  items, related PRs, honeybadger errors, etc
-->

- [bug bash](https://docs.google.com/document/d/11itS_kPLZSOvfndY8Ils7dhqHo2JyvSU3KhfDO1_CKs/edit)
- [jira LP 1303](https://codedotorg.atlassian.net/browse/LP-1303)
- [jira LP 1304](https://codedotorg.atlassian.net/browse/LP-1304)
