### PR TITLE
CRv2: Add CloudWatch metrics

### DIFF
--- a/bin/cron/build_contact_rollups_v2
+++ b/bin/cron/build_contact_rollups_v2
@@ -5,7 +5,16 @@ require_relative '../../dashboard/lib/contact_rollups_v2'
 require 'cdo/only_one'
 
 def main
-  contact_rollups = ContactRollupsV2.new
+  # To avoid accidentally syncing bad data to Pardot, this script should run
+  # only in production. In other environments, it has to be in dry-run mode.
+  force_dry_run = !CDO.rack_env?(:production)
+  if force_dry_run
+    puts "Contact Rollups V2 will run in DRY-RUN mode in #{CDO.rack_env} environment."
+  else
+    puts "Contact Rollups V2 will run in NORMAL mode and will send updates to Pardot!"
+  end
+
+  contact_rollups = ContactRollupsV2.new(is_dry_run: force_dry_run)
   contact_rollups.collect_and_process_contacts
   contact_rollups.sync_new_contacts_with_pardot
   contact_rollups.sync_updated_contacts_with_pardot

--- a/bin/cron/build_contact_rollups_v2
+++ b/bin/cron/build_contact_rollups_v2
@@ -9,6 +9,7 @@ def main
   contact_rollups.collect_and_process_contacts
   contact_rollups.sync_new_contacts_with_pardot
   contact_rollups.sync_updated_contacts_with_pardot
+ensure
   contact_rollups.report_results
 end
 

--- a/dashboard/app/models/contact_rollups_pardot_memory.rb
+++ b/dashboard/app/models/contact_rollups_pardot_memory.rb
@@ -119,32 +119,50 @@ class ContactRollupsPardotMemory < ApplicationRecord
   end
 
   def self.create_new_pardot_prospects(is_dry_run: false)
-    record_count = 0
+    request_count = 0
+    accepted_prospects = 0
+    rejected_prospects = 0
 
     # Adds contacts to a batch and then sends batch requests to create new Pardot prospects.
     # Requests may not be sent immediately until batch size is big enough.
     pardot_writer = PardotV2.new is_dry_run: is_dry_run
     ActiveRecord::Base.connection.exec_query(query_new_contacts).each do |record|
-      record_count += 1
       data = JSON.parse(record['data']).deep_symbolize_keys
       submissions, errors = pardot_writer.batch_create_prospects record['email'], data
-      save_sync_results(submissions, errors, Time.now.utc) unless submissions.blank? || is_dry_run
+      next if submissions.blank?
+
+      request_count += 1
+      accepted_prospects += submissions.count - errors.count
+      rejected_prospects += errors.count
+      save_sync_results(submissions, errors, Time.now.utc) unless is_dry_run
     end
 
     # There could be prospects left in the batch because batch size is not yet big enough
     # to trigger a Pardot request. Sends the remaining of the batch to Pardot now.
     submissions, errors = pardot_writer.batch_create_remaining_prospects
-    save_sync_results(submissions, errors, Time.now.utc) unless submissions.blank? || is_dry_run
+    if submissions.present?
+      request_count += 1
+      accepted_prospects += submissions.count - errors.count
+      rejected_prospects += errors.count
+      save_sync_results(submissions, errors, Time.now.utc) unless is_dry_run
+    end
 
-    CDO.log.info "#{record_count} total new prospects to be added" if is_dry_run
+    CDO.log.info "[Dry run] #{accepted_prospects} total new prospects to be added to Pardot." if is_dry_run
+
+    {
+      request_count: request_count,
+      accepted_prospects: accepted_prospects,
+      rejected_prospects: rejected_prospects
+    }
   end
 
   def self.update_pardot_prospects(is_dry_run: false)
-    record_count = 0
+    request_count = 0
+    updated_prospects = 0
+    rejected_prospects = 0
+
     pardot_writer = PardotV2.new is_dry_run: is_dry_run
     ActiveRecord::Base.connection.exec_query(query_updated_contacts).each do |record|
-      record_count += 1
-
       # If pardot_id has changed since the last data sync, we should assume that
       # Pardot prospect data is currently empty and re-sync all contact data.
       old_prospect_data =
@@ -159,13 +177,29 @@ class ContactRollupsPardotMemory < ApplicationRecord
         old_prospect_data,
         new_contact_data
       )
-      save_sync_results(submissions, errors, Time.now.utc) unless submissions.blank? || is_dry_run
+      next if submissions.blank?
+
+      request_count += 1
+      updated_prospects += submissions.count - errors.count
+      rejected_prospects += errors.count
+      save_sync_results(submissions, errors, Time.now.utc) unless is_dry_run
     end
 
     submissions, errors = pardot_writer.batch_update_remaining_prospects
-    save_sync_results(submissions, errors, Time.now.utc) unless submissions.blank? || is_dry_run
+    if submissions.present?
+      request_count += 1
+      updated_prospects += submissions.count - errors.count
+      rejected_prospects += errors.count
+      save_sync_results(submissions, errors, Time.now.utc) unless is_dry_run
+    end
 
