### PR TITLE
CSPWFRT: Unhide workshop type

### DIFF
--- a/apps/src/code-studio/pd/workshop_dashboard/components/workshop_form.jsx
+++ b/apps/src/code-studio/pd/workshop_dashboard/components/workshop_form.jsx
@@ -40,8 +40,7 @@ import {
 } from '../permission';
 import {
   Courses,
-  Subjects,
-  SubjectNames
+  Subjects
 } from '@cdo/apps/generated/pd/sharedWorkshopConstants';
 
 const styles = {
@@ -560,11 +559,6 @@ export class WorkshopForm extends React.Component {
     if (this.shouldRenderSubject()) {
       const options = Subjects[this.state.course]
         .filter(subject => {
-          // Temporary: Don't show the new workshop type as an option while we're still building it.
-          if (subject === SubjectNames.SUBJECT_CSP_FOR_RETURNING_TEACHERS) {
-            return false;
-          }
-
           // Only a WorkshopAdmin should be shown a Virtual workshop.
           return (
             subject.indexOf('Virtual') === -1 ||


### PR DESCRIPTION
([Spec](https://docs.google.com/document/d/1u1Vfm5DnsBpwUrV2XLp9XMcF2R3SU7b1EAtlBBB6wEU/edit#)) Shows the new "CS Principles Workshop for Returning Teachers" workshop type in the workshop type dropdown on the workshop editor, which allows partners and workshop organizers to create workshops of this type.

This removes code we added to hide this workshop type, introduced in https://github.com/code-dot-org/code-dot-org/pull/34393.

I've done manual testing of our workshop flows for this workshop type, as documented in a series of screenshots below.

## Related changes

 - #34393 Introduced the new workshop type
 - #34432 Added new registration questions and made answers show up in the enrollments table.
 - #34396 Added the new enrollment confirmation mailer
 - #34400 Ensures this workshop type is never “Code.org Funded.”
 - #34403 Added new 10 and 3 days enrollment reminder mailers
 - #34410 Added a new post-workshop mailer

## Known issues

- Trying to view daily or post-workshop surveys for one of these workshops currently results in an infinite loading spinner. Getting those surveys working is out of scope for today's change.

## Screenshots from manual testing

### Creating a workshop

![image](https://user-images.githubusercontent.com/1615761/80414320-b6f8ad80-8885-11ea-9bc6-f5c73bd67bf3.png)

### Signing up for the workshop

![image](https://user-images.githubusercontent.com/1615761/80414607-279fca00-8886-11ea-9fd5-97b0a0c41074.png)

![image](https://user-images.githubusercontent.com/1615761/80414636-31c1c880-8886-11ea-8922-25d121d4eae9.png)

Thank you after submitting

![image](https://user-images.githubusercontent.com/1615761/80414713-4c943d00-8886-11ea-9f7f-cc96a786af2b.png)

Enrollment receipt:

![image](https://user-images.githubusercontent.com/1615761/80415517-831e8780-8887-11ea-944a-f7ffa1ed4a41.png)

Enrollment notification to organizer:

![image](https://user-images.githubusercontent.com/1615761/80415580-97fb1b00-8887-11ea-80a1-fe82bc66121d.png)


### View workshop, not yet started

![image](https://user-images.githubusercontent.com/1615761/80414868-88c79d80-8886-11ea-9f2f-f09b416ba896.png)
![image](https://user-images.githubusercontent.com/1615761/80414886-941ac900-8886-11ea-92bf-9dd1b05d1256.png)

### 3-day workshop reminder

![image](https://user-images.githubusercontent.com/1615761/80416170-88c89d00-8888-11ea-8402-bf0500b8e145.png)

### View workshop, in progress

![image](https://user-images.githubusercontent.com/1615761/80416346-d513dd00-8888-11ea-829c-d97a6d639164.png)
![image](https://user-images.githubusercontent.com/1615761/80416387-e52bbc80-8888-11ea-9a58-368ca54d64de.png)

### Reporting attendance as an attendee

![image](https://user-images.githubusercontent.com/1615761/80416599-3fc51880-8889-11ea-9b71-6a384caa97ae.png)

### Checking attendance as an organizer

![image](https://user-images.githubusercontent.com/1615761/80416666-5b302380-8889-11ea-95c1-0a790f54f600.png)

### View workshop, ended

![image](https://user-images.githubusercontent.com/1615761/80416743-7dc23c80-8889-11ea-8bf4-b18ae87b00eb.png)
![image](https://user-images.githubusercontent.com/1615761/80416777-8a469500-8889-11ea-8e20-4e55e91b2b8d.png)

### Exit survey email

![image](https://user-images.githubusercontent.com/1615761/80416976-d98cc580-8889-11ea-8b03-625fb3aa442d.png)


### Cancelling registration

Confirming cancellation:

![image](https://user-images.githubusercontent.com/1615761/80415156-fb387d80-8886-11ea-95f5-97422483f7ed.png)

Cancel complete:

![image](https://user-images.githubusercontent.com/1615761/80415195-08ee0300-8887-11ea-8faf-413812ee6cfd.png)

Cancellation receipt:

![image](https://user-images.githubusercontent.com/1615761/80415258-228f4a80-8887-11ea-8d57-6dbacc229d53.png)

Cancellation notification to organizer:

![image](https://user-images.githubusercontent.com/1615761/80415305-39ce3800-8887-11ea-92a4-e350e923fede.png)
