### PR TITLE
Contact rollups pardot memory logic

### DIFF
--- a/dashboard/app/models/contact_rollups_pardot_memory.rb
+++ b/dashboard/app/models/contact_rollups_pardot_memory.rb
@@ -19,6 +19,51 @@
 #  index_contact_rollups_pardot_memory_on_pardot_id  (pardot_id) UNIQUE
 #
 
+require 'cdo/pardot'
+
 class ContactRollupsPardotMemory < ApplicationRecord
   self.table_name = 'contact_rollups_pardot_memory'
+
+  def self.update_from_new_contacts
+    # Find the highest Pardot ID of contacts stored in our database. Any newer
+    # contacts are guaranteed to have a higher ID. (Not stated in docs, but
+    # confirmed by Pardot support who said this was the best way to do this.)
+    # id_max = maximum(:pardot_id) || 0
+    id_max = 82_574_936
+
+    # Run repeated requests querying for prospects above our highest known
+    # Pardot ID. Up to 200 prospects will be returned at a time by Pardot, so
+    # query repeatedly if there are more than 200 to retrieve.
+    loop do
+      # Pardot request to return all prospects with ID greater than id_max.
+      url = "#{Pardot::PARDOT_PROSPECT_QUERY_URL}?id_greater_than=#{id_max}&fields=email,id&sort_by=id"
+
+      doc = Pardot.post_with_auth_retry(url)
+      Pardot.raise_if_response_error(doc)
+
+      # Pardot returns the count total available prospects (not capped to 200),
+      # although the data for a max of 200 are contained in the response.
+      total_results = doc.xpath('/rsp/result/total_results').text.to_i
+      results_in_response = 0
+
+      pp doc.xpath('/rsp/result/prospect')
+
+      # Process every prospect in the response.
+      doc.xpath('/rsp/result/prospect').each do |node|
+        id = node.xpath("id").text.to_i
+        email = node.xpath("email").text
+        results_in_response += 1
+        id_max = id
+
+        pardot_memory = find_or_initialize_by(email: email)
+        pardot_memory.pardot_id = id
+        pardot_memory.save
+      end
+
+      puts "Updated Pardot IDs in our database for #{results_in_response} contacts."
+
+      # Stop if all the remaining results were in this response - we're done. Otherwise, keep repeating.
+      break if results_in_response == total_results
+    end
+  end
 end

--- a/dashboard/app/models/contact_rollups_pardot_memory.rb
+++ b/dashboard/app/models/contact_rollups_pardot_memory.rb
@@ -24,42 +24,15 @@ require 'cdo/contact_rollups/v2/pardot'
 class ContactRollupsPardotMemory < ApplicationRecord
   self.table_name = 'contact_rollups_pardot_memory'
 
-  def self.update_from_new_contacts
-    # Find the highest Pardot ID of contacts stored in our database. Any newer
-    # contacts are guaranteed to have a higher ID. (Not stated in docs, but
-    # confirmed by Pardot support who said this was the best way to do this.)
-    # id_max = maximum(:pardot_id) || 0
-    id_max = 82_574_936
+  def self.add_and_update_pardot_ids(last_id = nil)
+    last_id ||= ContactRollupsPardotMemory.maximum(:pardot_id) || 0
 
-    # Run repeated requests querying for prospects above our highest known
-    # Pardot ID. Up to 200 prospects will be returned at a time by Pardot, so
-    # query repeatedly if there are more than 200 to retrieve.
-    loop do
-      # Pardot request to return all prospects with ID greater than id_max.
-      url = "#{Pardot::PARDOT_PROSPECT_QUERY_URL}?id_greater_than=#{id_max}&fields=email,id&sort_by=id"
-
-      doc = Pardot.post_with_auth_retry(url)
-      Pardot.raise_if_response_error(doc)
-
-      # Pardot returns the count total available prospects (not capped to 200),
-      # although the data for a max of 200 are contained in the response.
-      total_results = doc.xpath('/rsp/result/total_results').text.to_i
-      results_in_response = 0
-
-      # Process every prospect in the response.
-      doc.xpath('/rsp/result/prospect').each do |node|
-        id = node.xpath("id").text.to_i
-        email = node.xpath("email").text
-        results_in_response += 1
-        id_max = id
-
-        pardot_memory = find_or_initialize_by(email: email)
-        pardot_memory.pardot_id = id
-        pardot_memory.save
-      end
-
-      # Stop if all the remaining results were in this response - we're done. Otherwise, keep repeating.
-      break if results_in_response == total_results
+    # TODO: bulk insert and update. or even bulk delete and then bulk insert
+    Pardot.retrieve_new_ids(last_id).each do |mapping|
+      pardot_record = find_or_initialize_by(email: mapping[:email])
+      pardot_record.pardot_id = mapping[:id]
+      pardot_record.pardot_id_updated_at = Time.now
+      pardot_record.save
     end
   end
 end

--- a/dashboard/app/models/contact_rollups_pardot_memory.rb
+++ b/dashboard/app/models/contact_rollups_pardot_memory.rb
@@ -19,7 +19,7 @@
 #  index_contact_rollups_pardot_memory_on_pardot_id  (pardot_id) UNIQUE
 #
 
-require 'cdo/pardot'
+require 'cdo/contact_rollups/v2/pardot'
 
 class ContactRollupsPardotMemory < ApplicationRecord
   self.table_name = 'contact_rollups_pardot_memory'
@@ -46,8 +46,6 @@ class ContactRollupsPardotMemory < ApplicationRecord
       total_results = doc.xpath('/rsp/result/total_results').text.to_i
       results_in_response = 0
 
-      pp doc.xpath('/rsp/result/prospect')
-
       # Process every prospect in the response.
       doc.xpath('/rsp/result/prospect').each do |node|
         id = node.xpath("id").text.to_i
@@ -59,8 +57,6 @@ class ContactRollupsPardotMemory < ApplicationRecord
         pardot_memory.pardot_id = id
         pardot_memory.save
       end
-
-      puts "Updated Pardot IDs in our database for #{results_in_response} contacts."
 
       # Stop if all the remaining results were in this response - we're done. Otherwise, keep repeating.
       break if results_in_response == total_results

--- a/dashboard/app/models/contact_rollups_pardot_memory.rb
+++ b/dashboard/app/models/contact_rollups_pardot_memory.rb
@@ -30,7 +30,7 @@ class ContactRollupsPardotMemory < ApplicationRecord
     # TODO: bulk insert and update. or even bulk delete and then bulk insert
     PardotV2.retrieve_new_ids(last_id).each do |mapping|
       pardot_record = find_or_initialize_by(email: mapping[:email])
-      pardot_record.pardot_id = mapping[:id]
+      pardot_record.pardot_id = mapping[:pardot_id]
       pardot_record.pardot_id_updated_at = Time.now
       pardot_record.save
     end

--- a/dashboard/app/models/contact_rollups_pardot_memory.rb
+++ b/dashboard/app/models/contact_rollups_pardot_memory.rb
@@ -28,7 +28,7 @@ class ContactRollupsPardotMemory < ApplicationRecord
     last_id ||= ContactRollupsPardotMemory.maximum(:pardot_id) || 0
 
     # TODO: bulk insert and update. or even bulk delete and then bulk insert
