### PR TITLE
GET /libraries/get_updates

### DIFF
--- a/dashboard/app/controllers/libraries_controller.rb
+++ b/dashboard/app/controllers/libraries_controller.rb
@@ -1,4 +1,5 @@
 class LibrariesController < ApplicationController
+  before_action :authenticate_user!, only: :get_updates
   before_action :require_levelbuilder_mode, except: [:show, :get_updates]
   load_and_authorize_resource find_by: :name, except: [:show, :get_updates]
 

--- a/dashboard/app/controllers/libraries_controller.rb
+++ b/dashboard/app/controllers/libraries_controller.rb
@@ -1,6 +1,6 @@
 class LibrariesController < ApplicationController
-  before_action :require_levelbuilder_mode, except: :show
-  load_and_authorize_resource find_by: :name, except: :show
+  before_action :require_levelbuilder_mode, except: [:show, :get_updates]
+  load_and_authorize_resource find_by: :name, except: [:show, :get_updates]
 
   def show
     render plain: Library.content_from_cache(params[:id])
@@ -28,6 +28,17 @@ class LibrariesController < ApplicationController
   def destroy
     @library.destroy
     redirect_to(libraries_path, notice: 'Library Deleted')
+  end
+
+  # GET /libraries/get_updates
+  #
+  # @param params[:libraries] [Array<Object>] Formatted as follows:
+  #   [{channel_id: 'abc123', version: 'xyz987'}]
+  # @returns [Array<String>] The libraries from the given libraries that have been updated
+  #   (e.g., that library has a different latestLibraryVersion than the given version).
+  def get_updates
+    libraries = params[:libraries].present? ? JSON.parse(params[:libraries]) : []
+    render json: ProjectsList.fetch_updated_library_channels(libraries)
   end
 
   private

--- a/dashboard/config/routes.rb
+++ b/dashboard/config/routes.rb
@@ -225,7 +225,12 @@ Dashboard::Application.routes.draw do
     resources :blocks, constraints: {id: /[^\/]+/}
   end
   resources :shared_blockly_functions, path: '/functions'
-  resources :libraries
+
+  resources :libraries do
+    collection do
+      get '/get_updates', to: 'libraries#get_updates'
+    end
+  end
 
   resources :datasets, param: 'dataset_name', only: [:index, :show, :update] do
     collection do

--- a/dashboard/lib/projects_list.rb
+++ b/dashboard/lib/projects_list.rb
@@ -167,8 +167,9 @@ module ProjectsList
       PEGASUS_DB[:storage_apps].where(id: project_ids).each do |project|
         library = libraries.find {|lib| lib['project_id'] == project[:id]}
         project_value = JSON.parse(project[:value])
+        next unless library && project_value['latestLibraryVersion']
 
-        if library && library['version'] != project_value['latestLibraryVersion']
+        if library['version'] != project_value['latestLibraryVersion']
           updated_library_channels << library['channel_id']
         end
       end

--- a/dashboard/lib/projects_list.rb
+++ b/dashboard/lib/projects_list.rb
@@ -163,6 +163,8 @@ module ProjectsList
         nil
       end.compact
 
+      return [] if project_ids.nil_or_empty?
+
       updated_library_channels = []
       PEGASUS_DB[:storage_apps].where(id: project_ids).each do |project|
         library = libraries.find {|lib| lib['project_id'] == project[:id]}

--- a/dashboard/lib/projects_list.rb
+++ b/dashboard/lib/projects_list.rb
@@ -161,7 +161,7 @@ module ProjectsList
         id
       rescue
         nil
-      end.compact
+      end.compact.uniq
 
       return [] if project_ids.nil_or_empty?
 

--- a/dashboard/test/lib/projects_list_test.rb
+++ b/dashboard/test/lib/projects_list_test.rb
@@ -406,6 +406,10 @@ class ProjectsListTest < ActionController::TestCase
     assert_equal [updated_channel_id], updated_channel_ids
   end
 
+  test 'fetch_updated_library_channels returns empty array if no libraries given' do
+    assert_equal [], ProjectsList.fetch_updated_library_channels([])
+  end
+
   private
 
   def user_db_result(result)

--- a/dashboard/test/lib/projects_list_test.rb
+++ b/dashboard/test/lib/projects_list_test.rb
@@ -378,6 +378,34 @@ class ProjectsListTest < ActionController::TestCase
     assert_equal teacher_name, lib_response[0][:userName]
   end
 
+  test 'fetch_updated_library_channels returns channel_ids of libraries that have been updated' do
+    updated_channel_id = storage_encrypt_channel_id(1, 1)
+    libraries = [
+      {'channel_id' => updated_channel_id, 'version' => '1'},
+      {'channel_id' => storage_encrypt_channel_id(1, 2), 'version' => '1'},
+      {'channel_id' => storage_encrypt_channel_id(1, 3), 'version' => '1'}
+    ]
+    stub_projects = [
+      {
+        id: 1,
+        value: {'latestLibraryVersion': '2'}.to_json
+      },
+      {
+        id: 2,
+        value: {'latestLibraryVersion': '1'}.to_json
+      },
+      {
+        id: 3,
+        value: {}.to_json
+      }
+    ]
+
+    PEGASUS_DB.stubs(:[]).returns(stub(where: stub_projects))
+
+    updated_channel_ids = ProjectsList.fetch_updated_library_channels(libraries)
+    assert_equal [updated_channel_id], updated_channel_ids
+  end
+
   private
 
   def user_db_result(result)


### PR DESCRIPTION
Adds a new endpoint that accepts an array of library objects and returns the channel_ids of the given libraries that have been updated since the given version.

**Note / Context:** The response for this request will be used to determine which libraries will display the "Update" button in the "Manage Libraries" modal (currently, all imported libraries have this button, even if there is no update available):
![Screen Shot 2020-03-20 at 11 25 12 AM](https://user-images.githubusercontent.com/9812299/77194648-9460c100-6a9d-11ea-9a6d-3fc15d997b33.png)

**Request:**
```
const libraries = [
  {channel_id: "abc123", version: "123"},
  {channel_id: "def456", version: "456"},
  {channel_id: "ghi789", version: "789"}
];

GET /libraries/get_updates?libraries=libraries                                   
```

**Let's say the following is true:**
- library with channel_id "abc123" has been updated since version "123"
- library with channel_id "def456" has not been updated since version "456"
- library with channel_id "ghi789" has been deleted since version "789"

**Response:**
The response is an array of channel_ids indicating the channels whose libraries have been updated since the given version:
```
["abc123"]
```


## Links

- [STAR-707](https://codedotorg.atlassian.net/browse/STAR-707) - part 3

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
