### PR TITLE
[Student Libraries] Enable filtering class libraries by section

### DIFF
--- a/apps/i18n/common/en_us.json
+++ b/apps/i18n/common/en_us.json
@@ -1570,6 +1570,7 @@
   "showToolbox": "Show Toolbox",
   "showVersionsHeader": "Version History",
   "showWords": "Show words",
+  "showingLibrariesFromSection": "Showing libraries from section: ",
   "signup": "Sign up for the intro course",
   "signUpButton": "Sign up",
   "signupFormSchoolOrOrganization": "School / Organization",

--- a/apps/src/code-studio/components/libraries/LibraryManagerDialog.jsx
+++ b/apps/src/code-studio/components/libraries/LibraryManagerDialog.jsx
@@ -299,7 +299,7 @@ export class LibraryManagerDialog extends React.Component {
     }
 
     const filteredLibraries = sectionFilter
-      ? classLibraries.filter(library => library.section === sectionFilter)
+      ? classLibraries.filter(library => library.sectionName === sectionFilter)
       : classLibraries;
 
     return filteredLibraries.map(library => {
@@ -400,7 +400,7 @@ export class LibraryManagerDialog extends React.Component {
     }
 
     const sections = [
-      ...new Set(classLibraries.map(library => library.section))
+      ...new Set(classLibraries.map(library => library.sectionName))
     ];
 
     return (

--- a/apps/src/code-studio/components/libraries/LibraryManagerDialog.jsx
+++ b/apps/src/code-studio/components/libraries/LibraryManagerDialog.jsx
@@ -116,7 +116,8 @@ export class LibraryManagerDialog extends React.Component {
     displayLibraryMode: DisplayLibraryMode.NONE,
     isLoading: false,
     errorMessages: {},
-    updatedLibraryChannels: []
+    updatedLibraryChannels: [],
+    sectionFilter: ''
   };
 
   componentDidUpdate(prevProps) {
@@ -289,14 +290,19 @@ export class LibraryManagerDialog extends React.Component {
   };
 
   displayClassLibraries = () => {
-    const {classLibraries, errorMessages} = this.state;
+    const {classLibraries, errorMessages, sectionFilter} = this.state;
     if (errorMessages.loadClassLibraries) {
       return <div style={styles.error}>{errorMessages.loadClassLibraries}</div>;
     }
     if (!Array.isArray(classLibraries) || !classLibraries.length) {
       return <div style={styles.message}>{i18n.noLibrariesInClass()}</div>;
     }
-    return classLibraries.map(library => {
+
+    const filteredLibraries = sectionFilter
+      ? classLibraries.filter(library => library.section === sectionFilter)
+      : classLibraries;
+
+    return filteredLibraries.map(library => {
       return (
         <LibraryListItem
           key={library.channel}
@@ -385,12 +391,17 @@ export class LibraryManagerDialog extends React.Component {
       importLibraryId,
       displayLibrary,
       isLoading,
-      errorMessages
+      errorMessages,
+      classLibraries
     } = this.state;
 
     if (!isOpen) {
       return null;
     }
+
+    const sections = [
+      ...new Set(classLibraries.map(library => library.section))
+    ];
 
     return (
       <div>
@@ -403,6 +414,23 @@ export class LibraryManagerDialog extends React.Component {
           <h1 style={styles.header}>{i18n.libraryManage()}</h1>
           <div style={styles.libraryList}>{this.displayProjectLibraries()}</div>
           <h1 style={styles.header}>{i18n.libraryClassImport()}</h1>
+          <div style={{textAlign: 'left'}}>
+            <label style={{...styles.message, display: 'inline'}}>
+              {i18n.showingLibrariesFromSection()}
+            </label>
+            <select
+              onChange={event =>
+                this.setState({sectionFilter: event.target.value})
+              }
+            >
+              <option value="">{i18n.all()}</option>
+              {[...sections].map(section => (
+                <option key={section} value={section}>
+                  {section}
+                </option>
+              ))}
+            </select>
+          </div>
           <div style={styles.libraryList}>{this.displayClassLibraries()}</div>
           <h1 style={styles.header}>{i18n.libraryIdImport()}</h1>
           <div style={styles.inputParent}>

--- a/apps/src/code-studio/components/libraries/LibraryManagerDialog.jsx
+++ b/apps/src/code-studio/components/libraries/LibraryManagerDialog.jsx
@@ -424,7 +424,7 @@ export class LibraryManagerDialog extends React.Component {
               }
             >
               <option value="">{i18n.all()}</option>
-              {[...sections].map(section => (
+              {sections.map(section => (
                 <option key={section} value={section}>
                   {section}
                 </option>

--- a/apps/test/unit/code-studio/components/libraries/libraryManagerDialogTest.js
+++ b/apps/test/unit/code-studio/components/libraries/libraryManagerDialogTest.js
@@ -121,8 +121,8 @@ describe('LibraryManagerDialog', () => {
 
     it('displays LibraryListItem when the project contains libraries', () => {
       getProjectLibrariesStub.returns([
-        {name: 'first', channelId: 'abc123'},
-        {name: 'second', channelId: 'def456'}
+        {name: 'first', channelId: 'abc123', section: 'section'},
+        {name: 'second', channelId: 'def456', section: 'section'}
       ]);
       const wrapper = shallow(
         <LibraryManagerDialog onClose={() => {}} isOpen={true} />
@@ -136,7 +136,10 @@ describe('LibraryManagerDialog', () => {
     it('displays LibraryListItem when class libraries are available', () => {
       getProjectLibrariesStub.returns(undefined);
       getClassLibrariesStub.callsFake(callback =>
-        callback([{channel: '1'}, {channel: '2'}])
+        callback([
+          {channel: '1', section: 'section'},
+          {channel: '2', section: 'section'}
+        ])
       );
       const wrapper = shallow(
         <LibraryManagerDialog onClose={() => {}} isOpen={true} />
@@ -149,11 +152,14 @@ describe('LibraryManagerDialog', () => {
 
     it('displays all libraries from the project and the class', () => {
       getProjectLibrariesStub.returns([
-        {name: 'first', channelId: 'abc123'},
-        {name: 'second', channelId: 'def456'}
+        {name: 'first', channelId: 'abc123', section: 'section'},
+        {name: 'second', channelId: 'def456', section: 'section'}
       ]);
       getClassLibrariesStub.callsFake(callback =>
-        callback([{channel: '1'}, {channel: '2'}])
+        callback([
+          {channel: '1', section: 'section'},
+          {channel: '2', section: 'section'}
+        ])
       );
       const wrapper = shallow(
         <LibraryManagerDialog onClose={() => {}} isOpen={true} />
@@ -162,6 +168,25 @@ describe('LibraryManagerDialog', () => {
       expect(wrapper.find(LibraryListItem)).to.have.lengthOf(4);
       expect(wrapper.state().classLibraries).to.have.lengthOf(2);
       expect(wrapper.state().projectLibraries).to.have.lengthOf(2);
+    });
+
+    it('allows filtering class libraries by section', () => {
+      getProjectLibrariesStub.returns(undefined);
+      getClassLibrariesStub.callsFake(callback =>
+        callback([
+          {channel: 'abc123', section: 'section1'},
+          {channel: 'def456', section: 'section2'},
+          {channel: 'ghi789', section: 'section1'},
+          {channel: 'jkl1011', section: 'section3'}
+        ])
+      );
+      const wrapper = shallow(
+        <LibraryManagerDialog onClose={() => {}} isOpen={true} />
+      );
+      wrapper.instance().onOpen();
+      expect(wrapper.find(LibraryListItem)).to.have.lengthOf(4);
+      wrapper.setState({sectionFilter: 'section1'});
+      expect(wrapper.find(LibraryListItem)).to.have.lengthOf(2);
     });
 
     it('setLibraryToImport sets the import library', () => {
@@ -214,8 +239,8 @@ describe('LibraryManagerDialog', () => {
 
     it('removeLibrary calls setProjectLibrary without the given library', () => {
       const projectLibraries = [
-        {name: 'first', channelId: 'abc123'},
-        {name: 'second', channelId: 'def456'}
+        {name: 'first', channelId: 'abc123', section: 'section'},
+        {name: 'second', channelId: 'def456', section: 'section'}
       ];
       getProjectLibrariesStub.returns(projectLibraries);
       let setProjectLibraries = sinon.spy(

--- a/apps/test/unit/code-studio/components/libraries/libraryManagerDialogTest.js
+++ b/apps/test/unit/code-studio/components/libraries/libraryManagerDialogTest.js
@@ -121,8 +121,8 @@ describe('LibraryManagerDialog', () => {
 
     it('displays LibraryListItem when the project contains libraries', () => {
       getProjectLibrariesStub.returns([
-        {name: 'first', channelId: 'abc123', section: 'section'},
-        {name: 'second', channelId: 'def456', section: 'section'}
+        {name: 'first', channelId: 'abc123', sectionName: 'section'},
+        {name: 'second', channelId: 'def456', sectionName: 'section'}
       ]);
       const wrapper = shallow(
         <LibraryManagerDialog onClose={() => {}} isOpen={true} />
@@ -137,8 +137,8 @@ describe('LibraryManagerDialog', () => {
       getProjectLibrariesStub.returns(undefined);
       getClassLibrariesStub.callsFake(callback =>
         callback([
-          {channel: '1', section: 'section'},
-          {channel: '2', section: 'section'}
+          {channel: '1', sectionName: 'section'},
+          {channel: '2', sectionName: 'section'}
         ])
       );
       const wrapper = shallow(
@@ -152,13 +152,13 @@ describe('LibraryManagerDialog', () => {
 
     it('displays all libraries from the project and the class', () => {
       getProjectLibrariesStub.returns([
-        {name: 'first', channelId: 'abc123', section: 'section'},
-        {name: 'second', channelId: 'def456', section: 'section'}
+        {name: 'first', channelId: 'abc123', sectionName: 'section'},
+        {name: 'second', channelId: 'def456', sectionName: 'section'}
       ]);
       getClassLibrariesStub.callsFake(callback =>
         callback([
-          {channel: '1', section: 'section'},
-          {channel: '2', section: 'section'}
+          {channel: '1', sectionName: 'section'},
+          {channel: '2', sectionName: 'section'}
         ])
       );
       const wrapper = shallow(
@@ -174,10 +174,10 @@ describe('LibraryManagerDialog', () => {
       getProjectLibrariesStub.returns(undefined);
       getClassLibrariesStub.callsFake(callback =>
         callback([
-          {channel: 'abc123', section: 'section1'},
-          {channel: 'def456', section: 'section2'},
-          {channel: 'ghi789', section: 'section1'},
-          {channel: 'jkl1011', section: 'section3'}
+          {channel: 'abc123', sectionName: 'section1'},
+          {channel: 'def456', sectionName: 'section2'},
+          {channel: 'ghi789', sectionName: 'section1'},
+          {channel: 'jkl1011', sectionName: 'section3'}
         ])
       );
       const wrapper = shallow(
@@ -239,8 +239,8 @@ describe('LibraryManagerDialog', () => {
 
     it('removeLibrary calls setProjectLibrary without the given library', () => {
       const projectLibraries = [
-        {name: 'first', channelId: 'abc123', section: 'section'},
-        {name: 'second', channelId: 'def456', section: 'section'}
+        {name: 'first', channelId: 'abc123', sectionName: 'section'},
+        {name: 'second', channelId: 'def456', sectionName: 'section'}
       ];
       getProjectLibrariesStub.returns(projectLibraries);
       let setProjectLibraries = sinon.spy(

--- a/dashboard/lib/projects_list.rb
+++ b/dashboard/lib/projects_list.rb
@@ -139,7 +139,7 @@ module ProjectsList
             # when apps are remixed, so recompute the channel id.
             channel_id = storage_encrypt_channel_id(project[:storage_id], project[:id])
             project_owner = section_users.find {|user| user.id == student_storage_ids[project[:storage_id]]}
-            project_data = get_library_row_data(project, channel_id, project_owner)
+            project_data = get_library_row_data(project, channel_id, section.name, project_owner)
             if project_data && (project_owner.user_type == 'student' || project_data[:sharedWith].include?(section.id))
               projects_list_data << project_data
             end
@@ -269,9 +269,10 @@ module ProjectsList
     # pull various fields out of the user and project records to populate
     # a data structure that can be used to populate a UI component displaying a
     # single library or a list of libraries.
-    def get_library_row_data(project, channel_id, user = nil)
+    def get_library_row_data(project, channel_id, section_name, user = nil)
       project_value = project[:value] ? JSON.parse(project[:value]) : {}
       {
+        section: section_name,
         channel: channel_id,
         name: project_value['libraryName'],
         description: project_value['libraryDescription'],

--- a/dashboard/lib/projects_list.rb
+++ b/dashboard/lib/projects_list.rb
@@ -272,7 +272,7 @@ module ProjectsList
     def get_library_row_data(project, channel_id, section_name, user = nil)
       project_value = project[:value] ? JSON.parse(project[:value]) : {}
       {
-        section: section_name,
+        sectionName: section_name,
         channel: channel_id,
         name: project_value['libraryName'],
         description: project_value['libraryDescription'],

--- a/dashboard/test/lib/projects_list_test.rb
+++ b/dashboard/test/lib/projects_list_test.rb
@@ -319,8 +319,8 @@ class ProjectsListTest < ActionController::TestCase
     User = Struct.new(:id, :name, :user_type)
     teacher = User.new(6, teacher_name, 'teacher')
     student = User.new(4, student_name, 'student')
-    Section = Struct.new(:students, :user, :id)
-    section = Section.new([student], teacher, 321)
+    Section = Struct.new(:students, :user, :id, :name)
+    section = Section.new([student], teacher, 321, 'sectionName')
 
     PEGASUS_DB.stubs(:[]).returns(user_db_result(stub_users)).then.returns(library_db_result(stub_projects))
 
@@ -365,8 +365,8 @@ class ProjectsListTest < ActionController::TestCase
     }
     User = Struct.new(:id, :name, :user_type)
     teacher = User.new(4, teacher_name, 'teacher')
-    Section = Struct.new(:students, :user, :id)
-    section = Section.new([], teacher, 321)
+    Section = Struct.new(:students, :user, :id, :name)
+    section = Section.new([], teacher, 321, 'sectionName')
 
     PEGASUS_DB.stubs(:[]).returns(user_db_result(stub_users)).then.returns(library_db_result(stub_projects))
 


### PR DESCRIPTION
Teachers will probably want a way to filter the class libraries section of the library manager dialog to show only libraries from a particular section
![May-19-2020 14-30-34](https://user-images.githubusercontent.com/8787187/82380561-81a33380-99dd-11ea-92df-f478ca7b00a5.gif)


<!--
  Other aspects to consider. uncomment and add detail for any that seem necessary:
-->

<!-- ### Background -->
<!-- ### Privacy -->
<!-- ### Security -->
<!-- ### Caching -->
<!-- ### Deployment strategy -->
<!-- ### Future work -->

## Links

<!--
  Any relevant links to external resources; ie, specification documents, jira
  items, related PRs, honeybadger errors, etc
-->

- [jira](https://codedotorg.atlassian.net/browse/STAR-825)

## Testing story

<!--
  Does your change include appropriate tests?

  If so, please describe how the tests included in this PR are sufficient

  If not, please explain why this change does not need to be tested.
-->

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
