### PR TITLE
Fix assets:clean for wp-digested assets

### DIFF
--- a/dashboard/lib/tasks/asset_sync.rake
+++ b/dashboard/lib/tasks/asset_sync.rake
@@ -13,7 +13,12 @@ namespace :assets do
   desc 'Synchronize newly-added assets to S3'
   task sync: :record_manifest_files do
     m = manifest
-    changed_paths = (m.files.to_a - @manifest_files.to_a).
+
+    # Only compare digest to determine whether a path has changed.
+    new_files = m.files.transform_values {|f| f['digest']}.to_a
+    old_files = @manifest_files.transform_values {|f| f['digest']}.to_a
+
+    changed_paths = (new_files - old_files).
       map {|key, _| [key, File.join(m.dir, key)]}.to_h
     next if changed_paths.empty?
 
@@ -47,20 +52,32 @@ Rerun `assets:precompile` to regenerate new assets and try again."
   # Patch Sprockets to skip digesting already-digested webpack ('wp') assets.
   # Webpack adds its own hash to various files and doesn't have any
   # knowledge of Sprockets digests, so the Sprockets processed-asset digest
-  # path should equal the logical path for these assets. The webpack hash can
-  # be either a 20- or 32-character hexadecimal string. Search Gruntfile.js and
-  # webpack.js for [hash] and [contenthash] to see when webpack might generate
-  # content hashes of each length.
+  # path should equal the logical path for these assets.
   #
   # This means that the digest for these assets is based on the webpack content
   # and not the Sprockets-processed output, so the wp-digest will not get
   # updated if there are any changes to Sprockets processors.
   module NoDoubleDigest
     def digest_path
-      logical_path.match?(/wp\h{20}/) ? logical_path : super
+      logical_path.match?(WP_REGEX) ? logical_path : super
     end
   end
   Sprockets::Asset.prepend NoDoubleDigest
+
+  # Patch Sprockets to un-digest logical paths being saved to manifest on disk.
+  # This allows webpack asset versions to be grouped together and deleted as expected by `assets:clean`.
+  module UnDigestManifest
+    def json_encode(obj)
+      obj['files'].each {|_, attrs| attrs['logical_path'].sub!(WP_REGEX, '')}
+      super
+    end
+  end
+  Sprockets::Manifest.prepend UnDigestManifest
+
+  # The webpack hash can be either a 20- or 32-character hexadecimal string.
+  # Search Gruntfile.js and webpack.js for [hash] and [contenthash] to
+  # see when webpack might generate content hashes of each length.
+  WP_REGEX = /wp\h{20,32}/
 end
 
 Rake::Task['assets:precompile'].enhance([:record_manifest_files]) do


### PR DESCRIPTION
Followup to #30901, to fix an issue where `assets:clean` did not remove webpack-assets containing a `wp[hex...]` digest suffix, causing all previous versions of assets to accumulate on disk.

This happens because each individual version is loaded as its own separate source asset (with a separate logical path from other versions), so `assets:clean` never removes any of them.

This PR tries to fix the issue by 'un-digesting' the `wp[hex]` suffix from source-file assets in the `Manifest#json_encode` method that writes the manifest to disk, so that when [`Manifest#clean` groups assets by `logical_path`](https://github.com/wjordan/sprockets/blob/concurrent_asset_bundle_3.x/lib/sprockets/manifest.rb#L280), all versions of the assets will be grouped together and the oldest ones will be deleted.

### Testing story

Manually testing on a cdn-enabled adhoc (https://adhoc-wp-asset-clean-fix.cdn-code.org/) to confirm that assets still precompile and load successfully.

Also tested this by manually running `assets:clean` on `production-console`, and confirming that it removed all old asset versions from disk. (The initial run takes a _very long time_ because so many versions of each asset have accumulated!)

Not sure what other testing might be necessary to make sure this doesn't break random use-cases.

### Links

- [INF-322](https://codedotorg.atlassian.net/browse/INF-322)
- [LP-712](https://codedotorg.atlassian.net/browse/LP-712)
