### PR TITLE
Fnd 785 prototype string url logging

### DIFF
--- a/dashboard/app/controllers/application_controller.rb
+++ b/dashboard/app/controllers/application_controller.rb
@@ -18,6 +18,8 @@ class ApplicationController < ActionController::Base
   # this is needed to avoid devise breaking on email param
   before_action :configure_permitted_parameters, if: :devise_controller?
 
+  before_action :setup_i18n_tracking
+
   around_action :with_locale
 
   before_action :fix_crawlers_with_bad_accept_headers
@@ -141,6 +143,11 @@ class ApplicationController < ActionController::Base
     devise_parameter_sanitizer.permit(:account_update) {|u| u.permit PERMITTED_USER_FIELDS}
     devise_parameter_sanitizer.permit(:sign_up) {|u| u.permit PERMITTED_USER_FIELDS}
     devise_parameter_sanitizer.permit(:sign_in) {|u| u.permit PERMITTED_USER_FIELDS}
+  end
+
+  # Capture the current request URL for i18n string tracking
+  def setup_i18n_tracking
+    Thread.current[:current_request_url] = request.url
   end
 
   def with_locale

--- a/lib/cdo/i18n_backend.rb
+++ b/lib/cdo/i18n_backend.rb
@@ -2,6 +2,7 @@ require 'i18n'
 require 'active_support/core_ext/numeric/bytes'
 require 'cdo/key_value'
 require 'cdo/honeybadger'
+require 'cdo/i18n_string_url_tracker'
 
 module Cdo
   module I18n
@@ -140,16 +141,34 @@ module Cdo
       end
     end
 
+    # Plugin for logging usage information about i18n strings.
+    module I18nStringUrlTrackerPlugin
+      def translate(locale, key, options = ::I18n::EMPTY_HASH)
+        result = super
+        url = Thread.current[:current_request_url]
+        scope = options[:scope]
+        # Note that the separator here might not cover some edge cases. If we find that the separator used here is not
+        # sufficient, then refactor the SmartTranslate module so we can use `get_valid_separator` here.
+        separator = options[:separator] || ::I18n.default_separator
+        # We don't pass in a locale because we want the union of all string keys across all locales.
+        normalized_key = ::I18n.normalize_keys(nil, key, scope, separator).join(separator)
+        I18nStringUrlTracker.instance.log(normalized_key, url) if key && url
+        result
+      end
+    end
+
     class SimpleBackend < ::I18n::Backend::Simple
       include SmartTranslate
       include MarkdownTranslate
       include SafeInterpolation
+      include I18nStringUrlTrackerPlugin
     end
 
     # I18n backend instance used by the web application.
     class KeyValueCacheBackend < ::I18n::Backend::KeyValue
       include ::I18n::Backend::CacheFile
       include SmartTranslate
+      include I18nStringUrlTrackerPlugin
 
       CACHE_DIR = pegasus_dir('cache', 'i18n/cache')
 

--- a/lib/cdo/i18n_string_url_tracker.rb
+++ b/lib/cdo/i18n_string_url_tracker.rb
@@ -1,0 +1,22 @@
+require 'cdo/firehose'
+require 'dynamic_config/dcdo'
+
+class I18nStringUrlTracker
+  include Singleton
+
+  I18N_STRING_TRACKING_DCDO_KEY = 'i18n_string_tracking'.freeze
+
+  # Records the given string_key and URL so we can analyze later what strings are present on what pages.
+  # @param string_key [String] The key used to review the translated string from our i18n system.
+  # @param url [String] The url which required the translation of the given string_key.
+  def log(string_key, url)
+    return unless string_key && url
+    return unless DCDO.get(I18N_STRING_TRACKING_DCDO_KEY, false)
+
+    # record the string : url association.
+    FirehoseClient.instance.put_record(
+      :i18n,
+      {url: url, string_key: string_key}
+    )
+  end
+end

