### PR TITLE
Add tests on soft launch bug bash use cases - redirection

### DIFF
--- a/dashboard/app/controllers/courses_controller.rb
+++ b/dashboard/app/controllers/courses_controller.rb
@@ -30,7 +30,7 @@ class CoursesController < ApplicationController
     # csp and csd are each "course families", each containing multiple "course versions".
     # When the url of a course family is requested, redirect to a specific course version.
     #
-    # For now, use hard-coded list to determine whether the given course_name is actually
+    # For now, use hard-coded list to determine whether the given course_name is actually a course family name.
     if ScriptConstants::COURSE_FAMILY_NAMES.include?(params[:course_name])
       redirect_query_string = request.query_string.empty? ? '' : "?#{request.query_string}"
       redirect_to_course = Course.all_courses.

--- a/dashboard/test/controllers/courses_controller_test.rb
+++ b/dashboard/test/controllers/courses_controller_test.rb
@@ -72,6 +72,19 @@ class CoursesControllerTest < ActionController::TestCase
     assert_redirected_to '/courses/csd-2019'
   end
 
+  test "show: redirect from new unstable version to assigned version" do
+    student = create :student
+    csp2017 = create :course, name: 'csp-2017', family_name: 'csp', version_year: '2017', is_stable: true
+    create :follower, section: create(:section, course: csp2017), student_user: student
+    create :course, name: 'csp-2018', family_name: 'csp', version_year: '2018', is_stable: true
+    create :course, name: 'csp-2019', family_name: 'csp', version_year: '2019'
+
+    sign_in student
+    get :show, params: {course_name: 'csp-2019'}
+
+    assert_redirected_to '/courses/csp-2017/?redirect_warning=true'
+  end
+
   test "show: redirect to latest stable version in course family for logged out user" do
     sign_out @teacher
     create :course, name: 'csp-2017', family_name: 'csp', version_year: '2017', is_stable: true

--- a/dashboard/test/controllers/courses_controller_test.rb
+++ b/dashboard/test/controllers/courses_controller_test.rb
@@ -144,8 +144,8 @@ class CoursesControllerTest < ActionController::TestCase
   end
 
   test "show: do not redirect teacher to latest stable version in course family" do
-    create :course, name: 'csp-2017', family_name: 'csp', version_year: '2017'
-    create :course, name: 'csp-2018', family_name: 'csp', version_year: '2018'
+    create :course, name: 'csp-2017', family_name: 'csp', version_year: '2017', is_stable: true
+    create :course, name: 'csp-2018', family_name: 'csp', version_year: '2018', is_stable: true
 
     get :show, params: {course_name: 'csp-2017'}
 

--- a/dashboard/test/controllers/courses_controller_test.rb
+++ b/dashboard/test/controllers/courses_controller_test.rb
@@ -101,7 +101,9 @@ class CoursesControllerTest < ActionController::TestCase
 
     sign_in create(:student)
     get :show, params: {course_name: 'csp-2017'}
+    assert_redirected_to '/courses/csp-2018/?redirect_warning=true'
 
+    get :show, params: {course_name: 'csp-2019'}
     assert_redirected_to '/courses/csp-2018/?redirect_warning=true'
   end
 

--- a/dashboard/test/controllers/scripts_controller_test.rb
+++ b/dashboard/test/controllers/scripts_controller_test.rb
@@ -203,7 +203,7 @@ class ScriptsControllerTest < ActionController::TestCase
     assert_redirected_to "/s/#{@coursez_2018.name}?redirect_warning=true"
   end
 
-  test "show: redirect from new unstable version to to latest stable version in family for logged out user" do
+  test "show: redirect from new unstable version to latest stable version in family for logged out user" do
     get :show, params: {id: @coursez_2019.name}
     assert_redirected_to "/s/#{@coursez_2018.name}?redirect_warning=true"
   end
@@ -214,6 +214,9 @@ class ScriptsControllerTest < ActionController::TestCase
     assert_redirected_to "/s/#{@coursez_2017.name}?redirect_warning=true"
   end
 
