### PR TITLE
raise error if the sync out is run without a sync in

### DIFF
--- a/bin/i18n/sync-out.rb
+++ b/bin/i18n/sync-out.rb
@@ -68,6 +68,15 @@ end
 def restore_redacted_files
   total_locales = Languages.get_locale.count
   original_files = Dir.glob("i18n/locales/original/**/*.*").to_a
+  if original_files.empty?
+    raise <<~ERR
+      No original files found from which to restore.
+
+      Originals are created by running the sync-in, but are not persisted in
+      git; this likely happened because a sync-out was attempted without a
+      corresponding sync-in.
+    ERR
+  end
   Languages.get_locale.each_with_index do |prop, locale_index|
     locale = prop[:locale_s]
     next if locale == 'en-US'


### PR DESCRIPTION
Otherwise, the sync out will silently skip the restoration process and we'll end up with a bunch of unwanted redacted translations.

<!-- ### Background -->
<!-- ### Privacy -->
<!-- ### Security -->
<!-- ### Caching -->
<!-- ### Deployment strategy -->
<!-- ### Future work -->

## Links

<!--
  Any relevant links to external resources; ie, specification documents, jira
  items, related PRs, honeybadger errors, etc
-->

- [spec]()
- [jira]()

## Testing story

<!--
  Does your change include appropriate tests?

  If so, please describe how the tests included in this PR are sufficient

  If not, please explain why this change does not need to be tested.
-->

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
