### PR TITLE
added empty json check for voice request

### DIFF
--- a/dashboard/app/helpers/levels_helper.rb
+++ b/dashboard/app/helpers/levels_helper.rb
@@ -484,7 +484,7 @@ module LevelsHelper
       voice_request = Net::HTTP::Get.new(voice_uri.request_uri, voice_header)
       voice_response = voice_http_request.request(voice_request)
 
-      all_voices = JSON.parse(voice_response.body)
+      all_voices = voice_response.body && voice_response.body.length >= 2 ? JSON.parse(voice_response.body) : {}
       language_dictionary = {}
       all_voices.each do |voice|
         native_locale_name = Languages.get_native_name_by_locale(voice["Locale"])


### PR DESCRIPTION
When requests to azure time out, we return {} as the response as of [this PR](https://github.com/code-dot-org/code-dot-org/pull/35518). However, this introduced a new error in HoneyBadger. This adds a check to make sure the response was big enough to parse or if we should just forward the {} along to the frontend.

<!-- ### Background -->
<!-- ### Privacy -->
<!-- ### Security -->
<!-- ### Caching -->
<!-- ### Deployment strategy -->
<!-- ### Future work -->

## Links

<!--
  Any relevant links to external resources; ie, specification documents, jira
  items, related PRs, honeybadger errors, etc
-->

- [PR that introduced this](https://github.com/code-dot-org/code-dot-org/pull/35518)
- [Slack conversation about it](https://codedotorg.slack.com/archives/C1B3PNDL7/p1593622571213700)

## Testing story


# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