-    Pardot.retrieve_new_ids(last_id).each do |mapping|
+    PardotV2.retrieve_new_ids(last_id).each do |mapping|
       pardot_record = find_or_initialize_by(email: mapping[:email])
       pardot_record.pardot_id = mapping[:id]
       pardot_record.pardot_id_updated_at = Time.now

--- a/dashboard/test/factories/factories.rb
+++ b/dashboard/test/factories/factories.rb
@@ -1254,6 +1254,8 @@ FactoryGirl.define do
   factory :contact_rollups_pardot_memory do
     sequence (:email) {|n| "contact_#{n}@example.domain"}
     sequence(:pardot_id) {|n| n}
+    pardot_id_updated_at {Time.now - 1.hour}
     data_synced {{opt_in: 0}}
+    data_synced_at {Time.now}
   end
 end

--- a/dashboard/test/factories/factories.rb
+++ b/dashboard/test/factories/factories.rb
@@ -1250,4 +1250,10 @@ FactoryGirl.define do
     sequence(:email) {|n| "contact_#{n}@example.domain"}
     data {{'dashboard.email_preferences' => {'opt_in' => 1}}}
   end
+
+  factory :contact_rollups_pardot_memory do
+    sequence (:email) {|n| "contact_#{n}@example.domain"}
+    sequence(:pardot_id) {|n| n}
+    data_synced {{opt_in: 0}}
+  end
 end

--- a/dashboard/test/models/contact_rollups_pardot_memory_test.rb
+++ b/dashboard/test/models/contact_rollups_pardot_memory_test.rb
@@ -1,13 +1,76 @@
 require 'test_helper'
+require 'cdo/contact_rollups/v2/pardot'
 
 class ContactRollupsPardotMemoryTest < ActiveSupport::TestCase
   test 'update_from_new_contacts creates one row per email' do
-    # requires a) stub for get request to Pardot, and
-    # b) contents of that response to be XML similar to what Pardot currently shares?
+    response = Nokogiri::XML::Builder.new do |xml|
+      xml.rsp {
+        xml.result {
+          xml.prospect {
+            xml.id_ "1"
+            xml.email "alex@rollups.com"
+          }
+          xml.total_results "1"
+        }
+      }
+    end
+
+    Pardot.stubs(:post_with_auth_retry).returns(response.doc)
+    Pardot.stubs(:raise_if_response_error).returns(nil)
+
+    ContactRollupsPardotMemory.update_from_new_contacts
+
+    assert 1, ContactRollupsPardotMemory.find_by(email: 'alex@rollups.com').pardot_id
   end
 
-  test 'import_from_raw_table works when more than 200 records' do
-    # use part b) above,
-    # but need to be able to stub 200+ XML responses with distinct emails?
+  test 'update_from_new_contacts with two emails returns record with higher ID' do
+    create :contact_rollups_pardot_memory, email: 'alex@rollups.com', pardot_id: 1
+
+    response = Nokogiri::XML::Builder.new do |xml|
+      xml.rsp {
+        xml.result {
+          xml.prospect {
+            xml.id_ "2"
+            xml.email "alex@rollups.com"
+          }
+          xml.total_results "1"
+        }
+      }
+    end
+
+    Pardot.stubs(:post_with_auth_retry).returns(response.doc)
+    Pardot.stubs(:raise_if_response_error).returns(nil)
+
+    assert 1, ContactRollupsPardotMemory.find_by(email: 'alex@rollups.com').pardot_id
+    ContactRollupsPardotMemory.update_from_new_contacts
+    assert 2, ContactRollupsPardotMemory.find_by(email: 'alex@rollups.com').pardot_id
+  end
+
+  test 'can handle having multiple mappings in response' do
+    response = Nokogiri::XML::Builder.new do |xml|
+      xml.rsp {
+        xml.result {
+          xml.prospect {
+            xml.id_ "1"
+            xml.email "alex@rollups.com"
+          }
+          xml.prospect {
+            xml.id_ "2"
+            xml.email "becky@rollups.com"
+          }
+          xml.total_results "2"
+        }
+      }
+    end
+
+    Pardot.stubs(:post_with_auth_retry).returns(response.doc)
+    Pardot.stubs(:raise_if_response_error).returns(nil)
+
+    ContactRollupsPardotMemory.update_from_new_contacts
+
+    assert 1, ContactRollupsPardotMemory.find_by(email: 'alex@rollups.com').pardot_id
+    assert 2, ContactRollupsPardotMemory.find_by(email: 'becky@rollups.com').pardot_id
+    assert 2, ContactRollupsPardotMemory.count
   end
 end
+

--- a/dashboard/test/models/contact_rollups_pardot_memory_test.rb
+++ b/dashboard/test/models/contact_rollups_pardot_memory_test.rb
@@ -1,0 +1,13 @@
+require 'test_helper'
+
+class ContactRollupsPardotMemoryTest < ActiveSupport::TestCase
+  test 'update_from_new_contacts creates one row per email' do
+    # requires a) stub for get request to Pardot, and
+    # b) contents of that response to be XML similar to what Pardot currently shares?
+  end
+
+  test 'import_from_raw_table works when more than 200 records' do
+    # use part b) above,
+    # but need to be able to stub 200+ XML responses with distinct emails?
+  end
+end

--- a/dashboard/test/models/contact_rollups_pardot_memory_test.rb
+++ b/dashboard/test/models/contact_rollups_pardot_memory_test.rb
@@ -2,74 +2,33 @@ require 'test_helper'
 require 'cdo/contact_rollups/v2/pardot'
 
 class ContactRollupsPardotMemoryTest < ActiveSupport::TestCase
-  test 'update_from_new_contacts creates one row per email' do
-    response = <<~XML
-                 <rsp>
-                   <result>
-                     <prospect>
-                       <id>1</id>
-                       <email>alex@rollups.com</email>
-                     </prospect>
-                     <total_results>1</total_results>
-                   </result>
-                 </rsp>
-               XML
+  test 'add_and_update_pardot_ids inserts new mappings' do
+    ContactRollupsPardotMemory.delete_all
 
-    Pardot.stubs(:post_with_auth_retry).returns(Nokogiri::XML.parse(response))
-    Pardot.stubs(:raise_if_response_error).returns(nil)
+    new_mappings = [
+      {email: "alex@rollups.com", pardot_id: 1},
+      {email: "becky@rollups.com", pardot_id: 2}
+    ]
+    PardotV2.stubs(:retrieve_new_ids).returns(new_mappings)
 
-    ContactRollupsPardotMemory.update_from_new_contacts
+    ContactRollupsPardotMemory.add_and_update_pardot_ids
 
-    assert_equal 1, ContactRollupsPardotMemory.find_by(email: 'alex@rollups.com').pardot_id
+    new_mappings.each do |mapping|
+      refute_nil ContactRollupsPardotMemory.find_by(email: mapping[:email], pardot_id: mapping[:pardot_id])
+    end
   end
 
-  test 'update_from_new_contacts with two emails returns record with higher ID' do
-    create :contact_rollups_pardot_memory, email: 'alex@rollups.com', pardot_id: 1
+  test 'add_and_update_pardot_ids updates existing mapping' do
+    ContactRollupsPardotMemory.delete_all
+    existing_record = create :contact_rollups_pardot_memory
 
