### PR TITLE
Reload /projects/libraries on unpublish success

### DIFF
--- a/apps/src/templates/projects/LibraryTable.jsx
+++ b/apps/src/templates/projects/LibraryTable.jsx
@@ -11,6 +11,7 @@ import {tableLayoutStyles, sortableOptions} from '../tables/tableConstants';
 import {unpublishProjectLibrary} from './projectsRedux';
 import PersonalProjectsNameCell from './PersonalProjectsNameCell';
 import Button from '@cdo/apps/templates/Button';
+import {reload} from '@cdo/apps/utils';
 
 export const COLUMNS = {
   LIBRARY_NAME: 0,
@@ -225,7 +226,11 @@ class LibraryTable extends React.Component {
         __useDeprecatedTag
         text={i18n.unpublish()}
         color={Button.ButtonColor.orange}
-        onClick={() => this.props.unpublishProjectLibrary(rowData.channel)}
+        onClick={() =>
+          this.props.unpublishProjectLibrary(rowData.channel, error =>
+            error ? console.error(error) : reload()
+          )
+        }
       />
     );
   };
@@ -279,8 +284,8 @@ export default connect(
     personalProjectsList: state.projects.personalProjectsList.projects
   }),
   dispatch => ({
-    unpublishProjectLibrary(channelId, libraryApi, onComplete) {
-      dispatch(unpublishProjectLibrary(channelId, libraryApi, onComplete));
+    unpublishProjectLibrary(channelId, onComplete, libraryApi) {
+      dispatch(unpublishProjectLibrary(channelId, onComplete, libraryApi));
     }
   })
 )(LibraryTable);

--- a/apps/src/templates/projects/projectsRedux.js
+++ b/apps/src/templates/projects/projectsRedux.js
@@ -498,21 +498,17 @@ export const updateProjectLibrary = (projectId, newData) => {
 
 export const unpublishProjectLibrary = (
   projectId,
-  libraryApi = new LibraryClientApi(projectId),
-  onComplete = () => {}
+  onComplete,
+  libraryApi = new LibraryClientApi(projectId)
 ) => {
   return dispatch => {
     fetchProjectToUpdate(projectId, (error, data) => {
       if (error) {
-        onComplete(error, data);
-      } else {
-        libraryApi.unpublish(data, (error, serverData) => {
-          if (!error) {
-            dispatch(updatePersonalProjectData(projectId, serverData));
-          }
-          onComplete(error, serverData);
-        });
+        onComplete(error);
+        return;
       }
+
+      libraryApi.unpublish(data, (error, _) => onComplete(error));
     });
   };
 };

--- a/apps/test/unit/templates/projects/projectsReduxTest.js
+++ b/apps/test/unit/templates/projects/projectsReduxTest.js
@@ -319,7 +319,11 @@ describe('projectsRedux', () => {
     it('unpublishes library', () => {
       setFetchPersonalProjectsResponse(200);
 
-      const action = unpublishProjectLibrary(projectId, libraryApiStub);
+      const action = unpublishProjectLibrary(
+        projectId,
+        () => {},
+        libraryApiStub
+      );
       store.dispatch(action);
       server.respond();
 
@@ -332,8 +336,8 @@ describe('projectsRedux', () => {
 
       const action = unpublishProjectLibrary(
         projectId,
-        libraryApiStub,
-        onCompleteSpy
+        onCompleteSpy,
+        libraryApiStub
       );
       store.dispatch(action);
       server.respond();


### PR DESCRIPTION
Fixes a bug found by @jmkulwik where unpublishing a library from `/projects/libraries` led to some unexpected data being cleared from redux, causing the `<PersonalProjectsTable/>` to not display properly.

**Example:** Below, the "coolest library" project library was just unpublished -- notice "Type" and "Published" column info is missing:
<img width="986" alt="Screen Shot 2020-04-06 at 2 52 17 PM" src="https://user-images.githubusercontent.com/9812299/78608778-56da9280-7816-11ea-8d79-b68a70a6dcde.png">

To fix this, we now reload the page after unpublish succeeds. This is the easiest path forward because the `<PersonalProjectsTable/>` expects very specifically-formatted project data, so rather than overwriting the data in redux (and making more API calls to do so), we will just reload the page.