### PR TITLE
Adjust mobile zoom for levels

### DIFF
--- a/apps/src/StudioApp.js
+++ b/apps/src/StudioApp.js
@@ -77,7 +77,7 @@ var copyrightStrings;
 /**
  * The minimum width of a playable whole blockly game.
  */
-var MIN_WIDTH = 1400;
+var MIN_WIDTH = 1200;
 var DEFAULT_MOBILE_NO_PADDING_SHARE_WIDTH = 400;
 var MAX_VISUALIZATION_WIDTH = 400;
 var MIN_VISUALIZATION_WIDTH = 200;

--- a/apps/src/StudioApp.js
+++ b/apps/src/StudioApp.js
@@ -1847,13 +1847,17 @@ StudioApp.prototype.fixViewportForSmallScreens_ = function(viewport, config) {
     scale = screenWidth / width;
   }
 
-  // Setting `minimum-scale=scale`` meant that we were unable to shrink the
-  // entire playspace area down to fit on a portrait iPhone.
+  // Setting `minimum-scale=scale` means that we are unable to shrink the
+  // entire playspace area down to fit on a portrait iPhone, even though
+  // it's technically not visible because of the RotateContainer on top.
+  // But setting `maximum-scale=scale` was preventing an Android from starting
+  // in the desired zoom level in landscape, so we removed that but left
+  // `minimum-scale=scale`.
   var content = [
     'width=' + width,
     'minimal-ui',
     'initial-scale=' + scale,
-    'maximum-scale=' + scale,
+    'minimum-scale=' + scale,
     'target-densityDpi=device-dpi'
   ];
   viewport.setAttribute('content', content.join(', '));

--- a/apps/src/StudioApp.js
+++ b/apps/src/StudioApp.js
@@ -1858,7 +1858,8 @@ StudioApp.prototype.fixViewportForSmallScreens_ = function(viewport, config) {
     'minimal-ui',
     'initial-scale=' + scale,
     'minimum-scale=' + scale,
-    'target-densityDpi=device-dpi'
+    'target-densityDpi=device-dpi',
+    'viewport-fit=cover'
   ];
   viewport.setAttribute('content', content.join(', '));
 };

--- a/apps/src/StudioApp.js
+++ b/apps/src/StudioApp.js
@@ -77,7 +77,7 @@ var copyrightStrings;
 /**
  * The minimum width of a playable whole blockly game.
  */
-var MIN_WIDTH = 900;
+var MIN_WIDTH = 1400;
 var DEFAULT_MOBILE_NO_PADDING_SHARE_WIDTH = 400;
 var MAX_VISUALIZATION_WIDTH = 400;
 var MIN_VISUALIZATION_WIDTH = 200;

