### PR TITLE
Download Pardot prospect data

### DIFF
--- a/dashboard/app/models/contact_rollups_pardot_memory.rb
+++ b/dashboard/app/models/contact_rollups_pardot_memory.rb
@@ -26,9 +26,12 @@ require 'cdo/contact_rollups/v2/pardot'
 class ContactRollupsPardotMemory < ApplicationRecord
   self.table_name = 'contact_rollups_pardot_memory'
 
-  # Retrieves new email-Pardot ID mappings from Pardot and saves them to the database.
-  # @param [Integer, nil] last_id retrieves only Pardot ID greater than this value
-  def self.add_and_update_pardot_ids(last_id = nil, limit = nil)
+  # Downloads and saves new email-Pardot ID mappings from Pardot.
+  # *Warning:* This method overwrites existing data.
+  #
+  # @param [Integer] last_id retrieves only Pardot ID greater than this value
+  # @param [Integer] limit the maximum number of Pardot prospects to download
+  def self.download_pardot_ids(last_id = nil, limit = nil)
     last_id ||= ContactRollupsPardotMemory.maximum(:pardot_id) || 0
     fields = %w(id email)
 
@@ -36,8 +39,8 @@ class ContactRollupsPardotMemory < ApplicationRecord
       current_time = Time.now.utc
       batch = prospects.map do |item|
         {
-          pardot_id: item['id'].to_i,
           email: item['email'],
+          pardot_id: item['id'].to_i,
           pardot_id_updated_at: current_time
         }
       end

--- a/dashboard/app/models/contact_rollups_pardot_memory.rb
+++ b/dashboard/app/models/contact_rollups_pardot_memory.rb
@@ -48,6 +48,30 @@ class ContactRollupsPardotMemory < ApplicationRecord
     end
   end
 
+  def self.seed_data_from_pardot(last_id = nil, limit = nil)
+    last_id ||= ContactRollupsPardotMemory.maximum(:pardot_id) || 0
+    fields = %w(
+      id
+      email
+      db_Opt_In
+      db_State
+      db_Country
+      db_Roles
+      db_Has_Teacher_Account
+      db_Hour_of_Code_Organizer
+      db_Form_Roles
+      db_Forms_Submitted
+      db_City
+      db_Postal_Code
+      db_Professional_Learning_Attended
+      db_Professional_Learning_Enrolled
+    )
+
+    PardotV2.retrieve_prospects(last_id, fields, limit) do |prospects|
+      prospects.each {|prospect| puts prospect}
+    end
+  end
+
   def self.create_new_pardot_prospects
     # Adds contacts to a batch and then sends batch requests to create new Pardot prospects.
     # Requests may not be sent immediately until batch size is big enough.

--- a/dashboard/lib/contact_rollups_v2.rb
+++ b/dashboard/lib/contact_rollups_v2.rb
@@ -19,7 +19,7 @@ class ContactRollupsV2
     end
 
     log_collector.time!('Downloads new email-Pardot ID mappings') do
-      ContactRollupsPardotMemory.add_and_update_pardot_ids
+      ContactRollupsPardotMemory.download_pardot_ids
     end
     log_collector.time!('Creates new Pardot prospects') do
       ContactRollupsPardotMemory.create_new_pardot_prospects

--- a/dashboard/lib/contact_rollups_v2.rb
+++ b/dashboard/lib/contact_rollups_v2.rb
@@ -28,7 +28,7 @@ class ContactRollupsV2
       ContactRollupsPardotMemory.update_pardot_prospects
     end
     log_collector.time!('Downloads new email-Pardot ID mappings (again)') do
-      ContactRollupsPardotMemory.add_and_update_pardot_ids
+      ContactRollupsPardotMemory.download_pardot_ids
     end
 
     log_collector.time!("Overwrites contact_rollups_final table") do

