### PR TITLE
Fixed flaky test that relied on sessionStorage

### DIFF
--- a/apps/test/unit/templates/AgeDialogTest.js
+++ b/apps/test/unit/templates/AgeDialogTest.js
@@ -1,4 +1,4 @@
-import {assert} from '../../util/reconfiguredChai';
+import {assert} from 'chai';
 import React from 'react';
 import {UnconnectedAgeDialog as AgeDialog} from '@cdo/apps/templates/AgeDialog';
 import {shallow} from 'enzyme';
@@ -28,7 +28,8 @@ describe('AgeDialog', () => {
   });
 
   it('renders null if dialog was seen before', () => {
-    let getItem = sinon.stub(window.sessionStorage, 'getItem').returns('true');
+    let getItem = sinon.stub(window.sessionStorage, 'getItem');
+    getItem.withArgs('ad_anon_over13').returns('true');
     const wrapper = shallow(<AgeDialog {...defaultProps} />);
     assert.equal(wrapper.children().length, 0);
     getItem.restore();

--- a/apps/test/unit/templates/AgeDialogTest.js
+++ b/apps/test/unit/templates/AgeDialogTest.js
@@ -1,7 +1,9 @@
-import {assert} from '../../util/deprecatedChai';
+import {assert} from '../../util/reconfiguredChai';
 import React from 'react';
 import {UnconnectedAgeDialog as AgeDialog} from '@cdo/apps/templates/AgeDialog';
 import {shallow} from 'enzyme';
+import sinon from 'sinon';
+import {replaceOnWindow, restoreOnWindow} from '../../util/testUtils';
 
 describe('AgeDialog', () => {
   const defaultProps = {
@@ -9,7 +11,16 @@ describe('AgeDialog', () => {
     turnOffFilter: () => {}
   };
 
-  afterEach(() => sessionStorage.clear());
+  before(() => {
+    replaceOnWindow('sessionStorage', {
+      getItem: () => {},
+      setItem: () => {}
+    });
+  });
+
+  after(() => {
+    restoreOnWindow('sessionStorage');
+  });
 
   it('renders null if signed in', () => {
     const wrapper = shallow(<AgeDialog {...defaultProps} signedIn={true} />);
@@ -17,9 +28,10 @@ describe('AgeDialog', () => {
   });
 
   it('renders null if seen before', () => {
-    sessionStorage.setItem('ad_anon_over13', true);
+    let getItem = sinon.stub(window.sessionStorage, 'getItem').returns('true');
     const wrapper = shallow(<AgeDialog {...defaultProps} />);
     assert.equal(wrapper.children().length, 0);
+    getItem.restore();
   });
 
   it('renders a dialog otherwise', () => {

--- a/apps/test/unit/templates/AgeDialogTest.js
+++ b/apps/test/unit/templates/AgeDialogTest.js
@@ -22,19 +22,19 @@ describe('AgeDialog', () => {
     restoreOnWindow('sessionStorage');
   });
 
-  it('renders null if signed in', () => {
+  it('renders null if user is signed in', () => {
     const wrapper = shallow(<AgeDialog {...defaultProps} signedIn={true} />);
     assert.equal(wrapper.children().length, 0);
   });
 
-  it('renders null if seen before', () => {
+  it('renders null if dialog was seen before', () => {
     let getItem = sinon.stub(window.sessionStorage, 'getItem').returns('true');
     const wrapper = shallow(<AgeDialog {...defaultProps} />);
     assert.equal(wrapper.children().length, 0);
     getItem.restore();
   });
 
-  it('renders a dialog otherwise', () => {
+  it('renders a dialog if neither signed in nor seen before', () => {
     const wrapper = shallow(<AgeDialog {...defaultProps} />);
     assert.equal(wrapper.name(), 'BaseDialog');
   });

--- a/apps/test/unit/templates/SignInOrAgeDialogTest.js
+++ b/apps/test/unit/templates/SignInOrAgeDialogTest.js
@@ -1,4 +1,4 @@
-import {assert} from '../../util/reconfiguredChai';
+import {assert} from 'chai';
 import React from 'react';
 import {UnconnectedSignInOrAgeDialog as SignInOrAgeDialog} from '@cdo/apps/templates/SignInOrAgeDialog';
 import {shallow} from 'enzyme';
@@ -44,7 +44,8 @@ describe('SignInOrAgeDialog', () => {
   });
 
   it('renders null if seen before', () => {
-    let getItem = sinon.stub(window.sessionStorage, 'getItem').returns('true');
+    let getItem = sinon.stub(window.sessionStorage, 'getItem');
+    getItem.withArgs('anon_over13').returns('true');
     const wrapper = shallow(<SignInOrAgeDialog {...defaultProps} />);
     assert.equal(wrapper.children().length, 0);
     getItem.restore();

--- a/apps/test/unit/templates/SignInOrAgeDialogTest.js
+++ b/apps/test/unit/templates/SignInOrAgeDialogTest.js
@@ -107,7 +107,8 @@ describe('SignInOrAgeDialog', () => {
         .find('Button')
         .at(1)
         .simulate('click');
-      assert.equal(setItemSpy.callCount, 1);
+      assert(setItemSpy.calledOnce);
+      assert(setItemSpy.calledWith('anon_over13', true));
       assert(utils.reload.called);
       assert(
         cookies.remove.calledWith(environmentSpecificCookieName('storage_id'), {


### PR DESCRIPTION
Previously, both AgeDialogTest and SignInOrAgeDialogTest were using the window's sessionStorage object to test the functionality of components. This caused problems when the two tests were run in parallel. Here instead, we mock sessionStorage. (See linked slack conversation for more context)

Note, tests are in progress here: https://drone.cdn-code.org/code-dot-org/code-dot-org/12767

<!--
  Other aspects to consider. uncomment and add detail for any that seem necessary:
-->

<!-- ### Background -->
<!-- ### Privacy -->
<!-- ### Security -->
<!-- ### Caching -->
<!-- ### Deployment strategy -->
<!-- ### Future work -->

## Links

<!--
  Any relevant links to external resources; ie, specification documents, jira
  items, related PRs, honeybadger errors, etc
-->

- [slack discussion](https://codedotorg.slack.com/archives/C0T0PNR0D/p1588095579053900)

## Testing story

<!--
  Does your change include appropriate tests?

  If so, please describe how the tests included in this PR are sufficient

  If not, please explain why this change does not need to be tested.
-->

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
