### PR TITLE
AFE Integration: Titleize school info before sending it to CSTA

### DIFF
--- a/dashboard/app/controllers/api/v1/amazon_future_engineer_controller.rb
+++ b/dashboard/app/controllers/api/v1/amazon_future_engineer_controller.rb
@@ -22,7 +22,7 @@ class Api::V1::AmazonFutureEngineerController < ApplicationController
       street_1: afe_params['street1'],
       street_2: afe_params['street2'],
       city: afe_params['city'],
-      state: get_us_state_abbr_from_name(afe_params['state'], true),
+      state: afe_params['state'],
       zip: afe_params['zip'],
       marketing_kit: afe_params['inspirationKit'],
       csta_plus: afe_params['csta'],
@@ -59,7 +59,7 @@ class Api::V1::AmazonFutureEngineerController < ApplicationController
         street_1: afe_params['street1'] || school&.address_line1 || '',
         street_2: afe_params['street2'] || school&.address_line2 || '',
         city: afe_params['city'] || school&.city || '',
-        state: get_us_state_abbr_from_name(afe_params['state'], true) || school&.state || '',
+        state: afe_params['state'] || school&.state || '',
         zip: afe_params['zip'] || school&.zip || '',
         privacy_permission: to_bool(afe_params['consentCSTA'])
       )

--- a/dashboard/lib/services/afe_enrollment.rb
+++ b/dashboard/lib/services/afe_enrollment.rb
@@ -43,7 +43,7 @@ class Services::AFEEnrollment
       'school-address-1' => street_1,
       'school-address-2' => street_2,
       'school-city' => city,
-      'school-state' => state,
+      'school-state' => get_us_state_abbr(state),
       'school-zip' => zip,
       'inspirational-marketing-kit' => booleanize(marketing_kit),
       'csta-plus' => booleanize(csta_plus),

--- a/dashboard/lib/services/afe_enrollment.rb
+++ b/dashboard/lib/services/afe_enrollment.rb
@@ -43,7 +43,7 @@ class Services::AFEEnrollment
       'school-address-1' => street_1,
       'school-address-2' => street_2,
       'school-city' => city,
-      'school-state' => get_us_state_abbr(state),
+      'school-state' => get_us_state_abbr(state, true),
       'school-zip' => zip,
       'inspirational-marketing-kit' => booleanize(marketing_kit),
       'csta-plus' => booleanize(csta_plus),

--- a/dashboard/lib/services/csta_enrollment.rb
+++ b/dashboard/lib/services/csta_enrollment.rb
@@ -44,12 +44,12 @@ class Services::CSTAEnrollment
         "submission[15_first]" => first_name,
         "submission[15_last]" => last_name,
         "submission[16]" => email,
-        "submission[5]" => school_district_name,
-        "submission[18]" => school_name,
-        "submission[17_st1]" => street_1,
-        "submission[17_st2]" => street_2,
-        "submission[17_city]" => city,
-        "submission[17_state]" => state,
+        "submission[5]" => school_district_name.titleize,
+        "submission[18]" => school_name.titleize,
+        "submission[17_st1]" => titleize_address(street_1),
+        "submission[17_st2]" => titleize_address(street_2),
+        "submission[17_city]" => city.titleize,
+        "submission[17_state]" => get_us_state_abbr(state),
         "submission[17_zip]" => zip,
         "submission[19]" => "Yes, I provide my consent."
       }
@@ -60,5 +60,9 @@ class Services::CSTAEnrollment
     end
 
     nil
+  end
+
+  def self.titleize_address(address)
+    address.titleize.gsub(/\b(N|S|E|W|NE|SE|NW|SW)\b/i, &:upcase)
   end
 end

--- a/dashboard/lib/services/csta_enrollment.rb
+++ b/dashboard/lib/services/csta_enrollment.rb
@@ -49,7 +49,7 @@ class Services::CSTAEnrollment
         "submission[17_st1]" => titleize_address(street_1),
         "submission[17_st2]" => titleize_address(street_2),
         "submission[17_city]" => city.titleize,
-        "submission[17_state]" => get_us_state_abbr(state),
+        "submission[17_state]" => get_us_state_abbr(state, true),
         "submission[17_zip]" => zip,
         "submission[19]" => "Yes, I provide my consent."
       }

--- a/dashboard/test/controllers/api/v1/amazon_future_engineer_controller_test.rb
+++ b/dashboard/test/controllers/api/v1/amazon_future_engineer_controller_test.rb
@@ -72,7 +72,7 @@ class Api::V1::AmazonFutureEngineerControllerTest < ActionDispatch::IntegrationT
       street_1: 'test street',
       street_2: 'test street 2',
       city: 'seattle',
-      state: 'WA',
+      state: 'Washington',
       zip: '98105',
       marketing_kit: '0',
       csta_plus: '0',
@@ -142,7 +142,7 @@ class Api::V1::AmazonFutureEngineerControllerTest < ActionDispatch::IntegrationT
         street_1: 'test street',
         street_2: 'test street 2',
         city: 'seattle',
