### PR TITLE
[Applab] Gracefully handle when there's no callback

### DIFF
--- a/apps/src/lib/util/timeoutApi.js
+++ b/apps/src/lib/util/timeoutApi.js
@@ -15,7 +15,9 @@ export function injectExecuteCmd(fn) {
 }
 
 function onTimerFired(opts) {
-  opts.callback.call(null);
+  if (opts.callback) {
+    opts.callback.call(null);
+  }
 }
 
 /**


### PR DESCRIPTION
This was causing newrelic errors if you called `timedLoop()` without a callback 
![image](https://user-images.githubusercontent.com/8787187/82510133-ad4a1a80-9abe-11ea-92e1-a3f238a3b190.png)

Instead, we should just gracefully no-op
