### PR TITLE
Increase Redshift Snapshot retention to 5 days

### DIFF
--- a/aws/cloudformation/data.yml.erb
+++ b/aws/cloudformation/data.yml.erb
@@ -49,7 +49,7 @@ Resources:
     DeletionPolicy: Retain
     Properties:
       AllowVersionUpgrade: true
-      AutomatedSnapshotRetentionPeriod: 1
+      AutomatedSnapshotRetentionPeriod: 5
       ClusterParameterGroupName: default.redshift-1.0
       ClusterSubnetGroupName: !ImportValue VPC-RedshiftSubnetGroup
       ClusterType: single-node


### PR DESCRIPTION
https://codedotorg.atlassian.net/browse/INF-299


## Testing story


```
bundle exec rake stack:data:validate RAILS_ENV=production
Listing changes to existing stack `DATA-production`:
Modify DMSCronLevelSourcesPii [AWS::DMS::ReplicationTask] Properties Replacement: Conditional (TargetEndpointArn)
Modify DMSCronPii [AWS::DMS::ReplicationTask] Properties Replacement: Conditional (TargetEndpointArn)
Modify DMSCronUserHierarchyPii [AWS::DMS::ReplicationTask] Properties Replacement: Conditional (TargetEndpointArn)
Modify DMSCronUserHierarchy [AWS::DMS::ReplicationTask] Properties Replacement: Conditional (TargetEndpointArn)
Modify DMSCronUserLevels [AWS::DMS::ReplicationTask] Properties Replacement: Conditional (TargetEndpointArn)
Modify DMSCron [AWS::DMS::ReplicationTask] Properties Replacement: Conditional (TargetEndpointArn)
Modify RedshiftEndpoint [AWS::DMS::Endpoint] Properties Replacement: Conditional (ServerName, Port)
Modify Tableau [AWS::Redshift::Cluster] Properties (AutomatedSnapshotRetentionPeriod)
```

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
