### PR TITLE
Run first half of contact rollups daily at 5PM PST

### DIFF
--- a/cookbooks/cdo-apps/templates/default/crontab.erb
+++ b/cookbooks/cdo-apps/templates/default/crontab.erb
@@ -102,6 +102,7 @@
       cronjob at:'0 12 * * *', do:deploy_dir('bin', 'cron', 'applab_datasets', 'daily_weather')
       cronjob at:'0 12 * * *', do:deploy_dir('bin', 'cron', 'applab_datasets', 'spotify')
       cronjob at:'00 02 * * *', do:deploy_dir('bin', 'cron', 'export_mysql_database_to_redshift')
+      cronjob at:'0 0 * * *', do:deploy_dir('bin', 'cron', 'build_contact_rollups_v2')
 
       # RDS backup window is 08:50-09:20, so by 11:50 backups should definitely be ready
       cronjob at:'50 11 * * *', do:deploy_dir('bin', 'cron', 'push_latest_aurora_backup_to_secondary_account')


### PR DESCRIPTION
Sets up contact rollups process to run each day at 5 PM PST (midnight UTC). We want to run at 5 PM at least at first such that if there are any issues, it won't wake up a DOTD in the middle of the night, but still misses our peak traffic period. Note that this will currently skip the syncing to Pardot steps as the option, which is expected.