### PR TITLE
Allow teachers to share libraries with their classmates

### DIFF
--- a/dashboard/lib/projects_list.rb
+++ b/dashboard/lib/projects_list.rb
@@ -118,7 +118,7 @@ module ProjectsList
     end
 
     # Retrieve a class set of libraries for a specified class section
-    # @param section The section that has all students whose libraries should
+    # @param section The section that has all users whose libraries should
     #                be returned.
     # @return [Hash<Array<Hash>>] A hash of lists of published libraries.
     def fetch_section_libraries(section)
@@ -126,19 +126,19 @@ module ProjectsList
       section_users = section.students + [section.user]
 
       [].tap do |projects_list_data|
-        student_storage_ids = PEGASUS_DB[:user_storage_ids].
+        user_storage_ids = PEGASUS_DB[:user_storage_ids].
           where(user_id: section_users.pluck(:id)).
           select_hash(:id, :user_id)
-        student_storage_id_list = student_storage_ids.keys
+        user_storage_id_list = user_storage_ids.keys
         PEGASUS_DB[:storage_apps].
-          where(storage_id: student_storage_id_list, state: 'active').
+          where(storage_id: user_storage_id_list, state: 'active').
           where(project_type: project_types).
           where("value->'$.libraryName' IS NOT NULL").
           each do |project|
             # The channel id stored in the project's value field may not be reliable
             # when apps are remixed, so recompute the channel id.
             channel_id = storage_encrypt_channel_id(project[:storage_id], project[:id])
-            project_owner = section_users.find {|user| user.id == student_storage_ids[project[:storage_id]]}
+            project_owner = section_users.find {|user| user.id == user_storage_ids[project[:storage_id]]}
             project_data = get_library_row_data(project, channel_id, section.name, project_owner)
             if project_data && (project_owner.id != section.user_id || project_data[:sharedWith].include?(section.id))
               projects_list_data << project_data

--- a/dashboard/lib/projects_list.rb
+++ b/dashboard/lib/projects_list.rb
@@ -140,7 +140,7 @@ module ProjectsList
             channel_id = storage_encrypt_channel_id(project[:storage_id], project[:id])
             project_owner = section_users.find {|user| user.id == student_storage_ids[project[:storage_id]]}
             project_data = get_library_row_data(project, channel_id, section.name, project_owner)
-            if project_data && (project_owner.user_type == 'student' || project_data[:sharedWith].include?(section.id))
+            if project_data && (project_owner.id != section.user_id || project_data[:sharedWith].include?(section.id))
               projects_list_data << project_data
             end
           end

--- a/dashboard/test/lib/projects_list_test.rb
+++ b/dashboard/test/lib/projects_list_test.rb
@@ -316,11 +316,11 @@ class ProjectsListTest < ActionController::TestCase
       @storage_id => 4,
       @teacher_storage_id => 6
     }
-    User = Struct.new(:id, :name, :user_type)
-    teacher = User.new(6, teacher_name, 'teacher')
-    student = User.new(4, student_name, 'student')
-    Section = Struct.new(:students, :user, :id, :name)
-    section = Section.new([student], teacher, 321, 'sectionName')
+    User = Struct.new(:id, :name)
+    teacher = User.new(6, teacher_name)
+    student = User.new(4, student_name)
+    Section = Struct.new(:students, :user, :id, :name, :user_id)
+    section = Section.new([student], teacher, 321, 'sectionName', teacher.id)
 
     PEGASUS_DB.stubs(:[]).returns(user_db_result(stub_users)).then.returns(library_db_result(stub_projects))
 
@@ -331,6 +331,42 @@ class ProjectsListTest < ActionController::TestCase
     assert_equal gamelab_lib_name, lib_response[1][:name]
     assert_equal description, lib_response[0][:description]
     assert_equal student_name, lib_response[0][:userName]
+  end
+
+  test 'fetch_section_libraries returns libraries owned by teachers' do
+    applab_lib_name = 'applab_library'
+    description = 'library description'
+    section_owner_name = 'section owner'
+    section_participant_name = 'section participant'
+    stub_projects = [
+      {
+        name: applab_lib_name,
+        properties: {}.to_json,
+        birthday: 25.years.ago.to_datetime,
+        storage_id: @storage_id,
+        id: 1,
+        project_type: 'applab',
+        value: {'libraryName': applab_lib_name, 'libraryDescription': description}.to_json,
+        state: 'active'
+      }
+    ]
+    stub_users = {
+      @storage_id => 4
+    }
+    User = Struct.new(:id, :name, :user_type)
+    section_owner = User.new(6, section_owner_name, 'teacher')
+    section_participant = User.new(4, section_participant_name, 'teacher')
+    Section = Struct.new(:students, :user, :id, :name, :user_id)
+    section = Section.new([section_participant], section_owner, 321, 'sectionName', section_owner.id)
+
+    PEGASUS_DB.stubs(:[]).returns(user_db_result(stub_users)).then.returns(library_db_result(stub_projects))
+
+    StorageApps.stubs(:get_published_project_data).returns({})
+    lib_response = ProjectsList.send(:fetch_section_libraries, section)
+    assert_equal 1, lib_response.length
+    assert_equal applab_lib_name, lib_response[0][:name]
+    assert_equal description, lib_response[0][:description]
+    assert_equal section_participant_name, lib_response[0][:userName]
   end
 
   test 'fetch_section_libraries fetches libraries shared by teachers' do
@@ -363,10 +399,10 @@ class ProjectsListTest < ActionController::TestCase
     stub_users = {
       @storage_id => 4
     }
-    User = Struct.new(:id, :name, :user_type)
-    teacher = User.new(4, teacher_name, 'teacher')
-    Section = Struct.new(:students, :user, :id, :name)
-    section = Section.new([], teacher, 321, 'sectionName')
+    User = Struct.new(:id, :name)
+    teacher = User.new(4, teacher_name)
+    Section = Struct.new(:students, :user, :id, :name, :user_id)
+    section = Section.new([], teacher, 321, 'sectionName', teacher.id)
 
     PEGASUS_DB.stubs(:[]).returns(user_db_result(stub_users)).then.returns(library_db_result(stub_projects))
 


### PR DESCRIPTION
We discovered that when we disabled auto-sharing of libraries from teachers to students, we also unintentionally disabled auto-sharing of libraries from teachers to classmates.
[slack thread](https://codedotorg.slack.com/archives/CMRTVRN4C/p1594320157041300)

This has updated our rules so teachers can auto-share libraries with classmates (For example: other teachers at a training)
<!--
  Your description goes here: A summary of the change, including any relevant motivation and context.

  If relevant, include a description both of the existing behavior and of the new behavior.
-->

<!--
  Other aspects to consider. uncomment and add detail for any that seem necessary:
-->

<!-- ### Background -->
<!-- ### Privacy -->
<!-- ### Security -->
<!-- ### Caching -->
<!-- ### Deployment strategy -->
<!-- ### Future work -->

## Links
[spec](https://docs.google.com/document/d/1zZ6WU5oBfh5Ra5TkdUpYRFsoMpIu9MRCWO42oBMyhrM/edit#)

<!--
  Any relevant links to external resources; ie, specification documents, jira
  items, related PRs, honeybadger errors, etc
-->


## Testing story

<!--
  Does your change include appropriate tests?

  If so, please describe how the tests included in this PR are sufficient

  If not, please explain why this change does not need to be tested.
-->

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
