### PR TITLE
CRv2: Process hoc_organizer_years attribute

### DIFF
--- a/dashboard/app/models/contact_rollups_processed.rb
+++ b/dashboard/app/models/contact_rollups_processed.rb
@@ -183,6 +183,22 @@ class ContactRollupsProcessed < ApplicationRecord
     return uniq_courses.blank? ? {} : {professional_learning_attended: uniq_courses}
   end
 
+  def self.extract_hoc_organizer_years(contact_data)
+    kinds = extract_field(contact_data, 'pegasus.forms', 'kind') || []
+    hoc_years = kinds.uniq.map do |kind|
+      if kind == 'CSEdWeekEvent2013'
+        '2013'
+      else
+        # Get year from kind value, such as 'HocSignup2014' and 'HocSignup2019'
+        /HocSignup(?<year>\d{4})/.match(kind)&.[](:year)
+      end
+    end
+
+    # Only care about unique and non-nil value. The result is sorted to keep consistent order.
+    uniq_hoc_years = hoc_years.uniq.compact.sort.join(',')
+    return uniq_hoc_years.blank? ? {} : {hoc_organizer_years: uniq_hoc_years}
+  end
+
   # Extracts values of a field in a source table from contact data.
   #
   # @param contact_data [Hash] compiled data from multiple source tables.

--- a/dashboard/app/models/contact_rollups_processed.rb
+++ b/dashboard/app/models/contact_rollups_processed.rb
@@ -48,11 +48,12 @@ class ContactRollupsProcessed < ApplicationRecord
       end
 
       processed_contact_data = {}
-      processed_contact_data.merge!(extract_opt_in(contact_data))
-      processed_contact_data.merge!(extract_user_id(contact_data))
-      processed_contact_data.merge!(extract_professional_learning_enrolled(contact_data))
-      processed_contact_data.merge!(extract_professional_learning_attended(contact_data))
-      processed_contact_data.merge!(extract_updated_at(contact_data))
+      processed_contact_data.merge! extract_opt_in(contact_data)
+      processed_contact_data.merge! extract_user_id(contact_data)
+      processed_contact_data.merge! extract_professional_learning_enrolled(contact_data)
+      processed_contact_data.merge! extract_professional_learning_attended(contact_data)
+      processed_contact_data.merge! extract_updated_at(contact_data)
+      processed_contact_data.merge! extract_hoc_organizer_years(contact_data)
       batch << {email: contact['email'], data: processed_contact_data}
       next if batch.size < batch_size
 

--- a/dashboard/app/models/contact_rollups_processed.rb
+++ b/dashboard/app/models/contact_rollups_processed.rb
@@ -27,6 +27,7 @@ class ContactRollupsProcessed < ApplicationRecord
 
   # Reverse lookup from section_type to course
   SECTION_TYPE_INVERTED_MAP = Pd::WorkshopConstants::SECTION_TYPE_MAP.invert
+  HOC_YEAR_PATTERN = /HocSignup(?<year>\d{4})/
 
   # Aggregates data from contact_rollups_raw table and saves the results, one row per email.
   # @param batch_size [Integer] number of records to save per INSERT statement.
@@ -191,7 +192,7 @@ class ContactRollupsProcessed < ApplicationRecord
         '2013'
       else
         # Get year from kind value, such as 'HocSignup2014' and 'HocSignup2019'
-        /HocSignup(?<year>\d{4})/.match(kind)&.[](:year)
+        HOC_YEAR_PATTERN.match(kind)&.[](:year)
       end
     end
 

--- a/dashboard/test/models/contact_rollups_pardot_memory_test.rb
+++ b/dashboard/test/models/contact_rollups_pardot_memory_test.rb
@@ -121,6 +121,7 @@ class ContactRollupsPardotMemoryTest < ActiveSupport::TestCase
         'user_id' => 111,
         'professional_learning_enrolled' => "#{COURSE_CSD},#{COURSE_CSF}",
         'professional_learning_attended' => COURSE_CSF,
+        'hoc_organizer_years' => '2019',
       }
     refute ContactRollupsPardotMemory.find_by_email(contact.email)
     PardotV2.expects(:submit_batch_request).once.returns([])
@@ -133,7 +134,8 @@ class ContactRollupsPardotMemoryTest < ActiveSupport::TestCase
       'db_Has_Teacher_Account' => 'true',
       'db_Professional_Learning_Enrolled_0' => COURSE_CSD,
       'db_Professional_Learning_Enrolled_1' => COURSE_CSF,
-      'db_Professional_Learning_Attended_0' => COURSE_CSF
+      'db_Professional_Learning_Attended_0' => COURSE_CSF,
+      'db_Hour_of_Code_Organizer_0' => '2019',
     }
     assert_equal expected_data_synced, record[:data_synced]
   end

