### PR TITLE
CRv2: Disable adding new prospects to Pardot

### DIFF
--- a/bin/cron/build_contact_rollups_v2
+++ b/bin/cron/build_contact_rollups_v2
@@ -6,7 +6,8 @@ require 'cdo/only_one'
 
 def main
   contact_rollups = ContactRollupsV2.new
-  contact_rollups.build_and_sync
+  contact_rollups.collect_and_process_contacts
+  contact_rollups.sync_updated_contacts_with_pardot
   contact_rollups.report_results
 end
 

--- a/dashboard/lib/contact_rollups_v2.rb
+++ b/dashboard/lib/contact_rollups_v2.rb
@@ -1,7 +1,7 @@
 require 'cdo/log_collector'
 
 class ContactRollupsV2
-  def initialize(is_dry_run: true)
+  def initialize(is_dry_run: false)
     @is_dry_run = is_dry_run
     @log_collector = LogCollector.new('Contact Rollups')
   end

--- a/dashboard/test/lib/contact_rollups_v2_test.rb
+++ b/dashboard/test/lib/contact_rollups_v2_test.rb
@@ -28,7 +28,7 @@ class ContactRollupsV2Test < ActiveSupport::TestCase
     PardotV2.stubs(:submit_batch_request).once.returns([])
 
     # Execute the pipeline
-    ContactRollupsV2.new(is_dry_run: false).build_and_sync
+    ContactRollupsV2.new.build_and_sync
 
     # Verify email preference
     pardot_memory_record = ContactRollupsPardotMemory.find_by(email: email_preference.email, pardot_id: 1)
@@ -67,7 +67,7 @@ class ContactRollupsV2Test < ActiveSupport::TestCase
     PardotV2.stubs(:submit_batch_request).once.returns([])
 
     # Execute the pipeline
-    ContactRollupsV2.new(is_dry_run: false).build_and_sync
+    ContactRollupsV2.new.build_and_sync
 
     # Verify results
     pardot_memory_record = ContactRollupsPardotMemory.find_by(email: email, pardot_id: pardot_id)


### PR DESCRIPTION
Disable adding new prospects to Pardot since we went over the Pardot [mailable prospects limit](https://pi.pardot.com/account/usage) on 5/29/2020.

We're discussing on solutions with Marketing team (Slack [thread 1](https://codedotorg.slack.com/archives/C06E60KL4/p1590598668076600) and [thread 2](https://codedotorg.slack.com/archives/G014FSM8VU3/p1590776220010400)) and will discuss with Salesforce account manager next week. Meanwhile, we will pause creating new prospects in Pardot but still update the existing ones.

## Links
Previous PR to enable the full pipeline: https://github.com/code-dot-org/code-dot-org/pull/35013

## Testing story
Unit tests

# Reviewer Checklist:
- [ ] Tests provide adequate coverage
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
