### PR TITLE
Update the arrow buttons so they always display on one line. Especially on mobile.

### DIFF
--- a/apps/src/templates/ArrowButtons.jsx
+++ b/apps/src/templates/ArrowButtons.jsx
@@ -10,21 +10,12 @@ var ArrowButtons = function(props) {
       <button type="button" id="leftButton" disabled className="arrow">
         <img src="/blockly/media/1x1.gif" className="left-btn icon21" />
       </button>
-      {
-        ' ' /* Explicitly insert whitespace so that this behaves like our ejs file*/
-      }
       <button type="button" id="rightButton" disabled className="arrow">
         <img src="/blockly/media/1x1.gif" className="right-btn icon21" />
       </button>
-      {
-        ' ' /* Explicitly insert whitespace so that this behaves like our ejs file*/
-      }
       <button type="button" id="upButton" disabled className="arrow">
         <img src="/blockly/media/1x1.gif" className="up-btn icon21" />
       </button>
-      {
-        ' ' /* Explicitly insert whitespace so that this behaves like our ejs file*/
-      }
       <button type="button" id="downButton" disabled className="arrow">
         <img src="/blockly/media/1x1.gif" className="down-btn icon21" />
       </button>

--- a/apps/style/common.scss
+++ b/apps/style/common.scss
@@ -224,7 +224,7 @@ button.arrow {
   border: 1px solid #FFA000;
   background-color: #FFA000;
   color: #fff;
-  margin-left: 5px;
+  margin-left: 9px;
   margin-right: 0px;
   display: none;
 }
@@ -243,18 +243,19 @@ button.arrow:disabled {
 #soft-buttons {
   display: inline-block;
   vertical-align: top;
-  margin-left: -5px;
+  margin-left: -9px;
   -webkit-touch-callout: none;
   &.soft-buttons-none {
     display: none;
   }
   &.soft-buttons-compact {
-    margin-left: 0;
+    margin: 0;
     button {
-      margin: 0;
+      margin: 0 4px 0 0;
     }
   }
 }
+
 .soft-buttons-1 {
   display: table-cell;
   vertical-align: top;
@@ -488,9 +489,9 @@ html[dir='rtl'] div#visualizationResizeBar {
   @include karel-counter(32px, 2px);
 
   #soft-buttons {
-    margin-left: 0;
+    margin: 5px -8px 0 0;
     button {
-      margin: 0;
+      margin: 0 4px 0 0;
     }
   }
   .small-footer-base.responsive {

--- a/apps/style/craft/style.scss
+++ b/apps/style/craft/style.scss
@@ -160,6 +160,23 @@ $text-shadow-gray: #5a5a5a;
   @include pixelated();
 }
 
+#soft-buttons.soft-buttons-compact {
+  margin-left: 0;
+  button {
+    margin: 0;
+  }
+}
+
+@media screen and (max-width: 1000px),
+       screen and (max-height: 600px) {
+  #soft-buttons {
+    margin: 0, -5px, 0, 0;
+    button {
+      margin: 0;
+    }
+  }
+}
+
 .left-btn {
   @include arrow-icon("#{$root}Sliced_Parts/MC_Run_Arrow_Icon_Smaller.png");
   @include flip-horizontal(1);


### PR DESCRIPTION
Previously, when the visualization column was shrunk down to its minimum size, the arrow buttons on minecraft would display on two lines. This would be especially obvious on mobile where "minimum size" is the default.

Before
![Screenshot_20200413-133202_Chrome](https://user-images.githubusercontent.com/8324574/81022131-bc27a080-8e21-11ea-9800-2f88d21be800.jpg)

After
![Screenshot_20200504-155916_Chrome](https://user-images.githubusercontent.com/8324574/81022135-bd58cd80-8e21-11ea-8021-d7ba8d8e5895.jpg)

This improves the placement of the buttons for other apps too.

Before
![ButtonPlacementOld](https://user-images.githubusercontent.com/8324574/81022635-f47bae80-8e22-11ea-9877-98ecff94ab88.gif)

After
![ButtonPlacementNew](https://user-images.githubusercontent.com/8324574/81022338-3d7f3300-8e22-11ea-9d94-6dcd116ecf01.gif)


<!--
  Your description goes here: A summary of the change, including any relevant motivation and context.

  If relevant, include a description both of the existing behavior and of the new behavior.
-->

<!--
  Other aspects to consider. uncomment and add detail for any that seem necessary:
-->

<!-- ### Background -->
<!-- ### Privacy -->
<!-- ### Security -->
<!-- ### Caching -->
<!-- ### Deployment strategy -->
<!-- ### Future work -->

## Links

<!--
  Any relevant links to external resources; ie, specification documents, jira
  items, related PRs, honeybadger errors, etc
-->


## Testing story

<!--
  Does your change include appropriate tests?

  If so, please describe how the tests included in this PR are sufficient

  If not, please explain why this change does not need to be tested.
-->

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
