### PR TITLE
Hide the at-home callout on the signed-in homepage for non-en users

### DIFF
--- a/apps/src/sites/studio/pages/home/_homepage.js
+++ b/apps/src/sites/studio/pages/home/_homepage.js
@@ -89,6 +89,7 @@ function showHomepage() {
             sections={homepageData.sections}
             canViewAdvancedTools={homepageData.canViewAdvancedTools}
             studentId={homepageData.studentId}
+            isEnglish={isEnglish}
           />
         )}
       </div>

--- a/apps/src/templates/studioHomepages/StudentHomepage.jsx
+++ b/apps/src/templates/studioHomepages/StudentHomepage.jsx
@@ -19,7 +19,8 @@ export default class StudentHomepage extends Component {
     hasFeedback: PropTypes.bool,
     sections: shapes.sections,
     canViewAdvancedTools: PropTypes.bool,
-    studentId: PropTypes.number.isRequired
+    studentId: PropTypes.number.isRequired,
+    isEnglish: PropTypes.bool.isRequired
   };
 
   componentDidMount() {
@@ -30,14 +31,14 @@ export default class StudentHomepage extends Component {
   }
 
   render() {
-    const {courses, sections, topCourse, hasFeedback} = this.props;
+    const {courses, sections, topCourse, hasFeedback, isEnglish} = this.props;
     const {canViewAdvancedTools, studentId} = this.props;
 
     return (
       <div>
         <HeaderBanner headingText={i18n.homepageHeading()} short={true} />
         <ProtectedStatefulDiv ref="flashes" />
-        <SpecialAnnouncement isTeacher={false} />
+        {isEnglish && <SpecialAnnouncement isTeacher={false} />}
         {hasFeedback && <StudentFeedbackNotification studentId={studentId} />}
         <RecentCourses
           courses={courses}

--- a/apps/src/templates/studioHomepages/TeacherHomepage.jsx
+++ b/apps/src/templates/studioHomepages/TeacherHomepage.jsx
@@ -179,7 +179,7 @@ export default class TeacherHomepage extends Component {
         <HeaderBanner headingText={i18n.homepageHeading()} short={true} />
         <ProtectedStatefulDiv ref="flashes" />
         <ProtectedStatefulDiv ref="teacherReminders" />
-        <SpecialAnnouncement isTeacher={true} />
+        {isEnglish && <SpecialAnnouncement isTeacher={true} />}
         {/* Hide the SpecialAnnouncementActionBlock for now in favor of SpecialAnnouncement since SpecialAnnouncementActionBlock is not translatable */}
         {specialAnnouncement && false && (
           <SpecialAnnouncementActionBlock announcement={specialAnnouncement} />

--- a/apps/test/unit/templates/studioHomepages/StudentHomepageTest.js
+++ b/apps/test/unit/templates/studioHomepages/StudentHomepageTest.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import {assert, expect} from '../../../util/reconfiguredChai';
+import {assert} from 'chai';
 import {shallow} from 'enzyme';
 import StudentHomepage from '@cdo/apps/templates/studioHomepages/StudentHomepage';
 import HeaderBanner from '@cdo/apps/templates/HeaderBanner';
@@ -27,7 +27,7 @@ describe('StudentHomepage', () => {
 
   it('references a ProtectedStatefulDiv for flashes', () => {
     const wrapper = shallow(<StudentHomepage {...TEST_PROPS} />);
-    expect(wrapper.find('ProtectedStatefulDiv').exists()).to.be.true;
+    assert(wrapper.find('ProtectedStatefulDiv').exists());
   });
 
   it('shows RecentCourses component', () => {
@@ -43,7 +43,7 @@ describe('StudentHomepage', () => {
 
   it('shows ProjectWidgetWithData component', () => {
     const wrapper = shallow(<StudentHomepage {...TEST_PROPS} />);
-    expect(wrapper.find('ProjectWidgetWithData').exists()).to.be.true;
+    assert(wrapper.find('ProjectWidgetWithData').exists());
   });
 
   it('shows a StudentSections component', () => {

--- a/apps/test/unit/templates/studioHomepages/StudentHomepageTest.js
+++ b/apps/test/unit/templates/studioHomepages/StudentHomepageTest.js
@@ -7,6 +7,15 @@ import StudentSections from '@cdo/apps/templates/studioHomepages/StudentSections
 import {courses, topCourse, joinedSections} from './homepagesTestData';
 
 describe('StudentHomepage', () => {
+  const TEST_PROPS = {
+    courses,
+    topCourse,
+    sections: joinedSections,
+    codeOrgUrlPrefix: 'http://localhost:3000',
+    studentId: 123,
+    isEnglish: true
+  };
+
   it('shows a non-extended Header Banner that says My Dashboard', () => {
     const wrapper = shallow(
       <StudentHomepage
@@ -15,6 +24,7 @@ describe('StudentHomepage', () => {
         sections={[]}
         codeOrgUrlPrefix="http://localhost:3000/"
         studentId={123}
+        isEnglish
       />
     );
     const headerBanner = wrapper.find(HeaderBanner);
@@ -32,6 +42,7 @@ describe('StudentHomepage', () => {
         sections={[]}
         codeOrgUrlPrefix="http://localhost:3000/"
         studentId={123}
+        isEnglish
       />
     );
     expect(wrapper.find('ProtectedStatefulDiv').exists()).to.be.true;
@@ -46,6 +57,7 @@ describe('StudentHomepage', () => {
         codeOrgUrlPrefix="http://localhost:3000/"
         studentId={123}
         hasFeedback={false}
+        isEnglish
       />
     );
     const recentCourses = wrapper.find('RecentCourses');
@@ -65,6 +77,7 @@ describe('StudentHomepage', () => {
         sections={joinedSections}
         codeOrgUrlPrefix="http://localhost:3000/"
         studentId={123}
+        isEnglish
       />
     );
     expect(wrapper.find('ProjectWidgetWithData').exists()).to.be.true;
@@ -78,11 +91,26 @@ describe('StudentHomepage', () => {
         sections={joinedSections}
         codeOrgUrlPrefix="http://localhost:3000/"
         studentId={123}
+        isEnglish
       />
     );
     const studentSections = wrapper.find(StudentSections);
     assert.deepEqual(studentSections.props(), {
       initialSections: joinedSections
     });
+  });
+
+  it('shows the special announcement for English', () => {
+    const wrapper = shallow(
+      <StudentHomepage {...TEST_PROPS} isEnglish={true} />
+    );
+    assert(wrapper.find('SpecialAnnouncement').exists());
+  });
+
+  it('does not show the special announcement for non-English', () => {
+    const wrapper = shallow(
+      <StudentHomepage {...TEST_PROPS} isEnglish={false} />
+    );
+    assert.isFalse(wrapper.find('SpecialAnnouncement').exists());
   });
 });

--- a/apps/test/unit/templates/studioHomepages/StudentHomepageTest.js
+++ b/apps/test/unit/templates/studioHomepages/StudentHomepageTest.js
@@ -17,16 +17,7 @@ describe('StudentHomepage', () => {
   };
 
   it('shows a non-extended Header Banner that says My Dashboard', () => {
-    const wrapper = shallow(
-      <StudentHomepage
-        courses={[]}
-        topCourse={topCourse}
-        sections={[]}
-        codeOrgUrlPrefix="http://localhost:3000/"
-        studentId={123}
-        isEnglish
-      />
-    );
+    const wrapper = shallow(<StudentHomepage {...TEST_PROPS} />);
     const headerBanner = wrapper.find(HeaderBanner);
     assert.deepEqual(headerBanner.props(), {
       headingText: 'My Dashboard',
@@ -35,31 +26,12 @@ describe('StudentHomepage', () => {
   });
 
   it('references a ProtectedStatefulDiv for flashes', () => {
-    const wrapper = shallow(
-      <StudentHomepage
-        courses={[]}
-        topCourse={topCourse}
-        sections={[]}
-        codeOrgUrlPrefix="http://localhost:3000/"
-        studentId={123}
-        isEnglish
-      />
-    );
+    const wrapper = shallow(<StudentHomepage {...TEST_PROPS} />);
     expect(wrapper.find('ProtectedStatefulDiv').exists()).to.be.true;
   });
 
   it('shows RecentCourses component', () => {
-    const wrapper = shallow(
-      <StudentHomepage
-        courses={courses}
-        topCourse={topCourse}
-        sections={[]}
-        codeOrgUrlPrefix="http://localhost:3000/"
-        studentId={123}
-        hasFeedback={false}
-        isEnglish
-      />
-    );
+    const wrapper = shallow(<StudentHomepage {...TEST_PROPS} />);
     const recentCourses = wrapper.find('RecentCourses');
     assert.deepEqual(recentCourses.props(), {
       courses: courses,
@@ -70,30 +42,12 @@ describe('StudentHomepage', () => {
   });
 
   it('shows ProjectWidgetWithData component', () => {
-    const wrapper = shallow(
-      <StudentHomepage
-        courses={courses}
-        topCourse={topCourse}
-        sections={joinedSections}
-        codeOrgUrlPrefix="http://localhost:3000/"
-        studentId={123}
-        isEnglish
-      />
-    );
+    const wrapper = shallow(<StudentHomepage {...TEST_PROPS} />);
     expect(wrapper.find('ProjectWidgetWithData').exists()).to.be.true;
   });
 
   it('shows a StudentSections component', () => {
-    const wrapper = shallow(
-      <StudentHomepage
-        courses={courses}
-        topCourse={topCourse}
-        sections={joinedSections}
-        codeOrgUrlPrefix="http://localhost:3000/"
-        studentId={123}
-        isEnglish
-      />
-    );
+    const wrapper = shallow(<StudentHomepage {...TEST_PROPS} />);
     const studentSections = wrapper.find(StudentSections);
     assert.deepEqual(studentSections.props(), {
       initialSections: joinedSections

--- a/apps/test/unit/templates/studioHomepages/TeacherHomepageTest.js
+++ b/apps/test/unit/templates/studioHomepages/TeacherHomepageTest.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import {shallow} from 'enzyme';
 import sinon from 'sinon';
-import {assert, expect} from '../../../util/deprecatedChai';
+import {assert} from 'chai';
 import TeacherHomepage from '@cdo/apps/templates/studioHomepages/TeacherHomepage';
 import TeacherSections from '@cdo/apps/templates/studioHomepages/TeacherSections';
 import {courses, topCourse} from './homepagesTestData';
@@ -41,17 +41,17 @@ describe('TeacherHomepage', () => {
 
   it('references 2 ProtectedStatefulDivs', () => {
     const wrapper = shallow(<TeacherHomepage {...TEST_PROPS} />);
-    expect(wrapper.find('ProtectedStatefulDiv')).to.have.length(2);
+    assert.lengthOf(wrapper.find('ProtectedStatefulDiv'), 2);
   });
 
   it('renders a TeacherSections component', () => {
     const wrapper = shallow(<TeacherHomepage {...TEST_PROPS} />);
-    expect(wrapper).to.containMatchingElement(<TeacherSections />);
+    assert(wrapper.containsMatchingElement(<TeacherSections />));
   });
 
   it('renders a StudentSections component', () => {
     const wrapper = shallow(<TeacherHomepage {...TEST_PROPS} />);
-    expect(wrapper.find('StudentSections').exists()).to.be.true;
+    assert(wrapper.find('StudentSections').exists());
   });
 
   it('renders a RecentCourses component', () => {
@@ -68,7 +68,7 @@ describe('TeacherHomepage', () => {
 
   it('shows ProjectWidgetWithData component', () => {
     const wrapper = shallow(<TeacherHomepage {...TEST_PROPS} />);
-    expect(wrapper.find('ProjectWidgetWithData').exists()).to.be.true;
+    assert(wrapper.find('ProjectWidgetWithData').exists());
   });
 
   it('shows the special announcement for English', () => {

--- a/apps/test/unit/templates/studioHomepages/TeacherHomepageTest.js
+++ b/apps/test/unit/templates/studioHomepages/TeacherHomepageTest.js
@@ -7,8 +7,17 @@ import TeacherSections from '@cdo/apps/templates/studioHomepages/TeacherSections
 import {courses, topCourse} from './homepagesTestData';
 
 describe('TeacherHomepage', () => {
-  let server;
+  const TEST_PROPS = {
+    announcements: [],
+    courses,
+    topCourse,
+    codeOrgUrlPrefix: 'http://localhost:3000',
+    joinedSections: [],
+    isEnglish: true,
+    showCensusBanner: false
+  };
 
+  let server;
   const successResponse = () => [
     200,
     {'Content-Type': 'application/json'},
@@ -115,5 +124,19 @@ describe('TeacherHomepage', () => {
       />
     );
     expect(wrapper.find('ProjectWidgetWithData').exists()).to.be.true;
+  });
+
+  it('shows the special announcement for English', () => {
+    const wrapper = shallow(
+      <TeacherHomepage {...TEST_PROPS} isEnglish={true} />
+    );
+    assert(wrapper.find('SpecialAnnouncement').exists());
+  });
+
+  it('does not show the special announcement for non-English', () => {
+    const wrapper = shallow(
+      <TeacherHomepage {...TEST_PROPS} isEnglish={false} />
+    );
+    assert.isFalse(wrapper.find('SpecialAnnouncement').exists());
   });
 });

--- a/apps/test/unit/templates/studioHomepages/TeacherHomepageTest.js
+++ b/apps/test/unit/templates/studioHomepages/TeacherHomepageTest.js
@@ -31,16 +31,7 @@ describe('TeacherHomepage', () => {
   afterEach(() => server.restore());
 
   it('shows a non-extended Header Banner that says My Dashboard', () => {
-    const wrapper = shallow(
-      <TeacherHomepage
-        announcements={[]}
-        courses={[]}
-        topCourse={topCourse}
-        joinedSections={[]}
-        isEnglish={true}
-        showCensusBanner={false}
-      />
-    );
+    const wrapper = shallow(<TeacherHomepage {...TEST_PROPS} />);
     const headerBanner = wrapper.find('Connect(HeaderBanner)');
     assert.deepEqual(headerBanner.props(), {
       headingText: 'My Dashboard',
@@ -49,58 +40,22 @@ describe('TeacherHomepage', () => {
   });
 
   it('references 2 ProtectedStatefulDivs', () => {
-    const wrapper = shallow(
-      <TeacherHomepage
-        announcements={[]}
-        courses={[]}
-        topCourse={topCourse}
-        joinedSections={[]}
-        isEnglish={true}
-        showCensusBanner={false}
-      />
-    );
+    const wrapper = shallow(<TeacherHomepage {...TEST_PROPS} />);
     expect(wrapper.find('ProtectedStatefulDiv')).to.have.length(2);
   });
 
   it('renders a TeacherSections component', () => {
-    const wrapper = shallow(
-      <TeacherHomepage
-        announcements={[]}
-        courses={[]}
-        topCourse={topCourse}
-        joinedSections={[]}
-        isEnglish={true}
-        showCensusBanner={false}
-      />
-    );
+    const wrapper = shallow(<TeacherHomepage {...TEST_PROPS} />);
     expect(wrapper).to.containMatchingElement(<TeacherSections />);
   });
 
   it('renders a StudentSections component', () => {
-    const wrapper = shallow(
-      <TeacherHomepage
-        announcements={[]}
-        courses={[]}
-        topCourse={topCourse}
-        joinedSections={[]}
-        isEnglish={true}
-        showCensusBanner={false}
-      />
-    );
+    const wrapper = shallow(<TeacherHomepage {...TEST_PROPS} />);
     expect(wrapper.find('StudentSections').exists()).to.be.true;
   });
 
   it('renders a RecentCourses component', () => {
-    const wrapper = shallow(
-      <TeacherHomepage
-        announcements={[]}
-        topCourse={topCourse}
-        courses={courses}
-        joinedSections={[]}
-        isEnglish={true}
-        showCensusBanner={false}
-      />
-    );
+    const wrapper = shallow(<TeacherHomepage {...TEST_PROPS} />);
     const recentCourses = wrapper.find('RecentCourses');
     assert.deepEqual(recentCourses.props(), {
       showAllCoursesLink: true,
@@ -112,17 +67,7 @@ describe('TeacherHomepage', () => {
   });
 
   it('shows ProjectWidgetWithData component', () => {
-    const wrapper = shallow(
-      <TeacherHomepage
-        announcements={[]}
-        courses={courses}
-        topCourse={topCourse}
-        codeOrgUrlPrefix="http://localhost:3000/"
-        joinedSections={[]}
-        isEnglish={true}
-        showCensusBanner={false}
-      />
-    );
+    const wrapper = shallow(<TeacherHomepage {...TEST_PROPS} />);
     expect(wrapper.find('ProjectWidgetWithData').exists()).to.be.true;
   });
 


### PR DESCRIPTION
[PLC-843](https://codedotorg.atlassian.net/browse/PLC-843): Logged-in homepage: Remove the big teal at-home callout box for all non-EN versions of the site.

Did a little test cleanup while I was in there.

## Testing story

Unit tests for new behavior, and manually checked on local.

| EN | non-EN |
| --- | --- |
|![image](https://user-images.githubusercontent.com/1615761/79396374-9d27a400-7f30-11ea-9d7d-53dfaeb35bb7.png) | ![image](https://user-images.githubusercontent.com/1615761/79396400-ab75c000-7f30-11ea-87f7-0bd66335db4e.png) |

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
