### PR TITLE
Pre-workshop auto-email for facilitators

### DIFF
--- a/dashboard/app/mailers/pd/workshop_mailer.rb
+++ b/dashboard/app/mailers/pd/workshop_mailer.rb
@@ -142,6 +142,17 @@ class Pd::WorkshopMailer < ActionMailer::Base
          reply_to: email_address(@user.name, @user.email)
   end
 
+  def facilitator_pre_workshop(user, workshop)
+    @user = user
+    @workshop = workshop
+
+    mail content_type: 'text/html',
+         from: from_facilitators,
+         subject: 'Preparing for your upcoming workshop',
+         to: email_address(@user.name, @user.email),
+         reply_to: from_facilitators
+  end
+
   def facilitator_post_workshop(user, workshop)
     @user = user
     @workshop = workshop

--- a/dashboard/app/models/pd/workshop.rb
+++ b/dashboard/app/models/pd/workshop.rb
@@ -471,6 +471,7 @@ class Pd::Workshop < ActiveRecord::Base
         errors << "organizer workshop #{workshop.id} - #{e.message}"
       end
 
+      # send pre-workshop email for CSD and CSP facilitators 10 days before the workshop only
       next unless days == 10 && (workshop.course == COURSE_CSD || workshop.course == COURSE_CSP)
       workshop.facilitators.each do |facilitator|
         next unless facilitator.email

--- a/dashboard/app/models/pd/workshop.rb
+++ b/dashboard/app/models/pd/workshop.rb
@@ -470,6 +470,16 @@ class Pd::Workshop < ActiveRecord::Base
       rescue => e
         errors << "organizer workshop #{workshop.id} - #{e.message}"
       end
+
+      next unless days == 10 && (workshop.course == COURSE_CSD || workshop.course == COURSE_CSP)
+      workshop.facilitators.each do |facilitator|
+        next unless facilitator.email
+        begin
+          Pd::WorkshopMailer.facilitator_pre_workshop(facilitator, workshop).deliver_now
+        rescue => e
+          errors << "pre email for facilitator #{facilitator.id} - #{e.message}"
+        end
+      end
     end
 
     raise "Failed to send #{days} day workshop reminders: #{errors.join(', ')}" unless errors.empty?

--- a/dashboard/app/views/pd/workshop_mailer/facilitator_pre_workshop.html.haml
+++ b/dashboard/app/views/pd/workshop_mailer/facilitator_pre_workshop.html.haml
@@ -1,0 +1,45 @@
+:css
+  body {
+    font-family: Gotham, sans-serif;
+  }
+
+%p
+  Dear
+  = @user.name + ','
+
+%p
+  As you are finalizing your plans for your upcoming workshop, I encourage you to take advantage of the following support resources.
+%ul
+  %li
+    Review the workshop agenda and resources posted on the
+    - if @workshop.course == 'CS Principles'
+      =link_to('facilitator landing page', 'https://code.org/facilitator/csp') + '.'
+    - else
+      =link_to('facilitator landing page', ' https://code.org/facilitator/csd') + '.'
+  %li
+    Have quick questions about resources, agendas, or participant requests? Post them in the facilitator
+    =link_to('Slack', 'https://codefacilitators6-12.slack.com/messages')
+    channel!
+  %li
+    Want to share useful resources or engage in longer discussions with the facilitator community? Use the
+    =link_to('Facilitator Forum', 'https://forum.code.org/c/facilitators') + '!'
+  %li
+    Would you like 1:1 support? Schedule a quick check-in with Andrea via this
+    = link_to('scheduling tool', 'https://calendly.com/andrea-fac-supp/30min') + '.'
+  %li
+    Still need assistance with things like travel, scheduling, or Regional Partners? Contact us at
+    = mail_to('facilitators@code.org') + '.'
+
+
+%p
+  Thank you for your time and energy spent preparing for an awesome professional development experience.
+  Please schedule time to take care of yourself and encourage your co-lead to do the same. Have a great workshop!
+
+%p
+Best,
+%br
+Andrea Robertson-Nottingham
+%br
+Education Programs
+%br
+Code.org

--- a/dashboard/app/views/pd/workshop_mailer/facilitator_pre_workshop.html.haml
+++ b/dashboard/app/views/pd/workshop_mailer/facilitator_pre_workshop.html.haml
@@ -29,6 +29,19 @@
   %li
     Still need assistance with things like travel, scheduling, or Regional Partners? Contact us at
     = mail_to('facilitators@code.org') + '.'
+  %li
+    For multi-day workshops, you will need to share daily survey links with your workshop participants on all
+    but the final day of the workshop. These links are already in your slide deck, but can also be found in the
+    workshop agenda and in the
+    = link_to('Facilitator Tools Guide', 'https://docs.google.com/document/d/1Xhl4SnjVYycLOxE_BiVrZnhX-bwfL4Cik_PZkuWBn2s') + '.'
+    %ul
+      %li
+        If more daily survey links are needed, simply increase the last number
+        in the url to match the number of the day.
+      %li
+        The post-workshop survey link is sent to teachers via email after the workshop is closed.
+        Teachers will also be able to access the survey from the
+        = link_to('My Professional Learning Page', 'https://studio.code.org/my-professional-learning') + '.'
 
 
 %p

