### PR TITLE
Tests: Deflake progress_standards_view.feature

### DIFF
--- a/dashboard/test/ui/features/step_definitions/steps.rb
+++ b/dashboard/test/ui/features/step_definitions/steps.rb
@@ -1240,6 +1240,7 @@ And(/^I get hidden script access$/) do
 end
 
 And(/^I save the section url$/) do
+  wait_short_until {steps 'Then I should see the section table'}
   section_code = @browser.execute_script <<-SCRIPT
     return document
       .querySelector('.uitest-owned-sections tbody tr:last-of-type td:nth-child(6)')


### PR DESCRIPTION
[LP-1332](https://codedotorg.atlassian.net/browse/LP-1332): Wait for the section table to load on the teacher homepage before trying to copy the section code from the first row, during this flaky test.

Investigation into the last ten failures showed this error consistently:

![Screenshot from 2020-03-30 12-38-50](https://user-images.githubusercontent.com/1615761/77955926-dbad3580-7285-11ea-84d2-21e0c846e21a.png)

And the browser looked at this when that error occurred:

![Screenshot from 2020-03-30 12-39-01](https://user-images.githubusercontent.com/1615761/77955943-e4057080-7285-11ea-9cfa-5e64bba6de29.png)

It turns out the section table is loaded asynchronously, and we didn't have an appropriate wait in this test step.

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
