### PR TITLE
SafeNames does not abbreviate first names

### DIFF
--- a/lib/test/cdo/test_safe_names.rb
+++ b/lib/test/cdo/test_safe_names.rb
@@ -26,8 +26,17 @@ class SafeNamesTest < Minitest::Test
     # Handles names that have other names as their strict subset
     verify(['Thor', 'Thor Odinson'], ['Thor', 'Thor O'])
 
+    # Does not abbreviate first names when one is a strict subset of another
+    verify(['Anna', 'Annabel', 'Annabelle'], ['Anna', 'Annabel', 'Annabelle'])
+    # ...with or without last names
+    verify(
+      ['Ann', 'Anna Lemon', 'Annabel Lime', 'Annabelle Citron'],
+      ['Ann', 'Anna', 'Annabel', 'Annabelle']
+    )
+
     # Preserves duplicate names
     verify(['John Smith', 'John Smith'], ['John', 'John'])
+    verify(['John Smith', 'John Smith', 'John Smythe'], ['John Smi', 'John Smi', 'John Smy'])
 
     # Sorted by name
     verify(['Beth A', 'Alex Able', 'Cathy', 'Alex Aaron'], ['Alex Aa', 'Alex Ab', 'Beth', 'Cathy'])


### PR DESCRIPTION
[FND-1146](https://codedotorg.atlassian.net/browse/FND-1146): Fix the name abbreviation logic on section login page.

There were some documented problems with name abbreviations when one first-name was a strict subset of another.  For instance, for the set of names `Anna, Annabel, Annabelle, Brad, Bradford, Bradlee, Bradley, Branford, Maria, Mariamu` the login page would show the following:

![Screenshot from 2020-06-08 13-07-00](https://user-images.githubusercontent.com/1615761/84086947-e844bd00-a99d-11ea-9752-0904797636ee.png)

Notice that `Anna` and `Maria` have been reduced to one character, and `Annabel` has oddly been truncated to five characters.

The logic abbreviating names here is designed to find the smallest unique prefix that can be used to tell two students with the same name apart; for example, reducing `Tom Sawyer, Tom Smith` to `Tom Sa, Tom Sm`.  However, we never want to abbreviate a first name, and if the first name is already unique, we should be able to use it without trying to compute a minimum prefix.

We already had logic to that effect here:

```rb
    # If the first name is unique, simply use that
    return first_name if trie.words(first_name).count == 1
```

But `trie.words` gets all the words that start with a particular string.  If you put in `John Smith` and `Johnny Smith` then trie.words("John").count is 2 even though the first name is unique.

I've added a different check for first-name-uniqueness to fix this behavior.  Now the login page looks like this:

![Screenshot from 2020-06-08 14-08-09](https://user-images.githubusercontent.com/1615761/84087036-217d2d00-a99e-11ea-81bc-e0d1b790381c.png)


<!--
  Your description goes here: A summary of the change, including any relevant motivation and context.

  If relevant, include a description both of the existing behavior and of the new behavior.
-->

<!--
  Other aspects to consider. uncomment and add detail for any that seem necessary:
-->

<!-- ### Background -->
<!-- ### Privacy -->
<!-- ### Security -->
<!-- ### Caching -->
<!-- ### Deployment strategy -->
<!-- ### Future work -->

## Testing story

I've extended the existing test with new assertions capturing known problem cases.

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
