### PR TITLE
Bump js-interpreter to 1.3.13

### DIFF
--- a/apps/package.json
+++ b/apps/package.json
@@ -225,7 +225,7 @@
     "webpack-stats-plugin": "^0.2.1"
   },
   "dependencies": {
-    "@code-dot-org/js-interpreter": "1.3.12",
+    "@code-dot-org/js-interpreter": "1.3.13",
     "crypto-js": "^3.1.9-1",
     "details-element-polyfill": "https://github.com/javan/details-element-polyfill",
     "filesaver.js": "0.2.0",

--- a/apps/yarn.lock
+++ b/apps/yarn.lock
@@ -1608,10 +1608,10 @@
     test262-harness "^2.4.0"
     yargs "^7.0.1"
 
-"@code-dot-org/js-interpreter@1.3.12":
-  version "1.3.12"
-  resolved "https://registry.yarnpkg.com/@code-dot-org/js-interpreter/-/js-interpreter-1.3.12.tgz#0f4c8d4a181cfb2602333967425e5b052ae3b636"
-  integrity sha512-oOq7EBIEPrbk5pd9QWn+pW1YHkmBn39Wifh9xNtInPWOYYIgxrye//ndZcUO09jN3CHPssWCCJ3AOVH1+oZQMw==
+"@code-dot-org/js-interpreter@1.3.13":
+  version "1.3.13"
+  resolved "https://registry.yarnpkg.com/@code-dot-org/js-interpreter/-/js-interpreter-1.3.13.tgz#2fddcc9cf6bd4f1c752e171fe9f0eb20155eeacd"
+  integrity sha512-CsjSFqt0FNilxPM4WKAj4tS7/CuKLbHzfyP7N5NBr2wZARoeMrgoz9KhSX2BY20jW2FSZAv7hQdg3eMGZeJD0A==
   dependencies:
     yargs "^7.0.1"
 


### PR DESCRIPTION
Pulls in https://github.com/code-dot-org/JS-Interpreter/pull/37 to fix switch statements.