### PR TITLE
Section Setup: Show section code on Manage Students table 

### DIFF
--- a/apps/i18n/common/en_us.json
+++ b/apps/i18n/common/en_us.json
@@ -1450,6 +1450,7 @@
   "section": "Section",
   "sectionWithColon": "Section:",
   "sectionCode": "Section Code",
+  "sectionCodeWithColon": "Section Code:",
   "sectionCodePlaceholder": "6-character code (ABCDEF)",
   "sectionName": "Section Name",
   "sectionSignInInfo": "Alternatively, share this section's sign in page with your students: ",

--- a/apps/i18n/common/en_us.json
+++ b/apps/i18n/common/en_us.json
@@ -304,7 +304,7 @@
   "copied": "Copied!",
   "copy": "Copy",
   "copyId": "Copy ID",
-  "copySectionCodeSuccess": "You successfully copied the section code!",
+  "copySectionCodeSuccess": "You successfully copied the section join link!",
   "copySectionCodeTooltip": "Click here to copy the link students need to join the section",
   "copyStudentsConfirm": "Yes, I want to copy student(s) to be in this current section AND the new section.",
   "copyright": "Copyright",

--- a/apps/i18n/common/en_us.json
+++ b/apps/i18n/common/en_us.json
@@ -304,7 +304,7 @@
   "copied": "Copied!",
   "copy": "Copy",
   "copyId": "Copy ID",
-  "copySectionCodeSuccess": "You successfully copied the section join link!",
+  "copySectionCodeSuccess": "Link copied!",
   "copySectionCodeTooltip": "Click here to copy the link students need to join the section",
   "copyStudentsConfirm": "Yes, I want to copy student(s) to be in this current section AND the new section.",
   "copyright": "Copyright",

--- a/apps/i18n/common/en_us.json
+++ b/apps/i18n/common/en_us.json
@@ -304,6 +304,7 @@
   "copied": "Copied!",
   "copy": "Copy",
   "copyId": "Copy ID",
+  "copySectionCodeTooltip": "Click here to copy the link students need to join the section",
   "copyStudentsConfirm": "Yes, I want to copy student(s) to be in this current section AND the new section.",
   "copyright": "Copyright",
   "correct": "Correct",

--- a/apps/i18n/common/en_us.json
+++ b/apps/i18n/common/en_us.json
@@ -304,6 +304,7 @@
   "copied": "Copied!",
   "copy": "Copy",
   "copyId": "Copy ID",
+  "copySectionCodeSuccess": "You successfully copied the section code!",
   "copySectionCodeTooltip": "Click here to copy the link students need to join the section",
   "copyStudentsConfirm": "Yes, I want to copy student(s) to be in this current section AND the new section.",
   "copyright": "Copyright",

--- a/apps/src/templates/manageStudents/ManageStudentsTable.jsx
+++ b/apps/src/templates/manageStudents/ManageStudentsTable.jsx
@@ -9,6 +9,7 @@ import PasswordReset from './PasswordReset';
 import ShowSecret from './ShowSecret';
 import {SectionLoginType} from '@cdo/apps/util/sharedConstants';
 import i18n from '@cdo/locale';
+import color from '@cdo/apps/util/color';
 import {tableLayoutStyles, sortableOptions} from '../tables/tableConstants';
 import ManageStudentsNameCell from './ManageStudentsNameCell';
 import ManageStudentsAgeCell from './ManageStudentsAgeCell';
@@ -47,15 +48,25 @@ const styles = {
     width: '20%',
     float: 'left'
   },
-  buttonRow: {
-    display: 'flex'
+  button: {
+    float: 'left'
   },
   buttonWithMargin: {
-    marginRight: 5
+    marginRight: 5,
+    float: 'left'
   },
   verticalAlign: {
     display: 'flex',
     alignItems: 'center'
+  },
+  sectionCodeBox: {
+    float: 'right',
+    lineHeight: '30px'
+  },
+  sectionCode: {
+    marginLeft: 5,
+    color: color.teal,
+    fontFamily: '"Gotham 7r", sans-serif'
   }
 };
 
