### PR TITLE
Include subject on all PL Certificates

### DIFF
--- a/dashboard/app/models/pd/workshop.rb
+++ b/dashboard/app/models/pd/workshop.rb
@@ -327,7 +327,13 @@ class Pd::Workshop < ActiveRecord::Base
   end
 
   def friendly_subject
-    subject ? "#{subject} Workshop" : nil
+    if subject && (subject.downcase.include?("workshop") || subject == SUBJECT_TEACHER_CON)
+      subject
+    elsif subject
+      "#{subject} Workshop"
+    else
+      nil
+    end
   end
 
   # E.g. "March 1-3, 2017" or "March 30 - April 2, 2017"

--- a/dashboard/lib/pd/certificate_renderer.rb
+++ b/dashboard/lib/pd/certificate_renderer.rb
@@ -41,34 +41,22 @@ module Pd
     end
 
     private_class_method def self.course_name(workshop)
-      if workshop.csf?
-        [
-          {
-            string: workshop.course_name,
-            y: -30,
-            pointsize: 70,
-            width: 1600,
-            height: 100,
-          },
-          {
-            string: workshop.friendly_subject,
-            y: 65,
-            pointsize: 60,
-            width: 1600,
-            height: 100,
-          }
-        ]
-      else
-        [
-          {
-            string: workshop.course_name,
-            y: -10,
-            pointsize: 70,
-            width: 1600,
-            height: 100,
-          }
-        ]
-      end
+      [
+        {
+          string: workshop.course_name,
+          y: -30,
+          pointsize: 70,
+          width: 1600,
+          height: 100,
+        },
+        {
+          string: workshop.friendly_subject,
+          y: 65,
+          pointsize: 60,
+          width: 1600,
+          height: 100,
+        }
+      ]
     end
 
     private_class_method def self.pd_hours(workshop)

--- a/dashboard/test/controllers/pd/workshop_certificate_controller_test.rb
+++ b/dashboard/test/controllers/pd/workshop_certificate_controller_test.rb
@@ -66,6 +66,7 @@ class Pd::WorkshopCertificateControllerTest < ::ActionController::TestCase
     mock_image = expect_renders_certificate
     expect_renders_text(mock_image, enrollment.full_name)
     expect_renders_text(mock_image, 'CS Discoveries')
+    expect_renders_text(mock_image, '5-day Summer Workshop')
     @workshop.facilitators.each {|f| expect_renders_text(mock_image, f.name)}
     workshop_hours = Integer(@workshop.effective_num_hours)
     expect_renders_text(mock_image, workshop_hours.to_s)
@@ -87,6 +88,7 @@ class Pd::WorkshopCertificateControllerTest < ::ActionController::TestCase
     mock_image = expect_renders_certificate
     expect_renders_text(mock_image, enrollment.full_name)
     expect_renders_text(mock_image, 'CS Discoveries')
+    expect_renders_text(mock_image, 'Code.org TeacherCon')
     expect_renders_text(mock_image, Pd::CertificateRenderer::HARDCODED_CSD_FACILITATOR)
     workshop_hours = Integer(workshop.effective_num_hours)
     expect_renders_text(mock_image, workshop_hours.to_s)
@@ -108,6 +110,7 @@ class Pd::WorkshopCertificateControllerTest < ::ActionController::TestCase
     mock_image = expect_renders_certificate
     expect_renders_text(mock_image, enrollment.full_name)
     expect_renders_text(mock_image, 'CS Principles')
+    expect_renders_text(mock_image, 'Code.org TeacherCon')
     expect_renders_text(mock_image, Pd::CertificateRenderer::HARDCODED_CSP_FACILITATOR)
     workshop_hours = Integer(workshop.effective_num_hours)
     expect_renders_text(mock_image, workshop_hours.to_s)


### PR DESCRIPTION
We previously only included a workshop subject on PL certificates for CSF courses. This change adds including subject on all PL certificates. Previously we also always added "Workshop" at the end of the subject for certificates, in this change don't add "Workshop" if the subject already contains the word "workshop" or if it is teachercon.
New certificates look like this:
<img width="1259" alt="Screen Shot 2020-06-08 at 1 50 05 PM" src="https://user-images.githubusercontent.com/33666587/84083930-63ef3b80-a997-11ea-84e0-f930c9cbff3e.png">
<img width="1259" alt="Screen Shot 2020-06-08 at 1 48 09 PM" src="https://user-images.githubusercontent.com/33666587/84083933-65b8ff00-a997-11ea-89cd-2f02a74fdafe.png">
<img width="1259" alt="Screen Shot 2020-06-08 at 1 32 22 PM" src="https://user-images.githubusercontent.com/33666587/84083951-6b164980-a997-11ea-9047-86d5a90d61ed.png">


<!-- ### Background -->
<!-- ### Privacy -->
<!-- ### Security -->
<!-- ### Caching -->
<!-- ### Deployment strategy -->
<!-- ### Future work -->

## Links

<!--
  Any relevant links to external resources; ie, specification documents, jira
  items, related PRs, honeybadger errors, etc
-->

- [jira](https://codedotorg.atlassian.net/browse/PLC-907)

## Testing story
Validated that certificates render correctly on Chrome, Firefox and Safari. Also updated unit tests to reflect change.

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
