### PR TITLE
Fix: Parent Letter, for teachers with multiple sections

### DIFF
--- a/apps/src/sites/studio/pages/teacher_dashboard/parent_letter.js
+++ b/apps/src/sites/studio/pages/teacher_dashboard/parent_letter.js
@@ -3,6 +3,7 @@ import ReactDOM from 'react-dom';
 import {Provider} from 'react-redux';
 import {getStore, registerReducers} from '@cdo/apps/redux';
 import teacherSections, {
+  selectSection,
   setSections
 } from '@cdo/apps/templates/teacherDashboard/teacherSectionsRedux';
 import sectionData, {setSection} from '@cdo/apps/redux/sectionDataRedux';
@@ -28,6 +29,7 @@ const store = getStore();
 store.dispatch(setCurrentUserName(scriptData.userName));
 store.dispatch(setSections(scriptData.sections));
 store.dispatch(setSection(scriptData.section));
+store.dispatch(selectSection(scriptData.section.id));
 
 window.addEventListener('DOMContentLoaded', function() {
   // Mount and render the letter:


### PR DESCRIPTION
Fix a regression I introduced in https://github.com/code-dot-org/code-dot-org/pull/34070 by never testing with more than one section! ([Slack thread](https://codedotorg.slack.com/archives/C010VJ3EYRW/p1586391474068400))

Fix: Select section explicitly so teachers with multiple sections can see the letter.

Parent letter was not showing up for teachers with more than one section because our redux module selects the section by default if there's only one but leaves no section selected if there's more than one, leading to an empty `section` prop in the component and a failure to render.

![image](https://user-images.githubusercontent.com/1615761/78847536-f426f980-79c3-11ea-82cc-52bd4bc15d37.png)


## Testing story

<!--
  Does your change include appropriate tests?

  If so, please describe how the tests included in this PR are sufficient

  If not, please explain why this change does not need to be tested.
-->

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
