### PR TITLE
Address an old TODO

### DIFF
--- a/apps/test/integration/levelSolutions/applab1/ec_design.js
+++ b/apps/test/integration/levelSolutions/applab1/ec_design.js
@@ -1729,13 +1729,13 @@ module.exports = {
           'button was deleted'
         );
 
-        // TODO(dave): re-enable this section after we move to headless chrome.
-        // We don't know why this section started failing in phantomjs on
-        // circle, but it appears to pass in headless chrome on circle.
-
         // Drag image out of the app towards the bottom and verify element got deleted
-        // dragElement(image[0], 0, 550);
-        // assert.equal(designModeViz.find('#design_image1').length, 0, "image was deleted");
+        dragElement(image[0], 0, 550);
+        assert.equal(
+          designModeViz.find('#design_image1').length,
+          0,
+          'image was deleted'
+        );
 
         // Drag label out of the app towards the right and bottom and verify element got deleted
         dragElement(label[0], 200, 350);


### PR DESCRIPTION
Now that we've [dropped support for PhantomJS](https://github.com/code-dot-org/code-dot-org/pull/34769) we can start addressing some old TODOs in our test code, like this one to re-enable a test step once we are running on Chrome.