### PR TITLE
Fix GDPR checkbox style in sign up page

### DIFF
--- a/dashboard/app/assets/stylesheets/application.scss
+++ b/dashboard/app/assets/stylesheets/application.scss
@@ -1775,6 +1775,9 @@ a.download-video {
         padding: 0 10px;
         font-size: 14px;
       }
+      .field_with_errors {
+        flex-basis: auto;
+      }
     }
 
     #email-preference-radio {
@@ -1830,6 +1833,10 @@ a.download-video {
         font-size: 14px;
         margin: 0;
       }
+    }
+
+    #gdpr-section {
+      flex-wrap: wrap;
     }
   }
 }

--- a/dashboard/app/views/devise/registrations/_finish_sign_up.html.haml
+++ b/dashboard/app/views/devise/registrations/_finish_sign_up.html.haml
@@ -109,7 +109,7 @@
     -# If GDPR applies, show an additional checkbox.
     - if request.gdpr? || request.params['force_in_eu']
       .row
-        .span6
+        .span12#gdpr-section
           = f.hidden_field :data_transfer_agreement_required, value: "1"
           .checkbox
             = f.label :data_transfer_agreement_accepted do
@@ -117,9 +117,8 @@
               %span
                 = t('signup_form.agree_us_website')
                 = t('signup_form.my_data_to_us')
-        .span2
           - if @user.errors[:data_transfer_agreement_accepted].present?
-            %span.error= t('signup_form.accept_terms')
+            %p.error= t('signup_form.accept_terms')
 
     .row#email-preference-radio{style: "display: none;"}
       .span10.signup-field-label


### PR DESCRIPTION
I noticed there were some styling updates missed with the last big update to the sign up page style.
* Makes the GDPR checkbox dialog match the width of other inputs.
* Moves the error message below the input to make it consistent with other inputs.

## Screenshots
### Before
![image](https://user-images.githubusercontent.com/1372238/78930883-594a2000-7a94-11ea-9a6c-fa8d01fdca95.png)
### After
![image](https://user-images.githubusercontent.com/1372238/78930900-623af180-7a94-11ea-99db-1ccceb6e5acd.png)
![image](https://user-images.githubusercontent.com/1372238/78930918-6ebf4a00-7a94-11ea-87d9-3cf2d6bdb89c.png)


## Testing story
* Tested on my local machine.

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
