### PR TITLE
[Microbit] Add ledMatrix.display()

### DIFF
--- a/apps/src/lib/kits/maker/boards/microBit/LedMatrix.js
+++ b/apps/src/lib/kits/maker/boards/microBit/LedMatrix.js
@@ -10,6 +10,10 @@ export default class LedMatrix {
     ];
   }
 
+  display(pixelArray) {
+    this.board.mb.displayShow(/* useGrayscale */ false, pixelArray);
+  }
+
   scrollString(value) {
     this.board.mb.scrollString(value);
   }

--- a/apps/test/unit/lib/kits/maker/boards/MakerBoardTest.js
+++ b/apps/test/unit/lib/kits/maker/boards/MakerBoardTest.js
@@ -337,6 +337,7 @@ export function itImplementsTheMakerBoardInterface(
               'off',
               'toggle',
               'clear',
+              'display',
               'scrollString',
               'scrollNumber'
             ].forEach(fnName => {

--- a/apps/test/unit/lib/kits/maker/boards/makeStubBoard.js
+++ b/apps/test/unit/lib/kits/maker/boards/makeStubBoard.js
@@ -37,6 +37,8 @@ export class MicrobitStubBoard {
     callback();
   }
 
+  displayShow() {}
+
   displayPlot() {}
 
   displayClear() {}

--- a/apps/test/unit/lib/kits/maker/boards/microBit/LedMatrixTest.js
+++ b/apps/test/unit/lib/kits/maker/boards/microBit/LedMatrixTest.js
@@ -72,6 +72,32 @@ describe('LedMatrix', function() {
     });
   });
 
+  describe('display()', () => {
+    let led;
+    let boardClient = new MicrobitStubBoard();
+    let displaySpy;
+
+    before(() => {
+      led = new LedMatrix({
+        mb: boardClient
+      });
+      displaySpy = sinon.spy(boardClient, 'displayShow');
+    });
+
+    it('calls the parent displayShow', () => {
+      let pixelArray = [
+        [1, 0, 1, 0, 1],
+        [0, 1, 0, 1, 0],
+        [1, 0, 1, 0, 1],
+        [0, 1, 0, 1, 0],
+        [1, 0, 1, 0, 1]
+      ];
+      led.display(pixelArray);
+      expect(displaySpy).to.have.been.calledOnce;
+      expect(displaySpy).to.have.been.calledWith(false, pixelArray);
+    });
+  });
+
   describe('scrollString() and scrollNumber()', () => {
     let led;
     let boardClient = new MicrobitStubBoard();


### PR DESCRIPTION
Displays an array on the LED matrix on the microbit board. Input is a 5x5 array of pixels (0 = off, >0 = on).  We just pass the command through to `MBFirmataClient.displayShow()`. displayShow() has another argument, `useGrayscale`, which, if true, will set the brightness of each pixel between 0 and 255 . However, for simplicity, I think we want students to just think of pixels as on or off (0/1), so I have `useGrayscale = false`. We can always change this later if needed, though.

![Apr-30-2020 09-14-39](https://user-images.githubusercontent.com/8787187/80733822-1263af00-8ac3-11ea-8eb9-d981e16e4ea4.gif)


<!-- ### Background -->
<!-- ### Privacy -->
<!-- ### Security -->
<!-- ### Caching -->
<!-- ### Deployment strategy -->
<!-- ### Future work -->

## Links

<!--
  Any relevant links to external resources; ie, specification documents, jira
  items, related PRs, honeybadger errors, etc
-->

- [spec](https://docs.google.com/document/d/1oPqJpIsaaGIQv7_KvCShmw6i0mT6MP3VqBP41yZ5M5c/edit#heading=h.ak61axyp722j)
- [jira](https://codedotorg.atlassian.net/browse/STAR-1058)

## Testing story
Unit test following same pattern as other led matrix commands.

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
