### PR TITLE
Only show visible courses in dropdown on course overview page

### DIFF
--- a/dashboard/app/controllers/courses_controller.rb
+++ b/dashboard/app/controllers/courses_controller.rb
@@ -20,8 +20,8 @@ class CoursesController < ApplicationController
         @modern_elementary_courses_available = Script.modern_elementary_courses_available?(request.locale)
       end
       format.json do
-        courses = Course.valid_courses(user: current_user)
-        render json: courses
+        course_infos = Course.valid_course_infos(user: current_user)
+        render json: course_infos
       end
     end
   end

--- a/dashboard/app/views/teacher_dashboard/show.html.haml
+++ b/dashboard/app/views/teacher_dashboard/show.html.haml
@@ -4,7 +4,7 @@
   teacher_dashboard_data[:sections] = @sections
   teacher_dashboard_data[:section] = @section_summary
   teacher_dashboard_data[:validScripts] = Script.valid_scripts(current_user).map(&:assignable_info)
-  teacher_dashboard_data[:validCourses] = Course.valid_courses(user: @current_user)
+  teacher_dashboard_data[:validCourses] = Course.valid_course_infos(user: @current_user)
   teacher_dashboard_data[:studentScriptIds] = @section.student_script_ids
   teacher_dashboard_data[:currentUserId] = @current_user.id
   teacher_dashboard_data[:hasSeenStandardsReportInfo] = @current_user.has_seen_standards_report_info_dialog || false

--- a/dashboard/test/models/course_test.rb
+++ b/dashboard/test/models/course_test.rb
@@ -193,17 +193,20 @@ class CourseTest < ActiveSupport::TestCase
   end
 
   test 'summarize_version' do
-    create(:course, name: 'csp-2017', family_name: 'csp', version_year: '2017', is_stable: true)
-    csp_2018 = create(:course, name: 'csp-2018', family_name: 'csp', version_year: '2018', is_stable: true)
-    csp_2019 = create(:course, name: 'csp-2019', family_name: 'csp', version_year: '2019')
+    csp_2017 = create(:course, name: 'csp-2017', family_name: 'csp', version_year: '2017', visible: true, is_stable: true)
+    csp_2018 = create(:course, name: 'csp-2018', family_name: 'csp', version_year: '2018', visible: true, is_stable: true)
+    csp_2019 = create(:course, name: 'csp-2019', family_name: 'csp', version_year: '2019', visible: true)
+    csp_2020 = create(:course, name: 'csp-2020', family_name: 'csp', version_year: '2019')
 
-    summary = csp_2018.summarize_versions
-    assert_equal ['csp-2019', 'csp-2018', 'csp-2017'], summary.map {|h| h[:name]}
-    assert_equal [false, true, true], summary.map {|h| h[:is_stable]}
+    [csp_2017, csp_2018, csp_2019].each do |c|
+      summary = c.summarize_versions
+      assert_equal ['csp-2019', 'csp-2018', 'csp-2017'], summary.map {|h| h[:name]}
+      assert_equal [false, true, true], summary.map {|h| h[:is_stable]}
+    end
 
-    summary = csp_2019.summarize_versions
-    assert_equal ['csp-2019', 'csp-2018', 'csp-2017'], summary.map {|h| h[:name]}
-    assert_equal [false, true, true], summary.map {|h| h[:is_stable]}
+    # Result should include self, even if it's not visible
+    summary = csp_2020.summarize_versions
+    assert_equal ['csp-2020', 'csp-2019', 'csp-2018', 'csp-2017'], summary.map {|h| h[:name]}
   end
 
   class SelectCourseScriptTests < ActiveSupport::TestCase
@@ -479,73 +482,19 @@ class CourseTest < ActiveSupport::TestCase
 
   test "valid_courses" do
     csp = create(:course, name: 'csp-2017', visible: true, is_stable: true)
