### PR TITLE
Dismiss bottom workspace alerts on click

### DIFF
--- a/apps/src/code-studio/components/WorkspaceAlert.jsx
+++ b/apps/src/code-studio/components/WorkspaceAlert.jsx
@@ -46,7 +46,10 @@ export default class WorkspaceAlert extends React.Component {
       : {top: $('#headers').height(), left: toolbarWidth};
 
     return (
-      <div style={{...styles.alertContainer, ...position}}>
+      <div
+        style={{...styles.alertContainer, ...position}}
+        onClick={displayBottom ? onClose : undefined}
+      >
         <Alert
           onClose={onClose}
           type={type}


### PR DESCRIPTION
This makes it so that bottom workspace alerts can be dismissed by clicking anywhere within the alert. This is to help mobile users in larger projects as discussed in [this slack thread](https://codedotorg.slack.com/archives/CN4T89YP8/p1594075759051300). Currently, bottom workspace alerts are only created when a user edits their code while it's running. 

<!-- ### Background -->
<!-- ### Privacy -->
<!-- ### Security -->
<!-- ### Caching -->
<!-- ### Deployment strategy -->
<!-- ### Future work -->

## Links

- [Original bottom workspace alert PR](https://github.com/code-dot-org/code-dot-org/pull/35351)
- [Slack conversation about this](https://codedotorg.slack.com/archives/CN4T89YP8/p1594075759051300)

## Testing story

<!--
  Does your change include appropriate tests?

  If so, please describe how the tests included in this PR are sufficient

  If not, please explain why this change does not need to be tested.
-->

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
