### PR TITLE
Skip AppServerMetricsTest#test_reporting_task on non-Linux systems

### DIFF
--- a/lib/test/cdo/test_app_server_metrics.rb
+++ b/lib/test/cdo/test_app_server_metrics.rb
@@ -48,6 +48,9 @@ class AppServerMetricsTest < Minitest::Test
   end
 
   def test_reporting_task
+    # Note: this test only passes on Linux systems, since it relies on Raindrops reading from /proc/net/unix.
+    skip "Skip on non-Linux system" unless File.file? Raindrops::Linux::PROC_NET_UNIX_ARGS.first
+
     listener = Cdo::AppServerMetrics.new(nil,
       interval: 0.1,
       report_count: 2,


### PR DESCRIPTION
This test fails locally on my Mac. From @wjordan: 
> yea, it looks like the mechanism raindrops uses to check unix-socket listener stats is by reading /proc/net/unix which requires a component called 'procfs', which isn't available on OSX