### PR TITLE
Add year to branch names

### DIFF
--- a/bin/i18n/sync-all.rb
+++ b/bin/i18n/sync-all.rb
@@ -33,8 +33,8 @@ require_relative 'upload_i18n_translation_percentages_to_gdrive'
 
 require 'optparse'
 
-IN_UP_BRANCH = "i18n-sync-in-up-#{Date.today.strftime('%m-%d')}".freeze
-DOWN_OUT_BRANCH = "i18n-sync-down-out-#{Date.today.strftime('%m-%d')}".freeze
+IN_UP_BRANCH = "i18n-sync-in-up-#{Date.today.strftime('%m-%d-%Y')}".freeze
+DOWN_OUT_BRANCH = "i18n-sync-down-out-#{Date.today.strftime('%m-%d-%Y')}".freeze
 
 class I18nSync
   def initialize(args)


### PR DESCRIPTION
Now that the i18n-dev server has been around for a full year, we're getting very similar branch names living on the server. Last week, I checked out `i18n-sync-down-out-05-07` instead of `i18n-sync-down-out-05-08` to find the former was a year old. :)

<!-- ### Background -->
<!-- ### Privacy -->
<!-- ### Security -->
<!-- ### Caching -->
<!-- ### Deployment strategy -->
<!-- ### Future work -->

## Links

<!--
  Any relevant links to external resources; ie, specification documents, jira
  items, related PRs, honeybadger errors, etc
-->

- [spec]()
- [jira]()

## Testing story

<!--
  Does your change include appropriate tests?

  If so, please describe how the tests included in this PR are sufficient

  If not, please explain why this change does not need to be tested.
-->

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
