### PR TITLE
Shrink secret pictures and reposition sign-in button

### DIFF
--- a/dashboard/app/views/sections/show.html.haml
+++ b/dashboard/app/views/sections/show.html.haml
@@ -40,7 +40,7 @@
         %ul.pictures
           - @secret_pictures.each do |secret_picture|
             %li{id: secret_picture.id}
-              = image_tag secret_picture.path, width: 90, alt: secret_picture.name
+              = image_tag secret_picture.path, width: 66, alt: secret_picture.name
         .clear
 
     - if @section.login_type == Section::LOGIN_TYPE_WORD

--- a/dashboard/app/views/sections/show.html.haml
+++ b/dashboard/app/views/sections/show.html.haml
@@ -34,11 +34,6 @@
     = hidden_field_tag :secret_picture_id
     = hidden_field_tag :user_id
 
-    #pairing_checkbox{style: 'display: none'}
-      = check_box_tag :show_pairing_dialog
-      = label_tag :show_pairing_dialog, t('signinsection.pair_programming')
-    = button_tag t('signinsection.login'), id: 'login_button', style: 'display:none', class: 'btn btn-primary'
-
     - if @section.login_type == Section::LOGIN_TYPE_PICTURE
       #secret{style: 'display: none;'}
         %h4.instructions= t('signinsection.picture')
@@ -53,6 +48,11 @@
         %h4.instructions= t('signinsection.words')
         = text_field_tag :secret_words, nil, autocomplete: 'off'
         .clear
+        
+    #pairing_checkbox{style: 'display: none'}
+      = check_box_tag :show_pairing_dialog
+      = label_tag :show_pairing_dialog, t('signinsection.pair_programming')
+    = button_tag t('signinsection.login'), id: 'login_button', style: 'display:none', class: 'btn btn-primary'
 
 %br/
 %br/


### PR DESCRIPTION
<!--
  Your description goes here: A summary of the change, including any relevant motivation and context.

  If relevant, include a description both of the existing behavior and of the new behavior.
-->
Change the width of images on the sign-in page for secret picture-based sections so that they appear on two rows instead of three, thus allowing the "Sign in" button to appear above the fold even when repositioned below the rows of images, as it should be to follow the natural top-to-bottom flow of execution.
<!--
  Other aspects to consider. uncomment and add detail for any that seem necessary:
-->

### Background
As a student with a picture login, I log in to my account through the section login page. Currently, the "Sign in" button is positioned between my name and the picture options. This means I have to select my name, skip past the "sign in" button to select a picture, go back up to check the box if I have a partner at my computer, then hit "Sign in".

The natural flow of execution on this page is from top-to-bottom. However, merely repositioning the "Sign in" button (and partner checkbox) below the pictures would put it below the fold on smaller screens, which may prevent some younger students from achieving the success state because they don't realize they have to scroll or don't know how to scroll on a website. 

Design's suggestion was to shrink the secret pictures so that they would fit on two rows, thus allowing the repositioning of the "Sign in" button below the images but still above the fold on smaller screens.

#### Before
![image](https://user-images.githubusercontent.com/2933346/80564423-9ffbad80-89a2-11ea-9500-297ae329e152.png)

#### After
![image](https://user-images.githubusercontent.com/2933346/80564631-2ca66b80-89a3-11ea-898b-59371c54fd02.png)

## Links

<!--
  Any relevant links to external resources; ie, specification documents, jira
  items, related PRs, honeybadger errors, etc
-->

- [hack day spec](https://docs.google.com/document/d/1W-5Uh94GZZDOgtuud4FvAkBztLh-_yyQxXh0TKf228w/edit#bookmark=id.fr31d8of7uqr)