### PR TITLE
Null out the migrations from foreign key for script in section

### DIFF
--- a/dashboard/db/migrate/20200529004150_add_foreign_key_for_script_to_section.rb
+++ b/dashboard/db/migrate/20200529004150_add_foreign_key_for_script_to_section.rb
@@ -1,8 +1,8 @@
 class AddForeignKeyForScriptToSection < ActiveRecord::Migration[5.0]
   def change
-    # This migration fails in production because it takes too long to apply (roughly 4 minutes).
-    # We need to add this if statement to skip running it in production so the next migration can revert it.
-    return if Rails.env.production?
-    add_foreign_key :sections, :scripts
+    # This migration failed in production because it takes too long to apply (roughly 4 minutes).
+    # We reverted it in RevertAddForeignKeyForScriptToSection. As clean up we are removing the
+    # content of this and the revert migrations.
+    # See https://github.com/code-dot-org/code-dot-org/pull/35088 for more details.
   end
 end

--- a/dashboard/db/migrate/20200602014720_revert_add_foreign_key_for_script_to_section.rb
+++ b/dashboard/db/migrate/20200602014720_revert_add_foreign_key_for_script_to_section.rb
@@ -2,14 +2,9 @@ require_relative '20200529004150_add_foreign_key_for_script_to_section.rb'
 
 class RevertAddForeignKeyForScriptToSection < ActiveRecord::Migration[5.0]
   def change
-    # Original migration was never successfully applied to production,
-    # which is the reason we need to revert in the first place.
-    return if Rails.env.production?
-
-    revert AddForeignKeyForScriptToSection
-
-    # An index was implicitly added when foreign key constraint added, and rails doesn't know to delete it
-    # as part of the revert: https://github.com/rails/rails/issues/20048
-    remove_index :sections, name: :fk_rails_5c2401d1cb
+    # The AddForeignKeyForScriptToSection migration failed in production because it
+    # takes too long to apply (roughly 4 minutes). This reverted it. As clean up we
+    # are removing the content of this and the original migrations.
+    # See https://github.com/code-dot-org/code-dot-org/pull/35088 for more details.
   end
 end


### PR DESCRIPTION
Clean up work to null out migrations to add and then revert the foreign key for script_id on sections. 

See revert PR for more details about the issue: https://github.com/code-dot-org/code-dot-org/pull/35088