### PR TITLE
honor data_tables from project template level

### DIFF
--- a/dashboard/app/models/levels/blockly.rb
+++ b/dashboard/app/models/levels/blockly.rb
@@ -361,6 +361,7 @@ class Blockly < Level
       if is_a? Applab
         level_prop['startHtml'] = try(:project_template_level).try(:start_html) || start_html
         level_prop['dataTables'] = try(:project_template_level).try(:data_tables) || data_tables
+        level_prop['dataProperties'] = try(:project_template_level).try(:data_properties) || data_properties
         level_prop['name'] = name
       end
 

--- a/dashboard/app/models/levels/blockly.rb
+++ b/dashboard/app/models/levels/blockly.rb
@@ -360,6 +360,7 @@ class Blockly < Level
 
       if is_a? Applab
         level_prop['startHtml'] = try(:project_template_level).try(:start_html) || start_html
+        level_prop['dataTables'] = try(:project_template_level).try(:data_tables) || data_tables
         level_prop['name'] = name
       end
 

--- a/dashboard/test/controllers/script_levels_controller_test.rb
+++ b/dashboard/test/controllers/script_levels_controller_test.rb
@@ -224,6 +224,43 @@ class ScriptLevelsControllerTest < ActionController::TestCase
     assert_equal '<div><label id="label1">real_level html</label></div>', level_options['startHtml']
   end
 
+  test 'project template level sets data tables when defined' do
+    template_level = create :applab
+    template_level.data_tables = '{"key":"expected"}'
+    template_level.save!
+
+    real_level = create :applab
+    real_level.project_template_level_name = template_level.name
+    real_level.data_tables = '{"key":"wrong"}'
+    real_level.save!
+
+    sl = create :script_level, levels: [real_level]
+    get :show, params: {script_id: sl.script, stage_position: '1', id: '1'}
+
+    assert_response :success
+    # data tables comes from project_level not real_level
+    level_options = assigns(:level).blockly_level_options
+    assert_equal '{"key":"expected"}', level_options['dataTables']
+  end
+
+  test 'project template level does not set data tables when not defined' do
+    template_level = create :applab
+    template_level.save!
+
+    real_level = create :applab
+    real_level.project_template_level_name = template_level.name
+    real_level.data_tables = '{"key":"real"}'
+    real_level.save!
+
+    sl = create :script_level, levels: [real_level]
+    get :show, params: {script_id: sl.script, stage_position: '1', id: '1'}
+
+    assert_response :success
+    # data tables comes from real_level not project_level
+    level_options = assigns(:level).blockly_level_options
+    assert_equal '{"key":"real"}', level_options['dataTables']
+  end
+
   test 'project template level sets start animations when defined' do
     template_animations_json = '{"orderedKeys":["expected"],"propsByKey":{"expected":{}}}'
     template_level = create :gamelab

--- a/dashboard/test/controllers/script_levels_controller_test.rb
+++ b/dashboard/test/controllers/script_levels_controller_test.rb
@@ -227,11 +227,13 @@ class ScriptLevelsControllerTest < ActionController::TestCase
   test 'project template level sets data tables when defined' do
     template_level = create :applab
     template_level.data_tables = '{"key":"expected"}'
+    template_level.data_properties = '{"prop":"expected"}'
     template_level.save!
 
     real_level = create :applab
     real_level.project_template_level_name = template_level.name
     real_level.data_tables = '{"key":"wrong"}'
+    real_level.data_properties = '{"prop":"wrong"}'
     real_level.save!
 
     sl = create :script_level, levels: [real_level]
@@ -241,6 +243,7 @@ class ScriptLevelsControllerTest < ActionController::TestCase
     # data tables comes from project_level not real_level
     level_options = assigns(:level).blockly_level_options
     assert_equal '{"key":"expected"}', level_options['dataTables']
+    assert_equal '{"prop":"expected"}', level_options['dataProperties']
   end
 
   test 'project template level does not set data tables when not defined' do
@@ -250,6 +253,7 @@ class ScriptLevelsControllerTest < ActionController::TestCase
     real_level = create :applab
     real_level.project_template_level_name = template_level.name
     real_level.data_tables = '{"key":"real"}'
+    real_level.data_properties = '{"prop":"real"}'
     real_level.save!
 
     sl = create :script_level, levels: [real_level]
@@ -259,6 +263,7 @@ class ScriptLevelsControllerTest < ActionController::TestCase
     # data tables comes from real_level not project_level
     level_options = assigns(:level).blockly_level_options
     assert_equal '{"key":"real"}', level_options['dataTables']
+    assert_equal '{"prop":"real"}', level_options['dataProperties']
   end
 
   test 'project template level sets start animations when defined' do


### PR DESCRIPTION
## Background

Finishes https://codedotorg.atlassian.net/browse/LP-1115. Copies @cpirich 's solution verbatim from https://github.com/code-dot-org/code-dot-org/pull/28560 , and adds a bit to handle key-value pairs.

## Description

When a project template level is present, start using the data_tables from the project template level instead of the data_tables from the current level. The same is done for data_properties.

## Links

<!--
  Any relevant links to external resources; ie, specification documents, jira
  items, related PRs, honeybadger errors, etc
-->

## Testing story

new unit tests cover the new behavior. I've done the following manual verification to show that this will do no harm to existing levels in 2019 and 2020 curriculum:

In the 2019 curriculum, there are only 9 levels which have a project template level and also have data tables:
```
[levelbuilder] dashboard > scripts = Script.all.select {|s| s.version_year == '2019'}
[levelbuilder] dashboard > levels = scripts.map(&:script_levels).flatten.map(&:levels).flatten
[levelbuilder] dashboard > pbl = levels.select(&:project_template_level)
[levelbuilder] dashboard > pbl.select {|l| l.properties['data_tables']}.count
=> 9
```
I've checked those manually, and in each case, the project template level also has data tables which meets one of the following 2 criteria:
1. data tables in the template level are identical to the parent level, ignoring whitespace differences; or
2. data tables in the template level look similar, except they actually have correct syntax whereas the parent levels have incorrect syntax and fail to load ([example](https://levelbuilder-studio.code.org/s/csppostap-2019/stage/10/puzzle/3)). in this case, this PR will fix these levels.

There are no data_tables on levels with project template levels in CSP 2020:
```
[levelbuilder] dashboard > Course.find_by_name('csp-2020').default_scripts.map(&:name)
=> ["csp1-2020", "csp2-2020", "csp3-2020", "csp4-2020", "csp5-2020", "csp6-2020", "csp7-2020", "csp8-2020", "csp9-2020", "csp10-2020"]
[levelbuilder] dashboard > levels = Course.find_by_name('csp-2020').default_scripts.map(&:script_levels).flatten.map(&:levels).flatten
[levelbuilder] dashboard > pbl = levels.select(&:project_template_level)
[levelbuilder] dashboard > pbl.select {|l| l.properties['data_tables']}.count
=> 0
```

There are no instances of Applab levels which have both data_properties and a project_template_level:
```
[levelbuilder] dashboard > Applab.all.select(&:project_template_level).select(&:data_properties).count
=> 0
```

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
