### PR TITLE
Sync updated contacts to Pardot

### DIFF
--- a/dashboard/app/models/contact_rollups_pardot_memory.rb
+++ b/dashboard/app/models/contact_rollups_pardot_memory.rb
@@ -66,7 +66,7 @@ class ContactRollupsPardotMemory < ApplicationRecord
 
   def self.update_pardot_prospects
     pardot_writer = PardotV2.new
-    ActiveRecord::Base.connection.exec_query(find_updated_contacts_query).each do |record|
+    ActiveRecord::Base.connection.exec_query(query_updated_contacts).each do |record|
       old_prospect_data = JSON.parse(record['data_synced'] || '{}').deep_symbolize_keys
       new_contact_data = JSON.parse(record['data']).deep_symbolize_keys
 
@@ -80,7 +80,7 @@ class ContactRollupsPardotMemory < ApplicationRecord
     save_sync_results(submissions, errors, Time.now) if submissions.present?
   end
 
-  def self.find_updated_contacts_query
+  def self.query_updated_contacts
     # TODO: find contacts with updated pardot_id(s)
     <<-SQL.squish
       SELECT processed.email, processed.data, pardot.pardot_id, pardot.data_synced

--- a/dashboard/app/models/contact_rollups_pardot_memory.rb
+++ b/dashboard/app/models/contact_rollups_pardot_memory.rb
@@ -66,8 +66,26 @@ class ContactRollupsPardotMemory < ApplicationRecord
     save_sync_results(submissions, errors, Time.now) if submissions.present?
   end
 
-  # TODO: sync contacts that change pardot mappings
-  # TODO: sync contacts with updated content
+  def self.update_pardot_prospects
+    # Find updated contacts
+    # TODO: find contacts with updated pardot_id(s)
+    updated_contact_query = <<-SQL.squish
+      SELECT processed.email, processed.data, pardot.pardot_id, pardot.data_synced
+      FROM contact_rollups_processed AS processed
+      INNER JOIN contact_rollups_pardot_memory AS pardot
+        ON processed.email = pardot.email
+      WHERE pardot.pardot_id IS NOT NULL
+        AND ((pardot.data_synced_at IS NULL) OR (processed.data->>'$.updated_at' > pardot.data_synced_at))
+    SQL
+
+    ActiveRecord::Base.connection.exec_query(updated_contact_query).map do |record|
+      # TODO: Calculate content to sync
+      # TODO: Send to Pardot
+      record['email']
+      # TODO: Save sync results
+    end
+  end
+
   # TODO: sync deleted contacts
 
   # Saves sync results to database.

--- a/dashboard/app/models/contact_rollups_pardot_memory.rb
+++ b/dashboard/app/models/contact_rollups_pardot_memory.rb
@@ -90,6 +90,9 @@ class ContactRollupsPardotMemory < ApplicationRecord
   end
 
   def self.query_updated_contacts
+    # Updated contacts are contacts that exist in both the production database and Pardot
+    # (have valid Pardot IDs). However, their content or Pardot ID mappings have changed since the
+    # last sync.
     <<-SQL.squish
       SELECT
         processed.email, processed.data,

--- a/dashboard/app/models/contact_rollups_pardot_memory.rb
+++ b/dashboard/app/models/contact_rollups_pardot_memory.rb
@@ -88,7 +88,6 @@ class ContactRollupsPardotMemory < ApplicationRecord
   end
 
   def self.query_updated_contacts
-    # TODO: find contacts with updated pardot_id(s) and test
     <<-SQL.squish
       SELECT
         processed.email, processed.data,
@@ -136,6 +135,8 @@ class ContactRollupsPardotMemory < ApplicationRecord
       }
     end
 
+    # data_synced is the accumulation of all data that has been synced to Pardot.
+    # Its new value is a merger of the current value (could be null) and the recently synced data.
     update_values_sql = <<-SQL.squish
       data_synced = JSON_MERGE_PATCH(COALESCE(data_synced, JSON_OBJECT()), VALUES(data_synced)),
       data_synced_at = VALUES(data_synced_at)

--- a/dashboard/app/models/contact_rollups_pardot_memory.rb
+++ b/dashboard/app/models/contact_rollups_pardot_memory.rb
@@ -78,10 +78,12 @@ class ContactRollupsPardotMemory < ApplicationRecord
 
     pardot_writer = PardotV2.new
     ActiveRecord::Base.connection.exec_query(updated_contact_query).map do |record|
-      old_data = JSON.parse(record['data_synced'] || '{}').deep_symbolize_keys
-      new_data = JSON.parse(record['new_data']).deep_symbolize_keys
+      old_prospect_data = JSON.parse(record['data_synced'] || '{}').deep_symbolize_keys
+      new_contact_data = JSON.parse(record['data']).deep_symbolize_keys
 
-      pardot_writer.batch_update_prospects record['email'], record['pardot_id'], old_data, new_data
+      pardot_writer.batch_update_prospects(
+        record['email'], record['pardot_id'], old_prospect_data, new_contact_data
+      )
 
       # TODO: Save sync results
       record['email']

--- a/dashboard/app/models/contact_rollups_pardot_memory.rb
+++ b/dashboard/app/models/contact_rollups_pardot_memory.rb
@@ -53,10 +53,8 @@ class ContactRollupsPardotMemory < ApplicationRecord
     pardot_writer = PardotV2.new
 
     ActiveRecord::Base.connection.exec_query(new_contacts_query).each do |record|
-      data_col = JSON.parse(record['data']).deep_symbolize_keys
-      contact = {email: record['email']}.merge(data_col)
-
-      submissions, errors = pardot_writer.batch_create_prospects contact
+      data = JSON.parse(record['data']).deep_symbolize_keys
+      submissions, errors = pardot_writer.batch_create_prospects record['email'], data
       save_sync_results(submissions, errors, Time.now) if submissions.present?
     end
 

