### PR TITLE
Refactor maker_script in MakerController to make adding versions easier

### DIFF
--- a/bin/dashboard-console
+++ b/bin/dashboard-console
@@ -3,7 +3,7 @@ require_relative '../deployment'
 
 def main
   Dir.chdir(dashboard_dir) do
-    exec "./bin/rails console"
+    exec "DISABLE_SPRING=1 ./bin/rails console"
   end
 end
 

--- a/bin/dashboard-console
+++ b/bin/dashboard-console
@@ -3,7 +3,7 @@ require_relative '../deployment'
 
 def main
   Dir.chdir(dashboard_dir) do
-    exec "DISABLE_SPRING=1 ./bin/rails console"
+    exec "./bin/rails console"
   end
 end
 

--- a/bin/dashboard-server
+++ b/bin/dashboard-server
@@ -4,7 +4,7 @@ require_relative '../deployment'
 def main
   dirs = [deploy_dir('lib'), deploy_dir('shared/middleware')]
   dirs += [pegasus_dir] if CDO.dashboard_enable_pegasus
-  rerun = "rerun -p '**/*.{rb,ru,yml}' -d '#{dirs.join(',')}' -i '**/migrations/*.rb' -i 'test/**/*.rb' --"
+  rerun = "rerun -b -p '**/*.{rb,ru,yml}' -d '#{dirs.join(',')}' -i '**/migrations/*.rb' -i 'test/**/*.rb' --"
   pids = []
 
   unless CDO.use_my_apps

--- a/bin/dashboard-server
+++ b/bin/dashboard-server
@@ -4,7 +4,7 @@ require_relative '../deployment'
 def main
   dirs = [deploy_dir('lib'), deploy_dir('shared/middleware')]
   dirs += [pegasus_dir] if CDO.dashboard_enable_pegasus
-  rerun = "rerun -b -p '**/*.{rb,ru,yml}' -d '#{dirs.join(',')}' -i '**/migrations/*.rb' -i 'test/**/*.rb' --"
+  rerun = "rerun -p '**/*.{rb,ru,yml}' -d '#{dirs.join(',')}' -i '**/migrations/*.rb' -i 'test/**/*.rb' --"
   pids = []
 
   unless CDO.use_my_apps

--- a/dashboard/app/controllers/maker_controller.rb
+++ b/dashboard/app/controllers/maker_controller.rb
@@ -1,5 +1,4 @@
 require 'cdo/script_constants'
-require 'pry'
 
 class MakerController < ApplicationController
   authorize_resource class: :maker_discount, except: [:home, :setup, :login_code, :display_code]

--- a/dashboard/app/controllers/maker_controller.rb
+++ b/dashboard/app/controllers/maker_controller.rb
@@ -1,4 +1,5 @@
 require 'cdo/script_constants'
+require 'pry'
 
 class MakerController < ApplicationController
   authorize_resource class: :maker_discount, except: [:home, :setup, :login_code, :display_code]
@@ -20,32 +21,36 @@ class MakerController < ApplicationController
   end
 
   ScriptAndCourse = Struct.new(:script, :course)
-  MAKER_UNIT_SCRIPTS = Script.maker_unit_scripts.
-      sort_by(&:version_year).
-      reverse.
-      freeze
-  # A list of (script, course) tuples containing all visible versions of the CSD Unit on Maker.
-  # In order from most recent to least.
-  MAKER_YEARS = MAKER_UNIT_SCRIPTS.map {|s| ScriptAndCourse.new(s, s.course)}.freeze
 
   def self.maker_script(for_user)
+    maker_unit_scripts = Script.maker_unit_scripts.
+        sort_by(&:version_year).
+        reverse.
+        freeze
+    csd_courses = Course.all_courses.select {|c| c.family_name == Course::CSD}.freeze
+    # maker_years is a list of (script, course) tuples containing all visible versions of the CSD Unit on Maker.
+    # Ordered from most recent to least.
+    maker_years = maker_unit_scripts.map do |s|
+      ScriptAndCourse.new(s, csd_courses.find {|c| s.version_year == c.version_year})
+    end.freeze
+
     # Assigned course or script should take precedence - show most recent version that's been assigned.
     assigned = for_user.section_courses + for_user.section_scripts
-    MAKER_YEARS.each do |year|
+    maker_years.each do |year|
       if assigned.include?(year.course) || assigned.include?(year.script)
         return year.script
       end
     end
 
     # Otherwise, show the most recent version with progress.
-    script_names = MAKER_YEARS.map {|sc| sc.script.name}
+    script_names = maker_years.map {|sc| sc.script.name}
     progress = UserScript.lookup_hash(for_user, script_names)
-    MAKER_YEARS.each do |year|
+    maker_years.each do |year|
       return year.script if progress[year.script.name]
     end
 
     # If none of the above applies, default to most recent.
-    MAKER_YEARS.first.script
+    maker_years.first.script
   end
 
   def setup

--- a/dashboard/app/controllers/maker_controller.rb
+++ b/dashboard/app/controllers/maker_controller.rb
@@ -49,7 +49,7 @@ class MakerController < ApplicationController
     end
 
     # If none of the above applies, default to most recent.
-    maker_years.first.script
+    maker_years.find {|y| y.script.is_stable?}.script
   end
 
   def setup

--- a/dashboard/app/models/script.rb
+++ b/dashboard/app/models/script.rb
@@ -211,6 +211,10 @@ class Script < ActiveRecord::Base
     @@stage_extras_scripts ||= Script.all.select(&:stage_extras_available?).pluck(:id)
   end
 
