### PR TITLE
Refactor `only_one_running?` usage in scripts

### DIFF
--- a/aws/ci_build
+++ b/aws/ci_build
@@ -20,7 +20,7 @@
 # is an easy way to force a rebuild without needing to make a commit.
 #
 require_relative '../lib/cdo/only_one'
-exit unless only_one_running?(__FILE__)
+exit(1) unless only_one_running?(__FILE__)
 
 require 'active_support/inflector'
 require_relative '../deployment'

--- a/aws/ci_build
+++ b/aws/ci_build
@@ -19,6 +19,8 @@
 # NOTE: running `touch build-started` (or running the `bin/start-build` script)
 # is an easy way to force a rebuild without needing to make a commit.
 #
+require_relative '../lib/cdo/only_one'
+exit unless only_one_running?(__FILE__)
 
 require 'active_support/inflector'
 require_relative '../deployment'
@@ -31,7 +33,6 @@ require 'cdo/honeybadger'
 require 'cdo/infra_production_topic'
 require 'cdo/rake_utils'
 require 'cdo/test_server_status'
-require 'cdo/only_one'
 require 'cdo/metrics_helper'
 require 'dynamic_config/dcdo'
 require 'aws-sdk-cloudwatch'
@@ -276,5 +277,3 @@ rescue => error
   ChatClient.log 'Unable to emit metrics', color: 'red'
   ChatClient.log "/quote #{error}", color: 'gray', message_format: 'text'
 end
-
-main if only_one_running?(__FILE__)

--- a/bin/create-release
+++ b/bin/create-release
@@ -1,7 +1,7 @@
 #!/usr/bin/env ruby
 require_relative '../deployment.rb'
 require 'cdo/only_one'
-exit unless only_one_running?(__FILE__)
+exit(1) unless only_one_running?(__FILE__)
 
 require 'cdo/cdo_cli'
 include CdoCli

--- a/bin/create-release
+++ b/bin/create-release
@@ -1,6 +1,8 @@
 #!/usr/bin/env ruby
 require_relative '../deployment.rb'
 require 'cdo/only_one'
+exit unless only_one_running?(__FILE__)
+
 require 'cdo/cdo_cli'
 include CdoCli
 
@@ -165,4 +167,4 @@ OptionParser.new do |opts|
   end
 end.parse!
 
-main(options) if only_one_running?(__FILE__)
+main(options)

--- a/bin/cron/activity-monitor
+++ b/bin/cron/activity-monitor
@@ -1,4 +1,6 @@
 #!/usr/bin/env ruby
+require_relative 'only_one'
+exit unless only_one_running?(__FILE__)
 #
 # This script monitors level completion rates and issues Slack complaints if a significant
 # number of browsers has attempted a level without anybody finishing it successfully.
@@ -12,7 +14,6 @@
 #
 # including dashboard environment doesn't work if not in the dashboard dir
 require_relative '../../deployment'
-require 'cdo/only_one'
 require 'cdo/chat_client'
 require 'cdo/user_agent_parser'
 require 'retryable'
@@ -193,4 +194,4 @@ def main
   end
 end
 
-main if only_one_running?(__FILE__)
+main

--- a/bin/cron/activity-monitor
+++ b/bin/cron/activity-monitor
@@ -1,6 +1,6 @@
 #!/usr/bin/env ruby
 require_relative 'only_one'
-exit unless only_one_running?(__FILE__)
+exit(1) unless only_one_running?(__FILE__)
 #
 # This script monitors level completion rates and issues Slack complaints if a significant
 # number of browsers has attempted a level without anybody finishing it successfully.

--- a/bin/cron/analyze_hoc_activity
+++ b/bin/cron/analyze_hoc_activity
@@ -1,6 +1,6 @@
 #!/usr/bin/env ruby
 require_relative './only_one'
-exit unless only_one_running?(__FILE__)
+exit(1) unless only_one_running?(__FILE__)
 #
 # This script analyzes the activity that is launched from code.org/learn. We track outgoing clicks,
 # hidden image calls at the beginning and end of [3rd party] tutorials, and visits to our finish

--- a/bin/cron/analyze_hoc_activity
+++ b/bin/cron/analyze_hoc_activity
@@ -1,4 +1,6 @@
 #!/usr/bin/env ruby
+require_relative './only_one'
+exit unless only_one_running?(__FILE__)
 #
 # This script analyzes the activity that is launched from code.org/learn. We track outgoing clicks,
 # hidden image calls at the beginning and end of [3rd party] tutorials, and visits to our finish
@@ -14,7 +16,6 @@
 #
 require File.expand_path('../../../pegasus/src/env', __FILE__)
 require src_dir 'database'
-require 'cdo/only_one'
 require 'cdo/properties'
 require 'dynamic_config/dcdo'
 
@@ -26,8 +27,6 @@ require_relative '../../lib/analyze_hoc_activity_helper'
 DEFAULT_LINES_OF_CODE = 20_886_942_901
 
 def main
-  return unless only_one_running?(__FILE__)
-
   to_date = JSON.load(IO.read(pegasus_dir("cache/HourOfActivity_Totals_2014-12-05.json")))
 
   total_started = to_date['started']

--- a/bin/cron/applab_datasets/daily_weather
+++ b/bin/cron/applab_datasets/daily_weather
@@ -1,6 +1,6 @@
 #!/usr/bin/env ruby
 require_relative 'only_one'
-exit unless only_one_running?(__FILE__)
+exit(1) unless only_one_running?(__FILE__)
 
 # This script fetches weather forecast data from api.openweathermap and uploads to the shared firebase channel.
 require_relative '../../../deployment'

--- a/bin/cron/applab_datasets/daily_weather
+++ b/bin/cron/applab_datasets/daily_weather
@@ -1,8 +1,9 @@
 #!/usr/bin/env ruby
+require_relative 'only_one'
+exit unless only_one_running?(__FILE__)
 
 # This script fetches weather forecast data from api.openweathermap and uploads to the shared firebase channel.
 require_relative '../../../deployment'
-require 'cdo/only_one'
 require 'net/http'
 require 'json'
 require 'ostruct'
@@ -204,4 +205,4 @@ def main
   fb.upload_live_table('Daily Weather', records, columns)
 end
 
-main if only_one_running?(__FILE__)
+main

--- a/bin/cron/applab_datasets/spotify
+++ b/bin/cron/applab_datasets/spotify
@@ -1,8 +1,9 @@
 #!/usr/bin/env ruby
+require_relative 'only_one'
+exit unless only_one_running?(__FILE__)
 
 # This script fetches spotify data from api.spotify and uploads to the shared firebase channel.
 require_relative '../../../deployment'
-require 'cdo/only_one'
 require 'net/http'
 require 'csv'
 require 'ostruct'
@@ -99,4 +100,4 @@ def main
   fb.upload_live_table('Viral 50 Worldwide', records, columns)
 end
 
-main if only_one_running?(__FILE__)
+main

--- a/bin/cron/applab_datasets/spotify
+++ b/bin/cron/applab_datasets/spotify
@@ -1,6 +1,6 @@
 #!/usr/bin/env ruby
 require_relative 'only_one'
-exit unless only_one_running?(__FILE__)
+exit(1) unless only_one_running?(__FILE__)
 
 # This script fetches spotify data from api.spotify and uploads to the shared firebase channel.
 require_relative '../../../deployment'

--- a/bin/cron/build_contact_rollups
+++ b/bin/cron/build_contact_rollups
@@ -1,6 +1,6 @@
 #!/usr/bin/env ruby
 require_relative 'only_one'
-exit unless only_one_running?(__FILE__)
+exit(1) unless only_one_running?(__FILE__)
 
 require_relative('../../dashboard/config/environment')
 require 'cdo/contact_rollups'

--- a/bin/cron/build_contact_rollups
+++ b/bin/cron/build_contact_rollups
@@ -1,11 +1,12 @@
 #!/usr/bin/env ruby
+require_relative 'only_one'
+exit unless only_one_running?(__FILE__)
 
 require_relative('../../dashboard/config/environment')
 require 'cdo/contact_rollups'
 require 'cdo/contact_rollups_validation'
 require 'cdo/pardot'
 require 'cdo/chat_client'
