### PR TITLE
Updated pre-work link in faciltator workshop reminder

### DIFF
--- a/dashboard/app/views/pd/workshop_mailer/_teacher_enrollment_details_facilitator.html.haml
+++ b/dashboard/app/views/pd/workshop_mailer/_teacher_enrollment_details_facilitator.html.haml
@@ -1,4 +1,4 @@
-- pre_work_url = 'https://docs.google.com/document/d/1mmBcMoRKO2TVxQSEEb-SxMnhuDZUkjE06tHa-8CGeyE/edit'
+- pre_work_url = 'https://bit.ly/summer-prep-sessions'
 - zoom_download_url = 'https://zoom.us/download'
 - learning_tips_url = 'https://docs.google.com/document/d/e/2PACX-1vQbiURoyzHZhWrmT8jbXq7QRiCMicUIO58EQQcw7aIPdZrxhfn1XP64djtg2TVFTsBNEUZnSYHSx4Lx/pub'
 - digital_digest_url = 'https://bit.ly/summer-prep-sessions'


### PR DESCRIPTION
The incorrect link was included in the facilitator reminder email. Updating that link.

Viewed updated mailer locally.