### PR TITLE
[Applab Datasets] Check for channel before importing any data

### DIFF
--- a/apps/src/applab/applab.js
+++ b/apps/src/applab/applab.js
@@ -774,6 +774,7 @@ Applab.init = function(config) {
 };
 
 async function initDataTab(levelOptions) {
+  const channelExists = await Applab.storage.channelExists();
   if (levelOptions.dataTables) {
     Applab.storage.populateTable(levelOptions.dataTables).catch(outputError);
   }
@@ -785,7 +786,6 @@ async function initDataTab(levelOptions) {
     );
   }
   if (levelOptions.dataLibraryTables) {
-    const channelExists = await Applab.storage.channelExists();
     const libraryManifest = await Applab.storage.getLibraryManifest();
     if (!channelExists) {
       const tables = levelOptions.dataLibraryTables.split(',');


### PR DESCRIPTION
We check for whether the channel exists before importing library tables that are specified for the level. However, an issue arises if a level has JSON tables *and* library tables, because we populate the JSON tables first, so then when we check for the channel, it already exists, so we skip importing the library tables. Solving this just by checking whether the channel exists before doing anything else.
[slack thread](https://codedotorg.slack.com/archives/C1B3PNDL7/p1594225284255700)

## Testing story

Verified that this fixes the broken level

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
