### PR TITLE
Truncate Contact Rollups tables in production

### DIFF
--- a/dashboard/app/models/contact_rollups_final.rb
+++ b/dashboard/app/models/contact_rollups_final.rb
@@ -16,9 +16,8 @@
 class ContactRollupsFinal < ApplicationRecord
   self.table_name = 'contact_rollups_final'
 
-  def self.overwrite_from_processed_table
-    delete_all
-    insert_from_processed_table
+  def self.truncate_table
+    ActiveRecord::Base.connection.execute("TRUNCATE TABLE #{table_name}")
   end
 
   def self.insert_from_processed_table

--- a/dashboard/app/models/contact_rollups_final.rb
+++ b/dashboard/app/models/contact_rollups_final.rb
@@ -16,10 +16,6 @@
 class ContactRollupsFinal < ApplicationRecord
   self.table_name = 'contact_rollups_final'
 
-  def self.truncate_table
-    ActiveRecord::Base.connection.execute("TRUNCATE TABLE #{table_name}")
-  end
-
   def self.insert_from_processed_table
     insert_sql = <<~SQL
       INSERT INTO #{table_name}

--- a/dashboard/app/models/contact_rollups_processed.rb
+++ b/dashboard/app/models/contact_rollups_processed.rb
@@ -16,6 +16,10 @@
 class ContactRollupsProcessed < ApplicationRecord
   self.table_name = 'contact_rollups_processed'
 
+  def self.truncate_table
+    ActiveRecord::Base.connection.execute("TRUNCATE TABLE #{table_name}")
+  end
+
   DEFAULT_BATCH_SIZE = 10000
 
   # Aggregates data from contact_rollups_raw table and saves the results, one row per email.

--- a/dashboard/app/models/contact_rollups_processed.rb
+++ b/dashboard/app/models/contact_rollups_processed.rb
@@ -16,10 +16,6 @@
 class ContactRollupsProcessed < ApplicationRecord
   self.table_name = 'contact_rollups_processed'
 
-  def self.truncate_table
-    ActiveRecord::Base.connection.execute("TRUNCATE TABLE #{table_name}")
-  end
-
   DEFAULT_BATCH_SIZE = 10000
 
   # Aggregates data from contact_rollups_raw table and saves the results, one row per email.

--- a/dashboard/app/models/contact_rollups_raw.rb
+++ b/dashboard/app/models/contact_rollups_raw.rb
@@ -18,10 +18,6 @@
 class ContactRollupsRaw < ApplicationRecord
   self.table_name = 'contact_rollups_raw'
 
-  def self.truncate_table
-    ActiveRecord::Base.connection.execute("TRUNCATE TABLE #{table_name}")
-  end
-
   def self.extract_email_preferences
     query = get_extraction_query('email_preferences', 'email', ['opt_in'])
     ActiveRecord::Base.connection.execute(query)

--- a/dashboard/lib/contact_rollups_v2.rb
+++ b/dashboard/lib/contact_rollups_v2.rb
@@ -39,6 +39,10 @@ class ContactRollupsV2
   # Deletion is required in test environments, as tests generally do
   # not allow you to execute TRUNCATE statements.
   def self.truncate_or_delete_table(model)
-    CDO.rack_env == :production ? model.truncate_table : model.delete_all
+    CDO.rack_env == :production ? truncate_table(model) : model.delete_all
+  end
+
+  def self.truncate_table(model)
+    ActiveRecord::Base.connection.execute("TRUNCATE TABLE #{model.table_name}")
   end
 end

--- a/dashboard/lib/contact_rollups_v2.rb
+++ b/dashboard/lib/contact_rollups_v2.rb
@@ -34,6 +34,10 @@ class ContactRollupsV2
     end
   end
 
+  # Using truncate allows us to re-use row IDs,
+  # which is important in production so we don't overflow the table.
+  # Deletion is required in test environments, as tests generally do
+  # not allow you to execute TRUNCATE statements.
   def self.truncate_or_delete_table(model)
     CDO.rack_env == :production ? model.truncate_table : model.delete_all
   end

--- a/dashboard/test/models/contact_rollups_final_test.rb
+++ b/dashboard/test/models/contact_rollups_final_test.rb
@@ -2,7 +2,8 @@ require 'test_helper'
 
 class ContactRollupsFinalTest < ActiveSupport::TestCase
   test 'insert_from_processed_table properly inserts into contact_rollups_final' do
-    clean_tables
+    assert 0, ContactRollupsProcessed.count
+    assert 0, ContactRollupsFinal.count
 
     processed = create_list :contact_rollups_processed, 5
 
@@ -12,10 +13,5 @@ class ContactRollupsFinalTest < ActiveSupport::TestCase
     processed.each do |contact|
       assert_equal contact.data, ContactRollupsFinal.find_by(email: contact.email).data
     end
-  end
-
-  def clean_tables
-    ContactRollupsProcessed.delete_all
-    ContactRollupsFinal.delete_all
   end
 end


### PR DESCRIPTION
We noticed today that the row ID in the production `contact_rollups_final` table was already over 3 million. We believe this is a result of `delete` operations being rollback-able, meaning that each time the process deletes the contents of the table and inserts new ones, it starts new IDs at the highest value that previously existed. With daily runs at the volume of rows expected in contact rollups, we'd overflow the table in under 2 years.

This change uses truncate instead of `delete_all` in production -- truncate is is categorized as "data definition language" instead of "data manipulation language" like `delete`, and restarts row IDs at 1.

## Testing story

This test shouldn't actually change the process at all, so hoping that existing tests will cover this.

## Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
