### PR TITLE
delete more css referencing user hero

### DIFF
--- a/pegasus/sites.v3/code.org/public/css/theme.css
+++ b/pegasus/sites.v3/code.org/public/css/theme.css
@@ -144,35 +144,6 @@ a.user-menu-link {
   text-decoration: none;
 }
 
-#user_hero #welcome {
-  margin-top: 10px;
-  margin-bottom: 5px;
-  font-size: 18px;
-  font-family: 'Gotham 5r', sans-serif;
-  font-weight: normal;
-}
-
-#user_hero #student_progress {
-  font-family: 'Gotham 5r', sans-serif;
-  font-weight: normal;
-  width: 175px;
-  display: inline-block;
-}
-
-#user_hero #left_off {
-  font-family: 'Gotham 5r', sans-serif;
-  font-weight: normal;
-  width: 175px;
-  display: inline-block;
-}
-
-#user_hero #classroom {
-  font-family: 'Gotham 5r', sans-serif;
-  font-weight: normal;
-  font-size:16px;
-  margin-top:10px;
-}
-
 #sign_in_or_user .button-signin {
   text-decoration: none;
   -webkit-appearance: none;

--- a/pegasus/sites.v3/code.org/styles_min/050-theme.css
+++ b/pegasus/sites.v3/code.org/styles_min/050-theme.css
@@ -74,11 +74,6 @@ body {
 
 
 /* styling for the embedded dashboard components... */
-#user_hero #contents {
-  margin: 10px 0px;
-  padding-left: 5px;
-  width: 100%;
-}
 
 #sign_in_or_user {
   margin: .6875em 0 0 30px;

--- a/pegasus/sites.v3/hourofcode.com/styles/050-theme.css
+++ b/pegasus/sites.v3/hourofcode.com/styles/050-theme.css
@@ -147,39 +147,6 @@ body {
 
 /* styling for the embedded dashboard components... */
 
-#user_hero #welcome {
-  margin-top:10px;
-  margin-bottom:5px;
-  font-size: 18px;
-  font-family: 'Gotham 5r', sans-serif;
-}
-
-#user_hero #continue_button {
-  padding-top: 0px;
-  padding-bottom: 0px;
-  height: 22px;
-  background-color: rgb(255, 164, 0) ;
-  border-color: rgb(255, 164, 0) ;
-}
-
-#user_hero #student_progress {
-  font-family: 'Gotham 5r', sans-serif;
-  width: 175px;
-  display: inline-block;
-}
-
-#user_hero #left_off {
-  font-family: 'Gotham 5r', sans-serif;
-  width: 175px;
-  display: inline-block;
-}
-
-#user_hero #classroom {
-  font-family: 'Gotham 5r', sans-serif;
-  font-size:16px;
-  margin-top:10px;
-}
-
 #sign_in_or_user .button-signin {
   text-decoration: none;
   -webkit-appearance: none;


### PR DESCRIPTION
user hero was deleted in https://github.com/code-dot-org/code-dot-org/pull/23862 . I happened to spot some unused css pointing to it, while I was removing obsolete references to `student_progress`.