### PR TITLE
Hide upload button in spritelab

### DIFF
--- a/apps/src/p5lab/P5LabView.jsx
+++ b/apps/src/p5lab/P5LabView.jsx
@@ -104,7 +104,7 @@ class P5LabView extends React.Component {
               allowedExtensions=".png,.jpg,.jpeg"
               libraryManifest={this.getLibraryManifest()}
               categories={this.getCategories()}
-              hideUploadOption={true}
+              hideUploadOption={this.props.spriteLab}
             />
           )}
         </div>
@@ -132,7 +132,7 @@ class P5LabView extends React.Component {
         channelId={this.getChannelId()}
         libraryManifest={this.getLibraryManifest()}
         categories={this.getCategories()}
-        hideUploadOption={true}
+        hideUploadOption={this.props.spriteLab}
       />
     ) : (
       undefined


### PR DESCRIPTION
In #34771 I accidentally hid the upload button for both spritelab and gamelab. This corrects that to only hide it in spritelab.

Gamelab animation picker:
![Screenshot 2020-05-13 at 4 21 53 PM](https://user-images.githubusercontent.com/46464143/81875774-e66e1200-9535-11ea-9bba-fe3a8c4288b0.png)

Spritelab animation picker:
![Screenshot 2020-05-13 at 4 21 16 PM](https://user-images.githubusercontent.com/46464143/81875754-d1917e80-9535-11ea-8fbd-a9a4ad291dca.png)


<!-- ### Background -->
<!-- ### Privacy -->
<!-- ### Security -->
<!-- ### Caching -->
<!-- ### Deployment strategy -->
<!-- ### Future work -->

## Links

<!--
  Any relevant links to external resources; ie, specification documents, jira
  items, related PRs, honeybadger errors, etc
-->

- [spec]()
- [jira]()

## Testing story

<!--
  Does your change include appropriate tests?

  If so, please describe how the tests included in this PR are sufficient

  If not, please explain why this change does not need to be tested.
-->

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
