### PR TITLE
Translate custom behaviors

### DIFF
--- a/bin/i18n/sync-in.rb
+++ b/bin/i18n/sync-in.rb
@@ -73,8 +73,9 @@ def get_i18n_strings(level)
 
       ## Function Names
       functions = blocks.xpath("//block[@type=\"procedures_defnoreturn\"]")
-      i18n_strings['function_names'] = Hash.new unless functions.empty?
-      functions.each do |function|
+      behaviors = blocks.xpath("//block[@type=\"behavior_definition\"]")
+      i18n_strings['function_names'] = Hash.new unless functions.empty? && behaviors.empty?
+      (functions + behaviors).each do |function|
         name = function.at_xpath('./title[@name="NAME"]')
         i18n_strings['function_names'][name.content] = name.content if name
       end

--- a/bin/i18n/sync-in.rb
+++ b/bin/i18n/sync-in.rb
@@ -73,11 +73,18 @@ def get_i18n_strings(level)
 
       ## Function Names
       functions = blocks.xpath("//block[@type=\"procedures_defnoreturn\"]")
-      behaviors = blocks.xpath("//block[@type=\"behavior_definition\"]")
-      i18n_strings['function_names'] = Hash.new unless functions.empty? && behaviors.empty?
-      (functions + behaviors).each do |function|
+      i18n_strings['function_names'] = Hash.new unless functions.empty?
+      functions.each do |function|
         name = function.at_xpath('./title[@name="NAME"]')
         i18n_strings['function_names'][name.content] = name.content if name
+      end
+
+      # Spritelab behaviors
+      behaviors = blocks.xpath("//block[@type=\"behavior_definition\"]")
+      i18n_strings['behavior_names'] = Hash.new unless behaviors.empty?
+      behaviors.each do |behavior|
+        name = behavior.at_xpath('./title[@name="NAME"]')
+        i18n_strings['behavior_names'][name.content] = name.content if name
       end
     end
   end

--- a/dashboard/app/models/levels/blockly.rb
+++ b/dashboard/app/models/levels/blockly.rb
@@ -520,7 +520,7 @@ class Blockly < Level
       next unless behavior_name
       localized_name = I18n.t(
         behavior_name.content,
-        scope: [:data, :function_names, name],
+        scope: [:data, :behavior_names, name],
         default: nil,
         smart: true
       )
@@ -531,7 +531,7 @@ class Blockly < Level
       next unless behavior_name
       localized_name = I18n.t(
         behavior_name.content,
-        scope: [:data, :function_names, name],
+        scope: [:data, :behavior_names, name],
         default: nil,
         smart: true
       )

--- a/dashboard/app/models/levels/blockly.rb
+++ b/dashboard/app/models/levels/blockly.rb
@@ -515,6 +515,29 @@ class Blockly < Level
       )
       mutation.set_attribute('name', localized_name) if localized_name
     end
+    block_xml.xpath("//block[@type=\"gamelab_behavior_get\"]").each do |behavior|
+      behavior_name = behavior.at_xpath('./title[@name="VAR"]')
+      next unless behavior_name
+      localized_name = I18n.t(
+        behavior_name.content,
+        scope: [:data, :function_names, name],
+        default: nil,
+        smart: true
+      )
+      behavior_name.content = localized_name if localized_name
+    end
+    block_xml.xpath("//block[@type=\"behavior_definition\"]").each do |behavior|
+      behavior_name = behavior.at_xpath('./title[@name="NAME"]')
+      next unless behavior_name
+      localized_name = I18n.t(
+        behavior_name.content,
+        scope: [:data, :function_names, name],
+        default: nil,
+        smart: true
+      )
+      behavior_name.content = localized_name if localized_name
+    end
+
     return block_xml.serialize(save_with: XML_OPTIONS).strip
   end
 


### PR DESCRIPTION
Some levels define behaviors in the toolbox, eg https://studio.code.org/s/coursef-2019/stage/15/puzzle/1. Currently we don't translate these behaviors. This PR adds the ability to translate these, very similarly to custom functions. The translations will end up in `function_names.<lang>.yml`.

## Links

<!--
  Any relevant links to external resources; ie, specification documents, jira
  items, related PRs, honeybadger errors, etc
-->

- [jira](https://codedotorg.atlassian.net/browse/FND-1043)

## Testing story

Tested manually by grabbing a couple of translations and ensuring they appeared.

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
