### PR TITLE
Change default instance type to m5.12xlarge

### DIFF
--- a/lib/cdo/cloud_formation/cdo_app.rb
+++ b/lib/cdo/cloud_formation/cdo_app.rb
@@ -26,7 +26,7 @@ module Cdo::CloudFormation
     # Hard-coded constants and default values.
     CHEF_KEY = rack_env?(:adhoc) ? 'adhoc/chef' : 'chef'
     IMAGE_ID = ENV['IMAGE_ID'] || 'ami-07d0cf3af28718ef8' # ubuntu/images/hvm-ssd/ubuntu-bionic-18.04-amd64-server-20190722.1
-    INSTANCE_TYPE = rack_env?(:production) ? 'm4.10xlarge' : 't2.2xlarge'
+    INSTANCE_TYPE = rack_env?(:production) ? 'm5.12xlarge' : 't2.2xlarge'
     ORIGIN = "https://github.com/code-dot-org/code-dot-org.git"
     CHEF_VERSION = '15.2.20'
     DOMAIN = 'cdn-code.org'


### PR DESCRIPTION
Small one-line change to update the default `production` instance type from `m4.10xlarge` to `m5.12xlarge`.

Since stack parameters persist in each stack, I plan to manually update the parameter in the production stack by changing the `locals.yml` entry on `production-daemon` once this is merged.

The updated parameter will cause the instance type to be changed on new frontend instances that are swapped in during the next deploy.

## Testing story

Verified an adhoc instance provisions properly with this instance type, and also verified in production by changing the instance type on a canary instance and serving live traffic without any issues.

Also, we have been running `test` on an `m5.24xlarge` instance for several months without any issues so our application should be very stable on the `m5` instance class at this point.