### PR TITLE
Visualization width resizer: work with touch

### DIFF
--- a/apps/src/lib/ui/VisualizationResizeBar.jsx
+++ b/apps/src/lib/ui/VisualizationResizeBar.jsx
@@ -110,14 +110,16 @@ class VisualizationResizeBar extends React.Component {
         window.innerWidth -
         (window.pageXOffset + rect.left + rect.width / 2) -
         parseInt(window.getComputedStyle(this.domElement).right, 10);
-      newVizWidth = window.innerWidth - event.pageX - offset;
+      const pageX = event.pageX || (event.touches && event.touches[0].pageX);
+      newVizWidth = window.innerWidth - pageX - offset;
     } else {
       offset =
         window.pageXOffset +
         rect.left +
         rect.width / 2 -
         parseInt(window.getComputedStyle(this.domElement).left, 10);
-      newVizWidth = event.pageX - offset;
+      const pageX = event.pageX || (event.touches && event.touches[0].pageX);
+      newVizWidth = pageX - offset;
     }
     resizeVisualization(newVizWidth);
   };


### PR DESCRIPTION
This makes the visualization width resizer, which resizes the play space, work with touch on Android and iOS.
