### PR TITLE
Homepage: Code Break Promo, fix overlap on very narrow screens 

### DIFF
--- a/pegasus/sites.v3/code.org/views/homepage_hero.haml
+++ b/pegasus/sites.v3/code.org/views/homepage_hero.haml
@@ -119,9 +119,9 @@
 
   - elsif show_single_hero == "codebreak2020"
     :css
-      @media screen and (max-width: 512px) {
+      @media screen and (max-width: 400px) {
         #special-guest-stars {
-          padding-top: 60px;
+          padding-top: 60px !important;
         }
       }
 


### PR DESCRIPTION
On very narrow screens, such as Galaxy S5, the stars overlapped the tape because special casing css was not being applied. Now it is. 

BEFORE 
<img width="350" alt="Screen Shot 2020-04-13 at 12 04 49 PM" src="https://user-images.githubusercontent.com/12300669/79151686-bb9a6d80-7d7f-11ea-9c5c-e209cd204f03.png">

AFTER
<img width="488" alt="Screen Shot 2020-04-13 at 12 03 04 PM" src="https://user-images.githubusercontent.com/12300669/79151694-bf2df480-7d7f-11ea-9ec1-11b2aaf31232.png">