### PR TITLE
remove family name and version year from most units in CSD/CSP 2020

### DIFF
--- a/dashboard/config/scripts/csd1-2020.script
+++ b/dashboard/config/scripts/csd1-2020.script
@@ -6,8 +6,6 @@ teacher_resources [["lessonPlans", "https://curriculum.code.org/csd-20/unit1"], 
 has_verified_resources true
 has_lesson_plan true
 curriculum_path 'https://curriculum.code.org/csd-20/unit1/{LESSON}'
-family_name 'csd1'
-version_year '2020'
 project_sharing true
 curriculum_umbrella 'CSD'
 

--- a/dashboard/config/scripts/csd2-2020.script
+++ b/dashboard/config/scripts/csd2-2020.script
@@ -6,8 +6,6 @@ teacher_resources [["lessonPlans", "https://curriculum.code.org/csd-20/unit2/"],
 has_verified_resources true
 has_lesson_plan true
 curriculum_path 'https://curriculum.code.org/csd-20/unit2/{LESSON}'
-family_name 'csd2'
-version_year '2020'
 project_sharing true
 curriculum_umbrella 'CSD'
 tts true

--- a/dashboard/config/scripts/csd3-2020.script
+++ b/dashboard/config/scripts/csd3-2020.script
@@ -6,8 +6,6 @@ teacher_resources [["lessonPlans", "https://curriculum.code.org/csd-20/unit3/"],
 has_verified_resources true
 has_lesson_plan true
 curriculum_path 'https://curriculum.code.org/csd-20/unit3/{LESSON}'
-family_name 'csd3'
-version_year '2020'
 project_sharing true
 curriculum_umbrella 'CSD'
 tts true

--- a/dashboard/config/scripts/csd4-2020.script
+++ b/dashboard/config/scripts/csd4-2020.script
@@ -5,8 +5,6 @@ student_detail_progress_view true
 has_verified_resources true
 has_lesson_plan true
 curriculum_path 'https://curriculum.code.org/csd-20/unit4/{LESSON}'
-family_name 'csd4'
-version_year '2020'
 project_sharing true
 curriculum_umbrella 'CSD'
 tts true

--- a/dashboard/config/scripts/csd5-2020.script
+++ b/dashboard/config/scripts/csd5-2020.script
@@ -6,8 +6,6 @@ teacher_resources [["lessonPlans", "https://curriculum.code.org/csd-20/unit5/"],
 has_verified_resources true
 has_lesson_plan true
 curriculum_path 'https://curriculum.code.org/csd-20/unit5/{LESSON}'
-family_name 'csd5'
-version_year '2020'
 project_sharing true
 curriculum_umbrella 'CSD'
 

--- a/dashboard/config/scripts/csp1-2020.script
+++ b/dashboard/config/scripts/csp1-2020.script
@@ -6,8 +6,6 @@ teacher_resources [["lessonPlans", "https://curriculum.code.org/csp-20/unit1/"],
 has_verified_resources true
 has_lesson_plan true
 curriculum_path 'https://curriculum.code.org/{LOCALE}/csp-20/unit1/{LESSON}'
-family_name 'csp1'
-version_year '2020'
 curriculum_umbrella 'CSP'
 
 lesson_group 'csp_unit1_2020', display_name: 'Unit 1: Digital Information'

--- a/dashboard/config/scripts/csp10-2020.script
+++ b/dashboard/config/scripts/csp10-2020.script
@@ -6,7 +6,6 @@ teacher_resources [["lessonPlans", "https://curriculum.code.org/csp-20/unit10/"]
 has_verified_resources true
 has_lesson_plan true
 curriculum_path 'https://curriculum.code.org/{LOCALE}/csp-20/unit10/{LESSON}'
-version_year '2020'
 project_sharing true
 curriculum_umbrella 'CSP'
 

--- a/dashboard/config/scripts/csp2-2020.script
+++ b/dashboard/config/scripts/csp2-2020.script
@@ -6,8 +6,6 @@ teacher_resources [["lessonPlans", "https://curriculum.code.org/csp-20/unit2/"],
 has_verified_resources true
 has_lesson_plan true
 curriculum_path 'https://curriculum.code.org/{LOCALE}/csp-20/unit2/{LESSON}'
-family_name 'csp2'
-version_year '2020'
 project_sharing true
 curriculum_umbrella 'CSP'
 

--- a/dashboard/config/scripts/csp3-2020.script
+++ b/dashboard/config/scripts/csp3-2020.script
@@ -6,8 +6,6 @@ teacher_resources [["lessonPlans", "https://curriculum.code.org/csp-20/unit3/"],
 has_verified_resources true
 has_lesson_plan true
 curriculum_path 'https://curriculum.code.org/{LOCALE}/csp-20/unit3/{LESSON}'
-family_name 'csp3'
-version_year '2020'
 project_sharing true
 curriculum_umbrella 'CSP'
 

--- a/dashboard/config/scripts/csp4-2020.script
+++ b/dashboard/config/scripts/csp4-2020.script
@@ -6,8 +6,6 @@ teacher_resources [["lessonPlans", "https://curriculum.code.org/csp-20/unit4/"],
 has_verified_resources true
 has_lesson_plan true
 curriculum_path 'https://curriculum.code.org/{LOCALE}/csp-20/unit4/{LESSON}'
-family_name 'csp4'
-version_year '2020'
 project_sharing true
 curriculum_umbrella 'CSP'
 

--- a/dashboard/config/scripts/csp5-2020.script
+++ b/dashboard/config/scripts/csp5-2020.script
@@ -6,8 +6,6 @@ teacher_resources [["lessonPlans", "https://curriculum.code.org/csp-20/unit5/"],
 has_verified_resources true
 has_lesson_plan true
 curriculum_path 'https://curriculum.code.org/{LOCALE}/csp-20/unit5/{LESSON}'
-family_name 'csp5'
-version_year '2020'
 project_sharing true
 curriculum_umbrella 'CSP'
 

--- a/dashboard/config/scripts/csp6-2020.script
+++ b/dashboard/config/scripts/csp6-2020.script
@@ -6,7 +6,6 @@ teacher_resources [["lessonPlans", "https://curriculum.code.org/csp-20/unit6/"],
 has_verified_resources true
 has_lesson_plan true
 curriculum_path 'https://curriculum.code.org/{LOCALE}/csp-20/unit6/{LESSON}'
-version_year '2020'
 project_sharing true
 curriculum_umbrella 'CSP'
 

--- a/dashboard/config/scripts/csp7-2020.script
+++ b/dashboard/config/scripts/csp7-2020.script
@@ -6,7 +6,6 @@ teacher_resources [["lessonPlans", "https://curriculum.code.org/csp-20/unit7/"],
 has_verified_resources true
 has_lesson_plan true
 curriculum_path 'https://curriculum.code.org/{LOCALE}/csp-20/unit7/{LESSON}'
-version_year '2020'
 project_sharing true
 curriculum_umbrella 'CSP'
 

--- a/dashboard/config/scripts/csp8-2020.script
+++ b/dashboard/config/scripts/csp8-2020.script
@@ -4,7 +4,6 @@ hideable_lessons true
 student_detail_progress_view true
 has_verified_resources true
 curriculum_path 'https://curriculum.code.org/{LOCALE}/csp-20/unit8/{LESSON}'
-version_year '2020'
 project_sharing true
 curriculum_umbrella 'CSP'
 

--- a/dashboard/config/scripts/csp9-2020.script
+++ b/dashboard/config/scripts/csp9-2020.script
@@ -6,7 +6,6 @@ teacher_resources [["lessonPlans", "https://curriculum.code.org/csp-20/unit9/"],
 has_verified_resources true
 has_lesson_plan true
 curriculum_path 'https://curriculum.code.org/{LOCALE}/csp-20/unit9/{LESSON}'
-version_year '2020'
 project_sharing true
 curriculum_umbrella 'CSP'
 


### PR DESCRIPTION
## Background

Finishes [PLAT-183](https://codedotorg.atlassian.net/browse/PLAT-183). 

The backstory is that we're trying to get rid of links like /s/csp1, which originally pointed to the 2017 version of the unit, but have updated each year via our version redirect logic, and which now point to the 2019 version of the unit. The same thing happens to "deep" links like https://studio.code.org/s/csp1/stage/3/puzzle/4, which get redirected to https://studio.code.org/s/csp1-2019/stage/3/puzzle/4. We still get some traffic to these urls from referers which look like Learning Management Systems (see [gsheet](https://docs.google.com/spreadsheets/d/1ZD_lW4aHRcIu8p1hMKFh5FYIngVECvsggilsXPg6mWc/edit)).

 If we do nothing, these will update to point to 2020 versions on July 1, when those units are marked as `is_stable`. This would be bad, because some of the deep links to past CSP puzzles may not even exist in CSP 2020, and if they do, most of them will not contain the same content they pointed to before, most likely breaking the workflow of whoever was linking to them.

As a stopgap measure, the goal of this PR is to make it so that links like /s/csp1/ continue to point to the corresponding 2019 unit, not the 2020 unit.

## Description

Removes `family_name` and `version_year` from all units in CSP 2020 and CSD 2020 units, except CSD Unit 6. 

We *include* most CSD units, even though that course isn't changing substantially, because we want to deprecate these urls, so the first step is to stop making them go to the latest version of the course, without breaking existing links to them.

We *exclude* CSD unit 6, because we need the redirect for this one unit to point to the latest, because we rely on it to do so here:
* https://code.org/circuitplayground
* https://github.com/code-dot-org/code-dot-org/blob/d2392f9b72e075a388e7d3290339b3262bfb9af8/pegasus/sites.v3/code.org/public/circuitplayground.md#L15

We *exclude* CSF units, because those need to keep sending people to the latest version of each CSF course.

## Future work

In the future, if we want to get rid of this version redirect logic on CSD Unit 6, we could change code.org/circuitplayground to behave more like https://studio.code.org/maker/setup, which links to the latest version of the CSD course, and then instructs the user to click through to the maker unit: https://github.com/code-dot-org/code-dot-org/blob/48a5dd9cbdd8a7e3f5cbf426c782d4b15242fa56/dashboard/app/views/maker/setup.html.haml#L25-L24

## Testing story

Manually verified locally as follows:
* updated csp1-2020 and csp7-2020 to be `is_stable`
* ran `rake seed:scripts`
* verified is_stable, version_year, and family_name are set correctly on those 2 scripts in the DB
* verified /s/**csp1** still redirects to /s/**csp1-2019**
* verified /s/**csp1**/stage/1/puzzle/1 still redirects to /s/**csp1-2019**/stage/1/puzzle/1
* verified /s/**csp7** returns 404 (because it does not exist in CSP 2019 and earlier)

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
