### PR TITLE
Move fake timers into local test scope

### DIFF
--- a/apps/test/unit/code-studio/pd/professional_learning_landing/EnrolledWorkshopsTest.jsx
+++ b/apps/test/unit/code-studio/pd/professional_learning_landing/EnrolledWorkshopsTest.jsx
@@ -21,14 +21,15 @@ describe('EnrolledWorkshops', () => {
   let clock;
 
   beforeEach(() => {
-    // By default, use normal time
-    clock = sinon.useFakeTimers(new Date());
     sinon.stub(utils, 'windowOpen');
   });
 
   afterEach(() => {
+    if (clock) {
+      clock.restore();
+      clock = undefined;
+    }
     utils.windowOpen.restore();
-    clock.restore();
   });
 
   it('Clicking cancel enrollment cancels the enrollment', () => {

--- a/apps/test/unit/lib/kits/maker/ui/EligibilityChecklistTest.js
+++ b/apps/test/unit/lib/kits/maker/ui/EligibilityChecklistTest.js
@@ -15,8 +15,12 @@ describe('EligibilityChecklist', () => {
     currentlyDistributingDiscountCodes: true
   };
 
-  // By default, use normal time
-  let clock = sinon.useFakeTimers(new Date());
+  let clock;
+
+  beforeEach(function() {
+    // By default, use normal time
+    clock = sinon.useFakeTimers(new Date());
+  });
 
   afterEach(function() {
     clock.restore();

--- a/apps/test/unit/lib/kits/maker/ui/EligibilityChecklistTest.js
+++ b/apps/test/unit/lib/kits/maker/ui/EligibilityChecklistTest.js
@@ -17,13 +17,11 @@ describe('EligibilityChecklist', () => {
 
   let clock;
 
-  beforeEach(function() {
-    // By default, use normal time
-    clock = sinon.useFakeTimers(new Date());
-  });
-
   afterEach(function() {
-    clock.restore();
+    if (clock) {
+      clock.restore();
+      clock = undefined;
+    }
   });
 
   it('renders a div if we have no discountCode', () => {

--- a/apps/test/unit/lib/kits/maker/util/discountLogicTest.js
+++ b/apps/test/unit/lib/kits/maker/util/discountLogicTest.js
@@ -34,8 +34,12 @@ describe('discountLogic.js', () => {
   });
 
   describe('inDiscountRedemptionWindow', () => {
-    // By default, use normal time
-    let clock = sinon.useFakeTimers(new Date());
+    let clock;
+
+    beforeEach(function() {
+      // By default, use normal time
+      clock = sinon.useFakeTimers(new Date());
+    });
 
     afterEach(function() {
       clock.restore();

--- a/apps/test/unit/lib/kits/maker/util/discountLogicTest.js
+++ b/apps/test/unit/lib/kits/maker/util/discountLogicTest.js
@@ -36,13 +36,11 @@ describe('discountLogic.js', () => {
   describe('inDiscountRedemptionWindow', () => {
     let clock;
 
-    beforeEach(function() {
-      // By default, use normal time
-      clock = sinon.useFakeTimers(new Date());
-    });
-
     afterEach(function() {
-      clock.restore();
+      if (clock) {
+        clock.restore();
+        clock = undefined;
+      }
     });
 
     it('yes if teaching CSD6 during spring 2020', () => {


### PR DESCRIPTION
In recent PR, we noted that a pattern used here (setting a fake timer outside of a `beforeEach`) will result in leaking state between tests. As a cleanup step, trying to remove other instances where I did the same thing.

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
