### PR TITLE
Census: seed 2019-2020 AP CS offerings

### DIFF
--- a/dashboard/app/models/census/ap_cs_offering.rb
+++ b/dashboard/app/models/census/ap_cs_offering.rb
@@ -31,6 +31,7 @@ class Census::ApCsOffering < ApplicationRecord
   def self.seed_from_csv(course, school_year, filename, dry_run = false)
     succeeded = 0
     skipped = 0
+
     ActiveRecord::Base.transaction do
       CSV.foreach(filename, {headers: true}) do |row|
         raw_school_code = row.to_hash['School Code']  # College Board attending institution (AI) code
@@ -57,6 +58,7 @@ class Census::ApCsOffering < ApplicationRecord
         end
       end
     end
+
     CDO.log.info "AP CS Offering seeding: done processing #{course}-#{school_year} data. "\
       "#{succeeded} rows succeeded, #{skipped} rows skipped."
   end
@@ -99,9 +101,9 @@ class Census::ApCsOffering < ApplicationRecord
   #   Census::StateCsOffering.dry_seed_s3_object('CSA', 2019, 'txt')
   #   will seed from ap_cs_offerings/CSA-2019-2020.txt object.
   #
-  # @note: A CSV file with valid format name in S3 will be automatically
+  # @note: A CSV file with a right format name in S3 will be automatically
   # picked up by the +seed_from_s3+ method as part of the build seeding process.
-  # To prevent that, use a different file extension such as .test or .xyz.
+  # To prevent that, use a different file extension such as .test or .txt.
   def self.dry_seed_s3_object(course, school_year, file_extension = 'csv')
     object_key = construct_object_key(course, school_year, file_extension)
     AWS::S3.process_file(CENSUS_BUCKET_NAME, object_key) do |filename|

--- a/dashboard/app/models/census/ap_cs_offering.rb
+++ b/dashboard/app/models/census/ap_cs_offering.rb
@@ -88,6 +88,16 @@ class Census::ApCsOffering < ApplicationRecord
     end
   end
 
+  # Test seeding an object from S3 to find issues.
+  # This method does not check if the object had been seeded before
+  # and does not write to the database.
+  #
+  # @example:
+  #   Census::ApCsOffering.dry_seed_s3_object('CSP', 2017)
+  #   will seed from ap_cs_offerings/CSP-2017-2028.csv object.
+  #
+  #   Census::StateCsOffering.dry_seed_s3_object('CSA', 2019, 'txt')
+  #   will seed from ap_cs_offerings/CSA-2019-2020.txt object.
   def self.dry_seed_s3_object(course, school_year, file_extension = 'csv')
     object_key = construct_object_key(course, school_year, file_extension)
     AWS::S3.process_file(CENSUS_BUCKET_NAME, object_key) do |filename|

--- a/dashboard/app/models/census/ap_cs_offering.rb
+++ b/dashboard/app/models/census/ap_cs_offering.rb
@@ -47,8 +47,8 @@ class Census::ApCsOffering < ApplicationRecord
               course: course,
               school_year: school_year
             )
-            succeeded += 1
           end
+          succeeded += 1
         rescue ActiveRecord::RecordNotFound
           # We don't have mapping for every school code so skip over any that
           # can't be found in the database.

--- a/dashboard/app/models/census/ap_cs_offering.rb
+++ b/dashboard/app/models/census/ap_cs_offering.rb
@@ -98,6 +98,10 @@ class Census::ApCsOffering < ApplicationRecord
   #
   #   Census::StateCsOffering.dry_seed_s3_object('CSA', 2019, 'txt')
   #   will seed from ap_cs_offerings/CSA-2019-2020.txt object.
+  #
+  # @note: A CSV file with valid format name in S3 will be automatically
+  # picked up by the +seed_from_s3+ method as part of the build seeding process.
+  # To prevent that, use a different file extension such as .test or .xyz.
   def self.dry_seed_s3_object(course, school_year, file_extension = 'csv')
     object_key = construct_object_key(course, school_year, file_extension)
     AWS::S3.process_file(CENSUS_BUCKET_NAME, object_key) do |filename|

