### PR TITLE
Alert contact rollups on account deletion

### DIFF
--- a/dashboard/test/helpers/delete_accounts_helper_test.rb
+++ b/dashboard/test/helpers/delete_accounts_helper_test.rb
@@ -1860,6 +1860,26 @@ class DeleteAccountsHelperTest < ActionView::TestCase
   end
 
   #
+  # contact rollups V2
+  #
+
+  test "account deletion stages email for removal from pardot via purge_user" do
+    teacher = create :teacher
+    teacher_email = teacher.email
+    purge_user teacher
+
+    refute_nil ContactRollupsPardotMemory.find_by(email: teacher_email).marked_for_deletion_at
+  end
+
+  test "account deletion stages email for removal from pardot via purge_all_accounts_with_email" do
+    teacher = create :teacher
+    teacher_email = teacher.email
+    purge_all_accounts_with_email teacher_email
+
+    refute_nil ContactRollupsPardotMemory.find_by(email: teacher_email).marked_for_deletion_at
+  end
+
+  #
   # Testing our utilities
   #
 

--- a/lib/cdo/delete_accounts_helper.rb
+++ b/lib/cdo/delete_accounts_helper.rb
@@ -201,6 +201,13 @@ class DeleteAccountsHelper
     remove_from_pardot_and_contact_rollups @pegasus_db[:contact_rollups].where(email: email)
   end
 
+  # Marks emails for deletion from Pardot via contact rollups process.
+  # Will eventually replace current steps in account deletion process
+  # that directly delete prospects via Pardot API.
+  def set_pardot_deletion_via_contact_rollups(email)
+    ContactRollupsPardotMemory.find_or_create_by(email: email).update(marked_for_deletion_at: Time.now.utc)
+  end
+
   # Removes the StudioPerson record associated with the user IF it is not
   # associated with any other users.
   # @param [User] user The user whose studio person we will delete if it's not shared
@@ -325,6 +332,7 @@ class DeleteAccountsHelper
     remove_user_from_sections_as_student(user)
     remove_poste_data(user_email) if user_email&.present?
     remove_from_pardot_by_user_id(user.id)
+    set_pardot_deletion_via_contact_rollups(user_email) if user_email&.present?
     purge_unshared_studio_person(user)
     anonymize_user(user)
 
@@ -350,6 +358,7 @@ class DeleteAccountsHelper
 
     remove_poste_data(email)
     remove_from_pardot_by_email(email)
+    set_pardot_deletion_via_contact_rollups(email)
     clean_pegasus_forms_for_email(email)
   end
 


### PR DESCRIPTION
Marks an email address for deletion from Pardot (via contact rollups) when it is deleted via the account deletion process.

Note that once Contact Rollups is fully functional, we can delete the steps in the current account deletion process that delete prospects from Pardot directly.

This is essentially the work in [this PR](https://github.com/code-dot-org/code-dot-org/pull/34253), but leaves the current process for deleting prospects from Pardot in place until we're confident in the new Contact Rollups mechanism.

## Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
