### PR TITLE
Use tts field to determine `Script.text_to_speech_enabled?`

### DIFF
--- a/dashboard/app/models/script.rb
+++ b/dashboard/app/models/script.rb
@@ -780,12 +780,8 @@ class Script < ActiveRecord::Base
     @all_bonus_script_levels.select {|stage| stage[:stageNumber] <= current_stage.absolute_position}
   end
 
-  private def csf_tts_level?
-    k5_course?
-  end
-
   def text_to_speech_enabled?
-    csf_tts_level? || tts?
+    tts?
   end
 
   # Generates TTS files for each level in a script.

--- a/dashboard/app/models/script.rb
+++ b/dashboard/app/models/script.rb
@@ -784,59 +784,8 @@ class Script < ActiveRecord::Base
     k5_course?
   end
 
-  private def csd_tts_level?
-    [
-      Script::CSD2_NAME,
-      Script::CSD3_NAME,
-      Script::CSD4_NAME,
-      Script::CSD6_NAME,
-      Script::CSD2_2018_NAME,
-      Script::CSD3_2018_NAME,
-      Script::CSD4_2018_NAME,
-      Script::CSD6_2018_NAME,
-      Script::CSD2_2019_NAME,
-      Script::CSD3_2019_NAME,
-      Script::CSD4_2019_NAME,
-      Script::CSD6_2019_NAME,
-      Script::CSD1_PILOT_NAME,
-      Script::CSD2_PILOT_NAME,
-      Script::CSD3_PILOT_NAME,
-      Script::CSD2_2020_NAME,
-      Script::CSD3_2020_NAME,
-      Script::CSD4_2020_NAME,
-      Script::CSD6_2020_NAME
-    ].include?(name)
-  end
-
-  private def csp_tts_level?
-    [
-      Script::CSP17_UNIT3_NAME,
-      Script::CSP17_UNIT5_NAME,
-      Script::CSP17_POSTAP_NAME,
-      Script::CSP3_2018_NAME,
-      Script::CSP5_2018_NAME,
-      Script::CSP_POSTAP_2018_NAME,
-      Script::CSP3_2019_NAME,
-      Script::CSP5_2019_NAME,
-      Script::CSP_POSTAP_2019_NAME
-    ].include?(name)
-  end
-
-  private def hoc_tts_level?
-    [
-      Script::APPLAB_INTRO,
-      Script::DANCE_PARTY_NAME,
-      Script::DANCE_PARTY_EXTRAS_NAME,
-      Script::DANCE_PARTY_2019_NAME,
-      Script::DANCE_PARTY_EXTRAS_2019_NAME,
-      Script::ARTIST_NAME,
-      Script::SPORTS_NAME,
-      Script::BASKETBALL_NAME
-    ].include?(name)
-  end
-
   def text_to_speech_enabled?
-    csf_tts_level? || csd_tts_level? || csp_tts_level? || hoc_tts_level? || name == Script::TTS_NAME
+    csf_tts_level? || tts?
   end
 
   # Generates TTS files for each level in a script.

--- a/dashboard/config/scripts/allthettsthings.script
+++ b/dashboard/config/scripts/allthettsthings.script
@@ -1,3 +1,4 @@
+tts true
 stage 'TTS'
 level 'allthethings_ttscsf contained'
 level 'allthethings_ttscsd'

--- a/dashboard/config/scripts/applab-intro.script
+++ b/dashboard/config/scripts/applab-intro.script
@@ -1,3 +1,4 @@
+tts true
 hidden false
 student_detail_progress_view true
 has_lesson_plan true

--- a/dashboard/config/scripts/artist.script
+++ b/dashboard/config/scripts/artist.script
@@ -1,3 +1,4 @@
+tts true
 hidden 'false'
 
 stage 'Artist'

--- a/dashboard/config/scripts/basketball.script
+++ b/dashboard/config/scripts/basketball.script
@@ -1,3 +1,4 @@
+tts true
 hidden 'false'
 stage 'Bounce'
 skin 'basketball'

