### PR TITLE
Add ui-test-scripts information to scripts.en.yml

### DIFF
--- a/dashboard/config/locales/scripts.en.yml
+++ b/dashboard/config/locales/scripts.en.yml
@@ -32081,3 +32081,43 @@ en:
               display_name: Content
             cspSurvey:
               display_name: Content
+        ui-test-script-in-course-2017:
+          stages:
+            Lesson:
+              name: Lesson
+          lessons:
+            Lesson:
+              name: Lesson
+          lesson_groups:
+            lg_1:
+              display_name: Content
+        ui-test-script-in-course-2019:
+          stages:
+            Lesson:
+              name: Lesson
+          lessons:
+            Lesson:
+              name: Lesson
+          lesson_groups:
+            lg_1:
+              display_name: Content
+        ui-test-versioned-script-2017:
+          stages:
+            Lesson:
+              name: Lesson
+          lessons:
+            Lesson:
+              name: Lesson
+          lesson_groups:
+            lg_1:
+              display_name: Content
+        ui-test-versioned-script-2019:
+          stages:
+            Lesson:
+              name: Lesson
+          lessons:
+            Lesson:
+              name: Lesson
+          lesson_groups:
+            lg_1:
+              display_name: Content


### PR DESCRIPTION
Follow up to : https://github.com/code-dot-org/code-dot-org/pull/35694

Adds entries to scripts.en.yml for ui-test-scripts so that we don't end up with a merge conflict on Test because the ui-test-scripts are only seeded there.