### PR TITLE
Progress Performance: load teacher_scores in batches of 50 students at a time

### DIFF
--- a/apps/src/templates/sectionProgress/standards/sectionStandardsProgressRedux.js
+++ b/apps/src/templates/sectionProgress/standards/sectionStandardsProgressRedux.js
@@ -364,34 +364,32 @@ export function fetchStudentLevelScores(scriptId, sectionId) {
           unpluggedLessonIds.forEach(lessonId =>
             dispatch(setStudentLevelScores(scriptId, lessonId, scoresData))
           );
-          let initialCompletedUnpluggedLessons = getInitialUnpluggedLessonCompletionStatus(
-            state,
-            scriptId,
-            scoresData
-          );
-          const lessonsToSelect = _.filter(unpluggedLessonList, function(
-            lesson
-          ) {
-            if (initialCompletedUnpluggedLessons.includes(lesson.id)) {
-              return lesson;
-            }
-          });
-          dispatch(setSelectedLessons(lessonsToSelect));
         });
     });
-    Promise.all(requests);
+    Promise.all(requests).then(function() {
+      let initialCompletedUnpluggedLessons = getInitialUnpluggedLessonCompletionStatus(
+        getState(),
+        scriptId
+      );
+      const lessonsToSelect = _.filter(unpluggedLessonList, function(lesson) {
+        if (initialCompletedUnpluggedLessons.includes(lesson.id)) {
+          return lesson;
+        }
+      });
+      dispatch(setSelectedLessons(lessonsToSelect));
+    });
   };
 }
 
