### PR TITLE
AFE Integration: Handle submission failures

### DIFF
--- a/dashboard/app/controllers/api/v1/amazon_future_engineer_controller.rb
+++ b/dashboard/app/controllers/api/v1/amazon_future_engineer_controller.rb
@@ -1,24 +1,37 @@
-require 'cdo/contact_rollups/v2/pardot_helpers'
+require 'honeybadger/ruby'
 
+#
+# Handles submissions to our AFE form at code.org/afe, and in turn submits on
+# teachers' behalf to that program and related programs.
+#
 class Api::V1::AmazonFutureEngineerController < ApplicationController
-  include PardotHelpers
-
   # Necessary since Pegasus pages use this controller via dashboardapi
   skip_before_action :verify_authenticity_token
 
   def submit
     return head :forbidden unless current_user
-    if CDO.afe_pardot_form_handler_url
-      post_request CDO.afe_pardot_form_handler_url, afe_params
-    else
-      # Success, with a message:
-      <<~RESPONSE
-        It looks like you haven't configured the
-        afe_pardot_form_handler_url property.
-        Set this up in your locals.yml if you are testing this feature locally
-        and need to check the request sent to AFE-Pardot.
-      RESPONSE
-    end
+
+    afe_params = submit_params
+    Services::AFEEnrollment.new.submit(
+      traffic_source: 'AFE-code.org',
+      first_name: afe_params['firstName'],
+      last_name: afe_params['lastName'],
+      email: afe_params['email'],
+      nces_id: afe_params['schoolId'],
+      street_1: afe_params['street1'],
+      street_2: afe_params['street2'],
+      city: afe_params['city'],
+      state: afe_params['state'],
+      zip: afe_params['zip'],
+      marketing_kit: afe_params['inspirationKit'],
+      csta_plus: afe_params['csta'],
+      aws_educate: afe_params['awsEducate'],
+      amazon_terms: afe_params['consentAFE'],
+      new_code_account: current_user.created_at > 5.minutes.ago
+    )
+  rescue Services::AFEEnrollment::Error => e
+    Honeybadger.notify e
+    head :bad_request
   end
 
   private
@@ -49,27 +62,5 @@ class Api::V1::AmazonFutureEngineerController < ApplicationController
     params.require(:amazon_future_engineer).
            permit(*PERMITTED_PARAMETERS).
            tap {|p| p.require(REQUIRED_PARAMETERS)}
-  end
-
-  def afe_params
-    filtered_params = submit_params
-    {
-      'traffic-source' => filtered_params['trafficSource'],
-      'first-name' => filtered_params['firstName'],
-      'last-name' => filtered_params['lastName'],
-      'email' => filtered_params['email'],
-      'nces-id' => filtered_params['schoolId'],
-      'street-1' => filtered_params['street1'],
-      'street-2' => filtered_params['street2'],
-      'city' => filtered_params['city'],
-      'state' => filtered_params['state'],
-      'zip' => filtered_params['zip'],
-      'inspirational-marketing-kit' => filtered_params['inspirationKit'],
-      'csta-plus' => filtered_params['csta'],
-      'aws-educate' => filtered_params['awsEducate'],
-      'amazon-terms' => filtered_params['consentAFE'],
-      'new-code-account' => current_user.created_at > 5.minutes.ago ? '1' : '0',
-      'registration-date-time' => Time.now.iso8601
-    }
   end
 end

