### PR TITLE
AFE Integration: Detect and report submission failure

### DIFF
--- a/dashboard/app/controllers/api/v1/amazon_future_engineer_controller.rb
+++ b/dashboard/app/controllers/api/v1/amazon_future_engineer_controller.rb
@@ -31,7 +31,7 @@ class Api::V1::AmazonFutureEngineerController < ApplicationController
     )
   rescue Services::AFEEnrollment::Error => e
     Honeybadger.notify e
-    head :bad_request
+    render json: e.to_s, status: 400
   end
 
   private

--- a/pegasus/sites.v3/code.org/public/afe/submit.md.erb
+++ b/pegasus/sites.v3/code.org/public/afe/submit.md.erb
@@ -3,6 +3,4 @@ title: Bring computer science to your classroom with Code.org and Amazon Future 
 theme: responsive
 ---
 
-# Bring computer science to your classroom with Code.org and Amazon Future Engineer
-
 <%= view :amazon_future_engineer_eligibility %>


### PR DESCRIPTION
The AFE form can now detect when the AFE submission has failed and display an error message with error details and advising that the teacher get in touch with support.

## Links

[The AFE integration TODO list](https://docs.google.com/document/d/1Ny0pTrvkBMnOKx0CqoNnWTWhwq-oCn9IBYekSjiJMBc/edit)

## Testing story

Manual testing, captured in screencasts below.  Note: These scenarios are from my local machine.  They use accounts preconfigured on my machine, and all schools are considered "eligible" for purposes of this test.  I have not covered the "signs up for new account" case below as it should be the same as the "signs in to existing account" case for purposes of reporting submission errors.

**Already signed in, happy path**

![happy-path](https://user-images.githubusercontent.com/1615761/86181147-5afb1100-bae2-11ea-8966-53ab7ce8910a.gif)

**Already signed in, submission error**

![error-case](https://user-images.githubusercontent.com/1615761/86181177-62bab580-bae2-11ea-8a97-9444981eb667.gif)

**Signs in to existing account, happy path**

![happy-path-signed-out](https://user-images.githubusercontent.com/1615761/86181198-6bab8700-bae2-11ea-8fe3-f3f1993542a0.gif)

**Signs in to existing account, submission error**

![error-case-signed-out](https://user-images.githubusercontent.com/1615761/86181229-7a923980-bae2-11ea-9fab-c4d679134c27.gif)

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
