### PR TITLE
Make 'select all functions' bold

### DIFF
--- a/apps/src/code-studio/components/libraries/LibraryPublisher.jsx
+++ b/apps/src/code-studio/components/libraries/LibraryPublisher.jsx
@@ -25,6 +25,11 @@ const styles = {
     width: 20,
     height: 20
   },
+  selectAllFunctionsLabel: {
+    margin: 0,
+    fontSize: 20,
+    fontFamily: '"Gotham 5r", sans-serif'
+  },
   functionLabel: {
     margin: 0,
     fontSize: 20
@@ -397,7 +402,10 @@ export default class LibraryPublisher extends React.Component {
             checked={this.allFunctionsSelected()}
             onChange={this.toggleAllFunctionsSelected}
           />
-          <label htmlFor={selectAllCheckboxId} style={styles.functionLabel}>
+          <label
+            htmlFor={selectAllCheckboxId}
+            style={styles.selectAllFunctionsLabel}
+          >
             {i18n.selectAllFunctions()}
           </label>
         </div>


### PR DESCRIPTION
It was difficult to visually differentiate the "Select all functions" input from the function inputs, so making that header bold:
<img width="734" alt="Screen Shot 2020-05-18 at 3 17 57 PM" src="https://user-images.githubusercontent.com/9812299/82265070-01b49500-991b-11ea-868e-ec82b5c04b58.png">


## Links

<!--
  Any relevant links to external resources; ie, specification documents, jira
  items, related PRs, honeybadger errors, etc
-->

- [CSP bug bash](https://docs.google.com/document/d/15GQ1ogPG4wzfnnAOOS7hHW4BTDwUBj41LjOr2hFZEgc/edit?ts=5ebef457#bookmark=id.na8sbl7cmh0x)

## Testing story

<!--
  Does your change include appropriate tests?

  If so, please describe how the tests included in this PR are sufficient

  If not, please explain why this change does not need to be tested.
-->

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
