### PR TITLE
Foorm: View survey results bug fix

### DIFF
--- a/apps/src/code-studio/pd/workshop_dashboard/EnrollmentsPanel.jsx
+++ b/apps/src/code-studio/pd/workshop_dashboard/EnrollmentsPanel.jsx
@@ -187,7 +187,7 @@ export default class EnrollmentsPanel extends React.Component {
       return null;
     }
 
-    if (useFoormSurvey(lastSessionDate, course)) {
+    if (useFoormSurvey(subject, lastSessionDate)) {
       return `/pd/workshop_dashboard/workshop_daily_survey_results/${workshopId}`;
     } else {
       return `/pd/workshop_dashboard/daily_survey_results/${workshopId}`;


### PR DESCRIPTION
On moving to a helper method for determining which link to show for survey results I introduced a regression by calling the helper method with incorrect parameters in one place. This fixes that issue so "view survey results" on the enrollments panel will now show the correct link.

<!-- ### Background -->
<!-- ### Privacy -->
<!-- ### Security -->
<!-- ### Caching -->
<!-- ### Deployment strategy -->
<!-- ### Future work -->

## Testing story
Tested that before the fix the enrollments panel shows the wrong survey results page and after the fix it shows the correct one.

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
