### PR TITLE
 Add validation exception for old teacher accounts. 

### DIFF
--- a/dashboard/test/factories/factories.rb
+++ b/dashboard/test/factories/factories.rb
@@ -179,6 +179,20 @@ FactoryGirl.define do
           user.save validate: false
         end
       end
+
+      # We added validation to user accounts and some time which required
+      # teacher accounts to have emails. However, there were already existing
+      # teacher accounts which didn't have an email. Some of these have not yet
+      # been updated, so we need to make sure our system can handle them
+      # gracefully.
+      # FND-1130: This trait will no longer be required
+      trait :before_email_validation do
+        after(:create) do |user|
+          # Account created one day before the requirements were added.
+          user.created_at = User::DATE_TEACHER_EMAIL_REQUIREMENT_ADDED - 1
+          user.save validate: false
+        end
+      end
     end
 
     factory :student do

--- a/dashboard/test/models/user_test.rb
+++ b/dashboard/test/models/user_test.rb
@@ -679,10 +679,25 @@ class UserTest < ActiveSupport::TestCase
     end
   end
 
-  test "cannot create teacher without email" do
-    assert_does_not_create(User) do
-      User.create(user_type: User::TYPE_TEACHER, name: 'Bad Teacher', password: 'xxxxxxxx', provider: 'manual')
-    end
+  test "cannot create manual teacher without email" do
+    user = User.create(user_type: User::TYPE_TEACHER, name: 'Bad Teacher',
+                 password: 'xxxxxxxx', provider: 'manual'
+    )
+    assert_not_nil user.errors[:email]
+  end
+
+  # FND-1130: This test will no longer be required
+  test "teacher with no email created after 2016-06-14 should be invalid" do
+    user = create :teacher, :without_email
+    assert user.invalid?
+    assert_not_empty user.errors[:email]
+  end
+
+  # FND-1130: This test will no longer be required
+  test "teacher with no email created before 2016-06-14 should be valid" do
+    user = create :teacher, :without_email, :before_email_validation
+    assert user.valid?
+    assert_empty user.errors[:email]
   end
 
   test "cannot make an account without email a teacher" do

--- a/dashboard/test/models/user_test.rb
+++ b/dashboard/test/models/user_test.rb
@@ -680,9 +680,11 @@ class UserTest < ActiveSupport::TestCase
   end
 
   test "cannot create manual teacher without email" do
-    user = User.create(user_type: User::TYPE_TEACHER, name: 'Bad Teacher',
-                 password: 'xxxxxxxx', provider: 'manual'
-    )
+    user = assert_does_not_create(User) do
+      User.create(user_type: User::TYPE_TEACHER, name: 'Bad Teacher',
+                  password: 'xxxxxxxx', provider: 'manual'
+      )
+    end
     assert_not_nil user.errors[:email]
   end
 


### PR DESCRIPTION
A few years ago, we added an email requirement for teacher accounts.
At the time, we did not backfill existing teacher accounts, so we still
have active teacher accounts which don't have emails recorded for them.
These users currently experience pain because the code currently refuses
to update change to their account because the account is currently
invalid. This change makes it so these older accounts will be considered
valid for the time being. There is follow up work to get an email
recorded for the teacher accounts.

### Future work
https://codedotorg.atlassian.net/browse/FND-1130

## Links
- [jira](https://codedotorg.atlassian.net/browse/FND-1018)

## Testing story
- unit tests

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
