### PR TITLE
Virtual Workshops: Add 'virtual' and 'suppress_email' attributes to workshops

### DIFF
--- a/dashboard/test/models/pd/workshop_test.rb
+++ b/dashboard/test/models/pd/workshop_test.rb
@@ -1312,6 +1312,26 @@ class Pd::WorkshopTest < ActiveSupport::TestCase
     refute potential_organizer_ids.include? program_manager.id
   end
 
+  test 'virtual workshops must suppress email' do
+    workshop = build :workshop
+
+    # Non-virtual workshops may suppress email or not
+    workshop.virtual = false
+    workshop.suppress_email = false
+    assert workshop.valid?
+
+    workshop.suppress_email = true
+    assert workshop.valid?
+
+    # Virtual workshops must suppress email
+    workshop.virtual = true
+    workshop.suppress_email = false
+    refute workshop.valid?
+
+    workshop.suppress_email = true
+    assert workshop.valid?
+  end
+
   private
 
   def session_on_day(day_offset)


### PR DESCRIPTION
The first step in adding virtual workshop support is adding these serialized properties to the workshop model.  Proposing this change separately to unblock any related work that will use these properties.

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
