### PR TITLE
Revert "Merge pull request #34975 from code-dot-org/may26-sprite-pointer"

### DIFF
--- a/apps/package.json
+++ b/apps/package.json
@@ -49,7 +49,7 @@
     "@babel/preset-react": "^7.0.0",
     "@cdo/interpreted": "link:../dashboard/config/libraries",
     "@code-dot-org/artist": "0.2.1",
-    "@code-dot-org/blockly": "3.5.18",
+    "@code-dot-org/blockly": "3.5.15",
     "@code-dot-org/bramble": "0.1.26",
     "@code-dot-org/craft": "0.2.2",
     "@code-dot-org/dance-party": "1.0.1",

--- a/apps/src/block_utils.js
+++ b/apps/src/block_utils.js
@@ -1030,32 +1030,15 @@ exports.createJsWrapperBlockCreator = function(
 
         // For mini-toolbox, indicate which blocks should receive the duplicate on drag
         // behavior and indicates the sibling block to shadow the value from
-        if (this.type === 'gamelab_clickedSpritePointer') {
+        if (blockText === 'clicked {SPRITE}') {
           this.setParentForCopyOnDrag('gamelab_spriteClickedSet');
-          this.setBlockToShadow(
-            root =>
-              root.type === 'gamelab_spriteClicked' &&
-              root.getConnections_()[1] &&
-              root.getConnections_()[1].targetBlock()
-          );
+          this.setBlockToShadow('gamelab_allSpritesWithAnimation');
         }
-        if (this.type === 'gamelab_subjectSpritePointer') {
+        if (blockText === 'subject sprite') {
           this.setParentForCopyOnDrag('gamelab_whenTouchingSet');
-          this.setBlockToShadow(
-            root =>
-              root.type === 'gamelab_checkTouching' &&
-              root.getConnections_()[1] &&
-              root.getConnections_()[1].targetBlock()
-          );
         }
-        if (this.type === 'gamelab_objectSpritePointer') {
+        if (blockText === 'object sprite') {
           this.setParentForCopyOnDrag('gamelab_whenTouchingSet');
-          this.setBlockToShadow(
-            root =>
-              root.type === 'gamelab_checkTouching' &&
-              root.getConnections_()[2] &&
-              root.getConnections_()[2].targetBlock()
-          );
         }
 
         interpolateInputs(blockly, this, inputRows, inputTypes, inline);

--- a/apps/yarn.lock
+++ b/apps/yarn.lock
@@ -1526,10 +1526,10 @@
   version "0.2.1"
   resolved "https://registry.yarnpkg.com/@code-dot-org/artist/-/artist-0.2.1.tgz#fcfe7ea5cfb3f19ddb6b912e70e922ba4b7ef0b1"
 
-"@code-dot-org/blockly@3.5.18":
-  version "3.5.18"
-  resolved "https://registry.yarnpkg.com/@code-dot-org/blockly/-/blockly-3.5.18.tgz#49b189c7a919ea7750b43cda02678c43a381a6f9"
-  integrity sha512-lAzeCjQNSQBSmSKEP6TRM/NcFv/FZhPc3SKUme2KtUCJmktjsV4AHJ1ob0niWzBrXhglx1U23tAF+AIw4vBQgQ==
+"@code-dot-org/blockly@3.5.15":
+  version "3.5.15"
+  resolved "https://registry.yarnpkg.com/@code-dot-org/blockly/-/blockly-3.5.15.tgz#6995cefddb2fd8472e5054a035b55eaae37fb269"
+  integrity sha512-e4Tg0CzoofUQBRjS9pcwBzzHidVsPp8fiNC+j5/srHubwef+PiK1NxeELj20YoBehefii+RQ20qM6HtxFXZY/Q==
 
 "@code-dot-org/bramble@0.1.26":
   version "0.1.26"


### PR DESCRIPTION
On Firefox, this was causing an infinite number of window.resize events to be triggered at https://studio.code.org/s/algebra/stage/1/puzzle/2. Specifically, this error occurred in the upgrade from blockly 3.5.15 to 3.5.17 (the 3.5.18 version was in staging, but hadn't yet reached the test branch. It's quality is unknown).

Internal folks can see a discussion around this issue on [this slack thread](https://codedotorg.slack.com/archives/C1B3PNDL7/p1591129863387900)

This reverts commit 48fa20d5c78d995195f14ed3c002fc095409e6fe, reversing
changes made to 98d2713616c3f6775dbe6246ba80974150b78306.

<!--
  Your description goes here: A summary of the change, including any relevant motivation and context.

  If relevant, include a description both of the existing behavior and of the new behavior.
-->

<!--
  Other aspects to consider. uncomment and add detail for any that seem necessary:
-->

<!-- ### Background -->
<!-- ### Privacy -->
<!-- ### Security -->
<!-- ### Caching -->
<!-- ### Deployment strategy -->
<!-- ### Future work -->

## Links

<!--
  Any relevant links to external resources; ie, specification documents, jira
  items, related PRs, honeybadger errors, etc
-->

- [spec]()
- [jira]()

## Testing story

<!--
  Does your change include appropriate tests?

  If so, please describe how the tests included in this PR are sufficient

  If not, please explain why this change does not need to be tested.
-->

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
