### PR TITLE
Updated css to valid value. Correctly aligns minecraft buttons.

### DIFF
--- a/apps/style/craft/style.scss
+++ b/apps/style/craft/style.scss
@@ -170,7 +170,7 @@ $text-shadow-gray: #5a5a5a;
 @media screen and (max-width: 1000px),
        screen and (max-height: 600px) {
   #soft-buttons {
-    margin: 0, -5px, 0, 0;
+    margin: 0 -5px 0 0;
     button {
       margin: 0;
     }


### PR DESCRIPTION
Follow-up to a PR (https://github.com/code-dot-org/code-dot-org/pull/34611) that forced the arrow buttons to stay on one line.

After the above PR, there were some cases where the minecraft buttons would be poorly aligned. This was due to some invalid CSS that was being ignored.

OLD
![image](https://user-images.githubusercontent.com/8324574/84537387-7b366d80-aca4-11ea-9d25-f974e4e1ac17.png)


NEW
![image](https://user-images.githubusercontent.com/8324574/84537354-6bb72480-aca4-11ea-8a5a-14df4639007d.png)

<!--
  Other aspects to consider. uncomment and add detail for any that seem necessary:
-->

<!-- ### Background -->
<!-- ### Privacy -->
<!-- ### Security -->
<!-- ### Caching -->
<!-- ### Deployment strategy -->
<!-- ### Future work -->

## Links

<!--
  Any relevant links to external resources; ie, specification documents, jira
  items, related PRs, honeybadger errors, etc
-->

- [jira](https://codedotorg.atlassian.net/browse/STAR-1111)

## Testing story

<!--
  Does your change include appropriate tests?

  If so, please describe how the tests included in this PR are sufficient

  If not, please explain why this change does not need to be tested.
-->

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
