### PR TITLE
ABANDONED: contained level id

### DIFF
--- a/dashboard/app/models/levels/applab.rb
+++ b/dashboard/app/models/levels/applab.rb
@@ -16,11 +16,13 @@
 #  published             :boolean          default(FALSE), not null
 #  notes                 :text(65535)
 #  audit_log             :text(65535)
+#  contained_level_id    :integer
 #
 # Indexes
 #
-#  index_levels_on_game_id  (game_id)
-#  index_levels_on_name     (name)
+#  index_levels_on_contained_level_id  (contained_level_id)
+#  index_levels_on_game_id             (game_id)
+#  index_levels_on_name                (name)
 #
 
 require 'cdo/shared_constants'

--- a/dashboard/app/models/levels/applab.rb
+++ b/dashboard/app/models/levels/applab.rb
@@ -17,12 +17,14 @@
 #  notes                 :text(65535)
 #  audit_log             :text(65535)
 #  contained_level_id    :integer
+#  template_level_id     :integer
 #
 # Indexes
 #
 #  index_levels_on_contained_level_id  (contained_level_id)
 #  index_levels_on_game_id             (game_id)
 #  index_levels_on_name                (name)
+#  index_levels_on_template_level_id   (template_level_id)
 #
 
 require 'cdo/shared_constants'

--- a/dashboard/app/models/levels/artist.rb
+++ b/dashboard/app/models/levels/artist.rb
@@ -16,11 +16,13 @@
 #  published             :boolean          default(FALSE), not null
 #  notes                 :text(65535)
 #  audit_log             :text(65535)
+#  contained_level_id    :integer
 #
 # Indexes
 #
-#  index_levels_on_game_id  (game_id)
-#  index_levels_on_name     (name)
+#  index_levels_on_contained_level_id  (contained_level_id)
+#  index_levels_on_game_id             (game_id)
+#  index_levels_on_name                (name)
 #
 
 class Artist < Blockly

--- a/dashboard/app/models/levels/artist.rb
+++ b/dashboard/app/models/levels/artist.rb
@@ -17,12 +17,14 @@
 #  notes                 :text(65535)
 #  audit_log             :text(65535)
 #  contained_level_id    :integer
+#  template_level_id     :integer
 #
 # Indexes
 #
 #  index_levels_on_contained_level_id  (contained_level_id)
 #  index_levels_on_game_id             (game_id)
 #  index_levels_on_name                (name)
+#  index_levels_on_template_level_id   (template_level_id)
 #
 
 class Artist < Blockly

--- a/dashboard/app/models/levels/blockly.rb
+++ b/dashboard/app/models/levels/blockly.rb
@@ -16,11 +16,13 @@
 #  published             :boolean          default(FALSE), not null
 #  notes                 :text(65535)
 #  audit_log             :text(65535)
+#  contained_level_id    :integer
 #
 # Indexes
 #
-#  index_levels_on_game_id  (game_id)
-#  index_levels_on_name     (name)
+#  index_levels_on_contained_level_id  (contained_level_id)
+#  index_levels_on_game_id             (game_id)
+#  index_levels_on_name                (name)
 #
 
 require 'nokogiri'

--- a/dashboard/app/models/levels/blockly.rb
+++ b/dashboard/app/models/levels/blockly.rb
@@ -17,12 +17,14 @@
 #  notes                 :text(65535)
 #  audit_log             :text(65535)
 #  contained_level_id    :integer
+#  template_level_id     :integer
 #
 # Indexes
 #
 #  index_levels_on_contained_level_id  (contained_level_id)
 #  index_levels_on_game_id             (game_id)
 #  index_levels_on_name                (name)
+#  index_levels_on_template_level_id   (template_level_id)
 #
 
 require 'nokogiri'

--- a/dashboard/app/models/levels/bounce.rb
+++ b/dashboard/app/models/levels/bounce.rb
@@ -17,12 +17,14 @@
 #  notes                 :text(65535)
 #  audit_log             :text(65535)
 #  contained_level_id    :integer
+#  template_level_id     :integer
 #
 # Indexes
 #
 #  index_levels_on_contained_level_id  (contained_level_id)
 #  index_levels_on_game_id             (game_id)
 #  index_levels_on_name                (name)
+#  index_levels_on_template_level_id   (template_level_id)
 #
 
 class Bounce < Grid

--- a/dashboard/app/models/levels/bounce.rb
+++ b/dashboard/app/models/levels/bounce.rb
@@ -16,11 +16,13 @@
 #  published             :boolean          default(FALSE), not null
 #  notes                 :text(65535)
 #  audit_log             :text(65535)
+#  contained_level_id    :integer
 #
 # Indexes
 #
-#  index_levels_on_game_id  (game_id)
-#  index_levels_on_name     (name)
+#  index_levels_on_contained_level_id  (contained_level_id)
+#  index_levels_on_game_id             (game_id)
+#  index_levels_on_name                (name)
 #
 
 class Bounce < Grid

--- a/dashboard/app/models/levels/bubble_choice.rb
+++ b/dashboard/app/models/levels/bubble_choice.rb
@@ -17,12 +17,14 @@
 #  notes                 :text(65535)
 #  audit_log             :text(65535)
 #  contained_level_id    :integer
+#  template_level_id     :integer
 #
 # Indexes
 #
 #  index_levels_on_contained_level_id  (contained_level_id)
 #  index_levels_on_game_id             (game_id)
 #  index_levels_on_name                (name)
+#  index_levels_on_template_level_id   (template_level_id)
 #
 
 class BubbleChoice < DSLDefined

--- a/dashboard/app/models/levels/bubble_choice.rb
+++ b/dashboard/app/models/levels/bubble_choice.rb
@@ -16,11 +16,13 @@
 #  published             :boolean          default(FALSE), not null
 #  notes                 :text(65535)
 #  audit_log             :text(65535)
+#  contained_level_id    :integer
 #
 # Indexes
 #
-#  index_levels_on_game_id  (game_id)
-#  index_levels_on_name     (name)
+#  index_levels_on_contained_level_id  (contained_level_id)
+#  index_levels_on_game_id             (game_id)
+#  index_levels_on_name                (name)
 #
 
 class BubbleChoice < DSLDefined

--- a/dashboard/app/models/levels/calc.rb
+++ b/dashboard/app/models/levels/calc.rb
@@ -17,12 +17,14 @@
 #  notes                 :text(65535)
 #  audit_log             :text(65535)
 #  contained_level_id    :integer
+#  template_level_id     :integer
 #
 # Indexes
 #
 #  index_levels_on_contained_level_id  (contained_level_id)
 #  index_levels_on_game_id             (game_id)
 #  index_levels_on_name                (name)
+#  index_levels_on_template_level_id   (template_level_id)
 #
 
 class Calc < Blockly

--- a/dashboard/app/models/levels/calc.rb
+++ b/dashboard/app/models/levels/calc.rb
@@ -16,11 +16,13 @@
 #  published             :boolean          default(FALSE), not null
 #  notes                 :text(65535)
 #  audit_log             :text(65535)
+#  contained_level_id    :integer
 #
 # Indexes
 #
-#  index_levels_on_game_id  (game_id)
-#  index_levels_on_name     (name)
+#  index_levels_on_contained_level_id  (contained_level_id)
+#  index_levels_on_game_id             (game_id)
+#  index_levels_on_name                (name)
 #
 
 class Calc < Blockly

--- a/dashboard/app/models/levels/contract_match.rb
+++ b/dashboard/app/models/levels/contract_match.rb
@@ -16,11 +16,13 @@
 #  published             :boolean          default(FALSE), not null
 #  notes                 :text(65535)
 #  audit_log             :text(65535)
+#  contained_level_id    :integer
 #
 # Indexes
 #
-#  index_levels_on_game_id  (game_id)
-#  index_levels_on_name     (name)
+#  index_levels_on_contained_level_id  (contained_level_id)
+#  index_levels_on_game_id             (game_id)
+#  index_levels_on_name                (name)
 #
 
 # Contract Match type.

