### PR TITLE
Add facilitator id to pd_workshop_survey_foorm_submissions

### DIFF
--- a/dashboard/app/models/pd/workshop_survey_foorm_submission.rb
+++ b/dashboard/app/models/pd/workshop_survey_foorm_submission.rb
@@ -10,6 +10,7 @@
 #  day                 :integer
 #  created_at          :datetime         not null
 #  updated_at          :datetime         not null
+#  facilitator_id      :integer
 #
 # Indexes
 #

--- a/dashboard/db/migrate/20200317174030_add_facilitator_id_to_pd_workshop_survey_foorm_submissions.rb
+++ b/dashboard/db/migrate/20200317174030_add_facilitator_id_to_pd_workshop_survey_foorm_submissions.rb
@@ -1,0 +1,5 @@
+class AddFacilitatorIdToPdWorkshopSurveyFoormSubmissions < ActiveRecord::Migration[5.0]
+  def change
+    add_column :pd_workshop_survey_foorm_submissions, :facilitator_id, :integer
+  end
+end

--- a/dashboard/db/schema.rb
+++ b/dashboard/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20200310203427) do
+ActiveRecord::Schema.define(version: 20200317174030) do
 
   create_table "activities", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci" do |t|
     t.integer  "user_id"
@@ -997,6 +997,7 @@ ActiveRecord::Schema.define(version: 20200310203427) do
     t.integer  "day"
     t.datetime "created_at",          null: false
     t.datetime "updated_at",          null: false
+    t.integer  "facilitator_id"
     t.index ["foorm_submission_id"], name: "index_workshop_survey_foorm_submissions_on_foorm_id", unique: true, using: :btree
     t.index ["pd_session_id"], name: "index_pd_workshop_survey_foorm_submissions_on_pd_session_id", using: :btree
     t.index ["pd_workshop_id"], name: "index_pd_workshop_survey_foorm_submissions_on_pd_workshop_id", using: :btree


### PR DESCRIPTION
In order to do rollups on a per-facilitator basis (ex. get average response across all surveys for a facilitator) we need to add a facilitator id column to our metadata table. This column is optional, and will only be used for per-facilitator surveys.

<!-- ### Background -->
<!-- ### Privacy -->
<!-- ### Security -->
<!-- ### Caching -->
<!-- ### Deployment strategy -->
<!-- ### Future work -->


## Testing story
Validated that migration adds expected column and does not break existing functionality.

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
