### PR TITLE
Foorm: Minor rollups fixes

### DIFF
--- a/dashboard/app/controllers/pd/workshop_daily_survey_controller.rb
+++ b/dashboard/app/controllers/pd/workshop_daily_survey_controller.rb
@@ -538,7 +538,7 @@ module Pd
         render_404
         return false
       end
-      unless session.open_for_attendance? || day == workshop.sessions.size
+      unless params[:bypass_date] || session.open_for_attendance? || day == workshop.sessions.size
         render :too_late
         return false
       end

--- a/dashboard/config/foorm/rollups/rollups_by_course.json
+++ b/dashboard/config/foorm/rollups/rollups_by_course.json
@@ -3,12 +3,18 @@
     "general": [
       {"question_id": "teacher_engagement", "header_text": "Teacher Engagement"},
       {"question_id": "overall_success", "header_text": "Overall Success"}
+    ],
+    "facilitator": [
+      {"question_id":  "facilitator_effectiveness", "header_text":  "Facilitator Effectiveness"}
     ]
   },
   "CS Discoveries": {
     "general": [
       {"question_id": "teacher_engagement", "header_text": "Teacher Engagement"},
       {"question_id": "overall_success", "header_text": "Overall Success"}
+    ],
+    "facilitator": [
+      {"question_id":  "facilitator_effectiveness", "header_text":  "Facilitator Effectiveness"}
     ]
   },
   "CS Fundamentals": {

--- a/dashboard/lib/pd/foorm/foorm_parser.rb
+++ b/dashboard/lib/pd/foorm/foorm_parser.rb
@@ -137,7 +137,11 @@ module Pd::Foorm
     def self.flatten_choices(choices)
       choices_obj = {}
       choices.each do |choice_hash|
-        choices_obj[choice_hash[:value]] = fill_question_placeholders(choice_hash[:text])
+        if choice_hash.class == Hash && choice_hash.key?(:value) && choice_hash.key?(:text)
+          choices_obj[choice_hash[:value]] = fill_question_placeholders(choice_hash[:text])
+        elsif choice_hash.class == String
+          choices_obj[choice_hash] = fill_question_placeholders(choice_hash)
+        end
       end
       choices_obj
     end

--- a/dashboard/lib/pd/foorm/foorm_parser.rb
+++ b/dashboard/lib/pd/foorm/foorm_parser.rb
@@ -141,6 +141,9 @@ module Pd::Foorm
           choices_obj[choice_hash[:value]] = fill_question_placeholders(choice_hash[:text])
         elsif choice_hash.class == String
           choices_obj[choice_hash] = fill_question_placeholders(choice_hash)
+          Honeybadger.notify(
+            "Foorm configuration without key-value choice detected. Choice is #{choice_hash}. Please update the survey configuration."
+          )
         end
       end
       choices_obj

--- a/dashboard/lib/pd/foorm/foorm_parser.rb
+++ b/dashboard/lib/pd/foorm/foorm_parser.rb
@@ -142,7 +142,7 @@ module Pd::Foorm
         elsif choice_hash.class == String
           choices_obj[choice_hash] = fill_question_placeholders(choice_hash)
           Honeybadger.notify(
-            "Foorm configuration without key-value choice detected. Choice is #{choice_hash}. Please update the survey configuration."
+            "Foorm configuration contains question without key-value choice. Choice is '#{choice_hash}'. Please update the survey configuration."
           )
         end
       end

--- a/dashboard/lib/pd/foorm/foorm_parser.rb
+++ b/dashboard/lib/pd/foorm/foorm_parser.rb
@@ -116,8 +116,8 @@ module Pd::Foorm
     def self.get_friendly_rating_choices(question_data)
       choices = {}
       # survey js default min/max is 1/5
-      min_rate = 1 || question_data[:rateMin]
-      max_rate = 5 || question_data[:rateMax]
+      min_rate = question_data[:rateMin] || 1
+      max_rate = question_data[:rateMax] || 5
       min_rate_description = question_data[:minRateDescription] ?
                                "#{min_rate} - #{question_data[:minRateDescription]}" :
                                min_rate.to_s

--- a/dashboard/lib/pd/foorm/helper.rb
+++ b/dashboard/lib/pd/foorm/helper.rb
@@ -8,11 +8,28 @@ module Pd::Foorm
     # get friendly name for survey based on submission.
     # Name will either be Day X or Overall
     def get_survey_key(ws_submission)
+      if ws_submission.day == 0
+        return "Pre Workshop"
+      end
       if ws_submission.day
         return "Day #{ws_submission.day}"
       else
-        return "Overall"
+        return "Post Workshop"
       end
+    end
+
+    # Get order for each survey_key
+    # Pre-Workshop is first, daily surveys (named Day X)
+    # are ordered by day, and post-workshop is last.
+    def get_index_for_survey_key(survey_key)
+      if survey_key == "Pre Workshop"
+        return 0
+      end
+      if survey_key.include?("Day")
+        return survey_key[4..-1].to_i
+      end
+      # anything else (post workshop) should go last
+      return 1000
     end
   end
 end

--- a/dashboard/lib/pd/foorm/workshop_summarizer.rb
+++ b/dashboard/lib/pd/foorm/workshop_summarizer.rb
@@ -63,7 +63,7 @@ module Pd::Foorm
           )
         end
       end
