### PR TITLE
Add tests for lesson ordering in lesson group

### DIFF
--- a/dashboard/test/dsl/script_dsl_test.rb
+++ b/dashboard/test/dsl/script_dsl_test.rb
@@ -935,4 +935,31 @@ level 'Level 3'
     assert_equal expected, output
     assert_equal i18n_expected, i18n
   end
+
+  test 'serialize lessons in lesson groups in the correct order' do
+    script = create :script, hidden: true
+
+    level1 = create :maze, name: 'maze 1', level_num: 'custom'
+    level2 = create :maze, name: 'maze 2', level_num: 'custom'
+
+    lesson_group = create :lesson_group, key: 'content1', script: script, position: 1
+
+    # intentionally made in the opposite order of how we want them to show to test
+    lesson2 = create :lesson, name: 'lesson 2', script: script, lesson_group: lesson_group, absolute_position: 2
+    lesson1 = create :lesson, name: 'lesson 1', script: script, lesson_group: lesson_group, absolute_position: 1
+
+    create :script_level, levels: [level1], lesson: lesson1, script: script
+    script_level2 = create :script_level, levels: [level2], lesson: lesson2, script: script
+    script_text = ScriptDSL.serialize_to_string(script_level2.script)
+    expected = <<~SCRIPT
+      lesson_group 'content1', display_name: 'Content'
+      stage 'lesson 1'
+      level 'maze 1'
+
+      stage 'lesson 2'
+      level 'maze 2'
+
+    SCRIPT
+    assert_equal expected, script_text
+  end
 end

--- a/dashboard/test/models/lesson_group_test.rb
+++ b/dashboard/test/models/lesson_group_test.rb
@@ -5,4 +5,13 @@ class LessonGroupTest < ActiveSupport::TestCase
     lesson_group = create :lesson_group, key: 'Test'
     assert_equal "Bogus Lesson Group #{lesson_group.key}", 'Bogus Lesson Group Test'
   end
+  test "lessons ordered correctly" do
+    script = create :script
+    lesson_group = create :lesson_group
+    create :lesson, name: "Lesson3", script: script, lesson_group: lesson_group, absolute_position: 3
+    create :lesson, name: "Lesson2", script: script, lesson_group: lesson_group, absolute_position: 2
+    create :lesson, name: "Lesson1", script: script, lesson_group: lesson_group, absolute_position: 1
+
+    assert_equal ["Lesson1", "Lesson2", "Lesson3"], lesson_group.lessons.collect(&:name)
+  end
 end


### PR DESCRIPTION
Tests for https://github.com/code-dot-org/code-dot-org/pull/34395

I checked that both of these test failed before the change and then passed after the change.
