### PR TITLE
Apply stage renames to 2020 curriculum

### DIFF
--- a/dashboard/config/locales/scripts.en.yml
+++ b/dashboard/config/locales/scripts.en.yml
@@ -14691,7 +14691,7 @@ en:
               description_student: Click and drag to finish the puzzles.
               description_teacher: This lesson will give students an idea of what to expect when they head to the computer lab. It begins with a brief discussion introducing them to computer lab manners, then they will progress into using a computer to complete online puzzles.
             'Programming: Happy Maps':
-              name: 'Programming: Happy Maps'
+              name: Happy Maps
               description_student: Write instructions to get the Flurb to the fruit.
               description_teacher: 'This unplugged lesson brings together teams with a simple task: get the "flurb" to the fruit. Students will practice writing precise instructions as they work to translate instructions into the symbols provided. If problems arise in the code, students should also work together to recognize bugs and build solutions.'
             Sequencing with Scrat:
@@ -14699,7 +14699,7 @@ en:
               description_student: Program Scrat to reach the acorn.
               description_teacher: This lesson will give students an idea of what to expect when they head to the computer lab. It begins with a brief discussion introducing them to computer lab manners, then they will progress into using a computer to complete online puzzles.
             Programming in Ice Age:
-              name: Programming in Ice Age
+              name: Programming with Scrat
               description_student: Write programs to help Scrat reach the acorn.
               description_teacher: Using characters from the Ice Age, students will develop sequential algorithms to move Scrat from one side of a maze to the acorn at the other side. To do this they will stack code blocks together in a linear sequence, making them move straight, turn left, or turn right.
             Programming with Rey and BB-8:
@@ -14707,15 +14707,15 @@ en:
               description_student: Help BB-8 collect the scrap metal.
               description_teacher: In this lesson, students will use their newfound programming skills in more complicated ways to navigate a tricky course with BB-8.
             'Loops: Happy Loops':
-              name: 'Loops: Happy Loops'
+              name: Happy Loops
               description_student: Help the Flurb solve bigger problems using loops.
               description_teacher: This activity revisits Happy Maps. This time, student will be solving bigger, longer puzzles with their code, leading them to see utility in structures that let them write longer code in an easier way.
             Loops in Ice Age:
-              name: Loops in Ice Age
+              name: Loops with Scrat
               description_student: Help Scrat cover more ground using loops.
               description_teacher: Building on the concept of repeating instructions from "Happy Loops," this stage will have students using loops to get to the acorn more efficiently on Code.org.
             Loops in Collector:
-              name: Loops in Collector
+              name: Loops with Laurel
               description_student: Help Laurel the adventurer collect the treasure underground.
               description_teacher: In this lesson, students continue learning the concept of loops. In the previous lesson, students were introduced to loops by moving through a maze and picking corn. Here, loops are used to collect treasure in open cave spaces.
             Ocean Scene with Loops:
@@ -14723,11 +14723,11 @@ en:
               description_student: Use loops and patterns to finish the images.
               description_teacher: Returning to loops, students learn to draw images by looping simple sequences of instructions. In the previous plugged lesson, loops were used to traverse a maze and collect treasure. Here, loops are creating patterns. At the end of this stage, students will be given the opportunity to create their own images using loops.
             'Events: The Big Event':
-              name: 'Events: The Big Event'
+              name: The Big Event Jr.
               description_student: Move and shout when your teachers presses buttons on a giant remote.
               description_teacher: Events are a great way to add variety to a pre-written algorithm. Sometimes you want your program to be able to respond to the user exactly when the user wants it to. That is what events are for.
             Events in Play Lab:
-              name: Events in Play Lab
+              name: On the Move with Events
               description_student: Create your own game or story.
               description_teacher: In this online activity, students will have the opportunity to learn how to use events in Play Lab and to apply all of the coding skills they've learned to create an animated game. It's time to get creative and make a story in the Play Lab!
             Safety in My Online Neighborhood:
@@ -14747,31 +14747,31 @@ en:
               description_student: Program your classmates to step carefully from place to place.
               description_teacher: This lesson will work to prepare students mentally for the coding exercises that they will encounter over the length of this course.  In small teams, students will use physical activity to program their classmates to step carefully from place to place until a goal is achieved.
             Sequencing in Maze:
