### PR TITLE
Don't geocode virtual as a location address

### DIFF
--- a/dashboard/app/models/pd/workshop.rb
+++ b/dashboard/app/models/pd/workshop.rb
@@ -289,6 +289,7 @@ class Pd::Workshop < ActiveRecord::Base
   # 4. no location address at all? use TBA
   def friendly_location
     return 'Location TBA' if location_address_tba?
+    return 'Virtual Workshop' if location_address_virtual?
     return "#{location_city} #{location_state}" if processed_location
     location_address.presence || 'Location TBA'
   end
@@ -478,10 +479,14 @@ class Pd::Workshop < ActiveRecord::Base
     %w(tba tbd n/a).include?(location_address.try(:downcase))
   end
 
+  def location_address_virtual?
+    ['virtual', 'virtual workshop'].include? location_address.try(:downcase)
+  end
+
   def process_location
     result = nil
 
-    unless location_address.blank? || location_address_tba?
+    unless location_address.blank? || location_address_tba? || location_address_virtual?
       begin
         Geocoder.with_errors do
           # Geocoder can raise a number of errors including SocketError, with a common base of StandardError


### PR DESCRIPTION
Don't run "virtual" or "virtual workshop" through the geocoder.

When workshop organizers are editing a workshop and type "virtual" into the location address field, our system runs that through the geocoder and comes back with an address in Vinita, Oklahoma.  We've had similar issues in the past with locations like "TBD," "TBA," or "N/A" and we already have special cases for those.  I'm adding a special case for "virtual" or "virtual workshop" as well.  We will working on a more holistic solution for virtual workshops over the next few weeks, but this quick fix will resolve a lot of confusion for our partners.

Issue originally raised [in this Slack conversation](https://codedotorg.slack.com/archives/C0T10H26N/p1587520386063800).

## Testing story

Unit tests all the way.

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
