### PR TITLE
Fix code comment to correctly represent petition age policy

### DIFF
--- a/pegasus/sites.v3/code.org/views/petition_expand.haml
+++ b/pegasus/sites.v3/code.org/views/petition_expand.haml
@@ -148,7 +148,7 @@
     this.showEmailError(false);
     this.showNoError(true);
 
-    // Do not send the email or name server-side for under thirteen users for
+    // Do not send the email or name server-side for under sixteen users for
     // privacy reasons.
     if (parseInt(document.getElementById('age').value) < 16) {
       document.getElementById('email').value = 'anonymous@code.org';


### PR DESCRIPTION
Discovered while auditing our privacy policy implementation regarding our petitions.  Looks like the implementation is correct, but the comment is wrong!