### PR TITLE
Census: seed state CS offerings collected in 2020

### DIFF
--- a/dashboard/app/models/census/state_cs_offering.rb
+++ b/dashboard/app/models/census/state_cs_offering.rb
@@ -1537,7 +1537,11 @@ class Census::StateCsOffering < ApplicationRecord
   # Test seeding an object from S3 to find issues.
   # This method does not check if the object had been seeded before
   # and does not write to the database.
-  # @example: Census::StateCsOffering.seed_from_s3_test('AL', 2019, 1)
+  # @example:
+  #   Census::StateCsOffering.seed_from_s3_test('AL', 2019)
+  #     will seed from state_cs_offerings/AL/2019-2020.csv object
+  #   Census::StateCsOffering.seed_from_s3_test('WA', 2019, 'x')
+  #     will seed from state_cs_offerings/WA/2019-2020.x.csv object
   def self.seed_from_s3_test(state_code, school_year, update = 1)
     object_key = construct_object_key(state_code, school_year, update)
     begin

--- a/dashboard/app/models/census/state_cs_offering.rb
+++ b/dashboard/app/models/census/state_cs_offering.rb
@@ -89,6 +89,7 @@ class Census::StateCsOffering < ApplicationRecord
   STATES_USING_FORMAT_V2_IN_2018_19 = %w(
     AK
     AR
+    CA
     CO
     CT
     FL
@@ -107,6 +108,7 @@ class Census::StateCsOffering < ApplicationRecord
     MT
     ND
     NE
+    NJ
     NM
     NY
     OH
@@ -117,10 +119,11 @@ class Census::StateCsOffering < ApplicationRecord
     SD
     TX
     UT
+    VA
+    WA
     WI
     WV
     WY
-    VA
   ).freeze
 
   # For a few states, we already placed a 2017-2018 CSV on S3 using their V1 format,

--- a/dashboard/app/models/census/state_cs_offering.rb
+++ b/dashboard/app/models/census/state_cs_offering.rb
@@ -26,6 +26,7 @@ class Census::StateCsOffering < ApplicationRecord
     AK
     AL
     AR
+    AZ
     CA
     CO
     CT
@@ -69,6 +70,7 @@ class Census::StateCsOffering < ApplicationRecord
     UT
     VA
     VT
+    WA
     WI
     WV
     WY

--- a/dashboard/app/models/census/state_cs_offering.rb
+++ b/dashboard/app/models/census/state_cs_offering.rb
@@ -1527,21 +1527,23 @@ class Census::StateCsOffering < ApplicationRecord
         end
       end
     end
+    CDO.log.info "This is a dry run. No data is written to the database." if dry_run
   end
 
   # Test seeding an object from S3 to find issues.
   # This method does not check if the object had been seeded before
   # and does not write to the database.
   # @example: Census::StateCsOffering.seed_from_s3_test('AL', 2019, 1)
-  def self.seed_from_s3_test(state_code, school_year, update)
+  def self.seed_from_s3_test(state_code, school_year, update = 1)
     object_key = construct_object_key(state_code, school_year, update)
     begin
       AWS::S3.process_file(CENSUS_BUCKET_NAME, object_key) do |filename|
         seed_from_csv(state_code, school_year, update, filename, true)
       end
     rescue Aws::S3::Errors::NotFound
-      CDO.log.warn "State CS Offering seeding: Object #{object_key} not found in S3"
+      CDO.log.warn "State CS Offering seeding: Object #{object_key} not found in S3."
     end
+    CDO.log.info "This is a dry run. No data is written to the database."
   end
 
   def self.seed

--- a/dashboard/app/models/census/state_cs_offering.rb
+++ b/dashboard/app/models/census/state_cs_offering.rb
@@ -640,19 +640,18 @@ class Census::StateCsOffering < ApplicationRecord
     2156
   ).freeze
 
-  OH_COURSE_CODES = [
-    UNSPECIFIED_COURSE,
-    '031700',
-    '145060',
-    '145070',
-    '290200',
-    '290310',
-    '145090',
-    '175004',
-    '290250',
-    '145065',
-    '321600'
-  ].freeze
+  OH_COURSE_CODES = %w(
+    031700
+    145060
+    145070
+    290200
+    290310
+    145090
+    175004
+    290250
+    145065
+    321600
+  ).freeze
 
   OK_COURSE_CODES = %w(
     2510

--- a/dashboard/app/models/census/state_cs_offering.rb
+++ b/dashboard/app/models/census/state_cs_offering.rb
@@ -640,18 +640,19 @@ class Census::StateCsOffering < ApplicationRecord
     2156
   ).freeze
 
-  OH_COURSE_CODES = %w(
-    031700
-    145060
-    145070
-    290200
-    290310
-    145090
-    175004
-    290250
-    145065
-    321600
-  ).freeze
+  OH_COURSE_CODES = [
+    UNSPECIFIED_COURSE,
+    '031700',
+    '145060',
+    '145070',
+    '290200',
+    '290310',
+    '145090',
+    '175004',
+    '290250',
+    '145065',
+    '321600'
+  ].freeze
 
   OK_COURSE_CODES = %w(
     2510

--- a/dashboard/app/models/census/state_cs_offering.rb
+++ b/dashboard/app/models/census/state_cs_offering.rb
@@ -1517,7 +1517,7 @@ class Census::StateCsOffering < ApplicationRecord
         SUPPORTED_UPDATES.each do |update|
           object_key = construct_object_key(state_code, school_year, update)
           begin
-            AWS::S3.seed_from_file(CENSUS_BUCKET_NAME, object_key) do |filename|
+            AWS::S3.seed_from_file(CENSUS_BUCKET_NAME, object_key, dry_run) do |filename|
               seed_from_csv(state_code, school_year, update, filename, dry_run)
               seeded_objects << object_key
             end

--- a/dashboard/app/models/census/state_cs_offering.rb
+++ b/dashboard/app/models/census/state_cs_offering.rb
@@ -76,7 +76,7 @@ class Census::StateCsOffering < ApplicationRecord
     WY
   ).freeze
 
