### PR TITLE
Restrict login type switching for empty sections

### DIFF
--- a/apps/src/templates/teacherDashboard/EditSectionForm.jsx
+++ b/apps/src/templates/teacherDashboard/EditSectionForm.jsx
@@ -167,15 +167,10 @@ class EditSectionForm extends Component {
       SectionLoginType.google_classroom
     ];
 
-    const validLoginTypes =
-      section.studentCount === 0
-        ? Object.values(SectionLoginType)
-        : sectionLoginTypeTransforms[section.loginType];
+    const validLoginTypes = sectionLoginTypeTransforms[section.loginType];
 
     const showLoginTypeField =
-      !isNewSection &&
-      (section.studentCount === 0 ||
-        changeableLoginTypes.includes(section.loginType));
+      !isNewSection && changeableLoginTypes.includes(section.loginType);
 
     if (!section) {
       return null;

--- a/apps/test/unit/templates/teacherDashboard/EditSectionFormTest.js
+++ b/apps/test/unit/templates/teacherDashboard/EditSectionFormTest.js
@@ -11,7 +11,7 @@ import {
 import {SectionLoginType} from '@cdo/apps/util/sharedConstants';
 
 describe('EditSectionForm', () => {
-  it('renders LoginTypeField with word and picture options for word sections - students', () => {
+  it('renders LoginTypeField with word and picture options for word sections with students', () => {
     const wrapper = mount(
       <EditSectionForm
         title="Edit section details"
@@ -48,7 +48,7 @@ describe('EditSectionForm', () => {
       SectionLoginType.picture
     );
   });
-  it('renders LoginTypeField with word and picture options for word sections - NO students', () => {
+  it('renders LoginTypeField with word and picture options for word sections without students', () => {
     const wrapper = mount(
       <EditSectionForm
         title="Edit section details"
@@ -85,7 +85,7 @@ describe('EditSectionForm', () => {
       SectionLoginType.picture
     );
   });
-  it('renders LoginTypeField with word and picture options for picture sections - students', () => {
+  it('renders LoginTypeField with word and picture options for picture sections with students', () => {
     const wrapper = mount(
       <EditSectionForm
         title="Edit section details"
@@ -122,7 +122,7 @@ describe('EditSectionForm', () => {
       SectionLoginType.picture
     );
   });
-  it('renders LoginTypeField with word and picture options for picture sections - NO students', () => {
+  it('renders LoginTypeField with word and picture options for picture sections without students', () => {
     const wrapper = mount(
       <EditSectionForm
         title="Edit section details"
@@ -159,7 +159,7 @@ describe('EditSectionForm', () => {
       SectionLoginType.picture
     );
   });
-  it('does not render LoginTypeField for personal email sections - students', () => {
+  it('does not render LoginTypeField for personal email sections with students', () => {
     const wrapper = mount(
       <EditSectionForm
         title="Edit section details"
@@ -184,7 +184,7 @@ describe('EditSectionForm', () => {
     const loginTypeField = wrapper.find('LoginTypeField');
     assert.equal(loginTypeField.length, 0);
   });
-  it('does not render LoginTypeField for personal email sections - NO students', () => {
+  it('does not render LoginTypeField for personal email sections without students', () => {
     const wrapper = mount(
       <EditSectionForm
         title="Edit section details"
@@ -209,7 +209,7 @@ describe('EditSectionForm', () => {
     const loginTypeField = wrapper.find('LoginTypeField');
     assert.equal(loginTypeField.length, 0);
   });
-  it('does not render LoginTypeField for Google Classroom sections - students', () => {
+  it('does not render LoginTypeField for Google Classroom sections with students', () => {
     const wrapper = mount(
       <EditSectionForm
         title="Edit section details"
@@ -231,7 +231,7 @@ describe('EditSectionForm', () => {
     const loginTypeField = wrapper.find('LoginTypeField');
     assert.equal(loginTypeField.length, 0);
   });
-  it('does not render LoginTypeField for Google Classroom sections - NO students', () => {
+  it('does not render LoginTypeField for Google Classroom sections without students', () => {
     const wrapper = mount(
       <EditSectionForm
         title="Edit section details"
@@ -256,7 +256,7 @@ describe('EditSectionForm', () => {
     const loginTypeField = wrapper.find('LoginTypeField');
     assert.equal(loginTypeField.length, 0);
   });
-  it('does not render LoginTypeField for Clever sections - students', () => {
+  it('does not render LoginTypeField for Clever sections with students', () => {
     const wrapper = mount(
       <EditSectionForm
         title="Edit section details"
@@ -278,7 +278,7 @@ describe('EditSectionForm', () => {
     const loginTypeField = wrapper.find('LoginTypeField');
     assert.equal(loginTypeField.length, 0);
   });
-  it('does not render LoginTypeField for Clever sections - NO students', () => {
+  it('does not render LoginTypeField for Clever sections without students', () => {
     const wrapper = mount(
       <EditSectionForm
         title="Edit section details"

--- a/apps/test/unit/templates/teacherDashboard/EditSectionFormTest.js
+++ b/apps/test/unit/templates/teacherDashboard/EditSectionFormTest.js
@@ -11,65 +11,7 @@ import {
 import {SectionLoginType} from '@cdo/apps/util/sharedConstants';
 
 describe('EditSectionForm', () => {
-  it('renders LoginTypeField with all login type options when there are no students', () => {
-    const wrapper = mount(
-      <EditSectionForm
-        title="Edit section details"
-        handleSave={() => {}}
-        handleClose={() => {}}
-        editSectionProperties={() => {}}
-        validGrades={['K', '1', '2', '3']}
-        validAssignments={validAssignments}
-        assignmentFamilies={assignmentFamilies}
-        sections={{}}
-        section={noStudentsSection}
-        isSaveInProgress={false}
-        stageExtrasAvailable={() => false}
-        hiddenStageState={{}}
-        updateHiddenScript={() => {}}
-        assignedScriptName="script name"
-      />
-    );
-    const loginTypeField = wrapper.find('LoginTypeField');
-    assert.equal(loginTypeField.length, 1);
-    assert.equal(loginTypeField.find('option').length, 5);
-    assert.equal(
-      loginTypeField
-        .find('option')
-        .at(0)
-        .props().value,
-      SectionLoginType.word
-    );
-    assert.equal(
-      loginTypeField
-        .find('option')
-        .at(1)
-        .props().value,
-      SectionLoginType.picture
-    );
-    assert.equal(
-      loginTypeField
-        .find('option')
-        .at(2)
-        .props().value,
-      SectionLoginType.email
-    );
-    assert.equal(
-      loginTypeField
-        .find('option')
-        .at(3)
-        .props().value,
-      SectionLoginType.google_classroom
-    );
-    assert.equal(
-      loginTypeField
-        .find('option')
-        .at(4)
-        .props().value,
-      SectionLoginType.clever
-    );
-  });
-  it('renders LoginTypeField with word and picture options for word sections', () => {
+  it('renders LoginTypeField with word and picture options for word sections - students', () => {
     const wrapper = mount(
       <EditSectionForm
         title="Edit section details"
@@ -106,7 +48,44 @@ describe('EditSectionForm', () => {
       SectionLoginType.picture
     );
   });
-  it('renders LoginTypeField with word and picture options for picture sections', () => {
+  it('renders LoginTypeField with word and picture options for word sections - NO students', () => {
+    const wrapper = mount(
+      <EditSectionForm
+        title="Edit section details"
+        handleSave={() => {}}
+        handleClose={() => {}}
+        editSectionProperties={() => {}}
+        validGrades={['K', '1', '2', '3']}
+        validAssignments={validAssignments}
+        assignmentFamilies={assignmentFamilies}
+        sections={{}}
+        section={noStudentsSection}
+        isSaveInProgress={false}
+        stageExtrasAvailable={() => false}
+        hiddenStageState={{}}
+        updateHiddenScript={() => {}}
+        assignedScriptName="script name"
+      />
+    );
+    const loginTypeField = wrapper.find('LoginTypeField');
+    assert.equal(loginTypeField.length, 1);
+    assert.equal(loginTypeField.find('option').length, 2);
+    assert.equal(
+      loginTypeField
+        .find('option')
+        .at(0)
+        .props().value,
+      SectionLoginType.word
+    );
+    assert.equal(
+      loginTypeField
+        .find('option')
+        .at(1)
+        .props().value,
+      SectionLoginType.picture
+    );
+  });
+  it('renders LoginTypeField with word and picture options for picture sections - students', () => {
     const wrapper = mount(
       <EditSectionForm
         title="Edit section details"
@@ -143,7 +122,44 @@ describe('EditSectionForm', () => {
       SectionLoginType.picture
     );
   });
-  it('does not render LoginTypeField for personal email sections', () => {
+  it('renders LoginTypeField with word and picture options for picture sections - NO students', () => {
+    const wrapper = mount(
+      <EditSectionForm
+        title="Edit section details"
+        handleSave={() => {}}
+        handleClose={() => {}}
+        editSectionProperties={() => {}}
+        validGrades={['K', '1', '2', '3']}
+        validAssignments={validAssignments}
+        assignmentFamilies={assignmentFamilies}
+        sections={{}}
+        section={{...noStudentsSection, loginType: SectionLoginType.picture}}
+        isSaveInProgress={false}
+        stageExtrasAvailable={() => false}
+        hiddenStageState={{}}
+        updateHiddenScript={() => {}}
+        assignedScriptName="script name"
+      />
+    );
+    const loginTypeField = wrapper.find('LoginTypeField');
+    assert.equal(loginTypeField.length, 1);
+    assert.equal(loginTypeField.find('option').length, 2);
+    assert.equal(
+      loginTypeField
+        .find('option')
+        .at(0)
+        .props().value,
+      SectionLoginType.word
+    );
+    assert.equal(
+      loginTypeField
+        .find('option')
+        .at(1)
+        .props().value,
+      SectionLoginType.picture
+    );
+  });
+  it('does not render LoginTypeField for personal email sections - students', () => {
     const wrapper = mount(
       <EditSectionForm
         title="Edit section details"
@@ -168,7 +184,32 @@ describe('EditSectionForm', () => {
     const loginTypeField = wrapper.find('LoginTypeField');
     assert.equal(loginTypeField.length, 0);
   });
-  it('does not render LoginTypeField for Google Classroom sections', () => {
+  it('does not render LoginTypeField for personal email sections - NO students', () => {
+    const wrapper = mount(
+      <EditSectionForm
+        title="Edit section details"
+        handleSave={() => {}}
+        handleClose={() => {}}
+        editSectionProperties={() => {}}
+        validGrades={['K', '1', '2', '3']}
+        validAssignments={validAssignments}
+        assignmentFamilies={assignmentFamilies}
+        sections={{}}
+        section={{
+          ...noStudentsSection,
+          loginType: SectionLoginType.email
+        }}
+        isSaveInProgress={false}
+        stageExtrasAvailable={() => false}
+        hiddenStageState={{}}
+        updateHiddenScript={() => {}}
+        assignedScriptName="script name"
+      />
+    );
+    const loginTypeField = wrapper.find('LoginTypeField');
+    assert.equal(loginTypeField.length, 0);
+  });
+  it('does not render LoginTypeField for Google Classroom sections - students', () => {
     const wrapper = mount(
       <EditSectionForm
         title="Edit section details"
@@ -190,7 +231,32 @@ describe('EditSectionForm', () => {
     const loginTypeField = wrapper.find('LoginTypeField');
     assert.equal(loginTypeField.length, 0);
   });
-  it('does not render LoginTypeField for Clever sections', () => {
+  it('does not render LoginTypeField for Google Classroom sections - NO students', () => {
+    const wrapper = mount(
+      <EditSectionForm
+        title="Edit section details"
+        handleSave={() => {}}
+        handleClose={() => {}}
+        editSectionProperties={() => {}}
+        validGrades={['K', '1', '2', '3']}
+        validAssignments={validAssignments}
+        assignmentFamilies={assignmentFamilies}
+        sections={{}}
+        section={{
+          ...noStudentsSection,
+          loginType: SectionLoginType.google_classroom
+        }}
+        isSaveInProgress={false}
+        stageExtrasAvailable={() => false}
+        hiddenStageState={{}}
+        updateHiddenScript={() => {}}
+        assignedScriptName="script name"
+      />
+    );
+    const loginTypeField = wrapper.find('LoginTypeField');
+    assert.equal(loginTypeField.length, 0);
+  });
+  it('does not render LoginTypeField for Clever sections - students', () => {
     const wrapper = mount(
       <EditSectionForm
         title="Edit section details"
@@ -202,6 +268,28 @@ describe('EditSectionForm', () => {
         assignmentFamilies={assignmentFamilies}
         sections={{}}
         section={{...testSection, loginType: SectionLoginType.clever}}
+        isSaveInProgress={false}
+        stageExtrasAvailable={() => false}
+        hiddenStageState={{}}
+        updateHiddenScript={() => {}}
+        assignedScriptName="script name"
+      />
+    );
+    const loginTypeField = wrapper.find('LoginTypeField');
+    assert.equal(loginTypeField.length, 0);
+  });
+  it('does not render LoginTypeField for Clever sections - NO students', () => {
+    const wrapper = mount(
+      <EditSectionForm
+        title="Edit section details"
+        handleSave={() => {}}
+        handleClose={() => {}}
+        editSectionProperties={() => {}}
+        validGrades={['K', '1', '2', '3']}
+        validAssignments={validAssignments}
+        assignmentFamilies={assignmentFamilies}
+        sections={{}}
+        section={{...noStudentsSection, loginType: SectionLoginType.clever}}
         isSaveInProgress={false}
         stageExtrasAvailable={() => false}
         hiddenStageState={{}}


### PR DESCRIPTION
Adding a student to your section doesn't update the client-side state that is checked by the `EditSectionForm` to see which login types are eligible to switch to without a refresh. As a stop-gap before refactoring how state is managed and shared across teacher dashboard tabs [LP-1479](https://codedotorg.atlassian.net/browse/LP-1479), we're restricting login type switches to be between picture <-> word type sections regardless whether the section has students or not [LP-1470](https://codedotorg.atlassian.net/browse/LP-1470). 