### PR TITLE
Re-add teacher resources deleted by bug

### DIFF
--- a/dashboard/config/scripts/csd1-2020.script
+++ b/dashboard/config/scripts/csd1-2020.script
@@ -9,6 +9,7 @@ family_name 'csd1'
 version_year '2020'
 project_sharing true
 curriculum_umbrella 'CSD'
+teacher_resources [["lessonPlans", "https://curriculum.code.org/csd-20/unit1"], ["teacherForum", "https://forum.code.org/c/csd"], ["vocabulary", "https://curriculum.code.org/csd-20/unit1/vocab/"], ["standardMappings", "https://curriculum.code.org/csd-20/unit1/standards/"]]
 
 lesson_group 'cspSurvey', display_name: 'Survey'
 stage 'CS Discoveries Pre-survey', lockable: true

--- a/dashboard/config/scripts/csd1-pilot.script
+++ b/dashboard/config/scripts/csd1-pilot.script
@@ -7,6 +7,7 @@ curriculum_path 'https://curriculum.code.org/csd-20/unit1/{LESSON}'
 pilot_experiment 'csd-piloters'
 project_sharing true
 tts true
+teacher_resources [["lessonPlans", "https://curriculum.code.org/csd-20/unit1"], ["teacherForum", "https://forum.code.org/c/csd"], ["vocabulary", "https://curriculum.code.org/csd-20/unit1/vocab/"], ["standardMappings", "https://curriculum.code.org/csd-20/unit1/standards/"]]
 
 lesson_group 'cspSurvey', display_name: 'Survey'
 stage 'CS Discoveries Pre-survey', lockable: true

--- a/dashboard/config/scripts/csd2-2020.script
+++ b/dashboard/config/scripts/csd2-2020.script
@@ -10,6 +10,7 @@ version_year '2020'
 project_sharing true
 curriculum_umbrella 'CSD'
 tts true
+teacher_resources [["lessonPlans", "https://curriculum.code.org/csd-20/unit2/"], ["teacherForum", "https://forum.code.org/c/csd"]]
 
 lesson_group 'csd2_1', display_name: 'Chapter 1: Web Content and HTML'
 stage 'Exploring Web Pages'

--- a/dashboard/config/scripts/csd3-2020.script
+++ b/dashboard/config/scripts/csd3-2020.script
@@ -12,6 +12,7 @@ version_year '2020'
 project_sharing true
 curriculum_umbrella 'CSD'
 tts true
+teacher_resources [["lessonPlans", "https://curriculum.code.org/csd-20/unit3/"], ["teacherForum", "https://forum.code.org/c/csd3"], ["vocabulary", "https://curriculum.code.org/csd-20/unit3/vocab/"], ["standardMappings", "https://curriculum.code.org/csd-20/unit3/standards/"], ["codeIntroduced", "https://curriculum.code.org/csd-20/unit3/code/"]]
 
 lesson_group 'csd3_1', display_name: 'Chapter 1: Images and Animations'
 stage 'Programming for Entertainment'

--- a/dashboard/config/scripts/csd4-2020.script
+++ b/dashboard/config/scripts/csd4-2020.script
@@ -10,6 +10,7 @@ version_year '2020'
 project_sharing true
 curriculum_umbrella 'CSD'
 tts true
+teacher_resources [["lessonPlans", "https://curriculum.code.org/csd-20/unit4/"], ["teacherForum", "https://forum.code.org/c/csd"], ["vocabulary", "https://curriculum.code.org/csd-20/unit4/vocab/"], ["standardMappings", "https://curriculum.code.org/csd-20/unit4/standards/"], ["codeIntroduced", "https://curriculum.code.org/csd-20/unit4/code/"]]
 
 lesson_group 'csd4_1', display_name: 'Chapter 1: User Centered Design'
 stage 'Analysis of Design'

--- a/dashboard/config/scripts/csd5-2020.script
+++ b/dashboard/config/scripts/csd5-2020.script
@@ -9,6 +9,7 @@ family_name 'csd5'
 version_year '2020'
 project_sharing true
 curriculum_umbrella 'CSD'
+teacher_resources [["lessonPlans", "https://curriculum.code.org/csd-20/unit5/"], ["teacherForum", "https://forum.code.org/c/csd"], ["vocabulary", "https://curriculum.code.org/csd-20/unit5/vocab"], ["standardMappings", "https://curriculum.code.org/csd-20/unit5/standards/"]]
 
 lesson_group 'csd5_1', display_name: 'Chapter 1: Representing Information'
 stage 'Representation Matters'

--- a/dashboard/config/scripts/csd6-2020.script
+++ b/dashboard/config/scripts/csd6-2020.script
@@ -13,6 +13,7 @@ version_year '2020'
 project_sharing true
 curriculum_umbrella 'CSD'
 tts true
+teacher_resources [["lessonPlans", "https://curriculum.code.org/csd-20/unit6/"], ["teacherForum", "https://forum.code.org/c/csd"], ["vocabulary", "https://curriculum.code.org/csd-20/unit6/vocab/"], ["standardMappings", "https://curriculum.code.org/csd-20/unit6/standards/"], ["codeIntroduced", "https://curriculum.code.org/csd-20/unit6/code/"]]
 
 lesson_group 'csd6_1', display_name: 'Chapter 1: Programming with Hardware'
 stage 'Innovations in Computing'

--- a/dashboard/config/scripts/express-2019.script
+++ b/dashboard/config/scripts/express-2019.script
@@ -11,6 +11,7 @@ is_stable true
 supported_locales ["es-MX", "fr-FR"]
 curriculum_umbrella 'CSF'
 tts true
+teacher_resources [["lessonPlans", "https://curriculum.code.org/csf-19/express/"], ["teacherForum", "https://forum.code.org/c/csf"], ["vocabulary", "https://curriculum.code.org/csf-19/express/vocab/"], ["standardMappings", "https://curriculum.code.org/csf-19/express/standards/"]]
 
 lesson_group 'csf_warmup', display_name: 'Warm-Up'
 stage 'Dance Party'


### PR DESCRIPTION
Re-add teacher resources deleted by: https://github.com/code-dot-org/code-dot-org/pull/34652

Found these files by comparing to commit before that was merged: 1e4bfb5294b9d81cc4dcafb1ca2b75923359e200

## Testing story

`RAILS_ENV=development bundle exec rake seed:scripts` succeeds

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
