### PR TITLE
Pixelation widget now saves the width and height and bits per pixel

### DIFF
--- a/dashboard/public/pixelation/pixelation.js
+++ b/dashboard/public/pixelation/pixelation.js
@@ -166,8 +166,10 @@ function initProjects() {
 
             var charactersToTrim = 0;
             if (options.version === "2") {
+              // length & width
               charactersToTrim = 2;
             } else if (options.version === "3") {
+              // length & width & bitsPerPixel
               charactersToTrim = 3;
             }
 
@@ -668,11 +670,11 @@ function getPositiveValue(element) {
 function getSliderBytes() {
   var heightByte = pad(getPositiveValue(heightRange).toString(2), 8, "0");
   var widthByte = pad(getPositiveValue(widthRange).toString(2), 8, "0");
-  var bppByte = pad(getPositiveValue(bitsPerPixelRange).toString(2), 8, "0");
+  var bitsPerPixelByte = pad(getPositiveValue(bitsPerPixelRange).toString(2), 8, "0");
 
   var sliderBits = widthByte + heightByte;
   if (options.version === "3") {
-    sliderBits += bppByte;
+    sliderBits += bitsPerPixelByte;
   }
 
   return sliderBits;


### PR DESCRIPTION
Prior to this change, the width and height of a student's project was not saved with the binary code. This meant that the image would display as a 10x10 image on page reload for projects that used V1 of the pixelation project. This was especially problematic for teachers who would load their student's images and not be able to see what the image was that the student created.

Note: I have changed the data schema of pixelation projects. Previously, V2 & V3 used the first two or three bytes, respectively, of the student code to define the width, height, and sometimes bitsPerPixel of the widget. Please take a close look and let me know if you foresee any potential issues.

Old Schema (In V2 & V3, the first two or three bytes were the width, height, and bitsPerPixel)
`Data: "101010..."`

New Schema
```
Data: {
  width: 12,
  height: 9,
  bitsPerPixel: 6,
  code: "101010..."
}
```
There were two other options I see for storing the width and height:
0. Migrate only V1 to the new model and migrate V2 & V3 later. 
1. Store it as two bytes at the beginning of the code string (what V2 & V3 do currently). Then, (to support old projects) add a flag to the project indicating that the first two bytes are the width & height
2. Migrate V2 & V3 to the new model as well. On serialize/de-serialize, add & remove those bytes to/from the code.

I don't feel too strongly about the approach I took, but these are the pros/cons I can see for the various options

0. Migrate only V1
  -- Pro: Simple, starts migrating us to a more resilient data model
  -- Con: We're now managing two different data models
1. Prepend the code string (what V2 & V3 did in the old model)
  -- Pro: Everything follows the current model
  -- Con: We'd have to do something odd to store the flag that indicates whether this is a legacy or "normal" version. Perhaps overload the getProjectHtml method to store the flag.
2. (New Model) Migrate V2 & V3 to the new object model as well.
  -- Pro: Everything is on the same model and is migrated to the more resilient data model
  -- Con: not much of a con. Just a bigger PR and a more projects that are on the legacy model.

<!--
  Your description goes here: A summary of the change, including any relevant motivation and context.

  If relevant, include a description both of the existing behavior and of the new behavior.
-->

<!--
  Other aspects to consider. uncomment and add detail for any that seem necessary:
-->

<!-- ### Background -->
<!-- ### Privacy -->
<!-- ### Security -->
<!-- ### Caching -->
<!-- ### Deployment strategy -->
<!-- ### Future work -->

## Links

<!--
  Any relevant links to external resources; ie, specification documents, jira
  items, related PRs, honeybadger errors, etc
-->

- [jira](https://codedotorg.atlassian.net/browse/STAR-160)

## Testing story

<!--
  Does your change include appropriate tests?

  If so, please describe how the tests included in this PR are sufficient

  If not, please explain why this change does not need to be tested.
-->

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
