### PR TITLE
Revert back to old sync down

### DIFF
--- a/bin/i18n/sync-down.rb
+++ b/bin/i18n/sync-down.rb
@@ -5,39 +5,39 @@
 # https://crowdin.com/project/codeorg
 
 require_relative 'i18n_script_utils'
-
-require 'cdo/crowdin/utils'
-require 'cdo/crowdin/project'
+require 'open3'
 
 def sync_down
   I18nScriptUtils.with_synchronous_stdout do
     puts "Beginning sync down"
 
-    logger = Logger.new(STDOUT)
-    logger.level = Logger::INFO
-
     CROWDIN_PROJECTS.each do |name, options|
       puts "Downloading translations from #{name} project"
-      api_key = YAML.load_file(options[:identity_file])["api_key"]
-      project_id = YAML.load_file(options[:config_file])["project_identifier"]
-      project = Crowdin::Project.new(project_id, api_key)
-      options = {
-        etags_json: File.join(File.dirname(__FILE__), "crowdin", "#{project_id}_etags.json"),
-        locales_dir: File.join(I18N_SOURCE_DIR, '..'),
-        logger: logger
-      }
-      utils = Crowdin::Utils.new(project, options)
+      command = "crowdin --config #{options[:config_file]} --identity #{options[:identity_file]} download translations"
 
-      puts "Fetching list of changed files"
-      prefetch = Time.now
-      utils.fetch_changes
-      postfetch = Time.now
-      puts "Changes fetched in #{Time.at(postfetch - prefetch).utc.strftime('%H:%M:%S')}"
-      puts "Downloading changed files"
-      predownload = Time.now
-      utils.download_changed_files
-      postdownload = Time.now
-      puts "Files downloaded in #{Time.at(postdownload - predownload).utc.strftime('%H:%M:%S')}"
+      # Filter the output because the crowdin translation download is _super_
+      # verbose; it includes not only a progress spinner, but also information
+      # about each individual file downloaded in each individual language.
+      #
+      # We really only care about general progress monitoring, so we remove or
+      # ignore any things we identify as "noise" in the output.
+      Open3.popen2(command) do |_stdin, stdout, status_thread|
+        while line = stdout.gets
+          # strip out the progress spinner, which is implemented as the sequence
+          # \-/| followed by a backspace character
+          line.gsub!(/[\|\/\-\\][\b]/, '')
+
+          # skip lines detailing individual file extraction
+          next if line.start_with?("Extracting: ")
+
+          # skip warning that happens if the sync is run multiple times in succession
+          next if line == "Warning: Export was skipped. Please note that this method can be invoked only once per 30 minutes.\n"
+
+          puts line
+        end
+
+        raise "Sync down failed"  unless status_thread.value.success?
+      end
     end
 
     puts "Sync down complete"


### PR DESCRIPTION
The new sync down assumes that all translations are being downloaded directly into the locale directory, but our old approach relied on crowdin's configuration files to do some advanced filesystem placement:

https://github.com/code-dot-org/code-dot-org/blob/6baaa071c171b4819aae27d139541f3a128f89d5/bin/i18n/codeorg_crowdin.yml#L26
https://github.com/code-dot-org/code-dot-org/blob/6baaa071c171b4819aae27d139541f3a128f89d5/bin/i18n/hourofcode_crowdin.yml#L17-L21
https://github.com/code-dot-org/code-dot-org/blob/6baaa071c171b4819aae27d139541f3a128f89d5/bin/i18n/codeorg_markdown_crowdin.yml#L10

Switching back to the old method to unblock the sync while we figure out how we want to handle this moving forward.

<!--
  Your description goes here: A summary of the change, including any relevant motivation and context.

  If relevant, include a description both of the existing behavior and of the new behavior.
-->

<!--
  Other aspects to consider. uncomment and add detail for any that seem necessary:
-->

<!-- ### Background -->
<!-- ### Privacy -->
<!-- ### Security -->
<!-- ### Caching -->
<!-- ### Deployment strategy -->
<!-- ### Future work -->

## Links

<!--
  Any relevant links to external resources; ie, specification documents, jira
  items, related PRs, honeybadger errors, etc
-->

- [spec]()
- [jira]()

## Testing story

<!--
  Does your change include appropriate tests?

  If so, please describe how the tests included in this PR are sufficient

  If not, please explain why this change does not need to be tested.
-->

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
