### PR TITLE
User model changes to support parent notifications

### DIFF
--- a/dashboard/app/controllers/application_controller.rb
+++ b/dashboard/app/controllers/application_controller.rb
@@ -131,7 +131,10 @@ class ApplicationController < ActionController::Base
     :email_preference_opt_in,
     :data_transfer_agreement_accepted,
     :data_transfer_agreement_required,
-    school_info_attributes: SCHOOL_INFO_ATTRIBUTES
+    :parent_email_preference_opt_in_required,
+    :parent_email_preference_opt_in,
+    :parent_email_preference_email,
+    school_info_attributes: SCHOOL_INFO_ATTRIBUTES,
   ].freeze
 
   def configure_permitted_parameters

--- a/dashboard/app/controllers/registrations_controller.rb
+++ b/dashboard/app/controllers/registrations_controller.rb
@@ -145,6 +145,9 @@ class RegistrationsController < Devise::RegistrationsController
         params[:email_preference_request_ip] = request.ip
         params[:email_preference_source] = EmailPreference::ACCOUNT_SIGN_UP
         params[:email_preference_form_kind] = "0"
+      elsif params[:user_type] == "student"
+        params[:parent_email_preference_request_ip] = request.ip
+        params[:parent_email_preference_source] = EmailPreference::ACCOUNT_SIGN_UP
       end
 
       params[:data_transfer_agreement_accepted] = params[:data_transfer_agreement_accepted] == "1"

--- a/dashboard/app/models/user.rb
+++ b/dashboard/app/models/user.rb
@@ -209,7 +209,7 @@ class User < ActiveRecord::Base
 
   after_save :save_email_preference, if: -> {email_preference_opt_in.present?}
 
-  after_save :save_parent_email_preference, if: -> {parent_email_preference_opt_in.present?}
+  after_save :save_parent_email_preference, if: :parent_email_preference_opt_in_required?
 
   before_destroy :soft_delete_channels
 
@@ -382,7 +382,9 @@ class User < ActiveRecord::Base
   attr_accessor :email_preference_source
   attr_accessor :email_preference_form_kind
 
+  attr_accessor :parent_email_preference_opt_in_required
   attr_accessor :parent_email_preference_opt_in
+  attr_accessor :parent_email_preference_email
   attr_accessor :parent_email_preference_request_ip
   attr_accessor :parent_email_preference_source
 
@@ -455,6 +457,23 @@ class User < ActiveRecord::Base
   validates_presence_of :email_preference_request_ip, if: -> {email_preference_opt_in.present?}
   validates_presence_of :email_preference_source, if: -> {email_preference_opt_in.present?}
   validates_presence_of :email_preference_form_kind, if: -> {email_preference_opt_in.present?}
+
+  # Validations for adding parent email notifications
+  before_validation :parent_email_preference_setup, if: :parent_email_preference_opt_in_required?
+  validates_inclusion_of :parent_email_preference_opt_in, in: %w(yes no), if: :parent_email_preference_opt_in_required?
+  validates_presence_of :parent_email_preference_email, if: :parent_email_preference_opt_in_required?
+  validates_presence_of :parent_email_preference_request_ip, if: :parent_email_preference_opt_in_required?
+  validates_presence_of :parent_email_preference_source, if: :parent_email_preference_opt_in_required?
+
+  def parent_email_preference_opt_in_required?
+    # parent_email_preference_opt_in_required is a checkbox which either has the value '0' or '1'
+    # user_type 'student' is the only type which supports have a parent_email associated with it.
+    parent_email_preference_opt_in_required == '1' && user_type == 'student'
+  end
+
+  def parent_email_preference_setup
+    self.parent_email = parent_email_preference_email
+  end
 
   validates :data_transfer_agreement_accepted, acceptance: true, if: :data_transfer_agreement_required
   validates_presence_of :data_transfer_agreement_request_ip, if: -> {data_transfer_agreement_accepted.present?}

--- a/dashboard/test/models/user_test.rb
+++ b/dashboard/test/models/user_test.rb
@@ -2277,27 +2277,27 @@ class UserTest < ActiveSupport::TestCase
     assert_nil email_preference
   end
 
-  test 'creating a student with no parent notification should not create an email preference for the parent' do
+  test 'creating a student with no parent email preference should not create an email preference for the parent' do
     parent_email_params = @good_parent_email_params.merge({parent_email_preference_opt_in_required: '0'})
     User.create(@good_data.merge(parent_email_params))
     email_preference = EmailPreference.find_by_email(parent_email_params[:parent_email])
     assert_nil email_preference
   end
 
