### PR TITLE
Remove hyphen from compound noun "problem-solving"

### DIFF
--- a/dashboard/app/views/parent_mailer/parent_email_added_to_student_account.haml
+++ b/dashboard/app/views/parent_mailer/parent_email_added_to_student_account.haml
@@ -31,7 +31,7 @@
 %p
   = link_to('Six different studies show', 'https://medium.com/@codeorg/cs-helps-students-outperform-in-school-college-and-workplace-66dd64a69536') + ":"
   children who study computer science perform better in other subjects,
-  excel at problem-solving,
+  excel at problem solving,
   and are 17% more likely to attend college.
 
 %p

--- a/dashboard/app/views/pd/application/teacher_application_mailer/principal_approval.html.haml
+++ b/dashboard/app/views/pd/application/teacher_application_mailer/principal_approval.html.haml
@@ -13,7 +13,7 @@
   We are excited that this teacher is committed to computer science education!
   = link_to 'Six different studies show', 'https://medium.com/@codeorg/cs-helps-students-outperform-in-school-college-and-workplace-66dd64a69536'
   that children who study computer science perform better in other subjects,
-  excel at problem-solving,
+  excel at problem solving,
   and are 17% more likely to attend college.
 
 %p

--- a/dashboard/app/views/pd/application/teacher_application_mailer/principal_approval_teacher_reminder.html.haml
+++ b/dashboard/app/views/pd/application/teacher_application_mailer/principal_approval_teacher_reminder.html.haml
@@ -24,7 +24,7 @@
 %p
   = link_to('Six different studies show', 'https://medium.com/@codeorg/cs-helps-students-outperform-in-school-college-and-workplace-66dd64a69536') + ":"
   children who study computer science perform better in other subjects,
-  excel at problem-solving,
+  excel at problem solving,
   and are 17% more likely to attend college.
   For more information about
   = link_to('Code.org', 'https://code.org') + "'s"

--- a/dashboard/app/views/teacher_mailer/new_teacher_email.html.haml
+++ b/dashboard/app/views/teacher_mailer/new_teacher_email.html.haml
@@ -45,7 +45,7 @@
 %p
   = link_to('Six different studies show', 'https://medium.com/@codeorg/cs-helps-students-outperform-in-school-college-and-workplace-66dd64a69536') + ":"
   children who study computer science perform better in other subjects,
-  excel at problem-solving,
+  excel at problem solving,
   and are 17% more likely to attend college.
   You’re part of a movement of over 750,000 teachers and over 25 million students that have used
   Code.org globally, making it the most broadly used coding education platform and computer science


### PR DESCRIPTION
According to https://www.dailywritingtips.com/hyphenation-in-compound-nouns, "such treatment is justified only when the compound modifies a following noun".