### PR TITLE
Add rel="noreferrer noopener" to our 'open links in new tab' logic

### DIFF
--- a/dashboard/config/initializers/markdown_handler.rb
+++ b/dashboard/config/initializers/markdown_handler.rb
@@ -27,7 +27,9 @@ class CustomRewriter < Redcarpet::Render::HTML
   # Open links in a new tab by default.
   def link(link, title, content)
     # `content` is already escaped by Redcarpet.
-    "<a target='_blank' href='#{Rack::Utils.escape_html(link)}' title='#{Rack::Utils.escape_html(title)}'>#{content}</a>"
+    # make sure we use rel in addition to target=_blank to attempt to mitigate
+    # the inherent danger in opening links in a new tab.
+    "<a target='_blank' rel='noreferrer noopener nofollow' href='#{Rack::Utils.escape_html(link)}' title='#{Rack::Utils.escape_html(title)}'>#{content}</a>"
   end
 
   def autolink(link, _)


### PR DESCRIPTION
To at least attempt to mitigate the inherent danger in opening links in a new tab.

Hopefully I can track down why we're trying to do this and get rid of this dangerous practice entirely, but until then this will hopefully help.

<!--
  Your description goes here: A summary of the change, including any relevant motivation and context.

  If relevant, include a description both of the existing behavior and of the new behavior.
-->

<!--
  Other aspects to consider. uncomment and add detail for any that seem necessary:
-->

<!-- ### Background -->
<!-- ### Privacy -->
<!-- ### Security -->
<!-- ### Caching -->
<!-- ### Deployment strategy -->
<!-- ### Future work -->

## Links

<!--
  Any relevant links to external resources; ie, specification documents, jira
  items, related PRs, honeybadger errors, etc
-->

- [spec]()
- [jira]()

## Testing story

<!--
  Does your change include appropriate tests?

  If so, please describe how the tests included in this PR are sufficient

  If not, please explain why this change does not need to be tested.
-->

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
