### PR TITLE
New auto email: facilitator post-workshop survey

### DIFF
--- a/dashboard/app/mailers/pd/workshop_mailer.rb
+++ b/dashboard/app/mailers/pd/workshop_mailer.rb
@@ -142,6 +142,22 @@ class Pd::WorkshopMailer < ActionMailer::Base
          reply_to: email_address(@user.name, @user.email)
   end
 
+  def facilitator_post_workshop(user, workshop)
+    @user = user
+    @workshop = workshop
+    @cancel_url = '#'
+    @is_reminder = true
+    @survey_url = 'https://form.jotform.com/201595646393161'
+    @regional_partner_name = @workshop.regional_partner&.name
+    @deadline = (Time.now + 10.days).strftime('%b %d %Y').strip
+
+    mail content_type: 'text/html',
+         from: from_facilitators,
+         subject: 'How did your workshop go?',
+         to: email_address(@user.name, @user.email),
+         reply_to: from_facilitators
+  end
+
   def organizer_enrollment_reminder(workshop)
     @workshop = workshop
     @cancel_url = '#'

--- a/dashboard/app/mailers/pd/workshop_mailer.rb
+++ b/dashboard/app/mailers/pd/workshop_mailer.rb
@@ -145,8 +145,6 @@ class Pd::WorkshopMailer < ActionMailer::Base
   def facilitator_post_workshop(user, workshop)
     @user = user
     @workshop = workshop
-    @cancel_url = '#'
-    @is_reminder = true
     @survey_url = CDO.studio_url "/pd/misc_survey/facilitator_post", CDO.default_scheme
     @regional_partner_name = @workshop.regional_partner&.name
     @deadline = (Time.now + 10.days).strftime('%B %-d, %Y').strip

--- a/dashboard/app/mailers/pd/workshop_mailer.rb
+++ b/dashboard/app/mailers/pd/workshop_mailer.rb
@@ -149,7 +149,10 @@ class Pd::WorkshopMailer < ActionMailer::Base
     @is_reminder = true
     @survey_url = CDO.studio_url "/pd/misc_survey/facilitator_post", CDO.default_scheme
     @regional_partner_name = @workshop.regional_partner&.name
-    @deadline = (Time.now + 10.days).strftime('%b %d %Y').strip
+    @deadline = (Time.now + 10.days).strftime('%B %-d, %Y').strip
+    @workshop_date = @workshop.sessions.size == 1 ?
+                       @workshop.sessions.first.start.strftime('%B %-d, %Y').strip :
+                       @workshop.friendly_date_range
 
     mail content_type: 'text/html',
          from: from_facilitators,

--- a/dashboard/app/mailers/pd/workshop_mailer.rb
+++ b/dashboard/app/mailers/pd/workshop_mailer.rb
@@ -147,7 +147,7 @@ class Pd::WorkshopMailer < ActionMailer::Base
     @workshop = workshop
     @cancel_url = '#'
     @is_reminder = true
-    @survey_url = 'https://form.jotform.com/201595646393161'
+    @survey_url = CDO.studio_url "/pd/misc_survey/facilitator_post", CDO.default_scheme
     @regional_partner_name = @workshop.regional_partner&.name
     @deadline = (Time.now + 10.days).strftime('%b %d %Y').strip
 

--- a/dashboard/app/models/pd/misc_survey.rb
+++ b/dashboard/app/models/pd/misc_survey.rb
@@ -37,9 +37,9 @@ module Pd
         {tag: "virt_k12_f_2019",    form_id: "92175282703154", allow_embed: false}, # 2019 Virtual K-12 Facilitator Survey
         {tag: "virt_ay_post_1920",  form_id: "92174983603160", allow_embed: false}, # 2019-20 Virtual Academic Year Post-Survey
         {tag: "virt_ay_m1_1920",    form_id: "92175136628158", allow_embed: false}, # 2019-20 Virtual Academic Year Survey Module 1
-        {tag: "612_f_ay_post",  form_id: "91564407894165", allow_multiple_submissions: true, allow_embed: false}, # 6-12 Facilitator Academic Year post-workshop survey
+        {tag: "612_f_ay_post",      form_id: "91564407894165", allow_multiple_submissions: true, allow_embed: false}, # 6-12 Facilitator Academic Year post-workshop survey
         {tag: "summer_prep_post",   form_id: "201285758257160", allow_embed: true}, # Summer Prep Sessions Post Survey
-        {tag: "facilitator_post", form_id: "201595646393161", allow_embed: true}
+        {tag: "facilitator_post",   form_id: "201595646393161", allow_embed: true}
       ]
     end
 

--- a/dashboard/app/models/pd/misc_survey.rb
+++ b/dashboard/app/models/pd/misc_survey.rb
@@ -38,7 +38,8 @@ module Pd
         {tag: "virt_ay_post_1920",  form_id: "92174983603160", allow_embed: false}, # 2019-20 Virtual Academic Year Post-Survey
         {tag: "virt_ay_m1_1920",    form_id: "92175136628158", allow_embed: false}, # 2019-20 Virtual Academic Year Survey Module 1
         {tag: "612_f_ay_post",  form_id: "91564407894165", allow_multiple_submissions: true, allow_embed: false}, # 6-12 Facilitator Academic Year post-workshop survey