-    csp1 = create(:script, name: 'csp1')
-    csp2 = create(:script, name: 'csp2')
-    csp2_alt = create(:script, name: 'csp2-alt', hidden: true)
-    csp3 = create(:script, name: 'csp3')
     # Should still be in valid_courses if visible and not stable
     csd = create(:course, name: 'csd-2017', visible: true)
     create(:course, name: 'madeup')
 
-    create(:course_script, position: 1, course: csp, script: csp1)
-    create(:course_script, position: 2, course: csp, script: csp2)
-    create(:course_script,
-      position: 2,
-      course: csp,
-      script: csp2_alt,
-      experiment_name: 'csp2-alt-experiment',
-      default_script: csp2
-    )
-    create(:course_script, position: 3, course: csp, script: csp3)
-
-    courses = Course.valid_courses
-
-    # one entry for each 2017 course that is in ScriptConstants
-    assert_equal 2, courses.length
-    assert_equal csd.id, courses[0][:id]
-    assert_equal csp.id, courses[1][:id]
-
-    csp_assign_info = courses[1]
-
-    # has fields from ScriptConstants::Assignable_Info
-    assert_equal csp.id, csp_assign_info[:id]
-    assert_equal 'csp-2017', csp_assign_info[:script_name]
-    assert_equal(-1, csp_assign_info[:category_priority])
-
-    # has localized name, category
-    assert_equal "Computer Science Principles ('17-'18)", csp_assign_info[:name]
-    assert_equal 'Full Courses', csp_assign_info[:category]
-
-    # has script_ids
-    assert_equal [csp1.id, csp2.id, csp3.id], csp_assign_info[:script_ids]
-
-    # teacher without experiment has default script_ids
-    teacher = create(:teacher)
-    courses = Course.valid_courses(user: teacher)
-    assert_equal csp.id, courses[1][:id]
-    csp_assign_info = courses[1]
-    assert_equal [csp1.id, csp2.id, csp3.id], csp_assign_info[:script_ids]
-
-    # teacher with experiment has alternate script_ids
-    teacher_with_experiment = create(:teacher)
-    experiment = create(:single_user_experiment, name: 'csp2-alt-experiment', min_user_id: teacher_with_experiment.id)
-    courses = Course.valid_courses(user: teacher_with_experiment)
-    assert_equal csp.id, courses[1][:id]
-    csp_assign_info = courses[1]
-    assert_equal [csp1.id, csp2_alt.id, csp3.id], csp_assign_info[:script_ids]
-    experiment.destroy
+    assert_equal [csp, csd], Course.valid_courses
   end
 
-  test "valid_courses all versions" do
+  test "assignable_info" do
     csp = create(:course, name: 'csp-2017', visible: true, is_stable: true)
     csp1 = create(:script, name: 'csp1')
     csp2 = create(:script, name: 'csp2')
     csp2_alt = create(:script, name: 'csp2-alt', hidden: true)
     csp3 = create(:script, name: 'csp3')
-    csp18 = create(:course, name: 'csp-2018', visible: true, is_stable: true)
-    csd = create(:course, name: 'csd-2017', visible: true, is_stable: true)
-    csd18 = create(:course, name: 'csd-2018', visible: true, is_stable: true)
-    create(:course, name: 'madeup')
 
     create(:course_script, position: 1, course: csp, script: csp1)
     create(:course_script, position: 2, course: csp, script: csp2)
@@ -558,16 +507,7 @@ class CourseTest < ActiveSupport::TestCase
     )
     create(:course_script, position: 3, course: csp, script: csp3)
 
-    courses = Course.valid_courses
-
-    # one entry for each 2017 and 2018 course in ScriptConstants
-    assert_equal 4, courses.length
-    assert_equal csd.id, courses[0][:id]
-    assert_equal csd18.id, courses[1][:id]
-    assert_equal csp.id, courses[2][:id]
-    assert_equal csp18.id, courses[3][:id]
-
-    csp_assign_info = courses[2]
+    csp_assign_info = csp.assignable_info
 
     # has fields from ScriptConstants::Assignable_Info
     assert_equal csp.id, csp_assign_info[:id]