-    response = <<~XML
-                 <rsp>
-                   <result>
-                     <prospect>
-                       <id>2</id>
-                       <email>alex@rollups.com</email>
-                     </prospect>
-                     <total_results>1</total_results>
-                   </result>
-                 </rsp>
-               XML
+    new_pardot_id = existing_record.pardot_id + 1
+    PardotV2.stubs(:retrieve_new_ids).returns(
+      [{email: existing_record.email, pardot_id: new_pardot_id}]
+    )
 
-    Pardot.stubs(:post_with_auth_retry).returns(Nokogiri::XML.parse(response))
-    Pardot.stubs(:raise_if_response_error).returns(nil)
+    ContactRollupsPardotMemory.add_and_update_pardot_ids
 
-    assert_equal 1, ContactRollupsPardotMemory.find_by(email: 'alex@rollups.com').pardot_id
-    ContactRollupsPardotMemory.update_from_new_contacts
-    assert_equal 2, ContactRollupsPardotMemory.find_by(email: 'alex@rollups.com').pardot_id
-  end
-
-  test 'can handle having multiple mappings in response' do
-    response = <<~XML
-                 <rsp>
-                   <result>
-                     <prospect>
-                       <id>1</id>
-                       <email>alex@rollups.com</email>
-                     </prospect>
-                     <prospect>
-                       <id>3</id>
-                       <email>becky@rollups.com</email>
-                     </prospect>
-                     <total_results>2</total_results>
-                   </result>
-                 </rsp>
-               XML
-
-    Pardot.stubs(:post_with_auth_retry).returns(Nokogiri::XML.parse(response))
-    Pardot.stubs(:raise_if_response_error).returns(nil)
-
-    ContactRollupsPardotMemory.update_from_new_contacts
-
-    assert_equal 1, ContactRollupsPardotMemory.find_by(email: 'alex@rollups.com').pardot_id
-    assert_equal 3, ContactRollupsPardotMemory.find_by(email: 'becky@rollups.com').pardot_id
-    assert_equal 2, ContactRollupsPardotMemory.count
+    assert_equal new_pardot_id, ContactRollupsPardotMemory.find_by(email: existing_record.email)&.pardot_id
   end
 end

--- a/dashboard/test/models/contact_rollups_pardot_memory_test.rb
+++ b/dashboard/test/models/contact_rollups_pardot_memory_test.rb
@@ -3,74 +3,73 @@ require 'cdo/contact_rollups/v2/pardot'
 
 class ContactRollupsPardotMemoryTest < ActiveSupport::TestCase
   test 'update_from_new_contacts creates one row per email' do
-    response = Nokogiri::XML::Builder.new do |xml|
-      xml.rsp {
-        xml.result {
-          xml.prospect {
-            xml.id_ "1"
-            xml.email "alex@rollups.com"
-          }
-          xml.total_results "1"
-        }
-      }
-    end
+    response = <<~XML
+                 <rsp>
+                   <result>
+                     <prospect>
+                       <id>1</id>
+                       <email>alex@rollups.com</email>
+                     </prospect>
+                     <total_results>1</total_results>
+                   </result>
+                 </rsp>
+               XML
 
-    Pardot.stubs(:post_with_auth_retry).returns(response.doc)
+    Pardot.stubs(:post_with_auth_retry).returns(Nokogiri::XML.parse(response))
     Pardot.stubs(:raise_if_response_error).returns(nil)
 
     ContactRollupsPardotMemory.update_from_new_contacts
 
-    assert 1, ContactRollupsPardotMemory.find_by(email: 'alex@rollups.com').pardot_id
+    assert_equal 1, ContactRollupsPardotMemory.find_by(email: 'alex@rollups.com').pardot_id
   end
 
   test 'update_from_new_contacts with two emails returns record with higher ID' do
     create :contact_rollups_pardot_memory, email: 'alex@rollups.com', pardot_id: 1
 
-    response = Nokogiri::XML::Builder.new do |xml|
-      xml.rsp {
-        xml.result {
-          xml.prospect {
-            xml.id_ "2"
-            xml.email "alex@rollups.com"
-          }
-          xml.total_results "1"
-        }
-      }
-    end
+    response = <<~XML
+                 <rsp>
+                   <result>
+                     <prospect>
+                       <id>2</id>
+                       <email>alex@rollups.com</email>
+                     </prospect>
+                     <total_results>1</total_results>
+                   </result>
+                 </rsp>
+               XML
 
-    Pardot.stubs(:post_with_auth_retry).returns(response.doc)
+    Pardot.stubs(:post_with_auth_retry).returns(Nokogiri::XML.parse(response))
     Pardot.stubs(:raise_if_response_error).returns(nil)
 
-    assert 1, ContactRollupsPardotMemory.find_by(email: 'alex@rollups.com').pardot_id
+    assert_equal 1, ContactRollupsPardotMemory.find_by(email: 'alex@rollups.com').pardot_id
     ContactRollupsPardotMemory.update_from_new_contacts
-    assert 2, ContactRollupsPardotMemory.find_by(email: 'alex@rollups.com').pardot_id
+    assert_equal 2, ContactRollupsPardotMemory.find_by(email: 'alex@rollups.com').pardot_id
   end
 
   test 'can handle having multiple mappings in response' do
-    response = Nokogiri::XML::Builder.new do |xml|
-      xml.rsp {
-        xml.result {
-          xml.prospect {
-            xml.id_ "1"
-            xml.email "alex@rollups.com"
-          }
-          xml.prospect {
-            xml.id_ "2"
-            xml.email "becky@rollups.com"
-          }
-          xml.total_results "2"
-        }
-      }
-    end
+    response = <<~XML
+                 <rsp>
+                   <result>
+                     <prospect>
+                       <id>1</id>
+                       <email>alex@rollups.com</email>
+                     </prospect>
+                     <prospect>
+                       <id>3</id>
+                       <email>becky@rollups.com</email>
+                     </prospect>
+                     <total_results>2</total_results>
+                   </result>
+                 </rsp>
+               XML
 
-    Pardot.stubs(:post_with_auth_retry).returns(response.doc)
+    Pardot.stubs(:post_with_auth_retry).returns(Nokogiri::XML.parse(response))
     Pardot.stubs(:raise_if_response_error).returns(nil)
 
     ContactRollupsPardotMemory.update_from_new_contacts
 
-    assert 1, ContactRollupsPardotMemory.find_by(email: 'alex@rollups.com').pardot_id
-    assert 2, ContactRollupsPardotMemory.find_by(email: 'becky@rollups.com').pardot_id
-    assert 2, ContactRollupsPardotMemory.count
+    assert_equal 1, ContactRollupsPardotMemory.find_by(email: 'alex@rollups.com').pardot_id
+    assert_equal 3, ContactRollupsPardotMemory.find_by(email: 'becky@rollups.com').pardot_id
+    assert_equal 2, ContactRollupsPardotMemory.count
   end
 end
-

