### PR TITLE
Make debug console styles match workspace styles

### DIFF
--- a/apps/src/lib/tools/jsdebugger/DebugConsole.jsx
+++ b/apps/src/lib/tools/jsdebugger/DebugConsole.jsx
@@ -245,16 +245,14 @@ export default connect(
     displayOutputToConsole() {
       const inspectorTheme = {
         ...chromeLight,
-        ...{
-          OBJECT_VALUE_NULL_COLOR: 'rgb(88, 92, 246)',
-          OBJECT_VALUE_UNDEFINED_COLOR: 'rgb(88, 92, 246)',
-          OBJECT_VALUE_REGEXP_COLOR: '#1A1AA6',
-          OBJECT_VALUE_STRING_COLOR: '#1A1AA6',
-          OBJECT_VALUE_SYMBOL_COLOR: '#1A1AA6',
-          OBJECT_VALUE_NUMBER_COLOR: 'rgb(0, 0, 205)',
-          OBJECT_VALUE_BOOLEAN_COLOR: 'rgb(88, 92, 246)',
-          OBJECT_VALUE_FUNCTION_PREFIX_COLOR: 'rgb(85, 106, 242)'
-        }
+        OBJECT_VALUE_NULL_COLOR: 'rgb(88, 92, 246)',
+        OBJECT_VALUE_UNDEFINED_COLOR: 'rgb(88, 92, 246)',
+        OBJECT_VALUE_REGEXP_COLOR: '#1A1AA6',
+        OBJECT_VALUE_STRING_COLOR: '#1A1AA6',
+        OBJECT_VALUE_SYMBOL_COLOR: '#1A1AA6',
+        OBJECT_VALUE_NUMBER_COLOR: 'rgb(0, 0, 205)',
+        OBJECT_VALUE_BOOLEAN_COLOR: 'rgb(88, 92, 246)',
+        OBJECT_VALUE_FUNCTION_PREFIX_COLOR: 'rgb(85, 106, 242)'
       };
       if (this.props.logOutput.size > 0) {
         return this.props.logOutput.map((rowValue, i) => {

--- a/apps/src/lib/tools/jsdebugger/DebugConsole.jsx
+++ b/apps/src/lib/tools/jsdebugger/DebugConsole.jsx
@@ -243,6 +243,7 @@ export default connect(
     }
 
     displayOutputToConsole() {
+      // These colors come from the ace editor defaults
       const inspectorTheme = {
         ...chromeLight,
         OBJECT_VALUE_NULL_COLOR: 'rgb(88, 92, 246)',

--- a/apps/src/lib/tools/jsdebugger/DebugConsole.jsx
+++ b/apps/src/lib/tools/jsdebugger/DebugConsole.jsx
@@ -16,7 +16,7 @@ import {
 import CommandHistory from './CommandHistory';
 import {actions, selectors} from './redux';
 import color from '../../../util/color';
-import Inspector from 'react-inspector';
+import {Inspector, chromeLight} from 'react-inspector';
 
 const DEBUG_INPUT_HEIGHT = 16;
 const DEBUG_CONSOLE_LEFT_PADDING = 3;
@@ -243,6 +243,19 @@ export default connect(
     }
 
     displayOutputToConsole() {
+      const inspectorTheme = {
+        ...chromeLight,
+        ...{
+          OBJECT_VALUE_NULL_COLOR: 'rgb(88, 92, 246)',
+          OBJECT_VALUE_UNDEFINED_COLOR: 'rgb(88, 92, 246)',
+          OBJECT_VALUE_REGEXP_COLOR: '#1A1AA6',
+          OBJECT_VALUE_STRING_COLOR: '#1A1AA6',
+          OBJECT_VALUE_SYMBOL_COLOR: '#1A1AA6',
+          OBJECT_VALUE_NUMBER_COLOR: 'rgb(0, 0, 205)',
+          OBJECT_VALUE_BOOLEAN_COLOR: 'rgb(88, 92, 246)',
+          OBJECT_VALUE_FUNCTION_PREFIX_COLOR: 'rgb(85, 106, 242)'
+        }
+      };
       if (this.props.logOutput.size > 0) {
         return this.props.logOutput.map((rowValue, i) => {
           if ('function' === typeof rowValue.toJS) {
@@ -254,13 +267,19 @@ export default connect(
             return rowValue.output;
           } else if (this.isValidOutput(rowValue)) {
             if (rowValue.fromConsoleLog) {
-              return <Inspector key={i} data={rowValue.output} />;
+              return (
+                <Inspector
+                  theme={inspectorTheme}
+                  key={i}
+                  data={rowValue.output}
+                />
+              );
             } else {
               return (
                 <div key={i}>
                   &lt;{' '}
                   <div style={style.inspector}>
-                    <Inspector data={rowValue.output} />
+                    <Inspector theme={inspectorTheme} data={rowValue.output} />
                   </div>
                 </div>
               );


### PR DESCRIPTION
Currently, the same information (strings, integers, etc.) is formatted differently in the workspace and in the debug console. This makes the debug console formatting match the workspace formatting.

<img width="395" alt="Screen Shot 2020-07-08 at 4 08 40 PM" src="https://user-images.githubusercontent.com/17147070/86969233-7ba71480-c13b-11ea-9f3d-58b2a1adc942.png">


<!-- ### Background -->
<!-- ### Privacy -->
<!-- ### Security -->
<!-- ### Caching -->
<!-- ### Deployment strategy -->
<!-- ### Future work -->

## Links

- [jira](https://codedotorg.atlassian.net/browse/STAR-1129)

## Testing story

<!--
  Does your change include appropriate tests?

  If so, please describe how the tests included in this PR are sufficient

  If not, please explain why this change does not need to be tested.
-->

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
