### PR TITLE
Resolve CVE-2015-9284

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -172,6 +172,10 @@ gem 'omniauth-microsoft_v2_auth', github: 'dooly-ai/omniauth-microsoft_v2_auth'
 # Ref: https://github.com/joel/omniauth-windowslive/pull/17
 gem 'omniauth-windowslive', '~> 0.0.11', github: 'wjordan/omniauth-windowslive', ref: 'cdo'
 
+# Resolve CVE 2015 9284
+# see: https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2015-9284
+gem 'omniauth-rails_csrf_protection', '~> 0.1'
+
 gem 'bootstrap-sass', '~> 2.3.2.2'
 
 # Ref: https://github.com/haml/haml/issues/940

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -597,6 +597,9 @@ GEM
     omniauth-openid (1.0.1)
       omniauth (~> 1.0)
       rack-openid (~> 1.3.1)
+    omniauth-rails_csrf_protection (0.1.2)
+      actionpack (>= 4.2)
+      omniauth (>= 1.3.1)
     open_uri_redirections (0.2.1)
     openid_connect (1.0.3)
       activemodel
@@ -986,6 +989,7 @@ DEPENDENCIES
   omniauth-microsoft_v2_auth!
   omniauth-openid
   omniauth-openid-connect!
+  omniauth-rails_csrf_protection (~> 0.1)
   omniauth-windowslive (~> 0.0.11)!
   open_uri_redirections
   os

