### PR TITLE
safely remove user-progress.scss

### DIFF
--- a/dashboard/app/assets/stylesheets/application.scss
+++ b/dashboard/app/assets/stylesheets/application.scss
@@ -22,7 +22,6 @@
  *
  * Shared
  *= require user-menu
- *= require user-progress
  *= require buttons
  *= require course-blocks
  *= require details-polyfill

--- a/shared/css/user-progress.scss
+++ b/shared/css/user-progress.scss
@@ -1,4 +1,0 @@
-/* 
- * This file is no longer needed, however removing it causes the drone run to fail.
- * It should be removed once we figure out how to do so without disrupting drone.
- */


### PR DESCRIPTION
Follow-on to https://github.com/code-dot-org/code-dot-org/pull/34489 . the removed css file was being explicitly depended upon in application.scss, but there was no clear error message indicating this due to an unrelated problem in rails. For details on that problem, see https://codedotorg.slack.com/archives/C2ALWLRHN/p1588886674024600
