### PR TITLE
Legacy Survey Summaries: Fix exception on empty summary

### DIFF
--- a/dashboard/lib/pd/foorm/legacy_survey_summaries.rb
+++ b/dashboard/lib/pd/foorm/legacy_survey_summaries.rb
@@ -8,7 +8,7 @@ module Pd::Foorm
         course: Pd::Workshop::COURSE_CSF,
         subject: Pd::Workshop::SUBJECT_CSF_101
       ).first&.data
-      csf_intro_post_workshop_from_pegasus = JSON.parse(data) if data
+      csf_intro_post_workshop_from_pegasus = data ? JSON.parse(data) : {}
 
       # (Lookup strings from IDs.)
       csf_intro_post_workshop_from_pegasus_with_strings = {}
@@ -22,7 +22,7 @@ module Pd::Foorm
         course: Pd::Workshop::COURSE_CSF,
         subject: Pd::Workshop::SUBJECT_CSF_101
       ).first&.data
-      csf_intro_post_workshop_from_pegasus_for_all_workshops = JSON.parse(data) if data
+      csf_intro_post_workshop_from_pegasus_for_all_workshops = data ? JSON.parse(data) : {}
 
       # (Lookup strings from IDs.)
       csf_intro_post_workshop_from_pegasus_for_all_workshops_with_strings = {}
@@ -36,7 +36,7 @@ module Pd::Foorm
         course: Pd::Workshop::COURSE_CSD,
         subject: Pd::Workshop::SUBJECT_SUMMER_WORKSHOP
       ).first&.data
-      csd_summer_workshops_from_jotform = JSON.parse(data) if data
+      csd_summer_workshops_from_jotform = data ? JSON.parse(data) : {}
 
       # CSP summer workshops
       data = Pd::LegacySurveySummary.where(
@@ -44,7 +44,7 @@ module Pd::Foorm
         course: Pd::Workshop::COURSE_CSP,
         subject: Pd::Workshop::SUBJECT_SUMMER_WORKSHOP
       ).first&.data
-      csp_summer_workshops_from_jotform = JSON.parse(data) if data
+      csp_summer_workshops_from_jotform = data ? JSON.parse(data) : {}
 
       # Return everything.
       {

--- a/dashboard/test/lib/pd/foorm/legacy_survey_summaries_test.rb
+++ b/dashboard/test/lib/pd/foorm/legacy_survey_summaries_test.rb
@@ -1,0 +1,12 @@
+require 'test_helper'
+
+module Pd::Foorm
+  class LegacySurveySummariesTest < ActiveSupport::TestCase
+    test 'no errors if there are no summaries for the user' do
+      facilitator = create :facilitator
+      result = LegacySurveySummaries.get_summaries(facilitator)
+
+      assert_not_empty result
+    end
+  end
+end


### PR DESCRIPTION
The legacy survey summary creator was throwing an exception if there was no summary for the given user, this fix returns empty data in that case.

## Testing story
Added a unit test to validate the scenario and tested manually for a user without a legacy summary.

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
