### PR TITLE
Quick fix for function description error

### DIFF
--- a/dashboard/app/models/levels/blockly.rb
+++ b/dashboard/app/models/levels/blockly.rb
@@ -518,7 +518,9 @@ class Blockly < Level
         default: nil,
         smart: true
       )
-      function_description.content = localized_description if localized_description
+      # Some levels add a description to the function in the solution
+      # but not in the starter/toolbox blocks. These functions have the same key if they have the same name
+      function_description.content = localized_description if function_description && localized_description
       # Translate the "declared" parameter names
       function_mutation.xpath("./arg").each do |parameter|
         localized_parameter = I18n.t(


### PR DESCRIPTION
There have been over 650 occurrences of an [error](https://app.honeybadger.io/projects/3240/faults/64854296) over the past week where we have a translation for a non-existent function description. When I dug deeper, it looks like at least one level (likely more) have a description for a function in the _solution_ but not in the start blocks or toolbox blocks. Because the structure for these translations is level_name -> function_name -> {name, description}, two functions with the same name but different descriptions will clash.

The better option here would be to rethink how we treat start blocks, toolbox blocks, and solution blocks for translation. But this is a much quicker solution that will solve the immediate error.

Example level: https://studio.code.org/s/course4/stage/12/puzzle/4. This is definitiely broken in Traditional Chinese but also likely other languages as it will be broken in any language that has a translation for the `draw a square` function description.

<!-- ### Background -->
<!-- ### Privacy -->
<!-- ### Security -->
<!-- ### Caching -->
<!-- ### Deployment strategy -->
<!-- ### Future work -->

## Links

<!--
  Any relevant links to external resources; ie, specification documents, jira
  items, related PRs, honeybadger errors, etc
-->

- [spec]()
- [jira]()

## Testing story

<!--
  Does your change include appropriate tests?

  If so, please describe how the tests included in this PR are sufficient

  If not, please explain why this change does not need to be tested.
-->

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
