### PR TITLE
CRv2: Process professional_learning_attended attribute

### DIFF
--- a/dashboard/lib/contact_rollups_v2.rb
+++ b/dashboard/lib/contact_rollups_v2.rb
@@ -228,8 +228,6 @@ class ContactRollupsV2
     Cdo::Metrics.push('ContactRollupsV2', aws_metrics)
   end
 
-  private
-
   # Using truncate allows us to re-use row IDs,
   # which is important in production so we don't overflow the table.
   # Deletion is required in test environments, as tests generally do

--- a/dashboard/test/models/contact_rollups_pardot_memory_test.rb
+++ b/dashboard/test/models/contact_rollups_pardot_memory_test.rb
@@ -2,6 +2,8 @@ require 'test_helper'
 require 'cdo/contact_rollups/v2/pardot'
 
 class ContactRollupsPardotMemoryTest < ActiveSupport::TestCase
+  include Pd::WorkshopConstants
+
   setup do
     assert_equal 0, ContactRollupsPardotMemory.count
   end
@@ -113,16 +115,27 @@ class ContactRollupsPardotMemoryTest < ActiveSupport::TestCase
   end
 
   test 'create_new_pardot_prospects' do
-    assert_equal 0, ContactRollupsPardotMemory.count
-    contact = create :contact_rollups_processed, data: {'opt_in' => 1}
-
+    contact = create :contact_rollups_processed,
+      data: {
+        'opt_in' => 1,
+        'user_id' => 111,
+        'professional_learning_enrolled' => "#{COURSE_CSD},#{COURSE_CSF}",
+        'professional_learning_attended' => COURSE_CSF,
+      }
+    refute ContactRollupsPardotMemory.find_by_email(contact.email)
     PardotV2.expects(:submit_batch_request).once.returns([])
 
     ContactRollupsPardotMemory.create_new_pardot_prospects
 
-    assert_equal 1, ContactRollupsPardotMemory.count
-    record = ContactRollupsPardotMemory.find_by(email: contact.email)
-    assert_equal({'db_Opt_In' => 'Yes'}, record.data_synced)
+    record = ContactRollupsPardotMemory.find_by_email!(contact.email)
+    expected_data_synced = {
+      'db_Opt_In' => 'Yes',
+      'db_Has_Teacher_Account' => 'true',
+      'db_Professional_Learning_Enrolled_0' => COURSE_CSD,
+      'db_Professional_Learning_Enrolled_1' => COURSE_CSF,
+      'db_Professional_Learning_Attended_0' => COURSE_CSF
+    }
+    assert_equal expected_data_synced, record[:data_synced]
   end
 
   test 'query_updated_contacts' do
@@ -198,16 +211,35 @@ class ContactRollupsPardotMemoryTest < ActiveSupport::TestCase
   test 'update_pardot_prospects' do
     email = 'test@domain.com'
     last_sync_time = Time.now.utc - 7.days
-    create :contact_rollups_pardot_memory, email: email, data_synced: {db_Opt_In: 'No'}, data_synced_at: last_sync_time
-    create :contact_rollups_processed, email: email, data: {'opt_in' => 1}
+    # current data
+    create :contact_rollups_pardot_memory,
+      email: email,
+      data_synced: {
+        'db_Opt_In' => 'No',
+        'db_Professional_Learning_Attended' => COURSE_CSF
+      },
+      data_synced_at: last_sync_time
+
+    # new data
+    create :contact_rollups_processed,
+      email: email,
+      data: {
+        'opt_in' => 1,
+        'professional_learning_attended' => "#{COURSE_CSD},#{COURSE_CSF}",
+      }
 
     PardotV2.expects(:submit_batch_request).once.returns([])
 
     ContactRollupsPardotMemory.update_pardot_prospects
 
-    record = ContactRollupsPardotMemory.find_by(email: email)
-    assert_equal({'db_Opt_In' => 'Yes'}, record.data_synced)
-    assert last_sync_time < record.data_synced_at
+    record = ContactRollupsPardotMemory.find_by_email!(email)
+    expected_data_synced = {
+      'db_Opt_In' => 'Yes',
+      'db_Professional_Learning_Attended_0' => COURSE_CSD,
+      'db_Professional_Learning_Attended_1' => COURSE_CSF
+    }
+    assert_equal expected_data_synced, record[:data_synced]
+    assert last_sync_time < record[:data_synced_at]
   end
 
   test 'save_sync_results new prospect' do

--- a/dashboard/test/models/contact_rollups_processed_test.rb
+++ b/dashboard/test/models/contact_rollups_processed_test.rb
@@ -57,11 +57,15 @@ class ContactRollupsProcessedTest < ActiveSupport::TestCase
 
     # Each extraction function will be called once per unique email address
     ContactRollupsProcessed.expects(:extract_opt_in).
-      once.
-      returns({opt_in: 1})
+      once.returns({})
+    ContactRollupsProcessed.expects(:extract_user_id).
+      once.returns({})
+    ContactRollupsProcessed.expects(:extract_professional_learning_enrolled).
+      once.returns({})
+    ContactRollupsProcessed.expects(:extract_professional_learning_attended).
+      once.returns({})
     ContactRollupsProcessed.expects(:extract_updated_at).
-      once.
-      returns({updated_at: Time.now.utc})
+      once.returns({})
 
     ContactRollupsProcessed.import_from_raw_table
   end

--- a/dashboard/test/models/contact_rollups_processed_test.rb
+++ b/dashboard/test/models/contact_rollups_processed_test.rb
@@ -1,6 +1,8 @@
 require 'test_helper'
 
 class ContactRollupsProcessedTest < ActiveSupport::TestCase