--- a/dashboard/app/models/levels/contract_match.rb
+++ b/dashboard/app/models/levels/contract_match.rb
@@ -17,12 +17,14 @@
 #  notes                 :text(65535)
 #  audit_log             :text(65535)
 #  contained_level_id    :integer
+#  template_level_id     :integer
 #
 # Indexes
 #
 #  index_levels_on_contained_level_id  (contained_level_id)
 #  index_levels_on_game_id             (game_id)
 #  index_levels_on_name                (name)
+#  index_levels_on_template_level_id   (template_level_id)
 #
 
 # Contract Match type.

--- a/dashboard/app/models/levels/craft.rb
+++ b/dashboard/app/models/levels/craft.rb
@@ -17,12 +17,14 @@
 #  notes                 :text(65535)
 #  audit_log             :text(65535)
 #  contained_level_id    :integer
+#  template_level_id     :integer
 #
 # Indexes
 #
 #  index_levels_on_contained_level_id  (contained_level_id)
 #  index_levels_on_game_id             (game_id)
 #  index_levels_on_name                (name)
+#  index_levels_on_template_level_id   (template_level_id)
 #
 
 require "csv"

--- a/dashboard/app/models/levels/craft.rb
+++ b/dashboard/app/models/levels/craft.rb
@@ -16,11 +16,13 @@
 #  published             :boolean          default(FALSE), not null
 #  notes                 :text(65535)
 #  audit_log             :text(65535)
+#  contained_level_id    :integer
 #
 # Indexes
 #
-#  index_levels_on_game_id  (game_id)
-#  index_levels_on_name     (name)
+#  index_levels_on_contained_level_id  (contained_level_id)
+#  index_levels_on_game_id             (game_id)
+#  index_levels_on_name                (name)
 #
 
 require "csv"

--- a/dashboard/app/models/levels/curriculum_reference.rb
+++ b/dashboard/app/models/levels/curriculum_reference.rb
@@ -17,12 +17,14 @@
 #  notes                 :text(65535)
 #  audit_log             :text(65535)
 #  contained_level_id    :integer
+#  template_level_id     :integer
 #
 # Indexes
 #
 #  index_levels_on_contained_level_id  (contained_level_id)
 #  index_levels_on_game_id             (game_id)
 #  index_levels_on_name                (name)
+#  index_levels_on_template_level_id   (template_level_id)
 #
 
 class CurriculumReference < Level

--- a/dashboard/app/models/levels/curriculum_reference.rb
+++ b/dashboard/app/models/levels/curriculum_reference.rb
@@ -16,11 +16,13 @@
 #  published             :boolean          default(FALSE), not null
 #  notes                 :text(65535)
 #  audit_log             :text(65535)
+#  contained_level_id    :integer
 #
 # Indexes
 #
-#  index_levels_on_game_id  (game_id)
-#  index_levels_on_name     (name)
+#  index_levels_on_contained_level_id  (contained_level_id)
+#  index_levels_on_game_id             (game_id)
+#  index_levels_on_name                (name)
 #
 
 class CurriculumReference < Level

--- a/dashboard/app/models/levels/dancelab.rb
+++ b/dashboard/app/models/levels/dancelab.rb
@@ -16,11 +16,13 @@
 #  published             :boolean          default(FALSE), not null
 #  notes                 :text(65535)
 #  audit_log             :text(65535)
+#  contained_level_id    :integer
 #
 # Indexes
 #
-#  index_levels_on_game_id  (game_id)
-#  index_levels_on_name     (name)
+#  index_levels_on_contained_level_id  (contained_level_id)
+#  index_levels_on_game_id             (game_id)
+#  index_levels_on_name                (name)
 #
 
 class Dancelab < GamelabJr

--- a/dashboard/app/models/levels/dancelab.rb
+++ b/dashboard/app/models/levels/dancelab.rb
@@ -17,12 +17,14 @@
 #  notes                 :text(65535)
 #  audit_log             :text(65535)
 #  contained_level_id    :integer
+#  template_level_id     :integer
 #
 # Indexes
 #
 #  index_levels_on_contained_level_id  (contained_level_id)
 #  index_levels_on_game_id             (game_id)
 #  index_levels_on_name                (name)
+#  index_levels_on_template_level_id   (template_level_id)
 #
 
 class Dancelab < GamelabJr

--- a/dashboard/app/models/levels/dsl_defined.rb
+++ b/dashboard/app/models/levels/dsl_defined.rb
@@ -16,11 +16,13 @@
 #  published             :boolean          default(FALSE), not null
 #  notes                 :text(65535)
 #  audit_log             :text(65535)
+#  contained_level_id    :integer
 #
 # Indexes
 #
-#  index_levels_on_game_id  (game_id)
-#  index_levels_on_name     (name)
+#  index_levels_on_contained_level_id  (contained_level_id)
+#  index_levels_on_game_id             (game_id)
+#  index_levels_on_name                (name)
 #
 
 require 'cdo/script_constants'

--- a/dashboard/app/models/levels/dsl_defined.rb
+++ b/dashboard/app/models/levels/dsl_defined.rb
@@ -17,12 +17,14 @@
 #  notes                 :text(65535)
 #  audit_log             :text(65535)
 #  contained_level_id    :integer
+#  template_level_id     :integer
 #
 # Indexes
 #
 #  index_levels_on_contained_level_id  (contained_level_id)
 #  index_levels_on_game_id             (game_id)
 #  index_levels_on_name                (name)
+#  index_levels_on_template_level_id   (template_level_id)
 #
 
 require 'cdo/script_constants'

--- a/dashboard/app/models/levels/eval.rb
+++ b/dashboard/app/models/levels/eval.rb
@@ -17,12 +17,14 @@
 #  notes                 :text(65535)
 #  audit_log             :text(65535)
 #  contained_level_id    :integer
+#  template_level_id     :integer
 #
 # Indexes
 #
 #  index_levels_on_contained_level_id  (contained_level_id)
 #  index_levels_on_game_id             (game_id)
 #  index_levels_on_name                (name)
+#  index_levels_on_template_level_id   (template_level_id)
 #
 
 class Eval < Blockly

--- a/dashboard/app/models/levels/eval.rb
+++ b/dashboard/app/models/levels/eval.rb
@@ -16,11 +16,13 @@
 #  published             :boolean          default(FALSE), not null
 #  notes                 :text(65535)
 #  audit_log             :text(65535)
+#  contained_level_id    :integer
 #
 # Indexes
 #
-#  index_levels_on_game_id  (game_id)
-#  index_levels_on_name     (name)
+#  index_levels_on_contained_level_id  (contained_level_id)
+#  index_levels_on_game_id             (game_id)
+#  index_levels_on_name                (name)
 #
 
 class Eval < Blockly

--- a/dashboard/app/models/levels/evaluation_multi.rb
+++ b/dashboard/app/models/levels/evaluation_multi.rb
@@ -17,12 +17,14 @@
 #  notes                 :text(65535)
 #  audit_log             :text(65535)
 #  contained_level_id    :integer
+#  template_level_id     :integer
 #
 # Indexes
 #
 #  index_levels_on_contained_level_id  (contained_level_id)
 #  index_levels_on_game_id             (game_id)
 #  index_levels_on_name                (name)
+#  index_levels_on_template_level_id   (template_level_id)
 #
 
 class EvaluationMulti < Multi

--- a/dashboard/app/models/levels/evaluation_multi.rb
+++ b/dashboard/app/models/levels/evaluation_multi.rb
@@ -16,11 +16,13 @@
 #  published             :boolean          default(FALSE), not null
 #  notes                 :text(65535)
 #  audit_log             :text(65535)
+#  contained_level_id    :integer
 #
 # Indexes
 #