-        {tag: "summer_prep_post",   form_id: "201285758257160", allow_embed: true} # Summer Prep Sessions Post Survey
+        {tag: "summer_prep_post",   form_id: "201285758257160", allow_embed: true}, # Summer Prep Sessions Post Survey
+        {tag: "facilitator_post", form_id: "201595646393161", allow_embed: true}
       ]
     end
 

--- a/dashboard/app/models/pd/workshop.rb
+++ b/dashboard/app/models/pd/workshop.rb
@@ -396,10 +396,10 @@ class Pd::Workshop < ActiveRecord::Base
   # for details.
   def self.process_ends
     end_on_or_after(Time.now - 2.days).each do |workshop|
-      if !workshop.processed_at || workshop.processed_at < workshop.ended_at
-        workshop.send_exit_surveys
-        workshop.update!(processed_at: Time.zone.now)
-      end
+      next unless !workshop.processed_at || workshop.processed_at < workshop.ended_at
+      workshop.send_exit_surveys
+      workshop.send_facilitator_post_surveys
+      workshop.update!(processed_at: Time.zone.now)
     end
   end
 
@@ -542,6 +542,17 @@ class Pd::Workshop < ActiveRecord::Base
       end
 
       enrollment.send_exit_survey
+    end
+  end
+
+  # Send Post-surveys to facilitators of CSD and CSP workshops
+  def send_facilitator_post_surveys
+    if course == COURSE_CSD || course == COURSE_CSP
+      facilitators.each do |facilitator|
+        next unless facilitator.email
+
+        Pd::WorkshopMailer.facilitator_post_workshop(facilitator, self).deliver_now
+      end
     end
   end
 

--- a/dashboard/app/models/pd/workshop.rb
+++ b/dashboard/app/models/pd/workshop.rb
@@ -396,6 +396,8 @@ class Pd::Workshop < ActiveRecord::Base
   # for details.
   def self.process_ends
     end_on_or_after(Time.now - 2.days).each do |workshop|
+      # only process if the workshop has not already been processed or if workshop was
+      # processed before the workshop ended.
       next unless !workshop.processed_at || workshop.processed_at < workshop.ended_at
       workshop.send_exit_surveys
       workshop.send_facilitator_post_surveys

--- a/dashboard/app/views/pd/workshop_mailer/facilitator_post_workshop.html.haml
+++ b/dashboard/app/views/pd/workshop_mailer/facilitator_post_workshop.html.haml
@@ -15,7 +15,7 @@
   - if @regional_partner_name
     = 'with ' + @regional_partner_name
   on
-  = @workshop.sessions.first.start_date_us_format + '!'
+  = @workshop_date + '!'
   When you have a moment, please take 5 minutes to complete
   = link_to('this survey', @survey_url)
   so that our team can better understand how your workshop went and how you feel you're developing as a facilitator.

--- a/dashboard/app/views/pd/workshop_mailer/facilitator_post_workshop.html.haml
+++ b/dashboard/app/views/pd/workshop_mailer/facilitator_post_workshop.html.haml
@@ -35,7 +35,7 @@ As a reminder, there are a number of ways for you to get support between worksho
     = mail_to('facilitators@code.org')
   %li
     Schedule a 1:1 with Andrea via this
-    = link_to('scheduling tool', 'https://calendly.com/andrea-fac-supp/30min?month=2019-06')
+    = link_to('scheduling tool', 'https://calendly.com/andrea-fac-supp/30min')
 
 %p
   Lastly, if your workshop travel qualifies for reimbursement under the

--- a/dashboard/app/views/pd/workshop_mailer/facilitator_post_workshop.html.haml
+++ b/dashboard/app/views/pd/workshop_mailer/facilitator_post_workshop.html.haml
@@ -1,0 +1,52 @@
+:css
+  body {
+    font-family: Gotham, sans-serif;
+  }
+
+%p
+  Hi
+  = @user.name + ','
+
+%p
+  Thank you for facilitating a
+  = @workshop.subject
+  = @workshop.course_name
+  workshop
+  - if @regional_partner_name
+    = 'with ' + @regional_partner_name
+  on
+  = @workshop.sessions.first.start_date_us_format + '!'
+  When you have a moment, please take 5 minutes to complete
+  = link_to('this survey', @survey_url)
+  so that our team can better understand how your workshop went and how you feel you're developing as a facilitator.
+  We ask that you please submit this by
+  = @deadline + '.'
+
+%p
+As a reminder, there are a number of ways for you to get support between workshops. You can:
+%ul
+  %li Contact your Regional Partner directly
+  %li
+    Engage with other facilitators in the
+    = link_to('Facilitator Forum', 'https://forum.code.org/c/facilitators') + ' and'
+    = link_to('Facilitator Slack channel', 'https://codefacilitators6-12.slack.com/messages')
+  %li
+    Email
+    = mail_to('facilitators@code.org')
+  %li
+    Schedule a 1:1 with Andrea via this
+    = link_to('scheduling tool', 'https://calendly.com/andrea-fac-supp/30min?month=2019-06')
+
+%p
+  Lastly, if your workshop travel qualifies for reimbursement under the
+  = link_to('Facilitator Travel Policy', 'https://docs.google.com/document/d/1ichRN3P8XU71Ksr6VjejS6uYDK9yL3SMqEQjchm7xSo') + ','
+  please remember to submit an expense report via Certify within 30 days of your workshop.
+
+%p
+Best,
+%br
+Andrea Robertson-Nottingham
+%br
+Education Programs
+%br
+Code.org

