### PR TITLE
Chart sizing fixes

### DIFF
--- a/apps/src/storage/dataBrowser/dataVisualizer/DataVisualizer.jsx
+++ b/apps/src/storage/dataBrowser/dataVisualizer/DataVisualizer.jsx
@@ -32,6 +32,7 @@ class DataVisualizer extends React.Component {
     } else {
       return (
         <GoogleChartWrapper
+          style={{height: '100%'}}
           records={this.props.records}
           numericColumns={this.props.numericColumns}
           chartType={this.props.chartType}

--- a/apps/src/storage/dataBrowser/dataVisualizer/GoogleChartWrapper.jsx
+++ b/apps/src/storage/dataBrowser/dataVisualizer/GoogleChartWrapper.jsx
@@ -95,7 +95,11 @@ class GoogleChartWrapper extends React.Component {
 
   render() {
     return (
-      <div id={GOOGLE_CHART_AREA} ref={element => (this.chartArea = element)} />
+      <div
+        id={GOOGLE_CHART_AREA}
+        ref={element => (this.chartArea = element)}
+        style={{height: '100%'}}
+      />
     );
   }
 }

--- a/apps/src/storage/dataBrowser/dataVisualizer/GoogleChartWrapper.jsx
+++ b/apps/src/storage/dataBrowser/dataVisualizer/GoogleChartWrapper.jsx
@@ -26,11 +26,18 @@ class GoogleChartWrapper extends React.Component {
 
   componentDidMount() {
     this.updateChart();
+    window.addEventListener('resize', this.debouncedUpdate);
   }
 
   componentDidUpdate() {
     this.updateChart();
   }
+
+  componentWillUnmount() {
+    window.removeEventListener('resize', this.debouncedUpdate);
+  }
+
+  debouncedUpdate = _.debounce(() => this.updateChart(), 50);
 
   updateChart() {
     if (!this.chartArea) {

--- a/apps/src/storage/dataBrowser/dataVisualizer/GoogleChartWrapper.jsx
+++ b/apps/src/storage/dataBrowser/dataVisualizer/GoogleChartWrapper.jsx
@@ -7,6 +7,7 @@ import GoogleChart from '@cdo/apps/applab/GoogleChart';
 
 class GoogleChartWrapper extends React.Component {
   static propTypes = {
+    style: PropTypes.object,
     records: PropTypes.array.isRequired,
     numericColumns: PropTypes.arrayOf(PropTypes.string).isRequired,
     chartType: PropTypes.number.isRequired,
@@ -98,7 +99,7 @@ class GoogleChartWrapper extends React.Component {
       <div
         id={GOOGLE_CHART_AREA}
         ref={element => (this.chartArea = element)}
-        style={{height: '100%'}}
+        style={this.props.style}
       />
     );
   }

--- a/apps/src/storage/dataBrowser/dataVisualizer/VisualizerModal.jsx
+++ b/apps/src/storage/dataBrowser/dataVisualizer/VisualizerModal.jsx
@@ -13,6 +13,7 @@ import BaseDialog from '@cdo/apps/templates/BaseDialog.jsx';
 import DropdownField from './DropdownField';
 import DataVisualizer from './DataVisualizer';
 import Snapshot from './Snapshot';
+import placeholderImage from './placeholder.png';
 
 const styles = {
   container: {
@@ -35,7 +36,11 @@ const styles = {
   },
   placeholderContainer: {
     position: 'relative',
-    textAlign: 'center'
+    height: '100%',
+    textAlign: 'center',
+    backgroundImage: `url('${placeholderImage}')`,
+    backgroundRepeat: 'no-repeat',
+    backgroundPosition: 'center'
   },
   placeholderText: {
     position: 'absolute',
@@ -66,8 +71,6 @@ class VisualizerModal extends React.Component {
     tableName: PropTypes.string.isRequired,
     tableRecords: PropTypes.array.isRequired
   };
-
-  placeholder = require('./placeholder.png');
 
   state = {...INITIAL_STATE};
 
@@ -331,7 +334,6 @@ class VisualizerModal extends React.Component {
                   <div style={styles.placeholderText}>
                     {msg.dataVisualizerPlaceholderText()}
                   </div>
-                  <img src={this.placeholder} />
                 </div>
               )}
             </div>

--- a/apps/src/storage/dataBrowser/dataVisualizer/VisualizerModal.jsx
+++ b/apps/src/storage/dataBrowser/dataVisualizer/VisualizerModal.jsx
@@ -32,7 +32,8 @@ const styles = {
     float: 'left'
   },
   chartArea: {
-    flexGrow: 1
+    flexGrow: 1,
+    overflow: 'hidden'
   },
   placeholderContainer: {
     position: 'relative',

--- a/apps/src/storage/dataBrowser/dataVisualizer/VisualizerModal.jsx
+++ b/apps/src/storage/dataBrowser/dataVisualizer/VisualizerModal.jsx
@@ -19,12 +19,19 @@ const styles = {
     display: 'inline-block'
   },
   modalBody: {
-    overflow: 'auto',
-    maxHeight: '90%'
+    display: 'flex',
+    flexDirection: 'column',
+    height: '100%'
+  },
+  h2: {
+    margin: '0 0 10px 0'
   },
   input: {
     ...rowStyle.container,
     float: 'left'
+  },
+  chartArea: {
+    flexGrow: 1
   },
   placeholderContainer: {
     position: 'relative',
@@ -221,11 +228,9 @@ class VisualizerModal extends React.Component {
           fullWidth
           fullHeight
         >
-          <div
-            style={{display: 'flex', flexDirection: 'column', height: '100%'}}
-          >
+          <div style={styles.modalBody}>
             <div>
-              <h2 style={{margin: '0 0 10px 0'}}>
+              <h2 style={styles.h2}>
                 {' '}
                 {msg.exploreDataset({
                   datasetName: this.props.tableName
@@ -310,7 +315,7 @@ class VisualizerModal extends React.Component {
               )}
             </div>
 
-            <div style={{flexGrow: 1}}>
+            <div style={styles.chartArea}>
               {this.canDisplayChart() ? (
                 <DataVisualizer
                   records={filteredRecords}

--- a/apps/src/storage/dataBrowser/dataVisualizer/VisualizerModal.jsx
+++ b/apps/src/storage/dataBrowser/dataVisualizer/VisualizerModal.jsx
@@ -221,137 +221,150 @@ class VisualizerModal extends React.Component {
           fullWidth
           fullHeight
         >
-          <div style={styles.modalBody}>
-            <h2> {msg.exploreDataset({datasetName: this.props.tableName})} </h2>
-
+          <div
+            style={{display: 'flex', flexDirection: 'column', height: '100%'}}
+          >
             <div>
-              <div style={styles.input}>
-                <label style={rowStyle.description}>
-                  {msg.dataVisualizerChartTitle()}
-                </label>
-                <DebounceInput
-                  style={rowStyle.input}
-                  minLength={1}
-                  debounceTimeout={500}
-                  value={this.state.chartTitle}
-                  onChange={event =>
-                    this.setState({chartTitle: event.target.value})
-                  }
-                />
+              <h2 style={{margin: '0 0 10px 0'}}>
+                {' '}
+                {msg.exploreDataset({
+                  datasetName: this.props.tableName
+                })}{' '}
+              </h2>
+
+              <div>
+                <div style={styles.input}>
+                  <label style={rowStyle.description}>
+                    {msg.dataVisualizerChartTitle()}
+                  </label>
+                  <DebounceInput
+                    style={rowStyle.input}
+                    minLength={1}
+                    debounceTimeout={500}
+                    value={this.state.chartTitle}
+                    onChange={event =>
+                      this.setState({chartTitle: event.target.value})
+                    }
+                  />
+                </div>
               </div>
-            </div>
 
-            <DropdownField
-              displayName={msg.dataVisualizerChartType()}
-              options={[
-                ChartType.BAR_CHART,
-                ChartType.HISTOGRAM,
-                ChartType.SCATTER_PLOT,
-                ChartType.CROSS_TAB
-              ]}
-              getDisplayNameForOption={this.getDisplayNameForChartType}
-              value={this.state.chartType}
-              onChange={event =>
-                this.setState({
-                  chartType: parseFloat(event.target.value),
-                  selectedColumn1: '',
-                  selectedColumn2: ''
-                })
-              }
-            />
-
-            {this.state.chartType === ChartType.HISTOGRAM && (
-              <div style={styles.input}>
-                <label style={rowStyle.description}>
-                  {msg.dataVisualizerBucketSize()}
-                </label>
-                <input
-                  style={rowStyle.input}
-                  value={this.state.bucketSize}
-                  onChange={event =>
-                    this.setState({bucketSize: event.target.value})
-                  }
-                />
-              </div>
-            )}
-
-            <DropdownField
-              displayName={
-                isMultiColumnChart
-                  ? msg.dataVisualizerXValues()
-                  : msg.dataVisualizerValues()
-              }
-              options={this.props.tableColumns}
-              disabledOptions={disabledOptions}
-              value={this.state.selectedColumn1}
-              onChange={event =>
-                this.setState({selectedColumn1: event.target.value})
-              }
-            />
-
-            {isMultiColumnChart && (
               <DropdownField
-                displayName={msg.dataVisualizerYValues()}
-                options={this.props.tableColumns}
-                disabledOptions={disabledOptions}
-                value={this.state.selectedColumn2}
+                displayName={msg.dataVisualizerChartType()}
+                options={[
+                  ChartType.BAR_CHART,
+                  ChartType.HISTOGRAM,
+                  ChartType.SCATTER_PLOT,
+                  ChartType.CROSS_TAB
+                ]}
+                getDisplayNameForOption={this.getDisplayNameForChartType}
+                value={this.state.chartType}
                 onChange={event =>
-                  this.setState({selectedColumn2: event.target.value})
+                  this.setState({
+                    chartType: parseFloat(event.target.value),
+                    selectedColumn1: '',
+                    selectedColumn2: ''
+                  })
                 }
               />
-            )}
-          </div>
-          {this.canDisplayChart() ? (
-            <DataVisualizer
-              records={filteredRecords}
-              numericColumns={numericColumns}
-              chartType={this.state.chartType}
-              bucketSize={this.state.bucketSize}
-              chartTitle={this.state.chartTitle}
-              selectedColumn1={this.state.selectedColumn1}
-              selectedColumn2={this.state.selectedColumn2}
-            />
-          ) : (
-            <div style={styles.placeholderContainer}>
-              <div style={styles.placeholderText}>
-                {msg.dataVisualizerPlaceholderText()}
-              </div>
-              <img src={this.placeholder} />
-            </div>
-          )}
-          <div style={{paddingTop: 20}}>
-            <DropdownField
-              displayName={msg.filter()}
-              options={this.props.tableColumns}
-              disabledOptions={[]}
-              value={this.state.filterColumn}
-              onChange={event =>
-                this.setState({
-                  filterColumn: event.target.value,
-                  filterValue: ''
-                })
-              }
-              inlineLabel
-            />
-            <DropdownField
-              displayName={msg.by()}
-              options={this.getValuesForFilterColumn(
-                parsedRecords,
-                this.state.filterColumn
+
+              {this.state.chartType === ChartType.HISTOGRAM && (
+                <div style={styles.input}>
+                  <label style={rowStyle.description}>
+                    {msg.dataVisualizerBucketSize()}
+                  </label>
+                  <input
+                    style={rowStyle.input}
+                    value={this.state.bucketSize}
+                    onChange={event =>
+                      this.setState({bucketSize: event.target.value})
+                    }
+                  />
+                </div>
               )}
-              disabledOptions={[]}
-              value={this.state.filterValue}
-              onChange={event =>
-                this.setState({filterValue: event.target.value})
-              }
-              inlineLabel
+
+              <DropdownField
+                displayName={
+                  isMultiColumnChart
+                    ? msg.dataVisualizerXValues()
+                    : msg.dataVisualizerValues()
+                }
+                options={this.props.tableColumns}
+                disabledOptions={disabledOptions}
+                value={this.state.selectedColumn1}
+                onChange={event =>
+                  this.setState({selectedColumn1: event.target.value})
+                }
+              />
+
+              {isMultiColumnChart && (
+                <DropdownField
+                  displayName={msg.dataVisualizerYValues()}
+                  options={this.props.tableColumns}
+                  disabledOptions={disabledOptions}
+                  value={this.state.selectedColumn2}
+                  onChange={event =>
+                    this.setState({selectedColumn2: event.target.value})
+                  }
+                />
+              )}
+            </div>
+
+            <div style={{flexGrow: 1}}>
+              {this.canDisplayChart() ? (
+                <DataVisualizer
+                  records={filteredRecords}
+                  numericColumns={numericColumns}
+                  chartType={this.state.chartType}
+                  bucketSize={this.state.bucketSize}
+                  chartTitle={this.state.chartTitle}
+                  selectedColumn1={this.state.selectedColumn1}
+                  selectedColumn2={this.state.selectedColumn2}
+                />
+              ) : (
+                <div style={styles.placeholderContainer}>
+                  <div style={styles.placeholderText}>
+                    {msg.dataVisualizerPlaceholderText()}
+                  </div>
+                  <img src={this.placeholder} />
+                </div>
+              )}
+            </div>
+
+            <div style={{paddingTop: 20}}>
+              <DropdownField
+                displayName={msg.filter()}
+                options={this.props.tableColumns}
+                disabledOptions={[]}
+                value={this.state.filterColumn}
+                onChange={event =>
+                  this.setState({
+                    filterColumn: event.target.value,
+                    filterValue: ''
+                  })
+                }
+                inlineLabel
+              />
+              <DropdownField
+                displayName={msg.by()}
+                options={this.getValuesForFilterColumn(
+                  parsedRecords,
+                  this.state.filterColumn
+                )}
+                disabledOptions={[]}
+                value={this.state.filterValue}
+                onChange={event =>
+                  this.setState({filterValue: event.target.value})
+                }
+                inlineLabel
+              />
+            </div>
+            <Snapshot
+              chartType={this.state.chartType}
+              chartTitle={this.state.chartTitle}
+              selectedOptions={this.chartOptionsToString(this.state.chartType)}
             />
           </div>
-          <Snapshot
-            chartType={this.state.chartType}
-            chartTitle={this.state.chartTitle}
-            selectedOptions={this.chartOptionsToString(this.state.chartType)}
-          />
         </BaseDialog>
       </span>
     );

--- a/apps/src/templates/BaseDialog.jsx
+++ b/apps/src/templates/BaseDialog.jsx
@@ -87,6 +87,10 @@ export default class BaseDialog extends React.Component {
         ...bodyStyle,
         height: '80%'
       };
+      modalBodyStyle = {
+        ...modalBodyStyle,
+        boxSizing: 'border-box'
+      };
     }
 
     let wrapperClassNames = '';


### PR DESCRIPTION
Working from [this doc](https://docs.google.com/document/d/15Ij6AucowZSq1ESMY0pYjlts4m8Bn5s8rQExaBJy_jY/edit?usp=sharing): Makes Google Charts utilize maximum possible space in the visualizer dialog, and resize appropriately when the dialog and window are resized.

![Peek 2020-04-16 15-30](https://user-images.githubusercontent.com/1615761/79513397-93697380-7ff8-11ea-9d06-30f3d12d1e84.gif)

## Testing story

Checked locally in Chrome - probably worth testing this in other browsers too.

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
