### PR TITLE
Deploy to levelbuilder: notify DOTD on exception

### DIFF
--- a/bin/cron/deploy_to_levelbuilder
+++ b/bin/cron/deploy_to_levelbuilder
@@ -107,7 +107,7 @@ def main
 rescue Exception => e
   ChatClient.message(
     'levelbuilder',
-    "EXCEPTION: #{e.message}",
+    "<@#{DevelopersTopic.dotd}> EXCEPTION: #{e.message}",
     color: 'red'
   )
   DevelopersTopic.set_dtl TOPIC_DTL_FAILED


### PR DESCRIPTION
Similar to https://github.com/code-dot-org/code-dot-org/pull/33972.  Notify the DOTD when an exception occurs when attempting to deploy to levelbuilder.
