### PR TITLE
Foorm: allow emojis in submissions, completed

### DIFF
--- a/dashboard/app/models/foorm/submission.rb
+++ b/dashboard/app/models/foorm/submission.rb
@@ -5,20 +5,11 @@
 #  id           :integer          not null, primary key
 #  form_name    :string(255)      not null
 #  form_version :integer          not null
-#  answers      :text(4294967295) not null
+#  answers      :text(16777215)   not null
 #  created_at   :datetime         not null
 #  updated_at   :datetime         not null
 #
 
 class Foorm::Submission < ActiveRecord::Base
   belongs_to :foorm_form
-  before_validation :strip_emoji_from_answers
-
-  # Drops unicode characters not supported by utf8mb3 strings (most commonly emoji)
-  # from the submission answers
-  # We can remove this once our database has utf8mb4 support everywhere.
-  def strip_emoji_from_answers
-    # Drop emoji and other unsupported characters
-    self.answers = answers&.strip_utf8mb4&.strip
-  end
 end

--- a/dashboard/config/database.yml
+++ b/dashboard/config/database.yml
@@ -86,8 +86,8 @@ levelbuilder:
 # Do not set this db to the same as development or production.
 test:
   adapter: mysql2
-  encoding: utf8
-  collation: utf8_unicode_ci
+  encoding: utf8mb4
+  collation: utf8mb4_unicode_ci
   username: <%= writer.user || 'root' %>
   password: <%= writer.password || '' %>
   host: <%= writer.host || 'localhost' %>

--- a/dashboard/test/models/foorm/submission_test.rb
+++ b/dashboard/test/models/foorm/submission_test.rb
@@ -3,7 +3,7 @@ require 'test_helper'
 class Foorm::SubmissionTest < ActiveSupport::TestCase
   test 'submission strips out emojis from answers' do
     submission = create :basic_foorm_submission, answers: "{'a': 'b', 'c': '#{panda_panda} hello'}"
-    expected_answers = "{'a': 'b', 'c': 'Panda hello'}"
+    expected_answers = "{'a': 'b', 'c': '#{panda_panda} hello'}"
     assert_equal expected_answers, submission.answers
   end
 end


### PR DESCRIPTION
Followup to the migration in https://github.com/code-dot-org/code-dot-org/pull/34868.  Now that the migration is live, we can discontinue filtering emojis out of Foorm submissions.

Also updates an annotation, and updates the encoding used for the test database.
