### PR TITLE
Add visible stable course edit ui

### DIFF
--- a/apps/src/lib/script-editor/ScriptEditor.jsx
+++ b/apps/src/lib/script-editor/ScriptEditor.jsx
@@ -79,8 +79,6 @@ export default class ScriptEditor extends React.Component {
     super(props);
 
     this.state = {
-      hidden: this.props.hidden,
-      pilotExperiment: this.props.pilotExperiment,
       curriculumUmbrella: this.props.curriculumUmbrella
     };
   }
@@ -235,10 +233,9 @@ export default class ScriptEditor extends React.Component {
                 ))}
               </select>
             </label>
-            <VisibleInTeacherDashboard
-              checked={!this.state.hidden}
-              disabled={!!this.state.pilotExperiment}
-              onChange={e => this.setState({hidden: !e.target.checked})}
+            <VisibleAndPilotExperiment
+              visible={!this.props.hidden}
+              pilotExperiment={this.props.pilotExperiment}
             />
             <label>
               Can be recommended (aka stable)
@@ -254,10 +251,6 @@ export default class ScriptEditor extends React.Component {
                 the recommended version.
               </p>
             </label>
-            <PilotExperiment
-              value={this.state.pilotExperiment}
-              onChange={e => this.setState({pilotExperiment: e.target.value})}
-            />
           </div>
         )}
         <label>
@@ -546,7 +539,51 @@ export default class ScriptEditor extends React.Component {
   }
 }
 
