### PR TITLE
Simplify build_property_hash

### DIFF
--- a/dashboard/app/models/script.rb
+++ b/dashboard/app/models/script.rb
@@ -1565,29 +1565,41 @@ class Script < ActiveRecord::Base
     !Gatekeeper.allows('postMilestone', where: {script_name: name}, default: true)
   end
 
+  # Returns a property hash that always has the same keys, even if those keys were missing
+  # from the input. This ensures that values can be un-set via seeding or the script edit UI.
   def self.build_property_hash(script_data)
-    {
-      hideable_stages: script_data[:hideable_stages] || false, # default false
-      professional_learning_course: script_data[:professional_learning_course] || false, # default false
-      peer_reviews_to_complete: script_data[:peer_reviews_to_complete] || false,
-      student_detail_progress_view: script_data[:student_detail_progress_view] || false,
-      project_widget_visible: script_data[:project_widget_visible] || false,
-      project_widget_types: script_data[:project_widget_types] || false,
-      teacher_resources: script_data[:teacher_resources] || false,
-      stage_extras_available: script_data[:stage_extras_available] || false,
-      has_verified_resources: !!script_data[:has_verified_resources],
-      has_lesson_plan: !!script_data[:has_lesson_plan],
-      curriculum_path: script_data[:curriculum_path] || false,
-      script_announcements: script_data[:script_announcements] || false,
-      version_year: script_data[:version_year] || false,
-      is_stable: !!script_data[:is_stable],
-      supported_locales: script_data[:supported_locales] || false,
-      pilot_experiment: script_data[:pilot_experiment] || false,
-      editor_experiment: script_data[:editor_experiment] || false,
-      project_sharing: !!script_data[:project_sharing],
-      curriculum_umbrella: script_data[:curriculum_umbrella] || false,
-      tts: !!script_data[:tts]
-    }
+    nonboolean_keys = [
+      :hideable_stages,
+      :professional_learning_course,
+      :peer_reviews_to_complete,
+      :student_detail_progress_view,
+      :project_widget_visible,
+      :project_widget_types,
+      :teacher_resources,
+      :stage_extras_available,
+      :curriculum_path,
+      :script_announcements,
+      :version_year,
+      :supported_locales,
+      :pilot_experiment,
+      :editor_experiment,
+      :curriculum_umbrella,
+    ]
+    boolean_keys = [
+      :has_verified_resources,
+      :has_lesson_plan,
+      :is_stable,
+      :project_sharing,
+      :tts
+    ]
+
+    result = {}
+    # If a non-boolean prop was missing from the input, it'll get populated in the result hash as nil.
+    nonboolean_keys.each {|k| result[k] = script_data[k]}
+    # If a boolean prop was missing from the input, it'll get populated in the result hash as false.
+    boolean_keys.each {|k| result[k] = !!script_data[k]}
+
+    result
   end
 
   # A script is considered to have a matching course if there is exactly one


### PR DESCRIPTION
Saw this again today randomly and decided to finish cleaning it up. This was started in https://github.com/code-dot-org/code-dot-org/pull/34296.

Though this method still needs to be updated for each new property, at least it should be a bit more clear and less error-prone.

Originally I'd switched things to defaulting to `false` instead of `nil` for non-booleans because there used to be a `compact` on the result, but that isn't necessary (I'm not sure it ever was). Switched backed to using `nil` since I think that's a bit more natural.

## Testing story

Though I introduced a bug when trying to simplify this previously, those cases are now covered by unit tests:
* https://github.com/code-dot-org/code-dot-org/blob/5e1fb7173b75b2743daaff8fd81d72e7fa326995/dashboard/test/models/script_test.rb#L224
https://github.com/code-dot-org/code-dot-org/blob/5e1fb7173b75b2743daaff8fd81d72e7fa326995/dashboard/test/controllers/scripts_controller_test.rb#L505

Also manually tested setting and unsetting via script edit UI and seeding just to be safe.

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
