### PR TITLE
CRv2: Process user_id

### DIFF
--- a/dashboard/app/models/contact_rollups_processed.rb
+++ b/dashboard/app/models/contact_rollups_processed.rb
@@ -46,6 +46,7 @@ class ContactRollupsProcessed < ApplicationRecord
 
       processed_contact_data = {}
       processed_contact_data.merge!(extract_opt_in(contact_data))
+      processed_contact_data.merge!(extract_user_id(contact_data))
       processed_contact_data.merge!(extract_updated_at(contact_data))
       batch << {email: contact['email'], data: processed_contact_data}
       next if batch.size < batch_size
@@ -146,6 +147,13 @@ class ContactRollupsProcessed < ApplicationRecord
     # Since there should be no more than one opt_in value per contact,
     # we can just take the first value in the returned array.
     return values.nil? ? {} : {opt_in: values.first}
+  end
+
+  def self.extract_user_id(contact_data)
+    values = extract_field(contact_data, 'dashboard.users', 'user_id')
+    # Since there should be no more than one user_id per contact,
+    # we can just take the first value in the returned array.
+    return values.nil? ? {} : {user_id: values.first}
   end
 
   # Extracts values of a field in a source table from contact data.

--- a/lib/cdo/contact_rollups/v2/pardot.rb
+++ b/lib/cdo/contact_rollups/v2/pardot.rb
@@ -299,6 +299,8 @@ class PardotV2
       prospect[:db_Opt_In] = contact[:opt_in] == 1 ? 'Yes' : 'No'
     end
 
+    prospect[:db_Has_Teacher_Account] = 'true' if contact[:user_id]
+
     prospect
   end
 

--- a/lib/test/cdo/contact_rollups/test_pardot_v2.rb
+++ b/lib/test/cdo/contact_rollups/test_pardot_v2.rb
@@ -191,17 +191,20 @@ class PardotV2Test < Minitest::Test
   end
 
   def test_convert_to_pardot_prospect
-    contacts = [
-      {email: 'test0@domain.com', pardot_id: 10, opt_in: 1},
-      {email: 'test1@domain.com', pardot_id: nil, bad_key: true}
-    ]
-    expected_prospects = [
-      {email: 'test0@domain.com', id: 10, db_Opt_In: 'Yes'},
-      {email: 'test1@domain.com', id: nil}
+    tests = [
+      {
+        input: {email: 'test0@domain.com', pardot_id: 10, opt_in: 1, user_id: 111},
+        expected_output: {email: 'test0@domain.com', id: 10, db_Opt_In: 'Yes', db_Has_Teacher_Account: 'true'}
+      },
+      {
+        input: {email: 'test1@domain.com', pardot_id: nil, bad_key: true},
+        expected_output: {email: 'test1@domain.com', id: nil}
+      }
     ]
 
-    contacts.each_with_index do |contact, index|
-      assert_equal expected_prospects[index], PardotV2.convert_to_pardot_prospect(contact)
+    tests.each_with_index do |test, index|
+      output = PardotV2.convert_to_pardot_prospect test[:input]
+      assert_equal test[:expected_output], output, "Test index #{index} failed"
     end
   end
 


### PR DESCRIPTION
[PLC-918](https://codedotorg.atlassian.net/browse/PLC-918): Use contact's `user_id` value to set prospect's `db_Has_Teacher_Account`. `db_Has_Teacher_Account` is true if `user_id` exists.

## Links
[Speadsheet of all attributes to process](https://docs.google.com/spreadsheets/d/10oKPBVlC5LZee9WiECwd745sX-4EXFALuSIVVwdW5tc/edit#gid=0).
