### PR TITLE
disable tts when cloning scripts

### DIFF
--- a/dashboard/app/models/script.rb
+++ b/dashboard/app/models/script.rb
@@ -1194,6 +1194,7 @@ class Script < ActiveRecord::Base
     script_filename = "#{Script.script_directory}/#{name}.script"
     new_properties = {
       is_stable: false,
+      tts: false,
       script_announcements: nil
     }.merge(options)
     if /^[0-9]{4}$/ =~ (new_suffix)

--- a/dashboard/test/models/script_test.rb
+++ b/dashboard/test/models/script_test.rb
@@ -1526,6 +1526,34 @@ class ScriptTest < ActiveSupport::TestCase
     )
   end
 
+  test 'clone with suffix clears certain properties' do
+    script_file = File.join(self.class.fixture_path, "test-all-properties.script")
+    scripts, _ = Script.setup([script_file])
+    script = scripts.first
+
+    # all properties that should change
+    assert script.tts
+    assert script.is_stable
+    assert script.script_announcements
+
+    # some properties that should not change
+    assert script.curriculum_path
+    assert script.has_lesson_plan
+
+    Script.stubs(:script_directory).returns(self.class.fixture_path)
+    script_copy = script.clone_with_suffix('copy')
+    assert_equal 'test-all-properties-copy', script_copy.name
+
+    # all properties that should change
+    refute script_copy.tts
+    refute script_copy.is_stable
+    refute script_copy.script_announcements
+
+    # some properties that should not change
+    assert script_copy.curriculum_path
+    assert script_copy.has_lesson_plan
+  end
+
   test 'clone versioned script with suffix' do
     script_file = File.join(self.class.fixture_path, "test-fixture-versioned-1801.script")
     scripts, _ = Script.setup([script_file])

--- a/dashboard/test/models/script_test.rb
+++ b/dashboard/test/models/script_test.rb
@@ -1526,6 +1526,8 @@ class ScriptTest < ActiveSupport::TestCase
     )
   end
 
+  # This test case doesn't cover hidden (not a property) or version year (only
+  # updated under certain conditions). These are covered in other test cases.
   test 'clone with suffix clears certain properties' do
     script_file = File.join(self.class.fixture_path, "test-all-properties.script")
     scripts, _ = Script.setup([script_file])


### PR DESCRIPTION
Finishes https://codedotorg.atlassian.net/browse/PLAT-221

Previous PRs took away the need to update a hard-coded list of scripts with Text-To-Speech enabled, however this left us in a state where tts would be enabled immediately upon cloning a new script. We pay by the minute for generated speech, so this was not desirable. The timing also isn't right to tie this to a script becoming visible or stable. Therefore, simply disable tts when creating a new script via deep-copy. The [Shipping Curriculum](https://docs.google.com/document/d/1DGn1GoUKn14TtwbnBp4GcfMoesEK8TBc_2HlRdO46VY/edit#) doc has been updated to reflect that the curriculum team will need to check this checkbox prior to soft launch. See further discussion details in [slack](https://codedotorg.slack.com/archives/CA3KCSGTD/p1593641953362400).

## Testing story

* new test case covering tts and other properties that get cleared
* manually verified via `Script.find_by_name(...).clone_with_suffix(...)`

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