-        state: 'WA',
+        state: 'Washington',
         zip: '98105',
         privacy_permission: true
       },
@@ -185,9 +185,6 @@ class Api::V1::AmazonFutureEngineerControllerTest < ActionDispatch::IntegrationT
     school = create :school
     refute_equal 'example-street-1', school.address_line1
 
-    # We have to use an actual state here (Florida)
-    # that is different than what is in valid_params (Washington)
-    # because the form uses a select element to limit users to submit real states
     actual_args = capture_csta_args_for_request(
       valid_params.merge(
         'csta' => true,
@@ -203,7 +200,7 @@ class Api::V1::AmazonFutureEngineerControllerTest < ActionDispatch::IntegrationT
     assert_equal 'example-street-1', actual_args[:street_1]
     assert_equal 'example-street-2', actual_args[:street_2]
     assert_equal 'example-city', actual_args[:city]
-    assert_equal 'FL', actual_args[:state]
+    assert_equal 'Florida', actual_args[:state]
     assert_equal 'example-zip', actual_args[:zip]
   end
 

--- a/dashboard/test/lib/services/afe_enrollment_test.rb
+++ b/dashboard/test/lib/services/afe_enrollment_test.rb
@@ -26,7 +26,7 @@ class Services::AFEEnrollmentTest < ActiveSupport::TestCase
           'school-address-1' => 'test-street-1',
           'school-address-2' => 'test-street-2',
           'school-city' => 'test-city',
-          'school-state' => 'test-state',
+          'school-state' => 'WA',
           'school-zip' => 'test-zip',
           'inspirational-marketing-kit' => '1',
           'csta-plus' => '1',
@@ -95,6 +95,19 @@ class Services::AFEEnrollmentTest < ActiveSupport::TestCase
     end
   end
 
+  test 'converts state to a two-letter code' do
+    assert_param_translation(
+      {state: 'OHIO'},
+      {'school-state' => 'OH'}
+    )
+
+    # No transform if the state is already a two-letter code
+    assert_param_translation(
+      {state: 'OH'},
+      {'school-state' => 'OH'}
+    )
+  end
+
   private
 
   # Check that certain input params turn into expected output params
@@ -124,7 +137,7 @@ class Services::AFEEnrollmentTest < ActiveSupport::TestCase
       street_1: 'test-street-1',
       street_2: 'test-street-2',
       city: 'test-city',
-      state: 'test-state',
+      state: 'WA',
       zip: 'test-zip',
       marketing_kit: true,
       csta_plus: true,

--- a/lib/state_abbr.rb
+++ b/lib/state_abbr.rb
@@ -28,6 +28,15 @@ def get_us_state_abbr_from_name(name, include_dc = false)
   return abbr_sym.try(&:to_s)
 end
 
+# Given a state name or abbreviation, resolves to a two-letter state abbreviation.
+# @param [String|Symbol] name_or_abbr - full state name or state abbreviation
+# @param [Boolean] include_dc - (default: false) Whether to include Washington DC as a state.
+# @returns [String] two-letter state abbreviation, or nil
+def get_us_state_abbr(name_or_abbr, include_dc = false)
+  name = get_us_state_from_abbr(name_or_abbr, include_dc) || name_or_abbr
+  get_us_state_abbr_from_name name, include_dc
+end
+
 # Returns whether the abbreviation is a state (including Washington DC)
 # abbreviation.
 def us_state_abbr?(abbr, include_dc = false)

--- a/shared/test/test_state_abbr.rb
+++ b/shared/test/test_state_abbr.rb
@@ -114,6 +114,23 @@ class StateAbbrTest < Minitest::Test
     assert_equal 'DC', get_us_state_abbr_from_name('WASHINGTON DC', true)
   end
 
+  def test_get_us_state_abbr
+    # This method will coerce to the two-letter abbreviation
+    # whether you pass it an abbreviation or full name.
+    assert_equal 'IL', get_us_state_abbr('Illinois')
+    assert_equal 'IL', get_us_state_abbr('il')
+    assert_equal 'WA', get_us_state_abbr('Washington')
+    assert_equal 'WA', get_us_state_abbr('wa')
+    assert_nil get_us_state_abbr('British Columbia')
+    assert_nil get_us_state_abbr('BC')
+
+    # With DC option
+    assert_equal 'DC', get_us_state_abbr('Washington DC', true)
+    assert_equal 'DC', get_us_state_abbr('dc', true)
+    assert_nil get_us_state_abbr('Washington DC', false)
+    assert_nil get_us_state_abbr('dc', false)
+  end
+
   def test_us_state_abbr
     assert_equal true, us_state_abbr?(:IL)
     assert_equal true, us_state_abbr?(:IL, false)


### PR DESCRIPTION
At CSTA's request, titleize school name, district name, and school address info before sending it to CSTA.

## Testing story

Covered with new unit tests.

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
