### PR TITLE
Open help links in new tab

### DIFF
--- a/lib/cdo/help_header.rb
+++ b/lib/cdo/help_header.rb
@@ -12,13 +12,15 @@ class HelpHeader
       entries << {
         title: I18n.t("#{loc_prefix}game_lab_documentation"),
         url: "https://studio.code.org/docs/gamelab/",
-        id: "gamelab-docs"
+        id: "gamelab-docs",
+        target: "_blank"
       }
 
       entries << {
         title: I18n.t("#{loc_prefix}game_lab_tutorials"),
         url: CDO.code_org_url('/educate/gamelab'),
-        id: "gamelab-tutorials"
+        id: "gamelab-tutorials",
+        target: "_blank"
       }
     end
 
@@ -26,13 +28,15 @@ class HelpHeader
       entries << {
         title: I18n.t("#{loc_prefix}app_lab_documentation"),
         url: "https://studio.code.org/docs/applab/",
-        id: "applab-docs"
+        id: "applab-docs",
+        target: "_blank"
       }
 
       entries << {
         title: I18n.t("#{loc_prefix}app_lab_tutorials"),
         url: CDO.code_org_url('/educate/applab'),
-        id: "applab-tutorials"
+        id: "applab-tutorials",
+        target: "_blank"
       }
     end
 
@@ -40,13 +44,15 @@ class HelpHeader
       entries << {
         title: I18n.t("#{loc_prefix}sprite_lab_documentation"),
         url: "https://studio.code.org/docs/spritelab/",
-        id: "spritelab-docs"
+        id: "spritelab-docs",
+        target: "_blank"
       }
 
       entries << {
         title: I18n.t("#{loc_prefix}sprite_lab_tutorials"),
         url: CDO.code_org_url('/educate/spritelab'),
-        id: "spritelab-tutorials"
+        id: "spritelab-tutorials",
+        target: "_blank"
       }
     end
 

--- a/lib/cdo/help_header.rb
+++ b/lib/cdo/help_header.rb
@@ -83,6 +83,8 @@ class HelpHeader
 
     # We want help links to open in a new window so students can refer to them in parallel with their code.
     # However, there are security (and performance) risks to opening links in new windows.
+    # The current set of links are safe because they are internal.
+    # Adding external links to this help menu should be avoided while we are setting "target = _blank".
     # The security risks are partially mitigated by setting the rel attribute to "noopener noreferrer nofollow",
     # but not all browsers support these -- see these docs for more details:
     # https://developers.google.com/web/tools/lighthouse/audits/noopener

--- a/lib/cdo/help_header.rb
+++ b/lib/cdo/help_header.rb
@@ -12,15 +12,13 @@ class HelpHeader
       entries << {
         title: I18n.t("#{loc_prefix}game_lab_documentation"),
         url: "https://studio.code.org/docs/gamelab/",
-        id: "gamelab-docs",
-        target: "_blank"
+        id: "gamelab-docs"
       }
 
       entries << {
         title: I18n.t("#{loc_prefix}game_lab_tutorials"),
         url: CDO.code_org_url('/educate/gamelab'),
-        id: "gamelab-tutorials",
-        target: "_blank"
+        id: "gamelab-tutorials"
       }
     end
 
@@ -28,15 +26,13 @@ class HelpHeader
       entries << {
         title: I18n.t("#{loc_prefix}app_lab_documentation"),
         url: "https://studio.code.org/docs/applab/",
-        id: "applab-docs",
-        target: "_blank"
+        id: "applab-docs"
       }
 
       entries << {
         title: I18n.t("#{loc_prefix}app_lab_tutorials"),
         url: CDO.code_org_url('/educate/applab'),
-        id: "applab-tutorials",
-        target: "_blank"
+        id: "applab-tutorials"
       }
     end
 
@@ -44,15 +40,13 @@ class HelpHeader
       entries << {
         title: I18n.t("#{loc_prefix}sprite_lab_documentation"),
         url: "https://studio.code.org/docs/spritelab/",
-        id: "spritelab-docs",
-        target: "_blank"
+        id: "spritelab-docs"
       }
 
       entries << {
         title: I18n.t("#{loc_prefix}sprite_lab_tutorials"),
         url: CDO.code_org_url('/educate/spritelab'),
         id: "spritelab-tutorials",
-        target: "_blank"
       }
     end
 
@@ -63,32 +57,33 @@ class HelpHeader
       entries << {
         title: I18n.t("#{loc_prefix}report_bug"),
         url: report_url,
-        id: "report-bug",
-        target: "_blank"
+        id: "report-bug"
       }
     else
       entries << {
         title: I18n.t("#{loc_prefix}report_bug"),
         url: "https://support.code.org/hc/en-us/requests/new",
-        id: "report-bug",
-        target: "_blank"
+        id: "report-bug"
       }
     end
 
     entries << {
       title: I18n.t("#{loc_prefix}help_support"),
       url: "https://support.code.org",
-      id: "support",
-      target: "_blank"
+      id: "support"
     }
 
     if options[:user_type] == "teacher"
       entries << {
         title: I18n.t("#{loc_prefix}teacher_community"),
         url: "http://forum.code.org/",
-        target: "_blank",
         id: "teacher-community"
       }
