### PR TITLE
Rename "stages" to "lessons" in i18n: Step 1

### DIFF
--- a/dashboard/app/dsl/script_dsl.rb
+++ b/dashboard/app/dsl/script_dsl.rb
@@ -280,7 +280,13 @@ class ScriptDSL < BaseDSL
       i18n_lesson_group_strings[lesson_group[:key]] = {'display_name' => lesson_group[:display_name]}
     end
 
-    {@name => {'stages' => i18n_stage_strings, 'lesson_groups' => i18n_lesson_group_strings}}
+    # temporarily include "stage" strings under both "stages" and "lessons"
+    # while we transition from the former term to the latter.
+    {@name => {
+      'stages' => i18n_stage_strings,
+      'lessons' => i18n_stage_strings,
+      'lesson_groups' => i18n_lesson_group_strings
+    }}
   end
 
   def self.parse_file(filename, name = nil)

--- a/dashboard/app/dsl/script_dsl.rb
+++ b/dashboard/app/dsl/script_dsl.rb
@@ -282,6 +282,7 @@ class ScriptDSL < BaseDSL
 
     # temporarily include "stage" strings under both "stages" and "lessons"
     # while we transition from the former term to the latter.
+    # TODO FND-1122
     {@name => {
       'stages' => i18n_stage_strings,
       'lessons' => i18n_stage_strings,

--- a/dashboard/app/models/script.rb
+++ b/dashboard/app/models/script.rb
@@ -1320,14 +1320,20 @@ class Script < ActiveRecord::Base
   def self.update_i18n(existing_i18n, lessons_i18n, script_name = '', metadata_i18n = {})
     if metadata_i18n != {}
       stage_descriptions = metadata_i18n.delete(:stage_descriptions)
+      # temporarily include "stage" strings under both "stages" and "lessons"
+      # while we transition from the former term to the latter.
+      # TODO FND-1122
       metadata_i18n['stages'] = {}
+      metadata_i18n['lessons'] = {}
       unless stage_descriptions.nil?
         JSON.parse(stage_descriptions).each do |stage|
           stage_name = stage['name']
-          metadata_i18n['stages'][stage_name] = {
+          stage_data = {
             'description_student' => stage['descriptionStudent'],
             'description_teacher' => stage['descriptionTeacher']
           }
+          metadata_i18n['stages'][stage_name] = stage_data
+          metadata_i18n['lessons'][stage_name] = stage_data
         end
       end
       metadata_i18n = {'en' => {'data' => {'script' => {'name' => {script_name => metadata_i18n.to_h}}}}}
@@ -1488,13 +1494,19 @@ class Script < ActiveRecord::Base
       [key, I18n.t("data.script.name.#{name}.#{key}", default: '')]
     end.to_h
 
+    # temporarily include "stage" strings under both "stages" and "lessons"
+    # while we transition from the former term to the latter.
+    # TODO FND-1122
     data['stages'] = {}
+    data['lessons'] = {}
     lessons.each do |stage|
-      data['stages'][stage.name] = {
+      stage_data = {
         'name' => stage.name,
         'description_student' => (I18n.t "data.script.name.#{name}.stages.#{stage.name}.description_student", default: ''),
         'description_teacher' => (I18n.t "data.script.name.#{name}.stages.#{stage.name}.description_teacher", default: '')
       }
+      data['stages'][stage.name] = stage_data
+      data['lessons'][stage.name] = stage_data
     end
 
     {'en' => {'data' => {'script' => {'name' => {new_name => data}}}}}

--- a/dashboard/config/locales/scripts.en.yml
+++ b/dashboard/config/locales/scripts.en.yml
@@ -65,6 +65,43 @@ en:
             The Big Event:
               name: The Big Event
           lesson_groups: {}
+          lessons:
+            Happy Maps:
+              name: Happy Maps
+            Move it, Move it:
+              name: Move it, Move it
+            'Jigsaw: Learn to drag and drop':
+              name: 'Jigsaw: Learn to drag and drop'
+            'Maze: Sequence':
+              name: 'Maze: Sequence'
+            'Maze: Debugging':
+              name: 'Maze: Debugging'
+            'Real-life Algorithms: Plant a Seed':
+              name: 'Real-life Algorithms: Plant a Seed'
+            'Bee: Sequence':
+              name: 'Bee: Sequence'
+            'Artist: Sequence':
+              name: 'Artist: Sequence'
+            Building a Foundation:
+              name: Building a Foundation
+            'Artist: Shapes':
+              name: 'Artist: Shapes'
+            Spelling Bee:
+              name: Spelling Bee
+            Getting Loopy:
+              name: Getting Loopy
+            'Maze: Loops':
+              name: 'Maze: Loops'
+            'Bee: Loops':
+              name: 'Bee: Loops'
+            The Big Event:
+              name: The Big Event
+            'Studio: Create a Story':
+              name: 'Studio: Create a Story'
+            Going Places Safely:
+              name: Going Places Safely
+            'Artist: Loops':
+              name: 'Artist: Loops'
         course2:
           title: Course 2
           description: Start with Course 2 for students who can read and have no prior programming experience. In this course students will create programs to solve problems and develop interactive games or stories they can share. Recommended for grades 2-5.
@@ -110,6 +147,45 @@ en:
             Your Digital Footprint:
               name: Your Digital Footprint
           lesson_groups: {}
+          lessons:
+            Graph Paper Programming:
+              name: Graph Paper Programming
+            'Real-life Algorithms: Paper Planes':
+              name: 'Real-life Algorithms: Paper Planes'
+            'Maze: Sequence':
+              name: 'Maze: Sequence'
+            'Artist: Sequence':
+              name: 'Artist: Sequence'
+            Getting Loopy:
+              name: Getting Loopy
+            'Maze: Loops':
+              name: 'Maze: Loops'
+            'Artist: Loops':
+              name: 'Artist: Loops'
+            'Bee: Loops':
+              name: 'Bee: Loops'
+            Relay programming:
+              name: Relay programming
+            'Bee: Debugging':
+              name: 'Bee: Debugging'
+            'Artist: Debugging':
+              name: 'Artist: Debugging'
+            Conditionals:
+              name: Conditionals
+            'Bee: Conditionals':
+              name: 'Bee: Conditionals'
+            Binary Bracelets:
+              name: Binary Bracelets
+            The Big Event:
+              name: The Big Event
+            Flappy:
+              name: Flappy
+            'Studio: Create a Story':
+              name: 'Studio: Create a Story'
+            Your Digital Footprint:
+              name: Your Digital Footprint
+            'Artist: Nested Loops':
+              name: 'Artist: Nested Loops'
         course3:
           title: Course 3
           description: Course 3 is designed for students who have taken Course 2. Students will delve deeper into programming topics introduced in previous courses to create flexible solutions to more complex problems. By the end of this course, students create interactive stories and games they can share with anyone. Recommended for grades 4-5.
@@ -159,6 +235,49 @@ en:
             'Studio: Create a Story':
               name: 'Play Lab: Create a Story'
           lesson_groups: {}
+          lessons:
+            Computational Thinking:
+              name: Computational Thinking
+            Maze:
+              name: Maze
+            Artist:
+              name: Artist
+            Functional Suncatchers:
+              name: Functional Suncatchers
+            'Artist: Functions':
+              name: 'Artist: Functions'
+            'Bee: Functions':
+              name: 'Bee: Functions'
+            'Bee: Conditionals':
+              name: 'Bee: Conditionals'
+            'Maze: Conditionals':
+              name: 'Maze: Conditionals'
+            Songwriting:
+              name: Songwriting
+            Dice Race:
+              name: Dice Race
+            'Artist: Nested Loops':
+              name: 'Artist: Nested Loops'
+            'Farmer: While Loops':
+              name: 'Farmer: While Loops'
+            'Bee: Nested Loops':
+              name: 'Bee: Nested Loops'
+            'Bee: Debugging':
+              name: 'Bee: Debugging'
+            Bounce:
+              name: Bounce
+            'Studio: Create a Story':
+              name: 'Studio: Create a Story'
+            'Studio: Create a Game':
+              name: 'Studio: Create a Game'
+            Internet:
+              name: Internet
+            Crowdsourcing:
+              name: Crowdsourcing
+            Digital Citizenship:
+              name: Digital Citizenship
+            'Artist: Patterns':
+              name: 'Artist: Patterns'
         playlab:
           title: Play Lab
           description: Create a story or make a game with Play Lab!
@@ -167,6 +286,9 @@ en:
             Play Lab:
               name: Play Lab
           lesson_groups: {}
+          lessons:
+            Play Lab:
+              name: Play Lab
         artist:
           title: Artist
           description: Draw cool pictures and designs with the Artist!
@@ -175,6 +297,9 @@ en:
             Artist:
               name: Artist
           lesson_groups: {}
+          lessons:
+            Artist:
+              name: Artist
         hourofcode:
           title: Classic Maze
           description: Try the basics of computer science with characters from Angry Birds, Plants vs. Zombies, and Scrat from Ice Age!
@@ -184,6 +309,9 @@ en:
               name: Maze
           description_audience: ''
           lesson_groups: {}
+          lessons:
+            Maze:
+              name: Maze
         frozen:
           title: Code with Anna and Elsa
           description: Let's use code to join Anna and Elsa as they explore the magic and beauty of ice. You will create snowflakes and patterns as you ice-skate and make a winter wonderland that you can then share with your friends!
@@ -192,6 +320,9 @@ en:
             Artist:
               name: Artist
           lesson_groups: {}
+          lessons:
+            Artist:
+              name: Artist
         course4:
           title: Course 4
           description: Course 4 is designed for students who have taken Courses 2 and 3. Students will learn how to tackle puzzles with increased complexity as they learn how to combine several concepts when solving each challenge. By the time this Course is completed, students will be creating programs that let them showcase multiple skills, including for loops and functions with parameters. Recommended for grades 4-8.
@@ -243,6 +374,51 @@ en:
             'Unplugged: Tangrams':
               name: 'Unplugged: Tangrams'
           lesson_groups: {}
+          lessons:
+            'Unplugged: Tangrams':
+              name: 'Unplugged: Tangrams'
+            Maze and Bee:
+              name: Maze and Bee
+            Artist:
+              name: Artist
+            'Unplugged: Envelope Variables':
+              name: 'Unplugged: Envelope Variables'
+            'Unplugged: Madlibs':
+              name: 'Unplugged: Madlibs'
+            'Artist: Variables':
+              name: 'Artist: Variables'
+            'Play Lab: Variables':
+              name: 'Play Lab: Variables'
+            'Unplugged: For Loop Fun':
+              name: 'Unplugged: For Loop Fun'
+            'Bee: For Loops':
+              name: 'Bee: For Loops'
+            'Artist: For Loops':
+              name: 'Artist: For Loops'
+            'Play Lab: For Loops':
+              name: 'Play Lab: For Loops'
+            'Artist: Functions':
+              name: 'Artist: Functions'
+            'Unplugged: Songwriting with Parameters':
+              name: 'Unplugged: Songwriting with Parameters'
+            'Artist: Functions with Parameters':
+              name: 'Artist: Functions with Parameters'
+            'Play Lab: Functions with Parameters':
+              name: 'Play Lab: Functions with Parameters'
+            'Bee: Functions with Parameters':
+              name: 'Bee: Functions with Parameters'
+            'Unplugged: Binary':
+              name: 'Unplugged: Binary'
+            Artist Binary:
+              name: Artist Binary
+            Super Challenge - Variables:
+              name: Super Challenge - Variables
+            Super Challenge - For Loops:
+              name: Super Challenge - For Loops
+            Super Challenge - Functions and Parameters:
+              name: Super Challenge - Functions and Parameters
+            Extreme Challenge - Comprehensive:
+              name: Extreme Challenge - Comprehensive
         Course4pre:
           title: Course 4 Prerequisite
           description: A brief rampup of concepts for students who have not taken Course 2 and 3.
@@ -268,6 +444,25 @@ en:
             'Maze: Sequence':
               name: 'Maze: Sequence'
           lesson_groups: {}
+          lessons:
+            'Maze: Sequence':
+              name: 'Maze: Sequence'
+            'Artist: Sequence':
+              name: 'Artist: Sequence'
+            'Artist: Loops':
+              name: 'Artist: Loops'
+            'Bee: Conditionals':
+              name: 'Bee: Conditionals'
+            'Artist: Nested Loops':
+              name: 'Artist: Nested Loops'
+            'Farmer: While Loops':
+              name: 'Farmer: While Loops'
+            'Bee: Nested Loops':
+              name: 'Bee: Nested Loops'
+            'Artist: Functions':
+              name: 'Artist: Functions'
+            'Bee: Debugging':
+              name: 'Bee: Debugging'
         usability:
           title: Usability Testing
           description: A selection of Course 4 levels for usability testing.
@@ -285,6 +480,17 @@ en:
             Variables:
               name: Variables
           lesson_groups: {}
+          lessons:
+            Intro:
+              name: Intro
+            Variables:
+              name: Variables
+            For Loops:
+              name: For Loops
+            Functions and Functions with Parameters:
+              name: Functions and Functions with Parameters
+            Binary:
+              name: Binary
         algebra:
           title: Computer Science in Algebra
           description: Learn Functional Programming through Algebra.
@@ -332,6 +538,47 @@ en:
             'Unplugged: Video Games and Coordinate Planes':
               name: 'Unplugged: Video Games and Coordinate Planes'
           lesson_groups: {}
+          lessons:
+            'Unplugged: Video Games and Coordinate Planes':
+              name: 'Unplugged: Video Games and Coordinate Planes'
+            'Calc: Evaluation Blocks':
+              name: 'Calc: Evaluation Blocks'
+            'Eval: Strings and Images':
+              name: 'Eval: Strings and Images'
+            'Unplugged: Contracts':
+              name: 'Unplugged: Contracts'
+            'Eval: Writing Contracts':
+              name: 'Eval: Writing Contracts'
+            'Calc: Defining Variables':
+              name: 'Calc: Defining Variables'
+            'Play Lab: Defining Variables (Big Game)':
+              name: 'Play Lab: Defining Variables (Big Game)'
+            'Eval: Defining Functions':
+              name: 'Eval: Defining Functions'
+            'Unplugged: The Design Recipe':
+              name: 'Unplugged: The Design Recipe'
+            'Play Lab: Defining Functions':
+              name: 'Play Lab: Defining Functions'
+            'Eval: Functions':
+              name: 'Eval: Functions'
+            'Play Lab: Animation (Big Game)':
+              name: 'Play Lab: Animation (Big Game)'
+            'Unplugged: Booleans':
+              name: 'Unplugged: Booleans'
+            'Eval: Boolean Operators':
+              name: 'Eval: Boolean Operators'
+            'Play Lab: Booleans':
+              name: 'Play Lab: Booleans'
+            'Play Lab: Boolean (Big Game)':
+              name: 'Play Lab: Boolean (Big Game)'
+            'Unplugged: Conditionals and Piecewise Functions':
+              name: 'Unplugged: Conditionals and Piecewise Functions'
+            'Eval: Conditionals':
+              name: 'Eval: Conditionals'
+            'Unplugged: Collision Detection and the Distance Formula':
+              name: 'Unplugged: Collision Detection and the Distance Formula'
+            'Play Lab: Collision Detection (Big Game)':
+              name: 'Play Lab: Collision Detection (Big Game)'
         infinity:
           title: Disney Infinity Play Lab
           description: Use Play Lab to create a story or game starring Disney Infinity characters.
@@ -340,6 +587,9 @@ en:
             Infinity:
               name: Infinity
           lesson_groups: {}
+          lessons:
+            Infinity:
+              name: Infinity
         algebrademo:
           title: Algebra Demo
           description: A handful of puzzles to demonstrate the environment and programming language used in Code.org CS in Algebra
@@ -356,6 +606,17 @@ en:
             The Design Recipe:
               name: The Design Recipe
           lesson_groups: {}
+          lessons:
+            Evaluation Blocks:
+              name: Evaluation Blocks
+            Making Pictures:
+              name: Making Pictures
+            Defining Variables:
+              name: Defining Variables
+            Defining Simple Functions:
+              name: Defining Simple Functions
+            The Design Recipe:
+              name: The Design Recipe
         K5PD:
           title: K5 Professional Development (old)
           description: 'For the latest online Professional Development resources for elementary school teachers here: https://studio.code.org/s/k5-onlinepd'
@@ -389,6 +650,7 @@ en:
             new stage:
               name: new stage
           lesson_groups: {}
+          lessons: {}
         netsim:
           title: Internet Simulator
           description: Learn about how the Internet works.
@@ -416,6 +678,27 @@ en:
             Routers and addresses:
               name: Routers and addresses
           lesson_groups: {}
+          lessons:
+            Overview and Setup Instructions:
+              name: Overview and Setup Instructions
+            Peer to Peer - Sending Bits on a Shared Wire:
+              name: Peer to Peer - Sending Bits on a Shared Wire
+            Peer to Peer - Sending Numbers:
+              name: Peer to Peer - Sending Numbers
+            Peer to Peer - Sending Ascii:
+              name: Peer to Peer - Sending Ascii
+            Broadcasting messages:
+              name: Broadcasting messages
+            Routers and addresses:
+              name: Routers and addresses
+            Packets and Reliability:
+              name: Packets and Reliability
+            Manual DNS:
+              name: Manual DNS
+            Automatic DNS node:
+              name: Automatic DNS node
+            Internet Simulator Freeplay:
+              name: Internet Simulator Freeplay
         pixelation:
           title: Pixelation
           description: Create images with bits and bytes.
@@ -433,6 +716,17 @@ en:
             Color Pixelation Tutorial:
               name: Color Pixelation Tutorial
           lesson_groups: {}
+          lessons:
+            Black & White Pixelation Tutorial:
+              name: Black & White Pixelation Tutorial
+            Black & White Pixelation Freeplay:
+              name: Black & White Pixelation Freeplay
+            Color Pixelation Tutorial:
+              name: Color Pixelation Tutorial
+            Color Pixelation Examples:
+              name: Color Pixelation Examples
+            Color Pixelation Freeplay:
+              name: Color Pixelation Freeplay
         20-hour:
           title: Accelerated Intro to CS Course
           description: This 20-hour course covers the core computer science and programming concepts in courses 2-4. The course is designed for use with ages 10-18. Check out courses 2-4 for a more complete experience!
@@ -480,6 +774,47 @@ en:
             Wrap-up:
               name: Wrap-up
           lesson_groups: {}
+          lessons:
+            Introduction to Computer Science:
+              name: Introduction to Computer Science
+            The Maze:
+              name: The Maze
+            Computational Thinking:
+              name: Computational Thinking
+            Graph Paper Programming:
+              name: Graph Paper Programming
+            The Artist:
+              name: The Artist
+            Algorithms:
+              name: Algorithms
+            The Artist 2:
+              name: The Artist 2
+            Functions:
+              name: Functions
+            The Farmer:
+              name: The Farmer
+            Conditionals:
+              name: Conditionals
+            The Artist 3:
+              name: The Artist 3
+            Song Writing:
+              name: Song Writing
+            The Farmer 2:
+              name: The Farmer 2
+            Abstraction:
+              name: Abstraction
+            The Artist 4:
+              name: The Artist 4
+            Relay Programming:
+              name: Relay Programming
+            The Farmer 3:
+              name: The Farmer 3
+            The Internet:
+              name: The Internet
+            The Artist 5:
+              name: The Artist 5
+            Wrap-up:
+              name: Wrap-up
         edit-code:
           title: Edit Code
           description: Edit Code
@@ -497,6 +832,17 @@ en:
             The Maze:
               name: The Maze
           lesson_groups: {}
+          lessons:
+            The Maze:
+              name: The Maze
+            Applab:
+              name: Applab
+            The Artist:
+              name: The Artist
+            Play Lab:
+              name: Play Lab
+            Hoc2015 Blockly:
+              name: Hoc2015 Blockly
         events:
           title: Events
           description: Events
@@ -512,6 +858,15 @@ en:
             Studio:
               name: Studio
           lesson_groups: {}
+          lessons:
+            Bounce:
+              name: Bounce
+            Studio:
+              name: Studio
+            Calc:
+              name: Calc
+            Eval:
+              name: Eval
         flappy:
           title: Flappy Code
           description: Wanna write your own game in less than 10 minutes? Try our Flappy Code tutorial!
@@ -521,6 +876,9 @@ en:
             Flappy Code:
               name: Flappy Code
           lesson_groups: {}
+          lessons:
+            Flappy Code:
+              name: Flappy Code
         jigsaw:
           title: Jigsaw
           description: Try our Jigsaw tutorial.
@@ -530,6 +888,9 @@ en:
             Jigsaw:
               name: Jigsaw
           lesson_groups: {}
+          lessons:
+            Jigsaw:
+              name: Jigsaw
         step:
           title: Step
           description: Step tutorial
@@ -539,6 +900,9 @@ en:
             Step:
               name: Step
           lesson_groups: {}
+          lessons:
+            Step:
+              name: Step
         Hour of Code:
           title: Hour of Code 2013
           description: Try the basics of computer science with characters from Angry Birds and Plants vs. Zombies!
@@ -548,6 +912,9 @@ en:
             Hour of Code 2013:
               name: Hour of Code 2013
           lesson_groups: {}
+          lessons:
+            Hour of Code 2013:
+              name: Hour of Code 2013
         CodeStudioPuzzleChallenge:
           title: Code Studio Puzzle Challenge
           description: Try out these fun coding puzzles. Do your best!
@@ -557,6 +924,9 @@ en:
             Puzzles:
               name: Puzzles
           lesson_groups: {}
+          lessons:
+            Puzzles:
+              name: Puzzles
         Tutorial Video - Code Studio Puzzle Challenge:
           title: Tutorial - Code Studio Puzzle Challenge
           description: Try out these fun coding puzzles. Do your best!
@@ -566,6 +936,9 @@ en:
             Puzzles:
               name: Puzzles
           lesson_groups: {}
+          lessons:
+            Puzzles:
+              name: Puzzles
         cspunit1:
           title: "(old) CS Principles Unit 1 - Digital Information"
           description: This unit explores the technical challenges and questions that arise from the need to represent digital information in computers and transfer it between people and computational devices. This unit is a pilot version and is no longer supported or updated. You can find the new units at code.org/educate/csp.
@@ -607,6 +980,41 @@ en:
               name: Text Compression
           description_audience: ''
           lesson_groups: {}
+          lessons:
+            Personal Innovations:
+              name: Personal Innovations
+            Sending Binary Messages:
+              name: Sending Binary Messages
+            Sending Complex Messages:
+              name: Sending Complex Messages
+            Sending Binary Messages with the Internet Simulator:
+              name: Sending Binary Messages with the Internet Simulator
+            Sending Bits in the Real World:
+              name: Sending Bits in the Real World
+            Number Systems:
+              name: Number Systems
+            Binary Numbers:
+              name: Binary Numbers
+            Sending Numbers:
+              name: Sending Numbers
+            Encoding Numbers in the Real World:
+              name: Encoding Numbers in the Real World
+            Encoding and Sending Text:
+              name: Encoding and Sending Text
+            Sending Formatted Text:
+              name: Sending Formatted Text
+            Bytes and File Sizes:
+              name: Bytes and File Sizes
+            Text Compression:
+              name: Text Compression
+            Encoding B&W Images:
+              name: Encoding B&W Images
+            Encoding Color Images:
+              name: Encoding Color Images
+            Lossy Compression and File Formats:
+              name: Lossy Compression and File Formats
+            Encode a Complex Thing:
+              name: Encode a Complex Thing
         algebraPD:
           title: Computer Science in Algebra PD
           description: 'Phase 1: Online Introduction'
@@ -626,6 +1034,19 @@ en:
             Why Computer Science belongs in Algebra:
               name: Why Computer Science belongs in Algebra
           lesson_groups: {}
+          lessons:
+            Introduction to PD:
+              name: Introduction to PD
+            Course Overview:
+              name: Course Overview
+            Why Computer Science belongs in Algebra:
+              name: Why Computer Science belongs in Algebra
+            Evaluation Blocks:
+              name: Evaluation Blocks
+            Teacher Dashboard:
+              name: Teacher Dashboard
+            Preparing for in-person PD:
+              name: Preparing for in-person PD
         algPDmiami:
           title: Computer Science in Algebra PD
           description: Teach Algebra through Functional Programming
@@ -655,6 +1076,29 @@ en:
             Your Game - Player Movement:
               name: Your Game - Player Movement
           lesson_groups: {}
+          lessons:
+            Evaluation Blocks:
+              name: Evaluation Blocks
+            Strings and Images:
+              name: Strings and Images
+            Rocket-Height:
+              name: Rocket-Height
+            Design Recipe Practice:
+              name: Design Recipe Practice
+            Your Game - Animation:
+              name: Your Game - Animation
+            Booleans:
+              name: Booleans
+            Sam the Bat:
+              name: Sam the Bat
+            Your Game - Booleans:
+              name: Your Game - Booleans
+            Luigi's Pizza:
+              name: Luigi's Pizza
+            Your Game - Player Movement:
+              name: Your Game - Player Movement
+            Your Game - Collision Detection:
+              name: Your Game - Collision Detection
         text-compression:
           title: Text Compression
           description: Compress text by identifying repeated patterns.
@@ -664,6 +1108,9 @@ en:
             Text Compression:
               name: Text Compression
           lesson_groups: {}
+          lessons:
+            Text Compression:
+              name: Text Compression
         CSPPD:
           title: Computer Science Principles PD
           description: 'Phase 1: Online Introduction for CSP'
@@ -685,6 +1132,21 @@ en:
               name: What is CSP?
           description_audience: ''
           lesson_groups: {}
+          lessons:
+            Introduction to PD:
+              name: Introduction to PD
+            What is CSP?:
+              name: What is CSP?
+            Exploring CSP Instructional Materials:
+              name: Exploring CSP Instructional Materials
+            Impact of Computer Science:
+              name: Impact of Computer Science
+            Growth Mindset:
+              name: Growth Mindset
+            Teaching Strategies:
+              name: Teaching Strategies
+            Preparing for in-person PD:
+              name: Preparing for in-person PD
         CSPLessonSamples:
           title: CSP Lesson Samples
           description: Lesson samples for CSP
@@ -696,6 +1158,11 @@ en:
             Lesson 15:
               name: Lesson 15
           lesson_groups: {}
+          lessons:
+            Lesson 14:
+              name: Lesson 14
+            Lesson 15:
+              name: Lesson 15
         ECSPD:
           title: Exploring Computer Science PD
           description: 'Phase 1: Online Introduction'
@@ -714,6 +1181,19 @@ en:
             What is ECS?:
               name: What is ECS?
           lesson_groups: {}
+          lessons:
+            Introduction to PD:
+              name: Introduction to PD
+            What is ECS?:
+              name: What is ECS?
+            Impact of Computer Science:
+              name: Impact of Computer Science
+            Growth Mindset:
+              name: Growth Mindset
+            Teaching Strategies:
+              name: Teaching Strategies
+            Preparing for in-person PD:
+              name: Preparing for in-person PD
         sciencePD:
           title: Computer Science in Science PD
           description: 'Phase 1: Online Introduction'
@@ -745,6 +1225,31 @@ en:
             What to Expect:
               name: What to Expect
           lesson_groups: {}
+          lessons:
+            Introduction to PD:
+              name: Introduction to PD
+            What to Expect:
+              name: What to Expect
+            Introduction to Complex Adaptive Systems:
+              name: Introduction to Complex Adaptive Systems
+            Introduction to Computational Science:
+              name: Introduction to Computational Science
+            Agent Based Modeling of Complex Adaptive Systems:
+              name: Agent Based Modeling of Complex Adaptive Systems
+            Using Computer Models in Science:
+              name: Using Computer Models in Science
+            Using Models in the Classroom:
+              name: Using Models in the Classroom
+            Dispositions and Classroom Culture:
+              name: Dispositions and Classroom Culture
+            Computational Thinking And The Framework For K-12 Science Education:
+              name: Computational Thinking And The Framework For K-12 Science Education
+            Introduction to StarLogo Nova:
+              name: Introduction to StarLogo Nova
+            The Tutorial:
+              name: The Tutorial
+            Post-Survey:
+              name: Post-Survey
         rbo-reference:
           title: rbo-reference
           description: rbo-reference
@@ -754,6 +1259,9 @@ en:
             reference:
               name: reference
           lesson_groups: {}
+          lessons:
+            reference:
+              name: reference
         Test Wednesday:
           title: Test Wednesday
           description: Test Wednesday
@@ -762,6 +1270,9 @@ en:
             PDK5 Intro:
               name: PDK5 Intro
           lesson_groups: {}
+          lessons:
+            PDK5 Intro:
+              name: PDK5 Intro
         cspunit3:
           title: "(old) CS Principles Unit 3 - Programming"
           description: This unit introduces the foundational concepts of computer programming, which unlocks the ability to make rich, interactive apps. This course uses JavaScript as the programming language, and App Lab as the programming environment to build apps, but the concepts learned in these lessons span all programming languages and tools.
@@ -827,6 +1338,65 @@ en:
             While Loops:
               name: While Loops
           lesson_groups: {}
+          lessons:
+            The Need For Programming Languages:
+              name: The Need For Programming Languages
+            Using Simple Commands:
+              name: Using Simple Commands
+            Creating Functions:
+              name: Creating Functions
+            Functions and Top-Down Design:
+              name: Functions and Top-Down Design
+            APIs and Function Parameters:
+              name: APIs and Function Parameters
+            Creating functions with Parameters:
+              name: Creating functions with Parameters
+            Looping and Random Numbers:
+              name: Looping and Random Numbers
+            Practice PT - Design a Digital Scene:
+              name: Practice PT - Design a Digital Scene
+            Events Unplugged:
+              name: Events Unplugged
+            Event-Driven Programming and Debugging:
+              name: Event-Driven Programming and Debugging
+            Beyond Buttons Toward Apps:
+              name: Beyond Buttons Toward Apps
+            Introducing Design Mode:
+              name: Introducing Design Mode
+            Multi-screen Apps:
+              name: Multi-screen Apps
+            Controlling Memory with Variables:
+              name: Controlling Memory with Variables
+            Using Variables in Apps:
+              name: Using Variables in Apps
+            User Input and Strings:
+              name: User Input and Strings
+            Introduction to Digital Assistants:
+              name: Introduction to Digital Assistants
+            Understanding Program Flow and Logic:
+              name: Understanding Program Flow and Logic
+            Introduction to Conditional Logic:
+              name: Introduction to Conditional Logic
+            Compound Conditional Logic:
+              name: Compound Conditional Logic
+            Digital Assistant Project:
+              name: Digital Assistant Project
+            While Loops:
+              name: While Loops
+            Loops and Simulations:
+              name: Loops and Simulations
+            Introduction to Arrays:
+              name: Introduction to Arrays
+            Image Scroller with Key Events:
+              name: Image Scroller with Key Events
+            Processing Arrays:
+              name: Processing Arrays
+            Functions with Return Values:
+              name: Functions with Return Values
+            Canvas and Arrays in Apps:
+              name: Canvas and Arrays in Apps
+            'Practice PT: Create':
+              name: 'Practice PT: Create'
         algebraPD3:
           title: Phase 3 PD
           description: Teach Algebra through block-based Functional Programming
@@ -850,6 +1420,23 @@ en:
             The Design Recipe:
               name: The Design Recipe
           lesson_groups: {}
+          lessons:
+            Course Overview:
+              name: Course Overview
+            Computer Science Pedagogy:
+              name: Computer Science Pedagogy
+            Teacher Dashboard:
+              name: Teacher Dashboard
+            Evaluation Blocks:
+              name: Evaluation Blocks
+            Strings and Images:
+              name: Strings and Images
+            The Design Recipe:
+              name: The Design Recipe
+            The Big Game:
+              name: The Big Game
+            Next Steps:
+              name: Next Steps
         ECSPD-NexTech:
           title: Exploring Computer Science PD
           description: 'Phase 1: Online Introduction'
@@ -869,6 +1456,19 @@ en:
             What is ECS?:
               name: What is ECS?
           lesson_groups: {}
+          lessons:
+            Introduction to PD:
+              name: Introduction to PD
+            What is ECS?:
+              name: What is ECS?
+            Impact of Computer Science:
+              name: Impact of Computer Science
+            Growth Mindset:
+              name: Growth Mindset
+            Teaching Strategies:
+              name: Teaching Strategies
+            Preparing for in-person PD:
+              name: Preparing for in-person PD
         ECSPD-iZone:
           title: Exploring Computer Science PD
           description: 'Phase 1: Online Introduction'
@@ -888,6 +1488,19 @@ en:
             What is ECS?:
               name: What is ECS?
           lesson_groups: {}
+          lessons:
+            Introduction to PD:
+              name: Introduction to PD
+            What is ECS?:
+              name: What is ECS?
+            Impact of Computer Science:
+              name: Impact of Computer Science
+            Growth Mindset:
+              name: Growth Mindset
+            Teaching Strategies:
+              name: Teaching Strategies
+            Preparing for in-person PD:
+              name: Preparing for in-person PD
         algebraPD-NexTech:
           title: Computer Science in Algebra PD
           description: 'Phase 1: Online Introduction'
@@ -908,6 +1521,19 @@ en:
             Why Computer Science belongs in Algebra:
               name: Why Computer Science belongs in Algebra
           lesson_groups: {}
+          lessons:
+            Introduction to PD:
+              name: Introduction to PD
+            Course Overview:
+              name: Course Overview
+            Why Computer Science belongs in Algebra:
+              name: Why Computer Science belongs in Algebra
+            Evaluation Blocks:
+              name: Evaluation Blocks
+            Teacher Dashboard:
+              name: Teacher Dashboard
+            Preparing for in-person PD:
+              name: Preparing for in-person PD
         algebraPD-iZone:
           title: Computer Science in Algebra PD
           description: 'Phase 1: Online Introduction'
@@ -928,6 +1554,19 @@ en:
             Why Computer Science belongs in Algebra:
               name: Why Computer Science belongs in Algebra
           lesson_groups: {}
+          lessons:
+            Introduction to PD:
+              name: Introduction to PD
+            Course Overview:
+              name: Course Overview
+            Why Computer Science belongs in Algebra:
+              name: Why Computer Science belongs in Algebra
+            Evaluation Blocks:
+              name: Evaluation Blocks
+            Teacher Dashboard:
+              name: Teacher Dashboard
+            Preparing for in-person PD:
+              name: Preparing for in-person PD
         sciencePD-NexTech:
           title: Computer Science in Science PD
           description: 'Phase 1: Online Introduction'
@@ -960,6 +1599,31 @@ en:
             What to Expect:
               name: What to Expect
           lesson_groups: {}
+          lessons:
+            Introduction to PD:
+              name: Introduction to PD
+            What to Expect:
+              name: What to Expect
+            Introduction to Complex Adaptive Systems:
+              name: Introduction to Complex Adaptive Systems
+            Introduction to Computational Science:
+              name: Introduction to Computational Science
+            Agent Based Modeling of Complex Adaptive Systems:
+              name: Agent Based Modeling of Complex Adaptive Systems
+            Using Computer Models in Science:
+              name: Using Computer Models in Science
+            Using Models in the Classroom:
+              name: Using Models in the Classroom
+            Dispositions and Classroom Culture:
+              name: Dispositions and Classroom Culture
+            Computational Thinking And The Framework For K-12 Science Education:
+              name: Computational Thinking And The Framework For K-12 Science Education
+            Introduction to StarLogo Nova:
+              name: Introduction to StarLogo Nova
+            The Tutorial:
+              name: The Tutorial
+            Post-Survey:
+              name: Post-Survey
         sciencePD-iZone:
           title: Computer Science in Science PD
           description: 'Phase 1: Online Introduction'
@@ -992,6 +1656,31 @@ en:
             What to Expect:
               name: What to Expect
           lesson_groups: {}
+          lessons:
+            Introduction to PD:
+              name: Introduction to PD
+            What to Expect:
+              name: What to Expect
+            Introduction to Complex Adaptive Systems:
+              name: Introduction to Complex Adaptive Systems
+            Introduction to Computational Science:
+              name: Introduction to Computational Science
+            Agent Based Modeling of Complex Adaptive Systems:
+              name: Agent Based Modeling of Complex Adaptive Systems
+            Using Computer Models in Science:
+              name: Using Computer Models in Science
+            Using Models in the Classroom:
+              name: Using Models in the Classroom
+            Dispositions and Classroom Culture:
+              name: Dispositions and Classroom Culture
+            Computational Thinking And The Framework For K-12 Science Education:
+              name: Computational Thinking And The Framework For K-12 Science Education
+            Introduction to StarLogo Nova:
+              name: Introduction to StarLogo Nova
+            The Tutorial:
+              name: The Tutorial
+            Post-Survey:
+              name: Post-Survey
         sciencePD2:
           title: 'CS in Science: Part 2'
           description: Phase 2 Online Blended Summer Study
@@ -1012,6 +1701,21 @@ en:
             Wrap-Up:
               name: Wrap-Up
           lesson_groups: {}
+          lessons:
+            Welcome!:
+              name: Welcome!
+            Review StarLogo Nova:
+              name: Review StarLogo Nova
+            Creating Breeds in Starlogo Nova:
+              name: Creating Breeds in Starlogo Nova
+            Revisiting Agent Movement:
+              name: Revisiting Agent Movement
+            Epidemic Model Extensions:
+              name: Epidemic Model Extensions
+            Thinking Ahead to Implementation:
+              name: Thinking Ahead to Implementation
+            Wrap-Up:
+              name: Wrap-Up
         sciencePD3:
           title: 'CS in Science: Part 3'
           description: Academic Year Support - Semester 1
@@ -1024,6 +1728,13 @@ en:
             Welcome Back!:
               name: Welcome Back!
           lesson_groups: {}
+          lessons:
+            Welcome Back!:
+              name: Welcome Back!
+            Mystery Model:
+              name: Mystery Model
+            Decode and Share:
+              name: Decode and Share
         Testing:
           title: Testing
           description: Testing
@@ -1033,6 +1744,9 @@ en:
               name: Testing
           description_audience: ''
           lesson_groups: {}
+          lessons:
+            Testing:
+              name: Testing
         cspunit2:
           title: "(old) CS Principles Unit 2 - The Internet"
           description: In this unit, students extend their understanding of the internet and how it functions by building off the concepts learned when sending bits in Unit 1. This unit is a pilot version and is no longer supported or updated. You can find the new units at code.org/educate/csp.
@@ -1080,6 +1794,47 @@ en:
               name: The Need for DNS
           description_audience: ''
           lesson_groups: {}
+          lessons:
+            The Internet:
+              name: The Internet
+            The Need for Addressing:
+              name: The Need for Addressing
+            Invent an Addressing Protocol:
+              name: Invent an Addressing Protocol
+            Routers and Redundancy:
+              name: Routers and Redundancy
+            Packets and Making a Reliable Internet:
+              name: Packets and Making a Reliable Internet
+            Algorithms Detour - Minimum Spanning Tree:
+              name: Algorithms Detour - Minimum Spanning Tree
+            Algorithms Detour - Shortest Path:
+              name: Algorithms Detour - Shortest Path
+            Algorithms Detour - How Routers Learn:
+              name: Algorithms Detour - How Routers Learn
+            The Need for DNS:
+              name: The Need for DNS
+            DNS in the Real World:
+              name: DNS in the Real World
+            HTTP and Abstraction:
+              name: HTTP and Abstraction
+            Practice PT - The Internet and Society:
+              name: Practice PT - The Internet and Society
+            Tell Me a Secret - Encrypting Text:
+              name: Tell Me a Secret - Encrypting Text
+            Cracking the Code:
+              name: Cracking the Code
+            Encryption Algorithms:
+              name: Encryption Algorithms
+            Algorithms Detour - Hard Problems TSP:
+              name: Algorithms Detour - Hard Problems TSP
+            One Way Functions - Ice Cream Vans:
+              name: One Way Functions - Ice Cream Vans
+            Alice and Bob and Asymmetric Keys:
+              name: Alice and Bob and Asymmetric Keys
+            Public Key Crypto:
+              name: Public Key Crypto
+            Practice PT - Cybersecurity Innovations:
+              name: Practice PT - Cybersecurity Innovations
         algebraPD2a:
           title: Computer Science in Algebra PD
           description: 'Phase 2 Online: Blended Summer Study'
@@ -1115,6 +1870,35 @@ en:
             The Design Recipe:
               name: The Design Recipe
           lesson_groups: {}
+          lessons:
+            Evaluation Blocks:
+              name: Evaluation Blocks
+            Strings and Images:
+              name: Strings and Images
+            Defining Variables:
+              name: Defining Variables
+            Big Game - Variables:
+              name: Big Game - Variables
+            Rocket-Height:
+              name: Rocket-Height
+            The Design Recipe:
+              name: The Design Recipe
+            Big Game - Animation:
+              name: Big Game - Animation
+            Booleans:
+              name: Booleans
+            Sam the Bat:
+              name: Sam the Bat
+            Big Game - Booleans:
+              name: Big Game - Booleans
+            Luigi's Pizza:
+              name: Luigi's Pizza
+            Big Game - Player Movement:
+              name: Big Game - Player Movement
+            Big Game - Collision Detection:
+              name: Big Game - Collision Detection
+            Free Play:
+              name: Free Play
         allthethings:
           title: All the Things!
           description: All the level types for UI testing. Please sign in to test applab levels (By design, applab levels only work if signed in. Normally, we make people sign in, but this is only enforceable for a whole script and would be annoying to do for this script).
@@ -1212,6 +1996,95 @@ en:
             ML Fish:
               name: ML Fish
           lesson_groups: {}
+          lessons:
+            Jigsaw:
+              name: Jigsaw
+            Maze:
+              name: Maze
+            Artist:
+              name: Artist
+            Bee:
+              name: Bee
+            PlayLab:
+              name: PlayLab
+            Farmer:
+              name: Farmer
+            Flappy:
+              name: Flappy
+            Bounce:
+              name: Bounce
+            Multi:
+              name: Multi
+            Multi2:
+              name: Multi2
+            Match:
+              name: Match
+            TextMatch:
+              name: TextMatch
+            CSinA:
+              name: CSinA
+            Netsim:
+              name: Netsim
+            Odometer:
+              name: Odometer
+            Text Compression:
+              name: Text Compression
+            Pixelation:
+              name: Pixelation
+            AppLab:
+              name: AppLab
+            Gamelab:
+              name: Gamelab
+            Online PD:
+              name: Online PD
+            Markdown Details:
+              name: Markdown Details
+            Studio:
+              name: Studio
+            Multi page assessment:
+              name: Multi page assessment
+            Star wars:
+              name: Star wars
+            Minecraft:
+              name: Minecraft
+            Rich long assessment:
+              name: Rich long assessment
+            Free Response:
+              name: Free Response
+            Sample PLC Assessment:
+              name: Sample PLC Assessment
+            Swapped Levels:
+              name: Swapped Levels
+            Anonymous student survey:
+              name: Anonymous student survey
+            Anonymous student survey 2:
+              name: Anonymous student survey 2
+            Public Key Cryptography:
+              name: Public Key Cryptography
+            Web Lab:
+              name: Web Lab
+            Single page assessment:
+              name: Single page assessment
+            Standalone video:
+              name: Standalone video
+            Curriculum Reference:
+              name: Curriculum Reference
+            Sprite Lab:
+              name: Sprite Lab
+            Dance Lab:
+              name: Dance Lab
+            Mini Rubric:
+              name: Mini Rubric
+            Pluralsight Test:
+              name: Pluralsight Test
+            Externals Optionally Displayed as Unplugged:
+              name: Externals Optionally Displayed as Unplugged
+            Bubble Choice:
+              name: Bubble Choice
+            Contained Levels:
+              name: Contained Levels
+            ML Fish:
+              name: ML Fish
         algebraPD2b:
           title: Computer Science in Algebra PD
           description: 'Phase 2 Online: Blended Summer Study'
@@ -1243,6 +2116,31 @@ en:
             Writing Contracts:
               name: Writing Contracts
           lesson_groups: {}
+          lessons:
+            Course Overview:
+              name: Course Overview
+            Best Practices for Teaching Computer Science:
+              name: Best Practices for Teaching Computer Science
+            Teacher Dashboard:
+              name: Teacher Dashboard
+            Evaluation Blocks:
+              name: Evaluation Blocks
+            Strings and Images:
+              name: Strings and Images
+            Writing Contracts:
+              name: Writing Contracts
+            Defining Variables:
+              name: Defining Variables
+            Defining Functions:
+              name: Defining Functions
+            Rocket-Height:
+              name: Rocket-Height
+            Booleans:
+              name: Booleans
+            'Eval: Conditionals':
+              name: 'Eval: Conditionals'
+            Next Steps:
+              name: Next Steps
         cspfacilitator:
           title: 'CS Principles Facilitator Workshop '
           description: Online levels for PD workshop
@@ -1264,6 +2162,21 @@ en:
             Welcome!:
               name: Welcome!
           lesson_groups: {}
+          lessons:
+            Welcome!:
+              name: Welcome!
+            Pixelation Widget:
+              name: Pixelation Widget
+            Text Compression Widget:
+              name: Text Compression Widget
+            Internet Simulator:
+              name: Internet Simulator
+            App Lab:
+              name: App Lab
+            Broadcast Lesson:
+              name: Broadcast Lesson
+            Text Compression Lesson:
+              name: Text Compression Lesson
         K5-OnlinePD:
           title: Teaching Computer Science Fundamentals
           description: Learn how to teach computer science using Code.org's Computer Science Fundamentals with this free, self-paced online course.
@@ -1293,6 +2206,29 @@ en:
             Planning:
               name: Planning
           lesson_groups: {}
+          lessons:
+            Getting Started:
+              name: Getting Started
+            Computer Science Fundamentals:
+              name: Computer Science Fundamentals
+            Looking Ahead:
+              name: Looking Ahead
+            'Mastering the Basics: Sequencing':
+              name: 'Mastering the Basics: Sequencing'
+            'Mastering the Basics: Loops':
+              name: 'Mastering the Basics: Loops'
+            'Mastering the Basics: Conditionals':
+              name: 'Mastering the Basics: Conditionals'
+            'Mastering the Basics: Functions':
+              name: 'Mastering the Basics: Functions'
+            'Mastering the Basics: Events':
+              name: 'Mastering the Basics: Events'
+            Best Practices for Teaching Computer Science:
+              name: Best Practices for Teaching Computer Science
+            Planning:
+              name: Planning
+            Next Steps:
+              name: Next Steps
         ECSPD2:
           title: 'Exploring Computer Science PD: Blended Summer Study'
           description: 'Phase 2 Online: Blended Summer Study'
@@ -1324,6 +2260,31 @@ en:
             Wrap-up:
               name: Wrap-up
           lesson_groups: {}
+          lessons:
+            Welcome!:
+              name: Welcome!
+            ? |-
+              Unit 1, Days 1-2
+              What Is a Computer?
+            : name: |-
+                Unit 1, Days 1-2
+                What Is a Computer?
+            Unit 1, Days 3-4 Buying a Computer:
+              name: Unit 1, Days 3-4 Buying a Computer
+            Unit 1, Days 5-7 Searching and Web 2:
+              name: Unit 1, Days 5-7 Searching and Web 2
+            Unit 1, Days 8-9 Impact of Computers and Communication:
+              name: Unit 1, Days 8-9 Impact of Computers and Communication
+            Unit 1, Day 10 Telling a Story with Data:
+              name: Unit 1, Day 10 Telling a Story with Data
+            Unit 1, Day 11-14 Data Modeling and Design:
+              name: Unit 1, Day 11-14 Data Modeling and Design
+            Unit 1, Day 15-16 Computer Programs and Following Directions:
+              name: Unit 1, Day 15-16 Computer Programs and Following Directions
+            Unit 1, Day 17-19 What Is Intelligence?:
+              name: Unit 1, Day 17-19 What Is Intelligence?
+            Wrap-up:
+              name: Wrap-up
         equityPD:
           title: Leading a Discussion on Equity
           description: How to lead a discussion on equity in a Code.org PD
@@ -1334,6 +2295,11 @@ en:
             Necessary Background:
               name: Necessary Background
           lesson_groups: {}
+          lessons:
+            Necessary Background:
+              name: Necessary Background
+            Equity PD:
+              name: Equity PD
         algebraPD2:
           title: CS in Algebra Part 2
           description: Academic Year Support
@@ -1353,6 +2319,19 @@ en:
             Welcome!:
               name: Welcome!
           lesson_groups: {}
+          lessons:
+            Welcome!:
+              name: Welcome!
+            Teaching with Puzzles:
+              name: Teaching with Puzzles
+            Teaching with the Design Recipe:
+              name: Teaching with the Design Recipe
+            The Design Recipe:
+              name: The Design Recipe
+            Teacher Dashboard:
+              name: Teacher Dashboard
+            Lesson Prep:
+              name: Lesson Prep
         sciencePD2b:
           title: Computer Science in Science PD Phase 2b
           description: 'Phase 2 Online: Blended Summer Study'
@@ -1374,6 +2353,21 @@ en:
             Wrap-Up:
               name: Wrap-Up
           lesson_groups: {}
+          lessons:
+            Welcome!:
+              name: Welcome!
+            Review StarLogo Nova:
+              name: Review StarLogo Nova
+            Reviewing the Modules:
+              name: Reviewing the Modules
+            Advanced StarLogo Nova:
+              name: Advanced StarLogo Nova
+            Remixing Phases 1 and 2:
+              name: Remixing Phases 1 and 2
+            Thinking Ahead to Implementation:
+              name: Thinking Ahead to Implementation
+            Wrap-Up:
+              name: Wrap-Up
         equity-pd:
           title: Leading a Discussion on Equity
           description: How to lead a discussion on equity in a Code.org PD
@@ -1385,6 +2379,11 @@ en:
             Necessary Background:
               name: Necessary Background
           lesson_groups: {}
+          lessons:
+            Necessary Background:
+              name: Necessary Background
+            Code.org Equity PD:
+              name: Code.org Equity PD
         science-PD2:
           title: Computer Science in Science PD Phase 2b
           description: Phase 2 Online Blended Summer Study
@@ -1406,6 +2405,21 @@ en:
             Wrap-Up:
               name: Wrap-Up
           lesson_groups: {}
+          lessons:
+            Welcome!:
+              name: Welcome!
+            Review StarLogo Nova:
+              name: Review StarLogo Nova
+            Reviewing the Modules:
+              name: Reviewing the Modules
+            Advanced StarLogo Nova:
+              name: Advanced StarLogo Nova
+            Remixing Phases 1 and 2:
+              name: Remixing Phases 1 and 2
+            Thinking Ahead to Implementation:
+              name: Thinking Ahead to Implementation
+            Wrap-Up:
+              name: Wrap-Up
         Equity-OnlinePD:
           title: Creating More Equitable Computer Science Classrooms
           description: Develop strategies for creating equity in your classroom with this free, self-paced online course.
@@ -1421,6 +2435,15 @@ en:
             Next Steps:
               name: Next Steps
           lesson_groups: {}
+          lessons:
+            Getting Started:
+              name: Getting Started
+            Introduction to Equity:
+              name: Introduction to Equity
+            Creating Equitable Learning Environments:
+              name: Creating Equitable Learning Environments
+            Next Steps:
+              name: Next Steps
         sciencePD2b-iZone:
           title: Computer Science in Science PD Phase 2b
           description: 'Phase 2 Online: Blended Summer Study'
@@ -1442,6 +2465,21 @@ en:
             Wrap-Up:
               name: Wrap-Up
           lesson_groups: {}
+          lessons:
+            Welcome!:
+              name: Welcome!
+            Review StarLogo Nova:
+              name: Review StarLogo Nova
+            Reviewing the Modules:
+              name: Reviewing the Modules
+            Advanced StarLogo Nova:
+              name: Advanced StarLogo Nova
+            Remixing Phases 1 and 2:
+              name: Remixing Phases 1 and 2
+            Thinking Ahead to Implementation:
+              name: Thinking Ahead to Implementation
+            Wrap-Up:
+              name: Wrap-Up
         ECSPD2-iZone:
           title: 'Exploring Computer Science PD: Blended Summer Study'
           description: 'Phase 2 Online: Blended Summer Study'
@@ -1472,6 +2510,31 @@ en:
             Wrap-up:
               name: Wrap-up
           lesson_groups: {}
+          lessons:
+            Welcome!:
+              name: Welcome!
+            ? |-
+              Unit 1, Days 1-2
+              What Is a Computer?
+            : name: |-
+                Unit 1, Days 1-2
+                What Is a Computer?
+            Unit 1, Days 3-4 Buying a Computer:
+              name: Unit 1, Days 3-4 Buying a Computer
+            Unit 1, Days 5-7 Searching and Web 2:
+              name: Unit 1, Days 5-7 Searching and Web 2
+            Unit 1, Days 8-9 Impact of Computers and Communication:
+              name: Unit 1, Days 8-9 Impact of Computers and Communication
+            Unit 1, Day 10 Telling a Story with Data:
+              name: Unit 1, Day 10 Telling a Story with Data
+            Unit 1, Day 11-14 Data Modeling and Design:
+              name: Unit 1, Day 11-14 Data Modeling and Design
+            Unit 1, Day 15-16 Computer Programs and Following Directions:
+              name: Unit 1, Day 15-16 Computer Programs and Following Directions
+            Unit 1, Day 17-19 What Is Intelligence?:
+              name: Unit 1, Day 17-19 What Is Intelligence?
+            Wrap-up:
+              name: Wrap-up
         ECSPD2-NexTech:
           title: 'Exploring Computer Science PD: Blended Summer Study'
           description: 'Phase 2 Online: Blended Summer Study'
@@ -1502,6 +2565,31 @@ en:
             Wrap-up:
               name: Wrap-up
           lesson_groups: {}
+          lessons:
+            Welcome!:
+              name: Welcome!
+            ? |-
+              Unit 1, Days 1-2
+              What Is a Computer?
+            : name: |-
+                Unit 1, Days 1-2
+                What Is a Computer?
+            Unit 1, Days 3-4 Buying a Computer:
+              name: Unit 1, Days 3-4 Buying a Computer
+            Unit 1, Days 5-7 Searching and Web 2:
+              name: Unit 1, Days 5-7 Searching and Web 2
+            Unit 1, Days 8-9 Impact of Computers and Communication:
+              name: Unit 1, Days 8-9 Impact of Computers and Communication
+            Unit 1, Day 10 Telling a Story with Data:
+              name: Unit 1, Day 10 Telling a Story with Data
+            Unit 1, Day 11-14 Data Modeling and Design:
+              name: Unit 1, Day 11-14 Data Modeling and Design
+            Unit 1, Day 15-16 Computer Programs and Following Directions:
+              name: Unit 1, Day 15-16 Computer Programs and Following Directions
+            Unit 1, Day 17-19 What Is Intelligence?:
+              name: Unit 1, Day 17-19 What Is Intelligence?
+            Wrap-up:
+              name: Wrap-up
         CSPPD2:
           title: 'Computer Science Principles PD: Blended Summer Study'
           description: 8-hour online PD that builds on the 5-day in-person experience and helps teachers prepare for the beginning of the semester
@@ -1524,6 +2612,23 @@ en:
             Wrap Up and Next Steps:
               name: Wrap Up and Next Steps
           lesson_groups: {}
+          lessons:
+            Getting Started:
+              name: Getting Started
+            Welcome to the Course!:
+              name: Welcome to the Course!
+            Lesson Chunk 1- Sending Binary Messages:
+              name: Lesson Chunk 1- Sending Binary Messages
+            Lesson Chunk 2- Encoding and Sending Numbers:
+              name: Lesson Chunk 2- Encoding and Sending Numbers
+            Lesson Chunk 3- Encoding and Sending Text:
+              name: Lesson Chunk 3- Encoding and Sending Text
+            Lesson Chunk 4- Compressing and Storing Information:
+              name: Lesson Chunk 4- Compressing and Storing Information
+            Practice PT:
+              name: Practice PT
+            Wrap Up and Next Steps:
+              name: Wrap Up and Next Steps
         odometer:
           title: Odometer Widget
           description: Use the Odometer widget to control odometers with various number bases. Binary, Decimal and Hexadecimal are the most common number systems to see in computer science.
@@ -1533,6 +2638,9 @@ en:
             Odometer Widget:
               name: Odometer Widget
           lesson_groups: {}
+          lessons:
+            Odometer Widget:
+              name: Odometer Widget
         asUnplugged:
           title: Afterschool Unplugged
           description: Afterschool Unplugged is designed to teach computational thinking and computer science ideas through offline games and crafts. Created with informal classrooms in mind, these lessons are fantastic on their own, or in combination with Afterschool 1 . This course focuses on learning through entertainment. Recommended for grades K-8.
@@ -1558,6 +2666,25 @@ en:
             The Big Event:
               name: The Big Event
           lesson_groups: {}
+          lessons:
+            Happy Maps:
+              name: Happy Maps
+            Move it, Move it:
+              name: Move it, Move it
+            'Real-life Algorithms: Plant a Seed':
+              name: 'Real-life Algorithms: Plant a Seed'
+            Graph Paper Programming:
+              name: Graph Paper Programming
+            Building a Foundation:
+              name: Building a Foundation
+            Getting Loopy:
+              name: Getting Loopy
+            The Big Event:
+              name: The Big Event
+            Binary Bracelets:
+              name: Binary Bracelets
+            Songwriting:
+              name: Songwriting
         afterschool1:
           title: Afterschool 1
           description: Afterschool 1 is designed to for informal classrooms where students vary in age and assessment is not required. This course focuses on learning through entertainment, with varying options for implementation, all in 10 sessions or less. Use alone or with Afterschool Unplugged. Recommended for grades 3-8.
@@ -1574,6 +2701,9 @@ en:
             Vigenere:
               name: Vigenere
           lesson_groups: {}
+          lessons:
+            Vigenere:
+              name: Vigenere
         algebraPD3a:
           title: Computer Science in Algebra PD
           description: 'Phase 3 (Part 2): CS in Algebra blended online school year study'
@@ -1589,6 +2719,15 @@ en:
             Updates - Tweaks and Polish:
               name: Updates - Tweaks and Polish
           lesson_groups: {}
+          lessons:
+            Updates - Tweaks and Polish:
+              name: Updates - Tweaks and Polish
+            Updates - The Big Game and Projects:
+              name: Updates - The Big Game and Projects
+            Updates - The Design Recipe:
+              name: Updates - The Design Recipe
+            Lesson Prep:
+              name: Lesson Prep
         sciencePD3_pre1:
           title: CS in Science PD3 Before 1st In-Person
           description: 'Phase 3: Academic Year Development (Segment One)'
@@ -1602,6 +2741,13 @@ en:
             Welcome Back!:
               name: Welcome Back!
           lesson_groups: {}
+          lessons:
+            Welcome Back!:
+              name: Welcome Back!
+            The TLO:
+              name: The TLO
+            Prep With Your Modules:
+              name: Prep With Your Modules
         frequency_analysis:
           title: Frequency Analysis Widget
           description: Use the Frequency Analysis Widget to analyze letter frequencies in an input text compared to expected frequencies for standard English. Use that comparison to explore cracking Shift and Substitution Ciphers.
@@ -1611,6 +2757,9 @@ en:
               name: Frequency Analysis
           description_audience: ''
           lesson_groups: {}
+          lessons:
+            Frequency Analysis:
+              name: Frequency Analysis
         ECSPD3-Unit2:
           title: 'Exploring Computer Science: Unit 2'
           description: Online Professional Development Course
@@ -1630,6 +2779,19 @@ en:
             Unit 2 Challenge:
               name: Unit 2 Challenge
           lesson_groups: {}
+          lessons:
+            Getting Started:
+              name: Getting Started
+            Intro to Unit 2:
+              name: Intro to Unit 2
+            Teaching Strategies:
+              name: Teaching Strategies
+            Lesson Overviews:
+              name: Lesson Overviews
+            Unit 2 Challenge:
+              name: Unit 2 Challenge
+            Close & Next Steps:
+              name: Close & Next Steps
         ECSPD3-Unit3:
           title: 'Exploring Computer Science: Unit 3'
           description: Academic Year Development
@@ -1649,6 +2811,19 @@ en:
             Unit 3 Day-by-Day:
               name: Unit 3 Day-by-Day
           lesson_groups: {}
+          lessons:
+            Getting Started:
+              name: Getting Started
+            Intro to Unit 3:
+              name: Intro to Unit 3
+            Teaching Strategies:
+              name: Teaching Strategies
+            Unit 3 Day-by-Day:
+              name: Unit 3 Day-by-Day
+            Unit 3 Challenge:
+              name: Unit 3 Challenge
+            Close & Next Steps:
+              name: Close & Next Steps
         ECSPD3-Unit4:
           title: 'Exploring Computer Science: Unit 4'
           description: Academic Year Development
@@ -1668,6 +2843,19 @@ en:
             Unit 4 Day-by-Day:
               name: Unit 4 Day-by-Day
           lesson_groups: {}
+          lessons:
+            Getting Started:
+              name: Getting Started
+            Intro to Unit 4:
+              name: Intro to Unit 4
+            Teaching Strategies:
+              name: Teaching Strategies
+            Unit 4 Day-by-Day:
+              name: Unit 4 Day-by-Day
+            Unit 4 Challenge:
+              name: Unit 4 Challenge
+            Close & Next Steps:
+              name: Close & Next Steps
         ECSPD3-Unit5:
           title: 'Exploring Computer Science PD: Academic Year Development'
           description: Academic Year Development
@@ -1687,6 +2875,19 @@ en:
             Unit 5 lessons:
               name: Unit 5 lessons
           lesson_groups: {}
+          lessons:
+            Getting Started:
+              name: Getting Started
+            Unit 5 Overview:
+              name: Unit 5 Overview
+            Unit 5 lessons:
+              name: Unit 5 lessons
+            Introduction to the Unit 5 Challenge:
+              name: Introduction to the Unit 5 Challenge
+            Complete the Challenge:
+              name: Complete the Challenge
+            Share out and Submit:
+              name: Share out and Submit
         ECSPD3-Unit6:
           title: 'Exploring Computer Science PD: Academic Year Development'
           description: Academic Year Development
@@ -1706,6 +2907,19 @@ en:
             Unit 6 lessons:
               name: Unit 6 lessons
           lesson_groups: {}
+          lessons:
+            Getting Started:
+              name: Getting Started
+            Unit 6 Overview:
+              name: Unit 6 Overview
+            Unit 6 lessons:
+              name: Unit 6 lessons
+            Alternative Ideas for Unit 6:
+              name: Alternative Ideas for Unit 6
+            Unit 6 Challenge:
+              name: Unit 6 Challenge
+            Share out and Submit:
+              name: Share out and Submit
         cspunit4draft:
           title: CS Principles Unit 4 - Data
           description: "Collect, analyze, and extract knowledge from data by programming and\r\nbuilding apps. Process data imported from other sources and also pull\r\ndata from live data APIs."
@@ -1769,6 +2983,63 @@ en:
             Why Make Apps?:
               name: Why Make Apps?
           lesson_groups: {}
+          lessons:
+            Finding Trends with Visualizations:
+              name: Finding Trends with Visualizations
+            Good and Bad Data Visualizations:
+              name: Good and Bad Data Visualizations
+            Check Your Assumptions:
+              name: Check Your Assumptions
+            Making Data Visualizations:
+              name: Making Data Visualizations
+            Discover a Data Story:
+              name: Discover a Data Story
+            Cleaning Data:
+              name: Cleaning Data
+            Creating Summary Tables:
+              name: Creating Summary Tables
+            Rapid Research - Data Innovations:
+              name: Rapid Research - Data Innovations
+            Why Make Apps?:
+              name: Why Make Apps?
+            Creating Javascript Objects:
+              name: Creating Javascript Objects
+            Permanent Data Storage:
+              name: Permanent Data Storage
+            Reading Records:
+              name: Reading Records
+            Search Terms:
+              name: Search Terms
+            Unique IDs, Delete and Update Records:
+              name: Unique IDs, Delete and Update Records
+            Import, Export, and Visualize Data:
+              name: Import, Export, and Visualize Data
+            Interpreting Data Visualizations:
+              name: Interpreting Data Visualizations
+            How is Data Collected?:
+              name: How is Data Collected?
+            Using Data in the Real World:
+              name: Using Data in the Real World
+            Web Requests and APIs:
+              name: Web Requests and APIs
+            Data, Security, and Privacy:
+              name: Data, Security, and Privacy
+            Privacy vs Utility:
+              name: Privacy vs Utility
+            Privacy in a Digital World:
+              name: Privacy in a Digital World
+            Compiling Data:
+              name: Compiling Data
+            Designing Data Collection:
+              name: Designing Data Collection
+            Designing for Your User:
+              name: Designing for Your User
+            'Practice Create PT: Data App':
+              name: 'Practice Create PT: Data App'
+            What Data Can Tell Us:
+              name: What Data Can Tell Us
+            Permanent Data Storage and Clicker Completion:
+              name: Permanent Data Storage and Clicker Completion
         ScienceP3OLPT2:
           title: Computer Science in Science PD Phase 3A Post Work
           description: Phase 3 Academic Year Development
@@ -1808,6 +3079,21 @@ en:
             Teaching Support - Lessons 8-12:
               name: Teaching Support - Lessons 8-12
           lesson_groups: {}
+          lessons:
+            Getting Started:
+              name: Getting Started
+            Teaching Support - Lessons 1-3:
+              name: Teaching Support - Lessons 1-3
+            Teaching Support - Lessons 4-7:
+              name: Teaching Support - Lessons 4-7
+            Teaching Support - Lessons 8-12:
+              name: Teaching Support - Lessons 8-12
+            Teaching Support - Lessons 13-16:
+              name: Teaching Support - Lessons 13-16
+            Teaching Support - Lessons 17-20:
+              name: Teaching Support - Lessons 17-20
+            Close and Next Steps:
+              name: Close and Next Steps
         CSPPD3-Unit2:
           title: 'Computer Science Principles: Unit 2 PD'
           description: Online Exploration of CSP Unit 2
@@ -1825,6 +3111,17 @@ en:
             Unit 2 Overview:
               name: Unit 2 Overview
           lesson_groups: {}
+          lessons:
+            Getting Started:
+              name: Getting Started
+            Unit 2 Overview:
+              name: Unit 2 Overview
+            Challenge Overview:
+              name: Challenge Overview
+            Complete the Challenge:
+              name: Complete the Challenge
+            Share out and Submit:
+              name: Share out and Submit
         duino:
           title: Experimenting with Arduino stuff
           description: Testing some tools for teaching with Arduinos
@@ -1838,6 +3135,15 @@ en:
             Making Music:
               name: Making Music
           lesson_groups: {}
+          lessons:
+            Basic Circuits:
+              name: Basic Circuits
+            Blinky Lights:
+              name: Blinky Lights
+            Making Music:
+              name: Making Music
+            JunkBot:
+              name: JunkBot
         Special Fun:
           title: Special Fun
           description_short: Something special for those who know it exists. These puzzles might not be around long, so enjoy them while you can!
@@ -1847,6 +3153,9 @@ en:
             Halloween 2015:
               name: Halloween 2015
           lesson_groups: {}
+          lessons:
+            Halloween 2015:
+              name: Halloween 2015
         SpecialSeries:
           title: Special Levels
           description: Something special for those who know it exists. These puzzles might not be around long, so enjoy them while you can!
@@ -1858,6 +3167,9 @@ en:
             Halloween 2015:
               name: Halloween 2015
           lesson_groups: {}
+          lessons:
+            Halloween 2015:
+              name: Halloween 2015
         iceage:
           title: Ice Age Play Lab
           description: Create a story or make a game with Ice Age Play Lab!
@@ -1867,6 +3179,9 @@ en:
             Ice Age Play Lab:
               name: Ice Age Play Lab
           lesson_groups: {}
+          lessons:
+            Ice Age Play Lab:
+              name: Ice Age Play Lab
         CSPPD3-Unit3:
           title: 'Computer Science Principles: Unit 3 PD'
           description: Online Exploration of CSP Unit 3
@@ -1895,6 +3210,29 @@ en:
             Unit 3 Overview:
               name: Unit 3 Overview
           lesson_groups: {}
+          lessons:
+            Getting Started:
+              name: Getting Started
+            Unit 3 Overview:
+              name: Unit 3 Overview
+            Chunk 1 Overview:
+              name: Chunk 1 Overview
+            Chunk 2 Overview:
+              name: Chunk 2 Overview
+            Chunk 3 Overview:
+              name: Chunk 3 Overview
+            Chunk 4 Overview:
+              name: Chunk 4 Overview
+            Chunk 5 Overview:
+              name: Chunk 5 Overview
+            Practice Performance Task:
+              name: Practice Performance Task
+            Challenge Overview:
+              name: Challenge Overview
+            Complete the Challenge:
+              name: Complete the Challenge
+            Share out and Submit:
+              name: Share out and Submit
         cspunit3temp:
           title: "(old) CS Principles Unit 3 - Programming"
           description: This unit introduces the foundational concepts of computer programming, which unlocks the ability to make rich, interactive apps. This course uses JavaScript as the programming language, and App Lab as the programming environment to build apps, but the concepts learned in these lessons span all programming languages and tools.
@@ -1918,6 +3256,23 @@ en:
             While Loops:
               name: While Loops
           lesson_groups: {}
+          lessons:
+            While Loops:
+              name: While Loops
+            Loops and Simulations:
+              name: Loops and Simulations
+            Introduction to Arrays:
+              name: Introduction to Arrays
+            Image Scroller with Key Events:
+              name: Image Scroller with Key Events
+            Processing Arrays:
+              name: Processing Arrays
+            Functions with Return Values:
+              name: Functions with Return Values
+            Canvas and Arrays in Apps:
+              name: Canvas and Arrays in Apps
+            'Practice PT: Create':
+              name: 'Practice PT: Create'
         CSP-Unit3-Support:
           title: 'Computer Science Principles: Unit 3 PD'
           description: Online Exploration of CSP Unit 3
@@ -1938,6 +3293,21 @@ en:
             Unit 3 Overview:
               name: Unit 3 Overview
           lesson_groups: {}
+          lessons:
+            Unit 3 Overview:
+              name: Unit 3 Overview
+            Chunk 1 Overview:
+              name: Chunk 1 Overview
+            Chunk 2 Overview:
+              name: Chunk 2 Overview
+            Chunk 3 Overview:
+              name: Chunk 3 Overview
+            Chunk 4 Overview:
+              name: Chunk 4 Overview
+            Chunk 5 Overview:
+              name: Chunk 5 Overview
+            Practice Performance Task:
+              name: Practice Performance Task
         gumball:
           title: Gumball Play Lab
           description: Create a story or make a game with Gumball Play Lab!
@@ -1946,6 +3316,9 @@ en:
             Gumball Play Lab:
               name: Gumball Play Lab
           lesson_groups: {}
+          lessons:
+            Gumball Play Lab:
+              name: Gumball Play Lab
         starwars:
           title: 'Star Wars: Building a Galaxy With Code'
           description: Learn to program droids, and create your own Star Wars game in a galaxy far, far away.
@@ -1955,6 +3328,9 @@ en:
             Hour of Code 2015:
               name: Hour of Code 2015
           lesson_groups: {}
+          lessons:
+            Hour of Code 2015:
+              name: Hour of Code 2015
         starwarsblocks:
           title: 'Star Wars: Building a Galaxy With Code'
           description: Learn to program droids, and create your own Star Wars game in a galaxy far, far away.
@@ -1964,6 +3340,9 @@ en:
             Hour of Code 2015:
               name: Hour of Code 2015
           lesson_groups: {}
+          lessons:
+            Hour of Code 2015:
+              name: Hour of Code 2015
         mc:
           title: Minecraft Hour of Code
           description: Use blocks of code to take Steve or Alex on an adventure through this Minecraft world.
@@ -1973,6 +3352,9 @@ en:
               name: Hour of Code 2015
           description_audience: ''
           lesson_groups: {}
+          lessons:
+            Hour of Code 2015:
+              name: Hour of Code 2015
         oceans:
           title: AI for Oceans
           description: Learn how AI and machine learning can be used to address world problems.
@@ -1982,6 +3364,9 @@ en:
               name: Oceans
           description_audience: ''
           lesson_groups: {}
+          lessons:
+            Oceans:
+              name: Oceans
         CSPPD3-Unit3-pt2:
           title: 'Computer Science Principles: Unit 3 PD Challenges'
           description: Online Exploration of CSP Unit 3-- Lesson Challenges
@@ -1994,6 +3379,13 @@ en:
             Share out and Submit:
               name: Share out and Submit
           lesson_groups: {}
+          lessons:
+            Challenge Overview:
+              name: Challenge Overview
+            Complete the Challenge:
+              name: Complete the Challenge
+            Share out and Submit:
+              name: Share out and Submit
         ScienceP3OLPT3:
           title: Computer Science in Science PD Pre-Phase 3B
           description: Phase 3 Academic Year Development
@@ -2009,6 +3401,15 @@ en:
             Wrap-Up:
               name: Wrap-Up
           lesson_groups: {}
+          lessons:
+            Welcome!:
+              name: Welcome!
+            Assessing Computer Models:
+              name: Assessing Computer Models
+            "(optional) Refresh your connection to Complex Adaptive Systems":
+              name: "(optional) Refresh your connection to Complex Adaptive Systems"
+            Wrap-Up:
+              name: Wrap-Up
         cspunit5:
           title: "(old) CS Principles Unit 5 - Performance Tasks"
           description: This unit covers the preparation and completion of the Explore and Create Performance Tasks.
@@ -2024,6 +3425,15 @@ en:
               name: Explore PT Prep
           description_audience: ''
           lesson_groups: {}
+          lessons:
+            Explore PT Prep:
+              name: Explore PT Prep
+            Explore PT:
+              name: Explore PT
+            Create PT Prep:
+              name: Create PT Prep
+            Create PT:
+              name: Create PT
         cspunit4:
           title: "(old) CS Principles Unit 4 - Data"
           description: Being able to digitally manipulate data, visualize it, and identify patterns, trends and possible meanings are important practical skills that computer scientists do every day. The data-rich world we live in also introduces many complex questions related to public policy, law, ethics and societal impact. Understanding where data comes from, having intuitions about what could be learned or extracted from it, and being able to use computational tools to manipulate data and communicate about it are the primary skills addressed in the unit.
@@ -2059,6 +3469,35 @@ en:
             What is Big Data?:
               name: What is Big Data?
           lesson_groups: {}
+          lessons:
+            Intro to Data:
+              name: Intro to Data
+            Finding Trends with Visualizations:
+              name: Finding Trends with Visualizations
+            Check Your Assumptions:
+              name: Check Your Assumptions
+            Good and Bad Data Visualizations:
+              name: Good and Bad Data Visualizations
+            Making Data Visualizations:
+              name: Making Data Visualizations
+            Discover a Data Story:
+              name: Discover a Data Story
+            Cleaning Data:
+              name: Cleaning Data
+            Creating Summary Tables:
+              name: Creating Summary Tables
+            Practice PT - Tell a Data Story:
+              name: Practice PT - Tell a Data Story
+            What is Big Data?:
+              name: What is Big Data?
+            Rapid Research - Data Innovations:
+              name: Rapid Research - Data Innovations
+            Identifying People with Data:
+              name: Identifying People with Data
+            The Cost of Free:
+              name: The Cost of Free
+            Practice PT - Propose an Innovation:
+              name: Practice PT - Propose an Innovation
         CSPPD3-Unit4:
           title: 'Computer Science Principles: Unit 4 PD'
           description: Online Support for CSP Unit 4
@@ -2081,6 +3520,23 @@ en:
             Unit 4 Overview:
               name: Unit 4 Overview
           lesson_groups: {}
+          lessons:
+            Getting Started:
+              name: Getting Started
+            Unit 4 Overview:
+              name: Unit 4 Overview
+            Chapter 1 Overview:
+              name: Chapter 1 Overview
+            Chapter 2 Overview:
+              name: Chapter 2 Overview
+            Practice Performance Tasks:
+              name: Practice Performance Tasks
+            Challenge Overview:
+              name: Challenge Overview
+            Complete the Challenge:
+              name: Complete the Challenge
+            Share out and Submit:
+              name: Share out and Submit
         cspunit6draft:
           title: CSP Post-AP Material - Databases and Using Data in Your Apps
           description: App Lab has a number of tools that allow you to collect and use data in your apps. The following material provides an overview of how these tools work, and it concludes with a sampling of example projects that can be built using these tools.
@@ -2106,6 +3562,25 @@ en:
               name: Visualizing Data
           description_audience: ''
           lesson_groups: {}
+          lessons:
+            Creating Javascript Objects:
+              name: Creating Javascript Objects
+            Permanent Data Storage:
+              name: Permanent Data Storage
+            Reading Records:
+              name: Reading Records
+            Deleting Records:
+              name: Deleting Records
+            Updating Records:
+              name: Updating Records
+            Importing and Exporting Data:
+              name: Importing and Exporting Data
+            Visualizing Data:
+              name: Visualizing Data
+            Sample Apps:
+              name: Sample Apps
+            Final Project:
+              name: Final Project
         CSPPD3-Unit5:
           title: 'Computer Science Principles: Unit 5 PD'
           description: Online Support for CSP Unit 5
@@ -2126,6 +3601,21 @@ en:
             Unit 5 Overview:
               name: Unit 5 Overview
           lesson_groups: {}
+          lessons:
+            Getting Started:
+              name: Getting Started
+            Unit 5 Overview:
+              name: Unit 5 Overview
+            Explore PT Breakdown:
+              name: Explore PT Breakdown
+            Create PT Breakdown:
+              name: Create PT Breakdown
+            Challenge Overview:
+              name: Challenge Overview
+            Complete the Challenge:
+              name: Complete the Challenge
+            Share out and Submit:
+              name: Share out and Submit
         cspunit6:
           title: CSP Post-AP Material - Databases and Using Data in Your Apps
           description: App Lab has a number of tools that allow you to collect and use data in your apps. The following material provides an overview of how these tools work, a sampling of example projects that can be built using these tools, and a space in which to build and submit a final project.
@@ -2151,6 +3641,25 @@ en:
             Visualizing Data:
               name: Visualizing Data
           lesson_groups: {}
+          lessons:
+            Creating Javascript Objects:
+              name: Creating Javascript Objects
+            Permanent Data Storage:
+              name: Permanent Data Storage
+            Reading Records:
+              name: Reading Records
+            Deleting Records:
+              name: Deleting Records
+            Updating Records:
+              name: Updating Records
+            Importing and Exporting Data:
+              name: Importing and Exporting Data
+            Visualizing Data:
+              name: Visualizing Data
+            Sample Apps:
+              name: Sample Apps
+            Final Project:
+              name: Final Project
         AlgebraA:
           title: 'Computer Science in Algebra: Course A'
           description: Learn Functional Programming through Algebra
@@ -2178,6 +3687,27 @@ en:
             'Unplugged: The Design Recipe':
               name: 'Unplugged: The Design Recipe'
           lesson_groups: {}
+          lessons:
+            'Calc: Evaluation Blocks':
+              name: 'Calc: Evaluation Blocks'
+            'Eval: Strings and Images':
+              name: 'Eval: Strings and Images'
+            'Unplugged: Contracts':
+              name: 'Unplugged: Contracts'
+            'Eval: Writing Contracts':
+              name: 'Eval: Writing Contracts'
+            'Calc: Defining Variables':
+              name: 'Calc: Defining Variables'
+            'Unplugged: Fast Functions':
+              name: 'Unplugged: Fast Functions'
+            'Eval: Defining Functions':
+              name: 'Eval: Defining Functions'
+            'Unplugged: The Design Recipe':
+              name: 'Unplugged: The Design Recipe'
+            'Eval: Functions':
+              name: 'Eval: Functions'
+            'Play Lab: Defining Functions':
+              name: 'Play Lab: Defining Functions'
         AlgebraB:
           title: 'Computer Science in Algebra: Course B'
           description: Learn Functional Programming through Algebra
@@ -2207,6 +3737,29 @@ en:
             'Unplugged: Video Games and Coordinate Planes':
               name: 'Unplugged: Video Games and Coordinate Planes'
           lesson_groups: {}
+          lessons:
+            'Unplugged: Video Games and Coordinate Planes':
+              name: 'Unplugged: Video Games and Coordinate Planes'
+            'Play Lab: Defining Variables (Big Game)':
+              name: 'Play Lab: Defining Variables (Big Game)'
+            'Play Lab: Animation (Big Game)':
+              name: 'Play Lab: Animation (Big Game)'
+            'Unplugged: Booleans':
+              name: 'Unplugged: Booleans'
+            'Eval: Boolean Operators':
+              name: 'Eval: Boolean Operators'
+            'Play Lab: Booleans':
+              name: 'Play Lab: Booleans'
+            'Play Lab: Boolean (Big Game)':
+              name: 'Play Lab: Boolean (Big Game)'
+            'Unplugged: Conditionals and Piecewise Functions':
+              name: 'Unplugged: Conditionals and Piecewise Functions'
+            'Eval: Conditionals':
+              name: 'Eval: Conditionals'
+            'Unplugged: Collision Detection and the Distance Formula':
+              name: 'Unplugged: Collision Detection and the Distance Formula'
+            'Play Lab: Collision Detection (Big Game)':
+              name: 'Play Lab: Collision Detection (Big Game)'
         gamelab-hackathon:
           title: Gamelab Hackathon
           description: A place to try things out in Game Lab
@@ -2215,6 +3768,9 @@ en:
             Middle_School_Hackathon:
               name: Middle_School_Hackathon
           lesson_groups: {}
+          lessons:
+            Middle_School_Hackathon:
+              name: Middle_School_Hackathon
         algebraPD1:
           title: CS in Algebra Part 1
           description: Teach Algebra through Functional Programming
@@ -2234,6 +3790,19 @@ en:
             Why Computer Science belongs in Algebra:
               name: Why Computer Science belongs in Algebra
           lesson_groups: {}
+          lessons:
+            Introduction to PD:
+              name: Introduction to PD
+            Course Overview:
+              name: Course Overview
+            Why Computer Science belongs in Algebra:
+              name: Why Computer Science belongs in Algebra
+            Evaluation Blocks:
+              name: Evaluation Blocks
+            Teacher Dashboard:
+              name: Teacher Dashboard
+            Preparing for in-person PD:
+              name: Preparing for in-person PD
         algebraPD3c:
           title: Computer Science in Algebra PD
           description: CS in Algebra end of year reflection
@@ -2247,6 +3816,13 @@ en:
             Sharing Student Work:
               name: Sharing Student Work
           lesson_groups: {}
+          lessons:
+            Getting Started:
+              name: Getting Started
+            Sharing Student Work:
+              name: Sharing Student Work
+            Planning For the Future:
+              name: Planning For the Future
         csp1-2017:
           title: CSP Unit 1 - The Internet ('17-'18)
           description: This unit explores the technical challenges and questions that arise from the need to represent digital information in computers and transfer it between people and computational devices. The unit then explores the structure and design of the internet and the implications of those design decisions.
@@ -2302,6 +3878,43 @@ en:
               display_name: 'Chapter 1: Representing and Transmitting Information'
             csp1_2:
               display_name: 'Chapter 2: Inventing the Internet'
+          lessons:
+            CS Principles Pre-survey:
+              name: CS Principles Pre-survey
+            Personal Innovations:
+              name: Personal Innovations
+            Sending Binary Messages:
+              name: Sending Binary Messages
+            Sending Binary Messages with the Internet Simulator:
+              name: Sending Binary Messages with the Internet Simulator
+            Number Systems:
+              name: Number Systems
+            Binary Numbers:
+              name: Binary Numbers
+            Sending Numbers:
+              name: Sending Numbers
+            Encoding and Sending Formatted Text:
+              name: Encoding and Sending Formatted Text
+            Unit 1 Chapter 1 Assessment:
+              name: Unit 1 Chapter 1 Assessment
+            The Internet:
+              name: The Internet
+            The Need for Addressing:
+              name: The Need for Addressing
+            Routers and Redundancy:
+              name: Routers and Redundancy
+            Packets and Making a Reliable Internet:
+              name: Packets and Making a Reliable Internet
+            The Need for DNS:
+              name: The Need for DNS
+            HTTP and Abstraction:
+              name: HTTP and Abstraction
+            Practice PT - The Internet and Society:
+              name: Practice PT - The Internet and Society
+            Unit 1 Chapter 2 Assessment:
+              name: Unit 1 Chapter 2 Assessment
+            Post-Course Survey:
+              name: Post-Course Survey
         csp2-2017:
           title: CSP Unit 2 - Digital Information ('17-'18)
           description: This unit further explores the ways that digital information is encoded, represented and manipulated. Being able to digitally manipulate data, visualize it, and identify patterns, trends and possible meanings are important practical skills that computer scientists do every day. Understanding where data comes from, having intuitions about what could be learned or extracted from it, and being able to use computational tools to manipulate data and communicate about it are the primary skills addressed in the unit.
@@ -2359,6 +3972,43 @@ en:
               display_name: 'Chapter 2: Manipulating and Visualizing Data'
             cspSurvey:
               display_name: Survey
+          lessons:
+            Bytes and File Sizes:
+              name: Bytes and File Sizes
+            Text Compression:
+              name: Text Compression
+            Encoding B&W Images:
+              name: Encoding B&W Images
+            Encoding Color Images:
+              name: Encoding Color Images
+            Lossy Compression and File Formats:
+              name: Lossy Compression and File Formats
+            Practice PT - Encode an Experience:
+              name: Practice PT - Encode an Experience
+            Unit 2 Chapter 1 Assessment:
+              name: Unit 2 Chapter 1 Assessment
+            Intro to Data:
+              name: Intro to Data
+            Finding Trends with Visualizations:
+              name: Finding Trends with Visualizations
+            Check Your Assumptions:
+              name: Check Your Assumptions
+            Good and Bad Data Visualizations:
+              name: Good and Bad Data Visualizations
+            Making Data Visualizations:
+              name: Making Data Visualizations
+            Discover a Data Story:
+              name: Discover a Data Story
+            Cleaning Data:
+              name: Cleaning Data
+            Creating Summary Tables:
+              name: Creating Summary Tables
+            Practice PT - Tell a Data Story:
+              name: Practice PT - Tell a Data Story
+            Unit 2 Chapter 2 Assessment:
+              name: Unit 2 Chapter 2 Assessment
+            Post-Course Survey:
+              name: Post-Course Survey
         csp3-2017:
           title: CSP Unit 3 - Intro to Programming ('17-'18)
           description: "This unit introduces the foundational concepts of computer programming, which unlocks the ability to make rich, interactive apps. This course uses JavaScript as the programming language, and App Lab as the programming environment to build apps, but the concepts learned in these lessons span all programming languages and tools.\r\n\r\nThis unit was last updated October 30th, 2017. Read more about curriculum updates at forum.code.org/c/csp/updates."
@@ -2412,6 +4062,31 @@ en:
               display_name: Chapter Assessment
             cspSurvey:
               display_name: Survey
+          lessons:
+            The Need For Programming Languages:
+              name: The Need For Programming Languages
+            The Need for Algorithms:
+              name: The Need for Algorithms
+            Creativity in Algorithms:
+              name: Creativity in Algorithms
+            Using Simple Commands:
+              name: Using Simple Commands
+            Creating Functions:
+              name: Creating Functions
+            Functions and Top-Down Design:
+              name: Functions and Top-Down Design
+            APIs and Function Parameters:
+              name: APIs and Function Parameters
+            Creating functions with Parameters:
+              name: Creating functions with Parameters
+            Looping and Random Numbers:
+              name: Looping and Random Numbers
+            Practice PT - Design a Digital Scene:
+              name: Practice PT - Design a Digital Scene
+            Unit 3 Chapter 1 Assessment:
+              name: Unit 3 Chapter 1 Assessment
+            Post-Course Survey:
+              name: Post-Course Survey
         csp4-2017:
           title: CSP Unit 4 - Big Data and Privacy ('17-'18)
           description: "The data-rich world we live in introduces many complex questions related to public policy, law, ethics and societal impact. The goals of this unit are to develop a well-rounded and balanced view about data in the world, including the positive and negative effects of it, and to understand the basics of how and why modern encryption works.\r\n\r\nThis unit was last updated November, 2017. Read more about curriculum updates at forum.code.org/c/csp/updates."
@@ -2463,6 +4138,29 @@ en:
               display_name: Chapter Assessment
             cspSurvey:
               display_name: Survey
+          lessons:
+            What is Big Data?:
+              name: What is Big Data?
+            Rapid Research - Data Innovations:
+              name: Rapid Research - Data Innovations
+            Identifying People with Data:
+              name: Identifying People with Data
+            The Cost of Free:
+              name: The Cost of Free
+            Simple Encryption:
+              name: Simple Encryption
+            Encryption with Keys and Passwords:
+              name: Encryption with Keys and Passwords
+            Public Key Crypto:
+              name: Public Key Crypto
+            Rapid Research - Cybercrime:
+              name: Rapid Research - Cybercrime
+            Practice PT - Big Data and Security Dilemmas:
+              name: Practice PT - Big Data and Security Dilemmas
+            Unit 4 Chapter 1 Assessment:
+              name: Unit 4 Chapter 1 Assessment
+            Post-Course Survey:
+              name: Post-Course Survey
         csp5-2017:
           title: CSP Unit 5 - Building Apps ('17-'18)
           description: This unit continues the introduction of foundational concepts of computer programming, which unlocks the ability to make rich, interactive apps. This course uses JavaScript as the programming language, and App Lab as the programming environment to build apps, but the concepts learned in these lessons span all programming languages and tools.
@@ -2582,6 +4280,55 @@ en:
               display_name: 'Chapter 2: Programming with Data Structures'
             cspSurvey:
               display_name: Survey
+          lessons:
+            Buttons and Events:
+              name: Buttons and Events
+            Multi-screen Apps:
+              name: Multi-screen Apps
+            'Building an App: Multi-Screen App':
+              name: 'Building an App: Multi-Screen App'
+            Controlling Memory with Variables:
+              name: Controlling Memory with Variables
+            'Building an App: Clicker Game':
+              name: 'Building an App: Clicker Game'
+            Unit 5 Assessment 1:
+              name: Unit 5 Assessment 1
+            User Input and Strings:
+              name: User Input and Strings
+            '"If" Statements Unplugged':
+              name: '"If" Statements Unplugged'
+            Boolean Expressions and "If" Statements:
+              name: Boolean Expressions and "If" Statements
+            '"if-else-if" and Conditional Logic':
+              name: '"if-else-if" and Conditional Logic'
+            'Building an App: Color Sleuth':
+              name: 'Building an App: Color Sleuth'
+            Unit 5 Assessment 2:
+              name: Unit 5 Assessment 2
+            While Loops:
+              name: While Loops
+            Loops and Simulations:
+              name: Loops and Simulations
+            Introduction to Arrays:
+              name: Introduction to Arrays
+            'Building an App: Image Scroller':
+              name: 'Building an App: Image Scroller'
+            Unit 5 Assessment 3:
+              name: Unit 5 Assessment 3
+            Processing Arrays:
+              name: Processing Arrays
+            Functions with Return Values:
+              name: Functions with Return Values
+            'Building an App: Canvas Painter':
+              name: 'Building an App: Canvas Painter'
+            Unit 5 Assessment 4:
+              name: Unit 5 Assessment 4
+            'Practice PT: Create':
+              name: 'Practice PT: Create'
+            Unit 5 Assessment 5 - AP Pseudocode Practice Questions:
+              name: Unit 5 Assessment 5 - AP Pseudocode Practice Questions
+            Post-Course Survey:
+              name: Post-Course Survey
         csp6:
           title: CSP Unit 6 - AP Performance Tasks
           description: This unit covers the preparation and completion of the Create and Explore Performance Tasks.
@@ -2617,6 +4364,23 @@ en:
             CSP Student Post-Course Survey:
               name: CSP Student Post-Course Survey
           lesson_groups: {}
+          lessons:
+            Tech Setup - Your AP Digital Portfolio and Other Tools:
+              name: Tech Setup - Your AP Digital Portfolio and Other Tools
+            Create PT Prep - Reviewing the Task:
+              name: Create PT Prep - Reviewing the Task
+            Create PT Prep - Making a Plan:
+              name: Create PT Prep - Making a Plan
+            Create PT - Complete the Task:
+              name: Create PT - Complete the Task
+            Explore PT Prep - Reviewing the Task:
+              name: Explore PT Prep - Reviewing the Task
+            Explore PT - Making a Plan:
+              name: Explore PT - Making a Plan
+            Explore PT - Complete the Task:
+              name: Explore PT - Complete the Task
+            Participate in a longitudinal study!:
+              name: Participate in a longitudinal study!
         CSDU3-Draft:
           title: " TEMP CSD Unit 3 - Interactive Games and Animations"
           description: Temp place to work on U3 of Disco
@@ -2696,6 +4460,31 @@ en:
             What to Expect:
               name: What to Expect
           lesson_groups: {}
+          lessons:
+            Introduction to PD:
+              name: Introduction to PD
+            What to Expect:
+              name: What to Expect
+            Introduction to Complex Adaptive Systems:
+              name: Introduction to Complex Adaptive Systems
+            Introduction to Computational Science:
+              name: Introduction to Computational Science
+            Agent Based Modeling of Complex Adaptive Systems:
+              name: Agent Based Modeling of Complex Adaptive Systems
+            Using Computer Models in Science:
+              name: Using Computer Models in Science
+            Using Models in the Classroom:
+              name: Using Models in the Classroom
+            Dispositions and Classroom Culture:
+              name: Dispositions and Classroom Culture
+            Computational Thinking And The Framework For K-12 Science Education:
+              name: Computational Thinking And The Framework For K-12 Science Education
+            Introduction to StarLogo Nova:
+              name: Introduction to StarLogo Nova
+            The Tutorial:
+              name: The Tutorial
+            Post-Survey:
+              name: Post-Survey
         TEMP CSD Unit 3:
           title: " TEMP CSD Unit 3 - Interactive Games and Animations"
           description: ''
@@ -2713,6 +4502,9 @@ en:
             Sample Stage:
               name: Sample Stage
           lesson_groups: {}
+          lessons:
+            Sample Stage:
+              name: Sample Stage
         ECSPD1:
           title: ECS Part 1
           description: Two hour introduction to your Professional Learning Program for the ECS Version 5 curriculum
@@ -2734,6 +4526,17 @@ en:
             'Classroom and workshop style ':
               name: 'Classroom and workshop style '
           lesson_groups: {}
+          lessons:
+            Welcome to Phase 1!:
+              name: Welcome to Phase 1!
+            Background and Context:
+              name: Background and Context
+            ECS Curriculum:
+              name: ECS Curriculum
+            'Classroom and workshop style ':
+              name: 'Classroom and workshop style '
+            Wrap Up:
+              name: Wrap Up
         algebraFacilitator:
           title: Computer Science in Algebra Facilitator Pre Work
           description: Teach Algebra through Functional Programming
@@ -2749,6 +4552,15 @@ en:
             Why Computer Science belongs in Algebra:
               name: Why Computer Science belongs in Algebra
           lesson_groups: {}
+          lessons:
+            Introduction to PD:
+              name: Introduction to PD
+            Why Computer Science belongs in Algebra:
+              name: Why Computer Science belongs in Algebra
+            Evaluation Blocks:
+              name: Evaluation Blocks
+            Teacher Dashboard:
+              name: Teacher Dashboard
         sciencePD1:
           title: 'CS in Science: Part 1'
           description: In Partnership with Project GUTS
@@ -2780,6 +4592,31 @@ en:
             What to Expect:
               name: What to Expect
           lesson_groups: {}
+          lessons:
+            Introduction to PD:
+              name: Introduction to PD
+            What to Expect:
+              name: What to Expect
+            Introduction to Complex Adaptive Systems:
+              name: Introduction to Complex Adaptive Systems
+            Introduction to Computational Science:
+              name: Introduction to Computational Science
+            Agent Based Modeling of Complex Adaptive Systems:
+              name: Agent Based Modeling of Complex Adaptive Systems
+            Using Computer Models in Science:
+              name: Using Computer Models in Science
+            Using Models in the Classroom:
+              name: Using Models in the Classroom
+            Dispositions and Classroom Culture:
+              name: Dispositions and Classroom Culture
+            Computational Thinking And The Framework For K-12 Science Education:
+              name: Computational Thinking And The Framework For K-12 Science Education
+            Introduction to StarLogo Nova:
+              name: Introduction to StarLogo Nova
+            The Tutorial:
+              name: The Tutorial
+            Post-Survey:
+              name: Post-Survey
         cspoptional:
           title: CS Principles Optional Lessons
           description: Optional lessons and content across all of the CS Principles units are listed here
@@ -2807,6 +4644,27 @@ en:
             Unit 4 - One-Way Functions - The WiFi Hotspot Problem:
               name: Unit 4 - One-Way Functions - The WiFi Hotspot Problem
           lesson_groups: {}
+          lessons:
+            Unit 1 - Sending Bits in the Real World:
+              name: Unit 1 - Sending Bits in the Real World
+            Unit 1 - Encoding Numbers in the Real World:
+              name: Unit 1 - Encoding Numbers in the Real World
+            Unit 1 - Algorithms Detour - Minimum Spanning Tree:
+              name: Unit 1 - Algorithms Detour - Minimum Spanning Tree
+            Unit 1 - Algorithms Detour - Shortest Path:
+              name: Unit 1 - Algorithms Detour - Shortest Path
+            Unit 1 - How Routers Learn:
+              name: Unit 1 - How Routers Learn
+            Unit 4 - Hard Problems - The Traveling Salesperson Problem:
+              name: Unit 4 - Hard Problems - The Traveling Salesperson Problem
+            Unit 4 - One-Way Functions - The WiFi Hotspot Problem:
+              name: Unit 4 - One-Way Functions - The WiFi Hotspot Problem
+            Algorithms Detour - Minimum Spanning Tree:
+              name: Algorithms Detour - Minimum Spanning Tree
+            Algorithms Detour - Shortest Path:
+              name: Algorithms Detour - Shortest Path
+            Algorithms Detour - How Routers Learn:
+              name: Algorithms Detour - How Routers Learn
         cspunit1-support:
           title: Online Support for CSP Unit 1
           description: This is a test Professional Learning Course
@@ -2836,6 +4694,23 @@ en:
               display_name: Content
             practice:
               display_name: Teaching Practices
+          lessons:
+            Intro to the Unit:
+              name: Intro to the Unit
+            Chapter Overviews:
+              name: Chapter Overviews
+            'Tool Talk: Intro to Netsim':
+              name: 'Tool Talk: Intro to Netsim'
+            Sending Binary Messages:
+              name: Sending Binary Messages
+            Encoding and Sending Numbers:
+              name: Encoding and Sending Numbers
+            Supporting Peer Learning:
+              name: Supporting Peer Learning
+            Running a Constructive Classroom:
+              name: Running a Constructive Classroom
+            Strategies for Student Writing:
+              name: Strategies for Student Writing
         test-teaching-ap-cs-unit-1:
           title: Test CPS PD
           description_audience: ''
@@ -2863,6 +4738,21 @@ en:
               display_name: Content
             practice:
               display_name: Teaching Practices
+          lessons:
+            test Unit 1 required reading:
+              name: test Unit 1 required reading
+            test Unit 1 content module Alpha:
+              name: test Unit 1 content module Alpha
+            test Unit 1 content module Bravo:
+              name: test Unit 1 content module Bravo
+            test Unit 1 content module Charlie:
+              name: test Unit 1 content module Charlie
+            test Unit 1 practice module Delta:
+              name: test Unit 1 practice module Delta
+            test Unit 1 practice module Echo:
+              name: test Unit 1 practice module Echo
+            test Unit 1 practice module Foxtrot:
+              name: test Unit 1 practice module Foxtrot
         allthehiddenthings:
           title: All the Hidden Things!
           description: Unreleased level types for UI testing as admin
@@ -2873,6 +4763,11 @@ en:
             Game Lab:
               name: Game Lab
           lesson_groups: {}
+          lessons:
+            Game Lab:
+              name: Game Lab
+            Contained Levels:
+              name: Contained Levels
         cspunit1-support-test:
           title: CSP Unit 1 teacher support
           description: Online Supports for CSP Unit 1
@@ -2882,6 +4777,9 @@ en:
             Unit 1 Overview:
               name: Unit 1 Overview
           lesson_groups: {}
+          lessons:
+            Unit 1 Overview:
+              name: Unit 1 Overview
         cspunit1-tools:
           title: netsim task completion
           description: introduction to the internet simulator and a discussion of how we use it to teach the internet
@@ -2889,6 +4787,9 @@ en:
             netsim:
               name: netsim
           lesson_groups: {}
+          lessons:
+            netsim:
+              name: netsim
         csp-facilitators:
           title: CSP Tool Overview
           description: A collection of tools from the CS Principles course. These levels provide a glimpse into the tools we use throughout the curriculum to
@@ -2902,6 +4803,13 @@ en:
             Turtle Programming:
               name: Turtle Programming
           lesson_groups: {}
+          lessons:
+            Introduction to Text Compression:
+              name: Introduction to Text Compression
+            Turtle Programming:
+              name: Turtle Programming
+            Introduction to Events:
+              name: Introduction to Events
         cspassessment:
           title: "[Deprecated] CS Principles Culminating Assessment"
           description: 'This assessment has been deprecated and is scheduled for removal in Summer of 2017.  Students may complete the test and see their own results, but a teacher will not be able to see results for students in a section.  Please use the official CSP practice exam from the College Board.  [This 55-question multiple choice assessment covers questions across 7 big ideas of computer science: Creativity, Abstraction, Data, Algorithms, Programming, The Internet, and Global Impact.]'
@@ -2925,6 +4833,11 @@ en:
             RQB Questions test:
               name: RQB Questions test
           lesson_groups: {}
+          lessons:
+            'NOTE: Deprecated. Teacher cannot see results. CSP Culminating Assessment':
+              name: 'NOTE: Deprecated. Teacher cannot see results. CSP Culminating Assessment'
+            RQB Questions test:
+              name: RQB Questions test
         cspexam1-mWU7ilDYM9:
           title: CS Principles Culminating Assessment - Part 1
           description: 'This 25 question multiple choice assessment covers questions across 7 big ideas of computer science: Creativity, Abstraction, Data, Algorithms, Programming, The Internet, and Global Impact.'
@@ -2934,6 +4847,9 @@ en:
             CS Principles Culminating Assessment Part 1:
               name: CS Principles Culminating Assessment Part 1
           lesson_groups: {}
+          lessons:
+            CS Principles Culminating Assessment Part 1:
+              name: CS Principles Culminating Assessment Part 1
         cspexam2-AKwgAh1ac5:
           title: CS Principles Culminating Assessment - Part 2
           description: 'This 25 question multiple choice assessment covers questions across 7 big ideas of computer science: Creativity, Abstraction, Data, Algorithms, Programming, The Internet, and Global Impact.  It is part 2 of a two-part 50 question exam'
@@ -2943,6 +4859,9 @@ en:
             CS Principles Culminating Assessment Part 2:
               name: CS Principles Culminating Assessment Part 2
           lesson_groups: {}
+          lessons:
+            CS Principles Culminating Assessment Part 2:
+              name: CS Principles Culminating Assessment Part 2
         CSDU4-Draft:
           title: " TEMP CSD Unit 4 - The Design Process"
           description: Temp place to work on U4 of Disco
@@ -3089,6 +5008,9 @@ en:
             Sample Stage:
               name: Sample Stage
           lesson_groups: {}
+          lessons:
+            Sample Stage:
+              name: Sample Stage
         MikeTest:
           title: MikeTest
           description: Trying not to break anything
@@ -3104,6 +5026,15 @@ en:
             You are a coding STAR:
               name: You are a coding STAR
           lesson_groups: {}
+          lessons:
+            Sample Stage:
+              name: Sample Stage
+            Artist Functions:
+              name: Artist Functions
+            The same thing with named levels:
+              name: The same thing with named levels
+            You are a coding STAR:
+              name: You are a coding STAR
         artistExemplar:
           title: Artist Exemplar
           description: These artist levels will knock the socks off of third graders
@@ -3113,6 +5044,9 @@ en:
             Artist Exemplar:
               name: Artist Exemplar
           lesson_groups: {}
+          lessons:
+            Artist Exemplar:
+              name: Artist Exemplar
         teachercon:
           title: TeacherCon Supports
           description: We will use this during TeacherCon to deliver supports and materials for sessions
@@ -3152,6 +5086,33 @@ en:
               display_name: Content
             practice:
               display_name: Teaching Practices
+          lessons:
+            Introduction to Teachercon:
+              name: Introduction to Teachercon
+            Lesson 1,4:
+              name: Lesson 1,4
+            Lesson 1,6:
+              name: Lesson 1,6
+            Lesson 1,9:
+              name: Lesson 1,9
+            Lesson 1,10:
+              name: Lesson 1,10
+            Lesson 1,11:
+              name: Lesson 1,11
+            Lesson 2,2:
+              name: Lesson 2,2
+            Lesson 2,3:
+              name: Lesson 2,3
+            Lesson 2,10:
+              name: Lesson 2,10
+            Group Work and Peer Learning:
+              name: Group Work and Peer Learning
+            Balancing Teachers and Tools:
+              name: Balancing Teachers and Tools
+            Discovery Learning:
+              name: Discovery Learning
+            Measuring Student Learning:
+              name: Measuring Student Learning
         kinderTest:
           title: ''
           description_audience: ''
@@ -3163,6 +5124,11 @@ en:
             Kindergarten Stage 1:
               name: Kindergarten Stage 1
           lesson_groups: {}
+          lessons:
+            'Bee: Conditionals':
+              name: 'Bee: Conditionals'
+            Kindergarten Stage 1:
+              name: Kindergarten Stage 1
         gradeKinder:
           title: Kindergarten
           description: Planning Script for CSF 2.0
@@ -3310,6 +5276,7 @@ en:
             'Unplugged: Songwriting with Parameters':
               name: 'Unplugged: Songwriting with Parameters'
           lesson_groups: {}
+          lessons: {}
         ecs-unit1:
           title: ECS Unit 1
           description: 'Unit 1: Human-Computer Interaction'
@@ -3341,6 +5308,31 @@ en:
             Wrap-up:
               name: Wrap-up
           lesson_groups: {}
+          lessons:
+            Welcome!:
+              name: Welcome!
+            ? |-
+              Unit 1, Days 1-2
+              What Is a Computer?
+            : name: |-
+                Unit 1, Days 1-2
+                What Is a Computer?
+            Unit 1, Days 3-4 Buying a Computer:
+              name: Unit 1, Days 3-4 Buying a Computer
+            Unit 1, Days 5-7 Searching and Web 2:
+              name: Unit 1, Days 5-7 Searching and Web 2
+            Unit 1, Days 8-9 Impact of Computers and Communication:
+              name: Unit 1, Days 8-9 Impact of Computers and Communication
+            Unit 1, Day 10 Telling a Story with Data:
+              name: Unit 1, Day 10 Telling a Story with Data
+            Unit 1, Day 11-14 Data Modeling and Design:
+              name: Unit 1, Day 11-14 Data Modeling and Design
+            Unit 1, Day 15-16 Computer Programs and Following Directions:
+              name: Unit 1, Day 15-16 Computer Programs and Following Directions
+            Unit 1, Day 17-19 What Is Intelligence?:
+              name: Unit 1, Day 17-19 What Is Intelligence?
+            Wrap-up:
+              name: Wrap-up
         ecs-unit2:
           title: ECS Unit 2
           description: 'Unit 2: Problem Solving'
@@ -3360,6 +5352,19 @@ en:
             Unit 2 Challenge:
               name: Unit 2 Challenge
           lesson_groups: {}
+          lessons:
+            Getting Started:
+              name: Getting Started
+            Intro to Unit 2:
+              name: Intro to Unit 2
+            Teaching Strategies:
+              name: Teaching Strategies
+            Lesson Overviews:
+              name: Lesson Overviews
+            Unit 2 Challenge:
+              name: Unit 2 Challenge
+            Close & Next Steps:
+              name: Close & Next Steps
         ecs-unit3:
           title: ECS Unit 3
           description: 'Unit 3: Web Design'
@@ -3379,6 +5384,19 @@ en:
             Unit 3 Day-by-Day:
               name: Unit 3 Day-by-Day
           lesson_groups: {}
+          lessons:
+            Getting Started:
+              name: Getting Started
+            Intro to Unit 3:
+              name: Intro to Unit 3
+            Teaching Strategies:
+              name: Teaching Strategies
+            Unit 3 Day-by-Day:
+              name: Unit 3 Day-by-Day
+            Unit 3 Challenge:
+              name: Unit 3 Challenge
+            Close & Next Steps:
+              name: Close & Next Steps
         ecs-unit4:
           title: ECS Unit 4
           description: 'Unit 4: Programming'
@@ -3398,6 +5416,19 @@ en:
             Unit 4 Day-by-Day:
               name: Unit 4 Day-by-Day
           lesson_groups: {}
+          lessons:
+            Getting Started:
+              name: Getting Started
+            Intro to Unit 4:
+              name: Intro to Unit 4
+            Teaching Strategies:
+              name: Teaching Strategies
+            Unit 4 Day-by-Day:
+              name: Unit 4 Day-by-Day
+            Unit 4 Challenge:
+              name: Unit 4 Challenge
+            Close & Next Steps:
+              name: Close & Next Steps
         ecs-unit5:
           title: ECS Unit 5
           description: 'Unit 5: Computer and Data Analysis'
@@ -3421,6 +5452,17 @@ en:
             Close & Next Steps:
               name: Close & Next Steps
           lesson_groups: {}
+          lessons:
+            Getting Started:
+              name: Getting Started
+            Unit 5 Overview:
+              name: Unit 5 Overview
+            Unit 5 lessons:
+              name: Unit 5 lessons
+            Unit 5 Challenge:
+              name: Unit 5 Challenge
+            Close & Next Steps:
+              name: Close & Next Steps
         ecs-unit6:
           title: ECS Unit 6
           description: 'Unit 6: Robotics'
@@ -3442,6 +5484,19 @@ en:
             Close & Next Steps:
               name: Close & Next Steps
           lesson_groups: {}
+          lessons:
+            Getting Started:
+              name: Getting Started
+            Unit 6 Overview:
+              name: Unit 6 Overview
+            Unit 6 lessons:
+              name: Unit 6 lessons
+            Alternative Ideas for Unit 6:
+              name: Alternative Ideas for Unit 6
+            Unit 6 Challenge:
+              name: Unit 6 Challenge
+            Close & Next Steps:
+              name: Close & Next Steps
         grade3:
           title: Grade 3
           description: Planning Script for CSF 2.0
@@ -3515,6 +5570,31 @@ en:
               display_name: Content
             practice:
               display_name: Teaching Practices
+          lessons:
+            Introduction to Teachercon:
+              name: Introduction to Teachercon
+            Lesson 1,4:
+              name: Lesson 1,4
+            Lesson 1,6:
+              name: Lesson 1,6
+            Lesson 1,9:
+              name: Lesson 1,9
+            Lesson 1,10:
+              name: Lesson 1,10
+            Lesson 1,11:
+              name: Lesson 1,11
+            Lesson 2,2:
+              name: Lesson 2,2
+            Lesson 2,3:
+              name: Lesson 2,3
+            Lesson 2,10:
+              name: Lesson 2,10
+            Test stage with bubbles:
+              name: Test stage with bubbles
+            Group Work and Peer Learning:
+              name: Group Work and Peer Learning
+            Balancing Teachers and Tools:
+              name: Balancing Teachers and Tools
         csd3-2017:
           title: CSD Unit 3 - Animations and Games ('17-'18)
           description: " In Unit 3, you’ll build on your coding experience as you program animations, interactive art, and games in Game Lab. The unit starts off with simple shapes and builds up to more sophisticated sprite-based games, using the same programming concepts and the design process computer scientists use daily. In the final project, you’ll develop a personalized, interactive program."
@@ -3653,6 +5733,55 @@ en:
               display_name: Survey
             csd_survey:
               display_name: Post-Course Survey
+          lessons:
+            Programming for Entertainment:
+              name: Programming for Entertainment
+            Plotting Shapes:
+              name: Plotting Shapes
+            Drawing in Game Lab:
+              name: Drawing in Game Lab
+            Shapes and Randomization:
+              name: Shapes and Randomization
+            Variables:
+              name: Variables
+            Sprites:
+              name: Sprites
+            The Draw Loop:
+              name: The Draw Loop
+            The Counter Pattern Unplugged:
+              name: The Counter Pattern Unplugged
+            Sprite Movement:
+              name: Sprite Movement
+            Booleans Unplugged:
+              name: Booleans Unplugged
+            Conditionals:
+              name: Conditionals
+            Keyboard Input:
+              name: Keyboard Input
+            Other Forms of Input:
+              name: Other Forms of Input
+            Project - Interactive Card:
+              name: Project - Interactive Card
+            Velocity:
+              name: Velocity
+            Collision Detection:
+              name: Collision Detection
+            Complex Sprite Movement:
+              name: Complex Sprite Movement
+            Collisions:
+              name: Collisions
+            Functions:
+              name: Functions
+            The Game Design Process:
+              name: The Game Design Process
+            Using the Game Design Process:
+              name: Using the Game Design Process
+            Project - Design a Game:
+              name: Project - Design a Game
+            CS Discoveries End of Semester Survey:
+              name: CS Discoveries End of Semester Survey
+            CSD Post-Course Survey:
+              name: CSD Post-Course Survey
         grade2:
           title: Grade 2
           description: Planning Script for CSF 2.0
@@ -3712,6 +5841,17 @@ en:
             Course 3 Stage 17:
               name: Course 3 Stage 17
           lesson_groups: {}
+          lessons:
+            20-hr Stage 2:
+              name: 20-hr Stage 2
+            20-hr Stage 9:
+              name: 20-hr Stage 9
+            Course 2 Stage 17:
+              name: Course 2 Stage 17
+            Course 3 Stage 16:
+              name: Course 3 Stage 16
+            Course 3 Stage 17:
+              name: Course 3 Stage 17
         k5concepts:
           title: K5 Concepts
           description_audience: ''
@@ -3739,6 +5879,27 @@ en:
             While Loops:
               name: While Loops
           lesson_groups: {}
+          lessons:
+            Events:
+              name: Events
+            Loops:
+              name: Loops
+            Nested Loops:
+              name: Nested Loops
+            Conditionals:
+              name: Conditionals
+            While Loops:
+              name: While Loops
+            Functions:
+              name: Functions
+            Variables:
+              name: Variables
+            For Loops:
+              name: For Loops
+            Functions with Parameters:
+              name: Functions with Parameters
+            Binary:
+              name: Binary
         algebrapdnext:
           title: Computer Science in Algebra PD Phase 2
           description: Teach Algebra through Functional Programming
@@ -3758,6 +5919,19 @@ en:
             Welcome!:
               name: Welcome!
           lesson_groups: {}
+          lessons:
+            Welcome!:
+              name: Welcome!
+            Teaching with Puzzles:
+              name: Teaching with Puzzles
+            Teaching with the Design Recipe:
+              name: Teaching with the Design Recipe
+            The Design Recipe:
+              name: The Design Recipe
+            Teacher Dashboard:
+              name: Teacher Dashboard
+            Lesson Prep:
+              name: Lesson Prep
         csp-pre-survey:
           title: CS Principles Pre-Survey
           description_audience: ''
@@ -3777,6 +5951,19 @@ en:
             'Anonymous student survey: Taking the AP exam':
               name: 'Anonymous student survey: Taking the AP exam'
           lesson_groups: {}
+          lessons:
+            Anonymous student pre-survey:
+              name: Anonymous student pre-survey
+            Unit 1 Chapter 1 Assessment:
+              name: Unit 1 Chapter 1 Assessment
+            NEW Unit 1 Chapter 1 Assessment:
+              name: NEW Unit 1 Chapter 1 Assessment
+            Unit 3 Chapter 1 Assessment:
+              name: Unit 3 Chapter 1 Assessment
+            Unit 4 Chapter 1 Assessment:
+              name: Unit 4 Chapter 1 Assessment
+            'Anonymous student survey: Taking the AP exam':
+              name: 'Anonymous student survey: Taking the AP exam'
         csd1-2017:
           title: CSD Unit 1 - Problem Solving ('17-'18)
           description_short: "  Learn how humans work with computers to solve problems."
@@ -3847,6 +6034,27 @@ en:
               display_name: 'Chapter 1: The Problem Solving Process'
             csd1_2:
               display_name: 'Chapter 2: Computers and Problem Solving'
+          lessons:
+            CS Discoveries Pre-survey:
+              name: CS Discoveries Pre-survey
+            Intro to Problem Solving:
+              name: Intro to Problem Solving
+            The Problem Solving Process:
+              name: The Problem Solving Process
+            Exploring Problem Solving:
+              name: Exploring Problem Solving
+            What is a Computer?:
+              name: What is a Computer?
+            Input and Output:
+              name: Input and Output
+            Processing:
+              name: Processing
+            Storage:
+              name: Storage
+            Apps and Problem Solving:
+              name: Apps and Problem Solving
+            Project - Propose an App:
+              name: Project - Propose an App
         csp-online-test:
           title: test space for csp online support
           description_short: This is a sample course for testing csp online pd
@@ -3932,6 +6140,27 @@ en:
               display_name: Content
             practice:
               display_name: Teaching Practices
+          lessons:
+            Unit 5 Overview:
+              name: Unit 5 Overview
+            Event Driven Programming:
+              name: Event Driven Programming
+            Variables and Strings:
+              name: Variables and Strings
+            Conditionals and Boolean Logic:
+              name: Conditionals and Boolean Logic
+            While Loops and Introduction to Arrays:
+              name: While Loops and Introduction to Arrays
+            Processing Arrays and Functions with Return Values:
+              name: Processing Arrays and Functions with Return Values
+            Group Work and Peer Learning:
+              name: Group Work and Peer Learning
+            Balancing Teachers and Tools:
+              name: Balancing Teachers and Tools
+            Discovery Learning:
+              name: Discovery Learning
+            Measuring Student Learning:
+              name: Measuring Student Learning
         csp1-support:
           title: Unit 1 Online Professional Learning Course
           description_short: Teacher Professional Learning Course for CSP Unit 1
@@ -3969,6 +6198,31 @@ en:
               display_name: Content
             practice:
               display_name: Teaching Practices
+          lessons:
+            Unit 1 Overview:
+              name: Unit 1 Overview
+            AP Preparation and Support:
+              name: AP Preparation and Support
+            'Lessons 2 - 3: Binary Messages':
+              name: 'Lessons 2 - 3: Binary Messages'
+            'Lessons 4 - 6: Encoding and Sending Numbers':
+              name: 'Lessons 4 - 6: Encoding and Sending Numbers'
+            'Lesson 7: Encoding and Sending Text':
+              name: 'Lesson 7: Encoding and Sending Text'
+            'Lesson 9: Internet Addressing':
+              name: 'Lesson 9: Internet Addressing'
+            'Lessons 10 - 11: Routers, Redundancy, and Packets':
+              name: 'Lessons 10 - 11: Routers, Redundancy, and Packets'
+            'Lessons 12 - 13: Abstraction on the Internet':
+              name: 'Lessons 12 - 13: Abstraction on the Internet'
+            Group Work and Peer Learning:
+              name: Group Work and Peer Learning
+            Balancing Teachers and Tools:
+              name: Balancing Teachers and Tools
+            Discovery Learning:
+              name: Discovery Learning
+            Measuring Student Learning:
+              name: Measuring Student Learning
         basketball:
           title: Choose your team and make a basketball game
           description_audience: ''
@@ -3978,6 +6232,9 @@ en:
             Bounce:
               name: Bounce
           lesson_groups: {}
+          lessons:
+            Bounce:
+              name: Bounce
         sample-csp5:
           stages:
             Controlling Memory with Variables:
@@ -3991,6 +6248,9 @@ en:
             Simple Encryption:
               name: Simple Encryption
           lesson_groups: {}
+          lessons:
+            Simple Encryption:
+              name: Simple Encryption
         fesbinary:
           title: Binary
           description_audience: Mike
@@ -4123,6 +6383,37 @@ en:
               display_name: 'Chapter 2: Styling and CSS'
             csd_survey:
               display_name: Post-Course Survey
+          lessons:
+            Exploring Websites:
+              name: Exploring Websites
+            'Websites for Expression ':
+              name: 'Websites for Expression '
+            Intro to HTML:
+              name: Intro to HTML
+            Headings:
+              name: Headings
+            Digital Footprint:
+              name: Digital Footprint
+            Lists:
+              name: Lists
+            Intellectual Property and Images:
+              name: Intellectual Property and Images
+            Clean Code and Debugging:
+              name: Clean Code and Debugging
+            Project - Multi-Page Websites:
+              name: Project - Multi-Page Websites
+            Styling Text with CSS:
+              name: Styling Text with CSS
+            Styling Elements with CSS:
+              name: Styling Elements with CSS
+            Sources and Search Engines:
+              name: Sources and Search Engines
+            RGB Colors and Classes:
+              name: RGB Colors and Classes
+            Project - Personal Portfolio Website:
+              name: Project - Personal Portfolio Website
+            CSD Post-Course Survey:
+              name: CSD Post-Course Survey
         csp2-support:
           title: Unit 2 Online Professional Learning Course
           description_audience: ''
@@ -4158,6 +6449,29 @@ en:
               display_name: Content
             practice:
               display_name: Teaching Practices
+          lessons:
+            Unit 2 Overview:
+              name: Unit 2 Overview
+            AP Preparation and Support:
+              name: AP Preparation and Support
+            'Lessons 1 - 2: Bytes, File Sizes, and Text Compression':
+              name: 'Lessons 1 - 2: Bytes, File Sizes, and Text Compression'
+            'Lessons 3 - 4 : Encoding Images':
+              name: 'Lessons 3 - 4 : Encoding Images'
+            'Lessons 5 - 6: Compression Formats and Developing your own Encoding Scheme':
+              name: 'Lessons 5 - 6: Compression Formats and Developing your own Encoding Scheme'
+            'Lessons 7 - 10: Interpreting Visual Data':
+              name: 'Lessons 7 - 10: Interpreting Visual Data'
+            'Lessons 11 - 15: Communicating with Visualizations':
+              name: 'Lessons 11 - 15: Communicating with Visualizations'
+            Group Work and Peer Learning:
+              name: Group Work and Peer Learning
+            Balancing Teachers and Tools:
+              name: Balancing Teachers and Tools
+            Discovery Learning:
+              name: Discovery Learning
+            Measuring Student Learning:
+              name: Measuring Student Learning
         csd4-2017:
           title: CSD Unit 4 - The Design Process ('17-'18)
           description_audience: ''
@@ -4269,6 +6583,41 @@ en:
               display_name: 'Chapter 2: App Prototyping'
             csd_survey:
               display_name: Post-Course Survey
+          lessons:
+            Analysis of Design:
+              name: Analysis of Design
+            Understanding Your User:
+              name: Understanding Your User
+            User-Centered Design Micro Activity:
+              name: User-Centered Design Micro Activity
+            User Interfaces:
+              name: User Interfaces
+            Feedback and Testing:
+              name: Feedback and Testing
+            Identifying User Needs:
+              name: Identifying User Needs
+            Project - Paper Prototype:
+              name: Project - Paper Prototype
+            Designing Apps for Good:
+              name: Designing Apps for Good
+            Market Research:
+              name: Market Research
+            Paper Prototypes:
+              name: Paper Prototypes
+            Prototype Testing:
+              name: Prototype Testing
+            Digital Design:
+              name: Digital Design
+            Linking Screens:
+              name: Linking Screens
+            Testing the App:
+              name: Testing the App
+            Improving and Iterating:
+              name: Improving and Iterating
+            Project - App Presentation:
+              name: Project - App Presentation
+            CSD Post-Course Survey:
+              name: CSD Post-Course Survey
         minecraft:
           title: Minecraft Hour of Code Designer
           description_audience: ''
@@ -4278,6 +6627,9 @@ en:
             Minecraft Hour of Code Designer:
               name: Minecraft Hour of Code Designer
           lesson_groups: {}
+          lessons:
+            Minecraft Hour of Code Designer:
+              name: Minecraft Hour of Code Designer
         flappy-impact-study:
           title: Flappy Code with Survey
           description_audience: ''
@@ -4291,6 +6643,13 @@ en:
             Post Hour of Code Survey:
               name: Post Hour of Code Survey
           lesson_groups: {}
+          lessons:
+            Pre Hour of Code Survey:
+              name: Pre Hour of Code Survey
+            Flappy Code:
+              name: Flappy Code
+            Post Hour of Code Survey:
+              name: Post Hour of Code Survey
         coursea-draft:
           title: 'CS Fundamentals: Course A'
           description_audience: ''
@@ -4328,6 +6687,31 @@ en:
             'Debugging: Unspotted Bugs':
               name: 'Debugging: Unspotted Bugs'
           lesson_groups: {}
+          lessons:
+            'Debugging: Unspotted Bugs':
+              name: 'Debugging: Unspotted Bugs'
+            'Persistence & Frustration: Stevie and the Marbles':
+              name: 'Persistence & Frustration: Stevie and the Marbles'
+            'Real-life Algorithms: Plant a Seed':
+              name: 'Real-life Algorithms: Plant a Seed'
+            Learn to Drag and Drop:
+              name: Learn to Drag and Drop
+            'Programming: Happy Maps':
+              name: 'Programming: Happy Maps'
+            Programming in Maze:
+              name: Programming in Maze
+            Going Places Safely:
+              name: Going Places Safely
+            'Loops: Happy Loops':
+              name: 'Loops: Happy Loops'
+            Loops in Collector:
+              name: Loops in Collector
+            Loops in Artist:
+              name: Loops in Artist
+            'Events: The Big Event':
+              name: 'Events: The Big Event'
+            Events in Play Lab:
+              name: Events in Play Lab
         courseb-draft:
           title: 'CS Fundamentals: Course B'
           description_audience: ''
@@ -4367,6 +6751,31 @@ en:
             Your Digital Footprint:
               name: Your Digital Footprint
           lesson_groups: {}
+          lessons:
+            'Debugging: Unspotted Bugs':
+              name: 'Debugging: Unspotted Bugs'
+            'Persistence & Frustration: Stevie and the Marbles':
+              name: 'Persistence & Frustration: Stevie and the Marbles'
+            'Real-life Algorithms: Plant a Seed':
+              name: 'Real-life Algorithms: Plant a Seed'
+            Learn to Drag and Drop:
+              name: Learn to Drag and Drop
+            Your Digital Footprint:
+              name: Your Digital Footprint
+            'Programming: My Robotic Friends':
+              name: 'Programming: My Robotic Friends'
+            Programming in Maze:
+              name: Programming in Maze
+            'Loops: My Loopy Robotic Friends':
+              name: 'Loops: My Loopy Robotic Friends'
+            Loops in Collector:
+              name: Loops in Collector
+            Loops in Artist:
+              name: Loops in Artist
+            'Events: The Big Event':
+              name: 'Events: The Big Event'
+            Events in Play Lab:
+              name: Events in Play Lab
         coursec-draft:
           title: 'CS Fundamentals: Course C'
           description_audience: ''
@@ -4410,6 +6819,35 @@ en:
             Loops in Harvester:
               name: Loops in Harvester
           lesson_groups: {}
+          lessons:
+            Building a Foundation:
+              name: Building a Foundation
+            Programming in Maze:
+              name: Programming in Maze
+            Debugging in Maze:
+              name: Debugging in Maze
+            'Real-life Algorithms: Paper Planes':
+              name: 'Real-life Algorithms: Paper Planes'
+            Programming in Collector:
+              name: Programming in Collector
+            Programming in Artist:
+              name: Programming in Artist
+            'Loops: Getting Loopy':
+              name: 'Loops: Getting Loopy'
+            Loops in Maze:
+              name: Loops in Maze
+            Loops in Harvester:
+              name: Loops in Harvester
+            'Events: The Big Event':
+              name: 'Events: The Big Event'
+            Build a Flappy Game:
+              name: Build a Flappy Game
+            Events in Play Lab:
+              name: Events in Play Lab
+            Screen Out the Mean:
+              name: Screen Out the Mean
+            Binary Bracelets:
+              name: Binary Bracelets
         coursed-draft:
           title: 'CS Fundamentals: Course D'
           description_audience: ''
@@ -4463,6 +6901,39 @@ en:
             Debugging in Collector:
               name: Debugging in Collector
           lesson_groups: {}
+          lessons:
+            Introduction:
+              name: Introduction
+            'Algorithms: Graph Paper Programming':
+              name: 'Algorithms: Graph Paper Programming'
+            Events in Bounce:
+              name: Events in Bounce
+            Nested Loops:
+              name: Nested Loops
+            Nested Loops in Artist:
+              name: Nested Loops in Artist
+            'Algorithms: Relay Programming':
+              name: 'Algorithms: Relay Programming'
+            Debugging in Bee:
+              name: Debugging in Bee
+            While Loops in Farmer:
+              name: While Loops in Farmer
+            Conditionals with Cards:
+              name: Conditionals with Cards
+            Conditionals in Bee:
+              name: Conditionals in Bee
+            Conditionals & Loops in Maze:
+              name: Conditionals & Loops in Maze
+            Conditionals & Loops in Farmer:
+              name: Conditionals & Loops in Farmer
+            Digital Citizenship:
+              name: Digital Citizenship
+            Build a Play Lab Game:
+              name: Build a Play Lab Game
+            'Unplugged: Binary':
+              name: 'Unplugged: Binary'
+            Artist Binary:
+              name: Artist Binary
         coursee-draft:
           title: 'CS Fundamentals: Course E'
           description_audience: ''
@@ -4516,6 +6987,41 @@ en:
               display_name: End of Course Project
             extra_course_content:
               display_name: Extra Course Content
+          lessons:
+            'Algorithms: Dice Race':
+              name: 'Algorithms: Dice Race'
+            Introduction:
+              name: Introduction
+            Conditionals:
+              name: Conditionals
+            Private and Personal Information:
+              name: Private and Personal Information
+            Build a Star Wars Game:
+              name: Build a Star Wars Game
+            'Functions: Songwriting':
+              name: 'Functions: Songwriting'
+            Functions in Artist:
+              name: Functions in Artist
+            Functions in Bee:
+              name: Functions in Bee
+            Functions in Farmer:
+              name: Functions in Farmer
+            Determine the Concept:
+              name: Determine the Concept
+            Build a Play Lab Game:
+              name: Build a Play Lab Game
+            Explore Project Ideas:
+              name: Explore Project Ideas
+            The Design Process:
+              name: The Design Process
+            Build Your Project:
+              name: Build Your Project
+            Present Your Project:
+              name: Present Your Project
+            Internet:
+              name: Internet
+            Crowdsourcing:
+              name: Crowdsourcing
         coursef-draft:
           title: 'CS Fundamentals: Course F'
           description_audience: ''
@@ -4571,6 +7077,45 @@ en:
               display_name: Content
             end_of_course_project:
               display_name: End of Course Project
+          lessons:
+            'Algorithms: Tangrams':
+              name: 'Algorithms: Tangrams'
+            Introduction:
+              name: Introduction
+            The Power of Words:
+              name: The Power of Words
+            Ice Age Play Lab:
+              name: Ice Age Play Lab
+            Envelope Variables:
+              name: Envelope Variables
+            Variables in Artist:
+              name: Variables in Artist
+            Variables in Play Lab:
+              name: Variables in Play Lab
+            For Loop Fun:
+              name: For Loop Fun
+            For Loops in Bee:
+              name: For Loops in Bee
+            For Loops in Artist:
+              name: For Loops in Artist
+            Songwriting with Parameters:
+              name: Songwriting with Parameters
+            Conditionals and Functions in Bee:
+              name: Conditionals and Functions in Bee
+            Functions with Parameters in Artist:
+              name: Functions with Parameters in Artist
+            Functions with Parameters in Bee:
+              name: Functions with Parameters in Bee
+            Explore Project Ideas:
+              name: Explore Project Ideas
+            The Design Process:
+              name: The Design Process
+            Build Your Project:
+              name: Build Your Project
+            Revise Your Project:
+              name: Revise Your Project
+            Presentation Your Project:
+              name: Presentation Your Project
         classic-hoc-impact-study:
           title: Hour of Code with Survey
           description_audience: ''
@@ -4596,6 +7141,13 @@ en:
             Post Hour of Code Survey:
               name: Post Hour of Code Survey
           lesson_groups: {}
+          lessons:
+            Pre Hour of Code Survey:
+              name: Pre Hour of Code Survey
+            Hour of Code 2013:
+              name: Hour of Code 2013
+            Post Hour of Code Survey:
+              name: Post Hour of Code Survey
         sports:
           title: Code your own sports game
           description_audience: ''
@@ -4605,6 +7157,9 @@ en:
             Sports:
               name: Sports
           lesson_groups: {}
+          lessons:
+            Sports:
+              name: Sports
         2016_sciencePD-phase2b:
           title: ''
           description_audience: ''
@@ -4626,6 +7181,21 @@ en:
             Wrap-Up:
               name: Wrap-Up
           lesson_groups: {}
+          lessons:
+            Welcome!:
+              name: Welcome!
+            Review StarLogo Nova:
+              name: Review StarLogo Nova
+            Reviewing the Modules:
+              name: Reviewing the Modules
+            Advanced StarLogo Nova:
+              name: Advanced StarLogo Nova
+            Remixing Phases 1 and 2:
+              name: Remixing Phases 1 and 2
+            Thinking Ahead to Implementation:
+              name: Thinking Ahead to Implementation
+            Wrap-Up:
+              name: Wrap-Up
         2016_sciencePD_phase2b:
           title: ''
           description_audience: ''
@@ -4647,6 +7217,21 @@ en:
             Wrap-Up:
               name: Wrap-Up
           lesson_groups: {}
+          lessons:
+            Welcome!:
+              name: Welcome!
+            Review StarLogo Nova:
+              name: Review StarLogo Nova
+            Reviewing the Modules:
+              name: Reviewing the Modules
+            Advanced StarLogo Nova:
+              name: Advanced StarLogo Nova
+            Remixing Phases 1 and 2:
+              name: Remixing Phases 1 and 2
+            Thinking Ahead to Implementation:
+              name: Thinking Ahead to Implementation
+            Wrap-Up:
+              name: Wrap-Up
         sciencepd3-2016:
           title: ''
           description_audience: ''
@@ -4660,6 +7245,13 @@ en:
             Prep With Your Modules:
               name: Prep With Your Modules
           lesson_groups: {}
+          lessons:
+            Welcome Back!:
+              name: Welcome Back!
+            The TLO:
+              name: The TLO
+            Prep With Your Modules:
+              name: Prep With Your Modules
         csp3-support:
           title: Unit 3 Online Professional Learning Course
           description_audience: ''
@@ -4691,6 +7283,25 @@ en:
               display_name: Content
             practice:
               display_name: Teaching Practices
+          lessons:
+            Unit 3 Overview:
+              name: Unit 3 Overview
+            AP Preparation and Support:
+              name: AP Preparation and Support
+            'Lessons 1 - 3: Algorithms':
+              name: 'Lessons 1 - 3: Algorithms'
+            'Lessons 4 - 6 : Procedural Abstraction and Top-Down Design':
+              name: 'Lessons 4 - 6 : Procedural Abstraction and Top-Down Design'
+            'Lessons 7 - 9: Documentation, Simple Loops, and Random Numbers':
+              name: 'Lessons 7 - 9: Documentation, Simple Loops, and Random Numbers'
+            Group Work and Peer Learning:
+              name: Group Work and Peer Learning
+            Balancing Teachers and Tools:
+              name: Balancing Teachers and Tools
+            Discovery Learning:
+              name: Discovery Learning
+            Measuring Student Learning:
+              name: Measuring Student Learning
         csdgraveyard:
           title: ''
           description_audience: ''
@@ -4706,6 +7317,11 @@ en:
             External Style Sheets:
               name: External Style Sheets
           lesson_groups: {}
+          lessons:
+            Introduction to Styling with CSS:
+              name: Introduction to Styling with CSS
+            External Style Sheets:
+              name: External Style Sheets
         csp4-support:
           title: Unit 4 Online Professional Learning Course
           description_audience: ''
@@ -4739,6 +7355,23 @@ en:
               display_name: Content
             practice:
               display_name: Teaching Practices
+          lessons:
+            Unit 4 Overview:
+              name: Unit 4 Overview
+            'Lessons 1 - 4: Data in the Real World':
+              name: 'Lessons 1 - 4: Data in the Real World'
+            'Lessons 5 - 7: Security, Symmetric, and Asymmetric Encryption':
+              name: 'Lessons 5 - 7: Security, Symmetric, and Asymmetric Encryption'
+            'Lessons 8 - 9: Practice PT':
+              name: 'Lessons 8 - 9: Practice PT'
+            Group Work and Peer Learning:
+              name: Group Work and Peer Learning
+            Balancing Teachers and Tools:
+              name: Balancing Teachers and Tools
+            Discovery Learning:
+              name: Discovery Learning
+            Measuring Student Learning:
+              name: Measuring Student Learning
         sciencepd4:
           title: 'CS in Science: Part 4'
           description_audience: ''
@@ -4754,6 +7387,15 @@ en:
             Wrap-Up:
               name: Wrap-Up
           lesson_groups: {}
+          lessons:
+            Welcome!:
+              name: Welcome!
+            Revisiting Complex Adaptive Systems:
+              name: Revisiting Complex Adaptive Systems
+            Thinking About Implementation:
+              name: Thinking About Implementation
+            Wrap-Up:
+              name: Wrap-Up
         csp-ca-a:
           title: ''
           description_audience: ''
@@ -4763,6 +7405,9 @@ en:
             Commutative Assessment A:
               name: Commutative Assessment A
           lesson_groups: {}
+          lessons:
+            Commutative Assessment A:
+              name: Commutative Assessment A
         science-pd-ol-pt-5:
           title: ''
           description_audience: ''
@@ -4806,6 +7451,11 @@ en:
               display_name: End of Course Project
             content:
               display_name: Content
+          lessons:
+            Snowflakes:
+              name: Snowflakes
+            Binary:
+              name: Binary
         sciencepd5:
           title: 'CS in Science: Part 5'
           description_audience: ''
@@ -4823,6 +7473,17 @@ en:
             Wrap-Up:
               name: Wrap-Up
           lesson_groups: {}
+          lessons:
+            Welcome!:
+              name: Welcome!
+            Earth Science Challenges:
+              name: Earth Science Challenges
+            Life Science Challenges:
+              name: Life Science Challenges
+            Physical Science Challenges:
+              name: Physical Science Challenges
+            Wrap-Up:
+              name: Wrap-Up
         csp5-support:
           title: Unit 5 Online Professional Learning Course
           description_audience: ''
@@ -4856,6 +7517,27 @@ en:
               display_name: Content
             practice:
               display_name: Teaching Practices
+          lessons:
+            Unit 5 Overview:
+              name: Unit 5 Overview
+            Event Driven Programming:
+              name: Event Driven Programming
+            Variables and Strings:
+              name: Variables and Strings
+            Conditionals and Boolean Logic:
+              name: Conditionals and Boolean Logic
+            While Loops and Introduction to Arrays:
+              name: While Loops and Introduction to Arrays
+            Processing Arrays and Functions with Return Values:
+              name: Processing Arrays and Functions with Return Values
+            Group Work and Peer Learning:
+              name: Group Work and Peer Learning
+            Balancing Teachers and Tools:
+              name: Balancing Teachers and Tools
+            Discovery Learning:
+              name: Discovery Learning
+            Measuring Student Learning:
+              name: Measuring Student Learning
         csp6-support:
           stage: {}
           title: AP Preparation and Resources for Teachers
@@ -4864,6 +7546,7 @@ en:
           description: 'COMING SOON: soon this page will host a set of resources for teachers preparing for the AP exam'
           stages: {}
           lesson_groups: {}
+          lessons: {}
         csppostap-2017:
           title: CSP Post-AP - Databases and Using Data in Your Apps ('17-'18)
           description_audience: ''
@@ -4895,6 +7578,27 @@ en:
               display_name: Content
             cspSurvey:
               display_name: Survey
+          lessons:
+            Creating Javascript Objects:
+              name: Creating Javascript Objects
+            Permanent Data Storage:
+              name: Permanent Data Storage
+            Reading Records:
+              name: Reading Records
+            Deleting Records:
+              name: Deleting Records
+            Updating Records:
+              name: Updating Records
+            Importing and Exporting Data:
+              name: Importing and Exporting Data
+            Visualizing Data:
+              name: Visualizing Data
+            Sample Apps:
+              name: Sample Apps
+            Final Project:
+              name: Final Project
+            Post-Course Survey:
+              name: Post-Course Survey
         unit6-csd-draft:
           title: ''
           description_audience: ''
@@ -4914,6 +7618,9 @@ en:
             Simple Sprite Movement:
               name: Simple Sprite Movement
           lesson_groups: {}
+          lessons:
+            Simple Sprite Movement:
+              name: Simple Sprite Movement
         csd6-draft:
           title: CSD Unit 6 Revisions Draft
           description_audience: ''
@@ -4997,6 +7704,39 @@ en:
               display_name: 'Chapter 1: Programming with Hardware'
             csd6_2:
               display_name: 'Chapter 2: Building Physical Prototypes'
+          lessons:
+            Computing Innovations:
+              name: Computing Innovations
+            Designing Screens with Code:
+              name: Designing Screens with Code
+            The Circuit Playground:
+              name: The Circuit Playground
+            Input Unplugged:
+              name: Input Unplugged
+            Board Events:
+              name: Board Events
+            Getting Properties:
+              name: Getting Properties
+            Analog Input:
+              name: Analog Input
+            The Program Design Process:
+              name: The Program Design Process
+            'Project: Make a Game':
+              name: 'Project: Make a Game'
+            Arrays:
+              name: Arrays
+            Making Music:
+              name: Making Music
+            Arrays and For Loops:
+              name: Arrays and For Loops
+            Accelerometer:
+              name: Accelerometer
+            Functions with Parameters:
+              name: Functions with Parameters
+            Circuits and Physical Prototypes:
+              name: Circuits and Physical Prototypes
+            'Project: Prototype an Innovation':
+              name: 'Project: Prototype an Innovation'
         workshop-gamelab:
           title: Game Lab Workshop
           description_audience: Teachers attending an in-person Game Lab Workshop
@@ -5012,6 +7752,15 @@ en:
             'Project: Interactive Card':
               name: 'Project: Interactive Card'
           lesson_groups: {}
+          lessons:
+            Introduction:
+              name: Introduction
+            Sprites:
+              name: Sprites
+            Input:
+              name: Input
+            'Project: Interactive Card':
+              name: 'Project: Interactive Card'
         csd5-draft:
           title: Draft of CSD5
           description_audience: ''
@@ -5063,6 +7812,37 @@ en:
               display_name: 'Chapter 1: Representing Information'
             csd5_2:
               display_name: 'Chapter 2: Solving Data Problems'
+          lessons:
+            Representation Matters:
+              name: Representation Matters
+            Patterns and Representation:
+              name: Patterns and Representation
+            ASCII and Binary Representation:
+              name: ASCII and Binary Representation
+            Representing Images:
+              name: Representing Images
+            Representing Numbers:
+              name: Representing Numbers
+            Encryption:
+              name: Encryption
+            Combining Representations:
+              name: Combining Representations
+            Project - Create a Representation:
+              name: Project - Create a Representation
+            Problem Solving and Data:
+              name: Problem Solving and Data
+            Problem Solving with Big Data:
+              name: Problem Solving with Big Data
+            Structuring Data:
+              name: Structuring Data
+            Making Decisions with Data:
+              name: Making Decisions with Data
+            Interpreting Data:
+              name: Interpreting Data
+            Automating Data Decisions:
+              name: Automating Data Decisions
+            Project - Solve a Data Problem:
+              name: Project - Solve a Data Problem
         applab-1hour:
           title: App Lab 1 Hour Workshop
           description_audience: Middle and High School Students
@@ -5086,6 +7866,9 @@ en:
             Extra:
               name: Extra
           lesson_groups: {}
+          lessons:
+            Room Escape:
+              name: Room Escape
         applab-2hour:
           title: App Lab 2 Hour Workshop
           description_audience: Middle and High School Students
@@ -5105,6 +7888,15 @@ en:
             Getters and Setters:
               name: Getters and Setters
           lesson_groups: {}
+          lessons:
+            Digital Design:
+              name: Digital Design
+            Event Driven Programming:
+              name: Event Driven Programming
+            Basic App Functionality:
+              name: Basic App Functionality
+            Getters and Setters:
+              name: Getters and Setters
         coursed-ramp:
           title: 'CS Fundamentals: Course D'
           description_audience: ''
@@ -5114,6 +7906,9 @@ en:
             Introduction:
               name: Introduction
           lesson_groups: {}
+          lessons:
+            Introduction:
+              name: Introduction
         workshop-maker:
           title: Maker Toolkit Workshop
           description_audience: Teachers attending an in-person Maker Toolkit Workshop
@@ -5129,6 +7924,15 @@ en:
             Analog Input:
               name: Analog Input
           lesson_groups: {}
+          lessons:
+            App Lab Basics:
+              name: App Lab Basics
+            The Circuit Playground:
+              name: The Circuit Playground
+            Physical Input:
+              name: Physical Input
+            Analog Input:
+              name: Analog Input
         coursee-ramp:
           title: coursee-ramp
           description_audience: ''
@@ -5142,6 +7946,13 @@ en:
             'Real Life Algorithms: Dice Race':
               name: 'Real Life Algorithms: Dice Race'
           lesson_groups: {}
+          lessons:
+            'Real Life Algorithms: Dice Race':
+              name: 'Real Life Algorithms: Dice Race'
+            Introduction:
+              name: Introduction
+            Conditionals:
+              name: Conditionals
         csd6-2017:
           title: CSD Unit 6 - Physical Computing ('17-'18)
           description_audience: ''
@@ -5333,6 +8144,41 @@ en:
               display_name: 'Chapter 2: Building Physical Prototypes'
             csd_survey:
               display_name: Post-Course Survey
+          lessons:
+            Innovations in Computing_:
+              name: Innovations in Computing_
+            Designing Screens with Code_:
+              name: Designing Screens with Code_
+            The Circuit Playground_:
+              name: The Circuit Playground_
+            Input Unplugged_:
+              name: Input Unplugged_
+            Board Events_:
+              name: Board Events_
+            Getting Properties_:
+              name: Getting Properties_
+            Analog Input_:
+              name: Analog Input_
+            The Program Design Process_:
+              name: The Program Design Process_
+            'Project: Make a Game__':
+              name: 'Project: Make a Game__'
+            Arrays and Color LEDs__:
+              name: Arrays and Color LEDs__
+            Making Music_:
+              name: Making Music_
+            Arrays and For Loops_:
+              name: Arrays and For Loops_
+            Accelerometer_:
+              name: Accelerometer_
+            Functions with Parameters_:
+              name: Functions with Parameters_
+            Circuits and Physical Prototypes_:
+              name: Circuits and Physical Prototypes_
+            'Project: Prototype an Innovation_':
+              name: 'Project: Prototype an Innovation_'
+            CSD Post-Course Survey:
+              name: CSD Post-Course Survey
         csd3-draft:
           title: 'CSD Unit 3 - Programming: Animations and Games'
           description_audience: ''
@@ -5476,6 +8322,39 @@ en:
               display_name: 'Chapter 2: Solving Data Problems'
             csd_survey:
               display_name: Post-Course Survey
+          lessons:
+            Representation Matters:
+              name: Representation Matters
+            Patterns and Representation:
+              name: Patterns and Representation
+            ASCII and Binary Representation:
+              name: ASCII and Binary Representation
+            Representing Images:
+              name: Representing Images
+            Representing Numbers:
+              name: Representing Numbers
+            Keeping Data Secret:
+              name: Keeping Data Secret
+            Combining Representations:
+              name: Combining Representations
+            Project - Create a Representation:
+              name: Project - Create a Representation
+            Problem Solving and Data:
+              name: Problem Solving and Data
+            Problem Solving with Big Data:
+              name: Problem Solving with Big Data
+            Structuring Data:
+              name: Structuring Data
+            Making Decisions with Data:
+              name: Making Decisions with Data
+            Interpreting Data:
+              name: Interpreting Data
+            Automating Data Decisions:
+              name: Automating Data Decisions
+            Project - Solve a Data Problem:
+              name: Project - Solve a Data Problem
+            CSD Post-Course Survey:
+              name: CSD Post-Course Survey
         csd3-old:
           title: CSD Unit 3 (DEPRECATED)
           description_audience: ''
@@ -5519,6 +8398,43 @@ en:
             'Project: Design a Game':
               name: 'Project: Design a Game'
           lesson_groups: {}
+          lessons:
+            Drawing in Game Lab:
+              name: Drawing in Game Lab
+            Draw Loop and Randomization:
+              name: Draw Loop and Randomization
+            Variables Unplugged:
+              name: Variables Unplugged
+            Variables and Animation:
+              name: Variables and Animation
+            Sprites and Properties:
+              name: Sprites and Properties
+            Sprites and Images:
+              name: Sprites and Images
+            Booleans and Conditionals:
+              name: Booleans and Conditionals
+            Conditionals and Keyboard Input:
+              name: Conditionals and Keyboard Input
+            Complex Conditionals:
+              name: Complex Conditionals
+            'Project: Interactive Card':
+              name: 'Project: Interactive Card'
+            Velocity:
+              name: Velocity
+            Collision Detection:
+              name: Collision Detection
+            Complex Sprite Movement:
+              name: Complex Sprite Movement
+            Collisions:
+              name: Collisions
+            Functions:
+              name: Functions
+            The Game Design Process:
+              name: The Game Design Process
+            Using the Game Design Process:
+              name: Using the Game Design Process
+            'Project: Design a Game':
+              name: 'Project: Design a Game'
         csd1-old:
           title: CSD Unit 1 (DEPRECATED)
           description_audience: ''
@@ -5544,6 +8460,25 @@ en:
             'Project: Apps and Problem Solving':
               name: 'Project: Apps and Problem Solving'
           lesson_groups: {}
+          lessons:
+            Intro to Problem Solving:
+              name: Intro to Problem Solving
+            The Problem Solving Process:
+              name: The Problem Solving Process
+            Exploring Problem Solving:
+              name: Exploring Problem Solving
+            What is a Computer?:
+              name: What is a Computer?
+            Representing Information:
+              name: Representing Information
+            Processing with Bits:
+              name: Processing with Bits
+            Human vs Computer Processing:
+              name: Human vs Computer Processing
+            Processing with Apps:
+              name: Processing with Apps
+            'Project: Apps and Problem Solving':
+              name: 'Project: Apps and Problem Solving'
         csd2-draft:
           title: ''
           description_audience: ''
@@ -5687,6 +8622,15 @@ en:
           description_short: ''
           description: ''
           lesson_groups: {}
+          lessons:
+            'Algorithms: Tangrams':
+              name: 'Algorithms: Tangrams'
+            Introduction:
+              name: Introduction
+            Ice Age Play Lab:
+              name: Ice Age Play Lab
+            Conditionals and Functions in Bee:
+              name: Conditionals and Functions in Bee
         csppostsurvey-staging:
           title: "[Deprecated] CSP post survey staging area"
           description_audience: ''
@@ -5708,6 +8652,11 @@ en:
           description_short: ''
           description: ''
           lesson_groups: {}
+          lessons:
+            Plotting Shapes:
+              name: Plotting Shapes
+            Drawing in Game Lab:
+              name: Drawing in Game Lab
         csppostsurvey:
           stages:
             CSP Student Post-Course Survey:
@@ -5737,6 +8686,9 @@ en:
           lesson_groups:
             cspSurvey:
               display_name: Survey
+          lessons:
+            CSP post-course survey:
+              name: CSP post-course survey
         public-key-cryptography:
           stages:
             Public Key Crypto Widgets:
@@ -5746,6 +8698,9 @@ en:
           description_short: ''
           description: ''
           lesson_groups: {}
+          lessons:
+            Public Key Crypto Widgets:
+              name: Public Key Crypto Widgets
         csd2-old:
           stages:
             Quality Websites:
@@ -5785,6 +8740,39 @@ en:
           description_short: Web Development
           description: ''
           lesson_groups: {}
+          lessons:
+            Quality Websites:
+              name: Quality Websites
+            Website Design:
+              name: Website Design
+            Describing Web pages:
+              name: Describing Web pages
+            Text on the Web:
+              name: Text on the Web
+            Images in HTML:
+              name: Images in HTML
+            Clean Code and Debugging:
+              name: Clean Code and Debugging
+            Styling Text with CSS:
+              name: Styling Text with CSS
+            Styling Elements with CSS:
+              name: Styling Elements with CSS
+            Multi-Page Websites:
+              name: Multi-Page Websites
+            Classes:
+              name: Classes
+            Peer Review:
+              name: Peer Review
+            Digital Footprint:
+              name: Digital Footprint
+            Publishing a Website:
+              name: Publishing a Website
+            Sources and Search Engines:
+              name: Sources and Search Engines
+            Intellectual Property:
+              name: Intellectual Property
+            'Project: Personal Portfolio Website':
+              name: 'Project: Personal Portfolio Website'
         artist-and-bb8:
           stages:
             B8 New BB8:
@@ -5824,6 +8812,31 @@ en:
           description_short: ''
           description: ''
           lesson_groups: {}
+          lessons:
+            Programming with BB-8:
+              name: Programming with BB-8
+            Loops with BB-8:
+              name: Loops with BB-8
+            C9 Artist Loops:
+              name: C9 Artist Loops
+            D7 to Laurel:
+              name: D7 to Laurel
+            D6 Frozen Artist:
+              name: D6 Frozen Artist
+            F5 Minecraft:
+              name: F5 Minecraft
+            F7 add Conditionals:
+              name: F7 add Conditionals
+            D13 no If/While:
+              name: D13 no If/While
+            Ice Age Play Lab:
+              name: Ice Age Play Lab
+            Bounce:
+              name: Bounce
+            NewBounce:
+              name: NewBounce
+            F PlayLab Variables:
+              name: F PlayLab Variables
         coursea-2017:
           stages:
             'Debugging: Unspotted Bugs':
@@ -5880,6 +8893,31 @@ en:
           description_short: An introduction to computer science for pre-readers.
           description: Learn the basics of computer science and internet safety. At the end of the course, create your very own game or story you can share.
           lesson_groups: {}
+          lessons:
+            'Debugging: Unspotted Bugs':
+              name: 'Debugging: Unspotted Bugs'
+            'Persistence & Frustration: Stevie and the Marbles':
+              name: 'Persistence & Frustration: Stevie and the Marbles'
+            'Real-life Algorithms: Plant a Seed':
+              name: 'Real-life Algorithms: Plant a Seed'
+            Learn to Drag and Drop:
+              name: Learn to Drag and Drop
+            'Programming: Happy Maps':
+              name: 'Programming: Happy Maps'
+            Programming in Maze:
+              name: Programming in Maze
+            Going Places Safely:
+              name: Going Places Safely
+            'Loops: Happy Loops':
+              name: 'Loops: Happy Loops'
+            Loops in Collector:
+              name: Loops in Collector
+            Loops in Artist:
+              name: Loops in Artist
+            'Events: The Big Event':
+              name: 'Events: The Big Event'
+            Events in Play Lab:
+              name: Events in Play Lab
         courseb-2017:
           stages:
             'Debugging: Unspotted Bugs':
@@ -5916,6 +8954,33 @@ en:
           description_short: An introduction to computer science for pre-readers. (Similar to Course A, but with more variety for older students.)
           description: Learn the basics of computer science and internet safety. At the end of the course, create your very own game or story you can share.
           lesson_groups: {}
+          lessons:
+            'Debugging: Unspotted Bugs':
+              name: 'Debugging: Unspotted Bugs'
+            'Persistence & Frustration: Stevie and the Marbles':
+              name: 'Persistence & Frustration: Stevie and the Marbles'
+            'Real-life Algorithms: Plant a Seed':
+              name: 'Real-life Algorithms: Plant a Seed'
+            Learn to Drag and Drop:
+              name: Learn to Drag and Drop
+            Your Digital Footprint:
+              name: Your Digital Footprint
+            'Programming: My Robotic Friends':
+              name: 'Programming: My Robotic Friends'
+            Programming in Maze:
+              name: Programming in Maze
+            Programming with Rey and BB-8:
+              name: Programming with Rey and BB-8
+            'Loops: My Loopy Robotic Friends':
+              name: 'Loops: My Loopy Robotic Friends'
+            Loops in Collector:
+              name: Loops in Collector
+            Loops in Artist:
+              name: Loops in Artist
+            'Events: The Big Event':
+              name: 'Events: The Big Event'
+            Events in Play Lab:
+              name: Events in Play Lab
         coursec-2017:
           stages:
             Building a Foundation:
@@ -5956,6 +9021,37 @@ en:
           description_short: Learn the basics of computer science and create your own art, stories, and games.
           description: Create programs with sequencing, loops, and events. Translate your initials into binary, investigate different problem-solving techniques, and learn how to respond to cyberbullying. At the end of the course, create your very own game or story you can share!
           lesson_groups: {}
+          lessons:
+            Building a Foundation:
+              name: Building a Foundation
+            Programming in Maze:
+              name: Programming in Maze
+            Debugging in Maze:
+              name: Debugging in Maze
+            'Real-life Algorithms: Paper Planes':
+              name: 'Real-life Algorithms: Paper Planes'
+            Programming in Collector:
+              name: Programming in Collector
+            Programming in Artist:
+              name: Programming in Artist
+            'Loops: Getting Loopy':
+              name: 'Loops: Getting Loopy'
+            Loops with Rey and BB-8:
+              name: Loops with Rey and BB-8
+            Loops in Artist:
+              name: Loops in Artist
+            Loops in Harvester:
+              name: Loops in Harvester
+            'Events: The Big Event':
+              name: 'Events: The Big Event'
+            Build a Flappy Game:
+              name: Build a Flappy Game
+            Events in Play Lab:
+              name: Events in Play Lab
+            Screen Out the Mean:
+              name: Screen Out the Mean
+            Binary Bracelets:
+              name: Binary Bracelets
         coursed-2017:
           stages:
             Introduction:
@@ -6037,6 +9133,41 @@ en:
           description_short: Quickly cover concepts from Course C, then go further with algorithms, nested loops, conditionals, and more.
           description: Learn new coding concepts including algorithms, nested loops, while loops, conditionals, and events. Get an introduction to digital citizenship before creating your very own game or story that you can share.
           lesson_groups: {}
+          lessons:
+            'Algorithms: Graph Paper Programming':
+              name: 'Algorithms: Graph Paper Programming'
+            Introduction:
+              name: Introduction
+            Events in Bounce:
+              name: Events in Bounce
+            Nested Loops:
+              name: Nested Loops
+            Nested Loops in Artist:
+              name: Nested Loops in Artist
+            Nested Loops Project in Artist:
+              name: Nested Loops Project in Artist
+            'Algorithms: Relay Programming':
+              name: 'Algorithms: Relay Programming'
+            Debugging in Collector:
+              name: Debugging in Collector
+            While Loops in Farmer:
+              name: While Loops in Farmer
+            Conditionals with Cards:
+              name: Conditionals with Cards
+            Conditionals in Bee:
+              name: Conditionals in Bee
+            Conditionals & Loops in Maze:
+              name: Conditionals & Loops in Maze
+            Conditionals & Loops in Farmer:
+              name: Conditionals & Loops in Farmer
+            Digital Citizenship:
+              name: Digital Citizenship
+            Build a Play Lab Game:
+              name: Build a Play Lab Game
+            'Unplugged: Binary':
+              name: 'Unplugged: Binary'
+            Artist Binary:
+              name: Artist Binary
         coursee-2017:
           stages:
             'Algorithms: Tangrams':
@@ -6176,6 +9307,59 @@ en:
               display_name: End of Course Project
             extra_course_content:
               display_name: Extra Course Content
+          lessons:
+            'Programming: My Robotic Friends':
+              name: 'Programming: My Robotic Friends'
+            Sequence in Maze:
+              name: Sequence in Maze
+            Building a Foundation:
+              name: Building a Foundation
+            Debugging with Scrat:
+              name: Debugging with Scrat
+            Programming in Artist:
+              name: Programming in Artist
+            'Loops: My Loopy Robotic Friends':
+              name: 'Loops: My Loopy Robotic Friends'
+            Loops in Artist:
+              name: Loops in Artist
+            Nested Loops:
+              name: Nested Loops
+            Nested Loops with Frozen:
+              name: Nested Loops with Frozen
+            'Algorithms: Dice Race':
+              name: 'Algorithms: Dice Race'
+            Introduction:
+              name: Introduction
+            Conditionals:
+              name: Conditionals
+            Private and Personal Information:
+              name: Private and Personal Information
+            Build a Star Wars Game:
+              name: Build a Star Wars Game
+            'Functions: Songwriting':
+              name: 'Functions: Songwriting'
+            Functions in Artist:
+              name: Functions in Artist
+            Functions in Bee:
+              name: Functions in Bee
+            Functions in Harvester:
+              name: Functions in Harvester
+            Determine the Concept:
+              name: Determine the Concept
+            Build a Play Lab Game:
+              name: Build a Play Lab Game
+            Explore Project Ideas:
+              name: Explore Project Ideas
+            The Design Process:
+              name: The Design Process
+            Build Your Project:
+              name: Build Your Project
+            Present Your Project:
+              name: Present Your Project
+            Internet:
+              name: Internet
+            Crowdsourcing:
+              name: Crowdsourcing
         coursef-2017:
           stages:
             'Algorithms: Tangrams':
@@ -6292,6 +9476,65 @@ en:
               display_name: Course F Content
             end_of_course_project:
               display_name: End of Course Project
+          lessons:
+            'Programming: My Robotic Friends':
+              name: 'Programming: My Robotic Friends'
+            Sequence in Maze:
+              name: Sequence in Maze
+            Building a Foundation:
+              name: Building a Foundation
+            Debugging with Scrat:
+              name: Debugging with Scrat
+            Programming in Artist:
+              name: Programming in Artist
+            'Loops: My Loopy Robotic Friends':
+              name: 'Loops: My Loopy Robotic Friends'
+            Loops in Artist:
+              name: Loops in Artist
+            Nested Loops in Bee/Zombie:
+              name: Nested Loops in Bee/Zombie
+            Nested Loops with Frozen:
+              name: Nested Loops with Frozen
+            'Algorithms: Tangrams':
+              name: 'Algorithms: Tangrams'
+            Introduction:
+              name: Introduction
+            The Power of Words:
+              name: The Power of Words
+            Ice Age Play Lab:
+              name: Ice Age Play Lab
+            Conditionals in Minecraft:
+              name: Conditionals in Minecraft
+            Envelope Variables:
+              name: Envelope Variables
+            Variables in Artist:
+              name: Variables in Artist
+            Variables in Play Lab:
+              name: Variables in Play Lab
+            For Loop Fun:
+              name: For Loop Fun
+            For Loops in Bee:
+              name: For Loops in Bee
+            For Loops in Artist:
+              name: For Loops in Artist
+            Songwriting with Parameters:
+              name: Songwriting with Parameters
+            Functions in Bee:
+              name: Functions in Bee
+            Functions with Parameters in Artist:
+              name: Functions with Parameters in Artist
+            Functions with Parameters in Bee:
+              name: Functions with Parameters in Bee
+            Explore Project Ideas:
+              name: Explore Project Ideas
+            The Design Process:
+              name: The Design Process
+            Build Your Project:
+              name: Build Your Project
+            Revise Your Project:
+              name: Revise Your Project
+            Present Your Project:
+              name: Present Your Project
         csdnovice:
           stages:
             Tuesday:
@@ -6311,6 +9554,17 @@ en:
           description_short: Reflection questions for novice facilitators at TeacherCon.
           description: 'A place to keep track of your reflection from TeacherCon as a novice facilitator. '
           lesson_groups: {}
+          lessons:
+            Welcome:
+              name: Welcome
+            Tuesday:
+              name: Tuesday
+            Wednesday:
+              name: Wednesday
+            Thursday:
+              name: Thursday
+            Wrap Up:
+              name: Wrap Up
         csp-explore-task:
           stages:
             Explore PT Prep - Reviewing the Task:
@@ -6372,6 +9626,21 @@ en:
               display_name: 'Chapter 3: AP Create Performance Task'
             csp_ap_2:
               display_name: 'Chapter 2: AP Explore Performance Task'
+          lessons:
+            Tech Setup - Your AP Digital Portfolio and Other Tools:
+              name: Tech Setup - Your AP Digital Portfolio and Other Tools
+            Create PT Prep - Reviewing the Task:
+              name: Create PT Prep - Reviewing the Task
+            Create PT Prep - Making a Plan:
+              name: Create PT Prep - Making a Plan
+            Create PT - Complete the Task:
+              name: Create PT - Complete the Task
+            Explore PT Prep - Reviewing the Task:
+              name: Explore PT Prep - Reviewing the Task
+            Explore PT - Making a Plan:
+              name: Explore PT - Making a Plan
+            Explore PT - Complete the Task:
+              name: Explore PT - Complete the Task
         cspnovice:
           stages:
             Welcome:
@@ -6393,6 +9662,17 @@ en:
               display_name: Overview
             content:
               display_name: Content
+          lessons:
+            Welcome:
+              name: Welcome
+            Tuesday:
+              name: Tuesday
+            Wednesday:
+              name: Wednesday
+            Thursday:
+              name: Thursday
+            Wrap Up:
+              name: Wrap Up
         novice-view:
           stages:
             CSP Tuesday:
@@ -6412,6 +9692,19 @@ en:
           description_short: NA
           description: NA
           lesson_groups: {}
+          lessons:
+            CSP Tuesday:
+              name: CSP Tuesday
+            CSP Wednesday:
+              name: CSP Wednesday
+            CSP Thursday:
+              name: CSP Thursday
+            CSD Tuesday:
+              name: CSD Tuesday
+            CSD Wednesday:
+              name: CSD Wednesday
+            CSD Thursday:
+              name: CSD Thursday
         csp1-dlp:
           stages:
             Deeper Learning Overview:
@@ -6429,6 +9722,11 @@ en:
               display_name: Overview
             content:
               display_name: Content
+          lessons:
+            Deeper Learning Overview:
+              name: Deeper Learning Overview
+            Complete Unit 1 Deeper Learning Reflections:
+              name: Complete Unit 1 Deeper Learning Reflections
         csp2-dlp:
           stages:
             Deeper Learning Overview:
@@ -6446,6 +9744,11 @@ en:
               display_name: Overview
             content:
               display_name: Content
+          lessons:
+            Deeper Learning Overview:
+              name: Deeper Learning Overview
+            Complete Unit 2 Deeper Learning Reflections:
+              name: Complete Unit 2 Deeper Learning Reflections
         csp3-dlp:
           stages:
             Deeper Learning Overview:
@@ -6461,6 +9764,11 @@ en:
               display_name: Overview
             content:
               display_name: Content
+          lessons:
+            Deeper Learning Overview:
+              name: Deeper Learning Overview
+            Complete Unit 3 Deeper Learning Reflections:
+              name: Complete Unit 3 Deeper Learning Reflections
         csp4-dlp:
           stages:
             Deeper Learning Overview:
@@ -6476,6 +9784,11 @@ en:
               display_name: Overview
             content:
               display_name: Content
+          lessons:
+            Deeper Learning Overview:
+              name: Deeper Learning Overview
+            Complete Unit 4 Deeper Learning Reflections:
+              name: Complete Unit 4 Deeper Learning Reflections
         csp5-dlp:
           stages:
             Deeper Learning Overview:
@@ -6491,6 +9804,11 @@ en:
               display_name: Overview
             content:
               display_name: Content
+          lessons:
+            Deeper Learning Overview:
+              name: Deeper Learning Overview
+            Complete Unit 5 Deeper Learning Reflections:
+              name: Complete Unit 5 Deeper Learning Reflections
         csd1-dlp:
           stages:
             Deeper Learning Overview:
@@ -6506,6 +9824,11 @@ en:
               display_name: Overview
             content:
               display_name: Content
+          lessons:
+            Deeper Learning Overview:
+              name: Deeper Learning Overview
+            Complete Unit 1 Deeper Learning Reflections:
+              name: Complete Unit 1 Deeper Learning Reflections
         csd6-dlp:
           stages:
             Deeper Learning Overview:
@@ -6521,6 +9844,11 @@ en:
               display_name: Overview
             content:
               display_name: Content
+          lessons:
+            Deeper Learning Overview:
+              name: Deeper Learning Overview
+            Complete Unit 6 Deeper Learning Reflections:
+              name: Complete Unit 6 Deeper Learning Reflections
         csd5-dlp:
           stages:
             Deeper Learning Overview:
@@ -6536,6 +9864,11 @@ en:
               display_name: Overview
             content:
               display_name: Content
+          lessons:
+            Deeper Learning Overview:
+              name: Deeper Learning Overview
+            Complete Unit 5 Deeper Learning Reflections:
+              name: Complete Unit 5 Deeper Learning Reflections
         csd4-dlp:
           stages:
             Deeper Learning Overview:
@@ -6551,6 +9884,11 @@ en:
               display_name: Overview
             content:
               display_name: Content
+          lessons:
+            Deeper Learning Overview:
+              name: Deeper Learning Overview
+            Complete Unit 4 Deeper Learning Reflections:
+              name: Complete Unit 4 Deeper Learning Reflections
         csd3-dlp:
           stages:
             Deeper Learning Overview:
@@ -6566,6 +9904,11 @@ en:
               display_name: Overview
             content:
               display_name: Content
+          lessons:
+            Deeper Learning Overview:
+              name: Deeper Learning Overview
+            Complete Unit 3 Deeper Learning Reflections:
+              name: Complete Unit 3 Deeper Learning Reflections
         csd2-dlp:
           stages:
             Deeper Learning Overview:
@@ -6581,11 +9924,19 @@ en:
               display_name: Overview
             content:
               display_name: Content
+          lessons:
+            Deeper Learning Overview:
+              name: Deeper Learning Overview
+            Complete Unit 2 Deeper Learning Reflections:
+              name: Complete Unit 2 Deeper Learning Reflections
         allthettsthings:
           stages:
             TTS:
               name: TTS
           lesson_groups: {}
+          lessons:
+            TTS:
+              name: TTS
         express-2017:
           stages:
             'Programming Unplugged: My Robotic Friends':
@@ -6698,6 +10049,77 @@ en:
               display_name: Content
             end_of_course_project:
               display_name: End of Course Project
+          lessons:
+            'Algorithms: Graph Paper Programming':
+              name: 'Algorithms: Graph Paper Programming'
+            Introduction:
+              name: Introduction
+            Building a Foundation:
+              name: Building a Foundation
+            Debugging in Collector:
+              name: Debugging in Collector
+            'Loops: My Loopy Robotic Friends':
+              name: 'Loops: My Loopy Robotic Friends'
+            Loops in Artist:
+              name: Loops in Artist
+            Nested Loops:
+              name: Nested Loops
+            Nested Loops Project in Frozen:
+              name: Nested Loops Project in Frozen
+            'How it Works: The Internet':
+              name: 'How it Works: The Internet'
+            'Common Sense Education: Digital Citizenship':
+              name: 'Common Sense Education: Digital Citizenship'
+            'Common Sense Education: Screen Out the Mean':
+              name: 'Common Sense Education: Screen Out the Mean'
+            'Events: The Big Event':
+              name: 'Events: The Big Event'
+            Events in Star Wars:
+              name: Events in Star Wars
+            Events with Flappy:
+              name: Events with Flappy
+            Events in Bounce:
+              name: Events in Bounce
+            'Conditionals: Conditionals with Cards':
+              name: 'Conditionals: Conditionals with Cards'
+            While Loops in Farmer:
+              name: While Loops in Farmer
+            Until Loops in Maze:
+              name: Until Loops in Maze
+            Conditionals in Minecraft:
+              name: Conditionals in Minecraft
+            Conditionals & Loops in Harvester:
+              name: Conditionals & Loops in Harvester
+            'Variables: Envelope Variables':
+              name: 'Variables: Envelope Variables'
+            Variables in Artist:
+              name: Variables in Artist
+            Variables in Play Lab:
+              name: Variables in Play Lab
+            'For Loops: For Loop Fun':
+              name: 'For Loops: For Loop Fun'
+            For Loops in Bee:
+              name: For Loops in Bee
+            For Loops in Artist:
+              name: For Loops in Artist
+            'Functions: Songwriting with Parameters':
+              name: 'Functions: Songwriting with Parameters'
+            Functions in Bee:
+              name: Functions in Bee
+            Functions with Parameters in Artist:
+              name: Functions with Parameters in Artist
+            Functions with Parameters in Bee:
+              name: Functions with Parameters in Bee
+            Explore Project Ideas:
+              name: Explore Project Ideas
+            The Design Process:
+              name: The Design Process
+            Build Your Project:
+              name: Build Your Project
+            Revise Your Project:
+              name: Revise Your Project
+            Present Your Project:
+              name: Present Your Project
         pre-express-2017:
           stages:
             'Debugging: Unspotted Bugs':
@@ -6734,6 +10156,35 @@ en:
           description_short: 'An introduction to computer science for pre-readers: combines the best of our kindergarten and first grade courses.'
           description: Learn the basics of computer science and internet safety. At the end of the course, create your very own game or story you can share.
           lesson_groups: {}
+          lessons:
+            'Debugging: Unspotted Bugs':
+              name: 'Debugging: Unspotted Bugs'
+            'Persistence & Frustration: Stevie and the Marbles':
+              name: 'Persistence & Frustration: Stevie and the Marbles'
+            'Real-life Algorithms: Plant a Seed':
+              name: 'Real-life Algorithms: Plant a Seed'
+            Learn to Drag and Drop:
+              name: Learn to Drag and Drop
+            'Online Safety: Your Digital Footprint':
+              name: 'Online Safety: Your Digital Footprint'
+            'Programming: My Robotic Friends':
+              name: 'Programming: My Robotic Friends'
+            Programming in Maze:
+              name: Programming in Maze
+            'Programming: Star Wars':
+              name: 'Programming: Star Wars'
+            'Loops: My Loopy Robotic Friends':
+              name: 'Loops: My Loopy Robotic Friends'
+            Loops in Collector:
+              name: Loops in Collector
+            Loops in Artist:
+              name: Loops in Artist
+            'Events: The Big Event':
+              name: 'Events: The Big Event'
+            Events in Play Lab:
+              name: Events in Play Lab
+            Spelling Bee:
+              name: Spelling Bee
         subgoal-labels-opt-in:
           stages:
             Subgoal Labels Study Opt-In:
@@ -6753,6 +10204,9 @@ en:
           description_short: ''
           description: ''
           lesson_groups: {}
+          lessons:
+            Subgoal Labels Study Opt-In:
+              name: Subgoal Labels Study Opt-In
         csp-pre-survey-test-2017:
           stages:
             new stage:
@@ -6812,6 +10266,31 @@ en:
               display_name: Chapter Assessment
             cspSurvey:
               display_name: Survey
+          lessons:
+            The Need For Programming Languages:
+              name: The Need For Programming Languages
+            The Need for Algorithms:
+              name: The Need for Algorithms
+            Creativity in Algorithms:
+              name: Creativity in Algorithms
+            Using Simple Commands:
+              name: Using Simple Commands
+            Creating Functions:
+              name: Creating Functions
+            Functions and Top-Down Design:
+              name: Functions and Top-Down Design
+            APIs and Function Parameters:
+              name: APIs and Function Parameters
+            Creating functions with Parameters:
+              name: Creating functions with Parameters
+            Looping and Random Numbers:
+              name: Looping and Random Numbers
+            Practice PT - Design a Digital Scene:
+              name: Practice PT - Design a Digital Scene
+            Unit 3 Chapter 1 Assessment:
+              name: Unit 3 Chapter 1 Assessment
+            Please complete the CSP Mid-course survey:
+              name: Please complete the CSP Mid-course survey
         csd4-draft:
           stages:
             Analysis of Design:
@@ -6859,6 +10338,39 @@ en:
               display_name: 'Chapter 1: User Centered Design'
             csd4_2:
               display_name: 'Chapter 2: App Prototyping'
+          lessons:
+            Analysis of Design:
+              name: Analysis of Design
+            Understanding Your User:
+              name: Understanding Your User
+            User-Centered Design Micro Activity:
+              name: User-Centered Design Micro Activity
+            User Interface and Prototype Testing:
+              name: User Interface and Prototype Testing
+            Feedback and Prototypes:
+              name: Feedback and Prototypes
+            Identifying User Needs:
+              name: Identifying User Needs
+            Project - Paper Prototype:
+              name: Project - Paper Prototype
+            Designing Apps for Good:
+              name: Designing Apps for Good
+            Market Research:
+              name: Market Research
+            Paper Prototypes:
+              name: Paper Prototypes
+            Prototype Testing:
+              name: Prototype Testing
+            Digital Design:
+              name: Digital Design
+            Linking Screens:
+              name: Linking Screens
+            Testing the App:
+              name: Testing the App
+            Improving and Iterating:
+              name: Improving and Iterating
+            App Presentation:
+              name: App Presentation
         craft17:
           stages:
             craft17 stage:
@@ -6868,6 +10380,9 @@ en:
           description_short: ''
           description: ''
           lesson_groups: {}
+          lessons:
+            craft17 stage:
+              name: craft17 stage
         applab-intro:
           stages:
             Intro to AppLab - Choose Your Own Adventure:
@@ -6893,6 +10408,9 @@ en:
           description_short: Create your own app in JavaScript using either block based programming or text. If you've already done some programming with blocks, take your skills to the next level.
           description: Create your own app in JavaScript using either block based programming or text. If you've already done some programming with blocks, take your skills to the next level.
           lesson_groups: {}
+          lessons:
+            Intro to App Lab:
+              name: Intro to App Lab
         e-f-ramp:
           stages:
             'Programming: My Robotic Friends':
@@ -6968,6 +10486,59 @@ en:
               display_name: End of Course Project
             extra_course_content:
               display_name: Extra Course Content
+          lessons:
+            'Programming: My Robotic Friends':
+              name: 'Programming: My Robotic Friends'
+            Sequence in Maze:
+              name: Sequence in Maze
+            Building a Foundation:
+              name: Building a Foundation
+            Debugging with Scrat:
+              name: Debugging with Scrat
+            Programming in Artist:
+              name: Programming in Artist
+            'Loops: My Loopy Robotic Friends':
+              name: 'Loops: My Loopy Robotic Friends'
+            Loops in Artist:
+              name: Loops in Artist
+            Nested Loops in Bee/Zombie:
+              name: Nested Loops in Bee/Zombie
+            Nested Loops with Frozen:
+              name: Nested Loops with Frozen
+            'Algorithms: Dice Race':
+              name: 'Algorithms: Dice Race'
+            Course E Introduction:
+              name: Course E Introduction
+            Conditionals:
+              name: Conditionals
+            Private and Personal Information:
+              name: Private and Personal Information
+            Build a Star Wars Game:
+              name: Build a Star Wars Game
+            'Functions: Songwriting':
+              name: 'Functions: Songwriting'
+            Functions in Bee:
+              name: Functions in Bee
+            Functions in Artist:
+              name: Functions in Artist
+            Functions in Farmer:
+              name: Functions in Farmer
+            Determine the Concept:
+              name: Determine the Concept
+            Build a Play Lab Game:
+              name: Build a Play Lab Game
+            Explore Project Ideas:
+              name: Explore Project Ideas
+            The Design Process:
+              name: The Design Process
+            Build Your Project:
+              name: Build Your Project
+            Present Your Project:
+              name: Present Your Project
+            Internet:
+              name: Internet
+            Crowdsourcing:
+              name: Crowdsourcing
         new-d:
           stages:
             'Algorithms: Graph Paper Programming':
@@ -7017,6 +10588,43 @@ en:
           description_short: ''
           description: ''
           lesson_groups: {}
+          lessons:
+            'Algorithms: Graph Paper Programming':
+              name: 'Algorithms: Graph Paper Programming'
+            Introduction:
+              name: Introduction
+            Building a Foundation:
+              name: Building a Foundation
+            Debugging in Collector:
+              name: Debugging in Collector
+            Events in Bounce:
+              name: Events in Bounce
+            Loops in Ice Age:
+              name: Loops in Ice Age
+            Loops in Artist:
+              name: Loops in Artist
+            Nested Loops in Bee:
+              name: Nested Loops in Bee
+            Nested Loops in Artist:
+              name: Nested Loops in Artist
+            While Loops in Farmer:
+              name: While Loops in Farmer
+            Conditionals with Cards:
+              name: Conditionals with Cards
+            Conditionals in Bee:
+              name: Conditionals in Bee
+            Conditionals & Loops in Maze:
+              name: Conditionals & Loops in Maze
+            Conditionals & Loops in Farmer:
+              name: Conditionals & Loops in Farmer
+            Digital Citizenship:
+              name: Digital Citizenship
+            Build a Play Lab Game:
+              name: Build a Play Lab Game
+            'Unplugged: Binary':
+              name: 'Unplugged: Binary'
+            Artist Binary:
+              name: Artist Binary
         csp3-a:
           stages:
             new stage:
@@ -7030,6 +10638,9 @@ en:
           lesson_groups:
             csp3_1:
               display_name: 'Chapter 1: Programming Languages and Algorithms'
+          lessons:
+            'CSP3A: Using Simple Commands':
+              name: 'CSP3A: Using Simple Commands'
         new-express:
           stages:
             'Algorithms: Graph Paper Programming':
@@ -7119,6 +10730,79 @@ en:
               display_name: Content
             end_of_course_project:
               display_name: End of Course Project
+          lessons:
+            'Algorithms: Graph Paper Programming':
+              name: 'Algorithms: Graph Paper Programming'
+            Introduction:
+              name: Introduction
+            Building a Foundation:
+              name: Building a Foundation
+            Debugging with Scrat:
+              name: Debugging with Scrat
+            'Loops: My Loopy Robotic Friends':
+              name: 'Loops: My Loopy Robotic Friends'
+            Loops in Artist (UPDATED!):
+              name: Loops in Artist (UPDATED!)
+            Loops in Artist:
+              name: Loops in Artist
+            Nested Loops:
+              name: Nested Loops
+            Nested Loops Project in Frozen:
+              name: Nested Loops Project in Frozen
+            'How it Works: The Internet':
+              name: 'How it Works: The Internet'
+            'Common Sense Education: Digital Citizenship':
+              name: 'Common Sense Education: Digital Citizenship'
+            'Common Sense Education: Screen Out the Mean':
+              name: 'Common Sense Education: Screen Out the Mean'
+            'Events: The Big Event':
+              name: 'Events: The Big Event'
+            Events in Star Wars:
+              name: Events in Star Wars
+            Events with Flappy:
+              name: Events with Flappy
+            Events in Bounce:
+              name: Events in Bounce
+            'Conditionals: Conditionals with Cards':
+              name: 'Conditionals: Conditionals with Cards'
+            While Loops in Farmer:
+              name: While Loops in Farmer
+            Conditional Loops in Maze:
+              name: Conditional Loops in Maze
+            Conditionals in Minecraft:
+              name: Conditionals in Minecraft
+            Conditionals & Loops in Farmer:
+              name: Conditionals & Loops in Farmer
+            'Variables: Envelope Variables':
+              name: 'Variables: Envelope Variables'
+            Variables in Artist:
+              name: Variables in Artist
+            Variables in Play Lab:
+              name: Variables in Play Lab
+            'For Loops: For Loop Fun':
+              name: 'For Loops: For Loop Fun'
+            For Loops in Bee:
+              name: For Loops in Bee
+            For Loops in Artist:
+              name: For Loops in Artist
+            'Functions: Songwriting with Parameters':
+              name: 'Functions: Songwriting with Parameters'
+            Functions in Bee:
+              name: Functions in Bee
+            Functions with Parameters in Artist:
+              name: Functions with Parameters in Artist
+            Functions with Parameters in Bee:
+              name: Functions with Parameters in Bee
+            Explore Project Ideas:
+              name: Explore Project Ideas
+            The Design Process:
+              name: The Design Process
+            Build Your Project:
+              name: Build Your Project
+            Revise Your Project:
+              name: Revise Your Project
+            Present Your Project:
+              name: Present Your Project
         new-stages-sept-2017:
           stages:
             Loops in Artist:
@@ -7132,6 +10816,13 @@ en:
           description_short: ''
           description: ''
           lesson_groups: {}
+          lessons:
+            Loops in Artist:
+              name: Loops in Artist
+            Sequences with Scrat:
+              name: Sequences with Scrat
+            Testing Template:
+              name: Testing Template
         new-e:
           stages:
             'Programming: My Robotic Friends':
@@ -7199,6 +10890,59 @@ en:
               display_name: End of Course Project
             extra_course_content:
               display_name: Extra Course Content
+          lessons:
+            'Programming: My Robotic Friends':
+              name: 'Programming: My Robotic Friends'
+            Sequence in Maze:
+              name: Sequence in Maze
+            Building a Foundation:
+              name: Building a Foundation
+            Debugging with Scrat:
+              name: Debugging with Scrat
+            Programming in Artist:
+              name: Programming in Artist
+            'Loops: My Loopy Robotic Friends':
+              name: 'Loops: My Loopy Robotic Friends'
+            Loops in Artist:
+              name: Loops in Artist
+            Nested Loops in Bee/Zombie:
+              name: Nested Loops in Bee/Zombie
+            Nested Loops with Frozen:
+              name: Nested Loops with Frozen
+            'Algorithms: Dice Race':
+              name: 'Algorithms: Dice Race'
+            Course E Introduction:
+              name: Course E Introduction
+            Conditionals:
+              name: Conditionals
+            Private and Personal Information:
+              name: Private and Personal Information
+            Build a Star Wars Game:
+              name: Build a Star Wars Game
+            'Functions: Songwriting':
+              name: 'Functions: Songwriting'
+            Functions in Bee:
+              name: Functions in Bee
+            Functions in Artist:
+              name: Functions in Artist
+            Functions in Farmer:
+              name: Functions in Farmer
+            Determine the Concept:
+              name: Determine the Concept
+            Build a Play Lab Game:
+              name: Build a Play Lab Game
+            Explore Project Ideas:
+              name: Explore Project Ideas
+            The Design Process:
+              name: The Design Process
+            Build Your Project:
+              name: Build Your Project
+            Present Your Project:
+              name: Present Your Project
+            Internet:
+              name: Internet
+            Crowdsourcing:
+              name: Crowdsourcing
         new-f:
           stages:
             'Programming: My Robotic Friends':
@@ -7270,6 +11014,65 @@ en:
               display_name: Course F Content
             end_of_course_project:
               display_name: End of Course Project
+          lessons:
+            'Programming: My Robotic Friends':
+              name: 'Programming: My Robotic Friends'
+            Sequence in Maze:
+              name: Sequence in Maze
+            Building a Foundation:
+              name: Building a Foundation
+            Debugging with Scrat:
+              name: Debugging with Scrat
+            Programming in Artist:
+              name: Programming in Artist
+            'Loops: My Loopy Robotic Friends':
+              name: 'Loops: My Loopy Robotic Friends'
+            Loops in Artist:
+              name: Loops in Artist
+            Nested Loops in Bee/Zombie:
+              name: Nested Loops in Bee/Zombie
+            Nested Loops with Frozen:
+              name: Nested Loops with Frozen
+            'Algorithms: Tangrams':
+              name: 'Algorithms: Tangrams'
+            Course E Introduction:
+              name: Course E Introduction
+            The Power of Words:
+              name: The Power of Words
+            Ice Age Play Lab:
+              name: Ice Age Play Lab
+            Conditionals in Minecraft:
+              name: Conditionals in Minecraft
+            Envelope Variables:
+              name: Envelope Variables
+            Variables in Artist:
+              name: Variables in Artist
+            Variables in Play Lab:
+              name: Variables in Play Lab
+            For Loop Fun:
+              name: For Loop Fun
+            For Loops in Bee:
+              name: For Loops in Bee
+            For Loops in Artist:
+              name: For Loops in Artist
+            Songwriting with Parameters:
+              name: Songwriting with Parameters
+            Functions in Bee:
+              name: Functions in Bee
+            Functions with Parameters in Artist:
+              name: Functions with Parameters in Artist
+            Functions with Parameters in Bee:
+              name: Functions with Parameters in Bee
+            Explore Project Ideas:
+              name: Explore Project Ideas
+            The Design Process:
+              name: The Design Process
+            Build Your Project:
+              name: Build Your Project
+            Revise Your Project:
+              name: Revise Your Project
+            Present Your Project:
+              name: Present Your Project
         csd5-old:
           stages:
             Representation Matters:
@@ -7309,6 +11112,35 @@ en:
               display_name: 'Chapter 1: Representing Information'
             csd5_2:
               display_name: 'Chapter 2: Solving Data Problems'
+          lessons:
+            Representation Matters:
+              name: Representation Matters
+            Patterns and Representation:
+              name: Patterns and Representation
+            ASCII and Binary Representation:
+              name: ASCII and Binary Representation
+            Representing Images:
+              name: Representing Images
+            Representing Numbers:
+              name: Representing Numbers
+            8-bit Numbers:
+              name: 8-bit Numbers
+            Combining Representations:
+              name: Combining Representations
+            Project - Create a Representation:
+              name: Project - Create a Representation
+            Problem Solving and Data:
+              name: Problem Solving and Data
+            Making Decisions with Data:
+              name: Making Decisions with Data
+            Interpreting Data:
+              name: Interpreting Data
+            Automating Data Decisions:
+              name: Automating Data Decisions
+            Problem Solving with Big Data:
+              name: Problem Solving with Big Data
+            Project - Solve a Data Problem:
+              name: Project - Solve a Data Problem
         subgoals-assessment-staging:
           stages:
             subgoal assessments:
@@ -7338,6 +11170,19 @@ en:
           description_short: ''
           description: ''
           lesson_groups: {}
+          lessons:
+            all assessment items as standalone assessment levels:
+              name: all assessment items as standalone assessment levels
+            submittable if last assessment item:
+              name: submittable if last assessment item
+            dummy:
+              name: dummy
+            assessment sandwiched between app lab levels:
+              name: assessment sandwiched between app lab levels
+            all assessment items clustered in levelgroup as a single "test":
+              name: all assessment items clustered in levelgroup as a single "test"
+            CSP 3 updates staging ground:
+              name: CSP 3 updates staging ground
         hocali:
           stages:
             new stage:
@@ -7355,6 +11200,9 @@ en:
           description_short: ''
           description: ''
           lesson_groups: {}
+          lessons:
+            colehoc2017 stage:
+              name: colehoc2017 stage
         craft17-kiki:
           stages:
             craft17 stage:
@@ -7364,6 +11212,9 @@ en:
           description_short: ''
           description: ''
           lesson_groups: {}
+          lessons:
+            craft17 stage:
+              name: craft17 stage
         csd4-old:
           stages:
             Analysis of Design:
@@ -7409,6 +11260,41 @@ en:
               display_name: 'Chapter 1: User Centered Design'
             csd4_2:
               display_name: 'Chapter 2: App Prototyping'
+          lessons:
+            Analysis of Design:
+              name: Analysis of Design
+            Understanding Your User:
+              name: Understanding Your User
+            User-Centered Design Micro Activity:
+              name: User-Centered Design Micro Activity
+            User Interface and Prototype Testing:
+              name: User Interface and Prototype Testing
+            Feedback and Prototypes:
+              name: Feedback and Prototypes
+            Identifying User Needs:
+              name: Identifying User Needs
+            Project - Paper Prototype:
+              name: Project - Paper Prototype
+            Designing Apps for Good:
+              name: Designing Apps for Good
+            Market Research:
+              name: Market Research
+            Paper Prototypes:
+              name: Paper Prototypes
+            Prototype Testing:
+              name: Prototype Testing
+            Digital Design:
+              name: Digital Design
+            Event Driven Programming:
+              name: Event Driven Programming
+            Basic App Functionality:
+              name: Basic App Functionality
+            Testing the App:
+              name: Testing the App
+            Improving and Iterating:
+              name: Improving and Iterating
+            App Presentation:
+              name: App Presentation
         csp3-staging:
           stages:
             The Need For Programming Languages:
@@ -7442,6 +11328,29 @@ en:
               display_name: 'Chapter 1: Programming Languages and Algorithms'
             cspAssessment:
               display_name: Chapter Assessment
+          lessons:
+            The Need For Programming Languages:
+              name: The Need For Programming Languages
+            The Need for Algorithms:
+              name: The Need for Algorithms
+            Creativity in Algorithms:
+              name: Creativity in Algorithms
+            Using Simple Commands:
+              name: Using Simple Commands
+            Creating Functions:
+              name: Creating Functions
+            Functions and Top-Down Design:
+              name: Functions and Top-Down Design
+            APIs and Function Parameters:
+              name: APIs and Function Parameters
+            Creating functions with Parameters:
+              name: Creating functions with Parameters
+            Looping and Random Numbers:
+              name: Looping and Random Numbers
+            Practice PT - Design a Digital Scene:
+              name: Practice PT - Design a Digital Scene
+            Unit 3 Chapter 1 Assessment:
+              name: Unit 3 Chapter 1 Assessment
         pwc:
           stages:
             new stage:
@@ -7483,6 +11392,25 @@ en:
           description_short: ''
           description: At PwC, we believe that all students have the potential to be tomorrow’s leaders and tech-driven workforce. Access Your Potential is our commitment to help close the opportunity gap by equipping young people, especially those from disadvantaged communities, with the financial, technology and career-selection skills they need to change the trajectory of their lives. As part of our commitment, we’re excited to launch our Access Your Potential middle school technology and careers curriculum.
           lesson_groups: {}
+          lessons:
+            Personal Innovations:
+              name: Personal Innovations
+            What is a Computer?:
+              name: What is a Computer?
+            Problem Solving with Big Data:
+              name: Problem Solving with Big Data
+            Programming - Hour of Code:
+              name: Programming - Hour of Code
+            Creating Webpages:
+              name: Creating Webpages
+            User Interfaces:
+              name: User Interfaces
+            Intro to App Lab (13+):
+              name: Intro to App Lab (13+)
+            Simple Encryption:
+              name: Simple Encryption
+            Smart Clothing Design:
+              name: Smart Clothing Design
         allthesurveys:
           stages:
             CSP pre survey Test:
@@ -7530,6 +11458,31 @@ en:
           description_short: Place to stage and test Code.org surveys
           description: ''
           lesson_groups: {}
+          lessons:
+            CSP post course survey 2019 staging:
+              name: CSP post course survey 2019 staging
+            CSD post course survey 2019 staging:
+              name: CSD post course survey 2019 staging
+            CSP pre survey 2017 staging:
+              name: CSP pre survey 2017 staging
+            CSD pre survey 2017 staging:
+              name: CSD pre survey 2017 staging
+            CSD/P pulse check survey 2017:
+              name: CSD/P pulse check survey 2017
+            CSD mid and post survey 2017 staging:
+              name: CSD mid and post survey 2017 staging
+            CSP mid and post survey 2017 staging:
+              name: CSP mid and post survey 2017 staging
+            CSP post survey 2018 staging:
+              name: CSP post survey 2018 staging
+            CSD post survey 2018 staging:
+              name: CSD post survey 2018 staging
+            CSP pre survey 2018 staging:
+              name: CSP pre survey 2018 staging
+            CSP mid survey 2018 staging:
+              name: CSP mid survey 2018 staging
+            Place for testing crazy stuff:
+              name: Place for testing crazy stuff
         k1hoc2017:
           stages:
             Collector Hour of Code 2017:
@@ -7539,6 +11492,9 @@ en:
           description_short: ''
           description: ''
           lesson_groups: {}
+          lessons:
+            Collector Hour of Code 2017:
+              name: Collector Hour of Code 2017
         hero:
           stages:
             'Minecraft\: Hero''s Journey Hour of Code':
@@ -7550,6 +11506,9 @@ en:
           description_short: Minecraft is back with a brand new activity for Hour of Code!
           description: Minecraft is back for the Hour of Code with a brand new activity! Journey through Minecraft with code.
           lesson_groups: {}
+          lessons:
+            Minecraft Hour of Code:
+              name: Minecraft Hour of Code
         applab-intro-staging:
           stages:
             Intro to AppLab - Choose Your Own Adventure:
@@ -7573,6 +11532,23 @@ en:
           description_short: ''
           description: ''
           lesson_groups: {}
+          lessons:
+            Intro to AppLab - Choose Your Own Adventure:
+              name: Intro to AppLab - Choose Your Own Adventure
+            Intro to AppLab - Choose Your Own Adventure 2:
+              name: Intro to AppLab - Choose Your Own Adventure 2
+            Intro to AppLab - Your First App:
+              name: Intro to AppLab - Your First App
+            Intro to AppLab - Your First App 2:
+              name: Intro to AppLab - Your First App 2
+            Intro to AppLab - Your First App 3:
+              name: Intro to AppLab - Your First App 3
+            Intro to AppLab - Your First App 4:
+              name: Intro to AppLab - Your First App 4
+            Intro to AppLab - Getting Started:
+              name: Intro to AppLab - Getting Started
+            Intro to App Lab:
+              name: Intro to App Lab
         csp-explore-2017:
           stages:
             new stage:
@@ -7598,6 +11574,15 @@ en:
               display_name: 'Chapter 2: AP Explore Performance Task'
             cspSurvey:
               display_name: Survey
+          lessons:
+            Explore PT Prep - Reviewing the Task:
+              name: Explore PT Prep - Reviewing the Task
+            Explore PT - Making a Plan:
+              name: Explore PT - Making a Plan
+            Explore PT - Complete the Task:
+              name: Explore PT - Complete the Task
+            Post-Course Survey:
+              name: Post-Course Survey
         csp-create-2017:
           stages:
             Tech Setup - Your AP Digital Portfolio and Other Tools:
@@ -7619,6 +11604,15 @@ en:
               display_name: 'Chapter 3: AP Create Performance Task'
             cspSurvey:
               display_name: Survey
+          lessons:
+            Create PT Prep - Reviewing the Task:
+              name: Create PT Prep - Reviewing the Task
+            Create PT Prep - Making a Plan:
+              name: Create PT Prep - Making a Plan
+            Create PT - Complete the Task:
+              name: Create PT - Complete the Task
+            Post-Course Survey:
+              name: Post-Course Survey
         csp3-reovery:
           stages:
             Under the sea recovery:
@@ -7638,6 +11632,9 @@ en:
           description_short: ''
           description: ''
           lesson_groups: {}
+          lessons:
+            Under the sea recovery:
+              name: Under the sea recovery
         aws-demo:
           stages:
             new stage:
@@ -7647,6 +11644,9 @@ en:
           description_short: ''
           description: ''
           lesson_groups: {}
+          lessons:
+            new stage:
+              name: new stage
         halloween:
           stages:
             Halloween Artist:
@@ -7656,6 +11656,9 @@ en:
           description_short: ''
           description: ''
           lesson_groups: {}
+          lessons:
+            Halloween Artist:
+              name: Halloween Artist
         valentine:
           stages:
             special valentine:
@@ -7667,6 +11670,9 @@ en:
           description_short: Have fun creating valentines
           description: ''
           lesson_groups: {}
+          lessons:
+            Valentine Puzzles:
+              name: Valentine Puzzles
         colehoc17:
           stages:
             new stage:
@@ -7676,6 +11682,7 @@ en:
           description_short: ''
           description: ''
           lesson_groups: {}
+          lessons: {}
         course-e-2018:
           stages:
             courseB_unplugged_MRF_2018:
@@ -7749,6 +11756,59 @@ en:
               display_name: End of Course Project
             extra_course_content:
               display_name: Extra Course Content
+          lessons:
+            'Programming: My Robotic Friends':
+              name: 'Programming: My Robotic Friends'
+            Sequence in Maze:
+              name: Sequence in Maze
+            Building a Foundation:
+              name: Building a Foundation
+            Debugging with Scrat:
+              name: Debugging with Scrat
+            Programming in Artist:
+              name: Programming in Artist
+            'Loops: My Loopy Robotic Friends':
+              name: 'Loops: My Loopy Robotic Friends'
+            Loops in Artist:
+              name: Loops in Artist
+            Nested Loops:
+              name: Nested Loops
+            Nested Loops with Frozen:
+              name: Nested Loops with Frozen
+            'Algorithms: Dice Race':
+              name: 'Algorithms: Dice Race'
+            Introduction:
+              name: Introduction
+            Conditionals:
+              name: Conditionals
+            Private and Personal Information:
+              name: Private and Personal Information
+            Build a Star Wars Game:
+              name: Build a Star Wars Game
+            'Functions: Songwriting':
+              name: 'Functions: Songwriting'
+            Functions in Artist:
+              name: Functions in Artist
+            Functions in Bee:
+              name: Functions in Bee
+            Functions in Harvester:
+              name: Functions in Harvester
+            Determine the Concept:
+              name: Determine the Concept
+            Build a Play Lab Game:
+              name: Build a Play Lab Game
+            Explore Project Ideas:
+              name: Explore Project Ideas
+            The Design Process:
+              name: The Design Process
+            Build Your Project:
+              name: Build Your Project
+            Present Your Project:
+              name: Present Your Project
+            Internet:
+              name: Internet
+            Crowdsourcing:
+              name: Crowdsourcing
         course-f-2018:
           stages:
             'Programming: My Robotic Friends':
@@ -7820,6 +11880,65 @@ en:
               display_name: Course F Content
             end_of_course_project:
               display_name: End of Course Project
+          lessons:
+            'Programming: My Robotic Friends':
+              name: 'Programming: My Robotic Friends'
+            Sequence in Maze:
+              name: Sequence in Maze
+            Building a Foundation:
+              name: Building a Foundation
+            Debugging with Scrat:
+              name: Debugging with Scrat
+            Programming in Artist:
+              name: Programming in Artist
+            'Loops: My Loopy Robotic Friends':
+              name: 'Loops: My Loopy Robotic Friends'
+            Loops in Artist:
+              name: Loops in Artist
+            Nested Loops in Bee/Zombie:
+              name: Nested Loops in Bee/Zombie
+            Nested Loops with Frozen:
+              name: Nested Loops with Frozen
+            'Algorithms: Tangrams':
+              name: 'Algorithms: Tangrams'
+            Introduction:
+              name: Introduction
+            The Power of Words:
+              name: The Power of Words
+            Ice Age Play Lab:
+              name: Ice Age Play Lab
+            Conditionals in Minecraft:
+              name: Conditionals in Minecraft
+            Envelope Variables:
+              name: Envelope Variables
+            Variables in Artist:
+              name: Variables in Artist
+            Variables in Play Lab:
+              name: Variables in Play Lab
+            For Loop Fun:
+              name: For Loop Fun
+            For Loops in Bee:
+              name: For Loops in Bee
+            For Loops in Artist:
+              name: For Loops in Artist
+            Songwriting with Parameters:
+              name: Songwriting with Parameters
+            Functions in Bee:
+              name: Functions in Bee
+            Functions with Parameters in Artist:
+              name: Functions with Parameters in Artist
+            Functions with Parameters in Bee:
+              name: Functions with Parameters in Bee
+            Explore Project Ideas:
+              name: Explore Project Ideas
+            The Design Process:
+              name: The Design Process
+            Build Your Project:
+              name: Build Your Project
+            Revise Your Project:
+              name: Revise Your Project
+            Present Your Project:
+              name: Present Your Project
         csd6-old:
           stages:
             Computing Innovations:
@@ -7861,6 +11980,37 @@ en:
               display_name: 'Chapter 1: Programming with Hardware'
             csd6_2:
               display_name: 'Chapter 2: Building Physical Prototypes'
+          lessons:
+            Computing Innovations:
+              name: Computing Innovations
+            Input Unplugged:
+              name: Input Unplugged
+            Event Types:
+              name: Event Types
+            Getters and Setters:
+              name: Getters and Setters
+            The Circuit Playground:
+              name: The Circuit Playground
+            Lists:
+              name: Lists
+            Lights:
+              name: Lights
+            For Loops:
+              name: For Loops
+            Lists and For Loops:
+              name: Lists and For Loops
+            Timed Loops:
+              name: Timed Loops
+            'Project: Board Output':
+              name: 'Project: Board Output'
+            Physical Input:
+              name: Physical Input
+            Analog Input:
+              name: Analog Input
+            Sensor Applications:
+              name: Sensor Applications
+            'Project: Prototype an Innovation':
+              name: 'Project: Prototype an Innovation'
         unembeddedlevels:
           stages:
             CSD U3 Plotting Shapes Shape Lab - unembed:
@@ -7940,6 +12090,53 @@ en:
               display_name: 'Chapter 2: Building Games'
             cspSurvey:
               display_name: Survey
+          lessons:
+            Programming for Entertainment:
+              name: Programming for Entertainment
+            Plotting Shapes:
+              name: Plotting Shapes
+            Drawing in Game Lab:
+              name: Drawing in Game Lab
+            Shapes and Randomization:
+              name: Shapes and Randomization
+            Variables:
+              name: Variables
+            Sprites:
+              name: Sprites
+            The Draw Loop:
+              name: The Draw Loop
+            The Counter Pattern Unplugged:
+              name: The Counter Pattern Unplugged
+            Sprite Movement:
+              name: Sprite Movement
+            Booleans Unplugged:
+              name: Booleans Unplugged
+            Conditionals:
+              name: Conditionals
+            Keyboard Input:
+              name: Keyboard Input
+            Other Forms of Input:
+              name: Other Forms of Input
+            Project - Interactive Card:
+              name: Project - Interactive Card
+            Velocity:
+              name: Velocity
+            Collision Detection:
+              name: Collision Detection
+            Complex Sprite Movement:
+              name: Complex Sprite Movement
+            Collisions:
+              name: Collisions
+            Functions:
+              name: Functions
+            The Game Design Process:
+              name: The Game Design Process
+            Using the Game Design Process:
+              name: Using the Game Design Process
+            Project - Design a Game:
+              name: Project - Design a Game
+            CS Discoveries End of Semester Survey:
+              name: CS Discoveries End of Semester Survey
         textbook:
           stages:
             Test Map Level:
@@ -7951,6 +12148,9 @@ en:
           description_short: ''
           description: ''
           lesson_groups: {}
+          lessons:
+            new stage:
+              name: new stage
         glj-behavior-test:
           stages:
             Cats and Dogs:
@@ -7960,6 +12160,9 @@ en:
           description_short: ''
           description: ''
           lesson_groups: {}
+          lessons:
+            Cats and Dogs:
+              name: Cats and Dogs
         csd3-2018:
           title: CSD Unit 3 - Animations and Games ('18-'19)
           description: " In Unit 3, you’ll build on your coding experience as you program animations, interactive art, and games in Game Lab. The unit starts off with simple shapes and builds up to more sophisticated sprite-based games, using the same programming concepts and the design process computer scientists use daily. In the final project, you’ll develop a personalized, interactive program."
@@ -8072,6 +12275,55 @@ en:
               display_name: 'Chapter 2: Building Games'
             cspSurvey:
               display_name: Survey
+          lessons:
+            Programming for Entertainment:
+              name: Programming for Entertainment
+            Plotting Shapes:
+              name: Plotting Shapes
+            Drawing in Game Lab:
+              name: Drawing in Game Lab
+            Shapes and Randomization:
+              name: Shapes and Randomization
+            Variables:
+              name: Variables
+            Sprites:
+              name: Sprites
+            The Draw Loop:
+              name: The Draw Loop
+            The Counter Pattern Unplugged:
+              name: The Counter Pattern Unplugged
+            Sprite Movement:
+              name: Sprite Movement
+            Booleans Unplugged:
+              name: Booleans Unplugged
+            Conditionals:
+              name: Conditionals
+            Keyboard Input:
+              name: Keyboard Input
+            Other Forms of Input:
+              name: Other Forms of Input
+            Project - Interactive Card:
+              name: Project - Interactive Card
+            Velocity:
+              name: Velocity
+            Collision Detection:
+              name: Collision Detection
+            Complex Sprite Movement:
+              name: Complex Sprite Movement
+            Collisions:
+              name: Collisions
+            Functions:
+              name: Functions
+            The Game Design Process:
+              name: The Game Design Process
+            Using the Game Design Process:
+              name: Using the Game Design Process
+            Project - Design a Game:
+              name: Project - Design a Game
+            CS Discoveries End of Semester Survey:
+              name: CS Discoveries End of Semester Survey
+            CS Discoveries Post-Course Survey:
+              name: CS Discoveries Post-Course Survey
         csd2-2018:
           title: CSD Unit 2 - Web Development ('18-'19)
           description: " In Unit 2, you’ll learn how to create and share the content on your own web pages. After deciding what content you want to share with the world, you’ll learn how to structure and style your pages using HTML and CSS. You’ll also practice valuable programming skills such as debugging and commenting.  By the end of the unit, you’ll have a personal website that you can publish to the Internet."
@@ -8143,6 +12395,37 @@ en:
               display_name: 'Chapter 2: Styling and CSS'
             cspSurvey:
               display_name: Survey
+          lessons:
+            Exploring Websites:
+              name: Exploring Websites
+            'Websites for Expression ':
+              name: 'Websites for Expression '
+            Intro to HTML:
+              name: Intro to HTML
+            Headings:
+              name: Headings
+            Digital Footprint:
+              name: Digital Footprint
+            Lists:
+              name: Lists
+            Intellectual Property and Images:
+              name: Intellectual Property and Images
+            Clean Code and Debugging:
+              name: Clean Code and Debugging
+            Project - Multi-Page Websites:
+              name: Project - Multi-Page Websites
+            Styling Text with CSS:
+              name: Styling Text with CSS
+            Styling Elements with CSS:
+              name: Styling Elements with CSS
+            Sources and Search Engines:
+              name: Sources and Search Engines
+            RGB Colors and Classes:
+              name: RGB Colors and Classes
+            Project - Personal Portfolio Website:
+              name: Project - Personal Portfolio Website
+            CS Discoveries Post-Course Survey:
+              name: CS Discoveries Post-Course Survey
         coursea-2018:
           title: Course A (2018)
           assignment_family_title: Course A
@@ -8209,6 +12492,35 @@ en:
             'Persistence & Frustration: Stevie and the Big Project':
               name: Stevie and the Big Project
           lesson_groups: {}
+          lessons:
+            'Debugging: Unspotted Bugs':
+              name: 'Debugging: Unspotted Bugs'
+            'Persistence & Frustration: Stevie and the Big Project':
+              name: 'Persistence & Frustration: Stevie and the Big Project'
+            'Real-life Algorithms: Plant a Seed':
+              name: 'Real-life Algorithms: Plant a Seed'
+            Sequencing in Maze:
+              name: Sequencing in Maze
+            'Programming: Happy Maps':
+              name: 'Programming: Happy Maps'
+            Programming in Maze:
+              name: Programming in Maze
+            Programming in Harvester:
+              name: Programming in Harvester
+            Going Places Safely:
+              name: Going Places Safely
+            'Loops: Happy Loops':
+              name: 'Loops: Happy Loops'
+            Loops in Harvester:
+              name: Loops in Harvester
+            Loops in Collector:
+              name: Loops in Collector
+            Loops in Artist:
+              name: Loops in Artist
+            'Events: The Big Event':
+              name: 'Events: The Big Event'
+            Events in Play Lab:
+              name: Events in Play Lab
         express-2018:
           title: Express Course
           assignment_family_title: Express Course
@@ -8431,6 +12743,101 @@ en:
             Graph Paper Programming:
               name: Graph Paper Programming
           lesson_groups: {}
+          lessons:
+            Graph Paper Programming:
+              name: Graph Paper Programming
+            Programming in Maze:
+              name: Programming in Maze
+            Relay Programming:
+              name: Relay Programming
+            Debugging in Maze:
+              name: Debugging in Maze
+            Programming in Collector:
+              name: Programming in Collector
+            Programming in Artist:
+              name: Programming in Artist
+            'Loops: Getting Loopy':
+              name: 'Loops: Getting Loopy'
+            Loops with Rey and BB-8:
+              name: Loops with Rey and BB-8
+            Loops in Artist:
+              name: Loops in Artist
+            Copyright and Creativity:
+              name: Copyright and Creativity
+            'Concept Practice with Minecraft ':
+              name: 'Concept Practice with Minecraft '
+            Nested Loops in Bee:
+              name: Nested Loops in Bee
+            Nested Loops in Frozen:
+              name: Nested Loops in Frozen
+            While Loops in Farmer:
+              name: While Loops in Farmer
+            Until Loops in Maze:
+              name: Until Loops in Maze
+            Conditionals with Cards:
+              name: Conditionals with Cards
+            Conditionals in Bee:
+              name: Conditionals in Bee
+            Conditionals & Loops in Harvester:
+              name: Conditionals & Loops in Harvester
+            'Functions: Songwriting':
+              name: 'Functions: Songwriting'
+            Functions in Minecraft:
+              name: Functions in Minecraft
+            Functions in Harvester:
+              name: Functions in Harvester
+            Functions in Artist:
+              name: Functions in Artist
+            Screen Out the Mean:
+              name: Screen Out the Mean
+            Determine the Concept:
+              name: Determine the Concept
+            'Events: The Big Event':
+              name: 'Events: The Big Event'
+            Build a Flappy Game:
+              name: Build a Flappy Game
+            The Power of Words:
+              name: The Power of Words
+            Envelope Variables:
+              name: Envelope Variables
+            Variables as Constant in Artist:
+              name: Variables as Constant in Artist
+            Variables that Change in Bee:
+              name: Variables that Change in Bee
+            Variables that Change in Artist:
+              name: Variables that Change in Artist
+            For Loop Fun:
+              name: For Loop Fun
+            For Loops in Bee:
+              name: For Loops in Bee
+            For Loops in Artist:
+              name: For Loops in Artist
+            Learning Sprites with Sprite Lab:
+              name: Learning Sprites with Sprite Lab
+            Alien Dance Party with Sprite Lab:
+              name: Alien Dance Party with Sprite Lab
+            Pet Giraffe with Sprite Lab:
+              name: Pet Giraffe with Sprite Lab
+            Explore Project Ideas:
+              name: Explore Project Ideas
+            The Design Process:
+              name: The Design Process
+            Build Your Project:
+              name: Build Your Project
+            Revise Your Project:
+              name: Revise Your Project
+            Present Your Project:
+              name: Present Your Project
+            Binary Bracelets:
+              name: Binary Bracelets
+            'Unplugged: Binary':
+              name: 'Unplugged: Binary'
+            Artist Binary:
+              name: Artist Binary
+            Internet:
+              name: Internet
+            Crowdsourcing:
+              name: Crowdsourcing
         courseb-2018:
           title: Course B (2018)
           assignment_family_title: Course B
@@ -8501,6 +12908,33 @@ en:
             Copyright and Creativity:
               name: It's Great to Create and Play Fair
           lesson_groups: {}
+          lessons:
+            Move It, Move It:
+              name: Move It, Move It
+            Sequencing with Scrat:
+              name: Sequencing with Scrat
+            Your Digital Footprint:
+              name: Your Digital Footprint
+            'Programming: My Robotic Friends':
+              name: 'Programming: My Robotic Friends'
+            Programming in Ice Age:
+              name: Programming in Ice Age
+            Copyright and Creativity:
+              name: Copyright and Creativity
+            Programming with Rey and BB-8:
+              name: Programming with Rey and BB-8
+            'Loops: My Loopy Robotic Friends':
+              name: 'Loops: My Loopy Robotic Friends'
+            Loops in Ice Age:
+              name: Loops in Ice Age
+            Loops in Collector:
+              name: Loops in Collector
+            Loops in Artist:
+              name: Loops in Artist
+            'Events: The Big Event':
+              name: 'Events: The Big Event'
+            Events in Play Lab:
+              name: Events in Play Lab
         coursed-2018:
           title: Course D (2018)
           assignment_family_title: Course D
@@ -8599,6 +13033,45 @@ en:
             Nested Loops in Maze:
               name: Nested Loops in Maze
           lesson_groups: {}
+          lessons:
+            'Algorithms: Graph Paper Programming':
+              name: 'Algorithms: Graph Paper Programming'
+            Introduction to Online Puzzles:
+              name: Introduction to Online Puzzles
+            Relay Programming:
+              name: Relay Programming
+            Debugging in Collector:
+              name: Debugging in Collector
+            Events in Bounce:
+              name: Events in Bounce
+            Loops in Ice Age:
+              name: Loops in Ice Age
+            Loops in Artist:
+              name: Loops in Artist
+            Nested Loops in Bee:
+              name: Nested Loops in Bee
+            Nested Loops in Artist:
+              name: Nested Loops in Artist
+            Nested Loops in Frozen:
+              name: Nested Loops in Frozen
+            While Loops in Farmer:
+              name: While Loops in Farmer
+            Until Loops in Maze:
+              name: Until Loops in Maze
+            Conditionals with Cards:
+              name: Conditionals with Cards
+            Conditionals in Bee:
+              name: Conditionals in Bee
+            Conditionals & Loops in Harvester:
+              name: Conditionals & Loops in Harvester
+            Digital Citizenship:
+              name: Digital Citizenship
+            Build a Play Lab Game:
+              name: Build a Play Lab Game
+            'Unplugged: Binary':
+              name: 'Unplugged: Binary'
+            Artist Binary:
+              name: Artist Binary
         jr-test:
           stages:
             Programming with Behaviors:
@@ -8624,6 +13097,21 @@ en:
           description_short: ''
           description: ''
           lesson_groups: {}
+          lessons:
+            Using Behaviors:
+              name: Using Behaviors
+            Using Forever Loops:
+              name: Using Forever Loops
+            Virtual Pet - Behaviors:
+              name: Virtual Pet - Behaviors
+            Virtual Pet - Forever:
+              name: Virtual Pet - Forever
+            Fish Tank:
+              name: Fish Tank
+            Alien Dance Party - Input:
+              name: Alien Dance Party - Input
+            Virtual Pet - Interactions:
+              name: Virtual Pet - Interactions
         petgame:
           stages:
             pet game:
@@ -8633,6 +13121,9 @@ en:
           description_short: ''
           description: ''
           lesson_groups: {}
+          lessons:
+            pet game:
+              name: pet game
         csp-exam:
           stages:
             Unit 1 - Assessment 1:
@@ -8702,6 +13193,29 @@ en:
           description_short: CS Principles AP Exam Prep
           description: 'This page contains copies of all the multiple choice assessment questions that appeared in Units 1-5 in the course.  Students may want to practice for the multiple choice exam by re-taking these little tests.  '
           lesson_groups: {}
+          lessons:
+            'Unit 1 Assessment 1 - Binary and Ascii ':
+              name: 'Unit 1 Assessment 1 - Binary and Ascii '
+            Unit 1 Assessment 2 - Internet Protocols, TCP/IP, DNS, HTTP, etc:
+              name: Unit 1 Assessment 2 - Internet Protocols, TCP/IP, DNS, HTTP, etc
+            Unit 2 Assessment 1 - Bits, Bytes, Hexadecimal and Compression:
+              name: Unit 2 Assessment 1 - Bits, Bytes, Hexadecimal and Compression
+            Unit 2 Assessment 2 - Interpreting Data & Charts, Big Data, Global Impacts:
+              name: Unit 2 Assessment 2 - Interpreting Data & Charts, Big Data, Global Impacts
+            Unit 3 Assessment 1 - Turtle Programming, Loops, Functions, Abstraction:
+              name: Unit 3 Assessment 1 - Turtle Programming, Loops, Functions, Abstraction
+            Unit 4 Assessment 1 - Privacy, Cybersecurity, Encryption:
+              name: Unit 4 Assessment 1 - Privacy, Cybersecurity, Encryption
+            Unit 5 Assessment 1 - Events, Variables, Debugging, Arithmetic, Turtle Review:
+              name: Unit 5 Assessment 1 - Events, Variables, Debugging, Arithmetic, Turtle Review
+            Unit 5 Assessment 2 - If Statements, Boolean Expressions, Strings:
+              name: Unit 5 Assessment 2 - If Statements, Boolean Expressions, Strings
+            Unit 5 Assessment 3 - While Loops, Boolean Expressions, Arrays and Lists:
+              name: Unit 5 Assessment 3 - While Loops, Boolean Expressions, Arrays and Lists
+            Unit 5 Assessment 4 - List Algorithms, Functions with Return Values:
+              name: Unit 5 Assessment 4 - List Algorithms, Functions with Return Values
+            Unit 5 Assessment 5 - Practice AP Pseudocode Questions (Variables, Procedures, Loops, Conditionals):
+              name: Unit 5 Assessment 5 - Practice AP Pseudocode Questions (Variables, Procedures, Loops, Conditionals)
         coursec-2018:
           title: Course C (2018)
           assignment_family_title: Course C
@@ -8772,6 +13286,39 @@ en:
             Looking Ahead:
               name: Looking Ahead with Minecraft
           lesson_groups: {}
+          lessons:
+            Building a Foundation:
+              name: Building a Foundation
+            Programming in Maze:
+              name: Programming in Maze
+            Debugging in Maze:
+              name: Debugging in Maze
+            'Real-life Algorithms: Paper Planes':
+              name: 'Real-life Algorithms: Paper Planes'
+            Programming in Collector:
+              name: Programming in Collector
+            Programming in Artist:
+              name: Programming in Artist
+            'Loops: Getting Loopy':
+              name: 'Loops: Getting Loopy'
+            Loops with Rey and BB-8:
+              name: Loops with Rey and BB-8
+            Loops in Artist:
+              name: Loops in Artist
+            Loops in Harvester:
+              name: Loops in Harvester
+            'Events: The Big Event':
+              name: 'Events: The Big Event'
+            Build a Flappy Game:
+              name: Build a Flappy Game
+            Screen Out the Mean:
+              name: Screen Out the Mean
+            Events in Play Lab:
+              name: Events in Play Lab
+            Looking Ahead:
+              name: Looking Ahead
+            Binary Bracelets:
+              name: Binary Bracelets
         csd6-2018:
           title: CSD Unit 6 - Physical Computing ('18-'19)
           description: Unit 6 explores the role of hardware platforms in computing and how different sensors can provide more effective input and output than the traditional keyboard, mouse, and monitor. Using App Lab and Adafruit’s Circuit Playground, you’ll develop programs that utilize the same hardware inputs and outputs that you see in the smart devices, looking at how a simple rough prototype can lead to a finished product. The unit concludes with a design challenge to use the Circuit Playground as the basis for an innovation of your own design.
@@ -8883,6 +13430,41 @@ en:
               display_name: 'Chapter 2: Building Physical Prototypes'
             cspSurvey:
               display_name: Survey
+          lessons:
+            Innovations in Computing:
+              name: Innovations in Computing
+            Designing Screens with Code:
+              name: Designing Screens with Code
+            The Circuit Playground:
+              name: The Circuit Playground
+            Input Unplugged:
+              name: Input Unplugged
+            Board Events:
+              name: Board Events
+            Getting Properties:
+              name: Getting Properties
+            Analog Input:
+              name: Analog Input
+            The Program Design Process:
+              name: The Program Design Process
+            'Project: Make a Game':
+              name: 'Project: Make a Game'
+            Arrays and Color LEDs:
+              name: Arrays and Color LEDs
+            Making Music:
+              name: Making Music
+            Arrays and For Loops:
+              name: Arrays and For Loops
+            Accelerometer:
+              name: Accelerometer
+            Functions with Parameters:
+              name: Functions with Parameters
+            Circuits and Physical Prototypes:
+              name: Circuits and Physical Prototypes
+            'Project: Prototype an Innovation':
+              name: 'Project: Prototype an Innovation'
+            CS Discoveries Post-Course Survey:
+              name: CS Discoveries Post-Course Survey
         coursee-2018:
           title: Course E (2018)
           assignment_family_title: Course E
@@ -9020,6 +13602,63 @@ en:
               display_name: End of Course Project
             extra_course_content:
               display_name: Extra Course Content
+          lessons:
+            'Programming: My Robotic Friends':
+              name: 'Programming: My Robotic Friends'
+            Sequence in Maze:
+              name: Sequence in Maze
+            Building a Foundation:
+              name: Building a Foundation
+            Debugging with Scrat:
+              name: Debugging with Scrat
+            Programming in Artist:
+              name: Programming in Artist
+            'Loops: My Loopy Robotic Friends':
+              name: 'Loops: My Loopy Robotic Friends'
+            Loops in Artist:
+              name: Loops in Artist
+            Nested Loops:
+              name: Nested Loops
+            Nested Loops with Frozen:
+              name: Nested Loops with Frozen
+            Conditionals with Cards:
+              name: Conditionals with Cards
+            Conditionals:
+              name: Conditionals
+            Private and Personal Information:
+              name: Private and Personal Information
+            Build a Star Wars Game:
+              name: Build a Star Wars Game
+            'Functions: Songwriting':
+              name: 'Functions: Songwriting'
+            Functions in Minecraft:
+              name: Functions in Minecraft
+            Functions in Harvester:
+              name: Functions in Harvester
+            Copyright and Creativity:
+              name: Copyright and Creativity
+            Functions in Artist:
+              name: Functions in Artist
+            Determine the Concept:
+              name: Determine the Concept
+            Learning Sprites with Sprite Lab:
+              name: Learning Sprites with Sprite Lab
+            Alien Dance Party with Sprite Lab:
+              name: Alien Dance Party with Sprite Lab
+            Pet Giraffe with Sprite Lab:
+              name: Pet Giraffe with Sprite Lab
+            Explore Project Ideas:
+              name: Explore Project Ideas
+            The Design Process:
+              name: The Design Process
+            Build Your Project:
+              name: Build Your Project
+            Present Your Project:
+              name: Present Your Project
+            Internet:
+              name: Internet
+            Crowdsourcing:
+              name: Crowdsourcing
         coursef-2018:
           title: Course F (2018)
           assignment_family_title: Course F
@@ -9170,6 +13809,63 @@ en:
               display_name: Course F Content
             end_of_course_project:
               display_name: End of Course Project
+          lessons:
+            'Programming: My Robotic Friends':
+              name: 'Programming: My Robotic Friends'
+            Sequence in Maze:
+              name: Sequence in Maze
+            Building a Foundation:
+              name: Building a Foundation
+            Debugging with Scrat:
+              name: Debugging with Scrat
+            Programming in Artist:
+              name: Programming in Artist
+            'Loops: My Loopy Robotic Friends':
+              name: 'Loops: My Loopy Robotic Friends'
+            Loops in Artist:
+              name: Loops in Artist
+            Nested Loops in Bee/Zombie:
+              name: Nested Loops in Bee/Zombie
+            Nested Loops with Frozen:
+              name: Nested Loops with Frozen
+            Conditionals with Cards:
+              name: Conditionals with Cards
+            Conditionals in Farmer:
+              name: Conditionals in Farmer
+            Functions in Minecraft:
+              name: Functions in Minecraft
+            The Power of Words:
+              name: The Power of Words
+            Envelope Variables:
+              name: Envelope Variables
+            Variables as Constant in Artist:
+              name: Variables as Constant in Artist
+            Variables that Change in Bee:
+              name: Variables that Change in Bee
+            Variables that Change in Artist:
+              name: Variables that Change in Artist
+            For Loop Fun:
+              name: For Loop Fun
+            For Loops in Bee:
+              name: For Loops in Bee
+            For Loops in Artist:
+              name: For Loops in Artist
+            Learning Sprites with Sprite Lab:
+              name: Learning Sprites with Sprite Lab
+            Alien Dance Party with Sprite Lab:
+              name: Alien Dance Party with Sprite Lab
+            Pet Giraffe with Sprite Lab:
+              name: Pet Giraffe with Sprite Lab
+            Explore Project Ideas:
+              name: Explore Project Ideas
+            The Design Process:
+              name: The Design Process
+            Build Your Project:
+              name: Build Your Project
+            Revise Your Project:
+              name: Revise Your Project
+            Present Your Project:
+              name: Present Your Project
         csp1-2018:
           title: CSP Unit 1 - The Internet ('18-'19)
           description: This unit explores the technical challenges and questions that arise from the need to represent digital information in computers and transfer it between people and computational devices. The unit then explores the structure and design of the internet and the implications of those design decisions.
@@ -9253,6 +13949,41 @@ en:
               display_name: 'Chapter 1: Representing and Transmitting Information'
             csp1_2:
               display_name: 'Chapter 2: Inventing the Internet'
+          lessons:
+            CS Principles Pre-survey:
+              name: CS Principles Pre-survey
+            Personal Innovations:
+              name: Personal Innovations
+            Sending Binary Messages:
+              name: Sending Binary Messages
+            Sending Binary Messages with the Internet Simulator:
+              name: Sending Binary Messages with the Internet Simulator
+            Number Systems:
+              name: Number Systems
+            Binary Numbers:
+              name: Binary Numbers
+            Sending Numbers:
+              name: Sending Numbers
+            Sending Text:
+              name: Sending Text
+            Unit 1 Chapter 1 Assessment:
+              name: Unit 1 Chapter 1 Assessment
+            The Internet:
+              name: The Internet
+            The Need for Addressing:
+              name: The Need for Addressing
+            Routers and Redundancy:
+              name: Routers and Redundancy
+            Packets and Making a Reliable Internet:
+              name: Packets and Making a Reliable Internet
+            The Need for DNS:
+              name: The Need for DNS
+            HTTP and Abstraction:
+              name: HTTP and Abstraction
+            Practice PT - The Internet and Society:
+              name: Practice PT - The Internet and Society
+            Unit 1 Chapter 2 Assessment:
+              name: Unit 1 Chapter 2 Assessment
         csd1-2018:
           title: CSD Unit 1 - Problem Solving ('18-'19)
           description: " \r\nUnit 1 is a highly interactive and collaborative introduction to the field of computer science, as framed within the broader pursuit of solving problems. You’ll practice using a problem solving process to address a series of puzzles, challenges, and real world scenarios. Next, you’ll learn how computers input, output, store, and process information to help humans solve problems.  The unit concludes with a project in which you design an application that helps solve a problem of your choosing.\r\n"
@@ -9310,6 +14041,25 @@ en:
               display_name: 'Chapter 1: The Problem Solving Process'
             csd1_2:
               display_name: 'Chapter 2: Computers and Problem Solving'
+          lessons:
+            CS Discoveries Pre-survey:
+              name: CS Discoveries Pre-survey
+            Intro to Problem Solving:
+              name: Intro to Problem Solving
+            The Problem Solving Process:
+              name: The Problem Solving Process
+            Exploring Problem Solving:
+              name: Exploring Problem Solving
+            What is a Computer?:
+              name: What is a Computer?
+            Input and Output:
+              name: Input and Output
+            Processing:
+              name: Processing
+            Apps and Storage:
+              name: Apps and Storage
+            Project - Propose an App:
+              name: Project - Propose an App
         csd4-2018:
           title: CSD Unit 4 - The Design Process ('18-'19)
           description: Unit 4 introduces the broader social impacts of computing. Through a series of design challenges, you will learn how to better understand the needs of others while developing a solution to a problem. The second half of the unit consists of an iterative team project, during which teams have the opportunity to identify a need that they care about, prototype solutions both on paper and in App Lab, and test solutions with real users to get feedback and drive further iteration.
@@ -9389,6 +14139,41 @@ en:
               display_name: 'Chapter 2: App Prototyping'
             cspSurvey:
               display_name: Survey
+          lessons:
+            Analysis of Design:
+              name: Analysis of Design
+            Understanding Your User:
+              name: Understanding Your User
+            User-Centered Design Micro Activity:
+              name: User-Centered Design Micro Activity
+            User Interfaces:
+              name: User Interfaces
+            Feedback and Testing:
+              name: Feedback and Testing
+            Identifying User Needs:
+              name: Identifying User Needs
+            Project - Paper Prototype:
+              name: Project - Paper Prototype
+            Designing Apps for Good:
+              name: Designing Apps for Good
+            Market Research:
+              name: Market Research
+            Paper Prototypes:
+              name: Paper Prototypes
+            Prototype Testing:
+              name: Prototype Testing
+            Digital Design:
+              name: Digital Design
+            Linking Screens:
+              name: Linking Screens
+            Testing the App:
+              name: Testing the App
+            Improving and Iterating:
+              name: Improving and Iterating
+            Project - App Presentation:
+              name: Project - App Presentation
+            CS Discoveries Post-Course Survey:
+              name: CS Discoveries Post-Course Survey
         csd5-2018:
           title: CSD Unit 5 - Data and Society ('18-'19)
           description: Unit 5 is about the importance of data in solving problems and highlights how computers can help in this process. The first chapter explores different systems used to represent information in a computer and the challenges and tradeoffs posed by using them. In the second chapter you’ll learn how collections of data are used to solve problems, and how computers help to automate the steps of this process. The chapter concludes by considering how the data problem solving process can be applied to an area of your choosing.
@@ -9464,6 +14249,39 @@ en:
               display_name: 'Chapter 2: Solving Data Problems'
             cspSurvey:
               display_name: Survey
+          lessons:
+            Representation Matters:
+              name: Representation Matters
+            Patterns and Representation:
+              name: Patterns and Representation
+            ASCII and Binary Representation:
+              name: ASCII and Binary Representation
+            Representing Images:
+              name: Representing Images
+            Representing Numbers:
+              name: Representing Numbers
+            Keeping Data Secret:
+              name: Keeping Data Secret
+            Combining Representations:
+              name: Combining Representations
+            Project - Create a Representation:
+              name: Project - Create a Representation
+            Problem Solving and Data:
+              name: Problem Solving and Data
+            Problem Solving with Big Data:
+              name: Problem Solving with Big Data
+            Structuring Data:
+              name: Structuring Data
+            Making Decisions with Data:
+              name: Making Decisions with Data
+            Interpreting Data:
+              name: Interpreting Data
+            Automating Data Decisions:
+              name: Automating Data Decisions
+            Project - Solve a Data Problem:
+              name: Project - Solve a Data Problem
+            CS Discoveries Post-Course Survey:
+              name: CS Discoveries Post-Course Survey
         csp2-2018:
           title: CSP Unit 2 - Digital Information ('18-'19)
           description: This unit further explores the ways that digital information is encoded, represented and manipulated. Being able to digitally manipulate data, visualize it, and identify patterns, trends and possible meanings are important practical skills that computer scientists do every day. Understanding where data comes from, having intuitions about what could be learned or extracted from it, and being able to use computational tools to manipulate data and communicate about it are the primary skills addressed in the unit.
@@ -9551,6 +14369,21 @@ en:
               display_name: 'Unit 2: Digital Information'
             cspAssessment:
               display_name: Chapter Assessment
+          lessons:
+            Bytes and File Sizes:
+              name: Bytes and File Sizes
+            Text Compression:
+              name: Text Compression
+            Encoding B&W Images:
+              name: Encoding B&W Images
+            Encoding Color Images:
+              name: Encoding Color Images
+            Lossy vs Lossless Compression:
+              name: Lossy vs Lossless Compression
+            Rapid Research - Format Showdown:
+              name: Rapid Research - Format Showdown
+            Unit 2 Assessment:
+              name: Unit 2 Assessment
         csp3-2018:
           title: CSP Unit 3 - Intro to Programming ('18-'19)
           description: This unit introduces the foundational concepts of computer programming, which unlocks the ability to make rich, interactive apps. This course uses JavaScript as the programming language, and App Lab as the programming environment to build apps, but the concepts learned in these lessons span all programming languages and tools.
@@ -9618,6 +14451,33 @@ en:
               display_name: Chapter Assessment
             cspSurvey:
               display_name: Survey
+          lessons:
+            The Need For Programming Languages:
+              name: The Need For Programming Languages
+            The Need for Algorithms:
+              name: The Need for Algorithms
+            Creativity in Algorithms:
+              name: Creativity in Algorithms
+            Using Simple Commands:
+              name: Using Simple Commands
+            Creating Functions:
+              name: Creating Functions
+            Functions and Top-Down Design:
+              name: Functions and Top-Down Design
+            APIs and Function Parameters:
+              name: APIs and Function Parameters
+            Creating functions with Parameters:
+              name: Creating functions with Parameters
+            Looping and Random Numbers:
+              name: Looping and Random Numbers
+            Practice PT - Design a Digital Scene:
+              name: Practice PT - Design a Digital Scene
+            Unit 3 Chapter 1 Assessment:
+              name: Unit 3 Chapter 1 Assessment
+            Mid-Year Survey:
+              name: Mid-Year Survey
+            CS Principles Post-Course Survey:
+              name: CS Principles Post-Course Survey
         csp-explore-2018:
           title: Explore - AP Performance Task Prep ('18-'19)
           description: 'These lessons are here to help you understand, prepare for, and do the AP Explore Performance Task.  Each "lesson" contains links to helpful documents that your teacher can help walk you through. NOTE: the second item in the first lesson is not related to the Explore PT directly, but covers general tech setup and tools you need to do various elements of both the Explore and Create tasks.'
@@ -9645,6 +14505,15 @@ en:
               display_name: 'Chapter 2: AP Explore Performance Task'
             cspSurvey:
               display_name: Survey
+          lessons:
+            Explore PT Prep - Reviewing the Task:
+              name: Explore PT Prep - Reviewing the Task
+            Explore PT - Making a Plan:
+              name: Explore PT - Making a Plan
+            Explore PT - Complete the Task:
+              name: Explore PT - Complete the Task
+            CS Principles Post-Course Survey:
+              name: CS Principles Post-Course Survey
         csp-create-2018:
           title: Create - AP Performance Task Prep ('18-'19)
           description: 'These lessons are here to help you understand, prepare for, and do the AP Create Performance Task.  Each "lesson" contains links to helpful documents that your teacher can help walk you through. NOTE: the first item in the first lesson is not related to the Create PT directly, but covers general tech setup and tools you need to do various elements of both the Explore and Create tasks.'
@@ -9670,6 +14539,15 @@ en:
               display_name: 'Chapter 3: AP Create Performance Task'
             cspSurvey:
               display_name: Survey
+          lessons:
+            Create PT Prep - Reviewing the Task:
+              name: Create PT Prep - Reviewing the Task
+            Create PT Prep - Making a Plan:
+              name: Create PT Prep - Making a Plan
+            Create PT - Complete the Task:
+              name: Create PT - Complete the Task
+            CS Principles Post-Course Survey:
+              name: CS Principles Post-Course Survey
         csp4-2018:
           title: CSP Unit 4 - Big Data and Privacy ('18-'19)
           description: The data-rich world we live in introduces many complex questions related to public policy, law, ethics and societal impact. The goals of this unit are to develop a well-rounded and balanced view about data in the world, including the positive and negative effects of it, and to understand the basics of how and why modern encryption works.
@@ -9737,6 +14615,31 @@ en:
               display_name: Chapter Assessment
             cspSurvey:
               display_name: Survey
+          lessons:
+            What is Big Data?:
+              name: What is Big Data?
+            Finding Trends with Visualizations:
+              name: Finding Trends with Visualizations
+            Check Your Assumptions:
+              name: Check Your Assumptions
+            Rapid Research - Data Innovations:
+              name: Rapid Research - Data Innovations
+            Identifying People with Data:
+              name: Identifying People with Data
+            The Cost of Free:
+              name: The Cost of Free
+            Simple Encryption:
+              name: Simple Encryption
+            Encryption with Keys and Passwords:
+              name: Encryption with Keys and Passwords
+            Public Key Crypto:
+              name: Public Key Crypto
+            Rapid Research - Cybercrime:
+              name: Rapid Research - Cybercrime
+            Unit 4 Assessment:
+              name: Unit 4 Assessment
+            CS Principles Post-Course Survey:
+              name: CS Principles Post-Course Survey
         csp5-2018:
           title: CSP Unit 5 - Building Apps ('18-'19)
           description: This unit continues the introduction of foundational concepts of computer programming, which unlocks the ability to make rich, interactive apps. This course uses JavaScript as the programming language, and App Lab as the programming environment to build apps, but the concepts learned in these lessons span all programming languages and tools.
@@ -9850,6 +14753,53 @@ en:
               display_name: 'Chapter 2: Programming with Data Structures'
             cspSurvey:
               display_name: Survey
+          lessons:
+            Buttons and Events:
+              name: Buttons and Events
+            Multi-screen Apps:
+              name: Multi-screen Apps
+            'Building an App: Multi-Screen App':
+              name: 'Building an App: Multi-Screen App'
+            Controlling Memory with Variables:
+              name: Controlling Memory with Variables
+            'Building an App: Clicker Game':
+              name: 'Building an App: Clicker Game'
+            Unit 5 Assessment 1:
+              name: Unit 5 Assessment 1
+            User Input and Strings:
+              name: User Input and Strings
+            '"If" Statements Unplugged':
+              name: '"If" Statements Unplugged'
+            Boolean Expressions and "If" Statements:
+              name: Boolean Expressions and "If" Statements
+            '"if-else-if" and Conditional Logic':
+              name: '"if-else-if" and Conditional Logic'
+            'Building an App: Color Sleuth':
+              name: 'Building an App: Color Sleuth'
+            Unit 5 Assessment 2:
+              name: Unit 5 Assessment 2
+            While Loops:
+              name: While Loops
+            Loops and Simulations:
+              name: Loops and Simulations
+            Introduction to Arrays:
+              name: Introduction to Arrays
+            'Building an App: Image Scroller':
+              name: 'Building an App: Image Scroller'
+            Unit 5 Assessment 3:
+              name: Unit 5 Assessment 3
+            Processing Arrays:
+              name: Processing Arrays
+            Functions with Return Values:
+              name: Functions with Return Values
+            'Building an App: Canvas Painter':
+              name: 'Building an App: Canvas Painter'
+            Unit 5 Assessment 4:
+              name: Unit 5 Assessment 4
+            Unit 5 Assessment 5 - AP Pseudocode Practice Questions:
+              name: Unit 5 Assessment 5 - AP Pseudocode Practice Questions
+            CS Principles Post-Course Survey:
+              name: CS Principles Post-Course Survey
         csppostap-2018:
           title: Post AP - Data Tools ('18-'19)
           description: "In the first chapter of this unit students develop skills interpreting visual data and using spreadsheet and visualization tools to create their own digital artifacts.  Through an ongoing project  - the “class data tracker” - students learn how to collect and clean data, and to use a few common tools for computing aggregations and creating visualizations. \r\n\r\nThe second chapter explores the importance of data within apps. App Lab has a number of tools that allow you to collect and use data in your apps. The second chapter provides an overview of how these tools work, a sampling of example projects that can be built using these tools, and a space in which to build and submit a final project."
@@ -9923,6 +14873,43 @@ en:
               display_name: 'Chapter 2: Apps and Databases'
             cspSurvey:
               display_name: Survey
+          lessons:
+            Intro to Data:
+              name: Intro to Data
+            Good and Bad Data Visualizations:
+              name: Good and Bad Data Visualizations
+            Making Data Visualizations:
+              name: Making Data Visualizations
+            Discover a Data Story:
+              name: Discover a Data Story
+            Cleaning Data:
+              name: Cleaning Data
+            Creating Summary Tables:
+              name: Creating Summary Tables
+            Project - Tell a Data Story:
+              name: Project - Tell a Data Story
+            Chapter 1 Assessment:
+              name: Chapter 1 Assessment
+            Creating Javascript Objects:
+              name: Creating Javascript Objects
+            Permanent Data Storage:
+              name: Permanent Data Storage
+            Reading Records:
+              name: Reading Records
+            Deleting Records:
+              name: Deleting Records
+            Updating Records:
+              name: Updating Records
+            Importing and Exporting Data:
+              name: Importing and Exporting Data
+            Visualizing Data:
+              name: Visualizing Data
+            Sample Apps:
+              name: Sample Apps
+            Final Project:
+              name: Final Project
+            CS Principles Post-Course Survey:
+              name: CS Principles Post-Course Survey
         spritelab:
           stages:
             'Fish Tank: Creating Sprites':
@@ -9938,6 +14925,13 @@ en:
           description_short: This is a pilot course for Code.org's new Sprite Lab tool for Courses E and F
           description: This is a pilot course for Code.org's new Sprite Lab tool for Courses E and F
           lesson_groups: {}
+          lessons:
+            Fish Tank - Creating Sprites:
+              name: Fish Tank - Creating Sprites
+            Alien Dance Party - Input:
+              name: Alien Dance Party - Input
+            Virtual Pet - Interactions:
+              name: Virtual Pet - Interactions
         csd1-dlp-18:
           stages:
             Deeper Learning Overview:
@@ -9957,6 +14951,11 @@ en:
               display_name: Overview
             content:
               display_name: Content
+          lessons:
+            Deeper Learning Overview:
+              name: Deeper Learning Overview
+            Complete Unit 1 Deeper Learning Reflections:
+              name: Complete Unit 1 Deeper Learning Reflections
         csd2-dlp-18:
           stages:
             Deeper Learning Overview:
@@ -9972,6 +14971,11 @@ en:
               display_name: Overview
             content:
               display_name: Content
+          lessons:
+            Deeper Learning Overview:
+              name: Deeper Learning Overview
+            Complete Unit 2 Deeper Learning Reflections:
+              name: Complete Unit 2 Deeper Learning Reflections
         csd3-dlp-18:
           stages:
             Deeper Learning Overview:
@@ -9987,6 +14991,11 @@ en:
               display_name: Overview
             content:
               display_name: Content
+          lessons:
+            Deeper Learning Overview:
+              name: Deeper Learning Overview
+            Complete Unit 3 Deeper Learning Reflections:
+              name: Complete Unit 3 Deeper Learning Reflections
         csd4-dlp-18:
           stages:
             Deeper Learning Overview:
@@ -10004,6 +15013,11 @@ en:
               display_name: Overview
             content:
               display_name: Content
+          lessons:
+            Deeper Learning Overview:
+              name: Deeper Learning Overview
+            Complete Unit 4 Deeper Learning Reflections:
+              name: Complete Unit 4 Deeper Learning Reflections
         csd5-dlp-18:
           stages:
             Deeper Learning Overview:
@@ -10019,6 +15033,11 @@ en:
               display_name: Overview
             content:
               display_name: Content
+          lessons:
+            Deeper Learning Overview:
+              name: Deeper Learning Overview
+            Complete Unit 5 Deeper Learning Reflections:
+              name: Complete Unit 5 Deeper Learning Reflections
         csd6-dlp-18:
           stages:
             Deeper Learning Overview:
@@ -10036,6 +15055,11 @@ en:
               display_name: Overview
             content:
               display_name: Content
+          lessons:
+            Deeper Learning Overview:
+              name: Deeper Learning Overview
+            Complete Unit 6 Deeper Learning Reflections:
+              name: Complete Unit 6 Deeper Learning Reflections
         csp1-dlp-18:
           stages:
             Deeper Learning Overview:
@@ -10051,6 +15075,11 @@ en:
               display_name: Overview
             content:
               display_name: Content
+          lessons:
+            Deeper Learning Overview:
+              name: Deeper Learning Overview
+            Complete Unit 1 Deeper Learning Reflections:
+              name: Complete Unit 1 Deeper Learning Reflections
         csp2-dlp-18:
           stages:
             Deeper Learning Overview:
@@ -10066,6 +15095,11 @@ en:
               display_name: Overview
             content:
               display_name: Content
+          lessons:
+            Deeper Learning Overview:
+              name: Deeper Learning Overview
+            Complete Unit 2 Deeper Learning Reflections:
+              name: Complete Unit 2 Deeper Learning Reflections
         csp3-dlp-18:
           stages:
             Deeper Learning Overview:
@@ -10081,6 +15115,11 @@ en:
               display_name: Overview
             content:
               display_name: Content
+          lessons:
+            Deeper Learning Overview:
+              name: Deeper Learning Overview
+            Complete Unit 3 Deeper Learning Reflections:
+              name: Complete Unit 3 Deeper Learning Reflections
         csp4-dlp-18:
           stages:
             Deeper Learning Overview:
@@ -10098,6 +15137,11 @@ en:
               display_name: Overview
             content:
               display_name: Content
+          lessons:
+            Deeper Learning Overview:
+              name: Deeper Learning Overview
+            Complete Unit 4 Deeper Learning Reflections:
+              name: Complete Unit 4 Deeper Learning Reflections
         csp5-dlp-18:
           stages:
             Deeper Learning Overview:
@@ -10113,6 +15157,11 @@ en:
               display_name: Overview
             content:
               display_name: Content
+          lessons:
+            Deeper Learning Overview:
+              name: Deeper Learning Overview
+            Complete Unit 5 Deeper Learning Reflections:
+              name: Complete Unit 5 Deeper Learning Reflections
         csp-explore-dlp-18:
           stages:
             Deeper Learning Overview:
@@ -10132,6 +15181,11 @@ en:
               display_name: Overview
             content:
               display_name: Content
+          lessons:
+            Deeper Learning Overview:
+              name: Deeper Learning Overview
+            Complete Explore Deeper Learning Reflections:
+              name: Complete Explore Deeper Learning Reflections
         csp-create-dlp-18:
           stages:
             Deeper Learning Overview:
@@ -10147,6 +15201,11 @@ en:
               display_name: Overview
             content:
               display_name: Content
+          lessons:
+            Deeper Learning Overview:
+              name: Deeper Learning Overview
+            Complete Create Deeper Learning Reflections:
+              name: Complete Create Deeper Learning Reflections
         csd-post-survey:
           stages:
             CSD post-course survey:
@@ -10158,6 +15217,9 @@ en:
           lesson_groups:
             csd_survey:
               display_name: Post-Course Survey
+          lessons:
+            CSD post-course survey:
+              name: CSD post-course survey
         csd-novice-18:
           stages:
             Novice Reflections Overview:
@@ -10195,6 +15257,19 @@ en:
               display_name: Overview
             content:
               display_name: Content
+          lessons:
+            Novice Reflection Overview:
+              name: Novice Reflection Overview
+            Day 1:
+              name: Day 1
+            Day 2:
+              name: Day 2
+            Day 3:
+              name: Day 3
+            Day 4:
+              name: Day 4
+            Wrap Up:
+              name: Wrap Up
         csd-apprentice-18:
           stages:
             Novice Reflection Overview:
@@ -10226,6 +15301,19 @@ en:
               display_name: Overview
             content:
               display_name: Content
+          lessons:
+            Apprentice Reflection Overview:
+              name: Apprentice Reflection Overview
+            Day 1:
+              name: Day 1
+            Day 2:
+              name: Day 2
+            Day 3:
+              name: Day 3
+            Day 4:
+              name: Day 4
+            Wrap Up:
+              name: Wrap Up
         csp-novice-18:
           stages:
             Novice Reflection Overview:
@@ -10257,6 +15345,19 @@ en:
               display_name: Overview
             content:
               display_name: Content
+          lessons:
+            Novice Reflection Overview:
+              name: Novice Reflection Overview
+            Day 1:
+              name: Day 1
+            Day 2:
+              name: Day 2
+            Day 3:
+              name: Day 3
+            Day 4:
+              name: Day 4
+            Wrap Up:
+              name: Wrap Up
         csp-apprentice-18:
           stages:
             Novice Reflection Overview:
@@ -10288,6 +15389,19 @@ en:
               display_name: Overview
             content:
               display_name: Content
+          lessons:
+            Apprentice Reflection Overview:
+              name: Apprentice Reflection Overview
+            Day 1:
+              name: Day 1
+            Day 2:
+              name: Day 2
+            Day 3:
+              name: Day 3
+            Day 4:
+              name: Day 4
+            Wrap Up:
+              name: Wrap Up
         pre-express-2018:
           title: Pre-reader Express (2018)
           assignment_family_title: Pre-reader Express
@@ -10368,6 +15482,39 @@ en:
             'Persistence & Frustration: Stevie and the Big Project':
               name: Stevie and the Big Project
           lesson_groups: {}
+          lessons:
+            'Debugging: Unspotted Bugs':
+              name: 'Debugging: Unspotted Bugs'
+            'Persistence & Frustration: Stevie and the Big Project':
+              name: 'Persistence & Frustration: Stevie and the Big Project'
+            Move It, Move It:
+              name: Move It, Move It
+            Sequencing with Scrat:
+              name: Sequencing with Scrat
+            Your Digital Footprint:
+              name: Your Digital Footprint
+            'Programming: My Robotic Friends':
+              name: 'Programming: My Robotic Friends'
+            Programming in Ice Age:
+              name: Programming in Ice Age
+            Copyright and Creativity:
+              name: Copyright and Creativity
+            Programming with Rey and BB-8:
+              name: Programming with Rey and BB-8
+            'Loops: My Loopy Robotic Friends':
+              name: 'Loops: My Loopy Robotic Friends'
+            Loops in Ice Age:
+              name: Loops in Ice Age
+            Loops in Collector:
+              name: Loops in Collector
+            Loops in Artist:
+              name: Loops in Artist
+            'Events: The Big Event':
+              name: 'Events: The Big Event'
+            Events in Play Lab:
+              name: Events in Play Lab
+            Spelling Bee:
+              name: Spelling Bee
         spritelab-validated:
           stages:
             Fish Tank - Creating Sprites:
@@ -10381,6 +15528,13 @@ en:
           description_short: ''
           description: ''
           lesson_groups: {}
+          lessons:
+            Fish Tank - Creating Sprites:
+              name: Fish Tank - Creating Sprites
+            Alien Dance Party - Input:
+              name: Alien Dance Party - Input
+            Virtual Pet - Interactions:
+              name: Virtual Pet - Interactions
         2018hoc-ab:
           stages:
             Labyrinth:
@@ -10390,6 +15544,9 @@ en:
           description_short: ''
           description: ''
           lesson_groups: {}
+          lessons:
+            Labyrinth:
+              name: Labyrinth
         deepdive-debugging:
           stages:
             Debugging for AB Educators:
@@ -10401,6 +15558,11 @@ en:
           description_short: ''
           description: ''
           lesson_groups: {}
+          lessons:
+            Debugging for AB Educators:
+              name: Debugging for AB Educators
+            Debugging for CDEF Educators:
+              name: Debugging for CDEF Educators
         fit-test:
           stages:
             Deeper Learning Overview:
@@ -10416,6 +15578,11 @@ en:
               display_name: Overview
             content:
               display_name: Content
+          lessons:
+            Deeper Learning Overview:
+              name: Deeper Learning Overview
+            Complete Practice Question:
+              name: Complete Practice Question
         spritelab-simple:
           title: Introduction to Sprite Lab (EE)
           description: This is a pilot course for Code.org's new Sprite Lab tool for Courses E and F
@@ -10435,6 +15602,13 @@ en:
               description_student: ''
               description_teacher: ''
           lesson_groups: {}
+          lessons:
+            Fish Tank - Creating Sprites:
+              name: Fish Tank - Creating Sprites
+            Alien Dance Party - Input:
+              name: Alien Dance Party - Input
+            Virtual Pet - Interactions:
+              name: Virtual Pet - Interactions
         spritelab-ee:
           stages:
             Fish Tank - Creating Sprites:
@@ -10448,6 +15622,13 @@ en:
           description_short: ''
           description: ''
           lesson_groups: {}
+          lessons:
+            Fish Tank - Creating Sprites:
+              name: Fish Tank - Creating Sprites
+            Alien Dance Party - Input:
+              name: Alien Dance Party - Input
+            Virtual Pet - Interactions:
+              name: Virtual Pet - Interactions
         craft18:
           stages:
             craft18 levels:
@@ -10457,6 +15638,9 @@ en:
           description_short: ''
           description: ''
           lesson_groups: {}
+          lessons:
+            craft18 levels:
+              name: craft18 levels
         frozen-2018:
           stages:
             Artist:
@@ -10466,6 +15650,9 @@ en:
           description_short: ''
           description: ''
           lesson_groups: {}
+          lessons:
+            Artist:
+              name: Artist
         frozen-2018-test:
           title: New Frozen Script
           description: ''
@@ -10477,6 +15664,9 @@ en:
               description_student: ''
               description_teacher: ''
           lesson_groups: {}
+          lessons:
+            Artist:
+              name: Artist
         dance:
           stages:
             new stage:
@@ -10488,6 +15678,9 @@ en:
           description_short: Featuring Katy Perry, Madonna, J. Balvin, Sia, Keith Urban, Ciara, and 25 more!
           description: Code your own dance party to share with your friends!
           lesson_groups: {}
+          lessons:
+            Dance Party:
+              name: Dance Party
         frozen-2018-test-b:
           title: New Frozen Script
           description: ''
@@ -10499,6 +15692,9 @@ en:
               description_student: ''
               description_teacher: ''
           lesson_groups: {}
+          lessons:
+            Artist:
+              name: Artist
         aquatic:
           stages:
             Aquatic:
@@ -10508,6 +15704,9 @@ en:
           description_short: Use your creativity and problem solving skills to explore and build underwater worlds with code!
           description: Minecraft is back with a brand new activity! Use your creativity and problem solving skills to explore and build underwater worlds with code.
           lesson_groups: {}
+          lessons:
+            Aquatic:
+              name: Aquatic
         sconyers:
           stages:
             Lesson the first:
@@ -10523,6 +15722,13 @@ en:
           description_short: ''
           description: ''
           lesson_groups: {}
+          lessons:
+            Digital Design:
+              name: Digital Design
+            Linking Screens:
+              name: Linking Screens
+            Test Lesson:
+              name: Test Lesson
         dance--draft:
           title: ''
           description: ''
@@ -10544,6 +15750,7 @@ en:
               description_student: ''
               description_teacher: ''
           lesson_groups: {}
+          lessons: {}
         cspplayground:
           stages:
             Hannah's Test Stage:
@@ -10609,6 +15816,47 @@ en:
               display_name: Functions
             csp_project:
               display_name: Project
+          lessons:
+            Variables Explore:
+              name: Variables Explore
+            Variables Investigate:
+              name: Variables Investigate
+            Variables Practice:
+              name: Variables Practice
+            Variables Make:
+              name: Variables Make
+            Student Survey (Variables):
+              name: Student Survey (Variables)
+            Teacher Surveys (Variables):
+              name: Teacher Surveys (Variables)
+            Conditionals Explore:
+              name: Conditionals Explore
+            Conditionals Investigate:
+              name: Conditionals Investigate
+            Conditionals Practice:
+              name: Conditionals Practice
+            Conditional Make:
+              name: Conditional Make
+            Student Survey (Conditionals):
+              name: Student Survey (Conditionals)
+            Teacher Surveys (Conditionals):
+              name: Teacher Surveys (Conditionals)
+            Functions Explore / Investigate:
+              name: Functions Explore / Investigate
+            Functions Practice:
+              name: Functions Practice
+            Functions Make:
+              name: Functions Make
+            Practice PT Part 1:
+              name: Practice PT Part 1
+            Practice PT Part 2:
+              name: Practice PT Part 2
+            Practice PT Part 3:
+              name: Practice PT Part 3
+            Unit 4 Assessment:
+              name: Unit 4 Assessment
+            Lists Explore:
+              name: Lists Explore
         dance-extras:
           stages:
             Dance Party - Go Further:
@@ -10618,6 +15866,9 @@ en:
           description_short: Go beyond the Hour of Code with this follow-up activity to Code.org's Dance Party tutorial.
           description: Go beyond the first hour with extended project ideas.
           lesson_groups: {}
+          lessons:
+            Dance Party - Go Further:
+              name: Dance Party - Go Further
         coursef-2019:
           title: Course F (2019)
           description: Learn to use different kinds of loops, events, functions, and conditionals. Investigate different problem-solving techniques and discuss societal impacts of computing and the internet. In the second part of this course, design and create a capstone project you can share with friends and family.
@@ -10807,6 +16058,47 @@ en:
               display_name: Digital Citizenship
             end_of_course_project:
               display_name: End of Course Project
+          lessons:
+            Functions in Minecraft:
+              name: Functions in Minecraft
+            Learning Sprites with Sprite Lab:
+              name: Learning Sprites with Sprite Lab
+            Events with Sprite Lab:
+              name: Events with Sprite Lab
+            Loops with the Artist:
+              name: Loops with the Artist
+            Nested Loops in the Maze:
+              name: Nested Loops in the Maze
+            Envelope Variables:
+              name: Envelope Variables
+            Variables as Constant in Artist:
+              name: Variables as Constant in Artist
+            Variables that Change in Bee:
+              name: Variables that Change in Bee
+            Variables that Change in Artist:
+              name: Variables that Change in Artist
+            Simulating Experiments:
+              name: Simulating Experiments
+            For Loop Fun:
+              name: For Loop Fun
+            For Loops in Bee:
+              name: For Loops in Bee
+            For Loops in Artist:
+              name: For Loops in Artist
+            Internet:
+              name: Internet
+            Editing Behaviors:
+              name: Editing Behaviors
+            Virtual Pet:
+              name: Virtual Pet
+            The Power of Words:
+              name: The Power of Words
+            Crowdsourcing:
+              name: Crowdsourcing
+            Digital Sharing:
+              name: Digital Sharing
+            End of Course Project:
+              name: End of Course Project
         dance-low:
           stages:
             Dance Party:
@@ -10816,6 +16108,7 @@ en:
           description_short: Code your own dance party to share with your friends! (This version is for slow connections)
           description: ''
           lesson_groups: {}
+          lessons: {}
         coursed-2019:
           title: Course D (2019)
           description: Students develop their understanding of loops, conditionals, and events. Beyond coding, students learn about digital citizenship.
@@ -10921,6 +16214,43 @@ en:
               display_name: Digital Citizenship
             end_of_course_project:
               display_name: End of Course Project
+          lessons:
+            'Algorithms: Graph Paper Programming':
+              name: 'Algorithms: Graph Paper Programming'
+            Introduction to Online Puzzles:
+              name: Introduction to Online Puzzles
+            Relay Programming:
+              name: Relay Programming
+            Debugging in Collector:
+              name: Debugging in Collector
+            Events in Bounce:
+              name: Events in Bounce
+            Build a Star Wars Game:
+              name: Build a Star Wars Game
+            Loops in Ice Age:
+              name: Loops in Ice Age
+            Loops in Artist:
+              name: Loops in Artist
+            Nested Loops in Bee:
+              name: Nested Loops in Bee
+            Conditionals with Cards:
+              name: Conditionals with Cards
+            Conditionals in Bee:
+              name: Conditionals in Bee
+            While Loops in Farmer:
+              name: While Loops in Farmer
+            Until Loops in Maze:
+              name: Until Loops in Maze
+            Conditionals & Loops in Harvester:
+              name: Conditionals & Loops in Harvester
+            'Unplugged: Binary':
+              name: 'Unplugged: Binary'
+            Artist Binary:
+              name: Artist Binary
+            Digital Citizenship:
+              name: Digital Citizenship
+            Dance Party:
+              name: Dance Party
         coursee-2019:
           title: Course E (2019)
           description: Start coding with algorithms, loops, conditionals, and events and then you’ll move on functions. In the second part of this course, design and create a capstone project you can share with your friends and family.
@@ -11106,6 +16436,43 @@ en:
               display_name: Functions
             end_of_course_project:
               display_name: End of Course Project
+          lessons:
+            Sequencing in the Maze:
+              name: Sequencing in the Maze
+            Programming and Loops with the Artist:
+              name: Programming and Loops with the Artist
+            'Conditionals in Minecraft: Voyage Aquatic':
+              name: 'Conditionals in Minecraft: Voyage Aquatic'
+            Conditionals:
+              name: Conditionals
+            Simon Says:
+              name: Simon Says
+            Learning Sprites with Sprite Lab:
+              name: Learning Sprites with Sprite Lab
+            Alien Dance Party with Sprite Lab:
+              name: Alien Dance Party with Sprite Lab
+            Private and Personal Information:
+              name: Private and Personal Information
+            About Me:
+              name: About Me
+            Access Ability:
+              name: Access Ability
+            Nested Loops in Bee:
+              name: Nested Loops in Bee
+            Nested Loops in Artist:
+              name: Nested Loops in Artist
+            Nested Loops in Frozen:
+              name: Nested Loops in Frozen
+            'Functions: Songwriting':
+              name: 'Functions: Songwriting'
+            Functions in Minecraft:
+              name: Functions in Minecraft
+            Functions in Harvester:
+              name: Functions in Harvester
+            Functions in Artist:
+              name: Functions in Artist
+            End of Course Project:
+              name: End of Course Project
         express-2019:
           title: Express Course (2019)
           description: Learn computer science by trying the lessons below at your own pace! Learn to create computer programs, develop problem-solving skills, and work through fun challenges! Make games and creative projects to share with friends, family, and teachers.
@@ -11327,6 +16694,63 @@ en:
               display_name: For Loops
             csf_sprites:
               display_name: Sprites
+          lessons:
+            Dance Party:
+              name: Dance Party
+            Programming in Maze:
+              name: Programming in Maze
+            Debugging in Maze:
+              name: Debugging in Maze
+            Programming in Collector:
+              name: Programming in Collector
+            Programming in Artist:
+              name: Programming in Artist
+            Loops with Rey and BB-8:
+              name: Loops with Rey and BB-8
+            Loops in Artist:
+              name: Loops in Artist
+            Nested Loops in Bee:
+              name: Nested Loops in Bee
+            Nested Loops in Frozen:
+              name: Nested Loops in Frozen
+            'Concept Practice with Minecraft ':
+              name: 'Concept Practice with Minecraft '
+            Conditionals in Bee:
+              name: Conditionals in Bee
+            While Loops in Farmer:
+              name: While Loops in Farmer
+            'Conditionals in Minecraft: Voyage Aquatic':
+              name: 'Conditionals in Minecraft: Voyage Aquatic'
+            Until Loops in Maze:
+              name: Until Loops in Maze
+            Conditionals & Loops in Harvester:
+              name: Conditionals & Loops in Harvester
+            Functions in Minecraft:
+              name: Functions in Minecraft
+            Functions in Harvester:
+              name: Functions in Harvester
+            Functions in Artist:
+              name: Functions in Artist
+            Variables as Constant in Artist:
+              name: Variables as Constant in Artist
+            Variables that Change in Bee:
+              name: Variables that Change in Bee
+            Variables that Change in Artist:
+              name: Variables that Change in Artist
+            For Loops in Bee:
+              name: For Loops in Bee
+            For Loops in Artist:
+              name: For Loops in Artist
+            Learning Sprites with Sprite Lab:
+              name: Learning Sprites with Sprite Lab
+            Alien Dance Party with Sprite Lab:
+              name: Alien Dance Party with Sprite Lab
+            Editing Behaviors:
+              name: Editing Behaviors
+            Virtual Pet with Sprite Lab:
+              name: Virtual Pet with Sprite Lab
+            Build A Project:
+              name: Build A Project
         csd1-2019:
           title: CSD Unit 1 - Problem Solving and Computing ('19-'20)
           description: "Problem Solving and Computing is a highly interactive and collaborative introduction to the field of computer science, as framed within the broader pursuit of solving problems. You’ll practice using a problem solving process to address a series of puzzles, challenges, and real world scenarios. Next, you’ll learn how computers input, output, store, and process information to help humans solve problems.  The unit concludes with a project in which you design an application that helps solve a problem of your choosing.\r\n"
@@ -11378,6 +16802,27 @@ en:
               display_name: 'Chapter 1: The Problem Solving Process'
             csd1_2:
               display_name: 'Chapter 2: Computers and Problem Solving'
+          lessons:
+            CS Discoveries Pre-survey:
+              name: CS Discoveries Pre-survey
+            Intro to Problem Solving:
+              name: Intro to Problem Solving
+            The Problem Solving Process:
+              name: The Problem Solving Process
+            Exploring Problem Solving:
+              name: Exploring Problem Solving
+            What is a Computer?:
+              name: What is a Computer?
+            Input and Output:
+              name: Input and Output
+            Processing:
+              name: Processing
+            Apps and Storage:
+              name: Apps and Storage
+            Project - Propose an App:
+              name: Project - Propose an App
+            Post-Project Test:
+              name: Post-Project Test
         andrea-test:
           stages:
             new stage:
@@ -11425,6 +16870,15 @@ en:
               display_name: Overview
             content:
               display_name: Content
+          lessons:
+            Deeper Learning Overview:
+              name: Deeper Learning Overview
+            Part 1:
+              name: Part 1
+            Part 2:
+              name: Part 2
+            part 3:
+              name: part 3
         dance-extras-gallery:
           stages:
             Dance Party - Go Further:
@@ -11434,6 +16888,9 @@ en:
           description_short: Go beyond the Hour of Code with this follow-up activity to Code.org's Dance Party tutorial.
           description: Go beyond the first hour with extended project ideas.
           lesson_groups: {}
+          lessons:
+            Dance Party - Go Further:
+              name: Dance Party - Go Further
         coursec-2019:
           title: Course C (2019)
           description: Create programs with sequencing, loops, and events. Translate your initials into binary, investigate different problem-solving techniques, and learn how to respond to cyberbullying. At the end of the course, create your very own game or story you can share!
@@ -11543,6 +17000,43 @@ en:
               display_name: Data
             end_of_course_project:
               display_name: End of Course Project
+          lessons:
+            Screen Out the Mean:
+              name: Screen Out the Mean
+            Powerful Passwords:
+              name: Powerful Passwords
+            'Programming: My Robotic Friends':
+              name: 'Programming: My Robotic Friends'
+            Programming in Maze:
+              name: Programming in Maze
+            Debugging in Maze:
+              name: Debugging in Maze
+            Programming in Collector:
+              name: Programming in Collector
+            Programming in Artist:
+              name: Programming in Artist
+            Binary Bracelets:
+              name: Binary Bracelets
+            'Loops: My Loopy Robotic Friends':
+              name: 'Loops: My Loopy Robotic Friends'
+            Loops with Rey and BB-8:
+              name: Loops with Rey and BB-8
+            Loops in Harvester:
+              name: Loops in Harvester
+            Looking Ahead:
+              name: Looking Ahead
+            Sticker Art with Loops:
+              name: Sticker Art with Loops
+            'Events: The Big Event':
+              name: 'Events: The Big Event'
+            Build a Flappy Game:
+              name: Build a Flappy Game
+            Events in Play Lab:
+              name: Events in Play Lab
+            Picturing Data:
+              name: Picturing Data
+            'End of Course Project: Create a Play Lab Game':
+              name: 'End of Course Project: Create a Play Lab Game'
         csp-mid-survey:
           stages:
             CSP Mid-year survey:
@@ -11554,6 +17048,9 @@ en:
           lesson_groups:
             cspSurvey:
               display_name: Survey
+          lessons:
+            CSP Mid-year survey:
+              name: CSP Mid-year survey
         gamelab:
           stages:
             Start and End Screens:
@@ -11565,6 +17062,11 @@ en:
           description_short: ''
           description: Teacher-facing tutorials for development in Game Lab.  These tutorials go beyond the concepts covered in CSD.
           lesson_groups: {}
+          lessons:
+            Start and End Screens:
+              name: Start and End Screens
+            Start and End Screens2:
+              name: Start and End Screens2
         coursea-2019:
           title: Course A (2019)
           description: Learn the basics of computer science and internet safety. At the end of the course, create your very own game or story you can share.
@@ -11644,6 +17146,31 @@ en:
               display_name: Loops
             csf_events:
               display_name: Events
+          lessons:
+            Going Places Safely:
+              name: Going Places Safely
+            Learn to Drag and Drop:
+              name: Learn to Drag and Drop
+            'Programming: Happy Maps':
+              name: 'Programming: Happy Maps'
+            Sequencing with Scrat:
+              name: Sequencing with Scrat
+            Programming in Ice Age:
+              name: Programming in Ice Age
+            Programming with Rey and BB-8:
+              name: Programming with Rey and BB-8
+            'Loops: Happy Loops':
+              name: 'Loops: Happy Loops'
+            Loops in Ice Age:
+              name: Loops in Ice Age
+            Loops in Collector:
+              name: Loops in Collector
+            Ocean Scene with Loops:
+              name: Ocean Scene with Loops
+            'Events: The Big Event':
+              name: 'Events: The Big Event'
+            Events in Play Lab:
+              name: Events in Play Lab
         courseb-2019:
           title: Course B (2019)
           description: Learn the basics of computer science and internet safety. At the end of the course, create your very own game or story you can share.
@@ -11737,6 +17264,31 @@ en:
               display_name: Impacts of Computing
             csf_events:
               display_name: Events
+          lessons:
+            Your Digital Footprint:
+              name: Your Digital Footprint
+            Move It, Move It:
+              name: Move It, Move It
+            Sequencing in Maze:
+              name: Sequencing in Maze
+            Programming in Maze:
+              name: Programming in Maze
+            Programming in Harvester:
+              name: Programming in Harvester
+            'Loops: Getting Loopy':
+              name: 'Loops: Getting Loopy'
+            Loops in Harvester:
+              name: Loops in Harvester
+            Loops in Collector:
+              name: Loops in Collector
+            Loops in Artist:
+              name: Loops in Artist
+            The Right App:
+              name: The Right App
+            'Events: The Big Event':
+              name: 'Events: The Big Event'
+            Events in Play Lab:
+              name: Events in Play Lab
         pre-express-2019:
           title: Pre-reader Express (2019)
           description: Learn computer science by trying the lessons below at your own pace! Learn to create computer programs, develop problem-solving skills, and work through fun challenges! Make games and creative projects to share with friends, family, and teachers.
@@ -11826,6 +17378,31 @@ en:
               display_name: Loops
             csf_events:
               display_name: Events
+          lessons:
+            Learn to Drag and Drop:
+              name: Learn to Drag and Drop
+            Sequencing with Scrat:
+              name: Sequencing with Scrat
+            Programming in Maze:
+              name: Programming in Maze
+            Programming with Rey and BB-8:
+              name: Programming with Rey and BB-8
+            Programming in Harvester:
+              name: Programming in Harvester
+            Spelling Bee:
+              name: Spelling Bee
+            Loops in Ice Age:
+              name: Loops in Ice Age
+            Loops in Collector:
+              name: Loops in Collector
+            Ocean Scene with Loops:
+              name: Ocean Scene with Loops
+            Loops in Artist:
+              name: Loops in Artist
+            Tell a Story in Play Lab:
+              name: Tell a Story in Play Lab
+            Make a Game in Play Lab:
+              name: Make a Game in Play Lab
         removed19:
           stages:
             'Debugging: Unspotted Bugs':
@@ -11839,6 +17416,13 @@ en:
           description_short: ''
           description: ''
           lesson_groups: {}
+          lessons:
+            'Debugging: Unspotted Bugs':
+              name: 'Debugging: Unspotted Bugs'
+            'Persistence & Frustration: Stevie and the Big Project':
+              name: 'Persistence & Frustration: Stevie and the Big Project'
+            'Real-life Algorithms: Plant a Seed':
+              name: 'Real-life Algorithms: Plant a Seed'
         dani-test-script:
           stages:
             new stage:
@@ -11920,6 +17504,39 @@ en:
               display_name: 'Chapter 2: Styling and CSS'
             cspSurvey:
               display_name: Survey
+          lessons:
+            Exploring Websites:
+              name: Exploring Websites
+            'Websites for Expression ':
+              name: 'Websites for Expression '
+            Intro to HTML:
+              name: Intro to HTML
+            Headings:
+              name: Headings
+            Digital Footprint:
+              name: Digital Footprint
+            Lists:
+              name: Lists
+            Intellectual Property and Images:
+              name: Intellectual Property and Images
+            Clean Code and Debugging:
+              name: Clean Code and Debugging
+            Project - Multi-Page Websites:
+              name: Project - Multi-Page Websites
+            Styling Text with CSS:
+              name: Styling Text with CSS
+            Styling Elements with CSS:
+              name: Styling Elements with CSS
+            Sources and Search Engines:
+              name: Sources and Search Engines
+            RGB Colors and Classes:
+              name: RGB Colors and Classes
+            Project - Personal Portfolio Website:
+              name: Project - Personal Portfolio Website
+            Post-Project Test:
+              name: Post-Project Test
+            CS Discoveries Post Course survey:
+              name: CS Discoveries Post Course survey
         csd3-2019:
           title: CSD Unit 3 - Animations and Games ('19-'20)
           description: " In Unit 3, you’ll build on your coding experience as you program animations, interactive art, and games in Game Lab. The unit starts off with simple shapes and builds up to more sophisticated sprite-based games, using the same programming concepts and the design process computer scientists use daily. In the final project, you’ll develop a personalized, interactive program."
@@ -12034,6 +17651,55 @@ en:
               display_name: 'Chapter 2: Building Games'
             cspSurvey:
               display_name: Survey
+          lessons:
+            Programming for Entertainment:
+              name: Programming for Entertainment
+            Plotting Shapes:
+              name: Plotting Shapes
+            Drawing in Game Lab:
+              name: Drawing in Game Lab
+            Shapes and Randomization:
+              name: Shapes and Randomization
+            Variables:
+              name: Variables
+            Sprites:
+              name: Sprites
+            The Draw Loop:
+              name: The Draw Loop
+            The Counter Pattern Unplugged:
+              name: The Counter Pattern Unplugged
+            Sprite Movement:
+              name: Sprite Movement
+            Booleans Unplugged:
+              name: Booleans Unplugged
+            Conditionals:
+              name: Conditionals
+            Keyboard Input:
+              name: Keyboard Input
+            Other Forms of Input:
+              name: Other Forms of Input
+            Project - Interactive Card:
+              name: Project - Interactive Card
+            Velocity:
+              name: Velocity
+            Collision Detection:
+              name: Collision Detection
+            Complex Sprite Movement:
+              name: Complex Sprite Movement
+            Collisions:
+              name: Collisions
+            Functions:
+              name: Functions
+            The Game Design Process:
+              name: The Game Design Process
+            Using the Game Design Process:
+              name: Using the Game Design Process
+            Project - Design a Game:
+              name: Project - Design a Game
+            Post-Project Test:
+              name: Post-Project Test
+            CS Discoveries Post Course survey:
+              name: CS Discoveries Post Course survey
         csd4-2019:
           title: CSD Unit 4 - The Design Process ('19-'20)
           description: Unit 4 introduces the broader social impacts of computing. Through a series of design challenges, you will learn how to better understand the needs of others while developing a solution to a problem. The second half of the unit consists of an iterative team project, during which teams have the opportunity to identify a need that they care about, prototype solutions both on paper and in App Lab, and test solutions with real users to get feedback and drive further iteration.
@@ -12117,6 +17783,43 @@ en:
               display_name: 'Chapter 2: Solving Data Problems'
             cspSurvey:
               display_name: Survey
+          lessons:
+            Analysis of Design:
+              name: Analysis of Design
+            Understanding Your User:
+              name: Understanding Your User
+            User-Centered Design Micro Activity:
+              name: User-Centered Design Micro Activity
+            User Interfaces:
+              name: User Interfaces
+            Feedback and Testing:
+              name: Feedback and Testing
+            Identifying User Needs:
+              name: Identifying User Needs
+            Project - Paper Prototype:
+              name: Project - Paper Prototype
+            Designing Apps for Good:
+              name: Designing Apps for Good
+            Market Research:
+              name: Market Research
+            Paper Prototypes:
+              name: Paper Prototypes
+            Prototype Testing:
+              name: Prototype Testing
+            Digital Design:
+              name: Digital Design
+            Linking Screens:
+              name: Linking Screens
+            Testing the App:
+              name: Testing the App
+            Improving and Iterating:
+              name: Improving and Iterating
+            Project - App Presentation:
+              name: Project - App Presentation
+            Post-Project Test:
+              name: Post-Project Test
+            CS Discoveries Post Course survey:
+              name: CS Discoveries Post Course survey
         csd5-2019:
           title: CSD Unit 5 - Data and Society ('19-'20)
           description: Unit 5 is about the importance of data in solving problems and highlights how computers can help in this process. The first chapter explores different systems used to represent information in a computer and the challenges and tradeoffs posed by using them. In the second chapter you’ll learn how collections of data are used to solve problems, and how computers help to automate the steps of this process. The chapter concludes by considering how the data problem solving process can be applied to an area of your choosing.
@@ -12194,6 +17897,41 @@ en:
               display_name: 'Chapter 2: Solving Data Problems'
             cspSurvey:
               display_name: Survey
+          lessons:
+            Representation Matters:
+              name: Representation Matters
+            Patterns and Representation:
+              name: Patterns and Representation
+            ASCII and Binary Representation:
+              name: ASCII and Binary Representation
+            Representing Images:
+              name: Representing Images
+            Representing Numbers:
+              name: Representing Numbers
+            Keeping Data Secret:
+              name: Keeping Data Secret
+            Combining Representations:
+              name: Combining Representations
+            Project - Create a Representation:
+              name: Project - Create a Representation
+            Problem Solving and Data:
+              name: Problem Solving and Data
+            Problem Solving with Big Data:
+              name: Problem Solving with Big Data
+            Structuring Data:
+              name: Structuring Data
+            Making Decisions with Data:
+              name: Making Decisions with Data
+            Interpreting Data:
+              name: Interpreting Data
+            Automating Data Decisions:
+              name: Automating Data Decisions
+            Project - Solve a Data Problem:
+              name: Project - Solve a Data Problem
+            Post-Project Test:
+              name: Post-Project Test
+            CS Discoveries Post Course survey:
+              name: CS Discoveries Post Course survey
         csd6-2019:
           title: CSD Unit 6 - Physical Computing ('19-'20)
           description: Unit 6 explores the role of hardware platforms in computing and how different sensors can provide more effective input and output than the traditional keyboard, mouse, and monitor. Using App Lab and Adafruit’s Circuit Playground, you’ll develop programs that utilize the same hardware inputs and outputs that you see in the smart devices, looking at how a simple rough prototype can lead to a finished product. The unit concludes with a design challenge to use the Circuit Playground as the basis for an innovation of your own design.
@@ -12275,6 +18013,43 @@ en:
               display_name: 'Chapter 2: Building Physical Prototypes'
             cspSurvey:
               display_name: Survey
+          lessons:
+            Innovations in Computing:
+              name: Innovations in Computing
+            Designing Screens with Code:
+              name: Designing Screens with Code
+            The Circuit Playground:
+              name: The Circuit Playground
+            Input Unplugged:
+              name: Input Unplugged
+            Board Events:
+              name: Board Events
+            Getting Properties:
+              name: Getting Properties
+            Analog Input:
+              name: Analog Input
+            The Program Design Process:
+              name: The Program Design Process
+            'Project: Make a Game':
+              name: 'Project: Make a Game'
+            Arrays and Color LEDs:
+              name: Arrays and Color LEDs
+            Making Music:
+              name: Making Music
+            Arrays and For Loops:
+              name: Arrays and For Loops
+            Accelerometer:
+              name: Accelerometer
+            Functions with Parameters:
+              name: Functions with Parameters
+            Circuits and Physical Prototypes:
+              name: Circuits and Physical Prototypes
+            'Project: Prototype an Innovation':
+              name: 'Project: Prototype an Innovation'
+            Post-Project Test:
+              name: Post-Project Test
+            CS Discoveries Post Course survey:
+              name: CS Discoveries Post Course survey
         csp4-pilot:
           stages:
             Variables Explore:
@@ -12368,6 +18143,47 @@ en:
               display_name: Overview
             optional_stages:
               display_name: Optional Stages
+          lessons:
+            Variables Explore:
+              name: Variables Explore
+            Variables Investigate:
+              name: Variables Investigate
+            Variables Practice:
+              name: Variables Practice
+            Variables Make:
+              name: Variables Make
+            Conditionals Explore:
+              name: Conditionals Explore
+            Conditionals Investigate:
+              name: Conditionals Investigate
+            Conditionals Practice:
+              name: Conditionals Practice
+            Conditional Make:
+              name: Conditional Make
+            Functions Explore / Investigate:
+              name: Functions Explore / Investigate
+            Functions Practice:
+              name: Functions Practice
+            Functions Make:
+              name: Functions Make
+            Project - Decision Maker App Part 1:
+              name: Project - Decision Maker App Part 1
+            Project - Decision Maker App Part 2:
+              name: Project - Decision Maker App Part 2
+            Project - Decision Maker App Part 3:
+              name: Project - Decision Maker App Part 3
+            'Lesson 15: Assessment Day':
+              name: 'Lesson 15: Assessment Day'
+            Unit 4 STUDENT Survey:
+              name: Unit 4 STUDENT Survey
+            Unit 4 TEACHER Survey:
+              name: Unit 4 TEACHER Survey
+            "[OLD] Variables Make":
+              name: "[OLD] Variables Make"
+            "[OLD] Conditionals Make":
+              name: "[OLD] Conditionals Make"
+            "[OLD] Functions Make":
+              name: "[OLD] Functions Make"
         csp1-2019:
           title: CSP Unit 1 - The Internet ('19-'20)
           description: This unit explores the technical challenges and questions that arise from the need to represent digital information in computers and transfer it between people and computational devices. The unit then explores the structure and design of the internet and the implications of those design decisions.
@@ -12449,6 +18265,41 @@ en:
               display_name: 'Chapter 1: Representing and Transmitting Information'
             csp1_2:
               display_name: 'Chapter 2: Inventing the Internet'
+          lessons:
+            CS Principles Pre-survey:
+              name: CS Principles Pre-survey
+            Personal Innovations:
+              name: Personal Innovations
+            Sending Binary Messages:
+              name: Sending Binary Messages
+            Sending Binary Messages with the Internet Simulator:
+              name: Sending Binary Messages with the Internet Simulator
+            Number Systems:
+              name: Number Systems
+            Binary Numbers:
+              name: Binary Numbers
+            Sending Numbers:
+              name: Sending Numbers
+            Sending Text:
+              name: Sending Text
+            Unit 1 Chapter 1 Assessment:
+              name: Unit 1 Chapter 1 Assessment
+            The Internet:
+              name: The Internet
+            The Need for Addressing:
+              name: The Need for Addressing
+            Routers and Redundancy:
+              name: Routers and Redundancy
+            Packets and Making a Reliable Internet:
+              name: Packets and Making a Reliable Internet
+            The Need for DNS:
+              name: The Need for DNS
+            HTTP and Abstraction:
+              name: HTTP and Abstraction
+            Practice PT - The Internet and Society:
+              name: Practice PT - The Internet and Society
+            Unit 1 Chapter 2 Assessment:
+              name: Unit 1 Chapter 2 Assessment
         csp2-2019:
           title: CSP Unit 2 - Digital Information ('19-'20)
           description: This unit further explores the ways that digital information is encoded, represented and manipulated. Being able to digitally manipulate data, visualize it, and identify patterns, trends and possible meanings are important practical skills that computer scientists do every day. Understanding where data comes from, having intuitions about what could be learned or extracted from it, and being able to use computational tools to manipulate data and communicate about it are the primary skills addressed in the unit.
@@ -12492,6 +18343,23 @@ en:
               display_name: Chapter Assessment
             cspSurvey:
               display_name: Survey
+          lessons:
+            Bytes and File Sizes:
+              name: Bytes and File Sizes
+            Text Compression:
+              name: Text Compression
+            Encoding B&W Images:
+              name: Encoding B&W Images
+            Encoding Color Images:
+              name: Encoding Color Images
+            Lossy vs Lossless Compression:
+              name: Lossy vs Lossless Compression
+            Rapid Research - Format Showdown:
+              name: Rapid Research - Format Showdown
+            Unit 2 Assessment:
+              name: Unit 2 Assessment
+            CS Principles Post Course survey:
+              name: CS Principles Post Course survey
         csp3-2019:
           title: CSP Unit 3 - Intro to Programming ('19-'20)
           description: This unit introduces the foundational concepts of computer programming, which unlocks the ability to make rich, interactive apps. This course uses JavaScript as the programming language, and App Lab as the programming environment to build apps, but the concepts learned in these lessons span all programming languages and tools.
@@ -12555,6 +18423,31 @@ en:
               display_name: Chapter Assessment
             cspSurvey:
               display_name: Survey
+          lessons:
+            The Need For Programming Languages:
+              name: The Need For Programming Languages
+            The Need for Algorithms:
+              name: The Need for Algorithms
+            Creativity in Algorithms:
+              name: Creativity in Algorithms
+            Using Simple Commands:
+              name: Using Simple Commands
+            Creating Functions:
+              name: Creating Functions
+            Functions and Top-Down Design:
+              name: Functions and Top-Down Design
+            APIs and Function Parameters:
+              name: APIs and Function Parameters
+            Creating functions with Parameters:
+              name: Creating functions with Parameters
+            Looping and Random Numbers:
+              name: Looping and Random Numbers
+            Practice PT - Design a Digital Scene:
+              name: Practice PT - Design a Digital Scene
+            Unit 3 Chapter 1 Assessment:
+              name: Unit 3 Chapter 1 Assessment
+            CS Principles Post Course survey:
+              name: CS Principles Post Course survey
         csp4-2019:
           title: CSP Unit 4 - Big Data and Privacy ('19-'20)
           description: The data-rich world we live in introduces many complex questions related to public policy, law, ethics and societal impact. The goals of this unit are to develop a well-rounded and balanced view about data in the world, including the positive and negative effects of it, and to understand the basics of how and why modern encryption works.
@@ -12622,6 +18515,33 @@ en:
               display_name: Optional
             cspSurvey:
               display_name: Survey
+          lessons:
+            What is Big Data?:
+              name: What is Big Data?
+            Finding Trends with Visualizations:
+              name: Finding Trends with Visualizations
+            Check Your Assumptions:
+              name: Check Your Assumptions
+            Rapid Research - Data Innovations:
+              name: Rapid Research - Data Innovations
+            Identifying People with Data:
+              name: Identifying People with Data
+            The Cost of Free:
+              name: The Cost of Free
+            Simple Encryption:
+              name: Simple Encryption
+            Encryption with Keys and Passwords:
+              name: Encryption with Keys and Passwords
+            Public Key Crypto:
+              name: Public Key Crypto
+            Rapid Research - Cybercrime:
+              name: Rapid Research - Cybercrime
+            Unit 4 Assessment:
+              name: Unit 4 Assessment
+            'Optional: Data Questions':
+              name: 'Optional: Data Questions'
+            CS Principles Post Course survey:
+              name: CS Principles Post Course survey
         csp5-2019:
           title: CSP Unit 5 - Building Apps ('19-'20)
           description: This unit continues the introduction of foundational concepts of computer programming, which unlocks the ability to make rich, interactive apps. This course uses JavaScript as the programming language, and App Lab as the programming environment to build apps, but the concepts learned in these lessons span all programming languages and tools.
@@ -12729,6 +18649,53 @@ en:
               display_name: 'Chapter 2: Programming with Data Structures'
             cspSurvey:
               display_name: Survey
+          lessons:
+            Buttons and Events:
+              name: Buttons and Events
+            Multi-screen Apps:
+              name: Multi-screen Apps
+            'Building an App: Multi-Screen App':
+              name: 'Building an App: Multi-Screen App'
+            Controlling Memory with Variables:
+              name: Controlling Memory with Variables
+            'Building an App: Clicker Game':
+              name: 'Building an App: Clicker Game'
+            Unit 5 Assessment 1:
+              name: Unit 5 Assessment 1
+            User Input and Strings:
+              name: User Input and Strings
+            '"If" Statements Unplugged':
+              name: '"If" Statements Unplugged'
+            Boolean Expressions and "If" Statements:
+              name: Boolean Expressions and "If" Statements
+            '"if-else-if" and Conditional Logic':
+              name: '"if-else-if" and Conditional Logic'
+            'Building an App: Color Sleuth':
+              name: 'Building an App: Color Sleuth'
+            Unit 5 Assessment 2:
+              name: Unit 5 Assessment 2
+            While Loops:
+              name: While Loops
+            Loops and Simulations:
+              name: Loops and Simulations
+            Introduction to Arrays:
+              name: Introduction to Arrays
+            'Building an App: Image Scroller':
+              name: 'Building an App: Image Scroller'
+            Unit 5 Assessment 3:
+              name: Unit 5 Assessment 3
+            Processing Arrays:
+              name: Processing Arrays
+            Functions with Return Values:
+              name: Functions with Return Values
+            'Building an App: Canvas Painter':
+              name: 'Building an App: Canvas Painter'
+            Unit 5 Assessment 4:
+              name: Unit 5 Assessment 4
+            Unit 5 Assessment 5 - AP Pseudocode Practice Questions:
+              name: Unit 5 Assessment 5 - AP Pseudocode Practice Questions
+            CS Principles Post Course survey:
+              name: CS Principles Post Course survey
         csp-explore-2019:
           title: Explore - AP Performance Task Prep ('19-'20)
           description: 'These lessons are here to help you understand, prepare for, and do the AP Explore Performance Task.  Each "lesson" contains links to helpful documents that your teacher can help walk you through. NOTE: the second item in the first lesson is not related to the Explore PT directly, but covers general tech setup and tools you need to do various elements of both the Explore and Create tasks.'
@@ -12758,6 +18725,15 @@ en:
               display_name: 'Chapter 2: AP Explore Performance Task'
             cspSurvey:
               display_name: Survey
+          lessons:
+            Explore PT Prep - Reviewing the Task:
+              name: Explore PT Prep - Reviewing the Task
+            Explore PT - Making a Plan:
+              name: Explore PT - Making a Plan
+            Explore PT - Complete the Task:
+              name: Explore PT - Complete the Task
+            CS Principles Post Course survey:
+              name: CS Principles Post Course survey
         csp-create-2019:
           title: Create - AP Performance Task Prep ('19-'20)
           description: 'These lessons are here to help you understand, prepare for, and do the AP Create Performance Task.  Each "lesson" contains links to helpful documents that your teacher can help walk you through. NOTE: the first item in the first lesson is not related to the Create PT directly, but covers general tech setup and tools you need to do various elements of both the Explore and Create tasks.'
@@ -12783,6 +18759,15 @@ en:
               display_name: 'Chapter 3: AP Create Performance Task'
             cspSurvey:
               display_name: Survey
+          lessons:
+            Create PT Prep - Reviewing the Task:
+              name: Create PT Prep - Reviewing the Task
+            Create PT Prep - Making a Plan:
+              name: Create PT Prep - Making a Plan
+            Create PT - Complete the Task:
+              name: Create PT - Complete the Task
+            CS Principles Post Course survey:
+              name: CS Principles Post Course survey
         csppostap-2019:
           title: Post AP - Data Tools ('19-'20)
           description: "In the first chapter of this unit students develop skills interpreting visual data and using spreadsheet and visualization tools to create their own digital artifacts.  Through an ongoing project  - the “class data tracker” - students learn how to collect and clean data, and to use a few common tools for computing aggregations and creating visualizations. \r\n\r\nThe second chapter explores the importance of data within apps. App Lab has a number of tools that allow you to collect and use data in your apps. The second chapter provides an overview of how these tools work, a sampling of example projects that can be built using these tools, and a space in which to build and submit a final project."
@@ -12866,6 +18851,41 @@ en:
               display_name: 'Chapter 2: Apps and Databases'
             cspSurvey:
               display_name: Survey
+          lessons:
+            Intro to Data:
+              name: Intro to Data
+            Good and Bad Data Visualizations:
+              name: Good and Bad Data Visualizations
+            Making Data Visualizations:
+              name: Making Data Visualizations
+            Discover a Data Story:
+              name: Discover a Data Story
+            Cleaning Data:
+              name: Cleaning Data
+            Creating Summary Tables:
+              name: Creating Summary Tables
+            Project - Tell a Data Story:
+              name: Project - Tell a Data Story
+            Creating Javascript Objects:
+              name: Creating Javascript Objects
+            Permanent Data Storage:
+              name: Permanent Data Storage
+            Reading Records:
+              name: Reading Records
+            Deleting Records:
+              name: Deleting Records
+            Updating Records:
+              name: Updating Records
+            Importing and Exporting Data:
+              name: Importing and Exporting Data
+            Visualizing Data:
+              name: Visualizing Data
+            Sample Apps:
+              name: Sample Apps
+            Final Project:
+              name: Final Project
+            CS Principles Post Course survey:
+              name: CS Principles Post Course survey
         csp1-pilot:
           stages:
             new stage:
@@ -12959,6 +18979,41 @@ en:
               display_name: Survey
             required:
               display_name: Overview
+          lessons:
+            CS Principles Pre-survey:
+              name: CS Principles Pre-survey
+            Welcome to CSP:
+              name: Welcome to CSP
+            Representing Information:
+              name: Representing Information
+            Circle Square Patterns:
+              name: Circle Square Patterns
+            Binary Numbers:
+              name: Binary Numbers
+            Overflow and Rounding:
+              name: Overflow and Rounding
+            Representing Text:
+              name: Representing Text
+            Black and White Images:
+              name: Black and White Images
+            Color Images:
+              name: Color Images
+            Lossless Compression:
+              name: Lossless Compression
+            Lossy Compression:
+              name: Lossy Compression
+            Intellectual Property:
+              name: Intellectual Property
+            Project - Digital Information Dilemmas Part 1:
+              name: Project - Digital Information Dilemmas Part 1
+            Project - Digital Information Dilemmas Part 2:
+              name: Project - Digital Information Dilemmas Part 2
+            'Lesson 14: Assessment Day':
+              name: 'Lesson 14: Assessment Day'
+            Unit 1 STUDENT Survey:
+              name: Unit 1 STUDENT Survey
+            Unit 1 TEACHER Survey:
+              name: Unit 1 TEACHER Survey
         csd-tests:
           stages:
             Computers and Problem Solving:
@@ -12972,6 +19027,13 @@ en:
           description_short: ''
           description: ''
           lesson_groups: {}
+          lessons:
+            Computers and Problem Solving:
+              name: Computers and Problem Solving
+            Web Development:
+              name: Web Development
+            Interactive Animations and Games:
+              name: Interactive Animations and Games
         csd-videos:
           stages:
             new stage:
@@ -12993,6 +19055,19 @@ en:
           description_short: All the Videos in CS Discoveries
           description: All the Videos in CS Discoveries
           lesson_groups: {}
+          lessons:
+            Problem Solving and Computers:
+              name: Problem Solving and Computers
+            Web Development:
+              name: Web Development
+            Games and Animations:
+              name: Games and Animations
+            User Centered Design:
+              name: User Centered Design
+            Data and Society:
+              name: Data and Society
+            Physical Computing:
+              name: Physical Computing
         time4csdemo:
           stages:
             Introduction to the Problem:
@@ -13094,6 +19169,83 @@ en:
               display_name: 'Collection 4: Impact of Invasive Species (on the Everglades)'
             time4cs_c5:
               display_name: 'Collection 5: Citizens Take Action'
+          lessons:
+            'Programming: My Robotic Friends':
+              name: 'Programming: My Robotic Friends'
+            Sequence in Maze:
+              name: Sequence in Maze
+            Building a Foundation:
+              name: Building a Foundation
+            Debugging with Scrat:
+              name: Debugging with Scrat
+            Programming in Artist:
+              name: Programming in Artist
+            'Loops: My Loopy Robotic Friends':
+              name: 'Loops: My Loopy Robotic Friends'
+            Loops in Artist:
+              name: Loops in Artist
+            Nested Loops in Bee/Zombie:
+              name: Nested Loops in Bee/Zombie
+            Nested Loops with Frozen:
+              name: Nested Loops with Frozen
+            Learning Sprites with Sprite Lab:
+              name: Learning Sprites with Sprite Lab
+            Alien Dance Party with Sprite Lab:
+              name: Alien Dance Party with Sprite Lab
+            Pet Giraffe with Sprite Lab:
+              name: Pet Giraffe with Sprite Lab
+            Introduction to the Problem:
+              name: Introduction to the Problem
+            Crowdsourcing:
+              name: Crowdsourcing
+            Everglades Habitats:
+              name: Everglades Habitats
+            Reviewing Projects:
+              name: Reviewing Projects
+            Food Chains:
+              name: Food Chains
+            Conditionals with Cards:
+              name: Conditionals with Cards
+            Alligator Holes:
+              name: Alligator Holes
+            Conditionals in Sprite Lab:
+              name: Conditionals in Sprite Lab
+            Invasive Species:
+              name: Invasive Species
+            'Events: The Big Event':
+              name: 'Events: The Big Event'
+            Build a Flappy Game:
+              name: Build a Flappy Game
+            Build a Star Wars Game:
+              name: Build a Star Wars Game
+            I am in Big Trouble:
+              name: I am in Big Trouble
+            Events in Sprite Lab:
+              name: Events in Sprite Lab
+            Fishy Business:
+              name: Fishy Business
+            Broadcast a Message:
+              name: Broadcast a Message
+            Pythons & Mammals:
+              name: Pythons & Mammals
+            Broadcast in Scratch:
+              name: Broadcast in Scratch
+            Current Solutions:
+              name: Current Solutions
+            'Functions: Songwriting':
+              name: 'Functions: Songwriting'
+            Functions in Minecraft:
+              name: Functions in Minecraft
+            Functions in Harvester:
+              name: Functions in Harvester
+            Functions in Artist:
+              name: Functions in Artist
+            Determine the Concept:
+              name: Determine the Concept
+            Debate:
+              name: Debate
+            Functions in Sprite Lab:
+              name: Functions in Sprite Lab
         csp1-pilot-staging:
           stages:
             Variables Explore:
@@ -13147,6 +19299,45 @@ en:
               display_name: Functions
             csp_project:
               display_name: Project
+          lessons:
+            Variables Explore:
+              name: Variables Explore
+            Variables Investigate:
+              name: Variables Investigate
+            Variables Practice:
+              name: Variables Practice
+            Variables Make:
+              name: Variables Make
+            Student Survey (Variables):
+              name: Student Survey (Variables)
+            Teacher Surveys (Variables):
+              name: Teacher Surveys (Variables)
+            Conditionals Explore:
+              name: Conditionals Explore
+            Conditionals Investigate:
+              name: Conditionals Investigate
+            Conditionals Practice:
+              name: Conditionals Practice
+            Conditional Make:
+              name: Conditional Make
+            Student Survey (Conditionals):
+              name: Student Survey (Conditionals)
+            Teacher Surveys (Conditionals):
+              name: Teacher Surveys (Conditionals)
+            Functions Explore / Investigate:
+              name: Functions Explore / Investigate
+            Functions Practice:
+              name: Functions Practice
+            Functions Make:
+              name: Functions Make
+            Practice PT Part 1:
+              name: Practice PT Part 1
+            Practice PT Part 2:
+              name: Practice PT Part 2
+            Practice PT Part 3:
+              name: Practice PT Part 3
+            Unit 4 Assessment:
+              name: Unit 4 Assessment
         csp2-pilot-staging:
           stages:
             Variables Explore:
@@ -13200,6 +19391,45 @@ en:
               display_name: Functions
             csp_project:
               display_name: Project
+          lessons:
+            Variables Explore:
+              name: Variables Explore
+            Variables Investigate:
+              name: Variables Investigate
+            Variables Practice:
+              name: Variables Practice
+            Variables Make:
+              name: Variables Make
+            Student Survey (Variables):
+              name: Student Survey (Variables)
+            Teacher Surveys (Variables):
+              name: Teacher Surveys (Variables)
+            Conditionals Explore:
+              name: Conditionals Explore
+            Conditionals Investigate:
+              name: Conditionals Investigate
+            Conditionals Practice:
+              name: Conditionals Practice
+            Conditional Make:
+              name: Conditional Make
+            Student Survey (Conditionals):
+              name: Student Survey (Conditionals)
+            Teacher Surveys (Conditionals):
+              name: Teacher Surveys (Conditionals)
+            Functions Explore / Investigate:
+              name: Functions Explore / Investigate
+            Functions Practice:
+              name: Functions Practice
+            Functions Make:
+              name: Functions Make
+            Practice PT Part 1:
+              name: Practice PT Part 1
+            Practice PT Part 2:
+              name: Practice PT Part 2
+            Practice PT Part 3:
+              name: Practice PT Part 3
+            Unit 4 Assessment:
+              name: Unit 4 Assessment
         csp3-pilot-staging:
           stages:
             Variables Explore:
@@ -13277,6 +19507,27 @@ en:
           description_short: ''
           description: ''
           lesson_groups: {}
+          lessons:
+            Introduction to Apps:
+              name: Introduction to Apps
+            Introduction to Design Mode:
+              name: Introduction to Design Mode
+            Project - Designing an App Part 1:
+              name: Project - Designing an App Part 1
+            Project - Designing an App Part 2:
+              name: Project - Designing an App Part 2
+            The Need for Programming Languages:
+              name: The Need for Programming Languages
+            Programs Investigate:
+              name: Programs Investigate
+            Programs Practice:
+              name: Programs Practice
+            Project - Designing an App Part 3:
+              name: Project - Designing an App Part 3
+            Project - Designing an App Part 4:
+              name: Project - Designing an App Part 4
+            'Project: Share Your App':
+              name: 'Project: Share Your App'
         csp4-pilot-staging:
           stages:
             Variables Explore:
@@ -13330,6 +19581,45 @@ en:
               display_name: Functions
             csp_project:
               display_name: Project
+          lessons:
+            Variables Explore:
+              name: Variables Explore
+            Variables Investigate:
+              name: Variables Investigate
+            Variables Practice:
+              name: Variables Practice
+            Variables Make:
+              name: Variables Make
+            Student Survey (Variables):
+              name: Student Survey (Variables)
+            Teacher Surveys (Variables):
+              name: Teacher Surveys (Variables)
+            Conditionals Explore:
+              name: Conditionals Explore
+            Conditionals Investigate:
+              name: Conditionals Investigate
+            Conditionals Practice:
+              name: Conditionals Practice
+            Conditional Make:
+              name: Conditional Make
+            Student Survey (Conditionals):
+              name: Student Survey (Conditionals)
+            Teacher Surveys (Conditionals):
+              name: Teacher Surveys (Conditionals)
+            Functions Explore / Investigate:
+              name: Functions Explore / Investigate
+            Functions Practice:
+              name: Functions Practice
+            Functions Make:
+              name: Functions Make
+            Practice PT Part 1:
+              name: Practice PT Part 1
+            Practice PT Part 2:
+              name: Practice PT Part 2
+            Practice PT Part 3:
+              name: Practice PT Part 3
+            Unit 4 Assessment:
+              name: Unit 4 Assessment
         csp5-pilot-staging:
           stages:
             Variables Explore:
@@ -13431,6 +19721,49 @@ en:
               display_name: Project
             csp_libraries:
               display_name: Libraries
+          lessons:
+            Lists Explore:
+              name: Lists Explore
+            Lists Investigate:
+              name: Lists Investigate
+            Lists Practice:
+              name: Lists Practice
+            Lists Make:
+              name: Lists Make
+            Student Survey (Lists):
+              name: Student Survey (Lists)
+            Teacher Survey (Lists):
+              name: Teacher Survey (Lists)
+            Loops Explore:
+              name: Loops Explore
+            Loops Investigate and Practice:
+              name: Loops Investigate and Practice
+            Traversals Explore:
+              name: Traversals Explore
+            Traversals Investigate:
+              name: Traversals Investigate
+            Traversals Practice:
+              name: Traversals Practice
+            Traversals Make:
+              name: Traversals Make
+            Student Survey (Traversals):
+              name: Student Survey (Traversals)
+            Teacher Survey (Traversals):
+              name: Teacher Survey (Traversals)
+            Mini PT:
+              name: Mini PT
+            Student Survey (Mini PT):
+              name: Student Survey (Mini PT)
+            Unit 5 Mini Assessment:
+              name: Unit 5 Mini Assessment
+            Libraries Explore:
+              name: Libraries Explore
+            Libraries Investigate:
+              name: Libraries Investigate
+            Student Survey (Libraries):
+              name: Student Survey (Libraries)
+            Teacher Survey (Libraries):
+              name: Teacher Survey (Libraries)
         csp6-pilot-staging:
           stages:
             Variables Explore:
@@ -13484,6 +19817,45 @@ en:
               display_name: Functions
             csp_project:
               display_name: Project
+          lessons:
+            Variables Explore:
+              name: Variables Explore
+            Variables Investigate:
+              name: Variables Investigate
+            Variables Practice:
+              name: Variables Practice
+            Variables Make:
+              name: Variables Make
+            Student Survey (Variables):
+              name: Student Survey (Variables)
+            Teacher Surveys (Variables):
+              name: Teacher Surveys (Variables)
+            Conditionals Explore:
+              name: Conditionals Explore
+            Conditionals Investigate:
+              name: Conditionals Investigate
+            Conditionals Practice:
+              name: Conditionals Practice
+            Conditional Make:
+              name: Conditional Make
+            Student Survey (Conditionals):
+              name: Student Survey (Conditionals)
+            Teacher Surveys (Conditionals):
+              name: Teacher Surveys (Conditionals)
+            Functions Explore / Investigate:
+              name: Functions Explore / Investigate
+            Functions Practice:
+              name: Functions Practice
+            Functions Make:
+              name: Functions Make
+            Practice PT Part 1:
+              name: Practice PT Part 1
+            Practice PT Part 2:
+              name: Practice PT Part 2
+            Practice PT Part 3:
+              name: Practice PT Part 3
+            Unit 4 Assessment:
+              name: Unit 4 Assessment
         csp7-pilot-staging:
           stages:
             new stage:
@@ -13561,6 +19933,23 @@ en:
               display_name: Parameters and Return Values
             csp_libraries:
               display_name: Libraries
+          lessons:
+            Parameters and Return Values Explore:
+              name: Parameters and Return Values Explore
+            Parameters and Return Values Investigate:
+              name: Parameters and Return Values Investigate
+            Parameters and Return Values Practice:
+              name: Parameters and Return Values Practice
+            Libraries Explore:
+              name: Libraries Explore
+            Libraries Investigate:
+              name: Libraries Investigate
+            Libraries Project:
+              name: Libraries Project
+            Student Survey (Libraries):
+              name: Student Survey (Libraries)
+            Teacher Survey (Libraries):
+              name: Teacher Survey (Libraries)
         csp8-pilot-staging:
           stages:
             Variables Explore:
@@ -13614,6 +20003,45 @@ en:
               display_name: Functions
             csp_project:
               display_name: Project
+          lessons:
+            Variables Explore:
+              name: Variables Explore
+            Variables Investigate:
+              name: Variables Investigate
+            Variables Practice:
+              name: Variables Practice
+            Variables Make:
+              name: Variables Make
+            Student Survey (Variables):
+              name: Student Survey (Variables)
+            Teacher Surveys (Variables):
+              name: Teacher Surveys (Variables)
+            Conditionals Explore:
+              name: Conditionals Explore
+            Conditionals Investigate:
+              name: Conditionals Investigate
+            Conditionals Practice:
+              name: Conditionals Practice
+            Conditional Make:
+              name: Conditional Make
+            Student Survey (Conditionals):
+              name: Student Survey (Conditionals)
+            Teacher Surveys (Conditionals):
+              name: Teacher Surveys (Conditionals)
+            Functions Explore / Investigate:
+              name: Functions Explore / Investigate
+            Functions Practice:
+              name: Functions Practice
+            Functions Make:
+              name: Functions Make
+            Practice PT Part 1:
+              name: Practice PT Part 1
+            Practice PT Part 2:
+              name: Practice PT Part 2
+            Practice PT Part 3:
+              name: Practice PT Part 3
+            Unit 4 Assessment:
+              name: Unit 4 Assessment
         csp9-pilot-staging:
           stages:
             Variables Explore:
@@ -13667,6 +20095,45 @@ en:
               display_name: Functions
             csp_project:
               display_name: Project
+          lessons:
+            Variables Explore:
+              name: Variables Explore
+            Variables Investigate:
+              name: Variables Investigate
+            Variables Practice:
+              name: Variables Practice
+            Variables Make:
+              name: Variables Make
+            Student Survey (Variables):
+              name: Student Survey (Variables)
+            Teacher Surveys (Variables):
+              name: Teacher Surveys (Variables)
+            Conditionals Explore:
+              name: Conditionals Explore
+            Conditionals Investigate:
+              name: Conditionals Investigate
+            Conditionals Practice:
+              name: Conditionals Practice
+            Conditional Make:
+              name: Conditional Make
+            Student Survey (Conditionals):
+              name: Student Survey (Conditionals)
+            Teacher Surveys (Conditionals):
+              name: Teacher Surveys (Conditionals)
+            Functions Explore / Investigate:
+              name: Functions Explore / Investigate
+            Functions Practice:
+              name: Functions Practice
+            Functions Make:
+              name: Functions Make
+            Practice PT Part 1:
+              name: Practice PT Part 1
+            Practice PT Part 2:
+              name: Practice PT Part 2
+            Practice PT Part 3:
+              name: Practice PT Part 3
+            Unit 4 Assessment:
+              name: Unit 4 Assessment
         csp10-pilot-staging:
           stages:
             Variables Explore:
@@ -13720,6 +20187,45 @@ en:
               display_name: Functions
             csp_project:
               display_name: Project
+          lessons:
+            Variables Explore:
+              name: Variables Explore
+            Variables Investigate:
+              name: Variables Investigate
+            Variables Practice:
+              name: Variables Practice
+            Variables Make:
+              name: Variables Make
+            Student Survey (Variables):
+              name: Student Survey (Variables)
+            Teacher Surveys (Variables):
+              name: Teacher Surveys (Variables)
+            Conditionals Explore:
+              name: Conditionals Explore
+            Conditionals Investigate:
+              name: Conditionals Investigate
+            Conditionals Practice:
+              name: Conditionals Practice
+            Conditional Make:
+              name: Conditional Make
+            Student Survey (Conditionals):
+              name: Student Survey (Conditionals)
+            Teacher Surveys (Conditionals):
+              name: Teacher Surveys (Conditionals)
+            Functions Explore / Investigate:
+              name: Functions Explore / Investigate
+            Functions Practice:
+              name: Functions Practice
+            Functions Make:
+              name: Functions Make
+            Practice PT Part 1:
+              name: Practice PT Part 1
+            Practice PT Part 2:
+              name: Practice PT Part 2
+            Practice PT Part 3:
+              name: Practice PT Part 3
+            Unit 4 Assessment:
+              name: Unit 4 Assessment
         pluralsight:
           stages:
             Pluralsight LevelGroup:
@@ -13729,6 +20235,9 @@ en:
           description_short: ''
           description: ''
           lesson_groups: {}
+          lessons:
+            Pluralsight LevelGroup:
+              name: Pluralsight LevelGroup
         express-2018-vn:
           stages:
             Graph Paper Programming:
@@ -13752,6 +20261,9 @@ en:
           lesson_groups:
             cspSurvey:
               display_name: Survey
+          lessons:
+            CSD post-course survey:
+              name: CSD post-course survey
         csp-post-survey-2018:
           stages:
             CSP post-course survey:
@@ -13763,6 +20275,9 @@ en:
           lesson_groups:
             cspSurvey:
               display_name: Survey
+          lessons:
+            CSP post-course survey:
+              name: CSP post-course survey
         csp5-pilot:
           stages:
             new stage:
@@ -13874,6 +20389,53 @@ en:
               display_name: Overview
             optional_stages:
               display_name: Optional Stages
+          lessons:
+            Lists Explore:
+              name: Lists Explore
+            Lists Investigate:
+              name: Lists Investigate
+            Lists Practice:
+              name: Lists Practice
+            Lists Make:
+              name: Lists Make
+            Loops Explore:
+              name: Loops Explore
+            Loops Investigate:
+              name: Loops Investigate
+            Loops Practice:
+              name: Loops Practice
+            Loops Make:
+              name: Loops Make
+            Traversals Explore:
+              name: Traversals Explore
+            Traversals Investigate:
+              name: Traversals Investigate
+            Traversals Practice:
+              name: Traversals Practice
+            Traversals Make:
+              name: Traversals Make
+            Semester Hackathon Part 1:
+              name: Semester Hackathon Part 1
+            Semester Hackathon Part 2:
+              name: Semester Hackathon Part 2
+            Semester Hackathon Part 3:
+              name: Semester Hackathon Part 3
+            Semester Hackathon Part 4:
+              name: Semester Hackathon Part 4
+            Semester Hackathon Part 5:
+              name: Semester Hackathon Part 5
+            'Lesson 18: Assessment Day':
+              name: 'Lesson 18: Assessment Day'
+            Unit 5 STUDENT Survey:
+              name: Unit 5 STUDENT Survey
+            Unit 5 TEACHER Survey:
+              name: Unit 5 TEACHER Survey
+            "[OLD] Lists Make":
+              name: "[OLD] Lists Make"
+            "[OLD] Loops Make":
+              name: "[OLD] Loops Make"
+            "[OLD] Traversals Make":
+              name: "[OLD] Traversals Make"
         fit2019-novice:
           stages:
             Novice Reflection Overview:
@@ -13897,6 +20459,19 @@ en:
               display_name: Overview
             content:
               display_name: Content
+          lessons:
+            Novice Reflection Overview:
+              name: Novice Reflection Overview
+            Day 1:
+              name: Day 1
+            Day 2:
+              name: Day 2
+            Day 3:
+              name: Day 3
+            Day 4:
+              name: Day 4
+            Wrap Up:
+              name: Wrap Up
         csd-test-saving-state:
           stages:
             csd digital unplugged WIAC L1:
@@ -13914,6 +20489,11 @@ en:
           description_short: ''
           description: ''
           lesson_groups: {}
+          lessons:
+            What is a Computer?:
+              name: What is a Computer?
+            Problem Solving Process:
+              name: Problem Solving Process
         fit2019-apprentice:
           stages:
             Apprentice Reflection Overview:
@@ -13937,6 +20517,19 @@ en:
               display_name: Overview
             content:
               display_name: Content
+          lessons:
+            Apprentice Reflection Overview:
+              name: Apprentice Reflection Overview
+            Day 1:
+              name: Day 1
+            Day 2:
+              name: Day 2
+            Day 3:
+              name: Day 3
+            Day 4:
+              name: Day 4
+            Wrap Up:
+              name: Wrap Up
         csd-sample-online:
           stages:
             What is a Computer? - sample progression:
@@ -13948,6 +20541,11 @@ en:
           description_short: ''
           description: ''
           lesson_groups: {}
+          lessons:
+            What is a Computer? - sample progression:
+              name: What is a Computer? - sample progression
+            Problem Solving Process - sample activities:
+              name: Problem Solving Process - sample activities
         csd1-pilot:
           title: CSD Unit 1 - Problem Solving (Pilot Version)
           description: "Problem Solving and Computing is a highly interactive and collaborative introduction to the field of computer science, as framed within the broader pursuit of solving problems. You’ll practice using a problem solving process to address a series of puzzles, challenges, and real world scenarios. Next, you’ll learn how computers input, output, store, and process information to help humans solve problems.  The unit concludes with a project in which you design an application that helps solve a problem of your choosing.\r\n"
@@ -14001,6 +20599,23 @@ en:
               display_name: 'Chapter 1: The Problem Solving Process'
             csd1_2:
               display_name: 'Chapter 2: Computers and Problem Solving'
+          lessons:
+            CS Discoveries Pre-survey:
+              name: CS Discoveries Pre-survey
+            Intro to Problem Solving:
+              name: Intro to Problem Solving
+            The Problem Solving Process:
+              name: The Problem Solving Process
+            Exploring Problem Solving:
+              name: Exploring Problem Solving
+            What is a Computer?:
+              name: What is a Computer?
+            Input and Output:
+              name: Input and Output
+            Processing:
+              name: Processing
+            Apps and Storage:
+              name: Apps and Storage
         csd2-pilot:
           title: CSD Unit 2 - Web Development (Pilot Version)
           description: " In Unit 2, you’ll learn how to create and share the content on your own web pages. After deciding what content you want to share with the world, you’ll learn how to structure and style your pages using HTML and CSS. You’ll also practice valuable programming skills such as debugging and commenting.  By the end of the unit, you’ll have a personal website that you can publish to the Internet."
@@ -14110,6 +20725,49 @@ en:
               display_name: 'Chapter 2: Styling and CSS'
             cspSurvey:
               display_name: Survey
+          lessons:
+            Exploring Web Pages:
+              name: Exploring Web Pages
+            Intro to HTML:
+              name: Intro to HTML
+            Headings:
+              name: Headings
+            Digital Footprint:
+              name: Digital Footprint
+            Styling Text with CSS:
+              name: Styling Text with CSS
+            Intellectual Property:
+              name: Intellectual Property
+            Images:
+              name: Images
+            'Websites for Expression ':
+              name: 'Websites for Expression '
+            Styling Elements with CSS:
+              name: Styling Elements with CSS
+            Project - Planning Layout and Style:
+              name: Project - Planning Layout and Style
+            Project - Building a Webpage:
+              name: Project - Building a Webpage
+            Purpose of a  Websites:
+              name: Purpose of a  Websites
+            Team Problem Solving:
+              name: Team Problem Solving
+            Sources and Research:
+              name: Sources and Research
+            CSS Classes:
+              name: CSS Classes
+            Planning a Multi-page Website:
+              name: Planning a Multi-page Website
+            Linking and Navigation:
+              name: Linking and Navigation
+            Project - Website for a Purpose:
+              name: Project - Website for a Purpose
+            Peer Review and Final Touches:
+              name: Peer Review and Final Touches
+            Post-Project Test:
+              name: Post-Project Test
+            CS Discoveries Post Course survey:
+              name: CS Discoveries Post Course survey
         csd3-pilot:
           title: CSD Unit 3 - Animations and Games (Pilot Version)
           description: " In Unit 3, you’ll build on your coding experience as you program animations, interactive art, and games in Game Lab. The unit starts off with simple shapes and builds up to more sophisticated sprite-based games, using the same programming concepts and the design process computer scientists use daily. In the final project, you’ll develop a personalized, interactive program."
@@ -14236,6 +20894,61 @@ en:
               display_name: 'Chapter 2: Building Games'
             cspSurvey:
               display_name: Survey
+          lessons:
+            Programming for Entertainment:
+              name: Programming for Entertainment
+            Plotting Shapes:
+              name: Plotting Shapes
+            Drawing in Game Lab:
+              name: Drawing in Game Lab
+            Shapes and Parameters:
+              name: Shapes and Parameters
+            Variables:
+              name: Variables
+            Random Numbers:
+              name: Random Numbers
+            Sprites and Animations:
+              name: Sprites and Animations
+            Sprite Properties:
+              name: Sprite Properties
+            Text and Captioned Scenes:
+              name: Text and Captioned Scenes
+            The Draw Loop:
+              name: The Draw Loop
+            The Counter Pattern Unplugged:
+              name: The Counter Pattern Unplugged
+            Sprite Movement:
+              name: Sprite Movement
+            Booleans Unplugged:
+              name: Booleans Unplugged
+            Conditionals:
+              name: Conditionals
+            Keyboard Input:
+              name: Keyboard Input
+            Other Forms of Input:
+              name: Other Forms of Input
+            Project - Interactive Card:
+              name: Project - Interactive Card
+            Velocity:
+              name: Velocity
+            Collision Detection:
+              name: Collision Detection
+            Complex Sprite Movement:
+              name: Complex Sprite Movement
+            Collisions:
+              name: Collisions
+            Functions:
+              name: Functions
+            The Game Design Process:
+              name: The Game Design Process
+            Using the Game Design Process:
+              name: Using the Game Design Process
+            Project - Design a Game:
+              name: Project - Design a Game
+            Post-Project Test:
+              name: Post-Project Test
+            CS Discoveries Post Course survey:
+              name: CS Discoveries Post Course survey
         csd-bugs:
           stages:
             Game Lab Bugs:
@@ -14247,6 +20960,11 @@ en:
           description_short: ''
           description: ''
           lesson_groups: {}
+          lessons:
+            Game Lab Bugs:
+              name: Game Lab Bugs
+            Immovable Crab:
+              name: Immovable Crab
         maddie-test:
           stages:
             stage 1:
@@ -14306,6 +21024,33 @@ en:
               display_name: Content
             required:
               display_name: Overview
+          lessons:
+            Introduction to Apps:
+              name: Introduction to Apps
+            Introduction to Design Mode:
+              name: Introduction to Design Mode
+            Project - Designing an App Part 1:
+              name: Project - Designing an App Part 1
+            Project - Designing an App Part 2:
+              name: Project - Designing an App Part 2
+            The Need for Programming Languages:
+              name: The Need for Programming Languages
+            Intro to Programming:
+              name: Intro to Programming
+            Debugging:
+              name: Debugging
+            Project - Designing an App Part 3:
+              name: Project - Designing an App Part 3
+            Project - Designing an App Part 4:
+              name: Project - Designing an App Part 4
+            Project - Designing an App Part 5:
+              name: Project - Designing an App Part 5
+            'Lesson 11: Assessment Day':
+              name: 'Lesson 11: Assessment Day'
+            Unit 3 STUDENT Survey:
+              name: Unit 3 STUDENT Survey
+            Unit 3 TEACHER Survey:
+              name: Unit 3 TEACHER Survey
         csl-vn:
           stages:
             Sequencing with Scrat:
@@ -14331,6 +21076,19 @@ en:
               display_name: Loops
             csf_events:
               display_name: Events
+          lessons:
+            Sequencing with Scrat:
+              name: Sequencing with Scrat
+            Programming in Maze:
+              name: Programming in Maze
+            Programming with Rey and BB-8:
+              name: Programming with Rey and BB-8
+            Loops in Ice Age:
+              name: Loops in Ice Age
+            Ocean Scene with Loops:
+              name: Ocean Scene with Loops
+            Tell a Story in Play Lab:
+              name: Tell a Story in Play Lab
         dlp19-csd-mod-fit:
           stages:
             Deeper Learning Overview:
@@ -14348,6 +21106,13 @@ en:
               display_name: Overview
             content:
               display_name: Content
+          lessons:
+            Deeper Learning Overview:
+              name: Deeper Learning Overview
+            Understanding the Curriculum:
+              name: Understanding the Curriculum
+            Demonstrating Understanding:
+              name: Demonstrating Understanding
         dlp19-csp-mod-fit:
           stages:
             Deeper Learning Overview:
@@ -14365,6 +21130,13 @@ en:
               display_name: Overview
             content:
               display_name: Content
+          lessons:
+            Deeper Learning Overview:
+              name: Deeper Learning Overview
+            Understanding the Curriculum:
+              name: Understanding the Curriculum
+            Demonstrating Understanding:
+              name: Demonstrating Understanding
         pl-csd-bugs:
           stages:
             CSD Workshop 1 Bugs:
@@ -14374,6 +21146,9 @@ en:
           description_short: Debugging in Game Lab - Academic Year Workshop 1
           description: ''
           lesson_groups: {}
+          lessons:
+            CSD Workshop 1 Bugs:
+              name: CSD Workshop 1 Bugs
         dlp19-csd-mod-w1:
           stages:
             Module 1:
@@ -14397,6 +21172,13 @@ en:
               display_name: Overview
             content:
               display_name: Content
+          lessons:
+            Deeper Learning Overview:
+              name: Deeper Learning Overview
+            'Step 1: Develop Understanding':
+              name: 'Step 1: Develop Understanding'
+            'Step 2: Demonstrate Understanding':
+              name: 'Step 2: Demonstrate Understanding'
         dlp19-csd-mod-w2:
           stages:
             new stage:
@@ -14418,6 +21200,13 @@ en:
               display_name: Overview
             content:
               display_name: Content
+          lessons:
+            Deeper Learning Overview:
+              name: Deeper Learning Overview
+            'Step 1: Develop Understanding':
+              name: 'Step 1: Develop Understanding'
+            'Step 2: Demonstrate Understanding':
+              name: 'Step 2: Demonstrate Understanding'
         dlp19-csd-mod-w3:
           stages:
             CS Discoveries Deeper Learning Module 3:
@@ -14437,6 +21226,13 @@ en:
               display_name: Overview
             content:
               display_name: Content
+          lessons:
+            Deeper Learning Overview:
+              name: Deeper Learning Overview
+            'Step 1: Develop Understanding':
+              name: 'Step 1: Develop Understanding'
+            'Step 2: Demonstrate Understanding':
+              name: 'Step 2: Demonstrate Understanding'
         dlp19-csd-mod-w4:
           stages:
             CS Discoveries Deeper Learning Module 4:
@@ -14456,6 +21252,13 @@ en:
               display_name: Overview
             content:
               display_name: Content
+          lessons:
+            Deeper Learning Overview:
+              name: Deeper Learning Overview
+            'Step 1: Develop Understanding':
+              name: 'Step 1: Develop Understanding'
+            'Step 2: Demonstrate Understanding':
+              name: 'Step 2: Demonstrate Understanding'
         dlp19-csp-mod-w1:
           stages:
             CS Principles Deeper Learning Module 1:
@@ -14475,6 +21278,13 @@ en:
               display_name: Overview
             content:
               display_name: Content
+          lessons:
+            Deeper Learning Overview:
+              name: Deeper Learning Overview
+            'Step 1: Develop Understanding':
+              name: 'Step 1: Develop Understanding'
+            'Step 2: Demonstrate Understanding':
+              name: 'Step 2: Demonstrate Understanding'
         dlp19-csp-mod-w2:
           stages:
             CS Principles Deeper Learning Module 2:
@@ -14494,6 +21304,13 @@ en:
               display_name: Overview
             content:
               display_name: Content
+          lessons:
+            Deeper Learning Overview:
+              name: Deeper Learning Overview
+            'Step 1: Develop Understanding':
+              name: 'Step 1: Develop Understanding'
+            'Step 2: Demonstrate Understanding':
+              name: 'Step 2: Demonstrate Understanding'
         dlp19-csp-mod-w3:
           stages:
             CS Principles Deeper Learning Module 3:
@@ -14513,6 +21330,13 @@ en:
               display_name: Overview
             content:
               display_name: Content
+          lessons:
+            Deeper Learning Overview:
+              name: Deeper Learning Overview
+            'Step 1: Develop Understanding':
+              name: 'Step 1: Develop Understanding'
+            'Step 2: Demonstrate Understanding':
+              name: 'Step 2: Demonstrate Understanding'
         dlp19-csp-mod-w4:
           stages:
             CS Principles Deeper Learning Module 4:
@@ -14532,6 +21356,13 @@ en:
               display_name: Overview
             content:
               display_name: Content
+          lessons:
+            Deeper Learning Overview:
+              name: Deeper Learning Overview
+            'Step 1: Develop Understanding':
+              name: 'Step 1: Develop Understanding'
+            'Step 2: Demonstrate Understanding':
+              name: 'Step 2: Demonstrate Understanding'
         csd-pilot:
           stages:
             Pilot Information:
@@ -14599,6 +21430,65 @@ en:
           description_short: ''
           description: ''
           lesson_groups: {}
+          lessons:
+            Pilot Information 1:
+              name: Pilot Information 1
+            Pilot Information 2:
+              name: Pilot Information 2
+            Pilot Information 3:
+              name: Pilot Information 3
+            Pilot Information 4:
+              name: Pilot Information 4
+            Pilot Information 5:
+              name: Pilot Information 5
+            Pilot Information 6:
+              name: Pilot Information 6
+            Pilot Information 7:
+              name: Pilot Information 7
+            Pilot Information 8:
+              name: Pilot Information 8
+            Pilot Information 9:
+              name: Pilot Information 9
+            Pilot Information 10:
+              name: Pilot Information 10
+            Pilot Information 11:
+              name: Pilot Information 11
+            Pilot Information 12:
+              name: Pilot Information 12
+            Pilot Information 13:
+              name: Pilot Information 13
+            Pilot Information 14:
+              name: Pilot Information 14
+            Pilot Information 15:
+              name: Pilot Information 15
+            Pilot Information 16:
+              name: Pilot Information 16
+            Pilot Information 17:
+              name: Pilot Information 17
+            Pilot Information 18:
+              name: Pilot Information 18
+            Pilot Information 19:
+              name: Pilot Information 19
+            Pilot Information 20:
+              name: Pilot Information 20
+            Pilot Information 21:
+              name: Pilot Information 21
+            Pilot Information 22:
+              name: Pilot Information 22
+            Pilot Information 23:
+              name: Pilot Information 23
+            Pilot Information 24:
+              name: Pilot Information 24
+            Pilot Information 25:
+              name: Pilot Information 25
+            Pilot Information 26:
+              name: Pilot Information 26
+            Pilot Information 27:
+              name: Pilot Information 27
+            Pilot Information 28:
+              name: Pilot Information 28
+            Pilot Information 29:
+              name: Pilot Information 29
         csd4-pilot:
           stages:
             What is a Computer?:
@@ -14620,6 +21510,19 @@ en:
           lesson_groups:
             csd1_2:
               display_name: 'Chapter 2: Computers and Problem Solving'
+          lessons:
+            What is a Computer?:
+              name: What is a Computer?
+            Input and Output:
+              name: Input and Output
+            Processing:
+              name: Processing
+            Apps and Storage:
+              name: Apps and Storage
+            Project - Propose an App:
+              name: Project - Propose an App
+            Post-Project Test:
+              name: Post-Project Test
         csp2-pilot:
           stages:
             new stage:
@@ -14669,6 +21572,29 @@ en:
               display_name: Content
             required:
               display_name: Overview
+          lessons:
+            Welcome to the Internet:
+              name: Welcome to the Internet
+            Building a Network:
+              name: Building a Network
+            The Need for Addressing:
+              name: The Need for Addressing
+            Routers and Redundancy:
+              name: Routers and Redundancy
+            Packets:
+              name: Packets
+            DNS and HTTP:
+              name: DNS and HTTP
+            Project - Internet Dilemmas Part 1:
+              name: Project - Internet Dilemmas Part 1
+            Project - Internet Dilemmas Part 2:
+              name: Project - Internet Dilemmas Part 2
+            'Lesson 9: Assessment Day':
+              name: 'Lesson 9: Assessment Day'
+            Unit 2 STUDENT Survey:
+              name: Unit 2 STUDENT Survey
+            Unit 2 TEACHER Survey:
+              name: Unit 2 TEACHER Survey
         denny-science:
           stages:
             Earthquake Detector:
@@ -14682,6 +21608,11 @@ en:
           description_short: ''
           description: ''
           lesson_groups: {}
+          lessons:
+            'Earthquake Detector: Designing Screens':
+              name: 'Earthquake Detector: Designing Screens'
+            'Earthquake Detector: Processing with Events':
+              name: 'Earthquake Detector: Processing with Events'
         peru-2019:
           stages:
             new stage:
@@ -14709,6 +21640,21 @@ en:
           description_short: ''
           description: ''
           lesson_groups: {}
+          lessons:
+            Introduction:
+              name: Introduction
+            Introduction to Debugging:
+              name: Introduction to Debugging
+            'Loops: My Loopy Robotic Friends':
+              name: 'Loops: My Loopy Robotic Friends'
+            Loops in Artist:
+              name: Loops in Artist
+            Nested Loops:
+              name: Nested Loops
+            Nested Loops in Frozen:
+              name: Nested Loops in Frozen
+            Events in Star Wars:
+              name: Events in Star Wars
         csp6-pilot:
           stages:
             Algorithms Solve Problems:
@@ -14738,6 +21684,23 @@ en:
               display_name: Content
             required:
               display_name: Overview
+          lessons:
+            Algorithms Solve Problems:
+              name: Algorithms Solve Problems
+            Algorithm Efficiency:
+              name: Algorithm Efficiency
+            Unreasonable Time:
+              name: Unreasonable Time
+            The Limits of Algorithms:
+              name: The Limits of Algorithms
+            Parallel and Distributed Algorithms:
+              name: Parallel and Distributed Algorithms
+            'Lesson 6: Assessment Day':
+              name: 'Lesson 6: Assessment Day'
+            Unit 6 STUDENT Survey:
+              name: Unit 6 STUDENT Survey
+            Unit 6 TEACHER Survey:
+              name: Unit 6 TEACHER Survey
         denny-science-8:
           title: Collision Detector
           description: ''
@@ -14757,6 +21720,11 @@ en:
             'Collision Detector: Processing with Events':
               name: 'Collision Detector: Processing with Events'
           lesson_groups: {}
+          lessons:
+            'Collision Detector: Designing Screens':
+              name: 'Collision Detector: Designing Screens'
+            'Collision Detector: Processing with Events':
+              name: 'Collision Detector: Processing with Events'
         denny-science-copy:
           stages:
             'Collision Detector: Designing Screens':
@@ -14764,6 +21732,11 @@ en:
             'Collision Detector: Processing with Events':
               name: 'Collision Detector: Processing with Events'
           lesson_groups: {}
+          lessons:
+            'Collision Detector: Designing Screens':
+              name: 'Collision Detector: Designing Screens'
+            'Collision Detector: Processing with Events':
+              name: 'Collision Detector: Processing with Events'
         dance-2019:
           stages:
             Dance Party:
@@ -14773,6 +21746,9 @@ en:
           description_short: Featuring Katy Perry, Shawn Mendes, Panic! At The Disco, Lil Nas X, Jonas Brothers, Nicki Minaj, and 34 more!
           description: Code your own dance party to share with your friends!
           lesson_groups: {}
+          lessons:
+            Dance Party:
+              name: Dance Party
         k5-onlinepd-2019:
           title: Teaching Computer Science Fundamentals
           description: Learn how to teach computer science using Code.org's Computer Science Fundamentals with this free, self-paced online course!
@@ -14882,6 +21858,33 @@ en:
               display_name: 'Diving Deeper: Courses E and F'
             k5_next_steps:
               display_name: Next Steps
+          lessons:
+            Welcome to "Teaching Computer Science Fundamentals":
+              name: Welcome to "Teaching Computer Science Fundamentals"
+            Understanding the Computer Science Fundamentals Courses:
+              name: Understanding the Computer Science Fundamentals Courses
+            Sequencing:
+              name: Sequencing
+            Loops:
+              name: Loops
+            Events:
+              name: Events
+            Conditionals:
+              name: Conditionals
+            End of Course projects:
+              name: End of Course projects
+            Functions:
+              name: Functions
+            Variables:
+              name: Variables
+            For Loops:
+              name: For Loops
+            Sprite Lab:
+              name: Sprite Lab
+            Reviewing your reflections:
+              name: Reviewing your reflections
+            Next steps:
+              name: Next steps
         dance-extras-2019:
           title: Keep On Dancing (2019)
           description: Go beyond the first hour with extended project ideas.
@@ -14893,6 +21896,9 @@ en:
               description_student: ''
               description_teacher: ''
           lesson_groups: {}
+          lessons:
+            Dance Party - Go Further:
+              name: Dance Party - Go Further
         csp10-pilot:
           stages:
             new stage:
@@ -14942,6 +21948,35 @@ en:
           description_short: ''
           description: ''
           lesson_groups: {}
+          lessons:
+            Project - Innovation Simulation Part 1:
+              name: Project - Innovation Simulation Part 1
+            Project - Innovation Simulation Part 2:
+              name: Project - Innovation Simulation Part 2
+            Data Policies and Privacy:
+              name: Data Policies and Privacy
+            The Value of Privacy:
+              name: The Value of Privacy
+            Project - Innovation Simulation Part 3:
+              name: Project - Innovation Simulation Part 3
+            Security Risks Part 1:
+              name: Security Risks Part 1
+            Security Risks Part 2:
+              name: Security Risks Part 2
+            'Project: Innovation Simulation Part 4':
+              name: 'Project: Innovation Simulation Part 4'
+            Protecting Data Part 1:
+              name: Protecting Data Part 1
+            Protecting Data Part 2:
+              name: Protecting Data Part 2
+            'Project: Innovation Simulation Part 5':
+              name: 'Project: Innovation Simulation Part 5'
+            'Project: Innovation Simulation Part 6':
+              name: 'Project: Innovation Simulation Part 6'
+            'Project: Innovation Simulation Part 7':
+              name: 'Project: Innovation Simulation Part 7'
+            'Lesson 14: Unit Assessment Day':
+              name: 'Lesson 14: Unit Assessment Day'
         csp4-preview:
           stages:
             new stage:
@@ -14991,6 +22026,37 @@ en:
               display_name: Functions
             csp_project:
               display_name: Project
+          lessons:
+            Variables Explore:
+              name: Variables Explore
+            Variables Investigate:
+              name: Variables Investigate
+            Variables Practice:
+              name: Variables Practice
+            Variables Make:
+              name: Variables Make
+            Conditionals Explore:
+              name: Conditionals Explore
+            Conditionals Investigate:
+              name: Conditionals Investigate
+            Conditionals Practice:
+              name: Conditionals Practice
+            Conditional Make:
+              name: Conditional Make
+            Functions Explore / Investigate:
+              name: Functions Explore / Investigate
+            Functions Practice:
+              name: Functions Practice
+            Functions Make:
+              name: Functions Make
+            Practice PT Part 1:
+              name: Practice PT Part 1
+            Practice PT Part 2:
+              name: Practice PT Part 2
+            Practice PT Part 3:
+              name: Practice PT Part 3
+            'Lesson 15: Assessment Day':
+              name: 'Lesson 15: Assessment Day'
         time4cs-original-unit-1:
           stages:
             Sequencing in Maze:
@@ -15062,6 +22128,27 @@ en:
               display_name: Functions
             end_of_course_project:
               display_name: End of Course Project
+          lessons:
+            Crowdsourcing:
+              name: Crowdsourcing
+            Conditionals with Cards:
+              name: Conditionals with Cards
+            Nested Loops in Bee:
+              name: Nested Loops in Bee
+            Nested Loops in Artist:
+              name: Nested Loops in Artist
+            Nested Loops in Frozen:
+              name: Nested Loops in Frozen
+            'Functions: Songwriting':
+              name: 'Functions: Songwriting'
+            Functions in Minecraft:
+              name: Functions in Minecraft
+            Functions in Harvester:
+              name: Functions in Harvester
+            Functions in Artist:
+              name: Functions in Artist
+            End of Course Project:
+              name: End of Course Project
         time4cs-experiment-unit-2:
           stages:
             Introduction to the Problem:
@@ -15131,6 +22218,59 @@ en:
               display_name: 'Collection 4: Impact of Invasive Species (on the Everglades)'
             time4cs_c5:
               display_name: 'Collection 5: Citizens Take Action'
+          lessons:
+            Introduction to the Problem:
+              name: Introduction to the Problem
+            Crowdsourcing (Integrated lesson):
+              name: Crowdsourcing (Integrated lesson)
+            Everglades Habitats:
+              name: Everglades Habitats
+            Evaluating a Project in Sprite Lab:
+              name: Evaluating a Project in Sprite Lab
+            Food Chains:
+              name: Food Chains
+            Conditionals with Cards (Integrated Lesson)- Part 1:
+              name: Conditionals with Cards (Integrated Lesson)- Part 1
+            Alligator Holes:
+              name: Alligator Holes
+            Food Chain Game:
+              name: Food Chain Game
+            Invasive Species:
+              name: Invasive Species
+            Conditionals with Cards (Integrated Lesson)- Part 2:
+              name: Conditionals with Cards (Integrated Lesson)- Part 2
+            I am in Big Trouble:
+              name: I am in Big Trouble
+            Conditionals in Sprite Lab:
+              name: Conditionals in Sprite Lab
+            Nested Loops in Maze:
+              name: Nested Loops in Maze
+            Fancy Shapes using Nested Loops:
+              name: Fancy Shapes using Nested Loops
+            Nested Loops with Frozen:
+              name: Nested Loops with Frozen
+            Fishy Business:
+              name: Fishy Business
+            Songwriting (Integrated Lesson):
+              name: Songwriting (Integrated Lesson)
+            Functions in Minecraft:
+              name: Functions in Minecraft
+            Functions with Harvester:
+              name: Functions with Harvester
+            Functions with Artist:
+              name: Functions with Artist
+            Pythons impacting native populations:
+              name: Pythons impacting native populations
+            Functions in Sprite Lab:
+              name: Functions in Sprite Lab
+            Python Problem- Current Solutions:
+              name: Python Problem- Current Solutions
+            End of Course Project (integrated- project planning lesson):
+              name: End of Course Project (integrated- project planning lesson)
+            Debate- Pythons impacting native populations:
+              name: Debate- Pythons impacting native populations
+            Work on Project:
+              name: Work on Project
         time4cs-control-unit-1:
           title: Time4CS Control Unit 1
           description: ''
@@ -15202,6 +22342,31 @@ en:
               display_name: Impacts of Computing
             ramp_up:
               display_name: Ramp-Up
+          lessons:
+            Sequencing in Maze:
+              name: Sequencing in Maze
+            Programming and Loops with the Artist:
+              name: Programming and Loops with the Artist
+            'Conditionals in Minecraft: Voyage Aquatic':
+              name: 'Conditionals in Minecraft: Voyage Aquatic'
+            Conditionals:
+              name: Conditionals
+            'Events: The Big Event':
+              name: 'Events: The Big Event'
+            Simon Says:
+              name: Simon Says
+            Learning Sprites with Sprite Lab:
+              name: Learning Sprites with Sprite Lab
+            Alien Dance Party with Sprite Lab:
+              name: Alien Dance Party with Sprite Lab
+            Private and Personal Information:
+              name: Private and Personal Information
+            About Me:
+              name: About Me
+            Access Ability:
+              name: Access Ability
+            Conditionals Review:
+              name: Conditionals Review
         time4cs-experiment-unit-1:
           title: Time4CS Experiment Unit 1
           description: ''
@@ -15273,6 +22438,31 @@ en:
               display_name: Impacts of Computing
             ramp_up:
               display_name: Ramp-Up
+          lessons:
+            Sequencing in Maze:
+              name: Sequencing in Maze
+            Programming and Loops with the Artist:
+              name: Programming and Loops with the Artist
+            'Conditionals in Minecraft: Voyage Aquatic':
+              name: 'Conditionals in Minecraft: Voyage Aquatic'
+            Conditionals:
+              name: Conditionals
+            'Events: The Big Event':
+              name: 'Events: The Big Event'
+            Simon Says:
+              name: Simon Says
+            Learning Sprites with Sprite Lab:
+              name: Learning Sprites with Sprite Lab
+            Alien Dance Party with Sprite Lab:
+              name: Alien Dance Party with Sprite Lab
+            Private and Personal Information:
+              name: Private and Personal Information
+            About Me:
+              name: About Me
+            Access Ability:
+              name: Access Ability
+            Conditionals Review:
+              name: Conditionals Review
         csp7-pilot:
           stages:
             Parameters and Returns Explore:
@@ -15342,6 +22532,35 @@ en:
               display_name: Overview
             optional_stages:
               display_name: Optional Stages
+          lessons:
+            Parameters and Return Explore:
+              name: Parameters and Return Explore
+            Parameters and Return Investigate:
+              name: Parameters and Return Investigate
+            Parameters and Return Practice:
+              name: Parameters and Return Practice
+            Parameters and Return Make:
+              name: Parameters and Return Make
+            Libraries Explore:
+              name: Libraries Explore
+            Libraries Investigate:
+              name: Libraries Investigate
+            Libraries Practice:
+              name: Libraries Practice
+            Project - Make a Library Part 1:
+              name: Project - Make a Library Part 1
+            Project - Make a Library Part 2:
+              name: Project - Make a Library Part 2
+            Project - Make a Library Part 3:
+              name: Project - Make a Library Part 3
+            'Lesson 11: Assessment Day':
+              name: 'Lesson 11: Assessment Day'
+            Unit 7 STUDENT Survey:
+              name: Unit 7 STUDENT Survey
+            Unit 7 TEACHER Survey:
+              name: Unit 7 TEACHER Survey
+            "[OLD] Parameters and Return Make":
+              name: "[OLD] Parameters and Return Make"
         csp8-pilot:
           stages:
             new stage:
@@ -15357,6 +22576,13 @@ en:
           description_short: ''
           description: ''
           lesson_groups: {}
+          lessons:
+            Create PT - Review the Task:
+              name: Create PT - Review the Task
+            Create PT - Make a Plan:
+              name: Create PT - Make a Plan
+            Create PT - Complete the Task:
+              name: Create PT - Complete the Task
         csp4-2020:
           stages:
             Variables Explore:
@@ -15402,6 +22628,37 @@ en:
               display_name: Functions
             csp_project:
               display_name: Project
+          lessons:
+            Variables Explore:
+              name: Variables Explore
+            Variables Investigate:
+              name: Variables Investigate
+            Variables Practice:
+              name: Variables Practice
+            Variables Make:
+              name: Variables Make
+            Conditionals Explore:
+              name: Conditionals Explore
+            Conditionals Investigate:
+              name: Conditionals Investigate
+            Conditionals Practice:
+              name: Conditionals Practice
+            Conditional Make:
+              name: Conditional Make
+            Functions Explore / Investigate:
+              name: Functions Explore / Investigate
+            Functions Practice:
+              name: Functions Practice
+            Functions Make:
+              name: Functions Make
+            Project - Decision Maker App Part 1:
+              name: Project - Decision Maker App Part 1
+            Project - Decision Maker App Part 2:
+              name: Project - Decision Maker App Part 2
+            Project - Decision Maker App Part 3:
+              name: Project - Decision Maker App Part 3
+            'Lesson 15: Assessment Day':
+              name: 'Lesson 15: Assessment Day'
         csp5-2020:
           stages:
             Lists Explore:
@@ -15457,6 +22714,43 @@ en:
               display_name: Traversals
             csp_project:
               display_name: Project
+          lessons:
+            Lists Explore:
+              name: Lists Explore
+            Lists Investigate:
+              name: Lists Investigate
+            Lists Practice:
+              name: Lists Practice
+            Lists Make:
+              name: Lists Make
+            Loops Explore:
+              name: Loops Explore
+            Loops Investigate:
+              name: Loops Investigate
+            Loops Practice:
+              name: Loops Practice
+            Loops Make:
+              name: Loops Make
+            Traversals Explore:
+              name: Traversals Explore
+            Traversals Investigate:
+              name: Traversals Investigate
+            Traversals Practice:
+              name: Traversals Practice
+            Traversals Make:
+              name: Traversals Make
+            Semester Hackathon Part 1:
+              name: Semester Hackathon Part 1
+            Semester Hackathon Part 2:
+              name: Semester Hackathon Part 2
+            Semester Hackathon Part 3:
+              name: Semester Hackathon Part 3
+            Semester Hackathon Part 4:
+              name: Semester Hackathon Part 4
+            Semester Hackathon Part 5:
+              name: Semester Hackathon Part 5
+            'Lesson 18: Assessment Day':
+              name: 'Lesson 18: Assessment Day'
         csp7-2020:
           stages:
             Parameters and Return Explore:
@@ -15498,6 +22792,29 @@ en:
               display_name: Parameters and Return Values
             csp_libraries:
               display_name: Libraries
+          lessons:
+            Parameters and Return Explore:
+              name: Parameters and Return Explore
+            Parameters and Return Investigate:
+              name: Parameters and Return Investigate
+            Parameters and Return Practice:
+              name: Parameters and Return Practice
+            Parameters and Return Make:
+              name: Parameters and Return Make
+            Libraries Explore:
+              name: Libraries Explore
+            Libraries Investigate:
+              name: Libraries Investigate
+            Libraries Practice:
+              name: Libraries Practice
+            Project - Make a Library Part 1:
+              name: Project - Make a Library Part 1
+            Project - Make a Library Part 2:
+              name: Project - Make a Library Part 2
+            Project - Make a Library Part 3:
+              name: Project - Make a Library Part 3
+            'Lesson 11: Assessment Day':
+              name: 'Lesson 11: Assessment Day'
         csd2-projects-temp:
           stages:
             HTML  Project:
@@ -15509,6 +22826,11 @@ en:
           description_short: ''
           description: Temporary place to hold the new mini-projects for CSD Web Development
           lesson_groups: {}
+          lessons:
+            HTML  Project:
+              name: HTML  Project
+            CSS Project:
+              name: CSS Project
         csp9-pilot:
           stages:
             new stage:
@@ -15542,6 +22864,25 @@ en:
           description_short: ''
           description: ''
           lesson_groups: {}
+          lessons:
+            Learning From Data:
+              name: Learning From Data
+            Exploring One Column:
+              name: Exploring One Column
+            Filtering and Cleaning Data:
+              name: Filtering and Cleaning Data
+            Exploring Two Columns:
+              name: Exploring Two Columns
+            Big Data, Crowdsourcing, and Machine Learning:
+              name: Big Data, Crowdsourcing, and Machine Learning
+            Machine Learning and Bias:
+              name: Machine Learning and Bias
+            Project - Tell a Data Story - Part 1:
+              name: Project - Tell a Data Story - Part 1
+            Project - Tell a Data Story - Part 2:
+              name: Project - Tell a Data Story - Part 2
+            'Lesson 9: Assessment Day':
+              name: 'Lesson 9: Assessment Day'
         csd2-2020:
           title: CSD Unit 2 - Web Development
           description: " In Unit 2, you’ll learn how to create and share the content on your own web pages. After deciding what content you want to share with the world, you’ll learn how to structure and style your pages using HTML and CSS. You’ll also practice valuable programming skills such as debugging, using resources, and teamwork.  "
@@ -15653,6 +22994,53 @@ en:
               display_name: 'Chapter 2: Styling and CSS'
             cspSurvey:
               display_name: Survey
+          lessons:
+            Exploring Web Pages:
+              name: Exploring Web Pages
+            Intro to HTML:
+              name: Intro to HTML
+            Headings:
+              name: Headings
+            'Mini-Project: HTML Web Page':
+              name: 'Mini-Project: HTML Web Page'
+            Digital Footprint:
+              name: Digital Footprint
+            Styling Text with CSS:
+              name: Styling Text with CSS
+            'Mini-Project: Your Personal Style':
+              name: 'Mini-Project: Your Personal Style'
+            Intellectual Property:
+              name: Intellectual Property
+            Images:
+              name: Images
+            'Websites for Expression ':
+              name: 'Websites for Expression '
+            Styling Elements with CSS:
+              name: Styling Elements with CSS
+            Your Web Page - Prepare:
+              name: Your Web Page - Prepare
+            Project - Building a Webpage:
+              name: Project - Building a Webpage
+            Purpose of a  Websites:
+              name: Purpose of a  Websites
+            Team Problem Solving:
+              name: Team Problem Solving
+            Sources and Research:
+              name: Sources and Research
+            CSS Classes:
+              name: CSS Classes
+            Planning a Multi-page Website:
+              name: Planning a Multi-page Website
+            Linking and Navigation:
+              name: Linking and Navigation
+            Project - Website for a Purpose:
+              name: Project - Website for a Purpose
+            Peer Review and Final Touches:
+              name: Peer Review and Final Touches
+            Post-Project Test:
+              name: Post-Project Test
+            CS Discoveries Post Course survey:
+              name: CS Discoveries Post Course survey
         csd1-2020:
           title: CSD Unit 1 - Problem Solving and Computing
           description: "Problem Solving and Computing is a highly interactive and collaborative introduction to the field of computer science, as framed within the broader pursuit of solving problems. You’ll practice using a problem solving process to address a series of puzzles, challenges, and real world scenarios. Next, you’ll learn how computers input, output, store, and process information to help humans solve problems.  The unit concludes with a project in which you design an application that helps solve a problem of your choosing.\r\n"
@@ -15782,6 +23170,37 @@ en:
               display_name: 'Chapter 2: Computers and Problem Solving'
             csd1_3:
               display_name: Alternate Lessons
+          lessons:
+            CS Discoveries Pre-survey:
+              name: CS Discoveries Pre-survey
+            Intro to Problem Solving:
+              name: Intro to Problem Solving
+            The Problem Solving Process:
+              name: The Problem Solving Process
+            Exploring Problem Solving:
+              name: Exploring Problem Solving
+            What is a Computer?:
+              name: What is a Computer?
+            Input and Output:
+              name: Input and Output
+            Processing:
+              name: Processing
+            Apps and Storage:
+              name: Apps and Storage
+            Project - Propose an App:
+              name: Project - Propose an App
+            Post-Project Test:
+              name: Post-Project Test
+            Intro to Problem Solving - Newspaper Table (Alternate Lesson 1):
+              name: Intro to Problem Solving - Newspaper Table (Alternate Lesson 1)
+            Intro to Problem Solving - Spaghetti Bridge (Alternate Lesson 1):
+              name: Intro to Problem Solving - Spaghetti Bridge (Alternate Lesson 1)
+            Intro to Problem Solving - Paper Tower (Alternate Lesson 1):
+              name: Intro to Problem Solving - Paper Tower (Alternate Lesson 1)
+            Exploring Problem Solving - Games Theme (Alternate Lesson 3):
+              name: Exploring Problem Solving - Games Theme (Alternate Lesson 3)
+            Exploring Problem Solving - Animals Theme (Alternate Lesson 3):
+              name: Exploring Problem Solving - Animals Theme (Alternate Lesson 3)
         csd4-2020:
           title: CSD Unit 4 - The Design Process
           description: Unit 4 introduces the broader social impacts of computing. Through a series of design challenges, you will learn how to better understand the needs of others while developing a solution to a problem. The second half of the unit consists of an iterative team project, during which teams have the opportunity to identify a need that they care about, prototype solutions both on paper and in App Lab, and test solutions with real users to get feedback and drive further iteration.
@@ -15869,6 +23288,43 @@ en:
               display_name: 'Chapter 2: Solving Data Problems'
             cspSurvey:
               display_name: Survey
+          lessons:
+            Analysis of Design:
+              name: Analysis of Design
+            Understanding Your User:
+              name: Understanding Your User
+            User-Centered Design Micro Activity:
+              name: User-Centered Design Micro Activity
+            User Interfaces:
+              name: User Interfaces
+            Feedback and Testing:
+              name: Feedback and Testing
+            Identifying User Needs:
+              name: Identifying User Needs
+            Project - Paper Prototype:
+              name: Project - Paper Prototype
+            Designing Apps for Good:
+              name: Designing Apps for Good
+            Market Research:
+              name: Market Research
+            Paper Prototypes:
+              name: Paper Prototypes
+            Prototype Testing:
+              name: Prototype Testing
+            Digital Design:
+              name: Digital Design
+            Linking Screens:
+              name: Linking Screens
+            Testing the App:
+              name: Testing the App
+            Improving and Iterating:
+              name: Improving and Iterating
+            Project - App Presentation:
+              name: Project - App Presentation
+            Post-Project Test:
+              name: Post-Project Test
+            CS Discoveries Post Course survey:
+              name: CS Discoveries Post Course survey
         csd5-2020:
           title: CSD Unit 5 - Data and Society ('20-'21)
           description: Unit 5 is about the importance of data in solving problems and highlights how computers can help in this process. The first chapter explores different systems used to represent information in a computer and the challenges and tradeoffs posed by using them. In the second chapter you’ll learn how collections of data are used to solve problems, and how computers help to automate the steps of this process. The chapter concludes by considering how the data problem solving process can be applied to an area of your choosing.
@@ -15950,6 +23406,41 @@ en:
               display_name: 'Chapter 2: Solving Data Problems'
             cspSurvey:
               display_name: Survey
+          lessons:
+            Representation Matters:
+              name: Representation Matters
+            Patterns and Representation:
+              name: Patterns and Representation
+            ASCII and Binary Representation:
+              name: ASCII and Binary Representation
+            Representing Images:
+              name: Representing Images
+            Representing Numbers:
+              name: Representing Numbers
+            Keeping Data Secret:
+              name: Keeping Data Secret
+            Combining Representations:
+              name: Combining Representations
+            Project - Create a Representation:
+              name: Project - Create a Representation
+            Problem Solving and Data:
+              name: Problem Solving and Data
+            Problem Solving with Big Data:
+              name: Problem Solving with Big Data
+            Structuring Data:
+              name: Structuring Data
+            Making Decisions with Data:
+              name: Making Decisions with Data
+            Interpreting Data:
+              name: Interpreting Data
+            Automating Data Decisions:
+              name: Automating Data Decisions
+            Project - Solve a Data Problem:
+              name: Project - Solve a Data Problem
+            Post-Project Test:
+              name: Post-Project Test
+            CS Discoveries Post Course survey:
+              name: CS Discoveries Post Course survey
         csd6-2020:
           title: CSD Unit 6 - Physical Computing ('20-'21)
           description: Unit 6 explores the role of hardware platforms in computing and how different sensors can provide more effective input and output than the traditional keyboard, mouse, and monitor. Using App Lab and Adafruit’s Circuit Playground, you’ll develop programs that utilize the same hardware inputs and outputs that you see in the smart devices, looking at how a simple rough prototype can lead to a finished product. The unit concludes with a design challenge to use the Circuit Playground as the basis for an innovation of your own design.
@@ -16035,6 +23526,43 @@ en:
               display_name: 'Chapter 2: Building Physical Prototypes'
             cspSurvey:
               display_name: Survey
+          lessons:
+            Innovations in Computing:
+              name: Innovations in Computing
+            Designing Screens with Code:
+              name: Designing Screens with Code
+            The Circuit Playground:
+              name: The Circuit Playground
+            Input Unplugged:
+              name: Input Unplugged
+            Board Events:
+              name: Board Events
+            Getting Properties:
+              name: Getting Properties
+            Analog Input:
+              name: Analog Input
+            The Program Design Process:
+              name: The Program Design Process
+            'Project: Make a Game':
+              name: 'Project: Make a Game'
+            Arrays and Color LEDs:
+              name: Arrays and Color LEDs
+            Making Music:
+              name: Making Music
+            Arrays and For Loops:
+              name: Arrays and For Loops
+            Accelerometer:
+              name: Accelerometer
+            Functions with Parameters:
+              name: Functions with Parameters
+            Circuits and Physical Prototypes:
+              name: Circuits and Physical Prototypes
+            'Project: Prototype an Innovation':
+              name: 'Project: Prototype an Innovation'
+            Post-Project Test:
+              name: Post-Project Test
+            CS Discoveries Post Course survey:
+              name: CS Discoveries Post Course survey
         csd3-2020:
           title: CSD Unit 3 - Animations and Games
           description: " In Unit 3, you’ll build on your coding experience as you program animations, interactive art, and games in Game Lab. The unit starts off with simple shapes and builds up to more sophisticated sprite-based games, using the same programming concepts and the design process computer scientists use daily. In the final project, you’ll develop a personalized, interactive program."
@@ -16193,9 +23721,69 @@ en:
               display_name: 'Chapter 2: Building Games'
             cspSurvey:
               display_name: Survey
+          lessons:
+            Programming for Entertainment:
+              name: Programming for Entertainment
+            Plotting Shapes:
+              name: Plotting Shapes
+            Drawing in Game Lab:
+              name: Drawing in Game Lab
+            Shapes and Parameters:
+              name: Shapes and Parameters
+            Variables:
+              name: Variables
+            Random Numbers:
+              name: Random Numbers
+            Sprites and Animations:
+              name: Sprites and Animations
+            Sprite Properties:
+              name: Sprite Properties
+            Text:
+              name: Text
+            'Mini-Project: Captioned Scenes':
+              name: 'Mini-Project: Captioned Scenes'
+            The Draw Loop:
+              name: The Draw Loop
+            Sprite Movement:
+              name: Sprite Movement
+            'Mini-Project: Animation':
+              name: 'Mini-Project: Animation'
+            Conditionals:
+              name: Conditionals
+            Keyboard Input:
+              name: Keyboard Input
+            Mouse Input:
+              name: Mouse Input
+            Project - Interactive Card:
+              name: Project - Interactive Card
+            Velocity:
+              name: Velocity
+            Collision Detection:
+              name: Collision Detection
+            'Mini-Project: Side Scroller':
+              name: 'Mini-Project: Side Scroller'
+            Complex Sprite Movement:
+              name: Complex Sprite Movement
+            Collisions:
+              name: Collisions
+            'Mini-Project: Flyer Game':
+              name: 'Mini-Project: Flyer Game'
+            Functions:
+              name: Functions
+            The Game Design Process:
+              name: The Game Design Process
+            Using the Game Design Process:
+              name: Using the Game Design Process
+            Project - Design a Game:
+              name: Project - Design a Game
+            Post-Project Test:
+              name: Post-Project Test
+            CS Discoveries Post Course survey:
+              name: CS Discoveries Post Course survey
         moneppo-1:
           stages: {}
           lesson_groups: {}
+          lessons: {}
         coursea-2020:
           title: Course A (2020)
           description: Learn the basics of computer science and internet safety. At the end of the course, create your very own game or story you can share.
@@ -16261,6 +23849,31 @@ en:
               display_name: Loops
             csf_events:
               display_name: Events
+          lessons:
+            Safety in My Online Neighborhood:
+              name: Safety in My Online Neighborhood
+            Learn to Drag and Drop:
+              name: Learn to Drag and Drop
+            'Programming: Happy Maps':
+              name: 'Programming: Happy Maps'
+            Sequencing with Scrat:
+              name: Sequencing with Scrat
+            Programming in Ice Age:
+              name: Programming in Ice Age
+            Programming with Rey and BB-8:
+              name: Programming with Rey and BB-8
+            'Loops: Happy Loops':
+              name: 'Loops: Happy Loops'
+            Loops in Ice Age:
+              name: Loops in Ice Age
+            Loops in Collector:
+              name: Loops in Collector
+            Ocean Scene with Loops:
+              name: Ocean Scene with Loops
+            'Events: The Big Event':
+              name: 'Events: The Big Event'
+            Events in Play Lab:
+              name: Events in Play Lab
         courseb-2020:
           title: Course B (2020)
           description: Learn the basics of computer science and internet safety. At the end of the course, create your very own game or story you can share.
@@ -16328,6 +23941,31 @@ en:
               display_name: Impacts of Computing
             csf_events:
               display_name: Events
+          lessons:
+            Digital Trails:
+              name: Digital Trails
+            Move It, Move It:
+              name: Move It, Move It
+            Sequencing in Maze:
+              name: Sequencing in Maze
+            Programming in Maze:
+              name: Programming in Maze
+            Programming in Harvester:
+              name: Programming in Harvester
+            'Loops: Getting Loopy':
+              name: 'Loops: Getting Loopy'
+            Loops in Harvester:
+              name: Loops in Harvester
+            Loops in Collector:
+              name: Loops in Collector
+            Loops in Artist:
+              name: Loops in Artist
+            The Right App:
+              name: The Right App
+            'Events: The Big Event':
+              name: 'Events: The Big Event'
+            Events in Play Lab:
+              name: Events in Play Lab
         coursec-2020:
           title: Course C (2020)
           description: Create programs with sequencing, loops, and events. Translate your initials into binary, investigate different problem-solving techniques, and learn how to respond to cyberbullying. At the end of the course, create your very own game or story you can share!
@@ -16425,6 +24063,43 @@ en:
               display_name: Data
             end_of_course_project:
               display_name: End of Course Project
+          lessons:
+            Putting a STOP to Online Meanness:
+              name: Putting a STOP to Online Meanness
+            Password Power-Up:
+              name: Password Power-Up
+            'Programming: My Robotic Friends':
+              name: 'Programming: My Robotic Friends'
+            Programming in Maze:
+              name: Programming in Maze
+            Debugging in Maze:
+              name: Debugging in Maze
+            Programming in Collector:
+              name: Programming in Collector
+            Programming in Artist:
+              name: Programming in Artist
+            Binary Bracelets:
+              name: Binary Bracelets
+            'Loops: My Loopy Robotic Friends':
+              name: 'Loops: My Loopy Robotic Friends'
+            Loops with Rey and BB-8:
+              name: Loops with Rey and BB-8
+            Loops in Harvester:
+              name: Loops in Harvester
+            Looking Ahead:
+              name: Looking Ahead
+            Sticker Art with Loops:
+              name: Sticker Art with Loops
+            'Events: The Big Event':
+              name: 'Events: The Big Event'
+            Build a Flappy Game:
+              name: Build a Flappy Game
+            Events in Play Lab:
+              name: Events in Play Lab
+            Picturing Data:
+              name: Picturing Data
+            'End of Course Project: Create a Play Lab Game':
+              name: 'End of Course Project: Create a Play Lab Game'
         coursed-2020:
           title: Course D (2020)
           description: Students develop their understanding of loops, conditionals, and events. Beyond coding, students learn about digital citizenship.
@@ -16524,6 +24199,45 @@ en:
               display_name: Digital Citizenship
             end_of_course_project:
               display_name: End of Course Project
+          lessons:
+            'Algorithms: Graph Paper Programming':
+              name: 'Algorithms: Graph Paper Programming'
+            Introduction to Online Puzzles:
+              name: Introduction to Online Puzzles
+            Relay Programming:
+              name: Relay Programming
+            Debugging in Collector:
+              name: Debugging in Collector
+            Events in Bounce:
+              name: Events in Bounce
+            Build a Star Wars Game:
+              name: Build a Star Wars Game
+            Dance Party:
+              name: Dance Party
+            Loops in Ice Age:
+              name: Loops in Ice Age
+            Loops in Artist:
+              name: Loops in Artist
+            Nested Loops in Bee:
+              name: Nested Loops in Bee
+            Conditionals with Cards:
+              name: Conditionals with Cards
+            Conditionals in Bee:
+              name: Conditionals in Bee
+            While Loops in Farmer:
+              name: While Loops in Farmer
+            Until Loops in Maze:
+              name: Until Loops in Maze
+            Conditionals & Loops in Harvester:
+              name: Conditionals & Loops in Harvester
+            'Unplugged: Binary':
+              name: 'Unplugged: Binary'
+            Artist Binary:
+              name: Artist Binary
+            Be A Super Digital Citizen:
+              name: Be A Super Digital Citizen
+            End of Course Project:
+              name: End of Course Project
         coursee-2020:
           title: Course E (2020)
           description: Start coding with algorithms, loops, conditionals, and events and then you’ll move on functions. In the second part of this course, design and create a capstone project you can share with your friends and family.
@@ -16621,6 +24335,45 @@ en:
               display_name: Impacts of Computing
             end_of_course_project:
               display_name: End of Course Project
+          lessons:
+            Sequencing in the Maze:
+              name: Sequencing in the Maze
+            Programming and Loops with the Artist:
+              name: Programming and Loops with the Artist
+            'Conditionals in Minecraft: Voyage Aquatic':
+              name: 'Conditionals in Minecraft: Voyage Aquatic'
+            Conditionals:
+              name: Conditionals
+            Simon Says:
+              name: Simon Says
+            Learning Sprites with Sprite Lab:
+              name: Learning Sprites with Sprite Lab
+            Alien Dance Party with Sprite Lab:
+              name: Alien Dance Party with Sprite Lab
+            Private and Personal Information:
+              name: Private and Personal Information
+            About Me:
+              name: About Me
+            Digital Sharing:
+              name: Digital Sharing
+            Nested Loops in Bee:
+              name: Nested Loops in Bee
+            Nested Loops in Artist:
+              name: Nested Loops in Artist
+            Nested Loops in Frozen:
+              name: Nested Loops in Frozen
+            'Functions: Songwriting':
+              name: 'Functions: Songwriting'
+            Functions in Minecraft:
+              name: Functions in Minecraft
+            Functions in Harvester:
+              name: Functions in Harvester
+            Functions in Artist:
+              name: Functions in Artist
+            Designing for Accessibility:
+              name: Designing for Accessibility
+            End of Course Project:
+              name: End of Course Project
         coursef-2020:
           title: Course F (2020)
           description: Learn to use different kinds of loops, events, functions, and conditionals. Investigate different problem-solving techniques and discuss societal impacts of computing and the internet. In the second part of this course, design and create a capstone project you can share with friends and family.
@@ -16724,6 +24477,45 @@ en:
               display_name: Sprites
             end_of_course_project:
               display_name: End of Course Project
+          lessons:
+            Functions in Minecraft:
+              name: Functions in Minecraft
+            Learning Sprites with Sprite Lab:
+              name: Learning Sprites with Sprite Lab
+            Events with Sprite Lab:
+              name: Events with Sprite Lab
+            Loops with the Artist:
+              name: Loops with the Artist
+            Nested Loops in the Maze:
+              name: Nested Loops in the Maze
+            The Power of Words:
+              name: The Power of Words
+            Envelope Variables:
+              name: Envelope Variables
+            Variables as Constant in Artist:
+              name: Variables as Constant in Artist
+            Variables that Change in Bee:
+              name: Variables that Change in Bee
+            Variables that Change in Artist:
+              name: Variables that Change in Artist
+            Simulating Experiments:
+              name: Simulating Experiments
+            AI for Oceans:
+              name: AI for Oceans
+            Internet:
+              name: Internet
+            For Loop Fun:
+              name: For Loop Fun
+            For Loops in Bee:
+              name: For Loops in Bee
+            For Loops in Artist:
+              name: For Loops in Artist
+            Editing Behaviors:
+              name: Editing Behaviors
+            Virtual Pet:
+              name: Virtual Pet
+            End of Course Project:
+              name: End of Course Project
         express-2020:
           title: Express Course (2020)
           description: Learn computer science by trying the lessons below at your own pace! Learn to create computer programs, develop problem-solving skills, and work through fun challenges! Make games and creative projects to share with friends, family, and teachers.
@@ -16859,6 +24651,63 @@ en:
               display_name: For Loops
             csf_sprites:
               display_name: Sprites
+          lessons:
+            Dance Party:
+              name: Dance Party
+            Programming in Maze:
+              name: Programming in Maze
+            Debugging in Maze:
+              name: Debugging in Maze
+            Programming in Collector:
+              name: Programming in Collector
+            Programming in Artist:
+              name: Programming in Artist
+            Loops with Rey and BB-8:
+              name: Loops with Rey and BB-8
+            Loops in Artist:
+              name: Loops in Artist
+            Nested Loops in Bee:
+              name: Nested Loops in Bee
+            Nested Loops in Frozen:
+              name: Nested Loops in Frozen
+            'Concept Practice with Minecraft ':
+              name: 'Concept Practice with Minecraft '
+            Conditionals in Bee:
+              name: Conditionals in Bee
+            While Loops in Farmer:
+              name: While Loops in Farmer
+            'Conditionals in Minecraft: Voyage Aquatic':
+              name: 'Conditionals in Minecraft: Voyage Aquatic'
+            Until Loops in Maze:
+              name: Until Loops in Maze
+            Conditionals & Loops in Harvester:
+              name: Conditionals & Loops in Harvester
+            Functions in Minecraft:
+              name: Functions in Minecraft
+            Functions in Harvester:
+              name: Functions in Harvester
+            Functions in Artist:
+              name: Functions in Artist
+            Variables as Constant in Artist:
+              name: Variables as Constant in Artist
+            Variables that Change in Bee:
+              name: Variables that Change in Bee
+            Variables that Change in Artist:
+              name: Variables that Change in Artist
+            For Loops in Bee:
+              name: For Loops in Bee
+            For Loops in Artist:
+              name: For Loops in Artist
+            Learning Sprites with Sprite Lab:
+              name: Learning Sprites with Sprite Lab
+            Alien Dance Party with Sprite Lab:
+              name: Alien Dance Party with Sprite Lab
+            Editing Behaviors:
+              name: Editing Behaviors
+            Virtual Pet with Sprite Lab:
+              name: Virtual Pet with Sprite Lab
+            Build A Project:
+              name: Build A Project
         pre-express-2020:
           title: Pre-reader Express (2020)
           description: Learn computer science by trying the lessons below at your own pace! Learn to create computer programs, develop problem-solving skills, and work through fun challenges! Make games and creative projects to share with friends, family, and teachers.
@@ -16920,6 +24769,31 @@ en:
               display_name: Loops
             csf_events:
               display_name: Events
+          lessons:
+            Learn to Drag and Drop:
+              name: Learn to Drag and Drop
+            Sequencing with Scrat:
+              name: Sequencing with Scrat
+            Programming in Maze:
+              name: Programming in Maze
+            Programming with Rey and BB-8:
+              name: Programming with Rey and BB-8
+            Programming in Harvester:
+              name: Programming in Harvester
+            Spelling Bee:
+              name: Spelling Bee
+            Loops in Ice Age:
+              name: Loops in Ice Age
+            Loops in Collector:
+              name: Loops in Collector
+            Ocean Scene with Loops:
+              name: Ocean Scene with Loops
+            Loops in Artist:
+              name: Loops in Artist
+            Tell a Story in Play Lab:
+              name: Tell a Story in Play Lab
+            Make a Game in Play Lab:
+              name: Make a Game in Play Lab
         csp1-2020:
           stages:
             new stage:
@@ -16959,6 +24833,35 @@ en:
           lesson_groups:
             csp_unit1_2020:
               display_name: 'Unit 1: Digital Information'
+          lessons:
+            Welcome to CSP:
+              name: Welcome to CSP
+            Representing Information:
+              name: Representing Information
+            Circle Square Patterns:
+              name: Circle Square Patterns
+            Binary Numbers:
+              name: Binary Numbers
+            Overflow and Rounding:
+              name: Overflow and Rounding
+            Representing Text:
+              name: Representing Text
+            Black and White Images:
+              name: Black and White Images
+            Color Images:
+              name: Color Images
+            Lossless Compression:
+              name: Lossless Compression
+            Lossy Compression:
+              name: Lossy Compression
+            Intellectual Property:
+              name: Intellectual Property
+            Project - Digital Information Dilemmas Part 1:
+              name: Project - Digital Information Dilemmas Part 1
+            Project - Digital Information Dilemmas Part 2:
+              name: Project - Digital Information Dilemmas Part 2
+            'Lesson 14: Assessment Day':
+              name: 'Lesson 14: Assessment Day'
         csp2-2020:
           stages:
             new stage:
@@ -16988,6 +24891,25 @@ en:
           lesson_groups:
             csp_unit2_2020:
               display_name: 'Unit 2: The Internet'
+          lessons:
+            Welcome to the Internet:
+              name: Welcome to the Internet
+            Building a Network:
+              name: Building a Network
+            The Need for Addressing:
+              name: The Need for Addressing
+            Routers and Redundancy:
+              name: Routers and Redundancy
+            Packets:
+              name: Packets
+            DNS and HTTP:
+              name: DNS and HTTP
+            Project - Internet Dilemmas Part 1:
+              name: Project - Internet Dilemmas Part 1
+            Project - Internet Dilemmas Part 2:
+              name: Project - Internet Dilemmas Part 2
+            'Lesson 9: Assessment Day':
+              name: 'Lesson 9: Assessment Day'
         csp3-2020:
           stages:
             new stage:
@@ -17021,6 +24943,29 @@ en:
           lesson_groups:
             csp_unit3_2020:
               display_name: 'Unit 3: Intro to App Design'
+          lessons:
+            Introduction to Apps:
+              name: Introduction to Apps
+            Introduction to Design Mode:
+              name: Introduction to Design Mode
+            Project - Designing an App Part 1:
+              name: Project - Designing an App Part 1
+            Project - Designing an App Part 2:
+              name: Project - Designing an App Part 2
+            The Need for Programming Languages:
+              name: The Need for Programming Languages
+            Intro to Programming:
+              name: Intro to Programming
+            Debugging:
+              name: Debugging
+            Project - Designing an App Part 3:
+              name: Project - Designing an App Part 3
+            Project - Designing an App Part 4:
+              name: Project - Designing an App Part 4
+            Project - Designing an App Part 5:
+              name: Project - Designing an App Part 5
+            'Lesson 11: Assessment Day':
+              name: 'Lesson 11: Assessment Day'
         csp6-2020:
           stages:
             new stage:
@@ -17044,6 +24989,19 @@ en:
           lesson_groups:
             csp_unit6_2020:
               display_name: 'Unit 6: Algorithms'
+          lessons:
+            Algorithms Solve Problems:
+              name: Algorithms Solve Problems
+            Algorithm Efficiency:
+              name: Algorithm Efficiency
+            Unreasonable Time:
+              name: Unreasonable Time
+            The Limits of Algorithms:
+              name: The Limits of Algorithms
+            Parallel and Distributed Algorithms:
+              name: Parallel and Distributed Algorithms
+            'Lesson 6: Assessment Day':
+              name: 'Lesson 6: Assessment Day'
         csp8-2020:
           stages:
             new stage:
@@ -17059,6 +25017,7 @@ en:
           description_short: Practice and complete the Create Performance Task (PT).
           description: "In this unit prepare for, and do the AP Create Performance Task. Each lesson contains links to helpful documents and activities to help you understand the task and develop a plan for completing it.\r\n\r\n"
           lesson_groups: {}
+          lessons: {}
         csp9-2020:
           stages:
             new stage:
@@ -17088,6 +25047,25 @@ en:
           lesson_groups:
             csp_unit9_2020:
               display_name: 'Unit 9: Data'
+          lessons:
+            Learning From Data:
+              name: Learning From Data
+            Exploring One Column:
+              name: Exploring One Column
+            Filtering and Cleaning Data:
+              name: Filtering and Cleaning Data
+            Exploring Two Columns:
+              name: Exploring Two Columns
+            Big Data, Crowdsourcing, and Machine Learning:
+              name: Big Data, Crowdsourcing, and Machine Learning
+            Machine Learning and Bias:
+              name: Machine Learning and Bias
+            Project - Tell a Data Story - Part 1:
+              name: Project - Tell a Data Story - Part 1
+            Project - Tell a Data Story - Part 2:
+              name: Project - Tell a Data Story - Part 2
+            'Lesson 9: Assessment Day':
+              name: 'Lesson 9: Assessment Day'
         csp10-2020:
           stages:
             new stage:
@@ -17133,6 +25111,35 @@ en:
           lesson_groups:
             csp_unit10_2020:
               display_name: 'Unit 10: Cybersecurity and Global Impacts'
+          lessons:
+            Project - Innovation Simulation Part 1:
+              name: Project - Innovation Simulation Part 1
+            Project - Innovation Simulation Part 2:
+              name: Project - Innovation Simulation Part 2
+            Data Policies and Privacy:
+              name: Data Policies and Privacy
+            The Value of Privacy:
+              name: The Value of Privacy
+            Project - Innovation Simulation Part 3:
+              name: Project - Innovation Simulation Part 3
+            Security Risks Part 1:
+              name: Security Risks Part 1
+            Security Risks Part 2:
+              name: Security Risks Part 2
+            'Project: Innovation Simulation Part 4':
+              name: 'Project: Innovation Simulation Part 4'
+            Protecting Data Part 1:
+              name: Protecting Data Part 1
+            Protecting Data Part 2:
+              name: Protecting Data Part 2
+            'Project: Innovation Simulation Part 5':
+              name: 'Project: Innovation Simulation Part 5'
+            'Project: Innovation Simulation Part 6':
+              name: 'Project: Innovation Simulation Part 6'
+            'Project: Innovation Simulation Part 7':
+              name: 'Project: Innovation Simulation Part 7'
+            'Lesson 14: Unit Assessment Day':
+              name: 'Lesson 14: Unit Assessment Day'
         csp-march-virtual:
           stages:
             Kick-off:
@@ -17166,6 +25173,13 @@ en:
           description_short: ''
           description: Welcome to the CSP Facilitator Pre-work for the April call! This will be focused on deepening the understanding of EIPM, content in Unit 5, and the new datasets available in the course. This work is essential to completing before the April call since we will be processing and discussing the work together in the call.
           lesson_groups: {}
+          lessons:
+            Saturday Session Resources:
+              name: Saturday Session Resources
+            Getting Familiar with Traversals EIPM:
+              name: Getting Familiar with Traversals EIPM
+            Comparing Make Lessons:
+              name: Comparing Make Lessons
         csp3-virtual:
           title: Self Paced Introduction to Turtle Programming In App Lab
           description: This unit introduces the foundational concepts of computer programming, which unlocks the ability to make rich, interactive apps. This course uses JavaScript as the programming language, and App Lab as the programming environment to build apps, but the concepts learned in these lessons span all programming languages and tools.
@@ -17225,6 +25239,19 @@ en:
           lesson_groups:
             csp3_1_2018:
               display_name: 'Unit 3: Intro to Programming'
+          lessons:
+            Using Simple Commands:
+              name: Using Simple Commands
+            Creating Functions:
+              name: Creating Functions
+            APIs and Function Parameters:
+              name: APIs and Function Parameters
+            Creating functions with Parameters:
+              name: Creating functions with Parameters
+            Looping and Random Numbers:
+              name: Looping and Random Numbers
+            Make your own Digital Scene:
+              name: Make your own Digital Scene
         csd3-virtual:
           title: Self Paced Introduction to Game Lab
           description: You’ll program animations, interactive art, and games in Game Lab. The unit starts off with simple shapes and builds up to more sophisticated sprite-based games, using the same programming concepts and the design process computer scientists use daily. In the final project, you’ll develop a personalized, interactive program.
@@ -17357,6 +25384,35 @@ en:
           lesson_groups:
             csd3_1:
               display_name: 'Chapter 1: Images and Animations'
+          lessons:
+            Sample Programs:
+              name: Sample Programs
+            Drawing in Game Lab:
+              name: Drawing in Game Lab
+            Shapes and Parameters:
+              name: Shapes and Parameters
+            Variables:
+              name: Variables
+            Random Numbers:
+              name: Random Numbers
+            Sprites and Animations:
+              name: Sprites and Animations
+            Sprite Properties:
+              name: Sprite Properties
+            Text and Captioned Scenes:
+              name: Text and Captioned Scenes
+            The Draw Loop:
+              name: The Draw Loop
+            Sprite Movement:
+              name: Sprite Movement
+            Conditionals:
+              name: Conditionals
+            Keyboard Input:
+              name: Keyboard Input
+            Other Forms of Input:
+              name: Other Forms of Input
+            Project - Interactive Card:
+              name: Project - Interactive Card
         jess-test-script:
           stages:
             Our First Stage:
@@ -17382,6 +25438,15 @@ en:
           description_short: ''
           description: ''
           lesson_groups: {}
+          lessons:
+            Welcome to CSD Virtual Professional Learning:
+              name: Welcome to CSD Virtual Professional Learning
+            Introduction to CSD:
+              name: Introduction to CSD
+            Course Resources:
+              name: Course Resources
+            Debugging:
+              name: Debugging
         csd2-virtual:
           title: Self Paced Introduction to Web Lab
           description: You’ll learn how to create and share the content on your own web pages. After deciding what content you want to share with the world, you’ll learn how to structure and style your pages using HTML and CSS. You’ll also practice valuable programming skills such as debugging and commenting.  By the end of the unit, you’ll have a personal website that you can publish to the Internet.
@@ -17479,6 +25544,33 @@ en:
               display_name: 'Chapter 1: Web Content and HTML'
             csd2_2:
               display_name: 'Chapter 2: Styling and CSS'
+          lessons:
+            Exploring Web Pages:
+              name: Exploring Web Pages
+            Intro to HTML:
+              name: Intro to HTML
+            Headings:
+              name: Headings
+            Styling Text with CSS:
+              name: Styling Text with CSS
+            Images:
+              name: Images
+            'Websites for Expression ':
+              name: 'Websites for Expression '
+            Styling Elements with CSS:
+              name: Styling Elements with CSS
+            Project - Building a Webpage:
+              name: Project - Building a Webpage
+            Purpose of a Websites:
+              name: Purpose of a Websites
+            CSS Classes:
+              name: CSS Classes
+            Linking and Navigation:
+              name: Linking and Navigation
+            Project - Website for a Purpose:
+              name: Project - Website for a Purpose
+            Peer Review and Final Touches:
+              name: Peer Review and Final Touches
         csp5-virtual:
           title: Event-Driven Programming in App Lab
           description: This self-paced module introduces foundational concepts of computer programming, which unlocks the ability to make rich, interactive apps. This unit uses JavaScript as the programming language, and App Lab as the programming environment to build apps, but the concepts learned in these lessons span all programming languages and tools.
@@ -17592,6 +25684,29 @@ en:
             Keep Going!:
               name: Keep Going!
           lesson_groups: {}
+          lessons:
+            Intro to App Lab:
+              name: Intro to App Lab
+            Buttons and Events:
+              name: Buttons and Events
+            Multi-screen Apps:
+              name: Multi-screen Apps
+            Variables:
+              name: Variables
+            'Building an App: Clicker Game':
+              name: 'Building an App: Clicker Game'
+            If-Statements:
+              name: If-Statements
+            User Input and Strings:
+              name: User Input and Strings
+            Boolean Expressions and "If" Statements:
+              name: Boolean Expressions and "If" Statements
+            '"if-else-if" and Conditional Logic':
+              name: '"if-else-if" and Conditional Logic'
+            'Building an App: Color Sleuth':
+              name: 'Building an App: Color Sleuth'
+            Keep Going!:
+              name: Keep Going!
         virtual-holding-place:
           stages:
             Example Projects:
@@ -17621,6 +25736,25 @@ en:
               display_name: Content
             csd3_2:
               display_name: 'Chapter 2: Building Games'
+          lessons:
+            Example Projects:
+              name: Example Projects
+            Velocity:
+              name: Velocity
+            Collision Detection:
+              name: Collision Detection
+            Complex Sprite Movement:
+              name: Complex Sprite Movement
+            Collisions:
+              name: Collisions
+            Functions:
+              name: Functions
+            The Game Design Process:
+              name: The Game Design Process
+            Using the Game Design Process:
+              name: Using the Game Design Process
+            Project - Design a Game:
+              name: Project - Design a Game
         code-break:
           stages:
             new stage:
@@ -17674,6 +25808,25 @@ en:
           description_short: ''
           description: 'With schools closed and tens of millions of students at home, Code.org is launching Code Break — a live weekly interactive classroom where our team will teach your children at home while school is closed, and a weekly challenge to engage students of all abilities, even those without computers. More info at Code.org/break. Ages 13+. '
           lesson_groups: {}
+          lessons:
+            Episode 1 - Algorithms with Hill Harper:
+              name: Episode 1 - Algorithms with Hill Harper
+            Episode 2 - Prototypes with Mark Cuban & Lyndsey Scott:
+              name: Episode 2 - Prototypes with Mark Cuban & Lyndsey Scott
+            Episode 3 - Encryption with Ashton Kutcher & Mia Gil Epner:
+              name: Episode 3 - Encryption with Ashton Kutcher & Mia Gil Epner
+            Episode 4 - Digital Information with Mike Krieger & Alice Keeler:
+              name: Episode 4 - Digital Information with Mike Krieger & Alice Keeler
+            Episode 5 - Simulations & Data with Bill Gates:
+              name: Episode 5 - Simulations & Data with Bill Gates
+            The Internet with Keegan-Michael Key & Vint Cerf:
+              name: The Internet with Keegan-Michael Key & Vint Cerf
+            Conditionals with Sal Khan & Flo Vaughn:
+              name: Conditionals with Sal Khan & Flo Vaughn
+            Variables with Yara Shahidi & Fuzzy Khosrowshahi:
+              name: Variables with Yara Shahidi & Fuzzy Khosrowshahi
+            Events with Macklemore & Scott Forstall:
+              name: Events with Macklemore & Scott Forstall
         code-break-staging:
           stages:
             Episode 2 - Building Things with Mark Cuban & Lyndsey Scott:
@@ -17721,6 +25874,25 @@ en:
           description_short: ''
           description: ''
           lesson_groups: {}
+          lessons:
+            Algorithms with Hill Harper:
+              name: Algorithms with Hill Harper
+            Prototypes with Mark Cuban & Lyndsey Scott:
+              name: Prototypes with Mark Cuban & Lyndsey Scott
+            Encryption with Ashton Kutcher & Mia Gil Epner:
+              name: Encryption with Ashton Kutcher & Mia Gil Epner
+            Digital Information with Mike Krieger & Alice Keeler:
+              name: Digital Information with Mike Krieger & Alice Keeler
+            Simulations & Data with Bill Gates:
+              name: Simulations & Data with Bill Gates
+            The Internet with Keegan-Michael Key & Vint Cerf:
+              name: The Internet with Keegan-Michael Key & Vint Cerf
+            Conditionals with Sal Khan & Flo Vaughn:
+              name: Conditionals with Sal Khan & Flo Vaughn
+            Variables with Yara Shahidi & Fuzzy Khosrowshahi:
+              name: Variables with Yara Shahidi & Fuzzy Khosrowshahi
+            Events with Macklemore & Scott Forstall:
+              name: Events with Macklemore & Scott Forstall
         code-break-younger-staging:
           stages:
             Episode 1 - Algorithms with Hill Harper:
@@ -17750,6 +25922,25 @@ en:
           description_short: ''
           description: ''
           lesson_groups: {}
+          lessons:
+            Episode 1 - Algorithms with Hill Harper:
+              name: Episode 1 - Algorithms with Hill Harper
+            Episode 2 - Prototypes with Mark Cuban & Lyndsey Scott:
+              name: Episode 2 - Prototypes with Mark Cuban & Lyndsey Scott
+            Episode 3 - Encryption with Ashton Kutcher & Mia Gil Epner:
+              name: Episode 3 - Encryption with Ashton Kutcher & Mia Gil Epner
+            Episode 4 - Digital Information with Mike Krieger & Alice Keeler:
+              name: Episode 4 - Digital Information with Mike Krieger & Alice Keeler
+            Episode 5 - Simulations & Data with Bill Gates:
+              name: Episode 5 - Simulations & Data with Bill Gates
+            The Internet with Keegan-Michael Key & Vint Cerf:
+              name: The Internet with Keegan-Michael Key & Vint Cerf
+            Conditionals with Sal Khan and Flo Vaughn:
+              name: Conditionals with Sal Khan and Flo Vaughn
+            Variables with Yara Shahidi & Fuzzy Khosrowshahi:
+              name: Variables with Yara Shahidi & Fuzzy Khosrowshahi
+            Events with Macklemore & Scott Forstall:
+              name: Events with Macklemore & Scott Forstall
         code-break-younger:
           stages:
             Episode 1 - Algorithms with Hill Harper:
@@ -17781,6 +25972,25 @@ en:
           description_short: ''
           description: 'With schools closed and tens of millions of students at home, Code.org is launching Code Break — a live weekly interactive classroom where our team will teach your children at home while school is closed, and a weekly challenge to engage students of all abilities, even those without computers. More info at Code.org/break. Ages 6-12. '
           lesson_groups: {}
+          lessons:
+            Episode 1 - Algorithms with Hill Harper:
+              name: Episode 1 - Algorithms with Hill Harper
+            Episode 2 - Prototypes with Mark Cuban & Lyndsey Scott:
+              name: Episode 2 - Prototypes with Mark Cuban & Lyndsey Scott
+            Episode 3 - Encryption with Ashton Kutcher & Mia Gil Epner:
+              name: Episode 3 - Encryption with Ashton Kutcher & Mia Gil Epner
+            Episode 4 - Digital Information with Mike Krieger & Alice Keeler:
+              name: Episode 4 - Digital Information with Mike Krieger & Alice Keeler
+            Episode 5 - Simulations & Data with Bill Gates:
+              name: Episode 5 - Simulations & Data with Bill Gates
+            The Internet with Keegan-Michael Key & Vint Cerf:
+              name: The Internet with Keegan-Michael Key & Vint Cerf
+            Conditionals with Sal Khan and Flo Vaughn:
+              name: Conditionals with Sal Khan and Flo Vaughn
+            Variables with Yara Shahidi & Fuzzy Khosrowshahi:
+              name: Variables with Yara Shahidi & Fuzzy Khosrowshahi
+            Events with Macklemore & Scott Forstall:
+              name: Events with Macklemore & Scott Forstall
         no-lg:
           stages:
             new stage:
@@ -17822,3 +26032,26 @@ en:
               display_name: 'Chapter 1: Event-Driven Programming'
             csp5_2:
               display_name: 'Chapter 2: Programming with Data Structures'
+          lessons:
+            Unit 5 Assessment 2:
+              name: Unit 5 Assessment 2
+            While Loops:
+              name: While Loops
+            Loops and Simulations:
+              name: Loops and Simulations
+            Introduction to Arrays:
+              name: Introduction to Arrays
+            'Building an App: Image Scroller':
+              name: 'Building an App: Image Scroller'
+            Unit 5 Assessment 3:
+              name: Unit 5 Assessment 3
+            Processing Arrays:
+              name: Processing Arrays
+            Functions with Return Values:
+              name: Functions with Return Values
+            'Building an App: Canvas Painter':
+              name: 'Building an App: Canvas Painter'
+            Unit 5 Assessment 4:
+              name: Unit 5 Assessment 4
+            Unit 5 Assessment 5 - AP Pseudocode Practice Questions:
+              name: Unit 5 Assessment 5 - AP Pseudocode Practice Questions

--- a/dashboard/test/dsl/script_dsl_test.rb
+++ b/dashboard/test/dsl/script_dsl_test.rb
@@ -72,10 +72,20 @@ class ScriptDslTest < ActiveSupport::TestCase
       }
     )
 
-    i18n_expected = {'test' => {'stages' => {
-      'Lesson1' => {'name' => 'Lesson1'},
-      'Lesson2' => {'name' => 'Lesson2'}
-    }, "lesson_groups" => {}}}
+    # TODO: FND-1122
+    i18n_expected = {
+      'test' => {
+        'stages' => {
+          'Lesson1' => {'name' => 'Lesson1'},
+          'Lesson2' => {'name' => 'Lesson2'}
+        },
+        'lessons' => {
+          'Lesson1' => {'name' => 'Lesson1'},
+          'Lesson2' => {'name' => 'Lesson2'}
+        },
+        "lesson_groups" => {}
+      }
+    }
     assert_equal expected, output
     assert_equal i18n_expected, i18n
   end
@@ -859,10 +869,18 @@ level 'Level 3'
       }
     )
 
-    i18n_expected = {'test' => {'stages' => {
-      "Bob's stage" => {'name' => "Bob's stage"}
-    },
-      "lesson_groups" => {}}}
+    # TODO: FND-1122
+    i18n_expected = {
+      'test' => {
+        'stages' => {
+          "Bob's stage" => {'name' => "Bob's stage"}
+        },
+        'lessons' => {
+          "Bob's stage" => {'name' => "Bob's stage"}
+        },
+        "lesson_groups" => {}
+      }
+    }
     assert_equal expected, output
     assert_equal i18n_expected, i18n
   end

--- a/dashboard/test/en.yml
+++ b/dashboard/test/en.yml
@@ -1,4 +1,5 @@
 # Translations file for tests
+# TODO: FND-1122
 en:
   data:
     script:
@@ -9,8 +10,18 @@ en:
               name: report-stage-1
             Report Stage 2:
               name: report-stage-2
+          lessons:
+            Report Stage 1:
+              name: report-stage-1
+            Report Stage 2:
+              name: report-stage-2
         Milestone Script:
           stages:
+            Milestone Stage 1:
+              name: milestone-stage-1
+            Milestone Stage 2:
+              name: milestone-stage-2
+          lessons:
             Milestone Stage 1:
               name: milestone-stage-1
             Milestone Stage 2:
@@ -22,8 +33,18 @@ en:
               name: laurel-stage-1
             Laurel Stage 2:
               name: laurel-stage-2
+          lessons:
+            Laurel Stage 1:
+              name: laurel-stage-1
+            Laurel Stage 2:
+              name: laurel-stage-2
         text-response-script:
           stages:
+            First Stage:
+              name: First Stage
+            Second Stage:
+              name: Second Stage
+          lessons:
             First Stage:
               name: First Stage
             Second Stage:


### PR DESCRIPTION
Overall plan of attack:

1. Add all strings keyed by the term "stage" to crowdin under the key "lesson". (this PR)
2. Wait for a sync; Crowdin will automatically duplicate translations for the new strings
3. Update all I18n.t references currently using the key "stage" to use the new "lesson" translations (https://github.com/code-dot-org/code-dot-org/pull/34878)
4. Remove old "stage" strings now that they are no longer used

<!--
  Your description goes here: A summary of the change, including any relevant motivation and context.

  If relevant, include a description both of the existing behavior and of the new behavior.
-->

<!--
  Other aspects to consider. uncomment and add detail for any that seem necessary:
-->

<!-- ### Background -->
<!-- ### Privacy -->
<!-- ### Security -->
<!-- ### Caching -->
<!-- ### Deployment strategy -->
<!-- ### Future work -->

## Links

<!--
  Any relevant links to external resources; ie, specification documents, jira
  items, related PRs, honeybadger errors, etc
-->

- [jira](https://codedotorg.atlassian.net/browse/FND-1122)

## Testing story

Verified that running a sync-in produces the expected changes; this PR should have no other significant effects

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
