### PR TITLE
avoid link to csd6 in circuit playground markdown

### DIFF
--- a/pegasus/sites.v3/code.org/public/circuitplayground.md
+++ b/pegasus/sites.v3/code.org/public/circuitplayground.md
@@ -12,7 +12,7 @@ theme: responsive
 
 <div class="col-66" style="margin-top: 50px;">
 
-The Circuit Playground is family of small microcontroller boards with LEDs, buttons, and sensors built in. Designed specifically for novice programmers, the Circuit Playground enables students to get up and running quickly with physical computing without worrying about many of the traditional barriers to entry. Developed by our friends at <a href="//adafruit.com">Adafruit</a>, the Circuit Playground is the core tool used in <a href="//studio.code.org/s/csd6">CS Discoveries Unit 6, Physical Computing</a>.
+The Circuit Playground is family of small microcontroller boards with LEDs, buttons, and sensors built in. Designed specifically for novice programmers, the Circuit Playground enables students to get up and running quickly with physical computing without worrying about many of the traditional barriers to entry. Developed by our friends at <a href="//adafruit.com">Adafruit</a>, the Circuit Playground is the core tool used in Unit 6, Physical Computing in <a href="//studio.code.org/courses/csd">CS Discoveries</a>.
 
 </div>
 


### PR DESCRIPTION
## Background

Follow-on to https://github.com/code-dot-org/code-dot-org/pull/35489 . Please see that PR for context.

## Description

Eliminates the link to /s/csd6, because we are trying to deprecate this kind of link.

### before

![circuit-playground-before](https://user-images.githubusercontent.com/8001765/86179861-e7f09b00-badf-11ea-9409-d8b160f7f2b1.gif)


### after

![circuit-playground](https://user-images.githubusercontent.com/8001765/86179877-ecb54f00-badf-11ea-961a-abbb3409c242.gif)


## Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
