### PR TITLE
Add 'visible' field to course

### DIFF
--- a/dashboard/config/courses/csd-2017.course
+++ b/dashboard/config/courses/csd-2017.course
@@ -22,6 +22,7 @@
     "has_verified_resources": true,
     "family_name": "csd",
     "version_year": "2017",
-    "is_stable": true
+    "is_stable": true,
+    "visible": true
   }
 }

--- a/dashboard/config/courses/csd-2018.course
+++ b/dashboard/config/courses/csd-2018.course
@@ -23,6 +23,7 @@
     "has_verified_resources": true,
     "family_name": "csd",
     "version_year": "2018",
-    "is_stable": true
+    "is_stable": true,
+    "visible": true
   }
 }

--- a/dashboard/config/courses/csd-2019.course
+++ b/dashboard/config/courses/csd-2019.course
@@ -22,6 +22,7 @@
     "has_verified_resources": true,
     "family_name": "csd",
     "version_year": "2019",
-    "is_stable": true
+    "is_stable": true,
+    "visible": true
   }
 }

--- a/dashboard/config/courses/csp-2017.course
+++ b/dashboard/config/courses/csp-2017.course
@@ -41,6 +41,7 @@
     "has_verified_resources": true,
     "family_name": "csp",
     "version_year": "2017",
-    "is_stable": true
+    "is_stable": true,
+    "visible": true
   }
 }

--- a/dashboard/config/courses/csp-2018.course
+++ b/dashboard/config/courses/csp-2018.course
@@ -25,6 +25,7 @@
     "has_verified_resources": true,
     "family_name": "csp",
     "version_year": "2018",
-    "is_stable": true
+    "is_stable": true,
+    "visible": true
   }
 }

--- a/dashboard/config/courses/csp-2019.course
+++ b/dashboard/config/courses/csp-2019.course
@@ -24,6 +24,7 @@
     "has_verified_resources": true,
     "family_name": "csp",
     "version_year": "2019",
-    "is_stable": true
+    "is_stable": true,
+    "visible": true
   }
 }

--- a/dashboard/test/controllers/api/v1/sections_controller_test.rb
+++ b/dashboard/test/controllers/api/v1/sections_controller_test.rb
@@ -9,6 +9,9 @@ class Api::V1::SectionsControllerTest < ActionController::TestCase
     @student = create(:follower, section: @section).student_user
   end
 
+  CSP_COURSE_NAME = 'csp-2017'
+  CSP_COURSE_SOFT_LAUNCHED_NAME = 'csp-2018-soft-launched'
+
   setup do
     # place in setup instead of setup_all otherwise course ends up being serialized
     # to a file if levelbuilder_mode is true
@@ -19,7 +22,8 @@ class Api::V1::SectionsControllerTest < ActionController::TestCase
     @section_with_script = create(:section, user: @teacher, script: Script.flappy_script)
     @student_with_script = create(:follower, section: @section_with_script).student_user
 
-    @csp_course = create(:course, name: 'csp-2017', visible: true, is_stable: true)
+    @csp_course = create(:course, name: CSP_COURSE_NAME, visible: true, is_stable: true)
+    @csp_course_soft_launched = create(:course, name: CSP_COURSE_SOFT_LAUNCHED_NAME, visible: true)
     @csp_script = create(:script, name: 'csp1')
     create(:course_script, course: @csp_course, script: @csp_script, position: 1)
   end
@@ -411,17 +415,21 @@ class Api::V1::SectionsControllerTest < ActionController::TestCase
     assert_equal true, returned_section.pairing_allowed
   end
 
-  test 'can create with a course id but no script id' do
-    sign_in @teacher
-    post :create, params: {
-      login_type: Section::LOGIN_TYPE_EMAIL,
-      course_id: @csp_course.id,
-    }
+  [CSP_COURSE_NAME, CSP_COURSE_SOFT_LAUNCHED_NAME].each do |existing_course_name|
+    test "can create with a course id but no script id - #{existing_course_name}" do
+      existing_course = Course.find_by(name: existing_course_name)
 
-    assert_equal @csp_course.id, returned_json['course_id']
-    assert_equal @csp_course, returned_section.course
-    assert_nil returned_json['script']['id']
-    assert_nil returned_section.script
+      sign_in @teacher
+      post :create, params: {
+        login_type: Section::LOGIN_TYPE_EMAIL,
+        course_id: existing_course.id,
+      }
+
+      assert_equal existing_course.id, returned_json['course_id']
+      assert_equal existing_course, returned_section.course
+      assert_nil returned_json['script']['id']
+      assert_nil returned_section.script
+    end
   end
 
   test 'cannot assign an invalid course id' do
@@ -465,18 +473,22 @@ class Api::V1::SectionsControllerTest < ActionController::TestCase
     assert_nil returned_section.course
   end
 
