### PR TITLE
Remove one more in-person reference

### DIFF
--- a/dashboard/app/views/pd/workshop_mailer/teacher_cancel_receipt.html.haml
+++ b/dashboard/app/views/pd/workshop_mailer/teacher_cancel_receipt.html.haml
@@ -18,7 +18,7 @@
   = link_to('here', 'https://code.org/professional-development-workshops') + ','
   or check out our free, self-paced
   = link_to 'online professional development', 'https://code.org/educate/professional-development-online'
-  to get started before attending a different in-person workshop.
+  to get started before attending a different workshop.
 
 %p
   If this is a mistake and you did not mean to cancel your workshop registration,


### PR DESCRIPTION
Drops "in-person" language from the CSF workshop enrollment cancellation receipt, with Megan's approval.