### PR TITLE
Add parent email to new contact rollups process

### DIFF
--- a/dashboard/app/models/contact_rollups_processed.rb
+++ b/dashboard/app/models/contact_rollups_processed.rb
@@ -48,7 +48,7 @@ class ContactRollupsProcessed < ApplicationRecord
       contact_data = parse_contact_data(contact['all_data_and_metadata'])
 
       processed_contact_data = {}
-      processed_contact_data.merge!(extract_field(contact_data, 'dashboard.email_preferences', 'opt_in') || {})
+      processed_contact_data.merge!(extract_field(contact_data, "#{CDO.dashboard_db_name}.email_preferences", 'opt_in') || {})
       processed_contact_data.merge!(extract_updated_at(contact_data) || {})
 
       batch << {email: contact['email'], data: processed_contact_data}

--- a/dashboard/app/models/contact_rollups_processed.rb
+++ b/dashboard/app/models/contact_rollups_processed.rb
@@ -38,7 +38,7 @@ class ContactRollupsProcessed < ApplicationRecord
     # Because GROUP_CONCAT returns a string, we add a parser function to convert the result to a hash.
     group_by_query = <<-SQL.squish
       SELECT email, CONCAT('[', GROUP_CONCAT(data_and_metadata), ']') AS all_data_and_metadata
