### PR TITLE
Section SetUp: metrics for change login type

### DIFF
--- a/apps/src/templates/teacherDashboard/teacherSectionsRedux.js
+++ b/apps/src/templates/teacherDashboard/teacherSectionsRedux.js
@@ -263,9 +263,16 @@ export const finishEditingSection = () => (dispatch, getState) => {
 };
 
 export const reloadAfterEditingSection = () => (dispatch, getState) => {
+  const state = getState().teacherSections;
+  const section = state.sectionBeingEdited;
   return new Promise((resolve, reject) => {
     submitEditingSection(dispatch, getState)
       .done(result => {
+        dispatch({
+          type: EDIT_SECTION_SUCCESS,
+          sectionId: section.id,
+          serverSection: result
+        });
         reload();
       })
       .fail((jqXhr, status) => {
@@ -725,6 +732,7 @@ export default function teacherSections(state = initialState, action) {
       ...state,
       initialCourseId: initialSectionData.courseId,
       initialScriptId: initialSectionData.scriptId,
+      initialLoginType: initialSectionData.loginType,
       sectionBeingEdited: initialSectionData,
       showSectionEditDialog: !action.silent
     };
@@ -794,6 +802,22 @@ export default function teacherSections(state = initialState, action) {
       }
     }
 
+    if (section.loginType !== state.initialLoginType) {
+      firehoseClient.putRecord(
+        {
+          study: 'teacher-dashboard',
+          study_group: 'edit-section-details',
+          event: 'change-login-type',
+          data_json: JSON.stringify({
+            sectionId: section.id,
+            initialLoginType: state.initialLoginType,
+            updatedLoginType: section.loginType
+          })
+        },
+        {includeUserId: true}
+      );
+    }
+
     let assignmentData = {
       section_id: section.id,
       section_creation_timestamp: section.createdAt,
@@ -810,12 +834,15 @@ export default function teacherSections(state = initialState, action) {
       !(typeof assignmentData.script_id === 'undefined') ||
       !(typeof assignmentData.course_id === 'undefined')
     ) {
-      firehoseClient.putRecord({
-        study: 'assignment',
-        study_group: 'v1',
-        event: newSection ? 'create_section' : 'edit_section_details',
-        data_json: JSON.stringify(assignmentData)
-      });
+      firehoseClient.putRecord(
+        {
+          study: 'assignment',
+          study_group: 'v1',
+          event: newSection ? 'create_section' : 'edit_section_details',
+          data_json: JSON.stringify(assignmentData)
+        },
+        {includeUserId: true}
+      );
     }
 
     // When updating a persisted section, oldSectionId will be identical to


### PR DESCRIPTION
[LP-1431](https://codedotorg.atlassian.net/browse/LP-1431)

When a teacher changes a section's login type, we now log that event to firehose. 

<img width="809" alt="Screen Shot 2020-05-13 at 9 25 38 PM" src="https://user-images.githubusercontent.com/12300669/81892917-25658d00-9561-11ea-89de-8413aee28a11.png">

This PR also updates logging of assignment changes to now include user id. 