### PR TITLE
"Hide Toolbar" Helper

### DIFF
--- a/apps/i18n/common/en_us.json
+++ b/apps/i18n/common/en_us.json
@@ -814,6 +814,7 @@
   "hideProjectSharingColumn": "Hide project sharing column",
   "hideSection": "Hide Section",
   "hideSecret": "Hide secret",
+  "hideToolbarHelper": "Press **_A_A** and choose **Hide Toolbar** to see the full screen.",
   "hideToolbox": "(Hide)",
   "hintHeader": "Here's a tip:",
   "hintPrompt": "Need help?",

--- a/apps/src/templates/HideToolbarHelper.jsx
+++ b/apps/src/templates/HideToolbarHelper.jsx
@@ -16,7 +16,7 @@ const styles = {
 
 // Note that additional styling can be found in apps/style/HideToolbarHelper.scss.
 
-const HidetoolbarHelperCookieName = 'hide_toolbar_helper';
+const HideToolbarHelperCookieName = 'hide_toolbar_helper';
 
 /**
  * An overlay with instrutions on hiding the toolbar for iPhone with iOS 13.
@@ -39,7 +39,7 @@ export default class HideToolbarHelper extends React.Component {
 
   updateLayout = () => {
     const isiOS13 = navigator.userAgent.indexOf('iPhone OS 13') !== -1;
-    const isHideCookieSet = cookies.get(HidetoolbarHelperCookieName);
+    const isHideCookieSet = cookies.get(HideToolbarHelperCookieName);
     const isLandscape = window.orientation !== 0;
 
     // window.innerHeight is smaller than document.body.offsetHeight when
@@ -88,7 +88,7 @@ export default class HideToolbarHelper extends React.Component {
   }
 
   onClick = () => {
-    cookies.set(HidetoolbarHelperCookieName, 'true', {expires: 365, path: '/'});
+    cookies.set(HideToolbarHelperCookieName, 'true', {expires: 365, path: '/'});
     this.updateLayout();
 
     // Let's track the click-to-dismiss event.

--- a/apps/src/templates/HideToolbarHelper.jsx
+++ b/apps/src/templates/HideToolbarHelper.jsx
@@ -34,7 +34,7 @@ export default class HideToolbarHelper extends React.Component {
     this.wasToolbarShowing = false;
 
     // ...but only track it once.
-    this.trackedToolbarHide = false;
+    this.didTrackToolbarHide = false;
   }
 
   updateLayout = () => {
@@ -52,11 +52,11 @@ export default class HideToolbarHelper extends React.Component {
     if (
       this.wasToolbarShowing &&
       !isToolbarShowing &&
-      !this.trackedToolbarHide
+      !this.didTrackToolbarHide
     ) {
       trackEvent('Research', 'HideToolbarHelper', 'hid-' + window.innerHeight);
 
-      this.trackedToolbarHide = true;
+      this.didTrackToolbarHide = true;
     }
     this.wasToolbarShowing = isToolbarShowing;
 

--- a/apps/src/templates/HideToolbarHelper.jsx
+++ b/apps/src/templates/HideToolbarHelper.jsx
@@ -1,0 +1,54 @@
+import React from 'react';
+import cookies from 'js-cookie';
+import _ from 'lodash';
+
+/**
+ * An overlay with instrutions on hiding the toolbar for iPhone with iOS 13.
+ */
+export default class HideToolbarHelper extends React.Component {
+  state = {
+    isLandscape: false
+  };
+
+  updateOrientation = () => {
+    this.setState({isLandscape: window.orientation !== 0});
+  };
+
+  componentDidMount() {
+    this.updateOrientation();
+
+    this.orientationListener = _.throttle(this.updateOrientation, 200);
+    window.addEventListener('orientationchange', this.orientationListener);
+    window.addEventListener('resize', this.orientationListener);
+  }
+
+  componentWillUnmount() {
+    document.removeEventListener(
+      'orientationchange',
+      this.orientationListener,
+      false
+    );
+    document.removeEventListener('resize', this.orientationListener, false);
+  }
+
+  render() {
+    const isiOS13 = navigator.userAgent.indexOf('iPhone OS 13') !== -1;
+    const isHideCookieSet = cookies.get('hide_toolbar_helper');
+    const isToolbarShowing = window.innerHeight < document.body.offsetHeight;
+
+    if (
+      isiOS13 &&
+      !isHideCookieSet &&
+      this.state.isLandscape &&
+      isToolbarShowing
+    ) {
+      return (
+        <div className="hide_toolbar_helper">
+          Press AA and choose Hide Toolbar for more space. }
+        </div>
+      );
+    } else {
+      return null;
+    }
+  }
+}

