### PR TITLE
[DataViz] Updated crosstab formatting

### DIFF
--- a/apps/src/storage/dataBrowser/dataVisualizer/Charts.story.jsx
+++ b/apps/src/storage/dataBrowser/dataVisualizer/Charts.story.jsx
@@ -1,23 +1,38 @@
 import React from 'react';
 import CrossTabChart from './CrossTabChart';
+import _ from 'lodash';
 
 export default storybook =>
-  storybook
-    .storiesOf('Charts', module)
-    .add('CrossTab', () => (
+  storybook.storiesOf('Charts', module).add('CrossTab', () => (
+    <div style={{width: '100%', padding: 30}}>
       <CrossTabChart
-        records={[
-          {Date: '3/6 Fri', 'Wind Direction': 'E'},
-          {Date: '3/7 Sat', 'Wind Direction': 'NE'},
-          {Date: '3/8 Sun', 'Wind Direction': 'N'},
-          {Date: '3/9 Mon', 'Wind Direction': 'NW'},
-          {Date: '3/10 Tue', 'Wind Direction': 'W'},
-          {Date: '3/11 Wed', 'Wind Direction': 'SW'},
-          {Date: '3/11 Wed', 'Wind Direction': 'S'},
-          {Date: '3/11 Wed', 'Wind Direction': 'SE'}
-        ]}
+        records={makeFakeRecords()}
         numericColumns={[]}
         selectedColumn1="Date"
         selectedColumn2="Wind Direction"
+        chartTitle="Study of the wind"
       />
-    ));
+    </div>
+  ));
+
+const DATES = [
+  '3/4 Wed',
+  '3/5 Thu',
+  '3/6 Fri',
+  '3/7 Sat',
+  '3/8 Sun',
+  '3/9 Mon'
+];
+
+const DIRECTIONS = ['E', 'NE', 'N', 'Northwest', 'W', 'SW', 'S', 'SE'];
+
+function makeFakeRecords() {
+  const result = [];
+  for (let i = 0; i < 1000; i++) {
+    result.push({
+      Date: _.sample(DATES),
+      'Wind Direction': _.sample(DIRECTIONS)
+    });
+  }
+  return result;
+}

--- a/apps/src/storage/dataBrowser/dataVisualizer/Charts.story.jsx
+++ b/apps/src/storage/dataBrowser/dataVisualizer/Charts.story.jsx
@@ -1,0 +1,23 @@
+import React from 'react';
+import CrossTabChart from './CrossTabChart';
+
+export default storybook =>
+  storybook
+    .storiesOf('Charts', module)
+    .add('CrossTab', () => (
+      <CrossTabChart
+        records={[
+          {Date: '3/6 Fri', 'Wind Direction': 'E'},
+          {Date: '3/7 Sat', 'Wind Direction': 'NE'},
+          {Date: '3/8 Sun', 'Wind Direction': 'N'},
+          {Date: '3/9 Mon', 'Wind Direction': 'NW'},
+          {Date: '3/10 Tue', 'Wind Direction': 'W'},
+          {Date: '3/11 Wed', 'Wind Direction': 'SW'},
+          {Date: '3/11 Wed', 'Wind Direction': 'S'},
+          {Date: '3/11 Wed', 'Wind Direction': 'SE'}
+        ]}
+        numericColumns={[]}
+        selectedColumn1="Date"
+        selectedColumn2="Wind Direction"
+      />
+    ));

--- a/apps/src/storage/dataBrowser/dataVisualizer/CrossTabChart.jsx
+++ b/apps/src/storage/dataBrowser/dataVisualizer/CrossTabChart.jsx
@@ -12,46 +12,6 @@ export default class CrossTabChart extends React.Component {
     selectedColumn2: PropTypes.string
   };
 
