### PR TITLE
Clean up the logic that pulls in the markdown files

### DIFF
--- a/bin/i18n-codeorg/in.sh
+++ b/bin/i18n-codeorg/in.sh
@@ -62,19 +62,3 @@ loc_dir=i18n/locales/source/pegasus
 mkdir -p $loc_dir
 perl -i ./bin/i18n-codeorg/lib/fix-ruby-yml.pl $orig_dir/en-US.yml
 cp_in $orig_dir/en-US.yml $loc_dir/mobile.yml
-
-### Markdown
-mkdir -p i18n/locales/source/markdown
-loc_dir=i18n/locales/source/markdown/public/international/
-mkdir -p $loc_dir
-orig_file=pegasus/sites.v3/code.org/public/international/about.md.partial
-loc_file=i18n/locales/source/markdown/public/international/about.md
-cp_in $orig_file $loc_file
-loc_dir=i18n/locales/source/markdown/public/educate/curriculum/
-mkdir -p $loc_dir
-orig_file=pegasus/sites.v3/code.org/public/educate/curriculum/csf-transition-guide.md
-cp_in $orig_file $loc_dir
-loc_dir=i18n/locales/source/markdown/public/
-mkdir -p $loc_dir
-orig_file=pegasus/sites.v3/code.org/public/csforgood.md
-cp_in $orig_file $loc_dir

--- a/bin/i18n/sync-in.rb
+++ b/bin/i18n/sync-in.rb
@@ -22,7 +22,7 @@ def sync_in
   I18nScriptUtils.run_bash_script "bin/i18n-codeorg/in.sh"
   redact_level_content
   redact_block_content
-  localize_markdown_headers
+  localize_markdown_content
 end
 
 def get_i18n_strings(level)
@@ -298,7 +298,7 @@ def redact_block_content
   RedactRestoreUtils.redact(source, source, ['blockfield'], 'txt')
 end
 
-def localize_markdown_headers
+def localize_markdown_content
   markdown_files_to_localize = ['international/about.md.partial',
                                 'educate/curriculum/csf-transition-guide.md',
                                 'csforgood.md']

--- a/bin/i18n/sync-in.rb
+++ b/bin/i18n/sync-in.rb
@@ -22,7 +22,7 @@ def sync_in
   I18nScriptUtils.run_bash_script "bin/i18n-codeorg/in.sh"
   redact_level_content
   redact_block_content
-  sanitize_markdown_headers
+  localize_markdown_headers
 end
 
 def get_i18n_strings(level)
@@ -298,8 +298,18 @@ def redact_block_content
   RedactRestoreUtils.redact(source, source, ['blockfield'], 'txt')
 end
 
-def sanitize_markdown_headers
-  Dir.glob(File.join(I18N_SOURCE_DIR, "markdown/**/*.{md,md.partial}")).each do |path|
+def localize_markdown_headers
+  markdown_files_to_localize = ['international/about.md.partial',
+                                'educate/curriculum/csf-transition-guide.md',
+                                'csforgood.md']
+  markdown_files_to_localize.each do |path|
+    original_path = File.join('pegasus/sites.v3/code.org/public', path)
+    # Remove the .partial if it exists
+    source_path = File.join(I18N_SOURCE_DIR, 'markdown/public', File.dirname(path), File.basename(path, '.partial'))
+    FileUtils.mkdir_p(File.dirname(source_path))
+    FileUtils.cp(original_path, source_path)
+  end
+  Dir.glob(File.join(I18N_SOURCE_DIR, "markdown/**/*.md")).each do |path|
     header, content, _line = Documents.new.helpers.parse_yaml_header(path)
     I18nScriptUtils.sanitize_header!(header)
     I18nScriptUtils.write_markdown_with_header(content, header, path)


### PR DESCRIPTION
This moves the "list" of markdown files to translate into the `sync-in` script and out of `in.sh`.

<!-- ### Background -->
<!-- ### Privacy -->
<!-- ### Security -->
<!-- ### Caching -->
<!-- ### Deployment strategy -->
<!-- ### Future work -->

## Links

<!--
  Any relevant links to external resources; ie, specification documents, jira
  items, related PRs, honeybadger errors, etc
-->

- [spec]()
- [jira]()

## Testing story

<!--
  Does your change include appropriate tests?

  If so, please describe how the tests included in this PR are sufficient

  If not, please explain why this change does not need to be tested.
-->

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
