### PR TITLE
Handle deleted teacher accounts in workshop summary reports

### DIFF
--- a/dashboard/app/models/pd/workshop.rb
+++ b/dashboard/app/models/pd/workshop.rb
@@ -677,7 +677,7 @@ class Pd::Workshop < ActiveRecord::Base
 
   # Get all teachers who have attended all sessions of this workshop.
   def teachers_attending_all_sessions(filter_by_cdo_scholarship=false)
-    teachers_attending = sessions.flat_map(&:attendances).flat_map(&:teacher)
+    teachers_attending = sessions.flat_map(&:attendances).flat_map(&:teacher).compact
 
     # Filter attendances to only scholarship teachers
     if filter_by_cdo_scholarship

--- a/dashboard/test/factories/pd_factories.rb
+++ b/dashboard/test/factories/pd_factories.rb
@@ -452,11 +452,16 @@ FactoryGirl.define do
           create :pd_attendance, session: session, teacher: teacher
         end
       end
-      if evaluator.cdo_scholarship_recipient
+
+      scholarship_params = {
+        user: teacher,
+        course: Pd::Workshop::COURSE_KEY_MAP[evaluator.workshop.course],
+        application_year: evaluator.workshop.school_year
+      }
+
+      if evaluator.cdo_scholarship_recipient && Pd::ScholarshipInfo.find_by(scholarship_params).nil?
         create :pd_scholarship_info,
-          user: teacher,
-          course: Pd::Workshop::COURSE_KEY_MAP[evaluator.workshop.course],
-          application_year: evaluator.workshop.school_year
+          scholarship_params
       end
     end
   end

--- a/dashboard/test/factories/pd_factories.rb
+++ b/dashboard/test/factories/pd_factories.rb
@@ -459,6 +459,10 @@ FactoryGirl.define do
         application_year: evaluator.workshop.school_year
       }
 
+      # We have an after_create hook on the enrollment model (see :set_default_scholarship_info)
+      # that creates a ScholarshipInfo entry in certain cases (namely, if the enrollment is in a CSF workshop).
+      # Skip creating a new ScholarshipInfo entry if one has already been created
+      # when the enrollment is created above.
       if evaluator.cdo_scholarship_recipient && Pd::ScholarshipInfo.find_by(scholarship_params).nil?
         create :pd_scholarship_info,
           scholarship_params

--- a/dashboard/test/models/pd/workshop_test.rb
+++ b/dashboard/test/models/pd/workshop_test.rb
@@ -1,4 +1,5 @@
 require 'test_helper'
+require 'cdo/delete_accounts_helper'
 
 class Pd::WorkshopTest < ActiveSupport::TestCase
   include Pd::WorkshopConstants
@@ -855,7 +856,35 @@ class Pd::WorkshopTest < ActiveSupport::TestCase
     end
 
     assert_equal 4, workshop.teachers_attending_all_sessions.count
+
+    # Test that scholarship filter works.
+    # Set argument to filter to only scholarship teachers to true.
     assert_equal 2, workshop.teachers_attending_all_sessions(true).count
+  end
+
+  test 'teachers_attending_all_sessions with a teacher who deleted their account' do
+    workshop = create :workshop,
+      course: Pd::Workshop::COURSE_CSF
+
+    workshop_participant = create :pd_workshop_participant,
+      enrolled: true,
+      attended: true,
+      cdo_scholarship_recipient: true,
+      workshop: workshop
+
+    # Should return 1 before we've done anything
+    assert_equal 1, workshop.teachers_attending_all_sessions(true).count
+
+    # Delete the user
+    workshop_participant.destroy!
+
+    # Should still return 1, since we haven't run the account purger step yet
+    assert_equal 1, workshop.teachers_attending_all_sessions(true).count
+
+    DeleteAccountsHelper.new.clean_and_destroy_pd_content workshop_participant.id
+
+    # Should return 0 once we've fully purged the teacher user ID from the attendance
+    assert_equal 0, workshop.teachers_attending_all_sessions(true).count
   end
 
   # TODO: remove this test when workshop_organizer is deprecated

--- a/dashboard/test/models/pd/workshop_test.rb
+++ b/dashboard/test/models/pd/workshop_test.rb
@@ -872,18 +872,22 @@ class Pd::WorkshopTest < ActiveSupport::TestCase
       cdo_scholarship_recipient: true,
       workshop: workshop
 
-    # Should return 1 before we've done anything
+    # Should return 1 before we've done anything.
     assert_equal 1, workshop.teachers_attending_all_sessions(true).count
 
-    # Delete the user
+    # Delete the user.
     workshop_participant.destroy!
+    workshop.reload
 
-    # Should still return 1, since we haven't run the account purger step yet
-    assert_equal 1, workshop.teachers_attending_all_sessions(true).count
+    # With no user account, the user doesn't show up in array of attending teachers.
+    assert_equal 0, workshop.teachers_attending_all_sessions(true).count
 
+    # Fully purge the user account's PD records,
+    # which removes their user ID from attendances.
     DeleteAccountsHelper.new.clean_and_destroy_pd_content workshop_participant.id
+    workshop.reload
 
-    # Should return 0 once we've fully purged the teacher user ID from the attendance
+    # Should still return 0 once we've fully purged the teacher user ID from the attendance
     assert_equal 0, workshop.teachers_attending_all_sessions(true).count
   end
 


### PR DESCRIPTION
[This Honeybadger error](https://app.honeybadger.io/projects/3240/faults/65434817#notice-trace) occurred in a case where a user deleted their account, but the [account purging process](https://github.com/code-dot-org/code-dot-org/blob/staging/lib/cdo/delete_accounts_helper.rb#L97) hasn't run to remove their user ID from their attendances (runs 28 days after account is deleted.)

## Testing story

Added unit tests to cover uses of this method with deleted accounts.

## Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
