### PR TITLE
Add pending spinner for standards view of the progress tab

### DIFF
--- a/apps/src/templates/sectionProgress/standards/StandardsIntroDialog.jsx
+++ b/apps/src/templates/sectionProgress/standards/StandardsIntroDialog.jsx
@@ -35,7 +35,12 @@ class StandardsIntroDialog extends Component {
     setCurrentUserHasSeenStandardsReportInfo: PropTypes.func.isRequired
   };
 
+  state = {
+    pending: false
+  };
+
   dismissStandardsDialog = () => {
+    this.setState({pending: true});
     $.ajax({
       url: '/dashboardapi/v1/users/me/set_standards_report_info_to_seen',
       type: 'post',
@@ -92,6 +97,9 @@ class StandardsIntroDialog extends Component {
             onClick={this.dismissStandardsDialog}
             color={Button.ButtonColor.orange}
             className="uitest-standards-intro-button"
+            disabled={this.state.pending}
+            isPending={this.state.pending}
+            pendingText={i18n.loading()}
           />
         </DialogFooter>
       </BaseDialog>

--- a/apps/src/templates/sectionProgress/standards/StandardsProgressTable.jsx
+++ b/apps/src/templates/sectionProgress/standards/StandardsProgressTable.jsx
@@ -6,6 +6,8 @@ import i18n from '@cdo/locale';
 import StandardDescriptionCell from './StandardDescriptionCell';
 import {connect} from 'react-redux';
 import {lessonsByStandard} from '@cdo/apps/templates/sectionProgress/standards/sectionStandardsProgressRedux';
+import FontAwesome from '@cdo/apps/templates/FontAwesome';
+import _ from 'lodash';
 
 export const COLUMNS = {
   STANDARD_CATEGORY: 0,
@@ -167,6 +169,7 @@ class StandardsProgressTable extends Component {
   };
 
   render() {
+    const loading = _.isEmpty(this.props.lessonsByStandard);
     const columns = this.getColumns();
     const standards = this.props.standards || [];
     const rowData = standards.map((standard, index) => {
@@ -180,14 +183,25 @@ class StandardsProgressTable extends Component {
     });
 
     return (
-      <Table.Provider
-        columns={columns}
-        style={{...tableLayoutStyles.table, ...this.props.style}}
-        id="uitest-progress-standards-table"
-      >
-        <Table.Header />
-        <Table.Body rows={rowData} rowKey="id" />
-      </Table.Provider>
+      <div>
+        {loading && (
+          <FontAwesome
+            id="uitest-spinner"
+            icon="spinner"
+            className="fa-pulse fa-3x"
+          />
+        )}
+        {!loading && (
+          <Table.Provider
+            columns={columns}
+            style={{...tableLayoutStyles.table, ...this.props.style}}
+            id="uitest-progress-standards-table"
+          >
+            <Table.Header />
+            <Table.Body rows={rowData} rowKey="id" />
+          </Table.Provider>
+        )}
+      </div>
     );
   }
 }


### PR DESCRIPTION
Partial for [LP-1277](https://codedotorg.atlassian.net/browse/LP-1277), subtask[ LP-1350](https://codedotorg.atlassian.net/browse/LP-1350)

In #33768 I made a mega section with 250 students and max'ed them each out on progress, teacher scores and teacher feedback for two scripts. Loading the progress tab for that section was _slow_.  There's upcoming work to determine whether the standards tab contributes significantly to the sluggish page load time; in the meantime, I'm adding a loading spinner for the standards view and the "Got it" button of the standards intro dialog. I suspect even if we can optimize the load time for the progress tab in general, we'll still want this user experience improvement for those with slow connections.  This spinner is consistent with the one we show on the levels and lessons view of the progress tab. 

![loading-standards](https://user-images.githubusercontent.com/12300669/77809668-f301de00-704d-11ea-8bcb-c584e493f338.gif)

