### PR TITLE
print adhoc short name as SSHServerName for non-cdn adhocs

### DIFF
--- a/aws/cloudformation/cloud_formation_stack.yml.erb
+++ b/aws/cloudformation/cloud_formation_stack.yml.erb
@@ -466,6 +466,6 @@ Outputs:
 # display information about how to ssh to console if this is a single instance adhoc environment
 <% if rack_env?(:adhoc) && !frontends -%>
   SSHServerName:
-    Value: <%=cdn_enabled ? subdomain('origin') : subdomain%>
+    Value: <%=cdn_enabled ? subdomain('origin') : ${AWS::StackName} %>
     Description: SSH server name
 <%end-%>

--- a/aws/cloudformation/cloud_formation_stack.yml.erb
+++ b/aws/cloudformation/cloud_formation_stack.yml.erb
@@ -466,6 +466,6 @@ Outputs:
 # display information about how to ssh to console if this is a single instance adhoc environment
 <% if rack_env?(:adhoc) && !frontends -%>
   SSHServerName:
-    Value: <%=cdn_enabled ? subdomain('origin') : AWS::StackName%>
+    Value: <%=cdn_enabled ? subdomain('origin') : stack_name%>
     Description: SSH server name
 <%end-%>

--- a/aws/cloudformation/cloud_formation_stack.yml.erb
+++ b/aws/cloudformation/cloud_formation_stack.yml.erb
@@ -466,6 +466,6 @@ Outputs:
 # display information about how to ssh to console if this is a single instance adhoc environment
 <% if rack_env?(:adhoc) && !frontends -%>
   SSHServerName:
-    Value: <%=cdn_enabled ? subdomain('origin') : ${AWS::StackName} %>
+    Value: <%=cdn_enabled ? subdomain('origin') : AWS::StackName%>
     Description: SSH server name
 <%end-%>


### PR DESCRIPTION

## Testing story
- [x] verify that the code in this PR properly outputs the adhoc short name, and that it can be used to connect to the adhoc
- [x] verified that the short name for the adhoc still works after an adhoc is stopped and then restarted via `rake adhoc:start_inactive_instance`

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
