### PR TITLE
Recruitment: fix links on banners

### DIFF
--- a/apps/src/templates/ProfessionalLearningApplyBanner.jsx
+++ b/apps/src/templates/ProfessionalLearningApplyBanner.jsx
@@ -113,7 +113,7 @@ class ProfessionalLearningApplyBanner extends React.Component {
   };
 
   generateLink() {
-    let link = '/educate/professional-learning/middle-high';
+    let link = '/educate/professional-learning';
     if (this.props.linkSuffix) {
       link = `${link}/${this.props.linkSuffix}`;
     }

--- a/apps/src/templates/census2017/YourSchool.jsx
+++ b/apps/src/templates/census2017/YourSchool.jsx
@@ -128,6 +128,7 @@ class YourSchool extends Component {
           nominated={false}
           useSignUpText={true}
           style={styles.banner}
+          linkSuffix={'middle-high'}
         />
         <YourSchoolResources />
         {!this.props.hideMap && (


### PR DESCRIPTION
Fix a regression to links on banners made in https://github.com/code-dot-org/code-dot-org/pull/34780, while updating only the banner on https://code.org/yourschool to go directly to https://code.org/educate/professional-learning/middle-high.
