### PR TITLE
Redesign the international courses page

### DIFF
--- a/apps/i18n/common/en_us.json
+++ b/apps/i18n/common/en_us.json
@@ -842,6 +842,8 @@
   "inProgress": "In progress",
   "inspireStudents": "Inspire students",
   "instructions": "Instructions",
+  "intlAnnouncementSpecial2020Body": "Students can continue to learn at home while schools are closed. Take a Code Break with us, or see resources for students, parents, and teachers - including videos, fun tutorials, and projects! Most options only available in English.",
+  "intlAnnouncementSpecial2020Heading": "More resources for learning at home",
   "invalidDataEntryTypeError": "Value must be boolean, number, string, `undefined`, or `null`. Make sure to include quotes for strings like \"this\". ",
   "invalidRecordTypeError": "You attempted to add a record to the table that included a list or object. The data table can only store booleans, numbers, strings, null, and undefined.",
   "joinASection": "Join a section",

--- a/apps/src/templates/studioHomepages/CourseBlocks.jsx
+++ b/apps/src/templates/studioHomepages/CourseBlocks.jsx
@@ -206,7 +206,6 @@ export class CourseBlocksHoc extends Component {
 
 export class CourseBlocksAll extends Component {
   static propTypes = {
-    isEnglish: PropTypes.bool.isRequired,
     isTeacher: PropTypes.bool.isRequired,
     showModernElementaryCourses: PropTypes.bool.isRequired
   };
@@ -228,16 +227,14 @@ export class CourseBlocksAll extends Component {
           linkText={i18n.teacherCourseHocLinkText()}
           link={pegasus('/hourofcode/overview')}
         >
-          <CourseBlocksHoc isInternational={!this.props.isEnglish} />
+          <CourseBlocksHoc isInternational={true} />
         </ContentContainer>
 
-        {!this.props.isEnglish && (
-          <SpecialAnnouncement isTeacher={this.props.isTeacher} />
-        )}
+        <SpecialAnnouncement isTeacher={this.props.isTeacher} />
 
-        {!this.props.isEnglish && <CourseBlocksInternationalGradeBands />}
+        <CourseBlocksInternationalGradeBands />
 
-        <CourseBlocksTools isEnglish={this.props.isEnglish} />
+        <CourseBlocksTools isEnglish={false} />
       </div>
     );
   }

--- a/apps/src/templates/studioHomepages/CourseBlocks.jsx
+++ b/apps/src/templates/studioHomepages/CourseBlocks.jsx
@@ -112,24 +112,6 @@ const LegacyCSFNotification = () => (
   />
 );
 
-class CourseBlocksCsfLegacy extends Component {
-  render() {
-    return (
-      <ContentContainer
-        heading={i18n.csf()}
-        description={i18n.csfDescription()}
-        link={'/home/#recent-courses'}
-        linkText={i18n.viewMyRecentCourses()}
-      >
-        <Courses1To4 />
-        <br />
-        <br />
-        <AcceleratedAndUnplugged />
-      </ContentContainer>
-    );
-  }
-}
-
 class Courses1To4 extends Component {
   componentDidMount() {
     $('#course1')
@@ -148,12 +130,19 @@ class Courses1To4 extends Component {
 
   render() {
     return (
-      <div className="row">
-        <ProtectedStatefulDiv ref="course1" />
-        <ProtectedStatefulDiv ref="course2" />
-        <ProtectedStatefulDiv ref="course3" />
-        <ProtectedStatefulDiv ref="course4" />
-      </div>
+      <ContentContainer
+        heading={i18n.csf()}
+        description={i18n.csfDescription()}
+        link={'/home/#recent-courses'}
+        linkText={i18n.viewMyRecentCourses()}
+      >
+        <div className="row">
+          <ProtectedStatefulDiv ref="course1" />
+          <ProtectedStatefulDiv ref="course2" />
+          <ProtectedStatefulDiv ref="course3" />
+          <ProtectedStatefulDiv ref="course4" />
+        </div>
+      </ContentContainer>
     );
   }
 }
@@ -260,7 +249,9 @@ export class CourseBlocksIntl extends Component {
     } else {
       return (
         <div>
-          <CourseBlocksCsfLegacy />
+          <ContentContainer>
+            <AcceleratedAndUnplugged />
+          </ContentContainer>
 
           <ContentContainer
             heading={i18n.teacherCourseHoc()}
@@ -272,6 +263,8 @@ export class CourseBlocksIntl extends Component {
           </ContentContainer>
 
           <SpecialAnnouncement isTeacher={this.props.isTeacher} />
+
+          <Courses1To4 />
 
           <CourseBlocksInternationalGradeBands />
 

--- a/apps/src/templates/studioHomepages/CourseBlocks.jsx
+++ b/apps/src/templates/studioHomepages/CourseBlocks.jsx
@@ -30,32 +30,8 @@ class CourseBlocksCsfModern extends Component {
     return (
       <div>
         <ExpressCourses />
-
         <CoursesAToF />
-
-        <NotificationResponsive
-          type="bullhorn"
-          notice={i18n.courseBlocksLegacyNotificationHeading()}
-          details={i18n.courseBlocksLegacyNotificationBody()}
-          detailsLinkText={i18n.courseBlocksLegacyNotificationDetailsLinkText()}
-          detailsLink={pegasus('/educate/curriculum/csf-transition-guide')}
-          detailsLinkNewWindow={true}
-          dismissible={false}
-          buttons={[
-            {
-              text: i18n.courseBlocksLegacyNotificationButtonCourses14(),
-              link: pegasus(
-                '/educate/curriculum/cs-fundamentals-international'
-              ),
-              newWindow: true
-            },
-            {
-              text: i18n.courseBlocksLegacyNotificationButtonCoursesAccelerated(),
-              link: '/s/20-hour',
-              newWindow: true
-            }
-          ]}
-        />
+        <LegacyCSFNotification />
       </div>
     );
   }
@@ -136,6 +112,30 @@ class CoursesAToF extends Component {
     );
   }
 }
+
+const LegacyCSFNotification = () => (
+  <NotificationResponsive
+    type="bullhorn"
+    notice={i18n.courseBlocksLegacyNotificationHeading()}
+    details={i18n.courseBlocksLegacyNotificationBody()}
+    detailsLinkText={i18n.courseBlocksLegacyNotificationDetailsLinkText()}
+    detailsLink={pegasus('/educate/curriculum/csf-transition-guide')}
+    detailsLinkNewWindow={true}
+    dismissible={false}
+    buttons={[
+      {
+        text: i18n.courseBlocksLegacyNotificationButtonCourses14(),
+        link: pegasus('/educate/curriculum/cs-fundamentals-international'),
+        newWindow: true
+      },
+      {
+        text: i18n.courseBlocksLegacyNotificationButtonCoursesAccelerated(),
+        link: '/s/20-hour',
+        newWindow: true
+      }
+    ]}
+  />
+);
 
 class CourseBlocksCsfLegacy extends Component {
   render() {

--- a/apps/src/templates/studioHomepages/CourseBlocks.jsx
+++ b/apps/src/templates/studioHomepages/CourseBlocks.jsx
@@ -117,6 +117,24 @@ class CourseBlocksCsfModern extends Component {
 }
 
 class CourseBlocksCsfLegacy extends Component {
+  render() {
+    return (
+      <ContentContainer
+        heading={i18n.csf()}
+        description={i18n.csfDescription()}
+        link={'/home/#recent-courses'}
+        linkText={i18n.viewMyRecentCourses()}
+      >
+        <Courses1To4 />
+        <br />
+        <br />
+        <AcceleratedAndUnplugged />
+      </ContentContainer>
+    );
+  }
+}
+
+class Courses1To4 extends Component {
   componentDidMount() {
     $('#course1')
       .appendTo(ReactDOM.findDOMNode(this.refs.course1))
@@ -134,22 +152,12 @@ class CourseBlocksCsfLegacy extends Component {
 
   render() {
     return (
-      <ContentContainer
-        heading={i18n.csf()}
-        description={i18n.csfDescription()}
-        link={'/home/#recent-courses'}
-        linkText={i18n.viewMyRecentCourses()}
-      >
-        <div className="row">
-          <ProtectedStatefulDiv ref="course1" />
-          <ProtectedStatefulDiv ref="course2" />
-          <ProtectedStatefulDiv ref="course3" />
-          <ProtectedStatefulDiv ref="course4" />
-        </div>
-        <br />
-        <br />
-        <AcceleratedAndUnplugged />
-      </ContentContainer>
+      <div className="row">
+        <ProtectedStatefulDiv ref="course1" />
+        <ProtectedStatefulDiv ref="course2" />
+        <ProtectedStatefulDiv ref="course3" />
+        <ProtectedStatefulDiv ref="course4" />
+      </div>
     );
   }
 }

--- a/apps/src/templates/studioHomepages/CourseBlocks.jsx
+++ b/apps/src/templates/studioHomepages/CourseBlocks.jsx
@@ -204,7 +204,16 @@ export class CourseBlocksHoc extends Component {
   }
 
   render() {
-    return <CourseBlocks tiles={this.tiles()} />;
+    return (
+      <ContentContainer
+        heading={i18n.teacherCourseHoc()}
+        description={i18n.teacherCourseHocDescription()}
+        linkText={i18n.teacherCourseHocLinkText()}
+        link={pegasus('/hourofcode/overview')}
+      >
+        <CourseBlocks tiles={this.tiles()} />
+      </ContentContainer>
+    );
   }
 }
 
@@ -226,14 +235,7 @@ export class CourseBlocksIntl extends Component {
         <div>
           <ExpressCourses />
 
-          <ContentContainer
-            heading={i18n.teacherCourseHoc()}
-            description={i18n.teacherCourseHocDescription()}
-            linkText={i18n.teacherCourseHocLinkText()}
-            link={pegasus('/hourofcode/overview')}
-          >
-            <CourseBlocksHoc isInternational={true} />
-          </ContentContainer>
+          <CourseBlocksHoc isInternational />
 
           <SpecialAnnouncement isTeacher={this.props.isTeacher} />
 
@@ -253,14 +255,7 @@ export class CourseBlocksIntl extends Component {
             <AcceleratedAndUnplugged />
           </ContentContainer>
 
-          <ContentContainer
-            heading={i18n.teacherCourseHoc()}
-            description={i18n.teacherCourseHocDescription()}
-            linkText={i18n.teacherCourseHocLinkText()}
-            link={pegasus('/hourofcode/overview')}
-          >
-            <CourseBlocksHoc isInternational={true} />
-          </ContentContainer>
+          <CourseBlocksHoc isInternational />
 
           <SpecialAnnouncement isTeacher={this.props.isTeacher} />
 

--- a/apps/src/templates/studioHomepages/CourseBlocks.jsx
+++ b/apps/src/templates/studioHomepages/CourseBlocks.jsx
@@ -26,53 +26,12 @@ export class CourseBlocksCsf extends Component {
 }
 
 class CourseBlocksCsfModern extends Component {
-  componentDidMount() {
-    $('#coursea')
-      .appendTo(ReactDOM.findDOMNode(this.refs.coursea))
-      .show();
-    $('#courseb')
-      .appendTo(ReactDOM.findDOMNode(this.refs.courseb))
-      .show();
-    $('#coursec')
-      .appendTo(ReactDOM.findDOMNode(this.refs.coursec))
-      .show();
-    $('#coursed')
-      .appendTo(ReactDOM.findDOMNode(this.refs.coursed))
-      .show();
-    $('#coursee')
-      .appendTo(ReactDOM.findDOMNode(this.refs.coursee))
-      .show();
-    $('#coursef')
-      .appendTo(ReactDOM.findDOMNode(this.refs.coursef))
-      .show();
-  }
-
   render() {
     return (
       <div>
         <ExpressCourses />
 
-        <ContentContainer
-          heading={i18n.courseBlocksCsfYoungHeading()}
-          description={i18n.courseBlocksCsfYoungDescription()}
-        >
-          <div className="row">
-            <ProtectedStatefulDiv ref="coursea" />
-            <ProtectedStatefulDiv ref="courseb" />
-          </div>
-        </ContentContainer>
-
-        <ContentContainer
-          heading={i18n.courseBlocksCsfOlderHeading()}
-          description={i18n.courseBlocksCsfOlderDescription()}
-        >
-          <div className="row">
-            <ProtectedStatefulDiv ref="coursec" />
-            <ProtectedStatefulDiv ref="coursed" />
-            <ProtectedStatefulDiv ref="coursee" />
-            <ProtectedStatefulDiv ref="coursef" />
-          </div>
-        </ContentContainer>
+        <CoursesAToF />
 
         <NotificationResponsive
           type="bullhorn"
@@ -123,6 +82,57 @@ class ExpressCourses extends Component {
           <ProtectedStatefulDiv ref="express" />
         </div>
       </ContentContainer>
+    );
+  }
+}
+
+class CoursesAToF extends Component {
+  componentDidMount() {
+    $('#coursea')
+      .appendTo(ReactDOM.findDOMNode(this.refs.coursea))
+      .show();
+    $('#courseb')
+      .appendTo(ReactDOM.findDOMNode(this.refs.courseb))
+      .show();
+    $('#coursec')
+      .appendTo(ReactDOM.findDOMNode(this.refs.coursec))
+      .show();
+    $('#coursed')
+      .appendTo(ReactDOM.findDOMNode(this.refs.coursed))
+      .show();
+    $('#coursee')
+      .appendTo(ReactDOM.findDOMNode(this.refs.coursee))
+      .show();
+    $('#coursef')
+      .appendTo(ReactDOM.findDOMNode(this.refs.coursef))
+      .show();
+  }
+
+  render() {
+    return (
+      <div>
+        <ContentContainer
+          heading={i18n.courseBlocksCsfYoungHeading()}
+          description={i18n.courseBlocksCsfYoungDescription()}
+        >
+          <div className="row">
+            <ProtectedStatefulDiv ref="coursea" />
+            <ProtectedStatefulDiv ref="courseb" />
+          </div>
+        </ContentContainer>
+
+        <ContentContainer
+          heading={i18n.courseBlocksCsfOlderHeading()}
+          description={i18n.courseBlocksCsfOlderDescription()}
+        >
+          <div className="row">
+            <ProtectedStatefulDiv ref="coursec" />
+            <ProtectedStatefulDiv ref="coursed" />
+            <ProtectedStatefulDiv ref="coursee" />
+            <ProtectedStatefulDiv ref="coursef" />
+          </div>
+        </ContentContainer>
+      </div>
     );
   }
 }

--- a/apps/src/templates/studioHomepages/CourseBlocks.jsx
+++ b/apps/src/templates/studioHomepages/CourseBlocks.jsx
@@ -230,42 +230,28 @@ export class CourseBlocksIntl extends Component {
   }
 
   render() {
-    if (this.props.showModernElementaryCourses) {
-      return (
-        <div>
-          <ExpressCourses />
+    const {isTeacher, showModernElementaryCourses: modernCsf} = this.props;
+    const AcceleratedCourses = () => (
+      <ContentContainer>
+        <AcceleratedAndUnplugged />
+      </ContentContainer>
+    );
+    return (
+      <div>
+        {modernCsf ? <ExpressCourses /> : <AcceleratedCourses />}
 
-          <CourseBlocksHoc isInternational />
+        <CourseBlocksHoc isInternational />
 
-          <SpecialAnnouncement isTeacher={this.props.isTeacher} />
+        <SpecialAnnouncement isTeacher={isTeacher} />
 
-          <CoursesAToF />
+        {modernCsf ? <CoursesAToF /> : <Courses1To4 />}
 
-          <LegacyCSFNotification />
+        {modernCsf && <LegacyCSFNotification />}
 
-          <CourseBlocksInternationalGradeBands />
+        <CourseBlocksInternationalGradeBands />
 
-          <CourseBlocksTools isEnglish={false} />
-        </div>
-      );
-    } else {
-      return (
-        <div>
-          <ContentContainer>
-            <AcceleratedAndUnplugged />
-          </ContentContainer>
-
-          <CourseBlocksHoc isInternational />
-
-          <SpecialAnnouncement isTeacher={this.props.isTeacher} />
-
-          <Courses1To4 />
-
-          <CourseBlocksInternationalGradeBands />
-
-          <CourseBlocksTools isEnglish={false} />
-        </div>
-      );
-    }
+        <CourseBlocksTools isEnglish={false} />
+      </div>
+    );
   }
 }

--- a/apps/src/templates/studioHomepages/CourseBlocks.jsx
+++ b/apps/src/templates/studioHomepages/CourseBlocks.jsx
@@ -11,32 +11,6 @@ import ProtectedStatefulDiv from '../ProtectedStatefulDiv';
 import i18n from '@cdo/locale';
 import {pegasus} from '@cdo/apps/lib/util/urlHelpers';
 
-export class CourseBlocksCsf extends Component {
-  static propTypes = {
-    showModern: PropTypes.bool.isRequired
-  };
-
-  render() {
-    if (this.props.showModern) {
-      return <CourseBlocksCsfModern />;
-    } else {
-      return <CourseBlocksCsfLegacy />;
-    }
-  }
-}
-
-class CourseBlocksCsfModern extends Component {
-  render() {
-    return (
-      <div>
-        <ExpressCourses />
-        <CoursesAToF />
-        <LegacyCSFNotification />
-      </div>
-    );
-  }
-}
-
 class ExpressCourses extends Component {
   componentDidMount() {
     $('#pre-express')
@@ -57,6 +31,7 @@ class ExpressCourses extends Component {
           <ProtectedStatefulDiv ref="pre_express" />
           <ProtectedStatefulDiv ref="express" />
         </div>
+        <AcceleratedAndUnplugged />
       </ContentContainer>
     );
   }
@@ -244,7 +219,7 @@ export class CourseBlocksHoc extends Component {
   }
 }
 
-export class CourseBlocksAll extends Component {
+export class CourseBlocksIntl extends Component {
   static propTypes = {
     isTeacher: PropTypes.bool.isRequired,
     showModernElementaryCourses: PropTypes.bool.isRequired
@@ -257,25 +232,52 @@ export class CourseBlocksAll extends Component {
   }
 
   render() {
-    return (
-      <div>
-        <CourseBlocksCsf showModern={this.props.showModernElementaryCourses} />
+    if (this.props.showModernElementaryCourses) {
+      return (
+        <div>
+          <ExpressCourses />
 
-        <ContentContainer
-          heading={i18n.teacherCourseHoc()}
-          description={i18n.teacherCourseHocDescription()}
-          linkText={i18n.teacherCourseHocLinkText()}
-          link={pegasus('/hourofcode/overview')}
-        >
-          <CourseBlocksHoc isInternational={true} />
-        </ContentContainer>
+          <ContentContainer
+            heading={i18n.teacherCourseHoc()}
+            description={i18n.teacherCourseHocDescription()}
+            linkText={i18n.teacherCourseHocLinkText()}
+            link={pegasus('/hourofcode/overview')}
+          >
+            <CourseBlocksHoc isInternational={true} />
+          </ContentContainer>
 
-        <SpecialAnnouncement isTeacher={this.props.isTeacher} />
+          <SpecialAnnouncement isTeacher={this.props.isTeacher} />
 
-        <CourseBlocksInternationalGradeBands />
+          <CoursesAToF />
 
-        <CourseBlocksTools isEnglish={false} />
-      </div>
-    );
+          <LegacyCSFNotification />
+
+          <CourseBlocksInternationalGradeBands />
+
+          <CourseBlocksTools isEnglish={false} />
+        </div>
+      );
+    } else {
+      return (
+        <div>
+          <CourseBlocksCsfLegacy />
+
+          <ContentContainer
+            heading={i18n.teacherCourseHoc()}
+            description={i18n.teacherCourseHocDescription()}
+            linkText={i18n.teacherCourseHocLinkText()}
+            link={pegasus('/hourofcode/overview')}
+          >
+            <CourseBlocksHoc isInternational={true} />
+          </ContentContainer>
+
+          <SpecialAnnouncement isTeacher={this.props.isTeacher} />
+
+          <CourseBlocksInternationalGradeBands />
+
+          <CourseBlocksTools isEnglish={false} />
+        </div>
+      );
+    }
   }
 }

--- a/apps/src/templates/studioHomepages/CourseBlocks.jsx
+++ b/apps/src/templates/studioHomepages/CourseBlocks.jsx
@@ -4,6 +4,7 @@ import React, {Component} from 'react';
 import ReactDOM from 'react-dom';
 import ContentContainer from '../ContentContainer';
 import CourseBlocksTools from './CourseBlocksTools';
+import SpecialAnnouncement from './SpecialAnnouncement';
 import CourseBlocksInternationalGradeBands from './CourseBlocksInternationalGradeBands';
 import {NotificationResponsive} from '@cdo/apps/templates/Notification';
 import ProtectedStatefulDiv from '../ProtectedStatefulDiv';
@@ -206,6 +207,7 @@ export class CourseBlocksHoc extends Component {
 export class CourseBlocksAll extends Component {
   static propTypes = {
     isEnglish: PropTypes.bool.isRequired,
+    isTeacher: PropTypes.bool.isRequired,
     showModernElementaryCourses: PropTypes.bool.isRequired
   };
 
@@ -228,6 +230,10 @@ export class CourseBlocksAll extends Component {
         >
           <CourseBlocksHoc isInternational={!this.props.isEnglish} />
         </ContentContainer>
+
+        {!this.props.isEnglish && (
+          <SpecialAnnouncement isTeacher={this.props.isTeacher} />
+        )}
 
         {!this.props.isEnglish && <CourseBlocksInternationalGradeBands />}
 

--- a/apps/src/templates/studioHomepages/CourseBlocks.jsx
+++ b/apps/src/templates/studioHomepages/CourseBlocks.jsx
@@ -130,12 +130,6 @@ class CourseBlocksCsfLegacy extends Component {
     $('#course4')
       .appendTo(ReactDOM.findDOMNode(this.refs.course4))
       .show();
-    $('#20-hour')
-      .appendTo(ReactDOM.findDOMNode(this.refs.twenty_hour))
-      .show();
-    $('#unplugged')
-      .appendTo(ReactDOM.findDOMNode(this.refs.unplugged))
-      .show();
   }
 
   render() {
@@ -154,11 +148,28 @@ class CourseBlocksCsfLegacy extends Component {
         </div>
         <br />
         <br />
-        <div className="row">
-          <ProtectedStatefulDiv ref="twenty_hour" />
-          <ProtectedStatefulDiv ref="unplugged" />
-        </div>
+        <AcceleratedAndUnplugged />
       </ContentContainer>
+    );
+  }
+}
+
+class AcceleratedAndUnplugged extends Component {
+  componentDidMount() {
+    $('#20-hour')
+      .appendTo(ReactDOM.findDOMNode(this.refs.twenty_hour))
+      .show();
+    $('#unplugged')
+      .appendTo(ReactDOM.findDOMNode(this.refs.unplugged))
+      .show();
+  }
+
+  render() {
+    return (
+      <div className="row">
+        <ProtectedStatefulDiv ref="twenty_hour" />
+        <ProtectedStatefulDiv ref="unplugged" />
+      </div>
     );
   }
 }

--- a/apps/src/templates/studioHomepages/CourseBlocks.jsx
+++ b/apps/src/templates/studioHomepages/CourseBlocks.jsx
@@ -174,6 +174,7 @@ export class CourseBlocks extends Component {
         {this.props.tiles.map((tile, index) => (
           <ProtectedStatefulDiv
             className="tutorial-block"
+            key={tile}
             ref={el => {
               if (el) {
                 $(tile).appendTo(ReactDOM.findDOMNode(el));

--- a/apps/src/templates/studioHomepages/CourseBlocks.jsx
+++ b/apps/src/templates/studioHomepages/CourseBlocks.jsx
@@ -242,7 +242,7 @@ export class CourseBlocksIntl extends Component {
 
         <CourseBlocksHoc isInternational />
 
-        <SpecialAnnouncement isTeacher={isTeacher} />
+        <SpecialAnnouncement isEnglish={false} isTeacher={isTeacher} />
 
         {modernCsf ? <CoursesAToF /> : <Courses1To4 />}
 

--- a/apps/src/templates/studioHomepages/CourseBlocks.jsx
+++ b/apps/src/templates/studioHomepages/CourseBlocks.jsx
@@ -45,26 +45,12 @@ class CourseBlocksCsfModern extends Component {
     $('#coursef')
       .appendTo(ReactDOM.findDOMNode(this.refs.coursef))
       .show();
-    $('#pre-express')
-      .appendTo(ReactDOM.findDOMNode(this.refs.pre_express))
-      .show();
-    $('#express')
-      .appendTo(ReactDOM.findDOMNode(this.refs.express))
-      .show();
   }
 
   render() {
     return (
       <div>
-        <ContentContainer
-          heading={i18n.courseBlocksCsfExpressHeading()}
-          description={i18n.courseBlocksCsfExpressDescription()}
-        >
-          <div className="row">
-            <ProtectedStatefulDiv ref="pre_express" />
-            <ProtectedStatefulDiv ref="express" />
-          </div>
-        </ContentContainer>
+        <ExpressCourses />
 
         <ContentContainer
           heading={i18n.courseBlocksCsfYoungHeading()}
@@ -112,6 +98,31 @@ class CourseBlocksCsfModern extends Component {
           ]}
         />
       </div>
+    );
+  }
+}
+
+class ExpressCourses extends Component {
+  componentDidMount() {
+    $('#pre-express')
+      .appendTo(ReactDOM.findDOMNode(this.refs.pre_express))
+      .show();
+    $('#express')
+      .appendTo(ReactDOM.findDOMNode(this.refs.express))
+      .show();
+  }
+
+  render() {
+    return (
+      <ContentContainer
+        heading={i18n.courseBlocksCsfExpressHeading()}
+        description={i18n.courseBlocksCsfExpressDescription()}
+      >
+        <div className="row">
+          <ProtectedStatefulDiv ref="pre_express" />
+          <ProtectedStatefulDiv ref="express" />
+        </div>
+      </ContentContainer>
     );
   }
 }

--- a/apps/src/templates/studioHomepages/Courses.jsx
+++ b/apps/src/templates/studioHomepages/Courses.jsx
@@ -106,7 +106,7 @@ class Courses extends Component {
 
         <ProtectedStatefulDiv ref="flashes" />
 
-        <SpecialAnnouncement isTeacher={isTeacher} />
+        {isEnglish && <SpecialAnnouncement isTeacher={isTeacher} />}
 
         {/* English, teacher.  (Also can be shown when signed out.) */}
         {isEnglish && isTeacher && (
@@ -128,6 +128,7 @@ class Courses extends Component {
         {!isEnglish && (
           <CourseBlocksAll
             isEnglish={false}
+            isTeacher={isTeacher}
             showModernElementaryCourses={modernElementaryCoursesAvailable}
           />
         )}

--- a/apps/src/templates/studioHomepages/Courses.jsx
+++ b/apps/src/templates/studioHomepages/Courses.jsx
@@ -127,7 +127,6 @@ class Courses extends Component {
         {/* Non-English */}
         {!isEnglish && (
           <CourseBlocksAll
-            isEnglish={false}
             isTeacher={isTeacher}
             showModernElementaryCourses={modernElementaryCoursesAvailable}
           />

--- a/apps/src/templates/studioHomepages/Courses.jsx
+++ b/apps/src/templates/studioHomepages/Courses.jsx
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types';
 import React, {Component} from 'react';
 import ReactDOM from 'react-dom';
 import HeaderBanner from '../HeaderBanner';
-import {CourseBlocksAll} from './CourseBlocks';
+import {CourseBlocksIntl} from './CourseBlocks';
 import CoursesTeacherEnglish from './CoursesTeacherEnglish';
 import CoursesStudentEnglish from './CoursesStudentEnglish';
 import ProtectedStatefulDiv from '../ProtectedStatefulDiv';
@@ -126,7 +126,7 @@ class Courses extends Component {
 
         {/* Non-English */}
         {!isEnglish && (
-          <CourseBlocksAll
+          <CourseBlocksIntl
             isTeacher={isTeacher}
             showModernElementaryCourses={modernElementaryCoursesAvailable}
           />

--- a/apps/src/templates/studioHomepages/CoursesStudentEnglish.jsx
+++ b/apps/src/templates/studioHomepages/CoursesStudentEnglish.jsx
@@ -1,10 +1,7 @@
 import React, {Component} from 'react';
-import ContentContainer from '../ContentContainer';
 import {LocalClassActionBlock} from './TwoColumnActionBlock';
 import {CourseBlocksHoc} from './CourseBlocks';
 import CourseBlocksStudentGradeBands from './CourseBlocksStudentGradeBands';
-import i18n from '@cdo/locale';
-import {pegasus} from '@cdo/apps/lib/util/urlHelpers';
 
 /**
  * This is the main content for the Courses page for a student using English,
@@ -19,14 +16,7 @@ class CoursesStudentEnglish extends Component {
           hideBottomMargin={false}
         />
 
-        <ContentContainer
-          heading={i18n.teacherCourseHoc()}
-          description={i18n.teacherCourseHocDescription()}
-          linkText={i18n.teacherCourseHocLinkText()}
-          link={pegasus('/hourofcode/overview')}
-        >
-          <CourseBlocksHoc />
-        </ContentContainer>
+        <CourseBlocksHoc />
 
         <LocalClassActionBlock showHeading={true} />
       </div>

--- a/apps/src/templates/studioHomepages/CoursesTeacherEnglish.jsx
+++ b/apps/src/templates/studioHomepages/CoursesTeacherEnglish.jsx
@@ -8,7 +8,6 @@ import CourseBlocksTools from './CourseBlocksTools';
 import CourseBlocksTeacherGradeBands from './CourseBlocksTeacherGradeBands';
 import ProtectedStatefulDiv from '../ProtectedStatefulDiv';
 import i18n from '@cdo/locale';
-import {pegasus} from '@cdo/apps/lib/util/urlHelpers';
 
 /**
  * This is the main content for the Courses page for a teacher using English,
@@ -37,15 +36,7 @@ class CoursesTeacherEnglish extends Component {
 
           <CourseBlocksTeacherGradeBands />
 
-          <ContentContainer
-            heading={i18n.teacherCourseHoc()}
-            description={i18n.teacherCourseHocDescription()}
-            linkText={i18n.teacherCourseHocLinkText()}
-            link={pegasus('/hourofcode/overview')}
-            showLink={true}
-          >
-            <CourseBlocksHoc />
-          </ContentContainer>
+          <CourseBlocksHoc />
 
           <CourseBlocksTools isEnglish={true} />
 

--- a/apps/src/templates/studioHomepages/SpecialAnnouncement.jsx
+++ b/apps/src/templates/studioHomepages/SpecialAnnouncement.jsx
@@ -9,17 +9,26 @@ is not managed by the json system and can therefore be fully translated and
 can be shown to users viewing the site in languages other than English. */
 export default class SpecialAnnouncement extends Component {
   static propTypes = {
+    isEnglish: PropTypes.bool,
     isTeacher: PropTypes.bool
   };
 
+  static defaultProps = {
+    isEnglish: true
+  };
+
   render() {
-    const {isTeacher} = this.props;
-    const headingText = isTeacher
-      ? i18n.teacherAnnouncementSpecial2020Heading()
-      : i18n.studentAnnouncementSpecial2020Heading();
-    const descriptionText = isTeacher
-      ? i18n.teacherAnnouncementSpecial2020Body()
-      : i18n.studentAnnouncementSpecial2020Body();
+    const {isEnglish, isTeacher} = this.props;
+    const headingText = isEnglish
+      ? isTeacher
+        ? i18n.teacherAnnouncementSpecial2020Heading()
+        : i18n.studentAnnouncementSpecial2020Heading()
+      : i18n.intlAnnouncementSpecial2020Heading();
+    const descriptionText = isEnglish
+      ? isTeacher
+        ? i18n.teacherAnnouncementSpecial2020Body()
+        : i18n.studentAnnouncementSpecial2020Body()
+      : i18n.intlAnnouncementSpecial2020Body();
     const buttonId = isTeacher
       ? 'teacher_homepage_announcement_special2020'
       : 'student_homepage_announcement_special2020';

--- a/apps/test/unit/templates/studioHomepages/CoursesTest.jsx
+++ b/apps/test/unit/templates/studioHomepages/CoursesTest.jsx
@@ -74,10 +74,11 @@ describe('Courses', () => {
             });
             assertComponentsInOrder(wrapper, [
               'ExpressCourses',
-              'CoursesAToF',
-              'LegacyCSFNotification',
+              'AcceleratedAndUnplugged',
               'CourseBlocksHoc',
               'SpecialAnnouncement',
+              'CoursesAToF',
+              'LegacyCSFNotification',
               'CourseBlocksInternationalGradeBands',
               'CourseBlocksTools'
             ]);

--- a/apps/test/unit/templates/studioHomepages/CoursesTest.jsx
+++ b/apps/test/unit/templates/studioHomepages/CoursesTest.jsx
@@ -33,48 +33,73 @@ describe('Courses', () => {
   });
 
   describe('course ordering', () => {
-    it('English, student', () => {
-      const wrapper = mountCourses({isEnglish: true, isTeacher: false});
-      assertComponentsInOrder(wrapper, [
-        'SpecialAnnouncement',
-        'CourseBlocksStudentGradeBands',
-        'CourseBlocksHoc',
-        'LocalClassActionBlock'
-      ]);
+    describe('English', () => {
+      const isEnglish = true;
+
+      it('as student', () => {
+        const wrapper = mountCourses({isEnglish, isTeacher: false});
+        assertComponentsInOrder(wrapper, [
+          'SpecialAnnouncement',
+          'CourseBlocksStudentGradeBands',
+          'CourseBlocksHoc',
+          'LocalClassActionBlock'
+        ]);
+      });
+
+      it('as teacher', () => {
+        const wrapper = mountCourses({isEnglish, isTeacher: true});
+        assertComponentsInOrder(wrapper, [
+          'SpecialAnnouncement',
+          'CoursesTeacherEnglish',
+          'CourseBlocksTeacherGradeBands',
+          'CourseBlocksHoc',
+          'CourseBlocksTools',
+          'AdministratorResourcesActionBlock'
+        ]);
+      });
     });
 
-    it('English, teacher', () => {
-      const wrapper = mountCourses({isEnglish: true, isTeacher: true});
-      assertComponentsInOrder(wrapper, [
-        'SpecialAnnouncement',
-        'CoursesTeacherEnglish',
-        'CourseBlocksTeacherGradeBands',
-        'CourseBlocksHoc',
-        'CourseBlocksTools',
-        'AdministratorResourcesActionBlock'
-      ]);
-    });
+    describe('non-English', () => {
+      const isEnglish = false;
 
-    it('non-English, student', () => {
-      const wrapper = mountCourses({isEnglish: false, isTeacher: false});
-      assertComponentsInOrder(wrapper, [
-        'CourseBlocksCsf',
-        'CourseBlocksHoc',
-        'SpecialAnnouncement',
-        'CourseBlocksInternationalGradeBands',
-        'CourseBlocksTools'
-      ]);
-    });
+      // Student and teacher view should be the same for international
+      // users.  Run all tests for both cases to verify that this is true.
+      [false, true].forEach(isTeacher => {
+        describe(isTeacher ? 'as teacher' : 'as student', () => {
+          it('modern CSF', () => {
+            const wrapper = mountCourses({
+              isEnglish,
+              isTeacher,
+              modernElementaryCoursesAvailable: true
+            });
+            assertComponentsInOrder(wrapper, [
+              'CourseBlocksCsf',
+              'CourseBlocksCsfModern',
+              'CourseBlocksHoc',
+              'SpecialAnnouncement',
+              'CourseBlocksInternationalGradeBands',
+              'CourseBlocksTools'
+            ]);
+          });
 
-    it('non-English, teacher', () => {
-      const wrapper = mountCourses({isEnglish: false, isTeacher: true});
-      assertComponentsInOrder(wrapper, [
-        'CourseBlocksCsf',
-        'CourseBlocksHoc',
-        'SpecialAnnouncement',
-        'CourseBlocksInternationalGradeBands',
-        'CourseBlocksTools'
-      ]);
+          it('legacy CSF', () => {
+            const wrapper = mountCourses({
+              isEnglish,
+              isTeacher,
+              modernElementaryCoursesAvailable: false
+            });
+            assertComponentsInOrder(wrapper, [
+              'CourseBlocksCsf',
+              'CourseBlocksCsfLegacy',
+              'AcceleratedAndUnplugged',
+              'CourseBlocksHoc',
+              'SpecialAnnouncement',
+              'CourseBlocksInternationalGradeBands',
+              'CourseBlocksTools'
+            ]);
+          });
+        });
+      });
     });
   });
 });

--- a/apps/test/unit/templates/studioHomepages/CoursesTest.jsx
+++ b/apps/test/unit/templates/studioHomepages/CoursesTest.jsx
@@ -73,8 +73,6 @@ describe('Courses', () => {
               modernElementaryCoursesAvailable: true
             });
             assertComponentsInOrder(wrapper, [
-              'CourseBlocksCsf',
-              'CourseBlocksCsfModern',
               'ExpressCourses',
               'CoursesAToF',
               'LegacyCSFNotification',
@@ -92,8 +90,6 @@ describe('Courses', () => {
               modernElementaryCoursesAvailable: false
             });
             assertComponentsInOrder(wrapper, [
-              'CourseBlocksCsf',
-              'CourseBlocksCsfLegacy',
               'Courses1To4',
               'AcceleratedAndUnplugged',
               'CourseBlocksHoc',

--- a/apps/test/unit/templates/studioHomepages/CoursesTest.jsx
+++ b/apps/test/unit/templates/studioHomepages/CoursesTest.jsx
@@ -77,6 +77,7 @@ describe('Courses', () => {
               'CourseBlocksCsfModern',
               'ExpressCourses',
               'CoursesAToF',
+              'LegacyCSFNotification',
               'CourseBlocksHoc',
               'SpecialAnnouncement',
               'CourseBlocksInternationalGradeBands',

--- a/apps/test/unit/templates/studioHomepages/CoursesTest.jsx
+++ b/apps/test/unit/templates/studioHomepages/CoursesTest.jsx
@@ -76,6 +76,7 @@ describe('Courses', () => {
               'CourseBlocksCsf',
               'CourseBlocksCsfModern',
               'ExpressCourses',
+              'CoursesAToF',
               'CourseBlocksHoc',
               'SpecialAnnouncement',
               'CourseBlocksInternationalGradeBands',

--- a/apps/test/unit/templates/studioHomepages/CoursesTest.jsx
+++ b/apps/test/unit/templates/studioHomepages/CoursesTest.jsx
@@ -1,30 +1,104 @@
 import React from 'react';
 import {assert} from 'chai';
-import {shallow} from 'enzyme';
+import {mount, shallow} from 'enzyme';
+import {Provider} from 'react-redux';
+import {getStore} from '@cdo/apps/code-studio/redux';
 import Courses from '@cdo/apps/templates/studioHomepages/Courses';
 import HeaderBanner from '@cdo/apps/templates/HeaderBanner';
 
-describe('Courses', () => {
-  const TEST_PROPS = {
-    isEnglish: true,
-    isTeacher: true,
-    isSignedOut: true,
-    linesCount: '0',
-    studentsCount: '0',
-    modernElementaryCoursesAvailable: true
-  };
+const TEST_PROPS = {
+  isEnglish: true,
+  isTeacher: true,
+  isSignedOut: true,
+  linesCount: '0',
+  studentsCount: '0',
+  modernElementaryCoursesAvailable: true
+};
 
-  it('shows a short banner when signed in', () => {
-    const wrapper = shallow(<Courses {...TEST_PROPS} isSignedOut={false} />);
-    const header = wrapper.find(HeaderBanner);
-    assert.isTrue(header.prop('short'));
-    assert.isUndefined(header.prop('description'));
+describe('Courses', () => {
+  describe('hero banner', () => {
+    it('shows a short banner when signed in', () => {
+      const wrapper = shallow(<Courses {...TEST_PROPS} isSignedOut={false} />);
+      const header = wrapper.find(HeaderBanner);
+      assert.isTrue(header.prop('short'));
+      assert.isUndefined(header.prop('description'));
+    });
+
+    it('shows a long banner when signed out', () => {
+      const wrapper = shallow(<Courses {...TEST_PROPS} isSignedOut={true} />);
+      const header = wrapper.find(HeaderBanner);
+      assert.isFalse(header.prop('short'));
+      assert.isString(header.prop('description'));
+    });
   });
 
-  it('shows a long banner when signed out', () => {
-    const wrapper = shallow(<Courses {...TEST_PROPS} isSignedOut={true} />);
-    const header = wrapper.find(HeaderBanner);
-    assert.isFalse(header.prop('short'));
-    assert.isString(header.prop('description'));
+  describe('course ordering', () => {
+    it('English, student', () => {
+      const wrapper = mountCourses({isEnglish: true, isTeacher: false});
+      assertComponentsInOrder(wrapper, [
+        'SpecialAnnouncement',
+        'CourseBlocksStudentGradeBands',
+        'CourseBlocksHoc',
+        'LocalClassActionBlock'
+      ]);
+    });
+
+    it('English, teacher', () => {
+      const wrapper = mountCourses({isEnglish: true, isTeacher: true});
+      assertComponentsInOrder(wrapper, [
+        'SpecialAnnouncement',
+        'CoursesTeacherEnglish',
+        'CourseBlocksTeacherGradeBands',
+        'CourseBlocksHoc',
+        'CourseBlocksTools',
+        'AdministratorResourcesActionBlock'
+      ]);
+    });
+
+    it('non-English, student', () => {
+      const wrapper = mountCourses({isEnglish: false, isTeacher: false});
+      assertComponentsInOrder(wrapper, [
+        'SpecialAnnouncement',
+        'CourseBlocksCsf',
+        'CourseBlocksHoc',
+        'CourseBlocksInternationalGradeBands',
+        'CourseBlocksTools'
+      ]);
+    });
+
+    it('non-English, teacher', () => {
+      const wrapper = mountCourses({isEnglish: false, isTeacher: true});
+      assertComponentsInOrder(wrapper, [
+        'SpecialAnnouncement',
+        'CourseBlocksCsf',
+        'CourseBlocksHoc',
+        'CourseBlocksInternationalGradeBands',
+        'CourseBlocksTools'
+      ]);
+    });
   });
 });
+
+function mountCourses(overrideProps) {
+  return mount(
+    <Provider store={getStore()}>
+      <Courses {...TEST_PROPS} {...overrideProps} />
+    </Provider>
+  );
+}
+
+/**
+ * Asserts a list of components (given by name) can be found
+ * within the provided wrapper, in the order given.  Ignores
+ * any other content in the wrapper.
+ *
+ * @param {EnzymeWrapper} wrapper
+ * @param {Array.<string>} expectedComponents Component names,
+ *   in the order that we expect to find them on the page.
+ */
+function assertComponentsInOrder(wrapper, expectedComponents) {
+  const foundComponents = wrapper
+    .findWhere(n => expectedComponents.includes(n.name()))
+    .map(c => c.name());
+  assert.deepEqual(foundComponents, expectedComponents);
+}

--- a/apps/test/unit/templates/studioHomepages/CoursesTest.jsx
+++ b/apps/test/unit/templates/studioHomepages/CoursesTest.jsx
@@ -91,10 +91,10 @@ describe('Courses', () => {
               modernElementaryCoursesAvailable: false
             });
             assertComponentsInOrder(wrapper, [
-              'Courses1To4',
               'AcceleratedAndUnplugged',
               'CourseBlocksHoc',
               'SpecialAnnouncement',
+              'Courses1To4',
               'CourseBlocksInternationalGradeBands',
               'CourseBlocksTools'
             ]);

--- a/apps/test/unit/templates/studioHomepages/CoursesTest.jsx
+++ b/apps/test/unit/templates/studioHomepages/CoursesTest.jsx
@@ -58,9 +58,9 @@ describe('Courses', () => {
     it('non-English, student', () => {
       const wrapper = mountCourses({isEnglish: false, isTeacher: false});
       assertComponentsInOrder(wrapper, [
-        'SpecialAnnouncement',
         'CourseBlocksCsf',
         'CourseBlocksHoc',
+        'SpecialAnnouncement',
         'CourseBlocksInternationalGradeBands',
         'CourseBlocksTools'
       ]);
@@ -69,9 +69,9 @@ describe('Courses', () => {
     it('non-English, teacher', () => {
       const wrapper = mountCourses({isEnglish: false, isTeacher: true});
       assertComponentsInOrder(wrapper, [
-        'SpecialAnnouncement',
         'CourseBlocksCsf',
         'CourseBlocksHoc',
+        'SpecialAnnouncement',
         'CourseBlocksInternationalGradeBands',
         'CourseBlocksTools'
       ]);

--- a/apps/test/unit/templates/studioHomepages/CoursesTest.jsx
+++ b/apps/test/unit/templates/studioHomepages/CoursesTest.jsx
@@ -75,6 +75,7 @@ describe('Courses', () => {
             assertComponentsInOrder(wrapper, [
               'CourseBlocksCsf',
               'CourseBlocksCsfModern',
+              'ExpressCourses',
               'CourseBlocksHoc',
               'SpecialAnnouncement',
               'CourseBlocksInternationalGradeBands',

--- a/apps/test/unit/templates/studioHomepages/CoursesTest.jsx
+++ b/apps/test/unit/templates/studioHomepages/CoursesTest.jsx
@@ -91,6 +91,7 @@ describe('Courses', () => {
             assertComponentsInOrder(wrapper, [
               'CourseBlocksCsf',
               'CourseBlocksCsfLegacy',
+              'Courses1To4',
               'AcceleratedAndUnplugged',
               'CourseBlocksHoc',
               'SpecialAnnouncement',


### PR DESCRIPTION
Changes the layout of `studio.code.org/courses` for non-English viewers.

## Spec

> Studio.code.org/courses - Int'l versions only
>
> Change the order of the options on the page:
> - Express (if available in that language) AND Accelerated course (note that accelerated course is not showing up yet, it should be - try French for an example)
> - Hour of Code
> - The "Learn computer science at home" callout box that's currently at the top of the page. The headline text needs to be changed to read “More resources for learning at home” and a final sentence needs to be added at the end of the description: "Most options only available in English."
> - Rest of page stays as is (including courses 1-4 or A-F)

## Screenshots

**Non-English, modern CSF available** (Tested Spanish LA)

| Before | After |
| --- | --- |
| ![before_es_01](https://user-images.githubusercontent.com/1615761/79929910-08bfb480-83fc-11ea-8179-56b20b66c858.png)![before_es_02](https://user-images.githubusercontent.com/1615761/79929919-0cebd200-83fc-11ea-9be9-2ef53f9658db.png) | ![after_es_01](https://user-images.githubusercontent.com/1615761/79929927-0eb59580-83fc-11ea-8130-c9e01537a305.png)![after_es_02](https://user-images.githubusercontent.com/1615761/79929932-0fe6c280-83fc-11ea-9414-4987ed1ea2b3.png)![after_es_03](https://user-images.githubusercontent.com/1615761/79929935-11b08600-83fc-11ea-9944-8e7db371a57e.png) |

**Non-English, legacy CSF only** (Tested French)

| Before | After |
| --- | --- |
| ![before_fr_01](https://user-images.githubusercontent.com/1615761/79929992-3573cc00-83fc-11ea-8b64-ac45f81e544b.png)![before_fr_02](https://user-images.githubusercontent.com/1615761/79929997-36a4f900-83fc-11ea-8e61-af93976230ad.png) | ![after_fr_01](https://user-images.githubusercontent.com/1615761/79930000-39075300-83fc-11ea-8dad-257917a44297.png)![after_fr_02](https://user-images.githubusercontent.com/1615761/79930004-3ad11680-83fc-11ea-892c-286079df8486.png) |


## Testing story

Tested manually on local machine on matrix with axes:

- Signed in student, signed in teacher, signed out
- English, non-English with "modern CSF", non-English with "legacy CSF"

I've also added a set of unit tests that verify the ordering of key components on the page for these different scenarios.

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
