### PR TITLE
fix title for CSF scripts in assignment selector dropdown

### DIFF
--- a/dashboard/config/locales/scripts.en.yml
+++ b/dashboard/config/locales/scripts.en.yml
@@ -7,7 +7,7 @@ en:
         csd_category_name: CS Discoveries ('17-'18)
         csd_2018_category_name: CS Discoveries ('18-'19)
         csd_2019_category_name: CS Discoveries ('19-'20)
-        csf_category_name: CS Fundamentals (2017)
+        csf_category_name: CS Fundamentals
         csf_2018_category_name: CS Fundamentals (2018)
         csf_2019_category_name: CS Fundamentals (2019)
         csf_international_category_name: CS Fundamentals International


### PR DESCRIPTION
partially reverts https://github.com/code-dot-org/code-dot-org/pull/34249 to fix a regression in the assignment selector dropdown:
![image (1)](https://user-images.githubusercontent.com/8001765/80404189-a809ff00-8875-11ea-800e-2ab3066ec105.png)

this problem is much more severe than the problem the original PR fixed. 