### PR TITLE
Dataset Library Search

### DIFF
--- a/apps/i18n/common/en_us.json
+++ b/apps/i18n/common/en_us.json
@@ -437,6 +437,7 @@
   "dataTableNamePlaceholder": "Table name",
   "dataLibraryHeader": "Data Library",
   "dataLibraryDescription": "Find and import tables of real data from the Code.org library.",
+  "dataLibrarySearchPlacholder": "Search",
   "dataSource": "Data Source",
   "dataVisualizerPlaceholderText": "Select values to generate a visualization",
   "dataVisualizerBucketSize": "Bucket Size",

--- a/apps/src/storage/dataBrowser/DataLibraryPane.jsx
+++ b/apps/src/storage/dataBrowser/DataLibraryPane.jsx
@@ -59,6 +59,7 @@ class DataLibraryPane extends React.Component {
       FirebaseStorage.copyStaticTable(datasetInfo.name, () => {}, this.onError);
     }
   };
+
   search = e => {
     let searchValue = '';
     if (e !== undefined) {
@@ -68,23 +69,27 @@ class DataLibraryPane extends React.Component {
       search: searchValue
     });
   };
+
   filterCategories = allCategories => {
     const searchRegExp = new RegExp('(?:\\s+|^)' + this.state.search, 'i');
-    let potentialCategories = allCategories.map(category => {
-      category.datasets = category.datasets.filter(dataset => {
-        const datasetInfo = getDatasetInfo(
-          dataset,
-          this.props.libraryManifest.tables
-        );
-        return (
-          searchRegExp.test(dataset) ||
-          searchRegExp.test(datasetInfo.description)
-        );
-      });
-      return category;
-    });
-    potentialCategories = potentialCategories.filter(
-      category => category.datasets.length > 0
+    let potentialCategories = allCategories.reduce(
+      (filteredCategories, category) => {
+        category.datasets = category.datasets.filter(dataset => {
+          const datasetInfo = getDatasetInfo(
+            dataset,
+            this.props.libraryManifest.tables
+          );
+          return (
+            searchRegExp.test(dataset) ||
+            searchRegExp.test(datasetInfo.description)
+          );
+        });
+        if (category.datasets.length > 0) {
+          filteredCategories.push(category);
+        }
+        return filteredCategories;
+      },
+      []
     );
     return potentialCategories;
   };
@@ -101,7 +106,7 @@ class DataLibraryPane extends React.Component {
       <div style={styles.container}>
         <p>{msg.dataLibraryDescription()}</p>
         <SearchBar
-          placeholderText={'Search'}
+          placeholderText={msg.dataLibrarySearchPlacholder()}
           onChange={this.search}
           clearButton={this.state.search.length > 0}
         />

--- a/apps/src/storage/dataBrowser/DataLibraryPane.jsx
+++ b/apps/src/storage/dataBrowser/DataLibraryPane.jsx
@@ -69,7 +69,7 @@ class DataLibraryPane extends React.Component {
     });
   };
   filterCategories = allCategories => {
-    const searchRegExp = new RegExp('(?:\\s+|_|^|-)' + this.state.search, 'i');
+    const searchRegExp = new RegExp('\\s+' + this.state.search, 'i');
     let potentialCategories = allCategories.map(category => {
       category.datasets = category.datasets.filter(dataset => {
         const datasetInfo = getDatasetInfo(

--- a/apps/src/storage/dataBrowser/DataLibraryPane.jsx
+++ b/apps/src/storage/dataBrowser/DataLibraryPane.jsx
@@ -69,7 +69,7 @@ class DataLibraryPane extends React.Component {
     });
   };
   filterCategories = allCategories => {
-    const searchRegExp = new RegExp('\\s+' + this.state.search, 'i');
+    const searchRegExp = new RegExp('(?:\\s+|^)' + this.state.search, 'i');
     let potentialCategories = allCategories.map(category => {
       category.datasets = category.datasets.filter(dataset => {
         const datasetInfo = getDatasetInfo(

--- a/apps/src/storage/dataBrowser/DataLibraryPane.jsx
+++ b/apps/src/storage/dataBrowser/DataLibraryPane.jsx
@@ -97,6 +97,8 @@ class DataLibraryPane extends React.Component {
       category => showUnpublishedTables || category.published
     );
     categories = this.filterCategories(_.cloneDeep(categories));
+    console.log(this.state.search);
+    console.log(this.state.search.length > 0);
     return (
       <div style={styles.container}>
         <p>{msg.dataLibraryDescription()}</p>
@@ -113,6 +115,7 @@ class DataLibraryPane extends React.Component {
             datasets={category.datasets}
             description={category.description}
             importTable={this.importTable}
+            forceExpanded={this.state.search.length > 0}
           />
         ))}
         <PreviewModal importTable={this.importTable} />

--- a/apps/src/storage/dataBrowser/DataLibraryPane.jsx
+++ b/apps/src/storage/dataBrowser/DataLibraryPane.jsx
@@ -97,8 +97,6 @@ class DataLibraryPane extends React.Component {
       category => showUnpublishedTables || category.published
     );
     categories = this.filterCategories(_.cloneDeep(categories));
-    console.log(this.state.search);
-    console.log(this.state.search.length > 0);
     return (
       <div style={styles.container}>
         <p>{msg.dataLibraryDescription()}</p>

--- a/apps/src/storage/dataBrowser/LibraryCategory.jsx
+++ b/apps/src/storage/dataBrowser/LibraryCategory.jsx
@@ -34,12 +34,22 @@ class LibraryCategory extends React.Component {
     name: PropTypes.string.isRequired,
     datasets: PropTypes.arrayOf(PropTypes.string).isRequired,
     description: PropTypes.string,
-    importTable: PropTypes.func.isRequired
+    importTable: PropTypes.func.isRequired,
+    forceExpanded: PropTypes.bool
   };
 
   state = {
     collapsed: true
   };
+
+  componentWillReceiveProps(newProps) {
+    if (
+      (newProps.forceExpanded && this.state.collapsed) ||
+      (!newProps.forceExpanded && !this.state.collapsed)
+    ) {
+      this.toggleCollapsed();
+    }
+  }
 
   toggleCollapsed = () =>
     this.setState({

--- a/apps/src/templates/SearchBar.jsx
+++ b/apps/src/templates/SearchBar.jsx
@@ -52,7 +52,6 @@ export default class SearchBar extends React.Component {
   }
 
   render() {
-    console.log(this.searchBox);
     return (
       <div style={styles.searchArea}>
         <span className="fa fa-search" style={styles.icon} />

--- a/apps/src/templates/SearchBar.jsx
+++ b/apps/src/templates/SearchBar.jsx
@@ -27,6 +27,13 @@ const styles = {
     fontSize: 16,
     color: color.light_gray
   },
+  clearIcon: {
+    position: 'absolute',
+    top: 5,
+    right: 5,
+    fontSize: 16,
+    color: color.light_gray
+  },
   searchArea: {
     position: 'relative',
     margin: '10px 0'
@@ -36,7 +43,8 @@ const styles = {
 export default class SearchBar extends React.Component {
   static propTypes = {
     placeholderText: PropTypes.string.isRequired,
-    onChange: PropTypes.func.isRequired
+    onChange: PropTypes.func.isRequired,
+    clearButton: PropTypes.bool
   };
 
   componentDidMount() {
@@ -44,6 +52,7 @@ export default class SearchBar extends React.Component {
   }
 
   render() {
+    console.log(this.searchBox);
     return (
       <div style={styles.searchArea}>
         <span className="fa fa-search" style={styles.icon} />
@@ -55,6 +64,16 @@ export default class SearchBar extends React.Component {
             this.searchBox = input;
           }}
         />
+        {this.props.clearButton && (
+          <span
+            className="fa fa-close"
+            style={styles.clearIcon}
+            onClick={() => {
+              this.searchBox.value = '';
+              this.props.onChange();
+            }}
+          />
+        )}
       </div>
     );
   }

--- a/dashboard/test/ui/features/star_labs/applab/eyes3.feature
+++ b/dashboard/test/ui/features/star_labs/applab/eyes3.feature
@@ -11,8 +11,8 @@ Scenario: Data Browser
   When I switch to data mode
   Then I see no difference for "data overview"
 
-  When I press keys "foo" for element "#data-library-container input"
-  And I click selector "#data-library-container button:contains(Add)"
+  When I press keys "foo" for element "#data-browser input"
+  And I click selector "#data-browser button:contains(Add)"
   And I wait until element "#dataTable" is visible
   Then I see no difference for "data table"
 


### PR DESCRIPTION
This implements dataset library search in app lab. As the user searches, categories with datasets with names or descriptions with words starting with the query are expanded. When the search bar is empty, categories are collapsed by default.

![datasets search bar](https://user-images.githubusercontent.com/17147070/86049469-376f9200-ba20-11ea-9b9f-3ec0caeee4ae.gif)

## Links

- [spec for datasets in app lab](https://docs.google.com/document/d/1_ZC8JWI1ZS0bzCyilaomXtZZGwSjHVZ8zmCgTBpgK94/edit#heading=h.ih84412wcy79)
- [jira](https://codedotorg.atlassian.net/browse/STAR-629)

## Testing story

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