--- a/dashboard/test/mailers/previews/pd_workshop_mailer_preview.rb
+++ b/dashboard/test/mailers/previews/pd_workshop_mailer_preview.rb
@@ -198,18 +198,27 @@ class Pd::WorkshopMailerPreview < ActionMailer::Preview
     mail :facilitator_enrollment_reminder, target: :facilitator
   end
 
-  def facilitator_post_workshop
+  def facilitator_post_workshop_csp_summer
     regional_partner = build :regional_partner, name: 'We Teach Code'
 
     mail :facilitator_post_workshop,
+      Pd::Workshop::COURSE_CSP,
+      Pd::Workshop::SUBJECT_CSP_SUMMER_WORKSHOP,
       target: :facilitator,
       workshop_params: {
-        regional_partner: regional_partner
+        regional_partner: regional_partner,
+        num_sessions: 5
       }
   end
 
-  def facilitator_post_workshop_no_rp
-    mail :facilitator_post_workshop, target: :facilitator
+  def facilitator_post_workshop_no_rp_csd_workshop_1
+    mail :facilitator_post_workshop,
+      Pd::Workshop::COURSE_CSD,
+      Pd::Workshop::SUBJECT_CSD_WORKSHOP_1,
+      target: :facilitator,
+      workshop_params: {
+        num_sessions: 1
+      }
   end
 
   # The teacher_cancel_receipt has a variation for CSF. It's the same for all other courses.

--- a/dashboard/test/mailers/previews/pd_workshop_mailer_preview.rb
+++ b/dashboard/test/mailers/previews/pd_workshop_mailer_preview.rb
@@ -198,6 +198,20 @@ class Pd::WorkshopMailerPreview < ActionMailer::Preview
     mail :facilitator_enrollment_reminder, target: :facilitator
   end
 
+  def facilitator_post_workshop
+    regional_partner = build :regional_partner, name: 'We Teach Code'
+
+    mail :facilitator_post_workshop,
+      target: :facilitator,
+      workshop_params: {
+        regional_partner: regional_partner
+      }
+  end
+
+  def facilitator_post_workshop_no_rp
+    mail :facilitator_post_workshop, target: :facilitator
+  end
+
   # The teacher_cancel_receipt has a variation for CSF. It's the same for all other courses.
   def teacher_cancel_receipt__general
     mail :teacher_cancel_receipt

--- a/dashboard/test/models/pd/workshop_test.rb
+++ b/dashboard/test/models/pd/workshop_test.rb
@@ -298,6 +298,7 @@ class Pd::WorkshopTest < ActiveSupport::TestCase
     workshop.start!
 
     Pd::Workshop.any_instance.expects(:send_exit_surveys)
+    Pd::Workshop.any_instance.expects(:send_facilitator_post_surveys)
 
     workshop.end!
 


### PR DESCRIPTION
[PLC-901](https://codedotorg.atlassian.net/browse/PLC-901)
Add a new auto-email sent to CSD and CSP facilitators upon workshop close. The email will look like this, based on the [spec](https://docs.google.com/document/d/1mwpqMaNFqi2sjzruN5FHdFIZZEjXBgDDTV6lZY1s8j8/edit):
![Screen Shot 2020-06-22 at 9 35 01 AM](https://user-images.githubusercontent.com/33666587/85313790-678dc280-b46d-11ea-884e-8e2b48700040.png)


Note: if the workshop is closed twice the facilitator will get another email since we do not store information about the survey being sent in our database for facilitators.
<!-- ### Background -->
<!-- ### Privacy -->
<!-- ### Security -->
<!-- ### Caching -->
<!-- ### Deployment strategy -->
<!-- ### Future work -->

## Links

- [spec](https://docs.google.com/document/d/1mwpqMaNFqi2sjzruN5FHdFIZZEjXBgDDTV6lZY1s8j8/edit)
- [jira](https://codedotorg.atlassian.net/browse/PLC-901)

## Testing story
Added new mailer previews to validate the email content. Tested the new exit survey method by running locally and looking at the output manually. Also updated a unit test to ensure the new exit survey method is called.

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
