### PR TITLE
Add donate link to homepage

### DIFF
--- a/pegasus/src/homepage.rb
+++ b/pegasus/src/homepage.rb
@@ -302,8 +302,8 @@ class Homepage
                 url: "/yourschool"
               },
               {
-                text: "homepage_slot_text_link_shop",
-                url: "/shop"
+                text: "homepage_slot_text_link_donate",
+                url: "https://donate.code.org/give/172233/#!/donation/checkout"
               }
             ]
         }


### PR DESCRIPTION
[PLC-853](https://codedotorg.atlassian.net/browse/PLC-853): On the homepage: On the Get Involved tile, change the "T-shirts, hats, & more" option to "Donate", and have it linked directly to https://donate.code.org/give/172233/#!/donation/checkout

![Screenshot from 2020-04-16 16-41-22](https://user-images.githubusercontent.com/1615761/79516904-93ba3c80-8001-11ea-93c5-f30f6707418a.png)

Note, I'm using an existing i18n string that we already had, right alongside the existing one:

https://github.com/code-dot-org/code-dot-org/blob/66d9d42955ad2d453b1fd9691c5e311bb99ba462/pegasus/cache/i18n/en-US.yml#L385-L386

## Testing story

Checked on local server.

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
