### PR TITLE
Standards: tooltip revision

### DIFF
--- a/apps/i18n/common/en_us.json
+++ b/apps/i18n/common/en_us.json
@@ -246,7 +246,7 @@
   "completed": "Completed",
   "completedLevels": "Completed Levels",
   "completedLessons": "Completed Lessons",
-  "completedStudentCount": "{numStudentsCompleted} of {numStudents} students completed ({percentComplete} %)",
+  "completedStudentPercent": "{percentComplete}% of students completed",
   "completedUnpluggedLessons": "Tell us which unplugged lessons* your class has completed",
   "completedWithoutRecommendedBlock": "Congratulations! You completed Puzzle {puzzleNumber}. (But you could use a different block for stronger code.)",
   "completionStatus": "Completion Status",

--- a/apps/src/templates/sectionProgress/standards/StandardDescriptionCell.jsx
+++ b/apps/src/templates/sectionProgress/standards/StandardDescriptionCell.jsx
@@ -66,12 +66,7 @@ class StandardDescriptionCell extends Component {
                     {lesson.unplugged ? i18n.unplugged() : i18n.plugged()}
                   </div>
                   <div>
-                    {lesson.completed ? i18n.completed() : i18n.notCompleted()}
-                  </div>
-                  <div>
-                    {i18n.completedStudentCount({
-                      numStudentsCompleted: lesson.numStudentsCompleted,
-                      numStudents: lesson.numStudents,
+                    {i18n.completedStudentPercent({
                       percentComplete: percentComplete
                     })}
                   </div>

--- a/apps/src/templates/sectionProgress/standards/StandardDescriptionCell.jsx
+++ b/apps/src/templates/sectionProgress/standards/StandardDescriptionCell.jsx
@@ -48,7 +48,7 @@ class StandardDescriptionCell extends Component {
     if (this.props.lessonsForStandardStatus) {
       return this.props.lessonsForStandardStatus.map((lesson, index) => {
         const percentComplete =
-          Math.round(lesson.numStudentsCompleted / lesson.numStudents) * 100;
+          (lesson.numStudentsCompleted / lesson.numStudents).toFixed(2) * 100;
         return (
           <span key={lesson.name} style={styles.lessonBox}>
             {!this.props.isViewingReport && (


### PR DESCRIPTION
In the lesson box tooltip on the standards tab: 
-  Fix for an error in how I was calculating % completed
- Remove student counts to just focus on % 
- Remove completion status since we now have three states (not complete, partially complete, completed) indicated by color.

BEFORE: 
<img width="320" alt="Screen Shot 2020-03-25 at 6 40 58 PM" src="https://user-images.githubusercontent.com/12300669/77601891-44cd2b80-6ec9-11ea-88e7-e8214ea09372.png">

AFTER: 
<img width="249" alt="Screen Shot 2020-03-25 at 6 57 56 PM" src="https://user-images.githubusercontent.com/12300669/77602539-ffa9f900-6eca-11ea-829b-e3ea3db3c10c.png">



