### PR TITLE
Studio App displayPlayspaceAlert refactor

### DIFF
--- a/apps/src/StudioApp.js
+++ b/apps/src/StudioApp.js
@@ -42,7 +42,12 @@ import msg from '@cdo/locale';
 import project from './code-studio/initApp/project';
 import puzzleRatingUtils from './puzzleRatingUtils';
 import userAgentParser from './code-studio/initApp/userAgentParser';
-import {KeyCodes, TestResults, TOOLBOX_EDIT_MODE} from './constants';
+import {
+  KeyCodes,
+  TestResults,
+  TOOLBOX_EDIT_MODE,
+  NOTIFICATION_ALERT_TYPE
+} from './constants';
 import {assets as assetsApi} from './clientApi';
 import {blocks as makerDropletBlocks} from './lib/kits/maker/dropletConfig';
 import {closeDialog as closeInstructionsDialog} from './redux/instructionsDialog';
@@ -3120,19 +3125,21 @@ StudioApp.prototype.displayPlayspaceAlert = function(type, alertContents) {
   }
   var renderElement = container[0];
 
-  const playspaceAlert = React.createElement(
-    Alert,
-    {
-      onClose: () => {
-        ReactDOM.unmountComponentAtNode(renderElement);
-      },
-      type: type,
-      sideMargin: type === 'notification' ? undefined : 20,
-      closeDelayMillis: type === 'notification' ? 5000 : undefined,
-      childPadding: type === 'notification' ? '8px 14px' : undefined
+  let alertProps = {
+    onClose: () => {
+      ReactDOM.unmountComponentAtNode(renderElement);
     },
-    alertContents
-  );
+    type: type
+  };
+
+  if (type === NOTIFICATION_ALERT_TYPE) {
+    alertProps.closeDelayMillis = 5000;
+    alertProps.childPadding = '8px 14px';
+  } else {
+    alertProps.sideMargin = 20;
+  }
+
+  const playspaceAlert = React.createElement(Alert, alertProps, alertContents);
   ReactDOM.render(playspaceAlert, renderElement);
 };
 

