### PR TITLE
fix adhoc Rake config

### DIFF
--- a/lib/rake/adhoc.rake
+++ b/lib/rake/adhoc.rake
@@ -9,7 +9,9 @@ namespace :adhoc do
       stack_name: ENV['STACK_NAME'],
       template: ENV['TEMPLATE'] || 'cloud_formation_stack.yml.erb',
       stack: (@template = Cdo::CloudFormation::CdoApp.new(
-        frontends: ENV['FRONTENDS']
+        database: ENV['DATABASE'],
+        frontends: ENV['FRONTENDS'],
+        cdn_enabled: ENV['CDN_ENABLED']
       )),
       log: CDO.log,
       verbose: ENV['VERBOSE'],
@@ -63,8 +65,8 @@ Note: Consumes AWS resources until `adhoc:stop` is called.'
   end
 
   namespace :cdn do
-    task :environment do
-      ENV['CDN_ENABLED'] = '1'
+    task environment: 'adhoc:environment' do
+      @template.options[:cdn_enabled] = true
     end
 
     desc 'Launch an adhoc server, with CloudFront CDN enabled.


### PR DESCRIPTION
Followup to #33607, restores support for some extra ENV variables for setting stack-template config in `adhoc.rake` (`DATABASE`, `CDN_ENABLED` and the `adhoc:cdn:` sub-namespace).