--- a/dashboard/lib/services/afe_enrollment.rb
+++ b/dashboard/lib/services/afe_enrollment.rb
@@ -1,0 +1,72 @@
+#
+# As part of our Amazon Future Engineer partnership, teachers at eligible
+# schools may apply for a number of benefits by filling out a form on our
+# website at code.org/afe.  Our system then submits the teacher's data and
+# preferences to the AFE program, so that they can receive their benefits.
+#
+# We submit the teacher's data to a Pardot form handler set up by AFE which
+# receives submissions in a custom format agreed upon in advance.  The form
+# handler responds 200 OK whether the submission is accepted or not; we must
+# read the response body to determine whether the submission has been
+# successful.  This services wraps that whole process.
+#
+class Services::AFEEnrollment
+  # Submit a teacher's information to the AFE Pardot form handler.
+  #
+  # @param traffic_source [String] Should always be AFE-code.org, for now
+  # @param first_name [String] max 127 characters
+  # @param last_name [String] max 127 characters
+  # @param email [String] max 127 characters
+  # @param nces_id [String] 12-digit school id
+  # @param street_1 [String] Teacher's school's address, max 50 characters
+  # @param street_2 [String] Teacher's school's address, max 30 characters
+  # @param city [String] Teacher's school's city, max 50 characters
+  # @param state [String] Teacher's school's state, 2 characters
+  # @param zip [String] Teacher's school's postal code, 5 characters
+  # @param marketing_kit [Boolean] Whether the teacher opted in to receiving AFE's marketing kit
+  # @param csta_plus [Boolean] Whether the teacher opted in to a free CSTA Plus membership
+  # @param aws_educate [Boolean] Whether the teacher opted in to a free AWS Educate membership
+  # @param amazon_terms [Boolean] Whether the teacher agreed to AFE's privacy policy and terms
+  #        of service.  Should always be true; we don't submit without this.
+  # @param new_code_account [Boolean] Whether the teacher signed up for code.org as part of the
+  #        AFE process.
+  def submit(traffic_source:, first_name:, last_name:, email:, nces_id:,
+    street_1:, street_2:, city:, state:, zip:, marketing_kit:, csta_plus:,
+    aws_educate:, amazon_terms:, new_code_account:)
+    return unless CDO.afe_pardot_form_handler_url
+
+    raise 'AFE submission skipped: Terms and conditions were not accepted' unless amazon_terms
+
+    response = Net::HTTP.post_form(
+      URI(CDO.afe_pardot_form_handler_url),
+      {
+        'traffic-source' => traffic_source,
+        'first-name' => first_name,
+        'last-name' => last_name,
+        'email' => email,
+        'nces-id' => nces_id,
+        'street-1' => street_1,
+        'street-2' => street_2,
+        'city' => city,
+        'state' => state,
+        'zip' => zip,
+        'inspirational-marketing-kit' => booleanize(marketing_kit),
+        'csta-plus' => booleanize(csta_plus),
+        'aws-educate' => booleanize(aws_educate),
+        'amazon-terms' => booleanize(amazon_terms),
+        'new-code-account' => booleanize(new_code_account),
+        'registration-date-time' => Time.now.iso8601
+      }
+    )
+
+    raise "AFE submission failed with HTTP #{response.status}" unless response.status == 200
+    raise "AFE submission failed with a validation error" if response.body =~ /Cannot find error page/
+    nil
+  end
+
+  private
+
+  def booleanize(val)
+    ActiveModel::Type::Boolean.new.cast(val) ? '1' : '0'
+  end
+end

--- a/dashboard/lib/services/afe_enrollment.rb
+++ b/dashboard/lib/services/afe_enrollment.rb
@@ -11,6 +11,8 @@
 # successful.  This services wraps that whole process.
 #
 class Services::AFEEnrollment
+  class Error < StandardError; end
+
   # Submit a teacher's information to the AFE Pardot form handler.
   #
   # @param traffic_source [String] Should always be AFE-code.org, for now
@@ -35,7 +37,7 @@ class Services::AFEEnrollment
     aws_educate:, amazon_terms:, new_code_account:)
     return unless CDO.afe_pardot_form_handler_url
 
-    raise 'AFE submission skipped: Terms and conditions were not accepted' unless amazon_terms
+    raise Error.new('AFE submission skipped: Terms and conditions were not accepted') unless amazon_terms
 
     response = Net::HTTP.post_form(
       URI(CDO.afe_pardot_form_handler_url),
@@ -59,8 +61,8 @@ class Services::AFEEnrollment
       }
     )
 
-    raise "AFE submission failed with HTTP #{response.status}" unless response.status == 200
-    raise "AFE submission failed with a validation error" if response.body =~ /Cannot find error page/
+    raise Error.new("AFE submission failed with HTTP #{response.status}") unless response.status == 200
+    raise Error.new("AFE submission failed with a validation error") if response.body =~ /Cannot find error page/
     nil
   end
 

--- a/dashboard/test/controllers/api/v1/amazon_future_engineer_controller_test.rb
+++ b/dashboard/test/controllers/api/v1/amazon_future_engineer_controller_test.rb
@@ -14,7 +14,7 @@ class Api::V1::AmazonFutureEngineerControllerTest < ActionDispatch::IntegrationT
     assert_response :forbidden
   end
 
-  test 'submit returns BAD REQUEST when params are malformed' do
+  test 'responds BAD REQUEST when params are malformed' do
     Net::HTTP.expects(:post_form).never
 
     # Intentionally missing required field traffic-source
