### PR TITLE
CRv2: Report failures to process contacts

### DIFF
--- a/dashboard/app/models/contact_rollups_processed.rb
+++ b/dashboard/app/models/contact_rollups_processed.rb
@@ -57,50 +57,30 @@ class ContactRollupsProcessed < ApplicationRecord
   def self.import_from_raw_table(batch_size = DEFAULT_BATCH_SIZE)
     valid_contacts = 0
     invalid_contacts = 0
-    logger = Logger.new(deploy_dir('log', 'crv2_process.log'))
 
     # Process the aggregated data row by row and save the results to DB in batches.
     batch = []
     ContactRollupsV2.retrieve_query_results(get_data_aggregation_query).each do |contact|
       begin
-        step = 1
         contact.deep_stringify_keys!
-        step += 1
         contact_data = parse_contact_data(contact['all_data_and_metadata'])
-        step += 1
 
         processed_contact_data = {}
         processed_contact_data.merge! extract_opt_in(contact_data)
-        step += 1
         processed_contact_data.merge! extract_user_id(contact_data)
-        step += 1 #5
         processed_contact_data.merge! extract_professional_learning_enrolled(contact_data)
-        step += 1
         processed_contact_data.merge! extract_professional_learning_attended(contact_data)
-        step += 1
         processed_contact_data.merge! extract_hoc_organizer_years(contact_data)
-        step += 1
         processed_contact_data.merge! extract_forms_submitted(contact_data)
-        step += 1
         processed_contact_data.merge! extract_form_roles(contact_data)
-        step += 1 #10
         processed_contact_data.merge! extract_roles(contact_data)
-        step += 1
         processed_contact_data.merge! extract_state(contact_data)
-        step += 1
         processed_contact_data.merge! extract_city(contact_data)
-        step += 1
         processed_contact_data.merge! extract_postal_code(contact_data)
-        step += 1
         processed_contact_data.merge! extract_country(contact_data)
-        step += 1 #15
         processed_contact_data.merge! extract_updated_at(contact_data)
         valid_contacts += 1
-      rescue StandardError => e
-        # TODO: create a process to report and investigate invalid contacts
-        logger.error("failed at step #{step}")
-        logger.info("contact = #{contact.inspect}")
-        logger.info(e.message)
+      rescue StandardError
         invalid_contacts += 1
         next
       end

--- a/dashboard/app/models/contact_rollups_processed.rb
+++ b/dashboard/app/models/contact_rollups_processed.rb
@@ -234,13 +234,13 @@ class ContactRollupsProcessed < ApplicationRecord
 
     # Contact is a teacher or a petition signer if they submit certain (pegasus) forms
     form_kinds = extract_field contact_data, 'pegasus.forms', 'kind'
-    roles.merge(form_kinds.map {|kind| FORM_KIND_TO_ROLE_MAP[kind.to_sym]})
+    roles.merge(form_kinds.map {|kind| FORM_KIND_TO_ROLE_MAP[kind&.to_sym]})
 
     # @see Course::FAMILY_NAMES
     # TODO: extract course family_name (in properties column) instead of course name.
     courses = extract_field contact_data, 'dashboard.sections', 'course_name'
-    roles.add 'CSD Teacher' if courses.any? {|course| course.start_with? 'csd'}
-    roles.add 'CSP Teacher' if courses.any? {|course| course.start_with? 'csp'}
+    roles.add 'CSD Teacher' if courses.any? {|course| course&.start_with? 'csd'}
+    roles.add 'CSP Teacher' if courses.any? {|course| course&.start_with? 'csp'}
 
     # @see Script model, csf?, csd? and csp? methods
     curricula = extract_field contact_data, 'dashboard.sections', 'curriculum_umbrella'
@@ -257,7 +257,7 @@ class ContactRollupsProcessed < ApplicationRecord
     roles.add 'Parent' if contact_data.dig('dashboard.users', 'is_parent')
 
     permissions = extract_field contact_data, 'dashboard.user_permissions', 'permission'
-    roles.merge(permissions.map {|permission| USER_PERMISSION_TO_ROLE_MAP[permission.to_sym]})
+    roles.merge(permissions.map {|permission| USER_PERMISSION_TO_ROLE_MAP[permission&.to_sym]})
 
     # Only care about unique and non-nil values. Values are sorted before return.
     uniq_roles = roles.to_a.compact.sort.join(',')

--- a/dashboard/app/models/contact_rollups_processed.rb
+++ b/dashboard/app/models/contact_rollups_processed.rb
@@ -371,7 +371,6 @@ class ContactRollupsProcessed < ApplicationRecord
   # @param field [String]
   # @return [Array] an array of values, or an empty array if the field or table
   #   does not exist in the contact_data.
-  # TODO: returns empty array instead of nil. They both communicate the same thing
   def self.extract_field(contact_data, table, field)
     return [] unless contact_data.key?(table) && contact_data[table].key?(field)
     contact_data.dig(table, field).map {|item| item['value']}

