### PR TITLE
Fix create rollup tables

### DIFF
--- a/bin/cron/create_rollup_tables
+++ b/bin/cron/create_rollup_tables
@@ -5,6 +5,7 @@
 
 require_relative '../../dashboard/config/environment'
 require 'cdo/only_one'
+exit unless only_one_running?(__FILE__)
 
 TIME_NOW = DateTime.now.strftime('%F %T').freeze
 
@@ -237,4 +238,4 @@ def level_sources_multi_types_row(row_hash)
   ROW
 end
 
-main if only_one_running?(__FILE__)
+main

--- a/bin/cron/create_rollup_tables
+++ b/bin/cron/create_rollup_tables
@@ -3,10 +3,8 @@
 # This script populates (after truncating) the contained_levels,
 # contained_level_answers, and the level_sources_multi_type tables.
 
-require 'cdo/only_one'
-exit unless only_one_running?(__FILE__)
-
 require_relative '../../dashboard/config/environment'
+require 'cdo/only_one'
 
 TIME_NOW = DateTime.now.strftime('%F %T').freeze
 
@@ -238,3 +236,5 @@ def level_sources_multi_types_row(row_hash)
     )
   ROW
 end
+
+main if only_one_running?(__FILE__)

--- a/bin/cron/create_rollup_tables
+++ b/bin/cron/create_rollup_tables
@@ -3,9 +3,11 @@
 # This script populates (after truncating) the contained_levels,
 # contained_level_answers, and the level_sources_multi_type tables.
 
-require_relative '../../dashboard/config/environment'
-require 'cdo/only_one'
+require_relative '../../lib/cdo/only_one'
+
 exit unless only_one_running?(__FILE__)
+
+require_relative '../../dashboard/config/environment'
 
 TIME_NOW = DateTime.now.strftime('%F %T').freeze
 


### PR DESCRIPTION
This commit [Faster only_one exit](https://github.com/code-dot-org/code-dot-org/commit/6cd195e42b762bc6b45d17bc7368ee55caa50d2b) sure made this cronjob complete quickly! 😝 
```
Dave-MBP:~/src/cdo (staging)$ ./bin/cron/create_rollup_tables 
Traceback (most recent call last):
	2: from ./bin/cron/create_rollup_tables:6:in `<main>'
	1: from /Users/dsb/.rbenv/versions/2.5.0/lib/ruby/2.5.0/rubygems/core_ext/kernel_require.rb:59:in `require'
/Users/dsb/.rbenv/versions/2.5.0/lib/ruby/2.5.0/rubygems/core_ext/kernel_require.rb:59:in `require': 
cannot load such file -- cdo/only_one (LoadError)
```
This problem was introduced in https://github.com/code-dot-org/code-dot-org/pull/32091 on Dec 2, 2019. To confirm that I wasn't just having this problem locally, I looked at the `contained_levels` table in the staging DB and confirmed that a level group created before December does appear there, and a level group created after December does not.

Why didn't we catch this? It's fair to say that every single person on our team has missed it, because the cronjob has been failing every time it's run since December, and an error has been logged to HoneyBadger every time: https://app.honeybadger.io/projects/45435/faults?sort=last_seen_desc&q=create_rollup_tables

## Future work
* make sure these kinds of errors are getting noticed in HoneyBadger by whoever is oncall.

## Testing story

Manually ran this cronjob locally. Before this change it generated no rows:
```
mysql> select count(*) from contained_levels;
+----------+
| count(*) |
+----------+
|        0 |
+----------+
```
after this change, it generates:
```
mysql> select count(*) from contained_levels;
+----------+
| count(*) |
+----------+
|     3529 |
+----------+
```
on the staging machine, this table has only 2620 entries. The higher number generated locally is probably due to all the level groups created by cloning the 2019 curriculum to create the 2020 curriculum, which generally happens between January and March.

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
