### PR TITLE
Manage Students: OAuth button alignment and logging 

### DIFF
--- a/apps/src/lib/ui/SyncOmniAuthSectionControl.jsx
+++ b/apps/src/lib/ui/SyncOmniAuthSectionControl.jsx
@@ -11,6 +11,7 @@ import {
   sectionName
 } from '../../templates/teacherDashboard/teacherSectionsRedux';
 import Button, {ButtonColor, ButtonSize} from '../../templates/Button';
+import firehoseClient from '@cdo/apps/lib/util/firehose';
 
 const PROVIDER_NAME = {
   [OAuthSectionTypes.clever]: i18n.loginTypeClever(),
@@ -42,8 +43,28 @@ class SyncOmniAuthSectionControl extends React.Component {
   };
 
   onClick = () => {
-    const {sectionCode, sectionName, updateRoster} = this.props;
+    const {
+      sectionId,
+      sectionCode,
+      sectionName,
+      updateRoster,
+      sectionProvider
+    } = this.props;
     const {buttonState} = this.state;
+
+    firehoseClient.putRecord(
+      {
+        study: 'teacher-dashboard',
+        study_group: 'manage-students',
+        event: 'sync-oauth-button-click',
+        data_json: JSON.stringify({
+          sectionId: sectionId,
+          loginType: sectionProvider
+        })
+      },
+      {includeUserId: true}
+    );
+
     if ([IN_PROGRESS, SUCCESS].includes(buttonState)) {
       // Don't acknowledge click events while request is in progress.
       // For now, ignore them on success too - the page reload will take care of it.
@@ -110,7 +131,7 @@ export function SyncOmniAuthSectionButton({provider, buttonState, onClick}) {
     <Button
       __useDeprecatedTag
       text={buttonText(buttonState, providerName)}
-      color={ButtonColor.white}
+      color={ButtonColor.gray}
       size={ButtonSize.default}
       disabled={buttonState === IN_PROGRESS}
       onClick={onClick}

--- a/apps/src/lib/ui/SyncOmniAuthSectionControl.jsx
+++ b/apps/src/lib/ui/SyncOmniAuthSectionControl.jsx
@@ -111,10 +111,11 @@ export function SyncOmniAuthSectionButton({provider, buttonState, onClick}) {
       __useDeprecatedTag
       text={buttonText(buttonState, providerName)}
       color={ButtonColor.white}
-      size={ButtonSize.large}
+      size={ButtonSize.default}
       disabled={buttonState === IN_PROGRESS}
       onClick={onClick}
       {...iconProps(buttonState)}
+      style={{float: 'left'}}
     />
   );
 }


### PR DESCRIPTION
[LP-1437](https://codedotorg.atlassian.net/browse/LP-1437) 
**Log metrics for OAuth sync button**

<img width="681" alt="Screen Shot 2020-05-06 at 8 15 52 PM" src="https://user-images.githubusercontent.com/12300669/81250885-eb334300-8fd6-11ea-92f5-49158b2933cd.png">

[LP-1429](https://codedotorg.atlassian.net/browse/LP-1429) 
**Fix alignment of OAuth buttons**

BEFORE:
<img width="1077" alt="Screen Shot 2020-05-04 at 12 17 23 PM" src="https://user-images.githubusercontent.com/12300669/81250898-f1c1ba80-8fd6-11ea-934e-ebd74dcde7f6.png">

AFTER: 
<img width="987" alt="Screen Shot 2020-05-06 at 8 15 02 PM" src="https://user-images.githubusercontent.com/12300669/81250892-eec6ca00-8fd6-11ea-8fc3-5e620523ac0f.png">


