### PR TITLE
clone bubble choice sublevels

### DIFF
--- a/dashboard/app/dsl/bubble_choice_dsl.rb
+++ b/dashboard/app/dsl/bubble_choice_dsl.rb
@@ -36,4 +36,23 @@ class BubbleChoiceDSL < ContentDSL
   def self.parse_file(filename)
     super(filename, File.basename(filename, '.bubble_choice'))
   end
+
+  def self.serialize(level)
+    new_dsl = "name '#{escape(level.name)}'"
+    new_dsl += "\neditor_experiment '#{level.editor_experiment}'" if level.editor_experiment.present?
+    new_dsl += "\ndisplay_name '#{escape(level.display_name)}'" if level.display_name.present?
+    new_dsl += "\ndescription '#{escape(level.description)}'" if level.description.present?
+
+    new_dsl += "\n\nsublevels" if level.sublevels.any?
+    level.sublevels.each do |sublevel|
+      new_dsl += "\nlevel '#{sublevel.name}'"
+    end
+
+    new_dsl += "\n"
+    new_dsl
+  end
+
+  def self.escape(str)
+    str.gsub("'", "\\\\'")
+  end
 end

--- a/dashboard/app/models/levels/bubble_choice.rb
+++ b/dashboard/app/models/levels/bubble_choice.rb
@@ -158,4 +158,23 @@ class BubbleChoice < DSLDefined
   def icon
     'fa fa-sitemap'
   end
+
+  def clone_with_suffix(new_suffix, editor_experiment: nil)
+    level = super(new_suffix, editor_experiment: editor_experiment)
+
+    new_sublevel_names = []
+    sublevels.each do |sublevel|
+      new_sublevel = sublevel.clone_with_suffix(new_suffix, editor_experiment: editor_experiment)
+      new_sublevel_names.push(new_sublevel.name)
+    end
+
+    update_params = {
+      properties: {
+        sublevels: new_sublevel_names
+      }
+    }
+
+    level.update!(update_params)
+    level
+  end
 end

--- a/dashboard/app/models/levels/bubble_choice.rb
+++ b/dashboard/app/models/levels/bubble_choice.rb
@@ -162,19 +162,32 @@ class BubbleChoice < DSLDefined
   def clone_with_suffix(new_suffix, editor_experiment: nil)
     level = super(new_suffix, editor_experiment: editor_experiment)
 
-    new_sublevel_names = []
+    # map from old to new sublevel name
+    sublevel_name_map = {}
     sublevels.each do |sublevel|
       new_sublevel = sublevel.clone_with_suffix(new_suffix, editor_experiment: editor_experiment)
-      new_sublevel_names.push(new_sublevel.name)
+      sublevel_name_map[sublevel.name] = new_sublevel.name
     end
 
     update_params = {
       properties: {
-        sublevels: new_sublevel_names
+        sublevels: sublevel_name_map.values
       }
     }
 
     level.update!(update_params)
+
+    new_dsl_text = level.dsl_text
+
+    sublevel_name_map.each_pair do |old_name, new_name|
+      success = new_dsl_text.gsub!(
+        "level '#{old_name}'",
+        "level '#{new_name}'"
+      )
+      raise "level '#{old_name}' not found in input dsl" unless success
+    end
+
+    level.rewrite_dsl_file(new_dsl_text)
     level
   end
 end

--- a/dashboard/app/models/levels/bubble_choice.rb
+++ b/dashboard/app/models/levels/bubble_choice.rb
@@ -162,32 +162,17 @@ class BubbleChoice < DSLDefined
   def clone_with_suffix(new_suffix, editor_experiment: nil)
     level = super(new_suffix, editor_experiment: editor_experiment)
 
-    # map from old to new sublevel name
-    sublevel_name_map = {}
-    sublevels.each do |sublevel|
-      new_sublevel = sublevel.clone_with_suffix(new_suffix, editor_experiment: editor_experiment)
-      sublevel_name_map[sublevel.name] = new_sublevel.name
+    new_sublevel_names = sublevels.map do |sublevel|
+      sublevel.clone_with_suffix(new_suffix, editor_experiment: editor_experiment).name
     end
 
     update_params = {
       properties: {
-        sublevels: sublevel_name_map.values
+        sublevels: new_sublevel_names
       }
     }
-
     level.update!(update_params)
