### PR TITLE
[Applab Datasets] Filter out empty records

### DIFF
--- a/apps/src/storage/redux/data.js
+++ b/apps/src/storage/redux/data.js
@@ -86,9 +86,10 @@ export default function(state = initialState, action) {
         if (!action.tableRecords) {
           return state.set('tableRecords', []);
         }
-        const records = Array.isArray(action.tableRecords)
+        let records = Array.isArray(action.tableRecords)
           ? action.tableRecords
           : Object.values(action.tableRecords);
+        records = records.filter(record => record !== undefined);
         return state.set('tableRecords', records);
       }
       return state;


### PR DESCRIPTION
One of the weird quirks of Firebase is that it sometimes returns an object with records keyed by id and sometimes returns an array with records at indices corresponding to their id. See https://firebase.googleblog.com/2014/04/best-practices-arrays-in-firebase.html

If it's an object, we coerce it to an array using `Object.values()`, which, as you would expect, makes an array of just the values in the object (no blank spaces between missing indices). However, if Firebase returns an array, it might have blank spaces. In fact, with our usage it almost certainly does have a blank space at index 0, because our records start at id 1.
The problem with this is that the blank space counts towards the array's length, which we use to paginate the DataTable.
This led to the observation that the Top 500 Music Albums table displayed on two pages, not 1:
![image](https://user-images.githubusercontent.com/8787187/81587313-b7a44000-936b-11ea-9d9a-0b720337802e.png)

The solution here is just to filter out any empty records before setting the tableRecords in the redux store.
And now the Top 500 Albums table is one page, as expected:
![image](https://user-images.githubusercontent.com/8787187/81587511-fafeae80-936b-11ea-92e2-73889b901f6b.png)


<!-- ### Background -->
<!-- ### Privacy -->
<!-- ### Security -->
<!-- ### Caching -->
<!-- ### Deployment strategy -->
<!-- ### Future work -->

## Testing story

<!--
  Does your change include appropriate tests?

  If so, please describe how the tests included in this PR are sufficient

  If not, please explain why this change does not need to be tested.
-->

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
