### PR TITLE
Run tests in ChromeHeadless by default

### DIFF
--- a/apps/karma.conf.js
+++ b/apps/karma.conf.js
@@ -17,7 +17,7 @@ if (envConstants.COVERAGE) {
 process.env.BABEL_ENV = 'test';
 
 module.exports = function(config) {
-  var browser = envConstants.BROWSER || 'PhantomJS';
+  var browser = envConstants.BROWSER || 'ChromeHeadless';
   config.set({
     // base path that will be used to resolve all patterns (eg. files, exclude)
     basePath: '',

--- a/apps/package.json
+++ b/apps/package.json
@@ -133,7 +133,7 @@
     "json-parse-better-errors": "^1.0.1",
     "jsonic": "^0.3.0",
     "karma": "^1.7.0",
-    "karma-chrome-launcher": "^2.2.0",
+    "karma-chrome-launcher": "^3.1.0",
     "karma-coverage-istanbul-reporter": "^2.1.0",
     "karma-junit-reporter": "^1.2.0",
     "karma-mocha": "^1.3.0",

--- a/apps/yarn.lock
+++ b/apps/yarn.lock
@@ -7160,12 +7160,6 @@ from2@^2.1.0:
     inherits "^2.0.1"
     readable-stream "^2.0.0"
 
-fs-access@^1.0.0:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/fs-access/-/fs-access-1.0.1.tgz#d6a87f262271cefebec30c553407fb995da8777a"
-  dependencies:
-    null-check "^1.0.0"
-
 fs-extra@^0.30.0:
   version "0.30.0"
   resolved "https://registry.yarnpkg.com/fs-extra/-/fs-extra-0.30.0.tgz#f233ffcc08d4da7d432daa449776989db1df93f0"
@@ -9701,11 +9695,11 @@ just-extend@^4.0.2:
   resolved "https://registry.yarnpkg.com/just-extend/-/just-extend-4.0.2.tgz#f3f47f7dfca0f989c55410a7ebc8854b07108afc"
   integrity sha512-FrLwOgm+iXrPV+5zDU6Jqu4gCRXbWEQg2O3SKONsWE4w7AXFRkryS53bpWdaL9cNol+AmR3AEYz6kn+o0fCPnw==
 
-karma-chrome-launcher@^2.2.0:
-  version "2.2.0"
-  resolved "https://registry.yarnpkg.com/karma-chrome-launcher/-/karma-chrome-launcher-2.2.0.tgz#cf1b9d07136cc18fe239327d24654c3dbc368acf"
+karma-chrome-launcher@^3.1.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/karma-chrome-launcher/-/karma-chrome-launcher-3.1.0.tgz#805a586799a4d05f4e54f72a204979f3f3066738"
+  integrity sha512-3dPs/n7vgz1rxxtynpzZTvb9y/GIaW8xjAwcIGttLbycqoFtI7yo1NGnQi6oFTherRE+GIhCAHZC4vEqWGhNvg==
   dependencies:
-    fs-access "^1.0.0"
     which "^1.2.1"
 
 karma-coverage-istanbul-reporter@^2.1.0:
@@ -11410,10 +11404,6 @@ nth-check@~1.0.1:
   resolved "https://registry.yarnpkg.com/nth-check/-/nth-check-1.0.1.tgz#9929acdf628fc2c41098deab82ac580cf149aae4"
   dependencies:
     boolbase "~1.0.0"
-
-null-check@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/null-check/-/null-check-1.0.0.tgz#977dffd7176012b9ec30d2a39db5cf72a0439edd"
 
 num2fraction@^1.2.2:
   version "1.2.2"

--- a/cookbooks/cdo-apps/recipes/default.rb
+++ b/cookbooks/cdo-apps/recipes/default.rb
@@ -103,6 +103,7 @@ if node['cdo-secrets']["build_apps"] ||
   # TODO keep this logic in sync with `BUILD_PACKAGE` in `package.rake`.
   (node['cdo-apps']['daemon'] && %w[staging test adhoc].include?(node.chef_environment))
   include_recipe 'cdo-nodejs'
+  include_recipe 'cdo-apps::google_chrome'
   include_recipe 'cdo-apps::generate_pdf'
 end
 

--- a/cookbooks/cdo-apps/recipes/google_chrome.rb
+++ b/cookbooks/cdo-apps/recipes/google_chrome.rb
@@ -1,0 +1,14 @@
+# Installs Google Chrome for Linux.
+
+# Official Google Chrome debian/ubuntu repo.
+# https://www.google.com/linuxrepositories/
+apt_repository 'google-chrome' do
+  arch         'amd64'
+  uri          'http://dl.google.com/linux/chrome/deb'
+  distribution 'stable'
+  components   %w(main)
+  key          'https://dl-ssl.google.com/linux/linux_signing_key.pub'
+  retries 3
+end
+
+apt_package 'google-chrome-stable'

--- a/cookbooks/cdo-apps/recipes/lighthouse.rb
+++ b/cookbooks/cdo-apps/recipes/lighthouse.rb
@@ -1,15 +1,4 @@
 # Installs Lighthouse npm package and Google Chrome dependency.
 
-# Official Google Chrome debian/ubuntu repo.
-# https://www.google.com/linuxrepositories/
-apt_repository 'google-chrome' do
-  arch         'amd64'
-  uri          'http://dl.google.com/linux/chrome/deb'
-  distribution 'stable'
-  components   %w(main)
-  key          'https://dl-ssl.google.com/linux/linux_signing_key.pub'
-  retries 3
-end
-
-apt_package 'google-chrome-stable'
+include_recipe 'cdo-apps::google_chrome'
 nodejs_npm 'lighthouse'

--- a/lib/rake/build.rake
+++ b/lib/rake/build.rake
@@ -20,9 +20,6 @@ namespace :build do
       ChatClient.log 'Installing <b>apps</b> dependencies...'
       RakeUtils.npm_install
 
-      # Workaround for https://github.com/karma-runner/karma-phantomjs-launcher/issues/120
-      RakeUtils.npm_rebuild 'phantomjs-prebuilt'
-
       ChatClient.log 'Building <b>apps</b>...'
       npm_target = CDO.optimize_webpack_assets ? 'build:dist' : 'build'
       RakeUtils.system "npm run #{npm_target}"


### PR DESCRIPTION
Reverts code-dot-org/code-dot-org#34656, restoring https://github.com/code-dot-org/code-dot-org/pull/34547, with a couple of additional changes.

The original change was failing on our staging server because Chrome isn't installed there.
```
INFO [launcher]: Starting browser ChromeHeadless
ERROR [launcher]: No binary for ChromeHeadless browser on your platform.
  Please, set "CHROME_BIN" env variable.
```

So the important additional change here is that we're now using Chef to install Chrome in any environment that might need to run JS tests.  We were already installing Chrome on the test server to run [Lighthouse](https://developers.google.com/web/tools/lighthouse); I've extracted that code into its own recipe in the cdo-apps cookbook, and included it in a block that we run on environments that may build our static JS bundle.

The other change is to remove a build.rake step that rebuilds `phantomjs-prebuilt` since this should no longer be needed in our CI environments.

I verified that we don't actually need to set `CHROME_BIN` by trying a ChromeHeadless run on our test machine, where Chrome is already installed using this approach.