### PR TITLE
 add a script to simulate rendering the last year's worth of emails 

### DIFF
--- a/lib/cdo/poste.rb
+++ b/lib/cdo/poste.rb
@@ -298,8 +298,8 @@ module Poste
 
     def renderer
       @@renderer ||= begin
-        require 'cdo/pegasus/actionview_sinatra'
-        ActionView::Template.register_template_handler :md, ActionViewSinatra::MarkdownHandler
+        require 'cdo/markdown_handler'
+        MarkdownHandler.register
         ActionView::Base.new
       end
     end

--- a/lib/scripts/test_poste_deliveries.rb
+++ b/lib/scripts/test_poste_deliveries.rb
@@ -1,0 +1,27 @@
+#!/usr/bin/env ruby
+require File.expand_path('../../../pegasus/src/env', __FILE__)
+require 'cdo/db'
+require 'cdo/poste'
+
+# Create a [poste_messages.id -> template] hash of poste_messages so we don't
+# need to query for each delivery
+templates = POSTE_DB[:poste_messages].to_hash(:id, :name).map do |id, name|
+  # copied from Deliverer.load_template
+  path = Poste.resolve_template(name)
+  raise ArgumentError, "#{name.inspect} template wasn't found." unless path
+  template = Poste::Template.new path
+  [id, template]
+end.to_h
+
+# for each email we've delivered in the last year, simply attempt to render the
+# email so we will trigger the existing "ActionView/TextRender incompatibility"
+# warnings for that email.
+#
+# We do this because many of our emails are seasonal, so if we want to test
+# this thoroughly with the existing passive approach, we'd have to wait like a
+# year to be sure.
+POSTE_DB[:poste_deliveries].where("sent_at > '2019-01-01'").each do |delivery|
+  template = templates[delivery[:message_id]]
+  raise ValueError, "poste_messages[#{delivery[:message_id]}] does not exist" unless template
+  template.render(JSON.parse(delivery[:params]))
+end

--- a/lib/scripts/test_poste_deliveries.rb
+++ b/lib/scripts/test_poste_deliveries.rb
@@ -23,7 +23,7 @@ end.to_h
 deliveries = POSTE_DB[:poste_deliveries].where("sent_at > '2019-01-01'")
 total = deliveries.count
 i = 0
-deliveries.each do |delivery|
+deliveries.paged_each do |delivery|
   template = templates[delivery[:message_id]]
   raise ValueError, "poste_messages[#{delivery[:message_id]}] does not exist" unless template
   template.render(JSON.parse(delivery[:params]))

--- a/lib/scripts/test_poste_deliveries.rb
+++ b/lib/scripts/test_poste_deliveries.rb
@@ -20,8 +20,13 @@ end.to_h
 # We do this because many of our emails are seasonal, so if we want to test
 # this thoroughly with the existing passive approach, we'd have to wait like a
 # year to be sure.
-POSTE_DB[:poste_deliveries].where("sent_at > '2019-01-01'").each do |delivery|
+deliveries = POSTE_DB[:poste_deliveries].where("sent_at > '2019-01-01'")
+total = deliveries.count
+i = 0
+deliveries.each do |delivery|
   template = templates[delivery[:message_id]]
   raise ValueError, "poste_messages[#{delivery[:message_id]}] does not exist" unless template
   template.render(JSON.parse(delivery[:params]))
+  i += 1
+  puts "#{i}/#{total} finished (#{i * 100 / total}%)" if i % (total / 5) == 0
 end


### PR DESCRIPTION
Follow-up to https://github.com/code-dot-org/code-dot-org/pull/33399, which added an alternate ActionView-powered method for rendering our Poste emails, as well as testing to make sure that method produces identical results to our existing TextRender method.

Unfortunately, as @islemaster pointed out, many of our email our seasonal so this testing approach will have to run for a super long time for us to be confident in its results.

Instead, I propose this approach; we simply attempt to render every email we've sent in the last year, which should trigger the honeybadger reports if there are any errors or (ideally!) pass completely and give us the confidence we need to remove the old TextRender implementation entirely.

## Testing Story

Manually tested locally against the emails I have in my local `poste_deliveries` database by running once and confirming it was silent, then making a small change to one of the email templates, running again, and confirming that I got errors.

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
