### PR TITLE
Create new migration to undo adding foreign key

### DIFF
--- a/dashboard/app/models/sections/clever_section.rb
+++ b/dashboard/app/models/sections/clever_section.rb
@@ -24,7 +24,6 @@
 # Indexes
 #
 #  fk_rails_20b1e5de46        (course_id)
-#  fk_rails_5c2401d1cb        (script_id)
 #  index_sections_on_code     (code) UNIQUE
 #  index_sections_on_user_id  (user_id)
 #

--- a/dashboard/app/models/sections/email_section.rb
+++ b/dashboard/app/models/sections/email_section.rb
@@ -24,7 +24,6 @@
 # Indexes
 #
 #  fk_rails_20b1e5de46        (course_id)
-#  fk_rails_5c2401d1cb        (script_id)
 #  index_sections_on_code     (code) UNIQUE
 #  index_sections_on_user_id  (user_id)
 #

--- a/dashboard/app/models/sections/google_classroom_section.rb
+++ b/dashboard/app/models/sections/google_classroom_section.rb
@@ -24,7 +24,6 @@
 # Indexes
 #
 #  fk_rails_20b1e5de46        (course_id)
-#  fk_rails_5c2401d1cb        (script_id)
 #  index_sections_on_code     (code) UNIQUE
 #  index_sections_on_user_id  (user_id)
 #

--- a/dashboard/app/models/sections/omni_auth_section.rb
+++ b/dashboard/app/models/sections/omni_auth_section.rb
@@ -24,7 +24,6 @@
 # Indexes
 #
 #  fk_rails_20b1e5de46        (course_id)
-#  fk_rails_5c2401d1cb        (script_id)
 #  index_sections_on_code     (code) UNIQUE
 #  index_sections_on_user_id  (user_id)
 #

--- a/dashboard/app/models/sections/picture_section.rb
+++ b/dashboard/app/models/sections/picture_section.rb
@@ -24,7 +24,6 @@
 # Indexes
 #
 #  fk_rails_20b1e5de46        (course_id)
-#  fk_rails_5c2401d1cb        (script_id)
 #  index_sections_on_code     (code) UNIQUE
 #  index_sections_on_user_id  (user_id)
 #

--- a/dashboard/app/models/sections/section.rb
+++ b/dashboard/app/models/sections/section.rb
@@ -24,7 +24,6 @@
 # Indexes
 #
 #  fk_rails_20b1e5de46        (course_id)
-#  fk_rails_5c2401d1cb        (script_id)
 #  index_sections_on_code     (code) UNIQUE
 #  index_sections_on_user_id  (user_id)
 #

--- a/dashboard/app/models/sections/word_section.rb
+++ b/dashboard/app/models/sections/word_section.rb
@@ -24,7 +24,6 @@
 # Indexes
 #
 #  fk_rails_20b1e5de46        (course_id)
-#  fk_rails_5c2401d1cb        (script_id)
 #  index_sections_on_code     (code) UNIQUE
 #  index_sections_on_user_id  (user_id)
 #

--- a/dashboard/db/migrate/20200529004150_add_foreign_key_for_script_to_section.rb
+++ b/dashboard/db/migrate/20200529004150_add_foreign_key_for_script_to_section.rb
@@ -1,5 +1,8 @@
 class AddForeignKeyForScriptToSection < ActiveRecord::Migration[5.0]
   def change
+    # This migration fails in production because it takes too long to apply (roughly 4 minutes).
+    # We need to add this if statement to skip running it in production so the next migration can revert it.
+    return if Rails.env.production?
     add_foreign_key :sections, :scripts
   end
 end

