### PR TITLE
Remove ineffectual reference to common_locale.js

### DIFF
--- a/pegasus/sites.v3/code.org/public/hourofcode/overview.haml
+++ b/pegasus/sites.v3/code.org/public/hourofcode/overview.haml
@@ -21,9 +21,6 @@ social:
 %link{href: "/shared/css/course-blocks.css", rel: "stylesheet", type: "text/css"}
 %script{type: "text/javascript", src: "/js/hoc-overview.js"}
 
-- js_locale = request.locale.to_s.downcase.tr('-', '_')
-%script{src: asset_path("js/#{js_locale}/common_locale.js")}
-
 %h1= I18n.t(:hoc_overview_title)
 
 != I18n.t(:hoc_overview_subtitle_markdown, markdown: :inline)


### PR DESCRIPTION
I added this in the wrong place [here](https://github.com/code-dot-org/code-dot-org/pull/33799), and @Erin007 added it in the correct file [here](https://github.com/code-dot-org/code-dot-org/pull/34073). So I'm removing my useless code :)

<!--
  Your description goes here: A summary of the change, including any relevant motivation and context.

  If relevant, include a description both of the existing behavior and of the new behavior.
-->

<!--
  Other aspects to consider. uncomment and add detail for any that seem necessary:
-->

<!-- ### Background -->
<!-- ### Privacy -->
<!-- ### Security -->
<!-- ### Caching -->
<!-- ### Deployment strategy -->
<!-- ### Future work -->

## Links

<!--
  Any relevant links to external resources; ie, specification documents, jira
  items, related PRs, honeybadger errors, etc
-->

- [spec]()
- [jira]()

## Testing story

<!--
  Does your change include appropriate tests?

  If so, please describe how the tests included in this PR are sufficient

  If not, please explain why this change does not need to be tested.
-->

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
