### PR TITLE
Curriculum tracking pixel handles non English locales

### DIFF
--- a/dashboard/app/controllers/curriculum_tracking_pixel_controller.rb
+++ b/dashboard/app/controllers/curriculum_tracking_pixel_controller.rb
@@ -14,25 +14,45 @@ class CurriculumTrackingPixelController < ApplicationController
       # For ease of querying we attempt to parse the url into meaningful chunks.
       # EXAMPLE:
       # /csf-18/pre-express/11/
+      # es-mx/csf-1718/coursec/10/'
       split_url = curriculum_page.split('/')
       # ["", "csf-18", "pre-express", "11"]
+      # ["", "es-mx", "csf-1718", "coursec", "10"]
 
+      non_en = split_url[1][2] == "-"
       if split_url.length > 1
-        # csf, csd, csp including version year, algebra or hoc
-        csx = split_url[1]
+        if non_en
+          locale = split_url[1]
+        else
+          locale = "en-us"
+          # csf, csd, csp including version year, algebra or hoc
+          csx = split_url[1]
+        end
       end
 
       if split_url.length > 2
-        # csf -> coursea, courseb, ..., pre-express, express
-        # csd/csp -> unit1, unit2, ...
-        # algebra -> courseA, courseB
-        # hoc -> plugged, unplugged
-        course_or_unit = split_url[2]
+        if non_en
+          csx = split_url[2]
+        else
+          # csf -> coursea, courseb, ..., pre-express, express
+          # csd/csp -> unit1, unit2, ...
+          # algebra -> courseA, courseB
+          # hoc -> plugged, unplugged
+          course_or_unit = split_url[2]
+        end
       end
 
       if split_url.length > 3
