### PR TITLE
PL: Turn on legacy survey summaries view

### DIFF
--- a/apps/src/code-studio/pd/workshop_dashboard/legacy_survey_summaries.jsx
+++ b/apps/src/code-studio/pd/workshop_dashboard/legacy_survey_summaries.jsx
@@ -69,6 +69,10 @@ export default class LegacySurveySummaries extends React.Component {
       );
     }
 
+    // Don't show the legacy survey summaries for CSD & CSP until we transition
+    // them to use new Foorm-based surveys.
+    const showSummerSurveys = false;
+
     return (
       <div>
         <LegacySurveySummaryTable
@@ -82,14 +86,18 @@ export default class LegacySurveySummaries extends React.Component {
               .csf_intro_post_workshop_from_pegasus_for_all_workshops
           }
         />
-        <LegacySurveySummaryTable
-          title="CSD summer - my workshops"
-          data={this.state.data.csd_summer_workshops_from_jotform}
-        />
-        <LegacySurveySummaryTable
-          title="CSP summer - my workshops"
-          data={this.state.data.csp_summer_workshops_from_jotform}
-        />
+        {showSummerSurveys && (
+          <div>
+            <LegacySurveySummaryTable
+              title="CSD summer - my workshops"
+              data={this.state.data.csd_summer_workshops_from_jotform}
+            />
+            <LegacySurveySummaryTable
+              title="CSP summer - my workshops"
+              data={this.state.data.csp_summer_workshops_from_jotform}
+            />
+          </div>
+        )}
       </div>
     );
   }

--- a/apps/src/code-studio/pd/workshop_dashboard/workshop_dashboard.jsx
+++ b/apps/src/code-studio/pd/workshop_dashboard/workshop_dashboard.jsx
@@ -130,7 +130,7 @@ export default class WorkshopDashboard extends React.Component {
             />
             <Route
               path="legacy_survey_summaries"
-              breadcrumbs="Legacy Survey Summaries"
+              breadcrumbs="Legacy Facilitator Survey Summaries"
               component={LegacySurveySummaries}
             />
             <Route

--- a/apps/src/code-studio/pd/workshop_dashboard/workshop_index.jsx
+++ b/apps/src/code-studio/pd/workshop_dashboard/workshop_index.jsx
@@ -92,6 +92,7 @@ export class WorkshopIndex extends React.Component {
       ProgramManager
     );
     const canSeeLegacySurveySummaries = this.props.permission.hasAny(
+      Facilitator,
       CsfFacilitator
     );
 

--- a/apps/src/code-studio/pd/workshop_dashboard/workshop_index.jsx
+++ b/apps/src/code-studio/pd/workshop_dashboard/workshop_index.jsx
@@ -15,7 +15,6 @@ import {
   Facilitator,
   ProgramManager
 } from './permission';
-import queryString from 'query-string';
 import $ from 'jquery';
 
 const FILTER_API_URL = '/api/v1/pd/workshops/filter';
@@ -92,9 +91,9 @@ export class WorkshopIndex extends React.Component {
       Organizer,
       ProgramManager
     );
-    const canSeeLegacySurveySummaries =
-      queryString.parse(window.location.search).legacysurveys &&
-      this.props.permission.hasAny(Facilitator, CsfFacilitator);
+    const canSeeLegacySurveySummaries = this.props.permission.hasAny(
+      CsfFacilitator
+    );
 
     return (
       <div>

--- a/apps/test/unit/code-studio/pd/workshop_dashboard/workshop_indexTest.js
+++ b/apps/test/unit/code-studio/pd/workshop_dashboard/workshop_indexTest.js
@@ -27,10 +27,22 @@ describe('WorkshopIndex', () => {
     // map each user permission that utilizes the Workshop Dashboard
     // to the list of buttons to which it has access
     let permissionButtonMap = new Map([
-      [Facilitator, ['Facilitator Survey Results', 'Filter View']],
+      [
+        Facilitator,
+        [
+          'Facilitator Survey Results',
+          'Legacy Facilitator Survey Summaries',
+          'Filter View'
+        ]
+      ],
       [
         CsfFacilitator,
-        ['New Workshop', 'Facilitator Survey Results', 'Filter View']
+        [
+          'New Workshop',
+          'Facilitator Survey Results',
+          'Legacy Facilitator Survey Summaries',
+          'Filter View'
+        ]
       ],
       [Organizer, ['New Workshop', 'Attendance Reports', 'Filter View']],
       [ProgramManager, ['New Workshop', 'Attendance Reports', 'Filter View']],

--- a/bin/oneoff/generate_legacy_survey_summaries.rb
+++ b/bin/oneoff/generate_legacy_survey_summaries.rb
@@ -150,7 +150,7 @@ def snapshot_summer_workshops_from_jotform(course)
   end
 
   # delete all existing
-  Pd::LegacySurveySummary.where(facilitator_id: nil).where(course: course, subject: subject).delete_all
+  Pd::LegacySurveySummary.where(course: course, subject: subject).delete_all
 
   # write all entries
   survey_reports.each_pair do |id, report|

--- a/bin/oneoff/generate_legacy_survey_summaries.rb
+++ b/bin/oneoff/generate_legacy_survey_summaries.rb
@@ -53,7 +53,7 @@ def snapshot_csf_intro_post_workshop_from_pegasus
 
   survey_reports = {}
 
-  facilitators.first(10).each do |id, f|
+  facilitators.each do |id, f|
     all_their_workshops = Pd::Workshop.facilitated_by(f)
     all_their_completed_workshops = all_their_workshops.where(course: course, subject: subject).in_state(Pd::Workshop::STATE_ENDED).exclude_summer
 
@@ -124,7 +124,7 @@ def snapshot_summer_workshops_from_jotform(course)
 
   survey_reports = {}
 
-  facilitators.first(10).each do |id, f|
+  facilitators.each do |id, f|
     all_their_workshops = Pd::Workshop.facilitated_by(f)
     all_their_completed_workshops = all_their_workshops.where(course: course, subject: subject).in_state(Pd::Workshop::STATE_ENDED)
 


### PR DESCRIPTION
Followup to https://github.com/code-dot-org/code-dot-org/pull/33743

This activates the "Legacy Facilitator Survey Summaries" button for all facilitators and CSF facilitators.  It also adjusts the breadcrumb name to match the button text.

Finally, it hides CSD & CSP survey summaries for now; we will turn them on once we transition those surveys to Foorm.
