### PR TITLE
Deflake disable_toolbox_maze UI test

### DIFF
--- a/apps/src/maze/maze.js
+++ b/apps/src/maze/maze.js
@@ -40,6 +40,7 @@ module.exports = class Maze {
       stepSpeed: 5
     };
 
+    this.shouldSpeedUpInfiniteLoops = true;
     this.stepSpeed = 100;
     this.animating_ = false;
 
@@ -429,7 +430,7 @@ module.exports = class Maze {
           // possible
           this.result = ResultType.TIMEOUT;
           this.executionInfo.queueAction('finish', null);
-          this.stepSpeed = 0;
+          this.stepSpeed = this.shouldSpeedUpInfiniteLoops ? 0 : 100;
           break;
         case true:
           this.result = ResultType.SUCCESS;

--- a/dashboard/test/ui/features/star_labs/disable_toolbox_maze.feature
+++ b/dashboard/test/ui/features/star_labs/disable_toolbox_maze.feature
@@ -6,7 +6,7 @@ Background:
   And I wait for the page to fully load
   Then element "#runButton" is visible
   Then I drag block "4" to block "6"
-  And I drag block "1" to block "7" plus offset 35, 50
+  And I drag block "2" to block "7" plus offset 35, 50
 
 Scenario: Toolbox in maze (non-category) is enabled
   Then the workspace has "1" blocks of type "maze_forever"

--- a/dashboard/test/ui/features/step_definitions/steps.rb
+++ b/dashboard/test/ui/features/step_definitions/steps.rb
@@ -871,6 +871,7 @@ Then(/^I set slider speed to medium/) do
 end
 
 Then(/^I slow down execution speed$/) do
+  @browser.execute_script("Maze.shouldSpeedUpInfiniteLoops = false;")
   @browser.execute_script("Maze.scale.stepSpeed = 10;")
 end
 


### PR DESCRIPTION
This basic outline of the scenario is:
1. Start running code
2. Try to drag a block out from the toolbox
3. Verify that you cannot, because the toolbox is disabled while the code is running.

The issue is that if step 2 is slow enough, the code from step 1 may be done running, in which case you _can_ drag a block out, and the test fails. 
The code this test used previously looks like this:
![image](https://user-images.githubusercontent.com/8787187/78813441-d9339580-7981-11ea-8787-b079f708337a.png)
![image](https://user-images.githubusercontent.com/8787187/78813501-f49ea080-7981-11ea-8331-39e4d49318ac.png)

In maze, we stop execution after you hit a wall, and give the level failed feedback. So this test had a race condition between the zombie approaching the wall and the test-running code to try to move a block and verify that it didn't work.
We had slowed down the maze execution speed to try to mitigate this, but the test was still quite flaky. 

My approach here is to just change the code so it won't hit the wall (and won't trigger the early failure):
![image](https://user-images.githubusercontent.com/8787187/78813653-329bc480-7982-11ea-8b2c-1b412dd516e0.png)
This code will also eventually terminate, thanks to our infinite loop detection, but it will run for _much_ longer than the move forward loop. 
In order to make the "slow down execution" step still work, I added a flag to maze to configure whether or not to speed up the execution for infinite loops. This defaults to true so it will not affect any existing behavior, but allows us to override it in the test.