### PR TITLE
allow curriculum builder to load code studio in an iframe

### DIFF
--- a/config.yml.erb
+++ b/config.yml.erb
@@ -318,7 +318,7 @@ app_servers: {}
 rack_mini_profiler_enabled:
 https_development:
 default_scheme: '<%=(env == 'development') || ci ? 'http:' : 'https:'%>'
-allowed_iframe_ancestors: http://*.disney.com http://*.diznee.net <%=pegasus_hostname%> <%=dashboard_hostname%>
+allowed_iframe_ancestors: http://*.disney.com http://*.diznee.net <%=pegasus_hostname%> <%=dashboard_hostname%> curriculum.code.org codecurricula.com
 skip_locales:
 secret_pictures_csv:
 no_https_store:


### PR DESCRIPTION
## Background

Curriculum builder lives on curriculum.code.org (teacher-facing) and codecurricla.com (internal-facing). In some cases these sites try to host studio.code.org content in an iframe. this appears to be broken due to our content security policy. Here is an example of an iframe failing to load on https://www.codecurricula.com/csd-19/unit6/6/ (click level 7 or 17):

![Screen Shot 2020-05-12 at 9 06 23 AM](https://user-images.githubusercontent.com/8001765/81717825-e5eb5380-942f-11ea-9272-411f9c58ea1e.png)

We're not sure how long it's been broken, but the fix looks easy so the plan is to fix it without spending a lot of time investigating how it broke. However if reviewers are aware of any work that's been done in this area recently which could have caused this, that could be useful to know.

## Description 

add both curriculum builder domains to the list of domains which is allowed to host code studio urls in an iframe.

## Testing story

The fix would be hard to validate, because both instances of curriculum builder point at production code studio for documentation links. However it is a pretty simple configuration change, and this is not hotfix-urgent so it seems ok to ship the change and then confirm in production that the issue has been resolved.

There is no regression test on this change. However, we are just adding to a list of configuration parameters, so the risk of regression seems relatively low and there is no clear way to perform additional validations. 

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
