### PR TITLE
update setup docs to reflect the move from phantomjs to ChromeHeadless

### DIFF
--- a/SETUP.md
+++ b/SETUP.md
@@ -144,7 +144,8 @@ After setup, read about our [code styleguide](./STYLEGUIDE.md), our [test suites
     1. `sudo apt-get update && sudo apt-get install yarn=1.16.0-1`
     1. `yarn --version` Double check the version of yarn is correct.
 1. Make it so that you can run apps tests locally
-    1. `export CHROME_BIN=$(which chromium-browser)`
+    1. Add the following to `~/.bash_profile` or your desired shell configuration file:
+        1. `export CHROME_BIN=$(which chromium-browser)`
 1. Finally, configure your mysql to allow for a proper installation. You may run into errors if you did not leave mysql passwords blank
     1. `echo "ALTER USER 'root'@'localhost' IDENTIFIED WITH mysql_native_password BY '';" | sudo mysql`
 1. **IMPORTANT:** Read the following notes, then go back up to the [overview](#overview) and run the commands there.

--- a/SETUP.md
+++ b/SETUP.md
@@ -117,6 +117,8 @@ After setup, read about our [code styleguide](./STYLEGUIDE.md), our [test suites
 
 1. Install the [Java 8 JDK](http://www.oracle.com/technetwork/java/javase/downloads/index.html)
 
+1. [Download](https://www.google.com/chrome/) and install Google Chrome, if you have not already. This is needed in order to be able to run apps tests locally.
+
 ### Ubuntu 16.04 ([Download iso][ubuntu-iso-url]) Note: Virtual Machine Users should check the Windows Note below before starting
 
 1. `sudo apt-get update`

--- a/SETUP.md
+++ b/SETUP.md
@@ -64,9 +64,6 @@ After setup, read about our [code styleguide](./STYLEGUIDE.md), our [test suites
 
         If it complains about an old version of `<package>`, run `brew unlink <package>` and run `brew install <package>` again
     </details>
-
-
-1. Install PhantomJS: `brew cask install phantomjs`
 1. Set up MySQL
     1. Force link 5.7 version: `brew link mysql@5.7 --force`
     1. Have `launchd` start mysql at login: `ln -sfv /usr/local/opt/mysql/*.plist ~/Library/LaunchAgents`
@@ -123,7 +120,7 @@ After setup, read about our [code styleguide](./STYLEGUIDE.md), our [test suites
 ### Ubuntu 16.04 ([Download iso][ubuntu-iso-url]) Note: Virtual Machine Users should check the Windows Note below before starting
 
 1. `sudo apt-get update`
-1. `sudo apt-get install -y git mysql-server mysql-client libmysqlclient-dev libxslt1-dev libssl-dev zlib1g-dev imagemagick libmagickcore-dev libmagickwand-dev openjdk-9-jre-headless libcairo2-dev libjpeg8-dev libpango1.0-dev libgif-dev curl pdftk enscript libsqlite3-dev phantomjs build-essential redis-server rbenv`
+1. `sudo apt-get install -y git mysql-server mysql-client libmysqlclient-dev libxslt1-dev libssl-dev zlib1g-dev imagemagick libmagickcore-dev libmagickwand-dev openjdk-9-jre-headless libcairo2-dev libjpeg8-dev libpango1.0-dev libgif-dev curl pdftk enscript libsqlite3-dev build-essential redis-server rbenv chromium-browser`
     * **Hit enter and select default options for any configuration popups, leaving mysql passwords blank**
 1. *(If working from an EC2 instance)* `sudo apt-get install -y libreadline-dev libffi-dev`
 1. Install Node and Nodejs
@@ -146,13 +143,15 @@ After setup, read about our [code styleguide](./STYLEGUIDE.md), our [test suites
     1. `echo "deb https://dl.yarnpkg.com/debian/ stable main" | sudo tee /etc/apt/sources.list.d/yarn.list`
     1. `sudo apt-get update && sudo apt-get install yarn=1.16.0-1`
     1. `yarn --version` Double check the version of yarn is correct.
+1. Make it so that you can run apps tests locally
+    1. `export CHROME_BIN=$(which chromium-browser)`
 1. Finally, configure your mysql to allow for a proper installation. You may run into errors if you did not leave mysql passwords blank
-   1. `echo "ALTER USER 'root'@'localhost' IDENTIFIED WITH mysql_native_password BY '';" | sudo mysql`
+    1. `echo "ALTER USER 'root'@'localhost' IDENTIFIED WITH mysql_native_password BY '';" | sudo mysql`
 1. **IMPORTANT:** Read the following notes, then go back up to the [overview](#overview) and run the commands there.
-   1. If, for any reason, you are forced to interrupt the `bundle exec rake install` command before it completes,
-      cd into dashboard and run `bundle exec rake db:drop` before trying `bundle exec rake install` again
-   1. `bundle exec rake install` must always be called from the local project's root directory, or it won't work.
-   1. Finally, don't worry if your versions don't match the versions in the overview if you're following this method; the installation should still work properly regardless
+    1. If, for any reason, you are forced to interrupt the `bundle exec rake install` command before it completes,
+       cd into dashboard and run `bundle exec rake db:drop` before trying `bundle exec rake install` again
+    1. `bundle exec rake install` must always be called from the local project's root directory, or it won't work.
+    1. Finally, don't worry if your versions don't match the versions in the overview if you're following this method; the installation should still work properly regardless
 
 ### Windows note: use an Ubuntu VM
 
@@ -210,10 +209,6 @@ If you want to make JavaScript changes and have them take effect locally, you'll
 1. Run `bundle exec rake package` for the changes to take effect.
 
 This configures dashboard to rebuild apps whenever you run `bundle exec rake build` and to use the version that you built yourself.  See the documentation in that directory for faster ways to build and iterate.
-
-If waiting around for javascript builds is making you sad, consider sending build time logs to New Relic so we can track the slowness. You can do this by copying our license key from [the New Relic account page](https://rpm.newrelic.com/accounts/501463) and pasting it into `locals.yml`:
-
-    new_relic_license_key: <license key here>
 
 ## Editor configuration
 


### PR DESCRIPTION
See https://github.com/code-dot-org/code-dot-org/pull/34547 and [#test-tactics](https://codedotorg.slack.com/archives/CHZR21TLY/p1588605092044000) for context.

## Testing story

Verified on Mac OS and Ubuntu (EC2) that this allows apps tests to be run locally, after patching in https://github.com/code-dot-org/code-dot-org/pull/34547 and then running `yarn test:integration`