--- a/dashboard/app/models/contact_rollups_processed.rb
+++ b/dashboard/app/models/contact_rollups_processed.rb
@@ -74,7 +74,7 @@ class ContactRollupsProcessed < ApplicationRecord
         # In a valid item, only data value could be null
         sources = item['sources']
         data = item['data'] || {}
-        data_updated_at = Time.parse(item['data_updated_at'])
+        data_updated_at = Time.find_zone('UTC').parse(item['data_updated_at'])
 
         output[sources] = data.merge('data_updated_at' => data_updated_at)
       end

--- a/dashboard/app/models/contact_rollups_processed.rb
+++ b/dashboard/app/models/contact_rollups_processed.rb
@@ -25,7 +25,9 @@ class ContactRollupsProcessed < ApplicationRecord
     # Combines data and metadata for each record in contact_rollups_raw table into one JSON field.
     # The query result has the same number of rows as in contact_rollups_raw.
     select_query = <<-SQL.squish
-      SELECT email, JSON_OBJECT('sources', sources, 'data', data, 'data_updated_at', data_updated_at) AS data_and_metadata
+      SELECT
+        email,
+        JSON_OBJECT('sources', sources, 'data', data, 'data_updated_at', data_updated_at) AS data_and_metadata
       FROM contact_rollups_raw
     SQL
 
@@ -47,6 +49,7 @@ class ContactRollupsProcessed < ApplicationRecord
 
       processed_contact_data = {}
       processed_contact_data.merge!(extract_opt_in(contact_data) || {})
+      processed_contact_data.merge!(extract_updated_at(contact_data) || {})
 
       batch << {email: contact['email'], data: processed_contact_data}
       next if batch.size < batch_size
@@ -64,8 +67,7 @@ class ContactRollupsProcessed < ApplicationRecord
   # It will throw exception if cannot parse the entire input string.
   #
   # @param [String] str represents a JSON array. Each array item is a hash {sources:String, data:Hash, data_updated_at:DateTime}.
-  #
-  # @return [Hash] a hash {source_table => {contact_attribute => value}}
+  # @return [Hash] a hash with string keys {table_name => {field_name => value}}
   def self.parse_contact_data(str)
     parsed_items = JSON.parse(str)
 
@@ -84,8 +86,7 @@ class ContactRollupsProcessed < ApplicationRecord
   # Extracts opt_in info from contact data.
   #
   # @param [Hash] contact_data compiled data from multiple source tables.
-  #   Input hash structure: {source_table => {contact_attribute => value}}
-  #
+  #   @see output of parse_contact_data method.
   # @return [Hash, nil] a hash containing opt_in key and value (could be nil)
   #   or nil if opt_in does not exist in the input.
   def self.extract_opt_in(contact_data)
@@ -93,5 +94,22 @@ class ContactRollupsProcessed < ApplicationRecord
     field = 'opt_in'
     return nil unless contact_data.key?(table) && contact_data[table].key?(field)
     {opt_in: contact_data.dig(table, field)}
+  end
+
+  # Extracts the latest data_updated_at value.
+  #
+  # @param [Hash] contact_data @see output of parse_contact_data method.
+  # @return [Hash] a hash containing updated_at key and non-nil value
+  #
+  # @raise [StandardError] if couldn't find non-nil data_updated_at value
+  def self.extract_updated_at(contact_data)
+    max_data_updated_at = contact_data.values.map do |item|
+      # There MUST be a non-nil data_updated_at value in each item.
+      # @see parse_contact_data method and ContactRollupsRaw schema.
+      item['data_updated_at']
+    end.max
+
+    raise 'Missing data_updated_at value' unless max_data_updated_at
+    {updated_at: max_data_updated_at}
   end
 end

--- a/dashboard/test/factories/factories.rb
+++ b/dashboard/test/factories/factories.rb
@@ -1243,12 +1243,12 @@ FactoryGirl.define do
     sequence(:email) {|n| "contact_#{n}@example.domain"}
     sequence(:sources) {|n| "dashboard.table_#{n}"}
     data {{opt_in: true}}
-    data_updated_at {Time.now}
+    data_updated_at {Time.now.utc}
   end
 
   factory :contact_rollups_processed do
     transient do
-      data_updated_at {Time.now}
+      data_updated_at {Time.now.utc}
     end
 
     sequence(:email) {|n| "contact_#{n}@example.domain"}
@@ -1267,8 +1267,8 @@ FactoryGirl.define do
   factory :contact_rollups_pardot_memory do
     sequence (:email) {|n| "contact_#{n}@example.domain"}
     sequence(:pardot_id) {|n| n}
-    pardot_id_updated_at {Time.now - 1.hour}
+    pardot_id_updated_at {Time.now.utc - 1.hour}
     data_synced {{db_Opt_In: 'No'}}
-    data_synced_at {Time.now}
+    data_synced_at {Time.now.utc}
   end
 end

--- a/dashboard/test/factories/factories.rb
+++ b/dashboard/test/factories/factories.rb
@@ -1247,8 +1247,12 @@ FactoryGirl.define do
   end
 
   factory :contact_rollups_processed do
+    transient do
+      data_updated_at {Time.now}
+    end
+
     sequence(:email) {|n| "contact_#{n}@example.domain"}
-    data {{'opt_in' => true}}
+    data {{'opt_in' => true, 'updated_at' => data_updated_at}}
   end
 
   factory :contact_rollups_final do
@@ -1260,7 +1264,7 @@ FactoryGirl.define do
     sequence (:email) {|n| "contact_#{n}@example.domain"}
     sequence(:pardot_id) {|n| n}
     pardot_id_updated_at {Time.now - 1.hour}
