### PR TITLE
Fix post survey urls that rely on day

### DIFF
--- a/dashboard/app/controllers/pd/workshop_daily_survey_controller.rb
+++ b/dashboard/app/controllers/pd/workshop_daily_survey_controller.rb
@@ -227,7 +227,7 @@ module Pd
       enrollment = Enrollment.find_by!(code: params[:enrollment_code])
       workshop = enrollment.workshop
       session = workshop.sessions.last
-      session_count = get_last_valid_day(workshop)
+      session_count = workshop.last_valid_day
       return render_404 unless session
 
       begin
@@ -494,14 +494,6 @@ module Pd
 
     def get_session_for_workshop_and_day(workshop, day)
       day > 0 ? workshop.sessions[day - 1] : nil
-    end
-
-    def get_last_valid_day(workshop)
-      last_day = workshop.sessions.size
-      unless VALID_DAYS[CATEGORY_MAP[workshop.subject]].include? last_day
-        last_day = VALID_DAYS[CATEGORY_MAP[workshop.subject]].last
-      end
-      last_day
     end
 
     def validate_new_general_parameters(workshop)

--- a/dashboard/app/controllers/pd/workshop_daily_survey_controller.rb
+++ b/dashboard/app/controllers/pd/workshop_daily_survey_controller.rb
@@ -227,7 +227,7 @@ module Pd
       enrollment = Enrollment.find_by!(code: params[:enrollment_code])
       workshop = enrollment.workshop
       session = workshop.sessions.last
-      session_count = workshop.sessions.size
+      session_count = get_last_valid_day(workshop)
       return render_404 unless session
 
       begin
@@ -494,6 +494,14 @@ module Pd
 
     def get_session_for_workshop_and_day(workshop, day)
       day > 0 ? workshop.sessions[day - 1] : nil
+    end
+
+    def get_last_valid_day(workshop)
+      last_day = workshop.sessions.size
+      unless VALID_DAYS[CATEGORY_MAP[workshop.subject]].include? last_day
+        last_day = VALID_DAYS[CATEGORY_MAP[workshop.subject]].last
+      end
+      last_day
     end
 
     def validate_new_general_parameters(workshop)

--- a/dashboard/app/models/pd/enrollment.rb
+++ b/dashboard/app/models/pd/enrollment.rb
@@ -211,7 +211,7 @@ class Pd::Enrollment < ActiveRecord::Base
     elsif workshop.summer?
       pd_new_workshop_survey_url(code, protocol: CDO.default_scheme)
     elsif [Pd::Workshop::COURSE_CSP, Pd::Workshop::COURSE_CSD].include?(workshop.course) && workshop.workshop_starting_date > Date.new(2018, 8, 1)
-      CDO.studio_url "/pd/workshop_survey/day/#{workshop.sessions.size}?enrollmentCode=#{code}", CDO.default_scheme
+      CDO.studio_url "/pd/workshop_survey/day/#{get_last_valid_day}?enrollmentCode=#{code}", CDO.default_scheme
     elsif workshop.csf? && workshop.subject == Pd::Workshop::SUBJECT_CSF_201
       CDO.studio_url "/pd/workshop_survey/csf/post201/#{code}", CDO.default_scheme
     else
@@ -414,5 +414,13 @@ class Pd::Enrollment < ActiveRecord::Base
 
   def unused_random_code
     CodeGeneration.random_unique_code length: 10, model: Pd::Enrollment
+  end
+
+  def get_last_valid_day
+    last_day = workshop.sessions.size
+    unless VALID_DAYS[CATEGORY_MAP[workshop.subject]].include? last_day
+      last_day = VALID_DAYS[CATEGORY_MAP[workshop.subject]].last
+    end
+    last_day
   end
 end

--- a/dashboard/app/models/pd/enrollment.rb
+++ b/dashboard/app/models/pd/enrollment.rb
@@ -211,7 +211,7 @@ class Pd::Enrollment < ActiveRecord::Base
     elsif workshop.summer?
       pd_new_workshop_survey_url(code, protocol: CDO.default_scheme)
     elsif [Pd::Workshop::COURSE_CSP, Pd::Workshop::COURSE_CSD].include?(workshop.course) && workshop.workshop_starting_date > Date.new(2018, 8, 1)
