### PR TITLE
 Update pre-course surveys to link for 2020 curriculum launch

### DIFF
--- a/dashboard/app/models/pd/workshop_constants.rb
+++ b/dashboard/app/models/pd/workshop_constants.rb
@@ -97,8 +97,8 @@ module Pd
     #  - course_name : the name of the Course object associated with that workshop.
     # Only courses with a pre-survey will have an entry here
     PRE_SURVEY_BY_COURSE = {
-      COURSE_CSD => {course_name: 'csd-2019'},
-      COURSE_CSP => {course_name: 'csp-2019'}
+      COURSE_CSD => {course_name: 'csd-2020'},
+      COURSE_CSP => {course_name: 'csp-2020'}
     }.freeze
   end
 end


### PR DESCRIPTION
[PLC-927](https://codedotorg.atlassian.net/browse/PLC-927): Switch from 2019 to 2020 curricula.

The new pre-course surveys look like this
For CSD-2020:
<img width="800" alt="Screen Shot 2020-06-29 at 12 47 20 PM" src="https://user-images.githubusercontent.com/46507039/86049265-b3f57700-ba06-11ea-8a81-cff5d358c7c1.png">

For CSP-2020:
<img width="803" alt="Screen Shot 2020-06-29 at 12 15 34 PM" src="https://user-images.githubusercontent.com/46507039/86048974-2ca80380-ba06-11ea-994f-21a4e7bbcedf.png">

## Test story
See https://github.com/code-dot-org/code-dot-org/pull/28642 for how to test.