--- a/dashboard/test/mailers/previews/pd_workshop_mailer_preview.rb
+++ b/dashboard/test/mailers/previews/pd_workshop_mailer_preview.rb
@@ -198,8 +198,18 @@ class Pd::WorkshopMailerPreview < ActionMailer::Preview
     mail :facilitator_enrollment_reminder, target: :facilitator
   end
 
-  def facilitator_pre_workshop
-    mail :facilitator_pre_workshop, target: :facilitator
+  def facilitator_pre_workshop_csp
+    mail :facilitator_pre_workshop,
+      Pd::Workshop::COURSE_CSP,
+      Pd::Workshop::SUBJECT_CSP_SUMMER_WORKSHOP,
+      target: :facilitator
+  end
+
+  def facilitator_pre_workshop_csd
+    mail :facilitator_pre_workshop,
+      Pd::Workshop::COURSE_CSD,
+      Pd::Workshop::SUBJECT_CSD_VIRTUAL_1,
+      target: :facilitator
   end
 
   def facilitator_post_workshop_csp_summer

--- a/dashboard/test/mailers/previews/pd_workshop_mailer_preview.rb
+++ b/dashboard/test/mailers/previews/pd_workshop_mailer_preview.rb
@@ -198,6 +198,10 @@ class Pd::WorkshopMailerPreview < ActionMailer::Preview
     mail :facilitator_enrollment_reminder, target: :facilitator
   end
 
+  def facilitator_pre_workshop
+    mail :facilitator_pre_workshop, target: :facilitator
+  end
+
   def facilitator_post_workshop_csp_summer
     regional_partner = build :regional_partner, name: 'We Teach Code'
 

--- a/dashboard/test/models/pd/workshop_test.rb
+++ b/dashboard/test/models/pd/workshop_test.rb
@@ -801,6 +801,42 @@ class Pd::WorkshopTest < ActiveSupport::TestCase
     Pd::Workshop.send_reminder_for_upcoming_in_days(1)
   end
 
+  test '10 day reminder for academic year workshop sends pre email to facilitators' do
+    mock_mail = stub
+    mock_mail.stubs(:deliver_now).returns(nil)
+
+    workshop = create :academic_year_workshop, num_facilitators: 2
+    create_list :pd_enrollment, 3, workshop: workshop
+    Pd::Workshop.expects(:scheduled_start_in_days).returns([workshop])
+
+    Pd::WorkshopMailer.expects(:facilitator_pre_workshop).returns(mock_mail).times(2)
+    Pd::Workshop.send_reminder_for_upcoming_in_days(10)
+  end
+
+  test '10 day reminder for csf workshop does not send pre email to facilitators' do
+    mock_mail = stub
+    mock_mail.stubs(:deliver_now).returns(nil)
+
+    workshop = create :csf_deep_dive_workshop, num_facilitators: 2
+    create_list :pd_enrollment, 3, workshop: workshop
+    Pd::Workshop.expects(:scheduled_start_in_days).returns([workshop])
+
+    Pd::WorkshopMailer.expects(:facilitator_pre_workshop).returns(mock_mail).never
+    Pd::Workshop.send_reminder_for_upcoming_in_days(10)
+  end
+
+  test '3 day reminder for summer workshop does not send pre email to facilitators' do
+    mock_mail = stub
+    mock_mail.stubs(:deliver_now).returns(nil)
+
+    workshop = create :csp_summer_workshop, num_facilitators: 2
+    create_list :pd_enrollment, 3, workshop: workshop
+    Pd::Workshop.expects(:scheduled_start_in_days).returns([workshop])
+
+    Pd::WorkshopMailer.expects(:facilitator_pre_workshop).returns(mock_mail).never
+    Pd::Workshop.send_reminder_for_upcoming_in_days(3)
+  end
+
   test 'workshop starting date picks the day of the first session' do
     workshop = create :workshop, sessions: [
       session1 = create(:pd_session, start: Date.today + 15.days),


### PR DESCRIPTION
Adds new auto-email sent to all CSD and CSP facilitators 10 days before their workshops as specified [here](https://docs.google.com/document/d/1EpG8eBILQ1m66A42Yw7TsmNvitQwxrEGizgaG4NdErM). This email is currently sent out manually to facilitators.

<!-- ### Background -->
<!-- ### Privacy -->
<!-- ### Security -->
<!-- ### Caching -->
<!-- ### Deployment strategy -->
<!-- ### Future work -->

## Links

- [spec](https://docs.google.com/document/d/1EpG8eBILQ1m66A42Yw7TsmNvitQwxrEGizgaG4NdErM)
- [jira](https://codedotorg.atlassian.net/browse/PLC-925)

## Testing story
Added new mailer previews to validate the email text. Added unit tests and ran locally to validate the email send logic is set up correctly.

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