--- a/lib/test/cdo/test_i18n_string_url_tracker.rb
+++ b/lib/test/cdo/test_i18n_string_url_tracker.rb
@@ -1,0 +1,75 @@
+require_relative '../test_helper'
+require 'cdo/i18n_string_url_tracker'
+
+class TestI18nStringUrlTracker < Minitest::Test
+  # We don't want to make actual calls to the AWS Firehose apis, so stub it and verify we are trying to send the right
+  # data.
+  def stub_firehose
+    FirehoseClient.instance.stubs(:put_record).with do |stream, data|
+      # Capture the data we try to send to firehose so we can verify it is what we expect.
+      @firehose_stream = stream
+      @firehose_record = data.dup
+      true
+    end
+  end
+
+  def unstub_firehose
+    FirehoseClient.instance.unstub(:put_record)
+    @firehose_stream = nil
+    @firehose_record = nil
+  end
+
+  def stub_dcdo(flag)
+    DCDO.stubs(:get).with(I18nStringUrlTracker::I18N_STRING_TRACKING_DCDO_KEY, false).returns(flag)
+  end
+
+  def unstub_dcdo
+    DCDO.unstub(:get)
+  end
+
+  def setup
+    super
+    stub_firehose
+    stub_dcdo(true)
+  end
+
+  def teardown
+    super
+    unstub_firehose
+    unstub_dcdo
+  end
+
+  def test_instance_not_empty
+    assert I18nStringUrlTracker.instance
+  end
+
+  def test_log_given_no_string_key_should_not_call_firehose
+    unstub_firehose
+    FirehoseClient.instance.expects(:put_record).never
+    test_record = {string_key: nil, url: 'http://some.url.com/'}
+    I18nStringUrlTracker.instance.log(test_record[:string_key], test_record[:url])
+  end
+
+  def test_log_given_no_url_should_not_call_firehose
+    unstub_firehose
+    FirehoseClient.instance.expects(:put_record).never
+    test_record = {string_key: 'string.key', url: nil}
+    I18nStringUrlTracker.instance.log(test_record[:string_key], test_record[:url])
+  end
+
+  def test_log_given_data_should_call_firehose
+    test_record = {string_key: 'string.key', url: 'http://some.url.com/'}
+    I18nStringUrlTracker.instance.log(test_record[:string_key], test_record[:url])
+    assert_equal(:i18n, @firehose_stream)
+    assert_equal(@firehose_record, test_record)
+  end
+
+  def test_log_given_false_dcdo_flag_should_not_call_firehose
+    unstub_firehose
+    unstub_dcdo
+    stub_dcdo(false)
+    FirehoseClient.instance.expects(:put_record).never
+    test_record = {string_key: 'string.key', url: 'http://some.url.com/'}
+    I18nStringUrlTracker.instance.log(test_record[:string_key], test_record[:url])
+  end
+end

--- a/pegasus/router.rb
+++ b/pegasus/router.rb
@@ -120,6 +120,11 @@ class Documents < Sinatra::Base
     Haml::TempleEngine.disable_option_validator!
   end
 
+  # Capture the current request URL for i18n string tracking
+  before do
+    Thread.current[:current_request_url] = request.url
+  end
+
   before do
     $log.debug request.url
 


### PR DESCRIPTION
The i18n team at Code.org wants to know what strings are present on particular URLs so they can quickly tell translators what strings need translations. To try getting this data, we are going to record a `string_key` -> `url` association every time dashboard/pegasus does a translation. The records are sent to a AWS Firehose stream where they will be put in a a new Redshift table. Then, the I18n team can start querying the table from Tableau and create dashboards.
* Adds the i18n_string_tracker.rb which provides an API for logging String:URL associations
  * Provides `log(string_key, url)` for logging a translation
  * Uses the `FirehoseClient` which is already to setup buffer requests and send them in batches.
* Stores the current request URL being rendered into the Thread local variables so the information is available to the i18n_backend when it tries to log the association.
* Added DCDO flag so we can turn on/off this feature without doing a deployment.

## Links
* [Jira](https://codedotorg.atlassian.net/browse/FND-785)
## Testing story
* Added unit tests
* Manually tested.

## Screenshots
Gave my dev box credentials to access Firehose:
![image](https://user-images.githubusercontent.com/1372238/87744163-43a66e00-c7da-11ea-952c-06941bcb819a.png)

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
