### PR TITLE
render FreeResponse content side-by-side

### DIFF
--- a/apps/Gruntfile.js
+++ b/apps/Gruntfile.js
@@ -553,6 +553,8 @@ describe('entry tests', () => {
     'levels/_external': './src/sites/studio/pages/levels/_external.js',
     'levels/_external_link':
       './src/sites/studio/pages/levels/_external_link.js',
+    'levels/_free_response':
+      './src/sites/studio/pages/levels/_free_response.js',
     'levels/_level_group': './src/sites/studio/pages/levels/_level_group.js',
     'levels/_match': './src/sites/studio/pages/levels/_match.js',
     'levels/_multi': './src/sites/studio/pages/levels/_multi.js',

--- a/apps/package.json
+++ b/apps/package.json
@@ -244,6 +244,7 @@
     "react-portal": "^3.2.0",
     "react-router-dom": "^4.3.1",
     "react-transition-group": "2.9.0",
+    "rehype-stringify": "^7.0.0",
     "rosie": "^2.0.1",
     "selectize": "^0.12.4",
     "snack-build": "0.0.1",

--- a/apps/src/sites/studio/pages/levels/_free_response.js
+++ b/apps/src/sites/studio/pages/levels/_free_response.js
@@ -1,19 +1,83 @@
 import $ from 'jquery';
-import React from 'react';
-import ReactDom from 'react-dom';
-import SafeMarkdown from '@cdo/apps/templates/SafeMarkdown';
+import Parser from '@code-dot-org/redactable-markdown';
+import defaultSanitizationSchema from 'hast-util-sanitize/lib/github.json';
+import firehoseClient from '@cdo/apps/lib/util/firehose';
+import rehypeParse from 'rehype-parse';
+import rehypeRaw from 'rehype-raw';
+import rehypeSanitize from 'rehype-sanitize';
+import rehypeStringify from 'rehype-stringify';
+import remarkRehype from 'remark-rehype';
 
+// In preparation for switching FreeResponse levels over to use the
+// SafeMarkdown renderer, compare clientside-rendered markdown against
+// serverside-rendered markdown. Disparities will be logged to firehose so
+// markdown can be updated to work on both renderers, and the eventual
+// switchover will be guaranteed to be seamless.
 $(document).ready(() => {
-  // Render Markdown
+  // schema and parsing logic is copied from SafeMarkdown; this test is
+  // intended to run for only a short while, so I'm being lazy and copying
+  // rather than rebuilding the sanitization schema to be importable.
+  const schema = Object.assign({}, defaultSanitizationSchema);
+  schema.attributes.img.push('height', 'width');
+  schema.tagNames.push('span');
+  schema.attributes.span = ['dataUrl', 'className'];
+  schema.attributes['*'].push('style', 'className');
+  schema.clobber = [];
+  const blocklyTags = [
+    'block',
+    'functional_input',
+    'mutation',
+    'next',
+    'statement',
+    'title',
+    'value',
+    'xml'
+  ];
+  schema.tagNames = schema.tagNames.concat(blocklyTags);
+  blocklyTags.forEach(tag => {
+    schema.attributes[tag] = ['block_text', 'id', 'inline', 'name', 'type'];
+  });
+
+  const markdownToHtml = Parser.create()
+    .getParser()
+    .use(remarkRehype, {
+      allowDangerousHTML: true
+    })
+    .use(rehypeRaw)
+    .use(rehypeSanitize, schema)
+    .use(rehypeStringify);
+
+  const htmlNormalize = Parser.create()
+    .getParser()
+    .use(rehypeParse, {fragment: true})
+    .use(rehypeStringify);
+
   $('.free-response > .markdown-container').each(function() {
     const container = this;
     if (!container.dataset.markdown) {
       return;
     }
 
-    ReactDom.render(
-      React.createElement(SafeMarkdown, container.dataset, null),
-      container
-    );
+    // render the markdown with remark
+    const clientside = markdownToHtml.processSync(container.dataset.markdown)
+      .contents;
+    // normalize the HTML, to prevent false positives
+    const serverside = htmlNormalize.processSync(
+      $('.free-response > .serverside-render').html()
+    ).contents;
+
+    // ignore whitespace, again to prevent false positives
+    if (clientside.replace(/\s/g, '') !== serverside.replace(/\s/g, '')) {
+      firehoseClient.putRecord({
+        study: 'FreeResponse-rendering',
+        study_group: '',
+        event: 'mismatch',
+        data_string: document.URL,
+        data_json: JSON.stringify({
+          serverside,
+          clientside
+        })
+      });
+    }
   });
 });

--- a/apps/src/sites/studio/pages/levels/_free_response.js
+++ b/apps/src/sites/studio/pages/levels/_free_response.js
@@ -63,7 +63,9 @@ $(document).ready(() => {
       .contents;
     // normalize the HTML, to prevent false positives
     const serverside = htmlNormalize.processSync(
-      $('.free-response > .serverside-render').html()
+      $(container)
+        .siblings('.serverside-render')
+        .html()
     ).contents;
 
     // ignore whitespace, again to prevent false positives

--- a/apps/src/sites/studio/pages/levels/_free_response.js
+++ b/apps/src/sites/studio/pages/levels/_free_response.js
@@ -1,0 +1,19 @@
+import $ from 'jquery';
+import React from 'react';
+import ReactDom from 'react-dom';
+import SafeMarkdown from '@cdo/apps/templates/SafeMarkdown';
+
+$(document).ready(() => {
+  // Render Markdown
+  $('.free-response > .markdown-container').each(function() {
+    const container = this;
+    if (!container.dataset.markdown) {
+      return;
+    }
+
+    ReactDom.render(
+      React.createElement(SafeMarkdown, container.dataset, null),
+      container
+    );
+  });
+});

--- a/apps/yarn.lock
+++ b/apps/yarn.lock
@@ -8209,6 +8209,22 @@ hast-util-to-html@^5.0.0:
     unist-util-is "^2.0.0"
     xtend "^4.0.1"
 
+hast-util-to-html@^7.0.0:
+  version "7.1.0"
+  resolved "https://registry.yarnpkg.com/hast-util-to-html/-/hast-util-to-html-7.1.0.tgz#aa580e7b846438ee1e7af2bee6a650062eb0c3ec"
+  integrity sha512-RjvNL41bYnxTOA+s8W8mjhVxH1J0dXza9hlakVHbghFsfj3JO/lsq3DsR/Md2HbynS8y89/LA7k0lhtnYJ1Yzw==
+  dependencies:
+    ccount "^1.0.0"
+    comma-separated-tokens "^1.0.0"
+    hast-util-is-element "^1.0.0"
+    hast-util-whitespace "^1.0.0"
+    html-void-elements "^1.0.0"
+    property-information "^5.0.0"
+    space-separated-tokens "^1.0.0"
+    stringify-entities "^3.0.0"
+    unist-util-is "^4.0.0"
+    xtend "^4.0.0"
+
 hast-util-to-parse5@^5.0.0:
   version "5.0.0"
   resolved "https://registry.yarnpkg.com/hast-util-to-parse5/-/hast-util-to-parse5-5.0.0.tgz#1041df0d57e60210bd3e4b97596397500223399a"
@@ -8986,6 +9002,11 @@ is-date-object@^1.0.1:
 is-decimal@^1.0.0:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/is-decimal/-/is-decimal-1.0.2.tgz#894662d6a8709d307f3a276ca4339c8fa5dff0ff"
+
+is-decimal@^1.0.2:
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/is-decimal/-/is-decimal-1.0.4.tgz#65a3a5958a1c5b63a706e1b333d7cd9f630d3fa5"
+  integrity sha512-RGdriMmQQvZ2aqaQq3awNA6dCGtKpiDFcOzrTWrDAT2MiWrKQVPmxLGHl7Y2nNu6led0kEyoX0enY0qXYsv9zw==
 
 is-descriptor@^0.1.0:
   version "0.1.6"
@@ -13658,6 +13679,14 @@ rehype-sanitize@^2.0.2:
   dependencies:
     hast-util-sanitize "^1.1.0"
 
+rehype-stringify@^7.0.0:
+  version "7.0.0"
+  resolved "https://registry.yarnpkg.com/rehype-stringify/-/rehype-stringify-7.0.0.tgz#abbb172b3a2784a5739394846f6092eefda0ae1f"
+  integrity sha512-u3dQI7mIWN2X1H0MBFPva425HbkXgB+M39C9SM5leUS2kh5hHUn2SxQs2c2yZN5eIHipoLMojC0NP5e8fptxvQ==
+  dependencies:
+    hast-util-to-html "^7.0.0"
+    xtend "^4.0.0"
+
 relateurl@0.2.x:
   version "0.2.7"
   resolved "https://registry.yarnpkg.com/relateurl/-/relateurl-0.2.7.tgz#54dbf377e51440aca90a4cd274600d3ff2d888a9"
@@ -15067,6 +15096,17 @@ stringify-entities@^1.0.1:
     is-alphanumerical "^1.0.0"
     is-hexadecimal "^1.0.0"
 
+stringify-entities@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/stringify-entities/-/stringify-entities-3.0.0.tgz#455abe501f8b7859ba5726a25a8872333c65b0a7"
+  integrity sha512-h7NJJIssprqlyjHT2eQt2W1F+MCcNmwPGlKb0bWEdET/3N44QN3QbUF/ueKCgAssyKRZ3Br9rQ7FcXjHr0qLHw==
+  dependencies:
+    character-entities-html4 "^1.0.0"
+    character-entities-legacy "^1.0.0"
+    is-alphanumerical "^1.0.0"
+    is-decimal "^1.0.2"
+    is-hexadecimal "^1.0.0"
+
 stringstream@~0.0.4, stringstream@~0.0.5:
   version "0.0.5"
   resolved "https://registry.yarnpkg.com/stringstream/-/stringstream-0.0.5.tgz#4e484cd4de5a0bbbee18e46307710a8a81621878"
@@ -15905,6 +15945,11 @@ unist-util-generated@^1.1.0:
 unist-util-is@^2.0.0, unist-util-is@^2.1.2:
   version "2.1.2"
   resolved "https://registry.yarnpkg.com/unist-util-is/-/unist-util-is-2.1.2.tgz#1193fa8f2bfbbb82150633f3a8d2eb9a1c1d55db"
+
+unist-util-is@^4.0.0:
+  version "4.0.2"
+  resolved "https://registry.yarnpkg.com/unist-util-is/-/unist-util-is-4.0.2.tgz#c7d1341188aa9ce5b3cff538958de9895f14a5de"
+  integrity sha512-Ofx8uf6haexJwI1gxWMGg6I/dLnF2yE+KibhD3/diOqY2TinLcqHXCV6OI5gFVn3xQqDH+u0M625pfKwIwgBKQ==
 
 unist-util-position@^3.0.0:
   version "3.0.1"

--- a/dashboard/app/views/levels/_free_response.html.haml
+++ b/dashboard/app/views/levels/_free_response.html.haml
@@ -1,3 +1,6 @@
+- content_for(:head) do
+  %script{src: webpack_asset_path('js/levels/_free_response.js')}
+
 - level ||= @level
 - last_attempt = @last_attempt unless local_assigns.has_key? :last_attempt
 - in_level_group ||= false
@@ -34,7 +37,8 @@
     %h1= title
   - long_instructions = level.get_property("long_instructions")
   - if long_instructions
-    %div= render(inline: long_instructions, type: :md)
+    / Markdown will be rendered clientside by _free_response.js
+    .markdown-container{data: {markdown: long_instructions}}
 
   - if level.allow_user_uploads?
     %script{src: webpack_asset_path('js/fileupload/jquery.iframe-transport.js')}

--- a/dashboard/app/views/levels/_free_response.html.haml
+++ b/dashboard/app/views/levels/_free_response.html.haml
@@ -37,8 +37,9 @@
     %h1= title
   - long_instructions = level.get_property("long_instructions")
   - if long_instructions
+    %div.serverside-render= render(inline: long_instructions, type: :md)
     / Markdown will be rendered clientside by _free_response.js
-    .markdown-container{data: {markdown: long_instructions}}
+    .markdown-container{data: {markdown: long_instructions}, style: 'display: none'}
 
   - if level.allow_user_uploads?
     %script{src: webpack_asset_path('js/fileupload/jquery.iframe-transport.js')}


### PR DESCRIPTION
a la https://github.com/code-dot-org/code-dot-org/pull/33865

Compare the results of rendering FreeResponse levels as we would if rendering with SafeMarkdown with the current rendering strategy, and log discrepancies to firehose for eventual cleanup.

<!-- ### Background -->
<!-- ### Privacy -->
<!-- ### Security -->
<!-- ### Caching -->
<!-- ### Deployment strategy -->
<!-- ### Future work -->

## Links

<!--
  Any relevant links to external resources; ie, specification documents, jira
  items, related PRs, honeybadger errors, etc
-->

- [jira](https://codedotorg.atlassian.net/browse/FND-1100)

## Testing story

<!--
  Does your change include appropriate tests?

  If so, please describe how the tests included in this PR are sufficient

  If not, please explain why this change does not need to be tested.
-->

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