@@ -586,7 +597,7 @@ class ManageStudentsTable extends Component {
         )}
         {transferStatus.status === TransferStatus.SUCCESS &&
           this.renderTransferSuccessNotification()}
-        <div style={styles.buttonRow}>
+        <div>
           {(loginType === SectionLoginType.word ||
             loginType === SectionLoginType.picture) && (
             <div style={styles.buttonWithMargin}>
@@ -594,22 +605,34 @@ class ManageStudentsTable extends Component {
             </div>
           )}
           {this.isMoveStudentsEnabled() && (
-            <MoveStudents
-              studentData={this.studentDataMinusBlanks()}
-              transferData={transferData}
-              transferStatus={transferStatus}
-            />
+            <div style={styles.button}>
+              <MoveStudents
+                studentData={this.studentDataMinusBlanks()}
+                transferData={transferData}
+                transferStatus={transferStatus}
+              />
+            </div>
           )}
           {(loginType === SectionLoginType.word ||
             loginType === SectionLoginType.picture) && (
-            <PrintLoginCards sectionId={this.props.sectionId} />
+            <div style={styles.button}>
+              <PrintLoginCards sectionId={this.props.sectionId} />
+            </div>
           )}
-          <DownloadParentLetter
-            sectionId={this.props.sectionId}
-            buttonMetricsCategory={
-              ParentLetterButtonMetricsCategory.ABOVE_TABLE
-            }
-          />
+          <div style={styles.button}>
+            <DownloadParentLetter
+              sectionId={this.props.sectionId}
+              buttonMetricsCategory={
+                ParentLetterButtonMetricsCategory.ABOVE_TABLE
+              }
+            />
+          </div>
+          {LOGIN_TYPES_WITH_PASSWORD_COLUMN.includes(loginType) && (
+            <div style={styles.sectionCodeBox}>
+              <span>{i18n.sectionCodeWithColon()}</span>
+              <span style={styles.sectionCode}>{this.props.sectionCode}</span>
+            </div>
+          )}
         </div>
         <Table.Provider
           columns={columns}

--- a/apps/src/templates/manageStudents/ManageStudentsTable.jsx
+++ b/apps/src/templates/manageStudents/ManageStudentsTable.jsx
@@ -37,6 +37,7 @@ import MoveStudents from './MoveStudents';
 import DownloadParentLetter from './DownloadParentLetter';
 import PrintLoginCards from './PrintLoginCards';
 import Button from '../Button';
+import copyToClipboard from '@cdo/apps/util/copyToClipboard';
 
 const styles = {
   headerName: {
@@ -66,7 +67,8 @@ const styles = {
   sectionCode: {
     marginLeft: 5,
     color: color.teal,
-    fontFamily: '"Gotham 7r", sans-serif'
+    fontFamily: '"Gotham 7r", sans-serif',
+    cursor: 'copy'
   }
 };
 
@@ -546,6 +548,12 @@ class ManageStudentsTable extends Component {
     return dataColumns;
   };
 
+  copySectionCode = () => {
+    const {sectionCode} = this.props;
+    copyToClipboard(sectionCode);
+    alert(i18n.copySectionCodeSuccess());
+  };
+
   render() {
     // Define a sorting transform that can be applied to each column
     const sortable = wrappedSortable(
@@ -571,7 +579,8 @@ class ManageStudentsTable extends Component {
       loginType,
       transferStatus,
       transferData,
-      sectionId
+      sectionId,
+      sectionCode
     } = this.props;
     return (
       <div>
@@ -628,9 +637,14 @@ class ManageStudentsTable extends Component {
             />
           </div>
           {LOGIN_TYPES_WITH_PASSWORD_COLUMN.includes(loginType) && (
-            <div style={styles.sectionCodeBox} data-for="section-code" data-tip>
+            <div
+              style={styles.sectionCodeBox}
+              data-for="section-code"
+              data-tip
+              onClick={this.copySectionCode}
+            >
               <span>{i18n.sectionCodeWithColon()}</span>
-              <span style={styles.sectionCode}>{this.props.sectionCode}</span>
+              <span style={styles.sectionCode}>{sectionCode}</span>
               <ReactTooltip id="section-code" role="tooltip" effect="solid">
                 <div>{i18n.copySectionCodeTooltip()}</div>
               </ReactTooltip>

--- a/apps/src/templates/manageStudents/ManageStudentsTable.jsx
+++ b/apps/src/templates/manageStudents/ManageStudentsTable.jsx
@@ -157,7 +157,8 @@ class ManageStudentsTable extends Component {
         direction: 'asc',
         position: 0
       }
-    }
+    },
+    showCopiedMsg: false
   };
 
   renderTransferSuccessNotification = () => {
@@ -552,7 +553,11 @@ class ManageStudentsTable extends Component {
     const {sectionCode, studioUrlPrefix} = this.props;
     const joinLink = `${studioUrlPrefix}/join/${sectionCode}`;
     copyToClipboard(joinLink);
-    alert(i18n.copySectionCodeSuccess());
+    this.setState({showCopiedMsg: true});
+    setTimeout(() => {
+      this.setState({showCopiedMsg: false});
+    }, 5000);
+    clearTimeout();
   };
 
   render() {
@@ -644,11 +649,18 @@ class ManageStudentsTable extends Component {
               data-tip
               onClick={this.copySectionCode}
             >
-              <span>{i18n.sectionCodeWithColon()}</span>
-              <span style={styles.sectionCode}>{sectionCode}</span>
-              <ReactTooltip id="section-code" role="tooltip" effect="solid">
-                <div>{i18n.copySectionCodeTooltip()}</div>
-              </ReactTooltip>
+              {!this.state.showCopiedMsg && (
+                <span>
+                  <span>{i18n.sectionCodeWithColon()}</span>
+                  <span style={styles.sectionCode}>{sectionCode}</span>
+                  <ReactTooltip id="section-code" role="tooltip" effect="solid">
+                    <div>{i18n.copySectionCodeTooltip()}</div>
+                  </ReactTooltip>
+                </span>
+              )}
+              {this.state.showCopiedMsg && (
+                <span>{i18n.copySectionCodeSuccess()}</span>
+              )}
             </div>
           )}
         </div>

--- a/apps/src/templates/manageStudents/ManageStudentsTable.jsx
+++ b/apps/src/templates/manageStudents/ManageStudentsTable.jsx
@@ -628,9 +628,12 @@ class ManageStudentsTable extends Component {
             />
           </div>
           {LOGIN_TYPES_WITH_PASSWORD_COLUMN.includes(loginType) && (
-            <div style={styles.sectionCodeBox}>
+            <div style={styles.sectionCodeBox} data-for="section-code" data-tip>
               <span>{i18n.sectionCodeWithColon()}</span>
               <span style={styles.sectionCode}>{this.props.sectionCode}</span>
+              <ReactTooltip id="section-code" role="tooltip" effect="solid">
+                <div>{i18n.copySectionCodeTooltip()}</div>
+              </ReactTooltip>
             </div>
           )}
         </div>

--- a/apps/src/templates/manageStudents/ManageStudentsTable.jsx
+++ b/apps/src/templates/manageStudents/ManageStudentsTable.jsx
@@ -549,8 +549,9 @@ class ManageStudentsTable extends Component {
   };
 
   copySectionCode = () => {
-    const {sectionCode} = this.props;
-    copyToClipboard(sectionCode);
+    const {sectionCode, studioUrlPrefix} = this.props;
+    const joinLink = `${studioUrlPrefix}/join/${sectionCode}`;
+    copyToClipboard(joinLink);
     alert(i18n.copySectionCodeSuccess());
   };
 


### PR DESCRIPTION
[Spec](https://docs.google.com/document/d/1YaC8yPL4QUNshj0zXmCZJ1o-FcGYb1Dexv9J0-acHuM/edit#heading=h.hupraqk0xxj5) - Requirement 2
[LP-1388](https://codedotorg.atlassian.net/browse/LP-1388)

Add the section code to the top right of the Manage Students table for section types that have section codes (word, picture, email login). Clicking the section code copies the join link for the section, and a tooltip explains. 

![copy-section-link](https://user-images.githubusercontent.com/12300669/79994831-4a3b7880-846b-11ea-9ff6-93e890a00025.gif)
