### PR TITLE
only retrieve the HEAD of an S3 object when checking for existence

### DIFF
--- a/lib/cdo/aws/s3.rb
+++ b/lib/cdo/aws/s3.rb
@@ -86,7 +86,7 @@ module AWS
     def self.exists_in_bucket(bucket, key)
       create_client.head_object(bucket: bucket, key: key)
       return true
-    rescue Aws::S3::Errors::NotFound
+    rescue Aws::S3::Errors::NotFound, Aws::S3::Errors::Forbidden
       return false
     end
 

--- a/lib/cdo/aws/s3.rb
+++ b/lib/cdo/aws/s3.rb
@@ -84,9 +84,9 @@ module AWS
     # @param [String] key
     # @return [Boolean]
     def self.exists_in_bucket(bucket, key)
-      create_client.get_object(bucket: bucket, key: key)
+      create_client.head_object(bucket: bucket, key: key)
       return true
-    rescue Aws::S3::Errors::NoSuchKey
+    rescue Aws::S3::Errors::NotFound
       return false
     end
 

--- a/shared/test/fixtures/vcr/awss3integration/s3_presigned_url_delete-get_deleted.yml
+++ b/shared/test/fixtures/vcr/awss3integration/s3_presigned_url_delete-get_deleted.yml
@@ -1,7 +1,7 @@
 ---
 http_interactions:
 - request:
-    method: get
+    method: head
     uri: https://cdo-temp.s3.amazonaws.com/test-delete-key
     body:
       encoding: UTF-8
@@ -11,22 +11,20 @@ http_interactions:
       - '0'
   response:
     status:
-      code: 404
-      message: Not Found
+      code: 403
+      message: Forbidden
     headers:
       Content-Type:
       - application/xml
       Transfer-Encoding:
       - chunked
       Date:
-      - Sat, 29 Sep 2018 00:35:21 GMT
+      - Fri, 17 Apr 2020 18:44:37 GMT
       Server:
       - AmazonS3
     body:
       encoding: UTF-8
-      string: |-
-        <?xml version="1.0" encoding="UTF-8"?>
-        <Error><Code>NoSuchKey</Code><Message>The specified key does not exist.</Message><Key>test-delete-key</Key><RequestId>0EF6E9B152CDD81D</RequestId><HostId>NHNu28W8mdR/9JmaSuCSVyx+XcAeF4OrHggjVWlC0UFGCi/2iochmnAmxqj9KVypvTUZUBHDNN0=</HostId></Error>
+      string: ''
     http_version: 
-  recorded_at: Sat, 29 Sep 2018 00:35:21 GMT
+  recorded_at: Fri, 17 Apr 2020 18:44:38 GMT
 recorded_with: VCR 3.0.3


### PR DESCRIPTION
rather than the complete data

Should significantly speed up the method, which will in turn have a significant impact on the speed of the `update_tts_i18n` script.

<!--
  Your description goes here: A summary of the change, including any relevant motivation and context.

  If relevant, include a description both of the existing behavior and of the new behavior.
-->

<!--
  Other aspects to consider. uncomment and add detail for any that seem necessary:
-->

<!-- ### Background -->
<!-- ### Privacy -->
<!-- ### Security -->
<!-- ### Caching -->
<!-- ### Deployment strategy -->
<!-- ### Future work -->

## Links

<!--
  Any relevant links to external resources; ie, specification documents, jira
  items, related PRs, honeybadger errors, etc
-->

- [jira](https://codedotorg.atlassian.net/browse/FND-1118)

## Testing story

<!--
  Does your change include appropriate tests?

  If so, please describe how the tests included in this PR are sufficient

  If not, please explain why this change does not need to be tested.
-->

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
