### PR TITLE
Prefactoring callout component for future use

### DIFF
--- a/apps/src/code-studio/components/Callout.jsx
+++ b/apps/src/code-studio/components/Callout.jsx
@@ -1,0 +1,63 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import Button from '@cdo/apps/templates/Button';
+import color from '@cdo/apps/util/color';
+
+const styles = {
+  closeX: {
+    position: 'absolute',
+    top: 5,
+    right: 5,
+    fontSize: 13,
+    lineHeight: 0,
+    boxShadow: 'unset',
+    borderWidth: 0,
+    backgroundColor: 'unset',
+    paddingRight: 0,
+    color: color.black,
+    ':hover': {
+      boxShadow: 'unset',
+      backgroundColor: 'unset'
+    }
+  }
+};
+
+// Note that additional styling can be found in apps/style/Callout.scss.
+
+/**
+ * Displays a directional message box over the screen
+ */
+export default class Callout extends React.Component {
+  static propTypes = {
+    onCalloutDismissed: PropTypes.func.isRequired,
+    shouldShowCallout: PropTypes.bool.isRequired,
+    style: PropTypes.object,
+    children: PropTypes.node
+  };
+
+  render() {
+    if (this.props.shouldShowCallout) {
+      return (
+        <div
+          className="callout"
+          onClick={this.props.onCalloutDismissed}
+          style={this.props.style || {}}
+        >
+          {this.props.children}
+          <Button
+            style={styles.closeX}
+            onClick={this.props.onCalloutDismissed}
+            icon={'times'}
+            color={Button.ButtonColor.white}
+            // Elements that display over minecraft can't use <button> right now
+            // unless they want minecraft styling due to the use of !important
+            // in the minecraft stylesheet.
+            __useDeprecatedTag
+          />
+        </div>
+      );
+    } else {
+      return null;
+    }
+  }
+}

