### PR TITLE
Standards: tooltips plugged & % students complete

### DIFF
--- a/apps/i18n/common/en_us.json
+++ b/apps/i18n/common/en_us.json
@@ -1129,6 +1129,7 @@
   "plLandingHeading": "My Professional Learning",
   "plLandingSubheading": "Submit your feedback",
   "plLandingStartSurvey": "Start survey",
+  "plugged": "Plugged",
   "pluggedLessonsNote": "*Online or ‘plugged’ lessons are automatically marked as complete on your behalf once 80% of your class has completed 60% of the available lesson.",
   "policyViolation": "This project contains information that cannot be shared with others. Please contact the app owner to fix the contents of their app.",
   "positionAbsoluteDown": "down",

--- a/apps/i18n/common/en_us.json
+++ b/apps/i18n/common/en_us.json
@@ -243,7 +243,7 @@
   "completed": "Completed",
   "completedLevels": "Completed Levels",
   "completedLessons": "Completed Lessons",
-  "completedStudentCount": "{numStudentsCompleted} of {numStudents} students completed",
+  "completedStudentCount": "{numStudentsCompleted} of {numStudents} students completed ({percentComplete} %)",
   "completedUnpluggedLessons": "Tell us which unplugged lessons* your class has completed",
   "completedWithoutRecommendedBlock": "Congratulations! You completed Puzzle {puzzleNumber}. (But you could use a different block for stronger code.)",
   "completionStatus": "Completion Status",

--- a/apps/src/templates/sectionProgress/standards/StandardDescriptionCell.jsx
+++ b/apps/src/templates/sectionProgress/standards/StandardDescriptionCell.jsx
@@ -61,6 +61,9 @@ class StandardDescriptionCell extends Component {
                 <div style={styles.tooltip}>
                   <div style={styles.tooltipLessonName}>{lesson.name}</div>
                   <div>
+                    {lesson.unplugged ? i18n.unplugged() : i18n.plugged()}
+                  </div>
+                  <div>
                     {lesson.completed ? i18n.completed() : i18n.notCompleted()}
                   </div>
                   <div>

--- a/apps/src/templates/sectionProgress/standards/StandardDescriptionCell.jsx
+++ b/apps/src/templates/sectionProgress/standards/StandardDescriptionCell.jsx
@@ -47,6 +47,8 @@ class StandardDescriptionCell extends Component {
   getLessonBoxes = () => {
     if (this.props.lessonsForStandardStatus) {
       return this.props.lessonsForStandardStatus.map((lesson, index) => {
+        const percentComplete =
+          Math.round(lesson.numStudentsCompleted / lesson.numStudents) * 100;
         return (
           <span key={lesson.name} style={styles.lessonBox}>
             {!this.props.isViewingReport && (
@@ -69,7 +71,8 @@ class StandardDescriptionCell extends Component {
                   <div>
                     {i18n.completedStudentCount({
                       numStudentsCompleted: lesson.numStudentsCompleted,
-                      numStudents: lesson.numStudents
+                      numStudents: lesson.numStudents,
+                      percentComplete: percentComplete
                     })}
                   </div>
                 </div>


### PR DESCRIPTION
[LP-1311](https://codedotorg.atlassian.net/browse/LP-1311)

Added two new pieces of information to the standards lesson box tooltips. 1.) whether the lesson is plugged or unplugged 2.) % of students who've completed the lesson, since we calculate completeness based on 80% of students in a section this gives teachers more information at a glance how close their section is to the threshold. 

<img width="348" alt="Screen Shot 2020-03-17 at 10 17 30 AM" src="https://user-images.githubusercontent.com/12300669/76883214-01275180-6839-11ea-80e5-c5fec7491cb7.png">

