### PR TITLE
Support reporting-replica instance in DB cluster

### DIFF
--- a/aws/cloudformation/data.yml.erb
+++ b/aws/cloudformation/data.yml.erb
@@ -2,6 +2,7 @@
 require 'cdo/aws/dms'
 require 'active_support/core_ext/numeric/bytes'
 require 'active_support/core_ext/numeric/time'
+require 'active_support/inflector'
 require 'cdo/redshift'
 self.tags.push key: 'environment', value: rack_env
 -%>
@@ -193,42 +194,16 @@ Resources:
                   - 's3:ListBucket'
                 Resource: 'arn:aws:s3:::cdo-activities-archive'
       PermissionsBoundary: !ImportValue IAM-DevPermissions
-  PrimaryDBParameters:
-    Type: AWS::RDS::DBParameterGroup
+<%
+  YAML.load(erb_file(aws_dir('cloudformation/db_parameters.yml.erb'))).each do |key, values|
+-%>
+  <%=key%>DBParameters:
+    Type: AWS::RDS::DB<%=key.match('Cluster')%>ParameterGroup
     Properties:
-      Description: !Sub "Primary Database Parameters for ${AWS::StackName}."
-      Family: mysql5.7
-      Parameters: <%= YAML.load(erb_file(aws_dir('cloudformation/db_parameters.yml.erb')))['Primary'].compact.to_json %>
-  ReportingDBParameters:
-    Type: AWS::RDS::DBParameterGroup
-    Properties:
-      Description: !Sub "Reporting Read Replica DB Parameters for ${AWS::StackName}."
-      Family: mysql5.7
-      Parameters: <%= YAML.load(erb_file(aws_dir('cloudformation/db_parameters.yml.erb')))['Replica'].compact.to_json %>
-  AuroraClusterDBParameters:
-    Type: AWS::RDS::DBClusterParameterGroup
-    Properties:
-      Description: !Sub "Aurora DB Cluster Parameters for ${AWS::StackName}."
-      Family: aurora-mysql5.7
-      Parameters: <%= YAML.load(erb_file(aws_dir('cloudformation/db_parameters.yml.erb')))['AuroraCluster'].compact.to_json %>
-  AuroraReportingClusterDBParameters:
-    Type: AWS::RDS::DBClusterParameterGroup
-    Properties:
-      Description: !Sub "Aurora Reporting DB Cluster Parameters for ${AWS::StackName}."
-      Family: aurora-mysql5.7
-      Parameters: <%= YAML.load(erb_file(aws_dir('cloudformation/db_parameters.yml.erb')))['AuroraReportingCluster'].compact.to_json %>
-  AuroraWriterDBParameters:
-    Type: AWS::RDS::DBParameterGroup
-    Properties:
-      Description: !Sub "Aurora Writer Parameters for ${AWS::StackName}."
-      Family: aurora-mysql5.7
-      Parameters: <%= YAML.load(erb_file(aws_dir('cloudformation/db_parameters.yml.erb')))['AuroraWriter'].compact.to_json %>
-  AuroraReportingReplicaDBParameters:
-    Type: AWS::RDS::DBParameterGroup
-    Properties:
-      Description: !Sub "Aurora Reporting Replica Parameters for ${AWS::StackName}."
-      Family: aurora-mysql5.7
-      Parameters: <%= YAML.load(erb_file(aws_dir('cloudformation/db_parameters.yml.erb')))['AuroraReportingReplica'].compact.to_json %>
+      Description: !Sub "<%=key.titleize%> DB Parameters for ${AWS::StackName}."
+      Family: <%=key.include?('Aurora') ? 'aurora-' : ''%>mysql5.7
+      Parameters: <%=values.compact.to_json%>
+<%end -%>
 <%
   # Add CloudWatch Logs Metric Filters for RDS Enhanced Monitoring metrics.
   # Ref: https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/USER_Monitoring.OS.html#w2ab1c20c23c17b7b5

