### PR TITLE
CRv2: Process form_roles attribute

### DIFF
--- a/dashboard/app/models/contact_rollups_processed.rb
+++ b/dashboard/app/models/contact_rollups_processed.rb
@@ -25,9 +25,12 @@ class ContactRollupsProcessed < ApplicationRecord
   DATA_KEY = 'd'.freeze
   DATA_UPDATED_AT_KEY = 'u'.freeze
 
+  # Constants used to speed up attribute processing:
   # Reverse lookup from section_type to course
   SECTION_TYPE_INVERTED_MAP = Pd::WorkshopConstants::SECTION_TYPE_MAP.invert
   HOC_YEAR_PATTERN = /HocSignup(?<year>\d{4})/
+  # Allow only certain pegasus form roles since they are user-generated data
+  ALLOWED_FORM_ROLES = %w(administrator educator engineer other parent student teacher volunteer).to_set
 
   # Aggregates data from contact_rollups_raw table and saves the results, one row per email.
   # @param batch_size [Integer] number of records to save per INSERT statement.
@@ -55,6 +58,7 @@ class ContactRollupsProcessed < ApplicationRecord
       processed_contact_data.merge! extract_professional_learning_attended(contact_data)
       processed_contact_data.merge! extract_hoc_organizer_years(contact_data)
       processed_contact_data.merge! extract_forms_submitted(contact_data)
+      processed_contact_data.merge! extract_form_roles(contact_data)
       processed_contact_data.merge! extract_updated_at(contact_data)
       batch << {email: contact['email'], data: processed_contact_data}
       next if batch.size < batch_size
@@ -208,6 +212,22 @@ class ContactRollupsProcessed < ApplicationRecord
 
     uniq_kinds = kinds.uniq.compact.sort.join(',')
     uniq_kinds.blank? ? {} : {forms_submitted: uniq_kinds}
+  end
+
+  def self.extract_form_roles(contact_data)
+    # @see Census::CensusSubmission::ROLES for submitter_role values
+    census_roles = extract_field(contact_data, 'dashboard.census_submissions', 'submitter_role') || []
+    cleaned_census_roles = census_roles.compact.map(&:downcase)
+
+    # pegasus form roles are user-generated data, use an allowed list to filter them
+    pegasus_roles = extract_field(contact_data, 'pegasus.forms', 'role') || []
+    cleaned_pegasus_roles = pegasus_roles.
+      compact.
+      map(&:downcase).
+      select {|role| ALLOWED_FORM_ROLES.include? role}
+
+    uniq_form_roles = (cleaned_census_roles + cleaned_pegasus_roles).uniq.sort.join(',')
+    return uniq_form_roles.blank? ? {} : {form_roles: uniq_form_roles}
   end
 
   # Extracts values of a field in a source table from contact data.

--- a/dashboard/test/models/contact_rollups_pardot_memory_test.rb
+++ b/dashboard/test/models/contact_rollups_pardot_memory_test.rb
@@ -123,6 +123,7 @@ class ContactRollupsPardotMemoryTest < ActiveSupport::TestCase
         'professional_learning_attended' => COURSE_CSF,
         'hoc_organizer_years' => '2019',
         'forms_submitted' => 'Census,Petition',
+        'form_roles' => 'engineer,teacher',
       }
     refute ContactRollupsPardotMemory.find_by_email(contact.email)
     PardotV2.expects(:submit_batch_request).once.returns([])
@@ -138,6 +139,7 @@ class ContactRollupsPardotMemoryTest < ActiveSupport::TestCase
       'db_Professional_Learning_Attended_0' => COURSE_CSF,
       'db_Hour_of_Code_Organizer_0' => '2019',
       'db_Forms_Submitted' => 'Census,Petition',
+      'db_Form_Roles' => 'engineer,teacher',
     }
     assert_equal expected_data_synced, record[:data_synced]
   end

