### PR TITLE
Revert "Revert back to old sync down"

### DIFF
--- a/bin/i18n/sync-down.rb
+++ b/bin/i18n/sync-down.rb
@@ -9,6 +9,13 @@ require_relative 'i18n_script_utils'
 require 'cdo/crowdin/utils'
 require 'cdo/crowdin/project'
 
+def with_elapsed
+  before = Time.now
+  yield
+  after = Time.now
+  return Time.at(after - before).utc.strftime('%H:%M:%S')
+end
+
 def sync_down
   I18nScriptUtils.with_synchronous_stdout do
     puts "Beginning sync down"
@@ -29,15 +36,11 @@ def sync_down
       utils = Crowdin::Utils.new(project, options)
 
       puts "Fetching list of changed files"
-      prefetch = Time.now
-      utils.fetch_changes
-      postfetch = Time.now
-      puts "Changes fetched in #{Time.at(postfetch - prefetch).utc.strftime('%H:%M:%S')}"
+      elapsed = with_elapsed {utils.fetch_changes}
+      puts "Changes fetched in #{elapsed}"
       puts "Downloading changed files"
-      predownload = Time.now
-      utils.download_changed_files
-      postdownload = Time.now
-      puts "Files downloaded in #{Time.at(postdownload - predownload).utc.strftime('%H:%M:%S')}"
+      elapsed = with_elapsed {utils.download_changed_files}
+      puts "Files downloaded in #{elapsed}"
     end
 
     puts "Sync down complete"

--- a/bin/i18n/sync-down.rb
+++ b/bin/i18n/sync-down.rb
@@ -5,39 +5,39 @@
 # https://crowdin.com/project/codeorg
 
 require_relative 'i18n_script_utils'
-require 'open3'
+
+require 'cdo/crowdin/utils'
+require 'cdo/crowdin/project'
 
 def sync_down
   I18nScriptUtils.with_synchronous_stdout do
     puts "Beginning sync down"
 
+    logger = Logger.new(STDOUT)
+    logger.level = Logger::INFO
+
     CROWDIN_PROJECTS.each do |name, options|
       puts "Downloading translations from #{name} project"
-      command = "crowdin --config #{options[:config_file]} --identity #{options[:identity_file]} download translations"
+      api_key = YAML.load_file(options[:identity_file])["api_key"]
+      project_id = YAML.load_file(options[:config_file])["project_identifier"]
+      project = Crowdin::Project.new(project_id, api_key)
+      options = {
+        etags_json: File.join(File.dirname(__FILE__), "crowdin", "#{project_id}_etags.json"),
+        locales_dir: File.join(I18N_SOURCE_DIR, '..'),
+        logger: logger
+      }
+      utils = Crowdin::Utils.new(project, options)
 
-      # Filter the output because the crowdin translation download is _super_
-      # verbose; it includes not only a progress spinner, but also information
-      # about each individual file downloaded in each individual language.
-      #
-      # We really only care about general progress monitoring, so we remove or
-      # ignore any things we identify as "noise" in the output.
-      Open3.popen2(command) do |_stdin, stdout, status_thread|
-        while line = stdout.gets
-          # strip out the progress spinner, which is implemented as the sequence
-          # \-/| followed by a backspace character
-          line.gsub!(/[\|\/\-\\][\b]/, '')
-
-          # skip lines detailing individual file extraction
-          next if line.start_with?("Extracting: ")
-
-          # skip warning that happens if the sync is run multiple times in succession
-          next if line == "Warning: Export was skipped. Please note that this method can be invoked only once per 30 minutes.\n"
-
-          puts line
-        end
-
-        raise "Sync down failed"  unless status_thread.value.success?
-      end
+      puts "Fetching list of changed files"
+      prefetch = Time.now
+      utils.fetch_changes
+      postfetch = Time.now
+      puts "Changes fetched in #{Time.at(postfetch - prefetch).utc.strftime('%H:%M:%S')}"
+      puts "Downloading changed files"
+      predownload = Time.now
+      utils.download_changed_files
+      postdownload = Time.now
+      puts "Files downloaded in #{Time.at(postdownload - predownload).utc.strftime('%H:%M:%S')}"
     end
 
     puts "Sync down complete"

--- a/bin/i18n/sync-down.rb
+++ b/bin/i18n/sync-down.rb
@@ -33,6 +33,16 @@ def sync_down
         locales_dir: File.join(I18N_SOURCE_DIR, '..'),
         logger: logger
       }
