### PR TITLE
Add third option (Friday Institute) to virtual dropdown when creating/updating workshops

### DIFF
--- a/apps/src/code-studio/pd/workshop_dashboard/components/workshop_form.jsx
+++ b/apps/src/code-studio/pd/workshop_dashboard/components/workshop_form.jsx
@@ -66,8 +66,12 @@ const placeholderSession = {
   endTime: '5:00pm'
 };
 
+// When selecting whether a workshop is virtual through the UI,
+// a user is really selecting two things:
+//  a) whether the workshop is occurring virtually, and
+//  b) if there's a third party responsible for the content/structure of the workshop.
+// These two things are stored as separate attributes in the workshop model.
 const virtualWorkshopTypes = ['regional', 'friday_institute'];
-
 const thirdPartyProviders = ['friday_institute'];
 
 export class WorkshopForm extends React.Component {
@@ -746,7 +750,10 @@ export class WorkshopForm extends React.Component {
 
   currentVirtualStatus = () => {
     const {virtual, third_party_provider} = this.state;
-    if (third_party_provider) {
+
+    // First, check if the third party provider is a valid
+    // virtual workshop type.
+    if (virtualWorkshopTypes.includes(third_party_provider)) {
       return third_party_provider;
     } else if (virtual) {
       return 'regional';
@@ -762,12 +769,12 @@ export class WorkshopForm extends React.Component {
     const value = event.target.value;
     const virtual = virtualWorkshopTypes.includes(value);
     const suppress_email = virtual || this.state.suppress_email;
-    let stateUpdates = {
+
+    this.setState({
       virtual,
       suppress_email,
       third_party_provider: thirdPartyProviders.includes(value) ? value : null
-    };
-    this.setState(stateUpdates);
+    });
   };
 
   handleSuppressEmailChange = event => {
@@ -1207,11 +1214,11 @@ const SelectIsVirtual = ({value, readOnly, onChange}) => (
     <option key={'in_person'} value={'in_person'}>
       No, this is an in-person workshop.
     </option>
-    <option key={'regional'} value={'regional'}>
-      Yes, this is a virtual workshop.
-    </option>
     <option key={'friday_institute'} value={'friday_institute'}>
-      Friday Institute Virtual
+      Yes, this is a Code.org-Friday Institute virtual workshop.
+    </option>
+    <option key={'regional'} value={'regional'}>
+      Yes, this is a regional virtual workshop.
     </option>
   </FormControl>
 );

--- a/apps/src/code-studio/pd/workshop_dashboard/workshop.jsx
+++ b/apps/src/code-studio/pd/workshop_dashboard/workshop.jsx
@@ -103,7 +103,8 @@ export class Workshop extends React.Component {
             'potential_organizers',
             'created_at',
             'virtual',
-            'suppress_email'
+            'suppress_email',
+            'third_party_provider'
           ])
         });
       })

--- a/dashboard/app/controllers/api/v1/pd/workshops_controller.rb
+++ b/dashboard/app/controllers/api/v1/pd/workshops_controller.rb
@@ -274,6 +274,7 @@ class Api::V1::Pd::WorkshopsController < ::ApplicationController
       :organizer_id,
       :virtual,
       :suppress_email,
+      :third_party_provider,
       sessions_attributes: [:id, :start, :end, :_destroy],
     ]
 

--- a/dashboard/app/models/pd/workshop.rb
+++ b/dashboard/app/models/pd/workshop.rb
@@ -58,6 +58,14 @@ class Pd::Workshop < ActiveRecord::Base
     #   - Uses a different, virtual-specific post-workshop survey.
     'virtual',
 
+    # Allows a workshop to be associated with a third party
+    # organization.
+    # Only current allowed values are "friday_institute" and nil.
+    # "friday_institute" represents The Friday Institute,
+    # a regional partner whose model of virtual workshop is being used
+    # by several partners during summer 2020.
+    'third_party_provider',
+
     # If true, our system will not send enrollee-facing
     # emails related to this workshop *except* for a receipt for the teacher
     # if they cancel their enrollment and the post-workshop survey,