--- a/dashboard/test/lib/contact_rollups_v2_test.rb
+++ b/dashboard/test/lib/contact_rollups_v2_test.rb
@@ -17,16 +17,16 @@ class ContactRollupsV2Test < ActiveSupport::TestCase
     ContactRollupsFinal.delete_all
   end
 
-  test 'Sync new contact' do
+  test 'sync new contact' do
     # Create seed data in a source table
     email = 'test@domain.com'
     create :email_preference, email: email, opt_in: true
 
     # Stub out Pardot responses
     pardot_id = 1
-    PardotV2.stubs(:retrieve_new_ids).
+    PardotV2.stubs(:retrieve_prospects).
       yields([]).
-      then.yields([{email: email, pardot_id: pardot_id}])
+      then.yields([{'id' => pardot_id, 'email' => email}])
     PardotV2.stubs(:submit_batch_request).once.returns([])
 
     # Execute the pipeline
@@ -43,7 +43,7 @@ class ContactRollupsV2Test < ActiveSupport::TestCase
     assert_equal true, contact_record.data['opt_in']
   end
 
-  test 'Sync updated contact' do
+  test 'sync updated contact' do
     # Create seed data
     email = 'test@domain.com'
     base_time = Time.now.utc
@@ -57,7 +57,7 @@ class ContactRollupsV2Test < ActiveSupport::TestCase
       data_synced_at: base_time - 1.day
 
     # Stub out Pardot responses
-    PardotV2.stubs(:retrieve_new_ids).twice.yields([])
+    PardotV2.stubs(:retrieve_prospects).twice.yields([])
     PardotV2.stubs(:submit_batch_request).once.returns([])
 
     # Execute the pipeline

--- a/dashboard/test/models/contact_rollups_pardot_memory_test.rb
+++ b/dashboard/test/models/contact_rollups_pardot_memory_test.rb
@@ -2,9 +2,11 @@ require 'test_helper'
 require 'cdo/contact_rollups/v2/pardot'
 
 class ContactRollupsPardotMemoryTest < ActiveSupport::TestCase
-  test 'download_pardot_ids inserts new mappings' do
+  setup do
     assert_equal 0, ContactRollupsPardotMemory.count
+  end
 