-      FROM (#{select_query}) AS sub_query
+      FROM (#{select_query}) AS subquery
       GROUP BY email
     SQL
 

--- a/dashboard/app/models/contact_rollups_raw.rb
+++ b/dashboard/app/models/contact_rollups_raw.rb
@@ -23,7 +23,7 @@ class ContactRollupsRaw < ApplicationRecord
   end
 
   def self.extract_email_preferences
-    query = get_extraction_query("#{CDO.dashboard_db_name}.email_preferences", false, ['opt_in'], 'email')
+    query = get_extraction_query("#{CDO.dashboard_db_name}.email_preferences", 'email', ['opt_in'])
     ActiveRecord::Base.connection.execute(query)
   end
 
@@ -34,17 +34,17 @@ class ContactRollupsRaw < ApplicationRecord
       GROUP BY parent_email
     SQL
 
-    query = get_extraction_query(source_sql, true, [], 'parent_email', "#{CDO.dashboard_db_name}.users.parent_email")
+    query = get_extraction_query(source_sql, 'parent_email', [], true, "#{CDO.dashboard_db_name}.users.parent_email")
     ActiveRecord::Base.connection.execute(query)
   end
 
   # @param source [String] Source from which we want to extract data (can be a dashboard table name, or subquery)
-  # @param source_is_subquery [Boolean] True if source is a subquery, rather than a table name
-  # @param data_columns [Array] Columns we want reshaped into a single JSON object
   # @param email_column [String] Column in source table we want to insert ino the email column
-  # @param source_name [String] Name for source (should be non-nil if using a subquery or non-dashboard table)
+  # @param data_columns [Array] Columns we want reshaped into a single JSON object
+  # @param source_is_subquery [Boolean] (default false) Set to true if source is a subquery, rather than a table name
+  # @param source_name [String] (default nil) Name for source (non-nil if using a subquery)
   # @return [String] A SQL statement to extract and reshape data from the source table.
-  def self.get_extraction_query(source, source_is_subquery, data_columns, email_column, source_name=nil)
+  def self.get_extraction_query(source, email_column, data_columns, source_is_subquery=false, source_name=nil)
     if source_name.nil? && source_is_subquery
       raise "Source name required if source is a subquery"
     end

--- a/dashboard/app/models/contact_rollups_raw.rb
+++ b/dashboard/app/models/contact_rollups_raw.rb
@@ -41,7 +41,7 @@ class ContactRollupsRaw < ApplicationRecord
   # @param source [String] Source from which we want to extract data (can be a dashboard table name, or subquery)
   # @param data_columns [Array] Columns we want reshaped into a single JSON object
   # @param email_column [String] Column in source table we want to insert ino the email column
-  # @param source_name [String] Name for source if using a subquery
+  # @param source_name [String] Name for source (should be non-nil if using a subquery or non-dashboard table)
   # @return [String] A SQL statement to extract and reshape data from the source table.
   def self.extract_from_source_query(source, data_columns, email_column, source_name=nil)
     wrapped_source, sources_column = format_source(source, source_name)

--- a/dashboard/lib/contact_rollups_v2.rb
+++ b/dashboard/lib/contact_rollups_v2.rb
@@ -9,6 +9,10 @@ class ContactRollupsV2
       ContactRollupsRaw.extract_email_preferences
     end
 
+    log_collector.time!('Extracts parent emails from dashboard users') do
+      ContactRollupsRaw.extract_parent_emails
+    end
+
     log_collector.time!('Processes all extracted data') do
       ContactRollupsProcessed.import_from_raw_table
     end

--- a/dashboard/test/models/contact_rollups_processed_test.rb
+++ b/dashboard/test/models/contact_rollups_processed_test.rb
@@ -39,7 +39,7 @@ class ContactRollupsProcessedTest < ActiveSupport::TestCase
     create :contact_rollups_raw, email: email,
       data: nil, data_updated_at: base_time - 1.day
     create :contact_rollups_raw, email: email,
-      sources: 'dashboard.email_preferences', data: {opt_in: 1}, data_updated_at: base_time
+      sources: "#{CDO.dashboard_db_name}.email_preferences", data: {opt_in: 1}, data_updated_at: base_time
 
     ContactRollupsProcessed.import_from_raw_table
 
@@ -61,13 +61,13 @@ class ContactRollupsProcessedTest < ActiveSupport::TestCase
   end
 
   test 'extract_field' do
-    table = 'dashboard.email_preferences'
+    table = "#{CDO.dashboard_db_name}.email_preferences"
     field = 'opt_in'
 
     test_cases = [
       {input: [{}, nil, nil], expected_output: nil},
       {input: [{table => {}}, table, field], expected_output: nil},
-      {input: [{'dashboard.another_table' => {opt_in: 1}}, table, field], expected_output: nil},
+      {input: [{"#{CDO.dashboard_db_name}.another_table" => {opt_in: 1}}, table, field], expected_output: nil},
       {input: [{table => {'opt_in' => 0}}, table, field], expected_output: {opt_in: 0}},
       {input: [{table => {'opt_in' => 1}}, table, field], expected_output: {opt_in: 1}},
       {input: [{table => {'opt_in' => nil}}, table, field], expected_output: {opt_in: nil}}

--- a/dashboard/test/models/contact_rollups_raw_test.rb
+++ b/dashboard/test/models/contact_rollups_raw_test.rb
@@ -9,7 +9,7 @@ class ContactRollupsRawTest < ActiveSupport::TestCase
     expected_data = {opt_in: email_preference.opt_in ? 1 : 0}
     result = ContactRollupsRaw.find_by(
       email: email_preference.email,
-      sources: "dashboard.email_preferences"
+      sources: "#{CDO.dashboard_db_name}.email_preferences"
     )
 
     assert_equal expected_data, result.data.symbolize_keys
@@ -19,13 +19,12 @@ class ContactRollupsRawTest < ActiveSupport::TestCase
     student = create :student, parent_email: 'caring@parent.com'
     ContactRollupsRaw.extract_parent_emails
 
-    result = ContactRollupsRaw.find_by(
-      email: student.parent_email,
-      sources: 'dashboard.users.parent_email'
-    )
-
     # confirms that a) record exists, and b) data is blank
-    assert_nil result.data
+    refute_nil ContactRollupsRaw.find_by(
+      email: student.parent_email,
+      sources: "#{CDO.dashboard_db_name}.users.parent_email",
+      data: nil
+    )
   end
 
   test 'extract_email_preferences can import many email preferences' do
@@ -34,16 +33,16 @@ class ContactRollupsRawTest < ActiveSupport::TestCase
     assert 3, ContactRollupsRaw.count
   end
 
-  test 'extract_from_source_query can import when data column is null' do
+  test 'get_extraction_query can import when data column is null' do
     teacher = create :teacher
 
-    query = ContactRollupsRaw.extract_from_source_query('users', [], 'email')
+    query = ContactRollupsRaw.get_extraction_query('users', false, [], 'email')
     ActiveRecord::Base.connection.execute(query)
 
-    refute_nil ContactRollupsRaw.find_by(email: teacher.email, data: nil, sources: 'dashboard.users')
+    refute_nil ContactRollupsRaw.find_by(email: teacher.email, data: nil, sources: "#{CDO.dashboard_db_name}.users")
   end
 
-  test 'extract_from_source_query can import when source is a subquery' do
+  test 'get_extraction_query can import when source is a subquery' do
     first_child = create :student, parent_email: 'caring@parent.com'
     second_child = create :student, parent_email: 'caring@parent.com'
 
@@ -55,23 +54,23 @@ class ContactRollupsRawTest < ActiveSupport::TestCase
       GROUP BY 1
     SQL
 
-    query = ContactRollupsRaw.extract_from_source_query(subquery, ['higher_student_id'], 'parent_email', 'dashboard.users.id')
+    query = ContactRollupsRaw.get_extraction_query(subquery, true, ['higher_student_id'], 'parent_email', "#{CDO.dashboard_db_name}.users.id")
     ActiveRecord::Base.connection.execute(query)
 
     refute_empty ContactRollupsRaw.where(
       "email = :email and data->'$.higher_student_id' = :higher_student_id and sources = :sources",
       email: first_child.parent_email,
-      sources: 'dashboard.users.id',
+      sources: "#{CDO.dashboard_db_name}.users.id",
       higher_student_id: second_child.id
     )
   end
 
-  test 'extract_from_source_query looks as expected when called with a single column' do
+  test 'get_extraction_query looks as expected when called with a single column' do
     expected_sql = <<~SQL
       INSERT INTO #{ContactRollupsRaw.table_name} (email, sources, data, data_updated_at, created_at, updated_at)
       SELECT
         email,
-        'dashboard.email_preferences' AS sources,
+        '#{CDO.dashboard_db_name}.email_preferences' AS sources,
         JSON_OBJECT('opt_in',opt_in) AS data,
         updated_at AS data_updated_at,
         NOW() AS created_at,
@@ -80,15 +79,15 @@ class ContactRollupsRawTest < ActiveSupport::TestCase
       WHERE email IS NOT NULL AND email != ''
     SQL
 
-    assert_equal expected_sql, ContactRollupsRaw.extract_from_source_query('email_preferences', ['opt_in'], 'email')
+    assert_equal expected_sql, ContactRollupsRaw.get_extraction_query('email_preferences', false, ['opt_in'], 'email')
   end
 
-  test 'extract_from_source_query looks as expected when called with multiple columns' do
+  test 'get_extraction_query looks as expected when called with multiple columns' do
     expected_sql = <<~SQL
       INSERT INTO #{ContactRollupsRaw.table_name} (email, sources, data, data_updated_at, created_at, updated_at)
       SELECT
         parent_email,
-        'dashboard.users' AS sources,
+        '#{CDO.dashboard_db_name}.users' AS sources,
         JSON_OBJECT('birthday',birthday,'gender',gender) AS data,
         updated_at AS data_updated_at,
         NOW() AS created_at,
@@ -97,7 +96,7 @@ class ContactRollupsRawTest < ActiveSupport::TestCase
       WHERE parent_email IS NOT NULL AND parent_email != ''
     SQL
 
-    assert_equal expected_sql, ContactRollupsRaw.extract_from_source_query('users', ['birthday', 'gender'], 'parent_email')
+    assert_equal expected_sql, ContactRollupsRaw.get_extraction_query('users', false, ['birthday', 'gender'], 'parent_email')
   end
 
   test 'create_json_object looks as expected when called with single column' do

--- a/dashboard/test/models/contact_rollups_raw_test.rb
+++ b/dashboard/test/models/contact_rollups_raw_test.rb
@@ -36,7 +36,7 @@ class ContactRollupsRawTest < ActiveSupport::TestCase
   test 'get_extraction_query can import when data column is null' do
     teacher = create :teacher
 
-    query = ContactRollupsRaw.get_extraction_query("#{CDO.dashboard_db_name}.users", false, [], 'email')
+    query = ContactRollupsRaw.get_extraction_query("#{CDO.dashboard_db_name}.users", 'email', [])
     ActiveRecord::Base.connection.execute(query)
 
     refute_nil ContactRollupsRaw.find_by(email: teacher.email, data: nil, sources: "#{CDO.dashboard_db_name}.users")
@@ -54,7 +54,7 @@ class ContactRollupsRawTest < ActiveSupport::TestCase
       GROUP BY parent_email
     SQL
 
-    query = ContactRollupsRaw.get_extraction_query(subquery, true, ['higher_student_id'], 'parent_email', "#{CDO.dashboard_db_name}.users.id")
+    query = ContactRollupsRaw.get_extraction_query(subquery, 'parent_email', ['higher_student_id'], true, "#{CDO.dashboard_db_name}.users.id")
     ActiveRecord::Base.connection.execute(query)
 
     refute_empty ContactRollupsRaw.where(
@@ -79,7 +79,7 @@ class ContactRollupsRawTest < ActiveSupport::TestCase
       WHERE email IS NOT NULL AND email != ''
     SQL
 
-    assert_equal expected_sql, ContactRollupsRaw.get_extraction_query("#{CDO.dashboard_db_name}.email_preferences", false, ['opt_in'], 'email')
+    assert_equal expected_sql, ContactRollupsRaw.get_extraction_query("#{CDO.dashboard_db_name}.email_preferences", 'email', ['opt_in'])
   end
 
   test 'get_extraction_query looks as expected when called with multiple columns' do
@@ -96,7 +96,7 @@ class ContactRollupsRawTest < ActiveSupport::TestCase
       WHERE parent_email IS NOT NULL AND parent_email != ''
     SQL
 
-    assert_equal expected_sql, ContactRollupsRaw.get_extraction_query("#{CDO.dashboard_db_name}.users", false, ['birthday', 'gender'], 'parent_email')
+    assert_equal expected_sql, ContactRollupsRaw.get_extraction_query("#{CDO.dashboard_db_name}.users", 'parent_email', ['birthday', 'gender'])
   end
 
   test 'create_json_object looks as expected when called with single column' do

--- a/dashboard/test/models/contact_rollups_raw_test.rb
+++ b/dashboard/test/models/contact_rollups_raw_test.rb
@@ -15,6 +15,12 @@ class ContactRollupsRawTest < ActiveSupport::TestCase
     assert_equal expected_data, result.data.symbolize_keys
   end
 
+  test 'extract_email_preferences can import many email preferences' do
+    3.times {|i| create :email_preference, email: "contact_#{i}@rollups.com"}
+    ContactRollupsRaw.extract_email_preferences
+    assert 3, ContactRollupsRaw.count
+  end
+
   test 'extract_parent_email creates records as we would expect' do
     student = create :student, parent_email: 'caring@parent.com'
     ContactRollupsRaw.extract_parent_emails
@@ -25,12 +31,6 @@ class ContactRollupsRawTest < ActiveSupport::TestCase
       sources: "#{CDO.dashboard_db_name}.users.parent_email",
       data: nil
     )
-  end
-
-  test 'extract_email_preferences can import many email preferences' do
-    3.times {|i| create :email_preference, email: "contact_#{i}@rollups.com"}
-    ContactRollupsRaw.extract_email_preferences
-    assert 3, ContactRollupsRaw.count
   end
 
   test 'get_extraction_query can import when data column is null' do

--- a/dashboard/test/models/contact_rollups_raw_test.rb
+++ b/dashboard/test/models/contact_rollups_raw_test.rb
@@ -36,7 +36,7 @@ class ContactRollupsRawTest < ActiveSupport::TestCase
   test 'get_extraction_query can import when data column is null' do
     teacher = create :teacher
 
-    query = ContactRollupsRaw.get_extraction_query('users', false, [], 'email')
+    query = ContactRollupsRaw.get_extraction_query("#{CDO.dashboard_db_name}.users", false, [], 'email')
     ActiveRecord::Base.connection.execute(query)
 
     refute_nil ContactRollupsRaw.find_by(email: teacher.email, data: nil, sources: "#{CDO.dashboard_db_name}.users")
@@ -51,7 +51,7 @@ class ContactRollupsRawTest < ActiveSupport::TestCase
     subquery = <<~SQL
       SELECT parent_email, max(updated_at) as updated_at, max(id) as higher_student_id
       FROM users
-      GROUP BY 1
+      GROUP BY parent_email
     SQL
 
     query = ContactRollupsRaw.get_extraction_query(subquery, true, ['higher_student_id'], 'parent_email', "#{CDO.dashboard_db_name}.users.id")
@@ -75,11 +75,11 @@ class ContactRollupsRawTest < ActiveSupport::TestCase
         updated_at AS data_updated_at,
         NOW() AS created_at,
         NOW() AS updated_at
-      FROM email_preferences
+      FROM #{CDO.dashboard_db_name}.email_preferences
       WHERE email IS NOT NULL AND email != ''
     SQL
 
-    assert_equal expected_sql, ContactRollupsRaw.get_extraction_query('email_preferences', false, ['opt_in'], 'email')
+    assert_equal expected_sql, ContactRollupsRaw.get_extraction_query("#{CDO.dashboard_db_name}.email_preferences", false, ['opt_in'], 'email')
   end
 
   test 'get_extraction_query looks as expected when called with multiple columns' do
@@ -92,11 +92,11 @@ class ContactRollupsRawTest < ActiveSupport::TestCase
         updated_at AS data_updated_at,
         NOW() AS created_at,
         NOW() AS updated_at
-      FROM users
+      FROM #{CDO.dashboard_db_name}.users
       WHERE parent_email IS NOT NULL AND parent_email != ''
     SQL
 
-    assert_equal expected_sql, ContactRollupsRaw.get_extraction_query('users', false, ['birthday', 'gender'], 'parent_email')
+    assert_equal expected_sql, ContactRollupsRaw.get_extraction_query("#{CDO.dashboard_db_name}.users", false, ['birthday', 'gender'], 'parent_email')
   end
 
   test 'create_json_object looks as expected when called with single column' do

--- a/dashboard/test/models/contact_rollups_raw_test.rb
+++ b/dashboard/test/models/contact_rollups_raw_test.rb
@@ -24,6 +24,7 @@ class ContactRollupsRawTest < ActiveSupport::TestCase
       sources: 'dashboard.users.parent_email'
     )
 
+    # confirms that a) record exists, and b) data is blank
     assert_nil result.data
   end
 


### PR DESCRIPTION
[PLC-815](https://codedotorg.atlassian.net/browse/PLC-815)

Extracts `parent_email` from the `users` table and adds it to the contact rollups pipeline. Note that there are no additional attributes associated with the email  being extracted here, just the parent's email address itself. 

Required a little of restructuring to deal with allowing a subquery to be used. Namely, I've added an optional argument for a `source_name` when the data isn't coming from a single dashboard table -- @hacodeorg proposed this should follow the structure `schema.table.column_name`.

## Testing story

Ran `bin/cron/build_contact_rollups_v2` successfully and manually reviewed results in each step of contact rollups process (raw, processed, final). Successful integration test and unit tests for raw and processed steps. Added some new unit testing as well.

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
