### PR TITLE
Fix CloudFormation commit-option default

### DIFF
--- a/lib/cdo/cloud_formation/cdo_app.rb
+++ b/lib/cdo/cloud_formation/cdo_app.rb
@@ -51,13 +51,13 @@ module Cdo::CloudFormation
       options = @options = OpenStruct.new(options)
 
       # Various option defaults.
-      options.commit        ||= `git ls-remote origin #{branch}`.split.first
       options.frontends     ||= rack_env?(:production)
       options.database      ||= [:staging, :test, :levelbuilder].include?(rack_env)
       options.load_balancer ||= !rack_env?(:adhoc) || options.frontends
       options.alarms        ||= !rack_env?(:adhoc)
       options.cdn_enabled   ||= !rack_env?(:adhoc)
       options.branch        ||= (rack_env?(:adhoc) ? RakeUtils.git_branch : rack_env)
+      options.commit        ||= `git ls-remote origin #{branch}`.split.first
       options.domain        ||= DOMAIN
 
       stack_name << "-#{branch}" if stack_name == 'adhoc'

--- a/lib/rake/stack.rake
+++ b/lib/rake/stack.rake
@@ -11,7 +11,8 @@ namespace :stack do
         stack_name: ENV['STACK_NAME'],
         frontends: ENV['FRONTENDS'],
         domain: ENV['DOMAIN'],
-        cdn_enabled: ENV['CDN_ENABLED']
+        cdn_enabled: ENV['CDN_ENABLED'],
+        commit: ENV['COMMIT']
       )),
       log: CDO.log,
       verbose: ENV['VERBOSE'],


### PR DESCRIPTION
Allow commit to use `COMMIT` env override,
and set `branch` default before deriving `commit` default.
Followup to #33326.