+  # There are tests on can_view_version? in script_test.rb which verify that it returns true if a student is assigned
+  # or has made progress in a different version from the latest stable version. This test verifies that ultimately
+  # the student is not redirected if true is returned.
   test "show: do not redirect student to latest stable version in family if they can view the script version" do
     Script.any_instance.stubs(:can_view_version?).returns(true)
     sign_in @no_progress_or_assignment_student

--- a/dashboard/test/controllers/scripts_controller_test.rb
+++ b/dashboard/test/controllers/scripts_controller_test.rb
@@ -192,8 +192,18 @@ class ScriptsControllerTest < ActionController::TestCase
     assert_redirected_to "/s/#{@coursez_2018.name}?redirect_warning=true"
   end
 
+  test "show: redirect from older version to latest stable version in family for logged out user" do
+    get :show, params: {id: @coursez_2017.name}
+    assert_redirected_to "/s/#{@coursez_2018.name}?redirect_warning=true"
+  end
+
   test "show: redirect from new unstable version to latest stable version in family for student" do
     sign_in @no_progress_or_assignment_student
+    get :show, params: {id: @coursez_2019.name}
+    assert_redirected_to "/s/#{@coursez_2018.name}?redirect_warning=true"
+  end
+
+  test "show: redirect from new unstable version to to latest stable version in family for logged out user" do
     get :show, params: {id: @coursez_2019.name}
     assert_redirected_to "/s/#{@coursez_2018.name}?redirect_warning=true"
   end

--- a/dashboard/test/controllers/scripts_controller_test.rb
+++ b/dashboard/test/controllers/scripts_controller_test.rb
@@ -12,6 +12,7 @@ class ScriptsControllerTest < ActionController::TestCase
     @pilot_script = create :script, pilot_experiment: 'my-experiment'
     @pilot_section = create :section, user: @pilot_teacher, script: @pilot_script
     @pilot_student = create(:follower, section: @pilot_section).student_user
+    @no_progress_or_assignment_student = create :student
 
     @coursez_2017 = create :script, name: 'coursez-2017', family_name: 'coursez', version_year: '2017', is_stable: true
     @coursez_2018 = create :script, name: 'coursez-2018', family_name: 'coursez', version_year: '2018', is_stable: true
@@ -175,15 +176,21 @@ class ScriptsControllerTest < ActionController::TestCase
     assert_response :ok
   end
 
+  test "show: do not redirect when showing latest stable version in family for student" do
+    sign_in @no_progress_or_assignment_student
+    get :show, params: {id: @coursez_2018.name}
+    assert_response :success
+  end
+
   test "show: redirect to latest stable version in family for student" do
-    sign_in create(:student)
+    sign_in @no_progress_or_assignment_student
     get :show, params: {id: @coursez_2017.name}
     assert_redirected_to "/s/#{@coursez_2018.name}?redirect_warning=true"
   end
 
   test "show: do not redirect student to latest stable version in family if they can view the script version" do
     Script.any_instance.stubs(:can_view_version?).returns(true)
-    sign_in create(:student)
+    sign_in @no_progress_or_assignment_student
     get :show, params: {id: @coursez_2017.name}
     assert_response :ok
   end

--- a/dashboard/test/controllers/scripts_controller_test.rb
+++ b/dashboard/test/controllers/scripts_controller_test.rb
@@ -19,6 +19,10 @@ class ScriptsControllerTest < ActionController::TestCase
     @coursez_2019 = create :script, name: 'coursez-2019', family_name: 'coursez', version_year: '2019'
     @partner_script = create :script, editor_experiment: 'platformization-partners'
 
+    @student_coursez_2017 = create :student
+    @section_coursez_2017 = create :section, script: @coursez_2017
+    @section_coursez_2017.add_student(@student_coursez_2017)
+
     Rails.application.config.stubs(:levelbuilder_mode).returns false
   end
 
@@ -192,6 +196,12 @@ class ScriptsControllerTest < ActionController::TestCase
     sign_in @no_progress_or_assignment_student
     get :show, params: {id: @coursez_2019.name}
     assert_redirected_to "/s/#{@coursez_2018.name}?redirect_warning=true"
