### PR TITLE
AFE Integration: Sign up link should default to teacher type

### DIFF
--- a/apps/src/templates/amazonFutureEngineerEligibility/amazonFutureEngineerAccountConfirmation.jsx
+++ b/apps/src/templates/amazonFutureEngineerEligibility/amazonFutureEngineerAccountConfirmation.jsx
@@ -18,13 +18,13 @@ const styles = {
   }
 };
 
-export default class AmazonFutureEngineerAccountConfirmation extends React.Component {
-  returnToURL = relativeDashboardPath => {
-    return studio(
-      `${relativeDashboardPath}?user_return_to=${pegasus('/afe/submit')}`
-    );
-  };
+const RETURN_TO = `user_return_to=${pegasus('/afe/submit')}`;
+const SIGN_UP_URL = studio(
+  `/users/sign_up?user[user_type]=teacher&${RETURN_TO}`
+);
+const SIGN_IN_URL = studio(`/users/sign_in?${RETURN_TO}`);
 
+export default class AmazonFutureEngineerAccountConfirmation extends React.Component {
   logSignUpButtonPress = () => {
     firehoseClient.putRecord({
       study: 'amazon-future-engineer-eligibility',
@@ -43,12 +43,11 @@ export default class AmazonFutureEngineerAccountConfirmation extends React.Compo
           already have one.
         </div>
         <div style={styles.body}>
-          Already have a Code.org account?{' '}
-          <a href={this.returnToURL('/users/sign_in')}>Sign in.</a>
+          Already have a Code.org account? <a href={SIGN_IN_URL}>Sign in.</a>
         </div>
         <Button
           id="sign_up"
-          href={this.returnToURL('/users/sign_up')}
+          href={SIGN_UP_URL}
           style={styles.button}
           onClick={this.logSignUpButtonPress}
         >


### PR DESCRIPTION
When we ask someone going through the AFE flow to sign up, the sign up form they get should assume that they are a teacher.

This change can be merged independently, but it won't have any effect until [we fix this behavior on the sign-up form](https://github.com/code-dot-org/code-dot-org/pull/35637).

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
