### PR TITLE
CRv2: Use Sequel to avoid ActiveRecord timeout issue

### DIFF
--- a/dashboard/app/models/contact_rollups_final.rb
+++ b/dashboard/app/models/contact_rollups_final.rb
@@ -23,6 +23,8 @@ class ContactRollupsFinal < ApplicationRecord
       FROM contact_rollups_processed;
     SQL
 
-    transaction {ActiveRecord::Base.connection.exec_query(insert_sql)}
+    ContactRollupsV2::DASHBOARD_DB_WRITER.transaction do
+      ContactRollupsV2::DASHBOARD_DB_WRITER.run(insert_sql)
+    end
   end
 end

--- a/dashboard/app/models/contact_rollups_final.rb
+++ b/dashboard/app/models/contact_rollups_final.rb
@@ -22,9 +22,6 @@ class ContactRollupsFinal < ApplicationRecord
       SELECT *
       FROM contact_rollups_processed;
     SQL
-
-    ContactRollupsV2::DASHBOARD_DB_WRITER.transaction do
-      ContactRollupsV2::DASHBOARD_DB_WRITER.run(insert_sql)
-    end
+    ContactRollupsV2.execute_query_in_transaction(insert_sql)
   end
 end

--- a/dashboard/app/models/contact_rollups_raw.rb
+++ b/dashboard/app/models/contact_rollups_raw.rb
@@ -20,10 +20,7 @@ class ContactRollupsRaw < ApplicationRecord
 
   def self.extract_email_preferences
     query = get_extraction_query('email_preferences', 'email', ['opt_in'])
-
-    ContactRollupsV2::DASHBOARD_DB_WRITER.transaction do
-      ContactRollupsV2::DASHBOARD_DB_WRITER.run(query)
-    end
+    ContactRollupsV2.execute_query_in_transaction(query)
   end
 
   def self.extract_parent_emails
@@ -32,11 +29,8 @@ class ContactRollupsRaw < ApplicationRecord
       FROM users
       GROUP BY parent_email
     SQL
-
     query = get_extraction_query(source_sql, 'parent_email', [], true, 'dashboard.users.parent_email')
-    ContactRollupsV2::DASHBOARD_DB_WRITER.transaction do
-      ContactRollupsV2::DASHBOARD_DB_WRITER.run(query)
-    end
+    ContactRollupsV2.execute_query_in_transaction(query)
   end
 
   # @param source [String] Source from which we want to extract data (can be a dashboard table name, or subquery)

--- a/dashboard/app/models/contact_rollups_raw.rb
+++ b/dashboard/app/models/contact_rollups_raw.rb
@@ -53,7 +53,7 @@ class ContactRollupsRaw < ApplicationRecord
     source_name ||= "dashboard.#{source}"
     wrapped_source = source_is_subquery ? "(#{source}) AS subquery" : source
 
-    <<~SQL.squish
+    <<~SQL
       INSERT INTO #{ContactRollupsRaw.table_name} (email, sources, data, data_updated_at, created_at, updated_at)
       SELECT
         #{email_column},

--- a/dashboard/lib/contact_rollups_v2.rb
+++ b/dashboard/lib/contact_rollups_v2.rb
@@ -10,15 +10,21 @@ class ContactRollupsV2
   )
 
   def self.execute_query_in_transaction(query)
-    # TODO: add explanation
+    # For long-running queries, we use Sequel connection instead of ActiveRecord connection.
+    # ActiveRecord has a default 30s read_timeout that we cannot override. Sequel allows us
+    # to a create connection with custom query_timeout and read_timeout values.
+    #
+    # However, Sequel write operations to the dashboard database don't work in test environments
+    # (in local, Drone, and test machine) and Rails console sandbox. In those environments,
+    # all database operations are wrapped in a ActiveRecord transaction so they can be rolled
+    # back later. Sequel write operations cannot acquire a lock to the dashboard database, which
+    # already locked by ActiveRecord, then fail with "Lock wait timeout exceeded" error.
+    #
+    # The workaround is to use different database connections in different environments.
     if Rails.env.test?
-      ActiveRecord::Base.transaction do
-        ActiveRecord::Base.connection.exec_query(query)
-      end
+      ActiveRecord::Base.transaction {ActiveRecord::Base.connection.exec_query(query)}
     else
