### PR TITLE
Remove string parameter in test

### DIFF
--- a/apps/test/unit/lib/kits/maker/CircuitPlaygroundBoardTest.js
+++ b/apps/test/unit/lib/kits/maker/CircuitPlaygroundBoardTest.js
@@ -79,10 +79,7 @@ describe('CircuitPlaygroundBoard', () => {
     ChromeSerialPort.stub.reset();
   });
 
-  itImplementsTheMakerBoardInterface(
-    CircuitPlaygroundBoard,
-    'circuit_playground'
-  );
+  itImplementsTheMakerBoardInterface(CircuitPlaygroundBoard);
 
   describe(`connect()`, () => {
     // TODO (bbuchanan): Remove when maker-captouch is on by default.

--- a/apps/test/unit/lib/kits/maker/FakeBoardTest.js
+++ b/apps/test/unit/lib/kits/maker/FakeBoardTest.js
@@ -3,7 +3,7 @@ import FakeBoard from '@cdo/apps/lib/kits/maker/FakeBoard';
 import {expect} from '../../../../util/reconfiguredChai';
 
 describe('FakeBoard', () => {
-  itImplementsTheMakerBoardInterface(FakeBoard, 'circuit_playground');
+  itImplementsTheMakerBoardInterface(FakeBoard);
 
   describe(`boardConnected()`, () => {
     it('always returns false', () => {

--- a/apps/test/unit/lib/kits/maker/MakerBoardTest.js
+++ b/apps/test/unit/lib/kits/maker/MakerBoardTest.js
@@ -5,6 +5,7 @@ import {expect} from '../../../../util/deprecatedChai';
 import {N_COLOR_LEDS} from '@cdo/apps/lib/kits/maker/PlaygroundConstants';
 import MicroBitBoard from '@cdo/apps/lib/kits/maker/MicroBitBoard';
 import CircuitPlaygroundBoard from '@cdo/apps/lib/kits/maker/CircuitPlaygroundBoard';
+import FakeBoard from '@cdo/apps/lib/kits/maker/FakeBoard';
 
 /**
  * Interface that our board controllers must implement to be usable with
@@ -173,7 +174,7 @@ export function itImplementsTheMakerBoardInterface(
         });
 
         // Board-specific tests
-        if (BoardClass === CircuitPlaygroundBoard) {
+        if (BoardClass === CircuitPlaygroundBoard || BoardClass === FakeBoard) {
           describe('led', () => {
             function expectLedToHaveFunction(fnName) {
               expect(jsInterpreter.globalProperties.led[fnName]).to.be.a(
@@ -483,7 +484,7 @@ export function itImplementsTheMakerBoardInterface(
       });
     });
 
-    if (BoardClass === CircuitPlaygroundBoard) {
+    if (BoardClass === CircuitPlaygroundBoard || BoardClass === FakeBoard) {
       /**
        * @function
        * @name MakerBoard#createLed
@@ -532,7 +533,7 @@ export function itImplementsTheMakerBoardInterface(
         expect(button).to.have.property('isPressed');
 
         // TODO - not yet implemented for microbit
-        if (BoardClass === CircuitPlaygroundBoard) {
+        if (BoardClass === CircuitPlaygroundBoard || BoardClass === FakeBoard) {
           expect(button).to.have.property('holdtime');
         }
       });

--- a/apps/test/unit/lib/kits/maker/MakerBoardTest.js
+++ b/apps/test/unit/lib/kits/maker/MakerBoardTest.js
@@ -13,12 +13,6 @@ import CircuitPlaygroundBoard from '@cdo/apps/lib/kits/maker/CircuitPlaygroundBo
  * @extends EventEmitter
  */
 
-/**
- * Run the set of interface conformance tests on the provided class.
- * @param {function} BoardClass
- * @param {function} boardSpecificSetup optional
- */
-
 const CP_CONSTRUCTOR_COUNT = 13;
 const CP_COMPONENT_COUNT = 16;
 const MB_CONSTRUCTOR_COUNT = 4;
@@ -45,6 +39,11 @@ const MB_COMPONENTS = [
   'MicroBitThermometer'
 ];
 
+/**
+ * Run the set of interface conformance tests on the provided class.
+ * @param {function} BoardClass
+ * @param {function} boardSpecificSetup optional
+ */
 export function itImplementsTheMakerBoardInterface(
   BoardClass,
   boardSpecificSetup = null

--- a/apps/test/unit/lib/kits/maker/MakerBoardTest.js
+++ b/apps/test/unit/lib/kits/maker/MakerBoardTest.js
@@ -3,6 +3,8 @@ import sinon from 'sinon';
 import {EventEmitter} from 'events'; // see node-libs-browser
 import {expect} from '../../../../util/deprecatedChai';
 import {N_COLOR_LEDS} from '@cdo/apps/lib/kits/maker/PlaygroundConstants';
+import MicroBitBoard from '@cdo/apps/lib/kits/maker/MicroBitBoard';
+import CircuitPlaygroundBoard from '@cdo/apps/lib/kits/maker/CircuitPlaygroundBoard';
 
 /**
  * Interface that our board controllers must implement to be usable with
@@ -14,7 +16,6 @@ import {N_COLOR_LEDS} from '@cdo/apps/lib/kits/maker/PlaygroundConstants';
 /**
  * Run the set of interface conformance tests on the provided class.
  * @param {function} BoardClass
- * @param {function} boardType
  * @param {function} boardSpecificSetup optional
  */
 
@@ -46,7 +47,6 @@ const MB_COMPONENTS = [
 
 export function itImplementsTheMakerBoardInterface(
   BoardClass,
-  boardType,
   boardSpecificSetup = null
 ) {
   describe('implements the MakerBoard interface', () => {
@@ -129,7 +129,7 @@ export function itImplementsTheMakerBoardInterface(
 
         it(`correct number of them`, () => {
           let constructorCount =
-            boardType === 'microbit'
+            BoardClass === MicroBitBoard
               ? MB_CONSTRUCTOR_COUNT
               : CP_CONSTRUCTOR_COUNT;
           expect(jsInterpreter.addCustomMarshalObject).to.have.callCount(
@@ -138,7 +138,7 @@ export function itImplementsTheMakerBoardInterface(
         });
 
         let components =
-          boardType === 'microbit' ? MB_COMPONENTS : CP_COMPONENTS;
+          BoardClass === MicroBitBoard ? MB_COMPONENTS : CP_COMPONENTS;
 
         components.forEach(constructor => {
           it(constructor, () => {
@@ -165,7 +165,7 @@ export function itImplementsTheMakerBoardInterface(
 
         it(`correct number of them`, () => {
           let globalPropsCount =
-            boardType === 'microbit'
+            BoardClass === MicroBitBoard
               ? MB_CONSTRUCTOR_COUNT + MB_COMPONENT_COUNT
               : CP_CONSTRUCTOR_COUNT + CP_COMPONENT_COUNT;
           expect(Object.keys(jsInterpreter.globalProperties)).to.have.length(
@@ -174,7 +174,7 @@ export function itImplementsTheMakerBoardInterface(
         });
 
         // Board-specific tests
-        if (boardType === 'circuit playground') {
+        if (BoardClass === CircuitPlaygroundBoard) {
           describe('led', () => {
             function expectLedToHaveFunction(fnName) {
               expect(jsInterpreter.globalProperties.led[fnName]).to.be.a(
@@ -308,7 +308,7 @@ export function itImplementsTheMakerBoardInterface(
         }
 
         // Board-specific tests
-        if (boardType === 'microbit') {
+        if (BoardClass === MicroBitBoard) {
           ['buttonA', 'buttonB'].forEach(button => {
             describe(button, () => {
               let component;
@@ -484,7 +484,7 @@ export function itImplementsTheMakerBoardInterface(
       });
     });
 
-    if (boardType === 'circuit playground') {
+    if (BoardClass === CircuitPlaygroundBoard) {
       /**
        * @function
        * @name MakerBoard#createLed
@@ -533,7 +533,7 @@ export function itImplementsTheMakerBoardInterface(
         expect(button).to.have.property('isPressed');
 
         // TODO - not yet implemented for microbit
-        if (boardType === 'circuit playground') {
+        if (BoardClass === CircuitPlaygroundBoard) {
           expect(button).to.have.property('holdtime');
         }
       });

--- a/apps/test/unit/lib/kits/maker/MicroBitBoardTest.js
+++ b/apps/test/unit/lib/kits/maker/MicroBitBoardTest.js
@@ -19,7 +19,7 @@ describe('MicroBitBoard', () => {
   });
 
   describe('Maker Board Interface', () => {
-    itImplementsTheMakerBoardInterface(MicroBitBoard, 'microbit', board => {
+    itImplementsTheMakerBoardInterface(MicroBitBoard, board => {
       board.boardClient_ = new MicrobitStubBoard();
     });
   });


### PR DESCRIPTION
Haste makes waste - I added this string parameter to the MakerBoardTest (and ended up making a mistake which cases the CircuitPlayground specific tests not to run). Removing that string parameter to just check the BoardType, which we were also providing, to leave less room for errors in the future. Sidenote - maybe we should split these into separate tests? But at the least, we should fix this.

## Links

<!--
  Any relevant links to external resources; ie, specification documents, jira
  items, related PRs, honeybadger errors, etc
-->

- [spec]()
- [jira]()

## Testing story

<!--
  Does your change include appropriate tests?

  If so, please describe how the tests included in this PR are sufficient

  If not, please explain why this change does not need to be tested.
-->

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
cc: @islemaster - thanks for catching this bug!