--- a/dashboard/test/models/contact_rollups_processed_test.rb
+++ b/dashboard/test/models/contact_rollups_processed_test.rb
@@ -64,6 +64,8 @@ class ContactRollupsProcessedTest < ActiveSupport::TestCase
       once.returns({})
     ContactRollupsProcessed.expects(:extract_professional_learning_attended).
       once.returns({})
+    ContactRollupsProcessed.expects(:extract_hoc_organizer_years).
+      once.returns({})
     ContactRollupsProcessed.expects(:extract_updated_at).
       once.returns({})
 
@@ -183,6 +185,28 @@ class ContactRollupsProcessedTest < ActiveSupport::TestCase
       output = ContactRollupsProcessed.extract_professional_learning_attended test[:input]
       assert_equal test[:expected_output], output, "Test index #{index} failed"
     end
+  end
+
+  test 'extract_hoc_organizer_years' do
+    contact_data = {
+      'pegasus.forms' => {
+        'kind' => [
+          # most common value type 'HocSignup<year>'
+          {'value' => 'HocSignup2019'},
+          # duplicate values
+          {'value' => 'CSEdWeekEvent2013'},
+          {'value' => 'CSEdWeekEvent2013'},
+          # invalid values
+          {'value' => nil},
+          {'value' => 'HocSignup'},
+          {'value' => 'HocCensus2017'}
+        ]
+      }
+    }
+    expected_output = {hoc_organizer_years: '2013,2019'}
+
+    output = ContactRollupsProcessed.extract_hoc_organizer_years(contact_data)
+    assert_equal expected_output, output
   end
 
   test 'extract_updated_at with valid input' do

--- a/lib/test/cdo/contact_rollups/test_pardot_v2.rb
+++ b/lib/test/cdo/contact_rollups/test_pardot_v2.rb
@@ -228,10 +228,12 @@ class PardotV2Test < Minitest::Test
         input: {
           professional_learning_enrolled: COURSE_CSF,
           professional_learning_attended: COURSE_CSF,
+          hoc_organizer_years: '2019',
         },
         expected_output: {
           db_Professional_Learning_Enrolled_0: COURSE_CSF,
           db_Professional_Learning_Attended_0: COURSE_CSF,
+          db_Hour_of_Code_Organizer_0: '2019'
         }
       },
       {
@@ -239,12 +241,15 @@ class PardotV2Test < Minitest::Test
         input: {
           professional_learning_enrolled: "#{COURSE_CSD},#{COURSE_CSF}",
           professional_learning_attended: "#{COURSE_CSP},#{COURSE_ECS}",
+          hoc_organizer_years: '2018,2019',
         },
         expected_output: {
           db_Professional_Learning_Enrolled_0: COURSE_CSD,
           db_Professional_Learning_Enrolled_1: COURSE_CSF,
           db_Professional_Learning_Attended_0: COURSE_CSP,
           db_Professional_Learning_Attended_1: COURSE_ECS,
+          db_Hour_of_Code_Organizer_0: '2018',
+          db_Hour_of_Code_Organizer_1: '2019',
         }
       }
     ]


### PR DESCRIPTION
[PLC-918](https://codedotorg.atlassian.net/browse/PLC-918): Use contact's `hoc_organizer_years` to set Pardot prospect's `db_Hour_of_Code_Organizer`. 
* Contact's `hoc_organizer_years` value is deducted from `pegasus.forms#kind`.
* Prospect's [db_Hour_of_Code_Organizer](https://pi.pardot.com/prospectFieldCustom/read/id/6731) is a multi-value/multi-select attribute.

## Links
[Speadsheet with all attributes to process](https://docs.google.com/spreadsheets/d/10oKPBVlC5LZee9WiECwd745sX-4EXFALuSIVVwdW5tc/edit#gid=0).

## Test story
Test on an adhoc with connection to a production-cloned db
  ```ruby
  @limit = 100
  cr = ContactRollupsV2.new(is_dry_run: true, limit_extraction: @limit);

  # clean up existing tables
  cr.truncate_or_delete_table ContactRollupsRaw
  cr.truncate_or_delete_table ContactRollupsProcessed

  # extract only data used by this PR
  ContactRollupsRaw.extract_pegasus_forms(@limit)

  # dry run. Verify the sample queries sent to Pardot
  cr.process_contacts
  cr.sync_updated_contacts_with_pardot
  cr.sync_new_contacts_with_pardot
  cr.report_results

  # Verify content in ContactRollupsProcessed, ContactRollupsPardotMemory
  ```
