### PR TITLE
Replace all slashes in links to cucumber logs

### DIFF
--- a/dashboard/test/ui/test_status.js
+++ b/dashboard/test/ui/test_status.js
@@ -9,26 +9,28 @@
 /* global _, Clipboard, setTabStatusIcon */
 
 // Gather metadata for the run
-const COMMIT_HASH = document.querySelector('#commit-hash').dataset.hash;
-const RUN_START_TIME = new Date(document.querySelector('#start-time').textContent);
-const TEST_TYPE = document.querySelector('#test-type').value;
-const API_ORIGIN = document.querySelector('#api-origin').value;
-const S3_BUCKET = document.querySelector('#s3-bucket').value;
-const S3_PREFIX = document.querySelector('#s3-prefix').value;
+const COMMIT_HASH = document.querySelector("#commit-hash").dataset.hash;
+const RUN_START_TIME = new Date(
+  document.querySelector("#start-time").textContent
+);
+const TEST_TYPE = document.querySelector("#test-type").value;
+const API_ORIGIN = document.querySelector("#api-origin").value;
+const S3_BUCKET = document.querySelector("#s3-bucket").value;
+const S3_PREFIX = document.querySelector("#s3-prefix").value;
 
 // Simple constants
-const STATUS_PENDING = 'PENDING';
-const STATUS_FAILED = 'FAILED';
-const STATUS_SUCCEEDED = 'SUCCEEDED';
+const STATUS_PENDING = "PENDING";
+const STATUS_FAILED = "FAILED";
+const STATUS_SUCCEEDED = "SUCCEEDED";
 
 // Derived constants
-const S3_KEY_SUFFIX = `${/eyes/i.test(TEST_TYPE) ? '_eyes' : ''}_output.html`;
+const S3_KEY_SUFFIX = `${/eyes/i.test(TEST_TYPE) ? "_eyes" : ""}_output.html`;
 const API_BASEPATH = `${API_ORIGIN}/api/v1/test_logs`;
 
 // Grab DOM references
-let lastRefreshTimeLabel = document.querySelector('#last-refresh-time');
-let refreshButton = document.querySelector('#refresh-button');
-let autoRefreshButton = document.querySelector('#auto-refresh-button');
+let lastRefreshTimeLabel = document.querySelector("#last-refresh-time");
+let refreshButton = document.querySelector("#refresh-button");
+let autoRefreshButton = document.querySelector("#auto-refresh-button");
 
 var lastRefreshTime = RUN_START_TIME;
 
