### PR TITLE
Sharing: add QR Code to React-based sharing popup

### DIFF
--- a/apps/i18n/common/en_us.json
+++ b/apps/i18n/common/en_us.json
@@ -1349,6 +1349,7 @@
   "saveAndShare": "Save and share",
   "savedToGallery": "Saved",
   "saving": "Saving...",
+  "scanQRCode": "Scan this code with your phone camera:",
   "scatterPlot": "Scatter Plot",
   "searchForCountry": "Search for your country.",
   "searchForSchool": "Enter your school name, city, or zip code to search",

--- a/apps/src/code-studio/components/ShareAllowedDialog.jsx
+++ b/apps/src/code-studio/components/ShareAllowedDialog.jsx
@@ -20,6 +20,7 @@ import {createHiddenPrintWindow} from '@cdo/apps/utils';
 import i18n from '@cdo/locale';
 import firehoseClient from '@cdo/apps/lib/util/firehose';
 import LibraryCreationDialog from './libraries/LibraryCreationDialog';
+import QRCode from 'qrcode.react';
 
 function recordShare(type) {
   if (!window.dashboard) {
@@ -122,6 +123,20 @@ const styles = {
     transform: 'translate(-50%,-50%)',
     msTransform: 'translate(-50%,-50%)',
     WebkitTransform: 'translate(-50%,-50%)'
+  },
+  sendToPhoneContainer: {
+    width: '100%',
+    marginTop: 15
+  },
+  sendToPhoneLeft: {
+    float: 'left',
+    width: '70%',
+    paddingRight: 20,
+    boxSizing: 'border-box'
+  },
+  sendToPhoneRight: {
+    float: 'right',
+    width: '30%'
   }
 };
 
@@ -451,12 +466,22 @@ class ShareAllowedDialog extends React.Component {
                   )}
                 </div>
                 {this.state.showSendToPhone && (
-                  <SendToPhone
-                    channelId={this.props.channelId}
-                    appType={this.props.appType}
-                    isLegacyShare={false}
-                    styles={{label: {marginTop: 15, marginBottom: 0}}}
-                  />
+                  <div>
+                    <div style={styles.sendToPhoneContainer}>
+                      <div style={styles.sendToPhoneLeft}>
+                        <SendToPhone
+                          channelId={this.props.channelId}
+                          appType={this.props.appType}
+                          isLegacyShare={false}
+                        />
+                      </div>
+                      <div style={styles.sendToPhoneRight}>
+                        <label>{i18n.scanQRCode()}</label>
+                        <QRCode value={this.props.shareUrl} size={90} />
+                      </div>
+                    </div>
+                    <div style={{clear: 'both'}} />
+                  </div>
                 )}
                 {canPublish && !isPublished && !hasThumbnail && (
                   <div style={{clear: 'both', marginTop: 10}}>

--- a/apps/src/code-studio/components/ShareAllowedDialog.jsx
+++ b/apps/src/code-studio/components/ShareAllowedDialog.jsx
@@ -477,7 +477,10 @@ class ShareAllowedDialog extends React.Component {
                       </div>
                       <div style={styles.sendToPhoneRight}>
                         <label>{i18n.scanQRCode()}</label>
-                        <QRCode value={this.props.shareUrl} size={90} />
+                        <QRCode
+                          value={this.props.shareUrl + '?qr=true'}
+                          size={90}
+                        />
                       </div>
                     </div>
                     <div style={{clear: 'both'}} />


### PR DESCRIPTION
Similar to https://github.com/code-dot-org/code-dot-org/pull/33494, this adds a QR code to the React-based share dialog used for for sharings things like App Lab projects.

This dialog does not check whether users are US-based, and so the "Send to phone" button is always available, and both the phone number and QR code are always shown when that UI is revealed.

### before

![Screenshot 2020-03-26 22 12 25](https://user-images.githubusercontent.com/2205926/77723892-e8443c00-6fae-11ea-94a7-b60e3bcd79d3.png)

### after

![Screenshot 2020-03-26 21 57 06](https://user-images.githubusercontent.com/2205926/77723563-0eb5a780-6fae-11ea-9273-97f0c7537f2f.png)