-    CDO.log.info "#{record_count} total prospects to be updated" if is_dry_run
+    CDO.log.info "[Dry run] #{updated_prospects} total prospects to be updated in Pardot." if is_dry_run
+
+    {
+      request_count: request_count,
+      updated_prospects: updated_prospects,
+      rejected_prospects: rejected_prospects
+    }
   end
 
   def self.query_new_contacts

--- a/dashboard/lib/contact_rollups_v2.rb
+++ b/dashboard/lib/contact_rollups_v2.rb
@@ -137,10 +137,11 @@ class ContactRollupsV2
     CDO.log.info @log_collector
   end
 
-  # Send logs and metrics to external systems such as AWS CloudWatch and Slack.
+  # Send logs and metrics to external systems such asf AWS CloudWatch and Slack
+  # unless in dry-run mode.
   def report_results
     @log_collector.record_metrics(get_table_metrics)
-    upload_metrics(@log_collector.metrics)
+    upload_metrics(@log_collector.metrics) unless @is_dry_run
     # TODO: Report to slack channel
     print_logs
   end
@@ -155,7 +156,7 @@ class ContactRollupsV2
         dimensions: [{name: "Environment", value: CDO.rack_env}]
       }
     end
-    Cdo::Metrics.push('ContactRollupsV2', aws_metrics) unless @is_dry_run
+    Cdo::Metrics.push('ContactRollupsV2', aws_metrics)
   end
 
   private

--- a/dashboard/lib/contact_rollups_v2.rb
+++ b/dashboard/lib/contact_rollups_v2.rb
@@ -137,19 +137,19 @@ class ContactRollupsV2
     CDO.log.info @log_collector
   end
 
-  # Send logs and metrics to external systems such asf AWS CloudWatch and Slack
+  # Send logs and metrics to external systems such as AWS CloudWatch and Slack
   # unless in dry-run mode.
   def report_results
     @log_collector.record_metrics(get_table_metrics)
-    upload_metrics(@log_collector.metrics) unless @is_dry_run
+    upload_metrics unless @is_dry_run
     # TODO: Report to slack channel
     print_logs
   end
 
   # Upload pipeline metrics to AWS CloudWatch.
   # https://console.aws.amazon.com/cloudwatch/home?region=us-east-1#dashboards:name=Contact-Rollups-V2
-  def upload_metrics(metrics)
-    aws_metrics = metrics.map do |key, value|
+  def upload_metrics
+    aws_metrics = @log_collector.metrics.map do |key, value|
       {
         metric_name: key,
         value: value,

--- a/dashboard/lib/contact_rollups_v2.rb
+++ b/dashboard/lib/contact_rollups_v2.rb
@@ -55,6 +55,7 @@ class ContactRollupsV2
     @log_collector.time!('Extracts email preferences from dashboard.email_preferences') do
       ContactRollupsRaw.extract_email_preferences
     end
+    log_collector.info("ContactRollupsRaw row count after extraction = #{ContactRollupsRaw.count}")
 
     @log_collector.time!('Extracts parent emails from dashboard.users') do
       ContactRollupsRaw.extract_parent_emails
@@ -63,6 +64,7 @@ class ContactRollupsV2
     @log_collector.time!('Processes all extracted data') do
       ContactRollupsProcessed.import_from_raw_table
     end
+    log_collector.info("ContactRollupsProcessed row count after processing = #{ContactRollupsProcessed.count}")
 
     @log_collector.time!("Overwrites contact_rollups_final table") do
       truncate_or_delete_table ContactRollupsFinal
@@ -94,6 +96,7 @@ class ContactRollupsV2
     @log_collector.time_and_continue('Updates existing Pardot prospects') do
       ContactRollupsPardotMemory.update_pardot_prospects(is_dry_run: @is_dry_run)
     end
+    log_collector.info("ContactRollupsFinal row count after overwriting = #{ContactRollupsFinal.count}")
   end
 
   def report_results

--- a/dashboard/lib/contact_rollups_v2.rb
+++ b/dashboard/lib/contact_rollups_v2.rb
@@ -124,18 +124,25 @@ class ContactRollupsV2
     )
   end
 
-  def collect_table_metrics
-    @log_collector.record_metrics({'RawRows' => ContactRollupsRaw.count})
-    @log_collector.record_metrics({'ProcessedRows' => ContactRollupsProcessed.count})
-    @log_collector.record_metrics({'FinalRows' => ContactRollupsProcessed.count})
-    @log_collector.record_metrics({'PardotMemoryRows' => ContactRollupsPardotMemory.count})
+  def get_table_metrics
+    {
+      RawRows: ContactRollupsRaw.count,
+      ProcessedRows: ContactRollupsProcessed.count,
+      FinalRows: ContactRollupsProcessed.count,
+      PardotMemoryRows: ContactRollupsPardotMemory.count
+    }
   end
 
