### PR TITLE
CRv2: Update existing attribute processing methods

### DIFF
--- a/dashboard/app/models/contact_rollups_processed.rb
+++ b/dashboard/app/models/contact_rollups_processed.rb
@@ -99,17 +99,21 @@ class ContactRollupsProcessed < ApplicationRecord
   #   Input string:
   #     '[{"sources":"table1", "data":{"opt_in":1}, "data_updated_at":"2020-06-16"}]'
   #   Output hash:
-  #     {
-  #       'table1'=>{
-  #         'opt_in'=>{'value'=>1, 'data_updated_at'=>2020-06-16},
-  #         'last_data_updated_at'=>2020-06-16
-  #       }
-  #     }
+  #     {'table1'=>{
+  #       'opt_in'=>[{'value'=>1, 'data_updated_at'=>2020-06-16}],
+  #       'last_data_updated_at'=>2020-06-6
+  #     }}
+  # @see parse_contact_data test for more examples
   #
-  # @pa3ram str [String] a JSON array string.
+  # @param str [String] a JSON array string.
   #   Each array item is a hash {'sources'=>String, 'data'=>Hash, 'data_updated_at'=>DateTime}.
+  #
   # @return [Hash] a hash with string keys.
-  #   Output format: {source_table => {field_name => [{'value'=>String, 'data_updated_at'=>DateTime}]}}
+  #   Output format:
+  #     {source_table => {
+  #       field_name => [{'value'=>String, 'data_updated_at'=>DateTime}]},
+  #       'last_data_updated_at'=>DateTime
+  #     }}
   #
   # @raise [JSON::ParserError] if cannot parse the input string to JSON
   # @raise [ArgumentError] if cannot parse a time value in the input string to Time
@@ -129,10 +133,10 @@ class ContactRollupsProcessed < ApplicationRecord
           output[sources][field] << {'value' => value, 'data_updated_at' => data_updated_at}
         end
 
-        # if !output[sources].key?('last_data_updated_at') ||
-        #   data_updated_at > output[sources]['last_data_updated_at']
-        #   output[sources]['last_data_updated_at'] = data_updated_at
-        # end
+        if !output[sources].key?('last_data_updated_at') ||
+          data_updated_at > output[sources]['last_data_updated_at']
+          output[sources]['last_data_updated_at'] = data_updated_at
+        end
       end
     end
   end

--- a/dashboard/test/models/contact_rollups_processed_test.rb
+++ b/dashboard/test/models/contact_rollups_processed_test.rb
@@ -127,21 +127,28 @@ class ContactRollupsProcessedTest < ActiveSupport::TestCase
           '[{"%{sources_key}": "table1", "%{data_key}": null, "%{data_updated_at_key}": "%{time_str}"}]',
           format_values
         ),
-        expected_output: {'table1' => {'data_updated_at' => time_parsed}}
+        expected_output: {'table1' => {}}
       },
       {
         input: format(
           '[{"%{sources_key}": "table1", "%{data_key}": {}, "%{data_updated_at_key}": "%{time_str}"}]',
           format_values
         ),
-        expected_output: {'table1' => {'data_updated_at' => time_parsed}}
+        expected_output: {'table1' => {}}
+      },
+      {
+        input: format(
+          '[{"%{sources_key}": "table1", "%{data_key}": {"state": null}, "%{data_updated_at_key}": "%{time_str}"}]',
+          format_values
+        ),
+        expected_output: {'table1' => {}}
       },
       {
         input: format(
           '[{"%{sources_key}": "table1", "%{data_key}": {"opt_in": 1}, "%{data_updated_at_key}": "%{time_str}"}]',
           format_values
         ),
-        expected_output: {'table1' => {'opt_in' => 1, 'data_updated_at' => time_parsed}}
+        expected_output: {'table1' => {'opt_in' => [{'value' => 1, 'data_updated_at' => time_parsed}]}}
       },
       {
         input: format('['\
@@ -150,8 +157,8 @@ class ContactRollupsProcessedTest < ActiveSupport::TestCase
           format_values
         ),
         expected_output: {
-          'table1' => {'opt_in' => 1, 'data_updated_at' => time_parsed},
-          'table2' => {'state' => 'WA', 'data_updated_at' => time_parsed}
+          'table1' => {'opt_in' => [{'value' => 1, 'data_updated_at' => time_parsed}]},
+          'table2' => {'state' => [{'value' => 'WA', 'data_updated_at' => time_parsed}]}
         }
       }
     ]

--- a/dashboard/test/models/contact_rollups_processed_test.rb
+++ b/dashboard/test/models/contact_rollups_processed_test.rb
@@ -98,30 +98,30 @@ class ContactRollupsProcessedTest < ActiveSupport::TestCase
     end
   end
 
