### PR TITLE
Remove plc task tables

### DIFF
--- a/dashboard/db/migrate/20200403191929_drop_plc_tasks.rb
+++ b/dashboard/db/migrate/20200403191929_drop_plc_tasks.rb
@@ -1,0 +1,6 @@
+class DropPlcTasks < ActiveRecord::Migration[5.0]
+  def change
+    drop_table :plc_learning_modules_tasks
+    drop_table :plc_tasks
+  end
+end

--- a/dashboard/db/schema.rb
+++ b/dashboard/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20200317174030) do
+ActiveRecord::Schema.define(version: 20200403191929) do
 
   create_table "activities", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci" do |t|
     t.integer  "user_id"
@@ -1150,23 +1150,6 @@ ActiveRecord::Schema.define(version: 20200317174030) do
     t.index ["stage_id"], name: "index_plc_learning_modules_on_stage_id", using: :btree
   end
 
-  create_table "plc_learning_modules_tasks", id: false, force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci" do |t|
-    t.integer "plc_learning_module_id", null: false
-    t.integer "plc_task_id",            null: false
-    t.index ["plc_learning_module_id"], name: "index_plc_learning_modules_tasks_on_plc_learning_module_id", using: :btree
-    t.index ["plc_task_id"], name: "index_plc_learning_modules_tasks_on_plc_task_id", using: :btree
-  end
-
-  create_table "plc_tasks", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci" do |t|
-    t.string   "name"
-    t.datetime "created_at",                                          null: false
-    t.datetime "updated_at",                                          null: false
-    t.string   "type",                          default: "Plc::Task", null: false
-    t.text     "properties",      limit: 65535
-    t.integer  "script_level_id"
-    t.index ["script_level_id"], name: "index_plc_tasks_on_script_level_id", using: :btree
-  end
-
   create_table "plc_user_course_enrollments", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci" do |t|
     t.string   "status"
     t.integer  "plc_course_id"
@@ -1790,7 +1773,6 @@ ActiveRecord::Schema.define(version: 20200317174030) do
   add_foreign_key "plc_course_units", "scripts"
   add_foreign_key "plc_courses", "courses"
   add_foreign_key "plc_learning_modules", "stages"
-  add_foreign_key "plc_tasks", "script_levels"
   add_foreign_key "queued_account_purges", "users"
   add_foreign_key "school_infos", "school_districts"
   add_foreign_key "school_infos", "schools"


### PR DESCRIPTION
Follow-on to https://github.com/code-dot-org/code-dot-org/pull/34028 . Remove plc tasks table as well as mappings from plc learning modules to tasks. This step will destroy any plc tasks data in production.

## Testing story

## Deployment strategy

Wait until after removing the Plc::Task model to see if anything breaks before merging this PR.

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