@@ -25,13 +25,23 @@ class Api::V1::AmazonFutureEngineerControllerTest < ActionDispatch::IntegrationT
     assert_response :bad_request, "Expected BAD REQUEST, got: #{response.status}\n#{response.body}"
   end
 
-  test 'submit returns BAD REQUEST when params are missing' do
+  test 'responds BAD REQUEST when params are missing' do
     Net::HTTP.stubs(:post_form)
 
     sign_in create :teacher
     post '/dashboardapi/v1/amazon_future_engineer_submit'
 
     assert_response :bad_request, "Expected BAD REQUEST, got: #{response.status}\n#{response.body}"
+  end
+
+  test 'responds BAD REQUEST when terms are not accepted' do
+    Net::HTTP.expects(:post_form).never
+    Honeybadger.expects(:notify)
+
+    sign_in create :teacher
+    post '/dashboardapi/v1/amazon_future_engineer_submit',
+      params: valid_params.merge('consentAFE' => false), as: :json
+    assert_response :bad_request, "Wrong response: #{response.body}"
   end
 
   test 'logged in can submit' do

--- a/dashboard/test/lib/services/afe_enrollment_test.rb
+++ b/dashboard/test/lib/services/afe_enrollment_test.rb
@@ -1,0 +1,186 @@
+require 'test_helper'
+
+class Services::AFEEnrollmentTest < ActiveSupport::TestCase
+  FAKE_FORM_URL = 'https://example.com/testform'
+
+  def setup
+    CDO.stubs(:afe_pardot_form_handler_url).returns(FAKE_FORM_URL)
+  end
+
+  test 'submit does nothing if configuration is missing' do
+    CDO.unstub(:afe_pardot_form_handler_url)
+    CDO.stubs(:afe_pardot_form_handler_url).returns(nil)
+    Net::HTTP.expects(:post_form).never
+    Services::AFEEnrollment.new.submit(valid_test_params)
+  end
+
+  test 'submit posts to Pardot with the expected format' do
+    Timecop.freeze do
+      expected_request = Net::HTTP.expects(:post_form).with do |uri, params|
+        uri.to_s == FAKE_FORM_URL && params.to_h == {
+          'traffic-source' => 'AFE-code.org-test',
+          'first-name' => 'test-first-name',
+          'last-name' => 'test-last-name',
+          'email' => 'test-email',
+          'nces-id' => '012345678901',
+          'street-1' => 'test-street-1',
+          'street-2' => 'test-street-2',
+          'city' => 'test-city',
+          'state' => 'test-state',
+          'zip' => 'test-zip',
+          'inspirational-marketing-kit' => '1',
+          'csta-plus' => '1',
+          'aws-educate' => '1',
+          'amazon-terms' => '1',
+          'new-code-account' => '1',
+          'registration-date-time' => Time.now.iso8601
+        }
+      end
+      expected_request.returns(fake_success_response)
+
+      Services::AFEEnrollment.new.submit(valid_test_params)
+    end
+  end
+
+  test 'false becomes "0" for boolean params' do
+    expected_request = Net::HTTP.expects(:post_form).with do |_, params|
+      params['aws-educate'] == '0'
+    end
+    expected_request.returns(fake_success_response)
+
+    Services::AFEEnrollment.new.submit(valid_test_params.merge(aws_educate: false))
+  end
+
+  test 'the string "false" becomes "0" for boolean params' do
+    expected_request = Net::HTTP.expects(:post_form).with do |_, params|
+      params['aws-educate'] == '0'
+    end
+    expected_request.returns(fake_success_response)
+
+    Services::AFEEnrollment.new.submit(valid_test_params.merge(aws_educate: 'false'))
+  end
+
+  test 'the number 0 becomes "0" for boolean params' do
+    expected_request = Net::HTTP.expects(:post_form).with do |_, params|
+      params['aws-educate'] == '0'
+    end
+    expected_request.returns(fake_success_response)
+
+    Services::AFEEnrollment.new.submit(valid_test_params.merge(aws_educate: 0))
+  end
+
+  test 'the string "0" becomes "0" for boolean params' do
+    expected_request = Net::HTTP.expects(:post_form).with do |_, params|
+      params['aws-educate'] == '0'
+    end
+    expected_request.returns(fake_success_response)
+
+    Services::AFEEnrollment.new.submit(valid_test_params.merge(aws_educate: '0'))
+  end
+
+  test 'true becomes "1" for boolean params' do
+    expected_request = Net::HTTP.expects(:post_form).with do |_, params|
+      params['aws-educate'] == '1'
+    end
+    expected_request.returns(fake_success_response)
+
+    Services::AFEEnrollment.new.submit(valid_test_params.merge(aws_educate: true))
+  end
+
+  test 'the string "true" becomes "1" for boolean params' do
+    expected_request = Net::HTTP.expects(:post_form).with do |_, params|
+      params['aws-educate'] == '1'
+    end
+    expected_request.returns(fake_success_response)
+
+    Services::AFEEnrollment.new.submit(valid_test_params.merge(aws_educate: 'true'))
+  end
+
+  test 'the number 1 becomes "1" for boolean params' do
+    expected_request = Net::HTTP.expects(:post_form).with do |_, params|
+      params['aws-educate'] == '1'
+    end
+    expected_request.returns(fake_success_response)
+
+    Services::AFEEnrollment.new.submit(valid_test_params.merge(aws_educate: 1))
+  end
+
+  test 'the string "1" becomes "1" for boolean params' do
+    expected_request = Net::HTTP.expects(:post_form).with do |_, params|
+      params['aws-educate'] == '1'
+    end
+    expected_request.returns(fake_success_response)
+
+    Services::AFEEnrollment.new.submit(valid_test_params.merge(aws_educate: '1'))
+  end
+
+  test 'raises without submitting if amazon_terms is not true' do
+    Net::HTTP.expects(:post_form).never
+    assert_raises_matching /AFE submission skipped: Terms and conditions were not accepted/ do
+      Services::AFEEnrollment.new.submit(valid_test_params.merge(amazon_terms: false))
+    end
+  end
+
+  test 'submit raises when Pardot response is a failure status' do
+    Net::HTTP.stubs(:post_form).returns(fake_unavailable_response)
+    assert_raises_matching /AFE submission failed with HTTP 503/ do
+      Services::AFEEnrollment.new.submit(valid_test_params)
+    end
+  end
+
+  test 'submit raises when Pardot response is a validation failure' do
+    Net::HTTP.stubs(:post_form).returns(fake_validation_failure_response)
+    assert_raises_matching /AFE submission failed with a validation error/ do
+      Services::AFEEnrollment.new.submit(valid_test_params)
+    end
+  end
+
+  private
+
+  def valid_test_params
+    {
+      traffic_source: 'AFE-code.org-test',
+      first_name: 'test-first-name',
+      last_name: 'test-last-name',
+      email: 'test-email',
+      nces_id: '012345678901',
+      street_1: 'test-street-1',
+      street_2: 'test-street-2',
+      city: 'test-city',
+      state: 'test-state',
+      zip: 'test-zip',
+      marketing_kit: true,
+      csta_plus: true,
+      aws_educate: true,
+      amazon_terms: true,
+      new_code_account: true
+    }
+  end
+
+  def fake_success_response
+    mock.tap do |response|
+      response.stubs(:status).returns(200)
+      response.stubs(:body).returns(<<~BODY)
+        Cannot find success page to redirect to. Please use your browser back button.
+      BODY
+    end
+  end
+
+  def fake_validation_failure_response
+    mock.tap do |response|
+      # This reflects the actual behavior of the Pardot form handler: It returns a
+      # 200 when a validation failure occurs.
+      response.stubs(:status).returns(200)
+      response.stubs(:body).returns(<<~BODY)
+        Cannot find error page to redirect to. Please use your browser back button.
+        Please correct the following errors:~~~ - This field is required~~~
+      BODY
+    end
+  end
+
+  def fake_unavailable_response
+    mock.tap do |response|
+      response.stubs(:status).returns(503)
+    end
+  end
+end

