### PR TITLE
Darker workspace background in blockly labs when code is running

### DIFF
--- a/apps/src/StudioApp.js
+++ b/apps/src/StudioApp.js
@@ -72,7 +72,7 @@ import {addCallouts} from '@cdo/apps/code-studio/callouts';
 import {RESIZE_VISUALIZATION_EVENT} from './lib/ui/VisualizationResizeBar';
 import {userAlreadyReportedAbuse} from '@cdo/apps/reportAbuse';
 import {setArrowButtonDisabled} from '@cdo/apps/templates/arrowDisplayRedux';
-import {code_running, white} from '@cdo/apps/util/color';
+import {workspace_running_background, white} from '@cdo/apps/util/color';
 
 var copyrightStrings;
 
@@ -967,7 +967,7 @@ StudioApp.prototype.toggleRunReset = function(button) {
     } else if (this.config.app === 'craft') {
       $('.blocklySvg').css('background-color', '#7D7D7D');
     } else {
-      $('.blocklySvg').css('background-color', code_running);
+      $('.blocklySvg').css('background-color', workspace_running_background);
     }
   }
 

--- a/apps/src/StudioApp.js
+++ b/apps/src/StudioApp.js
@@ -955,7 +955,7 @@ StudioApp.prototype.toggleRunReset = function(button) {
     reset.style.display = !showRun ? 'inline-block' : 'none';
     reset.disabled = showRun;
   }
-  if (this.isUsingBlockly()) {
+  if (this.isUsingBlockly() && !this.config.readonlyWorkspace) {
     if (showRun && this.config.app !== 'craft') {
       $('.blocklySvg').css('background-color', '#FFF');
     } else if (showRun) {

--- a/apps/src/StudioApp.js
+++ b/apps/src/StudioApp.js
@@ -72,6 +72,7 @@ import {addCallouts} from '@cdo/apps/code-studio/callouts';
 import {RESIZE_VISUALIZATION_EVENT} from './lib/ui/VisualizationResizeBar';
 import {userAlreadyReportedAbuse} from '@cdo/apps/reportAbuse';
 import {setArrowButtonDisabled} from '@cdo/apps/templates/arrowDisplayRedux';
+import {code_running, white} from '@cdo/apps/util/color';
 
 var copyrightStrings;
 
@@ -956,14 +957,17 @@ StudioApp.prototype.toggleRunReset = function(button) {
     reset.disabled = showRun;
   }
   if (this.isUsingBlockly() && !this.config.readonlyWorkspace) {
-    if (showRun && this.config.app !== 'craft') {
-      $('.blocklySvg').css('background-color', '#FFF');
-    } else if (showRun) {
+    // craft has a darker color scheme than other blockly labs. It needs to
+    // toggle between different colors on run/reset or else, on run, the workspace
+    // would get lighter than the default.
+    if (showRun && this.config.app === 'craft') {
       $('.blocklySvg').css('background-color', '#A1A1A1');
-    } else if (this.config.app !== 'craft') {
-      $('.blocklySvg').css('background-color', '#E5E5E5');
-    } else {
+    } else if (showRun) {
+      $('.blocklySvg').css('background-color', white);
+    } else if (this.config.app === 'craft') {
       $('.blocklySvg').css('background-color', '#7D7D7D');
+    } else {
+      $('.blocklySvg').css('background-color', code_running);
     }
   }
 

--- a/apps/src/StudioApp.js
+++ b/apps/src/StudioApp.js
@@ -955,6 +955,17 @@ StudioApp.prototype.toggleRunReset = function(button) {
     reset.style.display = !showRun ? 'inline-block' : 'none';
     reset.disabled = showRun;
   }
+  if (this.isUsingBlockly()) {
+    if (showRun && this.config.app !== 'craft') {
+      $('.blocklySvg').css('background-color', '#FFF');
+    } else if (showRun) {
+      $('.blocklySvg').css('background-color', '#A1A1A1');
+    } else if (this.config.app !== 'craft') {
+      $('.blocklySvg').css('background-color', '#E5E5E5');
+    } else {
+      $('.blocklySvg').css('background-color', '#7D7D7D');
+    }
+  }
 
   // Toggle soft-buttons (all have the 'arrow' class set):
   getStore().dispatch(setArrowButtonDisabled(showRun));

--- a/shared/css/color.scss
+++ b/shared/css/color.scss
@@ -89,6 +89,7 @@ $level_current: $orange;
 $level_review_rejected: $red;
 $level_review_accepted: rgb(11, 142, 11); // TODO: $level_passed;
 $assessment: $cyan;
+$code_running: #e5e5e5;
 
 // Links (used in apps).
 $link_color: #0596CE;

--- a/shared/css/color.scss
+++ b/shared/css/color.scss
@@ -89,7 +89,7 @@ $level_current: $orange;
 $level_review_rejected: $red;
 $level_review_accepted: rgb(11, 142, 11); // TODO: $level_passed;
 $assessment: $cyan;
-$code_running: #e5e5e5;
+$workspace_running_background: #e5e5e5;
 
 // Links (used in apps).
 $link_color: #0596CE;


### PR DESCRIPTION

![blockly grey background](https://user-images.githubusercontent.com/17147070/84306507-6aed8980-ab10-11ea-90f2-40cbec0d3188.gif)
![grey background craft](https://user-images.githubusercontent.com/17147070/84306517-6e811080-ab10-11ea-99ce-94ec95b87379.gif)

Sets the workspace background color darker when code is running.

## Links
- [spec](https://docs.google.com/document/d/1oCqZcRYf_RuIIY7q-CccOvHLjyykVKF2ktsjotgOD7I/edit#heading=h.w49xghegksz8)
- [jira](https://codedotorg.atlassian.net/browse/STAR-1097)

## Testing story

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