-              name: Sequencing in Maze
+              name: Sequencing with Angry Birds
               description_student: Help Red the Angry Bird follow the path to the naughty pig.
               description_teacher: This lesson will give students an idea of what to expect when they head to the computer lab. It begins with a brief discussion introducing them to computer lab manners, then they will progress into using a computer to complete online puzzles.
             Programming in Maze:
-              name: Programming in Maze
+              name: Programming with Angry Birds
               description_student: Create programs to help the Angry Bird move through the maze.
               description_teacher: Using characters from the game Angry Birds, students will develop sequential algorithms to move a bird from one side of a maze to the pig at the other side. To do this they will stack code blocks together in a linear sequence, making them move straight, turn left, or turn right.
             Programming in Harvester:
-              name: Programming in Harvester
+              name: Programming with Harvester
               description_student: Help the Harvester collect vegetables along a path.
               description_teacher: 'Students will apply the programming concepts that they have learned to the Harvester environment. Now, instead of just getting the character to a goal, students have to collect corn using a new block. Students will continue to develop sequential algorithm skills and start using the debugging process. '
             'Loops: Getting Loopy':
-              name: 'Loops: Getting Loopy'
+              name: Getting Loopy
               description_student: In this lesson, we'll have a dance party using repeat loops!
               description_teacher: As we start to write longer and more interesting programs, our code often contains a lot of repetition. In this lesson, students will learn about how loops can be used to more easily communicate instructions that have a lot of repetition by looking at the repeated patterns of movement in a dance.
             Loops in Harvester:
-              name: Loops in Harvester
+              name: Loops with Harvester
               description_student: Help the Harvester collect even more, using loops!
               description_teacher: Building on the concept of repeating instructions from "Getting Loopy," this stage will have students using loops to pick corn more efficiently on Code.org.
             Loops in Collector:
-              name: Loops in Collector
+              name: Loops with Laurel
               description_student: Program Laurel the adventurer to collect treasure in an open cave.
               description_teacher: In this lesson, students continue learning the concept of loops. Here, Laurel the Adventurer uses loops to collect treasure in open cave spaces. A new `get treasure` block is introduced to help her on her journey.
             Loops in Artist:
-              name: Loops in Artist
+              name: Drawing Gardens with Loops
               description_student: Use patterns and loops to finish the images.
               description_teacher: Returning to loops, students learn to draw images by looping simple sequences of instructions. In the previous online lesson, loops were used to traverse a maze and collect treasure. Here, students use loops to create patterns. At the end of this stage, students will be given the opportunity to create their own images using loops.
             The Right App:
@@ -14779,11 +14779,11 @@ en:
               description_student: Sketch your own smartphone app.
               description_teacher: 'This lesson has students recognize that computer science can help people in real life. First, students empathize with several fictional smartphone users in order to help them find the “right app” that addresses their needs. Then, students exercise empathy and creativity to sketch their own smartphone app that addresses the needs of one additional user. '
             'Events: The Big Event':
-              name: 'Events: The Big Event'
+              name: The Big Event Jr.
               description_student: Move or shout when your teacher presses buttons on a giant remote.
               description_teacher: Events are a great way to add variety to a pre-written algorithm. Sometimes you want your program to be able to respond to the user exactly when the user wants it to. That is what events are for.
             Events in Play Lab:
-              name: Events in Play Lab
+              name: A Royal Battle with Events
               description_student: Use events to create a story or make an interactive game.
               description_teacher: In this online activity, students will have the opportunity to learn how to use events in Play Lab and apply all of the coding skills that they've learned to create an animated game. It's time to get creative and make a game in Play Lab!
             Digital Trails:
@@ -14803,11 +14803,11 @@ en:
               description_student: In this lesson, you'll learn about how passwords protect your information, and how to make a good password.
               description_teacher: "Students explore why people use passwords, learn the benefits of using passwords, and discover strategies for creating and keeping strong, secure passwords.\r\n\r\nStudents learn password tips, test their existing passwords with an interactive game, and create new passwords using guidelines for powerful passwords.\r\n"
             'Programming: My Robotic Friends':
