### PR TITLE
update category names for CSF 2017 and 2019

### DIFF
--- a/dashboard/config/locales/scripts.en.yml
+++ b/dashboard/config/locales/scripts.en.yml
@@ -7,8 +7,9 @@ en:
         csd_category_name: CS Discoveries ('17-'18)
         csd_2018_category_name: CS Discoveries ('18-'19)
         csd_2019_category_name: CS Discoveries ('19-'20)
-        csf_category_name: CS Fundamentals
+        csf_category_name: CS Fundamentals (2017)
         csf_2018_category_name: CS Fundamentals (2018)
+        csf_2019_category_name: CS Fundamentals (2019)
         csf_international_category_name: CS Fundamentals International
         csf2_draft_category_name: 'Under Development: Courses A - F'
         csp_category_name: "'15-'16 CS Principles"
@@ -14251,12 +14252,12 @@ en:
               description_teacher: "**Question of the Day:  How can we use feedback to make our websites better?**\r\n\r\nThis lesson focuses on the value of peer feedback.  Students first reflect on what they are proud of, and what they would like feedback on.  Teams then work with peers to get that feedback though a structured process that includes the project rubric criteria.  Afterwards, students decide how they would like to respond to the feedback and put the finishing touches on their sites.  After a final review of the rubric, they reflect on their process. To cap off the unit, they will share their projects and also a overview of the process they took to get to that final design.\r\n"
             Post-Project Test:
               name: Post-Project Test
-              description_student: 
-              description_teacher: 
+              description_student:
+              description_teacher:
             CS Discoveries Post Course survey:
               name: CS Discoveries Post Course survey
-              description_student: 
-              description_teacher: 
+              description_student:
+              description_teacher:
             'Mini-Project: HTML Web Page':
               name: 'Mini-Project: HTML Web Page'
               description_student: "**Question of the Day: How can I use HTML to express a personal value?**\r\n\r\nIn this lesson, the class creates personal web page on a topic of their choice.  The lesson starts with a review of HTML tags.  Next, the class designs web pages, identifying the tags needed to implement them, and creates the pages in Web Lab."


### PR DESCRIPTION
I noticed that the category headings are incorrect for CSF versions 2017 and 2019. This PR fixes the problem by updating the corresponding strings in our translation files:

before:
<img width="534" alt="Screen Shot 2020-04-15 at 10 38 35 AM" src="https://user-images.githubusercontent.com/8001765/79369129-507aa380-7f05-11ea-8faf-29aa8d028ed8.png">


after:
<img width="527" alt="Screen Shot 2020-04-15 at 10 36 05 AM" src="https://user-images.githubusercontent.com/8001765/79368916-07c2ea80-7f05-11ea-8120-deddfe81b282.png">


## Testing story

manually verified as shown in screenshots

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
