### PR TITLE
Remove animation names from spritelab

### DIFF
--- a/apps/src/p5lab/AnimationPicker/AnimationPicker.jsx
+++ b/apps/src/p5lab/AnimationPicker/AnimationPicker.jsx
@@ -42,6 +42,7 @@ class AnimationPicker extends React.Component {
     getLibraryManifest: PropTypes.func.isRequired,
     categories: PropTypes.object.isRequired,
     hideUploadOption: PropTypes.bool.isRequired,
+    hideAnimationNames: PropTypes.bool.isRequired,
 
     // Provided via Redux
     visible: PropTypes.bool.isRequired,
@@ -77,6 +78,7 @@ class AnimationPicker extends React.Component {
         getLibraryManifest={this.props.getLibraryManifest}
         categories={this.props.categories}
         hideUploadOption={this.props.hideUploadOption}
+        hideAnimationNames={this.props.hideAnimationNames}
       />
     );
   }

--- a/apps/src/p5lab/AnimationPicker/AnimationPickerBody.jsx
+++ b/apps/src/p5lab/AnimationPicker/AnimationPickerBody.jsx
@@ -46,7 +46,8 @@ export default class AnimationPickerBody extends React.Component {
     playAnimations: PropTypes.bool.isRequired,
     getLibraryManifest: PropTypes.func.isRequired,
     categories: PropTypes.object.isRequired,
-    hideUploadOption: PropTypes.bool.isRequired
+    hideUploadOption: PropTypes.bool.isRequired,
+    hideAnimationNames: PropTypes.bool.isRequired
   };
 
   state = {
@@ -140,7 +141,7 @@ export default class AnimationPickerBody extends React.Component {
     return animations.map(animationProps => (
       <AnimationPickerListItem
         key={animationProps.sourceUrl}
-        label={animationProps.name}
+        label={this.props.hideAnimationNames ? undefined : animationProps.name}
         animationProps={animationProps}
         onClick={this.props.onPickLibraryAnimation.bind(this, animationProps)}
         playAnimations={this.props.playAnimations}

--- a/apps/src/p5lab/AnimationPicker/AnimationPickerListItem.jsx
+++ b/apps/src/p5lab/AnimationPicker/AnimationPickerListItem.jsx
@@ -46,6 +46,9 @@ const styles = {
     whiteSpace: 'nowrap',
     overflow: 'hidden'
   },
+  noLabel: {
+    paddingBottom: 10
+  },
   labelIcon: {
     fontStyle: 'italic'
   },
@@ -65,6 +68,8 @@ class AnimationPickerListItem extends React.Component {
   };
 
   render() {
+    const rootStyle = [styles.root, !this.props.label && styles.noLabel];
+
     const thumbnailStyle = [
       styles.thumbnail,
       this.props.icon && styles.thumbnailIcon
@@ -78,7 +83,7 @@ class AnimationPickerListItem extends React.Component {
 
     return (
       <div
-        style={styles.root}
+        style={rootStyle}
         onClick={this.props.onClick}
         className="uitest-animation-picker-item"
       >

--- a/apps/src/p5lab/AnimationPicker/AnimationPickerListItem.jsx
+++ b/apps/src/p5lab/AnimationPicker/AnimationPickerListItem.jsx
@@ -58,7 +58,7 @@ class AnimationPickerListItem extends React.Component {
   static propTypes = {
     animationProps: shapes.AnimationProps,
     icon: PropTypes.string,
-    label: PropTypes.string.isRequired,
+    label: PropTypes.string,
     onClick: PropTypes.func,
     playAnimations: PropTypes.bool,
     category: PropTypes.string
@@ -103,7 +103,7 @@ class AnimationPickerListItem extends React.Component {
             />
           )}
         </div>
-        <div style={labelStyle}>{this.props.label}</div>
+        {this.props.label && <div style={labelStyle}>{this.props.label}</div>}
       </div>
     );
   }

--- a/apps/src/p5lab/AnimationTab/AnimationTab.jsx
+++ b/apps/src/p5lab/AnimationTab/AnimationTab.jsx
@@ -65,6 +65,7 @@ class AnimationTab extends React.Component {
     getLibraryManifest: PropTypes.func.isRequired,
     categories: PropTypes.object.isRequired,
     hideUploadOption: PropTypes.bool.isRequired,
+    hideAnimationNames: PropTypes.bool.isRequired,
 
     // Provided by Redux
     columnSizes: PropTypes.arrayOf(PropTypes.number).isRequired,
@@ -103,6 +104,7 @@ class AnimationTab extends React.Component {
             getLibraryManifest={this.props.getLibraryManifest}
             categories={this.props.categories}
             hideUploadOption={this.props.hideUploadOption}
+            hideAnimationNames={this.props.hideAnimationNames}
           />
         )}
       </div>

--- a/apps/src/p5lab/P5LabView.jsx
+++ b/apps/src/p5lab/P5LabView.jsx
@@ -113,6 +113,7 @@ class P5LabView extends React.Component {
               getLibraryManifest={this.getLibraryManifest}
               categories={this.getCategories()}
               hideUploadOption={this.props.spriteLab}
+              hideAnimationNames={this.props.spriteLab}
             />
           )}
         </div>
@@ -141,6 +142,7 @@ class P5LabView extends React.Component {
         getLibraryManifest={this.getLibraryManifest}
         categories={this.getCategories()}
         hideUploadOption={this.props.spriteLab}
+        hideAnimationNames={this.props.spriteLab}
       />
     ) : (
       undefined

--- a/apps/test/unit/p5lab/AnimationPicker/AnimationPickerBodyTest.js
+++ b/apps/test/unit/p5lab/AnimationPicker/AnimationPickerBodyTest.js
@@ -19,7 +19,8 @@ describe('AnimationPickerBody', function() {
     playAnimations: false,
     getLibraryManifest: () => spriteCostumeLibrary,
     categories: CostumeCategories,
-    hideUploadOption: false
+    hideUploadOption: false,
+    hideAnimationNames: false
   };
 
   describe('upload warning', function() {


### PR DESCRIPTION
The names of sprites in spritelab don't really serve a purpose as sprites are referenced by image. In addition the current names are pretty unfriendly (eg `kid_11`). This PR simply removes them from the animation picker dialog:

![Screenshot 2020-06-04 at 10 02 10 AM](https://user-images.githubusercontent.com/46464143/83792650-2ebdb300-a650-11ea-9aea-f4a0908c8df3.png)

Category labels are sticking around:
![Screenshot 2020-06-04 at 10 02 24 AM](https://user-images.githubusercontent.com/46464143/83792674-367d5780-a650-11ea-9b9e-43f8c8eb4910.png)

Gamelab still has the animation names. 

<!-- ### Background -->
<!-- ### Privacy -->
<!-- ### Security -->
<!-- ### Caching -->
<!-- ### Deployment strategy -->
<!-- ### Future work -->

## Links

<!--
  Any relevant links to external resources; ie, specification documents, jira
  items, related PRs, honeybadger errors, etc
-->

- [spec]()
- [jira]()

## Testing story

<!--
  Does your change include appropriate tests?

  If so, please describe how the tests included in this PR are sufficient

  If not, please explain why this change does not need to be tested.
-->

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
