### PR TITLE
[Applab Datasets]Add delete button to LB dataset page

### DIFF
--- a/apps/src/storage/levelbuilder/Dataset.jsx
+++ b/apps/src/storage/levelbuilder/Dataset.jsx
@@ -8,6 +8,7 @@ import {
   updateTableRecords
 } from '../redux/data';
 import {DataView} from '../constants';
+import ConfirmDeleteButton from '../dataBrowser/ConfirmDeleteButton';
 import ConfirmImportButton from '../dataBrowser/ConfirmImportButton';
 import DataTable from '../dataBrowser/DataTable';
 
@@ -58,6 +59,17 @@ class Dataset extends React.Component {
       .fail(() => this.setState({notice: 'Upload failed.', isError: true}));
   };
 
+  deleteTable = () => {
+    $.ajax({
+      url: `/datasets/${this.props.tableName}`,
+      method: 'DELETE'
+    })
+      .done(data => {
+        window.location.href = '/datasets';
+      })
+      .fail(() => this.setState({notice: 'Delete failed', isError: true}));
+  };
+
   render() {
     return (
       <div>
@@ -73,7 +85,17 @@ class Dataset extends React.Component {
           <a href="/datasets">Back to Index</a>
         </p>
         {!this.props.isLive && (
-          <ConfirmImportButton importCsv={this.importCsv} />
+          <div>
+            <ConfirmDeleteButton
+              body={'confirm?'}
+              buttonText="Delete table"
+              containerStyle={{width: 125, marginLeft: 10}}
+              buttonId="clearTableButton"
+              onConfirmDelete={this.deleteTable}
+              title="Delete table"
+            />
+            <ConfirmImportButton importCsv={this.importCsv} />
+          </div>
         )}
         <DataTable readOnly rowsPerPage={10} />
       </div>

--- a/apps/src/storage/levelbuilder/Dataset.jsx
+++ b/apps/src/storage/levelbuilder/Dataset.jsx
@@ -87,12 +87,14 @@ class Dataset extends React.Component {
         {!this.props.isLive && (
           <div>
             <ConfirmDeleteButton
-              body={'confirm?'}
+              body={`Are you sure you want to delete ${
+                this.props.tableName
+              }? This action cannot be undone.`}
               buttonText="Delete table"
               containerStyle={{width: 125, marginLeft: 10}}
               buttonId="clearTableButton"
               onConfirmDelete={this.deleteTable}
-              title="Delete table"
+              title={`Delete ${this.props.tableName}`}
             />
             <ConfirmImportButton importCsv={this.importCsv} />
           </div>

--- a/dashboard/app/controllers/datasets_controller.rb
+++ b/dashboard/app/controllers/datasets_controller.rb
@@ -35,6 +35,12 @@ class DatasetsController < ApplicationController
     render json: data, status: response.code
   end
 
+  # DELETE /datasets/:dataset_name/
+  def destroy
+    response = @firebase.delete_shared_table params[:dataset_name]
+    render json: {}, status: response.code
+  end
+
   # GET /datasets/manifest/edit
   def edit_manifest
     @dataset_library_manifest = @firebase.get_library_manifest

--- a/dashboard/app/models/ability.rb
+++ b/dashboard/app/models/ability.rb
@@ -243,7 +243,7 @@ class Ability
       # a corresponding model, use lower/snake-case symbol instead of class name.
       can [:upload, :destroy], :level_starter_asset
 
-      can [:edit_manifest, :update_manifest, :index, :show, :update], :dataset
+      can [:edit_manifest, :update_manifest, :index, :show, :update, :destroy], :dataset
     end
 
     if user.persisted?

--- a/dashboard/config/routes.rb
+++ b/dashboard/config/routes.rb
@@ -234,7 +234,7 @@ Dashboard::Application.routes.draw do
     end
   end
 
-  resources :datasets, param: 'dataset_name', only: [:index, :show, :update] do
+  resources :datasets, param: 'dataset_name', only: [:index, :show, :update, :destroy] do
     collection do
       get '/manifest/edit', to: 'datasets#edit_manifest'
       post '/manifest/update', to: 'datasets#update_manifest'


### PR DESCRIPTION
Curriculum owns uploading datasets to Firebase through the UI at https://levelbuilder-studio.code.org/datasets
However, they currently have no way of deleting datasets. This PR adds a delete button in the dataset view:
Before
![image](https://user-images.githubusercontent.com/8787187/79368486-56bc5000-7f04-11ea-85a3-6aa216c8568a.png)

After
![image](https://user-images.githubusercontent.com/8787187/79368417-312f4680-7f04-11ea-9e0d-2a0acfa7ebb6.png)


Live tables do *not* show the delete button
![image](https://user-images.githubusercontent.com/8787187/79368394-2674b180-7f04-11ea-8ee3-61d5a1c7b1c6.png)

Confirmation popup:
![image](https://user-images.githubusercontent.com/8787187/79368829-e06c1d80-7f04-11ea-8c85-5ce88eb881a2.png)



<!-- ### Background -->
<!-- ### Privacy -->
<!-- ### Security -->
<!-- ### Caching -->
<!-- ### Deployment strategy -->
<!-- ### Future work -->

## Links

<!--
  Any relevant links to external resources; ie, specification documents, jira
  items, related PRs, honeybadger errors, etc
-->

- [jira](https://codedotorg.atlassian.net/browse/STAR-1070)

## Testing story

<!--
  Does your change include appropriate tests?

  If so, please describe how the tests included in this PR are sufficient

  If not, please explain why this change does not need to be tested.
-->

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
