### PR TITLE
No longer add extra whitespace to markdown code blocks

### DIFF
--- a/lib/cdo/pegasus/actionview_sinatra.rb
+++ b/lib/cdo/pegasus/actionview_sinatra.rb
@@ -16,10 +16,6 @@ module ActionViewSinatra
       lax_spacing: true
     }
 
-    def preprocess(full_document)
-      full_document.gsub(/```/, "```\n")
-    end
-
     def postprocess(full_document)
       process_div_brackets(full_document)
     end


### PR DESCRIPTION
This was originally added in https://github.com/code-dot-org/code-dot-org/pull/4155; it's not super clear to me why it was originally necessary, but removing this results in no visual changes to applab docs.

From https://code.org/applab/docs/setText

Before | After
--- | ---
![Screen Shot 2020-03-26 at 11 33 12](https://user-images.githubusercontent.com/244100/77683505-b5ba2500-6f55-11ea-882f-fa24c213f402.png) | ![Screen Shot 2020-03-26 at 11 34 17](https://user-images.githubusercontent.com/244100/77683525-bce13300-6f55-11ea-98a8-80b547c044de.png)


My hypothesis is that the need for this went away when we started using CodeMirror

<!--
  Your description goes here: A summary of the change, including any relevant motivation and context.

  If relevant, include a description both of the existing behavior and of the new behavior.
-->

<!--
  Other aspects to consider. uncomment and add detail for any that seem necessary:
-->

<!-- ### Background -->
<!-- ### Privacy -->
<!-- ### Security -->
<!-- ### Caching -->
<!-- ### Deployment strategy -->
<!-- ### Future work -->

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