-#  index_levels_on_game_id  (game_id)
-#  index_levels_on_name     (name)
+#  index_levels_on_contained_level_id  (contained_level_id)
+#  index_levels_on_game_id             (game_id)
+#  index_levels_on_name                (name)
 #
 
 class EvaluationMulti < Multi

--- a/dashboard/app/models/levels/external.rb
+++ b/dashboard/app/models/levels/external.rb
@@ -17,12 +17,14 @@
 #  notes                 :text(65535)
 #  audit_log             :text(65535)
 #  contained_level_id    :integer
+#  template_level_id     :integer
 #
 # Indexes
 #
 #  index_levels_on_contained_level_id  (contained_level_id)
 #  index_levels_on_game_id             (game_id)
 #  index_levels_on_name                (name)
+#  index_levels_on_template_level_id   (template_level_id)
 #
 
 class External < DSLDefined

--- a/dashboard/app/models/levels/external.rb
+++ b/dashboard/app/models/levels/external.rb
@@ -16,11 +16,13 @@
 #  published             :boolean          default(FALSE), not null
 #  notes                 :text(65535)
 #  audit_log             :text(65535)
+#  contained_level_id    :integer
 #
 # Indexes
 #
-#  index_levels_on_game_id  (game_id)
-#  index_levels_on_name     (name)
+#  index_levels_on_contained_level_id  (contained_level_id)
+#  index_levels_on_game_id             (game_id)
+#  index_levels_on_name                (name)
 #
 
 class External < DSLDefined

--- a/dashboard/app/models/levels/external_link.rb
+++ b/dashboard/app/models/levels/external_link.rb
@@ -16,11 +16,13 @@
 #  published             :boolean          default(FALSE), not null
 #  notes                 :text(65535)
 #  audit_log             :text(65535)
+#  contained_level_id    :integer
 #
 # Indexes
 #
-#  index_levels_on_game_id  (game_id)
-#  index_levels_on_name     (name)
+#  index_levels_on_contained_level_id  (contained_level_id)
+#  index_levels_on_game_id             (game_id)
+#  index_levels_on_name                (name)
 #
 
 class ExternalLink < Level

--- a/dashboard/app/models/levels/external_link.rb
+++ b/dashboard/app/models/levels/external_link.rb
@@ -17,12 +17,14 @@
 #  notes                 :text(65535)
 #  audit_log             :text(65535)
 #  contained_level_id    :integer
+#  template_level_id     :integer
 #
 # Indexes
 #
 #  index_levels_on_contained_level_id  (contained_level_id)
 #  index_levels_on_game_id             (game_id)
 #  index_levels_on_name                (name)
+#  index_levels_on_template_level_id   (template_level_id)
 #
 
 class ExternalLink < Level

--- a/dashboard/app/models/levels/fish.rb
+++ b/dashboard/app/models/levels/fish.rb
@@ -16,11 +16,13 @@
 #  published             :boolean          default(FALSE), not null
 #  notes                 :text(65535)
 #  audit_log             :text(65535)
+#  contained_level_id    :integer
 #
 # Indexes
 #
-#  index_levels_on_game_id  (game_id)
-#  index_levels_on_name     (name)
+#  index_levels_on_contained_level_id  (contained_level_id)
+#  index_levels_on_game_id             (game_id)
+#  index_levels_on_name                (name)
 #
 
 class Fish < Level

--- a/dashboard/app/models/levels/fish.rb
+++ b/dashboard/app/models/levels/fish.rb
@@ -17,12 +17,14 @@
 #  notes                 :text(65535)
 #  audit_log             :text(65535)
 #  contained_level_id    :integer
+#  template_level_id     :integer
 #
 # Indexes
 #
 #  index_levels_on_contained_level_id  (contained_level_id)
 #  index_levels_on_game_id             (game_id)
 #  index_levels_on_name                (name)
+#  index_levels_on_template_level_id   (template_level_id)
 #
 
 class Fish < Level

--- a/dashboard/app/models/levels/flappy.rb
+++ b/dashboard/app/models/levels/flappy.rb
@@ -17,12 +17,14 @@
 #  notes                 :text(65535)
 #  audit_log             :text(65535)
 #  contained_level_id    :integer
+#  template_level_id     :integer
 #
 # Indexes
 #
 #  index_levels_on_contained_level_id  (contained_level_id)
 #  index_levels_on_game_id             (game_id)
 #  index_levels_on_name                (name)
+#  index_levels_on_template_level_id   (template_level_id)
 #
 
 class Flappy < Blockly

--- a/dashboard/app/models/levels/flappy.rb
+++ b/dashboard/app/models/levels/flappy.rb
@@ -16,11 +16,13 @@
 #  published             :boolean          default(FALSE), not null
 #  notes                 :text(65535)
 #  audit_log             :text(65535)
+#  contained_level_id    :integer
 #
 # Indexes
 #
-#  index_levels_on_game_id  (game_id)
-#  index_levels_on_name     (name)
+#  index_levels_on_contained_level_id  (contained_level_id)
+#  index_levels_on_game_id             (game_id)
+#  index_levels_on_name                (name)
 #
 
 class Flappy < Blockly

--- a/dashboard/app/models/levels/free_response.rb
+++ b/dashboard/app/models/levels/free_response.rb
@@ -17,12 +17,14 @@
 #  notes                 :text(65535)
 #  audit_log             :text(65535)
 #  contained_level_id    :integer
+#  template_level_id     :integer
 #
 # Indexes
 #
 #  index_levels_on_contained_level_id  (contained_level_id)
 #  index_levels_on_game_id             (game_id)
 #  index_levels_on_name                (name)
+#  index_levels_on_template_level_id   (template_level_id)
 #
 
 class FreeResponse < Level

--- a/dashboard/app/models/levels/free_response.rb
+++ b/dashboard/app/models/levels/free_response.rb
@@ -16,11 +16,13 @@
 #  published             :boolean          default(FALSE), not null
 #  notes                 :text(65535)
 #  audit_log             :text(65535)
+#  contained_level_id    :integer
 #
 # Indexes
 #
-#  index_levels_on_game_id  (game_id)
-#  index_levels_on_name     (name)
+#  index_levels_on_contained_level_id  (contained_level_id)
+#  index_levels_on_game_id             (game_id)
+#  index_levels_on_name                (name)
 #
 
 class FreeResponse < Level

--- a/dashboard/app/models/levels/frequency_analysis.rb
+++ b/dashboard/app/models/levels/frequency_analysis.rb
@@ -17,12 +17,14 @@
 #  notes                 :text(65535)
 #  audit_log             :text(65535)
 #  contained_level_id    :integer
+#  template_level_id     :integer
 #
 # Indexes
 #
 #  index_levels_on_contained_level_id  (contained_level_id)
 #  index_levels_on_game_id             (game_id)
 #  index_levels_on_name                (name)
+#  index_levels_on_template_level_id   (template_level_id)
 #
 
 class FrequencyAnalysis < Widget

--- a/dashboard/app/models/levels/frequency_analysis.rb
+++ b/dashboard/app/models/levels/frequency_analysis.rb
@@ -16,11 +16,13 @@
 #  published             :boolean          default(FALSE), not null
 #  notes                 :text(65535)
 #  audit_log             :text(65535)
+#  contained_level_id    :integer
 #
 # Indexes
 #
-#  index_levels_on_game_id  (game_id)
-#  index_levels_on_name     (name)
+#  index_levels_on_contained_level_id  (contained_level_id)
+#  index_levels_on_game_id             (game_id)
+#  index_levels_on_name                (name)
 #
 
 class FrequencyAnalysis < Widget

--- a/dashboard/app/models/levels/gamelab.rb
+++ b/dashboard/app/models/levels/gamelab.rb
@@ -16,11 +16,13 @@
 #  published             :boolean          default(FALSE), not null
 #  notes                 :text(65535)
 #  audit_log             :text(65535)
+#  contained_level_id    :integer
 #
 # Indexes
 #
