### PR TITLE
Sentence-case the Teach page hero heading

### DIFF
--- a/apps/i18n/common/en_us.json
+++ b/apps/i18n/common/en_us.json
@@ -373,7 +373,7 @@
   "coursesLearnHeroSubHeading": "{studentsCount} million students have learned on Code.org!",
   "coursesTeachHeroButton": "Get started",
   "coursesTeachHeroDescription": "More than one million teachers have brought CS to their students using Code.org. We make it easy, no matter your background. ",
-  "coursesTeachHeroHeading": "You Can Teach Computer Science",
+  "coursesTeachHeroHeading": "You can teach computer science",
   "coursesTeachHeroSubHeading": "You don't have to be a software developer to teach computer science.",
   "courseOverviewVersionLabel": "Version:",
   "create": "Create",


### PR DESCRIPTION
> Hey Brad,
> 
> Small thing, and this may have been a communication error on my part. On the [new header copy](https://github.com/code-dot-org/code-dot-org/pull/34269) for the student and teacher versions of /courses. The student version is sentence style "Anyone can learn computer science," while the teacher version is camel case, "You Can Teach Computer Science". Can we make the teacher version sentence-style-- "You can teach computer science"
> 
> Not urgent. 
> 
> Thank you!
> 
> Eric

:+1: :rocket: 