### PR TITLE
Prototype: Crowd sense

### DIFF
--- a/apps/src/lib/util/PubSubService.js
+++ b/apps/src/lib/util/PubSubService.js
@@ -2,6 +2,7 @@
  * @overview Wrapped pub/sub service client APIs (like Pusher)
  */
 
+import _ from 'lodash';
 import Pusher from 'pusher-js';
 import {PusherChannel, NullChannel} from './PubSubChannel';
 
@@ -47,7 +48,10 @@ import {PusherChannel, NullChannel} from './PubSubChannel';
  */
 export default function create(pubSubConfig) {
   if (pubSubConfig.usePusher) {
-    return new PusherService(pubSubConfig.pusherApplicationKey);
+    return new PusherService(
+      pubSubConfig.pusherApplicationKey,
+      _.pick(pubSubConfig, ['auth', 'authEndpoint', 'forceTLS'])
+    );
   }
 
   return new NullService();
@@ -72,8 +76,8 @@ class NullService {
  * @implements IPubSubService
  */
 class PusherService {
-  constructor(applicationKey) {
-    this.api_ = new Pusher(applicationKey, {encrypted: true});
+  constructor(applicationKey, config = {}) {
+    this.api_ = new Pusher(applicationKey, {encrypted: true, ...config});
   }
 
   subscribe(channelID) {

--- a/apps/src/sites/studio/pages/shared/_header_progress.js
+++ b/apps/src/sites/studio/pages/shared/_header_progress.js
@@ -5,6 +5,7 @@ import {Provider} from 'react-redux';
 import ScriptName from '@cdo/apps/code-studio/components/header/ScriptName';
 import getScriptData from '@cdo/apps/util/getScriptData';
 import {getStore} from '@cdo/apps/redux';
+import createPubSub from '@cdo/apps/lib/util/PubSubService';
 
 const container = document.getElementsByClassName('script_name_container');
 if (container.length) {
@@ -14,4 +15,42 @@ if (container.length) {
     </Provider>,
     container[0]
   );
+
+  if (true) {
+    const usersIcon = document.createElement('i');
+    usersIcon.className = 'fa fa-fw fa-users';
+    const userCount = document.createElement('span');
+    userCount.textContent = '0';
+    const userCountDiv = document.createElement('div');
+    userCountDiv.appendChild(usersIcon);
+    userCountDiv.appendChild(userCount);
+    userCountDiv.style.marginRight = '1em';
+    container[0].parentNode.insertBefore(userCountDiv, container[0]);
+
+    const pubSub = createPubSub(getScriptData('pubSub'));
+    const channel = pubSub.subscribe(`presence-test`);
+
+    let users = 0;
+    const updateUserCount = () => {
+      userCount.textContent = String(users);
+      if (users > 1) {
+        usersIcon.className = 'fa fa-fw fa-users';
+      } else {
+        usersIcon.className = 'fa fa-fw fa-user';
+      }
+    };
+
+    channel.subscribe('pusher:subscription_succeeded', members => {
+      users = members.count;
+      updateUserCount();
+    });
+    channel.subscribe('pusher:member_added', () => {
+      users++;
+      updateUserCount();
+    });
+    channel.subscribe('pusher:member_removed', () => {
+      users--;
+      updateUserCount();
+    });
+  }
 }

--- a/dashboard/app/controllers/pusher_controller.rb
+++ b/dashboard/app/controllers/pusher_controller.rb
@@ -1,0 +1,25 @@
+# Auth endpoint for prototype pusher features
+require 'pusher'
+
+class PusherController < ApplicationController
+  def auth
+    @pusher = Pusher::Client.new(
+      app_id: CDO.pusher_app_id,
+      key: CDO.pusher_application_key,
+      secret: CDO.pusher_application_secret,
+      use_tls: true
+    )
+
+    if current_user
+      render json: @pusher.authenticate(
+        params[:channel_name],
+        params[:socket_id],
+        {
+          user_id: current_user.id
+        }
+      )
+    else
+      render text: 'Forbidden', status: '403'
+    end
+  end
+end

--- a/dashboard/app/views/shared/_header_progress.html.haml
+++ b/dashboard/app/views/shared/_header_progress.html.haml
@@ -27,5 +27,10 @@
 - content_for(:body_scripts) do
   - script_data = {scriptName: {name: text,
     href: script_path(@script, section_id: section_id, user_id: user_id),
-    smallText: small_text}.to_json}
+    smallText: small_text}.to_json,
+    pubSub: {usePusher: CDO.use_pusher,
+    pusherApplicationKey: CDO.pusher_application_key,
+    forceTLS: true,
+    authEndpoint: '/pusher/auth',
+    auth: {headers: {'X-CSRF-Token' => form_authenticity_token}}}.to_json}
   %script{type: "text/javascript", src: webpack_asset_path('js/shared/_header_progress.js'), data: script_data}

--- a/dashboard/config/routes.rb
+++ b/dashboard/config/routes.rb
@@ -47,6 +47,8 @@ Dashboard::Application.routes.draw do
     end
   end
 
+  post 'pusher/auth', to: 'pusher#auth'
+
   get 'maker/home', to: 'maker#home'
   get 'maker/setup', to: 'maker#setup'
   get 'maker/discountcode', to: 'maker#discountcode'


### PR DESCRIPTION
![Peek 2020-03-19 15-15](https://user-images.githubusercontent.com/1615761/77120490-32994c00-69f6-11ea-820c-9bb8aef11410.gif)

Quick tech demo using [Pusher](https://pusher.com) to show how many signed-in users are currently looking at puzzle pages.

Prototype limitations: Only works up to 100 people.

This tech could enable several different features:

- How many people are viewing this level/lesson right now?
- How many people _in my class_ are viewing this level/lesson/script right now?
- As a teacher, which of my students are online? Which levels are they working on?
- As a teacher, push-notify when a student finishes a level I can give feedback on.
- As a student, push-notify when my teacher leaves me feedback.
- (Long-term) Live progress view for teachers.
