### PR TITLE
Only ever load blockly explicitly via separate entry point

### DIFF
--- a/apps/Gruntfile.js
+++ b/apps/Gruntfile.js
@@ -514,7 +514,6 @@ describe('entry tests', () => {
   );
 
   var codeStudioEntries = {
-    blockly: './src/sites/studio/pages/blockly.js',
     'code-studio': './src/sites/studio/pages/code-studio.js',
     'congrats/index': './src/sites/studio/pages/congrats/index.js',
     'courses/index': './src/sites/studio/pages/courses/index.js',
@@ -716,6 +715,10 @@ describe('entry tests', () => {
   };
 
   var otherEntries = {
+    // The blockly dependency is huge, so we currently control when it is
+    // loaded explicitly via script tags rather than via normal imports.
+    blockly: './src/sites/studio/pages/blockly.js',
+
     // Build embedVideo.js in its own step (skipping factor-bundle) so that
     // we don't have to include the large code-studio-common file in the
     // embedded video page, keeping it fairly lightweight.

--- a/apps/src/templates/instructions/utils.js
+++ b/apps/src/templates/instructions/utils.js
@@ -1,5 +1,4 @@
 import ReactDOM from 'react-dom';
-import Blockly from '@code-dot-org/blockly';
 import $ from 'jquery';
 
 /**


### PR DESCRIPTION
historically, we've include blockly as a separate entry point whenever we need it in our app. This gives us precise control over which pages need to have access to this very large (> 1MB) library.

https://github.com/code-dot-org/code-dot-org/pull/32484 deviated from this by introducing an instance where we also include it using normal import statements, which lead to this very large library being included too many times -- once on every code studio page, and an additional time on every page that actually uses Blockly for anything. This PR eliminates that dependency, going back to only ever loading blockly explicitly via script tag, so that we can load it the minimum number of times.

this PR also moves the blockly.js entry point out of codeStudioEntries, to keep us farther away from the Blockly dependency getting extracted into the code-studio-common chunk, which is included on every dashboard page.

### before
![Screen Shot 2020-04-29 at 9 34 26 AM](https://user-images.githubusercontent.com/8001765/80622342-80de3980-89fd-11ea-89e4-0e6d07d83c90.png)

### after
![Screen Shot 2020-04-29 at 9 37 16 AM](https://user-images.githubusercontent.com/8001765/80622350-8471c080-89fd-11ea-862e-e0d2d498dcf9.png)

## Testing 

* verified that external levels with blockly xml content still render properly (because levels/_content was already including blockly as an entry point)
* existing markdown_rendering.feature UI test will be run during the DTT
* further reasoning that because things were working fine before https://github.com/code-dot-org/code-dot-org/pull/32484 went in, that going back to how things were before that PR has a low chance of breaking anything outside of the scope of that PR

## Future work

### use normal imports

Why, one might ask, do we include this one library in a special way? I can't say for sure, but one complication is that we don't always know whether blockly will be needed for a given level type, because some level types (e.g. starwars HOC) can be run either with blockly or with droplet, and the current implementation allows us to only send blockly down when it is needed. Possible strategies to start using the normal import pattern include:
1. just do it, and pay the price of loading both droplet and blockly on pages like starwars (or write custom logic to provide blockly in a special way only for those specific level types). some refactoring of _apps_dependencies.html.haml would be needed to accomplish this
2. make a drastic shift to lazy-loading the level page for all of the [apps entry points](https://github.com/code-dot-org/code-dot-org/blob/eca01e2ab72a2aa0692de53a9343295f5f6c503b/apps/Gruntfile.js#L510-L514), which has the important side benefit of allowing webpack to decide how to chunk all its js, and when to send each chunk down to the client.
