### PR TITLE
Use channelId as element key instead of name

### DIFF
--- a/apps/src/code-studio/components/libraries/LibraryManagerDialog.jsx
+++ b/apps/src/code-studio/components/libraries/LibraryManagerDialog.jsx
@@ -274,7 +274,7 @@ export class LibraryManagerDialog extends React.Component {
     return projectLibraries.map(library => {
       return (
         <LibraryListItem
-          key={library.name}
+          key={library.channelId}
           library={library}
           onUpdate={
             updatedLibraryChannels.includes(library.channelId)

--- a/apps/test/unit/code-studio/components/libraries/libraryManagerDialogTest.js
+++ b/apps/test/unit/code-studio/components/libraries/libraryManagerDialogTest.js
@@ -120,7 +120,10 @@ describe('LibraryManagerDialog', () => {
     });
 
     it('displays LibraryListItem when the project contains libraries', () => {
-      getProjectLibrariesStub.returns([{name: 'first'}, {name: 'second'}]);
+      getProjectLibrariesStub.returns([
+        {name: 'first', channelId: 'abc123'},
+        {name: 'second', channelId: 'def456'}
+      ]);
       const wrapper = shallow(
         <LibraryManagerDialog onClose={() => {}} isOpen={true} />
       );
@@ -145,7 +148,10 @@ describe('LibraryManagerDialog', () => {
     });
 
     it('displays all libraries from the project and the class', () => {
-      getProjectLibrariesStub.returns([{name: 'first'}, {name: 'second'}]);
+      getProjectLibrariesStub.returns([
+        {name: 'first', channelId: 'abc123'},
+        {name: 'second', channelId: 'def456'}
+      ]);
       getClassLibrariesStub.callsFake(callback =>
         callback([{channel: '1'}, {channel: '2'}])
       );
@@ -207,7 +213,11 @@ describe('LibraryManagerDialog', () => {
     });
 
     it('removeLibrary calls setProjectLibrary without the given library', () => {
-      getProjectLibrariesStub.returns([{name: 'first'}, {name: 'second'}]);
+      const projectLibraries = [
+        {name: 'first', channelId: 'abc123'},
+        {name: 'second', channelId: 'def456'}
+      ];
+      getProjectLibrariesStub.returns(projectLibraries);
       let setProjectLibraries = sinon.spy(
         window.dashboard.project,
         'setProjectLibraries'
@@ -218,8 +228,8 @@ describe('LibraryManagerDialog', () => {
       wrapper.instance().onOpen();
       expect(setProjectLibraries.notCalled).to.be.true;
       wrapper.instance().removeLibrary('first');
-      expect(setProjectLibraries.withArgs([{name: 'second'}]).calledOnce).to.be
-        .true;
+      expect(setProjectLibraries.withArgs([projectLibraries[1]]).calledOnce).to
+        .be.true;
       window.dashboard.project.setProjectLibraries.restore();
     });
   });


### PR DESCRIPTION
Libraries can have the same name, so use `channelId` as the element key instead of the name.

## Links

- [CSP bug bash](https://docs.google.com/document/d/15GQ1ogPG4wzfnnAOOS7hHW4BTDwUBj41LjOr2hFZEgc/edit?ts=5ebef457#bookmark=id.676wpvg6menh)

## Testing story

<!--
  Does your change include appropriate tests?

  If so, please describe how the tests included in this PR are sufficient

  If not, please explain why this change does not need to be tested.
-->

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
