### PR TITLE
Part 1, delete prospects from Pardot: migration

### DIFF
--- a/dashboard/app/models/contact_rollups_pardot_memory.rb
+++ b/dashboard/app/models/contact_rollups_pardot_memory.rb
@@ -10,13 +10,15 @@
 #  data_synced_at       :datetime
 #  data_rejected_at     :datetime
 #  data_rejected_reason :string(255)
+#  delete_from_pardot   :boolean
 #  created_at           :datetime         not null
 #  updated_at           :datetime         not null
 #
 # Indexes
 #
-#  index_contact_rollups_pardot_memory_on_email      (email) UNIQUE
-#  index_contact_rollups_pardot_memory_on_pardot_id  (pardot_id) UNIQUE
+#  index_contact_rollups_pardot_memory_on_delete_from_pardot  (delete_from_pardot)
+#  index_contact_rollups_pardot_memory_on_email               (email) UNIQUE
+#  index_contact_rollups_pardot_memory_on_pardot_id           (pardot_id) UNIQUE
 #
 
 require 'cdo/contact_rollups/v2/pardot'

--- a/dashboard/app/models/contact_rollups_pardot_memory.rb
+++ b/dashboard/app/models/contact_rollups_pardot_memory.rb
@@ -2,23 +2,23 @@
 #
 # Table name: contact_rollups_pardot_memory
 #
-#  id                   :integer          not null, primary key
-#  email                :string(255)      not null
-#  pardot_id            :integer
-#  pardot_id_updated_at :datetime
-#  data_synced          :json
-#  data_synced_at       :datetime
-#  data_rejected_at     :datetime
-#  data_rejected_reason :string(255)
-#  delete_from_pardot   :boolean
-#  created_at           :datetime         not null
-#  updated_at           :datetime         not null
+#  id                     :integer          not null, primary key
+#  email                  :string(255)      not null
+#  pardot_id              :integer
+#  pardot_id_updated_at   :datetime
+#  data_synced            :json
+#  data_synced_at         :datetime
+#  data_rejected_at       :datetime
+#  data_rejected_reason   :string(255)
+#  marked_for_deletion_at :datetime
+#  created_at             :datetime         not null
+#  updated_at             :datetime         not null
 #
 # Indexes
 #
-#  index_contact_rollups_pardot_memory_on_delete_from_pardot  (delete_from_pardot)
-#  index_contact_rollups_pardot_memory_on_email               (email) UNIQUE
-#  index_contact_rollups_pardot_memory_on_pardot_id           (pardot_id) UNIQUE
+#  index_contact_rollups_pardot_memory_on_email                   (email) UNIQUE
+#  index_contact_rollups_pardot_memory_on_marked_for_deletion_at  (marked_for_deletion_at)
+#  index_contact_rollups_pardot_memory_on_pardot_id               (pardot_id) UNIQUE
 #
 
 require 'cdo/contact_rollups/v2/pardot'

--- a/dashboard/db/migrate/20200410165644_add_delete_from_pardot_column.rb
+++ b/dashboard/db/migrate/20200410165644_add_delete_from_pardot_column.rb
@@ -1,0 +1,6 @@
+class AddDeleteFromPardotColumn < ActiveRecord::Migration[5.0]
+  def change
+    add_column :contact_rollups_pardot_memory, :delete_from_pardot, :boolean, after: :data_rejected_reason
+    add_index :contact_rollups_pardot_memory, :delete_from_pardot
+  end
+end

--- a/dashboard/db/migrate/20200410165644_add_delete_from_pardot_column.rb
+++ b/dashboard/db/migrate/20200410165644_add_delete_from_pardot_column.rb
@@ -1,6 +1,6 @@
 class AddDeleteFromPardotColumn < ActiveRecord::Migration[5.0]
   def change
-    add_column :contact_rollups_pardot_memory, :delete_from_pardot, :boolean, after: :data_rejected_reason
-    add_index :contact_rollups_pardot_memory, :delete_from_pardot
+    add_column :contact_rollups_pardot_memory, :marked_for_deletion_at, :datetime, after: :data_rejected_reason
+    add_index :contact_rollups_pardot_memory, :marked_for_deletion_at
   end
 end

--- a/dashboard/db/schema.rb
+++ b/dashboard/db/schema.rb
@@ -294,8 +294,10 @@ ActiveRecord::Schema.define(version: 20200414185601) do
     t.datetime "data_synced_at"
     t.datetime "data_rejected_at"
     t.string   "data_rejected_reason"
+    t.boolean  "delete_from_pardot"
     t.datetime "created_at",           null: false
     t.datetime "updated_at",           null: false
+    t.index ["delete_from_pardot"], name: "index_contact_rollups_pardot_memory_on_delete_from_pardot", using: :btree
     t.index ["email"], name: "index_contact_rollups_pardot_memory_on_email", unique: true, using: :btree
     t.index ["pardot_id"], name: "index_contact_rollups_pardot_memory_on_pardot_id", unique: true, using: :btree
   end

--- a/dashboard/db/schema.rb
+++ b/dashboard/db/schema.rb
@@ -287,18 +287,18 @@ ActiveRecord::Schema.define(version: 20200414185601) do
   end
 
   create_table "contact_rollups_pardot_memory", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci" do |t|
-    t.string   "email",                null: false
+    t.string   "email",                  null: false
     t.integer  "pardot_id"
     t.datetime "pardot_id_updated_at"
     t.json     "data_synced"
     t.datetime "data_synced_at"
     t.datetime "data_rejected_at"
     t.string   "data_rejected_reason"
-    t.boolean  "delete_from_pardot"
-    t.datetime "created_at",           null: false
-    t.datetime "updated_at",           null: false
-    t.index ["delete_from_pardot"], name: "index_contact_rollups_pardot_memory_on_delete_from_pardot", using: :btree
+    t.datetime "marked_for_deletion_at"
+    t.datetime "created_at",             null: false
+    t.datetime "updated_at",             null: false
     t.index ["email"], name: "index_contact_rollups_pardot_memory_on_email", unique: true, using: :btree
+    t.index ["marked_for_deletion_at"], name: "index_contact_rollups_pardot_memory_on_marked_for_deletion_at", using: :btree
     t.index ["pardot_id"], name: "index_contact_rollups_pardot_memory_on_pardot_id", unique: true, using: :btree
   end
 


### PR DESCRIPTION
## Description

New column in `contact_rollups_pardot_memory` called `delete_from_pardot`, which is 1/0/nil. The idea is that the account deletion process will set this flag to one when it runs (part 3 of this PR set), then rely on the contact rollups process to actually conduct the deletion (part 2 of this PR set).

## Testing story

Ran migration locally.
