### PR TITLE
Revert "Run tests in ChromeHeadless by default"

### DIFF
--- a/apps/karma.conf.js
+++ b/apps/karma.conf.js
@@ -17,7 +17,7 @@ if (envConstants.COVERAGE) {
 process.env.BABEL_ENV = 'test';
 
 module.exports = function(config) {
-  var browser = envConstants.BROWSER || 'ChromeHeadless';
+  var browser = envConstants.BROWSER || 'PhantomJS';
   config.set({
     // base path that will be used to resolve all patterns (eg. files, exclude)
     basePath: '',

--- a/apps/package.json
+++ b/apps/package.json
@@ -133,7 +133,7 @@
     "json-parse-better-errors": "^1.0.1",
     "jsonic": "^0.3.0",
     "karma": "^1.7.0",
-    "karma-chrome-launcher": "^3.1.0",
+    "karma-chrome-launcher": "^2.2.0",
     "karma-coverage-istanbul-reporter": "^2.1.0",
     "karma-junit-reporter": "^1.2.0",
     "karma-mocha": "^1.3.0",

--- a/apps/yarn.lock
+++ b/apps/yarn.lock
@@ -7160,6 +7160,12 @@ from2@^2.1.0:
     inherits "^2.0.1"
     readable-stream "^2.0.0"
 
+fs-access@^1.0.0:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/fs-access/-/fs-access-1.0.1.tgz#d6a87f262271cefebec30c553407fb995da8777a"
+  dependencies:
+    null-check "^1.0.0"
+
 fs-extra@^0.30.0:
   version "0.30.0"
   resolved "https://registry.yarnpkg.com/fs-extra/-/fs-extra-0.30.0.tgz#f233ffcc08d4da7d432daa449776989db1df93f0"
@@ -9695,11 +9701,11 @@ just-extend@^4.0.2:
   resolved "https://registry.yarnpkg.com/just-extend/-/just-extend-4.0.2.tgz#f3f47f7dfca0f989c55410a7ebc8854b07108afc"
   integrity sha512-FrLwOgm+iXrPV+5zDU6Jqu4gCRXbWEQg2O3SKONsWE4w7AXFRkryS53bpWdaL9cNol+AmR3AEYz6kn+o0fCPnw==
 
-karma-chrome-launcher@^3.1.0:
-  version "3.1.0"
-  resolved "https://registry.yarnpkg.com/karma-chrome-launcher/-/karma-chrome-launcher-3.1.0.tgz#805a586799a4d05f4e54f72a204979f3f3066738"
-  integrity sha512-3dPs/n7vgz1rxxtynpzZTvb9y/GIaW8xjAwcIGttLbycqoFtI7yo1NGnQi6oFTherRE+GIhCAHZC4vEqWGhNvg==
+karma-chrome-launcher@^2.2.0:
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/karma-chrome-launcher/-/karma-chrome-launcher-2.2.0.tgz#cf1b9d07136cc18fe239327d24654c3dbc368acf"
   dependencies:
+    fs-access "^1.0.0"
     which "^1.2.1"
 
 karma-coverage-istanbul-reporter@^2.1.0:
@@ -11404,6 +11410,10 @@ nth-check@~1.0.1:
   resolved "https://registry.yarnpkg.com/nth-check/-/nth-check-1.0.1.tgz#9929acdf628fc2c41098deab82ac580cf149aae4"
   dependencies:
     boolbase "~1.0.0"
+
+null-check@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/null-check/-/null-check-1.0.0.tgz#977dffd7176012b9ec30d2a39db5cf72a0439edd"
 
 num2fraction@^1.2.2:
   version "1.2.2"


### PR DESCRIPTION
Reverts code-dot-org/code-dot-org#34547

This change was failing on our staging server because it wasn't configured for ChromeHeadless:
```
Compiled successfully.
06 05 2020 17:29:29.194:INFO [karma]: Karma v1.7.0 server started at http://0.0.0.0:9877/
06 05 2020 17:29:29.196:INFO [launcher]: Launching browser ChromeHeadless with unlimited concurrency
06 05 2020 17:29:29.202:INFO [launcher]: Starting browser ChromeHeadless
06 05 2020 17:29:29.203:ERROR [launcher]: No binary for ChromeHeadless browser on your platform.
  Please, set "CHROME_BIN" env variable.
```

Reverting to sort out how we ought to automate this configuration.