### PR TITLE
Surveys: change links for local summer workshop surveys to use Foorm

### DIFF
--- a/apps/src/code-studio/pd/workshop_dashboard/EnrollmentsPanel.jsx
+++ b/apps/src/code-studio/pd/workshop_dashboard/EnrollmentsPanel.jsx
@@ -186,12 +186,13 @@ export default class EnrollmentsPanel extends React.Component {
       return null;
     }
 
-    if (course === 'CS Fundamentals' && subject === 'Intro') {
-      if (lastSessionDate >= new Date('2020-05-08')) {
-        return `/pd/workshop_dashboard/workshop_daily_survey_results/${workshopId}`;
-      } else {
-        return `/pd/workshop_dashboard/survey_results/${workshopId}`;
-      }
+    // Local summer or CSF Intro after 5/8/2020 will use Foorm for survey completion.
+    if (
+      lastSessionDate >= new Date('2020-05-08') &&
+      (subject === '5-day Summer' ||
+        (course === 'CS Fundamentals' && subject === 'Intro'))
+    ) {
+      return `/pd/workshop_dashboard/workshop_daily_survey_results/${workshopId}`;
     } else {
       return `/pd/workshop_dashboard/daily_survey_results/${workshopId}`;
     }

--- a/apps/src/code-studio/pd/workshop_dashboard/components/workshop_management.jsx
+++ b/apps/src/code-studio/pd/workshop_dashboard/components/workshop_management.jsx
@@ -84,10 +84,12 @@ export class WorkshopManagement extends React.Component {
       ? new Date(this.props.endDate)
       : new Date(this.props.date);
 
+    // Local summer or CSF Intro after 5/8/2020 will use Foorm for survey completion.
     return (
       workshop_date >= new Date('2020-05-08') &&
-      this.props.subject === SubjectNames.SUBJECT_CSF_101 &&
-      this.props.course === 'CS Fundamentals'
+      (this.props.subject === '5-day Summer' ||
+        (this.props.subject === SubjectNames.SUBJECT_CSF_101 &&
+          this.props.course === 'CS Fundamentals'))
     );
   };
 

--- a/dashboard/app/controllers/pd/workshop_daily_survey_controller.rb
+++ b/dashboard/app/controllers/pd/workshop_daily_survey_controller.rb
@@ -22,6 +22,17 @@ module Pd
       # Accept days 0 through 4. Day 5 is the post workshop survey and should use the new_post route
       day = params[:day].to_i
       workshop = get_workshop_for_new_general(params[:enrollmentCode], current_user)
+
+      # Use Foorm for local summer workshops. This preserves the legacy url, which facilitators may
+      # have saved.
+      if workshop.local_summer?
+        if day == 0
+          return new_pre_foorm
+        else
+          return new_daily_foorm
+        end
+      end
+
       unless validate_new_general_parameters(workshop)
         return
       end
@@ -114,7 +125,9 @@ module Pd
     end
 
     def new_general_foorm(survey_names, day:)
-      workshop = get_workshop_for_new_general(params[:enrollmentCode], current_user)
+      # We may be redirecting from our legacy route which uses enrollment_code
+      enrollment_code = params[:enrollmentCode] || params[:enrollment_code]
+      workshop = get_workshop_for_new_general(enrollment_code, current_user)
       unless validate_enrolled(workshop)
         return
       end
@@ -228,6 +241,13 @@ module Pd
     def new_post
       enrollment = Enrollment.find_by!(code: params[:enrollment_code])
       workshop = enrollment.workshop
+
+      # Use Foorm for local summer workshops. This preserves the legacy url, which facilitators may
+      # have saved.
+      if workshop.local_summer?
+        return new_post_foorm
+      end
+
       session = workshop.sessions.last
       session_count = workshop.last_valid_day
       return render_404 unless session

--- a/dashboard/app/controllers/pd/workshop_daily_survey_controller.rb
+++ b/dashboard/app/controllers/pd/workshop_daily_survey_controller.rb
@@ -23,6 +23,10 @@ module Pd
       day = params[:day].to_i
       workshop = get_workshop_for_new_general(params[:enrollmentCode], current_user)
 
+      unless validate_new_general_parameters(workshop)
+        return
+      end
+
       # Use Foorm for local summer workshops. This preserves the legacy url, which facilitators may
       # have saved.
       if workshop.local_summer?
@@ -31,10 +35,6 @@ module Pd
         else
           return new_daily_foorm
         end
-      end
-
-      unless validate_new_general_parameters(workshop)
-        return
       end
 
       session = get_session_for_workshop_and_day(workshop, day)

--- a/dashboard/app/controllers/pd/workshop_daily_survey_controller.rb
+++ b/dashboard/app/controllers/pd/workshop_daily_survey_controller.rb
@@ -23,9 +23,8 @@ module Pd
       day = params[:day].to_i
       workshop = get_workshop_for_new_general(params[:enrollmentCode], current_user)
 
-      unless validate_new_general_parameters(workshop)
-        return
-      end
+      # Do nothing if there is no enrollment.
+      return unless validate_enrolled(workshop)
 
       # Use Foorm for local summer workshops. This preserves the legacy url, which facilitators may
       # have saved.
@@ -35,6 +34,12 @@ module Pd
         else
           return new_daily_foorm
         end
+      end
+
+      # Beyond here is for a non-Foorm survey.
+
+      unless validate_new_general_parameters(workshop)
+        return
       end
 
       session = get_session_for_workshop_and_day(workshop, day)

--- a/dashboard/app/models/pd/enrollment.rb
+++ b/dashboard/app/models/pd/enrollment.rb
@@ -223,7 +223,7 @@ class Pd::Enrollment < ActiveRecord::Base
       # TODO: This is a temporary, fake URL. Wire up a real one!
       CDO.studio_url '/pd/workshop_survey/post'
     elsif workshop.local_summer?
-      url_for(action: 'new_post_foorm', controller: 'pd/workshop_daily_survey', enrollmentCode: code)
+      CDO.studio_url "/pd/workshop_post_survey?enrollmentCode=#{code}", CDO.default_scheme
     elsif workshop.teachercon?
       pd_new_workshop_survey_url(code, protocol: CDO.default_scheme)
     elsif [Pd::Workshop::COURSE_CSP, Pd::Workshop::COURSE_CSD].include?(workshop.course)

--- a/dashboard/app/models/pd/workshop.rb
+++ b/dashboard/app/models/pd/workshop.rb
@@ -652,6 +652,10 @@ class Pd::Workshop < ActiveRecord::Base
     course == COURSE_CSF
   end
 
+  def csf_intro?
+    course == Pd::Workshop::COURSE_CSF && subject == Pd::Workshop::SUBJECT_CSF_101
+  end
+
   def csf_201?
     course == COURSE_CSF && subject == SUBJECT_CSF_201
   end

--- a/dashboard/test/controllers/pd/workshop_daily_survey_controller_test.rb
+++ b/dashboard/test/controllers/pd/workshop_daily_survey_controller_test.rb
@@ -109,34 +109,6 @@ module Pd
       assert_thanks
     end
 
-    test 'pre-workshop survey displays embedded JotForm when enrolled' do
-      setup_summer_workshop
-      submit_redirect = general_submit_redirect(day: 0)
-      assert_equal '/pd/workshop_survey/submit', URI.parse(submit_redirect).path
-
-      WorkshopDailySurveyController.view_context_class.any_instance.expects(:jotform_iframe).with(
-        FAKE_DAILY_FORM_IDS[0],
-        {
-          environment: 'test',
-          userId: @enrolled_summer_teacher.id,
-          workshopId: @summer_workshop.id,
-          day: 0,
-          formId: FAKE_DAILY_FORM_IDS[0],
-          sessionId: nil,
-          userName: @enrolled_summer_teacher.name,
-          userEmail: @enrolled_summer_teacher.email,
-          workshopCourse: @summer_workshop.course,
-          workshopSubject: @summer_workshop.subject,
-          regionalPartnerName: @regional_partner.name,
-          submitRedirect: submit_redirect
-        }
-      )
-
-      sign_in @enrolled_summer_teacher
-      get '/pd/workshop_survey/day/0'
-      assert_response :success
-    end
-
     test 'pre-workshop foorm survey displays foorm when enrolled' do
       setup_summer_workshop
 
@@ -152,25 +124,6 @@ module Pd
       sign_in @enrolled_summer_teacher
       get '/pd/workshop_post_survey'
       assert_template :new_general_foorm
-      assert_response :success
-    end
-
-    test 'pre-workshop survey reports render to New Relic' do
-      setup_summer_workshop
-      NewRelic::Agent.expects(:record_custom_event).with(
-        'RenderJotFormView',
-        {
-          route: 'GET /pd/workshop_survey/day/0',
-          form_id: FAKE_DAILY_FORM_IDS[0],
-          workshop_course: @summer_workshop.course,
-          workshop_subject: @summer_workshop.subject,
-          regional_partner_name: @regional_partner.name
-        }
-      )
-
-      CDO.stubs(:newrelic_logging).returns(true)
-      sign_in @enrolled_summer_teacher
-      get '/pd/workshop_survey/day/0'
       assert_response :success
     end
 
@@ -266,24 +219,6 @@ module Pd
 
       submit_redirect = general_submit_redirect(day: 1)
       assert_equal '/pd/workshop_survey/submit', URI.parse(submit_redirect).path
-
-      WorkshopDailySurveyController.view_context_class.any_instance.expects(:jotform_iframe).with(
-        FAKE_DAILY_FORM_IDS[1],
-        {
-          environment: 'test',
-          userId: @enrolled_summer_teacher.id,
-          workshopId: @summer_workshop.id,
-          day: 1,
-          formId: FAKE_DAILY_FORM_IDS[1],
-          sessionId: @summer_workshop.sessions[0].id,
-          userName: @enrolled_summer_teacher.name,
-          userEmail: @enrolled_summer_teacher.email,
-          workshopCourse: @summer_workshop.course,
-          workshopSubject: @summer_workshop.subject,
-          regionalPartnerName: @regional_partner.name,
-          submitRedirect: submit_redirect
-        }
-      )
 
       sign_in @enrolled_summer_teacher
       get '/pd/workshop_survey/day/1'
@@ -629,37 +564,6 @@ module Pd
       sign_in @enrolled_summer_teacher
       get '/pd/workshop_survey/post/invalid_enrollment_code'
       assert_response :not_found
-    end
-
-    test 'post workshop survey renders embedded JotForm' do
-      setup_summer_workshop
-      create :pd_attendance, session: @summer_workshop.sessions[4], teacher: @enrolled_summer_teacher, enrollment: @summer_enrollment
-
-      submit_redirect = general_submit_redirect(day: 5, enrollment_code: @summer_enrollment.code)
-      assert_equal '/pd/workshop_survey/submit', URI.parse(submit_redirect).path
-
-      WorkshopDailySurveyController.view_context_class.any_instance.expects(:jotform_iframe).with(
-        FAKE_DAILY_FORM_IDS[5],
-        {
-          environment: 'test',
-          userId: @enrolled_summer_teacher.id,
-          workshopId: @summer_workshop.id,
-          day: 5,
-          formId: FAKE_DAILY_FORM_IDS[5],
-          sessionId: @summer_workshop.sessions[4].id,
-          userName: @enrolled_summer_teacher.name,
-          userEmail: @enrolled_summer_teacher.email,
-          workshopCourse: @summer_workshop.course,
-          workshopSubject: @summer_workshop.subject,
-          regionalPartnerName: @regional_partner.name,
-          submitRedirect: submit_redirect,
-          enrollmentCode: @summer_enrollment.code
-        }
-      )
-
-      sign_in @enrolled_summer_teacher
-      get "/pd/workshop_survey/post/#{@summer_enrollment.code}"
-      assert_response :success
     end
 
     test 'post workshop for summer submit redirect creates a placeholder and redirects to thanks' do

--- a/dashboard/test/controllers/pd/workshop_daily_survey_controller_test.rb
+++ b/dashboard/test/controllers/pd/workshop_daily_survey_controller_test.rb
@@ -87,17 +87,7 @@ module Pd
       assert_not_enrolled
     end
 
-    test 'pre-workshop survey redirects to thanks when a response exists' do
-      setup_summer_workshop
-      create :pd_workshop_daily_survey, pd_workshop: @summer_workshop, user: @enrolled_summer_teacher,
-        day: 0, form_id: FAKE_DAILY_FORM_IDS[0]
-
-      sign_in @enrolled_summer_teacher
-      get '/pd/workshop_survey/day/0'
-      assert_redirected_to action: 'thanks'
-    end
-
-    test 'pre-workshop foorm survey redirects to thanks when a response exists' do
+    test 'pre-workshop foorm survey shows thanks when a response exists' do
       setup_summer_workshop
       create :day_0_workshop_foorm_submission,
         :answers_high,
@@ -200,19 +190,7 @@ module Pd
       assert_no_attendance
     end
 
-    test 'daily workshop survey redirects to first facilitator form when a response exists' do
-      setup_summer_workshop
-      Session.any_instance.expects(:open_for_attendance?).returns(true)
-      create :pd_attendance, session: @summer_workshop.sessions[0], teacher: @enrolled_summer_teacher, enrollment: @summer_enrollment
-      create :pd_workshop_daily_survey, pd_workshop: @summer_workshop, user: @enrolled_summer_teacher,
-        day: 1, form_id: FAKE_DAILY_FORM_IDS[1], pd_session: @summer_workshop.sessions[0]
-
-      sign_in @enrolled_summer_teacher
-      get '/pd/workshop_survey/day/1'
-      assert_redirected_to action: :new_facilitator, session_id: @summer_workshop.sessions[0].id, facilitator_index: 0
-    end
-
-    test 'daily summer workshop survey with open session attendance displays embedded JotForm' do
+    test 'daily summer workshop survey with open session attendance displays foorm' do
       setup_summer_workshop
       Session.any_instance.expects(:open_for_attendance?).returns(true)
       create :pd_attendance, session: @summer_workshop.sessions[0], teacher: @enrolled_summer_teacher, enrollment: @summer_enrollment
@@ -222,7 +200,7 @@ module Pd
 
       sign_in @enrolled_summer_teacher
       get '/pd/workshop_survey/day/1'
-      assert_response :success
+      assert_template :new_general_foorm
     end
 
     test 'academic year workshop with open session attendance displays embedded Jotform' do
@@ -360,18 +338,6 @@ module Pd
       sign_in @enrolled_summer_teacher
       get "/pd/workshop_survey/facilitators/#{@summer_workshop.sessions[0].id}/0"
       assert_redirected_to action: :new_facilitator, session_id: @summer_workshop.sessions[0].id, facilitator_index: 1
-    end
-
-    test 'last facilitator specific survey redirects to thanks when response exists' do
-      setup_summer_workshop
-      Session.any_instance.expects(:open_for_attendance?).returns(true)
-      create :pd_attendance, session: @summer_workshop.sessions[0], teacher: @enrolled_summer_teacher, enrollment: @summer_enrollment
-      create :pd_workshop_facilitator_daily_survey, pd_workshop: @summer_workshop, user: @enrolled_summer_teacher,
-        day: 1, form_id: FAKE_FACILITATOR_FORM_ID, pd_session: @summer_workshop.sessions[0], facilitator: @facilitators[1]
-
-      sign_in @enrolled_summer_teacher
-      get "/pd/workshop_survey/facilitators/#{@summer_workshop.sessions[0].id}/1"
-      assert_redirected_to '/pd/workshop_survey/thanks'
     end
 
     test 'facilitator specific survey with open session attendance displays embedded JotForm' do

--- a/dashboard/test/models/pd/enrollment_test.rb
+++ b/dashboard/test/models/pd/enrollment_test.rb
@@ -102,7 +102,7 @@ class Pd::EnrollmentTest < ActiveSupport::TestCase
     csf_intro_workshop = build :csf_intro_workshop
     csf_intro_workshop_enrollment = build :pd_enrollment, workshop: csf_intro_workshop
 
-    assert_equal "/pd/workshop_survey/day/0?enrollmentCode=#{csp_summer_workshop_enrollment.code}",
+    assert_equal "/pd/workshop_pre_survey?enrollmentCode=#{csp_summer_workshop_enrollment.code}",
       URI(csp_summer_workshop_enrollment.pre_workshop_survey_url).path + '?' + URI(csp_summer_workshop_enrollment.pre_workshop_survey_url).query
     assert_equal "/pd/pre_workshop_survey/#{csp_academic_year_workshop_enrollment.code}",
       URI(csp_academic_year_workshop_enrollment.pre_workshop_survey_url).path
@@ -139,9 +139,9 @@ class Pd::EnrollmentTest < ActiveSupport::TestCase
 
     studio_url = ->(path) {CDO.studio_url(path, CDO.default_scheme)}
     assert_equal studio_url["/pd/workshop_survey/csf/post101/#{csf_enrollment.code}"], csf_enrollment.exit_survey_url
-    assert_equal studio_url["/pd/workshop_survey/post/#{local_summer_enrollment.code}"], local_summer_enrollment.exit_survey_url
+    assert_equal studio_url["/pd/workshop_post_survey?enrollmentCode=#{local_summer_enrollment.code}"], local_summer_enrollment.exit_survey_url
     assert_equal studio_url["/pd/workshop_survey/post/#{teachercon_enrollment.code}"], teachercon_enrollment.exit_survey_url
-    assert_equal studio_url["/pd/workshop_survey/post/#{csp_enrollment.code}"], csp_enrollment.exit_survey_url
+    assert_equal studio_url["/pd/workshop_post_survey?enrollmentCode=#{csp_enrollment.code}"], csp_enrollment.exit_survey_url
   end
 
   test 'exit_survey_url falls back to last valid day' do
@@ -330,7 +330,10 @@ class Pd::EnrollmentTest < ActiveSupport::TestCase
     assert_equal [enrollment], Pd::Enrollment.filter_for_survey_completion([enrollment], false)
 
     # complete survey
-    create :pd_workshop_daily_survey, pd_workshop: workshop, user: enrollment.user
+    create :day_5_workshop_foorm_submission,
+      :answers_high,
+      user: enrollment.user,
+      pd_workshop_id: enrollment.workshop.id
     assert_equal [], Pd::Enrollment.filter_for_survey_completion([enrollment], false)
   end
 

--- a/pegasus/sites.v3/code.org/public/csd-pre-survey.redirect
+++ b/pegasus/sites.v3/code.org/public/csd-pre-survey.redirect
@@ -1,1 +1,1 @@
-https://studio.code.org/pd/workshop_survey/day/0
+https://studio.code.org/pd/workshop_pre_survey

--- a/pegasus/sites.v3/code.org/public/csp-pre-survey.redirect
+++ b/pegasus/sites.v3/code.org/public/csp-pre-survey.redirect
@@ -1,1 +1,1 @@
-https://studio.code.org/pd/workshop_survey/day/0
+https://studio.code.org/pd/workshop_pre_survey


### PR DESCRIPTION
Just as CSF Intro surveys did a few weeks ago, CSD/CSP local summer workshop surveys now go-live to Foorm as well.  This covers pre, post and daily surveys.

To keep things simpler, we are using the same date - 5/8/2020 - for the cutover.  That is, any local summer workshop with a start date of 5/8/2020 or later will use the new survey system.  This is possible because there were no local summer workshops between then and now.

For such workshops, results are now viewed at https://studio.code.org/pd/workshop_dashboard/workshop_daily_survey_results/[workshopId].

The new URLs for pre and post surveys are live:

https://studio.code.org/pd/workshop_pre_survey
https://studio.code.org/pd/workshop_post_survey
https://studio.code.org/pd/workshop_post_survey?enrollmentCode=[code]

The legacy redirects at https://code.org/csd-pre-survey https://code.org/csp-pre-survey now to go https://studio.code.org/pd/workshop_pre_survey. 

For daily surveys, we have previously-published links which are in printed materials, and so we have decided to continue to support them:

https://studio.code.org/pd/workshop_survey/day/[1-X]

They will render either the Foorm-based survey or the JotForm-based one.

At the moment we do still continue supporting new links for Foorm-based daily surveys, but we are debating removing them:

https://studio.code.org/pd/workshop_daily_survey/day/[1-X]

In both cases, X is the number of days minus one, since there is no daily survey for the last day.

This change also updates `filter_for_survey_completion` which is used to determine the most recent post survey URL.

Big credit to @molly-moen for pairing on and indeed driving these changes.