### PR TITLE
Updated mailers for facilitator workshops

### DIFF
--- a/bin/oneoff/diff_email_previews
+++ b/bin/oneoff/diff_email_previews
@@ -26,6 +26,7 @@ PREVIEWS = %w(
   exit_survey__csf_deepdive
   exit_survey__csf_intro
   exit_survey__csp_1
+  exit_survey__csp_for_returning_teachers
   exit_survey__csp_summer_workshop
   exit_survey__general
   facilitator_detail_change_notification__csf_intro
@@ -46,12 +47,14 @@ PREVIEWS = %w(
   teacher_enrollment_receipt__csf_deepdive
   teacher_enrollment_receipt__csf_intro
   teacher_enrollment_receipt__csp_1
+  teacher_enrollment_receipt__csp_for_returning_teachers
   teacher_enrollment_receipt__csp_summer_workshop
   teacher_enrollment_receipt__ecs_phase_4
   teacher_enrollment_receipt__ecs_unit_3
   teacher_enrollment_receipt__ecs_unit_4
   teacher_enrollment_receipt__ecs_unit_5
   teacher_enrollment_receipt__ecs_unit_6
+  teacher_enrollment_receipt__facilitator
   teacher_enrollment_receipt__formatted_notes
   teacher_enrollment_receipt__phase_2
   teacher_enrollment_receipt_csd_1
@@ -65,8 +68,11 @@ PREVIEWS = %w(
   teacher_enrollment_reminder__csf_intro_3_day
   teacher_enrollment_reminder__csp_1_10_day
   teacher_enrollment_reminder__csp_1_3_day
+  teacher_enrollment_reminder__csp_for_returning_teachers_10_day
+  teacher_enrollment_reminder__csp_for_returning_teachers_3_day
   teacher_enrollment_reminder__csp_summer_workshop_10_day
   teacher_enrollment_reminder__csp_summer_workshop_3_day
+  teacher_enrollment_reminder__facilitator
   teacher_enrollment_reminder_csd_1_10_day
   teacher_enrollment_reminder_csd_1_3_day
   teacher_enrollment_reminder_csd_unit_6_3_day

--- a/dashboard/app/mailers/pd/workshop_mailer.rb
+++ b/dashboard/app/mailers/pd/workshop_mailer.rb
@@ -41,13 +41,14 @@ class Pd::WorkshopMailer < ActionMailer::Base
     @details_partial = get_details_partial @workshop.course, @workshop.subject
     @online_url = ONLINE_URL
     @is_enrollment_receipt = true
-    from = from_teacher
-    reply_to = email_address(@workshop.organizer.name, @workshop.organizer.email)
 
     # Facilitator training workshops use different email addresses
     if @enrollment.workshop.course == Pd::Workshop::COURSE_FACILITATOR
       from = from_facilitators
       reply_to = from_facilitators
+    else
+      from = from_teacher
+      reply_to = email_address(@workshop.organizer.name, @workshop.organizer.email)
     end
 
     mail content_type: 'text/html',
@@ -106,13 +107,13 @@ class Pd::WorkshopMailer < ActionMailer::Base
     @pre_workshop_survey_url = enrollment.pre_workshop_survey_url
     @is_first_pre_survey_email = days_before == INITIAL_PRE_SURVEY_DAYS_BEFORE
 
-    from = from_teacher
-    reply_to = email_address(@workshop.organizer.name, @workshop.organizer.email)
-
     # Facilitator training workshops use a different email address
     if @enrollment.workshop.course == Pd::Workshop::COURSE_FACILITATOR
       from = from_facilitators
       reply_to = from_facilitators
+    else
+      from = from_teacher
+      reply_to = email_address(@workshop.organizer.name, @workshop.organizer.email)
     end
 
     return if @workshop.suppress_reminders?

--- a/dashboard/app/mailers/pd/workshop_mailer.rb
+++ b/dashboard/app/mailers/pd/workshop_mailer.rb
@@ -41,12 +41,20 @@ class Pd::WorkshopMailer < ActionMailer::Base
     @details_partial = get_details_partial @workshop.course, @workshop.subject
     @online_url = ONLINE_URL
     @is_enrollment_receipt = true
+    from = from_teacher
+    reply_to = email_address(@workshop.organizer.name, @workshop.organizer.email)
+
+    # Facilitator training workshops use different email addresses
+    if @enrollment.workshop.course == Pd::Workshop::COURSE_FACILITATOR
+      from = from_facilitators
+      reply_to = from_facilitators
+    end
 
     mail content_type: 'text/html',
-      from: from_teacher,
+      from: from,
       subject: teacher_enrollment_subject(@workshop),
       to: email_address(@enrollment.full_name, @enrollment.email),
-      reply_to: email_address(@workshop.organizer.name, @workshop.organizer.email)
+      reply_to: reply_to
   end
 
   def organizer_enrollment_receipt(enrollment)
@@ -98,13 +106,22 @@ class Pd::WorkshopMailer < ActionMailer::Base
     @pre_workshop_survey_url = enrollment.pre_workshop_survey_url
     @is_first_pre_survey_email = days_before == INITIAL_PRE_SURVEY_DAYS_BEFORE
 
+    from = from_teacher
+    reply_to = email_address(@workshop.organizer.name, @workshop.organizer.email)
+
+    # Facilitator training workshops use a different email address
+    if @enrollment.workshop.course == Pd::Workshop::COURSE_FACILITATOR
+      from = from_facilitators
+      reply_to = from_facilitators
+    end
+
     return if @workshop.suppress_reminders?
 
     mail content_type: 'text/html',
-      from: from_teacher,
+      from: from,
       subject: teacher_enrollment_subject(@workshop),
       to: email_address(@enrollment.full_name, @enrollment.email),
-      reply_to: email_address(@workshop.organizer.name, @workshop.organizer.email)
+      reply_to: reply_to
   end
 
   def facilitator_enrollment_reminder(user, workshop)
@@ -249,6 +266,10 @@ class Pd::WorkshopMailer < ActionMailer::Base
 
   def from_teacher
     email_address('Code.org', 'teacher@code.org')
+  end
+
+  def from_facilitators
+    email_address('Code.org', 'facilitators@code.org')
   end
 
   def from_no_reply

--- a/dashboard/app/views/pd/workshop_mailer/_teacher_enrollment_details_facilitator.html.haml
+++ b/dashboard/app/views/pd/workshop_mailer/_teacher_enrollment_details_facilitator.html.haml
@@ -11,7 +11,7 @@
 
 %p
   Please have the following with you on the day of your session to ensure you
-  are able to participate fully.
+  are able to participate fully:
 
 %ul
   %li
@@ -19,7 +19,7 @@
     = link_to 'this page', Pd::WorkshopMailer::SUPPORTED_TECH_URL
     for more information regarding compatible operating systems and browsers.
     We do not recommend bringing a tablet as your primary device.
-  %li Download the Zoom app (more information below)
+  %li Download the Zoom app. (more information below)
   %li Headphones or earphones. (optional)
   %li Your curiosity and readiness to learn!
 

--- a/dashboard/app/views/pd/workshop_mailer/_teacher_enrollment_details_facilitator.html.haml
+++ b/dashboard/app/views/pd/workshop_mailer/_teacher_enrollment_details_facilitator.html.haml
@@ -1,0 +1,82 @@
+- pre_work_url = 'https://docs.google.com/document/d/1mmBcMoRKO2TVxQSEEb-SxMnhuDZUkjE06tHa-8CGeyE/edit'
+- zoom_download_url = 'https://zoom.us/download'
+- learning_tips_url = 'https://docs.google.com/document/d/e/2PACX-1vQbiURoyzHZhWrmT8jbXq7QRiCMicUIO58EQQcw7aIPdZrxhfn1XP64djtg2TVFTsBNEUZnSYHSx4Lx/pub'
+- digital_digest_url = 'https://bit.ly/summer-prep-sessions'
+
+= render partial: 'workshop_logistics'
+
+= render partial: 'workshop_notes'
+
+%h3 Materials
+
+%p
+  Please have the following with you on the day of your session to ensure you
+  are able to participate fully.
+
+%ul
+  %li
+    Laptop and charger, as well as any adapters. Review
+    = link_to 'this page', Pd::WorkshopMailer::SUPPORTED_TECH_URL
+    for more information regarding compatible operating systems and browsers.
+    We do not recommend bringing a tablet as your primary device.
+  %li Download the Zoom app (more information below)
+  %li Headphones or earphones. (optional)
+  %li Your curiosity and readiness to learn!
+
+%h3 Complete your pre-work and download Zoom
+
+%p
+  To prepare for our time together, we ask that you engage with your pre-work
+  materials (linked below), which should take about
+  %strong 90 minutes
+  to complete. We’ve designed these resources to help you prepare for summer
+  workshops given your region’s chosen delivery modality.
+
+%p
+  = link_to 'Click here', pre_work_url
+  to access pre-work. Pre-work will be added as ready.
+
+%p
+  All of our sessions will be taking place via Zoom, so we strongly recommend
+  that you
+  %strong
+    download the Zoom app
+    = surround '(', ' for download options)' do
+      = link_to 'click here', zoom_download_url
+  because it offers a more reliable connection than the standard browser AND
+  will allow you to fully participate in the activities we’ve planned. Be sure
+  to also check out our
+  = link_to 'Tips for Having a Great Virtual Learning Experience', learning_tips_url
+  for more information about steps you can take to prepare for our time together.
+
+%h3 Visit and bookmark the Digital Digest
+
+%p
+  We also ask that you take a few moments to check out and bookmark the
+  = link_to 'Digital Digest', digital_digest_url
+  = surround '(', ').' do
+    = link_to(digital_digest_url, digital_digest_url)
+  It will serve as your one-stop-shop for a ton of important information, such
+  as your pre-work, session join links, notes doc, and more!
+
+%p
+  Keep an eye out for a calendar invite with the meeting link that will be sent
+  out roughly the week prior to the session.
+
+%h3 Did something come up? If you can’t make it, let us know
+
+%p
+  If for any reason, you can’t make it, please click this link to
+  = link_to 'cancel your registration', @cancel_url, target: "_blank"
+  so we can open up your spot to other interested educators.
+
+%p
+  If you have any questions, reach out to us directly at
+  = link_to('facilitators@code.org', 'mailto:facilitators@code.org') + '.'
+
+%p
+  Thank you,
+  %br
+  Megan Hochstatter
+  %br
+  Program Manager of K-12 Professional Learning Programs

--- a/dashboard/app/views/pd/workshop_mailer/teacher_enrollment_receipt.html.haml
+++ b/dashboard/app/views/pd/workshop_mailer/teacher_enrollment_receipt.html.haml
@@ -14,6 +14,10 @@
     5-day Summer workshop on the Code.org
     = @workshop.course
     curriculum.
+- elsif Pd::Workshop::COURSE_FACILITATOR == @workshop.course
+  %p
+    Thanks for enrolling in Code.org’s summer workshop prep session. We look
+    forward to seeing you there!
 - else
   %p
     Thanks for enrolling in Code.org’s
@@ -32,5 +36,7 @@
 
 -if [Pd::Workshop::COURSE_COUNSELOR, Pd::Workshop::COURSE_ADMIN].include? @workshop.course
   = render partial: 'teacher_enrollment_details_counselor'
+- elsif Pd::Workshop::COURSE_FACILITATOR == @workshop.course
+  = render partial: 'teacher_enrollment_details_facilitator'
 -else
   = render partial: 'teacher_enrollment_details'

--- a/dashboard/app/views/pd/workshop_mailer/teacher_enrollment_reminder.html.haml
+++ b/dashboard/app/views/pd/workshop_mailer/teacher_enrollment_reminder.html.haml
@@ -12,6 +12,10 @@
     This is a reminder about your upcoming 5-day summer workshop on the Code.org
     = @workshop.course
     curriculum.
+- elsif @workshop.course == Pd::Workshop::COURSE_FACILITATOR
+  %p
+    I wanted to remind you about your upcoming Code.org summer workshop prep
+    session.
 - elsif @workshop.course == Pd::Workshop::COURSE_CSF
   %p
     I wanted to remind you about your upcoming Code.org
@@ -44,7 +48,7 @@
     your workshop, reach out to your workshop organizer directly:
     = "#{@organizer.name} at "
     = mail_to @organizer.email, "#{@organizer.email}."
-- else
+- elsif @workshop.subject != Pd::Workshop::COURSE_FACILITATOR
   %p
     - if @workshop.course == Pd::Workshop::COURSE_CSF
       This is a great step towards bringing computer science to your classroom!
@@ -74,5 +78,7 @@
 
 -if [Pd::Workshop::COURSE_COUNSELOR, Pd::Workshop::COURSE_ADMIN].include? @workshop.course
   = render partial: 'teacher_enrollment_details_counselor'
+-elsif Pd::Workshop::COURSE_FACILITATOR == @workshop.course
+  = render partial: 'teacher_enrollment_details_facilitator'
 -else
   = render partial: 'teacher_enrollment_details'

--- a/dashboard/test/mailers/previews/pd_workshop_mailer_preview.rb
+++ b/dashboard/test/mailers/previews/pd_workshop_mailer_preview.rb
@@ -135,6 +135,15 @@ class Pd::WorkshopMailerPreview < ActionMailer::Preview
     mail :teacher_enrollment_reminder, Pd::Workshop::COURSE_COUNSELOR
   end
 
+  def teacher_enrollment_receipt__facilitator
+    mail :teacher_enrollment_receipt, Pd::Workshop::COURSE_FACILITATOR
+  end
+
+  def teacher_enrollment_reminder__facilitator
+    mail :teacher_enrollment_reminder, Pd::Workshop::COURSE_FACILITATOR,
+      options: {days_before: 10}
+  end
+
   def teacher_enrollment_reminder__csp_for_returning_teachers_10_day
     mail :teacher_enrollment_reminder, Pd::Workshop::COURSE_CSP, Pd::Workshop::SUBJECT_CSP_FOR_RETURNING_TEACHERS,
       options: {days_before: 10}


### PR DESCRIPTION
Customizes the facilitator workshop enrollment receipt and enrollment reminder emails, [as spec'd here](https://docs.google.com/document/d/17BaHQgeyAbvNZNxH_GjIKvGjqkLWa2XiDa57rsbIw38/edit#heading=h.kqapnvm82edn).

## Testing story

Manually tested using local mailer previews.  Verified with the `diff_email_previews` script that no other mailers were changed.

Enrollment receipt (Facilitator workshop):

| Before | After |
| --- | --- |
| ![image](https://user-images.githubusercontent.com/1615761/81209270-2c026c00-8f85-11ea-97a9-1cd9fc65f1fd.png) | ![image](https://user-images.githubusercontent.com/1615761/81209098-e6de3a00-8f84-11ea-91ff-73a9d6b3a0e9.png) |

Enrollment reminder (Facilitator workshop):

| Before | After |
| --- | --- |
| ![image](https://user-images.githubusercontent.com/1615761/81209315-3b81b500-8f85-11ea-94f6-550530b32b57.png) | ![image](https://user-images.githubusercontent.com/1615761/81209164-007f8180-8f85-11ea-8e0f-b3d00be66663.png) |

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
