### PR TITLE
No longer require `email` when updating a teacher

### DIFF
--- a/dashboard/app/models/user.rb
+++ b/dashboard/app/models/user.rb
@@ -641,7 +641,7 @@ class User < ActiveRecord::Base
     nil
   end
 
-  validate :presence_of_email, if: -> {teacher? && purged_at.nil?}
+  validate :presence_of_email, if: -> {teacher? && purged_at.nil?}, on: :create
   validate :presence_of_email_or_hashed_email, if: :email_required?, on: :create
   validates :email, no_utf8mb4: true
   validates_email_format_of :email, allow_blank: true, if: :email_changed?, unless: -> {email.to_s.utf8mb4?}

--- a/dashboard/test/controllers/omniauth_callbacks_controller_test.rb
+++ b/dashboard/test/controllers/omniauth_callbacks_controller_test.rb
@@ -1533,10 +1533,13 @@ class OmniauthCallbacksControllerTest < ActionController::TestCase
     uid = 'google-takeover-id'
 
     # Make account invalid
+    # Although teacher accounts should have an email, there are some legacy
+    # teacher accounts which don't have an email recorded for them.
+    # Therefore, the lack of email will not fail validation.
     malformed_account.email = ''
     malformed_account.save(validate: false)
     malformed_account.reload
-    refute malformed_account.valid?
+    assert malformed_account.valid?
 
     Honeybadger.expects(:notify).never
 

--- a/dashboard/test/integration/registration/destroy_test.rb
+++ b/dashboard/test/integration/registration/destroy_test.rb
@@ -157,7 +157,7 @@ module RegistrationsControllerTests
 
     test "does not send email when teacher destroyed if teacher has no email" do
       user = create :teacher, :without_email, password: 'apassword'
-      refute user.valid?
+      assert user.valid?
       sign_in user
 
       TeacherMailer.expects(:delete_teacher_email).never

--- a/dashboard/test/models/user_test.rb
+++ b/dashboard/test/models/user_test.rb
@@ -679,10 +679,25 @@ class UserTest < ActiveSupport::TestCase
     end
   end
 
-  test "cannot create teacher without email" do
+  test "creating a teacher given manual provider and no email should fail to create the user" do
     assert_does_not_create(User) do
       User.create(user_type: User::TYPE_TEACHER, name: 'Bad Teacher', password: 'xxxxxxxx', provider: 'manual')
     end
+  end
+
+  test "creating a teacher given no email should fail" do
+    user = User.create(user_type: User::TYPE_TEACHER, name: 'Bad Teacher',
+                       hashed_email: 'ebe8f16a62480d29a8af2ec3b5017af5'
+    )
+    assert_not_empty user.errors[:email]
+  end
+
+  test "updating a teacher given no email should succeed" do
+    # setup existing teacher which doesn't have an email
+    user = User.create(user_type: User::TYPE_TEACHER, name: 'No Email Teacher')
+    user.save(validate: false)
+    user.name = "No Email Teacher Name Updated"
+    user.save!
   end
 
   test "cannot make an account without email a teacher" do


### PR DESCRIPTION
We have some old `teacher` accounts which don't have the `email`
attribute on them. Right now this is preventing these existing accounts
from having changes made to them because they fail the existing
validation logic. This change removes the `email` requirement for
existing accounts but does require it on all new `teacher` accounts.

## Links
- [jira](https://codedotorg.atlassian.net/browse/FND-1018)

## Testing story
* unit tests

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
