### PR TITLE
Removing '20-hour lessons' from the es-MX /courses page

### DIFF
--- a/apps/src/sites/studio/pages/courses/index.js
+++ b/apps/src/sites/studio/pages/courses/index.js
@@ -15,6 +15,7 @@ function showCourses() {
   const script = document.querySelector('script[data-courses]');
   const coursesData = JSON.parse(script.dataset.courses);
   const isEnglish = coursesData.english;
+  const locale = coursesData.locale;
   const isTeacher = coursesData.teacher;
   const linesCount = coursesData.linescount;
   const studentsCount = coursesData.studentscount;
@@ -28,6 +29,7 @@ function showCourses() {
     <Provider store={getStore()}>
       <Courses
         isEnglish={isEnglish}
+        locale={locale}
         isTeacher={isTeacher}
         linesCount={linesCount}
         studentsCount={studentsCount}

--- a/apps/src/templates/studioHomepages/CourseBlocks.jsx
+++ b/apps/src/templates/studioHomepages/CourseBlocks.jsx
@@ -12,6 +12,10 @@ import i18n from '@cdo/locale';
 import {pegasus} from '@cdo/apps/lib/util/urlHelpers';
 
 class ExpressCourses extends Component {
+  static propTypes = {
+    locale: PropTypes.string.isRequired
+  };
+
   componentDidMount() {
     $('#pre-express')
       .appendTo(ReactDOM.findDOMNode(this.refs.pre_express))
@@ -22,6 +26,7 @@ class ExpressCourses extends Component {
   }
 
   render() {
+    const {locale} = this.props;
     return (
       <ContentContainer
         heading={i18n.courseBlocksCsfExpressHeading()}
@@ -31,7 +36,7 @@ class ExpressCourses extends Component {
           <ProtectedStatefulDiv ref="pre_express" />
           <ProtectedStatefulDiv ref="express" />
         </div>
-        <AcceleratedAndUnplugged />
+        <AcceleratedAndUnplugged locale={locale} />
       </ContentContainer>
     );
   }
@@ -103,10 +108,18 @@ class Courses1To4 extends Component {
 }
 
 class AcceleratedAndUnplugged extends Component {
+  static propTypes = {
+    locale: PropTypes.string.isRequired
+  };
+
   componentDidMount() {
-    $('#20-hour')
-      .appendTo(ReactDOM.findDOMNode(this.refs.twenty_hour))
-      .show();
+    const {locale} = this.props;
+    // [FND-1203] - replace this 'es-MX' conditional once full localization customization is implemented.
+    if (locale !== 'es-MX') {
+      $('#20-hour')
+        .appendTo(ReactDOM.findDOMNode(this.refs.twenty_hour))
+        .show();
+    }
     $('#unplugged')
       .appendTo(ReactDOM.findDOMNode(this.refs.unplugged))
       .show();
@@ -194,7 +207,8 @@ export class CourseBlocksHoc extends Component {
 export class CourseBlocksIntl extends Component {
   static propTypes = {
     isTeacher: PropTypes.bool.isRequired,
-    showModernElementaryCourses: PropTypes.bool.isRequired
+    showModernElementaryCourses: PropTypes.bool.isRequired,
+    locale: PropTypes.string.isRequired
   };
 
   componentDidMount() {
@@ -204,15 +218,23 @@ export class CourseBlocksIntl extends Component {
   }
 
   render() {
-    const {isTeacher, showModernElementaryCourses: modernCsf} = this.props;
+    const {
+      isTeacher,
+      showModernElementaryCourses: modernCsf,
+      locale
+    } = this.props;
     const AcceleratedCourses = () => (
       <ContentContainer>
-        <AcceleratedAndUnplugged />
+        <AcceleratedAndUnplugged locale={locale} />
       </ContentContainer>
     );
     return (
       <div>
-        {modernCsf ? <ExpressCourses /> : <AcceleratedCourses />}
+        {modernCsf ? (
+          <ExpressCourses locale={locale} />
+        ) : (
+          <AcceleratedCourses />
+        )}
 
         <CourseBlocksHoc isInternational />
 

--- a/apps/src/templates/studioHomepages/Courses.jsx
+++ b/apps/src/templates/studioHomepages/Courses.jsx
@@ -26,6 +26,7 @@ const styles = {
 class Courses extends Component {
   static propTypes = {
     isEnglish: PropTypes.bool.isRequired,
+    locale: PropTypes.string.isRequired,
     isTeacher: PropTypes.bool.isRequired,
     isSignedOut: PropTypes.bool.isRequired,
     linesCount: PropTypes.string.isRequired,
@@ -74,6 +75,7 @@ class Courses extends Component {
   render() {
     const {
       isEnglish,
+      locale,
       isTeacher,
       isSignedOut,
       modernElementaryCoursesAvailable,
@@ -131,6 +133,7 @@ class Courses extends Component {
           <CourseBlocksIntl
             isTeacher={isTeacher}
             showModernElementaryCourses={modernElementaryCoursesAvailable}
+            locale={locale}
           />
         )}
       </div>

--- a/dashboard/app/controllers/courses_controller.rb
+++ b/dashboard/app/controllers/courses_controller.rb
@@ -12,6 +12,7 @@ class CoursesController < ApplicationController
       format.html do
         @is_teacher = (current_user && current_user.teacher?) || params[:view] == 'teacher'
         @is_english = request.language == 'en'
+        @locale = request.locale
         @is_signed_out = current_user.nil?
         @force_race_interstitial = params[:forceRaceInterstitial]
         @header_banner_image_filename = !@is_teacher ? "courses-hero-student" : "courses-hero-teacher"

--- a/dashboard/app/views/courses/index.html.haml
+++ b/dashboard/app/views/courses/index.html.haml
@@ -7,6 +7,7 @@
 
   courses_data = {}
   courses_data[:english] = @is_english
+  courses_data[:locale] = @locale
   courses_data[:teacher] = @is_teacher
   courses_data[:linescount] = lines_count
   courses_data[:studentscount] = students_count


### PR DESCRIPTION
Product team has requested that the "Accelerated Course" aka "20-hour course" be removed from the es-MX locale.
* Pipes locale data to relevant React modules
* Small conditional check for 'es-MX' before displaying the 20-hour course.

## Links
- [spec](https://docs.google.com/document/d/1UhnomMGzeSudAWJhDr-lhIe6rWiQQ6PEzaDwGmuX_IA/edit?pli=1)
- [jira](https://codedotorg.atlassian.net/browse/FND-1215)

## Screenshot
### Before
![image](https://user-images.githubusercontent.com/1372238/87003718-afba1e00-c1ab-11ea-9ed1-b9fdd5814bf0.png)

### After
![image](https://user-images.githubusercontent.com/1372238/87003650-8ef1c880-c1ab-11ea-95c3-b350e6a1bf3d.png)

### After + Italian
We expect Italian to still have all 4 courses listed because we only want to remove the 20-hour course from es-MX
![image](https://user-images.githubusercontent.com/1372238/87004033-48509e00-c1ac-11ea-989f-2c72862fd1a7.png)

## Testing story
* Manually tested at http://localhost-studio.code.org:3000/courses/lang/es-mx

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
