### PR TITLE
Revert "Move unmatched regional partner contacts to zendesk-friendly from email address"

### DIFF
--- a/dashboard/app/mailers/pd/regional_partner_mini_contact_mailer.rb
+++ b/dashboard/app/mailers/pd/regional_partner_mini_contact_mailer.rb
@@ -1,6 +1,5 @@
 class Pd::RegionalPartnerMiniContactMailer < ActionMailer::Base
   NO_REPLY = 'Code.org <noreply@code.org>'
-  ZENDESK_FRIENDLY_FROM = 'Regional Partner Contact Request <regional_partner_contact_request@code.org>'
   default from: 'Liz Gauthier <partner@code.org>'
   default bcc: MailerConstants::PLC_EMAIL_LOG
 
@@ -25,7 +24,6 @@ class Pd::RegionalPartnerMiniContactMailer < ActionMailer::Base
     role = form[:role].downcase
 
     mail(
-      from: ZENDESK_FRIENDLY_FROM,
       to: email,
       subject: "A " + role + " wants to connect with Code.org"
     )

--- a/dashboard/app/models/pd/regional_partner_mini_contact.rb
+++ b/dashboard/app/models/pd/regional_partner_mini_contact.rb
@@ -18,7 +18,8 @@
 class Pd::RegionalPartnerMiniContact < ApplicationRecord
   include Pd::Form
 
-  UNMATCHED_FORM_EMAIL = 'support@code.org'
+  # Most unmatched contacts are from an international source
+  UNMATCHED_FORM_EMAIL = 'international@code.org'
 
   belongs_to :user
   belongs_to :regional_partner

--- a/dashboard/test/mailers/previews/pd_regional_partner_mini_contact_mailer_preview.rb
+++ b/dashboard/test/mailers/previews/pd_regional_partner_mini_contact_mailer_preview.rb
@@ -13,7 +13,7 @@ class Pd::RegionalPartnerMiniContactMailerPreview < ActionMailer::Preview
     Pd::RegionalPartnerMiniContactMailer.receipt(form, nil)
   end
 
-  def contact_unmatched
+  def mini_contact_unmatched
     form = build_form_data(:pd_regional_partner_mini_contact)
     Pd::RegionalPartnerMiniContactMailer.unmatched(form, 'test+employee@code.org')
   end
@@ -22,11 +22,6 @@ class Pd::RegionalPartnerMiniContactMailerPreview < ActionMailer::Preview
     rp_pm = create :regional_partner_program_manager
     form = build_form_data(:pd_regional_partner_mini_contact, regional_partner: rp_pm.regional_partner)
     Pd::RegionalPartnerMiniContactMailer.matched(form, rp_pm)
-  end
-
-  def mini_contact_unmatched
-    form = build_form_data(:pd_regional_partner_mini_contact)
-    Pd::RegionalPartnerMiniContactMailer.unmatched(form, 'test+employee@code.org')
   end
 
   private

--- a/dashboard/test/mailers/previews/pd_regional_partner_mini_contact_mailer_preview.rb
+++ b/dashboard/test/mailers/previews/pd_regional_partner_mini_contact_mailer_preview.rb
@@ -13,7 +13,7 @@ class Pd::RegionalPartnerMiniContactMailerPreview < ActionMailer::Preview
     Pd::RegionalPartnerMiniContactMailer.receipt(form, nil)
   end
 
-  def mini_contact_unmatched
+  def contact_unmatched
     form = build_form_data(:pd_regional_partner_mini_contact)
     Pd::RegionalPartnerMiniContactMailer.unmatched(form, 'test+employee@code.org')
   end
@@ -22,6 +22,11 @@ class Pd::RegionalPartnerMiniContactMailerPreview < ActionMailer::Preview
     rp_pm = create :regional_partner_program_manager
     form = build_form_data(:pd_regional_partner_mini_contact, regional_partner: rp_pm.regional_partner)
     Pd::RegionalPartnerMiniContactMailer.matched(form, rp_pm)
+  end
+
+  def mini_contact_unmatched
+    form = build_form_data(:pd_regional_partner_mini_contact)
+    Pd::RegionalPartnerMiniContactMailer.unmatched(form, 'test+employee@code.org')
   end
 
   private

--- a/dashboard/test/models/pd/regional_partner_mini_contact_test.rb
+++ b/dashboard/test/models/pd/regional_partner_mini_contact_test.rb
@@ -125,7 +125,7 @@ class Pd::RegionalPartnerMiniContactTest < ActiveSupport::TestCase
 
     assert_equal ['support@code.org'], mail.to
     assert_equal 'A teacher wants to connect with Code.org', mail.subject
-    assert_equal ['regional_partner_contact_request@code.org'], mail.from
+    assert_equal ['partner@code.org'], mail.from
     assert_equal 2, ActionMailer::Base.deliveries.count
     assert_sendable mail
   end
@@ -137,7 +137,7 @@ class Pd::RegionalPartnerMiniContactTest < ActiveSupport::TestCase
 
     assert_equal ['support@code.org'], mail.to
     assert_equal 'A teacher wants to connect with Code.org', mail.subject
-    assert_equal ['regional_partner_contact_request@code.org'], mail.from
+    assert_equal ['partner@code.org'], mail.from
     assert_equal 2, ActionMailer::Base.deliveries.count
     assert_sendable mail
   end

--- a/dashboard/test/models/pd/regional_partner_mini_contact_test.rb
+++ b/dashboard/test/models/pd/regional_partner_mini_contact_test.rb
@@ -123,7 +123,7 @@ class Pd::RegionalPartnerMiniContactTest < ActiveSupport::TestCase
     create :pd_regional_partner_mini_contact, form_data: build(:pd_regional_partner_mini_contact_hash).to_json
     mail = ActionMailer::Base.deliveries.first
 
-    assert_equal ['support@code.org'], mail.to
+    assert_equal ['international@code.org'], mail.to
     assert_equal 'A teacher wants to connect with Code.org', mail.subject
     assert_equal ['partner@code.org'], mail.from
     assert_equal 2, ActionMailer::Base.deliveries.count
@@ -135,7 +135,7 @@ class Pd::RegionalPartnerMiniContactTest < ActiveSupport::TestCase
     create :pd_regional_partner_mini_contact, form_data: build(:pd_regional_partner_mini_contact_hash).to_json
     mail = ActionMailer::Base.deliveries.first
 
-    assert_equal ['support@code.org'], mail.to
+    assert_equal ['international@code.org'], mail.to
     assert_equal 'A teacher wants to connect with Code.org', mail.subject
     assert_equal ['partner@code.org'], mail.from
     assert_equal 2, ActionMailer::Base.deliveries.count

--- a/lib/cdo/poste.rb
+++ b/lib/cdo/poste.rb
@@ -535,10 +535,7 @@ module Poste2
       facilitators@code.org
       volunteers@code.org
       partner@code.org
-      regional_partner_contact_request@code.org
     ]
-    # Note: regional_partner_contact_request@code.org should only be used
-    # to send email to internal recipients (eg, support@code.org)
 
     def initialize(settings = nil)
     end


### PR DESCRIPTION
Reverts code-dot-org/code-dot-org#34243, which created a new from: email that we thought would be Zendesk-friendly for sending unmatched contacts. It...didn't work. New plan is to send these contacts to international@code.org, which actually goes to a person's inbox (rather than being filtered by Zendesk). The international team will then pass along any contacts that are actually domestic to our outreach team.