### PR TITLE
Progress Box fills from the bottom up

### DIFF
--- a/apps/src/templates/sectionProgress/ProgressBox.jsx
+++ b/apps/src/templates/sectionProgress/ProgressBox.jsx
@@ -2,16 +2,19 @@ import PropTypes from 'prop-types';
 import React, {Component} from 'react';
 import color from '@cdo/apps/util/color';
 
+const PROGRESS_BOX_SIZE = 20;
+
 const styles = {
   box: {
-    height: 20,
-    width: 20,
+    height: PROGRESS_BOX_SIZE,
+    width: PROGRESS_BOX_SIZE,
     borderWidth: 1,
     borderStyle: 'solid',
-    boxSizing: 'content-box'
+    boxSizing: 'content-box',
+    position: 'relative'
   },
   filler: {
-    width: 20,
+    width: PROGRESS_BOX_SIZE,
     position: 'absolute'
   },
   lessonNumber: {
@@ -19,7 +22,7 @@ const styles = {
     zIndex: 2,
     paddingTop: 2,
     textAlign: 'center',
-    width: 20,
+    width: PROGRESS_BOX_SIZE,
     fontFamily: '"Gotham 4r", sans-serif'
   }
 };
@@ -57,13 +60,15 @@ export default class ProgressBox extends Component {
     const perfectLevels = {
       ...styles.filler,
       backgroundColor: color.level_perfect,
-      height: perfect
+      height: perfect,
+      top: PROGRESS_BOX_SIZE - perfect
     };
 
     const assessmentLevels = {
       ...styles.filler,
       backgroundColor: color.level_submitted,
-      height: perfect
+      height: perfect,
+      top: PROGRESS_BOX_SIZE - perfect
     };
 
     const incompleteLevels = {

--- a/dashboard/test/ui/features/learning_platform/teacher_dashboard/progress_tab_views_eyes.feature
+++ b/dashboard/test/ui/features/learning_platform/teacher_dashboard/progress_tab_views_eyes.feature
@@ -44,6 +44,7 @@ Feature: Using the progress tab of the teacher dashboard
     And I see no difference for "standards intro"
     And I press the first ".uitest-standards-intro-button" element
 
+    And I wait until element ".uitest-standards-intro-button" is not visible
     And I wait until element "#uitest-progress-standards-table" is visible
     And I see no difference for "standards view"
     And I close my eyes

--- a/dashboard/test/ui/features/learning_platform/teacher_dashboard/progress_tab_views_eyes.feature
+++ b/dashboard/test/ui/features/learning_platform/teacher_dashboard/progress_tab_views_eyes.feature
@@ -1,0 +1,50 @@
+@no_mobile
+@eyes
+Feature: Using the progress tab of the teacher dashboard
+
+  Scenario: Toggling between views in progress tab
+    When I open my eyes to test "progress tab views"
+    Given I create an authorized teacher-associated student named "Sally"
+
+   # Make sure Course A is in the drop down so we can use it for standards tab
+    Given I am assigned to script "coursea-2019"
+    Given I am assigned to script "allthethings"
+
+    And I complete the level on "http://studio.code.org/s/allthethings/stage/2/puzzle/1"
+    And I complete the free response on "http://studio.code.org/s/allthethings/stage/27/puzzle/1"
+    And I submit the assessment on "http://studio.code.org/s/allthethings/stage/33/puzzle/1"
+
+    # Navigate to Progress tab As Teacher
+    When I sign in as "Teacher_Sally" and go home
+    And I get hidden script access
+    And I wait until element "a:contains('Untitled Section')" is visible
+    And I save the section id from row 0 of the section table
+    Then I navigate to teacher dashboard for the section I saved with experiment "standardsReport"
+    And I wait until element "#uitest-course-dropdown" contains text "All the Things! *"
+
+    # Summary View
+    And I wait until element ".uitest-summary-cell" is visible
+    And I see no difference for "summary view"
+    And I wait until element "#uitest-toggle-detail-view" is visible
+    And I press the first "#uitest-toggle-detail-view" element
+
+    # Detail View
+    And I wait until element ".uitest-detail-cell" is visible
+    And I see no difference for "detail view"
+
+    # Standards View - Need to be in a course that has standards
+    And I select the "Course A (2019)" option in dropdown "uitest-course-dropdown"
+    And I wait until element "#uitest-course-dropdown" contains text "Course A (2019)"
+
+    And I wait until element "#uitest-standards-toggle" is visible
+    And I press the first "#uitest-standards-toggle" element
+
+    # Clear the intro dialog
+    And I wait until element ".uitest-standards-intro-button" is visible
+    And I see no difference for "standards intro"
+    And I press the first ".uitest-standards-intro-button" element
+
+    And I wait until element "#uitest-progress-standards-table" is visible
+    And I see no difference for "standards view"
+    And I close my eyes
+


### PR DESCRIPTION
Progress boxes now fill from the bottom.

### Before

![Screen Shot 2020-03-25 at 4 42 42 PM](https://user-images.githubusercontent.com/208083/77583554-a84e5d80-6eb7-11ea-9b78-9351b817c3a4.png)


### After
![Screen Shot 2020-03-24 at 1 11 20 PM](https://user-images.githubusercontent.com/208083/77457499-2be24e80-6dd3-11ea-8df0-d2061b1f861f.png)


## Links

<!--
  Any relevant links to external resources; ie, specification documents, jira
  items, related PRs, honeybadger errors, etc
-->

- [jira](https://codedotorg.atlassian.net/browse/LP-1322)

## Testing story

<!--
  Does your change include appropriate tests?

  If so, please describe how the tests included in this PR are sufficient

  If not, please explain why this change does not need to be tested.
-->

I added an eyes test for the different views in the progress tab so that we would catch this kind of regression again next time.


# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
