### PR TITLE
brokenLinkChecker: get slack endpoint from ENV

### DIFF
--- a/bin/cron/start_broken_link_checker
+++ b/bin/cron/start_broken_link_checker
@@ -3,7 +3,10 @@ require_relative '../../deployment'
 
 def main
   `pkill -9 -f brokenLinkChecker`
-  exec(deploy_dir('tools', 'scripts', 'brokenLinkChecker', 'brokenLinkChecker.js'))
+  exec(
+    {'SLACK_ENDPOINT' => CDO.slack_endpoint_broken_links},
+    deploy_dir('tools', 'scripts', 'brokenLinkChecker', 'brokenLinkChecker.js')
+  )
 end
 
 main

--- a/tools/scripts/brokenLinkChecker/brokenLinkChecker.js
+++ b/tools/scripts/brokenLinkChecker/brokenLinkChecker.js
@@ -3,14 +3,12 @@
 const blc = require('broken-link-checker');
 const https = require('https');
 const url = require('url');
-const YAML = require('yamljs');
-const path = require("path");
 
 const ignoreList = require('./brokenLinkChecker.json').ignore;
 
 const slackUrl =
   "https://hooks.slack.com/services/" +
-  YAML.load(path.join(__dirname, '..', '..', '..', 'globals.yml'))['slack_endpoint_broken_links'];
+  process.env.SLACK_ENDPOINT;
 
 let totalLinkCount = 0;
 let totalPageCount = 0;


### PR DESCRIPTION
This change passes the Slack endpoint used by the broken link checker via the `SLACK_ENDPOINT` env variable when `exec`ing the nodejs script from Ruby, instead of sourcing it directly from `globals.yml`.

This change unblocks work to fetch all of our application secrets directly from Secrets Manager through Ruby code instead of from Chef via the `globals.yml` file rendered to the filesystem.

## Links

- [`INF-255`](https://codedotorg.atlassian.net/browse/INF-255)

## Testing story

Manually cherry-picked this commit to `staging`, ran `bundle exec bin/cron/start_broken_link_checker`, and confirmed that reporting to Slack continued to work properly.