### PR TITLE
Add lesson_extras alias for Section.stage_extras

### DIFF
--- a/dashboard/app/controllers/script_levels_controller.rb
+++ b/dashboard/app/controllers/script_levels_controller.rb
@@ -195,7 +195,7 @@ class ScriptLevelsController < ApplicationController
       end
       # This errs on the side of showing the warning by only if the script we are in
       # is the assigned script for the section
-      @show_stage_extras_warning = !@section&.stage_extras && @section&.script&.name == params[:script_id]
+      @show_stage_extras_warning = !@section&.lesson_extras && @section&.script&.name == params[:script_id]
     end
 
     # Explicitly return 404 here so that we don't get a 5xx in get_from_cache.

--- a/dashboard/app/helpers/script_levels_helper.rb
+++ b/dashboard/app/helpers/script_levels_helper.rb
@@ -13,7 +13,7 @@ module ScriptLevelsHelper
         enabled_for_stage = script_level.script.lesson_extras_available &&
           !script_level.end_of_script?
         enabled_for_user = current_user && current_user.section_for_script(script_level.script) &&
-            current_user.section_for_script(script_level.script).stage_extras
+            current_user.section_for_script(script_level.script).lesson_extras
         enabled_for_teacher = current_user.try(:teacher?) &&
             current_user.sections.where(
               script_id: script_level.script_id,

--- a/dashboard/app/models/sections/section.rb
+++ b/dashboard/app/models/sections/section.rb
@@ -254,7 +254,7 @@ class Section < ActiveRecord::Base
       numberOfStudents: num_students,
       linkToStudents: "#{base_url}#{id}/manage",
       code: code,
-      stage_extras: stage_extras,
+      stage_extras: lesson_extras,
       pairing_allowed: pairing_allowed,
       autoplay_enabled: autoplay_enabled,
       sharing_disabled: sharing_disabled?,

--- a/dashboard/app/models/sections/section.rb
+++ b/dashboard/app/models/sections/section.rb
@@ -65,6 +65,10 @@ class Section < ActiveRecord::Base
   has_many :section_hidden_stages
   has_many :section_hidden_scripts
 
+  # We want to replace uses of "stage" with "lesson" when possible, since "lesson" is the term used by curriculum team.
+  # Use an alias here since it's not worth renaming the column in the database. Use "lesson_extras" when possible.
+  alias_attribute :lesson_extras, :stage_extras
+
   # This list is duplicated as SECTION_LOGIN_TYPE in shared_constants.rb and should be kept in sync.
   LOGIN_TYPES = [
     LOGIN_TYPE_EMAIL = 'email'.freeze,

--- a/dashboard/app/models/user.rb
+++ b/dashboard/app/models/user.rb
@@ -1992,7 +1992,7 @@ class User < ActiveRecord::Base
     return true if teacher?
 
     sections_as_student.any? do |section|
-      section.script_id == script.id && section.stage_extras
+      section.script_id == script.id && section.lesson_extras
     end
   end
 

--- a/dashboard/test/controllers/api/v1/sections_controller_test.rb
+++ b/dashboard/test/controllers/api/v1/sections_controller_test.rb
@@ -352,7 +352,7 @@ class Api::V1::SectionsControllerTest < ActionController::TestCase
       }
 
       assert_equal desired_value, returned_json['stage_extras']
-      assert_equal desired_value, returned_section.stage_extras
+      assert_equal desired_value, returned_section.lesson_extras
     end
   end
 
@@ -363,7 +363,7 @@ class Api::V1::SectionsControllerTest < ActionController::TestCase
     }
 
     assert_equal false, returned_json['stage_extras']
-    assert_equal false, returned_section.stage_extras
+    assert_equal false, returned_section.lesson_extras
   end
 
   test 'cannot set stage_extras to an invalid value' do
@@ -376,7 +376,7 @@ class Api::V1::SectionsControllerTest < ActionController::TestCase
     # TODO: Better to fail here?
 
     assert_equal true, returned_json['stage_extras']
-    assert_equal true, returned_section.stage_extras
+    assert_equal true, returned_section.lesson_extras
   end
 
   test 'can set pairing_allowed to TRUE or FALSE during creation' do
@@ -581,7 +581,7 @@ class Api::V1::SectionsControllerTest < ActionController::TestCase
     assert_equal("My Section", section_with_script.name)
     assert_equal(Section::LOGIN_TYPE_PICTURE, section_with_script.login_type)
     assert_equal("K", section_with_script.grade)
-    assert_equal(false, section_with_script.stage_extras)
+    assert_equal(false, section_with_script.lesson_extras)
     assert_equal(true, section_with_script.pairing_allowed)
     assert_equal(false, section_with_script.hidden)
   end

--- a/dashboard/test/helpers/script_levels_helper_test.rb
+++ b/dashboard/test/helpers/script_levels_helper_test.rb
@@ -61,7 +61,7 @@ class ScriptLevelsHelperTest < ActionView::TestCase
     script = @section.script
     script_level = script.get_script_level_by_relative_position_and_puzzle_position 2, 9, false
     assert script_level.end_of_stage?, 'bad script_level selected for test'
-    @section.stage_extras = true
+    @section.lesson_extras = true
     @section.save
     response = {}
 
@@ -74,7 +74,7 @@ class ScriptLevelsHelperTest < ActionView::TestCase
     script = @section.script
     script_level = script.get_script_level_by_relative_position_and_puzzle_position 2, 9, false
     assert script_level.end_of_stage?, 'bad script_level selected for test'
-    @section.stage_extras = false
+    @section.lesson_extras = false
     @section.save
     response = {}
 
@@ -87,7 +87,7 @@ class ScriptLevelsHelperTest < ActionView::TestCase
     script = @section.script
     script_level = script.get_script_level_by_relative_position_and_puzzle_position 2, 8, false
     assert_equal false, script_level.end_of_stage?, 'bad script_level selected for test'
-    @section.stage_extras = true
+    @section.lesson_extras = true
     @section.save
     response = {}
 
@@ -99,7 +99,7 @@ class ScriptLevelsHelperTest < ActionView::TestCase
     script = @section.script
     script_level = script.get_script_level_by_relative_position_and_puzzle_position 2, 9, false
     assert script_level.end_of_stage?, 'bad script_level selected for test'
-    @section.stage_extras = true
+    @section.lesson_extras = true
     @section.save
     response = {}
 
@@ -124,7 +124,7 @@ class ScriptLevelsHelperTest < ActionView::TestCase
     refute response[:redirect].end_with?('extras')
     response = {}
 
-    @section.stage_extras = false
+    @section.lesson_extras = false
     @section.save
     stubs(:current_user).returns(@teacher)
     script_level_solved_response(response, script_level)


### PR DESCRIPTION
I'm not positive this is a good pattern, but it at least seems easy to undo. Thoughts?

## Testing story

* drone tests

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
