### PR TITLE
More limited override of prospect information

### DIFF
--- a/lib/cdo/contact_rollups/v2/pardot.rb
+++ b/lib/cdo/contact_rollups/v2/pardot.rb
@@ -353,14 +353,14 @@ class PardotV2
     end
   end
 
-  # Calculates what needs to change to transform an old data to a new data.
+  # Identifies additional information that is in new data but not in old data.
   # Example:
-  #   old_data = {key1: 1, key2: 2, key3: nil}
-  #   new_data = {key1: 1.1, k4: 4}
-  #   delta output = {key1: 1.1, key2: nil, key4: 4}
-  #   The output means to transform old_data into new_data, we have to reset value for key1,
-  #   unset key2 value (i.e. set it to nil), ignore key3 (because its old value was nil)
-  #   and set key4.
+  #   old_data = {key1: 'v1', key2: 'v2', key3: nil}
+  #   new_data = {key1: 'v1.1', key2: 'v2', key4: 'v4'}
+  #   delta output = {key1: 'v1.1', key4: 'v4'}
+  #   The output means there is a new value for key1,
+  #   key2 and key3 are ignored (no new information about these keys in new_data),
+  #   and set key4 for the first time.
   #
   # @param [Hash] old_data
   # @param [Hash] new_data
@@ -369,17 +369,10 @@ class PardotV2
     return new_data unless old_data.present?
 
     # Set key-value pairs that exist only in the new data
-    delta = {}
-    new_data.each_pair do |key, val|
-      delta[key] = val unless old_data.key?(key) && old_data[key] == val
+    {}.tap do |delta|
+      new_data.each_pair do |key, val|
+        delta[key] = val unless old_data.key?(key) && old_data[key] == val
+      end
     end
-
-    # Unset entries that exist only in the old data and not in the new data.
-    # Ignore entries with values are nil.
-    old_data.each_pair do |key, val|
-      delta[key] = nil unless new_data.key?(key) || val.nil?
-    end
-
-    delta
   end
 end

--- a/lib/test/cdo/contact_rollups/test_pardot_v2.rb
+++ b/lib/test/cdo/contact_rollups/test_pardot_v2.rb
@@ -295,16 +295,16 @@ class PardotV2Test < Minitest::Test
     tests = [
       {old_data: nil, new_data: {}, expected_delta: {}},
       {old_data: nil, new_data: {k1: 'v1'}, expected_delta: {k1: 'v1'}},
-      {old_data: {k1: 'v1'}, new_data: {}, expected_delta: {k1: nil}},
+      {old_data: {k1: 'v1'}, new_data: {}, expected_delta: {}},
       {old_data: {k1: 'v1'}, new_data: {k1: 'v1'}, expected_delta: {}},
       {old_data: {k1: 'v1'}, new_data: {k1: 'v1.1'}, expected_delta: {k1: 'v1.1'}},
-      {old_data: {k1: 'v1'}, new_data: {k2: 'v2'}, expected_delta: {k1: nil, k2: 'v2'}},
+      {old_data: {k1: 'v1'}, new_data: {k2: 'v2'}, expected_delta: {k2: 'v2'}},
       {old_data: {k1: nil}, new_data: {k2: 'v2'}, expected_delta: {k2: 'v2'}},
       {
-        old_data: {k1: 'v1', k2: 'v2', k3: nil},
-        new_data: {k1: 'v1.1', k4: 'v4'},
-        expected_delta: {k1: 'v1.1', k2: nil, k4: 'v4'}
-      },
+        old_data: {key1: 'v1', key2: 'v2', key3: nil},
+        new_data: {key1: 'v1.1', key2: 'v2', key4: 'v4'},
+        expected_delta: {key1: 'v1.1', key4: 'v4'}
+      }
     ]
 
     tests.each_with_index do |test, index|


### PR DESCRIPTION
We have some information in Pardot that did not come from our production database. If we don't have that information in a given run of contact rollups, we don't want to override that information.

## Testing story

Updated existing tests that check this behavior.

## Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
