### PR TITLE
Fix 20-hour tile on legacy intl courses page

### DIFF
--- a/apps/src/templates/studioHomepages/CourseBlocks.jsx
+++ b/apps/src/templates/studioHomepages/CourseBlocks.jsx
@@ -129,7 +129,7 @@ class CourseBlocksCsfLegacy extends Component {
     $('#course4')
       .appendTo(ReactDOM.findDOMNode(this.refs.course4))
       .show();
-    $('#twenty_hour')
+    $('#20-hour')
       .appendTo(ReactDOM.findDOMNode(this.refs.twenty_hour))
       .show();
     $('#unplugged')


### PR DESCRIPTION
While working on broader changes to the international versions of the [`/courses`](https://studio.code.org/courses) page, found a small bug worth fixing on its own: The 20-hour course tile was not appearing.

| Before | After |
| --- | --- |
| ![before](https://user-images.githubusercontent.com/1615761/79619275-443b4580-80c1-11ea-929c-1394f69288c7.png) | ![after](https://user-images.githubusercontent.com/1615761/79619276-46050900-80c1-11ea-8199-46eae8793461.png) |

The bug is that we were trying to pull the tile out of the DOM by the selector `#twenty_hour` instead of its real script_constants name, `#20-hour`:

https://github.com/code-dot-org/code-dot-org/blob/f9692bff8379849e9ce5a7c346a772f49f0737b2/lib/cdo/script_constants.rb#L223

Checked on local machine.  To get into this situation you must view `/courses` in a language that does not yet have the newer CSF courses (A-F, Express, and pre-Express) translated; French is one such language.  Testing other languages locally requires that you set `load_locales: true` in your locals.yml and test in a private browsing window.

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
