### PR TITLE
[Spritelab] Distinguish between subject and clicked sprite in generated code

### DIFF
--- a/apps/src/p5lab/spritelab/blocks.js
+++ b/apps/src/p5lab/spritelab/blocks.js
@@ -224,11 +224,11 @@ const customInputTypes = {
     generateCode(block, arg) {
       switch (block.type) {
         case 'gamelab_clickedSpritePointer':
-          return '{id: extraArgs.sprite}';
+          return '{id: extraArgs.clickedSprite}';
         case 'gamelab_subjectSpritePointer':
-          return '{id: extraArgs.sprite}';
+          return '{id: extraArgs.subjectSprite}';
         case 'gamelab_objectSpritePointer':
-          return '{id: extraArgs.target}';
+          return '{id: extraArgs.objectSprite}';
         default:
           // unsupported block for spritePointer, returning undefined here
           // will match the behavior of an empty socket.

--- a/apps/src/p5lab/spritelab/commands/spriteCommands.js
+++ b/apps/src/p5lab/spritelab/commands/spriteCommands.js
@@ -40,10 +40,14 @@ export const commands = {
   getThisSprite(which, extraArgs) {
     if (extraArgs) {
       if (which === 'this') {
-        return {id: extraArgs.sprite};
+        if (extraArgs.clickedSprite !== undefined) {
+          return {id: extraArgs.clickedSprite};
+        } else if (extraArgs.subjectSprite !== undefined) {
+          return {id: extraArgs.subjectSprite};
+        }
       }
       if (which === 'other') {
-        return {id: extraArgs.target};
+        return {id: extraArgs.objectSprite};
       }
     }
   },

--- a/apps/src/p5lab/spritelab/coreLibrary.js
+++ b/apps/src/p5lab/spritelab/coreLibrary.js
@@ -201,7 +201,10 @@ function whenTouchEvent(inputEvent) {
         if (!firedOnce) {
           // Sprites are overlapping, and we haven't fired yet for this collision,
           // so we should fire the callback
-          callbackArgList.push({sprite: sprite.id, target: target.id});
+          callbackArgList.push({
+            subjectSprite: sprite.id,
+            objectSprite: target.id
+          });
           firedOnce = true;
         }
       } else {
@@ -224,7 +227,10 @@ function whileTouchEvent(inputEvent) {
   sprites.forEach(sprite => {
     targets.forEach(target => {
       if (sprite.overlap(target)) {
-        callbackArgList.push({sprite: sprite.id, target: target.id});
+        callbackArgList.push({
+          subjectSprite: sprite.id,
+          objectSprite: target.id
+        });
       }
     });
   });
@@ -237,7 +243,7 @@ function whenClickEvent(inputEvent, p5Inst) {
     let sprites = getSpriteArray(inputEvent.args.sprite);
     sprites.forEach(sprite => {
       if (p5Inst.mouseIsOver(sprite)) {
-        callbackArgList.push({sprite: sprite.id});
+        callbackArgList.push({clickedSprite: sprite.id});
       }
     });
   }
@@ -249,7 +255,7 @@ function whileClickEvent(inputEvent, p5Inst) {
   let sprites = getSpriteArray(inputEvent.args.sprite);
   sprites.forEach(sprite => {
     if (p5Inst.mousePressedOver(sprite)) {
-      callbackArgList.push({sprite: sprite.id});
+      callbackArgList.push({clickedSprite: sprite.id});
     }
   });
   return callbackArgList;

--- a/apps/test/unit/spritelab/coreLibraryTest.js
+++ b/apps/test/unit/spritelab/coreLibraryTest.js
@@ -318,7 +318,7 @@ describe('SpriteLab Core Library', () => {
         mouseIsOverStub.withArgs(sprite3).returns(false);
 
         coreLibrary.addEvent('whenclick', {sprite: {costume: 'a'}}, extraArgs =>
-          eventLog.push(extraArgs.sprite + ' was clicked')
+          eventLog.push(extraArgs.clickedSprite + ' was clicked')
         );
 
         coreLibrary.runEvents(p5Wrapper.p5);
@@ -339,7 +339,7 @@ describe('SpriteLab Core Library', () => {
         mouseIsOverStub.withArgs(sprite2).returns(true);
 
         coreLibrary.addEvent('whenclick', {sprite: {costume: 'a'}}, extraArgs =>
-          eventLog.push(extraArgs.sprite + ' was clicked')
+          eventLog.push(extraArgs.clickedSprite + ' was clicked')
         );
 
         coreLibrary.runEvents(p5Wrapper.p5);
@@ -500,14 +500,18 @@ describe('SpriteLab Core Library', () => {
           'whentouch',
           {sprite1: {costume: 'a'}, sprite2: {costume: 'b'}},
           extraArgs =>
-            eventLog.push(`when: ${extraArgs.sprite}, ${extraArgs.target}`)
+            eventLog.push(
+              `when: ${extraArgs.subjectSprite}, ${extraArgs.objectSprite}`
+            )
         );
 
         coreLibrary.addEvent(
           'whiletouch',
           {sprite1: {costume: 'a'}, sprite2: {costume: 'b'}},
           extraArgs =>
-            eventLog.push(`while: ${extraArgs.sprite}, ${extraArgs.target}`)
+            eventLog.push(
+              `while: ${extraArgs.subjectSprite}, ${extraArgs.objectSprite}`
+            )
         );
 
         coreLibrary.runEvents(p5Wrapper.p5);
@@ -525,7 +529,9 @@ describe('SpriteLab Core Library', () => {
           'whentouch',
           {sprite1: {costume: 'a'}, sprite2: {costume: 'b'}},
           extraArgs =>
-            eventLog.push(`when: ${extraArgs.sprite}, ${extraArgs.target}`)
+            eventLog.push(
+              `when: ${extraArgs.subjectSprite}, ${extraArgs.objectSprite}`
+            )
         );
 
         coreLibrary.runEvents(p5Wrapper.p5);
@@ -543,7 +549,9 @@ describe('SpriteLab Core Library', () => {
           'whentouch',
           {sprite1: {costume: 'a'}, sprite2: {costume: 'b'}},
           extraArgs =>
-            eventLog.push(`when: ${extraArgs.sprite}, ${extraArgs.target}`)
+            eventLog.push(
+              `when: ${extraArgs.subjectSprite}, ${extraArgs.objectSprite}`
+            )
         );
 
         coreLibrary.runEvents(p5Wrapper.p5);
@@ -561,7 +569,9 @@ describe('SpriteLab Core Library', () => {
           'whiletouch',
           {sprite1: {costume: 'a'}, sprite2: {costume: 'b'}},
           extraArgs =>
-            eventLog.push(`while: ${extraArgs.sprite}, ${extraArgs.target}`)
+            eventLog.push(
+              `while: ${extraArgs.subjectSprite}, ${extraArgs.objectSprite}`
+            )
         );
 
         coreLibrary.runEvents(p5Wrapper.p5);
@@ -581,7 +591,9 @@ describe('SpriteLab Core Library', () => {
           'whentouch',
           {sprite1: {costume: 'a'}, sprite2: {costume: 'b'}},
           extraArgs =>
-            eventLog.push(`when: ${extraArgs.sprite}, ${extraArgs.target}`)
+            eventLog.push(
+              `when: ${extraArgs.subjectSprite}, ${extraArgs.objectSprite}`
+            )
         );
         coreLibrary.runEvents(p5Wrapper.p5);
         expect(eventLog).to.deep.equal(['when: 0, 2']);
@@ -610,7 +622,9 @@ describe('SpriteLab Core Library', () => {
           'whiletouch',
           {sprite1: {costume: 'a'}, sprite2: {costume: 'a'}},
           extraArgs =>
-            eventLog.push(`while: ${extraArgs.sprite}, ${extraArgs.target}`)
+            eventLog.push(
+              `while: ${extraArgs.subjectSprite}, ${extraArgs.objectSprite}`
+            )
         );
 
         coreLibrary.runEvents(p5Wrapper.p5);


### PR DESCRIPTION
This PR ensures that the `clicked sprite` block only works in click events and the `subject sprite` block only works in touch events. The `this/other sprite` block is unaffected by this change.

Before (clicked sprite is incorrectly referring to the subject sprite):
![image](https://user-images.githubusercontent.com/8787187/85632829-e715c000-b62c-11ea-89fe-ca2fb98f5954.png)

After (clicked sprite is undefined, so no sprite turns red):
![image](https://user-images.githubusercontent.com/8787187/85632897-07457f00-b62d-11ea-8a2a-1350fae1c7c8.png)

this/other (no change):
(`this sprite` is the purple bunny, `other sprite` is the green car)
![image](https://user-images.githubusercontent.com/8787187/85632932-19bfb880-b62d-11ea-9de6-13c5f181a994.png)
(`this sprite` is the purple bunny, `other sprite` is undefined, so no sprite turns by 90 degrees)
![image](https://user-images.githubusercontent.com/8787187/85632983-352ac380-b62d-11ea-8e0b-243fecf94002.png)
