### PR TITLE
Foorm: Add is_friday_institute variable

### DIFF
--- a/apps/src/code-studio/pd/foorm/FoormEditor.jsx
+++ b/apps/src/code-studio/pd/foorm/FoormEditor.jsx
@@ -51,7 +51,8 @@ class FoormEditor extends React.Component {
           facilitator_position: 2
         }
       ],
-      day: 1
+      day: 1,
+      is_friday_institute: false
     };
   }
 
@@ -175,6 +176,16 @@ class FoormEditor extends React.Component {
                   onChange={e => this.setState({is_virtual: e.target.value})}
                 />
               </label>
+              <label>
+                is_friday_institute <br />
+                <input
+                  type="boolean"
+                  value={this.state.is_friday_institute}
+                  onChange={e =>
+                    this.setState({is_friday_institute: e.target.value})
+                  }
+                />
+              </label>
 
               <label>
                 day <br />
@@ -201,7 +212,8 @@ class FoormEditor extends React.Component {
                   workshop_subject: this.state.workshop_subject,
                   regional_partner_name: this.state.regional_partner_name,
                   is_virtual: this.state.is_virtual,
-                  day: this.state.day
+                  day: this.state.day,
+                  is_friday_institute: this.state.is_friday_institute
                 }}
               />
             )}

--- a/apps/src/code-studio/pd/foorm/FoormPreviewIndex.jsx
+++ b/apps/src/code-studio/pd/foorm/FoormPreviewIndex.jsx
@@ -29,7 +29,8 @@ export default class FoormPreviewIndex extends React.Component {
     {id: 'workshopCourse', caption: 'Workshop course', type: 'text'},
     {id: 'workshopSubject', caption: 'Workshop subject', type: 'text'},
     {id: 'regionalPartnerName', caption: 'Regional partner name', type: 'text'},
-    {id: 'isVirtual', caption: 'Is virtual', type: 'checkbox'}
+    {id: 'isVirtual', caption: 'Is virtual', type: 'checkbox'},
+    {id: 'isFridayInstitute', caption: 'Is Friday Institute', type: 'checkbox'}
   ];
 
   constructor(props) {

--- a/dashboard/app/controllers/foorm_preview_controller.rb
+++ b/dashboard/app/controllers/foorm_preview_controller.rb
@@ -51,6 +51,7 @@ class FoormPreviewController < ApplicationController
       workshop_subject: params[:workshopSubject] || "Sample Subject",
       regional_partner_name: params[:regionalPartnerName] || "Regional Partner A",
       is_virtual: params[:isVirtual] == 'true' || false,
+      is_friday_institute: params[:isFridayInstitute] == 'true' || false,
       num_facilitators: 3
     }
 

--- a/dashboard/app/controllers/pd/workshop_daily_survey_controller.rb
+++ b/dashboard/app/controllers/pd/workshop_daily_survey_controller.rb
@@ -614,7 +614,8 @@ module Pd
         regional_partner_name: regional_partner_name,
         is_virtual: workshop.virtual?,
         num_facilitators: workshop.facilitators.count,
-        day: day
+        day: day,
+        is_friday_institute: workshop.friday_institute?
       }
     end
   end

--- a/dashboard/app/models/pd/workshop.rb
+++ b/dashboard/app/models/pd/workshop.rb
@@ -130,7 +130,7 @@ class Pd::Workshop < ActiveRecord::Base
   end
 
   def friday_institute_workshops_must_be_virtual
-    if third_party_provider == 'friday_institute' && !virtual?
+    if friday_institute? && !virtual?
       errors.add :properties, 'Friday Institute workshops must be virtual'
     end
   end
@@ -850,5 +850,9 @@ class Pd::Workshop < ActiveRecord::Base
       last_day = VALID_DAYS[CATEGORY_MAP[subject]].last
     end
     last_day
+  end
+
+  def friday_institute?
+    third_party_provider == 'friday_institute'
   end
 end


### PR DESCRIPTION
Add new variable `is_friday_institute` sent to all foorm surveys. This variable will be true if `third_party_provider` equals `friday_institute`. Also updated Foorm previewer and editor to enable testing of this variable.
<!-- ### Background -->
<!-- ### Privacy -->
<!-- ### Security -->
<!-- ### Caching -->
<!-- ### Deployment strategy -->
<!-- ### Future work -->

## Links

- [jira](https://codedotorg.atlassian.net/browse/PLC-872)

## Testing story
Tested that updating a survey to show/hide questions using this variable works as expected, and existing surveys are not affected.

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
