### PR TITLE
Support nested `only_one_running?` locks

### DIFF
--- a/lib/cdo/only_one.rb
+++ b/lib/cdo/only_one.rb
@@ -1,7 +1,9 @@
 # Ensure only one instance of a Ruby script is running at a time,
-# using `File#flock` (advisory lock) on the script path.
-def only_one_running?(script)
-  # Prevent locked file from being closed by garbage-collector.
-  ($only_one = File.new(script)).
-    flock(File::LOCK_NB | File::LOCK_EX)
+# using `File#flock` (advisory lock) on the provided script path.
+# @return [Boolean] true if this is the only instance running.
+def only_one_running?(path)
+  !!((file = File.new(path)).
+    flock(File::LOCK_NB | File::LOCK_EX) &&
+    # Prevent locked files from being closed by garbage-collector.
+    ($only_one ||= []) << file)
 end

--- a/lib/cdo/only_one.rb
+++ b/lib/cdo/only_one.rb
@@ -2,8 +2,8 @@
 # using `File#flock` (advisory lock) on the provided script path.
 # @return [Boolean] true if this is the only instance running.
 def only_one_running?(path)
-  !!((file = File.new(path)).
-    flock(File::LOCK_NB | File::LOCK_EX) &&
-    # Prevent locked files from being closed by garbage-collector.
-    ($only_one ||= []) << file)
+  !!File.new(path).
+    # Prevent locked Files from being auto-closed by garbage-collector.
+    tap {|f| f.autoclose = false}.
+    flock(File::LOCK_NB | File::LOCK_EX)
 end

--- a/lib/test/cdo/test_only_one.rb
+++ b/lib/test/cdo/test_only_one.rb
@@ -1,9 +1,10 @@
 require_relative '../test_helper'
 require 'cdo/only_one'
+require 'tempfile'
 
 class OnlyOneTest < Minitest::Test
   def only_one?
-    !!only_one_running?(__FILE__)
+    only_one_running?(__FILE__)
   end
 
   def test_only_one
@@ -11,11 +12,24 @@ class OnlyOneTest < Minitest::Test
     pid = fork do
       w.puts only_one? # true
       GC.start
+      w.puts only_one? # false
       Process.wait(fork {w.puts only_one?}) # false
     end
     Process.wait pid
-    w.puts only_one? # true
+    Process.wait(fork {w.puts only_one?}) # true
     w.close
-    assert_equal %w[true false true], r.readlines(chomp: true)
+    assert_equal %w[true false false true], r.readlines(chomp: true)
+  end
+
+  def test_nested
+    tmp1, tmp2 = Array.new(2) {Tempfile.new}
+
+    assert only_one_running?(tmp1)
+    assert only_one_running?(tmp2)
+
+    GC.start
+
+    refute only_one_running?(tmp1)
+    refute only_one_running?(tmp2)
   end
 end


### PR DESCRIPTION
Updates #35225 / #35242 to support nested `only_one_running?` locks, by ~storing an Array of locked `File` objects (see https://github.com/code-dot-org/code-dot-org/pull/35242#issuecomment-641654564)~ setting [`#autoclose = false`](https://ruby-doc.org/core/IO.html#method-i-autoclose-3D).

Two other small tweaks to behavior (updated tests to match):
- Cast 'truthy' return value to strict Boolean by wrapping result in `!!()`
- Don't clobber existing lock on multiple calls to `only_one_running?` from same pid (ie, return `false` on second call)