### PR TITLE
Fix Archived sections appearing in teacher dashboard drop-down

### DIFF
--- a/apps/src/templates/teacherDashboard/TeacherDashboardHeader.jsx
+++ b/apps/src/templates/teacherDashboard/TeacherDashboardHeader.jsx
@@ -48,12 +48,15 @@ class TeacherDashboardHeader extends React.Component {
     this.getDropdownOptions = this.getDropdownOptions.bind(this);
     this.selectedSection = this.props.sections[this.props.selectedSectionId];
   }
-
   getDropdownOptions(optionMetricName) {
     let self = this;
-    let sections = this.props.sections;
-    let options = Object.keys(sections).map(function(key, i) {
-      let section = sections[key];
+    let visibleSections = Object.fromEntries(
+      Object.entries(this.props.sections).filter(
+        ([sectionId, section]) => !section.hidden
+      )
+    );
+    let options = Object.keys(visibleSections).map(function(key, i) {
+      let section = visibleSections[key];
       let optionOnClick = () => {
         switchToSection(section.id, self.selectedSection.id);
         recordSwitchToSection(

--- a/apps/src/templates/teacherDashboard/TeacherDashboardHeader.jsx
+++ b/apps/src/templates/teacherDashboard/TeacherDashboardHeader.jsx
@@ -50,11 +50,13 @@ class TeacherDashboardHeader extends React.Component {
   }
   getDropdownOptions(optionMetricName) {
     let self = this;
-    let visibleSections = Object.fromEntries(
-      Object.entries(this.props.sections).filter(
-        ([sectionId, section]) => !section.hidden
-      )
-    );
+    let visibleSections = Object.entries(this.props.sections)
+      .filter(([sectionId, section]) => !section.hidden)
+      .reduce((visibleSections, filteredEntry) => {
+        visibleSections[filteredEntry[0]] = filteredEntry[1];
+        return visibleSections;
+      }, {});
+
     let options = Object.keys(visibleSections).map(function(key, i) {
       let section = visibleSections[key];
       let optionOnClick = () => {

--- a/apps/test/unit/templates/teacherDashboard/TeacherDashboardHeaderTest.js
+++ b/apps/test/unit/templates/teacherDashboard/TeacherDashboardHeaderTest.js
@@ -13,6 +13,11 @@ const MOCK_SECTIONS = {
   2: {
     id: 2,
     name: 'intro to computer science II'
+  },
+  3: {
+    id: 3,
+    name: 'hidden section',
+    hidden: true
   }
 };
 
@@ -40,7 +45,7 @@ describe('TeacherDashboardHeader', () => {
     expect(wrapper.contains('Course D (2019)')).to.equal(true);
   });
 
-  it('renders dropdown button with links to sections, highlighting current section', () => {
+  it('renders dropdown button with links to sections, highlighting current section, ignoring hidden section', () => {
     const wrapper = shallow(<TeacherDashboardHeader {...DEFAULT_PROPS} />);
     let dropdownButton = wrapper.find('DropdownButton');
     expect(dropdownButton).to.have.lengthOf(1);


### PR DESCRIPTION
This fixes a regression in the  Teacher Dashboard Header that caused hidden/archived sections to render in the switch section dropdown.

<!--
  Other aspects to consider. uncomment and add detail for any that seem necessary:
-->

<!-- ### Background -->
<!-- ### Privacy -->
<!-- ### Security -->
<!-- ### Caching -->
<!-- ### Deployment strategy -->
<!-- ### Future work -->

## Links

<!--
  Any relevant links to external resources; ie, specification documents, jira
  items, related PRs, honeybadger errors, etc
-->

- [jira](https://codedotorg.atlassian.net/browse/LP-1358)

## Testing story
Added a unit test, tested manually as well by reproing the bug and insuring that this fixes the reproed bug
<!--
  Does your change include appropriate tests?

  If so, please describe how the tests included in this PR are sufficient

  If not, please explain why this change does not need to be tested.
-->

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
