### PR TITLE
Update sprockets fork

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -185,11 +185,11 @@ GIT
 
 GIT
   remote: https://github.com/wjordan/sprockets.git
-  revision: df60ba28584d51235cb0af23cef1b2bbd9d8d2dc
+  revision: 35caa45a78b739362b7db087b141f89e27d107c7
   ref: concurrent_asset_bundle_3.x
   specs:
     sprockets (3.7.1)
-      concurrent-ruby (~> 1.0)
+      concurrent-ruby (~> 1.1)
       rack (> 1, < 3)
 
 GEM
@@ -354,7 +354,7 @@ GEM
     colorize (0.8.1)
     composite_primary_keys (9.0.10)
       activerecord (~> 5.0.0, >= 5.0.7)
-    concurrent-ruby (1.1.5)
+    concurrent-ruby (1.1.6)
     connection_pool (2.2.1)
     crack (0.4.3)
       safe_yaml (~> 1.0.0)


### PR DESCRIPTION
Update `Gemfile.lock` with an updated commit on [wjordan/sprockets#concurrent_asset_bundle_3.x](https://github.com/rails/sprockets/compare/3.x...wjordan:concurrent_asset_bundle_3.x) fork-branch, to prevent asset precompilation from hanging when compilation errors are raised.