### PR TITLE
Allow crossdomain redirect in sign up (and update AFE component to use it)

### DIFF
--- a/apps/src/templates/amazonFutureEngineerEligibility/amazonFutureEngineerAccountConfirmation.jsx
+++ b/apps/src/templates/amazonFutureEngineerEligibility/amazonFutureEngineerAccountConfirmation.jsx
@@ -33,7 +33,6 @@ export default class AmazonFutureEngineerAccountConfirmation extends React.Compo
   };
 
   render() {
-    // TO DO: Add links to account sign up page.
     return (
       <div>
         <h2 style={styles.header}>Almost done!</h2>
@@ -49,7 +48,7 @@ export default class AmazonFutureEngineerAccountConfirmation extends React.Compo
         </div>
         <Button
           id="sign_up"
-          href={this.returnToURL('/users/sign_in')}
+          href={this.returnToURL('/users/sign_up')}
           style={styles.button}
           onClick={this.logSignUpButtonPress}
         >

--- a/dashboard/app/controllers/registrations_controller.rb
+++ b/dashboard/app/controllers/registrations_controller.rb
@@ -14,11 +14,7 @@ class RegistrationsController < Devise::RegistrationsController
   # GET /users/sign_up
   #
   def new
-    # Used by old signup form
     session[:user_return_to] ||= params[:user_return_to]
-    # Used by new signup form
-    store_location_for(:user, params[:user_return_to]) if params[:user_return_to]
-
     if PartialRegistration.in_progress?(session)
       user_params = params[:user] || {}
       @user = User.new_with_session(user_params, session)

--- a/dashboard/test/controllers/registrations_controller_test.rb
+++ b/dashboard/test/controllers/registrations_controller_test.rb
@@ -185,6 +185,28 @@ class RegistrationsControllerTest < ActionController::TestCase
     assert_equal EmailPreference::PARENT_EMAIL_CHANGE, email_preference[:source]
   end
 
+  test "sign up page saves return to url in session" do
+    # Note that we currently have no restrictions on what the domain of the
+    # redirect url can be; we may at some point want to add domain
+    # restrictions, but if we do so we want to make sure that both
+    # studio.code.org and code.org are supported.
+    #
+    # See also the "sign in page saves return to url in session" test in
+    # sessions_controller_test
+    urls = [
+      "/foo",
+      "//studio.code.org/foo",
+      "//code.org/foo",
+      "//some_other_domain.com/foo"
+    ]
+
+    urls.each do |url|
+      session.delete(:user_return_to)
+      get :new, params: {user_return_to: url}
+      assert_equal url, session[:user_return_to]
+    end
+  end
+
   test "teachers go to specified return to url after signing up" do
     session[:user_return_to] = user_return_to = '//test.code.org/the-return-to-url'
 

--- a/dashboard/test/controllers/sessions_controller_test.rb
+++ b/dashboard/test/controllers/sessions_controller_test.rb
@@ -46,10 +46,25 @@ class SessionsControllerTest < ActionController::TestCase
   end
 
   test "sign in page saves return to url in session" do
-    user_return_to = 'http://code.org/a-return-to-url'
-    get :new, params: {user_return_to:  user_return_to}
+    # Note that we currently have no restrictions on what the domain of the
+    # redirect url can be; we may at some point want to add domain
+    # restrictions, but if we do so we want to make sure that both
+    # studio.code.org and code.org are supported.
+    #
+    # See also the "sign up page saves return to url in session" test in
+    # registrations_controller_test
+    urls = [
+      "/foo",
+      "//studio.code.org/foo",
+      "//code.org/foo",
+      "//some_other_domain.com/foo"
+    ]
 
-    assert_equal user_return_to, session[:user_return_to]
+    urls.each do |url|
+      session.delete(:user_return_to)
+      get :new, params: {user_return_to: url}
+      assert_equal url, session[:user_return_to]
+    end
   end
 
   test "teachers go to specified return to url after signing in" do


### PR DESCRIPTION
Both the sign in and sign up pathways support redirecting the user via the `user_return_to` param, but only the sign up pathway was using the devise helper `store_location_for`. Unfortunately, this helper normalizes all paths to the rails domain; this becomes a problem when we want to, for example, redirect to a pegasus url which is technically on a different domain.

The simple fix is to just stop using that helper on the sign up pathway, which brings its functionality in line with the sign in pathway.

## Testing story

The 'save the url to be redirected to' functionality was already tested for the sign in pathway, but not for the sign up. I added a test to the sign up and taught both tests how to consider a variety of domains.

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
