### PR TITLE
Updates to adhoc rake tasks

### DIFF
--- a/lib/cdo/cloud_formation/adhoc.rb
+++ b/lib/cdo/cloud_formation/adhoc.rb
@@ -46,7 +46,7 @@ module Cdo::CloudFormation
                 resource_record_set: {
                   name: domain_name,
                   resource_records: [{value: public_ip_address}],
-                  ttl: DNS_TTL,
+                  ttl: CdoApp::DNS_TTL,
                   type: "A"
                 }
               }
@@ -61,7 +61,7 @@ module Cdo::CloudFormation
         route53_client.wait_until(:resource_record_sets_changed, {id: change_id})
         change_status = route53_client.get_change({id: change_id}).change_info.status
         log.info "DNS update status - #{change_status}"
-        log.info "Wait up to the configured Time To Live (#{DNS_TTL} seconds) to lookup new IP address."
+        log.info "Wait up to the configured Time To Live (#{CdoApp::DNS_TTL} seconds) to lookup new IP address."
       end
       stack.outputs.each do |output|
         log.info "#{output.output_key}: #{output.output_value}"

--- a/lib/cdo/cloud_formation/cdo_app.rb
+++ b/lib/cdo/cloud_formation/cdo_app.rb
@@ -91,15 +91,15 @@ module Cdo::CloudFormation
         # Current branch is the one we're deploying to the adhoc server,
         # so check whether it's up-to-date with the remote before we get any further.
         unless `git remote show '#{ORIGIN}' 2>&1 | grep '(up to date)' | grep '#{branch}' | wc -l`.strip.to_i > 0
-          raise 'Current adhoc branch needs to be up-to-date with GitHub branch of the same name, otherwise deploy will fail.
-To specify an alternate branch name, run `rake adhoc:start branch=BRANCH`.'
+          raise "Current adhoc branch (#{branch}) needs to be up-to-date with GitHub branch of the same name, otherwise deploy will fail.
+To specify an alternate branch name, run `rake adhoc:start branch=BRANCH`."
         end
       else
         # Either not adhoc or deploying a different branch than the current local one;
         # simply check that the branch exists on GitHub before deploying.
         unless system("git ls-remote --exit-code '#{ORIGIN}' #{branch} > /dev/null")
-          raise 'Current branch needs to be pushed to GitHub with the same name, otherwise deploy will fail.
-  To specify an alternate branch name, run `rake stack:start branch=BRANCH`.'
+          raise "Current branch (#{branch}) needs to be pushed to GitHub with the same name, otherwise deploy will fail.
+  To specify an alternate branch name, run `rake stack:start branch=BRANCH`."
         end
       end
     end

--- a/lib/rake/adhoc.rake
+++ b/lib/rake/adhoc.rake
@@ -6,9 +6,10 @@ namespace :adhoc do
     require 'cdo/aws/cloud_formation'
     require 'cdo/cloud_formation/cdo_app'
     @cfn = AWS::CloudFormation.new(
-      stack_name: ENV['STACK_NAME'],
-      template: ENV['TEMPLATE'] || 'cloud_formation_stack.yml.erb',
       stack: (@template = Cdo::CloudFormation::CdoApp.new(
+        filename: ENV['TEMPLATE'],
+        stack_name: ENV['STACK_NAME'].dup,
+        branch: ENV['BRANCH'] || ENV['branch'],
         database: ENV['DATABASE'],
         frontends: ENV['FRONTENDS'],
         cdn_enabled: ENV['CDN_ENABLED']

--- a/lib/rake/stack.rake
+++ b/lib/rake/stack.rake
@@ -8,7 +8,7 @@ namespace :stack do
     @cfn = AWS::CloudFormation.new(
       stack: (@stack = Cdo::CloudFormation::CdoApp.new(
         filename: ENV['TEMPLATE'],
-        stack_name: ENV['STACK_NAME'],
+        stack_name: ENV['STACK_NAME'].dup,
         frontends: ENV['FRONTENDS'],
         domain: ENV['DOMAIN'],
         cdn_enabled: ENV['CDN_ENABLED'],


### PR DESCRIPTION
- Fixes to `adhoc.rake` to allow `ENV`-customized template/stack-name/branch
- Fix `adhoc:start_inactive_instance` implementation in `lib/cdo/cloud_formation/adhoc.rb`