### PR TITLE
Lift restrictions on Academic Year Virtual Workshops

### DIFF
--- a/apps/src/code-studio/pd/workshop_dashboard/components/workshop_form.jsx
+++ b/apps/src/code-studio/pd/workshop_dashboard/components/workshop_form.jsx
@@ -575,21 +575,13 @@ export class WorkshopForm extends React.Component {
 
   renderSubjectSelect(validation) {
     if (this.shouldRenderSubject()) {
-      const options = Subjects[this.state.course]
-        .filter(subject => {
-          // Only a WorkshopAdmin should be shown a Virtual workshop.
-          return (
-            subject.indexOf('Virtual') === -1 ||
-            this.props.permission.has(WorkshopAdmin)
-          );
-        })
-        .map((subject, i) => {
-          return (
-            <option key={i} value={subject}>
-              {subject}
-            </option>
-          );
-        });
+      const options = Subjects[this.state.course].map((subject, i) => {
+        return (
+          <option key={i} value={subject}>
+            {subject}
+          </option>
+        );
+      });
       const placeHolder = this.state.subject ? null : <option />;
       return (
         <FormGroup validationState={validation.style.subject}>


### PR DESCRIPTION
In https://github.com/code-dot-org/code-dot-org/pull/30159 we added support for Academic Year Virtual Workshops but we restricted their use to users with `workshop_admin` permission.

Per a conversation with Megan today: Now, we'd like to give anyone with workshop-creating permissions access to create Academic Year Virtual Workshops (subjects starting with "Virtual Workshop") since many of our RPs will be doing so this year.

<!--
  Your description goes here: A summary of the change, including any relevant motivation and context.

  If relevant, include a description both of the existing behavior and of the new behavior.
-->

<!--
  Other aspects to consider. uncomment and add detail for any that seem necessary:
-->

<!-- ### Background -->
<!-- ### Privacy -->
<!-- ### Security -->
<!-- ### Caching -->
<!-- ### Deployment strategy -->
<!-- ### Future work -->

## Testing story

Tested manually.

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
