### PR TITLE
Foorm: Simple Survey Authoring Tool

### DIFF
--- a/apps/Gruntfile.js
+++ b/apps/Gruntfile.js
@@ -352,7 +352,8 @@ describe('entry tests', () => {
           [
             'build/package/css/publicKeyCryptography.css',
             'style/publicKeyCryptography/publicKeyCryptography.scss'
-          ]
+          ],
+          ['build/package/css/foorm.css', 'style/code-studio/foorm.scss']
         ].concat(
           appsToBuild.map(function(app) {
             return [
@@ -705,7 +706,8 @@ describe('entry tests', () => {
       './src/sites/studio/pages/peer_reviews/dashboard.js',
     'peer_reviews/show': './src/sites/studio/pages/peer_reviews/show.js',
 
-    'foorm/preview/index': './src/sites/studio/pages/foorm/preview/index.js'
+    'foorm/preview/index': './src/sites/studio/pages/foorm/preview/index.js',
+    'foorm/editor/index': './src/sites/studio/pages/foorm/editor/index.js'
   };
 
   // Entries which are shared between dashboard and pegasus, which are included

--- a/apps/src/code-studio/pd/foorm/FoormEditor.jsx
+++ b/apps/src/code-studio/pd/foorm/FoormEditor.jsx
@@ -7,6 +7,7 @@ import {connect} from 'react-redux';
 import PropTypes from 'prop-types';
 import {Button} from 'react-bootstrap';
 import Foorm from './Foorm';
+import FontAwesome from '../../../templates/FontAwesome';
 
 const sampleSurveyData = {
   facilitators: [
@@ -26,13 +27,21 @@ const sampleSurveyData = {
   workshop_course: 'Sample Course'
 };
 
+const styles = {
+  errorMessage: {
+    fontWeight: 'bold',
+    padding: '1em'
+  }
+};
+
 class FoormEditor extends React.Component {
   static propTypes = {
     populateCodeMirror: PropTypes.func.isRequired,
     formName: PropTypes.string,
     formVersion: PropTypes.number,
     // populated by redux
-    formQuestions: PropTypes.object
+    formQuestions: PropTypes.object,
+    formHasError: PropTypes.bool
   };
 
   constructor(props) {
@@ -83,17 +92,27 @@ class FoormEditor extends React.Component {
           // Change handler is required for this element, but changes will be handled by the code mirror.
           onChange={() => {}}
         />
-        <Button onClick={this.previewFoorm}>Preview</Button>
-        {this.state.formPreviewQuestions && (
-          // key allows us to force re-render when preview is clicked
-          <Foorm
-            formQuestions={this.state.formPreviewQuestions}
-            formName={'preview'}
-            formVersion={0}
-            submitApi={'/none'}
-            key={`form-${this.state.formKey}`}
-            surveyData={sampleSurveyData}
-          />
+        {this.props.formHasError ? (
+          <div style={styles.errorMessage}>
+            <FontAwesome icon="exclamation-triangle" /> There is a parsing error
+            in the survey configuration. Errors are noted on the left side of
+            the editor.
+          </div>
+        ) : (
+          <div>
+            <Button onClick={this.previewFoorm}>Preview</Button>
+            {this.state.formPreviewQuestions && (
+              // key allows us to force re-render when preview is clicked
+              <Foorm
+                formQuestions={this.state.formPreviewQuestions}
+                formName={'preview'}
+                formVersion={0}
+                submitApi={'/none'}
+                key={`form-${this.state.formKey}`}
+                surveyData={sampleSurveyData}
+              />
+            )}
+          </div>
         )}
       </div>
     );
@@ -101,6 +120,9 @@ class FoormEditor extends React.Component {
 }
 
 export default connect(
-  state => ({formQuestions: state.foorm.formQuestions || {}}),
+  state => ({
+    formQuestions: state.foorm.formQuestions || {},
+    formHasError: state.foorm.hasError
+  }),
   dispatch => ({})
 )(FoormEditor);

--- a/apps/src/code-studio/pd/foorm/FoormEditor.jsx
+++ b/apps/src/code-studio/pd/foorm/FoormEditor.jsx
@@ -1,0 +1,73 @@
+import React from 'react';
+import {connect} from 'react-redux';
+import PropTypes from 'prop-types';
+import {Button, DropdownButton, MenuItem} from 'react-bootstrap';
+import Foorm from './Foorm';
+
+class FoormEditor extends React.Component {
+  static propTypes = {
+    // populated by redux
+    formQuestions: PropTypes.object
+  };
+
+  constructor(props) {
+    super(props);
+
+    this.state = {
+      formKey: 0,
+      formPreviewQuestions: {}
+    };
+  }
+
+  previewFoorm = () => {
+    console.log(this.props.formQuestions);
+    $.ajax({
+      url: '/api/v1/pd/foorm/form_with_library_items',
+      type: 'post',
+      contentType: 'application/json',
+      processData: false,
+      data: JSON.stringify({
+        form_questions: this.props.formQuestions
+      })
+    }).done(result => {
+      console.log(result);
+      this.setState({
+        formKey: this.state.formKey + 1,
+        formPreviewQuestions: result
+      });
+    });
+  };
+
+  render() {
+    return (
+      <div>
+        <DropdownButton id="load_config" title="Load Existing Configuration">
+          <MenuItem key={1} eventKey={'ack'}>
+            Sample
+          </MenuItem>
+        </DropdownButton>
+        <textarea
+          ref="content"
+          // 3rd parameter specifies number of spaces to insert into the output JSON string for readability purposes.
+          // See https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/JSON/stringify
+          value={this.props.formQuestions}
+          // Change handler is required for this element, but changes will be handled by the code mirror.
+          onChange={() => {}}
+        />
+        <Button onClick={this.previewFoorm}>Preview</Button>
+        <Foorm
+          formQuestions={this.props.formQuestions}
+          formName={'preview'}
+          formVersion={0}
+          submitApi={'/none'}
+          key={this.state.formKey}
+        />
+      </div>
+    );
+  }
+}
+
+export default connect(
+  state => ({formQuestions: state.foorm.formQuestions || {}}),
+  dispatch => ({})
+)(FoormEditor);

--- a/apps/src/code-studio/pd/foorm/FoormEditor.jsx
+++ b/apps/src/code-studio/pd/foorm/FoormEditor.jsx
@@ -73,9 +73,11 @@ class FoormEditor extends React.Component {
         {this.props.formName && (
           <h3>{`${this.props.formName}, version ${this.props.formVersion}`}</h3>
         )}
+        {/* textarea is filled by populateCodeMirror()*/}
         <textarea
           ref="content"
-          // 3rd parameter specifies number of spaces to insert into the output JSON string for readability purposes.
+          // 3rd parameter specifies number of spaces to insert
+          // into the output JSON string for readability purposes.
           // See https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/JSON/stringify
           value={JSON.stringify(this.props.formQuestions, null, 2)}
           // Change handler is required for this element, but changes will be handled by the code mirror.

--- a/apps/src/code-studio/pd/foorm/FoormEditor.jsx
+++ b/apps/src/code-studio/pd/foorm/FoormEditor.jsx
@@ -1,11 +1,32 @@
 import React from 'react';
 import {connect} from 'react-redux';
 import PropTypes from 'prop-types';
-import {Button, DropdownButton, MenuItem} from 'react-bootstrap';
+import {Button} from 'react-bootstrap';
 import Foorm from './Foorm';
+
+const sampleSurveyData = {
+  facilitators: [
+    {
+      facilitatorId: 1,
+      facilitatorName: 'Alice'
+    },
+    {
+      facilitatorId: 2,
+      facilitatorName: 'Bob'
+    },
+    {
+      facilitatorId: 3,
+      facilitatorName: 'Chris'
+    }
+  ],
+  workshop_course: 'Sample Course'
+};
 
 class FoormEditor extends React.Component {
   static propTypes = {
+    populateCodeMirror: PropTypes.func.isRequired,
+    formName: PropTypes.string,
+    formVersion: PropTypes.number,
     // populated by redux
     formQuestions: PropTypes.object
   };
@@ -15,8 +36,12 @@ class FoormEditor extends React.Component {
 
     this.state = {
       formKey: 0,
-      formPreviewQuestions: {}
+      formPreviewQuestions: null
     };
+  }
+
+  componentDidMount() {
+    this.props.populateCodeMirror();
   }
 
   previewFoorm = () => {
@@ -41,27 +66,28 @@ class FoormEditor extends React.Component {
   render() {
     return (
       <div>
-        <DropdownButton id="load_config" title="Load Existing Configuration">
-          <MenuItem key={1} eventKey={'ack'}>
-            Sample
-          </MenuItem>
-        </DropdownButton>
+        {this.props.formName && (
+          <h3>{`${this.props.formName}, version ${this.props.formVersion}`}</h3>
+        )}
         <textarea
           ref="content"
           // 3rd parameter specifies number of spaces to insert into the output JSON string for readability purposes.
           // See https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/JSON/stringify
-          value={this.props.formQuestions}
+          value={JSON.stringify(this.props.formQuestions, null, 2)}
           // Change handler is required for this element, but changes will be handled by the code mirror.
           onChange={() => {}}
         />
         <Button onClick={this.previewFoorm}>Preview</Button>
-        <Foorm
-          formQuestions={this.props.formQuestions}
-          formName={'preview'}
-          formVersion={0}
-          submitApi={'/none'}
-          key={this.state.formKey}
-        />
+        {this.state.formPreviewQuestions && (
+          <Foorm
+            formQuestions={this.state.formPreviewQuestions}
+            formName={'preview'}
+            formVersion={0}
+            submitApi={'/none'}
+            key={`form-${this.state.formKey}`}
+            surveyData={sampleSurveyData}
+          />
+        )}
       </div>
     );
   }

--- a/apps/src/code-studio/pd/foorm/FoormEditor.jsx
+++ b/apps/src/code-studio/pd/foorm/FoormEditor.jsx
@@ -68,7 +68,6 @@ class FoormEditor extends React.Component {
         form_questions: this.props.formQuestions
       })
     }).done(result => {
-      console.log(result);
       this.setState({
         formKey: this.state.formKey + 1,
         formPreviewQuestions: result

--- a/apps/src/code-studio/pd/foorm/FoormEditor.jsx
+++ b/apps/src/code-studio/pd/foorm/FoormEditor.jsx
@@ -1,3 +1,7 @@
+// Interface for admins to try out Foorm configurations in real-time.
+// Includes a json editor with a starting configuration, along with
+// a preview button to preview the configuration in Foorm
+
 import React from 'react';
 import {connect} from 'react-redux';
 import PropTypes from 'prop-types';
@@ -45,7 +49,7 @@ class FoormEditor extends React.Component {
   }
 
   previewFoorm = () => {
-    console.log(this.props.formQuestions);
+    // fill in form with any library items
     $.ajax({
       url: '/api/v1/pd/foorm/form_with_library_items',
       type: 'post',
@@ -79,6 +83,7 @@ class FoormEditor extends React.Component {
         />
         <Button onClick={this.previewFoorm}>Preview</Button>
         {this.state.formPreviewQuestions && (
+          // key allows us to force re-render when preview is clicked
           <Foorm
             formQuestions={this.state.formPreviewQuestions}
             formName={'preview'}

--- a/apps/src/code-studio/pd/foorm/FoormEditorManager.jsx
+++ b/apps/src/code-studio/pd/foorm/FoormEditorManager.jsx
@@ -1,3 +1,7 @@
+// Main page for Foorm Editor interface. Will initially show a choice
+// between loading an existing configuration or an empty configuration.
+// After that choice is made, will render FoormEditor with the chosen configuration.
+
 import React from 'react';
 import {connect} from 'react-redux';
 import PropTypes from 'prop-types';
@@ -8,6 +12,7 @@ class FoormEditorManager extends React.Component {
   static propTypes = {
     updateFormQuestions: PropTypes.func,
     populateCodeMirror: PropTypes.func,
+    formNamesAndVersions: PropTypes.array,
 
     // populated by redux
     formQuestions: PropTypes.object
@@ -19,46 +24,29 @@ class FoormEditorManager extends React.Component {
     this.state = {
       formKey: 0,
       formPreviewQuestions: null,
-      formattedConfigurationOptions: null,
+      formattedConfigurationOptions: this.getFormattedConfigurationDropdownOptions(
+        this.props.formNamesAndVersions
+      ),
       showCodeMirror: false,
       formName: null,
       formVersion: null
     };
-
-    this.getConfigurationDropdownOptions();
-  }
-
-  getConfigurationDropdownOptions() {
-    if (!this.state.formattedConfigurationOptions) {
-      $.ajax({
-        url: '/api/v1/pd/foorm/form_names_and_versions',
-        type: 'get'
-      }).done(result => {
-        console.log('in done');
-        this.getFormattedConfigurationDropdownOptions(result);
-      });
-    }
   }
 
   getFormattedConfigurationDropdownOptions(formNamesAndVersions) {
-    console.log('in get formatted config options');
-    console.log(formNamesAndVersions);
-    const configurationOptions = formNamesAndVersions.map(
-      (formNameAndVersion, i) => {
-        const formName = formNameAndVersion['name'];
-        const formVersion = formNameAndVersion['version'];
-        return (
-          <MenuItem
-            key={i}
-            eventKey={i}
-            onClick={() => this.loadConfiguration(formName, formVersion)}
-          >
-            {`${formName}, version ${formVersion}`}
-          </MenuItem>
-        );
-      }
-    );
-    this.setState({formattedConfigurationOptions: configurationOptions});
+    return formNamesAndVersions.map((formNameAndVersion, i) => {
+      const formName = formNameAndVersion['name'];
+      const formVersion = formNameAndVersion['version'];
+      return (
+        <MenuItem
+          key={i}
+          eventKey={i}
+          onClick={() => this.loadConfiguration(formName, formVersion)}
+        >
+          {`${formName}, version ${formVersion}`}
+        </MenuItem>
+      );
+    });
   }
 
   loadConfiguration(formName, formVersion) {

--- a/apps/src/code-studio/pd/foorm/FoormEditorManager.jsx
+++ b/apps/src/code-studio/pd/foorm/FoormEditorManager.jsx
@@ -71,7 +71,13 @@ class FoormEditorManager extends React.Component {
   render() {
     return (
       <div>
-        {!this.state.showCodeMirror && (
+        {this.state.showCodeMirror ? (
+          <FoormEditor
+            populateCodeMirror={this.props.populateCodeMirror}
+            formName={this.state.formName}
+            formVersion={this.state.formVersion}
+          />
+        ) : (
           <div>
             <DropdownButton
               id="load_config"
@@ -84,13 +90,6 @@ class FoormEditorManager extends React.Component {
               Empty Configuration
             </Button>
           </div>
-        )}
-        {this.state.showCodeMirror && (
-          <FoormEditor
-            populateCodeMirror={this.props.populateCodeMirror}
-            formName={this.state.formName}
-            formVersion={this.state.formVersion}
-          />
         )}
       </div>
     );

--- a/apps/src/code-studio/pd/foorm/FoormEditorManager.jsx
+++ b/apps/src/code-studio/pd/foorm/FoormEditorManager.jsx
@@ -12,6 +12,7 @@ class FoormEditorManager extends React.Component {
   static propTypes = {
     updateFormQuestions: PropTypes.func,
     populateCodeMirror: PropTypes.func,
+    resetCodeMirror: PropTypes.func,
     formNamesAndVersions: PropTypes.array,
 
     // populated by redux
@@ -61,35 +62,35 @@ class FoormEditorManager extends React.Component {
         formName: formName,
         formVersion: formVersion
       });
+      this.props.resetCodeMirror(result);
     });
   }
 
   initializeEmptyCodeMirror = () => {
-    this.setState({showCodeMirror: true});
+    this.setState({
+      showCodeMirror: true,
+      formName: null,
+      formVersion: null
+    });
+    this.props.resetCodeMirror({});
   };
 
   render() {
     return (
       <div>
-        {this.state.showCodeMirror ? (
+        <div>
+          <DropdownButton id="load_config" title="Load Survey...">
+            {this.state.formattedConfigurationOptions &&
+              this.state.formattedConfigurationOptions}
+          </DropdownButton>
+          <Button onClick={this.initializeEmptyCodeMirror}>New Survey</Button>
+        </div>
+        {this.state.showCodeMirror && (
           <FoormEditor
             populateCodeMirror={this.props.populateCodeMirror}
             formName={this.state.formName}
             formVersion={this.state.formVersion}
           />
-        ) : (
-          <div>
-            <DropdownButton
-              id="load_config"
-              title="Load Existing Configuration"
-            >
-              {this.state.formattedConfigurationOptions &&
-                this.state.formattedConfigurationOptions}
-            </DropdownButton>
-            <Button onClick={this.initializeEmptyCodeMirror}>
-              Empty Configuration
-            </Button>
-          </div>
         )}
       </div>
     );

--- a/apps/src/code-studio/pd/foorm/FoormEditorManager.jsx
+++ b/apps/src/code-studio/pd/foorm/FoormEditorManager.jsx
@@ -1,0 +1,115 @@
+import React from 'react';
+import {connect} from 'react-redux';
+import PropTypes from 'prop-types';
+import {Button, DropdownButton, MenuItem} from 'react-bootstrap';
+import FoormEditor from './FoormEditor';
+
+class FoormEditorManager extends React.Component {
+  static propTypes = {
+    updateFormQuestions: PropTypes.func,
+    populateCodeMirror: PropTypes.func,
+
+    // populated by redux
+    formQuestions: PropTypes.object
+  };
+
+  constructor(props) {
+    super(props);
+
+    this.state = {
+      formKey: 0,
+      formPreviewQuestions: null,
+      formattedConfigurationOptions: null,
+      showCodeMirror: false,
+      formName: null,
+      formVersion: null
+    };
+
+    this.getConfigurationDropdownOptions();
+  }
+
+  getConfigurationDropdownOptions() {
+    if (!this.state.formattedConfigurationOptions) {
+      $.ajax({
+        url: '/api/v1/pd/foorm/form_names_and_versions',
+        type: 'get'
+      }).done(result => {
+        console.log('in done');
+        this.getFormattedConfigurationDropdownOptions(result);
+      });
+    }
+  }
+
+  getFormattedConfigurationDropdownOptions(formNamesAndVersions) {
+    console.log('in get formatted config options');
+    console.log(formNamesAndVersions);
+    const configurationOptions = formNamesAndVersions.map(
+      (formNameAndVersion, i) => {
+        const formName = formNameAndVersion['name'];
+        const formVersion = formNameAndVersion['version'];
+        return (
+          <MenuItem
+            key={i}
+            eventKey={i}
+            onClick={() => this.loadConfiguration(formName, formVersion)}
+          >
+            {`${formName}, version ${formVersion}`}
+          </MenuItem>
+        );
+      }
+    );
+    this.setState({formattedConfigurationOptions: configurationOptions});
+  }
+
+  loadConfiguration(formName, formVersion) {
+    $.ajax({
+      url: '/api/v1/pd/foorm/form_questions',
+      type: 'get',
+      data: {name: formName, version: formVersion}
+    }).done(result => {
+      this.props.updateFormQuestions(result);
+      this.setState({
+        showCodeMirror: true,
+        formName: formName,
+        formVersion: formVersion
+      });
+    });
+  }
+
+  initializeEmptyCodeMirror = () => {
+    this.setState({showCodeMirror: true});
+  };
+
+  render() {
+    return (
+      <div>
+        {!this.state.showCodeMirror && (
+          <div>
+            <DropdownButton
+              id="load_config"
+              title="Load Existing Configuration"
+            >
+              {this.state.formattedConfigurationOptions &&
+                this.state.formattedConfigurationOptions}
+            </DropdownButton>
+            <Button onClick={this.initializeEmptyCodeMirror}>
+              Empty Configuration
+            </Button>
+          </div>
+        )}
+        {this.state.showCodeMirror && (
+          <FoormEditor
+            populateCodeMirror={this.props.populateCodeMirror}
+            formName={this.state.formName}
+            formVersion={this.state.formVersion}
+          />
+        )}
+      </div>
+    );
+  }
+}
+
+export default connect(
+  state => ({formQuestions: state.foorm.formQuestions || {}}),
+  dispatch => ({})
+)(FoormEditorManager);

--- a/apps/src/code-studio/pd/foorm/foormEditorRedux.js
+++ b/apps/src/code-studio/pd/foorm/foormEditorRedux.js
@@ -24,7 +24,6 @@ export default function foormEditorRedux(state = initialState, action) {
     };
   }
   if (action.type === SET_HAS_ERROR) {
-    console.log(`setting has error to ${action.hasError}`);
     return {
       ...state,
       hasError: action.hasError

--- a/apps/src/code-studio/pd/foorm/foormEditorRedux.js
+++ b/apps/src/code-studio/pd/foorm/foormEditorRedux.js
@@ -5,15 +5,11 @@ export const setFormQuestions = formQuestions => ({
 });
 
 const initialState = {
-  foormQuestions: {}
+  foormQuestions: ''
 };
 
 export default function formQuestions(state = initialState, action) {
-  //console.log('in formQuestions action');
   if (action.type === SET_FORM_QUESTIONS) {
-    // console.log(
-    //   action.formQuestions
-    // );
     return {
       formQuestions: action.formQuestions
     };

--- a/apps/src/code-studio/pd/foorm/foormEditorRedux.js
+++ b/apps/src/code-studio/pd/foorm/foormEditorRedux.js
@@ -1,0 +1,23 @@
+const SET_FORM_QUESTIONS = 'foormEditor/SET_FORM_QUESTIONS';
+export const setFormQuestions = formQuestions => ({
+  type: SET_FORM_QUESTIONS,
+  formQuestions
+});
+
+const initialState = {
+  foormQuestions: {}
+};
+
+export default function formQuestions(state = initialState, action) {
+  //console.log('in formQuestions action');
+  if (action.type === SET_FORM_QUESTIONS) {
+    // console.log(
+    //   action.formQuestions
+    // );
+    return {
+      formQuestions: action.formQuestions
+    };
+  }
+
+  return state;
+}

--- a/apps/src/code-studio/pd/foorm/foormEditorRedux.js
+++ b/apps/src/code-studio/pd/foorm/foormEditorRedux.js
@@ -1,17 +1,33 @@
 const SET_FORM_QUESTIONS = 'foormEditor/SET_FORM_QUESTIONS';
+const SET_HAS_ERROR = 'foormEditor/SET_HAS_ERROR';
+
 export const setFormQuestions = formQuestions => ({
   type: SET_FORM_QUESTIONS,
   formQuestions
 });
 
+export const setHasError = hasError => ({
+  type: SET_HAS_ERROR,
+  hasError
+});
+
 const initialState = {
-  foormQuestions: ''
+  formQuestions: '',
+  hasError: false
 };
 
-export default function formQuestions(state = initialState, action) {
+export default function foormEditorRedux(state = initialState, action) {
   if (action.type === SET_FORM_QUESTIONS) {
     return {
+      ...state,
       formQuestions: action.formQuestions
+    };
+  }
+  if (action.type === SET_HAS_ERROR) {
+    console.log(`setting has error to ${action.hasError}`);
+    return {
+      ...state,
+      hasError: action.hasError
     };
   }
 

--- a/apps/src/sites/studio/pages/foorm/editor/index.js
+++ b/apps/src/sites/studio/pages/foorm/editor/index.js
@@ -26,14 +26,17 @@ $(document).ready(function() {
   );
 });
 
+// We want to wait to fill in the code mirror until we have selected
+// a configuration to populate it with.
 function populateCodeMirror() {
   const codeMirrorArea = document.getElementsByTagName('textarea')[0];
   initializeCodeMirror(codeMirrorArea, 'application/json', {
-    callback: onChange
+    callback: onCodeMirrorChange
   });
 }
 
-function onChange(editor) {
+// Functions for keeping the code mirror content in the redux store.
+function onCodeMirrorChange(editor) {
   try {
     const formQuestions = JSON.parse(editor.getValue());
     getStore().dispatch(setFormQuestions(formQuestions));

--- a/apps/src/sites/studio/pages/foorm/editor/index.js
+++ b/apps/src/sites/studio/pages/foorm/editor/index.js
@@ -2,13 +2,14 @@ import React from 'react';
 import ReactDOM from 'react-dom';
 import {Provider} from 'react-redux';
 import {getStore, registerReducers} from '@cdo/apps/redux';
+import getScriptData from '@cdo/apps/util/getScriptData';
 import initializeCodeMirror from '@cdo/apps/code-studio/initializeCodeMirror';
-
-import 'survey-react/survey.css';
-import FoormEditorManager from '../../../../../code-studio/pd/foorm/FoormEditorManager';
+import FoormEditorManager from '@cdo/apps/code-studio/pd/foorm/FoormEditorManager';
 import foorm, {
   setFormQuestions
-} from '../../../../../code-studio/pd/foorm/foormEditorRedux';
+} from '@cdo/apps/code-studio/pd/foorm/foormEditorRedux';
+
+import 'survey-react/survey.css';
 
 $(document).ready(function() {
   registerReducers({foorm});
@@ -18,6 +19,7 @@ $(document).ready(function() {
       <FoormEditorManager
         updateFormQuestions={updateFormQuestions}
         populateCodeMirror={populateCodeMirror}
+        {...getScriptData('props')}
       />
     </Provider>,
     document.getElementById('editor-container')

--- a/apps/src/sites/studio/pages/foorm/editor/index.js
+++ b/apps/src/sites/studio/pages/foorm/editor/index.js
@@ -1,0 +1,40 @@
+import React from 'react';
+import ReactDOM from 'react-dom';
+import {Provider} from 'react-redux';
+import {getStore, registerReducers} from '@cdo/apps/redux';
+import initializeCodeMirror from '@cdo/apps/code-studio/initializeCodeMirror';
+
+import 'survey-react/survey.css';
+import FoormEditor from '../../../../../code-studio/pd/foorm/FoormEditor';
+import foorm, {
+  setFormQuestions
+} from '../../../../../code-studio/pd/foorm/foormEditorRedux';
+
+$(document).ready(function() {
+  registerReducers({foorm});
+  const store = getStore();
+  ReactDOM.render(
+    <Provider store={store}>
+      <FoormEditor />
+    </Provider>,
+    document.getElementById('editor-container')
+  );
+  const codeMirrorArea = document.getElementsByTagName('textarea')[0];
+  initializeCodeMirror(codeMirrorArea, 'application/json', {
+    callback: onChange
+  });
+});
+
+function onChange(editor) {
+  try {
+    const formQuestions = JSON.parse(editor.getValue());
+    // console.log('in onChange');
+    // console.log(editor.getValue());
+    // console.log(formQuestions);
+    getStore().dispatch(setFormQuestions(formQuestions));
+  } catch (e) {
+    // There is a JSON error.
+    //console.log('there is a json error');
+    getStore().dispatch(setFormQuestions({}));
+  }
+}

--- a/apps/src/sites/studio/pages/foorm/editor/index.js
+++ b/apps/src/sites/studio/pages/foorm/editor/index.js
@@ -11,6 +11,8 @@ import foorm, {
 
 import 'survey-react/survey.css';
 
+let codeMirror = null;
+
 $(document).ready(function() {
   registerReducers({foorm});
   const store = getStore();
@@ -19,6 +21,7 @@ $(document).ready(function() {
       <FoormEditorManager
         updateFormQuestions={updateFormQuestions}
         populateCodeMirror={populateCodeMirror}
+        resetCodeMirror={resetCodeMirror}
         {...getScriptData('props')}
       />
     </Provider>,
@@ -30,7 +33,7 @@ $(document).ready(function() {
 // a configuration to populate it with.
 function populateCodeMirror() {
   const codeMirrorArea = document.getElementsByTagName('textarea')[0];
-  initializeCodeMirror(codeMirrorArea, 'application/json', {
+  codeMirror = initializeCodeMirror(codeMirrorArea, 'application/json', {
     callback: onCodeMirrorChange
   });
 }
@@ -49,3 +52,9 @@ function onCodeMirrorChange(editor) {
 const updateFormQuestions = formQuestions => {
   getStore().dispatch(setFormQuestions(formQuestions));
 };
+
+function resetCodeMirror(json) {
+  if (codeMirror) {
+    codeMirror.setValue(JSON.stringify(json, null, 2));
+  }
+}

--- a/apps/src/sites/studio/pages/foorm/editor/index.js
+++ b/apps/src/sites/studio/pages/foorm/editor/index.js
@@ -6,7 +6,8 @@ import getScriptData from '@cdo/apps/util/getScriptData';
 import initializeCodeMirror from '@cdo/apps/code-studio/initializeCodeMirror';
 import FoormEditorManager from '@cdo/apps/code-studio/pd/foorm/FoormEditorManager';
 import foorm, {
-  setFormQuestions
+  setFormQuestions,
+  setHasError
 } from '@cdo/apps/code-studio/pd/foorm/foormEditorRedux';
 
 import 'survey-react/survey.css';
@@ -43,18 +44,22 @@ function onCodeMirrorChange(editor) {
   try {
     const formQuestions = JSON.parse(editor.getValue());
     getStore().dispatch(setFormQuestions(formQuestions));
+    getStore().dispatch(setHasError(false));
   } catch (e) {
     // There is a JSON error.
     getStore().dispatch(setFormQuestions({}));
+    getStore().dispatch(setHasError(true));
   }
 }
 
 const updateFormQuestions = formQuestions => {
   getStore().dispatch(setFormQuestions(formQuestions));
+  getStore().dispatch(setHasError(false));
 };
 
 function resetCodeMirror(json) {
   if (codeMirror) {
     codeMirror.setValue(JSON.stringify(json, null, 2));
+    getStore().dispatch(setHasError(false));
   }
 }

--- a/apps/src/sites/studio/pages/foorm/editor/index.js
+++ b/apps/src/sites/studio/pages/foorm/editor/index.js
@@ -43,8 +43,7 @@ function populateCodeMirror() {
 function onCodeMirrorChange(editor) {
   try {
     const formQuestions = JSON.parse(editor.getValue());
-    getStore().dispatch(setFormQuestions(formQuestions));
-    getStore().dispatch(setHasError(false));
+    updateFormQuestions(formQuestions);
   } catch (e) {
     // There is a JSON error.
     getStore().dispatch(setFormQuestions({}));

--- a/apps/src/sites/studio/pages/foorm/editor/index.js
+++ b/apps/src/sites/studio/pages/foorm/editor/index.js
@@ -5,7 +5,7 @@ import {getStore, registerReducers} from '@cdo/apps/redux';
 import initializeCodeMirror from '@cdo/apps/code-studio/initializeCodeMirror';
 
 import 'survey-react/survey.css';
-import FoormEditor from '../../../../../code-studio/pd/foorm/FoormEditor';
+import FoormEditorManager from '../../../../../code-studio/pd/foorm/FoormEditorManager';
 import foorm, {
   setFormQuestions
 } from '../../../../../code-studio/pd/foorm/foormEditorRedux';
@@ -15,26 +15,32 @@ $(document).ready(function() {
   const store = getStore();
   ReactDOM.render(
     <Provider store={store}>
-      <FoormEditor />
+      <FoormEditorManager
+        updateFormQuestions={updateFormQuestions}
+        populateCodeMirror={populateCodeMirror}
+      />
     </Provider>,
     document.getElementById('editor-container')
   );
+});
+
+function populateCodeMirror() {
   const codeMirrorArea = document.getElementsByTagName('textarea')[0];
   initializeCodeMirror(codeMirrorArea, 'application/json', {
     callback: onChange
   });
-});
+}
 
 function onChange(editor) {
   try {
     const formQuestions = JSON.parse(editor.getValue());
-    // console.log('in onChange');
-    // console.log(editor.getValue());
-    // console.log(formQuestions);
     getStore().dispatch(setFormQuestions(formQuestions));
   } catch (e) {
     // There is a JSON error.
-    //console.log('there is a json error');
     getStore().dispatch(setFormQuestions({}));
   }
 }
+
+const updateFormQuestions = formQuestions => {
+  getStore().dispatch(setFormQuestions(formQuestions));
+};

--- a/apps/style/code-studio/foorm.scss
+++ b/apps/style/code-studio/foorm.scss
@@ -1,0 +1,16 @@
+@import "codemirror/lib/codemirror";
+@import "codemirror/addon/lint/lint";
+@import "codemirror-spell-checker/src/css/spell-checker";
+@import 'json_editor';
+
+.CodeMirror {
+  border: 1px solid #eee;
+  height: auto;
+}
+.CodeMirror-scroll {
+  overflow-y: hidden;
+  overflow-x: auto;
+}
+.CodeMirror-matchingtag {
+  background: rgba(255, 150, 0, .3);
+}

--- a/dashboard/app/controllers/api/v1/pd/foorm_controller.rb
+++ b/dashboard/app/controllers/api/v1/pd/foorm_controller.rb
@@ -5,4 +5,22 @@ class Api::V1::Pd::FoormController < ::ApplicationController
     filled_in_form = Foorm::Form.fill_in_library_items(form_questions)
     render json: filled_in_form
   end
+
+  # GET api/v1/pd/foorm/form_names_and_versions
+  def get_form_names_and_versions
+    form_names = Foorm::Form.pluck(:name, :version)
+    formatted_names_and_versions = []
+    form_names.each do |form_data|
+      formatted_names_and_versions << {name: form_data[0], version: form_data[1]}
+    end
+    render json: formatted_names_and_versions
+  end
+
+  # GET api/v1/pd/foorm/form_questions
+  def get_form_questions
+    form_name = params[:name]
+    form_version = params[:version]
+    form_questions = Foorm::Form.get_questions_for_name_and_version(form_name, form_version)
+    render json: form_questions
+  end
 end

--- a/dashboard/app/controllers/api/v1/pd/foorm_controller.rb
+++ b/dashboard/app/controllers/api/v1/pd/foorm_controller.rb
@@ -6,16 +6,6 @@ class Api::V1::Pd::FoormController < ::ApplicationController
     render json: filled_in_form
   end
 
-  # GET api/v1/pd/foorm/form_names_and_versions
-  def get_form_names_and_versions
-    form_names = Foorm::Form.pluck(:name, :version)
-    formatted_names_and_versions = []
-    form_names.each do |form_data|
-      formatted_names_and_versions << {name: form_data[0], version: form_data[1]}
-    end
-    render json: formatted_names_and_versions
-  end
-
   # GET api/v1/pd/foorm/form_questions
   def get_form_questions
     form_name = params[:name]

--- a/dashboard/app/controllers/api/v1/pd/foorm_controller.rb
+++ b/dashboard/app/controllers/api/v1/pd/foorm_controller.rb
@@ -1,0 +1,8 @@
+class Api::V1::Pd::FoormController < ::ApplicationController
+  # POST api/v1/pd/foorm/form_with_library_items
+  def fill_in_library_items
+    form_questions = params[:form_questions].as_json
+    filled_in_form = Foorm::Form.fill_in_library_items(form_questions)
+    render json: filled_in_form
+  end
+end

--- a/dashboard/app/controllers/foorm_editor_controller.rb
+++ b/dashboard/app/controllers/foorm_editor_controller.rb
@@ -1,6 +1,21 @@
 class FoormEditorController < ApplicationController
   # GET '/foorm/editor/'
   def index
+    # only show for admins on non-production for now
+    return render_404 if Rails.env.production? || !current_user.admin?
+
+    form_names = Foorm::Form.pluck(:name, :version)
+    formatted_names_and_versions = []
+    form_names.each do |form_data|
+      formatted_names_and_versions << {name: form_data[0], version: form_data[1]}
+    end
+
+    @script_data = {
+      props: {
+        formNamesAndVersions: formatted_names_and_versions
+      }.to_json
+    }
+
     render 'foorm/editor/index'
   end
 end

--- a/dashboard/app/controllers/foorm_editor_controller.rb
+++ b/dashboard/app/controllers/foorm_editor_controller.rb
@@ -4,11 +4,7 @@ class FoormEditorController < ApplicationController
     # only show for admins on non-production
     return render_404 if Rails.env.production? || !current_user.admin?
 
-    form_names = Foorm::Form.pluck(:name, :version)
-    formatted_names_and_versions = []
-    form_names.each do |form_data|
-      formatted_names_and_versions << {name: form_data[0], version: form_data[1]}
-    end
+    formatted_names_and_versions = Foorm::Form.all.map {|form| {name: form.name, version: form.version}}
 
     @script_data = {
       props: {

--- a/dashboard/app/controllers/foorm_editor_controller.rb
+++ b/dashboard/app/controllers/foorm_editor_controller.rb
@@ -1,7 +1,7 @@
 class FoormEditorController < ApplicationController
   # GET '/foorm/editor/'
   def index
-    # only show for admins on non-production for now
+    # only show for admins on non-production
     return render_404 if Rails.env.production? || !current_user.admin?
 
     form_names = Foorm::Form.pluck(:name, :version)

--- a/dashboard/app/controllers/foorm_editor_controller.rb
+++ b/dashboard/app/controllers/foorm_editor_controller.rb
@@ -1,0 +1,6 @@
+class FoormEditorController < ApplicationController
+  # GET '/foorm/editor/'
+  def index
+    render 'foorm/editor/index'
+  end
+end

--- a/dashboard/app/models/foorm/form.rb
+++ b/dashboard/app/models/foorm/form.rb
@@ -73,4 +73,23 @@ class Foorm::Form < ActiveRecord::Base
 
     return questions, latest_version
   end
+
+  def self.fill_in_library_items(questions)
+    questions["pages"]&.each do |page|
+      page["elements"]&.map! do |element|
+        if element["type"] == "library_item"
+          JSON.parse(
+            Foorm::LibraryQuestion.where(
+              library_name: element["library_name"],
+              library_version: element["library_version"].to_i,
+              question_name: element["name"]
+            ).first.question
+          )
+        else
+          element
+        end
+      end
+    end
+    return questions
+  end
 end

--- a/dashboard/app/views/foorm/editor/index.haml
+++ b/dashboard/app/views/foorm/editor/index.haml
@@ -1,0 +1,6 @@
+- content_for(:head) do
+  %script{src: webpack_asset_path('js/foorm/editor/index.js'), data: @script_data}
+  = stylesheet_link_tag 'css/foorm', media: 'all'
+
+#editor-container
+  -# populated by React

--- a/dashboard/config/routes.rb
+++ b/dashboard/config/routes.rb
@@ -484,6 +484,8 @@ Dashboard::Application.routes.draw do
       end
 
       post 'foorm/form_with_library_items', action: :fill_in_library_items, controller: 'foorm'
+      get 'foorm/form_names_and_versions', action: :get_form_names_and_versions, controller: 'foorm'
+      get 'foorm/form_questions', action: :get_form_questions, controller: 'foorm'
     end
   end
 

--- a/dashboard/config/routes.rb
+++ b/dashboard/config/routes.rb
@@ -484,7 +484,6 @@ Dashboard::Application.routes.draw do
       end
 
       post 'foorm/form_with_library_items', action: :fill_in_library_items, controller: 'foorm'
-      get 'foorm/form_names_and_versions', action: :get_form_names_and_versions, controller: 'foorm'
       get 'foorm/form_questions', action: :get_form_questions, controller: 'foorm'
     end
   end

--- a/dashboard/config/routes.rb
+++ b/dashboard/config/routes.rb
@@ -482,6 +482,8 @@ Dashboard::Application.routes.draw do
           get :fit_cohort
         end
       end
+
+      post 'foorm/form_with_library_items', action: :fill_in_library_items, controller: 'foorm'
     end
   end
 
@@ -700,6 +702,8 @@ Dashboard::Application.routes.draw do
   get '/dashboardapi/courses', to: 'courses#index', defaults: {format: 'json'}
 
   get 'foorm/preview/:name', to: 'foorm_preview#index', constraints: {name: /.*/}
+
+  get 'foorm/editor', to: 'foorm_editor#index', constraints: {name: /.*/}
 
   post '/safe_browsing', to: 'safe_browsing#safe_to_open', defaults: {format: 'json'}
 


### PR DESCRIPTION
Add a survey authoring tool at /foorm/editor (will only be available to admins on non-production). The tool allows you to load an existing configuration or start from scratch, and you can preview what the survey will look like as you go. The preview will pull in any library items the survey uses.
Screenshots:
Choose to load a survey or start a new one
![Screen Shot 2020-05-13 at 9 18 19 AM](https://user-images.githubusercontent.com/33666587/81838245-b8b7a780-94fa-11ea-89c1-bc67b66909a8.png)


Once you've loaded a survey:
<img width="1017" alt="Screen Shot 2020-05-12 at 4 12 21 PM" src="https://user-images.githubusercontent.com/33666587/81755561-f7535080-946d-11ea-973a-1ca94e0c3e13.png">
... scroll down to see:
<img width="1017" alt="Screen Shot 2020-05-12 at 4 12 32 PM" src="https://user-images.githubusercontent.com/33666587/81755581-01754f00-946e-11ea-8918-4cdf595c1396.png">
click preview:
<img width="1003" alt="Screen Shot 2020-05-12 at 4 12 47 PM" src="https://user-images.githubusercontent.com/33666587/81755594-0b974d80-946e-11ea-83d2-91e3f058eb04.png">

If there is a parsing error the preview button and preview will be replaced with:
![Screen Shot 2020-05-13 at 10 24 31 AM](https://user-images.githubusercontent.com/33666587/81845121-f5889c00-9504-11ea-833a-8dbb99dfc24f.png)


The preview is currently configured with 3 sample facilitators and the course name "Sample Course".
 
<!-- ### Background -->
<!-- ### Privacy -->
<!-- ### Security -->
<!-- ### Caching -->
<!-- ### Deployment strategy -->
<!-- ### Future work -->

## Links

- [jira](https://codedotorg.atlassian.net/browse/PLC-861)

## Testing story
Tested that the survey tool previews survey configurations correctly, and the existing survey functionality is unaffected.

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
