### PR TITLE
Course overview queries

### DIFF
--- a/dashboard/app/models/course.rb
+++ b/dashboard/app/models/course.rb
@@ -373,7 +373,7 @@ class Course < ApplicationRecord
 
     if user.teacher?
       alternates.each do |cs|
-        return cs if SingleUserExperiment.enabled?(user: user, experiment_name: cs.experiment_name)
+        return cs if Experiment.get_all_enabled(user: user, experiment_name: cs.experiment_name).any?
       end
     end
 

--- a/dashboard/test/models/course_test.rb
+++ b/dashboard/test/models/course_test.rb
@@ -253,6 +253,7 @@ class CourseTest < ActiveSupport::TestCase
         @alternate_course_script,
         @course.select_course_script(@other_teacher, @default_course_script)
       )
+
       experiment.destroy
     end
 
@@ -298,6 +299,31 @@ class CourseTest < ActiveSupport::TestCase
         @default_course_script,
         @course.select_course_script(@student, @default_course_script)
       )
+    end
+
+    test 'scripts_for_user query counts, teacher in experiment' do
+      experiment = create :single_user_experiment, min_user_id: @other_teacher.id, name: 'my-experiment'
+
+      assert_queries(9) do
+        @course.scripts_for_user(@other_teacher)
+      end
+      experiment.destroy
+    end
+
+    test 'scripts_for_user query counts, teacher in experiment, additional alternate script' do
+      experiment = create :single_user_experiment, min_user_id: @other_teacher.id, name: 'my-experiment'
+
+      create :course_script,
+        course: @course,
+        script: create(:script, name: 'script3a'),
+        position: 3,
+        default_script: @script3,
+        experiment_name: 'my-experiment'
+
+      assert_queries(10) do
+        @course.scripts_for_user(@other_teacher)
+      end
+      experiment.destroy
     end
   end
 


### PR DESCRIPTION
attempt for [LP-1219](https://codedotorg.atlassian.net/browse/LP-1219)

The intent was for ` Experiment.get_all_enabled(user: user, experiment_name: cs.experiment_name).any?` to replace `SingleUserExperiment.enabled?(user: user, experiment_name: cs.experiment_name)` and in doing so leverage the Experiment cache and reduce the query counts on the course over page for teachers viewing courses that have alternate scripts. However, the query counts remained consistent before and after the change so I'm likely missing something... 
