### PR TITLE
Make sure lessons are ordered by their position inside the lesson group

### DIFF
--- a/dashboard/app/models/lesson_group.rb
+++ b/dashboard/app/models/lesson_group.rb
@@ -17,7 +17,7 @@
 
 class LessonGroup < ApplicationRecord
   belongs_to :script
-  has_many :lessons
+  has_many :lessons, -> {order('absolute_position ASC')}
 
   validates_uniqueness_of :key, scope: :script_id
 


### PR DESCRIPTION
Mike reported that lessons in his script were getting reordered on the /edit page even after he changed them and saved them.

I tracked this down to the new lesson groups changes. Lessons right now are ordered for the script but not in the lesson group. This caused problems when we when to serialize the lesson groups for dsl:

```
      lesson_group.lessons.each do |lesson|
        s << serialize_stage(lesson)
      end
```

The order of the lessons would be based on creation instead of their absolute position. 

In the model we now order lessons by absolute position in the lesson group as well. 

I want to get this change out ASAP to unblock Mike but I will follow up with tests to make sure this works going forward.

