### PR TITLE
Rename uses of "stage" in Lesson

### DIFF
--- a/apps/src/code-studio/components/progress/LessonProgress.story.jsx
+++ b/apps/src/code-studio/components/progress/LessonProgress.story.jsx
@@ -100,7 +100,7 @@ export default storybook => {
         stages: [
           {
             id: 123,
-            stage_extras_level_url: showStageExtras && 'fakeurl',
+            lesson_extras_level_url: showStageExtras && 'fakeurl',
             levels
           }
         ]

--- a/apps/src/code-studio/header.js
+++ b/apps/src/code-studio/header.js
@@ -38,10 +38,10 @@ const PUZZLE_PAGE_NONE = -1;
  * @param {boolean} scriptData.disablePostMilestone
  * @param {boolean} scriptData.isHocScript
  * @param {string} scriptData.name
- * @param {object} stageData{{
+ * @param {object} lessonData{{
  *   script_id: number,
  *   script_name: number,
- *   script_stages: id,
+ *   num_script_lessons: number,
  *   title: string,
  *   finishLink: string,
  *   finishText: string,
@@ -62,7 +62,7 @@ const PUZZLE_PAGE_NONE = -1;
  */
 header.build = function(
   scriptData,
-  stageData,
+  lessonData,
   progressData,
   currentLevelId,
   puzzlePage,
@@ -70,28 +70,28 @@ header.build = function(
   stageExtrasEnabled
 ) {
   scriptData = scriptData || {};
-  stageData = stageData || {};
+  lessonData = lessonData || {};
   progressData = progressData || {};
 
   const scriptName = scriptData.name;
 
-  if (stageData.finishLink) {
+  if (lessonData.finishLink) {
     $('.header_finished_link')
       .show()
       .append(
         $('<a>')
-          .attr('href', stageData.finishLink)
-          .text(stageData.finishText)
+          .attr('href', lessonData.finishLink)
+          .text(lessonData.finishText)
       );
   }
-  if (stageData.script_stages > 1) {
+  if (lessonData.num_script_lessons > 1) {
     $('.header_popup_link').show();
   }
 
   let saveAnswersBeforeNavigation = puzzlePage !== PUZZLE_PAGE_NONE;
   progress.renderStageProgress(
     scriptData,
-    stageData,
+    lessonData,
     progressData,
     currentLevelId,
     saveAnswersBeforeNavigation,

--- a/apps/src/code-studio/progressRedux.js
+++ b/apps/src/code-studio/progressRedux.js
@@ -564,7 +564,7 @@ export const levelsForLessonId = (state, lessonId) =>
 
 export const lessonExtrasUrl = (state, stageId) =>
   state.stageExtrasEnabled
-    ? state.stages.find(stage => stage.id === stageId).stage_extras_level_url
+    ? state.stages.find(stage => stage.id === stageId).lesson_extras_level_url
     : '';
 
 export const isPerfect = (state, levelId) =>

--- a/apps/src/templates/sectionProgress/standards/standardsTestHelpers.js
+++ b/apps/src/templates/sectionProgress/standards/standardsTestHelpers.js
@@ -140,7 +140,7 @@ const scriptDataByScript = {
         lesson_plan_html_url: 'https://curriculum.code.org/csf-19/coursea/1',
         lesson_plan_pdf_url:
           '//localhost.code.org:3000/curriculum/coursea-2019/1/Teacher.pdf',
-        stage_extras_level_url:
+        lesson_extras_level_url:
           'http://localhost-studio.code.org:3000/s/coursea-2019/stage/1/extras'
       },
       {
@@ -162,7 +162,7 @@ const scriptDataByScript = {
         lesson_plan_html_url: 'https://curriculum.code.org/csf-19/coursea/2',
         lesson_plan_pdf_url:
           '//localhost.code.org:3000/curriculum/coursea-2019/2/Teacher.pdf',
-        stage_extras_level_url:
+        lesson_extras_level_url:
           'http://localhost-studio.code.org:3000/s/coursea-2019/stage/2/extras'
       },
       {
@@ -185,7 +185,7 @@ const scriptDataByScript = {
         lesson_plan_html_url: 'https://curriculum.code.org/csf-19/coursea/3',
         lesson_plan_pdf_url:
           '//localhost.code.org:3000/curriculum/coursea-2019/3/Teacher.pdf',
-        stage_extras_level_url:
+        lesson_extras_level_url:
           'http://localhost-studio.code.org:3000/s/coursea-2019/stage/3/extras'
       }
     ]

--- a/apps/test/unit/code-studio/progressReduxTest.js
+++ b/apps/test/unit/code-studio/progressReduxTest.js
@@ -140,7 +140,8 @@ const stageData = [
       '//localhost.code.org:3000/curriculum/course3/2/Teacher',
     lesson_plan_pdf_url:
       '//localhost.code.org:3000/curriculum/course3/2/Teacher.pdf',
-    stage_extras_level_url: '//localhost.code.org:3000/s/course3/stage/2/extras'
+    lesson_extras_level_url:
+      '//localhost.code.org:3000/s/course3/stage/2/extras'
   }
 ];
 

--- a/dashboard/app/controllers/script_levels_controller.rb
+++ b/dashboard/app/controllers/script_levels_controller.rb
@@ -222,9 +222,9 @@ class ScriptLevelsController < ApplicationController
     @stage = Script.get_from_cache(params[:script_id]).stage_by_relative_position(params[:stage_position].to_i)
     @script = @stage.script
     @stage_extras = {
-      next_stage_number: @stage.next_level_number_for_stage_extras(current_user),
+      next_stage_number: @stage.next_level_number_for_lesson_extras(current_user),
       stage_number: @stage.relative_position,
-      next_level_path: @stage.next_level_path_for_stage_extras(current_user),
+      next_level_path: @stage.next_level_path_for_lesson_extras(current_user),
       bonus_levels: @script.get_bonus_script_levels(@stage, current_user),
     }.camelize_keys
     @bonus_level_ids = @stage.script_levels.where(bonus: true).map(&:level_ids).flatten

--- a/dashboard/app/models/lesson.rb
+++ b/dashboard/app/models/lesson.rb
@@ -260,20 +260,20 @@ class Lesson < ActiveRecord::Base
     script_levels.reverse.find(&:valid_progression_level?)
   end
 
-  def next_level_for_stage_extras(user)
+  def next_level_for_lesson_extras(user)
     level_to_follow = script_levels.last.next_level
     level_to_follow = level_to_follow.next_level while level_to_follow.try(:locked_or_hidden?, user)
     level_to_follow
   end
 
-  def next_level_path_for_stage_extras(user)
-    next_level = next_level_for_stage_extras(user)
+  def next_level_path_for_lesson_extras(user)
+    next_level = next_level_for_lesson_extras(user)
     next_level ?
       build_script_level_path(next_level) : script_completion_redirect(script)
   end
 
-  def next_level_number_for_stage_extras(user)
-    next_level = next_level_for_stage_extras(user)
+  def next_level_number_for_lesson_extras(user)
+    next_level = next_level_for_lesson_extras(user)
     next_level ? next_level.lesson.relative_position : nil
   end
 

--- a/dashboard/app/models/lesson.rb
+++ b/dashboard/app/models/lesson.rb
@@ -173,7 +173,9 @@ class Lesson < ActiveRecord::Base
       end
 
       unless unplugged?
+        # TODO: remove stage_extras_level_url once corresponding js change is deployed and no longer cached
         lesson_data[:stage_extras_level_url] = script_stage_extras_url(script.name, stage_position: relative_position)
+        lesson_data[:lesson_extras_level_url] = lesson_data[:stage_extras_level_url]
       end
 
       lesson_data

--- a/dashboard/app/models/lesson.rb
+++ b/dashboard/app/models/lesson.rb
@@ -131,7 +131,8 @@ class Lesson < ActiveRecord::Base
       lesson_data = {
         script_id: script.id,
         script_name: script.name,
-        script_stages: script.lessons.to_a.size,
+        script_stages: script.lessons.to_a.size, # TODO: remove once corresponding js change is deployed and no longer cached
+        num_script_lessons: script.lessons.to_a.size,
         id: id,
         position: absolute_position,
         relative_position: relative_position,
@@ -170,7 +171,7 @@ class Lesson < ActiveRecord::Base
         lesson_data[:finishLink] = script.hoc_finish_url
         lesson_data[:finishText] = I18n.t('nav.header.finished_hoc')
       end
-      
+
       unless unplugged?
         lesson_data[:stage_extras_level_url] = script_stage_extras_url(script.name, stage_position: relative_position)
       end

--- a/dashboard/app/models/lesson.rb
+++ b/dashboard/app/models/lesson.rb
@@ -191,9 +191,10 @@ class Lesson < ActiveRecord::Base
   end
 
   # Provides a JSON summary of a particular stage, that is consumed by tools used to
-  # build lesson plans
+  # build lesson plans (Curriculum Builder)
   def summary_for_lesson_plans
     {
+      # TODO: should be renamed after we combine CurriculumBuilder into LevelBuilder, if we still need this.
       stageName: localized_name,
       lockable: lockable?,
       levels: script_levels.map do |script_level|

--- a/dashboard/app/models/lesson.rb
+++ b/dashboard/app/models/lesson.rb
@@ -125,10 +125,10 @@ class Lesson < ActiveRecord::Base
   end
 
   def summarize(include_bonus_levels = false)
-    stage_summary = Rails.cache.fetch("#{cache_key}/stage_summary/#{I18n.locale}/#{include_bonus_levels}") do
+    lesson_summary = Rails.cache.fetch("#{cache_key}/lesson_summary/#{I18n.locale}/#{include_bonus_levels}") do
       cached_levels = include_bonus_levels ? cached_script_levels : cached_script_levels.reject(&:bonus)
 
-      stage_data = {
+      lesson_data = {
         script_id: script.id,
         script_name: script.name,
         script_stages: script.lessons.to_a.size,
@@ -149,35 +149,35 @@ class Lesson < ActiveRecord::Base
       # Without it, script_levels.last goes back to the database.
       last_script_level = script_levels.to_a.last
 
-      # The last level in a stage might be a long assessment, so add extra information
+      # The last level in a lesson might be a long assessment, so add extra information
       # related to that.  This might include information for additional pages if it
       # happens to be a multi-page long assessment.
       if last_script_level.long_assessment?
-        last_level_summary = stage_data[:levels].last
+        last_level_summary = lesson_data[:levels].last
         extra_levels = ScriptLevel.summarize_extra_puzzle_pages(last_level_summary)
-        stage_data[:levels] += extra_levels
+        lesson_data[:levels] += extra_levels
         last_level_summary[:uid] = "#{last_level_summary[:ids].first}_0"
         last_level_summary[:url] << "/page/1"
       end
 
       # Don't want lesson plans for lockable levels
       if !lockable && script.has_lesson_plan?
-        stage_data[:lesson_plan_html_url] = lesson_plan_html_url
-        stage_data[:lesson_plan_pdf_url] = lesson_plan_pdf_url
+        lesson_data[:lesson_plan_html_url] = lesson_plan_html_url
+        lesson_data[:lesson_plan_pdf_url] = lesson_plan_pdf_url
       end
 
       if script.hoc?
-        stage_data[:finishLink] = script.hoc_finish_url
-        stage_data[:finishText] = I18n.t('nav.header.finished_hoc')
+        lesson_data[:finishLink] = script.hoc_finish_url
+        lesson_data[:finishText] = I18n.t('nav.header.finished_hoc')
       end
-
+      
       unless unplugged?
-        stage_data[:stage_extras_level_url] = script_stage_extras_url(script.name, stage_position: relative_position)
+        lesson_data[:stage_extras_level_url] = script_stage_extras_url(script.name, stage_position: relative_position)
       end
 
-      stage_data
+      lesson_data
     end
-    stage_summary.freeze
+    lesson_summary.freeze
   end
 
   def summarize_for_edit

--- a/dashboard/test/models/lesson_test.rb
+++ b/dashboard/test/models/lesson_test.rb
@@ -125,8 +125,8 @@ class StageTest < ActiveSupport::TestCase
     create :script_level, script: script, lesson: stage2
     create :script_level, script: script, lesson: stage2
 
-    assert_match /\/s\/bogus-script-\d+\/stage\/2\/puzzle\/1/, stage1.next_level_path_for_stage_extras(@student)
-    assert_equal '/', stage2.next_level_path_for_stage_extras(@student)
+    assert_match /\/s\/bogus-script-\d+\/stage\/2\/puzzle\/1/, stage1.next_level_path_for_lesson_extras(@student)
+    assert_equal '/', stage2.next_level_path_for_lesson_extras(@student)
   end
 
   class StagePublishedTests < ActiveSupport::TestCase


### PR DESCRIPTION
Renaming some of the remaining usages of "stage" in lesson.rb. I plan on going one model file at a time, for the models with a significant number of usages.

I18n keys will still remain using "stage" for now.

I tried to keep each commit scoped to a specific thing, so going commit by commit might help break up the large diff.

## Testing story

Relying on existing unit tests for the most part here. Happy to take suggestions.

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