-    data_synced {{db_Opt_in: 'No'}}
+    data_synced {{db_Opt_In: 'No'}}
     data_synced_at {Time.now}
   end
 end

--- a/dashboard/test/factories/factories.rb
+++ b/dashboard/test/factories/factories.rb
@@ -1260,7 +1260,7 @@ FactoryGirl.define do
     sequence (:email) {|n| "contact_#{n}@example.domain"}
     sequence(:pardot_id) {|n| n}
     pardot_id_updated_at {Time.now - 1.hour}
-    data_synced {{opt_in: false}}
+    data_synced {{db_Opt_in: 'No'}}
     data_synced_at {Time.now}
   end
 end

--- a/dashboard/test/factories/factories.rb
+++ b/dashboard/test/factories/factories.rb
@@ -1252,7 +1252,11 @@ FactoryGirl.define do
     end
 
     sequence(:email) {|n| "contact_#{n}@example.domain"}
-    data {{'opt_in' => true, 'updated_at' => data_updated_at}}
+    data {{'opt_in' => true}}
+
+    after(:build) do |contact, evaluator|
+      contact.data[:updated_at] = evaluator.data_updated_at
+    end
   end
 
   factory :contact_rollups_final do

--- a/dashboard/test/models/contact_rollups_pardot_memory_test.rb
+++ b/dashboard/test/models/contact_rollups_pardot_memory_test.rb
@@ -54,7 +54,7 @@ class ContactRollupsPardotMemoryTest < ActiveSupport::TestCase
       record['email']
     end
 
-    # Should find only 2 new contacts
+    # Should find only 2 new contacts that don't have valid Pardot IDs.
     assert_equal %w(alpha gamma), results
   end
 
@@ -77,16 +77,26 @@ class ContactRollupsPardotMemoryTest < ActiveSupport::TestCase
 
     base_time = Time.now.utc - 2.days
     pardot_memory_records = [
-      {email: 'alpha', pardot_id: 1, data_synced_at: nil, data_synced: nil},
+      {
+        email: 'alpha',
+        pardot_id: 1,
+        pardot_id_updated_at: base_time,
+        data_synced_at: nil,
+        data_synced: nil
+      },
       {
         email: 'beta',
-        pardot_id: 2, pardot_id_updated_at: base_time - 2.days,
-        data_synced_at: base_time - 1.day, data_synced: {db_Opt_In: 'Yes'}
+        pardot_id: 2,
+        pardot_id_updated_at: base_time - 2.days,
+        data_synced_at: base_time - 1.day,
+        data_synced: {db_Opt_In: 'Yes'}
       },
       {
         email: 'gamma',
-        pardot_id: 3, pardot_id_updated_at: base_time + 2.days,
-        data_synced_at: base_time + 1.day, data_synced: {db_Opt_In: 'Yes'}
+        pardot_id: 3,
+        pardot_id_updated_at: base_time + 2.days,
+        data_synced_at: base_time + 1.day,
+        data_synced: {db_Opt_In: 'Yes'}
       },
       # dummy records
       {email: 'delta', pardot_id: nil},
@@ -115,7 +125,7 @@ class ContactRollupsPardotMemoryTest < ActiveSupport::TestCase
     end
 
     expected_results = [
-      {'email' => 'alpha', 'pardot_id_changed' => nil},
+      {'email' => 'alpha', 'pardot_id_changed' => 0},
       {'email' => 'beta', 'pardot_id_changed' => 0},
       {'email' => 'gamma', 'pardot_id_changed' => 1}
     ]

--- a/dashboard/test/models/contact_rollups_pardot_memory_test.rb
+++ b/dashboard/test/models/contact_rollups_pardot_memory_test.rb
@@ -29,7 +29,8 @@ class ContactRollupsPardotMemoryTest < ActiveSupport::TestCase
 
     ContactRollupsPardotMemory.add_and_update_pardot_ids
 
-    assert_equal new_pardot_id, ContactRollupsPardotMemory.find_by(email: existing_record.email)&.pardot_id
+    assert_equal new_pardot_id,
+      ContactRollupsPardotMemory.find_by(email: existing_record.email).pardot_id
   end
 
   test 'query_new_contacts' do
@@ -67,7 +68,7 @@ class ContactRollupsPardotMemoryTest < ActiveSupport::TestCase
 
     assert_equal 1, ContactRollupsPardotMemory.count
     record = ContactRollupsPardotMemory.find_by(email: contact.email)
-    assert_equal({'db_Opt_In' => 'Yes'}, record&.data_synced)
+    assert_equal({'db_Opt_In' => 'Yes'}, record.data_synced)
   end
 
   test 'query_updated_contacts' do
@@ -132,8 +133,8 @@ class ContactRollupsPardotMemoryTest < ActiveSupport::TestCase
     ContactRollupsPardotMemory.update_pardot_prospects
 
     record = ContactRollupsPardotMemory.find_by(email: email)
-    assert_equal({'db_Opt_In' => 'Yes'}, record&.data_synced)
-    assert last_sync_time < record&.data_synced_at
+    assert_equal({'db_Opt_In' => 'Yes'}, record.data_synced)
+    assert last_sync_time < record.data_synced_at
   end
 
   test 'save_sync_results new prospect' do
@@ -149,7 +150,7 @@ class ContactRollupsPardotMemoryTest < ActiveSupport::TestCase
       data_synced_at: submitted_time
     )
     expected_data_synced = submission.except(:email, :id).deep_stringify_keys
-    assert_equal expected_data_synced, record&.data_synced
+    assert_equal expected_data_synced, record.data_synced
   end
 
   test 'save_sync_results updated prospects' do
