### PR TITLE
Add /athome and /break to the i18n sync

### DIFF
--- a/bin/i18n/sync-in.rb
+++ b/bin/i18n/sync-in.rb
@@ -310,6 +310,7 @@ def localize_markdown_content
   markdown_files_to_localize = ['international/about.md.partial',
                                 'educate/curriculum/csf-transition-guide.md',
                                 'athome.md.partial',
+                                'athome/csf.md.partial',
                                 'break.md.partial',
                                 'csforgood.md']
   markdown_files_to_localize.each do |path|

--- a/bin/i18n/sync-in.rb
+++ b/bin/i18n/sync-in.rb
@@ -309,6 +309,8 @@ end
 def localize_markdown_content
   markdown_files_to_localize = ['international/about.md.partial',
                                 'educate/curriculum/csf-transition-guide.md',
+                                'athome.md.partial',
+                                'break.md.partial',
                                 'csforgood.md']
   markdown_files_to_localize.each do |path|
     original_path = File.join('pegasus/sites.v3/code.org/public', path)


### PR DESCRIPTION
```
crowdin --config <config_file> --identity <identity_file> upload sources --dryrun
athome.md
athome/csf.md
break.md
csforgood.md
educate/curriculum/csf-transition-guide.md
international/about.md
```

<!-- ### Background -->
<!-- ### Privacy -->
<!-- ### Security -->
<!-- ### Caching -->
<!-- ### Deployment strategy -->
<!-- ### Future work -->

## Links

<!--
  Any relevant links to external resources; ie, specification documents, jira
  items, related PRs, honeybadger errors, etc
-->

- [spec]()
- [jira]()

## Testing story

<!--
  Does your change include appropriate tests?

  If so, please describe how the tests included in this PR are sufficient

  If not, please explain why this change does not need to be tested.
-->

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
