### PR TITLE
App lab camera integration fix

### DIFF
--- a/apps/src/applab/commands.js
+++ b/apps/src/applab/commands.js
@@ -1159,7 +1159,7 @@ applabCommands.getImageURL = function(opts) {
       return element.getAttribute('data-canonical-image-url');
     } else if (
       element.tagName === 'LABEL' &&
-      element.className === 'img-upload'
+      $(element).hasClass('img-upload')
     ) {
       var fileObj = element.children[0].files[0];
       if (fileObj) {

--- a/apps/src/applab/designElements/photoSelect.jsx
+++ b/apps/src/applab/designElements/photoSelect.jsx
@@ -177,7 +177,7 @@ export default {
   onDeserialize: function(element, updateProperty) {
     // Disable image upload events unless running
     $(element).on('click', () => {
-      element.childNodes[0] = !Applab.isRunning();
+      element.childNodes[0].disabled = !Applab.isRunning();
     });
   }
 };


### PR DESCRIPTION
app lab camera integration wasn't working due to a bug in how we recognized the photo select element in getImageURL.

## Links
- [Old PR](https://github.com/code-dot-org/code-dot-org/pull/34751)

## Testing story


# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
