### PR TITLE
Add rollback and retry logic

### DIFF
--- a/bin/cron/build_contact_rollups_v2
+++ b/bin/cron/build_contact_rollups_v2
@@ -6,8 +6,7 @@ require 'cdo/only_one'
 
 def main
   contact_rollups = ContactRollupsV2.new
-  contact_rollups.collect_and_process_contacts
-  contact_rollups.sync_contacts_with_pardot
+  contact_rollups.build_and_sync
   contact_rollups.report_results
 end
 

--- a/bin/cron/build_contact_rollups_v2
+++ b/bin/cron/build_contact_rollups_v2
@@ -3,14 +3,12 @@
 require_relative '../../dashboard/config/environment'
 require_relative '../../dashboard/lib/contact_rollups_v2'
 require 'cdo/only_one'
-require 'cdo/log_collector'
 
 def main
-  log_collector = LogCollector.new "Build contact rollups V2"
-
-  # Build new daily table of contact rollups
-  ContactRollupsV2.build_contact_rollups(log_collector: log_collector)
-  puts log_collector.to_s
+  contact_rollups = ContactRollupsV2.new
+  contact_rollups.collect_and_process_contacts
+  contact_rollups.sync_contacts_with_pardot
+  contact_rollups.report_results
 end
 
 main if only_one_running?(__FILE__)

--- a/bin/cron/build_contact_rollups_v2
+++ b/bin/cron/build_contact_rollups_v2
@@ -6,7 +6,8 @@ require 'cdo/only_one'
 
 def main
   contact_rollups = ContactRollupsV2.new
-  contact_rollups.build_and_sync
+  # TODO: invoke build_and_sync method to run the full pipeline
+  contact_rollups.collect_and_process_contacts
   contact_rollups.report_results
 end
 

--- a/dashboard/app/models/contact_rollups_final.rb
+++ b/dashboard/app/models/contact_rollups_final.rb
@@ -23,6 +23,6 @@ class ContactRollupsFinal < ApplicationRecord
       FROM contact_rollups_processed;
     SQL
 
-    ActiveRecord::Base.connection.exec_query(insert_sql)
+    transaction {ActiveRecord::Base.connection.exec_query(insert_sql)}
   end
 end

--- a/dashboard/app/models/contact_rollups_pardot_memory.rb
+++ b/dashboard/app/models/contact_rollups_pardot_memory.rb
@@ -45,9 +45,11 @@ class ContactRollupsPardotMemory < ApplicationRecord
         }
       end
 
-      import! batch,
-        validate: false,
-        on_duplicate_key_update: [:pardot_id, :pardot_id_updated_at]
+      transaction do
+        import! batch,
+          validate: false,
+          on_duplicate_key_update: [:pardot_id, :pardot_id_updated_at]
+      end
     end
   end
 
@@ -89,9 +91,11 @@ class ContactRollupsPardotMemory < ApplicationRecord
         }
       end
 
-      import! batch,
-        validate: false,
-        on_duplicate_key_update: [:pardot_id, :pardot_id_updated_at, :data_synced, :data_synced_at]
+      transaction do
+        import! batch,
+          validate: false,
+          on_duplicate_key_update: [:pardot_id, :pardot_id_updated_at, :data_synced, :data_synced_at]
+      end
     end
   end
 
@@ -106,9 +110,11 @@ class ContactRollupsPardotMemory < ApplicationRecord
         }
       end
 
-      import! batch,
-        validate: false,
-        on_duplicate_key_update: [:data_rejected_at, :data_rejected_reason]
+      transaction do
+        import! batch,
+          validate: false,
+          on_duplicate_key_update: [:data_rejected_at, :data_rejected_reason]
+      end
     end
   end
 
@@ -254,9 +260,11 @@ class ContactRollupsPardotMemory < ApplicationRecord
       }
     end
 
-    import! emails_and_data,
-      validate: false,
-      on_duplicate_key_update: [:data_synced, :data_synced_at]
+    transaction do
+      import! emails_and_data,
+        validate: false,
+        on_duplicate_key_update: [:data_synced, :data_synced_at]
+    end
   end
 
   def self.save_rejected_submissions(submissions, submitted_time)
