### PR TITLE
[Applab Datasets] Add covid19 live dataset script

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -344,3 +344,5 @@ gem 'hammerspace'
 gem 'require_all', require: false
 
 gem 'dotiw'
+
+gem 'datapackage'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -381,6 +381,11 @@ GEM
     dalli (2.7.6)
     dalli-elasticache (0.2.0)
       dalli (>= 1.0.0)
+    datapackage (0.0.4)
+      colorize
+      json
+      json-schema
+      rest-client
     debug_inspector (0.0.3)
     declarative (0.0.10)
     declarative-option (0.1.0)
@@ -503,6 +508,8 @@ GEM
       activesupport (>= 4.2)
       aes_key_wrap
       bindata
+    json-schema (2.8.1)
+      addressable (>= 2.4)
     jsonapi-serializers (1.0.0)
       activesupport
     jumphash (0.1.0)
@@ -918,6 +925,7 @@ DEPENDENCIES
   daemons
   dalli
   dalli-elasticache
+  datapackage
   devise (~> 4.4.0)
   devise_invitable (~> 1.6.0)
   dotiw

--- a/bin/cron/applab_datasets/covid19
+++ b/bin/cron/applab_datasets/covid19
@@ -1,0 +1,128 @@
+#!/usr/bin/env ruby
+
+# This script fetches covid19 data and uploads to the shared firebase channel.
+require_relative '../../../deployment'
+require 'cdo/only_one'
+require 'net/http'
+require 'csv'
+require 'date'
+require 'datapackage'
+require_relative '../../../shared/middleware/helpers/firebase_helper'
+
+US_DATA_URL = "https://raw.githubusercontent.com/nytimes/covid-19-data/master/us-states.csv"
+MAX_DAYS = 90 # there are 55 states/territories, and the table must be less than 5000 total rows (5000/55 = 90.9)
+MAX_WEEKS = 26 # there are 188 countries, and the table must be less than 5000 total rows (5000/188 = 26.5)
+
+def get_us_covid19_data
+  response = Net::HTTP.get_response(URI(US_DATA_URL))
+  return unless response.code == '200'
+  response.body.force_encoding('utf-8')
+  csv = CSV.new(response.body)
+  lines = csv.read
+  lines.shift #first line is column names
+
+  # Group records by date
+  daily_data = {}
+  lines.each do |line|
+    record = {}
+    parsed_date = Date.strptime(line[0], "%Y-%m-%d")
+    formatted_date = parsed_date.strftime('%a %-m/%-d') # ex Wed 1/7
+    record['Date'] = formatted_date
+    record['State'] = line[1]
+    # skip column 2 (FIPS code)
+    record['Confirmed New Cases'] = line[3].to_i
+    record['Deaths'] = line[4].to_i
+    if daily_data[formatted_date].nil?
+      daily_data[formatted_date] = []
+    end
+    daily_data[formatted_date].push record
+  end
+
+  # Truncate to MAX_DAYS most recent days
+  days = if daily_data.length > MAX_DAYS
+           daily_data.keys.slice(daily_data.length - MAX_DAYS, MAX_DAYS)
+         else
+           daily_data.keys
+         end
+
+  # Add id to each record
+  columns = ['id', 'Date', 'State', 'Confirmed New Cases', 'Deaths']
+  records = {}
+  id = 1
+  days.each do |day|
+    day_records = daily_data[day]
+    day_records.each do |record|
+      record['id'] = id
+      records[id] = record.to_json
+      id += 1
+    end
+  end
+
+  return records, columns
+end
+
+def get_world_covid19_data
+  package = DataPackage::Package.new('https://datahub.io/core/covid-19/datapackage.json')
+  resource = package.resources.find {|r| r['name'] == "countries-aggregated_csv"}
+  return unless resource
+  response = Net::HTTP.get_response(URI(resource['path']))
+  return unless response.code == '200'
+  csv = CSV.new(response.body)
+  lines = csv.read
+  lines.shift #first line is column names
+  weekly_data = {}
+
+  # Aggregate daily data by week
+  lines.each do |line|
+    parsed_date = Date.strptime(line[0], "%Y-%m-%d")
+    if weekly_data[parsed_date.cweek].nil?
+      weekly_data[parsed_date.cweek] = {}
+    end
+    if weekly_data[parsed_date.cweek][line[1]].nil?
+      weekly_data[parsed_date.cweek][line[1]] = {confirmed: 0, recovered: 0, deaths: 0}
+    end
+    country = weekly_data[parsed_date.cweek][line[1]]
+    country[:confirmed] += line[2].to_i
+    country[:recovered] += line[3].to_i
+    country[:deaths] += line[4].to_i
+  end
+
+  # Truncate to MAX_WEEKS most recent weeks
+  weeks = if weekly_data.length > MAX_WEEKS
+            weekly_data.keys.slice(weekly_data.length - MAX_WEEKS, MAX_WEEKS)
+          else
+            weekly_data.keys
+          end
+
+  columns = ['id', 'Date', 'Country', 'Confirmed New Cases', 'Recovered', 'Deaths']
+  records = {}
+  id = 1
+  weeks.each do |week_number|
+    date = Date.commercial(2020, week_number)
+    countries = weekly_data[week_number]
+    countries.each do |country, counts|
+      record = {}
+      record['id'] = id
+      record['Date'] = date.strftime('%a %-m/%-d') # ex Wed 1/7
+      record['Country'] = country
+      record['Confirmed New Cases'] = counts[:confirmed]
+      record['Recovered'] = counts[:recovered]
+      record['Deaths'] = counts[:deaths]
+
+      records[id] = record.to_json
+      id += 1
+    end
+  end
+  return records, columns
+end
+
+def main
+  fb = FirebaseHelper.new('shared')
+  records, columns = get_us_covid19_data
+  fb.upload_live_table('COVID-19 Cases per US State', records, columns)
+
+  records, columns = get_world_covid19_data
+  fb.upload_live_table('COVID-19 Cases per Country', records, columns)
+end
+
+main if only_one_running?(__FILE__)

