### PR TITLE
Revert "Revert "Add foreign key for script to section""

### DIFF
--- a/dashboard/app/models/sections/clever_section.rb
+++ b/dashboard/app/models/sections/clever_section.rb
@@ -24,6 +24,7 @@
 # Indexes
 #
 #  fk_rails_20b1e5de46        (course_id)
+#  fk_rails_5c2401d1cb        (script_id)
 #  index_sections_on_code     (code) UNIQUE
 #  index_sections_on_user_id  (user_id)
 #

--- a/dashboard/app/models/sections/email_section.rb
+++ b/dashboard/app/models/sections/email_section.rb
@@ -24,6 +24,7 @@
 # Indexes
 #
 #  fk_rails_20b1e5de46        (course_id)
+#  fk_rails_5c2401d1cb        (script_id)
 #  index_sections_on_code     (code) UNIQUE
 #  index_sections_on_user_id  (user_id)
 #

--- a/dashboard/app/models/sections/google_classroom_section.rb
+++ b/dashboard/app/models/sections/google_classroom_section.rb
@@ -24,6 +24,7 @@
 # Indexes
 #
 #  fk_rails_20b1e5de46        (course_id)
+#  fk_rails_5c2401d1cb        (script_id)
 #  index_sections_on_code     (code) UNIQUE
 #  index_sections_on_user_id  (user_id)
 #

--- a/dashboard/app/models/sections/omni_auth_section.rb
+++ b/dashboard/app/models/sections/omni_auth_section.rb
@@ -24,6 +24,7 @@
 # Indexes
 #
 #  fk_rails_20b1e5de46        (course_id)
+#  fk_rails_5c2401d1cb        (script_id)
 #  index_sections_on_code     (code) UNIQUE
 #  index_sections_on_user_id  (user_id)
 #

--- a/dashboard/app/models/sections/picture_section.rb
+++ b/dashboard/app/models/sections/picture_section.rb
@@ -24,6 +24,7 @@
 # Indexes
 #
 #  fk_rails_20b1e5de46        (course_id)
+#  fk_rails_5c2401d1cb        (script_id)
 #  index_sections_on_code     (code) UNIQUE
 #  index_sections_on_user_id  (user_id)
 #

--- a/dashboard/app/models/sections/section.rb
+++ b/dashboard/app/models/sections/section.rb
@@ -24,6 +24,7 @@
 # Indexes
 #
 #  fk_rails_20b1e5de46        (course_id)
+#  fk_rails_5c2401d1cb        (script_id)
 #  index_sections_on_code     (code) UNIQUE
 #  index_sections_on_user_id  (user_id)
 #

--- a/dashboard/app/models/sections/word_section.rb
+++ b/dashboard/app/models/sections/word_section.rb
@@ -24,6 +24,7 @@
 # Indexes
 #
 #  fk_rails_20b1e5de46        (course_id)
+#  fk_rails_5c2401d1cb        (script_id)
 #  index_sections_on_code     (code) UNIQUE
 #  index_sections_on_user_id  (user_id)
 #

--- a/dashboard/db/migrate/20200529004150_add_foreign_key_for_script_to_section.rb
+++ b/dashboard/db/migrate/20200529004150_add_foreign_key_for_script_to_section.rb
@@ -1,0 +1,5 @@
+class AddForeignKeyForScriptToSection < ActiveRecord::Migration[5.0]
+  def change
+    add_foreign_key :sections, :scripts
+  end
+end

--- a/dashboard/db/schema.rb
+++ b/dashboard/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20200518181001) do
+ActiveRecord::Schema.define(version: 20200529004150) do
 
   create_table "activities", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci" do |t|
     t.integer  "user_id"
@@ -1382,6 +1382,7 @@ ActiveRecord::Schema.define(version: 20200518181001) do
     t.boolean  "autoplay_enabled",  default: false,   null: false
     t.index ["code"], name: "index_sections_on_code", unique: true, using: :btree
     t.index ["course_id"], name: "fk_rails_20b1e5de46", using: :btree
+    t.index ["script_id"], name: "fk_rails_5c2401d1cb", using: :btree
     t.index ["user_id"], name: "index_sections_on_user_id", using: :btree
   end
 
@@ -1777,6 +1778,7 @@ ActiveRecord::Schema.define(version: 20200518181001) do
   add_foreign_key "school_stats_by_years", "schools"
   add_foreign_key "schools", "school_districts"
   add_foreign_key "sections", "courses"
+  add_foreign_key "sections", "scripts"
   add_foreign_key "state_cs_offerings", "schools", column: "state_school_id", primary_key: "state_school_id"
   add_foreign_key "survey_results", "users"
   add_foreign_key "user_geos", "users"


### PR DESCRIPTION
Reverts code-dot-org/code-dot-org#35045

Original Error:
Build failed because RAILS_ENV=test RACK_ENV=test bundle exec rake db:setup_or_migrate failed, which was because of foreign key constraint fails on test

```
== 20200529004150 AddForeignKeyForScriptToSection: migrating ==================
-- add_foreign_key(:sections, :scripts)
rake aborted!
StandardError: An error has occurred, all later migrations canceled:
Mysql2::Error: Cannot add or update a child row: a foreign key constraint fails (`dashboard_test`.`#sql-7e03_29b37`, CONSTRAINT `fk_rails_5c2401d1cb` FOREIGN KEY (`script_id`) REFERENCES `scripts` (`id`)): ALTER TABLE `sections` ADD CONSTRAINT `fk_rails_5c2401d1cb`
FOREIGN KEY (`script_id`)
  REFERENCES `scripts` (`id`)
```

Fix: 

After working with @davidsbailey and @uponthesun we identified the Sections in Test and Production that were assigned to scripts that no longer existed. We worked together to set those sections script_id to nil so there should no longer be sections that violate the foreign key constraint. 