### PR TITLE
Virtual workshops: Controls on workshop detail form

### DIFF
--- a/apps/src/code-studio/pd/workshop_dashboard/components/workshop_form.jsx
+++ b/apps/src/code-studio/pd/workshop_dashboard/components/workshop_form.jsx
@@ -42,8 +42,8 @@ import {
   Courses,
   Subjects
 } from '@cdo/apps/generated/pd/sharedWorkshopConstants';
-import HelpTip from '../../../../lib/ui/HelpTip';
-import experiments from '../../../../util/experiments';
+import HelpTip from '@cdo/apps/lib/ui/HelpTip';
+import experiments from '@cdo/apps/util/experiments';
 
 const styles = {
   readOnlyInput: {

--- a/apps/src/code-studio/pd/workshop_dashboard/components/workshop_form.jsx
+++ b/apps/src/code-studio/pd/workshop_dashboard/components/workshop_form.jsx
@@ -42,6 +42,7 @@ import {
   Courses,
   Subjects
 } from '@cdo/apps/generated/pd/sharedWorkshopConstants';
+import HelpTip from '../../../../lib/ui/HelpTip';
 
 const styles = {
   readOnlyInput: {
@@ -992,7 +993,23 @@ export class WorkshopForm extends React.Component {
           <Row>
             <Col sm={5}>
               <FormGroup validationState={validation.style.virtual}>
-                <ControlLabel>Is this a virtual workshop?</ControlLabel>
+                <ControlLabel>
+                  Is this a virtual workshop?
+                  <HelpTip>
+                    <p>When a workshop is virtual, our system:</p>
+                    <ul>
+                      <li>Does not require you to enter a location address</li>
+                      <li>
+                        Will not send email notifications, such as enrollment
+                        receipts and workshop reminders
+                      </li>
+                      <li>
+                        Will send a post-workshop survey designed for virtual
+                        workshops
+                      </li>
+                    </ul>
+                  </HelpTip>
+                </ControlLabel>
                 <SelectIsVirtual
                   value={this.state.virtual || false}
                   onChange={this.handleVirtualChange}
@@ -1003,7 +1020,26 @@ export class WorkshopForm extends React.Component {
             </Col>
             <Col sm={5}>
               <FormGroup validationState={validation.style.suppress_email}>
-                <ControlLabel>Enable email notifications?</ControlLabel>
+                <ControlLabel>
+                  Enable email notifications?
+                  <HelpTip>
+                    <p>
+                      Code.org can send email notifications about this workshop
+                      to your attendees on your behalf. Notifications may
+                      include:
+                    </p>
+                    <ul>
+                      <li>Enrollment receipts</li>
+                      <li>10-day and 3-day workshop reminders</li>
+                      <li>Updates when workshop details change</li>
+                    </ul>
+                    <p>
+                      Code.org will always email a post-workshop survey to
+                      participants, even if you disable workshop notifications
+                      here.
+                    </p>
+                  </HelpTip>
+                </ControlLabel>
                 <SelectSuppressEmail
                   onChange={this.handleSuppressEmailChange}
                   value={this.state.suppress_email || false}

--- a/apps/src/code-studio/pd/workshop_dashboard/components/workshop_form.jsx
+++ b/apps/src/code-studio/pd/workshop_dashboard/components/workshop_form.jsx
@@ -43,6 +43,7 @@ import {
   Subjects
 } from '@cdo/apps/generated/pd/sharedWorkshopConstants';
 import HelpTip from '../../../../lib/ui/HelpTip';
+import experiments from '../../../../util/experiments';
 
 const styles = {
   readOnlyInput: {
@@ -990,65 +991,69 @@ export class WorkshopForm extends React.Component {
             readOnly={this.props.readOnly}
           />
           <br />
-          <Row>
-            <Col sm={5}>
-              <FormGroup validationState={validation.style.virtual}>
-                <ControlLabel>
-                  Is this a virtual workshop?
-                  <HelpTip>
-                    <p>When a workshop is virtual, our system:</p>
-                    <ul>
-                      <li>Does not require you to enter a location address</li>
-                      <li>
-                        Will not send email notifications, such as enrollment
-                        receipts and workshop reminders
-                      </li>
-                      <li>
-                        Will send a post-workshop survey designed for virtual
-                        workshops
-                      </li>
-                    </ul>
-                  </HelpTip>
-                </ControlLabel>
-                <SelectIsVirtual
-                  value={this.state.virtual || false}
-                  onChange={this.handleVirtualChange}
-                  readOnly={this.props.readOnly}
-                />
-                <HelpBlock>{validation.help.virtual}</HelpBlock>
-              </FormGroup>
-            </Col>
-            <Col sm={5}>
-              <FormGroup validationState={validation.style.suppress_email}>
-                <ControlLabel>
-                  Enable email notifications?
-                  <HelpTip>
-                    <p>
-                      Code.org can send email notifications about this workshop
-                      to your attendees on your behalf. Notifications may
-                      include:
-                    </p>
-                    <ul>
-                      <li>Enrollment receipts</li>
-                      <li>10-day and 3-day workshop reminders</li>
-                      <li>Updates when workshop details change</li>
-                    </ul>
-                    <p>
-                      Code.org will always email a post-workshop survey to
-                      participants, even if you disable workshop notifications
-                      here.
-                    </p>
-                  </HelpTip>
-                </ControlLabel>
-                <SelectSuppressEmail
-                  onChange={this.handleSuppressEmailChange}
-                  value={this.state.suppress_email || false}
-                  readOnly={this.props.readOnly || this.state.virtual}
-                />
-                <HelpBlock>{validation.help.suppress_email}</HelpBlock>
-              </FormGroup>
-            </Col>
-          </Row>
+          {experiments.isEnabled(experiments.VIRTUAL_WORKSHOPS) && (
+            <Row>
+              <Col sm={5}>
+                <FormGroup validationState={validation.style.virtual}>
+                  <ControlLabel>
+                    Is this a virtual workshop?
+                    <HelpTip>
+                      <p>When a workshop is virtual, our system:</p>
+                      <ul>
+                        <li>
+                          Does not require you to enter a location address
+                        </li>
+                        <li>
+                          Will not send email notifications, such as enrollment
+                          receipts and workshop reminders
+                        </li>
+                        <li>
+                          Will send a post-workshop survey designed for virtual
+                          workshops
+                        </li>
+                      </ul>
+                    </HelpTip>
+                  </ControlLabel>
+                  <SelectIsVirtual
+                    value={this.state.virtual || false}
+                    onChange={this.handleVirtualChange}
+                    readOnly={this.props.readOnly}
+                  />
+                  <HelpBlock>{validation.help.virtual}</HelpBlock>
+                </FormGroup>
+              </Col>
+              <Col sm={5}>
+                <FormGroup validationState={validation.style.suppress_email}>
+                  <ControlLabel>
+                    Enable email notifications?
+                    <HelpTip>
+                      <p>
+                        Code.org can send email notifications about this
+                        workshop to your attendees on your behalf. Notifications
+                        may include:
+                      </p>
+                      <ul>
+                        <li>Enrollment receipts</li>
+                        <li>10-day and 3-day workshop reminders</li>
+                        <li>Updates when workshop details change</li>
+                      </ul>
+                      <p>
+                        Code.org will always email a post-workshop survey to
+                        participants, even if you disable workshop notifications
+                        here.
+                      </p>
+                    </HelpTip>
+                  </ControlLabel>
+                  <SelectSuppressEmail
+                    onChange={this.handleSuppressEmailChange}
+                    value={this.state.suppress_email || false}
+                    readOnly={this.props.readOnly || this.state.virtual}
+                  />
+                  <HelpBlock>{validation.help.suppress_email}</HelpBlock>
+                </FormGroup>
+              </Col>
+            </Row>
+          )}
           <Row>
             <Col sm={4}>
               <FormGroup validationState={validation.style.location_name}>

--- a/apps/src/code-studio/pd/workshop_dashboard/workshop.jsx
+++ b/apps/src/code-studio/pd/workshop_dashboard/workshop.jsx
@@ -101,7 +101,9 @@ export class Workshop extends React.Component {
             'regional_partner_id',
             'scholarship_workshop?',
             'potential_organizers',
-            'created_at'
+            'created_at',
+            'virtual',
+            'suppress_email'
           ])
         });
       })

--- a/apps/src/lib/ui/HelpTip.jsx
+++ b/apps/src/lib/ui/HelpTip.jsx
@@ -1,0 +1,27 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import ReactTooltip from 'react-tooltip';
+import Portal from 'react-portal';
+import FontAwesome from '../../templates/FontAwesome';
+import _ from 'lodash';
+
+export default function HelpTip({children}) {
+  const id = _.uniqueId();
+
+  return (
+    <span data-for={id} data-tip>
+      <FontAwesome
+        icon="question-circle-o"
+        style={{cursor: 'pointer', marginLeft: '0.5em', marginRight: '0.5em'}}
+      />
+      <Portal isOpened={true}>
+        <ReactTooltip id={id} role="tooltip" effect="solid">
+          <div style={{maxWidth: 400}}>{children}</div>
+        </ReactTooltip>
+      </Portal>
+    </span>
+  );
+}
+HelpTip.propTypes = {
+  children: PropTypes.node.isRequired
+};

--- a/apps/src/lib/ui/HelpTip.story.jsx
+++ b/apps/src/lib/ui/HelpTip.story.jsx
@@ -1,0 +1,98 @@
+import React from 'react';
+import HelpTip from './HelpTip';
+
+export default storybook =>
+  storybook.storiesOf('HelpTip', module).add('Helptip tooltip', () => (
+    <div style={{margin: '2em', maxWidth: 500}}>
+      <p>
+        The <code>HelpTip</code> component adds a helpful question mark icon
+        with an attached tooltip inline with your text.
+        <HelpTip>Like this!</HelpTip>
+        The tooltip can contain text or arbitrary React content.
+        <HelpTip>
+          For example, an unordered list:
+          <ul>
+            <li>Isn't</li>
+            <li>That</li>
+            <li>Neat?</li>
+          </ul>
+        </HelpTip>
+      </p>
+      <p>You use it like this:</p>
+      <pre>
+        &lt;p&gt;
+        <br />
+        &nbsp;&nbsp;Here's some text, with a HelpTip on the end of it.
+        <br />
+        &nbsp;&nbsp;&lt;HelpTip&gt;Here's the tooltip content.&lt;/HelpTip&gt;
+        <br />
+        &lt;/p&gt;
+      </pre>
+      <p style={{margin: '1em'}}>
+        Here's some text, with a HelpTip on the end of it:
+        <HelpTip>Here's the tooltip content.</HelpTip>
+      </p>
+      <p>
+        The tooltip has a maximum width of 400px, so that it wraps nicely when
+        given a large amount of text.
+        <HelpTip>
+          Here's a generic paragraph of text to demonstrate that behavior. Lorem
+          ipsum dolor sit amet jedi lightsaber. Darth vader ewok amok
+          landspeeder bird feeder cypress citrus listlessness. Lorem ipsum dolor
+          sit amet jedi lightsaber. Darth vader ewok amok landspeeder bird
+          feeder cypress citrus listlessness.
+        </HelpTip>
+      </p>
+      <p>
+        The tooltips also aren't given any direction about where they should
+        appear, and they're fairly good at automatically positioning themselves
+        in the viewport. So by default, they will appear above the question-mark
+        icon, but if you've scrolled and your content is near the top of the
+        viewport, they will appear below instead.
+      </p>
+      <hr />
+      <p>
+        The original use we had in mind when developing this component was for
+        form field labels, to provide additional information about constraints
+        on a field, or the effect of a particular option.
+      </p>
+      <div style={{margin: '1em'}}>
+        <label htmlFor="test-password" style={{fontWeight: 'bold'}}>
+          Create a new password
+          <HelpTip>
+            Requirements
+            <ul>
+              <li>8-30 characters</li>
+              <li>Must include both uppercase and lowercase characters</li>
+              <li>Must include a number</li>
+            </ul>
+          </HelpTip>
+        </label>
+        <input id="test-password" type="password" />
+      </div>
+      <div style={{margin: '1em'}}>
+        <label htmlFor="test-input" style={{fontWeight: 'bold'}}>
+          Send email notifications?
+          <HelpTip>
+            <p>
+              Controls whether our system will send the following email
+              notifications to attendees of this workshop:
+            </p>
+            <ul>
+              <li>An enrollment receipt</li>
+              <li>A ten-day workshop reminder</li>
+              <li>A three-day workshop reminder</li>
+            </ul>
+            <p>
+              We will also email a post-workshop survey to attendees, regardless
+              of this setting.
+            </p>
+          </HelpTip>
+        </label>
+        <select style={{width: '100%'}}>
+          <option>Yes, send email on my behalf.</option>
+          <option>No, I will manage communications myself.</option>
+        </select>
+      </div>
+    </div>
+  ));

--- a/apps/src/util/experiments.js
+++ b/apps/src/util/experiments.js
@@ -30,6 +30,7 @@ experiments.TEACHER_DASHBOARD_SECTION_BUTTONS =
 experiments.TEACHER_DASHBOARD_SECTION_BUTTONS_ALTERNATE_TEXT =
   'teacher-dashboard-section-buttons-alternate-text';
 experiments.MINI_TOOLBOX = 'miniToolbox';
+experiments.VIRTUAL_WORKSHOPS = 'virtual-workshops';
 
 /**
  * Get our query string. Provided as a method so that tests can mock this.

--- a/dashboard/app/serializers/api/v1/pd/workshop_serializer.rb
+++ b/dashboard/app/serializers/api/v1/pd/workshop_serializer.rb
@@ -4,7 +4,7 @@ class Api::V1::Pd::WorkshopSerializer < ActiveModel::Serializer
     :enrolled_teacher_count, :sessions, :account_required_for_attendance?,
     :enrollment_code, :pre_workshop_survey_url, :attended, :on_map, :funded, :funding_type, :ready_to_close?,
     :workshop_starting_date, :date_and_location_name, :regional_partner_name, :regional_partner_id,
-    :scholarship_workshop?, :can_delete, :created_at
+    :scholarship_workshop?, :can_delete, :created_at, :virtual, :suppress_email
 
   def sessions
     object.sessions.map do |session|


### PR DESCRIPTION
[PLC-846](https://codedotorg.atlassian.net/browse/PLC-846) Introduces controls into the workshop details form for designating a workshop "virtual" and for suppressing email.

![Peek 2020-05-07 12-39](https://user-images.githubusercontent.com/1615761/81338180-077bc200-9061-11ea-95c4-42d97f397b69.gif)

I've done my best to make these options human-readable.  That includes stating the `suppress_email` option in the positive in the user-facing UI.  I've included some inline help explaining what these options do.  In addition, they follow our business logic (also enforced in the model) saying "virtual workshops always suppress email."

The new fields on the form are hidden behind a client experiment `virtual-workshops`.  Use queryparams `?enableExperiments=virtual-workshops` on a workshop edit page to enable the experiment.

### HelpTip

For the inline help, I've introduced a new `HelpTip` component which may be useful in other places - it's fairly common, especially in our internal tools, to have options that aren't explained very well, and this seems like a nice way to explain them.  I've included a storybook entry that describes this new component and illustrates its use:

![Peek 2020-05-07 11-40](https://user-images.githubusercontent.com/1615761/81338415-7527ee00-9061-11ea-9d58-35b07c52ab19.gif)

There's [an ongoing discussion](https://codedotorg.slack.com/archives/C0T0PNTM3/p1588808782119400) about what our tooltips and callouts should look like, how to consolidate their implementations so we stop reinventing the wheel, and why `react-tooltip` may not be a good long-term solution for us. I'm not trying to make the situation worse.  I think the value proposition for `HelpTip` is not the particular tooltip implementation, but the ease-of-use afforded by bundling the FontAwesome icon with a tooltip and giving it a minimal interface.  I'd be happy for us to swap out the actual tooltip whenever we decide how we want to proceed.

## Testing story

Manual testing on my local machine of the following scenarios:

* Creating a new workshop with the experiment disabled.
* Creating a new workshop with the experiment enabled, with each of the three possible configurations of the two new fields.
* Updating a workshop with the experiment disabled.
* Updating a workshop with the experiment enabled, with each of the three possible configurations of the two new fields.
* Updating a workshop to be virtual (a non-default new value), then disabling the experiment, editing the workshop again, re-enabling the experiment and confirming that the "virtual" value was persisted across the experimentless edit.

:cry: There are no existing unit tests for this form.  Feel free to tell me I should stop and do that now.

## Followup work

There's a lot of duplication in this PR: You have to add any new workshop field to a lot of places to make it editable on the client.  I started tackling that code cleanup and realized I don't want to entangle that large change with the new feature work here.  So I propose a separate test-and-refactor PR should happen soon.

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
