### PR TITLE
Add CSP 2020 to ScriptConstants

### DIFF
--- a/lib/cdo/script_constants.rb
+++ b/lib/cdo/script_constants.rb
@@ -160,6 +160,18 @@ module ScriptConstants
       CSD5_NAME = 'csd5-2017'.freeze,
       CSD6_NAME = 'csd6-2017'.freeze,
     ],
+    csp_2020: [
+      CSP1_2020_NAME = 'csp1-2020'.freeze,
+      CSP2_2020_NAME = 'csp2-2020'.freeze,
+      CSP3_2020_NAME = 'csp3-2020'.freeze,
+      CSP4_2020_NAME = 'csp4-2020'.freeze,
+      CSP5_2020_NAME = 'csp5-2020'.freeze,
+      CSP6_2020_NAME = 'csp6-2020'.freeze,
+      CSP7_2020_NAME = 'csp7-2020'.freeze,
+      CSP8_2020_NAME = 'csp8-2020'.freeze,
+      CSP9_2020_NAME = 'csp9-2020'.freeze,
+      CSP10_2020_NAME = 'csp10-2020'.freeze,
+    ].freeze,
     csp_2019: [
       CSP1_2019_NAME = 'csp1-2019'.freeze,
       CSP2_2019_NAME = 'csp2-2019'.freeze,


### PR DESCRIPTION
<!-- ### Background -->
<!-- ### Privacy -->
<!-- ### Security -->
<!-- ### Caching -->
<!-- ### Deployment strategy -->
<!-- ### Future work -->

## Links

<!--
  Any relevant links to external resources; ie, specification documents, jira
  items, related PRs, honeybadger errors, etc
-->

- [jira](https://codedotorg.atlassian.net/browse/LP-1324)

## Testing story

Manual sanity check:
```
[development] dashboard > csp_2020_scripts = Script.all.select {|s| s.pilot_experiment == 'csp-2020-access'}}
[development] dashboard > csp_2020_script_names = csp_2020_scripts.map {|s| s.name}
=> ["csp1-2020", "csp10-2020", "csp2-2020", "csp3-2020", "csp4-2020", "csp5-2020", "csp6-2020", "csp7-2020", "csp8-2020", "csp9-2020"]
[development] dashboard > require 'set'
=> false
[development] dashboard > Set.new(csp_2020_script_names) == Set.new(ScriptConstants::CATEGORIES[:csp_2020])
=> true
```

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
