### PR TITLE
Baseline tests for image picker component

### DIFF
--- a/apps/src/code-studio/components/ImagePicker.jsx
+++ b/apps/src/code-studio/components/ImagePicker.jsx
@@ -84,7 +84,7 @@ export default class ImagePicker extends React.Component {
       !this.props.typeFilter || this.props.typeFilter === 'image';
     if (this.props.assetChosen && imageTypeFilter) {
       modeSwitch = (
-        <div>
+        <div id="modeSwitch">
           <p onClick={this.setFileMode} style={styles.fileModeToggle}>
             My Files
           </p>

--- a/apps/test/unit/code-studio/components/ImagePickerTest.js
+++ b/apps/test/unit/code-studio/components/ImagePickerTest.js
@@ -1,0 +1,25 @@
+import {assert} from '../../../util/reconfiguredChai';
+import React from 'react';
+import {shallow} from 'enzyme';
+import ImagePicker from '@cdo/apps/code-studio/components/ImagePicker';
+import IconLibrary from '@cdo/apps/code-studio/components/IconLibrary';
+
+describe('ImagePicker', () => {
+  const defaultProps = {
+    assetChosen: () => true,
+    typeFilter: 'image',
+    uploadsEnabled: false,
+    showUnderageWarning: false,
+    useFilesApi: false
+  };
+  it('shows two tabs by default', () => {
+    const wrapper = shallow(<ImagePicker {...defaultProps} />);
+    assert.equal(wrapper.find('#modeSwitch').length, 1);
+  });
+  it('shows icon picker when clicked', () => {
+    const wrapper = shallow(<ImagePicker {...defaultProps} />);
+    wrapper.find('p[children="Icons"]').simulate('click');
+    console.log(wrapper.debug());
+    assert.equal(wrapper.find(IconLibrary).length, 1);
+  });
+});

--- a/apps/test/unit/code-studio/components/ImagePickerTest.js
+++ b/apps/test/unit/code-studio/components/ImagePickerTest.js
@@ -21,9 +21,7 @@ describe('ImagePicker', () => {
 
   it('shows icons and files as options', () => {
     const wrapper = shallow(<ImagePicker {...defaultProps} />);
-    const tabs = wrapper
-      .find('#modeSwitch')
-      .find('p');
+    const tabs = wrapper.find('#modeSwitch').find('p');
 
     assert.equal(tabs.length, 2);
     assert.equal(tabs.find('p[children="Icons"]').length, 1);

--- a/apps/test/unit/code-studio/components/ImagePickerTest.js
+++ b/apps/test/unit/code-studio/components/ImagePickerTest.js
@@ -3,6 +3,7 @@ import React from 'react';
 import {shallow} from 'enzyme';
 import ImagePicker from '@cdo/apps/code-studio/components/ImagePicker';
 import IconLibrary from '@cdo/apps/code-studio/components/IconLibrary';
+import AssetManager from '@cdo/apps/code-studio/components/AssetManager';
 
 describe('ImagePicker', () => {
   const defaultProps = {
@@ -12,14 +13,31 @@ describe('ImagePicker', () => {
     showUnderageWarning: false,
     useFilesApi: false
   };
-  it('shows two tabs by default', () => {
+
+  it('shows mode switch', () => {
     const wrapper = shallow(<ImagePicker {...defaultProps} />);
     assert.equal(wrapper.find('#modeSwitch').length, 1);
   });
+
+  it('shows icons and files as options', () => {
+    const wrapper = shallow(<ImagePicker {...defaultProps} />);
+    const tabs = wrapper
+      .find('#modeSwitch')
+      .find('p');
+
+    assert.equal(tabs.length, 2);
+    assert.equal(tabs.find('p[children="Icons"]').length, 1);
+    assert.equal(tabs.find('p[children="My Files"]').length, 1);
+  });
+
+  it('initially shows file picker by default', () => {
+    const wrapper = shallow(<ImagePicker {...defaultProps} />);
+    assert.equal(wrapper.find(AssetManager).length, 1);
+  });
+
   it('shows icon picker when clicked', () => {
     const wrapper = shallow(<ImagePicker {...defaultProps} />);
     wrapper.find('p[children="Icons"]').simulate('click');
-    console.log(wrapper.debug());
     assert.equal(wrapper.find(IconLibrary).length, 1);
   });
 });


### PR DESCRIPTION
Add some basic tests for the imagePicker component, which is used in Applab to pick an image:

![image](https://user-images.githubusercontent.com/25372625/81095897-81257b80-8eba-11ea-943e-1e67f79850b8.png)

Pre-work for updates to `imagePicker` to show students it's possible to add an image directly from a URL.

## Testing story

New tests passed locally.

## Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
