### PR TITLE
Rename "stages" to "lessons" in i18n: Step 3

### DIFF
--- a/dashboard/app/models/lesson.rb
+++ b/dashboard/app/models/lesson.rb
@@ -93,7 +93,7 @@ class Lesson < ActiveRecord::Base
 
   def localized_name
     if script.lessons.many?
-      I18n.t "data.script.name.#{script.name}.stages.#{name}.name"
+      I18n.t "data.script.name.#{script.name}.lessons.#{name}.name"
     else
       I18n.t "data.script.name.#{script.name}.title"
     end
@@ -140,8 +140,8 @@ class Lesson < ActiveRecord::Base
         lesson_group_display_name: lesson_group&.localized_display_name,
         lockable: !!lockable,
         levels: cached_levels.map {|l| l.summarize(false)},
-        description_student: render_codespan_only_markdown(I18n.t("data.script.name.#{script.name}.stages.#{name}.description_student", default: '')),
-        description_teacher: render_codespan_only_markdown(I18n.t("data.script.name.#{script.name}.stages.#{name}.description_teacher", default: '')),
+        description_student: render_codespan_only_markdown(I18n.t("data.script.name.#{script.name}.lessons.#{name}.description_student", default: '')),
+        description_teacher: render_codespan_only_markdown(I18n.t("data.script.name.#{script.name}.lessons.#{name}.description_teacher", default: '')),
         unplugged: display_as_unplugged
       }
 
@@ -185,7 +185,7 @@ class Lesson < ActiveRecord::Base
   def summarize_for_edit
     summary = summarize.dup
     # Do not let script name override lesson name when there is only one lesson
-    summary[:name] = I18n.t("data.script.name.#{script.name}.stages.#{name}.name")
+    summary[:name] = I18n.t("data.script.name.#{script.name}.lessons.#{name}.name")
     summary.freeze
   end
 

--- a/dashboard/app/models/script.rb
+++ b/dashboard/app/models/script.rb
@@ -1502,8 +1502,8 @@ class Script < ActiveRecord::Base
     lessons.each do |stage|
       stage_data = {
         'name' => stage.name,
-        'description_student' => (I18n.t "data.script.name.#{name}.stages.#{stage.name}.description_student", default: ''),
-        'description_teacher' => (I18n.t "data.script.name.#{name}.stages.#{stage.name}.description_teacher", default: '')
+        'description_student' => (I18n.t "data.script.name.#{name}.lessons.#{stage.name}.description_student", default: ''),
+        'description_teacher' => (I18n.t "data.script.name.#{name}.lessons.#{stage.name}.description_teacher", default: '')
       }
       data['stages'][stage.name] = stage_data
       data['lessons'][stage.name] = stage_data
@@ -1521,8 +1521,8 @@ class Script < ActiveRecord::Base
       data['stageDescriptions'] = lessons.map do |stage|
         {
           name: stage.name,
-          descriptionStudent: (I18n.t "data.script.name.#{name}.stages.#{stage.name}.description_student", default: ''),
-          descriptionTeacher: (I18n.t "data.script.name.#{name}.stages.#{stage.name}.description_teacher", default: '')
+          descriptionStudent: (I18n.t "data.script.name.#{name}.lessons.#{stage.name}.description_student", default: ''),
+          descriptionTeacher: (I18n.t "data.script.name.#{name}.lessons.#{stage.name}.description_teacher", default: '')
         }
       end
     end

--- a/dashboard/test/helpers/script_levels_helper_test.rb
+++ b/dashboard/test/helpers/script_levels_helper_test.rb
@@ -47,7 +47,7 @@ class ScriptLevelsHelperTest < ActionView::TestCase
     stubs(:current_user).returns(nil)
     script = Script.find_by_name(Script::COURSE4_NAME)
     script_level = script.get_script_level_by_relative_position_and_puzzle_position 3, 1, false
-    assert_equal 'Lesson 3: ' + I18n.t("data.script.name.#{script.name}.stages.#{script_level.lesson.name}.name"), script_level.lesson.summarize[:title]
+    assert_equal 'Lesson 3: ' + I18n.t("data.script.name.#{script.name}.lessons.#{script_level.lesson.name}.name"), script_level.lesson.summarize[:title]
   end
 
   test 'show stage position in header for default script' do


### PR DESCRIPTION
Overall plan of attack:

1. Add all strings keyed by the term "stage" to crowdin under the key "lesson". (https://github.com/code-dot-org/code-dot-org/pull/34854)
2. Wait for a sync; Crowdin will automatically duplicate translations for the new strings (https://github.com/code-dot-org/code-dot-org/pull/34959 and https://github.com/code-dot-org/code-dot-org/pull/34960)
3. Update all I18n.t references currently using the key "stage" to use the new "lesson" translations (this PR)
4. Remove old "stage" strings now that they are no longer used

<!--
  Your description goes here: A summary of the change, including any relevant motivation and context.

  If relevant, include a description both of the existing behavior and of the new behavior.
-->

<!--
  Other aspects to consider. uncomment and add detail for any that seem necessary:
-->

<!-- ### Background -->
<!-- ### Privacy -->
<!-- ### Security -->
<!-- ### Caching -->
<!-- ### Deployment strategy -->
<!-- ### Future work -->

## Links

<!--
  Any relevant links to external resources; ie, specification documents, jira
  items, related PRs, honeybadger errors, etc
-->

- [spec]()
- [jira]()

## Testing story

<!--
  Does your change include appropriate tests?

  If so, please describe how the tests included in this PR are sufficient

  If not, please explain why this change does not need to be tested.
-->

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
