### PR TITLE
Revert Revert "Show library code in function tooltip"

### DIFF
--- a/apps/src/blockTooltips/DropletFunctionTooltip.html.ejs
+++ b/apps/src/blockTooltips/DropletFunctionTooltip.html.ejs
@@ -22,14 +22,14 @@
     </div>
   <% }) %>
 <% } %>
-<% var linkText = "See examples" %>
-<% if (locals.customExamplesLink) { %>
-  <% linkText = "" %>
+<% var linkText = "" %>
+<% if (locals.showCodeLink) { %>
+  <div class="tooltip-code-link">
+    <a href="javascript:void(0);">Show code</a>
+  </div>
 <% } %>
 <% if (locals.showExamplesLink) { %>
   <div class="tooltip-example-link">
-    <a href="javascript:void(0);">
-      <%= linkText %>
-    </a>
+    <a href="javascript:void(0);">See examples</a>
   </div>
 <% } %>

--- a/apps/src/blockTooltips/DropletFunctionTooltip.js
+++ b/apps/src/blockTooltips/DropletFunctionTooltip.js
@@ -66,8 +66,10 @@ var DropletFunctionTooltip = function(appMsg, definition) {
   var localizedDescription = this.getLocalization(this.descriptionKey());
   if (definition.comment) {
     this.description = definition.comment;
-    this.customExamplesLink = true;
+    this.showCodeLink = true;
+    this.showExamplesLink = false;
   } else if (localizedDescription) {
+    this.showExamplesLink = true;
     this.description = localizedDescription();
   }
 

--- a/apps/src/blockTooltips/DropletFunctionTooltip.js
+++ b/apps/src/blockTooltips/DropletFunctionTooltip.js
@@ -48,7 +48,6 @@ var DROPLET_BLOCK_I18N_PREFIX = 'dropletBlock_';
  * @constructor
  */
 var DropletFunctionTooltip = function(appMsg, definition) {
-  console.log(definition);
   this.appMsg = appMsg;
 
   /** @type {string} */

--- a/apps/src/blockTooltips/DropletFunctionTooltip.js
+++ b/apps/src/blockTooltips/DropletFunctionTooltip.js
@@ -48,6 +48,7 @@ var DROPLET_BLOCK_I18N_PREFIX = 'dropletBlock_';
  * @constructor
  */
 var DropletFunctionTooltip = function(appMsg, definition) {
+  console.log(definition);
   this.appMsg = appMsg;
 
   /** @type {string} */
@@ -64,12 +65,12 @@ var DropletFunctionTooltip = function(appMsg, definition) {
   this.customDocURL = definition.customDocURL;
 
   var localizedDescription = this.getLocalization(this.descriptionKey());
+  this.showExamplesLink = true;
   if (definition.comment) {
     this.description = definition.comment;
     this.showCodeLink = true;
     this.showExamplesLink = false;
   } else if (localizedDescription) {
-    this.showExamplesLink = true;
     this.description = localizedDescription();
   }
 

--- a/apps/style/common.scss
+++ b/apps/style/common.scss
@@ -1484,13 +1484,20 @@ $examples-link-font: $gotham-extra-bold;
 
 $see-examples-thick-underline-color: $yellow;
 
-.tooltip-example-link, .tooltip-choose-link {
+.tooltip-example-link,
+.tooltip-choose-link,
+.tooltip-code-link {
   margin-top: 5px;
   float: right;
 }
 
-.tooltip-example-link > a, .tooltip-choose-link > a {
-  &:hover, &:link, &:active, &:visited {
+.tooltip-example-link > a,
+.tooltip-choose-link > a,
+.tooltip-code-link > a {
+  &:hover,
+  &:link,
+  &:active,
+  &:visited {
     border-bottom: 3px solid $see-examples-thick-underline-color;
     color: white;
     font-family: $gotham-bold;


### PR DESCRIPTION
This fixes the issue with https://github.com/code-dot-org/code-dot-org/pull/34675 that caused the show examples link to not show for some blocks. The issue was that we were setting `this.showExamplesLink` to true only if the function had a description, so it wasn't showing the examples link for blocks that do not have descriptions. This fix sets `this.showExamplesLink` to true for all blocks, and only sets it to false if there's a comment (meaning that it's a library function)
![image](https://user-images.githubusercontent.com/8787187/82617062-c36dde80-9b83-11ea-8edb-183adb0ba5a5.png)