--- a/dashboard/config/scripts/course1.script
+++ b/dashboard/config/scripts/course1.script
@@ -1,3 +1,4 @@
+tts true
 hidden false
 hideable_stages true
 stage_extras_available true

--- a/dashboard/config/scripts/course2.script
+++ b/dashboard/config/scripts/course2.script
@@ -1,3 +1,4 @@
+tts true
 hidden false
 hideable_stages true
 stage_extras_available true

--- a/dashboard/config/scripts/course3.script
+++ b/dashboard/config/scripts/course3.script
@@ -1,3 +1,4 @@
+tts true
 hidden false
 hideable_stages true
 stage_extras_available true

--- a/dashboard/config/scripts/course4.script
+++ b/dashboard/config/scripts/course4.script
@@ -1,3 +1,4 @@
+tts true
 hidden false
 hideable_stages true
 has_lesson_plan true

--- a/dashboard/config/scripts/coursea-2017.script
+++ b/dashboard/config/scripts/coursea-2017.script
@@ -1,3 +1,4 @@
+tts true
 hidden false
 hideable_stages true
 stage_extras_available true

--- a/dashboard/config/scripts/coursea-2018.script
+++ b/dashboard/config/scripts/coursea-2018.script
@@ -1,3 +1,4 @@
+tts true
 hidden false
 hideable_stages true
 teacher_resources [["lessonPlans", "https://curriculum.code.org/csf-18/coursea/"], ["teacherForum", "http://forum.code.org/c/csf"], ["vocabulary", "https://curriculum.code.org/csf-18/coursea/vocab/"], ["standardMappings", "https://curriculum.code.org/csf-18/coursea/standards/"]]

--- a/dashboard/config/scripts/coursea-2019.script
+++ b/dashboard/config/scripts/coursea-2019.script
@@ -1,3 +1,4 @@
+tts true
 hidden false
 hideable_stages true
 teacher_resources [["lessonPlans", "https://curriculum.code.org/csf-19/coursea/"], ["teacherForum", "http://forum.code.org/c/csf"], ["vocabulary", "https://curriculum.code.org/csf-19/coursea/vocab/"], ["standardMappings", "https://curriculum.code.org/csf-19/coursea/standards/"], ["curriculumGuide", "https://docs.google.com/document/d/1UqCgO06NzB1L6y83fnwnUcYdKr3MooJAaUZajj48DnI/preview"]]

--- a/dashboard/config/scripts/coursea-2020.script
+++ b/dashboard/config/scripts/coursea-2020.script
@@ -1,3 +1,4 @@
+tts true
 hideable_stages true
 teacher_resources [["lessonPlans", "https://curriculum.code.org/csf-20/coursea/"], ["teacherForum", "http://forum.code.org/c/csf"], ["vocabulary", "https://curriculum.code.org/csf-20/coursea/vocab/"], ["standardMappings", "https://curriculum.code.org/csf-20/coursea/standards/"], ["curriculumGuide", "https://docs.google.com/document/d/1hstUHTGIdvtPP0TDdEfQeXG3zQ0q6ys237n2BY9CQmg/preview"]]
 stage_extras_available true

--- a/dashboard/config/scripts/courseb-2017.script
+++ b/dashboard/config/scripts/courseb-2017.script
@@ -1,3 +1,4 @@
+tts true
 hidden false
 hideable_stages true
 stage_extras_available true

--- a/dashboard/config/scripts/courseb-2018.script
+++ b/dashboard/config/scripts/courseb-2018.script
@@ -1,3 +1,4 @@
+tts true
 hidden false
 hideable_stages true
 teacher_resources [["lessonPlans", "https://curriculum.code.org/csf-18/courseb/"], ["teacherForum", "https://forum.code.org/c/csf"], ["vocabulary", "https://curriculum.code.org/csf-18/courseb/vocab/"], ["standardMappings", "https://curriculum.code.org/csf-18/courseb/standards/"]]

