### PR TITLE
recover gracefully when fetching stage descriptions

### DIFF
--- a/apps/src/lib/script-editor/StageDescriptions.jsx
+++ b/apps/src/lib/script-editor/StageDescriptions.jsx
@@ -121,11 +121,14 @@ export default class StageDescriptions extends React.Component {
     const {importedDescriptions} = this.state;
 
     // we want to make sure that we use the existing names, with the imported descriptions
-    return currentDescriptions.map((item, index) => ({
-      name: item.name,
-      descriptionStudent: importedDescriptions[index].descriptionStudent,
-      descriptionTeacher: importedDescriptions[index].descriptionTeacher
-    }));
+    return currentDescriptions.map((item, index) => {
+      const descriptions = importedDescriptions[index] || {};
+      return {
+        name: item.name,
+        descriptionStudent: descriptions.descriptionStudent,
+        descriptionTeacher: descriptions.descriptionTeacher
+      };
+    });
   };
 
   render() {
@@ -147,7 +150,7 @@ export default class StageDescriptions extends React.Component {
                 const currentStudent = stage.descriptionStudent;
                 const currentTeacher = stage.descriptionTeacher;
 
-                const importedStage = importedDescriptions[index];
+                const importedStage = importedDescriptions[index] || {};
                 const updatedStudent =
                   hasImported && importedStage.descriptionStudent;
                 const updatedTeacher =

--- a/apps/test/unit/lib/script-editor/StageDescriptionsTest.js
+++ b/apps/test/unit/lib/script-editor/StageDescriptionsTest.js
@@ -169,4 +169,44 @@ describe('StageDescriptions', () => {
       ])
     );
   });
+
+  it('recovers when there are too few importedDescriptions', () => {
+    const wrapper = mount(
+      <StageDescriptions
+        scriptName="myscript"
+        currentDescriptions={currentDescriptions}
+      />
+    );
+    wrapper.setState({collapsed: false});
+    // now click import button
+    const importButton = wrapper.find('button').at(1);
+    assert.equal(importButton.text(), 'Import from Curriculum Builder');
+    importButton.simulate('click');
+
+    assert.equal(requests.length, 1);
+    assert.equal(
+      requests[0].url,
+      'https://curriculum.code.org/metadata/myscript.json'
+    );
+
+    requests[0].respond(
+      200,
+      {'Content-Type': 'application/json'},
+      JSON.stringify({
+        lessons: [
+          {
+            title: currentDescriptions[0].name,
+            student_desc: currentDescriptions[0].descriptionStudent,
+            teacher_desc: currentDescriptions[0].descriptionTeacher
+          }
+        ]
+      })
+    );
+    wrapper.update();
+
+    // If we get here, the import completed without any JS errors.
+    assert.equal(wrapper.state('buttonText'), 'Imported');
+    const imported = wrapper.state('importedDescriptions');
+    assert.equal(imported.length, 1);
+  });
 });


### PR DESCRIPTION
Quick fix for broken pull-through of stage descriptions when levelbuilder has more stages than curriculum builder does. See https://codedotorg.slack.com/archives/CA3KCSGTD/p1585949395130800 for more context.

## Testing story

manually verified locally that when LB has more stages than CB, the operation succeeds instead of failing, and there is enough info in the output to see which stages are missing from CB:
![Screen Shot 2020-04-03 at 3 34 23 PM](https://user-images.githubusercontent.com/8001765/78410409-0fa79400-75c1-11ea-98ad-88e4a1079720.png)


# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
