### PR TITLE
Extract the "throw confetti" logic into standalone template

### DIFF
--- a/apps/src/templates/BackToFrontConfetti.jsx
+++ b/apps/src/templates/BackToFrontConfetti.jsx
@@ -1,0 +1,49 @@
+/**
+ * A simple wrapper for the react-dom-confetti Confetti component, which
+ * simulates the confetti being tossed up from behind the containing element,
+ * and then falling down in front of it.
+ *
+ * If you don't need or want this functionality, you probably want to use the
+ * Confetti component directly.
+ */
+
+import Confetti from 'react-dom-confetti';
+import React from 'react';
+import PropTypes from 'prop-types';
+
+const defaultStyle = {
+  position: 'relative',
+  left: '50%'
+};
+
+export default class BackToFrontConfetti extends React.Component {
+  static propTypes = {
+    style: PropTypes.object,
+    active: PropTypes.bool
+  };
+
+  constructor(props) {
+    super(props);
+    this.state = {
+      confettiOnTop: false
+    };
+  }
+
+  componentDidUpdate() {
+    if (this.props.active && !this.state.confettiOnTop) {
+      // We want the confetti to shoot up from behind the dialog and fall in
+      // front of it. Fake it by changing the z-index from -1 to 1 after 700ms
+      window.setTimeout(() => this.setState({confettiOnTop: true}), 700);
+    }
+  }
+
+  render() {
+    const confettiZIndex = this.state.confettiOnTop ? 1 : -1;
+    const customStyle = this.props.style || {};
+    return (
+      <div style={{...defaultStyle, ...customStyle, zIndex: confettiZIndex}}>
+        <Confetti active={this.props.active} />
+      </div>
+    );
+  }
+}

--- a/apps/src/templates/ChallengeDialog.jsx
+++ b/apps/src/templates/ChallengeDialog.jsx
@@ -1,5 +1,5 @@
+import BackToFrontConfetti from './BackToFrontConfetti';
 import BaseDialog from './BaseDialog';
-import Confetti from 'react-dom-confetti';
 import LegacyButton from './LegacyButton';
 import PuzzleRatingButtons from './PuzzleRatingButtons';
 import PropTypes from 'prop-types';
@@ -54,8 +54,6 @@ const styles = {
     lineHeight: '30px'
   },
   confetti: {
-    position: 'relative',
-    left: '50%',
     top: 150
   },
   primaryButton: {
@@ -92,8 +90,7 @@ class ChallengeDialog extends React.Component {
     super(props);
     this.state = {
       isOpen: this.props.isOpen === undefined || this.props.isOpen,
-      confettiActive: false,
-      confettiOnTop: false
+      confettiActive: false
     };
   }
 
@@ -112,15 +109,10 @@ class ChallengeDialog extends React.Component {
       // The confetti only starts when the `active` prop transitions from false
       // to true, so this defaults to false but is immediately set to true
       window.setTimeout(() => this.setState({confettiActive: true}), 0);
-
-      // I want the confetti to shoot up from behind the dialog and fall in
-      // front of it. Fake it by changing the z-index from -1 to 1 after 700ms
-      window.setTimeout(() => this.setState({confettiOnTop: true}), 700);
     }
   }
 
   render() {
-    const confettiZIndex = this.state.confettiOnTop ? 1 : -1;
     return (
       <BaseDialog
         isOpen={this.state.isOpen}
@@ -139,9 +131,10 @@ class ChallengeDialog extends React.Component {
           <h1 style={styles.title} id="uitest-challenge-title">
             {this.props.title}
           </h1>
-          <div style={{...styles.confetti, zIndex: confettiZIndex}}>
-            <Confetti active={this.state.confettiActive} />
-          </div>
+          <BackToFrontConfetti
+            active={this.state.confettiActive}
+            style={styles.confetti}
+          />
         </div>
         <div style={styles.content}>
           <div style={styles.text}>{this.props.text}</div>

--- a/apps/test/unit/templates/BackToFrontConfettiTest.js
+++ b/apps/test/unit/templates/BackToFrontConfettiTest.js
@@ -1,0 +1,45 @@
+import sinon from 'sinon';
+import BackToFrontConfetti from '@cdo/apps/templates/BackToFrontConfetti';
+import React from 'react';
+import {expect} from '../../util/deprecatedChai';
+import {mount} from 'enzyme';
+
+describe('BackToFrontConfetti', () => {
+  let clock;
+
+  beforeEach(() => {
+    clock = sinon.useFakeTimers();
+  });
+
+  afterEach(() => {
+    clock.restore();
+  });
+
+  it('initially renders with a negative zIndex', () => {
+    const wrapper = mount(<BackToFrontConfetti />);
+    expect(wrapper).to.have.style('zIndex', '-1');
+  });
+
+  it('remains negatively zIndexed indefinitely after rendering', () => {
+    const wrapper = mount(<BackToFrontConfetti />);
+    clock.tick(999);
+    expect(wrapper).to.have.style('zIndex', '-1');
+  });
+
+  it('remains negatively zIndexed temporarily after activation', () => {
+    const wrapper = mount(<BackToFrontConfetti />);
+    wrapper.setProps({active: true});
+    expect(wrapper).to.have.style('zIndex', '-1');
+    clock.tick(10);
+    expect(wrapper).to.have.style('zIndex', '-1');
+  });
+
+  it('switches to a positive zIndex shortly after activation', () => {
+    const wrapper = mount(<BackToFrontConfetti />);
+    wrapper.setProps({active: true});
+    clock.tick(600);
+    expect(wrapper).to.have.style('zIndex', '-1');
+    clock.tick(100);
+    expect(wrapper).to.have.style('zIndex', '1');
+  });
+});


### PR DESCRIPTION
Originally added in https://github.com/code-dot-org/code-dot-org/pull/17688 (and inspired by https://www.useronboard.com/how-hillary2016pt2-onboards-new-users/?slide=85), this PR extracts the confetti-specific logic from that component to a standalone component, for reuse.

Will be used in upcoming work to add confetti to the certificate congrats page.

## Testing story

Manually tested on http://studio.code.org/s/coursef-2018/stage/2/puzzle/10 to verify that there is no visual change.

Also added a basic unit test.

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
