### PR TITLE
Reorder "Learn at Home" menu options on the homepage

### DIFF
--- a/pegasus/src/homepage.rb
+++ b/pegasus/src/homepage.rb
@@ -213,16 +213,16 @@ class Homepage
           links:
             [
               {
-                text: "homepage_slot_text_link_code_break",
-                url: "/break"
-              },
-              {
                 text: "homepage_slot_text_link_do_hoc",
                 url: "/hourofcode/overview"
               },
               {
                 text: "homepage_slot_text_link_express_course",
                 url: "/educate/curriculum/express-course"
+              },
+              {
+                text: "homepage_slot_text_link_code_break",
+                url: "/break"
               }
             ]
         },


### PR DESCRIPTION
[PLC-910](https://codedotorg.atlassian.net/browse/PLC-910): Reorders the menu options in the "Learn at Home" block on the logged-out homepage so that "Take a Code Break" is last.  We're making this change now that Code Break has ended and episodes are available as an archive.

| Before | After |
| --- | --- |
| ![image](https://user-images.githubusercontent.com/1615761/84928641-9b3ea600-b083-11ea-9b06-731ead21247b.png) | ![image](https://user-images.githubusercontent.com/1615761/84928693-adb8df80-b083-11ea-91c5-b7865fac3d98.png) |


## Testing story

Tested manually.  This will result in an eyes change.

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