-
-    new_dsl_text = level.dsl_text
-
-    sublevel_name_map.each_pair do |old_name, new_name|
-      success = new_dsl_text.gsub!(
-        "level '#{old_name}'",
-        "level '#{new_name}'"
-      )
-      raise "level '#{old_name}' not found in input dsl" unless success
-    end
-
-    level.rewrite_dsl_file(new_dsl_text)
+    level.rewrite_dsl_file(BubbleChoiceDSL.serialize(level))
     level
   end
 end

--- a/dashboard/test/dsl/bubble_choice_dsl_test.rb
+++ b/dashboard/test/dsl/bubble_choice_dsl_test.rb
@@ -1,0 +1,91 @@
+require 'test_helper'
+
+class BubbleChoiceDslTest < ActiveSupport::TestCase
+  setup do
+    create :level, name: 'bubble choice level 1'
+    create :level, name: 'bubble choice level 2'
+  end
+
+  test 'create then serialize simple level returns original DSL' do
+    input_dsl = <<~DSL
+      name 'bubble choice'
+
+      sublevels
+      level 'bubble choice level 1'
+      level 'bubble choice level 2'
+    DSL
+
+    bubble_choice = BubbleChoice.create_from_level_builder({}, {name: 'bubble choice', dsl_text: input_dsl})
+    assert_equal input_dsl, BubbleChoiceDSL.serialize(bubble_choice)
+  end
+
+  test 'create then serialize with more fields returns original DSL' do
+    input_dsl = <<~DSL
+      name 'bubble choice'
+      editor_experiment 'my experiment'
+      display_name 'My Level Name'
+      description 'My Description'
+
+      sublevels
+      level 'bubble choice level 1'
+      level 'bubble choice level 2'
+    DSL
+
+    bubble_choice = BubbleChoice.create_from_level_builder({}, {name: 'bubble choice', dsl_text: input_dsl})
+    assert_equal input_dsl, BubbleChoiceDSL.serialize(bubble_choice)
+  end
+
+  test 'serialize escapes single quotes' do
+    input_dsl = <<~DSL
+      name 'Author\\'s Choice'
+      editor_experiment 'my experiment'
+      display_name 'Author\\'s Display Name'
+      description 'Author\\'s Description'
+
+      sublevels
+      level 'bubble choice level 1'
+      level 'bubble choice level 2'
+    DSL
+
+    bubble_choice = BubbleChoice.create_from_level_builder({}, {name: 'bubble choice', dsl_text: input_dsl})
+    # Make sure our input fields actually contain "'" but not "\"
+    assert_equal "Author's Choice", bubble_choice.name
+    assert_equal "Author's Display Name", bubble_choice.display_name
+    assert_equal "Author's Description", bubble_choice.description
+    assert_equal input_dsl, BubbleChoiceDSL.serialize(bubble_choice)
+  end
+
+  test 'serialize strips empty fields' do
+    input_dsl = <<~DSL
+      name 'bubble choice'
+      editor_experiment ''
+      display_name ''
+      description ''
+
+      sublevels
+      level 'bubble choice level 1'
+      level 'bubble choice level 2'
+
+      markdown <<MARKDOWN
+
+      MARKDOWN
+    DSL
+
+    output_dsl = <<~DSL
+      name 'bubble choice'
+
+      sublevels
+      level 'bubble choice level 1'
+      level 'bubble choice level 2'
+    DSL
+
+    bubble_choice = BubbleChoice.create_from_level_builder({}, {name: 'bubble choice', dsl_text: input_dsl})
+    assert_equal output_dsl, BubbleChoiceDSL.serialize(bubble_choice)
+  end
+
+  test 'escape method escapes single quotes' do
+    result = BubbleChoiceDSL.escape("foo'bar")
+    assert_equal "foo\\'bar", result
+    assert_equal 8, result.length
+  end
+end

--- a/dashboard/test/models/levels/bubble_choice_test.rb
+++ b/dashboard/test/models/levels/bubble_choice_test.rb
@@ -199,4 +199,33 @@ DSL
     assert_empty BubbleChoice.parent_levels("sublevel_12") # contains sublevel name above
     assert_empty BubbleChoice.parent_levels("nonexistent level name")
   end