@@ -583,17 +523,15 @@ class CourseTest < ActiveSupport::TestCase
 
     # teacher without experiment has default script_ids
     teacher = create(:teacher)
-    courses = Course.valid_courses(user: teacher)
-    assert_equal csp.id, courses[2][:id]
-    csp_assign_info = courses[2]
+    csp_assign_info = csp.assignable_info(teacher)
+    assert_equal csp.id, csp_assign_info[:id]
     assert_equal [csp1.id, csp2.id, csp3.id], csp_assign_info[:script_ids]
 
     # teacher with experiment has alternate script_ids
     teacher_with_experiment = create(:teacher)
     experiment = create(:single_user_experiment, name: 'csp2-alt-experiment', min_user_id: teacher_with_experiment.id)
-    courses = Course.valid_courses(user: teacher_with_experiment)
-    assert_equal csp.id, courses[2][:id]
-    csp_assign_info = courses[2]
+    csp_assign_info = csp.assignable_info(teacher_with_experiment)
+    assert_equal csp.id, csp_assign_info[:id]
     assert_equal [csp1.id, csp2_alt.id, csp3.id], csp_assign_info[:script_ids]
     experiment.destroy
   end
@@ -606,10 +544,10 @@ class CourseTest < ActiveSupport::TestCase
     create :course, pilot_experiment: 'my-experiment'
     assert Course.any?(&:pilot?)
 
-    refute Course.valid_courses(user: student).any? {|c| c[:pilot_experiment]}
-    refute Course.valid_courses(user: teacher).any? {|c| c[:pilot_experiment]}
-    assert Course.valid_courses(user: pilot_teacher).any? {|c| c[:pilot_experiment]}
-    assert Course.valid_courses(user: levelbuilder).any? {|c| c[:pilot_experiment]}
+    refute Course.valid_courses(user: student).any?(&:pilot_experiment)
+    refute Course.valid_courses(user: teacher).any?(&:pilot_experiment)
+    assert Course.valid_courses(user: pilot_teacher).any?(&:pilot_experiment)
+    assert Course.valid_courses(user: levelbuilder).any?(&:pilot_experiment)
   end
 
   test "update_teacher_resources" do


### PR DESCRIPTION
Fixes the issue where courses that aren't `visible` were still being shown in the course overview page dropdown.

Also fixes issue I forgot to fix from https://github.com/code-dot-org/code-dot-org/pull/34378 - `valid_courses` should only filter by `visible`, not `visible` and `stable`.

Also confirmed that other behaviors still match what is expected, as discussed here: https://codedotorg.slack.com/archives/CNZP84FJ5/p1588344125387900

![image](https://user-images.githubusercontent.com/6564873/80825130-a2bdf480-8b94-11ea-957e-86c92183ef98.png)

![image](https://user-images.githubusercontent.com/6564873/80825187-b701f180-8b94-11ea-9fc5-350d6ab8ef00.png)

![image](https://user-images.githubusercontent.com/6564873/80825249-d1d46600-8b94-11ea-9f26-03f13dcda0ac.png)

![image](https://user-images.githubusercontent.com/6564873/80825261-de58be80-8b94-11ea-8668-1c59d98ce7ad.png)

![image](https://user-images.githubusercontent.com/6564873/80825297-ef093480-8b94-11ea-88ab-5dd15e5b11f5.png)


<!-- ### Background -->
<!-- ### Privacy -->
<!-- ### Security -->
<!-- ### Caching -->
<!-- ### Deployment strategy -->
<!-- ### Future work -->

## Links

<!--
  Any relevant links to external resources; ie, specification documents, jira
  items, related PRs, honeybadger errors, etc
-->

- [spec]()
- [jira]()

## Testing story

* manual testing (see screenshots above)
* unit tests

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
