### PR TITLE
Script Edit: Do not show project widget settings unless lesson extras checked

### DIFF
--- a/apps/src/lib/script-editor/LessonExtrasEditor.jsx
+++ b/apps/src/lib/script-editor/LessonExtrasEditor.jsx
@@ -1,0 +1,114 @@
+import PropTypes from 'prop-types';
+import React from 'react';
+import $ from 'jquery';
+
+const styles = {
+  checkbox: {
+    margin: '0 0 0 7px'
+  }
+};
+
+/**
+ * Component for editing lesson extras settings on scripts
+ */
+export default class LessonExtrasEditor extends React.Component {
+  static propTypes = {
+    projectWidgetVisible: PropTypes.bool,
+    projectWidgetTypes: PropTypes.arrayOf(PropTypes.string),
+    lessonExtrasAvailable: PropTypes.bool
+  };
+
+  constructor(props) {
+    super(props);
+
+    this.state = {
+      lessonExtras: this.props.lessonExtrasAvailable
+    };
+  }
+
+  handleClearProjectWidgetSelectClick = () => {
+    $(this.projectWidgetSelect)
+      .children('option')
+      .removeAttr('selected', true);
+  };
+
+  render() {
+    return (
+      <div>
+        <h3> Lesson Extras Settings </h3>
+        <label>
+          Lesson Extras Available
+          <input
+            name="lesson_extras_available"
+            type="checkbox"
+            checked={this.state.lessonExtras}
+            style={styles.checkbox}
+            onChange={e => this.setState({lessonExtras: e.target.checked})}
+          />
+          <p>
+            If also enabled by the teacher, show the lesson extras page at the
+            end of each lesson.
+          </p>
+        </label>
+        {this.state.lessonExtras && (
+          <div>
+            <h4>Project widget options</h4>
+            <label>
+              Project widget visible
+              <input
+                name="project_widget_visible"
+                type="checkbox"
+                defaultChecked={this.props.projectWidgetVisible}
+                style={styles.checkbox}
+              />
+              <p>
+                If checked this script will have the projects widget (recent
+                projects and new project buttons) visible in lesson extras.
+              </p>
+            </label>
+            <label>
+              Project widget new project types
+              <p>
+                Select up to 4 project type options to appear in the 'Start a
+                new project' section. Select
+                <a onClick={this.handleClearProjectWidgetSelectClick}> none </a>
+                or shift-click or cmd-click to select multiple.
+              </p>
+              <select
+                name="project_widget_types[]"
+                multiple
+                defaultValue={this.props.projectWidgetTypes}
+                ref={select => (this.projectWidgetSelect = select)}
+              >
+                <option value="playlab">Play Lab</option>
+                <option value="playlab_k1">Play Lab K1</option>
+                <option value="artist">Artist</option>
+                <option value="artist_k1">Artist K1</option>
+                <option value="applab">App Lab</option>
+                <option value="gamelab">Game Lab</option>
+                <option value="weblab">Web Lab</option>
+                <option value="calc">Calc</option>
+                <option value="eval">Eval</option>
+                <option value="frozen">Frozen</option>
+                <option value="minecraft_adventurer">
+                  Minecraft Adventurer
+                </option>
+                <option value="minecraft_designer">Minecraft Designer</option>
+                <option value="minecraft_hero">Minecraft Hero</option>
+                <option value="starwars">Star Wars</option>
+                <option value="starwarsblocks">Star Wars Blocks</option>
+                <option value="flappy">Flappy</option>
+                <option value="sports">Sports</option>
+                <option value="basketball">Basketball</option>
+                <option value="bounce">Bounce</option>
+                <option value="infinity">Infinity</option>
+                <option value="iceage">Ice Age</option>
+                <option value="gumball">Gumball</option>
+              </select>
+            </label>
+          </div>
+        )}
+      </div>
+    );
+  }
+}

