### PR TITLE
try to deflake spritelab eyes by waiting for loading element to go away

### DIFF
--- a/dashboard/test/ui/features/star_labs/spritelab/eyes.feature
+++ b/dashboard/test/ui/features/star_labs/spritelab/eyes.feature
@@ -5,7 +5,6 @@ Feature: Sprite Lab Eyes
 Scenario: Basic Sprite Lab level
   When I open my eyes to test "sprite lab eyes"
   And I start a new Sprite Lab project
-  And I wait for 3 seconds
   And I wait until I don't see selector "#p5_loading"
   Then I see no difference for "initial load"
   And I've initialized the workspace for the sample Sprite Lab project

--- a/dashboard/test/ui/features/star_labs/spritelab/eyes.feature
+++ b/dashboard/test/ui/features/star_labs/spritelab/eyes.feature
@@ -5,6 +5,8 @@ Feature: Sprite Lab Eyes
 Scenario: Basic Sprite Lab level
   When I open my eyes to test "sprite lab eyes"
   And I start a new Sprite Lab project
+  And I wait for 3 seconds
+  And I wait until I don't see selector "#p5_loading"
   Then I see no difference for "initial load"
   And I've initialized the workspace for the sample Sprite Lab project
   Then I see no difference for "preview"


### PR DESCRIPTION
This test had a flaky eyes diff today in which the "loading..." element was visible:

![Screen Shot 2020-05-04 at 10 45 58 AM](https://user-images.githubusercontent.com/8001765/80996326-77d1db80-8df4-11ea-8053-3aa50ad40854.png)

This PR copies the approach used in [spritelab.feature](https://github.com/code-dot-org/code-dot-org/blob/staging/dashboard/test/ui/features/star_labs/spritelab/spritelab.feature) to wait for the loading element to disappear.