### PR TITLE
[Spritelab] Remove miniToolbox experiment

### DIFF
--- a/apps/src/block_utils.js
+++ b/apps/src/block_utils.js
@@ -1,6 +1,5 @@
 import _ from 'lodash';
 import xml from './xml';
-import experiments from '@cdo/apps/util/experiments';
 
 const ATTRIBUTES_TO_CLEAN = ['uservisible', 'deletable', 'movable'];
 const DEFAULT_COLOR = [184, 1.0, 0.74];
@@ -1000,10 +999,7 @@ exports.createJsWrapperBlockCreator = function(
           this.setPreviousStatement(true);
         }
 
-        if (
-          miniToolboxBlocks &&
-          experiments.isEnabled(experiments.MINI_TOOLBOX)
-        ) {
+        if (miniToolboxBlocks) {
           var toggle = new Blockly.FieldIcon('+');
           var miniToolboxXml = '<xml>';
           miniToolboxBlocks.forEach(block => {

--- a/apps/src/util/experiments.js
+++ b/apps/src/util/experiments.js
@@ -27,7 +27,6 @@ experiments.TEACHER_DASHBOARD_SECTION_BUTTONS =
   'teacher-dashboard-section-buttons';
 experiments.TEACHER_DASHBOARD_SECTION_BUTTONS_ALTERNATE_TEXT =
   'teacher-dashboard-section-buttons-alternate-text';
-experiments.MINI_TOOLBOX = 'miniToolbox';
 experiments.TEXT_TO_SPEECH_BLOCK = 'text-to-speech-block';
 experiments.FINISH_DIALOG_METRICS = 'finish-dialog-metrics';
 


### PR DESCRIPTION
Before:
![image](https://user-images.githubusercontent.com/8787187/86078881-f12c2a00-ba43-11ea-8b83-9f4a392f535e.png)
After:
![image](https://user-images.githubusercontent.com/8787187/86078916-0608bd80-ba44-11ea-87e5-59b58d2a0a0e.png)

The +/- toggle will be shown if the level has minitoolbox enabled AND the code is editable (so for example, not if you're viewing someone else's project)
The thumbnails on the pointer blocks will still show correctly even if the +/- toggle is not present:
![image](https://user-images.githubusercontent.com/8787187/86079084-829b9c00-ba44-11ea-9ccc-e023a2c59a00.png)

