### PR TITLE
Updates to Puma debugging instrumentation

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -158,7 +158,7 @@ GIT
 
 GIT
   remote: https://github.com/wjordan/puma.git
-  revision: d37165cb72a0eb68c8ec2431db39a7693e616bb0
+  revision: 29a576120b30c34db7706c062ddf9a046723789f
   branch: debugging
   specs:
     puma (3.12.0)

--- a/dashboard/config/puma.rb
+++ b/dashboard/config/puma.rb
@@ -37,6 +37,5 @@ out_of_band {GC::OOB.run}
 # Log thread backtraces and GC stats from all worker processes every second when enabled.
 plugin :log_stats
 LogStats.threshold = -> {DCDO.get('logStatsDashboard', nil)}
-worker_check_interval 1
-thread_backtraces
-gc_stats
+filter_gems = %w(puma sinatra actionview activesupport honeybadger newrelic rack)
+LogStats.backtrace_filter = ->(bt) {CDO.filter_backtrace(bt, filter_gems: filter_gems)}

--- a/lib/cdo.rb
+++ b/lib/cdo.rb
@@ -185,16 +185,17 @@ module Cdo
       filter_backtrace exception.backtrace
     end
 
-    def filter_backtrace(backtrace)
-      FILTER_GEMS.map do |gem|
+    def filter_backtrace(backtrace, filter_gems: FILTER_GEMS)
+      filter_gems.each do |gem|
         backtrace.reject! {|b| b =~ /gems\/#{gem}/}
       end
       backtrace.each do |b|
         b.gsub!(dir, '[CDO]')
         Gem.path.each do |gem|
-          b.gsub!(gem, '[GEM]')
+          b.gsub!(/#{gem}(\/gems|\/bundler\/gems)?/, '[GEM]')
         end
         b.gsub! Bundler.system_bindir, '[BIN]'
+        b.gsub! RbConfig::CONFIG['rubylibdir'], '[RUBY]'
       end
       backtrace.join("\n")
     end

--- a/pegasus/config/puma.rb
+++ b/pegasus/config/puma.rb
@@ -36,6 +36,5 @@ out_of_band {GC::OOB.run}
 # Log thread backtraces and GC stats from all worker processes every second when enabled.
 plugin :log_stats
 LogStats.threshold = -> {DCDO.get('logStatsPegasus', nil)}
-worker_check_interval 1
-thread_backtraces
-gc_stats
+filter_gems = %w(puma sinatra actionview activesupport honeybadger newrelic rack)
+LogStats.backtrace_filter = ->(bt) {CDO.filter_backtrace(bt, filter_gems: filter_gems)}


### PR DESCRIPTION
This PR fixes issues with the debugging instrumentation added to our fork of Puma by rewriting the `:log_stats` plugin (see wjordan/puma@29a576120b30c34db7706c062ddf9a046723789f).

The previous version passed all worker-usage data through a common pipe to the master process where it was parsed/compiled into a single stats output, but that approach caused issues/crashes due to writes of larger amounts of data becoming interleaved in the pipe.

In this version, debug logs are written separately from each individual worker-process, so no extra data is sent through the pipe. (The tradeoff is an extra background thread per worker for the debug logging). Overall this requires less tweaks to Puma system internals so should be simpler / more reliable.

This version also adds a `backtrace_filter` option so thread backtraces are filtered using `CDO.filter_backtrace`. I also updated this method to be a little more useful as well.
