### PR TITLE
Update parent email section copy

### DIFF
--- a/dashboard/app/views/devise/registrations/edit.html.haml
+++ b/dashboard/app/views/devise/registrations/edit.html.haml
@@ -103,7 +103,7 @@
   %div#add-parent-email
     %hr
     %h2= t('user.for_parents_and_guardians')
-    %p= "#{t('user.link_a_parent_email')}:"
+    %p= "#{t('user.link_a_parent_email')}"
     %p
       %b= "#{t('user.parent_guardian_email_label')}:"
       %span#displayed-parent-email= (current_user.parent_email == nil || current_user.parent_email.empty?) ? t('user.none') : current_user.parent_email

--- a/dashboard/app/views/devise/registrations/edit.html.haml
+++ b/dashboard/app/views/devise/registrations/edit.html.haml
@@ -103,7 +103,7 @@
   %div#add-parent-email
     %hr
     %h2= t('user.for_parents_and_guardians')
-    %p= "#{t('user.link_a_parent_email')}"
+    %p= t('user.link_a_parent_email')
     %p
       %b= "#{t('user.parent_guardian_email_label')}:"
       %span#displayed-parent-email= (current_user.parent_email == nil || current_user.parent_email.empty?) ? t('user.none') : current_user.parent_email

--- a/dashboard/config/locales/en.yml
+++ b/dashboard/config/locales/en.yml
@@ -481,7 +481,7 @@ en:
     auth_option_saved_no_email: "You have successfully linked your %{provider} account."
     update_email: "Update"
     for_parents_and_guardians: "For Parents and Guardians"
-    link_a_parent_email: "Link a parent/guardian email address to this account to stay updated on your child’s progress and projects"
+    link_a_parent_email: "Link a parent/guardian email address to this account to stay updated on your child’s progress and projects. You will also be able to use this email address for password recovery."
     parent_guardian_email_label: "Parent/guardian email"
     none: "None"
     only_one_parent_email_supported_warning: "Note: we are only able to support one parent/guardian email address per student account at this time."


### PR DESCRIPTION
Updated the description text on the account settings page to include a detail on how the parent email address can be used for password recovery, and removed the colon at the end of the line.

- [jira](https://codedotorg.atlassian.net/browse/FND-1149)

**Before**:
![image](https://user-images.githubusercontent.com/2933346/80548443-ce13ca00-896f-11ea-8fa7-c446fa476442.png)

**After**:
![image](https://user-images.githubusercontent.com/2933346/80548418-bd635400-896f-11ea-9199-dea917933de8.png)