-#  index_levels_on_game_id  (game_id)
-#  index_levels_on_name     (name)
+#  index_levels_on_contained_level_id  (contained_level_id)
+#  index_levels_on_game_id             (game_id)
+#  index_levels_on_name                (name)
 #
 
 require 'cdo/shared_constants'

--- a/dashboard/app/models/levels/gamelab.rb
+++ b/dashboard/app/models/levels/gamelab.rb
@@ -17,12 +17,14 @@
 #  notes                 :text(65535)
 #  audit_log             :text(65535)
 #  contained_level_id    :integer
+#  template_level_id     :integer
 #
 # Indexes
 #
 #  index_levels_on_contained_level_id  (contained_level_id)
 #  index_levels_on_game_id             (game_id)
 #  index_levels_on_name                (name)
+#  index_levels_on_template_level_id   (template_level_id)
 #
 
 require 'cdo/shared_constants'

--- a/dashboard/app/models/levels/gamelab_jr.rb
+++ b/dashboard/app/models/levels/gamelab_jr.rb
@@ -16,11 +16,13 @@
 #  published             :boolean          default(FALSE), not null
 #  notes                 :text(65535)
 #  audit_log             :text(65535)
+#  contained_level_id    :integer
 #
 # Indexes
 #
-#  index_levels_on_game_id  (game_id)
-#  index_levels_on_name     (name)
+#  index_levels_on_contained_level_id  (contained_level_id)
+#  index_levels_on_game_id             (game_id)
+#  index_levels_on_name                (name)
 #
 
 class GamelabJr < Gamelab

--- a/dashboard/app/models/levels/gamelab_jr.rb
+++ b/dashboard/app/models/levels/gamelab_jr.rb
@@ -17,12 +17,14 @@
 #  notes                 :text(65535)
 #  audit_log             :text(65535)
 #  contained_level_id    :integer
+#  template_level_id     :integer
 #
 # Indexes
 #
 #  index_levels_on_contained_level_id  (contained_level_id)
 #  index_levels_on_game_id             (game_id)
 #  index_levels_on_name                (name)
+#  index_levels_on_template_level_id   (template_level_id)
 #
 
 class GamelabJr < Gamelab

--- a/dashboard/app/models/levels/go_beyond.rb
+++ b/dashboard/app/models/levels/go_beyond.rb
@@ -16,11 +16,13 @@
 #  published             :boolean          default(FALSE), not null
 #  notes                 :text(65535)
 #  audit_log             :text(65535)
+#  contained_level_id    :integer
 #
 # Indexes
 #
-#  index_levels_on_game_id  (game_id)
-#  index_levels_on_name     (name)
+#  index_levels_on_contained_level_id  (contained_level_id)
+#  index_levels_on_game_id             (game_id)
+#  index_levels_on_name                (name)
 #
 
 class GoBeyond < Level

--- a/dashboard/app/models/levels/go_beyond.rb
+++ b/dashboard/app/models/levels/go_beyond.rb
@@ -17,12 +17,14 @@
 #  notes                 :text(65535)
 #  audit_log             :text(65535)
 #  contained_level_id    :integer
+#  template_level_id     :integer
 #
 # Indexes
 #
 #  index_levels_on_contained_level_id  (contained_level_id)
 #  index_levels_on_game_id             (game_id)
 #  index_levels_on_name                (name)
+#  index_levels_on_template_level_id   (template_level_id)
 #
 
 class GoBeyond < Level

--- a/dashboard/app/models/levels/grid.rb
+++ b/dashboard/app/models/levels/grid.rb
@@ -17,12 +17,14 @@
 #  notes                 :text(65535)
 #  audit_log             :text(65535)
 #  contained_level_id    :integer
+#  template_level_id     :integer
 #
 # Indexes
 #
 #  index_levels_on_contained_level_id  (contained_level_id)
 #  index_levels_on_game_id             (game_id)
 #  index_levels_on_name                (name)
+#  index_levels_on_template_level_id   (template_level_id)
 #
 
 require "csv"

--- a/dashboard/app/models/levels/grid.rb
+++ b/dashboard/app/models/levels/grid.rb
@@ -16,11 +16,13 @@
 #  published             :boolean          default(FALSE), not null
 #  notes                 :text(65535)
 #  audit_log             :text(65535)
+#  contained_level_id    :integer
 #
 # Indexes
 #
-#  index_levels_on_game_id  (game_id)
-#  index_levels_on_name     (name)
+#  index_levels_on_contained_level_id  (contained_level_id)
+#  index_levels_on_game_id             (game_id)
+#  index_levels_on_name                (name)
 #
 
 require "csv"

--- a/dashboard/app/models/levels/karel.rb
+++ b/dashboard/app/models/levels/karel.rb
@@ -16,11 +16,13 @@
 #  published             :boolean          default(FALSE), not null
 #  notes                 :text(65535)
 #  audit_log             :text(65535)
+#  contained_level_id    :integer
 #
 # Indexes
 #
-#  index_levels_on_game_id  (game_id)
-#  index_levels_on_name     (name)
+#  index_levels_on_contained_level_id  (contained_level_id)
+#  index_levels_on_game_id             (game_id)
+#  index_levels_on_name                (name)
 #
 
 class Karel < Maze

--- a/dashboard/app/models/levels/karel.rb
+++ b/dashboard/app/models/levels/karel.rb
@@ -17,12 +17,14 @@
 #  notes                 :text(65535)
 #  audit_log             :text(65535)
 #  contained_level_id    :integer
+#  template_level_id     :integer
 #
 # Indexes
 #
 #  index_levels_on_contained_level_id  (contained_level_id)
 #  index_levels_on_game_id             (game_id)
 #  index_levels_on_name                (name)
+#  index_levels_on_template_level_id   (template_level_id)
 #
 
 class Karel < Maze

--- a/dashboard/app/models/levels/level.rb
+++ b/dashboard/app/models/levels/level.rb
@@ -17,12 +17,14 @@
 #  notes                 :text(65535)
 #  audit_log             :text(65535)
 #  contained_level_id    :integer
+#  template_level_id     :integer
 #
 # Indexes
 #
 #  index_levels_on_contained_level_id  (contained_level_id)
 #  index_levels_on_game_id             (game_id)
 #  index_levels_on_name                (name)
+#  index_levels_on_template_level_id   (template_level_id)
 #
 
 class Level < ActiveRecord::Base

--- a/dashboard/app/models/levels/level.rb
+++ b/dashboard/app/models/levels/level.rb
@@ -101,18 +101,19 @@ class Level < ActiveRecord::Base
     thumbnail_url
   )
 
-  # returns all levels which depend on this level in order to function properly,
-  # including itself. This implementation relies on the assumption that the
+  # returns all levels which depend on this level in order to function properly.
+  # This implementation relies on the assumption that the
   # hierarchy of levels is only one layer deep, meaning:
   # 1. parent levels do not themselves have any parent levels or containing levels
   # 2. containing levels do not themselves have any containing levels or parent levels
-  def all_depending_levels
-    self + parent_levels + containing_levels
+  def all_parent_levels
+    parent_levels + containing_levels + template_backed_levels
   end
 
   # returns all scripts which depend on this level.
   def all_scripts
-    script_levels = all_depending_levels.map(&:script_levels).flatten
+    levels = self + all_parent_levels
+    script_levels = levels.map(&:script_levels).flatten
     script_levels.map(&:script).uniq
   end
 

--- a/dashboard/app/models/levels/level.rb
+++ b/dashboard/app/models/levels/level.rb
@@ -45,6 +45,9 @@ class Level < ActiveRecord::Base
   has_many :levels_child_levels, class_name: 'ParentLevelsChildLevel', foreign_key: :parent_level_id
   has_many :child_levels, through: :levels_child_levels, inverse_of: :parent_levels
 
+  belongs_to :contained_level, class_name: 'Level', inverse_of: :containing_levels
+  has_many :containing_levels, class_name: 'Level', foreign_key: :contained_level_id, inverse_of: :contained_level
+
   before_validation :strip_name
   before_destroy :remove_empty_script_levels
 