-      workshop_summary
+      sort_summary(workshop_summary)
     end
 
     def self.get_response_count_per_survey(workshop_id, form_name, form_version)
@@ -157,6 +157,17 @@ module Pd::Foorm
         end
       end
       summary_at_question
+    end
+
+    # Sort summaries so that survey data is ordered in the order surveys
+    # should be taken in. i.e. Pre-Workshop, Day 1, Day 2,.. Post-Workshop
+    def self.sort_summary(workshop_summary)
+      temp_summary = workshop_summary.sort_by {|survey_key, _| get_index_for_survey_key(survey_key)}
+      workshop_summary_sorted = {}
+      temp_summary.each do |summaries|
+        workshop_summary_sorted[summaries[0]] = summaries[1]
+      end
+      workshop_summary_sorted
     end
   end
 end

--- a/dashboard/lib/pd/foorm/workshop_summarizer.rb
+++ b/dashboard/lib/pd/foorm/workshop_summarizer.rb
@@ -161,9 +161,12 @@ module Pd::Foorm
 
     # Sort summaries so that survey data is ordered in the order surveys
     # should be taken in. i.e. Pre-Workshop, Day 1, Day 2,.. Post-Workshop
+    # @param workshop_summary: object in the format returned by summarize_answers_by_survey
     def self.sort_summary(workshop_summary)
       temp_summary = workshop_summary.sort_by {|survey_key, _| get_index_for_survey_key(survey_key)}
       workshop_summary_sorted = {}
+      # temp_summary is an array in the format [[survey_key, summary],[survey_key2, summary2],...]
+      # want to convert back to {survey_key: summary, survey_key2: summary2}
       temp_summary.each do |summaries|
         workshop_summary_sorted[summaries[0]] = summaries[1]
       end

--- a/dashboard/test/controllers/api/v1/pd/workshop_survey_foorm_report_controller_test.rb
+++ b/dashboard/test/controllers/api/v1/pd/workshop_survey_foorm_report_controller_test.rb
@@ -50,7 +50,7 @@ module Api::V1::Pd
       get :generic_survey_report, params: {workshop_id: @workshop.id}
       assert_response :success
       response = JSON.parse(@response.body)
-      day_0_general_response = response['this_workshop']['Day 0']['general']
+      day_0_general_response = response['this_workshop']['Pre Workshop']['general']
 
       assert_equal 2, day_0_general_response['response_count']
       matrix_response = day_0_general_response['surveys/pd/summer_workshop_pre_survey.0']['teaching_cs_matrix']
@@ -85,12 +85,12 @@ module Api::V1::Pd
 
       get :generic_survey_report, params: {workshop_id: csf_workshop.id}
       assert_response :success
-      response = JSON.parse(@response.body, symbolize_names: true)
+      response = JSON.parse(@response.body).with_indifferent_access
 
       assert_equal 'CS Fundamentals', response[:course_name]
       assert_not_empty response[:questions]
       assert_not_empty response[:this_workshop]
-      assert_equal 5, response[:this_workshop][:Overall][:general][:response_count]
+      assert_equal 5, response[:this_workshop]['Post Workshop'][:general][:response_count]
 
       assert_not_empty response[:workshop_rollups]
       general_rollup = response[:workshop_rollups][:general]
@@ -116,12 +116,12 @@ module Api::V1::Pd
 
       get :generic_survey_report, params: {workshop_id: csf_workshop.id}
       assert_response :success
