### PR TITLE
[Sprite Lab]Set Up Mini Toolbox Pointer Blocks

### DIFF
--- a/apps/i18n/spritelab/en_us.json
+++ b/apps/i18n/spritelab/en_us.json
@@ -1,4 +1,10 @@
 {
+  "clicked": "clicked ",
+  "clickedSprite": "clicked sprite",
+  "subject": "subject ",
+  "subjectSprite": "subject sprite",
+  "object": "object ",
+  "objectSprite": "object sprite",
   "errorLoadingAnimation": "It looks like we are having trouble loading your animation \"{animationName}\". Make sure you have a good internet connection and try reloading the page. If this problem persists, it is possible that this animation is broken. In this case, you may need to continue by removing the animation.",
   "reinfFeedbackMsg": "You're finished! Click \"Continue\" to move on to the next level.",
   "shareGame": "Share your game:",

--- a/apps/package.json
+++ b/apps/package.json
@@ -49,7 +49,7 @@
     "@babel/preset-react": "^7.0.0",
     "@cdo/interpreted": "link:../dashboard/config/libraries",
     "@code-dot-org/artist": "0.2.1",
-    "@code-dot-org/blockly": "3.5.15",
+    "@code-dot-org/blockly": "3.5.20",
     "@code-dot-org/bramble": "0.1.26",
     "@code-dot-org/craft": "0.2.2",
     "@code-dot-org/dance-party": "1.0.1",

--- a/apps/src/block_utils.js
+++ b/apps/src/block_utils.js
@@ -1030,15 +1030,32 @@ exports.createJsWrapperBlockCreator = function(
 
         // For mini-toolbox, indicate which blocks should receive the duplicate on drag
         // behavior and indicates the sibling block to shadow the value from
-        if (blockText === 'clicked {SPRITE}') {
+        if (this.type === 'gamelab_clickedSpritePointer') {
           this.setParentForCopyOnDrag('gamelab_spriteClickedSet');
-          this.setBlockToShadow('gamelab_allSpritesWithAnimation');
+          this.setBlockToShadow(
+            root =>
+              root.type === 'gamelab_spriteClicked' &&
+              root.getConnections_()[1] &&
+              root.getConnections_()[1].targetBlock()
+          );
         }
-        if (blockText === 'subject sprite') {
+        if (this.type === 'gamelab_subjectSpritePointer') {
           this.setParentForCopyOnDrag('gamelab_whenTouchingSet');
+          this.setBlockToShadow(
+            root =>
+              root.type === 'gamelab_checkTouching' &&
+              root.getConnections_()[1] &&
+              root.getConnections_()[1].targetBlock()
+          );
         }
-        if (blockText === 'object sprite') {
+        if (this.type === 'gamelab_objectSpritePointer') {
           this.setParentForCopyOnDrag('gamelab_whenTouchingSet');
+          this.setBlockToShadow(
+            root =>
+              root.type === 'gamelab_checkTouching' &&
+              root.getConnections_()[2] &&
+              root.getConnections_()[2].targetBlock()
+          );
         }
 
         interpolateInputs(blockly, this, inputRows, inputTypes, inline);

--- a/apps/src/p5lab/spritelab/blocks.js
+++ b/apps/src/p5lab/spritelab/blocks.js
@@ -10,6 +10,7 @@ import {animationSourceUrl} from '../animationListModule';
 import {changeInterfaceMode} from '../actions';
 import {Goal, show} from '../AnimationPicker/animationPickerModule';
 import i18n from '@cdo/locale';
+import spritelabMsg from '@cdo/spritelab/locale';
 
 function sprites() {
   const animationList = getStore().getState().animationList;
@@ -194,9 +195,27 @@ const customInputTypes = {
   },
   spritePointer: {
     addInput(blockly, block, inputConfig, currentInputRow) {
+      switch (block.type) {
+        case 'gamelab_clickedSpritePointer':
+          block.shortString = spritelabMsg.clicked();
+          block.longString = spritelabMsg.clickedSprite();
+          break;
+        case 'gamelab_subjectSpritePointer':
+          block.shortString = spritelabMsg.subject();
+          block.longString = spritelabMsg.subjectSprite();
+          break;
+        case 'gamelab_objectSpritePointer':
+          block.shortString = spritelabMsg.object();
+          block.longString = spritelabMsg.objectSprite();
+          break;
+        default:
+          // unsupported block for spritePointer, leave the block text blank
+          block.shortString = '';
+          block.longString = '';
+      }
       currentInputRow
-        .appendTitle(inputConfig.label)
-        .appendTitle(new Blockly.FieldImage('', 32, 32), inputConfig.name);
+        .appendTitle(block.longString)
+        .appendTitle(new Blockly.FieldImage('', 1, 1), inputConfig.name);
     },
     generateCode(block, arg) {
       switch (block.type) {

--- a/apps/yarn.lock
+++ b/apps/yarn.lock
@@ -1526,10 +1526,10 @@
   version "0.2.1"
   resolved "https://registry.yarnpkg.com/@code-dot-org/artist/-/artist-0.2.1.tgz#fcfe7ea5cfb3f19ddb6b912e70e922ba4b7ef0b1"
 
-"@code-dot-org/blockly@3.5.15":
-  version "3.5.15"
-  resolved "https://registry.yarnpkg.com/@code-dot-org/blockly/-/blockly-3.5.15.tgz#6995cefddb2fd8472e5054a035b55eaae37fb269"
-  integrity sha512-e4Tg0CzoofUQBRjS9pcwBzzHidVsPp8fiNC+j5/srHubwef+PiK1NxeELj20YoBehefii+RQ20qM6HtxFXZY/Q==
+"@code-dot-org/blockly@3.5.20":
+  version "3.5.20"
+  resolved "https://registry.yarnpkg.com/@code-dot-org/blockly/-/blockly-3.5.20.tgz#fac377381e98e52a79d8c52d6b969ac9697dc86b"
+  integrity sha512-kS8aU+P6todFXK4UqGvRLdWAKmxRWtPSW+IQ7/G2SkPEVdDadsdX47COWMviiLseD7Bh4e8Pg2aA7wdwJ/iGMQ==
 
 "@code-dot-org/bramble@0.1.26":
   version "0.1.26"


### PR DESCRIPTION
This is basically the same as https://github.com/code-dot-org/code-dot-org/pull/34975, but hopefully working this time. Also includes a change to have a short and long version of each block text so that we have an appropriate placeholder word when there's no sprite block to shadow. 

This PR contains a blockly version bump that includes:
https://github.com/code-dot-org/blockly/pull/218
https://github.com/code-dot-org/blockly/pull/219
https://github.com/code-dot-org/blockly/pull/220
https://github.com/code-dot-org/blockly/pull/221
https://github.com/code-dot-org/blockly/pull/222

![Jun-08-2020 15-30-09](https://user-images.githubusercontent.com/8787187/84088807-42478180-a9a2-11ea-9eac-bc5dec11f4ec.gif)

![Jun-08-2020 15-31-14](https://user-images.githubusercontent.com/8787187/84088790-365bbf80-a9a2-11ea-8ca7-6e9175eb5637.gif)


<!--
  Other aspects to consider. uncomment and add detail for any that seem necessary:
-->

<!-- ### Background -->
<!-- ### Privacy -->
<!-- ### Security -->
<!-- ### Caching -->
<!-- ### Deployment strategy -->
<!-- ### Future work -->

## Links

<!--
  Any relevant links to external resources; ie, specification documents, jira
  items, related PRs, honeybadger errors, etc
-->
- [jira](https://codedotorg.atlassian.net/browse/STAR-1091)

## Testing story

<!--
  Does your change include appropriate tests?

  If so, please describe how the tests included in this PR are sufficient

  If not, please explain why this change does not need to be tested.
-->

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
 