### PR TITLE
Fixed encoding issue for student name in header

### DIFF
--- a/shared/haml/user_header.haml
+++ b/shared/haml/user_header.haml
@@ -90,10 +90,8 @@
         var dataName = element.dataset.shortname;
         var id = element.dataset.id;
         if (storedName && !id) {
-          // unescape the storedName to support non-ASCII characters, but make
-          // sure to use textContent rather than innerHTML so the unescape
-          // doesn't create an HTML injection vulnerability.
-          element.textContent = element.textContent.replace(dataName, unescape(storedName));
+          // Use textContent to prevent HTML injection vulnerability
+          element.textContent = element.textContent.replace(dataName, decodeURI(storedName));
         }
       }
     }


### PR DESCRIPTION
We cached a student's display name in a cookie so it is easily
accessible by front-end javascript. But if a student has
accented latin characters in their name, then their name will be URI
encoded in the cookie. When we were displaying the name stored in the
cookie, we were incorrectly treating it as an HTML escaped String. This
change uses URI decoding instead.

## Links
- [jira](https://codedotorg.atlassian.net/browse/FND-1042)

## Screenshots
Student name should be "Caoimhín"
### Before
![image](https://user-images.githubusercontent.com/1372238/84112426-431afa80-aa18-11ea-99a0-fe94ebd0ed9d.png)

### After
![image](https://user-images.githubusercontent.com/1372238/84112295-fd5e3200-aa17-11ea-9d09-22370e306d35.png)

## Testing story
* manually tested using bug repro steps

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
