### PR TITLE
Batch Firebase delete_channels in the same client

### DIFF
--- a/dashboard/test/helpers/delete_accounts_helper_test.rb
+++ b/dashboard/test/helpers/delete_accounts_helper_test.rb
@@ -39,6 +39,7 @@ class DeleteAccountsHelperTest < ActionView::TestCase
 
     # Skip real Firebase operations
     FirebaseHelper.stubs(:delete_channel)
+    FirebaseHelper.stubs(:delete_channels)
 
     # Global log used to check expected log output
     @log = StringIO.new
@@ -1791,14 +1792,14 @@ class DeleteAccountsHelperTest < ActionView::TestCase
       with_channel_for student do |storage_app_id_b, storage_id|
         storage_apps.where(id: storage_app_id_a).update(state: 'deleted')
 
+        student_channels = [storage_encrypt_channel_id(storage_id, storage_app_id_a),
+                            storage_encrypt_channel_id(storage_id, storage_app_id_b)]
         FirebaseHelper.
-          expects(:delete_channel).
-          with(storage_encrypt_channel_id(storage_id, storage_app_id_a))
-        FirebaseHelper.
-          expects(:delete_channel).
-          with(storage_encrypt_channel_id(storage_id, storage_app_id_b))
+          expects(:delete_channels).
+          with(student_channels)
 
         purge_user student
+        assert_logged "Deleting Firebase contents for 2 channels"
       end
     end
   end

--- a/lib/cdo/delete_accounts_helper.rb
+++ b/lib/cdo/delete_accounts_helper.rb
@@ -47,15 +47,15 @@ class DeleteAccountsHelper
       update(value: nil, updated_ip: '', updated_at: Time.now)
 
     # Clear S3 contents for user's channels
+    @log.puts "Deleting S3 contents for #{channel_count} channels"
     buckets = [SourceBucket, AssetBucket, AnimationBucket, FileBucket].map(&:new)
     buckets.product(encrypted_channel_ids).each do |bucket, encrypted_channel_id|
       bucket.hard_delete_channel_content encrypted_channel_id
     end
 
     # Clear Firebase contents for user's channels
-    encrypted_channel_ids.each do |encrypted_channel_id|
-      FirebaseHelper.delete_channel encrypted_channel_id
-    end
+    @log.puts "Deleting Firebase contents for #{channel_count} channels"
+    FirebaseHelper.delete_channels encrypted_channel_ids
 
     @log.puts "Deleted #{channel_count} channels" if channel_count > 0
   end

--- a/shared/middleware/helpers/firebase_helper.rb
+++ b/shared/middleware/helpers/firebase_helper.rb
@@ -120,6 +120,13 @@ class FirebaseHelper
     @firebase.set("/v3/channels/shared/metadata/manifest", manifest)
   end
 
+  def self.delete_channels(encrypted_channel_ids)
+    firebase_client = create_client
+    encrypted_channel_ids.each do |encrypted_channel_id|
+      firebase_client.delete "/v3/channels/#{encrypted_channel_id}/"
+    end
+  end
+
   def self.delete_channel(encrypted_channel_id)
     raise "channel_id must be non-empty" if encrypted_channel_id.nil? || encrypted_channel_id.empty?
     create_client.delete "/v3/channels/#{encrypted_channel_id}/"

--- a/shared/test/middleware/helpers/test_firebase_helper.rb
+++ b/shared/test/middleware/helpers/test_firebase_helper.rb
@@ -27,8 +27,19 @@ class FirebaseHelperTest < Minitest::Test
 
   def test_delete_channel_with_fake_channel
     fake_channel_name = 'fake-channel-name'
-    Firebase::Client.expects(:new).returns(stub(:delete, nil))
+    fb_client = mock
+    fb_client.expects(:delete).with("/v3/channels/#{fake_channel_name}/")
+    Firebase::Client.expects(:new).returns(fb_client)
     FirebaseHelper.delete_channel fake_channel_name
+  end
+
+  def test_delete_channels_with_fake_channels
+    fake_channel_names = ['fake-channel-name1', 'fake-channel-name2']
+    fb_client = mock
+    fb_client.expects(:delete).with("/v3/channels/#{fake_channel_names[0]}/")
+    fb_client.expects(:delete).with("/v3/channels/#{fake_channel_names[1]}/")
+    Firebase::Client.expects(:new).returns(fb_client)
+    FirebaseHelper.delete_channels fake_channel_names
   end
 
   def test_delete_shared_table


### PR DESCRIPTION
A new FirebaseClient is created on every call to `delete_channel`. This PR adds a `delete_channels` method that creates one FirebaseClient and uses that to delete every channel id passed in. In addition, `DeleteAccountsHelper` is updated to use this method. 

## Testing story

Added/modified unit tests

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
