### PR TITLE
Update redirection script for 2020 course launch

### DIFF
--- a/aws/s3/cdo-curriculum/redirection_rules.rb
+++ b/aws/s3/cdo-curriculum/redirection_rules.rb
@@ -20,7 +20,7 @@ routing_rules = [
     },
     redirect: {
       host_name: HOST_NAME,
-      replace_key_prefix_with: "csp-19/"
+      replace_key_prefix_with: "csp-20/"
     }
   },
   {
@@ -38,7 +38,7 @@ routing_rules = [
     },
     redirect: {
       host_name: HOST_NAME,
-      replace_key_prefix_with: "csd-19/"
+      replace_key_prefix_with: "csd-20/"
     }
   },
   {
@@ -56,7 +56,7 @@ routing_rules = [
     },
     redirect: {
       host_name: HOST_NAME,
-      replace_key_prefix_with: "csf-19/"
+      replace_key_prefix_with: "csf-20/"
     }
   },
   {


### PR DESCRIPTION
Updates the script used to update the redirects for curriculum builder so that the default redirect is to the 2020 courses now.