### PR TITLE
add a cached version of the exists_in_bucket method

### DIFF
--- a/dashboard/app/models/concerns/text_to_speech.rb
+++ b/dashboard/app/models/concerns/text_to_speech.rb
@@ -91,7 +91,7 @@ module TextToSpeech
   def self.tts_upload_to_s3(text, filename)
     return if text.blank?
     return if CDO.acapela_login.blank? || CDO.acapela_storage_app.blank? || CDO.acapela_storage_password.blank?
-    return if AWS::S3.exists_in_bucket(TTS_BUCKET, filename)
+    return if AWS::S3.cached_exists_in_bucket?(TTS_BUCKET, filename)
 
     loc_voice = TextToSpeech.localized_voice
     url = acapela_text_to_audio_url(text, loc_voice[:VOICE], loc_voice[:SPEED], loc_voice[:SHAPE])

--- a/lib/test/cdo/aws/s3.rb
+++ b/lib/test/cdo/aws/s3.rb
@@ -1,0 +1,54 @@
+require_relative '../../test_helper'
+
+BUCKET = 'test-bucket'
+
+class CdoAwsS3Test < Minitest::Test
+  def setup
+    AWS::S3.create_client
+  end
+
+  def test_cached_exists_in_bucket_caches_list
+    # explicitly clear the cache variable before the test, in case antoher
+    # test has set it.
+    AWS::S3.instance_variable_set(:@cached_bucket_contents, nil)
+
+    # we expect the list operation to be called only once per bucket
+    AWS::S3.s3.stubs(:list_objects_v2).returns(
+      Aws::S3::Types::ListObjectsV2Output.new(
+        contents: [Aws::S3::Types::Object.new(key: "test-object")]
+      )
+    ).once
+
+    refute AWS::S3.instance_variable_get(:@cached_bucket_contents)
+    assert AWS::S3.cached_exists_in_bucket?(BUCKET, 'test-object')
+    refute AWS::S3.cached_exists_in_bucket?(BUCKET, 'test-nonexistent')
+    assert AWS::S3.instance_variable_get(:@cached_bucket_contents)
+
+    AWS::S3.s3.unstub(:list_objects_v2)
+  end
+
+  def test_upload_updates_cache
+    AWS::S3.instance_variable_set(:@cached_bucket_contents, {BUCKET => Set.new})
+    AWS::S3.s3.stubs(:put_object)
+
+    refute AWS::S3.cached_exists_in_bucket?(BUCKET, 'test-nonexistent')
+    AWS::S3.upload_to_bucket(BUCKET, 'test-nonexistent', '', {no_random: true})
+    assert AWS::S3.cached_exists_in_bucket?(BUCKET, 'test-nonexistent')
+
+    AWS::S3.s3.unstub(:put_object)
+  end
+
+  def test_delete_updates_cache
+    AWS::S3.instance_variable_set(:@cached_bucket_contents, {BUCKET => Set['test-object']})
+    mock = MiniTest::Mock.new
+    def mock.delete_marker
+    end
+    AWS::S3.s3.stubs(:delete_object).returns(mock)
+
+    assert AWS::S3.cached_exists_in_bucket?(BUCKET, 'test-object')
+    AWS::S3.delete_from_bucket(BUCKET, 'test-object')
+    refute AWS::S3.cached_exists_in_bucket?(BUCKET, 'test-object')
+
+    AWS::S3.s3.unstub(:delete_object)
+  end
+end


### PR DESCRIPTION
And use it for updating text-to-speech files.

Speeds up the update_tts_i18n script from about an hour to about a minute.

## Links

<!--
  Any relevant links to external resources; ie, specification documents, jira
  items, related PRs, honeybadger errors, etc
-->


- [jira](https://codedotorg.atlassian.net/browse/FND-1118)

## Testing story

Unit test included

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