+  test 'download_pardot_ids inserts new mappings' do
     new_mappings = [
       {'id' => '1', 'email' => 'alex@rollups.com'},
       {'id' => '2', 'email' => 'becky@rollups.com'}
@@ -22,8 +24,6 @@ class ContactRollupsPardotMemoryTest < ActiveSupport::TestCase
   end
 
   test 'download_pardot_ids updates existing mappings' do
-    assert_equal 0, ContactRollupsPardotMemory.count
-
     email = 'test@domain.com'
     base_time = Time.now.utc - 1.day
     create :contact_rollups_pardot_memory,
@@ -64,7 +64,6 @@ class ContactRollupsPardotMemoryTest < ActiveSupport::TestCase
   end
 
   test 'query_new_contacts' do
-    assert_equal 0, ContactRollupsPardotMemory.count
     assert_equal 0, ContactRollupsProcessed.count
 
     pardot_memory_records = [
@@ -91,7 +90,6 @@ class ContactRollupsPardotMemoryTest < ActiveSupport::TestCase
   end
 
   test 'create_new_pardot_prospects' do
-    assert_equal 0, ContactRollupsPardotMemory.count
     assert_equal 0, ContactRollupsProcessed.count
     contact = create :contact_rollups_processed, data: {'opt_in' => true}
 
@@ -105,7 +103,6 @@ class ContactRollupsPardotMemoryTest < ActiveSupport::TestCase
   end
 
   test 'query_updated_contacts' do
-    assert_equal 0, ContactRollupsPardotMemory.count
     assert_equal 0, ContactRollupsProcessed.count
 
     base_time = Time.now.utc - 2.days
@@ -181,8 +178,6 @@ class ContactRollupsPardotMemoryTest < ActiveSupport::TestCase
   end
 
   test 'save_sync_results new prospect' do
-    assert_equal 0, ContactRollupsPardotMemory.count
-
     submission = {email: 'valid@domain.com', db_Opt_In: 'Yes'}
     submitted_time = Time.now.utc
 
@@ -197,7 +192,6 @@ class ContactRollupsPardotMemoryTest < ActiveSupport::TestCase
   end
 
   test 'save_sync_results updated prospects' do
-    assert_equal 0, ContactRollupsPardotMemory.count
     pardot_memory_records = [
       {email: 'alpha', pardot_id: 1, data_synced: nil},
       {email: 'beta', pardot_id: 2, data_synced: {db_Opt_In: 'No'}},
@@ -225,8 +219,6 @@ class ContactRollupsPardotMemoryTest < ActiveSupport::TestCase
   end
 
   test 'save_sync_results rejected contact' do
-    assert_equal 0, ContactRollupsPardotMemory.count
-
     submission = {email: 'invalid_email', id: nil, db_Opt_In: 'No'}
     errors = [{prospect_index: 0, error_msg: PardotHelpers::ERROR_INVALID_EMAIL}]
     submitted_time = Time.now.utc

--- a/dashboard/test/models/contact_rollups_pardot_memory_test.rb
+++ b/dashboard/test/models/contact_rollups_pardot_memory_test.rb
@@ -2,7 +2,7 @@ require 'test_helper'
 require 'cdo/contact_rollups/v2/pardot'
 
 class ContactRollupsPardotMemoryTest < ActiveSupport::TestCase
-  test 'add_and_update_pardot_ids inserts new mappings' do
+  test 'download_pardot_ids inserts new mappings' do
     assert_equal 0, ContactRollupsPardotMemory.count
 
     new_mappings = [
@@ -11,7 +11,7 @@ class ContactRollupsPardotMemoryTest < ActiveSupport::TestCase
     ]
     PardotV2.stubs(:retrieve_prospects).once.yields(new_mappings)
 
-    ContactRollupsPardotMemory.add_and_update_pardot_ids
+    ContactRollupsPardotMemory.download_pardot_ids
 
     new_mappings.each do |mapping|
       refute_nil ContactRollupsPardotMemory.
@@ -21,7 +21,7 @@ class ContactRollupsPardotMemoryTest < ActiveSupport::TestCase
     end
   end
 
-  test 'add_and_update_pardot_ids updates existing mappings' do
+  test 'download_pardot_ids updates existing mappings' do
     assert_equal 0, ContactRollupsPardotMemory.count
 
     email = 'test@domain.com'
@@ -35,7 +35,7 @@ class ContactRollupsPardotMemoryTest < ActiveSupport::TestCase
       once.
       yields([{'id' => '2', 'email' => email}])
 
-    ContactRollupsPardotMemory.add_and_update_pardot_ids
+    ContactRollupsPardotMemory.download_pardot_ids
 
     refute_nil ContactRollupsPardotMemory.
       where(email: email, pardot_id: 2).

--- a/dashboard/test/models/contact_rollups_pardot_memory_test.rb
+++ b/dashboard/test/models/contact_rollups_pardot_memory_test.rb
@@ -43,6 +43,26 @@ class ContactRollupsPardotMemoryTest < ActiveSupport::TestCase
       first
   end
 
+  test 'download_pardot_prospects' do
+    prospects = [
+      {'id' => '1', 'email' => 'alex@rollups.com', 'db_Opt_In' => 'Yes'},
+      {'id' => '2', 'email' => 'beta@rollups.com', 'db_City' => 'Seattle'},
+    ]
+    PardotV2.stubs(:retrieve_prospects).once.yields(prospects)
+
+    ContactRollupsPardotMemory.download_pardot_prospects
+
+    prospects.each do |prospect|
+      record = ContactRollupsPardotMemory.
+        find_by(email: prospect['email'], pardot_id: prospect['id'].to_i)
+
+      refute_nil record
+      refute_nil record.pardot_id_updated_at
+      refute_nil record.data_synced_at
+      assert_equal prospect.except('email', 'id'), record.data_synced
+    end
+  end
+
   test 'query_new_contacts' do
     assert_equal 0, ContactRollupsPardotMemory.count
     assert_equal 0, ContactRollupsProcessed.count

--- a/lib/cdo/contact_rollups/v2/pardot.rb
+++ b/lib/cdo/contact_rollups/v2/pardot.rb
@@ -29,7 +29,7 @@ class PardotV2
   # @param [Integer] limit maximum number of prospects to retrieve
   # @return [Integer] number of results retrieved
   #
-  # @yieldreturn [Array<Hash>] an array of hash {email, id}
+  # @yieldreturn [Array<Hash>] an array of hash of prospect data
   # @raise [ArgumentError] if 'id' is not in the list of fields
   # @raise [StandardError] if receives errors in Pardot response
   def self.retrieve_prospects(last_id, fields, limit = nil)

--- a/lib/cdo/contact_rollups/v2/pardot.rb
+++ b/lib/cdo/contact_rollups/v2/pardot.rb
@@ -45,6 +45,8 @@ class PardotV2
 
       # Pardot returns the count total available prospects (not capped to 200),
       # although the data for a max of 200 are contained in the response.
+      # The total prospects count changes in each loop iteration because the url we
+      # send to Pardot also changes.
       # @see http://developer.pardot.com/kb/api-version-4/prospects/#xml-response-format
       total_results = doc.xpath('/rsp/result/total_results').text.to_i
 

--- a/lib/cdo/contact_rollups/v2/pardot.rb
+++ b/lib/cdo/contact_rollups/v2/pardot.rb
@@ -24,14 +24,14 @@ class PardotV2
 
   # Retrieves new (email, Pardot ID) mappings from Pardot
   #
+  # @param [Integer] last_id retrieves only Pardot ID greater than this value
+  # @param [Array<String>] a list of fields. Must have 'id' the list. Field names must be url-safe.
+  # @param [Integer] limit maximum number of prospects to retrieve
+  # @return [Integer] number of results retrieved
+  #
   # @yieldreturn [Array<Hash>] an array of hash {email, id}
   # @raise [ArgumentError] if 'id' is not in the list of fields
   # @raise [StandardError] if receives errors in Pardot response
-  #
-  # @param [Integer] last_id retrieves only Pardot ID greater than this value
-  # @param [Array<String>] a list of fields. Must have 'id' the list.
-  # @param [Integer] limit maximum number of prospects to retrieve
-  # @return [Integer] number of results retrieved
   def self.retrieve_prospects(last_id, fields, limit = nil)
     raise ArgumentError.new("Missing value 'id' in fields argument") unless fields.include? 'id'
     total_results_retrieved = 0
@@ -65,9 +65,10 @@ class PardotV2
       yield prospects if block_given?
       log "Retrieved #{results_in_response}/#{total_results} new Pardot IDs. Last Pardot ID = #{last_id}."
 
-      # Stop if all the remaining results were in this response
+      # Stop if all the remaining results were in this response or we reached the download limit.
       total_results_retrieved += results_in_response
-      break if results_in_response == total_results || total_results_retrieved >= limit
+      break if results_in_response == total_results ||
+        (limit && total_results_retrieved >= limit)
     end
 
     total_results_retrieved

--- a/lib/test/cdo/contact_rollups/test_pardot_v2.rb
+++ b/lib/test/cdo/contact_rollups/test_pardot_v2.rb
@@ -2,7 +2,7 @@ require_relative '../../test_helper'
 require 'cdo/contact_rollups/v2/pardot'
 
 class PardotV2Test < Minitest::Test
-  def test_retrieve_new_ids_without_result
+  def test_retrieve_prospects_without_result
     pardot_response = Nokogiri::XML <<-XML
       <rsp stat="ok">
         <result>
@@ -13,15 +13,15 @@ class PardotV2Test < Minitest::Test
     PardotV2.stubs(:post_with_auth_retry).once.returns(pardot_response)
 
     yielded_result = nil
-    result = PardotV2.retrieve_new_ids(0) {|mappings| yielded_result = mappings}
+    result = PardotV2.retrieve_prospects(0, ['id']) {|mappings| yielded_result = mappings}
 
     assert_equal 0, result
     assert_equal [], yielded_result
   end
 
-  def test_retrieve_new_ids_with_result
-    pardot_id = 1
-    email = "alex@rollups.com"
+  def test_retrieve_prospects_with_result
+    pardot_id = '1'
+    email = 'alex@rollups.com'
     pardot_response = Nokogiri::XML <<-XML
       <rsp stat="ok">
         <result>
@@ -36,10 +36,10 @@ class PardotV2Test < Minitest::Test
     PardotV2.stubs(:post_with_auth_retry).once.returns(pardot_response)
 
     yielded_result = nil
-    result = PardotV2.retrieve_new_ids(0) {|mappings| yielded_result = mappings}
+    result = PardotV2.retrieve_prospects(0, %w(id email)) {|mappings| yielded_result = mappings}
 
     assert_equal 1, result
-    assert_equal [{email: email, pardot_id: pardot_id}], yielded_result
+    assert_equal [{'id' => pardot_id, 'email' => email}], yielded_result
   end
 
   def test_batch_create_prospects_single_contact


### PR DESCRIPTION
[PLC-838](https://codedotorg.atlassian.net/browse/PLC-838): Downloading Pardot prospect data to use as seeds for contact roll-ups pipeline.

### How to read this PR
_(or Travel guide in contact roll-ups town)_

- Starts at `contact_rollups_pardot_memory.rb` 
  - `download_pardot_prospects` method: Downloads Pardot prospects and saves them to ContactRollupsPardotMemory. It has a list of 12 specific fields we want.
  - `download_pardot_ids` method (previously _add_and_update_pardot_ids_): Downloads only new Pardot IDs, no prospect data.

- Then goes to `pardot.rb`
  - `retrieve_prospects` method (previously _retrieve_new_ids_): Sends request to Pardot to retrieve prospect data, parses the response and yields the results back to the caller. Used by the 2 functions mentioned in `contact_rollups_pardot_memory.rb`.

- Then goes to test file `contact_rollups_pardot_memory_test.rb `
  - It adds a new test for `download_pardot_prospects` method and move common test pre-condition to a `setup` block.

Other changes are minor.

### Background
Contact roll-ups pipeline doesn't know what data is already in Pardot. Thus, every time we add a contact attribute to the pipeline, it will send million of updates to Pardot even though that data may already exist there. 

The solution is to do a 1-time download of all data from Pardot and seed them into the pipeline. Then when we add new attributes, only actual data changes will trigger Pardot updates.

### Deployment strategy
Manually execute download command in production as described in the manual test below.

### Testing story
- Manual test from Rails console sandbox (`bin/rails c --sandbox`)
  ```ruby
  require 'cdo/contact_rollups/v2/pardot'
  ContactRollupsPardotMemory.count  # should be 0

  # Download the 2 first prospects
  ContactRollupsPardotMemory.download_pardot_prospects(nil, 2)
  # Download 3 prospects with IDs greater than a certain number
  ContactRollupsPardotMemory.download_pardot_prospects(50848578, 3)

  ContactRollupsPardotMemory.count  # should be 5
  ```

- Unit tests
  - From dashboard: `bundle exec rails test test/models/contact_rollups_pardot_memory_test.rb`
  - From repo root: `bundle exec ruby -Ilib:test lib/test/cdo/contact_rollups/test_pardot_v2.rb`

## Reviewer Checklist:
- [ ] Tests provide adequate coverage
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
