### PR TITLE
[Sprite Lab] Give ties randomly to only one sprite in setupSim

### DIFF
--- a/dashboard/config/libraries/NativeSpriteLab.interpreted.js
+++ b/dashboard/config/libraries/NativeSpriteLab.interpreted.js
@@ -151,8 +151,8 @@ function setupSim(
   s3costume,
   s3speed
 ) {
-  World.s1ToCollect = [];
-  World.s2ToCollect = [];
+  World.collisions = {};
+  World.s3ToDelete = [];
   World.sprite1score = 0;
   World.sprite2score = 0;
 
@@ -168,25 +168,6 @@ function setupSim(
         changePropBy(spriteId, 'direction', randomNumber(135, 225));
       }
     };
-  }
-
-  // We don't allow certain list functions in the interpreter apparently, so writing my own.
-  function removeFromList(list, item) {
-    var newList = [];
-    for (var removeCounter = 0; removeCounter < list.length; removeCounter++) {
-      if (list[removeCounter] != item) {
-        newList.push(list[removeCounter]);
-      }
-    }
-    return newList;
-  }
-  function listIncludes(list, item) {
-    for (var includesCounter = 0; includesCounter < list.length; includesCounter++) {
-      if (list[includesCounter] == item) {
-        return true;
-      }
-    }
-    return false;
   }
 
   // Initialize sprites
@@ -206,64 +187,54 @@ function setupSim(
   }
   setProp({costume: s3costume}, 'scale', 50);
 