+
+      # download strings not in the regular codeorg project to
+      # a specific subdirectory within the locale directory
+      case name.to_s
+      when "codeorg-markdown"
+        options[:locale_subdir] = "codeorg-markdown"
+      when "hour-of-code"
+        options[:locale_subdir] = "hourofcode"
+      end
+
       utils = Crowdin::Utils.new(project, options)
 
       puts "Fetching list of changed files"

--- a/bin/i18n/sync-out.rb
+++ b/bin/i18n/sync-out.rb
@@ -259,11 +259,10 @@ def distribute_translations
 
     ### Pegasus markdown
     Dir.glob("i18n/locales/#{locale}/codeorg-markdown/**/*.*") do |loc_file|
+      destination_dir = "pegasus/sites.v3/code.org/i18n/public"
       relative_dir = File.dirname(loc_file.delete_prefix("i18n/locales/#{locale}/codeorg-markdown"))
       name = File.basename(loc_file, ".*")
-      dest_dir = "pegasus/sites.v3/code.org/i18n/public"
-      destination = File.join(dest_dir, relative_dir, "#{name}.#{locale}.md.partial")
-      puts "FileUtils.mv(#{loc_file}, #{destination})"
+      destination = File.join(destination_dir, relative_dir, "#{name}.#{locale}.md.partial")
       FileUtils.mv(loc_file, destination)
     end
 

--- a/bin/i18n/sync-out.rb
+++ b/bin/i18n/sync-out.rb
@@ -257,6 +257,16 @@ def distribute_translations
       sanitize_data_and_write(translations_with_fallback, destination)
     end
 
+    ### Pegasus markdown
+    Dir.glob("i18n/locales/#{locale}/codeorg-markdown/**/*.*") do |loc_file|
+      relative_dir = File.dirname(loc_file.delete_prefix("i18n/locales/#{locale}/codeorg-markdown"))
+      name = File.basename(loc_file, ".*")
+      dest_dir = "pegasus/sites.v3/code.org/i18n/public"
+      destination = File.join(dest_dir, relative_dir, "#{name}.#{locale}.md.partial")
+      puts "FileUtils.mv(#{loc_file}, #{destination})"
+      FileUtils.mv(loc_file, destination)
+    end
+
     ### Pegasus
     loc_file = "i18n/locales/#{locale}/pegasus/mobile.yml"
     destination = "pegasus/cache/i18n/#{locale}.yml"

--- a/lib/cdo/crowdin/project.rb
+++ b/lib/cdo/crowdin/project.rb
@@ -20,7 +20,10 @@ module Crowdin
 
     # @see https://support.crowdin.com/api/info/
     def project_info
-      self.class.post("/info")
+      # cache the result; we end up calling this method quite a lot since it's
+      # the source of both our lists of files and of languages, and it also
+      # shouldn't ever change mid-sync.
+      @info ||= self.class.post("/info")
     end
 
     # @param file [String] name of file (within crowdin) to be downloaded


### PR DESCRIPTION
Reverts code-dot-org/code-dot-org#35072

The first attempt was reverted because it downloaded all strings to the same directory, rather than respecting the crowdin destination configs:

https://github.com/code-dot-org/code-dot-org/blob/515129bc1b96021152265f6a40548840498607e9/bin/i18n/codeorg_crowdin.yml#L26
https://github.com/code-dot-org/code-dot-org/blob/515129bc1b96021152265f6a40548840498607e9/bin/i18n/codeorg_markdown_crowdin.yml#L10
https://github.com/code-dot-org/code-dot-org/blob/515129bc1b96021152265f6a40548840498607e9/bin/i18n/hourofcode_crowdin.yml#L17-L21

There are a couple of different ways I considered to handle this, but ultimately I went with a simple, if inelegant approach. Rather than having complex logic controlling the download destination, we simply add an option to specify a subdirectory within the locale directory to which files should be downloaded, and we use that option for the non-codeorg projects.

For the one project in which we are doing something particularly complicated in the crowdin download config (the hour of code project), we simply move that logic into the sync out.

Note that a cleaner approach would probably be to use a directory for each project and just use the names of the projects for the directory, rather than the minor `hour-of-code` vs `hourofcode` changes seen here. That would involve more extensive changes to the sync out, so I'm avoiding that solution for now but will consider adopting it later when I'm making other changes to the sync out.