### PR TITLE
Constrain AnimationPicker dialog width

### DIFF
--- a/apps/src/p5lab/AnimationPicker/AnimationPicker.jsx
+++ b/apps/src/p5lab/AnimationPicker/AnimationPicker.jsx
@@ -92,6 +92,7 @@ class AnimationPicker extends React.Component {
         handleClose={this.props.onClose}
         uncloseable={this.props.uploadInProgress}
         fullWidth={true}
+        style={styles.dialog}
       >
         <HiddenUploader
           ref="uploader"

--- a/apps/src/p5lab/AnimationPicker/styles.js
+++ b/apps/src/p5lab/AnimationPicker/styles.js
@@ -2,6 +2,16 @@
 var color = require('@cdo/apps/util/color');
 
 module.exports = {
+  dialog: {
+    /**
+     * Constrain the width of the dialog so that it is always vertically scrollable,
+     * which is necessary for infinite scroll to work.
+     * https://github.com/code-dot-org/code-dot-org/pull/34463
+     */
+    maxWidth: 1000,
+    marginLeft: 0,
+    transform: 'translate(-50%, 0)'
+  },
   title: {
     color: color.purple,
     textAlign: 'center',


### PR DESCRIPTION
Mike H. reported this morning that the "All" category in the Animation Library modal was only showing the "Animals" category ([Slack](https://codedotorg.slack.com/archives/C946FMBGT/p1590680014094600)). This is because the width of the modal is large enough on some screens that there is no vertical scrollbar, which meant infinite scroll was broken (it relies on there being an onScroll event to load more animations). To fix this, I've constrained the width of the Animation Library dialog.

**Before:**
![Screen Shot 2020-05-28 at 3 31 30 PM](https://user-images.githubusercontent.com/9812299/83200583-81e7b100-a0f8-11ea-902e-f6221f643b9c.png)

**After:**
![Screen Shot 2020-05-28 at 3 30 37 PM](https://user-images.githubusercontent.com/9812299/83200594-84e2a180-a0f8-11ea-86a2-1651832f6ee8.png)

## Testing story

Manually tested on:
- OSX - Chrome, Safari, Firefox
- Windows - IE11 (via Saucelabs)

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
