### PR TITLE
Link from workshop view to survey results view

### DIFF
--- a/apps/src/code-studio/pd/workshop_dashboard/EnrollmentsPanel.jsx
+++ b/apps/src/code-studio/pd/workshop_dashboard/EnrollmentsPanel.jsx
@@ -179,6 +179,18 @@ export default class EnrollmentsPanel extends React.Component {
     });
   };
 
+  getViewSurveyUrl = (workshopId, course, subject) => {
+    if (
+      !['CS Discoveries', 'CS Principles', 'CS Fundamentals'].includes(course)
+    ) {
+      return null;
+    }
+
+    return course === 'CS Fundamentals' && subject === 'Intro'
+      ? `/pd/workshop_dashboard/survey_results/${workshopId}`
+      : `/pd/workshop_dashboard/daily_survey_results/${workshopId}`;
+  };
+
   render() {
     const {
       workshopId,
@@ -254,24 +266,39 @@ export default class EnrollmentsPanel extends React.Component {
       const firstSessionDate = moment
         .utc(workshop.sessions[0].start)
         .format('MMMM Do');
+
+      let viewSurveyUrl = this.getViewSurveyUrl(
+        workshopId,
+        workshop.course,
+        workshop.subject
+      );
+
       contents = (
-        <WorkshopEnrollment
-          workshopId={workshopId}
-          workshopCourse={workshop.course}
-          workshopSubject={workshop.subject}
-          workshopDate={firstSessionDate}
-          numSessions={workshop.sessions.length}
-          enrollments={enrollments}
-          onDelete={this.handleDeleteEnrollment}
-          onClickSelect={this.handleClickSelect}
-          accountRequiredForAttendance={
-            workshop['account_required_for_attendance?']
-          }
-          scholarshipWorkshop={workshop['scholarship_workshop?']}
-          activeTab={this.state.enrollmentActiveTab}
-          onTabSelect={this.handleEnrollmentActiveTabSelect}
-          selectedEnrollments={this.state.selectedEnrollments}
-        />
+        <div>
+          <WorkshopEnrollment
+            workshopId={workshopId}
+            workshopCourse={workshop.course}
+            workshopSubject={workshop.subject}
+            workshopDate={firstSessionDate}
+            numSessions={workshop.sessions.length}
+            enrollments={enrollments}
+            onDelete={this.handleDeleteEnrollment}
+            onClickSelect={this.handleClickSelect}
+            accountRequiredForAttendance={
+              workshop['account_required_for_attendance?']
+            }
+            scholarshipWorkshop={workshop['scholarship_workshop?']}
+            activeTab={this.state.enrollmentActiveTab}
+            onTabSelect={this.handleEnrollmentActiveTabSelect}
+            selectedEnrollments={this.state.selectedEnrollments}
+          />
+
+          {['In Progress', 'Ended'].includes(workshop.state) && viewSurveyUrl && (
+            <Button bsSize="xsmall" href={viewSurveyUrl} target="_blank">
+              View Survey Results
+            </Button>
+          )}
+        </div>
       );
     }
 


### PR DESCRIPTION
[PLC-758](https://codedotorg.atlassian.net/browse/PLC-758): Adds a button to open workshop survey results view (in a new tab) from workshop detail view.

The button is in the Enrollment panel of the workshop view where we also show pre-workshop survey results. It only appears for **in-progress/ended** **CSF/CSD/CSP** workshops.

<img width="568" alt="Screen Shot 2020-04-24 at 10 56 33 AM" src="https://user-images.githubusercontent.com/46507039/80242537-5a458a80-861a-11ea-8d04-7d942d0bd5f7.png">

## Links
Examples
Workshop dashboard: https://studio.code.org/pd/workshop_dashboard/workshops/
Workshop detail view: https://studio.code.org/pd/workshop_dashboard/workshops/8326

## Testing story
Manual test: Created workshops with different types and different states in dev environment.  Verified that the view-survey-results button appear and open correct links.

# Reviewer Checklist:
- [ ] Tests provide adequate coverage
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