+  include Pd::WorkshopConstants
+
   test 'import_from_raw_table creates one row per email' do
     assert 0, ContactRollupsRaw.count
     assert 0, ContactRollupsProcessed.count
@@ -38,14 +40,14 @@ class ContactRollupsProcessedTest < ActiveSupport::TestCase
     create :contact_rollups_raw, email: email,
       sources: 'dashboard.email_preferences', data: {opt_in: 1}, data_updated_at: base_time - 1.day
     create :contact_rollups_raw, email: email,
-      sources: 'dashboard.pd_enrollments', data: {course: Pd::Workshop::COURSE_CSF}, data_updated_at: base_time
+      sources: 'dashboard.pd_enrollments', data: {course: COURSE_CSF}, data_updated_at: base_time
 
     refute ContactRollupsProcessed.find_by_email(email)
     ContactRollupsProcessed.import_from_raw_table
 
     record = ContactRollupsProcessed.find_by_email!(email)
     assert_equal 1, record.data['opt_in']
-    assert_equal Pd::Workshop::COURSE_CSF, record.data['professional_learning_enrolled']
+    assert_equal COURSE_CSF, record.data['professional_learning_enrolled']
     assert_equal base_time.to_i, Time.parse(record.data['updated_at']).to_i
   end
 
@@ -112,16 +114,16 @@ class ContactRollupsProcessedTest < ActiveSupport::TestCase
     contact_data = {
       'dashboard.pd_enrollments' => {
         'course' => [
-          {'value' => Pd::Workshop::COURSE_CSF},
-          {'value' => Pd::Workshop::COURSE_CSF},
-          {'value' => Pd::Workshop::COURSE_CSD},
+          {'value' => COURSE_CSF},
+          {'value' => COURSE_CSF},
+          {'value' => COURSE_CSD},
           {'value' => nil}
         ]
       }
     }
     # output should not contains nil or duplicate values, and should be sorted
     expected_output = {
-      professional_learning_enrolled: "#{Pd::Workshop::COURSE_CSD},#{Pd::Workshop::COURSE_CSF}"
+      professional_learning_enrolled: "#{COURSE_CSD},#{COURSE_CSF}"
     }
 
     output = ContactRollupsProcessed.extract_professional_learning_enrolled(contact_data)

--- a/lib/test/cdo/contact_rollups/test_pardot_v2.rb
+++ b/lib/test/cdo/contact_rollups/test_pardot_v2.rb
@@ -233,20 +233,25 @@ class PardotV2Test < Minitest::Test
       {
         # multi-value attribute has 1 value
         input: {
-          professional_learning_enrolled: COURSE_CSF
+          professional_learning_enrolled: COURSE_CSF,
+          professional_learning_attended: COURSE_CSF,
         },
         expected_output: {
-          db_Professional_Learning_Enrolled_0: COURSE_CSF
+          db_Professional_Learning_Enrolled_0: COURSE_CSF,
+          db_Professional_Learning_Attended_0: COURSE_CSF,
         }
       },
       {
         # multi-value attribute has more than 1 value
         input: {
-          professional_learning_enrolled: "#{COURSE_CSD},#{COURSE_CSF}"
+          professional_learning_enrolled: "#{COURSE_CSD},#{COURSE_CSF}",
+          professional_learning_attended: "#{COURSE_CSP},#{COURSE_ECS}",
         },
         expected_output: {
           db_Professional_Learning_Enrolled_0: COURSE_CSD,
-          db_Professional_Learning_Enrolled_1: COURSE_CSF
+          db_Professional_Learning_Enrolled_1: COURSE_CSF,
+          db_Professional_Learning_Attended_0: COURSE_CSP,
+          db_Professional_Learning_Attended_1: COURSE_ECS,
         }
       }
     ]

--- a/lib/test/cdo/contact_rollups/test_pardot_v2.rb
+++ b/lib/test/cdo/contact_rollups/test_pardot_v2.rb
@@ -210,15 +210,8 @@ class PardotV2Test < Minitest::Test
         }
       },
       {
-        input: {
-          email: 'test1@domain.com',
-          pardot_id: nil,
-          bad_key: true
-        },
-        expected_output: {
-          email: 'test1@domain.com',
-          id: nil
-        }
+        input: {bad_key: true},
+        expected_output: {}
       }
     ]
 


### PR DESCRIPTION
[PLC-918](https://codedotorg.atlassian.net/browse/PLC-918): Use contact's `professional_learning_attended` to set Pardot prospect's `db_Professional_Learning_Attended`. 

Contact's `professional_learning_attended` value is created from `dashboard.pd_workshops#course` and `dashboard.sections#section_type`.

Prospect's [db_Professional_Learning_Attended](https://pi.pardot.com/prospectFieldCustom/read/id/6739) is a multi-value/multi-select attribute.

## Links
[Speadsheet of all attributes to process](https://docs.google.com/spreadsheets/d/10oKPBVlC5LZee9WiECwd745sX-4EXFALuSIVVwdW5tc/edit#gid=0).

## Test story
Test on an adhoc with connection to a production-cloned db
  ```ruby
  @limit = 100
  cr = ContactRollupsV2.new(is_dry_run: true, limit_extraction: @limit);

  # clean up existing tables
  cr.truncate_or_delete_table ContactRollupsRaw
  cr.truncate_or_delete_table ContactRollupsProcessed

  # extract only data used by this PR
  ContactRollupsRaw.extract_professional_learning_attendance_old_attendance_model(@limit)
  ContactRollupsRaw.extract_professional_learning_attendance_new_attendance_model(@limit)

  # dry run
  cr.process_contacts
  cr.sync_updated_contacts_with_pardot
  cr.sync_new_contacts_with_pardot
  cr.report_results
  ```
