### PR TITLE
Commit content: notify DOTD when skip or fail

### DIFF
--- a/bin/cron/commit_content
+++ b/bin/cron/commit_content
@@ -26,7 +26,7 @@ class ContentCommitter
 
   # @return [String] An environment-specific string indicating that the robo-commit was skipped.
   def commit_skipped_string
-    "robo-commit skipped (#{@d_to_env.upcase}: no)"
+    "<@#{DevelopersTopic.dotd}> robo-commit skipped (#{@d_to_env.upcase}: no)"
   end
 
   # @return [String] An environment-specific string indicating that the robo-commit is happening.
@@ -41,7 +41,7 @@ class ContentCommitter
 
   # @return [String] An environment-specific string indicating that the robo-commit failed.
   def commit_failed_string
-    "no (robo-commit failed on #{@env})"
+    "<@#{DevelopersTopic.dotd}> no (robo-commit failed on #{@env})"
   end
 
   # Returns whether the Slack#developers topic allows for deploys in environment @env, messaging the


### PR DESCRIPTION
When attempting to commit content, usually as part of a cron job, now notify the Developer of the Day when it's skipped or failed.

For an example of how this should be helpful: sometimes the commit is skipped because the Slack channel's topic was set to "DTL: no" earlier, and it's easy for the DOTD to miss this.