-      response = JSON.parse(@response.body, symbolize_names: true)
+      response = JSON.parse(@response.body).with_indifferent_access
 
       assert_equal 'CS Fundamentals', response[:course_name]
       assert_not_empty response[:questions]
       assert_not_empty response[:this_workshop]
-      assert_equal 6, response[:this_workshop][:Overall][:general][:response_count]
+      assert_equal 6, response[:this_workshop]['Post Workshop'][:general][:response_count]
 
       assert_not_empty response[:workshop_rollups]
 
@@ -197,14 +197,14 @@ module Api::V1::Pd
       get :generic_survey_report, params: {workshop_id: csf_workshop.id}
       assert_response :success
 
-      response = JSON.parse(@response.body, symbolize_names: true)
+      response = JSON.parse(@response.body).with_indifferent_access
 
       facilitator_1_id = facilitator_1.id.to_s.to_sym
       facilitator_2_id = facilitator_2.id.to_s.to_sym
 
-      assert_equal 7, response[:this_workshop][:Overall][:facilitator][:response_count][facilitator_1_id]
+      assert_equal 7, response[:this_workshop]['Post Workshop'][:facilitator][:response_count][facilitator_1_id]
 
-      overall_facilitator = response[:this_workshop][:Overall][:facilitator]['surveys/pd/workshop_csf_intro_post.0'.to_sym]
+      overall_facilitator = response[:this_workshop]['Post Workshop'][:facilitator]['surveys/pd/workshop_csf_intro_post.0'.to_sym]
       facilitator_effectiveness = overall_facilitator[:facilitator_effectiveness]
       # Verify see results for facilitator 1
       assert_not_nil facilitator_effectiveness[facilitator_1_id][:on_track]

--- a/dashboard/test/lib/pd/foorm/workshop_summarizer_test.rb
+++ b/dashboard/test/lib/pd/foorm/workshop_summarizer_test.rb
@@ -23,7 +23,7 @@ module Pd::Foorm
       )
 
       expected_result = {
-        'Day 0': {
+        'Pre Workshop': {
           general: {
             response_count: 2,
             'surveys/pd/summer_workshop_pre_survey.0': {
@@ -91,7 +91,7 @@ module Pd::Foorm
         ws_submissions
       ).with_indifferent_access
 
-      facilitator_answers = summarized_answers[:Overall][:facilitator]['surveys/pd/workshop_csf_intro_post.0']
+      facilitator_answers = summarized_answers['Post Workshop'.to_s][:facilitator]['surveys/pd/workshop_csf_intro_post.0']
       assert_not_empty facilitator_answers
       expected_matrix_data = {
         demonstrated_knowledge: {"7": 1, "1": 1},
@@ -148,7 +148,7 @@ module Pd::Foorm
         healthy_relationship: {"1": 3}
       }.with_indifferent_access
 
-      facilitator_answers = summarized_answers[:Overall][:facilitator]['surveys/pd/workshop_csf_intro_post.0']
+      facilitator_answers = summarized_answers['Post Workshop'.to_s][:facilitator]['surveys/pd/workshop_csf_intro_post.0']
       assert_not_empty facilitator_answers
 
       assert_equal expected_matrix_data_high, facilitator_answers[:facilitator_effectiveness][facilitator1.id]


### PR DESCRIPTION
A couple rollups fixes to make things work for daily workshop pattern:
- rename tabs to Pre Workshop, Day 1, Day 2,..., Post Workshop (was Day 0, Day 1,..., General)
- sort tabs to always be in the order Pre Workshop, Day 1,..., Post Workshop (they could come out of order if for some reason someone took the Day 1 survey before the Pre Survey, for example)
- don't throw an exception if the survey configuration does not have a key and value for an answer choice (ex instead of a hash for an answer choice it uses just 1 string). In that case use the string for the key and value. We want to try to enforce using a key/value but don't want to fail if it's used.
- add facilitator rollups configuration for CSD and CSP.
- add a flag `bypass_date` so we can force-show daily surveys for testing

<!-- ### Background -->
<!-- ### Privacy -->
<!-- ### Security -->
<!-- ### Caching -->
<!-- ### Deployment strategy -->
<!-- ### Future work -->

## Testing story
Updated unit tests and ensured existing functionality (CSF Intro) was not affected. This change enables viewing of CSD/CSP rollups, as they were throwing an error due to the new configuration sometimes using strings instead of hashes for answer options.

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
