### PR TITLE
Update ISTE discount text in mail templates

### DIFF
--- a/dashboard/app/views/pd/workshop_mailer/_iste.html.haml
+++ b/dashboard/app/views/pd/workshop_mailer/_iste.html.haml
@@ -6,7 +6,7 @@
   practice.
 
 %p
-  We’re excited to offer ISTE membership and a gift exclusively to Code.org teachers at
-  the special price of $99. ISTE provides virtual on-demand professional learning,
-  in-person events and a vibrant online community of educators around the world.
+  We’re excited to offer a $10 discount on first-time ISTE membership. ISTE provides
+  virtual on-demand professional learning, in-person events and a vibrant online community
+  of educators around the world.
   =link_to 'Join today!', 'https://www.iste.org/membership/code-org'


### PR DESCRIPTION
Updates mail template copy. (Requested and spec'd over email by Megan H.)

For many years now, we have been able to offer a first-time ISTE membership discount to teachers that attend out workshops. ([Example in mailer preview](https://test-studio.code.org/rails/mailers/pd/workshop_mailer/exit_survey__csf_intro)) The value of the discount has recently changed, so we need to update the following mailers:

  * CSF Intro:  https://test-studio.code.org/rails/mailers/pd/workshop_mailer/exit_survey__csf_intro
  * CSD 1:  https://test-studio.code.org/rails/mailers/pd/workshop_mailer/exit_survey__csd_1
  * CSP 1:  https://test-studio.code.org/rails/mailers/pd/workshop_mailer/exit_survey__csp_1
  * CSP Summer:  https://test-studio.code.org/rails/mailers/pd/workshop_mailer/exit_survey__csp_summer_workshop
  * Exit Survey General:  https://test-studio.code.org/rails/mailers/pd/workshop_mailer/exit_survey__general

Before (removed copy in bold):

> We’re excited to offer **ISTE membership and a gift exclusively to Code.org teachers at the special price of $99.** ISTE provides virtual on-demand professional learning, in-person events and a vibrant online community of educators around the world. Join today!

After:

> We’re excited to offer **a $10 discount on first-time ISTE membership.** ISTE provides virtual on-demand professional learning, in-person events and a vibrant online community of educators around the world. Join today!

## Testing story

Checked with mailer previews locally.

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