--- a/apps/src/StudioApp.js
+++ b/apps/src/StudioApp.js
@@ -1825,7 +1825,9 @@ StudioApp.prototype.setIdealBlockNumber_ = function() {
 StudioApp.prototype.fixViewportForSmallScreens_ = function(viewport, config) {
   var deviceWidth;
   var desiredWidth;
-  var minWidth;
+  var width;
+  var scale;
+
   if (this.share && dom.isMobile()) {
     var mobileNoPaddingShareWidth =
       config.mobileNoPaddingShareWidth || DEFAULT_MOBILE_NO_PADDING_SHARE_WIDTH;
@@ -1834,23 +1836,25 @@ StudioApp.prototype.fixViewportForSmallScreens_ = function(viewport, config) {
     if (this.noPadding && deviceWidth < MAX_PHONE_WIDTH) {
       desiredWidth = Math.min(desiredWidth, mobileNoPaddingShareWidth);
     }
-    minWidth = mobileNoPaddingShareWidth;
+    var minWidth = mobileNoPaddingShareWidth;
+    width = Math.max(minWidth, desiredWidth);
+    scale = deviceWidth / width;
   } else {
-    // assume we are in landscape mode, so width is the longer of the two
-    deviceWidth = desiredWidth = Math.max(screen.width, screen.height);
-    minWidth = MIN_WIDTH;
-  }
-  var width = Math.max(minWidth, desiredWidth);
-  var scale = deviceWidth / width;
+    // We want the longer edge, the width in landscape, to get MIN_WIDTH.
+    let screenWidth = Math.max(screen.width, screen.height);
 
+    width = MIN_WIDTH;
+    scale = screenWidth / width;
+  }
+
+  // Setting `minimum-scale=scale`` meant that we were unable to shrink the
+  // entire playspace area down to fit on a portrait iPhone.
   var content = [
     'width=' + width,
     'minimal-ui',
     'initial-scale=' + scale,
     'maximum-scale=' + scale,
-    'minimum-scale=' + scale,
-    'target-densityDpi=device-dpi',
-    'user-scalable=no'
+    'target-densityDpi=device-dpi'
   ];
   viewport.setAttribute('content', content.join(', '));
 };

--- a/apps/src/fish/Fish.js
+++ b/apps/src/fish/Fish.js
@@ -87,7 +87,7 @@ Fish.prototype.init = function(config) {
 
   ReactDOM.render(
     <Provider store={getStore()}>
-      <FishView onMount={onMount} mobilePortraitWidth={MOBILE_PORTRAIT_WIDTH} />
+      <FishView onMount={onMount} />
     </Provider>,
     document.getElementById(config.containerId)
   );

--- a/apps/src/fish/FishView.jsx
+++ b/apps/src/fish/FishView.jsx
@@ -49,8 +49,7 @@ class FishView extends React.Component {
   static propTypes = {
     isProjectLevel: PropTypes.bool.isRequired,
     isReadOnlyWorkspace: PropTypes.bool.isRequired,
-    onMount: PropTypes.func.isRequired,
-    mobilePortraitWidth: PropTypes.number.isRequired
+    onMount: PropTypes.func.isRequired
   };
 
   componentDidMount() {
@@ -59,7 +58,7 @@ class FishView extends React.Component {
 
   render() {
     return (
-      <StudioAppWrapper rotateContainerWidth={this.props.mobilePortraitWidth}>
+      <StudioAppWrapper>
         <CodeWorkspaceContainer topMargin={0}>
           <ProtectedStatefulDiv id="container" style={styles.container}>
             <div id="container-react" style={styles.containerReact} />

--- a/apps/src/maze/maze.js
+++ b/apps/src/maze/maze.js
@@ -31,8 +31,6 @@ const tiles = maze.tiles;
 const createResultsHandlerForSubtype = require('./results/utils')
   .createResultsHandlerForSubtype;
 
-const MOBILE_PORTRAIT_WIDTH = 700;
-
 module.exports = class Maze {
   constructor() {
     this.scale = {
@@ -208,23 +206,10 @@ module.exports = class Maze {
         <AppView
           visualizationColumn={visualizationColumn}
           onMount={studioApp().init.bind(studioApp(), config)}
-          rotateContainerWidth={MOBILE_PORTRAIT_WIDTH}
         />
       </Provider>,
       document.getElementById(config.containerId)
     );
-
-    // studioApp.init calls fixViewportForSmallScreens_ which incorrectly
-    // positions the "Rotate Container" image on iOS devices. We correct this
-    // by calling fixViewportForSpecificWidthForSmallScreens_ after the init is
-    // finished.
-    var viewport = document.querySelector('meta[name="viewport"]');
-    if (viewport) {
-      studioApp().fixViewportForSpecificWidthForSmallScreens_(
-        viewport,
-        MOBILE_PORTRAIT_WIDTH
-      );
-    }
   }
 
   /**

--- a/apps/src/templates/AppView.jsx
+++ b/apps/src/templates/AppView.jsx
@@ -20,8 +20,7 @@ class AppView extends React.Component {
 
     // not provided by redux
     visualizationColumn: PropTypes.element,
-    onMount: PropTypes.func.isRequired,
-    rotateContainerWidth: PropTypes.number
+    onMount: PropTypes.func.isRequired
   };
 
   componentDidMount() {
@@ -35,7 +34,7 @@ class AppView extends React.Component {
     });
 
     return (
-      <StudioAppWrapper rotateContainerWidth={this.props.rotateContainerWidth}>
+      <StudioAppWrapper>
         <Overlay />
         <div id="visualizationColumn" className={visualizationColumnClassNames}>
           {this.props.visualizationColumn}

--- a/apps/src/templates/RotateContainer.jsx
+++ b/apps/src/templates/RotateContainer.jsx
@@ -17,23 +17,22 @@ const styles = {
     height: '100%'
   },
   rotateContainerInner: {
-    backgroundPosition: '50% 50%',
+    backgroundPosition: '50% 10%',
     backgroundSize: 'contain',
     backgroundRepeat: 'no-repeat'
   },
   rotateText: {
     position: 'relative',
-    top: '50%',
+    top: '25%',
     left: '-50%',
     marginLeft: '50px',
     marginRight: '-50px'
   },
   paragraph: {
     textAlign: 'center',
-    fontSize: '26px',
-    lineHeight: '26px',
-    transform: 'rotate(90deg)',
-    WebkitTransform: 'rotate(90deg)'
+    fontSize: 48,
+    lineHeight: 1.5,
+    transform: 'translate(40px, 0px) rotate(90deg)'
   }
 };
 
@@ -52,19 +51,8 @@ export default class RotateContainer extends React.Component {
       width = this.props.width;
       height = '100%';
     } else {
-      // In StudioApp.prototype.fixViewportForSmallScreens_ we end up scaling our
-      // viewport so that things look good in landscape mode. Unfortunately, this
-      // means that we can't dependably use CSS to size our rotate container in a
-      // way that works across ios and android.
-      // What we do is to figure out the scaling factor fixViewportForSmallScreens_
-      // is going to use and set our width relative to that factor.
-      // In addition, I've added an outer container that fills up the whole space
-      // with a white background, so that if you scroll off of the inner container
-      // you see white instead of the codeApp
-
-      const scale = screen.height / 1400;
-      width = window.screen.width / scale;
-      height = window.screen.height;
+      width = '90%';
+      height = '100%';
     }
 
     return (

--- a/apps/src/templates/RotateContainer.jsx
+++ b/apps/src/templates/RotateContainer.jsx
@@ -62,7 +62,7 @@ export default class RotateContainer extends React.Component {
       // with a white background, so that if you scroll off of the inner container
       // you see white instead of the codeApp
 
-      const scale = screen.height / 900;
+      const scale = screen.height / 1400;
       width = window.screen.width / scale;
       height = window.screen.height;
     }

--- a/apps/src/templates/StudioAppWrapper.jsx
+++ b/apps/src/templates/StudioAppWrapper.jsx
@@ -12,8 +12,7 @@ class StudioAppWrapper extends React.Component {
     assetUrl: PropTypes.func.isRequired,
     isEmbedView: PropTypes.bool.isRequired,
     isShareView: PropTypes.bool.isRequired,
-    children: PropTypes.node,
-    rotateContainerWidth: PropTypes.number
+    children: PropTypes.node
   };
 
   requiresLandscape() {
@@ -24,10 +23,7 @@ class StudioAppWrapper extends React.Component {
     return (
       <div>
         {this.requiresLandscape() && (
-          <RotateContainer
-            assetUrl={this.props.assetUrl}
-            width={this.props.rotateContainerWidth}
-          />
+          <RotateContainer assetUrl={this.props.assetUrl} />
         )}
         {this.props.children}
         <div className="clear" />

--- a/apps/style/craft/style.scss
+++ b/apps/style/craft/style.scss
@@ -239,10 +239,6 @@ body {
     top: 0 !important;
   }
 
-  @media screen and (max-device-height: 900px) and (max-device-width: 500px) {
-    top: 10px !important;
-  }
-
   .loading {
     @include pixelated();
     background: url("#{$root}Sliced_Parts/MC_Loading_Spinner.gif") no-repeat center center;

--- a/dashboard/app/assets/stylesheets/application.scss
+++ b/dashboard/app/assets/stylesheets/application.scss
@@ -171,12 +171,6 @@ img.video_thumbnail {
 }
 
 .header-wrapper {
-  &.hide_on_mobile {
-    @media screen and (max-device-width: 500px) {
-      display: none;
-    }
-  }
-
   padding-top: 0;
   min-height: 60px;
   position: relative;
@@ -1131,9 +1125,6 @@ input.header_input {
   left: $codeApp-left-margin;
   right: 25px;
   bottom: 10px;
-  @media screen and (max-device-height: 900px) and (max-device-width: 500px) {
-    top: 10px;
-  }
 
   &.centered_embed {
     position: relative;


### PR DESCRIPTION
This adjusts the viewport width for regular levels from 900px to 1200px, causing mobile devices that use this viewport to "zoom out", showing more content but with smaller sizes.  While elements are smaller, our levels work on desktop much better at 1200px than 900px, and this improved usability carries over. 

We did try 1400px but it made things quite small on small devices, and didn't seem necessary for fitting all the UI elements for the scripts most often used on mobile devices.

It removes the special-casing for maze added in https://github.com/code-dot-org/code-dot-org/pull/32240.

The second [commit](https://github.com/code-dot-org/code-dot-org/pull/33983/commits/d564c59ea9cfc72fd9ec82ecbf4f0acd66004854) helped me understand what I actually did in https://github.com/code-dot-org/code-dot-org/pull/32206 for Oceans.  I thought I was setting the landscape viewport width to 600px in that change, but I was actually setting the portrait viewport width, by virtue of the scaling value generated.  That is, the document body was 600px wide in portrait, while in landscape it was significantly wider, though with a height of 600px.  

In this change we're doing something different.  We want the landscape viewport width, which is the larger of the screen's two dimensions, and the document body itself, to be 1200px, and we pick a scaling value to that effect.  When in portrait mode, we are still 1200px wide, but with the scaling value we chose, it causes the page to be significantly larger than the physical screen.

The third [commit](https://github.com/code-dot-org/code-dot-org/pull/33983/commits/89bde6e7fea501bbe3c88bcaa39f1e6d90e75ac4)  shows the header even on mobile devices.

The fourth [commit](https://github.com/code-dot-org/code-dot-org/pull/33983/commits/0187de92f7f4c29f32357c46294f1bba3412dc0f) makes a substantial improvement to the "rotate phone" overlay, by using the newer [Visual Viewport API](https://developer.mozilla.org/en-US/docs/Web/API/Visual_Viewport_API), when available, to dynamically position and resize the content of the overlay to always be in view, even as the user adjusts zoom or position on their phone.  If the API isn't available, it just uses default styling.  

It also adjusts the viewport to better suit an Android issue we saw, as described in a comment, and removes the special parameter for setting up the "rotate phone" overlay for the Oceans tutorial.

The [fifth](https://github.com/code-dot-org/code-dot-org/pull/33983/commits/00df3bdf06271131ef51218e5e1605ec66f6ce8d) commit tells iOS Safari to ignore the notch.  A downside is that the notch now covers some of our content, but an upside is that it no longer shifts some of our content off the right edge of the screen.

Here are actual iPhone 11 Pro Max screen captures, though after using iOS Safari's somewhat-hard-to-find option to make landscape view go almost full screen.  Otherwise, the user must try and scroll up, to "push" the address bar and tabs out of the way.

### before

![IMG_0732](https://user-images.githubusercontent.com/2205926/78818029-dee0a980-7988-11ea-8d63-f8030688da8f.PNG)

### after

![IMG_0731](https://user-images.githubusercontent.com/2205926/78817975-cc667000-7988-11ea-844b-7f0f5fe6b54d.PNG)

### Rotate overlay

On a browser that supports the Visual Viewport API, the "rotate phone" overlay consistently looks like this.  If the user pans or zooms, it will refresh itself like this 1/5 of a second later.

![iphone_11_rotate](https://user-images.githubusercontent.com/2205926/78417322-ad14bf00-75e5-11ea-99d9-4eec0bc80199.PNG)


