### PR TITLE
Update ManifestBuilder to compute category map

### DIFF
--- a/tools/scripts/ManifestBuilder.rb
+++ b/tools/scripts/ManifestBuilder.rb
@@ -208,7 +208,7 @@ The animation has been skipped.
       metadata['aliases'].delete_if(&:blank?)
     end
     alias_map = build_alias_map(animation_metadata)
-    category_map = build_alias_map(animation_metadata)
+    category_map = build_category_map(animation_metadata)
 
     info "Uploading file to S3"
     AWS::S3.upload_to_bucket(

--- a/tools/scripts/ManifestBuilder.rb
+++ b/tools/scripts/ManifestBuilder.rb
@@ -157,18 +157,6 @@ The animation has been skipped.
         #{dim 'd[ o_0 ]b'}
     EOS
 
-    if @options[:spritelab] && @options[:upload_to_s3]
-      info "Uploading file to S3"
-      AWS::S3.upload_to_bucket(
-        DEFAULT_S3_BUCKET,
-        "manifests/spritelabCostumeLibrary.json",
-        generate_json(animation_metadata, alias_map),
-        acl: 'public-read',
-        no_random: true,
-        content_type: 'json'
-      )
-    end
-
   # Report any issues while talking to S3 and suggest most likely steps for fixing it.
   rescue Aws::Errors::ServiceError => service_error
     warn service_error.inspect


### PR DESCRIPTION
Part of the process of adding categories to the manifest, rather than computing categories based on aliases. This PR updates the script that builds the manifest based on the animation metadata files. I have not yet uploaded new manifests to S3, but I did run the script for spritelab to build a new manifest locally and verify that the changes look good.

<!-- ### Background -->
<!-- ### Privacy -->
<!-- ### Security -->
<!-- ### Caching -->
<!-- ### Deployment strategy -->
<!-- ### Future work -->

## Links

<!--
  Any relevant links to external resources; ie, specification documents, jira
  items, related PRs, honeybadger errors, etc
-->

- [doc](https://docs.google.com/document/d/1BozQDqvWLWZC-r-B7-9-RQ8F9mIhHCU1Ye6EMzhTrBo/edit#)
- [jira]()

## Testing story

<!--
  Does your change include appropriate tests?

  If so, please describe how the tests included in this PR are sufficient

  If not, please explain why this change does not need to be tested.
-->

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
