### PR TITLE
Updating user model to support parent email notifications

### DIFF
--- a/dashboard/app/models/user.rb
+++ b/dashboard/app/models/user.rb
@@ -209,6 +209,8 @@ class User < ActiveRecord::Base
 
   after_save :save_email_preference, if: -> {email_preference_opt_in.present?}
 
+  after_save :save_parent_email_preference, if: -> {parent_email_preference_opt_in.present?}
+
   before_destroy :soft_delete_channels
 
   def save_email_preference
@@ -219,6 +221,19 @@ class User < ActiveRecord::Base
         ip_address: email_preference_request_ip,
         source: email_preference_source,
         form_kind: email_preference_form_kind,
+      )
+    end
+  end
+
+  # Enables/disables email notifications for the parent.
+  def save_parent_email_preference
+    if student? && parent_email.present?
+      EmailPreference.upsert!(
+        email: parent_email,
+        opt_in: parent_email_preference_opt_in.downcase == "yes",
+        ip_address: parent_email_preference_request_ip,
+        source: parent_email_preference_source,
+        form_kind: nil
       )
     end
   end
@@ -366,6 +381,10 @@ class User < ActiveRecord::Base
   attr_accessor :email_preference_request_ip
   attr_accessor :email_preference_source
   attr_accessor :email_preference_form_kind
+
+  attr_accessor :parent_email_preference_opt_in
+  attr_accessor :parent_email_preference_request_ip
+  attr_accessor :parent_email_preference_source
 
   attr_accessor :data_transfer_agreement_required
 

--- a/dashboard/test/models/user_test.rb
+++ b/dashboard/test/models/user_test.rb
@@ -29,6 +29,12 @@ class UserTest < ActiveSupport::TestCase
       provider: AuthenticationOption::GOOGLE,
       uid: '110879982140384463192',
     }
+    @good_parent_email_params = {
+      parent_email: 'parent@email.com',
+      parent_email_preference_opt_in: 'yes',
+      parent_email_preference_request_ip: '127.0.0.1',
+      parent_email_preference_source: EmailPreference::ACCOUNT_SIGN_UP
+    }
     @admin = create :admin
     @user = create :user
     @teacher = create :teacher
@@ -2197,6 +2203,77 @@ class UserTest < ActiveSupport::TestCase
     assert_equal '127.0.0.1', email_preference.ip_address
     assert_equal EmailPreference::ACCOUNT_TYPE_CHANGE, email_preference.source
     assert_equal '0', email_preference.form_kind
+  end
+
+  def assert_parent_email_params_equals_email_preference(parent_email_params, email_preference)
+    assert_equal parent_email_params[:parent_email], email_preference.email
+    assert_equal parent_email_params[:parent_email_preference_opt_in].casecmp?('yes'), email_preference.opt_in
+    assert_equal parent_email_params[:parent_email_preference_request_ip], email_preference.ip_address
+    assert_equal parent_email_params[:parent_email_preference_source], email_preference.source
+  end
+
+  test 'creating a student with parent email should create an email preference for the parent' do
+    parent_email_params = @good_parent_email_params
+    User.create(@good_data.merge(parent_email_params))
+    email_preference = EmailPreference.find_by_email(parent_email_params[:parent_email])
+    assert_not_nil email_preference
+    assert_parent_email_params_equals_email_preference parent_email_params, email_preference
+  end
+
+  test 'creating a student with parent email and opt-out should create an email preference for the parent' do
+    parent_email_params = @good_parent_email_params.merge({parent_email_preference_opt_in: 'no'})
+    User.create(@good_data.merge(parent_email_params))
+    email_preference = EmailPreference.find_by_email(parent_email_params[:parent_email])
+    assert_not_nil email_preference
+    assert_parent_email_params_equals_email_preference parent_email_params, email_preference
+  end
+
+  test 'updating a student with parent email should create an email preference for the parent' do
+    parent_email_params = @good_parent_email_params
+    user = User.create(@good_data)
+    email_preference = EmailPreference.find_by_email(parent_email_params[:parent_email])
+    # There should be no email preference because no parent_email was defined.
+    assert_nil email_preference
+    user.update!(parent_email_params)
+    email_preference = EmailPreference.find_by_email(parent_email_params[:parent_email])
+    # There should now be an email preference because the user was updated with a parent_email.
+    assert_not_nil email_preference
+    assert_parent_email_params_equals_email_preference parent_email_params, email_preference
+  end
+
+  test 'creating a student with parent email opt in and a nil email address should not create an email preference for the parent' do
+    parent_email_params = @good_parent_email_params.merge({parent_email: nil})
+    User.create(@good_data.merge(parent_email_params))
+    email_preference = EmailPreference.find_by_email(parent_email_params[:parent_email])
+    assert_nil email_preference
+  end
+
+  test 'creating a student with parent email opt in and an empty string email address should not create an email preference for the parent' do
+    parent_email_params = @good_parent_email_params.merge({parent_email: ''})
+    User.create(@good_data.merge(parent_email_params))
+    email_preference = EmailPreference.find_by_email(parent_email_params[:parent_email])
+    assert_nil email_preference
+  end
+
+  test 'creating a student with parent email opt in and a blank string email address should not create an email preference for the parent' do
+    parent_email_params = @good_parent_email_params.merge({parent_email: '    '})
+    User.create(@good_data.merge(parent_email_params))
+    email_preference = EmailPreference.find_by_email(parent_email_params[:parent_email])
+    assert_nil email_preference
+  end
+
+  test 'creating a student with parent email opt in and a nil source should not create an email preference for the parent' do
+    parent_email_params = @good_parent_email_params.merge({parent_email_preference_source: nil})
+    User.create(@good_data.merge(parent_email_params))
+    email_preference = EmailPreference.find_by_email(parent_email_params[:parent_email])
+    assert_nil email_preference
+  end
+
+  test 'creating a student with parent email opt in and a nil request_ip should not create an email preference for the parent' do
+    parent_email_params = @good_parent_email_params.merge({parent_email_preference_request_ip: nil})
+    User.create(@good_data.merge(parent_email_params))
+    email_preference = EmailPreference.find_by_email(parent_email_params[:parent_email])
+    assert_nil email_preference
   end
 
   test 'google_classroom_student? is true if user belongs to a google classroom section as a student' do


### PR DESCRIPTION
We are adding a new feature to enable parents to get notification emails
about their child's progress. This changes make it so when a student
account changes, it will also update the parent's email preferences.

## Future work
Still need to test integration with front end. But that will be done in a futre PR.

## Links
- [jira](https://codedotorg.atlassian.net/browse/FND-1093)

## Testing story
* Added unit tests.

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
