### PR TITLE
Create led test

### DIFF
--- a/apps/src/lib/kits/maker/boards/microBit/ExternalButton.js
+++ b/apps/src/lib/kits/maker/boards/microBit/ExternalButton.js
@@ -1,5 +1,6 @@
 import {EXTERNAL_PINS as MB_EXTERNAL_PINS} from './MicroBitConstants';
 import {EventEmitter} from 'events';
+import '../../../../../utils'; // For Function.prototype.inherits
 
 export default function ExternalButton(board) {
   // There are six button events, ['', 'down', 'up', 'click', 'long-click', 'hold']

--- a/apps/src/lib/kits/maker/boards/microBit/MicroBitButton.js
+++ b/apps/src/lib/kits/maker/boards/microBit/MicroBitButton.js
@@ -1,4 +1,5 @@
 import {EventEmitter} from 'events';
+import '../../../../../utils'; // For Function.prototype.inherits
 
 export default function MicroBitButton(board) {
   // There are six button events, ['', 'down', 'up', 'click', 'long-click', 'hold']

--- a/apps/test/unit/lib/kits/maker/boards/MakerBoardTest.js
+++ b/apps/test/unit/lib/kits/maker/boards/MakerBoardTest.js
@@ -484,30 +484,31 @@ export function itImplementsTheMakerBoardInterface(
       });
     });
 
-    if (BoardClass === CircuitPlaygroundBoard || BoardClass === FakeBoard) {
-      /**
-       * @function
-       * @name MakerBoard#createLed
-       * @param {number} pin
-       * @return {Led} a newly constructed Led component
-       */
-      describe(`createLed(pin)`, () => {
-        beforeEach(() => {
-          return board.connect();
-        });
-
-        it(`returns an Led component`, () => {
-          const led = board.createLed(10);
-          // FakeBoard doesn't provide an LED component, so check the basic LED
-          // shape instead.
-          expect(led.on).to.be.a('function');
-          expect(led.off).to.be.a('function');
-          expect(led.blink).to.be.a('function');
-          expect(led.toggle).to.be.a('function');
-          expect(led.pulse).to.be.a('function');
-        });
+    /**
+     * @function
+     * @name MakerBoard#createLed
+     * @param {number} pin
+     * @return {Led} a newly constructed Led component
+     */
+    describe(`createLed(pin)`, () => {
+      beforeEach(() => {
+        return board.connect();
       });
-    }
+
+      it(`returns an Led component`, () => {
+        const led = board.createLed(10);
+        // FakeBoard doesn't provide an LED component, so check the basic LED
+        // shape instead.
+        expect(led.on).to.be.a('function');
+        expect(led.off).to.be.a('function');
+        expect(led.toggle).to.be.a('function');
+
+        if (BoardClass === CircuitPlaygroundBoard || BoardClass === FakeBoard) {
+          expect(led.blink).to.be.a('function');
+          expect(led.pulse).to.be.a('function');
+        }
+      });
+    });
 
     /**
      * @function


### PR DESCRIPTION
While refactoring tests, I noticed that the CreateLed tests in the maker board test where behind a flag to not run for MicroBit. I moved the flag only to the two functions we don't support yet for MicroBit ( blink and pulse).

## Links

<!--
  Any relevant links to external resources; ie, specification documents, jira
  items, related PRs, honeybadger errors, etc
-->

- [spec]()
- [jira]()

## Testing story

<!--
  Does your change include appropriate tests?

  If so, please describe how the tests included in this PR are sufficient

  If not, please explain why this change does not need to be tested.
-->

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
