### PR TITLE
Add Blob support to assertVisualMatch

### DIFF
--- a/apps/src/imageUtils.js
+++ b/apps/src/imageUtils.js
@@ -29,7 +29,7 @@ export function blobToDataURI(blob, onComplete) {
 }
 
 export function dataURIToSourceSize(dataURI) {
-  return imageFromURI(dataURI).then(image => ({
+  return toImage(dataURI).then(image => ({
     x: image.width,
     y: image.height
   }));
@@ -65,15 +65,6 @@ export function dataURIToFramedBlob(dataURI, callback) {
     }
   };
   frame.src = artistShareFrame;
-}
-
-export function imageFromURI(uri) {
-  return new Promise((resolve, reject) => {
-    let image = new Image();
-    image.onload = () => resolve(image);
-    image.onerror = err => reject(err);
-    image.src = uri;
-  });
 }
 
 export function svgToDataURI(svg, imageType = 'image/png', options = {}) {

--- a/apps/src/imageUtils.js
+++ b/apps/src/imageUtils.js
@@ -106,9 +106,46 @@ export async function dataURIToBlob(uri) {
  */
 
 /**
+ * Given an input of a supported type, converts it to an HTMLImageElement.
+ *
+ * @param {Blob|HTMLImageElement|ImageURI} input
+ * @returns {Promise<HTMLImageElement>}
+ */
+export async function toImage(input) {
+  if (input instanceof HTMLImageElement) {
+    return input;
+  }
+
+  let src;
+  let cleanup = () => {};
+
+  if (input instanceof Blob) {
+    src = URL.createObjectURL(input);
+    cleanup = () => URL.revokeObjectURL(input);
+  } else if (typeof input === 'string') {
+    src = input;
+  } else {
+    throw new Error('Unable to convert input to image');
+  }
+
+  return new Promise((resolve, reject) => {
+    let image = new Image();
+    image.onload = function() {
+      cleanup();
+      resolve(image);
+    };
+    image.onerror = function(err) {
+      cleanup();
+      reject(err);
+    };
+    image.src = src;
+  });
+}
+
+/**
  * Given an input of a supported type, converts it to an HTMLCanvasElement.
  *
- * @param {ImageURI|HTMLImageElement|HTMLCanvasElement} input
+ * @param {Blob|HTMLCanvasElement|HTMLImageElement|ImageURI} input
  * @returns {Promise<HTMLCanvasElement>}
  */
 export async function toCanvas(input) {
@@ -116,27 +153,23 @@ export async function toCanvas(input) {
     return input;
   }
 
-  let image;
-  if (input instanceof HTMLImageElement) {
-    image = input;
-  } else if (typeof input === 'string') {
-    image = await imageFromURI(input);
-  } else {
-    throw new Error('Unable to convert input to canvas');
+  try {
+    const image = await toImage(input);
+    const canvas = document.createElement('canvas');
+    canvas.width = image.width;
+    canvas.height = image.height;
+    const context = canvas.getContext('2d');
+    context.drawImage(image, 0, 0);
+    return canvas;
+  } catch (err) {
+    throw new Error('Unable to convert input to canvas: ' + err);
   }
-
-  const canvas = document.createElement('canvas');
-  canvas.width = image.width;
-  canvas.height = image.height;
-  const context = canvas.getContext('2d');
-  context.drawImage(image, 0, 0);
-  return canvas;
 }
 
 /**
  * Given an input of a supported type, converts it to an ImageData object.
  *
- * @param {ImageURI|HTMLImageElement|HTMLCanvasElement|ImageData} input
+ * @param {Blob|HTMLCanvasElement|HTMLImageElement|ImageData|ImageURI} input
  * @returns {Promise<ImageData>}
  */
 export async function toImageData(input) {
@@ -150,6 +183,6 @@ export async function toImageData(input) {
       .getContext('2d')
       .getImageData(0, 0, canvas.width, canvas.height);
   } catch (err) {
-    throw new Error('Unable to convert input to ImageData');
+    throw new Error('Unable to convert input to ImageData: ' + err);
   }
 }

--- a/apps/test/unit/util/imageUtilsTest.js
+++ b/apps/test/unit/util/imageUtilsTest.js
@@ -1,6 +1,4 @@
 import {
-  blobToDataURI,
-  dataURIFromURI,
   dataURIToBlob,
   dataURIToFramedBlob,
   imageFromURI,
@@ -8,7 +6,7 @@ import {
   toImage,
   toImageData
 } from '@cdo/apps/imageUtils';
-import {assert, expect} from 'chai';
+import {assert} from 'chai';
 import expectedPng from './expected.png';
 import assertVisualMatch from '../../util/assertVisualMatch';
 
@@ -18,12 +16,9 @@ const TEST_DATA_URI =
 describe('image utils', () => {
   it('overlays an image inside the Artist frame', done => {
     dataURIToFramedBlob(TEST_DATA_URI, actual => {
-      dataURIFromURI(expectedPng).then(expected => {
-        blobToDataURI(actual, actual => {
-          expect(expected).to.equal(actual);
-          done();
-        });
-      });
+      assertVisualMatch(expectedPng, actual)
+        .then(done)
+        .catch(done);
     });
   });
 

--- a/apps/test/unit/util/imageUtilsTest.js
+++ b/apps/test/unit/util/imageUtilsTest.js
@@ -1,9 +1,11 @@
 import {
   blobToDataURI,
   dataURIFromURI,
+  dataURIToBlob,
   dataURIToFramedBlob,
   imageFromURI,
   toCanvas,
+  toImage,
   toImageData
 } from '@cdo/apps/imageUtils';
 import {assert, expect} from 'chai';
@@ -22,6 +24,35 @@ describe('image utils', () => {
           done();
         });
       });
+    });
+  });
+
+  describe('toImage', () => {
+    it('returns an Image unchanged', async () => {
+      const image = await toImage(expectedPng);
+      assert.instanceOf(image, HTMLImageElement);
+      const result = await toImage(image);
+      assert(image === result);
+    });
+
+    it('converts an image URI to an Image', async () => {
+      assert.typeOf(expectedPng, 'string');
+      const result = await toImage(expectedPng);
+      assert.instanceOf(result, HTMLImageElement);
+      assertVisualMatch(expectedPng, result);
+    });
+
+    it('converts a data URI to an Image', async () => {
+      const result = await toImage(TEST_DATA_URI);
+      assert.instanceOf(result, HTMLImageElement);
+      assertVisualMatch(TEST_DATA_URI, result);
+    });
+
+    it('converts a blob to an Image', async () => {
+      const blob = await dataURIToBlob(TEST_DATA_URI);
+      const result = await toImage(blob);
+      assert.instanceOf(result, HTMLImageElement);
+      assertVisualMatch(TEST_DATA_URI, result);
     });
   });
 
@@ -48,6 +79,13 @@ describe('image utils', () => {
 
     it('converts a data URI to a canvas', async () => {
       const result = await toCanvas(TEST_DATA_URI);
+      assert.instanceOf(result, HTMLCanvasElement);
+      assertVisualMatch(TEST_DATA_URI, result);
+    });
+
+    it('converts a blob to a canvas', async () => {
+      const blob = await dataURIToBlob(TEST_DATA_URI);
+      const result = await toCanvas(blob);
       assert.instanceOf(result, HTMLCanvasElement);
       assertVisualMatch(TEST_DATA_URI, result);
     });
@@ -102,6 +140,13 @@ describe('image utils', () => {
 
     it('converts a data URI string to an ImageData object', async () => {
       const result = await toImageData(TEST_DATA_URI);
+      assert.instanceOf(result, ImageData);
+      assert.equal(180000, result.data.length);
+    });
+
+    it('converts a blob to an ImageData object', async () => {
+      const blob = await dataURIToBlob(TEST_DATA_URI);
+      const result = await toImageData(blob);
       assert.instanceOf(result, ImageData);
       assert.equal(180000, result.data.length);
     });

--- a/apps/test/unit/util/imageUtilsTest.js
+++ b/apps/test/unit/util/imageUtilsTest.js
@@ -1,7 +1,6 @@
 import {
   dataURIToBlob,
   dataURIToFramedBlob,
-  imageFromURI,
   toCanvas,
   toImage,
   toImageData
@@ -59,7 +58,7 @@ describe('image utils', () => {
     });
 
     it('converts an image element to a canvas', async () => {
-      const image = await imageFromURI(expectedPng);
+      const image = await toImage(expectedPng);
       const result = await toCanvas(image);
       assert.instanceOf(result, HTMLCanvasElement);
       assertVisualMatch(image, result);
@@ -120,7 +119,7 @@ describe('image utils', () => {
     });
 
     it('converts an image element to an ImageData object', async () => {
-      const image = await imageFromURI(expectedPng);
+      const image = await toImage(expectedPng);
       const result = await toImageData(image);
       assert.instanceOf(result, ImageData);
       assert.equal(522000, result.data.length);


### PR DESCRIPTION
As a followup to [removing our Phantom-specific code from imageUtilsTest](https://github.com/code-dot-org/code-dot-org/pull/34990), I wanted to use our new `assertVisualMatch` assertion in the artist frame test.  However, the code being tested returns a [Blob](https://developer.mozilla.org/en-US/docs/Web/API/Blob), and `assertVisualMatch` didn't have support for Blob arguments yet.

Here I've added Blob support to the assertion and updated the related test.  I've also extracted a new `toImage` helper, following the pattern of the `toCanvas` and `toImageData` helpers I created recently.  I hope to eventually add `toDataURI` and `toBlob` helpers as well, replacing most of the rest of imageUtils, but this seemed like enough change for now.

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
