### PR TITLE
pass locale code to moment in SectionProgress component via redux

### DIFF
--- a/apps/src/redux/localesRedux.js
+++ b/apps/src/redux/localesRedux.js
@@ -1,0 +1,21 @@
+const SET_LOCALE_CODE = 'locale/SET_LOCALE_CODE';
+
+export const setLocaleCode = localeCode => ({
+  type: SET_LOCALE_CODE,
+  localeCode
+});
+
+const initialState = {
+  // locale code like 'en-us', 'es-mx', or null if none is specified.
+  localeCode: null
+};
+
+export default function reducer(state = initialState, action) {
+  if (action.type === SET_LOCALE_CODE) {
+    return {
+      ...state,
+      localeCode: action.localeCode
+    };
+  }
+  return state;
+}

--- a/apps/src/sites/studio/pages/teacher_dashboard/show.js
+++ b/apps/src/sites/studio/pages/teacher_dashboard/show.js
@@ -29,6 +29,7 @@ import currentUser, {
   setCurrentUserHasSeenStandardsReportInfo
 } from '@cdo/apps/templates/currentUserRedux';
 import {setValidScripts} from '../../../../redux/scriptSelectionRedux';
+import locales, {setLocaleCode} from '@cdo/apps/redux/localesRedux';
 
 const script = document.querySelector('script[data-dashboard]');
 const scriptData = JSON.parse(script.dataset.dashboard);
@@ -40,6 +41,7 @@ const studentScriptIds = scriptData.studentScriptIds;
 const validCourses = scriptData.validCourses;
 const currentUserId = scriptData.currentUserId;
 const hasSeenStandardsReportInfo = scriptData.hasSeenStandardsReportInfo;
+const localeCode = scriptData.localeCode;
 const baseUrl = `/teacher_dashboard/sections/${section.id}`;
 
 $(document).ready(function() {
@@ -53,7 +55,8 @@ $(document).ready(function() {
     textResponses,
     sectionAssessments,
     currentUser,
-    sectionStandardsProgress
+    sectionStandardsProgress,
+    locales
   });
   const store = getStore();
   // TODO: (madelynkasula) remove duplication in sectionData.setSection and teacherSections.setSections
@@ -69,6 +72,7 @@ $(document).ready(function() {
   store.dispatch(setLoginType(section.login_type));
   store.dispatch(setValidAssignments(validCourses, validScripts));
   store.dispatch(setValidGrades(validGrades));
+  store.dispatch(setLocaleCode(localeCode));
 
   if (!section.sharing_disabled && section.script.project_sharing) {
     store.dispatch(setShowSharingColumn(true));

--- a/apps/src/templates/sectionProgress/SectionProgress.jsx
+++ b/apps/src/templates/sectionProgress/SectionProgress.jsx
@@ -85,7 +85,8 @@ class SectionProgress extends Component {
     setLessonOfInterest: PropTypes.func.isRequired,
     isLoadingProgress: PropTypes.bool.isRequired,
     showStandardsIntroDialog: PropTypes.bool,
-    studentTimestamps: PropTypes.object
+    studentTimestamps: PropTypes.object,
+    localeCode: PropTypes.string
   };
 
   componentDidMount() {
@@ -168,6 +169,10 @@ class SectionProgress extends Component {
   }
 
   tooltipTextForStudent = studentId => {
+    const {localeCode} = this.props;
+    if (localeCode) {
+      moment.locale(localeCode);
+    }
     const timestamp = this.props.studentTimestamps[studentId];
     return timestamp ? moment(timestamp).calendar() : i18n.none();
   };
@@ -286,7 +291,8 @@ export default connect(
     studentTimestamps:
       state.sectionProgress.studentTimestampsByScript[
         state.scriptSelection.scriptId
-      ]
+      ],
+    localeCode: state.locales.localeCode
   }),
   dispatch => ({
     loadScript(scriptId, sectionId) {

--- a/dashboard/app/views/teacher_dashboard/show.html.haml
+++ b/dashboard/app/views/teacher_dashboard/show.html.haml
@@ -10,6 +10,7 @@
   teacher_dashboard_data[:hasSeenStandardsReportInfo] = @current_user.has_seen_standards_report_info_dialog || false
   teacher_dashboard_data[:userName] = @current_user.short_name
   teacher_dashboard_data[:validGrades] = @valid_grades
+  teacher_dashboard_data[:localeCode] = request.locale
 
 %script{src: webpack_asset_path('js/teacher_dashboard/show.js'), data: {dashboard: teacher_dashboard_data.to_json}}
 


### PR DESCRIPTION

Follow-on to https://github.com/code-dot-org/code-dot-org/pull/33757 .  Makes the date in the tooltip showing the student's last progress localizable.  Redux is used to supply the locale, since it seems like other components will want this data in the future. The moment library localizes the date, so we don't have to worry about the implementation of that.

![Screen Shot 2020-03-25 at 9 59 33 AM](https://user-images.githubusercontent.com/8001765/77570434-06178100-6e89-11ea-9805-b2b1ab87a895.png)

note that the date is localized in the screenshot, because the moment library always has access to the translated strings it needs. but the words "last progress" are not translated because there hasn't been enough time for that string to be translated yet.

## Testing story

confirmed manually that the date in the tooltip looks localized when I specify a locale manually (see screenshot).

## Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
