### PR TITLE
Guard against undefined this.config object

### DIFF
--- a/apps/src/StudioApp.js
+++ b/apps/src/StudioApp.js
@@ -3094,7 +3094,7 @@ StudioApp.prototype.displayWorkspaceAlert = function(
         ReactDOM.unmountComponentAtNode(container[0]);
       },
       isBlockly: this.usingBlockly_,
-      isCraft: this.config.app === 'craft',
+      isCraft: this.config && this.config.app === 'craft',
       displayBottom: bottom
     },
     alertContents


### PR DESCRIPTION
In Weblab, we display an alert if the level was completed during a pairing session. In this case, `this.config` is undefined, which meant that this line:
https://github.com/code-dot-org/code-dot-org/blob/842e9a0236b859d16e5133118dc1dbb0f12c2beb/apps/src/StudioApp.js#L3097

was throwing this error:
<img width="587" alt="Screen Shot 2020-07-08 at 11 40 57 AM" src="https://user-images.githubusercontent.com/9812299/86961433-13920780-c116-11ea-82c0-dc083c959168.png">

and somehow resulted in the "Finish" button no-oping for that level.

## Links

- [Slack thread](https://codedotorg.slack.com/archives/CA3KCSGTD/p1594227362471000)

## Testing story

Confirmed manually that adding this guard fixes the undesired behavior.

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