-  /**
-   * @param {Array.<Object>} records
-   * @param {string} rowName
-   * @param {string} columnName
-   */
-  createPivotTable = (records, rowName, columnName) => {
-    let countMap = {};
-
-    // Find all values in columnName - these will be the columns of the pivot table
-    const pivotedColumns = new Set(records.map(record => record[columnName]));
-
-    // Count occurrences of each row/column pair
-    records.forEach(record => {
-      let key = record[rowName];
-      let value = record[columnName];
-      if (!countMap[key]) {
-        countMap[key] = {[rowName]: key};
-        pivotedColumns.forEach(column => (countMap[key][column] = 0));
-      }
-      countMap[key][value]++;
-    });
-
-    // Sort columns
-    let columns;
-    if (this.props.numericColumns.includes(columnName)) {
-      columns = [...pivotedColumns].sort(function(a, b) {
-        return a - b;
-      });
-    } else {
-      columns = [...pivotedColumns].sort();
-    }
-    columns.unshift(rowName);
-
-    // Sort rows
-    let chartData = Object.values(countMap).sort((a, b) =>
-      a[rowName] > b[rowName] ? 1 : -1
-    );
-    return {chartData, columns};
-  };
-
   getColorForValue = (value, min, max) => {
     if (typeof value !== 'number') {
       return 'white';
@@ -71,8 +31,9 @@ export default class CrossTabChart extends React.Component {
     ) {
       return null;
     }
-    const {chartData, columns} = this.createPivotTable(
+    const {chartData, columns} = createPivotTable(
       this.props.records,
+      this.props.numericColumns,
       this.props.selectedColumn1,
       this.props.selectedColumn2
     );
@@ -151,6 +112,46 @@ export default class CrossTabChart extends React.Component {
       </div>
     );
   }
+}
+
+/**
+ * @param {Array.<Object>} records
+ * @param {string} rowName
+ * @param {string} columnName
+ */
+export function createPivotTable(records, numericColumns, rowName, columnName) {
+  let countMap = {};
+
+  // Find all values in columnName - these will be the columns of the pivot table
+  const pivotedColumns = new Set(records.map(record => record[columnName]));
+
+  // Count occurrences of each row/column pair
+  records.forEach(record => {
+    let key = record[rowName];
+    let value = record[columnName];
+    if (!countMap[key]) {
+      countMap[key] = {[rowName]: key};
+      pivotedColumns.forEach(column => (countMap[key][column] = 0));
+    }
+    countMap[key][value]++;
+  });
+
+  // Sort columns
+  let columns;
+  if (numericColumns.includes(columnName)) {
+    columns = [...pivotedColumns].sort(function(a, b) {
+      return a - b;
+    });
+  } else {
+    columns = [...pivotedColumns].sort();
+  }
+  columns.unshift(rowName);
+
+  // Sort rows
+  let chartData = Object.values(countMap).sort((a, b) =>
+    a[rowName] > b[rowName] ? 1 : -1
+  );
+  return {chartData, columns};
 }
 
 const wrapperStyle = {

--- a/apps/src/storage/dataBrowser/dataVisualizer/CrossTabChart.jsx
+++ b/apps/src/storage/dataBrowser/dataVisualizer/CrossTabChart.jsx
@@ -43,47 +43,49 @@ export default function CrossTabChart(props) {
     <div id={CROSS_TAB_CHART_AREA} style={wrapperStyle}>
       <h1 style={chartTitleStyle}>{props.chartTitle}</h1>
       <table style={tableStyle}>
-        <tr>
-          <td>&nbsp;</td>
-          <td
-            style={{...topCellStyle, ...axisTitleStyle}}
-            colSpan={columns.length - 1}
-          >
-            {props.selectedColumn2}
-          </td>
-        </tr>
-        <tr>
-          {columns.map((column, i) => (
+        <tbody>
+          <tr>
+            <td>&nbsp;</td>
             <td
-              key={column}
-              style={
-                i === 0 ? {...leftCellStyle, ...axisTitleStyle} : topCellStyle
-              }
+              style={{...topCellStyle, ...axisTitleStyle}}
+              colSpan={columns.length - 1}
             >
-              {column}
+              {props.selectedColumn2}
             </td>
-          ))}
-        </tr>
-        {chartData.map((record, i) => (
-          <tr key={i}>
-            {columns.map((column, j) => {
-              const value = record[column];
-              const cellStyle =
-                j === 0
-                  ? {...leftCellStyle}
-                  : {
-                      ...innerCellStyle,
-                      width: columnWidth,
-                      backgroundColor: getColorForValue(value, min, max)
-                    };
-              return (
-                <td key={column} style={cellStyle}>
-                  {value}
-                </td>
-              );
-            })}
           </tr>
-        ))}
+          <tr>
+            {columns.map((column, i) => (
+              <td
+                key={column}
+                style={
+                  i === 0 ? {...leftCellStyle, ...axisTitleStyle} : topCellStyle
+                }
+              >
+                {column}
+              </td>
+            ))}
+          </tr>
+          {chartData.map((record, i) => (
+            <tr key={i}>
+              {columns.map((column, j) => {
+                const value = record[column];
+                const cellStyle =
+                  j === 0
+                    ? {...leftCellStyle}
+                    : {
+                        ...innerCellStyle,
+                        width: columnWidth,
+                        backgroundColor: getColorForValue(value, min, max)
+                      };
+                return (
+                  <td key={column} style={cellStyle}>
+                    {value}
+                  </td>
+                );
+              })}
+            </tr>
+          ))}
+        </tbody>
       </table>
     </div>
   );

--- a/apps/src/storage/dataBrowser/dataVisualizer/CrossTabChart.jsx
+++ b/apps/src/storage/dataBrowser/dataVisualizer/CrossTabChart.jsx
@@ -3,105 +3,99 @@ import React from 'react';
 import {CROSS_TAB_CHART_AREA} from './constants';
 import * as color from '../../../util/color';
 
-export default class CrossTabChart extends React.Component {
-  static propTypes = {
-    records: PropTypes.array.isRequired,
-    numericColumns: PropTypes.arrayOf(PropTypes.string).isRequired,
-    chartTitle: PropTypes.string,
-    selectedColumn1: PropTypes.string,
-    selectedColumn2: PropTypes.string
-  };
-
-  render() {
-    if (
-      !this.props.records ||
-      !this.props.selectedColumn1 ||
-      !this.props.selectedColumn2
-    ) {
-      return null;
-    }
-    const {chartData, columns} = createPivotTable(
-      this.props.records,
-      this.props.numericColumns,
-      this.props.selectedColumn1,
-      this.props.selectedColumn2
-    );
-    const numericValues = [];
-
-    chartData.forEach(record => {
-      Object.entries(record).forEach(entry => {
-        let key = entry[0];
-        let value = entry[1];
-        if (typeof value === 'number' && key !== this.props.selectedColumn1) {
-          numericValues.push(value);
-        }
-      });
-    });
-
-    // Our goal is uniform column widths, for all columns except the first one.
-    // There are a few steps that lead to successful layout here.
-    // 1. The table width is 100% to maximize available space.
-    // 2. The first column uses `white-space: nowrap` so it won't shrink too
-    //    small for its contents.
-    // 3. We set the rest of the columns to have the same percentage-width,
-    //    adding up to 99% of the table width (which is more than available space)
-    //    so after setting the first column width, the remaining columns
-    //    shrink to fit evenly.
-    const columnWidth = 99 / (columns.length - 1) + '%';
-
-    const min = Math.min(...numericValues);
-    const max = Math.max(...numericValues);
-
-    return (
-      <div id={CROSS_TAB_CHART_AREA} style={wrapperStyle}>
-        <h1 style={chartTitleStyle}>{this.props.chartTitle}</h1>
-        <table style={tableStyle}>
-          <tr>
-            <td>&nbsp;</td>
-            <td
-              style={{...topCellStyle, ...axisTitleStyle}}
-              colSpan={columns.length - 1}
-            >
-              {this.props.selectedColumn2}
-            </td>
-          </tr>
-          <tr>
-            {columns.map((column, i) => (
-              <td
-                key={column}
-                style={
-                  i === 0 ? {...leftCellStyle, ...axisTitleStyle} : topCellStyle
-                }
-              >
-                {column}
-              </td>
-            ))}
-          </tr>
-          {chartData.map((record, i) => (
-            <tr key={i}>
-              {columns.map((column, j) => {
-                const value = record[column];
-                const cellStyle =
-                  j === 0
-                    ? {...leftCellStyle}
-                    : {
-                        ...innerCellStyle,
-                        width: columnWidth,
-                        backgroundColor: getColorForValue(value, min, max)
-                      };
-                return (
-                  <td key={column} style={cellStyle}>
-                    {value}
-                  </td>
-                );
-              })}
-            </tr>
-          ))}
-        </table>
-      </div>
-    );
+export default function CrossTabChart(props) {
+  if (!props.records || !props.selectedColumn1 || !props.selectedColumn2) {
+    return null;
   }
+  const {chartData, columns} = createPivotTable(
+    props.records,
+    props.numericColumns,
+    props.selectedColumn1,
+    props.selectedColumn2
+  );
+  const numericValues = [];
+
+  chartData.forEach(record => {
+    Object.entries(record).forEach(entry => {
+      let key = entry[0];
+      let value = entry[1];
+      if (typeof value === 'number' && key !== props.selectedColumn1) {
+        numericValues.push(value);
+      }
+    });
+  });
+
+  // Our goal is uniform column widths, for all columns except the first one.
+  // There are a few steps that lead to successful layout here.
+  // 1. The table width is 100% to maximize available space.
+  // 2. The first column uses `white-space: nowrap` so it won't shrink too
+  //    small for its contents.
+  // 3. We set the rest of the columns to have the same percentage-width,
+  //    adding up to 99% of the table width (which is more than available space)
+  //    so after setting the first column width, the remaining columns
+  //    shrink to fit evenly.
+  const columnWidth = 99 / (columns.length - 1) + '%';
+
+  const min = Math.min(...numericValues);
+  const max = Math.max(...numericValues);
+
+  return (
+    <div id={CROSS_TAB_CHART_AREA} style={wrapperStyle}>
+      <h1 style={chartTitleStyle}>{props.chartTitle}</h1>
+      <table style={tableStyle}>
+        <tr>
+          <td>&nbsp;</td>
+          <td
+            style={{...topCellStyle, ...axisTitleStyle}}
+            colSpan={columns.length - 1}
+          >
+            {props.selectedColumn2}
+          </td>
+        </tr>
+        <tr>
+          {columns.map((column, i) => (
+            <td
+              key={column}
+              style={
+                i === 0 ? {...leftCellStyle, ...axisTitleStyle} : topCellStyle
+              }
+            >
+              {column}
+            </td>
+          ))}
+        </tr>
+        {chartData.map((record, i) => (
+          <tr key={i}>
+            {columns.map((column, j) => {
+              const value = record[column];
+              const cellStyle =
+                j === 0
+                  ? {...leftCellStyle}
+                  : {
+                      ...innerCellStyle,
+                      width: columnWidth,
+                      backgroundColor: getColorForValue(value, min, max)
+                    };
+              return (
+                <td key={column} style={cellStyle}>
+                  {value}
+                </td>
+              );
+            })}
+          </tr>
+        ))}
+      </table>
+    </div>
+  );
 }
+
+CrossTabChart.propTypes = {
+  records: PropTypes.array.isRequired,
+  numericColumns: PropTypes.arrayOf(PropTypes.string).isRequired,
+  chartTitle: PropTypes.string,
+  selectedColumn1: PropTypes.string,
+  selectedColumn2: PropTypes.string
+};
 
 /**
  * @param {Array.<Object>} records

--- a/apps/src/storage/dataBrowser/dataVisualizer/CrossTabChart.jsx
+++ b/apps/src/storage/dataBrowser/dataVisualizer/CrossTabChart.jsx
@@ -163,7 +163,7 @@ const tableStyle = {
   width: '100%'
 };
 const cellStyle = {
-  height: '3em',
+  height: '2em',
   border: '1px solid black',
   textAlign: 'center'
 };

--- a/apps/src/storage/dataBrowser/dataVisualizer/CrossTabChart.jsx
+++ b/apps/src/storage/dataBrowser/dataVisualizer/CrossTabChart.jsx
@@ -12,17 +12,6 @@ export default class CrossTabChart extends React.Component {
     selectedColumn2: PropTypes.string
   };
 
-  getColorForValue = (value, min, max) => {
-    if (typeof value !== 'number') {
-      return 'white';
-    }
-    const lightest = 100;
-    const darkest = 56;
-    const lightness =
-      lightest - ((value - min) / (max - min)) * (lightest - darkest);
-    return `hsl(217, 89%, ${lightness}%)`;
-  };
-
   render() {
     if (
       !this.props.records ||
@@ -98,7 +87,7 @@ export default class CrossTabChart extends React.Component {
                     : {
                         ...innerCellStyle,
                         width: columnWidth,
-                        backgroundColor: this.getColorForValue(value, min, max)
+                        backgroundColor: getColorForValue(value, min, max)
                       };
                 return (
                   <td key={column} style={cellStyle}>
@@ -152,6 +141,17 @@ export function createPivotTable(records, numericColumns, rowName, columnName) {
     a[rowName] > b[rowName] ? 1 : -1
   );
   return {chartData, columns};
+}
+
+export function getColorForValue(value, min, max) {
+  if (typeof value !== 'number') {
+    return 'white';
+  }
+  const lightest = 100;
+  const darkest = 56;
+  const lightness =
+    lightest - ((value - min) / (max - min)) * (lightest - darkest);
+  return `hsl(217, 89%, ${lightness}%)`;
 }
 
 const wrapperStyle = {

--- a/apps/src/storage/dataBrowser/dataVisualizer/CrossTabChart.jsx
+++ b/apps/src/storage/dataBrowser/dataVisualizer/CrossTabChart.jsx
@@ -150,7 +150,6 @@ export function getColorForValue(value, min, max) {
 
 const wrapperStyle = {
   width: '100%'
-  // padding: 10
 };
 const chartTitleStyle = {
   fontFamily: '"Gotham 7r", sans-serif',

--- a/apps/src/storage/dataBrowser/dataVisualizer/CrossTabChart.jsx
+++ b/apps/src/storage/dataBrowser/dataVisualizer/CrossTabChart.jsx
@@ -65,8 +65,8 @@ export default function CrossTabChart(props) {
               </td>
             ))}
           </tr>
-          {chartData.map((record, i) => (
-            <tr key={i}>
+          {chartData.map(record => (
+            <tr key={record[props.selectedColumn1]}>
               {columns.map((column, j) => {
                 const value = record[column];
                 const cellStyle =
@@ -101,6 +101,7 @@ CrossTabChart.propTypes = {
 
 /**
  * @param {Array.<Object>} records
+ * @param {Array.<string>} numericColumns
  * @param {string} rowName
  * @param {string} columnName
  */

--- a/apps/test/unit/storage/dataBrowser/dataVisualizer/CrossTabChartTest.js
+++ b/apps/test/unit/storage/dataBrowser/dataVisualizer/CrossTabChartTest.js
@@ -2,7 +2,8 @@ import React from 'react';
 import {mount} from 'enzyme';
 import {expect} from '../../../../util/reconfiguredChai';
 import CrossTabChart, {
-  createPivotTable
+  createPivotTable,
+  getColorForValue
 } from '@cdo/apps/storage/dataBrowser/dataVisualizer/CrossTabChart';
 
 const DEFAULT_PROPS = {
@@ -13,52 +14,35 @@ const DEFAULT_PROPS = {
 };
 
 describe('CrossTabChart', () => {
-  let wrapper;
-  beforeEach(() => {
-    wrapper = mount(<CrossTabChart {...DEFAULT_PROPS} />);
+  it('renders', () => {
+    mount(<CrossTabChart {...DEFAULT_PROPS} />);
   });
 
   describe('getColorForValue', () => {
     it('maps the min value to white', () => {
-      expect(wrapper.instance().getColorForValue(19, 19, 100)).to.equal(
-        'hsl(217, 89%, 100%)'
-      );
+      expect(getColorForValue(19, 19, 100)).to.equal('hsl(217, 89%, 100%)');
 
-      expect(wrapper.instance().getColorForValue(4, 4, 25)).to.equal(
-        'hsl(217, 89%, 100%)'
-      );
+      expect(getColorForValue(4, 4, 25)).to.equal('hsl(217, 89%, 100%)');
 
-      expect(wrapper.instance().getColorForValue(0, 0, 3)).to.equal(
-        'hsl(217, 89%, 100%)'
-      );
+      expect(getColorForValue(0, 0, 3)).to.equal('hsl(217, 89%, 100%)');
     });
 
     it('maps intermediate values proportionately', () => {
-      expect(wrapper.instance().getColorForValue(50, 0, 100)).to.equal(
-        'hsl(217, 89%, 78%)'
-      );
+      expect(getColorForValue(50, 0, 100)).to.equal('hsl(217, 89%, 78%)');
 
-      expect(wrapper.instance().getColorForValue(2, 0, 3)).to.equal(
+      expect(getColorForValue(2, 0, 3)).to.equal(
         'hsl(217, 89%, 70.66666666666667%)'
       );
 
-      expect(wrapper.instance().getColorForValue(20, 10, 50)).to.equal(
-        'hsl(217, 89%, 89%)'
-      );
+      expect(getColorForValue(20, 10, 50)).to.equal('hsl(217, 89%, 89%)');
     });
 
     it('maps the max value to hsl(217, 89%, 56%)', () => {
-      expect(wrapper.instance().getColorForValue(100, 19, 100)).to.equal(
-        'hsl(217, 89%, 56%)'
-      );
+      expect(getColorForValue(100, 19, 100)).to.equal('hsl(217, 89%, 56%)');
 
-      expect(wrapper.instance().getColorForValue(25, 4, 25)).to.equal(
-        'hsl(217, 89%, 56%)'
-      );
+      expect(getColorForValue(25, 4, 25)).to.equal('hsl(217, 89%, 56%)');
 
-      expect(wrapper.instance().getColorForValue(3, 0, 3)).to.equal(
-        'hsl(217, 89%, 56%)'
-      );
+      expect(getColorForValue(3, 0, 3)).to.equal('hsl(217, 89%, 56%)');
     });
   });
 

--- a/apps/test/unit/storage/dataBrowser/dataVisualizer/CrossTabChartTest.js
+++ b/apps/test/unit/storage/dataBrowser/dataVisualizer/CrossTabChartTest.js
@@ -1,7 +1,9 @@
 import React from 'react';
 import {mount} from 'enzyme';
 import {expect} from '../../../../util/reconfiguredChai';
-import CrossTabChart from '@cdo/apps/storage/dataBrowser/dataVisualizer/CrossTabChart';
+import CrossTabChart, {
+  createPivotTable
+} from '@cdo/apps/storage/dataBrowser/dataVisualizer/CrossTabChart';
 
 const DEFAULT_PROPS = {
   records: [],
@@ -75,9 +77,9 @@ describe('CrossTabChart', () => {
         ],
         columns: ['abc', 1, 2, 3]
       };
-      expect(
-        wrapper.instance().createPivotTable(records, 'abc', 'value')
-      ).to.deep.equal(expectedPivotData);
+      expect(createPivotTable(records, [], 'abc', 'value')).to.deep.equal(
+        expectedPivotData
+      );
     });
 
     it('sorts string columns alphabetically, but with the row column first', () => {
@@ -96,9 +98,9 @@ describe('CrossTabChart', () => {
         ],
         columns: ['abc', 'a', 'z']
       };
-      expect(
-        wrapper.instance().createPivotTable(records, 'abc', 'value')
-      ).to.deep.equal(expectedPivotData);
+      expect(createPivotTable(records, [], 'abc', 'value')).to.deep.equal(
+        expectedPivotData
+      );
     });
 
     it('sorts numeric columns numerically, with the row column first', () => {
@@ -117,9 +119,8 @@ describe('CrossTabChart', () => {
         ],
         columns: ['abc', 18, 134]
       };
-      wrapper.setProps({numericColumns: ['value']});
       expect(
-        wrapper.instance().createPivotTable(records, 'abc', 'value')
+        createPivotTable(records, ['value'], 'abc', 'value')
       ).to.deep.equal(expectedPivotData);
     });
 
@@ -140,9 +141,9 @@ describe('CrossTabChart', () => {
         ],
         columns: ['abc', 'x', 'y']
       };
-      expect(
-        wrapper.instance().createPivotTable(records, 'abc', 'value')
-      ).to.deep.equal(expectedPivotData);
+      expect(createPivotTable(records, [], 'abc', 'value')).to.deep.equal(
+        expectedPivotData
+      );
     });
   });
 });


### PR DESCRIPTION
[STAR-1014](https://codedotorg.atlassian.net/browse/STAR-1014): Updates the design of the crosstab chart in the data visualizer, per new [spec](https://docs.google.com/document/d/1WAkDvJq5XoHoEWK_kOiPsMh2lF53AgfCbYlUd1ABkdg/edit).

![image](https://user-images.githubusercontent.com/1615761/77581525-189ab600-6e9b-11ea-950d-e19f4e574a29.png)

The chart now expands to fill available width, and does its best to keep column widths uniform (although it can't solve this for certain datasets or particularly narrow window sizes).

![Peek 2020-03-25 12-18](https://user-images.githubusercontent.com/1615761/77581605-3c5dfc00-6e9b-11ea-8048-001561043d9f.gif)

Also converted this to a functional component, which has become new recommended practice.  If you only want to review the styling changes, [read the second commit](https://github.com/code-dot-org/code-dot-org/pull/33839/commits/ab41f8ce70b48dd8e178586d10d1a0aa5473620c).

## Testing story

Updated existing unit tests, and added a storybook entry which I used to rapidly iterate on this design and try out different screen sizes.  Also manually tested in local code studio using the `applabDatasets` experiment.

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
