### PR TITLE
Style changes for non-English /courses page.

### DIFF
--- a/apps/src/templates/studioHomepages/CourseBlocks.jsx
+++ b/apps/src/templates/studioHomepages/CourseBlocks.jsx
@@ -30,12 +30,18 @@ class ModernCsfCourses extends Component {
         heading={i18n.courseBlocksCsfExpressHeading()}
         description={i18n.courseBlocksCsfExpressDescription()}
       >
-        <div className="row">
-          <ProtectedStatefulDiv ref="pre_express" />
-          <ProtectedStatefulDiv ref="express" />
+        <div className="tutorial-row">
+          <ProtectedStatefulDiv
+            className="tutorial-block-wide"
+            ref="pre_express"
+          />
+          <ProtectedStatefulDiv className="tutorial-block-wide" ref="express" />
         </div>
-        <div className="row">
-          <ProtectedStatefulDiv ref="unplugged" />
+        <div className="tutorial-row">
+          <ProtectedStatefulDiv
+            className="tutorial-block-wide"
+            ref="unplugged"
+          />
         </div>
       </ContentContainer>
     );
@@ -119,9 +125,12 @@ class AcceleratedAndUnplugged extends Component {
 
   render() {
     return (
-      <div className="row">
-        <ProtectedStatefulDiv ref="twenty_hour" />
-        <ProtectedStatefulDiv ref="unplugged" />
+      <div className="tutorial-row">
+        <ProtectedStatefulDiv
+          className="tutorial-block-wide"
+          ref="twenty_hour"
+        />
+        <ProtectedStatefulDiv className="tutorial-block-wide" ref="unplugged" />
       </div>
     );
   }

--- a/dashboard/app/views/shared/_course_wide_block.haml
+++ b/dashboard/app/views/shared/_course_wide_block.haml
@@ -42,12 +42,13 @@
 - elsif id == Script::TWENTY_HOUR_NAME && view == 'small'
   - url = script_reset_url(id)
   - audience = data_t_suffix('script.name', id, 'description_audience')
-  .courseblock-span6.courseblock-wide-small{style: "min-height: 120px;"}
+  .courseblock-span6.courseblock-wide-small
     = link_to script_url(Script::TWENTY_HOUR_NAME) do
       .courseblock-span2.imgspan
         %img{src: CDO.code_org_url('/images/fit-150x100/code20hr.jpg')}
       .courseblock-span4.heading
         %h3= t('upsell.20-hour.title')
+        %h4= data_t_suffix('script.name', id, 'description_audience')
         .smalltext= t('upsell.20-hour.body_short')
 
 - elsif id == 'unplugged' && view == 'large'
@@ -69,6 +70,7 @@
         %img{src: CDO.code_org_url('/images/fit-150x100/unplugged.png')}
       .courseblock-span4.heading
         %h3= t("upsell.#{id}.title")
+        %h4= t("upsell.#{id}.audience")
         .smalltext= t("upsell.#{id}.body_short")
 
 - elsif [Script::ARTIST_NAME, Script::PLAYLAB_NAME].include? id
@@ -83,14 +85,15 @@
         %h3= title
         .smalltext= body
 
-- elsif [Script::EXPRESS_NAME, Script::PRE_READER_EXPRESS_NAME].include? id
-  .courseblock-span6.courseblock-wide-small{style: "min-height: 140px;"}
+- elsif [Script::EXPRESS, Script::PREEXPRESS].any? {|course| id.match(/^#{course}/)}
+  .courseblock-span6.courseblock-wide-small
     = link_to script_url(id)  do
       .courseblock-span2.imgspan
         - image = (family_name.nil?) ? "logo_tall_#{id}.jpg" : "logo_tall_#{family_name}.jpg"
         %img{src: CDO.code_org_url("/shared/images/courses/fill-150x110/#{image}")}
       .courseblock-span4.heading
         %h3= data_t_suffix('script.name', id, 'title')
+        %h4= data_t_suffix('script.name', id, 'description_audience')
         .smalltext= data_t_suffix('script.name', id, 'description_short')
 
 - elsif [Script::COURSE1_NAME, Script::COURSE2_NAME, Script::COURSE3_NAME, Script::COURSE4_NAME, Script::ALGEBRA_NAME].include? id
@@ -109,7 +112,7 @@
         .smalltext= data_t_suffix('script.name', id, 'description')
 
 - else
-  .courseblock-span6.courseblock-wide-small{style: "min-height: 140px;"}
+  .courseblock-span6.courseblock-wide-small
     = link_to script_url(id)  do
       .courseblock-span2.imgspan
         - image = (family_name.nil?) ? "logo_tall_#{id}.jpg" : "logo_tall_#{family_name}.jpg"

--- a/shared/css/course-blocks.scss
+++ b/shared/css/course-blocks.scss
@@ -58,14 +58,21 @@
   flex-flow: row wrap;
 }
 
-.tutorial-block {
+.tutorial-block, .tutorial-block-wide {
   flex: 0 0 auto;
-  min-height: 300px;
   border: solid 1px #bbb;
   border-radius: 5px;
-  margin: 30px 20px 0 0;
+  margin: 20px 20px 0 0;
+  overflow: hidden;
 }
 
+.tutorial-block {
+  min-height: 300px;
+}
+
+.tutorial-block-wide {
+  min-height: 140px;
+}
 /**
  * This overrides styles in the courseblock-tall class below. When all uses have
  * migrated to use tutorial-row and tutorial-block, then these styles can be removed
@@ -195,17 +202,18 @@
 }
 
 .courseblock-wide-small {
+  margin: 0px;
+  border: none;
+  float: none;
   background-color: white;
   overflow: hidden;
-  position: relative;
-  float: left;
   box-sizing: border-box;
-  border: solid 1px #bbb;
-  border-radius: 5px;
-  margin-top: 20px;
+  height: 100%;
 
   .heading {
     width: 280px;
+    margin: 0;
+    padding: 8px 0 16px 16px;
   }
 
   a {
@@ -214,57 +222,46 @@
 
   img {
     box-sizing: content-box;
-    float: right;
   }
 
   .imgspan {
     margin-left: 0;
     float: right;
     text-align: right;
+
+    html[dir=rtl] & {
+      float: left;
+      text-align: left;
+    }
   }
 
   h3 {
-    margin: 10px 0 0 10px;
+    margin: 0 0 0 0;
     color: $charcoal;
-    white-space: nowrap;
     overflow: hidden;
-    text-overflow: ellipsis;
     font-size: 24px;
+    line-height: 28px;
     font-family: $gotham-bold;
-    float: left;
+    float: none;
     width: 94%;
   }
 
   h4 {
-    margin-left: 10px;
-    color: $charcoal;
-    white-space: nowrap;
-    overflow: hidden;
-    text-overflow: ellipsis;
+    margin: 0 0 0 0;
     font-size: 14px;
-    font-family: $gotham-bold;
-    float: left;
-
-    html[dir=rtl] & {
-      float: right;
-      margin-left: 0px;
-      margin-right: 10px;
-    }
+    line-height: 17px;
+    font-family: $gotham-regular;
+    font-weight: normal;
+    color: $charcoal;
   }
 
   .smalltext {
-    margin-left: 10px;
+    margin: 12px 0 0 0;
     font-size: 13px;
     line-height: 17px;
     font-family: $gotham-regular;
     font-weight:normal;
     color:$charcoal;
-    float: left;
-    padding-right: 10px;
-  }
-
-  html[dir=rtl] & {
-    float: right;
   }
 }
 


### PR DESCRIPTION
Some UI improvements for the i18n experience on https://studio.code.org/courses/lang/es-mx . See the design doc in the links section for the mocks.
* Prevent title cutoff for the course name
* Add the recommended age ranges for the course
* Make neighbor course blocks the same size

## Links
- [spec](https://docs.google.com/document/d/1UhnomMGzeSudAWJhDr-lhIe6rWiQQ6PEzaDwGmuX_IA/edit?pli=1#)
- [jira](https://codedotorg.atlassian.net/browse/FND-1214)

## Screenshots
### Before
![image](https://user-images.githubusercontent.com/1372238/87026350-23b7ee80-c1cb-11ea-873a-993d374d5545.png)

### After
![image](https://user-images.githubusercontent.com/1372238/87098378-a5913180-c236-11ea-904e-38782bb6ed46.png)

### After + RTL
![image](https://user-images.githubusercontent.com/1372238/87098484-ea1ccd00-c236-11ea-9710-4b23d19358ea.png)

## Testing story
* Tested on http://localhost-studio.code.org:3000/courses/lang/es-mx

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