-  test 'can create with both a course id and a script id' do
-    sign_in @teacher
-    post :create, params: {
-      login_type: Section::LOGIN_TYPE_EMAIL,
-      course_id: @csp_course.id,
-      script: {id: @csp_script.id},
-    }
+  [CSP_COURSE_NAME, CSP_COURSE_SOFT_LAUNCHED_NAME].each do |existing_course_name|
+    test "can create with both a course id and a script id - #{existing_course_name}" do
+      existing_course = Course.find_by(name: existing_course_name)
 
-    assert_equal @csp_course.id, returned_json['course_id']
-    assert_equal @csp_course, returned_section.course
-    assert_equal @csp_script.id, returned_json['script']['id']
-    assert_equal @csp_script, returned_section.script
+      sign_in @teacher
+      post :create, params: {
+        login_type: Section::LOGIN_TYPE_EMAIL,
+        course_id: existing_course.id,
+        script: {id: @csp_script.id},
+      }
+
+      assert_equal existing_course.id, returned_json['course_id']
+      assert_equal existing_course, returned_section.course
+      assert_equal @csp_script.id, returned_json['script']['id']
+      assert_equal @csp_script, returned_section.script
+    end
   end
 
   test 'creating a section with a script assigns the script to the creating user' do

--- a/dashboard/test/controllers/api/v1/sections_controller_test.rb
+++ b/dashboard/test/controllers/api/v1/sections_controller_test.rb
@@ -19,7 +19,7 @@ class Api::V1::SectionsControllerTest < ActionController::TestCase
     @section_with_script = create(:section, user: @teacher, script: Script.flappy_script)
     @student_with_script = create(:follower, section: @section_with_script).student_user
 
-    @csp_course = create(:course, name: 'csp-2017')
+    @csp_course = create(:course, name: 'csp-2017', visible: true, is_stable: true)
     @csp_script = create(:script, name: 'csp1')
     create(:course_script, course: @csp_course, script: @csp_script, position: 1)
   end

--- a/dashboard/test/controllers/maker_controller_test.rb
+++ b/dashboard/test/controllers/maker_controller_test.rb
@@ -10,9 +10,9 @@ class MakerControllerTest < ActionController::TestCase
     @school = create :school
     @school_maker_high_needs = create :school, :is_maker_high_needs_school
 
-    @csd_2017 = ensure_course Script::CSD_2017, '2017'
-    @csd_2018 = ensure_course Script::CSD_2018, '2018'
-    @csd_2019 = ensure_course Script::CSD_2019, '2019'
+    @csd_2017 = ensure_course 'csd-2017', '2017'
+    @csd_2018 = ensure_course 'csd-2018', '2018'
+    @csd_2019 = ensure_course 'csd-2019', '2019'
     @csd_2020_unstable = ensure_course 'csd-2020-unstable', '2020'
     @csd6_2017 = ensure_script Script::CSD6_NAME, '2017'
     @csd6_2018 = ensure_script Script::CSD6_2018_NAME, '2018'

--- a/dashboard/test/models/course_test.rb
+++ b/dashboard/test/models/course_test.rb
@@ -483,7 +483,8 @@ class CourseTest < ActiveSupport::TestCase
     csp2 = create(:script, name: 'csp2')
     csp2_alt = create(:script, name: 'csp2-alt', hidden: true)
     csp3 = create(:script, name: 'csp3')
-    csd = create(:course, name: 'csd-2017', visible: true, is_stable: true)
+    # Should still be in valid_courses if visible and not stable
+    csd = create(:course, name: 'csd-2017', visible: true)
     create(:course, name: 'madeup')
 
     create(:course_script, position: 1, course: csp, script: csp1)

--- a/dashboard/test/models/course_test.rb
+++ b/dashboard/test/models/course_test.rb
@@ -478,13 +478,12 @@ class CourseTest < ActiveSupport::TestCase
   end
 
   test "valid_courses" do
-    # The data here must be in sync with the data in ScriptConstants.rb
-    csp = create(:course, name: 'csp-2017')
+    csp = create(:course, name: 'csp-2017', visible: true, is_stable: true)
     csp1 = create(:script, name: 'csp1')
     csp2 = create(:script, name: 'csp2')
     csp2_alt = create(:script, name: 'csp2-alt', hidden: true)
     csp3 = create(:script, name: 'csp3')
-    csd = create(:course, name: 'csd-2017')
+    csd = create(:course, name: 'csd-2017', visible: true, is_stable: true)
     create(:course, name: 'madeup')
 
     create(:course_script, position: 1, course: csp, script: csp1)
@@ -510,8 +509,7 @@ class CourseTest < ActiveSupport::TestCase
     # has fields from ScriptConstants::Assignable_Info
     assert_equal csp.id, csp_assign_info[:id]
     assert_equal 'csp-2017', csp_assign_info[:script_name]
