### PR TITLE
Correct Firmata Sketch Link for CPE

### DIFF
--- a/apps/src/lib/kits/maker/ui/SetupChecklist.jsx
+++ b/apps/src/lib/kits/maker/ui/SetupChecklist.jsx
@@ -339,7 +339,13 @@ export default class SetupChecklist extends Component {
             <br />
             You should make sure your board has the right firmware sketch
             installed. You can{' '}
-            <a href="https://learn.adafruit.com/circuit-playground-firmata/overview">
+            <a
+              href={
+                this.state.boardTypeDetected === BOARD_TYPE.CLASSIC
+                  ? 'https://learn.adafruit.com/circuit-playground-firmata/overview'
+                  : 'https://learn.adafruit.com/adafruit-circuit-playground-express/code-org-csd'
+              }
+            >
               install the Circuit Playground Firmata sketch with these
               instructions
             </a>


### PR DESCRIPTION
Report from Zendesk from a user attempting to follow the CPC instructions to flash the firmata sketch on a CPE board. This is because the link in our instructions is only for the CPC instructions, regardless of the board and the CPC instructions don't work for the CPE board.

This PR adds a conditional to check the board type and change the href to correctly direct the user.

## Links

<!--
  Any relevant links to external resources; ie, specification documents, jira
  items, related PRs, honeybadger errors, etc
-->

- [spec]()
- [jira]()

## Testing story
Manually tested

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
