### PR TITLE
Add data to printable parent letter

### DIFF
--- a/apps/i18n/common/en_us.json
+++ b/apps/i18n/common/en_us.json
@@ -1176,7 +1176,7 @@
   "parentLetterStudentPrivacy": "Code.org's commitment to student privacy",
   "parentLetterStudentPrivacyDetails": "Code.org assigns utmost importance to student safety and security. Code.org has signed the [Student Privacy Pledge]({pledgeLink}) and their privacy practices have received [one of the highest overall scores from Common Sense Media]({commonSenseLink}). You can find further details by viewing Code.org's [Privacy Policy]({privacyPolicyLink}).",
   "parentLetterWhy": "Why computer science",
-  "parentLetterWhyDetails": "[Six different studies show]({researchLink}): children who study computer science perform better in other subjects, excel at problem-solving, and are 17% more likely to attend college. Computer science teaches students critical thinking, problem solving, and digital citizenship, and benefits all students, no matter what opportunities they pursue in the future. And learning to make interactive animations, code-art, games, and apps on Code.org encourages creativity and makes learning fun.",
+  "parentLetterWhyDetails": "[Six different studies show]({researchLink}): children who study computer science perform better in other subjects, excel at problem solving, and are 17% more likely to attend college. Computer science teaches students critical thinking, problem solving, and digital citizenship, and benefits all students, no matter what opportunities they pursue in the future. And learning to make interactive animations, code-art, games, and apps on Code.org encourages creativity and makes learning fun.",
   "partner": "Partner: {partner}",
   "password": "Password",
   "passwordConfirmation": "Password confirmation",

--- a/apps/i18n/common/en_us.json
+++ b/apps/i18n/common/en_us.json
@@ -1176,7 +1176,7 @@
   "parentLetterStudentPrivacy": "Code.org's commitment to student privacy",
   "parentLetterStudentPrivacyDetails": "Code.org assigns utmost importance to student safety and security. Code.org has signed the [Student Privacy Pledge]({pledgeLink}) and their privacy practices have received [one of the highest overall scores from Common Sense Media]({commonSenseLink}). You can find further details by viewing Code.org's [Privacy Policy]({privacyPolicyLink}).",
   "parentLetterWhy": "Why computer science",
-  "parentLetterWhyDetails": "Computer science teaches students critical thinking, problem solving, and digital citizenship, and benefits all students, no matter what opportunities they pursue in the future. And learning to make interactive animations, code-art, games, and apps on Code.org encourages creativity and makes learning fun.",
+  "parentLetterWhyDetails": "[Six different studies show]({researchLink}): children who study computer science perform better in other subjects, excel at problem-solving, and are 17% more likely to attend college. Computer science teaches students critical thinking, problem solving, and digital citizenship, and benefits all students, no matter what opportunities they pursue in the future. And learning to make interactive animations, code-art, games, and apps on Code.org encourages creativity and makes learning fun.",
   "partner": "Partner: {partner}",
   "password": "Password",
   "passwordConfirmation": "Password confirmation",

--- a/apps/i18n/common/en_us.json
+++ b/apps/i18n/common/en_us.json
@@ -1154,8 +1154,6 @@
   "parentLetterClever1": "Have your students log in to their Clever account at [www.clever.com]({cleverLink}) (click \"Sign in as a student\" at the top right)",
   "parentLetterClever2": "Click on the Code.org logo on the Clever dashboard. The logo looks like this:",
   "parentLetterClosing": "Please let me know if you have any questions and thank you for your continued support of your child and of our classroom!",
-  "parentLetterCodeBreak": "Join the weekly \"Code Break\" every Wednesday",
-  "parentLetterCodeBreakDetails": "The team at Code.org hosts a live interactive classroom for students of all ages. Anybody can participate, and learn computer science in a fun format starring very special guests. [More info]({codebreakLink})",
   "parentLetterForgotPassword": "If your student does not remember their password, please email me and I will provide it",
   "parentLetterForgotPasswordEmail": "If your student does not remember their password, they can reset it from the sign in screen",
   "parentLetterForgotPicturePassword": "If your student does not remember their picture password, please email me and I will provide it",