@@ -268,8 +276,10 @@ class ContactRollupsPardotMemory < ApplicationRecord
       }
     end
 
-    import! emails_and_errors,
-      validate: false,
-      on_duplicate_key_update: [:data_rejected_reason, :data_rejected_at]
+    transaction do
+      import! emails_and_errors,
+        validate: false,
+        on_duplicate_key_update: [:data_rejected_reason, :data_rejected_at]
+    end
   end
 end

--- a/dashboard/app/models/contact_rollups_pardot_memory.rb
+++ b/dashboard/app/models/contact_rollups_pardot_memory.rb
@@ -168,7 +168,9 @@ class ContactRollupsPardotMemory < ApplicationRecord
     # In addition, they must not be previously rejected by Pardot as invalid emails
     # or have been deleted by someone in Pardot.
     <<-SQL.squish
-      SELECT processed.email, processed.data
+      SELECT
+        processed.email,
+        processed.data
       FROM contact_rollups_processed AS processed
       LEFT OUTER JOIN contact_rollups_pardot_memory AS pardot
         ON processed.email = pardot.email
@@ -187,8 +189,10 @@ class ContactRollupsPardotMemory < ApplicationRecord
     # will resuscitate it as an active prospect.
     <<-SQL.squish
       SELECT
-        processed.email, processed.data,
-        pardot.pardot_id, pardot.data_synced,
+        processed.email,
+        processed.data,
+        pardot.pardot_id,
+        pardot.data_synced,
         COALESCE(pardot.pardot_id_updated_at > pardot.data_synced_at, FALSE) AS pardot_id_changed
       FROM contact_rollups_processed AS processed
       INNER JOIN contact_rollups_pardot_memory AS pardot

--- a/dashboard/app/models/contact_rollups_processed.rb
+++ b/dashboard/app/models/contact_rollups_processed.rb
@@ -19,32 +19,12 @@ class ContactRollupsProcessed < ApplicationRecord
   DEFAULT_BATCH_SIZE = 10000
 
   # Aggregates data from contact_rollups_raw table and saves the results, one row per email.
-  #
+  # Do not rollback so we can investigate issues in case of failure
   # @param [Integer] batch_size number of records to save per INSERT statement.
   def self.import_from_raw_table(batch_size = DEFAULT_BATCH_SIZE)
