### PR TITLE
MB Button Holdtime

### DIFF
--- a/apps/src/lib/kits/maker/boards/microBit/ExternalButton.js
+++ b/apps/src/lib/kits/maker/boards/microBit/ExternalButton.js
@@ -11,6 +11,10 @@ export default function ExternalButton(board) {
   }
   // Flag to only trigger event on first of type
   this.connect = false;
+  // Length of millisecond before triggering 'hold' event.
+  // Default from Johnny-Five Button implementation.
+  this.holdThreshold = 500;
+  this.holdTimer = null;
 
   this.board.mb.trackDigitalComponent(this.board.pin, (sourceID, eventID) => {
     if (this.board.pin === sourceID) {
@@ -18,17 +22,33 @@ export default function ExternalButton(board) {
       if (eventID === 1 && !this.connect) {
         this.emit('down');
         this.connect = true;
+        this.holdTimer = setInterval(() => {
+          this.emit('hold');
+        }, this.holdThreshold);
       } else if (eventID === 2 && this.connect) {
         this.emit('up');
         this.connect = false;
+        if (this.holdTimer) {
+          clearInterval(this.holdTimer);
+          this.holdTimer = null;
+        }
       }
     }
   });
 
   // Add a read-only `isPressed` property
-  Object.defineProperty(this, 'isPressed', {
-    // More 'down' events than 'up' indicates we are in a pressed state
-    get: () => this.buttonEvents[1] > this.buttonEvents[2]
+  Object.defineProperties(this, {
+    isPressed: {
+      // More 'down' events than 'up' indicates we are in a pressed state
+      get: function() {
+        return this.buttonEvents[1] > this.buttonEvents[2];
+      }
+    },
+    holdtime: {
+      get: function() {
+        return this.holdThreshold;
+      }
+    }
   });
 }
 ExternalButton.inherits(EventEmitter);

--- a/apps/src/lib/kits/maker/boards/microBit/MicroBitButton.js
+++ b/apps/src/lib/kits/maker/boards/microBit/MicroBitButton.js
@@ -4,20 +4,41 @@ export default function MicroBitButton(board) {
   // There are six button events, ['', 'down', 'up', 'click', 'long-click', 'hold']
   this.buttonEvents = new Array(6).fill(0);
   this.board = board;
+  // Length of millisecond before triggering 'hold' event.
+  // Default from Johnny-Five Button implementation.
+  this.holdThreshold = 500;
+  this.holdTimer = null;
   this.board.mb.addFirmataEventListener((sourceID, eventID) => {
     if (this.board.pin === sourceID) {
       this.buttonEvents[eventID]++;
       if (eventID === 1) {
         this.emit('down');
+        this.holdTimer = setInterval(() => {
+          this.emit('hold');
+        }, this.holdThreshold);
       } else if (eventID === 2) {
         this.emit('up');
+        if (this.holdTimer) {
+          clearInterval(this.holdTimer);
+          this.holdTimer = null;
+        }
       }
     }
   });
 
   // Add a read-only `isPressed` property
-  Object.defineProperty(this, 'isPressed', {
-    get: () => this.buttonEvents[1] > this.buttonEvents[2]
+  Object.defineProperties(this, {
+    isPressed: {
+      // More 'down' events than 'up' indicates we are in a pressed state
+      get: function() {
+        return this.buttonEvents[1] > this.buttonEvents[2];
+      }
+    },
+    holdtime: {
+      get: function() {
+        return this.holdThreshold;
+      }
+    }
   });
 }
 MicroBitButton.inherits(EventEmitter);

--- a/apps/test/unit/lib/kits/maker/boards/MakerBoardTest.js
+++ b/apps/test/unit/lib/kits/maker/boards/MakerBoardTest.js
@@ -319,6 +319,8 @@ export function itImplementsTheMakerBoardInterface(
 
               it('isPressed', () =>
                 expect(component.isPressed).to.be.a('boolean'));
+              it('holdtime', () =>
+                expect(component.holdtime).to.be.a('number'));
             });
           });
 
@@ -531,11 +533,7 @@ export function itImplementsTheMakerBoardInterface(
         // Check the basic button shape
         expect(button).to.be.an.instanceOf(EventEmitter);
         expect(button).to.have.property('isPressed');
-
-        // TODO - not yet implemented for microbit
-        if (BoardClass === CircuitPlaygroundBoard || BoardClass === FakeBoard) {
-          expect(button).to.have.property('holdtime');
-        }
+        expect(button).to.have.property('holdtime');
       });
     });
   });

--- a/apps/test/unit/lib/kits/maker/boards/microBit/MicroBitButtonTest.js
+++ b/apps/test/unit/lib/kits/maker/boards/microBit/MicroBitButtonTest.js
@@ -41,6 +41,30 @@ describe('MicroBitButton', function() {
     });
   });
 
+  describe('holdtime', () => {
+    let button;
+
+    beforeEach(() => {
+      button = new MicroBitButton({
+        mb: new MicrobitStubBoard(),
+        pin: 0
+      });
+    });
+
+    it('is a readonly property', () => {
+      const descriptor = Object.getOwnPropertyDescriptor(button, 'holdtime');
+      expect(descriptor.get).to.be.a('function');
+      expect(descriptor.set).to.be.undefined;
+      expect(() => {
+        button.holdtime = 600;
+      }).to.throw();
+    });
+
+    it('returns the default value, 500 ms', () => {
+      expect(button.holdtime).to.equal(500);
+    });
+  });
+
   describe('emitsEvent', () => {
     it('emits the corresponding event and updates states when board receives event', () => {
       let boardClient = new MicrobitStubBoard();


### PR DESCRIPTION
Per this spec: https://codedotorg.atlassian.net/browse/STAR-1066

Adds the holdtime property to the button for MicroBit, to align with Circuit Playground.

## Links

<!--
  Any relevant links to external resources; ie, specification documents, jira
  items, related PRs, honeybadger errors, etc
-->

- [spec]()
- [jira]()

## Testing story
Includes tests
# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
