### PR TITLE
Gsheet export typo

### DIFF
--- a/bin/cron/teacher_applications_to_gdrive
+++ b/bin/cron/teacher_applications_to_gdrive
@@ -3,7 +3,7 @@ require_relative '../../lib/cdo/only_one'
 exit unless only_one_running?(__FILE__)
 
 require_relative '../../dashboard/config/environment'
-require 'cdo/google/sheets'
+require 'cdo/google/sheet'
 require 'honeybadger/ruby'
 
 # Writes teacher application data for this year into
@@ -72,7 +72,7 @@ end
 
 def main
   # Uses a Google Cloud service account to access Google Drive
-  sheet = Google::Sheet.new CDO.applications_2020_2021_gsheet_key
+  sheet = Google::Sheet.new '1Ne5hAh7Xu32EVsvJ_B_JKcymTU67HmSVckAWDogb24c'
   update_tabs(sheet)
   notify_of_external_sharing(sheet)
 end

--- a/bin/cron/teacher_applications_to_gdrive
+++ b/bin/cron/teacher_applications_to_gdrive
@@ -72,7 +72,7 @@ end
 
 def main
   # Uses a Google Cloud service account to access Google Drive
-  sheet = Google::Sheet.new '1Ne5hAh7Xu32EVsvJ_B_JKcymTU67HmSVckAWDogb24c'
+  sheet = Google::Sheet.new CDO.applications_2020_2021_gsheet_key
   update_tabs(sheet)
   notify_of_external_sharing(sheet)
 end


### PR DESCRIPTION
Singular `sheet` instead of `sheets` in new google sheet class 🤦 . Follow-up to https://github.com/code-dot-org/code-dot-org/pull/34779.

Tested running this script locally after making this change.