### PR TITLE
Remove pegasus dependencies on annual curricula in ScriptContants

### DIFF
--- a/lib/cdo/script_constants.rb
+++ b/lib/cdo/script_constants.rb
@@ -352,13 +352,52 @@ module ScriptConstants
     }
   end
 
+  CSF_COURSE_PATTERNS = [/^(course[a-f])-([0-9]+)$/, /^(express)-([0-9]+)$/, /^(pre-express)-([0-9]+)$/]
+
   def self.has_congrats_page?(script)
     script == ACCELERATED_NAME ||
       ScriptConstants.script_in_category?(:csf_international, script) ||
-      ScriptConstants.script_in_category?(:csf, script) ||
-      ScriptConstants.script_in_category?(:csf_2018, script) ||
-      ScriptConstants.script_in_category?(:csf_2019, script) ||
-      ScriptConstants.script_in_category?(:csf_2020, script)
+      CSF_COURSE_PATTERNS.map {|r| r =~ script}.any?
+  end
+
+  def self.csf_next_course_recommendation(course_name)
+    # These course names without years in them should be mapped statically to their recommendation.
+    static_mapping = {
+      "course1" => "course2",
+      "course2" => "course3",
+      "course3" => "course4",
+      "accelerated" => "course4",
+      "course4" => "applab"
+    }
+
+    return static_mapping[course_name] if static_mapping.include?(course_name)
+
+    # For CSF courses with years in their name, separate into prefix and year. Determine the recommended
+    # next prefix based on constant mapping, then add the year to the recommended prefix.
+    # Example: coursea-2019 becomes prefix: coursea, year: 2019.
+    # coursea maps to courseb, so return courseb-2019.
+    CSF_COURSE_PATTERNS.each do |r|
+      match_data = r.match(course_name)
+      next unless match_data
+
+      prefix = match_data[1]
+      year = match_data[2]
+
+      return "applab" if %w(coursef express).include?(prefix)
+
+      prefix_mapping = {
+        "coursea" => "courseb",
+        "courseb" => "coursec",
+        "coursec" => "coursed",
+        "coursed" => "coursee",
+        "coursee" => "coursef",
+        "pre-express" => "coursec"
+      }
+
+      return "#{prefix_mapping[prefix]}-#{year}" if prefix_mapping.include?(prefix)
+    end
+
+    return nil
   end
 
   def self.i18n?(script)

--- a/lib/test/test_script_constants.rb
+++ b/lib/test/test_script_constants.rb
@@ -76,6 +76,61 @@ class ScriptConstantsTest < Minitest::Test
     assert_equal 7, ScriptConstants.assignable_info({name: 'minecraft'})[:position]
   end
 
+  def test_congrats_page
+    %w(
+      coursea-2019
+      courseb-2019
+      coursec-2019
+      coursed-2019
+      coursee-2019
+      coursef-2019
+      express-2019
+      pre-express-2019
+      coursea-2020
+      courseb-2020
+      coursec-2020
+      coursed-2020
+      coursee-2020
+      coursef-2020
+      express-2020
+      pre-express-2020
+    ).each do |script_name|
+      assert ScriptConstants.has_congrats_page?(script_name), "#{script_name} should have congrats page"
+    end
+  end
+
+  def test_csf_next_course_recommendation
+    {
+      "course1" => "course2",
+      "course2" => "course3",
+      "course3" => "course4",
+      "accelerated" => "course4",
+      "course4" => "applab",
+
+      "coursea-2019" => "courseb-2019",
+      "courseb-2019" => "coursec-2019",
+      "coursec-2019" => "coursed-2019",
+      "coursed-2019" => "coursee-2019",
+      "coursee-2019" => "coursef-2019",
+      "pre-express-2019" => "coursec-2019",
+      "coursef-2019" => "applab",
+      "express-2019" => "applab",
+
+      "coursea-2020" => "courseb-2020",
+      "courseb-2020" => "coursec-2020",
+      "coursec-2020" => "coursed-2020",
+      "coursed-2020" => "coursee-2020",
+      "coursee-2020" => "coursef-2020",
+      "pre-express-2020" => "coursec-2020",
+      "coursef-2020" => "applab",
+      "express-2020" => "applab",
+    }.each do |course_name, expected|
+      assert_equal expected, ScriptConstants.csf_next_course_recommendation(course_name), "course: #{course_name}"
+    end
+
+    assert_nil ScriptConstants.csf_next_course_recommendation("something-unknown")
+  end
+
   describe 'ScriptConstants::script_in_any_category?' do
     it 'finds artist and csd1' do
       assert ScriptConstants.script_in_any_category?('artist')

--- a/pegasus/sites.v3/code.org/public/congrats.haml
+++ b/pegasus/sites.v3/code.org/public/congrats.haml
@@ -21,7 +21,6 @@ max_age: 60
   rescue ArgumentError
     bad_request
   end
-  pass unless ScriptConstants.script_in_any_category?(cert_script)
 
   if cert_id
     share_url = "http://#{request.host_with_port}/certificates/#{cert_id}"

--- a/pegasus/sites.v3/code.org/views/csf_congrats.haml
+++ b/pegasus/sites.v3/code.org/views/csf_congrats.haml
@@ -13,49 +13,7 @@
     :text=> I18n.t(:"just_did_course_donor", donor_twitter: get_random_donor_twitter, course: course_name)
   }
 
