### PR TITLE
Section SetUp: metrics for hide, show, reset secrets 

### DIFF
--- a/apps/src/templates/manageStudents/ShowSecret.jsx
+++ b/apps/src/templates/manageStudents/ShowSecret.jsx
@@ -8,6 +8,7 @@ import i18n from '@cdo/locale';
 import {SectionLoginType} from '@cdo/apps/util/sharedConstants';
 import {setSecretImage, setSecretWords} from './manageStudentsRedux';
 import {pegasus} from '@cdo/apps/lib/util/urlHelpers';
+import firehoseClient from '@cdo/apps/lib/util/firehose';
 
 const styles = {
   reset: {
@@ -38,18 +39,47 @@ class ShowSecret extends Component {
   };
 
   show = () => {
+    const {sectionId, id, loginType} = this.props;
     this.setState({
       isShowing: true
     });
+    firehoseClient.putRecord(
+      {
+        study: 'teacher-dashboard',
+        study_group: 'manage-students',
+        event: 'show-secret',
+        data_json: JSON.stringify({
+          sectionId: sectionId,
+          studentId: id,
+          loginType: loginType
+        })
+      },
+      {includeUserId: true}
+    );
   };
 
   hide = () => {
+    const {sectionId, id, loginType} = this.props;
     this.setState({
       isShowing: false
     });
+    firehoseClient.putRecord(
+      {
+        study: 'teacher-dashboard',
+        study_group: 'manage-students',
+        event: 'hide-secret',
+        data_json: JSON.stringify({
+          sectionId: sectionId,
+          studentId: id,
+          loginType: loginType
+        })
+      },
+      {includeUserId: true}
+    );
   };
 
   reset = () => {
+    const {sectionId, id, loginType} = this.props;
     const dataToUpdate = {
       secrets: 'reset_secrets',
       student: {id: this.props.id}
@@ -69,6 +99,19 @@ class ShowSecret extends Component {
         } else if (this.props.loginType === SectionLoginType.word) {
           this.props.setSecretWords(this.props.id, data.secret_words);
         }
+        firehoseClient.putRecord(
+          {
+            study: 'teacher-dashboard',
+            study_group: 'manage-students',
+            event: 'reset-secret',
+            data_json: JSON.stringify({
+              sectionId: sectionId,
+              studentId: id,
+              loginType: loginType
+            })
+          },
+          {includeUserId: true}
+        );
       })
       .fail((jqXhr, status) => {
         // We may want to handle this more cleanly in the future, but for now this


### PR DESCRIPTION
[LP-1432](https://codedotorg.atlassian.net/browse/LP-1432)
[Spec](https://docs.google.com/document/d/1YaC8yPL4QUNshj0zXmCZJ1o-FcGYb1Dexv9J0-acHuM/edit) Requirement 8, Action 2

Log metrics for showing, hiding and resetting passwords for word and picture login type sections. 

**Show secret:** 
<img width="710" alt="Screen Shot 2020-05-05 at 7 48 15 PM" src="https://user-images.githubusercontent.com/12300669/81135037-7f37d880-8f0b-11ea-9106-d63d1a95e94a.png">

**Hide secret:** 
<img width="695" alt="Screen Shot 2020-05-05 at 7 51 46 PM" src="https://user-images.githubusercontent.com/12300669/81135035-7cd57e80-8f0b-11ea-884f-e6271df89732.png">


**Reset secret:** 
<img width="677" alt="Screen Shot 2020-05-05 at 7 52 17 PM" src="https://user-images.githubusercontent.com/12300669/81135032-7ba45180-8f0b-11ea-9010-e5bb20274006.png">
