### PR TITLE
Revert "Translate custom behaviors"

### DIFF
--- a/bin/i18n/sync-in.rb
+++ b/bin/i18n/sync-in.rb
@@ -78,6 +78,14 @@ def get_i18n_strings(level)
         name = function.at_xpath('./title[@name="NAME"]')
         i18n_strings['function_names'][name.content] = name.content if name
       end
+
+      # Spritelab behaviors
+      behaviors = blocks.xpath("//block[@type=\"behavior_definition\"]")
+      i18n_strings['behavior_names'] = Hash.new unless behaviors.empty?
+      behaviors.each do |behavior|
+        name = behavior.at_xpath('./title[@name="NAME"]')
+        i18n_strings['behavior_names'][name.content] = name.content if name
+      end
     end
   end
 

--- a/bin/i18n/sync-in.rb
+++ b/bin/i18n/sync-in.rb
@@ -78,14 +78,6 @@ def get_i18n_strings(level)
         name = function.at_xpath('./title[@name="NAME"]')
         i18n_strings['function_names'][name.content] = name.content if name
       end
-
-      # Spritelab behaviors
-      behaviors = blocks.xpath("//block[@type=\"behavior_definition\"]")
-      i18n_strings['behavior_names'] = Hash.new unless behaviors.empty?
-      behaviors.each do |behavior|
-        name = behavior.at_xpath('./title[@name="NAME"]')
-        i18n_strings['behavior_names'][name.content] = name.content if name
-      end
     end
   end
 

--- a/dashboard/app/models/levels/blockly.rb
+++ b/dashboard/app/models/levels/blockly.rb
@@ -515,29 +515,6 @@ class Blockly < Level
       )
       mutation.set_attribute('name', localized_name) if localized_name
     end
-    block_xml.xpath("//block[@type=\"gamelab_behavior_get\"]").each do |behavior|
-      behavior_name = behavior.at_xpath('./title[@name="VAR"]')
-      next unless behavior_name
-      localized_name = I18n.t(
-        behavior_name.content,
-        scope: [:data, :behavior_names, name],
-        default: nil,
-        smart: true
-      )
-      behavior_name.content = localized_name if localized_name
-    end
-    block_xml.xpath("//block[@type=\"behavior_definition\"]").each do |behavior|
-      behavior_name = behavior.at_xpath('./title[@name="NAME"]')
-      next unless behavior_name
-      localized_name = I18n.t(
-        behavior_name.content,
-        scope: [:data, :behavior_names, name],
-        default: nil,
-        smart: true
-      )
-      behavior_name.content = localized_name if localized_name
-    end
-
     return block_xml.serialize(save_with: XML_OPTIONS).strip
   end
 


### PR DESCRIPTION
Reverts code-dot-org/code-dot-org#33683

Some levels import shared functions and simultaneously define those same behaviors in the toolbox. These levels have weird behavior, like adding the behaviors twice.

![Screenshot 2020-03-20 at 9 30 59 AM](https://user-images.githubusercontent.com/46464143/77184789-8acf5d00-6a8d-11ea-9471-fb226d9fc998.png)
(`errante` is the translation I added for `wandering`. They were both added.)