-              name: 'Programming: My Robotic Friends'
+              name: My Robotic Friends Jr.
               description_student: In this lesson, you'll pretend your classmates are robots and program them to build patterns of stacked cups.
               description_teacher: Using a set of symbols in place of code, students will design algorithms to instruct a "robot" to stack cups in different patterns. Students will take turns participating as the robot, responding only to the algorithm defined by their peers. This segment teaches students the connection between symbols and actions, the difference between an algorithm and a program, and the valuable skill of debugging.
             Programming in Maze:
-              name: Programming in Maze
+              name: Programming with Angry Birds
               description_student: Learn about sequences and algorithms with Angry Birds.
               description_teacher: Using characters from the game Angry Birds, students will develop sequential algorithms to move a bird from one side of a maze to the pig at the other side. To do this they will stack code blocks together in a linear sequence, making them move straight, turn left, or turn right.
             Debugging in Maze:
@@ -14815,11 +14815,11 @@ en:
               description_student: Find problems in puzzles and practice your debugging skills.
               description_teacher: Debugging is an essential element of learning to program. In this lesson, students will encounter puzzles that have been solved incorrectly. They will need to step through the existing code to identify errors, including incorrect loops, missing blocks, extra blocks, and blocks that are out of order.
             Programming in Collector:
-              name: Programming in Collector
+              name: Collecting Treasure with Laurel
               description_student: Write algorithms to help Laurel the Adventurer collect lots of gems!
               description_teacher: In this series of puzzles, students will continue to develop their understanding of algorithms and debugging. With a new character, Laurel the Adventurer, students will create sequential algorithms to get Laurel to pick up treasure as she walks along a path.
             Programming in Artist:
-              name: Programming in Artist
+              name: Creating Art with Code
               description_student: Create beautiful images by programming the Artist.
               description_teacher: In this lesson, students will take control of the Artist to complete drawings on the screen. This Artist stage will allow students to create images of increasing complexity using new blocks like `move forward by 100 pixels` and `turn right by 90 degrees`.
             Binary Bracelets:
@@ -14827,7 +14827,7 @@ en:
               description_student: Create your very own binary bracelet and learn how computers remember information!
               description_teacher: Binary is extremely important in the world of computers. The majority of computers today store all sorts of information in binary form. This lesson helps demonstrate how it is possible to take something from real life and translate it into a series of ons and offs.
             'Loops: My Loopy Robotic Friends':
-              name: 'Loops: My Loopy Robotic Friends'
+              name: My Loopy Robotic Friends Jr.
               description_student: In this lesson, you'll program your classmates again, but using loops you'll be able to solve bigger and more complicated problems.
               description_teacher: Building on the initial "My Robotic Friends" activity, students tackle larger and more complicated designs. In order to program their "robots" to complete these bigger designs, students will need to identify repeated patterns in their instructions that could be replaced with a loop.
             Loops with Rey and BB-8:
@@ -14835,11 +14835,11 @@ en:
               description_student: 'Help BB-8 through mazes using loops! '
               description_teacher: Building on the concept of repeating instructions from "Getting Loopy," this stage will have students using loops to help BB-8 traverse a maze more efficiently than before.
             Loops in Harvester:
-              name: Loops in Harvester
+              name: Harvesting Crops with Loops
               description_student: Let's use loops to help the harvester collect some veggies!
               description_teacher: "In the preceding stage, students used loops to create fantastic drawings. Now they're going to loop new actions in order to help the harvester collect multiple veggies growing in large bunches.\r\n"
             Looking Ahead:
-              name: Looking Ahead
+              name: Looking Ahead with Minecraft
               description_student: Avoid the lava! Here you will start to learn about conditionals in the world of Minecraft.
               description_teacher: This lesson was originally created for the Hour of Code, alongside the Minecraft team. Students will get the chance to practice ideas that they have learned up to this point, as well as getting a sneak peek at conditionals!
             Sticker Art with Loops:
@@ -14847,7 +14847,7 @@ en:
               description_student: In this lesson, loops make it easy to make even cooler images with Artist!
               description_teacher: Watch student faces light up as they make their own gorgeous designs using a small number of blocks and digital stickers! This lesson builds on the understanding of loops from previous lessons and gives students a chance to be truly creative.  This activity is fantastic for producing artifacts for portfolios or parent/teacher conferences.
             'Events: The Big Event':