-      ContactRollupsV2::DASHBOARD_DB_WRITER.transaction do
-        ContactRollupsV2::DASHBOARD_DB_WRITER.run(query)
-      end
+      DASHBOARD_DB_WRITER.transaction {DASHBOARD_DB_WRITER.run(query)}
     end
   end
 

--- a/dashboard/lib/contact_rollups_v2.rb
+++ b/dashboard/lib/contact_rollups_v2.rb
@@ -5,7 +5,7 @@ class ContactRollupsV2
 
   DASHBOARD_DB_WRITER = sequel_connect(
     CDO.dashboard_db_writer,
-    CDO.dashboard_db_writer,
+    CDO.dashboard_db_reader,
     query_timeout: MAX_EXECUTION_TIME_SEC
   )
 

--- a/dashboard/lib/contact_rollups_v2.rb
+++ b/dashboard/lib/contact_rollups_v2.rb
@@ -9,6 +9,19 @@ class ContactRollupsV2
     query_timeout: MAX_EXECUTION_TIME_SEC
   )
 
+  def self.execute_query_in_transaction(query)
+    # TODO: add explanation
+    if Rails.env.test?
+      ActiveRecord::Base.transaction do
+        ActiveRecord::Base.connection.exec_query(query)
+      end
+    else
+      ContactRollupsV2::DASHBOARD_DB_WRITER.transaction do
+        ContactRollupsV2::DASHBOARD_DB_WRITER.run(query)
+      end
+    end
+  end
+
   def initialize(is_dry_run: false)
     @is_dry_run = is_dry_run
     @log_collector = LogCollector.new('Contact Rollups')

--- a/dashboard/lib/contact_rollups_v2.rb
+++ b/dashboard/lib/contact_rollups_v2.rb
@@ -1,6 +1,14 @@
 require 'cdo/log_collector'
 
 class ContactRollupsV2
+  MAX_EXECUTION_TIME_SEC = 18_000
+
+  DASHBOARD_DB_WRITER = sequel_connect(
+    CDO.dashboard_db_writer,
+    CDO.dashboard_db_writer,
+    query_timeout: MAX_EXECUTION_TIME_SEC
+  )
+
   def initialize(is_dry_run: false)
     @is_dry_run = is_dry_run
     @log_collector = LogCollector.new('Contact Rollups')


### PR DESCRIPTION
[PLC-893](https://codedotorg.atlassian.net/browse/PLC-893): Using Sequel connection with custom `query_timeout` and `read_timeout` values to work around ActiveRecord read timeout issue.

## Background
We had insert queries that took several minutes to completed and caused ActiveRecord timeout error. They were reported in this [Honeybadger error](https://app.honeybadger.io/projects/45435/faults/63632941). We had to disable a long running query in https://github.com/code-dot-org/code-dot-org/pull/34969 to unblock the contact roll-ups pipeline.

By default, ActiveRecord `read_timeout` is only 30s, and we cannot change that just for Contact Rollups.
https://github.com/code-dot-org/code-dot-org/blob/49360044bd0d5271c020587b94b08d1fc1e059d9/dashboard/config/database.yml#L42

By using Sequel, we can explicitly set `query_timeout` value, which then implicitly set `read_timeout` value.
https://github.com/code-dot-org/code-dot-org/blob/0c1a2f327302f420d895034447fa35a1d9a77dda/lib/cdo/db.rb#L62

More discussion is in this [Slack thread](https://codedotorg.slack.com/archives/C03CK49G9/p1589474523293300) with INF team.

## Testing story
Test in an adhoc with connection to a production-clone db.
```ruby
# Clean up
ContactRollupsV2::DASHBOARD_DB_WRITER[:contact_rollups_raw].count
ContactRollupsV2::DASHBOARD_DB_WRITER[:contact_rollups_raw].delete
# Run extraction
ContactRollupsRaw.extract_email_preferences
ContactRollupsRaw.extract_parent_emails  # this was the step timed out in the Honeybadger error
# Verify result
ContactRollupsV2::DASHBOARD_DB_WRITER[:contact_rollups_raw].count
```

## Next steps
- [x] Revert PR https://github.com/code-dot-org/code-dot-org/pull/34969 to enable parent_email extraction again.

# Reviewer Checklist:
- [ ] Tests provide adequate coverage
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
