### PR TITLE
update video link

### DIFF
--- a/apps/src/lib/ui/ParentLetter.jsx
+++ b/apps/src/lib/ui/ParentLetter.jsx
@@ -120,9 +120,7 @@ class ParentLetter extends React.Component {
             learning and show you a project they are proud of (
             <a href={ENGAGEMENT_URL}>see details</a>
             ). Or watch one of{' '}
-            <a href={pegasus(`/educate/resources/inspire`)}>
-              these videos
-            </a>{' '}
+            <a href={pegasus(`/educate/resources/videos`)}>these videos</a>{' '}
             together.
           </p>
           <h1>Step 2 - Get your child set up to use Code.org at home</h1>


### PR DESCRIPTION
Quick fix to change the link in the parent letter (see screenshot) to point to https://code.org/educate/resources/videos

<img width="1000" alt="Screen Shot 2020-04-06 at 5 58 45 PM" src="https://user-images.githubusercontent.com/224089/78618852-85fdfd80-7830-11ea-8715-2e2d2712c74e.png">


<!--
  Your description goes here: A summary of the change, including any relevant motivation and context.

  If relevant, include a description both of the existing behavior and of the new behavior.
-->

<!--
  Other aspects to consider. uncomment and add detail for any that seem necessary:
-->

<!-- ### Background -->
<!-- ### Privacy -->
<!-- ### Security -->
<!-- ### Caching -->
<!-- ### Deployment strategy -->
<!-- ### Future work -->



<!--
  Any relevant links to external resources; ie, specification documents, jira
  items, related PRs, honeybadger errors, etc
-->



<!--
  Does your change include appropriate tests?

  If so, please describe how the tests included in this PR are sufficient

  If not, please explain why this change does not need to be tested.
-->

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