--- a/dashboard/config/scripts/courseb-2019.script
+++ b/dashboard/config/scripts/courseb-2019.script
@@ -1,3 +1,4 @@
+tts true
 hidden false
 hideable_stages true
 teacher_resources [["lessonPlans", "https://curriculum.code.org/csf-19/courseb/"], ["teacherForum", "https://forum.code.org/c/csf"], ["vocabulary", "https://curriculum.code.org/csf-19/courseb/vocab/"], ["standardMappings", "https://curriculum.code.org/csf-19/courseb/standards/"], ["curriculumGuide", "https://docs.google.com/document/d/1UqCgO06NzB1L6y83fnwnUcYdKr3MooJAaUZajj48DnI/preview"]]

--- a/dashboard/config/scripts/courseb-2020.script
+++ b/dashboard/config/scripts/courseb-2020.script
@@ -1,3 +1,4 @@
+tts true
 hideable_stages true
 teacher_resources [["lessonPlans", "https://curriculum.code.org/csf-20/courseb/"], ["teacherForum", "https://forum.code.org/c/csf"], ["vocabulary", "https://curriculum.code.org/csf-20/courseb/vocab/"], ["standardMappings", "https://curriculum.code.org/csf-20/courseb/standards/"], ["curriculumGuide", "https://docs.google.com/document/d/1hstUHTGIdvtPP0TDdEfQeXG3zQ0q6ys237n2BY9CQmg/preview"]]
 stage_extras_available true

--- a/dashboard/config/scripts/coursec-2017.script
+++ b/dashboard/config/scripts/coursec-2017.script
@@ -1,3 +1,4 @@
+tts true
 hidden false
 hideable_stages true
 stage_extras_available true

--- a/dashboard/config/scripts/coursec-2018.script
+++ b/dashboard/config/scripts/coursec-2018.script
@@ -1,3 +1,4 @@
+tts true
 hidden false
 hideable_stages true
 teacher_resources [["lessonPlans", "https://curriculum.code.org/csf-18/coursec/"], ["teacherForum", "https://forum.code.org/c/csf"], ["vocabulary", "https://curriculum.code.org/csf-18/coursec/vocab/"], ["standardMappings", "https://curriculum.code.org/csf-18/coursec/standards/"]]

--- a/dashboard/config/scripts/coursec-2019.script
+++ b/dashboard/config/scripts/coursec-2019.script
@@ -1,3 +1,4 @@
+tts true
 hidden false
 hideable_stages true
 teacher_resources [["lessonPlans", "https://curriculum.code.org/csf-19/coursec/"], ["teacherForum", "https://forum.code.org/c/csf"], ["vocabulary", "https://curriculum.code.org/csf-19/coursec/vocab/"], ["standardMappings", "https://curriculum.code.org/csf-19/coursec/standards/"], ["curriculumGuide", "https://docs.google.com/document/d/1UqCgO06NzB1L6y83fnwnUcYdKr3MooJAaUZajj48DnI/preview"]]

--- a/dashboard/config/scripts/coursec-2020.script
+++ b/dashboard/config/scripts/coursec-2020.script
@@ -1,3 +1,4 @@
+tts true
 hideable_stages true
 teacher_resources [["lessonPlans", "https://curriculum.code.org/csf-20/coursec/"], ["teacherForum", "https://forum.code.org/c/csf"], ["vocabulary", "https://curriculum.code.org/csf-20/coursec/vocab/"], ["standardMappings", "https://curriculum.code.org/csf-20/coursec/standards/"], ["curriculumGuide", "https://docs.google.com/document/d/1hstUHTGIdvtPP0TDdEfQeXG3zQ0q6ys237n2BY9CQmg/preview"]]
 stage_extras_available true

--- a/dashboard/config/scripts/coursed-2017.script
+++ b/dashboard/config/scripts/coursed-2017.script
@@ -1,3 +1,4 @@
+tts true
 hidden false
 hideable_stages true
 stage_extras_available true

