### PR TITLE
studio.code.org/help redirects to https://support.code.org

### DIFF
--- a/dashboard/config/routes.rb
+++ b/dashboard/config/routes.rb
@@ -708,4 +708,6 @@ Dashboard::Application.routes.draw do
   get '/curriculum_tracking_pixel', to: 'curriculum_tracking_pixel#index'
 
   post '/profanity/find', to: 'profanity#find'
+
+  get '/help', to: redirect("https://support.code.org/hc/en-us")
 end

--- a/dashboard/config/routes.rb
+++ b/dashboard/config/routes.rb
@@ -709,5 +709,5 @@ Dashboard::Application.routes.draw do
 
   post '/profanity/find', to: 'profanity#find'
 
-  get '/help', to: redirect("https://support.code.org/hc/en-us")
+  get '/help', to: redirect("https://support.code.org")
 end


### PR DESCRIPTION
We don't currently have any content at studio.code.org/help and the url results in a 404.  On the off chance that someone is looking for help and tries that url, let's send them to our support page (where our help & support links go). 