### PR TITLE
Adding parent_email confirmation email

### DIFF
--- a/dashboard/app/models/user.rb
+++ b/dashboard/app/models/user.rb
@@ -235,6 +235,9 @@ class User < ActiveRecord::Base
         source: parent_email_preference_source,
         form_kind: nil
       )
+      if parent_email_changed?
+        ParentMailer.parent_email_added_to_student_account(parent_email, self).deliver_now
+      end
     end
   end
 


### PR DESCRIPTION
When a parent sets their email preference so they receive updates about their child's progress, we want to send an email confirming they have made this setting.

