### PR TITLE
Fix Firefox bug where opacity filter breaks dropdown design elements

### DIFF
--- a/apps/style/applab/skins/modern.scss
+++ b/apps/style/applab/skins/modern.scss
@@ -44,7 +44,7 @@
     }
 
     &:hover {
-      filter: opacity(0.8)
+      opacity: 0.8
     }
   }
 


### PR DESCRIPTION
This bug came to us through [Zendesk](https://codeorg.zendesk.com/agent/tickets/276563) -- in Firefox, dropdown design elements were automatically closing, so the user was unable to select an option from the dropdown.

Please don't ask me why the `filter` CSS property was causing this, because I can't figure that out. I haven't found anything online where folks are running into this issue. I only found it by commenting out every line of CSS until I found which one was the problem 🙃 

There will be no user-facing change here (since the `filter` property was replaced with the `opacity` property), just the bug fix.

## Links

- [STAR-1080](https://codedotorg.atlassian.net/browse/STAR-1080)

## Testing story

Manually tested on OS X in Firefox, and tested via a SauceLabs tunnel in Firefox/Win10. Also manually tested in Chrome and Safari to make sure this change didn't break dropdowns there.

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
