### PR TITLE
Allow seeding of deleted contacts from Pardot

### DIFF
--- a/dashboard/app/models/contact_rollups_pardot_memory.rb
+++ b/dashboard/app/models/contact_rollups_pardot_memory.rb
@@ -95,8 +95,8 @@ class ContactRollupsPardotMemory < ApplicationRecord
     end
   end
 
-  def self.download_deleted_pardot_prospects(last_id = 0, limit = nil)
-    PardotV2.retrieve_prospects(last_id, %w(id email), limit, true) do |deleted_prospects|
+  def self.download_deleted_pardot_prospects(last_id = nil, limit = nil)
+    PardotV2.retrieve_prospects(last_id || 0,  %w(id email), limit, true) do |deleted_prospects|
       current_time = Time.now.utc
       batch = deleted_prospects.map do |item|
         {

--- a/dashboard/app/models/contact_rollups_pardot_memory.rb
+++ b/dashboard/app/models/contact_rollups_pardot_memory.rb
@@ -96,7 +96,7 @@ class ContactRollupsPardotMemory < ApplicationRecord
   end
 
   def self.download_deleted_pardot_prospects(last_id = nil, limit = nil)
-    PardotV2.retrieve_prospects(last_id,  %w(id email), limit, true) do |deleted_prospects|
+    PardotV2.retrieve_prospects(last_id, %w(id email), limit, true) do |deleted_prospects|
       current_time = Time.now.utc
       batch = deleted_prospects.map do |item|
         {

--- a/dashboard/app/models/contact_rollups_pardot_memory.rb
+++ b/dashboard/app/models/contact_rollups_pardot_memory.rb
@@ -96,7 +96,7 @@ class ContactRollupsPardotMemory < ApplicationRecord
   end
 
   def self.download_deleted_pardot_prospects(last_id = nil, limit = nil)
-    PardotV2.retrieve_prospects(last_id || 0,  %w(id email), limit, true) do |deleted_prospects|
+    PardotV2.retrieve_prospects(last_id,  %w(id email), limit, true) do |deleted_prospects|
       current_time = Time.now.utc
       batch = deleted_prospects.map do |item|
         {

--- a/dashboard/test/models/contact_rollups_pardot_memory_test.rb
+++ b/dashboard/test/models/contact_rollups_pardot_memory_test.rb
@@ -69,7 +69,8 @@ class ContactRollupsPardotMemoryTest < ActiveSupport::TestCase
     pardot_memory_records = [
       {email: 'alpha', pardot_id: nil},
       {email: 'beta', pardot_id: 1},
-      {email: 'omega', pardot_id: nil, data_rejected_reason: PardotHelpers::PROSPECT_DELETED_FROM_PARDOT}
+      {email: 'delta', pardot_id: nil, data_rejected_reason: PardotHelpers::ERROR_INVALID_EMAIL},
+      {email: 'omega', pardot_id: nil, data_rejected_reason: PardotHelpers::ERROR_PROSPECT_DELETED_FROM_PARDOT}
     ]
     pardot_memory_records.each {|record| create :contact_rollups_pardot_memory, record}
 
@@ -77,17 +78,18 @@ class ContactRollupsPardotMemoryTest < ActiveSupport::TestCase
       {email: 'alpha'},
       {email: 'beta'},
       {email: 'gamma'},
+      {email: 'delta'},
       {email: 'omega'}
     ]
     processed_contact_records.each {|record| create :contact_rollups_processed, record}
 
-    # Execute SQL query
+    # Execute SQL query to find new contacts to add to Pardot
     results = ActiveRecord::Base.connection.
       exec_query(ContactRollupsPardotMemory.query_new_contacts).map do |record|
       record['email']
     end
 
-    # Should find only 2 new contacts that don't have valid Pardot IDs.
+    # Should find only 2 new contacts that don't have valid Pardot IDs and are not rejected by Pardot.
     assert_equal %w(alpha gamma), results
   end
 
@@ -136,7 +138,7 @@ class ContactRollupsPardotMemoryTest < ActiveSupport::TestCase
         pardot_id_updated_at: base_time + 2.days,
         data_synced_at: base_time + 1.day,
         data_synced: {db_Opt_In: 'Yes'},
-        data_rejected_reason: PardotHelpers::PROSPECT_DELETED_FROM_PARDOT
+        data_rejected_reason: PardotHelpers::ERROR_PROSPECT_DELETED_FROM_PARDOT
       },
       # dummy records
       {email: 'delta', pardot_id: nil},

--- a/dashboard/test/models/contact_rollups_pardot_memory_test.rb
+++ b/dashboard/test/models/contact_rollups_pardot_memory_test.rb
@@ -68,14 +68,16 @@ class ContactRollupsPardotMemoryTest < ActiveSupport::TestCase
 
     pardot_memory_records = [
       {email: 'alpha', pardot_id: nil},
-      {email: 'beta', pardot_id: 1}
+      {email: 'beta', pardot_id: 1},
+      {email: 'omega', pardot_id: nil, data_rejected_reason: PardotHelpers::PROSPECT_DELETED_FROM_PARDOT}
     ]
     pardot_memory_records.each {|record| create :contact_rollups_pardot_memory, record}
 
     processed_contact_records = [
       {email: 'alpha'},
       {email: 'beta'},
-      {email: 'gamma'}
+      {email: 'gamma'},
+      {email: 'omega'}
     ]
     processed_contact_records.each {|record| create :contact_rollups_processed, record}
 
@@ -128,13 +130,21 @@ class ContactRollupsPardotMemoryTest < ActiveSupport::TestCase
         data_synced_at: base_time + 1.day,
         data_synced: {db_Opt_In: 'Yes'}
       },
