### PR TITLE
Never show student not started warning on a project page

### DIFF
--- a/apps/src/StudioApp.js
+++ b/apps/src/StudioApp.js
@@ -3235,7 +3235,7 @@ StudioApp.prototype.isResponsiveFromConfig = function(config) {
 StudioApp.prototype.isNotStartedLevel = function(config) {
   const progress = getStore().getState().progress;
 
-  if (config.hasContainedLevels) {
+  if (config.hasContainedLevels || config.level.isProjectLevel) {
     return false;
   } else if (
     ['Gamelab', 'Applab', 'Weblab', 'Spritelab', 'Dance'].includes(


### PR DESCRIPTION
Don't show the 'student has not started this level' warning on a page that is not part of a level progression ( has /projects/ in the url). 

Fixes bug where viewing a shared playlab project would show the warning.

### Before
![Screen Shot 2020-03-27 at 1 44 04 PM](https://user-images.githubusercontent.com/208083/77784519-0783ad80-7031-11ea-93fb-72810bcc8ef0.png)

### After
![Screen Shot 2020-03-27 at 1 42 27 PM](https://user-images.githubusercontent.com/208083/77784378-cdb2a700-7030-11ea-8997-51bd6b84e4be.png)

I should probably make a test to check we don't regress this but not sure if thats worth the time at the moment?