--- a/dashboard/config/scripts/coursed-2018.script
+++ b/dashboard/config/scripts/coursed-2018.script
@@ -1,3 +1,4 @@
+tts true
 hidden false
 hideable_stages true
 teacher_resources [["lessonPlans", "https://curriculum.code.org/csf-18/coursed/"], ["teacherForum", "https://forum.code.org/c/csf"], ["vocabulary", "https://curriculum.code.org/csf-18/coursed/vocab/"], ["standardMappings", "https://curriculum.code.org/csf-18/coursed/standards/"]]

--- a/dashboard/config/scripts/coursed-2019.script
+++ b/dashboard/config/scripts/coursed-2019.script
@@ -1,3 +1,4 @@
+tts true
 hidden false
 hideable_stages true
 teacher_resources [["lessonPlans", "https://curriculum.code.org/csf-19/coursed/"], ["teacherForum", "https://forum.code.org/c/csf"], ["vocabulary", "https://curriculum.code.org/csf-19/coursed/vocab/"], ["standardMappings", "https://curriculum.code.org/csf-19/coursed/standards/"], ["curriculumGuide", "https://docs.google.com/document/d/1UqCgO06NzB1L6y83fnwnUcYdKr3MooJAaUZajj48DnI/preview"]]

--- a/dashboard/config/scripts/coursed-2020.script
+++ b/dashboard/config/scripts/coursed-2020.script
@@ -1,3 +1,4 @@
+tts true
 hideable_stages true
 teacher_resources [["lessonPlans", "https://curriculum.code.org/csf-20/coursed/"], ["teacherForum", "https://forum.code.org/c/csf"], ["vocabulary", "https://curriculum.code.org/csf-20/coursed/vocab/"], ["standardMappings", "https://curriculum.code.org/csf-20/coursed/standards/"], ["curriculumGuide", "https://docs.google.com/document/d/1hstUHTGIdvtPP0TDdEfQeXG3zQ0q6ys237n2BY9CQmg/preview"]]
 stage_extras_available true

--- a/dashboard/config/scripts/coursee-2017.script
+++ b/dashboard/config/scripts/coursee-2017.script
@@ -1,3 +1,4 @@
+tts true
 hidden false
 hideable_stages true
 stage_extras_available true

--- a/dashboard/config/scripts/coursee-2018.script
+++ b/dashboard/config/scripts/coursee-2018.script
@@ -1,3 +1,4 @@
+tts true
 hidden false
 hideable_stages true
 teacher_resources [["lessonPlans", "https://curriculum.code.org/csf-18/coursee/"], ["teacherForum", "https://forum.code.org/c/csf"], ["vocabulary", "https://curriculum.code.org/csf-18/coursee/vocab/"], ["standardMappings", "https://curriculum.code.org/csf-18/coursee/standards/"]]

--- a/dashboard/config/scripts/coursee-2019.script
+++ b/dashboard/config/scripts/coursee-2019.script
@@ -1,3 +1,4 @@
+tts true
 hidden false
 hideable_stages true
 teacher_resources [["lessonPlans", "https://curriculum.code.org/csf-19/coursee/"], ["teacherForum", "https://forum.code.org/c/csf"], ["vocabulary", "https://curriculum.code.org/csf-19/coursee/vocab/"], ["standardMappings", "https://curriculum.code.org/csf-19/coursee/standards/"], ["curriculumGuide", "https://docs.google.com/document/d/1UqCgO06NzB1L6y83fnwnUcYdKr3MooJAaUZajj48DnI/preview"]]

--- a/dashboard/config/scripts/coursee-2020.script
+++ b/dashboard/config/scripts/coursee-2020.script
@@ -1,3 +1,4 @@
+tts true
 hideable_stages true
 teacher_resources [["lessonPlans", "https://curriculum.code.org/csf-20/coursee/"], ["teacherForum", "https://forum.code.org/c/csf"], ["vocabulary", "https://curriculum.code.org/csf-20/coursee/vocab/"], ["standardMappings", "https://curriculum.code.org/csf-20/coursee/standards/"], ["curriculumGuide", "https://docs.google.com/document/d/1hstUHTGIdvtPP0TDdEfQeXG3zQ0q6ys237n2BY9CQmg/preview"]]
 stage_extras_available true

