### PR TITLE
make redirects to latest versions of CB curriculum use 302 status code

### DIFF
--- a/aws/s3/cdo-curriculum/redirection_rules.rb
+++ b/aws/s3/cdo-curriculum/redirection_rules.rb
@@ -20,7 +20,8 @@ routing_rules = [
     },
     redirect: {
       host_name: HOST_NAME,
-      replace_key_prefix_with: "csp-20/"
+      replace_key_prefix_with: "csp-20/",
+      http_redirect_code: "302"
     }
   },
   {
@@ -38,7 +39,8 @@ routing_rules = [
     },
     redirect: {
       host_name: HOST_NAME,
-      replace_key_prefix_with: "csd-20/"
+      replace_key_prefix_with: "csd-20/",
+      http_redirect_code: "302"
     }
   },
   {
@@ -56,7 +58,8 @@ routing_rules = [
     },
     redirect: {
       host_name: HOST_NAME,
-      replace_key_prefix_with: "csf-20/"
+      replace_key_prefix_with: "csf-20/",
+      http_redirect_code: "302"
     }
   },
   {
@@ -65,7 +68,8 @@ routing_rules = [
     },
     redirect: {
       host_name: HOST_NAME,
-      replace_key_prefix_with: "plcsf-20/"
+      replace_key_prefix_with: "plcsf-20/",
+      http_redirect_code: "302"
     }
   },
   {
@@ -74,7 +78,8 @@ routing_rules = [
     },
     redirect: {
       host_name: HOST_NAME,
-      replace_key_prefix_with: "plcsd-20/"
+      replace_key_prefix_with: "plcsd-20/",
+      http_redirect_code: "302"
     }
   },
   {
@@ -83,7 +88,8 @@ routing_rules = [
     },
     redirect: {
       host_name: HOST_NAME,
-      replace_key_prefix_with: "plcsp-20/"
+      replace_key_prefix_with: "plcsp-20/",
+      http_redirect_code: "302"
     }
   },
   {


### PR DESCRIPTION
### Background

Hannah discovered that the 404 page on curriculum builder links to https://curriculum.code.org/csp-current/, which was redirecting to /csp-19/ rather than /csp-20/ (see discussion in [slack](https://codedotorg.slack.com/archives/CA3KCSGTD/p1594232052479100)). The problem is that we are using a `301 Moved Permanently` redirect, which some browsers cache indefinitely, causing some users to continue to be redirected to the old version of the curriculum after a new one is marked as current.

### Description

Use a `302 Moved Temporarily` redirect from the urls listed below to the latest version of the specified curriculum, so that browsers will not cache it.

This fix may be moot, since we hope to be off of curriculum builder by this time next year, which is the next time these links would change. But the fix seems straightforward, so it seems better to do it than not to.

### Testing Story

Ran the script locally, then verified each of the following links to go the right place with 302 status code:
* https://curriculum.code.org/csp-current/
* https://curriculum.code.org/csd-current/
* https://curriculum.code.org/csf-current/
* https://curriculum.code.org/plcsp/
* https://curriculum.code.org/plcsd/
* https://curriculum.code.org/plcsf/

Also verified that the updated config looks correct in S3:
![Screen Shot 2020-07-08 at 11 33 40 AM](https://user-images.githubusercontent.com/8001765/86964982-b9944080-c11b-11ea-856c-51fd97c17210.png)

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
