### PR TITLE
At-Home: The "Learn at Home" block on the signed-out homepage links to /courses

### DIFF
--- a/pegasus/src/homepage.rb
+++ b/pegasus/src/homepage.rb
@@ -317,7 +317,7 @@ class Homepage
           text: "homepage_slot_text_blurb_at_home",
           color1: "0, 173, 188",
           color2: "89, 202, 211",
-          url: "/athome",
+          url: CDO.studio_url("/courses"),
           image: "/images/mc/2016_homepage_hocblock.jpg"
         },
         {


### PR DESCRIPTION
[PLC-842](https://codedotorg.atlassian.net/browse/PLC-842): Logged-out homepage: On the new Learn at Home tile, change the link for "Learn at Home" to go to studio.code.org/courses for all non-EN versions of the site.

## Testing story

Checked locally.  For context, here's what the blocks look like on English and non-English (though the non-English isn't translated yet).

| EN | non-EN |
| --- | --- |
| ![Screenshot from 2020-04-15 14-20-56](https://user-images.githubusercontent.com/1615761/79394567-a878d080-7f2c-11ea-9213-1687f70520f5.png) | ![Screenshot from 2020-04-15 15-15-51](https://user-images.githubusercontent.com/1615761/79394570-aadb2a80-7f2c-11ea-95c6-120781f88ae1.png) |

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
