### PR TITLE
[Applab Datasets]fix escaping of table names on levelbuilder

### DIFF
--- a/apps/src/storage/levelbuilder/DatasetList.jsx
+++ b/apps/src/storage/levelbuilder/DatasetList.jsx
@@ -21,8 +21,8 @@ class DatasetList extends React.Component {
         <h1>Datasets</h1>
         <ul>
           {this.props.datasets.map(dataset => (
-            <li key={decodeURIComponent(dataset)}>
-              <a href={`/datasets/${dataset}`}>{decodeURIComponent(dataset)}</a>
+            <li key={dataset}>
+              <a href={`/datasets/${dataset}`}>{dataset}</a>
               {this.props.liveDatasets.includes(dataset) && (
                 <span> (Live) </span>
               )}

--- a/apps/src/storage/levelbuilder/DatasetList.jsx
+++ b/apps/src/storage/levelbuilder/DatasetList.jsx
@@ -21,8 +21,8 @@ class DatasetList extends React.Component {
         <h1>Datasets</h1>
         <ul>
           {this.props.datasets.map(dataset => (
-            <li key={dataset}>
-              <a href={`/datasets/${dataset}`}>{dataset}</a>
+            <li key={decodeURIComponent(dataset)}>
+              <a href={`/datasets/${dataset}`}>{decodeURIComponent(dataset)}</a>
               {this.props.liveDatasets.includes(dataset) && (
                 <span> (Live) </span>
               )}

--- a/dashboard/app/controllers/datasets_controller.rb
+++ b/dashboard/app/controllers/datasets_controller.rb
@@ -18,15 +18,15 @@ class DatasetsController < ApplicationController
   # GET /datasets/:dataset_name/
   def show
     @table_name = params[:dataset_name]
-    @dataset = @firebase.get_shared_table URI.escape(params[:dataset_name])
+    @dataset = @firebase.get_shared_table params[:dataset_name]
     @live_datasets = LIVE_DATASETS
   end
 
   # POST /datasets/:dataset_name/
   def update
     records, columns = @firebase.csv_as_table(params[:csv_data])
-    @firebase.delete_shared_table URI.escape(params[:dataset_name])
-    response = @firebase.upload_shared_table(URI.escape(params[:dataset_name]), records, columns)
+    @firebase.delete_shared_table params[:dataset_name]
+    response = @firebase.upload_shared_table(params[:dataset_name], records, columns)
     data = {}
     if response.success?
       data[:records] = records

--- a/shared/middleware/helpers/firebase_helper.rb
+++ b/shared/middleware/helpers/firebase_helper.rb
@@ -85,10 +85,11 @@ class FirebaseHelper
   end
 
   def get_shared_table(table_name)
-    columns_response = @firebase.get("/v3/channels/shared/metadata/tables/#{table_name}/columns")
+    escaped_table_name = URI.escape(table_name)
+    columns_response = @firebase.get("/v3/channels/shared/metadata/tables/#{escaped_table_name}/columns")
     columns = columns_response.body ? columns_response.body.map {|_, value| value['columnName']} : []
 
-    records_response = @firebase.get("/v3/channels/shared/storage/tables/#{table_name}/records")
+    records_response = @firebase.get("/v3/channels/shared/storage/tables/#{escaped_table_name}/records")
     records = records_response.body || []
 
     {columns: columns, records: records}


### PR DESCRIPTION
We were escaping the table name in both `datasets_controller` and `firebase_helper`, ending up with spaces double-escaped, so the actual table name in Firebase would be something like `"Anjali%20Test"`
Fixed so that `firebase_helper` fully owns escaping the table name before uploading to firebase.
Before:
![image](https://user-images.githubusercontent.com/8787187/79254870-3e7ffe80-7e3a-11ea-928d-3badd2f78501.png)

After:
![image](https://user-images.githubusercontent.com/8787187/79254816-26a87a80-7e3a-11ea-8092-f0564b02eb57.png)


<!--
  Other aspects to consider. uncomment and add detail for any that seem necessary:
-->

<!-- ### Background -->
<!-- ### Privacy -->
<!-- ### Security -->
<!-- ### Caching -->
<!-- ### Deployment strategy -->
<!-- ### Future work -->


## Testing story

<!--
  Does your change include appropriate tests?

  If so, please describe how the tests included in this PR are sufficient

  If not, please explain why this change does not need to be tested.
-->

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
