### PR TITLE
Unpublish failure modal

### DIFF
--- a/apps/i18n/common/en_us.json
+++ b/apps/i18n/common/en_us.json
@@ -1745,6 +1745,8 @@
   "unpluggedActivity": "Unplugged Activity",
   "unpublish": "Unpublish",
   "unpublishPending": "Unpublishing...",
+  "unpublishFailureTitle": "Unpublish Failed",
+  "unpublishFailureBody": "We failed to unpublish your library, \"{libraryName}.\" Please check your internet connection and try again.",
   "updateFirmware": "Update Firmware",
   "updateFirmwareExplanation": "This board is not using the most up-to-date version of the firmware. ",
   "updateFirmwareExplanationClassic": "For best results, please update the firmware by clicking on the button below.",

--- a/apps/src/templates/projects/LibraryTable.jsx
+++ b/apps/src/templates/projects/LibraryTable.jsx
@@ -11,6 +11,7 @@ import {tableLayoutStyles, sortableOptions} from '../tables/tableConstants';
 import {unpublishProjectLibrary} from './projectsRedux';
 import PersonalProjectsNameCell from './PersonalProjectsNameCell';
 import Button from '@cdo/apps/templates/Button';
+import BaseDialog from '@cdo/apps/templates/BaseDialog';
 import {reload} from '@cdo/apps/utils';
 
 export const COLUMNS = {
@@ -43,6 +44,13 @@ const styles = {
   },
   centeredCell: {
     textAlign: 'center'
+  },
+  dialog: {
+    padding: '0 15px 8px 15px'
+  },
+  dialogBody: {
+    fontSize: 18,
+    color: color.charcoal
   }
 };
 
@@ -84,7 +92,8 @@ class LibraryTable extends React.Component {
         direction: 'desc',
         position: 0
       }
-    }
+    },
+    unpublishFailedChannel: null
   };
 
   getSortingColumns = () => {
@@ -226,11 +235,16 @@ class LibraryTable extends React.Component {
         __useDeprecatedTag
         text={i18n.unpublish()}
         color={Button.ButtonColor.orange}
-        onClick={() =>
-          this.props.unpublishProjectLibrary(rowData.channel, error =>
-            error ? console.error(error) : reload()
-          )
-        }
+        onClick={() => {
+          this.setState({unpublishFailedChannel: null});
+          this.props.unpublishProjectLibrary(rowData.channel, error => {
+            if (error) {
+              this.setState({unpublishFailedChannel: rowData.channel});
+            } else {
+              reload();
+            }
+          });
+        }}
       />
     );
   };
@@ -260,6 +274,9 @@ class LibraryTable extends React.Component {
     })(libraries);
 
     const hasLibraries = libraries.length > 0;
+    const unpublishFailedLibrary = libraries.find(
+      library => library.channel === this.state.unpublishFailedChannel
+    );
 
     return (
       <div>
@@ -271,6 +288,21 @@ class LibraryTable extends React.Component {
         )}
         {!hasLibraries && (
           <h3 style={{textAlign: 'center'}}>{i18n.noLibraries()}</h3>
+        )}
+        {unpublishFailedLibrary && (
+          <BaseDialog
+            isOpen
+            handleClose={() => this.setState({unpublishFailedChannel: null})}
+            style={styles.dialog}
+            useUpdatedStyles
+          >
+            <h1>{i18n.unpublishFailureTitle()}</h1>
+            <p style={styles.dialogBody}>
+              {i18n.unpublishFailureBody({
+                libraryName: unpublishFailedLibrary.name
+              })}
+            </p>
+          </BaseDialog>
         )}
       </div>
     );

--- a/apps/src/templates/projects/generateFakeProjects.js
+++ b/apps/src/templates/projects/generateFakeProjects.js
@@ -113,3 +113,20 @@ export const stubFakeUnfeaturedProjectData = [
     unfeaturedAt: '2017-12-31T23:59:59.999-08:00'
   }
 ];
+
+export const stubFakeProjectLibraryData = [
+  {
+    name: 'Project w/ a Library',
+    type: 'applab',
+    channel: 'abc123',
+    publishedAt: '2015-12-31T23:59:59.999-08:00',
+    libraryName: 'My Cool Library'
+  },
+  {
+    name: 'Another Project Library',
+    type: 'applab',
+    channel: 'def456',
+    publishedAt: '2016-10-31T23:59:59.999-08:00',
+    libraryName: 'My Other Library'
+  }
+];

--- a/apps/test/unit/templates/projects/LibraryTableTest.js
+++ b/apps/test/unit/templates/projects/LibraryTableTest.js
@@ -1,0 +1,54 @@
+import React from 'react';
+import {shallow} from 'enzyme';
+import {expect} from '../../../util/reconfiguredChai';
+import {UnconnectedLibraryTable as LibraryTable} from '@cdo/apps/templates/projects/LibraryTable';
+import {stubFakeProjectLibraryData} from '@cdo/apps/templates/projects/generateFakeProjects';
+
+const DEFAULT_PROPS = {
+  personalProjectsList: [],
+  unpublishProjectLibrary: () => {}
+};
+
+describe('LibraryTable', () => {
+  it('renders null if personalProjectsList is falsy', () => {
+    const wrapper = shallow(
+      <LibraryTable {...DEFAULT_PROPS} personalProjectsList={null} />
+    );
+    expect(wrapper.html()).to.be.null;
+  });
+
+  it('renders a message if there are no libraries', () => {
+    let wrapper = shallow(<LibraryTable {...DEFAULT_PROPS} />);
+    expect(wrapper.text()).to.equal('You currently have no libraries.');
+
+    // Project that does not have a libraryName
+    const project = {channel: 'abc123', name: 'My Project'};
+    wrapper = shallow(
+      <LibraryTable {...DEFAULT_PROPS} personalProjectsList={[project]} />
+    );
+    expect(wrapper.text()).to.equal('You currently have no libraries.');
+  });
+
+  it('renders a table if there are libraries', () => {
+    const wrapper = shallow(
+      <LibraryTable
+        {...DEFAULT_PROPS}
+        personalProjectsList={stubFakeProjectLibraryData}
+      />
+    );
+    // Reactabular's Table.Provider renders as Provider
+    expect(wrapper.find('Provider').exists()).to.be.true;
+  });
+
+  it('renders a dialog if unpublishFailedLibrary is truthy', () => {
+    const projectLibraries = [...stubFakeProjectLibraryData];
+    const wrapper = shallow(
+      <LibraryTable
+        {...DEFAULT_PROPS}
+        personalProjectsList={projectLibraries}
+      />
+    );
+    wrapper.setState({unpublishFailedChannel: projectLibraries[0].channel});
+    expect(wrapper.find('BaseDialog').exists()).to.be.true;
+  });
+});


### PR DESCRIPTION
Display an error modal if unpublishing a library fails from the "My Libraries" tab at `/projects/libraries`:
<img width="1439" alt="Screen Shot 2020-06-04 at 9 19 18 PM" src="https://user-images.githubusercontent.com/9812299/83836750-470dec00-a6a9-11ea-984b-68c3a0e99762.png">

## Links

- [STAR-1050](https://codedotorg.atlassian.net/browse/STAR-1050)

## Testing story

Added unit tests for <LibraryTable/> component.

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
