### PR TITLE
Section SetUp: email sections with students shouldn't be able to switch login type

### DIFF
--- a/apps/src/templates/teacherDashboard/EditSectionForm.jsx
+++ b/apps/src/templates/teacherDashboard/EditSectionForm.jsx
@@ -139,19 +139,19 @@ class EditSectionForm extends Component {
     } = this.props;
 
     /**
-    OAuth login types can not be changed.
-    Personal email login type can be changed to word OR picture login type.
+    OAuth and personal email login types can not be changed.
     Picture login type can be changed to word login type.
     Word login type can be changed to picture login type.
     **/
     const changeableLoginTypes = [
       SectionLoginType.word,
-      SectionLoginType.picture,
-      SectionLoginType.email
+      SectionLoginType.picture
     ];
 
     let sectionLoginTypeTransforms = {};
-    sectionLoginTypeTransforms[SectionLoginType.email] = changeableLoginTypes;
+    sectionLoginTypeTransforms[SectionLoginType.email] = [
+      SectionLoginType.email
+    ];
     sectionLoginTypeTransforms[SectionLoginType.picture] = [
       SectionLoginType.word,
       SectionLoginType.picture

--- a/apps/test/unit/templates/teacherDashboard/EditSectionFormTest.js
+++ b/apps/test/unit/templates/teacherDashboard/EditSectionFormTest.js
@@ -69,53 +69,6 @@ describe('EditSectionForm', () => {
       SectionLoginType.clever
     );
   });
-  it('renders LoginTypeField with email, word and picture options for personal email sections', () => {
-    const wrapper = mount(
-      <EditSectionForm
-        title="Edit section details"
-        handleSave={() => {}}
-        handleClose={() => {}}
-        editSectionProperties={() => {}}
-        validGrades={['K', '1', '2', '3']}
-        validAssignments={validAssignments}
-        assignmentFamilies={assignmentFamilies}
-        sections={{}}
-        section={{
-          ...testSection,
-          loginType: SectionLoginType.email
-        }}
-        isSaveInProgress={false}
-        stageExtrasAvailable={() => false}
-        hiddenStageState={{}}
-        updateHiddenScript={() => {}}
-        assignedScriptName="script name"
-      />
-    );
-    const loginTypeField = wrapper.find('LoginTypeField');
-    assert.equal(loginTypeField.length, 1);
-    assert.equal(loginTypeField.find('option').length, 3);
-    assert.equal(
-      loginTypeField
-        .find('option')
-        .at(0)
-        .props().value,
-      SectionLoginType.word
-    );
-    assert.equal(
-      loginTypeField
-        .find('option')
-        .at(1)
-        .props().value,
-      SectionLoginType.picture
-    );
-    assert.equal(
-      loginTypeField
-        .find('option')
-        .at(2)
-        .props().value,
-      SectionLoginType.email
-    );
-  });
   it('renders LoginTypeField with word and picture options for word sections', () => {
     const wrapper = mount(
       <EditSectionForm
@@ -189,6 +142,31 @@ describe('EditSectionForm', () => {
         .props().value,
       SectionLoginType.picture
     );
+  });
+  it('does not render LoginTypeField for personal email sections', () => {
+    const wrapper = mount(
+      <EditSectionForm
+        title="Edit section details"
+        handleSave={() => {}}
+        handleClose={() => {}}
+        editSectionProperties={() => {}}
+        validGrades={['K', '1', '2', '3']}
+        validAssignments={validAssignments}
+        assignmentFamilies={assignmentFamilies}
+        sections={{}}
+        section={{
+          ...testSection,
+          loginType: SectionLoginType.email
+        }}
+        isSaveInProgress={false}
+        stageExtrasAvailable={() => false}
+        hiddenStageState={{}}
+        updateHiddenScript={() => {}}
+        assignedScriptName="script name"
+      />
+    );
+    const loginTypeField = wrapper.find('LoginTypeField');
+    assert.equal(loginTypeField.length, 0);
   });
   it('does not render LoginTypeField for Google Classroom sections', () => {
     const wrapper = mount(


### PR DESCRIPTION
[LP-1469](https://codedotorg.atlassian.net/browse/LP-1469)

When I moved changing login type functionality over to the `EditSectionForm` as part of [section setup work ](https://docs.google.com/document/d/1YaC8yPL4QUNshj0zXmCZJ1o-FcGYb1Dexv9J0-acHuM/edit#heading=h.hupraqk0xxj5) in #34530 I re-used the existing logic for which section types could be switched to which other section types; however, we no longer want email sections with students to be able switch login type. Now they can't. 