### PR TITLE
Extract CourseSelect and SectionSelect from WorkshopForm

### DIFF
--- a/apps/src/code-studio/pd/workshop_dashboard/components/CourseSelect.jsx
+++ b/apps/src/code-studio/pd/workshop_dashboard/components/CourseSelect.jsx
@@ -1,0 +1,75 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import {FormGroup, ControlLabel, FormControl, HelpBlock} from 'react-bootstrap';
+import {
+  Facilitator,
+  Organizer,
+  PermissionPropType,
+  ProgramManager,
+  WorkshopAdmin
+} from '../permission';
+import {Courses} from '@cdo/apps/generated/pd/sharedWorkshopConstants';
+
+/**
+ * A dropdown used on the Workshop form for selecting a course.
+ * For professional learning purposes, a course usually indicates which
+ * course a teacher is being trained to teach.
+ * For example: CS Discoveries, CS Fundamentals
+ */
+export default function CourseSelect({
+  course,
+  facilitatorCourses,
+  permission,
+  readOnly,
+  inputStyle,
+  validation,
+  onChange
+}) {
+  let allowedCourses;
+  if (permission.hasAny(Organizer, ProgramManager, WorkshopAdmin)) {
+    allowedCourses = Courses;
+  } else if (permission.has(Facilitator)) {
+    allowedCourses = facilitatorCourses;
+  } else {
+    console.error(
+      'Insufficient permissions, expected one one of: Organizer, ProgramManager, WorkshopAdmin, or Facilitator'
+    );
+    allowedCourses = [];
+  }
+
+  const options = allowedCourses.map((course, i) => {
+    return (
+      <option key={i} value={course}>
+        {course}
+      </option>
+    );
+  });
+  const placeHolder = course ? null : <option />;
+  return (
+    <FormGroup validationState={validation.style.course}>
+      <ControlLabel>Course</ControlLabel>
+      <FormControl
+        componentClass="select"
+        value={course || ''}
+        id="course"
+        name="course"
+        onChange={onChange}
+        style={inputStyle}
+        disabled={readOnly}
+      >
+        {placeHolder}
+        {options}
+      </FormControl>
+      <HelpBlock>{validation.help.course}</HelpBlock>
+    </FormGroup>
+  );
+}
+CourseSelect.propTypes = {
+  course: PropTypes.string,
+  facilitatorCourses: PropTypes.arrayOf(PropTypes.string).isRequired,
+  permission: PermissionPropType.isRequired,
+  readOnly: PropTypes.bool,
+  inputStyle: PropTypes.object,
+  validation: PropTypes.object,
+  onChange: PropTypes.func.isRequired
+};