-      CDO.studio_url "/pd/workshop_survey/day/#{get_last_valid_day}?enrollmentCode=#{code}", CDO.default_scheme
+      CDO.studio_url "/pd/workshop_survey/day/#{workshop.last_valid_day}?enrollmentCode=#{code}", CDO.default_scheme
     elsif workshop.csf? && workshop.subject == Pd::Workshop::SUBJECT_CSF_201
       CDO.studio_url "/pd/workshop_survey/csf/post201/#{code}", CDO.default_scheme
     else
@@ -414,13 +414,5 @@ class Pd::Enrollment < ActiveRecord::Base
 
   def unused_random_code
     CodeGeneration.random_unique_code length: 10, model: Pd::Enrollment
-  end
-
-  def get_last_valid_day
-    last_day = workshop.sessions.size
-    unless VALID_DAYS[CATEGORY_MAP[workshop.subject]].include? last_day
-      last_day = VALID_DAYS[CATEGORY_MAP[workshop.subject]].last
-    end
-    last_day
   end
 end

--- a/dashboard/app/models/pd/workshop.rb
+++ b/dashboard/app/models/pd/workshop.rb
@@ -33,6 +33,7 @@
 class Pd::Workshop < ActiveRecord::Base
   include Pd::WorkshopConstants
   include SerializedProperties
+  include Pd::WorkshopSurveyConstants
 
   acts_as_paranoid # Use deleted_at column instead of deleting rows.
 
@@ -729,5 +730,13 @@ class Pd::Workshop < ActiveRecord::Base
 
   def can_user_delete?(user)
     state != STATE_ENDED && Ability.new(user).can?(:destroy, self)
+  end
+
+  def last_valid_day
+    last_day = sessions.size
+    unless VALID_DAYS[CATEGORY_MAP[subject]].include? last_day
+      last_day = VALID_DAYS[CATEGORY_MAP[subject]].last
+    end
+    last_day
   end
 end

--- a/dashboard/test/models/pd/enrollment_test.rb
+++ b/dashboard/test/models/pd/enrollment_test.rb
@@ -140,6 +140,19 @@ class Pd::EnrollmentTest < ActiveSupport::TestCase
     assert_equal studio_url["/pd/workshop_survey/post/#{csp_enrollment.code}"], csp_enrollment.exit_survey_url
   end
 
+  test 'exit_survey_url falls back to last valid day' do
+    csd_workshop = create :workshop,
+      :ended,
+      course: Pd::Workshop::COURSE_CSD,
+      subject: SUBJECT_CSD_WORKSHOP_4,
+      num_sessions: 2
+    csd_enrollment = create :pd_enrollment, workshop: csd_workshop
+
+    studio_url = ->(path) {CDO.studio_url(path, CDO.default_scheme)}
+    assert_equal studio_url["/pd/workshop_survey/day/1?enrollmentCode=#{csd_enrollment.code}"],
+      csd_enrollment.exit_survey_url
+  end
+
   test 'should_send_exit_survey' do
     normal_workshop = create :workshop, :ended
     normal_enrollment = create :pd_enrollment, workshop: normal_workshop


### PR DESCRIPTION
Some of our post survey logic pulls the session count and uses that to determine the day to send in a url/as a parameter. This can cause issues if a workshop is of an irregular length. The simple fix here is to fall back to the largest valid day we have for a workshop if the actual workshop is too long. 
Found this issue due to a 1 day workshop that was split into 2 days, which caused the honeybadger errors linked below.
<!-- ### Background -->
<!-- ### Privacy -->
<!-- ### Security -->
<!-- ### Caching -->
<!-- ### Deployment strategy -->
<!-- ### Future work -->

## Links
- [honeybadger 1](https://app.honeybadger.io/projects/3240/faults/55995670)
- [honeybadger 2](https://app.honeybadger.io/projects/3240/faults/62994757)

## Testing story
Made a workshop with the same setup as the one that caused the honeybadger errors locally and verified the fix causes the links and survey submissions to work where the didn't before. Also added a unit test for the enrollments model to cover this case.

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
