### PR TITLE
show script name when seeding script results in an error

### DIFF
--- a/dashboard/app/models/script.rb
+++ b/dashboard/app/models/script.rb
@@ -889,7 +889,12 @@ class Script < ActiveRecord::Base
         name = File.basename(script, '.script')
         base_name = Script.base_name(name)
         name = "#{base_name}-#{new_suffix}" if new_suffix
-        script_data, i18n = ScriptDSL.parse_file(script, name)
+        script_data, i18n =
+          begin
+            ScriptDSL.parse_file(script, name)
+          rescue => e
+            raise e, "Error parsing script file #{script}: #{e}"
+          end
 
         lesson_groups = script_data[:lesson_groups]
         lessons = script_data[:lessons]
@@ -910,6 +915,8 @@ class Script < ActiveRecord::Base
       # Stable sort by ID then add each script, ensuring scripts with no ID end up at the end
       added_scripts = scripts_to_add.sort_by.with_index {|args, idx| [args[0][:id] || Float::INFINITY, idx]}.map do |options, raw_lesson_groups, raw_lessons|
         add_script(options, raw_lesson_groups, raw_lessons, new_suffix: new_suffix, editor_experiment: new_properties[:editor_experiment])
+      rescue => e
+        raise e, "Error adding script named '#{options[:name]}': #{e}"
       end
       [added_scripts, custom_i18n]
     end


### PR DESCRIPTION
### Background

When we run into errors while seeding scripts, it's often hard to track down which script the error is occurring in without adding custom instrumentation.

### Description

When an error occurs seeding a script, include the name of the script in the error message. 

### Testing

sample output:

```
Dave-MBP:~/src/cdo/dashboard (seed-error-script-name *)$ rake seed:single_script SCRIPT_NAME=valentine
WARNING: Nokogiri was built against LibXML version 2.9.9, but has dynamically loaded 2.9.4
rake aborted!
NoMethodError: Error parsing script file config/scripts/valentine.script: undefined method `lev' for #<ScriptDSL:0x00007fef9be02378>
Did you mean?  level
/Users/dsb/src/cdo/dashboard/app/models/script.rb:896:in `rescue in block (2 levels) in setup'
/Users/dsb/src/cdo/dashboard/app/models/script.rb:893:in `block (2 levels) in setup'
/Users/dsb/src/cdo/dashboard/app/models/script.rb:888:in `map'
/Users/dsb/src/cdo/dashboard/app/models/script.rb:888:in `block in setup'
/Users/dsb/src/cdo/dashboard/app/models/script.rb:883:in `setup'
/Users/dsb/src/cdo/dashboard/lib/tasks/seed.rake:168:in `update_scripts'
/Users/dsb/src/cdo/dashboard/lib/tasks/seed.rake:193:in `block (2 levels) in <top (required)>'
/Users/dsb/src/cdo/dashboard/lib/tasks/seed.rake:15:in `block in execute'
/Users/dsb/src/cdo/dashboard/lib/tasks/seed.rake:15:in `execute'
NoMethodError: undefined method `lev' for #<ScriptDSL:0x00007fef9be02378>
Did you mean?  level
config/scripts/valentine.script:3:in `parse'
/Users/dsb/src/cdo/dashboard/app/dsl/base_dsl.rb:24:in `instance_eval'
/Users/dsb/src/cdo/dashboard/app/dsl/base_dsl.rb:24:in `parse'
/Users/dsb/src/cdo/dashboard/app/dsl/base_dsl.rb:17:in `parse_file'
/Users/dsb/src/cdo/dashboard/app/dsl/script_dsl.rb:294:in `parse_file'
/Users/dsb/src/cdo/dashboard/app/models/script.rb:894:in `block (2 levels) in setup'
/Users/dsb/src/cdo/dashboard/app/models/script.rb:888:in `map'
/Users/dsb/src/cdo/dashboard/app/models/script.rb:888:in `block in setup'
/Users/dsb/src/cdo/dashboard/app/models/script.rb:883:in `setup'
/Users/dsb/src/cdo/dashboard/lib/tasks/seed.rake:168:in `update_scripts'
/Users/dsb/src/cdo/dashboard/lib/tasks/seed.rake:193:in `block (2 levels) in <top (required)>'
/Users/dsb/src/cdo/dashboard/lib/tasks/seed.rake:15:in `block in execute'
/Users/dsb/src/cdo/dashboard/lib/tasks/seed.rake:15:in `execute'
Tasks: TOP => seed:single_script
(See full trace by running task with --trace)
```

```                                              
Dave-MBP:~/src/cdo/dashboard (seed-error-script-name *)$ rake seed:single_script SCRIPT_NAME=coursea-2020                   
WARNING: Nokogiri was built against LibXML version 2.9.9, but has dynamically loaded 2.9.4
rake aborted!
Error adding script named 'coursea-2020': Expect key and display name to match. The Lesson Group with key: csf_digcit has display_name: Digital Citizenship
/Users/dsb/src/cdo/dashboard/app/models/script.rb:919:in `rescue in block (2 levels) in setup'
/Users/dsb/src/cdo/dashboard/app/models/script.rb:917:in `block (2 levels) in setup'
/Users/dsb/src/cdo/dashboard/app/models/script.rb:916:in `map'
/Users/dsb/src/cdo/dashboard/app/models/script.rb:916:in `block in setup'
/Users/dsb/src/cdo/dashboard/app/models/script.rb:883:in `setup'
/Users/dsb/src/cdo/dashboard/lib/tasks/seed.rake:168:in `update_scripts'
/Users/dsb/src/cdo/dashboard/lib/tasks/seed.rake:193:in `block (2 levels) in <top (required)>'
/Users/dsb/src/cdo/dashboard/lib/tasks/seed.rake:15:in `block in execute'
/Users/dsb/src/cdo/dashboard/lib/tasks/seed.rake:15:in `execute'
Expect key and display name to match. The Lesson Group with key: csf_digcit has display_name: Digital Citizenship
/Users/dsb/src/cdo/dashboard/app/models/script.rb:984:in `block in add_script'
/Users/dsb/src/cdo/dashboard/app/models/script.rb:959:in `each'
/Users/dsb/src/cdo/dashboard/app/models/script.rb:959:in `each_with_index'
/Users/dsb/src/cdo/dashboard/app/models/script.rb:959:in `add_script'
/Users/dsb/src/cdo/dashboard/app/models/script.rb:917:in `block (2 levels) in setup'
/Users/dsb/src/cdo/dashboard/app/models/script.rb:916:in `map'
/Users/dsb/src/cdo/dashboard/app/models/script.rb:916:in `block in setup'
/Users/dsb/src/cdo/dashboard/app/models/script.rb:883:in `setup'
/Users/dsb/src/cdo/dashboard/lib/tasks/seed.rake:168:in `update_scripts'
/Users/dsb/src/cdo/dashboard/lib/tasks/seed.rake:193:in `block (2 levels) in <top (required)>'
/Users/dsb/src/cdo/dashboard/lib/tasks/seed.rake:15:in `block in execute'
/Users/dsb/src/cdo/dashboard/lib/tasks/seed.rake:15:in `execute'
Tasks: TOP => seed:single_script
(See full trace by running task with --trace)
```

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
