### PR TITLE
Update Curriculum Builder PL redirection rules to point to the 2020 version

### DIFF
--- a/aws/s3/cdo-curriculum/redirection_rules.rb
+++ b/aws/s3/cdo-curriculum/redirection_rules.rb
@@ -65,7 +65,7 @@ routing_rules = [
     },
     redirect: {
       host_name: HOST_NAME,
-      replace_key_prefix_with: "plcsf-19/"
+      replace_key_prefix_with: "plcsf-20/"
     }
   },
   {
@@ -74,7 +74,7 @@ routing_rules = [
     },
     redirect: {
       host_name: HOST_NAME,
-      replace_key_prefix_with: "plcsd-19/"
+      replace_key_prefix_with: "plcsd-20/"
     }
   },
   {
@@ -83,7 +83,7 @@ routing_rules = [
     },
     redirect: {
       host_name: HOST_NAME,
-      replace_key_prefix_with: "plcsp-19/"
+      replace_key_prefix_with: "plcsp-20/"
     }
   },
   {


### PR DESCRIPTION
Updates the script which can be run to update the curriculum.code.org/plcs* links to point to curriculum.code.org/plcs*-20.
