### PR TITLE
update I18n.t to be resilient to missing keys

### DIFF
--- a/lib/cdo/i18n_backend.rb
+++ b/lib/cdo/i18n_backend.rb
@@ -24,7 +24,7 @@ module Cdo
         # any of the individual scope or key values, to prevent a situation in
         # which periods in a key name can be mistakenly interpreted as separators
         if options.key?(:scope) && !options.key?(:separator)
-          combined_key = [key] + options.get(:scope, [])
+          combined_key = [key] + options.fetch(:scope, [])
           options[:separator] = get_valid_separator(combined_key.join(""))
         end
 

--- a/lib/cdo/i18n_backend.rb
+++ b/lib/cdo/i18n_backend.rb
@@ -24,7 +24,8 @@ module Cdo
         # any of the individual scope or key values, to prevent a situation in
         # which periods in a key name can be mistakenly interpreted as separators
         if options.key?(:scope) && !options.key?(:separator)
-          options[:separator] = get_valid_separator(key + options[:scope].join(''))
+          combined_key = [key] + options.get(:scope, [])
+          options[:separator] = get_valid_separator(combined_key.join(""))
         end
 
         options


### PR DESCRIPTION
It's not clear how, but it appears that I18n.t can sometimes end up getting called with a `nil` key, and that unexpectedly breaks things. This tweaks the logic to be a bit more resilient.

Fixes https://app.honeybadger.io/projects/3240/faults/62646802

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
