### PR TITLE
[Sprite Lab] Set up shadowing for mini toolbox blocks

### DIFF
--- a/apps/package.json
+++ b/apps/package.json
@@ -49,7 +49,7 @@
     "@babel/preset-react": "^7.0.0",
     "@cdo/interpreted": "link:../dashboard/config/libraries",
     "@code-dot-org/artist": "0.2.1",
-    "@code-dot-org/blockly": "3.5.16",
+    "@code-dot-org/blockly": "3.5.17",
     "@code-dot-org/bramble": "0.1.26",
     "@code-dot-org/craft": "0.2.2",
     "@code-dot-org/dance-party": "1.0.1",

--- a/apps/package.json
+++ b/apps/package.json
@@ -49,7 +49,7 @@
     "@babel/preset-react": "^7.0.0",
     "@cdo/interpreted": "link:../dashboard/config/libraries",
     "@code-dot-org/artist": "0.2.1",
-    "@code-dot-org/blockly": "3.5.15",
+    "@code-dot-org/blockly": "3.5.16",
     "@code-dot-org/bramble": "0.1.26",
     "@code-dot-org/craft": "0.2.2",
     "@code-dot-org/dance-party": "1.0.1",

--- a/apps/src/block_utils.js
+++ b/apps/src/block_utils.js
@@ -1030,15 +1030,26 @@ exports.createJsWrapperBlockCreator = function(
 
         // For mini-toolbox, indicate which blocks should receive the duplicate on drag
         // behavior and indicates the sibling block to shadow the value from
-        if (blockText === 'clicked {SPRITE}') {
+        if (this.type === 'gamelab_clickedSpritePointer') {
           this.setParentForCopyOnDrag('gamelab_spriteClickedSet');
-          this.setBlockToShadow('gamelab_allSpritesWithAnimation');
+          this.setBlockToShadow(
+            root =>
+              root.type === 'gamelab_spriteClicked' && root.childBlocks_[0]
+          );
         }
-        if (blockText === 'subject sprite') {
+        if (this.type === 'gamelab_subjectSpritePointer') {
           this.setParentForCopyOnDrag('gamelab_whenTouchingSet');
+          this.setBlockToShadow(
+            root =>
+              root.type === 'gamelab_checkTouching' && root.childBlocks_[0]
+          );
         }
-        if (blockText === 'object sprite') {
+        if (this.type === 'gamelab_objectSpritePointer') {
           this.setParentForCopyOnDrag('gamelab_whenTouchingSet');
+          this.setBlockToShadow(
+            root =>
+              root.type === 'gamelab_checkTouching' && root.childBlocks_[1]
+          );
         }
 
         interpolateInputs(blockly, this, inputRows, inputTypes, inline);

--- a/apps/src/block_utils.js
+++ b/apps/src/block_utils.js
@@ -1034,21 +1034,27 @@ exports.createJsWrapperBlockCreator = function(
           this.setParentForCopyOnDrag('gamelab_spriteClickedSet');
           this.setBlockToShadow(
             root =>
-              root.type === 'gamelab_spriteClicked' && root.childBlocks_[0]
+              root.type === 'gamelab_spriteClicked' &&
+              root.getConnections_()[1] &&
+              root.getConnections_()[1].targetBlock()
           );
         }
         if (this.type === 'gamelab_subjectSpritePointer') {
           this.setParentForCopyOnDrag('gamelab_whenTouchingSet');
           this.setBlockToShadow(
             root =>
-              root.type === 'gamelab_checkTouching' && root.childBlocks_[0]
+              root.type === 'gamelab_checkTouching' &&
+              root.getConnections_()[1] &&
+              root.getConnections_()[1].targetBlock()
           );
         }
         if (this.type === 'gamelab_objectSpritePointer') {
           this.setParentForCopyOnDrag('gamelab_whenTouchingSet');
           this.setBlockToShadow(
             root =>
-              root.type === 'gamelab_checkTouching' && root.childBlocks_[1]
+              root.type === 'gamelab_checkTouching' &&
+              root.getConnections_()[2] &&
+              root.getConnections_()[2].targetBlock()
           );
         }
 

--- a/apps/yarn.lock
+++ b/apps/yarn.lock
@@ -1526,10 +1526,10 @@
   version "0.2.1"
   resolved "https://registry.yarnpkg.com/@code-dot-org/artist/-/artist-0.2.1.tgz#fcfe7ea5cfb3f19ddb6b912e70e922ba4b7ef0b1"
 
-"@code-dot-org/blockly@3.5.16":
-  version "3.5.16"
-  resolved "https://registry.yarnpkg.com/@code-dot-org/blockly/-/blockly-3.5.16.tgz#c009049ff39fbccf2bfe39ae38becb4b8cab75f5"
-  integrity sha512-FtViIqutJ4xft1hjFlAk3ZxPyQjCm416E+Ef5kxyufT0yfLSIFqkXhUynsaZScrIzUo5P+TsqB1b0n2+4gdsQA==
+"@code-dot-org/blockly@3.5.17":
+  version "3.5.17"
+  resolved "https://registry.yarnpkg.com/@code-dot-org/blockly/-/blockly-3.5.17.tgz#e8595d31f039d6c83de283f5cbfbc4d3ae74978d"
+  integrity sha512-PZZHnEhGpJfdgshaeaudAeTFcwG8QUs5UTZtfNvimlESNXfSUXPBbn6eYXnwl6IfPXM7BGLCdzFDoxTgggADKA==
 
 "@code-dot-org/bramble@0.1.26":
   version "0.1.26"

--- a/apps/yarn.lock
+++ b/apps/yarn.lock
@@ -1526,10 +1526,10 @@
   version "0.2.1"
   resolved "https://registry.yarnpkg.com/@code-dot-org/artist/-/artist-0.2.1.tgz#fcfe7ea5cfb3f19ddb6b912e70e922ba4b7ef0b1"
 
-"@code-dot-org/blockly@3.5.15":
-  version "3.5.15"
-  resolved "https://registry.yarnpkg.com/@code-dot-org/blockly/-/blockly-3.5.15.tgz#6995cefddb2fd8472e5054a035b55eaae37fb269"
-  integrity sha512-e4Tg0CzoofUQBRjS9pcwBzzHidVsPp8fiNC+j5/srHubwef+PiK1NxeELj20YoBehefii+RQ20qM6HtxFXZY/Q==
+"@code-dot-org/blockly@3.5.16":
+  version "3.5.16"
+  resolved "https://registry.yarnpkg.com/@code-dot-org/blockly/-/blockly-3.5.16.tgz#c009049ff39fbccf2bfe39ae38becb4b8cab75f5"
+  integrity sha512-FtViIqutJ4xft1hjFlAk3ZxPyQjCm416E+Ef5kxyufT0yfLSIFqkXhUynsaZScrIzUo5P+TsqB1b0n2+4gdsQA==
 
 "@code-dot-org/bramble@0.1.26":
   version "0.1.26"


### PR DESCRIPTION
Relies on https://github.com/code-dot-org/blockly/pull/218
The bulk of the logic for this change is in the blockly repo, this PR just sets up the shadowing relationships for the pointer blocks. `Blockly.Block.setBlockToShadow` takes in a function that describes how to get to the block to shadow from the root block. So in our case, that's how to find ![image](https://user-images.githubusercontent.com/8787187/82959028-a95d4300-9f6b-11ea-8fe2-fa97bafd7048.png) from either ![image](https://user-images.githubusercontent.com/8787187/82958950-85016680-9f6b-11ea-9a28-968420908d93.png)or ![image](https://user-images.githubusercontent.com/8787187/82958975-8e8ace80-9f6b-11ea-9198-620c9ba3249e.png)

The other change I make in this PR is to check the block type not block text, which will work with translations.

## Links

<!--
  Any relevant links to external resources; ie, specification documents, jira
  items, related PRs, honeybadger errors, etc
-->

- [spec](https://docs.google.com/document/d/1VV9qHE0qjvas1o8-7zavDpkrbxG9gUmCFRas3Xlwtx4/edit#heading=h.8u7mwfss3758)
Spec is sort of outdated though :(
- 
- [jira](https://codedotorg.atlassian.net/browse/STAR-1091)

## Testing story

<!--
  Does your change include appropriate tests?

  If so, please describe how the tests included in this PR are sufficient

  If not, please explain why this change does not need to be tested.
-->

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
