### PR TITLE
Reduce z-index of the parent email banner 

### DIFF
--- a/dashboard/app/assets/stylesheets/application.scss
+++ b/dashboard/app/assets/stylesheets/application.scss
@@ -3249,8 +3249,7 @@ h2.danger {
   color: $white;
   border-top: 1px solid $white;
 
-  /* Make sure we're in front of the AnswerDash icon in the lower-right corner. */
-  z-index: 2000000200;
+  z-index: 1030;
 
   .banner-content {
     max-width: 970px;


### PR DESCRIPTION
The modal backdrop is at 1040 and we want that to appear in front of the parent email banner.

The old z-index was copied from the cookie banner. I think it's that high because of something on pegasus, plus it doesn't bring up a modal so the z-index can be ridiculously large.


# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