+      {
+        email: 'omega',
+        pardot_id: 5,
+        pardot_id_updated_at: base_time + 2.days,
+        data_synced_at: base_time + 1.day,
+        data_synced: {db_Opt_In: 'Yes'},
+        data_rejected_reason: PardotHelpers::PROSPECT_DELETED_FROM_PARDOT
+      },
       # dummy records
       {email: 'delta', pardot_id: nil},
       {email: 'epsilon', pardot_id: 4},
     ]
     pardot_memory_records.each {|record| create :contact_rollups_pardot_memory, record}
 
-    # 3 cases that require updating contacts
+    # 3 cases that require updating contacts, and one that doesn't (deleted prospect)
     processed_contact_records = [
       # Case 1: data_synced_at is null
       {email: 'alpha', data: {opt_in: 0}, data_updated_at: base_time},
@@ -142,6 +152,8 @@ class ContactRollupsPardotMemoryTest < ActiveSupport::TestCase
       {email: 'beta', data: {opt_in: 0}, data_updated_at: base_time},
       # Case 3: pardot_id_updated_at > data_synced_at
       {email: 'gamma', data: {opt_in: 1}, data_updated_at: base_time},
+      # Case 4 (should be ignored): prospect has been deleted from Pardot
+      {email: 'omega', data: {opt_in: 1}, data_updated_at: base_time},
       # dummy records
       {email: 'delta'},
       {email: 'zeta'},

--- a/dashboard/test/models/contact_rollups_pardot_memory_test.rb
+++ b/dashboard/test/models/contact_rollups_pardot_memory_test.rb
@@ -68,7 +68,7 @@ class ContactRollupsPardotMemoryTest < ActiveSupport::TestCase
       {'id' => '1', 'email' => 'earth@rollups.com'},
       {'id' => '2', 'email' => 'mars@rollups.com'},
       # There could be multiple prospects with the same email address, but with different pardot_id.
-      {'id' => '3', 'email' => 'earths@rollups.com'}
+      {'id' => '3', 'email' => 'earth@rollups.com'}
     ]
     PardotV2.stubs(:retrieve_prospects).once.yields(deleted_prospects)
 

--- a/lib/cdo/contact_rollups/v2/pardot.rb
+++ b/lib/cdo/contact_rollups/v2/pardot.rb
@@ -36,7 +36,7 @@ class PardotV2
   # Retrieves new (email, Pardot ID) mappings from Pardot
   #
   # @param [Integer] last_id retrieves only Pardot ID greater than this value
