### PR TITLE
Census: Empty state exclusion list

### DIFF
--- a/dashboard/app/models/census/state_cs_offering.rb
+++ b/dashboard/app/models/census/state_cs_offering.rb
@@ -158,18 +158,9 @@ class Census::StateCsOffering < ApplicationRecord
 
   # By default we treat the lack of state data for high schools as an
   # indication that the school doesn't teach cs. We aren't as confident
-  # that the state data is conplete for the following states so we do
+  # that the state data is complete for the following states so we do
   # not want to treat the lack of data as a no for those.
-  INFERRED_NO_EXCLUSION_LIST = %w(
-    CO
-    DE
-    ID
-    ME
-    MI
-    OH
-    TN
-    TX
-  ).freeze
+  INFERRED_NO_EXCLUSION_LIST = [].freeze
 
   def self.infer_no(state_code)
     INFERRED_NO_EXCLUSION_LIST.exclude? state_code.upcase

--- a/dashboard/test/models/census/census_summary_test.rb
+++ b/dashboard/test/models/census/census_summary_test.rb
@@ -262,6 +262,7 @@ class Census::CensusSummaryTest < ActiveSupport::TestCase
   end
 
   test "High school lack of state data in a blacklist state does not override anything" do
+    return if Census::StateCsOffering::INFERRED_NO_EXCLUSION_LIST.empty?
     school_year = 2020
     school = create :census_school,
       :with_teaches_no_teacher_census_submission,


### PR DESCRIPTION
[PLC-821](https://codedotorg.atlassian.net/browse/PLC-821): Empty the state exclusion list since we have 100% of high school data now.

**Open question:** Is it safe to remove the list and its related code/test entirely? In other words, do we expect to exclude some states (for summarization purpose) again in the future?
**Update:** Checked with Ben and Liz during meeting, we still want to keep the state-exclusion logic in case we have to use it next year.
