### PR TITLE
Commit content: only notify DOTD on skip

### DIFF
--- a/bin/cron/commit_content
+++ b/bin/cron/commit_content
@@ -41,7 +41,7 @@ class ContentCommitter
 
   # @return [String] An environment-specific string indicating that the robo-commit failed.
   def commit_failed_string
-    "<@#{DevelopersTopic.dotd}> no (robo-commit failed on #{@env})"
+    "no (robo-commit failed on #{@env})"
   end
 
   # Returns whether the Slack#developers topic allows for deploys in environment @env, messaging the


### PR DESCRIPTION
Followup to https://github.com/code-dot-org/code-dot-org/pull/33972.  It turns out the failure case already notified the DOTD, and the string modified actually inadvertently added the DOTD's handle to the channel topic when we didn't want that.  

This leaves the other change intact, which is to add the DOTD's tag to the chat message generated when content is skipped, which was the original goal of the PR anyway.
