### PR TITLE
Update SerialPort.List

### DIFF
--- a/apps/src/lib/kits/maker/portScanning.js
+++ b/apps/src/lib/kits/maker/portScanning.js
@@ -68,14 +68,18 @@ export function ensureAppInstalled() {
  * @returns {Promise.<Array.<SerialPortInfo>>}
  */
 function listSerialDevices() {
-  const SerialPortType = isNodeSerialAvailable()
-    ? SerialPort
-    : ChromeSerialPort;
-  return new Promise((resolve, reject) => {
-    SerialPortType.list((error, list) =>
-      error ? reject(error) : resolve(list)
-    );
-  });
+  let SerialPortType;
+  if (isNodeSerialAvailable()) {
+    SerialPortType = SerialPort;
+    return SerialPortType.list();
+  } else {
+    SerialPortType = ChromeSerialPort;
+    return new Promise((resolve, reject) => {
+      SerialPortType.list((error, list) =>
+        error ? reject(error) : resolve(list)
+      );
+    });
+  }
 }
 
 /**


### PR DESCRIPTION
The AppVeyor build broke for the Maker Browser because we needed to update some dependencies. (https://github.com/code-dot-org/browser/pull/55/) This included updating serialport from 6.x.x. to 8.x.x, where the list interface was updated in SerialPort and our code was using an old API.

This PR updates the API format (removes callback and wrapping Promise). https://serialport.io/docs/api-stream#serialportlist


## Links

<!--
  Any relevant links to external resources; ie, specification documents, jira
  items, related PRs, honeybadger errors, etc
-->

- [spec]()
- [jira]()

## Testing story

<!--
  Does your change include appropriate tests?

  If so, please describe how the tests included in this PR are sufficient

  If not, please explain why this change does not need to be tested.
-->

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
