### PR TITLE
Standards: include plugged/unplugged icon in tooltip

### DIFF
--- a/apps/src/templates/sectionProgress/standards/StandardDescriptionCell.jsx
+++ b/apps/src/templates/sectionProgress/standards/StandardDescriptionCell.jsx
@@ -3,6 +3,8 @@ import React, {Component} from 'react';
 import ReactTooltip from 'react-tooltip';
 import i18n from '@cdo/locale';
 import ProgressBoxForLessonNumber from './ProgressBoxForLessonNumber';
+import FontAwesome from '@cdo/apps/templates/FontAwesome';
+import {LessonIcons} from './standardsConstants';
 
 const styles = {
   main: {
@@ -47,6 +49,9 @@ class StandardDescriptionCell extends Component {
   getLessonBoxes = () => {
     if (this.props.lessonsForStandardStatus) {
       return this.props.lessonsForStandardStatus.map((lesson, index) => {
+        const icon = lesson.unplugged
+          ? LessonIcons.UNPLUGGED
+          : LessonIcons.PLUGGED;
         const percentComplete =
           (lesson.numStudentsCompleted / lesson.numStudents).toFixed(2) * 100;
         return (
@@ -61,9 +66,8 @@ class StandardDescriptionCell extends Component {
                 place="top"
               >
                 <div style={styles.tooltip}>
-                  <div style={styles.tooltipLessonName}>{lesson.name}</div>
-                  <div>
-                    {lesson.unplugged ? i18n.unplugged() : i18n.plugged()}
+                  <div style={styles.tooltipLessonName}>
+                    {lesson.name} <FontAwesome icon={icon} />
                   </div>
                   <div>
                     {i18n.completedStudentPercent({

--- a/apps/src/templates/sectionProgress/standards/standardsConstants.js
+++ b/apps/src/templates/sectionProgress/standards/standardsConstants.js
@@ -1,3 +1,8 @@
+export const LessonIcons = {
+  PLUGGED: 'desktop',
+  UNPLUGGED: 'scissors'
+};
+
 export const cstaStandardsURL = 'https://www.csteachers.org/page/standards';
 
 // These constants help clarify the meaning of a TeacherScore.score.


### PR DESCRIPTION
[LP-1337 ](https://codedotorg.atlassian.net/browse/LP-1337)

Use icon rather than words to indicate plugged v. unplugged in the standards view tooltip. 

BEFORE: 
<img width="249" alt="Screen Shot 2020-03-25 at 6 57 56 PM" src="https://user-images.githubusercontent.com/12300669/77682101-9b7f4780-6f53-11ea-95ba-90b8151cf753.png">

AFTER:
<img width="246" alt="Screen Shot 2020-03-26 at 11 02 37 AM" src="https://user-images.githubusercontent.com/12300669/77682079-94f0d000-6f53-11ea-9c14-2d36affaa125.png">
<img width="242" alt="Screen Shot 2020-03-26 at 11 02 29 AM" src="https://user-images.githubusercontent.com/12300669/77682084-96ba9380-6f53-11ea-9f08-5e444b31f64a.png">

