### PR TITLE
Standards: remove experiment stub from tests

### DIFF
--- a/apps/test/unit/templates/sectionProgress/SectionProgressTest.js
+++ b/apps/test/unit/templates/sectionProgress/SectionProgressTest.js
@@ -3,8 +3,6 @@ import {shallow} from 'enzyme';
 import {expect} from '../../../util/reconfiguredChai';
 import {UnconnectedSectionProgress} from '@cdo/apps/templates/sectionProgress/SectionProgress';
 import {ViewType} from '@cdo/apps/templates/sectionProgress/sectionProgressRedux';
-import sinon from 'sinon';
-import experiments from '@cdo/apps/util/experiments';
 
 const studentData = [
   {id: 1, name: 'studentb'},
@@ -78,7 +76,6 @@ describe('SectionProgress', () => {
   });
 
   it('shows standards view', () => {
-    sinon.stub(experiments, 'isEnabled').returns(true);
     const wrapper = shallow(
       <UnconnectedSectionProgress
         {...DEFAULT_PROPS}
@@ -86,7 +83,6 @@ describe('SectionProgress', () => {
       />
     );
     expect(wrapper.find('#uitest-standards-view').exists()).to.be.true;
-    experiments.isEnabled.restore();
   });
 
   it('shows student timestamps', () => {

--- a/apps/test/unit/templates/sectionProgress/SectionProgressToggleTest.js
+++ b/apps/test/unit/templates/sectionProgress/SectionProgressToggleTest.js
@@ -3,8 +3,6 @@ import {shallow, mount} from 'enzyme';
 import {expect} from '../../../util/reconfiguredChai';
 import {UnconnectedSectionProgressToggle} from '@cdo/apps/templates/sectionProgress/SectionProgressToggle';
 import {ViewType} from '@cdo/apps/templates/sectionProgress/sectionProgressRedux';
-import sinon from 'sinon';
-import experiments from '@cdo/apps/util/experiments';
 
 describe('SectionProgressToggle', () => {
   let DEFAULT_PROPS;
@@ -19,16 +17,13 @@ describe('SectionProgressToggle', () => {
   });
 
   it('standards toggle shows for CSF', () => {
-    sinon.stub(experiments, 'isEnabled').returns(true);
     const wrapper = mount(
       <UnconnectedSectionProgressToggle {...DEFAULT_PROPS} />
     );
     expect(wrapper.find('#uitest-standards-toggle').exists()).to.be.true;
-    experiments.isEnabled.restore();
   });
 
   it('standards toggle does not shows for non-CSF', () => {
-    sinon.stub(experiments, 'isEnabled').returns(true);
     const wrapper = shallow(
       <UnconnectedSectionProgressToggle
         {...DEFAULT_PROPS}
@@ -36,6 +31,5 @@ describe('SectionProgressToggle', () => {
       />
     );
     expect(wrapper.find('#uitest-standards-toggle').exists()).to.be.false;
-    experiments.isEnabled.restore();
   });
 });


### PR DESCRIPTION
Follow up to #34049 to clean up a few straggler references to the standards experiment flag. 
