### PR TITLE
Standards: fix jumpy comment box cursor

### DIFF
--- a/apps/src/templates/sectionProgress/standards/CreateStandardsReportStep2.jsx
+++ b/apps/src/templates/sectionProgress/standards/CreateStandardsReportStep2.jsx
@@ -33,6 +33,12 @@ class CreateStandardsReportStep2 extends Component {
   };
 
   commentChanged = event => {
+    const cursorPosition = event.target.selectionStart;
+    const commentBox = event.target;
+    window.requestAnimationFrame(() => {
+      commentBox.selectionStart = cursorPosition;
+      commentBox.selectionEnd = cursorPosition;
+    });
     this.props.onCommentChange(event.target.value);
   };
 


### PR DESCRIPTION
[LP-1380](https://codedotorg.atlassian.net/browse/LP-1380)

Previously when editing the comment text on the standards tab, the cursor would always jump to the end of the line. 
![jumpy-cursor-problem](https://user-images.githubusercontent.com/12300669/78954518-47b34900-7a91-11ea-93dd-06caac8925f6.gif)

This is a [known issue with React controlled input fields.](https://github.com/facebook/react/issues/955) 

I used a little trick to fix the cursor positioning. 
![jumpy-cursor-fix](https://user-images.githubusercontent.com/12300669/78954520-48e47600-7a91-11ea-94f1-e2be3977f319.gif)

