### PR TITLE
Adjust mobile zoom for videos

### DIFF
--- a/apps/src/code-studio/videos.js
+++ b/apps/src/code-studio/videos.js
@@ -228,8 +228,10 @@ videos.showVideoDialog = function(options, forceShowVideo) {
   nav.append(fallbackPlayerLinkDiv);
 
   // Resize modal to fit constraining dimension.
-  let windowHeight = Math.min(screen.height, screen.width);
-  let windowWidth = Math.max(screen.height, screen.width);
+  let accurateInnerHeight = Math.min(window.innerHeight, window.outerHeight);
+  let accurateInnerWidth = Math.min(window.innerWidth, window.outerWidth);
+  let windowHeight = Math.min(accurateInnerHeight, accurateInnerWidth);
+  let windowWidth = Math.max(accurateInnerHeight, accurateInnerWidth);
 
   var height = windowHeight * widthRatio,
     width = windowWidth * heightRatio;

--- a/apps/src/code-studio/videos.js
+++ b/apps/src/code-studio/videos.js
@@ -228,8 +228,11 @@ videos.showVideoDialog = function(options, forceShowVideo) {
   nav.append(fallbackPlayerLinkDiv);
 
   // Resize modal to fit constraining dimension.
-  var height = $(window).height() * widthRatio,
-    width = $(window).width() * heightRatio;
+  let windowHeight = Math.min(screen.height, screen.width);
+  let windowWidth = Math.max(screen.height, screen.width);
+
+  var height = windowHeight * widthRatio,
+    width = windowWidth * heightRatio;
 
   if (height * aspectRatio < width) {
     $div.height(height);


### PR DESCRIPTION
This is a follow-up PR for https://github.com/code-dot-org/code-dot-org/pull/33983.

In the past, loading a tutorial in portrait mode and turning it to landscape on Android would cause the video to zoom in too far for the user to be able to click the x button. 
![Screenshot_20200406-181047_Chrome](https://user-images.githubusercontent.com/8324574/78621385-51417480-7837-11ea-88ad-901812e5bdde.jpg)

Prior to 33983, it was possible to swipe up to dismiss the url bar and display part of the x in the top right corner. After 33983, this is much more difficult. Usually, the x follows the address bar off the screen, making completing the level nearly impossible without a screen refresh.
![Screenshot_20200406-181904_Chrome](https://user-images.githubusercontent.com/8324574/78621403-5a324600-7837-11ea-8b16-fdaea10b5e6b.jpg)

Now, Android's level of zoom allows a user to more easily dismiss the video when finished watching. 
Samsung Galaxy S10:
![Screenshot_20200406-135528_Chrome](https://user-images.githubusercontent.com/8324574/78621553-b8f7bf80-7837-11ea-81d7-0933b75b845b.jpg)
![Screenshot_20200407-093751_Chrome](https://user-images.githubusercontent.com/8324574/78696892-e59dec80-78b4-11ea-81af-43ef5627aa1d.jpg)
iPad 2 Mini:
![20200407_094116](https://user-images.githubusercontent.com/8324574/78696896-e8004680-78b4-11ea-82f6-0cd168256003.jpg)

Note: Under certain circumstances, video renders very small. Since user-initiated zoom and full-screen is allowed, this is readily mitigated by the user.

![Screenshot_20200407-093653_Chrome](https://user-images.githubusercontent.com/8324574/78697096-24cc3d80-78b5-11ea-80c5-37fb9a67cb1a.jpg)

<!--
  Your description goes here: A summary of the change, including any relevant motivation and context.

  If relevant, include a description both of the existing behavior and of the new behavior.
-->

<!--
  Other aspects to consider. uncomment and add detail for any that seem necessary:
-->

### Background
The linked PR (https://github.com/code-dot-org/code-dot-org/pull/33983) updated the viewport of all apps/labs to zoom out, vastly increasing the usability of most of our apps and labs. Additionally, it allowed user-initiated zooming on Android devices (previously only enabled on iOS devices)

<!-- ### Privacy -->
<!-- ### Security -->
<!-- ### Caching -->
<!-- ### Deployment strategy -->
### Future work
https://codedotorg.atlassian.net/browse/STAR-1051
Update video player to resize responsively. This will allow us to consistently size the video to take up 80% of the vertical or horizontal width of the screen

## Links

<!--
  Any relevant links to external resources; ie, specification documents, jira
  items, related PRs, honeybadger errors, etc
-->


## Testing story

<!--
  Does your change include appropriate tests?

  If so, please describe how the tests included in this PR are sufficient

  If not, please explain why this change does not need to be tested.
-->

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
