### PR TITLE
Move Theme Picker in App Lab

### DIFF
--- a/apps/src/applab/DesignModeBox.jsx
+++ b/apps/src/applab/DesignModeBox.jsx
@@ -20,7 +20,8 @@ export default class DesignModeBox extends React.Component {
     onRestoreThemeDefaults: PropTypes.func.isRequired,
     onInsertEvent: PropTypes.func.isRequired,
     screenIds: PropTypes.arrayOf(PropTypes.string).isRequired,
-    currentTheme: PropTypes.string.isRequired
+    currentTheme: PropTypes.string.isRequired,
+    handleScreenChange: PropTypes.func.isRequired
   };
 
   render() {
@@ -67,7 +68,7 @@ export default class DesignModeBox extends React.Component {
         <DesignToolbox
           handleDragStart={this.props.handleDragStart}
           isToolboxVisible={this.props.isToolboxVisible}
-          handleChange={this.props.handleChange}
+          handleScreenChange={this.props.handleScreenChange}
           themeValue={this.props.currentTheme}
         />
         <div id="design-properties" style={styles.designProperties}>

--- a/apps/src/applab/DesignModeBox.jsx
+++ b/apps/src/applab/DesignModeBox.jsx
@@ -19,8 +19,7 @@ export default class DesignModeBox extends React.Component {
     onDuplicate: PropTypes.func.isRequired,
     onRestoreThemeDefaults: PropTypes.func.isRequired,
     onInsertEvent: PropTypes.func.isRequired,
-    screenIds: PropTypes.arrayOf(PropTypes.string).isRequired,
-    currentTheme: PropTypes.string.isRequired
+    screenIds: PropTypes.arrayOf(PropTypes.string).isRequired
   };
 
   render() {
@@ -68,7 +67,7 @@ export default class DesignModeBox extends React.Component {
           handleDragStart={this.props.handleDragStart}
           isToolboxVisible={this.props.isToolboxVisible}
           handleChange={this.props.handleChange}
-          themeValue={this.props.currentTheme}
+          element={this.props.element}
         />
         <div id="design-properties" style={styles.designProperties}>
           <DesignProperties

--- a/apps/src/applab/DesignModeBox.jsx
+++ b/apps/src/applab/DesignModeBox.jsx
@@ -19,7 +19,8 @@ export default class DesignModeBox extends React.Component {
     onDuplicate: PropTypes.func.isRequired,
     onRestoreThemeDefaults: PropTypes.func.isRequired,
     onInsertEvent: PropTypes.func.isRequired,
-    screenIds: PropTypes.arrayOf(PropTypes.string).isRequired
+    screenIds: PropTypes.arrayOf(PropTypes.string).isRequired,
+    currentTheme: PropTypes.string.isRequired
   };
 
   render() {
@@ -66,6 +67,8 @@ export default class DesignModeBox extends React.Component {
         <DesignToolbox
           handleDragStart={this.props.handleDragStart}
           isToolboxVisible={this.props.isToolboxVisible}
+          handleChange={this.props.handleChange}
+          themeValue={this.props.currentTheme}
         />
         <div id="design-properties" style={styles.designProperties}>
           <DesignProperties

--- a/apps/src/applab/DesignModeBox.jsx
+++ b/apps/src/applab/DesignModeBox.jsx
@@ -19,7 +19,8 @@ export default class DesignModeBox extends React.Component {
     onDuplicate: PropTypes.func.isRequired,
     onRestoreThemeDefaults: PropTypes.func.isRequired,
     onInsertEvent: PropTypes.func.isRequired,
-    screenIds: PropTypes.arrayOf(PropTypes.string).isRequired
+    screenIds: PropTypes.arrayOf(PropTypes.string).isRequired,
+    currentTheme: PropTypes.string.isRequired
   };
 
   render() {
@@ -67,7 +68,7 @@ export default class DesignModeBox extends React.Component {
           handleDragStart={this.props.handleDragStart}
           isToolboxVisible={this.props.isToolboxVisible}
           handleChange={this.props.handleChange}
-          element={this.props.element}
+          themeValue={this.props.currentTheme}
         />
         <div id="design-properties" style={styles.designProperties}>
           <DesignProperties

--- a/apps/src/applab/DesignToolbox.jsx
+++ b/apps/src/applab/DesignToolbox.jsx
@@ -2,13 +2,16 @@ import PropTypes from 'prop-types';
 import React from 'react';
 import DesignToolboxElement from './DesignToolboxElement';
 import applabMsg from '@cdo/applab/locale';
+import ThemePropertyRow from './designElements/ThemePropertyRow';
 
 const IMAGE_BASE_URL = '/blockly/media/applab/design_toolbox/';
 
 export default class DesignToolbox extends React.Component {
   static propTypes = {
     handleDragStart: PropTypes.func.isRequired,
-    isToolboxVisible: PropTypes.bool.isRequired
+    isToolboxVisible: PropTypes.bool.isRequired,
+    handleChange: PropTypes.func.isRequired,
+    themeValue: PropTypes.string.isRequired
   };
 
   render() {
@@ -24,9 +27,18 @@ export default class DesignToolbox extends React.Component {
       padding: 10,
       paddingRight: 0 // setting this to 0 allows 2 columns with the potential scrollbar on Windows
     };
-
+    const themeStyle = {
+      paddingLeft: 0,
+      marginBottom: 10
+    };
     return (
       <div id="design-toolbox" style={toolboxStyle}>
+        <ThemePropertyRow
+          containerStyle={themeStyle}
+          initialValue={this.props.themeValue}
+          handleChange={this.props.handleChange.bind(this, 'theme')}
+          desc={'Theme'}
+        />
         <p>{applabMsg.designToolboxDescription()}</p>
         <DesignToolboxElement
           imageUrl={IMAGE_BASE_URL + 'button.png'}

--- a/apps/src/applab/DesignToolbox.jsx
+++ b/apps/src/applab/DesignToolbox.jsx
@@ -10,7 +10,7 @@ export default class DesignToolbox extends React.Component {
   static propTypes = {
     handleDragStart: PropTypes.func.isRequired,
     isToolboxVisible: PropTypes.bool.isRequired,
-    handleChange: PropTypes.func.isRequired,
+    handleScreenChange: PropTypes.func.isRequired,
     themeValue: PropTypes.string.isRequired
   };
 
@@ -36,7 +36,7 @@ export default class DesignToolbox extends React.Component {
         <ThemePropertyRow
           containerStyle={themeStyle}
           initialValue={this.props.themeValue}
-          handleChange={this.props.handleChange.bind(this, 'theme')}
+          handleChange={this.props.handleScreenChange.bind(this, 'theme')}
           desc={'Theme'}
         />
         <p>{applabMsg.designToolboxDescription()}</p>

--- a/apps/src/applab/DesignToolbox.jsx
+++ b/apps/src/applab/DesignToolbox.jsx
@@ -31,6 +31,7 @@ export default class DesignToolbox extends React.Component {
       paddingLeft: 0,
       marginBottom: 10
     };
+
     return (
       <div id="design-toolbox" style={toolboxStyle}>
         <ThemePropertyRow

--- a/apps/src/applab/DesignToolbox.jsx
+++ b/apps/src/applab/DesignToolbox.jsx
@@ -11,7 +11,7 @@ export default class DesignToolbox extends React.Component {
     handleDragStart: PropTypes.func.isRequired,
     isToolboxVisible: PropTypes.bool.isRequired,
     handleChange: PropTypes.func.isRequired,
-    themeValue: PropTypes.string.isRequired
+    element: PropTypes.instanceOf(HTMLElement)
   };
 
   render() {
@@ -35,7 +35,11 @@ export default class DesignToolbox extends React.Component {
       <div id="design-toolbox" style={toolboxStyle}>
         <ThemePropertyRow
           containerStyle={themeStyle}
-          initialValue={this.props.themeValue}
+          initialValue={
+            (this.props.element &&
+              this.props.element.getAttribute('data-theme')) ||
+            ThemePropertyRow.defaultProps.initialValue
+          }
           handleChange={this.props.handleChange.bind(this, 'theme')}
           desc={'Theme'}
         />

--- a/apps/src/applab/DesignToolbox.jsx
+++ b/apps/src/applab/DesignToolbox.jsx
@@ -11,7 +11,7 @@ export default class DesignToolbox extends React.Component {
     handleDragStart: PropTypes.func.isRequired,
     isToolboxVisible: PropTypes.bool.isRequired,
     handleChange: PropTypes.func.isRequired,
-    element: PropTypes.instanceOf(HTMLElement)
+    themeValue: PropTypes.string.isRequired
   };
 
   render() {
@@ -35,11 +35,7 @@ export default class DesignToolbox extends React.Component {
       <div id="design-toolbox" style={toolboxStyle}>
         <ThemePropertyRow
           containerStyle={themeStyle}
-          initialValue={
-            (this.props.element &&
-              this.props.element.getAttribute('data-theme')) ||
-            ThemePropertyRow.defaultProps.initialValue
-          }
+          initialValue={this.props.themeValue}
           handleChange={this.props.handleChange.bind(this, 'theme')}
           desc={'Theme'}
         />

--- a/apps/src/applab/DesignWorkspace.jsx
+++ b/apps/src/applab/DesignWorkspace.jsx
@@ -25,8 +25,7 @@ class DesignWorkspace extends React.Component {
     showProjectTemplateWorkspaceIcon: PropTypes.bool.isRequired,
     isRunning: PropTypes.bool.isRequired,
     isRtl: PropTypes.bool.isRequired,
-    showMakerToggle: PropTypes.bool,
-    currentTheme: PropTypes.string.isRequired
+    showMakerToggle: PropTypes.bool
   };
 
   state = {isToolboxVisible: true};
@@ -65,7 +64,6 @@ class DesignWorkspace extends React.Component {
           onRestoreThemeDefaults={this.props.onRestoreThemeDefaults}
           onInsertEvent={this.props.onInsertEvent}
           screenIds={this.props.screenIds}
-          currentTheme={this.props.currentTheme}
         />
       </div>
     );

--- a/apps/src/applab/DesignWorkspace.jsx
+++ b/apps/src/applab/DesignWorkspace.jsx
@@ -20,13 +20,14 @@ class DesignWorkspace extends React.Component {
     onInsertEvent: PropTypes.func.isRequired,
     isDimmed: PropTypes.bool.isRequired,
     screenIds: PropTypes.arrayOf(PropTypes.string).isRequired,
+    currentTheme: PropTypes.string.isRequired,
+    handleScreenChange: PropTypes.func.isRequired,
 
     // provided by redux
     showProjectTemplateWorkspaceIcon: PropTypes.bool.isRequired,
     isRunning: PropTypes.bool.isRequired,
     isRtl: PropTypes.bool.isRequired,
-    showMakerToggle: PropTypes.bool,
-    currentTheme: PropTypes.string.isRequired
+    showMakerToggle: PropTypes.bool
   };
 
   state = {isToolboxVisible: true};
@@ -66,6 +67,7 @@ class DesignWorkspace extends React.Component {
           onInsertEvent={this.props.onInsertEvent}
           screenIds={this.props.screenIds}
           currentTheme={this.props.currentTheme}
+          handleScreenChange={this.props.handleScreenChange}
         />
       </div>
     );

--- a/apps/src/applab/DesignWorkspace.jsx
+++ b/apps/src/applab/DesignWorkspace.jsx
@@ -25,7 +25,8 @@ class DesignWorkspace extends React.Component {
     showProjectTemplateWorkspaceIcon: PropTypes.bool.isRequired,
     isRunning: PropTypes.bool.isRequired,
     isRtl: PropTypes.bool.isRequired,
-    showMakerToggle: PropTypes.bool
+    showMakerToggle: PropTypes.bool,
+    currentTheme: PropTypes.string.isRequired
   };
 
   state = {isToolboxVisible: true};
@@ -64,6 +65,7 @@ class DesignWorkspace extends React.Component {
           onRestoreThemeDefaults={this.props.onRestoreThemeDefaults}
           onInsertEvent={this.props.onInsertEvent}
           screenIds={this.props.screenIds}
+          currentTheme={this.props.currentTheme}
         />
       </div>
     );

--- a/apps/src/applab/designElements/EnumPropertyRow.jsx
+++ b/apps/src/applab/designElements/EnumPropertyRow.jsx
@@ -8,7 +8,8 @@ export default class EnumPropertyRow extends React.Component {
     displayOptions: PropTypes.arrayOf(PropTypes.string),
     options: PropTypes.arrayOf(PropTypes.string).isRequired,
     handleChange: PropTypes.func.isRequired,
-    desc: PropTypes.node
+    desc: PropTypes.node,
+    containerStyle: PropTypes.object
   };
 
   state = {
@@ -32,7 +33,7 @@ export default class EnumPropertyRow extends React.Component {
       );
     });
     return (
-      <div style={rowStyle.container}>
+      <div style={this.props.containerStyle || rowStyle.container}>
         <div style={rowStyle.description}>{desc}</div>
         <select
           className="form-control"

--- a/apps/src/applab/designElements/ThemePropertyRow.jsx
+++ b/apps/src/applab/designElements/ThemePropertyRow.jsx
@@ -12,4 +12,11 @@ export default class ThemePropertyRow extends EnumPropertyRow {
     initialValue: themeOptions[DEFAULT_THEME_INDEX],
     options: themeOptions
   };
+
+  componentWillReceiveProps(nextProps) {
+    const {initialValue} = nextProps;
+    if (this.props.initialValue !== initialValue) {
+      this.setState({selectedValue: initialValue});
+    }
+  }
 }

--- a/apps/src/applab/designElements/ThemePropertyRow.jsx
+++ b/apps/src/applab/designElements/ThemePropertyRow.jsx
@@ -13,6 +13,7 @@ export default class ThemePropertyRow extends EnumPropertyRow {
     options: themeOptions
   };
 
+  // Need to reset theme value if screen switches
   componentWillReceiveProps(nextProps) {
     const {initialValue} = nextProps;
     if (this.props.initialValue !== initialValue) {

--- a/apps/src/applab/designElements/screen.jsx
+++ b/apps/src/applab/designElements/screen.jsx
@@ -3,7 +3,6 @@ import React from 'react';
 import PropertyRow from './PropertyRow';
 import ColorPickerPropertyRow from './ColorPickerPropertyRow';
 import ImagePickerPropertyRow from './ImagePickerPropertyRow';
-import ThemePropertyRow from './ThemePropertyRow';
 import EventHeaderRow from './EventHeaderRow';
 import EventRow from './EventRow';
 import DefaultScreenButtonPropertyRow from './DefaultScreenButtonPropertyRow';
@@ -52,10 +51,6 @@ class ScreenProperties extends React.Component {
           initialValue={elementUtils.getId(element)}
           handleChange={this.props.handleChange.bind(this, 'id')}
           isIdRow={true}
-        />
-        <ThemePropertyRow
-          initialValue={element.getAttribute('data-theme')}
-          handleChange={this.props.handleChange.bind(this, 'theme')}
         />
         <ColorPickerPropertyRow
           desc={'background color'}

--- a/apps/src/applab/designElements/screen.jsx
+++ b/apps/src/applab/designElements/screen.jsx
@@ -3,6 +3,7 @@ import React from 'react';
 import PropertyRow from './PropertyRow';
 import ColorPickerPropertyRow from './ColorPickerPropertyRow';
 import ImagePickerPropertyRow from './ImagePickerPropertyRow';
+import ThemePropertyRow from './ThemePropertyRow';
 import EventHeaderRow from './EventHeaderRow';
 import EventRow from './EventRow';
 import DefaultScreenButtonPropertyRow from './DefaultScreenButtonPropertyRow';
@@ -51,6 +52,10 @@ class ScreenProperties extends React.Component {
           initialValue={elementUtils.getId(element)}
           handleChange={this.props.handleChange.bind(this, 'id')}
           isIdRow={true}
+        />
+        <ThemePropertyRow
+          initialValue={element.getAttribute('data-theme')}
+          handleChange={this.props.handleChange.bind(this, 'theme')}
         />
         <ColorPickerPropertyRow
           desc={'background color'}

--- a/apps/src/applab/designMode.js
+++ b/apps/src/applab/designMode.js
@@ -1821,11 +1821,3 @@ designMode.addKeyboardHandlers = function() {
 designMode.resetIds = function() {
   elementLibrary.resetIds();
 };
-
-designMode.getCurrentTheme = function(element) {
-  if (element) {
-    return element.getAttribute('data-theme');
-  } else {
-    return elementLibrary.getCurrentTheme(designMode.activeScreen());
-  }
-};

--- a/apps/src/applab/designMode.js
+++ b/apps/src/applab/designMode.js
@@ -1684,7 +1684,11 @@ designMode.renderDesignWorkspace = function(element) {
     handleVersionHistory: Applab.handleVersionHistory,
     isDimmed: Applab.running,
     screenIds: designMode.getAllScreenIds(),
-    currentTheme: designMode.getCurrentTheme(element)
+    currentTheme: elementLibrary.getCurrentTheme(designMode.activeScreen()),
+    handleScreenChange: designMode.onPropertyChange.bind(
+      this,
+      designMode.activeScreen()
+    )
   };
   ReactDOM.render(
     <Provider store={getStore()}>

--- a/apps/src/applab/designMode.js
+++ b/apps/src/applab/designMode.js
@@ -1683,7 +1683,8 @@ designMode.renderDesignWorkspace = function(element) {
     onInsertEvent: designMode.onInsertEvent.bind(this),
     handleVersionHistory: Applab.handleVersionHistory,
     isDimmed: Applab.running,
-    screenIds: designMode.getAllScreenIds()
+    screenIds: designMode.getAllScreenIds(),
+    currentTheme: designMode.getCurrentTheme(element)
   };
   ReactDOM.render(
     <Provider store={getStore()}>
@@ -1815,4 +1816,12 @@ designMode.addKeyboardHandlers = function() {
 
 designMode.resetIds = function() {
   elementLibrary.resetIds();
+};
+
+designMode.getCurrentTheme = function(element) {
+  if (element) {
+    return element.getAttribute('data-theme');
+  } else {
+    return elementLibrary.getCurrentTheme(designMode.activeScreen());
+  }
 };

--- a/apps/src/applab/designMode.js
+++ b/apps/src/applab/designMode.js
@@ -1683,8 +1683,7 @@ designMode.renderDesignWorkspace = function(element) {
     onInsertEvent: designMode.onInsertEvent.bind(this),
     handleVersionHistory: Applab.handleVersionHistory,
     isDimmed: Applab.running,
-    screenIds: designMode.getAllScreenIds(),
-    currentTheme: designMode.getCurrentTheme(element)
+    screenIds: designMode.getAllScreenIds()
   };
   ReactDOM.render(
     <Provider store={getStore()}>
@@ -1816,12 +1815,4 @@ designMode.addKeyboardHandlers = function() {
 
 designMode.resetIds = function() {
   elementLibrary.resetIds();
-};
-
-designMode.getCurrentTheme = function(element) {
-  if (element) {
-    return element.getAttribute('data-theme');
-  } else {
-    return elementLibrary.getCurrentTheme(designMode.activeScreen());
-  }
 };


### PR DESCRIPTION
Hackathon Item [#9](https://docs.google.com/document/d/1W-5Uh94GZZDOgtuud4FvAkBztLh-_yyQxXh0TKf228w/edit#)
Move App Lab theme picker from the screen design workspace to the design toolbox so it is always visible in design mode.
Before:
![Screen Shot 2020-04-28 at 9 18 37 AM](https://user-images.githubusercontent.com/33666587/80512977-33959580-8933-11ea-88ed-3b84fc3ae94c.png)
After:
![Screen Shot 2020-04-28 at 9 18 48 AM](https://user-images.githubusercontent.com/33666587/80512987-38f2e000-8933-11ea-8e1e-5181a026d970.png)
Still visible if clicked on a button:
![Screen Shot 2020-04-28 at 9 18 58 AM](https://user-images.githubusercontent.com/33666587/80513009-427c4800-8933-11ea-813f-c2f2e2c4728f.png)

Note that if the theme is changed and the user is not on the screen design workspace the screen design workspace will replace what was currently there, let me know if that is not desired behavior.
<!-- ### Background -->
<!-- ### Privacy -->
<!-- ### Security -->
<!-- ### Caching -->
<!-- ### Deployment strategy -->
<!-- ### Future work -->

## Testing story
Manually verified that changing the theme in the new picker updates the theme correctly, and the picker works when switching screens and to lower level items (buttons, etc.)

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
