### PR TITLE
Overwrite contact_rollups_final with contact_rollups_processed

### DIFF
--- a/dashboard/app/models/contact_rollups_final.rb
+++ b/dashboard/app/models/contact_rollups_final.rb
@@ -16,20 +16,16 @@
 class ContactRollupsFinal < ApplicationRecord
   self.table_name = 'contact_rollups_final'
 
-  def self.truncate_and_overwrite
+  def self.overwrite_from_processed_table
     truncate
-    overwrite_from_processed_table
+    insert_from_processed_table
   end
 
   def self.truncate
-    truncate_sql = <<~SQL
-      TRUNCATE contact_rollups_final;
-    SQL
-
-    ActiveRecord::Base.connection.exec_query(truncate_sql)
+    ActiveRecord::Base.connection.truncate('contact_rollups_final')
   end
 
-  def self.overwrite_from_processed_table
+  def self.insert_from_processed_table
     overwrite_sql = <<~SQL
       INSERT INTO contact_rollups_final
       SELECT *

--- a/dashboard/app/models/contact_rollups_final.rb
+++ b/dashboard/app/models/contact_rollups_final.rb
@@ -17,12 +17,8 @@ class ContactRollupsFinal < ApplicationRecord
   self.table_name = 'contact_rollups_final'
 
   def self.overwrite_from_processed_table
-    truncate
+    ActiveRecord::Base.connection.truncate(table_name)
     insert_from_processed_table
-  end
-
-  def self.truncate
-    ActiveRecord::Base.connection.truncate('contact_rollups_final')
   end
 
   def self.insert_from_processed_table

--- a/dashboard/app/models/contact_rollups_final.rb
+++ b/dashboard/app/models/contact_rollups_final.rb
@@ -22,12 +22,12 @@ class ContactRollupsFinal < ApplicationRecord
   end
 
   def self.insert_from_processed_table
-    overwrite_sql = <<~SQL
+    insert_sql = <<~SQL
       INSERT INTO #{table_name}
       SELECT *
       FROM contact_rollups_processed;
     SQL
 
-    ActiveRecord::Base.connection.exec_query(overwrite_sql)
+    ActiveRecord::Base.connection.exec_query(insert_sql)
   end
 end

--- a/dashboard/app/models/contact_rollups_final.rb
+++ b/dashboard/app/models/contact_rollups_final.rb
@@ -23,7 +23,7 @@ class ContactRollupsFinal < ApplicationRecord
 
   def self.insert_from_processed_table
     overwrite_sql = <<~SQL
-      INSERT INTO contact_rollups_final
+      INSERT INTO #{table_name}
       SELECT *
       FROM contact_rollups_processed;
     SQL

--- a/dashboard/app/models/contact_rollups_final.rb
+++ b/dashboard/app/models/contact_rollups_final.rb
@@ -15,4 +15,27 @@
 
 class ContactRollupsFinal < ApplicationRecord
   self.table_name = 'contact_rollups_final'
+
+  def self.truncate_and_overwrite
+    truncate
+    overwrite_from_processed_table
+  end
+
+  def self.truncate
+    truncate_sql = <<~SQL
+      TRUNCATE contact_rollups_final;
+    SQL
+
+    ActiveRecord::Base.connection.exec_query(truncate_sql)
+  end
+
+  def self.overwrite_from_processed_table
+    overwrite_sql = <<~SQL
+      INSERT INTO contact_rollups_final
+      SELECT *
+      FROM contact_rollups_processed;
+    SQL
+
+    ActiveRecord::Base.connection.exec_query(overwrite_sql)
+  end
 end

