### PR TITLE
Bump Blockly to pull in Mini Toolbox changes

### DIFF
--- a/apps/package.json
+++ b/apps/package.json
@@ -49,7 +49,7 @@
     "@babel/preset-react": "^7.0.0",
     "@cdo/interpreted": "link:../dashboard/config/libraries",
     "@code-dot-org/artist": "0.2.1",
-    "@code-dot-org/blockly": "3.5.21",
+    "@code-dot-org/blockly": "3.5.22",
     "@code-dot-org/bramble": "0.1.26",
     "@code-dot-org/craft": "0.2.2",
     "@code-dot-org/dance-party": "1.0.1",

--- a/apps/src/p5lab/spritelab/blocks.js
+++ b/apps/src/p5lab/spritelab/blocks.js
@@ -213,9 +213,13 @@ const customInputTypes = {
           block.shortString = '';
           block.longString = '';
       }
+      block.thumbnailSize = 32;
       currentInputRow
-        .appendTitle(block.longString)
-        .appendTitle(new Blockly.FieldImage('', 1, 1), inputConfig.name);
+        .appendTitle(block.shortString)
+        .appendTitle(
+          new Blockly.FieldImage('', block.thumbnailSize, block.thumbnailSize),
+          inputConfig.name
+        );
     },
     generateCode(block, arg) {
       switch (block.type) {

--- a/apps/yarn.lock
+++ b/apps/yarn.lock
@@ -1526,10 +1526,10 @@
   version "0.2.1"
   resolved "https://registry.yarnpkg.com/@code-dot-org/artist/-/artist-0.2.1.tgz#fcfe7ea5cfb3f19ddb6b912e70e922ba4b7ef0b1"
 
-"@code-dot-org/blockly@3.5.21":
-  version "3.5.21"
-  resolved "https://registry.yarnpkg.com/@code-dot-org/blockly/-/blockly-3.5.21.tgz#63f0675b67cccefb2f2431e55776c28e853ba81d"
-  integrity sha512-vq4IQLs8lXDWbdIiYteX3aXrXP5l6Gd//8PmiQmYlbsc20Lkz4ggqTh9r/qYHEpupmOzLoZIeEYwioZmUNDi/g==
+"@code-dot-org/blockly@3.5.22":
+  version "3.5.22"
+  resolved "https://registry.yarnpkg.com/@code-dot-org/blockly/-/blockly-3.5.22.tgz#ca188b0dd954c920639a9241e7888a9047620238"
+  integrity sha512-JgFCDLwgeFC5j8lRrp0g+Hd+sTAYjaQMsfZgUHK+3hGVYG7ISXw+iZhFdoCGqJBpCU3NV9cCXH6R2ax3SRL/WQ==
 
 "@code-dot-org/bramble@0.1.26":
   version "0.1.26"

--- a/dashboard/config/blocks/GamelabJr/gamelab_clickedSpritePointer.json
+++ b/dashboard/config/blocks/GamelabJr/gamelab_clickedSpritePointer.json
@@ -3,7 +3,7 @@
   "config": {
     "simpleValue": true,
     "name": "clickedSpritePointer",
-    "blockText": "clicked {SPRITE}",
+    "blockText": "{SPRITE}",
     "args": [
       {
         "name": "SPRITE",

--- a/dashboard/config/blocks/GamelabJr/gamelab_objectSpritePointer.json
+++ b/dashboard/config/blocks/GamelabJr/gamelab_objectSpritePointer.json
@@ -3,7 +3,7 @@
   "config": {
     "simpleValue": true,
     "name": "objectSpritePointer",
-    "blockText": "object {SPRITE}",
+    "blockText": "{SPRITE}",
     "args": [
       {
         "name": "SPRITE",

--- a/dashboard/config/blocks/GamelabJr/gamelab_subjectSpritePointer.json
+++ b/dashboard/config/blocks/GamelabJr/gamelab_subjectSpritePointer.json
@@ -3,7 +3,7 @@
   "config": {
     "simpleValue": true,
     "name": "subjectSpritePointer",
-    "blockText": "subject {SPRITE}",
+    "blockText": "{SPRITE}",
     "args": [
       {
         "name": "SPRITE",


### PR DESCRIPTION
pulls in https://github.com/code-dot-org/blockly/pull/224, https://github.com/code-dot-org/blockly/pull/225, and https://github.com/code-dot-org/blockly/pull/226

Also sets `thumbnailSize` on the pointer blocks, which is used by https://github.com/code-dot-org/blockly/pull/225

And finally, removes the words "clicked", "subject", and "object" from the blocks themselves, since the text is now being controlled by `block.shortString` and `block.longString` (which allows us to dynamically change it based on whether or not there's a thumbnail image).

## Links

<!--
  Any relevant links to external resources; ie, specification documents, jira
  items, related PRs, honeybadger errors, etc
-->

- [spec]()
- [jira]()

## Testing story

<!--
  Does your change include appropriate tests?

  If so, please describe how the tests included in this PR are sufficient

  If not, please explain why this change does not need to be tested.
-->

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