-  SUPPORTED_UPDATES = [1, 2].freeze
+  SUPPORTED_UPDATES = [1, 2, 3].freeze
 
   # The following states use the "V2" format for CSV files in 2017-2018.
   # (The expectation is that all states will use the new format as of 2019-20.)

--- a/dashboard/app/models/census/state_cs_offering.rb
+++ b/dashboard/app/models/census/state_cs_offering.rb
@@ -1507,7 +1507,7 @@ class Census::StateCsOffering < ApplicationRecord
     "state_cs_offerings/#{state_code}/#{school_year}-#{school_year + 1}#{update_string}.#{file_extension}"
   end
 
-  def self.seed_from_s3(dry_run: false, file_extension: 'csv')
+  def self.seed_from_s3(file_extension: 'csv', dry_run: false)
     # State CS Offering data files in S3 are named
     # "state_cs_offerings/<STATE_CODE>/<SCHOOL_YEAR_START>-<SCHOOL_YEAR_END>.csv"
     # The first school year where we have data is 2015-2016
@@ -1541,10 +1541,10 @@ class Census::StateCsOffering < ApplicationRecord
   #
   # @example:
   #   Census::StateCsOffering.dry_seed_s3_object('AL', 2019, 1)
-  #     will seed from state_cs_offerings/AL/2019-2020.csv object
+  #   will seed from state_cs_offerings/AL/2019-2020.csv object
   #
   #   Census::StateCsOffering.dry_seed_s3_object('WA', 2019, 2, 'txt')
-  #     will seed from state_cs_offerings/WA/2019-2020.2.txt object
+  #   will seed from state_cs_offerings/WA/2019-2020.2.txt object
   def self.dry_seed_s3_object(state_code, school_year, update, file_extension = 'csv')
     object_key = construct_object_key(state_code, school_year, update, file_extension)
     AWS::S3.process_file(CENSUS_BUCKET_NAME, object_key) do |filename|


### PR DESCRIPTION
[PLC-821](https://codedotorg.atlassian.net/browse/PLC-821): Ingesting 43 new CSV files we recently collected [here](https://drive.google.com/drive/u/0/folders/1kN53Ix4vuh6L99VehhU_Jj-Wg53A-C7K).

## Dry run
Since there are a large number of files to ingest and we need to verify if we can ingest them correctly, I add 2 dry-run options to test ingestion without saving anything to databases. 
(These dry-runs have been very helpful in detecting issues in this batch of data.)

1. Test ingesting a single file in S3: `Census::StateCsOffering.dry_seed_s3_object(<state>, <school_year>, <update>, <file_extension>)`. Example results:
    ```
    # Census::StateCsOffering.dry_seed_s3_object('AL', 2019, 1, 'test')
    Processing state_cs_offerings/AL/2019-2020.test from cdo-census...
    State CS Offering seeding: skipping row 313 unknown state school id #N/A
    State CS Offering seeding: done processing AL-2019-1 data. 428 rows succeeded, 1 rows skipped
    This is a dry run. No data is written to the database.
    ```

2. Test scanning and ingesting all new files (not yet ingested) in S3 `Census::StateCsOffering.seed_from_s3(dry_run: true, file_extension: 'test')`. Example results:
    ```
   # Census::StateCsOffering.seed_from_s3(dry_run: true, file_extension: 'test')
    Seeded data from 43 object(s).
    state_cs_offerings/CA/2018-2019.test
    state_cs_offerings/CO/2018-2019.2.test
    [...]
    This is a dry run. No data is written to the database.
    ```

## How to ingest a new state CS offering file
1. Upload the file to `cdo-census` S3 bucket follwing this path `state_cs_offerings/<state>/<school_year>-<school_year + 1><update>.test`. 
    * Example: _state_cs_offerings/AL/2019-2020.test_
    * The `.test` extension (or any extension other than `csv`) is meant to **exclude** this file from the automated seeding task that runs with every build in staging, test and production. https://github.com/code-dot-org/code-dot-org/blob/d57211e76b40247f61161d9b8070ec96a4a9402c/dashboard/lib/tasks/seed.rake#L294-L296

2. In a Rails console in `production-console` machine, test ingesting the new file by running `Census::StateCsOffering.dry_seed_s3_object(<state>, <school_year>, <update>, <file_extension>)`. 
    * Examples: _Census::StateCsOffering.dry_seed_s3_object('AL', 2019, 1, 'test')_ or  _Census::StateCsOffering.dry_seed_s3_object('WA', 2019, 2, 'test')_.

3. Fix any issues occur. This could mean cleaning the data file or making changes to the ingestion code.

4. Deploy code changes (if any).

5. Change the file extension in S3 from `.test` to `csv`. The file will be automatically ingested to staging/test/production instances the next time they rebuid. Or you can manually trigger ingestion by running `Census::StateCsOffering.seed_from_s3`.

## Testing story
- Manual dry-runs and real runs on an adhoc with connection to production-clone db.

## Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
