### PR TITLE
Make blockly levels vertically responsive

### DIFF
--- a/apps/style/common.scss
+++ b/apps/style/common.scss
@@ -460,25 +460,29 @@ html[dir='rtl'] div#visualizationResizeBar {
   }
 }
 
-@media screen and (min-width: 1101px) and (max-width: 1150px) {
+@media screen and (min-width: 1101px) and (max-width: 1150px),
+       screen and (min-height: 801px) and (max-height: 900px) {
   @include visualization-width(350px);
   @include studio-dpad-container-width(350px);
   @include karel-counter(20px, 1.2px);
 }
 
-@media screen and (min-width: 1051px) and (max-width: 1100px) {
+@media screen and (min-width: 1051px) and (max-width: 1100px),
+       screen and (min-height: 701px) and (max-height: 800px) {
   @include visualization-width(300px);
   @include studio-dpad-container-width(300px);
   @include karel-counter(24px, 1.4px);
 }
 
-@media screen and (min-width: 1001px) and (max-width: 1050px) {
+@media screen and (min-width: 1001px) and (max-width: 1050px),
+       screen and (min-height: 601px) and (max-height: 700px) {
   @include visualization-width(250px);
   @include studio-dpad-container-width(250px);
   @include karel-counter(28px, 1.6px);
 }
 
-@media screen and (max-width: 1000px) {
+@media screen and (max-width: 1000px),
+       screen and (max-height: 600px) {
   @include visualization-width(200px);
   @include studio-dpad-container-width(200px);
   @include karel-counter(32px, 2px);

--- a/dashboard/lib/tasks/seed.rake
+++ b/dashboard/lib/tasks/seed.rake
@@ -80,6 +80,7 @@ namespace :seed do
     'coursea-2019',
     'coursec-2019',
     'coursee-2019',
+    'csd3-2019',
     'csp1-2017',
     'csp2-2017',
     'csp3-2017',

--- a/dashboard/test/ui/features/star_labs/can_see_finish.feature
+++ b/dashboard/test/ui/features/star_labs/can_see_finish.feature
@@ -1,0 +1,47 @@
+Feature: Make sure we can see the finish button for all LEVEL TYPE levels on small screens
+
+  @no_mobile
+  Scenario: Can see finish button for free play "Dance Party", "Artist", "Bounce" on small screens
+    Given I create an authorized teacher-associated student named "Sally"
+    And I sign in as "Teacher_Sally" and go home
+
+    And I check that the blockly free play level for "Dance Party" shows the finish button for small screens
+    And I check that the blockly free play level for "Artist" shows the finish button for small screens
+    And I check that the blockly free play level for "Bounce" shows the finish button for small screens
+    And I check that the blockly free play level for "CS in Algebra" shows the finish button for small screens
+    And I check that the blockly free play level for "Flappy" shows the finish button for small screens
+    And I check that the blockly free play level for "Sprite Lab" shows the finish button for small screens
+
+    And I check that the droplet free play level for "Game Lab" shows the finish button for small screens
+
+    And I check that the minecraft free play level for "Minecraft Adventurer" shows the finish button for small screens
+
+    # The following levels currently do not render finish button for small screens.
+    # TODO: Fid this - https://codedotorg.atlassian.net/browse/LP-1318
+    #And I check that the minecraft free play level for "Minecraft Heroes Journey" shows the finish button for small screens
+    #And I check that the minecraft free play level for "Minecraft Designer" shows the finish button for small screens
+    #And I check that the droplet free play level for "App Lab" shows the finish button for small screens
+
+
+  @no_ie @no_safari @no_firefox @no_chrome
+  Scenario: Can see finish for free play levels on mobile
+    Given I create an authorized teacher-associated student named "Sally"
+    And I sign in as "Teacher_Sally" and go home
+
+    And I check that the blockly free play level for "Dance Party" shows the finish button for mobile screens
+    And I check that the blockly free play level for "Artist" shows the finish button for mobile screens
+    And I check that the blockly free play level for "CS in Algebra" shows the finish button for mobile screens
+    And I check that the blockly free play level for "Flappy" shows the finish button for mobile screens
+    And I check that the blockly free play level for "Sprite Lab" shows the finish button for mobile screens
+
+    And I check that the droplet free play level for "Game Lab" shows the finish button for mobile screens
+
+    And I check that the minecraft free play level for "Minecraft Adventurer" shows the finish button for mobile screens
+
+    # The following levels currently do not render finish button for iphone, but do on ipad
+    # TODO: Fid this - https://codedotorg.atlassian.net/browse/LP-1318
+    #And I check that the blockly free play level for "Bounce" shows the finish button for mobile screens
+    #And I check that the droplet free play level for "App Lab" shows the finish button for mobile screens
+    #And I check that the minecraft free play level for "Minecraft Heroes Journey" shows the finish button for mobile screens
+    #And I check that the minecraft free play level for "Minecraft Designer" shows the finish button for mobile screens
+

--- a/dashboard/test/ui/features/star_labs/can_see_finish.feature
+++ b/dashboard/test/ui/features/star_labs/can_see_finish.feature
@@ -36,8 +36,10 @@ Feature: Make sure we can see the finish button for all LEVEL TYPE levels on sma
   Scenario: can see finish button on "Minecraft Adventurer"
     And I check that the minecraft free play level for "Minecraft Adventurer" shows the finish button for small screens
 
-  # The following levels currently do not render finish button for small screens.
-  # TODO: Fid this - https://codedotorg.atlassian.net/browse/LP-1318
+  # The following levels currently do not show finish button
+  # in the viewport when play is pressed for small screens.
+
+  # TODO: Fix this - https://codedotorg.atlassian.net/browse/LP-1318
     # "Minecraft Heroes Journey"
     # "Minecraft Designer"
     # "App Lab"
@@ -71,8 +73,10 @@ Feature: Make sure we can see the finish button for all LEVEL TYPE levels on sma
   Scenario: can see finish button on "Minecraft Adventurer"
     And I check that the minecraft free play level for "Minecraft Adventurer" shows the finish button for small screens
 
-  # The following levels currently do not render finish button for iphone, but do on ipad
-  # TODO: Fid this - https://codedotorg.atlassian.net/browse/LP-1318
+  # The following levels currently do not show finish button
+  # in the viewport when play is pressed for iphone, but do on ipad
+  
+  # TODO: Fix # this - https://codedotorg.atlassian.net/browse/LP-1318
     # "Minecraft Heroes Journey"
     # "Minecraft Designer"
     # "App Lab"

--- a/dashboard/test/ui/features/star_labs/can_see_finish.feature
+++ b/dashboard/test/ui/features/star_labs/can_see_finish.feature
@@ -1,47 +1,80 @@
 Feature: Make sure we can see the finish button for all LEVEL TYPE levels on small screens
 
-  @no_mobile
-  Scenario: Can see finish button for free play "Dance Party", "Artist", "Bounce" on small screens
+  Background:
     Given I create an authorized teacher-associated student named "Sally"
     And I sign in as "Teacher_Sally" and go home
 
+  @no_mobile
+  Scenario: can see finish button on "Dance Party"
     And I check that the blockly free play level for "Dance Party" shows the finish button for small screens
+
+  @no_mobile
+  Scenario: can see finish button on "Artist"
     And I check that the blockly free play level for "Artist" shows the finish button for small screens
+
+  @no_mobile
+  Scenario: can see finish button on "Bounce"
     And I check that the blockly free play level for "Bounce" shows the finish button for small screens
+
+  @no_mobile
+  Scenario: can see finish button on "CS in Algebra"
     And I check that the blockly free play level for "CS in Algebra" shows the finish button for small screens
+
+  @no_mobile
+  Scenario: can see finish button on "Flappy"
     And I check that the blockly free play level for "Flappy" shows the finish button for small screens
+
+  @no_mobile
+  Scenario: can see finish button on "Sprite Lab"
     And I check that the blockly free play level for "Sprite Lab" shows the finish button for small screens
 
+  @no_mobile
+  Scenario: can see finish button on "Game Lab"
     And I check that the droplet free play level for "Game Lab" shows the finish button for small screens
 
+  @no_mobile
+  Scenario: can see finish button on "Minecraft Adventurer"
     And I check that the minecraft free play level for "Minecraft Adventurer" shows the finish button for small screens
 
-    # The following levels currently do not render finish button for small screens.
-    # TODO: Fid this - https://codedotorg.atlassian.net/browse/LP-1318
-    #And I check that the minecraft free play level for "Minecraft Heroes Journey" shows the finish button for small screens
-    #And I check that the minecraft free play level for "Minecraft Designer" shows the finish button for small screens
-    #And I check that the droplet free play level for "App Lab" shows the finish button for small screens
+  # The following levels currently do not render finish button for small screens.
+  # TODO: Fid this - https://codedotorg.atlassian.net/browse/LP-1318
+    # "Minecraft Heroes Journey"
+    # "Minecraft Designer"
+    # "App Lab"
+
+  @no_ie @no_safari @no_firefox @no_chrome
+  Scenario: can see finish button on "Dance Party"
+    And I check that the blockly free play level for "Dance Party" shows the finish button for small screens
+
+  @no_ie @no_safari @no_firefox @no_chrome
+  Scenario: can see finish button on "Artist"
+    And I check that the blockly free play level for "Artist" shows the finish button for small screens
 
 
   @no_ie @no_safari @no_firefox @no_chrome
-  Scenario: Can see finish for free play levels on mobile
-    Given I create an authorized teacher-associated student named "Sally"
-    And I sign in as "Teacher_Sally" and go home
+  Scenario: can see finish button on "CS in Algebra"
+    And I check that the blockly free play level for "CS in Algebra" shows the finish button for small screens
 
-    And I check that the blockly free play level for "Dance Party" shows the finish button for mobile screens
-    And I check that the blockly free play level for "Artist" shows the finish button for mobile screens
-    And I check that the blockly free play level for "CS in Algebra" shows the finish button for mobile screens
-    And I check that the blockly free play level for "Flappy" shows the finish button for mobile screens
-    And I check that the blockly free play level for "Sprite Lab" shows the finish button for mobile screens
+  @no_ie @no_safari @no_firefox @no_chrome
+  Scenario: can see finish button on "Flappy"
+    And I check that the blockly free play level for "Flappy" shows the finish button for small screens
 
-    And I check that the droplet free play level for "Game Lab" shows the finish button for mobile screens
+  @no_ie @no_safari @no_firefox @no_chrome
+  Scenario: can see finish button on "Sprite Lab"
+    And I check that the blockly free play level for "Sprite Lab" shows the finish button for small screens
 
-    And I check that the minecraft free play level for "Minecraft Adventurer" shows the finish button for mobile screens
+  @no_ie @no_safari @no_firefox @no_chrome
+  Scenario: can see finish button on "Game Lab"
+    And I check that the droplet free play level for "Game Lab" shows the finish button for small screens
 
-    # The following levels currently do not render finish button for iphone, but do on ipad
-    # TODO: Fid this - https://codedotorg.atlassian.net/browse/LP-1318
-    #And I check that the blockly free play level for "Bounce" shows the finish button for mobile screens
-    #And I check that the droplet free play level for "App Lab" shows the finish button for mobile screens
-    #And I check that the minecraft free play level for "Minecraft Heroes Journey" shows the finish button for mobile screens
-    #And I check that the minecraft free play level for "Minecraft Designer" shows the finish button for mobile screens
+  @no_ie @no_safari @no_firefox @no_chrome
+  Scenario: can see finish button on "Minecraft Adventurer"
+    And I check that the minecraft free play level for "Minecraft Adventurer" shows the finish button for small screens
+
+  # The following levels currently do not render finish button for iphone, but do on ipad
+  # TODO: Fid this - https://codedotorg.atlassian.net/browse/LP-1318
+    # "Minecraft Heroes Journey"
+    # "Minecraft Designer"
+    # "App Lab"
+    # "Bounce"
 

--- a/dashboard/test/ui/features/step_definitions/browser_control.rb
+++ b/dashboard/test/ui/features/step_definitions/browser_control.rb
@@ -6,7 +6,7 @@ end
 # https://stackoverflow.com/questions/45243992/verification-of-element-in-viewport-in-selenium
 And(/^I check that selector "([^"]*)" is in the viewport$/) do |selector|
   is_in_viewport = <<-JAVASCRIPT
-    var elem = $("#{selector}")[0],  //arguments[0],
+    var elem = $("#{selector}")[0],
       box = elem.getBoundingClientRect(),
       cx = box.left + box.width / 2,
       cy = box.top + box.height / 2,

--- a/dashboard/test/ui/features/step_definitions/browser_control.rb
+++ b/dashboard/test/ui/features/step_definitions/browser_control.rb
@@ -1,0 +1,22 @@
+And(/^I change the browser window size to (\d+) by (\d+)$/) do |length, height|
+  @browser.manage.window.resize_to(length, height)
+end
+
+# for explanation of js function, see
+# https://stackoverflow.com/questions/45243992/verification-of-element-in-viewport-in-selenium
+And(/^I check that selector "([^"]*)" is in the viewport$/) do |selector|
+  is_in_viewport = <<-JAVASCRIPT
+    var elem = $("#{selector}")[0],  //arguments[0],
+      box = elem.getBoundingClientRect(),
+      cx = box.left + box.width / 2,
+      cy = box.top + box.height / 2,
+      e = document.elementFromPoint(cx, cy);
+    for(; e; e = e.parentElement) {
+      if (e === elem)
+        return true;
+    }
+    return false;
+  JAVASCRIPT
+  wait_for_jquery
+  wait_until {@browser.execute_script(is_in_viewport) == true}
+end

--- a/dashboard/test/ui/features/step_definitions/check_finish_button.rb
+++ b/dashboard/test/ui/features/step_definitions/check_finish_button.rb
@@ -1,0 +1,41 @@
+# Helper steps for dance party levels
+free_play_level_urls = {
+  'blockly' => {
+    'Dance Party' => 'http://studio.code.org/s/dance/stage/1/puzzle/13?noautoplay=true',
+    'Artist' => 'http://studio.code.org/s/20-hour/stage/5/puzzle/10?noautoplay=true',
+    'Bounce' => 'http://studio.code.org/s/course3/stage/15/puzzle/10?noautoplay=true',
+    'CS in Algebra' => 'http://studio.code.org/s/algebra/stage/1/puzzle/2?noautoplay=true',
+    'Flappy' => 'http://studio.code.org/flappy/10?noautoplay=true',
+    'Sprite Lab' => 'http://studio.code.org/s/coursee-2018/stage/20/puzzle/9?noautoplay=true'
+  },
+  'droplet' => {
+    'App Lab' => 'http://studio.code.org/s/applab-intro/stage/1/puzzle/15?noautoplay=true',
+    'Game Lab' => 'http://studio.code.org/s/csd3-2019/stage/22/puzzle/12?noautoplay=true'
+  },
+  'minecraft' => {
+    'Minecraft Aquatic' => 'http://studio.code.org/s/aquatic/stage/1/puzzle/12?noautoplay=true',
+    'Minecraft Heroes Journey' => 'http://studio.code.org/s/hero/stage/1/puzzle/12?noautoplay=true',
+    'Minecraft Adventurer' => 'http://studio.code.org/s/mc/stage/1/puzzle/14?noautoplay=true',
+    'Minecraft Designer' => 'http://studio.code.org/s/minecraft/stage/1/puzzle/12?noautoplay=true'
+  }
+}
+
+When /^I check that the (blockly|droplet|minecraft) free play level for "([^"]*)" shows the finish button for (small|mobile) screens/i do |level_type, level_name, screen_type|
+  individual_steps <<-STEPS
+    And I set up the #{level_type} free play level for "#{level_name}"
+    #{screen_type == 'small' ? 'And I change the browser window size to 1366 by 600' : ''}
+    #{level_type == 'minecraft' ? 'And I wait until the Minecraft game is loaded' : ''}
+    And I press "runButton"
+    And I check that selector "button:contains('Finish')" is in the viewport
+  STEPS
+end
+
+When /^I set up the (blockly|droplet|minecraft) free play level for "([^"]*)"/i do |level_type, level_name|
+  individual_steps <<-STEPS
+    And I am on "#{free_play_level_urls[level_type][level_name]}"
+    And I rotate to landscape
+    And I wait for the page to fully load
+    And I bypass the age dialog
+    And I close the instructions overlay if it exists
+  STEPS
+end

--- a/dashboard/test/ui/features/step_definitions/check_finish_button.rb
+++ b/dashboard/test/ui/features/step_definitions/check_finish_button.rb
@@ -6,7 +6,7 @@ free_play_level_urls = {
     'Bounce' => 'http://studio.code.org/s/course3/stage/15/puzzle/10?noautoplay=true',
     'CS in Algebra' => 'http://studio.code.org/s/algebra/stage/1/puzzle/2?noautoplay=true',
     'Flappy' => 'http://studio.code.org/flappy/10?noautoplay=true',
-    'Sprite Lab' => 'http://studio.code.org/s/coursee-2018/stage/20/puzzle/9?noautoplay=true'
+    'Sprite Lab' => 'http://studio.code.org/s/coursee-2019/stage/9/puzzle/6?noautoplay=true'
   },
   'droplet' => {
     'App Lab' => 'http://studio.code.org/s/applab-intro/stage/1/puzzle/15?noautoplay=true',


### PR DESCRIPTION
As part of investigating the linked jira task, checked weather the finish button renders on low res screens for all free play levels I could find. 

In this context, low res is defined to be 1366 x 600 and mobile screens. This resolution was chosen because the problems we were experiencing in the linked JIRA ticket were due to a lack of scaling functionality for vertical scaling, since we already had functionality for horizontal scaling.

This fix resolves the problem on most free play levels. There is a [follow up JIRA item](https://codedotorg.atlassian.net/browse/LP-1318) to fix this problem on the pages it wasn't fixed for yet with this fix. The pages that aren't working are outlined in the E2E test comments, and in the follow up jira item.

Credit to Brendan Reville for the SCSS changes for this fix.

<!-- ### Background -->
<!-- ### Privacy -->
<!-- ### Security -->
<!-- ### Caching -->
<!-- ### Deployment strategy -->
<!-- ### Future work -->

## Links

<!--
  Any relevant links to external resources; ie, specification documents, jira
  items, related PRs, honeybadger errors, etc
-->

- [jira](https://codedotorg.atlassian.net/browse/LP-1104)

## Testing story

Added E2E tests for most scenarios in this PR


# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
