### PR TITLE
Recruitment: don't show banner on non-en teacher homepage

### DIFF
--- a/apps/src/templates/studioHomepages/TeacherHomepage.jsx
+++ b/apps/src/templates/studioHomepages/TeacherHomepage.jsx
@@ -178,7 +178,7 @@ export default class TeacherHomepage extends Component {
         <HeaderBanner headingText={i18n.homepageHeading()} short={true} />
         <ProtectedStatefulDiv ref="flashes" />
         <ProtectedStatefulDiv ref="teacherReminders" />
-        {specialAnnouncement && (
+        {isEnglish && specialAnnouncement && (
           <SpecialAnnouncementActionBlock announcement={specialAnnouncement} />
         )}
         {announcement && showAnnouncement && (


### PR DESCRIPTION
Followup to https://github.com/code-dot-org/code-dot-org/pull/34762.  Don't show the recruitment banner on non-en teacher homepage.
