### PR TITLE
fixed showElement, hideElement, setProperty fix for photo select

### DIFF
--- a/apps/src/applab/setPropertyDropdown.js
+++ b/apps/src/applab/setPropertyDropdown.js
@@ -161,6 +161,18 @@ var PROP_INFO = {
     type: 'string',
     defaultValue: '"red"'
   },
+  photoSelectIconColor: {
+    friendlyName: 'icon-color',
+    internalName: 'textColor',
+    type: 'string',
+    defaultValue: '"red"'
+  },
+  iconSize: {
+    friendlyName: 'icon-size',
+    internalName: 'fontSize',
+    type: 'number',
+    defaultValue: '32'
+  },
   groupId: {
     friendlyName: 'group-id',
     internalName: 'groupId',
@@ -404,6 +416,21 @@ PROPERTIES[ElementType.SLIDER] = {
     'hidden'
   ]
 };
+PROPERTIES[ElementType.PHOTO_SELECT] = {
+  propertyNames: [
+    'width',
+    'height',
+    'x',
+    'y',
+    'iconColor',
+    'backgroundColor',
+    'iconSize',
+    'hidden',
+    'borderWidth',
+    'borderColor',
+    'borderRadius'
+  ]
+};
 
 // Initialize dropdownOptions and infoForFriendlyNames fields in PROPERTIES map.
 for (var elementType in PROPERTIES) {
@@ -420,7 +447,20 @@ for (var elementType in PROPERTIES) {
           elementType
       );
     }
-    elementProperties.infoForFriendlyName[friendlyName] = PROP_INFO[propName];
+
+    // The PhotoSelect element is currently the only element that uses
+    // textColor to modify the color of the icon so we need to make sure that
+    // if we're accessing the icon-color of a photo select element, we are
+    // mapping it to the textColor property.
+    if (
+      elementType === ElementType.PHOTO_SELECT &&
+      friendlyName === 'icon-color'
+    ) {
+      elementProperties.infoForFriendlyName[friendlyName] =
+        PROP_INFO['photoSelectIconColor'];
+    } else {
+      elementProperties.infoForFriendlyName[friendlyName] = PROP_INFO[propName];
+    }
     let dropdownOption = constructDropdownOption(propName);
     if (dropdownOption) {
       elementProperties.dropdownOptions.push(dropdownOption);

--- a/apps/src/applab/setPropertyDropdown.js
+++ b/apps/src/applab/setPropertyDropdown.js
@@ -450,7 +450,7 @@ for (var elementType in PROPERTIES) {
 
     // The PhotoSelect element is currently the only element that uses
     // textColor to modify the color of the icon so we need to make sure that
-    // if we're accessing the icon-color of a photo select element, we are
+    // if we're accessing the icon-color of PhotoSelect, we are
     // mapping it to the textColor property.
     if (
       elementType === ElementType.PHOTO_SELECT &&

--- a/apps/test/unit/applab/setPropertyDropdownTest.js
+++ b/apps/test/unit/applab/setPropertyDropdownTest.js
@@ -1,4 +1,5 @@
 import {assert} from '../../util/deprecatedChai';
+import photoSelect from '@cdo/apps/applab/designElements/photoSelect';
 var testUtils = require('../../util/testUtils');
 
 var setPropertyDropdown = require('@cdo/apps/applab/setPropertyDropdown');
@@ -34,6 +35,20 @@ describe('setPropertyDropdown', function() {
       'picture'
     );
     assert.equal(info.internalName, 'picture');
+
+    // Check that icon-color maps to internal property textColor for photo select elements only
+    const photoSelectElement = photoSelect.create();
+    info = setPropertyDropdown.getInternalPropertyInfo(
+      photoSelectElement,
+      'icon-color'
+    );
+    assert.equal(info.internalName, 'textColor');
+
+    info = setPropertyDropdown.getInternalPropertyInfo(
+      {tagName: 'img'},
+      'icon-color'
+    );
+    assert.equal(info.internalName, 'icon-color');
 
     info = setPropertyDropdown.getInternalPropertyInfo(
       {tagName: 'img'},


### PR DESCRIPTION

![photo select element fix](https://user-images.githubusercontent.com/17147070/84423591-88375c00-abd3-11ea-8627-5c8e5e9b8700.gif)

showElement, hideElement, and setProperty were giving an undefined error when used on a photo select design element in app lab. This fixes that and adds some extra logic to make sure that use of icon-color in app lab design mode actually maps to changing the text-color property since photo select is the only element that uses text-color to change icon-color. 

## Links

- [original PR for photo select](https://github.com/code-dot-org/code-dot-org/pull/34751)
- [slack conversation](https://codedotorg.slack.com/archives/C1B3PNDL7/p1591884278006700)
- [forum post about the bug](https://forum.code.org/t/typeerror-cannot-read-property-infoforfriendlyname-of-undefined-happened-when-hiding-showing-the-new-photoselect-element/32767)

## Testing story

<!--
  Does your change include appropriate tests?

  If so, please describe how the tests included in this PR are sufficient

  If not, please explain why this change does not need to be tested.
-->

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
