### PR TITLE
Update only_one to use flock (advisory lock) instead of pidfile

### DIFF
--- a/lib/cdo/only_one.rb
+++ b/lib/cdo/only_one.rb
@@ -1,21 +1,5 @@
+# Ensure only one instance of a Ruby script is running at a time,
+# using `File#flock` (advisory lock) on the script path.
 def only_one_running?(script)
-  pidfile = "#{File.expand_path(script)}.pid"
-  if File.exist?(pidfile)
-    oldpid = File.read(pidfile).to_i
-    # does that process exist?
-    exists = true
-    begin
-      Process.kill(0, oldpid)
-    rescue Errno::ESRCH
-      File.delete(pidfile)
-      exists = false
-    rescue ::Exception => e # for example on EPERM (process exists but does not belong to us)
-      $stderr.puts "Could not run process, PID file #{pidfile} exists: #{e}"
-      exists = true
-    end
-    return false if exists
-  end
-  File.open(pidfile, "w") {|f| f.puts $$}
-  at_exit {File.unlink(pidfile)}
-  true
+  File.new(script).flock(File::LOCK_NB | File::LOCK_EX)
 end

--- a/lib/test/cdo/test_only_one.rb
+++ b/lib/test/cdo/test_only_one.rb
@@ -1,0 +1,20 @@
+require_relative '../test_helper'
+require 'cdo/only_one'
+
+class OnlyOneTest < Minitest::Test
+  def only_one?
+    !!only_one_running?(__FILE__)
+  end
+
+  def test_only_one
+    r, w = IO.pipe
+    pid = fork do
+      w.puts only_one? # true
+      Process.wait(fork {w.puts only_one?}) # false
+    end
+    Process.wait pid
+    w.puts only_one? # true
+    w.close
+    assert_equal %w[true false true], r.readlines(chomp: true)
+  end
+end


### PR DESCRIPTION
The implementation of `only_one.rb` (`#only_one_running?`) reads a pidfile and (if it exists) sends a `kill 0` to see if a previously-started process is still running. If not, the current process writes its PID to that file and deletes it with an `at_exit` hook on shutdown.

This script had two (known remaining) issues, both related to the `at_exit` hook deleting the pidfile on shutdown:
1. Forked processes also call the `at_exit` hook when they exit, causing the file to be deleted before the process actually exited;
2. A process can hang in between the `at_exit` hook and the process actually shutting down, causing the file to be deleted before the process actually exited.

These issues could be dealt with by fixing them individually (see #35069 for a fix to 1), or by removing the `at_exit` entirely and depending only on the `kill 0` rather than the file-existence to determine if another process is still running.

This PR offers an approach using advisory file locks (see [`flock(2)`](https://man7.org/linux/man-pages/man2/flock.2.html)) via [`File#flock`](https://ruby-doc.org/core/File.html#method-i-flock), which ends up being simpler than the approach using pidfiles and `kill 0`.

## Testing story

We didn't have existing test coverage for this script, so I added a simple test `OnlyOneTest` covering basic behavior using `fork` that fails on `staging` but passes with either this PR or #35069.

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
