### PR TITLE
Darker background in blockly on run with update for modal editors

### DIFF
--- a/apps/src/StudioApp.js
+++ b/apps/src/StudioApp.js
@@ -72,7 +72,7 @@ import {addCallouts} from '@cdo/apps/code-studio/callouts';
 import {RESIZE_VISUALIZATION_EVENT} from './lib/ui/VisualizationResizeBar';
 import {userAlreadyReportedAbuse} from '@cdo/apps/reportAbuse';
 import {setArrowButtonDisabled} from '@cdo/apps/templates/arrowDisplayRedux';
-
+import {workspace_running_background, white} from '@cdo/apps/util/color';
 var copyrightStrings;
 
 /**
@@ -954,6 +954,23 @@ StudioApp.prototype.toggleRunReset = function(button) {
     run.disabled = !showRun;
     reset.style.display = !showRun ? 'inline-block' : 'none';
     reset.disabled = showRun;
+  }
+  if (this.isUsingBlockly() && !this.config.readonlyWorkspace) {
+    // craft has a darker color scheme than other blockly labs. It needs to
+    // toggle between different colors on run/reset or else, on run, the workspace
+    // would get lighter than the default.
+    if (showRun && this.config.app === 'craft') {
+      $('#codeWorkspace > .blocklySvg').css('background-color', '#A1A1A1');
+    } else if (showRun) {
+      $('#codeWorkspace > .blocklySvg').css('background-color', white);
+    } else if (this.config.app === 'craft') {
+      $('#codeWorkspace > .blocklySvg').css('background-color', '#7D7D7D');
+    } else {
+      $('#codeWorkspace > .blocklySvg').css(
+        'background-color',
+        workspace_running_background
+      );
+    }
   }
 
   // Toggle soft-buttons (all have the 'arrow' class set):


### PR DESCRIPTION
This makes the code workspace background darker in blockly labs when code is run. This was previously implemented in [this pr](https://github.com/code-dot-org/code-dot-org/pull/35256) but had an issue in sprite lab when the modal editor was open while the code was running and was reverted. This reimplements the darker background with a fix for that across all labs.

when the modal editor is opened, just the underlying workspace has a darker background color:
<img width="1438" alt="Screen Shot 2020-06-22 at 10 19 59 AM" src="https://user-images.githubusercontent.com/17147070/85317083-a96d3780-b472-11ea-8b1d-d05265f04bb1.png">

workspace background color is darker when code is running: 
<img width="1424" alt="Screen Shot 2020-06-22 at 10 20 10 AM" src="https://user-images.githubusercontent.com/17147070/85317143-c1dd5200-b472-11ea-9745-c15ee979b5c7.png">




## Links

- [spec](https://docs.google.com/document/d/1oCqZcRYf_RuIIY7q-CccOvHLjyykVKF2ktsjotgOD7I/edit#heading=h.w49xghegksz8)
- [jira](https://codedotorg.atlassian.net/browse/STAR-1097)
- [previous PR](https://github.com/code-dot-org/code-dot-org/pull/35256)
- [slack conversation that discovered the sprite lab bug](https://codedotorg.slack.com/archives/C1B3PNDL7/p1592842774156900)

## Testing story

<!--
  Does your change include appropriate tests?

  If so, please describe how the tests included in this PR are sufficient

  If not, please explain why this change does not need to be tested.
-->

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