--- a/dashboard/app/models/census/ap_school_code.rb
+++ b/dashboard/app/models/census/ap_school_code.rb
@@ -30,23 +30,33 @@ class Census::ApSchoolCode < ApplicationRecord
     format("%06d", raw_school_code.to_i)
   end
 
-  def self.construct_object_key(school_year)
-    "ap_school_codes/#{school_year}-#{school_year + 1}.csv"
+  def self.construct_object_key(school_year, file_extension = 'csv')
+    "ap_school_codes/#{school_year}-#{school_year + 1}.#{file_extension}"
   end
 
-  def self.seed_from_csv(filename, school_year)
+  def self.seed_from_csv(filename, school_year, dry_run = false)
+    succeeded = 0
+    skipped = 0
+
     ActiveRecord::Base.transaction do
       CSV.foreach(filename, {headers: true}) do |row|
         normalized_school_code = normalize_school_code(row.to_hash['school_code'])
         school_id = School.normalize_school_id(row.to_hash['school_id'])
         school = School.find_by(id: school_id)
         if school.nil?
-          CDO.log.warn "AP School Code seed: school not found - skipping row for school_code:#{normalized_school_code} school_id:#{school_id}"
+          skipped += 1
+          CDO.log.warn "AP School Code seeding: school not found - skipping row for school_code:#{normalized_school_code} school_id:#{school_id}"
         else
-          find_or_create_by!(school_code: normalized_school_code, school: school, school_year: school_year)
+          unless dry_run
+            find_or_create_by!(school_code: normalized_school_code, school: school, school_year: school_year)
+          end
+          succeeded += 1
         end
       end
     end
+
+    CDO.log.info "AP School Code seeding: done processing {school_year} data. "\
+      "#{succeeded} rows succeeded, #{skipped} rows skipped."
   end
 
   CENSUS_BUCKET_NAME = "cdo-census".freeze
@@ -64,6 +74,31 @@ class Census::ApSchoolCode < ApplicationRecord
         CDO.log.warn "AP School Code seeding: object #{object_key} not found in S3 - skipping."
       end
     end
+  end
+
+  # Test seeding an object from S3 to find issues.
+  # This method does not check if the object had been seeded before
+  # and does not write to the database.
+  #
+  # @example:
+  #   Census::ApSchoolCode.dry_seed_s3_object(2017)
+  #   will seed from ap_school_codes/2017-2018.csv object.
+  #
+  #   Census::ApSchoolCode.dry_seed_s3_object(2019, 'txt')
+  #   will seed from ap_cs_offerings/2019-2020.txt object.
+  #
+  # @note: A CSV file with a right format name in S3 will be automatically
+  # picked up by the +seed_from_s3+ method as part of the build seeding process.
+  # To prevent that, use a different file extension such as .test or .txt.
+  def self.dry_seed_s3_object(school_year, file_extension = 'csv')
+    object_key = construct_object_key(school_year, file_extension)
+    AWS::S3.process_file(CENSUS_BUCKET_NAME, object_key) do |filename|
+      seed_from_csv(filename, school_year, true)
+    end
+  rescue Aws::S3::Errors::NoSuchKey
+    CDO.log.warn "AP School Code seeding: Object #{object_key} not found in S3."
+  ensure
+    CDO.log.info "This is a dry run. No data is written to the database."
   end
 
   def self.seed

--- a/dashboard/app/models/census/ap_school_code.rb
+++ b/dashboard/app/models/census/ap_school_code.rb
@@ -44,8 +44,8 @@ class Census::ApSchoolCode < ApplicationRecord
         school_id = School.normalize_school_id(row.to_hash['school_id'])
         school = School.find_by(id: school_id)
         if school.nil?
