### PR TITLE
Curriculum Tracking Pixel: don't throw error for base url 

### DIFF
--- a/dashboard/app/controllers/curriculum_tracking_pixel_controller.rb
+++ b/dashboard/app/controllers/curriculum_tracking_pixel_controller.rb
@@ -19,7 +19,7 @@ class CurriculumTrackingPixelController < ApplicationController
       # ["csf-18", "pre-express", "11"]
       # ["es-mx", "csf-1718", "coursec", "10"]
 
-      non_en = split_url[0].length == 5 && !!split_url[0].match(/\S{2}-\S{2}/)
+      non_en = split_url[0]&.length == 5 && !!split_url[0].match(/\S{2}-\S{2}/)
 
       locale = non_en ? split_url.shift : "en-us"
 


### PR DESCRIPTION
If you go to the base url https://curriculum.code.org/, the parsing logic in the curriculum tracking pixel controller (#33769) throws an [error](https://app.honeybadger.io/projects/3240/faults/62244939). To fix, I check to make sure we have a url to parse before checking its length. 
