### PR TITLE
end experiment and render FreeResponse levels entirely with remark

### DIFF
--- a/apps/src/sites/studio/pages/levels/_free_response.js
+++ b/apps/src/sites/studio/pages/levels/_free_response.js
@@ -1,85 +1,18 @@
 import $ from 'jquery';
-import Parser from '@code-dot-org/redactable-markdown';
-import defaultSanitizationSchema from 'hast-util-sanitize/lib/github.json';
-import firehoseClient from '@cdo/apps/lib/util/firehose';
-import rehypeParse from 'rehype-parse';
-import rehypeRaw from 'rehype-raw';
-import rehypeSanitize from 'rehype-sanitize';
-import rehypeStringify from 'rehype-stringify';
-import remarkRehype from 'remark-rehype';
+import React from 'react';
+import ReactDom from 'react-dom';
+import SafeMarkdown from '@cdo/apps/templates/SafeMarkdown';
 
-// In preparation for switching FreeResponse levels over to use the
-// SafeMarkdown renderer, compare clientside-rendered markdown against
-// serverside-rendered markdown. Disparities will be logged to firehose so
-// markdown can be updated to work on both renderers, and the eventual
-// switchover will be guaranteed to be seamless.
 $(document).ready(() => {
-  // schema and parsing logic is copied from SafeMarkdown; this test is
-  // intended to run for only a short while, so I'm being lazy and copying
-  // rather than rebuilding the sanitization schema to be importable.
-  const schema = Object.assign({}, defaultSanitizationSchema);
-  schema.attributes.img.push('height', 'width');
-  schema.tagNames.push('span');
-  schema.attributes.span = ['dataUrl', 'className'];
-  schema.attributes['*'].push('style', 'className');
-  schema.clobber = [];
-  const blocklyTags = [
-    'block',
-    'functional_input',
-    'mutation',
-    'next',
-    'statement',
-    'title',
-    'value',
-    'xml'
-  ];
-  schema.tagNames = schema.tagNames.concat(blocklyTags);
-  blocklyTags.forEach(tag => {
-    schema.attributes[tag] = ['block_text', 'id', 'inline', 'name', 'type'];
-  });
-
-  const markdownToHtml = Parser.create()
-    .getParser()
-    .use(remarkRehype, {
-      allowDangerousHTML: true
-    })
-    .use(rehypeRaw)
-    .use(rehypeSanitize, schema)
-    .use(rehypeStringify);
-
-  const htmlNormalize = Parser.create()
-    .getParser()
-    .use(rehypeParse, {fragment: true})
-    .use(rehypeStringify);
-
   $('.free-response > .markdown-container').each(function() {
     const container = this;
     if (!container.dataset.markdown) {
       return;
     }
 
-    // render the markdown with remark
-    const clientside = markdownToHtml.processSync(container.dataset.markdown)
-      .contents;
-    // normalize the HTML, to prevent false positives
-    const serverside = htmlNormalize.processSync(
-      $(container)
-        .siblings('.serverside-render')
-        .html()
-    ).contents;
-
-    // ignore whitespace, again to prevent false positives
-    if (clientside.replace(/\s/g, '') !== serverside.replace(/\s/g, '')) {
-      firehoseClient.putRecord({
-        study: 'FreeResponse-rendering',
-        study_group: '',
-        event: 'mismatch',
-        data_string: document.URL,
-        data_json: JSON.stringify({
-          serverside,
-          clientside
-        })
-      });
-    }
+    ReactDom.render(
+      React.createElement(SafeMarkdown, container.dataset, null),
+      container
+    );
   });
 });

--- a/dashboard/app/views/levels/_free_response.html.haml
+++ b/dashboard/app/views/levels/_free_response.html.haml
@@ -37,9 +37,8 @@
     %h1= title
   - long_instructions = level.get_property("long_instructions")
   - if long_instructions
-    %div.serverside-render= render(inline: long_instructions, type: :md)
     / Markdown will be rendered clientside by _free_response.js
-    .markdown-container{data: {markdown: long_instructions}, style: 'display: none'}
+    .markdown-container{data: {markdown: long_instructions}}
 
   - if level.allow_user_uploads?
     %script{src: webpack_asset_path('js/fileupload/jquery.iframe-transport.js')}


### PR DESCRIPTION
Now that all levels with rendering differences have been repaired or confirmed to be imperceptibly different, we can switch entirely to the new renderer.

## Testing story

No tests necessary.

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
