### PR TITLE
Remove unused stage_extras_disabled property from Lesson

### DIFF
--- a/dashboard/app/dsl/script_dsl.rb
+++ b/dashboard/app/dsl/script_dsl.rb
@@ -96,7 +96,6 @@ class ScriptDSL < BaseDSL
         stage: @stage,
         visible_after: @stage_visible_after,
         scriptlevels: @scriptlevels,
-        stage_extras_disabled: @stage_extras_disabled,
       }.compact
     end
     @stage = name
@@ -105,7 +104,6 @@ class ScriptDSL < BaseDSL
     @scriptlevels = []
     @concepts = []
     @skin = nil
-    @stage_extras_disabled = nil
   end
 
   # If visible_after value is blank default to next wednesday at 8am PDT
@@ -270,10 +268,6 @@ class ScriptDSL < BaseDSL
     @current_scriptlevel = nil
   end
 
-  def no_extras
-    @stage_extras_disabled = true
-  end
-
   # @override
   def i18n_hash
     i18n_stage_strings = {}
@@ -390,7 +384,6 @@ class ScriptDSL < BaseDSL
         s.concat(serialize_level(sl.level, type, nil, sl.progression, sl.named_level?, sl.challenge, sl.assessment))
       end
     end
-    s << 'no_extras' if stage.stage_extras_disabled
     s << ''
     s.join("\n")
   end

--- a/dashboard/app/helpers/script_levels_helper.rb
+++ b/dashboard/app/helpers/script_levels_helper.rb
@@ -11,8 +11,7 @@ module ScriptLevelsHelper
         # stages except for the last stage of a script
         # users in or teaching sections with an enabled "stage extras" flag
         enabled_for_stage = script_level.script.stage_extras_available &&
-          !script_level.end_of_script? &&
-          !script_level.lesson.stage_extras_disabled
+          !script_level.end_of_script?
         enabled_for_user = current_user && current_user.section_for_script(script_level.script) &&
             current_user.section_for_script(script_level.script).stage_extras
         enabled_for_teacher = current_user.try(:teacher?) &&

--- a/dashboard/app/models/lesson.rb
+++ b/dashboard/app/models/lesson.rb
@@ -38,7 +38,6 @@ class Lesson < ActiveRecord::Base
   self.table_name = 'stages'
 
   serialized_attrs %w(
-    stage_extras_disabled
     visible_after
   )
 
@@ -172,7 +171,7 @@ class Lesson < ActiveRecord::Base
         stage_data[:finishText] = I18n.t('nav.header.finished_hoc')
       end
 
-      if !unplugged? && !stage_extras_disabled
+      unless unplugged?
         stage_data[:stage_extras_level_url] = script_stage_extras_url(script.name, stage_position: relative_position)
       end
 

--- a/dashboard/app/models/script.rb
+++ b/dashboard/app/models/script.rb
@@ -1125,7 +1125,6 @@ class Script < ActiveRecord::Base
       end
 
       raw_lesson = raw_lessons.find {|rs| rs[:stage].downcase == lesson.name.downcase}
-      lesson.stage_extras_disabled = raw_lesson[:stage_extras_disabled]
       lesson.visible_after = raw_lesson[:visible_after]
       lesson.save! if lesson.changed?
     end

--- a/dashboard/test/dsl/script_dsl_test.rb
+++ b/dashboard/test/dsl/script_dsl_test.rb
@@ -481,33 +481,6 @@ level 'Level 3'
     assert_equal expected, output
   end
 
-  test 'Script DSL with skipped extras' do
-    input_dsl = <<~DSL
-      stage 'Lesson1'
-      level 'Level 1'
-      level 'Level 2'
-      no_extras
-    DSL
-    expected = DEFAULT_PROPS.merge(
-      {
-        stages: [
-          {
-            stage: "Lesson1",
-            stage_extras_disabled: true,
-            scriptlevels: [
-              {stage: "Lesson1", levels: [{name: "Level 1"}]},
-              {stage: "Lesson1", levels: [{name: "Level 2"}]},
-            ]
-          }
-        ],
-        lesson_groups: []
-      }
-    )
-
-    output, _ = ScriptDSL.parse(input_dsl, 'test.script', 'test')
-    assert_equal expected, output
-  end
-
   test 'Script DSL with blank stage visible after date will set visible after to next wednesday at 8 am PST' do
     Timecop.freeze(Time.new(2020, 3, 27))
 

--- a/dashboard/test/helpers/script_levels_helper_test.rb
+++ b/dashboard/test/helpers/script_levels_helper_test.rb
@@ -130,19 +130,4 @@ class ScriptLevelsHelperTest < ActionView::TestCase
     script_level_solved_response(response, script_level)
     refute response[:redirect].end_with?('extras')
   end
-
-  test 'do not get End-of-Stage experience if disabled for stage' do
-    stubs(:current_user).returns(@student)
-    script = @section.script
-    script_level = script.get_script_level_by_relative_position_and_puzzle_position 3, 14, false
-    script_level.lesson.stage_extras_disabled = true
-    script_level.lesson.save!
-    assert script_level.end_of_stage?, 'bad script_level selected for test'
-    @section.stage_extras = true
-    @section.save
-    response = {}
-
-    script_level_solved_response(response, script_level)
-    refute response[:redirect].end_with?('extras')
-  end
 end

--- a/dashboard/test/models/lesson_test.rb
+++ b/dashboard/test/models/lesson_test.rb
@@ -55,17 +55,13 @@ class StageTest < ActiveSupport::TestCase
     assert_equal stage.summarize[:levels].first[:uid], "#{stage.summarize[:levels].first[:ids].first}_0"
   end
 
-  test "summary for stage with and without extras" do
+  test "summary for stage with extras" do
     script = create :script, stage_extras_available: true
     level = create :level
     stage = create :lesson, script: script
     create :script_level, script: script, lesson: stage, levels: [level]
-    level2 = create :level
-    stage2 = create :lesson, script: script, stage_extras_disabled: true
-    create :script_level, script: script, lesson: stage2, levels: [level2]
 
     assert_match /extras$/, stage.summarize[:stage_extras_level_url]
-    assert_nil stage2.summarize[:stage_extras_level_url]
   end
 
   test "summary for stage with extras where include_bonus_levels is true" do


### PR DESCRIPTION
Saw this when reviewing for things that still need renaming from Stage -> Lesson. Don't know the context here, but wanted to see if we can delete this.

Does not seem like it's being used on any Lessons:

```
Winters-MacBook-Pro:scripts winterdong$ pwd
/Users/winterdong/CDO/code-dot-org/dashboard/config/scripts
Winters-MacBook-Pro:scripts winterdong$ grep -r no_extras .
Winters-MacBook-Pro:scripts winterdong$ grep -r stage_extras_disabled .
Winters-MacBook-Pro:scripts winterdong$ 
```
```
[production] dashboard > Lesson.all.select{|l| l.stage_extras_disabled?}
=> []
```

Or in frontend code:
```
Winters-MacBook-Pro:apps winterdong$ grep -r stage_extras_disabled .
grep: ./test/audio/assets/vignette4-intro.mp3: No such file or directory
grep: ./test/audio/assets/vignette4-intro.ogg: No such file or directory
	Winters-MacBook-Pro:apps winterdong$ 
```

<!-- ### Background -->
<!-- ### Privacy -->
<!-- ### Security -->
<!-- ### Caching -->
<!-- ### Deployment strategy -->
<!-- ### Future work -->

## Testing story

* searches above
* unit tests

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