--- a/dashboard/config/scripts/coursef-2017.script
+++ b/dashboard/config/scripts/coursef-2017.script
@@ -1,3 +1,4 @@
+tts true
 hidden false
 hideable_stages true
 stage_extras_available true

--- a/dashboard/config/scripts/coursef-2018.script
+++ b/dashboard/config/scripts/coursef-2018.script
@@ -1,3 +1,4 @@
+tts true
 hidden false
 hideable_stages true
 teacher_resources [["lessonPlans", "https://curriculum.code.org/csf-18/coursef/"], ["teacherForum", "https://forum.code.org/c/csf"], ["vocabulary", "https://curriculum.code.org/csf-18/coursef/vocab/"], ["standardMappings", "https://curriculum.code.org/csf-18/coursef/standards/"]]

--- a/dashboard/config/scripts/coursef-2019.script
+++ b/dashboard/config/scripts/coursef-2019.script
@@ -1,3 +1,4 @@
+tts true
 hidden false
 hideable_stages true
 teacher_resources [["lessonPlans", "https://curriculum.code.org/csf-19/coursef/"], ["teacherForum", "https://forum.code.org/c/csf"], ["vocabulary", "https://curriculum.code.org/csf-19/coursef/vocab/"], ["standardMappings", "https://curriculum.code.org/csf-19/coursef/standards/"], ["curriculumGuide", "https://docs.google.com/document/d/1UqCgO06NzB1L6y83fnwnUcYdKr3MooJAaUZajj48DnI/preview"]]

--- a/dashboard/config/scripts/coursef-2020.script
+++ b/dashboard/config/scripts/coursef-2020.script
@@ -1,3 +1,4 @@
+tts true
 hideable_stages true
 teacher_resources [["lessonPlans", "https://curriculum.code.org/csf-20/coursef/"], ["teacherForum", "https://forum.code.org/c/csf"], ["vocabulary", "https://curriculum.code.org/csf-20/coursef/vocab/"], ["standardMappings", "https://curriculum.code.org/csf-20/coursef/standards/"], ["curriculumGuide", "https://docs.google.com/document/d/1hstUHTGIdvtPP0TDdEfQeXG3zQ0q6ys237n2BY9CQmg/preview"]]
 stage_extras_available true

--- a/dashboard/config/scripts/csd1-pilot.script
+++ b/dashboard/config/scripts/csd1-pilot.script
@@ -1,3 +1,4 @@
+tts true
 login_required true
 hideable_stages true
 student_detail_progress_view true

--- a/dashboard/config/scripts/csd2-2017.script
+++ b/dashboard/config/scripts/csd2-2017.script
@@ -1,3 +1,4 @@
+tts true
 hidden false
 login_required true
 hideable_stages true

--- a/dashboard/config/scripts/csd2-2018.script
+++ b/dashboard/config/scripts/csd2-2018.script
@@ -1,3 +1,4 @@
+tts true
 hidden false
 login_required true
 hideable_stages true

--- a/dashboard/config/scripts/csd2-2019.script
+++ b/dashboard/config/scripts/csd2-2019.script
@@ -1,3 +1,4 @@
+tts true
 hidden false
 login_required true
 hideable_stages true

--- a/dashboard/config/scripts/csd2-2020.script
+++ b/dashboard/config/scripts/csd2-2020.script
@@ -1,3 +1,4 @@
+tts true
 login_required true
 hideable_stages true
 student_detail_progress_view true

--- a/dashboard/config/scripts/csd2-pilot.script
+++ b/dashboard/config/scripts/csd2-pilot.script
@@ -1,3 +1,4 @@
+tts true
 login_required true
 hideable_stages true
 student_detail_progress_view true