-require 'cdo/only_one'
 require 'cdo/log_collector'
 require 'honeybadger/ruby'
 
@@ -50,4 +51,4 @@ ensure
   end
 end
 
-main if only_one_running?(__FILE__)
+main

--- a/bin/cron/build_contact_rollups_v2
+++ b/bin/cron/build_contact_rollups_v2
@@ -1,8 +1,9 @@
 #!/usr/bin/env ruby
+require_relative 'only_one'
+exit unless only_one_running?(__FILE__)
 
 require_relative '../../dashboard/config/environment'
 require_relative '../../dashboard/lib/contact_rollups_v2'
-require 'cdo/only_one'
 
 def main
   # To avoid accidentally syncing bad data to Pardot, this script should run
@@ -20,4 +21,4 @@ ensure
   contact_rollups.report_results
 end
 
-main if only_one_running?(__FILE__)
+main

--- a/bin/cron/build_contact_rollups_v2
+++ b/bin/cron/build_contact_rollups_v2
@@ -1,6 +1,6 @@
 #!/usr/bin/env ruby
 require_relative 'only_one'
-exit unless only_one_running?(__FILE__)
+exit(1) unless only_one_running?(__FILE__)
 
 require_relative '../../dashboard/config/environment'
 require_relative '../../dashboard/lib/contact_rollups_v2'

--- a/bin/cron/cleanup_workshop_attendance_codes
+++ b/bin/cron/cleanup_workshop_attendance_codes
@@ -1,6 +1,6 @@
 #!/usr/bin/env ruby
 require_relative 'only_one'
-exit unless only_one_running?(__FILE__)
+exit(1) unless only_one_running?(__FILE__)
 
 require_relative '../../dashboard/config/environment'
 

--- a/bin/cron/cleanup_workshop_attendance_codes
+++ b/bin/cron/cleanup_workshop_attendance_codes
@@ -1,7 +1,8 @@
 #!/usr/bin/env ruby
+require_relative 'only_one'
+exit unless only_one_running?(__FILE__)
 
 require_relative '../../dashboard/config/environment'
-require 'cdo/only_one'
 
 def main
   three_days_ago = Time.now - 3.days
@@ -11,4 +12,4 @@ def main
     find_each(&:remove_code)
 end
 
-main if only_one_running?(__FILE__)
+main

--- a/bin/cron/commit_content
+++ b/bin/cron/commit_content
@@ -1,6 +1,6 @@
 #!/usr/bin/env ruby
 require_relative 'only_one'
-exit unless only_one_running?(__FILE__)
+exit(1) unless only_one_running?(__FILE__)
 
 # This script commits content on the machine to its associated branch. It is expected to be run only
 # on staging and levelbuilder (levelbuilder-staging).

--- a/bin/cron/commit_content
+++ b/bin/cron/commit_content
@@ -1,4 +1,6 @@
 #!/usr/bin/env ruby
+require_relative 'only_one'
+exit unless only_one_running?(__FILE__)
 
 # This script commits content on the machine to its associated branch. It is expected to be run only
 # on staging and levelbuilder (levelbuilder-staging).
@@ -6,7 +8,6 @@
 require_relative '../../deployment'
 require 'cdo/chat_client'
 require 'cdo/developers_topic'
-require 'cdo/only_one'
 
 class ContentCommitter
   # @param [Symbol] env The environment the commit is being performed on.
@@ -83,4 +84,4 @@ rescue Exception => e
   content_committer.set_slack_failed
 end
 
-main if only_one_running?(__FILE__)
+main

--- a/bin/cron/confirm_usage
+++ b/bin/cron/confirm_usage
@@ -1,6 +1,6 @@
 #!/usr/bin/env ruby
 require_relative 'only_one'
-exit unless only_one_running?(__FILE__)
+exit(1) unless only_one_running?(__FILE__)
 
 # A script that confirms we are seeing expected usage on our sites. An alert is
 # raised if we are missing expected usage in the most recent minutes.

--- a/bin/cron/confirm_usage
+++ b/bin/cron/confirm_usage
@@ -1,4 +1,6 @@
 #!/usr/bin/env ruby
+require_relative 'only_one'
+exit unless only_one_running?(__FILE__)
 
 # A script that confirms we are seeing expected usage on our sites. An alert is
 # raised if we are missing expected usage in the most recent minutes.
@@ -10,7 +12,6 @@
 require_relative('../../deployment')
 require 'cdo/chat_client'
 require 'cdo/db'
-require 'cdo/only_one'
 
 ALERT_FILENAME = 'confirm_usage_alert'.freeze
 SECONDS_PER_MINUTE = 60
@@ -82,4 +83,4 @@ def main
   end
 end
 
-main if only_one_running?(__FILE__)
+main

--- a/bin/cron/create_rollup_tables
+++ b/bin/cron/create_rollup_tables
@@ -5,7 +5,7 @@
 
 require_relative 'only_one'
 
-exit unless only_one_running?(__FILE__)
+exit(1) unless only_one_running?(__FILE__)
 
 require_relative '../../dashboard/config/environment'
 

--- a/bin/cron/create_rollup_tables
+++ b/bin/cron/create_rollup_tables
@@ -3,7 +3,7 @@
 # This script populates (after truncating) the contained_levels,
 # contained_level_answers, and the level_sources_multi_type tables.
 
-require_relative '../../lib/cdo/only_one'
+require_relative 'only_one'
 
 exit unless only_one_running?(__FILE__)
 

--- a/bin/cron/delete_twilio_data
+++ b/bin/cron/delete_twilio_data
@@ -1,6 +1,6 @@
 #!/usr/bin/env ruby
 require_relative 'only_one'
-exit unless only_one_running?(__FILE__)
+exit(1) unless only_one_running?(__FILE__)
 
 # This script instructs Twilio to delete data related to SMS messages we send
 # through their service. Doing so both protects our users (reducing PII data)

--- a/bin/cron/delete_twilio_data
+++ b/bin/cron/delete_twilio_data
@@ -1,4 +1,6 @@
 #!/usr/bin/env ruby
+require_relative 'only_one'
+exit unless only_one_running?(__FILE__)
 
 # This script instructs Twilio to delete data related to SMS messages we send
 # through their service. Doing so both protects our users (reducing PII data)
@@ -6,7 +8,6 @@
 
 require File.expand_path('../../../pegasus/src/env', __FILE__)
 require 'honeybadger'
-require 'cdo/only_one'
 require 'date'
 require 'twilio-ruby'
 
@@ -48,4 +49,4 @@ def main
   end
 end
 
-main if only_one_running?(__FILE__)
+main

--- a/bin/cron/deliver_poste_messages
+++ b/bin/cron/deliver_poste_messages
@@ -1,6 +1,6 @@
 #!/usr/bin/env ruby
 require_relative 'only_one'
-exit unless only_one_running?(__FILE__)
+exit(1) unless only_one_running?(__FILE__)
 
 require File.expand_path('../../../pegasus/src/env', __FILE__)
 require 'retryable'

--- a/bin/cron/deliver_poste_messages
+++ b/bin/cron/deliver_poste_messages
@@ -1,5 +1,5 @@
 #!/usr/bin/env ruby
-require_relative '../../lib/cdo/only_one'
+require_relative 'only_one'
 exit unless only_one_running?(__FILE__)
 
 require File.expand_path('../../../pegasus/src/env', __FILE__)

--- a/bin/cron/deploy_to_levelbuilder
+++ b/bin/cron/deploy_to_levelbuilder
@@ -1,6 +1,6 @@
 #!/usr/bin/env ruby
 require_relative 'only_one'
-exit unless only_one_running?(__FILE__)
+exit(1) unless only_one_running?(__FILE__)
 
 # A script that performs a merge of the test branch into the levelbuilder branch.
 #

--- a/bin/cron/deploy_to_levelbuilder
+++ b/bin/cron/deploy_to_levelbuilder
@@ -1,4 +1,6 @@
 #!/usr/bin/env ruby