+  def self.maker_unit_scripts
+    visible_scripts.select {|s| s.family_name == 'csd6'}
+  end
+
   # Get the set of scripts that are valid for the current user, ignoring those
   # that are hidden based on the user's permission.
   # @param [User] user

--- a/dashboard/test/controllers/maker_controller_test.rb
+++ b/dashboard/test/controllers/maker_controller_test.rb
@@ -13,9 +13,11 @@ class MakerControllerTest < ActionController::TestCase
     @csd_2017 = ensure_course Script::CSD_2017, '2017'
     @csd_2018 = ensure_course Script::CSD_2018, '2018'
     @csd_2019 = ensure_course Script::CSD_2019, '2019'
+    @csd_2020_unstable = ensure_course 'csd-2020-unstable', '2020'
     @csd6_2017 = ensure_script Script::CSD6_NAME, '2017'
     @csd6_2018 = ensure_script Script::CSD6_2018_NAME, '2018'
     @csd6_2019 = ensure_script Script::CSD6_2019_NAME, '2019'
+    @csd6_2020_unstable = ensure_script 'csd6-2020-unstable', '2020', false
   end
 
   test_redirect_to_sign_in_for :home
@@ -473,9 +475,9 @@ class MakerControllerTest < ActionController::TestCase
 
   private
 
-  def ensure_script(script_name, version_year)
+  def ensure_script(script_name, version_year, is_stable=true)
     Script.find_by_name(script_name) ||
-      create(:script, name: script_name, family_name: 'csd6', version_year: version_year).tap do |script|
+      create(:script, name: script_name, family_name: 'csd6', version_year: version_year, is_stable: is_stable).tap do |script|
         create :script_level, script: script
       end
   end

--- a/dashboard/test/controllers/maker_controller_test.rb
+++ b/dashboard/test/controllers/maker_controller_test.rb
@@ -1,4 +1,5 @@
 require 'test_helper'
+require 'pry'
 
 class MakerControllerTest < ActionController::TestCase
   include Devise::Test::ControllerHelpers
@@ -10,12 +11,12 @@ class MakerControllerTest < ActionController::TestCase
     @school = create :school
     @school_maker_high_needs = create :school, :is_maker_high_needs_school
 
-    @csd_2017 = ensure_course Script::CSD_2017
-    @csd_2018 = ensure_course Script::CSD_2018
-    @csd_2019 = ensure_course Script::CSD_2019
-    @csd6_2017 = ensure_script Script::CSD6_NAME
-    @csd6_2018 = ensure_script Script::CSD6_2018_NAME
-    @csd6_2019 = ensure_script Script::CSD6_2019_NAME
+    @csd_2017 = ensure_course Script::CSD_2017, '2017'
+    @csd_2018 = ensure_course Script::CSD_2018, '2018'
+    @csd_2019 = ensure_course Script::CSD_2019, '2019'
+    @csd6_2017 = ensure_script Script::CSD6_NAME, '2017'
+    @csd6_2018 = ensure_script Script::CSD6_2018_NAME, '2018'
+    @csd6_2019 = ensure_script Script::CSD6_2019_NAME, '2019'
   end
 
   test_redirect_to_sign_in_for :home
@@ -473,15 +474,15 @@ class MakerControllerTest < ActionController::TestCase
 
   private
 
-  def ensure_script(script_name)
+  def ensure_script(script_name, version_year)
     Script.find_by_name(script_name) ||
-      create(:script, name: script_name).tap do |script|
+      create(:script, name: script_name, family_name: 'csd6', version_year: version_year).tap do |script|
         create :script_level, script: script
       end
   end
 
-  def ensure_course(course_name)
+  def ensure_course(course_name, version_year)
     Course.find_by_name(course_name) ||
-      create(:course, name: course_name)
+      create(:course, name: course_name, version_year: version_year)
   end
 end

--- a/dashboard/test/controllers/maker_controller_test.rb
+++ b/dashboard/test/controllers/maker_controller_test.rb
@@ -1,5 +1,4 @@
 require 'test_helper'
-require 'pry'
 
 class MakerControllerTest < ActionController::TestCase
   include Devise::Test::ControllerHelpers

--- a/dashboard/test/controllers/maker_controller_test.rb
+++ b/dashboard/test/controllers/maker_controller_test.rb
@@ -482,6 +482,6 @@ class MakerControllerTest < ActionController::TestCase
 
   def ensure_course(course_name, version_year)
     Course.find_by_name(course_name) ||
-      create(:course, name: course_name, version_year: version_year)
+      create(:course, name: course_name, version_year: version_year, family_name: Course::CSD)
   end
 end


### PR DESCRIPTION
The idea is to make it a 1-line change to add a new version. 

EDIT: took Dave's suggestion below to instead make it fully dynamic based on script data, with no code changes needed each year.

If this makes sense, I'll follow up with a change to add 2020 after this is meregd.

<!-- ### Background -->
<!-- ### Privacy -->
<!-- ### Security -->
<!-- ### Caching -->
<!-- ### Deployment strategy -->
<!-- ### Future work -->

## Links

<!--
  Any relevant links to external resources; ie, specification documents, jira
  items, related PRs, honeybadger errors, etc
-->

- [jira](https://codedotorg.atlassian.net/browse/LP-1329)

## Testing story

Existing MakerControllerTest unit tests pass.

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
