### PR TITLE
default blockly strings to english in the i18n sync

### DIFF
--- a/bin/i18n/sync-out.rb
+++ b/bin/i18n/sync-out.rb
@@ -230,10 +230,24 @@ def distribute_translations
     end
 
     ### Blockly Core
+    # Blockly doesn't know how to fall back to English, so here we manually and
+    # explicitly default all untranslated strings to English.
+    blockly_english = JSON.load(File.open("i18n/locales/source/blockly-core/core.json"))
     Dir.glob("i18n/locales/#{locale}/blockly-core/*.json") do |loc_file|
+      translations = JSON.load(File.open(loc_file))
+      # Create a hash containing all translations, with English strings in
+      # place of any missing translations. We do this as 'english merge
+      # translations' rather than 'translations merge english' to ensure that
+      # we include all the keys from English, regardless of which keys are in
+      # the translations hash.
+      translations_with_fallback = blockly_english.merge(translations) do |_key, english, translation|
+        translation.empty? ? english : translation
+      end
+      #puts "\ntranslations:\n#{translations_with_fallback.inspect}\n" if locale == "co-CO"
+      #puts "\ntranslations:\n#{translations_with_fallback.inspect}\n" if locale == "es-MX"
       relname = File.basename(loc_file)
       destination = "apps/node_modules/@code-dot-org/blockly/i18n/locales/#{locale}/#{relname}"
-      sanitize_file_and_write(loc_file, destination)
+      sanitize_data_and_write(translations_with_fallback, destination)
     end
 
     ### Pegasus

--- a/bin/i18n/sync-out.rb
+++ b/bin/i18n/sync-out.rb
@@ -243,8 +243,6 @@ def distribute_translations
       translations_with_fallback = blockly_english.merge(translations) do |_key, english, translation|
         translation.empty? ? english : translation
       end
-      #puts "\ntranslations:\n#{translations_with_fallback.inspect}\n" if locale == "co-CO"
-      #puts "\ntranslations:\n#{translations_with_fallback.inspect}\n" if locale == "es-MX"
       relname = File.basename(loc_file)
       destination = "apps/node_modules/@code-dot-org/blockly/i18n/locales/#{locale}/#{relname}"
       sanitize_data_and_write(translations_with_fallback, destination)


### PR DESCRIPTION
 since it doesn't know how to do that itself. See https://github.com/code-dot-org/code-dot-org/pull/34002 for what this change will look like

## Testing story

On https://studio.code.org/s/allthethings/stage/4/puzzle/4/lang/co-co:

Before | After
--- | ---
![Screen Shot 2020-04-02 at 12 02 59](https://user-images.githubusercontent.com/244100/78291239-e9f38f80-74d9-11ea-85c5-12763c0eacd5.png) | ![Screen Shot 2020-04-02 at 12 02 41](https://user-images.githubusercontent.com/244100/78291240-ea8c2600-74d9-11ea-9116-07c822ff7e14.png)


<!--
  Does your change include appropriate tests?

  If so, please describe how the tests included in this PR are sufficient

  If not, please explain why this change does not need to be tested.
-->

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
