### PR TITLE
[Spritelab] Add Mini Toolbox to event blocks, behind experiment

### DIFF
--- a/apps/src/block_utils.js
+++ b/apps/src/block_utils.js
@@ -1010,7 +1010,9 @@ exports.createJsWrapperBlockCreator = function(
             miniToolboxXml += `\n <block type="${block}"></block>`;
           });
           miniToolboxXml += '\n</xml>';
+          // Block.tray is used in the blockly repo to track whether or not the horizontal flyout is open.
           this.tray = false;
+          // On button click, open/close the horizontal flyout, toggle button text between +/-, and re-render the block.
           Blockly.bindEvent_(toggle.fieldGroup_, 'mousedown', this, () => {
             if (this.tray) {
               toggle.setText('+');

--- a/apps/src/block_utils.js
+++ b/apps/src/block_utils.js
@@ -867,6 +867,7 @@ exports.createJsWrapperBlockCreator = function(
    * @param {boolean} opts.simpleValue Just return the field value of the block.
    * @param {string[]} opts.extraArgs Additional arguments to pass into the generated function.
    * @param {string[]} opts.callbackParams Parameters to add to the generated callback function.
+   * @param {string[]} opts.miniToolboxBlocks
    * @param {?string} helperCode The block's helper code, to verify the func.
    *
    * @returns {string} the name of the generated block
@@ -890,7 +891,8 @@ exports.createJsWrapperBlockCreator = function(
       inline,
       simpleValue,
       extraArgs,
-      callbackParams
+      callbackParams,
+      miniToolboxBlocks
     },
     helperCode,
     pool
@@ -995,6 +997,29 @@ exports.createJsWrapperBlockCreator = function(
         } else {
           this.setNextStatement(true);
           this.setPreviousStatement(true);
+        }
+
+        if (miniToolboxBlocks) {
+          var toggle = new Blockly.FieldIcon('+');
+          var miniToolboxXml = '<xml>';
+          miniToolboxBlocks.forEach(block => {
+            miniToolboxXml += `\n <block type="${block}"></block>`;
+          });
+          miniToolboxXml += '\n</xml>';
+          this.tray = false;
+          Blockly.bindEvent_(toggle.fieldGroup_, 'mousedown', this, () => {
+            if (this.tray) {
+              toggle.setText('+');
+            } else {
+              toggle.setText('-');
+            }
+            this.tray = !this.tray;
+            this.render();
+          });
+          this.appendDummyInput()
+            .appendTitle(toggle)
+            .appendTitle(' ');
+          this.initMiniFlyout(miniToolboxXml);
         }
 
         // For mini-toolbox, indicate which blocks should receive the duplicate on drag

--- a/apps/src/block_utils.js
+++ b/apps/src/block_utils.js
@@ -606,7 +606,8 @@ const determineInputs = function(text, args, strictTypes = []) {
         type: arg.type,
         options: arg.options,
         assignment: arg.assignment,
-        defer: arg.defer
+        defer: arg.defer,
+        customOptions: arg.customOptions
       };
       Object.keys(labeledInput).forEach(key => {
         if (labeledInput[key] === undefined) {

--- a/apps/src/block_utils.js
+++ b/apps/src/block_utils.js
@@ -1,5 +1,6 @@
 import _ from 'lodash';
 import xml from './xml';
+import experiments from '@cdo/apps/util/experiments';
 
 const ATTRIBUTES_TO_CLEAN = ['uservisible', 'deletable', 'movable'];
 const DEFAULT_COLOR = [184, 1.0, 0.74];
@@ -999,7 +1000,10 @@ exports.createJsWrapperBlockCreator = function(
           this.setPreviousStatement(true);
         }
 
-        if (miniToolboxBlocks) {
+        if (
+          miniToolboxBlocks &&
+          experiments.isEnabled(experiments.MINI_TOOLBOX)
+        ) {
           var toggle = new Blockly.FieldIcon('+');
           var miniToolboxXml = '<xml>';
           miniToolboxBlocks.forEach(block => {

--- a/apps/src/p5lab/spritelab/blocks.js
+++ b/apps/src/p5lab/spritelab/blocks.js
@@ -192,34 +192,6 @@ const customInputTypes = {
       return block.getTitleValue(arg.name);
     }
   },
-  miniToolbox: {
-    addInput(blockly, block, inputConfig, currentInputRow) {
-      var toggle = new Blockly.FieldIcon('+');
-      var miniToolboxBlocks =
-        (inputConfig.customOptions && inputConfig.customOptions.blocks) || [];
-      var miniToolboxXml = '<xml>';
-      miniToolboxBlocks.forEach(block => {
-        miniToolboxXml += `\n  <block type="${block}"></block>`;
-      });
-      miniToolboxXml += '\n</xml>';
-
-      block.isOpen = false;
-      Blockly.bindEvent_(toggle.fieldGroup_, 'mousedown', block, () => {
-        if (block.isOpen) {
-          toggle.setText('-');
-        } else {
-          toggle.setText('+');
-        }
-        block.isOpen = !block.isOpen;
-        block.render();
-      });
-      currentInputRow.appendTitle(toggle);
-      block.initMiniFlyout(miniToolboxXml);
-    },
-    generateCode(block, arg) {
-      return '';
-    }
-  },
   spritePointer: {
     addInput(blockly, block, inputConfig, currentInputRow) {
       currentInputRow

--- a/apps/src/p5lab/spritelab/blocks.js
+++ b/apps/src/p5lab/spritelab/blocks.js
@@ -199,7 +199,18 @@ const customInputTypes = {
         .appendTitle(new Blockly.FieldImage('', 32, 32), inputConfig.name);
     },
     generateCode(block, arg) {
-      return `'${block.getTitleValue(arg.name)}'`;
+      switch (block.type) {
+        case 'gamelab_clickedSpritePointer':
+          return '{id: extraArgs.sprite}';
+        case 'gamelab_subjectSpritePointer':
+          return '{id: extraArgs.sprite}';
+        case 'gamelab_objectSpritePointer':
+          return '{id: extraArgs.target}';
+        default:
+          // unsupported block for spritePointer, returning undefined here
+          // will match the behavior of an empty socket.
+          return undefined;
+      }
     }
   },
   spritePicker: {

--- a/apps/src/p5lab/spritelab/blocks.js
+++ b/apps/src/p5lab/spritelab/blocks.js
@@ -192,6 +192,34 @@ const customInputTypes = {
       return block.getTitleValue(arg.name);
     }
   },
+  miniToolbox: {
+    addInput(blockly, block, inputConfig, currentInputRow) {
+      var toggle = new Blockly.FieldIcon('+');
+      var miniToolboxBlocks =
+        (inputConfig.customOptions && inputConfig.customOptions.blocks) || [];
+      var miniToolboxXml = '<xml>';
+      miniToolboxBlocks.forEach(block => {
+        miniToolboxXml += `\n  <block type="${block}"></block>`;
+      });
+      miniToolboxXml += '\n</xml>';
+
+      block.isOpen = false;
+      Blockly.bindEvent_(toggle.fieldGroup_, 'mousedown', block, () => {
+        if (block.isOpen) {
+          toggle.setText('-');
+        } else {
+          toggle.setText('+');
+        }
+        block.isOpen = !block.isOpen;
+        block.render();
+      });
+      currentInputRow.appendTitle(toggle);
+      block.initMiniFlyout(miniToolboxXml);
+    },
+    generateCode(block, arg) {
+      return '';
+    }
+  },
   spritePointer: {
     addInput(blockly, block, inputConfig, currentInputRow) {
       currentInputRow

--- a/apps/src/p5lab/spritelab/commands.js
+++ b/apps/src/p5lab/spritelab/commands.js
@@ -117,7 +117,7 @@ export const commands = {
   },
 
   // Event commands
-  checkTouching(condition, sprite1, sprite2, callback) {
+  checkTouching(condition, sprite1, sprite2, unusedArg, callback) {
     eventCommands.checkTouching(condition, sprite1, sprite2, callback);
   },
 
@@ -125,7 +125,7 @@ export const commands = {
     eventCommands.keyPressed(condition, key, callback);
   },
 
-  spriteClicked(condition, spriteArg, callback) {
+  spriteClicked(condition, spriteArg, unusedArg, callback) {
     eventCommands.spriteClicked(condition, spriteArg, callback);
   },
 

--- a/apps/src/p5lab/spritelab/commands.js
+++ b/apps/src/p5lab/spritelab/commands.js
@@ -117,7 +117,7 @@ export const commands = {
   },
 
   // Event commands
-  checkTouching(condition, sprite1, sprite2, unusedArg, callback) {
+  checkTouching(condition, sprite1, sprite2, callback) {
     eventCommands.checkTouching(condition, sprite1, sprite2, callback);
   },
 
@@ -125,7 +125,7 @@ export const commands = {
     eventCommands.keyPressed(condition, key, callback);
   },
 
-  spriteClicked(condition, spriteArg, unusedArg, callback) {
+  spriteClicked(condition, spriteArg, callback) {
     eventCommands.spriteClicked(condition, spriteArg, callback);
   },
 

--- a/apps/src/util/experiments.js
+++ b/apps/src/util/experiments.js
@@ -29,6 +29,7 @@ experiments.TEACHER_DASHBOARD_SECTION_BUTTONS =
   'teacher-dashboard-section-buttons';
 experiments.TEACHER_DASHBOARD_SECTION_BUTTONS_ALTERNATE_TEXT =
   'teacher-dashboard-section-buttons-alternate-text';
+experiments.MINI_TOOLBOX = 'miniToolbox';
 
 /**
  * Get our query string. Provided as a method so that tests can mock this.

--- a/dashboard/config/blocks/GamelabJr/gamelab_checkTouching.json
+++ b/dashboard/config/blocks/GamelabJr/gamelab_checkTouching.json
@@ -7,7 +7,7 @@
       0.74
     ],
     "func": "checkTouching",
-    "blockText": "{CONDITION} {SPRITE1} touches {SPRITE2}",
+    "blockText": "{MINITOOLBOX} {CONDITION} {SPRITE1} touches {SPRITE2}",
     "callbackParams": [
       "extraArgs"
     ],
@@ -32,6 +32,16 @@
       {
         "name": "SPRITE2",
         "type": "Sprite"
+      },
+      {
+        "name": "MINITOOLBOX",
+        "customInput": "miniToolbox",
+        "customOptions": {
+          "blocks": [
+            "gamelab_subjectSpritePointer",
+            "gamelab_objectSpritePointer"
+          ]
+        }
       }
     ],
     "eventBlock": true

--- a/dashboard/config/blocks/GamelabJr/gamelab_checkTouching.json
+++ b/dashboard/config/blocks/GamelabJr/gamelab_checkTouching.json
@@ -7,7 +7,11 @@
       0.74
     ],
     "func": "checkTouching",
-    "blockText": "{MINITOOLBOX} {CONDITION} {SPRITE1} touches {SPRITE2}",
+    "blockText": "{CONDITION} {SPRITE1} touches {SPRITE2}",
+    "miniToolboxBlocks": [
+      "gamelab_subjectSpritePointer",
+      "gamelab_objectSpritePointer"
+    ],
     "callbackParams": [
       "extraArgs"
     ],
@@ -32,16 +36,6 @@
       {
         "name": "SPRITE2",
         "type": "Sprite"
-      },
-      {
-        "name": "MINITOOLBOX",
-        "customInput": "miniToolbox",
-        "customOptions": {
-          "blocks": [
-            "gamelab_subjectSpritePointer",
-            "gamelab_objectSpritePointer"
-          ]
-        }
       }
     ],
     "eventBlock": true

--- a/dashboard/config/blocks/GamelabJr/gamelab_clickedSpritePointer.js
+++ b/dashboard/config/blocks/GamelabJr/gamelab_clickedSpritePointer.js
@@ -1,3 +1,0 @@
-function clickedSpritePointer() {
-  return thisSprite;
-}

--- a/dashboard/config/blocks/GamelabJr/gamelab_objectSpritePointer.json
+++ b/dashboard/config/blocks/GamelabJr/gamelab_objectSpritePointer.json
@@ -2,8 +2,8 @@
   "category": "Events",
   "config": {
     "simpleValue": true,
-    "name": "clickedSpritePointer",
-    "blockText": "clicked {SPRITE}",
+    "name": "objectSpritePointer",
+    "blockText": "object {SPRITE}",
     "args": [
       {
         "name": "SPRITE",

--- a/dashboard/config/blocks/GamelabJr/gamelab_spriteClicked.json
+++ b/dashboard/config/blocks/GamelabJr/gamelab_spriteClicked.json
@@ -7,7 +7,10 @@
       0.74
     ],
     "func": "spriteClicked",
-    "blockText": "{MINITOOLBOX} {CONDITION} {SPRITE} clicked",
+    "blockText": "{CONDITION} {SPRITE} clicked",
+    "miniToolboxBlocks": [
+      "gamelab_clickedSpritePointer"
+    ],
     "callbackParams": [
       "extraArgs"
     ],
@@ -28,15 +31,6 @@
       {
         "name": "SPRITE",
         "type": "Sprite"
-      },
-      {
-        "name": "MINITOOLBOX",
-        "customInput": "miniToolbox",
-        "customOptions": {
-          "blocks": [
-            "gamelab_clickedSpritePointer"
-          ]
-        }
       }
     ],
     "eventBlock": true

--- a/dashboard/config/blocks/GamelabJr/gamelab_spriteClicked.json
+++ b/dashboard/config/blocks/GamelabJr/gamelab_spriteClicked.json
@@ -7,7 +7,7 @@
       0.74
     ],
     "func": "spriteClicked",
-    "blockText": "{CONDITION} {SPRITE} clicked",
+    "blockText": "{MINITOOLBOX} {CONDITION} {SPRITE} clicked",
     "callbackParams": [
       "extraArgs"
     ],
@@ -28,6 +28,15 @@
       {
         "name": "SPRITE",
         "type": "Sprite"
+      },
+      {
+        "name": "MINITOOLBOX",
+        "customInput": "miniToolbox",
+        "customOptions": {
+          "blocks": [
+            "gamelab_clickedSpritePointer"
+          ]
+        }
       }
     ],
     "eventBlock": true

--- a/dashboard/config/blocks/GamelabJr/gamelab_subjectSpritePointer.json
+++ b/dashboard/config/blocks/GamelabJr/gamelab_subjectSpritePointer.json
@@ -2,8 +2,8 @@
   "category": "Events",
   "config": {
     "simpleValue": true,
-    "name": "clickedSpritePointer",
-    "blockText": "clicked {SPRITE}",
+    "name": "subjectSpritePointer",
+    "blockText": "subject {SPRITE}",
     "args": [
       {
         "name": "SPRITE",

--- a/dashboard/config/libraries/NativeSpriteLab.interpreted.js
+++ b/dashboard/config/libraries/NativeSpriteLab.interpreted.js
@@ -1,4 +1,4 @@
-var extraArgs = null;
+var extraArgs = {};
 var other = [];
 
 function draw() {


### PR DESCRIPTION
Experiment flag: `miniToolbox`

Done:
- miniToolboxBlocks as a new option in the block config
- generated code changes to make everything work
- subject/object pointer blocks

To Do:
- set up shadowing for subject and object blocks
- make the blocks within the mini toolbox shadow the costume
- add the word "sprite" on the block when there's no costume to show
- Make it configurable on levelbuilder whether or not to show the minitoolbox

![image](https://user-images.githubusercontent.com/8787187/81010065-8f1bc380-8e0a-11ea-92b7-0a03d4d769a1.png)

![image](https://user-images.githubusercontent.com/8787187/81010202-bbcfdb00-8e0a-11ea-8ee2-8afbe4d98056.png)

Without experiment:
![image](https://user-images.githubusercontent.com/8787187/81022602-e463cf00-8e22-11ea-89c0-5b156e14cc8a.png)
