### PR TITLE
Change background color for NewProjectButtons

### DIFF
--- a/apps/src/templates/projects/NewProjectButtons.jsx
+++ b/apps/src/templates/projects/NewProjectButtons.jsx
@@ -129,7 +129,8 @@ const styles = {
     float: 'left',
     display: 'flex',
     justifyContent: 'flex-start',
-    alignItems: 'center'
+    alignItems: 'center',
+    backgroundColor: color.white
   },
   tilePadding: {
     marginRight: 35


### PR DESCRIPTION
Tiny polish item follow up from reviewing #34736 to set the background color of `NewProjectButton` to white. Most of the places we show this component - the home page, project gallery, etc have white backgrounds that show through this transparent component. However, on the gray background of Lesson Extras, this change will help the new project buttons pop and keep them consistent with project cards. 

BEFORE 
<img width="1068" alt="Screen Shot 2020-05-12 at 10 27 43 AM" src="https://user-images.githubusercontent.com/12300669/81727856-70d34a80-943e-11ea-99cf-65ed79a6a691.png">

AFTER 
<img width="1012" alt="Screen Shot 2020-05-12 at 10 46 29 AM" src="https://user-images.githubusercontent.com/12300669/81727868-7597fe80-943e-11ea-89e8-c83307720922.png">

