### PR TITLE
Remove us-east-1e subnet from frontend auto scaling group

### DIFF
--- a/aws/cloudformation/cloud_formation_stack.yml.erb
+++ b/aws/cloudformation/cloud_formation_stack.yml.erb
@@ -98,6 +98,7 @@ Resources:
 <%=  component 'ami', ami: (ami = commit[0..4]),
   image_id: IMAGE_ID,
   ssh_key_name: SSH_KEY_NAME,
+  subnets: subnets(azs(AVAILABILITY_ZONES - ['us-east-1e'])), # us-east-1e doesn't support m5 instance types.
   frontend_policies: [Ref: 'CDOPolicy'],
   frontend_properties: {TargetGroupARNs: [Ref: 'ALBTargetGroup']},
   frontend_volume_size: 64,

--- a/aws/cloudformation/components/ami.yml.erb
+++ b/aws/cloudformation/components/ami.yml.erb
@@ -65,7 +65,7 @@ frontend_device_name ||= '/dev/sda1'
       InstanceType: <%=instance_type%>
       IamInstanceProfile: !Ref FrontendInstanceProfile
       SecurityGroupIds: [!ImportValue VPC-FrontendSecurityGroup]
-      SubnetId: !ImportValue VPC-Subnet<%=azs.first%>
+      SubnetId: <%=subnets.first.to_json%>
       KeyName: <%=ssh_key_name%>
       BlockDeviceMappings:
         - DeviceName: <%=frontend_device_name%>

--- a/lib/cdo/cloud_formation/vpc.rb
+++ b/lib/cdo/cloud_formation/vpc.rb
@@ -4,15 +4,15 @@ module Cdo::CloudFormation
     AVAILABILITY_ZONES = ('b'..'e').map {|i| "us-east-1#{i}"}
     SSH_IP = '0.0.0.0/0'.freeze
 
-    def azs
-      AVAILABILITY_ZONES.map {|zone| zone[-1].upcase}
+    def azs(zones=AVAILABILITY_ZONES)
+      zones.map {|zone| zone[-1].upcase}
     end
 
-    def subnets
+    def subnets(azs=self.azs)
       azs.map {|az| {'Fn::ImportValue': "VPC-Subnet#{az}"}}
     end
 
-    def public_subnets
+    def public_subnets(azs=self.azs)
       azs.map {|az| {'Fn::ImportValue': "VPC-PublicSubnet#{az}"}}
     end
   end


### PR DESCRIPTION
This is a quick fix to exclude the private subnet in the `us-east-1e` availability zone from the list of private subnets passed to the `VPCZoneIdentifier` property of the `Frontends` Auto Scaling Group in the CDO application stack, by adding a `subnets` argument to the `ami` component (which overrides the `subnets` method that previously returned all private subnets).

This reduces the total number of AZs in which frontends will get deployed from 4 to 3, which is okay for the time being. (We can consider configuring additional subnets in `us-east-1a` or `us-east-1f` in the future.)

The `us-east-1e` AZ needs to be excluded because it doesn't support the `m5` instance class in general (and `m5.12xlarge` instance types in particular), which can be sort-of confirmed using the [`DescribeReservedInstancesOfferings`](https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_DescribeReservedInstancesOfferings.html) API call:

```ruby
require 'aws-sdk-ec2'
require 'active_support/core_ext/numeric/time'
# https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ec2-reserved-instances.html#ri-pricing-variable-term-commitment
EC2_RI_DURATION = 1095.days

# List all availability zones that support launching the specified instance type.
def compatible_availability_zones(instance_type)
  require 'aws-sdk-ec2'
  Aws::EC2::Client.new.describe_reserved_instances_offerings(
    instance_type: instance_type,
    min_duration: EC2_RI_DURATION,
    include_marketplace: false,
    offering_class: 'standard',
    product_description: 'Linux/UNIX (Amazon VPC)',
    offering_type: 'No Upfront',
    instance_tenancy: 'default',
    filters: [name: 'scope', values: ['Availability Zone']]
  ).reserved_instances_offerings.map(&:availability_zone)
end
```

```ruby
irb(main):021:0> compatible_availability_zones 'm5.12xlarge'
=> ["us-east-1a", "us-east-1b", "us-east-1c", "us-east-1f", "us-east-1d"]
```

Rather than add this complicated/fragile code to the template code directly to exclude this zone based on the results of this API call, I figured it would be simpler to just exclude the `us-east-1e` subnet directly in the template with a comment explaining the exclusion.