### PR TITLE
Show timestamp of when user last made progress in a script

### DIFF
--- a/apps/src/templates/sectionProgress/SectionProgress.jsx
+++ b/apps/src/templates/sectionProgress/SectionProgress.jsx
@@ -58,6 +58,10 @@ const styles = {
   },
   hide: {
     display: 'none'
+  },
+  studentTooltip: {
+    display: 'flex',
+    textAlign: 'center'
   }
 };
 
@@ -152,7 +156,11 @@ class SectionProgress extends Component {
           wrapper="span"
           effect="solid"
         >
-          {this.tooltipTextForStudent(studentId)}
+          <span style={styles.studentTooltip}>
+            Last Progress:
+            <br />
+            {this.tooltipTextForStudent(studentId)}
+          </span>
         </ReactTooltip>
       )
     );
@@ -162,8 +170,7 @@ class SectionProgress extends Component {
 
   tooltipTextForStudent = studentId => {
     const timestamp = this.props.studentTimestamps[studentId];
-    const time = timestamp ? moment(timestamp).calendar() : i18n.none();
-    return `Last Progress: ${time}`;
+    return timestamp ? moment(timestamp).calendar() : i18n.none();
   };
 
   navigateToScript = () => {

--- a/apps/src/templates/sectionProgress/SectionProgress.jsx
+++ b/apps/src/templates/sectionProgress/SectionProgress.jsx
@@ -162,7 +162,8 @@ class SectionProgress extends Component {
 
   tooltipTextForStudent = studentId => {
     const timestamp = this.props.studentTimestamps[studentId];
-    return `Last Progress: ${moment(timestamp * 1000).calendar()}`;
+    const time = timestamp ? moment(timestamp).calendar() : i18n.none();
+    return `Last Progress: ${time}`;
   };
 
   navigateToScript = () => {

--- a/apps/src/templates/sectionProgress/SectionProgress.jsx
+++ b/apps/src/templates/sectionProgress/SectionProgress.jsx
@@ -147,23 +147,22 @@ class SectionProgress extends Component {
       </ReactTooltip>
     ));
 
-    const studentTooltips = Object.keys(this.props.studentTimestamps).map(
-      studentId => (
-        <ReactTooltip
-          id={tooltipIdForStudent(studentId)}
-          key={tooltipIdForStudent(studentId)}
-          role="tooltip"
-          wrapper="span"
-          effect="solid"
-        >
-          <span style={styles.studentTooltip}>
-            Last Progress:
-            <br />
-            {this.tooltipTextForStudent(studentId)}
-          </span>
-        </ReactTooltip>
-      )
-    );
+    const studentTimestamps = this.props.studentTimestamps || {};
+    const studentTooltips = Object.keys(studentTimestamps).map(studentId => (
+      <ReactTooltip
+        id={tooltipIdForStudent(studentId)}
+        key={tooltipIdForStudent(studentId)}
+        role="tooltip"
+        wrapper="span"
+        effect="solid"
+      >
+        <span style={styles.studentTooltip}>
+          Last Progress:
+          <br />
+          {this.tooltipTextForStudent(studentId)}
+        </span>
+      </ReactTooltip>
+    ));
 
     return lessonTooltips.concat(studentTooltips);
   }

--- a/apps/src/templates/sectionProgress/SectionProgressNameCell.jsx
+++ b/apps/src/templates/sectionProgress/SectionProgressNameCell.jsx
@@ -3,6 +3,7 @@ import React, {Component} from 'react';
 import {connect} from 'react-redux';
 import {progressStyles} from './multiGridConstants';
 import {getSelectedScriptName} from '@cdo/apps/redux/scriptSelectionRedux';
+import {getStudentTimestamp} from '@cdo/apps/templates/sectionProgress/sectionProgressRedux';
 import {scriptUrlForStudent} from '@cdo/apps/templates/teacherDashboard/urlHelpers';
 import firehoseClient from '../../lib/util/firehose';
 
@@ -14,7 +15,8 @@ class SectionProgressNameCell extends Component {
 
     // Provided by redux.
     scriptName: PropTypes.string,
-    scriptId: PropTypes.number
+    scriptId: PropTypes.number,
+    studentTimestamp: PropTypes.number // seconds since epoch
   };
 
   recordStudentNameClick = () => {
@@ -34,11 +36,18 @@ class SectionProgressNameCell extends Component {
   };
 
   render() {
-    const {name, studentId, sectionId, scriptName} = this.props;
+    const {
+      name,
+      studentId,
+      sectionId,
+      scriptName,
+      studentTimestamp
+    } = this.props;
     const studentUrl = scriptUrlForStudent(sectionId, scriptName, studentId);
+    const title = `Last Progress: ${studentTimestamp}`;
 
     return (
-      <div style={progressStyles.nameCell}>
+      <div style={progressStyles.nameCell} title={title}>
         {studentUrl && (
           <a
             href={studentUrl}
@@ -55,7 +64,8 @@ class SectionProgressNameCell extends Component {
 }
 
 export const UnconnectedSectionProgressNameCell = SectionProgressNameCell;
-export default connect(state => ({
+export default connect((state, ownProps) => ({
   scriptName: getSelectedScriptName(state),
-  scriptId: state.scriptSelection.scriptId
+  scriptId: state.scriptSelection.scriptId,
+  studentTimestamp: getStudentTimestamp(state, ownProps.studentId)
 }))(SectionProgressNameCell);

--- a/apps/src/templates/sectionProgress/SectionProgressNameCell.jsx
+++ b/apps/src/templates/sectionProgress/SectionProgressNameCell.jsx
@@ -3,10 +3,9 @@ import React, {Component} from 'react';
 import {connect} from 'react-redux';
 import {progressStyles} from './multiGridConstants';
 import {getSelectedScriptName} from '@cdo/apps/redux/scriptSelectionRedux';
-import {getStudentTimestamp} from '@cdo/apps/templates/sectionProgress/sectionProgressRedux';
+import {tooltipIdForStudent} from './sectionProgressRedux';
 import {scriptUrlForStudent} from '@cdo/apps/templates/teacherDashboard/urlHelpers';
 import firehoseClient from '../../lib/util/firehose';
-import moment from 'moment';
 
 class SectionProgressNameCell extends Component {
   static propTypes = {
@@ -16,8 +15,7 @@ class SectionProgressNameCell extends Component {
 
     // Provided by redux.
     scriptName: PropTypes.string,
-    scriptId: PropTypes.number,
-    studentTimestamp: PropTypes.number
+    scriptId: PropTypes.number
   };
 
   recordStudentNameClick = () => {
@@ -37,18 +35,17 @@ class SectionProgressNameCell extends Component {
   };
 
   render() {
-    const {
-      name,
-      studentId,
-      sectionId,
-      scriptName,
-      studentTimestamp
-    } = this.props;
+    const {name, studentId, sectionId, scriptName} = this.props;
     const studentUrl = scriptUrlForStudent(sectionId, scriptName, studentId);
-    const title = `Last Progress: ${moment(studentTimestamp).calendar()}`;
+    const tooltipId = tooltipIdForStudent(studentId);
 
     return (
-      <div style={progressStyles.nameCell} title={title}>
+      <div
+        style={progressStyles.nameCell}
+        data-tip
+        data-for={tooltipId}
+        aria-describedby={tooltipId}
+      >
         {studentUrl && (
           <a
             href={studentUrl}
@@ -67,6 +64,5 @@ class SectionProgressNameCell extends Component {
 export const UnconnectedSectionProgressNameCell = SectionProgressNameCell;
 export default connect((state, ownProps) => ({
   scriptName: getSelectedScriptName(state),
-  scriptId: state.scriptSelection.scriptId,
-  studentTimestamp: getStudentTimestamp(state, ownProps.studentId)
+  scriptId: state.scriptSelection.scriptId
 }))(SectionProgressNameCell);

--- a/apps/src/templates/sectionProgress/SectionProgressNameCell.jsx
+++ b/apps/src/templates/sectionProgress/SectionProgressNameCell.jsx
@@ -6,6 +6,7 @@ import {getSelectedScriptName} from '@cdo/apps/redux/scriptSelectionRedux';
 import {getStudentTimestamp} from '@cdo/apps/templates/sectionProgress/sectionProgressRedux';
 import {scriptUrlForStudent} from '@cdo/apps/templates/teacherDashboard/urlHelpers';
 import firehoseClient from '../../lib/util/firehose';
+import moment from 'moment';
 
 class SectionProgressNameCell extends Component {
   static propTypes = {
@@ -16,7 +17,7 @@ class SectionProgressNameCell extends Component {
     // Provided by redux.
     scriptName: PropTypes.string,
     scriptId: PropTypes.number,
-    studentTimestamp: PropTypes.number // seconds since epoch
+    studentTimestamp: PropTypes.number
   };
 
   recordStudentNameClick = () => {
@@ -44,7 +45,7 @@ class SectionProgressNameCell extends Component {
       studentTimestamp
     } = this.props;
     const studentUrl = scriptUrlForStudent(sectionId, scriptName, studentId);
-    const title = `Last Progress: ${studentTimestamp}`;
+    const title = `Last Progress: ${moment(studentTimestamp).calendar()}`;
 
     return (
       <div style={progressStyles.nameCell} title={title}>

--- a/apps/src/templates/sectionProgress/sectionProgressRedux.js
+++ b/apps/src/templates/sectionProgress/sectionProgressRedux.js
@@ -445,21 +445,8 @@ export function getStudentLevelResult(dataByStudent) {
   return getInfoByStudentByLevel(dataByStudent, getLevelResult);
 }
 
-/**
- * Returns the last time this user made progress on any level in the currently
- * selected script. This is based on the updated_at time in the user_levels
- * table, and does not take into account any updates to project-backed levels.
- *
- * @param state {Object} The redux state tree.
- * @param studentId {number} The user id of the student.
- * @returns {number} Number of milliseconds since the beginning of the epoch,
- *   truncated to the nearest second.
- */
-export const getStudentTimestamp = (state, studentId) => {
-  const scriptId = state.scriptSelection.scriptId;
-  const timestamps = state.sectionProgress.studentTimestampsByScript[scriptId];
-  return timestamps && timestamps[studentId] * 1000;
-};
+export const tooltipIdForStudent = studentId =>
+  `tooltipIdForStudent${studentId}`;
 
 function getInfoByStudentByLevel(dataByStudent, infoFromLevelData) {
   return _.mapValues(dataByStudent, studentData =>

--- a/apps/src/templates/sectionProgress/sectionProgressRedux.js
+++ b/apps/src/templates/sectionProgress/sectionProgressRedux.js
@@ -216,12 +216,16 @@ export default function sectionProgress(state = initialState, action) {
     };
   }
   if (action.type === ADD_STUDENT_TIMESTAMPS) {
+    const studentTimestamps = _.mapValues(
+      action.studentTimestamps,
+      seconds => seconds * 1000
+    );
     return {
       ...state,
       studentTimestampsByScript: {
         [action.scriptId]: {
           ...state.studentTimestampsByScript[action.scriptId],
-          ...action.studentTimestamps
+          ...studentTimestamps
         }
       }
     };

--- a/apps/src/templates/sectionProgress/sectionProgressRedux.js
+++ b/apps/src/templates/sectionProgress/sectionProgressRedux.js
@@ -452,12 +452,13 @@ export function getStudentLevelResult(dataByStudent) {
  *
  * @param state {Object} The redux state tree.
  * @param studentId {number} The user id of the student.
- * @returns {number} Number of *seconds* since the beginning of the epoch.
+ * @returns {number} Number of milliseconds since the beginning of the epoch,
+ *   truncated to the nearest second.
  */
 export const getStudentTimestamp = (state, studentId) => {
   const scriptId = state.scriptSelection.scriptId;
   const timestamps = state.sectionProgress.studentTimestampsByScript[scriptId];
-  return timestamps && timestamps[studentId];
+  return timestamps && timestamps[studentId] * 1000;
 };
 
 function getInfoByStudentByLevel(dataByStudent, infoFromLevelData) {

--- a/apps/src/templates/sectionProgress/sectionProgressRedux.js
+++ b/apps/src/templates/sectionProgress/sectionProgressRedux.js
@@ -25,6 +25,7 @@ const SET_LESSON_OF_INTEREST = 'sectionProgress/SET_LESSON_OF_INTEREST';
 const ADD_SCRIPT_DATA = 'sectionProgress/ADD_SCRIPT_DATA';
 const ADD_STUDENT_LEVEL_PROGRESS = 'sectionProgress/ADD_STUDENT_LEVEL_PROGRESS';
 const ADD_STUDENT_LEVEL_PAIRING = 'sectionProgress/ADD_STUDENT_LEVEL_PAIRING';
+const ADD_STUDENT_TIMESTAMPS = 'sectionProgress/ADD_STUDENT_TIMESTAMPS';
 const START_LOADING_PROGRESS = 'sectionProgress/START_LOADING_PROGRESS';
 const FINISH_LOADING_PROGRESS = 'sectionProgress/FINISH_LOADING_PROGRESS';
 const ADD_LEVELS_BY_LESSON = 'sectionProgress/ADD_LEVELS_BY_LESSON';
@@ -76,6 +77,11 @@ export const addStudentLevelPairing = (scriptId, studentLevelPairing) => {
     studentLevelPairing
   };
 };
+export const addStudentTimestamps = (scriptId, studentTimestamps) => ({
+  type: ADD_STUDENT_TIMESTAMPS,
+  scriptId,
+  studentTimestamps
+});
 
 const NUM_STUDENTS_PER_PAGE = 50;
 
@@ -122,6 +128,7 @@ const initialState = {
   scriptDataByScript: {},
   studentLevelProgressByScript: {},
   studentLevelPairingByScript: {},
+  studentTimestampsByScript: {},
   levelsByLessonByScript: {},
   lessonOfInterest: INITIAL_LESSON_OF_INTEREST,
   isLoadingProgress: true
@@ -204,6 +211,17 @@ export default function sectionProgress(state = initialState, action) {
         [action.scriptId]: {
           ...state.studentLevelPairingByScript[action.scriptId],
           ...action.studentLevelPairing
+        }
+      }
+    };
+  }
+  if (action.type === ADD_STUDENT_TIMESTAMPS) {
+    return {
+      ...state,
+      studentTimestampsByScript: {
+        [action.scriptId]: {
+          ...state.studentTimestampsByScript[action.scriptId],
+          ...action.studentTimestamps
         }
       }
     };
@@ -380,6 +398,8 @@ export const loadScript = (scriptId, sectionId) => {
               getStudentLevelResult(dataByStudent)
             )
           );
+          dispatch(addStudentTimestamps(scriptId, data.student_timestamps));
+
           dispatch(
             addStudentLevelPairing(scriptId, getStudentPairing(dataByStudent))
           );

--- a/apps/src/templates/sectionProgress/sectionProgressRedux.js
+++ b/apps/src/templates/sectionProgress/sectionProgressRedux.js
@@ -445,6 +445,21 @@ export function getStudentLevelResult(dataByStudent) {
   return getInfoByStudentByLevel(dataByStudent, getLevelResult);
 }
 
+/**
+ * Returns the last time this user made progress on any level in the currently
+ * selected script. This is based on the updated_at time in the user_levels
+ * table, and does not take into account any updates to project-backed levels.
+ *
+ * @param state {Object} The redux state tree.
+ * @param studentId {number} The user id of the student.
+ * @returns {number} Number of *seconds* since the beginning of the epoch.
+ */
+export const getStudentTimestamp = (state, studentId) => {
+  const scriptId = state.scriptSelection.scriptId;
+  const timestamps = state.sectionProgress.studentTimestampsByScript[scriptId];
+  return timestamps && timestamps[studentId];
+};
+
 function getInfoByStudentByLevel(dataByStudent, infoFromLevelData) {
   return _.mapValues(dataByStudent, studentData =>
     _.mapValues(studentData, infoFromLevelData)

--- a/apps/test/unit/templates/sectionProgress/SectionProgressTest.js
+++ b/apps/test/unit/templates/sectionProgress/SectionProgressTest.js
@@ -43,7 +43,10 @@ describe('SectionProgress', () => {
       },
       isLoadingProgress: false,
       scriptFriendlyName: 'My Script',
-      showStandardsIntroDialog: false
+      showStandardsIntroDialog: false,
+      studentTimestamps: {
+        1: Date.now()
+      }
     };
   });
 
@@ -84,5 +87,16 @@ describe('SectionProgress', () => {
     );
     expect(wrapper.find('#uitest-standards-view').exists()).to.be.true;
     experiments.isEnabled.restore();
+  });
+
+  it('shows student timestamps', () => {
+    const wrapper = shallow(<UnconnectedSectionProgress {...DEFAULT_PROPS} />);
+    const tooltip = wrapper.find('#tooltipIdForStudent1');
+    expect(
+      tooltip
+        .children()
+        .first()
+        .text()
+    ).to.contain('Today');
   });
 });

--- a/apps/test/unit/templates/sectionProgress/sectionProgressReduxTest.js
+++ b/apps/test/unit/templates/sectionProgress/sectionProgressReduxTest.js
@@ -5,6 +5,7 @@ import sectionProgress, {
   addScriptData,
   addStudentLevelProgress,
   addStudentLevelPairing,
+  addStudentTimestamps,
   setLessonOfInterest,
   startLoadingProgress,
   finishLoadingProgress,
@@ -15,6 +16,7 @@ import sectionProgress, {
 } from '@cdo/apps/templates/sectionProgress/sectionProgressRedux';
 import {setScriptId} from '@cdo/apps/redux/scriptSelectionRedux';
 import {setSection} from '@cdo/apps/redux/sectionDataRedux';
+import _ from 'lodash';
 
 const fakeSectionData = {
   id: 123,
@@ -57,6 +59,12 @@ const fakeStudentProgress = {
   2: {242: 1000, 243: 1000}
 };
 
+const timeInSeconds = Date.now() / 1000;
+const fakeStudentTimestamps = {
+  1: timeInSeconds,
+  2: timeInSeconds + 1
+};
+
 const lessonOfInterest = 16;
 
 describe('sectionProgressRedux', () => {
@@ -81,6 +89,7 @@ describe('sectionProgressRedux', () => {
       assert.deepEqual(nextState.scriptDataByScript, {});
       assert.deepEqual(nextState.studentLevelProgressByScript, {});
       assert.deepEqual(nextState.levelsByLessonByScript, {});
+      assert.deepEqual(nextState.studentTimestampsByScript, {});
     });
   });
 
@@ -232,6 +241,17 @@ describe('sectionProgressRedux', () => {
         3: {},
         4: {}
       });
+    });
+  });
+
+  describe('addStudentTimestamps', () => {
+    it('converts timestamps from seconds to milliseconds', () => {
+      const action = addStudentTimestamps(130, fakeStudentTimestamps);
+      const nextState = sectionProgress(initialState, action);
+      assert.deepEqual(
+        _.mapValues(fakeStudentTimestamps, sec => sec * 1000),
+        nextState.studentTimestampsByScript[130]
+      );
     });
   });
 

--- a/dashboard/app/controllers/api_controller.rb
+++ b/dashboard/app/controllers/api_controller.rb
@@ -269,9 +269,12 @@ class ApiController < ApplicationController
       return head :range_not_satisfiable
     end
 
+    student_progress, student_timestamps = script_progress_for_users(paged_students, script)
+
     # Get the level progress for each student
     render json: {
-      students: script_progress_for_users(paged_students, script),
+      students: student_progress,
+      student_timestamps: student_timestamps,
       pagination: {
         total_pages: paged_students.total_pages,
         page: page,
@@ -298,15 +301,25 @@ class ApiController < ApplicationController
   private def script_progress_for_users(users, script)
     user_levels = User.user_levels_by_user_by_level(users, script)
     paired_user_levels_by_user = PairedUserLevel.pairs_by_user(users)
-    users.inject({}) do |progress_by_user, user|
-      progress_by_user[user.id] = merge_user_progress_by_level(
+    progress_by_user = users.inject({}) do |progress, user|
+      progress[user.id] = merge_user_progress_by_level(
         script: script,
         user: user,
         user_levels_by_level: user_levels[user.id],
-        paired_user_levels: paired_user_levels_by_user[user.id]
+        paired_user_levels: paired_user_levels_by_user[user.id],
+        include_timestamp: true
       )
-      progress_by_user
+      progress
     end
+    timestamp_by_user = progress_by_user.transform_values do |user|
+      user.values.map {|level| level[:last_progress_at]}.compact.max
+    end
+    progress_by_user.values.each do |user|
+      user.values.each do |level|
+        level.delete(:last_progress_at)
+      end
+    end
+    [progress_by_user, timestamp_by_user]
   end
 
   use_database_pool student_progress: :persistent

--- a/dashboard/app/controllers/api_controller.rb
+++ b/dashboard/app/controllers/api_controller.rb
@@ -314,6 +314,8 @@ class ApiController < ApplicationController
     timestamp_by_user = progress_by_user.transform_values do |user|
       user.values.map {|level| level[:last_progress_at]}.compact.max
     end
+    # Remove last_progress_at from the return value, to keep the data sent to
+    # the client to a minimum.
     progress_by_user.values.each do |user|
       user.values.each do |level|
         level.delete(:last_progress_at)

--- a/dashboard/app/helpers/users_helper.rb
+++ b/dashboard/app/helpers/users_helper.rb
@@ -161,7 +161,7 @@ module UsersHelper
   #   A collection of UserLevel ids where the user was pairing.
   # @return [Hash<Integer, Hash>]
   #   a map from level_id to a progress summary for the level.
-  private def merge_user_progress_by_level(script:, user:, user_levels_by_level:, paired_user_levels:)
+  private def merge_user_progress_by_level(script:, user:, user_levels_by_level:, paired_user_levels:, include_timestamp: false)
     levels = {}
     script.script_levels.each do |sl|
       sl.level_ids.each do |level_id|
@@ -195,6 +195,7 @@ module UsersHelper
           readonly_answers: readonly_answers ? true : nil,
           paired: (paired_user_levels.include? ul.try(:id)) ? true : nil,
           locked: locked ? true : nil,
+          last_progress_at: include_timestamp ? ul&.updated_at&.to_i : nil
         }.compact
 
         # Just in case this level has multiple pages, in which case we add an additional

--- a/dashboard/test/controllers/api_controller_test.rb
+++ b/dashboard/test/controllers/api_controller_test.rb
@@ -871,18 +871,21 @@ class ApiControllerTest < ActionController::TestCase
     assert_response :success
     data = JSON.parse(@response.body)
     assert_equal 2, data['students'].keys.length
+    assert_equal 2, data['student_timestamps'].keys.length
     assert_equal 3, data['pagination']['total_pages']
 
     get :section_level_progress, params: {section_id: @section.id, script_id: script.id, page: 2, per: 2}
     assert_response :success
     data = JSON.parse(@response.body)
     assert_equal 2, data['students'].keys.length
+    assert_equal 2, data['student_timestamps'].keys.length
 
     # third page has only one student (of 5 total)
     get :section_level_progress, params: {section_id: @section.id, script_id: script.id, page: 3, per: 2}
     assert_response :success
     data = JSON.parse(@response.body)
     assert_equal 1, data['students'].keys.length
+    assert_equal 1, data['student_timestamps'].keys.length
   end
 
   test "should get paired icons for paired user levels" do


### PR DESCRIPTION
## Background

Finishes https://codedotorg.atlassian.net/browse/LP-1323

## Description

Today, in the progress view, we fetch all progress for all levels in the selected script, for each student in the section. In this PR, we start also sending down a timestamp for each user, indicating the most recent timestamp for any progress made across the levels in the script. We do not send down the progress timestamp for each level, to keep the data size small. However, we might start sending down per-level timestamps in the future.

### Screenshots

![Screen Shot 2020-03-23 at 5 09 38 PM](https://user-images.githubusercontent.com/8001765/77374907-3cd68580-6d29-11ea-8df0-6e60ee1249f4.png)

![Screen Shot 2020-03-23 at 5 09 45 PM](https://user-images.githubusercontent.com/8001765/77374909-3fd17600-6d29-11ea-8dfe-fbee4c32ec45.png)

![Screen Shot 2020-03-23 at 5 10 14 PM](https://user-images.githubusercontent.com/8001765/77374919-465fed80-6d29-11ea-98bc-dd9975859af2.png)

![Screen Shot 2020-03-23 at 5 10 21 PM](https://user-images.githubusercontent.com/8001765/77374925-49f37480-6d29-11ea-805c-74a1fc9c1a67.png)


## Testing story

Added new unit tests. Manually tested end-to-end.

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