@@ -176,7 +177,7 @@ class ContactRollupsPardotMemoryTest < ActiveSupport::TestCase
         data_synced_at: submitted_time
       )
       expected_data_synced = submission.except(:email, :id).deep_stringify_keys
-      assert_equal expected_data_synced, record&.data_synced
+      assert_equal expected_data_synced, record.data_synced
     end
   end
 

--- a/dashboard/test/models/contact_rollups_pardot_memory_test.rb
+++ b/dashboard/test/models/contact_rollups_pardot_memory_test.rb
@@ -32,7 +32,63 @@ class ContactRollupsPardotMemoryTest < ActiveSupport::TestCase
     assert_equal new_pardot_id, ContactRollupsPardotMemory.find_by(email: existing_record.email)&.pardot_id
   end
 
-  test 'create_new_pardot_contacts' do
+  test 'update_pardot_prospects' do
+    # Function under test: ContactRollupsPardotMemory.update_pardot_prospects
+    # Input: processed table + pardot_memory table
+    # Expected outputs/results:
+    # 1. Send requests to Pardot
+    #   1.1. Find all contacts with updates
+    #     1.1.1 Contacts has pardot ID but never synced to pardot
+    #     1.1.2 Contacts updated after the last time synced to Pardot
+    #     1.1.3 Contacts have new pardot ids
+    #   1.2. Calculate content of each contact to sync (delta could be none)
+    #   1.3. Create batch update query
+    #   1.4. Send update query
+    # 2. Make changes to PardotMemory table
+    #   2.1 Update successfully synced contacts: time synced, data synced
+    #   2.2 Update rejected contacts: time rejected, reason
+
+    # Test 1.1.1 + 1.1.2
+    # setup:
+    #   processed table:
+    #     contact (a).
+    #     contact (b) w/ data_updated_at > pardot data_synced_at.
+    #     contact (c) w/ data_updated_at < pardot data_synced_at.
+    #     contact (d)
+    #     contact (e) not in pardot_memory
+    #   pardot_memory table:
+    #     contact (a) with pardot_id (data_synced_at = null).
+    #     contact (b) w/ pardot_id + data_synced + data_synced_at.
+    #     contact (c) w/ pardot_id + data_synced + data_synced_at.
+    #     contact (d) w/o pardot_id
+    #     contact (f) not in processed table
+    # expect: find (a) & (b)
+
+    base_time = Time.now - 2.days
+    contact_list = [
+      {email: 'alpha@cdo.org', pardot_id: 1, data_updated_at: base_time, data_synced_at: nil, data_synced: nil},
+      {email: 'beta@cdo.org', pardot_id: 2, data_updated_at: base_time, data_synced_at: base_time - 1.day, data_synced: {}},
+      {email: 'gamma@cdo.org', pardot_id: 3, data_updated_at: base_time, data_synced_at: base_time + 1.day, data_synced: {}},
+      {email: 'delta@cdo.org', pardot_id: nil},
+      {email: 'epsilon@cdo.org', not_in_pardot_memory_table: true},
+      {email: 'zeta@cdo.org', not_in_processed_table: true},
+    ]
+    expected_updated_contacts = %w(alpha@cdo.org beta@cdo.org)
+
+    contact_list.each do |contact|
+      unless contact[:not_in_processed_table]
+        create :contact_rollups_processed, email: contact[:email], data: {updated_at: contact[:data_updated_at]}
+      end
+
+      unless contact[:not_in_pardot_memory_table]
+        create :contact_rollups_pardot_memory, contact.slice(:email, :data_synced_at, :data_synced)
+      end
+    end
+
+    assert_equal expected_updated_contacts, ContactRollupsPardotMemory.update_pardot_prospects
+  end
+
+  test 'create_new_pardot_prospects' do
     assert_equal 0, ContactRollupsPardotMemory.count
     assert_equal 0, ContactRollupsProcessed.count
     PardotV2.stubs(:submit_batch_request).returns([])

--- a/dashboard/test/models/contact_rollups_pardot_memory_test.rb
+++ b/dashboard/test/models/contact_rollups_pardot_memory_test.rb
@@ -74,7 +74,7 @@ class ContactRollupsPardotMemoryTest < ActiveSupport::TestCase
     assert_equal 0, ContactRollupsPardotMemory.count
     assert_equal 0, ContactRollupsProcessed.count
 
-    base_time = Time.now - 2.days
+    base_time = Time.now.utc - 2.days
     pardot_memory_records = [
       {email: 'alpha', pardot_id: 1, data_synced_at: nil, data_synced: nil},
       {email: 'beta', pardot_id: 2, data_synced_at: base_time - 1.day, data_synced: {db_Opt_In: 'Yes'}},
@@ -105,7 +105,7 @@ class ContactRollupsPardotMemoryTest < ActiveSupport::TestCase
 
   test 'update_pardot_prospects' do
     email = 'test@domain.com'
-    last_sync_time = Time.now - 7.days
+    last_sync_time = Time.now.utc - 7.days
     create :contact_rollups_pardot_memory, email: email, data_synced: {db_Opt_In: 'No'}, data_synced_at: last_sync_time
     create :contact_rollups_processed, email: email, data: {'opt_in' => true}
 
@@ -122,7 +122,7 @@ class ContactRollupsPardotMemoryTest < ActiveSupport::TestCase
     assert_equal 0, ContactRollupsPardotMemory.count
 
     submission = {email: 'valid@domain.com', db_Opt_In: 'Yes'}
-    submitted_time = Time.now
+    submitted_time = Time.now.utc
 
     ContactRollupsPardotMemory.save_sync_results [submission], [], submitted_time
 
@@ -148,7 +148,7 @@ class ContactRollupsPardotMemoryTest < ActiveSupport::TestCase
       {email: 'beta', id: 2, db_Opt_In: 'Yes'},
       {email: 'gamma', id: 3, db_Opt_In: 'Yes'},
     ]
