### PR TITLE
Revert "Update pegasus templates to use markdown versions of HTML strings"

### DIFF
--- a/pegasus/sites.v3/code.org/public/athletes.haml
+++ b/pegasus/sites.v3/code.org/public/athletes.haml
@@ -80,8 +80,8 @@ video_player: true
 
   .video-smalltext
     %ul
-      %li!= I18n.t(:videos_more_markdown, inspiring_videos_playlist: 'https://www.youtube.com/playlist?list=PLzdnOPI1iJNfpD8i4Sx7U0y2MccnrNZuP', markdown: :inline)
-      %li!= I18n.t(:careers_page_more_markdown, careers_url: CDO.code_org_url('/careers'), markdown: :inline)
+      %li!= I18n.t(:videos_more, inspiring_videos_playlist: 'https://www.youtube.com/playlist?list=PLzdnOPI1iJNfpD8i4Sx7U0y2MccnrNZuP')
+      %li!= I18n.t(:careers_page_more, careers_url: CDO.code_org_url('/careers'))
 
 %div#featured-athletes
   %h2= I18n.t(:sports_athletes_title)

--- a/pegasus/sites.v3/code.org/public/certificates.haml
+++ b/pegasus/sites.v3/code.org/public/certificates.haml
@@ -17,10 +17,9 @@ theme: responsive
   %div{:style=>"float: left; width: 360px; margin-top: 20px;"}<
     != I18n.t(:enter_certificate_names, script_name: script_name, markdown: true)
   %p{:style=>"float: left; width: 360px; margin-top: 20px;"}<
-    = I18n.t :want_a_blank_certificate_template
     -# We need a space after want_a_blank_certificate_template as these sentences are translated separately
     -# but appear on the same line.
-    != " "
+    != "#{I18n.t :want_a_blank_certificate_template} "
     %a{href: "/images/#{certificate_template_for(script)}", target: '_blank'}=I18n.t :print_one_here_certificates
 %br
 %form{:method=>"post", :action=>'/printcertificates'}

--- a/pegasus/sites.v3/code.org/public/css/common.css
+++ b/pegasus/sites.v3/code.org/public/css/common.css
@@ -639,7 +639,7 @@ button {
   font-weight: bold;
   margin: 1em 0;
 }
-.form-required-field, .form-required-em em {
+.form-required-field {
   color: #f00;
 }
 

--- a/pegasus/sites.v3/code.org/public/css/dance-landing/dance.css
+++ b/pegasus/sites.v3/code.org/public/css/dance-landing/dance.css
@@ -281,11 +281,6 @@ a:hover {
   color: rgb(89, 202, 211);
 }
 
-.highlight-strong strong  {
-  font-family: 'Gotham 5r', sans-serif;
-  color: rgb(89, 202, 211);
-}
-
 .new-announcement-tablet {
   position: absolute;
   bottom: 10%;

--- a/pegasus/sites.v3/code.org/public/hourofcode/overview.haml
+++ b/pegasus/sites.v3/code.org/public/hourofcode/overview.haml
@@ -26,7 +26,7 @@ social:
 
 %h1= I18n.t(:hoc_overview_title)
 
-!= I18n.t(:hoc_overview_subtitle_markdown, markdown: true)
+!= I18n.t(:hoc_overview_subtitle)
 
 - if request.language == 'en'
   %br/

--- a/pegasus/sites.v3/code.org/public/learn/index.haml
+++ b/pegasus/sites.v3/code.org/public/learn/index.haml
@@ -93,10 +93,10 @@ style_min: false
       .bannerHeading= hoc_s(:learn_banner_heading)
       = hoc_s(:learn_banner_blurb)
       .bannerBeyond
-        != hoc_s(:learn_banner_beyond_markdown, markdown: true, locals: {url: "https://hourofcode.com/beyond"})
+        != hoc_s(:learn_banner_beyond)
       .bannerTeachers
         %img.bannerTeacherIcon{src: "/images/learn/teacher_icon.png"}
-        != hoc_s(:learn_banner_teachers_markdown, markdown: :inline, locals: {host_url: "https://hourofcode.com/#join", howto_url: "https://hourofcode.com/how-to"})
+        != hoc_s(:learn_banner_teachers)
     #studentImage.col-50.tablet-feature
 
   .clear{style: "clear:both"}
@@ -145,18 +145,15 @@ style_min: false
       img.fadeTo('normal', 1);
     });
 
