### PR TITLE
Remove unneeded PLC course un-slug logic

### DIFF
--- a/dashboard/app/controllers/courses_controller.rb
+++ b/dashboard/app/controllers/courses_controller.rb
@@ -1,5 +1,3 @@
-require 'cdo/honeybadger'
-
 class CoursesController < ApplicationController
   include VersionRedirectOverrider
 
@@ -47,15 +45,7 @@ class CoursesController < ApplicationController
     end
 
     course = Course.get_from_cache(params[:course_name])
-    unless course
-      # PLC courses have different ways of getting to name. ideally this goes
-      # away eventually
-      course_name = params[:course_name].tr('-', '_').titleize
-      course = Course.get_from_cache(course_name)
-      # only support this alternative course name for plc courses
-      raise ActiveRecord::RecordNotFound unless course.try(:plc_course)
-      Honeybadger.notify "Deprecated PLC course name logic used for course #{course_name}"
-    end
+    raise ActiveRecord::RecordNotFound unless course
 
     if course.plc_course
       authorize! :show, Plc::UserCourseEnrollment

--- a/dashboard/test/controllers/courses_controller_integration_test.rb
+++ b/dashboard/test/controllers/courses_controller_integration_test.rb
@@ -4,21 +4,11 @@ class CoursesControllerIntegrationTest < ActionDispatch::IntegrationTest
   self.use_transactional_test_case = true
 
   test "show: plc courses get sent to user_course_enrollments_controller" do
-    Honeybadger.expects(:notify).never
     sign_in create :teacher
     # Note: We intentionally use a complex-ish course name here, similar to what
     # our real PLC course names look like.
     plc_course = create :plc_course, name: "CS Discoveries Deeper Learning 2119 - 2120"
     get course_path(plc_course.course)
-    assert_template 'plc/user_course_enrollments/index'
-  end
-
-  # We'd like to deprecate this behavior as soon as we're confident nothing depends on it
-  test "show: plc course names get titleized" do
-    Honeybadger.expects(:notify)
-    sign_in create :teacher
-    create :plc_course, name: "My Plc"
-    get '/courses/my_plc'
     assert_template 'plc/user_course_enrollments/index'
   end
 end

--- a/dashboard/test/controllers/courses_controller_test.rb
+++ b/dashboard/test/controllers/courses_controller_test.rb
@@ -42,12 +42,6 @@ class CoursesControllerTest < ActionController::TestCase
     assert_template 'courses/show'
   end
 
-  test "show: regular courses do not get titlized" do
-    assert_raises ActiveRecord::RecordNotFound do
-      get :show, params: {course_name: 'non_plc_course'}
-    end
-  end
-
   test "show: non existant course throws" do
     assert_raises ActiveRecord::RecordNotFound do
       get :show, params: {course_name: 'nosuchcourse'}


### PR DESCRIPTION
This change removes some unneeded CoursesController logic.

Prior to September 2019, we had a system in place that would "slug-ify" PLC course names in generated links.  For example: A course named `Professional Learning` would be slugified to `professional-learning` for urls.  We also had code in CoursesController to "un-slug-ify" these course names so the appropriate course could be loaded.

Unfortunately, our course names got more complicated and this system wasn't able to handle them well.  Here's a known broken case:

```
// The real course name
"CS Discoveries Deeper Learning 2019 - 2020"
// Slug-ified
"cs-discoveries-deeper-learning-2019---2020"
// Unsuccessfully restored
"Cs Discoveries Deeper Learning 2019   2020"
```

Nine months ago we [removed this slugification logic](https://github.com/code-dot-org/code-dot-org/pull/30779); now we simply urlencode course names. At the time, we left the unslug logic in with a Honeybadger notification, to avoid breaking existing links and to monitor how much use this system was seeing.

In the last nine months we have [seen slugified PLC course links used a total of 89 times](https://app.honeybadger.io/projects/3240/faults?sort=last_seen_desc&q=Deprecated+PLC+course+name+logic), and only for the `CSP Support` course.  Nobody among developers or PLC partners has been able to track down where such a link still exists in our system.  Andrea shared that this is an old course, and that link should not be used by anyone except a former participant trying to review their answers.

![image](https://user-images.githubusercontent.com/1615761/84921706-adb3e200-b079-11ea-9c50-23f1791f4b77.png)

I propose that it's time to deprecate this logic, which unnecessarily complicates our course routing.  If anyone contacts us about the `csp-support` link, we can handle this manually and share an updated link with them.

<!--
  Your description goes here: A summary of the change, including any relevant motivation and context.

  If relevant, include a description both of the existing behavior and of the new behavior.
-->

<!--
  Other aspects to consider. uncomment and add detail for any that seem necessary:
-->


# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
