### PR TITLE
Standards: clean up stage -> lesson 

### DIFF
--- a/apps/src/templates/sectionProgress/standards/StandardsViewHeaderButtons.jsx
+++ b/apps/src/templates/sectionProgress/standards/StandardsViewHeaderButtons.jsx
@@ -122,22 +122,22 @@ class StandardsViewHeaderButtons extends Component {
 
   onSaveUnpluggedLessonStatus = () => {
     const {sectionId, selectedLessons, unpluggedLessons} = this.props;
-    let selectedStageScores = [];
-    let unselectedStageScores = [];
-    const stageIds = _.map(unpluggedLessons, 'id');
-    const selectedStageIds = _.map(selectedLessons, 'id');
-    const unselectedStageIds = _.difference(stageIds, selectedStageIds);
+    let selectedLessonScores = [];
+    let unselectedLessonScores = [];
+    const lessonIds = _.map(unpluggedLessons, 'id');
+    const selectedLessonIds = _.map(selectedLessons, 'id');
+    const unselectedLessonIds = _.difference(lessonIds, selectedLessonIds);
 
-    for (var i = 0; i < selectedStageIds.length; i++) {
-      selectedStageScores[i] = {
-        stage_id: selectedStageIds[i],
+    for (var i = 0; i < selectedLessonIds.length; i++) {
+      selectedLessonScores[i] = {
+        stage_id: selectedLessonIds[i],
         score: TeacherScores.COMPLETE
       };
     }
 
-    for (var j = 0; j < unselectedStageIds.length; j++) {
-      unselectedStageScores[j] = {
-        stage_id: unselectedStageIds[j],
+    for (var j = 0; j < unselectedLessonIds.length; j++) {
+      unselectedLessonScores[j] = {
+        stage_id: unselectedLessonIds[j],
         score: TeacherScores.INCOMPLETE
       };
     }
@@ -149,7 +149,7 @@ class StandardsViewHeaderButtons extends Component {
       dataType: 'json',
       data: JSON.stringify({
         section_id: sectionId,
-        stage_scores: selectedStageScores.concat(unselectedStageScores)
+        stage_scores: selectedLessonScores.concat(unselectedLessonScores)
       })
     }).done(() => {
       if (this.state.isLessonStatusDialogOpen) {

--- a/apps/src/templates/sectionProgress/standards/standardsTestHelpers.js
+++ b/apps/src/templates/sectionProgress/standards/standardsTestHelpers.js
@@ -110,7 +110,7 @@ export const standardsData = [
   }
 ];
 
-export const stageId = 662;
+export const lessonId = 662;
 export const scriptId = 92;
 
 const scriptDataByScript = {
@@ -125,7 +125,7 @@ const scriptDataByScript = {
         script_id: 92,
         script_name: 'coursea-2019',
         script_stages: 3,
-        id: stageId,
+        id: lessonId,
         position: 1,
         relative_position: 1,
         name: 'Going Places Safely',
@@ -192,7 +192,7 @@ const scriptDataByScript = {
   }
 };
 
-export const pluggedStage = scriptDataByScript[scriptId].stages[1];
+export const pluggedLesson = scriptDataByScript[scriptId].stages[1];
 
 const sectionCompletedLesson = {
   92: {

--- a/apps/src/templates/sectionProgress/standards/standardsTestHelpers.js
+++ b/apps/src/templates/sectionProgress/standards/standardsTestHelpers.js
@@ -232,11 +232,11 @@ const sectionPartialCompletedLesson = {
   }
 };
 
-const studentLevelScoresByStageComplete = {
+const studentLevelScoresByLessonComplete = {
   92: {662: {100001: {10001: TeacherScores.COMPLETE}}}
 };
 
-const studentLevelScoresByStageIncomplete = {
+const studentLevelScoresByLessonIncomplete = {
   92: {662: {100001: {10001: TeacherScores.INCOMPLETE}}}
 };
 
@@ -261,7 +261,7 @@ export const fakeState = {
   },
   sectionStandardsProgress: {
     standardsData: standardsData,
-    studentLevelScoresByStage: {92: {662: {}}}
+    studentLevelScoresByLesson: {92: {662: {}}}
   },
   teacherSections: teacherSections
 };
@@ -304,7 +304,7 @@ export const stateForTeacherMarkedCompletedLesson = {
   },
   sectionStandardsProgress: {
     standardsData: standardsData,
-    studentLevelScoresByStage: studentLevelScoresByStageComplete,
+    studentLevelScoresByLesson: studentLevelScoresByLessonComplete,
     selectedLessons: selectedLessons
   },
   teacherSections: teacherSections
@@ -320,7 +320,7 @@ export const stateForTeacherMarkedIncompletedLesson = {
   },
   sectionStandardsProgress: {
     standardsData: standardsData,
-    studentLevelScoresByStage: studentLevelScoresByStageIncomplete,
+    studentLevelScoresByLesson: studentLevelScoresByLessonIncomplete,
     selectedLessons: []
   },
   teacherSections: teacherSections
@@ -336,7 +336,7 @@ export const stateForTeacherMarkedAndProgress = {
   },
   sectionStandardsProgress: {
     standardsData: standardsData,
-    studentLevelScoresByStage: studentLevelScoresByStageComplete,
+    studentLevelScoresByLesson: studentLevelScoresByLessonComplete,
     selectedLessons: selectedLessons
   },
   teacherSections: teacherSections

--- a/apps/test/unit/templates/sectionProgress/sectionStandardsProgressReduxTest.js
+++ b/apps/test/unit/templates/sectionProgress/sectionStandardsProgressReduxTest.js
@@ -10,9 +10,9 @@ import sectionStandardsProgress, {
   getLessonSelectionStatus
 } from '@cdo/apps/templates/sectionProgress/standards/sectionStandardsProgressRedux';
 import {
-  stageId,
+  lessonId,
   scriptId,
-  pluggedStage,
+  pluggedLesson,
   stateForTeacherMarkedAndProgress,
   stateForTeacherMarkedIncompletedLesson,
   stateForTeacherMarkedCompletedLesson,
@@ -27,14 +27,14 @@ describe('sectionStandardsProgressRedux', () => {
   describe('getLessonSelectionStatus', () => {
     it('returns true if lesson is in selected list', () => {
       expect(
-        getLessonSelectionStatus(stateForTeacherMarkedCompletedLesson, stageId)
+        getLessonSelectionStatus(stateForTeacherMarkedCompletedLesson, lessonId)
       ).to.equal(true);
     });
     it('returns false if lesson is not in selected', () => {
       expect(
         getLessonSelectionStatus(
           stateForTeacherMarkedIncompletedLesson,
-          stageId
+          lessonId
         )
       ).to.equal(false);
     });
@@ -300,9 +300,9 @@ describe('sectionStandardsProgressRedux', () => {
   });
 
   describe('getUnPluggedLessonCompletionStatus', () => {
-    it('incomplete when no teacher scores for stage', () => {
+    it('incomplete when no teacher scores for lesson', () => {
       expect(
-        getUnpluggedLessonCompletionStatus(fakeState, scriptId, stageId)
+        getUnpluggedLessonCompletionStatus(fakeState, scriptId, lessonId)
       ).to.deep.equal({
         completed: false,
         inProgress: false,
@@ -310,12 +310,12 @@ describe('sectionStandardsProgressRedux', () => {
       });
     });
 
-    it('incomplete when teacher scores stage as incomplete', () => {
+    it('incomplete when teacher scores lesson as incomplete', () => {
       expect(
         getUnpluggedLessonCompletionStatus(
           stateForTeacherMarkedIncompletedLesson,
           scriptId,
-          stageId
+          lessonId
         )
       ).to.deep.equal({
         completed: false,
@@ -324,12 +324,12 @@ describe('sectionStandardsProgressRedux', () => {
       });
     });
 
-    it('complete when teacher scores stage as complete', () => {
+    it('complete when teacher scores lesson as complete', () => {
       expect(
         getUnpluggedLessonCompletionStatus(
           stateForTeacherMarkedCompletedLesson,
           scriptId,
-          stageId
+          lessonId
         )
       ).to.deep.equal({
         completed: true,
@@ -342,7 +342,7 @@ describe('sectionStandardsProgressRedux', () => {
   describe('getPluggedLessonCompletionStatus', () => {
     it('accurately calculates no progress', () => {
       expect(
-        getPluggedLessonCompletionStatus(fakeState, pluggedStage)
+        getPluggedLessonCompletionStatus(fakeState, pluggedLesson)
       ).to.deep.equal({
         completed: false,
         inProgress: false,
@@ -354,7 +354,7 @@ describe('sectionStandardsProgressRedux', () => {
       expect(
         getPluggedLessonCompletionStatus(
           stateForPartiallyCompletedLesson,
-          pluggedStage
+          pluggedLesson
         )
       ).to.deep.equal({
         completed: false,
@@ -365,7 +365,7 @@ describe('sectionStandardsProgressRedux', () => {
 
     it('accurately calculates > 80% of students completed > 60% of levels', () => {
       expect(
-        getPluggedLessonCompletionStatus(stateForCompletedLesson, pluggedStage)
+        getPluggedLessonCompletionStatus(stateForCompletedLesson, pluggedLesson)
       ).to.deep.equal({
         completed: true,
         inProgress: true,


### PR DESCRIPTION
As part of the initiative to clean up our content hierarchy and align it more closely to curriculum team needs the Curriculum Platform team is switching "stage" to "lesson", for example https://github.com/code-dot-org/code-dot-org/pull/34821#discussion_r426081924. For consistency, the Learning Platform team is taking on cleaning up references to "stage" in the part of the codebase we own.  In this PR, I've updated "stage" to "lesson" in `sectionStandardsProgressRedux` and related test code and UI components. 

This change is not comprehensive; notably "stage" is still used in related server-side code and in `sectionProgressRedux` from which standards components pull state. Learning Platform will tackle the term change incrementally. 