### PR TITLE
Google sheet export cleanup

### DIFF
--- a/bin/cron/summer_workshop_enrollments_to_gdrive
+++ b/bin/cron/summer_workshop_enrollments_to_gdrive
@@ -14,7 +14,7 @@ require 'cdo/google/sheet'
 EARLIEST_WORKSHOP_END_DATE = Date.new(2020, 6, 1)
 LATEST_WORKSHOP_START_DATE = Date.new(2020, 8, 31)
 
-def get_data
+def get_rows
   # Seed results array with a header row
   results = [%w(teacher_email first_name last_name workshop_id
                 workshop_start_date workshop_course regional_partner)]
@@ -46,7 +46,7 @@ end
 
 def main
   sheet = Google::Sheet.new CDO.enrollments_summer_2020_gsheet_key
-  sheet.export(tab_name: 'enrollments', data: get_data)
+  sheet.export(tab_name: 'enrollments', rows: get_rows)
   sheet.notify_of_external_sharing
 end
 

--- a/bin/cron/summer_workshop_enrollments_to_gdrive
+++ b/bin/cron/summer_workshop_enrollments_to_gdrive
@@ -14,7 +14,7 @@ require 'cdo/google/sheet'
 EARLIEST_WORKSHOP_END_DATE = Date.new(2020, 6, 1)
 LATEST_WORKSHOP_START_DATE = Date.new(2020, 8, 31)
 
-def update_tabs(sheet)
+def get_data
   # Seed results array with a header row
   results = [%w(teacher_email first_name last_name workshop_id
                 workshop_start_date workshop_course regional_partner)]
@@ -41,29 +41,13 @@ def update_tabs(sheet)
     ]
   end
 
-  sheet.export(
-    sheet_name: 'enrollments',
-    rows: results
-  )
-end
-
-def notify_of_external_sharing(sheet)
-  external_emails = sheet.external_emails_with_access
-  if external_emails.present?
-    email_domains = external_emails.map {|email| email.slice(/@.*/)}.uniq
-    error_msg = "Document containing PII information is shared to "\
-      "#{external_emails.length} external account(s) at the following domain(s): #{email_domains.join(', ')}. "\
-      "Please check with PLC team that this is intentional!"
-
-    Honeybadger.notify error_msg
-    puts error_msg
-  end
+  results
 end
 
 def main
   sheet = Google::Sheet.new CDO.enrollments_summer_2020_gsheet_key
-  update_tabs(sheet)
-  notify_of_external_sharing(sheet)
+  sheet.export(tab_name: 'enrollments', data: get_data)
+  sheet.notify_of_external_sharing
 end
 
 main

--- a/bin/cron/summer_workshops_to_gdrive
+++ b/bin/cron/summer_workshops_to_gdrive
@@ -3,59 +3,38 @@ require_relative '../../lib/cdo/only_one'
 exit unless only_one_running?(__FILE__)
 
 require_relative '../../dashboard/config/environment'
-require 'cdo/google/drive'
-
-# Squash an unhelpful warning that's causing a Honeybadger error
-# see https://github.com/nahi/httpclient/issues/252#issuecomment-302427338
-class WebAgent
-  class Cookie < HTTP::Cookie
-    def domain
-      original_domain
-    end
-  end
-end
+require 'cdo/google/sheet'
 
 #
 # Uses a Google Cloud service account to write summer workshop data for this year into
 # a spreadsheet in Google Drive (with permissions locked down to our organization) for exploration
 # by our programs team.
 #
+def get_data
+  subjects = [
+    Pd::SharedWorkshopConstants::SUBJECT_SUMMER_WORKSHOP,
+    Pd::SharedWorkshopConstants::SUBJECT_CSF_101,
+    Pd::SharedWorkshopConstants::SUBJECT_CSF_201
+  ]
 
-subjects = [
-  Pd::SharedWorkshopConstants::SUBJECT_SUMMER_WORKSHOP,
-  Pd::SharedWorkshopConstants::SUBJECT_CSF_101,
-  Pd::SharedWorkshopConstants::SUBJECT_CSF_201
-]
+  workshops = []
 
-workshops = []
+  # The first row is an array of strings, one for each attribute name.
+  workshops << Api::V1::Pd::WorkshopDownloadSerializer.new(Pd::Workshop.first).attributes.keys.map(&:to_s)
 
