### PR TITLE
Update directions for archiving a section

### DIFF
--- a/apps/i18n/common/en_us.json
+++ b/apps/i18n/common/en_us.json
@@ -513,7 +513,7 @@
   "deleteProjectConfirm": "Do you really want to delete your project? You cannot undo this action.",
   "deleteSection": "Delete Section",
   "deleteSectionConfirm": "Are you sure you want to delete this section? You will not be able to undo this.",
-  "deleteSectionHideSuggestion": "If you simply want to remove this section from your list of sections, consider using the 'Hide section' option instead.",
+  "deleteSectionArchiveSuggestion": "If you simply want to remove this section from your list of sections, consider using the 'Archive section' option instead.",
   "deleteUsedImage": "{name} is used in {value, plural, one {1 place} other {# places}} in this app. If you delete it, the image will not appear in any of those places. Are you sure you want to delete it?",
   "deleting": "Deleting",
   "description": "Description",

--- a/apps/src/templates/teacherDashboard/SectionActionDropdown.jsx
+++ b/apps/src/templates/teacherDashboard/SectionActionDropdown.jsx
@@ -178,7 +178,7 @@ class SectionActionDropdown extends Component {
           <h2 style={styles.heading}>{i18n.deleteSection()}</h2>
           <div>{i18n.deleteSectionConfirm()}</div>
           <br />
-          <div>{i18n.deleteSectionHideSuggestion()}</div>
+          <div>{i18n.deleteSectionArchiveSuggestion()}</div>
           <DialogFooter>
             <Button
               __useDeprecatedTag


### PR DESCRIPTION
This string previously referred to the "Hide section" button, which is actually called "Archive section", so this updates the string to match the button label.

**before:**
<img width="712" alt="Screen Shot 2020-07-06 at 11 36 36 AM" src="https://user-images.githubusercontent.com/224089/86627334-ff66d280-bf7c-11ea-9a19-b8d5f62c1a01.png">

**after:**
<img width="689" alt="Screen Shot 2020-07-06 at 11 32 50 AM" src="https://user-images.githubusercontent.com/224089/86627335-0097ff80-bf7d-11ea-97b0-1550bf6aefd7.png">

<!--
  Your description goes here: A summary of the change, including any relevant motivation and context.

  If relevant, include a description both of the existing behavior and of the new behavior.
-->

<!--
  Other aspects to consider. uncomment and add detail for any that seem necessary:
-->

<!-- ### Background -->
<!-- ### Privacy -->
<!-- ### Security -->
<!-- ### Caching -->
<!-- ### Deployment strategy -->
<!-- ### Future work -->

## Links

<!--
  Any relevant links to external resources; ie, specification documents, jira
  items, related PRs, honeybadger errors, etc
-->

- [jira](https://codedotorg.atlassian.net/browse/LP-1494?atlOrigin=eyJpIjoiMWJjZDYwMTc5Njg3NDlmN2E3ZDRhZmQzODAyMTJkZmMiLCJwIjoiaiJ9)

## Testing story

<!--
  Does your change include appropriate tests?

  If so, please describe how the tests included in this PR are sufficient

  If not, please explain why this change does not need to be tested.
-->

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