--- a/dashboard/test/lib/services/afe_enrollment_test.rb
+++ b/dashboard/test/lib/services/afe_enrollment_test.rb
@@ -43,75 +43,35 @@ class Services::AFEEnrollmentTest < ActiveSupport::TestCase
   end
 
   test 'false becomes "0" for boolean params' do
-    expected_request = Net::HTTP.expects(:post_form).with do |_, params|
-      params['aws-educate'] == '0'
-    end
-    expected_request.returns(fake_success_response)
-
-    Services::AFEEnrollment.new.submit(valid_test_params.merge(aws_educate: false))
+    assert_param_translation({aws_educate: false}, {'aws-educate' => '0'})
   end
 
   test 'the string "false" becomes "0" for boolean params' do
-    expected_request = Net::HTTP.expects(:post_form).with do |_, params|
-      params['aws-educate'] == '0'
-    end
-    expected_request.returns(fake_success_response)
-
-    Services::AFEEnrollment.new.submit(valid_test_params.merge(aws_educate: 'false'))
+    assert_param_translation({aws_educate: 'false'}, {'aws-educate' => '0'})
   end
 
   test 'the number 0 becomes "0" for boolean params' do
-    expected_request = Net::HTTP.expects(:post_form).with do |_, params|
-      params['aws-educate'] == '0'
-    end
-    expected_request.returns(fake_success_response)
-
-    Services::AFEEnrollment.new.submit(valid_test_params.merge(aws_educate: 0))
+    assert_param_translation({aws_educate: 0}, {'aws-educate' => '0'})
   end
 
   test 'the string "0" becomes "0" for boolean params' do
