### PR TITLE
Hide Toolbar Helper: fix

### DIFF
--- a/apps/src/templates/HideToolbarHelper.jsx
+++ b/apps/src/templates/HideToolbarHelper.jsx
@@ -70,6 +70,7 @@ export default class HideToolbarHelper extends React.Component {
 
     if (!isiOS13 || !isLandscape || isHideCookieSet) {
       this.setState({showHelper: false});
+      return;
     }
 
     // We are on iOS 13, in landscape, and we haven't hidden due to a cookie.


### PR DESCRIPTION
State was being accidentally set twice, and on production, on machines where it looked like a toolbar was showing, even when none of the other criteria was being matched, the helper was being shown.  It definitely should not have been.

Followup to https://github.com/code-dot-org/code-dot-org/pull/34535