### PR TITLE
Add permission to copy/delete ParameterGroups.

### DIFF
--- a/aws/cloudformation/cloud_formation_stack.yml.erb
+++ b/aws/cloudformation/cloud_formation_stack.yml.erb
@@ -310,6 +310,18 @@ Resources:
                 Action:
                   - 'rds:DescribeDBInstances'
                 Resource: '*'
+              - Effect: Allow
+                Action:
+                  - 'rds:CopyDBClusterParameterGroup'
+                  - 'rds:DeleteDBClusterParameterGroup'
+                Resource:
+                  - !Sub "arn:aws:rds:${AWS::Region}:${AWS::AccountId}:cluster-pg:*"
+              - Effect: Allow
+                Action:
+                  - 'rds:CopyDBParameterGroup'
+                  - 'rds:DeleteDBParameterGroup'
+                Resource:
+                  - !Sub "arn:aws:rds:${AWS::Region}:${AWS::AccountId}:pg:*"
         - PolicyName: StopInactiveAdhocInstances
           PolicyDocument:
             Statement:


### PR DESCRIPTION
Additional permissions needed now that RDS `clone_cluster` and `delete_cluster` copy & delete ParameterGroups.

### Background

Fixes #33547 

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
