### PR TITLE
Make address optional when creating and updating workshops

### DIFF
--- a/apps/src/code-studio/pd/workshop_dashboard/components/workshop_form.jsx
+++ b/apps/src/code-studio/pd/workshop_dashboard/components/workshop_form.jsx
@@ -688,6 +688,8 @@ export class WorkshopForm extends React.Component {
       return false;
     }
 
+    // If location address is modified, then returned to blank,
+    // this.state.location_address is a blank string instead of null.
     return (
       this.state.sessionsModified ||
       this.state.location_name !== workshop.location_name ||

--- a/apps/src/code-studio/pd/workshop_dashboard/components/workshop_form.jsx
+++ b/apps/src/code-studio/pd/workshop_dashboard/components/workshop_form.jsx
@@ -683,15 +683,18 @@ export class WorkshopForm extends React.Component {
 
   shouldConfirmSave() {
     const workshop = this.props.workshop;
+
     if (!workshop || workshop.enrolled_teacher_count === 0) {
       return false;
     }
+
     return (
-      (this.state.sessionsModified ||
-        this.state.location_name !== workshop.location_name ||
-        this.state.location_address !== workshop.location_address ||
-        this.state.notes !== workshop.notes) &&
-      this.state.location_address !== ''
+      this.state.sessionsModified ||
+      this.state.location_name !== workshop.location_name ||
+      (this.state.location_address === ''
+        ? null
+        : this.state.location_address) !== workshop.location_address ||
+      this.state.notes !== workshop.notes
     );
   }
 
@@ -997,9 +1000,6 @@ export class WorkshopForm extends React.Component {
                       <p>When a workshop is virtual, our system:</p>
                       <ul>
                         <li>
-                          Does not require you to enter a location address
-                        </li>
-                        <li>
                           Will not send email notifications, such as enrollment
                           receipts and workshop reminders
                         </li>
@@ -1069,7 +1069,7 @@ export class WorkshopForm extends React.Component {
             </Col>
             <Col sm={6}>
               <FormGroup>
-                <ControlLabel>Location Address</ControlLabel>
+                <ControlLabel>Location Address (optional)</ControlLabel>
                 <FormControl
                   type="text"
                   key={this.state.useAutocomplete} // Change key to force re-draw

--- a/apps/src/code-studio/pd/workshop_dashboard/components/workshop_form.jsx
+++ b/apps/src/code-studio/pd/workshop_dashboard/components/workshop_form.jsx
@@ -687,10 +687,11 @@ export class WorkshopForm extends React.Component {
       return false;
     }
     return (
-      this.state.sessionsModified ||
-      this.state.location_name !== workshop.location_name ||
-      this.state.location_address !== workshop.location_address ||
-      this.state.notes !== workshop.notes
+      (this.state.sessionsModified ||
+        this.state.location_name !== workshop.location_name ||
+        this.state.location_address !== workshop.location_address ||
+        this.state.notes !== workshop.notes) &&
+      this.state.location_address !== ''
     );
   }
 
@@ -937,11 +938,6 @@ export class WorkshopForm extends React.Component {
         validation.style.location_name = 'error';
         validation.help.location_name = 'Required.';
       }
-      if (!this.state.location_address) {
-        validation.isValid = false;
-        validation.style.location_address = 'error';
-        validation.help.location_address = 'Required.';
-      }
       if (!this.state.capacity) {
         validation.isValid = false;
         validation.style.capacity = 'error';
@@ -1072,7 +1068,7 @@ export class WorkshopForm extends React.Component {
               </FormGroup>
             </Col>
             <Col sm={6}>
-              <FormGroup validationState={validation.style.location_address}>
+              <FormGroup>
                 <ControlLabel>Location Address</ControlLabel>
                 <FormControl
                   type="text"
@@ -1089,7 +1085,6 @@ export class WorkshopForm extends React.Component {
                   style={this.getInputStyle()}
                   disabled={this.props.readOnly}
                 />
-                <HelpBlock>{validation.help.location_address}</HelpBlock>
               </FormGroup>
             </Col>
           </Row>

--- a/dashboard/app/views/pd/workshop_enrollment/_workshop_details.html.haml
+++ b/dashboard/app/views/pd/workshop_enrollment/_workshop_details.html.haml
@@ -16,8 +16,9 @@
       Location:
   %div.span2
     = @workshop.location_name
-    %br
-    = @workshop.location_address
+    - if @workshop.location_address.present?
+      %br
+      = @workshop.location_address
 
 %div.row
   %div.span2{style: 'text-align: right'}

--- a/dashboard/app/views/pd/workshop_mailer/_workshop_logistics.html.haml
+++ b/dashboard/app/views/pd/workshop_mailer/_workshop_logistics.html.haml
@@ -13,8 +13,9 @@
       Location:
     %td
       = @workshop.location_name
-      %br
-      = @workshop.location_address
+      - if @workshop.location_address.present?
+        %br
+        = @workshop.location_address
   %tr
     %td.heading
       Organizer:

--- a/dashboard/test/models/pd/workshop_test.rb
+++ b/dashboard/test/models/pd/workshop_test.rb
@@ -1063,13 +1063,13 @@ class Pd::WorkshopTest < ActiveSupport::TestCase
     workshop = build :workshop, num_sessions: 5, sessions_from: Date.new(2017, 3, 30),
       processed_location: nil
 
-    assert_equal 'March 30 - April 3, 2017, Location TBA', workshop.date_and_location_name
+    assert_equal 'March 30 - April 3, 2017', workshop.date_and_location_name
   end
 
   test 'date_and_location_name with no location nor sessions' do
     workshop = create :workshop, processed_location: nil, num_sessions: 0
 
-    assert_equal 'Dates TBA, Location TBA', workshop.date_and_location_name
+    assert_equal 'Dates TBA', workshop.date_and_location_name
   end
 
   test 'date_and_location_name for teachercon' do
@@ -1113,7 +1113,7 @@ class Pd::WorkshopTest < ActiveSupport::TestCase
 
   test 'friendly_location with no location returns tba' do
     workshop = build :workshop, location_address: '', processed_location: nil
-    assert_equal 'Location TBA', workshop.friendly_location
+    assert_equal '', workshop.friendly_location
   end
 
   test 'friendly_location with virtual location' do


### PR DESCRIPTION
Make workshop address optional when creating and updating workshops.

Note that this may result in some funky formatting in places where we expect there to be a workshop address (eg, places where we expect `date_and_location_name` to include a location name). @islemaster suggested we can clean these up in follow-up work.

## Testing story

Updated existing tests for affected methods.

## Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
