### PR TITLE
Grey workspace area in block mode when applab is running

### DIFF
--- a/apps/src/applab/applab.js
+++ b/apps/src/applab/applab.js
@@ -1011,7 +1011,9 @@ Applab.clearEventHandlersKillTickLoop = function() {
   Applab.running = false;
   $('#headers').removeClass('dimmed');
   $('#codeWorkspace').removeClass('dimmed');
-  $('.droplet-main-canvas').css('background-color', '#FFF');
+  if (!Applab.isReadOnlyView) {
+    $('.droplet-main-canvas').css('background-color', '#FFF');
+  }
   Applab.tickCount = 0;
 };
 
@@ -1307,7 +1309,9 @@ Applab.beginVisualizationRun = function() {
   Applab.running = true;
   $('#headers').addClass('dimmed');
   $('#codeWorkspace').addClass('dimmed');
-  $('.droplet-main-canvas').css('background-color', '#E5E5E5');
+  if (!Applab.isReadOnlyView) {
+    $('.droplet-main-canvas').css('background-color', '#E5E5E5');
+  }
   designMode.renderDesignWorkspace();
   queueOnTick();
 };

--- a/apps/src/applab/applab.js
+++ b/apps/src/applab/applab.js
@@ -79,7 +79,7 @@ import {
 } from '../util/exporter';
 import {setExportGeneratedProperties} from '../code-studio/components/exportDialogRedux';
 import {userAlreadyReportedAbuse} from '@cdo/apps/reportAbuse';
-import {code_running, white} from '@cdo/apps/util/color';
+import {workspace_running_background, white} from '@cdo/apps/util/color';
 
 /**
  * Create a namespace for the application.
@@ -1311,7 +1311,10 @@ Applab.beginVisualizationRun = function() {
   $('#headers').addClass('dimmed');
   $('#codeWorkspace').addClass('dimmed');
   if (!Applab.isReadOnlyView) {
-    $('.droplet-main-canvas').css('background-color', code_running);
+    $('.droplet-main-canvas').css(
+      'background-color',
+      workspace_running_background
+    );
   }
   designMode.renderDesignWorkspace();
   queueOnTick();

--- a/apps/src/applab/applab.js
+++ b/apps/src/applab/applab.js
@@ -1011,6 +1011,7 @@ Applab.clearEventHandlersKillTickLoop = function() {
   Applab.running = false;
   $('#headers').removeClass('dimmed');
   $('#codeWorkspace').removeClass('dimmed');
+  $('.droplet-main-canvas').css('background-color', '#FFF');
   Applab.tickCount = 0;
 };
 
@@ -1306,6 +1307,7 @@ Applab.beginVisualizationRun = function() {
   Applab.running = true;
   $('#headers').addClass('dimmed');
   $('#codeWorkspace').addClass('dimmed');
+  $('.droplet-main-canvas').css('background-color', '#E5E5E5');
   designMode.renderDesignWorkspace();
   queueOnTick();
 };

--- a/apps/src/applab/applab.js
+++ b/apps/src/applab/applab.js
@@ -79,6 +79,7 @@ import {
 } from '../util/exporter';
 import {setExportGeneratedProperties} from '../code-studio/components/exportDialogRedux';
 import {userAlreadyReportedAbuse} from '@cdo/apps/reportAbuse';
+import {code_running, white} from '@cdo/apps/util/color';
 
 /**
  * Create a namespace for the application.
@@ -1012,7 +1013,7 @@ Applab.clearEventHandlersKillTickLoop = function() {
   $('#headers').removeClass('dimmed');
   $('#codeWorkspace').removeClass('dimmed');
   if (!Applab.isReadOnlyView) {
-    $('.droplet-main-canvas').css('background-color', '#FFF');
+    $('.droplet-main-canvas').css('background-color', white);
   }
   Applab.tickCount = 0;
 };
@@ -1310,7 +1311,7 @@ Applab.beginVisualizationRun = function() {
   $('#headers').addClass('dimmed');
   $('#codeWorkspace').addClass('dimmed');
   if (!Applab.isReadOnlyView) {
-    $('.droplet-main-canvas').css('background-color', '#E5E5E5');
+    $('.droplet-main-canvas').css('background-color', code_running);
   }
   designMode.renderDesignWorkspace();
   queueOnTick();

--- a/shared/css/color.scss
+++ b/shared/css/color.scss
@@ -89,6 +89,7 @@ $level_current: $orange;
 $level_review_rejected: $red;
 $level_review_accepted: rgb(11, 142, 11); // TODO: $level_passed;
 $assessment: $cyan;
+$code_running: #e5e5e5;
 
 // Links (used in apps).
 $link_color: #0596CE;

--- a/shared/css/color.scss
+++ b/shared/css/color.scss
@@ -89,7 +89,7 @@ $level_current: $orange;
 $level_review_rejected: $red;
 $level_review_accepted: rgb(11, 142, 11); // TODO: $level_passed;
 $assessment: $cyan;
-$code_running: #e5e5e5;
+$workspace_running_background: #e5e5e5;
 
 // Links (used in apps).
 $link_color: #0596CE;


### PR DESCRIPTION

![applab grey background](https://user-images.githubusercontent.com/17147070/84298403-ed238100-ab03-11ea-9e54-38519a1e34a0.gif)

Sets the workspace background color to grey in block mode when code is running.

### Background 
The workspace background color is currently only set to grey in text mode when running.

## Links
- [spec](https://docs.google.com/document/u/6/d/1oCqZcRYf_RuIIY7q-CccOvHLjyykVKF2ktsjotgOD7I/edit#heading=h.w49xghegksz8)
- [jira](https://codedotorg.atlassian.net/browse/STAR-1109)

## Testing story

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
