### PR TITLE
AFE Integration: Submit CSTA form from our server

### DIFF
--- a/config.yml.erb
+++ b/config.yml.erb
@@ -249,6 +249,8 @@ aws_secret_key:
 
 # Amazon Future Engineer integration
 afe_pardot_form_handler_url:
+csta_jotform_api_key: !Secret
+csta_jotform_form_id: !Secret
 
 ### Service configurations (urls, endpoints, etc)
 

--- a/dashboard/lib/services/csta_enrollment.rb
+++ b/dashboard/lib/services/csta_enrollment.rb
@@ -1,0 +1,64 @@
+#
+# As part of our Amazon Future Engineer partnership, teachers at eligible
+# schools are offered a free CSTA+ membership. Our system expedites this
+# process by automatically creating a submission to CSTA's enrollment form
+# on the teacher's behalf.
+#
+# The CSTA form runs on JotForm, and we are using JotForm's public API to
+# create new form submissions.  CSTA has provided us with a form ID and API key.
+# See: https://api.jotform.com/docs/#post-form-id-submissions
+#
+class Services::CSTAEnrollment
+  class Error < StandardError; end
+
+  # Submit a teacher's information to the CSTA Plus Jotform API
+  #
+  # @param first_name [String] max 127 characters
+  # @param last_name [String] max 127 characters
+  # @param email [String] max 127 characters
+  # @param school_district_name [String]
+  # @param school_name [String]
+  # @param street_1 [String] School address, max 50 characters
+  # @param street_2 [String] School address, max 30 characters
+  # @param city [String] School city, max 50 characters
+  # @param state [String] School state, 2 characters
+  # @param zip [String] School zip, 5 characters
+  # @param privacy_permission [Boolean] Whether the teacher agreed to
+  #        the CSTA privacy policy.
+  def self.submit(first_name:, last_name:, email:, school_district_name:,
+    school_name:, street_1:, street_2:, city:, state:, zip:,
+    privacy_permission:)
+    return unless CDO.csta_jotform_api_key && CDO.csta_jotform_form_id
+
+    raise Error.new('CSTA submission skipped: Privacy consent was not provided') unless privacy_permission
+
+    url = "https://api.jotform.com/form/#{CDO.csta_jotform_form_id}/submissions" \
+      "?apiKey=#{CDO.csta_jotform_api_key}"
+
+    # These question IDs are hard-coded for now; we've manually verified that
+    # they are the same for CSTA's test form and their production form.
+    # If their form changes, these may need to be updated.
+    response = Net::HTTP.post_form(
+      URI(url),
+      {
+        "submission[15_first]" => first_name,
+        "submission[15_last]" => last_name,
+        "submission[16]" => email,
+        "submission[5]" => school_district_name,
+        "submission[18]" => school_name,
+        "submission[17_st1]" => street_1,
+        "submission[17_st2]" => street_2,
+        "submission[17_city]" => city,
+        "submission[17_state]" => state,
+        "submission[17_zip]" => zip,
+        "submission[19]" => "Yes, I provide my consent."
+      }
+    )
+
+    unless response.code == '200'
+      raise Error.new("CSTA submission failed with HTTP #{response.code}: #{response.body}")
+    end
+
+    nil
+  end
+end

--- a/dashboard/test/factories/factories.rb
+++ b/dashboard/test/factories/factories.rb
@@ -1080,6 +1080,8 @@ FactoryGirl.define do
   factory :school_common, class: School do
     # school ids are not auto-assigned, so we have to assign one here
     id {(School.maximum(:id).next).to_s}
+    address_line1 "123 Sample St"
+    address_line2 "attn: Main Office"
     city "Seattle"
     state "WA"
     zip "98122"

