### PR TITLE
Add caching to profanity filter route

### DIFF
--- a/apps/src/code-studio/components/libraries/util.js
+++ b/apps/src/code-studio/components/libraries/util.js
@@ -1,10 +1,10 @@
 import $ from 'jquery';
 
-export const findProfanity = (text, language) => {
+export const findProfanity = (text, language, shouldCache) => {
   return $.ajax({
     url: '/profanity/find',
     method: 'POST',
     contentType: 'application/json;charset=UTF-8',
-    data: JSON.stringify({text, language})
+    data: JSON.stringify({text, language, should_cache: shouldCache})
   });
 };

--- a/apps/src/lib/util/speech.js
+++ b/apps/src/lib/util/speech.js
@@ -98,7 +98,7 @@ export function textToSpeech(
 
     var request = new XMLHttpRequest();
     const resultPromise = new Promise(async function(resolve, reject) {
-      let profaneWords = await findProfanity(text, languageCode);
+      let profaneWords = await findProfanity(text, languageCode, true);
       if (profaneWords && profaneWords.length > 0) {
         if (!Array.isArray(profaneWords)) {
           profaneWords = [profaneWords];

--- a/dashboard/app/controllers/profanity_controller.rb
+++ b/dashboard/app/controllers/profanity_controller.rb
@@ -10,7 +10,7 @@ class ProfanityController < ApplicationController
     profanity_result = []
     unless params[:text].nil?
       if params[:should_cache]
-        cache_key = "profanity/#{params[:language] || request.locale}/#{params[:text] || ''}"
+        cache_key = "profanity/#{params[:language] || request.locale}/#{params[:text]}"
         profanity_result = Rails.cache.fetch(cache_key) do
           ProfanityFilter.find_potential_profanities(params[:text], params[:language] || request.locale)
         end

--- a/dashboard/app/controllers/profanity_controller.rb
+++ b/dashboard/app/controllers/profanity_controller.rb
@@ -4,8 +4,18 @@ class ProfanityController < ApplicationController
   # POST /profanity/find
   # @param [String] params[:text] String to test
   # @param [String] params[:language] Language of the text to test
+  # @param [Boolean] params[:should_cache] Whether or not we should use the cache on this request
   # @returns [Array<String>|nil] Profane words within the given string
   def find
-    render json: ProfanityFilter.find_potential_profanities(params[:text] || "", params[:language] || request.locale)
+    profanity_result = []
+    if params[:should_cache]
+      cache_key = "profanity/#{params[:language] || request.locale}/#{params[:text] || ''}"
+      profanity_result = Rails.cache.fetch(cache_key) do
+        ProfanityFilter.find_potential_profanities(params[:text] || "", params[:language] || request.locale)
+      end
+    else
+      profanity_result = ProfanityFilter.find_potential_profanities(params[:text] || "", params[:language] || request.locale)
+    end
+    render json: profanity_result
   end
 end

--- a/dashboard/app/controllers/profanity_controller.rb
+++ b/dashboard/app/controllers/profanity_controller.rb
@@ -8,13 +8,15 @@ class ProfanityController < ApplicationController
   # @returns [Array<String>|nil] Profane words within the given string
   def find
     profanity_result = []
-    if params[:should_cache]
-      cache_key = "profanity/#{params[:language] || request.locale}/#{params[:text] || ''}"
-      profanity_result = Rails.cache.fetch(cache_key) do
-        ProfanityFilter.find_potential_profanities(params[:text] || "", params[:language] || request.locale)
+    unless params[:text].nil?
+      if params[:should_cache]
+        cache_key = "profanity/#{params[:language] || request.locale}/#{params[:text] || ''}"
+        profanity_result = Rails.cache.fetch(cache_key) do
+          ProfanityFilter.find_potential_profanities(params[:text], params[:language] || request.locale)
+        end
+      else
+        profanity_result = ProfanityFilter.find_potential_profanities(params[:text], params[:language] || request.locale)
       end
-    else
-      profanity_result = ProfanityFilter.find_potential_profanities(params[:text] || "", params[:language] || request.locale)
     end
     render json: profanity_result
   end


### PR DESCRIPTION
This adds caching to the profanity filter route. Currently, we check webpurify each time a student uses a project with playSpeech in it for the first time. This will cache those results so we don't make as many webpurify requests for the same text.

<!-- ### Background -->
<!-- ### Privacy -->
<!-- ### Security -->
<!-- ### Caching -->
<!-- ### Deployment strategy -->
<!-- ### Future work -->

## Links

<!--
  Any relevant links to external resources; ie, specification documents, jira
  items, related PRs, honeybadger errors, etc
-->

- [slack thread about this](https://codedotorg.slack.com/archives/C0T10HG6N/p1593731050038200)

## Testing story

<!--
  Does your change include appropriate tests?

  If so, please describe how the tests included in this PR are sufficient

  If not, please explain why this change does not need to be tested.
-->

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
