### PR TITLE
Only allow the process that created the pidfile to remove it

### DIFF
--- a/lib/cdo/only_one.rb
+++ b/lib/cdo/only_one.rb
@@ -15,7 +15,8 @@ def only_one_running?(script)
     end
     return false if exists
   end
-  File.open(pidfile, "w") {|f| f.puts $$}
-  at_exit {File.unlink(pidfile)}
+  pid = $$
+  File.open(pidfile, "w") {|f| f.puts pid}
+  at_exit {File.unlink(pidfile) if $$ == pid}
   true
 end


### PR DESCRIPTION
Because apparently worker processes will call their parent's `at_exit` when they themselves exit. See https://github.com/grosser/parallel/issues/230

## Testing story

I found this error because the [new i18n sync down process](https://github.com/code-dot-org/code-dot-org/pull/34846) uses the parallel gem, and it broke when run with the `bin/i18n/sync-all.rb` script which uses `only_one`. I [also updated that script](https://github.com/code-dot-org/code-dot-org/pull/35068) to independently work fine without this change, but before I did I verified that this change is sufficient for that to not break.

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