-export const VisibleInTeacherDashboard = props => (
+/**
+ * Component which renders two input fields: a checkbox which controls whether the course/script
+ * should be available in the dropdown on Teacher Dashboard, and a text field which controls whether
+ * the course/script is in a pilot experiment. This component also ensures that if there is a pilot experiment,
+ * then the visible checkbox will be unchecked and greyed out, to maintain consistency between the two.
+ */
+export class VisibleAndPilotExperiment extends React.Component {
+  static propTypes = {
+    visible: PropTypes.bool.isRequired,
+    pilotExperiment: PropTypes.string,
+    paramName: PropTypes.string
+  };
+
+  static defaultProps = {
+    paramName: 'visible_to_teachers'
+  };
+
+  constructor(props) {
+    super(props);
+
+    this.state = {
+      visible: this.props.visible,
+      pilotExperiment: this.props.pilotExperiment
+    };
+  }
+
+  render() {
+    return (
+      <div>
+        <VisibleInTeacherDashboard
+          checked={this.state.visible}
+          disabled={!!this.state.pilotExperiment}
+          onChange={e => this.setState({visible: e.target.checked})}
+          paramName={this.props.paramName}
+        />
+        <PilotExperiment
+          value={this.state.pilotExperiment}
+          onChange={e => this.setState({pilotExperiment: e.target.value})}
+        />
+      </div>
+    );
+  }
+}
+
+const VisibleInTeacherDashboard = props => (
   <label style={props.disabled ? {opacity: 0.5} : {}}>
     Visible in Teacher Dashboard
     <input
@@ -567,16 +604,13 @@ export const VisibleInTeacherDashboard = props => (
   </label>
 );
 VisibleInTeacherDashboard.propTypes = {
-  paramName: PropTypes.string,
+  paramName: PropTypes.string.isRequired,
   checked: PropTypes.bool,
   disabled: PropTypes.bool,
   onChange: PropTypes.func.isRequired
 };
-VisibleInTeacherDashboard.defaultProps = {
-  paramName: 'visible_to_teachers'
-};
 
-export const PilotExperiment = props => (
+const PilotExperiment = props => (
   <label>
     Pilot Experiment. If specified, this script will only be accessible to
     levelbuilders, or to classrooms whose teacher has this user experiment

--- a/apps/src/lib/script-editor/ScriptEditor.jsx
+++ b/apps/src/lib/script-editor/ScriptEditor.jsx
@@ -573,7 +573,7 @@ VisibleInTeacherDashboard.propTypes = {
   onChange: PropTypes.func.isRequired
 };
 VisibleInTeacherDashboard.defaultProps = {
-  paramName: "visible_to_teachers"
+  paramName: 'visible_to_teachers'
 };
 
 export const PilotExperiment = props => (

--- a/apps/src/lib/script-editor/ScriptEditor.jsx
+++ b/apps/src/lib/script-editor/ScriptEditor.jsx
@@ -546,11 +546,11 @@ export default class ScriptEditor extends React.Component {
   }
 }
 
-const VisibleInTeacherDashboard = props => (
+export const VisibleInTeacherDashboard = props => (
   <label style={props.disabled ? {opacity: 0.5} : {}}>
     Visible in Teacher Dashboard
     <input
-      name="visible_to_teachers"
+      name={props.paramName}
       type="checkbox"
       disabled={props.disabled}
       checked={props.checked && !props.disabled}
@@ -567,12 +567,16 @@ const VisibleInTeacherDashboard = props => (
   </label>
 );
 VisibleInTeacherDashboard.propTypes = {
+  paramName: PropTypes.string,
   checked: PropTypes.bool,
   disabled: PropTypes.bool,
   onChange: PropTypes.func.isRequired
 };
+VisibleInTeacherDashboard.defaultProps = {
+  paramName: "visible_to_teachers"
+};
 
-const PilotExperiment = props => (
+export const PilotExperiment = props => (
   <label>
     Pilot Experiment. If specified, this script will only be accessible to
     levelbuilders, or to classrooms whose teacher has this user experiment

--- a/apps/src/sites/studio/pages/courses/edit.js
+++ b/apps/src/sites/studio/pages/courses/edit.js
@@ -22,6 +22,8 @@ function showCourseEditor() {
         title={courseEditorData.course_summary.title}
         familyName={courseEditorData.course_summary.family_name}
         versionYear={courseEditorData.course_summary.version_year}
+        visible={courseEditorData.course_summary.visible}
+        isStable={courseEditorData.course_summary.is_stable}
         pilotExperiment={courseEditorData.course_summary.pilot_experiment}
         descriptionShort={courseEditorData.course_summary.description_short}
         descriptionStudent={courseEditorData.course_summary.description_student}

--- a/apps/src/templates/courseOverview/CourseEditor.js
+++ b/apps/src/templates/courseOverview/CourseEditor.js
@@ -4,7 +4,10 @@ import CourseScriptsEditor from './CourseScriptsEditor';
 import ResourcesEditor from './ResourcesEditor';
 import CourseOverviewTopRow from './CourseOverviewTopRow';
 import {resourceShape} from './resourceType';
-import {PilotExperiment, VisibleInTeacherDashboard} from '../../lib/script-editor/ScriptEditor.jsx';
+import {
+  PilotExperiment,
+  VisibleInTeacherDashboard
+} from '../../lib/script-editor/ScriptEditor.jsx';
 
 const styles = {
   input: {
@@ -48,7 +51,7 @@ export default class CourseEditor extends Component {
 
     this.state = {
       visible: this.props.visible,
-      pilotExperiment: this.props.pilotExperiment,
+      pilotExperiment: this.props.pilotExperiment
     };
   }
 
@@ -124,9 +127,9 @@ export default class CourseEditor extends Component {
             style={styles.checkbox}
           />
           <p>
-            If checked, this unit will be eligible to be the recommended
-            version of the unit. The most recent eligible version will be
-            the recommended version.
+            If checked, this unit will be eligible to be the recommended version
+            of the unit. The most recent eligible version will be the
+            recommended version.
           </p>
         </label>
         <PilotExperiment

--- a/apps/src/templates/courseOverview/CourseEditor.js
+++ b/apps/src/templates/courseOverview/CourseEditor.js
@@ -4,10 +4,7 @@ import CourseScriptsEditor from './CourseScriptsEditor';
 import ResourcesEditor from './ResourcesEditor';
 import CourseOverviewTopRow from './CourseOverviewTopRow';
 import {resourceShape} from './resourceType';
-import {
-  PilotExperiment,
-  VisibleInTeacherDashboard
-} from '../../lib/script-editor/ScriptEditor.jsx';
+import {VisibleAndPilotExperiment} from '../../lib/script-editor/ScriptEditor.jsx';
 
 const styles = {
   input: {
@@ -45,15 +42,6 @@ export default class CourseEditor extends Component {
     courseFamilies: PropTypes.arrayOf(PropTypes.string).isRequired,
     versionYearOptions: PropTypes.arrayOf(PropTypes.string).isRequired
   };
-
-  constructor(props) {
-    super(props);
-
-    this.state = {
-      visible: this.props.visible,
-      pilotExperiment: this.props.pilotExperiment
-    };
-  }
 
   render() {
     const {
@@ -112,11 +100,10 @@ export default class CourseEditor extends Component {
             ))}
           </select>
         </label>
-        <VisibleInTeacherDashboard
+        <VisibleAndPilotExperiment
+          visible={this.props.visible}
+          pilotExperiment={this.props.pilotExperiment}
           paramName="visible"
-          checked={this.state.visible}
-          disabled={!!this.state.pilotExperiment}
-          onChange={e => this.setState({visible: e.target.checked})}
         />
         <label>
           Can be recommended (aka stable)
@@ -132,10 +119,6 @@ export default class CourseEditor extends Component {
             recommended version.
           </p>
         </label>
-        <PilotExperiment
-          value={this.state.pilotExperiment}
-          onChange={e => this.setState({pilotExperiment: e.target.value})}
-        />
         <label>
           Short Description (used in course cards on homepage)
           <textarea

--- a/apps/src/templates/courseOverview/CourseEditor.js
+++ b/apps/src/templates/courseOverview/CourseEditor.js
@@ -4,6 +4,7 @@ import CourseScriptsEditor from './CourseScriptsEditor';
 import ResourcesEditor from './ResourcesEditor';
 import CourseOverviewTopRow from './CourseOverviewTopRow';
 import {resourceShape} from './resourceType';
+import {PilotExperiment, VisibleInTeacherDashboard} from '../../lib/script-editor/ScriptEditor.jsx';
 
 const styles = {
   input: {
@@ -28,6 +29,8 @@ export default class CourseEditor extends Component {
     title: PropTypes.string.isRequired,
     familyName: PropTypes.string,
     versionYear: PropTypes.string,
+    visible: PropTypes.bool.isRequired,
+    isStable: PropTypes.bool.isRequired,
     pilotExperiment: PropTypes.string,
     descriptionShort: PropTypes.string,
     descriptionStudent: PropTypes.string,
@@ -40,13 +43,21 @@ export default class CourseEditor extends Component {
     versionYearOptions: PropTypes.arrayOf(PropTypes.string).isRequired
   };
 
+  constructor(props) {
+    super(props);
+
+    this.state = {
+      visible: this.props.visible,
+      pilotExperiment: this.props.pilotExperiment,
+    };
+  }
+
   render() {
     const {
       name,
       title,
       familyName,
       versionYear,
-      pilotExperiment,
       descriptionShort,
       descriptionStudent,
       descriptionTeacher,
@@ -98,14 +109,30 @@ export default class CourseEditor extends Component {
             ))}
           </select>
         </label>
+        <VisibleInTeacherDashboard
+          paramName="visible"
+          checked={this.state.visible}
+          disabled={!!this.state.pilotExperiment}
+          onChange={e => this.setState({visible: e.target.checked})}
+        />
         <label>
-          Pilot Experiment
+          Can be recommended (aka stable)
           <input
-            name="pilot_experiment"
-            defaultValue={pilotExperiment}
-            style={styles.input}
+            name="is_stable"
+            type="checkbox"
+            defaultChecked={this.props.isStable}
+            style={styles.checkbox}
           />
+          <p>
+            If checked, this unit will be eligible to be the recommended
+            version of the unit. The most recent eligible version will be
+            the recommended version.
+          </p>
         </label>
+        <PilotExperiment
+          value={this.state.pilotExperiment}
+          onChange={e => this.setState({pilotExperiment: e.target.value})}
+        />
         <label>
           Short Description (used in course cards on homepage)
           <textarea

--- a/apps/src/templates/courseOverview/CourseEditor.js
+++ b/apps/src/templates/courseOverview/CourseEditor.js
@@ -127,8 +127,8 @@ export default class CourseEditor extends Component {
             style={styles.checkbox}
           />
           <p>
-            If checked, this unit will be eligible to be the recommended version
-            of the unit. The most recent eligible version will be the
+            If checked, this course will be eligible to be the recommended
+            version of the course. The most recent eligible version will be the
             recommended version.
           </p>
         </label>

--- a/apps/test/unit/lib/script-editor/ScriptEditorTest.jsx
+++ b/apps/test/unit/lib/script-editor/ScriptEditorTest.jsx
@@ -1,7 +1,9 @@
 import {expect} from 'chai';
 import React from 'react';
 import {mount} from 'enzyme';
-import ScriptEditor from '@cdo/apps/lib/script-editor/ScriptEditor';
+import ScriptEditor, {
+  VisibleAndPilotExperiment
+} from '@cdo/apps/lib/script-editor/ScriptEditor';
 
 describe('ScriptEditor', () => {
   const DEFAULT_PROPS = {
@@ -30,12 +32,13 @@ describe('ScriptEditor', () => {
       const checkbox = wrapper.find('input[name="visible_to_teachers"]');
       expect(checkbox.prop('checked')).to.be.false;
     });
+  });
 
-    it('is disabled and unchecked when pilotExperiment is present', () => {
+  describe('VisibleAndPilotExperiment', () => {
+    it('visible is disabled and unchecked when pilotExperiment is present', () => {
       const wrapper = mount(
-        <ScriptEditor
-          {...DEFAULT_PROPS}
-          hidden={false}
+        <VisibleAndPilotExperiment
+          visible={true}
           pilotExperiment="test-pilot"
         />
       );
@@ -44,8 +47,8 @@ describe('ScriptEditor', () => {
       expect(checkbox.prop('checked')).to.be.false;
     });
 
-    it('updates state as pilotExperiment changes', () => {
-      const wrapper = mount(<ScriptEditor {...DEFAULT_PROPS} hidden={false} />);
+    it('visible updates state as pilotExperiment changes', () => {
+      const wrapper = mount(<VisibleAndPilotExperiment visible={true} />);
       const visibleInTeacherDashboard = () =>
         wrapper.find('input[name="visible_to_teachers"]');
       const pilotExperiment = () =>

--- a/apps/test/unit/templates/courseOverview/CourseEditorTest.js
+++ b/apps/test/unit/templates/courseOverview/CourseEditorTest.js
@@ -1,4 +1,4 @@
-import {assert} from '../../../util/reconfiguredChai';
+import {assert, expect} from '../../../util/reconfiguredChai';
 import React from 'react';
 import {mount} from 'enzyme';
 import CourseEditor from '@cdo/apps/templates/courseOverview/CourseEditor';
@@ -39,16 +39,34 @@ describe('CourseEditor', () => {
     restoreRedux();
   });
 
-  it('renders full course editor page', () => {
-    const wrapper = mount(
+  const createWrapper = overrideProps => {
+    const combinedProps = {...defaultProps, ...overrideProps};
+    return mount(
       <Provider store={getStore()}>
-        <CourseEditor {...defaultProps} />
+        <CourseEditor {...combinedProps} />
       </Provider>
     );
+  };
 
+  it('renders full course editor page', () => {
+    const wrapper = createWrapper({});
     assert.equal(wrapper.find('textarea').length, 3);
     assert.equal(wrapper.find('CourseScriptsEditor').length, 1);
     assert.equal(wrapper.find('ResourcesEditor').length, 1);
     assert.equal(wrapper.find('CourseOverviewTopRow').length, 1);
+  });
+
+  describe('VisibleInTeacherDashboard', () => {
+    it('is unchecked when visible is false', () => {
+      const wrapper = createWrapper({});
+      const checkbox = wrapper.find('input[name="visible"]');
+      expect(checkbox.prop('checked')).to.be.false;
+    });
+
+    it('is checked when visible is true', () => {
+      const wrapper = createWrapper({visible: true});
+      const checkbox = wrapper.find('input[name="visible"]');
+      expect(checkbox.prop('checked')).to.be.true;
+    });
   });
 });

--- a/apps/test/unit/templates/courseOverview/CourseEditorTest.js
+++ b/apps/test/unit/templates/courseOverview/CourseEditorTest.js
@@ -16,6 +16,8 @@ const defaultProps = {
   title: 'Computer Science Principles 2017',
   familyName: 'CSP',
   versionYear: '2017',
+  visible: false,
+  isStable: false,
   descriptionShort: 'Desc here',
   descriptionStudent: 'Desc here',
   descriptionTeacher: 'Desc here',

--- a/dashboard/app/controllers/courses_controller.rb
+++ b/dashboard/app/controllers/courses_controller.rb
@@ -103,8 +103,8 @@ class CoursesController < ApplicationController
     course = Course.find_by_name!(params[:course_name])
     course.persist_strings_and_scripts_changes(params[:scripts], params[:alternate_scripts], i18n_params)
     course.update_teacher_resources(params[:resourceTypes], params[:resourceLinks])
-    # Convert has_verified_resources from a string ("on") to a boolean.
-    params[:has_verified_resources] = !!params[:has_verified_resources]
+    # Convert checkbox values from a string ("on") to a boolean.
+    [:has_verified_resources, :visible, :is_stable].each {|key| params[key] = !!params[key]}
     course.update(course_params)
     redirect_to course
   end
@@ -129,7 +129,7 @@ class CoursesController < ApplicationController
   private
 
   def course_params
-    params.permit(:version_year, :family_name, :has_verified_resources, :pilot_experiment).to_h
+    params.permit(:version_year, :family_name, :has_verified_resources, :pilot_experiment, :visible, :is_stable).to_h
   end
 
   def set_redirect_override

--- a/dashboard/app/models/course.rb
+++ b/dashboard/app/models/course.rb
@@ -287,6 +287,8 @@ class Course < ApplicationRecord
       assignment_family_title: localized_assignment_family_title,
       family_name: family_name,
       version_year: version_year,
+      visible: visible?,
+      is_stable: is_stable?,
       pilot_experiment: pilot_experiment,
       description_short: I18n.t("data.course.name.#{name}.description_short", default: ''),
       description_student: I18n.t("data.course.name.#{name}.description_student", default: ''),

--- a/dashboard/test/controllers/courses_controller_test.rb
+++ b/dashboard/test/controllers/courses_controller_test.rb
@@ -284,18 +284,24 @@ class CoursesControllerTest < ActionController::TestCase
     assert_nil course.version_year
     assert_nil course.family_name
     refute course.has_verified_resources
+    refute course.visible?
+    refute course.is_stable?
 
     post :update, params: {
       course_name: course.name,
       version_year: '2019',
       family_name: 'csp',
-      has_verified_resources: 'on'
+      has_verified_resources: 'on',
+      visible: 'on',
+      is_stable: 'on'
     }
     course.reload
 
     assert_equal '2019', course.version_year
     assert_equal 'csp', course.family_name
     assert course.has_verified_resources
+    assert course.visible?
+    assert course.is_stable?
   end
 
   # tests for edit

--- a/dashboard/test/models/course_test.rb
+++ b/dashboard/test/models/course_test.rb
@@ -166,8 +166,8 @@ class CourseTest < ActiveSupport::TestCase
     summary = course.summarize
 
     assert_equal [:name, :id, :title, :assignment_family_title,
-                  :family_name, :version_year, :pilot_experiment,
-                  :description_short, :description_student,
+                  :family_name, :version_year, :visible, :is_stable,
+                  :pilot_experiment, :description_short, :description_student,
                   :description_teacher, :scripts, :teacher_resources,
                   :has_verified_resources, :versions, :show_assign_button], summary.keys
     assert_equal 'my-course', summary[:name]


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/6564873/80810312-6aa8b880-8b78-11ea-92ac-cf611ac460be.png)


When something is entered for pilot experiment, it automatically changes to:

![image](https://user-images.githubusercontent.com/6564873/80810279-58c71580-8b78-11ea-9257-1e05cf98d597.png)

Which should be the same behavior as on the script edit UI.

I did a small refactor to create a new component which combines VisibleInTeacherDashboard and PilotExperiment, which now handles greying out visible if pilot experiment is set. Then it can be used more cleanly between both the script edit and course edit UI. As a result the ordering in the UI is changed slightly - pilot experiment is now between visible and stable.

## Testing story

* Manually tested checking and unchecking both new checkboxes on course edit UI, and also the "Visible in teacher dashboard" checkbox in script edit UI.
* Updated unit tests

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
