### PR TITLE
fix broken pdf link

### DIFF
--- a/pegasus/sites.v3/code.org/public/educate/csp-course-updates.md.erb
+++ b/pegasus/sites.v3/code.org/public/educate/csp-course-updates.md.erb
@@ -240,7 +240,7 @@ We have forums for educators to discuss and trade ideas about the CS Principles 
 
 <div class="col-60">
 
-<p>Code.org is recognized by the <a href="http://collegeboard.org/APCSP", target=_"blank">College Board</a> as an endorsed provider of curriculum and professional development for AP Computer Science Principles. This endorsement affirms that all components of Code.org’s CS Principles offerings are aligned to the AP Curriculum framework standards and the AP CS Principles assessment. This affords schools access to resources including an <a href="https://code.org/files/CSPSyllabus2020.pdf ", target=_"blank">AP CS Principles syllabus</a> pre-approved by the College Board’s AP Course Audit, and officially recognized professional development that prepares teachers to teach this course.</p>
+<p>Code.org is recognized by the <a href="http://collegeboard.org/APCSP", target=_"blank">College Board</a> as an endorsed provider of curriculum and professional development for AP Computer Science Principles. This endorsement affirms that all components of Code.org’s CS Principles offerings are aligned to the AP Curriculum framework standards and the AP CS Principles assessment. This affords schools access to resources including an <a href="https://code.org/files/CSPSyllabus2020.pdf", target=_"blank">AP CS Principles syllabus</a> pre-approved by the College Board’s AP Course Audit, and officially recognized professional development that prepares teachers to teach this course.</p>
 
 </div>
 


### PR DESCRIPTION
Fixing a broken PDF link in response to a bug report (link had a space after the .pdf)

https://codeorg.zendesk.com/agent/tickets/283363

<!--
  Other aspects to consider. uncomment and add detail for any that seem necessary:
-->

<!-- ### Background -->
<!-- ### Privacy -->
<!-- ### Security -->
<!-- ### Caching -->
<!-- ### Deployment strategy -->
<!-- ### Future work -->

## Links

<!--
  Any relevant links to external resources; ie, specification documents, jira
  items, related PRs, honeybadger errors, etc
-->


## Testing story

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
