### PR TITLE
Mb digital read

### DIFF
--- a/apps/src/lib/kits/maker/MBFirmataWrapper.js
+++ b/apps/src/lib/kits/maker/MBFirmataWrapper.js
@@ -1,0 +1,20 @@
+import MBFirmataClient from '../../../third-party/maker/MBFirmataClient';
+
+export default class MicrobitFirmataWrapper extends MBFirmataClient {
+  constructor(port) {
+    super(port);
+    this.digitalCallbacks = [];
+  }
+
+  setPinMode(pin, mode) {
+    // If setting a pin to input, start tracking it immediately
+    if (mode === 0) {
+      this.trackDigitalPin(pin);
+    }
+    super.setPinMode(pin, mode);
+  }
+
+  digitalRead(pin, callback) {
+    callback(this.digitalInput[pin]);
+  }
+}

--- a/apps/src/lib/kits/maker/MicroBitBoard.js
+++ b/apps/src/lib/kits/maker/MicroBitBoard.js
@@ -81,9 +81,8 @@ export default class MicroBitBoard extends EventEmitter {
     this.boardClient_.digitalWrite(pin, value);
   }
 
-  // TODO
   digitalRead(pin, callback) {
-    callback(pin);
+    this.boardClient_.digitalRead(pin, callback);
   }
 
   analogWrite(pin, value) {

--- a/apps/src/lib/kits/maker/MicroBitBoard.js
+++ b/apps/src/lib/kits/maker/MicroBitBoard.js
@@ -1,7 +1,6 @@
 /** @file Board controller for BBC micro:bit */
 /* global SerialPort */ // Maybe provided by the Code.org Browser
 import {EventEmitter} from 'events'; // provided by webpack's node-libs-browser
-import MBFirmataClient from '../../../third-party/maker/MBFirmataClient';
 import {
   createMicroBitComponents,
   cleanupMicroBitComponents,
@@ -9,6 +8,7 @@ import {
   componentConstructors
 } from './MicroBitComponents';
 import {MicroBitButton} from './Button';
+import MBFirmataWrapper from './MBFirmataWrapper';
 
 /**
  * Controller interface for BBC micro:bit board using
@@ -24,7 +24,7 @@ export default class MicroBitBoard extends EventEmitter {
     this.prewiredComponents_ = null;
 
     /** @private {MicrobitFirmataClient} serial port controller */
-    this.boardClient_ = new MBFirmataClient(SerialPort);
+    this.boardClient_ = new MBFirmataWrapper(SerialPort);
 
     /** @private {Array} List of dynamically-created component controllers. */
     this.dynamicComponents_ = [];

--- a/apps/src/third-party/maker/MBFirmataClient.js
+++ b/apps/src/third-party/maker/MBFirmataClient.js
@@ -480,11 +480,6 @@ class MicrobitFirmataClient {
     this.myPort.write([this.STREAM_DIGITAL | port, 1]);
   }
 
-  digitalRead(pin, callback) {
-    this.addFirmataUpdateListener(callback);
-    this.trackDigitalPin(pin);
-  }
-
   stopTrackingDigitalPins() {
     // Stop tracking all digital pins.
 

--- a/apps/src/third-party/maker/MBFirmataClient.js
+++ b/apps/src/third-party/maker/MBFirmataClient.js
@@ -480,6 +480,11 @@ class MicrobitFirmataClient {
     this.myPort.write([this.STREAM_DIGITAL | port, 1]);
   }
 
+  digitalRead(pin, callback) {
+    this.addFirmataUpdateListener(callback);
+    this.trackDigitalPin(pin);
+  }
+
   stopTrackingDigitalPins() {
     // Stop tracking all digital pins.
 

--- a/apps/test/unit/lib/kits/maker/MicroBitBoardTest.js
+++ b/apps/test/unit/lib/kits/maker/MicroBitBoardTest.js
@@ -20,7 +20,12 @@ describe('MicroBitBoard', () => {
 
   describe('Maker Board Interface', () => {
     itImplementsTheMakerBoardInterface(MicroBitBoard, board => {
-      board.boardClient_ = new MicrobitStubBoard();
+      sinon.stub(board.boardClient_, 'connect').callsFake(() => {
+        board.boardClient_.myPort = {write: () => {}};
+        sinon.stub(board.boardClient_.myPort, 'write');
+      });
+
+      sinon.stub(board.boardClient_, 'digitalRead').callsArgWith(1, 0);
     });
   });
 
@@ -85,6 +90,18 @@ describe('MicroBitBoard', () => {
         const arg2 = 1023;
         board.digitalWrite(pin, arg2);
         expect(digitalWriteSpy).to.have.been.calledWith(pin, arg2);
+      });
+    });
+  });
+
+  describe(`digitalRead(pin, callback)`, () => {
+    it('forwards the call to firmata', () => {
+      return board.connect().then(() => {
+        let digitalReadSpy = sinon.spy(board.boardClient_, 'digitalRead');
+        const pin = 11;
+        const arg2 = () => {};
+        board.digitalRead(pin, arg2);
+        expect(digitalReadSpy).to.have.been.calledWith(pin, arg2);
       });
     });
   });

--- a/apps/test/unit/lib/kits/maker/makeStubBoard.js
+++ b/apps/test/unit/lib/kits/maker/makeStubBoard.js
@@ -27,6 +27,10 @@ export class MicrobitStubBoard {
 
   digitalWrite(pinNum, value) {}
 
+  digitalRead(pinNum, callback) {
+    callback();
+  }
+
   analogWrite(pinNum, value) {}
 
   displayPlot() {}


### PR DESCRIPTION
In order to get some forward momentum on this task (https://codedotorg.atlassian.net/browse/STAR-645) I'm starting to break out small bits. This one covers digitalRead. This PR introduces a wrapper around the MBFirmataCode to add the callback functionality needed for digitalRead.

This function can be tested using this code in a project:
```
pinMode(0, "input");

timedLoop(1000, function() {
  console.log(digitalRead(0));
});
```

## Links

<!--
  Any relevant links to external resources; ie, specification documents, jira
  items, related PRs, honeybadger errors, etc
-->

- [spec]()
- [jira]()

## Testing story

Includes tests

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
