### PR TITLE
Log unversioned course unit redirects

### DIFF
--- a/dashboard/app/controllers/script_levels_controller.rb
+++ b/dashboard/app/controllers/script_levels_controller.rb
@@ -256,8 +256,12 @@ class ScriptLevelsController < ApplicationController
 
   def self.get_script(request)
     script_id = request.params[:script_id]
+    # Due to a programming error, we have been inadvertently passing user: nil
+    # to Script.get_script_family_redirect_for_user . Since end users may be
+    # depending on this incorrect behavior, and we are trying to deprecate this
+    # codepath anyway, the current plan is to not fix this bug.
     script = ScriptConstants::FAMILY_NAMES.include?(script_id) ?
-      Script.get_script_family_redirect_for_user(script_id, user: current_user, locale: request.locale) :
+      Script.get_script_family_redirect_for_user(script_id, user: nil, locale: request.locale) :
       Script.get_from_cache(script_id)
 
     raise ActiveRecord::RecordNotFound unless script

--- a/dashboard/app/controllers/script_levels_controller.rb
+++ b/dashboard/app/controllers/script_levels_controller.rb
@@ -87,6 +87,10 @@ class ScriptLevelsController < ApplicationController
       new_script = Script.get_from_cache(@script.redirect_to)
       new_path = request.fullpath.sub(%r{^/s/#{params[:script_id]}/}, "/s/#{new_script.name}/")
 
+      if ScriptConstants::FAMILY_NAMES.include?(params[:script_id])
+        Script.log_redirect(params[:script_id], new_script.name, request, 'unversioned-script-level-redirect')
+      end
+
       # avoid a redirect loop if the string substitution failed
       if new_path == request.fullpath
         redirect_to build_script_level_path(new_script.starting_level)
@@ -253,7 +257,7 @@ class ScriptLevelsController < ApplicationController
   def self.get_script(request)
     script_id = request.params[:script_id]
     script = ScriptConstants::FAMILY_NAMES.include?(script_id) ?
-      Script.get_script_family_redirect_for_user(script_id, user: current_user, locale: request.locale, log_request: request, log_event_name: 'unversioned-script-level-redirect') :
+      Script.get_script_family_redirect_for_user(script_id, user: current_user, locale: request.locale) :
       Script.get_from_cache(script_id)
 
     raise ActiveRecord::RecordNotFound unless script

--- a/dashboard/app/controllers/script_levels_controller.rb
+++ b/dashboard/app/controllers/script_levels_controller.rb
@@ -88,7 +88,7 @@ class ScriptLevelsController < ApplicationController
       new_path = request.fullpath.sub(%r{^/s/#{params[:script_id]}/}, "/s/#{new_script.name}/")
 
       if ScriptConstants::FAMILY_NAMES.include?(params[:script_id])
-        log_redirect(params[:script_id], new_script.name)
+        Script.log_redirect(params[:script_id], new_script.name, request, 'unversioned-script-level-redirect')
       end
 
       # avoid a redirect loop if the string substitution failed
@@ -265,20 +265,6 @@ class ScriptLevelsController < ApplicationController
   end
 
   private
-
-  def log_redirect(old_script_name, new_script_name)
-    FirehoseClient.instance.put_record(
-      study: 'script-family-redirect',
-      event: 'unversioned-script-level-redirect',
-      data_string: request.path,
-      data_json: {
-        old_script_name: old_script_name,
-        new_script_name: new_script_name,
-        url: request.url,
-        referer: request.referer,
-      }.to_json
-    )
-  end
 
   # Configure http caching for the given script. Caching is disabled unless the
   # Gatekeeper configuration for 'script' specifies that it is publicly

--- a/dashboard/app/controllers/script_levels_controller.rb
+++ b/dashboard/app/controllers/script_levels_controller.rb
@@ -88,7 +88,7 @@ class ScriptLevelsController < ApplicationController
       new_path = request.fullpath.sub(%r{^/s/#{params[:script_id]}/}, "/s/#{new_script.name}/")
 
       if ScriptConstants::FAMILY_NAMES.include?(params[:script_id])
-        Script.log_redirect(params[:script_id], new_script.name, request, 'unversioned-script-level-redirect')
+        Script.log_redirect(params[:script_id], new_script.name, request, 'unversioned-script-level-redirect', current_user&.user_type)
       end
 
       # avoid a redirect loop if the string substitution failed

--- a/dashboard/app/controllers/script_levels_controller.rb
+++ b/dashboard/app/controllers/script_levels_controller.rb
@@ -87,10 +87,6 @@ class ScriptLevelsController < ApplicationController
       new_script = Script.get_from_cache(@script.redirect_to)
       new_path = request.fullpath.sub(%r{^/s/#{params[:script_id]}/}, "/s/#{new_script.name}/")
 
-      if ScriptConstants::FAMILY_NAMES.include?(params[:script_id])
-        Script.log_redirect(params[:script_id], new_script.name, request, 'unversioned-script-level-redirect')
-      end
-
       # avoid a redirect loop if the string substitution failed
       if new_path == request.fullpath
         redirect_to build_script_level_path(new_script.starting_level)
@@ -257,7 +253,7 @@ class ScriptLevelsController < ApplicationController
   def self.get_script(request)
     script_id = request.params[:script_id]
     script = ScriptConstants::FAMILY_NAMES.include?(script_id) ?
-      Script.get_script_family_redirect_for_user(script_id, user: current_user, locale: request.locale) :
+      Script.get_script_family_redirect_for_user(script_id, user: current_user, locale: request.locale, log_request: request, log_event_name: 'unversioned-script-level-redirect') :
       Script.get_from_cache(script_id)
 
     raise ActiveRecord::RecordNotFound unless script

--- a/dashboard/app/controllers/scripts_controller.rb
+++ b/dashboard/app/controllers/scripts_controller.rb
@@ -157,9 +157,13 @@ class ScriptsController < ApplicationController
   def set_script
     script_id = params[:id]
     @script = ScriptConstants::FAMILY_NAMES.include?(script_id) ?
-      Script.get_script_family_redirect_for_user(script_id, user: current_user, locale: request.locale, log_request: request, log_event_name: 'unversioned-script-redirect') :
+      Script.get_script_family_redirect_for_user(script_id, user: current_user, locale: request.locale) :
       Script.get_from_cache(script_id)
     raise ActiveRecord::RecordNotFound unless @script
+
+    if ScriptConstants::FAMILY_NAMES.include?(script_id)
+      Script.log_redirect(script_id, @script.redirect_to, request, 'unversioned-script-redirect')
+    end
 
     if current_user && @script.pilot? && !@script.has_pilot_access?(current_user)
       render :no_access

--- a/dashboard/app/controllers/scripts_controller.rb
+++ b/dashboard/app/controllers/scripts_controller.rb
@@ -157,13 +157,9 @@ class ScriptsController < ApplicationController
   def set_script
     script_id = params[:id]
     @script = ScriptConstants::FAMILY_NAMES.include?(script_id) ?
-      Script.get_script_family_redirect_for_user(script_id, user: current_user, locale: request.locale) :
+      Script.get_script_family_redirect_for_user(script_id, user: current_user, locale: request.locale, log_request: request, log_event_name: 'unversioned-script-redirect') :
       Script.get_from_cache(script_id)
     raise ActiveRecord::RecordNotFound unless @script
-
-    if ScriptConstants::FAMILY_NAMES.include?(script_id)
-      Script.log_redirect(script_id, @script.redirect_to, request, 'unversioned-script-redirect')
-    end
 
     if current_user && @script.pilot? && !@script.has_pilot_access?(current_user)
       render :no_access

--- a/dashboard/app/controllers/scripts_controller.rb
+++ b/dashboard/app/controllers/scripts_controller.rb
@@ -162,7 +162,7 @@ class ScriptsController < ApplicationController
     raise ActiveRecord::RecordNotFound unless @script
 
     if ScriptConstants::FAMILY_NAMES.include?(script_id)
-      Script.log_redirect(script_id, @script.redirect_to, request, 'unversioned-script-redirect')
+      Script.log_redirect(script_id, @script.redirect_to, request, 'unversioned-script-redirect', current_user&.user_type)
     end
 
     if current_user && @script.pilot? && !@script.has_pilot_access?(current_user)

--- a/dashboard/app/controllers/scripts_controller.rb
+++ b/dashboard/app/controllers/scripts_controller.rb
@@ -162,26 +162,12 @@ class ScriptsController < ApplicationController
     raise ActiveRecord::RecordNotFound unless @script
 
     if ScriptConstants::FAMILY_NAMES.include?(script_id)
-      log_redirect(script_id, @script.redirect_to)
+      Script.log_redirect(script_id, @script.redirect_to, request, 'unversioned-script-redirect')
     end
 
     if current_user && @script.pilot? && !@script.has_pilot_access?(current_user)
       render :no_access
     end
-  end
-
-  def log_redirect(old_script_name, new_script_name)
-    FirehoseClient.instance.put_record(
-      study: 'script-family-redirect',
-      event: 'unversioned-script-redirect',
-      data_string: request.path,
-      data_json: {
-        old_script_name: old_script_name,
-        new_script_name: new_script_name,
-        url: request.url,
-        referer: request.referer,
-      }.to_json
-    )
   end
 
   def script_params

--- a/dashboard/app/controllers/scripts_controller.rb
+++ b/dashboard/app/controllers/scripts_controller.rb
@@ -161,9 +161,27 @@ class ScriptsController < ApplicationController
       Script.get_from_cache(script_id)
     raise ActiveRecord::RecordNotFound unless @script
 
+    if ScriptConstants::FAMILY_NAMES.include?(script_id)
+      log_redirect(script_id, @script.redirect_to)
+    end
+
     if current_user && @script.pilot? && !@script.has_pilot_access?(current_user)
       render :no_access
     end
+  end
+
+  def log_redirect(old_script_name, new_script_name)
+    FirehoseClient.instance.put_record(
+      study: 'script-family-redirect',
+      event: 'unversioned-script-redirect',
+      data_string: request.path,
+      data_json: {
+        old_script_name: old_script_name,
+        new_script_name: new_script_name,
+        url: request.url,
+        referer: request.referer,
+      }.to_json
+    )
   end
 
   def script_params

--- a/dashboard/app/models/script.rb
+++ b/dashboard/app/models/script.rb
@@ -467,7 +467,7 @@ class Script < ActiveRecord::Base
     end
   end
 
-  def self.get_script_family_redirect_for_user(family_name, user: nil, locale: 'en-US')
+  def self.get_script_family_redirect_for_user(family_name, user: nil, locale: 'en-US', log_request: {}, log_event_name: nil)
     return nil unless family_name
 
     family_scripts = Script.get_family_from_cache(family_name).sort_by(&:version_year).reverse
@@ -478,6 +478,7 @@ class Script < ActiveRecord::Base
       progress_script_ids = user.user_levels.map(&:script_id)
       script_ids = assigned_script_ids.concat(progress_script_ids).compact.uniq
       script_name = family_scripts.select {|s| script_ids.include?(s.id)}&.first&.name
+      log_redirect(family_name, script_name, log_request, log_event_name) if log_event_name
       return Script.new(redirect_to: script_name) if script_name
     end
 
@@ -497,6 +498,7 @@ class Script < ActiveRecord::Base
     end
 
     script_name = latest_version&.name
+    log_redirect(family_name, script_name, log_request, log_event_name) if script_name && log_event_name
     script_name ? Script.new(redirect_to: script_name) : nil
   end
 

--- a/dashboard/app/models/script.rb
+++ b/dashboard/app/models/script.rb
@@ -500,6 +500,20 @@ class Script < ActiveRecord::Base
     script_name ? Script.new(redirect_to: script_name) : nil
   end
 
+  def self.log_redirect(old_script_name, new_script_name, request, event_name)
+    FirehoseClient.instance.put_record(
+      study: 'script-family-redirect',
+      event: event_name,
+      data_string: request.path,
+      data_json: {
+        old_script_name: old_script_name,
+        new_script_name: new_script_name,
+        url: request.url,
+        referer: request.referer,
+      }.to_json
+    )
+  end
+
   # @param user [User]
   # @param locale [String] User or request locale. Optional.
   # @return [String|nil] URL to the script overview page the user should be redirected to (if any).

--- a/dashboard/app/models/script.rb
+++ b/dashboard/app/models/script.rb
@@ -500,7 +500,7 @@ class Script < ActiveRecord::Base
     script_name ? Script.new(redirect_to: script_name) : nil
   end
 
-  def self.log_redirect(old_script_name, new_script_name, request, event_name)
+  def self.log_redirect(old_script_name, new_script_name, request, event_name, user_type)
     FirehoseClient.instance.put_record(
       study: 'script-family-redirect',
       event: event_name,
@@ -511,6 +511,7 @@ class Script < ActiveRecord::Base
         method: request.method,
         url: request.url,
         referer: request.referer,
+        user_type: user_type
       }.to_json
     )
   end

--- a/dashboard/app/models/script.rb
+++ b/dashboard/app/models/script.rb
@@ -467,7 +467,7 @@ class Script < ActiveRecord::Base
     end
   end
 
-  def self.get_script_family_redirect_for_user(family_name, user: nil, locale: 'en-US', log_request: {}, log_event_name: nil)
+  def self.get_script_family_redirect_for_user(family_name, user: nil, locale: 'en-US')
     return nil unless family_name
 
     family_scripts = Script.get_family_from_cache(family_name).sort_by(&:version_year).reverse
@@ -478,7 +478,6 @@ class Script < ActiveRecord::Base
       progress_script_ids = user.user_levels.map(&:script_id)
       script_ids = assigned_script_ids.concat(progress_script_ids).compact.uniq
       script_name = family_scripts.select {|s| script_ids.include?(s.id)}&.first&.name
-      log_redirect(family_name, script_name, log_request, log_event_name) if log_event_name
       return Script.new(redirect_to: script_name) if script_name
     end
 
@@ -498,7 +497,6 @@ class Script < ActiveRecord::Base
     end
 
     script_name = latest_version&.name
-    log_redirect(family_name, script_name, log_request, log_event_name) if script_name && log_event_name
     script_name ? Script.new(redirect_to: script_name) : nil
   end
 

--- a/dashboard/app/models/script.rb
+++ b/dashboard/app/models/script.rb
@@ -508,6 +508,7 @@ class Script < ActiveRecord::Base
       data_json: {
         old_script_name: old_script_name,
         new_script_name: new_script_name,
+        method: request.method,
         url: request.url,
         referer: request.referer,
       }.to_json


### PR DESCRIPTION
Finishes [PLAT-182](https://codedotorg.atlassian.net/browse/PLAT-182)

For context, see the kinds of data that we pulled out of cloudfront logs which was useful for analysis: [gsheet](https://docs.google.com/spreadsheets/d/1ZD_lW4aHRcIu8p1hMKFh5FYIngVECvsggilsXPg6mWc/edit#gid=1425542697)

request.path is listed as data_string since that could be useful to aggregate and count on, while request.path might be useful if we want to look at url params.

## Testing story

Manually verified that firehose events are created on unversioned script and script level paths.

http://localhost-studio.code.org:3000/s/csp1?foo=1 :
```
Skipped sending record to analysis-events: 
{:study=>"script-family-redirect", :event=>"unversioned-script-redirect", :data_string=>"/s/csp1", :data_json=>"{\"old_script_name\":\"csp1\",\"new_script_name\":\"csp1-2019\",\"url\":\"http://localhost-studio.code.org:3000/s/csp1?foo=1\",\"referer\":null}"}
```

http://localhost-studio.code.org:3000/s/csp3/stage/1/puzzle/1?baz=3 :
```
Skipped sending record to analysis-events: 
{:study=>"script-family-redirect", :event=>"unversioned-script-level-redirect", :data_string=>"/s/csp3/stage/1/puzzle/1", :data_json=>"{\"old_script_name\":\"csp3\",\"new_script_name\":\"csp3-2019\",\"url\":\"http://localhost-studio.code.org:3000/s/csp3/stage/1/puzzle/1?baz=3\",\"referer\":null}"}
```

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
