### PR TITLE
Load CDO application config in Chef context

### DIFF
--- a/cookbooks/cdo-apps/recipes/default.rb
+++ b/cookbooks/cdo-apps/recipes/default.rb
@@ -61,8 +61,6 @@ apt_package %w(
   cmake
 )
 
-include_recipe 'cdo-mysql'
-
 include_recipe 'cdo-ruby'
 
 # Ensure the correct locale is generated and set as default (e.g. for Docker containers).
@@ -87,6 +85,7 @@ end
 node.default['cdo-secrets']['daemon'] = node['cdo-apps']['daemon'] if node['cdo-apps']['daemon']
 
 include_recipe 'cdo-secrets'
+include_recipe 'cdo-mysql'
 include_recipe 'cdo-postfix'
 include_recipe 'cdo-varnish'
 

--- a/cookbooks/cdo-mysql/recipes/proxy.rb
+++ b/cookbooks/cdo-mysql/recipes/proxy.rb
@@ -32,6 +32,8 @@ reporting = URI.parse((node['cdo-secrets']['reporting_db_writer'] || writer).to_
 
 # If this is an Aurora cluster, resolve instance-endpoint hostnames
 # to help with instance auto-discovery.
+node.default['cdo-secrets']['db_cluster_id'] = CDO.db_cluster_id
+
 if (is_aurora = !!node['cdo-secrets']['db_cluster_id'])
   [writer, reader, reporting].each {|server| server.host = get_cname(server.host)}
 end

--- a/cookbooks/cdo-mysql/recipes/proxy.rb
+++ b/cookbooks/cdo-mysql/recipes/proxy.rb
@@ -30,14 +30,6 @@ writer.hostname = '127.0.0.1' if writer.hostname == 'localhost'
 reader = URI.parse((node['cdo-secrets']['db_reader'] || writer).to_s)
 reporting = URI.parse((node['cdo-secrets']['reporting_db_writer'] || writer).to_s)
 
-# If this is an Aurora cluster, resolve instance-endpoint hostnames
-# to help with instance auto-discovery.
-node.default['cdo-secrets']['db_cluster_id'] = CDO.db_cluster_id
-
-if (is_aurora = !!node['cdo-secrets']['db_cluster_id'])
-  [writer, reader, reporting].each {|server| server.host = get_cname(server.host)}
-end
-
 admin = URI.parse(node['cdo-mysql']['proxy']['admin'])
 admin_opt_str = %w(user host port).map {|x| "--#{x}=#{admin.send(x)}"}.join(' ')
 # Set password via named pipe (requires Bash) to suppress password-warning message on stderr.
@@ -52,16 +44,13 @@ template 'proxysql.cnf' do
   path "/etc/#{name}"
   source "#{name}.erb"
   variables(
-    mysql_servers: {
-      writer => [0, 1, 2],
-      reader => [1, 2],
-      reporting => [3]
-    }.flat_map {|server, hostgroup| [server].product(hostgroup)},
+    mysql_servers: [
+      {writer => [0, 1, 2]},
+      {reader => [1, 2]},
+      {reporting => [3]}
+    ],
     data_dir: data_dir,
-    is_aurora: is_aurora,
-    writer: writer,
-    reader: reader,
-    reporting: reporting,
+    is_aurora: lazy {!!CDO.db_cluster_id},
     admin: admin,
     port: proxy_port,
     reporting_port: reporting_port

--- a/cookbooks/cdo-mysql/templates/default/proxysql.cnf.erb
+++ b/cookbooks/cdo-mysql/templates/default/proxysql.cnf.erb
@@ -1,3 +1,15 @@
+<%
+# If this is an Aurora cluster, resolve instance-endpoint hostnames
+# to help with instance auto-discovery.
+servers = @mysql_servers.map {|s| s.keys.first}
+if @is_aurora
+  servers.each do |server|
+    server.host = get_cname(server.host)
+  end
+end
+writer, reader, reporting = servers
+-%>
+
 # libconfig file format:
 # http://www.hyperrealm.com/libconfig/libconfig_manual.html#Configuration-Files
 
@@ -33,8 +45,8 @@ mysql_variables=
   # The user needs also REPLICATION CLIENT if it needs to monitor replication lag.
   # https://github.com/sysown/proxysql/wiki/Global-variables#mysql-monitor_username
   # https://github.com/sysown/proxysql/wiki/Global-variables#mysql-monitor_password
-  monitor_username="<%= @reader.user %>"
-  monitor_password="<%= @reader.password %>"
+  monitor_username="<%= reader.user %>"
+  monitor_password="<%= reader.password %>"
 
   # If this variable is set, after an OK packet with `last_insert_id` is received,
   # multiplexing is temporary disabled for the number of queries specified (default 5).
@@ -75,7 +87,12 @@ mysql_variables=
 # https://github.com/sysown/proxysql/wiki/Main-(runtime)#mysql_servers
 mysql_servers =
 (
-<% @mysql_servers.each do |server, hostgroup| -%>
+<%
+  # Expand {server => [hg, ..]} to individual [server, hg] table rows.
+  @mysql_servers.map {|s| s.to_a.first}.
+    flat_map {|s, hgs| [s].product(hgs)}.
+    uniq.each do |server, hostgroup|
+-%>
   {
     address =        "<%= server.host %>"
     port =            <%= server.port || 3306 %>
@@ -103,7 +120,7 @@ mysql_aws_aurora_hostgroups:
     reader_hostgroup=1
     new_reader_weight=10000000
     writer_is_also_reader=1
-    domain_name="<%=@writer.host.sub(/[^.]*/, '')%>"
+    domain_name="<%=writer.host.sub(/[^.]*/, '')%>"
   }
 )
 <% end -%>
@@ -111,17 +128,17 @@ mysql_aws_aurora_hostgroups:
 # https://github.com/sysown/proxysql/wiki/Main-(runtime)#mysql_users
 mysql_users:
 (
-<% if @writer.user != @reader.user -%>
+<% if writer.user != reader.user -%>
   {
-    username = "<%= @reader.user %>"
-    password = "<%= @reader.password %>"
+    username = "<%= reader.user %>"
+    password = "<%= reader.password %>"
     # Send all reader-user queries to reader hostgroup (1) by default.
     default_hostgroup = 1
   },
 <% end -%>
   {
-    username = "<%= @writer.user %>"
-    password = "<%= @writer.password %>"
+    username = "<%= writer.user %>"
+    password = "<%= writer.password %>"
     default_hostgroup = 0
   }
 )
@@ -152,7 +169,7 @@ mysql_query_rules:
   {
     # Send writer-user SELECTs to the primary-reader (HG2).
     rule_id=3
-    username="<%= @writer.user %>"
+    username="<%= writer.user %>"
     active=1
     match_pattern="^SELECT"
     destination_hostgroup=2

--- a/cookbooks/cdo-repository/libraries/git.rb
+++ b/cookbooks/cdo-repository/libraries/git.rb
@@ -7,7 +7,7 @@
 # - Better branch names:
 #   - Set checkout branch to remote track the corresponding remote branch with the same name.
 #   - Support switching to a new checkout branch after the initial clone.
-module CDO
+module Cdo
   module Provider
     class Git < Chef::Provider::Git
       def initialize(new_resource, run_context)

--- a/cookbooks/cdo-repository/recipes/default.rb
+++ b/cookbooks/cdo-repository/recipes/default.rb
@@ -11,10 +11,10 @@ if has_ssh_key
 end
 
 home_path = node[:home]
-git_path = File.join home_path, node.chef_environment
+git_path = node.default['cdo-repository']['git_path'] = File.join(home_path, node.chef_environment)
 
 git git_path do
-  provider CDO::Provider::Git
+  provider Cdo::Provider::Git
 
   repository node['cdo-repository']['url']
   depth node['cdo-repository']['depth'] if node['cdo-repository']['depth']

--- a/cookbooks/cdo-secrets/README.md
+++ b/cookbooks/cdo-secrets/README.md
@@ -1,1 +1,5 @@
 # cdo-secrets
+
+Synchronizes Chef-attribute config/secrets with application config/secrets.
+
+If `cdo-repository` is active this cookbook will load `[CDO]/deployment.rb`, making the `CDO` application config available to the Chef environment.

--- a/cookbooks/cdo-secrets/recipes/app.rb
+++ b/cookbooks/cdo-secrets/recipes/app.rb
@@ -1,0 +1,19 @@
+# Load deployment.rb into Chef context.
+# This makes CDO.* variables and secrets available to Chef resources in the execution phase.
+#
+# To resolve a reference in the execution phase use `#lazy in a Chef-resource property, e.g.:
+#
+# resource do
+#   property lazy {CDO.variable_name}
+# end
+
+# Install gem dependencies used by Cdo::Secrets.
+chef_gem 'aws-sdk-secretsmanager'
+chef_gem 'activesupport'
+
+ruby_block 'CDO config' do
+  block do
+    ENV['BUNDLE_GEMFILE'] = '' # Disable Bundler
+    require "#{node['cdo-repository']['git_path']}/deployment"
+  end
+end

--- a/cookbooks/cdo-secrets/recipes/default.rb
+++ b/cookbooks/cdo-secrets/recipes/default.rb
@@ -5,3 +5,4 @@
 
 include_recipe 'cdo-secrets::globals'
 include_recipe 'cdo-secrets::words'
+include_recipe 'cdo-secrets::app' if node['cdo-repository']

--- a/lib/cdo/aws/cdo_google_credentials.rb
+++ b/lib/cdo/aws/cdo_google_credentials.rb
@@ -1,5 +1,3 @@
-require 'aws/google'
-
 # Set AWS SDK environment variables from provided config and standardize on aws_* attributes
 ENV['AWS_ACCESS_KEY_ID'] ||= CDO.aws_access_key
 ENV['AWS_SECRET_ACCESS_KEY'] ||= CDO.aws_secret_key
@@ -11,6 +9,7 @@ ENV['AWS_DEFAULT_REGION'] ||= CDO.aws_region
 if CDO.aws_role &&
   CDO.google_client_id &&
   CDO.google_client_secret
+  require 'aws/google'
   Aws::Google.config = {
     role_arn: CDO.aws_role,
     google_client_id: CDO.google_client_id,

--- a/lib/cdo/config.rb
+++ b/lib/cdo/config.rb
@@ -1,4 +1,5 @@
 require 'singleton'
+require 'delegate'
 require 'cdo/yaml'
 
 module Cdo


### PR DESCRIPTION
Adds a new, small Chef-cookbook recipe `cdo-secrets::app`, which executes `require '[CDO]/deployment'` within the running chef-client's Ruby context after the repository has been cloned to the server (via the `cdo-repository` cookbook). This makes the `CDO.*` application-config system available to any subsequent Chef resources in the ['execution phase'](https://docs.chef.io/chef_client_overview/).

Narrowly, this allows us to reference `CDO.db_cluster_id` within the `cdo-mysql::proxy` recipe to change the behavior in the `proxysql.cnf.erb` template based on the value derived from CDO config. More generally, this provides access to `CDO` config (and secrets) using our existing Ruby codebase without having to duplicate functionality between Chef-cookbooks and our application and keep them in sync.

### Background

This work is part of an effort to remove secrets + configuration from hosted Chef into our application repo and AWS Secrets Manager, which is one step in an ongoing migration from hosted Chef to [local mode](https://docs.chef.io/ctl_chef_client/#run-in-local-mode).

<!-- ### Privacy -->
<!-- ### Security -->
<!-- ### Caching -->
<!-- ### Deployment strategy -->
<!-- ### Future work -->

## Links

- [INF-101](https://codedotorg.atlassian.net/browse/INF-101)

## Testing story

- [x] Test provisioning on a default adhoc, to ensure access to `CDO` variables works correctly after provisioning repository
- [x] Test provisioning on an adhoc with `DATABASE=1` to ensure updates to proxy cookbook 
