### PR TITLE
CRv2: Report results to Slack and S3

### DIFF
--- a/dashboard/lib/contact_rollups_v2.rb
+++ b/dashboard/lib/contact_rollups_v2.rb
@@ -251,18 +251,18 @@ class ContactRollupsV2
     ).compact.sum
     formatted_duration = Time.at(duration).utc.strftime("%Hh:%Mm:%Ss")
 
-    log_link = "<a href='#{log_url}'>☁ Log on S3</a>"
+    log_link = "<a href='#{log_url}'>:cloud: Log on S3</a>"
 
     cloud_watch_link =
       "<a href='https://console.aws.amazon.com/cloudwatch/home?region=us-east-1#dashboards:name=Contact-Rollups-V2'>"\
-      "📈 CloudWatch dashboard</a>"
+      ":chart_with_upwards_trend: CloudWatch dashboard</a>"
 
     summary = [
       "*ContactRollupsV2* (#{CDO.rack_env}#{', dry-run' if @is_dry_run})",
       "Number of Pardot prospects created: #{@log_collector.metrics[:ProspectsCreated]}",
       "Number of Pardot prospects updated: #{@log_collector.metrics[:ProspectsUpdated]}",
       "Number of contacts in ContactRollupsFinal: #{@log_collector.metrics[:FinalRows]}",
-      "🕐 #{formatted_duration} #{log_link} #{cloud_watch_link}"
+      ":clock10: #{formatted_duration} #{log_link} #{cloud_watch_link}"
     ].join("\n")
 
     ChatClient.message 'cron-daily', summary

--- a/dashboard/lib/contact_rollups_v2.rb
+++ b/dashboard/lib/contact_rollups_v2.rb
@@ -251,12 +251,18 @@ class ContactRollupsV2
     ).compact.sum
     formatted_duration = Time.at(duration).utc.strftime("%Hh:%Mm:%Ss")
 
+    log_link = "<a href='#{log_url}'>☁ Log on S3</a>"
+
+    cloud_watch_link =
+      "<a href='https://console.aws.amazon.com/cloudwatch/home?region=us-east-1#dashboards:name=Contact-Rollups-V2'>"\
+      "📈 CloudWatch dashboard</a>"
+
     summary = [
       "*ContactRollupsV2* (#{CDO.rack_env}#{', dry-run' if @is_dry_run})",
       "Number of Pardot prospects created: #{@log_collector.metrics[:ProspectsCreated]}",
       "Number of Pardot prospects updated: #{@log_collector.metrics[:ProspectsUpdated]}",
       "Number of contacts in ContactRollupsFinal: #{@log_collector.metrics[:FinalRows]}",
-      "🕐 #{formatted_duration} <a href='#{log_url}'>☁ Log on S3</a>"
+      "🕐 #{formatted_duration} #{log_link} #{cloud_watch_link}"
     ].join("\n")
 
     ChatClient.message 'cron-daily', summary


### PR DESCRIPTION
Reports pipeline summary to Slack and uploads full log to S3. Inspired by [ExpiredDeletedAccountPurger](https://github.com/code-dot-org/code-dot-org/blob/2e31c191c3cb8c962245332c59087e4433e1409b/dashboard/lib/expired_deleted_account_purger.rb#L138-L157) work.

Example summary message in `cron-daily` channel:

<img width="337" alt="Screen Shot 2020-07-01 at 11 36 11 AM" src="https://user-images.githubusercontent.com/46507039/86279636-327d2080-bb8f-11ea-86ef-fe54eebde748.png">

## Links
- [Test message in cron-daily channel](https://codedotorg.slack.com/archives/C3S8AJY9K/p1593563576005000).
- [CRv2 audit logs in S3](https://s3.console.aws.amazon.com/s3/buckets/cdo-audit-logs/contact-rollups-v2/).
- [CRv2 CloudWatch dashboard](https://console.aws.amazon.com/cloudwatch/home?region=us-east-1#dashboards:name=Contact-Rollups-V2).

## Testing story
- On local machine, in `locals.yml` file, set `hip_chat_logging` to true, add `slack_token` and `slack_endpoint` from AWS Secrets Manager.
- Test the pipeline:
    ```ruby
    # Run the pipeline
    cr = ContactRollupsV2.new(is_dry_run: true, limit_extraction: 100); 
    cr.build_and_sync
    cr.report_results

    # In dry-run mode, report_results doesn't report to Slack and S3.
    # Manually call the following methods to send report
    url = cr.upload_to_s3
    cr.report_to_slack log_url: url
    ```
