### PR TITLE
Add missing apps string

### DIFF
--- a/apps/i18n/common/en_us.json
+++ b/apps/i18n/common/en_us.json
@@ -1455,6 +1455,7 @@
   "shareWarningsStoreDataAfterHighlight": ".",
   "sharingAgePrompt": "Please select an age.",
   "sharingBlockedByTeacher": "Sorry, you do not have permissions to share this project. If you want to be able to share your project, please ask your teacher to enable sharing of App Lab / Game Lab / Web Lab projects for your section from the 'Manage students' tab in their dashboard. They can do this by adding the project sharing column from the Actions settings menu.",
+  "sharingDisabled": "Sorry, this project is not available for sharing. If this is your project or the project of one of your students, please [sign in]({sign_in_url}) to your account to view the project.",
   "show": "Show",
   "showAnswers": "Show answers",
   "showAnswersInstructions": "\"Show answers\" to put the assessment into a read-only mode.",

--- a/apps/src/code-studio/initApp/loadApp.js
+++ b/apps/src/code-studio/initApp/loadApp.js
@@ -312,7 +312,12 @@ function loadProjectAndCheckAbuse(appOptions) {
         return;
       }
       if (project.getSharingDisabled()) {
-        renderAbusive(project, msg.sharingDisabled());
+        renderAbusive(
+          project,
+          msg.sharingDisabled({
+            sign_in_url: 'https://studio.code.org/users/sign_in'
+          })
+        );
         return;
       }
       resolve(appOptions);


### PR DESCRIPTION
In #32576 I removed `javascript_strings` and forgot to add `sharingDisabled` to the apps strings. This adds the string back (and markdown-ifies it). The original string is [here](https://github.com/code-dot-org/code-dot-org/blob/962aa125547b2f4189bee8a0c59a70845f98d664/dashboard/config/locales/en.yml#L871).

<!-- ### Background -->
<!-- ### Privacy -->
<!-- ### Security -->
<!-- ### Caching -->
<!-- ### Deployment strategy -->
<!-- ### Future work -->

## Testing story

I set `sharingDisabled` to true [here](https://github.com/code-dot-org/code-dot-org/blob/962aa125547b2f4189bee8a0c59a70845f98d664/apps/src/code-studio/initApp/project.js#L90). I could repro the issue and this change fixed it.

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