+require_relative 'only_one'
+exit unless only_one_running?(__FILE__)
 
 # A script that performs a merge of the test branch into the levelbuilder branch.
 #
@@ -9,7 +11,6 @@ require 'cdo/chat_client'
 require 'cdo/developers_topic'
 require 'cdo/infra_test_topic'
 require 'cdo/github'
-require 'cdo/only_one'
 
 TOPIC_DTL_SOON = 'yes (deploying soon)'.freeze
 TOPIC_DTL_IN_PROGRESS = 'no (in progress)'.freeze
@@ -113,4 +114,4 @@ rescue Exception => e
   DevelopersTopic.set_dtl TOPIC_DTL_FAILED
 end
 
-main if only_one_running?(__FILE__)
+main

--- a/bin/cron/deploy_to_test
+++ b/bin/cron/deploy_to_test
@@ -1,6 +1,6 @@
 #!/usr/bin/env ruby
 require_relative 'only_one'
-exit unless only_one_running?(__FILE__)
+exit(1) unless only_one_running?(__FILE__)
 
 require_relative '../../deployment'
 require 'cdo/chat_client'

--- a/bin/cron/deploy_to_test
+++ b/bin/cron/deploy_to_test
@@ -1,11 +1,12 @@
 #!/usr/bin/env ruby
+require_relative 'only_one'
+exit unless only_one_running?(__FILE__)
 
 require_relative '../../deployment'
 require 'cdo/chat_client'
 require 'cdo/developers_topic'
 require 'cdo/github'
 require 'cdo/infra_test_topic'
-require 'cdo/only_one'
 require 'cdo/metrics_helper'
 
 TOPIC_DTT_IN_PROGRESS = 'no (robo-DTT in progress)'.freeze
@@ -46,4 +47,4 @@ rescue Exception => e
   DevelopersTopic.set_dtt TOPIC_DTT_FAILED
 end
 
-main if only_one_running?(__FILE__)
+main

--- a/bin/cron/detect_restricted_videos
+++ b/bin/cron/detect_restricted_videos
@@ -1,6 +1,6 @@
 #!/usr/bin/env ruby
 require_relative 'only_one'
-exit unless only_one_running?(__FILE__)
+exit(1) unless only_one_running?(__FILE__)
 
 require 'csv'
 require 'httparty'

--- a/bin/cron/detect_restricted_videos
+++ b/bin/cron/detect_restricted_videos
@@ -1,7 +1,6 @@
 #!/usr/bin/env ruby
-
-require_relative '../../lib/cdo/only_one'
-exit(1) unless only_one_running?(__FILE__)
+require_relative 'only_one'
+exit unless only_one_running?(__FILE__)
 
 require 'csv'
 require 'httparty'

--- a/bin/cron/export_mysql_database_to_redshift
+++ b/bin/cron/export_mysql_database_to_redshift
@@ -1,5 +1,5 @@
 #!/usr/bin/env ruby
-require_relative '../../lib/cdo/only_one'
+require_relative 'only_one'
 exit unless only_one_running?(__FILE__)
 
 require_relative '../../dashboard/config/environment'

--- a/bin/cron/export_mysql_database_to_redshift
+++ b/bin/cron/export_mysql_database_to_redshift
@@ -1,6 +1,6 @@
 #!/usr/bin/env ruby
 require_relative 'only_one'
-exit unless only_one_running?(__FILE__)
+exit(1) unless only_one_running?(__FILE__)
 
 require_relative '../../dashboard/config/environment'
 exit unless rack_env?(:production) && CDO.dashboard_hostname == 'studio.code.org'

--- a/bin/cron/form_geos
+++ b/bin/cron/form_geos
@@ -1,6 +1,6 @@
 #!/usr/bin/env ruby
 require_relative 'only_one'
-exit unless only_one_running?(__FILE__)
+exit(1) unless only_one_running?(__FILE__)
 
 # This script incrementally populates the pegasus form_geos table using
 # geolocation of the ip_address.

--- a/bin/cron/form_geos
+++ b/bin/cron/form_geos
@@ -1,4 +1,6 @@
 #!/usr/bin/env ruby
+require_relative 'only_one'
+exit unless only_one_running?(__FILE__)
 
 # This script incrementally populates the pegasus form_geos table using
 # geolocation of the ip_address.
@@ -8,7 +10,6 @@ require 'active_support'
 require 'active_support/core_ext/object/blank'
 require 'cdo/db'
 require 'cdo/geocoder'
-require 'cdo/only_one'
 require 'retryable'
 
 BATCH_SIZE = 1000
@@ -34,4 +35,4 @@ def main
   end
 end
 
-main if only_one_running?(__FILE__)
+main

--- a/bin/cron/geocode_hoc_activity
+++ b/bin/cron/geocode_hoc_activity
@@ -1,6 +1,6 @@
 #!/usr/bin/env ruby
 require_relative 'only_one'
-exit unless only_one_running?(__FILE__)
+exit(1) unless only_one_running?(__FILE__)
 
 # This script updates the location data in the hoc_activity table using
 # geolocation.

--- a/bin/cron/geocode_hoc_activity
+++ b/bin/cron/geocode_hoc_activity
@@ -1,11 +1,12 @@
 #!/usr/bin/env ruby
+require_relative 'only_one'
+exit unless only_one_running?(__FILE__)
 
 # This script updates the location data in the hoc_activity table using
 # geolocation.
 
 require File.expand_path('../../../pegasus/src/env', __FILE__)
 require src_dir 'database'
-require 'cdo/only_one'
 require 'cdo/properties'
 
 BATCH_SIZE = 5000
@@ -47,4 +48,4 @@ def main
   Properties.set('hoc_activity.last_id', last_index) if last_index
 end
 
-main if only_one_running?(__FILE__)
+main

--- a/bin/cron/hoc_signup_counts
+++ b/bin/cron/hoc_signup_counts
@@ -1,11 +1,12 @@
 #!/usr/bin/env ruby
+require_relative 'only_one'
+exit unless only_one_running?(__FILE__)
 
 # This script performs aggregation queries on the pegasus.forms table, specifically HOC signup
 # forms, saving the results to the pegasus.properties table.
 
 require File.expand_path('../../../pegasus/src/env', __FILE__)
 require 'cdo/db'
-require 'cdo/only_one'
 require 'cdo/properties'
 require 'dynamic_config/dcdo'
 
@@ -47,4 +48,4 @@ def main
   )
 end
 
-main if only_one_running?(__FILE__)
+main

--- a/bin/cron/hoc_signup_counts
+++ b/bin/cron/hoc_signup_counts
@@ -1,6 +1,6 @@
 #!/usr/bin/env ruby
 require_relative 'only_one'
-exit unless only_one_running?(__FILE__)
+exit(1) unless only_one_running?(__FILE__)
 
 # This script performs aggregation queries on the pegasus.forms table, specifically HOC signup
 # forms, saving the results to the pegasus.properties table.

--- a/bin/cron/import_google_sheets
+++ b/bin/cron/import_google_sheets
@@ -1,6 +1,6 @@
 #!/usr/bin/env ruby
 require_relative 'only_one'
-exit unless only_one_running?(__FILE__)
+exit(1) unless only_one_running?(__FILE__)
 
 require File.expand_path('../../../pegasus/src/env', __FILE__)
 

--- a/bin/cron/import_google_sheets
+++ b/bin/cron/import_google_sheets
@@ -1,6 +1,8 @@
 #!/usr/bin/env ruby
+require_relative 'only_one'
+exit unless only_one_running?(__FILE__)
+
 require File.expand_path('../../../pegasus/src/env', __FILE__)
-require 'cdo/only_one'
 
 def main
   Dir.chdir(pegasus_dir) do
@@ -9,8 +11,4 @@ def main
   end
 end
 
-if only_one_running?(__FILE__)
-  main
-else
-  puts "Importing Google sheets was unsuccessful. This might be because there is already another import_google_sheet process that is stuck. Check for an import_google_sheets.pid file, delete it and try again."
-end
+main

