### PR TITLE
Add common_locale.js to at_home_banner

### DIFF
--- a/pegasus/sites.v3/code.org/views/at_home_banner.haml
+++ b/pegasus/sites.v3/code.org/views/at_home_banner.haml
@@ -1,3 +1,4 @@
 %script{src: webpack_asset_path('js/code.org/views/at_home_banner.js')}
+%script{src: webpack_asset_path("js/#{js_locale}/common_locale.js")}
 
 #at-home-banner-container

--- a/pegasus/sites.v3/code.org/views/at_home_banner.haml
+++ b/pegasus/sites.v3/code.org/views/at_home_banner.haml
@@ -1,4 +1,5 @@
 %script{src: webpack_asset_path('js/code.org/views/at_home_banner.js')}
+- js_locale = request.locale.to_s.downcase.tr('-', '_')
 %script{src: webpack_asset_path("js/#{js_locale}/common_locale.js")}
 
 #at-home-banner-container


### PR DESCRIPTION
In order to render strings that have been translated in the apps i18n pipeline (ie. strings used in React components) on Pegasus across environments, the view needs to reference this script: `%script{src: webpack_asset_path("js/#{js_locale}/common_locale.js")}`. 

In this case, the At Home banner wasn't showing up on code.org/hourofcode/overview because there was this JS error: 
<img width="1007" alt="Screen Shot 2020-04-06 at 4 21 25 PM" src="https://user-images.githubusercontent.com/12300669/78614353-3107ba80-7823-11ea-8955-1ab97678173c.png">