### PR TITLE
Fix icons for "display as unplugged" external levels 

### DIFF
--- a/apps/src/templates/progress/progressHelpers.js
+++ b/apps/src/templates/progress/progressHelpers.js
@@ -78,6 +78,11 @@ export function getIconForLevel(level, inProgressView = false) {
   if (inProgressView && isLevelAssessment(level)) {
     return 'check-circle';
   }
+
+  if (level.isUnplugged) {
+    return 'scissors';
+  }
+
   if (level.icon) {
     // Eventually I'd like to have dashboard return an icon type. For now, I'm just
     // going to treat the css class it sends as a type, and map it to an icon name.
@@ -86,10 +91,6 @@ export function getIconForLevel(level, inProgressView = false) {
       throw new Error('Unknown iconType: ' + level.icon);
     }
     return match[1];
-  }
-
-  if (level.isUnplugged) {
-    return 'scissors';
   }
 
   if (level.bonus) {


### PR DESCRIPTION
[LP-1338](https://codedotorg.atlassian.net/browse/LP-1338)

In #28325 we added the ability for a levelbuilder to designate that an external markdown level should display as unplugged. The `level.isUnplugged` value was set correctly to show the correct unplugged level bubble, but the icon for "display as unplugged" was not correct. Now the icon for "display as unplugged" levels is scissors consistent with other unplugged levels. 

Before: 
<img width="1021" alt="Screen Shot 2020-04-20 at 9 26 14 AM" src="https://user-images.githubusercontent.com/12300669/79776408-90b59980-82ea-11ea-9751-80e873857f72.png">

After: 
<img width="812" alt="Screen Shot 2020-04-20 at 9 30 44 AM" src="https://user-images.githubusercontent.com/12300669/79776426-93b08a00-82ea-11ea-9ef5-abae6235085a.png">
