### PR TITLE
Remove "rewrite youtube iframes" feature

### DIFF
--- a/dashboard/config/initializers/markdown_handler.rb
+++ b/dashboard/config/initializers/markdown_handler.rb
@@ -1,28 +1,11 @@
-require 'nokogiri'
+# Add Markdown .md support to the ActionView template system.
+
 require 'cdo/markdown_handler'
 
-# Add Markdown .md support to the ActionView template system.
 MARKDOWN_OPTIONS = {
   autolink: true,
   tables: true,
   space_after_headers: true
 }.freeze
 
-class CustomRewriter < Redcarpet::Render::HTML
-  # Rewrite YouTube iframe elements to use the fallback-player iframe instead.
-  def block_html(html)
-    doc = ::Nokogiri::HTML(html)
-    nodes = doc.xpath(%w(youtube youtubeeducation youtube-nocookie).map {|x| "//iframe[@src[contains(.,'#{x}.com/embed')]]"}.join(' | '))
-    nodes.each do |node|
-      next unless node['src']
-      id = node['src'].match(Video::EMBED_URL_REGEX)[:id]
-      node['src'] = node['src'].sub(
-        Video::EMBED_URL_REGEX,
-        Video.embed_url(id)
-      )
-    end
-    doc.css('body').children.to_html
-  end
-end
-
-MarkdownHandler.register(CustomRewriter, MARKDOWN_OPTIONS)
+MarkdownHandler.register(Redcarpet::Render::HTML, MARKDOWN_OPTIONS)


### PR DESCRIPTION
This was originally written to add fallback player support to youtube videos that are embedded in level instructions via iframes.

We want to remove this for a number of reasons:

1. We no longer support embedding youtube videos in markdown directly
2. We no longer support iframes in markdown at all
3. We no longer use this renderer for level instructions (we switched to the clientside renderer)
4. We want to merge the Dashboard and Pegasus markdown renderers, and removing this will make that process easier

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