@@ -84,6 +92,7 @@ class Pd::Workshop < ActiveRecord::Base
   validates_inclusion_of :on_map, in: [true, false]
   validates_inclusion_of :funded, in: [true, false]
   validate :all_virtual_workshops_suppress_email
+  validates_inclusion_of :third_party_provider, in: %w(friday_institute), allow_nil: true
 
   validates :funding_type,
     inclusion: {in: FUNDING_TYPES, if: :funded_csf?},

--- a/dashboard/app/models/pd/workshop.rb
+++ b/dashboard/app/models/pd/workshop.rb
@@ -93,6 +93,7 @@ class Pd::Workshop < ActiveRecord::Base
   validates_inclusion_of :funded, in: [true, false]
   validate :all_virtual_workshops_suppress_email
   validates_inclusion_of :third_party_provider, in: %w(friday_institute), allow_nil: true
+  validate :friday_institute_workshops_must_be_virtual
 
   validates :funding_type,
     inclusion: {in: FUNDING_TYPES, if: :funded_csf?},
@@ -125,6 +126,12 @@ class Pd::Workshop < ActiveRecord::Base
   def all_virtual_workshops_suppress_email
     if virtual? && !suppress_email?
       errors.add :properties, 'All virtual workshops must suppress email.'
+    end
+  end
+
+  def friday_institute_workshops_must_be_virtual
+    if third_party_provider == 'friday_institute' && !virtual?
+      errors.add :properties, 'Friday Institute workshops must be virtual'
     end
   end
 

--- a/dashboard/app/serializers/api/v1/pd/workshop_serializer.rb
+++ b/dashboard/app/serializers/api/v1/pd/workshop_serializer.rb
@@ -4,7 +4,7 @@ class Api::V1::Pd::WorkshopSerializer < ActiveModel::Serializer
     :enrolled_teacher_count, :sessions, :account_required_for_attendance?,
     :enrollment_code, :pre_workshop_survey_url, :attended, :on_map, :funded, :funding_type, :ready_to_close?,
     :workshop_starting_date, :date_and_location_name, :regional_partner_name, :regional_partner_id,
-    :scholarship_workshop?, :can_delete, :created_at, :virtual, :suppress_email
+    :scholarship_workshop?, :can_delete, :created_at, :virtual, :suppress_email, :third_party_provider
 
   def sessions
     object.sessions.map do |session|

--- a/dashboard/test/models/pd/workshop_test.rb
+++ b/dashboard/test/models/pd/workshop_test.rb
@@ -1347,6 +1347,23 @@ class Pd::WorkshopTest < ActiveSupport::TestCase
     assert workshop.valid?
   end
 
+  test 'friday_institute workshops must be virtual' do
+    workshop = build :workshop, third_party_provider: 'friday_institute', virtual: false
+    refute workshop.valid?
+
+    workshop.virtual = true
+    workshop.suppress_email = true
+    assert workshop.valid?
+  end
+
+  test 'workshops third_party_provider must be nil or from specified list' do
+    workshop = build :workshop, third_party_provider: 'unknown_pd_provider'
+    refute workshop.valid?
+
+    workshop.third_party_provider = nil
+    assert workshop.valid?
+  end
+
   private
 
   def session_on_day(day_offset)


### PR DESCRIPTION
Adds a third option to the "Is this a virtual workshop?" dropdown when creating or updating a workshop.

Implemented as a new attribute on the workshop model, `third_party_provider`. There's some hairy logic in the `workshop_form` JSX file to make this work in a single dropdown, would appreciate feedback on how to make it cleaner. 

## Testing story

Tested creating and editing workshops via UI locally and verified data being stored in database, as well as adding a couple of unit tests to limit new model attributes.

## Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
