### PR TITLE
added null check in Google Chart options for drawChart in app lab

### DIFF
--- a/apps/src/applab/GoogleChart.js
+++ b/apps/src/applab/GoogleChart.js
@@ -68,12 +68,12 @@ export default class GoogleChart {
    *        are column names.
    * @param {string[]} columnList - Ordered list of column names to use as source
    *        data for the chart.  Column names must match keys in rawData.
-   * @param {Object} options - Plain options object that gets passed through to
+   * @param {Object} options - Optional plain options object that gets passed through to
    *        the Charts API.
    * @returns {Promise} that resolves when the chart has been rendered to the
    *          target container.
    */
-  async drawChart(rawData, columnList, options) {
+  async drawChart(rawData, columnList, options = {}) {
     await this.loadDependencies();
 
     this.verifyData_({data: rawData, columns: columnList});


### PR DESCRIPTION
In app lab, drawChart and drawChartFromRecords is breaking if options are not provided. This sets the default options to {} in case users do not provide options.

Without options provided: 
<img width="1410" alt="Screen Shot 2020-07-06 at 3 05 08 PM" src="https://user-images.githubusercontent.com/17147070/86630130-6e9eef80-bf9a-11ea-8d97-c20550f2b9bd.png">

With options provided: 
<img width="1401" alt="Screen Shot 2020-07-06 at 3 04 56 PM" src="https://user-images.githubusercontent.com/17147070/86630148-7494d080-bf9a-11ea-85dc-3cffa3b22556.png">

## Links

- [slack thread](https://codedotorg.slack.com/archives/CN4T89YP8/p1594061021047800)

## Testing story

<!--
  Does your change include appropriate tests?

  If so, please describe how the tests included in this PR are sufficient

  If not, please explain why this change does not need to be tested.
-->

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