--- a/dashboard/app/models/contact_rollups_processed.rb
+++ b/dashboard/app/models/contact_rollups_processed.rb
@@ -57,31 +57,50 @@ class ContactRollupsProcessed < ApplicationRecord
   def self.import_from_raw_table(batch_size = DEFAULT_BATCH_SIZE)
     valid_contacts = 0
     invalid_contacts = 0
+    logger = Logger.new(deploy_dir('log', 'crv2_process.log'))
 
     # Process the aggregated data row by row and save the results to DB in batches.
     batch = []
     ContactRollupsV2.retrieve_query_results(get_data_aggregation_query).each do |contact|
       begin
+        step = 1
         contact.deep_stringify_keys!
+        step += 1
         contact_data = parse_contact_data(contact['all_data_and_metadata'])
+        step += 1
 
         processed_contact_data = {}
         processed_contact_data.merge! extract_opt_in(contact_data)
+        step += 1
         processed_contact_data.merge! extract_user_id(contact_data)
+        step += 1 #5
         processed_contact_data.merge! extract_professional_learning_enrolled(contact_data)
+        step += 1
         processed_contact_data.merge! extract_professional_learning_attended(contact_data)
+        step += 1
         processed_contact_data.merge! extract_hoc_organizer_years(contact_data)
+        step += 1
         processed_contact_data.merge! extract_forms_submitted(contact_data)
+        step += 1
         processed_contact_data.merge! extract_form_roles(contact_data)
+        step += 1 #10
         processed_contact_data.merge! extract_roles(contact_data)
+        step += 1
         processed_contact_data.merge! extract_state(contact_data)
+        step += 1
         processed_contact_data.merge! extract_city(contact_data)
+        step += 1
         processed_contact_data.merge! extract_postal_code(contact_data)
+        step += 1
         processed_contact_data.merge! extract_country(contact_data)
+        step += 1 #15
         processed_contact_data.merge! extract_updated_at(contact_data)
         valid_contacts += 1
-      rescue StandardError
+      rescue StandardError => e
         # TODO: create a process to report and investigate invalid contacts
+        logger.error("failed at step #{step}")
+        logger.info("contact = #{contact.inspect}")
+        logger.info(e.message)
         invalid_contacts += 1
         next
       end

--- a/dashboard/app/models/contact_rollups_processed.rb
+++ b/dashboard/app/models/contact_rollups_processed.rb
@@ -64,26 +64,26 @@ class ContactRollupsProcessed < ApplicationRecord
       begin
         contact.deep_stringify_keys!
         contact_data = parse_contact_data(contact['all_data_and_metadata'])
-
-        processed_contact_data = {}
-        processed_contact_data.merge! extract_opt_in(contact_data)
-        processed_contact_data.merge! extract_user_id(contact_data)
-        processed_contact_data.merge! extract_professional_learning_enrolled(contact_data)
-        processed_contact_data.merge! extract_professional_learning_attended(contact_data)
-        processed_contact_data.merge! extract_hoc_organizer_years(contact_data)
-        processed_contact_data.merge! extract_forms_submitted(contact_data)
-        processed_contact_data.merge! extract_form_roles(contact_data)
-        processed_contact_data.merge! extract_roles(contact_data)
-        processed_contact_data.merge! extract_state(contact_data)
-        processed_contact_data.merge! extract_city(contact_data)
-        processed_contact_data.merge! extract_postal_code(contact_data)
-        processed_contact_data.merge! extract_country(contact_data)
-        processed_contact_data.merge! extract_updated_at(contact_data)
         valid_contacts += 1
-      rescue StandardError
+      rescue JSON::ParserError, ArgumentError
         invalid_contacts += 1
         next
       end
+
+      processed_contact_data = {}
+      processed_contact_data.merge! extract_opt_in(contact_data)
+      processed_contact_data.merge! extract_user_id(contact_data)
+      processed_contact_data.merge! extract_professional_learning_enrolled(contact_data)
+      processed_contact_data.merge! extract_professional_learning_attended(contact_data)
+      processed_contact_data.merge! extract_hoc_organizer_years(contact_data)
+      processed_contact_data.merge! extract_forms_submitted(contact_data)
+      processed_contact_data.merge! extract_form_roles(contact_data)
+      processed_contact_data.merge! extract_roles(contact_data)
+      processed_contact_data.merge! extract_state(contact_data)
+      processed_contact_data.merge! extract_city(contact_data)
+      processed_contact_data.merge! extract_postal_code(contact_data)
+      processed_contact_data.merge! extract_country(contact_data)
+      processed_contact_data.merge! extract_updated_at(contact_data)
 
       # Contact data is successful processed, add it to a batch.
       # When the batch is big enough, save it to the database.

--- a/dashboard/app/models/contact_rollups_processed.rb
+++ b/dashboard/app/models/contact_rollups_processed.rb
@@ -234,13 +234,13 @@ class ContactRollupsProcessed < ApplicationRecord
 
     # Contact is a teacher or a petition signer if they submit certain (pegasus) forms
     form_kinds = extract_field contact_data, 'pegasus.forms', 'kind'
