### PR TITLE
Recruitment: update links on two banners

### DIFF
--- a/apps/src/templates/ProfessionalLearningApplyBanner.jsx
+++ b/apps/src/templates/ProfessionalLearningApplyBanner.jsx
@@ -113,7 +113,7 @@ class ProfessionalLearningApplyBanner extends React.Component {
   };
 
   generateLink() {
-    let link = '/educate/professional-learning';
+    let link = '/educate/professional-learning/middle-high';
     if (this.props.linkSuffix) {
       link = `${link}/${this.props.linkSuffix}`;
     }

--- a/pegasus/sites.v3/code.org/views/homepage_below_hero_plane_banner.haml
+++ b/pegasus/sites.v3/code.org/views/homepage_below_hero_plane_banner.haml
@@ -2,7 +2,7 @@
   = inline_css 'homepage_below_hero_plane_banner.css'
 
   .homepage-professional-learning-banner
-    %a.linktag#pl-2019{href: "/educate/professional-learning"}
+    %a.linktag#pl-2019{href: "/educate/professional-learning/middle-high"}
       .nonphone.col-80.tablet-feature
         .left.col-80.animateSlideInFromLeft
           .banner


### PR DESCRIPTION
The https://code.org/ homepage & https://code.org/yourschool recruitment banners now go direct to https://code.org/educate/professional-learning/middle-high.

Followup to https://github.com/code-dot-org/code-dot-org/pull/34770