--- a/apps/src/lib/script-editor/LessonExtrasEditor.jsx
+++ b/apps/src/lib/script-editor/LessonExtrasEditor.jsx
@@ -52,7 +52,6 @@ export default class LessonExtrasEditor extends React.Component {
         </label>
         {this.state.lessonExtras && (
           <div>
-            <h4>Project widget options</h4>
             <label>
               Project widget visible
               <input

--- a/apps/src/lib/script-editor/ScriptEditor.jsx
+++ b/apps/src/lib/script-editor/ScriptEditor.jsx
@@ -14,6 +14,7 @@ import ResourceType, {
 } from '@cdo/apps/templates/courseOverview/resourceType';
 import {announcementShape} from '@cdo/apps/code-studio/scriptAnnouncementsRedux';
 import VisibleAndPilotExperiment from './VisibleAndPilotExperiment';
+import LessonExtrasEditor from './LessonExtrasEditor';
 
 const styles = {
   input: {
@@ -83,12 +84,6 @@ export default class ScriptEditor extends React.Component {
       curriculumUmbrella: this.props.curriculumUmbrella
     };
   }
-
-  handleClearProjectWidgetSelectClick = () => {
-    $(this.projectWidgetSelect)
-      .children('option')
-      .removeAttr('selected', true);
-  };
 
   handleClearSupportedLocalesSelectClick = () => {
     $(this.supportedLocaleSelect)
@@ -305,19 +300,11 @@ export default class ScriptEditor extends React.Component {
             this script.
           </p>
         </label>
-        <label>
-          Lesson Extras Available
-          <input
-            name="lesson_extras_available"
-            type="checkbox"
-            defaultChecked={this.props.lessonExtrasAvailable}
-            style={styles.checkbox}
-          />
-          <p>
-            If also enabled by the teacher, show the lesson extras page at the
-            end of each lesson.
-          </p>
-        </label>
+        <LessonExtrasEditor
+          lessonExtrasAvailable={this.props.lessonExtrasAvailable}
+          projectWidgetTypes={this.props.projectWidgetTypes}
+          projectWidgetVisible={this.props.projectWidgetVisible}
+        />
         <label>
           Verified Resources
           <input
@@ -403,60 +390,6 @@ export default class ScriptEditor extends React.Component {
             style={styles.input}
           />
         </label>
-
-        <h3>Project widget options</h3>
-        <label>
-          Project widget visible
-          <input
-            name="project_widget_visible"
-            type="checkbox"
-            defaultChecked={this.props.projectWidgetVisible}
-            style={styles.checkbox}
-          />
-          <p>
-            If checked this script will have the projects widget (recent
-            projects and new project buttons) visible in lesson extras.
-          </p>
-        </label>
-        <label>
-          Project widget new project types
-          <p>
-            Select up to 4 project type options to appear in the 'Start a new
-            project' section. Select
-            <a onClick={this.handleClearProjectWidgetSelectClick}> none </a>
-            or shift-click or cmd-click to select multiple.
-          </p>
-          <select
-            name="project_widget_types[]"
-            multiple
-            defaultValue={this.props.projectWidgetTypes}
-            ref={select => (this.projectWidgetSelect = select)}
-          >
-            <option value="playlab">Play Lab</option>
-            <option value="playlab_k1">Play Lab K1</option>
-            <option value="artist">Artist</option>
-            <option value="artist_k1">Artist K1</option>
-            <option value="applab">App Lab</option>
-            <option value="gamelab">Game Lab</option>
-            <option value="weblab">Web Lab</option>
-            <option value="calc">Calc</option>
-            <option value="eval">Eval</option>
-            <option value="frozen">Frozen</option>
-            <option value="minecraft_adventurer">Minecraft Adventurer</option>
-            <option value="minecraft_designer">Minecraft Designer</option>
-            <option value="minecraft_hero">Minecraft Hero</option>
-            <option value="starwars">Star Wars</option>
-            <option value="starwarsblocks">Star Wars Blocks</option>
-            <option value="flappy">Flappy</option>
-            <option value="sports">Sports</option>
-            <option value="basketball">Basketball</option>
-            <option value="bounce">Bounce</option>
-            <option value="infinity">Infinity</option>
-            <option value="iceage">Ice Age</option>
-            <option value="gumball">Gumball</option>
-          </select>
-        </label>
-
         <label>
           Supported locales
           <p>

--- a/apps/test/unit/lib/script-editor/LessonExtrasEditorTest.jsx
+++ b/apps/test/unit/lib/script-editor/LessonExtrasEditorTest.jsx
@@ -1,0 +1,35 @@
+import {expect} from 'chai';
+import React from 'react';
+import {mount} from 'enzyme';
+import LessonExtrasEditor from '@cdo/apps/lib/script-editor/LessonExtrasEditor';
+
+const DEFAULT_PROPS = {
+  projectWidgetVisible: false,
+  projectWidgetTypes: [],
+  lessonExtrasAvailable: false
+};
+
+describe('LessonExtrasEditor', () => {
+  it('project settings are not visible when lesson extras is not checked', () => {
+    const wrapper = mount(<LessonExtrasEditor {...DEFAULT_PROPS} />);
+    expect(wrapper.find('input[name="project_widget_visible"]')).to.have.length(
+      0
+    );
+    expect(
+      wrapper.find('select[name="project_widget_types[]"]')
+    ).to.have.length(0);
+  });
+
+  it('project settings are visible when lesson extras is checked', () => {
+    const wrapper = mount(
+      <LessonExtrasEditor {...DEFAULT_PROPS} lessonExtrasAvailable={true} />
+    );
+
+    expect(wrapper.find('input[name="project_widget_visible"]')).to.have.length(
+      1
+    );
+    expect(
+      wrapper.find('select[name="project_widget_types[]"]')
+    ).to.have.length(1);
+  });
+});


### PR DESCRIPTION
The project widget settings on the script edit page are only applicable if lesson extras are turned on for that script. This hides those settings unless lesson extras is checked.

I added a test for the new component I created that checks hiding and showing the fields based on checking and unchecking lesson extras available.

![lesson-extras-edit](https://user-images.githubusercontent.com/208083/82259716-07fe3d80-992a-11ea-95d9-c8320fffc291.gif)

Talked with the curriculum team and they were on board with the change.