### PR TITLE
Remove 'limtus tracking id' from new actionview templates

### DIFF
--- a/pegasus/emails/hoc_signup_2014_receipt.md.actionview
+++ b/pegasus/emails/hoc_signup_2014_receipt.md.actionview
@@ -1,7 +1,6 @@
 ---
 from: "Hadi Partovi (Code.org) <hadi_partovi@code.org>"
 subject: "Thanks for signing up to host an Hour of Code!"
-litmus_tracking_id: "5g5lyi1a"
 ---
 <% hostname = CDO.canonical_hostname('hourofcode.com') %>
 

--- a/pegasus/emails/hoc_signup_2015_receipt.md.actionview
+++ b/pegasus/emails/hoc_signup_2015_receipt.md.actionview
@@ -1,7 +1,6 @@
 ---
 from: "Hadi Partovi (Code.org) <hadi_partovi@code.org>"
 subject: "Thanks for signing up to host an Hour of Code!"
-litmus_tracking_id: "5g5lyi1a"
 ---
 <% hostname = CDO.canonical_hostname('hourofcode.com') %>
 

--- a/pegasus/emails/hoc_signup_2017_receipt_en.md.actionview
+++ b/pegasus/emails/hoc_signup_2017_receipt_en.md.actionview
@@ -1,7 +1,6 @@
 ---
 from: "Hadi Partovi (Code.org) <hadi_partovi@code.org>"
 subject: "Get ready for the Hour of Code"
-litmus_tracking_id: "5g5lyi1a"
 ---
   <% hourofcode = CDO.canonical_hostname('hourofcode.com') %>
   <% codedotorg = CDO.canonical_hostname('code.org') %>

--- a/pegasus/emails/hoc_signup_2018_receipt_en.md.actionview
+++ b/pegasus/emails/hoc_signup_2018_receipt_en.md.actionview
@@ -1,7 +1,6 @@
 ---
 from: "Hadi Partovi (Code.org) <hadi_partovi@code.org>"
 subject: "Get ready for the Hour of Code"
-litmus_tracking_id: "5g5lyi1a"
 ---
   <% hourofcode = CDO.canonical_hostname('hourofcode.com') %>
   <% codedotorg = CDO.canonical_hostname('code.org') %>

--- a/pegasus/emails/hoc_signup_2018_receipt_es.md.actionview
+++ b/pegasus/emails/hoc_signup_2018_receipt_es.md.actionview
@@ -1,7 +1,6 @@
 ---
 from: "Hadi Partovi (Code.org) <hadi_partovi@code.org>"
 subject: "¡Gracias por inscribirte para ser anfitrión de una Hora de Código!"
-litmus_tracking_id: "5g5lyi1a"
 ---
   <% hostname = CDO.canonical_hostname('hourofcode.com') %>
   <% codedotorg = CDO.canonical_hostname('code.org') %>

--- a/pegasus/emails/hoc_signup_2018_receipt_pt.md.actionview
+++ b/pegasus/emails/hoc_signup_2018_receipt_pt.md.actionview
@@ -1,7 +1,6 @@
 ---
 from: "Hadi Partovi (Code.org) <hadi_partovi@code.org>"
 subject: "Obrigado por se inscrever para sediar a Hora do Código!"
-litmus_tracking_id: "5g5lyi1a"
 ---
   <% hostname = CDO.canonical_hostname('hourofcode.com') %>
   <% codedotorg = CDO.canonical_hostname('code.org') %>

--- a/pegasus/emails/hoc_signup_2019_receipt_en.md.actionview
+++ b/pegasus/emails/hoc_signup_2019_receipt_en.md.actionview
@@ -1,7 +1,6 @@
 ---
 from: "Hadi Partovi (Code.org) <hadi_partovi@code.org>"
 subject: "Get ready for the Hour of Code"
-litmus_tracking_id: "5g5lyi1a"
 ---
   <% hourofcode = CDO.canonical_hostname('hourofcode.com') %>
   <% codedotorg = CDO.canonical_hostname('code.org') %>

--- a/pegasus/emails/hoc_signup_2019_receipt_es.md.actionview
+++ b/pegasus/emails/hoc_signup_2019_receipt_es.md.actionview
@@ -1,7 +1,6 @@
 ---
 from: "Hadi Partovi (Code.org) <hadi_partovi@code.org>"
 subject: "¡Gracias por inscribirte para ser anfitrión de una Hora de Código!"
-litmus_tracking_id: "5g5lyi1a"
 ---
   <% hostname = CDO.canonical_hostname('hourofcode.com') %>
   <% codedotorg = CDO.canonical_hostname('code.org') %>

--- a/pegasus/emails/hoc_signup_2019_receipt_pt.md.actionview
+++ b/pegasus/emails/hoc_signup_2019_receipt_pt.md.actionview
@@ -1,7 +1,6 @@
 ---
 from: "Hadi Partovi (Code.org) <hadi_partovi@code.org>"
 subject: "Obrigado por se inscrever para sediar a Hora do Código!"
-litmus_tracking_id: "5g5lyi1a"
 ---
   <% hostname = CDO.canonical_hostname('hourofcode.com') %>
   <% codedotorg = CDO.canonical_hostname('code.org') %>

--- a/pegasus/emails/petition_receipt.md.actionview
+++ b/pegasus/emails/petition_receipt.md.actionview
@@ -1,7 +1,6 @@
 ---
 from: 'Hadi Partovi (Code.org) <hadi_partovi@code.org>'
 subject: 'Thanks!'
-litmus_tracking_id: 'sfgaovfs'
 ---
 
 ## Thank you for signing your name to support computer science!


### PR DESCRIPTION
Follow-up to https://github.com/code-dot-org/code-dot-org/pull/33402, which removed them from the current templates.

<!--
  Your description goes here: A summary of the change, including any relevant motivation and context.

  If relevant, include a description both of the existing behavior and of the new behavior.
-->

<!--
  Other aspects to consider. uncomment and add detail for any that seem necessary:
-->

<!-- ### Background -->
<!-- ### Privacy -->
<!-- ### Security -->
<!-- ### Caching -->
<!-- ### Deployment strategy -->
<!-- ### Future work -->

## Links

<!--
  Any relevant links to external resources; ie, specification documents, jira
  items, related PRs, honeybadger errors, etc
-->

- [spec]()
- [jira]()

## Testing story

<!--
  Does your change include appropriate tests?

  If so, please describe how the tests included in this PR are sufficient

  If not, please explain why this change does not need to be tested.
-->

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
