### PR TITLE
Virtual workshops: API support

### DIFF
--- a/dashboard/app/controllers/api/v1/pd/workshops_controller.rb
+++ b/dashboard/app/controllers/api/v1/pd/workshops_controller.rb
@@ -272,6 +272,8 @@ class Api::V1::Pd::WorkshopsController < ::ApplicationController
       :fee,
       :regional_partner_id,
       :organizer_id,
+      :virtual,
+      :suppress_email,
       sessions_attributes: [:id, :start, :end, :_destroy],
     ]
 

--- a/dashboard/test/controllers/api/v1/pd/workshops_controller_test.rb
+++ b/dashboard/test/controllers/api/v1/pd/workshops_controller_test.rb
@@ -422,9 +422,7 @@ class Api::V1::Pd::WorkshopsControllerTest < ::ActionController::TestCase
       assert_response :success
     end
 
-    id = JSON.parse(@response.body)['id']
-    workshop = Pd::Workshop.find id
-    assert_equal 1, workshop.sessions.length
+    assert_equal 1, response_workshop.sessions.length
   end
 
   # TODO: remove this test when workshop_organizer is deprecated

--- a/dashboard/test/controllers/api/v1/pd/workshops_controller_test.rb
+++ b/dashboard/test/controllers/api/v1/pd/workshops_controller_test.rb
@@ -668,6 +668,39 @@ class Api::V1::Pd::WorkshopsControllerTest < ::ActionController::TestCase
     params: -> {{id: @workshop.id, pd_workshop: workshop_params}}
   )
 
+  test 'can update a workshop to be virtual with suppressed email' do
+    sign_in @organizer
+    workshop = create :workshop, organizer: @organizer
+    refute workshop.virtual?
+
+    put :update, params: {id: workshop.id, pd_workshop: workshop_params.merge(virtual: true, suppress_email: true)}
+    assert_response :success
+    workshop.reload
+    assert workshop.virtual?
+  end
+
+  test 'cannot update a workshop to be virtual without suppressed email' do
+    sign_in @organizer
+    workshop = create :workshop, organizer: @organizer
+    refute workshop.virtual?
+
+    put :update, params: {id: workshop.id, pd_workshop: workshop_params.merge(virtual: true, suppress_email: false)}
+    assert_response :bad_request
+    workshop.reload
+    refute workshop.virtual?
+  end
+
+  test 'can update a workshop to have suppressed email' do
+    sign_in @organizer
+    workshop = create :workshop, organizer: @organizer
+    refute workshop.suppress_email?
+
+    put :update, params: {id: workshop.id, pd_workshop: workshop_params.merge(suppress_email: true)}
+    assert_response :success
+    workshop.reload
+    assert workshop.suppress_email?
+  end
+
   test 'updating with notify true sends detail change notification emails' do
     sign_in create :admin
 


### PR DESCRIPTION
Updates `Api::V1::Pd::WorkshopsController` to support setting the new `virtual` and `suppress_email` attributes introduced in https://github.com/code-dot-org/code-dot-org/pull/34601 when creating or updating a workshop.

I'm updating this API in particular because it's the one used by [`WorkshopForm`](https://github.com/code-dot-org/code-dot-org/blob/550bb43a102ae9256c32902cf17fbc4e195d76df/apps/src/code-studio/pd/workshop_dashboard/components/workshop_form.jsx) on the workshop dashboard.  The next step after this PR is to update that form with new fields that allow users to set these attributes.

## Testing story

Depending on new and existing unit tests to check new behavior.

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
