### PR TITLE
Don't show option to send update emails for virtual workshops

### DIFF
--- a/apps/src/code-studio/pd/workshop_dashboard/components/workshop_form.jsx
+++ b/apps/src/code-studio/pd/workshop_dashboard/components/workshop_form.jsx
@@ -698,6 +698,12 @@ export class WorkshopForm extends React.Component {
       return false;
     }
 
+    // Don't ask if admins want to send updates with workshop changes for virtual workshops.
+    // Update emails are suppressed for virtual workshops.
+    if (this.state.virtual) {
+      return false;
+    }
+
     // If location address is modified, then returned to blank,
     // this.state.location_address is a blank string instead of null.
     return (


### PR DESCRIPTION
There's a dialog that appears asking whether admins want to email workshop enrollees when they update certain information about a workshop. This is turned off for virtual workshops, so suppressing the dialog if a workshop is virtual. Image below is the dialog that is being hidden by this PR.

![image](https://user-images.githubusercontent.com/25372625/84530724-43292d80-ac98-11ea-8d09-ee59d2117b36.png)


## Testing story

Tested manually by flipping back and forth between virtual and non-virtual workshop types, and adding to the notes field, which is one of the [changes that generally triggers showing the dialog](https://github.com/code-dot-org/code-dot-org/blob/staging/apps/src/code-studio/pd/workshop_dashboard/components/workshop_form.jsx#L703).

## Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