--- a/dashboard/test/lib/services/csta_enrollment_test.rb
+++ b/dashboard/test/lib/services/csta_enrollment_test.rb
@@ -1,0 +1,108 @@
+require 'test_helper'
+
+class Services::CSTAEnrollmentTest < ActiveSupport::TestCase
+  setup do
+    CDO.stubs(:csta_jotform_api_key).returns('fake-key')
+    CDO.stubs(:csta_jotform_form_id).returns('fake-form-id')
+  end
+
+  test 'does nothing if configuration is missing' do
+    CDO.unstub(:csta_jotform_api_key)
+    CDO.unstub(:csta_jotform_form_id)
+    CDO.stubs(:csta_jotform_api_key).returns(nil)
+    CDO.stubs(:csta_jotform_form_id).returns(nil)
+    Net::HTTP.expects(:post_form).never
+    Services::CSTAEnrollment.submit(valid_params)
+  end
+
+  test 'posts to CSTA Jotform in the expected format' do
+    expected_request = Net::HTTP.expects(:post_form).with(
+      URI("https://api.jotform.com/form/#{CDO.csta_jotform_form_id}/submissions?apiKey=#{CDO.csta_jotform_api_key}"),
+      {
+        'submission[15_first]' => 'test-first-name',
+        'submission[15_last]' => 'test-last-name',
+        'submission[16]' => 'test-email',
+        'submission[5]' => 'test-school-district-name',
+        'submission[18]' => 'test-school-name',
+        'submission[17_st1]' => 'test-street-1',
+        'submission[17_st2]' => 'test-street-2',
+        'submission[17_city]' => 'test-city',
+        'submission[17_state]' => 'test-state',
+        'submission[17_zip]' => 'test-zip',
+        'submission[19]' => "Yes, I provide my consent."
+      }
+    )
+    expected_request.returns(success_response)
+
+    Services::CSTAEnrollment.submit(valid_params)
+  end
+
+  test 'raises without submitting if privacy_permission is not true' do
+    Net::HTTP.expects(:post_form).never
+    assert_raises_matching /CSTA submission skipped: Privacy consent was not provided/ do
+      Services::CSTAEnrollment.submit(valid_params.merge(privacy_permission: false))
+    end
+  end
+
+  test 'raises when JotForm response is a failure' do
+    Net::HTTP.expects(:post_form).returns(failure_response)
+    assert_raises_matching /CSTA submission failed/ do
+      Services::CSTAEnrollment.submit(valid_params)
+    end
+  end
+
+  private
+
+  def valid_params
+    {
+      first_name: 'test-first-name',
+      last_name: 'test-last-name',
+      email: 'test-email',
+      school_district_name: 'test-school-district-name',
+      school_name: 'test-school-name',
+      street_1: 'test-street-1',
+      street_2: 'test-street-2',
+      city: 'test-city',
+      state: 'test-state',
+      zip: 'test-zip',
+      privacy_permission: true
+    }
+  end
+
+  def success_response
+    mock.tap do |response|
+      # This is what a real success response from this API looks like
+      response.stubs(:code).returns('200')
+      response.stubs(:body).returns(<<~BODY)
+        {
+          "responseCode": 200,
+          "message": "success",
+          "content": {
+            "submissionID": "4693670621822232790",
+            "URL": "https:\/\/api.jotform.com\/submission\/4693670621822232790"
+          },
+          "duration": "24ms",
+          "limit-left": 49996
+        }
+      BODY
+    end
+  end
+
+  def failure_response
+    mock.tap do |response|
+      # This is the only real failure I was able to generate when
+      # testing this API - it's a response to sending no fields
+      # at all.
+      response.stubs(:code).returns('400')
+      response.stubs(:body).returns(<<~BODY)
+        {
+          "responseCode": 400,
+          "message": "Bad request (\/form-id-submissions) - Submissions couldn't inserted",
+          "content": [],
+          "duration": "12ms",
+          "info": "https:\/\/api.jotform.com\/docs#form-id-submissions"
+        }
+      BODY
+    end
+  end
+end


### PR DESCRIPTION
Adds some code that handles submitting from our server to the CSTA+ form.  Isolating this into a Service because there's some semi-complex translation of the parameters into the appropriate JotForm-friendly format.

I've already added the appropriate configuration values as secrets to AWS secrets manager.

## Links

[AFE Integration TODO list](https://docs.google.com/document/d/1Ny0pTrvkBMnOKx0CqoNnWTWhwq-oCn9IBYekSjiJMBc/edit)

## Testing story

I've added unit tests that check the parameters are passed through into a well-formed format.  I've manually verified that this format is well-formed by submitting matching requests to the CSTA test JotForm and retrieving the generated submissions, confirming that all the data we sent is intact.

I've also verified that the production CSTA form has exactly the same question format as the test CSTA form by asking their REST API for the question metadata on each form and diffing the responses - so it's reasonable to assume that if this feature is working against the test form, it will work against the production form.

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
