### PR TITLE
Use webpack_asset_path instead of asset_path

### DIFF
--- a/pegasus/sites.v3/code.org/public/hourofcode/overview.haml
+++ b/pegasus/sites.v3/code.org/public/hourofcode/overview.haml
@@ -22,7 +22,7 @@ social:
 %script{type: "text/javascript", src: "/js/hoc-overview.js"}
 
 - js_locale = request.locale.to_s.downcase.tr('-', '_')
-%script{src: asset_path("js/#{js_locale}/common_locale.js")}
+%script{src: webpack_asset_path("js/#{js_locale}/common_locale.js")}
 
 %h1= I18n.t(:hoc_overview_title)
 


### PR DESCRIPTION
Alternate to #34073 which didn't solve the problem as expected. This change makes the reference to the locale script the same as on /yourschool where the banner is rendering correctly. 

https://github.com/code-dot-org/code-dot-org/blob/1aada72865ef500a96d98f75b806d353c41ffaf7/pegasus/sites.v3/code.org/public/yourschool.haml#L31