### PR TITLE
Remove five-day language from RP landing page

### DIFF
--- a/apps/src/templates/RegionalPartnerSearch.jsx
+++ b/apps/src/templates/RegionalPartnerSearch.jsx
@@ -371,15 +371,6 @@ class RegionalPartnerSearch extends Component {
             <div style={styles.clear} />
 
             <div style={styles.action}>
-              {appState !== WorkshopApplicationStates.now_closed && (
-                <div>
-                  The Professional Learning Program is a yearlong commitment,
-                  consisting of a five-day in-person summer workshop, plus
-                  follow up academic year workshops hosted in-person or
-                  virtually.
-                </div>
-              )}
-
               {appState === WorkshopApplicationStates.now_closed && (
                 <h3>Applications are now closed.</h3>
               )}


### PR DESCRIPTION
[From the Virtual Support spec](https://docs.google.com/document/d/1IE_CFnueA4AaAt4CqBAz01jcDRvE7Dgr4jkoZY8krJ0/edit#bookmark=id.bm2521ar1d05) and with Liz' approval: We've been asked to simply remove this copy, since virtual workshops may or may not be five days.

## Testing story

Manual testing on local machine. (Seemed sufficient for removing copy.)

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
