### PR TITLE
Edit level datasets more easily

### DIFF
--- a/apps/src/sites/studio/pages/levels/editors/_applab.js
+++ b/apps/src/sites/studio/pages/levels/editors/_applab.js
@@ -3,6 +3,7 @@ import $ from 'jquery';
 import React from 'react';
 import ReactDOM from 'react-dom';
 import getScriptData from '@cdo/apps/util/getScriptData';
+import color from '@cdo/apps/util/color';
 
 $(document).ready(function() {
   const makerBlocks = {
@@ -62,6 +63,15 @@ $(document).ready(function() {
     }
   });
 
+  const styles = {
+    optgroup: {
+      color: color.lightest_gray
+    },
+    option: {
+      color: color.black
+    }
+  };
+
   const data = getScriptData('applabOptions');
   const categories = (data.dataset_library_manifest.categories || []).filter(
     category => category.published
@@ -117,11 +127,16 @@ $(document).ready(function() {
             value={this.state.value}
             multiple={true}
             onChange={this.handleChange}
+            size={20}
           >
             {categories.map(category => (
-              <optgroup label={category.name} key={category.name}>
+              <optgroup
+                label={category.name}
+                key={category.name}
+                style={styles.optGroup}
+              >
                 {category.datasets.map(name => (
-                  <option key={name} value={name}>
+                  <option key={name} value={name} style={styles.option}>
                     {name}
                   </option>
                 ))}

--- a/apps/src/sites/studio/pages/levels/editors/_applab.js
+++ b/apps/src/sites/studio/pages/levels/editors/_applab.js
@@ -63,6 +63,9 @@ $(document).ready(function() {
   });
 
   const data = getScriptData('applabOptions');
+  const categories = (data.dataset_library_manifest.categories || []).filter(
+    category => category.published
+  );
   const tableNames = data.dataset_library_manifest.tables.map(
     table => table.name
   );
@@ -115,13 +118,15 @@ $(document).ready(function() {
             multiple={true}
             onChange={this.handleChange}
           >
-            {tableNames.map(name => {
-              return (
-                <option key={name} value={name}>
-                  {name}
-                </option>
-              );
-            })}
+            {categories.map(category => (
+              <optgroup label={category.name} key={category.name}>
+                {category.datasets.map(name => (
+                  <option key={name} value={name}>
+                    {name}
+                  </option>
+                ))}
+              </optgroup>
+            ))}
           </select>
         </div>
       );


### PR DESCRIPTION
### Description

Per request from the curriculum team, make it easier to edit datasets by (1) make the area bigger, (2) group by category, and (3) use alphabetical order. For context see: https://codedotorg.slack.com/archives/CNZP84FJ5/p1591887703260500

### Before

![dataset-select-before](https://user-images.githubusercontent.com/8001765/84431755-aeafc400-abe0-11ea-93bd-372f5e00db7e.gif)

### After

![dataset-select](https://user-images.githubusercontent.com/8001765/84431766-b1aab480-abe0-11ea-8f6a-e5d5fdc5532f.gif)

## Testing story

Manually verified that changes made via level edit page are persisted on level page reload, that they are persisted to the .level file, and that the corresponding datasets show up as tables containing data in the data tab.