### PR TITLE
Move unmatched regional partner contacts to zendesk-friendly from email address

### DIFF
--- a/dashboard/app/mailers/pd/regional_partner_mini_contact_mailer.rb
+++ b/dashboard/app/mailers/pd/regional_partner_mini_contact_mailer.rb
@@ -1,5 +1,6 @@
 class Pd::RegionalPartnerMiniContactMailer < ActionMailer::Base
   NO_REPLY = 'Code.org <noreply@code.org>'
+  ZENDESK_FRIENDLY_FROM = 'Regional Partner Contact Request <regional_partner_contact_request@code.org>'
   default from: 'Liz Gauthier <partner@code.org>'
   default bcc: MailerConstants::PLC_EMAIL_LOG
 
@@ -24,6 +25,7 @@ class Pd::RegionalPartnerMiniContactMailer < ActionMailer::Base
     role = form[:role].downcase
 
     mail(
+      from: ZENDESK_FRIENDLY_FROM,
       to: email,
       subject: "A " + role + " wants to connect with Code.org"
     )

--- a/dashboard/test/mailers/previews/pd_regional_partner_mini_contact_mailer_preview.rb
+++ b/dashboard/test/mailers/previews/pd_regional_partner_mini_contact_mailer_preview.rb
@@ -13,7 +13,7 @@ class Pd::RegionalPartnerMiniContactMailerPreview < ActionMailer::Preview
     Pd::RegionalPartnerMiniContactMailer.receipt(form, nil)
   end
 
-  def contact_unmatched
+  def mini_contact_unmatched
     form = build_form_data(:pd_regional_partner_mini_contact)
     Pd::RegionalPartnerMiniContactMailer.unmatched(form, 'test+employee@code.org')
   end
@@ -22,11 +22,6 @@ class Pd::RegionalPartnerMiniContactMailerPreview < ActionMailer::Preview
     rp_pm = create :regional_partner_program_manager
     form = build_form_data(:pd_regional_partner_mini_contact, regional_partner: rp_pm.regional_partner)
     Pd::RegionalPartnerMiniContactMailer.matched(form, rp_pm)
-  end
-
-  def mini_contact_unmatched
-    form = build_form_data(:pd_regional_partner_mini_contact)
-    Pd::RegionalPartnerMiniContactMailer.unmatched(form, 'test+employee@code.org')
   end
 
   private

--- a/dashboard/test/models/pd/regional_partner_mini_contact_test.rb
+++ b/dashboard/test/models/pd/regional_partner_mini_contact_test.rb
@@ -125,7 +125,7 @@ class Pd::RegionalPartnerMiniContactTest < ActiveSupport::TestCase
 
     assert_equal ['support@code.org'], mail.to
     assert_equal 'A teacher wants to connect with Code.org', mail.subject
-    assert_equal ['partner@code.org'], mail.from
+    assert_equal ['regional_partner_contact_request@code.org'], mail.from
     assert_equal 2, ActionMailer::Base.deliveries.count
     assert_sendable mail
   end
@@ -137,7 +137,7 @@ class Pd::RegionalPartnerMiniContactTest < ActiveSupport::TestCase
 
     assert_equal ['support@code.org'], mail.to
     assert_equal 'A teacher wants to connect with Code.org', mail.subject
-    assert_equal ['partner@code.org'], mail.from
+    assert_equal ['regional_partner_contact_request@code.org'], mail.from
     assert_equal 2, ActionMailer::Base.deliveries.count
     assert_sendable mail
   end

--- a/lib/cdo/poste.rb
+++ b/lib/cdo/poste.rb
@@ -535,7 +535,10 @@ module Poste2
       facilitators@code.org
       volunteers@code.org
       partner@code.org
+      regional_partner_contact_request@code.org
     ]
+    # Note: regional_partner_contact_request@code.org should only be used
+    # to send email to internal recipients (eg, support@code.org)
 
     def initialize(settings = nil)
     end


### PR DESCRIPTION
Changes `from:` email address in unmatched regional partner contacts to something that isn't already a Zendesk alias. Emails were previously being sent from partner@code.org, which is an email address that is already forwarded to Zendesk, so Zendesk viewed it as spam.

I'll also ask Josh to whitelist this new email address so it doesn't end up getting filtered into spam.

## Testing story

Checked out the mailer preview, which looked good. Also noted that we had two mailer previews with the exact same content, so I deleted one.