### PR TITLE
Fix cursor styles in LibraryManagerDialog

### DIFF
--- a/apps/src/code-studio/components/libraries/LibraryListItem.jsx
+++ b/apps/src/code-studio/components/libraries/LibraryListItem.jsx
@@ -24,6 +24,7 @@ const styles = {
   libraryTitle: {
     fontFamily: "'Gotham 5r', sans-serif",
     fontSize: 16,
+    cursor: 'pointer',
     color: color.link_color,
     ':hover': {
       color: color.link_color

--- a/apps/src/code-studio/components/libraries/LibraryManagerDialog.jsx
+++ b/apps/src/code-studio/components/libraries/LibraryManagerDialog.jsx
@@ -17,7 +17,8 @@ const DEFAULT_MARGIN = 7;
 
 const styles = {
   dialog: {
-    padding: '0 15px'
+    padding: '0 15px',
+    cursor: 'default'
   },
   linkBox: {
     cursor: 'auto',


### PR DESCRIPTION
Fixes cursor styling in the LibraryManagerDialog and LibraryListItem.

**Before:**
We were using the pointer cursor in the dialog:
![libraries](https://user-images.githubusercontent.com/9812299/83204217-25888f80-a100-11ea-85e6-376e314ccc4a.gif)

**After:**
The dialog has the default cursor, and links to library code are still the pointer cursor.