### PR TITLE
Show 'unknown' for age range on project cards if the owner doesn't have a birthday

### DIFF
--- a/lib/cdo/user_helpers.rb
+++ b/lib/cdo/user_helpers.rb
@@ -84,6 +84,7 @@ SQL
   # Return the highest age range for the given birthday, e.g.
   # 18+, 13+, 8+ or 4+
   def self.age_range_from_birthday(birthday)
+    return "unknown" unless birthday
     age = age_from_birthday(birthday)
     age_cutoff = AGE_CUTOFFS.find {|cutoff| cutoff <= age}
     age_cutoff ? "#{age_cutoff}+" : nil


### PR DESCRIPTION
<img width="236" alt="Screen Shot 2020-05-13 at 6 37 32 PM" src="https://user-images.githubusercontent.com/12300669/82005129-746ef900-9619-11ea-91f3-fac9c4bf7025.png">

If a teacher adds a student to a section without indicating the student's age, and that student creates and publishes a project to the public project gallery, the gallery can fail to load because the API call to projects_list will have an error because we can't get the age range to display on the project card because the user doesn't have a birthday stored in our system. This scenario caused a [HoneyBadger Error ](https://app.honeybadger.io/projects/3240/faults/62845986). We [decided](https://codedotorg.slack.com/archives/CA3KCSGTD/p1589421512021100) the best way to prevent this from occurring is to show the user's age as "unknown" if they don't have a birthday.