--- a/bin/cron/applab_datasets/covid19
+++ b/bin/cron/applab_datasets/covid19
@@ -17,24 +17,19 @@ def get_us_covid19_data
   response = Net::HTTP.get_response(URI(US_DATA_URL))
   return unless response.code == '200'
   response.body.force_encoding('utf-8')
-  csv = CSV.new(response.body)
-  lines = csv.read
-  lines.shift #first line is column names
+  lines = CSV.parse(response.body, headers: true)
 
   # Group records by date
   daily_data = {}
   lines.each do |line|
     record = {}
-    parsed_date = Date.strptime(line[0], "%Y-%m-%d")
+    parsed_date = Date.strptime(line.field("date"), "%Y-%m-%d")
     formatted_date = parsed_date.strftime('%a %-m/%-d') # ex Wed 1/7
     record['Date'] = formatted_date
-    record['State'] = line[1]
-    # skip column 2 (FIPS code)
-    record['Confirmed New Cases'] = line[3].to_i
-    record['Deaths'] = line[4].to_i
-    if daily_data[formatted_date].nil?
-      daily_data[formatted_date] = []
-    end
+    record['State'] = line.field("state")
+    record['Confirmed New Cases'] = line.field("cases").to_i
+    record['Deaths'] = line.field("deaths").to_i
+    daily_data[formatted_date] ||= []
     daily_data[formatted_date].push record
   end
 
@@ -67,24 +62,18 @@ def get_world_covid19_data
   return unless resource
   response = Net::HTTP.get_response(URI(resource['path']))
   return unless response.code == '200'
-  csv = CSV.new(response.body)
-  lines = csv.read
-  lines.shift #first line is column names
+  lines = CSV.parse(response.body, headers: true)
   weekly_data = {}
 
   # Aggregate daily data by week
   lines.each do |line|
