### PR TITLE
Bump blockly to 3.5.26

### DIFF
--- a/apps/package.json
+++ b/apps/package.json
@@ -49,7 +49,7 @@
     "@babel/preset-react": "^7.0.0",
     "@cdo/interpreted": "link:../dashboard/config/libraries",
     "@code-dot-org/artist": "0.2.1",
-    "@code-dot-org/blockly": "3.5.25",
+    "@code-dot-org/blockly": "3.5.26",
     "@code-dot-org/bramble": "0.1.26",
     "@code-dot-org/craft": "0.2.2",
     "@code-dot-org/dance-party": "1.0.1",

--- a/apps/yarn.lock
+++ b/apps/yarn.lock
@@ -1526,10 +1526,10 @@
   version "0.2.1"
   resolved "https://registry.yarnpkg.com/@code-dot-org/artist/-/artist-0.2.1.tgz#fcfe7ea5cfb3f19ddb6b912e70e922ba4b7ef0b1"
 
-"@code-dot-org/blockly@3.5.25":
-  version "3.5.25"
-  resolved "https://registry.yarnpkg.com/@code-dot-org/blockly/-/blockly-3.5.25.tgz#ddd478e549dcc4db21189d56301b5247f4f0e19c"
-  integrity sha512-ahBxuPndJsbPHJWuenEbdo4b5/YRbtgqtTUIhajBSxgk0Bf51xNiOuLLPrboZfJ2etrI8dZDYujP60/ZMIjEMw==
+"@code-dot-org/blockly@3.5.26":
+  version "3.5.26"
+  resolved "https://registry.yarnpkg.com/@code-dot-org/blockly/-/blockly-3.5.26.tgz#83ca5ebceaa531d8334a93a1db886480ea4d1bf7"
+  integrity sha512-U5p5YDfCZa9gibiL/ybH0sA6rxDDiInBgrL/lqpeqkJlJsJS6yRl61zWROho23K/7rmaoYjqPwG/3pHKLakcng==
 
 "@code-dot-org/bramble@0.1.26":
   version "0.1.26"


### PR DESCRIPTION
Pulls in
- [Add prettier and apply changes](https://github.com/code-dot-org/blockly/pull/234)
- [Manual Lint Fixes](https://github.com/code-dot-org/blockly/pull/235)
- [Run lint on each commit](https://github.com/code-dot-org/blockly/pull/236)
- [rename master->main](https://github.com/code-dot-org/blockly/pull/238)