-    // Open banner links in new tab; we render them with markdown, so we can't do this in the haml
-    // Add the rel tag to attempt to mitigate the inherent danger in opening
-    // links in a new tab; will only work for modern browsers, though.
-    $(".banner a").attr({target: "_blank", rel: "noopener noreferrer nofollow"});
+    // Set up beyond hyperlink.
+    $("#learn_banner_beyond").attr({href: "https://hourofcode.com/beyond", target: "_blank"});
 
-    // Set up google analytics tracking
-    $('.bannerTeachers a[href$="join"]').click(function () {
+    // Set up teacher hyperlinks.
+    $("#teacher_banner_host").attr({href: "https://hourofcode.com/#join", target: "_blank"}).click(function () {
       ga('send', 'event', 'learn', 'click', 'teacher_banner_host');
     });
-    $('.bannerTeachers a[href$="how-to"]').click(function () {
+    $("#teacher_banner_howto").attr({href: "https://hourofcode.com/how-to", target: "_blank"}).click(function() {
       ga('send', 'event', 'learn', 'click', 'teacher_banner_howto');
     });
-
     $(".bannerTeachers").fadeTo('slow', 1);
   });

--- a/pegasus/sites.v3/code.org/public/lesson_plans.haml
+++ b/pegasus/sites.v3/code.org/public/lesson_plans.haml
@@ -22,7 +22,7 @@ theme: responsive
     %a{href: CDO.code_org_url('/curriculum/docs/k-5/complete.pdf'), target: '_blank'}
       = I18n.t :dashboard_view_all_lesson_plans
   %p
-    != I18n.t :dashboard_unplugged_markdown, unplugged_url: CDO.code_org_url('/curriculum/unplugged'), markdown: true
+    != I18n.t :dashboard_unplugged, unplugged_url: CDO.code_org_url('/curriculum/unplugged')
 
   %h2= I18n.t :dashboard_curriculum_middle_title
   %p

--- a/pegasus/sites.v3/code.org/public/oceans.haml
+++ b/pegasus/sites.v3/code.org/public/oceans.haml
@@ -94,7 +94,7 @@ theme: responsive
 
   %div{style: "clear: both; margin-top: 10px;"}
 
-  %h3.blurb!= hoc_s(:oceans_landing_explanation_markdown, markdown: true)
+  %h3.blurb!= hoc_s(:oceans_landing_explanation)
 
   = view :resource_boxes, resources: resources
 
@@ -129,8 +129,8 @@ theme: responsive
   #behind-the-scenes
     %h2= hoc_s(:oceans_behind_the_scenes)
 
-    %h3!= hoc_s(:oceans_behind_the_scenes_1_markdown, markdown: :inline)
+    %h3!= hoc_s(:oceans_behind_the_scenes_1)
 
-    %h3!= hoc_s(:oceans_behind_the_scenes_2_markdown, markdown: :inline)
+    %h3!= hoc_s(:oceans_behind_the_scenes_2)
 
 .clear

--- a/pegasus/sites.v3/code.org/views/congrats_certificate.haml
+++ b/pegasus/sites.v3/code.org/views/congrats_certificate.haml
@@ -103,10 +103,10 @@
     %h2{:style=>'margin-top: 0px; margin-bottom: .5em;'}=I18n.t :thanks_for_submitting
 
     %p
-      !=I18n.t :get_a_certificate_message_after_markdown, markdown: true
+      !=I18n.t :get_a_certificate_message_after
 
   #certificate_disable{:style=>'display: none'}
     %h2{:style=>'margin-top: 0px; margin-bottom: .5em;'}=I18n.t :congratulations
 
     %p
-      !=I18n.t :beyond_hour_message_markdown, markdown: true
+      !=I18n.t :beyond_hour_message

--- a/pegasus/sites.v3/code.org/views/dance_sponsor_logo.haml
+++ b/pegasus/sites.v3/code.org/views/dance_sponsor_logo.haml
@@ -6,4 +6,4 @@
     %img{src:"/images/fit-250/AFE-dark-logo.png"}
 
 .sponsor-subtext-description
-  != I18n.t(:hoc2018_dance_amazon_sponsor_section_with_logo_description_with_link_markdown, markdown: true, amazon_future_engineer_link: 'https://www.amazonfutureengineer.com')
+  != I18n.t(:hoc2018_dance_amazon_sponsor_section_with_logo_description_with_link, amazon_future_engineer_link: 'https://www.amazonfutureengineer.com')

--- a/pegasus/sites.v3/code.org/views/dance_tutorial_section.haml
+++ b/pegasus/sites.v3/code.org/views/dance_tutorial_section.haml
@@ -9,12 +9,12 @@
     %img.img-dance-stars.desktop-only{src: "/images/fit-300x300/homepage/hoc2019_dance_stars_mobile.png"}
     %img.img-dance-stars.tablet-only{src: "/images/fit-520/homepage/hoc2019_dance_stars.png"}
     %img.img-dance-stars.mobile-only{src: "/images/fit-300x300/homepage/hoc2019_dance_stars_mobile.png"}
-    .new-announcement.desktop-only.highlight-strong
-      != hoc_s(:codeorg_homepage_hoc2019_dance_heading_markdown, markdown: true)
-    .new-announcement-tablet.tablet-only.highlight-strong
-      != hoc_s(:codeorg_homepage_hoc2019_dance_heading_markdown, markdown: true)
-    .new-announcement-mobile.mobile-only.highlight-strong
-      != hoc_s(:codeorg_homepage_hoc2019_dance_heading_markdown, markdown: true)
+    .new-announcement.desktop-only
+      != hoc_s(:codeorg_homepage_hoc2019_dance_heading)
+    .new-announcement-tablet.tablet-only
+      != hoc_s(:codeorg_homepage_hoc2019_dance_heading)
+    .new-announcement-mobile.mobile-only
+      != hoc_s(:codeorg_homepage_hoc2019_dance_heading)
 
   .col-25.specific-tutorial.right-tutorial.dance-tutorial
     .tutorial-box

--- a/pegasus/sites.v3/code.org/views/index_hoc.haml
+++ b/pegasus/sites.v3/code.org/views/index_hoc.haml
@@ -1,6 +1,5 @@
 .lines_of_code_header{style: "background-color: #d43f3a"}
-  %a{href: "/csteacher", style: "color: white; text-decoration: none; font-weight: 400"}
-    =I18n.t(:csedweek_banner_teachers_text)
+  !=I18n.t(:csedweek_banner_teachers)
 %br/
 
 :css

--- a/pegasus/sites.v3/code.org/views/inspirational_videos.haml
+++ b/pegasus/sites.v3/code.org/views/inspirational_videos.haml
@@ -21,5 +21,5 @@
 
 .video-smalltext
   %ul
-    %li!= I18n.t(:videos_more_markdown, inspiring_videos_playlist: 'https://www.youtube.com/playlist?list=PLzdnOPI1iJNfpD8i4Sx7U0y2MccnrNZuP', markdown: :inline)
-    %li!= I18n.t(:careers_page_more_markdown, careers_url: CDO.code_org_url('/careers'), markdown: :inline)
+    %li!= I18n.t(:videos_more, inspiring_videos_playlist: 'https://www.youtube.com/playlist?list=PLzdnOPI1iJNfpD8i4Sx7U0y2MccnrNZuP')
+    %li!= I18n.t(:careers_page_more, careers_url: CDO.code_org_url('/careers'))

--- a/pegasus/sites.v3/code.org/views/petition_expand.haml
+++ b/pegasus/sites.v3/code.org/views/petition_expand.haml
@@ -62,8 +62,7 @@
             = I18n.t :homepage_diversity_pledge
         %button{onclick: "expandPetition();", style: "margin-top: 0px; margin-bottom:5px"}
           -if request.language  == 'en'
-            = I18n.t :homepage_signpetition_dropdown_text
-            != "&#x25BE;"
+            != I18n.t :homepage_signpetition_dropdown
           -else
             = I18n.t :hoc2014_support
         -# Temp: English only until we have translations.

--- a/pegasus/sites.v3/code.org/views/testimonials.haml
+++ b/pegasus/sites.v3/code.org/views/testimonials.haml
@@ -3,14 +3,14 @@
   .col-33{style: "text-align:center; margin-top: 20px;"}
     %img{src: "/images/stats-kid1.jpg", style: "width: 70%"}
     %br/
-    !=I18n.t :stats_nina_markdown, markdown: true
+    !=I18n.t :stats_nina
 
   .col-33{style: "text-align:center; margin-top: 20px;"}
     %img{src: "/images/stats-kid2.jpg", style: "width: 70%"}
     %br/
-    !=I18n.t :stats_student_markdown, markdown: true
+    !=I18n.t :stats_student
 
   .col-33{style: "text-align:center; margin-top: 20px;"}
     %img{src: "/images/stats-kid3.jpg", style: "width: 70%"}
     %br/
-    !=I18n.t :stats_michael_markdown, markdown: true
+    !=I18n.t :stats_michael

--- a/pegasus/sites.v3/code.org/views/try_hoc_count.haml
+++ b/pegasus/sites.v3/code.org/views/try_hoc_count.haml
@@ -1,5 +1,5 @@
 .count{:style=>"font-size: 42px; line-height: 42px; font-family: 'Gotham 5r', sans-serif;"}
-  -count_string = I18n.t(:try_hoc_num_served_markdown, markdown: true, num: format_integer_with_commas(fetch_hoc_metrics['started']))
+  -count_string = I18n.t(:n_have_learned_an_hoc).gsub("#", format_integer_with_commas(fetch_hoc_metrics['started']).to_s)
   -if request.locale == 'en-US'
     %a{:href=>'/leaderboards', :style=>'text-decoration:none'}
       != count_string

--- a/pegasus/sites.v3/code.org/views/volunteer_engineer_form.haml
+++ b/pegasus/sites.v3/code.org/views/volunteer_engineer_form.haml
@@ -130,7 +130,7 @@
 
 #volunteer-engineer-thanks{:style=>"display: none;"}
   .alert.alert-success{role:"alert"}
-    %p!= I18n.t(:volunteer_engineer_submission_thankyou, url: '/volunteer/local', markdown: :inline)
+    %p!= I18n.t(:volunteer_engineer_submission_thankyou, url: '/volunteer/local')
   - if !form.secret
     #edit-information
       You can update your volunteer information or email subscription preferences anytime

--- a/pegasus/sites.v3/code.org/views/volunteer_engineer_form_intro.haml
+++ b/pegasus/sites.v3/code.org/views/volunteer_engineer_form_intro.haml
@@ -1,7 +1,7 @@
 %h1= I18n.t(:volunteer_engineer_submission_title)
 %p
-  != I18n.t(:volunteer_engineer_submission_intro_recruit_markdown, markdown: :inline)
-  != I18n.t(:volunteer_engineer_submission_intro_guide_markdown, markdown: :inline, volunteer_guide: '/volunteer/guide')
-%p!= I18n.t(:volunteer_engineer_submission_intro_links_markdown, markdown: :inline, learn_more: 'https://hourofcode.com', volunteer_local: '/volunteer/local')
+  != I18n.t(:volunteer_engineer_submission_intro_recruit)
+  != I18n.t(:volunteer_engineer_submission_intro_guide, volunteer_guide: '/volunteer/guide')
+%p!= I18n.t(:volunteer_engineer_submission_intro_links, learn_more: 'https://hourofcode.com', volunteer_local: '/volunteer/local')
 %img{src: "/images/fill-300x150/homepage/kids3_2x.jpg", style: "margin: 10px 0 20px 0; max-width: 100%;"}
-%p.form-required-em!= I18n.t(:volunteer_engineer_submission_intro_signup_markdown, markdown: :inline)
+%p!= I18n.t(:volunteer_engineer_submission_intro_signup)

--- a/pegasus/sites.v3/hourofcode.com/public/index.haml
+++ b/pegasus/sites.v3/hourofcode.com/public/index.haml
@@ -122,11 +122,11 @@ social:
       -# Show a picture of the map unless it is currently the week of HOC.
       -if hoc_mode != "actual-hoc"
         = view :hoc_events_map
-        .footnote!=hoc_s(:map_warning_markdown, markdown: true, locals: {events_url: resolve_url('/events')})
+        .footnote!=hoc_s(:map_warning).gsub(/%{events_url}/, resolve_url('/events'))
       -else
         %a{href: resolve_url('/map')}
           %img{src: '/images/fit-1000/map.jpg', style: 'width: 100%;'}
-        .footnote!=hoc_s(:map_warning_markdown, markdown: true, locals: {events_url: resolve_url('/events')})
+        .footnote!=hoc_s(:map_warning).gsub(/%{events_url}/, resolve_url('/events'))
 
   -# Signup and Highlights
 
@@ -161,9 +161,9 @@ social:
       -if @language == "en"
         %p=hoc_s(:stats_females)
         %img{src: "/images/fit-300/stats-females.jpg", style: "width: 100%;"}
-        %p!=hoc_s(:stats_females_more_markdown, markdown: true)
+        %p!=hoc_s(:stats_females_more)
       -else
-        %p=hoc_s(:stats_girls_more)
+        %p!=hoc_s(:stats_girls_more)
         %img{src: "/images/fit-300/stats-info3.jpg", style: "width: 100%;"}
 
   -# FAQ

--- a/pegasus/sites.v3/hourofcode.com/public/learn/index.haml
+++ b/pegasus/sites.v3/hourofcode.com/public/learn/index.haml
@@ -83,10 +83,10 @@ social:
       .bannerHeading= hoc_s(:learn_banner_heading)
       = hoc_s(:learn_banner_blurb)
       .bannerBeyond
-        != hoc_s(:learn_banner_beyond_markdown, markdown: true, locals: {url: "https://hourofcode.com/beyond"})
+        != hoc_s(:learn_banner_beyond)
       .bannerTeachers
         %img.bannerTeacherIcon{src: "/images/learn/teacher_icon.png"}
-        != hoc_s(:learn_banner_teachers_markdown, markdown: :inline, locals: {host_url: "https://hourofcode.com/#join", howto_url: "https://hourofcode.com/how-to"})
+        != hoc_s(:learn_banner_teachers)
     #studentImage.hidden-xs.col-sm-12.col-md-6
 
 -# Not ideal but we can pull the undigested files from /blockly.
@@ -139,18 +139,15 @@ social:
       img.fadeTo('normal', 1);
     });
 
