### PR TITLE
Revert "Revert "add a cached version of the exists_in_bucket method""

### DIFF
--- a/dashboard/app/models/concerns/text_to_speech.rb
+++ b/dashboard/app/models/concerns/text_to_speech.rb
@@ -91,7 +91,7 @@ module TextToSpeech
   def self.tts_upload_to_s3(text, filename)
     return if text.blank?
     return if CDO.acapela_login.blank? || CDO.acapela_storage_app.blank? || CDO.acapela_storage_password.blank?
-    return if AWS::S3.exists_in_bucket(TTS_BUCKET, filename)
+    return if AWS::S3.cached_exists_in_bucket?(TTS_BUCKET, filename)
 
     loc_voice = TextToSpeech.localized_voice
     url = acapela_text_to_audio_url(text, loc_voice[:VOICE], loc_voice[:SPEED], loc_voice[:SHAPE])

--- a/lib/cdo/aws/s3.rb
+++ b/lib/cdo/aws/s3.rb
@@ -90,7 +90,7 @@ module AWS
       return false
     end
 
-    # Returns true iff the specified S3 key exists in the buckep
+    # Returns true iff the specified S3 key exists in the bucket
     #
     # Will query all objects in the bucket up front and cache that result. Note
     # this cache will not expire, so this method is not recommended for use in
@@ -109,12 +109,21 @@ module AWS
     # @return [Boolean]
     def self.cached_exists_in_bucket?(bucket, key)
       @cached_bucket_contents ||= {}
-      @cached_bucket_contents[bucket] ||=
-        create_client.
-          list_objects_v2({bucket: bucket}).
-          contents.
-          collect(&:key).
-          to_set
+
+      unless @cached_bucket_contents.key? bucket
+        cache = Set[]
+        # list_objects_v2 returns at most 1,000 items from the bucket, so we
+        # need to repeatedly call it with a continuation token in order to
+        # retrieve all items in the bucket.
+        result = create_client.list_objects_v2({bucket: bucket})
+        while result.is_truncated
+          cache.merge(result.contents.collect(&:key))
+          token = result.next_continuation_token
+          result = create_client.list_objects_v2({bucket: bucket, continuation_token: token})
+        end
+        cache.merge(result.contents.collect(&:key))
+        @cached_bucket_contents[bucket] = cache
+      end
 
       @cached_bucket_contents[bucket].include? key
     end

--- a/lib/test/cdo/aws/s3.rb
+++ b/lib/test/cdo/aws/s3.rb
@@ -1,0 +1,54 @@
+require_relative '../../test_helper'
+
+BUCKET = 'test-bucket'
+
+class CdoAwsS3Test < Minitest::Test
+  def setup
+    AWS::S3.create_client
+  end
+
+  def test_cached_exists_in_bucket_caches_list
+    # explicitly clear the cache variable before the test, in case antoher
+    # test has set it.
+    AWS::S3.instance_variable_set(:@cached_bucket_contents, nil)
+
+    # we expect the list operation to be called only once per bucket
+    AWS::S3.s3.stubs(:list_objects_v2).returns(
+      Aws::S3::Types::ListObjectsV2Output.new(
+        contents: [Aws::S3::Types::Object.new(key: "test-object")]
+      )
+    ).once
+
+    refute AWS::S3.instance_variable_get(:@cached_bucket_contents)
+    assert AWS::S3.cached_exists_in_bucket?(BUCKET, 'test-object')
+    refute AWS::S3.cached_exists_in_bucket?(BUCKET, 'test-nonexistent')
+    assert AWS::S3.instance_variable_get(:@cached_bucket_contents)
+
+    AWS::S3.s3.unstub(:list_objects_v2)
+  end
+
+  def test_upload_updates_cache
+    AWS::S3.instance_variable_set(:@cached_bucket_contents, {BUCKET => Set.new})
+    AWS::S3.s3.stubs(:put_object)
+
+    refute AWS::S3.cached_exists_in_bucket?(BUCKET, 'test-nonexistent')
+    AWS::S3.upload_to_bucket(BUCKET, 'test-nonexistent', '', {no_random: true})
+    assert AWS::S3.cached_exists_in_bucket?(BUCKET, 'test-nonexistent')
+
+    AWS::S3.s3.unstub(:put_object)
+  end
+
+  def test_delete_updates_cache
+    AWS::S3.instance_variable_set(:@cached_bucket_contents, {BUCKET => Set['test-object']})
+    mock = MiniTest::Mock.new
+    def mock.delete_marker
+    end
+    AWS::S3.s3.stubs(:delete_object).returns(mock)
+
+    assert AWS::S3.cached_exists_in_bucket?(BUCKET, 'test-object')
+    AWS::S3.delete_from_bucket(BUCKET, 'test-object')
+    refute AWS::S3.cached_exists_in_bucket?(BUCKET, 'test-object')
+
+    AWS::S3.s3.unstub(:delete_object)
+  end
+end


### PR DESCRIPTION
Reverts code-dot-org/code-dot-org#34745, restoring https://github.com/code-dot-org/code-dot-org/pull/34355

It turns out, `list_objects_v2` only returns the first thousand items of a bucket, and needs to be iterated on if you want to grab everything.

Unfortunately, when I was writing (and testing) the first implementation, I hadn't reseeded my local database recently, and so missed the change to put `tts?` on the script model itself rather than in a constant. This meant that my local db was only trying to text-to-speechify the one script I happened to have manually seeded, making the speedup I saw false.

I've verified that I'm _actually_ testing what I think I'm testing this time :smile: 