### PR TITLE
Fix query timeout

### DIFF
--- a/dashboard/app/models/contact_rollups_final.rb
+++ b/dashboard/app/models/contact_rollups_final.rb
@@ -18,7 +18,8 @@ class ContactRollupsFinal < ApplicationRecord
 
   def self.insert_from_processed_table
     insert_sql = <<~SQL
-      INSERT INTO #{table_name}
+      INSERT /*+ MAX_EXECUTION_TIME(#{ContactRollupsV2::MAX_EXECUTION_TIME}) */
+      INTO #{table_name}
       SELECT *
       FROM contact_rollups_processed;
     SQL

--- a/dashboard/app/models/contact_rollups_pardot_memory.rb
+++ b/dashboard/app/models/contact_rollups_pardot_memory.rb
@@ -158,7 +158,8 @@ class ContactRollupsPardotMemory < ApplicationRecord
     # In addition, they must not be previously rejected by Pardot as invalid emails
     # or have been deleted by someone in Pardot.
     <<-SQL.squish
-      SELECT processed.email, processed.data
+      SELECT /*+ MAX_EXECUTION_TIME(#{ContactRollupsV2::MAX_EXECUTION_TIME}) */
+        processed.email, processed.data
       FROM contact_rollups_processed AS processed
       LEFT OUTER JOIN contact_rollups_pardot_memory AS pardot
         ON processed.email = pardot.email
@@ -176,7 +177,7 @@ class ContactRollupsPardotMemory < ApplicationRecord
     # as attempting to update a prospect that has been deleted from Pardot
     # will resuscitate it as an active prospect.
     <<-SQL.squish
-      SELECT
+      SELECT /*+ MAX_EXECUTION_TIME(#{ContactRollupsV2::MAX_EXECUTION_TIME}) */
         processed.email, processed.data,
         pardot.pardot_id, pardot.data_synced,
         COALESCE(pardot.pardot_id_updated_at > pardot.data_synced_at, FALSE) AS pardot_id_changed

--- a/dashboard/app/models/contact_rollups_processed.rb
+++ b/dashboard/app/models/contact_rollups_processed.rb
@@ -16,35 +16,19 @@
 class ContactRollupsProcessed < ApplicationRecord
   self.table_name = 'contact_rollups_processed'
 
-  DEFAULT_BATCH_SIZE = 10000
+  # Max execution time for query in millisecond.
+  # Can be used to override the production database global query timeout.
+  MAX_EXECUTION_TIME = 1_800_000
+
+  DEFAULT_BATCH_SIZE = 1000
 
   # Aggregates data from contact_rollups_raw table and saves the results, one row per email.
   #
   # @param [Integer] batch_size number of records to save per INSERT statement.
   def self.import_from_raw_table(batch_size = DEFAULT_BATCH_SIZE)
