### PR TITLE
Add author name for project libraries from classmates

### DIFF
--- a/apps/src/code-studio/components/libraries/LibraryManagerDialog.jsx
+++ b/apps/src/code-studio/components/libraries/LibraryManagerDialog.jsx
@@ -95,10 +95,22 @@ export class LibraryManagerDialog extends React.Component {
 
   onOpen = () => {
     let libraryClient = new LibraryClientApi();
-    this.setState({libraries: dashboard.project.getProjectLibraries() || []});
     libraryClient.getClassLibraries(
-      libraries => {
-        this.setState({classLibraries: libraries});
+      classLibraries => {
+        // Map userName from class libraries to project libraries.
+        // We only want users to see the author name for libraries from their classmates.
+        const projectLibraries = dashboard.project.getProjectLibraries() || [];
+        projectLibraries.forEach(projectLibrary => {
+          const classLibrary = classLibraries.find(
+            library => library.channel === projectLibrary.channelId
+          );
+          projectLibrary.userName = classLibrary && classLibrary.userName;
+        });
+
+        this.setState({
+          libraries: projectLibraries,
+          classLibraries
+        });
       },
       error => {
         console.log('error: ' + error);

--- a/apps/src/code-studio/components/libraries/LibraryManagerDialog.jsx
+++ b/apps/src/code-studio/components/libraries/LibraryManagerDialog.jsx
@@ -70,6 +70,26 @@ const styles = {
   }
 };
 
+// Map userName from class libraries to project libraries so the author is displayed in the UI.
+// We only want users to see the author name for libraries from their classmates.
+export const mapUserNameToProjectLibraries = (
+  projectLibraries,
+  classLibraries
+) => {
+  if (classLibraries.length === 0) {
+    return projectLibraries;
+  }
+
+  projectLibraries.forEach(projectLibrary => {
+    const classLibrary = classLibraries.find(
+      library => library.channel === projectLibrary.channelId
+    );
+    projectLibrary.userName = classLibrary && classLibrary.userName;
+  });
+
+  return projectLibraries;
+};
+
 export class LibraryManagerDialog extends React.Component {
   static propTypes = {
     onClose: PropTypes.func.isRequired,
@@ -98,38 +118,20 @@ export class LibraryManagerDialog extends React.Component {
 
     let libraryClient = new LibraryClientApi();
     libraryClient.getClassLibraries(
-      libraries => {
-        this.setState(
-          {classLibraries: libraries || []},
-          this.mapUserNameToProjectLibraries
+      classLibraries => {
+        const projectLibraries = mapUserNameToProjectLibraries(
+          this.state.libraries,
+          classLibraries
         );
+        this.setState({
+          classLibraries,
+          libraries: projectLibraries
+        });
       },
       error => {
         console.log('error: ' + error);
       }
     );
-  };
-
-  // Map userName from class libraries to project libraries so the author is displayed in the UI.
-  // We only want users to see the author name for libraries from their classmates.
-  mapUserNameToProjectLibraries = () => {
-    const {libraries, classLibraries} = this.state;
-
-    if (classLibraries.length === 0) {
-      return;
-    }
-
-    const projectLibraries = [
-      ...(libraries || dashboard.project.getProjectLibraries() || [])
-    ];
-    projectLibraries.forEach(projectLibrary => {
-      const classLibrary = classLibraries.find(
-        library => library.channel === projectLibrary.channelId
-      );
-      projectLibrary.userName = classLibrary && classLibrary.userName;
-    });
-
-    this.setState({libraries: projectLibraries});
   };
 
   setLibraryToImport = event => {

--- a/apps/src/code-studio/components/libraries/LibraryManagerDialog.jsx
+++ b/apps/src/code-studio/components/libraries/LibraryManagerDialog.jsx
@@ -94,28 +94,42 @@ export class LibraryManagerDialog extends React.Component {
   }
 
   onOpen = () => {
+    this.setState({libraries: dashboard.project.getProjectLibraries() || []});
+
     let libraryClient = new LibraryClientApi();
     libraryClient.getClassLibraries(
-      classLibraries => {
-        // Map userName from class libraries to project libraries.
-        // We only want users to see the author name for libraries from their classmates.
-        const projectLibraries = dashboard.project.getProjectLibraries() || [];
-        projectLibraries.forEach(projectLibrary => {
-          const classLibrary = classLibraries.find(
-            library => library.channel === projectLibrary.channelId
-          );
-          projectLibrary.userName = classLibrary && classLibrary.userName;
-        });
-
-        this.setState({
-          libraries: projectLibraries,
-          classLibraries
-        });
+      libraries => {
+        this.setState(
+          {classLibraries: libraries || []},
+          this.mapUserNameToProjectLibraries
+        );
       },
       error => {
         console.log('error: ' + error);
       }
     );
+  };
+
+  // Map userName from class libraries to project libraries so the author is displayed in the UI.
+  // We only want users to see the author name for libraries from their classmates.
+  mapUserNameToProjectLibraries = () => {
+    const {libraries, classLibraries} = this.state;
+
+    if (classLibraries.length === 0) {
+      return;
+    }
+
+    const projectLibraries = [
+      ...(libraries || dashboard.project.getProjectLibraries() || [])
+    ];
+    projectLibraries.forEach(projectLibrary => {
+      const classLibrary = classLibraries.find(
+        library => library.channel === projectLibrary.channelId
+      );
+      projectLibrary.userName = classLibrary && classLibrary.userName;
+    });
+
+    this.setState({libraries: projectLibraries});
   };
 
   setLibraryToImport = event => {

--- a/apps/test/unit/code-studio/components/libraries/libraryManagerDialogTest.js
+++ b/apps/test/unit/code-studio/components/libraries/libraryManagerDialogTest.js
@@ -1,7 +1,9 @@
 import {expect} from '../../../../util/reconfiguredChai';
 import React from 'react';
 import {shallow} from 'enzyme';
-import LibraryManagerDialog from '@cdo/apps/code-studio/components/libraries/LibraryManagerDialog';
+import LibraryManagerDialog, {
+  mapUserNameToProjectLibraries
+} from '@cdo/apps/code-studio/components/libraries/LibraryManagerDialog';
 import LibraryListItem from '@cdo/apps/code-studio/components/libraries/LibraryListItem';
 import LibraryClientApi from '@cdo/apps/code-studio/components/libraries/LibraryClientApi';
 import libraryParser from '@cdo/apps/code-studio/components/libraries/libraryParser';
@@ -208,6 +210,21 @@ describe('LibraryManagerDialog', () => {
       expect(setProjectLibraries.withArgs([{name: 'second'}]).calledOnce).to.be
         .true;
       window.dashboard.project.setProjectLibraries.restore();
+    });
+  });
+
+  describe('mapUserNameToProjectLibraries', () => {
+    it('maps userName from classLibraries to project libraries', () => {
+      const projectLibraries = [{channelId: '123456'}, {channelId: '654321'}];
+      const classLibraries = [{channel: '123456', userName: 'Library Author'}];
+
+      const mappedProjectLibraries = mapUserNameToProjectLibraries(
+        projectLibraries,
+        classLibraries
+      );
+
+      expect(mappedProjectLibraries[0].userName).to.equal('Library Author');
+      expect(mappedProjectLibraries[1].userName).to.be.undefined;
     });
   });
 });


### PR DESCRIPTION
Adds a `mapUserNameToProjectLibraries` helper to map all `userName` fields in `classLibraries` to `projectLibraries`. We want to display the library author name for imported projects (the "Manage libraries in this project" section) that are from your classmates.

Below, "Dev2Library" is from a classmate, whereas "RandoLibrary" is from someone who is not in any of your sections.
![Screen Shot 2020-03-13 at 5 37 51 PM](https://user-images.githubusercontent.com/9812299/76671056-705b2800-6551-11ea-85c2-642857612752.png)


## Links

- [STAR-967](https://codedotorg.atlassian.net/browse/STAR-967)

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