--- a/lib/cdo/contact_rollups/v2/contact_rollups.rb
+++ b/lib/cdo/contact_rollups/v2/contact_rollups.rb
@@ -9,5 +9,9 @@ class ContactRollupsV2
 
     log_collector.time!('ContactRollupsComparison.delete_all') {ContactRollupsComparison.delete_all}
     log_collector.time!('ContactRollupsComparison.compare_processed_data') {ContactRollupsComparison.compile_processed_data}
+
+    log_collector.time!('ContactRollupsPardotMemory.update_from_new_contacts') {ContactRollupsPardotMemory.update_from_new_contacts}
+
+    # To do: sync upstream step
   end
 end

--- a/lib/cdo/contact_rollups/v2/contact_rollups.rb
+++ b/lib/cdo/contact_rollups/v2/contact_rollups.rb
@@ -10,8 +10,8 @@ class ContactRollupsV2
     log_collector.time!('ContactRollupsComparison.delete_all') {ContactRollupsComparison.delete_all}
     log_collector.time!('ContactRollupsComparison.compare_processed_data') {ContactRollupsComparison.compile_processed_data}
 
-    log_collector.time!('ContactRollupsPardotMemory.update_from_new_contacts') {ContactRollupsPardotMemory.update_from_new_contacts}
+    log_collector.time!('ContactRollupsPardotMemory.add_and_update_pardot_ids') {ContactRollupsPardotMemory.add_and_update_pardot_ids}
 
-    # To do: sync upstream step
+    # TODO: sync upstream step
   end
 end

--- a/lib/cdo/contact_rollups/v2/pardot.rb
+++ b/lib/cdo/contact_rollups/v2/pardot.rb
@@ -1,8 +1,3 @@
-require File.expand_path('../../../../../pegasus/src/env', __FILE__)
-require 'net/http'
-require 'net/http/responses'
-require_relative('../../../../dashboard/config/environment')
-require 'cdo/properties'
 require_relative 'pardot_helpers'
 
 class PardotV2
@@ -38,7 +33,7 @@ class PardotV2
         results_in_response += 1
         last_id = id
 
-        mappings << {email: email, id: id}
+        mappings << {email: email, pardot_id: id}
       end
 
       # Stop if all the remaining results were in this response - we're done. Otherwise, keep repeating.

--- a/lib/cdo/contact_rollups/v2/pardot.rb
+++ b/lib/cdo/contact_rollups/v2/pardot.rb
@@ -3,124 +3,17 @@ require 'net/http'
 require 'net/http/responses'
 require_relative('../../../../dashboard/config/environment')
 require 'cdo/properties'
+require_relative 'pardot_helpers'
 
 # Global variable for Pardot API key. This can become invalid and need to be refreshed
 # and replaced midstream.
 $pardot_api_key = nil
 
-class Pardot
-  PARDOT_AUTHENTICATION_URL = "https://pi.pardot.com/api/login/version/4".freeze
+class PardotV2
+  extend PardotHelpers
+
   PARDOT_API_V4_BASE = "https://pi.pardot.com/api/prospect/version/4".freeze
   PARDOT_PROSPECT_QUERY_URL = "#{PARDOT_API_V4_BASE}/do/query".freeze
-  PARDOT_SUCCESS_HTTP_CODES = %w(200 201 204).freeze
-
-  # Exception to throw to ourselves if Pardot API key is invalid (which probably
-  # means it needs to be re-authed)
-  class InvalidApiKeyException < RuntimeError
-  end
-
-  # Login to Pardot and request an API key. The API key is valid for (up to) one
-  # hour, after which it will become invalid and we will need to request a new
-  # one.
-  # @return [String] API key to use for subsequent requests
-  def self.request_pardot_api_key
-    puts "Requesting new API key"
-    doc = post_request(
-      PARDOT_AUTHENTICATION_URL,
-      {
-        email: CDO.pardot_username,
-        password: CDO.pardot_password,
-        user_key: CDO.pardot_user_key
-      }
-    )
-
-    status = doc.xpath('/rsp/@stat').text
-    if status != "ok"
-      raise "Pardot authentication response failed with status #{status}  #{doc}"
-    end
-
-    api_key = doc.xpath('/rsp/api_key').text
-    raise "Pardot authentication response did not include api_key" if api_key.nil?
-
-    $pardot_api_key = api_key
-  end
-
-  # Make an API request with Pardot authentication, including appending auth
-  # params and refreshing Pardot API key and retrying if necessary.
-  # @param url [String] URL to post to
-  # @return [Nokogiri::XML, nil] XML response from Pardot
-  def self.post_with_auth_retry(url)
-    # do the post to Pardot
-    post_request_with_auth(url)
-  rescue InvalidApiKeyException
-    # If we fail with an invalid key, that probably means our API key (which is
-    # good for one hour) has expired. Try one time to request a new API key and
-    # try the post again. If that fails, that is a fatal error.
-    request_pardot_api_key
-    post_request_with_auth(url)
-  end
-
-  # Make an API request with Pardot authentication
-  # @param url [String] URL to post to. The URL passed in should not contain
-  #   auth params, as auth params will get appended in this method.
-  # @return [Nokogiri::XML] XML response from Pardot
-  def self.post_request_with_auth(url)
-    request_pardot_api_key if $pardot_api_key.nil?
-
-    # add the API key and user key parameters to body of the POST request
-    post_request(
-      url,
-      {
-        api_key: $pardot_api_key,
-        user_key: CDO.pardot_user_key
-      }
-    )
-  end
-
-  # Make an API request. This method may raise exceptions.
-  # @param url [String] URL to post to - must already include Pardot auth params
-  #   in query string
-  # @param params [Hash] hash of POST params (may be empty hash)
-  # @return [Nokogiri::XML, nil] XML response from Pardot
-  def self.post_request(url, params)
-    uri = URI(url)
-
-    response = Net::HTTP.post_form(uri, params)
-
-    # Do common error handling for Pardot response.
-    unless PARDOT_SUCCESS_HTTP_CODES.include?(response.code)
-      raise "Pardot request failed with HTTP #{response.code}"
-    end
-
-    if response.code == '204'
-      return nil
-    end
-
-    doc = Nokogiri::XML(response.body, &:noblanks)
-    raise "Pardot response did not return parsable XML" if doc.nil?
-
-    error_details = doc.xpath('/rsp/err').text
-    raise InvalidApiKeyException if error_details.include? "Invalid API key or user key"
-
-    status = doc.xpath('/rsp/@stat').text
-    raise "Pardot response did not include status" if status.nil?
-
-    doc
-  end
-
-  # Parse a Pardot XML response and raise an exception on the first error
-  # if there is one.
-  # @param doc [Nokogiri::XML] XML response from Pardot
-  def self.raise_if_response_error(doc)
-    status = doc.xpath('/rsp/@stat').text
-    if status != "ok"
-      error_text = doc.xpath('/rsp/errors/*').first.try(:text)
-      error_text = "Unknown error" if error_text.nil? || error_text.empty?
-      puts doc.to_s
-      puts error_text
-      raise "Error in Pardot response: #{error_text}"
-    end
-  end
 
   # Retrieves new email-id mappings from Pardot
   # @param [Integer] last_id
@@ -133,10 +26,9 @@ class Pardot
 
     loop do
       # Pardot request to return all prospects with ID greater than the last id.