--- a/apps/src/templates/Button.jsx
+++ b/apps/src/templates/Button.jsx
@@ -164,7 +164,7 @@ class Button extends React.Component {
   static propTypes = {
     className: PropTypes.string,
     href: PropTypes.string,
-    text: PropTypes.string.isRequired,
+    text: PropTypes.string,
     size: PropTypes.oneOf(Object.keys(ButtonSize)),
     color: PropTypes.oneOf(Object.keys(ButtonColor)),
     icon: PropTypes.string,

--- a/apps/src/templates/HideToolbarHelper.jsx
+++ b/apps/src/templates/HideToolbarHelper.jsx
@@ -46,11 +46,16 @@ export default class HideToolbarHelper extends React.Component {
   }
 
   isToolbarShowing() {
-    // window.innerHeight is smaller than document.body.offsetHeight when
-    // the iOS 13 Safari toolbar is showing.  It becomes equal when the toolbar
-    // is hidden.  (Interestingly, document.documentElement.clientHeight is
-    // the same as document.body.offsetHeight in both cases.)
-    return window.innerHeight < document.body.offsetHeight;
+    // In general, window.innerHeight is smaller than document.body.offsetHeight
+    // and document.documentElement.clientHeight when the iOS 13 Safari toolbar
+    // is showing. However, as the page is loading, these three values change at
+    // different times when the viewport is loading. Therefore we check the
+    // innerHeight against the offsetHeight and the clientHeight. When the
+    // toolbar is hidden, all values are the same.
+    return (
+      window.innerHeight < document.body.offsetHeight ||
+      window.innerHeight < document.documentElement.clientHeight
+    );
   }
 
   updateLayout = () => {
@@ -64,16 +69,19 @@ export default class HideToolbarHelper extends React.Component {
     if (
       !((this.forceShowHelper || isiOS13) && isLandscape && !isHideCookieSet)
     ) {
+      // alert('blocking helper forceShowHelper: ' + this.forceShowHelper + ' isiOS13: ' + isiOS13 + ' isLandscape: ' + isLandscape + ' isHideCookieSet: ' + isHideCookieSet + ' window.innerHeight: ' + window.innerHeight + ' document.body.offsetHeight: ' + document.body.offsetHeigh + ' document.documentElement.clientHeight: ' + document.documentElement.clientHeight)
       this.setState({shouldShowHelper: false});
       return;
     }
 
     // Let's show the helper if we think the toolbar is showing.
     const shouldShowHelper = this.isToolbarShowing() || this.forceShowHelper;
+    // alert('not blocking helper. shouldShowHelper: ' + shouldShowHelper + ' window.innerHeight: ' + window.innerHeight + ' document.body.offsetHeight: ' + document.body.offsetHeight + ' document.documentElement.clientHeight: ' + document.documentElement.clientHeight)
 
     // If we previously have shown the helper, and aren't now, and it's the
     // first time we've encountered this situation, then do a couple things.
     if (this.wasHelperShowing && !shouldShowHelper) {
+      // alert('setting cookie this.wasHelperShowing: ' + this.wasHelperShowing + ' shouldShowHelper: ' + shouldShowHelper)
       // Let's track the disapearance of the toolbar after we had previously
       // shown the helper.
       trackEvent('Research', 'HideToolbarHelper', 'hid-' + window.innerHeight);
@@ -90,7 +98,7 @@ export default class HideToolbarHelper extends React.Component {
   componentDidMount() {
     this.updateLayout();
 
-    this.updateLayoutListener = _.throttle(this.updateLayout, 1000);
+    this.updateLayoutListener = _.throttle(this.updateLayout, 200);
     window.addEventListener('orientationchange', this.updateLayoutListener);
 
     /* These two events catch all viewport changes. */

--- a/apps/src/templates/HideToolbarHelper.jsx
+++ b/apps/src/templates/HideToolbarHelper.jsx
@@ -5,29 +5,7 @@ import cookies from 'js-cookie';
 import SafeMarkdown from '@cdo/apps/templates/SafeMarkdown';
 import trackEvent from '../util/trackEvent';
 import _ from 'lodash';
-import Button from '@cdo/apps/templates/Button';
-import color from '@cdo/apps/util/color';
-
-const styles = {
-  closeX: {
-    position: 'absolute',
-    top: 5,
-    right: 5,
-    fontSize: 13,
-    lineHeight: 0,
-    boxShadow: 'unset',
-    borderWidth: 0,
-    backgroundColor: 'unset',
-    paddingRight: 0,
-    color: color.black,
-    ':hover': {
-      boxShadow: 'unset',
-      backgroundColor: 'unset'
-    }
-  }
-};
-
-// Note that additional styling can be found in apps/style/HideToolbarHelper.scss.
+import Callout from '@cdo/apps/code-studio/components/Callout';
 
 const HideToolbarHelperCookieName = 'hide_toolbar_helper';
 
@@ -147,24 +125,14 @@ export default class HideToolbarHelper extends React.Component {
   }
 
   render() {
-    if (this.state.shouldShowHelper) {
-      return (
-        <div className="hide_toolbar_helper" onClick={this.dismissCallout}>
-          <SafeMarkdown markdown={msg.hideToolbarHelper()} />
-          <Button
-            style={styles.closeX}
-            onClick={this.dismissCallout}
-            icon={'times'}
-            color={Button.ButtonColor.white}
-            // Elements that display over minecraft can't use <button> right now
-            // unless they want minecraft styling due to the use of !important
-            // in the minecraft stylesheet.
-            __useDeprecatedTag
-          />
-        </div>
-      );
-    } else {
-      return null;
-    }
+    return (
+      <Callout
+        onCalloutDismissed={this.dismissCallout}
+        shouldShowCallout={this.state.shouldShowHelper}
+        style={{position: 'fixed', top: '22px', left: '6%'}}
+      >
+        <SafeMarkdown markdown={msg.hideToolbarHelper()} />
+      </Callout>
+    );
   }
 }

--- a/apps/src/templates/HideToolbarHelper.jsx
+++ b/apps/src/templates/HideToolbarHelper.jsx
@@ -69,19 +69,16 @@ export default class HideToolbarHelper extends React.Component {
     if (
       !((this.forceShowHelper || isiOS13) && isLandscape && !isHideCookieSet)
     ) {
-      // alert('blocking helper forceShowHelper: ' + this.forceShowHelper + ' isiOS13: ' + isiOS13 + ' isLandscape: ' + isLandscape + ' isHideCookieSet: ' + isHideCookieSet + ' window.innerHeight: ' + window.innerHeight + ' document.body.offsetHeight: ' + document.body.offsetHeigh + ' document.documentElement.clientHeight: ' + document.documentElement.clientHeight)
       this.setState({shouldShowHelper: false});
       return;
     }
 
     // Let's show the helper if we think the toolbar is showing.
     const shouldShowHelper = this.isToolbarShowing() || this.forceShowHelper;
-    // alert('not blocking helper. shouldShowHelper: ' + shouldShowHelper + ' window.innerHeight: ' + window.innerHeight + ' document.body.offsetHeight: ' + document.body.offsetHeight + ' document.documentElement.clientHeight: ' + document.documentElement.clientHeight)
 
     // If we previously have shown the helper, and aren't now, and it's the
     // first time we've encountered this situation, then do a couple things.
     if (this.wasHelperShowing && !shouldShowHelper) {
-      // alert('setting cookie this.wasHelperShowing: ' + this.wasHelperShowing + ' shouldShowHelper: ' + shouldShowHelper)
       // Let's track the disapearance of the toolbar after we had previously
       // shown the helper.
       trackEvent('Research', 'HideToolbarHelper', 'hid-' + window.innerHeight);

--- a/apps/style/Callout.scss
+++ b/apps/style/Callout.scss
@@ -1,9 +1,9 @@
-// Style rules associated with the HideToolbarHelper popup
+// Style rules associated with the Callout component
 
-.hide_toolbar_helper {
+.callout {
   position: fixed;
-  top: 22px;
-  left: 6%;
+  top: 20px;
+  left: 0;
   background-color: $white;
   color: $black;
   z-index: 1040;
@@ -24,7 +24,7 @@
   }
 }
 
-.hide_toolbar_helper:after, .hide_toolbar_helper:before {
+.callout:after, .callout:before {
   bottom: 100%;
   left: 50%;
   border: solid transparent;
@@ -35,14 +35,14 @@
   pointer-events: none;
 }
 
-.hide_toolbar_helper:after {
+.callout:after {
   border-color: rgba(255, 255, 255, 0);
   border-bottom-color: #fff;
   border-width: 20px;
   margin-left: -20px;
 }
 
-.hide_toolbar_helper:before {
+.callout:before {
   border-color: rgba(0, 0, 0, 0);
   border-bottom-color: #000;
   border-width: 21px;

--- a/apps/style/common.scss
+++ b/apps/style/common.scss
@@ -1713,4 +1713,4 @@ a.WireframeButtons_active, div.WireframeButtons_active {
 }
 
 @import "RotateContainer";
-@import "HideToolbarHelper";
+@import "Callout";

--- a/apps/test/unit/templates/instructions/HideToolbarHelperTest.jsx
+++ b/apps/test/unit/templates/instructions/HideToolbarHelperTest.jsx
@@ -17,7 +17,7 @@ describe('HideToolbarHelper', function() {
 
     instance.updateLayout();
 
-    expect(instance.state.showHelper).to.be.true;
+    expect(instance.state.shouldShowHelper).to.be.true;
   });
 
   it('does not show the hide toolbar helper', function() {
@@ -32,7 +32,7 @@ describe('HideToolbarHelper', function() {
 
     instance.updateLayout();
 
-    expect(instance.state.showHelper).to.be.false;
+    expect(instance.state.shouldShowHelper).to.be.false;
   });
 
   it('we set a cookie when the toolbar goes away', function() {
@@ -51,7 +51,7 @@ describe('HideToolbarHelper', function() {
 
     instance.updateLayout();
 
-    expect(instance.state.showHelper).to.be.true;
+    expect(instance.state.shouldShowHelper).to.be.true;
     expect(setHideHelperCookie).not.to.have.been.called;
 
     isToolbarShowing.restore();
@@ -59,7 +59,7 @@ describe('HideToolbarHelper', function() {
 
     instance.updateLayout();
 
-    expect(instance.state.showHelper).to.be.false;
+    expect(instance.state.shouldShowHelper).to.be.false;
     expect(setHideHelperCookie).to.have.been.called;
   });
 });


### PR DESCRIPTION
A callout component was created as part of https://github.com/code-dot-org/code-dot-org/pull/34390. I separated it into a reusable callout component with the intent to using it to also display a message prompting the user to use swipe actions on playlab and minecraft tutorials. This message is now going to be an overlay instead, but there are other tasks that will require a callout component in the future, so I'd like to merge this change anyway.

What the callout looks like: 
![image](https://user-images.githubusercontent.com/8324574/81351336-f179fb80-9078-11ea-98b6-de250c5f05c2.png)

Example task: Getting Started Callout [#24 from hack days](https://docs.google.com/document/d/1W-5Uh94GZZDOgtuud4FvAkBztLh-_yyQxXh0TKf228w/edit)

While working on this prefactor, I noticed two bugs with the HideToolbarHelper. I fixed one and opened a bug for the second.

1. The helper assumed that `document.documentElement.clientHeight` was always the same as `document.body.offsetHeight`. But during transitions, these values diverge. Sometimes, the `innerHeight` is larger than the `offsetHeight` during transitions while still being smaller than the `clientHeight`. This caused the `HideToolbarHelper` to occasionally "think" the toolbar had been dismissed when in fact it hadn't. The screen was in process of transitioning the viewport. Waiting until the `innerHeight` is smaller than the `offsetHeight` _and_ the `clientHeight` addresses some of these false-positive instances.
2. The helper assumed that the `innerHeight` and `offsetHeight` would be equal only when the toolbar was dismissed, but on SauceLabs iPhone 11, this turned out to be false during the transition from portrait to landscape mode. I did not spend time investigating this, but instead created a bug to address this in the future. [Screen Rotation Bug](https://codedotorg.atlassian.net/browse/STAR-1094)

<!--
  Your description goes here: A summary of the change, including any relevant motivation and context.

  If relevant, include a description both of the existing behavior and of the new behavior.
-->

<!--
  Other aspects to consider. uncomment and add detail for any that seem necessary:
-->

<!-- ### Background -->
<!-- ### Privacy -->
<!-- ### Security -->
<!-- ### Caching -->
<!-- ### Deployment strategy -->
<!-- ### Future work -->

## Links

<!--
  Any relevant links to external resources; ie, specification documents, jira
  items, related PRs, honeybadger errors, etc
-->

## Testing story

<!--
  Does your change include appropriate tests?

  If so, please describe how the tests included in this PR are sufficient

  If not, please explain why this change does not need to be tested.
-->

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
