### PR TITLE
CRv2: Ignore contacts marked for deletion

### DIFF
--- a/dashboard/app/models/contact_rollups_pardot_memory.rb
+++ b/dashboard/app/models/contact_rollups_pardot_memory.rb
@@ -183,6 +183,7 @@ class ContactRollupsPardotMemory < ApplicationRecord
       WHERE pardot.pardot_id IS NULL
         AND NOT (pardot.data_rejected_reason <=> '#{PardotHelpers::ERROR_INVALID_EMAIL}')
         AND NOT (pardot.data_rejected_reason <=> '#{PardotHelpers::ERROR_PROSPECT_DELETED_FROM_PARDOT}')
+        AND pardot.marked_for_deletion_at IS NULL
     SQL
   end
 
@@ -210,6 +211,7 @@ class ContactRollupsPardotMemory < ApplicationRecord
           OR (pardot.pardot_id_updated_at > pardot.data_synced_at)
         )
         AND NOT (pardot.data_rejected_reason <=> '#{PardotHelpers::ERROR_PROSPECT_DELETED_FROM_PARDOT}')
+        AND pardot.marked_for_deletion_at IS NULL
     SQL
   end
 


### PR DESCRIPTION
Minor optimization: Don't add or update contacts that are already marked for deletion by the AccountPurger process.
https://github.com/code-dot-org/code-dot-org/blob/7572961bc907da1a9838db1f4e7336abe857ef96/lib/cdo/delete_accounts_helper.rb#L204-L209