### PR TITLE
Change homepage "hour of code" tile to "at home"

### DIFF
--- a/pegasus/src/homepage.rb
+++ b/pegasus/src/homepage.rb
@@ -189,8 +189,8 @@ class Homepage
         {
           id: "at-home-en",
           type: "block",
-          title: "homepage_slot_text_title_at-home",
-          text: "homepage_slot_text_blurb_at-home",
+          title: "homepage_slot_text_title_at_home",
+          text: "homepage_slot_text_blurb_at_home",
           color1: "0, 173, 188",
           color2: "89, 202, 211",
           url: "/athome",
@@ -294,8 +294,8 @@ class Homepage
         {
           id: "at-home-nonen",
           type: "blockshort",
-          title: "homepage_slot_text_title_at-home",
-          text: "homepage_slot_text_blurb_at-home",
+          title: "homepage_slot_text_title_at_home",
+          text: "homepage_slot_text_blurb_at_home",
           color1: "0, 173, 188",
           color2: "89, 202, 211",
           url: "/athome",

--- a/pegasus/src/homepage.rb
+++ b/pegasus/src/homepage.rb
@@ -185,6 +185,32 @@ class Homepage
   def self.get_blocks(request)
     if request.language == "en"
       [
+
+        {
+          id: "at-home-en",
+          type: "block",
+          title: "homepage_slot_text_title_at-home",
+          text: "homepage_slot_text_blurb_at-home",
+          color1: "0, 173, 188",
+          color2: "89, 202, 211",
+          url: "/athome",
+          image: "/images/mc/2016_homepage_hocblock.jpg",
+          links:
+            [
+              {
+                text: "homepage_slot_text_link_code_break",
+                url: "/break"
+              },
+              {
+                text: "homepage_slot_text_link_do_hoc",
+                url: "/hourofcode/overview"
+              },
+              {
+                text: "homepage_slot_text_link_express_course",
+                url: "/educate/curriculum/express-course"
+              }
+            ]
+        },
         {
           id: "students-en",
           type: "block",
@@ -238,32 +264,6 @@ class Homepage
         },
 
         {
-          id: "hoc-en",
-          type: "block",
-          title: "homepage_slot_text_title_hoc",
-          text: "homepage_slot_text_blurb_hoc",
-          color1: "0, 173, 188",
-          color2: "89, 202, 211",
-          url: "/hourofcode/overview",
-          image: "/images/mc/2016_homepage_hocblock.jpg",
-          links:
-            [
-              {
-                text: "homepage_slot_text_link_about_hoc",
-                url: "https://hourofcode.com/"
-              },
-              {
-                text: "homepage_slot_text_link_host",
-                url: "https://hourofcode.com/how-to"
-              },
-              {
-                text: "homepage_slot_text_link_hocserved",
-                url: "/leaderboards"
-              }
-            ]
-        },
-
-        {
           id: "advocate-en",
           type: "block",
           title: "homepage_slot_text_link_buy",
@@ -292,6 +292,16 @@ class Homepage
     else
       [
         {
+          id: "at-home-nonen",
+          type: "blockshort",
+          title: "homepage_slot_text_title_at-home",
+          text: "homepage_slot_text_blurb_at-home",
+          color1: "0, 173, 188",
+          color2: "89, 202, 211",
+          url: "/athome",
+          image: "/images/mc/2016_homepage_hocblock.jpg"
+        },
+        {
           id: "students-nonen",
           type: "blockshort",
           title: "homepage_slot_text_title_students",
@@ -310,16 +320,6 @@ class Homepage
           color2: "89, 185, 220",
           url: CDO.studio_url("/courses?view=teacher"),
           image: "/shared/images/courses/logo_tall_teacher2.jpg"
-        },
-        {
-          id: "hoc-nonen",
-          type: "blockshort",
-          title: "homepage_slot_text_title_hoc",
-          text: "homepage_slot_text_blurb_hoc",
-          color1: "0, 173, 188",
-          color2: "89, 202, 211",
-          url: "/hourofcode/overview",
-          image: "/images/mc/2016_homepage_hocblock.jpg"
         },
         {
           id: 'dance-nonen',


### PR DESCRIPTION
[PLC-823](https://codedotorg.atlassian.net/browse/PLC-823)
Update the hour of code tile on the signed out homepage to be an at home tile. New tile looks like this:
<img width="359" alt="Screen Shot 2020-04-08 at 3 34 58 PM" src="https://user-images.githubusercontent.com/33666587/78840141-d733fb80-79ae-11ea-9f24-48efb95354f0.png">


The at home tile is also now the leftmost tile:
<img width="1452" alt="Screen Shot 2020-04-08 at 3 35 39 PM" src="https://user-images.githubusercontent.com/33666587/78840082-b8ce0000-79ae-11ea-8dfa-61af12edc336.png">

On a non-english version of the site the tile is shortened as it was before (currently we have no translations for the text so will be English)
<img width="358" alt="Screen Shot 2020-04-08 at 3 36 06 PM" src="https://user-images.githubusercontent.com/33666587/78840171-ea46cb80-79ae-11ea-8a82-c83c8698caad.png">

New translation strings have been added to the pegasus gsheet and will be in the next staging scoop (they are on the staging server now).

<!-- ### Background -->
<!-- ### Privacy -->
<!-- ### Security -->
<!-- ### Caching -->
<!-- ### Deployment strategy -->
<!-- ### Future work -->

## Links
- [jira](https://codedotorg.atlassian.net/browse/PLC-823)

## Testing story
Tested by copying the strings from staging to my local version of the pegasus cache file and checking the tile works for english/non-english users, with the correct text and links.

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
