### PR TITLE
MicroBit Button - Remove reference to johnny five

### DIFF
--- a/apps/src/lib/kits/maker/Button.js
+++ b/apps/src/lib/kits/maker/Button.js
@@ -2,6 +2,7 @@
 import five from '@code-dot-org/johnny-five';
 import '../../../utils'; // For Function.prototype.inherits
 import {EXTERNAL_PINS} from './PlaygroundConstants';
+import {EventEmitter} from 'events';
 
 /**
  * Wrap Johnny-Five's Button component to add attributes and customize behavior.
@@ -41,4 +42,4 @@ export function MicroBitButton(board) {
     get: () => this.buttonEvents[1] > this.buttonEvents[2]
   });
 }
-MicroBitButton.inherits(five.Button);
+MicroBitButton.inherits(EventEmitter);

--- a/apps/test/unit/lib/kits/maker/ButtonTest.js
+++ b/apps/test/unit/lib/kits/maker/ButtonTest.js
@@ -9,6 +9,7 @@ import {
 } from '@cdo/apps/lib/kits/maker/Button';
 import {EXTERNAL_PINS} from '@cdo/apps/lib/kits/maker/PlaygroundConstants';
 import sinon from 'sinon';
+import {EventEmitter} from 'events';
 
 describe('PlaygroundButton', function() {
   it('is a johnny-five Button component', function() {
@@ -63,12 +64,12 @@ describe('PlaygroundButton', function() {
 });
 
 describe('MicroBitButton', function() {
-  it('is a johnny-five Button component', function() {
+  it('is an event emitter component', function() {
     const button = new MicroBitButton({
       mb: new MicrobitStubBoard(),
       pin: 0
     });
-    expect(button).to.be.an.instanceOf(five.Button);
+    expect(button).to.be.an.instanceOf(EventEmitter);
   });
 
   describe('isPressed', () => {

--- a/apps/test/unit/lib/kits/maker/MicroBitComponentsTest.js
+++ b/apps/test/unit/lib/kits/maker/MicroBitComponentsTest.js
@@ -6,7 +6,7 @@ import {
   enableMicroBitComponents
 } from '@cdo/apps/lib/kits/maker/MicroBitComponents';
 import {MicrobitStubBoard} from './makeStubBoard';
-import five from '@code-dot-org/johnny-five';
+import {EventEmitter} from 'events';
 import sinon from 'sinon';
 
 describe('MicroBit Components', () => {
@@ -42,8 +42,8 @@ describe('MicroBit Components', () => {
       );
     });
 
-    it('creates a five.Button', () => {
-      expect(buttonA).to.be.an.instanceOf(five.Button);
+    it('creates an EventEmitter', () => {
+      expect(buttonA).to.be.an.instanceOf(EventEmitter);
     });
 
     it('bound to the board controller', () => {
@@ -64,8 +64,8 @@ describe('MicroBit Components', () => {
       );
     });
 
-    it('creates a five.Button', () => {
-      expect(buttonB).to.be.an.instanceOf(five.Button);
+    it('creates an EventEmitter', () => {
+      expect(buttonB).to.be.an.instanceOf(EventEmitter);
     });
 
     it('bound to the board controller', () => {


### PR DESCRIPTION
MicroBit components should not reference johnny five. This was a hold-over from creating a board-specific version of buttons. Five.button inherits EventEmitter, so I replaced Five.Button with EventEmitter to remove playground specific side-effects.

## Links

- [spec]()
- [jira]()

## Testing story

<!--
  Does your change include appropriate tests?

  If so, please describe how the tests included in this PR are sufficient

  If not, please explain why this change does not need to be tested.
-->

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