--- a/apps/src/code-studio/pd/workshop_dashboard/components/CourseSelect.jsx
+++ b/apps/src/code-studio/pd/workshop_dashboard/components/CourseSelect.jsx
@@ -25,26 +25,7 @@ export default function CourseSelect({
   validation,
   onChange
 }) {
-  let allowedCourses;
-  if (permission.hasAny(Organizer, ProgramManager, WorkshopAdmin)) {
-    allowedCourses = Courses;
-  } else if (permission.has(Facilitator)) {
-    allowedCourses = facilitatorCourses;
-  } else {
-    console.error(
-      'Insufficient permissions, expected one one of: Organizer, ProgramManager, WorkshopAdmin, or Facilitator'
-    );
-    allowedCourses = [];
-  }
-
-  const options = allowedCourses.map((course, i) => {
-    return (
-      <option key={i} value={course}>
-        {course}
-      </option>
-    );
-  });
-  const placeHolder = course ? null : <option />;
+  const allowedCourses = getAllowedCourses(permission, facilitatorCourses);
   return (
     <FormGroup validationState={validation.style.course}>
       <ControlLabel>Course</ControlLabel>
@@ -57,13 +38,18 @@ export default function CourseSelect({
         style={inputStyle}
         disabled={readOnly}
       >
-        {placeHolder}
-        {options}
+        {course ? null : <option />}
+        {allowedCourses.map((course, i) => (
+          <option key={i} value={course}>
+            {course}
+          </option>
+        ))}
       </FormControl>
       <HelpBlock>{validation.help.course}</HelpBlock>
     </FormGroup>
   );
 }
+
 CourseSelect.propTypes = {
   course: PropTypes.string,
   facilitatorCourses: PropTypes.arrayOf(PropTypes.string).isRequired,
@@ -73,3 +59,16 @@ CourseSelect.propTypes = {
   validation: PropTypes.object,
   onChange: PropTypes.func.isRequired
 };
+
+function getAllowedCourses(permission, facilitatorCourses) {
+  if (permission.hasAny(Organizer, ProgramManager, WorkshopAdmin)) {
+    return Courses;
+  } else if (permission.has(Facilitator)) {
+    return facilitatorCourses;
+  }
+
+  console.error(
+    'Insufficient permissions, expected one one of: Organizer, ProgramManager, WorkshopAdmin, or Facilitator'
+  );
+  return [];
+}

--- a/apps/src/code-studio/pd/workshop_dashboard/components/SubjectSelect.jsx
+++ b/apps/src/code-studio/pd/workshop_dashboard/components/SubjectSelect.jsx
@@ -17,14 +17,6 @@ export default function SubjectSelect({
   validation,
   onChange
 }) {
-  const options = Subjects[course].map((subject, i) => {
-    return (
-      <option key={i} value={subject}>
-        {subject}
-      </option>
-    );
-  });
-  const placeHolder = subject ? null : <option />;
   return (
     <FormGroup validationState={validation.style.subject}>
       <ControlLabel>Subject</ControlLabel>
@@ -37,13 +29,18 @@ export default function SubjectSelect({
         style={inputStyle}
         disabled={readOnly}
       >
-        {placeHolder}
-        {options}
+        {subject ? null : <option />}
+        {Subjects[course].map((subject, i) => (
+          <option key={i} value={subject}>
+            {subject}
+          </option>
+        ))}
       </FormControl>
       <HelpBlock>{validation.help.subject}</HelpBlock>
     </FormGroup>
   );
 }
+
 SubjectSelect.propTypes = {
   course: PropTypes.string.isRequired,
   subject: PropTypes.string,

--- a/apps/src/code-studio/pd/workshop_dashboard/components/SubjectSelect.jsx
+++ b/apps/src/code-studio/pd/workshop_dashboard/components/SubjectSelect.jsx
@@ -1,0 +1,54 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import {FormGroup, ControlLabel, FormControl, HelpBlock} from 'react-bootstrap';
+import {Subjects} from '@cdo/apps/generated/pd/sharedWorkshopConstants';
+
+/**
+ * A dropdown used on the Workshop form for selecting a subject.
+ * For professional learning purposes, a subject usually indicates which
+ * part of a multi-step PL course this workshop represents.
+ * For example: 5-day summer workshop, academic workshop 3, etc.
+ */
+export default function SubjectSelect({
+  course,
+  subject,
+  readOnly,
+  inputStyle,
+  validation,
+  onChange
+}) {
+  const options = Subjects[course].map((subject, i) => {
+    return (
+      <option key={i} value={subject}>
+        {subject}
+      </option>
+    );
+  });
+  const placeHolder = subject ? null : <option />;
+  return (
+    <FormGroup validationState={validation.style.subject}>
+      <ControlLabel>Subject</ControlLabel>
+      <FormControl
+        componentClass="select"
+        value={subject || ''}
+        id="subject"
+        name="subject"
+        onChange={onChange}
+        style={inputStyle}
+        disabled={readOnly}
+      >
+        {placeHolder}
+        {options}
+      </FormControl>
+      <HelpBlock>{validation.help.subject}</HelpBlock>
+    </FormGroup>
+  );
+}
+SubjectSelect.propTypes = {
+  course: PropTypes.string.isRequired,
+  subject: PropTypes.string,
+  readOnly: PropTypes.bool,
+  inputStyle: PropTypes.object,
+  validation: PropTypes.object,
+  onChange: PropTypes.func.isRequired
+};

--- a/apps/src/code-studio/pd/workshop_dashboard/components/workshop_form.jsx
+++ b/apps/src/code-studio/pd/workshop_dashboard/components/workshop_form.jsx
@@ -34,15 +34,13 @@ import {
   PermissionPropType,
   WorkshopAdmin,
   Organizer,
-  Facilitator,
   ProgramManager,
   CsfFacilitator
 } from '../permission';
-import {
-  Courses,
-  Subjects
-} from '@cdo/apps/generated/pd/sharedWorkshopConstants';
+import {Subjects} from '@cdo/apps/generated/pd/sharedWorkshopConstants';
 import HelpTip from '@cdo/apps/lib/ui/HelpTip';
+import CourseSelect from './CourseSelect';
+import SubjectSelect from './SubjectSelect';
 
 const styles = {
   readOnlyInput: {
@@ -1194,107 +1192,5 @@ const SelectSuppressEmail = ({value, readOnly, onChange}) => (
 SelectSuppressEmail.propTypes = {
   value: PropTypes.bool.isRequired,
   readOnly: PropTypes.bool,
-  onChange: PropTypes.func.isRequired
-};
-
-function CourseSelect({
-  course,
-  facilitatorCourses,
-  permission,
-  readOnly,
-  inputStyle,
-  validation,
-  onChange
-}) {
-  let allowedCourses;
-  if (permission.hasAny(Organizer, ProgramManager, WorkshopAdmin)) {
-    allowedCourses = Courses;
-  } else if (permission.has(Facilitator)) {
-    allowedCourses = facilitatorCourses;
-  } else {
-    console.error(
-      'Insufficient permissions, expected one one of: Organizer, ProgramManager, WorkshopAdmin, or Facilitator'
-    );
-    allowedCourses = [];
-  }
-
-  const options = allowedCourses.map((course, i) => {
-    return (
-      <option key={i} value={course}>
-        {course}
-      </option>
-    );
-  });
-  const placeHolder = course ? null : <option />;
-  return (
-    <FormGroup validationState={validation.style.course}>
-      <ControlLabel>Course</ControlLabel>
-      <FormControl
-        componentClass="select"
-        value={course || ''}
-        id="course"
-        name="course"
-        onChange={onChange}
-        style={inputStyle}
-        disabled={readOnly}
-      >
-        {placeHolder}
-        {options}
-      </FormControl>
-      <HelpBlock>{validation.help.course}</HelpBlock>
-    </FormGroup>
-  );
-}
-CourseSelect.propTypes = {
-  course: PropTypes.string,
-  facilitatorCourses: PropTypes.arrayOf(PropTypes.string).isRequired,
-  permission: PermissionPropType.isRequired,
-  readOnly: PropTypes.bool,
-  inputStyle: PropTypes.object,
-  validation: PropTypes.object,
-  onChange: PropTypes.func.isRequired
-};
-
-const SubjectSelect = ({
-  course,
-  subject,
-  readOnly,
-  inputStyle,
-  validation,
-  onChange
-}) => {
-  const options = Subjects[course].map((subject, i) => {
-    return (
-      <option key={i} value={subject}>
-        {subject}
-      </option>
-    );
-  });
-  const placeHolder = subject ? null : <option />;
-  return (
-    <FormGroup validationState={validation.style.subject}>
-      <ControlLabel>Subject</ControlLabel>
-      <FormControl
-        componentClass="select"
-        value={subject || ''}
-        id="subject"
-        name="subject"
-        onChange={onChange}
-        style={inputStyle}
-        disabled={readOnly}
-      >
-        {placeHolder}
-        {options}
-      </FormControl>
-      <HelpBlock>{validation.help.subject}</HelpBlock>
-    </FormGroup>
-  );
-};
-SubjectSelect.propTypes = {
-  course: PropTypes.string.isRequired,
-  subject: PropTypes.string,
-  readOnly: PropTypes.bool,
-  inputStyle: PropTypes.object,
-  validation: PropTypes.object,
   onChange: PropTypes.func.isRequired
 };

--- a/apps/src/code-studio/pd/workshop_dashboard/components/workshop_form.jsx
+++ b/apps/src/code-studio/pd/workshop_dashboard/components/workshop_form.jsx
@@ -573,37 +573,6 @@ export class WorkshopForm extends React.Component {
     );
   }
 
-  renderSubjectSelect(validation) {
-    if (this.shouldRenderSubject()) {
-      const options = Subjects[this.state.course].map((subject, i) => {
-        return (
-          <option key={i} value={subject}>
-            {subject}
-          </option>
-        );
-      });
-      const placeHolder = this.state.subject ? null : <option />;
-      return (
-        <FormGroup validationState={validation.style.subject}>
-          <ControlLabel>Subject</ControlLabel>
-          <FormControl
-            componentClass="select"
-            value={this.state.subject || ''}
-            id="subject"
-            name="subject"
-            onChange={this.handleFieldChange}
-            style={this.getInputStyle()}
-            disabled={this.props.readOnly}
-          >
-            {placeHolder}
-            {options}
-          </FormControl>
-          <HelpBlock>{validation.help.subject}</HelpBlock>
-        </FormGroup>
-      );
-    }
-  }
-
   renderFeeInput(validation) {
     // If state.fee is null, there is no fee and no custom fee message.
     // If state.fee is '', the user needs to provide a custom fee message.
@@ -1135,7 +1104,18 @@ export class WorkshopForm extends React.Component {
               </FormGroup>
             </Col>
             <Col sm={3}>{this.renderCourseSelect(validation)}</Col>
-            <Col sm={3}>{this.renderSubjectSelect(validation)}</Col>
+            <Col sm={3}>
+              {this.shouldRenderSubject() && (
+                <SubjectSelect
+                  course={this.state.course}
+                  subject={this.state.subject}
+                  readOnly={this.props.readOnly}
+                  inputStyle={this.getInputStyle()}
+                  validation={validation}
+                  onChange={this.handleFieldChange}
+                />
+              )}
+            </Col>
           </Row>
           <Row>
             <Col sm={10}>
@@ -1247,5 +1227,49 @@ const SelectSuppressEmail = ({value, readOnly, onChange}) => (
 SelectSuppressEmail.propTypes = {
   value: PropTypes.bool.isRequired,
   readOnly: PropTypes.bool,
+  onChange: PropTypes.func.isRequired
+};
+
+const SubjectSelect = ({
+  course,
+  subject,
+  readOnly,
+  inputStyle,
+  validation,
+  onChange
+}) => {
+  const options = Subjects[course].map((subject, i) => {
+    return (
+      <option key={i} value={subject}>
+        {subject}
+      </option>
+    );
+  });
+  const placeHolder = subject ? null : <option />;
+  return (
+    <FormGroup validationState={validation.style.subject}>
+      <ControlLabel>Subject</ControlLabel>
+      <FormControl
+        componentClass="select"
+        value={subject || ''}
+        id="subject"
+        name="subject"
+        onChange={onChange}
+        style={inputStyle}
+        disabled={readOnly}
+      >
+        {placeHolder}
+        {options}
+      </FormControl>
+      <HelpBlock>{validation.help.subject}</HelpBlock>
+    </FormGroup>
+  );
+};
+SubjectSelect.propTypes = {
+  course: PropTypes.string.isRequired,
+  subject: PropTypes.string,
+  readOnly: PropTypes.bool,
+  inputStyle: PropTypes.object,
+  validation: PropTypes.object,
   onChange: PropTypes.func.isRequired
 };

--- a/apps/src/code-studio/pd/workshop_dashboard/components/workshop_form.jsx
+++ b/apps/src/code-studio/pd/workshop_dashboard/components/workshop_form.jsx
@@ -334,49 +334,6 @@ export class WorkshopForm extends React.Component {
     this.setState({organizer: {id: parseInt(event.target.value)}});
   };
 
-  renderCourseSelect(validation) {
-    let allowedCourses;
-    if (
-      this.props.permission.hasAny(Organizer, ProgramManager, WorkshopAdmin)
-    ) {
-      allowedCourses = Courses;
-    } else if (this.props.permission.has(Facilitator)) {
-      allowedCourses = this.props.facilitatorCourses;
-    } else {
-      console.error(
-        'Insufficient permissions, expected one one of: Organizer, ProgramManager, WorkshopAdmin, or Facilitator'
-      );
-      allowedCourses = [];
-    }
-
-    const options = allowedCourses.map((course, i) => {
-      return (
-        <option key={i} value={course}>
-          {course}
-        </option>
-      );
-    });
-    const placeHolder = this.state.course ? null : <option />;
-    return (
-      <FormGroup validationState={validation.style.course}>
-        <ControlLabel>Course</ControlLabel>
-        <FormControl
-          componentClass="select"
-          value={this.state.course || ''}
-          id="course"
-          name="course"
-          onChange={this.handleCourseChange}
-          style={this.getInputStyle()}
-          disabled={this.props.readOnly}
-        >
-          {placeHolder}
-          {options}
-        </FormControl>
-        <HelpBlock>{validation.help.course}</HelpBlock>
-      </FormGroup>
-    );
-  }
-
   renderOnMapRadios(validation) {
     return (
       <FormGroup validationState={validation.style.on_map}>
@@ -1103,7 +1060,17 @@ export class WorkshopForm extends React.Component {
                 <HelpBlock>{validation.help.capacity}</HelpBlock>
               </FormGroup>
             </Col>
-            <Col sm={3}>{this.renderCourseSelect(validation)}</Col>
+            <Col sm={3}>
+              <CourseSelect
+                course={this.state.course}
+                facilitatorCourses={this.props.facilitatorCourses}
+                permission={this.props.permission}
+                readOnly={this.props.readOnly}
+                inputStyle={this.getInputStyle()}
+                validation={validation}
+                onChange={this.handleCourseChange}
+              />
+            </Col>
             <Col sm={3}>
               {this.shouldRenderSubject() && (
                 <SubjectSelect
@@ -1227,6 +1194,64 @@ const SelectSuppressEmail = ({value, readOnly, onChange}) => (
 SelectSuppressEmail.propTypes = {
   value: PropTypes.bool.isRequired,
   readOnly: PropTypes.bool,
+  onChange: PropTypes.func.isRequired
+};
+
+function CourseSelect({
+  course,
+  facilitatorCourses,
+  permission,
+  readOnly,
+  inputStyle,
+  validation,
+  onChange
+}) {
+  let allowedCourses;
+  if (permission.hasAny(Organizer, ProgramManager, WorkshopAdmin)) {
+    allowedCourses = Courses;
+  } else if (permission.has(Facilitator)) {
+    allowedCourses = facilitatorCourses;
+  } else {
+    console.error(
+      'Insufficient permissions, expected one one of: Organizer, ProgramManager, WorkshopAdmin, or Facilitator'
+    );
+    allowedCourses = [];
+  }
+
+  const options = allowedCourses.map((course, i) => {
+    return (
+      <option key={i} value={course}>
+        {course}
+      </option>
+    );
+  });
+  const placeHolder = course ? null : <option />;
+  return (
+    <FormGroup validationState={validation.style.course}>
+      <ControlLabel>Course</ControlLabel>
+      <FormControl
+        componentClass="select"
+        value={course || ''}
+        id="course"
+        name="course"
+        onChange={onChange}
+        style={inputStyle}
+        disabled={readOnly}
+      >
+        {placeHolder}
+        {options}
+      </FormControl>
+      <HelpBlock>{validation.help.course}</HelpBlock>
+    </FormGroup>
+  );
+}
+CourseSelect.propTypes = {
+  course: PropTypes.string,
+  facilitatorCourses: PropTypes.arrayOf(PropTypes.string).isRequired,
+  permission: PermissionPropType.isRequired,
+  readOnly: PropTypes.bool,
+  inputStyle: PropTypes.object,
+  validation: PropTypes.object,
   onChange: PropTypes.func.isRequired
 };
 


### PR DESCRIPTION
Code cleanup: Extract `CourseSelect` and `SectionSelect` components out of `WorkshopForm`.  No change in appearance or behavior.

**Why?** Because WorkshopForm.jsx has grown large and unwieldy, and changes are easier to make and test when components are small and can be rendered in isolation.

## Testing story

Tested manually.  You can check this yourself by signing in as a user with permission to create a workshop (`workshop_admin` is one option) and navigating to http://localhost-studio.code.org:3000/pd/workshop_dashboard/workshops/new.

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