-              name: 'Events: The Big Event'
+              name: The Big Event
               description_student: 'Play a fun game to learn about events. '
               description_teacher: Students will soon learn that events are a great way to add flexibility to a pre-written algorithm. Sometimes you want your program to be able to respond to the user exactly when the user wants it to. Events can make your program more interesting and interactive.
             Build a Flappy Game:
@@ -14855,7 +14855,7 @@ en:
               description_student: Build you own Flappy Bird game however you like, then share it with your friends!
               description_teacher: In this special stage, students get to build their own Flappy Bird game by using event handlers to detect mouse clicks and object collisions. At the end of the level, students will be able to customize their game by changing the visuals or rules.
             Events in Play Lab:
-              name: Events in Play Lab
+              name: Chase Game with Events
               description_student: It's time to get creative and make a game in Play Lab!
               description_teacher: In this online activity, students will have the opportunity to learn how to use events in Play Lab and to apply all the coding skills they've learned to create an animated game. It's time to get creative and make a game in Play Lab!
             Picturing Data:
@@ -14863,7 +14863,7 @@ en:
               description_student: Data can be used to help students understand their world and answer interesting questions. In this lesson, students will collect data from a Play Lab project and visualize it using different kinds of graphs.
               description_teacher: Data can be used to help students understand their world and answer interesting questions. In this lesson, students will collect data from a Play Lab project and visualize it using different kinds of graphs.
             'End of Course Project: Create a Play Lab Game':
-              name: 'End of Course Project: Create a Play Lab Game'
+              name: End of Course Project
               description_student: Get those hands ready for plenty of coding! It's time to start building your project.
               description_teacher: 'This capstone lesson takes students through the process of designing, developing, and showcasing their own Play Lab projects! To ensure this process goes smoothly, we have provided a step-by-step structure for students to follow, from planning on paper to coding on our website. In addition, we offer ideas to help teachers facilitate a showcase finale! '
             Putting a STOP to Online Meanness:
@@ -14877,7 +14877,7 @@ en:
           description_audience: 'Ages: 7-11'
           stages:
             'Algorithms: Graph Paper Programming':
-              name: 'Algorithms: Graph Paper Programming'
+              name: Graph Paper Programming
               description_student: In this lesson, you will program your classmate to draw pictures!
               description_teacher: 'By "programming" one another to draw pictures, students get an opportunity to experience some of the core concepts of programming in a fun and accessible way. The class will start by having students use symbols to instruct each other to color squares on graph paper in an effort to reproduce an existing picture. If there’s time, the lesson can conclude with images that the students create themselves.  '
             Introduction to Online Puzzles:
@@ -14889,7 +14889,7 @@ en:
               description_student: Remember at the beginning of the course when you made drawings with code? In this lesson, you will be working with a team to do something very similar!
               description_teacher: This activity will begin with a short lesson on debugging and persistence, then will quickly move to a race against the clock as students break into teams and work together to write a program one instruction at a time.
             Debugging in Collector:
-              name: Debugging in Collector
+              name: Debugging with Laurel
               description_student: Have you ever run into problems while coding? In this lesson, you will learn about the secrets of debugging. Debugging is the process of finding and fixing problems in your code.
               description_teacher: In this online activity, students will practice debugging in the "collector" environment. Students will get to practice reading and editing code to fix puzzles with simple algorithms, loops and nested loops.
             Events in Bounce:
@@ -14905,11 +14905,11 @@ en:
               description_student: In this lesson you'll use the repeat block to help Scrat reach the acorn as efficiently as possible.
               description_teacher: As a quick update (or introduction) to using loops, this stage will have students using the `repeat` block to get Scrat to the acorn more efficiently.
             Loops in Artist:
-              name: Loops in Artist
+              name: Drawing Shapes with Loops
               description_student: In this lesson, loops make it easy to make cool images with the Artist!
               description_teacher: This lesson builds on the understanding of loops from previous lessons and gives students a chance to be truly creative.  This activity doubles as a debugging exercise for extra problem-solving practice.
             Nested Loops in Bee:
