### PR TITLE
AFE: Make optional location parameters optional

### DIFF
--- a/dashboard/app/controllers/api/v1/amazon_future_engineer_controller.rb
+++ b/dashboard/app/controllers/api/v1/amazon_future_engineer_controller.rb
@@ -29,10 +29,6 @@ class Api::V1::AmazonFutureEngineerController < ApplicationController
     lastName
     email
     schoolId
-    street1
-    city
-    state
-    zip
     inspirationKit
     csta
     awsEducate
@@ -42,8 +38,12 @@ class Api::V1::AmazonFutureEngineerController < ApplicationController
 
   PERMITTED_PARAMETERS = [
     *REQUIRED_PARAMETERS,
+    'street1',
     'street2',
-    'street3'
+    'street3',
+    'city',
+    'state',
+    'zip'
   ]
 
   def submit_params


### PR DESCRIPTION
Geographic fields (city, state, etc.) are only required if a user wants to receive some additional materials from Amazon. This makes those fields optional. Noticed while testing, as our server returned bad request errors when I wasn't including geographic information.

## Testing story

Our code still generates a blank entry for each of these geographic fields to send to AFE. The real difference is just that our server won't reject a request that doesn't have these fields. Tested that existing AFE controller tests still pass. A curl request to AFE is successful, even if these parameters aren't included (like the one below):

```
curl --request POST \
>   --url https://go.pardot.com/l/105672/2019-10-02/85q8cd \
>   --header 'content-type: application/x-www-form-urlencoded' \
>   --data first-name=FirstExample \
>   --data last-name=LastExample \
>   --data email=test@code.org \
>   --data nces-id=123456789012 \
>   --data inspirational-marketing-kit=1 \
>   --data csta-plus=1 \
>   --data aws-educate=1 \
>   --data amazon-terms=1 \
>   --data new-code-account=1 \
>   --data traffic-source=AFE-code.org \
>   --data registration-date-time=2020-06-16T23:34:25.122Z
```

Returns (presumed success message):
`Cannot find success page to redirect to. Please use your browser back button.<br/>`

## Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
