### PR TITLE
Show all password reset links if there are multiple associated users

### DIFF
--- a/dashboard/app/controllers/passwords_controller.rb
+++ b/dashboard/app/controllers/passwords_controller.rb
@@ -45,6 +45,13 @@ class PasswordsController < Devise::PasswordsController
     if raw_token = resource.try(:raw_token)
       url = edit_password_url(resource, reset_password_token: raw_token)
       flash[:notice] = "Reset password link sent to user. You may also send this link directly: <a href='#{url}'>#{url}</a>".html_safe
+    elsif resource.child_users
+      notice = "Reset password link sent to user. You may also send the link directly:<br>"
+      resource.child_users.each do |user|
+        url = edit_password_url(user, reset_password_token: user.raw_token)
+        notice += "#{user.username}: <a href='#{url}'>#{url}</a><br>"
+      end
+      flash[:notice] = notice.html_safe
     end
   end
 

--- a/dashboard/app/controllers/passwords_controller.rb
+++ b/dashboard/app/controllers/passwords_controller.rb
@@ -49,7 +49,7 @@ class PasswordsController < Devise::PasswordsController
       notice = "Reset password link sent to user. You may also send the link directly:<br>"
       resource.child_users.each do |user|
         url = edit_password_url(user, reset_password_token: user.raw_token)
-        notice += "#{user.username}: <a href='#{url}'>#{url}</a><br>"
+        notice += "#{ActionController::Base.helpers.sanitize(user.username)}: <a href='#{url}'>#{url}</a><br>"
       end
       flash[:notice] = notice.html_safe
     end

--- a/dashboard/app/models/user.rb
+++ b/dashboard/app/models/user.rb
@@ -1474,6 +1474,7 @@ class User < ActiveRecord::Base
       raw, _enc = Devise.token_generator.generate(User, :reset_password_token)
       self.child_users = unique_users
       send_devise_notification(:reset_password_instructions, raw, {to: email})
+      return self
     rescue ArgumentError
       errors.add :base, I18n.t('password.reset_errors.invalid_email')
       return nil

--- a/dashboard/test/controllers/passwords_controller_test.rb
+++ b/dashboard/test/controllers/passwords_controller_test.rb
@@ -44,6 +44,20 @@ class PasswordsControllerTest < ActionController::TestCase
     assert flash[:notice].include? 'http://test.host/users/password/edit?reset_password_token='
   end
 
+  test "create with multiple associated accounts includes link for admin" do
+    sign_in create(:admin)
+
+    user1 = create :student, email: 'student1@email.com', parent_email: 'parent@email.com'
+    user2 = create :student, email: 'student2@email.com', parent_email: 'parent@email.com'
+    post :create, params: {user: {email: 'parent@email.com'}}
+
+    assert_redirected_to '/users/password/new'
+
+    assert flash[:notice].include? 'Reset password link sent to user. You may also send the link directly:'
+    assert flash[:notice].include? "#{user1.username}: <a href='http://test.host/users/password/edit?reset_password_token="
+    assert flash[:notice].include? "#{user2.username}: <a href='http://test.host/users/password/edit?reset_password_token="
+  end
+
   test "create with valid email that doesn't exist says it doesn't work" do
     post :create, params: {user: {email: 'asdasda@asdasd.asda'}}
 


### PR DESCRIPTION
If there were multiple user associated with an email and an admin tried to generate a password reset link, no links would show up in the reset password tool.

Now:
![Screenshot 2020-05-14 at 6 17 51 PM](https://user-images.githubusercontent.com/46464143/82001170-63b98580-960f-11ea-8a93-9050de23d99c.png)


<!-- ### Background -->
<!-- ### Privacy -->
<!-- ### Security -->
<!-- ### Caching -->
<!-- ### Deployment strategy -->
<!-- ### Future work -->

## Links

<!--
  Any relevant links to external resources; ie, specification documents, jira
  items, related PRs, honeybadger errors, etc
-->

- [jira](https://codedotorg.atlassian.net/browse/FND-1151)

## Testing story

manual testing and unit test

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