-              name: Nested Loops in Bee
+              name: Nested Loops in Maze
               description_student: Loops inside loops inside loops. What does this mean? This lesson will teach you what happens when you create a nested loop.
               description_teacher: In this online activity, students will have the opportunity to push their understanding of loops to a whole new level. Playing with the Bee and Plants vs Zombies, students will learn how to program a loop to be inside of another loop. They will also be encouraged to figure out how little changes in either loop will affect their program when they click `Run`.
             Conditionals with Cards:
@@ -14917,7 +14917,7 @@ en:
               description_student: It's time to play a game where you earn points only under certain conditions!
               description_teacher: "This lesson demonstrates how conditionals can be used to tailor a program to specific information. We don’t always have all of the information we need when writing a program. Sometimes you will want to do something different in one situation than in another, even if you don't know what situation will be true when your code runs. That is where conditionals come in. Conditionals allow a computer to make a decision, based on the information that is true any time your code is run.\r\n\r\n"
             Conditionals in Bee:
-              name: Conditionals in Bee
+              name: If/Else with Bee
               description_student: 'Now that you understand conditionals, it''s time to program Bee to use them when collecting honey and nectar. '
               description_teacher: Up until this point students have been writing code that executes exactly the same way each time it is run - reliable, but not very flexible. In this lesson, your class will begin to code with conditionals, allowing them to write code that functions differently depending on the specific conditions the program encounters.
             While Loops in Farmer:
@@ -14929,15 +14929,15 @@ en:
               description_student: You can do some amazing things when you use `until` loops!
               description_teacher: In this lesson, students will learn about `until` loops. Students will build programs that have the main character repeat actions `until` they reach their desired stopping point.
             Conditionals & Loops in Harvester:
-              name: Conditionals & Loops in Harvester
+              name: Harvesting with Conditionals
               description_student: It's not always clear when to use each conditional.  This lesson will help you get practice deciding what to do.
               description_teacher: Students will practice `while` loops, `until` loops, and `if / else` statements. All of these blocks use conditionals. By practicing all three, students will learn to write complex and flexible code.
             'Unplugged: Binary':
-              name: 'Unplugged: Binary'
+              name: Binary Images
               description_student: Learn how computers store pictures using a language with only two options.
               description_teacher: Though many people think of binary as strictly zeros and ones, students will be introduced to the idea that information can be represented in a variety of binary options. This lesson takes that concept one step further as it illustrates how a computer can store even more complex information (such as images and colors) in binary, as well.
             Artist Binary:
-              name: Artist Binary
+              name: Binary Images with Artist
               description_student: In this lesson, you will learn how to make images using only 0s and 1s.
               description_teacher: This series of online lessons will have students learning to make images using on and off.
             Digital Citizenship:
@@ -14965,7 +14965,7 @@ en:
               description_student: In this lesson, you will learn how to write your very own programs!
               description_teacher: "In this set of puzzles, students will begin with an introduction (or review depending on the experience of your class) of Code.org's online workspace. There will be videos pointing out the basic functionality of the workspace including the `Run`, `Reset`, and `Step` buttons. Also discussed in these videos: dragging Blockly blocks, deleting Blockly blocks, and connecting Blockly blocks. Next, students will practice their _sequencing_ and _debugging_ skills in the maze. \r\nDebugging is an essential element of learning to program. Students will encounter some puzzles that have been solved incorrectly. They will need to step through the existing code to identify errors, including incorrect loops, missing blocks, extra blocks, and blocks that are out of order."
             Programming and Loops with the Artist:
-              name: Programming and Loops with the Artist
+              name: Drawing with Loops
               description_student: In this lesson, loops make it easy to make even cooler images with Artist!
               description_teacher: Watch student faces light up as they make their own gorgeous designs using a small number of blocks and digital stickers! This lesson builds on the understanding of loops from previous lessons and gives students a chance to be truly creative.  This activity is fantastic for producing artifacts for portfolios or parent/teacher conferences.
             'Conditionals in Minecraft: Voyage Aquatic':
