### PR TITLE
Redirect to account edit page on existing account auth

### DIFF
--- a/dashboard/app/views/devise/registrations/existing_account.html.haml
+++ b/dashboard/app/views/devise/registrations/existing_account.html.haml
@@ -3,18 +3,16 @@
 
 #signin
 
-  - link_authentication_path = connect_authentication_option_path(provider: params[:provider])
-
   %p
     = I18n.t('auth.existing_account.sign_in', provider: I18n.t(params[:provider], scope: "auth"))
 
   %p
-    = link_to new_user_session_path({user_return_to: link_authentication_path}) do
+    = link_to new_user_session_path({user_return_to: edit_user_registration_path}) do
       %button= I18n.t('nav.user.signin')
 
   %p
     = I18n.t('auth.existing_account.sign_up', provider: I18n.t(params[:provider], scope: "auth"))
 
   %p
-    = link_to new_user_registration_path({user_return_to: link_authentication_path}) do
+    = link_to new_user_registration_path({user_return_to: edit_user_registration_path}) do
       %button.blue-button= I18n.t('nav.user.signup')

--- a/dashboard/config/locales/en.yml
+++ b/dashboard/config/locales/en.yml
@@ -139,8 +139,8 @@ en:
     already_linked: "Your %{provider} account is already linked to your Code.org account."
     existing_account:
       account_exists: "Good news! You already have a Code.org account that uses %{email}"
-      sign_in: "Please sign in and we'll link your %{provider} profile."
-      sign_up: "Not your email? Want to create a new account with a different email? We will also link your %{provider} profile if you choose to create a new account."
+      sign_in: "Please sign in to your existing account. Then you will be able to link your %{provider} profile from your Account Settings page."
+      sign_up: "Not your email? Want to create a new account with a different email? You will also be able to link your %{provider} profile from your Account Settings page if you choose to create a new account."
   signup_form:
     email_signup: 'Sign up with your email address'
     student_count: '%{count} students have already signed up.'

--- a/dashboard/test/controllers/registrations_controller_test.rb
+++ b/dashboard/test/controllers/registrations_controller_test.rb
@@ -488,4 +488,11 @@ class RegistrationsControllerTest < ActionController::TestCase
     assert_response :success
     assert_select '#user_name', 1
   end
+
+  test "existing account sign in/up links redirect to user edit page" do
+    get :existing_account, params: {email: "test@email.com", provider: "facebook"}
+    assert_response :success
+    assert_select "a[href=?]", "/users/sign_in?user_return_to=%2Fusers%2Fedit"
+    assert_select "a[href=?]", "/users/sign_up?user_return_to=%2Fusers%2Fedit"
+  end
 end


### PR DESCRIPTION
Rather than redirecting to the recently-deprecated "connect" route.

"Existing account" page was added in its current form in https://github.com/code-dot-org/code-dot-org/pull/31955
Connect route was deprecated in https://github.com/code-dot-org/code-dot-org/pull/35425

This will require users to manually click the "connect" button after signing in, rather than automatically initiating the connection process for them. This is a small step backwards for usability but a big step forwards for security, so all in all it's still a win.

Also updated some copy to match:

Before | After
--- | ---
![image](https://user-images.githubusercontent.com/244100/86832270-ceee6980-c04c-11ea-82c5-24777beac18a.png) | ![image](https://user-images.githubusercontent.com/244100/86832187-b4b48b80-c04c-11ea-8149-e9298684f0d0.png)


<!--
  Your description goes here: A summary of the change, including any relevant motivation and context.

  If relevant, include a description both of the existing behavior and of the new behavior.
-->

<!--
  Other aspects to consider. uncomment and add detail for any that seem necessary:
-->

<!-- ### Background -->
<!-- ### Privacy -->
<!-- ### Security -->
<!-- ### Caching -->
<!-- ### Deployment strategy -->
<!-- ### Future work -->

## Links

<!--
  Any relevant links to external resources; ie, specification documents, jira
  items, related PRs, honeybadger errors, etc
-->

- [honeybadger](https://app.honeybadger.io/projects/3240/faults/65447618)

## Testing story

Added a basic unit test

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
