### PR TITLE
Add data to principal approval emails

### DIFF
--- a/dashboard/app/views/pd/application/teacher_application_mailer/_partner_signature.html.haml
+++ b/dashboard/app/views/pd/application/teacher_application_mailer/_partner_signature.html.haml
@@ -8,7 +8,7 @@
   - else
     = link_to @application.regional_partner.name, CDO.code_org_url('educate/professional-learning/contact-regional-partner', CDO.default_scheme)
 - else
-  Liz Gauthier
+  Tawny Bradley
   %br
   = mail_to 'teacher@code.org'
   %br

--- a/dashboard/app/views/pd/application/teacher_application_mailer/_partner_signature.html.haml
+++ b/dashboard/app/views/pd/application/teacher_application_mailer/_partner_signature.html.haml
@@ -12,6 +12,6 @@
   %br
   = mail_to 'teacher@code.org'
   %br
-  Project Manager of District & School Recruitment
+  Outreach Program Manager
   %br
   Code.org

--- a/dashboard/app/views/pd/application/teacher_application_mailer/principal_approval.html.haml
+++ b/dashboard/app/views/pd/application/teacher_application_mailer/principal_approval.html.haml
@@ -11,6 +11,10 @@
   = @application.course_name
   curriculum during the school year.
   We are excited that this teacher is committed to computer science education!
+  = link_to 'Six different studies show', 'https://medium.com/@codeorg/cs-helps-students-outperform-in-school-college-and-workplace-66dd64a69536'
+  that children who study computer science perform better in other subjects,
+  excel at problem-solving,
+  and are 17% more likely to attend college.
 
 %p
   %strong

--- a/dashboard/app/views/pd/application/teacher_application_mailer/principal_approval_teacher_reminder.html.haml
+++ b/dashboard/app/views/pd/application/teacher_application_mailer/principal_approval_teacher_reminder.html.haml
@@ -22,6 +22,10 @@
     %li You hope to teach the course in the 2019-20 school year
 
 %p
+  = link_to('Six different studies show', 'https://medium.com/@codeorg/cs-helps-students-outperform-in-school-college-and-workplace-66dd64a69536') + ":"
+  children who study computer science perform better in other subjects,
+  excel at problem-solving,
+  and are 17% more likely to attend college.
   For more information about
   = link_to('Code.org', 'https://code.org') + "'s"
   professional development programs, please visit
@@ -29,6 +33,8 @@
   and refer to this
   = link_to('brochure', 'https://code.org/files/programs/codeorg-program-brochure.pdf')
   that highlights how to bring computer science to your school.
+  
+%p
   Please send any additional questions to your regional partner below.
   Thank you very much for your support of computer science for all!
 


### PR DESCRIPTION
We recently have compiled (or completed with partners) some really strong research backing up the value of learning CS.  We would like to add a reference to this research in the emails sent when asking for principal approval for teachers attending our professional learning programs. The six email templates we would like to update include these three emails sent to principals...

- [principal_approval__with_partner](https://test-studio.code.org/rails/mailers/pd/teacher_application_mailer/principal_approval__with_partner)
- [principal_approval__with_partner_no_contact](https://test-studio.code.org/rails/mailers/pd/teacher_application_mailer/principal_approval__with_partner_no_contact)
- [principal_approval__without_partner](https://test-studio.code.org/rails/mailers/pd/teacher_application_mailer/principal_approval__without_partner)

...and these three reminder emails sent to teachers:

- [principal_approval_teacher_reminder__with_partner](https://test-studio.code.org/rails/mailers/pd/teacher_application_mailer/principal_approval_teacher_reminder__with_partner)
- [principal_approval_teacher_reminder__with_partner_no_contact](https://test-studio.code.org/rails/mailers/pd/teacher_application_mailer/principal_approval_teacher_reminder__with_partner_no_contact)
- [principal_approval_teacher_reminder__without_partner](https://test-studio.code.org/rails/mailers/pd/teacher_application_mailer/principal_approval_teacher_reminder__without_partner)

## Links

<!--
  Any relevant links to external resources; ie, specification documents, jira
  items, related PRs, honeybadger errors, etc
-->

- [spec](https://docs.google.com/document/d/1q3S28_GomttVt-XwrMtRKJdHN_vDjpYpG2QrB44K_oQ/edit)