@@ -14973,7 +14973,7 @@ en:
               description_student: Here you will learn about conditionals in the world of Minecraft.
               description_teacher: This lesson was originally created for the Hour of Code, alongside the Minecraft team. Students will get the chance to practice ideas that they have learned up to this point, as well as getting a sneak peek at conditionals!
             Conditionals:
-              name: Conditionals
+              name: Conditionals with the Farmer
               description_student: You will get to tell the computer what to do under certain conditions in this fun and challenging series.
               description_teacher: This lesson introduces students to `while` loops and `if / else` statements. _While loops_ are loops that continue to repeat commands as long as a condition is true. While loops are used when the programmer doesn't know the exact number of times the commands need to be repeated, but the programmer does know what condition needs to be true in order for the loop to continue looping. `If / Else` statements offer flexibility in programming by running entire sections of code only if something is true, otherwise it runs something else.
             Simon Says:
@@ -14981,7 +14981,7 @@ en:
               description_student: Play a game and think about what commands are needed to get the right result.
               description_teacher: 'In this lesson, students will play a game intended to get them thinking about the way commands need to be given to produce the right result. This will help them more easily carry over to Sprite Lab in the upcoming lessons. '
             Learning Sprites with Sprite Lab:
-              name: Learning Sprites with Sprite Lab
+              name: Swimming Fish with Sprite Lab
               description_student: Learn how to create and edit sprites.
               description_teacher: 'In this lesson, students will learn about the two concepts at the heart of Sprite Lab: sprites and behaviors. Sprites are characters or objects on the screen that students can move, change, and manipulate. Behaviors are actions that sprites will take continuously until they are stopped.'
             Alien Dance Party with Sprite Lab:
@@ -14993,27 +14993,27 @@ en:
               description_student: The internet is fun and exciting, but it's important to stay safe too. This lesson teaches you the difference between information that is safe to share and information that is private.
               description_teacher: "Developed by Common Sense Education, this lesson is about the difference between information that is safe to share online and information that is not.\r\n\r\nAs students visit sites that request information about their identities, they learn to adopt a critical inquiry process that empowers them to protect themselves and their families from identity theft. In this lesson, students learn to think critically about the user information that some websites request or require. They learn the difference between private information and personal information, as well as how to distinguish what is safe or unsafe to share online."
             About Me:
-              name: About Me
+              name: About Me with Sprite Lab
               description_student: By creating an interactive poster with SpriteLab, students will apply their understanding of sharing personal and private information on the web.
               description_teacher: "By creating an interactive poster with SpriteLab, students will apply their understanding of sharing personal and private information on the web.\r\n"
             Access Ability:
-              name: Access Ability
+              name: Designing for Accessibility
               description_student: 'In this lesson, students will learn about accessibility and the value of empathy through brainstorming and designing accessible solutions for hypothetical apps. '
               description_teacher: 'In this lesson, students will learn about accessibility and the value of empathy through brainstorming and designing accessible solutions for hypothetical apps. '
             Nested Loops in Bee:
-              name: Nested Loops in Bee
+              name: Nested Loops in Maze
               description_student: Loops inside loops inside loops. What does this mean? This lesson will teach you what happens when you place a loop inside another loop.
               description_teacher: In this online activity, students will have the opportunity to push their understanding of loops to a whole new level. Playing with the Bee and Plants vs Zombies, students will learn how to program a loop to be inside of another loop. They will also be encouraged to figure out how little changes in either loop will affect their program when they click `Run`.
             Nested Loops in Artist:
-              name: Nested Loops in Artist
+              name: Fancy Shapes using Nested Loops
               description_student: More nested loops! This time, you get to make some AMAZING drawing with nested loops.
               description_teacher: Students will create intricate designs using Artist in today's set of puzzles. By continuing to practice nested loops with new goals, students will see more uses of loops in general. This set of puzzles also offers a lot more potential for creativity with an opportunity for students to create their own design at the end of the stage.
             Nested Loops in Frozen:
-              name: Nested Loops in Frozen
+              name: Nested Loops with Frozen
               description_student: 'Anna and Elsa have excellent ice-skating skills, but need your help to create patterns in the ice. Use nested loops to create something super COOL. '
               description_teacher: Now that students know how to layer their loops, they can create so many beautiful things.  This lesson will take students through a series of exercises to help them create their own portfolio-ready images using Anna and Elsa's excellent ice-skating skills!
             'Functions: Songwriting':