--- a/dashboard/config/scripts/csd3-2017.script
+++ b/dashboard/config/scripts/csd3-2017.script
@@ -1,3 +1,4 @@
+tts true
 hidden false
 login_required true
 hideable_stages true

--- a/dashboard/config/scripts/csd3-2018.script
+++ b/dashboard/config/scripts/csd3-2018.script
@@ -1,3 +1,4 @@
+tts true
 hidden false
 login_required true
 hideable_stages true

--- a/dashboard/config/scripts/csd3-2019.script
+++ b/dashboard/config/scripts/csd3-2019.script
@@ -1,3 +1,4 @@
+tts true
 hidden false
 login_required true
 hideable_stages true

--- a/dashboard/config/scripts/csd3-2020.script
+++ b/dashboard/config/scripts/csd3-2020.script
@@ -1,3 +1,4 @@
+tts true
 login_required true
 hideable_stages true
 student_detail_progress_view true

--- a/dashboard/config/scripts/csd3-pilot.script
+++ b/dashboard/config/scripts/csd3-pilot.script
@@ -1,3 +1,4 @@
+tts true
 login_required true
 hideable_stages true
 student_detail_progress_view true

--- a/dashboard/config/scripts/csd4-2017.script
+++ b/dashboard/config/scripts/csd4-2017.script
@@ -1,3 +1,4 @@
+tts true
 hidden false
 login_required true
 hideable_stages true

--- a/dashboard/config/scripts/csd4-2018.script
+++ b/dashboard/config/scripts/csd4-2018.script
@@ -1,3 +1,4 @@
+tts true
 hidden false
 login_required true
 hideable_stages true

--- a/dashboard/config/scripts/csd4-2019.script
+++ b/dashboard/config/scripts/csd4-2019.script
@@ -1,3 +1,4 @@
+tts true
 hidden false
 login_required true
 hideable_stages true

--- a/dashboard/config/scripts/csd4-2020.script
+++ b/dashboard/config/scripts/csd4-2020.script
@@ -1,3 +1,4 @@
+tts true
 login_required true
 hideable_stages true
 student_detail_progress_view true

--- a/dashboard/config/scripts/csd6-2017.script
+++ b/dashboard/config/scripts/csd6-2017.script
@@ -1,3 +1,4 @@
+tts true
 hidden false
 login_required true
 hideable_stages true

--- a/dashboard/config/scripts/csd6-2018.script
+++ b/dashboard/config/scripts/csd6-2018.script
@@ -1,3 +1,4 @@
+tts true
 hidden false
 login_required true
 hideable_stages true

--- a/dashboard/config/scripts/csd6-2019.script
+++ b/dashboard/config/scripts/csd6-2019.script
@@ -1,3 +1,4 @@
+tts true
 hidden false
 login_required true
 hideable_stages true

--- a/dashboard/config/scripts/csd6-2020.script
+++ b/dashboard/config/scripts/csd6-2020.script
@@ -1,3 +1,4 @@
+tts true
 login_required true
 hideable_stages true
 student_detail_progress_view true

--- a/dashboard/config/scripts/csp3-2017.script
+++ b/dashboard/config/scripts/csp3-2017.script
@@ -1,3 +1,4 @@
+tts true
 hidden false
 login_required true
 hideable_stages true

--- a/dashboard/config/scripts/csp3-2018.script
+++ b/dashboard/config/scripts/csp3-2018.script
@@ -1,3 +1,4 @@
+tts true
 hidden false
 login_required true
 hideable_stages true

--- a/dashboard/config/scripts/csp3-2019.script
+++ b/dashboard/config/scripts/csp3-2019.script
@@ -1,3 +1,4 @@
+tts true
 hidden false
 login_required true
 hideable_stages true

--- a/dashboard/config/scripts/csp5-2017.script
+++ b/dashboard/config/scripts/csp5-2017.script
@@ -1,3 +1,4 @@
+tts true
 hidden false
 login_required true
 hideable_stages true