+
+  test 'clone with suffix copies sublevels' do
+    sublevel1 = create :level, name: 'sublevel_1'
+    sublevel2 = create :level, name: 'sublevel_2'
+    sublevel3 = create :level, name: 'sublevel_3'
+
+    # clone_with_suffix needs to be able to access the level object as well as
+    # its DSL text. Rather than create an actual DSL file, we stub the level's
+    # dsl_text method to return the DSL text. Since we've got the DSL text
+    # handy, also use it (rather than factories) to create the level itself.
+    # This approach also helps validate that the DSL text is correct and avoid
+    # any unintended inconsistencies between DSL text and factory calls.
+    input_dsl = <<~DSL
+      name 'bubble choice'
+      sublevels
+      level 'sublevel_1'
+      level 'sublevel_2'
+      level 'sublevel_3'
+    DSL
+    bubble_choice = BubbleChoice.create_from_level_builder({}, {name: 'bubble choice', dsl_text: input_dsl})
+    bubble_choice.stubs(:dsl_text).returns(input_dsl)
+
+    assert_equal [sublevel1, sublevel2, sublevel3], bubble_choice.sublevels
+
+    bubble_choice_copy = bubble_choice.clone_with_suffix('_copy')
+    puts bubble_choice_copy.properties
+    expected_names = %w(sublevel_1_copy sublevel_2_copy sublevel_3_copy)
+    assert_equal expected_names, bubble_choice_copy.sublevels.map(&:name)
+  end
 end

--- a/dashboard/test/models/levels/bubble_choice_test.rb
+++ b/dashboard/test/models/levels/bubble_choice_test.rb
@@ -229,8 +229,10 @@ DSL
       level 'sublevel_3_copy'
     DSL
 
+    File.stubs(:exist?).returns(true)
+    File.stubs(:read).with {|filepath| filepath.to_s.end_with?('bubble_choice.bubble_choice')}.returns(input_dsl).once
+
     bubble_choice = BubbleChoice.create_from_level_builder({}, {name: 'bubble choice', dsl_text: input_dsl})
-    bubble_choice.stubs(:dsl_text).returns(input_dsl)
 
     assert_equal [sublevel1, sublevel2, sublevel3], bubble_choice.sublevels
 

--- a/dashboard/test/models/levels/bubble_choice_test.rb
+++ b/dashboard/test/models/levels/bubble_choice_test.rb
@@ -234,13 +234,14 @@ DSL
 
     assert_equal [sublevel1, sublevel2, sublevel3], bubble_choice.sublevels
 
+    File.stubs(:write).with do |filepath, actual_dsl|
+      filepath.basename.to_s == 'bubble_choice_copy.bubble_choice' &&
+        copy_dsl == actual_dsl
+    end.once
+
     bubble_choice_copy = bubble_choice.clone_with_suffix('_copy')
 
     expected_names = %w(sublevel_1_copy sublevel_2_copy sublevel_3_copy)
     assert_equal expected_names, bubble_choice_copy.sublevels.map(&:name)
-    assert_equal copy_dsl, bubble_choice_copy.dsl_text
-
-    # clean up
-    File.delete(bubble_choice_copy.filename)
   end
 end

--- a/dashboard/test/models/levels/bubble_choice_test.rb
+++ b/dashboard/test/models/levels/bubble_choice_test.rb
@@ -201,9 +201,6 @@ DSL
   end
 
   test 'clone with suffix copies sublevels' do
-    # Ensures that DSLDefined.clone_with_name will generate a new dsl file.
-    Rails.application.config.stubs(:levelbuilder_mode).returns true
-
     sublevel1 = create :level, name: 'sublevel_1'
     sublevel2 = create :level, name: 'sublevel_2'
     sublevel3 = create :level, name: 'sublevel_3'
@@ -216,6 +213,7 @@ DSL
     # any unintended inconsistencies between DSL text and factory calls.
     input_dsl = <<~DSL
       name 'bubble choice'
+
       sublevels
       level 'sublevel_1'
       level 'sublevel_2'
@@ -224,6 +222,7 @@ DSL
 
     copy_dsl = <<~DSL
       name 'bubble choice_copy'
+
       sublevels
       level 'sublevel_1_copy'
       level 'sublevel_2_copy'
@@ -242,10 +241,6 @@ DSL
     assert_equal copy_dsl, bubble_choice_copy.dsl_text
 
     # clean up
-    File.delete(bubble_choice.filename)
     File.delete(bubble_choice_copy.filename)
-    bubble_choice_copy.sublevels.each do |sublevel|
-      File.delete(Level.level_file_path(sublevel.name))
-    end
   end
 end


### PR DESCRIPTION
Update the clone_with_suffix method to copy Bubble Choice sublevels. In the process, also adds a serialize method to generate DSL file contents directly from the level object in the DB, so that we don't have to try to use regular expressions to try and update the sublevel names.

## Testing story

* added new unit tests
* manually verified that clone_with_suffix on a bubble choice level produces expected results

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
