### PR TITLE
Adding put_record_batch API to firehose.rb

### DIFF
--- a/dashboard/app/controllers/activities_controller.rb
+++ b/dashboard/app/controllers/activities_controller.rb
@@ -66,7 +66,7 @@ class ActivitiesController < ApplicationController
           params[:program].strip_utf8mb4
         )
         if share_filtering_error
-          FirehoseClient.instance.put_record(
+          FirehoseClient.instance.put_record(ANALYSIS_EVENTS_STREAM_NAME,
             study: 'share_filtering',
             study_group: 'v0',
             event: 'share_filtering_error',

--- a/dashboard/app/controllers/api/v1/regional_partners_controller.rb
+++ b/dashboard/app/controllers/api/v1/regional_partners_controller.rb
@@ -66,7 +66,7 @@ class Api::V1::RegionalPartnersController < ApplicationController
       result = 'no-state'
     end
 
-    FirehoseClient.instance.put_record(
+    FirehoseClient.instance.put_record(ANALYSIS_EVENTS_STREAM_NAME,
       study: 'regional-partner-search-log',
       event: result,
       data_string: zip_code,

--- a/dashboard/app/controllers/api/v1/schools_controller.rb
+++ b/dashboard/app/controllers/api/v1/schools_controller.rb
@@ -25,7 +25,7 @@ class Api::V1::SchoolsController < ApplicationController
       params[:use_new_search]
     )
     if Gatekeeper.allows('logSchoolSearch')
-      FirehoseClient.instance.put_record(
+      FirehoseClient.instance.put_record(ANALYSIS_EVENTS_STREAM_NAME,
         study: 'school-search-log',
         # TODO: (suresh) Change this to log request.headers["Referer"] (the URL of the page that the current
         # XMLHTTPRequest was embedded in) so we can identify which page ("yourschool", "account sign up", etc.) was

--- a/dashboard/app/controllers/api_controller.rb
+++ b/dashboard/app/controllers/api_controller.rb
@@ -461,7 +461,7 @@ class ApiController < ApplicationController
     original_data = params.require(:original_data)
     event = original_data['event']
     project_id = original_data['project_id'] || nil
-    FirehoseClient.instance.put_record(
+    FirehoseClient.instance.put_record(ANALYSIS_EVENTS_STREAM_NAME,
       study: 'firehose-error-unreachable',
       event: event,
       project_id: project_id,

--- a/dashboard/app/controllers/curriculum_tracking_pixel_controller.rb
+++ b/dashboard/app/controllers/curriculum_tracking_pixel_controller.rb
@@ -41,7 +41,7 @@ class CurriculumTrackingPixelController < ApplicationController
         lesson = split_url[2]
       end
 
-      FirehoseClient.instance.put_record(
+      FirehoseClient.instance.put_record(ANALYSIS_EVENTS_STREAM_NAME,
         study: STUDY_NAME,
         study_group: 'v1',
         event: EVENT_NAME,

--- a/dashboard/app/controllers/levels_controller.rb
+++ b/dashboard/app/controllers/levels_controller.rb
@@ -451,7 +451,7 @@ class LevelsController < ApplicationController
   # Gathers data on top pain points for level builders by logging error details
   # to Firehose / Redshift.
   def log_save_error(level)
-    FirehoseClient.instance.put_record(
+    FirehoseClient.instance.put_record(ANALYSIS_EVENTS_STREAM_NAME,
       study: 'level-save-error',
       # Make it easy to count most frequent field name in which errors occur.
       event: level.errors.keys.first,

--- a/dashboard/app/controllers/projects_controller.rb
+++ b/dashboard/app/controllers/projects_controller.rb
@@ -342,7 +342,7 @@ class ProjectsController < ApplicationController
       # continue as normal, as we only use this value for stats.
     end
 
-    FirehoseClient.instance.put_record(
+    FirehoseClient.instance.put_record(ANALYSIS_EVENTS_STREAM_NAME,
       study: 'project-views',
       event: project_view_event_type(iframe_embed, sharing),
       # allow cross-referencing with the storage_apps table.

--- a/dashboard/app/controllers/registrations_controller.rb
+++ b/dashboard/app/controllers/registrations_controller.rb
@@ -478,7 +478,7 @@ class RegistrationsController < Devise::RegistrationsController
 
   def log_account_deletion_to_firehose(current_user, dependent_users)
     # Log event for user initiating account deletion.
-    FirehoseClient.instance.put_record(
+    FirehoseClient.instance.put_record(ANALYSIS_EVENTS_STREAM_NAME,
       study: 'user-soft-delete-audit-v2',
       event: 'initiated-account-deletion',
       user_id: current_user.id,
@@ -491,7 +491,7 @@ class RegistrationsController < Devise::RegistrationsController
     # Log separate events for dependent users destroyed in user-initiated account deletion.
     # This should only happen for teachers.
     dependent_users.each do |user|
-      FirehoseClient.instance.put_record(
+      FirehoseClient.instance.put_record(ANALYSIS_EVENTS_STREAM_NAME,
         study: 'user-soft-delete-audit-v2',
         event: 'dependent-account-deletion',
         user_id: user[:id],

--- a/dashboard/app/helpers/levels_helper.rb
+++ b/dashboard/app/helpers/levels_helper.rb
@@ -813,7 +813,7 @@ module LevelsHelper
         error_message = I18n.t("errors.messages.teacher_must_accept_terms")
       else
         error_message = I18n.t("errors.messages.too_young")
-        FirehoseClient.instance.put_record(
+        FirehoseClient.instance.put_record(ANALYSIS_EVENTS_STREAM_NAME,
           study: "redirect_under_13",
           event: "student_with_no_teacher_redirected",
           user_id: current_user.id,

--- a/dashboard/app/helpers/users_helper.rb
+++ b/dashboard/app/helpers/users_helper.rb
@@ -52,7 +52,7 @@ module UsersHelper
   end
 
   def log_account_takeover_to_firehose(source_user:, destination_user:, type:, provider:, error: nil)
-    FirehoseClient.instance.put_record(
+    FirehoseClient.instance.put_record(ANALYSIS_EVENTS_STREAM_NAME,
       study: 'user-soft-delete-audit-v2',
       event: "#{type}-account-takeover", # Silent or OAuth takeover
       user_id: source_user.id, # User account being "taken over" (deleted)

--- a/dashboard/app/models/studio_person.rb
+++ b/dashboard/app/models/studio_person.rb
@@ -40,7 +40,7 @@ class StudioPerson < ActiveRecord::Base
       end
     end
 
-    FirehoseClient.instance.put_record(
+    FirehoseClient.instance.put_record(ANALYSIS_EVENTS_STREAM_NAME,
       {
         study: 'studio_person_audit',
         event: 'studio_person_merge',
@@ -79,7 +79,7 @@ class StudioPerson < ActiveRecord::Base
     studio_person.update!(emails: users.first.email)
     users.second.update!(studio_person: StudioPerson.create!(emails: users.second.email))
 
-    FirehoseClient.instance.put_record(
+    FirehoseClient.instance.put_record(ANALYSIS_EVENTS_STREAM_NAME,
       {
         study: 'studio_person_audit',
         event: 'studio_person_split',
@@ -104,7 +104,7 @@ class StudioPerson < ActiveRecord::Base
     return if emails_as_array.include? normalized_email
     update!(emails: (emails_as_array << normalized_email).join(','))
 
-    FirehoseClient.instance.put_record(
+    FirehoseClient.instance.put_record(ANALYSIS_EVENTS_STREAM_NAME,
       {
         study: 'studio_person_audit',
         event: 'studio_person_add_email_to_emails',

--- a/dashboard/lib/sign_up_tracking.rb
+++ b/dashboard/lib/sign_up_tracking.rb
@@ -47,7 +47,7 @@ module SignUpTracking
 
   def self.log_load_sign_up(session)
     event_name = new_sign_up_experience?(session) ? 'load-new-sign-up-page' : 'load-sign-up-page'
-    FirehoseClient.instance.put_record(
+    FirehoseClient.instance.put_record(ANALYSIS_EVENTS_STREAM_NAME,
       study: STUDY_NAME,
       study_group: study_group(session),
       event: event_name,
@@ -67,11 +67,11 @@ module SignUpTracking
         errors: user.errors&.full_messages
       }.to_json
     }
-    FirehoseClient.instance.put_record(tracking_data)
+    FirehoseClient.instance.put_record(ANALYSIS_EVENTS_STREAM_NAME, tracking_data)
   end
 
   def self.log_load_finish_sign_up(session, provider)
-    FirehoseClient.instance.put_record(
+    FirehoseClient.instance.put_record(ANALYSIS_EVENTS_STREAM_NAME,
       study: STUDY_NAME,
       study_group: study_group(session),
       event: "#{provider}-load-finish-sign-up-page",
@@ -80,7 +80,7 @@ module SignUpTracking
   end
 
   def self.log_cancel_finish_sign_up(session, provider)
-    FirehoseClient.instance.put_record(
+    FirehoseClient.instance.put_record(ANALYSIS_EVENTS_STREAM_NAME,
       study: STUDY_NAME,
       study_group: study_group(session),
       event: "#{provider}-cancel-finish-sign-up",
@@ -91,7 +91,7 @@ module SignUpTracking
   def self.log_oauth_callback(provider, session)
     return unless provider && session
     if session[:sign_up_tracking_expiration]&.future?
-      FirehoseClient.instance.put_record(
+      FirehoseClient.instance.put_record(ANALYSIS_EVENTS_STREAM_NAME,
         study: STUDY_NAME,
         study_group: study_group(session),
         event: "#{provider}-callback",
@@ -110,7 +110,7 @@ module SignUpTracking
         event: "#{provider}-sign-in",
         data_string: session[:sign_up_uid]
       }
-      FirehoseClient.instance.put_record(tracking_data)
+      FirehoseClient.instance.put_record(ANALYSIS_EVENTS_STREAM_NAME, tracking_data)
     end
     end_sign_up_tracking session
   end
@@ -130,7 +130,7 @@ module SignUpTracking
         errors: user.errors&.full_messages
       }.to_json
     }
-    FirehoseClient.instance.put_record(tracking_data)
+    FirehoseClient.instance.put_record(ANALYSIS_EVENTS_STREAM_NAME, tracking_data)
 
     end_sign_up_tracking session if user.persisted?
   end

--- a/dashboard/test/controllers/activities_controller_test.rb
+++ b/dashboard/test/controllers/activities_controller_test.rb
@@ -6,8 +6,9 @@ class ActivitiesControllerTest < ActionController::TestCase
   include UsersHelper
 
   def stub_firehose
-    FirehoseClient.instance.stubs(:put_record).with do |args|
+    FirehoseClient.instance.stubs(:put_record).with do |stream_name, args|
       @firehose_record = args
+      @firehose_stream_name = stream_name
       true
     end
   end
@@ -778,6 +779,7 @@ class ActivitiesControllerTest < ActionController::TestCase
     assert @firehose_record[:event], 'share_filtering_error'
     assert @firehose_record[:data_string], 'OpenURI::HTTPError: something broke'
     refute_nil @firehose_record[:data_json]["level_source_id"]
+    assert_equal ANALYSIS_EVENTS_STREAM_NAME, @firehose_stream_name
   end
 
   test 'sharing program with IO::EAGAINWaitReadable error logs' do
@@ -800,6 +802,7 @@ class ActivitiesControllerTest < ActionController::TestCase
     assert @firehose_record[:event], 'share_filtering_error'
     assert @firehose_record[:data_string], 'IO::EAGAINWaitReadable: Resource temporarily unavailable'
     refute_nil @firehose_record[:data_json]["level_source_id"]
+    assert_equal ANALYSIS_EVENTS_STREAM_NAME, @firehose_stream_name
   end
 
   test 'sharing program with swear word in Spanish rejects word' do

--- a/dashboard/test/controllers/curriculum_tracking_pixel_controller_test.rb
+++ b/dashboard/test/controllers/curriculum_tracking_pixel_controller_test.rb
@@ -2,8 +2,9 @@ require 'test_helper'
 
 class CurriculumTrackingPixelControllerTest < ActionController::TestCase
   def stub_firehose
-    FirehoseClient.instance.stubs(:put_record).with do |args|
+    FirehoseClient.instance.stubs(:put_record).with do |stream_name, args|
       @firehose_record = args
+      @firehose_stream_name = stream_name
       true
     end
   end
@@ -17,6 +18,7 @@ class CurriculumTrackingPixelControllerTest < ActionController::TestCase
     assert_equal parsed_result['csx'], "csf-18"
     assert_equal parsed_result['course_or_unit'], "pre-express"
     assert_equal parsed_result['lesson'], "11"
+    assert_equal ANALYSIS_EVENTS_STREAM_NAME, @firehose_stream_name
   end
 
   def assert_non_english_curriculum_page_view_logged(curriculum_url, user_id)
@@ -28,6 +30,7 @@ class CurriculumTrackingPixelControllerTest < ActionController::TestCase
     assert_equal parsed_result['csx'], "csf-1718"
     assert_equal parsed_result['course_or_unit'], "coursec"
     assert_equal parsed_result['lesson'], "10"
+    assert_equal ANALYSIS_EVENTS_STREAM_NAME, @firehose_stream_name
   end
 
   def refute_curriculum_page_view_logged

--- a/dashboard/test/integration/omniauth/utils.rb
+++ b/dashboard/test/integration/omniauth/utils.rb
@@ -132,15 +132,16 @@ module OmniauthCallbacksControllerTests
     # Skip firehose logging for these tests
     # Instead record the sequence of events logged, for easy validation in test cases.
     def stub_firehose
-      @firehose_records = []
-      FirehoseClient.instance.stubs(:put_record).with do |args|
-        @firehose_records << args
+      @firehose_requests = []
+      FirehoseClient.instance.stubs(:put_record).with do |stream_name, args|
+        @firehose_requests = [stream_name, args]
         true
       end
     end
 
     def assert_sign_up_tracking(expected_study_group, expected_events)
-      study_records = @firehose_records.select {|e| e[:study] == SignUpTracking::STUDY_NAME}
+      study_requests = @firehose_requests.select {|e| e[1][:study] == SignUpTracking::STUDY_NAME && e[0] == ANALYSIS_EVENTS_STREAM_NAME}
+      study_records = study_requests.map {|e| e[1]}
       study_groups = study_records.map {|e| e[:study_group]}.uniq.compact
       study_events = study_records.map {|e| e[:event]}
 
@@ -151,7 +152,8 @@ module OmniauthCallbacksControllerTests
     end
 
     def refute_sign_up_tracking
-      study_records = @firehose_records.select {|e| e[:study] == SignUpTracking::STUDY_NAME}
+      study_requests = @firehose_requests.select {|e| e[1][:study] == SignUpTracking::STUDY_NAME && e[0] == ANALYSIS_EVENTS_STREAM_NAME}
+      study_records = study_requests.map {|e| e[1]}
       assert_empty study_records
     end
   end

--- a/lib/cdo/azure_content_moderator.rb
+++ b/lib/cdo/azure_content_moderator.rb
@@ -104,7 +104,7 @@ class AzureContentModerator
 
   # Report to Firehose that we're about to make a request to Azure
   def report_request(image_url)
-    FirehoseClient.instance.put_record(
+    FirehoseClient.instance.put_record(ANALYSIS_EVENTS_STREAM_NAME,
       study: 'azure-content-moderation',
       study_group: 'v1',
       event: 'moderation-request',
@@ -116,7 +116,7 @@ class AzureContentModerator
 
   # Report the response we got from Azure to Firehose
   def report_response(image_url, rating, data, request_duration)
-    FirehoseClient.instance.put_record(
+    FirehoseClient.instance.put_record(ANALYSIS_EVENTS_STREAM_NAME,
       study: 'azure-content-moderation',
       study_group: 'v1',
       event: 'moderation-result',

--- a/lib/cdo/firehose.rb
+++ b/lib/cdo/firehose.rb
@@ -1,9 +1,10 @@
 require 'singleton'
 require 'aws-sdk-firehose'
+require 'dynamic_config/dcdo'
 
 # A wrapper client to the AWS Firehose service.
 # @example
-#   FirehoseClient.instance.put_record(
+#   FirehoseClient.instance.put_record(ANALYSIS_EVENTS_STREAM_NAME,
 #     {
 #       study: 'underwater basket weaving', # REQUIRED
 #       study_group: 'control',             # OPTIONAL
@@ -18,31 +19,109 @@ require 'aws-sdk-firehose'
 #       data_json: "{\"key\":\"value\"}"    # OPTIONAL
 #     }
 #   )
+# The `data` in the records which are sent to Firehose will be JSON encoded, so make sure your Redshift "Copy options"
+# have `json 'auto'`. This will tell Redshift to parse the data as a JSON blob.
+#
+# All records uploaded to Firehose will have some common attributes added to them which you can optionally tell Firehose
+# top copy.
+#   `created_at` timestamp - The timestamp of when this record was created.
+#   `environment` varchar(128) - The Ruby RACK_ENV which produced this record e.g. 'Production', 'Test'
+#   `device` varchar(1024) - JSON blob with information about the source of the record
+#    e.g. "server-side", {"useragent: ..."}
 
-STREAM_NAME = 'analysis-events'.freeze
+ANALYSIS_EVENTS_STREAM_NAME = 'analysis-events'.freeze
+# This Firehose stream is used for collecting data about string:url associations.
+I18N_STRING_TRACKING_EVENTS_STREAM_NAME = 'i18n-string-tracking-events'.freeze
+
+# Experiment name for using the Firehose put_record_batch API
+FIREHOSE_PUT_RECORD_BATCH_DCDO_KEY = 'firehose_put_record_batch'.freeze
 
 class FirehoseClient
   include Singleton
 
   REGION = 'us-east-1'.freeze
+  # Max number of records Firehose allows to be pushed in a batch.
+  FIREHOSE_PUT_MAX_RECORDS = 500
 
   # Initializes the @firehose to an AWS Firehose client.
   def initialize
-    if [:development, :test].include? rack_env
+    @rack_env = rack_env
+    if [:development, :test].include? @rack_env
       return
     end
     @firehose = Aws::Firehose::Client.new(region: REGION)
   end
 
+  # Posts records in batches to the given AWS Kinesis Firehose stream.
+  # @param stream_name [string] The Kinesis stream to send the data to.
+  # @param datas [array[hash]] The list of data to send to the stream.
+  def put_record_batch(stream_name, datas)
+    return if datas.nil? || datas.empty?
+    return unless Gatekeeper.allows('firehose', default: true)
+
+    # convert the given data into the format Firehose expects
+    records = []
+    datas.each do |data|
+      records << create_record_from_data(add_common_values(data))
+    end
+
+    # don't update our Firehose tables on dev or test environments.
+    if [:development, :test].include?(@rack_env)
+      CDO.log.info "Skipped sending record to #{stream_name}: "
+      CDO.log.info datas
+      return
+    end
+
+    # AWS Firehose batch_put has a limit on how many records can be uploaded
+    # at once. This will break up the list of records in multiple lists of
+    # the max batch size and then upload those.
+    i = 0
+    while i < records.size
+      # get a batch of records to send
+      batch_end = i + FIREHOSE_PUT_MAX_RECORDS
+      records_batch = records[i..batch_end - 1]
+      batch_response = @firehose.put_record_batch(
+        {
+          delivery_stream_name: stream_name,
+          records: records_batch
+        }
+      )
+      batch_response.request_responses.each do |response|
+        if response.error_code
+          Honeybadger.notify(error_code: response.error_code, error_message: response.error_message)
+        end
+      end
+      i += FIREHOSE_PUT_MAX_RECORDS
+    end
+  # Swallow and log all errors because an issue sending analytics should not prevent the caller from continuing.
+  rescue StandardError => error
+    # TODO(suresh): if the exception is Firehose ServiceUnavailableException, we should consider
+    # backing off and retrying.
+    # See http://docs.aws.amazon.com/sdkforruby/api/Aws/Firehose/Client.html#put_record-instance_method.
+    Honeybadger.notify(error)
+  end
+
+  # Posts a record to the given AWS Kinesis Firehose stream.
+  # @param stream_name [string] The Kinesis stream to send the data to.
+  # @param data [hash] The data to send to the stream.
+  def put_record(stream_name, data)
+    if DCDO.get(FIREHOSE_PUT_RECORD_BATCH_DCDO_KEY, false)
+      put_record_batch(stream_name, [data])
+    else
+      put_record_old(data)
+    end
+  end
+
+  # ----------------- START Old Code Remove when firehose_put_record_batch ends --------------------
   # Posts a record to the analytics stream.
   # @param data [hash] The data to insert into the stream.
-  def put_record(data)
+  def put_record_old(data)
     return unless Gatekeeper.allows('firehose', default: true)
 
     data_with_common_values = add_common_values(data)
 
-    if [:development, :test].include? rack_env
-      CDO.log.info "Skipped sending record to #{STREAM_NAME}: "
+    if [:development, :test].include? @rack_env
+      CDO.log.info "Skipped sending record to #{ANALYSIS_EVENTS_STREAM_NAME}: "
       CDO.log.info data
       return
     end
@@ -53,7 +132,7 @@ class FirehoseClient
     # for documentation.
     @firehose.put_record(
       {
-        delivery_stream_name: STREAM_NAME,
+        delivery_stream_name: ANALYSIS_EVENTS_STREAM_NAME,
         record: {data: data_with_common_values.to_json}
       }
     )
@@ -64,6 +143,7 @@ class FirehoseClient
     # See http://docs.aws.amazon.com/sdkforruby/api/Aws/Firehose/Client.html#put_record-instance_method.
     Honeybadger.notify(error)
   end
+  # ----------------- END Old Code Remove when firehose_put_record_batch ends --------------------
 
   private
 
@@ -73,10 +153,19 @@ class FirehoseClient
   def add_common_values(data)
     data_with_common_values = data.merge(
       created_at: DateTime.now,
-      environment: rack_env,
+      environment: @rack_env,
       device: 'server-side'.to_json
     )
-    data_with_common_values[user_id] ||= current_user.id if current_user
+    data_with_common_values[:user_id] ||= current_user.id if defined?(current_user) && current_user
     data_with_common_values
+  end
+
+  # Take the hash of data and converts it in the record structure which Firehose expects.
+  # @param data [hash] The data to add the key-value pairs to.
+  # @return [hash] a hash which the Firehose API will accept.
+  def create_record_from_data(data)
+    {
+      data: data.to_json
+    }
   end
 end

--- a/lib/cdo/image_moderation.rb
+++ b/lib/cdo/image_moderation.rb
@@ -21,7 +21,7 @@ module ImageModeration
     Honeybadger.notify(err)
 
     # Log to firehose as well, to have longer-lived data
-    FirehoseClient.instance.put_record(
+    FirehoseClient.instance.put_record(ANALYSIS_EVENTS_STREAM_NAME,
       study: 'azure-content-moderation',
       study_group: 'v1',
       event: 'moderation-error',

--- a/lib/cdo/safe_browsing.rb
+++ b/lib/cdo/safe_browsing.rb
@@ -54,7 +54,7 @@ module SafeBrowsing
 
     # Record to Firehose the response time of request rounded to thousandths of a second,
     # url, and human-readable response message
-    FirehoseClient.instance.put_record(
+    FirehoseClient.instance.put_record(ANALYSIS_EVENTS_STREAM_NAME,
       study: "safe-browsing-request",
       study_group: "v1",
       event: "api-response",

--- a/lib/test/cdo/test_firehose.rb
+++ b/lib/test/cdo/test_firehose.rb
@@ -1,0 +1,172 @@
+require_relative '../test_helper'
+require 'cdo/firehose'
+
+class TestFirehose < Minitest::Test
+  def stub_firehose
+    @firehose_mock = mock
+    FirehoseClient.instance.instance_variable_set(:@rack_env, :unit_test)
+    FirehoseClient.instance.instance_variable_set(:@firehose, @firehose_mock)
+  end
+
+  def unstub_firehose
+    FirehoseClient.instance.instance_variable_set(:@rack_env, :test)
+    FirehoseClient.instance.instance_variable_set(:@firehose, nil)
+  end
+
+  def setup
+    stub_firehose
+    DCDO.set(FIREHOSE_PUT_RECORD_BATCH_DCDO_KEY, true)
+  end
+
+  def teardown
+    unstub_firehose
+    DCDO.set(FIREHOSE_PUT_RECORD_BATCH_DCDO_KEY, false)
+  end
+
+  def test_instance_not_null
+    assert FirehoseClient.instance
+  end
+
+  def test_put_record_batch_given_test_environment_should_do_nothing
+    data = {test_key: 'key', test_value: 'value'}
+    FirehoseClient.instance.instance_variable_set(:@rack_env, :test)
+
+    @firehose_mock.expects(:put_record_batch).never
+    Honeybadger.expects(:notify).never
+
+    FirehoseClient.instance.put_record_batch('TEST_STREAM_NAME', [data])
+  end
+
+  # The :test and :development should not make actual calls to AWS.
+  def test_put_record_batch_given_no_records_should_do_nothing
+    @firehose_mock.expects(:put_record_batch).never
+    Honeybadger.expects(:notify).never
+
+    FirehoseClient.instance.put_record_batch('TEST_STREAM_NAME', [])
+  end
+
+  def test_put_record_batch_given_one_record_should_send_in_expected_format
+    datas = [{test_key_1: 'value_1', test_value_2: 'value_2'}]
+    test_stream_name = 'TEST_STREAM_NAME'
+    actual_request = nil
+    @firehose_mock.expects(:put_record_batch).with do |params|
+      # Capture the request being sent so we can verify it has the expected arguments.
+      actual_request = params
+    end.returns(generate_valid_batch_response(datas))
+    Honeybadger.expects(:notify).never
+
+    FirehoseClient.instance.put_record_batch(test_stream_name, datas)
+
+    assert_expected_put_record_batch_request(test_stream_name, datas, actual_request)
+  end
+
+  def test_put_record_batch_given_999_records_should_send_smaller_batches
+    datas = []
+    999.times do |_|
+      datas << {test_key_1: 'value_1', test_value_2: 'value_2'}
+    end
+    test_stream_name = 'TEST_STREAM_NAME'
+    # We expect multiple requests, so store all of them.
+    actual_requests = []
+    @firehose_mock.expects(:put_record_batch).with do |params|
+      # Capture the request being sent so we can verify it has the expected arguments.
+      actual_requests << params
+    end.returns(generate_valid_batch_response(datas)).twice
+    Honeybadger.expects(:notify).never
+
+    FirehoseClient.instance.put_record_batch(test_stream_name, datas)
+
+    # The firehose API has a batch limit of 500, so we need to verify that our
+    # calls to the API do no exceed 500.
+    assert_equal(500, actual_requests[0][:records].size)
+    assert_equal(499, actual_requests[1][:records].size)
+  end
+
+  # Delete this test once the FIREHOSE_PUT_RECORD_BATCH_DCDO_KEY experiment ends
+  def test_put_record_given_disabled_experiment_should_use_old_put_record_api
+    DCDO.set(FIREHOSE_PUT_RECORD_BATCH_DCDO_KEY, false)
+    data = {test_key_1: 'value_1', test_value_2: 'value_2'}
+    test_stream_name = 'TEST_STREAM_NAME'
+    actual_request = nil
+    # We can verify the old code is being used because it uses the put_record API
+    @firehose_mock.expects(:put_record).with do |params|
+      # Capture the request being sent so we can verify it has the expected arguments.
+      actual_request = params
+    end
+    Honeybadger.expects(:notify).never
+
+    FirehoseClient.instance.put_record(test_stream_name, data)
+
+    assert(actual_request)
+    # the old code could only send data to the analysis.events stream.
+    assert_equal(ANALYSIS_EVENTS_STREAM_NAME, actual_request[:delivery_stream_name])
+    record = actual_request[:record]
+    assert(record)
+    assert(valid_json?(record[:data]), "#{record[:data]} is not valid JSON")
+    actual_data = JSON.parse(record[:data])
+    assert_equal(data[:test_key_1], actual_data[:test_key_1.to_s])
+  end
+
+  def test_put_record_given_data_should_send_it
+    data = {test_key_1: 'value_1', test_value_2: 'value_2'}
+    test_stream_name = 'TEST_STREAM_NAME'
+    actual_request = nil
+    # Our put_record wrapper method calls the put_record_batch API with one record.
+    @firehose_mock.expects(:put_record_batch).with do |params|
+      # Capture the request being sent so we can verify it has the expected arguments.
+      actual_request = params
+    end.returns(generate_valid_batch_response([data]))
+    Honeybadger.expects(:notify).never
+
+    FirehoseClient.instance.put_record(test_stream_name, data)
+
+    assert_expected_put_record_batch_request(test_stream_name, [data], actual_request)
+  end
+
+  private
+
+  # creates a mock success response for the put_batch_record API
+  def generate_valid_batch_response(datas)
+    request_responses = []
+    datas.each do |_|
+      request_response = mock
+      request_response.stubs(:error_code).returns(nil)
+      request_responses << request_response
+    end
+    batch_response = mock
+    batch_response.stubs(:request_responses).returns(request_responses)
+    batch_response
+  end
+
+  def valid_json?(json)
+    return false unless json.is_a?(String)
+    JSON.parse(json)
+    true
+  rescue JSON::ParserError => _
+    return false
+  end
+
+  # Asserts that the given stream_name and data are found in the correct format when passed to the
+  # AWS Firehose put_record_batch API.
+  def assert_expected_put_record_batch_request(expected_stream_name, expected_datas, actual_request)
+    # The firehose API expects the request format to be:
+    # {
+    #   delivery_stream_name: 'some_firehose_stream_name',
+    #   records: [
+    #     {
+    #       data: '{ "json_key": "json_value"}'
+    #     }
+    #   ]
+    # }
+    assert(actual_request)
+    assert_equal(expected_stream_name, actual_request[:delivery_stream_name])
+    records = actual_request[:records]
+    assert(records)
+    assert_equal(expected_datas.size, records.size)
+    assert(valid_json?(records[0][:data]), "#{records[0][:data]} is not valid JSON")
+    actual_data = JSON.parse(records[0][:data])
+    # Verify the data we gave it is present in the request we send.
+    assert_equal(expected_datas[0][:test_key_1], actual_data[:test_key_1.to_s])
+    assert_equal(expected_datas[0][:test_value_2], actual_data[:test_value_2.to_s])
+  end
+end

--- a/shared/middleware/helpers/animation_bucket.rb
+++ b/shared/middleware/helpers/animation_bucket.rb
@@ -51,7 +51,7 @@ class AnimationBucket < BucketHelper
 
     # If the fallback is successful, let's notify Firehose, because we'd
     # like these to go down over time.
-    FirehoseClient.instance.put_record(
+    FirehoseClient.instance.put_record(ANALYSIS_EVENTS_STREAM_NAME,
       study: 'bucket-warning',
       study_group: self.class.name,
       event: 'served-latest-version',

--- a/shared/middleware/helpers/bucket_helper.rb
+++ b/shared/middleware/helpers/bucket_helper.rb
@@ -242,7 +242,7 @@ class BucketHelper
         'reject-comparing-older-main-json'
       end
 
-    FirehoseClient.instance.put_record(
+    FirehoseClient.instance.put_record(ANALYSIS_EVENTS_STREAM_NAME,
       study: 'project-data-integrity',
       study_group: 'v4',
       event: error_type,
@@ -411,7 +411,7 @@ class BucketHelper
           }
         )
         version_restored = true
-        FirehoseClient.instance.put_record(
+        FirehoseClient.instance.put_record(ANALYSIS_EVENTS_STREAM_NAME,
           study: 'bucket-warning',
           study_group: self.class.name,
           event: 'restore-specific-version',
@@ -425,7 +425,7 @@ class BucketHelper
         # It is probably deleted.
         # In this case, we want to do nothing.
         response = {status: 'NOT_MODIFIED'}
-        FirehoseClient.instance.put_record(
+        FirehoseClient.instance.put_record(ANALYSIS_EVENTS_STREAM_NAME,
           study: 'bucket-warning',
           study_group: self.class.name,
           event: 'restore-deleted-object',
@@ -476,7 +476,7 @@ class BucketHelper
   def log_restored_file(project_id:, user_id:, filename:, source_version_id:, new_version_id:)
     owner_id, storage_app_id = storage_decrypt_channel_id(project_id)
     key = s3_path owner_id, storage_app_id, filename
-    FirehoseClient.instance.put_record(
+    FirehoseClient.instance.put_record(ANALYSIS_EVENTS_STREAM_NAME,
       study: 'project-data-integrity',
       study_group: 'v4',
       event: 'version-restored',

--- a/shared/middleware/helpers/profanity_privacy_helper.rb
+++ b/shared/middleware/helpers/profanity_privacy_helper.rb
@@ -33,7 +33,7 @@ def title_profanity_privacy_violation(name, locale)
     ShareFiltering.find_name_failure(name, locale)
   rescue OpenURI::HTTPError, IO::EAGAINWaitReadable => error
     # If WebPurify or Geocoder are unavailable, default to viewable, but log error
-    FirehoseClient.instance.put_record(
+    FirehoseClient.instance.put_record(ANALYSIS_EVENTS_STREAM_NAME,
       study: 'share_filtering',
       study_group: 'v0',
       event: 'share_filtering_error',


### PR DESCRIPTION
Adding `put_record_batch` API to firehose.rb

* Adds support for batch requests to the AWS Firehose API.
* Adds support for using AWS Firehose streams other than analysis.events
* Adds unit tests for firehose.rb

## Context
I'm working on a different task to send batches of data to a new Firehose stream. I needed to update our existing Firehose client to support a batch API and also support a Firehose stream other than `analysis.evens`.

## Follow up work
* [Remove the DCDO experiment](https://codedotorg.atlassian.net/browse/FND-1190)

## Links
- [firehose put_record_batch docs](https://docs.aws.amazon.com/sdk-for-ruby/v3/api/Aws/Firehose/Client.html#put_record_batch-instance_method)

## Testing story
* Unit tests
* Manually tested that my new Firehose stream gets updates using this API.

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
