### PR TITLE
Re-Implement: Lesson Group: Update PLC Objects to Use Lesson Group Instead of Flex Category

### DIFF
--- a/apps/src/code-studio/progress.js
+++ b/apps/src/code-studio/progress.js
@@ -301,7 +301,7 @@ function initializeStoreWithProgress(
       professionalLearningCourse: scriptData.plc,
       saveAnswersBeforeNavigation: saveAnswersBeforeNavigation,
       stages: scriptData.stages,
-      peerReviewStage: scriptData.peerReviewStage,
+      peerReviewLessonInfo: scriptData.peerReviewLessonInfo,
       scriptId: scriptData.id,
       scriptName: scriptData.name,
       scriptTitle: scriptData.title,

--- a/apps/src/code-studio/progressRedux.js
+++ b/apps/src/code-studio/progressRedux.js
@@ -47,7 +47,7 @@ const initialState = {
   // a mapping of level id to result
   levelProgress: {},
   focusAreaStageIds: [],
-  peerReviewStage: null,
+  peerReviewLessonInfo: null,
   peerReviewsPerformed: [],
   showTeacherInfo: false,
   postMilestoneDisabled: false,
@@ -76,7 +76,7 @@ export default function reducer(state = initialState, action) {
       professionalLearningCourse: action.professionalLearningCourse,
       saveAnswersBeforeNavigation: action.saveAnswersBeforeNavigation,
       stages: processedStages(stages, action.professionalLearningCourse),
-      peerReviewStage: action.peerReviewStage,
+      peerReviewLessonInfo: action.peerReviewLessonInfo,
       scriptId: action.scriptId,
       scriptName: action.scriptName,
       scriptTitle: action.scriptTitle,
@@ -117,9 +117,9 @@ export default function reducer(state = initialState, action) {
   if (action.type === MERGE_PEER_REVIEW_PROGRESS) {
     return {
       ...state,
-      peerReviewStage: {
-        ...state.peerReviewStage,
-        levels: state.peerReviewStage.levels.map((level, index) => ({
+      peerReviewLessonInfo: {
+        ...state.peerReviewLessonInfo,
+        levels: state.peerReviewLessonInfo.levels.map((level, index) => ({
           ...level,
           ...action.peerReviewsPerformed[index]
         }))
@@ -365,7 +365,7 @@ export const initProgress = ({
   professionalLearningCourse,
   saveAnswersBeforeNavigation,
   stages,
-  peerReviewStage,
+  peerReviewLessonInfo,
   scriptId,
   scriptName,
   scriptTitle,
@@ -379,7 +379,7 @@ export const initProgress = ({
   professionalLearningCourse,
   saveAnswersBeforeNavigation,
   stages,
-  peerReviewStage,
+  peerReviewLessonInfo,
   scriptId,
   scriptName,
   scriptTitle,
@@ -472,11 +472,11 @@ export const lessons = state =>
   state.stages.map((_, index) => lessonFromStageAtIndex(state, index));
 
 /**
- * Extract lesson from our peerReviewStage if we have one. We want this to end up
+ * Extract lesson from our peerReviewLessonInfo if we have one. We want this to end up
  * having the same fields as our non-peer review stages.
  */
 const peerReviewLesson = state => ({
-  ...lessonFromStage(state.peerReviewStage),
+  ...lessonFromStage(state.peerReviewLessonInfo),
   // add some fields that are missing for this stage but required for lessonType
   id: PEER_REVIEW_ID,
   lockable: false,
@@ -484,11 +484,11 @@ const peerReviewLesson = state => ({
 });
 
 /**
- * Extract levels from our peerReviewStage, making sure the levels have the same
+ * Extract levels from our peerReviewLessonInfo, making sure the levels have the same
  * set of fields as our non-peer review levels.
  */
 const peerReviewLevels = state =>
-  state.peerReviewStage.levels.map((level, index) => ({
+  state.peerReviewLessonInfo.levels.map((level, index) => ({
     // These aren't true levels (i.e. we won't have an entry in levelProgress),
     // so always use a specific id that won't collide with real levels
     id: PEER_REVIEW_ID,
@@ -664,12 +664,12 @@ export const groupedLessons = (state, includeBonusLevels = false) => {
     byGroup[group].levels.push(lessonLevels);
   });
 
-  // Peer reviews get their own group, but these levels/lessson are stored
+  // Peer reviews get their own group, but these levels/lesson are stored
   // separately from our other levels/lessons in redux (since they're slightly
   // different)
-  if (state.peerReviewStage) {
-    byGroup['Peer Review'] = {
-      group: 'Peer Review',
+  if (state.peerReviewLessonInfo) {
+    byGroup[state.peerReviewLessonInfo.lesson_group_display_name] = {
+      group: state.peerReviewLessonInfo.lesson_group_display_name,
       lessons: [peerReviewLesson(state)],
       levels: [peerReviewLevels(state)]
     };

--- a/apps/src/templates/FinishDialog.story.jsx
+++ b/apps/src/templates/FinishDialog.story.jsx
@@ -68,7 +68,7 @@ const mockProgress = {
       levels
     }
   ],
-  peerReviewStage: false,
+  peerReviewLessonInfo: false,
   scriptId: 1,
   scriptName: 'test',
   scriptTitle: 'Test Script',

--- a/apps/test/unit/code-studio/progressReduxTest.js
+++ b/apps/test/unit/code-studio/progressReduxTest.js
@@ -471,9 +471,9 @@ describe('progressReduxTest', () => {
 
   describe('with peer reviews', () => {
     // Sample stage of peer review
-    const peerReviewStage = {
+    const peerReviewLessonInfo = {
       name: 'You must complete 2 reviews for this unit',
-      flex_category: 'Peer Review',
+      lesson_group_display_name: 'Peer Review',
       levels: [
         {
           ids: [0],
@@ -502,7 +502,7 @@ describe('progressReduxTest', () => {
       professionalLearningCourse: true,
       saveAnswersBeforeNavigation: false,
       stages: stageData,
-      peerReviewStage: peerReviewStage,
+      peerReviewLessonInfo: peerReviewLessonInfo,
       scriptName: 'alltheplcthings'
     };
 
@@ -518,7 +518,7 @@ describe('progressReduxTest', () => {
         nextState.stages,
         processedStages(intialOverviewProgressWithPeerReview.stages, true)
       );
-      assert.deepEqual(nextState.peerReviewStage, peerReviewStage);
+      assert.deepEqual(nextState.peerReviewLessonInfo, peerReviewLessonInfo);
       assert.equal(nextState.scriptName, 'alltheplcthings');
       assert.equal(nextState.currentStageId, undefined);
     });
@@ -531,12 +531,12 @@ describe('progressReduxTest', () => {
           341: TestResults.MISSING_RECOMMENDED_BLOCK_UNFINISHED
         },
         stages: [stageData[1]],
-        peerReviewStage: peerReviewStage
+        peerReviewLessonInfo: peerReviewLessonInfo
       };
       assert.equal(state.stages[0].levels[2].ids[0], 341);
       state.stages[0].levels[2].status = LevelStatus.attempted;
 
-      assert.deepEqual(peerReviewStage.levels[0], {
+      assert.deepEqual(peerReviewLessonInfo.levels[0], {
         ids: [0],
         kind: LevelKind.peer_review,
         title: '',
@@ -564,15 +564,15 @@ describe('progressReduxTest', () => {
         state.levelProgress,
         'no change to levelProgress'
       );
-      const peerReviewLevels = nextState.peerReviewStage.levels;
+      const peerReviewLevels = nextState.peerReviewLessonInfo.levels;
       assert.equal(
         peerReviewLevels.length,
-        state.peerReviewStage.levels.length,
+        state.peerReviewLessonInfo.levels.length,
         'same number of peer review levels in stage'
       );
 
       // First assert about previous state, to make sure that we didn't mutate it
-      assert.deepEqual(state.peerReviewStage.levels[0], {
+      assert.deepEqual(state.peerReviewLessonInfo.levels[0], {
         ids: [0],
         kind: LevelKind.peer_review,
         title: '',
@@ -583,7 +583,7 @@ describe('progressReduxTest', () => {
       });
 
       // Now assert for our new state
-      assert.deepEqual(nextState.peerReviewStage.levels[0], {
+      assert.deepEqual(nextState.peerReviewLessonInfo.levels[0], {
         // TODO: Seems strange to have both an id and ids. Can we make this better?
         id: 13,
         ids: [0],
@@ -1132,10 +1132,10 @@ describe('progressReduxTest', () => {
 
   describe('peerReviewLesson', () => {
     const {peerReviewLesson, PEER_REVIEW_ID} = __testonly__;
-    it('extracts lesson data from our peerReviewStage', () => {
+    it('extracts lesson data from our peerReviewLessonInfo', () => {
       const state = {
-        peerReviewStage: {
-          flex_category: 'Peer Review',
+        peerReviewLessonInfo: {
+          lesson_group_display_name: 'Peer Review',
           levels: [],
           lockable: false,
           name: 'You must complete 5 reviews for this unit'
@@ -1154,7 +1154,7 @@ describe('progressReduxTest', () => {
 
     it('sets status and icon to locked when locked', () => {
       const state = {
-        peerReviewStage: {
+        peerReviewLessonInfo: {
           levels: [
             {
               icon: 'fa-lock',
@@ -1173,13 +1173,13 @@ describe('progressReduxTest', () => {
       assert.equal(levels[0].id, PEER_REVIEW_ID);
       assert.equal(levels[0].status, LevelStatus.locked);
       assert.equal(levels[0].url, '');
-      assert.equal(levels[0].name, state.peerReviewStage.levels[0].name);
+      assert.equal(levels[0].name, state.peerReviewLessonInfo.levels[0].name);
       assert.equal(levels[0].icon, 'fa-lock');
     });
 
     it('uses given status, no icon when not locked', () => {
       const state = {
-        peerReviewStage: {
+        peerReviewLessonInfo: {
           levels: [
             {
               icon: 'fa-lock',
@@ -1201,7 +1201,7 @@ describe('progressReduxTest', () => {
       assert.equal(levels[0].id, PEER_REVIEW_ID);
       assert.equal(levels[0].status, LevelStatus.perfect);
       assert.equal(levels[0].url, '/peer_reviews/1');
-      assert.equal(levels[0].name, state.peerReviewStage.levels[0].name);
+      assert.equal(levels[0].name, state.peerReviewLessonInfo.levels[0].name);
       assert.equal(levels[0].icon, undefined);
     });
   });

--- a/dashboard/app/models/plc/enrollment_unit_assignment.rb
+++ b/dashboard/app/models/plc/enrollment_unit_assignment.rb
@@ -75,26 +75,23 @@ class Plc::EnrollmentUnitAssignment < ActiveRecord::Base
   def summarize_progress
     summary = []
 
-    categories_for_stage = plc_course_unit.script.lessons.map(&:flex_category).uniq
-
     # If the course unit has an evaluation level, then status is determined by the completion of the focus group modules
     if plc_course_unit.has_evaluation?
-      Plc::LearningModule::MODULE_TYPES.select {|type| categories_for_stage.include?(type)}.each do |flex_category|
-        module_category = flex_category
-        category_name = I18n.t("flex_category.#{module_category}", default: I18n.t('flex_category.required'))
+      plc_course_unit.script.lesson_groups.each do |lesson_group|
+        next unless Plc::LearningModule::MODULE_TYPES.include?(lesson_group.key)
         summary << {
-          category: category_name,
-          status: module_assignment_for_type(flex_category).try(:status) || Plc::EnrollmentModuleAssignment::NOT_STARTED,
-          link: Rails.application.routes.url_helpers.script_path(plc_course_unit.script, anchor: category_name.downcase.tr(' ', '-'))
+          category: lesson_group.localized_display_name,
+          status: module_assignment_for_type(lesson_group.key).try(:status) || Plc::EnrollmentModuleAssignment::NOT_STARTED,
+          link: Rails.application.routes.url_helpers.script_path(plc_course_unit.script, anchor: lesson_group.key.downcase.tr(' ', '-'))
         }
       end
     else
       # Otherwise, status is determined by the completion of stages
-      categories_for_stage.each do |category|
+      plc_course_unit.script.lesson_groups.each do |lesson_group|
         summary << {
-          category: I18n.t("flex_category.#{category || 'content'}"),
+          category: lesson_group.localized_display_name,
           status: Plc::EnrollmentModuleAssignment.stages_based_status(
-            plc_course_unit.script.lessons.select {|stage| stage.flex_category == category},
+            plc_course_unit.script.lessons.select {|lesson| lesson.lesson_group == lesson_group},
             user,
             plc_course_unit.script
           ),
@@ -106,7 +103,7 @@ class Plc::EnrollmentUnitAssignment < ActiveRecord::Base
     # If there are peer reviews, summarize that progress as well
     if plc_course_unit.script.has_peer_reviews?
       summary << {
-        category: I18n.t('flex_category.peer_review'),
+        category: I18n.t('peer_review.peer_review'),
         status: PeerReview.get_review_completion_status(user, plc_course_unit.script),
         link: Rails.application.routes.url_helpers.script_path(plc_course_unit.script, anchor: 'peer-review')
       }

--- a/dashboard/app/models/plc/learning_module.rb
+++ b/dashboard/app/models/plc/learning_module.rb
@@ -54,8 +54,4 @@ class Plc::LearningModule < ActiveRecord::Base
   def required?
     module_type == REQUIRED_MODULE
   end
-
-  def name_with_required_tag
-    "#{name}#{' - Required' if required?}"
-  end
 end

--- a/dashboard/app/models/script.rb
+++ b/dashboard/app/models/script.rb
@@ -115,7 +115,7 @@ class Script < ActiveRecord::Base
         lm.update!(
           plc_course_unit_id: unit.id,
           name: lesson.name,
-          module_type: lesson.lesson_group&.key || Plc::LearningModule::REQUIRED_MODULE,
+          module_type: lesson.lesson_group&.key.presence || Plc::LearningModule::REQUIRED_MODULE,
         )
       end
     end

--- a/dashboard/app/models/script.rb
+++ b/dashboard/app/models/script.rb
@@ -110,12 +110,12 @@ class Script < ActiveRecord::Base
       )
 
       lessons.reload
-      lessons.each do |stage|
-        lm = Plc::LearningModule.find_or_initialize_by(stage_id: stage.id)
+      lessons.each do |lesson|
+        lm = Plc::LearningModule.find_or_initialize_by(stage_id: lesson.id)
         lm.update!(
           plc_course_unit_id: unit.id,
-          name: stage.name,
-          module_type: stage.flex_category.try(:downcase) || Plc::LearningModule::REQUIRED_MODULE,
+          name: lesson.name,
+          module_type: lesson.lesson_group&.key || Plc::LearningModule::REQUIRED_MODULE,
         )
       end
     end
@@ -1364,6 +1364,9 @@ class Script < ActiveRecord::Base
   end
 
   def summarize(include_lessons = true, user = nil, include_bonus_levels = false)
+    # TODO: Set up peer reviews to be more consistent with the rest of the system
+    # so that they don't need a bunch of one off cases (example peer reviews
+    # don't have a lesson group in the database right now)
     if has_peer_reviews?
       levels = []
       peer_reviews_to_complete.times do |x|
@@ -1378,9 +1381,9 @@ class Script < ActiveRecord::Base
         }
       end
 
-      peer_review_stage = {
+      peer_review_lesson_info = {
         name: I18n.t('peer_review.review_count', {review_count: peer_reviews_to_complete}),
-        flex_category: 'Peer Review',
+        lesson_group_display_name: 'Peer Review',
         levels: levels,
         lockable: false
       }
@@ -1410,7 +1413,8 @@ class Script < ActiveRecord::Base
       isHocScript: hoc?,
       csf: csf?,
       peerReviewsRequired: peer_reviews_to_complete || 0,
-      peerReviewStage: peer_review_stage,
+      peerReviewStage: peer_review_lesson_info, #TODO(dmcavoy) REMOVE AFTER A COUPLE DAYS April 2020
+      peerReviewLessonInfo: peer_review_lesson_info,
       student_detail_progress_view: student_detail_progress_view?,
       project_widget_visible: project_widget_visible?,
       project_widget_types: project_widget_types,

--- a/dashboard/app/views/peer_reviews/show.html.haml
+++ b/dashboard/app/views/peer_reviews/show.html.haml
@@ -6,7 +6,7 @@
   - if @peer_review.script.professional_learning_course?
     #breadcrumb
     - course_unit = @peer_review.script.plc_course_unit
-    - react_props = {unit_name: course_unit.unit_name, unit_view_path: script_path(course_unit.script), course_view_path: course_path(course_unit.plc_course.course), page_name: t('flex_category.peer_review')}
+    - react_props = {unit_name: course_unit.unit_name, unit_view_path: script_path(course_unit.script), course_view_path: course_path(course_unit.plc_course.course), page_name: I18n.t('peer_review.peer_review')}
     :javascript
       ReactDOM.render(
         React.createElement(window.dashboard.plcHeader, #{react_props.to_json}),
@@ -14,7 +14,7 @@
       );
 
   %h1
-    =t('flex_category.peer_review')
+    =I18n.t('peer_review.peer_review')
 
   - unless reviewed
     %p Please review the peer submission in the grey box below.

--- a/dashboard/config/locales/en.yml
+++ b/dashboard/config/locales/en.yml
@@ -902,6 +902,7 @@ en:
     no_reviews_at_this_moment_notice: 'There are no peer reviews available at this moment, please check back soon'
     review_submitted: 'Your peer review was submitted'
     review_new_submission: 'Review a new submission'
+    peer_review: 'Peer Review'
   flex_category:
     required: 'Overview'
     content: 'Content'

--- a/dashboard/test/models/plc/course_unit_module_selection_test.rb
+++ b/dashboard/test/models/plc/course_unit_module_selection_test.rb
@@ -7,59 +7,62 @@ class CourseUnitModuleSelectionTest < ActionView::TestCase
 
     @course_unit = create(:plc_course_unit, plc_course: course)
 
-    @stage_cliffs = create(:lesson, name: 'Cliff stage', script: @course_unit.script, flex_category: Plc::LearningModule::CONTENT_MODULE)
-    @stage_ornithology = create(:lesson, name: 'Ornithology stage', script: @course_unit.script, flex_category: Plc::LearningModule::CONTENT_MODULE)
-    @stage_ignorance = create(:lesson, name: 'Ignorance stage', script: @course_unit.script, flex_category: Plc::LearningModule::CONTENT_MODULE)
-    @stage_blue = create(:lesson, name: 'Blue stage', script: @course_unit.script, flex_category: Plc::LearningModule::CONTENT_MODULE)
+    @content_lesson_group = create(:lesson_group, key: Plc::LearningModule::CONTENT_MODULE)
+    @practice_lesson_group = create(:lesson_group, key: Plc::LearningModule::PRACTICE_MODULE)
 
-    @stage_honesty = create(:lesson, name: 'Honesty stage', script: @course_unit.script, flex_category: Plc::LearningModule::PRACTICE_MODULE)
-    @stage_no_nickname = create(:lesson, name: 'No nickname stage', script: @course_unit.script, flex_category: Plc::LearningModule::PRACTICE_MODULE)
+    @lesson_cliffs = create(:lesson, name: 'Cliff lesson', script: @course_unit.script, lesson_group: @content_lesson_group)
+    @lesson_ornithology = create(:lesson, name: 'Ornithology lesson', script: @course_unit.script, lesson_group: @content_lesson_group)
+    @lesson_ignorance = create(:lesson, name: 'Ignorance lesson', script: @course_unit.script, lesson_group: @content_lesson_group)
+    @lesson_blue = create(:lesson, name: 'Blue lesson', script: @course_unit.script, lesson_group: @content_lesson_group)
 
-    @module_cliffs = create(:plc_learning_module, name: 'Getting thrown off cliffs', plc_course_unit: @course_unit, module_type: Plc::LearningModule::CONTENT_MODULE, lesson: @stage_cliffs)
-    @module_ornithology = create(:plc_learning_module, name: 'Ornithology', plc_course_unit: @course_unit, module_type: Plc::LearningModule::CONTENT_MODULE, lesson: @stage_ornithology)
-    @module_ignorance = create(:plc_learning_module, name: 'Admitting Ignorance', plc_course_unit: @course_unit, module_type: Plc::LearningModule::CONTENT_MODULE, lesson: @stage_ignorance)
-    @module_blue = create(:plc_learning_module, name: 'Blue', plc_course_unit: @course_unit, module_type: Plc::LearningModule::CONTENT_MODULE, lesson: @stage_blue)
+    @lesson_honesty = create(:lesson, name: 'Honesty lesson', script: @course_unit.script, lesson_group: @practice_lesson_group)
+    @lesson_no_nickname = create(:lesson, name: 'No nickname lesson', script: @course_unit.script, lesson_group: @practice_lesson_group)
 
-    @module_honesty = create(:plc_learning_module, name: 'Answering questions honestly', plc_course_unit: @course_unit, module_type: Plc::LearningModule::PRACTICE_MODULE, lesson: @stage_honesty)
-    @module_no_nickname = create(:plc_learning_module, name: 'Not revealing your nickname', plc_course_unit: @course_unit, module_type: Plc::LearningModule::PRACTICE_MODULE, lesson: @stage_no_nickname)
+    @module_cliffs = create(:plc_learning_module, name: 'Getting thrown off cliffs', plc_course_unit: @course_unit, module_type: @lesson_cliffs.lesson_group.key, lesson: @lesson_cliffs)
+    @module_ornithology = create(:plc_learning_module, name: 'Ornithology', plc_course_unit: @course_unit, module_type: @lesson_ornithology.lesson_group.key, lesson: @lesson_ornithology)
+    @module_ignorance = create(:plc_learning_module, name: 'Admitting Ignorance', plc_course_unit: @course_unit, module_type: @lesson_ignorance.lesson_group.key, lesson: @lesson_ignorance)
+    @module_blue = create(:plc_learning_module, name: 'Blue', plc_course_unit: @course_unit, module_type: @lesson_blue.lesson_group.key, lesson: @lesson_blue)
+
+    @module_honesty = create(:plc_learning_module, name: 'Answering questions honestly', plc_course_unit: @course_unit, module_type: @lesson_honesty.lesson_group.key, lesson: @lesson_honesty)
+    @module_no_nickname = create(:plc_learning_module, name: 'Not revealing your nickname', plc_course_unit: @course_unit, module_type: @lesson_no_nickname.lesson_group.key, lesson: @lesson_no_nickname)
 
     q1_dsl = <<-DSL.strip_heredoc.chomp
     name 'Question 1'
       question 'What is your name?'
-      answer 'Sir Lancelot', weight: 1, stage_name: '#{@stage_honesty.name}'
-      answer 'Sir Robin', weight: 1, stage_name: '#{@stage_no_nickname.name}'
-      answer 'Sir Galahad', weight: 1, stage_name: '#{@stage_honesty.name}'
-      answer 'King Arthur', weight: 1, stage_name: '#{@stage_honesty.name}'
+      answer 'Sir Lancelot', weight: 1, stage_name: '#{@lesson_honesty.name}'
+      answer 'Sir Robin', weight: 1, stage_name: '#{@lesson_no_nickname.name}'
+      answer 'Sir Galahad', weight: 1, stage_name: '#{@lesson_honesty.name}'
+      answer 'King Arthur', weight: 1, stage_name: '#{@lesson_honesty.name}'
       answer 'Mr Edgecase'
     DSL
 
     q2_dsl = <<-DSL.strip_heredoc.chomp
     name 'Question 2'
       question 'What is your quest?'
-      answer 'I seek the grail', weight: 1, stage_name: '#{@stage_honesty.name}'
-      answer 'Yes, yes, I seek the Grail', weight: 1, stage_name: '#{@stage_no_nickname.name}'
+      answer 'I seek the grail', weight: 1, stage_name: '#{@lesson_honesty.name}'
+      answer 'Yes, yes, I seek the Grail', weight: 1, stage_name: '#{@lesson_no_nickname.name}'
       answer 'I seek something else'
     DSL
 
     q3_dsl = <<-DSL.strip_heredoc.chomp
     name 'Question 3'
       question 'What is your favorite color?'
-      answer 'Blue', weight: 1, stage_name: '#{@stage_blue.name}'
-      answer 'Yellow - no, blue', weight: 1, stage_name: '#{@stage_cliffs.name}'
+      answer 'Blue', weight: 1, stage_name: '#{@lesson_blue.name}'
+      answer 'Yellow - no, blue', weight: 1, stage_name: '#{@lesson_cliffs.name}'
       answer 'No preference'
     DSL
 
     q4_dsl = <<-DSL.strip_heredoc.chomp
     name 'Question 4'
       question 'What is the capital of Assyria?'
-      answer 'I dont know that!', weight: 1, stage_name: '#{@stage_ignorance.name}'
+      answer 'I dont know that!', weight: 1, stage_name: '#{@lesson_ignorance.name}'
       answer 'Nineveh'
     DSL
 
     q5_dsl = <<-DSL.strip_heredoc.chomp
     name 'Question 5'
       question 'What is the airspeed velocity of an unladen swallow?'
-      answer 'What do you mean, an African or European Swallow?', weight: 1, stage_name: '#{@stage_ornithology.name}'
+      answer 'What do you mean, an African or European Swallow?', weight: 1, stage_name: '#{@lesson_ornithology.name}'
       answer '15 m/s'
     DSL
 

--- a/dashboard/test/models/plc/enrollment_unit_assignment_test.rb
+++ b/dashboard/test/models/plc/enrollment_unit_assignment_test.rb
@@ -8,13 +8,17 @@ class Plc::EnrollmentUnitAssignmentTest < ActiveSupport::TestCase
     @script = @course_unit.script
     @script.update(professional_learning_course: @course.name)
 
-    @required_learning_module = create(:plc_learning_module, plc_course_unit: @course_unit, module_type: Plc::LearningModule::REQUIRED_MODULE)
-    @content_learning_module = create(:plc_learning_module, plc_course_unit: @course_unit, module_type: Plc::LearningModule::CONTENT_MODULE)
-    @practice_learning_module = create(:plc_learning_module, plc_course_unit: @course_unit, module_type: Plc::LearningModule::PRACTICE_MODULE)
+    @required_lesson_group = create(:lesson_group, key: Plc::LearningModule::REQUIRED_MODULE, script: @script)
+    @content_lesson_group = create(:lesson_group, key: Plc::LearningModule::CONTENT_MODULE, script: @script)
+    @practice_lesson_group = create(:lesson_group, key: Plc::LearningModule::PRACTICE_MODULE, script: @script)
 
-    @required_learning_module.lesson.update(script: @script, flex_category: Plc::LearningModule::REQUIRED_MODULE)
-    @content_learning_module.lesson.update(script: @script, flex_category: Plc::LearningModule::CONTENT_MODULE)
-    @practice_learning_module.lesson.update(script: @script, flex_category: Plc::LearningModule::PRACTICE_MODULE)
+    @required_learning_module = create(:plc_learning_module, plc_course_unit: @course_unit, module_type: @required_lesson_group.key)
+    @content_learning_module = create(:plc_learning_module, plc_course_unit: @course_unit, module_type: @content_lesson_group.key)
+    @practice_learning_module = create(:plc_learning_module, plc_course_unit: @course_unit, module_type: @practice_lesson_group.key)
+
+    @required_learning_module.lesson.update(script: @script, lesson_group: @required_lesson_group)
+    @content_learning_module.lesson.update(script: @script, lesson_group: @content_lesson_group)
+    @practice_learning_module.lesson.update(script: @script, lesson_group: @practice_lesson_group)
 
     Plc::EnrollmentModuleAssignment.any_instance.stubs(:status).returns(Plc::EnrollmentModuleAssignment::NOT_STARTED)
 
@@ -46,11 +50,12 @@ class Plc::EnrollmentUnitAssignmentTest < ActiveSupport::TestCase
     @script.update(peer_reviews_to_complete: 2)
     PeerReview.stubs(:get_review_completion_status).returns(Plc::EnrollmentModuleAssignment::NOT_STARTED)
 
+    # All the categories except Peer Review will be Content because there is no translation and that is the default
     assert_equal [
       {
-        category: "Overview",
+        category: "Content",
         status: Plc::EnrollmentModuleAssignment::NOT_STARTED,
-        link: "/s/#{@script.name}#overview"
+        link: "/s/#{@script.name}#required"
       },
       {
         category: "Content",
@@ -58,9 +63,9 @@ class Plc::EnrollmentUnitAssignmentTest < ActiveSupport::TestCase
         link: "/s/#{@script.name}#content"
       },
       {
-        category: "Teaching Practices",
+        category: "Content",
         status: Plc::EnrollmentModuleAssignment::NOT_STARTED,
-        link: "/s/#{@script.name}#teaching-practices"
+        link: "/s/#{@script.name}#practice"
       },
       {
         category: "Peer Review",
@@ -70,12 +75,13 @@ class Plc::EnrollmentUnitAssignmentTest < ActiveSupport::TestCase
     ], @unit_enrollment.summarize_progress
   end
 
+  # All the categories except Peer Review will be Content because there is no translation and that is the default
   test 'Enrolling user in a course without an evaluation returns status appropriately' do
     Plc::CourseUnit.any_instance.stubs(:has_evaluation?).returns(false)
 
     assert_equal [
       {
-        category: "Teaching Practices",
+        category: "Content",
         status: Plc::EnrollmentModuleAssignment::COMPLETED,
         link: "/s/#{@script.name}"
       },
@@ -85,7 +91,7 @@ class Plc::EnrollmentUnitAssignmentTest < ActiveSupport::TestCase
         link: "/s/#{@script.name}"
       },
       {
-        category: "Overview",
+        category: "Content",
         status: Plc::EnrollmentModuleAssignment::COMPLETED,
         link: "/s/#{@script.name}"
       }

--- a/dashboard/test/models/script_test.rb
+++ b/dashboard/test/models/script_test.rb
@@ -738,7 +738,7 @@ class ScriptTest < ActiveSupport::TestCase
     summary = script.summarize
 
     assert_equal 1, summary[:stages].count
-    assert_nil summary[:peerReviewStage]
+    assert_nil summary[:peerReviewLessonInfo]
     assert_equal 0, summary[:peerReviewsRequired]
     assert_equal [['curriculum', '/link/to/curriculum']], summary[:teacher_resources]
   end
@@ -754,7 +754,7 @@ class ScriptTest < ActiveSupport::TestCase
 
     expected_peer_review_lesson = {
       name: "You must complete 1 reviews for this unit",
-      flex_category: "Peer Review",
+      lesson_group_display_name: "Peer Review",
       levels: [{
         ids: [0],
         kind: LEVEL_KIND.peer_review,
@@ -768,7 +768,7 @@ class ScriptTest < ActiveSupport::TestCase
     }
 
     assert_equal 2, summary[:stages].count
-    assert_equal expected_peer_review_lesson, summary[:peerReviewStage]
+    assert_equal expected_peer_review_lesson, summary[:peerReviewLessonInfo]
     assert_equal 1, summary[:peerReviewsRequired]
   end
 


### PR DESCRIPTION
Reverts code-dot-org/code-dot-org#34561 Re-implements #34133 

Reason for revert: Staging seeding failed because of generate_plc_objects getting a bad module type. The issue was that for the non-user-facing lesson group the key is `''` which is not an acceptable model type. In the past with flex categories these stages would not have had a flex category so they would have used the default value. So now we check the presence of key which will go back to using the default value for the non-user-facing lesson groups.

Ran `bundle exec rake seed:default` and it passed locally.