--- a/aws/cloudformation/db_parameters.yml.erb
+++ b/aws/cloudformation/db_parameters.yml.erb
@@ -189,5 +189,8 @@ AuroraReportingReplica:
   slave_parallel_workers: 8
   # Relax transaction isolation for improved concurrency under load:
   # https://docs.aws.amazon.com/AmazonRDS/latest/AuroraUserGuide/AuroraMySQL.Reference.html#AuroraMySQL.Reference.IsolationLevels.relaxed
+  # The `aurora_read_replica_read_committed` parameter is only present in Aurora engine 2.07 or greater,
+  # and due to this constraint it is not available in the `aurora-mysql5.7` Parameter Group.
+  # As a workaround, apply to all client sessions using `init_connect`.
   init_connect: 'SET SESSION aurora_read_replica_read_committed=ON; SET SESSION tx_isolation="READ-COMMITTED";'
   tx_isolation: READ-COMMITTED

--- a/aws/cloudformation/db_parameters.yml.erb
+++ b/aws/cloudformation/db_parameters.yml.erb
@@ -107,7 +107,7 @@ Primary: &primary
   slave_compressed_protocol: 1
 
 # System variables used by read-replica RDS instance.
-Replica:
+Reporting:
   # Merge all primary variables into replica.
   <<: *primary
 
@@ -187,3 +187,7 @@ AuroraReportingReplica:
   max_execution_time: null
   # Use 8 parallel worker threads for replication.
   slave_parallel_workers: 8
+  # Relax transaction isolation for improved concurrency under load:
+  # https://docs.aws.amazon.com/AmazonRDS/latest/AuroraUserGuide/AuroraMySQL.Reference.html#AuroraMySQL.Reference.IsolationLevels.relaxed
+  init_connect: 'SET SESSION aurora_read_replica_read_committed=ON; SET SESSION tx_isolation="READ-COMMITTED";'
+  tx_isolation: READ-COMMITTED

--- a/cookbooks/cdo-mysql/attributes/default.rb
+++ b/cookbooks/cdo-mysql/attributes/default.rb
@@ -3,6 +3,7 @@ default['cdo-mysql'] = {
     # Enable proxy on non-daemon app-servers by default.
     enabled: node['cdo-apps'] && !node['cdo-apps']['daemon'],
     port: 6033,
+    reporting_port: 6034,
     admin: 'mysql2://admin:admin@127.0.0.1:6032'
   }
 }

--- a/cookbooks/cdo-mysql/files/default/diff.sql
+++ b/cookbooks/cdo-mysql/files/default/diff.sql
@@ -1,0 +1,16 @@
+-- Return count of changed rows (where `mysql_servers` is different from `runtime_mysql_servers`).
+-- (Simulate FULL OUTER JOIN using a UNION of LEFT OUTER JOINs.)
+SELECT COUNT(*) AS diff
+FROM (
+  SELECT *
+  FROM `mysql_servers`
+    LEFT OUTER JOIN `runtime_mysql_servers`
+    USING (hostgroup_id, hostname, weight)
+  WHERE `runtime_mysql_servers`.hostgroup_id IS NULL
+  UNION ALL
+  SELECT *
+  FROM `runtime_mysql_servers`
+    LEFT OUTER JOIN `mysql_servers`
+    USING (hostgroup_id, hostname, weight)
+  WHERE `mysql_servers`.hostgroup_id IS NULL
+);

--- a/cookbooks/cdo-mysql/files/default/update_servers.sql
+++ b/cookbooks/cdo-mysql/files/default/update_servers.sql
@@ -5,39 +5,27 @@
 -- * HG1 weights are updated to favor readers with a fallback to the writer.
 -- * HG2 is created as a 'primary-reader' hostgroup, with the same servers as HG1
 --   but weights inverted, so it favors the writer with a fallback to readers.
