### PR TITLE
Foorm: allow emojis in submissions

### DIFF
--- a/dashboard/app/models/foorm/submission.rb
+++ b/dashboard/app/models/foorm/submission.rb
@@ -12,4 +12,13 @@
 
 class Foorm::Submission < ActiveRecord::Base
   belongs_to :foorm_form
+  before_validation :strip_emoji_from_answers
+
+  # Drops unicode characters not supported by utf8mb3 strings (most commonly emoji)
+  # from the submission answers
+  # We can remove this once our database has utf8mb4 support everywhere.
+  def strip_emoji_from_answers
+    # Drop emoji and other unsupported characters
+    self.answers = answers&.strip_utf8mb4&.strip
+  end
 end

--- a/dashboard/app/models/foorm/submission.rb
+++ b/dashboard/app/models/foorm/submission.rb
@@ -5,20 +5,11 @@
 #  id           :integer          not null, primary key
 #  form_name    :string(255)      not null
 #  form_version :integer          not null
-#  answers      :text(65535)      not null
+#  answers      :text(4294967295) not null
 #  created_at   :datetime         not null
 #  updated_at   :datetime         not null
 #
 
 class Foorm::Submission < ActiveRecord::Base
   belongs_to :foorm_form
-  before_validation :strip_emoji_from_answers
-
-  # Drops unicode characters not supported by utf8mb3 strings (most commonly emoji)
-  # from the submission answers
-  # We can remove this once our database has utf8mb4 support everywhere.
-  def strip_emoji_from_answers
-    # Drop emoji and other unsupported characters
-    self.answers = answers&.strip_utf8mb4&.strip
-  end
 end

--- a/dashboard/config/database.yml
+++ b/dashboard/config/database.yml
@@ -12,8 +12,8 @@ mysql_defaults: &mysql_defaults
   adapter: seamless_database_pool
   prepared_statements: false
   pool_adapter: mysql2
-  encoding: utf8
-  collation: utf8_unicode_ci
+  encoding: utf8mb4
+  collation: utf8mb4_unicode_ci
   default_group: 'cdo'
 
   # ActiveRecord connection-pool settings:

--- a/dashboard/db/migrate/20200518181001_convert_foorm_submissions_to_utf8mb4.rb
+++ b/dashboard/db/migrate/20200518181001_convert_foorm_submissions_to_utf8mb4.rb
@@ -1,0 +1,9 @@
+class ConvertFoormSubmissionsToUtf8mb4 < ActiveRecord::Migration[5.0]
+  def up
+    execute "ALTER TABLE foorm_submissions CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_bin"
+  end
+
+  def down
+    execute "ALTER TABLE foorm_submissions CONVERT TO CHARACTER SET utf8 COLLATE utf8_unicode_ci"
+  end
+end

--- a/dashboard/db/schema.rb
+++ b/dashboard/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20200504210058) do
+ActiveRecord::Schema.define(version: 20200518181001) do
 
   create_table "activities", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci" do |t|
     t.integer  "user_id"
@@ -440,12 +440,12 @@ ActiveRecord::Schema.define(version: 20200504210058) do
     t.index ["library_name", "library_version", "question_name"], name: "index_foorm_library_questions_on_multiple_fields", unique: true, using: :btree
   end
 
-  create_table "foorm_submissions", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci" do |t|
-    t.string   "form_name",                  null: false
-    t.integer  "form_version",               null: false
-    t.text     "answers",      limit: 65535, null: false
-    t.datetime "created_at",                 null: false
-    t.datetime "updated_at",                 null: false
+  create_table "foorm_submissions", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin" do |t|
+    t.string   "form_name",                       null: false
+    t.integer  "form_version",                    null: false
+    t.text     "answers",      limit: 4294967295, null: false
+    t.datetime "created_at",                      null: false
+    t.datetime "updated_at",                      null: false
   end
 
   create_table "games", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci" do |t|


### PR DESCRIPTION
By changing the `Foorm::Submission` backing table to use `utf8mb4` instead of `utf8` encoding, we now support emojis in Foorm submissions.

Successful submission as seen in `dashboard-console`:

![Screenshot 2020-05-19 09 40 53](https://user-images.githubusercontent.com/2205926/82354507-be5b3480-99b5-11ea-8033-b43ebe82239e.png)

Successful submission seen in facilitator results:

![Screenshot 2020-05-19 09 40 12](https://user-images.githubusercontent.com/2205926/82354504-bd2a0780-99b5-11ea-9008-b66ad03950af.png)
