### PR TITLE
Allow applab mouse events to listen for touch events as well

### DIFF
--- a/apps/src/applab/EventSandboxer.js
+++ b/apps/src/applab/EventSandboxer.js
@@ -98,6 +98,28 @@ EventSandboxer.prototype.sandboxEvent = function(event) {
       newEvent[prop] = event[prop];
     }
   });
+
+  // map touch events to mouse events
+  if (event.type.substring(0, 5) === 'touch') {
+    switch (event.type) {
+      case 'touchmove':
+        newEvent.type = 'mousemove';
+        break;
+      case 'touchstart':
+        newEvent.type = 'mousedown';
+        break;
+      case 'touchend':
+        newEvent.type = 'mouseup';
+        break;
+    }
+    event.clientX = event.changedTouches[0].clientX;
+    event.clientY = event.changedTouches[0].clientY;
+    event.pageX = event.changedTouches[0].pageX;
+    event.pageY = event.changedTouches[0].pageY;
+    event.x = event.changedTouches[0].clientX;
+    event.y = event.changedTouches[0].clientY;
+  }
+
   // Convert x coordinates and then pass through to applabEvent:
   ['clientX', 'pageX', 'x'].forEach(function(prop) {
     if (typeof event[prop] !== 'undefined') {

--- a/apps/src/applab/EventSandboxer.js
+++ b/apps/src/applab/EventSandboxer.js
@@ -100,7 +100,7 @@ EventSandboxer.prototype.sandboxEvent = function(event) {
   });
 
   // map touch events to mouse events
-  if (event.type.substring(0, 5) === 'touch') {
+  if (event.type && event.type.substring(0, 5) === 'touch') {
     switch (event.type) {
       case 'touchmove':
         newEvent.type = 'mousemove';

--- a/apps/src/applab/commands.js
+++ b/apps/src/applab/commands.js
@@ -1532,6 +1532,20 @@ applabCommands.onEvent = function(opts) {
           opts.eventName,
           applabCommands.onEventFired.bind(this, opts)
         );
+
+        // Touch events will be mapped to mouse events in the EventSandboxer
+        if (opts.eventName === 'mousedown') {
+          domElement.addEventListener(
+            'touchstart',
+            applabCommands.onEventFired.bind(this, opts)
+          );
+        }
+        if (opts.eventName === 'mouseup') {
+          domElement.addEventListener(
+            'touchend',
+            applabCommands.onEventFired.bind(this, opts)
+          );
+        }
         // To allow INPUT type="range" (Slider) events to work on downlevel browsers, we need to
         // register a 'change' listener whenever an 'input' listner is requested.  Downlevel
         // browsers typically only sent 'change' events.
@@ -1549,6 +1563,11 @@ applabCommands.onEvent = function(opts) {
       case 'mousemove':
         domElement.addEventListener(
           opts.eventName,
+          applabCommands.onEventFired.bind(this, opts)
+        );
+        // Touch events will be mapped to mouse events in the EventSandboxer
+        domElement.addEventListener(
+          'touchmove',
           applabCommands.onEventFired.bind(this, opts)
         );
         // Additional handler needed to ensure correct calculation of


### PR DESCRIPTION
Currently, AppLab only allows students to add event handlers for MouseEvents and not for TouchEvents. This is an intentional decision as we want students to be able to write one set of code that works on both their desktop (with the browser's MouseEvents) and their phone (with the browser's TouchEvents). To support this "one set of code" however, we need to create an AppLab MouseEvent any time a browser TouchEvent is triggered. This PR adds this support.

### Background 
Apps such as https://studio.code.org/projects/applab/CFIGLWODxUoc7U5qWL09VA/view rely on the `mousemove` event to draw on the canvas. 

On a touchscreen, a "click-and-draw" action would trigger the following events
`touchstart`
`touchmove` x multiple
`touchend`

When using a mouse, a "click-and-draw" action would trigger the following events
`mousedown`
`mousemove` x multiple
`mouseup`

Conversely, click support already exists because a "click" action on a touch screen fires all the events that a mouse "click" action would fire.
On a touchscreen, a "click" action triggers the following events
`touchstart`
`touchmove` x zero or more
`touchend`
`mousemove`
`mousedown`
`mouseup`
`click`

When using a mouse, a "click" action triggers the following events
`mousedown`
`mouseup`
`click`

Documentation: https://developer.mozilla.org/en-US/docs/Web/API/Touch_events/Supporting_both_TouchEvent_and_MouseEvent
<!--
  Your description goes here: A summary of the change, including any relevant motivation and context.

  If relevant, include a description both of the existing behavior and of the new behavior.
-->

<!--
  Other aspects to consider. uncomment and add detail for any that seem necessary:
-->

<!-- ### Background -->
<!-- ### Privacy -->
<!-- ### Security -->
<!-- ### Caching -->
<!-- ### Deployment strategy -->
<!-- ### Future work -->

## Testing story
Tested on Android, and Surface Book (laptop with touch screen)

<!--
  Does your change include appropriate tests?

  If so, please describe how the tests included in this PR are sufficient

  If not, please explain why this change does not need to be tested.
-->

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
