### PR TITLE
Modify searchAssets so that it works with non-latin characters

### DIFF
--- a/apps/src/code-studio/assets/searchAssets.js
+++ b/apps/src/code-studio/assets/searchAssets.js
@@ -41,7 +41,6 @@ export function searchAssets(
     .reduce((resultSet, nextAlias) => {
       return resultSet.union(assetLibrary.aliases[nextAlias]);
     }, Immutable.Set());
-  console.log(resultSet);
 
   if (categoryQuery !== '' && categoryQuery !== 'category_all') {
     let categoryResultSet = Object.keys(assetLibrary.aliases)

--- a/apps/src/code-studio/assets/searchAssets.js
+++ b/apps/src/code-studio/assets/searchAssets.js
@@ -1,5 +1,16 @@
 import Immutable from 'immutable';
 
+function prefixMatch(alias, search) {
+  const words = alias.split(RegExp('-|_'));
+  var matchFound = false;
+  words.forEach(word => {
+    if (word.startsWith(search)) {
+      matchFound = true;
+    }
+  });
+  return matchFound;
+}
+
 /**
  * Given a search query, generate a results list of animationProps objects that
  * can be displayed and used to add an animation to the project.
@@ -23,14 +34,14 @@ export function searchAssets(
   // Example: searchQuery "bar"
   //   Will match: "barbell", "foo-bar", "foo_bar" or "foo bar"
   //   Will not match: "foobar", "ubar"
-  const searchRegExp = new RegExp('(?:\\b|_)' + searchQuery, 'i');
 
   // Generate the set of all results associated with all matched aliases
   let resultSet = Object.keys(assetLibrary.aliases)
-    .filter(alias => searchRegExp.test(alias))
+    .filter(alias => prefixMatch(alias, searchQuery))
     .reduce((resultSet, nextAlias) => {
       return resultSet.union(assetLibrary.aliases[nextAlias]);
     }, Immutable.Set());
+  console.log(resultSet);
 
   if (categoryQuery !== '' && categoryQuery !== 'category_all') {
     let categoryResultSet = Object.keys(assetLibrary.aliases)

--- a/apps/src/p5lab/AnimationPicker/AnimationPickerBody.jsx
+++ b/apps/src/p5lab/AnimationPicker/AnimationPickerBody.jsx
@@ -104,6 +104,9 @@ class AnimationPickerBody extends React.Component {
     let libraryManifest = this.props.spriteLab
       ? spriteCostumeLibrary
       : animationLibrary;
+    if (!libraryManifest) {
+      return <div>Loading...</div>;
+    }
     let categories = this.props.spriteLab
       ? CostumeCategories
       : AnimationCategories;

--- a/apps/src/p5lab/AnimationPicker/AnimationPickerBody.jsx
+++ b/apps/src/p5lab/AnimationPicker/AnimationPickerBody.jsx
@@ -104,9 +104,6 @@ class AnimationPickerBody extends React.Component {
     let libraryManifest = this.props.spriteLab
       ? spriteCostumeLibrary
       : animationLibrary;
-    if (!libraryManifest) {
-      return <div>Loading...</div>;
-    }
     let categories = this.props.spriteLab
       ? CostumeCategories
       : AnimationCategories;

--- a/apps/src/p5lab/spritelab/spriteCostumeLibrary.json
+++ b/apps/src/p5lab/spritelab/spriteCostumeLibrary.json
@@ -7836,7 +7836,6 @@
     "monster_in_case": ["category_characters/monster_in_case"],
     "motorcycle": ["category_vehicles/motorcycle"],
     "mouse": ["category_animals/mouse"],
-    "ratón": ["category_animals/mouse"],
     "mouse_gray": ["category_animals/mouse_gray"],
     "mushroom_brown": ["category_food/mushroom_brown"],
     "mushroom_red": ["category_food/mushroom_red"],

--- a/apps/src/p5lab/spritelab/spriteCostumeLibrary.json
+++ b/apps/src/p5lab/spritelab/spriteCostumeLibrary.json
@@ -7836,6 +7836,7 @@
     "monster_in_case": ["category_characters/monster_in_case"],
     "motorcycle": ["category_vehicles/motorcycle"],
     "mouse": ["category_animals/mouse"],
+    "ratón": ["category_animals/mouse"],
     "mouse_gray": ["category_animals/mouse_gray"],
     "mushroom_brown": ["category_food/mushroom_brown"],
     "mushroom_red": ["category_food/mushroom_red"],

--- a/apps/test/unit/code-studio/searchAssetsTest.js
+++ b/apps/test/unit/code-studio/searchAssetsTest.js
@@ -4,6 +4,7 @@ import assert from 'assert';
 import {searchAssets} from '@cdo/apps/code-studio/assets/searchAssets';
 import animationLibrary from '@cdo/apps/p5lab/gamelab/animationLibrary.json';
 import soundLibrary from '@cdo/apps/code-studio/soundLibrary.json';
+import translatedAnimationLibrary from './translatedAnimationLibrary.json';
 
 describe('search assets from animation library', function() {
   it('searchAssets searches the animation library in a category', function() {
@@ -116,5 +117,19 @@ describe('search assets from animation library', function() {
       searchedData.results[0].name,
       'lighthearted_bonus_objective_2'
     );
+  });
+
+  it('can search non-latin characters', function() {
+    const maxResults = 3;
+    const pageCount = 0;
+    const searchedData = searchAssets(
+      'медведь',
+      '',
+      translatedAnimationLibrary,
+      pageCount,
+      maxResults
+    );
+
+    assert.equal(searchedData.results.length, 2);
   });
 });

--- a/apps/test/unit/code-studio/translatedAnimationLibrary.json
+++ b/apps/test/unit/code-studio/translatedAnimationLibrary.json
@@ -1,0 +1,53 @@
+{
+  "//": [
+    "Animation Library Manifest",
+    "GENERATED FILE: DO NOT MODIFY DIRECTLY",
+    "See tools/scripts/rebuildAnimationLibraryManifest.rb for more information."
+  ],
+  "metadata": {
+    "category_animals/bear": {
+      "name": "медведь",
+      "frameCount": 1,
+      "frameSize": {
+        "x": 254,
+        "y": 333
+      },
+      "looping": true,
+      "frameDelay": 2,
+      "jsonLastModified": "2020-01-29 19:47:52 UTC",
+      "pngLastModified": "2020-01-29 19:47:52 UTC",
+      "version": "5exqcW6rEnA.7zF34mgDjj_2F9cqpi4w",
+      "sourceUrl": "/api/v1/animation-library/gamelab/5exqcW6rEnA.7zF34mgDjj_2F9cqpi4w/category_animals/bear.png",
+      "sourceSize": {
+        "x": 254,
+        "y": 333
+      }
+    },
+    "category_animals/bear_with_fish": {
+      "name": "медведь с рыбой",
+      "frameCount": 1,
+      "frameSize": {
+        "x": 222,
+        "y": 300
+      },
+      "looping": true,
+      "frameDelay": 2,
+      "jsonLastModified": "2020-01-29 19:47:53 UTC",
+      "pngLastModified": "2020-01-29 19:47:52 UTC",
+      "version": "MatyzuecEWjBMV8EmXXC1W7PqpeBhK.t",
+      "sourceUrl": "/api/v1/animation-library/gamelab/MatyzuecEWjBMV8EmXXC1W7PqpeBhK.t/category_animals/bear_with_fish.png",
+      "sourceSize": {
+        "x": 222,
+        "y": 300
+      }
+    }
+  },
+  "aliases": {
+    "медведь": [
+      "category_animals/bear"
+    ],
+    "медведь с рыбой": [
+      "category_animals/bear_with_fish"
+    ]
+  }
+} 


### PR DESCRIPTION
The current implementation we have doesn't work with non-latin characters. It seems like we're only checking for prefix matches on the words in the alias, which doesn't necessarily need a regex.

<!-- ### Background -->
<!-- ### Privacy -->
<!-- ### Security -->
<!-- ### Caching -->
<!-- ### Deployment strategy -->
<!-- ### Future work -->

## Links

<!--
  Any relevant links to external resources; ie, specification documents, jira
  items, related PRs, honeybadger errors, etc
-->

- [spec]()
- [jira]()

## Testing story

<!--
  Does your change include appropriate tests?

  If so, please describe how the tests included in this PR are sufficient

  If not, please explain why this change does not need to be tested.
-->

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
