### PR TITLE
Avoid using sessionStorage without replacing window.sessionStorage

### DIFF
--- a/apps/src/templates/AgeDialog.jsx
+++ b/apps/src/templates/AgeDialog.jsx
@@ -65,7 +65,12 @@ class AgeDialog extends Component {
 
   static propTypes = {
     signedIn: PropTypes.bool.isRequired,
-    turnOffFilter: PropTypes.func.isRequired
+    turnOffFilter: PropTypes.func.isRequired,
+    sessionStorage: PropTypes.object.isRequired
+  };
+
+  static defaultProps = {
+    sessionStorage: window.sessionStorage
   };
 
   setManualFilter = () => {
@@ -73,7 +78,7 @@ class AgeDialog extends Component {
   };
 
   setSessionStorage = over13 => {
-    sessionStorage.setItem(AGE_DIALOG_SESSION_KEY, over13);
+    this.props.sessionStorage.setItem(AGE_DIALOG_SESSION_KEY, over13);
     this.setState({open: false});
   };
 
@@ -106,7 +111,7 @@ class AgeDialog extends Component {
 
     // Don't show dialog unless script requires 13+, we're not signed in, and
     // we haven't already given this dialog our age or we do not require sign-in
-    if (signedIn || sessionStorage.getItem(AGE_DIALOG_SESSION_KEY)) {
+    if (signedIn || this.props.sessionStorage.getItem(AGE_DIALOG_SESSION_KEY)) {
       return null;
     }
 

--- a/apps/src/templates/AgeDialog.jsx
+++ b/apps/src/templates/AgeDialog.jsx
@@ -66,11 +66,11 @@ class AgeDialog extends Component {
   static propTypes = {
     signedIn: PropTypes.bool.isRequired,
     turnOffFilter: PropTypes.func.isRequired,
-    sessionStorage: PropTypes.object.isRequired
+    storage: PropTypes.object.isRequired
   };
 
   static defaultProps = {
-    sessionStorage: window.sessionStorage
+    storage: window.sessionStorage
   };
 
   setManualFilter = () => {
@@ -78,7 +78,7 @@ class AgeDialog extends Component {
   };
 
   setSessionStorage = over13 => {
-    this.props.sessionStorage.setItem(AGE_DIALOG_SESSION_KEY, over13);
+    this.props.storage.setItem(AGE_DIALOG_SESSION_KEY, over13);
     this.setState({open: false});
   };
 
@@ -107,11 +107,11 @@ class AgeDialog extends Component {
   };
 
   render() {
-    const {signedIn} = this.props;
+    const {signedIn, storage} = this.props;
 
     // Don't show dialog unless script requires 13+, we're not signed in, and
     // we haven't already given this dialog our age or we do not require sign-in
-    if (signedIn || this.props.sessionStorage.getItem(AGE_DIALOG_SESSION_KEY)) {
+    if (signedIn || storage.getItem(AGE_DIALOG_SESSION_KEY)) {
       return null;
     }
 

--- a/apps/src/templates/SignInOrAgeDialog.js
+++ b/apps/src/templates/SignInOrAgeDialog.js
@@ -80,7 +80,12 @@ class SignInOrAgeDialog extends Component {
 
   static propTypes = {
     signedIn: PropTypes.bool.isRequired,
-    age13Required: PropTypes.bool.isRequired
+    age13Required: PropTypes.bool.isRequired,
+    sessionStorage: PropTypes.object.isRequired
+  };
+
+  static defaultProps = {
+    sessionStorage: window.sessionStorage
   };
 
   onClickAgeOk = () => {
@@ -96,7 +101,10 @@ class SignInOrAgeDialog extends Component {
     }
 
     // Sets cookie to true when anon user is 13+. False otherwise.
-    sessionStorage.setItem(sessionStorageKey, parseInt(value, 10) >= 13);
+    this.props.sessionStorage.setItem(
+      sessionStorageKey,
+      parseInt(value, 10) >= 13
+    );
 
     // When opening a new tab, we'll have a new session (and thus show this dialog),
     // but may still be using a storage_id for a previous user. Clear that cookie
@@ -117,7 +125,7 @@ class SignInOrAgeDialog extends Component {
     if (
       !age13Required ||
       signedIn ||
-      sessionStorage.getItem(sessionStorageKey)
+      this.props.sessionStorage.getItem(sessionStorageKey)
     ) {
       return null;
     }

--- a/apps/src/templates/SignInOrAgeDialog.js
+++ b/apps/src/templates/SignInOrAgeDialog.js
@@ -81,11 +81,11 @@ class SignInOrAgeDialog extends Component {
   static propTypes = {
     signedIn: PropTypes.bool.isRequired,
     age13Required: PropTypes.bool.isRequired,
-    sessionStorage: PropTypes.object.isRequired
+    storage: PropTypes.object.isRequired
   };
 
   static defaultProps = {
-    sessionStorage: window.sessionStorage
+    storage: window.sessionStorage
   };
 
   onClickAgeOk = () => {
@@ -101,10 +101,7 @@ class SignInOrAgeDialog extends Component {
     }
 
     // Sets cookie to true when anon user is 13+. False otherwise.
-    this.props.sessionStorage.setItem(
-      sessionStorageKey,
-      parseInt(value, 10) >= 13
-    );
+    this.props.storage.setItem(sessionStorageKey, parseInt(value, 10) >= 13);
 
     // When opening a new tab, we'll have a new session (and thus show this dialog),
     // but may still be using a storage_id for a previous user. Clear that cookie
@@ -119,14 +116,10 @@ class SignInOrAgeDialog extends Component {
   };
 
   render() {
-    const {signedIn, age13Required} = this.props;
+    const {signedIn, age13Required, storage} = this.props;
     // Don't show dialog unless script requires 13+, we're not signed in, and
     // we haven't already given this dialog our age or we do not require sign-in
-    if (
-      !age13Required ||
-      signedIn ||
-      this.props.sessionStorage.getItem(sessionStorageKey)
-    ) {
+    if (!age13Required || signedIn || storage.getItem(sessionStorageKey)) {
       return null;
     }
 

--- a/apps/test/unit/templates/AgeDialogTest.js
+++ b/apps/test/unit/templates/AgeDialogTest.js
@@ -3,24 +3,18 @@ import React from 'react';
 import {UnconnectedAgeDialog as AgeDialog} from '@cdo/apps/templates/AgeDialog';
 import {shallow} from 'enzyme';
 import sinon from 'sinon';
-import {replaceOnWindow, restoreOnWindow} from '../../util/testUtils';
+
+class FakeSessionStorage {
+  getItem() {}
+  setItem() {}
+}
 
 describe('AgeDialog', () => {
   const defaultProps = {
     signedIn: false,
-    turnOffFilter: () => {}
+    turnOffFilter: () => {},
+    sessionStorage: new FakeSessionStorage()
   };
-
-  before(() => {
-    replaceOnWindow('sessionStorage', {
-      getItem: () => {},
-      setItem: () => {}
-    });
-  });
-
-  after(() => {
-    restoreOnWindow('sessionStorage');
-  });
 
   it('renders null if user is signed in', () => {
     const wrapper = shallow(<AgeDialog {...defaultProps} signedIn={true} />);
@@ -28,7 +22,7 @@ describe('AgeDialog', () => {
   });
 
   it('renders null if dialog was seen before', () => {
-    let getItem = sinon.stub(window.sessionStorage, 'getItem');
+    let getItem = sinon.stub(defaultProps.sessionStorage, 'getItem');
     getItem.withArgs('ad_anon_over13').returns('true');
     const wrapper = shallow(<AgeDialog {...defaultProps} />);
     assert.equal(wrapper.children().length, 0);

--- a/apps/test/unit/templates/AgeDialogTest.js
+++ b/apps/test/unit/templates/AgeDialogTest.js
@@ -3,17 +3,13 @@ import React from 'react';
 import {UnconnectedAgeDialog as AgeDialog} from '@cdo/apps/templates/AgeDialog';
 import {shallow} from 'enzyme';
 import sinon from 'sinon';
-
-class FakeSessionStorage {
-  getItem() {}
-  setItem() {}
-}
+import FakeStorage from '../../util/FakeStorage';
 
 describe('AgeDialog', () => {
   const defaultProps = {
     signedIn: false,
     turnOffFilter: () => {},
-    sessionStorage: new FakeSessionStorage()
+    sessionStorage: new FakeStorage()
   };
 
   it('renders null if user is signed in', () => {

--- a/apps/test/unit/templates/AgeDialogTest.js
+++ b/apps/test/unit/templates/AgeDialogTest.js
@@ -9,7 +9,7 @@ describe('AgeDialog', () => {
   const defaultProps = {
     signedIn: false,
     turnOffFilter: () => {},
-    sessionStorage: new FakeStorage()
+    storage: new FakeStorage()
   };
 
   it('renders null if user is signed in', () => {
@@ -18,7 +18,7 @@ describe('AgeDialog', () => {
   });
 
   it('renders null if dialog was seen before', () => {
-    let getItem = sinon.stub(defaultProps.sessionStorage, 'getItem');
+    let getItem = sinon.stub(defaultProps.storage, 'getItem');
     getItem.withArgs('ad_anon_over13').returns('true');
     const wrapper = shallow(<AgeDialog {...defaultProps} />);
     assert.equal(wrapper.children().length, 0);

--- a/apps/test/unit/templates/SignInOrAgeDialogTest.js
+++ b/apps/test/unit/templates/SignInOrAgeDialogTest.js
@@ -13,7 +13,7 @@ describe('SignInOrAgeDialog', () => {
   const defaultProps = {
     age13Required: true,
     signedIn: false,
-    sessionStorage: new FakeStorage()
+    storage: new FakeStorage()
   };
 
   before(() => {
@@ -41,7 +41,7 @@ describe('SignInOrAgeDialog', () => {
   });
 
   it('renders null if seen before', () => {
-    let getItem = sinon.stub(defaultProps.sessionStorage, 'getItem');
+    let getItem = sinon.stub(defaultProps.storage, 'getItem');
     getItem.withArgs('anon_over13').returns('true');
     const wrapper = shallow(<SignInOrAgeDialog {...defaultProps} />);
     assert.equal(wrapper.children().length, 0);
@@ -91,7 +91,7 @@ describe('SignInOrAgeDialog', () => {
     });
 
     it('sets sessionStorage, clears cookie, and reloads if you provide an age >= 13', () => {
-      const setItemSpy = sinon.spy(defaultProps.sessionStorage, 'setItem');
+      const setItemSpy = sinon.spy(defaultProps.storage, 'setItem');
       // We stub cookies, as the domain portion of our cookies.remove in SignInOrAgeDialog
       // does not work in unit tests
       sinon.stub(cookies, 'get').returns('something');

--- a/apps/test/unit/templates/SignInOrAgeDialogTest.js
+++ b/apps/test/unit/templates/SignInOrAgeDialogTest.js
@@ -8,24 +8,25 @@ import cookies from 'js-cookie';
 import {environmentSpecificCookieName} from '@cdo/apps/code-studio/utils';
 import {replaceOnWindow, restoreOnWindow} from '../../util/testUtils';
 
+class FakeSessionStorage {
+  getItem() {}
+  setItem() {}
+}
+
 describe('SignInOrAgeDialog', () => {
   const defaultProps = {
     age13Required: true,
-    signedIn: false
+    signedIn: false,
+    sessionStorage: new FakeSessionStorage()
   };
 
   before(() => {
-    replaceOnWindow('sessionStorage', {
-      getItem: () => {},
-      setItem: () => {}
-    });
     replaceOnWindow('dashboard', {
       rack_env: 'unit_test'
     });
   });
 
   after(() => {
-    restoreOnWindow('sessionStorage');
     restoreOnWindow('dashboard');
   });
 
@@ -44,7 +45,7 @@ describe('SignInOrAgeDialog', () => {
   });
 
   it('renders null if seen before', () => {
-    let getItem = sinon.stub(window.sessionStorage, 'getItem');
+    let getItem = sinon.stub(defaultProps.sessionStorage, 'getItem');
     getItem.withArgs('anon_over13').returns('true');
     const wrapper = shallow(<SignInOrAgeDialog {...defaultProps} />);
     assert.equal(wrapper.children().length, 0);
@@ -94,7 +95,7 @@ describe('SignInOrAgeDialog', () => {
     });
 
     it('sets sessionStorage, clears cookie, and reloads if you provide an age >= 13', () => {
-      let setItemSpy = sinon.spy(window.sessionStorage, 'setItem');
+      const setItemSpy = sinon.spy(defaultProps.sessionStorage, 'setItem');
       // We stub cookies, as the domain portion of our cookies.remove in SignInOrAgeDialog
       // does not work in unit tests
       sinon.stub(cookies, 'get').returns('something');
@@ -117,7 +118,7 @@ describe('SignInOrAgeDialog', () => {
           domain: '.code.org'
         })
       );
-      window.sessionStorage.setItem.restore();
+      setItemSpy.restore();
     });
 
     it('does not reload when providing an age >= 13 if you did not have a cookie', () => {

--- a/apps/test/unit/templates/SignInOrAgeDialogTest.js
+++ b/apps/test/unit/templates/SignInOrAgeDialogTest.js
@@ -7,17 +7,13 @@ import * as utils from '@cdo/apps/utils';
 import cookies from 'js-cookie';
 import {environmentSpecificCookieName} from '@cdo/apps/code-studio/utils';
 import {replaceOnWindow, restoreOnWindow} from '../../util/testUtils';
-
-class FakeSessionStorage {
-  getItem() {}
-  setItem() {}
-}
+import FakeStorage from '../../util/FakeStorage';
 
 describe('SignInOrAgeDialog', () => {
   const defaultProps = {
     age13Required: true,
     signedIn: false,
-    sessionStorage: new FakeSessionStorage()
+    sessionStorage: new FakeStorage()
   };
 
   before(() => {

--- a/apps/test/util/FakeStorage.js
+++ b/apps/test/util/FakeStorage.js
@@ -1,0 +1,8 @@
+/**
+ * Fake implementation of the storage interface, usable in place
+ * of window.localStorage or window.sessionStorage during tests.
+ */
+export default class FakeStorage {
+  getItem() {}
+  setItem() {}
+}


### PR DESCRIPTION
Different version of the fix made in https://github.com/code-dot-org/code-dot-org/pull/34492 that is friendly to ChromeHeadless, where replacing window.sessionStorage is not allowed.