--- a/apps/src/lib/ui/accounts/BootstrapButton.jsx
+++ b/apps/src/lib/ui/accounts/BootstrapButton.jsx
@@ -15,13 +15,14 @@ const styles = {
 };
 
 const BUTTON_TYPE = {
-  DANGER: 'danger'
+  DANGER: 'danger',
+  SUBMIT: 'submit'
 };
 
 export default class BootstrapButton extends React.Component {
   static propTypes = {
     style: PropTypes.object,
-    onClick: PropTypes.func.isRequired,
+    onClick: PropTypes.func,
     disabled: PropTypes.bool,
     text: PropTypes.string.isRequired,
     type: PropTypes.oneOf(Object.values(BUTTON_TYPE))
@@ -36,12 +37,27 @@ export default class BootstrapButton extends React.Component {
     }
   };
 
+  buttonType = () => {
+    switch (this.props.type) {
+      case BUTTON_TYPE.SUBMIT:
+        return 'submit';
+      default:
+        return 'button';
+    }
+  };
+
   render() {
     const {style, onClick, disabled, text} = this.props;
 
     return (
+      // for some reason, the 'button has type' rule isn't able to recognize
+      // that we are actually passing a valid button type here. Valid types
+      // include "button", "submit", or "reset", and we are currently always
+      // returning either "button" or "submit".
+      // see https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/button-has-type.md
+      // eslint-disable-next-line react/button-has-type
       <button
-        type="button"
+        type={this.buttonType()}
         className={this.buttonClasses()}
         style={{...styles.button, ...style}}
         onClick={onClick}

--- a/apps/src/lib/ui/accounts/ManageLinkedAccounts.jsx
+++ b/apps/src/lib/ui/accounts/ManageLinkedAccounts.jsx
@@ -7,7 +7,6 @@ import color from '@cdo/apps/util/color';
 import {tableLayoutStyles} from '@cdo/apps/templates/tables/tableConstants';
 import BootstrapButton from './BootstrapButton';
 import {connect} from 'react-redux';
-import {disconnect} from './manageLinkedAccountsRedux';
 
 const OAUTH_PROVIDERS = {
   GOOGLE: 'google_oauth2',
@@ -39,8 +38,7 @@ class ManageLinkedAccounts extends React.Component {
     authenticityToken: PropTypes.string.isRequired,
     userHasPassword: PropTypes.bool.isRequired,
     isGoogleClassroomStudent: PropTypes.bool.isRequired,
-    isCleverStudent: PropTypes.bool.isRequired,
-    disconnect: PropTypes.func.isRequired
+    isCleverStudent: PropTypes.bool.isRequired
   };
 
   cannotDisconnectGoogle = authOption => {
@@ -178,21 +176,13 @@ class ManageLinkedAccounts extends React.Component {
 
 export const UnconnectedManageLinkedAccounts = ManageLinkedAccounts;
 
-export default connect(
-  state => ({
-    authenticationOptions: state.manageLinkedAccounts.authenticationOptions,
-    authenticityToken: state.manageLinkedAccounts.authenticityToken,
-    userHasPassword: state.manageLinkedAccounts.userHasPassword,
-    isGoogleClassroomStudent:
-      state.manageLinkedAccounts.isGoogleClassroomStudent,
-    isCleverStudent: state.manageLinkedAccounts.isCleverStudent
-  }),
-  dispatch => ({
-    disconnect(id) {
-      dispatch(disconnect(id));
-    }
-  })
-)(ManageLinkedAccounts);
+export default connect(state => ({
+  authenticationOptions: state.manageLinkedAccounts.authenticationOptions,
+  authenticityToken: state.manageLinkedAccounts.authenticityToken,
+  userHasPassword: state.manageLinkedAccounts.userHasPassword,
+  isGoogleClassroomStudent: state.manageLinkedAccounts.isGoogleClassroomStudent,
+  isCleverStudent: state.manageLinkedAccounts.isCleverStudent
+}))(ManageLinkedAccounts);
 
 class OauthConnection extends React.Component {
   static propTypes = {

--- a/apps/src/lib/ui/accounts/ManageLinkedAccounts.jsx
+++ b/apps/src/lib/ui/accounts/ManageLinkedAccounts.jsx
@@ -3,7 +3,6 @@ import React from 'react';
 import ReactTooltip from 'react-tooltip';
 import _ from 'lodash';
 import i18n from '@cdo/locale';
-import {navigateToHref} from '@cdo/apps/utils';
 import color from '@cdo/apps/util/color';
 import {tableLayoutStyles} from '@cdo/apps/templates/tables/tableConstants';
 import BootstrapButton from './BootstrapButton';
@@ -37,22 +36,11 @@ class ManageLinkedAccounts extends React.Component {
   static propTypes = {
     // Provided by redux
     authenticationOptions: PropTypes.objectOf(authOptionPropType),
+    authenticityToken: PropTypes.string.isRequired,
     userHasPassword: PropTypes.bool.isRequired,
     isGoogleClassroomStudent: PropTypes.bool.isRequired,
     isCleverStudent: PropTypes.bool.isRequired,
     disconnect: PropTypes.func.isRequired
-  };
-
-  connect = provider => {
-    navigateToHref(`/users/auth/${provider}/connect`);
-  };
-
-  toggleProvider = (id, provider) => {
-    if (id) {
-      this.props.disconnect(id);
-    } else {
-      this.connect(provider);
-    }
   };
 
   cannotDisconnectGoogle = authOption => {
@@ -169,11 +157,11 @@ class ManageLinkedAccounts extends React.Component {
               return (
                 <OauthConnection
                   key={option.id || _.uniqueId('empty_')}
+                  authenticityToken={this.props.authenticityToken}
                   displayName={this.getDisplayName(option.credentialType)}
+                  id={option.id}
                   email={this.formatEmail(option)}
-                  onClick={() =>
-                    this.toggleProvider(option.id, option.credentialType)
-                  }
+                  credentialType={option.credentialType}
                   disconnectDisabledStatus={
                     option.id ? this.disconnectDisabledStatus(option) : null
                   }
@@ -193,6 +181,7 @@ export const UnconnectedManageLinkedAccounts = ManageLinkedAccounts;
 export default connect(
   state => ({
     authenticationOptions: state.manageLinkedAccounts.authenticationOptions,
+    authenticityToken: state.manageLinkedAccounts.authenticityToken,
     userHasPassword: state.manageLinkedAccounts.userHasPassword,
     isGoogleClassroomStudent:
       state.manageLinkedAccounts.isGoogleClassroomStudent,
@@ -208,8 +197,10 @@ export default connect(
 class OauthConnection extends React.Component {
   static propTypes = {
     displayName: PropTypes.string.isRequired,
+    id: PropTypes.number,
+    credentialType: PropTypes.string.isRequired,
+    authenticityToken: PropTypes.string.isRequired,
     email: PropTypes.string,
-    onClick: PropTypes.func.isRequired,
     disconnectDisabledStatus: PropTypes.string,
     error: PropTypes.string
   };
@@ -227,19 +218,29 @@ class OauthConnection extends React.Component {
 
   render() {
     const {
-      displayName,
-      email,
-      onClick,
+      authenticityToken,
+      credentialType,
       disconnectDisabledStatus,
+      displayName,
+      id,
+      email,
       error
     } = this.props;
-    const emailStyles = !!email
+    // if given an email, we are already connected to this provider and should
+    // present the option to disconnect. Otherwise, we should present the
+    // option to connect.
+    const isConnected = !!email;
+    const emailStyles = isConnected
       ? styles.cell
       : {...styles.cell, ...styles.emptyEmailCell};
-    const buttonText = !!email
+    const buttonText = isConnected
       ? i18n.manageLinkedAccounts_disconnect()
       : i18n.manageLinkedAccounts_connect();
     const tooltipId = _.uniqueId();
+
+    const oauthConnectPath = isConnected
+      ? `/users/auth/${id}/disconnect`
+      : `/users/auth/${credentialType}?action=connect`;
 
     return (
       <tr>
@@ -248,14 +249,26 @@ class OauthConnection extends React.Component {
           {email || i18n.manageLinkedAccounts_notConnected()}
         </td>
         <td style={styles.cell}>
-          <span data-for={tooltipId} data-tip>
-            {/* This button intentionally uses BootstrapButton to match other account page buttons */}
-            <BootstrapButton
-              style={styles.button}
-              text={buttonText}
-              onClick={onClick}
-              disabled={!!disconnectDisabledStatus}
-            />
+          <div data-for={tooltipId} data-tip>
+            <form
+              style={styles.noMargin}
+              method="POST"
+              action={oauthConnectPath}
+            >
+              {/* This button intentionally uses BootstrapButton to match other
+                  account page buttons */}
+              <BootstrapButton
+                type="submit"
+                style={styles.button}
+                text={buttonText}
+                disabled={!!disconnectDisabledStatus}
+              />
+              <input
+                type="hidden"
+                name="authenticity_token"
+                value={authenticityToken}
+              />
+            </form>
             {disconnectDisabledStatus && (
               <ReactTooltip
                 id={tooltipId}
@@ -268,8 +281,8 @@ class OauthConnection extends React.Component {
                 </div>
               </ReactTooltip>
             )}
-          </span>
-          <span style={styles.error}>{error}</span>
+          </div>
+          {error && <span style={styles.error}>{error}</span>}
         </td>
       </tr>
     );
@@ -321,5 +334,8 @@ const styles = {
     paddingLeft: GUTTER / 2,
     color: color.red,
     fontStyle: 'italic'
+  },
+  noMargin: {
+    margin: 0
   }
 };

--- a/apps/src/lib/ui/accounts/ManageLinkedAccounts.jsx
+++ b/apps/src/lib/ui/accounts/ManageLinkedAccounts.jsx
@@ -238,7 +238,7 @@ class OauthConnection extends React.Component {
       : i18n.manageLinkedAccounts_connect();
     const tooltipId = _.uniqueId();
 
-    const oauthConnectPath = isConnected
+    const oauthToggleConnectionPath = isConnected
       ? `/users/auth/${id}/disconnect`
       : `/users/auth/${credentialType}?action=connect`;
 
@@ -253,7 +253,7 @@ class OauthConnection extends React.Component {
             <form
               style={styles.noMargin}
               method="POST"
-              action={oauthConnectPath}
+              action={oauthToggleConnectionPath}
             >
               {/* This button intentionally uses BootstrapButton to match other
                   account page buttons */}

--- a/apps/src/lib/ui/accounts/ManageLinkedAccounts.jsx
+++ b/apps/src/lib/ui/accounts/ManageLinkedAccounts.jsx
@@ -7,6 +7,7 @@ import color from '@cdo/apps/util/color';
 import {tableLayoutStyles} from '@cdo/apps/templates/tables/tableConstants';
 import BootstrapButton from './BootstrapButton';
 import {connect} from 'react-redux';
+import {disconnect} from './manageLinkedAccountsRedux';
 
 const OAUTH_PROVIDERS = {
   GOOGLE: 'google_oauth2',
@@ -38,7 +39,8 @@ class ManageLinkedAccounts extends React.Component {
     authenticityToken: PropTypes.string.isRequired,
     userHasPassword: PropTypes.bool.isRequired,
     isGoogleClassroomStudent: PropTypes.bool.isRequired,
-    isCleverStudent: PropTypes.bool.isRequired
+    isCleverStudent: PropTypes.bool.isRequired,
+    disconnect: PropTypes.func.isRequired
   };
 
   cannotDisconnectGoogle = authOption => {
@@ -176,13 +178,21 @@ class ManageLinkedAccounts extends React.Component {
 
 export const UnconnectedManageLinkedAccounts = ManageLinkedAccounts;
 
-export default connect(state => ({
-  authenticationOptions: state.manageLinkedAccounts.authenticationOptions,
-  authenticityToken: state.manageLinkedAccounts.authenticityToken,
-  userHasPassword: state.manageLinkedAccounts.userHasPassword,
-  isGoogleClassroomStudent: state.manageLinkedAccounts.isGoogleClassroomStudent,
-  isCleverStudent: state.manageLinkedAccounts.isCleverStudent
-}))(ManageLinkedAccounts);
+export default connect(
+  state => ({
+    authenticationOptions: state.manageLinkedAccounts.authenticationOptions,
+    authenticityToken: state.manageLinkedAccounts.authenticityToken,
+    userHasPassword: state.manageLinkedAccounts.userHasPassword,
+    isGoogleClassroomStudent:
+      state.manageLinkedAccounts.isGoogleClassroomStudent,
+    isCleverStudent: state.manageLinkedAccounts.isCleverStudent
+  }),
+  dispatch => ({
+    disconnect(id) {
+      dispatch(disconnect(id));
+    }
+  })
+)(ManageLinkedAccounts);
 
 class OauthConnection extends React.Component {
   static propTypes = {

--- a/apps/src/lib/ui/accounts/ManageLinkedAccounts.story.jsx
+++ b/apps/src/lib/ui/accounts/ManageLinkedAccounts.story.jsx
@@ -4,6 +4,7 @@ import {UnconnectedManageLinkedAccounts as ManageLinkedAccounts} from './ManageL
 
 const DEFAULT_PROPS = {
   userType: 'student',
+  authenticityToken: 'fake CSRF token',
   authenticationOptions: {},
   connect: action('connect'),
   disconnect: action('disconnect'),

--- a/apps/src/lib/ui/accounts/ManageLinkedAccountsController.js
+++ b/apps/src/lib/ui/accounts/ManageLinkedAccountsController.js
@@ -14,7 +14,8 @@ export default class ManageLinkedAccountsController {
     authenticationOptions,
     userHasPassword,
     isGoogleClassroomStudent,
-    isCleverStudent
+    isCleverStudent,
+    authenticityToken
   ) {
     registerReducers({manageLinkedAccounts});
     const store = getStore();
@@ -24,7 +25,8 @@ export default class ManageLinkedAccountsController {
         authenticationOptions,
         userHasPassword,
         isGoogleClassroomStudent,
-        isCleverStudent
+        isCleverStudent,
+        authenticityToken
       })
     );
 

--- a/apps/src/lib/ui/accounts/manageLinkedAccountsRedux.js
+++ b/apps/src/lib/ui/accounts/manageLinkedAccountsRedux.js
@@ -30,6 +30,7 @@ export default function manageLinkedAccounts(state = initialState, action) {
   if (action.type === INITIALIZE_STATE) {
     const {
       authenticationOptions,
+      authenticityToken,
       userHasPassword,
       isGoogleClassroomStudent,
       isCleverStudent
@@ -37,6 +38,7 @@ export default function manageLinkedAccounts(state = initialState, action) {
     return {
       ...state,
       authenticationOptions,
+      authenticityToken,
       userHasPassword,
       isGoogleClassroomStudent,
       isCleverStudent

--- a/apps/src/lib/ui/accounts/manageLinkedAccountsRedux.js
+++ b/apps/src/lib/ui/accounts/manageLinkedAccountsRedux.js
@@ -1,6 +1,3 @@
-import $ from 'jquery';
-import _ from 'lodash';
-
 /** Initial state for manageLinkedAccounts redux store.
  * authenticationOptions - object of authentication options for current user with id key and authentication option value
  * userHasPassword - whether or not the user has a code.org password
@@ -15,16 +12,8 @@ export const initialState = {
 };
 
 const INITIALIZE_STATE = 'manageLinkedAccounts/INITIALIZE_STATE';
-const REMOVE_AUTH_OPTION = 'manageLinkedAccounts/REMOVE_AUTH_OPTION';
-const SET_AUTH_OPTION_ERROR = 'manageLinkedAccounts/SET_AUTH_OPTION_ERROR';
 
 export const initializeState = state => ({type: INITIALIZE_STATE, state});
-export const removeAuthOption = id => ({type: REMOVE_AUTH_OPTION, id});
-export const setAuthOptionError = (id, error) => ({
-  type: SET_AUTH_OPTION_ERROR,
-  id,
-  error
-});
 
 export default function manageLinkedAccounts(state = initialState, action) {
   if (action.type === INITIALIZE_STATE) {
@@ -45,40 +34,8 @@ export default function manageLinkedAccounts(state = initialState, action) {
     };
   }
 
-  if (action.type === REMOVE_AUTH_OPTION) {
-    findAuthOption(state, action.id);
-    return {
-      ...state,
-      authenticationOptions: _.omit(state.authenticationOptions, action.id)
-    };
-  }
-
-  if (action.type === SET_AUTH_OPTION_ERROR) {
-    findAuthOption(state, action.id);
-    return {
-      ...state,
-      authenticationOptions: {
-        ...state.authenticationOptions,
-        [action.id]: {
-          ...state.authenticationOptions[action.id],
-          error: action.error
-        }
-      }
-    };
-  }
-
   return state;
 }
-
-// Returns authentication option by id
-// Throws an error if authentication option is not found
-const findAuthOption = (state, id) => {
-  const authOption = state.authenticationOptions[id];
-  if (!authOption) {
-    throw new Error(`Authentication option with id ${id} does not exist`);
-  }
-  return authOption;
-};
 
 export const convertServerAuthOptions = authOptions => {
   let optionLookup = {};
@@ -91,34 +48,4 @@ export const convertServerAuthOptions = authOptions => {
     };
   });
   return optionLookup;
-};
-
-export const disconnect = id => {
-  return (dispatch, _) => {
-    disconnectOnServer(id, error => {
-      if (error) {
-        dispatch(setAuthOptionError(id, error));
-      } else {
-        dispatch(removeAuthOption(id));
-      }
-    });
-  };
-};
-
-// Make a DELETE request to remove an authentication option by id
-export const disconnectOnServer = (id, onComplete) => {
-  $.ajax({
-    url: `/users/auth/${id}/disconnect`,
-    method: 'DELETE'
-  })
-    .done(_ => {
-      onComplete(null);
-    })
-    .fail((jqXhr, _) => {
-      if (jqXhr.responseText) {
-        onComplete(jqXhr.responseText);
-      } else {
-        onComplete(`Unexpected failure: ${jqXhr.status}`);
-      }
-    });
 };

--- a/apps/src/lib/ui/accounts/manageLinkedAccountsRedux.js
+++ b/apps/src/lib/ui/accounts/manageLinkedAccountsRedux.js
@@ -1,3 +1,6 @@
+import $ from 'jquery';
+import _ from 'lodash';
+
 /** Initial state for manageLinkedAccounts redux store.
  * authenticationOptions - object of authentication options for current user with id key and authentication option value
  * userHasPassword - whether or not the user has a code.org password
@@ -12,8 +15,16 @@ export const initialState = {
 };
 
 const INITIALIZE_STATE = 'manageLinkedAccounts/INITIALIZE_STATE';
+const REMOVE_AUTH_OPTION = 'manageLinkedAccounts/REMOVE_AUTH_OPTION';
+const SET_AUTH_OPTION_ERROR = 'manageLinkedAccounts/SET_AUTH_OPTION_ERROR';
 
 export const initializeState = state => ({type: INITIALIZE_STATE, state});
+export const removeAuthOption = id => ({type: REMOVE_AUTH_OPTION, id});
+export const setAuthOptionError = (id, error) => ({
+  type: SET_AUTH_OPTION_ERROR,
+  id,
+  error
+});
 
 export default function manageLinkedAccounts(state = initialState, action) {
   if (action.type === INITIALIZE_STATE) {
@@ -34,8 +45,40 @@ export default function manageLinkedAccounts(state = initialState, action) {
     };
   }
 
+  if (action.type === REMOVE_AUTH_OPTION) {
+    findAuthOption(state, action.id);
+    return {
+      ...state,
+      authenticationOptions: _.omit(state.authenticationOptions, action.id)
+    };
+  }
+
+  if (action.type === SET_AUTH_OPTION_ERROR) {
+    findAuthOption(state, action.id);
+    return {
+      ...state,
+      authenticationOptions: {
+        ...state.authenticationOptions,
+        [action.id]: {
+          ...state.authenticationOptions[action.id],
+          error: action.error
+        }
+      }
+    };
+  }
+
   return state;
 }
+
+// Returns authentication option by id
+// Throws an error if authentication option is not found
+const findAuthOption = (state, id) => {
+  const authOption = state.authenticationOptions[id];
+  if (!authOption) {
+    throw new Error(`Authentication option with id ${id} does not exist`);
+  }
+  return authOption;
+};
 
 export const convertServerAuthOptions = authOptions => {
   let optionLookup = {};
@@ -48,4 +91,34 @@ export const convertServerAuthOptions = authOptions => {
     };
   });
   return optionLookup;
+};
+
+export const disconnect = id => {
+  return (dispatch, _) => {
+    disconnectOnServer(id, error => {
+      if (error) {
+        dispatch(setAuthOptionError(id, error));
+      } else {
+        dispatch(removeAuthOption(id));
+      }
+    });
+  };
+};
+
+// Make a DELETE request to remove an authentication option by id
+export const disconnectOnServer = (id, onComplete) => {
+  $.ajax({
+    url: `/users/auth/${id}/disconnect`,
+    method: 'DELETE'
+  })
+    .done(_ => {
+      onComplete(null);
+    })
+    .fail((jqXhr, _) => {
+      if (jqXhr.responseText) {
+        onComplete(jqXhr.responseText);
+      } else {
+        onComplete(`Unexpected failure: ${jqXhr.status}`);
+      }
+    });
 };

--- a/apps/src/sites/studio/pages/devise/registrations/edit.js
+++ b/apps/src/sites/studio/pages/devise/registrations/edit.js
@@ -25,7 +25,8 @@ const {
   isCleverStudent,
   dependedUponForLogin,
   dependentStudents,
-  studentCount
+  studentCount,
+  authenticityToken
 } = scriptData;
 
 $(document).ready(() => {
@@ -86,7 +87,8 @@ $(document).ready(() => {
       authenticationOptions,
       isPasswordRequired,
       isGoogleClassroomStudent,
-      isCleverStudent
+      isCleverStudent,
+      authenticityToken
     );
   }
 

--- a/apps/test/unit/lib/ui/accounts/ManageLinkedAccountsTest.jsx
+++ b/apps/test/unit/lib/ui/accounts/ManageLinkedAccountsTest.jsx
@@ -1,15 +1,14 @@
 import React from 'react';
 import {mount} from 'enzyme';
-import sinon from 'sinon';
 import {expect} from '../../../../util/deprecatedChai';
 import {
   UnconnectedManageLinkedAccounts as ManageLinkedAccounts,
   ENCRYPTED
 } from '@cdo/apps/lib/ui/accounts/ManageLinkedAccounts';
-import * as utils from '@cdo/apps/utils';
 
 const DEFAULT_PROPS = {
   userType: 'student',
+  authenticityToken: 'fake CSRF token',
   authenticationOptions: {},
   disconnect: () => {},
   userHasPassword: true,
@@ -148,37 +147,38 @@ describe('ManageLinkedAccounts', () => {
     expect(googleEmailCell).to.include.text('Oh no!');
   });
 
-  it('navigates to provider endpoint if authentication option is not connected', () => {
-    sinon.stub(utils, 'navigateToHref');
+  it('posts form data to connect endpoint if authentication option is not connected', () => {
     const wrapper = mount(<ManageLinkedAccounts {...DEFAULT_PROPS} />);
-    wrapper
-      .find('BootstrapButton')
-      .at(0)
-      .simulate('click');
-    expect(utils.navigateToHref).to.have.been.calledOnce.and.calledWith(
-      '/users/auth/google_oauth2/connect'
+    const form = wrapper.find('form').at(0);
+    expect(form.prop('method')).to.equal('POST');
+    expect(form.prop('action')).to.equal(
+      '/users/auth/google_oauth2?action=connect'
     );
-    utils.navigateToHref.restore();
   });
 
-  it('calls disconnect if authentication option is connected', () => {
+  it('posts form data to disconnect endpoint if authentication option is connected', () => {
     const authOptions = {
       1: {id: 1, credentialType: 'google_oauth2', email: 'student@email.com'},
       2: {id: 2, credentialType: 'facebook', email: 'student@email.com'}
     };
-    const disconnect = sinon.stub();
     const wrapper = mount(
       <ManageLinkedAccounts
         {...DEFAULT_PROPS}
         authenticationOptions={authOptions}
-        disconnect={disconnect}
       />
     );
-    wrapper
-      .find('BootstrapButton')
-      .at(0)
-      .simulate('click');
-    expect(disconnect).to.have.been.calledOnce;
+
+    const forms = wrapper.find('form');
+    const expected = [
+      '/users/auth/1/disconnect',
+      '/users/auth/microsoft_v2_auth?action=connect',
+      '/users/auth/clever?action=connect',
+      '/users/auth/2/disconnect'
+    ];
+    forms.forEach((form, i) => {
+      expect(form.prop('method')).to.equal('POST');
+      expect(form.prop('action')).to.equal(expected[i]);
+    });
   });
 
   it('disables disconnecting from google if user is in a google classroom section', () => {

--- a/dashboard/app/controllers/authentication_options_controller.rb
+++ b/dashboard/app/controllers/authentication_options_controller.rb
@@ -1,13 +1,5 @@
 class AuthenticationOptionsController < ApplicationController
-  # GET /users/auth/:provider/connect
-  def connect
-    return head(:bad_request) unless current_user&.migrated? && AuthenticationOption::OAUTH_CREDENTIAL_TYPES.include?(params[:provider])
-
-    session[:connect_provider] = 2.minutes.from_now
-    redirect_to omniauth_authorize_path(current_user, params[:provider])
-  end
-
-  # DELETE /users/auth/:id/disconnect
+  # POST /users/auth/:id/disconnect
   def disconnect
     return head(:bad_request) unless current_user&.migrated?
     auth_option = current_user.authentication_options.find(params[:id])

--- a/dashboard/app/controllers/omniauth_callbacks_controller.rb
+++ b/dashboard/app/controllers/omniauth_callbacks_controller.rb
@@ -86,13 +86,13 @@ class OmniauthCallbacksController < Devise::OmniauthCallbacksController
   # Call GET /users/auth/:provider/connect and the callback will trigger this code path
   def connect_provider
     unless current_user&.migrated?
-      flash.alert = "cannot connect an unmigrated user"
+      flash.alert = I18n.t('auth.migration_required')
       return redirect_to edit_user_registration_path
     end
 
     provider = auth_hash.provider.to_s
     unless AuthenticationOption::OAUTH_CREDENTIAL_TYPES.include? provider
-      flash.alert = "provider #{provider.inspect} not one of the supported authentication option credential types"
+      flash.alert = I18n.t('auth.invalid_provider', provider: provider)
       return redirect_to edit_user_registration_path
     end
 

--- a/dashboard/app/controllers/omniauth_callbacks_controller.rb
+++ b/dashboard/app/controllers/omniauth_callbacks_controller.rb
@@ -85,10 +85,16 @@ class OmniauthCallbacksController < Devise::OmniauthCallbacksController
 
   # Call GET /users/auth/:provider/connect and the callback will trigger this code path
   def connect_provider
-    return head(:bad_request) unless can_connect_provider?
+    unless current_user&.migrated?
+      flash.alert = "cannot connect an unmigrated user"
+      return redirect_to edit_user_registration_path
+    end
 
     provider = auth_hash.provider.to_s
-    return head(:bad_request) unless AuthenticationOption::OAUTH_CREDENTIAL_TYPES.include? provider
+    unless AuthenticationOption::OAUTH_CREDENTIAL_TYPES.include? provider
+      flash.alert = "provider #{provider.inspect} not one of the supported authentication option credential types"
+      return redirect_to edit_user_registration_path
+    end
 
     existing_credential_holder = User.find_by_credential type: provider, id: auth_hash.uid
 
@@ -457,14 +463,7 @@ class OmniauthCallbacksController < Devise::OmniauthCallbacksController
   end
 
   def should_connect_provider?
-    return current_user && session[:connect_provider].present?
-  end
-
-  def can_connect_provider?
-    return false unless current_user&.migrated?
-
-    connect_flag_expiration = session.delete :connect_provider
-    connect_flag_expiration&.future?
+    return current_user && auth_params.fetch("action", nil) == "connect"
   end
 
   def get_connect_provider_errors(auth_option)

--- a/dashboard/app/views/devise/registrations/edit.html.haml
+++ b/dashboard/app/views/devise/registrations/edit.html.haml
@@ -227,6 +227,7 @@
       isCleverStudent: current_user.clever_student?,
       dependentStudents: current_user.dependent_students,
       studentCount: current_user.students.count,
+      authenticityToken: form_authenticity_token
     }.to_json
   }
 %script{src: webpack_asset_path('js/devise/registrations/edit.js'), data: script_data}

--- a/dashboard/config/locales/en.yml
+++ b/dashboard/config/locales/en.yml
@@ -131,7 +131,10 @@ en:
     need_unlock: "Didn't receive unlock instructions?"
     not_linked: "Sorry, your Code.org account is not linked to %{provider}. You'll have to sign in by typing your password below."
     use_clever: "Sorry, your Code.org account is not linked to %{provider}. Please sign in through your Clever Portal instead."
+    invalid_provider: "Sorry, but %{provider} accounts cannot be linked to Code.org accounts."
+    migration_required: "Sorry, we cannot connect or disconnect accounts that are still using the old account experience. Please update to the new account experience."
     unable_to_connect_provider: "Unable to connect your Code.org account to your %{provider} account. Please try again."
+    disconnect_successful: "Success! We have unlinked the external account from your Code.org account."
     already_in_use: "Your %{provider} account is already connected to another Code.org account."
     already_linked: "Your %{provider} account is already linked to your Code.org account."
     existing_account:

--- a/dashboard/config/locales/en.yml
+++ b/dashboard/config/locales/en.yml
@@ -131,10 +131,10 @@ en:
     need_unlock: "Didn't receive unlock instructions?"
     not_linked: "Sorry, your Code.org account is not linked to %{provider}. You'll have to sign in by typing your password below."
     use_clever: "Sorry, your Code.org account is not linked to %{provider}. Please sign in through your Clever Portal instead."
-    invalid_provider: "Sorry, but %{provider} accounts cannot be linked to Code.org accounts."
+    invalid_provider: "Sorry, %{provider} accounts cannot be linked to Code.org accounts."
     migration_required: "Sorry, we cannot connect or disconnect accounts that are still using the old account experience. Please update to the new account experience."
     unable_to_connect_provider: "Unable to connect your Code.org account to your %{provider} account. Please try again."
-    disconnect_successful: "Success! We have unlinked the external account from your Code.org account."
+    disconnect_successful: "Success! We have disconnected the external account from your Code.org account."
     already_in_use: "Your %{provider} account is already connected to another Code.org account."
     already_linked: "Your %{provider} account is already linked to your Code.org account."
     existing_account:

--- a/dashboard/config/routes.rb
+++ b/dashboard/config/routes.rb
@@ -146,8 +146,7 @@ Dashboard::Application.routes.draw do
     patch '/users/parent_email', to: 'registrations#set_parent_email'
     patch '/users/user_type', to: 'registrations#set_user_type'
     get '/users/cancel', to: 'registrations#cancel'
-    get '/users/auth/:provider/connect', to: 'authentication_options#connect', as: :connect_authentication_option
-    delete '/users/auth/:id/disconnect', to: 'authentication_options#disconnect'
+    post '/users/auth/:id/disconnect', to: 'authentication_options#disconnect'
     get '/users/migrate_to_multi_auth', to: 'registrations#migrate_to_multi_auth'
     get '/users/demigrate_from_multi_auth', to: 'registrations#demigrate_from_multi_auth'
     get '/users/to_destroy', to: 'registrations#users_to_destroy'

--- a/dashboard/test/controllers/authentication_options_controller_test.rb
+++ b/dashboard/test/controllers/authentication_options_controller_test.rb
@@ -1,76 +1,10 @@
 require 'test_helper'
 
 class AuthenticationOptionsControllerTest < ActionDispatch::IntegrationTest
-  test 'connect: returns bad_request if user not signed in' do
-    get '/users/auth/google_oauth2/connect'
-    assert_response :bad_request
-  end
-
-  test 'connect: returns bad_request if provider not supported' do
-    user = create :user
-    sign_in user
-    get '/users/auth/some_fake_provider/connect'
-    assert_response :bad_request
-  end
-
-  test 'connect: sets connect_provider on session and redirects to google authorization' do
-    user = create :user
-    sign_in user
-
-    Timecop.freeze do
-      get '/users/auth/google_oauth2/connect'
-      assert_equal 2.minutes.from_now, session[:connect_provider]
-      assert_redirected_to '/users/auth/google_oauth2'
-    end
-  end
-
-  test 'connect: sets connect_provider on session and redirects to facebook authorization' do
-    user = create :user
-    sign_in user
-
-    Timecop.freeze do
-      get '/users/auth/facebook/connect'
-      assert_equal 2.minutes.from_now, session[:connect_provider]
-      assert_redirected_to '/users/auth/facebook'
-    end
-  end
-
-  test 'connect: sets connect_provider on session and redirects to windowslive authorization' do
-    user = create :user
-    sign_in user
-
-    Timecop.freeze do
-      get '/users/auth/windowslive/connect'
-      assert_equal 2.minutes.from_now, session[:connect_provider]
-      assert_redirected_to '/users/auth/windowslive'
-    end
-  end
-
-  test 'connect: sets connect_provider on session and redirects to clever authorization' do
-    user = create :user
-    sign_in user
-
-    Timecop.freeze do
-      get '/users/auth/clever/connect'
-      assert_equal 2.minutes.from_now, session[:connect_provider]
-      assert_redirected_to '/users/auth/clever'
-    end
-  end
-
-  test 'connect: sets connect_provider on session and redirects to powerschool authorization' do
-    user = create :user
-    sign_in user
-
-    Timecop.freeze do
-      get '/users/auth/powerschool/connect'
-      assert_equal 2.minutes.from_now, session[:connect_provider]
-      assert_redirected_to '/users/auth/powerschool'
-    end
-  end
-
-  test 'disconnect: returns bad_request if user is not signed in' do
-    delete '/users/auth/1/disconnect'
-    assert_response :bad_request
+  test 'disconnect: redirects with an error message if user is not signed in' do
+    post '/users/auth/1/disconnect'
+    assert flash[:alert].include? 'Sorry'
+    assert_response :redirect
   end
 
   test 'disconnect: destroys the AuthenticationOption if it exists and is not primary' do
@@ -79,8 +13,9 @@ class AuthenticationOptionsControllerTest < ActionDispatch::IntegrationTest
     sign_in user
 
     assert_destroys(AuthenticationOption) do
-      delete "/users/auth/#{auth_option.id}/disconnect"
-      assert_response :success
+      post "/users/auth/#{auth_option.id}/disconnect"
+      assert flash[:notice].include? "Success!"
+      assert_response :redirect
       assert_raises ActiveRecord::RecordNotFound do
         AuthenticationOption.find(auth_option.id)
       end
@@ -102,8 +37,9 @@ class AuthenticationOptionsControllerTest < ActionDispatch::IntegrationTest
     assert_equal google_option, teacher.primary_contact_info
 
     sign_in teacher
-    delete "/users/auth/#{teacher.primary_contact_info_id}/disconnect"
-    assert_response :success
+    post "/users/auth/#{teacher.primary_contact_info_id}/disconnect"
+    assert flash[:notice].include? "Success!"
+    assert_response :redirect
 
     teacher.reload
     assert_equal 2, teacher.authentication_options.size
@@ -126,8 +62,9 @@ class AuthenticationOptionsControllerTest < ActionDispatch::IntegrationTest
     refute_empty teacher.encrypted_password
 
     sign_in teacher
-    delete "/users/auth/#{teacher.primary_contact_info_id}/disconnect"
-    assert_response :success
+    post "/users/auth/#{teacher.primary_contact_info_id}/disconnect"
+    assert flash[:notice].include? "Success!"
+    assert_response :redirect
 
     teacher.reload
     assert_equal 2, teacher.authentication_options.size
@@ -145,7 +82,7 @@ class AuthenticationOptionsControllerTest < ActionDispatch::IntegrationTest
     sign_in user
 
     assert_does_not_destroy(AuthenticationOption) do
-      delete "/users/auth/1/disconnect"
+      post "/users/auth/1/disconnect"
       assert_response :not_found
     end
   end
@@ -156,7 +93,7 @@ class AuthenticationOptionsControllerTest < ActionDispatch::IntegrationTest
     sign_in user
 
     assert_does_not_destroy(AuthenticationOption) do
-      delete "/users/auth/#{auth_option.id}/disconnect"
+      post "/users/auth/#{auth_option.id}/disconnect"
       assert_response :not_found
     end
   end

--- a/dashboard/test/controllers/omniauth_callbacks_controller_test.rb
+++ b/dashboard/test/controllers/omniauth_callbacks_controller_test.rb
@@ -1140,19 +1140,15 @@ class OmniauthCallbacksControllerTest < ActionController::TestCase
       }
     )
 
-    auth = generate_auth_user_hash(provider: 'facebook', uid: user.uid, refresh_token: '65432', email: email)
-    @request.env['omniauth.auth'] = auth
-
-    Timecop.freeze do
-      setup_should_connect_provider(user, 2.days.from_now)
-      assert_creates(AuthenticationOption) do
-        get :facebook
-      end
-
-      user.reload
-      assert_redirected_to 'http://test.host/users/edit'
-      assert_equal 3, user.authentication_options.length
+    auth_hash = generate_auth_user_hash(provider: 'facebook', uid: user.uid, refresh_token: '65432', email: email)
+    setup_should_connect_provider(user, auth_hash)
+    assert_creates(AuthenticationOption) do
+      get :facebook
     end
+
+    user.reload
+    assert_redirected_to 'http://test.host/users/edit'
+    assert_equal 3, user.authentication_options.length
   end
 
   test 'connect_provider: cannot connect multiple auth options with the same email to a different user' do
@@ -1175,148 +1171,114 @@ class OmniauthCallbacksControllerTest < ActionController::TestCase
 
     user_b = create :user
     auth = generate_auth_user_hash(provider: 'facebook', uid: 'some-other-uid', refresh_token: '65432', email: email)
-    @request.env['omniauth.auth'] = auth
-
-    Timecop.freeze do
-      setup_should_connect_provider(user_b, 2.days.from_now)
-      assert_does_not_create(AuthenticationOption) do
-        get :facebook
-      end
-
-      assert_redirected_to 'http://test.host/users/edit'
-      assert_equal 'Email has already been taken', flash.alert
+    setup_should_connect_provider(user_b, auth)
+    assert_does_not_create(AuthenticationOption) do
+      get :facebook
     end
+
+    assert_redirected_to 'http://test.host/users/edit'
+    assert_equal 'Email has already been taken', flash.alert
+
     user_a.reload
     user_b.reload
     assert_equal 2, user_a.authentication_options.length
     assert_equal 1, user_b.authentication_options.length
   end
 
-  test 'connect_provider: returns bad_request if user not migrated' do
-    user = create :user, :facebook_sso_provider
-    Timecop.freeze do
-      setup_should_connect_provider(user)
-      get :google_oauth2
-      assert_response :bad_request
+  test 'connect_provider: does not connect if user not migrated' do
+    user = create :user, :demigrated
+    auth = generate_auth_user_hash(provider: 'facebook', uid: user.uid, refresh_token: '65432', email: user.email)
+    setup_should_connect_provider(user, auth)
+    assert_does_not_create(AuthenticationOption) do
+      get :facebook
     end
-  end
-
-  test 'connect_provider: returns bad_request if session[:connect_provider] is expired' do
-    user = create :user
-    Timecop.freeze do
-      setup_should_connect_provider(user, 3.minutes.ago)
-      get :google_oauth2
-      assert_response :bad_request
-    end
+    assert_redirected_to 'http://test.host/users/edit'
+    assert_equal 'Sorry, we cannot connect or disconnect accounts that are still using the old account experience. Please update to the new account experience.', flash.alert
   end
 
   test 'connect_provider: creates new google auth option for signed in user' do
     user = create :user, uid: 'some-uid'
     auth = generate_auth_user_hash(provider: 'google_oauth2', uid: user.uid, refresh_token: '54321')
 
-    @request.env['omniauth.auth'] = auth
-
-    Timecop.freeze do
-      setup_should_connect_provider(user, 2.days.from_now)
-      assert_creates(AuthenticationOption) do
-        get :google_oauth2
-      end
-
-      user.reload
-      assert_redirected_to 'http://test.host/users/edit'
-      assert_auth_option(user, auth)
+    setup_should_connect_provider(user, auth)
+    assert_creates(AuthenticationOption) do
+      get :google_oauth2
     end
+
+    user.reload
+    assert_redirected_to 'http://test.host/users/edit'
+    assert_auth_option(user, auth)
   end
 
   test 'connect_provider: creates new windowslive auth option for signed in user' do
     user = create :user, uid: 'some-uid'
     auth = generate_auth_user_hash(provider: 'windowslive', uid: user.uid)
 
-    @request.env['omniauth.auth'] = auth
-
-    Timecop.freeze do
-      setup_should_connect_provider(user, 2.days.from_now)
-      assert_creates(AuthenticationOption) do
-        get :windowslive
-      end
-
-      user.reload
-      assert_redirected_to 'http://test.host/users/edit'
-      assert_auth_option(user, auth)
+    setup_should_connect_provider(user, auth)
+    assert_creates(AuthenticationOption) do
+      get :windowslive
     end
+
+    user.reload
+    assert_redirected_to 'http://test.host/users/edit'
+    assert_auth_option(user, auth)
   end
 
   test 'connect_provider: creates new facebook auth option for signed in user' do
     user = create :user, uid: 'some-uid'
     auth = generate_auth_user_hash(provider: 'facebook', uid: user.uid)
 
-    @request.env['omniauth.auth'] = auth
-
-    Timecop.freeze do
-      setup_should_connect_provider(user, 2.days.from_now)
-      assert_creates(AuthenticationOption) do
-        get :facebook
-      end
-
-      user.reload
-      assert_redirected_to 'http://test.host/users/edit'
-      assert_auth_option(user, auth)
+    setup_should_connect_provider(user, auth)
+    assert_creates(AuthenticationOption) do
+      get :facebook
     end
+
+    user.reload
+    assert_redirected_to 'http://test.host/users/edit'
+    assert_auth_option(user, auth)
   end
 
   test 'connect_provider: creates new clever auth option for signed in user' do
     user = create :user, uid: 'some-uid'
     auth = generate_auth_user_hash(provider: 'clever', uid: user.uid)
 
-    @request.env['omniauth.auth'] = auth
-
-    Timecop.freeze do
-      setup_should_connect_provider(user, 2.days.from_now)
-      assert_creates(AuthenticationOption) do
-        get :clever
-      end
-
-      user.reload
-      assert_redirected_to 'http://test.host/users/edit'
-      assert_auth_option(user, auth)
+    setup_should_connect_provider(user, auth)
+    assert_creates(AuthenticationOption) do
+      get :clever
     end
+
+    user.reload
+    assert_redirected_to 'http://test.host/users/edit'
+    assert_auth_option(user, auth)
   end
 
   test 'connect_provider: creates new powerschool auth option for signed in user' do
     user = create :user, uid: 'some-uid'
     auth = generate_auth_user_hash(provider: 'powerschool', uid: user.uid)
 
-    @request.env['omniauth.auth'] = auth
-
-    Timecop.freeze do
-      setup_should_connect_provider(user, 2.days.from_now)
-      assert_creates(AuthenticationOption) do
-        get :powerschool
-      end
-
-      user.reload
-      assert_redirected_to 'http://test.host/users/edit'
-      assert_auth_option(user, auth)
+    setup_should_connect_provider(user, auth)
+    assert_creates(AuthenticationOption) do
+      get :powerschool
     end
+
+    user.reload
+    assert_redirected_to 'http://test.host/users/edit'
+    assert_auth_option(user, auth)
   end
 
   test 'connect_provider: redirects to account edit page with an error if AuthenticationOption cannot save' do
     user = create :user, uid: 'some-uid'
     auth = generate_auth_user_hash(provider: 'google_oauth2', uid: user.uid, refresh_token: '54321')
 
-    @request.env['omniauth.auth'] = auth
-
-    Timecop.freeze do
-      AuthenticationOption.any_instance.expects(:save).returns(false)
-      setup_should_connect_provider(user, 2.days.from_now)
-      assert_does_not_create(AuthenticationOption) do
-        get :google_oauth2
-      end
-
-      assert_redirected_to 'http://test.host/users/edit'
-      expected_error = I18n.t('auth.unable_to_connect_provider', provider: I18n.t("auth.google_oauth2"))
-      assert_equal expected_error, flash.alert
+    AuthenticationOption.any_instance.expects(:save).returns(false)
+    setup_should_connect_provider(user, auth)
+    assert_does_not_create(AuthenticationOption) do
+      get :google_oauth2
     end
+
+    assert_redirected_to 'http://test.host/users/edit'
+    expected_error = I18n.t('auth.unable_to_connect_provider', provider: I18n.t("auth.google_oauth2"))
+    assert_equal expected_error, flash.alert
   end
 
   test "connect_provider: Performs takeover of an account with matching credential that has no activity" do
@@ -1507,22 +1469,19 @@ class OmniauthCallbacksControllerTest < ActionController::TestCase
         provider: provider,
         email: user.email
       )
-      @request.env['omniauth.auth'] = auth
 
-      Timecop.freeze do
-        setup_should_connect_provider(user, 2.days.from_now)
-        get provider
+      setup_should_connect_provider(user, auth)
+      get provider
 
-        assert_redirected_to 'http://test.host/users/edit'
+      assert_redirected_to 'http://test.host/users/edit'
 
-        provider_name = I18n.t(provider, scope: :auth)
-        expected_notice = user.teacher? ?
-          I18n.t('user.auth_option_saved', provider: provider_name, email: user.email) :
-          I18n.t('user.auth_option_saved_no_email', provider: provider_name)
+      provider_name = I18n.t(provider, scope: :auth)
+      expected_notice = user.teacher? ?
+        I18n.t('user.auth_option_saved', provider: provider_name, email: user.email) :
+        I18n.t('user.auth_option_saved_no_email', provider: provider_name)
 
-        assert_equal expected_notice, flash.notice
-        sign_out user
-      end
+      assert_equal expected_notice, flash.notice
+      sign_out user
     end
   end
 
@@ -1693,8 +1652,7 @@ class OmniauthCallbacksControllerTest < ActionController::TestCase
   #   linked credentials with assert_auth_option
   def link_credential(user, type:, id:)
     auth = generate_auth_user_hash(provider: type, uid: id)
-    @request.env['omniauth.auth'] = auth
-    setup_should_connect_provider(user, 2.days.from_now)
+    setup_should_connect_provider(user, auth)
     get :google_oauth2
     auth
   end
@@ -1718,9 +1676,10 @@ class OmniauthCallbacksControllerTest < ActionController::TestCase
     )
   end
 
-  def setup_should_connect_provider(user, timestamp = Time.now)
+  def setup_should_connect_provider(user, auth_hash)
+    @request.env['omniauth.auth'] = auth_hash
+    @request.env['omniauth.params'] = {'action' => 'connect'}
     sign_in user
-    session[:connect_provider] = timestamp
   end
 
   def assert_auth_option(user, oauth_hash)

--- a/dashboard/test/integration/omniauth/utils.rb
+++ b/dashboard/test/integration/omniauth/utils.rb
@@ -38,7 +38,7 @@ module OmniauthCallbacksControllerTests
     # which in turn does some work and redirects to something else: homepage, finish_sign_up, etc.
     # @param [String] provider
     def sign_in_through(provider)
-      get "/users/auth/#{provider}"
+      post "/users/auth/#{provider}"
       assert_redirected_to "/users/auth/#{provider}/callback"
       follow_redirect!
     end

--- a/dashboard/test/integration/registration/new_account_tracking_test.rb
+++ b/dashboard/test/integration/registration/new_account_tracking_test.rb
@@ -150,7 +150,7 @@ module RegistrationsControllerTests
 
       @request.env["devise.mapping"] = Devise.mappings[:user]
       assert_does_not_create(User) do
-        get '/users/auth/google_oauth2'
+        post '/users/auth/google_oauth2'
         follow_redirect!
       end
     end


### PR DESCRIPTION
Turns out there's a fairly obscure set of conditions which can result in oauths that use GET requests being insecure. To prevent that, we install a gem which proactively prevents that request method from being used, and update the one part of our system which was using GET requests.

That part of our system is the "manage linked accounts" form on the user settings page; it implements the ability to distinguish between a "connect" oauth action and a "sign in/up" action by setting a timed session variable and redirecting to the oauth endpoint. Because we can no longer redirect, the new version distinguishes between different oauth actions by using oauth parameters, specifically by adding a new 'action' parameter. (Note that we could also in the future use this parameter to distinguish between sign ins and sign ups!)

Because the new connection pathway requires us to use form posts and redirects rather than clientside actions, we also update the disconnection pathway to use the same for parallelism.

**Reviewer note:** the rails unit test updates will probably be easiest to review [with whitespace changes ignored](https://github.com/code-dot-org/code-dot-org/pull/35425/commits/0b3b053306a1bca9575cd64e9121ea6bdceec4b7?w=1), since the removal of the timed session variable means we can take a lot of stuff out of Timecop blocks

## Links

<!--
  Any relevant links to external resources; ie, specification documents, jira
  items, related PRs, honeybadger errors, etc
-->

- [CVE report](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2015-9284)
- [Resolution how-to](https://github.com/omniauth/omniauth/wiki/Resolving-CVE-2015-9284)

## Testing story

No new tests were added; I played around with adding some initially, but eventually realized that the existing tests in this space are already more than sufficient, so I merely updated those.

## Follow-up

As a result of removing the clientside `disconnect` logic, there's a bunch of redux work that is no longer used. I'll take that out in a follow-up PR, in the interests of keeping this one focused.

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
