### PR TITLE
fix dataset category color

### DIFF
--- a/apps/src/sites/studio/pages/levels/editors/_applab.js
+++ b/apps/src/sites/studio/pages/levels/editors/_applab.js
@@ -65,7 +65,7 @@ $(document).ready(function() {
 
   const styles = {
     optgroup: {
-      color: color.lightest_gray
+      color: color.light_gray
     },
     option: {
       color: color.black
@@ -133,7 +133,7 @@ $(document).ready(function() {
               <optgroup
                 label={category.name}
                 key={category.name}
-                style={styles.optGroup}
+                style={styles.optgroup}
               >
                 {category.datasets.map(name => (
                   <option key={name} value={name} style={styles.option}>


### PR DESCRIPTION
Follow-on to https://github.com/code-dot-org/code-dot-org/pull/35277 fixing a careless error that made the category color not get applied properly.

before:

<img width="541" alt="Screen Shot 2020-06-11 at 9 07 46 PM" src="https://user-images.githubusercontent.com/8001765/84463820-c1012080-ac27-11ea-8c0c-f91841bd7e65.png">

after:

<img width="578" alt="Screen Shot 2020-06-11 at 9 08 01 PM" src="https://user-images.githubusercontent.com/8001765/84463824-c52d3e00-ac27-11ea-8195-2ac8a372ab16.png">
