### PR TITLE
[Fix] Signal CloudFormation daemon-instance resource

### DIFF
--- a/aws/cloudformation/cloud_formation_stack.yml.erb
+++ b/aws/cloudformation/cloud_formation_stack.yml.erb
@@ -457,6 +457,14 @@ Resources:
             daemon: true,
             chef_version: chef_version
           ), 10)%>
+          # Signal CloudFormation resource.
+          aws cloudformation signal-resource \
+            --unique-id $INSTANCE_ID \
+            --stack-name $STACK \
+            --logical-resource-id $RESOURCE_ID \
+            --status $STATUS \
+            --region $REGION \
+            || true
       NetworkInterfaces:
       - AssociatePublicIpAddress: true
         DeviceIndex: 0


### PR DESCRIPTION
Followup to #33665, fixes adhoc-instance provisioning by replacing a call to `aws cloudformation signal-resource` that was inadvertently removed from the `daemon` ec2-instance resource.