### PR TITLE
Fix markdown spacing on hourofcode.com

### DIFF
--- a/pegasus/sites.v3/hourofcode.com/views/faq.haml
+++ b/pegasus/sites.v3/hourofcode.com/views/faq.haml
@@ -57,7 +57,7 @@
 %div!= hoc_s(:hoc_faq_map_a_markdown, markdown: :inline, locals: {events_url: resolve_url('/events')})
 
 %h2= hoc_s(:hoc_faq_one_hour_q)
-%div!= hoc_s(:hoc_faq_one_hour_a_markdown, markdown: :inline)
+%div!= hoc_s(:hoc_faq_one_hour_a_markdown, markdown: true)
 
 %h2= hoc_s(:hoc_faq_keep_learning_q)
 %div!= hoc_s(:hoc_faq_keep_learning_a_markdown, markdown: :inline, locals: {promote: resolve_url('/promote')})


### PR DESCRIPTION
use regular markdown; the string being rendered here has paragraphs, so it can't be inlined

Before | After
--- | ---
![image](https://user-images.githubusercontent.com/244100/78609606-dddc3a80-7817-11ea-93ca-265cf94dd575.png) | ![image](https://user-images.githubusercontent.com/244100/78609625-e7fe3900-7817-11ea-9d13-49263dd55afd.png)
