### PR TITLE
Fix only_one_running?

### DIFF
--- a/lib/cdo/only_one.rb
+++ b/lib/cdo/only_one.rb
@@ -1,5 +1,7 @@
 # Ensure only one instance of a Ruby script is running at a time,
 # using `File#flock` (advisory lock) on the script path.
 def only_one_running?(script)
-  File.new(script).flock(File::LOCK_NB | File::LOCK_EX)
+  # Prevent locked file from being closed by garbage-collector.
+  ($only_one = File.new(script)).
+    flock(File::LOCK_NB | File::LOCK_EX)
 end

--- a/lib/test/cdo/test_only_one.rb
+++ b/lib/test/cdo/test_only_one.rb
@@ -10,6 +10,7 @@ class OnlyOneTest < Minitest::Test
     r, w = IO.pipe
     pid = fork do
       w.puts only_one? # true
+      GC.start
       Process.wait(fork {w.puts only_one?}) # false
     end
     Process.wait pid


### PR DESCRIPTION
Fix to #35225. In order for a file-lock to be held, the `File` object can't be garbage-collected since that closes the underlying file-descriptor. This PR sets a global-variable `$only_one` to prevent GC from claiming the object so the lock remains until the process exits.

Updated the test to cover this fix as well.