### PR TITLE
Deleting an application deletes its unsent email

### DIFF
--- a/dashboard/app/models/pd/application/application_base.rb
+++ b/dashboard/app/models/pd/application/application_base.rb
@@ -103,7 +103,7 @@ module Pd::Application
       ]
     }
 
-    has_many :emails, class_name: 'Pd::Application::Email'
+    has_many :emails, class_name: 'Pd::Application::Email', foreign_key: 'pd_application_id'
     has_and_belongs_to_many :tags, class_name: 'Pd::Application::Tag', foreign_key: 'pd_application_id', association_foreign_key: 'pd_application_tag_id'
 
     after_initialize -> {self.status = :unreviewed}, if: :new_record?

--- a/dashboard/app/models/pd/application/application_base.rb
+++ b/dashboard/app/models/pd/application/application_base.rb
@@ -112,6 +112,7 @@ module Pd::Application
     before_validation :set_type_and_year
     before_save :update_accepted_date, if: :status_changed?
     before_create :generate_application_guid, if: -> {application_guid.blank?}
+    after_destroy :delete_unsent_email
 
     serialized_attrs %w(
       notes_2
@@ -194,6 +195,13 @@ module Pd::Application
         title: email.email_type + '_email'
       }
       update(status_timestamp_change_log: sanitize_status_timestamp_change_log.append(entry).to_json)
+    end
+
+    # Used as an after-destroy hook; deleting an application should
+    # also delete any unsent email, which can no longer be sent
+    # successfully anyway.
+    def delete_unsent_email
+      emails.unsent.destroy_all
     end
 
     # Override in derived class


### PR DESCRIPTION
Every once in a while, our application email sending process hits an error where it tries to send an email for an application that has been deleted. (example: https://app.honeybadger.io/projects/45435/faults/48199539)  This isn't terribly common because we don't often delete applications and it has to be deleted within a certain window to hit this error as well.  However, it would be best if our system cleaned up unsent emails automatically when an application was deleted.  This change adds that behavior.

I've added a unit test to cover this behavior, and am leaning on existing tests to catch any edge cases I haven't considered.

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
