### PR TITLE
Foorm: Update day validation on submission

### DIFF
--- a/dashboard/app/models/pd/workshop_survey_foorm_submission.rb
+++ b/dashboard/app/models/pd/workshop_survey_foorm_submission.rb
@@ -31,6 +31,7 @@ class Pd::WorkshopSurveyFoormSubmission < ApplicationRecord
     :pd_workshop_id
   )
   validates :pd_workshop, presence: true
+  validate :day_for_workshop
 
   def save_with_foorm_submission(answers, form_name, form_version)
     ActiveRecord::Base.transaction do
@@ -54,5 +55,17 @@ class Pd::WorkshopSurveyFoormSubmission < ApplicationRecord
     end
 
     !submissions.empty?
+  end
+
+  private
+
+  def day_for_workshop
+    if pd_workshop && !day.nil?
+      session_count = pd_workshop.sessions.count
+      if day > session_count
+        errors[:day] << "#{day} is not valid for workshop #{pd_workshop.id}"
+        Honeybadger.notify("Foorm was submitted for day #{day} for workshop #{pd_workshop.id}, which only had #{session_count} sessions.")
+      end
+    end
   end
 end

--- a/dashboard/app/models/pd/workshop_survey_foorm_submission.rb
+++ b/dashboard/app/models/pd/workshop_survey_foorm_submission.rb
@@ -21,8 +21,6 @@
 #
 
 class Pd::WorkshopSurveyFoormSubmission < ApplicationRecord
-  include Pd::WorkshopSurveyConstants
-
   belongs_to :foorm_submission, class_name: 'Foorm::Submission'
   belongs_to :user
   belongs_to :pd_session, class_name: 'Pd::Session'
@@ -33,8 +31,6 @@ class Pd::WorkshopSurveyFoormSubmission < ApplicationRecord
     :pd_workshop_id
   )
   validates :pd_workshop, presence: true
-
-  validate :day_for_subject
 
   def save_with_foorm_submission(answers, form_name, form_version)
     ActiveRecord::Base.transaction do
@@ -58,15 +54,5 @@ class Pd::WorkshopSurveyFoormSubmission < ApplicationRecord
     end
 
     !submissions.empty?
-  end
-
-  private
-
-  def day_for_subject
-    if pd_workshop && !day.nil?
-      unless VALID_DAYS[CATEGORY_MAP[pd_workshop.subject]].include? day
-        errors[:day] << "Day #{day} is not valid for workshop subject #{pd_workshop.subject}"
-      end
-    end
   end
 end

--- a/dashboard/test/models/pd/workshop_survey_foorm_submission_test.rb
+++ b/dashboard/test/models/pd/workshop_survey_foorm_submission_test.rb
@@ -32,5 +32,33 @@ module Pd
     test 'can check that survey has not already been submitted' do
       refute Pd::WorkshopSurveyFoormSubmission.has_submitted_form?(@user.id, @pd_summer_workshop.id, nil, nil, @foorm_form.name)
     end
+
+    test 'do not allow a day 6 survey for a 5 day workshop' do
+      workshop_survey = Pd::WorkshopSurveyFoormSubmission.new(user_id: @user.id, pd_workshop_id: @pd_summer_workshop.id, day: 6)
+      assert_raises(ActiveRecord::RecordInvalid) do
+        workshop_survey.save_with_foorm_submission({'question1': 'answer1'}, @foorm_form.name, @foorm_form.version)
+      end
+    end
+
+    test 'allow a day 6 survey for a 6 day workshop' do
+      long_summer_workshop = create :csp_summer_workshop, num_sessions: 6
+      workshop_survey = Pd::WorkshopSurveyFoormSubmission.new(
+        user_id: @user.id,
+        pd_workshop_id: long_summer_workshop.id,
+        day: 6
+      )
+      workshop_survey.save_with_foorm_submission(
+        {'question1': 'answer1'},
+        @foorm_form.name,
+        @foorm_form.version
+      )
+      assert Pd::WorkshopSurveyFoormSubmission.has_submitted_form?(
+        @user.id,
+        long_summer_workshop.id,
+        nil,
+        6,
+        nil
+      )
+    end
   end
 end


### PR DESCRIPTION
We were previously validating the `day` field on a foorm submission based on our constants for number of days in a workshop type. Since we now allow irregular workshop lengths, change this validation to be `day` must be less than or equal to number of sessions in the workshop.
<!-- ### Background -->
<!-- ### Privacy -->
<!-- ### Security -->
<!-- ### Caching -->
<!-- ### Deployment strategy -->
<!-- ### Future work -->

## Testing story
Tested manually that we can now submit a survey for a '5-day' workshop with more than 5 days. Also add unit tests to cover this case.

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