-      url = "#{Pardot::PARDOT_PROSPECT_QUERY_URL}?id_greater_than=#{last_id}&fields=email,id&sort_by=id"
-
-      doc = Pardot.post_with_auth_retry(url)
-      Pardot.raise_if_response_error(doc)
+      url = "#{PARDOT_PROSPECT_QUERY_URL}?id_greater_than=#{last_id}&fields=email,id&sort_by=id"
+      doc = post_with_auth_retry(url)
+      raise_if_response_error(doc)
 
       # Pardot returns the count total available prospects (not capped to 200),
       # although the data for a max of 200 are contained in the response.

--- a/lib/cdo/contact_rollups/v2/pardot.rb
+++ b/lib/cdo/contact_rollups/v2/pardot.rb
@@ -9,13 +9,9 @@ require 'cdo/properties'
 $pardot_api_key = nil
 
 class Pardot
-  # URL for Pardot login
   PARDOT_AUTHENTICATION_URL = "https://pi.pardot.com/api/login/version/4".freeze
-
   PARDOT_API_V4_BASE = "https://pi.pardot.com/api/prospect/version/4".freeze
-  # URL for prospect query
   PARDOT_PROSPECT_QUERY_URL = "#{PARDOT_API_V4_BASE}/do/query".freeze
-
   PARDOT_SUCCESS_HTTP_CODES = %w(200 201 204).freeze
 
   # Exception to throw to ourselves if Pardot API key is invalid (which probably
@@ -28,7 +24,7 @@ class Pardot
   # one.
   # @return [String] API key to use for subsequent requests
   def self.request_pardot_api_key
