### PR TITLE
Add maps.googleapis.com to startWebRequest()

### DIFF
--- a/dashboard/app/controllers/xhr_proxy_controller.rb
+++ b/dashboard/app/controllers/xhr_proxy_controller.rb
@@ -66,6 +66,7 @@ class XhrProxyController < ApplicationController
     images-api.nasa.gov
     isenseproject.org
     lakeside-cs.org
+    maps.googleapis.com
     opentdb.com
     pokeapi.co
     qrng.anu.edu.au


### PR DESCRIPTION
[Zendesk](https://codeorg.zendesk.com/agent/tickets/278644) request to add support for `maps.googleapis.com` to the allow list for `startWebRequest()`