### PR TITLE
Improve unit tests for cloning level groups

### DIFF
--- a/dashboard/app/models/levels/dsl_defined.rb
+++ b/dashboard/app/models/levels/dsl_defined.rb
@@ -176,7 +176,8 @@ class DSLDefined < Level
   end
 
   def dsl_text
-    self.class.decrypt_dsl_text_if_necessary(File.read(file_path)) if file_path && File.exist?(file_path)
+    path = file_path
+    self.class.decrypt_dsl_text_if_necessary(File.read(path)) if path && File.exist?(path)
   end
 
   def assign_attributes(params)

--- a/dashboard/test/models/level_group_test.rb
+++ b/dashboard/test/models/level_group_test.rb
@@ -285,7 +285,7 @@ MARKDOWN
   level 'level7'
   "
 
-    level_group_copy_dsl = "name 'level_group_test long assessment_copy'
+    expected_copy_dsl = "name 'level_group_test long assessment_copy'
 title 'Long Assessment'
 submittable 'true'
 
@@ -304,36 +304,42 @@ level 'level6_copy'
 level 'level7_copy'"
 
     # Create multis named level1-level7.
-    levels = {}
-    multi_stubs = Multi.any_instance.stubs(:dsl_text)
     (1..7).each do |id|
-      dsl_text = get_multi_dsl(id)
-      levels["multi_#{id}"] = Multi.create_from_level_builder({}, {dsl_text: dsl_text})
-      multi_stubs.returns(dsl_text)
+      multi_dsl = get_multi_dsl(id)
+      multi = Multi.create_from_level_builder({}, {dsl_text: multi_dsl})
+      File.stubs(:exist?).with {|filepath, _| filepath.to_s.end_with?(multi.filename)}.returns(true)
+      File.stubs(:read).with {|filepath, _| filepath.to_s.end_with?(multi.filename)}.returns(multi_dsl)
     end
 
     # Create the external level.
     external_dsl = get_external_dsl(1)
     External.create_from_level_builder({}, {dsl_text: external_dsl})
-    External.any_instance.stubs(:dsl_text).returns(external_dsl)
+    File.stubs(:exist?).with {|filepath, _| filepath.to_s.end_with?("external1.external")}.returns(true)
+    File.stubs(:read).with {|filename, _| filename.to_s.end_with?("external1.external")}.returns(external_dsl)
 
     # Create the level_group.
     level_group = LevelGroup.create_from_level_builder({}, {name: 'my_level_group', dsl_text: level_group_input_dsl})
-    level_group.stubs(:dsl_text).returns(level_group_input_dsl)
+    File.stubs(:exist?).with {|filepath, _| filepath.to_s.end_with?("level_group_test_long_assessment.level_group")}.returns(true)
+    File.stubs(:read).with {|filepath, _| filepath.to_s.end_with?("level_group_test_long_assessment.level_group")}.returns(level_group_input_dsl)
+
+    File.stubs(:write).with do |filepath, actual_dsl|
+      filepath.basename.to_s == 'level_group_test_long_assessment_copy.level_group' &&
+        expected_copy_dsl == actual_dsl
+    end.once
 
     # Copy the level group and all its sub levels.
     level_group_copy = level_group.clone_with_suffix('_copy')
 
-    assert_equal level_group_copy_dsl, level_group_copy.dsl_text
+    # Verify the result
+    assert_equal 'level_group_test long assessment_copy', level_group_copy.name
+    assert_equal 3, level_group_copy.pages.count
+
     (1..7).each do |id|
       refute_nil l = Level.find_by_name("level#{id}_copy")
       assert_equal 'What is the name of this function?', l.properties['questions'].first['text']
     end
     refute_nil l = Level.find_by_name('external1_copy')
     assert_includes l.properties['markdown'], 'Sample external'
-
-    # clean up
-    File.delete(level_group_copy.filename)
   end
 
   test 'clone previously cloned level group' do

--- a/dashboard/test/models/level_group_test.rb
+++ b/dashboard/test/models/level_group_test.rb
@@ -239,13 +239,14 @@ MARKDOWN
     # Create the sublevel.
     multi_dsl = get_multi_dsl(1)
     multi = Multi.create_from_level_builder({}, {dsl_text: multi_dsl})
