### PR TITLE
remove applitools links from eyes test output

### DIFF
--- a/dashboard/test/ui/runner.rb
+++ b/dashboard/test/ui/runner.rb
@@ -416,8 +416,7 @@ def report_tests_finished(start_time, run_results)
   "Total duration: #{RakeUtils.format_duration(suite_duration)}. " \
   "Total reruns of flaky tests: #{total_flaky_reruns}. " \
   "Total successful reruns of flaky tests: #{total_flaky_successful_reruns}." \
-  + (status_page_url ? " <a href=\"#{status_page_url}\">#{test_type} test status page</a>." : '') \
-  + (applitools_batch_url ? " <a href=\"#{applitools_batch_url}\">Applitools results</a>." : '')
+  + (status_page_url ? " <a href=\"#{status_page_url}\">#{test_type} test status page</a>." : '')
 
   unless failures.empty?
     ChatClient.log "Failed tests: \n #{failures.join("\n")}"

--- a/lib/rake/test.rake
+++ b/lib/rake/test.rake
@@ -69,7 +69,7 @@ namespace :test do
         ChatClient.log message
         ChatClient.message 'server operations', message, color: 'green'
       else
-        message = 'ಠ_ಠ Eyes tests for <b>dashboard</b> failed. See <a href="https://eyes.applitools.com/app/sessions/">the console</a> for results or to modify baselines.'
+        message = 'ಠ_ಠ Eyes tests for <b>dashboard</b> failed.'
         ChatClient.log message, color: 'red'
         ChatClient.message 'server operations', message, color: 'red', notify: 1
         raise "Eyes tests failed"


### PR DESCRIPTION
this fixes a problem where cucumber failures in eyes tests could be accidentally overlooked. imagine the scenario where there are two failures, one eyes diff and one cucumber error in a different eyes test. the DOTD goes to the applitools console, sees one diff, resolves it, and then marks the DTT green. 

This PR attempts to prevent this by taking away the links to the applitools console from the test output. This forces the DOTD to either click the "eyes test status page" link or the individual "log on s3" links (both pictured further below), which then let you click through to the individual applitools failure:
![Screen Shot 2020-05-04 at 4 47 15 PM](https://user-images.githubusercontent.com/8001765/81024014-efb8f980-8e26-11ea-986d-884440567af6.png)

### Eyes test failure output, before
![eyes-failed-before](https://user-images.githubusercontent.com/8001765/81023803-673a5900-8e26-11ea-9b03-a475b5b52360.png)

### Eyes test failure output, after
![eyes-failed-after](https://user-images.githubusercontent.com/8001765/81023807-6a354980-8e26-11ea-9010-e0715dbae639.png)

### UI test failure output, for comparison
![Screen Shot 2020-05-04 at 4 44 26 PM](https://user-images.githubusercontent.com/8001765/81023870-a23c8c80-8e26-11ea-94ff-7271eeef7819.png)