-    submitted_time = Time.now
+    submitted_time = Time.now.utc
 
     ContactRollupsPardotMemory.save_sync_results submissions, [], submitted_time
 
@@ -167,7 +167,7 @@ class ContactRollupsPardotMemoryTest < ActiveSupport::TestCase
 
     submissions = [{email: 'invalid_email', id: nil, db_Opt_In: 'No'}]
     errors = [{prospect_index: 0, error_msg: PardotHelpers::ERROR_INVALID_EMAIL}]
-    submitted_time = Time.now
+    submitted_time = Time.now.utc
 
     ContactRollupsPardotMemory.save_sync_results submissions, errors, submitted_time
 

--- a/dashboard/test/models/contact_rollups_pardot_memory_test.rb
+++ b/dashboard/test/models/contact_rollups_pardot_memory_test.rb
@@ -53,7 +53,7 @@ class ContactRollupsPardotMemoryTest < ActiveSupport::TestCase
     end
   end
 
-  test 'find_updated_contacts_query' do
+  test 'query_updated_contacts' do
     assert_equal 0, ContactRollupsPardotMemory.count
     assert_equal 0, ContactRollupsProcessed.count
 
@@ -80,11 +80,13 @@ class ContactRollupsPardotMemoryTest < ActiveSupport::TestCase
       create :contact_rollups_processed, contact_info
     end
 
+    # Execute SQL query
     results = ActiveRecord::Base.connection.
-      exec_query(ContactRollupsPardotMemory.find_updated_contacts_query).map do |record|
+      exec_query(ContactRollupsPardotMemory.query_updated_contacts).map do |record|
       record['email']
     end
 
+    # Should find only 2 contacts to update
     assert_equal %w(alpha beta), results
   end
 

--- a/dashboard/test/models/contact_rollups_pardot_memory_test.rb
+++ b/dashboard/test/models/contact_rollups_pardot_memory_test.rb
@@ -152,7 +152,7 @@ class ContactRollupsPardotMemoryTest < ActiveSupport::TestCase
     assert_equal expected_data_synced, record&.data_synced
   end
 
