### PR TITLE
Add -b flag to rerun for dashboard-server [ci skip]

### DIFF
--- a/bin/dashboard-server
+++ b/bin/dashboard-server
@@ -4,7 +4,7 @@ require_relative '../deployment'
 def main
   dirs = [deploy_dir('lib'), deploy_dir('shared/middleware')]
   dirs += [pegasus_dir] if CDO.dashboard_enable_pegasus
-  rerun = "rerun -p '**/*.{rb,ru,yml}' -d '#{dirs.join(',')}' -i '**/migrations/*.rb' -i 'test/**/*.rb' --"
+  rerun = "rerun -b -p '**/*.{rb,ru,yml}' -d '#{dirs.join(',')}' -i '**/migrations/*.rb' -i 'test/**/*.rb' --"
   pids = []
 
   unless CDO.use_my_apps

--- a/bin/dashboard-server
+++ b/bin/dashboard-server
@@ -1,10 +1,12 @@
 #!/usr/bin/env ruby
 require_relative '../deployment'
 
+# Any arguments to bin/dashboard-server will get passed through to the rerun command, for example -b to run in background,
+# which allows for pry debugging.
 def main
   dirs = [deploy_dir('lib'), deploy_dir('shared/middleware')]
   dirs += [pegasus_dir] if CDO.dashboard_enable_pegasus
-  rerun = "rerun -b -p '**/*.{rb,ru,yml}' -d '#{dirs.join(',')}' -i '**/migrations/*.rb' -i 'test/**/*.rb' --"
+  rerun = "rerun -p '**/*.{rb,ru,yml}' -d '#{dirs.join(',')}' -i '**/migrations/*.rb' -i 'test/**/*.rb' #{ARGV.join(' ')} --"
   pids = []
 
   unless CDO.use_my_apps


### PR DESCRIPTION
This change allows me to use `pry` when running `dashboard-server`, otherwise the keystrokes get intercepted by `rerun`. See: https://github.com/alexch/rerun/issues/88

<!-- ### Background -->
<!-- ### Privacy -->
<!-- ### Security -->
<!-- ### Caching -->
<!-- ### Deployment strategy -->
<!-- ### Future work -->

## Testing story

Was able to use pry with dashboard-server after this change.

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