--- a/dashboard/app/models/levels/level.rb
+++ b/dashboard/app/models/levels/level.rb
@@ -50,6 +50,13 @@ class Level < ActiveRecord::Base
   belongs_to :contained_level, class_name: 'Level', inverse_of: :containing_levels
   has_many :containing_levels, class_name: 'Level', foreign_key: :contained_level_id, inverse_of: :contained_level
 
+  # Terminology: When a set of levels need to share start code and source code,
+  # this is implemented by having them share a template level. A level which has
+  # a template level is called a template-backed level.
+
+  belongs_to :template_level, class_name: 'Level', inverse_of: :template_backed_levels
+  has_many :template_backed_levels, class_name: 'Level', foreign_key: :template_level_id, inverse_of: :template_level
+
   before_validation :strip_name
   before_destroy :remove_empty_script_levels
 

--- a/dashboard/app/models/levels/level.rb
+++ b/dashboard/app/models/levels/level.rb
@@ -92,6 +92,21 @@ class Level < ActiveRecord::Base
     thumbnail_url
   )
 
+  # returns all levels which depend on this level in order to function properly,
+  # including itself. This implementation relies on the assumption that the
+  # hierarchy of levels is only one layer deep, meaning:
+  # 1. parent levels do not themselves have any parent levels or containing levels
+  # 2. containing levels do not themselves have any containing levels or parent levels
+  def all_depending_levels
+    self + parent_levels + containing_levels
+  end
+
+  # returns all scripts which depend on this level.
+  def all_scripts
+    script_levels = all_depending_levels.map(&:script_levels).flatten
+    script_levels.map(&:script).uniq
+  end
+
   # Fix STI routing http://stackoverflow.com/a/9463495
   def self.model_name
     self < Level ? Level.model_name : super

--- a/dashboard/app/models/levels/level.rb
+++ b/dashboard/app/models/levels/level.rb
@@ -16,11 +16,13 @@
 #  published             :boolean          default(FALSE), not null
 #  notes                 :text(65535)
 #  audit_log             :text(65535)
+#  contained_level_id    :integer
 #
 # Indexes
 #
-#  index_levels_on_game_id  (game_id)
-#  index_levels_on_name     (name)
+#  index_levels_on_contained_level_id  (contained_level_id)
+#  index_levels_on_game_id             (game_id)
+#  index_levels_on_name                (name)
 #
 
 class Level < ActiveRecord::Base

--- a/dashboard/app/models/levels/level_group.rb
+++ b/dashboard/app/models/levels/level_group.rb
@@ -17,12 +17,14 @@
 #  notes                 :text(65535)
 #  audit_log             :text(65535)
 #  contained_level_id    :integer
+#  template_level_id     :integer
 #
 # Indexes
 #
 #  index_levels_on_contained_level_id  (contained_level_id)
 #  index_levels_on_game_id             (game_id)
 #  index_levels_on_name                (name)
+#  index_levels_on_template_level_id   (template_level_id)
 #
 
 class LevelGroup < DSLDefined

--- a/dashboard/app/models/levels/level_group.rb
+++ b/dashboard/app/models/levels/level_group.rb
@@ -16,11 +16,13 @@
 #  published             :boolean          default(FALSE), not null
 #  notes                 :text(65535)
 #  audit_log             :text(65535)
+#  contained_level_id    :integer
 #
 # Indexes
 #
-#  index_levels_on_game_id  (game_id)
-#  index_levels_on_name     (name)
+#  index_levels_on_contained_level_id  (contained_level_id)
+#  index_levels_on_game_id             (game_id)
+#  index_levels_on_name                (name)
 #
 
 class LevelGroup < DSLDefined

--- a/dashboard/app/models/levels/map.rb
+++ b/dashboard/app/models/levels/map.rb
@@ -17,12 +17,14 @@
 #  notes                 :text(65535)
 #  audit_log             :text(65535)
 #  contained_level_id    :integer
+#  template_level_id     :integer
 #
 # Indexes
 #
 #  index_levels_on_contained_level_id  (contained_level_id)
 #  index_levels_on_game_id             (game_id)
 #  index_levels_on_name                (name)
+#  index_levels_on_template_level_id   (template_level_id)
 #
 
 class Map < CurriculumReference

--- a/dashboard/app/models/levels/map.rb
+++ b/dashboard/app/models/levels/map.rb
@@ -16,11 +16,13 @@
 #  published             :boolean          default(FALSE), not null
 #  notes                 :text(65535)
 #  audit_log             :text(65535)
+#  contained_level_id    :integer
 #
 # Indexes
 #
-#  index_levels_on_game_id  (game_id)
-#  index_levels_on_name     (name)
+#  index_levels_on_contained_level_id  (contained_level_id)
+#  index_levels_on_game_id             (game_id)
+#  index_levels_on_name                (name)
 #
 
 class Map < CurriculumReference

--- a/dashboard/app/models/levels/match.rb
+++ b/dashboard/app/models/levels/match.rb
@@ -16,11 +16,13 @@
 #  published             :boolean          default(FALSE), not null
 #  notes                 :text(65535)
 #  audit_log             :text(65535)
+#  contained_level_id    :integer
 #
 # Indexes
 #
-#  index_levels_on_game_id  (game_id)
-#  index_levels_on_name     (name)
+#  index_levels_on_contained_level_id  (contained_level_id)
+#  index_levels_on_game_id             (game_id)
+#  index_levels_on_name                (name)
 #
 
 class Match < DSLDefined

--- a/dashboard/app/models/levels/match.rb
+++ b/dashboard/app/models/levels/match.rb
@@ -17,12 +17,14 @@
 #  notes                 :text(65535)
 #  audit_log             :text(65535)
 #  contained_level_id    :integer
+#  template_level_id     :integer
 #
 # Indexes
 #
 #  index_levels_on_contained_level_id  (contained_level_id)
 #  index_levels_on_game_id             (game_id)
 #  index_levels_on_name                (name)
+#  index_levels_on_template_level_id   (template_level_id)
 #
 
 class Match < DSLDefined

--- a/dashboard/app/models/levels/maze.rb
+++ b/dashboard/app/models/levels/maze.rb
@@ -17,12 +17,14 @@
 #  notes                 :text(65535)
 #  audit_log             :text(65535)
 #  contained_level_id    :integer
+#  template_level_id     :integer
 #
 # Indexes
 #
 #  index_levels_on_contained_level_id  (contained_level_id)
 #  index_levels_on_game_id             (game_id)
 #  index_levels_on_name                (name)
+#  index_levels_on_template_level_id   (template_level_id)
 #
 
 class Maze < Grid

--- a/dashboard/app/models/levels/maze.rb
+++ b/dashboard/app/models/levels/maze.rb
@@ -16,11 +16,13 @@
 #  published             :boolean          default(FALSE), not null
 #  notes                 :text(65535)
 #  audit_log             :text(65535)
+#  contained_level_id    :integer
 #
 # Indexes
 #
-#  index_levels_on_game_id  (game_id)
-#  index_levels_on_name     (name)
+#  index_levels_on_contained_level_id  (contained_level_id)
+#  index_levels_on_game_id             (game_id)
+#  index_levels_on_name                (name)
 #
 
 class Maze < Grid

--- a/dashboard/app/models/levels/multi.rb
+++ b/dashboard/app/models/levels/multi.rb
@@ -17,12 +17,14 @@
 #  notes                 :text(65535)
 #  audit_log             :text(65535)
 #  contained_level_id    :integer
+#  template_level_id     :integer
 #
 # Indexes
 #
 #  index_levels_on_contained_level_id  (contained_level_id)
 #  index_levels_on_game_id             (game_id)
 #  index_levels_on_name                (name)
+#  index_levels_on_template_level_id   (template_level_id)
 #
 
 require "csv"

