### PR TITLE
Parent letter: New print approach

### DIFF
--- a/apps/Gruntfile.js
+++ b/apps/Gruntfile.js
@@ -578,6 +578,8 @@ describe('entry tests', () => {
     'shared/_school_info': './src/sites/studio/pages/shared/_school_info.js',
     'teacher_dashboard/show':
       './src/sites/studio/pages/teacher_dashboard/show.js',
+    'teacher_dashboard/parent_letter':
+      './src/sites/studio/pages/teacher_dashboard/parent_letter.js',
     'teacher_feedbacks/index':
       './src/sites/studio/pages/teacher_feedbacks/index.js'
   };

--- a/apps/src/lib/ui/ParentLetter.jsx
+++ b/apps/src/lib/ui/ParentLetter.jsx
@@ -52,7 +52,8 @@ class ParentLetter extends React.Component {
         secret_words: PropTypes.string
       })
     ),
-    teacherName: PropTypes.string.isRequired
+    teacherName: PropTypes.string.isRequired,
+    logoUrl: PropTypes.string
   };
 
   static defaultProps = {
@@ -66,7 +67,7 @@ class ParentLetter extends React.Component {
   }
 
   render() {
-    const {students, teacherName, section, studentId} = this.props;
+    const {logoUrl, students, teacherName, section, studentId} = this.props;
     const sectionCode = section.code;
     const loginType = section.loginType;
     const student =
@@ -81,7 +82,7 @@ class ParentLetter extends React.Component {
 
     return (
       <div id="printArea">
-        <Header />
+        <Header logoUrl={logoUrl} />
         <article>
           <p>Hello!</p>
           <p>
@@ -177,12 +178,18 @@ export default connect(state => ({
   studentId: queryParams('studentId')
 }))(ParentLetter);
 
-const Header = () => {
+const Header = ({logoUrl}) => {
   return (
     <header style={styles.header}>
-      <img src="/shared/images/CodeLogo_White.png" style={styles.codeOrgLogo} />
+      <img src={logoUrl} style={styles.codeOrgLogo} />
     </header>
   );
+};
+Header.propTypes = {
+  logoUrl: PropTypes.string.isRequired
+};
+Header.defaultProps = {
+  logoUrl: '/shared/images/CodeLogo_White.png'
 };
 
 const SignInInstructions = ({
@@ -333,6 +340,6 @@ GoToSectionSignIn.propTypes = {
 
 const styles = {
   cleverCodeOrgLogo: {width: 60, margin: 10},
-  codeOrgLogo: {height: 30, margin: 15},
+  codeOrgLogo: {height: 42, margin: '4px 16px'},
   header: {backgroundColor: color.teal, marginBottom: 30}
 };

--- a/apps/src/lib/ui/ParentLetter.jsx
+++ b/apps/src/lib/ui/ParentLetter.jsx
@@ -3,6 +3,7 @@ import PropTypes from 'prop-types';
 import {connect} from 'react-redux';
 import {studio, pegasus} from '../util/urlHelpers';
 import {SectionLoginType} from '../../util/sharedConstants';
+import {queryParams} from '../../code-studio/utils';
 import color from '../../util/color';
 
 const PRIVACY_PLEDGE_URL = 'https://studentprivacypledge.org/signatories/';
@@ -172,7 +173,8 @@ export default connect(state => ({
   section:
     state.teacherSections.sections[state.teacherSections.selectedSectionId],
   students: state.sectionData.section.students,
-  teacherName: state.currentUser.userName
+  teacherName: state.currentUser.userName,
+  studentId: queryParams('studentId')
 }))(ParentLetter);
 
 const Header = () => {

--- a/apps/src/lib/ui/ParentLetter.jsx
+++ b/apps/src/lib/ui/ParentLetter.jsx
@@ -332,7 +332,7 @@ SignInInstructions.propTypes = {
 
 const GoToSignIn = () => (
   <li>
-    Go to <a href={studio('/')}>{studio('/')}</a> and click 'Sign in'
+    Go to <a href={studio('/')}>studio.code.org</a> and click 'Sign in'
   </li>
 );
 
@@ -340,7 +340,8 @@ const GoToSectionSignIn = ({sectionCode, studentName}) => {
   const sectionUrl = studio(`/sections/${sectionCode}`);
   return (
     <li>
-      Go to <a href={sectionUrl}>{sectionUrl}</a> and click on their name
+      Go to <a href={sectionUrl}>studio.code.org/sections/{sectionCode}</a> and
+      click on their name
       {studentName && ` (${studentName})`}
     </li>
   );

--- a/apps/src/lib/ui/ParentLetter.jsx
+++ b/apps/src/lib/ui/ParentLetter.jsx
@@ -1,7 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import {connect} from 'react-redux';
-import _ from 'lodash';
 import {studio, pegasus} from '../util/urlHelpers';
 import {SectionLoginType} from '../../util/sharedConstants';
 import color from '../../util/color';
@@ -61,30 +60,9 @@ class ParentLetter extends React.Component {
 
   componentDidMount() {
     if (this.props.autoPrint) {
-      this.printParentLetter();
+      print();
     }
   }
-
-  printParentLetter = () => {
-    const printArea = document.getElementById('printArea').outerHTML;
-    // Adding a unique ID to the window name allows for multiple instances of this window
-    // to be open at once without affecting each other.
-    const windowName = `printWindow-${_.uniqueId()}`;
-    let printWindow = window.open('', windowName, '');
-
-    printWindow.document.open();
-    printWindow.addEventListener('load', event => {
-      printWindow.print();
-    });
-
-    printWindow.document.write(
-      `<html><head><link rel="stylesheet" type="text/css" href="/shared/css/standards-report-print.css"></head>`
-    );
-    printWindow.document.write('<body onafterprint="self.close()">');
-    printWindow.document.write(printArea);
-    printWindow.document.write('</body></html>');
-    printWindow.document.close();
-  };
 
   render() {
     const {students, teacherName, section, studentId} = this.props;

--- a/apps/src/sites/studio/pages/teacher_dashboard/parent_letter.js
+++ b/apps/src/sites/studio/pages/teacher_dashboard/parent_letter.js
@@ -28,7 +28,7 @@ window.addEventListener('DOMContentLoaded', function() {
   document.body.appendChild(mountPoint);
   ReactDOM.render(
     <Provider store={store}>
-      <ParentLetter autoPrint />
+      <ParentLetter autoPrint logoUrl={scriptData.logoUrl} />
     </Provider>,
     mountPoint
   );

--- a/apps/src/sites/studio/pages/teacher_dashboard/parent_letter.js
+++ b/apps/src/sites/studio/pages/teacher_dashboard/parent_letter.js
@@ -1,4 +1,3 @@
-import $ from 'jquery';
 import React from 'react';
 import ReactDOM from 'react-dom';
 import {Provider} from 'react-redux';
@@ -12,7 +11,7 @@ import currentUser, {
 } from '@cdo/apps/templates/currentUserRedux';
 import ParentLetter from '@cdo/apps/lib/ui/ParentLetter';
 
-$(() => {
+window.addEventListener('DOMContentLoaded', function() {
   // Register the reducers we need to show the parent letter:
   registerReducers({currentUser, sectionData, teacherSections});
 

--- a/apps/src/sites/studio/pages/teacher_dashboard/parent_letter.js
+++ b/apps/src/sites/studio/pages/teacher_dashboard/parent_letter.js
@@ -1,0 +1,36 @@
+import $ from 'jquery';
+import React from 'react';
+import ReactDOM from 'react-dom';
+import {Provider} from 'react-redux';
+import {getStore, registerReducers} from '@cdo/apps/redux';
+import teacherSections, {
+  setSections
+} from '@cdo/apps/templates/teacherDashboard/teacherSectionsRedux';
+import sectionData, {setSection} from '@cdo/apps/redux/sectionDataRedux';
+import currentUser, {
+  setCurrentUserName
+} from '@cdo/apps/templates/currentUserRedux';
+import ParentLetter from '@cdo/apps/lib/ui/ParentLetter';
+
+$(() => {
+  // Register the reducers we need to show the parent letter:
+  registerReducers({currentUser, sectionData, teacherSections});
+
+  // Populate the store with data passed down from the server:
+  const script = document.querySelector('script[data-dashboard]');
+  const scriptData = JSON.parse(script.dataset.dashboard);
+  const store = getStore();
+  store.dispatch(setCurrentUserName(scriptData.userName));
+  store.dispatch(setSections(scriptData.sections));
+  store.dispatch(setSection(scriptData.section));
+
+  // Mount and render the letter:
+  const mountPoint = document.createElement('div');
+  document.body.appendChild(mountPoint);
+  ReactDOM.render(
+    <Provider store={store}>
+      <ParentLetter autoPrint />
+    </Provider>,
+    mountPoint
+  );
+});

--- a/apps/src/templates/teacherDashboard/TeacherDashboard.jsx
+++ b/apps/src/templates/teacherDashboard/TeacherDashboard.jsx
@@ -16,8 +16,6 @@ import EmptySection from './EmptySection';
 import _ from 'lodash';
 import firehoseClient from '../../lib/util/firehose';
 import StandardsReport from '../sectionProgress/standards/StandardsReport';
-import ParentLetter from '@cdo/apps/lib/ui/ParentLetter';
-import {queryParams} from '@cdo/apps/code-studio/utils';
 
 class TeacherDashboard extends Component {
   static propTypes = {
@@ -72,11 +70,10 @@ class TeacherDashboard extends Component {
       location.pathname = TeacherDashboardPath.progress;
     }
 
-    // Include header components unless we are on the /login_info, /standards_report, or /parent_letter page.
+    // Include header components unless we are on the /login_info or /standards_report page.
     const includeHeader =
       location.pathname !== TeacherDashboardPath.loginInfo &&
-      location.pathname !== TeacherDashboardPath.standardsReport &&
-      location.pathname !== TeacherDashboardPath.parentLetter;
+      location.pathname !== TeacherDashboardPath.standardsReport;
 
     return (
       <div>
@@ -106,15 +103,6 @@ class TeacherDashboard extends Component {
           <Route
             path={TeacherDashboardPath.standardsReport}
             component={props => <StandardsReport />}
-          />
-          <Route
-            path={TeacherDashboardPath.parentLetter}
-            component={props => (
-              <ParentLetter
-                studentId={queryParams('studentId')}
-                autoPrint={true}
-              />
-            )}
           />
           {/* Break out of Switch if we have 0 students. Display EmptySection component instead. */}
           {studentCount === 0 && (

--- a/apps/src/templates/teacherDashboard/TeacherDashboardNavigation.jsx
+++ b/apps/src/templates/teacherDashboard/TeacherDashboardNavigation.jsx
@@ -15,8 +15,7 @@ export const TeacherDashboardPath = {
   stats: '/stats',
   manageStudents: '/manage_students',
   loginInfo: '/login_info',
-  standardsReport: '/standards_report',
-  parentLetter: '/parent_letter'
+  standardsReport: '/standards_report'
 };
 
 const teacherDashboardLinks = [

--- a/dashboard/app/controllers/teacher_dashboard_controller.rb
+++ b/dashboard/app/controllers/teacher_dashboard_controller.rb
@@ -6,4 +6,10 @@ class TeacherDashboardController < ApplicationController
     @sections = current_user.sections.map(&:summarize)
     @valid_grades = Section.valid_grades
   end
+
+  def parent_letter
+    @section_summary = @section.summarize
+    @sections = current_user.sections.map(&:summarize)
+    render layout: false
+  end
 end

--- a/dashboard/app/views/teacher_dashboard/parent_letter.html.haml
+++ b/dashboard/app/views/teacher_dashboard/parent_letter.html.haml
@@ -12,9 +12,9 @@
   -# Here where we pass data down to the particular script we'd like to run
   :ruby
     teacher_dashboard_data = {}
-    teacher_dashboard_data[:studioUrlPrefix] = CDO.studio_url('', CDO.default_scheme)
     teacher_dashboard_data[:sections] = @sections
     teacher_dashboard_data[:section] = @section_summary
     teacher_dashboard_data[:userName] = @current_user.short_name
     teacher_dashboard_data[:localeCode] = request.locale
+    teacher_dashboard_data[:logoUrl] = asset_path('logo.png')
   %script{src: webpack_asset_path('js/teacher_dashboard/parent_letter.js'), data: {dashboard: teacher_dashboard_data.to_json}}

--- a/dashboard/app/views/teacher_dashboard/parent_letter.html.haml
+++ b/dashboard/app/views/teacher_dashboard/parent_letter.html.haml
@@ -1,6 +1,23 @@
 %head
   %title Parent Letter
 
+  %link{rel:'stylesheet', type:'text/css', href: asset_path('gotham-font.css')}
+  :css
+    body {
+      max-width: 8.5in;
+      font-family: "Gotham 4r", sans-serif;
+      font-size: 13px;
+      line-height: 18px;
+    }
+    h1 {
+      font-family: "Gotham 7r", sans-serif;
+      font-weight: normal;
+      font-size: 18px;
+      line-height: 24px;
+      margin: 10px 0 0 0;
+      color: #7665a0;
+    }
+
   -# These files are all prerequisites for running a code studio webpack bundle
   %script{src: webpack_asset_path('js/webpack-runtime.js')}
   %script{src: webpack_asset_path('js/essential.js')}

--- a/dashboard/app/views/teacher_dashboard/parent_letter.html.haml
+++ b/dashboard/app/views/teacher_dashboard/parent_letter.html.haml
@@ -1,0 +1,20 @@
+%head
+  %title Parent Letter
+
+  -# These files are all prerequisites for running a code studio webpack bundle
+  %script{src: webpack_asset_path('js/webpack-runtime.js')}
+  %script{src: webpack_asset_path('js/essential.js')}
+  %script{src: webpack_asset_path('js/vendors.js')}
+  = javascript_include_tag 'application'
+  %script{src: webpack_asset_path("js/#{js_locale}/common_locale.js")}
+  %script{src: webpack_asset_path('js/code-studio-common.js')}
+
+  -# Here where we pass data down to the particular script we'd like to run
+  :ruby
+    teacher_dashboard_data = {}
+    teacher_dashboard_data[:studioUrlPrefix] = CDO.studio_url('', CDO.default_scheme)
+    teacher_dashboard_data[:sections] = @sections
+    teacher_dashboard_data[:section] = @section_summary
+    teacher_dashboard_data[:userName] = @current_user.short_name
+    teacher_dashboard_data[:localeCode] = request.locale
+  %script{src: webpack_asset_path('js/teacher_dashboard/parent_letter.js'), data: {dashboard: teacher_dashboard_data.to_json}}

--- a/dashboard/config/routes.rb
+++ b/dashboard/config/routes.rb
@@ -5,6 +5,7 @@ Dashboard::Application.routes.draw do
   get "404", to: "application#render_404", via: :all
 
   # React-router will handle sub-routes on the client.
+  get 'teacher_dashboard/sections/:section_id/parent_letter', to: 'teacher_dashboard#parent_letter'
   get 'teacher_dashboard/sections/:section_id/*path', to: 'teacher_dashboard#show', via: :all
   get 'teacher_dashboard/sections/:section_id', to: 'teacher_dashboard#show'
 


### PR DESCRIPTION
Trying a different solution to auto-printing the parent letter, by using a template-less route and no temporary document.

![Peek 2020-04-06 15-23](https://user-images.githubusercontent.com/1615761/78611072-fef25a80-781a-11ea-9a1d-e5acfe99404b.gif)

## Testing story

Manually tested, locally and using SauceLabs.  Print dialog worked in all scenarios, and didn't see any pop-up blocker issues.

| Browser | Tested? |
| --- | --- |
| Chrome 80, Ubuntu 18 | Looks good! |
| Firefox 74, Ubuntu 18 | Looks good! |
| Safari 12, Mojave | Looks good! |
| Edge 80, Win 10 | Looks good! |
| IE11, Win10 | Looks good! |

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