-  # @param [Array<String>] fields prospect fields. Must have 'id' the list. Field names must be url-safe.
+  # @param [Array<String>] fields url-safe prospect field names. Must have 'id' the list.
   # @param [Integer] limit the maximum number of prospects to retrieve
   # @param [Boolean] only_deleted get deleted prospects (default false). Note this is in place of non-deleted prospects, not in addition to.
   # @return [Integer] number of results retrieved

--- a/lib/cdo/contact_rollups/v2/pardot.rb
+++ b/lib/cdo/contact_rollups/v2/pardot.rb
@@ -36,15 +36,15 @@ class PardotV2
   # Retrieves new (email, Pardot ID) mappings from Pardot
   #
   # @param [Integer] last_id retrieves only Pardot ID greater than this value
-  # @param [Array<String>] a list of fields. Must have 'id' the list. Field names must be url-safe.
-  # @param [Integer] limit maximum number of prospects to retrieve
-  # @param [Boolean] get deleted prospects (default false). Note this is in place of non-deleted prospects, not in addition to.
+  # @param [Array<String>] fields prospect fields. Must have 'id' the list. Field names must be url-safe.
+  # @param [Integer] limit the maximum number of prospects to retrieve
+  # @param [Boolean] only_deleted get deleted prospects (default false). Note this is in place of non-deleted prospects, not in addition to.
   # @return [Integer] number of results retrieved
   #
   # @yieldreturn [Array<Hash>] an array of hash of prospect data
   # @raise [ArgumentError] if 'id' is not in the list of fields
   # @raise [StandardError] if receives errors in Pardot response
-  def self.retrieve_prospects(last_id, fields, limit = nil, retrieve_deleted=false)
+  def self.retrieve_prospects(last_id, fields, limit = nil, only_deleted = false)
     raise ArgumentError.new("Missing value 'id' in fields argument") unless fields.include? 'id'
     total_results_retrieved = 0
 
@@ -55,7 +55,7 @@ class PardotV2
     # Run repeated requests querying for prospects above our highest known Pardot ID.
     # Stop when receiving no prospects or reaching the download limit.
     loop do
-      url = create_query_url(last_id, fields, limit_in_query, retrieve_deleted)
+      url = build_prospect_query_url(last_id, fields, limit_in_query, only_deleted)
       doc = post_with_auth_retry(url)
       raise_if_response_error(doc)
 
@@ -79,12 +79,12 @@ class PardotV2
   end
 
   # Creates URL and query string for use with Pardot prospect query API
-  def self.create_query_url(last_id, fields, limit_in_query, retrieve_deleted)
+  def self.build_prospect_query_url(last_id, fields, limit_in_query, only_deleted)
     # Use bulk output format as recommended at http://developer.pardot.com/kb/bulk-data-pull/.
     url = "#{PROSPECT_QUERY_URL}?output=bulk"
     url += "&id_greater_than=#{last_id}&fields=#{fields.join(',')}&sort_by=id"
     url += "&limit=#{limit_in_query}" if limit_in_query
-    url += "&deleted=true" if retrieve_deleted
+    url += "&deleted=true" if only_deleted
 
     return url
   end

--- a/lib/cdo/contact_rollups/v2/pardot.rb
+++ b/lib/cdo/contact_rollups/v2/pardot.rb
@@ -79,12 +79,18 @@ class PardotV2
   end
 
   # Creates URL and query string for use with Pardot prospect query API
-  def self.build_prospect_query_url(last_id, fields, limit_in_query, only_deleted)
+  # @param id_greater_than [String, Integer]
+  # @param fields [Array<String>]
+  # @param limit [String, Integer]
+  # @param deleted [Boolean]
+  # @return [String]
+  def self.build_prospect_query_url(id_greater_than, fields, limit, deleted)
     # Use bulk output format as recommended at http://developer.pardot.com/kb/bulk-data-pull/.