--- a/dashboard/app/models/levels/multi.rb
+++ b/dashboard/app/models/levels/multi.rb
@@ -16,11 +16,13 @@
 #  published             :boolean          default(FALSE), not null
 #  notes                 :text(65535)
 #  audit_log             :text(65535)
+#  contained_level_id    :integer
 #
 # Indexes
 #
-#  index_levels_on_game_id  (game_id)
-#  index_levels_on_name     (name)
+#  index_levels_on_contained_level_id  (contained_level_id)
+#  index_levels_on_game_id             (game_id)
+#  index_levels_on_name                (name)
 #
 
 require "csv"

--- a/dashboard/app/models/levels/net_sim.rb
+++ b/dashboard/app/models/levels/net_sim.rb
@@ -16,11 +16,13 @@
 #  published             :boolean          default(FALSE), not null
 #  notes                 :text(65535)
 #  audit_log             :text(65535)
+#  contained_level_id    :integer
 #
 # Indexes
 #
-#  index_levels_on_game_id  (game_id)
-#  index_levels_on_name     (name)
+#  index_levels_on_contained_level_id  (contained_level_id)
+#  index_levels_on_game_id             (game_id)
+#  index_levels_on_name                (name)
 #
 
 class NetSim < Blockly

--- a/dashboard/app/models/levels/net_sim.rb
+++ b/dashboard/app/models/levels/net_sim.rb
@@ -17,12 +17,14 @@
 #  notes                 :text(65535)
 #  audit_log             :text(65535)
 #  contained_level_id    :integer
+#  template_level_id     :integer
 #
 # Indexes
 #
 #  index_levels_on_contained_level_id  (contained_level_id)
 #  index_levels_on_game_id             (game_id)
 #  index_levels_on_name                (name)
+#  index_levels_on_template_level_id   (template_level_id)
 #
 
 class NetSim < Blockly

--- a/dashboard/app/models/levels/odometer.rb
+++ b/dashboard/app/models/levels/odometer.rb
@@ -16,11 +16,13 @@
 #  published             :boolean          default(FALSE), not null
 #  notes                 :text(65535)
 #  audit_log             :text(65535)
+#  contained_level_id    :integer
 #
 # Indexes
 #
-#  index_levels_on_game_id  (game_id)
-#  index_levels_on_name     (name)
+#  index_levels_on_contained_level_id  (contained_level_id)
+#  index_levels_on_game_id             (game_id)
+#  index_levels_on_name                (name)
 #
 
 class Odometer < Widget

--- a/dashboard/app/models/levels/odometer.rb
+++ b/dashboard/app/models/levels/odometer.rb
@@ -17,12 +17,14 @@
 #  notes                 :text(65535)
 #  audit_log             :text(65535)
 #  contained_level_id    :integer
+#  template_level_id     :integer
 #
 # Indexes
 #
 #  index_levels_on_contained_level_id  (contained_level_id)
 #  index_levels_on_game_id             (game_id)
 #  index_levels_on_name                (name)
+#  index_levels_on_template_level_id   (template_level_id)
 #
 
 class Odometer < Widget

--- a/dashboard/app/models/levels/pixelation.rb
+++ b/dashboard/app/models/levels/pixelation.rb
@@ -17,12 +17,14 @@
 #  notes                 :text(65535)
 #  audit_log             :text(65535)
 #  contained_level_id    :integer
+#  template_level_id     :integer
 #
 # Indexes
 #
 #  index_levels_on_contained_level_id  (contained_level_id)
 #  index_levels_on_game_id             (game_id)
 #  index_levels_on_name                (name)
+#  index_levels_on_template_level_id   (template_level_id)
 #
 
 class Pixelation < Widget

--- a/dashboard/app/models/levels/pixelation.rb
+++ b/dashboard/app/models/levels/pixelation.rb
@@ -16,11 +16,13 @@
 #  published             :boolean          default(FALSE), not null
 #  notes                 :text(65535)
 #  audit_log             :text(65535)
+#  contained_level_id    :integer
 #
 # Indexes
 #
-#  index_levels_on_game_id  (game_id)
-#  index_levels_on_name     (name)
+#  index_levels_on_contained_level_id  (contained_level_id)
+#  index_levels_on_game_id             (game_id)
+#  index_levels_on_name                (name)
 #
 
 class Pixelation < Widget

--- a/dashboard/app/models/levels/public_key_cryptography.rb
+++ b/dashboard/app/models/levels/public_key_cryptography.rb
@@ -17,12 +17,14 @@
 #  notes                 :text(65535)
 #  audit_log             :text(65535)
 #  contained_level_id    :integer
+#  template_level_id     :integer
 #
 # Indexes
 #
 #  index_levels_on_contained_level_id  (contained_level_id)
 #  index_levels_on_game_id             (game_id)
 #  index_levels_on_name                (name)
+#  index_levels_on_template_level_id   (template_level_id)
 #
 
 # Level type for standalone widget teaching public key cryptography

--- a/dashboard/app/models/levels/public_key_cryptography.rb
+++ b/dashboard/app/models/levels/public_key_cryptography.rb
@@ -16,11 +16,13 @@
 #  published             :boolean          default(FALSE), not null
 #  notes                 :text(65535)
 #  audit_log             :text(65535)
+#  contained_level_id    :integer
 #
 # Indexes
 #
-#  index_levels_on_game_id  (game_id)
-#  index_levels_on_name     (name)
+#  index_levels_on_contained_level_id  (contained_level_id)
+#  index_levels_on_game_id             (game_id)
+#  index_levels_on_name                (name)
 #
 
 # Level type for standalone widget teaching public key cryptography

--- a/dashboard/app/models/levels/scratch.rb
+++ b/dashboard/app/models/levels/scratch.rb
@@ -17,12 +17,14 @@
 #  notes                 :text(65535)
 #  audit_log             :text(65535)
 #  contained_level_id    :integer
+#  template_level_id     :integer
 #
 # Indexes
 #
 #  index_levels_on_contained_level_id  (contained_level_id)
 #  index_levels_on_game_id             (game_id)
 #  index_levels_on_name                (name)
+#  index_levels_on_template_level_id   (template_level_id)
 #
 
 class Scratch < Level

--- a/dashboard/app/models/levels/scratch.rb
+++ b/dashboard/app/models/levels/scratch.rb
@@ -16,11 +16,13 @@
 #  published             :boolean          default(FALSE), not null
 #  notes                 :text(65535)
 #  audit_log             :text(65535)
+#  contained_level_id    :integer
 #
 # Indexes
 #
-#  index_levels_on_game_id  (game_id)
-#  index_levels_on_name     (name)
+#  index_levels_on_contained_level_id  (contained_level_id)
+#  index_levels_on_game_id             (game_id)
+#  index_levels_on_name                (name)
 #
 
 class Scratch < Level

--- a/dashboard/app/models/levels/script_completion.rb
+++ b/dashboard/app/models/levels/script_completion.rb
@@ -16,11 +16,13 @@
 #  published             :boolean          default(FALSE), not null
 #  notes                 :text(65535)
 #  audit_log             :text(65535)
+#  contained_level_id    :integer
 #
 # Indexes
 #
-#  index_levels_on_game_id  (game_id)
-#  index_levels_on_name     (name)
+#  index_levels_on_contained_level_id  (contained_level_id)
+#  index_levels_on_game_id             (game_id)
+#  index_levels_on_name                (name)
 #
 
 class ScriptCompletion < Level

--- a/dashboard/app/models/levels/script_completion.rb
+++ b/dashboard/app/models/levels/script_completion.rb
@@ -17,12 +17,14 @@
 #  notes                 :text(65535)
 #  audit_log             :text(65535)
 #  contained_level_id    :integer
+#  template_level_id     :integer
 #
 # Indexes
 #
 #  index_levels_on_contained_level_id  (contained_level_id)
 #  index_levels_on_game_id             (game_id)
 #  index_levels_on_name                (name)
+#  index_levels_on_template_level_id   (template_level_id)
 #
 
 class ScriptCompletion < Level