--- a/dashboard/test/models/contact_rollups_final_test.rb
+++ b/dashboard/test/models/contact_rollups_final_test.rb
@@ -1,0 +1,23 @@
+require 'test_helper'
+
+class ContactRollupsFinalTest < ActiveSupport::TestCase
+  test 'overwrite_from_processed_table! overwrites contact_rollups_final' do
+    clean_tables
+
+    processed = create_list :contact_rollups_processed, 5
+    create_list :contact_rollups_final, 3
+
+    ContactRollupsFinal.delete_all # Stand in for ContactRollupsFinal.truncate, which tests don't allow b/c modifies DDL
+    ContactRollupsFinal.overwrite_from_processed_table
+
+    assert_equal 5, ContactRollupsFinal.count
+    processed.each do |contact|
+      assert_equal contact.data, ContactRollupsFinal.find_by(email: contact.email).data
+    end
+  end
+
+  def clean_tables
+    ContactRollupsProcessed.delete_all
+    ContactRollupsFinal.delete_all
+  end
+end

--- a/dashboard/test/models/contact_rollups_final_test.rb
+++ b/dashboard/test/models/contact_rollups_final_test.rb
@@ -8,7 +8,7 @@ class ContactRollupsFinalTest < ActiveSupport::TestCase
     create_list :contact_rollups_final, 3
 
     ContactRollupsFinal.delete_all # Stand in for ContactRollupsFinal.truncate, which tests don't allow b/c modifies DDL
-    ContactRollupsFinal.overwrite_from_processed_table
+    ContactRollupsFinal.insert_from_processed_table
 
     assert_equal 5, ContactRollupsFinal.count
     processed.each do |contact|

--- a/dashboard/test/models/contact_rollups_final_test.rb
+++ b/dashboard/test/models/contact_rollups_final_test.rb
@@ -1,13 +1,10 @@
 require 'test_helper'
 
 class ContactRollupsFinalTest < ActiveSupport::TestCase
-  test 'overwrite_from_processed_table! overwrites contact_rollups_final' do
+  test 'insert_from_processed_table properly inserts into contact_rollups_final' do
     clean_tables
-
     processed = create_list :contact_rollups_processed, 5
-    create_list :contact_rollups_final, 3
 
-    ContactRollupsFinal.delete_all # Stand in for ContactRollupsFinal.truncate, which tests don't allow b/c modifies DDL
     ContactRollupsFinal.insert_from_processed_table
 
     assert_equal 5, ContactRollupsFinal.count

--- a/dashboard/test/models/contact_rollups_final_test.rb
+++ b/dashboard/test/models/contact_rollups_final_test.rb
@@ -3,6 +3,7 @@ require 'test_helper'
 class ContactRollupsFinalTest < ActiveSupport::TestCase
   test 'insert_from_processed_table properly inserts into contact_rollups_final' do
     clean_tables
+
     processed = create_list :contact_rollups_processed, 5
 
     ContactRollupsFinal.insert_from_processed_table

--- a/lib/cdo/contact_rollups/v2/contact_rollups.rb
+++ b/lib/cdo/contact_rollups/v2/contact_rollups.rb
@@ -13,5 +13,7 @@ class ContactRollupsV2
     log_collector.time!('ContactRollupsPardotMemory.add_and_update_pardot_ids') {ContactRollupsPardotMemory.add_and_update_pardot_ids}
 
     # TODO: sync upstream step
+
+    log_collector.time!("ContactRollupsFinal.truncate_and_overwrite!") {ContactRollupsFinal.truncate_and_overwrite!}
   end
 end

--- a/lib/cdo/contact_rollups/v2/contact_rollups.rb
+++ b/lib/cdo/contact_rollups/v2/contact_rollups.rb
@@ -10,7 +10,7 @@ class ContactRollupsV2
     log_collector.time!('ContactRollupsComparison.delete_all') {ContactRollupsComparison.delete_all}
     log_collector.time!('ContactRollupsComparison.compare_processed_data') {ContactRollupsComparison.compile_processed_data}
 