-    log "Requesting new API key"
+    puts "Requesting new API key"
     doc = post_request(
       PARDOT_AUTHENTICATION_URL,
       {
@@ -120,9 +116,47 @@ class Pardot
     if status != "ok"
       error_text = doc.xpath('/rsp/errors/*').first.try(:text)
       error_text = "Unknown error" if error_text.nil? || error_text.empty?
-      log doc.to_s
-      log error_text
+      puts doc.to_s
+      puts error_text
       raise "Error in Pardot response: #{error_text}"
     end
+  end
+
+  # Retrieves new email-id mappings from Pardot
+  # @param [Integer] last_id
+  # @return [Array] an array of hash {email, id}
+  def self.retrieve_new_ids(last_id = 0)
+    # Run repeated requests querying for prospects above our highest known
+    # Pardot ID. Up to 200 prospects will be returned at a time by Pardot, so
+    # query repeatedly if there are more than 200 to retrieve.
+    mappings = []
+
+    loop do
+      # Pardot request to return all prospects with ID greater than the last id.
+      url = "#{Pardot::PARDOT_PROSPECT_QUERY_URL}?id_greater_than=#{last_id}&fields=email,id&sort_by=id"
+
+      doc = Pardot.post_with_auth_retry(url)
+      Pardot.raise_if_response_error(doc)
+
+      # Pardot returns the count total available prospects (not capped to 200),
+      # although the data for a max of 200 are contained in the response.
+      total_results = doc.xpath('/rsp/result/total_results').text.to_i
+      results_in_response = 0
+
+      # Process every prospect in the response.
+      doc.xpath('/rsp/result/prospect').each do |node|
+        id = node.xpath("id").text.to_i
+        email = node.xpath("email").text
+        results_in_response += 1
+        last_id = id
+
+        mappings << {email: email, id: id}
+      end
+
+      # Stop if all the remaining results were in this response - we're done. Otherwise, keep repeating.
+      break if results_in_response == total_results
+    end
+
+    mappings
   end
 end

--- a/lib/cdo/contact_rollups/v2/pardot.rb
+++ b/lib/cdo/contact_rollups/v2/pardot.rb
@@ -9,7 +9,7 @@ class PardotV2
   # Retrieves new email-id mappings from Pardot
   # @param [Integer] last_id
   # @return [Array] an array of hash {email, id}
-  def self.retrieve_new_ids(last_id = 0)
+  def self.retrieve_new_ids(last_id)
     # Run repeated requests querying for prospects above our highest known
     # Pardot ID. Up to 200 prospects will be returned at a time by Pardot, so
     # query repeatedly if there are more than 200 to retrieve.

--- a/lib/cdo/contact_rollups/v2/pardot.rb
+++ b/lib/cdo/contact_rollups/v2/pardot.rb
@@ -5,10 +5,6 @@ require_relative('../../../../dashboard/config/environment')
 require 'cdo/properties'
 require_relative 'pardot_helpers'
 
-# Global variable for Pardot API key. This can become invalid and need to be refreshed
-# and replaced midstream.
-$pardot_api_key = nil
-
 class PardotV2
   extend PardotHelpers
 

--- a/lib/cdo/contact_rollups/v2/pardot.rb
+++ b/lib/cdo/contact_rollups/v2/pardot.rb
@@ -125,9 +125,4 @@ class Pardot
       raise "Error in Pardot response: #{error_text}"
     end
   end
-
-  def self.log(s)
-    # puts s
-    CDO.log.info s
-  end
 end

--- a/lib/cdo/contact_rollups/v2/pardot.rb
+++ b/lib/cdo/contact_rollups/v2/pardot.rb
@@ -1,0 +1,133 @@
+require File.expand_path('../../../../../pegasus/src/env', __FILE__)
+require 'net/http'
+require 'net/http/responses'
+require_relative('../../../../dashboard/config/environment')
+require 'cdo/properties'
+
+# Global variable for Pardot API key. This can become invalid and need to be refreshed
+# and replaced midstream.
+$pardot_api_key = nil
+
+class Pardot
+  # URL for Pardot login
+  PARDOT_AUTHENTICATION_URL = "https://pi.pardot.com/api/login/version/4".freeze
+
+  PARDOT_API_V4_BASE = "https://pi.pardot.com/api/prospect/version/4".freeze
+  # URL for prospect query
+  PARDOT_PROSPECT_QUERY_URL = "#{PARDOT_API_V4_BASE}/do/query".freeze
+
+  PARDOT_SUCCESS_HTTP_CODES = %w(200 201 204).freeze
+
+  # Exception to throw to ourselves if Pardot API key is invalid (which probably
+  # means it needs to be re-authed)
+  class InvalidApiKeyException < RuntimeError
+  end
+
+  # Login to Pardot and request an API key. The API key is valid for (up to) one
+  # hour, after which it will become invalid and we will need to request a new
+  # one.
+  # @return [String] API key to use for subsequent requests
+  def self.request_pardot_api_key
+    log "Requesting new API key"
+    doc = post_request(
+      PARDOT_AUTHENTICATION_URL,
+      {
+        email: CDO.pardot_username,
+        password: CDO.pardot_password,
+        user_key: CDO.pardot_user_key
+      }
+    )
+
+    status = doc.xpath('/rsp/@stat').text
+    if status != "ok"
+      raise "Pardot authentication response failed with status #{status}  #{doc}"
+    end
+
+    api_key = doc.xpath('/rsp/api_key').text
+    raise "Pardot authentication response did not include api_key" if api_key.nil?
+
+    $pardot_api_key = api_key
+  end
+
+  # Make an API request with Pardot authentication, including appending auth
+  # params and refreshing Pardot API key and retrying if necessary.
+  # @param url [String] URL to post to
+  # @return [Nokogiri::XML, nil] XML response from Pardot
+  def self.post_with_auth_retry(url)
+    # do the post to Pardot
+    post_request_with_auth(url)
+  rescue InvalidApiKeyException
+    # If we fail with an invalid key, that probably means our API key (which is
+    # good for one hour) has expired. Try one time to request a new API key and
+    # try the post again. If that fails, that is a fatal error.
+    request_pardot_api_key
+    post_request_with_auth(url)
+  end
+
+  # Make an API request with Pardot authentication
+  # @param url [String] URL to post to. The URL passed in should not contain
+  #   auth params, as auth params will get appended in this method.
+  # @return [Nokogiri::XML] XML response from Pardot
+  def self.post_request_with_auth(url)
+    request_pardot_api_key if $pardot_api_key.nil?
+
+    # add the API key and user key parameters to body of the POST request
+    post_request(
+      url,
+      {
+        api_key: $pardot_api_key,
+        user_key: CDO.pardot_user_key
+      }
+    )
+  end
+
+  # Make an API request. This method may raise exceptions.
+  # @param url [String] URL to post to - must already include Pardot auth params
+  #   in query string
+  # @param params [Hash] hash of POST params (may be empty hash)
+  # @return [Nokogiri::XML, nil] XML response from Pardot
+  def self.post_request(url, params)
+    uri = URI(url)
+
+    response = Net::HTTP.post_form(uri, params)
+
+    # Do common error handling for Pardot response.
+    unless PARDOT_SUCCESS_HTTP_CODES.include?(response.code)
+      raise "Pardot request failed with HTTP #{response.code}"
+    end
+
+    if response.code == '204'
+      return nil
+    end
+
+    doc = Nokogiri::XML(response.body, &:noblanks)
+    raise "Pardot response did not return parsable XML" if doc.nil?
+
+    error_details = doc.xpath('/rsp/err').text
+    raise InvalidApiKeyException if error_details.include? "Invalid API key or user key"
+
+    status = doc.xpath('/rsp/@stat').text
+    raise "Pardot response did not include status" if status.nil?
+
+    doc
+  end
+
+  # Parse a Pardot XML response and raise an exception on the first error
+  # if there is one.
+  # @param doc [Nokogiri::XML] XML response from Pardot
+  def self.raise_if_response_error(doc)
+    status = doc.xpath('/rsp/@stat').text
+    if status != "ok"
+      error_text = doc.xpath('/rsp/errors/*').first.try(:text)
+      error_text = "Unknown error" if error_text.nil? || error_text.empty?
+      log doc.to_s
+      log error_text
+      raise "Error in Pardot response: #{error_text}"
+    end
+  end
+
+  def self.log(s)
+    # puts s
+    CDO.log.info s
+  end
+end

--- a/lib/cdo/contact_rollups/v2/pardot_helpers.rb
+++ b/lib/cdo/contact_rollups/v2/pardot_helpers.rb
@@ -1,21 +1,22 @@
 module PardotHelpers
-  class InvalidApiKeyException < RuntimeError
-  end
-
   PARDOT_AUTHENTICATION_URL = "https://pi.pardot.com/api/login/version/4".freeze
   PARDOT_SUCCESS_HTTP_CODES = %w(200 201 204).freeze
+
+  class InvalidApiKeyException < RuntimeError
+  end
 
   private
 
   # Note: Pardot API key can become invalid and need to be refreshed midstream.
   @@pardot_api_key = nil
 
-  # Login to Pardot and request an API key. The API key is valid for (up to) one
-  # hour, after which it will become invalid and we will need to request a new
-  # one.
+  # Authenticates and requests a new API key.
+  # API keys are valid for one hour while user keys are valid indefinitely.
+  # http://developer.pardot.com/#authentication
+  #
   # @return [String] API key to use for subsequent requests
+  # @note This method has a side effect (it modifies a class variable) and may raise exception.
   def request_pardot_api_key
-    puts "Requesting new API key"
     doc = post_request(
       PARDOT_AUTHENTICATION_URL,
       {
@@ -26,88 +27,75 @@ module PardotHelpers
     )
 
     status = doc.xpath('/rsp/@stat').text
-    if status != "ok"
-      raise "Pardot authentication response failed with status #{status}  #{doc}"
-    end
+    raise "Pardot authentication response failed with status #{status}  #{doc}" unless status == 'ok'
 
     api_key = doc.xpath('/rsp/api_key').text
-    raise "Pardot authentication response did not include api_key" if api_key.nil?
+    raise 'Pardot authentication response did not include api_key' if api_key.nil?
 
     @@pardot_api_key = api_key
   end
 
-  # Make an API request with Pardot authentication, including appending auth
-  # params and refreshing Pardot API key and retrying if necessary.
+  # Makes an API request with Pardot authentication.
+  # Retries with new Pardot API key if necessary.
+  #
   # @param url [String] URL to post to
   # @return [Nokogiri::XML, nil] XML response from Pardot
   def post_with_auth_retry(url)
     post_request_with_auth(url)
   rescue InvalidApiKeyException
-    # If we fail with an invalid key, that probably means our API key (which is
-    # good for one hour) has expired. Try one time to request a new API key and
-    # try the post again. If that fails, that is a fatal error.
+    # The API key might have been expired, try again with a new API key
     request_pardot_api_key
     post_request_with_auth(url)
   end
 
   # Make an API request with Pardot authentication
-  # @param url [String] URL to post to. The URL passed in should not contain
-  #   auth params, as auth params will get appended in this method.
+  #
+  # @param url [String] URL to post to. The URL should not contain auth params.
   # @return [Nokogiri::XML] XML response from Pardot
   def post_request_with_auth(url)
     request_pardot_api_key if @@pardot_api_key.nil?
-
     post_request(
       url,
-      {
-        api_key: @@pardot_api_key,
-        user_key: CDO.pardot_user_key
-      }
+      {api_key: @@pardot_api_key, user_key: CDO.pardot_user_key}
     )
   end
 
   # Make an API request. This method may raise exceptions.
+  #
   # @param url [String] URL to post to - must already include Pardot auth params
-  #   in query string
   # @param params [Hash] hash of POST params (may be empty hash)
   # @return [Nokogiri::XML, nil] XML response from Pardot
   def post_request(url, params)
     uri = URI(url)
-
     response = Net::HTTP.post_form(uri, params)
 
-    # Do common error handling for Pardot response.
-    unless PARDOT_SUCCESS_HTTP_CODES.include?(response.code)
-      raise "Pardot request failed with HTTP #{response.code}"
-    end
+    raise "Pardot request failed with HTTP #{response.code}" unless
+      PARDOT_SUCCESS_HTTP_CODES.include?(response.code)
 
-    if response.code == '204'
-      return nil
-    end
+    return nil if response.code == '204'  # No content
 
     doc = Nokogiri::XML(response.body, &:noblanks)
-    raise "Pardot response did not return parsable XML" if doc.nil?
+    raise 'Pardot response did not return parsable XML' if doc.nil?
 
     error_details = doc.xpath('/rsp/err').text
-    raise InvalidApiKeyException if error_details.include? "Invalid API key or user key"
+    raise InvalidApiKeyException if error_details.include? 'Invalid API key or user key'
 
     status = doc.xpath('/rsp/@stat').text
-    raise "Pardot response did not include status" if status.nil?
+    raise 'Pardot response did not include status' if status.nil?
 
     doc
   end
 
-  # Parse a Pardot XML response and raise an exception on the first error
-  # if there is one.
+  # Parse a Pardot XML response and raise an exception on the first error if there is one.
+  # http://developer.pardot.com/kb/error-codes-messages/
+  #
   # @param doc [Nokogiri::XML] XML response from Pardot
   def raise_if_response_error(doc)
     status = doc.xpath('/rsp/@stat').text
-    if status != "ok"
-      error_text = doc.xpath('/rsp/errors/*').first.try(:text)
-      error_text = "Unknown error" if error_text.nil? || error_text.empty?
-      puts doc.to_s
-      puts error_text
-      raise "Error in Pardot response: #{error_text}"
-    end
+    return if status == 'ok'
+
+    error_code = doc.xpath('//err/@code').first&.value || 'unknown'
+    error_text = doc.xpath('//err').first&.children&.text || 'unknown error message'
+    raise "Error in Pardot response: code #{error_code}, #{error_text}"
   end
 end

--- a/lib/cdo/contact_rollups/v2/pardot_helpers.rb
+++ b/lib/cdo/contact_rollups/v2/pardot_helpers.rb
@@ -1,0 +1,111 @@
+module PardotHelpers
+  class InvalidApiKeyException < RuntimeError
+  end
+
+  PARDOT_AUTHENTICATION_URL = "https://pi.pardot.com/api/login/version/4".freeze
+  PARDOT_SUCCESS_HTTP_CODES = %w(200 201 204).freeze
+
+  private
+
+  # Login to Pardot and request an API key. The API key is valid for (up to) one
+  # hour, after which it will become invalid and we will need to request a new
+  # one.
+  # @return [String] API key to use for subsequent requests
+  def request_pardot_api_key
+    puts "Requesting new API key"
+    doc = post_request(
+      PARDOT_AUTHENTICATION_URL,
+      {
+        email: CDO.pardot_username,
+        password: CDO.pardot_password,
+        user_key: CDO.pardot_user_key
+      }
+    )
+
+    status = doc.xpath('/rsp/@stat').text
+    if status != "ok"
+      raise "Pardot authentication response failed with status #{status}  #{doc}"
+    end
+
+    api_key = doc.xpath('/rsp/api_key').text
+    raise "Pardot authentication response did not include api_key" if api_key.nil?
+
+    $pardot_api_key = api_key
+  end
+
+  # Make an API request with Pardot authentication, including appending auth
+  # params and refreshing Pardot API key and retrying if necessary.
+  # @param url [String] URL to post to
+  # @return [Nokogiri::XML, nil] XML response from Pardot
+  def post_with_auth_retry(url)
+    post_request_with_auth(url)
+  rescue InvalidApiKeyException
+    # If we fail with an invalid key, that probably means our API key (which is
+    # good for one hour) has expired. Try one time to request a new API key and
+    # try the post again. If that fails, that is a fatal error.
+    request_pardot_api_key
+    post_request_with_auth(url)
+  end
+
+  # Make an API request with Pardot authentication
+  # @param url [String] URL to post to. The URL passed in should not contain
+  #   auth params, as auth params will get appended in this method.
+  # @return [Nokogiri::XML] XML response from Pardot
+  def post_request_with_auth(url)
+    request_pardot_api_key if $pardot_api_key.nil?
+
+    # add the API key and user key parameters to body of the POST request
+    post_request(
+      url,
+      {
+        api_key: $pardot_api_key,
+        user_key: CDO.pardot_user_key
+      }
+    )
+  end
+
+  # Make an API request. This method may raise exceptions.
+  # @param url [String] URL to post to - must already include Pardot auth params
+  #   in query string
+  # @param params [Hash] hash of POST params (may be empty hash)
+  # @return [Nokogiri::XML, nil] XML response from Pardot
+  def post_request(url, params)
+    uri = URI(url)
+
+    response = Net::HTTP.post_form(uri, params)
+
+    # Do common error handling for Pardot response.
+    unless PARDOT_SUCCESS_HTTP_CODES.include?(response.code)
+      raise "Pardot request failed with HTTP #{response.code}"
+    end
+
+    if response.code == '204'
+      return nil
+    end
+
+    doc = Nokogiri::XML(response.body, &:noblanks)
+    raise "Pardot response did not return parsable XML" if doc.nil?
+
+    error_details = doc.xpath('/rsp/err').text
+    raise InvalidApiKeyException if error_details.include? "Invalid API key or user key"
+
+    status = doc.xpath('/rsp/@stat').text
+    raise "Pardot response did not include status" if status.nil?
+
+    doc
+  end
+
+  # Parse a Pardot XML response and raise an exception on the first error
+  # if there is one.
+  # @param doc [Nokogiri::XML] XML response from Pardot
+  def raise_if_response_error(doc)
+    status = doc.xpath('/rsp/@stat').text
+    if status != "ok"
+      error_text = doc.xpath('/rsp/errors/*').first.try(:text)
+      error_text = "Unknown error" if error_text.nil? || error_text.empty?
+      puts doc.to_s
+      puts error_text
+      raise "Error in Pardot response: #{error_text}"
+    end
+  end
+end

--- a/lib/cdo/contact_rollups/v2/pardot_helpers.rb
+++ b/lib/cdo/contact_rollups/v2/pardot_helpers.rb
@@ -7,6 +7,9 @@ module PardotHelpers
 
   private
 
+  # Note: Pardot API key can become invalid and need to be refreshed midstream.
+  @@pardot_api_key = nil
+
   # Login to Pardot and request an API key. The API key is valid for (up to) one
   # hour, after which it will become invalid and we will need to request a new
   # one.
@@ -30,7 +33,7 @@ module PardotHelpers
     api_key = doc.xpath('/rsp/api_key').text
     raise "Pardot authentication response did not include api_key" if api_key.nil?
 
-    $pardot_api_key = api_key
+    @@pardot_api_key = api_key
   end
 
   # Make an API request with Pardot authentication, including appending auth
@@ -52,13 +55,12 @@ module PardotHelpers
   #   auth params, as auth params will get appended in this method.
   # @return [Nokogiri::XML] XML response from Pardot
   def post_request_with_auth(url)
-    request_pardot_api_key if $pardot_api_key.nil?
+    request_pardot_api_key if @@pardot_api_key.nil?
 
-    # add the API key and user key parameters to body of the POST request
     post_request(
       url,
       {
-        api_key: $pardot_api_key,
+        api_key: @@pardot_api_key,
         user_key: CDO.pardot_user_key
       }
     )

--- a/lib/test/cdo/contact_rollups/test_pardot_helpers.rb
+++ b/lib/test/cdo/contact_rollups/test_pardot_helpers.rb
@@ -1,5 +1,4 @@
-require 'minitest/autorun'
-require 'nokogiri'
+require_relative '../../test_helper'
 require 'cdo/contact_rollups/v2/pardot_helpers'
 
 class PardotHelpersTest < Minitest::Test

--- a/lib/test/cdo/contact_rollups/test_pardot_helpers.rb
+++ b/lib/test/cdo/contact_rollups/test_pardot_helpers.rb
@@ -1,0 +1,36 @@
+require 'minitest/autorun'
+require 'nokogiri'
+require 'cdo/contact_rollups/v2/pardot_helpers'
+
+class PardotHelpersTest < Minitest::Test
+  extend PardotHelpers
+
+  def test_raise_if_response_error
+    # List of Pardot error codes: http://developer.pardot.com/kb/error-codes-messages/
+    error_code = 51
+    error_text = 'Invalid parameter'
+    pardot_error = Nokogiri::XML <<-XML
+      <rsp stat="fail" version="1.0">
+        <err code="#{error_code}">#{error_text}</err>
+      </rsp>
+    XML
+
+    exception = assert_raises do
+      PardotHelpersTest.send(:raise_if_response_error, pardot_error)
+    end
+
+    assert_match /#{error_code}.*#{error_text}/, exception.message
+  end
+
+  def test_raise_if_response_error_no_error
+    pardot_ok = Nokogiri::XML <<-XML
+      <rsp stat="ok" version="1.0">
+        <result>
+          <total_results>0</total_results>
+        </result>
+      </rsp>
+    XML
+
+    assert_nil PardotHelpersTest.send(:raise_if_response_error, pardot_ok)
+  end
+end

--- a/lib/test/cdo/contact_rollups/test_pardot_helpers.rb
+++ b/lib/test/cdo/contact_rollups/test_pardot_helpers.rb
@@ -15,6 +15,7 @@ class PardotHelpersTest < Minitest::Test
     XML
 
     exception = assert_raises do
+      # Since the method we want to test is a private method, we have to invoke it using `send`
       PardotHelpersTest.send(:raise_if_response_error, pardot_error)
     end
 

--- a/lib/test/cdo/contact_rollups/test_pardot_v2.rb
+++ b/lib/test/cdo/contact_rollups/test_pardot_v2.rb
@@ -1,6 +1,4 @@
-require 'minitest/autorun'
-require 'mocha/mini_test'
-require 'nokogiri'
+require_relative '../../test_helper'
 require 'cdo/contact_rollups/v2/pardot'
 
 class PardotV2Test < Minitest::Test

--- a/lib/test/cdo/contact_rollups/test_pardot_v2.rb
+++ b/lib/test/cdo/contact_rollups/test_pardot_v2.rb
@@ -1,0 +1,40 @@
+require 'minitest/autorun'
+require 'mocha/mini_test'
+require 'nokogiri'
+require 'cdo/contact_rollups/v2/pardot'
+
+class PardotV2Test < Minitest::Test
+  def test_retrieve_new_ids_without_result
+    xml_content = <<-XML
+      <rsp stat="ok">
+        <result>
+          <total_results>0</total_results>
+        </result>
+      </rsp>
+    XML
+
+    PardotV2.stubs(:post_with_auth_retry).returns(Nokogiri::XML(xml_content))
+
+    assert_equal [], PardotV2.retrieve_new_ids
+  end
+
+  def test_retrieve_new_ids_with_result
+    pardot_id = 1
+    email = "alex@rollups.com"
+    xml_content = <<-XML
+      <rsp stat="ok">
+        <result>
+          <prospect>
+            <id>#{pardot_id}</id>
+            <email>#{email}</email>
+          </prospect>
+          <total_results>1</total_results>
+        </result>
+      </rsp>
+    XML
+    PardotV2.stubs(:post_with_auth_retry).returns(Nokogiri::XML(xml_content))
+
+    expected_result = [{email: email, pardot_id: pardot_id}]
+    assert_equal expected_result, PardotV2.retrieve_new_ids
+  end
+end

--- a/lib/test/cdo/contact_rollups/test_pardot_v2.rb
+++ b/lib/test/cdo/contact_rollups/test_pardot_v2.rb
@@ -13,7 +13,7 @@ class PardotV2Test < Minitest::Test
 
     PardotV2.stubs(:post_with_auth_retry).returns(pardot_response)
 
-    assert_equal [], PardotV2.retrieve_new_ids
+    assert_equal [], PardotV2.retrieve_new_ids(0)
   end
 
   def test_retrieve_new_ids_with_result
@@ -33,6 +33,6 @@ class PardotV2Test < Minitest::Test
     PardotV2.stubs(:post_with_auth_retry).returns(pardot_response)
 
     expected_result = [{email: email, pardot_id: pardot_id}]
-    assert_equal expected_result, PardotV2.retrieve_new_ids
+    assert_equal expected_result, PardotV2.retrieve_new_ids(0)
   end
 end

--- a/lib/test/cdo/contact_rollups/test_pardot_v2.rb
+++ b/lib/test/cdo/contact_rollups/test_pardot_v2.rb
@@ -5,7 +5,7 @@ require 'cdo/contact_rollups/v2/pardot'
 
 class PardotV2Test < Minitest::Test
   def test_retrieve_new_ids_without_result
-    xml_content = <<-XML
+    pardot_response = Nokogiri::XML <<-XML
       <rsp stat="ok">
         <result>
           <total_results>0</total_results>
@@ -13,7 +13,7 @@ class PardotV2Test < Minitest::Test
       </rsp>
     XML
 
-    PardotV2.stubs(:post_with_auth_retry).returns(Nokogiri::XML(xml_content))
+    PardotV2.stubs(:post_with_auth_retry).returns(pardot_response)
 
     assert_equal [], PardotV2.retrieve_new_ids
   end
@@ -21,7 +21,7 @@ class PardotV2Test < Minitest::Test
   def test_retrieve_new_ids_with_result
     pardot_id = 1
     email = "alex@rollups.com"
-    xml_content = <<-XML
+    pardot_response = Nokogiri::XML <<-XML
       <rsp stat="ok">
         <result>
           <prospect>
@@ -32,7 +32,7 @@ class PardotV2Test < Minitest::Test
         </result>
       </rsp>
     XML
-    PardotV2.stubs(:post_with_auth_retry).returns(Nokogiri::XML(xml_content))
+    PardotV2.stubs(:post_with_auth_retry).returns(pardot_response)
 
     expected_result = [{email: email, pardot_id: pardot_id}]
     assert_equal expected_result, PardotV2.retrieve_new_ids


### PR DESCRIPTION
Logic to extract email-pardot ID mappings from Pardot -- reuses code from previous contact rollups to either a) create a mapping for a given email if one doesn't already exist, or b) update mappings where a newer mapping was found.

Separates common Pardot helpers into private methods in `PardotHelpers` module, and contact rollups-specific logic into new `PardotV2` class. Also makes the Pardot API key a class (module?) variable on `PardotHelpers`, instead of a global variable. Actual logic inside of `ContactRollupsPardotMemory` is minimal.

## Testing story

Lots of testing added here (thanks to @hacodeorg!), including:
- unit tests for ContactRollupsPardotMemory (eg, importing email-pardot ID mappings onto our database)
- unit tests for Pardot helpers (eg, connection/response errors)
- unit tests for PardotV2 (eg, retrieve XML response from Pardot)

## Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
