### PR TITLE
Add fixes and end to end tests to ensure 'finish' button shows up on …

### DIFF
--- a/apps/style/common.scss
+++ b/apps/style/common.scss
@@ -460,25 +460,29 @@ html[dir='rtl'] div#visualizationResizeBar {
   }
 }
 
-@media screen and (min-width: 1101px) and (max-width: 1150px) {
+@media screen and (min-width: 1101px) and (max-width: 1150px),
+       screen and (min-height: 801px) and (max-height: 900px) {
   @include visualization-width(350px);
   @include studio-dpad-container-width(350px);
   @include karel-counter(20px, 1.2px);
 }
 
-@media screen and (min-width: 1051px) and (max-width: 1100px) {
+@media screen and (min-width: 1051px) and (max-width: 1100px),
+       screen and (min-height: 701px) and (max-height: 800px) {
   @include visualization-width(300px);
   @include studio-dpad-container-width(300px);
   @include karel-counter(24px, 1.4px);
 }
 
-@media screen and (min-width: 1001px) and (max-width: 1050px) {
+@media screen and (min-width: 1001px) and (max-width: 1050px),
+       screen and (min-height: 601px) and (max-height: 700px) {
   @include visualization-width(250px);
   @include studio-dpad-container-width(250px);
   @include karel-counter(28px, 1.6px);
 }
 
-@media screen and (max-width: 1000px) {
+@media screen and (max-width: 1000px),
+       screen and (max-height: 600px) {
   @include visualization-width(200px);
   @include studio-dpad-container-width(200px);
   @include karel-counter(32px, 2px);

--- a/dashboard/test/ui/features/star_labs/can_see_finish.feature
+++ b/dashboard/test/ui/features/star_labs/can_see_finish.feature
@@ -1,0 +1,47 @@
+Feature: Make sure we can see the finish button for all LEVEL TYPE levels on small screens
+
+  @no_mobile
+  Scenario: Can see finish button for free play "Dance Party", "Artist", "Bounce" on small screens
+    Given I create an authorized teacher-associated student named "Sally"
+    And I sign in as "Teacher_Sally" and go home
+
+    And I check that the blockly free play level for "Dance Party" shows the finish button for small screens
+    And I check that the blockly free play level for "Artist" shows the finish button for small screens
+    And I check that the blockly free play level for "Bounce" shows the finish button for small screens
+    And I check that the blockly free play level for "CS in Algebra" shows the finish button for small screens
+    And I check that the blockly free play level for "Flappy" shows the finish button for small screens
+    And I check that the blockly free play level for "Sprite Lab" shows the finish button for small screens
+
+    And I check that the droplet free play level for "Game Lab" shows the finish button for small screens
+
+    And I check that the minecraft free play level for "Minecraft Adventurer" shows the finish button for small screens
+
+    # The following levels currently do not render finish button for small screens.
+    # TODO: Fid this - https://codedotorg.atlassian.net/browse/LP-1318
+    #And I check that the minecraft free play level for "Minecraft Heroes Journey" shows the finish button for small screens
+    #And I check that the minecraft free play level for "Minecraft Designer" shows the finish button for small screens
+    #And I check that the droplet free play level for "App Lab" shows the finish button for small screens
+
+
+  @no_ie @no_safari @no_firefox @no_chrome
+  Scenario: Can see finish for free play levels on mobile
+    Given I create an authorized teacher-associated student named "Sally"
+    And I sign in as "Teacher_Sally" and go home
+
+    And I check that the blockly free play level for "Dance Party" shows the finish button for mobile screens
+    And I check that the blockly free play level for "Artist" shows the finish button for mobile screens
+    And I check that the blockly free play level for "CS in Algebra" shows the finish button for mobile screens
+    And I check that the blockly free play level for "Flappy" shows the finish button for mobile screens
+    And I check that the blockly free play level for "Sprite Lab" shows the finish button for mobile screens
+
+    And I check that the droplet free play level for "Game Lab" shows the finish button for mobile screens
+
+    And I check that the minecraft free play level for "Minecraft Adventurer" shows the finish button for mobile screens
+
+    # The following levels currently do not render finish button for iphone, but do on ipad
+    # TODO: Fid this - https://codedotorg.atlassian.net/browse/LP-1318
+    #And I check that the blockly free play level for "Bounce" shows the finish button for mobile screens
+    #And I check that the droplet free play level for "App Lab" shows the finish button for mobile screens
+    #And I check that the minecraft free play level for "Minecraft Heroes Journey" shows the finish button for mobile screens
+    #And I check that the minecraft free play level for "Minecraft Designer" shows the finish button for mobile screens
+

--- a/dashboard/test/ui/features/step_definitions/browser_control.rb
+++ b/dashboard/test/ui/features/step_definitions/browser_control.rb
@@ -1,0 +1,22 @@
+And(/^I change the browser window size to (\d+) by (\d+)$/) do |length, height| 
+  @browser.manage.window.resize_to(length, height)
+end
+
+# for explanation of js function, see
+# https://stackoverflow.com/questions/45243992/verification-of-element-in-viewport-in-selenium
+And(/^I check that selector "([^"]*)" is in the viewport$/) do |selector|
+  is_in_viewport = <<-JAVASCRIPT
+    var elem = $("#{selector}")[0],  //arguments[0],
+      box = elem.getBoundingClientRect(),
+      cx = box.left + box.width / 2,
+      cy = box.top + box.height / 2,
+      e = document.elementFromPoint(cx, cy);
+    for(; e; e = e.parentElement) {
+      if (e === elem)
+        return true;
+    }
+    return false;
+  JAVASCRIPT
+  wait_for_jquery
+  wait_until {@browser.execute_script(is_in_viewport) == true}
+end

--- a/dashboard/test/ui/features/step_definitions/check_finish_button.rb
+++ b/dashboard/test/ui/features/step_definitions/check_finish_button.rb
@@ -1,0 +1,41 @@
+# Helper steps for dance party levels
+free_play_level_urls = {
+  'blockly' => {
+     'Dance Party' => 'http://studio.code.org/s/dance/stage/1/puzzle/13?noautoplay=true',
+     'Artist' => 'http://studio.code.org/s/20-hour/stage/5/puzzle/10?noautoplay=true',
+     'Bounce' => 'http://studio.code.org/s/course3/stage/15/puzzle/10?noautoplay=true',
+     'CS in Algebra' => 'http://studio.code.org/s/algebra/stage/1/puzzle/2?noautoplay=true',
+     'Flappy' => 'http://studio.code.org/flappy/10?noautoplay=true',
+     'Sprite Lab' => 'http://studio.code.org/s/coursee-2018/stage/20/puzzle/9?noautoplay=true'
+  },
+  'droplet' => {
+    'App Lab' => 'http://studio.code.org/s/applab-intro/stage/1/puzzle/15?noautoplay=true',
+    'Game Lab' => 'http://studio.code.org/s/csd3-2019/stage/22/puzzle/12?noautoplay=true'
+  },
+  'minecraft' => {
+     'Minecraft Aquatic' => 'http://studio.code.org/s/aquatic/stage/1/puzzle/12?noautoplay=true',
+     'Minecraft Heroes Journey' => 'http://studio.code.org/s/hero/stage/1/puzzle/12?noautoplay=true',
+     'Minecraft Adventurer' => 'http://studio.code.org/s/mc/stage/1/puzzle/14?noautoplay=true',
+     'Minecraft Designer' => 'http://studio.code.org/s/minecraft/stage/1/puzzle/12?noautoplay=true'
+  }
+}
+
+When /^I check that the (blockly|droplet|minecraft) free play level for "([^"]*)" shows the finish button for (small|mobile) screens/i do |level_type, level_name, screen_type|
+  individual_steps <<-STEPS
+    And I set up the #{level_type} free play level for "#{level_name}"
+    #{screen_type == 'small' ? 'And I change the browser window size to 1366 by 600' : ''}
+    #{level_type == 'minecraft'? 'And I wait until the Minecraft game is loaded' : ''}
+    And I press "runButton"
+    And I check that selector "button:contains('Finish')" is in the viewport
+  STEPS
+end
+
+When /^I set up the (blockly|droplet|minecraft) free play level for "([^"]*)"/i do |level_type, level_name|
+  individual_steps <<-STEPS
+    And I am on "#{free_play_level_urls[level_type][level_name]}"
+    And I rotate to landscape
+    And I wait for the page to fully load
+    And I bypass the age dialog
+    And I close the instructions overlay if it exists
+  STEPS
+end


### PR DESCRIPTION
…small screens for free play levels

To resolve LP-1104. The finish button has been observed to not show up
on free play levels on small resolution screens. This commit contains a
fix for most free play levels on most devices, but there are still some
issues that will need to be resolved Bounce, minecraft, and app lab all
fail to show the finish button in the viewport under some circumstances,
outlined in comments for end to end tests.

<!--
  Your description goes here: A summary of the change, including any relevant motivation and context.

  If relevant, include a description both of the existing behavior and of the new behavior.
-->

<!--
  Other aspects to consider. uncomment and add detail for any that seem necessary:
-->

<!-- ### Background -->
<!-- ### Privacy -->
<!-- ### Security -->
<!-- ### Caching -->
<!-- ### Deployment strategy -->
<!-- ### Future work -->

## Links

<!--
  Any relevant links to external resources; ie, specification documents, jira
  items, related PRs, honeybadger errors, etc
-->

- [spec]()
- [jira]()

## Testing story

<!--
  Does your change include appropriate tests?

  If so, please describe how the tests included in this PR are sufficient

  If not, please explain why this change does not need to be tested.
-->

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