@@ -36,10 +38,11 @@ function Test(fromRow) {
   /** @type {HTMLRowElement} */
   this.row = fromRow;
 
-
   /** @type {string} */
-  this.browser = (typeof this.row.dataset.browser === 'string') ?
-      this.row.dataset.browser : 'UnknownBrowser';
+  this.browser =
+    typeof this.row.dataset.browser === "string"
+      ? this.row.dataset.browser
+      : "UnknownBrowser";
 
   /** @type {string} */
   this.feature = this.row.dataset.feature;
@@ -69,15 +72,16 @@ function Test(fromRow) {
   this.updateView();
 }
 
-Test.prototype.setLastModified = function (object, lastModified) {
+Test.prototype.setLastModified = function(object, lastModified) {
   // Do no updating if things haven't changed.
   if (this.lastModified_ && lastModified <= this.lastModified_) {
     return Promise.resolve();
   }
 
   if (lastModified > RUN_START_TIME && this.status !== STATUS_SUCCEEDED) {
-    return this.fetchStatus(object)
-      .then(() => this.lastModified_ = lastModified);
+    return this.fetchStatus(object).then(
+      () => (this.lastModified_ = lastModified)
+    );
   } else {
     this.lastModified_ = lastModified;
     this.updateView();
@@ -85,7 +89,7 @@ Test.prototype.setLastModified = function (object, lastModified) {
   }
 };
 
-Test.prototype.fetchStatus = function (object) {
+Test.prototype.fetchStatus = function(object) {
   this.isUpdating_ = true;
   this.updateView();
   const ensure = () => {
@@ -98,7 +102,7 @@ Test.prototype.fetchStatus = function (object) {
       if (json.commit === COMMIT_HASH) {
         this.versionId = json.version_id;
         this.attempt = parseInt(json.attempt, 10);
-        this.success = json.success === 'true';
+        this.success = json.success === "true";
         this.duration = parseInt(json.duration, 10);
         this.status = this.success ? STATUS_SUCCEEDED : STATUS_FAILED;
       }
@@ -109,25 +113,26 @@ Test.prototype.fetchStatus = function (object) {
     });
 };
 
-Test.prototype.updateView = function () {
+Test.prototype.updateView = function() {
   const succeeded = this.status === STATUS_SUCCEEDED;
   const failed = this.status === STATUS_FAILED;
 
   // Get references to row elements
   let row = this.row;
-  let statusCell = row.querySelector('.status');
-  let logLinkCell = row.querySelector('.log-link');
+  let statusCell = row.querySelector(".status");
+  let logLinkCell = row.querySelector(".log-link");
 
   // Update row appearance
   row.className = this.status;
   if (succeeded || failed) {
-    statusCell.innerHTML = (succeeded ? 'Succeeded' : 'Failed') +
-        ` in ${Math.round(this.duration)} seconds` +
-        (this.attempt > 0 ? ` on retry #${this.attempt}` : '');
+    statusCell.innerHTML =
+      (succeeded ? "Succeeded" : "Failed") +
+      ` in ${Math.round(this.duration)} seconds` +
+      (this.attempt > 0 ? ` on retry #${this.attempt}` : "");
     logLinkCell.innerHTML = `<a href="${this.publicLogUrl()}">Log on S3</a>`;
   } else {
-    statusCell.innerHTML = '';
-    logLinkCell.innerHTML = '';
+    statusCell.innerHTML = "";
+    logLinkCell.innerHTML = "";
   }
 
   if (this.isUpdating_) {
@@ -138,27 +143,29 @@ Test.prototype.updateView = function () {
   updateProgress && updateProgress();
 };
 
-Test.prototype.s3Key = function () {
+Test.prototype.s3Key = function() {
   const featureRegex = /features\/(.*)\.feature/i;
   let result = featureRegex.exec(this.feature);
-  let featureName = result[1].replace('/', '_');
+  let featureName = result[1].replace("/", "_");
   return `${S3_PREFIX}/${this.browser}_${featureName}${S3_KEY_SUFFIX}`;
 };
 
-Test.prototype.publicLogUrl = function () {
-  return `https://${S3_BUCKET}.s3.amazonaws.com/${this.s3Key()}?versionId=${this.versionId}`;
+Test.prototype.publicLogUrl = function() {
+  return `https://${S3_BUCKET}.s3.amazonaws.com/${this.s3Key()}?versionId=${
+    this.versionId
+  }`;
 };
 
 // Connect up "Copy Rerun Command" buttons
-new Clipboard('button.copy-button');
+new Clipboard("button.copy-button");
 
 function keyify(str) {
-  return str.replace(/\//g, '_');
+  return str.replace(/\//g, "_");
 }
 
 // Build a cache of tests for this run.
 var tests = {};
-var rows = document.querySelectorAll('tbody tr');
+var rows = document.querySelectorAll("tbody tr");
 rows.forEach(row => {
   let test = new Test(row);
   tests[test.browser] = tests[test.browser] || {};
@@ -166,9 +173,12 @@ rows.forEach(row => {
 });
 
 function testFromS3Key(key) {
-  let escapedPrefix = S3_PREFIX.replace(/\//g, '\/');
-  let escapedSuffix = S3_KEY_SUFFIX.replace(/\./g, '\\.');
-  var result = new RegExp(`${escapedPrefix}\/([^_]+)_(.*)${escapedSuffix}`, 'i').exec(key);
+  let escapedPrefix = S3_PREFIX.replace(/\//g, "/");
+  let escapedSuffix = S3_KEY_SUFFIX.replace(/\./g, "\\.");
+  var result = new RegExp(
+    `${escapedPrefix}\/([^_]+)_(.*)${escapedSuffix}`,
+    "i"
+  ).exec(key);
   // Ignore tests with a different suffix (from other runs, e.g. eyes vs. non-eyes).
   if (!result) {
     return undefined;
@@ -184,7 +194,9 @@ function testFromS3Key(key) {
 }
 
 function calculateBrowserProgress(browser) {
-  let successCount = 0, failureCount = 0, pendingCount = 0;
+  let successCount = 0,
+    failureCount = 0,
+    pendingCount = 0;
   for (let feature in tests[browser]) {
     let status = tests[browser][feature].status;
     if (status === STATUS_PENDING) {
@@ -203,22 +215,31 @@ function calculateBrowserProgress(browser) {
 }
 
 function renderBrowserProgress(browser, progress) {
-  let {successCount, failureCount, pendingCount} = progress;
+  let { successCount, failureCount, pendingCount } = progress;
   let totalCount = successCount + failureCount + pendingCount;
 
   // DOM references
   let progressDiv = document.querySelector(`#${browser}-progress`);
-  let progressText = progressDiv.querySelector('.progress-text');
-  let progressBar = progressDiv.querySelector('.progress-bar');
-  let successBar = progressBar.querySelector('.success');
-  let failureBar = progressBar.querySelector('.failure');
-  let pendingBar = progressBar.querySelector('.pending');
+  let progressText = progressDiv.querySelector(".progress-text");
+  let progressBar = progressDiv.querySelector(".progress-bar");
+  let successBar = progressBar.querySelector(".success");
+  let failureBar = progressBar.querySelector(".failure");
+  let pendingBar = progressBar.querySelector(".pending");
 
   // We manipulate the percentages to make them round numbers, adding up to 100,
   // and each category gets at least 1% if its count is greater than zero.
-  let successPercent = Math.max(Math.floor(successCount * 1000 / totalCount)/10, successCount > 0 ? 0.1 : 0);
-  let failurePercent = Math.max(Math.floor(failureCount * 1000 / totalCount)/10, failureCount > 0 ? 0.1 : 0);
-  let pendingPercent = Math.max(Math.floor(pendingCount * 1000 / totalCount)/10, pendingCount > 0 ? 0.1 : 0);
+  let successPercent = Math.max(
+    Math.floor((successCount * 1000) / totalCount) / 10,
+    successCount > 0 ? 0.1 : 0
+  );
+  let failurePercent = Math.max(
+    Math.floor((failureCount * 1000) / totalCount) / 10,
+    failureCount > 0 ? 0.1 : 0
+  );
+  let pendingPercent = Math.max(
+    Math.floor((pendingCount * 1000) / totalCount) / 10,
+    pendingCount > 0 ? 0.1 : 0
+  );
   let leftover = 100 - (successPercent + failurePercent + pendingPercent);
   if (leftover > 0) {
     if (pendingCount > 0) {
@@ -240,10 +261,11 @@ function renderBrowserProgress(browser, progress) {
 
   // Set progress text
   let runPercent = successPercent + failurePercent;
-  progressText.textContent = `${runPercent}% of ${totalCount} tests have run.`
-      + ` ${successCount} passed,`
-      + ` ${failureCount} failed,`
-      + ` ${pendingCount} are pending.`;
+  progressText.textContent =
+    `${runPercent}% of ${totalCount} tests have run.` +
+    ` ${successCount} passed,` +
+    ` ${failureCount} failed,` +
+    ` ${pendingCount} are pending.`;
 
   // Update the progress bar
   successBar.style.width = `${successPercent}%`;
@@ -253,7 +275,9 @@ function renderBrowserProgress(browser, progress) {
 
 function updateProgressNow() {
   // Count up tests by status
-  let successCount = 0, failureCount = 0, pendingCount = 0;
+  let successCount = 0,
+    failureCount = 0,
+    pendingCount = 0;
   for (let browser in tests) {
     let browserProgress = calculateBrowserProgress(browser);
     renderBrowserProgress(browser, browserProgress);
@@ -261,7 +285,7 @@ function updateProgressNow() {
     failureCount += browserProgress.failureCount;
     pendingCount += browserProgress.pendingCount;
   }
-  renderBrowserProgress('total', {
+  renderBrowserProgress("total", {
     successCount,
     failureCount,
     pendingCount
@@ -269,11 +293,11 @@ function updateProgressNow() {
 
   // Set the tab's status icon according to how complete the test run is
   if (failureCount > 0) {
-    setTabStatusIcon('fail');
+    setTabStatusIcon("fail");
   } else if (pendingCount > 0) {
-    setTabStatusIcon('in-progress');
+    setTabStatusIcon("in-progress");
   } else {
-    setTabStatusIcon('pass');
+    setTabStatusIcon("pass");
   }
 
   // Disable auto-refresh if the test run is done and green.
@@ -294,23 +318,29 @@ function refresh() {
   const ensure = () => {
     refreshButton.disabled = false;
   };
-  let lastRefreshEpochSeconds = Math.floor(lastRefreshTime.getTime()/1000);
+  let lastRefreshEpochSeconds = Math.floor(lastRefreshTime.getTime() / 1000);
   let newTime = new Date();
-  fetch(`${API_BASEPATH}/${S3_PREFIX}/since/${lastRefreshEpochSeconds}`, { mode: 'no-cors' })
+  fetch(`${API_BASEPATH}/${S3_PREFIX}/since/${lastRefreshEpochSeconds}`, {
+    mode: "no-cors"
+  })
     .then(response => {
       if (response.ok) {
         return response.json();
       }
-      throw new Error(`While fetching updates, "${response.url}" returned ${response.status}.`);
+      throw new Error(
+        `While fetching updates, "${response.url}" returned ${response.status}.`
+      );
     })
     .then(json => {
       return Promise.all(json.map(object => refreshIndividualTest(object)))
         .then(() => {
           lastRefreshTime = newTime;
-          lastRefreshTimeLabel.textContent = 'Updated ' + lastRefreshTime.toTimeString();
+          lastRefreshTimeLabel.textContent =
+            "Updated " + lastRefreshTime.toTimeString();
         })
         .catch(error => {
-          lastRefreshTimeLabel.textContent = 'Partially updated at ' + newTime.toTimeString();
+          lastRefreshTimeLabel.textContent =
+            "Partially updated at " + newTime.toTimeString();
           console.warn(error);
         });
     })
@@ -333,14 +363,14 @@ function refreshIndividualTest(object) {
 
 var refreshInterval = null;
 function enableAutoRefresh() {
-  refreshButton.style.display = 'none';
-  autoRefreshButton.textContent = 'Disable Auto-Refresh';
+  refreshButton.style.display = "none";
+  autoRefreshButton.textContent = "Disable Auto-Refresh";
   refreshInterval = setInterval(refresh, 10000); // 10 seconds
 }
 
 function disableAutoRefresh() {
-  refreshButton.style.display = 'inline-block';
-  autoRefreshButton.textContent = 'Enable Auto-Refresh';
+  refreshButton.style.display = "inline-block";
+  autoRefreshButton.textContent = "Enable Auto-Refresh";
   clearInterval(refreshInterval);
   refreshInterval = null;
 }
@@ -361,27 +391,32 @@ refresh();
 let hideSucceeded = false;
 function toggleHideSucceeded() {
   hideSucceeded = !hideSucceeded;
-  hideSucceededButton.textContent = `${hideSucceeded ? 'Show' : 'Hide'} Succeeded`;
+  hideSucceededButton.textContent = `${
+    hideSucceeded ? "Show" : "Hide"
+  } Succeeded`;
   let sheet = document.styleSheets[document.styleSheets.length - 1];
-  let display = hideSucceeded ? 'none' : 'table-row';
-  let rule = _.findLast(sheet.rules, rule => rule.selectorText === '.SUCCEEDED');
+  let display = hideSucceeded ? "none" : "table-row";
+  let rule = _.findLast(
+    sheet.rules,
+    rule => rule.selectorText === ".SUCCEEDED"
+  );
   if (rule) {
     rule.style.display = display;
   } else {
-    sheet.insertRule(`.SUCCEEDED{display: ${display}}`,sheet.cssRules.length);
+    sheet.insertRule(`.SUCCEEDED{display: ${display}}`, sheet.cssRules.length);
   }
 }
-let hideSucceededButton = document.querySelector('#hide-succeeded-button');
+let hideSucceededButton = document.querySelector("#hide-succeeded-button");
 hideSucceededButton.onclick = toggleHideSucceeded;
 
 // Help text
-const helpLink = document.querySelector('#help-link');
-const helpText = document.querySelector('#help-text');
+const helpLink = document.querySelector("#help-link");
+const helpText = document.querySelector("#help-text");
 function toggleHelpText() {
-  if (getComputedStyle(helpText).display === 'none') {
-    helpText.style.display = 'block';
+  if (getComputedStyle(helpText).display === "none") {
+    helpText.style.display = "block";
   } else {
-    helpText.style.display = 'none';
+    helpText.style.display = "none";
   }
 }
 helpLink.onclick = toggleHelpText;

--- a/dashboard/test/ui/test_status.js
+++ b/dashboard/test/ui/test_status.js
@@ -145,8 +145,8 @@ Test.prototype.updateView = function() {
 
 Test.prototype.s3Key = function() {
   const featureRegex = /features\/(.*)\.feature/i;
-  let result = featureRegex.exec(this.feature);
-  let featureName = result[1].replace("/", "_");
+  const result = featureRegex.exec(this.feature);
+  const featureName = result[1].replace(/\//g, "_");
   return `${S3_PREFIX}/${this.browser}_${featureName}${S3_KEY_SUFFIX}`;
 };
 


### PR DESCRIPTION
Follow-on to https://github.com/code-dot-org/code-dot-org/pull/33204 . Now that some .feature files are more deeply nested, our regex which generates the "Log on S3" links for https://test-studio.code.org/ui_test/test_status_UI.html and https://test-studio.code.org/ui_test/test_status_Eyes.html needs to be updated. 

before: 
https://cucumber-logs.s3.amazonaws.com/test/test/Chrome_learning_platform_instructions/top_instructions_eyes_output.html?versionId=bWSZFfhgPgWejOKJpBMT5jd7yzGxx3c6

after: 
https://cucumber-logs.s3.amazonaws.com/test/test/Chrome_learning_platform_instructions_top_instructions_eyes_output.html?versionId=bWSZFfhgPgWejOKJpBMT5jd7yzGxx3c6

## Testing story

Manually verified https://github.com/code-dot-org/code-dot-org/commit/fe0840dce3eb61d3e451482c8083b800ce6f66fd on the test machine.

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
