### PR TITLE
Make "New Section" dialog more responsive to a variety of content lengths

### DIFF
--- a/apps/src/templates/teacherDashboard/LoginTypeCard.jsx
+++ b/apps/src/templates/teacherDashboard/LoginTypeCard.jsx
@@ -12,7 +12,8 @@ const styles = {
     // Set width to form a three-column layout on 970px teacher dashboard.
     width: 312,
     // Uniform height, even in different rows
-    height: 150,
+    flex: '0 0 auto',
+    minHeight: 150,
     padding: 16,
     marginBottom: 5,
     borderStyle: 'solid',

--- a/apps/src/templates/teacherDashboard/LoginTypePicker.jsx
+++ b/apps/src/templates/teacherDashboard/LoginTypePicker.jsx
@@ -15,6 +15,7 @@ import DialogFooter from './DialogFooter';
 import LoginTypeCard from './LoginTypeCard';
 import Button from '../Button';
 import {OAuthSectionTypes} from './shapes';
+import styleConstants from '../../styleConstants';
 
 /**
  * UI for selecting the login type of a class section:
@@ -57,8 +58,14 @@ class LoginTypePicker extends Component {
       (withGoogle || withMicrosoft || withClever) &&
       typeof handleImportOpen === 'function';
 
+    // explicitly constrain the container as a whole to the width of the
+    // content. We expect that differing length of translations versus english
+    // source text can cause unexpected layout changes, and this constraint
+    // should help mitigate some of them.
+    const containerStyle = {maxWidth: styleConstants['content-width']};
+
     return (
-      <div>
+      <div style={containerStyle}>
         <Heading1>{title}</Heading1>
         <Heading2>{i18n.addStudentsToSectionInstructions()}</Heading2>
         {anyImportOptions && (


### PR DESCRIPTION
Before | After
--- | ---
![image](https://user-images.githubusercontent.com/244100/80647083-bb0e0200-8a22-11ea-9ac5-c861babb0910.png) | ![image](https://user-images.githubusercontent.com/244100/80647063-b5182100-8a22-11ea-9230-47af12f87470.png)

## Testing story

no tests added

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
