### PR TITLE
Minecraft page: restore download link

### DIFF
--- a/pegasus/sites.v3/code.org/views/minecraft_2019.haml
+++ b/pegasus/sites.v3/code.org/views/minecraft_2019.haml
@@ -64,6 +64,11 @@
           %a{href: designer_link, target: '_blank'}
             %button= I18n.t(:minecraft_agent_button)
 
+%div{style: "clear: both; margin-bottom: 40px;"}
+%h3.responsive-padding
+  =I18n.t(:minecraft_no_internet)
+  %a{href: CDO.studio_url("/download/mc")}= I18n.t(:minecraft_download_adventurer)
+
 .clear
 %h2= I18n.t(:hoc2018_mc_educators)
 


### PR DESCRIPTION
This restores the download link to https://code.org/minecraft that was removed in https://github.com/code-dot-org/code-dot-org/pull/31586, with slightly updated styling.

### before

![Screenshot 2020-03-16 12 16 13](https://user-images.githubusercontent.com/2205926/76793009-78011380-6781-11ea-8f9e-d1a8b1114d1a.png)

### after

![Screenshot 2020-03-16 12 19 25](https://user-images.githubusercontent.com/2205926/76793017-7df6f480-6781-11ea-9c4d-350ec21ce48f.png)
