### PR TITLE
Foorm: improve styling

### DIFF
--- a/apps/src/code-studio/pd/foorm/Foorm.jsx
+++ b/apps/src/code-studio/pd/foorm/Foorm.jsx
@@ -38,6 +38,9 @@ export default class Foorm extends React.Component {
     matrix: {
       root: 'sv_q_matrix foorm-adjust-matrix'
     },
+    rating: {
+      root: 'sv_q_rating foorm-adjust-rating'
+    },
     navigation: {
       prev: 'sv_prev_button foorm-button',
       next: 'sv_next_button foorm-button foorm-button-right',

--- a/dashboard/app/assets/stylesheets/application.scss
+++ b/dashboard/app/assets/stylesheets/application.scss
@@ -3246,6 +3246,10 @@ h2.danger {
   }
 }
 
+.foorm-adjust-rating {
+  text-align: center;
+}
+
 .foorm-button {
   font-size: 100% !important;
   padding-top: 10px !important;

--- a/dashboard/app/assets/stylesheets/application.scss
+++ b/dashboard/app/assets/stylesheets/application.scss
@@ -3222,14 +3222,23 @@ h2.danger {
 }
 
 .foorm-adjust-matrix {
+  table-layout: fixed;
+
   th {
-    font-size: 100%;
+    font-size: 13px;
     text-align: center;
+    font-family: 'Gotham 4r', sans-serif;
+    font-weight: normal;
   }
 
-  tr td:not(:first-child) {
-    text-align: center;
-    width: 10%;
+  @media (min-width: 601px) {
+    tr td:first-child {
+      width: 40%;
+    }
+
+    tr td:not(:first-child) {
+      text-align: center;
+    }
   }
 
   td {


### PR DESCRIPTION
This improves the styling of matrix questions on both mobile (below 600px width) and larger (600px and wider).  In the latter case, the question gets 40% of the width while the remaining space is divided evenly between however many options are provided.  The heading font is also reduced in weight and size.  Layout on mobile is improved.

It also improves the styling of rating questions by centering them.

# matrix

## desktop

### before

![Screenshot 2020-05-26 23 00 08](https://user-images.githubusercontent.com/2205926/82983714-7637a580-9fa5-11ea-9e80-4c67d3037b6e.png)

### after

![Screenshot 2020-05-26 23 03 19](https://user-images.githubusercontent.com/2205926/82983719-7768d280-9fa5-11ea-9027-1af81d1f4a30.png)

## mobile

### before

![Screenshot 2020-05-26 23 00 27](https://user-images.githubusercontent.com/2205926/82983717-76d03c00-9fa5-11ea-9bdb-a353d063ee5a.png)

### after

![Screenshot 2020-05-26 23 01 42](https://user-images.githubusercontent.com/2205926/82983718-7768d280-9fa5-11ea-966e-a388ae06de6e.png)

# rating

### before

![Screenshot 2020-05-26 23 22 50](https://user-images.githubusercontent.com/2205926/82985119-4f2ea300-9fa8-11ea-97ca-123781afaa56.png)

### after

![Screenshot 2020-05-26 23 23 32](https://user-images.githubusercontent.com/2205926/82985121-4fc73980-9fa8-11ea-988e-8c24ecb0f9a7.png)


Followup to https://github.com/code-dot-org/code-dot-org/pull/33852.