### PR TITLE
Migrate old spritelab projects

### DIFF
--- a/apps/src/p5lab/animationListModule.js
+++ b/apps/src/p5lab/animationListModule.js
@@ -267,7 +267,7 @@ export function setInitialAnimationList(serializedAnimationList) {
     serializedAnimationList = {orderedKeys: [], propsByKey: {}};
   }
 
-  // TODO (from 2015): Tear out this migration when we don't think we need it anymore.
+  // TODO (from 2015): Tear out this migration when it hasn't been used for at least 3 consecutive non-summer months.
   if (Array.isArray(serializedAnimationList)) {
     trackEvent('Research', 'RanMigration', '2015-animation-migration');
     // We got old animation data that needs to be migrated.
@@ -280,7 +280,7 @@ export function setInitialAnimationList(serializedAnimationList) {
     };
   }
 
-  // TODO (from 2020): Tear out this migration when we don't think we need it anymore.
+  // TODO (from 2020): Tear out this migration when it hasn't been used for at least 3 consecutive non-summer months.
   serializedAnimationList.orderedKeys.forEach(loadedKey => {
     let animation = serializedAnimationList.propsByKey[loadedKey];
     if (animation.sourceUrl && animation.sourceUrl.includes('/v3/')) {

--- a/apps/src/p5lab/animationListModule.js
+++ b/apps/src/p5lab/animationListModule.js
@@ -262,7 +262,6 @@ function generateAnimationName(baseName, animationList) {
  * @returns {function()}
  */
 export function setInitialAnimationList(serializedAnimationList) {
-  debugger;
   // Set default empty animation list if none was provided
   if (!serializedAnimationList) {
     serializedAnimationList = {orderedKeys: [], propsByKey: {}};
@@ -284,33 +283,17 @@ export function setInitialAnimationList(serializedAnimationList) {
   // TODO (from 2020): Tear out this migration when we don't think we need it anymore.
   serializedAnimationList.orderedKeys.forEach(loadedKey => {
     let animation = serializedAnimationList.propsByKey[loadedKey];
-    if (animation.sourceUrl.includes('/v3/')) {
+    if (animation.sourceUrl && animation.sourceUrl.includes('/v3/')) {
       // We want to replace this sprite with the /v1/ sprite
-      console.log("attempting migration")
       let details = `name=${animation.name};key=${loadedKey}`;
       if (defaultSprites.propsByKey[loadedKey]) {
         // The key is the same in the main.json and in default sprites. Do a simple replacement.
-        console.log(`key migration of ${animation.name} successful`)
-        serializedAnimationList.propsByKey[loadedKey] = defaultSprites.propsByKey[loadedKey];
+        serializedAnimationList.propsByKey[loadedKey] =
+          defaultSprites.propsByKey[loadedKey];
         trackEvent('Research', 'ReplacedSpriteByKey', details);
       } else {
-        // The key is different between the main.json and default sprites. Try to find a default sprite with the same name.
-        let replacementSpriteKey = defaultSprites.orderedKeys.find(orderedKey => {
-          return defaultSprites.propsByKey[orderedKey].name === animation.name;
-        });
-        if (replacementSpriteKey) {
-          // We found a default sprite with a matching name. Delete the old one and replace it with the new.
-          delete serializedAnimationList.propsByKey[loadedKey];
-          serializedAnimationList.propsByKey[replacementSpriteKey] = defaultSprites.propsByKey[replacementSpriteKey];
-          serializedAnimationList.orderedKeys = serializedAnimationList.orderedKeys.filter(key => key !== loadedKey);
-          serializedAnimationList.orderedKeys.push(replacementSpriteKey);
-          console.log(`name migration of ${animation.name} successful`)
-          trackEvent('Research', 'ReplacedSpriteByName', details);
-        } else {
-          // We were unable to find a replacement for the /v3/ sprite
-          console.log(details)
-          trackEvent('Research', 'CouldNotReplaceSprite', details);
-        }
+        // We were unable to find a replacement for the /v3/ sprite
+        trackEvent('Research', 'CouldNotReplaceSprite', details);
       }
     }
   });

--- a/apps/src/p5lab/animationListModule.js
+++ b/apps/src/p5lab/animationListModule.js
@@ -20,6 +20,8 @@ import {
   getCurrentId
 } from '@cdo/apps/code-studio/initApp/project';
 import firehoseClient from '@cdo/apps/lib/util/firehose';
+import defaultSprites from './spritelab/defaultSprites.json';
+import trackEvent from '@cdo/apps/util/trackEvent';
 
 // TODO: Overwrite version ID within session
 // TODO: Load exact version ID on project load
@@ -265,7 +267,7 @@ export function setInitialAnimationList(serializedAnimationList) {
     serializedAnimationList = {orderedKeys: [], propsByKey: {}};
   }
 
-  // TODO: Tear out this migration when we don't think we need it anymore.
+  // TODO (from 2015): Tear out this migration when we don't think we need it anymore.
   if (Array.isArray(serializedAnimationList)) {
     // We got old animation data that needs to be migrated.
     serializedAnimationList = {
@@ -276,6 +278,19 @@ export function setInitialAnimationList(serializedAnimationList) {
       }, {})
     };
   }
+
+  // TODO (from 2020): Tear out this migration when we don't think we need it anymore.
+  serializedAnimationList.orderedKeys.forEach(key => {
+    let animation = serializedAnimationList.propsByKey[key];
+    if (animation.sourceUrl.includes('/v3/')) {
+      if (defaultSprites.propsByKey[key]) {
+        animation = defaultSprites.propsByKey[key];
+      } else {
+        let details = `name=${animation.name};key=${key}`;
+        trackEvent('Research', 'CouldNotReplaceSprite', details);
+      }
+    }
+  });
 
   // Convert frameRates to frameDelays.
   for (let key in serializedAnimationList.propsByKey) {


### PR DESCRIPTION
As part of an ongoing effort to migrate to our v1 animation api to fix the issues caused by deleting a levelbuilder's account, we are migrating old spritelab projects to the new api. As of this change, only the default animations are being migrated. This will address the majority of the cases and allow us to track animations that we are unable to migrate.

There is at least one known locations where the method in this PR will not work. This approach replaces old images by ID. There are a few levels, however, that use different IDs for their images. These levels are still on the old api. We should migrate them to the new api before migrating projects created from them.

<!--
  Other aspects to consider. uncomment and add detail for any that seem necessary:
-->

<!-- ### Background -->
<!-- ### Privacy -->
<!-- ### Security -->
<!-- ### Caching -->
<!-- ### Deployment strategy -->
<!-- ### Future work -->

## Links

<!--
  Any relevant links to external resources; ie, specification documents, jira
  items, related PRs, honeybadger errors, etc
-->

- [jira](https://codedotorg.atlassian.net/browse/STAR-861)
- [Example level using the old api URLs](https://studio.code.org/s/coursee-2019/stage/6/puzzle/4)
- [Follow-up task](https://codedotorg.atlassian.net/browse/STAR-1153)

## Testing story

<!--
  Does your change include appropriate tests?

  If so, please describe how the tests included in this PR are sufficient

  If not, please explain why this change does not need to be tested.
-->

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
