### PR TITLE
Minecraft: Fix scroll-to-top on iPhone

### DIFF
--- a/apps/src/craft/agent/craft.js
+++ b/apps/src/craft/agent/craft.js
@@ -314,6 +314,15 @@ export default class Craft {
             mc.on('pressup', () =>
               Craft.gameController.codeOrgAPI.clickUp(() => {})
             );
+
+            // Prevent Phaser from scrolling up on iPhones when it receives a resize event.
+            Craft.gameController.game.device.whenReady(
+              () => {
+                Craft.gameController.game.scale.compatibility.scrollTo = false;
+              },
+              this,
+              false
+            );
           },
           twitter: {
             text: 'Share on Twitter',

--- a/apps/src/craft/aquatic/craft.js
+++ b/apps/src/craft/aquatic/craft.js
@@ -259,6 +259,15 @@ Craft.init = function(config) {
             );
             visualizationColumn.style.width = this.nativeVizWidth + 'px';
           }
+
+          // Prevent Phaser from scrolling up on iPhones when it receives a resize event.
+          Craft.gameController.game.device.whenReady(
+            () => {
+              Craft.gameController.game.scale.compatibility.scrollTo = false;
+            },
+            this,
+            false
+          );
         },
         twitter: {
           text: 'Share on Twitter',

--- a/apps/src/craft/designer/craft.js
+++ b/apps/src/craft/designer/craft.js
@@ -390,6 +390,15 @@ Craft.init = function(config) {
         mc.on('pressup', () =>
           Craft.gameController.codeOrgAPI.clickUp(() => {})
         );
+
+        // Prevent Phaser from scrolling up on iPhones when it receives a resize event.
+        Craft.gameController.game.device.whenReady(
+          () => {
+            Craft.gameController.game.scale.compatibility.scrollTo = false;
+          },
+          this,
+          false
+        );
       },
       twitter: {
         text: 'Share on Twitter',

--- a/apps/src/craft/simple/craft.js
+++ b/apps/src/craft/simple/craft.js
@@ -396,6 +396,15 @@ Craft.init = function(config) {
             );
             visualizationColumn.style.width = this.nativeVizWidth + 'px';
           }
+
+          // Prevent Phaser from scrolling up on iPhones when it receives a resize event.
+          Craft.gameController.game.device.whenReady(
+            () => {
+              Craft.gameController.game.scale.compatibility.scrollTo = false;
+            },
+            this,
+            false
+          );
         },
         twitter: {
           text: 'Share on Twitter',


### PR DESCRIPTION
When playing one of our Minecraft levels on an iPhone with the page scrolled down, so that our header wasn't visible, every time a block was placed, the device would scroll to the top, which was very annoying.

It turns out that when placing a block, our Blockly implementation fires a resize event to the window, apparently so that the Blockly layout (and maybe layout outside of Blockly, I'm not sure) is adjusted.  The window had 24 resize listeners at this point, and it seemed that one of them was also triggering a scroll-to-top.  It turns out that it's a default behaviour of the Phaser library, used in our Minecraft tutorials.

This change patches the Phaser setup to no longer scroll-to-top.

Tested on an iPhone in the following scripts: `mc`, `minecraft`, `hero`, `aquatic`.
