### PR TITLE
AFE: Styling updates

### DIFF
--- a/apps/src/templates/amazonFutureEngineerEligibility/amazonFutureEngineerAccountConfirmation.jsx
+++ b/apps/src/templates/amazonFutureEngineerEligibility/amazonFutureEngineerAccountConfirmation.jsx
@@ -2,6 +2,14 @@ import firehoseClient from '@cdo/apps/lib/util/firehose';
 import React from 'react';
 import {Button} from 'react-bootstrap';
 import {studio, pegasus} from '@cdo/apps/lib/util/urlHelpers';
+import color from '@cdo/apps/util/color';
+
+const styles = {
+  button: {
+    backgroundColor: color.orange,
+    color: color.white
+  }
+};
 
 export default class AmazonFutureEngineerAccountConfirmation extends React.Component {
   returnToURL = relativeDashboardPath => {
@@ -36,7 +44,8 @@ export default class AmazonFutureEngineerAccountConfirmation extends React.Compo
         </div>
         <Button
           id="sign_up"
-          href={this.returnToURL('/users/sign_up')}
+          href={this.returnToURL('/users/sign_in')}
+          style={styles.button}
           onClick={this.logSignUpButtonPress}
         >
           Sign up

--- a/apps/src/templates/amazonFutureEngineerEligibility/amazonFutureEngineerAccountConfirmation.jsx
+++ b/apps/src/templates/amazonFutureEngineerEligibility/amazonFutureEngineerAccountConfirmation.jsx
@@ -8,6 +8,13 @@ const styles = {
   button: {
     backgroundColor: color.orange,
     color: color.white
+  },
+  header: {
+    marginTop: '10px',
+    marginBottom: '10px'
+  },
+  body: {
+    marginBottom: '10px'
   }
 };
 
@@ -31,14 +38,14 @@ export default class AmazonFutureEngineerAccountConfirmation extends React.Compo
     // at which point we'll send an API request to Amazon's Pardot API endpoint.
     return (
       <div>
-        <h2>Almost done!</h2>
-        <div>
+        <h2 style={styles.header}>Almost done!</h2>
+        <div style={styles.body}>
           Thank you for completing your application information for the Amazon
           Future Engineer program. To finalize your participation and start
           receiving benefits, sign up for a Code.org account, or sign in if you
           already have one.
         </div>
-        <div>
+        <div style={styles.body}>
           Already have a Code.org account?{' '}
           <a href={this.returnToURL('/users/sign_in')}>Sign in.</a>
         </div>

--- a/apps/src/templates/amazonFutureEngineerEligibility/amazonFutureEngineerEligibility.jsx
+++ b/apps/src/templates/amazonFutureEngineerEligibility/amazonFutureEngineerEligibility.jsx
@@ -3,6 +3,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import {FormGroup, Button} from 'react-bootstrap';
 import FieldGroup from '../../code-studio/pd/form_components/FieldGroup';
+import color from '@cdo/apps/util/color';
 import SchoolAutocompleteDropdownWithLabel from '@cdo/apps/templates/census2017/SchoolAutocompleteDropdownWithLabel';
 import AmazonFutureEngineerEligibilityForm from './amazonFutureEngineerEligibilityForm';
 import AmazonFutureEngineerAccountConfirmation from './amazonFutureEngineerAccountConfirmation';
@@ -12,6 +13,10 @@ import {isEmail} from '@cdo/apps/util/formatValidation';
 const styles = {
   intro: {
     paddingBottom: 10
+  },
+  button: {
+    backgroundColor: color.orange,
+    color: color.white
   }
 };
 
@@ -258,7 +263,11 @@ export default class AmazonFutureEngineerEligibility extends React.Component {
                 value={formData.schoolId}
                 showErrorMsg={this.state.errors.hasOwnProperty('schoolId')}
               />
-              <Button id="submit" onClick={this.handleClickCheckEligibility}>
+              <Button
+                id="submit"
+                onClick={this.handleClickCheckEligibility}
+                style={styles.button}
+              >
                 Find out if I'm eligible
               </Button>
             </FormGroup>

--- a/apps/src/templates/amazonFutureEngineerEligibility/amazonFutureEngineerEligibility.jsx
+++ b/apps/src/templates/amazonFutureEngineerEligibility/amazonFutureEngineerEligibility.jsx
@@ -14,9 +14,18 @@ const styles = {
   intro: {
     paddingBottom: 10
   },
+  container: {
+    borderColor: color.teal,
+    borderWidth: 'thin',
+    borderStyle: 'solid',
+    padding: '10px 15px 10px 15px'
+  },
   button: {
     backgroundColor: color.orange,
     color: color.white
+  },
+  header: {
+    marginTop: '10px'
   }
 };
 
@@ -233,10 +242,10 @@ export default class AmazonFutureEngineerEligibility extends React.Component {
     let {formData} = this.state;
 
     return (
-      <div>
+      <div style={styles.container}>
         {formData.schoolEligible === null && (
           <div>
-            <h2>Am I eligible?</h2>
+            <h2 style={styles.header}>Am I eligible?</h2>
             <FormGroup id="amazon-future-engineer-eligiblity-intro">
               <div style={styles.intro}>
                 Enter your teacher email address and select your school below to
@@ -262,6 +271,7 @@ export default class AmazonFutureEngineerEligibility extends React.Component {
                 showRequiredIndicator={true}
                 value={formData.schoolId}
                 showErrorMsg={this.state.errors.hasOwnProperty('schoolId')}
+                style={styles.schoolInput}
               />
               <Button
                 id="submit"

--- a/apps/src/templates/amazonFutureEngineerEligibility/amazonFutureEngineerEligibilityForm.jsx
+++ b/apps/src/templates/amazonFutureEngineerEligibility/amazonFutureEngineerEligibilityForm.jsx
@@ -21,6 +21,10 @@ const styles = {
   },
   consentIndent: {
     marginLeft: '25px'
+  },
+  button: {
+    backgroundColor: color.orange,
+    color: color.white
   }
 };
 
@@ -282,7 +286,7 @@ export default class AmazonFutureEngineerEligibilityForm extends React.Component
             always have the choice to adjust your interest settings or
             unsubscribe.
           </div>
-          <Button id="continue" onClick={this.onContinue}>
+          <Button id="continue" onClick={this.onContinue} style={styles.button}>
             Continue
           </Button>
         </form>


### PR DESCRIPTION
Makes buttons in AFE flow visible (white text on orange background). Also surrounds entire eligibility form in a blue box to make it more of a call to action (part of the spec I missed) and improves spacing.

Also uses https://studio.code.org/users/sign_in instead of sign_up because the redirect back to the AFE page does not work for some reason (it tries to redirect you back to studio.code.org/afe instead of code.org/afe for reasons I do not understand). You can sign up or sign in from /users/sign_in.

Current views:

![image](https://user-images.githubusercontent.com/25372625/85884781-0715c280-b798-11ea-8514-a8b6923c57cf.png)

![image](https://user-images.githubusercontent.com/25372625/85884892-34fb0700-b798-11ea-8f5f-3a3234c82042.png)

![image](https://user-images.githubusercontent.com/25372625/85885163-c4081f00-b798-11ea-974e-a118a89589aa.png)

## Testing story

Reviewed changes locally.

## Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