--- a/apps/src/StudioApp.js
+++ b/apps/src/StudioApp.js
@@ -3105,56 +3105,11 @@ StudioApp.prototype.displayWorkspaceAlert = function(
  * @param {React.Component} alertContents
  */
 StudioApp.prototype.displayPlayspaceAlert = function(type, alertContents) {
-  StudioApp.prototype.displayAlert(
-    '#visualization',
-    {
-      type: type,
-      sideMargin: 20
-    },
-    alertContents
-  );
-};
-
-/**
- * Displays a small notification box inside the playspace that goes away after 5 seconds
- * @param {React.Component} notificationContents
- */
-StudioApp.prototype.displayPlayspaceNotification = function(
-  notificationContents
-) {
-  StudioApp.prototype.displayAlert(
-    '#visualization',
-    {
-      type: 'notification',
-      closeDelayMillis: 5000,
-      childPadding: '8px 14px'
-    },
-    notificationContents
-  );
-};
-
-/**
- * Displays a small alert box inside DOM element at parentSelector. Parent is
- * assumed to have at most a single alert (we'll either create a new one or
- * replace the existing one).
- * @param {object} props
- * @param {string} object.type - Alert type (error or warning)
- * @param {number} [object.sideMaring] - Optional param specifying margin on
- *   either side of element
- * @param {React.Component} alertContents
- * @param {?string} position
- */
-StudioApp.prototype.displayAlert = function(
-  selector,
-  props,
-  alertContents,
-  position = 'absolute'
-) {
-  var parent = $(selector);
+  var parent = $('#visualization');
   var container = parent.children('.react-alert');
   if (container.length === 0) {
     container = $("<div class='react-alert ignore-transform'/>").css({
-      position: position,
+      position: 'absolute',
       left: 0,
       right: 0,
       top: 0,
@@ -3165,23 +3120,20 @@ StudioApp.prototype.displayAlert = function(
   }
   var renderElement = container[0];
 
-  var handleAlertClose = function() {
-    ReactDOM.unmountComponentAtNode(renderElement);
-  };
-  ReactDOM.render(
-    <Alert
-      onClose={handleAlertClose}
-      type={props.type}
-      sideMargin={props.sideMargin}
-      closeDelayMillis={props.closeDelayMillis}
-      childPadding={props.childPadding}
-    >
-      {alertContents}
-    </Alert>,
-    renderElement
+  const playspaceAlert = React.createElement(
+    Alert,
+    {
+      onClose: () => {
+        ReactDOM.unmountComponentAtNode(renderElement);
+      },
+      type: type,
+      sideMargin: type === 'notification' ? undefined : 20,
+      closeDelayMillis: type === 'notification' ? 5000 : undefined,
+      childPadding: type === 'notification' ? '8px 14px' : undefined
+    },
+    alertContents
   );
-
-  return renderElement;
+  ReactDOM.render(playspaceAlert, renderElement);
 };
 
 /**

--- a/apps/src/applab/designMode.js
+++ b/apps/src/applab/designMode.js
@@ -14,7 +14,7 @@ import * as assetPrefix from '../assetManagement/assetPrefix';
 import elementLibrary from './designElements/library';
 import * as elementUtils from './designElements/elementUtils';
 import {singleton as studioApp} from '../StudioApp';
-import {KeyCodes} from '../constants';
+import {KeyCodes, NOTIFICATION_ALERT_TYPE} from '../constants';
 import * as applabConstants from './constants';
 import sanitizeHtml from './sanitizeHtml';
 import * as utils from '../utils';
@@ -869,7 +869,7 @@ function duplicateScreen(element) {
       Duplicated <b>{sourceScreenId}</b> to <b>{newScreenId}</b>
     </div>
   );
-  studioApp().displayPlayspaceAlert('notification', alert);
+  studioApp().displayPlayspaceAlert(NOTIFICATION_ALERT_TYPE, alert);
 
   return newScreenId;
 }
@@ -923,7 +923,7 @@ designMode.onCopyElementToScreen = function(element, destScreen) {
       <b>{elementUtils.getId(duplicateElement)}</b>
     </div>
   );
-  studioApp().displayPlayspaceAlert('notification', alert);
+  studioApp().displayPlayspaceAlert(NOTIFICATION_ALERT_TYPE, alert);
 };
 
 designMode.onDeletePropertiesButton = function(element, event) {

--- a/apps/src/applab/designMode.js
+++ b/apps/src/applab/designMode.js
@@ -869,7 +869,7 @@ function duplicateScreen(element) {
       Duplicated <b>{sourceScreenId}</b> to <b>{newScreenId}</b>
     </div>
   );
-  studioApp().displayPlayspaceNotification(alert);
+  studioApp().displayPlayspaceAlert('notification', alert);
 
   return newScreenId;
 }
@@ -923,7 +923,7 @@ designMode.onCopyElementToScreen = function(element, destScreen) {
       <b>{elementUtils.getId(duplicateElement)}</b>
     </div>
   );
-  studioApp().displayPlayspaceNotification(alert);
+  studioApp().displayPlayspaceAlert('notification', alert);
 };
 
 designMode.onDeletePropertiesButton = function(element, event) {

--- a/apps/src/constants.js
+++ b/apps/src/constants.js
@@ -185,3 +185,5 @@ export const BASE_DIALOG_WIDTH = 700;
 export const TOOLBOX_EDIT_MODE = 'toolbox_blocks';
 
 export const PROFANITY_FOUND = 'profanity_found';
+
+export const NOTIFICATION_ALERT_TYPE = 'notification';

--- a/apps/test/unit/applab/designModeThemesTest.js
+++ b/apps/test/unit/applab/designModeThemesTest.js
@@ -306,12 +306,12 @@ describe('themes: ', () => {
         designMode.activeScreen().style.display = 'none';
         getPrefixedElementById(screenId).style.display = 'block';
       });
-      sinon.stub(studioApp(), 'displayPlayspaceNotification');
+      sinon.stub(studioApp(), 'displayPlayspaceAlert');
     });
 
     afterEach(() => {
       designMode.changeScreen.restore();
-      studioApp().displayPlayspaceNotification.restore();
+      studioApp().displayPlayspaceAlert.restore();
     });
 
     it('copies element from a screen with one theme to a screen with a different theme', () => {
@@ -329,7 +329,7 @@ describe('themes: ', () => {
       );
 
       expect(designMode.changeScreen).to.be.called;
-      expect(studioApp().displayPlayspaceNotification).to.be.called;
+      expect(studioApp().displayPlayspaceAlert).to.be.called;
 
       expect(getPrefixedElementById('text_input2')).not.to.be.null;
       // Should have the background color appropriate for the theme of screen2 (watermelon)


### PR DESCRIPTION
displayAlert and displayWorkspaceAlert were decoupled as part of [this PR](https://github.com/code-dot-org/code-dot-org/pull/35351). As part of trying to decrease the size of StudioApp, this merges displayPlayspaceNotification and displayAlert into displayPlayspaceAlert.

<!-- ### Background -->
<!-- ### Privacy -->
<!-- ### Security -->
<!-- ### Caching -->
<!-- ### Deployment strategy -->
<!-- ### Future work -->

## Links

- [PR that does something similar for displayWorkspaceAlert](https://github.com/code-dot-org/code-dot-org/pull/35351)

## Testing story

<!--
  Does your change include appropriate tests?

  If so, please describe how the tests included in this PR are sufficient

  If not, please explain why this change does not need to be tested.
-->

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