-  rec_code_studio = {
-    "course1" => "course2",
-    "course2" => "course3",
-    "course3" => "course4",
-    "accelerated" => "course4",
-    "course4" => "applab",
-
-    ScriptConstants::COURSEA_NAME => ScriptConstants::COURSEB_NAME,
-    ScriptConstants::COURSEB_NAME => ScriptConstants::COURSEC_NAME,
-    ScriptConstants::PRE_READER_EXPRESS_NAME => ScriptConstants::COURSEC_NAME,
-    ScriptConstants::COURSEC_NAME => ScriptConstants::COURSED_NAME,
-    ScriptConstants::COURSED_NAME => ScriptConstants::COURSEE_NAME,
-    ScriptConstants::COURSEE_NAME => ScriptConstants::COURSEF_NAME,
-    ScriptConstants::COURSEF_NAME => "applab",
-    ScriptConstants::EXPRESS_NAME => "applab",
-
-    ScriptConstants::COURSEA_2018_NAME => ScriptConstants::COURSEB_2018_NAME,
-    ScriptConstants::COURSEB_2018_NAME => ScriptConstants::COURSEC_2018_NAME,
-    ScriptConstants::PRE_READER_EXPRESS_2018_NAME => ScriptConstants::COURSEC_2018_NAME,
-    ScriptConstants::COURSEC_2018_NAME => ScriptConstants::COURSED_2018_NAME,
-    ScriptConstants::COURSED_2018_NAME => ScriptConstants::COURSEE_2018_NAME,
-    ScriptConstants::COURSEE_2018_NAME => ScriptConstants::COURSEF_2018_NAME,
-    ScriptConstants::COURSEF_2018_NAME => "applab",
-    ScriptConstants::EXPRESS_2018_NAME => "applab",
-
-    ScriptConstants::COURSEA_2019_NAME => ScriptConstants::COURSEB_2019_NAME,
-    ScriptConstants::COURSEB_2019_NAME => ScriptConstants::COURSEC_2019_NAME,
-    ScriptConstants::PRE_READER_EXPRESS_2019_NAME => ScriptConstants::COURSEC_2019_NAME,
-    ScriptConstants::COURSEC_2019_NAME => ScriptConstants::COURSED_2019_NAME,
-    ScriptConstants::COURSED_2019_NAME => ScriptConstants::COURSEE_2019_NAME,
-    ScriptConstants::COURSEE_2019_NAME => ScriptConstants::COURSEF_2019_NAME,
-    ScriptConstants::COURSEF_2019_NAME => "applab",
-    ScriptConstants::EXPRESS_2019_NAME => "applab",
-
-    ScriptConstants::COURSEA_2020_NAME => ScriptConstants::COURSEB_2020_NAME,
-    ScriptConstants::COURSEB_2020_NAME => ScriptConstants::COURSEC_2020_NAME,
-    ScriptConstants::COURSEC_2020_NAME => ScriptConstants::COURSED_2020_NAME,
-    ScriptConstants::COURSED_2020_NAME => ScriptConstants::COURSEE_2020_NAME,
-    ScriptConstants::COURSEE_2020_NAME => ScriptConstants::COURSEF_2020_NAME,
-    ScriptConstants::COURSEF_2020_NAME => "applab",
-    ScriptConstants::EXPRESS_2020_NAME => "applab",
-    ScriptConstants::PRE_READER_EXPRESS_2020_NAME => ScriptConstants::COURSEC_2020_NAME
-  }
+  rec_code_studio = ScriptConstants.csf_next_course_recommendation(course)
 
   rec_third_party = {
     "course1" => "course1_next",
@@ -119,10 +77,9 @@
   %h1= I18n.t(:congrats_third_party_title)
   = view :"#{rec_third_party[course]}"
 
-  - rec_code_studio.each do |current_course, next_course|
-    - if current_course.eql? course
-      %h1= I18n.t(:congrats_next_tutorials_title)
-      = view :course_block, id: next_course
+  - if rec_code_studio
+    %h1= I18n.t(:congrats_next_tutorials_title)
+    = view :course_block, id: rec_code_studio
 
   %div{:style=>'clear: both; height:30px;'}
   %h1= I18n.t(:congrats_guest_speaker_title)


### PR DESCRIPTION
Removes Pegasus dependencies on the presence of annual curricula in ScriptConstants. Follows strategies described in: https://docs.google.com/document/d/117axlZenMsUDal3E7pzKEhmhd1oGhi2sjpkyvD0PqRw/edit#heading=h.51wlsbjlevnm

These changes are hacky / brittle, but IMO it's the lesser of two evils compared to having to update each of these constant lists each year for launching curricula. See discussion in doc linked above.

There will still be Pegasus dependencies on ScriptConstants after these changes, but they should only be for HOC categories.

The change I'm least certain about is removing `pass unless ScriptConstants.script_in_any_category?(cert_script)` from `public/congrats.haml `. My reasoning here is that even if `cert_script` is not a known script, each place it's used should still work since it already has fallback logic. Please let me know if this is sufficient. If not, I can implement a new method which can use regexes to determine if it's a valid script/course name for the annual curricula case.

## Testing story

* test_script_constants.rb passes
* I would like to manually test these changes, but I wasn't sure how to do so, advice appreciated.

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
