### PR TITLE
Make sure all lesson group positions are zero based

### DIFF
--- a/dashboard/app/models/lesson_group.rb
+++ b/dashboard/app/models/lesson_group.rb
@@ -19,6 +19,8 @@ class LessonGroup < ApplicationRecord
   belongs_to :script
   has_many :lessons, -> {order('absolute_position ASC')}
 
+  validates :position, numericality: {greater_than: 1}
+
   validates_uniqueness_of :key, scope: :script_id
 
   validates :key,

--- a/dashboard/app/models/lesson_group.rb
+++ b/dashboard/app/models/lesson_group.rb
@@ -19,7 +19,7 @@ class LessonGroup < ApplicationRecord
   belongs_to :script
   has_many :lessons, -> {order('absolute_position ASC')}
 
-  validates :position, numericality: {greater_than: 1}
+  validates :position, numericality: {greater_than: 0}
 
   validates_uniqueness_of :key, scope: :script_id
 

--- a/dashboard/app/models/script.rb
+++ b/dashboard/app/models/script.rb
@@ -922,7 +922,7 @@ class Script < ActiveRecord::Base
           key: '',
           script: script,
           user_facing: false,
-          position: 0
+          position: 1
         )
 
         script_lesson_groups << lesson_group

--- a/dashboard/test/factories/factories.rb
+++ b/dashboard/test/factories/factories.rb
@@ -736,6 +736,10 @@ FactoryGirl.define do
   factory :lesson_group do
     sequence(:key) {|n| "Bogus Lesson Group #{n}"}
     script
+
+    position do |lesson_group|
+      (lesson_group.script.lesson_groups.maximum(:position) || 0) + 1
+    end
   end
 
   factory :lesson do


### PR DESCRIPTION
Fixes an issue where non-user-facing lesson groups were 0 based when they should be 1 based. Tested locally that the change will update the lesson groups during the seed process.

## Testing story

<!--
  Does your change include appropriate tests?

  If so, please describe how the tests included in this PR are sufficient

  If not, please explain why this change does not need to be tested.
-->

1. Tested seeding locally
2. Added validation that makes sure position is an integer greater than 0
3. Updated the lesson group factory to set position for a new factory created lesson group

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
