### PR TITLE
CRv2: Process forms_submitted attribute

### DIFF
--- a/dashboard/app/models/contact_rollups_processed.rb
+++ b/dashboard/app/models/contact_rollups_processed.rb
@@ -53,8 +53,9 @@ class ContactRollupsProcessed < ApplicationRecord
       processed_contact_data.merge! extract_user_id(contact_data)
       processed_contact_data.merge! extract_professional_learning_enrolled(contact_data)
       processed_contact_data.merge! extract_professional_learning_attended(contact_data)
-      processed_contact_data.merge! extract_updated_at(contact_data)
       processed_contact_data.merge! extract_hoc_organizer_years(contact_data)
+      processed_contact_data.merge! extract_forms_submitted(contact_data)
+      processed_contact_data.merge! extract_updated_at(contact_data)
       batch << {email: contact['email'], data: processed_contact_data}
       next if batch.size < batch_size
 
@@ -199,6 +200,14 @@ class ContactRollupsProcessed < ApplicationRecord
     # Only care about unique and non-nil value. The result is sorted to keep consistent order.
     uniq_hoc_years = hoc_years.uniq.compact.sort.join(',')
     return uniq_hoc_years.blank? ? {} : {hoc_organizer_years: uniq_hoc_years}
+  end
+
+  def self.extract_forms_submitted(contact_data)
+    kinds = extract_field(contact_data, 'pegasus.forms', 'kind') || []
+    kinds << 'Census' if contact_data.key?('dashboard.census_submissions')
+
+    uniq_kinds = kinds.uniq.compact.sort.join(',')
+    uniq_kinds.blank? ? {} : {forms_submitted: uniq_kinds}
   end
 
   # Extracts values of a field in a source table from contact data.

--- a/dashboard/test/models/contact_rollups_pardot_memory_test.rb
+++ b/dashboard/test/models/contact_rollups_pardot_memory_test.rb
@@ -122,6 +122,7 @@ class ContactRollupsPardotMemoryTest < ActiveSupport::TestCase
         'professional_learning_enrolled' => "#{COURSE_CSD},#{COURSE_CSF}",
         'professional_learning_attended' => COURSE_CSF,
         'hoc_organizer_years' => '2019',
+        'forms_submitted' => 'Census,Petition',
       }
     refute ContactRollupsPardotMemory.find_by_email(contact.email)
     PardotV2.expects(:submit_batch_request).once.returns([])
@@ -136,6 +137,7 @@ class ContactRollupsPardotMemoryTest < ActiveSupport::TestCase
       'db_Professional_Learning_Enrolled_1' => COURSE_CSF,
       'db_Professional_Learning_Attended_0' => COURSE_CSF,
       'db_Hour_of_Code_Organizer_0' => '2019',
+      'db_Forms_Submitted' => 'Census,Petition',
     }
     assert_equal expected_data_synced, record[:data_synced]
   end

--- a/dashboard/test/models/contact_rollups_processed_test.rb
+++ b/dashboard/test/models/contact_rollups_processed_test.rb
@@ -66,6 +66,8 @@ class ContactRollupsProcessedTest < ActiveSupport::TestCase
       once.returns({})
     ContactRollupsProcessed.expects(:extract_hoc_organizer_years).
       once.returns({})
+    ContactRollupsProcessed.expects(:extract_forms_submitted).
+      once.returns({})
     ContactRollupsProcessed.expects(:extract_updated_at).
       once.returns({})
 
@@ -206,6 +208,25 @@ class ContactRollupsProcessedTest < ActiveSupport::TestCase
     expected_output = {hoc_organizer_years: '2013,2019'}
 
     output = ContactRollupsProcessed.extract_hoc_organizer_years(contact_data)
+    assert_equal expected_output, output
+  end
+
+  test 'extract_forms_submitted' do
+    contact_data = {
+      'pegasus.forms' => {
+        'kind' => [
+          {'value' => 'VolunteerContact2015'},
+          # user can submit 2 forms of the same kind
+          {'value' => 'Petition'},
+          {'value' => 'Petition'},
+          {'value' => nil},
+        ]
+      },
+      'dashboard.census_submissions' => {}
+    }
+    expected_output = {forms_submitted: 'Census,Petition,VolunteerContact2015'}
+
+    output = ContactRollupsProcessed.extract_forms_submitted contact_data
     assert_equal expected_output, output
   end
 

--- a/lib/test/cdo/contact_rollups/test_pardot_v2.rb
+++ b/lib/test/cdo/contact_rollups/test_pardot_v2.rb
@@ -200,13 +200,15 @@ class PardotV2Test < Minitest::Test
           email: 'test0@domain.com',
           pardot_id: 10,
           opt_in: 1,
-          user_id: 111
+          user_id: 111,
+          forms_submitted: 'Census,Petition',
         },
         expected_output: {
           email: 'test0@domain.com',
           id: 10,
           db_Opt_In: 'Yes',
-          db_Has_Teacher_Account: 'true'
+          db_Has_Teacher_Account: 'true',
+          db_Forms_Submitted: 'Census,Petition'
         }
       },
       {


### PR DESCRIPTION
[PLC-918](https://codedotorg.atlassian.net/browse/PLC-918): Use contact's `forms_submitted` to set Pardot prospect's `db_Forms_Submitted`. 
* Contact's `form_submitted` value is combined from `pegasus.forms#kind` and `dashboard.census_submissions` (Census kind).
* Prospect's [db_Forms_Submitted](https://pi.pardot.com/prospectFieldCustom/read/id/6725) is a text attribute, even though it is a compilation of multiple values. 

## Links
[Speadsheet with all attributes to process](https://docs.google.com/spreadsheets/d/10oKPBVlC5LZee9WiECwd745sX-4EXFALuSIVVwdW5tc/edit#gid=0).

## Test story
Test on an adhoc with connection to a production-cloned db
  ```ruby
  @limit = 100
  cr = ContactRollupsV2.new(is_dry_run: true, limit_extraction: @limit);

  # clean up existing tables
  cr.truncate_or_delete_table ContactRollupsRaw
  cr.truncate_or_delete_table ContactRollupsProcessed

  # extract only data used by this PR
  ContactRollupsRaw.extract_pegasus_forms(@limit)
  ContactRollupsRaw.extract_census_submissions(@limit)

  # dry run. Verify the sample queries sent to Pardot
  cr.process_contacts
  cr.sync_updated_contacts_with_pardot
  cr.sync_new_contacts_with_pardot
  cr.report_results

  # Verify content in ContactRollupsProcessed, ContactRollupsPardotMemory
  ```
