### PR TITLE
HOC: Add sign up emails for 2020

### DIFF
--- a/pegasus/emails/hoc_signup_2020_receipt_en.md
+++ b/pegasus/emails/hoc_signup_2020_receipt_en.md
@@ -1,0 +1,76 @@
+---
+from: "Hadi Partovi (Code.org) <hadi_partovi@code.org>"
+subject: "You’re signed up for the Hour of Code!"
+---
+  <% hourofcode = CDO.canonical_hostname('hourofcode.com') %>
+  <% codedotorg = CDO.canonical_hostname('code.org') %>
+  <% storedotcodedotorg = CDO.canonical_hostname('store.code.org') %>
+
+### Thank you for signing up for the Hour of Code!
+Your event is now registered. By volunteering to host an Hour of Code, you’re making it possible for more students to
+get the chance to learn computer science. While Hour of Code events are held all over the world during the celebration
+of Computer Science Education Week, you can choose to organize an Hour of Code any time! 
+
+## Here are some steps to get started:
+
+### 1. Start planning your event
+Explore our library of [Hour of Code activities](https://<%= hourofcode %>/learn) and
+[review this how-to guide](https://<%= hourofcode %>/how-to) for helpful tips on how to inspire students, 
+determine your technology needs, and more. 
+
+### 2. Spread the word and recruit more people
+We need your help to inspire volunteers and organizers from across the globe. 
+Tell your friends about the #HourOfCode and [use these helpful resources](https://<%= hourofcode %>/promote/resources) 
+to promote your event.
+
+You can also help recruit more people from your school and community by 
+[sending our sample emails](https://<%= hourofcode %>/promote/resources#sample-emails) to your principal,
+ a local group, or even some friends.
+
+
+### 3. Invite a local volunteer to inspire your students
+[Search our volunteer map](https://<%= codedotorg %>/volunteer/local) to find volunteers who can visit your classroom
+ or video chat remotely to inspire your students about the breadth of possibilities with computer science.
+
+### 4. Check-out Hour of Code swag
+Swag is a great way to get students excited about the Hour of Code and reward them for completing their activity. 
+At the Code.org [Amazon store](https://www.amazon.com/stores/page/8557B2A6-EBF2-4C9F-95C5-C3256FBA0220), you can 
+[order posters](https://www.amazon.com/dp/B07J6T18DH?m=A2ZEA2ORKPFEVK) with inspirational role models, 
+Hour of Code kits, fun stickers, and more! But hurry, supplies are limited.
+
+### Encourage kids to continue learning 
+<% if form.data["hoc_event_country_s"] == 'US' %> An Hour of Code is just the beginning! We hear over and over again 
+how much students love the Hour of Code and discover a newfound interest in computer science. Encourage them to 
+continue learning. Whether you’re an administrator, teacher, or advocate, we have professional learning, curriculum, 
+and resources to help you [bring computer science classes to your school](https://<%= codedotorg %>/yourschool) or 
+expand your offerings.  
+
+Many of the organizations offering activities on HourofCode.com also have curriculum and professional learning 
+available as well. We've highlighted 
+[curriculum providers that can help you or your students go beyond an hour.](https://<%= hourofcode %>/beyond) 
+
+<% else %> An Hour of Code is just the beginning! We hear over and over again how much students love the Hour of Code
+ and discover a newfound interest in computer science. Encourage them to continue learning. 
+
+Many of the organizations offering Hour of Code lessons also have curriculum available to go further.
+To help you get started, we've highlighted a number of [
+curriculum providers that will help you or your students go beyond an hour.](https://<%= hourofcode %>/beyond)
+
+Code.org also offers full 
+[introductory computer science courses](https://<%= codedotorg %>/educate/curriculum/cs-fundamentals-international) 
+translated into over 67 languages at no cost to you or your school. <% end %> Thank you for leading the movement 
+to give every student the chance to learn foundational computer science skills.
+
+
+Hadi Partovi<br />
+Founder, Code.org<br />
+
+<hr/>
+<small>
+You're receiving this email because you signed up for the Hour of Code, supported by more than 200 partners and 
+organized by Code.org. Code.org is a 501c3 non-profit. Our address is 
+[1501 4th Avenue, Suite 900, Seattle, WA 98101](https://maps.google.com/?q=1501+4th+Avenue,+Suite+900,+Seattle,+WA+98101&entry=gmail&source=g). 
+Don't want these emails? [Unsubscribe](<%= local_assigns.fetch(:unsubscribe_link, "") %>).
+</small>
+
+![](<%= local_assigns.fetch(:tracking_pixel, "") %>)

--- a/pegasus/emails/hoc_signup_2020_receipt_es.md
+++ b/pegasus/emails/hoc_signup_2020_receipt_es.md
@@ -6,7 +6,7 @@ subject: "¡Gracias por inscribirte para ser anfitrión de una Hora de Código!"
   <% codedotorg = CDO.canonical_hostname('code.org') %>
 
 # ¡Gracias por inscribirte para ser anfitrión de una Hora de Código!
-Usted está haciendo posible para que los estudiantes de todo el mundo aprendan una Hora de Código que puede cambiar el resto de sus vidas, durante los días del 1 al 7 de octubre. Estaremos en contacto sobre nuevos tutoriales y otras noticias interesantes. ¿Qué puede usted hacer ahora?
+Usted está haciendo posible para que los estudiantes de todo el mundo aprendan una Hora de Código que puede cambiar el resto de sus vidas, desde el 1 de Octubre hasta el 18 de Diciembre. Estaremos en contacto sobre nuevos tutoriales y otras noticias interesantes. ¿Qué puede usted hacer ahora?
 
 ## 1. Encuentre a un voluntario local para ayudarle con su evento.
 [Buscar en nuestro mapa del voluntariado](https://<%= codedotorg %>/volunteer/local) para que los voluntarios puedan visitar tu aula o hagan un videochat remotamente para inspirar a tus estudiantes acerca de la amplitud de posibilidades con las Ciencias de la Computación.

--- a/pegasus/emails/hoc_signup_2020_receipt_es.md
+++ b/pegasus/emails/hoc_signup_2020_receipt_es.md
@@ -6,7 +6,7 @@ subject: "¡Gracias por inscribirte para ser anfitrión de una Hora de Código!"
   <% codedotorg = CDO.canonical_hostname('code.org') %>
 
 # ¡Gracias por inscribirte para ser anfitrión de una Hora de Código!
-Usted está haciendo posible para que los estudiantes de todo el mundo aprendan una Hora de Código que puede cambiar el resto de sus vidas, desde el 1 de Octubre hasta el 18 de Diciembre. Estaremos en contacto sobre nuevos tutoriales y otras noticias interesantes. ¿Qué puede usted hacer ahora?
+Usted está haciendo posible para que los estudiantes de todo el mundo aprendan una Hora de Código que puede cambiar el resto de sus vidas, desde el 1ro de octubre hasta el 18 de diciembre. Estaremos en contacto sobre nuevos tutoriales y otras noticias interesantes. ¿Qué puede usted hacer ahora?
 
 ## 1. Encuentre a un voluntario local para ayudarle con su evento.
 [Buscar en nuestro mapa del voluntariado](https://<%= codedotorg %>/volunteer/local) para que los voluntarios puedan visitar tu aula o hagan un videochat remotamente para inspirar a tus estudiantes acerca de la amplitud de posibilidades con las Ciencias de la Computación.

--- a/pegasus/emails/hoc_signup_2020_receipt_es.md
+++ b/pegasus/emails/hoc_signup_2020_receipt_es.md
@@ -1,0 +1,36 @@
+---
+from: "Hadi Partovi (Code.org) <hadi_partovi@code.org>"
+subject: "¡Gracias por inscribirte para ser anfitrión de una Hora de Código!"
+---
+  <% hostname = CDO.canonical_hostname('hourofcode.com') %>
+  <% codedotorg = CDO.canonical_hostname('code.org') %>
+
+# ¡Gracias por inscribirte para ser anfitrión de una Hora de Código!
+Usted está haciendo posible para que los estudiantes de todo el mundo aprendan una Hora de Código que puede cambiar el resto de sus vidas, durante los días del 1 al 7 de octubre. Estaremos en contacto sobre nuevos tutoriales y otras noticias interesantes. ¿Qué puede usted hacer ahora?
+
+## 1. Encuentre a un voluntario local para ayudarle con su evento.
+[Buscar en nuestro mapa del voluntariado](https://<%= codedotorg %>/volunteer/local) para que los voluntarios puedan visitar tu aula o hagan un videochat remotamente para inspirar a tus estudiantes acerca de la amplitud de posibilidades con las Ciencias de la Computación.
+
+## 2. Corre la voz
+Necesitamos su ayuda para llegar a los organizadores en todo el mundo. ¡Habla a tus amigos de la #HoraDeCódigo! [Use estos recursos útiles](https://<%= hostname %>/promote/resources) para promocionar tu evento.
+
+## 3. Pídele a tu escuela que ofrezca una Hora de Código
+[Envíe este correo electrónico](https://<%= hostname %>/promote/resources#sample-emails) o [comparte estos folletos](https://<%= hostname %>/promote/resources) a su director y desafíe a cada clase de su escuela para que se inscriba.
+
+## 4. Pídele a tu compañía que se involucre
+[Envia este correo electrónico](https://<%= hostname %>/promote/resources#sample-emails) a tu gerente o director general.
+
+## 5. Promociona la Hora de Código en tu comunidad
+Recluta a un grupo local o incluso algunos amigos. [Enviar este correo electrónico](https://<%= hostname %>/promote/resources#sample-emails).
+
+Gracias por dirigir el movimiento para dar a cada estudiante la oportunidad de aprender habilidades informáticas fundacionales.
+
+Hadi Partovi<br />
+Fundador, Code.org
+
+<hr/>
+<small>
+Estás recibiendo este correo electrónico porque usted se registro para la Hora de Código, apoyado por más de 200 socios y organizado por Code.org. Code.org es una 501c3 sin fines de lucro. Nuestra dirección es 1501 4th Avenue, Suite 900, Seattle, WA 98101. ¿No quieres estos correos? [Darse de baja](<%= local_assigns.fetch(:unsubscribe_link, "") %>).
+</small>
+
+![](<%= local_assigns.fetch(:tracking_pixel, "") %>)

--- a/pegasus/emails/hoc_signup_2020_receipt_pt.md
+++ b/pegasus/emails/hoc_signup_2020_receipt_pt.md
@@ -6,7 +6,7 @@ subject: "Obrigado por se inscrever para sediar a Hora do Código!"
   <% codedotorg = CDO.canonical_hostname('code.org') %>
 
 # Obrigado por se inscrever para organizar um evento da Hora do Código!
-Você está possibilitando que alunos de todo o mundo aprendam uma Hora do Código que pode mudar suas vidas, no período de 1 de outubro a 18 de dezembro. Entraremos em contato para falar sobre novos tutoriais e outras atualizações. Então, o que você pode fazer agora?
+Você está possibilitando que alunos de todo o mundo aprendam uma Hora do Código que pode mudar suas vidas, desde o 1ro de outubro ate o 18 de dezembro. Entraremos em contato para falar sobre novos tutoriais e outras atualizações. Então, o que você pode fazer agora?
 
 ## 1. Encontre um voluntário para ajudá-lo no evento.
 [Busque em nosso mapa de voluntários](https://<%= codedotorg %>/volunteer/local) voluntários que possam visitar sua sala de aula ou fazer um chat de vídeo remotamente para inspirar seus alunos, falando sobre a imensidão de possibilidades que a Ciência da Computação proporciona.

--- a/pegasus/emails/hoc_signup_2020_receipt_pt.md
+++ b/pegasus/emails/hoc_signup_2020_receipt_pt.md
@@ -6,7 +6,7 @@ subject: "Obrigado por se inscrever para sediar a Hora do Código!"
   <% codedotorg = CDO.canonical_hostname('code.org') %>
 
 # Obrigado por se inscrever para organizar um evento da Hora do Código!
-Você está possibilitando que alunos de todo o mundo aprendam uma Hora do Código que pode mudar suas vidas, no período de 1 a 7 de outubro. Entraremos em contato para falar sobre novos tutoriais e outras atualizações. Então, o que você pode fazer agora?
+Você está possibilitando que alunos de todo o mundo aprendam uma Hora do Código que pode mudar suas vidas, no período de 1 de outubro a 18 de dezembro. Entraremos em contato para falar sobre novos tutoriais e outras atualizações. Então, o que você pode fazer agora?
 
 ## 1. Encontre um voluntário para ajudá-lo no evento.
 [Busque em nosso mapa de voluntários](https://<%= codedotorg %>/volunteer/local) voluntários que possam visitar sua sala de aula ou fazer um chat de vídeo remotamente para inspirar seus alunos, falando sobre a imensidão de possibilidades que a Ciência da Computação proporciona.

--- a/pegasus/emails/hoc_signup_2020_receipt_pt.md
+++ b/pegasus/emails/hoc_signup_2020_receipt_pt.md
@@ -1,0 +1,36 @@
+---
+from: "Hadi Partovi (Code.org) <hadi_partovi@code.org>"
+subject: "Obrigado por se inscrever para sediar a Hora do Código!"
+---
+  <% hostname = CDO.canonical_hostname('hourofcode.com') %>
+  <% codedotorg = CDO.canonical_hostname('code.org') %>
+
+# Obrigado por se inscrever para organizar um evento da Hora do Código!
+Você está possibilitando que alunos de todo o mundo aprendam uma Hora do Código que pode mudar suas vidas, no período de 1 a 7 de outubro. Entraremos em contato para falar sobre novos tutoriais e outras atualizações. Então, o que você pode fazer agora?
+
+## 1. Encontre um voluntário para ajudá-lo no evento.
+[Busque em nosso mapa de voluntários](https://<%= codedotorg %>/volunteer/local) voluntários que possam visitar sua sala de aula ou fazer um chat de vídeo remotamente para inspirar seus alunos, falando sobre a imensidão de possibilidades que a Ciência da Computação proporciona.
+
+## 2. Divulgue
+Precisamos da sua ajuda para alcançar organizadores do mundo todo. Fale para os seus amigos sobre a #HoraDoCodigo. [Use estes recursos](https://<%= hostname %>/promote/resources) para promover seu evento.
+
+## 3. Convide sua escola inteira para participar da Hora do Código
+[Envie este e-mail](https://<%= hostname %>/promote/resources#sample-emails) para o diretor ou [compartilhe estes materiais](https://<%= hostname %>/promote/resources).
+
+## 4. Peça para que sua empresa participe
+[Envie este e-mail](https://<%= hostname %>/promote/resources#sample-emails) para seu gerente ou CEO.
+
+## 5. Promova a Hora do Código na sua comunidade
+Reúna um grupo da sua região ou mesmo alguns amigos. [Envie este e-mail](https://<%= hostname %>/promote/resources#sample-emails).
+
+Obrigado por participar deste movimento e por dar aos alunos a chance de aprender as habilidades básicas da Ciência da Computação.
+
+Hadi Partovi<br />
+Fundador da Code.org
+
+<hr/>
+<small>
+Você está recebendo este e-mail porque você se cadastrou na Hora do Código, apoiada por mais de 200 parceiros e organizada pela Code.org. A Code.org é uma organização sem fins lucrativos. Nosso endereço é: 1501 4th Avenue, Suite 900, Seattle, WA 98101. Não quer receber esses e-mails? [Cancele sua assinatura](<%= local_assigns.fetch(:unsubscribe_link, "") %>).
+</small>
+
+![](<%= local_assigns.fetch(:tracking_pixel, "") %>)

--- a/pegasus/forms/hoc_signup_2020.rb
+++ b/pegasus/forms/hoc_signup_2020.rb
@@ -1,0 +1,15 @@
+require pegasus_dir 'forms/hoc_signup_2017'
+
+#HOC Sign up form for 2020. 2017 was the last form with new logic
+class HocSignup2020 < HocSignup2017
+  def self.receipt(data)
+    country = data["hoc_event_country_s"].downcase unless data["hoc_event_country_s"].nil_or_empty?
+    if %w(ar bo cl co cr cu do ec gq gt hn mx ni pa pe pr py sv uy ve).include? country
+      'hoc_signup_2020_receipt_es'
+    elsif country == "br"
+      'hoc_signup_2020_receipt_pt'
+    else
+      'hoc_signup_2020_receipt_en'
+    end
+  end
+end


### PR DESCRIPTION
Add new 2020 sign-up receipt emails for hour of code. The English one is updated for this year and the Spanish and Portuguese ones are copied from last year with new dates. Adding these will not change any behavior until we switch to `pre-hoc` mode and update the `hoc_year` to 2020. We will likely completely change the Spanish and Portuguese emails later on, once the new text is translated.

<!-- ### Background -->
<!-- ### Privacy -->
<!-- ### Security -->
<!-- ### Caching -->
<!-- ### Deployment strategy -->
<!-- ### Future work -->

## Links

- [email text doc](https://docs.google.com/document/d/1Gcul-wfz8DUaiuyb6vpR48WUMk16RfbbE_biMMuujjg/edit#heading=h.6h602wg50amw)
- [jira](https://codedotorg.atlassian.net/browse/PLC-934)

## Testing story
Validated that when hoc_year is changed to 2020 the new emails get sent, and the html looks correct.

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
