### PR TITLE
Sync named function parameters to Crowdin

### DIFF
--- a/bin/i18n/sync-in.rb
+++ b/bin/i18n/sync-in.rb
@@ -79,14 +79,14 @@ def get_i18n_strings(level)
       functions.each do |function|
         name = function.at_xpath('./title[@name="NAME"]')
         description = function.at_xpath('./mutation/description')
-        parameters = function.xpath('./mutation/arg')
-        i18n_strings['function_definitions'][name.content] = Hash.new
-        i18n_strings['function_definitions'][name.content]["name"] = name.content if name
-        i18n_strings['function_definitions'][name.content]["description"] = description.content if description
-        i18n_strings['function_definitions'][name.content]["parameters"] = Hash.new if parameters.count > 0
-        parameters.each do |parameter|
-          i18n_strings['function_definitions'][name.content]["parameters"][parameter["name"]] = parameter["name"]
-        end
+        parameters = function.xpath('./mutation/arg').map do |parameter|
+          [parameter["name"], parameter["name"]]
+        end.to_h
+        function_definition = Hash.new
+        function_definition["name"] = name.content if name
+        function_definition["description"] = description.content if description
+        function_definition["parameters"] = parameters unless parameters.empty?
+        i18n_strings['function_definitions'][name.content] = function_definition
       end
 
       # Spritelab behaviors

--- a/bin/i18n/sync-in.rb
+++ b/bin/i18n/sync-in.rb
@@ -79,9 +79,14 @@ def get_i18n_strings(level)
       functions.each do |function|
         name = function.at_xpath('./title[@name="NAME"]')
         description = function.at_xpath('./mutation/description')
+        parameters = function.xpath('./mutation/arg')
         i18n_strings['function_definitions'][name.content] = Hash.new
         i18n_strings['function_definitions'][name.content]["name"] = name.content if name
         i18n_strings['function_definitions'][name.content]["description"] = description.content if description
+        i18n_strings['function_definitions'][name.content]["parameters"] = Hash.new if parameters.count > 0
+        parameters.each do |parameter|
+          i18n_strings['function_definitions'][name.content]["parameters"][parameter["name"]] = parameter["name"]
+        end
       end
 
       # Spritelab behaviors


### PR DESCRIPTION
This PR adds the named parameters to the `function_definitions` object for each level. I'll create a separate PR to actually use the translations.

Example:
```
  "https://studio.code.org/p/artist": {
   ...
    "function_definitions": {
      "draw a star": {
        "name": "draw a star",
        "description": "draw a star with given points and sides of given length",
        "parameters": {
          "points": "points",
          "length": "length"
        }
      },
      "draw a circle": {
        "name": "draw a circle",
        "description": "draw a circle of given radius",
        "parameters": {
          "radius": "radius"
        }
      }
      ...
  }
}
```

<!-- ### Background -->
<!-- ### Privacy -->
<!-- ### Security -->
<!-- ### Caching -->
<!-- ### Deployment strategy -->
<!-- ### Future work -->

## Links

<!--
  Any relevant links to external resources; ie, specification documents, jira
  items, related PRs, honeybadger errors, etc
-->

- [spec]()
- [jira]()

## Testing story

<!--
  Does your change include appropriate tests?

  If so, please describe how the tests included in this PR are sufficient

  If not, please explain why this change does not need to be tested.
-->

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
