### PR TITLE
Fixing bug with parent email checkbox in signup

### DIFF
--- a/apps/src/sites/studio/pages/devise/registrations/_finish_sign_up.js
+++ b/apps/src/sites/studio/pages/devise/registrations/_finish_sign_up.js
@@ -85,18 +85,22 @@ $(document).ready(() => {
     }
   }
 
-  $('#user_parent_email_preference_opt_in_required').change(
-    renderParentSignUpSection
-  );
+  $('#user_parent_email_preference_opt_in_required').change(function() {
+    // If the user_type is currently blank, switch the user_type to 'student' because that is the only user_type which
+    // allows the parent sign up section of the form.
+    if (getUserType() === '') {
+      $('#user_user_type')
+        .val('student')
+        .change();
+    }
+    renderParentSignUpSection();
+  });
 
   function renderParentSignUpSection() {
     let checked = $('#user_parent_email_preference_opt_in_required').is(
       ':checked'
     );
     if (checked) {
-      $('#user_user_type')
-        .val('student')
-        .change();
       fadeInFields(['.parent-email-field']);
     } else {
       hideFields(['.parent-email-field']);


### PR DESCRIPTION
* Updated the parent email preference section to only render if the
user type is a 'student'.
* Updated the parent email preference
checkbox to only switch the user type to 'student' if there is currently
no user type selected.

## Bug repro steps
1. on page 2 of the sign-up flow, check the parent checkbox
2. switch the user type to teacher
3. hit submit with a blank display name or no email opt-in
4. the form refreshes with user_type switched back to Student instead of staying on Teacher. I'm assuming this is happening because the "I am a parent" checkbox is still 'checked' even though it's hidden. Additionally, the parent checkbox is hidden even though the user_type is student.

## Testing story
Tested on my localhost

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
