### PR TITLE
Reduce deliver_poste_messages down to a single thread

### DIFF
--- a/bin/cron/deliver_poste_messages
+++ b/bin/cron/deliver_poste_messages
@@ -49,53 +49,46 @@ def main
     POSTE_DB[:poste_deliveries].where(sent_at: nil).limit(BATCH_SIZE).reverse_order(:id).each {|i| results << i}
   end
 
-  queue_count = queue.length
+  deliverer = Deliverer.new SMTP_OPTIONS
 
-  worker_count = [[queue_count / MIN_MESSAGES_PER_THREAD, MAX_THREAD_COUNT].min, 1].max
+  until queue.empty?
+    next unless delivery = queue.pop(true) rescue nil
 
-  workers = create_threads(worker_count) do
-    deliverer = Deliverer.new SMTP_OPTIONS
+    sent_at = DateTime.now
 
-    until queue.empty?
-      next unless delivery = queue.pop(true) rescue nil
+    begin
+      deliverer.send delivery
+    rescue Net::SMTPSyntaxError, Net::SMTPFatalError => e
+      Honeybadger.notify(
+        e,
+        error_message: "Unable to deliver #{delivery[:id]} to '#{delivery[:contact_email]}' because '#{e.message.to_s.strip}'"
+      )
+      deliverer.reset_connection
+      sent_at = 0
+    rescue AbortEmailError => e
+      Honeybadger.notify(
+        e,
+        error_message: "Abandoning delivery of #{delivery[:id]} because '#{e.message.to_s.strip}'"
+      )
+      sent_at = 0
+    rescue => e
+      Honeybadger.notify(
+        e,
+        error_message: "Unable to deliver #{delivery[:id]} to '#{delivery[:contact_email]}' because '#{e.message.to_s.strip}'"
+      )
+      raise
+    end
 
-      sent_at = DateTime.now
-
-      begin
-        deliverer.send delivery
-      rescue Net::SMTPSyntaxError, Net::SMTPFatalError => e
-        Honeybadger.notify(
-          e,
-          error_message: "Unable to deliver #{delivery[:id]} to '#{delivery[:contact_email]}' because '#{e.message.to_s.strip}'"
-        )
-        deliverer.reset_connection
-        sent_at = 0
-      rescue AbortEmailError => e
-        Honeybadger.notify(
-          e,
-          error_message: "Abandoning delivery of #{delivery[:id]} because '#{e.message.to_s.strip}'"
-        )
-        sent_at = 0
-      rescue => e
-        Honeybadger.notify(
-          e,
-          error_message: "Unable to deliver #{delivery[:id]} to '#{delivery[:contact_email]}' because '#{e.message.to_s.strip}'"
-        )
-        raise
-      end
-
-      if Poste.dashboard_student?(delivery[:hashed_email])
-        # We clear the email here for privacy. Note that (given architecture)
-        # it has to be persisted for a short while to actually send the email.
-        POSTE_DB[:poste_deliveries].where(id: delivery[:id]).
-          update(sent_at: sent_at, contact_email: '')
-      else
-        POSTE_DB[:poste_deliveries].where(id: delivery[:id]).
-          update(sent_at: sent_at)
-      end
+    if Poste.dashboard_student?(delivery[:hashed_email])
+      # We clear the email here for privacy. Note that (given architecture)
+      # it has to be persisted for a short while to actually send the email.
+      POSTE_DB[:poste_deliveries].where(id: delivery[:id]).
+        update(sent_at: sent_at, contact_email: '')
+    else
+      POSTE_DB[:poste_deliveries].where(id: delivery[:id]).
+        update(sent_at: sent_at)
     end
   end
-  workers.each(&:join)
 
   if CDO.newrelic_logging
     # How many emails we sent on _this run_ of the cronjob


### PR DESCRIPTION
Purely for diagnostic reasons; we've been having an issue recently where this process is hanging indefinitely on the production-daemon server, and we want to discount the theory that it's because of this threading. We send on average about four or five emails every time this runs, so the threading is currently overkill and we shouldn't suffer any kind of performance issues from this test.

Recommend reviewing [with whitespace changes disabled](https://github.com/code-dot-org/code-dot-org/pull/35014/files?w=1)

<!--
  Your description goes here: A summary of the change, including any relevant motivation and context.

  If relevant, include a description both of the existing behavior and of the new behavior.
-->

<!--
  Other aspects to consider. uncomment and add detail for any that seem necessary:
-->

<!-- ### Background -->
<!-- ### Privacy -->
<!-- ### Security -->
<!-- ### Caching -->
<!-- ### Deployment strategy -->
<!-- ### Future work -->

## Testing story

Ran locally, saw no errors

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
