### PR TITLE
Course Explorer: delete repeated 'the'

### DIFF
--- a/shared/haml/course_explorer_table.haml
+++ b/shared/haml/course_explorer_table.haml
@@ -153,7 +153,7 @@
     link: CDO.code_org_url("/educate/curriculum/express-course"),
     course_link: CDO.studio_url("/s/express"),
     img: "/shared/images/courses/logo_tall_express.jpg",
-    description: "For a lightweight option that can be integrated as a supplemental resource in an existing technology or programming class, or as an after-school program, Code.org offers the the 30-hour Computer Science Fundamentals Express Course. This course covers all the core concepts from the elementary school curriculum <a href='#{k5_curriculum_link}'>Computer Science Fundamentals</a>, but at an accelerated pace designed for older students.
+    description: "For a lightweight option that can be integrated as a supplemental resource in an existing technology or programming class, or as an after-school program, Code.org offers the 30-hour Computer Science Fundamentals Express Course. This course covers all the core concepts from the elementary school curriculum <a href='#{k5_curriculum_link}'>Computer Science Fundamentals</a>, but at an accelerated pace designed for older students.
       <ul>
         <li> <strong>Audience:</strong> Students ages 9-18</li>
         <li> <strong>Curriculum length:</strong> 30 hours</li>


### PR DESCRIPTION
A very attentive user found a typo in the Course Explorer and wrote in via [Zendesk](https://codeorg.zendesk.com/agent/tickets/279049).  I fixed it.

Before: 
<img width="644" alt="double-the" src="https://user-images.githubusercontent.com/12300669/81127790-3de7fe80-8ef4-11ea-8f25-0c976d2e5e8a.png">

After: 
<img width="660" alt="Screen Shot 2020-05-05 at 5 14 35 PM" src="https://user-images.githubusercontent.com/12300669/81127740-05482500-8ef4-11ea-876c-dbb861d37373.png">

