### PR TITLE
remove 'open in new tab' functionality from Dashboard markdown

### DIFF
--- a/dashboard/config/initializers/markdown_handler.rb
+++ b/dashboard/config/initializers/markdown_handler.rb
@@ -23,16 +23,6 @@ class CustomRewriter < Redcarpet::Render::HTML
     end
     doc.css('body').children.to_html
   end
-
-  # Open links in a new tab by default.
-  def link(link, title, content)
-    # `content` is already escaped by Redcarpet.
-    "<a target='_blank' href='#{Rack::Utils.escape_html(link)}' title='#{Rack::Utils.escape_html(title)}'>#{content}</a>"
-  end
-
-  def autolink(link, _)
-    link(link, nil, link)
-  end
 end
 
 MarkdownHandler.register(CustomRewriter, MARKDOWN_OPTIONS)


### PR DESCRIPTION
Originally added in https://github.com/code-dot-org/code-dot-org/pull/9941 to make links in level instructions open in a new tab so students don't lose level progress.

We no longer render level instructions with the dashboard renderer (we now use react to render them clientside), so we no longer need this.

We'd like to remove it for two reasons; first, because we are trying to merge the Dashboard and Pegasus markdown rendering logic into just a single set of logic, and removing this functionality from Dashboard is a lot lower-impact than adding it to Pegasus. And second, [opening links in a new tab presents a significant security vulnerability to malicious code on the opened tab](https://mathiasbynens.github.io/rel-noopener/).

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