-              name: 'Functions: Songwriting'
+              name: Songwriting
               description_student: Even rockstars need programming skills. This lesson will teach you about functions using lyrics from songs.
               description_teacher: One of the most magnificent structures in the computer science world is the function. Functions (sometimes called procedures) are mini programs that you can use over and over inside of your bigger program. This lesson will help students intuitively understand why combining chunks of code into functions can be such a helpful practice.
             Functions in Minecraft:
@@ -15021,11 +15021,11 @@ en:
               description_student: Can you figure out how to use functions for the most efficient code?
               description_teacher: Students will begin to understand how functions can be helpful in this fun and interactive Minecraft adventure!
             Functions in Harvester:
-              name: Functions in Harvester
+              name: Functions with Harvester
               description_student: Functions will save you lots of work as you help the farmer with her harvest!
               description_teacher: Students have practiced creating impressive designs in Artist and navigating mazes in Bee, but today they will use functions to harvest crops in Harvester. This lesson will push students to use functions in the new ways by combining them with `while` loops and `if / else` statements.
             Functions in Artist:
-              name: Functions in Artist
+              name: Functions with Artist
               description_student: Make complex drawings more easily with functions!
               description_teacher: Students will be introduced to using functions with the Artist. Magnificent images will be created and modified. For more complicated patterns, students will learn about nesting functions by calling one function from inside another.
             End of Course Project:
@@ -15047,19 +15047,19 @@ en:
               description_student: Can you figure out how to use functions for the most efficient code?
               description_teacher: Students will begin to understand how functions can be helpful in this fun and interactive Minecraft adventure!
             Learning Sprites with Sprite Lab:
-              name: Learning Sprites with Sprite Lab
+              name: Swimming Fish with Sprite Lab
               description_student: Learn how to create and edit sprites.
               description_teacher: 'In this lesson, students will learn about the two concepts at the heart of Sprite Lab: sprites and behaviors. Sprites are characters or objects on the screen that students can move, change, and manipulate. Behaviors are actions that sprites will take continuously until they are stopped.'
             Events with Sprite Lab:
-              name: Events with Sprite Lab
+              name: Alien Dance Party with Sprite Lab
               description_student: Create an interactive project that can be shared with classmates.
               description_teacher: 'This lesson features Sprite Lab, a platform where students can create their own interactive animations and games. In addition to behaviors, today students will incorporate user input as events to create an "alien dance party".   '
             Loops with the Artist:
-              name: Loops with the Artist
+              name: Drawing with Loops
               description_student: In this lesson, loops make it easy to make even cooler images with Artist!
               description_teacher: Watch student faces light up as they make their own gorgeous designs using a small number of blocks and digital stickers! This lesson builds on the understanding of loops from previous lessons and gives students a chance to be truly creative.  This activity is fantastic for producing artifacts for portfolios or parent/teacher conferences.
             Nested Loops in the Maze:
-              name: Nested Loops in the Maze
+              name: Nested Loops in Maze
               description_student: Loops inside loops inside loops. What does this mean? This lesson will teach you what happens when you place a loop inside another loop.
               description_teacher: In this online activity, students will have the opportunity to push their understanding of loops to a whole new level. Playing with the Bee and Plants vs Zombies, students will learn how to program a loop to be inside of another loop. They will also be encouraged to figure out how little changes in either loop will affect their program when they click `Run`.
             Envelope Variables:
@@ -15067,15 +15067,15 @@ en:
               description_student: 'Envelopes and variables have something in common: both can hold valuable things. Here you will learn what variables are and the awesome things they can do.'
               description_teacher: Variables are used as placeholders for values such as numbers or words. Variables allow for a lot of freedom in programming. Instead of having to type out a phrase many times or remember an obscure number, computer scientists can use variables to reference them. This lesson helps to explain what variables are and how we can use them in many different ways. The idea of variables isn't an easy concept to grasp, so we recommend allowing plenty of time for discussion at the end of the lesson.
             Variables as Constant in Artist:
