### PR TITLE
Remove obsolete Reporting Replica Lag alarm [ci skip]

### DIFF
--- a/aws/cloudformation/data.yml.erb
+++ b/aws/cloudformation/data.yml.erb
@@ -306,25 +306,6 @@ Resources:
     Properties:
       AliasName: !Sub "alias/snapshot-${AWS::StackName}"
       TargetKeyId: !Ref DBSnapshotKey
-  # The production reporting Aurora cluster replicates via MySQL binlog from the production Aurora cluster.
-  ReportingBinLogReplicaLagAlarm:
-    Type: AWS::CloudWatch::Alarm
-    Properties:
-      AlarmName: !Sub "${AWS::StackName}-ReportingBinLogReplicaLag"
-      AlarmDescription: Alarms when the Aurora Reporting Cluster binlog replica lag exceeds 900 seconds for 12 datapoints.
-      AlarmActions:
-        - !Sub "arn:aws:sns:${AWS::Region}:${AWS::AccountId}:CDO-LowPriority"
-      Dimensions:
-        - Name: DBClusterIdentifier
-          Value: !Ref ReportingCluster
-      MetricName: AuroraBinlogReplicaLag
-      Namespace: AWS/RDS
-      Statistic: Average
-      ComparisonOperator: GreaterThanThreshold
-      Threshold: 600
-      Period: 3600 # 1 hour
-      EvaluationPeriods: 12
-      TreatMissingData: breaching
 # ELB Access Logs tables defined in Glue Data Catalog.
   ELBLogsDatabase:
     Type: AWS::Glue::Database


### PR DESCRIPTION
This alarm is useless / has no data since we got rid of our reporting replica.

https://console.aws.amazon.com/cloudwatch/home?region=us-east-1#alarmsV2:alarm/DATA-production-ReportingBinLogReplicaLag?~(search~'data)

<!-- ### Background -->
<!-- ### Privacy -->
<!-- ### Security -->
<!-- ### Caching -->
<!-- ### Deployment strategy -->
<!-- ### Future work -->

## Testing story

```
Winters-MBP:code-dot-org winterdong$ bundle exec rake stack:data:validate RAILS_ENV=production
...
Listing changes to existing stack `DATA-production`:
Remove ReportingBinLogReplicaLagAlarm [AWS::CloudWatch::Alarm] 
```

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
