### PR TITLE
Redirect from family name to latest stable version of course

### DIFF
--- a/dashboard/app/controllers/courses_controller.rb
+++ b/dashboard/app/controllers/courses_controller.rb
@@ -30,16 +30,14 @@ class CoursesController < ApplicationController
     # csp and csd are each "course families", each containing multiple "course versions".
     # When the url of a course family is requested, redirect to a specific course version.
     #
-    # For now, Hard-code the redirection logic because there are only two course
-    # families to worry about. In the future we will want to make this redirect
-    # happen based on the data in the DB so it can be configured via levelbuilder.
-    redirect_query_string = request.query_string.empty? ? '' : "?#{request.query_string}"
-    case params[:course_name]
-    when 'csd'
-      redirect_to "/courses/csd-2019#{redirect_query_string}"
-      return
-    when 'csp'
-      redirect_to "/courses/csp-2019#{redirect_query_string}"
+    # For now, use hard-coded list to determine whether the given course_name is actually
+    if ScriptConstants::COURSE_FAMILY_NAMES.include?(params[:course_name])
+      redirect_query_string = request.query_string.empty? ? '' : "?#{request.query_string}"
+      redirect_to_course = Course.all_courses.
+          select {|c| c.family_name == params[:course_name] && c.is_stable?}.
+          sort_by(&:version_year).
+          last
+      redirect_to "/courses/#{redirect_to_course.name}#{redirect_query_string}"
       return
     end
 

--- a/dashboard/test/controllers/courses_controller_test.rb
+++ b/dashboard/test/controllers/courses_controller_test.rb
@@ -58,17 +58,16 @@ class CoursesControllerTest < ActionController::TestCase
 
   test_user_gets_response_for :show, response: :forbidden, user: :admin, params: -> {{course_name: @course_regular.name}}, queries: 2
 
-  # For now, this test passes due to hard-coded logic in CoursesController#show.
-  # This test ensures that hard-coded logic is not removed without being replaced
-  # by the appropriate db-driven redirection logic.
   test "show: redirect to latest stable version in course family" do
-    create :course, name: 'csp-2018', family_name: 'csp', version_year: '2018'
-    create :course, name: 'csp-2019', family_name: 'csp', version_year: '2019'
+    create :course, name: 'csp-2018', family_name: 'csp', version_year: '2018', is_stable: true
+    create :course, name: 'csp-2019', family_name: 'csp', version_year: '2019', is_stable: true
+    create :course, name: 'csp-2020', family_name: 'csp', version_year: '2020'
     get :show, params: {course_name: 'csp'}
     assert_redirected_to '/courses/csp-2019'
 
-    create :course, name: 'csd-2018', family_name: 'csd', version_year: '2018'
-    create :course, name: 'csd-2019', family_name: 'csd', version_year: '2019'
+    create :course, name: 'csd-2018', family_name: 'csd', version_year: '2018', is_stable: true
+    create :course, name: 'csd-2019', family_name: 'csd', version_year: '2019', is_stable: true
+    create :course, name: 'csd-2020', family_name: 'csd', version_year: '2019'
     get :show, params: {course_name: 'csd'}
     assert_redirected_to '/courses/csd-2019'
   end

--- a/lib/cdo/script_constants.rb
+++ b/lib/cdo/script_constants.rb
@@ -245,6 +245,12 @@ module ScriptConstants
 
   DEFAULT_VERSION_YEAR = '2017'
 
+  # An allowlist of all family names for courses.
+  COURSE_FAMILY_NAMES = [
+    CSD = 'csd'.freeze,
+    CSP = 'csp'.freeze,
+  ].freeze
+
   # An allowlist of all family names for scripts.
   FAMILY_NAMES = [
     # CSF


### PR DESCRIPTION
Reduces amount of hard-coding for course family redirects.

I'm making this change as part of my work to reduce the amount of manual testing we need each year for launching curriculum.

## Testing story
* Unit tests
* Checked that csd and csp courses for 2019/2020 have the correct data

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
