### PR TITLE
Fix test-low-memory script for Mac

### DIFF
--- a/SETUP.md
+++ b/SETUP.md
@@ -53,7 +53,7 @@ After setup, read about our [code styleguide](./STYLEGUIDE.md), our [test suites
 
 1. Install Homebrew: `ruby -e "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install)"`
 1. Install Redis: `brew install redis`
-1. Run `brew install https://raw.github.com/quantiverge/homebrew-binary/pdftk/pdftk.rb enscript gs mysql@5.7 nvm imagemagick rbenv ruby-build coreutils sqlite`
+1. Run `brew install https://raw.github.com/quantiverge/homebrew-binary/pdftk/pdftk.rb enscript gs mysql@5.7 nvm imagemagick rbenv ruby-build coreutils sqlite parallel`
     <details>
         <summary>Troubleshoot: <code>Formula.sha1</code> is disabled or <code>Error: pdftk: undefined method sha1' for #&lt;Class:...&gt;</code></summary>
 
@@ -122,7 +122,7 @@ After setup, read about our [code styleguide](./STYLEGUIDE.md), our [test suites
 ### Ubuntu 16.04 ([Download iso][ubuntu-iso-url]) Note: Virtual Machine Users should check the Windows Note below before starting
 
 1. `sudo apt-get update`
-1. `sudo apt-get install -y git mysql-server mysql-client libmysqlclient-dev libxslt1-dev libssl-dev zlib1g-dev imagemagick libmagickcore-dev libmagickwand-dev openjdk-9-jre-headless libcairo2-dev libjpeg8-dev libpango1.0-dev libgif-dev curl pdftk enscript libsqlite3-dev build-essential redis-server rbenv chromium-browser`
+1. `sudo apt-get install -y git mysql-server mysql-client libmysqlclient-dev libxslt1-dev libssl-dev zlib1g-dev imagemagick libmagickcore-dev libmagickwand-dev openjdk-9-jre-headless libcairo2-dev libjpeg8-dev libpango1.0-dev libgif-dev curl pdftk enscript libsqlite3-dev build-essential redis-server rbenv chromium-browser parallel`
     * **Hit enter and select default options for any configuration popups, leaving mysql passwords blank**
 1. *(If working from an EC2 instance)* `sudo apt-get install -y libreadline-dev libffi-dev`
 1. Install Node and Nodejs

--- a/apps/test-low-memory.sh
+++ b/apps/test-low-memory.sh
@@ -49,7 +49,7 @@ GRUNT_CMD="node --max_old_space_size=${MEM_PER_PROCESS} `npm bin`/grunt"
 $GRUNT_CMD preconcat
 
 echo "Running with parallelism: ${PROCS}"
-PARALLEL="xargs -I{} -P${PROCS} -L1 /bin/bash -c {}"
+PARALLEL="parallel --will-cite --halt 2 -j ${PROCS} --joblog - :::"
 
 ${PARALLEL} <<SCRIPT
 npm run lint

--- a/apps/test-low-memory.sh
+++ b/apps/test-low-memory.sh
@@ -17,9 +17,8 @@ function linuxNumProcs() {
   local mem_procs=$(awk "/${mem_metric}/ {printf \"%d\", \$2/1024/${MEM_PER_PROCESS}}" /proc/meminfo)
   local procs=$(( ${mem_procs} < ${nprocs} ? ${mem_procs} : ${nprocs} ))
 
-  if [ "$PROCS" -eq 0 ]; then
+  if ((procs == 0)); then
     local free_kb=$(awk "/MemFree/ {printf \"%d\", \$2/1024}" /proc/meminfo)
-    echo "Warning: There may not be enough free memory to run tests. Required: ${MEM_PER_PROCESS}KB; Free: ${free_kb}KB"
     procs=1
   fi 
 


### PR DESCRIPTION
I spent some time trying to get the `xargs` command to work, and got close, but it seemed fragile - there were differences between the `xargs` command on my mac and in the drone container, for example. Some people online claimed `parallel` is the better tool for this, and I saw it is available to install via `brew`, so I think it's fine to require as part of our dev setup.

All of the logic which uses `nproc`, `meminfo`, etc. to determine # of processes seems like it'll be different between Mac and Linux, so I changed the script to branch on the OS, not sure if this is a good pattern but it seems to work for my Mac, the drone container, and our managed environments. I didn't add logic yet for dynamically determining # of processes to the Mac branch since I'm not sure if it's needed. I figure getting it working for a static number is an improvement over it not working at all.

I'm also not sure whether the old memory calculations are still needed after the switch to Chrome Headless, or if they can be updated at all. My impression is that PhantomJS used more memory because of memory leaks.

## Testing story

* Tested on my mac and on drone. Strangely, `npm run lint` fails on my mac, but everything else passes, and I got a green drone run. `npm run lint` by itself fails on my mac, so that seems like a separate issue.
* Would love to have others test this version of their script on their local machines.

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
