### PR TITLE
Remove 20-hour course if Express courses available

### DIFF
--- a/apps/src/templates/studioHomepages/CourseBlocks.jsx
+++ b/apps/src/templates/studioHomepages/CourseBlocks.jsx
@@ -11,13 +11,16 @@ import ProtectedStatefulDiv from '../ProtectedStatefulDiv';
 import i18n from '@cdo/locale';
 import {pegasus} from '@cdo/apps/lib/util/urlHelpers';
 
-class ExpressCourses extends Component {
+class ModernCsfCourses extends Component {
   componentDidMount() {
     $('#pre-express')
       .appendTo(ReactDOM.findDOMNode(this.refs.pre_express))
       .show();
     $('#express')
       .appendTo(ReactDOM.findDOMNode(this.refs.express))
+      .show();
+    $('#unplugged')
+      .appendTo(ReactDOM.findDOMNode(this.refs.unplugged))
       .show();
   }
 
@@ -31,7 +34,9 @@ class ExpressCourses extends Component {
           <ProtectedStatefulDiv ref="pre_express" />
           <ProtectedStatefulDiv ref="express" />
         </div>
-        <AcceleratedAndUnplugged />
+        <div className="row">
+          <ProtectedStatefulDiv ref="unplugged" />
+        </div>
       </ContentContainer>
     );
   }
@@ -212,7 +217,7 @@ export class CourseBlocksIntl extends Component {
     );
     return (
       <div>
-        {modernCsf ? <ExpressCourses /> : <AcceleratedCourses />}
+        {modernCsf ? <ModernCsfCourses /> : <AcceleratedCourses />}
 
         <CourseBlocksHoc isInternational />
 

--- a/apps/test/unit/templates/studioHomepages/CoursesTest.jsx
+++ b/apps/test/unit/templates/studioHomepages/CoursesTest.jsx
@@ -72,8 +72,7 @@ describe('Courses', () => {
               modernElementaryCoursesAvailable: true
             });
             assertComponentsInOrder(wrapper, [
-              'ExpressCourses',
-              'AcceleratedAndUnplugged',
+              'ModernCsfCourses',
               'CourseBlocksHoc',
               'SpecialAnnouncement',
               'CoursesAToF',


### PR DESCRIPTION
The 20-hour course should not be displayed on the `/courses` page if the Express courses are available in that language.

## Links
- [spec](https://docs.google.com/document/d/1UhnomMGzeSudAWJhDr-lhIe6rWiQQ6PEzaDwGmuX_IA/edit?pli=1)
- [jira](https://codedotorg.atlassian.net/browse/FND-1215)

## Screenshots
### Before
![image](https://user-images.githubusercontent.com/1372238/87078016-90ef7200-c213-11ea-9c5b-c2476231442e.png)

### After + es-MX
![image](https://user-images.githubusercontent.com/1372238/87079456-a06fba80-c215-11ea-81d8-f2f0742e1ef5.png)

### After + id-ID
![image](https://user-images.githubusercontent.com/1372238/87078133-b7ada880-c213-11ea-947e-e5719f21c25d.png)

## Testing story
* Manually tested locally with http://localhost-studio.code.org:3000/courses/lang/es-mx

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