-  test 'save_sync_results updated prospect' do
+  test 'save_sync_results updated prospects' do
     assert_equal 0, ContactRollupsPardotMemory.count
     pardot_memory_records = [
       {email: 'alpha', pardot_id: 1, data_synced: nil},
@@ -183,14 +183,14 @@ class ContactRollupsPardotMemoryTest < ActiveSupport::TestCase
   test 'save_sync_results rejected contact' do
     assert_equal 0, ContactRollupsPardotMemory.count
 
-    submissions = [{email: 'invalid_email', id: nil, db_Opt_In: 'No'}]
+    submission = {email: 'invalid_email', id: nil, db_Opt_In: 'No'}
     errors = [{prospect_index: 0, error_msg: PardotHelpers::ERROR_INVALID_EMAIL}]
     submitted_time = Time.now.utc
 
-    ContactRollupsPardotMemory.save_sync_results submissions, errors, submitted_time
+    ContactRollupsPardotMemory.save_sync_results [submission], errors, submitted_time
 
     refute_nil ContactRollupsPardotMemory.find_by(
-      email: submissions.first[:email],
+      email: submission[:email],
       data_rejected_reason: PardotHelpers::ERROR_INVALID_EMAIL,
       data_rejected_at: submitted_time
     )

--- a/dashboard/test/models/contact_rollups_processed_test.rb
+++ b/dashboard/test/models/contact_rollups_processed_test.rb
@@ -72,9 +72,9 @@ class ContactRollupsProcessedTest < ActiveSupport::TestCase
 
   test 'parse_contact_data parses valid input' do
     time_str = '2020-03-11 15:01:26'
-    time_parsed = Time.parse(time_str)
+    time_parsed = Time.find_zone('UTC').parse(time_str)
 
-    test_cases = [
+    tests = [
       {
         input: format('[{"sources": "table1", "data": null, "data_updated_at": "%s"}]', time_str),
         expected_output: {'table1' => {'data_updated_at' => time_parsed}}
@@ -100,7 +100,7 @@ class ContactRollupsProcessedTest < ActiveSupport::TestCase
       }
     ]
 
-    test_cases.each_with_index do |test, index|
+    tests.each_with_index do |test, index|
       output = ContactRollupsProcessed.parse_contact_data test[:input]
       assert_equal test[:expected_output], output, "Test index #{index} failed"
     end

--- a/dashboard/test/models/contact_rollups_processed_test.rb
+++ b/dashboard/test/models/contact_rollups_processed_test.rb
@@ -70,6 +70,35 @@ class ContactRollupsProcessedTest < ActiveSupport::TestCase
     end
   end
 
+  test 'extract_updated_at' do
+    base_time = Time.now.utc - 7.days
+    tests = [
+      {
+        input: {'table1' => {'data_updated_at' => base_time}},
+        expected_output: {updated_at: base_time}
+      },
+      {
+        input: {
+          'table1' => {'data_updated_at' => base_time - 1.day},
+          'table2' => {'data_updated_at' => base_time + 1.day},
+          'table3' => {'data_updated_at' => base_time},
+        },
+        expected_output: {updated_at: base_time + 1.day}
+      }
+    ]
+
+    # Test valid inputs
+    tests.each_with_index do |test, index|
+      output = ContactRollupsProcessed.extract_updated_at(test[:input])
+      assert_equal test[:expected_output], output, "Test index #{index} failed"
+    end
+
+    # Test invalid input
+    assert_raise StandardError do
+      ContactRollupsProcessed.extract_updated_at({'table' => {}})
+    end
+  end
+
   test 'parse_contact_data parses valid input' do
     time_str = '2020-03-11 15:01:26'
     time_parsed = Time.find_zone('UTC').parse(time_str)

--- a/lib/cdo/contact_rollups/v2/contact_rollups.rb
+++ b/lib/cdo/contact_rollups/v2/contact_rollups.rb
@@ -1,18 +1,29 @@
 class ContactRollupsV2
   def self.build_contact_rollups(log_collector)
-    # Set opt_in based on information collected in Dashboard Email Preference.
-    log_collector.time!('ContactRollupsRaw.truncate_table') {ContactRollupsRaw.truncate_table}
-    log_collector.time!('ContactRollupsRaw.extract_email_preferences') {ContactRollupsRaw.extract_email_preferences}
+    ContactRollupsRaw.truncate_table
+    log_collector.time!('Extracts data from dashboard email_preferences') do
+      ContactRollupsRaw.extract_email_preferences
+    end
 
-    log_collector.time!('ContactRollupsProcessed.delete_all') {ContactRollupsProcessed.delete_all}
-    log_collector.time!('ContactRollupsProcessed.import_from_raw_table') {ContactRollupsProcessed.import_from_raw_table}
+    log_collector.time!('Processes all extracted data') do
+      ContactRollupsProcessed.delete_all
+      ContactRollupsProcessed.import_from_raw_table
+    end
 
-    log_collector.time!('ContactRollupsComparison.delete_all') {ContactRollupsComparison.delete_all}
-    log_collector.time!('ContactRollupsComparison.compare_processed_data') {ContactRollupsComparison.compile_processed_data}
+    log_collector.time!('Compares new and previously processed data') do
+      ContactRollupsComparison.delete_all
+      ContactRollupsComparison.compile_processed_data
+    end
 
-    log_collector.time!('ContactRollupsPardotMemory.add_and_update_pardot_ids') {ContactRollupsPardotMemory.add_and_update_pardot_ids}
-    log_collector.time!('ContactRollupsComparison.sync_new_contacts_to_pardot') {ContactRollupsPardotMemory.create_new_pardot_prospects}
+    log_collector.time!('Downloads new email-Pardot ID mappings') do
+      ContactRollupsPardotMemory.add_and_update_pardot_ids
+    end
+    log_collector.time!('Creates new Pardot prospects') do
+      ContactRollupsPardotMemory.create_new_pardot_prospects
+    end
 
-    log_collector.time!("ContactRollupsFinal.overwrite_from_processed_table") {ContactRollupsFinal.overwrite_from_processed_table}
+    log_collector.time!("Overwrites contact_rollups_final table") do
+      ContactRollupsFinal.overwrite_from_processed_table
+    end
   end
 end

--- a/lib/cdo/contact_rollups/v2/contact_rollups.rb
+++ b/lib/cdo/contact_rollups/v2/contact_rollups.rb
@@ -21,6 +21,9 @@ class ContactRollupsV2
     log_collector.time!('Creates new Pardot prospects') do
       ContactRollupsPardotMemory.create_new_pardot_prospects
     end
+    log_collector.time!('Updates existing Pardot prospects') do
+      ContactRollupsPardotMemory.update_pardot_prospects
+    end
 
     log_collector.time!("Overwrites contact_rollups_final table") do
       ContactRollupsFinal.overwrite_from_processed_table

--- a/lib/cdo/contact_rollups/v2/pardot.rb
+++ b/lib/cdo/contact_rollups/v2/pardot.rb
@@ -207,9 +207,9 @@ class PardotV2
 
     # Send request to Pardot
     url = build_batch_url api_endpoint, prospects
-    time_start = Time.now
+    time_start = Time.now.utc
     doc = post_with_auth_retry url
-    time_elapsed = Time.now - time_start
+    time_elapsed = Time.now.utc - time_start
 
     # Return indexes of rejected emails and their error messages
     errors = extract_batch_request_errors doc

--- a/lib/cdo/contact_rollups/v2/pardot.rb
+++ b/lib/cdo/contact_rollups/v2/pardot.rb
@@ -237,4 +237,25 @@ class PardotV2
       {prospect_index: node.attr("identifier").to_i, error_msg: node.text}
     end
   end
+
+  # Calculates what needs to change to transform an old data to a new data.
+  # @param [Hash] old_data
+  # @param [Hash] new_data
+  # @return [Hash]
+  def self.calculate_data_delta(old_data, new_data)
+    return new_data unless old_data.present?
+
+    # Collect key-value pairs that exist only in the new data
+    delta = {}
+    new_data.each_pair do |key, val|
+      delta[key] = val unless old_data.key?(key) && old_data[key] == val
+    end
+
+    # Remove entries that exist only in the old data and not in the new data
+    old_data.each_pair do |key, _|
+      delta[key] = nil unless new_data.key?(key)
+    end
+
+    delta
+  end
 end

--- a/lib/cdo/contact_rollups/v2/pardot.rb
+++ b/lib/cdo/contact_rollups/v2/pardot.rb
@@ -236,15 +236,16 @@ class PardotV2
   def self.calculate_data_delta(old_data, new_data)
     return new_data unless old_data.present?
 
-    # Collect key-value pairs that exist only in the new data
+    # Set key-value pairs that exist only in the new data
     delta = {}
     new_data.each_pair do |key, val|
       delta[key] = val unless old_data.key?(key) && old_data[key] == val
     end
 
-    # Remove entries that exist only in the old data and not in the new data
-    old_data.each_pair do |key, _|
-      delta[key] = nil unless new_data.key?(key)
+    # Unset entries that exist only in the old data and not in the new data.
+    # Ignore entries with values are nil.
+    old_data.each_pair do |key, val|
+      delta[key] = nil unless new_data.key?(key) || val.nil?
     end
 
     delta

--- a/lib/cdo/contact_rollups/v2/pardot.rb
+++ b/lib/cdo/contact_rollups/v2/pardot.rb
@@ -66,14 +66,15 @@ class PardotV2
   # You can think of using this method as writing to an output stream, which at the end you
   # have to flush out the remaining content in the stream.
   #
-  # @param [Hash] contact
+  # @param [String] email
+  # @param [Hash] data
   # @param [Boolean] eager_submit
   # @return [Array] two arrays, one for all submitted prospects and one for Pardot errors
-  def batch_create_prospects(contact, eager_submit = false)
+  def batch_create_prospects(email, data, eager_submit = false)
     submissions = []
     errors = []
 
-    prospect = self.class.convert_to_prospect_fields contact
+    prospect = self.class.convert_to_prospect_fields data.merge(email: email)
     @new_prospects << prospect
 
     url = self.class.build_batch_url BATCH_CREATE_URL, @new_prospects
@@ -109,6 +110,8 @@ class PardotV2
     prospect = {}
 
     CONTACT_TO_PARDOT_PROSPECT_MAP.each do |key, prospect_info|
+      next unless contact.key?(key)
+
       if prospect_info[:multi]
         # For multi data fields (multi-select, etc.), set key names as [field_name]_0, [field_name]_1, etc.
         contact[key].split(',').each_with_index do |value, index|

--- a/lib/test/cdo/contact_rollups/test_pardot_v2.rb
+++ b/lib/test/cdo/contact_rollups/test_pardot_v2.rb
@@ -241,10 +241,13 @@ class PardotV2Test < Minitest::Test
       {old_data: nil, new_data: {k1: 'v1'}, expected_delta: {k1: 'v1'}},
       {old_data: {k1: 'v1'}, new_data: {}, expected_delta: {k1: nil}},
       {old_data: {k1: 'v1'}, new_data: {k1: 'v1'}, expected_delta: {}},
+      {old_data: {k1: 'v1'}, new_data: {k1: 'v1.1'}, expected_delta: {k1: 'v1.1'}},
+      {old_data: {k1: 'v1'}, new_data: {k2: 'v2'}, expected_delta: {k1: nil, k2: 'v2'}},
+      {old_data: {k1: nil}, new_data: {k2: 'v2'}, expected_delta: {k2: 'v2'}},
       {
-        old_data: {k1: 'v1', k2: 'v2'},
-        new_data: {k1: 'v1.1', k3: 'v3'},
-        expected_delta: {k1: 'v1.1', k2: nil, k3: 'v3'}
+        old_data: {k1: 'v1', k2: 'v2', k3: nil},
+        new_data: {k1: 'v1.1', k4: 'v4'},
+        expected_delta: {k1: 'v1.1', k2: nil, k4: 'v4'}
       },
     ]
 

--- a/lib/test/cdo/contact_rollups/test_pardot_v2.rb
+++ b/lib/test/cdo/contact_rollups/test_pardot_v2.rb
@@ -148,4 +148,23 @@ class PardotV2Test < Minitest::Test
 
     assert_equal expected_errors, PardotV2.submit_batch_request('a_pardot_endpoint', prospects)
   end
+
+  def test_calculate_data_delta
+    tests = [
+      {old_data: nil, new_data: {}, expected_delta: {}},
+      {old_data: nil, new_data: {k1: 'v1'}, expected_delta: {k1: 'v1'}},
+      {old_data: {k1: 'v1'}, new_data: {}, expected_delta: {k1: nil}},
+      {old_data: {k1: 'v1'}, new_data: {k1: 'v1'}, expected_delta: {}},
+      {
+        old_data: {k1: 'v1', k2: 'v2'},
+        new_data: {k1: 'v1.1', k3: 'v3'},
+        expected_delta: {k1: 'v1.1', k2: nil, k3: 'v3'}
+      },
+    ]
+
+    tests.each_with_index do |test, index|
+      delta = PardotV2.calculate_data_delta test[:old_data], test[:new_data]
+      assert_equal test[:expected_delta], delta, "Test index #{index} failed"
+    end
+  end
 end

--- a/lib/test/cdo/contact_rollups/test_pardot_v2.rb
+++ b/lib/test/cdo/contact_rollups/test_pardot_v2.rb
@@ -88,9 +88,18 @@ class PardotV2Test < Minitest::Test
   end
 
   def test_convert_to_prospect_fields
-    contact = {email: 'test@domain.com', pardot_id: 10, opt_in: true}
-    expected_prospect = {email: 'test@domain.com', id: 10, db_Opt_In: 'Yes'}
-    assert_equal expected_prospect, PardotV2.convert_to_prospect_fields(contact)
+    contacts = [
+      {email: 'test0@domain.com', pardot_id: 10, opt_in: true},
+      {email: 'test1@domain.com', pardot_id: nil, bad_key: true}
+    ]
+    expected_prospects = [
+      {email: 'test0@domain.com', id: 10, db_Opt_In: 'Yes'},
+      {email: 'test1@domain.com', id: nil}
+    ]
+
+    contacts.each_with_index do |contact, index|
+      assert_equal expected_prospects[index], PardotV2.convert_to_prospect_fields(contact)
+    end
   end
 
   def test_build_batch_url

--- a/lib/test/cdo/contact_rollups/test_pardot_v2.rb
+++ b/lib/test/cdo/contact_rollups/test_pardot_v2.rb
@@ -11,7 +11,7 @@ class PardotV2Test < Minitest::Test
       </rsp>
     XML
 
-    PardotV2.stubs(:post_with_auth_retry).returns(pardot_response)
+    PardotV2.stubs(:post_with_auth_retry).once.returns(pardot_response)
 
     assert_equal [], PardotV2.retrieve_new_ids(0)
   end
@@ -30,7 +30,7 @@ class PardotV2Test < Minitest::Test
         </result>
       </rsp>
     XML
-    PardotV2.stubs(:post_with_auth_retry).returns(pardot_response)
+    PardotV2.stubs(:post_with_auth_retry).once.returns(pardot_response)
 
     expected_result = [{email: email, pardot_id: pardot_id}]
     assert_equal expected_result, PardotV2.retrieve_new_ids(0)
@@ -44,7 +44,7 @@ class PardotV2Test < Minitest::Test
           <errors/>
       </rsp>
     XML
-    PardotV2.stubs(:post_with_auth_retry).returns(ok_response)
+    PardotV2.stubs(:post_with_auth_retry).once.returns(ok_response)
 
     # Eagerly send a batch-create request
     submitted, errors = PardotV2.new.batch_create_prospects contact[:email], contact[:data], true
@@ -67,7 +67,7 @@ class PardotV2Test < Minitest::Test
           </errors>
       </rsp>
     XML
-    PardotV2.stubs(:post_with_auth_retry).returns(response_with_errors)
+    PardotV2.stubs(:post_with_auth_retry).once.returns(response_with_errors)
 
     # Calling batch_create for each contact. No request shall be sent
     pardot_writer = PardotV2.new
@@ -102,7 +102,7 @@ class PardotV2Test < Minitest::Test
           <errors/>
       </rsp>
     XML
-    PardotV2.stubs(:post_with_auth_retry).returns(ok_response)
+    PardotV2.stubs(:post_with_auth_retry).once.returns(ok_response)
 
     # Eagerly submit an update request
     submissions, errors = PardotV2.new.batch_update_prospects(
@@ -140,7 +140,7 @@ class PardotV2Test < Minitest::Test
           </errors>
       </rsp>
     XML
-    PardotV2.stubs(:post_with_auth_retry).returns(response_with_errors)
+    PardotV2.stubs(:post_with_auth_retry).once.returns(response_with_errors)
 
     # Calling batch_update for each contact. No update request shall be sent
     pardot_writer = PardotV2.new
@@ -207,7 +207,7 @@ class PardotV2Test < Minitest::Test
           <errors/>
       </rsp>
     XML
-    PardotV2.stubs(:post_with_auth_retry).returns(ok_response)
+    PardotV2.stubs(:post_with_auth_retry).once.returns(ok_response)
 
     assert_equal [], PardotV2.submit_batch_request('a_pardot_endpoint', prospects)
   end
@@ -225,7 +225,7 @@ class PardotV2Test < Minitest::Test
           </errors>
       </rsp>
     XML
-    PardotV2.stubs(:post_with_auth_retry).returns(response_with_errors)
+    PardotV2.stubs(:post_with_auth_retry).once.returns(response_with_errors)
 
     expected_errors = [
       {prospect_index: 0, error_msg: 'Invalid prospect email address'},

--- a/lib/test/cdo/contact_rollups/test_pardot_v2.rb
+++ b/lib/test/cdo/contact_rollups/test_pardot_v2.rb
@@ -164,7 +164,7 @@ class PardotV2Test < Minitest::Test
     assert_equal expected_errors, errors
   end
 
-  def test_convert_to_prospect_fields
+  def test_convert_to_pardot_prospect
     contacts = [
       {email: 'test0@domain.com', pardot_id: 10, opt_in: true},
       {email: 'test1@domain.com', pardot_id: nil, bad_key: true}
@@ -175,7 +175,7 @@ class PardotV2Test < Minitest::Test
     ]
 
     contacts.each_with_index do |contact, index|
-      assert_equal expected_prospects[index], PardotV2.convert_to_prospect_fields(contact)
+      assert_equal expected_prospects[index], PardotV2.convert_to_pardot_prospect(contact)
     end
   end
 

--- a/lib/test/cdo/contact_rollups/test_pardot_v2.rb
+++ b/lib/test/cdo/contact_rollups/test_pardot_v2.rb
@@ -90,6 +90,9 @@ class PardotV2Test < Minitest::Test
   end
 
   def test_batch_update_prospects_single_contact
+    # TODO: add more fields to new_contact_data so that new_contact_data and old_prospect_data
+    #   semantically overlap (field names could be different).
+    #   Same in test_batch_update_prospects_multiple_contacts.
     contact = {
       email: 'alpha@cdo.org',
       pardot_id: 1,


### PR DESCRIPTION
[PLC-787](https://codedotorg.atlassian.net/browse/PLC-787): Finding contacts that have been updated since the last sync (either contact data have changed or Pardot IDs have changed) and updating their corresponding Pardot prospects.

This is the next step after finding new contacts and creating Pardot prospects for them in https://github.com/code-dot-org/code-dot-org/pull/33822.

## Testing story
- Unit tests
  - From dashboard: `bundle exec rails test test/models/contact_rollups_pardot_memory_test.rb`
  - From dashboard: `bundle exec rails test test/models/contact_rollups_processed_test.rb`
  - From repo root: `bundle exec ruby -Ilib:test lib/test/cdo/contact_rollups/test_pardot_v2.rb`
- Manual test in rails console
  ```ruby
  require 'cdo/contact_rollups/v2/pardot'

  # Use an existing Pardot prospect
  # https://pi.pardot.com/prospect/read/id/82839621
  contact = {
    email: 'crv2_test@domain.com',
    pardot_id: 82839621,
    old_prospect_data: {db_Opt_In: 'No'},
    new_contact_data: {opt_in: true}
  }

  # Send request to update to Pardot
  PardotV2.new.batch_update_prospects *contact.values_at(:email, :pardot_id, :old_prospect_data, :new_contact_data), true
  
  # Verify that prospect data is updated correctly
  # at https://pi.pardot.com/prospect/read/id/82839621
  ```

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
