### PR TITLE
Foorm: improve styling more

### DIFF
--- a/dashboard/app/assets/stylesheets/application.scss
+++ b/dashboard/app/assets/stylesheets/application.scss
@@ -3225,10 +3225,10 @@ h2.danger {
   table-layout: fixed;
 
   th {
-    font-size: 13px;
+    font-size: 12px;
     text-align: center;
     font-family: 'Gotham 4r', sans-serif;
-    font-weight: normal;
+    font-weight: normal !important;
   }
 
   @media (min-width: 601px) {


### PR DESCRIPTION
Followup to https://github.com/code-dot-org/code-dot-org/pull/34981 which improves the matrix question header more.

By making its text smaller, we should reduce the frequency of words being split into new lines.

### before

![Screenshot 2020-05-27 13 46 43](https://user-images.githubusercontent.com/2205926/83071388-e1bf5880-a021-11ea-91e9-b63c15cb1942.png)

### after

![Screenshot 2020-05-27 13 51 43](https://user-images.githubusercontent.com/2205926/83071390-e2f08580-a021-11ea-904f-21e0da92c24f.png)

