### PR TITLE
use the existing CourseBlocks component for all course blocks

### DIFF
--- a/apps/src/templates/studioHomepages/CourseBlocks.jsx
+++ b/apps/src/templates/studioHomepages/CourseBlocks.jsx
@@ -12,25 +12,13 @@ import i18n from '@cdo/locale';
 import {pegasus} from '@cdo/apps/lib/util/urlHelpers';
 
 class ExpressCourses extends Component {
-  componentDidMount() {
-    $('#pre-express')
-      .appendTo(ReactDOM.findDOMNode(this.refs.pre_express))
-      .show();
-    $('#express')
-      .appendTo(ReactDOM.findDOMNode(this.refs.express))
-      .show();
-  }
-
   render() {
     return (
       <ContentContainer
         heading={i18n.courseBlocksCsfExpressHeading()}
         description={i18n.courseBlocksCsfExpressDescription()}
       >
-        <div className="row">
-          <ProtectedStatefulDiv ref="pre_express" />
-          <ProtectedStatefulDiv ref="express" />
-        </div>
+        <CourseBlocks tiles={['#pre_express', '#express']} />
         <AcceleratedAndUnplugged />
       </ContentContainer>
     );
@@ -38,27 +26,6 @@ class ExpressCourses extends Component {
 }
 
 class CoursesAToF extends Component {
-  componentDidMount() {
-    $('#coursea')
-      .appendTo(ReactDOM.findDOMNode(this.refs.coursea))
-      .show();
-    $('#courseb')
-      .appendTo(ReactDOM.findDOMNode(this.refs.courseb))
-      .show();
-    $('#coursec')
-      .appendTo(ReactDOM.findDOMNode(this.refs.coursec))
-      .show();
-    $('#coursed')
-      .appendTo(ReactDOM.findDOMNode(this.refs.coursed))
-      .show();
-    $('#coursee')
-      .appendTo(ReactDOM.findDOMNode(this.refs.coursee))
-      .show();
-    $('#coursef')
-      .appendTo(ReactDOM.findDOMNode(this.refs.coursef))
-      .show();
-  }
-
   render() {
     return (
       <div>
@@ -66,22 +33,16 @@ class CoursesAToF extends Component {
           heading={i18n.courseBlocksCsfYoungHeading()}
           description={i18n.courseBlocksCsfYoungDescription()}
         >
-          <div className="row">
-            <ProtectedStatefulDiv ref="coursea" />
-            <ProtectedStatefulDiv ref="courseb" />
-          </div>
+          <CourseBlocks tiles={['#coursea', '#courseb']} />
         </ContentContainer>
 
         <ContentContainer
           heading={i18n.courseBlocksCsfOlderHeading()}
           description={i18n.courseBlocksCsfOlderDescription()}
         >
-          <div className="row">
-            <ProtectedStatefulDiv ref="coursec" />
-            <ProtectedStatefulDiv ref="coursed" />
-            <ProtectedStatefulDiv ref="coursee" />
-            <ProtectedStatefulDiv ref="coursef" />
-          </div>
+          <CourseBlocks
+            tiles={['#coursec', '#coursed', '#coursee', '#coursef']}
+          />
         </ContentContainer>
       </div>
     );
@@ -113,21 +74,6 @@ const LegacyCSFNotification = () => (
 );
 
 class Courses1To4 extends Component {
-  componentDidMount() {
-    $('#course1')
-      .appendTo(ReactDOM.findDOMNode(this.refs.course1))
-      .show();
-    $('#course2')
-      .appendTo(ReactDOM.findDOMNode(this.refs.course2))
-      .show();
-    $('#course3')
-      .appendTo(ReactDOM.findDOMNode(this.refs.course3))
-      .show();
-    $('#course4')
-      .appendTo(ReactDOM.findDOMNode(this.refs.course4))
-      .show();
-  }
-
   render() {
     return (
       <ContentContainer
@@ -136,12 +82,9 @@ class Courses1To4 extends Component {
         link={'/home/#recent-courses'}
         linkText={i18n.viewMyRecentCourses()}
       >
-        <div className="row">
-          <ProtectedStatefulDiv ref="course1" />
-          <ProtectedStatefulDiv ref="course2" />
-          <ProtectedStatefulDiv ref="course3" />
-          <ProtectedStatefulDiv ref="course4" />
-        </div>
+        <CourseBlocks
+          tiles={['#course1', '#course2', '#course3', '#course4']}
+        />
       </ContentContainer>
     );
   }


### PR DESCRIPTION
Primarily to fix a sizing issue for international strings:

Before | After
--- | ---
![image](https://user-images.githubusercontent.com/244100/80647438-52735500-8a23-11ea-88b3-f818d5f2e394.png) | ![image](https://user-images.githubusercontent.com/244100/80647463-5c955380-8a23-11ea-9912-a8c8a1cd3796.png)

But also just generally to DRY out the code a bit.

Do note, however, that there are some minor styling differences between the `row` and the `tutorial-row` classes; most notably, the new components no longer have a hover effect. I think this is still worth doing in that it moves more parts of the page to use the newest version of the component, but we should also do some work to make sure that newer version has all the functionality we want.

## Testing story

No new tests added

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
