### PR TITLE
Logging in contact rollups dry run

### DIFF
--- a/dashboard/test/models/contact_rollups_pardot_memory_test.rb
+++ b/dashboard/test/models/contact_rollups_pardot_memory_test.rb
@@ -214,7 +214,7 @@ class ContactRollupsPardotMemoryTest < ActiveSupport::TestCase
     submission = {email: 'valid@domain.com', db_Opt_In: 'Yes'}
     submitted_time = Time.now.utc
 
-    ContactRollupsPardotMemory.save_sync_results [submission], [], submitted_time, false
+    ContactRollupsPardotMemory.save_sync_results [submission], [], submitted_time
 
     record = ContactRollupsPardotMemory.find_by(
       email: submission[:email],
@@ -239,7 +239,7 @@ class ContactRollupsPardotMemoryTest < ActiveSupport::TestCase
     ]
     submitted_time = Time.now.utc
 
-    ContactRollupsPardotMemory.save_sync_results submissions, [], submitted_time, false
+    ContactRollupsPardotMemory.save_sync_results submissions, [], submitted_time
 
     submissions.each do |submission|
       record = ContactRollupsPardotMemory.find_by(
@@ -256,7 +256,7 @@ class ContactRollupsPardotMemoryTest < ActiveSupport::TestCase
     errors = [{prospect_index: 0, error_msg: PardotHelpers::ERROR_INVALID_EMAIL}]
     submitted_time = Time.now.utc
 
-    ContactRollupsPardotMemory.save_sync_results [submission], errors, submitted_time, false
+    ContactRollupsPardotMemory.save_sync_results [submission], errors, submitted_time
 
     refute_nil ContactRollupsPardotMemory.find_by(
       email: submission[:email],

--- a/lib/cdo/contact_rollups/v2/pardot.rb
+++ b/lib/cdo/contact_rollups/v2/pardot.rb
@@ -204,11 +204,11 @@ class PardotV2
         # If we did not include this limit, the entire batch would be displayed,
         # which could be overwhelming for debugging purposes.
         unless @dry_run_api_endpoints_hit.include? api_endpoint
-          log "[Sample Batch] Prospects to sync to Pardot: #{prospects.length}"
-          log "[Sample Batch] Query string:\n#{url}"
-          log '[Sample Batch] Prospects to be synced:'
+          self.class.log "Prospects in sample batch to sync to Pardot: #{prospects.length}"
+          self.class.log "Query string for sample batch:\n#{url}"
+          self.class.log 'Prospects to be synced in sample batch:'
           prospects.each do |prospect|
-            log prospect
+            self.class.log prospect
           end
 
           @dry_run_api_endpoints_hit << api_endpoint

--- a/lib/cdo/contact_rollups/v2/pardot_helpers.rb
+++ b/lib/cdo/contact_rollups/v2/pardot_helpers.rb
@@ -32,6 +32,10 @@ module PardotHelpers
     end
   end
 
+  def log(s)
+    CDO.log.info s
+  end
+
   private
 
   # Note: Pardot API key can become invalid and need to be refreshed midstream.
@@ -131,9 +135,5 @@ module PardotHelpers
 
   def get_response_status(doc)
     doc.xpath('/rsp/@stat').text
-  end
-
-  def log(s)
-    CDO.log.info s
   end
 end


### PR DESCRIPTION
Uses class method to log during contact rollups dry run.

Tested by running dry run steps locally:
```
cr = ContactRollupsV2.new
cr.build_and_sync
```