### PR TITLE
CRv2: Re-enable creating new prospects in Pardot

### DIFF
--- a/bin/cron/build_contact_rollups_v2
+++ b/bin/cron/build_contact_rollups_v2
@@ -7,6 +7,7 @@ require 'cdo/only_one'
 def main
   contact_rollups = ContactRollupsV2.new
   contact_rollups.collect_and_process_contacts
+  contact_rollups.sync_new_contacts_with_pardot
   contact_rollups.sync_updated_contacts_with_pardot
   contact_rollups.report_results
 end


### PR DESCRIPTION
We disabled adding new prospects to Pardot in https://github.com/code-dot-org/code-dot-org/pull/35040 because we went over the 3.2 mailable prospects limit in Pardot.

Since then, Marketing team had deleted more than 600K prospects to free up space ([slack discussion](https://codedotorg.slack.com/archives/G014FSM8VU3/p1591127736007300), this is a group message so unsure if everyone can see it). We can resume creating new prospects in Pardot now.