### PR TITLE
[Applab Data Tab] Fix Scrolling for Data Tables

### DIFF
--- a/apps/src/storage/dataBrowser/DataTable.jsx
+++ b/apps/src/storage/dataBrowser/DataTable.jsx
@@ -222,14 +222,16 @@ class DataTable extends React.Component {
     return (
       <div>
         <DataEntryError isVisible={this.state.showError} />
-        <div style={styles.pagination}>
-          <PaginationWrapper
-            totalPages={numPages}
-            currentPage={this.state.currentPage + 1}
-            onChangePage={this.onChangePageNumber}
-            label={msg.paginationLabel()}
-          />
-        </div>
+        {numPages > 1 && (
+          <div style={styles.pagination}>
+            <PaginationWrapper
+              totalPages={numPages}
+              currentPage={this.state.currentPage + 1}
+              onChangePage={this.onChangePageNumber}
+              label={msg.paginationLabel()}
+            />
+          </div>
+        )}
         <table style={styles.table}>
           <tbody>
             <tr>
@@ -297,6 +299,16 @@ class DataTable extends React.Component {
             ))}
           </tbody>
         </table>
+        {numPages > 1 && (
+          <div style={styles.pagination}>
+            <PaginationWrapper
+              totalPages={numPages}
+              currentPage={this.state.currentPage + 1}
+              onChangePage={this.onChangePageNumber}
+              label={msg.paginationLabel()}
+            />
+          </div>
+        )}
       </div>
     );
   }

--- a/apps/src/storage/dataBrowser/DataTableView.jsx
+++ b/apps/src/storage/dataBrowser/DataTableView.jsx
@@ -26,19 +26,15 @@ const styles = {
   ],
   container: {
     flexDirection: 'column',
-    height: '100%',
+    height: '99%',
     minWidth: MIN_TABLE_WIDTH,
-    maxWidth: '100%',
+    maxWidth: '99%',
     paddingLeft: experiments.isEnabled(experiments.APPLAB_DATASETS)
       ? '8px'
       : '0px'
   },
   table: {
     minWidth: MIN_TABLE_WIDTH
-  },
-  tableWrapper: {
-    flexGrow: 1,
-    overflow: 'scroll'
   },
   pagination: {
     float: 'right',
@@ -180,7 +176,11 @@ class DataTableView extends React.Component {
           readOnly={readOnly}
         />
         <div style={debugDataStyle}>{this.getTableJson()}</div>
-        {!this.state.showDebugView && <DataTable readOnly={readOnly} />}
+        {!this.state.showDebugView && (
+          <div style={{overflow: 'auto'}}>
+            <DataTable readOnly={readOnly} />
+          </div>
+        )}
       </div>
     );
   }


### PR DESCRIPTION
2 Small changes to scrolling UI for tables:
1. Scroll only the table, so that the buttons and table title are still visible
2. Only show the pagination controls if there's more than one page, and show it at both the top and bottom of the table.
Before:
Scroll hides table control buttons:
![image](https://user-images.githubusercontent.com/8787187/79167125-961b5d00-7d9b-11ea-8fec-03b0110269fc.png)
Pagination UI with only one page:
![image](https://user-images.githubusercontent.com/8787187/79167147-a6cbd300-7d9b-11ea-9478-fb800e85d44f.png)


After:
buttons/title still visible as you scroll:
![image](https://user-images.githubusercontent.com/8787187/79167140-a16e8880-7d9b-11ea-8e05-6cd6ec4c356d.png)
pagination ui hidden when there's only one page:
![image](https://user-images.githubusercontent.com/8787187/79167152-ab908700-7d9b-11ea-9399-25d930fdc1a4.png)
pagination ui with multiple pages:
![image](https://user-images.githubusercontent.com/8787187/79167168-b3502b80-7d9b-11ea-861e-2ecd97cd873d.png)
pagination ui at the bottom of the table:
![image](https://user-images.githubusercontent.com/8787187/79167179-b8ad7600-7d9b-11ea-99d6-77225027a6de.png)


<!--
  Other aspects to consider. uncomment and add detail for any that seem necessary:
-->

<!-- ### Background -->
<!-- ### Privacy -->
<!-- ### Security -->
<!-- ### Caching -->
<!-- ### Deployment strategy -->
<!-- ### Future work -->

## Links

<!--
  Any relevant links to external resources; ie, specification documents, jira
  items, related PRs, honeybadger errors, etc
-->

- [jira](https://codedotorg.atlassian.net/browse/STAR-966)

## Testing story

<!--
  Does your change include appropriate tests?

  If so, please describe how the tests included in this PR are sufficient

  If not, please explain why this change does not need to be tested.
-->

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
