### PR TITLE
Fix flaky enrollment unit assignment test

### DIFF
--- a/dashboard/test/models/plc/enrollment_unit_assignment_test.rb
+++ b/dashboard/test/models/plc/enrollment_unit_assignment_test.rb
@@ -51,9 +51,11 @@ class Plc::EnrollmentUnitAssignmentTest < ActiveSupport::TestCase
     PeerReview.stubs(:get_review_completion_status).returns(Plc::EnrollmentModuleAssignment::NOT_STARTED)
 
     # All the categories except Peer Review will be Content because there is no translation and that is the default
-    assert_equal ["/s/#{@script.name}#required", "/s/#{@script.name}#content", "/s/#{@script.name}#practice", "/s/#{@script.name}#peer-review"], @unit_enrollment.summarize_progress.map {|summary| summary[:link]}
+    assert_equal ["/s/#{@script.name}#required", "/s/#{@script.name}#content", "/s/#{@script.name}#practice", "/s/#{@script.name}#peer-review"],
+      @unit_enrollment.summarize_progress.map {|summary| summary[:link]}
 
-    assert_equal [Plc::EnrollmentModuleAssignment::NOT_STARTED], @unit_enrollment.summarize_progress.map {|summary| summary[:status]}.uniq
+    assert_equal [Plc::EnrollmentModuleAssignment::NOT_STARTED],
+      @unit_enrollment.summarize_progress.map {|summary| summary[:status]}.uniq
   end
 
   # All the categories except Peer Review will be Content because there is no translation and that is the default

--- a/dashboard/test/models/plc/enrollment_unit_assignment_test.rb
+++ b/dashboard/test/models/plc/enrollment_unit_assignment_test.rb
@@ -51,11 +51,11 @@ class Plc::EnrollmentUnitAssignmentTest < ActiveSupport::TestCase
     PeerReview.stubs(:get_review_completion_status).returns(Plc::EnrollmentModuleAssignment::NOT_STARTED)
 
     # All the categories except Peer Review will be Content because there is no translation and that is the default
-    assert_equal ["/s/#{@script.name}#required", "/s/#{@script.name}#content", "/s/#{@script.name}#practice", "/s/#{@script.name}#peer-review"],
-      @unit_enrollment.summarize_progress.map {|summary| summary[:link]}
+    assert_equal ["/s/#{@script.name}#required", "/s/#{@script.name}#content", "/s/#{@script.name}#practice", "/s/#{@script.name}#peer-review"].sort,
+      @unit_enrollment.summarize_progress.map {|summary| summary[:link]}.sort
 
-    assert_equal [Plc::EnrollmentModuleAssignment::NOT_STARTED],
-      @unit_enrollment.summarize_progress.map {|summary| summary[:status]}.uniq
+    assert_equal [Plc::EnrollmentModuleAssignment::NOT_STARTED].sort,
+      @unit_enrollment.summarize_progress.map {|summary| summary[:status]}.uniq.sort
   end
 
   # All the categories except Peer Review will be Content because there is no translation and that is the default

--- a/dashboard/test/models/plc/enrollment_unit_assignment_test.rb
+++ b/dashboard/test/models/plc/enrollment_unit_assignment_test.rb
@@ -51,28 +51,9 @@ class Plc::EnrollmentUnitAssignmentTest < ActiveSupport::TestCase
     PeerReview.stubs(:get_review_completion_status).returns(Plc::EnrollmentModuleAssignment::NOT_STARTED)
 
     # All the categories except Peer Review will be Content because there is no translation and that is the default
-    assert_equal [
-      {
-        category: "Content",
-        status: Plc::EnrollmentModuleAssignment::NOT_STARTED,
-        link: "/s/#{@script.name}#required"
-      },
-      {
-        category: "Content",
-        status: Plc::EnrollmentModuleAssignment::NOT_STARTED,
-        link: "/s/#{@script.name}#content"
-      },
-      {
-        category: "Content",
-        status: Plc::EnrollmentModuleAssignment::NOT_STARTED,
-        link: "/s/#{@script.name}#practice"
-      },
-      {
-        category: "Peer Review",
-        status: Plc::EnrollmentModuleAssignment::NOT_STARTED,
-        link: "/s/#{@script.name}#peer-review"
-      }
-    ], @unit_enrollment.summarize_progress
+    assert_equal ["/s/#{@script.name}#required", "/s/#{@script.name}#content", "/s/#{@script.name}#practice", "/s/#{@script.name}#peer-review"], @unit_enrollment.summarize_progress.map {|summary| summary[:link]}
+
+    assert_equal [Plc::EnrollmentModuleAssignment::NOT_STARTED], @unit_enrollment.summarize_progress.map {|summary| summary[:status]}.uniq
   end
 
   # All the categories except Peer Review will be Content because there is no translation and that is the default

--- a/dashboard/test/models/plc/enrollment_unit_assignment_test.rb
+++ b/dashboard/test/models/plc/enrollment_unit_assignment_test.rb
@@ -54,8 +54,8 @@ class Plc::EnrollmentUnitAssignmentTest < ActiveSupport::TestCase
     assert_equal ["/s/#{@script.name}#required", "/s/#{@script.name}#content", "/s/#{@script.name}#practice", "/s/#{@script.name}#peer-review"].sort,
       @unit_enrollment.summarize_progress.map {|summary| summary[:link]}.sort
 
-    assert_equal [Plc::EnrollmentModuleAssignment::NOT_STARTED].sort,
-      @unit_enrollment.summarize_progress.map {|summary| summary[:status]}.uniq.sort
+    assert_equal [Plc::EnrollmentModuleAssignment::NOT_STARTED],
+      @unit_enrollment.summarize_progress.map {|summary| summary[:status]}.uniq
   end
 
   # All the categories except Peer Review will be Content because there is no translation and that is the default


### PR DESCRIPTION
This test has been flaky since I updated it #34133. I hit it locally and the output was:

```
==== FAIL["test_Enrolling_user_in_a_course_creates_other_assignment_objects", "Plc::EnrollmentUnitAssignmentTest", 893.7549107875675]
test_Enrolling_user_in_a_course_creates_other_assignment_objects#Plc::EnrollmentUnitAssignmentTest (893.75s)
--- expected
+++ actual
@@ -1 +1 @@
-[{:category=>"Content", :status=>:not_started, :link=>"/s/bogus-script-604#required"}, {:category=>"Content", :status=>:not_started, :link=>"/s/bogus-script-604#content"}, {:category=>"Content", :status=>:not_started, :link=>"/s/bogus-script-604#practice"}, {:category=>"Peer Review", :status=>:not_started, :link=>"/s/bogus-script-604#peer-review"}]
+[{:category=>"Content", :status=>:not_started, :link=>"/s/bogus-script-604#content"}, {:category=>"Content", :status=>:not_started, :link=>"/s/bogus-script-604#practice"}, {:category=>"Content", :status=>:not_started, :link=>"/s/bogus-script-604#required"}, {:category=>"Peer Review", :status=>:not_started, :link=>"/s/bogus-script-604#peer-review"}]
test/models/plc/enrollment_unit_assignment_test.rb:54:in `block in <class:EnrollmentUnitAssignmentTest>'
test/testing/setup_all_and_teardown_all.rb:22:in `run'
```

It looks like the same hash values just in different orders. So i think the fact that all the categories are the same might be the issue here. So instead I check the other fields individually.