--- a/dashboard/db/migrate/20200602014720_revert_add_foreign_key_for_script_to_section.rb
+++ b/dashboard/db/migrate/20200602014720_revert_add_foreign_key_for_script_to_section.rb
@@ -1,0 +1,15 @@
+require_relative '20200529004150_add_foreign_key_for_script_to_section.rb'
+
+class RevertAddForeignKeyForScriptToSection < ActiveRecord::Migration[5.0]
+  def change
+    # Original migration was never successfully applied to production,
+    # which is the reason we need to revert in the first place.
+    return if Rails.env.production?
+
+    revert AddForeignKeyForScriptToSection
+
+    # An index was implicitly added when foreign key constraint added, and rails doesn't know to delete it
+    # as part of the revert: https://github.com/rails/rails/issues/20048
+    remove_index :sections, name: :fk_rails_5c2401d1cb
+  end
+end

--- a/dashboard/db/schema.rb
+++ b/dashboard/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20200529004150) do
+ActiveRecord::Schema.define(version: 20200602014720) do
 
   create_table "activities", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci" do |t|
     t.integer  "user_id"
@@ -1382,7 +1382,6 @@ ActiveRecord::Schema.define(version: 20200529004150) do
     t.boolean  "autoplay_enabled",  default: false,   null: false
     t.index ["code"], name: "index_sections_on_code", unique: true, using: :btree
     t.index ["course_id"], name: "fk_rails_20b1e5de46", using: :btree
-    t.index ["script_id"], name: "fk_rails_5c2401d1cb", using: :btree
     t.index ["user_id"], name: "index_sections_on_user_id", using: :btree
   end
 
@@ -1778,7 +1777,6 @@ ActiveRecord::Schema.define(version: 20200529004150) do
   add_foreign_key "school_stats_by_years", "schools"
   add_foreign_key "schools", "school_districts"
   add_foreign_key "sections", "courses"
-  add_foreign_key "sections", "scripts"
   add_foreign_key "state_cs_offerings", "schools", column: "state_school_id", primary_key: "state_school_id"
   add_foreign_key "survey_results", "users"
   add_foreign_key "user_geos", "users"


### PR DESCRIPTION
Reverting https://github.com/code-dot-org/code-dot-org/pull/35051 again because the migration times out in production:

https://app.honeybadger.io/projects/3240/faults/64320902

Running the SQL statement on a clone takes about 4 minutes:

```
mysql> ALTER TABLE `sections` ADD CONSTRAINT `fk_rails_5c2401d1cb` FOREIGN KEY (`script_id`) REFERENCES `scripts` (`id`);
Query OK, 2739553 rows affected (4 min 34.15 sec)
Records: 2739553  Duplicates: 0  Warnings: 0
```

Inspiration for hack for not running in production comes from https://github.com/code-dot-org/code-dot-org/blob/staging/dashboard/db/migrate/20181106201126_change_id_to_bigint_in_user_levels.rb

I'm not sure what our current best practices are for migrations on tables of this size - large but not `user_levels` large. Prepping this revert to unblock the pipeline.

## Testing story

* Ran migration locally and verified results with `show create table sections`. Relevant output:

```
  PRIMARY KEY (`id`),
  UNIQUE KEY `index_sections_on_code` (`code`) USING BTREE,
  KEY `fk_rails_20b1e5de46` (`course_id`) USING BTREE,
  KEY `index_sections_on_user_id` (`user_id`) USING BTREE,
  CONSTRAINT `fk_rails_20b1e5de46` FOREIGN KEY (`course_id`) REFERENCES `courses` (`id`)
```

compared to staging:
```
  PRIMARY KEY (`id`),
  UNIQUE KEY `index_sections_on_code` (`code`) USING BTREE,
  KEY `fk_rails_20b1e5de46` (`course_id`) USING BTREE,
  KEY `index_sections_on_user_id` (`user_id`) USING BTREE,
  KEY `fk_rails_5c2401d1cb` (`script_id`),
  CONSTRAINT `fk_rails_20b1e5de46` FOREIGN KEY (`course_id`) REFERENCES `courses` (`id`),
  CONSTRAINT `fk_rails_5c2401d1cb` FOREIGN KEY (`script_id`) REFERENCES `scripts` (`id`)
```
# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