-
-  // We want to be able to randomize which sprite gets the point in the case of a tie. So the approach here is
-  // to use checkTouching() to detect all the collisions, but delay until the next frame to actually give a point
-  // and remove the s3 sprite. I'm using World.s1ToCollect and World.s2ToCollect to keep track of which sprite ids
-  // will be removed the following frame. Then if there's a tie (ie. s2 wants to remove a sprite id that's already
-  // in World.s1ToCollect or vice versa), use randomNumber(0,1) to give the sprite a 50-50 chance of "stealing" the
-  // s3 sprite.
-  // Then to actually remove the s3 sprites and keep track of the score, I'm using a behavior. I have the behavior
-  // attached to sprite id 0, but it doesn't really matter which sprite (as long as it's not an s3 sprite that
-  // might get deleted). A behavior is just the simplest way to add a snippet of code that will get executed each frame.
-  // The behavior basically just tallies the score and deletes the sprites from the previous frame, then checks
-  // whether the simulation should end. The one-frame delay isn't really noticeable since frames are so fast.
+  /**
+  * We want to be able to randomize which sprite gets the point in the case of a tie. So the approach here is
+  * to use checkTouching() to detect all the collisions, but delay until the next frame to actually give a point
+  * and remove the s3 sprite. I'm using World.collisions to keep track of which s3 sprites should be deleted. The
+  * format is an object whose keys are the ids of s3 sprites, and the value is a list indicating which sprites are
+  * touching the given s3 sprite.
+  *
+  * Then to actually remove the s3 sprites and keep track of the score, I'm using a behavior. I have the behavior
+  * attached to sprite id 0, but it doesn't really matter which sprite (as long as it's not an s3 sprite that
+  * might get deleted). A behavior is just the simplest way to add a snippet of code that will get executed each frame.
+  * The behavior goes through each s3 to delete and randomly chooses one element from its corresponding list to be
+  * the sprite that "wins" the tie. Then it just tllie the score, deletes the s3 sprites, and checks whether the
+  * simulation should end. The one-frame delay isn't really noticeable since frames are so fast.
+  */
 
   checkTouching('while', {costume: s1costume}, {costume: s3costume}, function(extraArgs) {
-    if (listIncludes(World.s1ToCollect, extraArgs.target)) {
-      // another s1 is also touching. Either way, s1 gets the point, but only count once, so don't add it again.
-    } else if (listIncludes(World.s2ToCollect, extraArgs.target)) {
-      // an s2 is also touching. We should decide randomly whether s1 or s2 gets the point.
-      if (randomNumber(0, 1) == 1) {
-        // s1 wins the coin toss, so remove from s2ToCollect and add to s1ToCollect
-        World.s1ToCollect.push(extraArgs.target);
-        World.s2ToCollect = removeFromList(World.s2ToCollect, extraArgs.target);
-      }
-    } else {
-      // no other sprite is touching
-      World.s1ToCollect.push(extraArgs.target);
+    if (World.collisions[extraArgs.target] == undefined) {
+      World.collisions[extraArgs.target] = [];
+      World.s3ToDelete.push(extraArgs.target);
     }
+    World.collisions[extraArgs.target].push(s1costume);
   });
 
   checkTouching('while', {costume: s2costume}, {costume: s3costume}, function(extraArgs) {
-    if (listIncludes(World.s2ToCollect, extraArgs.target)) {
-      // another s2 is also touching. Either way, s2 gets the point, but only count once, so don't add it again.
-    } else if (listIncludes(World.s1ToCollect, extraArgs.target)) {
-      // an s1 is also touching. We should decide randomly whether s1 or s2 gets the point.
-      if (randomNumber(0, 1) == 1) {
-        // s2 wins the coin toss, so remove from s1ToCollect and add to s2ToCollect
-        World.s2ToCollect.push(extraArgs.target);
-        World.s1ToCollect = removeFromList(World.s1ToCollect, extraArgs.target);
-      }
-    } else {
-      // no other sprite is touching
-      World.s2ToCollect.push(extraArgs.target);
+    if (World.collisions[extraArgs.target] == undefined) {
+      World.collisions[extraArgs.target] = [];
+      World.s3ToDelete.push(extraArgs.target);
     }
+    World.collisions[extraArgs.target].push(s2costume);
   });
 
   function collectBehavior() {
-    for (var s1ToDelete_i = 0; s1ToDelete_i < World.s1ToCollect.length; s1ToDelete_i++) {
-      World.sprite1score += 1;
-      printText(s1costume + ' has collected ' + World.sprite1score);
-      destroy({id: World.s1ToCollect[s1ToDelete_i]});
+    for (var s3_counter = 0; s3_counter < World.s3ToDelete.length; s3_counter++) {
+      var s3_sprite = World.s3ToDelete[s3_counter];
+      var collidedSprites = World.collisions[s3_sprite];
+      var winnerIndex = randomNumber(0, collidedSprites.length - 1);
+      if (collidedSprites[winnerIndex] == s1costume) {
+        World.sprite1score += 1;
+        printText(s1costume + ' has collected ' + World.sprite1score);
+      }
+      if (collidedSprites[winnerIndex] == s2costume) {
+        World.sprite2score += 1;
+        printText(s2costume + ' has collected ' + World.sprite2score);
+      }
+      destroy({id: s3_sprite});
     }
-    World.s1ToCollect = [];
-    for (var s2ToDelete_i = 0; s2ToDelete_i < World.s2ToCollect.length; s2ToDelete_i++) {
-      World.sprite2score += 1;
-      printText(s2costume + ' has collected ' + World.sprite2score);
-      destroy({id: World.s2ToCollect[s2ToDelete_i]});
-    }
-    World.s2ToCollect = [];
+    World.collisions = {};
+    World.s3ToDelete = [];
     checkSimulationEnd();
   }
   // We just need to run collectBehavior() each tick, doesn't actually matter which sprite it's attached to,

--- a/dashboard/config/libraries/NativeSpriteLab.interpreted.js
+++ b/dashboard/config/libraries/NativeSpriteLab.interpreted.js
@@ -204,6 +204,8 @@ function setupSim(
 
   checkTouching('while', {costume: s1costume}, {costume: s3costume}, function(extraArgs) {
     if (World.collisions[extraArgs.target] == undefined) {
+      // We don't have any recorded collisions for this s3 sprite yet. Add it to the collisions map and
+      // to the list of s3 to delete next tick.
       World.collisions[extraArgs.target] = [];
       World.s3ToDelete.push(extraArgs.target);
     }
@@ -212,6 +214,8 @@ function setupSim(
 
   checkTouching('while', {costume: s2costume}, {costume: s3costume}, function(extraArgs) {
     if (World.collisions[extraArgs.target] == undefined) {
+      // We don't have any recorded collisions for this s3 sprite yet. Add it to the collisions map and
+      // to the list of s3 to delete next tick.
       World.collisions[extraArgs.target] = [];
       World.s3ToDelete.push(extraArgs.target);
     }
@@ -222,6 +226,7 @@ function setupSim(
     for (var s3_counter = 0; s3_counter < World.s3ToDelete.length; s3_counter++) {
       var s3_sprite = World.s3ToDelete[s3_counter];
       var collidedSprites = World.collisions[s3_sprite];
+      // Randomly pick one "winner" for the collision.
       var winnerIndex = randomNumber(0, collidedSprites.length - 1);
       if (collidedSprites[winnerIndex] == s1costume) {
         World.sprite1score += 1;
@@ -233,6 +238,7 @@ function setupSim(
       }
       destroy({id: s3_sprite});
     }
+    // Reset collisions and s3ToDelete before the next tick
     World.collisions = {};
     World.s3ToDelete = [];
     checkSimulationEnd();

--- a/dashboard/config/libraries/NativeSpriteLab.interpreted.js
+++ b/dashboard/config/libraries/NativeSpriteLab.interpreted.js
@@ -198,7 +198,8 @@ function setupSim(
   * attached to sprite id 0, but it doesn't really matter which sprite (as long as it's not an s3 sprite that
   * might get deleted). A behavior is just the simplest way to add a snippet of code that will get executed each frame.
   * The behavior goes through each s3 to delete and randomly chooses one element from its corresponding list to be
-  * the sprite that "wins" the tie. Then it just tllie the score, deletes the s3 sprites, and checks whether the
+  * the sprite that "wins" the tie. (If there's only one item in the list, it means there was no tie, and that sprite
+  * wins by default.) Then it just tallies the score, deletes the s3 sprites, and checks whether the
   * simulation should end. The one-frame delay isn't really noticeable since frames are so fast.
   */
 

--- a/dashboard/config/libraries/NativeSpriteLab.interpreted.js
+++ b/dashboard/config/libraries/NativeSpriteLab.interpreted.js
@@ -151,9 +151,12 @@ function setupSim(
   s3costume,
   s3speed
 ) {
+  World.s1ToCollect = [];
+  World.s2ToCollect = [];
   World.sprite1score = 0;
   World.sprite2score = 0;
 
+  // Wandering behavior at a certain speed, will be added to both s1 and s2 sprites.
   function movementBehavior(speed) {
     return function(spriteId) {
       if (randomNumber(0, 5) == 0) {
@@ -167,35 +170,105 @@ function setupSim(
     };
   }
 
-  var counter_i = 0;
-  for (counter_i = 0; counter_i < s3number; counter_i++) {
-    makeNewSpriteAnon(s3costume, randomLocation());
+  // We don't allow certain list functions in the interpreter apparently, so writing my own.
+  function removeFromList(list, item) {
+    var newList = [];
+    for (var removeCounter = 0; removeCounter < list.length; removeCounter++) {
+      if (list[removeCounter] != item) {
+        newList.push(list[removeCounter]);
+      }
+    }
+    return newList;
   }
-  setProp({costume: s3costume}, 'scale', 50);
+  function listIncludes(list, item) {
+    for (var includesCounter = 0; includesCounter < list.length; includesCounter++) {
+      if (list[includesCounter] == item) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  // Initialize sprites
+  var counter_i = 0;
+  for (counter_i = 0; counter_i < s1number; counter_i++) {
+    makeNewSpriteAnon(s1costume, randomLocation());
+  }
+  addBehaviorSimple({costume: s1costume}, new Behavior(movementBehavior(s1speed)));
 
   for (counter_i = 0; counter_i < s2number; counter_i++) {
     makeNewSpriteAnon(s2costume, randomLocation());
   }
   addBehaviorSimple({costume: s2costume}, new Behavior(movementBehavior(s2speed)));
 
-  for (counter_i = 0; counter_i < s1number; counter_i++) {
-    makeNewSpriteAnon(s1costume, randomLocation());
+  for (counter_i = 0; counter_i < s3number; counter_i++) {
+    makeNewSpriteAnon(s3costume, randomLocation());
   }
-  addBehaviorSimple({costume: s1costume}, new Behavior(movementBehavior(s1speed)));
+  setProp({costume: s3costume}, 'scale', 50);
+
+
+  // We want to be able to randomize which sprite gets the point in the case of a tie. So the approach here is
+  // to use checkTouching() to detect all the collisions, but delay until the next frame to actually give a point
+  // and remove the s3 sprite. I'm using World.s1ToCollect and World.s2ToCollect to keep track of which sprite ids
+  // will be removed the following frame. Then if there's a tie (ie. s2 wants to remove a sprite id that's already
+  // in World.s1ToCollect or vice versa), use randomNumber(0,1) to give the sprite a 50-50 chance of "stealing" the
+  // s3 sprite.
+  // Then to actually remove the s3 sprites and keep track of the score, I'm using a behavior. I have the behavior
+  // attached to sprite id 0, but it doesn't really matter which sprite (as long as it's not an s3 sprite that
+  // might get deleted). A behavior is just the simplest way to add a snippet of code that will get executed each frame.
+  // The behavior basically just tallies the score and deletes the sprites from the previous frame, then checks
+  // whether the simulation should end. The one-frame delay isn't really noticeable since frames are so fast.
 
   checkTouching('while', {costume: s1costume}, {costume: s3costume}, function(extraArgs) {
-    destroy({id: extraArgs.target});
-    World.sprite1score++;
-    printText(s1costume + ' has collected ' + World.sprite1score);
-    checkSimulationEnd();
+    if (listIncludes(World.s1ToCollect, extraArgs.target)) {
+      // another s1 is also touching. Either way, s1 gets the point, but only count once, so don't add it again.
+    } else if (listIncludes(World.s2ToCollect, extraArgs.target)) {
+      // an s2 is also touching. We should decide randomly whether s1 or s2 gets the point.
+      if (randomNumber(0, 1) == 1) {
+        // s1 wins the coin toss, so remove from s2ToCollect and add to s1ToCollect
+        World.s1ToCollect.push(extraArgs.target);
+        World.s2ToCollect = removeFromList(World.s2ToCollect, extraArgs.target);
+      }
+    } else {
+      // no other sprite is touching
+      World.s1ToCollect.push(extraArgs.target);
+    }
   });
 
   checkTouching('while', {costume: s2costume}, {costume: s3costume}, function(extraArgs) {
-    destroy({id: extraArgs.target});
-    World.sprite2score++;
-    printText(s2costume + ' has collected ' + World.sprite2score);
-    checkSimulationEnd();
+    if (listIncludes(World.s2ToCollect, extraArgs.target)) {
+      // another s2 is also touching. Either way, s2 gets the point, but only count once, so don't add it again.
+    } else if (listIncludes(World.s1ToCollect, extraArgs.target)) {
+      // an s1 is also touching. We should decide randomly whether s1 or s2 gets the point.
+      if (randomNumber(0, 1) == 1) {
+        // s2 wins the coin toss, so remove from s1ToCollect and add to s2ToCollect
+        World.s2ToCollect.push(extraArgs.target);
+        World.s1ToCollect = removeFromList(World.s1ToCollect, extraArgs.target);
+      }
+    } else {
+      // no other sprite is touching
+      World.s2ToCollect.push(extraArgs.target);
+    }
   });
+
+  function collectBehavior() {
+    for (var s1ToDelete_i = 0; s1ToDelete_i < World.s1ToCollect.length; s1ToDelete_i++) {
+      World.sprite1score += 1;
+      printText(s1costume + ' has collected ' + World.sprite1score);
+      destroy({id: World.s1ToCollect[s1ToDelete_i]});
+    }
+    World.s1ToCollect = [];
+    for (var s2ToDelete_i = 0; s2ToDelete_i < World.s2ToCollect.length; s2ToDelete_i++) {
+      World.sprite2score += 1;
+      printText(s2costume + ' has collected ' + World.sprite2score);
+      destroy({id: World.s2ToCollect[s2ToDelete_i]});
+    }
+    World.s2ToCollect = [];
+    checkSimulationEnd();
+  }
+  // We just need to run collectBehavior() each tick, doesn't actually matter which sprite it's attached to,
+  // as long as it's not one of the s3 sprites that might get destroyed at some point.
+  addBehaviorSimple({id: 0}, new Behavior(collectBehavior));
 
   function checkSimulationEnd() {
     if (countByAnimation(s3costume) === 0) {


### PR DESCRIPTION
Context:
[Zendesk Ticket](https://codeorg.zendesk.com/agent/tickets/268615)
Basically, we run into issues with the setupSim block because if multiple sprites touch the apple at the same frame, they all get a point for "getting" the apple. This can easily lead to situations where the number of points at the end is more than the number of apples there were, which is confusing for students.
The solution here is *not* to change the way collisions are handled generally in Sprite Lab (multiple collisions involving the same sprites per frame is definitely acceptable behavior generally). But in this case, we want to detect whether two sprites are about to "get" the same apple, and randomly pick only one to get it. I'm like, 80% sure this approach gives a truly random result in the case of a tie, but double-checking my reasoning would be appreciated! The implementation here is a little roundabout but I couldn't think of a better way to do it within the constraints of Sprite Lab. I tried to document how it works as much as I could, though. Please let me know if there's a better approach or if the documentation is insufficient

Before:
![image](https://user-images.githubusercontent.com/8787187/78085160-fa3b2b80-736e-11ea-8b8c-9a43c18b104a.png)

After:
![image](https://user-images.githubusercontent.com/8787187/78085150-f27b8700-736e-11ea-8425-907e2ab466f6.png)

Of course, with randomness the results are different every time, but with this setup, I consistently got scores above 100 in the Before, and I ran it about 10 times in the After and the score always added up to 100.

<!--
  Other aspects to consider. uncomment and add detail for any that seem necessary:
-->

<!-- ### Background -->
<!-- ### Privacy -->
<!-- ### Security -->
<!-- ### Caching -->
<!-- ### Deployment strategy -->
<!-- ### Future work -->

## Testing story

<!--
  Does your change include appropriate tests?

  If so, please describe how the tests included in this PR are sufficient

  If not, please explain why this change does not need to be tested.
-->

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
