### PR TITLE
CRv2: Remove ContactRollupsRaw unique constraint

### DIFF
--- a/dashboard/app/models/contact_rollups_raw.rb
+++ b/dashboard/app/models/contact_rollups_raw.rb
@@ -10,10 +10,6 @@
 #  created_at      :datetime         not null
 #  updated_at      :datetime         not null
 #
-# Indexes
-#
-#  index_contact_rollups_raw_on_email_and_sources  (email,sources) UNIQUE
-#
 
 class ContactRollupsRaw < ApplicationRecord
   self.table_name = 'contact_rollups_raw'

--- a/dashboard/db/migrate/20200611222103_remove_contact_rollups_raw_index.rb
+++ b/dashboard/db/migrate/20200611222103_remove_contact_rollups_raw_index.rb
@@ -1,0 +1,5 @@
+class RemoveContactRollupsRawIndex < ActiveRecord::Migration[5.0]
+  def change
+    remove_index :contact_rollups_raw, column: [:email, :sources]
+  end
+end

--- a/dashboard/db/schema.rb
+++ b/dashboard/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20200602014720) do
+ActiveRecord::Schema.define(version: 20200611222103) do
 
   create_table "activities", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci" do |t|
     t.integer  "user_id"
@@ -307,7 +307,6 @@ ActiveRecord::Schema.define(version: 20200602014720) do
     t.datetime "data_updated_at", null: false
     t.datetime "created_at",      null: false
     t.datetime "updated_at",      null: false
-    t.index ["email", "sources"], name: "index_contact_rollups_raw_on_email_and_sources", unique: true, using: :btree
   end
 
   create_table "contained_level_answers", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci" do |t|


### PR DESCRIPTION
[PLC-905](https://codedotorg.atlassian.net/browse/PLC-905): Remove an unique constraint on `email`-`sources` in `ContactRollupsRaw` table since we can have multiple records of the same email in a source table. 

For example, an user can submit multiple forms (`pegasus.forms`), and can attend multiple PD workshops (`dashboard.pd_enrollments`).

We want to keep the extraction step as simple as possible and keep all complicated logic in the processing step (in `ContactRollupsProcessed`).

## Next step
Adding an unique constraint for `email`-`sources`-`data`. The challenge here is `data` is a JSON field and we cannot simply create an index for it. May need to work around it by creating a virtual column, or find a different way to enforce the intended unique relationship.

## Testing story
Ran `rails db:migrate` in local machine.