### PR TITLE
Updated spritelab migration to skip user-created animations and to run only when spritelab is loaded.

### DIFF
--- a/apps/src/p5lab/P5Lab.js
+++ b/apps/src/p5lab/P5Lab.js
@@ -440,7 +440,10 @@ P5Lab.prototype.init = function(config) {
     config.initialAnimationList && !config.embed && !config.hasContainedLevels
       ? config.initialAnimationList
       : this.startAnimations;
-  getStore().dispatch(setInitialAnimationList(initialAnimationList));
+
+  getStore().dispatch(
+    setInitialAnimationList(initialAnimationList, this.isSpritelab)
+  );
 
   this.generatedProperties = {
     ...config.initialGeneratedProperties

--- a/apps/src/p5lab/P5Lab.js
+++ b/apps/src/p5lab/P5Lab.js
@@ -442,7 +442,10 @@ P5Lab.prototype.init = function(config) {
       : this.startAnimations;
 
   getStore().dispatch(
-    setInitialAnimationList(initialAnimationList, this.isSpritelab)
+    setInitialAnimationList(
+      initialAnimationList,
+      this.isSpritelab /* shouldRunV3Migration */
+    )
   );
 
   this.generatedProperties = {

--- a/apps/src/p5lab/animationListModule.js
+++ b/apps/src/p5lab/animationListModule.js
@@ -292,7 +292,7 @@ export function setInitialAnimationList(
         !animation.sourceUrl ||
         animation.sourceUrl.includes(dashboard.project.getCurrentId())
       ) {
-        // The animation was created by the user. Skip.
+        // The animation was created by the project owner. Skip.
         return;
       }
 

--- a/apps/src/p5lab/animationListModule.js
+++ b/apps/src/p5lab/animationListModule.js
@@ -1,3 +1,4 @@
+/*global dashboard*/
 /**
  * @file Redux module for new format for tracking project animations.
  */
@@ -261,7 +262,10 @@ function generateAnimationName(baseName, animationList) {
  * @param {!SerializedAnimationList} serializedAnimationList
  * @returns {function()}
  */
-export function setInitialAnimationList(serializedAnimationList) {
+export function setInitialAnimationList(
+  serializedAnimationList,
+  shouldRunV3Migration
+) {
   // Set default empty animation list if none was provided
   if (!serializedAnimationList) {
     serializedAnimationList = {orderedKeys: [], propsByKey: {}};
@@ -281,22 +285,32 @@ export function setInitialAnimationList(serializedAnimationList) {
   }
 
   // TODO (from 2020): Tear out this migration when it hasn't been used for at least 3 consecutive non-summer months.
-  serializedAnimationList.orderedKeys.forEach(loadedKey => {
-    let animation = serializedAnimationList.propsByKey[loadedKey];
-    if (animation.sourceUrl && animation.sourceUrl.includes('/v3/')) {
-      // We want to replace this sprite with the /v1/ sprite
-      let details = `name=${animation.name};key=${loadedKey}`;
-      if (defaultSprites.propsByKey[loadedKey]) {
-        // The key is the same in the main.json and in default sprites. Do a simple replacement.
-        serializedAnimationList.propsByKey[loadedKey] =
-          defaultSprites.propsByKey[loadedKey];
-        trackEvent('Research', 'ReplacedSpriteByKey', details);
-      } else {
-        // We were unable to find a replacement for the /v3/ sprite
-        trackEvent('Research', 'CouldNotReplaceSprite', details);
+  if (shouldRunV3Migration) {
+    serializedAnimationList.orderedKeys.forEach(loadedKey => {
+      let animation = serializedAnimationList.propsByKey[loadedKey];
+      if (
+        !animation.sourceUrl ||
+        animation.sourceUrl.includes(dashboard.project.getCurrentId())
+      ) {
+        // The animation was created by the user. Skip.
+        return;
       }
-    }
-  });
+
+      if (animation.sourceUrl.includes('/v3/')) {
+        // We want to replace this sprite with the /v1/ sprite
+        let details = `name=${animation.name};key=${loadedKey}`;
+        if (defaultSprites.propsByKey[loadedKey]) {
+          // The key is the same in the main.json and in default sprites. Do a simple replacement.
+          serializedAnimationList.propsByKey[loadedKey] =
+            defaultSprites.propsByKey[loadedKey];
+          trackEvent('Research', 'ReplacedSpriteByKey', details);
+        } else {
+          // We were unable to find a replacement for the /v3/ sprite
+          trackEvent('Research', 'CouldNotReplaceSprite', details);
+        }
+      }
+    });
+  }
 
   // Convert frameRates to frameDelays.
   for (let key in serializedAnimationList.propsByKey) {


### PR DESCRIPTION
We should only attempt to migrate v3 animations to v1 if they are spritelab animations that are not user-created. This adjusts the migration to run in these cases only. This is a follow-up to the following PR: https://github.com/code-dot-org/code-dot-org/pull/35243

<!--
  Your description goes here: A summary of the change, including any relevant motivation and context.

  If relevant, include a description both of the existing behavior and of the new behavior.
-->

<!--
  Other aspects to consider. uncomment and add detail for any that seem necessary:
-->

<!-- ### Background -->
<!-- ### Privacy -->
<!-- ### Security -->
<!-- ### Caching -->
<!-- ### Deployment strategy -->
<!-- ### Future work -->

## Links

<!--
  Any relevant links to external resources; ie, specification documents, jira
  items, related PRs, honeybadger errors, etc
-->

- [slack conversation](https://codedotorg.slack.com/archives/C1B3PNDL7/p1591920791062500)
- [jira](https://codedotorg.atlassian.net/browse/STAR-861)
- [related PR](https://github.com/code-dot-org/code-dot-org/pull/35243)

## Testing story

<!--
  Does your change include appropriate tests?

  If so, please describe how the tests included in this PR are sufficient

  If not, please explain why this change does not need to be tested.
-->

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
