### PR TITLE
[Applab Datasets][Cleanup] Category description is not required

### DIFF
--- a/apps/src/storage/dataBrowser/LibraryCategory.jsx
+++ b/apps/src/storage/dataBrowser/LibraryCategory.jsx
@@ -33,7 +33,7 @@ class LibraryCategory extends React.Component {
   static propTypes = {
     name: PropTypes.string.isRequired,
     datasets: PropTypes.arrayOf(PropTypes.string).isRequired,
-    description: PropTypes.string.isRequired,
+    description: PropTypes.string,
     importTable: PropTypes.func.isRequired
   };
 
@@ -60,9 +60,11 @@ class LibraryCategory extends React.Component {
         </a>
         {!this.state.collapsed && (
           <div style={styles.collapsibleContainer}>
-            <span style={styles.categoryDescription}>
-              {this.props.description}
-            </span>
+            {this.props.description && (
+              <span style={styles.categoryDescription}>
+                {this.props.description}
+              </span>
+            )}
             {this.props.datasets.map(tableName => (
               <LibraryTable
                 key={tableName}


### PR DESCRIPTION
Small cleanup to not mark the description as a required prop. Some categories don't have descriptions. No user-visible change
![image](https://user-images.githubusercontent.com/8787187/84419811-fc6f0100-abcd-11ea-8a0e-dad94ea86b64.png)