-    parsed_date = Date.strptime(line[0], "%Y-%m-%d")
-    if weekly_data[parsed_date.cweek].nil?
-      weekly_data[parsed_date.cweek] = {}
-    end
-    if weekly_data[parsed_date.cweek][line[1]].nil?
-      weekly_data[parsed_date.cweek][line[1]] = {confirmed: 0, recovered: 0, deaths: 0}
-    end
-    country = weekly_data[parsed_date.cweek][line[1]]
-    country[:confirmed] += line[2].to_i
-    country[:recovered] += line[3].to_i
-    country[:deaths] += line[4].to_i
+    parsed_date = Date.strptime(line.field("Date"), "%Y-%m-%d")
+    weekly_data[parsed_date.cweek] ||= {}
+    weekly_data[parsed_date.cweek][line.field("Country")] ||= {confirmed: 0, recovered: 0, deaths: 0}
+    country = weekly_data[parsed_date.cweek][line.field("Country")]
+    country[:confirmed] += line.field("Confirmed").to_i
+    country[:recovered] += line.field("Recovered").to_i
+    country[:deaths] += line.field("Deaths").to_i
   end
 
   # Truncate to MAX_WEEKS most recent weeks

--- a/cookbooks/cdo-apps/templates/default/crontab.erb
+++ b/cookbooks/cdo-apps/templates/default/crontab.erb
@@ -102,6 +102,7 @@
       cronjob at:'31 16 * * 1-5', do:deploy_dir('bin', 'cron', 'zendesk_slack_report')
       cronjob at:'0 12 * * *', do:deploy_dir('bin', 'cron', 'applab_datasets', 'daily_weather')
       cronjob at:'0 12 * * *', do:deploy_dir('bin', 'cron', 'applab_datasets', 'spotify')
+      cronjob at:'0 12 * * *', do:deploy_dir('bin', 'cron', 'applab_datasets', 'covid19')
       cronjob at:'00 02 * * *', do:deploy_dir('bin', 'cron', 'export_mysql_database_to_redshift')
       cronjob at:'0 0 * * *', do:deploy_dir('bin', 'cron', 'build_contact_rollups_v2')
 

--- a/dashboard/app/controllers/datasets_controller.rb
+++ b/dashboard/app/controllers/datasets_controller.rb
@@ -6,7 +6,8 @@ class DatasetsController < ApplicationController
   before_action :initialize_firebase
   authorize_resource class: false
 
-  LIVE_DATASETS = ['Daily Weather', 'Top 200 USA', 'Top 200 Worldwide', 'Viral 50 USA', 'Viral 50 Worldwide']
+  LIVE_DATASETS = ['Daily Weather', 'Top 200 USA', 'Top 200 Worldwide', 'Viral 50 USA', 'Viral 50 Worldwide',
+                   'COVID-19 Cases per US State', 'COVID-19 Cases per Country']
 
   # GET /datasets
   def index


### PR DESCRIPTION
Script for COVID-19 live datasets. One is 90 days of daily data for 55 US states/territories from [source](https://github.com/nytimes/covid-19-data). The other is 26 weeks of data for 188 countries from [source](https://datahub.io/core/covid-19#data). These time-windows were chosen to stay under the 5000 row limit for applab data tables. 

![image](https://user-images.githubusercontent.com/8787187/84953733-e4552100-b0a8-11ea-8ed9-b94f63d8b342.png)
![image](https://user-images.githubusercontent.com/8787187/84953744-eb7c2f00-b0a8-11ea-9243-11261d4119a7.png)

## Links

<!--
  Any relevant links to external resources; ie, specification documents, jira
  items, related PRs, honeybadger errors, etc
-->

- [slack thread](https://codedotorg.slack.com/archives/CT90GHV35/p1592236533030900)

## Testing story

<!--
  Does your change include appropriate tests?

  If so, please describe how the tests included in this PR are sufficient

  If not, please explain why this change does not need to be tested.
-->

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
