### PR TITLE
Add api.fungenerators.com

### DIFF
--- a/dashboard/app/controllers/xhr_proxy_controller.rb
+++ b/dashboard/app/controllers/xhr_proxy_controller.rb
@@ -34,6 +34,7 @@ class XhrProxyController < ApplicationController
     api.exchangeratesapi.io
     api.football-data.org
     api.foursquare.com
+    api.fungenerators.com
     api.nasa.gov
     api.open-notify.org
     api.openweathermap.org


### PR DESCRIPTION
Adds [api.fungenerators.com](https://fungenerators.com/) to the allowed list of hostnames for startWebRequest(). Requested in [this Zendesk ticket](https://codeorg.zendesk.com/agent/tickets/284035).