-  test 'creating a student with parent notification and no parent_email should return an error' do
+  test 'creating a student with parent email preference and no parent_email should return an error' do
     parent_email_params = @good_parent_email_params.merge({parent_email_preference_email: nil})
     user = User.create(@good_data.merge(parent_email_params))
     assert user.errors[:parent_email_preference_email].length == 1
   end
 
-  test 'creating a student with parent notification and no opt-in should return an error' do
+  test 'creating a student with parent email preference and no opt-in should return an error' do
     parent_email_params = @good_parent_email_params.merge({parent_email_preference_opt_in: nil})
     user = User.create(@good_data.merge(parent_email_params))
     assert user.errors[:parent_email_preference_opt_in].length == 1
   end
 
-  test 'creating a teacher with parent notification should not create a notification' do
-    # This tests when someone starts filling out the parent notification form on the student UI but then switches
+  test 'creating a teacher with parent email preference should not create a parent email preference' do
+    # This tests when someone starts filling out the parent email preference form on the student UI but then switches
     # to a Teacher form and submits that.
     parent_email_params = @good_parent_email_params.merge({user_type: 'teacher'})
     user = User.create(@good_data.merge(parent_email_params))

--- a/dashboard/test/models/user_test.rb
+++ b/dashboard/test/models/user_test.rb
@@ -30,7 +30,8 @@ class UserTest < ActiveSupport::TestCase
       uid: '110879982140384463192',
     }
     @good_parent_email_params = {
-      parent_email: 'parent@email.com',
+      parent_email_preference_email: 'parent@email.com',
+      parent_email_preference_opt_in_required: '1',
       parent_email_preference_opt_in: 'yes',
       parent_email_preference_request_ip: '127.0.0.1',
       parent_email_preference_source: EmailPreference::ACCOUNT_SIGN_UP
@@ -2206,7 +2207,7 @@ class UserTest < ActiveSupport::TestCase
   end
 
   def assert_parent_email_params_equals_email_preference(parent_email_params, email_preference)
-    assert_equal parent_email_params[:parent_email], email_preference.email
+    assert_equal parent_email_params[:parent_email_preference_email], email_preference.email
     assert_equal parent_email_params[:parent_email_preference_opt_in].casecmp?('yes'), email_preference.opt_in
     assert_equal parent_email_params[:parent_email_preference_request_ip], email_preference.ip_address
     assert_equal parent_email_params[:parent_email_preference_source], email_preference.source
@@ -2215,7 +2216,7 @@ class UserTest < ActiveSupport::TestCase
   test 'creating a student with parent email should create an email preference for the parent' do
     parent_email_params = @good_parent_email_params
     User.create(@good_data.merge(parent_email_params))
-    email_preference = EmailPreference.find_by_email(parent_email_params[:parent_email])
+    email_preference = EmailPreference.find_by_email(parent_email_params[:parent_email_preference_email])
     assert_not_nil email_preference
     assert_parent_email_params_equals_email_preference parent_email_params, email_preference
   end
@@ -2223,7 +2224,7 @@ class UserTest < ActiveSupport::TestCase
   test 'creating a student with parent email and opt-out should create an email preference for the parent' do
     parent_email_params = @good_parent_email_params.merge({parent_email_preference_opt_in: 'no'})
     User.create(@good_data.merge(parent_email_params))
-    email_preference = EmailPreference.find_by_email(parent_email_params[:parent_email])
+    email_preference = EmailPreference.find_by_email(parent_email_params[:parent_email_preference_email])
     assert_not_nil email_preference
     assert_parent_email_params_equals_email_preference parent_email_params, email_preference
   end
@@ -2231,34 +2232,34 @@ class UserTest < ActiveSupport::TestCase
   test 'updating a student with parent email should create an email preference for the parent' do
     parent_email_params = @good_parent_email_params
     user = User.create(@good_data)
-    email_preference = EmailPreference.find_by_email(parent_email_params[:parent_email])
+    email_preference = EmailPreference.find_by_email(parent_email_params[:parent_email_preference_email])
     # There should be no email preference because no parent_email was defined.
     assert_nil email_preference
     user.update!(parent_email_params)
-    email_preference = EmailPreference.find_by_email(parent_email_params[:parent_email])
+    email_preference = EmailPreference.find_by_email(parent_email_params[:parent_email_preference_email])
     # There should now be an email preference because the user was updated with a parent_email.
     assert_not_nil email_preference
     assert_parent_email_params_equals_email_preference parent_email_params, email_preference
   end
 
   test 'creating a student with parent email opt in and a nil email address should not create an email preference for the parent' do
-    parent_email_params = @good_parent_email_params.merge({parent_email: nil})
+    parent_email_params = @good_parent_email_params.merge({parent_email_preference_email: nil})
     User.create(@good_data.merge(parent_email_params))
-    email_preference = EmailPreference.find_by_email(parent_email_params[:parent_email])
+    email_preference = EmailPreference.find_by_email(parent_email_params[:parent_email_preference_email])
     assert_nil email_preference
   end
 
   test 'creating a student with parent email opt in and an empty string email address should not create an email preference for the parent' do
-    parent_email_params = @good_parent_email_params.merge({parent_email: ''})
+    parent_email_params = @good_parent_email_params.merge({parent_email_preference_email: ''})
     User.create(@good_data.merge(parent_email_params))
-    email_preference = EmailPreference.find_by_email(parent_email_params[:parent_email])
+    email_preference = EmailPreference.find_by_email(parent_email_params[:parent_email_preference_email])
     assert_nil email_preference
   end
 
   test 'creating a student with parent email opt in and a blank string email address should not create an email preference for the parent' do
-    parent_email_params = @good_parent_email_params.merge({parent_email: '    '})
+    parent_email_params = @good_parent_email_params.merge({parent_email_preference_email: '    '})
     User.create(@good_data.merge(parent_email_params))
-    email_preference = EmailPreference.find_by_email(parent_email_params[:parent_email])
+    email_preference = EmailPreference.find_by_email(parent_email_params[:parent_email_preference_email])
     assert_nil email_preference
   end
 
@@ -2272,6 +2273,38 @@ class UserTest < ActiveSupport::TestCase
   test 'creating a student with parent email opt in and a nil request_ip should not create an email preference for the parent' do
     parent_email_params = @good_parent_email_params.merge({parent_email_preference_request_ip: nil})
     User.create(@good_data.merge(parent_email_params))
+    email_preference = EmailPreference.find_by_email(parent_email_params[:parent_email])
+    assert_nil email_preference
+  end
+
+  test 'creating a student with no parent notification should not create an email preference for the parent' do
+    parent_email_params = @good_parent_email_params.merge({parent_email_preference_opt_in_required: '0'})
+    User.create(@good_data.merge(parent_email_params))
+    email_preference = EmailPreference.find_by_email(parent_email_params[:parent_email])
+    assert_nil email_preference
+  end
+
+  test 'creating a student with parent notification and no parent_email should return an error' do
+    parent_email_params = @good_parent_email_params.merge({parent_email_preference_email: nil})
+    user = User.create(@good_data.merge(parent_email_params))
+    assert user.errors[:parent_email_preference_email].length == 1
+  end
+
+  test 'creating a student with parent notification and no opt-in should return an error' do
+    parent_email_params = @good_parent_email_params.merge({parent_email_preference_opt_in: nil})
+    user = User.create(@good_data.merge(parent_email_params))
+    assert user.errors[:parent_email_preference_opt_in].length == 1
+  end
+
+  test 'creating a teacher with parent notification should not create a notification' do
+    # This tests when someone starts filling out the parent notification form on the student UI but then switches
+    # to a Teacher form and submits that.
+    parent_email_params = @good_parent_email_params.merge({user_type: 'teacher'})
+    user = User.create(@good_data.merge(parent_email_params))
+    assert user.errors[:parent_email_preference_opt_in].empty?
+    # parent_email shouldn't be set for a teacher.
+    assert_nil user.parent_email
+    # no parent email_preference should be created for teachers.
     email_preference = EmailPreference.find_by_email(parent_email_params[:parent_email])
     assert_nil email_preference
   end


### PR DESCRIPTION
As a code.org developer, I want the User model to support functionality
for defining a parent_email and generating an EmailPreference.
* Adds flag to enable/disable setting up a parent notification.
* Adds validation for the parent notification settings.

## Links
- [jira](https://codedotorg.atlassian.net/browse/FND-1093)

## Testing story
* unit tests
* tried with my front end changes and verified they work.

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
