### PR TITLE
App Lab: Fix touch

### DIFF
--- a/apps/src/applab/EventSandboxer.js
+++ b/apps/src/applab/EventSandboxer.js
@@ -75,7 +75,9 @@ EventSandboxer.prototype.sandboxEvent = function(event) {
     );
   }
 
+  // Calculate and assign any relevant values here, and then return it at the end.
   var newEvent = {};
+
   // Pass these properties through to applabEvent:
   [
     'altKey',
@@ -112,6 +114,16 @@ EventSandboxer.prototype.sandboxEvent = function(event) {
   if (touchEvents[event.type]) {
     newEvent.type = touchEvents[event.type];
     mouseEvent = event.changedTouches[0];
+
+    // Calculate and assign values that can be missing when touch is used.
+    // We treat mouseEvent as read-only, so we will go ahead and write these
+    // to the desired destination: newEvent.
+    if (mouseEvent.x === undefined) {
+      newEvent.x = (mouseEvent.clientX - this.xOffset_) / this.xScale_;
+    }
+    if (mouseEvent.y === undefined) {
+      newEvent.y = (mouseEvent.clientY - this.yOffset_) / this.yScale_;
+    }
   } else {
     mouseEvent = event;
   }
@@ -128,14 +140,6 @@ EventSandboxer.prototype.sandboxEvent = function(event) {
       newEvent[prop] = (mouseEvent[prop] - this.yOffset_) / this.yScale_;
     }
   }, this);
-
-  // Add values that can be missing when touch is used.
-  if (mouseEvent.x === undefined) {
-    newEvent.x = (mouseEvent.pageX - this.xOffset_) / this.xScale_;
-  }
-  if (mouseEvent.y === undefined) {
-    newEvent.y = (mouseEvent.pageY - this.yOffset_) / this.yScale_;
-  }
 
   // Set movementX and movementY, computing it from clientX and clientY if necessary.
   // The element must have an element id for this to work.

--- a/apps/src/applab/EventSandboxer.js
+++ b/apps/src/applab/EventSandboxer.js
@@ -99,55 +99,60 @@ EventSandboxer.prototype.sandboxEvent = function(event) {
     }
   });
 