-    assert_equal 0, csp_assign_info[:position]
-    assert_equal(0, csp_assign_info[:category_priority])
+    assert_equal(-1, csp_assign_info[:category_priority])
 
     # has localized name, category
     assert_equal "Computer Science Principles ('17-'18)", csp_assign_info[:name]
@@ -538,15 +536,14 @@ class CourseTest < ActiveSupport::TestCase
   end
 
   test "valid_courses all versions" do
-    # The data here must be in sync with the data in ScriptConstants.rb
-    csp = create(:course, name: 'csp-2017')
+    csp = create(:course, name: 'csp-2017', visible: true, is_stable: true)
     csp1 = create(:script, name: 'csp1')
     csp2 = create(:script, name: 'csp2')
     csp2_alt = create(:script, name: 'csp2-alt', hidden: true)
     csp3 = create(:script, name: 'csp3')
-    csp18 = create(:course, name: 'csp-2018')
-    csd = create(:course, name: 'csd-2017')
-    csd18 = create(:course, name: 'csd-2018')
+    csp18 = create(:course, name: 'csp-2018', visible: true, is_stable: true)
+    csd = create(:course, name: 'csd-2017', visible: true, is_stable: true)
+    csd18 = create(:course, name: 'csd-2018', visible: true, is_stable: true)
     create(:course, name: 'madeup')
 
     create(:course_script, position: 1, course: csp, script: csp1)
@@ -574,8 +571,7 @@ class CourseTest < ActiveSupport::TestCase
     # has fields from ScriptConstants::Assignable_Info
     assert_equal csp.id, csp_assign_info[:id]
     assert_equal 'csp-2017', csp_assign_info[:script_name]
-    assert_equal 0, csp_assign_info[:position]
-    assert_equal(0, csp_assign_info[:category_priority])
+    assert_equal(-1, csp_assign_info[:category_priority])
 
     # has localized name, category
     assert_equal "Computer Science Principles ('17-'18)", csp_assign_info[:name]

--- a/lib/cdo/script_constants.rb
+++ b/lib/cdo/script_constants.rb
@@ -19,14 +19,6 @@ module ScriptConstants
   # a category will be the order in which they appear in the dropdown, and the
   # order of the categories will be their order in the dropdown.
   CATEGORIES = {
-    full_course: [
-      CSP_2017 = 'csp-2017'.freeze,
-      CSP_2018 = 'csp-2018'.freeze,
-      CSP_2019 = 'csp-2019'.freeze,
-      CSD_2017 = 'csd-2017'.freeze,
-      CSD_2018 = 'csd-2018'.freeze,
-      CSD_2019 = 'csd-2019'.freeze,
-    ],
     csf: [
       COURSEA_NAME = 'coursea-2017'.freeze,
       COURSEB_NAME = 'courseb-2017'.freeze,

--- a/lib/test/test_script_constants.rb
+++ b/lib/test/test_script_constants.rb
@@ -62,9 +62,8 @@ class ScriptConstantsTest < Minitest::Test
   end
 
   def test_category_priority
-    assert_equal 0, ScriptConstants.category_priority(:full_course)
-    assert_equal 6, ScriptConstants.category_priority(:csf_international)
-    assert_equal 8, ScriptConstants.category_priority(:research_studies)
+    assert_equal 5, ScriptConstants.category_priority(:csf_international)
+    assert_equal 7, ScriptConstants.category_priority(:research_studies)
   end
 
   def test_assignable_info


### PR DESCRIPTION
I decided to go with `visible` rather than `hidden` since I found the double negative to be harder to parse, and because `visible` and `is_stable` should generally match each other. It is inconsistent with the naming for `Script`, so let me know if you strongly prefer the other way.

This introduces slight changes to the data returned by `dashboardapi/courses` and `dashboardapi/sections/valid_scripts`. `/courses` still returns the same six courses, but `position` is `nil` and `category_priority` is -1 instead of 0. `category_priority` for everything else in `ScriptConstants::CATEGORIES` is also decreased by one, so the `category_priority` for full courses must be -1 so it can stay at the top of the dropdown. I think the position being nil doesn't matter for the dropdown use case since it sorts by `category_priority` first: https://github.com/code-dot-org/code-dot-org/blob/77b823b60e8e3bce9b6a9629a5f0053ac8348782/apps/src/templates/teacherDashboard/AssignmentSelector.jsx#L41-L51

## Links

<!--
  Any relevant links to external resources; ie, specification documents, jira
  items, related PRs, honeybadger errors, etc
-->

- [jira](https://codedotorg.atlassian.net/browse/PLAT-47)

## Testing story

- Unit tests
- Verified locally that dropdown looks the same after changes:
![image](https://user-images.githubusercontent.com/6564873/80042164-27cd4d80-84b3-11ea-88fc-fe9cd2ed7b85.png)

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
