### PR TITLE
Add a helper method to make loading i18n in a blockly-less environment fail nicer.

### DIFF
--- a/apps/src/bounce/locale.js
+++ b/apps/src/bounce/locale.js
@@ -1,3 +1,4 @@
 // locale for bounce
 
-module.exports = window.blockly.bounce_locale;
+import safeLoadLocale from '@cdo/apps/util/safeLoadLocale';
+module.exports = safeLoadLocale('bounce_locale');

--- a/apps/src/calc/locale.js
+++ b/apps/src/calc/locale.js
@@ -1,3 +1,4 @@
 // locale for calc
 
-module.exports = window.blockly.calc_locale;
+import safeLoadLocale from '@cdo/apps/util/safeLoadLocale';
+module.exports = safeLoadLocale('calc_locale');

--- a/apps/src/craft/locale.js
+++ b/apps/src/craft/locale.js
@@ -1,1 +1,2 @@
-module.exports = window.blockly.craft_locale;
+import safeLoadLocale from '@cdo/apps/util/safeLoadLocale';
+module.exports = safeLoadLocale('craft_locale');

--- a/apps/src/dance/locale.js
+++ b/apps/src/dance/locale.js
@@ -1,1 +1,2 @@
-module.exports = window.blockly.dance_locale;
+import safeLoadLocale from '@cdo/apps/util/safeLoadLocale';
+module.exports = safeLoadLocale('dance_locale');

--- a/apps/src/eval/locale.js
+++ b/apps/src/eval/locale.js
@@ -1,3 +1,4 @@
 // locale for eval
 
-module.exports = window.blockly.eval_locale;
+import safeLoadLocale from '@cdo/apps/util/safeLoadLocale';
+module.exports = safeLoadLocale('eval_locale');

--- a/apps/src/fish/locale.js
+++ b/apps/src/fish/locale.js
@@ -1,2 +1,3 @@
 // locale for fish
-module.exports = window.blockly.fish_locale;
+import safeLoadLocale from '@cdo/apps/util/safeLoadLocale';
+module.exports = safeLoadLocale('fish_locale');

--- a/apps/src/flappy/locale.js
+++ b/apps/src/flappy/locale.js
@@ -1,3 +1,4 @@
 // locale for flappy
 
-module.exports = window.blockly.flappy_locale;
+import safeLoadLocale from '@cdo/apps/util/safeLoadLocale';
+module.exports = safeLoadLocale('flappy_locale');

--- a/apps/src/jigsaw/locale.js
+++ b/apps/src/jigsaw/locale.js
@@ -1,3 +1,4 @@
 // locale for jigsaw
 
-module.exports = window.blockly.jigsaw_locale;
+import safeLoadLocale from '@cdo/apps/util/safeLoadLocale';
+module.exports = safeLoadLocale('jigsaw_locale');

--- a/apps/src/maze/locale.js
+++ b/apps/src/maze/locale.js
@@ -1,2 +1,3 @@
 // locale for maze
-module.exports = window.blockly.maze_locale;
+import safeLoadLocale from '@cdo/apps/util/safeLoadLocale';
+module.exports = safeLoadLocale('maze_locale');

--- a/apps/src/netsim/locale-do-not-import.js
+++ b/apps/src/netsim/locale-do-not-import.js
@@ -8,4 +8,5 @@
  */
 // locale for netsim
 
-module.exports = window.blockly.netsim_locale;
+import safeLoadLocale from '@cdo/apps/util/safeLoadLocale';
+module.exports = safeLoadLocale('netsim_locale');

--- a/apps/src/p5lab/gamelab/locale-do-not-import.js
+++ b/apps/src/p5lab/gamelab/locale-do-not-import.js
@@ -7,4 +7,5 @@
  * which is important for making locale setup work seamlessly in tests.
  */
 // locale for gamelab
-module.exports = window.blockly.gamelab_locale;
+import safeLoadLocale from '@cdo/apps/util/safeLoadLocale';
+module.exports = safeLoadLocale('gamelab_locale');

--- a/apps/src/p5lab/spritelab/locale-do-not-import.js
+++ b/apps/src/p5lab/spritelab/locale-do-not-import.js
@@ -1,3 +1,4 @@
 // locale for Spritelab
 
-module.exports = window.blockly.spritelab_locale;
+import safeLoadLocale from '@cdo/apps/util/safeLoadLocale';
+module.exports = safeLoadLocale('spritelab_locale');