--- a/bin/cron/merge_lb_to_staging
+++ b/bin/cron/merge_lb_to_staging
@@ -1,4 +1,6 @@
 #!/usr/bin/env ruby
+require_relative 'only_one'
+exit unless only_one_running?(__FILE__)
 
 # This script merges the levelbuilder branch into the staging branch.
 
@@ -6,7 +8,6 @@ require_relative '../../deployment'
 require 'cdo/chat_client'
 require 'cdo/developers_topic'
 require 'cdo/github'
-require 'cdo/only_one'
 
 def slack_permission?
   return true if DevelopersTopic.dts?
@@ -57,4 +58,4 @@ rescue Exception => e
   DevelopersTopic.set_dts 'no (robo-DTS failed (Levelbuilder > Staging))'
 end
 
-main if only_one_running?(__FILE__)
+main

--- a/bin/cron/merge_lb_to_staging
+++ b/bin/cron/merge_lb_to_staging
@@ -1,6 +1,6 @@
 #!/usr/bin/env ruby
 require_relative 'only_one'
-exit unless only_one_running?(__FILE__)
+exit(1) unless only_one_running?(__FILE__)
 
 # This script merges the levelbuilder branch into the staging branch.
 

--- a/bin/cron/mysql-metrics
+++ b/bin/cron/mysql-metrics
@@ -1,6 +1,6 @@
 #!/usr/bin/env ruby
 require_relative 'only_one'
-exit unless only_one_running?(__FILE__)
+exit(1) unless only_one_running?(__FILE__)
 
 require_relative '../../deployment'
 require 'cdo/db'

--- a/bin/cron/mysql-metrics
+++ b/bin/cron/mysql-metrics
@@ -1,4 +1,7 @@
 #!/usr/bin/env ruby
+require_relative 'only_one'
+exit unless only_one_running?(__FILE__)
+
 require_relative '../../deployment'
 require 'cdo/db'
 require 'aws-sdk-cloudwatch'

--- a/bin/cron/only_one.rb
+++ b/bin/cron/only_one.rb
@@ -1,0 +1,1 @@
+../../lib/cdo/only_one.rb

--- a/bin/cron/process_forms
+++ b/bin/cron/process_forms
@@ -1,7 +1,9 @@
 #!/usr/bin/env ruby
+require_relative 'only_one'
+exit unless only_one_running?(__FILE__)
+
 require File.expand_path('../../../pegasus/src/env', __FILE__)
 require 'cdo/chat_client'
-require 'cdo/only_one'
 require 'retryable'
 require src_dir 'forms'
 require src_dir 'abort_form_error'
@@ -96,4 +98,4 @@ def main
   system "#{deploy_dir('bin/cron', 'deliver_poste_messages').shellescape} 2>&1" unless receipt_count == 0
 end
 
-main if only_one_running?(__FILE__)
+main

--- a/bin/cron/process_forms
+++ b/bin/cron/process_forms
@@ -1,6 +1,6 @@
 #!/usr/bin/env ruby
 require_relative 'only_one'
-exit unless only_one_running?(__FILE__)
+exit(1) unless only_one_running?(__FILE__)
 
 require File.expand_path('../../../pegasus/src/env', __FILE__)
 require 'cdo/chat_client'

--- a/bin/cron/process_jotform_data
+++ b/bin/cron/process_jotform_data
@@ -1,6 +1,6 @@
 #!/usr/bin/env ruby
 require_relative 'only_one'
-exit unless only_one_running?(__FILE__)
+exit(1) unless only_one_running?(__FILE__)
 
 require_relative '../../dashboard/config/environment'
 

--- a/bin/cron/process_jotform_data
+++ b/bin/cron/process_jotform_data
@@ -1,7 +1,8 @@
 #!/usr/bin/env ruby
+require_relative 'only_one'
+exit unless only_one_running?(__FILE__)
 
 require_relative '../../dashboard/config/environment'
-require 'cdo/only_one'
 
 TIME_NOW = DateTime.now.strftime('%F %T').freeze
 
@@ -146,4 +147,4 @@ def main
   end
 end
 
-main if only_one_running?(__FILE__)
+main

--- a/bin/cron/purge_expired_deleted_accounts
+++ b/bin/cron/purge_expired_deleted_accounts
@@ -1,6 +1,6 @@
 #!/usr/bin/env ruby
 require_relative 'only_one'
-exit unless only_one_running?(__FILE__)
+exit(1) unless only_one_running?(__FILE__)
 
 #
 # purge_expired_deleted_accounts

--- a/bin/cron/purge_expired_deleted_accounts
+++ b/bin/cron/purge_expired_deleted_accounts
@@ -1,4 +1,6 @@
 #!/usr/bin/env ruby
+require_relative 'only_one'
+exit unless only_one_running?(__FILE__)
 
 #
 # purge_expired_deleted_accounts
@@ -18,7 +20,6 @@
 require 'active_support/core_ext/numeric/time'
 require 'date'
 require 'optparse'
-require_relative '../../lib/cdo/only_one'
 
 options = {}
 OptionParser.new do |opts|
@@ -41,9 +42,6 @@ OptionParser.new do |opts|
     exit
   end
 end.parse!
-
-# Make sure we're the only copy of this script running.
-exit(1) unless only_one_running?(__FILE__)
 
 require_relative '../../dashboard/config/environment'
 require_relative '../../dashboard/lib/expired_deleted_account_purger'

--- a/bin/cron/restart_high_memory_frontend_services
+++ b/bin/cron/restart_high_memory_frontend_services
@@ -1,6 +1,6 @@
 #!/usr/bin/env ruby
 require_relative 'only_one'
-exit unless only_one_running?(__FILE__)
+exit(1) unless only_one_running?(__FILE__)
 
 require_relative '../../dashboard/config/environment'
 require 'aws-sdk-ec2'

--- a/bin/cron/restart_high_memory_frontend_services
+++ b/bin/cron/restart_high_memory_frontend_services
@@ -1,7 +1,8 @@
 #!/usr/bin/env ruby
+require_relative 'only_one'
+exit unless only_one_running?(__FILE__)
 
 require_relative '../../dashboard/config/environment'
-require_relative '../../lib/cdo/only_one'
 require 'aws-sdk-ec2'
 require 'aws-sdk-cloudwatch'
 require 'cdo/chat_client'
@@ -76,4 +77,4 @@ def main
   end
 end
 
-main if only_one_running?(__FILE__)
+main

--- a/bin/cron/run_server_generate_pdfs
+++ b/bin/cron/run_server_generate_pdfs
@@ -1,6 +1,6 @@
 #!/usr/bin/env ruby
 require_relative 'only_one'
-exit unless only_one_running?(__FILE__)
+exit(1) unless only_one_running?(__FILE__)
 
 require_relative '../../deployment'
 require 'cdo/rack/rackup'

--- a/bin/cron/run_server_generate_pdfs
+++ b/bin/cron/run_server_generate_pdfs
@@ -1,7 +1,9 @@
 #!/usr/bin/env ruby
+require_relative 'only_one'
+exit unless only_one_running?(__FILE__)
+
 require_relative '../../deployment'
 require 'cdo/rack/rackup'
-require 'cdo/only_one'
 require 'cdo/rake_utils'
 CDO.log.level = Logger::WARN
 
@@ -13,4 +15,4 @@ def main
   end
 end
 
-main if only_one_running?(__FILE__)
+main

--- a/bin/cron/stop_inactive_adhoc_instances
+++ b/bin/cron/stop_inactive_adhoc_instances
@@ -1,11 +1,11 @@
 #!/usr/bin/env ruby
+require_relative 'only_one'
+exit unless only_one_running?(__FILE__)
 
 # This script stops AWS EC2 instances being used to run adhoc environments,
 # reporting a list of all stopped instances to ChatClient.
 
 require_relative '../../deployment'
-require 'cdo/only_one'
-exit unless only_one_running?(__FILE__)
 
 require 'aws-sdk-ec2'
 require 'cdo/chat_client'

--- a/bin/cron/stop_inactive_adhoc_instances
+++ b/bin/cron/stop_inactive_adhoc_instances
@@ -1,6 +1,6 @@
 #!/usr/bin/env ruby
 require_relative 'only_one'