-# The first row is an array of strings, one for each attribute name.
-workshops << Api::V1::Pd::WorkshopDownloadSerializer.new(Pd::Workshop.first).attributes.keys.map(&:to_s)
-
-# Subsequent rows are for each workshop.
-Pd::Workshop.where(subject: subjects).find_each do |w|
-  if w.workshop_starting_date && w.workshop_starting_date >= Date.new(2020, 5, 15) && w.workshop_starting_date <= Date.new(2020, 8, 31)
-    workshops << Api::V1::Pd::WorkshopDownloadSerializer.new(w).attributes.values
+  # Subsequent rows are for each workshop.
+  Pd::Workshop.where(subject: subjects).find_each do |w|
+    if w.workshop_starting_date && w.workshop_starting_date >= Date.new(2020, 5, 15) && w.workshop_starting_date <= Date.new(2020, 8, 31)
+      workshops << Api::V1::Pd::WorkshopDownloadSerializer.new(w).attributes.values
+    end
   end
+
+  workshops
 end
 
-drive = Google::Drive.new service_account_key: StringIO.new(CDO.gdrive_export_secret.to_json)
-drive.update_sheet workshops, CDO.applications_2020_2021_gsheet_key, 'summer_workshops (auto)'
+def main
+  sheet = Google::Sheet.new CDO.applications_2020_2021_gsheet_key
+  sheet.export(tab_name: 'summer_workshops', data: get_data)
+end
 
-# Write another tab with some information
-
-last_updated = DateTime.now.in_time_zone ActiveSupport::TimeZone.new "Pacific Time (US & Canada)"
-metadata = [
-  ['SUMMER WORKSHOPS AUTOMATION METADATA'],
-  [''],
-  ['The tabs "summer_workshops (auto)" and "summer_workshops_meta (auto)" are auto-generated;'],
-  ['Any edits you make to them (besides formatting) may be lost.'],
-  [''],
-  ['Last updated:', last_updated.strftime('%Y-%m-%d %l:%M%P GMT%:::z')],
-  ['Written by:', CDO.gdrive_export_secret.client_email],
-  ['Summer workshops:', workshops.length - 1],
-  [''],
-  ['Parts of this Google Sheet are auto-populated from our live application by an automated process.'],
-  ["The sheet is shared with a \"service account\" that updates it on the application's behalf."],
-]
-drive.update_sheet metadata, CDO.applications_2020_2021_gsheet_key, 'summer_workshops_meta (auto)'
+main

--- a/bin/cron/summer_workshops_to_gdrive
+++ b/bin/cron/summer_workshops_to_gdrive
@@ -10,7 +10,7 @@ require 'cdo/google/sheet'
 # a spreadsheet in Google Drive (with permissions locked down to our organization) for exploration
 # by our programs team.
 #
-def get_data
+def get_rows
   subjects = [
     Pd::SharedWorkshopConstants::SUBJECT_SUMMER_WORKSHOP,
     Pd::SharedWorkshopConstants::SUBJECT_CSF_101,
@@ -34,7 +34,7 @@ end
 
 def main
   sheet = Google::Sheet.new CDO.applications_2020_2021_gsheet_key
-  sheet.export(tab_name: 'summer_workshops', data: get_data)
+  sheet.export(tab_name: 'summer_workshops', rows: get_rows)
 end
 
 main

--- a/bin/cron/teacher_applications_to_gdrive
+++ b/bin/cron/teacher_applications_to_gdrive
@@ -3,14 +3,13 @@ require_relative '../../lib/cdo/only_one'
 exit unless only_one_running?(__FILE__)
 
 require_relative '../../dashboard/config/environment'
-require 'cdo/google/sheets'
+require 'cdo/google/sheet'
 require 'honeybadger/ruby'
 
-# Writes teacher application data for this year into
+# Returns a set of teacher application data to be written to
 # a spreadsheet in Google Drive (with permissions locked down to our organization) for exploration
 # by our programs team.
-def update_tabs(sheet)
-  # Update application sheet
+def get_data
   applications = [%w(course regional_partner status scholarship_status school_type pay_fee email created_at
                      meets_minimum_requirements meets_scholarship_criteria registered_for_workshop rural_status
                      free_reduced_lunch_percent urm_percent accepted_at)]
@@ -46,35 +45,14 @@ def update_tabs(sheet)
     ]
   end
 
