### PR TITLE
Update CSP course length description on Course Explorer

### DIFF
--- a/shared/haml/course_explorer_table.haml
+++ b/shared/haml/course_explorer_table.haml
@@ -62,7 +62,7 @@
     description: "Computer Science Principles covers many topics including the Internet, Big Data and Privacy, and Programming and Algorithms. The curriculum is flexible to be taught as an AP or non-AP course.
       <ul>
         <li> <strong>Audience:</strong> High school students, grades 9 - 12</li>
-        <li> <strong>Curriculum length:</strong> 100-180 hours, should be taught as a full-year course. Includes five units, two AP prep units, and a Post-AP unit.</li>
+        <li> <strong>Curriculum length:</strong> 100-180 hours, should be taught as a full-year course. Contains 10 units, including a Create Performance Task prep unit.</li>
         <li> <strong>Prior knowledge:</strong> None! Just bring your curiosity.</li>
         <li> <strong>Optional <a href='#{csp_pl_link}'>professional learning</a>:</strong> Our year-long program includes a 1-week summer workshop, 24 hours' worth of follow up workshops during the academic year, and online support through the Code.org teacher forum.</li>
         <li> <strong>Cost to use curriculum:</strong> None</li>


### PR DESCRIPTION
As requested in [slack](https://codedotorg.slack.com/archives/C0T10H26N/p1593117868499400), update the curriculum length description for CSP to an up to date description. The description now looks like (only the second sentence of the curriculum length bullet point has changed):
![Screen Shot 2020-06-25 at 2 51 29 PM](https://user-images.githubusercontent.com/33666587/85799023-68d02100-b6f3-11ea-8f06-28c6a4b832de.png)

<!-- ### Background -->
<!-- ### Privacy -->
<!-- ### Security -->
<!-- ### Caching -->
<!-- ### Deployment strategy -->
<!-- ### Future work -->


## Testing story
Validated manually

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
