### PR TITLE
change stage to lesson in new script dsl contents

### DIFF
--- a/apps/src/lib/script-editor/ScriptEditor.jsx
+++ b/apps/src/lib/script-editor/ScriptEditor.jsx
@@ -490,7 +490,7 @@ export default class ScriptEditor extends React.Component {
               style={styles.input}
               defaultValue={
                 this.props.lessonLevelData ||
-                "lesson_group 'lesson group', display_name: 'display name'\nstage 'new lesson'\n"
+                "lesson_group 'lesson group', display_name: 'display name'\nlesson 'new lesson'\n"
               }
               ref={textArea => (this.scriptTextArea = textArea)}
             />


### PR DESCRIPTION
I stumbled across one hard-to-grep-for `\nstage` which controls the initial DSL text of a new script. before:

<img width="444" alt="Screen Shot 2020-05-28 at 4 42 52 PM" src="https://user-images.githubusercontent.com/8001765/83205048-57025a80-a102-11ea-9e54-d974529946bf.png">

after:

<img width="457" alt="Screen Shot 2020-05-28 at 4 43 11 PM" src="https://user-images.githubusercontent.com/8001765/83205057-5d90d200-a102-11ea-85c7-987b82f308bb.png">
