### PR TITLE
Fix "assigned" in the Teacher Dashboard header when there's no assignment 

### DIFF
--- a/apps/src/templates/teacherDashboard/TeacherDashboardHeader.jsx
+++ b/apps/src/templates/teacherDashboard/TeacherDashboardHeader.jsx
@@ -10,7 +10,7 @@ import PropTypes from 'prop-types';
 import i18n from '@cdo/locale';
 import SmallChevronLink from '../SmallChevronLink';
 import {ReloadAfterEditSectionDialog} from './EditSectionDialog';
-import {beginEditingSection} from './teacherSectionsRedux';
+import {beginEditingSection, getAssignmentName} from './teacherSectionsRedux';
 import Button from '../Button';
 import DropdownButton from '../DropdownButton';
 
@@ -39,8 +39,8 @@ class TeacherDashboardHeader extends React.Component {
   static propTypes = {
     sections: PropTypes.object.isRequired,
     selectedSectionId: PropTypes.number.isRequired,
-    selectedSectionScript: PropTypes.object.isRequired,
-    openEditSectionDialog: PropTypes.func.isRequired
+    openEditSectionDialog: PropTypes.func.isRequired,
+    assignmentName: PropTypes.string
   };
 
   constructor(props) {
@@ -92,12 +92,14 @@ class TeacherDashboardHeader extends React.Component {
         <div style={styles.header}>
           <div>
             <h1>{this.selectedSection.name}</h1>
-            <div>
-              <span style={styles.sectionPrompt}>
-                {i18n.assignedToWithColon()}{' '}
-              </span>
-              {this.props.selectedSectionScript.name}
-            </div>
+            {this.props.assignmentName && (
+              <div id="assignment-name">
+                <span style={styles.sectionPrompt}>
+                  {i18n.assignedToWithColon()}{' '}
+                </span>
+                {this.props.assignmentName}
+              </div>
+            )}
           </div>
           <div style={styles.rightColumn}>
             <div style={styles.buttonSection}>
@@ -138,12 +140,8 @@ export default connect(
   state => {
     let sections = state.teacherSections.sections;
     let selectedSectionId = state.teacherSections.selectedSectionId;
-
-    let selectedSectionScriptId = state.scriptSelection.scriptId;
-    let selectedSectionScript = state.scriptSelection.validScripts.filter(
-      script => script.id === selectedSectionScriptId
-    )[0];
-    return {sections, selectedSectionId, selectedSectionScript};
+    let assignmentName = getAssignmentName(state, selectedSectionId);
+    return {sections, selectedSectionId, assignmentName};
   },
   dispatch => {
     return {

--- a/apps/src/templates/teacherDashboard/teacherSectionsRedux.js
+++ b/apps/src/templates/teacherDashboard/teacherSectionsRedux.js
@@ -1008,6 +1008,10 @@ export function getSectionRows(state, sectionIds) {
   }));
 }
 
+export function getAssignmentName(state, sectionId) {
+  const {sections, validAssignments} = getRoot(state);
+  return assignmentNames(validAssignments, sections[sectionId])[0];
+}
 /**
  * Maps from the data we get back from the server for a section, to the format
  * we want to have in our store.

--- a/apps/test/unit/templates/teacherDashboard/TeacherDashboardHeaderTest.js
+++ b/apps/test/unit/templates/teacherDashboard/TeacherDashboardHeaderTest.js
@@ -28,7 +28,7 @@ const MOCK_SCRIPT = {
 const DEFAULT_PROPS = {
   sections: MOCK_SECTIONS,
   selectedSectionId: 1,
-  selectedSectionScript: MOCK_SCRIPT,
+  assignmentName: MOCK_SCRIPT.name,
   openEditSectionDialog: () => {}
 };
 
@@ -40,9 +40,18 @@ describe('TeacherDashboardHeader', () => {
     expect(h1Elements.contains('intro to computer science I')).to.equal(true);
   });
 
-  it('renders selected section script name', () => {
+  it('renders assigned script name if assigned', () => {
     const wrapper = shallow(<TeacherDashboardHeader {...DEFAULT_PROPS} />);
+    expect(wrapper.find('#assignment-name')).to.have.lengthOf(1);
     expect(wrapper.contains('Course D (2019)')).to.equal(true);
+  });
+
+  it('does not render script name if not assigned', () => {
+    const wrapper = shallow(
+      <TeacherDashboardHeader {...DEFAULT_PROPS} assignmentName="" />
+    );
+    expect(wrapper.find('#assignment-name')).to.have.lengthOf(0);
+    expect(wrapper.contains('Course D (2019)')).to.equal(false);
   });
 
   it('renders dropdown button with links to sections, highlighting current section, ignoring hidden section', () => {

--- a/apps/test/unit/templates/teacherDashboard/TeacherDashboardTest.js
+++ b/apps/test/unit/templates/teacherDashboard/TeacherDashboardTest.js
@@ -23,7 +23,6 @@ describe('TeacherDashboard', () => {
     const wrapper = shallow(
       <TeacherDashboard {...DEFAULT_PROPS} location={location} />
     );
-    console.log(wrapper.debug());
     expect(wrapper.find('Connect(TeacherDashboardHeader)')).to.not.exist;
   });
 


### PR DESCRIPTION
[LP-1444](https://codedotorg.atlassian.net/browse/LP-1444) and [LP-1426](https://codeorg.zendesk.com/agent/tickets/279239)

User reported via [Zendesk](https://codeorg.zendesk.com/agent/tickets/279239) that the Manage Students page wouldn't load for them.  This occurred for sections that did not have an assignment. I repro'ed locally with the following error: 
<img width="715" alt="Screen Shot 2020-05-06 at 5 53 31 PM" src="https://user-images.githubusercontent.com/12300669/81248361-01d69b80-8fd1-11ea-9b32-19b26e77d503.png">

`this.props.selectedSectionScript` was a required prop even though it shouldn't be since there might not be an assignment, and I was able to reuse functionality from `teacherSectionsRedux` to determine `assignmentName` from `validAssignments`; reusing this helps keep the `TeacherDashboardHeader`, `OwnedSectionsTable` and the `EditSectionDialog` in sync with regards to current assignment.  In addition to using the new `assignmentName` prop I check if there is an assignment name to conditionally render the "Assigned: <assignmentName>" portion of the `TeacherDashboardHeader`.  That way the Manage Students content will still render even if there isn't an assignment. I update test cases to include sections with and without assignment. 

When there is no assignment before 🙀 : 
<img width="1082" alt="Screen Shot 2020-05-06 at 5 53 38 PM" src="https://user-images.githubusercontent.com/12300669/81249309-2764a480-8fd3-11ea-96a2-a44871567997.png">

When there is no assignment after: 
<img width="1023" alt="Screen Shot 2020-05-06 at 7 50 54 PM" src="https://user-images.githubusercontent.com/12300669/81249292-203d9680-8fd3-11ea-8947-32767cff9b57.png">

When there is an assignment (same as before): 
<img width="1009" alt="Screen Shot 2020-05-06 at 7 51 21 PM" src="https://user-images.githubusercontent.com/12300669/81249297-22075a00-8fd3-11ea-8645-cdd0b01f41af.png">
