### PR TITLE
Fallback to perfect == false if no user is signed in

### DIFF
--- a/dashboard/app/models/script.rb
+++ b/dashboard/app/models/script.rb
@@ -768,7 +768,7 @@ class Script < ActiveRecord::Base
       @all_bonus_script_levels = lessons.map do |stage|
         {
           stageNumber: stage.relative_position,
-          levels: stage.script_levels.select(&:bonus).map {|bonus_level| bonus_level.summarize_as_bonus(current_user.id)}
+          levels: stage.script_levels.select(&:bonus).map {|bonus_level| bonus_level.summarize_as_bonus(current_user&.id)}
         }
       end
       @all_bonus_script_levels.select! {|stage| stage[:levels].any?}

--- a/dashboard/app/models/script_level.rb
+++ b/dashboard/app/models/script_level.rb
@@ -361,7 +361,8 @@ class ScriptLevel < ActiveRecord::Base
     extra_levels
   end
 
-  def summarize_as_bonus(user_id)
+  def summarize_as_bonus(user_id = nil)
+    perfect = user_id ? UserLevel.find_by(level: level, user_id: user_id)&.perfect? : false
     {
       id: id,
       type: level.type,
@@ -369,7 +370,7 @@ class ScriptLevel < ActiveRecord::Base
       display_name: level.display_name || I18n.t('lesson_extras.bonus_level'),
       thumbnail_url: level.try(:thumbnail_url) || level.try(:solution_image_url),
       url: build_script_level_url(self),
-      perfect: UserLevel.find_by(level: level, user_id: user_id)&.perfect?,
+      perfect: perfect,
       maze_summary: {
         map: JSON.parse(level.try(:maze) || '[]'),
         serialized_maze: level.try(:serialized_maze) && JSON.parse(level.try(:serialized_maze)),


### PR DESCRIPTION
Fixes an issue @bethanyaconnor noticed in Honeybadger where the stage extras page fails to load (renders a sad bee) if there is no signed in user. This adds a fallback so that `current_user` is no longer required

## Links

- [Slack thread](https://codedotorg.slack.com/archives/CA3KCSGTD/p1588715237437200)

## Testing story

Manually tested that the page loads properly for signed out users.

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
