### PR TITLE
AFE Integration: No duplicate requests

### DIFF
--- a/apps/src/templates/amazonFutureEngineerEligibility/amazonFutureEngineerAccountConfirmation.jsx
+++ b/apps/src/templates/amazonFutureEngineerEligibility/amazonFutureEngineerAccountConfirmation.jsx
@@ -34,10 +34,6 @@ export default class AmazonFutureEngineerAccountConfirmation extends React.Compo
 
   render() {
     // TO DO: Add links to account sign up page.
-    // TO DO: Need to put submission data
-    //  (currently kept in state of AmazonFutureEngineerEligibility component)
-    //  somewhere (session cookie?) that will persist while they sign up or sign in,
-    // at which point we'll send an API request to Amazon's Pardot API endpoint.
     return (
       <div>
         <h2 style={styles.header}>Almost done!</h2>

--- a/apps/src/templates/amazonFutureEngineerEligibility/amazonFutureEngineerAccountConfirmation.jsx
+++ b/apps/src/templates/amazonFutureEngineerEligibility/amazonFutureEngineerAccountConfirmation.jsx
@@ -20,7 +20,9 @@ const styles = {
 
 export default class AmazonFutureEngineerAccountConfirmation extends React.Component {
   returnToURL = relativeDashboardPath => {
-    return studio(`${relativeDashboardPath}?user_return_to=${pegasus('/afe')}`);
+    return studio(
+      `${relativeDashboardPath}?user_return_to=${pegasus('/afe/submit')}`
+    );
   };
 
   logSignUpButtonPress = () => {

--- a/apps/src/templates/amazonFutureEngineerEligibility/amazonFutureEngineerEligibility.jsx
+++ b/apps/src/templates/amazonFutureEngineerEligibility/amazonFutureEngineerEligibility.jsx
@@ -243,6 +243,7 @@ export default class AmazonFutureEngineerEligibility extends React.Component {
 
     if (formData.schoolEligible && formData.consentAFE && formData.signedIn) {
       this.loadCompletionPage();
+      return <div>Your request is being processed...</div>;
     }
 
     return (

--- a/apps/src/templates/amazonFutureEngineerEligibility/amazonFutureEngineerEligibility.jsx
+++ b/apps/src/templates/amazonFutureEngineerEligibility/amazonFutureEngineerEligibility.jsx
@@ -96,6 +96,7 @@ export default class AmazonFutureEngineerEligibility extends React.Component {
 
     sessionStorage.setItem(sessionStorageKey, JSON.stringify(newFormData));
     this.setState({formData: newFormData});
+    this.root.scrollIntoView();
   };
 
   saveToSessionStorage = () => {
@@ -247,7 +248,7 @@ export default class AmazonFutureEngineerEligibility extends React.Component {
     }
 
     return (
-      <div style={styles.container}>
+      <div style={styles.container} ref={el => (this.root = el)}>
         {formData.schoolEligible === null && (
           <div>
             <h2 style={styles.header}>Am I eligible?</h2>

--- a/pegasus/sites.v3/code.org/public/afe/index.md.erb
+++ b/pegasus/sites.v3/code.org/public/afe/index.md.erb
@@ -15,6 +15,8 @@ Code.org has partnered with Amazon Future Engineer (AFE) to offer middle and hig
 
 Scroll down to learn more about what Code.org offers and the benefits of participating through AFE, or if you’re ready, fill out the short form below to see if your school is eligible!
 
+<a name="check-eligibility-form"></a>
+
 <%= view :amazon_future_engineer_eligibility %>
 
 ## The Code.org program
@@ -120,4 +122,4 @@ In addition to the Code.org platform and curricula, AFE provides:
 * Posters and other materials to help recruit and inspire students to learn
 * AWS Cloud Computing credits and courses for your class
 
-<%= view :amazon_future_engineer_eligibility %>
+<span style="font-size: large">[Click here](#check-eligibility-form) to see if you are eligible.</span>

--- a/pegasus/sites.v3/code.org/public/afe/submit.md.erb
+++ b/pegasus/sites.v3/code.org/public/afe/submit.md.erb
@@ -1,0 +1,8 @@
+---
+title: Bring computer science to your classroom with Code.org and Amazon Future Engineer
+theme: responsive
+---
+
+# Bring computer science to your classroom with Code.org and Amazon Future Engineer
+
+<%= view :amazon_future_engineer_eligibility %>


### PR DESCRIPTION
Solves a bug in the existing flow that was generating duplicate AFE submissions, along with a few quality-of-life changes.

## Changes

### Remove the second form from `/afe`

The critical change to avoid duplicate requests.  Replaced with this "Click here to see if you are eligible." message, which scrolls back up the page to the form.

![image](https://user-images.githubusercontent.com/1615761/86066929-57a34f00-ba28-11ea-9278-b061f68e461b.png)

### Scroll the form back into view when advancing to "Almost done!"

Before, when this component switched from being a long form to a relatively short one, we would lose it from view because of the scroll position.  Now we scroll back to the top of the form when we advance.

![Peek 2020-06-29 16-50](https://user-images.githubusercontent.com/1615761/86067032-a8b34300-ba28-11ea-96ae-873b524d0b9a.gif)

### Add a "Your request is being processed" page

When returning from sign-up or sign-in we were loading the `/afe` page again for a moment, only to auto-submit the final form data and redirect to the success page.  I've swapped this out for `/afe/submit`, which only renders the eligibility form without the surrounding promo material.

![Peek 2020-06-29 16-52](https://user-images.githubusercontent.com/1615761/86067192-211a0400-ba29-11ea-9453-ced423bffc34.gif)

It's still not a _great_ experience, but feels more intentional than the flash of the original marketing page on the way to a complete submission.


## Links

[The AFE integration TODO list.](https://docs.google.com/document/d/1Ny0pTrvkBMnOKx0CqoNnWTWhwq-oCn9IBYekSjiJMBc/edit)

## Testing story

Manually tested the behaviors above, in particular the flow for a signed-out user.

You can test this on your local copy by signing out of the app, navigating to `localhost.code.org:3000/afe`, and filling out the form.  You may need to make sure you have an eligible school on your local machine to test with - this requires a `School` and an associated `SchoolStatsByYear` with eligible stats - I found setting `students_total` and `frl_eligible_total` so that `frl_eligible_percent` was very high was a quick way to get something up and running.

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
