### PR TITLE
Add basic UI test for script edit page

### DIFF
--- a/dashboard/app/controllers/application_controller.rb
+++ b/dashboard/app/controllers/application_controller.rb
@@ -236,7 +236,7 @@ class ApplicationController < ActionController::Base
   # not modify curriculum content in a way could introduce intermittent failures
   # in other tests. Developers wishing to run these tests locally should run
   # their local server in levelbuilder_mode.
-  def require_levelbuilder_mode_or_test
+  def require_levelbuilder_mode_or_test_env
     unless Rails.application.config.levelbuilder_mode || rack_env?(:test)
       raise CanCan::AccessDenied.new('Cannot create or modify levels from this environment.')
     end

--- a/dashboard/app/controllers/application_controller.rb
+++ b/dashboard/app/controllers/application_controller.rb
@@ -228,6 +228,20 @@ class ApplicationController < ActionController::Base
     end
   end
 
+  # Allow us to get some UI test coverage on levelbuilder-only features. This
+  # protection must be applied carefully to make sure that script and level
+  # files in the test environment are never modified.
+  #
+  # UI test authors must be careful to clean up after themselves so that they do
+  # not modify curriculum content in a way could introduce intermittent failures
+  # in other tests. Developers wishing to run these tests locally should run
+  # their local server in levelbuilder_mode.
+  def require_levelbuilder_mode_or_test
+    unless Rails.application.config.levelbuilder_mode || rack_env?(:test)
+      raise CanCan::AccessDenied.new('Cannot create or modify levels from this environment.')
+    end
+  end
+
   def require_admin
     authorize! :read, :reports
   end

--- a/dashboard/app/controllers/scripts_controller.rb
+++ b/dashboard/app/controllers/scripts_controller.rb
@@ -2,7 +2,7 @@ class ScriptsController < ApplicationController
   include VersionRedirectOverrider
 
   before_action :require_levelbuilder_mode, except: [:show, :edit, :update]
-  before_action :require_levelbuilder_mode_or_test, only: [:edit, :update]
+  before_action :require_levelbuilder_mode_or_test_env, only: [:edit, :update]
   before_action :authenticate_user!, except: :show
   check_authorization
   before_action :set_script, only: [:show, :edit, :update, :destroy]

--- a/dashboard/app/controllers/scripts_controller.rb
+++ b/dashboard/app/controllers/scripts_controller.rb
@@ -1,7 +1,8 @@
 class ScriptsController < ApplicationController
   include VersionRedirectOverrider
 
-  before_action :require_levelbuilder_mode, except: :show
+  before_action :require_levelbuilder_mode, except: [:show, :edit, :update]
+  before_action :require_levelbuilder_mode_or_test, only: [:edit, :update]
   before_action :authenticate_user!, except: :show
   check_authorization
   before_action :set_script, only: [:show, :edit, :update, :destroy]
@@ -77,8 +78,10 @@ class ScriptsController < ApplicationController
     end
 
     @script.destroy
-    filename = "config/scripts/#{@script.name}.script"
-    File.delete(filename) if File.exist?(filename)
+    if Rails.application.config.levelbuilder_mode
+      filename = "config/scripts/#{@script.name}.script"
+      File.delete(filename) if File.exist?(filename)
+    end
     redirect_to scripts_path, notice: I18n.t('crud.destroyed', model: Script.model_name.human)
   end
 

--- a/dashboard/app/models/script.rb
+++ b/dashboard/app/models/script.rb
@@ -1165,7 +1165,9 @@ class Script < ActiveRecord::Base
           },
           script_data[:stages],
         )
-        Script.merge_and_write_i18n(i18n, script_name, metadata_i18n)
+        if Rails.application.config.levelbuilder_mode
+          Script.merge_and_write_i18n(i18n, script_name, metadata_i18n)
+        end
       end
     rescue StandardError => e
       errors.add(:base, e.to_s)
@@ -1173,9 +1175,11 @@ class Script < ActiveRecord::Base
     end
     update_teacher_resources(general_params[:resourceTypes], general_params[:resourceLinks])
     begin
-      # write script to file
-      filename = "config/scripts/#{script_params[:name]}.script"
-      ScriptDSL.serialize(Script.find_by_name(script_name), filename)
+      if Rails.application.config.levelbuilder_mode
+        # write script to file
+        filename = "config/scripts/#{script_params[:name]}.script"
+        ScriptDSL.serialize(Script.find_by_name(script_name), filename)
+      end
       true
     rescue StandardError => e
       errors.add(:base, e.to_s)

--- a/dashboard/lib/tasks/seed.rake
+++ b/dashboard/lib/tasks/seed.rake
@@ -124,6 +124,8 @@ namespace :seed do
     'starwars',
     'starwarsblocks',
     'step',
+    'oceans',
+    'sports',
   ].map {|script| "config/scripts/#{script}.script"}.freeze
   SEEDED = 'config/scripts/.seeded'.freeze
 
