### PR TITLE
Updated artist to use the thumbnail as its image for social media.

### DIFF
--- a/dashboard/app/controllers/projects_controller.rb
+++ b/dashboard/app/controllers/projects_controller.rb
@@ -324,7 +324,7 @@ class ProjectsController < ApplicationController
     )
 
     if params[:key] == 'artist'
-      @project_image = CDO.studio_url "/v3/files/#{@view_options['channel']}/_share_image.png", 'https:'
+      @project_image = CDO.studio_url "/v3/files/#{@view_options['channel']}/.metadata/thumbnail.png", 'https:'
     end
 
     if params[:key] == 'dance'


### PR DESCRIPTION
Social-media sharing of artist projects with a preview thumbnail is currently broken.
Actual:
![image](https://user-images.githubusercontent.com/8324574/77488292-00229100-6df2-11ea-8a8e-5ec955f4916e.png)
Expected contents:
![image](https://user-images.githubusercontent.com/8324574/77488317-116b9d80-6df2-11ea-87f0-d3414ecbf37f.png)

The OG tag points to (example) https://studio.code.org/v3/files/mNqIchUHCrX37Nm6dig-hXZ03nB6BneQA7sISfM2nY0/_share_image.png which is currently broken. 

This PR updates the OG tag to point to (example) https://studio.code.org/v3/files/mNqIchUHCrX37Nm6dig-hXZ03nB6BneQA7sISfM2nY0/.metadata/thumbnail.png 
which is the image used in the thumbnail.

<!-- ### Background -->
<!-- ### Privacy -->
<!-- ### Security -->
<!-- ### Caching -->
<!-- ### Deployment strategy -->
<!-- ### Future work -->

## Links

<!--
  Any relevant links to external resources; ie, specification documents, jira
  items, related PRs, honeybadger errors, etc
-->

This is a fix for Code Break

## Testing story

<!--
  Does your change include appropriate tests?

  If so, please describe how the tests included in this PR are sufficient

  If not, please explain why this change does not need to be tested.
-->

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
