### PR TITLE
Shorten user course enrollments notice

### DIFF
--- a/dashboard/app/controllers/plc/user_course_enrollments_controller.rb
+++ b/dashboard/app/controllers/plc/user_course_enrollments_controller.rb
@@ -34,16 +34,31 @@ class Plc::UserCourseEnrollmentsController < ApplicationController
     enrolled_users, nonexistent_users, nonteacher_users, other_failure_users, other_failure_reasons =
       Plc::UserCourseEnrollment.enroll_users(user_emails, user_course_enrollment_params[:plc_course_id])
 
-    notice_string = enrolled_users.empty? ? '' : "Enrollments created for #{listify(enrolled_users)}<br/>"
-    notice_string += "The following users did not exist #{listify(nonexistent_users)}<br/>" unless nonexistent_users.empty?
-    notice_string += "The following users were not teachers #{listify(nonteacher_users)}<br/>" unless nonteacher_users.empty?
-    notice_string += "The following users failed for other reasons #{listify(other_failure_users)}<br/>" unless other_failure_users.empty?
-    notice_string += "The failures were because of reasons #{listify(other_failure_reasons)}" unless other_failure_reasons.empty?
+    notice_string = enrolled_users.empty? ? '' : "#{enrolled_users.length} enrollment(s) created#{listify_first_ten(enrolled_users)}<br/>"
+    notice_string += "#{nonexistent_users.length} user(s) did not exist#{listify_first_ten(nonexistent_users)}<br/>" unless nonexistent_users.empty?
+    notice_string += "#{nonteacher_users.length} user(s) were not teachers#{listify_first_ten(nonteacher_users)}<br/>" unless nonteacher_users.empty?
+    notice_string += "#{other_failure_users.length} user(s) failed for other reasons#{listify_first_ten(other_failure_users)}<br/>" unless other_failure_users.empty?
+    other_failure_message = "The failure(s) were because of reasons: "
+    if other_failure_reasons.length > 10
+      other_failure_message = "The first 10 failure reasons were: "
+      other_failure_reasons = other_failure_reasons[0..9]
+    end
+    notice_string += "#{other_failure_message} #{listify(other_failure_reasons)}<br/>" unless other_failure_reasons.empty?
 
     redirect_to action: :new, notice: notice_string
   end
 
   private
+
+  def listify_first_ten(user_list)
+    result = ': '
+    if user_list.length > 10
+      result = '. The first 10 are: '
+      user_list = user_list[0..9]
+    end
+    result += listify(user_list)
+    result
+  end
 
   def listify(user_list)
     user_list.map {|user| "<li>#{user}</li>"}.join ''


### PR DESCRIPTION
We got this [honeybadger error](https://app.honeybadger.io/projects/3240/faults/62681985) due to the notice from the user_course_enrollments controller being too long. This fix cuts the email lists returned to 10 if there are more than 10 emails in a list.
## Links

- [honeybadger](https://app.honeybadger.io/projects/3240/faults/62681985)
- [jira](https://codedotorg.atlassian.net/browse/PLC-824)

## Testing story
Validated through unit tests and manual UI testing that the new messages look correct and only show the first ten emails/error messages.

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
