### PR TITLE
[Spritelab] Add isTouchingSprite and bounceOff blocks

### DIFF
--- a/apps/src/p5lab/spritelab/commands.js
+++ b/apps/src/p5lab/spritelab/commands.js
@@ -50,6 +50,10 @@ export const commands = {
     return actionCommands.isTouchingEdges.apply(this, [spriteArg]);
   },
 
+  isTouchingSprite(spriteArg, targetArg) {
+    return actionCommands.isTouchingSprite(spriteArg, targetArg);
+  },
+
   jumpTo(spriteArg, location) {
     actionCommands.jumpTo(spriteArg, location);
   },

--- a/apps/src/p5lab/spritelab/commands.js
+++ b/apps/src/p5lab/spritelab/commands.js
@@ -38,6 +38,9 @@ export const commands = {
   },
 
   // Action commands
+  bounceOff(spriteArg, targetArg) {
+    actionCommands.bounceOff(spriteArg, targetArg);
+  },
   changePropBy(spriteArg, prop, val) {
     actionCommands.changePropBy(spriteArg, prop, val);
   },

--- a/apps/src/p5lab/spritelab/commands/actionCommands.js
+++ b/apps/src/p5lab/spritelab/commands/actionCommands.js
@@ -2,6 +2,23 @@ import * as coreLibrary from '../coreLibrary';
 import {commands as behaviorCommands} from './behaviorCommands';
 
 export const commands = {
+  bounceOff(spriteArg, targetArg) {
+    let sprites = coreLibrary.getSpriteArray(spriteArg);
+    let targets = coreLibrary.getSpriteArray(targetArg);
+    sprites.forEach(sprite => {
+      targets.forEach(target => {
+        if (sprite.isTouching(target)) {
+          sprite.direction = (sprite.direction + 180) % 360;
+          target.direction = (target.direction + 180) % 360;
+          sprite.x += 1 * Math.cos((sprite.direction * Math.PI) / 180);
+          sprite.y += 1 * Math.sin((sprite.direction * Math.PI) / 180);
+          target.x += 1 * Math.cos((target.direction * Math.PI) / 180);
+          target.y += 1 * Math.sin((target.direction * Math.PI) / 180);
+        }
+      });
+    });
+  },
+
   changePropBy(spriteArg, prop, val) {
     if (val === undefined || prop === undefined) {
       return;
@@ -47,9 +64,6 @@ export const commands = {
   },
 
   isTouchingSprite(spriteArg, targetArg) {
-    if (!spriteArg || !targetArg) {
-      return false;
-    }
     let sprites = coreLibrary.getSpriteArray(spriteArg);
     let targets = coreLibrary.getSpriteArray(targetArg);
     let touching = false;

--- a/apps/src/p5lab/spritelab/commands/actionCommands.js
+++ b/apps/src/p5lab/spritelab/commands/actionCommands.js
@@ -45,6 +45,23 @@ export const commands = {
     });
     return touching;
   },
+
+  isTouchingSprite(spriteArg, targetArg) {
+    if (!spriteArg || !targetArg) {
+      return false;
+    }
+    let sprites = coreLibrary.getSpriteArray(spriteArg);
+    let targets = coreLibrary.getSpriteArray(targetArg);
+    let touching = false;
+    sprites.forEach(sprite => {
+      targets.forEach(target => {
+        if (sprite.isTouching(target)) {
+          touching = true;
+        }
+      });
+    });
+    return touching;
+  },
   jumpTo(spriteArg, location) {
     if (!location) {
       return;

--- a/apps/src/p5lab/spritelab/coreLibrary.js
+++ b/apps/src/p5lab/spritelab/coreLibrary.js
@@ -23,6 +23,9 @@ export function reset() {
  * the specified id/name, or a list containing all sprites with the specified animation.
  */
 export function getSpriteArray(spriteArg) {
+  if (!spriteArg) {
+    return [];
+  }
   if (spriteArg.hasOwnProperty('id')) {
     let sprite = nativeSpriteMap[spriteArg.id];
     if (sprite) {

--- a/apps/test/unit/spritelab/actionCommandsTest.js
+++ b/apps/test/unit/spritelab/actionCommandsTest.js
@@ -12,6 +12,38 @@ describe('Action Commands', () => {
     makeSprite = spriteCommands.makeSprite.bind(p5Wrapper.p5);
   });
 
+  describe('bounceOff', () => {
+    it('changes direction if sprites are touching', () => {
+      makeSprite({name: 'spriteName1', location: {x: 200, y: 200}});
+      commands.changePropBy({name: 'spriteName1'}, 'direction', 180);
+      makeSprite({name: 'spriteName2', location: {x: 200, y: 200}});
+      commands.bounceOff({name: 'spriteName1'}, {name: 'spriteName2'});
+      expect(
+        spriteCommands.getProp({name: 'spriteName1'}, 'direction')
+      ).to.equal(0);
+      expect(spriteCommands.getProp({name: 'spriteName1'}, 'x')).to.equal(201);
+      expect(
+        spriteCommands.getProp({name: 'spriteName2'}, 'direction')
+      ).to.equal(180);
+      expect(spriteCommands.getProp({name: 'spriteName2'}, 'x')).to.equal(199);
+    });
+
+    it('does not change direction if sprites are not touching', () => {
+      makeSprite({name: 'spriteName1', location: {x: 0, y: 0}});
+      commands.changePropBy({name: 'spriteName1'}, 'direction', 180);
+      makeSprite({name: 'spriteName2', location: {x: 400, y: 400}});
+      commands.bounceOff({name: 'spriteName1'}, {name: 'spriteName2'});
+      expect(
+        spriteCommands.getProp({name: 'spriteName1'}, 'direction')
+      ).to.equal(180);
+      expect(spriteCommands.getProp({name: 'spriteName1'}, 'x')).to.equal(0);
+      expect(
+        spriteCommands.getProp({name: 'spriteName2'}, 'direction')
+      ).to.equal(0);
+      expect(spriteCommands.getProp({name: 'spriteName2'}, 'x')).to.equal(400);
+    });
+  });
+
   it('changePropBy', () => {
     makeSprite({name: spriteName, location: {x: 123, y: 321}});
     commands.changePropBy({name: spriteName}, 'x', 100);
@@ -29,6 +61,19 @@ describe('Action Commands', () => {
     expect(spriteCommands.getProp({name: spriteName}, 'direction')).to.equal(
       40
     );
+  });
+
+  it('isTouchingSprite', () => {
+    makeSprite({name: 'spriteName1', location: {x: 0, y: 0}});
+    makeSprite({name: 'spriteName2', location: {x: 200, y: 200}});
+    makeSprite({name: 'spriteName3', location: {x: 200, y: 200}});
+
+    expect(
+      commands.isTouchingSprite({name: 'spriteName1'}, {name: 'spriteName2'})
+    ).to.be.false;
+    expect(
+      commands.isTouchingSprite({name: 'spriteName3'}, {name: 'spriteName2'})
+    ).to.be.true;
   });
 
   it('jumpTo', () => {

--- a/dashboard/config/blocks/GamelabJr/gamelab_bounceOff.json
+++ b/dashboard/config/blocks/GamelabJr/gamelab_bounceOff.json
@@ -1,0 +1,22 @@
+{
+  "category": "Sprites",
+  "config": {
+    "color": [
+      184,
+      1,
+      0.74
+    ],
+    "func": "bounceOff",
+    "blockText": "{SPRITE} bounces off {TARGET}",
+    "args": [
+      {
+        "name": "SPRITE",
+        "type": "Sprite"
+      },
+      {
+        "name": "TARGET",
+        "type": "Sprite"
+      }
+    ]
+  }
+}

--- a/dashboard/config/blocks/GamelabJr/gamelab_isTouchingSprite.json
+++ b/dashboard/config/blocks/GamelabJr/gamelab_isTouchingSprite.json
@@ -1,0 +1,23 @@
+{
+  "category": "Logic",
+  "config": {
+    "func": "isTouchingSprite",
+    "blockText": "{SPRITE} is touching {TARGET}",
+    "args": [
+      {
+        "name": "SPRITE",
+        "type": "Sprite"
+      },
+      {
+        "name": "TARGET",
+        "type": "Sprite"
+      }
+    ],
+    "returnType": "Boolean",
+    "color": [
+      197,
+      0.88,
+      0.78
+    ]
+  }
+}


### PR DESCRIPTION
Pair programmed with @JillianK
These two blocks will be used for the upcoming codebreak.
![image](https://user-images.githubusercontent.com/8787187/79590728-577fee00-808c-11ea-9994-d7d6130abe58.png)
![image](https://user-images.githubusercontent.com/8787187/79590749-5d75cf00-808c-11ea-820a-2bb0332674ec.png)


<!-- ### Background -->
<!-- ### Privacy -->
<!-- ### Security -->
<!-- ### Caching -->
<!-- ### Deployment strategy -->
<!-- ### Future work -->

## Testing story
Unit tests for the two new functions. 

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
