### PR TITLE
Suppress workshop email

### DIFF
--- a/dashboard/app/controllers/api/v1/pd/workshop_enrollments_controller.rb
+++ b/dashboard/app/controllers/api/v1/pd/workshop_enrollments_controller.rb
@@ -63,7 +63,7 @@ class Api::V1::Pd::WorkshopEnrollmentsController < ApplicationController
         if user
           user.update_school_info(enrollment.school_info)
         end
-        Pd::WorkshopMailer.teacher_enrollment_receipt(enrollment).deliver_now
+        Pd::WorkshopMailer.teacher_enrollment_receipt(enrollment).deliver_now unless @workshop.suppress_email?
         Pd::WorkshopMailer.organizer_enrollment_receipt(enrollment).deliver_now
 
         render json: {

--- a/dashboard/app/controllers/api/v1/pd/workshop_enrollments_controller.rb
+++ b/dashboard/app/controllers/api/v1/pd/workshop_enrollments_controller.rb
@@ -63,7 +63,7 @@ class Api::V1::Pd::WorkshopEnrollmentsController < ApplicationController
         if user
           user.update_school_info(enrollment.school_info)
         end
-        Pd::WorkshopMailer.teacher_enrollment_receipt(enrollment).deliver_now unless @workshop.suppress_email?
+        Pd::WorkshopMailer.teacher_enrollment_receipt(enrollment).deliver_now
         Pd::WorkshopMailer.organizer_enrollment_receipt(enrollment).deliver_now
 
         render json: {

--- a/dashboard/app/controllers/api/v1/pd/workshops_controller.rb
+++ b/dashboard/app/controllers/api/v1/pd/workshops_controller.rb
@@ -228,7 +228,7 @@ class Api::V1::Pd::WorkshopsController < ::ApplicationController
 
   def notify
     @workshop.enrollments.each do |enrollment|
-      Pd::WorkshopMailer.detail_change_notification(enrollment).deliver_now unless @workshop.suppress_email?
+      Pd::WorkshopMailer.detail_change_notification(enrollment).deliver_now
     end
     @workshop.facilitators.each do |facilitator|
       Pd::WorkshopMailer.facilitator_detail_change_notification(facilitator, @workshop).deliver_now

--- a/dashboard/app/controllers/api/v1/pd/workshops_controller.rb
+++ b/dashboard/app/controllers/api/v1/pd/workshops_controller.rb
@@ -228,7 +228,7 @@ class Api::V1::Pd::WorkshopsController < ::ApplicationController
 
   def notify
     @workshop.enrollments.each do |enrollment|
-      Pd::WorkshopMailer.detail_change_notification(enrollment).deliver_now
+      Pd::WorkshopMailer.detail_change_notification(enrollment).deliver_now unless @workshop.suppress_email?
     end
     @workshop.facilitators.each do |facilitator|
       Pd::WorkshopMailer.facilitator_detail_change_notification(facilitator, @workshop).deliver_now

--- a/dashboard/app/controllers/pd/workshop_enrollment_controller.rb
+++ b/dashboard/app/controllers/pd/workshop_enrollment_controller.rb
@@ -119,7 +119,7 @@ class Pd::WorkshopEnrollmentController < ApplicationController
       @enrollment.school_info_attributes = school_info_params
 
       if @enrollment.update enrollment_params
-        Pd::WorkshopMailer.teacher_enrollment_receipt(@enrollment).deliver_now unless @workshop.suppress_email?
+        Pd::WorkshopMailer.teacher_enrollment_receipt(@enrollment).deliver_now
         Pd::WorkshopMailer.organizer_enrollment_receipt(@enrollment).deliver_now
         redirect_to action: :thanks, code: @enrollment.code, controller: 'pd/workshop_enrollment'
       else

--- a/dashboard/app/controllers/pd/workshop_enrollment_controller.rb
+++ b/dashboard/app/controllers/pd/workshop_enrollment_controller.rb
@@ -119,7 +119,7 @@ class Pd::WorkshopEnrollmentController < ApplicationController
       @enrollment.school_info_attributes = school_info_params
 
       if @enrollment.update enrollment_params
-        Pd::WorkshopMailer.teacher_enrollment_receipt(@enrollment).deliver_now
+        Pd::WorkshopMailer.teacher_enrollment_receipt(@enrollment).deliver_now unless @workshop.suppress_email?
         Pd::WorkshopMailer.organizer_enrollment_receipt(@enrollment).deliver_now
         redirect_to action: :thanks, code: @enrollment.code, controller: 'pd/workshop_enrollment'
       else

--- a/dashboard/app/mailers/pd/workshop_mailer.rb
+++ b/dashboard/app/mailers/pd/workshop_mailer.rb
@@ -244,6 +244,10 @@ class Pd::WorkshopMailer < ActionMailer::Base
     Pd::EnrollmentNotification.create(enrollment: @enrollment, name: action_name)
   end
 
+  # Note that this is one of (at least) three mechanisms we use to suppress
+  # email in various cases -- see Workshop.suppress_reminders? for
+  # other subject-specific suppression of reminder emails, and
+  # the Workshop serialized attribute 'suppress_email' for a third mechanism.
   # Virtual workshops should not have any mail sent.
   def check_should_send
     if @workshop.subject&.include? "Virtual"

--- a/dashboard/app/mailers/pd/workshop_mailer.rb
+++ b/dashboard/app/mailers/pd/workshop_mailer.rb
@@ -51,6 +51,8 @@ class Pd::WorkshopMailer < ActionMailer::Base
       reply_to = email_address(@workshop.organizer.name, @workshop.organizer.email)
     end
 
+    return if @workshop.suppress_email?
+
     mail content_type: 'text/html',
       from: from,
       subject: teacher_enrollment_subject(@workshop),
@@ -116,7 +118,7 @@ class Pd::WorkshopMailer < ActionMailer::Base
       reply_to = email_address(@workshop.organizer.name, @workshop.organizer.email)
     end
 
-    return if @workshop.suppress_reminders?
+    return if @workshop.suppress_reminders? || @workshop.suppress_email?
 
     mail content_type: 'text/html',
       from: from,
@@ -131,7 +133,7 @@ class Pd::WorkshopMailer < ActionMailer::Base
     @cancel_url = '#'
     @is_reminder = true
 
-    return if @workshop.suppress_reminders?
+    return if @workshop.suppress_reminders? || @workshop.suppress_email?
 
     mail content_type: 'text/html',
          from: from_teacher,
@@ -145,7 +147,7 @@ class Pd::WorkshopMailer < ActionMailer::Base
     @cancel_url = '#'
     @is_reminder = true
 
-    return if @workshop.suppress_reminders?
+    return if @workshop.suppress_reminders? || @workshop.suppress_email?
 
     mail content_type: 'text/html',
          from: from_teacher,
@@ -158,6 +160,8 @@ class Pd::WorkshopMailer < ActionMailer::Base
     @enrollment = enrollment
     @workshop = enrollment.workshop
     @cancel_url = url_for controller: 'pd/workshop_enrollment', action: :cancel, code: enrollment.code
+
+    return if @workshop.suppress_email?
 
     mail content_type: 'text/html',
       from: from_teacher,

--- a/dashboard/app/models/pd/workshop.rb
+++ b/dashboard/app/models/pd/workshop.rb
@@ -400,6 +400,8 @@ class Pd::Workshop < ActiveRecord::Base
     # Collect errors, but do not stop batch. Rethrow all errors below.
     errors = []
     scheduled_start_in_days(days).each do |workshop|
+      next if workshop.suppress_email?
+
       workshop.enrollments.each do |enrollment|
         email = Pd::WorkshopMailer.teacher_enrollment_reminder(enrollment, days_before: days)
         email.deliver_now
@@ -464,10 +466,8 @@ class Pd::Workshop < ActiveRecord::Base
   end
 
   def self.send_automated_emails
-    unless suppress_email?
-      send_reminder_for_upcoming_in_days(3)
-      send_reminder_for_upcoming_in_days(10)
-    end
+    send_reminder_for_upcoming_in_days(3)
+    send_reminder_for_upcoming_in_days(10)
     send_reminder_to_close
     send_follow_up_after_days(30)
   end

--- a/dashboard/app/models/pd/workshop.rb
+++ b/dashboard/app/models/pd/workshop.rb
@@ -59,12 +59,20 @@ class Pd::Workshop < ActiveRecord::Base
     #   - Uses a different, virtual-specific post-workshop survey.
     'virtual',
 
-    # If true, our system will not send any emails related to this workshop
-    # *except* for the post-workshop survey, which is exempt from this policy
+    # If true, our system will not send enrollee-facing
+    # emails related to this workshop *except* for a receipt for the teacher
+    # if they cancel their enrollment and the post-workshop survey,
+    # which is exempt from this policy
     # because it is important for our measurement of workshop outcomes.
     # This option is useful to regional partners who may wish to have more
     # direct control over workshop communication, at the cost of managing it
     # themselves.
+    # Note that this is one of (at least) three mechanisms we use to suppress
+    # email in various cases -- see Workshop.suppress_reminders? for
+    # subject-specific suppression of reminder emails, and
+    # WorkshopMailer.check_should_send, which suppresses ALL email
+    # for workshops with a virtual subject (note, this is different than the
+    # virtual serialized attribute)
     'suppress_email'
   ]
 
@@ -385,6 +393,11 @@ class Pd::Workshop < ActiveRecord::Base
       "#{workshop_year.to_i - 1}-#{workshop_year}"
   end
 
+  # Note that this is one of (at least) three mechanisms we use to suppress
+  # email in various cases -- see the serialized attribute 'suppress_email' and
+  # WorkshopMailer.check_should_send, which suppresses ALL email
+  # for workshops with a virtual subject (note, this is different than the
+  # virtual serialized attribute)
   # Suppress 3 and 10-day reminders for certain workshops
   def suppress_reminders?
     [

--- a/dashboard/app/models/pd/workshop.rb
+++ b/dashboard/app/models/pd/workshop.rb
@@ -413,8 +413,6 @@ class Pd::Workshop < ActiveRecord::Base
     # Collect errors, but do not stop batch. Rethrow all errors below.
     errors = []
     scheduled_start_in_days(days).each do |workshop|
-      next if workshop.suppress_email?
-
       workshop.enrollments.each do |enrollment|
         email = Pd::WorkshopMailer.teacher_enrollment_reminder(enrollment, days_before: days)
         email.deliver_now

--- a/dashboard/app/models/pd/workshop.rb
+++ b/dashboard/app/models/pd/workshop.rb
@@ -464,8 +464,10 @@ class Pd::Workshop < ActiveRecord::Base
   end
 
   def self.send_automated_emails
-    send_reminder_for_upcoming_in_days(3)
-    send_reminder_for_upcoming_in_days(10)
+    unless suppress_email?
+      send_reminder_for_upcoming_in_days(3)
+      send_reminder_for_upcoming_in_days(10)
+    end
     send_reminder_to_close
     send_follow_up_after_days(30)
   end

--- a/dashboard/test/mailers/pd/workshop_mailer_test.rb
+++ b/dashboard/test/mailers/pd/workshop_mailer_test.rb
@@ -67,12 +67,40 @@ class WorkshopMailerTest < ActionMailer::TestCase
     end
   end
 
-  test 'emails are not sent for virtual workshops' do
+  test 'emails are not sent for workshops with virtual workshop subject' do
     workshop = create :pd_workshop, course: Pd::Workshop::COURSE_CSD, subject: Pd::Workshop::SUBJECT_VIRTUAL_1, num_sessions: 1
     enrollment = create :pd_enrollment, workshop: workshop
 
     assert_no_emails do
       Pd::WorkshopMailer.organizer_cancel_receipt(enrollment).deliver_now
+    end
+  end
+
+  test 'specific emails are not sent for workshops with suppress_email attribute' do
+    workshop = create :csp_summer_workshop, suppress_email: true
+    facilitator = workshop.facilitators.first
+    enrollment = create :pd_enrollment, workshop: workshop
+
+    assert_no_emails do
+      Pd::WorkshopMailer.teacher_enrollment_reminder(enrollment).deliver_now
+      Pd::WorkshopMailer.teacher_enrollment_receipt(enrollment).deliver_now
+      Pd::WorkshopMailer.facilitator_enrollment_reminder(facilitator, workshop).deliver_now
+      Pd::WorkshopMailer.organizer_enrollment_reminder(workshop).deliver_now
+      Pd::WorkshopMailer.detail_change_notification(enrollment).deliver_now
+    end
+  end
+
+  test 'specific emails that should be sent for workshops with suppress_email attribute' do
+    workshop = create :csp_summer_workshop, suppress_email: true
+    enrollment = create :pd_enrollment, workshop: workshop
+
+    assert_emails 3 do
+      Pd::WorkshopMailer.teacher_cancel_receipt(enrollment).deliver_now
+      Pd::WorkshopMailer.organizer_cancel_receipt(enrollment).deliver_now
+
+      # Organizers want to stay informed of who has enrolled, even if
+      # email is suppressed
+      Pd::WorkshopMailer.organizer_enrollment_receipt(enrollment).deliver_now
     end
   end
 

--- a/dashboard/test/mailers/pd/workshop_mailer_test.rb
+++ b/dashboard/test/mailers/pd/workshop_mailer_test.rb
@@ -94,12 +94,14 @@ class WorkshopMailerTest < ActionMailer::TestCase
     workshop = create :csp_summer_workshop, suppress_email: true
     enrollment = create :pd_enrollment, workshop: workshop
 
-    assert_emails 3 do
+    assert_emails 4 do
+      # Still send cancellation receipt and exit survey to teachers
       Pd::WorkshopMailer.teacher_cancel_receipt(enrollment).deliver_now
-      Pd::WorkshopMailer.organizer_cancel_receipt(enrollment).deliver_now
+      Pd::WorkshopMailer.exit_survey(enrollment).deliver_now
 
       # Organizers want to stay informed of who has enrolled, even if
       # email is suppressed
+      Pd::WorkshopMailer.organizer_cancel_receipt(enrollment).deliver_now
       Pd::WorkshopMailer.organizer_enrollment_receipt(enrollment).deliver_now
     end
   end


### PR DESCRIPTION
Suppresses certain emails for workshops with the `suppress_email` attribute, which will be used for virtual workshops. 

Emails being suppressed:
- Reminders to teachers (and copies to facilitators and organizers) sent out 3 and 10 days prior to workshops
- Teacher-facing enrollment receipts sent when a teacher signs up for a workshop
- Teacher-facing notifications when workshop details change.

Emails not being suppressed:
- Teacher-facing receipts when they cancel their enrollment
- Teacher-facing post-workshop survey emails
- Organizer-facing receipts when someone enrolls or cancels their enrollment

In this process, I noted two other places where we suppress email in some form. I've added verbose comments to each of those places, and think we should do some follow-up work to figure out a better means of suppressing email (not 100% sure what that looks like at the moment).

Once this PR is DTP'd, I will manually run the following for each of the 8 workshops starting June 1-8 (note that this needs to be done before 7:30 AM PST on Friday, May 22, which is when the daily cron runs to send emails, or emails will be sent to workshop enrollees for June 1 workshops):

```
workshop = Pd::Workshop.find([ID])
workshop.virtual = true
workshop.suppress_email = true
workshop.save!
```

## Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