-    url = "#{PROSPECT_QUERY_URL}?output=bulk"
-    url += "&id_greater_than=#{last_id}&fields=#{fields.join(',')}&sort_by=id"
-    url += "&limit=#{limit_in_query}" if limit_in_query
-    url += "&deleted=true" if only_deleted
+    url = "#{PROSPECT_QUERY_URL}?output=bulk&sort_by=id"
+    url += "&id_greater_than=#{id_greater_than}" if id_greater_than
+    url += "&fields=#{fields.join(',')}" if fields
+    url += "&limit=#{limit}" if limit
+    url += "&deleted=true" if deleted
 
     return url
   end

--- a/lib/cdo/contact_rollups/v2/pardot.rb
+++ b/lib/cdo/contact_rollups/v2/pardot.rb
@@ -91,8 +91,7 @@ class PardotV2
     url += "&fields=#{fields.join(',')}" if fields
     url += "&limit=#{limit}" if limit
     url += "&deleted=true" if deleted
-
-    return url
+    url
   end
 
   # Compiles a batch of prospects and batch-create them in Pardot when batch size

--- a/lib/cdo/contact_rollups/v2/pardot_helpers.rb
+++ b/lib/cdo/contact_rollups/v2/pardot_helpers.rb
@@ -4,6 +4,7 @@ module PardotHelpers
   STATUS_OK = 'ok'.freeze
   ERROR_INVALID_EMAIL = 'Invalid prospect email address'
   ERROR_INVALID_API_KEY = 'Invalid API key or user key'
+  PROSPECT_DELETED_FROM_PARDOT = 'Prospect deleted from Pardot'
 
   class InvalidApiKeyException < RuntimeError
   end
@@ -66,8 +67,8 @@ module PardotHelpers
 
   # Make an API request. This method may raise exceptions.
   #
-  # @param url [String] URL to post to - must already include Pardot auth params
-  # @param params [Hash] hash of POST params (may be empty hash)
+  # @param url [String] URL to post to
+  # @param params [Hash] hash of POST params (may be empty hash or contain API and user keys)
   # @return [Nokogiri::XML, nil] XML response from Pardot
   def post_request(url, params)
     uri = URI(url)

--- a/lib/cdo/contact_rollups/v2/pardot_helpers.rb
+++ b/lib/cdo/contact_rollups/v2/pardot_helpers.rb
@@ -4,7 +4,7 @@ module PardotHelpers
   STATUS_OK = 'ok'.freeze
   ERROR_INVALID_EMAIL = 'Invalid prospect email address'
   ERROR_INVALID_API_KEY = 'Invalid API key or user key'
-  PROSPECT_DELETED_FROM_PARDOT = 'Prospect deleted from Pardot'
+  ERROR_PROSPECT_DELETED_FROM_PARDOT = 'Prospect deleted from Pardot'
 
   class InvalidApiKeyException < RuntimeError
   end

--- a/lib/test/cdo/contact_rollups/test_pardot_v2.rb
+++ b/lib/test/cdo/contact_rollups/test_pardot_v2.rb
@@ -43,6 +43,12 @@ class PardotV2Test < Minitest::Test
     assert_equal [{'id' => pardot_id, 'email' => email}], yielded_result
   end
 
+  def create_query_url_with_deleted_prospects
+    expected_url = "#{PardotV2::PROSPECT_QUERY_URL}?output=bulk&id_greater_than=0&fields=id,email&sort_by=id&deleted=true"
+
+    assert_equal expected_url, PardotV2.create_query_url(0, %w(id email), nil, true)
+  end
+
   def test_batch_create_prospects_single_contact
     contact = {email: 'crv2_test@domain.com', data: {opt_in: 1}}
 

--- a/lib/test/cdo/contact_rollups/test_pardot_v2.rb
+++ b/lib/test/cdo/contact_rollups/test_pardot_v2.rb
@@ -43,10 +43,18 @@ class PardotV2Test < Minitest::Test
     assert_equal [{'id' => pardot_id, 'email' => email}], yielded_result
   end
 
