### PR TITLE
Use UTC always instead of device time in test helper

### DIFF
--- a/dashboard/test/test_helper.rb
+++ b/dashboard/test/test_helper.rb
@@ -322,7 +322,7 @@ class ActiveSupport::TestCase
   #     freeze_time
   #     #...
   def self.freeze_time(time=nil)
-    time ||= Date.today + 9.hours
+    time ||= Time.now.utc.to_date + 9.hours
     setup do
       Timecop.freeze time
     end


### PR DESCRIPTION
@uponthesun noted recently that a test using the `freeze_time` test helper failed when run on a device where the time wasn't UTC (eg, a developer laptop). This change updates `freeze_time` to freeze time in UTC.

## Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
