### PR TITLE
fix adhoc daemon-instance userdata script

### DIFF
--- a/aws/cloudformation/cloud_formation_stack.yml.erb
+++ b/aws/cloudformation/cloud_formation_stack.yml.erb
@@ -446,15 +446,17 @@ Resources:
             VolumeSize: 64
             VolumeType: gp2
       UserData:
-        Fn::Base64: <%=file('bootstrap_chef_stack.sh.erb',
-          resource_id: daemon,
-          node_name: '$STACK',
-          run_list: local_mode ? ['recipe[cdo-apps]', 'recipe[cdo-home-ubuntu]'] : ['role[daemon]'],
-          commit: nil, # track branch
-          shutdown: false,
-          daemon: true,
-          chef_version: chef_version
-        )%>
+        Fn::Base64: !Sub |
+          #!/bin/bash -x
+          <%=indent(erb_file(aws_dir('cloudformation', 'bootstrap_chef_stack.sh.erb'),
+            resource_id: daemon,
+            node_name: '$STACK',
+            run_list: local_mode ? ['recipe[cdo-apps]', 'recipe[cdo-home-ubuntu]'] : ['role[daemon]'],
+            commit: nil, # track branch
+            shutdown: false,
+            daemon: true,
+            chef_version: chef_version
+          ), 10)%>
       NetworkInterfaces:
       - AssociatePublicIpAddress: true
         DeviceIndex: 0


### PR DESCRIPTION
This fixes a bug introduced in #33665 affecting adhoc instances, by re-adding the shell-script shebang header (`#!/bin/bash`) (removed from `bootstrap_chef_stack.sh.erb` since it was added to the `ami` component's userdata directly) to the daemon-instance resource's `UserData`.