### PR TITLE
Fix a validation bug in the workshop enrollment form

### DIFF
--- a/apps/src/code-studio/pd/workshop_enrollment/enroll_form.jsx
+++ b/apps/src/code-studio/pd/workshop_enrollment/enroll_form.jsx
@@ -104,18 +104,11 @@ export default class EnrollForm extends React.Component {
   constructor(props) {
     super(props);
 
-    let initialState = {
+    this.state = {
+      first_name: this.props.first_name,
+      email: this.props.email,
       errors: {}
     };
-
-    if (this.props.email) {
-      initialState = {
-        ...initialState,
-        ...{first_name: this.props.first_name, email: this.props.email}
-      };
-    }
-
-    this.state = initialState;
   }
 
   handleChange = change => {


### PR DESCRIPTION
Every once in a while, a teacher will try to fill out a workshop enrollment form with a student account.  We allow this, to minimize friction - the student account gets automatically upgraded to a teacher account when the enrollment is accepted.  However, there's an edge-case validation bug in this scenario:  They could be told that their first name is missing, even though it is present in the form.

![image](https://user-images.githubusercontent.com/1615761/86658968-5335e380-bf9e-11ea-9092-07060dd88a3b.png)

**Why this happens:** The component was be passed initial props with a first name but no email. In this situation, neither the name nor email would be added to the component state, however, the name would be pushed into the UI as a default value.

On submit, the component state is validated and used to submit the form. If the user never interacted with the first name field (which they shouldn't need to, since it was autofilled) they will still receive a validation error because the first name was never added to the component state.

The solution is to always push the provided name and email into the component state on construction, since their presence is not always linked.

I've added a unit test that would have caught this scenario.  It's somewhat brittle and I'm not entirely happy with it, but it seems better than not adding a test with this fix.


# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
