### PR TITLE
Fix 'can see finish' tests to run on mobile [test ipad] [test iphone]

### DIFF
--- a/dashboard/test/ui/features/plc/yourschool.feature
+++ b/dashboard/test/ui/features/plc/yourschool.feature
@@ -1,8 +1,9 @@
 @no_ie
+@no_circle
 Feature: Using the YourSchool census page
 
   Scenario: Loading yourschool and fill out form
-    Given I am on "http://code.org/yourschool"
+    Given I am on "http://code.org/yourschool?noautoplay=true"
     Then I see "#map"
     And I see "#census-form"
     Then I press "#schoolNotFoundCheckbox" using jQuery

--- a/dashboard/test/ui/features/star_labs/can_see_finish.feature
+++ b/dashboard/test/ui/features/star_labs/can_see_finish.feature
@@ -44,40 +44,33 @@ Feature: Make sure we can see the finish button for all LEVEL TYPE levels on sma
     # "Minecraft Designer"
     # "App Lab"
 
-  @skip
   @no_ie @no_safari @no_firefox @no_chrome
   Scenario: can see finish button on "Dance Party"
-    And I check that the blockly free play level for "Dance Party" shows the finish button for small screens
+    And I check that the blockly free play level for "Dance Party" shows the finish button for mobile screens
 
-  @skip
   @no_ie @no_safari @no_firefox @no_chrome
   Scenario: can see finish button on "Artist"
-    And I check that the blockly free play level for "Artist" shows the finish button for small screens
+    And I check that the blockly free play level for "Artist" shows the finish button for mobile screens
 
-  @skip
   @no_ie @no_safari @no_firefox @no_chrome
   Scenario: can see finish button on "CS in Algebra"
-    And I check that the blockly free play level for "CS in Algebra" shows the finish button for small screens
+    And I check that the blockly free play level for "CS in Algebra" shows the finish button for mobile screens
 
-  @skip
   @no_ie @no_safari @no_firefox @no_chrome
   Scenario: can see finish button on "Flappy"
-    And I check that the blockly free play level for "Flappy" shows the finish button for small screens
+    And I check that the blockly free play level for "Flappy" shows the finish button for mobile screens
 
-  @skip
   @no_ie @no_safari @no_firefox @no_chrome
   Scenario: can see finish button on "Sprite Lab"
-    And I check that the blockly free play level for "Sprite Lab" shows the finish button for small screens
+    And I check that the blockly free play level for "Sprite Lab" shows the finish button for mobile screens
 
-  @skip
   @no_ie @no_safari @no_firefox @no_chrome
   Scenario: can see finish button on "Game Lab"
-    And I check that the droplet free play level for "Game Lab" shows the finish button for small screens
+    And I check that the droplet free play level for "Game Lab" shows the finish button for mobile screens
 
-  @skip
   @no_ie @no_safari @no_firefox @no_chrome
   Scenario: can see finish button on "Minecraft Adventurer"
-    And I check that the minecraft free play level for "Minecraft Adventurer" shows the finish button for small screens
+    And I check that the minecraft free play level for "Minecraft Adventurer" shows the finish button for mobile screens
 
   # The following levels currently do not show finish button
   # in the viewport when play is pressed for iphone, but do on ipad


### PR DESCRIPTION
Previous tests had a typo keeping them from working on mobile, and the issue
was missed because mobile testing tags were not included.  Fixing.

<!--
  Your description goes here: A summary of the change, including any relevant motivation and context.

  If relevant, include a description both of the existing behavior and of the new behavior.
-->

<!--
  Other aspects to consider. uncomment and add detail for any that seem necessary:
-->

<!-- ### Background -->
<!-- ### Privacy -->
<!-- ### Security -->
<!-- ### Caching -->
<!-- ### Deployment strategy -->
<!-- ### Future work -->

## Links

<!--
  Any relevant links to external resources; ie, specification documents, jira
  items, related PRs, honeybadger errors, etc
-->

- [spec]()
- [jira]()

## Testing story

<!--
  Does your change include appropriate tests?

  If so, please describe how the tests included in this PR are sufficient

  If not, please explain why this change does not need to be tested.
-->

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
