### PR TITLE
destroy CourseScript objects when destroying a Course

### DIFF
--- a/dashboard/app/models/course.rb
+++ b/dashboard/app/models/course.rb
@@ -17,9 +17,9 @@ require 'cdo/script_constants'
 class Course < ApplicationRecord
   # Some Courses will have an associated Plc::Course, most will not
   has_one :plc_course, class_name: 'Plc::Course'
-  has_many :default_course_scripts, -> {where(experiment_name: nil).order('position ASC')}, class_name: 'CourseScript'
+  has_many :default_course_scripts, -> {where(experiment_name: nil).order('position ASC')}, class_name: 'CourseScript', dependent: :destroy
   has_many :default_scripts, through: :default_course_scripts, source: :script
-  has_many :alternate_course_scripts, -> {where.not(experiment_name: nil)}, class_name: 'CourseScript'
+  has_many :alternate_course_scripts, -> {where.not(experiment_name: nil)}, class_name: 'CourseScript', dependent: :destroy
 
   after_save :write_serialization
 


### PR DESCRIPTION
As part of deploying https://github.com/code-dot-org/code-dot-org/pull/33943, I removed all the unneeded courses and scripts from the test machine. this revealed that destroying a course does not destroy its CourseScript objects, resulting in server errors. This PR makes it so that destroying a course also destroys its CourseScript objects.

## Testing story

manually verified that destroying a course also destroys its course_scripts.

## Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
