### PR TITLE
AFE: Use dropdown to select state in form

### DIFF
--- a/apps/src/templates/amazonFutureEngineerEligibility/amazonFutureEngineerEligibilityForm.jsx
+++ b/apps/src/templates/amazonFutureEngineerEligibility/amazonFutureEngineerEligibilityForm.jsx
@@ -9,8 +9,15 @@ import FieldGroup from '../../code-studio/pd/form_components/FieldGroup';
 import SingleCheckbox from '../../code-studio/pd/form_components/SingleCheckbox';
 import color from '@cdo/apps/util/color';
 import {isEmail} from '@cdo/apps/util/formatValidation';
+import {STATES} from '@cdo/apps/geographyConstants';
 
 const VALIDATION_STATE_ERROR = 'error';
+
+const renderedStateOptions = STATES.map(state => (
+  <option key={state} value={state}>
+    {state}
+  </option>
+));
 
 const styles = {
   wrong_school: {
@@ -363,15 +370,17 @@ class ShippingAddressFormGroup extends React.Component {
         <FieldGroup
           id="state"
           label="State"
-          type="text"
           required={true}
           onChange={this.handleChange}
           validationState={
-            this.props.checkValidationState('state')
+            this.props.checkValidationState('stateSelect')
               ? VALIDATION_STATE_ERROR
               : null
           }
-        />
+          componentClass="select"
+        >
+          {renderedStateOptions}
+        </FieldGroup>
         <FieldGroup
           id="zip"
           label="Zip code"

--- a/apps/src/templates/amazonFutureEngineerEligibility/amazonFutureEngineerEligibilityForm.jsx
+++ b/apps/src/templates/amazonFutureEngineerEligibility/amazonFutureEngineerEligibilityForm.jsx
@@ -310,8 +310,6 @@ export default class AmazonFutureEngineerEligibilityForm extends React.Component
   }
 }
 
-// This might be better as pure functional component?
-// Just takes handleChange as argument, returns form?
 const ShippingAddressFormGroup = ({handleChange, checkValidationState}) => {
   const renderedStateOptions = STATES.map(state => (
     <option key={state} value={state}>

--- a/apps/src/templates/amazonFutureEngineerEligibility/amazonFutureEngineerEligibilityForm.jsx
+++ b/apps/src/templates/amazonFutureEngineerEligibility/amazonFutureEngineerEligibilityForm.jsx
@@ -13,12 +13,6 @@ import {STATES} from '@cdo/apps/geographyConstants';
 
 const VALIDATION_STATE_ERROR = 'error';
 
-const renderedStateOptions = STATES.map(state => (
-  <option key={state} value={state}>
-    {state}
-  </option>
-));
-
 const styles = {
   wrong_school: {
     textAlign: 'right'
@@ -318,82 +312,72 @@ export default class AmazonFutureEngineerEligibilityForm extends React.Component
 
 // This might be better as pure functional component?
 // Just takes handleChange as argument, returns form?
-class ShippingAddressFormGroup extends React.Component {
-  static propTypes = {
-    handleChange: PropTypes.func.isRequired,
-    checkValidationState: PropTypes.func.isRequired
-  };
+const ShippingAddressFormGroup = ({handleChange, checkValidationState}) => {
+  const renderedStateOptions = STATES.map(state => (
+    <option key={state} value={state}>
+      {state}
+    </option>
+  ));
 
-  handleChange = change => {
-    this.props.handleChange(change);
-  };
-
-  render() {
-    // TO DO: Maybe outermost element should be FormGroup, not div
-    return (
+  return (
+    <div>
       <div>
-        <div>
-          Since you checked the box above, please verify your school address
-          below.
-        </div>
-        <FieldGroup
-          id="street1"
-          label="Street 1"
-          type="text"
-          required={true}
-          onChange={this.handleChange}
-          validationState={
-            this.props.checkValidationState('street1')
-              ? VALIDATION_STATE_ERROR
-              : null
-          }
-        />
-        <FieldGroup
-          id="street2"
-          label="Street 2"
-          type="text"
-          required={false}
-          onChange={this.handleChange}
-        />
-        <FieldGroup
-          id="city"
-          label="City"
-          type="text"
-          required={true}
-          onChange={this.handleChange}
-          validationState={
-            this.props.checkValidationState('city')
-              ? VALIDATION_STATE_ERROR
-              : null
-          }
-        />
-        <FieldGroup
-          id="state"
-          label="State"
-          required={true}
-          onChange={this.handleChange}
-          validationState={
-            this.props.checkValidationState('stateSelect')
-              ? VALIDATION_STATE_ERROR
-              : null
-          }
-          componentClass="select"
-        >
-          {renderedStateOptions}
-        </FieldGroup>
-        <FieldGroup
-          id="zip"
-          label="Zip code"
-          type="number"
-          required={true}
-          onChange={this.handleChange}
-          validationState={
-            this.props.checkValidationState('zip')
-              ? VALIDATION_STATE_ERROR
-              : null
-          }
-        />
+        Since you checked the box above, please verify your school address
+        below.
       </div>
-    );
-  }
-}
+      <FieldGroup
+        id="street1"
+        label="Street 1"
+        type="text"
+        required={true}
+        onChange={handleChange}
+        validationState={
+          checkValidationState('street1') ? VALIDATION_STATE_ERROR : null
+        }
+      />
+      <FieldGroup
+        id="street2"
+        label="Street 2"
+        type="text"
+        required={false}
+        onChange={handleChange}
+      />
+      <FieldGroup
+        id="city"
+        label="City"
+        type="text"
+        required={true}
+        onChange={handleChange}
+        validationState={
+          checkValidationState('city') ? VALIDATION_STATE_ERROR : null
+        }
+      />
+      <FieldGroup
+        id="state"
+        label="State"
+        required={true}
+        onChange={handleChange}
+        validationState={
+          checkValidationState('state') ? VALIDATION_STATE_ERROR : null
+        }
+        componentClass="select"
+      >
+        {renderedStateOptions}
+      </FieldGroup>
+      <FieldGroup
+        id="zip"
+        label="Zip code"
+        type="number"
+        required={true}
+        onChange={handleChange}
+        validationState={
+          checkValidationState('zip') ? VALIDATION_STATE_ERROR : null
+        }
+      />
+    </div>
+  );
+};
+ShippingAddressFormGroup.propTypes = {
+  handleChange: PropTypes.func.isRequired,
+  checkValidationState: PropTypes.func.isRequired
+};

--- a/dashboard/app/controllers/api/v1/amazon_future_engineer_controller.rb
+++ b/dashboard/app/controllers/api/v1/amazon_future_engineer_controller.rb
@@ -44,7 +44,7 @@ class Api::V1::AmazonFutureEngineerController < ApplicationController
         street_1: afe_params['street1'] || school&.address_line1 || '',
         street_2: afe_params['street2'] || school&.address_line2 || '',
         city: afe_params['city'] || school&.city || '',
-        state: afe_params['state'] || school&.state || '',
+        state: get_us_state_abbr_from_name(afe_params['state'], true) || school&.state || '',
         zip: afe_params['zip'] || school&.zip || '',
         privacy_permission: to_bool(afe_params['consentCSTA'])
       )

--- a/dashboard/app/controllers/api/v1/amazon_future_engineer_controller.rb
+++ b/dashboard/app/controllers/api/v1/amazon_future_engineer_controller.rb
@@ -1,4 +1,5 @@
 require 'honeybadger/ruby'
+require 'state_abbr'
 
 #
 # Handles submissions to our AFE form at code.org/afe, and in turn submits on
@@ -20,7 +21,7 @@ class Api::V1::AmazonFutureEngineerController < ApplicationController
       street_1: afe_params['street1'],
       street_2: afe_params['street2'],
       city: afe_params['city'],
-      state: afe_params['state'],
+      state: get_us_state_abbr_from_name(afe_params['state'], true),
       zip: afe_params['zip'],
       marketing_kit: afe_params['inspirationKit'],
       csta_plus: afe_params['csta'],

--- a/dashboard/test/controllers/api/v1/amazon_future_engineer_controller_test.rb
+++ b/dashboard/test/controllers/api/v1/amazon_future_engineer_controller_test.rb
@@ -61,7 +61,7 @@ class Api::V1::AmazonFutureEngineerControllerTest < ActionDispatch::IntegrationT
       street_1: 'test street',
       street_2: 'test street 2',
       city: 'seattle',
-      state: 'wa',
+      state: 'WA',
       zip: '98105',
       marketing_kit: '0',
       csta_plus: '0',
@@ -131,7 +131,7 @@ class Api::V1::AmazonFutureEngineerControllerTest < ActionDispatch::IntegrationT
         street_1: 'test street',
         street_2: 'test street 2',
         city: 'seattle',
-        state: 'wa',
+        state: 'WA',
         zip: '98105',
         privacy_permission: true
       },
@@ -174,6 +174,9 @@ class Api::V1::AmazonFutureEngineerControllerTest < ActionDispatch::IntegrationT
     school = create :school
     refute_equal 'example-street-1', school.address_line1
 
+    # We have to use an actual state here (Florida)
+    # that is different than what is in valid_params (Washington)
+    # because the form uses a select element to limit users to submit real states
     actual_args = capture_csta_args_for_request(
       valid_params.merge(
         'csta' => true,
@@ -181,7 +184,7 @@ class Api::V1::AmazonFutureEngineerControllerTest < ActionDispatch::IntegrationT
         'street1' => 'example-street-1',
         'street2' => 'example-street-2',
         'city' => 'example-city',
-        'state' => 'example-state',
+        'state' => 'Florida',
         'zip' => 'example-zip'
       )
     )
@@ -189,7 +192,7 @@ class Api::V1::AmazonFutureEngineerControllerTest < ActionDispatch::IntegrationT
     assert_equal 'example-street-1', actual_args[:street_1]
     assert_equal 'example-street-2', actual_args[:street_2]
     assert_equal 'example-city', actual_args[:city]
-    assert_equal 'example-state', actual_args[:state]
+    assert_equal 'FL', actual_args[:state]
     assert_equal 'example-zip', actual_args[:zip]
   end
 
@@ -290,7 +293,7 @@ class Api::V1::AmazonFutureEngineerControllerTest < ActionDispatch::IntegrationT
       'street1' => 'test street',
       'street2' => 'test street 2',
       'city' => 'seattle',
-      'state' => 'wa',
+      'state' => 'Washington',
       'zip' => '98105',
       'inspirationKit' => '0',
       'csta' => '0',


### PR DESCRIPTION
Uses dropdown instead of free form text to select state in AFE form. Also did a bit of cleanup to convert the `ShippingAddressFormGroup` into a functional component -- I'll highlight the logical changes with a comment.

![image](https://user-images.githubusercontent.com/25372625/86943839-cdc84580-c0fb-11ea-97b5-2ce1cc2cbd02.png)

## Testing story

Tested manually via React devtools that the payload being generated is the same as it was previously.

## Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
