### PR TITLE
Jobs page: Add COVID-19 note

### DIFF
--- a/pegasus/sites.v3/code.org/public/about/jobs.md.erb
+++ b/pegasus/sites.v3/code.org/public/about/jobs.md.erb
@@ -36,6 +36,8 @@ Launched in 2013, Code.org&reg; is a nonprofit dedicated to expanding access to 
 </script>
 <script type='text/javascript' src='https://andreasmb.github.io/lever-jobs-embed/index.js'></script>
 
+_**COVID-19 update:** We are continuing to closely monitor the evolving situation and we appreciate your understanding and flexibility with any related changes to our interviewing process._
+
 ## <a name="info" href="#info">Working at Code.org</a>
 
 **Company Profile**


### PR DESCRIPTION
Adds a COVID-19 note to [the jobs page](https://code.org/about/jobs).  Requested directly by Kristina.

![image](https://user-images.githubusercontent.com/1615761/77685528-ce780a00-6f58-11ea-93c2-afef829b3591.png)

## Testing story

Content change: Checked on localhost.