### PR TITLE
CSPWFRT: Enrollment reminder emails

### DIFF
--- a/dashboard/app/models/pd/workshop.rb
+++ b/dashboard/app/models/pd/workshop.rb
@@ -674,6 +674,7 @@ class Pd::Workshop < ActiveRecord::Base
   end
 
   def pre_survey?
+    return false if subject == SUBJECT_CSP_FOR_RETURNING_TEACHERS
     PRE_SURVEY_BY_COURSE.key? course
   end
 

--- a/dashboard/app/views/pd/workshop_mailer/teacher_enrollment_reminder.html.haml
+++ b/dashboard/app/views/pd/workshop_mailer/teacher_enrollment_reminder.html.haml
@@ -48,8 +48,8 @@
   %p
     - if @workshop.course == Pd::Workshop::COURSE_CSF
       This is a great step towards bringing computer science to your classroom!
-    - else
-    We’re excited to continue to work together to bring computer science to your classroom.
+    - unless @workshop.subject == Pd::Workshop::SUBJECT_CSP_FOR_RETURNING_TEACHERS
+      We’re excited to continue to work together to bring computer science to your classroom.
     If you have any questions, reach out to your workshop organizer directly:
     = "#{@organizer.name} at "
     = mail_to @organizer.email, "#{@organizer.email}."

--- a/dashboard/test/mailers/previews/pd_workshop_mailer_preview.rb
+++ b/dashboard/test/mailers/previews/pd_workshop_mailer_preview.rb
@@ -135,6 +135,16 @@ class Pd::WorkshopMailerPreview < ActionMailer::Preview
     mail :teacher_enrollment_reminder, Pd::Workshop::COURSE_COUNSELOR
   end
 
+  def teacher_enrollment_reminder__csp_for_returning_teachers_10_day
+    mail :teacher_enrollment_reminder, Pd::Workshop::COURSE_CSP, Pd::Workshop::SUBJECT_CSP_FOR_RETURNING_TEACHERS,
+      options: {days_before: 10}
+  end
+
+  def teacher_enrollment_reminder__csp_for_returning_teachers_3_day
+    mail :teacher_enrollment_reminder, Pd::Workshop::COURSE_CSP, Pd::Workshop::SUBJECT_CSP_FOR_RETURNING_TEACHERS,
+      options: {days_before: 3}
+  end
+
   def teacher_follow_up__csf_intro_with_rp
     facilitator1 = build :facilitator, name: 'Fiona Facilitator', email: 'fiona_facilitator@example.net'
     facilitator2 = build :facilitator, name: 'Fred Facilitator', email: 'fred_facilitator@example.net'


### PR DESCRIPTION
Small updates for the 10-day and 3-day enrollment emails for the new CS Principles Workshop for Returning Teachers workshop type. ([spec](https://docs.google.com/document/d/1u1Vfm5DnsBpwUrV2XLp9XMcF2R3SU7b1EAtlBBB6wEU/edit#))

10-day reminder:

![image](https://user-images.githubusercontent.com/1615761/80151536-147fb800-856f-11ea-8b12-00d8832a47c7.png)

3-day reminder:

![image](https://user-images.githubusercontent.com/1615761/80151573-23ff0100-856f-11ea-97e0-cbf198cd5438.png)

## Testing story

Tested locally with the Rails mailer previews.

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