-  def report_results
-    collect_table_metrics
-    upload_metrics @log_collector.metrics if @is_dry_run
+  def print_logs
     CDO.log.info @log_collector
+  end
+
+  # Send logs and metrics to external systems such as AWS CloudWatch and Slack.
+  def report_results
+    @log_collector.record_metrics(get_table_metrics)
+    upload_metrics(@log_collector.metrics)
     # TODO: Report to slack channel
+    print_logs
   end
 
   # Upload pipeline metrics to AWS CloudWatch.

--- a/lib/cdo/log_collector.rb
+++ b/lib/cdo/log_collector.rb
@@ -23,18 +23,20 @@ class LogCollector
   # Save exception if caught, do not re-raise. Caller's flow will continue as normal.
   #
   # @param action_name [string] a friendly name of the block being executed
-  def time(action_name = nil)
+  def time(action_name = nil, print_to_stdout = true)
     return unless block_given?
     start_time = Time.now
 
     yield
 
     info("#{action_name || 'Unnamed'} action completed without error in"\
-      " #{self.class.get_friendly_time(Time.now - start_time)}."
+      " #{self.class.get_friendly_time(Time.now - start_time)}.",
+      print_to_stdout
     )
   rescue StandardError => e
     error("#{action_name || 'Unnamed'} action exited with error in"\
-      " #{self.class.get_friendly_time(Time.now - start_time)}."
+      " #{self.class.get_friendly_time(Time.now - start_time)}.",
+      print_to_stdout
     )
     record_exception(e)
   end
@@ -45,19 +47,21 @@ class LogCollector
   #
   # @param action_name [string] friendly name for the given block
   #
-  # @raise [StandardError] error encoutered when executing the given block
-  def time!(action_name = nil)
+  # @raise [StandardError] error encountered when executing the given block
+  def time!(action_name = nil, print_to_stdout = true)
     return unless block_given?
     start_time = Time.now
 
     yield
 
     info("#{action_name || 'Unnamed'} action completed without error in"\
-      " #{self.class.get_friendly_time(Time.now - start_time)}."
+      " #{self.class.get_friendly_time(Time.now - start_time)}.",
+      print_to_stdout
     )
   rescue StandardError
     error("#{action_name || 'Unnamed'} action exited with error in"\
-      " #{self.class.get_friendly_time(Time.now - start_time)}. Exception re-raised!"
+      " #{self.class.get_friendly_time(Time.now - start_time)}. Exception re-raised!",
+      print_to_stdout
     )
 
     # To be handled by caller
@@ -65,12 +69,14 @@ class LogCollector
   end
   alias_method :time_and_raise!, :time!
 
-  def info(message)
+  def info(message, print_to_stdout = true)
     logs << "[#{Time.now}] INFO: #{message}"
+    CDO.log.info logs.last if print_to_stdout
   end
 
-  def error(message)
+  def error(message, print_to_stdout = true)
     logs << "[#{Time.now}] ERROR: #{message}"
+    CDO.log.info logs.last if print_to_stdout
   end
 
   def record_exception(e)
@@ -80,6 +86,10 @@ class LogCollector
 
   def ok?
     exceptions.blank?
+  end
+
+  def last_message
+    logs.last
   end
 
   def to_s


### PR DESCRIPTION
[PLC-836](https://codedotorg.atlassian.net/browse/PLC-836) Add 13 AWS CloudWatch metrics to monitor CRv2 pipeline execution in.

- 3 metrics for creating new prospects in Pardot:
  - ProspectsCreated  
  - ProspectsRejected  
  - CreateAPICalls (number of API calls to Pardot batchCreate endpoint) 

- 3 metrics for updating existing prospects in Pardot:
  - ProspectsUpdated  
  - ProspectUpdatesRejected  
  - UpdateAPICalls  (number of API calls to Pardot batchUpdate endpoint)

- 3 performance metrics:
  - CollectAndProcessContactsDuration (in second)
  - SyncNewContactsDuration (in second)
  - SyncUpdatedContactsDuration (in second)

- 4 table metrics:
  - RawRows  
  - ProcessedRows  
  - FinalRows  
  - PardotMemoryRows  

CloudWatch dashboard for CRv2 is [here](https://console.aws.amazon.com/cloudwatch/home?region=us-east-1#dashboards:name=Contact-Rollups-V2).
<img width="769" alt="Screen Shot 2020-06-10 at 9 55 44 AM" src="https://user-images.githubusercontent.com/46507039/84296289-af712900-ab00-11ea-8ab7-6877f2255a09.png">

## Testing story
- Ran the following code on a local machine (`development` environment) and on an adhoc machine with connection to a production-clone db (`adhoc` environment).
    ```ruby
    crv2 = ContactRollupsV2.new(is_dry_run: true); 
    crv2.build_and_sync; 
    crv2.report_results;
    ```
- Verified that metrics are displayed correctly in CloudWatch dashboard for both development and adhoc environment.

## Reviewer Checklist:
- [ ] Tests provide adequate coverage
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
