### PR TITLE
Restore missing entries in schema.rb

### DIFF
--- a/dashboard/db/schema.rb
+++ b/dashboard/db/schema.rb
@@ -1755,6 +1755,14 @@ ActiveRecord::Schema.define(version: 20200504210058) do
     t.index ["key", "locale"], name: "index_videos_on_key_and_locale", unique: true, using: :btree
   end
 
+  add_foreign_key "ap_school_codes", "schools"
+  add_foreign_key "census_inaccuracy_investigations", "census_overrides"
+  add_foreign_key "census_inaccuracy_investigations", "census_submissions"
+  add_foreign_key "census_inaccuracy_investigations", "users"
+  add_foreign_key "census_overrides", "schools"
+  add_foreign_key "census_submission_form_maps", "census_submissions"
+  add_foreign_key "census_summaries", "schools"
+  add_foreign_key "circuit_playground_discount_applications", "schools"
   add_foreign_key "hint_view_requests", "users"
   add_foreign_key "ib_school_codes", "schools"
   add_foreign_key "level_concept_difficulties", "levels"


### PR DESCRIPTION
This restores some entries inadvertently removed in https://github.com/code-dot-org/code-dot-org/pull/34604.
