### PR TITLE
Sharing: tweak to the QR code in original sharing popup

### DIFF
--- a/apps/src/templates/sharing.html.ejs
+++ b/apps/src/templates/sharing.html.ejs
@@ -83,7 +83,7 @@
     </div>
   <% } %>
   <div id="send-to-phone-right">
-    <label>Scan this code with your phone camera:</label>
+    <label><%= msg.scanQRCode() %></label>
     <div id="send-to-phone-qr-code"></div>
   </div>
 </div>

--- a/apps/style/common.scss
+++ b/apps/style/common.scss
@@ -1357,12 +1357,14 @@ $workspace-header-button-margin: ($workspace-headers-height - $workspace-header-
 
   #send-to-phone-left {
     float: left;
-    width: 60%;
+    width: 65%;
+    padding-right: 20px;
+    box-sizing: border-box;
   }
 
   #send-to-phone-right {
     float: left;
-    width: 40%;
+    width: 35%;
     margin-bottom: 0px;
   }
 


### PR DESCRIPTION
Followup to https://github.com/code-dot-org/code-dot-org/pull/33494.  The QR Code string is now localised (with the string added in https://github.com/code-dot-org/code-dot-org/pull/33892) and the layout gets a tiny tweak to add space between the phone number and the QR code.

![Screenshot 2020-03-27 12 42 37](https://user-images.githubusercontent.com/2205926/77794387-06e71900-7029-11ea-8de7-c98b54219945.png)
