### PR TITLE
Identify tests over 0.2 flake factor and send a 'scarier' red message

### DIFF
--- a/aws/ci_build
+++ b/aws/ci_build
@@ -189,6 +189,9 @@ def main
       end
     end
 
+    tests_over_flake_threshold = `./bin/test_flakiness -x 0.2`
+    ChatClient.log "Tests exceeding flakiness threshold: <br/><pre>#{tests_over_flake_threshold}</pre><br/><br/> Please ensure these tests are being investigated!", color: 'red'
+
     emit_deploy_metric(rack_env.to_s.titleize, status == 0)
   end
 

--- a/aws/ci_build
+++ b/aws/ci_build
@@ -189,8 +189,18 @@ def main
       end
     end
 
-    tests_over_flake_threshold = `./bin/test_flakiness -x 0.2`
-    ChatClient.log "Tests exceeding flakiness threshold: <br/><pre>#{tests_over_flake_threshold}</pre><br/><br/> Please ensure these tests are being investigated!", color: 'red'
+    if CDO.test_system?
+      tests_over_flake_threshold = `./bin/test_flakiness -x 0.2`
+      flake_factor_message = {}
+      if tests_over_flake_threshold.empty?
+        flake_factor_message[:color] = 'green'
+        flake_factor_message[:message] = "Hooray! There are no UI tests over 0.2 flakiness."
+      else
+        flake_factor_message[:color] = 'red'
+        flake_factor_message[:message] = "Tests exceeding flakiness threshold: <br/><pre>#{tests_over_flake_threshold}</pre><br/><br/> Please ensure these tests are being investigated!"
+      end
+      ChatClient.log flake_factor_message.message, color: flake_factor_message.color
+    end
 
     emit_deploy_metric(rack_env.to_s.titleize, status == 0)
   end

--- a/bin/test_flakiness
+++ b/bin/test_flakiness
@@ -15,6 +15,9 @@ OptionParser.new do |opts|
   opts.on('-n', '--limit N', 'Top N flakiest tests.') do |n|
     options[:limit] = Integer(n)
   end
+  opts.on('-x', '--threshold X', 'Tests over flakiness threshold X') do |x|
+    options[:threshold] = Integer(x)
+  end
   opts.on('-r', '--reruns', 'Show recommended reruns/confidence.') do
     options[:reruns] = true
   end
@@ -37,9 +40,15 @@ FileUtils.rm(TestFlakiness::CACHE_FILENAME) if options[:recalc]
 
 results = TestFlakiness.method(options[:method]).call
 results.to_a.sort_by(&:last).reverse[0..options[:limit]].map do |name, value|
-  result = [value, name]
   if options[:reruns]
     result.insert(1, *TestFlakiness.recommend_reruns(TestFlakiness.test_flakiness[name]))
   end
-  puts result.join("\t")
+
+  if options[:flake_threshold]
+    if value >= options[:flake_threshold]
+      puts result.join("\t")
+    end
+  else
+    puts result.join("\t")
+  end
 end

--- a/bin/test_flakiness
+++ b/bin/test_flakiness
@@ -46,7 +46,7 @@ results.to_a.sort_by(&:last).reverse[0..options[:limit]].map do |name, value|
     result.insert(1, *TestFlakiness.recommend_reruns(TestFlakiness.test_flakiness[name]))
   end
 
-  if options[:flake_threshold]
+  if options[:threshold]
     if value >= options[:threshold]
       puts result.join("\t")
     end

--- a/bin/test_flakiness
+++ b/bin/test_flakiness
@@ -40,12 +40,14 @@ FileUtils.rm(TestFlakiness::CACHE_FILENAME) if options[:recalc]
 
 results = TestFlakiness.method(options[:method]).call
 results.to_a.sort_by(&:last).reverse[0..options[:limit]].map do |name, value|
+  result = [value, name]
+
   if options[:reruns]
     result.insert(1, *TestFlakiness.recommend_reruns(TestFlakiness.test_flakiness[name]))
   end
 
   if options[:flake_threshold]
-    if value >= options[:flake_threshold]
+    if value >= options[:threshold]
       puts result.join("\t")
     end
   else

--- a/bin/test_flakiness
+++ b/bin/test_flakiness
@@ -16,7 +16,7 @@ OptionParser.new do |opts|
     options[:limit] = Integer(n)
   end
   opts.on('-x', '--threshold X', 'Tests over flakiness threshold X') do |x|
-    options[:threshold] = Integer(x)
+    options[:threshold] = BigDecimal(x)
   end
   opts.on('-r', '--reruns', 'Show recommended reruns/confidence.') do
     options[:reruns] = true

--- a/lib/rake/test.rake
+++ b/lib/rake/test.rake
@@ -94,6 +94,8 @@ namespace :test do
     Dir.chdir(deploy_dir) do
       flakiness_output = `./bin/test_flakiness -n 5`
       ChatClient.log "Flakiest tests: <br/><pre>#{flakiness_output}</pre>"
+      tests_over_flake_threshold = `./bin/test_flakiness -x 0.2`
+      ChatClient.log "Tests exceeding flakiness threshold: <br/><pre>#{tests_over_flake_threshold}</pre><br/><br/>These tests should be investigated!", color: 'red'
     end
   end
 

--- a/lib/rake/test.rake
+++ b/lib/rake/test.rake
@@ -94,8 +94,6 @@ namespace :test do
     Dir.chdir(deploy_dir) do
       flakiness_output = `./bin/test_flakiness -n 5`
       ChatClient.log "Flakiest tests: <br/><pre>#{flakiness_output}</pre>"
-      tests_over_flake_threshold = `./bin/test_flakiness -x 0.2`
-      ChatClient.log "Tests exceeding flakiness threshold: <br/><pre>#{tests_over_flake_threshold}</pre><br/><br/>These tests should be investigated!", color: 'red'
     end
   end
 


### PR DESCRIPTION
[LP-1312](https://codedotorg.atlassian.net/browse/LP-1312), more follow up to [COE ](https://docs.google.com/document/d/1JhQ5TeNFt51qz_8fGgbW9GkksAPjeaPMEVbNn2kcfjw/edit?ouid=118428218617133301660&usp=docs_home&ths=true)
