### PR TITLE
Added grey workspace colors to shared colors and updated usage in gamelab

### DIFF
--- a/apps/src/p5lab/gamelab/GameLab.js
+++ b/apps/src/p5lab/gamelab/GameLab.js
@@ -1,7 +1,7 @@
 import P5Lab from '../P5Lab';
 import project from '@cdo/apps/code-studio/initApp/project';
 import {showLevelBuilderSaveButton} from '../../code-studio/header';
-import {code_running, white} from '@cdo/apps/util/color';
+import {workspace_running_background, white} from '@cdo/apps/util/color';
 
 var GameLab = function() {
   P5Lab.call(this);
@@ -35,9 +35,15 @@ GameLab.prototype.resetHandler = function(ignore) {
 
 GameLab.prototype.runButtonClick = function() {
   if (!this.studioApp_.config.readonlyWorkspace) {
-    $('.droplet-main-canvas').css('background-color', code_running);
-    $('.droplet-transition-container').css('background-color', code_running);
-    $('.ace_scroller').css('background-color', code_running);
+    $('.droplet-main-canvas').css(
+      'background-color',
+      workspace_running_background
+    );
+    $('.droplet-transition-container').css(
+      'background-color',
+      workspace_running_background
+    );
+    $('.ace_scroller').css('background-color', workspace_running_background);
   }
   P5Lab.prototype.runButtonClick.call(this);
 };

--- a/apps/src/p5lab/gamelab/GameLab.js
+++ b/apps/src/p5lab/gamelab/GameLab.js
@@ -1,6 +1,7 @@
 import P5Lab from '../P5Lab';
 import project from '@cdo/apps/code-studio/initApp/project';
 import {showLevelBuilderSaveButton} from '../../code-studio/header';
+import {code_running, white} from '@cdo/apps/util/color';
 
 var GameLab = function() {
   P5Lab.call(this);
@@ -25,18 +26,18 @@ GameLab.prototype.init = function(config) {
 
 GameLab.prototype.resetHandler = function(ignore) {
   if (!this.studioApp_.config.readonlyWorkspace) {
-    $('.droplet-main-canvas').css('background-color', '#FFF');
-    $('.droplet-transition-container').css('background-color', '#FFF');
-    $('.ace_scroller').css('background-color', '#FFF');
+    $('.droplet-main-canvas').css('background-color', white);
+    $('.droplet-transition-container').css('background-color', white);
+    $('.ace_scroller').css('background-color', white);
   }
   P5Lab.prototype.resetHandler.call(this, ignore);
 };
 
 GameLab.prototype.runButtonClick = function() {
   if (!this.studioApp_.config.readonlyWorkspace) {
-    $('.droplet-main-canvas').css('background-color', '#E5E5E5');
-    $('.droplet-transition-container').css('background-color', '#E5E5E5');
-    $('.ace_scroller').css('background-color', '#E5E5E5');
+    $('.droplet-main-canvas').css('background-color', code_running);
+    $('.droplet-transition-container').css('background-color', code_running);
+    $('.ace_scroller').css('background-color', code_running);
   }
   P5Lab.prototype.runButtonClick.call(this);
 };

--- a/apps/src/p5lab/gamelab/GameLab.js
+++ b/apps/src/p5lab/gamelab/GameLab.js
@@ -1,7 +1,7 @@
 import P5Lab from '../P5Lab';
 import project from '@cdo/apps/code-studio/initApp/project';
 import {showLevelBuilderSaveButton} from '../../code-studio/header';
-import {workspace_running_background, white} from '@cdo/apps/util/color';
+import color from '@cdo/apps/util/color';
 
 var GameLab = function() {
   P5Lab.call(this);
@@ -26,9 +26,9 @@ GameLab.prototype.init = function(config) {
 
 GameLab.prototype.resetHandler = function(ignore) {
   if (!this.studioApp_.config.readonlyWorkspace) {
-    $('.droplet-main-canvas').css('background-color', white);
-    $('.droplet-transition-container').css('background-color', white);
-    $('.ace_scroller').css('background-color', white);
+    $('.droplet-main-canvas').css('background-color', color.white);
+    $('.droplet-transition-container').css('background-color', color.white);
+    $('.ace_scroller').css('background-color', color.white);
   }
   P5Lab.prototype.resetHandler.call(this, ignore);
 };
@@ -37,13 +37,16 @@ GameLab.prototype.runButtonClick = function() {
   if (!this.studioApp_.config.readonlyWorkspace) {
     $('.droplet-main-canvas').css(
       'background-color',
-      workspace_running_background
+      color.workspace_running_background
     );
     $('.droplet-transition-container').css(
       'background-color',
-      workspace_running_background
+      color.workspace_running_background
     );
-    $('.ace_scroller').css('background-color', workspace_running_background);
+    $('.ace_scroller').css(
+      'background-color',
+      color.workspace_running_background
+    );
   }
   P5Lab.prototype.runButtonClick.call(this);
 };

--- a/shared/css/color.scss
+++ b/shared/css/color.scss
@@ -89,6 +89,7 @@ $level_current: $orange;
 $level_review_rejected: $red;
 $level_review_accepted: rgb(11, 142, 11); // TODO: $level_passed;
 $assessment: $cyan;
+$code_running: #e5e5e5;
 
 // Links (used in apps).
 $link_color: #0596CE;

--- a/shared/css/color.scss
+++ b/shared/css/color.scss
@@ -89,7 +89,7 @@ $level_current: $orange;
 $level_review_rejected: $red;
 $level_review_accepted: rgb(11, 142, 11); // TODO: $level_passed;
 $assessment: $cyan;
-$code_running: #e5e5e5;
+$workspace_running_background: #e5e5e5;
 
 // Links (used in apps).
 $link_color: #0596CE;


### PR DESCRIPTION
The grey code running color will be used across droplet and blockly labs so this adds it to shared colors and modifies the grey workspace on run logic in gamelab to use it.

## Links

- [spec](https://docs.google.com/document/d/1oCqZcRYf_RuIIY7q-CccOvHLjyykVKF2ktsjotgOD7I/edit#heading=h.w49xghegksz8)
- [jira](https://codedotorg.atlassian.net/browse/STAR-1109)
- [original PR](https://github.com/code-dot-org/code-dot-org/pull/35258)

## Testing story

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
