### PR TITLE
AFE: POST to AFE's Pardot instance

### DIFF
--- a/config.yml.erb
+++ b/config.yml.erb
@@ -247,6 +247,9 @@ aws_region: us-east-1
 aws_access_key:
 aws_secret_key:
 
+# Amazon Future Engineer integration
+afe_pardot_form_handler_url:
+
 ### Service configurations (urls, endpoints, etc)
 
 freegeoip_host:

--- a/config/production.yml.erb
+++ b/config/production.yml.erb
@@ -26,3 +26,6 @@ use_pusher:                             true
 
 # Used for the exporting teacher enrollment data to a gsheet
 enrollments_summer_2020_gsheet_key: !Secret
+
+# Amazon Future Engineer integration
+afe_pardot_form_handler_url: !Secret

--- a/dashboard/app/controllers/api/v1/amazon_future_engineer_controller.rb
+++ b/dashboard/app/controllers/api/v1/amazon_future_engineer_controller.rb
@@ -8,6 +8,52 @@ class Api::V1::AmazonFutureEngineerController < ApplicationController
   def submit
     return head :forbidden unless current_user
 
-    post_request('fake_pardot_url.com', params[:amazon_future_engineer])
+    post_request('fake_pardot_url.com', submit_params)
+  end
+
+  private
+
+  def submit_params
+    params.
+      require(:amazon_future_engineer).
+      permit(
+        'traffic-source',
+        'first-name',
+        'last-name',
+        'email',
+        'nces-id',
+        'street-1',
+        'street-2',
+        'street-3',
+        'city',
+        'state',
+        'zip',
+        'inspirational-marketing-kit',
+        'csta-plus',
+        'aws-educate',
+        'amazon-terms',
+        'new-code-account',
+        'registration-date-time',
+      ).tap do |submit_params|
+      submit_params.require(
+        %w(
+          traffic-source
+          first-name
+          last-name
+          email
+          nces-id
+          street-1
+          city
+          state
+          zip
+          inspirational-marketing-kit
+          csta-plus
+          aws-educate
+          amazon-terms
+          new-code-account
+          registration-date-time
+        )
+      )
+    end
   end
 end

--- a/dashboard/app/controllers/api/v1/amazon_future_engineer_controller.rb
+++ b/dashboard/app/controllers/api/v1/amazon_future_engineer_controller.rb
@@ -7,53 +7,38 @@ class Api::V1::AmazonFutureEngineerController < ApplicationController
 
   def submit
     return head :forbidden unless current_user
-
     post_request('fake_pardot_url.com', submit_params)
   end
 
   private
 
+  REQUIRED_PARAMETERS = %w(
+    traffic-source
+    first-name
+    last-name
+    email
+    nces-id
+    street-1
+    city
+    state
+    zip
+    inspirational-marketing-kit
+    csta-plus
+    aws-educate
+    amazon-terms
+    new-code-account
+    registration-date-time
+  )
+
+  PERMITTED_PARAMETERS = [
+    *REQUIRED_PARAMETERS,
+    'street-2',
+    'street-3'
+  ]
+
   def submit_params
-    params.
-      require(:amazon_future_engineer).
-      permit(
-        'traffic-source',
-        'first-name',
-        'last-name',
-        'email',
-        'nces-id',
-        'street-1',
-        'street-2',
-        'street-3',
-        'city',
-        'state',
-        'zip',
-        'inspirational-marketing-kit',
-        'csta-plus',
-        'aws-educate',
-        'amazon-terms',
-        'new-code-account',
-        'registration-date-time',
-      ).tap do |submit_params|
-      submit_params.require(
-        %w(
-          traffic-source
-          first-name
-          last-name
-          email
-          nces-id
-          street-1
-          city
-          state
-          zip
-          inspirational-marketing-kit
-          csta-plus
-          aws-educate
-          amazon-terms
-          new-code-account
-          registration-date-time
-        )
-      )
-    end
+    params.require(:amazon_future_engineer).
+           permit(*PERMITTED_PARAMETERS).
+           tap {|p| p.require(REQUIRED_PARAMETERS)}
   end
 end