-    // Open banner links in new tab; we render them with markdown, so we can't do this in the haml
-    // Add the rel tag to attempt to mitigate the inherent danger in opening
-    // links in a new tab; will only work for modern browsers, though.
-    $(".banner a").attr({target: "_blank", rel: "noopener noreferrer nofollow"});
+    // Set up beyond hyperlink.
+    $("#learn_banner_beyond").attr({href: "#{resolve_url('/beyond')}", target: "_blank"});
 
-    // Set up google analytics tracking
-    $('.bannerTeachers a[href$="join"]').click(function () {
+    // Set up teacher hyperlinks.
+    $("#teacher_banner_host").attr({href: "https://hourofcode.com/#join", target: "_blank"}).click(function () {
       ga('send', 'event', 'learn', 'click', 'teacher_banner_host');
     });
-    $('.bannerTeachers a[href$="how-to"]').click(function () {
+    $("#teacher_banner_howto").attr({href: "https://hourofcode.com/how-to", target: "_blank"}).click(function() {
       ga('send', 'event', 'learn', 'click', 'teacher_banner_howto');
     });
-
     $(".bannerTeachers").fadeTo('slow', 1);
   });

--- a/pegasus/sites.v3/hourofcode.com/public/map.haml
+++ b/pegasus/sites.v3/hourofcode.com/public/map.haml
@@ -10,4 +10,4 @@ layout: wide_index
   = view :header
 %h2.center-text= view :hoc_events_counter
 = view :hoc_events_map
-.footnote!=hoc_s(:map_warning_markdown, markdown: true, locals:{events_url: resolve_url('/events')})
+.footnote!=hoc_s(:map_warning).gsub(/%{events_url}/, resolve_url('/events'))

--- a/pegasus/sites.v3/hourofcode.com/views/faq.haml
+++ b/pegasus/sites.v3/hourofcode.com/views/faq.haml
@@ -1,7 +1,7 @@
 %h1= hoc_s(:hoc_faq_title)
 
 %h2#about= hoc_s(:hoc_faq_what_is_hoc_q)
-%div!= hoc_s(:hoc_faq_what_is_hoc_a_markdown, markdown: true, locals: {tutorials: resolve_url('/learn'), partners: resolve_url('/partners')})
+%div!= hoc_s(:hoc_faq_what_is_hoc_a).gsub(/%{tutorials}/, resolve_url('/learn')).gsub(/%{partners}/, resolve_url('/partners'))
 
 -# Hide signup buttons during Hour of Code
   %br/
@@ -10,54 +10,54 @@
     =hoc_s(:signup_host_an_hour)
 
 %h2= hoc_s(:hoc_faq_when_is_hoc_q)
-%div!= hoc_s(:hoc_faq_when_is_hoc_a_markdown, markdown: true, locals: {csedweek_url: 'https://csedweek.org', campaign_date_year: campaign_date('year'), campaign_date_full: campaign_date('full'), grace_hopper: 'http://en.wikipedia.org/wiki/Grace_Hopper'})
+%div!= hoc_s(:hoc_faq_when_is_hoc_a).gsub(/%{csedweek_url}/, 'https://csedweek.org').gsub(/%{campaign_date_year}/, campaign_date('year')).gsub(/%{campaign_date_full}/, campaign_date('full')).gsub(/%{grace_hopper}/, 'http://en.wikipedia.org/wiki/Grace_Hopper')
 
 %h2= hoc_s(:hoc_faq_why_cs_q)
-%div!= hoc_s(:hoc_faq_why_cs_a_markdown, markdown: true, locals: {stats_url: resolve_url('/promote/stats')})
+%div!= hoc_s(:hoc_faq_why_cs_a).gsub(/%{stats_url}/, resolve_url('/promote/stats'))
 
 %h2= hoc_s(:hoc_faq_how_participate_q)
-%div!= hoc_s(:hoc_faq_how_participate_a_markdown, markdown: true, locals: {howto: resolve_url('/how-to'), campaign_date: campaign_date('start-short')})
+%div!= hoc_s(:hoc_faq_how_participate_a).gsub('/how-to', resolve_url('/how-to')).gsub(/%{campaign_date}/, campaign_date('start-short'))
 
 %h2= hoc_s(:hoc_faq_behind_hoc_q)
-%div!= hoc_s(:hoc_faq_behind_hoc_a_markdown, markdown: true, locals: {partner_url: resolve_url('/partners')})
+%div!= hoc_s(:hoc_faq_behind_hoc_a).gsub(/%{partner_url}/, resolve_url('/partners'))
 
 %h2= hoc_s(:hoc_faq_host_q)
-%div!= hoc_s(:hoc_faq_host_a_markdown, markdown: true, locals: {howto: resolve_url('/how-to'), codeorg_url: codeorg_url('/')})
+%div!= hoc_s(:hoc_faq_host_a).gsub('/how-to', resolve_url('/how-to')).gsub(/%{codeorg_url}\/?/, codeorg_url('/'))
 
 %h2= hoc_s(:hoc_faq_devices_q)
-%div!= hoc_s(:hoc_faq_devices_a_markdown, markdown: true, locals: {codeorg_url: codeorg_url('/'), partner_url: 'code.org', unplugged_url: codeorg_url('/curriculum/unplugged')})
+%div!= hoc_s(:hoc_faq_devices_a).gsub(/%{codeorg_url}\/?/, codeorg_url('/')).gsub(/%{partner_url}/, 'code.org').gsub(/%{unplugged_url}\/?/, codeorg_url('/curriculum/unplugged'))
 
 %h2= hoc_s(:hoc_faq_need_computers_q)
-%div!= hoc_s(:hoc_faq_need_computers_a_markdown, markdown: true, locals: {codeorg_url: codeorg_url('/'), pair_programming_research: 'http://www.ncwit.org/resources/pair-programming-box-power-collaborative-learning', pair_programming_video: 'https://www.youtube.com/watch?v=vgkahOzFH2Q', unplugged_url: codeorg_url('/curriculum/unplugged')})
+%div!= hoc_s(:hoc_faq_need_computers_a).gsub(/%{codeorg_url}\/?/, codeorg_url('/')).gsub(/%{pair_programming_research}/, 'http://www.ncwit.org/resources/pair-programming-box-power-collaborative-learning').gsub(/%{pair_programming_video}/, 'https://www.youtube.com/watch?v=vgkahOzFH2Q').gsub(/%{unplugged_url}\/?/, codeorg_url('/curriculum/unplugged'))
 
 -if @country == 'us'
   %h2= hoc_s(:hoc_faq_logo_q)
-  %div!= hoc_s(:hoc_faq_logo_a_markdown, markdown: true, locals: {logo_url: "https://support.code.org/hc/en-us/articles/202518403"})
+  %div!= hoc_s(:hoc_faq_logo_a).gsub(/%{logo_url}/, "https://support.code.org/hc/en-us/articles/202518403")
 
 -if @country != 'us'
   %h2= hoc_s(:hoc_faq_international_q).gsub(/<country>/, HOC_COUNTRIES[@country]['full_name'])
-  %div!= hoc_s(:hoc_faq_international_a_markdown, markdown: true, locals: {promote: resolve_url('/promote')})
+  %div!= hoc_s(:hoc_faq_international_a).gsub('/promote', resolve_url('/promote'))
 
 %h2= hoc_s(:hoc_faq_tutorial_q)
-%div!= hoc_s(:hoc_faq_tutorial_a_markdown, markdown: true, locals: {tutorial_guidelines: resolve_url('/tutorial-guidelines')})
+%div!= hoc_s(:hoc_faq_tutorial_a).gsub('/tutorial-guidelines', resolve_url('/tutorial-guidelines'))
 
 %h2= hoc_s(:hoc_faq_account_q)
-%div!= hoc_s(:hoc_faq_account_a_markdown, markdown: true, locals: {codeorg_url: codeorg_url('/')})
+%div!= hoc_s(:hoc_faq_account_a).gsub(/%{codeorg_url}\/?/, codeorg_url('/'))
 
 %h2= hoc_s(:hoc_faq_certificates_q)
-%div!= hoc_s(:hoc_faq_certificates_a_markdown, markdown: true, locals: {codeorg_url: codeorg_url('/')})
+%div!= hoc_s(:hoc_faq_certificates_a).gsub(/%{codeorg_url}\/?/, codeorg_url('/'))
 
 %h2= hoc_s(:hoc_faq_high_school_q)
-%div!= hoc_s(:hoc_faq_high_school_a_markdown, markdown: true, locals: {codeorg_url: codeorg_url('/'), partner_url: 'code.org'})
+%div!= hoc_s(:hoc_faq_high_school_a).gsub(/%{codeorg_url}\/?/, codeorg_url('/')).gsub(/%{partner_url}/, 'code.org')
 
 %h2= hoc_s(:hoc_faq_count_hoc_q)
-%div!= hoc_s(:hoc_faq_count_hoc_a_markdown, markdown: true, locals: {codeorg_url: codeorg_url('/')})
+%div!= hoc_s(:hoc_faq_count_hoc_a).gsub(/%{codeorg_url}\/?/, codeorg_url('/'))
 
 %h2= hoc_s(:hoc_faq_map_q)
-%div!= hoc_s(:hoc_faq_map_a_markdown, markdown: true, locals: {events_url: resolve_url('/events')})
+%div!= hoc_s(:hoc_faq_map_a).gsub(/%{events_url}/, resolve_url('/events'))
 
 %h2= hoc_s(:hoc_faq_one_hour_q)
 %div!= hoc_s(:hoc_faq_one_hour_a)
 
 %h2= hoc_s(:hoc_faq_keep_learning_q)
-%div!= hoc_s(:hoc_faq_keep_learning_a_markdown, markdown: true, locals: {promote: resolve_url('/promote')})
+%div!= hoc_s(:hoc_faq_keep_learning_a).gsub('/promote', resolve_url('/promote'))

--- a/pegasus/sites.v3/hourofcode.com/views/home_signup.haml
+++ b/pegasus/sites.v3/hourofcode.com/views/home_signup.haml
@@ -4,7 +4,7 @@
   %h1#join-us-header=hoc_s(:front_join_us_button)
   -if ["post-hoc", false].include?(hoc_mode)
     #signup-closed
-      !=hoc_s(:signup_registration_not_required_markdown, markdown: true, locals: {hoc_activities_url: resolve_url('/learn'), howto_guide_url: resolve_url('/how-to')})
+      !=hoc_s(:signup_registration_not_required).gsub(/%{hoc_activities_url}/, resolve_url('/learn')).gsub(/%{howto_guide_url}/, resolve_url('/how-to'))
       =hoc_s(:signup_registration_closed)
     =view :index_video
   -else

--- a/pegasus/sites.v3/hourofcode.com/views/share_buttons.haml
+++ b/pegasus/sites.v3/hourofcode.com/views/share_buttons.haml
@@ -2,11 +2,11 @@
   %a.window-popup{:href=>"https://www.facebook.com/sharer/sharer.php?#{facebook.to_query}"}<
     %button.button-color-share.share-button-facebook<
       %i{:class=>"fa fa-facebook"}<
-      =hoc_s(:share_on_facebook)
+      !=hoc_s(:share_on_facebook)
   %a.window-popup{:href=>"https://twitter.com/share?#{twitter.to_query}"}<
     %button.button-color-share.share-button-twitter<
       %i{:class=>"fa fa-twitter"}<
-      =hoc_s(:share_on_twitter)
+      !=hoc_s(:share_on_twitter)
   -download_url ||= nil
   -unless download_url.nil_or_empty?
     %a.desktop-feature{:href=>download_url, :style=>'padding-left:10px'}


### PR DESCRIPTION
Reverts code-dot-org/code-dot-org#33567

The "try_hoc_num_served_markdown" string is rendering with escaped newlines; likely an issue with syncing the string from gsheets.

![image](https://user-images.githubusercontent.com/244100/77965084-271b1000-7295-11ea-9b38-c9024807282c.png)
