### PR TITLE
Surveys: fix to filter out legacy surveys when enumerating links

### DIFF
--- a/dashboard/app/models/pd/enrollment.rb
+++ b/dashboard/app/models/pd/enrollment.rb
@@ -174,6 +174,12 @@ class Pd::Enrollment < ActiveRecord::Base
         (enrollment.workshop.csf_intro? || enrollment.workshop.local_summer?)
     end
 
+    # Filter out legacy (pre-Foorm) local summer and CSF Intro surveys so that we aren't
+    # providing a link to fill them out.
+    _, other_enrollments = other_enrollments.partition do |enrollment|
+      (enrollment.workshop.csf_intro? || enrollment.workshop.local_summer?)
+    end
+
     new_academic_year_enrollments, other_enrollments = other_enrollments.partition do |enrollment|
       [Pd::Workshop::COURSE_CSP, Pd::Workshop::COURSE_CSD].include?(enrollment.workshop.course) && enrollment.workshop.workshop_starting_date > Date.new(2018, 8, 1)
     end


### PR DESCRIPTION
Visitors to https://studio.code.org/my-professional-learning who still hadn't filled out a non-Foorm CSF Intro or local summer survey (say from last summer) were encountering an error.  Now we filter out those surveys, and will no longer suggest them.

Followup to https://github.com/code-dot-org/code-dot-org/pull/34922