-  sheet.export(
-    sheet_name: 'all_apps',
-    rows: applications
-  )
-end
-
-def notify_of_external_sharing(sheet)
-  # List of external emails that we can share this document with.
-  # This list is saved in DCDO as an array. To append a new value to this list:
-  # DCDO.set(key_name, DCDO.get(key_name, []) << new_value)
-  allowed_list = DCDO.get('external_emails_with_application_data_access', [])
-  external_emails = sheet.external_emails_with_access - allowed_list
-
-  if external_emails.present?
-    email_domains = external_emails.map {|email| email.slice(/@.*/)}.uniq
-    error_msg = "Document containing PII information is shared to "\
-      "#{external_emails.length} external account(s) at the following domain(s): #{email_domains.join(', ')}. "\
-      "Please check with PLC team that this is intentional!"
-
-    Honeybadger.notify error_msg
-    puts error_msg
-  end
+  applications
 end
 
 def main
   # Uses a Google Cloud service account to access Google Drive
   sheet = Google::Sheet.new CDO.applications_2020_2021_gsheet_key
-  update_tabs(sheet)
-  notify_of_external_sharing(sheet)
+  sheet.export(sheet_name: 'all_apps', data: get_data)
+  sheet.notify_of_external_sharing('external_emails_with_application_data_access')
 end
 
 main

--- a/bin/cron/teacher_applications_to_gdrive
+++ b/bin/cron/teacher_applications_to_gdrive
@@ -51,7 +51,7 @@ end
 def main
   # Uses a Google Cloud service account to access Google Drive
   sheet = Google::Sheet.new CDO.applications_2020_2021_gsheet_key
-  sheet.export(sheet_name: 'all_apps', data: get_data)
+  sheet.export(tab_name: 'all_apps', data: get_data)
   sheet.notify_of_external_sharing('external_emails_with_application_data_access')
 end
 

--- a/bin/cron/teacher_applications_to_gdrive
+++ b/bin/cron/teacher_applications_to_gdrive
@@ -9,7 +9,7 @@ require 'honeybadger/ruby'
 # Returns a set of teacher application data to be written to
 # a spreadsheet in Google Drive (with permissions locked down to our organization) for exploration
 # by our programs team.
-def get_data
+def get_rows
   applications = [%w(course regional_partner status scholarship_status school_type pay_fee email created_at
                      meets_minimum_requirements meets_scholarship_criteria registered_for_workshop rural_status
                      free_reduced_lunch_percent urm_percent accepted_at)]
@@ -49,10 +49,14 @@ def get_data
 end
 
 def main
+  # This list is saved in DCDO as an array. To append a new value to this list:
+  # DCDO.set(key_name, DCDO.get(key_name, []) << new_value)
+  allowed_list = DCDO.get('external_emails_with_application_data_access', [])
+
   # Uses a Google Cloud service account to access Google Drive
   sheet = Google::Sheet.new CDO.applications_2020_2021_gsheet_key
-  sheet.export(tab_name: 'all_apps', data: get_data)
-  sheet.notify_of_external_sharing('external_emails_with_application_data_access')
+  sheet.export(tab_name: 'all_apps', rows: get_rows)
+  sheet.notify_of_external_sharing(allowed_list)
 end
 
 main

--- a/lib/cdo/google/sheet.rb
+++ b/lib/cdo/google/sheet.rb
@@ -21,9 +21,9 @@ module Google
       @document_key = document_key
     end
 
-    def export(tab_name:, data:)
+    def export(tab_name:, rows:)
       # Write exported data to a sheet in the document
-      @drive.update_sheet data, @document_key, "#{tab_name} (auto)"
+      @drive.update_sheet rows, @document_key, "#{tab_name} (auto)"
 
       # Write new metadata to a second sheet in the document
       last_updated = DateTime.now.in_time_zone ActiveSupport::TimeZone.new "Pacific Time (US & Canada)"
@@ -35,7 +35,7 @@ module Google
 
         Last updated: #{last_updated.strftime '%Y-%m-%d %l:%M%P GMT%:::z'}
         Written by: #{CDO.gdrive_export_secret.client_email}