-  def create_query_url_with_deleted_prospects
-    expected_url = "#{PardotV2::PROSPECT_QUERY_URL}?output=bulk&id_greater_than=0&fields=id,email&sort_by=id&deleted=true"
+  def test_build_prospect_query_url
+    # Create query to retrieve active prospects
+    assert_equal(
+      "#{PardotV2::PROSPECT_QUERY_URL}?output=bulk&id_greater_than=0&fields=id,email&sort_by=id",
+      PardotV2.build_prospect_query_url(0, %w(id email), nil, false)
+    )
 
-    assert_equal expected_url, PardotV2.create_query_url(0, %w(id email), nil, true)
+    # Create query to retrieve only deleted prospects
+    assert_equal(
+      "#{PardotV2::PROSPECT_QUERY_URL}?output=bulk&id_greater_than=0&fields=id,email&sort_by=id&deleted=true",
+      PardotV2.build_prospect_query_url(0, %w(id email), nil, true)
+    )
   end
 
   def test_batch_create_prospects_single_contact

--- a/lib/test/cdo/contact_rollups/test_pardot_v2.rb
+++ b/lib/test/cdo/contact_rollups/test_pardot_v2.rb
@@ -46,13 +46,13 @@ class PardotV2Test < Minitest::Test
   def test_build_prospect_query_url
     # Create query to retrieve active prospects
     assert_equal(
-      "#{PardotV2::PROSPECT_QUERY_URL}?output=bulk&id_greater_than=0&fields=id,email&sort_by=id",
+      "#{PardotV2::PROSPECT_QUERY_URL}?output=bulk&sort_by=id&id_greater_than=0&fields=id,email",
       PardotV2.build_prospect_query_url(0, %w(id email), nil, false)
     )
 
     # Create query to retrieve only deleted prospects
     assert_equal(
-      "#{PardotV2::PROSPECT_QUERY_URL}?output=bulk&id_greater_than=0&fields=id,email&sort_by=id&deleted=true",
+      "#{PardotV2::PROSPECT_QUERY_URL}?output=bulk&sort_by=id&id_greater_than=0&fields=id,email&deleted=true",
       PardotV2.build_prospect_query_url(0, %w(id email), nil, true)
     )
   end


### PR DESCRIPTION
## Summary
Seeding contact roll-ups with a list of deleted prospects from Pardot. This list is then used to prevent contact-rollups from re-adding prospects that we had deleted on purpose. 
This is an one-time seeding.

## Background
We have a limit of 3.2M mail-able prospects in Pardot (which we can increase if we pay more).
As of 5/8/2020, we were at 96.5% of the limit. Marketing team did a clean-up before Hour of Code and deleted about 300K prospects; they are currently sitting in Pardot recycle bin. [Slack discussion](https://codedotorg.slack.com/archives/C06E60KL4/p1588951171059800).

If we do nothing, contact roll-ups v2 will re-add many of those deleted prospects because they are considered as new prospects (they exists in the production db but not in Pardot). This PR is to make contact roll-ups v2 aware of those deleted prospects and avoid re-creating them.

<img width="720" alt="Screen Shot 2020-05-08 at 8 13 41 AM" src="https://user-images.githubusercontent.com/46507039/81507360-bf071300-92b1-11ea-8bdb-0a5c26d317a4.png">

## Testing story
- Unit tests
- Manual tests on local and adhoc machine
  ```ruby
  # in rails console
  ContactRollupsPardotMemory.count
  ContactRollupsPardotMemory.download_deleted_pardot_prospects(nil, 2)  # download first 2 deleted contacts
  ContactRollupsPardotMemory.download_deleted_pardot_prospects(50848578, 3)  # download 3 deleted contacts after this id
  ContactRollupsPardotMemory.download_deleted_pardot_prospects(50848578, nil) # download all deleted contacts after this id
  ContactRollupsPardotMemory.download_deleted_pardot_prospects(nil, nil)  # download all deleted contacts
  ContactRollupsPardotMemory.count
  ```

# Reviewer Checklist:
- [ ] Tests provide adequate coverage
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