-function getInitialUnpluggedLessonCompletionStatus(
-  state,
-  scriptId,
-  scoresData
-) {
+function getInitialUnpluggedLessonCompletionStatus(state, scriptId) {
   let completedLessonIds = [];
 
-  if (scoresData[scriptId]) {
-    const levelScoresByStudentForScript = scoresData[scriptId];
+  if (
+    state.sectionStandardsProgress.studentLevelScoresByStage &&
+    state.sectionStandardsProgress.studentLevelScoresByStage[scriptId]
+  ) {
+    const levelScoresByStudentForScript =
+      state.sectionStandardsProgress.studentLevelScoresByStage[scriptId];
 
     Object.keys(levelScoresByStudentForScript).forEach(function(item) {
       const studentScoresComplete = _.filter(

--- a/apps/src/templates/sectionProgress/standards/sectionStandardsProgressRedux.js
+++ b/apps/src/templates/sectionProgress/standards/sectionStandardsProgressRedux.js
@@ -351,7 +351,8 @@ export function fetchStudentLevelScores(scriptId, sectionId) {
     const numStudents =
       state.teacherSections.sections[state.teacherSections.selectedSectionId]
         .studentCount;
-    const unpluggedLessonIds = _.map(getUnpluggedLessonsForScript(state), 'id');
+    let unpluggedLessonList = getUnpluggedLessonsForScript(state);
+    const unpluggedLessonIds = _.map(unpluggedLessonList, 'id');
     const NUM_STUDENTS_PER_PAGE = 50;
     const numPages = Math.ceil(numStudents / NUM_STUDENTS_PER_PAGE);
     const requests = _.range(1, numPages + 1).map(currentPage => {
@@ -368,7 +369,6 @@ export function fetchStudentLevelScores(scriptId, sectionId) {
             scriptId,
             scoresData
           );
-          let unpluggedLessonList = getUnpluggedLessonsForScript(state);
           const lessonsToSelect = _.filter(unpluggedLessonList, function(
             lesson
           ) {

--- a/dashboard/app/controllers/api/v1/teacher_scores_controller.rb
+++ b/dashboard/app/controllers/api/v1/teacher_scores_controller.rb
@@ -24,10 +24,12 @@ class Api::V1::TeacherScoresController < Api::V1::JsonApiController
   # GET /teacher_scores/<:section_id>/<:script_id>
   def get_teacher_scores_for_script
     section = Section.find(params[:section_id])
+    page = [params[:page].to_i, 1].max
     if section.user_id == current_user.id
       @teacher_scores = TeacherScore.get_level_scores_for_script_for_section(
         params[:script_id],
-        params[:section_id]
+        params[:section_id],
+        page
       )
       render json: @teacher_scores, each_serializer: Api::V1::TeacherScoreSerializer
     else

--- a/dashboard/app/models/teacher_score.rb
+++ b/dashboard/app/models/teacher_score.rb
@@ -59,7 +59,7 @@ class TeacherScore < ApplicationRecord
   def self.get_level_scores_for_script_for_section(script_id, section_id, page)
     level_scores_by_student_by_stage_by_script = {}
     stages = Script.find(script_id).stages
-    student_ids = Section.find(section_id).students.pluck(:id).each_slice(50).to_a[page - 1]
+    student_ids = Section.find(section_id).students.page(page).per(50).pluck(:id)
     stage_student_level_scores = {}
     stages.each do |stage|
       level_scores = get_level_scores_for_stage_for_students(stage, student_ids)

--- a/dashboard/app/models/teacher_score.rb
+++ b/dashboard/app/models/teacher_score.rb
@@ -56,12 +56,13 @@ class TeacherScore < ApplicationRecord
     )
   end
 
-  def self.get_level_scores_for_script_for_section(script_id, section_id)
+  def self.get_level_scores_for_script_for_section(script_id, section_id, page)
     level_scores_by_student_by_stage_by_script = {}
     stages = Script.find(script_id).stages
+    student_ids = Section.find(section_id).students.pluck(:id).each_slice(50).to_a[page - 1]
     stage_student_level_scores = {}
     stages.each do |stage|
-      level_scores = get_level_scores_for_stage_for_section(stage, section_id)
+      level_scores = get_level_scores_for_stage_for_students(stage, student_ids)
       unless level_scores.empty?
         stage_student_level_scores[stage.id] = level_scores
       end
@@ -70,9 +71,8 @@ class TeacherScore < ApplicationRecord
     level_scores_by_student_by_stage_by_script
   end
 
-  def self.get_level_scores_for_stage_for_section(stage, section_id)
+  def self.get_level_scores_for_stage_for_students(stage, student_ids)
     script_id = stage.script_id
-    student_ids = Section.find(section_id).students.pluck(:id)
     level_ids = stage.script_levels.map(&:level_id)
     user_levels = UserLevel.select(:id, :level_id, :user_id).where(user_id: student_ids, level_id: level_ids, script_id: script_id)
 

--- a/dashboard/app/models/teacher_score.rb
+++ b/dashboard/app/models/teacher_score.rb
@@ -58,7 +58,8 @@ class TeacherScore < ApplicationRecord
 
   def self.get_level_scores_for_script_for_section(script_id, section_id, page)
     level_scores_by_student_by_stage_by_script = {}
-    stages = Script.find(script_id).stages
+    # Teacher scores are currently only relevant for unplugged lessons
+    stages = Script.find(script_id).stages.select(&:display_as_unplugged)
     student_ids = Section.find(section_id).students.page(page).per(50).pluck(:id)
     stage_student_level_scores = {}
     stages.each do |stage|

--- a/dashboard/test/controllers/api/v1/teacher_scores_controller_test.rb
+++ b/dashboard/test/controllers/api/v1/teacher_scores_controller_test.rb
@@ -100,7 +100,7 @@ class Api::V1::TeacherScoresControllerTest < ActionDispatch::IntegrationTest
       :script_level,
       script: script,
       levels: [
-        create(:maze, name: 'test level 1')
+        create(:unplugged, name: 'test level 1')
       ]
     )
     level = script_level.levels[0]
@@ -128,7 +128,7 @@ class Api::V1::TeacherScoresControllerTest < ActionDispatch::IntegrationTest
       :script_level,
       script: script,
       levels: [
-        create(:maze, name: 'test level 1')
+        create(:unplugged, name: 'test level 1')
       ]
     )
     level = script_level.levels[0]
@@ -141,7 +141,7 @@ class Api::V1::TeacherScoresControllerTest < ActionDispatch::IntegrationTest
 
     post '/dashboardapi/v1/teacher_scores', params: {section_id: section.id, stage_scores: [{stage_id: stage.id, score: score}]}
 
-    assert_queries 11 do
+    assert_queries 13 do
       get "/dashboardapi/v1/teacher_scores/#{section.id}/#{script.id}"
     end
 
@@ -153,7 +153,7 @@ class Api::V1::TeacherScoresControllerTest < ActionDispatch::IntegrationTest
 
     assert_equal section.students.count, 11
 
-    assert_queries 11 do
+    assert_queries 13 do
       get "/dashboardapi/v1/teacher_scores/#{section.id}/#{script.id}"
     end
   end

--- a/dashboard/test/models/teacher_score_test.rb
+++ b/dashboard/test/models/teacher_score_test.rb
@@ -106,18 +106,18 @@ class TeacherScoreTest < ActiveSupport::TestCase
       )
     end
 
-    assert_equal(TeacherScore.get_level_scores_for_stage_for_section(@stage, @section.id), {@student_1.id => {@level_1.id => @score_2}})
+    assert_equal(TeacherScore.get_level_scores_for_stage_for_students(@stage, @section.students.pluck(:id)), {@student_1.id => {@level_1.id => @score_2}})
   end
 
-  test 'get scores for stage for section' do
+  test 'get scores for stage for students' do
     TeacherScore.score_stage_for_section(
       @section.id, @stage.id, @score
     )
 
     assert_equal(
-      TeacherScore.get_level_scores_for_stage_for_section(
+      TeacherScore.get_level_scores_for_stage_for_students(
         @stage,
-        @section.id
+        @section.students.pluck(:id)
       ),
       {
         @student_1.id => {@level_1.id => @score},
@@ -131,11 +131,12 @@ class TeacherScoreTest < ActiveSupport::TestCase
     TeacherScore.score_stage_for_section(
       @section.id, @stage.id, @score
     )
-
+    page = 1
     assert_equal(
       TeacherScore.get_level_scores_for_script_for_section(
         @script.id,
-        @section.id
+        @section.id,
+        page
       ),
       {
         @script.id => {

--- a/dashboard/test/models/teacher_score_test.rb
+++ b/dashboard/test/models/teacher_score_test.rb
@@ -16,7 +16,7 @@ class TeacherScoreTest < ActiveSupport::TestCase
       :script_level,
       script: @script,
       levels: [
-        create(:maze, name: 'test level 1')
+        create(:unplugged, name: 'test level 1')
       ]
     )
     @stage = @script_level.stage


### PR DESCRIPTION
[LP-1357](https://codedotorg.atlassian.net/browse/LP-1357)

As part of ensuring that [standards](https://docs.google.com/document/d/1xlm_syljGXIapl72GaKxN63V7kt6syHyvWHuqZhTCfE/edit) work is ready to launch, I've been checking teacher dashboard load times for a really large section. 

Occasionally the network request for teacher scores for a script for a section would time out for mega section (shown here on staging).

BEFORE: 
![Screen Shot 2020-03-31 at 1 48 23 PM](https://user-images.githubusercontent.com/12300669/78074142-0adfa780-7357-11ea-9c55-9e2d07253c24.png)

Following the pattern for [fetching section_level_progress](https://github.com/code-dot-org/code-dot-org/blob/2dd0c43d6b044219edc059fdd40056806d341edb/dashboard/app/controllers/api_controller.rb#L259), we're now fetching teacher scores in batches of 50 students at a time to prevent a network request timeout. 

AFTER: 
<img width="784" alt="bactch-fetch-teacher-scores" src="https://user-images.githubusercontent.com/12300669/78074074-e1268080-7356-11ea-94e0-272105e24a0d.png">
