### PR TITLE
Foorm: fix CSF Intro other field

### DIFF
--- a/dashboard/config/foorm/forms/surveys/pd/workshop_csf_intro_post.0.json
+++ b/dashboard/config/foorm/forms/surveys/pd/workshop_csf_intro_post.0.json
@@ -319,6 +319,8 @@
           "name": "race",
           "title": "What is your racial or ethnic identity?",
           "isRequired": true,
+          "hasOther": true,
+          "otherText": "Other",
           "choices": [
             {
               "value": "ai_or_an",
@@ -343,10 +345,6 @@
             {
               "value": "white",
               "text": "White"
-            },
-            {
-              "value": "other",
-              "text": "Other"
             },
             {
               "value": "prefer_not_answer",


### PR DESCRIPTION
Surveyjs has buggy behavior if an answer choice is named "other"--it will pop up a text box but not save the text, because it overlaps with their implementation of an "other" field. Use the built-in hasOther configuration value for the CSF Intro question that has an "other" option. This will make typing something in the text box mandatory because we have made the question required.
The question now looks like this:
<img width="941" alt="Screen Shot 2020-05-08 at 11 14 30 AM" src="https://user-images.githubusercontent.com/33666587/81436003-93532400-911d-11ea-9ee4-b61507fcd263.png">
If they check the box:
<img width="947" alt="Screen Shot 2020-05-08 at 11 14 39 AM" src="https://user-images.githubusercontent.com/33666587/81436025-9b12c880-911d-11ea-809b-d27fa480b4dd.png">

If they try to submit without filling in the text box:

<img width="940" alt="Screen Shot 2020-05-08 at 11 14 53 AM" src="https://user-images.githubusercontent.com/33666587/81436040-9f3ee600-911d-11ea-920e-6dd76dc6971a.png">


## Links

- [jira](https://codedotorg.atlassian.net/browse/PLC-884)

## Testing story
Verified that the other field now works as expected and we both store and can view the text the user inputs.

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
