### PR TITLE
Open documentation in new tab

### DIFF
--- a/apps/src/storage/dataBrowser/LibraryTable.jsx
+++ b/apps/src/storage/dataBrowser/LibraryTable.jsx
@@ -112,7 +112,9 @@ class LibraryTable extends React.Component {
 
               {datasetInfo.docUrl && (
                 <span style={{display: 'block'}}>
-                  <a href={datasetInfo.docUrl}>{msg.moreInfo()}</a>
+                  <a target="_blank" href={datasetInfo.docUrl}>
+                    {msg.moreInfo()}
+                  </a>
                 </span>
               )}
 


### PR DESCRIPTION
Request from Marina came in to have this documentation open in a new tab (so the user could come back to this page when done with documentation).


## Links

<!--
  Any relevant links to external resources; ie, specification documents, jira
  items, related PRs, honeybadger errors, etc
-->

- [spec]()
- [jira]()

## Testing story

<!--
  Does your change include appropriate tests?

  If so, please describe how the tests included in this PR are sufficient

  If not, please explain why this change does not need to be tested.
-->

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
