### PR TITLE
Update congrats page constants for 2020

### DIFF
--- a/lib/cdo/script_constants.rb
+++ b/lib/cdo/script_constants.rb
@@ -340,7 +340,8 @@ module ScriptConstants
       ScriptConstants.script_in_category?(:csf_international, script) ||
       ScriptConstants.script_in_category?(:csf, script) ||
       ScriptConstants.script_in_category?(:csf_2018, script) ||
-      ScriptConstants.script_in_category?(:csf_2019, script)
+      ScriptConstants.script_in_category?(:csf_2019, script) ||
+      ScriptConstants.script_in_category?(:csf_2020, script)
   end
 
   def self.i18n?(script)

--- a/pegasus/sites.v3/code.org/views/csf_congrats.haml
+++ b/pegasus/sites.v3/code.org/views/csf_congrats.haml
@@ -46,6 +46,15 @@
     ScriptConstants::COURSEE_2019_NAME => ScriptConstants::COURSEF_2019_NAME,
     ScriptConstants::COURSEF_2019_NAME => "applab",
     ScriptConstants::EXPRESS_2019_NAME => "applab",
+
+    ScriptConstants::COURSEA_2020_NAME => ScriptConstants::COURSEB_2020_NAME,
+    ScriptConstants::COURSEB_2020_NAME => ScriptConstants::COURSEC_2020_NAME,
+    ScriptConstants::COURSEC_2020_NAME => ScriptConstants::COURSED_2020_NAME,
+    ScriptConstants::COURSED_2020_NAME => ScriptConstants::COURSEE_2020_NAME,
+    ScriptConstants::COURSEE_2020_NAME => ScriptConstants::COURSEF_2020_NAME,
+    ScriptConstants::COURSEF_2020_NAME => "applab",
+    ScriptConstants::EXPRESS_2020_NAME => "applab",
+    ScriptConstants::PRE_READER_EXPRESS_2020_NAME => ScriptConstants::COURSEC_2020_NAME
   }
 
   rec_third_party = {
@@ -82,6 +91,15 @@
     ScriptConstants::COURSED_2019_NAME => "csf_next",
     ScriptConstants::COURSEE_2019_NAME => "csf_next",
     ScriptConstants::COURSEF_2019_NAME => "csf_next",
+
+    ScriptConstants::COURSEA_2020_NAME => "csf_next",
+    ScriptConstants::COURSEB_2020_NAME => "csf_next",
+    ScriptConstants::COURSEC_2020_NAME => "csf_next",
+    ScriptConstants::COURSED_2020_NAME => "csf_next",
+    ScriptConstants::COURSEE_2020_NAME => "csf_next",
+    ScriptConstants::COURSEF_2020_NAME => "csf_next",
+    ScriptConstants::EXPRESS_2020_NAME => "csf_next",
+    ScriptConstants::PRE_READER_EXPRESS_2020_NAME => "csf_next"
   }
 
 #congrats.mobile-pad{:style=>'margin: 0 auto;'}


### PR DESCRIPTION
Same changes as https://github.com/code-dot-org/code-dot-org/pull/28779/files for 2020  (except `CATEGORIES` had already been updated.)

I've added names for course A-F, express, and pre-reader express 2020 to the i18n gsheet: https://docs.google.com/spreadsheets/d/1Tq7VqZALgRA0wYk0HDfEOTyRI0TM2Dir2rloXIPGCgU/edit#gid=0 (search for `coursea-2020_name`)

<!--
  Other aspects to consider. uncomment and add detail for any that seem necessary:
-->

<!-- ### Background -->
<!-- ### Privacy -->
<!-- ### Security -->
<!-- ### Caching -->
<!-- ### Deployment strategy -->
<!-- ### Future work -->

## Links

<!--
  Any relevant links to external resources; ie, specification documents, jira
  items, related PRs, honeybadger errors, etc
-->

- [jira](https://codedotorg.atlassian.net/browse/LP-1324)

## Testing story

`congrats/coursea-2020` page works locally after changes (except for missing translations, but those should get scooped soon.)

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