--- a/apps/src/studio/locale.js
+++ b/apps/src/studio/locale.js
@@ -1,3 +1,4 @@
 // locale for studio
 
-module.exports = window.blockly.studio_locale;
+import safeLoadLocale from '@cdo/apps/util/safeLoadLocale';
+module.exports = safeLoadLocale('studio_locale');

--- a/apps/src/turtle/locale.js
+++ b/apps/src/turtle/locale.js
@@ -1,2 +1,3 @@
 // locale for turtle
-module.exports = window.blockly.turtle_locale;
+import safeLoadLocale from '@cdo/apps/util/safeLoadLocale';
+module.exports = safeLoadLocale('turtle_locale');

--- a/apps/src/util/locale-do-not-import.js
+++ b/apps/src/util/locale-do-not-import.js
@@ -8,4 +8,5 @@
  */
 
 // base locale
-module.exports = window.blockly.common_locale;
+import safeLoadLocale from '@cdo/apps/util/safeLoadLocale';
+module.exports = safeLoadLocale('common_locale');

--- a/apps/src/util/safeLoadLocale.js
+++ b/apps/src/util/safeLoadLocale.js
@@ -1,0 +1,25 @@
+/**
+ * Helper method for loading the locale from blockly, which will detect if
+ * blockly is not present in the environment and fall back to an empty locale
+ * object.
+ *
+ * @param localeKey {String} The name of the locale on the global blockly
+ *     object. Usually something like "common_locale", "studio_locale",
+ *     "applab_locale", etc.
+ */
+export default function safeLoadLocale(localeKey) {
+  if (window.blockly && window.blockly[localeKey]) {
+    return window.blockly[localeKey];
+  } else {
+    console.warn(
+      'Loading translations can only be done in a context where blockly is ' +
+        'available, but blockly was not found in the global scope. Falling ' +
+        'back on an empty translation object. The page may break due to ' +
+        'missing translations.'
+    );
+
+    // Return an empty object, so i18n methods throw where they are called and
+    // generate more useful stack traces.
+    return {};
+  }
+}

--- a/apps/src/weblab/locale.js
+++ b/apps/src/weblab/locale.js
@@ -1,2 +1,3 @@
 // locale for weblab
-module.exports = window.blockly.weblab_locale;
+import safeLoadLocale from '@cdo/apps/util/safeLoadLocale';
+module.exports = safeLoadLocale('weblab_locale');


### PR DESCRIPTION
Follow-up to https://github.com/code-dot-org/code-dot-org/pull/33670.

Specifically, add a helper method to wrap loading in locales from blockly. This method will take care to detect whether or not blockly is actually loaded in the calling environment, and will give a helpful warning message if it isn't. Thanks @islemaster for prototyping the implementation!

<!--
  Your description goes here: A summary of the change, including any relevant motivation and context.

  If relevant, include a description both of the existing behavior and of the new behavior.
-->

<!--
  Other aspects to consider. uncomment and add detail for any that seem necessary:
-->

<!-- ### Background -->
<!-- ### Privacy -->
<!-- ### Security -->
<!-- ### Caching -->
<!-- ### Deployment strategy -->
<!-- ### Future work -->

## Links

<!--
  Any relevant links to external resources; ie, specification documents, jira
  items, related PRs, honeybadger errors, etc
-->

- [jira](https://codedotorg.atlassian.net/browse/FND-1080)

## Testing story

To recreate the original error from https://github.com/code-dot-org/code-dot-org/pull/33670, I added the following code:

```diff
diff --git a/apps/src/templates/projects/projectConstants.js b/apps/src/templates/projects/projectConstants.js
index 50a45e7ae49..90a040d986c 100644
--- a/apps/src/templates/projects/projectConstants.js
+++ b/apps/src/templates/projects/projectConstants.js
@@ -1,4 +1,7 @@
 import PropTypes from 'prop-types';
+import i18n from '@cdo/locale';
+
+console.log(`i18n.projectTypeAlgebra(): ${i18n.projectTypeAlgebra()}`);
 
 export const projectDataPropType = PropTypes.shape({
   channel: PropTypes.string.isRequired,
```

Loading http://localhost.code.org:3000/educate/regional-partner/playbook then gives the following console output

![image](https://user-images.githubusercontent.com/244100/77952690-e4e7d380-7280-11ea-9d6d-d048440ac504.png)


<!--
  Does your change include appropriate tests?

  If so, please describe how the tests included in this PR are sufficient

  If not, please explain why this change does not need to be tested.
-->

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