--- a/dashboard/config/scripts/csp5-2018.script
+++ b/dashboard/config/scripts/csp5-2018.script
@@ -1,3 +1,4 @@
+tts true
 hidden false
 login_required true
 hideable_stages true

--- a/dashboard/config/scripts/csp5-2019.script
+++ b/dashboard/config/scripts/csp5-2019.script
@@ -1,3 +1,4 @@
+tts true
 hidden false
 login_required true
 hideable_stages true

--- a/dashboard/config/scripts/csppostap-2017.script
+++ b/dashboard/config/scripts/csppostap-2017.script
@@ -1,3 +1,4 @@
+tts true
 hidden false
 login_required true
 hideable_stages true

--- a/dashboard/config/scripts/csppostap-2018.script
+++ b/dashboard/config/scripts/csppostap-2018.script
@@ -1,3 +1,4 @@
+tts true
 hidden false
 login_required true
 hideable_stages true

--- a/dashboard/config/scripts/csppostap-2019.script
+++ b/dashboard/config/scripts/csppostap-2019.script
@@ -1,3 +1,4 @@
+tts true
 hidden false
 login_required true
 hideable_stages true

--- a/dashboard/config/scripts/dance-2019.script
+++ b/dashboard/config/scripts/dance-2019.script
@@ -1,3 +1,4 @@
+tts true
 hidden false
 
 stage 'Dance Party'

--- a/dashboard/config/scripts/dance-extras-2019.script
+++ b/dashboard/config/scripts/dance-extras-2019.script
@@ -1,3 +1,4 @@
+tts true
 hidden false
 
 stage 'Dance Party - Go Further'

--- a/dashboard/config/scripts/dance-extras.script
+++ b/dashboard/config/scripts/dance-extras.script
@@ -1,3 +1,4 @@
+tts true
 hidden false
 
 stage 'Dance Party - Go Further'

--- a/dashboard/config/scripts/dance.script
+++ b/dashboard/config/scripts/dance.script
@@ -1,3 +1,4 @@
+tts true
 hidden false
 has_lesson_plan true
 

--- a/dashboard/config/scripts/express-2017.script
+++ b/dashboard/config/scripts/express-2017.script
@@ -1,3 +1,4 @@
+tts true
 hidden false
 hideable_stages true
 stage_extras_available true

--- a/dashboard/config/scripts/express-2018.script
+++ b/dashboard/config/scripts/express-2018.script
@@ -1,3 +1,4 @@
+tts true
 hidden false
 hideable_stages true
 teacher_resources [["lessonPlans", "https://curriculum.code.org/csf-18/express/"], ["teacherForum", "https://forum.code.org/c/csf"], ["vocabulary", "https://curriculum.code.org/csf-18/express/vocab/"], ["standardMappings", "https://curriculum.code.org/csf-18/express/standards/"]]

--- a/dashboard/config/scripts/express-2019.script
+++ b/dashboard/config/scripts/express-2019.script
@@ -1,3 +1,4 @@
+tts true
 hidden false
 hideable_stages true
 teacher_resources [["lessonPlans", "https://curriculum.code.org/csf-19/express/"], ["teacherForum", "https://forum.code.org/c/csf"], ["vocabulary", "https://curriculum.code.org/csf-19/express/vocab/"], ["standardMappings", "https://curriculum.code.org/csf-19/express/standards/"]]

--- a/dashboard/config/scripts/express-2020.script
+++ b/dashboard/config/scripts/express-2020.script
@@ -1,3 +1,4 @@
+tts true
 hideable_stages true
 teacher_resources [["lessonPlans", "https://curriculum.code.org/csf-20/express/"], ["teacherForum", "https://forum.code.org/c/csf"], ["vocabulary", "https://curriculum.code.org/csf-20/express/vocab/"], ["standardMappings", "https://curriculum.code.org/csf-20/express/standards/"]]
 stage_extras_available true

