### PR TITLE
Standards: link to standards overview on curriculum builder for csf 2020+

### DIFF
--- a/apps/i18n/common/en_us.json
+++ b/apps/i18n/common/en_us.json
@@ -404,6 +404,7 @@
   "createStandardsReportSuggestion": "**Suggestions:**",
   "createStandardsReportSuggestion1": "Describe what your class is working on",
   "createStandardsReportSuggestion2": "Explain how your computer science lessons relate to other subjects or standards",
+  "createStandardsReportSuggestion2Link": "Explain how your computer science lessons relate to [other subjects or standards]({standardsOverviewLink})",
   "createStandardsReportSuggestion4": "[Add a link to a student project]({projectsLink})",
   "createTableHeader": "Create data tables to store rows of data with multiple columns for different fields.",
   "crossTab": "Cross Tab",

--- a/apps/src/templates/sectionProgress/ProgressViewHeader.jsx
+++ b/apps/src/templates/sectionProgress/ProgressViewHeader.jsx
@@ -45,6 +45,17 @@ class ProgressViewHeader extends Component {
     return scriptData ? `${scriptData.path}?section_id=${section.id}` : null;
   }
 
+  getLinkToStandardsOverview() {
+    const {scriptData} = this.props;
+    return scriptData &&
+      scriptData.hasStandards &&
+      scriptData.version_year >= 2020
+      ? `http://curriculum.code.org/csf-${scriptData.version_year.slice(-2)}/${
+          scriptData.family_name
+        }/standards`
+      : null;
+  }
+
   navigateToScript = () => {
     firehoseClient.putRecord(
       {
@@ -63,6 +74,7 @@ class ProgressViewHeader extends Component {
   render() {
     const {currentView, scriptFriendlyName} = this.props;
     const linkToOverview = this.getLinkToOverview();
+    const linkToStandardsOverview = this.getLinkToStandardsOverview();
     const headingText = {
       [ViewType.SUMMARY]: i18n.lessonsAttempted() + ' ',
       [ViewType.DETAIL]: i18n.levelsAttempted() + ' ',
@@ -81,7 +93,10 @@ class ProgressViewHeader extends Component {
           </a>
         </span>
         {currentView === ViewType.STANDARDS && (
-          <StandardsViewHeaderButtons sectionId={this.props.section.id} />
+          <StandardsViewHeaderButtons
+            sectionId={this.props.section.id}
+            linkToStandardsOverview={linkToStandardsOverview}
+          />
         )}
       </div>
     );

--- a/apps/src/templates/sectionProgress/ProgressViewHeader.jsx
+++ b/apps/src/templates/sectionProgress/ProgressViewHeader.jsx
@@ -45,17 +45,6 @@ class ProgressViewHeader extends Component {
     return scriptData ? `${scriptData.path}?section_id=${section.id}` : null;
   }
 
-  getLinkToStandardsOverview() {
-    const {scriptData} = this.props;
-    return scriptData &&
-      scriptData.hasStandards &&
-      scriptData.version_year >= 2020
-      ? `http://curriculum.code.org/csf-${scriptData.version_year.slice(-2)}/${
-          scriptData.family_name
-        }/standards`
-      : null;
-  }
-
   navigateToScript = () => {
     firehoseClient.putRecord(
       {
@@ -74,7 +63,6 @@ class ProgressViewHeader extends Component {
   render() {
     const {currentView, scriptFriendlyName} = this.props;
     const linkToOverview = this.getLinkToOverview();
-    const linkToStandardsOverview = this.getLinkToStandardsOverview();
     const headingText = {
       [ViewType.SUMMARY]: i18n.lessonsAttempted() + ' ',
       [ViewType.DETAIL]: i18n.levelsAttempted() + ' ',
@@ -93,10 +81,7 @@ class ProgressViewHeader extends Component {
           </a>
         </span>
         {currentView === ViewType.STANDARDS && (
-          <StandardsViewHeaderButtons
-            sectionId={this.props.section.id}
-            linkToStandardsOverview={linkToStandardsOverview}
-          />
+          <StandardsViewHeaderButtons sectionId={this.props.section.id} />
         )}
       </div>
     );

--- a/apps/src/templates/sectionProgress/sectionProgressRedux.js
+++ b/apps/src/templates/sectionProgress/sectionProgressRedux.js
@@ -50,7 +50,9 @@ export const addScriptData = (scriptId, scriptData) => {
     hasStandards: scriptData.hasStandards,
     title: scriptData.title,
     path: scriptData.path,
-    stages: scriptData.lessons
+    stages: scriptData.lessons,
+    family_name: scriptData.family_name,
+    version_year: scriptData.version_year
   };
   return {type: ADD_SCRIPT_DATA, scriptId, scriptData: filteredScriptData};
 };
@@ -107,7 +109,9 @@ export const scriptDataPropType = PropTypes.shape({
     PropTypes.shape({
       levels: PropTypes.arrayOf(PropTypes.object).isRequired
     })
-  )
+  ),
+  family_name: PropTypes.string,
+  version_year: PropTypes.string
 });
 
 /**

--- a/apps/src/templates/sectionProgress/standards/CreateStandardsReportDialog.jsx
+++ b/apps/src/templates/sectionProgress/standards/CreateStandardsReportDialog.jsx
@@ -24,7 +24,6 @@ const styles = {
 export class CreateStandardsReportDialog extends Component {
   static propTypes = {
     sectionId: PropTypes.number,
-    linkToStandardsOverview: PropTypes.string,
     isOpen: PropTypes.bool.isRequired,
     handleConfirm: PropTypes.func.isRequired,
     handleNext: PropTypes.func.isRequired,
@@ -73,7 +72,6 @@ export class CreateStandardsReportDialog extends Component {
             handleConfirm={this.handleConfirm}
             onCommentChange={this.props.onCommentChange}
             sectionId={this.props.sectionId}
-            linkToStandardsOverview={this.props.linkToStandardsOverview}
           />
         )}
       </BaseDialog>

--- a/apps/src/templates/sectionProgress/standards/CreateStandardsReportDialog.jsx
+++ b/apps/src/templates/sectionProgress/standards/CreateStandardsReportDialog.jsx
@@ -24,6 +24,7 @@ const styles = {
 export class CreateStandardsReportDialog extends Component {
   static propTypes = {
     sectionId: PropTypes.number,
+    linkToStandardsOverview: PropTypes.string,
     isOpen: PropTypes.bool.isRequired,
     handleConfirm: PropTypes.func.isRequired,
     handleNext: PropTypes.func.isRequired,
@@ -72,6 +73,7 @@ export class CreateStandardsReportDialog extends Component {
             handleConfirm={this.handleConfirm}
             onCommentChange={this.props.onCommentChange}
             sectionId={this.props.sectionId}
+            linkToStandardsOverview={this.props.linkToStandardsOverview}
           />
         )}
       </BaseDialog>

--- a/apps/src/templates/sectionProgress/standards/CreateStandardsReportStep2.jsx
+++ b/apps/src/templates/sectionProgress/standards/CreateStandardsReportStep2.jsx
@@ -25,6 +25,7 @@ const styles = {
 class CreateStandardsReportStep2 extends Component {
   static propTypes = {
     sectionId: PropTypes.number,
+    linkToStandardsOverview: PropTypes.string,
     onBack: PropTypes.func.isRequired,
     handleConfirm: PropTypes.func.isRequired,
     onCommentChange: PropTypes.func.isRequired,
@@ -56,7 +57,19 @@ class CreateStandardsReportStep2 extends Component {
             <SafeMarkdown markdown={i18n.createStandardsReportSuggestion1()} />
           </li>
           <li>
-            <SafeMarkdown markdown={i18n.createStandardsReportSuggestion2()} />
+            {this.props.linkToStandardsOverview && (
+              <SafeMarkdown
+                openExternalLinksInNewTab={true}
+                markdown={i18n.createStandardsReportSuggestion2Link({
+                  standardsOverviewLink: this.props.linkToStandardsOverview
+                })}
+              />
+            )}
+            {!this.props.linkToStandardsOverview && (
+              <SafeMarkdown
+                markdown={i18n.createStandardsReportSuggestion2()}
+              />
+            )}
           </li>
           <li>
             <SafeMarkdown

--- a/apps/src/templates/sectionProgress/standards/CreateStandardsReportStep2.jsx
+++ b/apps/src/templates/sectionProgress/standards/CreateStandardsReportStep2.jsx
@@ -6,6 +6,7 @@ import DialogFooter from '../../teacherDashboard/DialogFooter';
 import SafeMarkdown from '@cdo/apps/templates/SafeMarkdown';
 import {teacherDashboardUrl} from '@cdo/apps/templates/teacherDashboard/urlHelpers';
 import {connect} from 'react-redux';
+import {getCurrentScriptData} from '@cdo/apps/templates/sectionProgress/sectionProgressRedux';
 
 const styles = {
   textArea: {
@@ -25,12 +26,13 @@ const styles = {
 class CreateStandardsReportStep2 extends Component {
   static propTypes = {
     sectionId: PropTypes.number,
-    linkToStandardsOverview: PropTypes.string,
     onBack: PropTypes.func.isRequired,
     handleConfirm: PropTypes.func.isRequired,
     onCommentChange: PropTypes.func.isRequired,
     //redux
-    teacherComment: PropTypes.string
+    teacherComment: PropTypes.string,
+    versionYear: PropTypes.string,
+    familyName: PropTypes.string
   };
 
   commentChanged = event => {
@@ -44,6 +46,8 @@ class CreateStandardsReportStep2 extends Component {
   };
 
   render() {
+    const {versionYear, familyName} = this.props;
+    const showLinkToStandardsOverview = versionYear >= 2020;
     return (
       <div>
         <div style={styles.header}>
@@ -57,15 +61,17 @@ class CreateStandardsReportStep2 extends Component {
             <SafeMarkdown markdown={i18n.createStandardsReportSuggestion1()} />
           </li>
           <li>
-            {this.props.linkToStandardsOverview && (
+            {showLinkToStandardsOverview && (
               <SafeMarkdown
                 openExternalLinksInNewTab={true}
                 markdown={i18n.createStandardsReportSuggestion2Link({
-                  standardsOverviewLink: this.props.linkToStandardsOverview
+                  standardsOverviewLink: `http://curriculum.code.org/csf-${versionYear.slice(
+                    -2
+                  )}/${familyName}/standards`
                 })}
               />
             )}
-            {!this.props.linkToStandardsOverview && (
+            {!showLinkToStandardsOverview && (
               <SafeMarkdown
                 markdown={i18n.createStandardsReportSuggestion2()}
               />
@@ -115,5 +121,7 @@ class CreateStandardsReportStep2 extends Component {
 export const UnconnectedCreateStandardsReportStep2 = CreateStandardsReportStep2;
 
 export default connect(state => ({
-  teacherComment: state.sectionStandardsProgress.teacherComment
+  teacherComment: state.sectionStandardsProgress.teacherComment,
+  versionYear: getCurrentScriptData(state).version_year,
+  familyName: getCurrentScriptData(state).family_name
 }))(CreateStandardsReportStep2);

--- a/apps/src/templates/sectionProgress/standards/StandardsViewHeaderButtons.jsx
+++ b/apps/src/templates/sectionProgress/standards/StandardsViewHeaderButtons.jsx
@@ -29,6 +29,7 @@ const styles = {
 class StandardsViewHeaderButtons extends Component {
   static propTypes = {
     sectionId: PropTypes.number,
+    linkToStandardsOverview: PropTypes.string,
     // redux
     setTeacherCommentForReport: PropTypes.func.isRequired,
     scriptId: PropTypes.number,
@@ -194,6 +195,7 @@ class StandardsViewHeaderButtons extends Component {
           handleClose={this.closeCreateReportDialog}
           onCommentChange={this.onCommentChange}
           sectionId={this.props.sectionId}
+          linkToStandardsOverview={this.props.linkToStandardsOverview}
         />
       </div>
     );

--- a/apps/src/templates/sectionProgress/standards/StandardsViewHeaderButtons.jsx
+++ b/apps/src/templates/sectionProgress/standards/StandardsViewHeaderButtons.jsx
@@ -29,7 +29,6 @@ const styles = {
 class StandardsViewHeaderButtons extends Component {
   static propTypes = {
     sectionId: PropTypes.number,
-    linkToStandardsOverview: PropTypes.string,
     // redux
     setTeacherCommentForReport: PropTypes.func.isRequired,
     scriptId: PropTypes.number,
@@ -195,7 +194,6 @@ class StandardsViewHeaderButtons extends Component {
           handleClose={this.closeCreateReportDialog}
           onCommentChange={this.onCommentChange}
           sectionId={this.props.sectionId}
-          linkToStandardsOverview={this.props.linkToStandardsOverview}
         />
       </div>
     );

--- a/apps/test/unit/templates/sectionProgress/ProgressViewHeaderTest.jsx
+++ b/apps/test/unit/templates/sectionProgress/ProgressViewHeaderTest.jsx
@@ -21,7 +21,9 @@ describe('ProgressViewHeader', () => {
       excludeCsfColumnInLegend: true,
       title: 'CSD Unit 1 - Problem Solving and Computing (19-20)',
       path: '//localhost-studio.code.org:3000/s/csd1-2019',
-      stages: []
+      stages: [],
+      version_year: '2019',
+      family_name: 'csd-1'
     },
     scriptFriendlyName: "CSD Unit 1 - Problem Solving and Computing ('19-'20)"
   };

--- a/apps/test/unit/templates/sectionProgress/sectionProgressReduxTest.js
+++ b/apps/test/unit/templates/sectionProgress/sectionProgressReduxTest.js
@@ -42,7 +42,9 @@ const fakeScriptData789 = {
   hasStandards: false,
   title: 'Title 789',
   path: '/',
-  lessons: [{id: 1, levels: []}, {id: 2, levels: []}]
+  lessons: [{id: 1, levels: []}, {id: 2, levels: []}],
+  family_name: 'fakeScript789',
+  version_year: 2020
 };
 
 const fakeScriptData456 = {
@@ -51,7 +53,9 @@ const fakeScriptData456 = {
   hasStandards: false,
   title: 'Title 456',
   path: '/',
-  lessons: [{id: 3, levels: []}, {id: 4, levels: []}]
+  lessons: [{id: 3, levels: []}, {id: 4, levels: []}],
+  family_name: 'fakeScript456',
+  version_year: 2020
 };
 
 const fakeStudentProgress = {


### PR DESCRIPTION
[LP-1250](https://codedotorg.atlassian.net/browse/LP-1250)
[spec](https://docs.google.com/document/d/1QdziEl6bcKBcdfqgqzZ3xQrWxTdR6U9ked307eb55Bc/edit)

For CSF courses for the 20-21 school year we added additional explanatory information about how teachers can use our content to meet cross-curricular standards to the standards overview pages on Curriculum Builder. 
<img width="1179" alt="Screen Shot 2020-06-25 at 11 54 16 AM" src="https://user-images.githubusercontent.com/12300669/85754303-f2272980-b6da-11ea-9338-8abad0a18ff4.png">

As a continuation to that work on the Code Studio side, we now link to the standards overview page on Curriculum Builder from the Create Standards Report dialog for version years 2020+. 

CSF version years before 2020 remain unchanged: 
<img width="1040" alt="Screen Shot 2020-06-25 at 10 56 30 AM" src="https://user-images.githubusercontent.com/12300669/85754316-f5bab080-b6da-11ea-943b-aad69d7cc12e.png">

CSF version years 2020 and beyond will link to the the standards overview page: 
![standards-link](https://user-images.githubusercontent.com/12300669/85754328-f7847400-b6da-11ea-860b-8e45e3f3b86d.gif)

