### PR TITLE
Disables block highlighting when the user edits running code

### DIFF
--- a/apps/src/StudioApp.js
+++ b/apps/src/StudioApp.js
@@ -564,6 +564,7 @@ StudioApp.prototype.init = function(config) {
           React.createElement('div', {}, msg.editDuringRunMessage()),
           true
         );
+        this.clearHighlighting();
       }
     });
   }
@@ -1561,7 +1562,7 @@ StudioApp.prototype.resizeToolboxHeader = function() {
  * @param {boolean} spotlight Optional.  Highlight entire block if true
  */
 StudioApp.prototype.highlight = function(id, spotlight) {
-  if (this.isUsingBlockly()) {
+  if (this.isUsingBlockly() && this.editDuringRunAlert === undefined) {
     if (id) {
       var m = id.match(/^block_id_(\d+)$/);
       if (m) {


### PR DESCRIPTION
This disables block highlighting due to executing code when the user edits running code. If the user is stepping through their code or the code is being highlighted as its run and the user edits their code, this clears highlighting while preventing future highlight due to run. Highlighting due to clicking on blocks is still allowed. 

Note that in this branch, you can get block highlighting due to stepping through code back after an edit while code is running in Droplet labs by continuing to advance the debugger. The debug buttons will be disabled in this scenario by [this PR](https://github.com/code-dot-org/code-dot-org/pull/35393)

## Links

- [spec](https://docs.google.com/document/d/1oCqZcRYf_RuIIY7q-CccOvHLjyykVKF2ktsjotgOD7I/edit#heading=h.iydiy1mm8pyc)
- [jira](https://codedotorg.atlassian.net/browse/STAR-1099)
- [PR this is branching off of](https://github.com/code-dot-org/code-dot-org/pull/35351)


## Testing story


# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked

