### PR TITLE
Census: Remove Maine 2018-2019 reference

### DIFF
--- a/dashboard/app/models/census/state_cs_offering.rb
+++ b/dashboard/app/models/census/state_cs_offering.rb
@@ -109,7 +109,6 @@ class Census::StateCsOffering < ApplicationRecord
     LA
     MA
     MD
-    ME
     MN
     MO
     MS


### PR DESCRIPTION
Maine 2018-2019 state CS offerings data was deleted in https://github.com/code-dot-org/code-dot-org/pull/35710. However, it is still in `STATES_USING_FORMAT_V2_IN_2018_19` list, causing `seed:state_cs_offerings` to fail as reported in this [Slack discussion](https://codedotorg.slack.com/archives/CC4U03GA0/p1594328716191700?thread_ts=1590768544.089200&cid=CC4U03GA0).

This change simply removes Maine from `STATES_USING_FORMAT_V2_IN_2018_19` list.
Verified by running `bundle exec rake seed:state_cs_offerings` from `dashboard` folder on local machine.