+-- * HG3 is a reporting-reader hostgroup with instances isolated from regular read/write splitting.
 
 -- Note: although the ProxySQL admin interface uses the MySQL client protocol,
 -- it uses the SQLite dialect for its SQL-query syntax.
 
-DELETE FROM `mysql_servers`;
-
--- Copy `runtime_mysql_servers` to `mysql_servers`, with HG2 copied from HG1.
-INSERT INTO `mysql_servers` SELECT * FROM `runtime_mysql_servers` WHERE `hostgroup_id` != 2;
-UPDATE `mysql_servers` SET `hostgroup_id` = 2 WHERE `hostgroup_id` = 1;
-INSERT INTO `mysql_servers` SELECT * FROM `runtime_mysql_servers` WHERE `hostgroup_id` = 1;
+-- Set HG2 copied from HG1.
+REPLACE INTO `mysql_servers` (hostgroup_id, hostname, port, status, weight)
+    SELECT 2, hostname, port, status, weight FROM `mysql_servers` WHERE `hostgroup_id` = 1;
 
 -- Update weights on servers.
 UPDATE `mysql_servers` SET `weight` = CASE
-  WHEN ( -- Test if row is a writer (hostname exists in HG0)
+  WHEN ( -- If row is a writer (hostname in HG0)
     `hostname` IN (SELECT `hostname` FROM `mysql_servers` WHERE (`hostgroup_id` = 0))
   ) THEN
     -- Set writer weight low for HG1, high for HG2.
     CASE WHEN (`hostgroup_id` = 1) THEN 1 ELSE 10000000 END
+  WHEN ( -- If row is a reporting-reader (hostname in HG3)
+    `hostname` IN (SELECT `hostname` FROM `mysql_servers` WHERE (`hostgroup_id` = 3))
+  ) THEN
+    1 -- Set reporting-reader weight low for all HG.
   ELSE
     -- Set reader weight high for HG1, low for HG2.
     CASE WHEN (`hostgroup_id` = 1) THEN 10000000 ELSE 1 END
   END;
-
--- Return count of changed rows (where `mysql_servers` is different from `runtime_mysql_servers`).
--- (Simulate FULL OUTER JOIN using a UNION of LEFT OUTER JOINs.)
-SELECT COUNT(*) AS diff FROM (
-  SELECT * FROM `mysql_servers`
-    LEFT OUTER JOIN `runtime_mysql_servers`
-        USING (hostgroup_id, hostname, weight)
-  WHERE `runtime_mysql_servers`.hostgroup_id IS NULL
-UNION ALL
-  SELECT * FROM `runtime_mysql_servers`
-    LEFT OUTER JOIN `mysql_servers`
-        USING (hostgroup_id, hostname, weight)
-  WHERE `mysql_servers`.hostgroup_id IS NULL
-);

--- a/cookbooks/cdo-mysql/recipes/proxy.rb
+++ b/cookbooks/cdo-mysql/recipes/proxy.rb
@@ -28,30 +28,41 @@ end
 writer = URI.parse(node['cdo-secrets']['db_writer'] || 'mysql2://root@localhost/')
 writer.hostname = '127.0.0.1' if writer.hostname == 'localhost'
 reader = URI.parse((node['cdo-secrets']['db_reader'] || writer).to_s)
+reporting = URI.parse((node['cdo-secrets']['reporting_db_writer'] || writer).to_s)
 
 # If this is an Aurora cluster, resolve instance-endpoint hostnames
 # to help with instance auto-discovery.
 if (is_aurora = !!node['cdo-secrets']['db_cluster_id'])
-  [writer, reader].each {|server| server.host = get_cname(server.host)}
+  [writer, reader, reporting].each {|server| server.host = get_cname(server.host)}
 end
 
 admin = URI.parse(node['cdo-mysql']['proxy']['admin'])
-admin_opt_str = %w(user password host port).map {|x| "--#{x}=#{admin.send(x)}"}.join(' ')
-mysql_admin = "mysql #{admin_opt_str}"
+admin_opt_str = %w(user host port).map {|x| "--#{x}=#{admin.send(x)}"}.join(' ')
+# Set password via named pipe (requires Bash) to suppress password-warning message on stderr.
+admin_password = "--defaults-extra-file=<(printf \"[client]\\npassword=#{admin.password}\")"
+mysql_admin = "mysql #{admin_password} #{admin_opt_str}"
 
 proxy_port = node['cdo-mysql']['proxy']['port']
+reporting_port = node['cdo-mysql']['proxy']['reporting_port']
 data_dir = '/var/lib/proxysql'
 
 template 'proxysql.cnf' do
   path "/etc/#{name}"
   source "#{name}.erb"
   variables(
+    mysql_servers: {
+      writer => [0, 1, 2],
+      reader => [1, 2],
+      reporting => [3]
+    }.flat_map {|server, hostgroup| [server].product(hostgroup)},
     data_dir: data_dir,
     is_aurora: is_aurora,
     writer: writer,
     reader: reader,
+    reporting: reporting,
     admin: admin,
-    port: proxy_port
+    port: proxy_port,
+    reporting_port: reporting_port
   )
 end
 
@@ -75,15 +86,28 @@ cookbook_file "update_servers.sql" do
   owner 'proxysql'
 end
 
+cookbook_file "diff.sql" do
+  path "#{data_dir}/#{name}"
+  owner 'proxysql'
+end
+
 # Run update_servers SQL using mysql client, then run LOAD if any rows are changed.
 file "#{data_dir}/update_servers.sh" do
   owner 'proxysql'
   mode '0700'
   content <<BASH
-#!/bin/bash
-DIFF=$(#{mysql_admin} -rN <#{data_dir}/update_servers.sql 2>/dev/null)
+#!/bin/bash -e
+
+DIFF=$(#{mysql_admin} -rN <#{data_dir}/diff.sql)
 if [ "$DIFF" -ne 0 ]; then
-  #{mysql_admin} -e 'LOAD MYSQL SERVERS TO RUNTIME' 2>/dev/null
+  #{mysql_admin} -e 'SAVE MYSQL SERVERS FROM RUNTIME'
+fi
+
+#{mysql_admin} -rN < #{data_dir}/update_servers.sql
+
+DIFF=$(#{mysql_admin} -rN <#{data_dir}/diff.sql)
+if [ "$DIFF" -ne 0 ]; then
+  #{mysql_admin} -e 'LOAD MYSQL SERVERS TO RUNTIME'
 fi
 BASH
 end
@@ -91,12 +115,12 @@ end
 # Configure ProxySQL scheduler to run update_servers every second.
 # Load via MySQL admin interface because configuring scheduler from file is not supported.
 execute 'proxysql-aurora-admin' do
-  admin_sql = <<~SQL
+  environment SQL: <<~SQL
     REPLACE INTO `scheduler` (id, interval_ms, filename) VALUES (1, 1000, "#{data_dir}/update_servers.sh");
     LOAD SCHEDULER TO RUNTIME;
     SAVE SCHEDULER TO DISK;
   SQL
-  command "#{mysql_admin} -e '#{admin_sql}'"
+  command "bash -c '#{mysql_admin} -e \"$SQL\"'"
   action :nothing
   retries 3
   sensitive true
@@ -105,6 +129,8 @@ end
 # Override application config to use proxy endpoint for DB reads and writes.
 node.override['cdo-secrets']['db_writer'] = writer.dup.tap {|r| r.hostname = '127.0.0.1'; r.port = proxy_port}.to_s
 node.override['cdo-secrets']['db_reader'] = reader.dup.tap {|r| r.hostname = '127.0.0.1'; r.port = proxy_port}.to_s
+node.override['cdo-secrets']['reporting_db_writer'] = reporting.dup.tap {|r| r.hostname = '127.0.0.1'; r.port = reporting_port}.to_s
+
 node.override['cdo-secrets']['db_proxy_admin'] = admin.to_s
 # Send log to CloudWatch.
 node.default['cdo-cloudwatch-agent']['log_files']['proxysql'] = '/var/lib/proxysql/proxysql.log'

--- a/cookbooks/cdo-mysql/templates/default/proxysql.cnf.erb
+++ b/cookbooks/cdo-mysql/templates/default/proxysql.cnf.erb
@@ -23,7 +23,7 @@ mysql_variables=
 
   # Semicolon-separated list of hostname:port entries for interfaces for incoming MySQL traffic.
   # https://github.com/sysown/proxysql/wiki/Global-variables#mysql-interfaces
-  interfaces="127.0.0.1:<%= @port %>"
+  interfaces="127.0.0.1:<%=@port%>;127.0.0.1:<%=@reporting_port%>"
 
   # The server version with which the proxy will respond to the clients.
   # https://github.com/sysown/proxysql/wiki/Global-variables#mysql-server_version
@@ -75,7 +75,7 @@ mysql_variables=
 # https://github.com/sysown/proxysql/wiki/Main-(runtime)#mysql_servers
 mysql_servers =
 (
-<% [@writer, @reader].uniq.product([1, 2]).push([@writer, 0]).each do |server, hostgroup| -%>
+<% @mysql_servers.each do |server, hostgroup| -%>
   {
     address =        "<%= server.host %>"
     port =            <%= server.port || 3306 %>
@@ -174,4 +174,12 @@ mysql_query_rules:
     match_digest="SET @@wait_timeout"
     multiplex=2
   },
+  {
+    # Send reporting-port queries to the reporting hostgroup (HG3).
+    rule_id=6
+    proxy_port=<%=@reporting_port%>
+    active=1
+    destination_hostgroup=3
+    apply=1
+  }
 )


### PR DESCRIPTION
This PR makes changes to 1. `data` cloudformation stack, 2. proxysql fallback-weight SQL logic, and 3. proxysql configuration code, to support adding a 'reporting' read-replica instance to the production Aurora DB cluster.

1. Refactor the db-parameter resources to be more document-driven and less boilerplate. Add an `init_connect` parameter to set the `aurora_read_replica_read_committed` session variable on all connections to instances with the `AuroraReportingReplica` db-parameter group attached.

2. Refactor the ProxySQL fallback-weight logic to be more stable/reliable. This work originally began in #32279 (but wasn't merged yet) and I've tweaked it a bit further here.

3. Add an extra 'reporting' hostgroup (HG3) to the ProxySQL configuration. The Chef code adds the `reporting_db_writer` endpoint to HG3 by itself, and the fallback-weight script is updated to use HG3 as a sort of 'exclude filter' to set low weights for the server in its other read-only hostgroups HG1 and HG2.
  In addition, a new 'reporting' listener port is added to proxy queries to HG3, and the server's local `reporting_db_writer` config is updated to use this proxy endpoint, so reporting queries are multiplexed through ProxySQL. This probably isn't absolutely necessary, but it helps for consistency/parity with all other read/write queries on the frontend, and doesn't add much complexity since the hostgroup is already configured.

## Links

- [INF-235](https://codedotorg.atlassian.net/browse/INF-235)

## Testing story

We currently don't run ProxySQL in other environments, so all testing was done manually in an adhoc environment with databases enabled (`DATABASE=1`), an additional RDS read-replica instance `adhoc-reporting-reporting` manually added to the existing DB cluster, and the following override attributes added to the local Chef config (via editing `/etc/chef/first-boot.json`):
```
  "cdo-mysql": {
    "proxy": {
      "enabled": true
    }
  },
  "cdo-secrets": {
    "reporting_db_writer": "mysql://master:[password]@adhoc-reporting-reporting.[domain].[region].rds.amazonaws.com:3306/"
  }
```