--- a/apps/src/templates/HideToolbarHelper.jsx
+++ b/apps/src/templates/HideToolbarHelper.jsx
@@ -42,16 +42,32 @@ export default class HideToolbarHelper extends React.Component {
     }
   }
 
+  isiOS13() {
+    return navigator.userAgent.indexOf('iPhone OS 13') !== -1;
+  }
+
+  isHideCookieSet() {
+    return cookies.get(HideToolbarHelperCookieName);
+  }
+
+  isLandscape() {
+    return window.orientation !== 0;
+  }
+
+  isToolbarShowing() {
+    return window.innerHeight < document.body.offsetHeight;
+  }
+
   updateLayout = () => {
-    const isiOS13 = navigator.userAgent.indexOf('iPhone OS 13') !== -1;
-    const isHideCookieSet = cookies.get(HideToolbarHelperCookieName);
-    const isLandscape = window.orientation !== 0;
+    const isiOS13 = this.isiOS13();
+    const isHideCookieSet = this.isHideCookieSet();
+    const isLandscape = this.isLandscape();
 
     // window.innerHeight is smaller than document.body.offsetHeight when
     // the iOS 13 Safari toolbar is showing.  It becomes equal when the toolbar
     // is hidden.  (Interestingly, document.documentElement.clientHeight is
     // the same as document.body.offsetHeight in both cases.)
-    const isToolbarShowing = window.innerHeight < document.body.offsetHeight;
+    const isToolbarShowing = this.isToolbarShowing();
 
     if (
       this.wasToolbarShowing &&
@@ -61,7 +77,7 @@ export default class HideToolbarHelper extends React.Component {
       // Let's track the disapearance of the toolbar.
       trackEvent('Research', 'HideToolbarHelper', 'hid-' + window.innerHeight);
 
-      // And also set the cookie so the this use doesn't see the helper again
+      // And also set the cookie so this user doesn't see the helper again
       // for a year.
       this.setHideHelperCookie();
 

--- a/apps/src/templates/HideToolbarHelper.jsx
+++ b/apps/src/templates/HideToolbarHelper.jsx
@@ -1,50 +1,78 @@
 import React from 'react';
+import msg from '@cdo/locale';
 import cookies from 'js-cookie';
+import SafeMarkdown from '@cdo/apps/templates/SafeMarkdown';
 import _ from 'lodash';
+
+const styles = {
+  closeX: {
+    position: 'absolute',
+    top: 5,
+    right: 5,
+    fontSize: 13
+  }
+};
 
 /**
  * An overlay with instrutions on hiding the toolbar for iPhone with iOS 13.
  */
 export default class HideToolbarHelper extends React.Component {
   state = {
-    isLandscape: false
+    showHelper: false
   };
 
-  updateOrientation = () => {
-    this.setState({isLandscape: window.orientation !== 0});
+  updateLayout = () => {
+    const isiOS13 = navigator.userAgent.indexOf('iPhone OS 13') !== -1;
+    const isHideCookieSet = cookies.get('hide_toolbar_helper');
+    const isLandscape = window.orientation !== 0;
+
+    // window.innerHeight is smaller than document.body.offsetHeight when
+    // the iOS 13 Safari toolbar is showing.  It becomes equal when the toolbar
+    // is hidden.  (Interestingly, document.documentElement.clientHeight is
+    // the same as document.body.offsetHeight in both cases.)
+    const isToolbarShowing = window.innerHeight < document.body.offsetHeight;
+
+    const showHelper =
+      isiOS13 && !isHideCookieSet && isLandscape && isToolbarShowing;
+
+    this.setState({showHelper});
   };
 
   componentDidMount() {
-    this.updateOrientation();
+    this.updateLayout();
 
-    this.orientationListener = _.throttle(this.updateOrientation, 200);
-    window.addEventListener('orientationchange', this.orientationListener);
-    window.addEventListener('resize', this.orientationListener);
+    this.updateLayoutListener = _.throttle(this.updateLayout, 200);
+    window.addEventListener('orientationchange', this.updateLayoutListener);
+
+    /* These two events catch all viewport changes. */
+    window.addEventListener('resize', this.updateLayoutListener);
+    window.addEventListener('scroll', this.updateLayoutListener);
   }
 
   componentWillUnmount() {
     document.removeEventListener(
       'orientationchange',
-      this.orientationListener,
+      this.updateLayoutListener,
       false
     );
-    document.removeEventListener('resize', this.orientationListener, false);
+    document.removeEventListener('resize', this.updateLayoutListener, false);
+    document.removeEventListener('scroll', this.updateLayoutListener, false);
   }
 
-  render() {
-    const isiOS13 = navigator.userAgent.indexOf('iPhone OS 13') !== -1;
-    const isHideCookieSet = cookies.get('hide_toolbar_helper');
-    const isToolbarShowing = window.innerHeight < document.body.offsetHeight;
+  onClick = () => {
+    cookies.set('hide_toolbar_helper', 'true', {expires: 365, path: '/'});
+    this.updateLayout();
+  };
 
-    if (
-      isiOS13 &&
-      !isHideCookieSet &&
-      this.state.isLandscape &&
-      isToolbarShowing
-    ) {
+  render() {
+    const forceShowHelper =
+      window.location.search.indexOf('force_show_toolbar_helper') !== -1;
+
+    if (this.state.showHelper || forceShowHelper) {
       return (
-        <div className="hide_toolbar_helper">
-          Press AA and choose Hide Toolbar for more space. }
+        <div className="hide_toolbar_helper" onClick={this.onClick}>
+          <SafeMarkdown markdown={msg.hideToolbarHelper()} />
+          <i className="fa fa-times" style={styles.closeX} />
         </div>
       );
     } else {

--- a/apps/src/templates/StudioAppWrapper.jsx
+++ b/apps/src/templates/StudioAppWrapper.jsx
@@ -1,5 +1,6 @@
 import PropTypes from 'prop-types';
 import React from 'react';
+import HideToolbarHelper from '../templates/HideToolbarHelper';
 import RotateContainer from '../templates/RotateContainer';
 import {connect} from 'react-redux';
 
@@ -22,6 +23,7 @@ class StudioAppWrapper extends React.Component {
   render() {
     return (
       <div>
+        <HideToolbarHelper />
         {this.requiresLandscape() && (
           <RotateContainer assetUrl={this.props.assetUrl} />
         )}

--- a/apps/style/HideToolbarHelper.scss
+++ b/apps/style/HideToolbarHelper.scss
@@ -3,15 +3,24 @@
 .hide_toolbar_helper {
   position: fixed;
   top: 22px;
-  left: 10%;
+  left: 6%;
   background-color: white;
   color: black;
   z-index: 2;
-  padding: 20px;
+  padding: 20px 40px 20px 20px;
   max-width: 30%;
   border-radius: 5px;
   background: #fff;
   border: 1px solid #000;
+
+  em {
+    font-size: 70%;
+    font-family: inherit;
+  }
+
+  p {
+    margin-bottom: 0px;
+  }
 }
 
 .hide_toolbar_helper:after, .hide_toolbar_helper:before {
@@ -31,6 +40,7 @@
   border-width: 20px;
   margin-left: -20px;
 }
+
 .hide_toolbar_helper:before {
   border-color: rgba(0, 0, 0, 0);
   border-bottom-color: #000;

--- a/apps/style/HideToolbarHelper.scss
+++ b/apps/style/HideToolbarHelper.scss
@@ -1,0 +1,39 @@
+// Style rules associated with the HideToolbarHelper popup
+
+.hide_toolbar_helper {
+  position: fixed;
+  top: 22px;
+  left: 10%;
+  background-color: white;
+  color: black;
+  z-index: 2;
+  padding: 20px;
+  max-width: 30%;
+  border-radius: 5px;
+  background: #fff;
+  border: 1px solid #000;
+}
+
+.hide_toolbar_helper:after, .hide_toolbar_helper:before {
+  bottom: 100%;
+  left: 50%;
+  border: solid transparent;
+  content: " ";
+  height: 0;
+  width: 0;
+  position: absolute;
+  pointer-events: none;
+}
+
+.hide_toolbar_helper:after {
+  border-color: rgba(255, 255, 255, 0);
+  border-bottom-color: #fff;
+  border-width: 20px;
+  margin-left: -20px;
+}
+.hide_toolbar_helper:before {
+  border-color: rgba(0, 0, 0, 0);
+  border-bottom-color: #000;
+  border-width: 21px;
+  margin-left: -21px;
+}

--- a/apps/style/HideToolbarHelper.scss
+++ b/apps/style/HideToolbarHelper.scss
@@ -4,11 +4,11 @@
   position: fixed;
   top: 22px;
   left: 6%;
-  background-color: white;
-  color: black;
-  z-index: 2;
+  background-color: $white;
+  color: $black;
+  z-index: 1040;
   padding: 20px 40px 20px 20px;
-  max-width: 30%;
+  max-width: 40%;
   border-radius: 5px;
   background: #fff;
   border: 1px solid #000;
@@ -19,6 +19,7 @@
   }
 
   p {
+    font-size: 16px;
     margin-bottom: 0px;
   }
 }

--- a/apps/style/common.scss
+++ b/apps/style/common.scss
@@ -1712,3 +1712,4 @@ a.WireframeButtons_active, div.WireframeButtons_active {
 }
 
 @import "RotateContainer";
+@import "HideToolbarHelper";

--- a/apps/test/unit/templates/instructions/HideToolbarHelperTest.jsx
+++ b/apps/test/unit/templates/instructions/HideToolbarHelperTest.jsx
@@ -1,0 +1,65 @@
+import React from 'react';
+import {expect} from '../../../util/deprecatedChai';
+import {shallow} from 'enzyme';
+import sinon from 'sinon';
+import HideToolbarHelper from '@cdo/apps/templates/HideToolbarHelper';
+
+describe('HideToolbarHelper', function() {
+  it('shows the hide toolbar helper', function() {
+    const component = shallow(<HideToolbarHelper />);
+
+    const instance = component.instance();
+
+    sinon.stub(instance, 'isiOS13').returns(true);
+    sinon.stub(instance, 'isHideCookieSet').returns(false);
+    sinon.stub(instance, 'isLandscape').returns(true);
+    sinon.stub(instance, 'isToolbarShowing').returns(true);
+
+    instance.updateLayout();
+
+    expect(instance.state.showHelper).to.be.true;
+  });
+
+  it('does not show the hide toolbar helper', function() {
+    const component = shallow(<HideToolbarHelper />);
+
+    const instance = component.instance();
+
+    sinon.stub(instance, 'isiOS13').returns(true);
+    sinon.stub(instance, 'isHideCookieSet').returns(false);
+    sinon.stub(instance, 'isLandscape').returns(true);
+    sinon.stub(instance, 'isToolbarShowing').returns(false);
+
+    instance.updateLayout();
+
+    expect(instance.state.showHelper).to.be.false;
+  });
+
+  it('we set a cookie when the toolbar goes away', function() {
+    const component = shallow(<HideToolbarHelper />);
+
+    const instance = component.instance();
+
+    const setHideHelperCookie = sinon.stub(instance, 'setHideHelperCookie');
+
+    sinon.stub(instance, 'isiOS13').returns(true);
+    sinon.stub(instance, 'isHideCookieSet').returns(false);
+    sinon.stub(instance, 'isLandscape').returns(true);
+    const isToolbarShowing = sinon
+      .stub(instance, 'isToolbarShowing')
+      .returns(true);
+
+    instance.updateLayout();
+
+    expect(instance.state.showHelper).to.be.true;
+    expect(setHideHelperCookie).not.to.have.been.called;
+
+    isToolbarShowing.restore();
+    sinon.stub(instance, 'isToolbarShowing').returns(false);
+
+    instance.updateLayout();
+
+    expect(instance.state.showHelper).to.be.false;
+    expect(setHideHelperCookie).to.have.been.called;
+  });
+});


### PR DESCRIPTION
This adds a small helper UI that pops up when it detects an iPhone running iOS 13 in landscape mode, when we believe the Toolbar is still showing.  We suggest that the user use iOS Safari's built-in "Hide Toolbar" option to better see the current level.

Once dismissed, by clicking anywhere on it, a `hide_toolbar_helper` cookie is written to not show it again for a year.  The cookie is also written if we detect that we've gone from the toolbar showing to the toolbar being hidden, so that users who successfully hide it once will also no longer see the helper.

For testing purposes, `?force_show_toolbar_helper=true` can be added to a URL to force it to show again by removing the cookie.

We track Google Analytics events for both the click-to-hide, and for the first time the toolbar is detected to have gone away.  These events will help understand how often users engage with the feature, as well as gather data on phone heights.

![IMG_0972](https://user-images.githubusercontent.com/2205926/80257071-f9777b80-8634-11ea-85a4-68d090042626.PNG)