-exit unless only_one_running?(__FILE__)
+exit(1) unless only_one_running?(__FILE__)
 
 # This script stops AWS EC2 instances being used to run adhoc environments,
 # reporting a list of all stopped instances to ChatClient.

--- a/bin/cron/summer_workshop_enrollments_to_gdrive
+++ b/bin/cron/summer_workshop_enrollments_to_gdrive
@@ -1,5 +1,5 @@
 #!/usr/bin/env ruby
-require_relative '../../lib/cdo/only_one'
+require_relative 'only_one'
 exit unless only_one_running?(__FILE__)
 
 require_relative '../../dashboard/config/environment'

--- a/bin/cron/summer_workshop_enrollments_to_gdrive
+++ b/bin/cron/summer_workshop_enrollments_to_gdrive
@@ -1,6 +1,6 @@
 #!/usr/bin/env ruby
 require_relative 'only_one'
-exit unless only_one_running?(__FILE__)
+exit(1) unless only_one_running?(__FILE__)
 
 require_relative '../../dashboard/config/environment'
 require 'cdo/google/sheet'

--- a/bin/cron/summer_workshops_to_gdrive
+++ b/bin/cron/summer_workshops_to_gdrive
@@ -1,5 +1,5 @@
 #!/usr/bin/env ruby
-require_relative '../../lib/cdo/only_one'
+require_relative 'only_one'
 exit unless only_one_running?(__FILE__)
 
 require_relative '../../dashboard/config/environment'

--- a/bin/cron/summer_workshops_to_gdrive
+++ b/bin/cron/summer_workshops_to_gdrive
@@ -1,6 +1,6 @@
 #!/usr/bin/env ruby
 require_relative 'only_one'
-exit unless only_one_running?(__FILE__)
+exit(1) unless only_one_running?(__FILE__)
 
 require_relative '../../dashboard/config/environment'
 require 'cdo/google/sheet'

--- a/bin/cron/sync_dropbox
+++ b/bin/cron/sync_dropbox
@@ -1,4 +1,6 @@
 #!/usr/bin/env ruby
+require_relative 'only_one'
+exit unless only_one_running?(__FILE__)
 
 # This syncs content changes from the shared dropbox folder to our github repo
 # on the staging machine. This is required for contents changes from dropbox to
@@ -6,12 +8,10 @@
 
 SCRIPT_START = Time.now
 
-require_relative "../../lib/cdo/only_one"
 require_relative "../../deployment"
 require "cdo/slack"
 require "cdo/high_frequency_reporter"
 require "open3"
