### PR TITLE
prevent wrapping on the 'sort' icon in table headers

### DIFF
--- a/apps/src/templates/tables/tableConstants.js
+++ b/apps/src/templates/tables/tableConstants.js
@@ -45,5 +45,14 @@ export const tableLayoutStyles = {
 // Settings for WrappedSortable
 export const sortableOptions = {
   // Dim inactive sorting icons in the column headers
-  default: {color: 'rgba(0, 0, 0, 0.2 )'}
+  default: {color: 'rgba(0, 0, 0, 0.2 )'},
+
+  // Disable wrapping on the sorting icon to ensure that the header will never
+  // wrap such that the sorting icon is on a row all on its own.
+  //
+  // Note that we could apply this style to the whole header cell, but that
+  // would prevent any wrapping from happening at all; because we want to allow
+  // for the possibility of long header names that _should_ wrap, this provides
+  // a nice compromise.
+  container: {whiteSpace: 'nowrap'}
 };

--- a/apps/src/templates/tables/tableConstants.js
+++ b/apps/src/templates/tables/tableConstants.js
@@ -45,14 +45,5 @@ export const tableLayoutStyles = {
 // Settings for WrappedSortable
 export const sortableOptions = {
   // Dim inactive sorting icons in the column headers
-  default: {color: 'rgba(0, 0, 0, 0.2 )'},
-
-  // Disable wrapping on the sorting icon to ensure that the header will never
-  // wrap such that the sorting icon is on a row all on its own.
-  //
-  // Note that we could apply this style to the whole header cell, but that
-  // would prevent any wrapping from happening at all; because we want to allow
-  // for the possibility of long header names that _should_ wrap, this provides
-  // a nice compromise.
-  container: {whiteSpace: 'nowrap'}
+  default: {color: 'rgba(0, 0, 0, 0.2 )'}
 };

--- a/apps/src/templates/tables/wrapped_sortable.js
+++ b/apps/src/templates/tables/wrapped_sortable.js
@@ -42,12 +42,21 @@ function wrappedSortable(getSortingColumns, onSort, styles = {}) {
       );
     }
 
+    // Disable wrapping on the sorting icon to ensure that the header will
+    // never wrap such that the sorting icon is on a row all on its own.
+    //
+    // Note that we could apply this style to the whole header cell, but that
+    // would prevent any wrapping from happening at all; because we want to
+    // allow for the possibility of long header names that _should_ wrap, this
+    // provides a nice compromise.
+    const sortIconSpanStyle = {whiteSpace: 'nowrap'};
+
     return {
       ...newProps,
       style: Object.assign({}, {cursor: 'pointer'}),
       children: (
         <span style={styles.container}>
-          <span>{sortIcon}</span>
+          <span style={sortIconSpanStyle}>{sortIcon}</span>
           <span>{label}</span>
         </span>
       )


### PR DESCRIPTION
Specifically, prevent the situation where the relative sizes of cells can result in the sort icon being on its own line, with the header text on the following line.

Before | After
--- | ---
![image](https://user-images.githubusercontent.com/244100/80432113-22ec0d80-88a8-11ea-83e3-cca675a02a10.png) | ![image](https://user-images.githubusercontent.com/244100/80432164-3e571880-88a8-11ea-98ea-ec11fbc51722.png)
![image](https://user-images.githubusercontent.com/244100/80432077-064fd580-88a8-11ea-9fe1-29cc17764dd6.png) | ![image](https://user-images.githubusercontent.com/244100/80432039-ef10e800-88a7-11ea-8ccf-59e80cb291ce.png)

Another option for how to fix this would be to prevent wrapping on the header icons entirely, but I suspect there are still situations in which we'd like the header text to wrap, we just don't want it to wrap away from the sort icon.

Note also that this change will impact every table that's using this code. This is intentional; we could implement this fix more surgically, but I suspect we do actually want this functionality everywhere.

## Testing story

Tested manually; I don't think any automated tests are necessary.

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
