### PR TITLE
Display confirmation modal before updating library

### DIFF
--- a/apps/i18n/common/en_us.json
+++ b/apps/i18n/common/en_us.json
@@ -1633,6 +1633,7 @@
   "updateFirmwareExplanation": "This board is not using the most up-to-date version of the firmware. ",
   "updateFirmwareExplanationClassic": "For best results, please update the firmware by clicking on the button below.",
   "updateFirmwareExplanationExpress": "For best results, please update the firmware by clicking on the button below and following the instructions on the Adafruit website.",
+  "updateLibraryConfirmation": "Are you sure you want to update {libraryName}?",
   "updateUnpluggedLessonProgress": "Update unplugged lesson progress",
   "updateUnpluggedLessonProgressSubHeading": "Make sure your report accurately reflects the unplugged lessons* your class has worked on.",
   "updateUnpluggedProgress": "Update unplugged progress",

--- a/apps/src/code-studio/components/libraries/LibraryListItem.jsx
+++ b/apps/src/code-studio/components/libraries/LibraryListItem.jsx
@@ -133,7 +133,7 @@ export class LibraryListItem extends React.Component {
             <button
               type="button"
               key={'update-' + library.id}
-              onClick={this.props.onUpdate}
+              onClick={() => this.props.onUpdate(library.channelId)}
               style={[styles.actionBtn, styles.updateBtn]}
             >
               <FontAwesome icon="refresh" style={{padding: '0 1px'}} />

--- a/apps/src/code-studio/components/libraries/LibraryListItem.jsx
+++ b/apps/src/code-studio/components/libraries/LibraryListItem.jsx
@@ -133,7 +133,7 @@ export class LibraryListItem extends React.Component {
             <button
               type="button"
               key={'update-' + library.id}
-              onClick={() => this.props.onUpdate(library.channelId)}
+              onClick={this.props.onUpdate}
               style={[styles.actionBtn, styles.updateBtn]}
             >
               <FontAwesome icon="refresh" style={{padding: '0 1px'}} />

--- a/apps/src/code-studio/components/libraries/LibraryManagerDialog.jsx
+++ b/apps/src/code-studio/components/libraries/LibraryManagerDialog.jsx
@@ -364,10 +364,14 @@ export class LibraryManagerDialog extends React.Component {
     const {isOpen} = this.props;
     const {importLibraryId, displayLibrary, isLoading, error} = this.state;
 
+    if (!isOpen) {
+      return null;
+    }
+
     return (
       <div>
         <BaseDialog
-          isOpen={isOpen}
+          isOpen={true}
           handleClose={this.closeLibraryManager}
           style={{...styles.dialog, ...(displayLibrary ? styles.hidden : {})}}
           useUpdatedStyles
@@ -399,7 +403,7 @@ export class LibraryManagerDialog extends React.Component {
           </div>
           <div style={styles.error}>{error}</div>
         </BaseDialog>
-        {isOpen && displayLibrary && this.renderDisplayLibrary()}
+        {displayLibrary && this.renderDisplayLibrary()}
       </div>
     );
   }

--- a/apps/src/code-studio/components/libraries/LibraryManagerDialog.jsx
+++ b/apps/src/code-studio/components/libraries/LibraryManagerDialog.jsx
@@ -316,11 +316,8 @@ export class LibraryManagerDialog extends React.Component {
 
   renderDisplayLibrary = () => {
     const {displayLibrary, displayLibraryMode} = this.state;
-    if (
-      !displayLibrary ||
-      !Object.values(DisplayLibraryMode).includes(displayLibraryMode)
-    ) {
-      return;
+    if (!displayLibrary) {
+      return null;
     }
 
     const onClose = () =>
@@ -329,41 +326,42 @@ export class LibraryManagerDialog extends React.Component {
         displayLibraryMode: DisplayLibraryMode.NONE
       });
 
-    if (displayLibraryMode === DisplayLibraryMode.VIEW) {
-      return (
-        <LibraryViewCode
-          title={displayLibrary.name}
-          description={displayLibrary.description}
-          onClose={onClose}
-          sourceCode={displayLibrary.source}
-        />
-      );
-    }
-
-    if (displayLibraryMode === DisplayLibraryMode.UPDATE) {
-      return (
-        <LibraryViewCode
-          title={i18n.updateLibraryConfirmation({
-            libraryName: displayLibrary.name
-          })}
-          description={displayLibrary.description}
-          onClose={onClose}
-          sourceCode={displayLibrary.source}
-          buttons={
-            <div style={styles.updateButtons}>
-              <Button
-                text={i18n.cancel()}
-                color={Button.ButtonColor.gray}
-                onClick={onClose}
-              />
-              <Button
-                text={i18n.update()}
-                onClick={() => this.updateLibraryInProject(displayLibrary)}
-              />
-            </div>
-          }
-        />
-      );
+    switch (displayLibraryMode) {
+      case DisplayLibraryMode.VIEW:
+        return (
+          <LibraryViewCode
+            title={displayLibrary.name}
+            description={displayLibrary.description}
+            onClose={onClose}
+            sourceCode={displayLibrary.source}
+          />
+        );
+      case DisplayLibraryMode.UPDATE:
+        return (
+          <LibraryViewCode
+            title={i18n.updateLibraryConfirmation({
+              libraryName: displayLibrary.name
+            })}
+            description={displayLibrary.description}
+            onClose={onClose}
+            sourceCode={displayLibrary.source}
+            buttons={
+              <div style={styles.updateButtons}>
+                <Button
+                  text={i18n.cancel()}
+                  color={Button.ButtonColor.gray}
+                  onClick={onClose}
+                />
+                <Button
+                  text={i18n.update()}
+                  onClick={() => this.updateLibraryInProject(displayLibrary)}
+                />
+              </div>
+            }
+          />
+        );
+      default:
+        return null;
     }
   };
 

--- a/apps/src/code-studio/components/libraries/LibraryManagerDialog.jsx
+++ b/apps/src/code-studio/components/libraries/LibraryManagerDialog.jsx
@@ -316,6 +316,13 @@ export class LibraryManagerDialog extends React.Component {
 
   renderDisplayLibrary = () => {
     const {displayLibrary, displayLibraryMode} = this.state;
+    if (
+      !displayLibrary ||
+      !Object.values(DisplayLibraryMode).includes(displayLibraryMode)
+    ) {
+      return;
+    }
+
     const onClose = () =>
       this.setState({
         displayLibrary: null,

--- a/apps/src/code-studio/components/libraries/LibraryManagerDialog.jsx
+++ b/apps/src/code-studio/components/libraries/LibraryManagerDialog.jsx
@@ -28,7 +28,6 @@ const styles = {
   },
   header: {
     textAlign: 'left',
-    color: color.purple,
     fontSize: 24,
     marginTop: 20
   },

--- a/apps/src/code-studio/components/libraries/LibraryManagerDialog.jsx
+++ b/apps/src/code-studio/components/libraries/LibraryManagerDialog.jsx
@@ -399,7 +399,7 @@ export class LibraryManagerDialog extends React.Component {
           </div>
           <div style={styles.error}>{error}</div>
         </BaseDialog>
-        {displayLibrary && this.renderDisplayLibrary()}
+        {isOpen && displayLibrary && this.renderDisplayLibrary()}
       </div>
     );
   }

--- a/apps/src/code-studio/components/libraries/LibraryManagerDialog.jsx
+++ b/apps/src/code-studio/components/libraries/LibraryManagerDialog.jsx
@@ -376,7 +376,7 @@ export class LibraryManagerDialog extends React.Component {
     return (
       <div>
         <BaseDialog
-          isOpen={true}
+          isOpen
           handleClose={this.closeLibraryManager}
           style={{...styles.dialog, ...(displayLibrary ? styles.hidden : {})}}
           useUpdatedStyles

--- a/apps/src/code-studio/components/libraries/LibraryManagerDialog.jsx
+++ b/apps/src/code-studio/components/libraries/LibraryManagerDialog.jsx
@@ -102,8 +102,7 @@ export class LibraryManagerDialog extends React.Component {
     projectLibraries: [],
     classLibraries: [],
     cachedClassLibraries: [],
-    viewingLibrary: {},
-    isViewingCode: false,
+    viewingLibrary: null,
     isLoading: false,
     error: null,
     updatedLibraryChannels: []
@@ -291,7 +290,7 @@ export class LibraryManagerDialog extends React.Component {
       return;
     }
 
-    this.setState({viewingLibrary: library, isViewingCode: true});
+    this.setState({viewingLibrary: library});
   };
 
   closeLibraryManager = () => {
@@ -301,19 +300,13 @@ export class LibraryManagerDialog extends React.Component {
 
   render() {
     const {isOpen} = this.props;
-    const {
-      isViewingCode,
-      importLibraryId,
-      viewingLibrary,
-      isLoading,
-      error
-    } = this.state;
+    const {importLibraryId, viewingLibrary, isLoading, error} = this.state;
     return (
       <div>
         <BaseDialog
           isOpen={isOpen}
           handleClose={this.closeLibraryManager}
-          style={{...styles.dialog, ...(isViewingCode ? styles.hidden : {})}}
+          style={{...styles.dialog, ...(viewingLibrary ? styles.hidden : {})}}
           useUpdatedStyles
         >
           <h1 style={styles.header}>{i18n.libraryManage()}</h1>
@@ -343,11 +336,11 @@ export class LibraryManagerDialog extends React.Component {
           </div>
           <div style={styles.error}>{error}</div>
         </BaseDialog>
-        {isViewingCode && (
+        {viewingLibrary && (
           <LibraryViewCode
             title={viewingLibrary.name}
             description={viewingLibrary.description}
-            onClose={() => this.setState({isViewingCode: false})}
+            onClose={() => this.setState({viewingLibrary: null})}
             sourceCode={viewingLibrary.source}
           />
         )}

--- a/apps/src/code-studio/components/libraries/LibraryManagerDialog.jsx
+++ b/apps/src/code-studio/components/libraries/LibraryManagerDialog.jsx
@@ -343,11 +343,12 @@ export class LibraryManagerDialog extends React.Component {
           </div>
           <div style={styles.error}>{error}</div>
         </BaseDialog>
-        <LibraryViewCode
-          isOpen={isViewingCode}
-          onClose={() => this.setState({isViewingCode: false})}
-          library={viewingLibrary}
-        />
+        {isViewingCode && (
+          <LibraryViewCode
+            onClose={() => this.setState({isViewingCode: false})}
+            library={viewingLibrary}
+          />
+        )}
       </div>
     );
   }

--- a/apps/src/code-studio/components/libraries/LibraryManagerDialog.jsx
+++ b/apps/src/code-studio/components/libraries/LibraryManagerDialog.jsx
@@ -91,6 +91,12 @@ export const mapUserNameToProjectLibraries = (
   return projectLibraries;
 };
 
+const DisplayLibraryMode = {
+  NONE: 'none',
+  VIEW: 'view',
+  UPDATE: 'update'
+};
+
 export class LibraryManagerDialog extends React.Component {
   static propTypes = {
     onClose: PropTypes.func.isRequired,
@@ -102,7 +108,8 @@ export class LibraryManagerDialog extends React.Component {
     projectLibraries: [],
     classLibraries: [],
     cachedClassLibraries: [],
-    viewingLibrary: null,
+    displayLibrary: null,
+    displayLibraryMode: DisplayLibraryMode.NONE,
     isLoading: false,
     error: null,
     updatedLibraryChannels: []
@@ -285,12 +292,15 @@ export class LibraryManagerDialog extends React.Component {
     });
   };
 
-  viewCode = library => {
+  viewCode = (library, mode) => {
     if (!library) {
       return;
     }
 
-    this.setState({viewingLibrary: library});
+    this.setState({
+      displayLibrary: library,
+      displayLibraryMode: mode || DisplayLibraryMode.VIEW
+    });
   };
 
   closeLibraryManager = () => {
@@ -300,13 +310,20 @@ export class LibraryManagerDialog extends React.Component {
 
   render() {
     const {isOpen} = this.props;
-    const {importLibraryId, viewingLibrary, isLoading, error} = this.state;
+    const {
+      importLibraryId,
+      displayLibrary,
+      displayLibraryMode,
+      isLoading,
+      error
+    } = this.state;
+
     return (
       <div>
         <BaseDialog
           isOpen={isOpen}
           handleClose={this.closeLibraryManager}
-          style={{...styles.dialog, ...(viewingLibrary ? styles.hidden : {})}}
+          style={{...styles.dialog, ...(displayLibrary ? styles.hidden : {})}}
           useUpdatedStyles
         >
           <h1 style={styles.header}>{i18n.libraryManage()}</h1>
@@ -336,12 +353,17 @@ export class LibraryManagerDialog extends React.Component {
           </div>
           <div style={styles.error}>{error}</div>
         </BaseDialog>
-        {viewingLibrary && (
+        {displayLibraryMode === DisplayLibraryMode.VIEW && displayLibrary && (
           <LibraryViewCode
-            title={viewingLibrary.name}
-            description={viewingLibrary.description}
-            onClose={() => this.setState({viewingLibrary: null})}
-            sourceCode={viewingLibrary.source}
+            title={displayLibrary.name}
+            description={displayLibrary.description}
+            onClose={() =>
+              this.setState({
+                displayLibrary: null,
+                displayLibraryMode: DisplayLibraryMode.NONE
+              })
+            }
+            sourceCode={displayLibrary.source}
           />
         )}
       </div>

--- a/apps/src/code-studio/components/libraries/LibraryManagerDialog.jsx
+++ b/apps/src/code-studio/components/libraries/LibraryManagerDialog.jsx
@@ -254,22 +254,22 @@ export class LibraryManagerDialog extends React.Component {
       return <div style={styles.message}>{i18n.noLibrariesInProject()}</div>;
     }
 
-    return projectLibraries.map(library => {
-      // Only pass onUpdate prop for libraries with updates available.
-      let onUpdate;
-      if (updatedLibraryChannels.includes(library.channelId)) {
-        onUpdate = () => {
-          this.fetchLatestLibrary(library.channelId, lib =>
-            this.viewCode(lib, DisplayLibraryMode.UPDATE)
-          );
-        };
-      }
+    const onUpdate = channelId => {
+      this.fetchLatestLibrary(channelId, lib =>
+        this.viewCode(lib, DisplayLibraryMode.UPDATE)
+      );
+    };
 
+    return projectLibraries.map(library => {
       return (
         <LibraryListItem
           key={library.name}
           library={library}
-          onUpdate={onUpdate}
+          onUpdate={
+            updatedLibraryChannels.includes(library.channelId)
+              ? onUpdate
+              : undefined
+          }
           onRemove={this.removeLibrary}
           onViewCode={() => this.viewCode(library)}
         />

--- a/apps/src/code-studio/components/libraries/LibraryManagerDialog.jsx
+++ b/apps/src/code-studio/components/libraries/LibraryManagerDialog.jsx
@@ -345,8 +345,10 @@ export class LibraryManagerDialog extends React.Component {
         </BaseDialog>
         {isViewingCode && (
           <LibraryViewCode
+            title={viewingLibrary.name}
+            description={viewingLibrary.description}
             onClose={() => this.setState({isViewingCode: false})}
-            library={viewingLibrary}
+            sourceCode={viewingLibrary.source}
           />
         )}
       </div>

--- a/apps/src/code-studio/components/libraries/LibraryViewCode.jsx
+++ b/apps/src/code-studio/components/libraries/LibraryViewCode.jsx
@@ -28,19 +28,12 @@ const styles = {
 export default class LibraryViewCode extends React.Component {
   static propTypes = {
     onClose: PropTypes.func.isRequired,
-    isOpen: PropTypes.bool.isRequired,
     library: PropTypes.object.isRequired
   };
 
-  componentDidUpdate(prevProps) {
-    if (prevProps.isOpen === false && this.props.isOpen === true) {
-      this.onOpen();
-    }
-  }
-
-  onOpen = () => {
+  componentDidMount() {
     const {library} = this.props;
-    this.editor = new droplet.Editor(this.refs.libraryCodeViewer, {
+    this.editor = new droplet.Editor(this.libraryCodeViewer, {
       mode: 'javascript',
       allowFloatingBlocks: false,
       enablePaletteAtStart: false,
@@ -50,18 +43,18 @@ export default class LibraryViewCode extends React.Component {
 
     this.editor.setValue(library.source);
     this.editor.setReadOnly(true);
-  };
+  }
 
   render() {
-    const {isOpen, onClose, library} = this.props;
+    const {onClose, library} = this.props;
     return (
-      <BaseDialog isOpen={isOpen} handleClose={onClose} useUpdatedStyles>
+      <BaseDialog isOpen={true} handleClose={onClose} useUpdatedStyles>
         <Title>{library.name}</Title>
         <Body>
           <div style={{textAlign: 'left'}}>
             <p style={styles.message}>{library.description}</p>
             <div className="libraryCodeViewerContainer" style={styles.code}>
-              <div ref="libraryCodeViewer" />
+              <div ref={node => (this.libraryCodeViewer = node)} />
             </div>
           </div>
         </Body>

--- a/apps/src/code-studio/components/libraries/LibraryViewCode.jsx
+++ b/apps/src/code-studio/components/libraries/LibraryViewCode.jsx
@@ -27,12 +27,14 @@ const styles = {
 
 export default class LibraryViewCode extends React.Component {
   static propTypes = {
+    title: PropTypes.string.isRequired,
+    description: PropTypes.string.isRequired,
     onClose: PropTypes.func.isRequired,
-    library: PropTypes.object.isRequired
+    sourceCode: PropTypes.string.isRequired,
+    buttons: PropTypes.node
   };
 
   componentDidMount() {
-    const {library} = this.props;
     this.editor = new droplet.Editor(this.libraryCodeViewer, {
       mode: 'javascript',
       allowFloatingBlocks: false,
@@ -41,23 +43,25 @@ export default class LibraryViewCode extends React.Component {
       palette: []
     });
 
-    this.editor.setValue(library.source);
+    this.editor.setValue(this.props.sourceCode);
     this.editor.setReadOnly(true);
   }
 
   render() {
-    const {onClose, library} = this.props;
+    const {title, description, onClose, buttons} = this.props;
+
     return (
       <BaseDialog isOpen={true} handleClose={onClose} useUpdatedStyles>
-        <Title>{library.name}</Title>
+        <Title>{title}</Title>
         <Body>
           <div style={{textAlign: 'left'}}>
-            <p style={styles.message}>{library.description}</p>
+            <p style={styles.message}>{description}</p>
             <div className="libraryCodeViewerContainer" style={styles.code}>
               <div ref={node => (this.libraryCodeViewer = node)} />
             </div>
           </div>
         </Body>
+        {buttons}
       </BaseDialog>
     );
   }

--- a/apps/src/code-studio/components/libraries/LibraryViewCode.jsx
+++ b/apps/src/code-studio/components/libraries/LibraryViewCode.jsx
@@ -2,12 +2,24 @@
 import PropTypes from 'prop-types';
 import React from 'react';
 import BaseDialog from '@cdo/apps/templates/BaseDialog';
-import {Body, Title} from '@cdo/apps/templates/Dialog';
+import {Body} from '@cdo/apps/templates/Dialog';
 import color from '@cdo/apps/util/color';
 
 const DEFAULT_MARGIN = 7;
 
 const styles = {
+  dialog: {
+    padding: 15
+  },
+  header: {
+    textAlign: 'left',
+    fontSize: 24,
+    marginTop: 5,
+    whiteSpace: 'pre-wrap',
+    lineHeight: 1.25,
+    textOverflow: 'ellipsis',
+    overflow: 'hidden'
+  },
   message: {
     color: color.dark_charcoal,
     margin: DEFAULT_MARGIN,
@@ -51,8 +63,13 @@ export default class LibraryViewCode extends React.Component {
     const {title, description, onClose, buttons} = this.props;
 
     return (
-      <BaseDialog isOpen={true} handleClose={onClose} useUpdatedStyles>
-        <Title>{title}</Title>
+      <BaseDialog
+        isOpen={true}
+        handleClose={onClose}
+        style={styles.dialog}
+        useUpdatedStyles
+      >
+        <h1 style={styles.header}>{title}</h1>
         <Body>
           <div style={{textAlign: 'left'}}>
             <p style={styles.message}>{description}</p>

--- a/apps/test/unit/code-studio/components/libraries/libraryManagerDialogTest.js
+++ b/apps/test/unit/code-studio/components/libraries/libraryManagerDialogTest.js
@@ -263,6 +263,50 @@ describe('LibraryManagerDialog', () => {
     });
   });
 
+  describe('renderDisplayLibrary', () => {
+    let wrapper, library;
+
+    beforeEach(() => {
+      wrapper = shallow(
+        <LibraryManagerDialog onClose={() => {}} isOpen={false} />
+      );
+      library = {
+        name: 'MyLibrary',
+        description: 'Very fun!',
+        source: 'function myLibrary() {};'
+      };
+    });
+
+    it('returns the view mode component if displayLibraryMode is "view"', () => {
+      wrapper.setState({displayLibrary: library, displayLibraryMode: 'view'});
+
+      const libraryComponent = wrapper.instance().renderDisplayLibrary();
+      expect(libraryComponent.props.title).to.equal(library.name);
+      expect(libraryComponent.props.description).to.equal(library.description);
+      expect(libraryComponent.props.sourceCode).to.equal(library.source);
+      expect(libraryComponent.props.buttons).to.be.undefined;
+    });
+
+    it('returns the update mode component if displayLibraryMode is "update"', () => {
+      wrapper.setState({displayLibrary: library, displayLibraryMode: 'update'});
+
+      const libraryComponent = wrapper.instance().renderDisplayLibrary();
+      expect(libraryComponent.props.title).to.equal(
+        `Are you sure you want to update ${library.name}?`
+      );
+      expect(libraryComponent.props.description).to.equal(library.description);
+      expect(libraryComponent.props.sourceCode).to.equal(library.source);
+      expect(libraryComponent.props.buttons).to.not.be.undefined;
+    });
+
+    it('returns undefined if displayLibraryMode is neither "view" nor "update"', () => {
+      wrapper.setState({displayLibrary: library, displayLibraryMode: 'hi'});
+
+      const libraryComponent = wrapper.instance().renderDisplayLibrary();
+      expect(libraryComponent).to.be.undefined;
+    });
+  });
+
   describe('mapUserNameToProjectLibraries', () => {
     it('maps userName from classLibraries to project libraries', () => {
       const projectLibraries = [{channelId: '123456'}, {channelId: '654321'}];

--- a/apps/test/unit/code-studio/components/libraries/libraryManagerDialogTest.js
+++ b/apps/test/unit/code-studio/components/libraries/libraryManagerDialogTest.js
@@ -16,16 +16,23 @@ describe('LibraryManagerDialog', () => {
     'An error occurred while importing your library. Please make sure you have a valid ID and an internet connection.';
 
   describe('viewCode', () => {
-    it('sets the view library', () => {
+    it('sets displayLibrary and displayLibraryMode in state', () => {
       const wrapper = shallow(
-        <LibraryManagerDialog onClose={() => {}} isOpen={true} />
+        <LibraryManagerDialog onClose={() => {}} isOpen={false} />
       );
       let library = {foo: 'bar'};
-      expect(wrapper.state().viewingLibrary).to.deep.equal({});
-      expect(wrapper.state().isViewingCode).to.be.false;
+      expect(wrapper.state().displayLibrary).to.be.null;
+      expect(wrapper.state().displayLibraryMode).to.equal('none');
       wrapper.instance().viewCode(library);
-      expect(wrapper.state().isViewingCode).to.be.true;
-      expect(wrapper.state().viewingLibrary).to.deep.equal(library);
+      expect(wrapper.state().displayLibraryMode).to.equal('view');
+      expect(wrapper.state().displayLibrary).to.deep.equal(library);
+      library = {new: 'library'};
+      wrapper.instance().viewCode(library, 'update');
+      expect(wrapper.state().displayLibraryMode).to.equal('update');
+      expect(wrapper.state().displayLibrary).to.deep.equal(library);
+      wrapper.instance().viewCode(library, null);
+      expect(wrapper.state().displayLibraryMode).to.equal('view');
+      expect(wrapper.state().displayLibrary).to.deep.equal(library);
     });
   });
 

--- a/apps/test/unit/code-studio/components/libraries/libraryManagerDialogTest.js
+++ b/apps/test/unit/code-studio/components/libraries/libraryManagerDialogTest.js
@@ -299,8 +299,15 @@ describe('LibraryManagerDialog', () => {
       expect(libraryComponent.props.buttons).to.not.be.undefined;
     });
 
-    it('returns undefined if displayLibraryMode is neither "view" nor "update"', () => {
+    it('returns undefined if displayLibraryMode is not present in DisplayLibraryMode', () => {
       wrapper.setState({displayLibrary: library, displayLibraryMode: 'hi'});
+
+      const libraryComponent = wrapper.instance().renderDisplayLibrary();
+      expect(libraryComponent).to.be.undefined;
+    });
+
+    it('returns undefined if displayLibrary is not set in state', () => {
+      wrapper.setState({displayLibrary: null, displayLibraryMode: 'view'});
 
       const libraryComponent = wrapper.instance().renderDisplayLibrary();
       expect(libraryComponent).to.be.undefined;

--- a/apps/test/unit/code-studio/components/libraries/libraryManagerDialogTest.js
+++ b/apps/test/unit/code-studio/components/libraries/libraryManagerDialogTest.js
@@ -299,18 +299,18 @@ describe('LibraryManagerDialog', () => {
       expect(libraryComponent.props.buttons).to.not.be.undefined;
     });
 
-    it('returns undefined if displayLibraryMode is not present in DisplayLibraryMode', () => {
+    it('returns null if displayLibraryMode is not "update" or "view"', () => {
       wrapper.setState({displayLibrary: library, displayLibraryMode: 'hi'});
 
       const libraryComponent = wrapper.instance().renderDisplayLibrary();
-      expect(libraryComponent).to.be.undefined;
+      expect(libraryComponent).to.be.null;
     });
 
-    it('returns undefined if displayLibrary is not set in state', () => {
+    it('returns null if displayLibrary is not set in state', () => {
       wrapper.setState({displayLibrary: null, displayLibraryMode: 'view'});
 
       const libraryComponent = wrapper.instance().renderDisplayLibrary();
-      expect(libraryComponent).to.be.undefined;
+      expect(libraryComponent).to.be.null;
     });
   });
 


### PR DESCRIPTION
Before, when you clicked the "update" button (shown below) in the "Manage Libraries" modal, it would automatically update the library and reload the page.
<img width="748" alt="Screen Shot 2020-03-31 at 3 22 26 PM" src="https://user-images.githubusercontent.com/9812299/78306020-38fbed80-74f7-11ea-9e8f-4686db21d019.png">

Now, we display a confirmation modal before updating the library, which allows the user to see the code in the updated library version. [Video of new behavior](https://drive.google.com/file/d/1TlfBGdR8-ct5pEB-QzxaJ5n_r0Kk-9aJ/view?usp=sharing)

I also made some styling changes to avoid clipping really long library names. Examples:

1. A library name that takes up more than one line:
![Screen Shot 2020-04-01 at 4 57 44 PM](https://user-images.githubusercontent.com/9812299/78306246-c3dce800-74f7-11ea-8ff8-98b4c654333a.png)

2. A title that needs to wrap onto two lines:
![Screen Shot 2020-04-01 at 4 57 16 PM](https://user-images.githubusercontent.com/9812299/78306248-c50e1500-74f7-11ea-930e-023c8814a9b5.png)

## Links

- [STAR-1010](https://codedotorg.atlassian.net/browse/STAR-1010)


# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
