### PR TITLE
Don't restore unchanged files

### DIFF
--- a/lib/cdo/crowdin/utils.rb
+++ b/lib/cdo/crowdin/utils.rb
@@ -8,6 +8,13 @@ module Crowdin
   MAX_THREADS = 10
 
   class Utils
+    attr_reader :project
+    attr_reader :changes_json
+    attr_reader :etags_json
+    attr_reader :locales_dir
+    attr_reader :locale_subdir
+    attr_reader :logger
+
     # @param project [Crowdin::Project]
     # @param options [Hash, nil]
     # @param options.changes_json [String, nil] path to file where files with

--- a/lib/cdo/languages.rb
+++ b/lib/cdo/languages.rb
@@ -20,6 +20,10 @@ class Languages
     table.select(:locale_s).to_a
   end
 
+  cached def self.get_locale_and_code
+    table.select(:locale_s, :code_s).to_a
+  end
+
   cached def self.get_hoc_languages
     table.select(:locale_s, :unique_language_s, :crowdin_code_s, :crowdin_name_s).where("crowdin_code_s != 'en'").to_a
   end

--- a/lib/cdo/languages.rb
+++ b/lib/cdo/languages.rb
@@ -20,10 +20,6 @@ class Languages
     table.select(:locale_s).to_a
   end
 
-  cached def self.get_locale_and_code
-    table.select(:locale_s, :code_s).to_a
-  end
-
   cached def self.get_hoc_languages
     table.select(:locale_s, :unique_language_s, :crowdin_code_s, :crowdin_name_s).where("crowdin_code_s != 'en'").to_a
   end
@@ -38,6 +34,10 @@ class Languages
 
   cached def self.get_native_name_by_locale(locale)
     table.select(:native_name_s, :locale_s).where("locale_s = '#{locale}'").to_a
+  end
+
+  cached def self.get_code_by_locale(locale)
+    table.select(:code_s, :locale_s).where("locale_s = '#{locale}'").first[:code_s]
   end
 
   cached def self.get_csf_languages


### PR DESCRIPTION
Now that the new i18n sync down generates lists of files changed for
each language, we can update the sync out to only bother to do work on
those specific files. In this case, we update only the "restore" step as
a proof of concept, as it is both time-consuming and relatively simple.
Future work will update more!

For future reference, a basic `Time.now` test shows this is the time breakdown
of each of the major sync out steps (in seconds):

Step | Time
--- | ---
rename_from_crowdin_name_to_locale | 0.01791207
restore_redacted_files | 1181.758671453
distribute_translations | 1805.899603872
copy_untranslated_apps | 0.063158018
rebuild_blockly_js_files | 52.412017963
restore_markdown_headers | 1.042028401
HocSyncUtils.sync_out | 2.896593008

<!--
  Your description goes here: A summary of the change, including any relevant motivation and context.

  If relevant, include a description both of the existing behavior and of the new behavior.
-->

<!--
  Other aspects to consider. uncomment and add detail for any that seem necessary:
-->

<!-- ### Background -->
<!-- ### Privacy -->
<!-- ### Security -->
<!-- ### Caching -->
<!-- ### Deployment strategy -->
<!-- ### Future work -->

## Links

<!--
  Any relevant links to external resources; ie, specification documents, jira
  items, related PRs, honeybadger errors, etc
-->

- [spec]()
- [jira]()

## Testing story

<!--
  Does your change include appropriate tests?

  If so, please describe how the tests included in this PR are sufficient

  If not, please explain why this change does not need to be tested.
-->

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
