### PR TITLE
CSPWFRT: Updated copy for exit survey mailer

### DIFF
--- a/dashboard/app/models/pd/enrollment.rb
+++ b/dashboard/app/models/pd/enrollment.rb
@@ -208,6 +208,9 @@ class Pd::Enrollment < ActiveRecord::Base
   def exit_survey_url
     if [Pd::Workshop::COURSE_ADMIN, Pd::Workshop::COURSE_COUNSELOR].include? workshop.course
       CDO.code_org_url "/pd-workshop-survey/counselor-admin/#{code}", CDO.default_scheme
+    elsif workshop.subject == Pd::Workshop::SUBJECT_CSP_FOR_RETURNING_TEACHERS
+      # TODO: This is a temporary, fake URL. Wire up a real one!
+      CDO.studio_url '/pd/workshop_survey/post'
     elsif workshop.summer?
       pd_new_workshop_survey_url(code, protocol: CDO.default_scheme)
     elsif [Pd::Workshop::COURSE_CSP, Pd::Workshop::COURSE_CSD].include?(workshop.course) && workshop.workshop_starting_date > Date.new(2018, 8, 1)

--- a/dashboard/app/views/pd/workshop_mailer/exit_survey.html.haml
+++ b/dashboard/app/views/pd/workshop_mailer/exit_survey.html.haml
@@ -11,16 +11,18 @@
 
 %p
   Thank you for attending a Code.org
-  = @workshop.course
   - if @workshop.course == Pd::Workshop::COURSE_CSF
+    = @workshop.course + ' ' + @workshop.subject + ' workshop'
+  - elsif @workshop.subject == Pd::Workshop::SUBJECT_CSP_FOR_RETURNING_TEACHERS
     = @workshop.subject
-  workshop on
+  - else
+    = @workshop.course + ' workshop'
+  on
   = @workshop.sessions.first.start_date_us_format + '.'
 
 %p
-  %strong
-    Please tell us about your experience by filling out this 5 minute
-    = link_to('survey', @survey_url) + '.'
+  Please tell us about your experience by filling out this 5 minute
+  = link_to('survey', @survey_url) + '.'
 
 %p
   %i Why? Because your opinion matters!!
@@ -30,9 +32,11 @@
   and your feedback helps us build the experience that teachers have in the future!
 
 %p
-  Please note that the facilitator of your session and your Regional Partner will see your responses.
-  Your name and email will not be shared with your facilitator or Regional Partner to protect your anonymity.
-  However, it's possible your facilitator or Regional Partner could identify you from your written responses.
+  Please note that your responses will be shared
+  %strong anonymously
+  with the facilitator of your workshop and your Regional Partner. Your responses are confidential
+  and your name and email will not be shared with your facilitator or Regional Partner. However,
+  it's possible your facilitator or Regional Partner could identify you from your written responses.
 
 %p
   %a{href: @survey_url,
@@ -58,7 +62,7 @@
     or connect with other teachers on our
     = link_to('teacher forum', 'https://forum.code.org/') + '.'
 
-- unless @workshop.subject == Pd::Workshop::SUBJECT_CSF_201
+- unless [Pd::Workshop::SUBJECT_CSF_201, Pd::Workshop::SUBJECT_CSP_FOR_RETURNING_TEACHERS].include? @workshop.subject
   %h3
     Additional workshop benefits
 

--- a/dashboard/test/mailers/previews/pd_workshop_mailer_preview.rb
+++ b/dashboard/test/mailers/previews/pd_workshop_mailer_preview.rb
@@ -251,6 +251,10 @@ class Pd::WorkshopMailerPreview < ActionMailer::Preview
     mail :exit_survey, Pd::Workshop::COURSE_CSD, Pd::Workshop::SUBJECT_CSD_WORKSHOP_1
   end
 
+  def exit_survey__csp_for_returning_teachers
+    mail :exit_survey, Pd::Workshop::COURSE_CSP, Pd::Workshop::SUBJECT_CSP_FOR_RETURNING_TEACHERS
+  end
+
   private
 
   def mail(method, course = nil, subject = nil, options: nil, target: :enrollment, workshop_params: {})


### PR DESCRIPTION
Updates the text of the exit survey email for the new CS Principles Workshop for Returning Teachers workshop type. ([spec](https://docs.google.com/document/d/1u1Vfm5DnsBpwUrV2XLp9XMcF2R3SU7b1EAtlBBB6wEU/edit#))

Had to drop in a nonfunctional exit survey URL for the new workshop type to get this to render.  We'll have to return to that when we actually get the generic exit survey up and running.

![image](https://user-images.githubusercontent.com/1615761/80158434-51eb4200-857d-11ea-97be-217525059601.png)


Note, it's intentional that some of the copy changes here apply to all workshop types.

## Testing story

Tested locally using Rails mailer preview.

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
