### PR TITLE
CRv2: Fix cronjob script

### DIFF
--- a/bin/cron/build_contact_rollups_v2
+++ b/bin/cron/build_contact_rollups_v2
@@ -15,9 +15,7 @@ def main
   end
 
   contact_rollups = ContactRollupsV2.new(is_dry_run: force_dry_run)
-  contact_rollups.collect_and_process_contacts
-  contact_rollups.sync_new_contacts_with_pardot
-  contact_rollups.sync_updated_contacts_with_pardot
+  contact_rollups.build_and_sync
 ensure
   contact_rollups.report_results
 end


### PR DESCRIPTION
Fix [Honeybadger error](https://app.honeybadger.io/projects/45435/faults/65038626) caused by breaking ContactRollupsV2 `collect_and_process` method into `collect_contacts` and `process_contacts` in https://github.com/code-dot-org/code-dot-org/pull/35412/.

Tested by running `./bin/cron/build_contact_rollups_v2` from repo root.