### PR TITLE
CSPWFRT: Workshops cannot be Code.org funded

### DIFF
--- a/apps/src/code-studio/pd/workshop_dashboard/components/workshop_form.jsx
+++ b/apps/src/code-studio/pd/workshop_dashboard/components/workshop_form.jsx
@@ -405,7 +405,7 @@ export class WorkshopForm extends React.Component {
           text: 'Yes, it is funded. Please pay the Facilitator directly.'
         }
       );
-    } else {
+    } else if (this.state.subject !== 'Workshop for Returning Teachers') {
       options.push({
         value: {funded: true, funding_type: null},
         text: 'Yes, it is funded.'


### PR DESCRIPTION
Removes the ability to mark the workshop as "Code.org funded" for this one workshop type. ([spec](https://docs.google.com/document/d/1u1Vfm5DnsBpwUrV2XLp9XMcF2R3SU7b1EAtlBBB6wEU/edit#))

Done in kind of a clumsy way by leaving a one-option dropdown, for this temporary workshop type.  Seemed fastest, and better than nothing.

![image](https://user-images.githubusercontent.com/1615761/80143873-5ce4a900-8562-11ea-8df6-7dc63e08daa6.png)

## Testing story

Quick local testing.

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
