### PR TITLE
Bump blockly to 3.5.10

### DIFF
--- a/apps/package.json
+++ b/apps/package.json
@@ -49,7 +49,7 @@
     "@babel/preset-react": "^7.0.0",
     "@cdo/interpreted": "link:../dashboard/config/libraries",
     "@code-dot-org/artist": "0.2.1",
-    "@code-dot-org/blockly": "3.5.8",
+    "@code-dot-org/blockly": "3.5.10",
     "@code-dot-org/bramble": "0.1.26",
     "@code-dot-org/craft": "0.2.2",
     "@code-dot-org/dance-party": "1.0.1",

--- a/apps/yarn.lock
+++ b/apps/yarn.lock
@@ -1526,10 +1526,10 @@
   version "0.2.1"
   resolved "https://registry.yarnpkg.com/@code-dot-org/artist/-/artist-0.2.1.tgz#fcfe7ea5cfb3f19ddb6b912e70e922ba4b7ef0b1"
 
-"@code-dot-org/blockly@3.5.8":
-  version "3.5.8"
-  resolved "https://registry.yarnpkg.com/@code-dot-org/blockly/-/blockly-3.5.8.tgz#f3b9818dda8f955bce78b4454631da9c3766177f"
-  integrity sha512-X39kzCcfS8FsLcO5BTP3PQQHoHjAQ7VrSoplyNNR/hyAMRmddLZKdOBSNdyV+6YwuZDgu9/CMlJ76qeqRMCiMQ==
+"@code-dot-org/blockly@3.5.10":
+  version "3.5.10"
+  resolved "https://registry.yarnpkg.com/@code-dot-org/blockly/-/blockly-3.5.10.tgz#f84b5df062c550f68f8160c029286a3da4e9021b"
+  integrity sha512-KI7jkldinEVPLXhb8DRnTN6MbpXHSC1Aq4Fvq0XW2V/jn0I0kzchJoKfr549yPq9ph/GTDYK0UVSmkNu31ttUg==
 
 "@code-dot-org/bramble@0.1.26":
   version "0.1.26"


### PR DESCRIPTION
Pulls in https://github.com/code-dot-org/blockly/pull/204 to get updated angle picker UI:
![image](https://user-images.githubusercontent.com/8787187/77378791-45808900-6d34-11ea-934b-6c3aa8ed736a.png)
