### PR TITLE
Remove encryption key

### DIFF
--- a/docker/ui_tests.sh
+++ b/docker/ui_tests.sh
@@ -35,7 +35,6 @@ echo "
 netsim_redis_groups:
 - master: redis://ui-tests-redis:6379
 bundler_use_sudo: false
-properties_encryption_key: $PROPERTIES_ENCRYPTION_KEY
 cloudfront_key_pair_id: $CLOUDFRONT_KEY_PAIR_ID
 cloudfront_private_key: \"$CLOUDFRONT_PRIVATE_KEY\"
 saucelabs_username: $SAUCE_USERNAME


### PR DESCRIPTION
Our LP contributor has been running into problems trying to seed her environment because she does not have our encryption key. I asked Dave: Are there ways where we could add tests to make sure seeding works for someone without the encryption key so we prevent breaking this for contributors down the road? He suggested removing this encryption key for drone as a way to try to try to make sure that we don't make changes that will break seeding specifically `rake seed:ui_test`