@@ -370,7 +372,7 @@ namespace :seed do
 
   FULL_SEED_TASKS = [:videos, :concepts, :scripts, :courses, :callouts, :school_districts, :schools, :secret_words, :secret_pictures, :ap_school_codes, :ap_cs_offerings, :ib_school_codes, :ib_cs_offerings, :state_cs_offerings, :donors, :donor_schools, :foorm_libraries, :foorm_forms, :standards].freeze
   UI_TEST_SEED_TASKS = [:videos, :concepts, :scripts_ui_tests, :courses_ui_tests, :callouts, :school_districts, :schools, :secret_words, :secret_pictures, :donors, :donor_schools, :standards].freeze
-  DEFAULT_SEED_TASKS = rack_env?(:adhoc) ? UI_TEST_SEED_TASKS : FULL_SEED_TASKS
+  DEFAULT_SEED_TASKS = [:adhoc, :test].include?(rack_env) ? UI_TEST_SEED_TASKS : FULL_SEED_TASKS
 
   desc "seed the data needed for this type of environment by default"
   timed_task default: DEFAULT_SEED_TASKS

--- a/dashboard/test/controllers/scripts_controller_test.rb
+++ b/dashboard/test/controllers/scripts_controller_test.rb
@@ -352,7 +352,7 @@ class ScriptsControllerTest < ActionController::TestCase
     sign_in @levelbuilder
 
     script = create :script, hidden: true
