### PR TITLE
make rollup tables use LevelGroup.pages instead of accessing properties directly

### DIFF
--- a/bin/cron/create_rollup_tables
+++ b/bin/cron/create_rollup_tables
@@ -47,10 +47,9 @@ def main
   contained_level_answers = []
   level_sources_multi_types = []
 
-  Level.where(type: 'LevelGroup').find_each do |level|
-    level.properties['pages'].each_with_index do |page, page_index|
-      page['levels'].each_with_index do |contained_level_name, position_index|
-        contained_level = Level.find_by_name(contained_level_name)
+  LevelGroup.find_each do |level|
+    level.pages.each_with_index do |page, page_index|
+      page.levels.each_with_index do |contained_level, position_index|
         next unless contained_level.type == 'Multi'
         next if contained_levels.
           select {|existing_contained_level| existing_contained_level[:level_id] == contained_level.id}.


### PR DESCRIPTION
## Background

Follow-on to https://github.com/code-dot-org/code-dot-org/pull/34677 . See that PR for context.

## Description

We need to stop accessing LevelGroup.properties['pages'], so that we can change how sublevels are implemented. The LevelGroup.pages API will keep working under the new implementation, so use that API instead.

## Testing story

@islemaster or @madelynkasula , how have you verified changes to this script when you've made changes in the past?

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
