### PR TITLE
More clear warning on closing workshop early

### DIFF
--- a/apps/src/code-studio/pd/components/confirmation_dialog.jsx
+++ b/apps/src/code-studio/pd/components/confirmation_dialog.jsx
@@ -11,7 +11,8 @@ export default class ConfirmationDialog extends React.Component {
     onOk: PropTypes.func.isRequired,
     onCancel: PropTypes.func,
     headerText: PropTypes.string.isRequired,
-    bodyText: PropTypes.string.isRequired,
+    bodyText: PropTypes.oneOfType([PropTypes.string, PropTypes.element])
+      .isRequired,
     okText: PropTypes.string,
     cancelText: PropTypes.string,
     width: PropTypes.number

--- a/apps/src/code-studio/pd/workshop_dashboard/EndWorkshopPanel.jsx
+++ b/apps/src/code-studio/pd/workshop_dashboard/EndWorkshopPanel.jsx
@@ -4,6 +4,35 @@ import PropTypes from 'prop-types';
 import {Button} from 'react-bootstrap';
 import WorkshopPanel from './WorkshopPanel';
 import ConfirmationDialog from '../components/confirmation_dialog';
+import color from '@cdo/apps/util/color';
+
+const warningStyle = {
+  color: color.red,
+  fontWeight: 'bold'
+};
+
+const earlyCloseWarning = (
+  <div>
+    <span style={warningStyle}>Warning: </span>There are still sessions
+    remaining for this workshop. Once you end a workshop:
+    <ul>
+      <li>The post-workshop survey is automatically sent to attendees.</li>
+      <li>Surveys can’t be unsent and will not be resent.</li>
+      <li>Attendance is locked.</li>
+    </ul>
+    Are you sure you want to end this workshop now?
+  </div>
+);
+
+const normalCloseWarning = (
+  <div>
+    Ending this workshop will close the attendance and send the end of workshop
+    survey to participants.
+    <br />
+    <br />
+    Are you sure you want to end this workshop now?
+  </div>
+);
 
 export default class EndWorkshopPanel extends React.Component {
   static propTypes = {
@@ -74,14 +103,8 @@ export default class EndWorkshopPanel extends React.Component {
             onOk={this.handleEndWorkshopConfirmed}
             okText={isReadyToClose ? 'OK' : 'Yes, end this workshop'}
             onCancel={this.handleEndWorkshopCancel}
-            headerText="End Workshop and Send Survey"
-            bodyText={
-              isReadyToClose
-                ? 'Are you sure? Once ended, the workshop cannot be restarted.'
-                : 'There are still sessions remaining in this workshop. ' +
-                  'Once a workshop is ended, attendees can no longer mark themselves as attended for the remaining sessions. ' +
-                  'Are you sure you want to end this workshop?'
-            }
+            headerText="End workshop and send survey"
+            bodyText={isReadyToClose ? normalCloseWarning : earlyCloseWarning}
             width={isReadyToClose ? 500 : 800}
           />
         </div>

--- a/apps/src/code-studio/pd/workshop_dashboard/EndWorkshopPanel.jsx
+++ b/apps/src/code-studio/pd/workshop_dashboard/EndWorkshopPanel.jsx
@@ -101,7 +101,7 @@ export default class EndWorkshopPanel extends React.Component {
           <ConfirmationDialog
             show={this.state.showEndWorkshopConfirmation}
             onOk={this.handleEndWorkshopConfirmed}
-            okText={isReadyToClose ? 'OK' : 'Yes, end this workshop'}
+            okText={'Yes, end this workshop'}
             onCancel={this.handleEndWorkshopCancel}
             headerText="End workshop and send survey"
             bodyText={isReadyToClose ? normalCloseWarning : earlyCloseWarning}


### PR DESCRIPTION
[Note: I've allowed React elements as the body prop for all confirmation dialogs, which I don't think should cause issues but worth considering before merging.]

Per request from our PL team, a more clear warning when someone tries to close a workshop. If they're trying to close particularly early (ie, no one has attended the last session of the workshop):

![image](https://user-images.githubusercontent.com/25372625/85911568-cbe8b300-b7da-11ea-8f8f-4772eb6b946e.png)

If they're trying to close at an appropriate time:

![image](https://user-images.githubusercontent.com/25372625/85911659-37cb1b80-b7db-11ea-91ee-a3d7eb95ac88.png)

## Testing story

Tested locally.

## Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