--- a/dashboard/app/models/levels/standalone_video.rb
+++ b/dashboard/app/models/levels/standalone_video.rb
@@ -16,11 +16,13 @@
 #  published             :boolean          default(FALSE), not null
 #  notes                 :text(65535)
 #  audit_log             :text(65535)
+#  contained_level_id    :integer
 #
 # Indexes
 #
-#  index_levels_on_game_id  (game_id)
-#  index_levels_on_name     (name)
+#  index_levels_on_contained_level_id  (contained_level_id)
+#  index_levels_on_game_id             (game_id)
+#  index_levels_on_name                (name)
 #
 
 class StandaloneVideo < Level

--- a/dashboard/app/models/levels/standalone_video.rb
+++ b/dashboard/app/models/levels/standalone_video.rb
@@ -17,12 +17,14 @@
 #  notes                 :text(65535)
 #  audit_log             :text(65535)
 #  contained_level_id    :integer
+#  template_level_id     :integer
 #
 # Indexes
 #
 #  index_levels_on_contained_level_id  (contained_level_id)
 #  index_levels_on_game_id             (game_id)
 #  index_levels_on_name                (name)
+#  index_levels_on_template_level_id   (template_level_id)
 #
 
 class StandaloneVideo < Level

--- a/dashboard/app/models/levels/star_wars_grid.rb
+++ b/dashboard/app/models/levels/star_wars_grid.rb
@@ -17,12 +17,14 @@
 #  notes                 :text(65535)
 #  audit_log             :text(65535)
 #  contained_level_id    :integer
+#  template_level_id     :integer
 #
 # Indexes
 #
 #  index_levels_on_contained_level_id  (contained_level_id)
 #  index_levels_on_game_id             (game_id)
 #  index_levels_on_name                (name)
+#  index_levels_on_template_level_id   (template_level_id)
 #
 
 class StarWarsGrid < Studio

--- a/dashboard/app/models/levels/star_wars_grid.rb
+++ b/dashboard/app/models/levels/star_wars_grid.rb
@@ -16,11 +16,13 @@
 #  published             :boolean          default(FALSE), not null
 #  notes                 :text(65535)
 #  audit_log             :text(65535)
+#  contained_level_id    :integer
 #
 # Indexes
 #
-#  index_levels_on_game_id  (game_id)
-#  index_levels_on_name     (name)
+#  index_levels_on_contained_level_id  (contained_level_id)
+#  index_levels_on_game_id             (game_id)
+#  index_levels_on_name                (name)
 #
 
 class StarWarsGrid < Studio

--- a/dashboard/app/models/levels/studio.rb
+++ b/dashboard/app/models/levels/studio.rb
@@ -17,12 +17,14 @@
 #  notes                 :text(65535)
 #  audit_log             :text(65535)
 #  contained_level_id    :integer
+#  template_level_id     :integer
 #
 # Indexes
 #
 #  index_levels_on_contained_level_id  (contained_level_id)
 #  index_levels_on_game_id             (game_id)
 #  index_levels_on_name                (name)
+#  index_levels_on_template_level_id   (template_level_id)
 #
 
 class Studio < Grid

--- a/dashboard/app/models/levels/studio.rb
+++ b/dashboard/app/models/levels/studio.rb
@@ -16,11 +16,13 @@
 #  published             :boolean          default(FALSE), not null
 #  notes                 :text(65535)
 #  audit_log             :text(65535)
+#  contained_level_id    :integer
 #
 # Indexes
 #
-#  index_levels_on_game_id  (game_id)
-#  index_levels_on_name     (name)
+#  index_levels_on_contained_level_id  (contained_level_id)
+#  index_levels_on_game_id             (game_id)
+#  index_levels_on_name                (name)
 #
 
 class Studio < Grid

--- a/dashboard/app/models/levels/studio_ec.rb
+++ b/dashboard/app/models/levels/studio_ec.rb
@@ -17,12 +17,14 @@
 #  notes                 :text(65535)
 #  audit_log             :text(65535)
 #  contained_level_id    :integer
+#  template_level_id     :integer
 #
 # Indexes
 #
 #  index_levels_on_contained_level_id  (contained_level_id)
 #  index_levels_on_game_id             (game_id)
 #  index_levels_on_name                (name)
+#  index_levels_on_template_level_id   (template_level_id)
 #
 
 class StudioEC < Studio

--- a/dashboard/app/models/levels/studio_ec.rb
+++ b/dashboard/app/models/levels/studio_ec.rb
@@ -16,11 +16,13 @@
 #  published             :boolean          default(FALSE), not null
 #  notes                 :text(65535)
 #  audit_log             :text(65535)
+#  contained_level_id    :integer
 #
 # Indexes
 #
-#  index_levels_on_game_id  (game_id)
-#  index_levels_on_name     (name)
+#  index_levels_on_contained_level_id  (contained_level_id)
+#  index_levels_on_game_id             (game_id)
+#  index_levels_on_name                (name)
 #
 
 class StudioEC < Studio

--- a/dashboard/app/models/levels/text_compression.rb
+++ b/dashboard/app/models/levels/text_compression.rb
@@ -17,12 +17,14 @@
 #  notes                 :text(65535)
 #  audit_log             :text(65535)
 #  contained_level_id    :integer
+#  template_level_id     :integer
 #
 # Indexes
 #
 #  index_levels_on_contained_level_id  (contained_level_id)
 #  index_levels_on_game_id             (game_id)
 #  index_levels_on_name                (name)
+#  index_levels_on_template_level_id   (template_level_id)
 #
 
 class TextCompression < Widget

--- a/dashboard/app/models/levels/text_compression.rb
+++ b/dashboard/app/models/levels/text_compression.rb
@@ -16,11 +16,13 @@
 #  published             :boolean          default(FALSE), not null
 #  notes                 :text(65535)
 #  audit_log             :text(65535)
+#  contained_level_id    :integer
 #
 # Indexes
 #
-#  index_levels_on_game_id  (game_id)
-#  index_levels_on_name     (name)
+#  index_levels_on_contained_level_id  (contained_level_id)
+#  index_levels_on_game_id             (game_id)
+#  index_levels_on_name                (name)
 #
 
 class TextCompression < Widget

--- a/dashboard/app/models/levels/text_match.rb
+++ b/dashboard/app/models/levels/text_match.rb
@@ -17,12 +17,14 @@
 #  notes                 :text(65535)
 #  audit_log             :text(65535)
 #  contained_level_id    :integer
+#  template_level_id     :integer
 #
 # Indexes
 #
 #  index_levels_on_contained_level_id  (contained_level_id)
 #  index_levels_on_game_id             (game_id)
 #  index_levels_on_name                (name)
+#  index_levels_on_template_level_id   (template_level_id)
 #
 
 # Text Match type.

--- a/dashboard/app/models/levels/text_match.rb
+++ b/dashboard/app/models/levels/text_match.rb
@@ -16,11 +16,13 @@
 #  published             :boolean          default(FALSE), not null
 #  notes                 :text(65535)
 #  audit_log             :text(65535)
+#  contained_level_id    :integer
 #
 # Indexes
 #
-#  index_levels_on_game_id  (game_id)
-#  index_levels_on_name     (name)
+#  index_levels_on_contained_level_id  (contained_level_id)
+#  index_levels_on_game_id             (game_id)
+#  index_levels_on_name                (name)
 #
 
 # Text Match type.

--- a/dashboard/app/models/levels/unplugged.rb
+++ b/dashboard/app/models/levels/unplugged.rb
@@ -16,11 +16,13 @@
 #  published             :boolean          default(FALSE), not null
 #  notes                 :text(65535)
 #  audit_log             :text(65535)
+#  contained_level_id    :integer
 #
 # Indexes
 #
-#  index_levels_on_game_id  (game_id)
-#  index_levels_on_name     (name)
+#  index_levels_on_contained_level_id  (contained_level_id)
+#  index_levels_on_game_id             (game_id)
+#  index_levels_on_name                (name)
 #
 
 class Unplugged < Level

