### PR TITLE
Standards: add file icon to generate pdf button

### DIFF
--- a/apps/src/templates/sectionProgress/standards/StandardsViewHeaderButtons.jsx
+++ b/apps/src/templates/sectionProgress/standards/StandardsViewHeaderButtons.jsx
@@ -182,9 +182,10 @@ class StandardsViewHeaderButtons extends Component {
           onClick={this.openCreateReportDialog}
           color={Button.ButtonColor.gray}
           text={i18n.generatePDFReport()}
-          size={'narrow'}
+          size="narrow"
           style={styles.button}
           className="uitest-standards-generate-report"
+          icon="file-text"
         />
         <CreateStandardsReportDialog
           isOpen={this.state.isCreateReportDialogOpen}


### PR DESCRIPTION
In the [parent letter spec](https://docs.google.com/document/d/1wWJOLZ1GKEOerWFu0eX-knnG_vmP1D92ReC-M5M7yI4/edit#heading=h.xtgfp7g6g2u0), looks like we're standardizing on having the file icon in buttons that generate PDFs, so I added it to the standards button as well for consistency. 

<img width="184" alt="Screen Shot 2020-04-03 at 9 39 25 AM" src="https://user-images.githubusercontent.com/12300669/78384635-61cfc180-758f-11ea-8a0b-42be5653a241.png">
