### PR TITLE
cdo-mysql fix: move get_cname to libraries/proxy

### DIFF
--- a/cookbooks/cdo-mysql/libraries/proxy.rb
+++ b/cookbooks/cdo-mysql/libraries/proxy.rb
@@ -1,0 +1,11 @@
+# Recursively resolve CNAME entries to get the last-resolved domain.
+def get_cname(domain)
+  require 'resolv'
+  Resolv::DNS.open do |dns|
+    loop do
+      domain = dns.getresource(domain, Resolv::DNS::Resource::IN::CNAME)&.name.to_s
+    end
+  end
+rescue Resolv::ResolvError
+  domain
+end

--- a/cookbooks/cdo-mysql/recipes/proxy.rb
+++ b/cookbooks/cdo-mysql/recipes/proxy.rb
@@ -13,18 +13,6 @@ apt_package 'proxysql' do
   action :upgrade
 end
 
-# Recursively resolve CNAME entries to get the last-resolved domain.
-def get_cname(domain)
-  require 'resolv'
-  Resolv::DNS.open do |dns|
-    loop do
-      domain = dns.getresource(domain, Resolv::DNS::Resource::IN::CNAME)&.name.to_s
-    end
-  end
-rescue Resolv::ResolvError
-  domain
-end
-
 writer = URI.parse(node['cdo-secrets']['db_writer'] || 'mysql2://root@localhost/')
 writer.hostname = '127.0.0.1' if writer.hostname == 'localhost'
 reader = URI.parse((node['cdo-secrets']['db_reader'] || writer).to_s)


### PR DESCRIPTION
Followup to #35399. It moves `#get_cname` from recipe to library in order to make it accessible within the `proxy.cnf.erb` template where the call was moved.

## Testing story

This had been tested and verified working previously on an adhoc instance, but I had manually updated the code on the adhoc server I was testing with this small fix and forgot to commit back to the branch. (Oops!)