### PR TITLE
Only display "update" button for libraries with updates available

### DIFF
--- a/apps/src/code-studio/components/libraries/LibraryManagerDialog.jsx
+++ b/apps/src/code-studio/components/libraries/LibraryManagerDialog.jsx
@@ -1,4 +1,5 @@
 /*globals dashboard*/
+import $ from 'jquery';
 import PropTypes from 'prop-types';
 import React from 'react';
 import Radium from 'radium';
@@ -104,7 +105,8 @@ export class LibraryManagerDialog extends React.Component {
     viewingLibrary: {},
     isViewingCode: false,
     isLoading: false,
-    error: null
+    error: null,
+    updatedLibraryChannels: []
   };
 
   componentDidUpdate(prevProps) {
@@ -114,14 +116,14 @@ export class LibraryManagerDialog extends React.Component {
   }
 
   onOpen = () => {
-    const libraries = dashboard.project.getProjectLibraries() || [];
-    this.setState({projectLibraries: libraries});
+    let projectLibraries = dashboard.project.getProjectLibraries() || [];
+    this.setState({projectLibraries});
 
     let libraryClient = new LibraryClientApi();
     libraryClient.getClassLibraries(
       classLibraries => {
-        const projectLibraries = mapUserNameToProjectLibraries(
-          libraries,
+        projectLibraries = mapUserNameToProjectLibraries(
+          projectLibraries,
           classLibraries
         );
         this.setState({classLibraries, projectLibraries});
@@ -130,6 +132,20 @@ export class LibraryManagerDialog extends React.Component {
         console.log('error: ' + error);
       }
     );
+
+    this.fetchUpdates(projectLibraries);
+  };
+
+  fetchUpdates = libraries => {
+    const libraryQuery = libraries.map(library => ({
+      channel_id: library.channelId,
+      version: library.versionId
+    }));
+
+    $.ajax({
+      method: 'GET',
+      url: `/libraries/get_updates?libraries=${JSON.stringify(libraryQuery)}`
+    }).done(updatedLibraryChannels => this.setState({updatedLibraryChannels}));
   };
 
   setLibraryToImport = event => {
@@ -219,18 +235,25 @@ export class LibraryManagerDialog extends React.Component {
   };
 
   displayProjectLibraries = () => {
-    const {projectLibraries} = this.state;
+    const {projectLibraries, updatedLibraryChannels} = this.state;
     if (!Array.isArray(projectLibraries) || !projectLibraries.length) {
       return <div style={styles.message}>{i18n.noLibrariesInProject()}</div>;
     }
+
     return projectLibraries.map(library => {
+      // Only pass onUpdate prop for libraries with updates available.
+      let onUpdate;
+      if (updatedLibraryChannels.includes(library.channelId)) {
+        onUpdate = channelId => {
+          this.fetchLatestLibrary(channelId, this.updateLibraryInProject);
+        };
+      }
+
       return (
         <LibraryListItem
           key={library.name}
           library={library}
-          onUpdate={channelId =>
-            this.fetchLatestLibrary(channelId, this.updateLibraryInProject)
-          }
+          onUpdate={onUpdate}
           onRemove={this.removeLibrary}
           onViewCode={() => this.viewCode(library)}
         />

--- a/apps/src/code-studio/components/libraries/LibraryManagerDialog.jsx
+++ b/apps/src/code-studio/components/libraries/LibraryManagerDialog.jsx
@@ -124,10 +124,7 @@ export class LibraryManagerDialog extends React.Component {
           libraries,
           classLibraries
         );
-        this.setState({
-          classLibraries,
-          projectLibraries: projectLibraries
-        });
+        this.setState({classLibraries, projectLibraries});
       },
       error => {
         console.log('error: ' + error);

--- a/apps/src/code-studio/components/libraries/LibraryManagerDialog.jsx
+++ b/apps/src/code-studio/components/libraries/LibraryManagerDialog.jsx
@@ -141,7 +141,6 @@ export class LibraryManagerDialog extends React.Component {
       return;
     }
 
-    // TODO: filter out class libraries
     const libraryQuery = libraries.map(library => ({
       channel_id: library.channelId,
       version: library.versionId

--- a/apps/src/code-studio/components/libraries/LibraryManagerDialog.jsx
+++ b/apps/src/code-studio/components/libraries/LibraryManagerDialog.jsx
@@ -137,14 +137,18 @@ export class LibraryManagerDialog extends React.Component {
   };
 
   fetchUpdates = libraries => {
-    const libraryQuery = libraries.map(library => ({
+    if (libraries.length === 0) {
+      return;
+    }
+
+    const queryObj = libraries.map(library => ({
       channel_id: library.channelId,
       version: library.versionId
     }));
 
     $.ajax({
       method: 'GET',
-      url: `/libraries/get_updates?libraries=${JSON.stringify(libraryQuery)}`
+      url: `/libraries/get_updates?libraries=${JSON.stringify(queryObj)}`
     }).done(updatedLibraryChannels => this.setState({updatedLibraryChannels}));
   };
 

--- a/apps/src/code-studio/components/libraries/LibraryManagerDialog.jsx
+++ b/apps/src/code-studio/components/libraries/LibraryManagerDialog.jsx
@@ -141,14 +141,15 @@ export class LibraryManagerDialog extends React.Component {
       return;
     }
 
-    const queryObj = libraries.map(library => ({
+    // TODO: filter out class libraries
+    const libraryQuery = libraries.map(library => ({
       channel_id: library.channelId,
       version: library.versionId
     }));
 
     $.ajax({
       method: 'GET',
-      url: `/libraries/get_updates?libraries=${JSON.stringify(queryObj)}`
+      url: `/libraries/get_updates?libraries=${JSON.stringify(libraryQuery)}`
     }).done(updatedLibraryChannels => this.setState({updatedLibraryChannels}));
   };
 

--- a/dashboard/lib/projects_list.rb
+++ b/dashboard/lib/projects_list.rb
@@ -276,7 +276,8 @@ module ProjectsList
         name: project_value['libraryName'],
         description: project_value['libraryDescription'],
         userName: user&.name,
-        sharedWith: project_value['sharedWith'] ? project_value['sharedWith'] : []
+        sharedWith: project_value['sharedWith'] ? project_value['sharedWith'] : [],
+        latestLibraryVersion: project_value['latestLibraryVersion']
       }.with_indifferent_access
     end
 

--- a/dashboard/lib/projects_list.rb
+++ b/dashboard/lib/projects_list.rb
@@ -276,8 +276,7 @@ module ProjectsList
         name: project_value['libraryName'],
         description: project_value['libraryDescription'],
         userName: user&.name,
-        sharedWith: project_value['sharedWith'] ? project_value['sharedWith'] : [],
-        latestLibraryVersion: project_value['latestLibraryVersion']
+        sharedWith: project_value['sharedWith'] ? project_value['sharedWith'] : []
       }.with_indifferent_access
     end
 


### PR DESCRIPTION
## Before
All project libraries had the "update" button displayed in the "Manage Libraries" modal. In the image below, "RandoLibrary" **has not** been updated, but "UntitledProject" **has** been updated:
<img width="748" alt="Screen Shot 2020-03-31 at 3 23 37 PM" src="https://user-images.githubusercontent.com/9812299/78080704-9d864380-7363-11ea-80e4-b882c200a25b.png">


## After
Only libraries that have been updated display the "update" button. Again, "RandoLibrary" **has not** been updated, but "UntitledProject" **has** been updated:
<img width="748" alt="Screen Shot 2020-03-31 at 3 22 26 PM" src="https://user-images.githubusercontent.com/9812299/78080630-7596e000-7363-11ea-8cac-f7d21df61527.png">


## Links

- [STAR-707](https://codedotorg.atlassian.net/browse/STAR-707)

## Testing story

New `fetchUpdates` method is covered by unit tests.

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
