### PR TITLE
Make UI tests wait after a UI resize

### DIFF
--- a/dashboard/test/ui/features/step_definitions/applab.rb
+++ b/dashboard/test/ui/features/step_definitions/applab.rb
@@ -206,8 +206,8 @@ def drag_grippy(element_js, delta_x, delta_y)
     element[0].dispatchEvent(drag);
     element[0].dispatchEvent(mouseup);
   }
-
-  @browser.execute_script(script)
+  # Run the script and then wait a little bit of time to give the UI a chance to reflow.
+  @browser.execute_script(script, 0.5)
 end
 
 And /^I drag the instructions grippy by ([-|\d]+) pixels$/ do |delta|


### PR DESCRIPTION
Applitools was reporting UI differences after the AppLab UI had been resized, but when I reviewed the video recording, there seemed the be no difference. I think that maybe the screenshot which Applitools takes is capturing the HTML mid-reflow, which explains the weird gas I saw. This change adds a small .5 second wait after the UI has been adjusted. Hopefully when the screenshot is taken, the browser will have had enough time to redraw the page.

## Screenshot
This is a screenshot of the "weird gap" I mentioned above. The unexpected gap is at the bottom of the page (Ignore the other differences).
![image](https://user-images.githubusercontent.com/1372238/83463114-93b0b780-a45c-11ea-8342-ee8af35c7f0d.png)

## Testing story
* Going to watch the automated to see if the tests are showing the expected result.

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