-exit unless only_one_running?(__FILE__)
 
 FOLDERS = {
   "advocacy.code.org" => "sites.v3/advocacy.code.org",

--- a/bin/cron/sync_dropbox
+++ b/bin/cron/sync_dropbox
@@ -1,6 +1,6 @@
 #!/usr/bin/env ruby
 require_relative 'only_one'
-exit unless only_one_running?(__FILE__)
+exit(1) unless only_one_running?(__FILE__)
 
 # This syncs content changes from the shared dropbox folder to our github repo
 # on the staging machine. This is required for contents changes from dropbox to

--- a/bin/cron/teacher_applications_to_gdrive
+++ b/bin/cron/teacher_applications_to_gdrive
@@ -1,5 +1,5 @@
 #!/usr/bin/env ruby
-require_relative '../../lib/cdo/only_one'
+require_relative 'only_one'
 exit unless only_one_running?(__FILE__)
 
 require_relative '../../dashboard/config/environment'

--- a/bin/cron/teacher_applications_to_gdrive
+++ b/bin/cron/teacher_applications_to_gdrive
@@ -1,6 +1,6 @@
 #!/usr/bin/env ruby
 require_relative 'only_one'
-exit unless only_one_running?(__FILE__)
+exit(1) unless only_one_running?(__FILE__)
 
 require_relative '../../dashboard/config/environment'
 require 'cdo/google/sheet'

--- a/bin/cron/update_census_mapbox
+++ b/bin/cron/update_census_mapbox
@@ -1,4 +1,6 @@
 #!/usr/bin/env ruby
+require_relative 'only_one'
+exit unless only_one_running?(__FILE__)
 
 # The map on code.org/yourschool is run off of Mapbox.
 # This script updates the data on Mapbox by querying all rows from
@@ -10,7 +12,6 @@
 #   CDO.mapbox_upload_token: (the auth token for uploading tiles to Mapbox's servers)
 
 require_relative '../../dashboard/config/environment'
-require 'cdo/only_one'
 require 'cdo/properties'
 
 require_relative 'upload_to_mapbox'
@@ -22,8 +23,6 @@ def make_location(lat, long)
 end
 
 def main
-  return unless only_one_running?(__FILE__)
-
   # Update summaries before updating the fusion table
   # If any single teaches_cs category in a given year changes by more than
   # 10% of the total number of schools then issue a Honeybadger notification.

--- a/bin/cron/update_census_mapbox
+++ b/bin/cron/update_census_mapbox
@@ -1,6 +1,6 @@
 #!/usr/bin/env ruby
 require_relative 'only_one'
-exit unless only_one_running?(__FILE__)
+exit(1) unless only_one_running?(__FILE__)
 
 # The map on code.org/yourschool is run off of Mapbox.
 # This script updates the data on Mapbox by querying all rows from

--- a/bin/cron/update_dotd
+++ b/bin/cron/update_dotd
@@ -1,10 +1,11 @@
 #!/usr/bin/env ruby
+require_relative 'only_one'
+exit unless only_one_running?(__FILE__)
 
 require 'open-uri'
 require 'json'
 require File.expand_path('../../../pegasus/src/env', __FILE__)
 require_relative '../../deployment'
-require 'cdo/only_one'
 require 'cdo/pager_duty'
 require 'cdo/slack'
 
@@ -26,4 +27,4 @@ def main
   Slack.update_topic('developers', new_topic) unless new_topic == current_topic
 end
 
-main if only_one_running?(__FILE__)
+main

--- a/bin/cron/update_dotd
+++ b/bin/cron/update_dotd
@@ -1,6 +1,6 @@
 #!/usr/bin/env ruby
 require_relative 'only_one'
-exit unless only_one_running?(__FILE__)
+exit(1) unless only_one_running?(__FILE__)
 
 require 'open-uri'
 require 'json'

--- a/bin/cron/update_dts
+++ b/bin/cron/update_dts
@@ -1,11 +1,12 @@
 #!/usr/bin/env ruby
+require_relative 'only_one'
+exit unless only_one_running?(__FILE__)
 
 # This script updates the "DTS" check on PRs
 
 require_relative '../../deployment'
 require 'cdo/github'
 require 'cdo/developers_topic'
-require 'cdo/only_one'
 
 DTS_FILE = '.dts'.freeze
 
@@ -23,4 +24,4 @@ def main
   end
 end
 
-main if only_one_running?(__FILE__)
+main

--- a/bin/cron/update_dts
+++ b/bin/cron/update_dts
@@ -1,6 +1,6 @@
 #!/usr/bin/env ruby
 require_relative 'only_one'
-exit unless only_one_running?(__FILE__)
+exit(1) unless only_one_running?(__FILE__)
 
 # This script updates the "DTS" check on PRs
 

--- a/bin/cron/update_dtsn
+++ b/bin/cron/update_dtsn
@@ -1,6 +1,6 @@
 #!/usr/bin/env ruby
 require_relative 'only_one'
-exit unless only_one_running?(__FILE__)
+exit(1) unless only_one_running?(__FILE__)
 
 # This script updates the "DTSN" check on PRs
 

--- a/bin/cron/update_dtsn
+++ b/bin/cron/update_dtsn
@@ -1,11 +1,12 @@
 #!/usr/bin/env ruby
+require_relative 'only_one'
+exit unless only_one_running?(__FILE__)
 
 # This script updates the "DTSN" check on PRs
 
 require_relative '../../deployment'
 require 'cdo/github'
 require 'cdo/developers_topic'
-require 'cdo/only_one'
 
 DTSN_FILE = '.dtsn'.freeze
 
@@ -23,4 +24,4 @@ def main
   end
 end
 
-main if only_one_running?(__FILE__)
+main

--- a/bin/cron/update_hoc_map
+++ b/bin/cron/update_hoc_map
@@ -1,6 +1,6 @@
 #!/usr/bin/env ruby
 require_relative 'only_one'
-exit unless only_one_running?(__FILE__)
+exit(1) unless only_one_running?(__FILE__)
 
 # The map on hourofcode.com is run off of Mapbox.
 # This script updates the data on Mapbox by querying all rows from

--- a/bin/cron/update_hoc_map
+++ b/bin/cron/update_hoc_map
@@ -1,4 +1,6 @@
 #!/usr/bin/env ruby
+require_relative 'only_one'
+exit unless only_one_running?(__FILE__)
 
 # The map on hourofcode.com is run off of Mapbox.
 # This script updates the data on Mapbox by querying all rows from
@@ -12,7 +14,6 @@
 
 require File.expand_path('../../../pegasus/src/env', __FILE__)
 require src_dir 'database'
-require 'cdo/only_one'
 require 'cdo/properties'
 require 'dynamic_config/dcdo'
 require 'open3'
@@ -24,8 +25,6 @@ DB_READONLY = Sequel.connect(CDO.pegasus_db_reader.sub('mysql:', 'mysql2:'))
 
 CURRENT_HOC_SIGNUP = "HocSignup#{DCDO.get('hoc_year', 2017)}".freeze
 def main
-  return unless only_one_running?(__FILE__)
-
   geojson = JSON.parse('{ "type": "FeatureCollection", "features": [] }')
 
   DB_READONLY[:forms].where(kind: CURRENT_HOC_SIGNUP).paged_each(rows_per_fetch: 10_000) do |form|

--- a/bin/cron/update_project_count
+++ b/bin/cron/update_project_count
@@ -1,6 +1,6 @@
 #!/usr/bin/env ruby
 require_relative 'only_one'
-exit unless only_one_running?(__FILE__)
+exit(1) unless only_one_running?(__FILE__)
 
 # This script analyzes the number of standalone projects we have in our database and
 # saves that value.

--- a/bin/cron/update_project_count
+++ b/bin/cron/update_project_count
@@ -1,5 +1,7 @@
 #!/usr/bin/env ruby
-#
+require_relative 'only_one'
+exit unless only_one_running?(__FILE__)
+
 # This script analyzes the number of standalone projects we have in our database and
 # saves that value.
 #
@@ -8,7 +10,6 @@
 
 require 'sequel'
 require File.expand_path('../../../pegasus/src/env', __FILE__)
-require 'cdo/only_one'
 require 'cdo/properties'
 require src_dir 'database'
 require_relative '../../deployment.rb'

--- a/bin/cron/user_geos
+++ b/bin/cron/user_geos
@@ -1,12 +1,13 @@
 #!/usr/bin/env ruby
-#
+require_relative 'only_one'
+exit unless only_one_running?(__FILE__)
+
 # This script incrementally populates the dashboard user_geos table using
 # geolocation of the existing ip_address.
 
 require File.expand_path('../../../pegasus/src/env', __FILE__)
 require 'cdo/db'
 require 'cdo/geocoder'
-require 'cdo/only_one'
 require 'retryable'
 
 def main
@@ -30,4 +31,4 @@ def main
   end
 end
 
-main if only_one_running?(__FILE__)
+main

--- a/bin/cron/user_geos
+++ b/bin/cron/user_geos
@@ -1,6 +1,6 @@
 #!/usr/bin/env ruby
 require_relative 'only_one'
-exit unless only_one_running?(__FILE__)
+exit(1) unless only_one_running?(__FILE__)
 
 # This script incrementally populates the dashboard user_geos table using
 # geolocation of the existing ip_address.

--- a/bin/cron/zendesk_slack_report
+++ b/bin/cron/zendesk_slack_report
@@ -1,4 +1,6 @@
 #!/usr/bin/env ruby
+require_relative 'only_one'
+exit unless only_one_running?(__FILE__)
 
 #
 # Zendesk -> Slack ticket count integration
@@ -19,7 +21,6 @@
 require 'httparty'
 require 'uri'
 require_relative '../../deployment'
-require 'cdo/chat_client'
 
 # CONFIGURATION
 

--- a/bin/cron/zendesk_slack_report
+++ b/bin/cron/zendesk_slack_report
@@ -1,6 +1,6 @@
 #!/usr/bin/env ruby
 require_relative 'only_one'
-exit unless only_one_running?(__FILE__)
+exit(1) unless only_one_running?(__FILE__)
 
 #
 # Zendesk -> Slack ticket count integration

--- a/bin/i18n/sync-all.rb
+++ b/bin/i18n/sync-all.rb
@@ -1,6 +1,6 @@
 #!/usr/bin/env ruby
 require_relative '../../lib/cdo/only_one'
-exit unless only_one_running?(__FILE__)
+exit(1) unless only_one_running?(__FILE__)
 
 # If run with the "interactive" flag, runs all steps necessary for a full i18n
 # update:

--- a/bin/i18n/sync-all.rb
+++ b/bin/i18n/sync-all.rb
@@ -1,4 +1,6 @@
 #!/usr/bin/env ruby
+require_relative '../../lib/cdo/only_one'
+exit unless only_one_running?(__FILE__)
 
 # If run with the "interactive" flag, runs all steps necessary for a full i18n
 # update:
@@ -20,7 +22,6 @@
 # the full sync
 
 require_relative '../../deployment'
-require_relative '../../lib/cdo/only_one'
 require_relative '../../lib/cdo/github'
 
 require_relative 'i18n_script_utils'
@@ -297,4 +298,4 @@ class I18nSync
   end
 end
 
-I18nSync.new(ARGV).run if only_one_running?(__FILE__)
+I18nSync.new(ARGV).run

--- a/bin/kill-tests
+++ b/bin/kill-tests
@@ -5,7 +5,7 @@
 
 require_relative '../deployment'
 require 'cdo/only_one'
-exit unless only_one_running?(__FILE__)
+exit(1) unless only_one_running?(__FILE__)
 
 require 'cdo/chat_client'
 

--- a/bin/kill-tests
+++ b/bin/kill-tests
@@ -4,8 +4,10 @@
 # currently running.
 
 require_relative '../deployment'
-require 'cdo/chat_client'
 require 'cdo/only_one'
+exit unless only_one_running?(__FILE__)
+
+require 'cdo/chat_client'
 
 SUCCESS_MSG = 'successfully killed all tests'.freeze
 FAIL_MSG = 'failed to kill all tests'.freeze
@@ -62,4 +64,4 @@ def main
   print_and_chat msg
 end
 
-main if only_one_running?(__FILE__)
+main

--- a/bin/oneoff/accessibility/accessibility_checker.rb
+++ b/bin/oneoff/accessibility/accessibility_checker.rb
@@ -1,7 +1,7 @@
 #!/usr/bin/env ruby
 require_relative '../../../deployment'
 require 'cdo/only_one'
-exit unless only_one_running?(__FILE__)
+exit(1) unless only_one_running?(__FILE__)
 
 require 'json'
 require 'cdo/chat_client'

--- a/bin/oneoff/accessibility/accessibility_checker.rb
+++ b/bin/oneoff/accessibility/accessibility_checker.rb
@@ -1,6 +1,8 @@
 #!/usr/bin/env ruby
 require_relative '../../../deployment'
 require 'cdo/only_one'
+exit unless only_one_running?(__FILE__)
+
 require 'json'
 require 'cdo/chat_client'
 
@@ -46,4 +48,4 @@ def main
   end
 end
 
-main if only_one_running?(__FILE__)
+main

--- a/bin/oneoff/backfill_data/migrate_workshop_survey_data
+++ b/bin/oneoff/backfill_data/migrate_workshop_survey_data
@@ -1,6 +1,6 @@
 #!/usr/bin/env ruby
 require_relative '../../../lib/cdo/only_one'
-exit unless only_one_running?(__FILE__)
+exit(1) unless only_one_running?(__FILE__)
 
 require_relative '../../../dashboard/config/environment'
 require File.expand_path('../../../../pegasus/src/env', __FILE__)

--- a/bin/oneoff/backfill_data/migrate_workshop_survey_data
+++ b/bin/oneoff/backfill_data/migrate_workshop_survey_data
@@ -1,8 +1,9 @@
 #!/usr/bin/env ruby
+require_relative '../../../lib/cdo/only_one'
+exit unless only_one_running?(__FILE__)
 
 require_relative '../../../dashboard/config/environment'
 require File.expand_path('../../../../pegasus/src/env', __FILE__)
-require 'cdo/only_one'
 require src_dir 'database'
 
 FIELD_MAPPING = {
@@ -125,4 +126,4 @@ def main
   end
 end
 
-main if only_one_running?(__FILE__)
+main

--- a/bin/oneoff/backfill_pegasus_forms_sans_solr.rb
+++ b/bin/oneoff/backfill_pegasus_forms_sans_solr.rb
@@ -1,6 +1,6 @@
 #!/usr/bin/env ruby
 require_relative '../../lib/cdo/only_one'
-exit unless only_one_running?(__FILE__)
+exit(1) unless only_one_running?(__FILE__)
 
 require File.expand_path('../../../pegasus/src/env', __FILE__)
 require 'cdo/chat_client'

--- a/bin/oneoff/backfill_pegasus_forms_sans_solr.rb
+++ b/bin/oneoff/backfill_pegasus_forms_sans_solr.rb
@@ -1,7 +1,9 @@
 #!/usr/bin/env ruby
+require_relative '../../lib/cdo/only_one'
+exit unless only_one_running?(__FILE__)
+
 require File.expand_path('../../../pegasus/src/env', __FILE__)
 require 'cdo/chat_client'
-require 'cdo/only_one'
 require 'retryable'
 require src_dir 'forms'
 require src_dir 'abort_form_error'
@@ -71,4 +73,4 @@ def main
   process_existing_batch_of_forms
 end
 
-main if only_one_running?(__FILE__)
+main

--- a/bin/oneoff/import_coderdojo_classes
+++ b/bin/oneoff/import_coderdojo_classes
@@ -1,6 +1,6 @@
 #!/usr/bin/env ruby
 require_relative '../../lib/cdo/only_one'
-exit unless only_one_running?(__FILE__)
+exit(1) unless only_one_running?(__FILE__)
 
 require File.expand_path('../../pegasus/src/env', __FILE__)
 require src_dir 'database'

--- a/bin/oneoff/import_coderdojo_classes
+++ b/bin/oneoff/import_coderdojo_classes
@@ -1,7 +1,9 @@
 #!/usr/bin/env ruby
+require_relative '../../lib/cdo/only_one'
+exit unless only_one_running?(__FILE__)
+
 require File.expand_path('../../pegasus/src/env', __FILE__)
 require src_dir 'database'
-require 'cdo/only_one'
 require 'json'
 
 def main
@@ -35,4 +37,4 @@ def insert_data(data)
   data
 end
 
-main if only_one_running?(__FILE__)
+main

--- a/bin/oneoff/send_missing_pd_workshop_surveys
+++ b/bin/oneoff/send_missing_pd_workshop_surveys
@@ -1,4 +1,6 @@
 #!/usr/bin/env ruby
+require_relative '../../lib/cdo/only_one'
+exit unless only_one_running?(__FILE__)
 
 # This script updates the pd_enrollment survey_sent_at and survey_id fields for existing surveys
 # from before those fields existed, and sends missing pd_workshop survey emails that didn't go out.
@@ -6,7 +8,6 @@
 require_relative '../../dashboard/config/environment'
 require File.expand_path('../../../pegasus/src/env', __FILE__)
 require src_dir 'database'
-require 'cdo/only_one'
 
 def main
   dashboard_message_id = DB[:poste_messages].where(name: 'dashboard').order(:id).last[:id]
@@ -67,4 +68,4 @@ def main
   puts "#{unprocessed_workshop_ids.count} unprocessed workshops processed."
 end
 
-main if only_one_running?(__FILE__)
+main

--- a/bin/oneoff/send_missing_pd_workshop_surveys
+++ b/bin/oneoff/send_missing_pd_workshop_surveys
@@ -1,6 +1,6 @@
 #!/usr/bin/env ruby
 require_relative '../../lib/cdo/only_one'
-exit unless only_one_running?(__FILE__)
+exit(1) unless only_one_running?(__FILE__)
 
 # This script updates the pd_enrollment survey_sent_at and survey_id fields for existing surveys
 # from before those fields existed, and sends missing pd_workshop survey emails that didn't go out.

--- a/bin/oneoff/update_pd_workshop_survey_ids.rb
+++ b/bin/oneoff/update_pd_workshop_survey_ids.rb
@@ -1,6 +1,6 @@
 #!/usr/bin/env ruby
 require_relative '../../lib/cdo/only_one'
-exit unless only_one_running?(__FILE__)
+exit(1) unless only_one_running?(__FILE__)
 
 require_relative '../../dashboard/config/environment'
 require File.expand_path('../../../pegasus/src/env', __FILE__)

--- a/bin/oneoff/update_pd_workshop_survey_ids.rb
+++ b/bin/oneoff/update_pd_workshop_survey_ids.rb
@@ -1,8 +1,9 @@
 #!/usr/bin/env ruby
+require_relative '../../lib/cdo/only_one'
+exit unless only_one_running?(__FILE__)
 
 require_relative '../../dashboard/config/environment'
 require File.expand_path('../../../pegasus/src/env', __FILE__)
-require 'cdo/only_one'
 require src_dir 'database'
 
 def main
@@ -14,4 +15,4 @@ def main
   end
 end
 
-main if only_one_running?(__FILE__)
+main

--- a/bin/oneoff/wipe_data/opt_out_petition_emails_under_16
+++ b/bin/oneoff/wipe_data/opt_out_petition_emails_under_16
@@ -8,7 +8,7 @@
 # our Contact Rollups process does not currently have any functionality to delete emails from Pardot that were deleted
 # in our database, but it does comply with GDPR by opting out those email addresses.
 require_relative '../../../lib/cdo/only_one'
-exit unless only_one_running?(__FILE__)
+exit(1) unless only_one_running?(__FILE__)
 
 require File.expand_path('../../../../pegasus/src/env', __FILE__)
 require src_dir 'database'

--- a/bin/oneoff/wipe_data/opt_out_petition_emails_under_16
+++ b/bin/oneoff/wipe_data/opt_out_petition_emails_under_16
@@ -7,11 +7,12 @@
 # anonymize or delete email addresses submitted by Petitioners who were between the ages of 13 and 16 because
 # our Contact Rollups process does not currently have any functionality to delete emails from Pardot that were deleted
 # in our database, but it does comply with GDPR by opting out those email addresses.
+require_relative '../../../lib/cdo/only_one'
+exit unless only_one_running?(__FILE__)
 
 require File.expand_path('../../../../pegasus/src/env', __FILE__)
 require src_dir 'database'
 load pegasus_dir('helpers.rb')
-require 'cdo/only_one'
 
 # Twenty minutes.
 MAX_EXECUTION_TIME = 1_200_000
@@ -48,4 +49,4 @@ def main
   CDO.log.info "Finished Opt Out of Petition Emails Under 16"
 end
 
-main if only_one_running?(__FILE__)
+main

--- a/bin/watch-and-test-levelbuilder
+++ b/bin/watch-and-test-levelbuilder
@@ -1,7 +1,7 @@
 #!/usr/bin/env ruby
 require_relative '../deployment.rb'
 require 'cdo/only_one'
-exit unless only_one_running?(__FILE__)
+exit(1) unless only_one_running?(__FILE__)
 
 require_relative '../tools/hooks/hooks_utils.rb'
 require 'time'

--- a/bin/watch-and-test-levelbuilder
+++ b/bin/watch-and-test-levelbuilder
@@ -1,7 +1,9 @@
 #!/usr/bin/env ruby
 require_relative '../deployment.rb'
-require_relative '../tools/hooks/hooks_utils.rb'
 require 'cdo/only_one'
+exit unless only_one_running?(__FILE__)
+
+require_relative '../tools/hooks/hooks_utils.rb'
 require 'time'
 
 REPO_DIR = File.expand_path('../../', __FILE__).freeze
@@ -12,8 +14,6 @@ LEVELS_DIR = File.expand_path(REPO_DIR + '/dashboard/config/scripts', __FILE__).
 LEVELBUILDER_CI_LAST_RUN_FILENAME = 'levelbuilder_ci_last_run'.freeze
 
 Dir.chdir(REPO_DIR)
-
-exit unless only_one_running?(__FILE__)
 
 last_modified_time = File.exist?(LEVELBUILDER_CI_LAST_RUN_FILENAME) ?
     DateTime.parse(File.read(LEVELBUILDER_CI_LAST_RUN_FILENAME)).to_time : Time.at(0)

--- a/dashboard/bin/fill_jotform_placeholders
+++ b/dashboard/bin/fill_jotform_placeholders
@@ -5,7 +5,7 @@
 # and update the questions.
 
 require_relative '../../lib/cdo/only_one'
-exit unless only_one_running?(__FILE__)
+exit(1) unless only_one_running?(__FILE__)
 
 require_relative '../config/environment'
 

--- a/dashboard/bin/process_pd_workshop_ends
+++ b/dashboard/bin/process_pd_workshop_ends
@@ -1,6 +1,6 @@
 #!/usr/bin/env ruby
 require_relative '../../lib/cdo/only_one'
-exit unless only_one_running?(__FILE__)
+exit(1) unless only_one_running?(__FILE__)
 
 # When a workshop is ended, we might need to send exit survey emails.  They need
 # to be sent from production-daemon, and so we do it here.

--- a/dashboard/bin/scheduled_pd_application_emails
+++ b/dashboard/bin/scheduled_pd_application_emails
@@ -1,6 +1,6 @@
 #!/usr/bin/env ruby
 require_relative '../../lib/cdo/only_one'
-exit unless only_one_running?(__FILE__)
+exit(1) unless only_one_running?(__FILE__)
 
 require_relative '../config/environment'
 

--- a/dashboard/bin/scheduled_pd_workshop_emails
+++ b/dashboard/bin/scheduled_pd_workshop_emails
@@ -1,6 +1,6 @@
 #!/usr/bin/env ruby
 require_relative '../../lib/cdo/only_one'
-exit unless only_one_running?(__FILE__)
+exit(1) unless only_one_running?(__FILE__)
 
 require_relative '../config/environment'
 

--- a/dashboard/bin/scheduled_pd_workshop_emails
+++ b/dashboard/bin/scheduled_pd_workshop_emails
@@ -1,9 +1,11 @@
 #!/usr/bin/env ruby
 require_relative '../../lib/cdo/only_one'
+exit unless only_one_running?(__FILE__)
+
 require_relative '../config/environment'
 
 def main
   Pd::Workshop.send_automated_emails
 end
 
-main if only_one_running?(__FILE__)
+main

--- a/dashboard/bin/sync_jotforms
+++ b/dashboard/bin/sync_jotforms
@@ -4,7 +4,7 @@
 # filled out directly by end-users without seeing them embedded via our site.
 
 require_relative '../../lib/cdo/only_one'
-exit unless only_one_running?(__FILE__)
+exit(1) unless only_one_running?(__FILE__)
 
 require_relative '../config/environment'
 require 'honeybadger/ruby'

--- a/pegasus/sites/virtual/collate_pdfs
+++ b/pegasus/sites/virtual/collate_pdfs
@@ -1,7 +1,7 @@
 #!/usr/bin/env ruby
 require_relative '../../../deployment'
 require 'cdo/only_one'
-exit unless only_one_running?(__FILE__)
+exit(1) unless only_one_running?(__FILE__)
 
 require 'cdo/rack/rackup'
 require 'cdo/rake_utils'

--- a/pegasus/sites/virtual/collate_pdfs
+++ b/pegasus/sites/virtual/collate_pdfs
@@ -1,7 +1,9 @@
 #!/usr/bin/env ruby
 require_relative '../../../deployment'
-require 'cdo/rack/rackup'
 require 'cdo/only_one'
+exit unless only_one_running?(__FILE__)
+
+require 'cdo/rack/rackup'
 require 'cdo/rake_utils'
 CDO.log.level = Logger::WARN
 
@@ -13,4 +15,4 @@ def main
   end
 end
 
-main if only_one_running?(__FILE__)
+main

--- a/pegasus/sites/virtual/run_server_generate_curriculum_pdfs
+++ b/pegasus/sites/virtual/run_server_generate_curriculum_pdfs
@@ -1,7 +1,7 @@
 #!/usr/bin/env ruby
 require_relative '../../../deployment'
 require 'cdo/only_one'
-exit unless only_one_running?(__FILE__)
+exit(1) unless only_one_running?(__FILE__)
 
 require 'cdo/rack/rackup'
 require 'cdo/rake_utils'

--- a/pegasus/sites/virtual/run_server_generate_curriculum_pdfs
+++ b/pegasus/sites/virtual/run_server_generate_curriculum_pdfs
@@ -1,16 +1,14 @@
 #!/usr/bin/env ruby
 require_relative '../../../deployment'
-require 'cdo/rack/rackup'
 require 'cdo/only_one'
+exit unless only_one_running?(__FILE__)
+
+require 'cdo/rack/rackup'
 require 'cdo/rake_utils'
 CDO.log.level = Logger::WARN
 
-def main
-  ENV['HONEYBADGER_ENV'] = 'test'
-  Rack.with_rackup(pegasus_dir, port: CDO.pdf_port_markdown) do |params|
-    RakeUtils.rake '--rakefile', pegasus_dir('sites/virtual/generate_curriculum_pdfs.rake'), "base_url=http://localhost.code.org:#{params[:port]}/"
-    exit $?.exitstatus
-  end
+ENV['HONEYBADGER_ENV'] = 'test'
+Rack.with_rackup(pegasus_dir, port: CDO.pdf_port_markdown) do |params|
+  RakeUtils.rake '--rakefile', pegasus_dir('sites/virtual/generate_curriculum_pdfs.rake'), "base_url=http://localhost.code.org:#{params[:port]}/"
+  exit $?.exitstatus
 end
-
-main if only_one_running?(__FILE__)

--- a/tools/scripts/rebuildDefaultSprites.rb
+++ b/tools/scripts/rebuildDefaultSprites.rb
@@ -1,7 +1,9 @@
 #!/usr/bin/env ruby
 require_relative '../../deployment'
+require 'cdo/only_one'
+exit unless only_one_running?(__FILE__)
+
 require_relative './constants'
-require '../../lib/cdo/only_one'
 require 'securerandom'
 require 'json'
 
@@ -45,4 +47,4 @@ def main
   end
 end
 
-main if only_one_running?(__FILE__)
+main

--- a/tools/scripts/rebuildDefaultSprites.rb
+++ b/tools/scripts/rebuildDefaultSprites.rb
@@ -1,7 +1,7 @@
 #!/usr/bin/env ruby
 require_relative '../../deployment'
 require 'cdo/only_one'
-exit unless only_one_running?(__FILE__)
+exit(1) unless only_one_running?(__FILE__)
 
 require_relative './constants'
 require 'securerandom'


### PR DESCRIPTION
This PR is a 'find-all' refactoring pass over all our executable scripts using `only_one_running?` to apply the best-practice of invoking this guard at the earliest point possible in a script.

It also changes the scripts to `exit(1)` returning a nonzero (failure) exit code, which will cause our honeybadger cronjob-wrapper script to notify developers of the failure, since overlapping script runs are not expected in normal operation.

This should not only catch any latent bugs in any script executions potentially overlapping during the loading process, but more importantly it makes sure this best practice will be more consistently followed when any new scripts are created in the future.