--- a/apps/src/lib/ui/ParentLetter.jsx
+++ b/apps/src/lib/ui/ParentLetter.jsx
@@ -121,12 +121,6 @@ class ParentLetter extends React.Component {
               accountEditLink: studio('/users/edit')
             })}
           />
-          <h1>{i18n.parentLetterCodeBreak()}</h1>
-          <SafeMarkdown
-            markdown={i18n.parentLetterCodeBreakDetails({
-              codebreakLink: pegasus('/break')
-            })}
-          />
           <h1>{i18n.parentLetterWhy()}</h1>
           <p>{i18n.parentLetterWhyDetails()}</p>
           <h1>{i18n.parentLetterStudentPrivacy()}</h1>

--- a/apps/src/lib/ui/ParentLetter.jsx
+++ b/apps/src/lib/ui/ParentLetter.jsx
@@ -11,6 +11,8 @@ import SafeMarkdown from '@cdo/apps/templates/SafeMarkdown';
 const PRIVACY_PLEDGE_URL = 'https://studentprivacypledge.org/signatories/';
 const COMMON_SENSE_ARTICLE_URL =
   'https://medium.com/@codeorg/code-orgs-commitment-to-student-privacy-earns-accolades-cae1cca35632';
+const RESEARCH_ARTICLE_URL = 
+  'https://medium.com/@codeorg/cs-helps-students-outperform-in-school-college-and-workplace-66dd64a69536';
 const ENGAGEMENT_URL =
   'https://support.code.org/hc/en-us/articles/360041539831-How-can-I-keep-track-of-what-my-child-is-working-on-on-Code-org-';
 
@@ -122,7 +124,11 @@ class ParentLetter extends React.Component {
             })}
           />
           <h1>{i18n.parentLetterWhy()}</h1>
-          <p>{i18n.parentLetterWhyDetails()}</p>
+          <SafeMarkdown
+            markdown={i18n.parentLetterWhyDetails({
+              researchLink: RESEARCH_ARTICLE_URL
+            })}
+          />
           <h1>{i18n.parentLetterStudentPrivacy()}</h1>
           <SafeMarkdown
             markdown={i18n.parentLetterStudentPrivacyDetails({

--- a/apps/src/lib/ui/ParentLetter.jsx
+++ b/apps/src/lib/ui/ParentLetter.jsx
@@ -11,7 +11,7 @@ import SafeMarkdown from '@cdo/apps/templates/SafeMarkdown';
 const PRIVACY_PLEDGE_URL = 'https://studentprivacypledge.org/signatories/';
 const COMMON_SENSE_ARTICLE_URL =
   'https://medium.com/@codeorg/code-orgs-commitment-to-student-privacy-earns-accolades-cae1cca35632';
-const RESEARCH_ARTICLE_URL = 
+const RESEARCH_ARTICLE_URL =
   'https://medium.com/@codeorg/cs-helps-students-outperform-in-school-college-and-workplace-66dd64a69536';
 const ENGAGEMENT_URL =
   'https://support.code.org/hc/en-us/articles/360041539831-How-can-I-keep-track-of-what-my-child-is-working-on-on-Code-org-';


### PR DESCRIPTION
We recently have compiled (or completed with partners) some really strong research backing up the value of learning CS. We would like to add a reference to this research in the printable letter that teachers can send to parents of students in their section.

Because Code Break wrapped up this week, I also took the opportunity to remove references to Code Break and remove the associated strings as well.

<!-- ### Background -->
<!-- ### Privacy -->
<!-- ### Security -->
<!-- ### Caching -->
<!-- ### Deployment strategy -->
<!-- ### Future work -->

## Links

<!--
  Any relevant links to external resources; ie, specification documents, jira
  items, related PRs, honeybadger errors, etc
-->

- [spec](https://docs.google.com/document/d/1q3S28_GomttVt-XwrMtRKJdHN_vDjpYpG2QrB44K_oQ/edit)

## Testing story
- manually tested locally

## Screenshots
### Before
![before_highlighted](https://user-images.githubusercontent.com/2933346/84486349-2833ca80-ac52-11ea-959b-907348bf7fa7.png)

### After
![after_highlighted](https://user-images.githubusercontent.com/2933346/84486367-2cf87e80-ac52-11ea-8c99-743832927558.png)

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
