### PR TITLE
Temporarily disable CSRF protection

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -174,7 +174,10 @@ gem 'omniauth-windowslive', '~> 0.0.11', github: 'wjordan/omniauth-windowslive',
 
 # Resolve CVE 2015 9284
 # see: https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2015-9284
-gem 'omniauth-rails_csrf_protection', '~> 0.1'
+# temporarily disabled as of July 9 2020; an existing feature still depends on
+# the GET functionality blocked here, so we disable this gem to allow the
+# feature to continue to work until we can develop a secure alternative.
+#gem 'omniauth-rails_csrf_protection', '~> 0.1'
 
 gem 'bootstrap-sass', '~> 2.3.2.2'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -597,9 +597,6 @@ GEM
     omniauth-openid (1.0.1)
       omniauth (~> 1.0)
       rack-openid (~> 1.3.1)
-    omniauth-rails_csrf_protection (0.1.2)
-      actionpack (>= 4.2)
-      omniauth (>= 1.3.1)
     open_uri_redirections (0.2.1)
     openid_connect (1.0.3)
       activemodel
@@ -989,7 +986,6 @@ DEPENDENCIES
   omniauth-microsoft_v2_auth!
   omniauth-openid
   omniauth-openid-connect!
-  omniauth-rails_csrf_protection (~> 0.1)
   omniauth-windowslive (~> 0.0.11)!
   open_uri_redirections
   os


### PR DESCRIPTION
Turns out there's a "reauthorize with Google classroom" feature that's still using insecure GET requests: https://github.com/code-dot-org/code-dot-org/blob/58ab74b14f606342367a54b2e07d7e7052cd0393/apps/src/templates/teacherDashboard/RosterDialog.jsx#L131-L133

Disable the CSRF protection gem added in https://github.com/code-dot-org/code-dot-org/pull/35425 until we can refactor that feature.

## Links

<!--
  Any relevant links to external resources; ie, specification documents, jira
  items, related PRs, honeybadger errors, etc
-->

- [Zendesk](https://codeorg.zendesk.com/agent/tickets/286436)

## Testing story

I tested the regular link/unlink buttons to confirm they still work.

With the following change, I was able to repro the "reauthorize with Google" behavior:

```diff
diff --git a/dashboard/app/controllers/api_controller.rb b/dashboard/app/controllers/api_controller.rb
index c1c3f401431..a2ff54b2745 100644
--- a/dashboard/app/controllers/api_controller.rb
+++ b/dashboard/app/controllers/api_controller.rb
@@ -53,15 +53,14 @@ class ApiController < ApplicationController
   ].freeze
 
   private def query_google_classroom_service
-    tokens = current_user.oauth_tokens_for_provider(AuthenticationOption::GOOGLE)
     client = Signet::OAuth2::Client.new(
       authorization_uri: 'https://accounts.google.com/o/oauth2/auth',
       token_credential_uri:  'https://www.googleapis.com/oauth2/v3/token',
       client_id: CDO.dashboard_google_key,
       client_secret: CDO.dashboard_google_secret,
-      refresh_token: tokens[:oauth_refresh_token],
-      access_token: tokens[:oauth_token],
-      expires_at: tokens[:oauth_token_expiration],
+      refresh_token: nil,
+      access_token: nil,
+      expires_at: 1.week.ago,
       scope: GOOGLE_AUTH_SCOPES,
     )
     service = Google::Apis::ClassroomV1::ClassroomService.new
```

And confirm that removing this gem does unblock that!

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
