### PR TITLE
Standards: make lesson status links teal

### DIFF
--- a/apps/src/templates/sectionProgress/standards/LessonStatusList.jsx
+++ b/apps/src/templates/sectionProgress/standards/LessonStatusList.jsx
@@ -7,11 +7,16 @@ import {
   getUnpluggedLessonsForScript,
   setSelectedLessons
 } from './sectionStandardsProgressRedux';
+import color from '@cdo/apps/util/color';
 
 const styles = {
   lessonListItem: {
     display: 'flex',
     flexDirection: 'row'
+  },
+  links: {
+    paddingLeft: 10,
+    color: color.teal
   }
 };
 
@@ -52,7 +57,7 @@ const ComplexLessonComponent = function({lesson}) {
           lessonNumber={lesson.number}
         />
       </div>
-      <a style={{paddingLeft: 10}} href={lesson.url} target={'_blank'}>
+      <a style={styles.links} href={lesson.url} target={'_blank'}>
         {lesson.name}
       </a>
     </div>


### PR DESCRIPTION
[LP-1305](https://codedotorg.atlassian.net/browse/LP-1305)

Lesson status links are now teal, instead of blue and red on hover. 

BEFORE 
![Screen Shot 2020-03-17 at 5 23 52 PM](https://user-images.githubusercontent.com/12300669/76913483-57fe4c80-6874-11ea-9218-822ed9f18e1e.png)

AFTER
<img width="736" alt="Screen Shot 2020-03-17 at 5 18 28 PM" src="https://user-images.githubusercontent.com/12300669/76913540-7fedb000-6874-11ea-8400-9b958576c748.png">