-    roles.merge(form_kinds.map {|kind| FORM_KIND_TO_ROLE_MAP[kind&.to_sym]})
+    roles.merge(form_kinds.map {|kind| FORM_KIND_TO_ROLE_MAP[kind.to_sym]})
 
     # @see Course::FAMILY_NAMES
     # TODO: extract course family_name (in properties column) instead of course name.
     courses = extract_field contact_data, 'dashboard.sections', 'course_name'
-    roles.add 'CSD Teacher' if courses.any? {|course| course&.start_with? 'csd'}
-    roles.add 'CSP Teacher' if courses.any? {|course| course&.start_with? 'csp'}
+    roles.add 'CSD Teacher' if courses.any? {|course| course.start_with? 'csd'}
+    roles.add 'CSP Teacher' if courses.any? {|course| course.start_with? 'csp'}
 
     # @see Script model, csf?, csd? and csp? methods
     curricula = extract_field contact_data, 'dashboard.sections', 'curriculum_umbrella'
@@ -257,7 +257,7 @@ class ContactRollupsProcessed < ApplicationRecord
     roles.add 'Parent' if contact_data.dig('dashboard.users', 'is_parent')
 
     permissions = extract_field contact_data, 'dashboard.user_permissions', 'permission'
-    roles.merge(permissions.map {|permission| USER_PERMISSION_TO_ROLE_MAP[permission&.to_sym]})
+    roles.merge(permissions.map {|permission| USER_PERMISSION_TO_ROLE_MAP[permission.to_sym]})
 
     # Only care about unique and non-nil values. Values are sorted before return.
     uniq_roles = roles.to_a.compact.sort.join(',')

--- a/dashboard/test/models/contact_rollups_processed_test.rb
+++ b/dashboard/test/models/contact_rollups_processed_test.rb
@@ -260,14 +260,18 @@ class ContactRollupsProcessedTest < ActiveSupport::TestCase
     followers_input = {'dashboard.followers' => {}}
     census_submissions_input = {
       'dashboard.census_submissions' => {
-        'submitter_role' => [{'value' => Census::CensusSubmission::ROLES[:teacher]}]
+        'submitter_role' => [
+          {'value' => Census::CensusSubmission::ROLES[:teacher]},
+          {'value' => nil},
+        ]
       }
     }
     forms_input = {
       'pegasus.forms' => {
         'kind' => [
           {'value' => 'Petition'},
-          {'value' => 'ClassSubmission'}
+          {'value' => 'ClassSubmission'},
+          {'value' => nil},
         ]
       }
     }
@@ -275,7 +279,8 @@ class ContactRollupsProcessedTest < ActiveSupport::TestCase
       'dashboard.sections' => {
         'course_name' => [
           {'value' => 'csp-2020'},
-          {'value' => 'csd-2019'}
+          {'value' => 'csd-2019'},
+          {'value' => nil},
         ]
       }
     }
@@ -283,7 +288,8 @@ class ContactRollupsProcessedTest < ActiveSupport::TestCase
       'dashboard.sections' => {
         'curriculum_umbrella' => [
           {'value' => 'CSF'},
-          {'value' => 'CSD'}
+          {'value' => 'CSD'},
+          {'value' => nil},
         ]
       }
     }
@@ -291,7 +297,8 @@ class ContactRollupsProcessedTest < ActiveSupport::TestCase
       'dashboard.user_permissions' => {
         'permission' => [
           {'value' => 'workshop_organizer'},
-          {'value' => 'facilitator'}
+          {'value' => 'facilitator'},
+          {'value' => nil},
         ]
       }
     }

--- a/dashboard/test/models/contact_rollups_processed_test.rb
+++ b/dashboard/test/models/contact_rollups_processed_test.rb
@@ -95,17 +95,17 @@ class ContactRollupsProcessedTest < ActiveSupport::TestCase
       {
         # all empty
         input: [{}, nil, nil],
-        expected_output: nil
+        expected_output: []
       },
       {
         # table exists in contact data but field doesn't
         input: [{table => {}}, table, field],
-        expected_output: nil
+        expected_output: []
       },
       {
         # field exists in contact data but table doesn't
         input: [{'pegasus.another_table' => {field => [{'value' => 'WA'}]}}, table, field],
-        expected_output: nil
+        expected_output: []
       },
       {
         # table and field exists in contact data, field value is nil


### PR DESCRIPTION
A bunch of minor changes to ContactRollupsProcessed on how it reports failures when processing contact data.

1. In `import_from_raw_table` method, moves attribute processing out of `begin`-`rescue` block. Any failure to process an attribute will raise error and stop the pipeline. (We could have bad data but shouldn't fail to process them.)

2. Also in `import_from_raw_table` method, ignores only `JSON::ParserError`,` ArgumentError` exceptions (failure to parse JSON string). We want to know about other failures immediately.

3. In `extract_roles` method, uses safe navigator `&.` because field value could be `nil`.

4. In `extract_field`, returns an empty array instead of `nil` to reduce chance of error.

## Test story
* Unit tests
* Tested the full pipeline on an adhoc with connection to a production-cloned db.