--- a/dashboard/config/scripts/pre-express-2017.script
+++ b/dashboard/config/scripts/pre-express-2017.script
@@ -1,3 +1,4 @@
+tts true
 hidden false
 hideable_stages true
 stage_extras_available true

--- a/dashboard/config/scripts/pre-express-2018.script
+++ b/dashboard/config/scripts/pre-express-2018.script
@@ -1,3 +1,4 @@
+tts true
 hidden false
 hideable_stages true
 stage_extras_available true

--- a/dashboard/config/scripts/pre-express-2019.script
+++ b/dashboard/config/scripts/pre-express-2019.script
@@ -1,3 +1,4 @@
+tts true
 hidden false
 hideable_stages true
 stage_extras_available true

--- a/dashboard/config/scripts/pre-express-2020.script
+++ b/dashboard/config/scripts/pre-express-2020.script
@@ -1,3 +1,4 @@
+tts true
 hideable_stages true
 teacher_resources [["lessonPlans", "https://curriculum.code.org/csf-20/express/"], ["teacherForum", "https://forum.code.org/c/csf"], ["vocabulary", "https://curriculum.code.org/csf-20/express/vocab/"], ["standardMappings", "https://curriculum.code.org/csf-20/express/standards"]]
 stage_extras_available true

--- a/dashboard/config/scripts/sports.script
+++ b/dashboard/config/scripts/sports.script
@@ -1,3 +1,4 @@
+tts true
 hidden false
 
 stage 'Sports'

--- a/dashboard/test/models/script_test.rb
+++ b/dashboard/test/models/script_test.rb
@@ -1112,10 +1112,6 @@ class ScriptTest < ActiveSupport::TestCase
     assert_equal 'This is what you should know as a teacher', updated_report_script['stages']['Report Stage 1']['description_teacher']
   end
 
-  test 'text_to_speech_enabled? for k5_course' do
-    assert Script.find_by_name('csf1').text_to_speech_enabled?
-  end
-
   test '!text_to_speech_enabled? by default' do
     refute create(:script).text_to_speech_enabled?
   end

--- a/dashboard/test/models/script_test.rb
+++ b/dashboard/test/models/script_test.rb
@@ -1120,6 +1120,11 @@ class ScriptTest < ActiveSupport::TestCase
     refute create(:script).text_to_speech_enabled?
   end
 
+  test 'text_to_speech_enabled? if tts true' do
+    script = create :script, tts: true
+    assert script.text_to_speech_enabled?
+  end
+
   test 'FreeResponse level is listed in text_response_levels' do
     script = create :script
     stage = create :stage, script: script


### PR DESCRIPTION
* Added `tts true` to .script file for each script currently treated as text-to-speech enabled by the `Script.text_to_speech_enabled?` method.
* Changed `text_to_speech_enabled?` to just return the value of the `tts` field.

.script files edited en masse via:
```
# tts_scripts is a file containing the script filenames to change
cat ~/CDO/curriculum2020/tts_scripts | while read line; do sed -i '' -e $'1s/^/tts true\\\n/' $line; done
```
Handy sed command for prepending to files from: https://stackoverflow.com/a/10587853

<!--
  Other aspects to consider. uncomment and add detail for any that seem necessary:
-->

<!-- ### Background -->
<!-- ### Privacy -->
<!-- ### Security -->
<!-- ### Caching -->
<!-- ### Deployment strategy -->

## Links

<!--
  Any relevant links to external resources; ie, specification documents, jira
  items, related PRs, honeybadger errors, etc
-->

- [jira](https://codedotorg.atlassian.net/browse/LP-1331)

## Testing story
* script_test tests pass locally
* Manual verification in console, comparing local env after these changes + seeding to staging:

local:
```
[development] dashboard > tts_scripts = Script.all.select {|s| s.text_to_speech_enabled?}
...
[development] dashboard > tts_scripts.length
=> 73
```

staging:
```
[staging] dashboard > tts_scripts = Script.all.select {|s| s.text_to_speech_enabled?}
...
[staging] dashboard > tts_scripts.length
=> 73
```
# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
