### PR TITLE
Reapply lesson extras rename

### DIFF
--- a/apps/src/lib/script-editor/ScriptEditor.jsx
+++ b/apps/src/lib/script-editor/ScriptEditor.jsx
@@ -308,7 +308,7 @@ export default class ScriptEditor extends React.Component {
         <label>
           Lesson Extras Available
           <input
-            name="stage_extras_available"
+            name="lesson_extras_available"
             type="checkbox"
             defaultChecked={this.props.lessonExtrasAvailable}
             style={styles.checkbox}

--- a/apps/src/sites/studio/pages/home/_homepage.js
+++ b/apps/src/sites/studio/pages/home/_homepage.js
@@ -32,7 +32,7 @@ function showHomepage() {
   registerReducers({locales});
   const store = getStore();
   store.dispatch(setValidGrades(homepageData.valid_grades));
-  store.dispatch(setStageExtrasScriptIds(homepageData.stageExtrasScriptIds));
+  store.dispatch(setStageExtrasScriptIds(homepageData.lessonExtrasScriptIds));
   store.dispatch(setAuthProviders(homepageData.providers));
   store.dispatch(initializeHiddenScripts(homepageData.hiddenScripts));
   store.dispatch(setPageType(pageTypes.homepage));

--- a/apps/src/sites/studio/pages/scripts/edit.js
+++ b/apps/src/sites/studio/pages/scripts/edit.js
@@ -70,7 +70,7 @@ export default function initPage(scriptEditorData) {
         projectWidgetVisible={scriptData.project_widget_visible}
         projectWidgetTypes={scriptData.project_widget_types}
         teacherResources={teacherResources}
-        lessonExtrasAvailable={!!scriptData.stage_extras_available}
+        lessonExtrasAvailable={!!scriptData.lesson_extras_available}
         lessonLevelData={lessonLevelData}
         hasVerifiedResources={scriptData.has_verified_resources}
         hasLessonPlan={scriptData.has_lesson_plan}

--- a/apps/src/templates/teacherDashboard/teacherSectionsRedux.js
+++ b/apps/src/templates/teacherDashboard/teacherSectionsRedux.js
@@ -750,7 +750,7 @@ export default function teacherSections(state = initialState, action) {
         state.validAssignments[assignmentId(null, action.props.scriptId)];
       if (script) {
         stageExtraSettings.stageExtras =
-          script.stage_extras_available || defaultStageExtras;
+          script.lesson_extras_available || defaultStageExtras;
       }
     }
 

--- a/apps/test/unit/templates/teacherDashboard/teacherSectionsReduxTest.js
+++ b/apps/test/unit/templates/teacherDashboard/teacherSectionsReduxTest.js
@@ -177,7 +177,7 @@ const validScripts = [
     category: 'other',
     position: null,
     category_priority: 3,
-    stage_extras_available: true
+    lesson_extras_available: true
   },
   {
     id: 112,
@@ -225,7 +225,7 @@ const validScripts = [
     category: 'other',
     position: null,
     category_priority: 3,
-    stage_extras_available: true
+    lesson_extras_available: true
   }
 ];
 

--- a/dashboard/app/controllers/home_controller.rb
+++ b/dashboard/app/controllers/home_controller.rb
@@ -94,7 +94,7 @@ class HomeController < ApplicationController
 
     @homepage_data = {}
     @homepage_data[:valid_grades] = Section.valid_grades
-    @homepage_data[:stageExtrasScriptIds] = Script.stage_extras_script_ids
+    @homepage_data[:lessonExtrasScriptIds] = Script.lesson_extras_script_ids
     @homepage_data[:isEnglish] = request.language == 'en'
     @homepage_data[:locale] = Script.locale_english_name_map[request.locale]
     @homepage_data[:canViewAdvancedTools] = !(current_user.under_13? && current_user.terms_version.nil?)

--- a/dashboard/app/controllers/scripts_controller.rb
+++ b/dashboard/app/controllers/scripts_controller.rb
@@ -186,7 +186,8 @@ class ScriptsController < ApplicationController
       :wrapup_video,
       :student_detail_progress_view,
       :project_widget_visible,
-      :stage_extras_available,
+      :stage_extras_available, # TODO: remove once corresopnding js change is deployed and no longer cached
+      :lesson_extras_available,
       :has_verified_resources,
       :has_lesson_plan,
       :tts,
@@ -199,6 +200,7 @@ class ScriptsController < ApplicationController
       project_widget_types: [],
       supported_locales: [],
     ).to_h
+    h[:lesson_extras_available] ||= h[:stage_extras_available] # TODO: remove once corresponding js change is deployed and no longer cached
     h[:peer_reviews_to_complete] = h[:peer_reviews_to_complete].to_i
     h[:hidden] = !h[:visible_to_teachers]
     h[:script_announcements] = JSON.parse(h[:script_announcements]) if h[:script_announcements]

--- a/dashboard/app/dsl/script_dsl.rb
+++ b/dashboard/app/dsl/script_dsl.rb
@@ -18,7 +18,7 @@ class ScriptDSL < BaseDSL
     @hideable_stages = false
     @student_detail_progress_view = false
     @teacher_resources = []
-    @stage_extras_available = false
+    @lesson_extras_available = false
     @project_widget_visible = false
     @has_verified_resources = false
     @has_lesson_plan = false
@@ -46,7 +46,7 @@ class ScriptDSL < BaseDSL
   boolean :login_required
   boolean :hideable_stages
   boolean :student_detail_progress_view
-  boolean :stage_extras_available
+  boolean :lesson_extras_available
   boolean :project_widget_visible
   boolean :has_verified_resources
   boolean :has_lesson_plan
@@ -134,7 +134,7 @@ class ScriptDSL < BaseDSL
       professional_learning_course: @professional_learning_course,
       peer_reviews_to_complete: @peer_reviews_to_complete,
       teacher_resources: @teacher_resources,
-      stage_extras_available: @stage_extras_available,
+      lesson_extras_available: @lesson_extras_available,
       has_verified_resources: @has_verified_resources,
       has_lesson_plan: @has_lesson_plan,
       curriculum_path: @curriculum_path,
@@ -313,7 +313,7 @@ class ScriptDSL < BaseDSL
     s << 'student_detail_progress_view true' if script.student_detail_progress_view
     s << "wrapup_video '#{script.wrapup_video.key}'" if script.wrapup_video
     s << "teacher_resources #{script.teacher_resources}" if script.teacher_resources
-    s << 'stage_extras_available true' if script.stage_extras_available
+    s << 'lesson_extras_available true' if script.lesson_extras_available
     s << 'has_verified_resources true' if script.has_verified_resources
     s << 'has_lesson_plan true' if script.has_lesson_plan
     s << "curriculum_path '#{script.curriculum_path}'" if script.curriculum_path

--- a/dashboard/app/helpers/script_levels_helper.rb
+++ b/dashboard/app/helpers/script_levels_helper.rb
@@ -7,10 +7,10 @@ module ScriptLevelsHelper
         response[:stage_changing] = {previous: {name: script_level.name, position: script_level.lesson.absolute_position}}
 
         # End-of-Stage Experience is only enabled for:
-        # scripts with the stage_extras_available property
+        # scripts with the lesson_extras_available property
         # stages except for the last stage of a script
         # users in or teaching sections with an enabled "stage extras" flag
-        enabled_for_stage = script_level.script.stage_extras_available &&
+        enabled_for_stage = script_level.script.lesson_extras_available &&
           !script_level.end_of_script?
         enabled_for_user = current_user && current_user.section_for_script(script_level.script) &&
             current_user.section_for_script(script_level.script).stage_extras

--- a/dashboard/app/models/script.rb
+++ b/dashboard/app/models/script.rb
@@ -130,7 +130,7 @@ class Script < ActiveRecord::Base
     project_widget_visible
     project_widget_types
     teacher_resources
-    stage_extras_available
+    lesson_extras_available
     has_verified_resources
     has_lesson_plan
     curriculum_path
@@ -201,8 +201,8 @@ class Script < ActiveRecord::Base
     Script.get_from_cache(Script::ARTIST_NAME)
   end
 
-  def self.stage_extras_script_ids
-    @@stage_extras_scripts ||= Script.all.select(&:stage_extras_available?).pluck(:id)
+  def self.lesson_extras_script_ids
+    @@lesson_extras_scripts ||= Script.all.select(&:lesson_extras_available?).pluck(:id)
   end
 
   def self.maker_unit_scripts
@@ -1416,7 +1416,8 @@ class Script < ActiveRecord::Base
       project_widget_visible: project_widget_visible?,
       project_widget_types: project_widget_types,
       teacher_resources: teacher_resources,
-      stage_extras_available: stage_extras_available,
+      stage_extras_available: lesson_extras_available, # TODO: remove after corresponding js code is changed and not cached anymore
+      lesson_extras_available: lesson_extras_available,
       has_verified_resources: has_verified_resources?,
       has_lesson_plan: has_lesson_plan?,
       curriculum_path: curriculum_path,
@@ -1574,7 +1575,8 @@ class Script < ActiveRecord::Base
       :student_detail_progress_view,
       :project_widget_visible,
       :project_widget_types,
-      :stage_extras_available,
+      :stage_extras_available, # TODO: remove after corresponding dependencies are updated to use lesson_extras_available
+      :lesson_extras_available,
       :curriculum_path,
       :script_announcements,
       :version_year,
@@ -1658,7 +1660,8 @@ class Script < ActiveRecord::Base
 
     info[:category] = I18n.t("data.script.category.#{info[:category]}_category_name", default: info[:category])
     info[:supported_locales] = supported_locale_names
-    info[:stage_extras_available] = stage_extras_available
+    # TODO: remove stage_extras_available after correesponding js change is deployed and not cached
+    info[:stage_extras_available] = info[:lesson_extras_available] = lesson_extras_available
     if has_standards_associations?
       info[:standards] = standards
     end

--- a/dashboard/app/models/user.rb
+++ b/dashboard/app/models/user.rb
@@ -1987,8 +1987,8 @@ class User < ActiveRecord::Base
       sections.find {|section| section.script_id == script.id}
   end
 
-  def stage_extras_enabled?(script)
-    return false unless script.stage_extras_available?
+  def lesson_extras_enabled?(script)
+    return false unless script.lesson_extras_available?
     return true if teacher?
 
     sections_as_student.any? do |section|

--- a/dashboard/app/views/layouts/_header.html.haml
+++ b/dashboard/app/views/layouts/_header.html.haml
@@ -107,7 +107,7 @@
   - user_progress = current_user == nil ? 'null' : summarize_user_progress(script, view_as, view_as == current_user && @public_caching).to_json
 
   - if view_as
-    - stage_extras_enabled = view_as.stage_extras_enabled?(script)
+    - lesson_extras_enabled = view_as.lesson_extras_enabled?(script)
 
   -# don't trust outside content in parameter :puzzle_page - should be integer, so immediately call to_i
   - puzzle_page = params[:puzzle_page] ? params[:puzzle_page].to_i : ApplicationHelper::PUZZLE_PAGE_NONE
@@ -131,7 +131,7 @@
       "#{uid}",
       #{puzzle_page},
       #{signed_in},
-      #{stage_extras_enabled || 'null'}
+      #{lesson_extras_enabled || 'null'}
     )
     //]]>
 

--- a/dashboard/config/scripts/allthethings.script
+++ b/dashboard/config/scripts/allthethings.script
@@ -1,5 +1,5 @@
 hideable_stages true
-stage_extras_available true
+lesson_extras_available true
 
 stage 'Jigsaw'
 skin 'jigsaw'

--- a/dashboard/config/scripts/course1.script
+++ b/dashboard/config/scripts/course1.script
@@ -1,7 +1,7 @@
 tts true
 hidden false
 hideable_stages true
-stage_extras_available true
+lesson_extras_available true
 project_widget_visible true
 has_lesson_plan true
 curriculum_path 'https://code.org/curriculum/course1/{LESSON}/Teacher'

--- a/dashboard/config/scripts/course2.script
+++ b/dashboard/config/scripts/course2.script
@@ -1,7 +1,7 @@
 tts true
 hidden false
 hideable_stages true
-stage_extras_available true
+lesson_extras_available true
 project_widget_visible true
 has_lesson_plan true
 curriculum_path 'https://code.org/curriculum/course2/{LESSON}/Teacher'

--- a/dashboard/config/scripts/course3.script
+++ b/dashboard/config/scripts/course3.script
@@ -1,7 +1,7 @@
 tts true
 hidden false
 hideable_stages true
-stage_extras_available true
+lesson_extras_available true
 project_widget_visible true
 has_lesson_plan true
 curriculum_path 'https://code.org/curriculum/course3/{LESSON}/Teacher'

--- a/dashboard/config/scripts/coursea-2017.script
+++ b/dashboard/config/scripts/coursea-2017.script
@@ -1,7 +1,7 @@
 tts true
 hidden false
 hideable_stages true
-stage_extras_available true
+lesson_extras_available true
 has_lesson_plan true
 curriculum_path 'https://curriculum.code.org/{LOCALE}/csf-1718/coursea/{LESSON}'
 project_widget_visible true

--- a/dashboard/config/scripts/coursea-2018.script
+++ b/dashboard/config/scripts/coursea-2018.script
@@ -2,7 +2,7 @@ tts true
 hidden false
 hideable_stages true
 teacher_resources [["lessonPlans", "https://curriculum.code.org/csf-18/coursea/"], ["teacherForum", "http://forum.code.org/c/csf"], ["vocabulary", "https://curriculum.code.org/csf-18/coursea/vocab/"], ["standardMappings", "https://curriculum.code.org/csf-18/coursea/standards/"]]
-stage_extras_available true
+lesson_extras_available true
 has_lesson_plan true
 curriculum_path 'https://curriculum.code.org/{LOCALE}/csf-18/coursea/{LESSON}'
 project_widget_visible true

--- a/dashboard/config/scripts/coursea-2019.script
+++ b/dashboard/config/scripts/coursea-2019.script
@@ -2,7 +2,7 @@ tts true
 hidden false
 hideable_stages true
 teacher_resources [["lessonPlans", "https://curriculum.code.org/csf-19/coursea/"], ["teacherForum", "http://forum.code.org/c/csf"], ["vocabulary", "https://curriculum.code.org/csf-19/coursea/vocab/"], ["standardMappings", "https://curriculum.code.org/csf-19/coursea/standards/"], ["curriculumGuide", "https://docs.google.com/document/d/1UqCgO06NzB1L6y83fnwnUcYdKr3MooJAaUZajj48DnI/preview"]]
-stage_extras_available true
+lesson_extras_available true
 has_lesson_plan true
 curriculum_path 'https://curriculum.code.org/{LOCALE}/csf-19/coursea/{LESSON}'
 project_widget_visible true

--- a/dashboard/config/scripts/coursea-2020.script
+++ b/dashboard/config/scripts/coursea-2020.script
@@ -1,7 +1,7 @@
 tts true
 hideable_stages true
 teacher_resources [["lessonPlans", "https://curriculum.code.org/csf-20/coursea/"], ["teacherForum", "http://forum.code.org/c/csf"], ["vocabulary", "https://curriculum.code.org/csf-20/coursea/vocab/"], ["standardMappings", "https://curriculum.code.org/csf-20/coursea/standards/"], ["curriculumGuide", "https://docs.google.com/document/d/1hstUHTGIdvtPP0TDdEfQeXG3zQ0q6ys237n2BY9CQmg/preview"]]
-stage_extras_available true
+lesson_extras_available true
 has_lesson_plan true
 curriculum_path 'https://curriculum.code.org/{LOCALE}/csf-20/coursea/{LESSON}'
 project_widget_visible true

--- a/dashboard/config/scripts/courseb-2017.script
+++ b/dashboard/config/scripts/courseb-2017.script
@@ -1,7 +1,7 @@
 tts true
 hidden false
 hideable_stages true
-stage_extras_available true
+lesson_extras_available true
 has_lesson_plan true
 curriculum_path 'https://curriculum.code.org/{LOCALE}/csf-1718/courseb/{LESSON}'
 project_widget_visible true

--- a/dashboard/config/scripts/courseb-2018.script
+++ b/dashboard/config/scripts/courseb-2018.script
@@ -2,7 +2,7 @@ tts true
 hidden false
 hideable_stages true
 teacher_resources [["lessonPlans", "https://curriculum.code.org/csf-18/courseb/"], ["teacherForum", "https://forum.code.org/c/csf"], ["vocabulary", "https://curriculum.code.org/csf-18/courseb/vocab/"], ["standardMappings", "https://curriculum.code.org/csf-18/courseb/standards/"]]
-stage_extras_available true
+lesson_extras_available true
 has_lesson_plan true
 curriculum_path 'https://curriculum.code.org/{LOCALE}/csf-18/courseb/{LESSON}'
 project_widget_visible true

--- a/dashboard/config/scripts/courseb-2019.script
+++ b/dashboard/config/scripts/courseb-2019.script
@@ -2,7 +2,7 @@ tts true
 hidden false
 hideable_stages true
 teacher_resources [["lessonPlans", "https://curriculum.code.org/csf-19/courseb/"], ["teacherForum", "https://forum.code.org/c/csf"], ["vocabulary", "https://curriculum.code.org/csf-19/courseb/vocab/"], ["standardMappings", "https://curriculum.code.org/csf-19/courseb/standards/"], ["curriculumGuide", "https://docs.google.com/document/d/1UqCgO06NzB1L6y83fnwnUcYdKr3MooJAaUZajj48DnI/preview"]]
-stage_extras_available true
+lesson_extras_available true
 has_lesson_plan true
 curriculum_path 'https://curriculum.code.org/{LOCALE}/csf-19/courseb/{LESSON}'
 project_widget_visible true

--- a/dashboard/config/scripts/courseb-2020.script
+++ b/dashboard/config/scripts/courseb-2020.script
@@ -1,7 +1,7 @@
 tts true
 hideable_stages true
 teacher_resources [["lessonPlans", "https://curriculum.code.org/csf-20/courseb/"], ["teacherForum", "https://forum.code.org/c/csf"], ["vocabulary", "https://curriculum.code.org/csf-20/courseb/vocab/"], ["standardMappings", "https://curriculum.code.org/csf-20/courseb/standards/"], ["curriculumGuide", "https://docs.google.com/document/d/1hstUHTGIdvtPP0TDdEfQeXG3zQ0q6ys237n2BY9CQmg/preview"]]
-stage_extras_available true
+lesson_extras_available true
 has_lesson_plan true
 curriculum_path 'https://curriculum.code.org/{LOCALE}/csf-20/courseb/{LESSON}'
 project_widget_visible true

--- a/dashboard/config/scripts/coursec-2017.script
+++ b/dashboard/config/scripts/coursec-2017.script
@@ -1,7 +1,7 @@
 tts true
 hidden false
 hideable_stages true
-stage_extras_available true
+lesson_extras_available true
 has_lesson_plan true
 curriculum_path 'https://curriculum.code.org/{LOCALE}/csf-1718/coursec/{LESSON}'
 project_widget_visible true

--- a/dashboard/config/scripts/coursec-2018.script
+++ b/dashboard/config/scripts/coursec-2018.script
@@ -2,7 +2,7 @@ tts true
 hidden false
 hideable_stages true
 teacher_resources [["lessonPlans", "https://curriculum.code.org/csf-18/coursec/"], ["teacherForum", "https://forum.code.org/c/csf"], ["vocabulary", "https://curriculum.code.org/csf-18/coursec/vocab/"], ["standardMappings", "https://curriculum.code.org/csf-18/coursec/standards/"]]
-stage_extras_available true
+lesson_extras_available true
 has_lesson_plan true
 curriculum_path 'https://curriculum.code.org/{LOCALE}/csf-18/coursec/{LESSON}'
 project_widget_visible true

--- a/dashboard/config/scripts/coursec-2019.script
+++ b/dashboard/config/scripts/coursec-2019.script
@@ -2,7 +2,7 @@ tts true
 hidden false
 hideable_stages true
 teacher_resources [["lessonPlans", "https://curriculum.code.org/csf-19/coursec/"], ["teacherForum", "https://forum.code.org/c/csf"], ["vocabulary", "https://curriculum.code.org/csf-19/coursec/vocab/"], ["standardMappings", "https://curriculum.code.org/csf-19/coursec/standards/"], ["curriculumGuide", "https://docs.google.com/document/d/1UqCgO06NzB1L6y83fnwnUcYdKr3MooJAaUZajj48DnI/preview"]]
-stage_extras_available true
+lesson_extras_available true
 has_lesson_plan true
 curriculum_path 'https://curriculum.code.org/{LOCALE}/csf-19/coursec/{LESSON}'
 project_widget_visible true

--- a/dashboard/config/scripts/coursec-2020.script
+++ b/dashboard/config/scripts/coursec-2020.script
@@ -1,7 +1,7 @@
 tts true
 hideable_stages true
 teacher_resources [["lessonPlans", "https://curriculum.code.org/csf-20/coursec/"], ["teacherForum", "https://forum.code.org/c/csf"], ["vocabulary", "https://curriculum.code.org/csf-20/coursec/vocab/"], ["standardMappings", "https://curriculum.code.org/csf-20/coursec/standards/"], ["curriculumGuide", "https://docs.google.com/document/d/1hstUHTGIdvtPP0TDdEfQeXG3zQ0q6ys237n2BY9CQmg/preview"]]
-stage_extras_available true
+lesson_extras_available true
 has_lesson_plan true
 curriculum_path 'https://curriculum.code.org/{LOCALE}/csf-20/coursec/{LESSON}'
 project_widget_visible true

--- a/dashboard/config/scripts/coursed-2017.script
+++ b/dashboard/config/scripts/coursed-2017.script
@@ -1,7 +1,7 @@
 tts true
 hidden false
 hideable_stages true
-stage_extras_available true
+lesson_extras_available true
 has_lesson_plan true
 curriculum_path 'https://curriculum.code.org/{LOCALE}/csf-1718/coursed/{LESSON}'
 project_widget_visible true

--- a/dashboard/config/scripts/coursed-2018.script
+++ b/dashboard/config/scripts/coursed-2018.script
@@ -2,7 +2,7 @@ tts true
 hidden false
 hideable_stages true
 teacher_resources [["lessonPlans", "https://curriculum.code.org/csf-18/coursed/"], ["teacherForum", "https://forum.code.org/c/csf"], ["vocabulary", "https://curriculum.code.org/csf-18/coursed/vocab/"], ["standardMappings", "https://curriculum.code.org/csf-18/coursed/standards/"]]
-stage_extras_available true
+lesson_extras_available true
 has_lesson_plan true
 curriculum_path 'https://curriculum.code.org/{LOCALE}/csf-18/coursed/{LESSON}'
 family_name 'coursed'

--- a/dashboard/config/scripts/coursed-2019.script
+++ b/dashboard/config/scripts/coursed-2019.script
@@ -2,7 +2,7 @@ tts true
 hidden false
 hideable_stages true
 teacher_resources [["lessonPlans", "https://curriculum.code.org/csf-19/coursed/"], ["teacherForum", "https://forum.code.org/c/csf"], ["vocabulary", "https://curriculum.code.org/csf-19/coursed/vocab/"], ["standardMappings", "https://curriculum.code.org/csf-19/coursed/standards/"], ["curriculumGuide", "https://docs.google.com/document/d/1UqCgO06NzB1L6y83fnwnUcYdKr3MooJAaUZajj48DnI/preview"]]
-stage_extras_available true
+lesson_extras_available true
 has_lesson_plan true
 curriculum_path 'https://curriculum.code.org/{LOCALE}/csf-19/coursed/{LESSON}'
 script_announcements [{"notice"=>"Our 2019 CS Fundamentals Lessons are Live!", "details"=>"Click \"Learn More\" to view all of the lesson plans for the 2019 version of Course D!", "link"=>"https://curriculum.code.org/csf-19/coursed", "type"=>"information", "visibility"=>"Teacher-only"}]

--- a/dashboard/config/scripts/coursed-2020.script
+++ b/dashboard/config/scripts/coursed-2020.script
@@ -1,7 +1,7 @@
 tts true
 hideable_stages true
 teacher_resources [["lessonPlans", "https://curriculum.code.org/csf-20/coursed/"], ["teacherForum", "https://forum.code.org/c/csf"], ["vocabulary", "https://curriculum.code.org/csf-20/coursed/vocab/"], ["standardMappings", "https://curriculum.code.org/csf-20/coursed/standards/"], ["curriculumGuide", "https://docs.google.com/document/d/1hstUHTGIdvtPP0TDdEfQeXG3zQ0q6ys237n2BY9CQmg/preview"]]
-stage_extras_available true
+lesson_extras_available true
 has_lesson_plan true
 curriculum_path 'https://curriculum.code.org/{LOCALE}/csf-20/coursed/{LESSON}'
 family_name 'coursed'

--- a/dashboard/config/scripts/coursee-2017.script
+++ b/dashboard/config/scripts/coursee-2017.script
@@ -1,7 +1,7 @@
 tts true
 hidden false
 hideable_stages true
-stage_extras_available true
+lesson_extras_available true
 has_lesson_plan true
 curriculum_path 'https://curriculum.code.org/{LOCALE}/csf-1718/coursee/{LESSON}'
 project_widget_visible true

--- a/dashboard/config/scripts/coursee-2018.script
+++ b/dashboard/config/scripts/coursee-2018.script
@@ -2,7 +2,7 @@ tts true
 hidden false
 hideable_stages true
 teacher_resources [["lessonPlans", "https://curriculum.code.org/csf-18/coursee/"], ["teacherForum", "https://forum.code.org/c/csf"], ["vocabulary", "https://curriculum.code.org/csf-18/coursee/vocab/"], ["standardMappings", "https://curriculum.code.org/csf-18/coursee/standards/"]]
-stage_extras_available true
+lesson_extras_available true
 has_lesson_plan true
 curriculum_path 'https://curriculum.code.org/{LOCALE}/csf-18/coursee/{LESSON}'
 project_widget_visible true

--- a/dashboard/config/scripts/coursee-2019.script
+++ b/dashboard/config/scripts/coursee-2019.script
@@ -2,7 +2,7 @@ tts true
 hidden false
 hideable_stages true
 teacher_resources [["lessonPlans", "https://curriculum.code.org/csf-19/coursee/"], ["teacherForum", "https://forum.code.org/c/csf"], ["vocabulary", "https://curriculum.code.org/csf-19/coursee/vocab/"], ["standardMappings", "https://curriculum.code.org/csf-19/coursee/standards/"], ["curriculumGuide", "https://docs.google.com/document/d/1UqCgO06NzB1L6y83fnwnUcYdKr3MooJAaUZajj48DnI/preview"]]
-stage_extras_available true
+lesson_extras_available true
 has_lesson_plan true
 curriculum_path 'https://curriculum.code.org/{LOCALE}/csf-19/coursee/{LESSON}'
 project_widget_visible true

--- a/dashboard/config/scripts/coursee-2020.script
+++ b/dashboard/config/scripts/coursee-2020.script
@@ -1,6 +1,6 @@
 hideable_stages true
 teacher_resources [["lessonPlans", "https://curriculum.code.org/csf-20/coursee/"], ["teacherForum", "https://forum.code.org/c/csf"], ["vocabulary", "https://curriculum.code.org/csf-20/coursee/vocab/"], ["standardMappings", "https://curriculum.code.org/csf-20/coursee/standards/"], ["curriculumGuide", "https://docs.google.com/document/d/1hstUHTGIdvtPP0TDdEfQeXG3zQ0q6ys237n2BY9CQmg/preview"]]
-stage_extras_available true
+lesson_extras_available true
 has_lesson_plan true
 curriculum_path 'https://curriculum.code.org/{LOCALE}/csf-20/coursee/{LESSON}'
 project_widget_visible true

--- a/dashboard/config/scripts/coursef-2017.script
+++ b/dashboard/config/scripts/coursef-2017.script
@@ -1,7 +1,7 @@
 tts true
 hidden false
 hideable_stages true
-stage_extras_available true
+lesson_extras_available true
 has_lesson_plan true
 curriculum_path 'https://curriculum.code.org/{LOCALE}/csf-1718/coursef/{LESSON}'
 project_widget_visible true

--- a/dashboard/config/scripts/coursef-2018.script
+++ b/dashboard/config/scripts/coursef-2018.script
@@ -2,7 +2,7 @@ tts true
 hidden false
 hideable_stages true
 teacher_resources [["lessonPlans", "https://curriculum.code.org/csf-18/coursef/"], ["teacherForum", "https://forum.code.org/c/csf"], ["vocabulary", "https://curriculum.code.org/csf-18/coursef/vocab/"], ["standardMappings", "https://curriculum.code.org/csf-18/coursef/standards/"]]
-stage_extras_available true
+lesson_extras_available true
 has_lesson_plan true
 curriculum_path 'https://curriculum.code.org/{LOCALE}/csf-18/coursef/{LESSON}'
 project_widget_visible true

--- a/dashboard/config/scripts/coursef-2019.script
+++ b/dashboard/config/scripts/coursef-2019.script
@@ -2,7 +2,7 @@ tts true
 hidden false
 hideable_stages true
 teacher_resources [["lessonPlans", "https://curriculum.code.org/csf-19/coursef/"], ["teacherForum", "https://forum.code.org/c/csf"], ["vocabulary", "https://curriculum.code.org/csf-19/coursef/vocab/"], ["standardMappings", "https://curriculum.code.org/csf-19/coursef/standards/"], ["curriculumGuide", "https://docs.google.com/document/d/1UqCgO06NzB1L6y83fnwnUcYdKr3MooJAaUZajj48DnI/preview"]]
-stage_extras_available true
+lesson_extras_available true
 has_lesson_plan true
 curriculum_path 'https://curriculum.code.org/{LOCALE}/csf-19/coursef/{LESSON}'
 project_widget_visible true

--- a/dashboard/config/scripts/coursef-2020.script
+++ b/dashboard/config/scripts/coursef-2020.script
@@ -1,6 +1,6 @@
 hideable_stages true
 teacher_resources [["lessonPlans", "https://curriculum.code.org/csf-20/coursef/"], ["teacherForum", "https://forum.code.org/c/csf"], ["vocabulary", "https://curriculum.code.org/csf-20/coursef/vocab/"], ["standardMappings", "https://curriculum.code.org/csf-20/coursef/standards/"], ["curriculumGuide", "https://docs.google.com/document/d/1hstUHTGIdvtPP0TDdEfQeXG3zQ0q6ys237n2BY9CQmg/preview"]]
-stage_extras_available true
+lesson_extras_available true
 has_lesson_plan true
 curriculum_path 'https://curriculum.code.org/{LOCALE}/csf-20/coursef/{LESSON}'
 project_widget_visible true

--- a/dashboard/config/scripts/csd3-2018.script
+++ b/dashboard/config/scripts/csd3-2018.script
@@ -4,7 +4,7 @@ login_required true
 hideable_stages true
 student_detail_progress_view true
 teacher_resources [["lessonPlans", "https://curriculum.code.org/csd-18/unit3/"], ["teacherForum", "https://forum.code.org/c/csd3"], ["vocabulary", "https://curriculum.code.org/csd-18/unit3/vocab/"], ["standardMappings", "https://curriculum.code.org/csd-18/unit3/standards/"], ["codeIntroduced", "https://curriculum.code.org/csd-18/unit3/code/"]]
-stage_extras_available true
+lesson_extras_available true
 has_verified_resources true
 has_lesson_plan true
 project_widget_visible true

--- a/dashboard/config/scripts/csd3-2019.script
+++ b/dashboard/config/scripts/csd3-2019.script
@@ -4,7 +4,7 @@ login_required true
 hideable_stages true
 student_detail_progress_view true
 teacher_resources [["lessonPlans", "https://curriculum.code.org/csd-19/unit3/"], ["teacherForum", "https://forum.code.org/c/csd"], ["vocabulary", "https://curriculum.code.org/csd-19/unit3/vocab/"], ["standardMappings", "https://curriculum.code.org/csd-19/unit3/standards/"], ["codeIntroduced", "https://curriculum.code.org/csd-19/unit3/code/"]]
-stage_extras_available true
+lesson_extras_available true
 has_verified_resources true
 has_lesson_plan true
 curriculum_path 'https://curriculum.code.org/csd-19/unit3/{LESSON}'

--- a/dashboard/config/scripts/csd6-2018.script
+++ b/dashboard/config/scripts/csd6-2018.script
@@ -4,7 +4,7 @@ login_required true
 hideable_stages true
 student_detail_progress_view true
 teacher_resources [["lessonPlans", "https://curriculum.code.org/csd-18/unit6/"], ["teacherForum", "https://forum.code.org/c/csd6"], ["vocabulary", "https://curriculum.code.org/csd-18/unit6/vocab/"], ["standardMappings", "https://curriculum.code.org/csd-18/unit6/standards/"], ["codeIntroduced", "https://curriculum.code.org/csd-18/unit6/code/"]]
-stage_extras_available true
+lesson_extras_available true
 has_verified_resources true
 has_lesson_plan true
 project_widget_visible true

--- a/dashboard/config/scripts/csd6-2019.script
+++ b/dashboard/config/scripts/csd6-2019.script
@@ -4,7 +4,7 @@ login_required true
 hideable_stages true
 student_detail_progress_view true
 teacher_resources [["lessonPlans", "https://curriculum.code.org/csd-19/unit6/"], ["teacherForum", "https://forum.code.org/c/csd"], ["vocabulary", "https://curriculum.code.org/csd-19/unit6/vocab/"], ["standardMappings", "https://curriculum.code.org/csd-19/unit6/standards/"], ["codeIntroduced", "https://curriculum.code.org/csd-19/unit6/code/"]]
-stage_extras_available true
+lesson_extras_available true
 has_verified_resources true
 has_lesson_plan true
 curriculum_path 'https://curriculum.code.org/csd-19/unit6/{LESSON}'

--- a/dashboard/config/scripts/csd6-2020.script
+++ b/dashboard/config/scripts/csd6-2020.script
@@ -2,7 +2,7 @@ hidden false
 login_required true
 hideable_stages true
 student_detail_progress_view true
-stage_extras_available true
+lesson_extras_available true
 has_verified_resources true
 has_lesson_plan true
 curriculum_path 'https://curriculum.code.org/csd-20/unit6/{LESSON}'

--- a/dashboard/config/scripts/csd6-draft.script
+++ b/dashboard/config/scripts/csd6-draft.script
@@ -1,7 +1,7 @@
 login_required true
 hideable_stages true
 student_detail_progress_view true
-stage_extras_available true
+lesson_extras_available true
 project_widget_visible true
 project_widget_types ["applab", "gamelab", "weblab"]
 

--- a/dashboard/config/scripts/csd6-old.script
+++ b/dashboard/config/scripts/csd6-old.script
@@ -1,6 +1,6 @@
 login_required true
 student_detail_progress_view true
-stage_extras_available true
+lesson_extras_available true
 project_widget_visible true
 project_widget_types ["applab"]
 

--- a/dashboard/config/scripts/express-2017.script
+++ b/dashboard/config/scripts/express-2017.script
@@ -1,7 +1,7 @@
 tts true
 hidden false
 hideable_stages true
-stage_extras_available true
+lesson_extras_available true
 has_lesson_plan true
 curriculum_path 'https://curriculum.code.org/{LOCALE}/csf-1718/express/{LESSON}'
 project_widget_visible true

--- a/dashboard/config/scripts/express-2018.script
+++ b/dashboard/config/scripts/express-2018.script
@@ -2,7 +2,7 @@ tts true
 hidden false
 hideable_stages true
 teacher_resources [["lessonPlans", "https://curriculum.code.org/csf-18/express/"], ["teacherForum", "https://forum.code.org/c/csf"], ["vocabulary", "https://curriculum.code.org/csf-18/express/vocab/"], ["standardMappings", "https://curriculum.code.org/csf-18/express/standards/"]]
-stage_extras_available true
+lesson_extras_available true
 has_lesson_plan true
 curriculum_path 'https://curriculum.code.org/{LOCALE}/csf-18/express/{LESSON}'
 project_widget_visible true

--- a/dashboard/config/scripts/express-2019.script
+++ b/dashboard/config/scripts/express-2019.script
@@ -1,6 +1,6 @@
 hidden false
 hideable_stages true
-stage_extras_available true
+lesson_extras_available true
 has_lesson_plan true
 curriculum_path 'https://curriculum.code.org/{LOCALE}/csf-19/express/{LESSON}'
 project_widget_visible true

--- a/dashboard/config/scripts/express-2020.script
+++ b/dashboard/config/scripts/express-2020.script
@@ -1,6 +1,6 @@
 hideable_stages true
 teacher_resources [["lessonPlans", "https://curriculum.code.org/csf-20/express/"], ["teacherForum", "https://forum.code.org/c/csf"], ["vocabulary", "https://curriculum.code.org/csf-20/express/vocab/"], ["standardMappings", "https://curriculum.code.org/csf-20/express/standards/"]]
-stage_extras_available true
+lesson_extras_available true
 has_lesson_plan true
 curriculum_path 'https://curriculum.code.org/{LOCALE}/csf-20/express/{LESSON}'
 project_widget_visible true

--- a/dashboard/config/scripts/pre-express-2017.script
+++ b/dashboard/config/scripts/pre-express-2017.script
@@ -1,7 +1,7 @@
 tts true
 hidden false
 hideable_stages true
-stage_extras_available true
+lesson_extras_available true
 has_lesson_plan true
 curriculum_path 'https://curriculum.code.org/{LOCALE}/csf-1718/pre-express/{LESSON}'
 project_widget_visible true

--- a/dashboard/config/scripts/pre-express-2018.script
+++ b/dashboard/config/scripts/pre-express-2018.script
@@ -1,7 +1,7 @@
 tts true
 hidden false
 hideable_stages true
-stage_extras_available true
+lesson_extras_available true
 has_lesson_plan true
 curriculum_path 'https://curriculum.code.org/{LOCALE}/csf-18/pre-express/{LESSON}'
 project_widget_visible true

--- a/dashboard/config/scripts/pre-express-2019.script
+++ b/dashboard/config/scripts/pre-express-2019.script
@@ -1,6 +1,6 @@
 hidden false
 hideable_stages true
-stage_extras_available true
+lesson_extras_available true
 has_lesson_plan true
 curriculum_path 'https://curriculum.code.org/{LOCALE}/csf-19/pre-express/{LESSON}'
 project_widget_visible true

--- a/dashboard/config/scripts/pre-express-2020.script
+++ b/dashboard/config/scripts/pre-express-2020.script
@@ -1,6 +1,6 @@
 hideable_stages true
 teacher_resources [["lessonPlans", "https://curriculum.code.org/csf-20/express/"], ["teacherForum", "https://forum.code.org/c/csf"], ["vocabulary", "https://curriculum.code.org/csf-20/express/vocab/"], ["standardMappings", "https://curriculum.code.org/csf-20/express/standards"]]
-stage_extras_available true
+lesson_extras_available true
 has_lesson_plan true
 curriculum_path 'https://curriculum.code.org/{LOCALE}/csf-20/pre-express/{LESSON}'
 project_widget_visible true

--- a/dashboard/config/scripts/time4cs-control-unit-1.script
+++ b/dashboard/config/scripts/time4cs-control-unit-1.script
@@ -1,6 +1,6 @@
 login_required true
 hideable_stages true
-stage_extras_available true
+lesson_extras_available true
 pilot_experiment 'time4cs-control'
 editor_experiment 'broward'
 

--- a/dashboard/config/scripts/time4cs-control-unit-2.script
+++ b/dashboard/config/scripts/time4cs-control-unit-2.script
@@ -1,6 +1,6 @@
 login_required true
 hideable_stages true
-stage_extras_available true
+lesson_extras_available true
 editor_experiment 'broward'
 
 lesson_group 'csf_digcit', display_name: 'Digital Citizenship'

--- a/dashboard/config/scripts/time4cs-experiment-unit-1.script
+++ b/dashboard/config/scripts/time4cs-experiment-unit-1.script
@@ -1,6 +1,6 @@
 login_required true
 hideable_stages true
-stage_extras_available true
+lesson_extras_available true
 editor_experiment 'broward'
 
 lesson_group 'csf_sequencing', display_name: 'Sequencing'

--- a/dashboard/config/scripts/time4csdemo.script
+++ b/dashboard/config/scripts/time4csdemo.script
@@ -1,4 +1,4 @@
-stage_extras_available true
+lesson_extras_available true
 has_lesson_plan true
 
 lesson_group 'ramp_up', display_name: 'Ramp-Up'

--- a/dashboard/test/controllers/scripts_controller_test.rb
+++ b/dashboard/test/controllers/scripts_controller_test.rb
@@ -554,7 +554,7 @@ class ScriptsControllerTest < ActionController::TestCase
       hideable_stages: 'on',
       project_widget_visible: 'on',
       student_detail_progress_view: 'on',
-      stage_extras_available: 'on',
+      lesson_extras_available: 'on',
       has_verified_resources: 'on',
       has_lesson_plan: 'on',
       is_stable: 'on',

--- a/dashboard/test/dsl/script_dsl_test.rb
+++ b/dashboard/test/dsl/script_dsl_test.rb
@@ -18,7 +18,7 @@ class ScriptDslTest < ActiveSupport::TestCase
     student_detail_progress_view: false,
     peer_reviews_to_complete: nil,
     teacher_resources: [],
-    stage_extras_available: false,
+    lesson_extras_available: false,
     has_verified_resources: false,
     has_lesson_plan: false,
     curriculum_path: nil,

--- a/dashboard/test/fixtures/test-all-properties.script
+++ b/dashboard/test/fixtures/test-all-properties.script
@@ -1,7 +1,7 @@
 hideable_stages true
 project_widget_visible true
 student_detail_progress_view true
-stage_extras_available true
+lesson_extras_available true
 has_verified_resources true
 has_lesson_plan true
 is_stable true

--- a/dashboard/test/helpers/script_levels_helper_test.rb
+++ b/dashboard/test/helpers/script_levels_helper_test.rb
@@ -9,7 +9,7 @@ class ScriptLevelsHelperTest < ActionView::TestCase
     @teacher = create(:teacher)
     @student = create(:student)
     script = Script.find_by_name(Script::COURSE4_NAME)
-    script.stage_extras_available = true
+    script.lesson_extras_available = true
     script.save
     create(:section, user: @teacher, script: script)
     @section = create(:section, user: @teacher, script: script)

--- a/dashboard/test/models/lesson_test.rb
+++ b/dashboard/test/models/lesson_test.rb
@@ -56,7 +56,7 @@ class StageTest < ActiveSupport::TestCase
   end
 
   test "summary for stage with extras" do
-    script = create :script, stage_extras_available: true
+    script = create :script, lesson_extras_available: true
     level = create :level
     stage = create :lesson, script: script
     create :script_level, script: script, lesson: stage, levels: [level]

--- a/dashboard/test/models/script_test.rb
+++ b/dashboard/test/models/script_test.rb
@@ -1584,13 +1584,14 @@ endvariants
   end
 
   test "assignable_info: returns assignable info for a script" do
-    script = create(:script, name: 'fake-script', hidden: true, stage_extras_available: true)
+    script = create(:script, name: 'fake-script', hidden: true, lesson_extras_available: true)
     assignable_info = script.assignable_info
 
     assert_equal("fake-script *", assignable_info[:name])
     assert_equal("fake-script", assignable_info[:script_name])
     assert_equal("other", assignable_info[:category])
     assert(assignable_info[:stage_extras_available])
+    assert(assignable_info[:lesson_extras_available])
   end
 
   test "assignable_info: correctly translates script info" do

--- a/dashboard/test/models/user_test.rb
+++ b/dashboard/test/models/user_test.rb
@@ -3516,9 +3516,9 @@ class UserTest < ActiveSupport::TestCase
     end
   end
 
-  test 'stage_extras_enabled?' do
-    script = create :script, stage_extras_available: true
-    other_script = create :script, stage_extras_available: true
+  test 'lesson_extras_enabled?' do
+    script = create :script, lesson_extras_available: true
+    other_script = create :script, lesson_extras_available: true
     teacher = create :teacher
     student = create :student
 
@@ -3529,14 +3529,14 @@ class UserTest < ActiveSupport::TestCase
     section3 = create :section, stage_extras: true, script_id: other_script.id
     section3.add_student(teacher)
 
-    assert student.stage_extras_enabled?(script)
-    refute student.stage_extras_enabled?(other_script)
+    assert student.lesson_extras_enabled?(script)
+    refute student.lesson_extras_enabled?(other_script)
 
-    assert teacher.stage_extras_enabled?(script)
-    assert teacher.stage_extras_enabled?(other_script)
+    assert teacher.lesson_extras_enabled?(script)
+    assert teacher.lesson_extras_enabled?(other_script)
 
-    refute (create :student).stage_extras_enabled?(script)
-    assert (create :teacher).stage_extras_enabled?(script)
+    refute (create :student).lesson_extras_enabled?(script)
+    assert (create :teacher).lesson_extras_enabled?(script)
   end
 
   class HiddenIds < ActiveSupport::TestCase

--- a/dashboard/test/testing/capture_queries.rb
+++ b/dashboard/test/testing/capture_queries.rb
@@ -41,7 +41,7 @@ module CaptureQueries
     # Level-cache queries don't count.
     /script\.rb.*cache_find_(script_level|level)/,
     # Ignore cached script id lookup
-    /stage_extras_script_ids/,
+    /lesson_extras_script_ids/,
     # Ignore random updates to experiment cache.
     /experiment\.rb.*update_cache/
   ]


### PR DESCRIPTION
Reapplies https://github.com/code-dot-org/code-dot-org/pull/34705 , which broke a unit test because `capture_queries.rb` had the old method name `stage_extras_script_ids` hard coded in. Sigh.