### PR TITLE
Assignment Metrics: set pageType correctly on script overview

### DIFF
--- a/apps/src/code-studio/progress.js
+++ b/apps/src/code-studio/progress.js
@@ -162,7 +162,7 @@ progress.renderCourseProgress = function(scriptData) {
     store.dispatch(setSections(scriptData.sections));
   }
 
-  store.dispatch(setPageType, pageTypes.scriptOverview);
+  store.dispatch(setPageType(pageTypes.scriptOverview));
 
   const mountPoint = document.createElement('div');
   $('.user-stats-block').prepend(mountPoint);


### PR DESCRIPTION
[LP-1423](https://codedotorg.atlassian.net/browse/LP-1423)

Amanda noticed that we weren't [correctly logging assignment metrics from the script overview page](https://codedotorg.slack.com/archives/CA3KCSGTD/p1588111349365500).  This occurred because we weren't correctly setting `pageType` on the script overview page, so the assignment logging never had `script_overview` for the `page_name` field in the metric. 

I corrected the syntax error, and now `pageType` is correctly set on the script overview page, which results in accurate logging. 

<img width="1014" alt="Screen Shot 2020-05-12 at 1 39 25 PM" src="https://user-images.githubusercontent.com/12300669/81744028-7f7a2b80-9457-11ea-9ae0-1936b0fbcfeb.png">

<img width="804" alt="Screen Shot 2020-05-12 at 1 40 02 PM" src="https://user-images.githubusercontent.com/12300669/81744031-80ab5880-9457-11ea-9b49-767b47e5a922.png">
