### PR TITLE
AFE: prevent student account submission

### DIFF
--- a/apps/src/sites/code.org/pages/views/amazon_future_engineer_eligibility.js
+++ b/apps/src/sites/code.org/pages/views/amazon_future_engineer_eligibility.js
@@ -12,20 +12,15 @@ function showAmazonFutureEngineerEligibility() {
   );
 
   let signedIn = false;
-  let schoolData = {};
+  let accountInformation = {};
 
   $.ajax({
     type: 'GET',
     url: '/dashboardapi/v1/users/me/donor_teacher_banner_details'
   })
     .done(results => {
-      // This request returns a 403 if the user isn't signed in,
-      // and 204 (no content) if a user is signed in to a student account.
       signedIn = true;
-
-      if (results) {
-        schoolData = results;
-      }
+      accountInformation = results;
     })
     .complete(() => {
       firehoseClient.putRecord({
@@ -38,9 +33,12 @@ function showAmazonFutureEngineerEligibility() {
           ReactDOM.render(
             <AmazonFutureEngineerEligibility
               signedIn={signedIn}
-              schoolId={schoolData.nces_school_id || ''}
-              schoolEligible={schoolData.afe_high_needs || null}
-              accountEmail={schoolData.teacher_email || null}
+              schoolId={accountInformation.nces_school_id || ''}
+              schoolEligible={accountInformation.afe_high_needs || null}
+              accountEmail={accountInformation.teacher_email || null}
+              isStudentAccount={
+                accountInformation.user_type === 'student' ? true : false
+              }
             />,
             amazonFutureEngineerEligibilityElement
           );

--- a/apps/src/templates/amazonFutureEngineerEligibility/amazonFutureEngineerAccountConfirmation.jsx
+++ b/apps/src/templates/amazonFutureEngineerEligibility/amazonFutureEngineerAccountConfirmation.jsx
@@ -39,8 +39,8 @@ export default class AmazonFutureEngineerAccountConfirmation extends React.Compo
         <div style={styles.body}>
           Thank you for completing your application information for the Amazon
           Future Engineer program. To finalize your participation and start
-          receiving benefits, sign up for a Code.org account, or sign in if you
-          already have one.
+          receiving benefits, sign up for a Code.org teacher account, or sign in
+          if you already have one.
         </div>
         <div style={styles.body}>
           Already have a Code.org account? <a href={SIGN_IN_URL}>Sign in.</a>

--- a/apps/src/templates/amazonFutureEngineerEligibility/amazonFutureEngineerEligibility.jsx
+++ b/apps/src/templates/amazonFutureEngineerEligibility/amazonFutureEngineerEligibility.jsx
@@ -332,14 +332,13 @@ export default class AmazonFutureEngineerEligibility extends React.Component {
 
 const StudentAccountNotification = (
   <div style={styles.container}>
-    <h2 style={styles.header}>Am I eligible?</h2>
+    <h2 style={styles.header}>You need a Code.org teacher account</h2>
     <div>
       <p>You're currently signed in to Code.org with a student account.</p>
       <p>
         You'll need to sign in with a teacher account to apply to receive Amazon
         Future Engineer benefits. You can use the button below to sign out, then
-        return to this page (<a href={pegasus('/afe')}>code.org/afe</a>) to
-        check your eligibility.
+        return to <a href={pegasus('/afe')}>code.org/afe</a> to continue.
       </p>
       <Button
         id="sign_out"

--- a/apps/src/templates/amazonFutureEngineerEligibility/amazonFutureEngineerEligibility.jsx
+++ b/apps/src/templates/amazonFutureEngineerEligibility/amazonFutureEngineerEligibility.jsx
@@ -7,7 +7,7 @@ import color from '@cdo/apps/util/color';
 import SchoolAutocompleteDropdownWithLabel from '@cdo/apps/templates/census2017/SchoolAutocompleteDropdownWithLabel';
 import AmazonFutureEngineerEligibilityForm from './amazonFutureEngineerEligibilityForm';
 import AmazonFutureEngineerAccountConfirmation from './amazonFutureEngineerAccountConfirmation';
-import {pegasus} from '@cdo/apps/lib/util/urlHelpers';
+import {studio, pegasus} from '@cdo/apps/lib/util/urlHelpers';
 import {isEmail} from '@cdo/apps/util/formatValidation';
 
 const styles = {
@@ -38,7 +38,8 @@ export default class AmazonFutureEngineerEligibility extends React.Component {
     signedIn: PropTypes.bool.isRequired,
     schoolId: PropTypes.string,
     schoolEligible: PropTypes.bool,
-    accountEmail: PropTypes.string
+    accountEmail: PropTypes.string,
+    isStudentAccount: PropTypes.bool
   };
 
   constructor(props) {
@@ -249,6 +250,10 @@ export default class AmazonFutureEngineerEligibility extends React.Component {
   render() {
     let {formData, submissionError} = this.state;
 
+    if (this.props.isStudentAccount) {
+      return StudentAccountNotification;
+    }
+
     if (submissionError) {
       return (
         <SubmissionError
@@ -324,6 +329,28 @@ export default class AmazonFutureEngineerEligibility extends React.Component {
     );
   }
 }
+
+const StudentAccountNotification = (
+  <div style={styles.container}>
+    <h2 style={styles.header}>Am I eligible?</h2>
+    <div>
+      <p>You're currently signed in to Code.org with a student account.</p>
+      <p>
+        You'll need to sign in with a teacher account to apply to receive Amazon
+        Future Engineer benefits. You can use the button below to sign out, then
+        return to this page (<a href={pegasus('/afe')}>code.org/afe</a>) to
+        check your eligibility.
+      </p>
+      <Button
+        id="sign_out"
+        href={studio('/users/sign_out')}
+        style={styles.button}
+      >
+        Sign out
+      </Button>
+    </div>
+  </div>
+);
 
 const SubmissionError = ({submissionError, submissionErrorTime}) => (
   <div style={styles.container}>

--- a/dashboard/app/controllers/api/v1/amazon_future_engineer_controller.rb
+++ b/dashboard/app/controllers/api/v1/amazon_future_engineer_controller.rb
@@ -9,7 +9,7 @@ class Api::V1::AmazonFutureEngineerController < ApplicationController
   skip_before_action :verify_authenticity_token
 
   def submit
-    return head :forbidden unless current_user
+    return head :forbidden unless current_user&.teacher?
 
     afe_params = submit_params
     Services::AFEEnrollment.submit(

--- a/dashboard/app/controllers/api/v1/users_controller.rb
+++ b/dashboard/app/controllers/api/v1/users_controller.rb
@@ -38,6 +38,7 @@ class Api::V1::UsersController < Api::V1::JsonApiController
     if current_user.teacher?
       teachers_school = Queries::SchoolInfo.last_complete(current_user)&.school
       render json: {
+        user_type: 'teacher',
         teacher_first_name: current_user.short_name,
         teacher_second_name: current_user.second_name,
         teacher_email: current_user.email,
@@ -51,7 +52,9 @@ class Api::V1::UsersController < Api::V1::JsonApiController
         afe_high_needs: teachers_school&.afe_high_needs?
       }
     else
-      head :no_content
+      render json: {
+        user_type: 'student'
+      }
     end
   end
 

--- a/dashboard/test/controllers/api/v1/amazon_future_engineer_controller_test.rb
+++ b/dashboard/test/controllers/api/v1/amazon_future_engineer_controller_test.rb
@@ -17,6 +17,17 @@ class Api::V1::AmazonFutureEngineerControllerTest < ActionDispatch::IntegrationT
     assert_response :forbidden
   end
 
+  test 'logged in student cannot submit' do
+    Services::AFEEnrollment.expects(:submit).never
+
+    sign_in create :student
+
+    post '/dashboardapi/v1/amazon_future_engineer_submit',
+      params: valid_params, as: :json
+
+    assert_response :forbidden
+  end
+
   test 'responds BAD REQUEST when params are malformed' do
     Services::AFEEnrollment.expects(:submit).never
 


### PR DESCRIPTION
Prevents signed in student accounts from submitting to CSTA or AFE. Also changes UI to alert users if they're signed into a student account, and won't be able to submit until they sign in to a teacher account.

**Signed in student visits code.org/afe**
![image](https://user-images.githubusercontent.com/25372625/86847294-ecc5c980-c060-11ea-899b-769947549199.png)

**User signs up for student account after going through eligibility flow**
![image](https://user-images.githubusercontent.com/25372625/86845246-0f0a1800-c05e-11ea-8d1e-bd6517559b1d.png)


## Testing story

Manually ran through scenarios:
- Signed in student visits code.org/afe (sees "you need teacher account" inline)
- Signed out user goes through eligibility flow and signs in to student account (sees "you need teacher account" on code.org/afe/submit)
- Signed in teacher whose school eligible for discount and gives their contact information (sees success page)
- Signed out user goes through eligibility flow and signs in to teacher account (sees success page)

## Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
