### PR TITLE
Tests: Fix NetSim unit tests on Chrome

### DIFF
--- a/apps/test/unit/netsim/NetSimLogEntry.js
+++ b/apps/test/unit/netsim/NetSimLogEntry.js
@@ -75,7 +75,7 @@ describe('NetSimLogEntry', function() {
   it('gracefully converts a malformed base64Payload to empty string', function() {
     var logEntry = new NetSimLogEntry(testShard, {
       base64Binary: {
-        string: 'totally not a base64 string',
+        string: 'not a base64 string because of the question mark?',
         len: 7
       }
     });

--- a/apps/test/unit/netsim/NetSimMessage.js
+++ b/apps/test/unit/netsim/NetSimMessage.js
@@ -71,7 +71,7 @@ describe('NetSimMessage', function() {
   it('gracefully converts a malformed base64Payload to empty string', function() {
     var message = new NetSimMessage(testShard, {
       base64Payload: {
-        string: 'totally not a base64 string',
+        string: 'not a base64 string because of the question mark?',
         len: 7
       }
     });


### PR DESCRIPTION
These tests, designed to check behavior when base64 fails to decode, were passing on PhantomJS because the browser's [`atob`](https://developer.mozilla.org/en-US/docs/Web/API/WindowOrWorkerGlobalScope/atob) function would break in these cases; but Chrome (and Firefox) seem to be more flexible about the base64 input to these functions, so they wouldn't hit the "graceful fallback" case like we want them to.

Fixed by including a question mark in the input for these "bad base64" tests, because it's [not a valid base64 character](https://base64.guru/learn/base64-characters).