### PR TITLE
join infra-honeybadger slack room when running bin/dotd

### DIFF
--- a/bin/dotd
+++ b/bin/dotd
@@ -499,6 +499,7 @@ def main
   Slack.join_room('infra-staging')
   Slack.join_room('infra-test')
   Slack.join_room('infra-production')
+  Slack.join_room('infra-honeybadger')
   Slack.join_room('levelbuilder')
 
   puts_script_intro


### PR DESCRIPTION
a [recent poll](https://codedotorg.slack.com/archives/C0T0PNTM3/p1592932732167800) shows that most developers rely on [#infra-honeybadger](https://codedotorg.slack.com/archives/C55JZ1BPZ) to be notified of new honeybadger issues. Because some errors only ever notify here once, it's important for every oncall developer to monitor this channel, to maximize our chances of catching the first occurrence of each new issue.