### PR TITLE
Foorm: Fix results link logic

### DIFF
--- a/apps/src/code-studio/pd/workshop_dashboard/EnrollmentsPanel.jsx
+++ b/apps/src/code-studio/pd/workshop_dashboard/EnrollmentsPanel.jsx
@@ -274,7 +274,7 @@ export default class EnrollmentsPanel extends React.Component {
         .format('MMMM Do');
 
       const lastSessionDate = new Date(
-        workshop.sessions[workshop.sessions.length - 1].start
+        workshop.sessions[workshop.sessions.length - 1].end
       );
 
       let viewSurveyUrl = this.getViewSurveyUrl(

--- a/apps/src/code-studio/pd/workshop_dashboard/components/workshop_management.jsx
+++ b/apps/src/code-studio/pd/workshop_dashboard/components/workshop_management.jsx
@@ -26,7 +26,8 @@ export class WorkshopManagement extends React.Component {
     editUrl: PropTypes.string,
     onDelete: PropTypes.func,
     showSurveyUrl: PropTypes.bool,
-    date: PropTypes.string
+    date: PropTypes.string,
+    endDate: PropTypes.string
   };
 
   static defaultProps = {
@@ -79,7 +80,9 @@ export class WorkshopManagement extends React.Component {
   };
 
   use_foorm_route = () => {
-    let workshop_date = new Date(this.props.date);
+    let workshop_date = this.props.endDate
+      ? new Date(this.props.endDate)
+      : new Date(this.props.date);
 
     return (
       workshop_date >= new Date('2020-05-08') &&

--- a/apps/src/code-studio/pd/workshop_dashboard/components/workshop_table.jsx
+++ b/apps/src/code-studio/pd/workshop_dashboard/components/workshop_table.jsx
@@ -282,7 +282,7 @@ export default class WorkshopTable extends React.Component {
   };
 
   formatManagement = manageData => {
-    const {id, course, subject, state, date, canDelete} = manageData;
+    const {id, course, subject, state, date, canDelete, endDate} = manageData;
 
     return (
       <WorkshopManagement
@@ -299,6 +299,7 @@ export default class WorkshopTable extends React.Component {
             subject !== SubjectNames.SUBJECT_FIT) ||
           (course === CSF && subject === SubjectNames.SUBJECT_CSF_201)
         }
+        endDate={endDate}
       />
     );
   };
@@ -319,7 +320,8 @@ export default class WorkshopTable extends React.Component {
           subject: row.subject,
           state: row.state,
           date: row.sessions[0].start,
-          canDelete: row.can_delete
+          canDelete: row.can_delete,
+          endDate: row.sessions[row.sessions.length - 1].end
         }
       })
     );


### PR DESCRIPTION
We found an edge case in the view survey results button from the workshop dashboard. It was using the start date of the workshop to determine which results page to view instead of the end date. Fixed to use the end date instead. The other link (from the workshop details page) was using the last session date, although it was using the start time of that session, so I updated it to use the end time of the session to make everything consistent.

<!-- ### Background -->
<!-- ### Privacy -->
<!-- ### Security -->
<!-- ### Caching -->
<!-- ### Deployment strategy -->
<!-- ### Future work -->


## Testing story
Validated by making a workshop with a first session before 5/8 and a last session after 5/8, and verified the link worked after applying the fix. Also validated other workshop links were unaffected.

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
