### PR TITLE
Translate long instructions and teacher markdown for standalone videos

### DIFF
--- a/dashboard/app/models/levels/standalone_video.rb
+++ b/dashboard/app/models/levels/standalone_video.rb
@@ -60,4 +60,22 @@ class StandaloneVideo < Level
   def self.create_from_level_builder(params, level_params)
     create!(level_params.merge(user: params[:user], game: Game.standalone_video, level_num: 'custom'))
   end
+
+  def localized_long_instructions
+    return nil unless long_instructions
+    return long_instructions if I18n.en?
+    return I18n.t(name,
+      scope: [:data, "long_instructions"],
+      default: long_instructions,
+    )
+  end
+
+  def localized_teacher_markdown
+    return nil unless teacher_markdown
+    return teacher_markdown if I18n.en?
+    return I18n.t(name,
+      scope: [:data, "teacher_markdown"],
+      default: teacher_markdown,
+    )
+  end
 end

--- a/dashboard/app/views/levels/_standalone_video.html.haml
+++ b/dashboard/app/views/levels/_standalone_video.html.haml
@@ -13,7 +13,7 @@
 
   - unless @level.video_full_width
     %h1= "#{t('video.label')}: #{video.localized_name}"
-  %div= render(inline: @level.long_instructions, type: :md) if @level.long_instructions
+  %div= render(inline: @level.localized_long_instructions, type: :md) if @level.localized_long_instructions
 
   .video-content
   - if @slides
@@ -44,4 +44,4 @@
       %a.btn.btn-large.btn-primary.next-stage.submitButton
         =t('continue')
 
-  = render partial: 'levels/teacher_markdown', locals: {data: {'teacher_markdown' => @level.teacher_markdown}}
+  = render partial: 'levels/teacher_markdown', locals: {data: {'teacher_markdown' => @level.localized_teacher_markdown}}


### PR DESCRIPTION
The PD course is being used in Italian but a number of the levels aren't translated, despite the translations being in Crowdin, (i.e. https://studio.code.org/s/K5-OnlinePD/stage/2/puzzle/2). It turns out most of the levels that aren't translated correctly are standalone video levels, which don't have translateable long instructions.

<!-- ### Background -->
<!-- ### Privacy -->
<!-- ### Security -->
<!-- ### Caching -->
<!-- ### Deployment strategy -->
<!-- ### Future work -->

## Links

<!--
  Any relevant links to external resources; ie, specification documents, jira
  items, related PRs, honeybadger errors, etc
-->

- [spec]()
- [jira]()

## Testing story

<!--
  Does your change include appropriate tests?

  If so, please describe how the tests included in this PR are sufficient

  If not, please explain why this change does not need to be tested.
-->

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
