### PR TITLE
Foorm: Switch to new system for CSF Intro

### DIFF
--- a/apps/src/code-studio/pd/workshop_dashboard/EnrollmentsPanel.jsx
+++ b/apps/src/code-studio/pd/workshop_dashboard/EnrollmentsPanel.jsx
@@ -179,16 +179,22 @@ export default class EnrollmentsPanel extends React.Component {
     });
   };
 
-  getViewSurveyUrl = (workshopId, course, subject) => {
+  getViewSurveyUrl = (workshopId, course, subject, lastSessionDate) => {
     if (
       !['CS Discoveries', 'CS Principles', 'CS Fundamentals'].includes(course)
     ) {
       return null;
     }
 
-    return course === 'CS Fundamentals' && subject === 'Intro'
-      ? `/pd/workshop_dashboard/survey_results/${workshopId}`
-      : `/pd/workshop_dashboard/daily_survey_results/${workshopId}`;
+    if (course === 'CS Fundamentals' && subject === 'Intro') {
+      if (lastSessionDate >= new Date('2020-05-08')) {
+        return `/pd/workshop_dashboard/workshop_daily_survey_results/${workshopId}`;
+      } else {
+        return `/pd/workshop_dashboard/survey_results/${workshopId}`;
+      }
+    } else {
+      return `/pd/workshop_dashboard/daily_survey_results/${workshopId}`;
+    }
   };
 
   render() {
@@ -267,10 +273,15 @@ export default class EnrollmentsPanel extends React.Component {
         .utc(workshop.sessions[0].start)
         .format('MMMM Do');
 
+      const lastSessionDate = new Date(
+        workshop.sessions[workshop.sessions.length - 1].start
+      );
+
       let viewSurveyUrl = this.getViewSurveyUrl(
         workshopId,
         workshop.course,
-        workshop.subject
+        workshop.subject,
+        lastSessionDate
       );
 
       contents = (

--- a/apps/src/code-studio/pd/workshop_dashboard/components/survey_results/survey_rollup_table_foorm.jsx
+++ b/apps/src/code-studio/pd/workshop_dashboard/components/survey_results/survey_rollup_table_foorm.jsx
@@ -27,6 +27,9 @@ const styles = {
   },
   headerRow: {
     borderTop: 'solid'
+  },
+  dateNotice: {
+    textAlign: 'right'
   }
 };
 
@@ -438,16 +441,26 @@ export default class SurveyRollupTableFoorm extends React.Component {
     const rows = this.getTableRows();
     const columns = this.getTableColumns();
     return (
-      <Table.Provider className="table table-bordered" columns={columns}>
-        <Table.Header />
-        <Table.Body
-          rows={rows}
-          rowKey="id"
-          onRow={row => {
-            return {style: row.isHeader ? styles.headerRow : {}};
-          }}
-        />
-      </Table.Provider>
+      <div>
+        <Table.Provider className="table table-bordered" columns={columns}>
+          <Table.Header />
+          <Table.Body
+            rows={rows}
+            rowKey="id"
+            onRow={row => {
+              return {style: row.isHeader ? styles.headerRow : {}};
+            }}
+          />
+        </Table.Provider>
+        <div style={styles.dateNotice}>
+          The averages shown above are for workshops from May 2020 onwards.{' '}
+          <br />
+          Earlier averages can be found at{' '}
+          <a href="/pd/workshop_dashboard/legacy_survey_summaries">
+            Legacy Facilitator Survey Summaries.
+          </a>
+        </div>
+      </div>
     );
   }
 }

--- a/apps/src/code-studio/pd/workshop_dashboard/components/survey_results/survey_rollup_table_foorm.jsx
+++ b/apps/src/code-studio/pd/workshop_dashboard/components/survey_results/survey_rollup_table_foorm.jsx
@@ -457,8 +457,9 @@ export default class SurveyRollupTableFoorm extends React.Component {
           <br />
           Earlier averages can be found at{' '}
           <a href="/pd/workshop_dashboard/legacy_survey_summaries">
-            Legacy Facilitator Survey Summaries.
+            Legacy Facilitator Survey Summaries
           </a>
+          .
         </div>
       </div>
     );

--- a/apps/src/code-studio/pd/workshop_dashboard/components/workshop_management.jsx
+++ b/apps/src/code-studio/pd/workshop_dashboard/components/workshop_management.jsx
@@ -39,7 +39,9 @@ export class WorkshopManagement extends React.Component {
 
     if (props.showSurveyUrl) {
       let surveyBaseUrl;
-      if (this.use_daily_survey_route()) {
+      if (this.use_foorm_route()) {
+        surveyBaseUrl = 'workshop_daily_survey_results';
+      } else if (this.use_daily_survey_route()) {
         surveyBaseUrl = 'daily_survey_results';
       } else if (props.subject === WorkshopTypes.local_summer) {
         surveyBaseUrl = 'local_summer_workshop_survey_results';
@@ -73,6 +75,16 @@ export class WorkshopManagement extends React.Component {
 
     return (
       new_local_summer_and_teachercon || new_facilitator_weekend || new_csf_201
+    );
+  };
+
+  use_foorm_route = () => {
+    let workshop_date = new Date(this.props.date);
+
+    return (
+      workshop_date >= new Date('2020-05-08') &&
+      this.props.subject === SubjectNames.SUBJECT_CSF_101 &&
+      this.props.course === 'CS Fundamentals'
     );
   };
 

--- a/apps/src/code-studio/pd/workshop_dashboard/workshop_dashboard.jsx
+++ b/apps/src/code-studio/pd/workshop_dashboard/workshop_dashboard.jsx
@@ -124,7 +124,7 @@ export default class WorkshopDashboard extends React.Component {
               component={DailySurveyResultsLoader}
             />
             <Route
-              path="daily_survey_results_foorm(/:workshopId)"
+              path="workshop_daily_survey_results(/:workshopId)"
               breadcrumbs="Survey Results"
               component={FoormDailySurveyResultsLoader}
             />

--- a/dashboard/app/models/pd/enrollment.rb
+++ b/dashboard/app/models/pd/enrollment.rb
@@ -173,12 +173,18 @@ class Pd::Enrollment < ActiveRecord::Base
     new_academic_year_enrollments, other_enrollments = other_enrollments.partition do |enrollment|
       [Pd::Workshop::COURSE_CSP, Pd::Workshop::COURSE_CSD].include?(enrollment.workshop.course) && enrollment.workshop.workshop_starting_date > Date.new(2018, 8, 1)
     end
+    csf_intro_foorm_enrollments, other_enrollments = other_enrollments.partition do |enrollment|
+      enrollment.workshop.course == Pd::Workshop::COURSE_CSF &&
+        enrollment.workshop.subject == Pd::Workshop::SUBJECT_CSF_101 &&
+        enrollment.workshop.workshop_ending_date > Date.new(2020, 5, 8)
+    end
 
     (
       filter_for_regular_survey_completion(other_enrollments, select_completed) +
       filter_for_teachercon_survey_completion(teachercon_enrollments, select_completed) +
       filter_for_local_summer_survey_completion(local_summer_enrollments, select_completed) +
-      filter_for_academic_year_survey_completion(new_academic_year_enrollments, select_completed)
+      filter_for_academic_year_survey_completion(new_academic_year_enrollments, select_completed) +
+      filter_for_csf_intro_foorm_survey_completion(csf_intro_foorm_enrollments, select_completed)
     )
   end
 
@@ -210,7 +216,10 @@ class Pd::Enrollment < ActiveRecord::Base
   end
 
   def exit_survey_url
-    if [Pd::Workshop::COURSE_ADMIN, Pd::Workshop::COURSE_COUNSELOR].include? workshop.course
+    if workshop.course == Pd::Workshop::COURSE_CSF && workshop.subject == Pd::Workshop::SUBJECT_CSF_101 &&
+      workshop.workshop_ending_date >= Date.new(2020, 5, 8)
+      CDO.studio_url "pd/workshop_survey/csf/post101/#{code}", CDO.default_scheme
+    elsif [Pd::Workshop::COURSE_ADMIN, Pd::Workshop::COURSE_COUNSELOR].include? workshop.course
       CDO.code_org_url "/pd-workshop-survey/counselor-admin/#{code}", CDO.default_scheme
     elsif workshop.subject == Pd::Workshop::SUBJECT_CSP_FOR_RETURNING_TEACHERS
       # TODO: This is a temporary, fake URL. Wire up a real one!
@@ -412,6 +421,16 @@ class Pd::Enrollment < ActiveRecord::Base
     completed_surveys, uncompleted_surveys = academic_year_enrollments.partition do |enrollment|
       workshop = enrollment.workshop
       Pd::WorkshopDailySurvey.exists?(pd_workshop: workshop, user: enrollment.user, form_id: Pd::WorkshopDailySurvey.get_form_id_for_subject_and_day(workshop.subject, POST_WORKSHOP_FORM_KEY))
+    end
+
+    select_completed ? completed_surveys : uncompleted_surveys
+  end
+
+  private_class_method def self.filter_for_csf_intro_foorm_survey_completion(enrollments, select_completed)
+    completed_surveys, uncompleted_surveys = enrollments.partition do |enrollment|
+      workshop = enrollment.workshop
+      # there is only 1 CSF Intro survey
+      Pd::WorkshopSurveyFoormSubmission.exists?(pd_workshop: workshop, user: enrollment.user)
     end
 
     select_completed ? completed_surveys : uncompleted_surveys

--- a/dashboard/test/controllers/pd/professional_learning_landing_controller_test.rb
+++ b/dashboard/test/controllers/pd/professional_learning_landing_controller_test.rb
@@ -26,7 +26,7 @@ class Pd::ProfessionalLearningLandingControllerTest < ::ActionController::TestCa
     load_pl_landing @teacher
 
     response = assigns(:landing_page_data)
-    assert_equal CDO.code_org_url("/pd-workshop-survey/#{@ended_enrollment.code}", CDO.default_scheme),
+    assert_equal CDO.studio_url("/pd/workshop_survey/csf/post101/#{@ended_enrollment.code}", CDO.default_scheme),
       response[:last_workshop_survey_url]
     assert_equal Pd::Workshop::COURSE_CSF, response[:last_workshop_survey_course]
   end

--- a/dashboard/test/mailers/previews/pd_workshop_mailer_preview.rb
+++ b/dashboard/test/mailers/previews/pd_workshop_mailer_preview.rb
@@ -264,6 +264,11 @@ class Pd::WorkshopMailerPreview < ActionMailer::Preview
     mail :exit_survey, Pd::Workshop::COURSE_CSP, Pd::Workshop::SUBJECT_CSP_FOR_RETURNING_TEACHERS
   end
 
+  def exit_survey__csf_pre_foorm
+    mail :exit_survey, Pd::Workshop::COURSE_CSF, Pd::Workshop::SUBJECT_CSF_101,
+      workshop_params: {sessions_from: Date.new(2020, 5, 4)}
+  end
+
   private
 
   def mail(method, course = nil, subject = nil, options: nil, target: :enrollment, workshop_params: {})

--- a/dashboard/test/models/pd/enrollment_test.rb
+++ b/dashboard/test/models/pd/enrollment_test.rb
@@ -111,7 +111,10 @@ class Pd::EnrollmentTest < ActiveSupport::TestCase
   end
 
   test 'exit_survey_url' do
-    csf_workshop = create :csf_workshop, :ended
+    csf_workshop_legacy = create :csf_workshop, :ended, sessions_from: Date.new(2020, 5, 4)
+    csf_enrollment_legacy = create :pd_enrollment, workshop: csf_workshop_legacy
+
+    csf_workshop = create :csf_workshop, :ended, sessions_from: Date.new(2020, 5, 8)
     csf_enrollment = create :pd_enrollment, workshop: csf_workshop
 
     csp_workshop = create :workshop, :ended, course: Pd::Workshop::COURSE_CSP
@@ -130,11 +133,12 @@ class Pd::EnrollmentTest < ActiveSupport::TestCase
     teachercon_enrollment = create :pd_enrollment, workshop: teachercon_workshop
 
     code_org_url = ->(path) {CDO.code_org_url(path, CDO.default_scheme)}
-    assert_equal code_org_url["/pd-workshop-survey/#{csf_enrollment.code}"], csf_enrollment.exit_survey_url
+    assert_equal code_org_url["/pd-workshop-survey/#{csf_enrollment_legacy.code}"], csf_enrollment_legacy.exit_survey_url
     assert_equal code_org_url["/pd-workshop-survey/counselor-admin/#{counselor_enrollment.code}"], counselor_enrollment.exit_survey_url
     assert_equal code_org_url["/pd-workshop-survey/counselor-admin/#{admin_enrollment.code}"], admin_enrollment.exit_survey_url
 
     studio_url = ->(path) {CDO.studio_url(path, CDO.default_scheme)}
+    assert_equal studio_url["/pd/workshop_survey/csf/post101/#{csf_enrollment.code}"], csf_enrollment.exit_survey_url
     assert_equal studio_url["/pd/workshop_survey/post/#{local_summer_enrollment.code}"], local_summer_enrollment.exit_survey_url
     assert_equal studio_url["/pd/workshop_survey/post/#{teachercon_enrollment.code}"], teachercon_enrollment.exit_survey_url
     assert_equal studio_url["/pd/workshop_survey/post/#{csp_enrollment.code}"], csp_enrollment.exit_survey_url


### PR DESCRIPTION
Switch all CSF Intro post survey links and summaries to use Foorm for workshops starting on or after 5/8. 

Links updates are below. All links will still go to the pegasus surveys/views for workshops before 5/8.
- teacher exit survey url (linked from professional development page and sent via mailer).
- summary view linked from workshop dashboard and workshop details page

We can take out the date logic for which survey a teacher sees in a few weeks, but for now it will ensure if they are taking their survey late it won't be in a different system from the rest of the results for that workshop.

Also added a notice below each rollup table to indicate averages are from May onwards, with a link to the legacy page:
<img width="673" alt="Screen Shot 2020-05-07 at 10 05 11 AM" src="https://user-images.githubusercontent.com/33666587/81323480-4c482e80-904a-11ea-95c9-db8b8d69a94d.png">


<!-- ### Background -->
<!-- ### Privacy -->
<!-- ### Security -->
<!-- ### Caching -->
<!-- ### Deployment strategy -->
<!-- ### Future work -->

## Links

- [jira](https://codedotorg.atlassian.net/browse/PLC-878)

## Testing story
Added a unit test and new mailer preview for exit survey logic. Manually tested links by setting up a workshop for May 9th locally and validating links all go to the new system, and testing an old workshop still showed the old links.

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
