### PR TITLE
uninstall rb-readline gem from development environment

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -58,7 +58,6 @@ gem 'rack-mini-profiler'
 group :development do
   gem 'annotate'
   gem 'pry'
-  gem 'rb-readline'
   gem 'ruby-progressbar', require: false
   gem 'web-console'
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -690,7 +690,6 @@ GEM
     rb-fsevent (0.10.2)
     rb-inotify (0.9.10)
       ffi (>= 0.5.0, < 2)
-    rb-readline (0.5.5)
     rdoc (4.2.2)
       json (~> 1.4)
     recaptcha (4.6.3)
@@ -1000,7 +999,6 @@ DEPENDENCIES
   rails (~> 5.0.7.2)
   rails-controller-testing
   rambling-trie
-  rb-readline
   recaptcha
   redcarpet (~> 3.3.4)
   redis (~> 3.3.3)


### PR DESCRIPTION
today, the arrow keys in bin/dashboard-console do not work reliably for moving between previous commands:
![dashboard-console-garbled](https://user-images.githubusercontent.com/8001765/83313557-80d38400-a1cb-11ea-985d-5fd0dc17b940.gif)

by patching in this PR and running `gem uninstall rb-readline`, the arrows work again:
![dashboard-console-fixed](https://user-images.githubusercontent.com/8001765/83313683-21c23f00-a1cc-11ea-8449-f42e3d9acbd9.gif)

I've verified the problem and the fix on both mac and linux environments.

This was originally added to make `pry` work in local development: https://github.com/code-dot-org/code-dot-org/pull/27247 However, since this problem affects [many developers](https://codedotorg.slack.com/archives/C0T10HG6N/p1590794455020000), I'd rather make this fix for the greater number of people and let the smaller group who use pry have to run `gem install rb-readline` manually (if it is even still needed) in order to use that particular debugging tool.

If this change actually does break `pry` then I'm also open to other proposals which fix the arrow keys without breaking pry.