### PR TITLE
Migration to drop contact_rollups_comparison

### DIFF
--- a/dashboard/db/migrate/20200429234529_drop_contact_rollups_comparison.rb
+++ b/dashboard/db/migrate/20200429234529_drop_contact_rollups_comparison.rb
@@ -1,0 +1,9 @@
+class DropContactRollupsComparison < ActiveRecord::Migration[5.0]
+  def up
+    drop_table :contact_rollups_comparisons
+  end
+
+  def down
+    raise ActiveRecord::IrreversibleMigration, 'Cannot recover the deleted table'
+  end
+end

--- a/dashboard/db/schema.rb
+++ b/dashboard/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20200415193328) do
+ActiveRecord::Schema.define(version: 20200429234529) do
 
   create_table "activities", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci" do |t|
     t.integer  "user_id"
@@ -266,16 +266,6 @@ ActiveRecord::Schema.define(version: 20200415193328) do
     t.integer "level_id"
     t.index ["concept_id"], name: "index_concepts_levels_on_concept_id", using: :btree
     t.index ["level_id"], name: "index_concepts_levels_on_level_id", using: :btree
-  end
-
-  create_table "contact_rollups_comparisons", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci" do |t|
-    t.string   "email",               null: false
-    t.json     "old_data"
-    t.datetime "old_data_updated_at"
-    t.json     "new_data"
-    t.datetime "new_data_updated_at"
-    t.datetime "created_at"
-    t.index ["email"], name: "index_contact_rollups_comparisons_on_email", unique: true, using: :btree
   end
 
   create_table "contact_rollups_final", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci" do |t|


### PR DESCRIPTION
Continuation of https://github.com/code-dot-org/code-dot-org/pull/34525, dropping `contact_rollups_comparison` table.

Tested locally by running `bundle exec rails db:migrate`