-        Rows: #{data.length - 1}
+        Rows: #{rows.length - 1}
 
         Parts of this Google Sheet are auto-populated from our live application by an automated process.
         The sheet is shared with a \"service account\" that updates it on the application's behalf.
@@ -44,19 +44,15 @@ module Google
       @drive.update_sheet metadata, @document_key, "#{tab_name}_meta (auto)"
     end
 
-    def notify_of_external_sharing(dcdo_key=nil)
+    def notify_of_external_sharing(allowed_list=[])
       # List of external emails that we can share this document with.
-      # This list is saved in DCDO as an array. To append a new value to this list:
-      # DCDO.set(key_name, DCDO.get(key_name, []) << new_value)
-      allowed_list = dcdo_key.nil? ? [] : DCDO.get(dcdo_key, [])
       external_emails = external_emails_with_access - allowed_list
 
       if external_emails.present?
         email_domains = external_emails.map {|email| email.slice(/@.*/)}.uniq
         error_msg = <<~ERROR_MSG
-          Document containing PII information is shared to
+          A Google Sheet containing PII information is shared to
           #{external_emails.length} external account(s) at the following domain(s): #{email_domains.join(', ')}.
-          Document key: #{@document_key}
           Please check with PLC team that this is intentional!
         ERROR_MSG
 

--- a/lib/cdo/google/sheet.rb
+++ b/lib/cdo/google/sheet.rb
@@ -21,16 +21,16 @@ module Google
       @document_key = document_key
     end
 
-    def export(sheet_name:, data:)
+    def export(tab_name:, data:)
       # Write exported data to a sheet in the document
-      @drive.update_sheet data, @document_key, "#{sheet_name} (auto)"
+      @drive.update_sheet data, @document_key, "#{tab_name} (auto)"
 
       # Write new metadata to a second sheet in the document
       last_updated = DateTime.now.in_time_zone ActiveSupport::TimeZone.new "Pacific Time (US & Canada)"
       metadata = <<~META.split("\n").map {|line| [line]}
         AUTOMATION METADATA
 
-        The tabs "#{sheet_name} (auto)" and "#{sheet_name}_meta (auto)" are auto-generated;
+        The tabs "#{tab_name} (auto)" and "#{tab_name}_meta (auto)" are auto-generated;
         Any edits you make to them (besides formatting) may be lost.
 
         Last updated: #{last_updated.strftime '%Y-%m-%d %l:%M%P GMT%:::z'}
@@ -41,7 +41,7 @@ module Google
         The sheet is shared with a \"service account\" that updates it on the application's behalf.
         (Technical Details: https://github.com/code-dot-org/code-dot-org/pull/32597)
       META
-      @drive.update_sheet metadata, @document_key, "#{sheet_name}_meta (auto)"
+      @drive.update_sheet metadata, @document_key, "#{tab_name}_meta (auto)"
     end
 
     def notify_of_external_sharing(dcdo_key=nil)
@@ -53,10 +53,12 @@ module Google
 
       if external_emails.present?
         email_domains = external_emails.map {|email| email.slice(/@.*/)}.uniq
-        error_msg = "Document containing PII information is shared to "\
-          "#{external_emails.length} external account(s) at the following domain(s): #{email_domains.join(', ')}. "\
-          "Document key: #{@document_key}"\
-          "Please check with PLC team that this is intentional!"
+        error_msg = <<~ERROR_MSG
+          Document containing PII information is shared to
+          #{external_emails.length} external account(s) at the following domain(s): #{email_domains.join(', ')}.
+          Document key: #{@document_key}
+          Please check with PLC team that this is intentional!
+        ERROR_MSG
 
         Honeybadger.notify error_msg
         puts error_msg


### PR DESCRIPTION
Follow-up to https://github.com/code-dot-org/code-dot-org/pull/34779, this PR:

1. Moves `notify_of_external_sharing` into `Sheet` class. Can be executed with a dcdo list of allowed emails, or with no list of allowed emails provided (assumes no external emails should have access).
2. Sets up each cronjob in a similar structure, where a sheet is created, some data is added to a given tab via a `get_rows` function), and (optionally) a check on whether the sheet has been shared externally is done.
3. Refactors summer workshop export to use the new `Sheet` class.

## Testing story

Tested that all three cron entries run successfully locally, with a test export of data from my development database to a test gsheet.

## Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
