### PR TITLE
Foorm Editor: add configurable variables

### DIFF
--- a/apps/src/code-studio/pd/foorm/FoormEditor.jsx
+++ b/apps/src/code-studio/pd/foorm/FoormEditor.jsx
@@ -56,7 +56,26 @@ class FoormEditor extends React.Component {
 
     this.state = {
       formKey: 0,
-      formPreviewQuestions: null
+      formPreviewQuestions: null,
+      surveyData: {
+        num_facilitators: 2,
+        workshop_course: 'CS Principles',
+        workshop_subject: '5-day Summer',
+        regional_partner_name: 'Regional Partner A',
+        is_virtual: true,
+        facilitators: [
+          {
+            facilitator_id: 1,
+            facilitator_name: 'Alice',
+            facilitator_position: 1
+          },
+          {
+            facilitator_id: 2,
+            facilitator_name: 'Bob',
+            facilitator_position: 2
+          }
+        ]
+      }
     };
   }
 
@@ -106,6 +125,15 @@ class FoormEditor extends React.Component {
           </div>
         ) : (
           <div>
+            <form>
+              <label>
+                Course:{' '}
+                <input
+                  type="text"
+                  value={this.state.surveyData.workshop_course}
+                />
+              </label>
+            </form>
             <Button onClick={this.previewFoorm}>Preview</Button>
             {this.state.formPreviewQuestions && (
               // key allows us to force re-render when preview is clicked

--- a/apps/src/code-studio/pd/foorm/FoormEditor.jsx
+++ b/apps/src/code-studio/pd/foorm/FoormEditor.jsx
@@ -59,7 +59,7 @@ class FoormEditor extends React.Component {
     this.props.populateCodeMirror();
   }
 
-  updateNumFacilitators = e => {
+  updateFacilitators = e => {
     if (this.state.num_facilitators !== e.target.value) {
       let num_facilitators = e.target.value;
       let facilitators = [];
@@ -154,7 +154,7 @@ class FoormEditor extends React.Component {
                 <input
                   type="number"
                   value={this.state.num_facilitators}
-                  onChange={this.updateNumFacilitators}
+                  onChange={this.updateFacilitators}
                 />
               </label>
               <label>

--- a/apps/src/code-studio/pd/foorm/FoormEditor.jsx
+++ b/apps/src/code-studio/pd/foorm/FoormEditor.jsx
@@ -9,30 +9,7 @@ import {Button} from 'react-bootstrap';
 import Foorm from './Foorm';
 import FontAwesome from '../../../templates/FontAwesome';
 
-const sampleSurveyData = {
-  facilitators: [
-    {
-      facilitator_id: 1,
-      facilitator_name: 'Alice',
-      facilitator_position: 1
-    },
-    {
-      facilitator_id: 2,
-      facilitator_name: 'Bob',
-      facilitator_position: 2
-    },
-    {
-      facilitator_id: 3,
-      facilitator_name: 'Chris',
-      facilitator_position: 3
-    }
-  ],
-  workshop_course: 'Sample Course',
-  workshop_subject: 'Sample Subject',
-  regional_partner_name: 'Regional Partner A',
-  is_virtual: false,
-  num_facilitators: 3
-};
+const facilitator_names = ['Alice', 'Bob', 'Carly', 'Dave'];
 
 const styles = {
   errorMessage: {
@@ -57,31 +34,55 @@ class FoormEditor extends React.Component {
     this.state = {
       formKey: 0,
       formPreviewQuestions: null,
-      surveyData: {
-        num_facilitators: 2,
-        workshop_course: 'CS Principles',
-        workshop_subject: '5-day Summer',
-        regional_partner_name: 'Regional Partner A',
-        is_virtual: true,
-        facilitators: [
-          {
-            facilitator_id: 1,
-            facilitator_name: 'Alice',
-            facilitator_position: 1
-          },
-          {
-            facilitator_id: 2,
-            facilitator_name: 'Bob',
-            facilitator_position: 2
-          }
-        ]
-      }
+      num_facilitators: 2,
+      workshop_course: 'CS Principles',
+      workshop_subject: '5-day Summer',
+      regional_partner_name: 'Regional Partner A',
+      is_virtual: true,
+      facilitators: [
+        {
+          facilitator_id: 1,
+          facilitator_name: 'Alice',
+          facilitator_position: 1
+        },
+        {
+          facilitator_id: 2,
+          facilitator_name: 'Bob',
+          facilitator_position: 2
+        }
+      ],
+      day: 1
     };
   }
 
   componentDidMount() {
     this.props.populateCodeMirror();
   }
+
+  updateNumFacilitators = e => {
+    if (this.state.num_facilitators !== e.target.value) {
+      let num_facilitators = e.target.value;
+      let facilitators = [];
+      for (var i = 0; i < num_facilitators; i++) {
+        let facilitator_name = '';
+        if (i < facilitator_names.length) {
+          facilitator_name = facilitator_names[i];
+        } else {
+          facilitator_name =
+            facilitator_names[i % facilitator_names.length] + '_' + i;
+        }
+        facilitators.push({
+          facilitator_id: i,
+          facilitator_name: facilitator_name,
+          facilitator_position: i + 1
+        });
+      }
+      this.setState({
+        num_facilitators: num_facilitators,
+        facilitators: facilitators
+      });
+    }
+  };
 
   previewFoorm = () => {
     // fill in form with any library items
@@ -126,11 +127,61 @@ class FoormEditor extends React.Component {
         ) : (
           <div>
             <form>
+              <h3>Survey Variables</h3>
               <label>
-                Course:{' '}
+                workshop_course <br />
                 <input
                   type="text"
-                  value={this.state.surveyData.workshop_course}
+                  value={this.state.workshop_course}
+                  onChange={e =>
+                    this.setState({workshop_course: e.target.value})
+                  }
+                />
+              </label>
+              <label>
+                workshop_subject <br />
+                <input
+                  type="text"
+                  value={this.state.workshop_subject}
+                  onChange={e =>
+                    this.setState({workshop_course: e.target.value})
+                  }
+                />
+              </label>
+              <label>
+                num_facilitators (will auto-generate facilitator names)
+                <br />
+                <input
+                  type="number"
+                  value={this.state.num_facilitators}
+                  onChange={this.updateNumFacilitators}
+                />
+              </label>
+              <label>
+                regional_partner_name <br />
+                <input
+                  type="text"
+                  value={this.state.regional_partner_name}
+                  onChange={e =>
+                    this.setState({regional_partner_name: e.target.value})
+                  }
+                />
+              </label>
+              <label>
+                is_virtual <br />
+                <input
+                  type="boolean"
+                  value={this.state.is_virtual}
+                  onChange={e => this.setState({is_virtual: e.target.value})}
+                />
+              </label>
+
+              <label>
+                day <br />
+                <input
+                  type="number"
+                  value={this.state.day}
+                  onChange={e => this.setState({day: e.target.value})}
                 />
               </label>
             </form>
@@ -143,7 +194,15 @@ class FoormEditor extends React.Component {
                 formVersion={0}
                 submitApi={'/none'}
                 key={`form-${this.state.formKey}`}
-                surveyData={sampleSurveyData}
+                surveyData={{
+                  facilitators: this.state.facilitators,
+                  num_facilitators: this.state.num_facilitators,
+                  workshop_course: this.state.workshop_course,
+                  workshop_subject: this.state.workshop_subject,
+                  regional_partner_name: this.state.regional_partner_name,
+                  is_virtual: this.state.is_virtual,
+                  day: this.state.day
+                }}
               />
             )}
           </div>


### PR DESCRIPTION
Update Foorm editor with a form to set all configurable variables. The form is below the editor and above the preview button:
<img width="408" alt="image" src="https://user-images.githubusercontent.com/33666587/83200219-b73fcf00-a0f7-11ea-99da-e96897abd4ee.png">

The num_facilitators variable will also set up a list of x facilitators to fill in the survey with. 
<!-- ### Background -->
<!-- ### Privacy -->
<!-- ### Security -->
<!-- ### Caching -->
<!-- ### Deployment strategy -->
<!-- ### Future work -->

## Links

- [jira](https://codedotorg.atlassian.net/browse/PLC-756)

## Testing story
This is an internal tool, not available on production and only available to admins on non-production so it is pretty low-risk to update. Tested manually that updating a variable in the configuration works as expected.

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