-    # Combines data and metadata for each record in contact_rollups_raw table into one JSON field.
-    # The query result has the same number of rows as in contact_rollups_raw.
-    select_query = <<-SQL.squish
-      SELECT
-        email,
-        JSON_OBJECT('sources', sources, 'data', data, 'data_updated_at', data_updated_at) AS data_and_metadata
-      FROM contact_rollups_raw
-    SQL
-
-    # Groups records by emails. Aggregates all data and metadata belong to an email into one JSON field.
-    #
-    # Note: use GROUP_CONCAT instead of JSON_OBJECT_AGG because the current Aurora Mysql version in
-    # production is 5.7.12, while JSON_OBJECT_AGG is only available from 5.7.22.
-    # Because GROUP_CONCAT returns a string, we add a parser function to convert the result to a hash.
-    group_by_query = <<-SQL.squish
-      SELECT email, CONCAT('[', GROUP_CONCAT(data_and_metadata), ']') AS all_data_and_metadata
-      FROM (#{select_query}) AS subquery
-      GROUP BY email
-    SQL
-
-    # Process the aggregated data row by row and save the results to DB.
+    # Process the aggregated data row by row and save the results to DB in batches.
     batch = []
-    ActiveRecord::Base.connection.exec_query(group_by_query).each do |contact|
+    ActiveRecord::Base.connection.exec_query(get_data_aggregation_query).each do |contact|
       contact_data = parse_contact_data(contact['all_data_and_metadata'])
 
       processed_contact_data = {}
@@ -61,6 +41,29 @@ class ContactRollupsProcessed < ApplicationRecord
     end
 
     import! batch, validate: false unless batch.empty?
+  end
+
+  def self.get_data_aggregation_query
+    # Combines data and metadata for each record in contact_rollups_raw table into one JSON field.
+    # The query result has the same number of rows as in contact_rollups_raw.
+    data_transformation_query = <<-SQL.squish
+      SELECT
+        email,
+        JSON_OBJECT('sources', sources, 'data', data, 'data_updated_at', data_updated_at) AS data_and_metadata
+      FROM contact_rollups_raw
+    SQL
+
+    # Groups records by emails. Aggregates all data and metadata belong to an email into one JSON field.
+    # Note: use GROUP_CONCAT instead of JSON_OBJECT_AGG because the current Aurora Mysql version in
+    # production is 5.7.12, while JSON_OBJECT_AGG is only available from 5.7.22.
+    # Because GROUP_CONCAT returns a string, we add a parser function to convert the result to a hash.
+    <<-SQL.squish
+      SELECT
+        email,
+        CONCAT('[', GROUP_CONCAT(data_and_metadata), ']') AS all_data_and_metadata
+      FROM (#{data_transformation_query}) AS subquery
+      GROUP BY email
+    SQL
   end
 
   # Parses a JSON string contains all data and metadata of a contact.

--- a/dashboard/app/models/contact_rollups_processed.rb
+++ b/dashboard/app/models/contact_rollups_processed.rb
@@ -34,13 +34,15 @@ class ContactRollupsProcessed < ApplicationRecord
       batch << {email: contact['email'], data: processed_contact_data}
       next if batch.size < batch_size
 
-      # Note: Skipping validation here because the only validation we need is that an email
-      # is unique, which will be done at the DB level anyway thanks to an unique index on email.
-      import! batch, validate: false
-      batch = []
+      transaction do
+        # Note: Skipping validation here because the only validation we need is that an email
+        # is unique, which will be done at the DB level anyway thanks to an unique index on email.
+        import! batch, validate: false
+        batch = []
+      end
     end
 
-    import! batch, validate: false unless batch.empty?
+    transaction {import! batch, validate: false} unless batch.empty?
   end
 
   def self.get_data_aggregation_query

--- a/dashboard/app/models/contact_rollups_processed.rb
+++ b/dashboard/app/models/contact_rollups_processed.rb
@@ -19,7 +19,6 @@ class ContactRollupsProcessed < ApplicationRecord
   DEFAULT_BATCH_SIZE = 10000
 
   # Aggregates data from contact_rollups_raw table and saves the results, one row per email.
-  # Do not rollback so we can investigate issues in case of failure
   # @param [Integer] batch_size number of records to save per INSERT statement.
   def self.import_from_raw_table(batch_size = DEFAULT_BATCH_SIZE)
     # Process the aggregated data row by row and save the results to DB in batches.

--- a/dashboard/app/models/contact_rollups_raw.rb
+++ b/dashboard/app/models/contact_rollups_raw.rb
@@ -20,7 +20,7 @@ class ContactRollupsRaw < ApplicationRecord
 
   def self.extract_email_preferences
     query = get_extraction_query('email_preferences', 'email', ['opt_in'])
-    ActiveRecord::Base.connection.execute(query)
+    transaction {ActiveRecord::Base.connection.execute(query)}
   end
 
   def self.extract_parent_emails
@@ -31,7 +31,7 @@ class ContactRollupsRaw < ApplicationRecord
     SQL
 
     query = get_extraction_query(source_sql, 'parent_email', [], true, 'dashboard.users.parent_email')
-    ActiveRecord::Base.connection.execute(query)
+    transaction {ActiveRecord::Base.connection.execute(query)}
   end
 
   # @param source [String] Source from which we want to extract data (can be a dashboard table name, or subquery)

--- a/dashboard/app/models/contact_rollups_raw.rb
+++ b/dashboard/app/models/contact_rollups_raw.rb
@@ -18,11 +18,13 @@
 class ContactRollupsRaw < ApplicationRecord
   self.table_name = 'contact_rollups_raw'
 
+  # Extracts opt_in data from dashboard.email_preferences table.
   def self.extract_email_preferences
     query = get_extraction_query('email_preferences', 'email', ['opt_in'])
-    ActiveRecord::Base.connection.execute(query)
+    transaction {ActiveRecord::Base.connection.execute(query)}
   end
 
+  # Extract parent emails from dashboard.users table.
   def self.extract_parent_emails
     source_sql = <<~SQL
       SELECT parent_email, MAX(updated_at) AS updated_at
@@ -31,7 +33,7 @@ class ContactRollupsRaw < ApplicationRecord
     SQL
 
     query = get_extraction_query(source_sql, 'parent_email', [], true, 'dashboard.users.parent_email')
-    ActiveRecord::Base.connection.execute(query)
+    transaction {ActiveRecord::Base.connection.execute(query)}
   end
 
   # @param source [String] Source from which we want to extract data (can be a dashboard table name, or subquery)

--- a/dashboard/app/models/contact_rollups_raw.rb
+++ b/dashboard/app/models/contact_rollups_raw.rb
@@ -18,13 +18,11 @@
 class ContactRollupsRaw < ApplicationRecord
   self.table_name = 'contact_rollups_raw'
 
-  # Extracts opt_in data from dashboard.email_preferences table.
   def self.extract_email_preferences
     query = get_extraction_query('email_preferences', 'email', ['opt_in'])
-    transaction {ActiveRecord::Base.connection.execute(query)}
+    ActiveRecord::Base.connection.execute(query)
   end
 
-  # Extract parent emails from dashboard.users table.
   def self.extract_parent_emails
     source_sql = <<~SQL
       SELECT parent_email, MAX(updated_at) AS updated_at
@@ -33,7 +31,7 @@ class ContactRollupsRaw < ApplicationRecord
     SQL
 
     query = get_extraction_query(source_sql, 'parent_email', [], true, 'dashboard.users.parent_email')
-    transaction {ActiveRecord::Base.connection.execute(query)}
+    ActiveRecord::Base.connection.execute(query)
   end
 
   # @param source [String] Source from which we want to extract data (can be a dashboard table name, or subquery)

--- a/dashboard/lib/contact_rollups_v2.rb
+++ b/dashboard/lib/contact_rollups_v2.rb
@@ -25,6 +25,7 @@ class ContactRollupsV2
       successful_extraction_count += 1
     end
 
+    # If all extractions fail, there is no reason to continue.
     return unless successful_extraction_count
     @log_collector.time_and_raise!('Processes all extracted data') do
       ContactRollupsProcessed.import_from_raw_table

--- a/dashboard/lib/contact_rollups_v2.rb
+++ b/dashboard/lib/contact_rollups_v2.rb
@@ -3,31 +3,45 @@ require 'cdo/log_collector'
 class ContactRollupsV2
   def initialize(is_dry_run: true)
     @is_dry_run = is_dry_run
-    @log_collector = LogCollector.new
+    @log_collector = LogCollector.new('Contact Rollups')
   end
 
   def collect_and_process_contacts
-    @log_collector.time!('Deletes intermediate content from previous runs') do
+    number_of_extractions = 2
+    successful_extraction_count = 0
+
+    @log_collector.time_and_raise!('Deletes intermediate content from previous runs') do
       truncate_or_delete_table ContactRollupsRaw
       truncate_or_delete_table ContactRollupsProcessed
     end
 
-    @log_collector.time!('Extracts data from dashboard email_preferences') do
+    @log_collector.time_and_continue('Extracts data from dashboard email_preferences') do
       ContactRollupsRaw.extract_email_preferences
+      successful_extraction_count += 1
     end
 
-    @log_collector.time!('Extracts parent emails from dashboard.users') do
+    @log_collector.time_and_continue('Extracts parent emails from dashboard.users') do
       ContactRollupsRaw.extract_parent_emails
+      successful_extraction_count += 1
     end
 
-    @log_collector.time!('Processes all extracted data') do
+    return unless successful_extraction_count
+    @log_collector.time_and_raise!('Processes all extracted data') do
       ContactRollupsProcessed.import_from_raw_table
     end
 
-    @log_collector.time!("Overwrites contact_rollups_final table") do
+    # Update the final table only if all the steps above have passed to avoid saving incomplete data.
+    if successful_extraction_count != number_of_extractions
+      @log_collector.info("Skips overwriting contact_rollups_final_table")
+      return
+    end
+
+    @log_collector.time_and_raise!("Overwrites contact_rollups_final table") do
       truncate_or_delete_table ContactRollupsFinal
       ContactRollupsFinal.insert_from_processed_table
     end
+  rescue StandardError => e
+    @log_collector.record_exception(e)
   end
 
   def sync_contacts_with_pardot

--- a/dashboard/lib/contact_rollups_v2.rb
+++ b/dashboard/lib/contact_rollups_v2.rb
@@ -25,7 +25,7 @@ class ContactRollupsV2
       truncate_or_delete_table ContactRollupsProcessed
     end
 
-    @log_collector.time!('Extracts data from dashboard email_preferences') do
+    @log_collector.time!('Extracts email preferences from dashboard.email_preferences') do
       ContactRollupsRaw.extract_email_preferences
     end
 

--- a/dashboard/lib/contact_rollups_v2.rb
+++ b/dashboard/lib/contact_rollups_v2.rb
@@ -1,58 +1,73 @@
+require 'cdo/log_collector'
+
 class ContactRollupsV2
-  def self.build_contact_rollups(log_collector:, sync_with_pardot: false, is_dry_run: true)
-    log_collector.time!('Deletes intermediate content from previous runs') do
+  def initialize(is_dry_run: true)
+    @is_dry_run = is_dry_run
+    @log_collector = LogCollector.new
+  end
+
+  def collect_and_process_contacts
+    @log_collector.time!('Deletes intermediate content from previous runs') do
       truncate_or_delete_table ContactRollupsRaw
       truncate_or_delete_table ContactRollupsProcessed
     end
 
-    log_collector.time!('Extracts email preferences from dashboard.email_preferences') do
+    @log_collector.time!('Extracts data from dashboard email_preferences') do
       ContactRollupsRaw.extract_email_preferences
     end
 
-    log_collector.time!('Extracts parent emails from dashboard.users') do
+    @log_collector.time!('Extracts parent emails from dashboard.users') do
       ContactRollupsRaw.extract_parent_emails
     end
 
-    log_collector.time!('Processes all extracted data') do
+    @log_collector.time!('Processes all extracted data') do
       ContactRollupsProcessed.import_from_raw_table
     end
 
-    if sync_with_pardot
-      unless is_dry_run
-        log_collector.time!('Downloads new email-Pardot ID mappings') do
-          ContactRollupsPardotMemory.download_pardot_ids
-        end
-      end
-
-      log_collector.time!('Creates new Pardot prospects') do
-        ContactRollupsPardotMemory.create_new_pardot_prospects(is_dry_run: is_dry_run)
-      end
-      log_collector.time!('Updates existing Pardot prospects') do
-        ContactRollupsPardotMemory.update_pardot_prospects(is_dry_run: is_dry_run)
-      end
-
-      unless is_dry_run
-        log_collector.time!('Downloads new email-Pardot ID mappings (again)') do
-          ContactRollupsPardotMemory.download_pardot_ids
-        end
-      end
-    end
-
-    log_collector.time!("Overwrites contact_rollups_final table") do
+    @log_collector.time!("Overwrites contact_rollups_final table") do
       truncate_or_delete_table ContactRollupsFinal
       ContactRollupsFinal.insert_from_processed_table
     end
   end
 
+  def sync_contacts_with_pardot
+    unless @is_dry_run
+      @log_collector.time!('Downloads new email-Pardot ID mappings') do
+        ContactRollupsPardotMemory.download_pardot_ids
+      end
+    end
+
+    @log_collector.time!('Creates new Pardot prospects') do
+      ContactRollupsPardotMemory.create_new_pardot_prospects(is_dry_run: @is_dry_run)
+    end
+
+    @log_collector.time!('Updates existing Pardot prospects') do
+      ContactRollupsPardotMemory.update_pardot_prospects(is_dry_run: @is_dry_run)
+    end
+
+    unless @is_dry_run
+      @log_collector.time!('Downloads new email-Pardot ID mappings (again)') do
+        ContactRollupsPardotMemory.download_pardot_ids
+      end
+    end
+  end
+
+  def report_results
+    # TODO: Add reporting to log file, slack channel and AWS CloudWatch.
+    puts @log_collector
+  end
+
+  private
+
   # Using truncate allows us to re-use row IDs,
   # which is important in production so we don't overflow the table.
   # Deletion is required in test environments, as tests generally do
   # not allow you to execute TRUNCATE statements.
-  def self.truncate_or_delete_table(model)
+  def truncate_or_delete_table(model)
     CDO.rack_env == :production ? truncate_table(model) : model.delete_all
   end
 
-  def self.truncate_table(model)
+  def truncate_table(model)
     ActiveRecord::Base.connection.execute("TRUNCATE TABLE #{model.table_name}")
   end
 end

--- a/dashboard/test/lib/contact_rollups_v2_test.rb
+++ b/dashboard/test/lib/contact_rollups_v2_test.rb
@@ -28,12 +28,9 @@ class ContactRollupsV2Test < ActiveSupport::TestCase
     PardotV2.stubs(:submit_batch_request).once.returns([])
 
     # Execute the pipeline
-    cr = ContactRollupsV2.new(is_dry_run: false)
-    cr.build_and_sync
+    cr = ContactRollupsV2.new(is_dry_run: false).build_and_sync
 
-    # Verify results
-
-    # Email preference
+    # Verify email preference
     pardot_memory_record = ContactRollupsPardotMemory.find_by(email: email_preference.email, pardot_id: 1)
     refute_nil pardot_memory_record
     assert_equal({'db_Opt_In' => 'Yes'}, pardot_memory_record.data_synced)
@@ -42,7 +39,7 @@ class ContactRollupsV2Test < ActiveSupport::TestCase
     refute_nil contact_record
     assert_equal 1, contact_record.data['opt_in']
 
-    # Parent email
+    # Verify parent email
     pardot_memory_record = ContactRollupsPardotMemory.find_by(email: student_with_parent_email.parent_email, pardot_id: 2)
     refute_nil pardot_memory_record
     assert_equal({}, pardot_memory_record.data_synced)
@@ -78,8 +75,7 @@ class ContactRollupsV2Test < ActiveSupport::TestCase
     PardotV2.stubs(:submit_batch_request).once.returns([])
 
     # Execute the pipeline
-    cr = ContactRollupsV2.new(is_dry_run: false)
-    cr.build_and_sync
+    cr = ContactRollupsV2.new(is_dry_run: false).build_and_sync
 
     # Verify results
     pardot_memory_record = ContactRollupsPardotMemory.find_by(email: email, pardot_id: pardot_id)

--- a/dashboard/test/lib/contact_rollups_v2_test.rb
+++ b/dashboard/test/lib/contact_rollups_v2_test.rb
@@ -28,7 +28,7 @@ class ContactRollupsV2Test < ActiveSupport::TestCase
     PardotV2.stubs(:submit_batch_request).once.returns([])
 
     # Execute the pipeline
-    cr = ContactRollupsV2.new(is_dry_run: false).build_and_sync
+    ContactRollupsV2.new(is_dry_run: false).build_and_sync
 
     # Verify email preference
     pardot_memory_record = ContactRollupsPardotMemory.find_by(email: email_preference.email, pardot_id: 1)
@@ -75,7 +75,7 @@ class ContactRollupsV2Test < ActiveSupport::TestCase
     PardotV2.stubs(:submit_batch_request).once.returns([])
 
     # Execute the pipeline
-    cr = ContactRollupsV2.new(is_dry_run: false).build_and_sync
+    ContactRollupsV2.new(is_dry_run: false).build_and_sync
 
     # Verify results
     pardot_memory_record = ContactRollupsPardotMemory.find_by(email: email, pardot_id: pardot_id)
@@ -92,15 +92,11 @@ class ContactRollupsV2Test < ActiveSupport::TestCase
     PardotV2.expects(:submit_batch_request).never
     ContactRollupsPardotMemory.expects(:save_accepted_submissions).never
     ContactRollupsPardotMemory.expects(:save_rejected_submissions).never
+
     # Called when downloading Pardot ID-email mappings
     PardotV2.expects(:post_with_auth_retry).never
 
     # Execute the pipeline
-    log_collector = LogCollector.new "Tests end-to-end pipeline"
-    ContactRollupsV2.build_contact_rollups(
-      log_collector: log_collector,
-      sync_with_pardot: true,
-      is_dry_run: true
-    )
+    ContactRollupsV2.new(is_dry_run: true).build_and_sync
   end
 end

--- a/dashboard/test/lib/contact_rollups_v2_test.rb
+++ b/dashboard/test/lib/contact_rollups_v2_test.rb
@@ -1,6 +1,5 @@
 require 'test_helper'
 require 'cdo/contact_rollups/v2/pardot'
-require 'cdo/log_collector'
 
 class ContactRollupsV2Test < ActiveSupport::TestCase
   test 'sync new contact' do
@@ -29,12 +28,8 @@ class ContactRollupsV2Test < ActiveSupport::TestCase
     PardotV2.stubs(:submit_batch_request).once.returns([])
 
     # Execute the pipeline
-    log_collector = LogCollector.new "Tests end-to-end pipeline"
-    ContactRollupsV2.build_contact_rollups(
-      log_collector: log_collector,
-      sync_with_pardot: true,
-      is_dry_run: false
-    )
+    cr = ContactRollupsV2.new(is_dry_run: false)
+    cr.build_and_sync
 
     # Verify results
 
@@ -83,12 +78,8 @@ class ContactRollupsV2Test < ActiveSupport::TestCase
     PardotV2.stubs(:submit_batch_request).once.returns([])
 
     # Execute the pipeline
-    log_collector = LogCollector.new "Tests end-to-end pipeline"
-    ContactRollupsV2.build_contact_rollups(
-      log_collector: log_collector,
-      sync_with_pardot: true,
-      is_dry_run: false
-    )
+    cr = ContactRollupsV2.new(is_dry_run: false)
+    cr.build_and_sync
 
     # Verify results
     pardot_memory_record = ContactRollupsPardotMemory.find_by(email: email, pardot_id: pardot_id)

--- a/lib/cdo/contact_rollups/v2/pardot.rb
+++ b/lib/cdo/contact_rollups/v2/pardot.rb
@@ -62,7 +62,9 @@ class PardotV2
     # Stop when receiving no prospects or reaching the download limit.
     loop do
       url = build_prospect_query_url(last_id, fields, limit_in_query, only_deleted)
-      doc = post_with_auth_retry(url)
+      doc = try_with_exponential_backoff(3) do
+        post_with_auth_retry url
+      end
       raise_if_response_error(doc)
 
       prospects = []
@@ -150,7 +152,9 @@ class PardotV2
     prospect_delta = email_pardot_id.merge delta
     @updated_prospect_deltas << prospect_delta
 
-    delta_submissions, errors = process_batch BATCH_UPDATE_URL, @updated_prospect_deltas, eager_submit
+    delta_submissions, errors = self.class.try_with_exponential_backoff(3) do
+      process_batch BATCH_UPDATE_URL, @updated_prospect_deltas, eager_submit
+    end
     return [], [] unless delta_submissions.present?
 
     # As an optimization, we only send the deltas to Pardot. However, as far as
@@ -163,7 +167,9 @@ class PardotV2
   # Immediately batch-update the remaining prospects in Pardot.
   # @return [Array<Array>] @see process_batch method
   def batch_update_remaining_prospects
-    delta_submissions, errors = process_batch BATCH_UPDATE_URL, @updated_prospect_deltas, true
+    delta_submissions, errors = self.class.try_with_exponential_backoff(3) do
+      process_batch BATCH_UPDATE_URL, @updated_prospect_deltas, true
+    end
     return [], [] unless delta_submissions.present?
 
     full_submissions = @updated_prospects

--- a/lib/cdo/contact_rollups/v2/pardot.rb
+++ b/lib/cdo/contact_rollups/v2/pardot.rb
@@ -119,7 +119,7 @@ class PardotV2
   def batch_create_prospects(email, data, eager_submit = false)
     prospect = self.class.convert_to_pardot_prospect data.merge(email: email)
     @new_prospects << prospect
-
+    # Creating new prospects is not a retriable action, unlike updating existing prospects.
     process_batch BATCH_CREATE_URL, @new_prospects, eager_submit
   end
 

--- a/lib/test/cdo/contact_rollups/test_pardot_helpers.rb
+++ b/lib/test/cdo/contact_rollups/test_pardot_helpers.rb
@@ -35,20 +35,20 @@ class PardotHelpersTest < Minitest::Test
   end
 
   def test_try_with_exponential_backoff_one_retry
-    tries = 0
+    try_counter = 0
     max_tries = 2
     assert_raises RuntimeError do
       PardotHelpersTest.try_with_exponential_backoff(max_tries, [RuntimeError]) do
-        tries += 1
+        try_counter += 1
         raise RuntimeError
       end
     end
-    assert tries == max_tries
+    assert try_counter == max_tries
   end
 
   def test_try_with_exponential_backoff_no_retry
-    tries = 0
-    PardotHelpersTest.try_with_exponential_backoff(3, [RuntimeError]) {tries += 1}
-    assert tries == 1
+    try_counter = 0
+    PardotHelpersTest.try_with_exponential_backoff(3, [RuntimeError]) {try_counter += 1}
+    assert try_counter == 1
   end
 end

--- a/lib/test/cdo/contact_rollups/test_pardot_helpers.rb
+++ b/lib/test/cdo/contact_rollups/test_pardot_helpers.rb
@@ -33,4 +33,22 @@ class PardotHelpersTest < Minitest::Test
 
     assert_nil PardotHelpersTest.send(:raise_if_response_error, pardot_ok)
   end
+
+  def test_try_with_exponential_backoff_one_retry
+    tries = 0
+    max_tries = 2
+    assert_raises RuntimeError do
+      PardotHelpersTest.try_with_exponential_backoff(max_tries, [RuntimeError]) do
+        tries += 1
+        raise RuntimeError
+      end
+    end
+    assert tries == max_tries
+  end
+
+  def test_try_with_exponential_backoff_no_retry
+    tries = 0
+    PardotHelpersTest.try_with_exponential_backoff(3, [RuntimeError]) {tries += 1}
+    assert tries == 1
+  end
 end


### PR DESCRIPTION
[PLC-840](https://codedotorg.atlassian.net/browse/PLC-840) This PR does 3 main things:

1. Breaking the pipeline into 3 main parts: collecting & processing contacts, syncing new contacts to Pardot, and syncing updated contacts to Pardot. This allows each part to run independently. Failures in _syncing new contacts Pardot_ do not affect _syncing updated contacts to Pardot_ and vice versa. 
2. Wraping all data modification queries in transactions so they can be rolled back properly when they fail.
3. Adding retrying with exponential backoff for downloading Pardot prospects and updating existing prospects.

Other smaller things (I must admit they could be in a separate PR):
1. Encapsulating logging responsibility into `ContactRollupsV2` object.
2. Moving query building in `ContactRollupsProcessed` to its own function. It will be easier to write test for this query or test it on a mysql client.
3. Cleaning up `LogCollector` class.

## Testing story
- Unit tests
- [Ongoing] Testing on an adhoc with connection to a production-clone database.

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
