### PR TITLE
Update style of code to match linter requirements

### DIFF
--- a/dashboard/app/views/levels/editors/fields/_netsim_editors.html.haml
+++ b/dashboard/app/views/levels/editors/fields/_netsim_editors.html.haml
@@ -68,7 +68,7 @@
     %table.checkboxes
       %tr
         %td= boolean_check_box f, :automatic_receive
-        %td(nowrap)= f.label :automatic_receive, 'Auto-receive'
+        %td{style: "white-space: nowrap"}= f.label :automatic_receive, 'Auto-receive'
         %td
           Whether the local node will watch the message table and automatically
           pick up messages directed to itself, dumping them into the message log.
@@ -76,13 +76,13 @@
           manual 'receive' button)
       %tr
         %td= boolean_check_box f, :broadcast_mode
-        %td(nowrap)= f.label :broadcast_mode, 'Broadcast Mode'
+        %td{style: "white-space: nowrap"}= f.label :broadcast_mode, 'Broadcast Mode'
         %td
           Turns routers into "rooms" where any packets sent will go to everyone
           present in the room. (Recommended to hide the Router tab when using this)
       %tr
         %td= boolean_check_box f, :connected_routers
-        %td(nowrap)= f.label :connected_routers, 'Connected routers'
+        %td{style: "white-space: nowrap"}= f.label :connected_routers, 'Connected routers'
         %td
           When unchecked, each router or room exists in isolation and will have
           no contact with other routers or rooms.  When checked, it is possible


### PR DESCRIPTION
Updated the code to match the requirements of the linter. Error was:

```
'RAILS_ENV=staging RACK_ENV=staging bundle exec haml-lint dashboard pegasus' returned 65
warning: parser/current is loading parser/ruby25, which recognizes
warning: 2.5.0-compliant syntax, but you are running 2.5.7.
warning: please see https://github.com/whitequark/parser#compatibility-with-ruby-mri.
dashboard/app/views/levels/editors/fields/_netsim_editors.html.haml:71 [W] HtmlAttributes: Prefer the hash attributes syntax (%tag{ lang: 'en' }) over HTML attributes syntax (%tag(lang=en))
dashboard/app/views/levels/editors/fields/_netsim_editors.html.haml:79 [W] HtmlAttributes: Prefer the hash attributes syntax (%tag{ lang: 'en' }) over HTML attributes syntax (%tag(lang=en))
dashboard/app/views/levels/editors/fields/_netsim_editors.html.haml:85 [W] HtmlAttributes: Prefer the hash attributes syntax (%tag{ lang: 'en' }) over HTML attributes syntax (%tag(lang=en))
```

Checked that it looked the same before and after

Before
<img width="987" alt="Screen Shot 2020-06-09 at 2 18 34 PM" src="https://user-images.githubusercontent.com/208083/84184864-1c7eb300-aa5c-11ea-8bf5-b2c45ddb277e.png">

After
<img width="996" alt="Screen Shot 2020-06-09 at 2 18 51 PM" src="https://user-images.githubusercontent.com/208083/84184889-26a0b180-aa5c-11ea-9543-04ac46fbe177.png">
