### PR TITLE
Project Ideas for Home Learning Banner

### DIFF
--- a/apps/src/sites/studio/pages/projects/index.js
+++ b/apps/src/sites/studio/pages/projects/index.js
@@ -17,6 +17,7 @@ import deleteDialogReducer from '@cdo/apps/templates/projects/deleteDialog/delet
 
 $(document).ready(() => {
   const projectsData = getScriptData('projects');
+  const specialAnnouncement = projectsData.specialAnnouncement;
   registerReducers({
     projects,
     publishDialog: publishDialogReducer,
@@ -45,6 +46,7 @@ $(document).ready(() => {
         <ProjectHeader
           canViewAdvancedTools={projectsData.canViewAdvancedTools}
           projectCount={projectsData.projectCount}
+          specialAnnouncement={specialAnnouncement}
         />
         <ProjectsGallery
           limitedGallery={projectsData.limitedGallery}

--- a/apps/src/templates/projects/ProjectHeader.jsx
+++ b/apps/src/templates/projects/ProjectHeader.jsx
@@ -4,11 +4,13 @@ import React from 'react';
 import i18n from '@cdo/locale';
 import StartNewProject from '@cdo/apps/templates/projects/StartNewProject';
 import HeaderBanner from '@cdo/apps/templates/HeaderBanner';
+import {SpecialAnnouncementActionBlock} from '../studioHomepages/TwoColumnActionBlock';
 
 export default class ProjectHeader extends React.Component {
   static propTypes = {
     canViewAdvancedTools: PropTypes.bool,
-    projectCount: PropTypes.number
+    projectCount: PropTypes.number,
+    specialAnnouncement: PropTypes.object
   };
 
   render() {
@@ -23,6 +25,11 @@ export default class ProjectHeader extends React.Component {
             project_count: projectCountWithCommas
           })}
         />
+        {this.props.specialAnnouncement && (
+          <SpecialAnnouncementActionBlock
+            announcement={this.props.specialAnnouncement}
+          />
+        )}
         <StartNewProject
           canViewFullList
           canViewAdvancedTools={this.props.canViewAdvancedTools}

--- a/dashboard/app/views/projects/index.html.haml
+++ b/dashboard/app/views/projects/index.html.haml
@@ -10,6 +10,8 @@
     projects_data[:canShare] = !current_user.sharing_disabled?
   end
 
+  projects_data[:specialAnnouncement] = Announcements.get_announcement_for_page("/projects")
+
 %script{src: webpack_asset_path("js/#{js_locale}/common_locale.js")}
 %script{src: webpack_asset_path('js/projects/index.js'), data: {projects: projects_data.to_json}}
 

--- a/pegasus/sites.v3/code.org/announcements.json
+++ b/pegasus/sites.v3/code.org/announcements.json
@@ -1,7 +1,8 @@
 {
   "pages": {
     "/home": "teacher-apps-open-2020",
-    "/courses": "teacher-apps-open-2020"
+    "/courses": "teacher-apps-open-2020",
+    "/projects": "home-learning-2020"
   },
   "banners": {
     "teacher-apps-open-2020": {
@@ -27,6 +28,15 @@
       "buttonText": "Nominate a Teacher",
       "buttonUrl": "https://code.org/nominate",
       "buttonId": "teacher-apps-nominate-2020-button",
+      "backgroundColor": "#59b9dc"
+    },
+    "home-learning-2020": {
+      "image": "/images/athome/fill-970x562/app-lab.png",
+      "title": "Project Ideas for Home Learning",
+      "body": "Parents and teachers — take a look at our Project Ideas page for starter projects in Game Lab, App Lab, and Web Lab. These include project descriptions, tips, and demo projects students can remix to make their own! ",
+      "buttonText": "View Project Ideas",
+      "buttonUrl": "https://code.org/athome/project-ideas",
+      "buttonId": "view-project-ideas-2020-button",
       "backgroundColor": "#59b9dc"
     }
   }


### PR DESCRIPTION
[PLC-825](https://codedotorg.atlassian.net/browse/PLC-825)
Add Project Ideas for Home Learning banner to studio.code.org/projects/public. The banner is English-only and is configured via announcements.json, using the /projects key. If announcements.json has any issues or /projects is missing the banner will not show up.

![Screen Shot 2020-04-13 at 3 45 04 PM](https://user-images.githubusercontent.com/33666587/79168035-c5cb6480-7d9d-11ea-8706-70e477c294be.png)

## Links

- [jira](https://codedotorg.atlassian.net/browse/PLC-825)

## Testing story
Validated on multiple browsers and on signed in/signed out views that the banner works as expected.

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
