### PR TITLE
Recruitment: update text for two banners

### DIFF
--- a/apps/src/templates/ProfessionalLearningApplyBanner.jsx
+++ b/apps/src/templates/ProfessionalLearningApplyBanner.jsx
@@ -126,7 +126,7 @@ class ProfessionalLearningApplyBanner extends React.Component {
 
   getText() {
     if (this.props.useSignUpText) {
-      return 'Sign up for Professional Learning! Applications are now open for Middle and High School teachers.';
+      return 'Professional Learning is still on! Applications are open for Middle and High School teachers!';
     } else if (this.props.nominated) {
       return 'CONGRATULATIONS! You’ve been nominated for a scholarship!';
     } else {

--- a/pegasus/sites.v3/code.org/views/homepage_below_hero_plane_banner.haml
+++ b/pegasus/sites.v3/code.org/views/homepage_below_hero_plane_banner.haml
@@ -8,16 +8,16 @@
           .banner
             %img{src: "/images/homepage/professional-learning-2018-banner.png"}
             .text
-              Sign up for Professional Learning! Applications are
+              Professional Learning is still on! Applications
               %br/
-              now open for Middle and High School teachers.
+              are open for Middle and High School teachers!
         .right.col-20
           %button
             Join us
       .phone.phone-feature
         .text
-          Sign up for Professional Learning! Applications are
-          now open for Middle and High School teachers.
+          Professional Learning is still on! Applications are open
+          for Middle and High School teachers!
         %button
           Join us
 


### PR DESCRIPTION
Followup to https://github.com/code-dot-org/code-dot-org/pull/34762

### Homepage for Code Break

![Screenshot 2020-05-12 13 02 19](https://user-images.githubusercontent.com/2205926/81740072-36bf7400-9451-11ea-8c9b-822e9f931033.png)

### Homepage for not Code Break

![Screenshot 2020-05-12 13 08 45](https://user-images.githubusercontent.com/2205926/81740391-bfd6ab00-9451-11ea-893d-c9a5b15e69e8.png)

### https://code.org/yourschool

![Screenshot 2020-05-12 13 02 34](https://user-images.githubusercontent.com/2205926/81740074-37580a80-9451-11ea-97a0-6eb5a8457af2.png)