-          skipped += 1
           CDO.log.warn "AP School Code seeding: school not found - skipping row for school_code:#{normalized_school_code} school_id:#{school_id}"
+          skipped += 1
         else
           unless dry_run
             find_or_create_by!(school_code: normalized_school_code, school: school, school_year: school_year)

--- a/dashboard/app/models/census/ap_school_code.rb
+++ b/dashboard/app/models/census/ap_school_code.rb
@@ -55,7 +55,7 @@ class Census::ApSchoolCode < ApplicationRecord
       end
     end
 
-    CDO.log.info "AP School Code seeding: done processing {school_year} data. "\
+    CDO.log.info "AP School Code seeding: done processing #{school_year} data. "\
       "#{succeeded} rows succeeded, #{skipped} rows skipped."
   end
 


### PR DESCRIPTION
[PLC-821](https://codedotorg.atlassian.net/browse/PLC-821): Ingesting 2019-2020 CollegeBoard CSA and CSP data from [here](https://drive.google.com/drive/u/0/folders/16_zeAcCHNC5OIOkH40Lsgb6nBfDU4YHv).

Before we can ingest AP CS offerings, we have to first extract and ingest CollegeBoard school code-NCES code mappings.

## How to ingest College board school code-NCES code mappings
1. Copy CSV file with mappings to `ap_school_codes/<school_year>-<school_year + 1>.test` in [cdo-census](https://s3.console.aws.amazon.com/s3/buckets/cdo-census?region=us-east-1&tab=overview) S3 bucket.

2. From a Rails console in `production-console` machine, test ingesting the new file by running `Census::ApSchoolCode.dry_seed_s3_object(<school_year>, <file_extension>)`.
    * Example: Census::ApSchoolCode.dry_seed_s3_object(2019, 'test')
    * Have to test on `production-console` because the seeding process relies on matching school IDs to valid records in `School` model.

3. Change the file extension in S3 from .test to .csv. The file will be automatically ingested to staging/test/production instances the next time they rebuid. Or you can manually trigger ingestion by running `Census::ApSchoolCode.seed_from_s3`.

## How to ingest an AP CS offering file
1. Copy the file to [cdo-census](https://s3.console.aws.amazon.com/s3/buckets/cdo-census/?region=us-east-1#)  S3 bucket following this path `ap_cs_offerings/{CSA|CSP}-{year}-{year+1}.test`.
    * Example: CSP-2019-2020.test
    * Use`.test` extension or any extensions other than `.csv` so the automated seeding process won't pick up the new file.

2. From a Rails console in production-console machine, test ingesting the new file by running `Census::ApCsOffering.dry_seed_s3_object(<CSP|CSA>, <school_year>, <file_extension>)`.
    * Example: Census::ApCsOffering.dry_seed_s3_object('CSP', 2019, 'test')
    * Have to test on `production-console` because the seeding process relies on matching school codes (College board AI code) in CSV file to valid records in `Census::ApSchoolCode` table.

3. Fix any issues that occur and deploy code to production if there are code changes.

4. Change the file extension in S3 from .test to .csv. The file will be automatically ingested to staging/test/production instances the next time they rebuid. Or you can manually trigger ingestion by running `Census::ApCsOffering.seed_from_s3`.

## Links
Related PR: Ingesting state CS offerings https://github.com/code-dot-org/code-dot-org/pull/34925/

## Testing story
From a Rails console in production-console, dry-test ingesting individual files:
```
Census::ApSchoolCode.dry_seed_s3_object(2017)
Census::ApSchoolCode.dry_seed_s3_object(2019, 'test')

Census::ApCsOffering.dry_seed_s3_object('CSA', 2016)
Census::ApCsOffering.dry_seed_s3_object('CSP', 2017)
Census::ApCsOffering.dry_seed_s3_object('CSA', 2019, 'test')
Census::ApCsOffering.dry_seed_s3_object('CSP', 2019, 'test')
```

## Reviewer Checklist:
- [ ] Tests provide adequate coverage
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
