### PR TITLE
Part 3, delete prospects from Pardot: rely on contact rollups when deleting accounts

### DIFF
--- a/dashboard/test/helpers/delete_accounts_helper_test.rb
+++ b/dashboard/test/helpers/delete_accounts_helper_test.rb
@@ -1819,59 +1819,15 @@ class DeleteAccountsHelperTest < ActionView::TestCase
   end
 
   #
-  # Pardot
-  # pegasus.contact_rollups
+  # contact rollups
   #
 
-  test "Pardot: Calls delete_pardot_prospects" do
+  test "account deletion stages email for removal from pardot" do
     teacher = create :teacher
+    teacher_email = teacher.email
+    purge_user teacher
 
-    CDO.stubs(:rack_env?).with(:production).returns(true)
-
-    with_contact_rollup_for(teacher) do |_, pardot_id|
-      Pardot.expects(:delete_pardot_prospects).with([pardot_id]).returns([])
-      purge_user teacher
-    end
-  end
-
-  test "Pardot: Raises if Pardot reports issues deleting prospects" do
-    teacher = create :teacher
-
-    CDO.stubs(:rack_env?).with(:production).returns(true)
-
-    with_contact_rollup_for(teacher) do |_, pardot_id|
-      Pardot.expects(:delete_pardot_prospects).with([pardot_id]).returns([pardot_id])
-      assert_raises RuntimeError do
-        purge_user teacher
-      end
-    end
-  end
-
-  test "Pardot: Does not contact Pardot outside of production" do
-    teacher = create :teacher
-
-    CDO.stubs(:rack_env?).with(:production).returns(false)
-
-    with_contact_rollup_for(teacher) do
-      Pardot.expects(:delete_pardot_prospects).never
-      purge_user teacher
-    end
-  end
-
-  test "contact_rollups: Deletes user records" do
-    teacher_a = create :teacher
-    teacher_b = create :teacher
-    with_contact_rollup_for(teacher_a) do |contact_rollups_id_a|
-      with_contact_rollup_for(teacher_b) do |contact_rollups_id_b|
-        refute_empty contact_rollups.where(id: contact_rollups_id_a)
-        refute_empty contact_rollups.where(id: contact_rollups_id_b)
-
-        purge_user teacher_a
-
-        assert_empty contact_rollups.where(id: contact_rollups_id_a)
-        refute_empty contact_rollups.where(id: contact_rollups_id_b)
-      end
-    end
+    assert_equal true, ContactRollupsPardotMemory.find_by(email: teacher_email).delete_from_pardot
   end
 
   #

--- a/lib/cdo/delete_accounts_helper.rb
+++ b/lib/cdo/delete_accounts_helper.rb
@@ -175,34 +175,12 @@ class DeleteAccountsHelper
     @pegasus_db[:contacts].where(id: contact_ids).delete
   end
 
-  def remove_from_pardot_and_contact_rollups(contact_rollups_recordset)
-    # TODO: Make this an operation handled by the contact rollups task itself
-    #       instead of crossing the architectural boundary ourselves.
-    #       For now this is unsafe to run while contact rollups is itself running.
-    # Though we have the DB tables in all environments, we only sync data from the production
-    # environment with Pardot.
-    if CDO.rack_env? :production
-      pardot_ids = contact_rollups_recordset.
-        select(:pardot_id).
-        map {|contact_rollup| contact_rollup[:pardot_id]}
-      failed_ids = Pardot.delete_pardot_prospects(pardot_ids)
-      if failed_ids.any?
-        raise "Pardot.delete_pardot_prospects failed for Pardot IDs #{failed_ids.join(', ')}."
-      end
-    end
-    contact_rollups_recordset.delete
-  end
-
-  # Removes all information about the user pertaining to Pardot. This encompasses Pardot itself, the
-  # contact_rollups pegasus table (master and reporting)
-  # @param [Integer] The user ID to purge from Pardot.
-  def remove_from_pardot_by_user_id(user_id)
-    @log.puts "Removing from Pardot"
-    remove_from_pardot_and_contact_rollups @pegasus_db[:contact_rollups].where(dashboard_user_id: user_id)
-  end
-
-  def remove_from_pardot_by_email(email)
-    remove_from_pardot_and_contact_rollups @pegasus_db[:contact_rollups].where(email: email)
+  # This does not actually delete records from Pardot,
+  # but sets a flag to remove records from Pardot next time
+  # the contact rollups process runs.
+  def stage_removal_from_pardot_by_email(email)
+    @log.puts "Staging for removal from Pardot"
+    ContactRollupsPardotMemory.find_or_create_by(email: email).update(delete_from_pardot: 1)
   end
 
   # Removes the StudioPerson record associated with the user IF it is not
@@ -328,7 +306,7 @@ class DeleteAccountsHelper
     clean_user_sections(user.id)
     remove_user_from_sections_as_student(user)
     remove_poste_data(user_email) if user_email&.present?
-    remove_from_pardot_by_user_id(user.id)
+    stage_removal_from_pardot_by_email(user_email)
     purge_unshared_studio_person(user)
     anonymize_user(user)
 
@@ -353,7 +331,7 @@ class DeleteAccountsHelper
     migrated_users.or(unmigrated_users).each {|u| purge_user u}
 
     remove_poste_data(email)
-    remove_from_pardot_by_email(email)
+    stage_removal_from_pardot_by_email(email)
     clean_pegasus_forms_for_email(email)
   end
 


### PR DESCRIPTION
## Description

Sets delete accounts process to rely on contact rollups process to delete data from Pardot, rather than deleting data itself.

## Testing story

Tests that previously covered the behavior to delete from Pardot is moved to PardotV2 tests [here](https://github.com/code-dot-org/code-dot-org/pull/34242/files).

## Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