--- a/dashboard/test/models/contact_rollups_processed_test.rb
+++ b/dashboard/test/models/contact_rollups_processed_test.rb
@@ -68,6 +68,8 @@ class ContactRollupsProcessedTest < ActiveSupport::TestCase
       once.returns({})
     ContactRollupsProcessed.expects(:extract_forms_submitted).
       once.returns({})
+    ContactRollupsProcessed.expects(:extract_form_roles).
+      once.returns({})
     ContactRollupsProcessed.expects(:extract_updated_at).
       once.returns({})
 
@@ -251,6 +253,31 @@ class ContactRollupsProcessedTest < ActiveSupport::TestCase
       output = ContactRollupsProcessed.extract_updated_at(test[:input])
       assert_equal test[:expected_output], output, "Test index #{index} failed"
     end
+  end
+
+  test 'extract_form_roles' do
+    contact_data = {
+      'dashboard.census_submissions' => {
+        'submitter_role' => [
+          {'value' => Census::CensusSubmission::ROLES[:teacher]},
+          {'value' => Census::CensusSubmission::ROLES[:parent]},
+          {'value' => nil}
+        ]
+      },
+      'pegasus.forms' => {
+        'role' => [
+          {'value' => 'Teacher'},
+          {'value' => 'educator'},
+          {'value' => 'not_valid_role'},
+          {'value' => ''},
+          {'value' => nil}
+        ]
+      }
+    }
+    expected_output = {form_roles: 'educator,parent,teacher'}
+
+    output = ContactRollupsProcessed.extract_form_roles contact_data
+    assert_equal expected_output, output
   end
 
   test 'extract_updated_at with invalid input' do

--- a/lib/test/cdo/contact_rollups/test_pardot_v2.rb
+++ b/lib/test/cdo/contact_rollups/test_pardot_v2.rb
@@ -202,13 +202,15 @@ class PardotV2Test < Minitest::Test
           opt_in: 1,
           user_id: 111,
           forms_submitted: 'Census,Petition',
+          form_roles: 'engineer,teacher',
         },
         expected_output: {
           email: 'test0@domain.com',
           id: 10,
           db_Opt_In: 'Yes',
           db_Has_Teacher_Account: 'true',
-          db_Forms_Submitted: 'Census,Petition'
+          db_Forms_Submitted: 'Census,Petition',
+          db_Form_Roles: 'engineer,teacher',
         }
       },
       {


### PR DESCRIPTION
[PLC-918](https://codedotorg.atlassian.net/browse/PLC-918): Use contact's `form_roles` to set Pardot prospect's `db_Form_Roles`. 
* Contact's `form_roles` value is combined from `dashboard.census_submissions#submitter_role` and `pegasus.forms#role`.
* Prospect's [db_Form_Roles](https://pi.pardot.com/prospectFieldCustom/read/id/6723) is a text attribute, even though it is a compilation of multiple values. 

## Links
[Speadsheet with all attributes to process](https://docs.google.com/spreadsheets/d/10oKPBVlC5LZee9WiECwd745sX-4EXFALuSIVVwdW5tc/edit#gid=0).

## Test story
Test on an adhoc with connection to a production-cloned db
  ```ruby
  @limit = 100
  cr = ContactRollupsV2.new(is_dry_run: true, limit_extraction: @limit);

  # clean up existing tables
  cr.truncate_or_delete_table ContactRollupsRaw
  cr.truncate_or_delete_table ContactRollupsProcessed

  # extract only data used by this PR
  ContactRollupsRaw.extract_census_submissions(@limit)
  ContactRollupsRaw.extract_pegasus_forms(@limit)

  # dry run. Verify the sample queries sent to Pardot
  cr.process_contacts
  cr.sync_updated_contacts_with_pardot
  cr.sync_new_contacts_with_pardot
  cr.report_results

  # Verify content in ContactRollupsProcessed, ContactRollupsPardotMemory
  ```
