### PR TITLE
Track which sprite is chosen from animation library

### DIFF
--- a/apps/src/p5lab/AnimationPicker/animationPickerModule.js
+++ b/apps/src/p5lab/AnimationPicker/animationPickerModule.js
@@ -13,6 +13,7 @@ import {animations as animationsApi} from '@cdo/apps/clientApi';
 var msg = require('@cdo/locale');
 import {changeInterfaceMode} from '../actions';
 import {P5LabInterfaceMode} from '../constants';
+import firehoseClient from '@cdo/apps/lib/util/firehose';
 
 /**
  * @enum {string} Export possible targets for animation picker for consumers
@@ -199,6 +200,12 @@ export function pickNewAnimation() {
  * @returns {function}
  */
 export function pickLibraryAnimation(animation) {
+  firehoseClient.putRecord({
+    study: 'sprite-use',
+    study_group: 'before-update',
+    event: 'select-sprite',
+    data_string: animation.name
+  });
   return (dispatch, getState) => {
     const goal = getState().animationPicker.goal;
     if (goal === Goal.NEW_ANIMATION) {


### PR DESCRIPTION
In a meeting about sprite refreshing, there were questions about which sprites are actually used. This PR adds a quick metric to track the name of the animation when an animation is chosen from the animation library.

## Testing story

<!--
  Does your change include appropriate tests?

  If so, please describe how the tests included in this PR are sufficient

  If not, please explain why this change does not need to be tested.
-->

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
