### PR TITLE
PL: hide survey links for Pegasus-based surveys

### DIFF
--- a/apps/src/code-studio/pd/workshop_dashboard/EnrollmentsPanel.jsx
+++ b/apps/src/code-studio/pd/workshop_dashboard/EnrollmentsPanel.jsx
@@ -8,6 +8,7 @@ import EditEnrollmentNameDialog from './components/edit_enrollment_name_dialog';
 import Spinner from '../components/spinner';
 import WorkshopEnrollment from './components/workshop_enrollment';
 import WorkshopPanel from './WorkshopPanel';
+import {SubjectNames} from '@cdo/apps/generated/pd/sharedWorkshopConstants';
 import {useFoormSurvey} from './workshop_summary_utils';
 
 export const MOVE_ENROLLMENT_BUTTON_NAME = 'moveEnrollment';
@@ -189,6 +190,9 @@ export default class EnrollmentsPanel extends React.Component {
 
     if (useFoormSurvey(lastSessionDate, course)) {
       return `/pd/workshop_dashboard/workshop_daily_survey_results/${workshopId}`;
+    } else if (subject === SubjectNames.SUBJECT_CSF_101) {
+      // Pegasus-based results are no longer offered.
+      return null;
     } else {
       return `/pd/workshop_dashboard/daily_survey_results/${workshopId}`;
     }

--- a/apps/src/code-studio/pd/workshop_dashboard/components/workshop_table.jsx
+++ b/apps/src/code-studio/pd/workshop_dashboard/components/workshop_table.jsx
@@ -15,6 +15,7 @@ import {workshopShape} from '../types.js';
 import {Button} from 'react-bootstrap';
 import {CSF, CSD, CSP} from '../../application/ApplicationConstants';
 import {SubjectNames} from '@cdo/apps/generated/pd/sharedWorkshopConstants';
+import {useFoormSurvey} from '../workshop_summary_utils';
 
 const styles = {
   container: {
@@ -281,6 +282,18 @@ export default class WorkshopTable extends React.Component {
     );
   };
 
+  showSurveyUrl = (state, course, subject, date) => {
+    const pegasusBasedCsfIntro =
+      subject === SubjectNames.SUBJECT_CSF_101 &&
+      !useFoormSurvey(subject, date);
+
+    return (
+      (state === 'Ended' && !pegasusBasedCsfIntro) ||
+      ([CSD, CSP].includes(course) && subject !== SubjectNames.SUBJECT_FIT) ||
+      (course === CSF && subject === SubjectNames.SUBJECT_CSF_201)
+    );
+  };
+
   formatManagement = manageData => {
     const {id, course, subject, state, date, canDelete, endDate} = manageData;
 
@@ -293,12 +306,7 @@ export default class WorkshopTable extends React.Component {
         date={date}
         editUrl={state === 'Not Started' ? `/workshops/${id}/edit` : null}
         onDelete={canDelete ? this.props.onDelete : null}
-        showSurveyUrl={
-          state === 'Ended' ||
-          ([CSD, CSP].includes(course) &&
-            subject !== SubjectNames.SUBJECT_FIT) ||
-          (course === CSF && subject === SubjectNames.SUBJECT_CSF_201)
-        }
+        showSurveyUrl={this.showSurveyUrl(state, course, subject, date)}
         endDate={endDate}
       />
     );


### PR DESCRIPTION
This hides survey links for older Pegasus-based surveys on the "Workshops" page and the "View Workshop" page.

Followup to https://github.com/code-dot-org/code-dot-org/pull/28936