-    expected_request = Net::HTTP.expects(:post_form).with do |_, params|
-      params['aws-educate'] == '0'
-    end
-    expected_request.returns(fake_success_response)
-
-    Services::AFEEnrollment.new.submit(valid_test_params.merge(aws_educate: '0'))
+    assert_param_translation({aws_educate: '0'}, {'aws-educate' => '0'})
   end
 
   test 'true becomes "1" for boolean params' do
-    expected_request = Net::HTTP.expects(:post_form).with do |_, params|
-      params['aws-educate'] == '1'
-    end
-    expected_request.returns(fake_success_response)
-
-    Services::AFEEnrollment.new.submit(valid_test_params.merge(aws_educate: true))
+    assert_param_translation({aws_educate: true}, {'aws-educate' => '1'})
   end
 
   test 'the string "true" becomes "1" for boolean params' do
-    expected_request = Net::HTTP.expects(:post_form).with do |_, params|
-      params['aws-educate'] == '1'
-    end
-    expected_request.returns(fake_success_response)
-
-    Services::AFEEnrollment.new.submit(valid_test_params.merge(aws_educate: 'true'))
+    assert_param_translation({aws_educate: 'true'}, {'aws-educate' => '1'})
   end
 
   test 'the number 1 becomes "1" for boolean params' do
-    expected_request = Net::HTTP.expects(:post_form).with do |_, params|
-      params['aws-educate'] == '1'
-    end
-    expected_request.returns(fake_success_response)
-
-    Services::AFEEnrollment.new.submit(valid_test_params.merge(aws_educate: 1))
+    assert_param_translation({aws_educate: 1}, {'aws-educate' => '1'})
   end
 
   test 'the string "1" becomes "1" for boolean params' do
-    expected_request = Net::HTTP.expects(:post_form).with do |_, params|
-      params['aws-educate'] == '1'
-    end
-    expected_request.returns(fake_success_response)
-
-    Services::AFEEnrollment.new.submit(valid_test_params.merge(aws_educate: '1'))
+    assert_param_translation({aws_educate: '1'}, {'aws-educate' => '1'})
   end
 
   test 'raises without submitting if amazon_terms is not true' do
@@ -136,6 +96,24 @@ class Services::AFEEnrollmentTest < ActiveSupport::TestCase
   end
 
   private
+
+  # Check that certain input params turn into expected output params
+  # @param input_params [Hash] partial input params, to be merged over valid input
+  # @param expected_params [Hash] expected params sent to AFE; does not need to be complete
+  def assert_param_translation(input_params, expected_params)
+    captured_params = nil
+    expected_request = Net::HTTP.expects(:post_form).with do |_, params|
+      captured_params = params; true
+    end
+    expected_request.returns(fake_success_response)
+
+    Services::AFEEnrollment.new.submit(valid_test_params.merge(input_params))
+
+    refute_nil captured_params
+    expected_params.each do |key, expected_value|
+      assert_equal expected_value, captured_params[key]
+    end
+  end
 
   def valid_test_params
     {


### PR DESCRIPTION
Our controller correctly detects failed attempts to submit to AFE, logs them to Honeybadger, and response with BAD REQUEST.

I've also extracted a lot of our AFE submission logic to a service, to hide away details before we add a CSTA submission to this controller as well.

## Links

[The AFE integration TODO list.](https://docs.google.com/document/d/1Ny0pTrvkBMnOKx0CqoNnWTWhwq-oCn9IBYekSjiJMBc/edit)

## Testing story

Covered by new unit tests and existing unit tests.

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
