### PR TITLE
Teacher Dashboard: fix spacing for progress tab arrow

### DIFF
--- a/apps/src/templates/sectionProgress/detail/VirtualizedDetailView.jsx
+++ b/apps/src/templates/sectionProgress/detail/VirtualizedDetailView.jsx
@@ -35,8 +35,7 @@ const styles = {
   numberHeader: {
     ...progressStyles.lessonNumberHeading,
     margin: 0,
-    paddingLeft: 16,
-    width: 39
+    paddingLeft: 16
   },
   lessonHeaderContainer: {
     display: 'flex',


### PR DESCRIPTION
[Mark noticed this months ago](https://codedotorg.slack.com/archives/C0SUN2SSF/p1556748773000300); finally fixing. 

BEFORE 

<img width="1036" alt="Screen Shot 2020-04-08 at 9 27 26 PM" src="https://user-images.githubusercontent.com/12300669/78858275-c8fed300-79e0-11ea-986b-75d877abfaad.png">

AFTER

<img width="1022" alt="Screen Shot 2020-04-08 at 9 31 02 PM" src="https://user-images.githubusercontent.com/12300669/78858277-cb612d00-79e0-11ea-9e91-e54beb23f099.png">