-        # lesson number, standards, vocab, resources
-        lesson = split_url[3]
+        if non_en
+          course_or_unit = split_url[3]
+        else
+          # lesson number, standards, vocab, resources
+          lesson = split_url[3]
+        end
+      end
+
+      if split_url.length > 4 && non_en
+        lesson = split_url[4]
       end
 
       FirehoseClient.instance.put_record(
@@ -42,6 +62,7 @@ class CurriculumTrackingPixelController < ApplicationController
         user_id: user_id,
         data_string: curriculum_page,
         data_json: {
+          locale: locale,
           csx: csx,
           course_or_unit: course_or_unit,
           lesson: lesson

--- a/dashboard/app/controllers/curriculum_tracking_pixel_controller.rb
+++ b/dashboard/app/controllers/curriculum_tracking_pixel_controller.rb
@@ -17,15 +17,10 @@ class CurriculumTrackingPixelController < ApplicationController
       # es-mx/csf-1718/coursec/10/'
       split_url = curriculum_page.split('/')
       # ["", "csf-18", "pre-express", "11"]
-      # ["", "es-mx", "csf-1718", "coursec", "10"]
+      # ["es-mx", "csf-1718", "coursec", "10"]
 
-      non_en = split_url[1][2] == "-"
-      if non_en
-        locale = split_url.shift
-        split_url.drop(1)
-      else
-        locale = "en-us"
-      end
+      non_en = !!split_url[0].match(/\S{2}-\S{2}/)
+      locale = non_en ? split_url[0] : "en-us"
 
       if split_url.length > 1
         # csf, csd, csp including version year, algebra or hoc

--- a/dashboard/app/controllers/curriculum_tracking_pixel_controller.rb
+++ b/dashboard/app/controllers/curriculum_tracking_pixel_controller.rb
@@ -21,12 +21,7 @@ class CurriculumTrackingPixelController < ApplicationController
 
       non_en = split_url[0].length == 5 && !!split_url[0].match(/\S{2}-\S{2}/)
 
-      if non_en
-        locale = split_url[0]
-        split_url.shift(1)
-      else
-        locale = "en-us"
-      end
+      locale = non_en ? split_url.shift : "en-us"
 
       unless split_url.empty?
         # csf, csd, csp including version year, algebra or hoc

--- a/dashboard/app/controllers/curriculum_tracking_pixel_controller.rb
+++ b/dashboard/app/controllers/curriculum_tracking_pixel_controller.rb
@@ -20,39 +20,29 @@ class CurriculumTrackingPixelController < ApplicationController
       # ["", "es-mx", "csf-1718", "coursec", "10"]
 
       non_en = split_url[1][2] == "-"
+      if non_en
+        locale = split_url.shift
+        split_url.drop(1)
+      else
+        locale = "en-us"
+      end
+
       if split_url.length > 1
-        if non_en
-          locale = split_url[1]
-        else
-          locale = "en-us"
-          # csf, csd, csp including version year, algebra or hoc
-          csx = split_url[1]
-        end
+        # csf, csd, csp including version year, algebra or hoc
+        csx = split_url[1]
       end
 
       if split_url.length > 2
-        if non_en
-          csx = split_url[2]
-        else
-          # csf -> coursea, courseb, ..., pre-express, express
-          # csd/csp -> unit1, unit2, ...
-          # algebra -> courseA, courseB
-          # hoc -> plugged, unplugged
-          course_or_unit = split_url[2]
-        end
+        # csf -> coursea, courseb, ..., pre-express, express
+        # csd/csp -> unit1, unit2, ...
+        # algebra -> courseA, courseB
+        # hoc -> plugged, unplugged
+        course_or_unit = split_url[2]
       end
 
       if split_url.length > 3
-        if non_en
-          course_or_unit = split_url[3]
-        else
-          # lesson number, standards, vocab, resources
-          lesson = split_url[3]
-        end
-      end
-
-      if split_url.length > 4 && non_en
-        lesson = split_url[4]
+        # lesson number, standards, vocab, resources
+        lesson = split_url[3]
       end
 
       FirehoseClient.instance.put_record(

--- a/dashboard/app/controllers/curriculum_tracking_pixel_controller.rb
+++ b/dashboard/app/controllers/curriculum_tracking_pixel_controller.rb
@@ -14,30 +14,36 @@ class CurriculumTrackingPixelController < ApplicationController
       # For ease of querying we attempt to parse the url into meaningful chunks.
       # EXAMPLE:
       # /csf-18/pre-express/11/
-      # es-mx/csf-1718/coursec/10/'
-      split_url = curriculum_page.split('/')
-      # ["", "csf-18", "pre-express", "11"]
+      # /es-mx/csf-1718/coursec/10/'
+      split_url = curriculum_page.split('/').reject(&:empty?)
+      # ["csf-18", "pre-express", "11"]
       # ["es-mx", "csf-1718", "coursec", "10"]
 
-      non_en = !!split_url[0].match(/\S{2}-\S{2}/)
-      locale = non_en ? split_url[0] : "en-us"
+      non_en = split_url[0].length == 5 && !!split_url[0].match(/\S{2}-\S{2}/)
 
-      if split_url.length > 1
-        # csf, csd, csp including version year, algebra or hoc
-        csx = split_url[1]
+      if non_en
+        locale = split_url[0]
+        split_url.shift(1)
+      else
+        locale = "en-us"
       end
 
-      if split_url.length > 2
+      unless split_url.empty?
+        # csf, csd, csp including version year, algebra or hoc
+        csx = split_url[0]
+      end
+
+      if split_url.length > 1
         # csf -> coursea, courseb, ..., pre-express, express
         # csd/csp -> unit1, unit2, ...
         # algebra -> courseA, courseB
         # hoc -> plugged, unplugged
-        course_or_unit = split_url[2]
+        course_or_unit = split_url[1]
       end
 
-      if split_url.length > 3
+      if split_url.length > 2
         # lesson number, standards, vocab, resources
-        lesson = split_url[3]
+        lesson = split_url[2]
       end
 
       FirehoseClient.instance.put_record(

--- a/dashboard/test/controllers/curriculum_tracking_pixel_controller_test.rb
+++ b/dashboard/test/controllers/curriculum_tracking_pixel_controller_test.rb
@@ -54,7 +54,7 @@ class CurriculumTrackingPixelControllerTest < ActionController::TestCase
   end
 
   test "get index for signed out, non-English curriculum_url" do
-    get :index, params: {from:   @example_curriculum_url_with_locale}
+    get :index, params: {from: @example_curriculum_url_with_locale}
     assert_response :success
     assert_non_english_curriculum_page_view_logged(@example_curriculum_url_with_locale, nil)
   end
@@ -68,7 +68,7 @@ class CurriculumTrackingPixelControllerTest < ActionController::TestCase
 
   test "get index for signed in, non-English curriculum_url" do
     sign_in @teacher
-    get :index, params: {from:   @example_curriculum_url_with_locale}
+    get :index, params: {from: @example_curriculum_url_with_locale}
     assert_response :success
     assert_non_english_curriculum_page_view_logged(@example_curriculum_url_with_locale, @teacher.id)
   end

--- a/dashboard/test/controllers/curriculum_tracking_pixel_controller_test.rb
+++ b/dashboard/test/controllers/curriculum_tracking_pixel_controller_test.rb
@@ -13,9 +13,21 @@ class CurriculumTrackingPixelControllerTest < ActionController::TestCase
     assert @firehose_record[:event], CurriculumTrackingPixelController::EVENT_NAME
     assert @firehose_record[:data_string], curriculum_url
     split_url = curriculum_url.try(:split, '/')
+    assert @firehose_record[:data_json]["locale"], "en-us"
     assert @firehose_record[:data_json]["csx"], split_url[1]
     assert @firehose_record[:data_json]["course_or_unit"], split_url[2]
     assert @firehose_record[:data_json]["lesson"], split_url[3]
+  end
+
+  def assert_non_english_curriculum_page_view_logged(curriculum_url, user_id)
+    assert @firehose_record[:study], CurriculumTrackingPixelController::STUDY_NAME
+    assert @firehose_record[:event], CurriculumTrackingPixelController::EVENT_NAME
+    assert @firehose_record[:data_string], curriculum_url
+    split_url = curriculum_url.try(:split, '/')
+    assert @firehose_record[:data_json]["locale"], split_url[1]
+    assert @firehose_record[:data_json]["csx"], split_url[2]
+    assert @firehose_record[:data_json]["course_or_unit"], split_url[3]
+    assert @firehose_record[:data_json]["lesson"], split_url[4]
   end
 
   def refute_curriculum_page_view_logged
@@ -26,6 +38,7 @@ class CurriculumTrackingPixelControllerTest < ActionController::TestCase
     stub_firehose
     @teacher = create :teacher
     @example_curriculum_url = '/csf-18/pre-express/11/'
+    @example_curriculum_url_with_locale = 'es-mx/csf-1718/coursec/10/'
   end
 
   test "get index for signed out, no curriculum_url" do
@@ -40,11 +53,24 @@ class CurriculumTrackingPixelControllerTest < ActionController::TestCase
     assert_curriculum_page_view_logged(@example_curriculum_url, nil)
   end
 
+  test "get index for signed out, non-English curriculum_url" do
+    get :index, params: {from:   @example_curriculum_url_with_locale}
+    assert_response :success
+    assert_non_english_curriculum_page_view_logged(@example_curriculum_url_with_locale, nil)
+  end
+
   test "get index for signed in, no curriculum_url" do
     sign_in @teacher
     get :index
     assert_response :success
     refute_curriculum_page_view_logged
+  end
+
+  test "get index for signed in, non-English curriculum_url" do
+    sign_in @teacher
+    get :index, params: {from:   @example_curriculum_url_with_locale}
+    assert_response :success
+    assert_non_english_curriculum_page_view_logged(@example_curriculum_url_with_locale, @teacher.id)
   end
 
   test "get index for signed in, curriculum_url" do

--- a/dashboard/test/controllers/curriculum_tracking_pixel_controller_test.rb
+++ b/dashboard/test/controllers/curriculum_tracking_pixel_controller_test.rb
@@ -9,23 +9,25 @@ class CurriculumTrackingPixelControllerTest < ActionController::TestCase
   end
 
   def assert_curriculum_page_view_logged(curriculum_url, user_id)
-    assert @firehose_record[:study], CurriculumTrackingPixelController::STUDY_NAME
-    assert @firehose_record[:event], CurriculumTrackingPixelController::EVENT_NAME
-    assert @firehose_record[:data_string], curriculum_url
-    assert @firehose_record[:data_json]["locale"], "en-us"
-    assert @firehose_record[:data_json]["csx"], "csf-18"
-    assert @firehose_record[:data_json]["course_or_unit"], "pre-express"
-    assert @firehose_record[:data_json]["lesson"], 11
+    assert_equal @firehose_record[:study], CurriculumTrackingPixelController::STUDY_NAME
+    assert_equal @firehose_record[:event], CurriculumTrackingPixelController::EVENT_NAME
+    assert_equal @firehose_record[:data_string], curriculum_url
+    parsed_result = JSON.parse(@firehose_record[:data_json])
+    assert parsed_result['locale'], "en-us"
+    assert_equal parsed_result['csx'], "csf-18"
+    assert_equal parsed_result['course_or_unit'], "pre-express"
+    assert_equal parsed_result['lesson'], "11"
   end
 
   def assert_non_english_curriculum_page_view_logged(curriculum_url, user_id)
-    assert @firehose_record[:study], CurriculumTrackingPixelController::STUDY_NAME
-    assert @firehose_record[:event], CurriculumTrackingPixelController::EVENT_NAME
-    assert @firehose_record[:data_string], curriculum_url
-    assert @firehose_record[:data_json]["locale"], "es-mx"
-    assert @firehose_record[:data_json]["csx"], "csf-1718"
-    assert @firehose_record[:data_json]["course_or_unit"], "coursec"
-    assert @firehose_record[:data_json]["lesson"], 10
+    assert_equal @firehose_record[:study], CurriculumTrackingPixelController::STUDY_NAME
+    assert_equal @firehose_record[:event], CurriculumTrackingPixelController::EVENT_NAME
+    assert_equal @firehose_record[:data_string], curriculum_url
+    parsed_result = JSON.parse(@firehose_record[:data_json])
+    assert parsed_result['locale'], "es-mx"
+    assert_equal parsed_result['csx'], "csf-1718"
+    assert_equal parsed_result['course_or_unit'], "coursec"
+    assert_equal parsed_result['lesson'], "10"
   end
 
   def refute_curriculum_page_view_logged
@@ -36,7 +38,7 @@ class CurriculumTrackingPixelControllerTest < ActionController::TestCase
     stub_firehose
     @teacher = create :teacher
     @example_curriculum_url = '/csf-18/pre-express/11/'
-    @example_curriculum_url_with_locale = 'es-mx/csf-1718/coursec/10/'
+    @example_curriculum_url_with_locale = '/es-mx/csf-1718/coursec/10/'
   end
 
   test "get index for signed out, no curriculum_url" do

--- a/dashboard/test/controllers/curriculum_tracking_pixel_controller_test.rb
+++ b/dashboard/test/controllers/curriculum_tracking_pixel_controller_test.rb
@@ -12,22 +12,20 @@ class CurriculumTrackingPixelControllerTest < ActionController::TestCase
     assert @firehose_record[:study], CurriculumTrackingPixelController::STUDY_NAME
     assert @firehose_record[:event], CurriculumTrackingPixelController::EVENT_NAME
     assert @firehose_record[:data_string], curriculum_url
-    split_url = curriculum_url.try(:split, '/')
     assert @firehose_record[:data_json]["locale"], "en-us"
-    assert @firehose_record[:data_json]["csx"], split_url[1]
-    assert @firehose_record[:data_json]["course_or_unit"], split_url[2]
-    assert @firehose_record[:data_json]["lesson"], split_url[3]
+    assert @firehose_record[:data_json]["csx"], "csf-18"
+    assert @firehose_record[:data_json]["course_or_unit"], "pre-express"
+    assert @firehose_record[:data_json]["lesson"], 11
   end
 
   def assert_non_english_curriculum_page_view_logged(curriculum_url, user_id)
     assert @firehose_record[:study], CurriculumTrackingPixelController::STUDY_NAME
     assert @firehose_record[:event], CurriculumTrackingPixelController::EVENT_NAME
     assert @firehose_record[:data_string], curriculum_url
-    split_url = curriculum_url.try(:split, '/')
-    assert @firehose_record[:data_json]["locale"], split_url[1]
-    assert @firehose_record[:data_json]["csx"], split_url[2]
-    assert @firehose_record[:data_json]["course_or_unit"], split_url[3]
-    assert @firehose_record[:data_json]["lesson"], split_url[4]
+    assert @firehose_record[:data_json]["locale"], "es-mx"
+    assert @firehose_record[:data_json]["csx"], "csf-1718"
+    assert @firehose_record[:data_json]["course_or_unit"], "coursec"
+    assert @firehose_record[:data_json]["lesson"], 10
   end
 
   def refute_curriculum_page_view_logged


### PR DESCRIPTION
[LP-1191](https://codedotorg.atlassian.net/browse/LP-1191)

We use a tracking pixel to log metrics to firehose about which lesson plans have been viewed on curriculum.code.org.  If a user is viewing curriculum builder in a language other than English, the locale code is in the url, for example https://curriculum.code.org/it-it/csf-1718/courseb/1/ When we log to firehose, we parse the url with expectations about the order of information in the url.  We didn’t handle the cases where the locale code is present; now we do. 