### PR TITLE
Remove opt_in attribute from contact rollups V1

### DIFF
--- a/lib/cdo/contact_rollups.rb
+++ b/lib/cdo/contact_rollups.rb
@@ -199,9 +199,6 @@ class ContactRollups
     log_collector.time!('update_teachers_from_forms') {update_teachers_from_forms}
     log_collector.time!('update_teachers_from_census_submissions') {update_teachers_from_census_submissions}
 
-    # Set opt_in based on information collected in Dashboard Email Preference.
-    log_collector.time!('update_email_preferences') {update_email_preferences}
-
     count = PEGASUS_REPORTING_DB_READER["select count(*) as cnt from #{PEGASUS_DB_NAME}.#{DEST_TABLE_NAME}"].first[:cnt]
     log "Done. Total overall time: #{Time.now - start} seconds. #{count} records created in contact_rollups_daily table."
 
@@ -482,16 +479,6 @@ class ContactRollups
     INNER JOIN #{PEGASUS_DB_NAME}.contacts on contacts.email = #{DEST_TABLE_NAME}.email
     SET opted_out = true
     WHERE unsubscribed_at IS NOT NULL"
-    log_completion(start)
-  end
-
-  def self.update_email_preferences
-    start = Time.now
-    log "Updating from dashboard.email_preferences"
-    PEGASUS_REPORTING_DB_WRITER.run "
-    UPDATE #{PEGASUS_DB_NAME}.#{DEST_TABLE_NAME}
-    INNER JOIN #{DASHBOARD_DB_NAME}.email_preferences on email_preferences.email = #{DEST_TABLE_NAME}.email
-    SET #{PEGASUS_DB_NAME}.#{DEST_TABLE_NAME}.opt_in = #{DASHBOARD_DB_NAME}.email_preferences.opt_in"
     log_completion(start)
   end
 

--- a/lib/cdo/pardot.rb
+++ b/lib/cdo/pardot.rb
@@ -272,10 +272,6 @@ class Pardot
       dest[:is_do_not_email] = true
     end
 
-    # The custom Pardot db_Opt_In field has type "Dropdown" with permitted values "Yes" or "No".
-    # Set db_Opt_in to 'No' when there is no source entry, matching the process used by Marketing team.
-    dest[:db_Opt_In] = src[:opt_in] == true ? 'Yes' : 'No'
-
     # If this contact has a dashboard user ID (which means it is a teacher
     # account), mark that in a Pardot field so we can segment on that.
     if src[:dashboard_user_id].present?


### PR DESCRIPTION
Deprecates `opt_in` attribute from being collected / processed / uploaded to Pardot in V1 Contact Rollups process.

Note that this won't be merged until we have the `opt_in` attribute successfully flowing through the V1.5 pipeline.

## Testing story

Chatted with @hacodeorg on this -- there's not a straightforward way to test this all the way through to Pardot, and since it's going to be deprecated soon, we're ok with not being super well tested for now.

I did execute `ContactRollups.build_contact_rollups` locally just to test for any immediate errors, and it executed successfully.
