### PR TITLE
Fixed droplet tooltips so they no longer cover blocks

### DIFF
--- a/apps/src/blockTooltips/DropletBlockTooltipManager.js
+++ b/apps/src/blockTooltips/DropletBlockTooltipManager.js
@@ -87,6 +87,13 @@ DropletBlockTooltipManager.prototype.installTooltipsForCurrentCategoryBlocks_ = 
       const hoverDivRect = blockHoverDiv.getBoundingClientRect();
       const toolboxRight = $('.droplet-palette-scroller').width();
       const offsetX = Math.min(hoverDivRect.width, toolboxRight);
+      if (offsetX === 0) {
+        // This happens when we start in design mode and the toolbox hasn't yet
+        // rendered. In this case, skip installing the tooltips. We can try
+        // again when the student switches to code mode and this method is
+        // called again.
+        return;
+      }
 
       // Vertically center the tooltip on the block it belongs to.
       //


### PR DESCRIPTION
On levels where applab starts in design mode, we hit an issue where the toolbox block tooltip would cover an an entire block. This made it difficult to click the block.
![image](https://user-images.githubusercontent.com/8324574/77961789-4151ef80-728f-11ea-8629-ea4ccb1bd64d.png)

This happened because the block and toolbox locations were calculated while in design mode when the two had not yet been created.

This PR fixes this issue by waiting to calculate the tooltip location until the block and toolbox has been rendered.

![image](https://user-images.githubusercontent.com/8324574/77962190-fdabb580-728f-11ea-90f8-731e486fbc26.png)


<!-- ### Background -->
<!-- ### Privacy -->
<!-- ### Security -->
<!-- ### Caching -->
<!-- ### Deployment strategy -->
<!-- ### Future work -->

## Links

<!--
  Any relevant links to external resources; ie, specification documents, jira
  items, related PRs, honeybadger errors, etc
-->

## Testing story

<!--
  Does your change include appropriate tests?

  If so, please describe how the tests included in this PR are sufficient

  If not, please explain why this change does not need to be tested.
-->

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
