### PR TITLE
Section SetUp: email login type improvements

### DIFF
--- a/apps/i18n/common/en_us.json
+++ b/apps/i18n/common/en_us.json
@@ -1518,7 +1518,7 @@
   "setUpClassWordPic1": "1. Add each of your students in the table above.",
   "setUpClassWord2": "2. [Print login cards]({printLoginCardLink}) that show each student's name and 'secret words'. Share these with your students.",
   "setUpClassPic2": "2. [Print login cards]({printLoginCardLink}) that show each student's name and picture password. Share these with your students.",
-  "setUpClassEmailIntro": "To get your class set up with picture password accounts, do the following:",
+  "setUpClassEmailIntro": "To get your class set up with personal logins, do the following:",
   "setUpClassEmail1": "1. Have your students [create Code.org accounts]({createAccountLink}) with their own email addresses. If they already have a Code.org account associated with their email address, they can skip this step.",
   "setUpClassEmail2": "2. Have your students visit this link to join your section: [{joinLink}]({joinLink})",
   "setUpClass3": "3. [Share our privacy letter]({parentLetterLink}) with parents to introduce them to Code.org and allow them to review our policies on student privacy.",

--- a/apps/src/templates/manageStudents/PasswordReset.jsx
+++ b/apps/src/templates/manageStudents/PasswordReset.jsx
@@ -4,13 +4,18 @@ import ReactTooltip from 'react-tooltip';
 import _ from 'lodash';
 import Button from '../Button';
 import i18n from '@cdo/locale';
+import firehoseClient from '@cdo/apps/lib/util/firehose';
 
 const styles = {
   input: {
-    width: 100,
+    width: '90%',
     height: 29,
-    marginTop: -25,
-    marginRight: 10
+    marginRight: 10,
+    marginLeft: 5,
+    padding: 5
+  },
+  button: {
+    margin: 5
   }
 };
 
@@ -59,6 +64,19 @@ class PasswordReset extends Component {
           isResetting: false,
           input: ''
         });
+        firehoseClient.putRecord(
+          {
+            study: 'teacher-dashboard',
+            study_group: 'manage-students',
+            event: 'reset-secret',
+            data_json: JSON.stringify({
+              sectionId: sectionId,
+              studentId: studentId,
+              loginType: 'email'
+            })
+          },
+          {includeUserId: true}
+        );
       })
       .fail((jqXhr, status) => {
         // We may want to handle this more cleanly in the future, but for now this
@@ -109,15 +127,15 @@ class PasswordReset extends Component {
               onClick={this.save}
               color={Button.ButtonColor.blue}
               text={i18n.save()}
+              style={styles.button}
             />
-            <div>
-              <Button
-                __useDeprecatedTag
-                onClick={this.cancel}
-                color={Button.ButtonColor.white}
-                text={i18n.cancel()}
-              />
-            </div>
+            <Button
+              __useDeprecatedTag
+              onClick={this.cancel}
+              color={Button.ButtonColor.white}
+              text={i18n.cancel()}
+              style={styles.button}
+            />
           </div>
         )}
       </div>


### PR DESCRIPTION
3 changes related to the Manage Students table for person email sections: 

1.) Logging for reseting email passwords, similar to  #34647 for word and picture login types  
<img width="669" alt="Screen Shot 2020-05-05 at 8 27 19 PM" src="https://user-images.githubusercontent.com/12300669/81136176-ab555880-8f0f-11ea-9d1a-65db8a551e5c.png">

2.) Styling fixes for the `PasswordReset` component in the Manage Students table.

Before: 
<img width="242" alt="Screen Shot 2020-05-05 at 8 06 00 PM" src="https://user-images.githubusercontent.com/12300669/81136324-16069400-8f10-11ea-9513-81bcfc0c3a4b.png">

After:
<img width="227" alt="Screen Shot 2020-05-05 at 8 20 33 PM" src="https://user-images.githubusercontent.com/12300669/81136327-1868ee00-8f10-11ea-8e7c-94913701513b.png">

3.) String fix for the introduction to the setting up your section paragraph. 

Before: 
<img width="1004" alt="picture-wrong" src="https://user-images.githubusercontent.com/12300669/81136304-0c7d2c00-8f10-11ea-8e79-9148b43bdaab.png">

After: 
<img width="1042" alt="personal login-fixed" src="https://user-images.githubusercontent.com/12300669/81136301-0ab36880-8f10-11ea-8495-e14dc20bd338.png">