-    log_collector.time!('ContactRollupsPardotMemory.add_and_update_pardot_ids') {ContactRollupsPardotMemory.add_and_update_pardot_ids(82_574_936)}
+    log_collector.time!('ContactRollupsPardotMemory.add_and_update_pardot_ids') {ContactRollupsPardotMemory.add_and_update_pardot_ids}
 
     # TODO: sync upstream step
 

--- a/lib/cdo/contact_rollups/v2/contact_rollups.rb
+++ b/lib/cdo/contact_rollups/v2/contact_rollups.rb
@@ -10,10 +10,10 @@ class ContactRollupsV2
     log_collector.time!('ContactRollupsComparison.delete_all') {ContactRollupsComparison.delete_all}
     log_collector.time!('ContactRollupsComparison.compare_processed_data') {ContactRollupsComparison.compile_processed_data}
 
-    log_collector.time!('ContactRollupsPardotMemory.add_and_update_pardot_ids') {ContactRollupsPardotMemory.add_and_update_pardot_ids}
+    log_collector.time!('ContactRollupsPardotMemory.add_and_update_pardot_ids') {ContactRollupsPardotMemory.add_and_update_pardot_ids(82_574_936)}
 
     # TODO: sync upstream step
 
-    log_collector.time!("ContactRollupsFinal.truncate_and_overwrite!") {ContactRollupsFinal.truncate_and_overwrite!}
+    log_collector.time!("ContactRollupsFinal.overwrite_from_processed_table") {ContactRollupsFinal.overwrite_from_processed_table}
   end
 end

--- a/lib/cdo/contact_rollups/v2/pardot.rb
+++ b/lib/cdo/contact_rollups/v2/pardot.rb
@@ -37,9 +37,7 @@ class PardotV2
       end
 
       # Stop if all the remaining results were in this response - we're done. Otherwise, keep repeating.
-      # Also stops after first iteration (200 contacts) if we're in dev environment, which
-      # prevents from downloading all new contacts from Pardot.
-      break if (results_in_response == total_results) || CDO.env == 'development'
+      break if results_in_response == total_results
     end
 
     mappings

--- a/lib/cdo/contact_rollups/v2/pardot.rb
+++ b/lib/cdo/contact_rollups/v2/pardot.rb
@@ -24,6 +24,7 @@ class PardotV2
       # Pardot returns the count total available prospects (not capped to 200),
       # although the data for a max of 200 are contained in the response.
       total_results = doc.xpath('/rsp/result/total_results').text.to_i
+      puts total_results
       results_in_response = 0
 
       # Process every prospect in the response.
@@ -37,7 +38,7 @@ class PardotV2
       end
 
       # Stop if all the remaining results were in this response - we're done. Otherwise, keep repeating.
-      break if results_in_response == total_results
+      break if (results_in_response == total_results) || CDO.env == 'development'
     end
 
     mappings

--- a/lib/cdo/contact_rollups/v2/pardot.rb
+++ b/lib/cdo/contact_rollups/v2/pardot.rb
@@ -24,7 +24,6 @@ class PardotV2
       # Pardot returns the count total available prospects (not capped to 200),
       # although the data for a max of 200 are contained in the response.
       total_results = doc.xpath('/rsp/result/total_results').text.to_i
-      puts total_results
       results_in_response = 0
 
       # Process every prospect in the response.

--- a/lib/cdo/contact_rollups/v2/pardot.rb
+++ b/lib/cdo/contact_rollups/v2/pardot.rb
@@ -37,6 +37,8 @@ class PardotV2
       end
 
       # Stop if all the remaining results were in this response - we're done. Otherwise, keep repeating.
+      # Also stops after first iteration (200 contacts) if we're in dev environment, which
+      # prevents from downloading all new contacts from Pardot.
       break if (results_in_response == total_results) || CDO.env == 'development'
     end
 


### PR DESCRIPTION
Final step in contact rollups process is to overwrite current version of `ContactRollupsFinal` with `ContactRollupsProcessed`.

## Testing story

Simple unit test here, but could add more.

## Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
