### PR TITLE
CSPWFRT: Enrollment confirmation email

### DIFF
--- a/dashboard/app/views/pd/workshop_mailer/_supply_list.html.haml
+++ b/dashboard/app/views/pd/workshop_mailer/_supply_list.html.haml
@@ -18,5 +18,5 @@
       do not have one available, one will be provided for you at the workshop.
   - if @workshop.csf? && @is_enrollment_receipt
     %li Your curiosity and readiness to learn!
-  - unless @workshop.summer? || @workshop.fit_weekend? || @workshop.csf?
+  - unless @workshop.summer? || @workshop.fit_weekend? || @workshop.csf? || (@workshop.subject == Pd::Workshop::SUBJECT_CSP_FOR_RETURNING_TEACHERS)
     %li Code.org Curriculum Guide.

--- a/dashboard/app/views/pd/workshop_mailer/_teacher_enrollment_details.html.haml
+++ b/dashboard/app/views/pd/workshop_mailer/_teacher_enrollment_details.html.haml
@@ -46,8 +46,12 @@
     = render partial: 'csp_pre_course_reading'
 
 %p
-  If you have any accessibility needs or food allergies, please let the workshop organizer know so they can make appropriate accommodation plans and answer any of your questions. You can reach them at
-  = mail_to(@workshop.organizer.email) + '.'
+  - if @workshop.subject == Pd::Workshop::SUBJECT_CSP_FOR_RETURNING_TEACHERS
+    If you have any accessibility needs or food allergies, please contact the workshop organizer to discuss appropriate accommodation plans and to answer any of your questions. You can reach them at
+    = mail_to(@workshop.organizer.email) + '.'
+  - else
+    If you have any accessibility needs or food allergies, please let the workshop organizer know so they can make appropriate accommodation plans and answer any of your questions. You can reach them at
+    = mail_to(@workshop.organizer.email) + '.'
 
 %p
   Thank you,

--- a/dashboard/app/views/pd/workshop_mailer/_teacher_enrollment_details.html.haml
+++ b/dashboard/app/views/pd/workshop_mailer/_teacher_enrollment_details.html.haml
@@ -46,12 +46,8 @@
     = render partial: 'csp_pre_course_reading'
 
 %p
-  - if @workshop.subject == Pd::Workshop::SUBJECT_CSP_FOR_RETURNING_TEACHERS
-    If you have any accessibility needs or food allergies, please contact the workshop organizer to discuss appropriate accommodation plans and to answer any of your questions. You can reach them at
-    = mail_to(@workshop.organizer.email) + '.'
-  - else
-    If you have any accessibility needs or food allergies, please let the workshop organizer know so they can make appropriate accommodation plans and answer any of your questions. You can reach them at
-    = mail_to(@workshop.organizer.email) + '.'
+  If you have any accessibility needs or food allergies, please contact the workshop organizer to discuss appropriate accommodation plans and to answer any of your questions. You can reach them at
+  = mail_to(@workshop.organizer.email) + '.'
 
 %p
   Thank you,

--- a/dashboard/test/mailers/previews/pd_workshop_mailer_preview.rb
+++ b/dashboard/test/mailers/previews/pd_workshop_mailer_preview.rb
@@ -42,6 +42,10 @@ class Pd::WorkshopMailerPreview < ActionMailer::Preview
     mail :teacher_enrollment_receipt, Pd::Workshop::COURSE_ADMIN
   end
 
+  def teacher_enrollment_receipt__csp_for_returning_teachers
+    mail :teacher_enrollment_receipt, Pd::Workshop::COURSE_CSP, Pd::Workshop::SUBJECT_CSP_FOR_RETURNING_TEACHERS
+  end
+
   def teacher_enrollment_receipt__formatted_notes
     notes = <<-NOTES.strip_heredoc
       This is a multi-line, formatted notes section, with preserved whitespace:


### PR DESCRIPTION
Fix up the enrollment confirmation email for the new CSP Workshop for Returning Teachers workshop type. ([spec](https://docs.google.com/document/d/1u1Vfm5DnsBpwUrV2XLp9XMcF2R3SU7b1EAtlBBB6wEU/edit#))

![image](https://user-images.githubusercontent.com/1615761/80137204-c6ab8580-8557-11ea-817c-b7871a125e16.png)

## Testing story

Tested using rails mailer previews.

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
