### PR TITLE
PL: Turn on legacy survey summaries view for local summer

### DIFF
--- a/apps/src/code-studio/pd/workshop_dashboard/legacy_survey_summaries.jsx
+++ b/apps/src/code-studio/pd/workshop_dashboard/legacy_survey_summaries.jsx
@@ -69,34 +69,40 @@ export default class LegacySurveySummaries extends React.Component {
       );
     }
 
-    // Don't show the legacy survey summaries for CSD & CSP until we transition
-    // them to use new Foorm-based surveys.
-    const showSummerSurveys = false;
+    const {
+      csf_intro_post_workshop_from_pegasus,
+      csf_intro_post_workshop_from_pegasus_for_all_workshops,
+      csd_summer_workshops_from_jotform,
+      csp_summer_workshops_from_jotform
+    } = this.state.data;
 
     return (
       <div>
-        <LegacySurveySummaryTable
-          title="CSF Intro - my workshops"
-          data={this.state.data.csf_intro_post_workshop_from_pegasus}
-        />
-        <LegacySurveySummaryTable
-          title="CSF Intro - all workshops"
-          data={
-            this.state.data
-              .csf_intro_post_workshop_from_pegasus_for_all_workshops
-          }
-        />
-        {showSummerSurveys && (
+        {Object.keys(csf_intro_post_workshop_from_pegasus).length > 0 && (
           <div>
             <LegacySurveySummaryTable
-              title="CSD summer - my workshops"
-              data={this.state.data.csd_summer_workshops_from_jotform}
+              title="CSF Intro - my workshops"
+              data={csf_intro_post_workshop_from_pegasus}
             />
             <LegacySurveySummaryTable
-              title="CSP summer - my workshops"
-              data={this.state.data.csp_summer_workshops_from_jotform}
+              title="CSF Intro - all workshops"
+              data={csf_intro_post_workshop_from_pegasus_for_all_workshops}
             />
           </div>
+        )}
+
+        {Object.keys(csd_summer_workshops_from_jotform).length > 0 && (
+          <LegacySurveySummaryTable
+            title="CSD summer - my workshops"
+            data={csd_summer_workshops_from_jotform}
+          />
+        )}
+
+        {Object.keys(csp_summer_workshops_from_jotform).length > 0 && (
+          <LegacySurveySummaryTable
+            title="CSP summer - my workshops"
+            data={csp_summer_workshops_from_jotform}
+          />
         )}
       </div>
     );


### PR DESCRIPTION
As a followup to what https://github.com/code-dot-org/code-dot-org/pull/34654 did for CSF Intro, this shows legacy facilitator survey summaries for CSD/CSP local summer workshops.

It also adjusts the page so that we only show summaries when there are results for that user.  Additionally, the CSF Intro summary for all workshops is only shown if the user has a result for their own CSF Intro workshops.
