### PR TITLE
Replacing usage of a CSS property which isn't used widely yet

### DIFF
--- a/dashboard/app/assets/stylesheets/application.scss
+++ b/dashboard/app/assets/stylesheets/application.scss
@@ -1804,7 +1804,7 @@ a.download-video {
         margin-right: 5px;
       }
       .field_with_errors {
-        flex-basis: content;
+        flex-basis: auto;
       }
     }
 


### PR DESCRIPTION
The `content` value for `flex-basis` is note widely used yet: https://caniuse.com/#feat=mdn-css_properties_flex-basis_content

I'm replacing it with `auto` which seems to accomplish the same thing but is widely used.

## Links
- https://caniuse.com/#feat=mdn-css_properties_flex-basis_content

## Testing
- Manually tested locally.