+  end
+
+  test "show: redirect from new unstable version to assigned version for student" do
+    sign_in @student_coursez_2017
+    get :show, params: {id: @coursez_2019.name}
+    assert_redirected_to "/s/#{@coursez_2017.name}?redirect_warning=true"
   end
 
   test "show: do not redirect student to latest stable version in family if they can view the script version" do

--- a/dashboard/test/controllers/scripts_controller_test.rb
+++ b/dashboard/test/controllers/scripts_controller_test.rb
@@ -182,9 +182,15 @@ class ScriptsControllerTest < ActionController::TestCase
     assert_response :success
   end
 
-  test "show: redirect to latest stable version in family for student" do
+  test "show: redirect from older version to latest stable version in family for student" do
     sign_in @no_progress_or_assignment_student
     get :show, params: {id: @coursez_2017.name}
+    assert_redirected_to "/s/#{@coursez_2018.name}?redirect_warning=true"
+  end
+
+  test "show: redirect from new unstable version to latest stable version in family for student" do
+    sign_in @no_progress_or_assignment_student
+    get :show, params: {id: @coursez_2019.name}
     assert_redirected_to "/s/#{@coursez_2018.name}?redirect_warning=true"
   end
 

--- a/dashboard/test/controllers/scripts_controller_test.rb
+++ b/dashboard/test/controllers/scripts_controller_test.rb
@@ -719,7 +719,9 @@ class ScriptsControllerTest < ActionController::TestCase
     assert script.has_lesson_plan?
   end
 
-  test 'should redirect to latest stable version in script family' do
+  test 'should redirect to latest stable version in script family for student without progress or assignment' do
+    sign_in create(:student)
+
     dogs1 = create :script, name: 'dogs1', family_name: 'coursea', version_year: '1901'
 
     assert_raises ActiveRecord::RecordNotFound do

--- a/dashboard/test/models/script_test.rb
+++ b/dashboard/test/models/script_test.rb
@@ -602,6 +602,13 @@ class ScriptTest < ActiveSupport::TestCase
     assert latest_in_locale.can_view_version?(student, locale: 'it-it')
   end
 
+  test 'can_view_version? is false if script is unstable and has no progress and is not assigned' do
+    unstable = create :script, name: 'new-unstable', family_name: 'courseg', version_year: '2018'
+    student = create :student
+
+    refute unstable.can_view_version?(student, locale: 'it-it')
+  end
+
   test 'can_view_version? is true if student is assigned to script' do
     script = create :script, name: 'my-script', family_name: 'script-fam'
     student = create :student

--- a/dashboard/test/models/script_test.rb
+++ b/dashboard/test/models/script_test.rb
@@ -599,7 +599,9 @@ class ScriptTest < ActiveSupport::TestCase
     student = create :student
 
     assert latest_in_english.can_view_version?(student, locale: 'it-it')
+    assert latest_in_english.can_view_version?(nil)
     assert latest_in_locale.can_view_version?(student, locale: 'it-it')
+    assert latest_in_locale.can_view_version?(nil, locale: 'it-it')
   end
 
   test 'can_view_version? is false if script is unstable and has no progress and is not assigned' do


### PR DESCRIPTION
The goal here is to not do a manual bug bash next year for soft launching curriculum.

Our current bug bash is extremely labor intensive is because we're testing so many different cases. My feeling is that we should be trusting our unit tests to cover most of those cases, and indeed most of them are already covered. The gaps I found I added tests on in this PR.

With enough test coverage, it should be sufficient to just check that the values for family_name, version_year, visible/hidden, and is_stable are correct for the scripts / courses being launched, and perhaps also doing a manual sanity check on the dropdown for sections.

The audit of the cases and corresponding tests is in this doc: https://docs.google.com/document/d/1bzSLGuuNgzgm7tUGJOMtGM4HHxxUDqNp5jDeSFk63vw/edit#

This PR is limited to the redirection section of the doc.

## Testing story

* unit tests
* to verify that the unit tests are actually covering the right behavior, I compared the expected behavior from the tests to the expected behavior from the doc, and manually tested some cases again. I noted any discrepancies in the doc.

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
