### PR TITLE
CRv2: Re-download Pardot prospects

### DIFF
--- a/dashboard/app/models/contact_rollups_pardot_memory.rb
+++ b/dashboard/app/models/contact_rollups_pardot_memory.rb
@@ -105,6 +105,9 @@ class ContactRollupsPardotMemory < ApplicationRecord
   end
 
   def self.download_deleted_pardot_prospects(last_id = nil, limit = nil)
+    # Find emails that have been deleted in Pardot and mark them as such in our db.
+    # Don't need to download prospect data because Pardot data is derived from our
+    # production data. We have the source of truth to recreate those contacts if needed.
     PardotV2.retrieve_prospects(last_id, %w(id email), limit, true) do |deleted_prospects|
       current_time = Time.now.utc
       batch = deleted_prospects.map do |item|

--- a/dashboard/app/models/contact_rollups_pardot_memory.rb
+++ b/dashboard/app/models/contact_rollups_pardot_memory.rb
@@ -24,6 +24,29 @@
 require 'cdo/contact_rollups/v2/pardot'
 
 class ContactRollupsPardotMemory < ApplicationRecord
+  # All Pardot prospect fields we care about, used to sync
+  # contacts between the production database and Pardot.
+  # db_* are custom fields and sorted alphabetically.
+  # @see https://pi.pardot.com/prospectFieldCustom
+  PARDOT_FIELDS = %w(
+    id
+    email
+    opted_out
+    db_City
+    db_Country
+    db_Form_Roles
+    db_Forms_Submitted
+    db_Has_Teacher_Account
+    db_Hour_of_Code_Organizer
+    db_Imported
+    db_Opt_In
+    db_Postal_Code
+    db_Professional_Learning_Attended
+    db_Professional_Learning_Enrolled
+    db_Roles
+    db_State
+  ).freeze
+
   self.table_name = 'contact_rollups_pardot_memory'
 
   # Downloads and saves new email-Pardot ID mappings from Pardot.
@@ -61,25 +84,7 @@ class ContactRollupsPardotMemory < ApplicationRecord
   def self.download_pardot_prospects(last_id = nil, limit = nil)
     last_id ||= ContactRollupsPardotMemory.maximum(:pardot_id) || 0
 
-    # Note: db_* fields are sorted alphabetically
-    fields = %w(
-      id
-      email
-      db_City
-      db_Country
-      db_Form_Roles
-      db_Forms_Submitted
-      db_Has_Teacher_Account
-      db_Hour_of_Code_Organizer
-      db_Opt_In
-      db_Postal_Code
-      db_Professional_Learning_Attended
-      db_Professional_Learning_Enrolled
-      db_Roles
-      db_State
-    )
-
-    PardotV2.retrieve_prospects(last_id, fields, limit) do |prospects|
+    PardotV2.retrieve_prospects(last_id, PARDOT_FIELDS, limit) do |prospects|
       current_time = Time.now.utc
       batch = prospects.map do |item|
         {

--- a/dashboard/app/models/contact_rollups_pardot_memory.rb
+++ b/dashboard/app/models/contact_rollups_pardot_memory.rb
@@ -38,7 +38,6 @@ class ContactRollupsPardotMemory < ApplicationRecord
     db_Forms_Submitted
     db_Has_Teacher_Account
     db_Hour_of_Code_Organizer
-    db_Imported
     db_Opt_In
     db_Postal_Code
     db_Professional_Learning_Attended


### PR DESCRIPTION
Continuing from the multi-value fix in https://github.com/code-dot-org/code-dot-org/pull/35472, we need to re-download Pardot prospects to the production database. 

The real change is just adding `opted_out` attribute.
The rest of the change creates a constant and  adds a few comments.

## Links
- [Spreadsheet of all Pardot fields we care about](https://docs.google.com/spreadsheets/d/10oKPBVlC5LZee9WiECwd745sX-4EXFALuSIVVwdW5tc/edit#gid=0)
- [All Pardot custom fields](https://pi.pardot.com/prospectFieldCustom)

## Test story
Create a test prospect [crv2_test@domain.com](https://pi.pardot.com/prospect/read/id/82839621) with the following settings
<img width="268" alt="Screen Shot 2020-06-25 at 10 58 06 AM" src="https://user-images.githubusercontent.com/46507039/85773500-c43de700-b6d2-11ea-92ba-966981ca42e9.png">
<img width="361" alt="Screen Shot 2020-06-25 at 10 58 45 AM" src="https://user-images.githubusercontent.com/46507039/85773573-d9b31100-b6d2-11ea-9d1d-401394dd6ae6.png">

Try downloading it to the local db and verify that we get the right data
```ruby
# The test prospect
test_pardot_id = 82839621
test_email = 'crv2_test@domain.com'

# Delete local copy if it exists
ContactRollupsPardotMemory.find_by_email(test_email).delete
# Download the test prospect to the local db
ContactRollupsPardotMemory.download_pardot_prospects(test_pardot_id - 1, 1)

# Verify that prospect data is saved correctly
# Expected values: 
#  "db_Opt_In"=>"Yes", 
#  "db_Roles_0"=>"Facilitator", 
#  "db_Roles_1"=>"Parent", 
#  "db_Roles_2"=>"Student", 
#  "db_Roles_3"=>"Teacher", 
#  "db_Hour_of_Code_Organizer_0"=>"2013",
#  "opted_out"=>"1",
#  "db_Imported"=>"true"
ContactRollupsPardotMemory.find_by_email(test_email)[:data_synced]

# Also try to download the first 2 deleted prospect to make sure this code path is not affected.
ContactRollupsPardotMemory.download_deleted_pardot_prospects(nil, 2)
```
