### PR TITLE
Bump blockly to 3.5.8

### DIFF
--- a/apps/package.json
+++ b/apps/package.json
@@ -49,7 +49,7 @@
     "@babel/preset-react": "^7.0.0",
     "@cdo/interpreted": "link:../dashboard/config/libraries",
     "@code-dot-org/artist": "0.2.1",
-    "@code-dot-org/blockly": "3.5.7",
+    "@code-dot-org/blockly": "3.5.8",
     "@code-dot-org/bramble": "0.1.26",
     "@code-dot-org/craft": "0.2.2",
     "@code-dot-org/dance-party": "1.0.1",

--- a/apps/yarn.lock
+++ b/apps/yarn.lock
@@ -1526,10 +1526,10 @@
   version "0.2.1"
   resolved "https://registry.yarnpkg.com/@code-dot-org/artist/-/artist-0.2.1.tgz#fcfe7ea5cfb3f19ddb6b912e70e922ba4b7ef0b1"
 
-"@code-dot-org/blockly@3.5.7":
-  version "3.5.7"
-  resolved "https://registry.yarnpkg.com/@code-dot-org/blockly/-/blockly-3.5.7.tgz#9f313de7fb54682ec22c8a1ff0c4bd81a833b814"
-  integrity sha512-3kiAF1eOLAlKYV14p0TPcAkRQHE88GcUkQxt4xcDcEn3rW0tPMthgp2Yz03Lrfz0wRk54OI3rsYELLd4TmMXfg==
+"@code-dot-org/blockly@3.5.8":
+  version "3.5.8"
+  resolved "https://registry.yarnpkg.com/@code-dot-org/blockly/-/blockly-3.5.8.tgz#f3b9818dda8f955bce78b4454631da9c3766177f"
+  integrity sha512-X39kzCcfS8FsLcO5BTP3PQQHoHjAQ7VrSoplyNNR/hyAMRmddLZKdOBSNdyV+6YwuZDgu9/CMlJ76qeqRMCiMQ==
 
 "@code-dot-org/bramble@0.1.26":
   version "0.1.26"


### PR DESCRIPTION
Pulls in https://github.com/code-dot-org/blockly/pull/203 to fix https://studio.code.org/s/coursec-2019/stage/16/puzzle/6 on Firefox