### PR TITLE
Fix teacher resources script edit ui

### DIFF
--- a/dashboard/app/models/script.rb
+++ b/dashboard/app/models/script.rb
@@ -1574,7 +1574,6 @@ class Script < ActiveRecord::Base
       :student_detail_progress_view,
       :project_widget_visible,
       :project_widget_types,
-      :teacher_resources,
       :stage_extras_available,
       :curriculum_path,
       :script_announcements,
@@ -1591,12 +1590,16 @@ class Script < ActiveRecord::Base
       :project_sharing,
       :tts
     ]
+    not_defaulted_keys = [
+      :teacher_resources, # teacher_resources gets updated from the script edit UI through its own code path
+    ]
 
     result = {}
     # If a non-boolean prop was missing from the input, it'll get populated in the result hash as nil.
     nonboolean_keys.each {|k| result[k] = script_data[k]}
     # If a boolean prop was missing from the input, it'll get populated in the result hash as false.
     boolean_keys.each {|k| result[k] = !!script_data[k]}
+    not_defaulted_keys.each {|k| result[k] = script_data[k] if script_data.keys.include?(k)}
 
     result
   end

--- a/dashboard/test/controllers/scripts_controller_test.rb
+++ b/dashboard/test/controllers/scripts_controller_test.rb
@@ -509,6 +509,9 @@ class ScriptsControllerTest < ActionController::TestCase
     script = create :script
     File.stubs(:write).with {|filename, _| filename == "config/scripts/#{script.name}.script" || filename.end_with?('scripts.en.yml')}
 
+    # Test doing this twice because teacher_resources in particular is set via its own code path in update_teacher_resources,
+    # which can cause incorrect behavior if it is removed during the Script.add_script while being added via the
+    # update_teacher_resources during the same call to Script.update_text
     2.times do
       post :update, params: {
         id: script.id,


### PR DESCRIPTION
(Because apparently I'm incapable of changing this code without breaking it...)

Fixes bug where teacher resources would become unset if edited a script via the script edit UI that already had teacher resources set. Interestingly, setting teacher resources for a script which had no teacher resources works correctly (!)

I still don't fully understand why it works this way, but the comment on the unit test has what I know about it. Here's the call to `update_teacher_resources` that makes this work differently from other properties: https://github.com/code-dot-org/code-dot-org/blob/827d973238c55f6c5afc5e1094d8583d7e032869/dashboard/app/models/script.rb#L1271 Would love to hear ideas.

I think this bug was introduced in https://github.com/code-dot-org/code-dot-org/pull/34296. Turns out teacher resources was one of the properties in build_properties_hash that wasn't being defaulted for a reason, and also the reason to keep the call to `compact`. I think before that change, un-setting teacher resources by removing it from a .script file was not working, though. Now there's a unit test on both scenarios.

## Testing story

Added unit test. Also manually tested.

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
