### PR TITLE
Replicate foorm tables to Redshift

### DIFF
--- a/aws/dms/tasks.yml
+++ b/aws/dms/tasks.yml
@@ -15,6 +15,7 @@ cron-pii:
 - dashboard.circuit_playground_discount_codes
 - dashboard.survey_questions
 - dashboard.survey_answers
+- dashboard.foorm_%
 cron:
 - dashboard.experiments
 - dashboard.authored_hint_view_requests


### PR DESCRIPTION
Replicates `foorm` tables to Redshift. There might be `foorm_` tables that don't contain PII, but following precedent with `pd_` tables where we put everything in `dashboard_production_pii` schema. I think this is a good pattern so that everything in a given namespace appears in the same schema, instead of being split across the two (`dashboard_production` and `dashboard_production_pii`).

## Testing story

So far, just checked whether this looks like it would appropriately update the cron-pii DMS task:

```
Benjamins-MacBook-Pro:code-dot-org benjaminbrooks$ RAILS_ENV=production bundle exec rake stack:data:validate
GetSecretValue: production/cdo/db_writer
Data layer including RedShift cluster configuration and synchronization with RDS instance.
Listing changes to existing stack `DATA-production`:
Modify DMSCronPii [AWS::DMS::ReplicationTask] Properties Replacement: Conditional (TableMappings)
```

Once approved, can run `RAILS_ENV=production bundle exec rake stack:data:start` to actually modify the CloudFormation template.