### PR TITLE
Use FreeResponse translations

### DIFF
--- a/dashboard/app/models/levels/free_response.rb
+++ b/dashboard/app/models/levels/free_response.rb
@@ -61,15 +61,13 @@ class FreeResponse < Level
     # Return the default English string from the database model if we shouldn't
     # localize this property or we couldn't find a localized value.
     default = try(property_name)
-    if should_localize?
-      I18n.t(
-        name,
-        scope: [:data, property_name],
-        default: nil,
-        smart: true
-      ) || default
-    else
-      default
-    end
+    return default unless should_localize?
+
+    I18n.t(
+      name,
+      scope: [:data, property_name],
+      default: default,
+      smart: true
+    )
   end
 end

--- a/dashboard/app/views/levels/_free_response.html.haml
+++ b/dashboard/app/views/levels/_free_response.html.haml
@@ -48,7 +48,7 @@
       ReactDOM.render(React.createElement(dashboard.Attachments, {showUnderageWarning: !appOptions.is13Plus, readonly: #{!!@view_options.readonly_workspace}}), document.querySelector('#free-response-upload'));
 
   - height = level.height || '80'
-  - placeholder = level.get_property(:placeholder)
+  - placeholder = level.get_property(:placeholder) || I18n.t('free_response.placeholder')
   %textarea.response{id: "level_#{level.id}", placeholder: placeholder, style: "height: #{height}px;", readonly: @view_options.readonly_workspace}= last_attempt
 
   -# Don't render the dialog partial if we're inside a LevelGroup.

--- a/dashboard/app/views/levels/_free_response.html.haml
+++ b/dashboard/app/views/levels/_free_response.html.haml
@@ -29,9 +29,9 @@
     );
 
 .free-response{:class => ('left-aligned' if left_align)}
-  -# FND-984 title needs to be localized level property.
-  - if level.title.present? && (!in_level_group || is_contained_level)
-    %h1= level.title
+  - title = level.get_property(:title)
+  - if title.present? && (!in_level_group || is_contained_level)
+    %h1= title
   - long_instructions = level.get_property("long_instructions")
   - if long_instructions
     %div= render(inline: long_instructions, type: :md)
@@ -48,8 +48,7 @@
       ReactDOM.render(React.createElement(dashboard.Attachments, {showUnderageWarning: !appOptions.is13Plus, readonly: #{!!@view_options.readonly_workspace}}), document.querySelector('#free-response-upload'));
 
   - height = level.height || '80'
-  -# FND-984 placeholder needs to be localized level property.
-  - placeholder = level.placeholder || I18n.t('free_response.placeholder')
+  - placeholder = level.get_property(:placeholder)
   %textarea.response{id: "level_#{level.id}", placeholder: placeholder, style: "height: #{height}px;", readonly: @view_options.readonly_workspace}= last_attempt
 
   -# Don't render the dialog partial if we're inside a LevelGroup.

--- a/dashboard/config/locales/en.yml
+++ b/dashboard/config/locales/en.yml
@@ -719,8 +719,6 @@ en:
     help_support: "Help and support"
     documentation: "Documentation"
     tutorials: "Tutorials"
-  free_response:
-    placeholder: "Enter your answer here"
   multi:
     wrong_title: "Incorrect answer"
     wrong_body: "The answer you've entered is not correct.  Please try again!"

--- a/dashboard/config/locales/en.yml
+++ b/dashboard/config/locales/en.yml
@@ -719,6 +719,8 @@ en:
     help_support: "Help and support"
     documentation: "Documentation"
     tutorials: "Tutorials"
+  free_response:
+    placeholder: "Enter your answer here"
   multi:
     wrong_title: "Incorrect answer"
     wrong_body: "The answer you've entered is not correct.  Please try again!"


### PR DESCRIPTION
Use translations of FreeResponse fields (added in https://github.com/code-dot-org/code-dot-org/pull/33970) in the view. Also remove the placeholder placeholder we added to hold us over until now.

<!--
  Other aspects to consider. uncomment and add detail for any that seem necessary:
-->

<!-- ### Background -->
<!-- ### Privacy -->
<!-- ### Security -->
<!-- ### Caching -->
<!-- ### Deployment strategy -->
<!-- ### Future work -->

## Links

<!--
  Any relevant links to external resources; ie, specification documents, jira
  items, related PRs, honeybadger errors, etc
-->

- [jira](https://codedotorg.atlassian.net/browse/FND-984)

## Testing story

<!--
  Does your change include appropriate tests?

  If so, please describe how the tests included in this PR are sufficient

  If not, please explain why this change does not need to be tested.
-->

Added a test translation file to `dashboard/config/locales/free_responses.es-MX.yml`:

```yml
---
es-MX:
  data:
    placeholder:
      csp_socialBelonging_intervention_2018: "yay, a translation"
```

Then checked `http://localhost-studio.code.org:3000/s/csp1-2018/stage/1/puzzle/3/lang/es-mx`:

![image](https://user-images.githubusercontent.com/244100/78170150-62d5e700-7407-11ea-92eb-77970f8e9f54.png)


# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
