### PR TITLE
Manage Students: pass studioUrlPrefix to LoginCard

### DIFF
--- a/apps/src/templates/teacherDashboard/SectionLoginInfo.jsx
+++ b/apps/src/templates/teacherDashboard/SectionLoginInfo.jsx
@@ -297,6 +297,7 @@ class WordOrPictureLogins extends React.Component {
                   key={student.id}
                   section={section}
                   student={student}
+                  studioUrlPrefix={studioUrlPrefix}
                 />
               ))}
             </div>


### PR DESCRIPTION
Missing prop erroneously deleted in #33727 caused this: 
<img width="283" alt="Screen Shot 2020-03-21 at 1 06 09 PM" src="https://user-images.githubusercontent.com/12300669/77235631-ddd00f80-6b74-11ea-89a8-e1aa27d7ff48.png">

Passing `studioUrlPrefix` fixes the issue: 
<img width="239" alt="Screen Shot 2020-03-21 at 1 01 31 PM" src="https://user-images.githubusercontent.com/12300669/77235625-cdb83000-6b74-11ea-932b-d9816181f23b.png">
