### PR TITLE
Update to latest version of acmesmith

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -277,7 +277,7 @@ gem 'rest-client', '~> 2.0.1'
 gem 'unf_ext', '0.0.7.2'
 
 # Generate SSL certificates.
-gem 'acmesmith', '~> 0'
+gem 'acmesmith', '~> 2.3.1'
 
 gem 'addressable'
 gem 'bcrypt'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -197,10 +197,10 @@ GEM
   specs:
     Ascii85 (1.0.2)
     StreetAddress (1.0.6)
-    acme-client (1.0.0)
+    acme-client (2.0.5)
       faraday (~> 0.9, >= 0.9.1)
-    acmesmith (0.11.1)
-      acme-client (~> 1)
+    acmesmith (2.3.1)
+      acme-client (~> 2)
       aws-sdk-acm
       aws-sdk-route53
       aws-sdk-s3
@@ -877,7 +877,7 @@ PLATFORMS
 
 DEPENDENCIES
   StreetAddress
-  acmesmith (~> 0)
+  acmesmith (~> 2.3.1)
   active_model_serializers!
   active_record_query_trace
   active_record_union

--- a/aws/cloudformation/acmesmith.yml
+++ b/aws/cloudformation/acmesmith.yml
@@ -1,4 +1,5 @@
-endpoint: https://acme-v01.api.letsencrypt.org/
+directory: https://acme-v02.api.letsencrypt.org/directory
+
 # For staging API, use this endpoint instead:
 #endpoint: https://acme-staging.api.letsencrypt.org/
 storage:

--- a/aws/cloudformation/acmesmith.yml
+++ b/aws/cloudformation/acmesmith.yml
@@ -1,7 +1,7 @@
 directory: https://acme-v02.api.letsencrypt.org/directory
 
-# For staging API, use this endpoint instead:
-#endpoint: https://acme-staging.api.letsencrypt.org/
+# For staging API, use this directory instead (see https://letsencrypt.org/docs/acme-protocol-updates/#acme-v2-rfc-8555):
+#directory: https://acme-staging-v02.api.letsencrypt.org/directory
 storage:
   type: s3
   region: 'us-east-1'


### PR DESCRIPTION
ACMEv1 is being end-of-lifed, which as of this month means it will now refuse to allocate new domains:

    $ RAILS_ENV=adhoc bundle exec rake adhoc:start
    RAILS_ENV=adhoc RACK_ENV=adhoc bundle exec ./update_certs adhoc-mikewu.cdn-code.org adhoc-mikewu-studio.cdn-code.org origin-adhoc-mikewu.cdn-code.org
    rake aborted!
    'RAILS_ENV=adhoc RACK_ENV=adhoc bundle exec ./update_certs adhoc-mikewu.cdn-code.org adhoc-mikewu-studio.cdn-code.org origin-adhoc-mikewu.cdn-code.org' returned 1
    Authorizing SSL certificates for adhoc-mikewu.cdn-code.org
    bundler: failed to load command: ./update_certs (./update_certs)
    Acme::Client::Error::Unauthorized: Error creating new authz :: Validations for new domains are disabled in the V1 API (https://community.letsencrypt.org/t/end-of-life-plan-for-acmev1/88430)
      [CDO]/.bundle/bundle/ruby/2.5.0/gems/acme-client-1.0.0/lib/acme/client/faraday_middleware.rb:43:in `raise_on_error!'
      [CDO]/.bundle/bundle/ruby/2.5.0/gems/acme-client-1.0.0/lib/acme/client/faraday_middleware.rb:33:in `on_complete'
      [CDO]/.bundle/bundle/ruby/2.5.0/gems/acme-client-1.0.0/lib/acme/client/faraday_middleware.rb:18:in `block in call'
      [CDO]/.bundle/bundle/ruby/2.5.0/gems/faraday-0.15.4/lib/faraday/response.rb:61:in `on_complete'
      [CDO]/.bundle/bundle/ruby/2.5.0/gems/acme-client-1.0.0/lib/acme/client/faraday_middleware.rb:18:in `call'
      [CDO]/.bundle/bundle/ruby/2.5.0/gems/faraday-0.15.4/lib/faraday/rack_builder.rb:143:in `build_response'
      [CDO]/.bundle/bundle/ruby/2.5.0/gems/faraday-0.15.4/lib/faraday/connection.rb:387:in `run_request'
      [CDO]/.bundle/bundle/ruby/2.5.0/gems/faraday-0.15.4/lib/faraday/connection.rb:175:in `post'
      [CDO]/.bundle/bundle/ruby/2.5.0/gems/acme-client-1.0.0/lib/acme/client.rb:69:in `authorize'
      [CDO]/.bundle/bundle/ruby/2.5.0/gems/acmesmith-0.11.1/lib/acmesmith/acme_client.rb:21:in `block in authorize'
      [CDO]/.bundle/bundle/ruby/2.5.0/gems/acmesmith-0.11.1/lib/acmesmith/acme_client.rb:51:in `retry_once_on_bad_nonce'
      [CDO]/.bundle/bundle/ruby/2.5.0/gems/acmesmith-0.11.1/lib/acmesmith/acme_client.rb:20:in `authorize'
      [CDO]/.bundle/bundle/ruby/2.5.0/gems/acmesmith-0.11.1/lib/acmesmith/client.rb:25:in `block in authorize'
      [CDO]/.bundle/bundle/ruby/2.5.0/gems/acmesmith-0.11.1/lib/acmesmith/client.rb:24:in `map'
      [CDO]/.bundle/bundle/ruby/2.5.0/gems/acmesmith-0.11.1/lib/acmesmith/client.rb:24:in `authorize'
      [CDO]/.bundle/bundle/ruby/2.5.0/gems/acmesmith-0.11.1/lib/acmesmith/command.rb:19:in `authorize'
      [CDO]/.bundle/bundle/ruby/2.5.0/gems/thor-0.20.3/lib/thor/command.rb:27:in `run'
      [CDO]/.bundle/bundle/ruby/2.5.0/gems/thor-0.20.3/lib/thor/invocation.rb:126:in `invoke_command'
      [CDO]/.bundle/bundle/ruby/2.5.0/gems/thor-0.20.3/lib/thor.rb:387:in `dispatch'
      [CDO]/.bundle/bundle/ruby/2.5.0/gems/thor-0.20.3/lib/thor/base.rb:466:in `start'
      [CDO]/aws/cloudformation/update_certs:35:in `block in <top (required)>'
      [CDO]/aws/cloudformation/update_certs:34:in `each'
      [CDO]/aws/cloudformation/update_certs:34:in `rescue in <top (required)>'
      [CDO]/aws/cloudformation/update_certs:30:in `<top (required)>'
    Tasks: TOP => adhoc:start
    (See full trace by running task with --trace)

Fortunately, updating is relatively simple! The most significant change is that new acme wants you to define a [directory rather than an endpoint](https://github.com/sorah/acmesmith#configuration); updating our local config file seems to be sufficient.

I should note that it's not 100% clear to me that `/directory` is actually the directory that we want, but I was successfully able to spin up an adhoc with it set to that value.

## Testing story

With these changes, I was successfully able to initialize an adhoc from https://github.com/code-dot-org/code-dot-org/pull/35371: https://adhoc-mikewu.cdn-code.org/

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