-              name: Variables as Constant in Artist
+              name: Variables with Artist
               description_student: Don't forget to bring creativity to class! In these puzzles you will be making fantastic drawings using variables.
               description_teacher: In this lesson, students will explore the creation of repetitive designs using variables in the Artist environment. Students will learn how variables can be used to make code easier to write and easier to read, even when the values don't change at runtime.
             Variables that Change in Bee:
-              name: Variables that Change in Bee
+              name: Changing Variables with Bee
               description_student: This bee loves variables!
               description_teacher: 'This lesson will help illustrate how variables can make programs more powerful by allowing values to change while the code is running. '
             Variables that Change in Artist:
-              name: Variables that Change in Artist
+              name: Changing Variables with Artist
               description_student: In this lesson, you'll make drawings using variables that change as the program runs.
               description_teacher: In this lesson, students will explore the creation of repetitive designs using variables in the Artist environment. Students will learn how variables can be used to make code easier to write and easier to read. After guided puzzles, students will end in a freeplay level to show what they have learned and create their own designs.
             Simulating Experiments:
@@ -15087,23 +15087,23 @@ en:
               description_student: You're going to have loads of fun learning about `for` loops!
               description_teacher: 'We know that loops allow us to do things over and over again, but now we’re going to learn how to use loops that have extra structures built right in. These new structures will allow students to create code that is more powerful and dynamic. '
             For Loops in Bee:
-              name: For Loops in Bee
+              name: For Loops with Bee
               description_student: Buzz buzz. In these puzzles you will be guiding a bee to nectar and honey using `for` loops!
               description_teacher: Featuring Bee, this lesson focuses on `for` loops and using an incrementing variable to solve more complicated puzzles. Students will begin by reviewing loops from previous lessons, then they'll walk through an introduction to `for` loops so they can more effectively solve complicated problems.
             For Loops in Artist:
-              name: For Loops in Artist
+              name: For Loops with Artist
               description_student: Get ready to make your next masterpiece. Here you will be using `for` loops to make some jaw-dropping pictures.
               description_teacher: In this lesson, students continue to practice `for` loops, but this time with Artist. Students will complete puzzles combining the ideas of variables, loops, and `for` loops to create complex designs. At the end, they will have a chance to create their own art in a freeplay level.
             Internet:
-              name: Internet
+              name: The Internet
               description_student: Ever wondered how information travels across the internet? It's not magic! This lesson will teach you the basics of how the internet works.
               description_teacher: Even though many people use the internet daily, not very many know how it works. In this lesson, students will pretend to flow through the internet, all the while learning about connections, URLs, IP Addresses, and the DNS.
             Editing Behaviors:
-              name: Editing Behaviors
+              name: Behaviors in Sprite Lab
               description_student: Learn to program your own sprite behaviors!
               description_teacher: Here, students will use Sprite Lab to create their own customized behaviors.
             Virtual Pet:
-              name: Virtual Pet
+              name: Virtual Pet with Sprite Lab
               description_student: In this lesson, students will create an interactive Virtual Pet that looks and behaves how they wish. Students will use Sprite Lab's "Costumes" tool to customize their pet's appearance. They will then use events, behaviors, and other concepts they have learned to give their pet a life of its own!
               description_teacher: In this lesson, students will create an interactive Virtual Pet that looks and behaves how they wish. Students will use Sprite Lab's "Costumes" tool to customize their pet's appearance. They will then use events, behaviors, and other concepts they have learned to give their pet a life of its own!
             The Power of Words:


### PR DESCRIPTION
See https://codedotorg.atlassian.net/browse/LP-1330

I found the stages from 2019 scripts that had previously been renamed, and applied the same renames to the `scripts.en.yml`, via a ruby script.

<!-- ### Background -->
<!-- ### Privacy -->
<!-- ### Security -->
<!-- ### Caching -->
<!-- ### Deployment strategy -->
<!-- ### Future work -->

## Links

<!--
  Any relevant links to external resources; ie, specification documents, jira
  items, related PRs, honeybadger errors, etc
-->

- [jira](https://codedotorg.atlassian.net/browse/LP-1330)

## Testing story

Spot checked: https://adhoc-curriculum-2020-softlaunch-studio.cdn-code.org/s/coursea-2020

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
