### PR TITLE
Parent Letter: single student option in Manage Students table 

### DIFF
--- a/apps/i18n/common/en_us.json
+++ b/apps/i18n/common/en_us.json
@@ -516,6 +516,7 @@
   "downloadCSV": "Download CSV",
   "downloadAssessmentCSV": "Download CSV of student responses",
   "downloadFeedbackCSV": "Download CSV of Feedback",
+  "downloadParentLetter": "Download parent letter",
   "downloadReplayVideoButtonDownload": "Animation",
   "downloadReplayVideoButtonError": "Sorry, we were unable to download your animation. Please try re-running your project and trying again.",
   "dragBlocksToMatch": "Drag the blocks to match",

--- a/apps/src/templates/manageStudents/ManageStudentsActionsCell.jsx
+++ b/apps/src/templates/manageStudents/ManageStudentsActionsCell.jsx
@@ -20,6 +20,7 @@ import i18n from '@cdo/locale';
 import {navigateToHref} from '@cdo/apps/utils';
 import {teacherDashboardUrl} from '@cdo/apps/templates/teacherDashboard/urlHelpers';
 import firehoseClient from '@cdo/apps/lib/util/firehose';
+import experiments from '@cdo/apps/util/experiments';
 
 const styles = {
   xIcon: {
@@ -192,6 +193,22 @@ class ManageStudentActionsCell extends Component {
     navigateToHref(url);
   };
 
+  onDownloadParentLetter = () => {
+    const {id, sectionId} = this.props;
+    firehoseClient.putRecord(
+      {
+        study: 'teacher-dashboard',
+        study_group: 'manage-students-actions',
+        event: 'single-student-download-parent-letter',
+        data_json: JSON.stringify({
+          sectionId: sectionId,
+          studentId: id
+        })
+      },
+      {includeUserId: true}
+    );
+  };
+
   render() {
     const {rowType, isEditing, loginType} = this.props;
     const canDelete = [
@@ -200,7 +217,7 @@ class ManageStudentActionsCell extends Component {
       SectionLoginType.email
     ].includes(loginType);
 
-    const showLoginCardOption = [
+    const showWordPictureOptions = [
       SectionLoginType.word,
       SectionLoginType.picture
     ].includes(loginType);
@@ -214,11 +231,17 @@ class ManageStudentActionsCell extends Component {
                 {i18n.edit()}
               </PopUpMenu.Item>
             )}
-            {showLoginCardOption && (
+            {showWordPictureOptions && (
               <PopUpMenu.Item onClick={this.onPrintLoginInfo}>
                 {i18n.printLoginCard()}
               </PopUpMenu.Item>
             )}
+            {showWordPictureOptions &&
+              experiments.isEnabled(experiments.PARENT_LETTER) && (
+                <PopUpMenu.Item onClick={this.onDownloadParentLetter}>
+                  {i18n.downloadParentLetter()}
+                </PopUpMenu.Item>
+              )}
             {this.props.canEdit && canDelete && <MenuBreak />}
             {canDelete && (
               <PopUpMenu.Item onClick={this.onRequestDelete} color={color.red}>

--- a/apps/src/util/experiments.js
+++ b/apps/src/util/experiments.js
@@ -25,6 +25,7 @@ experiments.APPLAB_DATASETS = 'applabDatasets';
 experiments.SHOW_UNPUBLISHED_FIREBASE_TABLES = 'showUnpublishedFirebaseTables';
 experiments.STUDENT_LIBRARIES = 'student-libraries';
 experiments.STANDARDS_REPORT = 'standardsReport';
+experiments.PARENT_LETTER = 'parentLetter';
 experiments.BETT_DEMO = 'bett-demo';
 experiments.TEACHER_DASHBOARD_SECTION_BUTTONS =
   'teacher-dashboard-section-buttons';


### PR DESCRIPTION
[LP-1366](https://codedotorg.atlassian.net/browse/LP-1366) partial 
[Parent Letter spec, Req. 6](https://docs.google.com/document/d/1wWJOLZ1GKEOerWFu0eX-knnG_vmP1D92ReC-M5M7yI4/edit#bookmark=id.3uecncfvcfqy)

If experiment `parentLetter` is enabled, and a teacher is viewing the Manage Students Table for a Word or Picture section there is now an additional option to "Download parent letter". 

<img width="483" alt="Screen Shot 2020-04-03 at 10 17 56 AM" src="https://user-images.githubusercontent.com/12300669/78388189-6f884580-7595-11ea-848c-b8c690838531.png">

Clicking that option doesn't do anything yet, except log a firehose event: 
<img width="993" alt="Screen Shot 2020-04-03 at 10 20 25 AM" src="https://user-images.githubusercontent.com/12300669/78388194-70b97280-7595-11ea-8242-263a39eeccdf.png">

Up next will be opening the parent letter PDF customized for that student when the new option is clicked. 