--- a/dashboard/app/controllers/api/v1/amazon_future_engineer_controller.rb
+++ b/dashboard/app/controllers/api/v1/amazon_future_engineer_controller.rb
@@ -7,7 +7,17 @@ class Api::V1::AmazonFutureEngineerController < ApplicationController
 
   def submit
     return head :forbidden unless current_user
-    post_request('fake_pardot_url.com', submit_params)
+    if CDO.afe_pardot_form_handler_url
+      post_request CDO.afe_pardot_form_handler_url, submit_params
+    else
+      # Success, with a message:
+      <<~RESPONSE
+        It looks like you haven't configured the
+        afe_pardot_form_handler_url property.
+        Set this up in your locals.yml if you are testing this feature locally
+        and need to check the request sent to AFE-Pardot.
+      RESPONSE
+    end
   end
 
   private

--- a/dashboard/app/controllers/api/v1/amazon_future_engineer_controller.rb
+++ b/dashboard/app/controllers/api/v1/amazon_future_engineer_controller.rb
@@ -3,6 +3,7 @@ require 'cdo/contact_rollups/v2/pardot_helpers'
 class Api::V1::AmazonFutureEngineerController < ApplicationController
   include PardotHelpers
 
+  # Necessary since Pegasus pages use this controller via dashboardapi
   skip_before_action :verify_authenticity_token
 
   def submit

--- a/dashboard/app/controllers/api/v1/amazon_future_engineer_controller.rb
+++ b/dashboard/app/controllers/api/v1/amazon_future_engineer_controller.rb
@@ -9,7 +9,7 @@ class Api::V1::AmazonFutureEngineerController < ApplicationController
   def submit
     return head :forbidden unless current_user
     if CDO.afe_pardot_form_handler_url
-      post_request CDO.afe_pardot_form_handler_url, submit_params
+      post_request CDO.afe_pardot_form_handler_url, afe_params
     else
       # Success, with a message:
       <<~RESPONSE
@@ -24,32 +24,53 @@ class Api::V1::AmazonFutureEngineerController < ApplicationController
   private
 
   REQUIRED_PARAMETERS = %w(
-    traffic-source
-    first-name
-    last-name
+    trafficSource
+    firstName
+    lastName
     email
-    nces-id
-    street-1
+    schoolId
+    street1
     city
     state
     zip
-    inspirational-marketing-kit
-    csta-plus
-    aws-educate
-    amazon-terms
-    new-code-account
-    registration-date-time
+    inspirationKit
+    csta
+    awsEducate
+    consentAFE
+    newCodeAccount
   )
 
   PERMITTED_PARAMETERS = [
     *REQUIRED_PARAMETERS,
-    'street-2',
-    'street-3'
+    'street2',
+    'street3'
   ]
 
   def submit_params
     params.require(:amazon_future_engineer).
            permit(*PERMITTED_PARAMETERS).
            tap {|p| p.require(REQUIRED_PARAMETERS)}
+  end
+
+  def afe_params
+    filtered_params = submit_params
+    {
+      'traffic-source' => filtered_params['trafficSource'],
+      'first-name' => filtered_params['firstName'],
+      'last-name' => filtered_params['lastName'],
+      'email' => filtered_params['email'],
+      'nces-id' => filtered_params['schoolId'],
+      'street-1' => filtered_params['street1'],
+      'street-2' => filtered_params['street2'],
+      'city' => filtered_params['city'],
+      'state' => filtered_params['state'],
+      'zip' => filtered_params['zip'],
+      'inspirational-marketing-kit' => filtered_params['inspirationKit'],
+      'csta-plus' => filtered_params['csta'],
+      'aws-educate' => filtered_params['awsEducate'],
+      'amazon-terms' => filtered_params['consentAFE'],
+      'new-code-account' => filtered_params['newCodeAccount'],
+      'registration-date-time' => Time.now.iso8601
+    }
   end
 end

--- a/dashboard/test/controllers/api/v1/amazon_future_engineer_controller_test.rb
+++ b/dashboard/test/controllers/api/v1/amazon_future_engineer_controller_test.rb
@@ -17,6 +17,33 @@ class Api::V1::AmazonFutureEngineerControllerTest < ActionDispatch::IntegrationT
     assert_response :forbidden
   end
 
