### PR TITLE
Remove library by channelId instead of name

### DIFF
--- a/apps/src/code-studio/components/libraries/LibraryListItem.jsx
+++ b/apps/src/code-studio/components/libraries/LibraryListItem.jsx
@@ -158,7 +158,7 @@ export class LibraryListItem extends React.Component {
               <button
                 type="button"
                 key={'remove-' + library.id}
-                onClick={() => this.props.onRemove(library.name)}
+                onClick={() => this.props.onRemove(library.channelId)}
                 style={[styles.actionBtn, styles.removeBtn]}
                 disabled={!!library.fromLevelbuilder}
               >

--- a/apps/src/code-studio/components/libraries/LibraryManagerDialog.jsx
+++ b/apps/src/code-studio/components/libraries/LibraryManagerDialog.jsx
@@ -249,11 +249,11 @@ export class LibraryManagerDialog extends React.Component {
     );
   };
 
-  removeLibrary = libraryName => {
+  removeLibrary = channelId => {
     const {projectLibraries} = this.state;
     dashboard.project.setProjectLibraries(
       projectLibraries.filter(library => {
-        return library.name !== libraryName;
+        return library.channelId !== channelId;
       })
     );
     this.setState({projectLibraries: dashboard.project.getProjectLibraries()});

--- a/apps/test/unit/code-studio/components/libraries/libraryManagerDialogTest.js
+++ b/apps/test/unit/code-studio/components/libraries/libraryManagerDialogTest.js
@@ -227,7 +227,7 @@ describe('LibraryManagerDialog', () => {
       );
       wrapper.instance().onOpen();
       expect(setProjectLibraries.notCalled).to.be.true;
-      wrapper.instance().removeLibrary('first');
+      wrapper.instance().removeLibrary('abc123');
       expect(setProjectLibraries.withArgs([projectLibraries[1]]).calledOnce).to
         .be.true;
       window.dashboard.project.setProjectLibraries.restore();


### PR DESCRIPTION
When we call `removeLibrary` to remove a library from a project, we now key by channelId instead of name so that libraries with duplicate names don't all get removed in the process.

## Links

- [STAR-1115](https://codedotorg.atlassian.net/browse/STAR-1115)

## Testing story

Updated appropriate unit test.

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
