### PR TITLE
Consolidated beforeEach and afterEach in ShowCodeToggleTest

### DIFF
--- a/apps/test/unit/templates/ShowCodeToggleTest.js
+++ b/apps/test/unit/templates/ShowCodeToggleTest.js
@@ -23,25 +23,10 @@ describe('The ShowCodeToggle component', () => {
     sinon.spy($, 'post');
     sinon.spy($, 'getJSON');
     sinon.stub(project, 'getCurrentId').returns('some-project-id');
-  });
-  afterEach(() => {
-    server.restore();
-    $.post.restore();
-    $.getJSON.restore();
-    project.getCurrentId.restore();
-  });
-
-  beforeEach(stubStudioApp);
-  afterEach(restoreStudioApp);
-  beforeEach(() => sinon.stub(LegacyDialog.prototype, 'show'));
-  afterEach(() => LegacyDialog.prototype.show.restore());
-  beforeEach(() => {
+    stubStudioApp();
+    sinon.stub(LegacyDialog.prototype, 'show');
     stubRedux();
     registerReducers(commonReducers);
-  });
-  afterEach(restoreRedux);
-
-  beforeEach(() => {
     editor = {
       session: {
         currentlyUsingBlocks: true
@@ -57,9 +42,6 @@ describe('The ShowCodeToggle component', () => {
     sinon.stub(studioApp(), 'handleEditCode_').callsFake(function() {
       this.editor = editor;
     });
-  });
-
-  beforeEach(() => {
     config = {
       enableShowCode: true,
       containerId: 'foo',
@@ -73,6 +55,18 @@ describe('The ShowCodeToggle component', () => {
       },
       skin: {}
     };
+
+    afterEach(() => {
+      server.restore();
+      $.post.restore();
+      $.getJSON.restore();
+      project.getCurrentId.restore();
+      restoreStudioApp();
+      LegacyDialog.prototype.show.restore();
+      restoreRedux();
+      document.body.removeChild(codeWorkspaceDiv);
+      document.body.removeChild(containerDiv);
+    });
 
     codeWorkspaceDiv = document.createElement('div');
     codeWorkspaceDiv.id = 'codeWorkspace';
@@ -90,16 +84,9 @@ describe('The ShowCodeToggle component', () => {
 
     studioApp().configure(config);
     studioApp().init(config);
+    sinon.stub(studioApp(), 'onDropletToggle');
+    sinon.stub(studioApp(), 'showGeneratedCode');
   });
-
-  afterEach(() => {
-    document.body.removeChild(codeWorkspaceDiv);
-    document.body.removeChild(containerDiv);
-  });
-
-  beforeEach(() => sinon.stub(studioApp(), 'onDropletToggle'));
-
-  beforeEach(() => sinon.stub(studioApp(), 'showGeneratedCode'));
 
   describe('when the studioApp editor has currentlyUsingBlocks=false', () => {
     beforeEach(() => {

--- a/apps/test/unit/templates/ShowCodeToggleTest.js
+++ b/apps/test/unit/templates/ShowCodeToggleTest.js
@@ -56,18 +56,6 @@ describe('The ShowCodeToggle component', () => {
       skin: {}
     };
 
-    afterEach(() => {
-      server.restore();
-      $.post.restore();
-      $.getJSON.restore();
-      project.getCurrentId.restore();
-      restoreStudioApp();
-      LegacyDialog.prototype.show.restore();
-      restoreRedux();
-      document.body.removeChild(codeWorkspaceDiv);
-      document.body.removeChild(containerDiv);
-    });
-
     codeWorkspaceDiv = document.createElement('div');
     codeWorkspaceDiv.id = 'codeWorkspace';
     document.body.appendChild(codeWorkspaceDiv);
@@ -86,6 +74,18 @@ describe('The ShowCodeToggle component', () => {
     studioApp().init(config);
     sinon.stub(studioApp(), 'onDropletToggle');
     sinon.stub(studioApp(), 'showGeneratedCode');
+  });
+
+  afterEach(() => {
+    server.restore();
+    $.post.restore();
+    $.getJSON.restore();
+    project.getCurrentId.restore();
+    restoreStudioApp();
+    LegacyDialog.prototype.show.restore();
+    restoreRedux();
+    document.body.removeChild(codeWorkspaceDiv);
+    document.body.removeChild(containerDiv);
   });
 
   describe('when the studioApp editor has currentlyUsingBlocks=false', () => {


### PR DESCRIPTION
ShowCodeToggleTest has been causing intermittent errors in its afterEach calls: [Example](https://drone.cdn-code.org/code-dot-org/code-dot-org/12814/1/4). This PR does a brief cleanup of those calls to make future debugging and diagnosing easier.

<!--
  Other aspects to consider. uncomment and add detail for any that seem necessary:
-->

<!-- ### Background -->
<!-- ### Privacy -->
<!-- ### Security -->
<!-- ### Caching -->
<!-- ### Deployment strategy -->
<!-- ### Future work -->

## Links

<!--
  Any relevant links to external resources; ie, specification documents, jira
  items, related PRs, honeybadger errors, etc
-->


## Testing story

<!--
  Does your change include appropriate tests?

  If so, please describe how the tests included in this PR are sufficient

  If not, please explain why this change does not need to be tested.
-->

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