-  // map touch events to mouse events
-  if (event.type && event.type.substring(0, 5) === 'touch') {
-    switch (event.type) {
-      case 'touchmove':
-        newEvent.type = 'mousemove';
-        break;
-      case 'touchstart':
-        newEvent.type = 'mousedown';
-        break;
-      case 'touchend':
-        newEvent.type = 'mouseup';
-        break;
-    }
-    event.clientX = event.changedTouches[0].clientX;
-    event.clientY = event.changedTouches[0].clientY;
-    event.pageX = event.changedTouches[0].pageX;
-    event.pageY = event.changedTouches[0].pageY;
-    event.x = event.changedTouches[0].clientX;
-    event.y = event.changedTouches[0].clientY;
+  // This "mouse" event will come either from a normal input, or from the first
+  // of multiple touches.
+  let mouseEvent;
+
+  const touchEvents = {
+    touchstart: 'mousedown',
+    touchmove: 'mousemove',
+    touchend: 'mouseup'
+  };
+
+  if (touchEvents[event.type]) {
+    newEvent.type = touchEvents[event.type];
+    mouseEvent = event.changedTouches[0];
+  } else {
+    mouseEvent = event;
   }
 
   // Convert x coordinates and then pass through to applabEvent:
   ['clientX', 'pageX', 'x'].forEach(function(prop) {
-    if (typeof event[prop] !== 'undefined') {
-      newEvent[prop] = (event[prop] - this.xOffset_) / this.xScale_;
+    if (typeof mouseEvent[prop] !== 'undefined') {
+      newEvent[prop] = (mouseEvent[prop] - this.xOffset_) / this.xScale_;
     }
   }, this);
   // Convert y coordinates and then pass through to applabEvent:
   ['clientY', 'pageY', 'y'].forEach(function(prop) {
-    if (typeof event[prop] !== 'undefined') {
-      newEvent[prop] = (event[prop] - this.yOffset_) / this.yScale_;
+    if (typeof mouseEvent[prop] !== 'undefined') {
+      newEvent[prop] = (mouseEvent[prop] - this.yOffset_) / this.yScale_;
     }
   }, this);
+
+  // Add values that can be missing when touch is used.
+  if (mouseEvent.x === undefined) {
+    newEvent.x = (mouseEvent.pageX - this.xOffset_) / this.xScale_;
+  }
+  if (mouseEvent.y === undefined) {
+    newEvent.y = (mouseEvent.pageY - this.yOffset_) / this.yScale_;
+  }
+
   // Set movementX and movementY, computing it from clientX and clientY if necessary.
   // The element must have an element id for this to work.
   if (
-    typeof event.movementX !== 'undefined' &&
-    typeof event.movementY !== 'undefined'
+    typeof mouseEvent.movementX !== 'undefined' &&
+    typeof mouseEvent.movementY !== 'undefined'
   ) {
     // The browser supports movementX and movementY natively.
-    newEvent.movementX = event.movementX;
-    newEvent.movementY = event.movementY;
-  } else if (event.type === 'mousemove') {
+    newEvent.movementX = mouseEvent.movementX;
+    newEvent.movementY = mouseEvent.movementY;
+  } else if (newEvent.type === 'mousemove') {
     var currentTargetId = event.currentTarget && event.currentTarget.id;
     var lastEvent = this.lastMouseMoveEventMap_[currentTargetId];
     if (currentTargetId && lastEvent) {
       // Compute movementX and movementY from clientX and clientY.
-      newEvent.movementX = event.clientX - lastEvent.clientX;
-      newEvent.movementY = event.clientY - lastEvent.clientY;
+      newEvent.movementX = mouseEvent.clientX - lastEvent.clientX;
+      newEvent.movementY = mouseEvent.clientY - lastEvent.clientY;
     } else {
       // There has been no mousemove event on this element since the most recent
       // mouseout event, or this element does not have an element id.
@@ -155,7 +160,7 @@ EventSandboxer.prototype.sandboxEvent = function(event) {
       newEvent.movementY = 0;
     }
     if (currentTargetId) {
-      this.lastMouseMoveEventMap_[currentTargetId] = event;
+      this.lastMouseMoveEventMap_[currentTargetId] = mouseEvent;
     }
   }
   // Replace DOM elements with IDs and then add them to applabEvent:


### PR DESCRIPTION
This is a followup to https://github.com/code-dot-org/code-dot-org/pull/34164 to get it working on iOS devices.  From some very rudimentary print-to-screen debugging, it appeared that [modifying a read-only property of a Touch event](https://github.com/code-dot-org/code-dot-org/pull/34164/files#diff-62379d80b2be88365b79e987c324d831R117) was triggering an exception on iOS devices and no further code was executed.

In this fix, I refactor the code a bit to treat the event as immutable.

To test, I built an App Lab app which supports both drawing (using a mouse or touch) and a button click:

```
hide();
penColor("green");
penWidth(5);
penUp();

onEvent("button1", "click", function(event) {
  penColor("red");
  textLabel("label1", "clicked");
});

onEvent("screen1", "mousemove", function(event) {
  moveTo(event.x, event.y);
});
onEvent("screen1", "mousedown", function(event) {
  moveTo(event.x, event.y);
  penDown();
});
onEvent("screen1", "mouseup", function(event) {
  penUp();
});
```

It appears to operate successfully both in the App Lab editor and as a shared page, on both desktop and iOS device.

I did come across a couple other existing issues that are not addressed here:

- If the share view is scrolled down, the ink is drawn above the cursor/touch point because we don't appear to compensate for the page's scroll offset.
- While drawing on an iOS device, it also causes the page to scroll a bit.  I attempted to call `preventDefault` for [touch events](https://github.com/code-dot-org/code-dot-org/pull/34215/files#diff-62379d80b2be88365b79e987c324d831R112-R114), and while it prevented scrolling, it also prevented the app's button's click event from firing.  I also looked into adding an `overflow: hidden` to the page's [`<html>`](https://github.com/code-dot-org/code-dot-org/blob/534e0d378d70b2f8e3ab12444983a64066e0c1e2/dashboard/app/views/layouts/application.html.haml#L2) element, and while it also prevented any page movement from occuring, I don't think we can make an assumption that the user doesn't want to scroll since the share view doesn't appear to shrink the page's content to fit the user's vertical screen space, at least on my desktop browser.