-    # Combines data and metadata for each record in contact_rollups_raw table into one JSON field.
-    # The query result has the same number of rows as in contact_rollups_raw.
-    select_query = <<-SQL.squish
-      SELECT
-        email,
-        JSON_OBJECT('sources', sources, 'data', data, 'data_updated_at', data_updated_at) AS data_and_metadata
-      FROM contact_rollups_raw
-    SQL
-
-    # Groups records by emails. Aggregates all data and metadata belong to an email into one JSON field.
-    #
-    # Note: use GROUP_CONCAT instead of JSON_OBJECT_AGG because the current Aurora Mysql version in
-    # production is 5.7.12, while JSON_OBJECT_AGG is only available from 5.7.22.
-    # Because GROUP_CONCAT returns a string, we add a parser function to convert the result to a hash.
-    group_by_query = <<-SQL.squish
-      SELECT email, CONCAT('[', GROUP_CONCAT(data_and_metadata), ']') AS all_data_and_metadata
-      FROM (#{select_query}) AS subquery
-      GROUP BY email
-    SQL
-
-    # Process the aggregated data row by row and save the results to DB.
+    # Process the aggregated data row by row and save the results to DB in batches.
     batch = []
-    ActiveRecord::Base.connection.exec_query(group_by_query).each do |contact|
+    ActiveRecord::Base.connection.exec_query(get_data_aggregation_query).each do |contact|
       contact_data = parse_contact_data(contact['all_data_and_metadata'])
 
       processed_contact_data = {}
@@ -61,6 +45,30 @@ class ContactRollupsProcessed < ApplicationRecord
     end
 
     import! batch, validate: false unless batch.empty?
+  end
+
+  def self.get_data_aggregation_query
+    # Combines data and metadata for each record in contact_rollups_raw table into one JSON field.
+    # The query result has the same number of rows as in contact_rollups_raw.
+    data_transformation_query = <<-SQL.squish
+      SELECT
+        email,
+        JSON_OBJECT('sources', sources, 'data', data, 'data_updated_at', data_updated_at) AS data_and_metadata
+      FROM contact_rollups_raw
+    SQL
+
+    # Groups records by emails. Aggregates all data and metadata belong to an email into one JSON field.
+    #
+    # Note: use GROUP_CONCAT instead of JSON_OBJECT_AGG because the current Aurora Mysql version in
+    # production is 5.7.12, while JSON_OBJECT_AGG is only available from 5.7.22.
+    # Because GROUP_CONCAT returns a string, we add a parser function to convert the result to a hash.
+    <<-SQL.squish
+      SELECT /*+ MAX_EXECUTION_TIME(#{MAX_EXECUTION_TIME}) */
+        email,
+        CONCAT('[', GROUP_CONCAT(data_and_metadata), ']') AS all_data_and_metadata
+      FROM (#{data_transformation_query}) AS subquery
+      GROUP BY email
+    SQL
   end
 
   # Parses a JSON string contains all data and metadata of a contact.

--- a/dashboard/app/models/contact_rollups_processed.rb
+++ b/dashboard/app/models/contact_rollups_processed.rb
@@ -16,7 +16,7 @@
 class ContactRollupsProcessed < ApplicationRecord
   self.table_name = 'contact_rollups_processed'
 
-  DEFAULT_BATCH_SIZE = 1000
+  DEFAULT_BATCH_SIZE = 10000
 
   # Aggregates data from contact_rollups_raw table and saves the results, one row per email.
   #

--- a/dashboard/app/models/contact_rollups_processed.rb
+++ b/dashboard/app/models/contact_rollups_processed.rb
@@ -16,10 +16,6 @@
 class ContactRollupsProcessed < ApplicationRecord
   self.table_name = 'contact_rollups_processed'
 
-  # Max execution time for query in millisecond.
-  # Can be used to override the production database global query timeout.
-  MAX_EXECUTION_TIME = 1_800_000
-
   DEFAULT_BATCH_SIZE = 1000
 
   # Aggregates data from contact_rollups_raw table and saves the results, one row per email.
@@ -63,7 +59,7 @@ class ContactRollupsProcessed < ApplicationRecord
     # production is 5.7.12, while JSON_OBJECT_AGG is only available from 5.7.22.
     # Because GROUP_CONCAT returns a string, we add a parser function to convert the result to a hash.
     <<-SQL.squish
-      SELECT /*+ MAX_EXECUTION_TIME(#{MAX_EXECUTION_TIME}) */
+      SELECT /*+ MAX_EXECUTION_TIME(#{ContactRollupsV2::MAX_EXECUTION_TIME}) */
         email,
         CONCAT('[', GROUP_CONCAT(data_and_metadata), ']') AS all_data_and_metadata
       FROM (#{data_transformation_query}) AS subquery

--- a/dashboard/app/models/contact_rollups_raw.rb
+++ b/dashboard/app/models/contact_rollups_raw.rb
@@ -50,9 +50,8 @@ class ContactRollupsRaw < ApplicationRecord
 
     <<~SQL.squish
       INSERT /*+ MAX_EXECUTION_TIME(#{ContactRollupsV2::MAX_EXECUTION_TIME}) */
-      INTO #{ContactRollupsRaw.table_name} (
-        email, sources, data, data_updated_at, created_at, updated_at
-      )
+      INTO #{ContactRollupsRaw.table_name}
+        (email, sources, data, data_updated_at, created_at, updated_at)
       SELECT
         #{email_column},
         '#{source_name}' AS sources,

--- a/dashboard/app/models/contact_rollups_raw.rb
+++ b/dashboard/app/models/contact_rollups_raw.rb
@@ -18,10 +18,6 @@
 class ContactRollupsRaw < ApplicationRecord
   self.table_name = 'contact_rollups_raw'
 
-  # Max execution time for query in millisecond.
-  # Can be used to override the production database global query timeout.
-  MAX_EXECUTION_TIME = 1_800_000
-
   def self.extract_email_preferences
     query = get_extraction_query('email_preferences', 'email', ['opt_in'])
     ActiveRecord::Base.connection.execute(query)
@@ -53,7 +49,7 @@ class ContactRollupsRaw < ApplicationRecord
     wrapped_source = source_is_subquery ? "(#{source}) AS subquery" : source
 
     <<~SQL.squish
-      INSERT /*+ MAX_EXECUTION_TIME(#{MAX_EXECUTION_TIME}) */
+      INSERT /*+ MAX_EXECUTION_TIME(#{ContactRollupsV2::MAX_EXECUTION_TIME}) */
       INTO #{ContactRollupsRaw.table_name} (
         email, sources, data, data_updated_at, created_at, updated_at
       )

--- a/dashboard/lib/contact_rollups_v2.rb
+++ b/dashboard/lib/contact_rollups_v2.rb
@@ -1,4 +1,8 @@
 class ContactRollupsV2
+  # Query max execution time in millisecond.
+  # Can be used to override the production database global query timeout.
+  MAX_EXECUTION_TIME = 1_800_000
+
   def self.build_contact_rollups(log_collector, sync_with_pardot=false)
     log_collector.time!('Deletes intermediate content from previous runs') do
       truncate_or_delete_table ContactRollupsRaw

--- a/dashboard/test/models/contact_rollups_raw_test.rb
+++ b/dashboard/test/models/contact_rollups_raw_test.rb
@@ -67,8 +67,9 @@ class ContactRollupsRawTest < ActiveSupport::TestCase
   end
 
   test 'get_extraction_query looks as expected when called with a single column' do
-    expected_sql = <<~SQL
-      INSERT INTO #{ContactRollupsRaw.table_name} (email, sources, data, data_updated_at, created_at, updated_at)
+    expected_sql = <<~SQL.squish
+      INSERT /*+ MAX_EXECUTION_TIME(#{ContactRollupsV2::MAX_EXECUTION_TIME}) */
+      INTO #{ContactRollupsRaw.table_name} (email, sources, data, data_updated_at, created_at, updated_at)
       SELECT
         email,
         'dashboard.email_preferences' AS sources,
@@ -84,8 +85,9 @@ class ContactRollupsRawTest < ActiveSupport::TestCase
   end
 
   test 'get_extraction_query looks as expected when called with multiple columns' do
-    expected_sql = <<~SQL
-      INSERT INTO #{ContactRollupsRaw.table_name} (email, sources, data, data_updated_at, created_at, updated_at)
+    expected_sql = <<~SQL.squish
+      INSERT /*+ MAX_EXECUTION_TIME(#{ContactRollupsV2::MAX_EXECUTION_TIME}) */
+      INTO #{ContactRollupsRaw.table_name} (email, sources, data, data_updated_at, created_at, updated_at)
       SELECT
         parent_email,
         'dashboard.users' AS sources,


### PR DESCRIPTION
Fixing query timeout caught by this [Honeybadger error](https://app.honeybadger.io/projects/45435/faults/63632941) by using [MAX_EXECUTION_TIME optimizer hint.](https://dev.mysql.com/doc/refman/5.7/en/optimizer-hints.html#optimizer-hints-execution-time)

Interestingly, when I run this query `show variables like '%max_execution%';` in the production db, it returns 0.
```
+--------------------+-------+
| Variable_name      | Value |
+--------------------+-------+
| max_execution_time | 0     |
+--------------------+-------+
```
## Testing story
- Unit tests and manual local run.

# Reviewer Checklist:
- [ ] Tests provide adequate coverage
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
