### PR TITLE
Clone RDS Cluster to Point In Time

### DIFF
--- a/lib/rake/rds.rake
+++ b/lib/rake/rds.rake
@@ -1,18 +1,26 @@
 require 'cdo/aws/rds'
 
 namespace :rds do
-  # Provide all 3 arguments
+  # EXAMPLE USAGE
+  #
+  # Providing 3 arguments and defaulting to latest restorable time:
   # bundle exec rake rds:clone_cluster SOURCE_CLUSTER_ID=my-favorite-cluster CLONE_CLUSTER_ID=my-second-fav INSTANCE_ID=db.r4.4xlarge
-  # Use default 'db.r4.large' instance type
+  #
+  # Using default 'db.r4.large' instance type and defaulting to latest restorable time:
   # bundle exec rake rds:clone_cluster SOURCE_CLUSTER_ID=my-favorite-cluster CLONE_CLUSTER_ID=my-second-fav
-  # Use default clone id (suffix source cluster id with '-clone')
+  #
+  # Using default 'db.r4.large' instance type and specifying restore to time:
+  # bundle exec rake rds:clone_cluster SOURCE_CLUSTER_ID=my-favorite-cluster CLONE_CLUSTER_ID=my-second-fav RESTORE_TO_TIME="2012-04-20T16:20:00Z"
+  #
+  # Using default clone id (suffix source cluster id with '-clone'), default instance type, and defaulting to latest restorable time:
   # bundle exec rake rds:clone_cluster SOURCE_CLUSTER_ID=my-favorite-cluster
   desc 'Clone SOURCE_CLUSTER_ID to optional CLONE_CLUSTER_ID with optional INSTANCE_TYPE.'
   task :clone_cluster do
     options = {
       source_cluster_id: ENV['SOURCE_CLUSTER_ID'],
       clone_cluster_id: ENV['CLONE_CLUSTER_ID'],
-      instance_type: ENV['INSTANCE_TYPE']
+      instance_type: ENV['INSTANCE_TYPE'],
+      restore_to_time: ENV['RESTORE_TO_TIME']
     }
     Cdo::RDS.clone_cluster(options.compact)
   end


### PR DESCRIPTION
Add an option to create a copy of a source RDS Aurora cluster that is restored to a specific Point In Time, defaulting to a copy-on-write clone that uses the latest restorable time.
# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
