### PR TITLE
remove old TextRender implementation of yaml parsing

### DIFF
--- a/lib/cdo/yaml.rb
+++ b/lib/cdo/yaml.rb
@@ -1,6 +1,5 @@
 require 'yaml'
 require 'cdo/erb'
-require 'cdo/pegasus/text_render'
 
 module Cdo
   # Extend YAML with customizations.
@@ -9,16 +8,9 @@ module Cdo
       match = content.match(/\A\s*^(?<yaml>---\s*\n.*?\n?)^(---\s*$\n?)/m)
       return [{}, content] unless match
 
-      # Implement new, TextRender-less parsing behind a DCDO flag so we can
-      # verify it doesn't have any unexpected side effects before switching
-      # over entirely.
-      if DCDO.get('parse_yaml_header-manually', true)
-        yaml = match[:yaml]
-        yaml = ERB.new(yaml).result_with_hash(locals)
-        [YAML.safe_load(yaml), match.post_match]
-      else
-        [TextRender.yaml(match[:yaml], locals), match.post_match]
-      end
+      yaml = match[:yaml]
+      yaml = ERB.new(yaml).result_with_hash(locals)
+      [YAML.safe_load(yaml), match.post_match]
     end
 
     # Return +nil+ if file not found.


### PR DESCRIPTION
 after confirming that the new implementation doesn't break.

The current "deploy behind a flag" implementation is out and seems to be working; I'll give it a few days to confirm, then this should be super safe to merge.

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
