### PR TITLE
Fix clone cluster policy

### DIFF
--- a/aws/cloudformation/cloud_formation_stack.yml.erb
+++ b/aws/cloudformation/cloud_formation_stack.yml.erb
@@ -294,6 +294,7 @@ Resources:
                 Resource:
                   - !Sub "arn:aws:rds:${AWS::Region}:${AWS::AccountId}:cluster:*"
                   - !Sub "arn:aws:rds:${AWS::Region}:${AWS::AccountId}:subgrp:*"
+                  - !Sub "arn:aws:rds:${AWS::Region}:${AWS::AccountId}:cluster-pg:*"
               - Effect: Allow
                 Action:
                   - 'rds:DeleteDBCluster'


### PR DESCRIPTION
Grant `production-daemon` permission to use any DB Cluster Parameter Group when cloning (RestoreToPointInTIme) a cluster.

### Background

Fix for #33547 


# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
