### PR TITLE
Fix valid courses cache bug

### DIFF
--- a/dashboard/app/models/course.rb
+++ b/dashboard/app/models/course.rb
@@ -239,7 +239,7 @@ class Course < ApplicationRecord
 
     if user && has_any_pilot_access?(user)
       pilot_courses = all_courses.select {|c| c.has_pilot_access?(user)}
-      courses = courses.concat(pilot_courses)
+      courses += pilot_courses
     end
 
     courses


### PR DESCRIPTION
Fixes bug where CSP 2020, which is not visible and behind a pilot experiment right now, was sometimes incorrectly present in the edit sections dialog in production for users not in the experiment. Other times it was not.

The bug ended up being that `arr.concat(foo)` in ruby modifies `arr`, so when a user with pilot experiment access visited their home page and called this method, the value in the cache, a ruby array, would end up getting mutated, and the courses behind pilot experiment would get stuck in the cache. (Thanks @davidsbailey for spotting this!)

`+` avoids this by returning a new array without modifying the original.

## Testing story

* Added unit test which fails before fix and passes after

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
