### PR TITLE
Add testing.lmao.cx to list of allowed hostnames for startWebRequest()

### DIFF
--- a/dashboard/app/controllers/xhr_proxy_controller.rb
+++ b/dashboard/app/controllers/xhr_proxy_controller.rb
@@ -84,6 +84,7 @@ class XhrProxyController < ApplicationController
     spreadsheets.google.com
     stats.minecraftservers.org
     swapi.co
+    testing.lmao.cx
     theunitedstates.io
     transitchicago.com
     translate.yandex.net


### PR DESCRIPTION
Add `testing.lmao.cx` as an allowed hostname for `startWebRequest()`. This came in as a [Zendesk ticket](https://codeorg.zendesk.com/agent/tickets/275650) -- a student built an API that they would like to use for their College Board's CS Create Task project.