-  test 'extract_updated_at' do
+  test 'extract_updated_at with valid input' do
     base_time = Time.now.utc - 7.days
     tests = [
       {
-        input: {'table1' => {'data_updated_at' => base_time}},
+        input: {'table1' => {'last_data_updated_at' => base_time}},
         expected_output: {updated_at: base_time}
       },
       {
         input: {
-          'table1' => {'data_updated_at' => base_time - 1.day},
-          'table2' => {'data_updated_at' => base_time + 1.day},
-          'table3' => {'data_updated_at' => base_time},
+          'table1' => {'last_data_updated_at' => base_time - 1.day},
+          'table2' => {'last_data_updated_at' => base_time + 1.day},
+          'table3' => {'last_data_updated_at' => base_time},
         },
         expected_output: {updated_at: base_time + 1.day}
       }
     ]
 
-    # Test valid inputs
     tests.each_with_index do |test, index|
       output = ContactRollupsProcessed.extract_updated_at(test[:input])
       assert_equal test[:expected_output], output, "Test index #{index} failed"
     end
+  end
 
-    # Test invalid input
+  test 'extract_updated_at with invalid input' do
     assert_raise StandardError do
       ContactRollupsProcessed.extract_updated_at({'table' => {}})
     end

--- a/dashboard/test/models/contact_rollups_processed_test.rb
+++ b/dashboard/test/models/contact_rollups_processed_test.rb
@@ -61,16 +61,35 @@ class ContactRollupsProcessedTest < ActiveSupport::TestCase
   end
 
   test 'extract_field' do
-    table = 'dashboard.email_preferences'
-    field = 'opt_in'
+    table = 'pegasus.form_geos'
+    field = 'state'
 
     test_cases = [
-      {input: [{}, nil, nil], expected_output: nil},
-      {input: [{table => {}}, table, field], expected_output: nil},
-      {input: [{'dashboard.another_table' => {opt_in: 1}}, table, field], expected_output: nil},
-      {input: [{table => {'opt_in' => 0}}, table, field], expected_output: {opt_in: 0}},
-      {input: [{table => {'opt_in' => 1}}, table, field], expected_output: {opt_in: 1}},
-      {input: [{table => {'opt_in' => nil}}, table, field], expected_output: {opt_in: nil}}
+      # 3 input params are: contact_data, table, field
+      {
+        input: [{}, nil, nil],
+        expected_output: nil
+      },
+      {
+        input: [{table => {}}, table, field],
+        expected_output: nil
+      },
+      {
+        input: [{'pegasus.another_table' => {field => [{'value' => 'WA'}]}}, table, field],
+        expected_output: nil
+      },
+      {
+        input: [{table => {field => [{'value' => nil}]}}, table, field],
+        expected_output: [nil]
+      },
+      {
+        input: [{table => {field => [{'value' => 'WA'}]}}, table, field],
+        expected_output: ['WA']
+      },
+      {
+        input: [{table => {field => [{'value' => 'WA'}, {'value' => 'OR'}]}}, table, field],
+        expected_output: %w[WA OR]
+      },
     ]
 
     test_cases.each_with_index do |test, index|

--- a/dashboard/test/models/contact_rollups_processed_test.rb
+++ b/dashboard/test/models/contact_rollups_processed_test.rb
@@ -141,7 +141,7 @@ class ContactRollupsProcessedTest < ActiveSupport::TestCase
           '[{"%{sources_key}": "table1", "%{data_key}": {"state": null}, "%{data_updated_at_key}": "%{time_str}"}]',
           format_values
         ),
-        expected_output: {'table1' => {}}
+        expected_output: {'table1' => {'state' => ['value' => nil, 'data_updated_at' => time_parsed]}}
       },
       {
         input: format(

--- a/dashboard/test/models/contact_rollups_processed_test.rb
+++ b/dashboard/test/models/contact_rollups_processed_test.rb
@@ -54,8 +54,12 @@ class ContactRollupsProcessedTest < ActiveSupport::TestCase
     create :contact_rollups_raw
 
     # Each extraction function will be called once per unique email address
-    ContactRollupsProcessed.expects(:extract_field).once
-    ContactRollupsProcessed.expects(:extract_updated_at).once
+    ContactRollupsProcessed.expects(:extract_opt_in).
+      once.
+      returns({opt_in: 1})
+    ContactRollupsProcessed.expects(:extract_updated_at).
+      once.
+      returns({updated_at: Time.now.utc})
 
     ContactRollupsProcessed.import_from_raw_table
   end


### PR DESCRIPTION
Updating methods to process contact `opt_in` and `updated_at` attributes after we removed the unique email-sources constraint from ContactRollupsRaw in https://github.com/code-dot-org/code-dot-org/pull/35285 and added 12 more raw data extraction methods in https://github.com/code-dot-org/code-dot-org/pull/35347.

## Testing story
- Ran local unit test
- Running full pipeline on an adhoc machine with production-cloned db (_to be updated_)