### PR TITLE
Reorganize the login page to make the flow better

### DIFF
--- a/dashboard/app/views/sections/show.html.haml
+++ b/dashboard/app/views/sections/show.html.haml
@@ -24,20 +24,9 @@
           = student.name
     .clear
 
-    %br/
-    %div.span{ :style => "margin-left: auto"}
-      != "*&nbsp;"
-    %span
-      != t('signinsection.student_privacy_markdown', student_privacy_blog: 'http://teacherblog.code.org/post/156768797364/privacy-concern-with-using-student-full-names', markdown: true)
-
   = form_tag(log_in_section_path(id: @section.code), class: 'section-user-sign-in') do
     = hidden_field_tag :secret_picture_id
     = hidden_field_tag :user_id
-
-    #pairing_checkbox{style: 'display: none'}
-      = check_box_tag :show_pairing_dialog
-      = label_tag :show_pairing_dialog, t('signinsection.pair_programming')
-    = button_tag t('signinsection.login'), id: 'login_button', style: 'display:none', class: 'btn btn-primary'
 
     - if @section.login_type == Section::LOGIN_TYPE_PICTURE
       #secret{style: 'display: none;'}
@@ -45,7 +34,7 @@
         %ul.pictures
           - @secret_pictures.each do |secret_picture|
             %li{id: secret_picture.id}
-              = image_tag secret_picture.path, width: 90, alt: secret_picture.name
+              = image_tag secret_picture.path, width: 60, alt: secret_picture.name
         .clear
 
     - if @section.login_type == Section::LOGIN_TYPE_WORD
@@ -53,6 +42,18 @@
         %h4.instructions= t('signinsection.words')
         = text_field_tag :secret_words, nil, autocomplete: 'off'
         .clear
+
+    #pairing_checkbox{style: 'display: none'}
+      = check_box_tag :show_pairing_dialog
+      = label_tag :show_pairing_dialog, t('signinsection.pair_programming')
+    = button_tag t('signinsection.login'), id: 'login_button', style: 'display:none', class: 'btn btn-primary'
+
+    %br/
+    %br/
+    %div.span{ :style => "margin-left: auto"}
+      != "*&nbsp;"
+    %span
+      != t('signinsection.student_privacy_markdown', student_privacy_blog: 'http://teacherblog.code.org/post/156768797364/privacy-concern-with-using-student-full-names', markdown: true)
 
 %br/
 %br/

--- a/dashboard/app/views/sections/show.html.haml
+++ b/dashboard/app/views/sections/show.html.haml
@@ -34,7 +34,7 @@
         %ul.pictures
           - @secret_pictures.each do |secret_picture|
             %li{id: secret_picture.id}
-              = image_tag secret_picture.path, width: 60, alt: secret_picture.name
+              = image_tag secret_picture.path, width: 66, alt: secret_picture.name
         .clear
 
     - if @section.login_type == Section::LOGIN_TYPE_WORD


### PR DESCRIPTION
Hack Day Project: Improve Login Page UI

Improves the login page UI for secret word and picture logins.
- Partner check box shows up below pictures or secret word entry point
- Makes pictures show up on two lines by making the images smaller
- Move the why is my whole name on here text to the very bottom.
- Sign in button is below everything except the help text

## Picture

| Before | After |
| -- | -- |
| <img width="1176" alt="Screen Shot 2020-04-28 at 9 20 48 PM" src="https://user-images.githubusercontent.com/208083/80552998-4beacc00-8996-11ea-91de-9fa4f7a5fd45.png"> |  <img width="1164" alt="Screen Shot 2020-04-28 at 9 15 00 PM" src="https://user-images.githubusercontent.com/208083/80552829-ded73680-8995-11ea-92ba-249f3b8f8db7.png"> |

## Secret Word

| Before | After |
| -- | -- |
| <img width="1178" alt="Screen Shot 2020-04-28 at 9 22 52 PM" src="https://user-images.githubusercontent.com/208083/80553032-72a90280-8996-11ea-8d94-c949d673fbca.png"> | <img width="1175" alt="Screen Shot 2020-04-28 at 9 16 41 PM" src="https://user-images.githubusercontent.com/208083/80552837-e4348100-8995-11ea-9c06-9572bea1544d.png"> |
