### PR TITLE
update "test emails" script to keep going if we encounter a nonexistent template

### DIFF
--- a/lib/scripts/test_poste_deliveries.rb
+++ b/lib/scripts/test_poste_deliveries.rb
@@ -8,7 +8,10 @@ require 'cdo/poste'
 templates = POSTE_DB[:poste_messages].to_hash(:id, :name).map do |id, name|
   # copied from Deliverer.load_template
   path = Poste.resolve_template(name)
-  raise ArgumentError, "#{name.inspect} template wasn't found." unless path
+  unless path
+    puts "#{name.inspect} template (id: #{id}) wasn't found."
+    next
+  end
   template = Poste::Template.new path
   [id, template]
 end.to_h
@@ -25,8 +28,7 @@ total = deliveries.count
 i = 0
 deliveries.paged_each do |delivery|
   template = templates[delivery[:message_id]]
-  raise ValueError, "poste_messages[#{delivery[:message_id]}] does not exist" unless template
-  template.render(JSON.parse(delivery[:params]))
+  template.render(JSON.parse(delivery[:params])) if template
   i += 1
   puts "#{i}/#{total} finished (#{i * 100 / total}%)" if i % (total / 5) == 0
 end


### PR DESCRIPTION
I tried to run this script on production, and got:

```bash
$ ./lib/scripts/test_poste_deliveries.rb
GetSecretValue: production/cdo/slack_token
Traceback (most recent call last):
        3: from ./lib/scripts/test_poste_deliveries.rb:8:in `<main>'
        2: from ./lib/scripts/test_poste_deliveries.rb:8:in `map'
        1: from ./lib/scripts/test_poste_deliveries.rb:8:in `each'
./lib/scripts/test_poste_deliveries.rb:11:in `block in <main>': "08-08-16-latam-hoc" template wasn't found. (ArgumentError)
```

In retrospect, I expect some to have been removed over the last year, so we don't want to completely fail if that happened. Instead, just log the failures and keep going.

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
