### PR TITLE
Revert bubble choice progress tab updates that weren't ready to go out 

### DIFF
--- a/apps/i18n/common/en_us.json
+++ b/apps/i18n/common/en_us.json
@@ -229,7 +229,6 @@
   "changeUserTypeModal_save_teacher": "Update to teacher account",
   "changeUserTypeModal_title": "Update account type",
   "changeUserTypeModal_unexpectedError": "An unexpected error has occurred.  Please wait a moment and try again.",
-  "choiceLevel": "Choice level",
   "choose": "Choose",
   "chooseActivity": "Choose from the following activities:",
   "chooseColumn": "Choose a column from \"{table}\"",

--- a/apps/src/code-studio/progressRedux.js
+++ b/apps/src/code-studio/progressRedux.js
@@ -520,13 +520,13 @@ const isCurrentLevel = (currentLevelId, level) => {
  * state.levelProgress
  */
 const levelWithStatus = (
-  {levelProgress, levelPairing = {}, currentLevelId, isSublevel = false},
+  {levelProgress, levelPairing = {}, currentLevelId},
   level
 ) => {
-  if (level.kind !== LevelKind.unplugged && !isSublevel) {
+  if (level.kind !== LevelKind.unplugged) {
     if (!level.title || typeof level.title !== 'number') {
       throw new Error(
-        'Expect all non-unplugged, non-bubble choice sublevel, levels to have a numerical title'
+        'Expect all non-unplugged levels to have a numerical title'
       );
     }
   }
@@ -549,22 +549,9 @@ export const levelsByLesson = ({
   currentLevelId
 }) =>
   stages.map(stage =>
-    stage.levels.map(level => {
-      let statusLevel = levelWithStatus(
-        {levelProgress, levelPairing, currentLevelId},
-        level
-      );
-
-      if (statusLevel.sublevels) {
-        statusLevel.sublevels = level.sublevels.map(sublevel =>
-          levelWithStatus(
-            {levelProgress, levelPairing, currentLevelId, isSublevel: true},
-            sublevel
-          )
-        );
-      }
-      return statusLevel;
-    })
+    stage.levels.map(level =>
+      levelWithStatus({levelProgress, levelPairing, currentLevelId}, level)
+    )
   );
 
 /**
@@ -621,11 +608,9 @@ export function statusForLevel(level, levelProgress) {
   // for each uid). When locked, they will end up not having a per-uid
   // test result, but will have a LOCKED_RESULT for the LevelGroup (which
   // is tracked by ids)
-  // BubbleChoice sublevels will have a level_id
   // Worth noting that in the majority of cases, ids will be a single
   // id here
-  const id =
-    level.uid || level.level_id || bestResultLevelId(level.ids, levelProgress);
+  const id = level.uid || bestResultLevelId(level.ids, levelProgress);
   let status = activityCssClass(levelProgress[id]);
   if (
     level.uid &&

--- a/apps/src/templates/progress/ProgressBubble.jsx
+++ b/apps/src/templates/progress/ProgressBubble.jsx
@@ -59,8 +59,7 @@ const styles = {
     width: SMALL_DOT_SIZE,
     height: SMALL_DOT_SIZE,
     borderRadius: SMALL_DOT_SIZE,
-    fontSize: 0,
-    alignItems: 'none'
+    fontSize: 0
   },
   smallDiamond: {
     width: SMALL_DIAMOND_SIZE,

--- a/apps/src/templates/progress/ProgressBubbleSet.jsx
+++ b/apps/src/templates/progress/ProgressBubbleSet.jsx
@@ -27,9 +27,6 @@ const styles = {
     // dot size, plus borders, plus margin, minus our height of "background"
     top: (DOT_SIZE + 4 + 6 - 10) / 2
   },
-  backgroundSublevel: {
-    top: 4
-  },
   backgroundDiamond: {
     top: (DIAMOND_DOT_SIZE + 4 + 12 - 10) / 2
   },
@@ -88,69 +85,48 @@ class ProgressBubbleSet extends React.Component {
     return false;
   };
 
-  renderBubble = (level, index, isSublevel) => {
+  render() {
     const {
       levels,
+      style,
       selectedSectionId,
       selectedStudentId,
       hideAssessmentIcon
     } = this.props;
 
     return (
-      <div style={styles.withBackground} key={index}>
-        <div
-          style={[
-            styles.background,
-            level.isConceptLevel && styles.backgroundDiamond,
-            isSublevel && styles.backgroundSublevel,
-            level.isUnplugged && styles.backgroundPill,
-            !isSublevel && index === 0 && styles.backgroundFirst,
-            !level.sublevels &&
-              index === levels.length - 1 &&
-              styles.backgroundLast
-          ]}
-        />
-        <div
-          style={[
-            styles.container,
-            level.isUnplugged && styles.pillContainer,
-            level.isConceptLevel && styles.diamondContainer
-          ]}
-        >
-          <ProgressBubble
-            level={level}
-            disabled={this.bubbleDisabled(level)}
-            smallBubble={isSublevel}
-            selectedSectionId={selectedSectionId}
-            selectedStudentId={selectedStudentId}
-            hideToolTips={this.props.hideToolTips}
-            pairingIconEnabled={this.props.pairingIconEnabled}
-            hideAssessmentIcon={hideAssessmentIcon}
-          />
-        </div>
-      </div>
-    );
-  };
-
-  render() {
-    const {levels, style} = this.props;
-    return (
       <div style={{...styles.main, ...style}}>
-        {levels.map((level, index) => {
-          return (
-            <span key={index}>
-              {this.renderBubble(level, index, false)}
-              {level.sublevels &&
-                level.sublevels.map((sublevel, index) => {
-                  return (
-                    <span key={index}>
-                      {this.renderBubble(sublevel, index, true)}
-                    </span>
-                  );
-                })}
-            </span>
-          );
-        })}
+        {levels.map((level, index) => (
+          <div style={styles.withBackground} key={index}>
+            <div
+              style={[
+                styles.background,
+                level.isConceptLevel && styles.backgroundDiamond,
+                level.isUnplugged && styles.backgroundPill,
+                index === 0 && styles.backgroundFirst,
+                index === levels.length - 1 && styles.backgroundLast
+              ]}
+            />
+            <div
+              style={[
+                styles.container,
+                level.isUnplugged && styles.pillContainer,
+                level.isConceptLevel && styles.diamondContainer
+              ]}
+            >
+              <ProgressBubble
+                level={level}
+                disabled={this.bubbleDisabled(level)}
+                smallBubble={false}
+                selectedSectionId={selectedSectionId}
+                selectedStudentId={selectedStudentId}
+                hideToolTips={this.props.hideToolTips}
+                pairingIconEnabled={this.props.pairingIconEnabled}
+                hideAssessmentIcon={hideAssessmentIcon}
+              />
+            </div>
+          </div>
+        ))}
       </div>
     );
   }

--- a/apps/src/templates/progress/ProgressLegend.jsx
+++ b/apps/src/templates/progress/ProgressLegend.jsx
@@ -217,13 +217,13 @@ export default class ProgressLegend extends Component {
               </div>
             </TD>
             <TD style={styles.rightBorder}>
-              <div style={styles.iconAndTextDivTop}>
+              <div style={styles.iconAndTextDiv}>
                 <FontAwesome icon="list-ul" style={styles.icon} />
                 {i18n.question()}
               </div>
+              {/* Blank space to keep spacing consistent */}
               <div style={styles.conAndTextDivBottom}>
-                <FontAwesome icon="sitemap" style={styles.icon} />
-                {i18n.choiceLevel()}
+                <FontAwesome icon="" style={styles.icon} />{' '}
               </div>
             </TD>
             <TD rowSpan={secondRowRowSpan}>

--- a/apps/src/templates/progress/progressHelpers.js
+++ b/apps/src/templates/progress/progressHelpers.js
@@ -178,8 +178,6 @@ export const processedLevel = level => {
     isUnplugged: level.display_as_unplugged,
     levelNumber: level.kind === LevelKind.unplugged ? undefined : level.title,
     isConceptLevel: level.is_concept_level,
-    bonus: level.bonus,
-    sublevels: level.sublevels,
-    bubbleChoiceLetter: level.letter
+    bonus: level.bonus
   };
 };

--- a/apps/src/templates/progress/progressTypes.js
+++ b/apps/src/templates/progress/progressTypes.js
@@ -8,8 +8,7 @@ export const levelType = PropTypes.shape({
   isUnplugged: PropTypes.bool,
   levelNumber: PropTypes.number,
   isCurrentLevel: PropTypes.bool,
-  isConceptLevel: PropTypes.bool,
-  sublevels: PropTypes.arrayOf(PropTypes.object)
+  isConceptLevel: PropTypes.bool
 });
 
 /**

--- a/apps/src/templates/sectionProgress/detail/VirtualizedDetailView.jsx
+++ b/apps/src/templates/sectionProgress/detail/VirtualizedDetailView.jsx
@@ -169,36 +169,17 @@ class VirtualizedDetailView extends Component {
         )}
         {rowIndex === 1 && columnIndex >= 1 && (
           <span style={styles.bubbleSet}>
-            {scriptData.stages[stageIdIndex].levels.map((level, i) => {
-              return (
-                <span key={i}>
-                  <FontAwesome
-                    icon={getIconForLevel(level, true)}
-                    style={
-                      level.isUnplugged
-                        ? progressStyles.unpluggedIcon
-                        : progressStyles.icon
-                    }
-                  />
-                  {level.sublevels &&
-                    level.sublevels.map((sublevel, i) => {
-                      return (
-                        <span
-                          className="filler"
-                          key={i}
-                          style={{
-                            width: 17,
-                            display: 'inline-block',
-                            color: color.background_gray
-                          }}
-                        >
-                          .
-                        </span>
-                      );
-                    })}
-                </span>
-              );
-            })}
+            {scriptData.stages[stageIdIndex].levels.map((level, i) => (
+              <FontAwesome
+                icon={getIconForLevel(level, true)}
+                style={
+                  level.isUnplugged
+                    ? progressStyles.unpluggedIcon
+                    : progressStyles.icon
+                }
+                key={i}
+              />
+            ))}
           </span>
         )}
       </div>

--- a/apps/src/templates/sectionProgress/sectionProgressRedux.js
+++ b/apps/src/templates/sectionProgress/sectionProgressRedux.js
@@ -334,11 +334,6 @@ export const getColumnWidthsForDetailView = state => {
         // Circle bubble
         width = width + PROGRESS_BUBBLE_WIDTH;
       }
-      if (levels[levelIndex].sublevels) {
-        // TODO: import SMALL_DOT_SIZE from progressStyles
-        // TODO: make consistent with multiGridConstants
-        width = width + levels[levelIndex].sublevels.length * 18;
-      }
     }
     columnLengths.push(width || 0);
   }

--- a/apps/test/unit/code-studio/progressReduxTest.js
+++ b/apps/test/unit/code-studio/progressReduxTest.js
@@ -53,9 +53,7 @@ const stageData = [
         previous: false,
         is_concept_level: false,
         bonus: false,
-        display_as_unplugged: true,
-        bubbleChoiceLetter: null,
-        sublevels: []
+        display_as_unplugged: true
       },
       {
         ids: [323],
@@ -67,9 +65,7 @@ const stageData = [
         url: 'http://localhost-studio.code.org:3000/s/course3/stage/1/puzzle/2',
         is_concept_level: false,
         bonus: false,
-        display_as_unplugged: false,
-        bubbleChoiceLetter: null,
-        sublevels: []
+        display_as_unplugged: false
       },
       {
         ids: [322],
@@ -82,9 +78,7 @@ const stageData = [
         next: [2, 1],
         is_concept_level: false,
         bonus: true,
-        display_as_unplugged: false,
-        bubbleChoiceLetter: null,
-        sublevels: []
+        display_as_unplugged: false
       }
     ],
     lesson_plan_html_url:
@@ -115,9 +109,7 @@ const stageData = [
         previous: [1, 3],
         is_concept_level: false,
         bonus: false,
-        display_as_unplugged: false,
-        bubbleChoiceLetter: null,
-        sublevels: []
+        display_as_unplugged: false
       },
       {
         ids: [339],
@@ -129,9 +121,7 @@ const stageData = [
         url: 'http://localhost-studio.code.org:3000/s/course3/stage/2/puzzle/2',
         is_concept_level: false,
         bonus: false,
-        display_as_unplugged: false,
-        bubbleChoiceLetter: null,
-        sublevels: []
+        display_as_unplugged: false
       },
       {
         ids: [341],
@@ -143,9 +133,7 @@ const stageData = [
         url: 'http://localhost-studio.code.org:3000/s/course3/stage/2/puzzle/3',
         is_concept_level: false,
         bonus: false,
-        display_as_unplugged: false,
-        bubbleChoiceLetter: null,
-        sublevels: []
+        display_as_unplugged: false
       }
     ],
     lesson_plan_html_url:
@@ -645,9 +633,7 @@ describe('progressReduxTest', () => {
             isCurrentLevel: false,
             isConceptLevel: false,
             paired: undefined,
-            bonus: false,
-            sublevels: [],
-            bubbleChoiceLetter: undefined
+            bonus: false
           },
           {
             status: 'not_tried',
@@ -663,9 +649,7 @@ describe('progressReduxTest', () => {
             isCurrentLevel: false,
             isConceptLevel: false,
             paired: undefined,
-            bonus: false,
-            sublevels: [],
-            bubbleChoiceLetter: undefined
+            bonus: false
           },
           {
             status: 'not_tried',
@@ -681,9 +665,7 @@ describe('progressReduxTest', () => {
             isCurrentLevel: false,
             isConceptLevel: false,
             paired: undefined,
-            bonus: true,
-            sublevels: [],
-            bubbleChoiceLetter: undefined
+            bonus: true
           }
         ],
         [
@@ -701,9 +683,7 @@ describe('progressReduxTest', () => {
             isCurrentLevel: false,
             isConceptLevel: false,
             paired: undefined,
-            bonus: false,
-            sublevels: [],
-            bubbleChoiceLetter: undefined
+            bonus: false
           },
           {
             status: 'perfect',
@@ -719,9 +699,7 @@ describe('progressReduxTest', () => {
             isCurrentLevel: false,
             isConceptLevel: false,
             paired: undefined,
-            bonus: false,
-            sublevels: [],
-            bubbleChoiceLetter: undefined
+            bonus: false
           },
           {
             status: 'attempted',
@@ -737,9 +715,7 @@ describe('progressReduxTest', () => {
             isCurrentLevel: false,
             isConceptLevel: false,
             paired: undefined,
-            bonus: false,
-            sublevels: [],
-            bubbleChoiceLetter: undefined
+            bonus: false
           }
         ]
       ];

--- a/apps/test/unit/templates/sectionProgress/VirtualizedDetailViewTest.js
+++ b/apps/test/unit/templates/sectionProgress/VirtualizedDetailViewTest.js
@@ -66,7 +66,6 @@ describe('VirtualizedSummaryView', () => {
         <UnconnectedVirtualizedDetailView {...defaultProps} />
       </Provider>
     );
-
     const studentNames = wrapper.find('SectionProgressNameCell');
     expect(studentNames.at(0)).to.have.text(studentData[0].name);
     expect(studentNames.at(1)).to.have.text(studentData[1].name);

--- a/apps/test/unit/templates/sectionProgress/sectionProgressReduxTest.js
+++ b/apps/test/unit/templates/sectionProgress/sectionProgressReduxTest.js
@@ -327,9 +327,7 @@ describe('sectionProgressRedux', () => {
                       is_concept_level: false,
                       title: 'hello world',
                       bonus: false,
-                      display_as_unplugged: false,
-                      bubbleChoiceLetter: undefined,
-                      sublevels: []
+                      display_as_unplugged: false
                     }
                   ]
                 }
@@ -351,9 +349,7 @@ describe('sectionProgressRedux', () => {
                 name: 'name',
                 progression: 'progression',
                 url: 'url',
-                bonus: false,
-                bubbleChoiceLetter: undefined,
-                sublevels: []
+                bonus: false
               }
             ]
           }

--- a/dashboard/app/helpers/users_helper.rb
+++ b/dashboard/app/helpers/users_helper.rb
@@ -168,39 +168,6 @@ module UsersHelper
         # if we have a contained level or BubbleChoice level, use that to represent progress
         level = Level.cache_find(level_id)
         sublevel_id = level.is_a?(BubbleChoice) ? level.best_result_sublevel(user)&.id : nil
-        if level.is_a?(BubbleChoice) # we have a parent level
-          # get progress for sublevels to save in levels hash
-          level.sublevels.each do |sublevel|
-            ul = user_levels_by_level.try(:[], sublevel.id)
-            completion_status = activity_css_class(ul)
-            # a UL is submitted if the state is submitted UNLESS it is a peer reviewable level that has been reviewed
-            submitted = !!ul.try(:submitted) &&
-              !(ul.level.try(:peer_reviewable?) && [ActivityConstants::REVIEW_REJECTED_RESULT, ActivityConstants::REVIEW_ACCEPTED_RESULT].include?(ul.best_result))
-            readonly_answers = !!ul.try(:readonly_answers)
-            locked = ul.try(:locked?, sl.lesson) || sl.lesson.lockable? && !ul
-
-            if completion_status == LEVEL_STATUS.not_tried
-              # for now, we don't allow authorized teachers to be "locked"
-              if locked && !user.authorized_teacher?
-                levels[level_id] = {
-                  status: LEVEL_STATUS.locked
-                }
-              end
-              next
-            end
-
-            levels[sublevel.id] = {
-              status: completion_status,
-              result: ul.try(:best_result) || 0,
-              submitted: submitted ? true : nil,
-              readonly_answers: readonly_answers ? true : nil,
-              paired: (paired_user_levels.include? ul.try(:id)) ? true : nil,
-              locked: locked ? true : nil,
-              last_progress_at: include_timestamp ? ul&.updated_at&.to_i : nil
-            }.compact
-          end
-
-        end
         contained_level_id = level.contained_levels.try(:first).try(:id)
 
         ul = user_levels_by_level.try(:[], sublevel_id || contained_level_id || level_id)

--- a/dashboard/app/models/script_level.rb
+++ b/dashboard/app/models/script_level.rb
@@ -303,10 +303,6 @@ class ScriptLevel < ActiveRecord::Base
       summary[:name] = level.display_name || level.name
     end
 
-    if bubble_choice?
-      summary[:sublevels] = level.summarize_sublevels(script_level: self)
-    end
-
     if Rails.application.config.levelbuilder_mode
       summary[:key] = level.key
       summary[:skin] = level.try(:skin)


### PR DESCRIPTION
I accidentally merged #34986 via the command line and then created a big ol' knot and couldn't revert cleanly. See this [discussion ](https://codedotorg.slack.com/archives/C0T0PNTM3/p1591388454029300) for details. 

I used `git checkout <commit> -- <files>` to create this PR that reverses the changes in #34986