### PR TITLE
CSPWFRT: Enable certificate

### DIFF
--- a/dashboard/app/models/pd/enrollment.rb
+++ b/dashboard/app/models/pd/enrollment.rb
@@ -424,7 +424,13 @@ class Pd::Enrollment < ActiveRecord::Base
   private_class_method def self.filter_for_academic_year_survey_completion(academic_year_enrollments, select_completed)
     completed_surveys, uncompleted_surveys = academic_year_enrollments.partition do |enrollment|
       workshop = enrollment.workshop
-      Pd::WorkshopDailySurvey.exists?(pd_workshop: workshop, user: enrollment.user, form_id: Pd::WorkshopDailySurvey.get_form_id_for_subject_and_day(workshop.subject, POST_WORKSHOP_FORM_KEY))
+      begin
+        Pd::WorkshopDailySurvey.exists?(pd_workshop: workshop, user: enrollment.user, form_id: Pd::WorkshopDailySurvey.get_form_id_for_subject_and_day(workshop.subject, POST_WORKSHOP_FORM_KEY))
+      # if we can't find the expected form id we will get a key error. Consider this to be a completed survey as there
+      # is no survey.
+      rescue KeyError
+        true
+      end
     end
 
     select_completed ? completed_surveys : uncompleted_surveys

--- a/dashboard/app/models/pd/enrollment.rb
+++ b/dashboard/app/models/pd/enrollment.rb
@@ -180,6 +180,13 @@ class Pd::Enrollment < ActiveRecord::Base
       (enrollment.workshop.csf_intro? || enrollment.workshop.local_summer?)
     end
 
+    # we currently don't have a post survey for CSP for returning teachers.
+    # Once we do we will need to convert _ to a useful variable.
+    _, other_enrollments = other_enrollments.partition do |enrollment|
+      enrollment.workshop.course == Pd::Workshop::COURSE_CSP &&
+        enrollment.workshop.subject == Pd::Workshop::SUBJECT_CSP_FOR_RETURNING_TEACHERS
+    end
+
     new_academic_year_enrollments, other_enrollments = other_enrollments.partition do |enrollment|
       [Pd::Workshop::COURSE_CSP, Pd::Workshop::COURSE_CSD].include?(enrollment.workshop.course) && enrollment.workshop.workshop_starting_date > Date.new(2018, 8, 1)
     end

--- a/dashboard/app/models/pd/workshop_constants.rb
+++ b/dashboard/app/models/pd/workshop_constants.rb
@@ -63,7 +63,8 @@ module Pd
         SUBJECT_CSP_WORKSHOP_4 => {min_days: 1, max_days: 1, max_hours: 6},
         SUBJECT_CSP_WORKSHOP_5 => {min_days: 2, max_days: 2, max_hours: 12},
         SUBJECT_CSP_WORKSHOP_6 => {min_days: 2, max_days: 2, max_hours: 12},
-        SUBJECT_CSP_TEACHER_CON => {max_hours: 33.5}
+        SUBJECT_CSP_TEACHER_CON => {max_hours: 33.5},
+        SUBJECT_CSP_FOR_RETURNING_TEACHERS => {max_hours: 7}
       },
       COURSE_CSD => {
         SUBJECT_CSD_SUMMER_WORKSHOP => {max_hours: 33.5},


### PR DESCRIPTION
Enable certificate for CSP Workshop for Returning Teachers. There was a bug that prevented the /my-professional-learning page from showing if a teacher had completed CSPWFRT, because it was trying to load a JotForm link that did not exist. Fixed that issue and added the max of 7 hours requested for CSPWFRT

The certificate looks like this:
<img width="1257" alt="image" src="https://user-images.githubusercontent.com/33666587/83465740-c2fa0100-a429-11ea-8709-91d4a4a20f32.png">

Let me know if we should be showing anything besides CS Principles in the middle section, currently our default for CSP/CSD courses is to only show the course, not the subject.

<!-- ### Background -->
<!-- ### Privacy -->
<!-- ### Security -->
<!-- ### Caching -->
<!-- ### Deployment strategy -->
<!-- ### Future work -->

## Links

<!--
  Any relevant links to external resources; ie, specification documents, jira
  items, related PRs, honeybadger errors, etc
-->

- [spec](https://docs.google.com/document/d/1u1Vfm5DnsBpwUrV2XLp9XMcF2R3SU7b1EAtlBBB6wEU/edit#heading=h.3fd0u51qnkuv)
- [jira](https://codedotorg.atlassian.net/browse/PLC-863)

## Testing story
Verified that the certificate renders the right information for multiple teachers. Checked that a workshop > 7 hours will only show 7 hours, and a workshop < 7 hours will show the correct number of hours.

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
