### PR TITLE
Sign-up can set default user type by queryparam

### DIFF
--- a/dashboard/test/controllers/registrations_controller_test.rb
+++ b/dashboard/test/controllers/registrations_controller_test.rb
@@ -6,7 +6,7 @@ require 'test_helper'
 #
 # Please locate new tests for RegistrationsController in files for individual
 # routes under
-#   test/controllers/registrations_controller/*_test.rb
+#   test/integration/registration/*_test.rb
 #
 # New tests should inherit from ActionDispatch::IntegrationTest instead of
 # ActionController::TestCase

--- a/dashboard/test/controllers/registrations_controller_test.rb
+++ b/dashboard/test/controllers/registrations_controller_test.rb
@@ -5,8 +5,9 @@ require 'test_helper'
 # DEPRECATION NOTICE
 #
 # Please locate new tests for RegistrationsController in files for individual
-# routes under
+# routes under one of:
 #   test/integration/registration/*_test.rb
+#   test/integration/omniauth/*_test.rb
 #
 # New tests should inherit from ActionDispatch::IntegrationTest instead of
 # ActionController::TestCase

--- a/dashboard/test/integration/omniauth/facebook_test.rb
+++ b/dashboard/test/integration/omniauth/facebook_test.rb
@@ -127,6 +127,28 @@ module OmniauthCallbacksControllerTests
       )
     end
 
+    test 'user_type is usually unset on finish_sign_up' do
+      mock_oauth
+
+      get '/users/sign_up'
+      sign_in_through_facebook
+      follow_redirect!
+
+      assert_template partial: '_finish_sign_up'
+      assert_nil assigns(:user).user_type
+    end
+
+    test 'sign_up queryparam can prefill user_type on finish_sign_up' do
+      mock_oauth
+
+      get '/users/sign_up?user[user_type]=teacher'
+      sign_in_through_facebook
+      follow_redirect!
+
+      assert_template partial: '_finish_sign_up'
+      assert_equal 'teacher', assigns(:user).user_type
+    end
+
     private
 
     def mock_oauth

--- a/dashboard/test/integration/omniauth/google_oauth2_test.rb
+++ b/dashboard/test/integration/omniauth/google_oauth2_test.rb
@@ -289,6 +289,28 @@ module OmniauthCallbacksControllerTests
       )
     end
 
+    test 'user_type is usually unset on finish_sign_up' do
+      mock_oauth
+
+      get '/users/sign_up'
+      sign_in_through_google
+      follow_redirect!
+
+      assert_template partial: '_finish_sign_up'
+      assert_nil assigns(:user).user_type
+    end
+
+    test 'sign_up queryparam can prefill user_type on finish_sign_up' do
+      mock_oauth
+
+      get '/users/sign_up?user[user_type]=teacher'
+      sign_in_through_google
+      follow_redirect!
+
+      assert_template partial: '_finish_sign_up'
+      assert_equal 'teacher', assigns(:user).user_type
+    end
+
     private
 
     # @return [OmniAuth::AuthHash] that will be passed to the callback when test-mode OAuth is invoked

--- a/dashboard/test/integration/registration/new_test.rb
+++ b/dashboard/test/integration/registration/new_test.rb
@@ -33,5 +33,61 @@ module RegistrationsControllerTests
       assert_response :success
       assert_template partial: '_finish_sign_up'
     end
+
+    test 'user type is typically blank on finish_sign_up' do
+      get '/users/sign_up'
+      start_email_password_signup
+      assert_template partial: '_finish_sign_up'
+      assert_nil assigns(:user).user_type
+    end
+
+    test 'queryparam user[user_type] sets default user type on finish_sign_up' do
+      get '/users/sign_up?user[user_type]=teacher'
+      start_email_password_signup
+      assert_template partial: '_finish_sign_up'
+      assert_equal 'teacher', assigns(:user).user_type
+    end
+
+    test 'queryparam user[user_type] ignores invalid user types' do
+      get '/users/sign_up?user[user_type]=lemon'
+      start_email_password_signup
+      assert_template partial: '_finish_sign_up'
+      assert_nil assigns(:user).user_type
+    end
+
+    test 'visiting sign_up without the user_type param clears a previous setting' do
+      get '/users/sign_up?user[user_type]=teacher'
+      start_email_password_signup
+      assert_template partial: '_finish_sign_up'
+      assert_equal 'teacher', assigns(:user).user_type
+
+      get '/users/cancel'
+
+      get '/users/sign_up?user[user_type]=student'
+      start_email_password_signup
+      assert_template partial: '_finish_sign_up'
+      assert_equal 'student', assigns(:user).user_type
+
+      get '/users/cancel'
+
+      get '/users/sign_up'
+      start_email_password_signup
+      assert_template partial: '_finish_sign_up'
+      assert_nil assigns(:user).user_type
+    end
+
+    private
+
+    def start_email_password_signup
+      post '/users/begin_sign_up', params: {
+        user: {
+          email: 'myemail@example.com',
+          password: 'mypassword',
+          password_confirmation: 'mypassword'
+        }
+      }
+      assert_redirected_to new_user_registration_path
+      follow_redirect!
+    end
   end
 end


### PR DESCRIPTION
Adds the ability to link to a sign-up flow with a particular user type preselected, by adding a queryparam to the URL:

```
/users/sign_up?user[user_type]=teacher
/users/sign_up?user[user_type]=student
```

![Peek 2020-07-02 17-29](https://user-images.githubusercontent.com/1615761/86419950-bca9af80-bc89-11ea-829b-cdb23dd3e4e3.gif)

This actually restores an old ability in our sign-up flow; we still have sign-up links lying around that use the above format, but it looks like we lost this behavior when we switched to a multi-step sign-up flow.

In the new flow, the user_type control is actually in the "finish sign-up" view, so we're storing the given user type until we reach that second page.  If you cancel out at that point, you'll navigate back to the first step _without_ the queryparam, and we'll clear the default user type so you'll have to select one if you try again.

This queryparam works for our email+password flow and for OAuth flows that use the finish-sign-up step.  For Clever and Powerschool, which provide their own user-type as part of their SSO process, we ignore this default and respect the user-type sent by the provider.

**Why  now?** While working on the AFE Integration I realized the sign-up button in that teacher-specific flow ought to default to creating a teacher account.  I've [set up the correct link here](https://github.com/code-dot-org/code-dot-org/pull/35635) but it won't work until this PR is merged.

## Testing story

I've included integration tests that cover the new behavior, and done local manual testing of the email+password sign-up flows.

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
