### PR TITLE
Move Teacher Only Box to Teacher Only Tab for CSP and CSD

### DIFF
--- a/apps/src/templates/instructions/TopInstructions.jsx
+++ b/apps/src/templates/instructions/TopInstructions.jsx
@@ -583,11 +583,8 @@ class TopInstructions extends Component {
       return <div />;
     }
 
-    /* TODO: When we move CSD and CSP to the Teacher Only tab remove CSF restriction here*/
     const showContainedLevelAnswer =
-      this.props.hasContainedLevels &&
-      isCSF &&
-      $('#containedLevelAnswer0').length > 0;
+      this.props.hasContainedLevels && $('#containedLevelAnswer0').length > 0;
 
     return (
       <div style={mainStyle} className="editor-column" ref="topInstructions">

--- a/apps/src/templates/instructions/TopInstructions.jsx
+++ b/apps/src/templates/instructions/TopInstructions.jsx
@@ -572,8 +572,9 @@ class TopInstructions extends Component {
 
     // Teacher is viewing students work and in the Feedback Tab
     const teacherOnly =
-      this.state.tabSelected === TabType.COMMENTS &&
-      this.state.teacherViewingStudentWork;
+      this.state.tabSelected === TabType.TEACHER_ONLY ||
+      (this.state.tabSelected === TabType.COMMENTS &&
+        this.state.teacherViewingStudentWork);
 
     if (
       hidden ||

--- a/apps/src/templates/instructions/TopInstructions.jsx
+++ b/apps/src/templates/instructions/TopInstructions.jsx
@@ -652,9 +652,7 @@ class TopInstructions extends Component {
                     isRtl={this.props.isRtl}
                   />
                 )}
-              {/* TODO: When we move CSD and CSP to the Teacher Only tab remove CSF restriction here*/}
-              {isCSF &&
-                this.props.viewAs === ViewType.Teacher &&
+              {this.props.viewAs === ViewType.Teacher &&
                 (this.props.teacherMarkdown || showContainedLevelAnswer) && (
                   <InstructionsTab
                     className="uitest-teacherOnlyTab"
@@ -700,16 +698,6 @@ class TopInstructions extends Component {
                     ref="instructions"
                     hidden={this.state.tabSelected !== TabType.INSTRUCTIONS}
                   />
-                  {/* TODO: When we move CSD and CSP to the Teacher Only tab remove this*/}
-                  {!isCSF && this.props.viewAs === ViewType.Teacher && (
-                    <div>
-                      <ContainedLevelAnswer
-                        ref="teacherOnlyTab"
-                        hidden={this.state.tabSelected !== TabType.INSTRUCTIONS}
-                      />
-                      {this.props.teacherMarkdown && <TeacherOnlyMarkdown />}
-                    </div>
-                  )}
                 </div>
               )}
               {!this.props.hasContainedLevels &&
@@ -735,7 +723,6 @@ class TopInstructions extends Component {
                       onResize={this.adjustMaxNeededHeight}
                       inTopPane
                     />
-                    {this.props.teacherMarkdown && <TeacherOnlyMarkdown />}
                   </div>
                 )}
             </div>
@@ -762,9 +749,7 @@ class TopInstructions extends Component {
                 token={this.state.token}
               />
             )}
-            {/* TODO: When we move CSD and CSP to the Teacher Only tab remove CSF restriction here*/}
-            {isCSF &&
-              this.props.viewAs === ViewType.Teacher &&
+            {this.props.viewAs === ViewType.Teacher &&
               (this.props.hasContainedLevels || this.props.teacherMarkdown) && (
                 <div>
                   {this.props.hasContainedLevels && (

--- a/apps/test/unit/templates/instructions/TopInstructionsTest.jsx
+++ b/apps/test/unit/templates/instructions/TopInstructionsTest.jsx
@@ -163,28 +163,7 @@ describe('TopInstructions', () => {
         expect(wrapper.find('.uitest-teacherOnlyTab')).to.have.lengthOf(0);
       });
 
-      it('shows the Teacher Instructions on a level with markdown for CSF', () => {
-        const wrapper = shallow(
-          <TopInstructions
-            {...DEFAULT_PROPS}
-            noInstructionsWhenCollapsed={false}
-          />
-        );
-
-        wrapper.setState({
-          tabSelected: 'instructions',
-          feedbacks: [],
-          rubric: null,
-          teacherViewingStudentWork: false,
-          studentId: null,
-          fetchingData: false,
-          token: null
-        });
-
-        expect(wrapper.find('.uitest-teacherOnlyTab')).to.have.lengthOf(1);
-      });
-
-      it('does not show the Teacher Instructions on a level with markdown for CSP and CSD', () => {
+      it('shows the Teacher Instructions on a level with markdown', () => {
         const wrapper = shallow(<TopInstructions {...DEFAULT_PROPS} />);
 
         wrapper.setState({
@@ -197,7 +176,7 @@ describe('TopInstructions', () => {
           token: null
         });
 
-        expect(wrapper.find('.uitest-teacherOnlyTab')).to.have.lengthOf(0);
+        expect(wrapper.find('.uitest-teacherOnlyTab')).to.have.lengthOf(1);
       });
     });
 

--- a/dashboard/test/ui/features/learning_platform/level_types/contained_levels.feature
+++ b/dashboard/test/ui/features/learning_platform/level_types/contained_levels.feature
@@ -94,8 +94,9 @@ Scenario: Authorized Teacher on App Lab with free response contained level
   Then I see no difference for "initial load"
   And I press keys "Here is my response!" for element ".response"
   And I see no difference for "answer entered"
-  # Check that answer shows in instructions tab
-  And element ".uitest-teacherOnlyTab" is not visible
+  # Check that answer shows in teacher only tab
+  Then I press the first ".uitest-teacherOnlyTab" element
+  And I wait to see ".editor-column"
   And element ".editor-column" contains text "For Teachers Only"
   And I see no difference for "free response answer for teacher"
   Then I press "runButton"


### PR DESCRIPTION
Last year we added the Teacher Only Tab to hold the Teacher Only area for CSF levels. We are now ready to move CSP and CSD over to using this tab as well.  I got the thumbs up from curriculum and PL.

<img width="1046" alt="Screen Shot 2020-06-03 at 8 48 04 PM" src="https://user-images.githubusercontent.com/208083/83703009-5115e900-a5dc-11ea-9ccb-4c06892c8011.png">


## Testing story

<!--
  Does your change include appropriate tests?

  If so, please describe how the tests included in this PR are sufficient

  If not, please explain why this change does not need to be tested.
-->

Updated the TopInstructions Tests based on this change.

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