-    File.stubs(:write).raises('must not modify script files')
+    File.stubs(:write).raises('must not modify filesystem')
     post :update, params: {
       id: script.id,
       script: {name: script.name},
@@ -387,7 +387,7 @@ class ScriptsControllerTest < ActionController::TestCase
     sign_in @levelbuilder
 
     script = create :script, hidden: true
-    File.stubs(:write).raises('must not modify script files')
+    File.stubs(:write).raises('must not modify filesystem')
     post :update, params: {
       id: script.id,
       script: {name: script.name},
@@ -405,7 +405,7 @@ class ScriptsControllerTest < ActionController::TestCase
     sign_in @levelbuilder
 
     script = create :script, hidden: true
-    File.stubs(:write).raises('must not modify script files')
+    File.stubs(:write).raises('must not modify filesystem')
     post :update, params: {
       id: script.id,
       script: {name: script.name},

--- a/dashboard/test/controllers/scripts_controller_test.rb
+++ b/dashboard/test/controllers/scripts_controller_test.rb
@@ -194,11 +194,34 @@ class ScriptsControllerTest < ActionController::TestCase
     assert_response :ok
   end
 
-  test "should not get edit if not levelbuilder mode" do
+  test "should not get edit on production" do
+    CDO.stubs(:rack_env).returns(:production)
     Rails.application.config.stubs(:levelbuilder_mode).returns false
     sign_in @levelbuilder
     get :edit, params: {id: 'course1'}
+    assert_response :forbidden
+  end
 
+  test "should get edit on levelbuilder" do
+    Rails.application.config.stubs(:levelbuilder_mode).returns true
+    sign_in @levelbuilder
+    get :edit, params: {id: 'course1'}
+    assert_response :ok
+  end
+
+  test "should get edit on test" do
+    CDO.stubs(:rack_env).returns(:test)
+    Rails.application.config.stubs(:levelbuilder_mode).returns false
+    sign_in @levelbuilder
+    get :edit, params: {id: 'course1'}
+    assert_response :ok
+  end
+
+  test "should not get edit on staging" do
+    CDO.stubs(:rack_env).returns(:staging)
+    Rails.application.config.stubs(:levelbuilder_mode).returns false
+    sign_in @levelbuilder
+    get :edit, params: {id: 'course1'}
     assert_response :forbidden
   end
 
@@ -289,12 +312,6 @@ class ScriptsControllerTest < ActionController::TestCase
     assert_redirected_to "/s/flappy"
   end
 
-  test "edit forbidden if not on levelbuilder" do
-    sign_in @levelbuilder
-    get :edit, params: {id: 'course1'}
-    assert_response :forbidden
-  end
-
   test 'create' do
     expected_contents = ''
     File.stubs(:write).with {|filename, _| filename.end_with? 'scripts.en.yml'}.once
@@ -327,6 +344,77 @@ class ScriptsControllerTest < ActionController::TestCase
         delete :destroy, params: {id: evil_script.id}
       end
     end
+  end
+
+  test "cannot update on production" do
+    CDO.stubs(:rack_env).returns(:production)
+    Rails.application.config.stubs(:levelbuilder_mode).returns false
+    sign_in @levelbuilder
+
+    script = create :script, hidden: true
+    File.stubs(:write).raises('must not modify script files')
+    post :update, params: {
+      id: script.id,
+      script: {name: script.name},
+      script_text: '',
+      visible_to_teachers: true
+    }
+    assert_response :forbidden
+    script.reload
+    assert script.hidden
+  end
+
+  test "can update on levelbuilder" do
+    Rails.application.config.stubs(:levelbuilder_mode).returns true
+    sign_in @levelbuilder
+
+    script = create :script, hidden: true
+    File.stubs(:write).with {|filename, _| filename == "config/scripts/#{script.name}.script" || filename.end_with?('scripts.en.yml')}
+    post :update, params: {
+      id: script.id,
+      script: {name: script.name},
+      script_text: '',
+      visible_to_teachers: true
+    }
+    assert_response :redirect
+    script.reload
+    refute script.hidden
+  end
+
+  test "can update on test without modifying filesystem" do
+    CDO.stubs(:rack_env).returns(:test)
+    Rails.application.config.stubs(:levelbuilder_mode).returns false
+    sign_in @levelbuilder
+
+    script = create :script, hidden: true
+    File.stubs(:write).raises('must not modify script files')
+    post :update, params: {
+      id: script.id,
+      script: {name: script.name},
+      script_text: '',
+      visible_to_teachers: true
+    }
+    assert_response :redirect
+    script.reload
+    refute script.hidden
+  end
+
+  test "cannot update on staging" do
+    CDO.stubs(:rack_env).returns(:staging)
+    Rails.application.config.stubs(:levelbuilder_mode).returns false
+    sign_in @levelbuilder
+
+    script = create :script, hidden: true
+    File.stubs(:write).raises('must not modify script files')
+    post :update, params: {
+      id: script.id,
+      script: {name: script.name},
+      script_text: '',
+      visible_to_teachers: true
+    }
+    assert_response :forbidden
+    script.reload
+    assert script.hidden
   end
 
   test 'updates teacher resources' do

--- a/dashboard/test/ui/features/learning_platform/levelbuilder/script_edit_page.feature
+++ b/dashboard/test/ui/features/learning_platform/levelbuilder/script_edit_page.feature
@@ -1,0 +1,8 @@
+Feature: Using the Script Edit Page
+
+Scenario: View the script edit page
+Given I create a levelbuilder named "Levi"
+And I create a temp script
+And I view the temp script overview page
+And I view the temp script edit page
+And I delete the temp script

--- a/dashboard/test/ui/features/step_definitions/steps.rb
+++ b/dashboard/test/ui/features/step_definitions/steps.rb
@@ -992,6 +992,37 @@ Given(/^I am assigned to script "([^"]*)"$/) do |script_name|
   )
 end
 
+Given(/^I create a temp script$/) do
+  response = browser_request(
+    url: '/api/test/create_script',
+    method: 'POST'
+  )
+  @temp_script_name = JSON.parse(response)['script_name']
+  puts "created temp script named '#{@temp_script_name}'"
+end
+
+Given(/^I view the temp script overview page$/) do
+  steps %{
+    Given I am on "http://studio.code.org/s/#{@temp_script_name}"
+    And I wait until element "#script-title" is visible
+  }
+end
+
+Given(/^I view the temp script edit page$/) do
+  steps %{
+    Given I am on "http://studio.code.org/s/#{@temp_script_name}/edit"
+    And I wait until element ".edit_script" is visible
+  }
+end
+
+Given(/^I delete the temp script$/) do
+  browser_request(
+    url: '/api/test/destroy_script',
+    method: 'POST',
+    body: {script_name: @temp_script_name}
+  )
+end
+
 Then(/^I fake completion of the assessment$/) do
   browser_request(url: '/api/test/fake_completion_assessment', method: 'POST', code: 204)
 end
@@ -1105,6 +1136,13 @@ And(/^I create a(n authorized)? teacher-associated( under-13)? student named "([
   section_code = section['code']
   @section_url = "http://studio.code.org/join/#{section_code}"
   create_user(name, url: "/join/#{section_code}", code: 200, age: under_13 ? '10' : '16')
+end
+
+And(/^I create a levelbuilder named "([^"]*)"$/) do |name|
+  steps %{
+    Given I create a teacher named "#{name}"
+    And I get levelbuilder access
+  }
 end
 
 def sign_up(name)
@@ -1237,6 +1275,10 @@ end
 
 And(/^I get hidden script access$/) do
   browser_request(url: '/api/test/hidden_script_access', method: 'POST')
+end
+
+And(/^I get levelbuilder access$/) do
+  browser_request(url: '/api/test/levelbuilder_access', method: 'POST')
 end
 
 And(/^I save the section url$/) do


### PR DESCRIPTION
## Background

Finishes [PLAT-61](https://codedotorg.atlassian.net/browse/PLAT-61) . See that issue for background.

## Description

This PR relaxes the current restrictions on the script edit and script update actions, so that these can be covered by UI tests which run in both Drone / CI as well as the on test machine. All other permissions remain restricted, but could be relaxed in a similar fashion for example if we wanted to start writing UI tests for the level edit page.

Caveat: if a UI test fails, the temp script it created won't get cleaned up. This is probably fine, since it still means we'll clean up the temp script most of the time, and new temp scripts are guaranteed not to have name collisions with old ones. It's possible the test machine will someday encounter a bottleneck if it has 1000s of temp scripts lying around, but that's a bottleneck we probably wouldn't mind learning about. If we hit that bottleneck too soon and want to crack down more aggressively on cleanup, we could use a `@with_temp_script` tag which takes care of creating and destroying the temp script reliably, at the expense of having to write a bit more scaffolding to make that work.

## Testing story

We typically don't write tests for our test code, but I did manually verify that the temp script is getting cleaned up after a successful test run.

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
