### PR TITLE
Bubble Choice UI Polish: Reduce size of title on SubLevelCards

### DIFF
--- a/apps/src/code-studio/components/SublevelCard.jsx
+++ b/apps/src/code-studio/components/SublevelCard.jsx
@@ -64,10 +64,11 @@ const styles = {
   },
   title: {
     minHeight: 30,
-    fontSize: 20,
+    fontSize: 16,
     lineHeight: '25px',
     fontFamily: '"Gotham 5r"',
     color: color.teal,
+    marginBottom: 10,
     marginLeft: MARGIN,
     overflowWrap: 'break-word',
     wordWrap: 'break-word',


### PR DESCRIPTION
The [Curriculum Team noticed ](https://codedotorg.slack.com/archives/CA3KCSGTD/p1589921151049900) that long titles on choice level sub-level cards were often long enough to need hyphens; I reduced the font size. 

BEFORE: 
<img width="907" alt="Screen Shot 2020-05-19 at 4 04 52 PM" src="https://user-images.githubusercontent.com/12300669/82386991-ab168c00-99ea-11ea-8f0d-4035ab94963e.png">

AFTER: 
<img width="925" alt="Screen Shot 2020-05-19 at 4 01 24 PM" src="https://user-images.githubusercontent.com/12300669/82386873-67238700-99ea-11ea-9edf-8ed18425c7fe.png">
