### PR TITLE
Render StandaloneVideo long instructions client-side and use the translations

### DIFF
--- a/apps/src/sites/studio/pages/levels/_standalone_video.js
+++ b/apps/src/sites/studio/pages/levels/_standalone_video.js
@@ -6,6 +6,9 @@ import {
 } from '@cdo/apps/code-studio/levels/postOnLoad';
 import {createVideoWithFallback} from '@cdo/apps/code-studio/videos';
 import getScriptData from '@cdo/apps/util/getScriptData';
+import React from 'react';
+import ReactDom from 'react-dom';
+import SafeMarkdown from '@cdo/apps/templates/SafeMarkdown';
 
 $(document).ready(() => {
   registerGetResult();
@@ -55,4 +58,17 @@ $(document).ready(() => {
     videoFullWidth,
     videoRoundedCorners
   );
+
+  // Render markdown contents
+  $('.standalone-video > .markdown-container').each(function() {
+    const container = this;
+    if (!container.dataset.markdown) {
+      return;
+    }
+
+    ReactDom.render(
+      React.createElement(SafeMarkdown, container.dataset, null),
+      container
+    );
+  });
 });

--- a/dashboard/app/models/levels/standalone_video.rb
+++ b/dashboard/app/models/levels/standalone_video.rb
@@ -67,6 +67,7 @@ class StandaloneVideo < Level
     return I18n.t(name,
       scope: [:data, "long_instructions"],
       default: long_instructions,
+      smart: true
     )
   end
 
@@ -76,6 +77,7 @@ class StandaloneVideo < Level
     return I18n.t(name,
       scope: [:data, "teacher_markdown"],
       default: teacher_markdown,
+      smart: true
     )
   end
 end

--- a/dashboard/app/models/levels/standalone_video.rb
+++ b/dashboard/app/models/levels/standalone_video.rb
@@ -60,4 +60,22 @@ class StandaloneVideo < Level
   def self.create_from_level_builder(params, level_params)
     create!(level_params.merge(user: params[:user], game: Game.standalone_video, level_num: 'custom'))
   end
+
+  def localized_long_instructions
+    return nil unless long_instructions
+    return long_instructions if I18n.en?
+    return I18n.t(name,
+      scope: [:data, "long_instructions"],
+      default: long_instructions,
+    )
+  end
+
+  def localized_teacher_markdown
+    return nil unless teacher_markdown
+    return teacher_markdown if I18n.en?
+    return I18n.t(name,
+      scope: [:data, "teacher_markdown"],
+      default: teacher_markdown,
+    )
+  end
 end

--- a/dashboard/app/views/levels/_standalone_video.html.haml
+++ b/dashboard/app/views/levels/_standalone_video.html.haml
@@ -13,7 +13,10 @@
 
   - unless @level.video_full_width
     %h1= "#{t('video.label')}: #{video.localized_name}"
-  %div= render(inline: @level.long_instructions, type: :md) if @level.long_instructions
+  - long_instructions = @level.long_instructions
+  - if long_instructions
+    / Markdown will be rendered clientside by _standalone_video.js
+    .markdown-container{data: {markdown: long_instructions}}
 
   .video-content
   - if @slides

--- a/dashboard/app/views/levels/_standalone_video.html.haml
+++ b/dashboard/app/views/levels/_standalone_video.html.haml
@@ -13,7 +13,7 @@
 
   - unless @level.video_full_width
     %h1= "#{t('video.label')}: #{video.localized_name}"
-  - long_instructions = @level.long_instructions
+  - long_instructions = @level.localized_long_instructions
   - if long_instructions
     / Markdown will be rendered clientside by _standalone_video.js
     .markdown-container{data: {markdown: long_instructions}}
@@ -47,4 +47,4 @@
       %a.btn.btn-large.btn-primary.next-stage.submitButton
         =t('continue')
 
-  = render partial: 'levels/teacher_markdown', locals: {data: {'teacher_markdown' => @level.teacher_markdown}}
+  = render partial: 'levels/teacher_markdown', locals: {data: {'teacher_markdown' => @level.localized_teacher_markdown}}

--- a/dashboard/config/scripts/levels/OPD-K5 CS Video.level
+++ b/dashboard/config/scripts/levels/OPD-K5 CS Video.level
@@ -1,20 +1,20 @@
 <StandaloneVideo>
   <config><![CDATA[{
   "game_id": 54,
-  "created_at": "2019-10-21T18:26:17.000Z",
+  "created_at": "2019-10-31T17:41:59.000Z",
   "level_num": "custom",
   "user_id": 898,
   "properties": {
     "encrypted": "false",
     "video_key": "how-to-k5-workshops",
     "instructions_important": "false",
-    "long_instructions": "## Getting Started: Why Computer Science (CS) Fundamentals?\r\n\r\nYou'll complete this free, self-paced course using the same learning platform you can use in your classroom with your students. \r\n\r\nLet's start by learning a bit about what Computer Science (CS) Fundamentals is, and how it's worked for teachers and students around the globe. In the next level, we'll cover how to interact with the CS Fundamentals learning platform, which you'll be using to complete this course.\r\n\r\n> ## Reflect\r\nWhat are your first impressions of CS Fundamentals?\r\n\r\n> [Tweet your thoughts](https://twitter.com/teachcode) and be sure to tag @teachcode in your tweet so we can respond.\r\n\r\n> <a href=\"http://ctt.ec/Bfjw3\" target=\"blank\"><button class=\"default\">Share on Twitter >></button></a><br><br>\r\nDon't have a Twitter account? You can also find us on [Facebook](https://www.facebook.com/Code.org/) or [Instagram](https://www.instagram.com/codeorg/).",
+    "long_instructions": "## Getting Started: Why Computer Science (CS) Fundamentals?\r\n\r\nYou'll complete this free, self-paced course using the same learning platform you can use in your classroom with your students. \r\n\r\nLet's start by learning a bit about what Computer Science (CS) Fundamentals is, and how it's worked for teachers and students around the globe. In the next level, we'll cover how to interact with the CS Fundamentals learning platform, which you'll be using to complete this course.\r\n\r\n> ## Reflect\r\nWhat are your first impressions of CS Fundamentals?\r\n>\r\n> [Tweet your thoughts](https://twitter.com/teachcode) and be sure to tag @teachcode in your tweet so we can respond.\r\n>\r\n> <a href=\"http://ctt.ec/Bfjw3\" target=\"blank\">Share on Twitter >></a>\r\n>\r\nDon't have a Twitter account? You can also find us on [Facebook](https://www.facebook.com/Code.org/) or [Instagram](https://www.instagram.com/codeorg/).",
     "skip_dialog": true,
     "skip_sound": true
   },
   "published": true,
   "notes": "",
-  "audit_log": "[{\"changed_at\":\"2019-10-21 18:29:07 +0000\",\"changed\":[],\"changed_by_id\":898,\"changed_by_email\":\"bryan+teacher@code.org\"},{\"changed_at\":\"2019-10-21 18:29:58 +0000\",\"changed\":[\"long_instructions\"],\"changed_by_id\":898,\"changed_by_email\":\"bryan+teacher@code.org\"},{\"changed_at\":\"2019-10-21 19:18:55 +0000\",\"changed\":[\"name\"],\"changed_by_id\":898,\"changed_by_email\":\"bryan+teacher@code.org\"},{\"changed_at\":\"2019-10-21 19:22:25 +0000\",\"changed\":[],\"changed_by_id\":898,\"changed_by_email\":\"bryan+teacher@code.org\"}]",
+  "audit_log": "[{\"changed_at\":\"2019-10-21 18:29:07 +0000\",\"changed\":[],\"changed_by_id\":898,\"changed_by_email\":\"bryan+teacher@code.org\"},{\"changed_at\":\"2019-10-21 18:29:58 +0000\",\"changed\":[\"long_instructions\"],\"changed_by_id\":898,\"changed_by_email\":\"bryan+teacher@code.org\"},{\"changed_at\":\"2019-10-21 19:18:55 +0000\",\"changed\":[\"name\"],\"changed_by_id\":898,\"changed_by_email\":\"bryan+teacher@code.org\"},{\"changed_at\":\"2019-10-21 19:22:25 +0000\",\"changed\":[],\"changed_by_id\":898,\"changed_by_email\":\"bryan+teacher@code.org\"},{\"changed_at\":\"2020-05-19 23:39:27 +0000\",\"changed\":[\"long_instructions\"],\"changed_by_id\":10,\"changed_by_email\":\"bethany+levelbuilder@code.org\"},{\"changed_at\":\"2020-05-19 23:46:57 +0000\",\"changed\":[\"long_instructions\"],\"changed_by_id\":10,\"changed_by_email\":\"bethany+levelbuilder@code.org\"}]",
   "level_concept_difficulty": {
   }
 }]]></config>

--- a/dashboard/config/scripts/levels/OPD-K5 Closing.level
+++ b/dashboard/config/scripts/levels/OPD-K5 Closing.level
@@ -1,17 +1,21 @@
 <StandaloneVideo>
   <config><![CDATA[{
   "game_id": 54,
-  "created_at": "2019-02-15T19:37:35.000Z",
+  "created_at": "2019-02-19T17:36:57.000Z",
   "level_num": "custom",
   "user_id": 884,
   "properties": {
     "video_key": "opd_closing",
     "instructions_important": "false",
-    "long_instructions": "> **If you enjoyed this course, sign up for an in-person workshop:**\r\n\r\n> [Sign up now](http://code.org/professional-development-workshops) to continue learning computer science and its pedagogy. The free in-person workshops are a valuable place to collaborate and engage with other passionate educators in your area.",
+    "long_instructions": "> **If you enjoyed this course, sign up for an in-person workshop:**\r\n>\r\n> [Sign up now](http://code.org/professional-development-workshops) to continue learning computer science and its pedagogy. The free in-person workshops are a valuable place to collaborate and engage with other passionate educators in your area.",
     "skip_dialog": true,
-    "skip_sound": true
+    "skip_sound": true,
+    "encrypted": "false"
   },
   "published": true,
-  "notes": ""
+  "notes": "",
+  "audit_log": "[{\"changed_at\":\"2020-05-19 23:35:36 +0000\",\"changed\":[\"long_instructions\"],\"changed_by_id\":10,\"changed_by_email\":\"bethany+levelbuilder@code.org\"}]",
+  "level_concept_difficulty": {
+  }
 }]]></config>
 </StandaloneVideo>

--- a/dashboard/config/scripts/levels/OPD-K5 Closing_copy.level
+++ b/dashboard/config/scripts/levels/OPD-K5 Closing_copy.level
@@ -1,13 +1,13 @@
 <StandaloneVideo>
   <config><![CDATA[{
   "game_id": 54,
-  "created_at": "2019-10-21T17:56:49.000Z",
+  "created_at": "2019-10-31T17:41:59.000Z",
   "level_num": "custom",
   "user_id": 884,
   "properties": {
     "video_key": "opd_closing",
     "instructions_important": "false",
-    "long_instructions": "> **If you enjoyed this course, sign up for an in-person workshop:**\r\n\r\n> <a href=\"http://code.org/professional-development-workshops\" target=\"blank\">Sign up now</a> to continue learning computer science and its pedagogy. The free in-person workshops are a valuable place to collaborate and engage with other passionate educators in your area.",
+    "long_instructions": "> **If you enjoyed this course, sign up for an in-person workshop:**\r\n>\r\n> <a href=\"http://code.org/professional-development-workshops\" target=\"blank\">Sign up now</a> to continue learning computer science and its pedagogy. The free in-person workshops are a valuable place to collaborate and engage with other passionate educators in your area.",
     "skip_dialog": true,
     "skip_sound": true,
     "parent_level_id": 16685,
@@ -16,7 +16,7 @@
   },
   "published": true,
   "notes": "",
-  "audit_log": "[{\"changed_at\":\"2019-11-14 21:57:53 +0000\",\"changed\":[\"long_instructions\"],\"changed_by_id\":884,\"changed_by_email\":\"emma@code.org\"}]",
+  "audit_log": "[{\"changed_at\":\"2019-11-14 21:57:53 +0000\",\"changed\":[\"long_instructions\"],\"changed_by_id\":884,\"changed_by_email\":\"emma@code.org\"},{\"changed_at\":\"2020-05-19 23:36:15 +0000\",\"changed\":[\"long_instructions\"],\"changed_by_id\":10,\"changed_by_email\":\"bethany+levelbuilder@code.org\"}]",
   "level_concept_difficulty": {
   }
 }]]></config>

--- a/dashboard/config/scripts/levels/OPD-K5 Problem Solving Video.level
+++ b/dashboard/config/scripts/levels/OPD-K5 Problem Solving Video.level
@@ -1,20 +1,20 @@
 <StandaloneVideo>
   <config><![CDATA[{
   "game_id": 54,
-  "created_at": "2019-10-15T21:11:59.000Z",
+  "created_at": "2019-10-31T17:41:59.000Z",
   "level_num": "custom",
   "user_id": 177,
   "properties": {
     "encrypted": "false",
     "video_key": "CSF-Teaching-Problem-Solving",
     "instructions_important": "false",
-    "long_instructions": "# Best Practices > Meta-Cognitive Problem Solving\r\n\r\nExplicitly teaching meta-cognitive problem solving strategies before, during and after coding is extremely important in helping students process their learning. Mega-cognitive problem solving involves thinking about your thought process itself, and reflecting on _how_ you solve problems. Watch the video below to learn about Code.org's \"Puzzle Solving Recipe\" that can help students have success with difficult problems:\r\n\r\n[This worksheet](http://code.org/curriculum/docs/k-5/PuzzleSolvingStudent.png) details the different steps of the Puzzle Solving Recipe.\r\n\r\n<img src=\"https://images.code.org/18ec61f8b911b83ca1cdea404a34c40e-image-1434399798952.png\" width=\"650px\" style=\"margin-right:45px; border-radius:10px;\">\r\n\r\n> ## Reflect: \r\n> How might you explicitly teach problem solving in your CS classroom?\r\n\r\n> [Tweet your thoughts](https://twitter.com/teachcode) and be sure to tag @teachcode in your tweet so we can respond.\r\n\r\n> <a href=\"http://ctt.ec/ic2bx\" target=\"blank\"><h4><i class=\"fa fa-external-link-square\" ></i> Share on Twitter</h4></a>",
+    "long_instructions": "# Best Practices > Meta-Cognitive Problem Solving\r\n\r\nExplicitly teaching meta-cognitive problem solving strategies before, during and after coding is extremely important in helping students process their learning. Mega-cognitive problem solving involves thinking about your thought process itself, and reflecting on _how_ you solve problems. Watch the video below to learn about Code.org's \"Puzzle Solving Recipe\" that can help students have success with difficult problems:\r\n\r\n[This worksheet](http://code.org/curriculum/docs/k-5/PuzzleSolvingStudent.png) details the different steps of the Puzzle Solving Recipe.\r\n\r\n<img src=\"https://images.code.org/18ec61f8b911b83ca1cdea404a34c40e-image-1434399798952.png\" width=\"650px\" style=\"margin-right:45px; border-radius:10px;\">\r\n\r\n> ## Reflect: \r\n> How might you explicitly teach problem solving in your CS classroom?\r\n>\r\n> [Tweet your thoughts](https://twitter.com/teachcode) and be sure to tag @teachcode in your tweet so we can respond.\r\n>\r\n> <a href=\"http://ctt.ec/ic2bx\" target=\"blank\"><h4><i class=\"fa fa-external-link-square\" ></i> Share on Twitter</h4></a>",
     "skip_dialog": true,
     "skip_sound": true
   },
   "published": true,
   "notes": "",
-  "audit_log": "[{\"changed_at\":\"2019-10-15 21:13:36 +0000\",\"changed\":[\"name\"],\"changed_by_id\":177,\"changed_by_email\":\"josh.schulte@code.org\"},{\"changed_at\":\"2019-10-15 21:15:05 +0000\",\"changed\":[\"long_instructions\"],\"changed_by_id\":177,\"changed_by_email\":\"josh.schulte@code.org\"},{\"changed_at\":\"2019-10-21 19:11:53 +0000\",\"changed\":[\"long_instructions\"],\"changed_by_id\":898,\"changed_by_email\":\"bryan+teacher@code.org\"}]",
+  "audit_log": "[{\"changed_at\":\"2019-10-15 21:13:36 +0000\",\"changed\":[\"name\"],\"changed_by_id\":177,\"changed_by_email\":\"josh.schulte@code.org\"},{\"changed_at\":\"2019-10-15 21:15:05 +0000\",\"changed\":[\"long_instructions\"],\"changed_by_id\":177,\"changed_by_email\":\"josh.schulte@code.org\"},{\"changed_at\":\"2019-10-21 19:11:53 +0000\",\"changed\":[\"long_instructions\"],\"changed_by_id\":898,\"changed_by_email\":\"bryan+teacher@code.org\"},{\"changed_at\":\"2020-05-19 23:40:21 +0000\",\"changed\":[\"long_instructions\"],\"changed_by_id\":10,\"changed_by_email\":\"bethany+levelbuilder@code.org\"}]",
   "level_concept_difficulty": {
   }
 }]]></config>

--- a/dashboard/config/scripts/levels/OPD-K5 Problem Solving.level
+++ b/dashboard/config/scripts/levels/OPD-K5 Problem Solving.level
@@ -1,20 +1,20 @@
 <StandaloneVideo>
   <config><![CDATA[{
   "game_id": 54,
-  "created_at": "2015-06-09T18:59:20.000Z",
+  "created_at": "2019-02-07T19:58:30.000Z",
   "level_num": "custom",
   "user_id": 177,
   "properties": {
     "encrypted": "false",
     "video_key": "CSF-Teaching-Problem-Solving",
     "instructions_important": "false",
-    "long_instructions": "# Best Practices > Meta-Cognitive Problem Solving\r\n\r\nExplicitly teaching meta-cognitive problem solving strategies before, during and after coding is extremely important in helping students process their learning. Mega-cognitive problem solving involves thinking about your thought process itself, and reflecting on _how_ you solve problems. Watch the video below to learn about Code.org's \"Puzzle Solving Recipe\" that can help students have success with difficult problems:\r\n\r\n[This worksheet](http://code.org/curriculum/docs/k-5/PuzzleSolvingStudent.png) details the different steps of the Puzzle Solving Recipe.\r\n\r\n<img src=\"https://images.code.org/18ec61f8b911b83ca1cdea404a34c40e-image-1434399798952.png\" width=\"650px\" style=\"margin-right:45px; border-radius:10px;\">\r\n\r\n> ## Reflect: \r\n> How might you explicitly teach problem solving in your CS classroom?\r\n\r\n> [Tweet your thoughts](https://twitter.com/teachcode) and be sure to tag @teachcode in your tweet so we can respond.\r\n\r\n> <a href=\"http://ctt.ec/ic2bx\" target=\"blank\"><h4><i class=\"fa fa-external-link-square\" ></i> Share on Twitter</h4></a>",
+    "long_instructions": "# Best Practices > Meta-Cognitive Problem Solving\r\n\r\nExplicitly teaching meta-cognitive problem solving strategies before, during and after coding is extremely important in helping students process their learning. Mega-cognitive problem solving involves thinking about your thought process itself, and reflecting on _how_ you solve problems. Watch the video below to learn about Code.org's \"Puzzle Solving Recipe\" that can help students have success with difficult problems:\r\n\r\n[This worksheet](http://code.org/curriculum/docs/k-5/PuzzleSolvingStudent.png) details the different steps of the Puzzle Solving Recipe.\r\n\r\n<img src=\"https://images.code.org/18ec61f8b911b83ca1cdea404a34c40e-image-1434399798952.png\" width=\"650px\" style=\"margin-right:45px; border-radius:10px;\">\r\n\r\n> ## Reflect: \r\n> How might you explicitly teach problem solving in your CS classroom?\r\n>\r\n> [Tweet your thoughts](https://twitter.com/teachcode) and be sure to tag @teachcode in your tweet so we can respond.\r\n>\r\n> <a href=\"http://ctt.ec/ic2bx\" target=\"blank\"><h4><i class=\"fa fa-external-link-square\" ></i> Share on Twitter</h4></a>",
     "skip_dialog": true,
     "skip_sound": true
   },
   "published": true,
   "notes": "",
-  "audit_log": "[{\"changed_at\":\"2019-10-21 19:08:25 +0000\",\"changed\":[\"long_instructions\"],\"changed_by_id\":898,\"changed_by_email\":\"bryan+teacher@code.org\"},{\"changed_at\":\"2019-10-21 19:11:37 +0000\",\"changed\":[\"long_instructions\"],\"changed_by_id\":898,\"changed_by_email\":\"bryan+teacher@code.org\"}]",
+  "audit_log": "[{\"changed_at\":\"2019-10-21 19:08:25 +0000\",\"changed\":[\"long_instructions\"],\"changed_by_id\":898,\"changed_by_email\":\"bryan+teacher@code.org\"},{\"changed_at\":\"2019-10-21 19:11:37 +0000\",\"changed\":[\"long_instructions\"],\"changed_by_id\":898,\"changed_by_email\":\"bryan+teacher@code.org\"},{\"changed_at\":\"2020-05-19 23:32:22 +0000\",\"changed\":[\"long_instructions\"],\"changed_by_id\":10,\"changed_by_email\":\"bethany+levelbuilder@code.org\"}]",
   "level_concept_difficulty": {
   }
 }]]></config>


### PR DESCRIPTION
This PR:
- Switches the long instructions for StandaloneVideo levels to be rendered clientside
- Fixes up a handful of levels that had differences
- Use the translated long instructions and teacher markdown for StandaloneLevels

Elijah paired with me to write the code that led to e63e69c as well as helping me identify the levels that needed to be reviewed.


# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
