### PR TITLE
wait for section dialog to close using jquery

### DIFF
--- a/dashboard/test/ui/features/step_definitions/steps.rb
+++ b/dashboard/test/ui/features/step_definitions/steps.rb
@@ -1108,7 +1108,7 @@ And /^I create a new section with course "([^"]*)", version "([^"]*)"(?: and uni
 
   individual_steps %Q{
     And I press the save button to create a new section
-    And I wait for the dialog to close
+    And I wait for the dialog to close using jQuery
     Then I should see the section table
   }
 end
@@ -1631,6 +1631,10 @@ end
 
 When /^I wait for the dialog to close$/ do
   steps 'When I wait until element ".modal" is gone'
+end
+
+When /^I wait for the dialog to close using jQuery$/ do
+  steps 'When I wait until element ".modal" is not visible'
 end
 
 Then /^I should see the section table$/ do


### PR DESCRIPTION
After https://github.com/code-dot-org/code-dot-org/pull/33943, I started seeing some flaky failures when saving the edit section dialog on IE11: https://cucumber-logs.s3.amazonaws.com/test/test/IE11_learning_platform_teacher_homepage_output.html?versionId=bbIciTKv50tSfvzdqFVjmni1KQpSDJf8
![Screen Shot 2020-04-01 at 5 07 35 PM](https://user-images.githubusercontent.com/8001765/78197817-5c616280-743b-11ea-8fe8-82094d4b7d63.png)

this PR is to test the hypothesis that waiting for the dialog to disappear using selenium (as opposed to jquery) is somehow unreliable on IE11.

If this works, we might use this approach to start re-enabling tests which are disabled on IE that call `I wait until the dialog is gone`.

## Testing story

The test shown above failed roughly 5 out of 7 times this afternoon. After adding this fix on the test machine, it passed 4 out of 4 times.

## Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
