### PR TITLE
Guard against user trying to access sprite with invalid spriteIndex

### DIFF
--- a/apps/src/studio/studio.js
+++ b/apps/src/studio/studio.js
@@ -6364,10 +6364,10 @@ function getSpritesByName(name) {
 }
 
 Studio.setSpriteBehavior = function(opts) {
-  Studio.sprite[opts.spriteIndex].setActivity(
-    opts.behavior,
-    opts.targetSpriteIndex
-  );
+  const sprite = Studio.sprite[opts.spriteIndex];
+  if (sprite) {
+    sprite.setActivity(opts.behavior, opts.targetSpriteIndex);
+  }
 };
 
 Studio.setSpritesWander = function(opts) {


### PR DESCRIPTION
Only call setActivity if a sprite with the requested spriteIndex exists. Addresses [this New Relic error](https://rpm.newrelic.com/accounts/501463/browser/3787364/errors/details#?tw_start=&tw_end=now&tw_offset=10800000&selectedItem=Cannot%20read%20property%20'setActivity'%20of%20undefined&selectedTab=instances):
<img width="747" alt="Screen Shot 2020-06-30 at 5 05 08 PM" src="https://user-images.githubusercontent.com/9812299/86188564-e16c1e80-baf3-11ea-9a51-7353ca49f652.png">

## Testing story

Tested manually. No new tests are seem necessary.

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
