### PR TITLE
update newrelic_rpm gem from 4.8.0 to 6.10.0

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -188,7 +188,7 @@ gem 'highline', '~> 1.6.21'
 
 gem 'honeybadger' # error monitoring
 
-gem 'newrelic_rpm', '~> 4.8.0', group: [:staging, :development, :production] # perf/error/etc monitoring
+gem 'newrelic_rpm', group: [:staging, :development, :production] # perf/error/etc monitoring
 
 gem 'redcarpet', '~> 3.3.4'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -559,7 +559,7 @@ GEM
     net-ssh (5.2.0)
     net_http_ssl_fix (0.0.10)
     netrc (0.11.0)
-    newrelic_rpm (4.8.0.341)
+    newrelic_rpm (6.10.0.364)
     nio4r (2.3.1)
     nokogiri (1.10.3)
       mini_portile2 (~> 2.4.0)
@@ -969,7 +969,7 @@ DEPENDENCIES
   net-http-persistent
   net-scp
   net-ssh
-  newrelic_rpm (~> 4.8.0)
+  newrelic_rpm
   nokogiri (>= 1.10.0)
   octokit
   oj
@@ -1056,4 +1056,4 @@ RUBY VERSION
    ruby 2.5.0p0
 
 BUNDLED WITH
-   1.17.1
+   1.17.3


### PR DESCRIPTION
Updates `newrelic_rpm` to the latest version, fixes a shutdown race-condition bug that was causing short-lived scheduled-job processes to hang in production.