### PR TITLE
Teacher Dashboard: make last progress tooltip translatable

### DIFF
--- a/apps/i18n/common/en_us.json
+++ b/apps/i18n/common/en_us.json
@@ -835,6 +835,7 @@
   "keyValuePairLink": "Key/value pairs",
   "languages": "Languages",
   "lastEdited": "Last Edited",
+  "lastProgress": "Last Progress:",
   "lastPublished": "Last Published",
   "lastUpdated": "Last updated {time}",
   "lastUpdatedNoTime": "Last Updated:",

--- a/apps/src/templates/sectionProgress/SectionProgress.jsx
+++ b/apps/src/templates/sectionProgress/SectionProgress.jsx
@@ -158,7 +158,7 @@ class SectionProgress extends Component {
         effect="solid"
       >
         <span style={styles.studentTooltip}>
-          Last Progress:
+          {i18n.lastProgress()}
           <br />
           {this.tooltipTextForStudent(studentId)}
         </span>


### PR DESCRIPTION
We missed making a string in the last progress timestamp translatable. Now "Last Progress:" is in the i18n pipeline.

<img width="189" alt="Screen Shot 2020-04-06 at 9 45 34 AM" src="https://user-images.githubusercontent.com/12300669/78583637-f2a2d900-77eb-11ea-8011-9808bef4b2e4.png">
