### PR TITLE
Add Text-to-speech field to script

### DIFF
--- a/apps/src/lib/script-editor/ScriptEditor.jsx
+++ b/apps/src/lib/script-editor/ScriptEditor.jsx
@@ -343,7 +343,7 @@ export default class ScriptEditor extends React.Component {
             defaultChecked={this.props.tts}
             style={styles.checkbox}
           />
-          <p>Check if this course has text-to-speech available.</p>
+          <p>Check to enable text-to-speech for this course.</p>
         </label>
         {this.props.isLevelbuilder && (
           <label>

--- a/apps/src/lib/script-editor/ScriptEditor.jsx
+++ b/apps/src/lib/script-editor/ScriptEditor.jsx
@@ -70,7 +70,8 @@ export default class ScriptEditor extends React.Component {
     versionYear: PropTypes.string,
     scriptFamilies: PropTypes.arrayOf(PropTypes.string).isRequired,
     versionYearOptions: PropTypes.arrayOf(PropTypes.string).isRequired,
-    isLevelbuilder: PropTypes.bool
+    isLevelbuilder: PropTypes.bool,
+    tts: PropTypes.bool
   };
 
   constructor(props) {
@@ -333,6 +334,16 @@ export default class ScriptEditor extends React.Component {
             Check if this course has lesson plans (on Curriculum Builder or in
             PDF form) that we should provide links to.
           </p>
+        </label>
+        <label>
+          Text-to-Speech
+          <input
+            name="tts"
+            type="checkbox"
+            defaultChecked={this.props.tts}
+            style={styles.checkbox}
+          />
+          <p>Check if this course has text-to-speech available.</p>
         </label>
         {this.props.isLevelbuilder && (
           <label>

--- a/apps/src/sites/studio/pages/scripts/edit.js
+++ b/apps/src/sites/studio/pages/scripts/edit.js
@@ -86,6 +86,7 @@ export default function initPage(scriptEditorData) {
         scriptFamilies={scriptEditorData.script_families}
         versionYearOptions={scriptEditorData.version_year_options}
         isLevelbuilder={scriptEditorData.is_levelbuilder}
+        tts={scriptData.tts}
       />
     </Provider>,
     document.querySelector('.edit_container')

--- a/dashboard/app/controllers/scripts_controller.rb
+++ b/dashboard/app/controllers/scripts_controller.rb
@@ -172,6 +172,7 @@ class ScriptsController < ApplicationController
       :stage_extras_available,
       :has_verified_resources,
       :has_lesson_plan,
+      :tts,
       :script_announcements,
       :pilot_experiment,
       :editor_experiment,

--- a/dashboard/app/dsl/script_dsl.rb
+++ b/dashboard/app/dsl/script_dsl.rb
@@ -33,6 +33,7 @@ class ScriptDSL < BaseDSL
     @editor_experiment = nil
     @project_sharing = nil
     @curriculum_umbrella = nil
+    @tts = false
   end
 
   integer :id
@@ -49,6 +50,7 @@ class ScriptDSL < BaseDSL
   boolean :has_lesson_plan
   boolean :is_stable
   boolean :project_sharing
+  boolean :tts
 
   string :wrapup_video
   string :script_announcements
@@ -121,7 +123,8 @@ class ScriptDSL < BaseDSL
       pilot_experiment: @pilot_experiment,
       editor_experiment: @editor_experiment,
       project_sharing: @project_sharing,
-      curriculum_umbrella: @curriculum_umbrella
+      curriculum_umbrella: @curriculum_umbrella,
+      tts: @tts
     }
   end
 
@@ -298,6 +301,7 @@ class ScriptDSL < BaseDSL
     s << "editor_experiment '#{script.editor_experiment}'" if script.editor_experiment
     s << 'project_sharing true' if script.project_sharing
     s << "curriculum_umbrella '#{script.curriculum_umbrella}'" if script.curriculum_umbrella
+    s << 'tts true' if script.tts
 
     s << '' unless s.empty?
     s << serialize_stages(script)

--- a/dashboard/app/models/script.rb
+++ b/dashboard/app/models/script.rb
@@ -1527,7 +1527,8 @@ class Script < ActiveRecord::Base
       pilot_experiment: script_data[:pilot_experiment],
       editor_experiment: script_data[:editor_experiment],
       project_sharing: !!script_data[:project_sharing],
-      curriculum_umbrella: script_data[:curriculum_umbrella]
+      curriculum_umbrella: script_data[:curriculum_umbrella],
+      tts: script_data[:tts]
     }.compact
   end
 

--- a/dashboard/app/models/script.rb
+++ b/dashboard/app/models/script.rb
@@ -149,6 +149,7 @@ class Script < ActiveRecord::Base
     editor_experiment
     project_sharing
     curriculum_umbrella
+    tts
   )
 
   def self.twenty_hour_script
@@ -1381,7 +1382,8 @@ class Script < ActiveRecord::Base
       family_name: family_name,
       version_year: version_year,
       assigned_section_id: assigned_section_id,
-      hasStandards: has_standards_associations?
+      hasStandards: has_standards_associations?,
+      tts: tts?,
     }
 
     summary[:stages] = stages.map {|stage| stage.summarize(include_bonus_levels)} if include_stages
@@ -1528,7 +1530,7 @@ class Script < ActiveRecord::Base
       editor_experiment: script_data[:editor_experiment],
       project_sharing: !!script_data[:project_sharing],
       curriculum_umbrella: script_data[:curriculum_umbrella],
-      tts: script_data[:tts]
+      tts: !!script_data[:tts]
     }.compact
   end
 

--- a/dashboard/config/scripts/csd6-2019.script
+++ b/dashboard/config/scripts/csd6-2019.script
@@ -15,6 +15,7 @@ version_year '2019'
 is_stable true
 project_sharing true
 curriculum_umbrella 'CSD'
+tts true
 
 stage 'Innovations in Computing', flex_category: 'csd6_1'
 level 'CSD U6L01 TFMD_2019', named: true

--- a/dashboard/config/scripts/csd6-2019.script
+++ b/dashboard/config/scripts/csd6-2019.script
@@ -15,7 +15,6 @@ version_year '2019'
 is_stable true
 project_sharing true
 curriculum_umbrella 'CSD'
-tts true
 
 stage 'Innovations in Computing', flex_category: 'csd6_1'
 level 'CSD U6L01 TFMD_2019', named: true

--- a/dashboard/test/dsl/script_dsl_test.rb
+++ b/dashboard/test/dsl/script_dsl_test.rb
@@ -325,6 +325,19 @@ endvariants
     assert_equal true, output[:has_lesson_plan]
   end
 
+  test 'can set tts' do
+    input_dsl = <<~DSL
+      tts 'true'
+
+      stage 'Stage1'
+      level 'Level 1'
+      stage 'Stage2'
+      level 'Level 2'
+    DSL
+    output, _ = ScriptDSL.parse(input_dsl, 'test.script', 'test')
+    assert_equal true, output[:tts]
+  end
+
   test 'can set teacher_resources' do
     input_dsl = <<~DSL
       teacher_resources [['curriculum', '/link/to/curriculum'], ['vocabulary', '/link/to/vocab']]

--- a/dashboard/test/dsl/script_dsl_test.rb
+++ b/dashboard/test/dsl/script_dsl_test.rb
@@ -33,7 +33,8 @@ class ScriptDslTest < ActiveSupport::TestCase
     pilot_experiment: nil,
     editor_experiment: nil,
     project_sharing: nil,
-    curriculum_umbrella: nil
+    curriculum_umbrella: nil,
+    tts: false
   }
 
   test 'test Script DSL' do


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/6564873/77674388-c1531f00-6f48-11ea-860b-97588ef4c4ae.png)

Part 1 of story to make configuring text-to-speech for scripts self-service for curriculum editors.

Looking for input on what the label text for the checkbox should be.

<!-- ### Background -->
<!-- ### Privacy -->
<!-- ### Security -->
<!-- ### Caching -->
<!-- ### Deployment strategy -->
### Future work
Once this is deployed to levelbuilder and manually tested there, the other changes listed in the Jira will follow - backfilling existing scripts to set this field if they have TTS, and updating the application code to read from this field.


## Links

<!--
  Any relevant links to external resources; ie, specification documents, jira
  items, related PRs, honeybadger errors, etc
-->

- [jira](https://codedotorg.atlassian.net/browse/LP-1331)

## Testing story

Manually tested checking and unchecking the box in the levelbuilder UI locally, and verified that change was propagated to .script file.

Not sure what automated tests should apply if any; open to suggestions.

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
