### PR TITLE
Validate that position is always greater than 0 for lesson and script level

### DIFF
--- a/dashboard/app/models/lesson.rb
+++ b/dashboard/app/models/lesson.rb
@@ -34,6 +34,9 @@ class Lesson < ActiveRecord::Base
   belongs_to :lesson_group
   has_and_belongs_to_many :standards, foreign_key: 'stage_id'
 
+  validates :absolute_position, numericality: {greater_than: 0}
+  validates :relative_position, numericality: {greater_than: 0}
+
   self.table_name = 'stages'
 
   serialized_attrs %w(

--- a/dashboard/app/models/script_level.rb
+++ b/dashboard/app/models/script_level.rb
@@ -35,6 +35,8 @@ class ScriptLevel < ActiveRecord::Base
   belongs_to :lesson, inverse_of: :script_levels, foreign_key: 'stage_id'
   has_many :callouts, inverse_of: :script_level
 
+  validates :position, numericality: {greater_than: 0}
+
   validate :anonymous_must_be_assessment
 
   # Make sure we never create a level that is not an assessment, but is anonymous,


### PR DESCRIPTION
Adds validation to lesson and script level models to make sure that position values are always integers greater than 0. This is to help prevent any kind of regression as we look to update position values to prevent 2 sources of truth now that we have lesson groups.