### PR TITLE
add basic UI test for updating a script

### DIFF
--- a/dashboard/test/ui/features/learning_platform/levelbuilder/script_edit_page.feature
+++ b/dashboard/test/ui/features/learning_platform/levelbuilder/script_edit_page.feature
@@ -6,3 +6,17 @@ And I create a temp script
 And I view the temp script overview page
 And I view the temp script edit page
 And I delete the temp script
+
+Scenario: Save changes to a script
+  Given I create a levelbuilder named "Levi"
+  And I create a temp script
+  And I view the temp script overview page
+  And element ".uitest-bubble" does not contain text "1"
+
+  When I view the temp script edit page
+  And I type "stage 'My Lesson'\nlevel 'Standalone_Artist_1'\n" into "#script_text"
+  And I click selector ".btn-primary" to load a new page
+  And I wait until element "#script-title" is visible
+
+  Then element ".uitest-bubble" contains text "1"
+  And I delete the temp script


### PR DESCRIPTION
## Description

Follow-on to https://github.com/code-dot-org/code-dot-org/pull/33943, making sure we can also save updates to the script.

I was worried that we'd have to deal with cache invalidation issues, but we don't have to yet because we [write through](https://en.wikipedia.org/wiki/Cache_(computing)#Writing_policies) the cache by first fetching it from the cache: https://github.com/code-dot-org/code-dot-org/blob/c65c9791ef496da4e91592cb1b45d76c2c72860b/dashboard/app/controllers/scripts_controller.rb#L155-L159
before modifying it: https://github.com/code-dot-org/code-dot-org/blob/c65c9791ef496da4e91592cb1b45d76c2c72860b/dashboard/app/controllers/scripts_controller.rb#L121-L123

Caveat: the correctness of this write-through behavior appears to rely on the fact that there is only one instance of the server in each non-production environment. When we consolidate Levelbuilder into Production, we'll have to find a way to invalidate the caches on other frontends.

### Deployment strategy

I'll let the previous PR go through DTT before shipping this one, to help isolate any problems that might only show up during DTT.

## Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
