### PR TITLE
Check password confirmation when setting/updating password

### DIFF
--- a/dashboard/app/models/user.rb
+++ b/dashboard/app/models/user.rb
@@ -806,7 +806,7 @@ class User < ActiveRecord::Base
     return false unless managing_own_credentials?
 
     # Password is required for:
-    # New users with no encrypted_password set and users changing their password.
+    # New users with no encrypted_password set
     !persisted? && encrypted_password.blank?
   end
 

--- a/dashboard/app/models/user.rb
+++ b/dashboard/app/models/user.rb
@@ -796,15 +796,18 @@ class User < ActiveRecord::Base
   end
 
   def password_required?
+    # If the user is changing their password, then we should run all the password
+    # field verifications.
+    is_changing_password = password.present? || password_confirmation.present?
+    return true if is_changing_password
+
     # Password is not required if the user is not managing their own account
     # (i.e., someone is creating their account for them or the user is using OAuth).
     return false unless managing_own_credentials?
 
     # Password is required for:
     # New users with no encrypted_password set and users changing their password.
-    new_without_password = !persisted? && encrypted_password.blank?
-    is_changing_password = password.present? || password_confirmation.present?
-    new_without_password || is_changing_password
+    !persisted? && encrypted_password.blank?
   end
 
   # FND-1130: This field will no longer be required

--- a/dashboard/test/factories/factories.rb
+++ b/dashboard/test/factories/factories.rb
@@ -50,7 +50,7 @@ FactoryGirl.define do
   factory :user do
     birthday Time.zone.today - 21.years
     email {("#{user_type}_#{(User.maximum(:id) || 0) + 1}@code.org")}
-    encrypted_password "00secret"
+    password "00secret"
     locale 'en-US'
     sequence(:name) {|n| "User#{n} Codeberg"}
     user_type User::TYPE_STUDENT
@@ -280,6 +280,16 @@ FactoryGirl.define do
       trait :without_email do
         email ''
         hashed_email nil
+      end
+    end
+
+    # We have some tests which want to create student accounts which don't have any authentication setup.
+    # Using this will put the user into an invalid state.
+    trait :without_encrypted_password do
+      after(:create) do |user|
+        user.encrypted_password = nil
+        user.password = nil
+        user.save validate: false
       end
     end
 

--- a/dashboard/test/factories/factories.rb
+++ b/dashboard/test/factories/factories.rb
@@ -50,7 +50,7 @@ FactoryGirl.define do
   factory :user do
     birthday Time.zone.today - 21.years
     email {("#{user_type}_#{(User.maximum(:id) || 0) + 1}@code.org")}
-    password "00secret"
+    encrypted_password "00secret"
     locale 'en-US'
     sequence(:name) {|n| "User#{n} Codeberg"}
     user_type User::TYPE_STUDENT

--- a/dashboard/test/models/user_test.rb
+++ b/dashboard/test/models/user_test.rb
@@ -3418,7 +3418,6 @@ class UserTest < ActiveSupport::TestCase
 
   test 'password_required? is true for new users with no encrypted password' do
     user = create :user, encrypted_password: nil
-    user.expects(:managing_own_credentials?).returns(true)
     assert user.encrypted_password.nil?
     assert user.password_required?
   end
@@ -3427,7 +3426,6 @@ class UserTest < ActiveSupport::TestCase
     user = create :user
     user.password = "mypassword"
     user.password_confirmation = "mypassword"
-    user.expects(:managing_own_credentials?).returns(true)
     assert user.password_required?
   end
 

--- a/dashboard/test/models/user_test.rb
+++ b/dashboard/test/models/user_test.rb
@@ -1600,11 +1600,11 @@ class UserTest < ActiveSupport::TestCase
 
   test 'can_edit_password? is true for user with or without a password' do
     student1 = create :student
-    refute_empty student1.encrypted_password
+    refute_nil student1.encrypted_password
     assert student1.can_edit_password?
 
-    student1 = create :student, encrypted_password: ''
-    assert_empty student1.encrypted_password
+    student1 = create :student, :without_encrypted_password
+    assert_nil student1.encrypted_password
     assert student1.can_edit_password?
   end
 
@@ -1619,12 +1619,12 @@ class UserTest < ActiveSupport::TestCase
   end
 
   test 'can_edit_password? is true for student without a password' do
-    student = create :student, encrypted_password: ''
+    student = create :student, :without_encrypted_password
     assert student.can_edit_password?
   end
 
   test 'can_edit_password? is true for teacher without a password' do
-    teacher = create :teacher, encrypted_password: ''
+    teacher = create :teacher, :without_encrypted_password
     assert teacher.can_edit_password?
   end
 
@@ -1703,11 +1703,7 @@ class UserTest < ActiveSupport::TestCase
   end
 
   test 'cannot delete own account if teacher-managed student' do
-    picture_section = create(:section, login_type: Section::LOGIN_TYPE_PICTURE)
-    user = create(:student, encrypted_password: '')
-    create(:follower, student_user: user, section: picture_section)
-    user.reload
-
+    user = create :student_in_picture_section
     assert user.teacher_managed_account?
     refute user.can_delete_own_account?
   end
@@ -1771,7 +1767,7 @@ class UserTest < ActiveSupport::TestCase
     word_section = create(:section, login_type: Section::LOGIN_TYPE_WORD)
 
     [picture_section, word_section].each do |section|
-      student_without_password = create(:student, encrypted_password: '')
+      student_without_password = create(:student, :without_encrypted_password)
       create(:follower, student_user: student_without_password, section: section)
       student_without_password.reload
       assert student_without_password.teacher_managed_account?
@@ -1801,11 +1797,7 @@ class UserTest < ActiveSupport::TestCase
   end
 
   test 'roster_managed_account? is true for migrated student in an externally rostered section without a password' do
-    student = create :student, encrypted_password: nil
-    section = create :section, login_type: Section::LOGIN_TYPE_GOOGLE_CLASSROOM
-    section.students << student
-    student.reload
-
+    student = create :student, :migrated_imported_from_google_classroom
     assert student.roster_managed_account?
   end
 
@@ -3411,15 +3403,16 @@ class UserTest < ActiveSupport::TestCase
   end
 
   test 'password_required? is false if user is not creating their own account' do
-    user = create :user
+    user = create :student, :without_encrypted_password
     user.expects(:managing_own_credentials?).returns(false)
     refute user.password_required?
   end
 
-  test 'password_required? is true for new users with no encrypted password' do
-    user = create :user, encrypted_password: nil
-    assert user.encrypted_password.nil?
-    assert user.password_required?
+  test 'new users require a password if no authentication provided' do
+    assert_raises(ActiveRecord::RecordInvalid) do
+      user = create :user, password: nil
+      assert !user.errors[:password].empty?
+    end
   end
 
   test 'password_required? is true for user changing their password' do


### PR DESCRIPTION
On the "My Account" page, users can create a personal login or update
their account's existing password. There is already a "Password
confirmation" field where the user is supposed to type in their password
again. However, on the backend we were not verifying that the password
and password confirmation fields matched.

This change makes sure we run password field validations when a user is
trying to create or change their password.

## Links
- [jira](https://codedotorg.atlassian.net/browse/FND-1120)

## Testing story
* Manually tested

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
