### PR TITLE
Add api.uclassify.com to allow list

### DIFF
--- a/dashboard/app/controllers/xhr_proxy_controller.rb
+++ b/dashboard/app/controllers/xhr_proxy_controller.rb
@@ -44,6 +44,7 @@ class XhrProxyController < ApplicationController
     api.spotify.com
     api.themoviedb.org
     api.thingspeak.com
+    api.uclassify.com
     api.zippopotam.us
     atlas.media.mit.edu
     bible-api.com


### PR DESCRIPTION
Add `api.uclassify.com` API to allow list, based on [this Zendesk request](https://codeorg.zendesk.com/agent/tickets/275993)

Here is the [uClassify API documentation](https://www.uclassify.com/docs) (it's a "free text classification" tool to teach introductory machine learning/classification).