+  test 'submit returns BAD REQUEST when params are malformed' do
+    Net::HTTP.expects(:post_form).never
+    sign_in create :teacher
+
+    post '/dashboardapi/v1/amazon_future_engineer_submit',
+      params: {
+        # Intentionally missing required field traffic-source
+        # 'traffic-source' => 'AFE-code.org',
+        'first-name' => 'test',
+        'last-name' => 'test',
+        'email' => 'test@code.org',
+        'nces-id' => '123456789012',
+        'street-1' => 'test street',
+        'city' => 'seattle',
+        'state' => 'wa',
+        'zip' => '98105',
+        'inspirational-marketing-kit' => '0',
+        'csta-plus' => '0',
+        'aws-educate' => '0',
+        'amazon-terms' => '1',
+        'new-code-account' => '0',
+        'registration-date-time' => '1997-07-16T19:20:30+01:00'
+      }, as: :json
+
+    assert_response :bad_request, "Expected BAD REQUEST, got: #{response.status}\n#{response.body}"
+  end
+
   test 'logged in can submit' do
     Net::HTTP.stubs(:post_form)
     Net::HTTP.expects(:post_form).returns(FakeResponse.new)
@@ -25,6 +52,7 @@ class Api::V1::AmazonFutureEngineerControllerTest < ActionDispatch::IntegrationT
 
     post '/dashboardapi/v1/amazon_future_engineer_submit',
       params: {
+        'traffic-source' => 'AFE-code.org',
         'first-name' => 'test',
         'last-name' => 'test',
         'email' => 'test@code.org',

--- a/dashboard/test/controllers/api/v1/amazon_future_engineer_controller_test.rb
+++ b/dashboard/test/controllers/api/v1/amazon_future_engineer_controller_test.rb
@@ -3,7 +3,6 @@ require 'test_helper'
 class Api::V1::AmazonFutureEngineerControllerTest < ActionDispatch::IntegrationTest
   setup do
     CDO.stubs(:afe_pardot_form_handler_url).returns('fake_pardot_url.com')
-    @teacher = create :teacher
   end
 
   test 'logged out cannot submit' do
@@ -20,9 +19,9 @@ class Api::V1::AmazonFutureEngineerControllerTest < ActionDispatch::IntegrationT
 
   test 'submit returns BAD REQUEST when params are malformed' do
     Net::HTTP.expects(:post_form).never
-    sign_in create :teacher
 
     # Intentionally missing required field traffic-source
+    sign_in create :teacher
     post '/dashboardapi/v1/amazon_future_engineer_submit',
       params: valid_params.delete('traffic-source'), as: :json
 
@@ -31,8 +30,8 @@ class Api::V1::AmazonFutureEngineerControllerTest < ActionDispatch::IntegrationT
 
   test 'submit returns BAD REQUEST when params are missing' do
     Net::HTTP.stubs(:post_form)
-    sign_in create :teacher
 
+    sign_in create :teacher
     post '/dashboardapi/v1/amazon_future_engineer_submit'
 
     assert_response :bad_request, "Expected BAD REQUEST, got: #{response.status}\n#{response.body}"
@@ -41,8 +40,7 @@ class Api::V1::AmazonFutureEngineerControllerTest < ActionDispatch::IntegrationT
   test 'logged in can submit' do
     Net::HTTP.expects(:post_form).returns(FakeResponse.new)
 
-    sign_in(@teacher)
-
+    sign_in create :teacher
     post '/dashboardapi/v1/amazon_future_engineer_submit',
       params: valid_params, as: :json
 

--- a/dashboard/test/controllers/api/v1/amazon_future_engineer_controller_test.rb
+++ b/dashboard/test/controllers/api/v1/amazon_future_engineer_controller_test.rb
@@ -2,6 +2,7 @@ require 'test_helper'
 
 class Api::V1::AmazonFutureEngineerControllerTest < ActionDispatch::IntegrationTest
   setup do
+    CDO.stubs(:afe_pardot_form_handler_url).returns('fake_pardot_url.com')
     @teacher = create :teacher
   end
 

--- a/dashboard/test/controllers/api/v1/amazon_future_engineer_controller_test.rb
+++ b/dashboard/test/controllers/api/v1/amazon_future_engineer_controller_test.rb
@@ -21,55 +21,44 @@ class Api::V1::AmazonFutureEngineerControllerTest < ActionDispatch::IntegrationT
     Net::HTTP.expects(:post_form).never
     sign_in create :teacher
 
+    # Intentionally missing required field traffic-source
     post '/dashboardapi/v1/amazon_future_engineer_submit',
-      params: {
-        # Intentionally missing required field traffic-source
-        # 'traffic-source' => 'AFE-code.org',
-        'first-name' => 'test',
-        'last-name' => 'test',
-        'email' => 'test@code.org',
-        'nces-id' => '123456789012',
-        'street-1' => 'test street',
-        'city' => 'seattle',
-        'state' => 'wa',
-        'zip' => '98105',
-        'inspirational-marketing-kit' => '0',
-        'csta-plus' => '0',
-        'aws-educate' => '0',
-        'amazon-terms' => '1',
-        'new-code-account' => '0',
-        'registration-date-time' => '1997-07-16T19:20:30+01:00'
-      }, as: :json
+      params: valid_params.delete('traffic-source'), as: :json
 
     assert_response :bad_request, "Expected BAD REQUEST, got: #{response.status}\n#{response.body}"
   end
 
   test 'logged in can submit' do
-    Net::HTTP.stubs(:post_form)
     Net::HTTP.expects(:post_form).returns(FakeResponse.new)
 
     sign_in(@teacher)
 
     post '/dashboardapi/v1/amazon_future_engineer_submit',
-      params: {
-        'traffic-source' => 'AFE-code.org',
-        'first-name' => 'test',
-        'last-name' => 'test',
-        'email' => 'test@code.org',
-        'nces-id' => '123456789012',
-        'street-1' => 'test street',
-        'city' => 'seattle',
-        'state' => 'wa',
-        'zip' => '98105',
-        'inspirational-marketing-kit' => '0',
-        'csta-plus' => '0',
-        'aws-educate' => '0',
-        'amazon-terms' => '1',
-        'new-code-account' => '0',
-        'registration-date-time' => '1997-07-16T19:20:30+01:00'
-      }, as: :json
+      params: valid_params, as: :json
 
     assert_response :success, "Failed response: #{response.body}"
+  end
+
+  private
+
+  def valid_params
+    {
+      'traffic-source' => 'AFE-code.org',
+      'first-name' => 'test',
+      'last-name' => 'test',
+      'email' => 'test@code.org',
+      'nces-id' => '123456789012',
+      'street-1' => 'test street',
+      'city' => 'seattle',
+      'state' => 'wa',
+      'zip' => '98105',
+      'inspirational-marketing-kit' => '0',
+      'csta-plus' => '0',
+      'aws-educate' => '0',
+      'amazon-terms' => '1',
+      'new-code-account' => '0',
+      'registration-date-time' => '1997-07-16T19:20:30+01:00'
+    }
   end
 
   class FakeResponse

--- a/dashboard/test/controllers/api/v1/amazon_future_engineer_controller_test.rb
+++ b/dashboard/test/controllers/api/v1/amazon_future_engineer_controller_test.rb
@@ -28,6 +28,15 @@ class Api::V1::AmazonFutureEngineerControllerTest < ActionDispatch::IntegrationT
     assert_response :bad_request, "Expected BAD REQUEST, got: #{response.status}\n#{response.body}"
   end
 
+  test 'submit returns BAD REQUEST when params are missing' do
+    Net::HTTP.stubs(:post_form)
+    sign_in create :teacher
+
+    post '/dashboardapi/v1/amazon_future_engineer_submit'
+
+    assert_response :bad_request, "Expected BAD REQUEST, got: #{response.status}\n#{response.body}"
+  end
+
   test 'logged in can submit' do
     Net::HTTP.expects(:post_form).returns(FakeResponse.new)
 

--- a/dashboard/test/controllers/api/v1/amazon_future_engineer_controller_test.rb
+++ b/dashboard/test/controllers/api/v1/amazon_future_engineer_controller_test.rb
@@ -9,10 +9,7 @@ class Api::V1::AmazonFutureEngineerControllerTest < ActionDispatch::IntegrationT
     Net::HTTP.expects(:post_form).never
 
     post '/dashboardapi/v1/amazon_future_engineer_submit',
-      params: {
-        'first-name' => 'test',
-        'last-name' => 'test'
-      }, as: :json
+      params: valid_params, as: :json
 
     assert_response :forbidden
   end
@@ -38,34 +35,60 @@ class Api::V1::AmazonFutureEngineerControllerTest < ActionDispatch::IntegrationT
   end
 
   test 'logged in can submit' do
-    Net::HTTP.expects(:post_form).returns(FakeResponse.new)
+    Timecop.freeze do
+      # Establish an expectation that we post to Pardot with the
+      # correct parameters
+      expected_call = Net::HTTP.expects(:post_form).with do |url, params|
+        url.to_s == CDO.afe_pardot_form_handler_url &&
+          params.to_h == {
+            'traffic-source' => 'AFE-code.org',
+            'first-name' => 'test',
+            'last-name' => 'test',
+            'email' => 'test@code.org',
+            'nces-id' => '123456789012',
+            'street-1' => 'test street',
+            'street-2' => 'test street 2',
+            'city' => 'seattle',
+            'state' => 'wa',
+            'zip' => '98105',
+            'inspirational-marketing-kit' => '0',
+            'csta-plus' => '0',
+            'aws-educate' => '0',
+            'amazon-terms' => '1',
+            'new-code-account' => '0',
+            'registration-date-time' => Time.now.iso8601
+          }
+      end
+      expected_call.returns FakeResponse.new
 
-    sign_in create :teacher
-    post '/dashboardapi/v1/amazon_future_engineer_submit',
-      params: valid_params, as: :json
+      sign_in create :teacher
+      post '/dashboardapi/v1/amazon_future_engineer_submit',
+        params: valid_params, as: :json
 
-    assert_response :success, "Failed response: #{response.body}"
+      assert_response :success, "Failed response: #{response.body}"
+    end
   end
 
   private
 
   def valid_params
     {
-      'traffic-source' => 'AFE-code.org',
-      'first-name' => 'test',
-      'last-name' => 'test',
+      'trafficSource' => 'AFE-code.org',
+      'firstName' => 'test',
+      'lastName' => 'test',
       'email' => 'test@code.org',
-      'nces-id' => '123456789012',
-      'street-1' => 'test street',
+      'schoolId' => '123456789012',
+      'street1' => 'test street',
+      'street2' => 'test street 2',
       'city' => 'seattle',
       'state' => 'wa',
       'zip' => '98105',
-      'inspirational-marketing-kit' => '0',
-      'csta-plus' => '0',
-      'aws-educate' => '0',
-      'amazon-terms' => '1',
-      'new-code-account' => '0',
-      'registration-date-time' => '1997-07-16T19:20:30+01:00'
+      'inspirationKit' => '0',
+      'csta' => '0',
+      'consentCSTA' => '0',
+      'awsEducate' => '0',
+      'consentAFE' => '1',
+      'newCodeAccount' => '0'
     }
   end
 

--- a/dashboard/test/controllers/api/v1/amazon_future_engineer_controller_test.rb
+++ b/dashboard/test/controllers/api/v1/amazon_future_engineer_controller_test.rb
@@ -7,7 +7,7 @@ class Api::V1::AmazonFutureEngineerControllerTest < ActionDispatch::IntegrationT
   end
 
   test 'logged out cannot submit' do
-    # Add expectation that there are no HTTP requests to Pardot.
+    Net::HTTP.expects(:post_form).never
 
     post '/dashboardapi/v1/amazon_future_engineer_submit',
       params: {


### PR DESCRIPTION
Gives our AFE controller the ability to post to AFE's Pardot form handler endpoint in the correct format.

The endpoint URL is configurable, and stored in Secrets Manager for the production environment.  You should add it to locals.yml if you're doing active development on this feature.

Covered by unit tests.  Not used in production yet.

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
