### PR TITLE
Add position to lesson group

### DIFF
--- a/dashboard/app/models/lesson_group.rb
+++ b/dashboard/app/models/lesson_group.rb
@@ -8,6 +8,7 @@
 #  user_facing :boolean          default(TRUE), not null
 #  created_at  :datetime         not null
 #  updated_at  :datetime         not null
+#  position    :integer
 #
 # Indexes
 #

--- a/dashboard/db/migrate/20200414185601_add_position_to_lesson_group.rb
+++ b/dashboard/db/migrate/20200414185601_add_position_to_lesson_group.rb
@@ -1,0 +1,5 @@
+class AddPositionToLessonGroup < ActiveRecord::Migration[5.0]
+  def change
+    add_column :lesson_groups, :position, :integer
+  end
+end

--- a/dashboard/db/schema.rb
+++ b/dashboard/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20200410205642) do
+ActiveRecord::Schema.define(version: 20200414185601) do
 
   create_table "activities", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci" do |t|
     t.integer  "user_id"
@@ -515,6 +515,7 @@ ActiveRecord::Schema.define(version: 20200410205642) do
     t.boolean  "user_facing", default: true, null: false
     t.datetime "created_at",                 null: false
     t.datetime "updated_at",                 null: false
+    t.integer  "position"
     t.index ["script_id"], name: "index_lesson_groups_on_script_id", using: :btree
   end
 


### PR DESCRIPTION
Adds the position column to Lesson Group. This will be used to order Lesson Groups in a script.

![Screen Shot 2020-04-14 at 3 10 00 PM](https://user-images.githubusercontent.com/208083/79264113-04c2ee00-7e62-11ea-8a79-7fffc0b1bce1.png)