+    end
+
+    entries.each do |entry|
+      entry[:target] = "_blank"
+      entry[:rel] = "noopener noreferrer nofollow"
     end
 
     entries

--- a/lib/cdo/help_header.rb
+++ b/lib/cdo/help_header.rb
@@ -46,7 +46,7 @@ class HelpHeader
       entries << {
         title: I18n.t("#{loc_prefix}sprite_lab_tutorials"),
         url: CDO.code_org_url('/educate/spritelab'),
-        id: "spritelab-tutorials",
+        id: "spritelab-tutorials"
       }
     end
 
@@ -81,6 +81,11 @@ class HelpHeader
       }
     end
 
+    # We want help links to open in a new window so students can refer to them in parallel with their code.
+    # However, there are security (and performance) risks to opening links in new windows.
+    # The security risks are partially mitigated by setting the rel attribute to "noopener noreferrer nofollow",
+    # but not all browsers support these -- see these docs for more details:
+    # https://developers.google.com/web/tools/lighthouse/audits/noopener
     entries.each do |entry|
       entry[:target] = "_blank"
       entry[:rel] = "noopener noreferrer nofollow"

--- a/shared/haml/hamburger.haml
+++ b/shared/haml/hamburger.haml
@@ -20,7 +20,7 @@
         %div{class: entry[:class]}
           .item
             - target = entry[:target] ? entry[:target] : "_self"
-            %a{id: entry[:id], href: entry[:url], target: target}= entry[:title]
+            %a{id: entry[:id], href: entry[:url], target: target, rel: entry[:rel]}= entry[:title]
 
   #hamburger-icon.clicktag{class: contents[:visibility]}
     %span{style: "pointer-events: none"}

--- a/shared/haml/hamburger.haml
+++ b/shared/haml/hamburger.haml
@@ -19,7 +19,6 @@
       - else
         %div{class: entry[:class]}
           .item
-            = puts "entry ID: #{entry[:id]} target: #{entry[:target] ? entry[:target] : '_self'}"
             - target = entry[:target] ? entry[:target] : "_self"
             %a{id: entry[:id], href: entry[:url], target: target}= entry[:title]
 

--- a/shared/haml/hamburger.haml
+++ b/shared/haml/hamburger.haml
@@ -1,10 +1,6 @@
 :ruby
-  require 'cdo/help_header'
-
   options = { level: level, script_level: script_level, language: language, user_type: user_type, loc_prefix: loc_prefix, request: request }
-
   contents = Hamburger.get_hamburger_contents(options)
-  help_items = HelpHeader.get_help_contents(options)
 
 #hamburger{class: contents[:visibility]}
   #hamburger-contents.hide-responsive-menu
@@ -23,6 +19,7 @@
       - else
         %div{class: entry[:class]}
           .item
+            = puts "entry ID: #{entry[:id]} target: #{entry[:target] ? entry[:target] : '_self'}"
             - target = entry[:target] ? entry[:target] : "_self"
             %a{id: entry[:id], href: entry[:url], target: target}= entry[:title]
 

--- a/shared/haml/help_button.haml
+++ b/shared/haml/help_button.haml
@@ -8,8 +8,7 @@
 .help_button{class: "hide-mobile", id: "help-button"}
   .help_contents{style: 'display: none', id: "help-contents"}
     - help_items.each do |entry|
-      - target = entry[:target] ? entry[:target] : "_self"
-      %a.linktag{id: entry[:id], href: entry[:url], target: target}=entry[:title]
+      %a.linktag{id: entry[:id], href: entry[:url], target: entry[:target], rel: entry[:rel]}=entry[:title]
 
   %i.help_icon.clicktag{class: "fa fa-question-circle hide-mobile", id: "help-icon"}
     %span{style: "pointer-events: none"}

--- a/shared/haml/help_button.haml
+++ b/shared/haml/help_button.haml
@@ -8,7 +8,8 @@
 .help_button{class: "hide-mobile", id: "help-button"}
   .help_contents{style: 'display: none', id: "help-contents"}
     - help_items.each do |entry|
-      %a.linktag{id: entry[:id], href: entry[:url]}=entry[:title]
+      - target = entry[:target] ? entry[:target] : "_self"
+      %a.linktag{id: entry[:id], href: entry[:url], target: target}=entry[:title]
 
   %i.help_icon.clicktag{class: "fa fa-question-circle hide-mobile", id: "help-icon"}
     %span{style: "pointer-events: none"}


### PR DESCRIPTION
Opens links accessed in the "?" header, or the same links in the mobile friendly version of the hamburger, in a new tab.

Also have a small bit of cleanup to remove what appears to be unused code (`help_items` variable).

![image](https://user-images.githubusercontent.com/25372625/80535418-98fa7e00-8955-11ea-998a-7edd46008c5a.png)

![image](https://user-images.githubusercontent.com/25372625/80535482-b596b600-8955-11ea-898e-e8bc3f4cef35.png)

## Testing story

Tested locally.

## Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
