### PR TITLE
[Spritelab] Add levelbuilder option to enable mini toolbox

### DIFF
--- a/apps/src/block_utils.js
+++ b/apps/src/block_utils.js
@@ -1003,8 +1003,6 @@ exports.createJsWrapperBlockCreator = function(
 
         if (
           miniToolboxBlocks &&
-          appOptions.level.miniToolbox &&
-          !appOptions.readonlyWorkspace &&
           experiments.isEnabled(experiments.MINI_TOOLBOX)
         ) {
           var toggle = new Blockly.FieldIcon('+');
@@ -1025,9 +1023,11 @@ exports.createJsWrapperBlockCreator = function(
             this.tray = !this.tray;
             this.render();
           });
-          this.appendDummyInput()
-            .appendTitle(toggle)
-            .appendTitle(' ');
+          if (appOptions.level.miniToolbox && !appOptions.readonlyWorkspace) {
+            this.appendDummyInput()
+              .appendTitle(toggle)
+              .appendTitle(' ');
+          }
           this.initMiniFlyout(miniToolboxXml);
         }
 

--- a/apps/src/block_utils.js
+++ b/apps/src/block_utils.js
@@ -1,3 +1,4 @@
+/* global appOptions */
 import _ from 'lodash';
 import xml from './xml';
 import experiments from '@cdo/apps/util/experiments';
@@ -1002,6 +1003,7 @@ exports.createJsWrapperBlockCreator = function(
 
         if (
           miniToolboxBlocks &&
+          appOptions.level.miniToolbox &&
           experiments.isEnabled(experiments.MINI_TOOLBOX)
         ) {
           var toggle = new Blockly.FieldIcon('+');

--- a/apps/src/block_utils.js
+++ b/apps/src/block_utils.js
@@ -1004,6 +1004,7 @@ exports.createJsWrapperBlockCreator = function(
         if (
           miniToolboxBlocks &&
           appOptions.level.miniToolbox &&
+          !appOptions.readonlyWorkspace &&
           experiments.isEnabled(experiments.MINI_TOOLBOX)
         ) {
           var toggle = new Blockly.FieldIcon('+');

--- a/dashboard/app/models/levels/gamelab_jr.rb
+++ b/dashboard/app/models/levels/gamelab_jr.rb
@@ -30,6 +30,7 @@ class GamelabJr < Gamelab
     hide_custom_blocks
     use_default_sprites
     block_pools
+    mini_toolbox
   )
 
   def shared_blocks
@@ -55,7 +56,8 @@ class GamelabJr < Gamelab
           show_type_hints: true,
           hide_custom_blocks: true,
           all_animations_single_frame: true,
-          use_modal_function_editor: true
+          use_modal_function_editor: true,
+          mini_toolbox: false
         }
       )
     )

--- a/dashboard/app/views/levels/editors/fields/_blockly.html.haml
+++ b/dashboard/app/views/levels/editors/fields/_blockly.html.haml
@@ -24,6 +24,10 @@
   .aligned-input-group
     = f.check_box :disable_param_editing, {}, 'false', 'true'
     = f.label :disable_param_editing, 'Enable param editing in function blocks'
+  - if (@level.instance_of?(GamelabJr))
+    .aligned-input-group
+      = f.check_box :mini_toolbox, {}, 'true', 'false'
+      = f.label :mini_toolbox, 'Enable mini toolbox for event blocks'
   .field
     = f.label :goal_override, 'Goal Override Object (Legacy Levels)'
     = f.text_area :goal_override, placeholder: '{"goalAnimation": "animatedGoal"}'

--- a/dashboard/app/views/levels/new.html.haml
+++ b/dashboard/app/views/levels/new.html.haml
@@ -10,10 +10,6 @@
   %li= link_to 'Build a Playlab Level', new_level_path(type: 'Studio')
   %li
     =link_to 'Build a Sprite Lab Level', new_level_path(type: 'GamelabJr')
-    %ul
-      %li
-        Sprite Lab is still in beta and subject to change. Anything you
-        build could break or be deleted without notice.
   %li
     =link_to 'Build a Dance Lab Level', new_level_path(type: 'Dancelab')
     %ul


### PR DESCRIPTION
Add an option for Sprite Lab levels on the level edit page to configure whether event blocks should have the mini toolbox.
![Screen Shot 2020-06-18 at 2 25 08 PM](https://user-images.githubusercontent.com/8787187/85073421-95be8a00-b16f-11ea-9b17-cf5b8c00cce4.png)

With checkbox unchecked:
![image](https://user-images.githubusercontent.com/8787187/85073331-70ca1700-b16f-11ea-971c-6c5be55bb050.png)

With checkbox checked:
![image](https://user-images.githubusercontent.com/8787187/85073614-f6e65d80-b16f-11ea-9609-e92ca2535943.png)


Also while I was in here, I took the beta notice off of Sprite Lab. I think we're well past the point where we could delete/break spritelab without notice :) 
Before:
![image](https://user-images.githubusercontent.com/8787187/85073892-783df000-b170-11ea-9b89-4c2f7870c96b.png)

After:
![image](https://user-images.githubusercontent.com/8787187/85073870-6fe5b500-b170-11ea-9124-5378ef849b49.png)


<!--
  Other aspects to consider. uncomment and add detail for any that seem necessary:
-->

<!-- ### Background -->
<!-- ### Privacy -->
<!-- ### Security -->
<!-- ### Caching -->
<!-- ### Deployment strategy -->
<!-- ### Future work -->

## Testing story

<!--
  Does your change include appropriate tests?

  If so, please describe how the tests included in this PR are sufficient

  If not, please explain why this change does not need to be tested.
-->

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
