### PR TITLE
record progress on bubble choice parent after completing its sublevel

### DIFF
--- a/dashboard/app/controllers/activities_controller.rb
+++ b/dashboard/app/controllers/activities_controller.rb
@@ -188,13 +188,13 @@ class ActivitiesController < ApplicationController
       is_sublevel = !@script_level.levels.include?(@level)
 
       if is_sublevel
-        parent_level = @script_level.levels.find do |level|
-          level.sublevels.include?(@level)
+        bubble_choice_parent_level = @script_level.levels.find do |level|
+          level.is_a?(BubbleChoice) && level.sublevels.include?(@level)
         end
-        if parent_level && parent_level.is_a?(BubbleChoice)
+        if bubble_choice_parent_level
           User.track_level_progress(
             user_id: current_user.id,
-            level_id: parent_level.id,
+            level_id: bubble_choice_parent_level.id,
             script_id: @script_level.script_id,
             new_result: test_result,
             submitted: false,

--- a/dashboard/app/controllers/activities_controller.rb
+++ b/dashboard/app/controllers/activities_controller.rb
@@ -187,21 +187,21 @@ class ActivitiesController < ApplicationController
 
       is_sublevel = !@script_level.levels.include?(@level)
 
-      if is_sublevel
-        bubble_choice_parent_level = @script_level.levels.find do |level|
-          level.is_a?(BubbleChoice) && level.sublevels.include?(@level)
-        end
-        if bubble_choice_parent_level
-          User.track_level_progress(
-            user_id: current_user.id,
-            level_id: bubble_choice_parent_level.id,
-            script_id: @script_level.script_id,
-            new_result: test_result,
-            submitted: false,
-            level_source_id: nil,
-            pairing_user_ids: pairing_user_ids,
-            )
-        end
+      # The level might belong to more than one bubble choice parent level.
+      # Find the one that's in this script.
+      bubble_choice_parent_level = is_sublevel && @script_level.levels.find do |level|
+        level.is_a?(BubbleChoice) && level.sublevels.include?(@level)
+      end
+      if bubble_choice_parent_level
+        User.track_level_progress(
+          user_id: current_user.id,
+          level_id: bubble_choice_parent_level.id,
+          script_id: @script_level.script_id,
+          new_result: test_result,
+          submitted: false,
+          level_source_id: nil,
+          pairing_user_ids: pairing_user_ids,
+          )
       end
 
       # Make sure we don't log when @script_level is a multi-page assessment

--- a/dashboard/app/controllers/script_levels_controller.rb
+++ b/dashboard/app/controllers/script_levels_controller.rb
@@ -452,6 +452,9 @@ class ScriptLevelsController < ApplicationController
       level_id: @level.id
     )
 
+    # for level groups, @level and @callback point to the parent level, so we
+    # generate a url which can be used to report sublevel progress (after
+    # appending the sublevel id).
     if @level.game.level_group? || @level.try(:contained_levels).present?
       @sublevel_callback = milestone_script_level_url(
         user_id: current_user.try(:id) || 0,


### PR DESCRIPTION
## Background

* finishes [PLAT-121](https://codedotorg.atlassian.net/browse/PLAT-121)

## Description

in order to efficiently query progress for bubble choice levels, we want to store progress on the bubble choice level, rather than only on its sublevels.

## Testing story

Added a unit test to verify progress is being recorded in both places.

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
