### PR TITLE
Deflake disable_toolbox_maze UI test

### DIFF
--- a/apps/src/maze/maze.js
+++ b/apps/src/maze/maze.js
@@ -38,6 +38,7 @@ module.exports = class Maze {
       stepSpeed: 5
     };
 
+    this.shouldSpeedUpInfiniteLoops = true;
     this.stepSpeed = 100;
     this.animating_ = false;
 
@@ -414,7 +415,7 @@ module.exports = class Maze {
           // possible
           this.result = ResultType.TIMEOUT;
           this.executionInfo.queueAction('finish', null);
-          this.stepSpeed = 0;
+          this.stepSpeed = this.shouldSpeedUpInfiniteLoops ? 0 : 100;
           break;
         case true:
           this.result = ResultType.SUCCESS;

--- a/dashboard/test/ui/features/star_labs/disable_toolbox_maze.feature
+++ b/dashboard/test/ui/features/star_labs/disable_toolbox_maze.feature
@@ -6,7 +6,7 @@ Background:
   And I wait for the page to fully load
   Then element "#runButton" is visible
   Then I drag block "4" to block "6"
-  And I drag block "1" to block "7" plus offset 35, 50
+  And I drag block "2" to block "7" plus offset 35, 50
 
 Scenario: Toolbox in maze (non-category) is enabled
   Then the workspace has "1" blocks of type "maze_forever"

--- a/dashboard/test/ui/features/star_labs/disable_toolbox_maze.feature
+++ b/dashboard/test/ui/features/star_labs/disable_toolbox_maze.feature
@@ -1,33 +1,56 @@
 Feature: Disabling/Reenabling the Toolbox While Running
 
 Background:
-  Given I am on "http://studio.code.org/s/20-hour/stage/2/puzzle/17?noautoplay=true"
+  Given "when run" refers to block "6"
+  Given "move forward" refers to block "1"
+  Given "turn left" refers to block "2"
+  Given "repeat forever" refers to block "4"
+
+Scenario: Toolbox in maze (non-category) is enabled
+  Given I am on "http://studio.code.org/s/20-hour/stage/2/puzzle/15?noautoplay=true"
   And I rotate to landscape
   And I wait for the page to fully load
   Then element "#runButton" is visible
-  Then I drag block "4" to block "6"
-  And I drag block "2" to block "7" plus offset 35, 50
-
-Scenario: Toolbox in maze (non-category) is enabled
+  Then I drag block "repeat forever" to block "when run"
   Then the workspace has "1" blocks of type "maze_forever"
 
 Scenario: Toolbox in maze (non-category) is disabled while running
+  Given I am on "http://studio.code.org/s/20-hour/stage/2/puzzle/16?noautoplay=true"
+  And I rotate to landscape
+  And I wait for the page to fully load
+  Then element "#runButton" is visible
+  Then I drag block "repeat forever" to block "when run"
+  And I drag block "turn left" to block "7" plus offset 35, 50
   Then I slow down execution speed
   And I press "runButton"
   And element "#resetButton" is visible
-  Then I drag block "4" to block "6"
+  Then I wait for 10 seconds
+  Then I drag block "repeat forever" to block "when run"
   Then the workspace has "1" blocks of type "maze_forever"
 
 @no_mobile
 Scenario: Toolbox in maze (non-category) is reenabled after finished running
+  Given I am on "http://studio.code.org/s/20-hour/stage/2/puzzle/17?noautoplay=true"
+  And I rotate to landscape
+  And I wait for the page to fully load
+  Then element "#runButton" is visible
+  Then I drag block "repeat forever" to block "when run"
+  And I drag block "turn left" to block "7" plus offset 35, 50
+  And I drag block "move forward" to block "8" plus offset 0, 20
   Then I press "runButton"
   Then I wait to see ".uitest-topInstructions-inline-feedback"
-  Then I drag block "4" to block "6"
+  Then I drag block "repeat forever" to block "when run"
   Then the workspace has "2" blocks of type "maze_forever"
 
 Scenario: Toolbox in maze (non-category) is reenabled after hitting reset
+  Given I am on "http://studio.code.org/s/20-hour/stage/2/puzzle/18?noautoplay=true"
+  And I rotate to landscape
+  And I wait for the page to fully load
+  Then element "#runButton" is visible
+  Then I drag block "repeat forever" to block "when run"
+  And I drag block "turn left" to block "7" plus offset 35, 50
   Then I press "runButton"
   Then I press "resetButton"
   Then element "#runButton" is visible
-  Then I drag block "4" to block "6"
+  Then I drag block "repeat forever" to block "when run"
   Then the workspace has "2" blocks of type "maze_forever"

--- a/dashboard/test/ui/features/step_definitions/steps.rb
+++ b/dashboard/test/ui/features/step_definitions/steps.rb
@@ -871,6 +871,7 @@ Then(/^I set slider speed to medium/) do
 end
 
 Then(/^I slow down execution speed$/) do
+  @browser.execute_script("Maze.shouldSpeedUpInfiniteLoops = false;")
   @browser.execute_script("Maze.scale.stepSpeed = 10;")
 end
 


### PR DESCRIPTION
A second attempt at deflaking this test. From watching a bunch of the failing scenarios playback on Saucelabs, it looks like one of the issues is that sometimes when the page reloads for the next scenario, the code from the previous scenario is still present. This causes the test to fail because we don't account for the duplicated blocks in our counts of how many blocks to expect to be present.
I tried a couple ways to reset the puzzle before starting each scenario, but none of my attempts really worked, so decided it was simpler to just use different levels for each scenario.

![image](https://user-images.githubusercontent.com/8787187/79265258-b0604400-7e4a-11ea-9db6-287f10cf6d20.png)

## Links

<!--
  Any relevant links to external resources; ie, specification documents, jira
  items, related PRs, honeybadger errors, etc
-->

- [jira](https://codedotorg.atlassian.net/browse/STAR-1003)

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
