### PR TITLE
Improve visibility in Sprite Lab titles and subtitles

### DIFF
--- a/apps/src/p5lab/spritelab/commands.js
+++ b/apps/src/p5lab/spritelab/commands.js
@@ -21,6 +21,8 @@ function drawBackground() {
 
 function updateTitle() {
   this.fill('black');
+  this.stroke('white');
+  this.strokeWeight(3);
   this.textAlign(this.CENTER, this.CENTER);
   this.textSize(50);
   this.text(coreLibrary.title, 0, 0, 400, 200);

--- a/dashboard/config/blocks/GamelabJr/gamelab_showTitleScreen.json
+++ b/dashboard/config/blocks/GamelabJr/gamelab_showTitleScreen.json
@@ -7,7 +7,7 @@
       0.65
     ],
     "func": "showTitleScreen",
-    "blockText": "show title screen {BREAK} title {TITLE} text {SUBTITLE}",
+    "blockText": "show title screen {BREAK} title {TITLE} subtitle {SUBTITLE}",
     "args": [
       {
         "name": "BREAK",


### PR DESCRIPTION
Adds a white outline to the title and subtitle elements on Sprite Lab projects:

![image](https://user-images.githubusercontent.com/25372625/80434600-10290700-88af-11ea-89c0-80d87035337d.png)

![image](https://user-images.githubusercontent.com/25372625/80434640-2afb7b80-88af-11ea-8e88-0d72ad655c12.png)

![image](https://user-images.githubusercontent.com/25372625/80434661-3d75b500-88af-11ea-8655-0a1a598403ed.png)

Also a line of cleanup to change appropriately label the input for the subtitle as "subtitle" -- this is what it looked like before:

![image](https://user-images.githubusercontent.com/25372625/80434545-e7a10d00-88ae-11ea-8359-12bf88037e8b.png)

Note that this would change all existing Sprite Lab projects.

## Testing story

I tested locally on a number of different background colors.

## Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
