### PR TITLE
Bump blockly to 3.5.24

### DIFF
--- a/apps/package.json
+++ b/apps/package.json
@@ -49,7 +49,7 @@
     "@babel/preset-react": "^7.0.0",
     "@cdo/interpreted": "link:../dashboard/config/libraries",
     "@code-dot-org/artist": "0.2.1",
-    "@code-dot-org/blockly": "3.5.23",
+    "@code-dot-org/blockly": "3.5.24",
     "@code-dot-org/bramble": "0.1.26",
     "@code-dot-org/craft": "0.2.2",
     "@code-dot-org/dance-party": "1.0.1",

--- a/apps/yarn.lock
+++ b/apps/yarn.lock
@@ -1526,10 +1526,10 @@
   version "0.2.1"
   resolved "https://registry.yarnpkg.com/@code-dot-org/artist/-/artist-0.2.1.tgz#fcfe7ea5cfb3f19ddb6b912e70e922ba4b7ef0b1"
 
-"@code-dot-org/blockly@3.5.23":
-  version "3.5.23"
-  resolved "https://registry.yarnpkg.com/@code-dot-org/blockly/-/blockly-3.5.23.tgz#5935ca62404ba0ed8dbbc5c44cd3db9d30c918dc"
-  integrity sha512-zb6yK4vL5uYK18IcrxQk8uRrXxuMSrBTGoNs/89m9BHIAk46knGat1VB4U46OkZdjboMp+rg6kY5mVmbMo00MQ==
+"@code-dot-org/blockly@3.5.24":
+  version "3.5.24"
+  resolved "https://registry.yarnpkg.com/@code-dot-org/blockly/-/blockly-3.5.24.tgz#6527c1a778e566b08371a8f8ffa5b1babae4a52f"
+  integrity sha512-mNmVVbfkyEzpXNOzX5+gMFn2St9ikHZbTDlYaWYF8KgUsaHy2AZ8pV1t1ocey0pIW7cpZtB9of/VPrbrjxhFkQ==
 
 "@code-dot-org/bramble@0.1.26":
   version "0.1.26"


### PR DESCRIPTION
3.5.24 Includes
- [Make block highlighting more obvious](https://github.com/code-dot-org/blockly/pull/227)
- [Add ESLint and fix ES5 violations](https://github.com/code-dot-org/blockly/pull/230)
- [IE fixes for minitoolbox](https://github.com/code-dot-org/blockly/pull/232)