### PR TITLE
Add google maps for startWebRequest

### DIFF
--- a/dashboard/app/controllers/xhr_proxy_controller.rb
+++ b/dashboard/app/controllers/xhr_proxy_controller.rb
@@ -73,6 +73,7 @@ class XhrProxyController < ApplicationController
     quizlet.com
     rejseplanen.dk
     maker.ifttt.com
+    maps.googleapis.com
     noaa.gov
     numbersapi.com
     pastebin.com


### PR DESCRIPTION
Requested [here](https://codeorg.zendesk.com/agent/tickets/278644)
I looked at the API docs and while they do require API keys, they don't require custom request headers so it should be fine. The student will need to make their own google developers account in order to actually use any APIs.