### PR TITLE
added timeout error handling for azure token request

### DIFF
--- a/dashboard/app/helpers/levels_helper.rb
+++ b/dashboard/app/helpers/levels_helper.rb
@@ -476,8 +476,7 @@ module LevelsHelper
 
   def azure_speech_service_options
     speech_service_options = {}
-
-    if @level.game.use_azure_speech_service? && !CDO.azure_speech_service_region.nil? && !CDO.azure_speech_service_key.nil?
+    if @level.game.use_azure_speech_service? && CDO.azure_speech_service_region.present? && CDO.azure_speech_service_key.present?
       uri = URI.parse("https://#{CDO.azure_speech_service_region}.api.cognitive.microsoft.com/sts/v1.0/issueToken")
       header = {'Ocp-Apim-Subscription-Key': CDO.azure_speech_service_key}
       http = Net::HTTP.new(uri.host, uri.port)
@@ -488,7 +487,8 @@ module LevelsHelper
       speech_service_options[:azureSpeechServiceToken] = response.body
       speech_service_options[:azureSpeechServiceRegion] = CDO.azure_speech_service_region
     end
-
+    speech_service_options
+  rescue SocketError, Net::OpenTimeout, Net::ReadTimeout, Errno::ECONNRESET, Errno::ECONNREFUSED, Errno::ENETUNREACH
     speech_service_options
   end
 

--- a/dashboard/app/helpers/levels_helper.rb
+++ b/dashboard/app/helpers/levels_helper.rb
@@ -476,7 +476,7 @@ module LevelsHelper
 
   def azure_speech_service_options
     speech_service_options = {}
-    if @level.game.use_azure_speech_service? && CDO.azure_speech_service_region.present? && CDO.azure_speech_service_key.present?
+    if @level.game.use_azure_speech_service? && !CDO.azure_speech_service_region.nil? && !CDO.azure_speech_service_key.nil?
       uri = URI.parse("https://#{CDO.azure_speech_service_region}.api.cognitive.microsoft.com/sts/v1.0/issueToken")
       header = {'Ocp-Apim-Subscription-Key': CDO.azure_speech_service_key}
       http = Net::HTTP.new(uri.host, uri.port)


### PR DESCRIPTION
This is part of the text to speech block backend that was merged as part of [this PR](https://github.com/code-dot-org/code-dot-org/pull/35328). Occasionally, there were errors on honeybadger due to the http request to azure timing out. This adds error handling for that case.

## Links


- [spec](https://docs.google.com/document/d/1EUVGzgSFprrwp9A_fEceidL3bhkTP12kxvEA_SfFSm0/edit)
- [original PR](https://github.com/code-dot-org/code-dot-org/pull/35328)

## Testing story


# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
