### PR TITLE
Foorm: Minor survey updates and version update

### DIFF
--- a/apps/package.json
+++ b/apps/package.json
@@ -250,7 +250,7 @@
     "selectize": "^0.12.4",
     "snack-build": "0.0.1",
     "snack-sdk": "2.3.6",
-    "survey-react": "^1.5.8",
+    "survey-react": "^1.7.4",
     "wgxpath": "^1.2.0",
     "whatwg-fetch": "^2.0.3"
   }

--- a/apps/yarn.lock
+++ b/apps/yarn.lock
@@ -15521,10 +15521,10 @@ supports-color@^6.1.0:
   dependencies:
     has-flag "^3.0.0"
 
-survey-react@^1.5.8:
-  version "1.5.8"
-  resolved "https://registry.yarnpkg.com/survey-react/-/survey-react-1.5.8.tgz#acd34b1eb234ea3f38ee12a3fe5c18495bfbd389"
-  integrity sha512-BgjTiPnzs7Tlp8D0VZZ2Rz+fjyQ3uKMkAJQWtY6OiOXtfeQvHlIiUrCd+CYaUjslzXugTgDK+qLWfFuqjUzQAg==
+survey-react@^1.7.4:
+  version "1.7.4"
+  resolved "https://registry.yarnpkg.com/survey-react/-/survey-react-1.7.4.tgz#41194f0c4c4a96a88676a19f812ff362aa62f243"
+  integrity sha512-s6MsZvHUbp9YYoMsmpxcGEL3hz0iWLUQQ3aR+C1V6EBQrHwnhUN0nl7llpQsTc5pn0l4r0kwlGpKMFArVVInIA==
 
 svg-tag-names@^1.1.0:
   version "1.1.1"

--- a/dashboard/config/foorm/forms/surveys/pd/workshop_csf_intro_post.0.json
+++ b/dashboard/config/foorm/forms/surveys/pd/workshop_csf_intro_post.0.json
@@ -1,5 +1,5 @@
 {
-  "title": "Satisfaction Survey for Code.org's CS Fundamentals 5-day Summer Professional Development Workshop",
+  "title": "Satisfaction Survey for Code.org's CS Fundamentals Intro Professional Development Workshop",
   "pages": [
     {
       "name": "page1",
@@ -282,7 +282,9 @@
           "type": "text",
           "name": "year_of_birth",
           "title": "What is your year of birth?",
-          "inputType": "number"
+          "inputType": "number",
+          "min":"1920",
+          "max": "2020"
         },
         {
           "type": "radiogroup",


### PR DESCRIPTION
Made a couple minor updates to the CSF Intro survey configuration--set a minimum and maximum for the birth year field and fixed the survey title.
Previously if you clicked on the arrows on the birth year field it would start at 1, now it starts at 1920.

Also updated the version we use for survey-react (the surveyjs package), as the min/max date capability was added in a later version than what we were using.

<!-- ### Background -->
<!-- ### Privacy -->
<!-- ### Security -->
<!-- ### Caching -->
<!-- ### Deployment strategy -->
<!-- ### Future work -->

## Links

- [jira](https://codedotorg.atlassian.net/browse/PLC-879)

## Testing story
Tested in multiple browsers that the survey title is now correct and the birth year field uses the new min/max.

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
