### PR TITLE
Add research data to welcome emails

### DIFF
--- a/dashboard/app/views/parent_mailer/parent_email_added_to_student_account.haml
+++ b/dashboard/app/views/parent_mailer/parent_email_added_to_student_account.haml
@@ -12,12 +12,6 @@
   including fun introductory tutorials, short educational videos, express courses, and open-ended projects.
 
 %p
-  You and your student can also participate in Code Break each Wednesday at 10 am PST / 1 pm ET.
-  Code Break is a live, interactive classroom with weekly challenges to engage students of all abilities,
-  even those without computers. Learn more about
-  %a{href:"https://code.org/break"}Code Break.
-
-%p
   Don’t have a computer? We can suggest some options that work great on mobile phones or tablets too!
   %a{href:"https://code.org/athome#apps"}See smartphone options.
 
@@ -34,6 +28,12 @@
 
 %h3
   Stay involved with CS Education
+%p
+  = link_to('Six different studies show', 'https://medium.com/@codeorg/cs-helps-students-outperform-in-school-college-and-workplace-66dd64a69536') + ":"
+  children who study computer science perform better in other subjects,
+  excel at problem-solving,
+  and are 17% more likely to attend college.
+  
 %p
   Every student in every school should have the opportunity to learn computer science.
   Our coding platform and K-12 computer science curriculum are the most broadly used in the world,

--- a/dashboard/app/views/parent_mailer/parent_email_added_to_student_account.haml
+++ b/dashboard/app/views/parent_mailer/parent_email_added_to_student_account.haml
@@ -33,7 +33,7 @@
   children who study computer science perform better in other subjects,
   excel at problem-solving,
   and are 17% more likely to attend college.
-  
+
 %p
   Every student in every school should have the opportunity to learn computer science.
   Our coding platform and K-12 computer science curriculum are the most broadly used in the world,

--- a/dashboard/app/views/teacher_mailer/new_teacher_email.html.haml
+++ b/dashboard/app/views/teacher_mailer/new_teacher_email.html.haml
@@ -43,6 +43,10 @@
   or reach out to
   %a{href:"mailto:support@code.org"}support@code.org
 %p
+  = link_to('Six different studies show', 'https://medium.com/@codeorg/cs-helps-students-outperform-in-school-college-and-workplace-66dd64a69536') + ":"
+  children who study computer science perform better in other subjects,
+  excel at problem-solving,
+  and are 17% more likely to attend college.
   You’re part of a movement of over 750,000 teachers and over 25 million students that have used
   Code.org globally, making it the most broadly used coding education platform and computer science
   curriculum in K-12. Thank you for all you do to give our children the opportunity to build their future.


### PR DESCRIPTION
We recently have compiled (or completed with partners) some really strong research backing up the value of learning CS. We would like to add a reference to this research in the emails sent when welcoming a new teacher or parent to our platform after they have either created a new account or linked their email address to their child's account, respectively. Note: the branch name is misleading - it should be 'add-research-data-to-welcome-emails'

## Links

<!--
  Any relevant links to external resources; ie, specification documents, jira
  items, related PRs, honeybadger errors, etc
-->

- [spec](https://docs.google.com/document/d/1q3S28_GomttVt-XwrMtRKJdHN_vDjpYpG2QrB44K_oQ/edit)