### PR TITLE
Revert "Darker workspace background in blockly labs when code is running"

### DIFF
--- a/apps/src/StudioApp.js
+++ b/apps/src/StudioApp.js
@@ -72,7 +72,6 @@ import {addCallouts} from '@cdo/apps/code-studio/callouts';
 import {RESIZE_VISUALIZATION_EVENT} from './lib/ui/VisualizationResizeBar';
 import {userAlreadyReportedAbuse} from '@cdo/apps/reportAbuse';
 import {setArrowButtonDisabled} from '@cdo/apps/templates/arrowDisplayRedux';
-import {workspace_running_background, white} from '@cdo/apps/util/color';
 
 var copyrightStrings;
 
@@ -955,20 +954,6 @@ StudioApp.prototype.toggleRunReset = function(button) {
     run.disabled = !showRun;
     reset.style.display = !showRun ? 'inline-block' : 'none';
     reset.disabled = showRun;
-  }
-  if (this.isUsingBlockly() && !this.config.readonlyWorkspace) {
-    // craft has a darker color scheme than other blockly labs. It needs to
-    // toggle between different colors on run/reset or else, on run, the workspace
-    // would get lighter than the default.
-    if (showRun && this.config.app === 'craft') {
-      $('.blocklySvg').css('background-color', '#A1A1A1');
-    } else if (showRun) {
-      $('.blocklySvg').css('background-color', white);
-    } else if (this.config.app === 'craft') {
-      $('.blocklySvg').css('background-color', '#7D7D7D');
-    } else {
-      $('.blocklySvg').css('background-color', workspace_running_background);
-    }
   }
 
   // Toggle soft-buttons (all have the 'arrow' class set):

--- a/shared/css/color.scss
+++ b/shared/css/color.scss
@@ -89,6 +89,7 @@ $level_current: $orange;
 $level_review_rejected: $red;
 $level_review_accepted: rgb(11, 142, 11); // TODO: $level_passed;
 $assessment: $cyan;
+$workspace_running_background: #e5e5e5;
 
 // Links (used in apps).
 $link_color: #0596CE;

--- a/shared/css/color.scss
+++ b/shared/css/color.scss
@@ -89,7 +89,6 @@ $level_current: $orange;
 $level_review_rejected: $red;
 $level_review_accepted: rgb(11, 142, 11); // TODO: $level_passed;
 $assessment: $cyan;
-$workspace_running_background: #e5e5e5;
 
 // Links (used in apps).
 $link_color: #0596CE;


### PR DESCRIPTION
Reverts code-dot-org/code-dot-org#35256