### PR TITLE
Height resizer: work with touch & fix drift

### DIFF
--- a/apps/src/templates/instructions/HeightResizer.jsx
+++ b/apps/src/templates/instructions/HeightResizer.jsx
@@ -86,7 +86,9 @@ class HeightResizer extends React.Component {
     }
 
     event.stopPropagation();
-    event.preventDefault();
+    if (event.cancelable) {
+      event.preventDefault();
+    }
 
     const pageY = event.pageY || (event.touches && event.touches[0].pageY);
     this.setState({dragging: true, dragStart: pageY});
@@ -94,14 +96,18 @@ class HeightResizer extends React.Component {
 
   onMouseUp = event => {
     event.stopPropagation();
-    event.preventDefault();
+    if (event.cancelable) {
+      event.preventDefault();
+    }
 
     this.setState({dragging: false});
   };
 
   onMouseMove = event => {
     event.stopPropagation();
-    event.preventDefault();
+    if (event.cancelable) {
+      event.preventDefault();
+    }
 
     if (!this.state.dragging) {
       return;

--- a/apps/src/templates/instructions/HeightResizer.jsx
+++ b/apps/src/templates/instructions/HeightResizer.jsx
@@ -8,8 +8,16 @@ import PropTypes from 'prop-types';
 import Radium from 'radium';
 import color from '../../util/color';
 import styleConstants from '../../styleConstants';
+import {getTouchEventName} from '../../dom';
 
 const RESIZER_HEIGHT = styleConstants['resize-bar-width'];
+
+const MOUSE_DOWN_EVENT_NAME = 'mousedown';
+const MOUSE_DOWN_TOUCH_EVENT_NAME = getTouchEventName(MOUSE_DOWN_EVENT_NAME);
+const MOUSE_UP_EVENT_NAME = 'mouseup';
+const MOUSE_UP_TOUCH_EVENT_NAME = getTouchEventName(MOUSE_UP_EVENT_NAME);
+const MOUSE_MOVE_EVENT_NAME = 'mousemove';
+const MOUSE_MOVE_TOUCH_EVENT_NAME = getTouchEventName(MOUSE_MOVE_EVENT_NAME);
 
 const styles = {
   main: {
@@ -50,33 +58,55 @@ class HeightResizer extends React.Component {
   };
 
   componentDidMount() {
-    this.resizerRef.addEventListener('mousedown', this.onMouseDown);
-    this.resizerRef.addEventListener('mouseup', this.onMouseUp);
-    this.resizerRef.addEventListener('mousemove', this.onMouseMove);
-    this.resizerRef.addEventListener('touchstart', this.onMouseDown);
-    this.resizerRef.addEventListener('touchend', this.onMouseUp);
-    this.resizerRef.addEventListener('touchmove', this.onMouseMove);
+    this.resizerRef.addEventListener(MOUSE_DOWN_EVENT_NAME, this.onMouseDown);
+    this.resizerRef.addEventListener(MOUSE_UP_EVENT_NAME, this.onMouseUp);
+    this.resizerRef.addEventListener(MOUSE_MOVE_EVENT_NAME, this.onMouseMove);
+    this.resizerRef.addEventListener(
+      MOUSE_DOWN_TOUCH_EVENT_NAME,
+      this.onMouseDown
+    );
+    this.resizerRef.addEventListener(MOUSE_UP_TOUCH_EVENT_NAME, this.onMouseUp);
+    this.resizerRef.addEventListener(
+      MOUSE_MOVE_TOUCH_EVENT_NAME,
+      this.onMouseMove
+    );
   }
 
   componentWillUnmount() {
-    this.resizerRef.removeEventListener('mousedown', this.onMouseDown);
-    this.resizerRef.removeEventListener('mouseup', this.onMouseUp);
-    this.resizerRef.removeEventListener('mousemove', this.onMouseMove);
-    this.resizerRef.removeEventListener('touchstart', this.onMouseDown);
-    this.resizerRef.removeEventListener('touchend', this.onMouseUp);
-    this.resizerRef.removeEventListener('touchmove', this.onMouseMove);
+    this.resizerRef.removeEventListener(
+      MOUSE_DOWN_EVENT_NAME,
+      this.onMouseDown
+    );
+    this.resizerRef.removeEventListener(MOUSE_UP_EVENT_NAME, this.onMouseUp);
+    this.resizerRef.removeEventListener(
+      MOUSE_MOVE_EVENT_NAME,
+      this.onMouseMove
+    );
+    this.resizerRef.removeEventListener(
+      MOUSE_DOWN_TOUCH_EVENT_NAME,
+      this.onMouseDown
+    );
+    this.resizerRef.removeEventListener(
+      MOUSE_UP_TOUCH_EVENT_NAME,
+      this.onMouseUp
+    );
+    this.resizerRef.removeEventListener(
+      MOUSE_MOVE_TOUCH_EVENT_NAME,
+      this.onMouseMove
+    );
   }
 
   componentDidUpdate(_, prevState) {
     // Update listeners as dragging state changes.
+    // These appear to be necessary for mouse, but not for touch.
     if (!prevState.dragging && this.state.dragging) {
       // Add document listeners when drag starts.
-      document.addEventListener('mousemove', this.onMouseMove);
-      document.addEventListener('mouseup', this.onMouseUp);
+      document.addEventListener(MOUSE_MOVE_EVENT_NAME, this.onMouseMove);
+      document.addEventListener(MOUSE_UP_EVENT_NAME, this.onMouseUp);
     } else if (prevState.dragging && !this.state.dragging) {
       // Remove document listeners when drag ends.
-      document.removeEventListener('mousemove', this.onMouseMove);
-      document.removeEventListener('mouseup', this.onMouseUp);
+      document.removeEventListener(MOUSE_MOVE_EVENT_NAME, this.onMouseMove);
+      document.removeEventListener(MOUSE_UP_EVENT_NAME, this.onMouseUp);
     }
   }
 

--- a/apps/src/templates/instructions/HeightResizer.jsx
+++ b/apps/src/templates/instructions/HeightResizer.jsx
@@ -47,24 +47,12 @@ class HeightResizer extends React.Component {
   };
 
   componentDidMount() {
-    this.resizerRef.addEventListener('mousedown', this.onMouseDown, {
-      passive: false
-    });
-    this.resizerRef.addEventListener('mouseup', this.onMouseUp, {
-      passive: false
-    });
-    this.resizerRef.addEventListener('mousemove', this.onMouseMove, {
-      passive: false
-    });
-    this.resizerRef.addEventListener('touchstart', this.onMouseDown, {
-      passive: false
-    });
-    this.resizerRef.addEventListener('touchend', this.onMouseUp, {
-      passive: false
-    });
-    this.resizerRef.addEventListener('touchmove', this.onMouseMove, {
-      passive: false
-    });
+    this.resizerRef.addEventListener('mousedown', this.onMouseDown);
+    this.resizerRef.addEventListener('mouseup', this.onMouseUp);
+    this.resizerRef.addEventListener('mousemove', this.onMouseMove);
+    this.resizerRef.addEventListener('touchstart', this.onMouseDown);
+    this.resizerRef.addEventListener('touchend', this.onMouseUp);
+    this.resizerRef.addEventListener('touchmove', this.onMouseMove);
   }
 
   componentWillUnmount() {
@@ -76,14 +64,14 @@ class HeightResizer extends React.Component {
     this.resizerRef.removeEventListener('touchmove', this.onMouseMove);
   }
 
-  componentDidUpdate(_, state) {
-    // Update listeners as dragging state changes
-    if (this.state.dragging && !state.dragging) {
-      document.addEventListener('mousemove', this.onMouseMove, {
-        passive: false
-      });
-      document.addEventListener('mouseup', this.onMouseUp, {passive: false});
-    } else if (!this.state.dragging && state.dragging) {
+  componentDidUpdate(_, prevState) {
+    // Update listeners as dragging state changes.
+    if (!prevState.dragging && this.state.dragging) {
+      // Add document listeners when drag starts.
+      document.addEventListener('mousemove', this.onMouseMove);
+      document.addEventListener('mouseup', this.onMouseUp);
+    } else if (prevState.dragging && !this.state.dragging) {
+      // Remove document listeners when drag ends.
       document.removeEventListener('mousemove', this.onMouseMove);
       document.removeEventListener('mouseup', this.onMouseUp);
     }

--- a/apps/src/templates/instructions/HeightResizer.jsx
+++ b/apps/src/templates/instructions/HeightResizer.jsx
@@ -32,10 +32,13 @@ const styles = {
 
 class HeightResizer extends React.Component {
   static propTypes = {
+    /**
+     * @returns {number} top - the top Y value of the element we are resizing
+     */
+    resizeItemTop: PropTypes.func.isRequired,
     position: PropTypes.number.isRequired,
     /**
-     * @param {number} delta - amount we're trying to resize by
-     * @returns {number} delta - amount we've actually resized
+     * @param {number} desiredHeight - the height we'd like to resize to
      */
     onResize: PropTypes.func.isRequired,
     style: PropTypes.object
@@ -104,12 +107,9 @@ class HeightResizer extends React.Component {
     }
 
     const pageY = event.pageY || (event.touches && event.touches[0].pageY);
-    const delta = pageY - this.state.dragStart;
+    const desiredHeight = pageY - this.props.resizeItemTop();
 
-    // onResize can choose to limit how much we actually move, and will report
-    // back the value
-    const actualDelta = this.props.onResize(delta);
-    this.setState({dragStart: this.state.dragStart + actualDelta});
+    this.props.onResize(desiredHeight);
   };
 
   render() {

--- a/apps/src/templates/instructions/HeightResizer.jsx
+++ b/apps/src/templates/instructions/HeightResizer.jsx
@@ -46,11 +46,43 @@ class HeightResizer extends React.Component {
     dragStart: 0
   };
 
+  componentDidMount() {
+    this.resizerRef.addEventListener('mousedown', this.onMouseDown, {
+      passive: false
+    });
+    this.resizerRef.addEventListener('mouseup', this.onMouseUp, {
+      passive: false
+    });
+    this.resizerRef.addEventListener('mousemove', this.onMouseMove, {
+      passive: false
+    });
+    this.resizerRef.addEventListener('touchstart', this.onMouseDown, {
+      passive: false
+    });
+    this.resizerRef.addEventListener('touchend', this.onMouseUp, {
+      passive: false
+    });
+    this.resizerRef.addEventListener('touchmove', this.onMouseMove, {
+      passive: false
+    });
+  }
+
+  componentWillUnmount() {
+    this.resizerRef.removeEventListener('mousedown', this.onMouseDown);
+    this.resizerRef.removeEventListener('mouseup', this.onMouseUp);
+    this.resizerRef.removeEventListener('mousemove', this.onMouseDown);
+    this.resizerRef.removeEventListener('touchstart', this.onMouseMove);
+    this.resizerRef.removeEventListener('touchend', this.onMouseUp);
+    this.resizerRef.removeEventListener('touchmove', this.onMouseMove);
+  }
+
   componentDidUpdate(_, state) {
     // Update listeners as dragging state changes
     if (this.state.dragging && !state.dragging) {
-      document.addEventListener('mousemove', this.onMouseMove);
-      document.addEventListener('mouseup', this.onMouseUp);
+      document.addEventListener('mousemove', this.onMouseMove, {
+        passive: false
+      });
+      document.addEventListener('mouseup', this.onMouseUp, {passive: false});
     } else if (!this.state.dragging && state.dragging) {
       document.removeEventListener('mousemove', this.onMouseMove);
       document.removeEventListener('mouseup', this.onMouseUp);
@@ -58,13 +90,14 @@ class HeightResizer extends React.Component {
   }
 
   onMouseDown = event => {
-    if (event.button !== 0) {
+    if (event.button && event.button !== 0) {
       return;
     }
     event.stopPropagation();
     event.preventDefault();
 
-    this.setState({dragging: true, dragStart: event.pageY});
+    const pageY = event.pageY || (event.touches && event.touches[0].pageY);
+    this.setState({dragging: true, dragStart: pageY});
   };
 
   onMouseUp = event => {
@@ -82,7 +115,8 @@ class HeightResizer extends React.Component {
       return;
     }
 
-    const delta = event.pageY - this.state.dragStart;
+    const pageY = event.pageY || (event.touches && event.touches[0].pageY);
+    const delta = pageY - this.state.dragStart;
 
     // onResize can choose to limit how much we actually move, and will report
     // back the value
@@ -103,9 +137,7 @@ class HeightResizer extends React.Component {
       <div
         id="ui-test-resizer"
         style={mainStyle}
-        onMouseDown={this.onMouseDown}
-        onMouseUp={this.onMouseUp}
-        onMouseMove={this.onMouseMove}
+        ref={ref => (this.resizerRef = ref)}
       >
         <div style={styles.ellipsis} className="fa fa-ellipsis-h" />
       </div>

--- a/apps/src/templates/instructions/HeightResizer.jsx
+++ b/apps/src/templates/instructions/HeightResizer.jsx
@@ -70,8 +70,8 @@ class HeightResizer extends React.Component {
   componentWillUnmount() {
     this.resizerRef.removeEventListener('mousedown', this.onMouseDown);
     this.resizerRef.removeEventListener('mouseup', this.onMouseUp);
-    this.resizerRef.removeEventListener('mousemove', this.onMouseDown);
-    this.resizerRef.removeEventListener('touchstart', this.onMouseMove);
+    this.resizerRef.removeEventListener('mousemove', this.onMouseMove);
+    this.resizerRef.removeEventListener('touchstart', this.onMouseDown);
     this.resizerRef.removeEventListener('touchend', this.onMouseUp);
     this.resizerRef.removeEventListener('touchmove', this.onMouseMove);
   }

--- a/apps/src/templates/instructions/HeightResizer.jsx
+++ b/apps/src/templates/instructions/HeightResizer.jsx
@@ -8,16 +8,8 @@ import PropTypes from 'prop-types';
 import Radium from 'radium';
 import color from '../../util/color';
 import styleConstants from '../../styleConstants';
-import {getTouchEventName} from '../../dom';
 
 const RESIZER_HEIGHT = styleConstants['resize-bar-width'];
-
-const MOUSE_DOWN_EVENT_NAME = 'mousedown';
-const MOUSE_DOWN_TOUCH_EVENT_NAME = getTouchEventName(MOUSE_DOWN_EVENT_NAME);
-const MOUSE_UP_EVENT_NAME = 'mouseup';
-const MOUSE_UP_TOUCH_EVENT_NAME = getTouchEventName(MOUSE_UP_EVENT_NAME);
-const MOUSE_MOVE_EVENT_NAME = 'mousemove';
-const MOUSE_MOVE_TOUCH_EVENT_NAME = getTouchEventName(MOUSE_MOVE_EVENT_NAME);
 
 const styles = {
   main: {
@@ -58,55 +50,33 @@ class HeightResizer extends React.Component {
   };
 
   componentDidMount() {
-    this.resizerRef.addEventListener(MOUSE_DOWN_EVENT_NAME, this.onMouseDown);
-    this.resizerRef.addEventListener(MOUSE_UP_EVENT_NAME, this.onMouseUp);
-    this.resizerRef.addEventListener(MOUSE_MOVE_EVENT_NAME, this.onMouseMove);
-    this.resizerRef.addEventListener(
-      MOUSE_DOWN_TOUCH_EVENT_NAME,
-      this.onMouseDown
-    );
-    this.resizerRef.addEventListener(MOUSE_UP_TOUCH_EVENT_NAME, this.onMouseUp);
-    this.resizerRef.addEventListener(
-      MOUSE_MOVE_TOUCH_EVENT_NAME,
-      this.onMouseMove
-    );
+    this.resizerRef.addEventListener('mousedown', this.onMouseDown);
+    this.resizerRef.addEventListener('mouseup', this.onMouseUp);
+    this.resizerRef.addEventListener('mousemove', this.onMouseMove);
+    this.resizerRef.addEventListener('touchstart', this.onMouseDown);
+    this.resizerRef.addEventListener('touchend', this.onMouseUp);
+    this.resizerRef.addEventListener('touchmove', this.onMouseMove);
   }
 
   componentWillUnmount() {
-    this.resizerRef.removeEventListener(
-      MOUSE_DOWN_EVENT_NAME,
-      this.onMouseDown
-    );
-    this.resizerRef.removeEventListener(MOUSE_UP_EVENT_NAME, this.onMouseUp);
-    this.resizerRef.removeEventListener(
-      MOUSE_MOVE_EVENT_NAME,
-      this.onMouseMove
-    );
-    this.resizerRef.removeEventListener(
-      MOUSE_DOWN_TOUCH_EVENT_NAME,
-      this.onMouseDown
-    );
-    this.resizerRef.removeEventListener(
-      MOUSE_UP_TOUCH_EVENT_NAME,
-      this.onMouseUp
-    );
-    this.resizerRef.removeEventListener(
-      MOUSE_MOVE_TOUCH_EVENT_NAME,
-      this.onMouseMove
-    );
+    this.resizerRef.removeEventListener('mousedown', this.onMouseDown);
+    this.resizerRef.removeEventListener('mouseup', this.onMouseUp);
+    this.resizerRef.removeEventListener('mousemove', this.onMouseMove);
+    this.resizerRef.removeEventListener('touchstart', this.onMouseDown);
+    this.resizerRef.removeEventListener('touchend', this.onMouseUp);
+    this.resizerRef.removeEventListener('touchmove', this.onMouseMove);
   }
 
   componentDidUpdate(_, prevState) {
     // Update listeners as dragging state changes.
-    // These appear to be necessary for mouse, but not for touch.
     if (!prevState.dragging && this.state.dragging) {
       // Add document listeners when drag starts.
-      document.addEventListener(MOUSE_MOVE_EVENT_NAME, this.onMouseMove);
-      document.addEventListener(MOUSE_UP_EVENT_NAME, this.onMouseUp);
+      document.addEventListener('mousemove', this.onMouseMove);
+      document.addEventListener('mouseup', this.onMouseUp);
     } else if (prevState.dragging && !this.state.dragging) {
       // Remove document listeners when drag ends.
-      document.removeEventListener(MOUSE_MOVE_EVENT_NAME, this.onMouseMove);
-      document.removeEventListener(MOUSE_UP_EVENT_NAME, this.onMouseUp);
+      document.removeEventListener('mousemove', this.onMouseMove);
+      document.removeEventListener('mouseup', this.onMouseUp);
     }
   }
 

--- a/apps/src/templates/instructions/HeightResizer.jsx
+++ b/apps/src/templates/instructions/HeightResizer.jsx
@@ -84,6 +84,7 @@ class HeightResizer extends React.Component {
     if (event.button && event.button !== 0) {
       return;
     }
+
     event.stopPropagation();
     event.preventDefault();
 

--- a/apps/src/templates/instructions/TopInstructions.jsx
+++ b/apps/src/templates/instructions/TopInstructions.jsx
@@ -326,19 +326,23 @@ class TopInstructions extends Component {
   };
 
   /**
-   * Given a prospective delta, determines how much we can actually change the
-   * height (accounting for min/max) and changes height by that much.
-   * @param {number} delta
-   * @returns {number} How much we actually changed
+   * Returns the top Y coordinate of the instructions that are being resized
+   * via a call to handleHeightResize from HeightResizer.
    */
-  handleHeightResize = delta => {
-    const currentHeight = this.props.height;
+  getItemTop = () => {
+    return this.refs.topInstructions.getBoundingClientRect().top;
+  };
 
-    let newHeight = Math.max(MIN_HEIGHT, currentHeight + delta);
+  /**
+   * Given a desired height, determines how much we can actually change the
+   * height (account for min/max) and changes the height to that.
+   * @param {number} desired height
+   */
+  handleHeightResize = desiredHeight => {
+    let newHeight = Math.max(MIN_HEIGHT, desiredHeight);
     newHeight = Math.min(newHeight, this.props.maxHeight);
 
     this.props.setInstructionsRenderedHeight(newHeight);
-    return newHeight - currentHeight;
   };
 
   /**
@@ -585,7 +589,7 @@ class TopInstructions extends Component {
       $('#containedLevelAnswer0').length > 0;
 
     return (
-      <div style={mainStyle} className="editor-column">
+      <div style={mainStyle} className="editor-column" ref="topInstructions">
         <PaneHeader
           hasFocus={false}
           teacherOnly={teacherOnly}
@@ -777,6 +781,7 @@ class TopInstructions extends Component {
           </div>
           {!this.props.isEmbedView && (
             <HeightResizer
+              resizeItemTop={this.getItemTop}
               position={this.props.height}
               onResize={this.handleHeightResize}
             />

--- a/apps/test/unit/templates/instructions/HeightResizerTest.jsx
+++ b/apps/test/unit/templates/instructions/HeightResizerTest.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import {mount} from 'enzyme';
 import sinon from 'sinon';
-import {expect} from '../../../util/reconfiguredChai';
+import {expect} from '../../../util/deprecatedChai';
 import HeightResizer from '@cdo/apps/templates/instructions/HeightResizer';
 
 describe('HeightResizer', () => {

--- a/apps/test/unit/templates/instructions/HeightResizerTest.jsx
+++ b/apps/test/unit/templates/instructions/HeightResizerTest.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import {mount} from 'enzyme';
 import sinon from 'sinon';
-import {expect} from '../../../util/deprecatedChai';
+import {expect} from '../../../util/reconfiguredChai';
 import HeightResizer from '@cdo/apps/templates/instructions/HeightResizer';
 
 describe('HeightResizer', () => {

--- a/apps/test/unit/templates/instructions/HeightResizerTest.jsx
+++ b/apps/test/unit/templates/instructions/HeightResizerTest.jsx
@@ -6,9 +6,14 @@ import HeightResizer from '@cdo/apps/templates/instructions/HeightResizer';
 
 describe('HeightResizer', () => {
   it('handles a drag event', () => {
-    const onResizeCallback = sinon.stub().returnsArg(0);
+    const resizeItemTopCallback = sinon.stub().returns(5);
+    const onResizeCallback = sinon.stub();
     const wrapper = mount(
-      <HeightResizer position={0} onResize={onResizeCallback} />
+      <HeightResizer
+        resizeItemTop={resizeItemTopCallback}
+        position={0}
+        onResize={onResizeCallback}
+      />
     );
 
     // Simulate mouseDown
@@ -16,8 +21,9 @@ describe('HeightResizer', () => {
       button: 0,
       pageY: 20
     });
-    wrapper.simulate('mouseDown', mouseDownEvent);
+    wrapper.instance().onMouseDown(mouseDownEvent);
 
+    expect(resizeItemTopCallback).not.to.have.been.called;
     expect(onResizeCallback).not.to.have.been.called;
     expect(mouseDownEvent.stopPropagation).to.have.been.called;
     expect(mouseDownEvent.preventDefault).to.have.been.called;
@@ -26,9 +32,10 @@ describe('HeightResizer', () => {
     const mouseMoveEvent = mouseEvent({
       pageY: 30
     });
-    wrapper.simulate('mouseMove', mouseMoveEvent);
+    wrapper.instance().onMouseMove(mouseMoveEvent);
 
-    expect(onResizeCallback).to.have.been.calledOnce.and.calledWith(10);
+    expect(resizeItemTopCallback).to.have.been.calledOnce;
+    expect(onResizeCallback).to.have.been.calledOnce.and.calledWith(25);
     expect(mouseMoveEvent.stopPropagation).to.have.been.called;
     expect(mouseMoveEvent.preventDefault).to.have.been.called;
 
@@ -37,15 +44,22 @@ describe('HeightResizer', () => {
       button: 0,
       pageY: 40
     });
-    wrapper.simulate('mouseUp', mouseUpEvent);
+    wrapper.instance().onMouseUp(mouseUpEvent);
 
+    expect(resizeItemTopCallback).to.have.been.calledOnce;
     expect(onResizeCallback).to.have.been.calledOnce;
     expect(mouseUpEvent.stopPropagation).to.have.been.called;
     expect(mouseUpEvent.preventDefault).to.have.been.called;
   });
 
   it('ignores secondary mouse buttons', () => {
-    const wrapper = mount(<HeightResizer position={0} onResize={() => {}} />);
+    const wrapper = mount(
+      <HeightResizer
+        resizeItemTop={() => {}}
+        position={0}
+        onResize={() => {}}
+      />
+    );
     sinon.spy(wrapper.instance(), 'setState');
 
     // Simulate mouseDown with non-primary mouse button
@@ -53,7 +67,7 @@ describe('HeightResizer', () => {
       button: 1,
       pageY: 20
     });
-    wrapper.simulate('mouseDown', mouseDownEvent);
+    wrapper.instance().onMouseDown(mouseDownEvent);
 
     expect(wrapper.instance().setState).not.to.have.been.called;
     expect(mouseDownEvent.stopPropagation).not.to.have.been.called;
@@ -61,17 +75,23 @@ describe('HeightResizer', () => {
   });
 
   it('ignores mouseMove events if not dragging', () => {
-    const onResizeCallback = sinon.stub().returnsArg(0);
+    const resizeItemTopCallback = sinon.stub().returns(10);
+    const onResizeCallback = sinon.stub();
     const wrapper = mount(
-      <HeightResizer position={0} onResize={onResizeCallback} />
+      <HeightResizer
+        resizeItemTop={resizeItemTopCallback}
+        position={0}
+        onResize={onResizeCallback}
+      />
     );
     sinon.spy(wrapper.instance(), 'setState');
 
     const mouseMoveEvent = mouseEvent({
       pageY: 30
     });
-    wrapper.simulate('mouseMove', mouseMoveEvent);
+    wrapper.instance().onMouseMove(mouseMoveEvent);
 
+    expect(resizeItemTopCallback).not.to.have.been.called;
     expect(onResizeCallback).not.to.have.been.called;
     expect(wrapper.instance().setState).not.to.have.been.called;
     expect(mouseMoveEvent.stopPropagation).to.have.been.called;

--- a/apps/test/unit/templates/instructions/HeightResizerTest.jsx
+++ b/apps/test/unit/templates/instructions/HeightResizerTest.jsx
@@ -19,7 +19,8 @@ describe('HeightResizer', () => {
     // Simulate mouseDown
     const mouseDownEvent = mouseEvent({
       button: 0,
-      pageY: 20
+      pageY: 20,
+      cancelable: true
     });
     wrapper.instance().onMouseDown(mouseDownEvent);
 
@@ -30,7 +31,8 @@ describe('HeightResizer', () => {
 
     // Simulate mouseMove
     const mouseMoveEvent = mouseEvent({
-      pageY: 30
+      pageY: 30,
+      cancelable: true
     });
     wrapper.instance().onMouseMove(mouseMoveEvent);
 
@@ -42,7 +44,8 @@ describe('HeightResizer', () => {
     // Simulate mouseUp
     const mouseUpEvent = mouseEvent({
       button: 0,
-      pageY: 40
+      pageY: 40,
+      cancelable: true
     });
     wrapper.instance().onMouseUp(mouseUpEvent);
 
@@ -65,7 +68,8 @@ describe('HeightResizer', () => {
     // Simulate mouseDown with non-primary mouse button
     const mouseDownEvent = mouseEvent({
       button: 1,
-      pageY: 20
+      pageY: 20,
+      cancelable: true
     });
     wrapper.instance().onMouseDown(mouseDownEvent);
 
@@ -87,7 +91,8 @@ describe('HeightResizer', () => {
     sinon.spy(wrapper.instance(), 'setState');
 
     const mouseMoveEvent = mouseEvent({
-      pageY: 30
+      pageY: 30,
+      cancelable: true
     });
     wrapper.instance().onMouseMove(mouseMoveEvent);
 


### PR DESCRIPTION
# touch

The height resizer, which allows the user to drag a horizontal bar down and up to show more or less of the instructions, was never touch enabled.  Now it is.

![Screenshot 2020-04-10 21 20 43](https://user-images.githubusercontent.com/2205926/79035245-743e9200-7b71-11ea-93dc-86621242cce5.png)

# drift 

This also fixes a long-standing issues with the resizer.  The resizer used to lose tracking to the pointer once the user dragged it past its minimum or maximum size.  I rewrote this code to instead rely on the absolute position of the pointer each update, and now the resizer tracks the pointer at all times.

### before

![vertical_resize_before](https://user-images.githubusercontent.com/2205926/79399077-32c63200-7f37-11ea-9a48-656410a71e26.gif)

### after

![vertical_resize_after](https://user-images.githubusercontent.com/2205926/79399086-38bc1300-7f37-11ea-92c6-38c73d0e854c.gif)

