### PR TITLE
added readonly check to grey workspace in gamelab on run

### DIFF
--- a/apps/src/p5lab/gamelab/GameLab.js
+++ b/apps/src/p5lab/gamelab/GameLab.js
@@ -24,16 +24,20 @@ GameLab.prototype.init = function(config) {
 };
 
 GameLab.prototype.resetHandler = function(ignore) {
-  $('.droplet-main-canvas').css('background-color', '#FFF');
-  $('.droplet-transition-container').css('background-color', '#FFF');
-  $('.ace_scroller').css('background-color', '#FFF');
+  if (!this.studioApp_.config.readonlyWorkspace) {
+    $('.droplet-main-canvas').css('background-color', '#FFF');
+    $('.droplet-transition-container').css('background-color', '#FFF');
+    $('.ace_scroller').css('background-color', '#FFF');
+  }
   P5Lab.prototype.resetHandler.call(this, ignore);
 };
 
 GameLab.prototype.runButtonClick = function() {
-  $('.droplet-main-canvas').css('background-color', '#E5E5E5');
-  $('.droplet-transition-container').css('background-color', '#E5E5E5');
-  $('.ace_scroller').css('background-color', '#E5E5E5');
+  if (!this.studioApp_.config.readonlyWorkspace) {
+    $('.droplet-main-canvas').css('background-color', '#E5E5E5');
+    $('.droplet-transition-container').css('background-color', '#E5E5E5');
+    $('.ace_scroller').css('background-color', '#E5E5E5');
+  }
   P5Lab.prototype.runButtonClick.call(this);
 };
 


### PR DESCRIPTION
Added a readonly check to grey workspace in gamelab on run so that background will only become grey if the workspace is not readonly.

Workspace is grey on run when project is not readonly:
<img width="1049" alt="Screen Shot 2020-06-10 at 2 17 17 PM" src="https://user-images.githubusercontent.com/17147070/84319657-39cb8400-ab25-11ea-8250-3352299e1143.png">

Workspace remains white on run when project is readonly:
<img width="826" alt="Screen Shot 2020-06-10 at 2 17 28 PM" src="https://user-images.githubusercontent.com/17147070/84319701-48b23680-ab25-11ea-9227-c89ff210ef0f.png">


## Background
Read only game lab workspaces started toggling between grey and white on run/reset.

## Links
[slack conversation that discovered this](https://codedotorg.slack.com/archives/CA3KCSGTD/p1591819104220100)
[original PR](https://github.com/code-dot-org/code-dot-org/pull/35233)
## Testing story

<!--
  Does your change include appropriate tests?

  If so, please describe how the tests included in this PR are sufficient

  If not, please explain why this change does not need to be tested.
-->

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
