### PR TITLE
Remove flag hiding virtual workshop options

### DIFF
--- a/apps/src/code-studio/pd/workshop_dashboard/components/workshop_form.jsx
+++ b/apps/src/code-studio/pd/workshop_dashboard/components/workshop_form.jsx
@@ -43,7 +43,6 @@ import {
   Subjects
 } from '@cdo/apps/generated/pd/sharedWorkshopConstants';
 import HelpTip from '@cdo/apps/lib/ui/HelpTip';
-import experiments from '@cdo/apps/util/experiments';
 
 const styles = {
   readOnlyInput: {
@@ -992,66 +991,64 @@ export class WorkshopForm extends React.Component {
             readOnly={this.props.readOnly}
           />
           <br />
-          {experiments.isEnabled(experiments.VIRTUAL_WORKSHOPS) && (
-            <Row>
-              <Col sm={5}>
-                <FormGroup validationState={validation.style.virtual}>
-                  <ControlLabel>
-                    Is this a virtual workshop?
-                    <HelpTip>
-                      <p>When a workshop is virtual, our system:</p>
-                      <ul>
-                        <li>
-                          Will not send email notifications, such as enrollment
-                          receipts and workshop reminders
-                        </li>
-                        <li>
-                          Will send a post-workshop survey designed for virtual
-                          workshops
-                        </li>
-                      </ul>
-                    </HelpTip>
-                  </ControlLabel>
-                  <SelectIsVirtual
-                    value={this.state.virtual || false}
-                    onChange={this.handleVirtualChange}
-                    readOnly={this.props.readOnly}
-                  />
-                  <HelpBlock>{validation.help.virtual}</HelpBlock>
-                </FormGroup>
-              </Col>
-              <Col sm={5}>
-                <FormGroup validationState={validation.style.suppress_email}>
-                  <ControlLabel>
-                    Enable email notifications?
-                    <HelpTip>
-                      <p>
-                        Code.org can send email notifications about this
-                        workshop to your attendees on your behalf. Notifications
-                        may include:
-                      </p>
-                      <ul>
-                        <li>Enrollment receipts</li>
-                        <li>10-day and 3-day workshop reminders</li>
-                        <li>Updates when workshop details change</li>
-                      </ul>
-                      <p>
-                        Code.org will always email a post-workshop survey to
-                        participants, even if you disable workshop notifications
-                        here.
-                      </p>
-                    </HelpTip>
-                  </ControlLabel>
-                  <SelectSuppressEmail
-                    onChange={this.handleSuppressEmailChange}
-                    value={this.state.suppress_email || false}
-                    readOnly={this.props.readOnly || this.state.virtual}
-                  />
-                  <HelpBlock>{validation.help.suppress_email}</HelpBlock>
-                </FormGroup>
-              </Col>
-            </Row>
-          )}
+          <Row>
+            <Col sm={5}>
+              <FormGroup validationState={validation.style.virtual}>
+                <ControlLabel>
+                  Is this a virtual workshop?
+                  <HelpTip>
+                    <p>When a workshop is virtual, our system:</p>
+                    <ul>
+                      <li>
+                        Will not send most email notifications to enrollees,
+                        such as enrollment receipts and workshop reminders
+                      </li>
+                      <li>
+                        Will send a post-workshop survey designed for virtual
+                        workshops
+                      </li>
+                    </ul>
+                  </HelpTip>
+                </ControlLabel>
+                <SelectIsVirtual
+                  value={this.state.virtual || false}
+                  onChange={this.handleVirtualChange}
+                  readOnly={this.props.readOnly}
+                />
+                <HelpBlock>{validation.help.virtual}</HelpBlock>
+              </FormGroup>
+            </Col>
+            <Col sm={5}>
+              <FormGroup validationState={validation.style.suppress_email}>
+                <ControlLabel>
+                  Enable email notifications?
+                  <HelpTip>
+                    <p>
+                      Code.org can send email notifications about this workshop
+                      to your attendees on your behalf. Notifications may
+                      include:
+                    </p>
+                    <ul>
+                      <li>Enrollment receipts</li>
+                      <li>10-day and 3-day workshop reminders</li>
+                      <li>Updates when workshop details change</li>
+                    </ul>
+                    <p>
+                      Code.org will always email a post-workshop survey to
+                      participants, even if you disable workshop notifications
+                      here.
+                    </p>
+                  </HelpTip>
+                </ControlLabel>
+                <SelectSuppressEmail
+                  onChange={this.handleSuppressEmailChange}
+                  value={this.state.suppress_email || false}
+                  readOnly={this.props.readOnly || this.state.virtual}
+                />
+                <HelpBlock>{validation.help.suppress_email}</HelpBlock>
+              </FormGroup>
+            </Col>
+          </Row>
           <Row>
             <Col sm={4}>
               <FormGroup validationState={validation.style.location_name}>

--- a/apps/src/util/experiments.js
+++ b/apps/src/util/experiments.js
@@ -28,7 +28,6 @@ experiments.TEACHER_DASHBOARD_SECTION_BUTTONS =
 experiments.TEACHER_DASHBOARD_SECTION_BUTTONS_ALTERNATE_TEXT =
   'teacher-dashboard-section-buttons-alternate-text';
 experiments.MINI_TOOLBOX = 'miniToolbox';
-experiments.VIRTUAL_WORKSHOPS = 'virtual-workshops';
 
 /**
  * Get our query string. Provided as a method so that tests can mock this.


### PR DESCRIPTION
Makes virtual workshop and email suppression options visible to workshop admins.

Also, learned this from Elijah this week -- try looking at changes with [whitespace changes ignored](https://github.com/code-dot-org/code-dot-org/pull/35058/files?w=1)!
