### PR TITLE
AFE integration: Derive new-code-account from account age

### DIFF
--- a/dashboard/app/controllers/api/v1/amazon_future_engineer_controller.rb
+++ b/dashboard/app/controllers/api/v1/amazon_future_engineer_controller.rb
@@ -33,7 +33,6 @@ class Api::V1::AmazonFutureEngineerController < ApplicationController
     csta
     awsEducate
     consentAFE
-    newCodeAccount
   )
 
   PERMITTED_PARAMETERS = [
@@ -69,7 +68,7 @@ class Api::V1::AmazonFutureEngineerController < ApplicationController
       'csta-plus' => filtered_params['csta'],
       'aws-educate' => filtered_params['awsEducate'],
       'amazon-terms' => filtered_params['consentAFE'],
-      'new-code-account' => filtered_params['newCodeAccount'],
+      'new-code-account' => current_user.created_at > 5.minutes.ago ? '1' : '0',
       'registration-date-time' => Time.now.iso8601
     }
   end

--- a/dashboard/test/controllers/api/v1/amazon_future_engineer_controller_test.rb
+++ b/dashboard/test/controllers/api/v1/amazon_future_engineer_controller_test.rb
@@ -59,7 +59,7 @@ class Api::V1::AmazonFutureEngineerControllerTest < ActionDispatch::IntegrationT
             'registration-date-time' => Time.now.iso8601
           }
       end
-      expected_call.returns FakeResponse.new
+      expected_call.returns fake_response
 
       sign_in create :teacher
       post '/dashboardapi/v1/amazon_future_engineer_submit',
@@ -75,7 +75,7 @@ class Api::V1::AmazonFutureEngineerControllerTest < ActionDispatch::IntegrationT
       url.to_s == CDO.afe_pardot_form_handler_url &&
         params['new-code-account'] == '0'
     end
-    expected_call.returns FakeResponse.new
+    expected_call.returns fake_response
 
     Timecop.freeze do
       # Create the teacher more than five minutes before we submit
@@ -95,7 +95,7 @@ class Api::V1::AmazonFutureEngineerControllerTest < ActionDispatch::IntegrationT
       url.to_s == CDO.afe_pardot_form_handler_url &&
         params['new-code-account'] == '1'
     end
-    expected_call.returns FakeResponse.new
+    expected_call.returns fake_response
 
     Timecop.freeze do
       # Create the teacher less than five minutes before we submit
@@ -131,13 +131,11 @@ class Api::V1::AmazonFutureEngineerControllerTest < ActionDispatch::IntegrationT
     }
   end
 
-  class FakeResponse
-    def code
-      '200'
-    end
-
-    def body
-      ''
+  def fake_response
+    mock.tap do |fake|
+      fake.stubs(:status).returns(200)
+      fake.stubs(:code).returns('200')
+      fake.stubs(:body).returns('')
     end
   end
 end

--- a/dashboard/test/controllers/api/v1/amazon_future_engineer_controller_test.rb
+++ b/dashboard/test/controllers/api/v1/amazon_future_engineer_controller_test.rb
@@ -55,7 +55,7 @@ class Api::V1::AmazonFutureEngineerControllerTest < ActionDispatch::IntegrationT
             'csta-plus' => '0',
             'aws-educate' => '0',
             'amazon-terms' => '1',
-            'new-code-account' => '0',
+            'new-code-account' => '1',
             'registration-date-time' => Time.now.iso8601
           }
       end
@@ -65,6 +65,46 @@ class Api::V1::AmazonFutureEngineerControllerTest < ActionDispatch::IntegrationT
       post '/dashboardapi/v1/amazon_future_engineer_submit',
         params: valid_params, as: :json
 
+      assert_response :success, "Failed response: #{response.body}"
+    end
+  end
+
+  test 'new-code-account is 0 if the user was created five minutes ago or more' do
+    # Expect the post to Pardot with the appropriate new-code-account value
+    expected_call = Net::HTTP.expects(:post_form).with do |url, params|
+      url.to_s == CDO.afe_pardot_form_handler_url &&
+        params['new-code-account'] == '0'
+    end
+    expected_call.returns FakeResponse.new
+
+    Timecop.freeze do
+      # Create the teacher more than five minutes before we submit
+      teacher = create :teacher
+      Timecop.travel(5.minutes)
+
+      sign_in teacher
+      post '/dashboardapi/v1/amazon_future_engineer_submit',
+        params: valid_params, as: :json
+      assert_response :success, "Failed response: #{response.body}"
+    end
+  end
+
+  test 'new-code-account is 1 if the user was created less than five minutes ago' do
+    # Expect the post to Pardot with the appropriate new-code-account value
+    expected_call = Net::HTTP.expects(:post_form).with do |url, params|
+      url.to_s == CDO.afe_pardot_form_handler_url &&
+        params['new-code-account'] == '1'
+    end
+    expected_call.returns FakeResponse.new
+
+    Timecop.freeze do
+      # Create the teacher less than five minutes before we submit
+      teacher = create :teacher
+      Timecop.travel(5.minutes - 1.second)
+
+      sign_in teacher
+      post '/dashboardapi/v1/amazon_future_engineer_submit',
+        params: valid_params, as: :json
       assert_response :success, "Failed response: #{response.body}"
     end
   end
@@ -87,8 +127,7 @@ class Api::V1::AmazonFutureEngineerControllerTest < ActionDispatch::IntegrationT
       'csta' => '0',
       'consentCSTA' => '0',
       'awsEducate' => '0',
-      'consentAFE' => '1',
-      'newCodeAccount' => '0'
+      'consentAFE' => '1'
     }
   end
 


### PR DESCRIPTION
Updates our AmazonFutureEngineerController to derive a `new-code-account` parameter to sent to AFE's Pardot form handler from the submitter's account age, instead of passing along a value from the client.

## Links

[The AFE integration TODO list](https://docs.google.com/document/d/1Ny0pTrvkBMnOKx0CqoNnWTWhwq-oCn9IBYekSjiJMBc/edit).

## Testing story

New unit tests have been added for this behavior.

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