-    File.stubs(:exist?).with {|filepath, _| filepath.to_s.end_with?(multi.filename)}.returns(true)
-    File.stubs(:read).with {|filepath, _| filepath.to_s.end_with?(multi.filename)}.returns(multi_dsl)
+    multi_filename = multi.filename.split('/').last
+    File.stubs(:exist?).with {|filepath| filepath.basename.to_s == multi_filename}.returns(true)
+    File.stubs(:read).with {|filepath| filepath.basename.to_s == multi_filename}.returns(multi_dsl)
 
     # Create the level_group.
     level_group = LevelGroup.create_from_level_builder({}, {name: 'my_level_group', dsl_text: level_group_input_dsl})
-    File.stubs(:exist?).with {|filepath, _| filepath.to_s.end_with?("my_level_group.level_group")}.returns(true)
-    File.stubs(:read).with {|filepath, _| filepath.to_s.end_with?("my_level_group.level_group")}.returns(level_group_input_dsl)
+    File.stubs(:exist?).with {|filepath| filepath.basename.to_s == 'my_level_group.level_group'}.returns(true)
+    File.stubs(:read).with {|filepath| filepath.basename.to_s == 'my_level_group.level_group'}.returns(level_group_input_dsl)
 
     File.stubs(:write).with do |filepath, actual_dsl|
       filepath.basename.to_s == 'my_level_group_copy.level_group' &&
@@ -303,24 +304,26 @@ page
 level 'level6_copy'
 level 'level7_copy'"
 
+    # To make the test run faster, just stub File.exist? once. If the code under
+    # test tries to read a nonexistent file, we'll get an error during File.read.
+    File.stubs(:exist?).returns(true)
+
     # Create multis named level1-level7.
     (1..7).each do |id|
       multi_dsl = get_multi_dsl(id)
       multi = Multi.create_from_level_builder({}, {dsl_text: multi_dsl})
-      File.stubs(:exist?).with {|filepath, _| filepath.to_s.end_with?(multi.filename)}.returns(true)
-      File.stubs(:read).with {|filepath, _| filepath.to_s.end_with?(multi.filename)}.returns(multi_dsl)
+      multi_filename = multi.filename.split('/').last
+      File.stubs(:read).with {|filepath| filepath.basename.to_s == multi_filename}.returns(multi_dsl)
     end
 
     # Create the external level.
     external_dsl = get_external_dsl(1)
     External.create_from_level_builder({}, {dsl_text: external_dsl})
-    File.stubs(:exist?).with {|filepath, _| filepath.to_s.end_with?("external1.external")}.returns(true)
-    File.stubs(:read).with {|filename, _| filename.to_s.end_with?("external1.external")}.returns(external_dsl)
+    File.stubs(:read).with {|filepath| filepath.basename.to_s == 'external1.external'}.returns(external_dsl)
 
     # Create the level_group.
     level_group = LevelGroup.create_from_level_builder({}, {name: 'my_level_group', dsl_text: level_group_input_dsl})
-    File.stubs(:exist?).with {|filepath, _| filepath.to_s.end_with?("level_group_test_long_assessment.level_group")}.returns(true)
-    File.stubs(:read).with {|filepath, _| filepath.to_s.end_with?("level_group_test_long_assessment.level_group")}.returns(level_group_input_dsl)
+    File.stubs(:read).with {|filepath| filepath.basename.to_s == 'level_group_test_long_assessment.level_group'}.returns(level_group_input_dsl)
 
     File.stubs(:write).with do |filepath, actual_dsl|
       filepath.basename.to_s == 'level_group_test_long_assessment_copy.level_group' &&

--- a/dashboard/test/models/level_group_test.rb
+++ b/dashboard/test/models/level_group_test.rb
@@ -223,7 +223,7 @@ MARKDOWN
     assert_nil LevelGroup.get_sublevel_last_attempt(nil, nil, level1, script)
   end
 
-  test 'clone simple level group with suffix' do
+  test 'clone with suffix for simple level group' do
     level_group_input_dsl = <<~DSL
       name 'my level group'
       page


### PR DESCRIPTION
In preparation for changing how level groups implement sublevels, this PR makes some improvements to the level group tests for clone_with_suffix:
1. stubs File operations, rather than actually reading/writing .level_group files
2. adds more assertions, to make sure the tests catch more kinds of errors
3. makes the test run faster, by stubbing File operations fewer times
4. adds a simpler test case, in part to have a test case that runs faster

Without this change, the code became hard to refactor without breaking the test.

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
