### PR TITLE
Simplify legacy applab docs sync

### DIFF
--- a/bin/cron/sync_dropbox
+++ b/bin/cron/sync_dropbox
@@ -14,8 +14,6 @@ exit unless only_one_running?(__FILE__)
 
 FOLDERS = {
   "advocacy.code.org" => "sites.v3/advocacy.code.org",
-  "applab-docs-1" => "sites.v3/code.org/public/applab/docs1",
-  "applab-docs" => "sites.v3/code.org/public/applab/docs",
   "code.org" => "sites.v3/code.org",
   "csedweek.org" => "sites.v3/csedweek.org",
   "curriculum-6-8" => "sites/virtual/curriculum-6-8",
@@ -43,11 +41,6 @@ while (Time.now - SCRIPT_START) < TOTAL_SECONDS
     # 'unison' will sync the two folders. It will return true on success and false on failure.
     # For full details, see unison's man page. Docs are also here: https://www.cis.upenn.edu/~bcpierce/unison/download/releases/stable/unison-manual.html
     command = "unison /home/ubuntu/Dropbox/Shared/#{key} /home/ubuntu/staging/pegasus/#{value} -silent -ignore \"Name .dropbox\" -auto -perms 0 -dontchmod"
-    if key == "code.org"
-      # The applab-docs and applab-docs-1 folders on dropbox are synced separately even though
-      # they are sub-paths of the code.org folder on git.
-      command << " -ignore \"Path */public/applab/docs\" -ignore \"Path */public/applab/docs1\""
-    end
     stdout, stderr, _ = Open3.capture3(command)
     if stdout != "" || stderr != ""
       error_message = "#{error_message}Dropbox directory: #{key}. staging directory: #{value}. \n#{stdout}#{stderr}\n"


### PR DESCRIPTION
## Description

Applab docs get special treatment in our sync between Dropbox and pegasus -- after discussion with a curriculum writer (GT), curriculum builder experts (Dani and Dave), it appears that these docs are only used in a few legacy places, and are not edited on Dropbox.

As a result, this PR simplifies our sync process to no longer give Applab docs special treatment. Dani also opened [a ticket](https://codedotorg.atlassian.net/browse/PLAT-62) for the team to look into removing these docs entirely.

More to come on cleaning up the Dropbox sync script, but wanted to get this out on it's own for consideration.

## Testing story

- Given that (I think) a change in the dropbox `Code.org/public/applab/docs` folder could be made currently without being synced to pegasus (because of the ignore in the current code I am deleting), I did download `applab-docs` and `applab-docs-v1` folders from dropbox, and diffed them against `Code.org/public/applab/docs` and `Code.org/public/applab/docs1` and saw no difference.
- **I did not** do any testing of this change on staging -- up for input on whether I should do so.