### PR TITLE
Set theme to default if handleChange event === null

### DIFF
--- a/apps/src/applab/designElements/ThemeDropdown.jsx
+++ b/apps/src/applab/designElements/ThemeDropdown.jsx
@@ -2,7 +2,7 @@
 // each theme will look like
 import PropTypes from 'prop-types';
 import React from 'react';
-import {themeOptionsForSelect} from '../constants';
+import {themeOptionsForSelect, DEFAULT_THEME_INDEX} from '../constants';
 import Select from 'react-select';
 import 'react-select/dist/react-select.css';
 
@@ -39,9 +39,14 @@ export default class ThemeDropdown extends React.Component {
   state = {
     selectedValue: this.props.initialValue
   };
+
   handleChange = event => {
-    this.props.handleChange(event.value);
-    this.setState({selectedValue: event.value});
+    const newValue = event
+      ? event.value
+      : themeOptionsForSelect[DEFAULT_THEME_INDEX].option;
+
+    this.props.handleChange(newValue);
+    this.setState({selectedValue: newValue});
   };
 
   render() {

--- a/apps/test/unit/applab/designElements/ThemeDropdownTest.js
+++ b/apps/test/unit/applab/designElements/ThemeDropdownTest.js
@@ -1,0 +1,43 @@
+import React from 'react';
+import {expect} from '../../../util/reconfiguredChai';
+import {shallow} from 'enzyme';
+import sinon from 'sinon';
+import ThemeDropdown from '@cdo/apps/applab/designElements/ThemeDropdown';
+
+const DEFAULT_PROPS = {
+  initialValue: 'citrus',
+  handleChange: () => {},
+  description: 'Theme'
+};
+
+describe('ThemeDropdown', () => {
+  describe('handleChange', () => {
+    it('sets the new theme from the event value', () => {
+      const handleChangeSpy = sinon.spy();
+      const wrapper = shallow(
+        <ThemeDropdown {...DEFAULT_PROPS} handleChange={handleChangeSpy} />
+      );
+
+      expect(wrapper.state('selectedValue')).to.equal(
+        DEFAULT_PROPS.initialValue
+      );
+      wrapper.find('Select').simulate('change', {value: 'bubblegum'});
+      expect(handleChangeSpy.callCount).to.equal(1);
+      expect(wrapper.state('selectedValue')).to.equal('bubblegum');
+    });
+
+    it('sets the theme to default if the event is null', () => {
+      const handleChangeSpy = sinon.spy();
+      const wrapper = shallow(
+        <ThemeDropdown {...DEFAULT_PROPS} handleChange={handleChangeSpy} />
+      );
+
+      expect(wrapper.state('selectedValue')).to.equal(
+        DEFAULT_PROPS.initialValue
+      );
+      wrapper.find('Select').simulate('change', null);
+      expect(handleChangeSpy.callCount).to.equal(1);
+      expect(wrapper.state('selectedValue')).to.equal('default');
+    });
+  });
+});


### PR DESCRIPTION
Reported by Hannah in [Slack](https://codedotorg.slack.com/archives/CN4T89YP8/p1588861391034200). 

When the user clicks the "x" (clear theme) icon in the theme dropdown, nothing was happening. The event is null in this case, so we now set the theme to the default if the change event is null.

## Testing story

Added unit tests for `handleChange`.

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
