### PR TITLE
CSPWFRT: Add new questions to returning CSP teachers workshop enrollment

### DIFF
--- a/apps/src/code-studio/pd/workshop_dashboard/components/workshop_enrollment.jsx
+++ b/apps/src/code-studio/pd/workshop_dashboard/components/workshop_enrollment.jsx
@@ -8,6 +8,7 @@ import {Tabs, Tab} from 'react-bootstrap';
 import {enrollmentShape} from '../types';
 import WorkshopEnrollmentSchoolInfo from './workshop_enrollment_school_info';
 import WorkshopEnrollmentPreSurvey from './workshop_enrollment_pre_survey';
+import {SubjectNames} from '@cdo/apps/generated/pd/sharedWorkshopConstants';
 
 export default class WorkshopEnrollment extends React.Component {
   static propTypes = {
@@ -32,7 +33,8 @@ export default class WorkshopEnrollment extends React.Component {
   shouldShowPreSurveys() {
     return (
       ['CS Discoveries', 'CS Principles'].includes(this.props.workshopCourse) &&
-      this.props.workshopSubject !== 'Workshop for Returning Teachers'
+      this.props.workshopSubject !==
+        SubjectNames.SUBJECT_CSP_FOR_RETURNING_TEACHERS
     );
   }
 

--- a/apps/src/code-studio/pd/workshop_dashboard/components/workshop_enrollment.jsx
+++ b/apps/src/code-studio/pd/workshop_dashboard/components/workshop_enrollment.jsx
@@ -30,8 +30,9 @@ export default class WorkshopEnrollment extends React.Component {
   static defaultProps = {activeTab: 0};
 
   shouldShowPreSurveys() {
-    return ['CS Discoveries', 'CS Principles'].includes(
-      this.props.workshopCourse
+    return (
+      ['CS Discoveries', 'CS Principles'].includes(this.props.workshopCourse) &&
+      this.props.workshopSubject !== 'Workshop for Returning Teachers'
     );
   }
 

--- a/apps/src/code-studio/pd/workshop_dashboard/components/workshop_enrollment_school_info.jsx
+++ b/apps/src/code-studio/pd/workshop_dashboard/components/workshop_enrollment_school_info.jsx
@@ -20,8 +20,6 @@ const DEEP_DIVE = SubjectNames.SUBJECT_CSF_201;
 const NA = 'N/A';
 const LOCAL_SUMMER = SubjectNames.SUBJECT_SUMMER_WORKSHOP;
 
-const RETURNING_TEACHERS = 'Workshop for Returning Teachers';
-
 export class WorkshopEnrollmentSchoolInfo extends React.Component {
   constructor(props) {
     super(props);
@@ -252,19 +250,23 @@ export class WorkshopEnrollmentSchoolInfo extends React.Component {
               <td>{enrollment.csf_has_physical_curriculum_guide}</td>
             )}
           {this.props.workshopCourse === CSP &&
-            this.props.workshopSubject === RETURNING_TEACHERS && (
+            this.props.workshopSubject ===
+              SubjectNames.SUBJECT_CSP_FOR_RETURNING_TEACHERS && (
               <td>{enrollment.years_teaching}</td>
             )}
           {this.props.workshopCourse === CSP &&
-            this.props.workshopSubject === RETURNING_TEACHERS && (
+            this.props.workshopSubject ===
+              SubjectNames.SUBJECT_CSP_FOR_RETURNING_TEACHERS && (
               <td>{enrollment.years_teaching_cs}</td>
             )}
           {this.props.workshopCourse === CSP &&
-            this.props.workshopSubject === RETURNING_TEACHERS && (
+            this.props.workshopSubject ===
+              SubjectNames.SUBJECT_CSP_FOR_RETURNING_TEACHERS && (
               <td>{enrollment.taught_ap_before}</td>
             )}
           {this.props.workshopCourse === CSP &&
-            this.props.workshopSubject === RETURNING_TEACHERS && (
+            this.props.workshopSubject ===
+              SubjectNames.SUBJECT_CSP_FOR_RETURNING_TEACHERS && (
               <td>{enrollment.planning_to_teach_ap}</td>
             )}
           {this.props.workshopSubject === LOCAL_SUMMER && (
@@ -344,19 +346,23 @@ export class WorkshopEnrollmentSchoolInfo extends React.Component {
                 <th style={styles.th}>Has Physical Copy of Curriculum?</th>
               )}
             {this.props.workshopCourse === CSP &&
-              this.props.workshopSubject === RETURNING_TEACHERS && (
+              this.props.workshopSubject ===
+                SubjectNames.SUBJECT_CSP_FOR_RETURNING_TEACHERS && (
                 <th style={styles.th}>Years Teaching</th>
               )}
             {this.props.workshopCourse === CSP &&
-              this.props.workshopSubject === RETURNING_TEACHERS && (
+              this.props.workshopSubject ===
+                SubjectNames.SUBJECT_CSP_FOR_RETURNING_TEACHERS && (
                 <th style={styles.th}>Years Teaching CS</th>
               )}
             {this.props.workshopCourse === CSP &&
-              this.props.workshopSubject === RETURNING_TEACHERS && (
+              this.props.workshopSubject ===
+                SubjectNames.SUBJECT_CSP_FOR_RETURNING_TEACHERS && (
                 <th style={styles.th}>Taught AP Before?</th>
               )}
             {this.props.workshopCourse === CSP &&
-              this.props.workshopSubject === RETURNING_TEACHERS && (
+              this.props.workshopSubject ===
+                SubjectNames.SUBJECT_CSP_FOR_RETURNING_TEACHERS && (
                 <th style={styles.th}>Planning to teach AP?</th>
               )}
             {this.props.workshopSubject === LOCAL_SUMMER && (

--- a/apps/src/code-studio/pd/workshop_dashboard/components/workshop_enrollment_school_info.jsx
+++ b/apps/src/code-studio/pd/workshop_dashboard/components/workshop_enrollment_school_info.jsx
@@ -20,6 +20,8 @@ const DEEP_DIVE = SubjectNames.SUBJECT_CSF_201;
 const NA = 'N/A';
 const LOCAL_SUMMER = SubjectNames.SUBJECT_SUMMER_WORKSHOP;
 
+const RETURNING_TEACHERS = 'Workshop for Returning Teachers';
+
 export class WorkshopEnrollmentSchoolInfo extends React.Component {
   constructor(props) {
     super(props);
@@ -249,6 +251,22 @@ export class WorkshopEnrollmentSchoolInfo extends React.Component {
             this.props.workshopSubject === DEEP_DIVE && (
               <td>{enrollment.csf_has_physical_curriculum_guide}</td>
             )}
+          {this.props.workshopCourse === CSP &&
+            this.props.workshopSubject === RETURNING_TEACHERS && (
+              <td>{enrollment.years_teaching}</td>
+            )}
+          {this.props.workshopCourse === CSP &&
+            this.props.workshopSubject === RETURNING_TEACHERS && (
+              <td>{enrollment.years_teaching_cs}</td>
+            )}
+          {this.props.workshopCourse === CSP &&
+            this.props.workshopSubject === RETURNING_TEACHERS && (
+              <td>{enrollment.taught_ap_before}</td>
+            )}
+          {this.props.workshopCourse === CSP &&
+            this.props.workshopSubject === RETURNING_TEACHERS && (
+              <td>{enrollment.planning_to_teach_ap}</td>
+            )}
           {this.props.workshopSubject === LOCAL_SUMMER && (
             <td>
               {enrollment.attendances} / {this.props.numSessions}
@@ -324,6 +342,22 @@ export class WorkshopEnrollmentSchoolInfo extends React.Component {
             {this.props.workshopCourse === CSF &&
               this.props.workshopSubject === DEEP_DIVE && (
                 <th style={styles.th}>Has Physical Copy of Curriculum?</th>
+              )}
+            {this.props.workshopCourse === CSP &&
+              this.props.workshopSubject === RETURNING_TEACHERS && (
+                <th style={styles.th}>Years Teaching</th>
+              )}
+            {this.props.workshopCourse === CSP &&
+              this.props.workshopSubject === RETURNING_TEACHERS && (
+                <th style={styles.th}>Years Teaching CS</th>
+              )}
+            {this.props.workshopCourse === CSP &&
+              this.props.workshopSubject === RETURNING_TEACHERS && (
+                <th style={styles.th}>Taught AP Before?</th>
+              )}
+            {this.props.workshopCourse === CSP &&
+              this.props.workshopSubject === RETURNING_TEACHERS && (
+                <th style={styles.th}>Planning to teach AP?</th>
               )}
             {this.props.workshopSubject === LOCAL_SUMMER && (
               <th style={styles.th}>Total Attendance</th>

--- a/apps/src/code-studio/pd/workshop_dashboard/components/workshop_form.jsx
+++ b/apps/src/code-studio/pd/workshop_dashboard/components/workshop_form.jsx
@@ -40,7 +40,8 @@ import {
 } from '../permission';
 import {
   Courses,
-  Subjects
+  Subjects,
+  SubjectNames
 } from '@cdo/apps/generated/pd/sharedWorkshopConstants';
 
 const styles = {
@@ -560,7 +561,7 @@ export class WorkshopForm extends React.Component {
       const options = Subjects[this.state.course]
         .filter(subject => {
           // Temporary: Don't show the new workshop type as an option while we're still building it.
-          if (subject === 'Workshop for Returning Teachers') {
+          if (subject === SubjectNames.SUBJECT_CSP_FOR_RETURNING_TEACHERS) {
             return false;
           }
 

--- a/apps/src/code-studio/pd/workshop_enrollment/enroll_form.jsx
+++ b/apps/src/code-studio/pd/workshop_enrollment/enroll_form.jsx
@@ -21,6 +21,9 @@ const CSF = 'CS Fundamentals';
 const INTRO = SubjectNames.SUBJECT_CSF_101;
 const DEEP_DIVE = SubjectNames.SUBJECT_CSF_201;
 
+const CSP = 'CS Principles';
+const RETURNING_TEACHERS = 'Workshop for Returning Teachers';
+
 const VALIDATION_STATE_ERROR = 'error';
 
 const SCHOOL_TYPES_MAPPING = {
@@ -264,7 +267,11 @@ export default class EnrollForm extends React.Component {
       previous_courses: this.state.previous_courses,
       replace_existing: this.state.replace_existing,
       csf_intro_intent: this.state.csf_intro_intent,
-      csf_intro_other_factors: this.state.csf_intro_other_factors
+      csf_intro_other_factors: this.state.csf_intro_other_factors,
+      years_teaching: this.state.years_teaching,
+      years_teaching_cs: this.state.years_teaching_cs,
+      taught_ap_before: this.state.taught_ap_before,
+      planning_to_teach_ap: this.state.planning_to_teach_ap
     };
     this.submitRequest = $.ajax({
       method: 'POST',
@@ -344,6 +351,21 @@ export default class EnrollForm extends React.Component {
       'I want to learn computer science concepts.',
       'Computer science is a required subject in my region.',
       'I am here to bring information back to my school or district.'
+    ];
+
+    const cspReturningTeachersTaughtAPLabel = `Have you taught an Advanced Placement (AP) course before?`;
+    const cspReturningTeachersTaughtAPAnswers = [
+      'Yes, AP CS Principles or AP CS A',
+      'Yes, but in another subject',
+      'No'
+    ];
+
+    const cspReturningTeachersPlanningAPLabel = `Are you planning to teach CS Principles as an AP course?`;
+    const cspReturningTeachersPlanningAPAnswers = [
+      'Yes',
+      'No',
+      'Both AP and non-AP',
+      'Unsure / Still deciding'
     ];
 
     const csfCourses = Object.keys(CSF_COURSES)
@@ -634,6 +656,70 @@ export default class EnrollForm extends React.Component {
           </div>
         )}
 
+        {this.props.workshop_course === CSP &&
+          this.props.workshop_subject === RETURNING_TEACHERS && (
+            <div>
+              <FieldGroup
+                id="years_teaching"
+                label="Years Teaching (overall)"
+                type="text"
+                required={true}
+                onChange={this.handleChange}
+                validationState={
+                  this.state.errors.hasOwnProperty('years_teaching')
+                    ? VALIDATION_STATE_ERROR
+                    : null
+                }
+                errorMessage={this.state.errors.years_teaching}
+              />
+              <FieldGroup
+                id="years_teaching_cs"
+                label="Years Teaching Computer Science"
+                type="text"
+                required={true}
+                onChange={this.handleChange}
+                validationState={
+                  this.state.errors.hasOwnProperty('years_teaching_cs')
+                    ? VALIDATION_STATE_ERROR
+                    : null
+                }
+                errorMessage={this.state.errors.years_teaching_cs}
+              />
+              <ButtonList
+                groupName="taught_ap_before"
+                type="radio"
+                required
+                label={cspReturningTeachersTaughtAPLabel}
+                answers={cspReturningTeachersTaughtAPAnswers}
+                onChange={this.handleChange}
+                selectedItems={this.state.taught_ap_before}
+                validationState={
+                  this.state.errors.hasOwnProperty('taught_ap_before')
+                    ? VALIDATION_STATE_ERROR
+                    : null
+                }
+                errorText={this.state.errors.taught_ap_before}
+                suppressLineBreak={true}
+              />
+              <ButtonList
+                groupName="planning_to_teach_ap"
+                type="radio"
+                required
+                label={cspReturningTeachersPlanningAPLabel}
+                answers={cspReturningTeachersPlanningAPAnswers}
+                onChange={this.handleChange}
+                selectedItems={this.state.planning_to_teach_ap}
+                validationState={
+                  this.state.errors.hasOwnProperty('planning_to_teach_ap')
+                    ? VALIDATION_STATE_ERROR
+                    : null
+                }
+                errorText={this.state.errors.planning_to_teach_ap}
+                suppressLineBreak={true}
+              />
+            </div>
+          )}
+
         <p>
           Code.org works closely with local Regional Partners and Code.org
           facilitators to deliver the Professional Learning Program. By
@@ -669,14 +755,27 @@ export default class EnrollForm extends React.Component {
     }
 
     if (this.props.workshop_course === CSF) {
-      requiredFields.push('role');
-      requiredFields.push('grades_teaching');
+      requiredFields.push('role', 'grades_teaching');
       if (this.props.workshop_subject === INTRO) {
         requiredFields.push('csf_intro_intent');
       } else if (this.props.workshop_subject === DEEP_DIVE) {
-        requiredFields.push('attended_csf_intro_workshop');
-        requiredFields.push('csf_has_physical_curriculum_guide');
+        requiredFields.push(
+          'attended_csf_intro_workshop',
+          'csf_has_physical_curriculum_guide'
+        );
       }
+    }
+
+    if (
+      this.props.workshop_course === CSP &&
+      this.props.workshop_subject === RETURNING_TEACHERS
+    ) {
+      requiredFields.push(
+        'years_teaching',
+        'years_teaching_cs',
+        'taught_ap_before',
+        'planning_to_teach_ap'
+      );
     }
 
     const missingRequiredFields = requiredFields.filter(f => {

--- a/apps/src/code-studio/pd/workshop_enrollment/enroll_form.jsx
+++ b/apps/src/code-studio/pd/workshop_enrollment/enroll_form.jsx
@@ -22,7 +22,6 @@ const INTRO = SubjectNames.SUBJECT_CSF_101;
 const DEEP_DIVE = SubjectNames.SUBJECT_CSF_201;
 
 const CSP = 'CS Principles';
-const RETURNING_TEACHERS = 'Workshop for Returning Teachers';
 
 const VALIDATION_STATE_ERROR = 'error';
 
@@ -657,7 +656,8 @@ export default class EnrollForm extends React.Component {
         )}
 
         {this.props.workshop_course === CSP &&
-          this.props.workshop_subject === RETURNING_TEACHERS && (
+          this.props.workshop_subject ===
+            SubjectNames.SUBJECT_CSP_FOR_RETURNING_TEACHERS && (
             <div>
               <FieldGroup
                 id="years_teaching"
@@ -768,7 +768,8 @@ export default class EnrollForm extends React.Component {
 
     if (
       this.props.workshop_course === CSP &&
-      this.props.workshop_subject === RETURNING_TEACHERS
+      this.props.workshop_subject ===
+        SubjectNames.SUBJECT_CSP_FOR_RETURNING_TEACHERS
     ) {
       requiredFields.push(
         'years_teaching',

--- a/apps/src/code-studio/pd/workshop_enrollment/enroll_form.jsx
+++ b/apps/src/code-studio/pd/workshop_enrollment/enroll_form.jsx
@@ -662,7 +662,7 @@ export default class EnrollForm extends React.Component {
               <FieldGroup
                 id="years_teaching"
                 label="Years Teaching (overall)"
-                type="text"
+                type="number"
                 required={true}
                 onChange={this.handleChange}
                 validationState={
@@ -675,7 +675,7 @@ export default class EnrollForm extends React.Component {
               <FieldGroup
                 id="years_teaching_cs"
                 label="Years Teaching Computer Science"
-                type="text"
+                type="number"
                 required={true}
                 onChange={this.handleChange}
                 validationState={

--- a/apps/test/unit/code-studio/pd/workshop_dashboard/components/workshop_enrollment_school_infoTest.js
+++ b/apps/test/unit/code-studio/pd/workshop_dashboard/components/workshop_enrollment_school_infoTest.js
@@ -104,4 +104,61 @@ describe('Workshop Enrollment School Info', () => {
         .filterWhere(col => col.text().includes('Scholarship Teacher?'))
     ).to.have.length(0);
   });
+
+  it('shows questions for CSP returning teachers', () => {
+    let workshopEnrollmentSchoolInfo = shallow(
+      <WorkshopEnrollmentSchoolInfo
+        enrollments={[]}
+        accountRequiredForAttendance={true}
+        scholarshipWorkshop={false}
+        onDelete={() => {}}
+        onClickSelect={() => {}}
+        workshopCourse="CS Principles"
+        workshopSubject="Workshop for Returning Teachers"
+        numSessions={5}
+        permissionList={new Permission(['ProgramManager'])}
+      />,
+      {context}
+    );
+
+    ['Years Teaching CS', 'Taught AP Before?', 'Planning to teach AP?'].forEach(
+      question => {
+        expect(
+          workshopEnrollmentSchoolInfo
+            .find('th')
+            .filterWhere(col => col.text().includes(question))
+        ).to.have.length(1);
+      }
+    );
+  });
+
+  it('does not show questions for CSP returning teachers in other CSP workshops', () => {
+    let workshopEnrollmentSchoolInfo = shallow(
+      <WorkshopEnrollmentSchoolInfo
+        enrollments={[]}
+        accountRequiredForAttendance={true}
+        scholarshipWorkshop={false}
+        onDelete={() => {}}
+        onClickSelect={() => {}}
+        workshopCourse="CS Principles"
+        workshopSubject="5-day Summer"
+        numSessions={5}
+        permissionList={new Permission(['ProgramManager'])}
+      />,
+      {context}
+    );
+
+    [
+      'Years Teaching',
+      'Years Teaching CS',
+      'Taught AP Before?',
+      'Planning to teach AP?'
+    ].forEach(question => {
+      expect(
+        workshopEnrollmentSchoolInfo
+          .find('th')
+          .filterWhere(col => col.text().includes(question))
+      ).to.have.length(0);
+    });
+  });
 });

--- a/apps/test/unit/code-studio/pd/workshop_dashboard/components/workshop_enrollment_school_infoTest.js
+++ b/apps/test/unit/code-studio/pd/workshop_dashboard/components/workshop_enrollment_school_infoTest.js
@@ -3,6 +3,7 @@ import Permission from '@cdo/apps/code-studio/pd/workshop_dashboard/permission';
 import React from 'react';
 import {expect} from 'chai';
 import {shallow} from 'enzyme';
+import {SubjectNames} from '@cdo/apps/generated/pd/sharedWorkshopConstants';
 
 describe('Workshop Enrollment School Info', () => {
   const fakeRouter = {
@@ -114,7 +115,7 @@ describe('Workshop Enrollment School Info', () => {
         onDelete={() => {}}
         onClickSelect={() => {}}
         workshopCourse="CS Principles"
-        workshopSubject="Workshop for Returning Teachers"
+        workshopSubject={SubjectNames.SUBJECT_CSP_FOR_RETURNING_TEACHERS}
         numSessions={5}
         permissionList={new Permission(['ProgramManager'])}
       />,

--- a/apps/test/unit/code-studio/pd/workshop_enrollment/enroll_formTest.js
+++ b/apps/test/unit/code-studio/pd/workshop_enrollment/enroll_formTest.js
@@ -170,7 +170,7 @@ describe('Enroll Form', () => {
         <EnrollForm
           workshop_id={props.workshop_id}
           workshop_course="CS Principles"
-          workshop_subject="Workshop for Returning Teachers"
+          workshop_subject={SubjectNames.SUBJECT_CSP_FOR_RETURNING_TEACHERS}
           first_name={props.first_name}
           email={props.email}
           previous_courses={props.previous_courses}

--- a/apps/test/unit/code-studio/pd/workshop_enrollment/enroll_formTest.js
+++ b/apps/test/unit/code-studio/pd/workshop_enrollment/enroll_formTest.js
@@ -163,6 +163,48 @@ describe('Enroll Form', () => {
     });
   });
 
+  describe('CSP Returning Teachers Form', () => {
+    let enrollForm;
+    before(() => {
+      enrollForm = shallow(
+        <EnrollForm
+          workshop_id={props.workshop_id}
+          workshop_course="CS Principles"
+          workshop_subject="Workshop for Returning Teachers"
+          first_name={props.first_name}
+          email={props.email}
+          previous_courses={props.previous_courses}
+          onSubmissionComplete={props.onSubmissionComplete}
+          collect_demographics={false}
+        />
+      );
+    });
+
+    ['years_teaching', 'years_teaching_cs'].forEach(question => {
+      it('displays questions specific to this workshop type', () => {
+        assert(enrollForm.exists('#' + question));
+      });
+    });
+
+    ['taught_ap_before', 'planning_to_teach_ap'].forEach(question => {
+      it('displays questions specific to this workshop type', () => {
+        assert(enrollForm.exists({groupName: question}));
+      });
+    });
+
+    ['role', 'previous_courses', 'replace_existing'].forEach(question => {
+      it('displays questions not relevant for this workshop type', () => {
+        refute(enrollForm.exists('#' + question));
+      });
+    });
+
+    ['csf_intro_intent', 'csf_intro_other_factors'].forEach(question => {
+      it('displays questions not relevant for this workshop type', () => {
+        refute(enrollForm.exists({groupName: question}));
+      });
+    });
+  });
+
   describe('Enroll Form', () => {
     let enrollForm;
     beforeEach(() => {

--- a/dashboard/app/controllers/api/v1/pd/workshop_enrollments_controller.rb
+++ b/dashboard/app/controllers/api/v1/pd/workshop_enrollments_controller.rb
@@ -135,7 +135,12 @@ class Api::V1::Pd::WorkshopEnrollmentsController < ApplicationController
       previous_courses: params[:previous_courses],
       replace_existing: params[:replace_existing],
       csf_intro_intent: params[:csf_intro_intent],
-      csf_intro_other_factors: params[:csf_intro_other_factors]
+      csf_intro_other_factors: params[:csf_intro_other_factors],
+      # params only collected in CSP returning teachers workshop
+      years_teaching: params[:years_teaching],
+      years_teaching_cs: params[:years_teaching_cs],
+      taught_ap_before: params[:taught_ap_before],
+      planning_to_teach_ap: params[:planning_to_teach_ap]
     }
   end
 

--- a/dashboard/app/models/pd/enrollment.rb
+++ b/dashboard/app/models/pd/enrollment.rb
@@ -79,6 +79,10 @@ class Pd::Enrollment < ActiveRecord::Base
     replace_existing
     csf_intro_intent
     csf_intro_other_factors
+    years_teaching
+    years_teaching_cs
+    taught_ap_before
+    planning_to_teach_ap
   )
 
   def set_default_scholarship_info

--- a/dashboard/app/serializers/api/v1/pd/workshop_enrollment_serializer.rb
+++ b/dashboard/app/serializers/api/v1/pd/workshop_enrollment_serializer.rb
@@ -3,7 +3,8 @@ class Api::V1::Pd::WorkshopEnrollmentSerializer < ActiveModel::Serializer
     :grades_teaching, :attended_csf_intro_workshop, :csf_course_experience,
     :csf_courses_planned, :csf_has_physical_curriculum_guide, :user_id, :attended,
     :pre_workshop_survey, :previous_courses, :replace_existing, :attendances,
-    :scholarship_status, :scholarship_ineligible_reason, :enrolled_date
+    :scholarship_status, :scholarship_ineligible_reason, :enrolled_date,
+    :years_teaching, :years_teaching_cs, :taught_ap_before, :planning_to_teach_ap
 
   def user_id
     user = object.resolve_user

--- a/dashboard/test/serializers/api/v1/pd/workshop_enrollment_serializer_test.rb
+++ b/dashboard/test/serializers/api/v1/pd/workshop_enrollment_serializer_test.rb
@@ -11,7 +11,8 @@ class Api::V1::Pd::WorkshopEnrollmentSerializerTest < ::ActionController::TestCa
       :grades_teaching, :attended_csf_intro_workshop, :csf_course_experience,
       :csf_courses_planned, :csf_has_physical_curriculum_guide, :user_id, :attended,
       :pre_workshop_survey, :previous_courses, :replace_existing, :attendances,
-      :scholarship_status, :scholarship_ineligible_reason, :enrolled_date
+      :scholarship_status, :scholarship_ineligible_reason, :enrolled_date,
+      :years_teaching, :years_teaching_cs, :taught_ap_before, :planning_to_teach_ap
     ]
 
     serialized = ::Api::V1::Pd::WorkshopEnrollmentSerializer.new(enrollment).attributes

--- a/lib/cdo/shared_constants/pd/shared_workshop_constants.rb
+++ b/lib/cdo/shared_constants/pd/shared_workshop_constants.rb
@@ -31,7 +31,8 @@ module Pd
       SUBJECT_VIRTUAL_5: SUBJECT_VIRTUAL_5 = 'Virtual Workshop 5'.freeze,
       SUBJECT_VIRTUAL_6: SUBJECT_VIRTUAL_6 = 'Virtual Workshop 6'.freeze,
       SUBJECT_VIRTUAL_7: SUBJECT_VIRTUAL_7 = 'Virtual Workshop 7'.freeze,
-      SUBJECT_VIRTUAL_8: SUBJECT_VIRTUAL_8 = 'Virtual Workshop 8'.freeze
+      SUBJECT_VIRTUAL_8: SUBJECT_VIRTUAL_8 = 'Virtual Workshop 8'.freeze,
+      SUBJECT_CSP_FOR_RETURNING_TEACHERS: SUBJECT_CSP_FOR_RETURNING_TEACHERS = 'Workshop for Returning Teachers'.freeze
     }
     SUBJECTS = {
       COURSE_ECS => [
@@ -69,7 +70,7 @@ module Pd
         SUBJECT_CSP_VIRTUAL_6 = SUBJECT_VIRTUAL_6,
         SUBJECT_CSP_VIRTUAL_7 = SUBJECT_VIRTUAL_7,
         SUBJECT_CSP_VIRTUAL_8 = SUBJECT_VIRTUAL_8,
-        SUBJECT_CSP_FOR_RETURNING_TEACHERS = 'Workshop for Returning Teachers'.freeze
+        SUBJECT_CSP_FOR_RETURNING_TEACHERS = SUBJECT_CSP_FOR_RETURNING_TEACHERS
       ],
       COURSE_CSD => [
         SUBJECT_CSD_SUMMER_WORKSHOP = SUBJECT_SUMMER_WORKSHOP,


### PR DESCRIPTION
Adds 4 new questions to the workshop enrollment form for the new "returning CSP teachers" workshop type, and shows responses to admins in the workshop dashboard.

Workshop dashboard view:

![image](https://user-images.githubusercontent.com/25372625/80261539-8d4e4500-863f-11ea-8306-f58ca5db03f0.png)

Enrollment page view:

![image](https://user-images.githubusercontent.com/25372625/80261698-0057bb80-8640-11ea-93c2-27e3bb14a651.png)

Requires all fields to submit:

![image](https://user-images.githubusercontent.com/25372625/80261832-680e0680-8640-11ea-9180-a251e30244ed.png)

## Testing story

Tested locally. Also added basic unit tests in line with other unit testing that exists (which may not be comprehensive -- eg, there's no testing of the contents of the table of enrollments shown to admins, only the headers.

## Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
