### PR TITLE
Revert "Temporarily disable parent email extraction"

### DIFF
--- a/dashboard/lib/contact_rollups_v2.rb
+++ b/dashboard/lib/contact_rollups_v2.rb
@@ -56,6 +56,10 @@ class ContactRollupsV2
       ContactRollupsRaw.extract_email_preferences
     end
 
+    @log_collector.time!('Extracts parent emails from dashboard.users') do
+      ContactRollupsRaw.extract_parent_emails
+    end
+
     @log_collector.time!('Processes all extracted data') do
       ContactRollupsProcessed.import_from_raw_table
     end

--- a/dashboard/test/lib/contact_rollups_v2_test.rb
+++ b/dashboard/test/lib/contact_rollups_v2_test.rb
@@ -38,6 +38,14 @@ class ContactRollupsV2Test < ActiveSupport::TestCase
     contact_record = ContactRollupsFinal.find_by_email(email_preference.email)
     refute_nil contact_record
     assert_equal 1, contact_record.data['opt_in']
+
+    # Verify parent email
+    pardot_memory_record = ContactRollupsPardotMemory.find_by(email: student_with_parent_email.parent_email, pardot_id: 2)
+    refute_nil pardot_memory_record
+    assert_equal({}, pardot_memory_record.data_synced)
+
+    contact_record = ContactRollupsFinal.find_by_email(student_with_parent_email.parent_email)
+    refute_nil contact_record
   end
 
   test 'sync updated contact' do


### PR DESCRIPTION
Reverts code-dot-org/code-dot-org#34969 as the fix for query time-out issue https://github.com/code-dot-org/code-dot-org/pull/35119 is merged.