### PR TITLE
[Student Created Libraries] library function blocks can be used either as topline statements or as values

### DIFF
--- a/apps/src/code-studio/components/libraries/libraryParser.js
+++ b/apps/src/code-studio/components/libraries/libraryParser.js
@@ -36,7 +36,8 @@ function createDropletConfig(functions, libraryName) {
     let individualConfig = {
       func: currentFunction.functionName,
       category: 'Functions',
-      comment: currentFunction.comment
+      comment: currentFunction.comment,
+      type: 'either'
     };
 
     if (currentFunction.parameters && currentFunction.parameters.length > 0) {

--- a/apps/test/unit/code-studio/components/libraries/libraryParserTest.js
+++ b/apps/test/unit/code-studio/components/libraries/libraryParserTest.js
@@ -140,7 +140,8 @@ describe('Library parser', () => {
         {
           func: functionName,
           category: category,
-          comment: comment
+          comment: comment,
+          type: 'either'
         }
       ];
 
@@ -180,12 +181,14 @@ describe('Library parser', () => {
         {
           func: functions[0],
           category: category,
+          type: 'either',
           params: params,
           paletteParams: params
         },
         {
           func: functions[1],
-          category: category
+          category: category,
+          type: 'either'
         }
       ];
 


### PR DESCRIPTION
We should allow function blocks to be top-level statements or drop into value sockets.
Note we are not doing any static analysis or anything to determine whether the function actually has a return value, we're jut allowing the block to fit into the value sockets.
Before:
![Apr-20-2020 11-50-00](https://user-images.githubusercontent.com/8787187/79788342-5c97a400-82fd-11ea-9243-5bfd11c7b98b.gif)

After:
![Apr-20-2020 11-51-25](https://user-images.githubusercontent.com/8787187/79788353-602b2b00-82fd-11ea-8e70-250c3d89fb80.gif)

<!-- ### Background -->
<!-- ### Privacy -->
<!-- ### Security -->
<!-- ### Caching -->
<!-- ### Deployment strategy -->
<!-- ### Future work -->

## Links

<!--
  Any relevant links to external resources; ie, specification documents, jira
  items, related PRs, honeybadger errors, etc
-->

- [slack thread](https://codedotorg.slack.com/archives/CMRTVRN4C/p1579733395001200)
- [jira](https://codedotorg.atlassian.net/browse/STAR-993)

## Testing story

<!--
  Does your change include appropriate tests?

  If so, please describe how the tests included in this PR are sufficient

  If not, please explain why this change does not need to be tested.
-->

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
