### PR TITLE
Removing parent_email link when a Student becomes a Teacher

### DIFF
--- a/apps/i18n/common/en_us.json
+++ b/apps/i18n/common/en_us.json
@@ -233,7 +233,7 @@
   "changeUserTypeModal_emailOptIn_description": "Can we email you about updates to our courses, local opportunities, or other computer science news?",
   "changeUserTypeModal_emailOptIn_isRequired": "This field is required.",
   "changeUserTypeModal_emailOptIn_privacyPolicy": "(See our privacy policy)",
-  "changeUserTypeModal_description_toTeacher": "You must provide the following information before we can convert your account into a teacher account.",
+  "changeUserTypeModal_description_toTeacher": "You must provide the following information before we can convert your account into a teacher account.  Once you convert to a teacher account, any parent/guardian email address currently linked to your account will be removed.",
   "changeUserTypeModal_save_teacher": "Update to teacher account",
   "changeUserTypeModal_title": "Update account type",
   "changeUserTypeModal_unexpectedError": "An unexpected error has occurred.  Please wait a moment and try again.",

--- a/dashboard/app/models/user.rb
+++ b/dashboard/app/models/user.rb
@@ -938,6 +938,8 @@ class User < ActiveRecord::Base
 
     hashed_email = User.hash_email(email)
     self.user_type = TYPE_TEACHER
+    # teachers do not need another adult to have access to their account.
+    self.parent_email = nil
 
     new_attributes = email_preference.nil? ? {} : email_preference
 

--- a/dashboard/test/models/user_test.rb
+++ b/dashboard/test/models/user_test.rb
@@ -2206,6 +2206,15 @@ class UserTest < ActiveSupport::TestCase
     assert_equal '0', email_preference.form_kind
   end
 
+  test 'upgrade_to_teacher given valid params should delete parent_email field' do
+    parent_email = 'parent@email.com'
+    user = User.create(@good_data.merge(parent_email: parent_email))
+    assert_equal parent_email, user.parent_email
+    assert user.upgrade_to_teacher('example@email.com', email_preference_params)
+    user.reload
+    assert_nil user.parent_email
+  end
+
   def assert_parent_email_params_equals_email_preference(parent_email_params, email_preference)
     assert_equal parent_email_params[:parent_email_preference_email], email_preference.email
     assert_equal parent_email_params[:parent_email_preference_opt_in].casecmp?('yes'), email_preference.opt_in


### PR DESCRIPTION
When a 'student' account upgrades to a 'teacher' account, a parent_email
associated with the account should not be able to take it over or get
email updates. To accomplish this, we will delete the parent_email
associated with the user.
* Change `upgrade_to_teacher` method to delete the `parent_email` field
* Add text to the modal indicating the parent email will be unlinked from the account.

## Links
- [jira](https://codedotorg.atlassian.net/browse/FND-1103)

## Testing story
* Manually tested on localhost by creating a student account with an associated parent_email and then upgraded to a teacher account using the Manage account page. Then I checked ./bin/dashboard-console to verify `parent_email` is nil.
* Unit test added.

## Screenshots
![image](https://user-images.githubusercontent.com/1372238/79193162-978b6a80-7e19-11ea-8a70-efa7572e06a5.png)

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