--- a/dashboard/app/models/levels/unplugged.rb
+++ b/dashboard/app/models/levels/unplugged.rb
@@ -17,12 +17,14 @@
 #  notes                 :text(65535)
 #  audit_log             :text(65535)
 #  contained_level_id    :integer
+#  template_level_id     :integer
 #
 # Indexes
 #
 #  index_levels_on_contained_level_id  (contained_level_id)
 #  index_levels_on_game_id             (game_id)
 #  index_levels_on_name                (name)
+#  index_levels_on_template_level_id   (template_level_id)
 #
 
 class Unplugged < Level

--- a/dashboard/app/models/levels/vigenere.rb
+++ b/dashboard/app/models/levels/vigenere.rb
@@ -16,11 +16,13 @@
 #  published             :boolean          default(FALSE), not null
 #  notes                 :text(65535)
 #  audit_log             :text(65535)
+#  contained_level_id    :integer
 #
 # Indexes
 #
-#  index_levels_on_game_id  (game_id)
-#  index_levels_on_name     (name)
+#  index_levels_on_contained_level_id  (contained_level_id)
+#  index_levels_on_game_id             (game_id)
+#  index_levels_on_name                (name)
 #
 
 class Vigenere < Widget

--- a/dashboard/app/models/levels/vigenere.rb
+++ b/dashboard/app/models/levels/vigenere.rb
@@ -17,12 +17,14 @@
 #  notes                 :text(65535)
 #  audit_log             :text(65535)
 #  contained_level_id    :integer
+#  template_level_id     :integer
 #
 # Indexes
 #
 #  index_levels_on_contained_level_id  (contained_level_id)
 #  index_levels_on_game_id             (game_id)
 #  index_levels_on_name                (name)
+#  index_levels_on_template_level_id   (template_level_id)
 #
 
 class Vigenere < Widget

--- a/dashboard/app/models/levels/weblab.rb
+++ b/dashboard/app/models/levels/weblab.rb
@@ -17,12 +17,14 @@
 #  notes                 :text(65535)
 #  audit_log             :text(65535)
 #  contained_level_id    :integer
+#  template_level_id     :integer
 #
 # Indexes
 #
 #  index_levels_on_contained_level_id  (contained_level_id)
 #  index_levels_on_game_id             (game_id)
 #  index_levels_on_name                (name)
+#  index_levels_on_template_level_id   (template_level_id)
 #
 
 class Weblab < Level

--- a/dashboard/app/models/levels/weblab.rb
+++ b/dashboard/app/models/levels/weblab.rb
@@ -16,11 +16,13 @@
 #  published             :boolean          default(FALSE), not null
 #  notes                 :text(65535)
 #  audit_log             :text(65535)
+#  contained_level_id    :integer
 #
 # Indexes
 #
-#  index_levels_on_game_id  (game_id)
-#  index_levels_on_name     (name)
+#  index_levels_on_contained_level_id  (contained_level_id)
+#  index_levels_on_game_id             (game_id)
+#  index_levels_on_name                (name)
 #
 
 class Weblab < Level

--- a/dashboard/app/models/levels/widget.rb
+++ b/dashboard/app/models/levels/widget.rb
@@ -17,12 +17,14 @@
 #  notes                 :text(65535)
 #  audit_log             :text(65535)
 #  contained_level_id    :integer
+#  template_level_id     :integer
 #
 # Indexes
 #
 #  index_levels_on_contained_level_id  (contained_level_id)
 #  index_levels_on_game_id             (game_id)
 #  index_levels_on_name                (name)
+#  index_levels_on_template_level_id   (template_level_id)
 #
 
 class Widget < Level

--- a/dashboard/app/models/levels/widget.rb
+++ b/dashboard/app/models/levels/widget.rb
@@ -16,11 +16,13 @@
 #  published             :boolean          default(FALSE), not null
 #  notes                 :text(65535)
 #  audit_log             :text(65535)
+#  contained_level_id    :integer
 #
 # Indexes
 #
-#  index_levels_on_game_id  (game_id)
-#  index_levels_on_name     (name)
+#  index_levels_on_contained_level_id  (contained_level_id)
+#  index_levels_on_game_id             (game_id)
+#  index_levels_on_name                (name)
 #
 
 class Widget < Level

--- a/dashboard/db/migrate/20200503234555_add_contained_level_to_levels.rb
+++ b/dashboard/db/migrate/20200503234555_add_contained_level_to_levels.rb
@@ -1,0 +1,6 @@
+class AddContainedLevelToLevels < ActiveRecord::Migration[5.0]
+  def change
+    add_column :levels, :contained_level_id, :integer
+    add_index :levels, :contained_level_id
+  end
+end

--- a/dashboard/db/migrate/20200504195918_add_template_level_to_levels.rb
+++ b/dashboard/db/migrate/20200504195918_add_template_level_to_levels.rb
@@ -1,0 +1,6 @@
+class AddTemplateLevelToLevels < ActiveRecord::Migration[5.0]
+  def change
+    add_column :levels, :template_level_id, :integer
+    add_index :levels, :template_level_id
+  end
+end

--- a/dashboard/db/schema.rb
+++ b/dashboard/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20200503234555) do
+ActiveRecord::Schema.define(version: 20200504195918) do
 
   create_table "activities", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci" do |t|
     t.integer  "user_id"
@@ -581,9 +581,11 @@ ActiveRecord::Schema.define(version: 20200503234555) do
     t.text     "notes",                 limit: 65535
     t.text     "audit_log",             limit: 65535
     t.integer  "contained_level_id"
+    t.integer  "template_level_id"
     t.index ["contained_level_id"], name: "index_levels_on_contained_level_id", using: :btree
     t.index ["game_id"], name: "index_levels_on_game_id", using: :btree
     t.index ["name"], name: "index_levels_on_name", using: :btree
+    t.index ["template_level_id"], name: "index_levels_on_template_level_id", using: :btree
   end
 
   create_table "levels_script_levels", id: false, force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci" do |t|

--- a/dashboard/db/schema.rb
+++ b/dashboard/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20200503222610) do
+ActiveRecord::Schema.define(version: 20200503234555) do
 
   create_table "activities", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci" do |t|
     t.integer  "user_id"
@@ -580,6 +580,8 @@ ActiveRecord::Schema.define(version: 20200503222610) do
     t.boolean  "published",                           default: false, null: false
     t.text     "notes",                 limit: 65535
     t.text     "audit_log",             limit: 65535
+    t.integer  "contained_level_id"
+    t.index ["contained_level_id"], name: "index_levels_on_contained_level_id", using: :btree
     t.index ["game_id"], name: "index_levels_on_game_id", using: :btree
     t.index ["name"], name: "index_levels_on_name", using: :btree
   end

--- a/dashboard/test/models/level_test.rb
+++ b/dashboard/test/models/level_test.rb
@@ -1017,4 +1017,12 @@ class LevelTest < ActiveSupport::TestCase
       child.parent_levels << parent
     end
   end
+
+  test 'contained level id' do
+    container = create :level
+    containee = create :level
+    container.contained_level = containee
+    container.save!
+    assert_equal [container], containee.containing_levels
+  end
 end

--- a/dashboard/test/models/level_test.rb
+++ b/dashboard/test/models/level_test.rb
@@ -1025,4 +1025,12 @@ class LevelTest < ActiveSupport::TestCase
     container.save!
     assert_equal [container], containee.containing_levels
   end
+
+  test 'template level id' do
+    template_backed = create :level
+    template = create :level
+    template_backed.template_level = template
+    template_backed.save!
+    assert_equal [template_backed], template.template_backed_levels
+  end
 end


### PR DESCRIPTION
This PR illustrates the option of using a new `contained_level_id` column on the `levels` table to implement the relationship between containing levels and contained levels. See https://github.com/code-dot-org/code-dot-org/pull/34586 for alternative.