### PR TITLE
Google Classroom reauthorization flow with CSRF protection

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -174,10 +174,7 @@ gem 'omniauth-windowslive', '~> 0.0.11', github: 'wjordan/omniauth-windowslive',
 
 # Resolve CVE 2015 9284
 # see: https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2015-9284
-# temporarily disabled as of July 9 2020; an existing feature still depends on
-# the GET functionality blocked here, so we disable this gem to allow the
-# feature to continue to work until we can develop a secure alternative.
-#gem 'omniauth-rails_csrf_protection', '~> 0.1'
+gem 'omniauth-rails_csrf_protection', '~> 0.1'
 
 gem 'bootstrap-sass', '~> 2.3.2.2'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -597,6 +597,9 @@ GEM
     omniauth-openid (1.0.1)
       omniauth (~> 1.0)
       rack-openid (~> 1.3.1)
+    omniauth-rails_csrf_protection (0.1.2)
+      actionpack (>= 4.2)
+      omniauth (>= 1.3.1)
     open_uri_redirections (0.2.1)
     openid_connect (1.0.3)
       activemodel
@@ -986,6 +989,7 @@ DEPENDENCIES
   omniauth-microsoft_v2_auth!
   omniauth-openid
   omniauth-openid-connect!
+  omniauth-rails_csrf_protection (~> 0.1)
   omniauth-windowslive (~> 0.0.11)!
   open_uri_redirections
   os

--- a/apps/src/lib/util/RailsAuthenticityToken.jsx
+++ b/apps/src/lib/util/RailsAuthenticityToken.jsx
@@ -1,0 +1,22 @@
+import React from 'react';
+
+/**
+ * React component that renders a hidden input populated with the name and
+ * value for a Rails authenticity token as retrieved from meta tags in the
+ * page's head.
+ * This is necessary for React-rendered forms to submit to Rails endpoints
+ * that have CSRF protection enabled.
+ */
+export default function RailsAuthenticityToken() {
+  const csrfParam = document.querySelector('meta[name="csrf-param"]');
+  const csrfToken = document.querySelector('meta[name="csrf-token"]');
+  if (csrfParam && csrfToken) {
+    return (
+      <input type="hidden" name={csrfParam.content} value={csrfToken.content} />
+    );
+  }
+  console.error(
+    'Tried to render an authenticity token into the form but no CSRF meta tags were found in the document.'
+  );
+  return null;
+}

--- a/apps/src/sites/studio/pages/home/_homepage.js
+++ b/apps/src/sites/studio/pages/home/_homepage.js
@@ -78,6 +78,7 @@ function showHomepage() {
             teacherEmail={homepageData.teacherEmail}
             schoolYear={homepageData.currentSchoolYear}
             specialAnnouncement={specialAnnouncement}
+            authenticityToken={homepageData.authenticityToken}
           />
         )}
         {!isTeacher && (

--- a/apps/src/sites/studio/pages/home/_homepage.js
+++ b/apps/src/sites/studio/pages/home/_homepage.js
@@ -78,7 +78,6 @@ function showHomepage() {
             teacherEmail={homepageData.teacherEmail}
             schoolYear={homepageData.currentSchoolYear}
             specialAnnouncement={specialAnnouncement}
-            authenticityToken={homepageData.authenticityToken}
           />
         )}
         {!isTeacher && (

--- a/apps/src/templates/studioHomepages/TeacherHomepage.jsx
+++ b/apps/src/templates/studioHomepages/TeacherHomepage.jsx
@@ -41,7 +41,8 @@ export default class TeacherHomepage extends Component {
     teacherId: PropTypes.number,
     teacherEmail: PropTypes.string,
     schoolYear: PropTypes.number,
-    specialAnnouncement: shapes.specialAnnouncement
+    specialAnnouncement: shapes.specialAnnouncement,
+    authenticityToken: PropTypes.string
   };
 
   state = {
@@ -163,7 +164,8 @@ export default class TeacherHomepage extends Component {
       canViewAdvancedTools,
       queryStringOpen,
       isEnglish,
-      specialAnnouncement
+      specialAnnouncement,
+      authenticityToken
     } = this.props;
 
     // Hide the regular announcement/notification for now.
@@ -226,7 +228,10 @@ export default class TeacherHomepage extends Component {
             <div style={styles.clear} />
           </div>
         )}
-        <TeacherSections queryStringOpen={queryStringOpen} />
+        <TeacherSections
+          queryStringOpen={queryStringOpen}
+          authenticityToken={authenticityToken}
+        />
         <RecentCourses
           courses={courses}
           topCourse={topCourse}

--- a/apps/src/templates/studioHomepages/TeacherHomepage.jsx
+++ b/apps/src/templates/studioHomepages/TeacherHomepage.jsx
@@ -44,7 +44,6 @@ export class UnconnectedTeacherHomepage extends Component {
     teacherEmail: PropTypes.string,
     schoolYear: PropTypes.number,
     specialAnnouncement: shapes.specialAnnouncement,
-    authenticityToken: PropTypes.string,
     beginGoogleImportRosterFlow: PropTypes.func
   };
 
@@ -173,8 +172,7 @@ export class UnconnectedTeacherHomepage extends Component {
       teacherEmail,
       canViewAdvancedTools,
       isEnglish,
-      specialAnnouncement,
-      authenticityToken
+      specialAnnouncement
     } = this.props;
 
     // Hide the regular announcement/notification for now.
@@ -237,7 +235,7 @@ export class UnconnectedTeacherHomepage extends Component {
             <div style={styles.clear} />
           </div>
         )}
-        <TeacherSections authenticityToken={authenticityToken} />
+        <TeacherSections />
         <RecentCourses
           courses={courses}
           topCourse={topCourse}

--- a/apps/src/templates/studioHomepages/TeacherHomepage.jsx
+++ b/apps/src/templates/studioHomepages/TeacherHomepage.jsx
@@ -1,5 +1,6 @@
 import PropTypes from 'prop-types';
 import React, {Component} from 'react';
+import {connect} from 'react-redux';
 import ReactDOM from 'react-dom';
 import $ from 'jquery';
 import HeaderBanner from '../HeaderBanner';
@@ -15,6 +16,7 @@ import ProtectedStatefulDiv from '../ProtectedStatefulDiv';
 import i18n from '@cdo/locale';
 import CensusTeacherBanner from '../census2017/CensusTeacherBanner';
 import DonorTeacherBanner from '@cdo/apps/templates/DonorTeacherBanner';
+import {beginGoogleImportRosterFlow} from '../teacherDashboard/teacherSectionsRedux';
 
 const styles = {
   clear: {
@@ -23,7 +25,7 @@ const styles = {
   }
 };
 
-export default class TeacherHomepage extends Component {
+export class UnconnectedTeacherHomepage extends Component {
   static propTypes = {
     joinedSections: shapes.sections,
     hocLaunch: PropTypes.string,
@@ -42,7 +44,8 @@ export default class TeacherHomepage extends Component {
     teacherEmail: PropTypes.string,
     schoolYear: PropTypes.number,
     specialAnnouncement: shapes.specialAnnouncement,
-    authenticityToken: PropTypes.string
+    authenticityToken: PropTypes.string,
+    beginGoogleImportRosterFlow: PropTypes.func
   };
 
   state = {
@@ -147,6 +150,13 @@ export default class TeacherHomepage extends Component {
     $('#flashes')
       .appendTo(ReactDOM.findDOMNode(this.refs.flashes))
       .show();
+
+    // A special on-load behavior: If requested by queryparam, automatically
+    // launch the Google Classroom rostering flow.
+    const {queryStringOpen, beginGoogleImportRosterFlow} = this.props;
+    if (queryStringOpen === 'rosterDialog') {
+      beginGoogleImportRosterFlow();
+    }
   }
 
   render() {
@@ -162,7 +172,6 @@ export default class TeacherHomepage extends Component {
       teacherName,
       teacherEmail,
       canViewAdvancedTools,
-      queryStringOpen,
       isEnglish,
       specialAnnouncement,
       authenticityToken
@@ -228,10 +237,7 @@ export default class TeacherHomepage extends Component {
             <div style={styles.clear} />
           </div>
         )}
-        <TeacherSections
-          queryStringOpen={queryStringOpen}
-          authenticityToken={authenticityToken}
-        />
+        <TeacherSections authenticityToken={authenticityToken} />
         <RecentCourses
           courses={courses}
           topCourse={topCourse}
@@ -248,3 +254,8 @@ export default class TeacherHomepage extends Component {
     );
   }
 }
+
+export default connect(
+  state => ({}),
+  {beginGoogleImportRosterFlow}
+)(UnconnectedTeacherHomepage);

--- a/apps/src/templates/studioHomepages/TeacherSections.jsx
+++ b/apps/src/templates/studioHomepages/TeacherSections.jsx
@@ -8,7 +8,6 @@ import {asyncLoadSectionData} from '../teacherDashboard/teacherSectionsRedux';
 
 class TeacherSections extends Component {
   static propTypes = {
-    queryStringOpen: PropTypes.string,
     authenticityToken: PropTypes.string,
 
     //Redux provided
@@ -20,15 +19,12 @@ class TeacherSections extends Component {
   }
 
   render() {
-    const {authenticityToken, queryStringOpen} = this.props;
+    const {authenticityToken} = this.props;
 
     return (
       <div id="classroom-sections">
         <ContentContainer heading={i18n.sectionsTitle()}>
-          <OwnedSections
-            queryStringOpen={queryStringOpen}
-            authenticityToken={authenticityToken}
-          />
+          <OwnedSections authenticityToken={authenticityToken} />
         </ContentContainer>
       </div>
     );

--- a/apps/src/templates/studioHomepages/TeacherSections.jsx
+++ b/apps/src/templates/studioHomepages/TeacherSections.jsx
@@ -9,6 +9,7 @@ import {asyncLoadSectionData} from '../teacherDashboard/teacherSectionsRedux';
 class TeacherSections extends Component {
   static propTypes = {
     queryStringOpen: PropTypes.string,
+    authenticityToken: PropTypes.string,
 
     //Redux provided
     asyncLoadSectionData: PropTypes.func.isRequired
@@ -19,12 +20,15 @@ class TeacherSections extends Component {
   }
 
   render() {
-    const {queryStringOpen} = this.props;
+    const {authenticityToken, queryStringOpen} = this.props;
 
     return (
       <div id="classroom-sections">
         <ContentContainer heading={i18n.sectionsTitle()}>
-          <OwnedSections queryStringOpen={queryStringOpen} />
+          <OwnedSections
+            queryStringOpen={queryStringOpen}
+            authenticityToken={authenticityToken}
+          />
         </ContentContainer>
       </div>
     );

--- a/apps/src/templates/studioHomepages/TeacherSections.jsx
+++ b/apps/src/templates/studioHomepages/TeacherSections.jsx
@@ -8,8 +8,6 @@ import {asyncLoadSectionData} from '../teacherDashboard/teacherSectionsRedux';
 
 class TeacherSections extends Component {
   static propTypes = {
-    authenticityToken: PropTypes.string,
-
     //Redux provided
     asyncLoadSectionData: PropTypes.func.isRequired
   };
@@ -19,12 +17,10 @@ class TeacherSections extends Component {
   }
 
   render() {
-    const {authenticityToken} = this.props;
-
     return (
       <div id="classroom-sections">
         <ContentContainer heading={i18n.sectionsTitle()}>
-          <OwnedSections authenticityToken={authenticityToken} />
+          <OwnedSections />
         </ContentContainer>
       </div>
     );

--- a/apps/src/templates/teacherDashboard/OwnedSections.jsx
+++ b/apps/src/templates/teacherDashboard/OwnedSections.jsx
@@ -42,8 +42,6 @@ const styles = {
 
 class OwnedSections extends React.Component {
   static propTypes = {
-    authenticityToken: PropTypes.string,
-
     // redux provided
     sectionIds: PropTypes.arrayOf(PropTypes.number).isRequired,
     hiddenSectionIds: PropTypes.arrayOf(PropTypes.number).isRequired,
@@ -141,7 +139,7 @@ class OwnedSections extends React.Component {
             )}
           </div>
         )}
-        <RosterDialog authenticityToken={this.props.authenticityToken} />
+        <RosterDialog />
         <AddSectionDialog />
         <EditSectionDialog />
       </div>

--- a/apps/src/templates/teacherDashboard/OwnedSections.jsx
+++ b/apps/src/templates/teacherDashboard/OwnedSections.jsx
@@ -10,8 +10,7 @@ import Button from '@cdo/apps/templates/Button';
 import {
   hiddenSectionIds,
   beginEditingNewSection,
-  beginEditingSection,
-  beginImportRosterFlow
+  beginEditingSection
 } from './teacherSectionsRedux';
 import i18n from '@cdo/locale';
 import color from '@cdo/apps/util/color';
@@ -43,7 +42,6 @@ const styles = {
 
 class OwnedSections extends React.Component {
   static propTypes = {
-    queryStringOpen: PropTypes.string,
     authenticityToken: PropTypes.string,
 
     // redux provided
@@ -51,8 +49,7 @@ class OwnedSections extends React.Component {
     hiddenSectionIds: PropTypes.arrayOf(PropTypes.number).isRequired,
     asyncLoadComplete: PropTypes.bool.isRequired,
     beginEditingNewSection: PropTypes.func.isRequired,
-    beginEditingSection: PropTypes.func.isRequired,
-    beginImportRosterFlow: PropTypes.func.isRequired
+    beginEditingSection: PropTypes.func.isRequired
   };
 
   state = {
@@ -66,14 +63,6 @@ class OwnedSections extends React.Component {
       recordImpression('owned_sections_table_with_dashboard_header_buttons');
     } else {
       recordImpression('owned_sections_table_without_dashboard_header_buttons');
-    }
-  }
-
-  componentDidMount() {
-    const {queryStringOpen, beginImportRosterFlow} = this.props;
-
-    if (queryStringOpen === 'rosterDialog') {
-      beginImportRosterFlow();
     }
   }
 
@@ -169,7 +158,6 @@ export default connect(
   }),
   {
     beginEditingNewSection,
-    beginEditingSection,
-    beginImportRosterFlow
+    beginEditingSection
   }
 )(OwnedSections);

--- a/apps/src/templates/teacherDashboard/OwnedSections.jsx
+++ b/apps/src/templates/teacherDashboard/OwnedSections.jsx
@@ -44,6 +44,7 @@ const styles = {
 class OwnedSections extends React.Component {
   static propTypes = {
     queryStringOpen: PropTypes.string,
+    authenticityToken: PropTypes.string,
 
     // redux provided
     sectionIds: PropTypes.arrayOf(PropTypes.number).isRequired,
@@ -151,7 +152,7 @@ class OwnedSections extends React.Component {
             )}
           </div>
         )}
-        <RosterDialog />
+        <RosterDialog authenticityToken={this.props.authenticityToken} />
         <AddSectionDialog />
         <EditSectionDialog />
       </div>

--- a/apps/src/templates/teacherDashboard/RosterDialog.jsx
+++ b/apps/src/templates/teacherDashboard/RosterDialog.jsx
@@ -10,6 +10,7 @@ import {
   importOrUpdateRoster,
   isRosterDialogOpen
 } from './teacherSectionsRedux';
+import RailsAuthenticityToken from '../../lib/util/RailsAuthenticityToken';
 
 const orangeButtonStyle = {
   background: color.orange,
@@ -125,13 +126,13 @@ NoClassroomsFound.propTypes = {
 const ROSTERED_SECTIONS_SUPPORT_URL =
   'https://support.code.org/hc/en-us/articles/115001319312';
 
-const LoadError = ({rosterProvider, loginType, authenticityToken}) => {
+const LoadError = ({rosterProvider, loginType}) => {
   switch (rosterProvider) {
     case OAuthSectionTypes.google_classroom:
       return (
         <div>
           <p>{locale.authorizeGoogleClassroomsText()}</p>
-          <ReauthorizeGoogleClassroom authenticityToken={authenticityToken} />
+          <ReauthorizeGoogleClassroom />
           <p>
             <a href={ROSTERED_SECTIONS_SUPPORT_URL} target="_blank">
               {locale.errorLoadingRosteredSectionsSupport()}
@@ -152,29 +153,21 @@ const LoadError = ({rosterProvider, loginType, authenticityToken}) => {
 };
 LoadError.propTypes = {
   rosterProvider: PropTypes.string,
-  loginType: PropTypes.string,
-  authenticityToken: PropTypes.string
+  loginType: PropTypes.string
 };
 
 const REAUTHORIZE_URL =
   '/users/auth/google_oauth2?scope=userinfo.email,userinfo.profile,classroom.courses.readonly,classroom.rosters.readonly';
-function ReauthorizeGoogleClassroom({authenticityToken}) {
+function ReauthorizeGoogleClassroom() {
   return (
     <form method="POST" action={REAUTHORIZE_URL}>
-      <input
-        type="hidden"
-        name="authenticity_token"
-        value={authenticityToken}
-      />
+      <RailsAuthenticityToken />
       <button type="submit" style={orangeButtonStyle}>
         {locale.authorizeGoogleClassrooms()}
       </button>
     </form>
   );
 }
-ReauthorizeGoogleClassroom.propTypes = {
-  authenticityToken: PropTypes.string
-};
 
 class RosterDialog extends React.Component {
   static propTypes = {
@@ -184,8 +177,7 @@ class RosterDialog extends React.Component {
     isOpen: PropTypes.bool,
     classrooms: PropTypes.arrayOf(classroomShape),
     loadError: loadErrorShape,
-    rosterProvider: PropTypes.oneOf(Object.keys(OAuthSectionTypes)),
-    authenticityToken: PropTypes.string
+    rosterProvider: PropTypes.oneOf(Object.keys(OAuthSectionTypes))
   };
 
   state = {selectedId: null};
@@ -238,7 +230,6 @@ class RosterDialog extends React.Component {
             <LoadError
               rosterProvider={this.props.rosterProvider}
               loginType={loginType}
-              authenticityToken={this.props.authenticityToken}
             />
           ) : this.props.classrooms ? (
             <ClassroomList

--- a/apps/src/templates/teacherDashboard/RosterDialog.jsx
+++ b/apps/src/templates/teacherDashboard/RosterDialog.jsx
@@ -184,7 +184,7 @@ class RosterDialog extends React.Component {
     isOpen: PropTypes.bool,
     classrooms: PropTypes.arrayOf(classroomShape),
     loadError: loadErrorShape,
-    rosterProvider: PropTypes.oneOf(Object.keys(OAuthSectionTypes)).isRequired,
+    rosterProvider: PropTypes.oneOf(Object.keys(OAuthSectionTypes)),
     authenticityToken: PropTypes.string
   };
 

--- a/apps/src/templates/teacherDashboard/RosterDialog.jsx
+++ b/apps/src/templates/teacherDashboard/RosterDialog.jsx
@@ -165,7 +165,7 @@ class RosterDialog extends React.Component {
     isOpen: PropTypes.bool,
     classrooms: PropTypes.arrayOf(classroomShape),
     loadError: loadErrorShape,
-    rosterProvider: PropTypes.oneOf(Object.keys(OAuthSectionTypes))
+    rosterProvider: PropTypes.oneOf(Object.keys(OAuthSectionTypes)).isRequired
   };
 
   state = {selectedId: null};

--- a/apps/src/templates/teacherDashboard/RosterDialog.jsx
+++ b/apps/src/templates/teacherDashboard/RosterDialog.jsx
@@ -12,7 +12,7 @@ import {
 } from './teacherSectionsRedux';
 import RailsAuthenticityToken from '../../lib/util/RailsAuthenticityToken';
 
-const orangeButtonStyle = {
+const ctaButtonStyle = {
   background: color.orange,
   color: color.white,
   border: '1px solid #b07202',
@@ -51,7 +51,7 @@ const styles = {
     left: 20
   },
   buttonPrimary: {
-    ...orangeButtonStyle,
+    ...ctaButtonStyle,
     float: 'right'
   },
   buttonSecondary: {
@@ -162,7 +162,7 @@ function ReauthorizeGoogleClassroom() {
   return (
     <form method="POST" action={REAUTHORIZE_URL}>
       <RailsAuthenticityToken />
-      <button type="submit" style={orangeButtonStyle}>
+      <button type="submit" style={ctaButtonStyle}>
         {locale.authorizeGoogleClassrooms()}
       </button>
     </form>

--- a/apps/src/templates/teacherDashboard/RosterDialog.story.jsx
+++ b/apps/src/templates/teacherDashboard/RosterDialog.story.jsx
@@ -48,12 +48,23 @@ export default storybook => {
         .add(`${provider}: No sections found`, () => (
           <RosterDialog rosterProvider={provider} classrooms={[]} />
         ))
-        .add(`${provider}: Load error`, () => (
-          <RosterDialog
-            rosterProvider={provider}
-            loadError={{status: 403, message: 'Sample error message.'}}
-          />
-        ));
+        .add(`${provider}: Load error`, () => {
+          // Stub CSRF meta tags into the document so we can render the reauthorization
+          // button successfully.
+          const csrfParam = document.createElement('meta');
+          const csrfToken = document.createElement('meta');
+          csrfParam.setAttribute('name', 'csrf-param');
+          csrfToken.setAttribute('name', 'csrf-token');
+          document.head.appendChild(csrfParam);
+          document.head.appendChild(csrfToken);
+
+          return (
+            <RosterDialog
+              rosterProvider={provider}
+              loadError={{status: 403, message: 'Sample error message.'}}
+            />
+          );
+        });
     }
   );
   return storybook;

--- a/apps/src/templates/teacherDashboard/RosterDialog.story.jsx
+++ b/apps/src/templates/teacherDashboard/RosterDialog.story.jsx
@@ -40,7 +40,7 @@ export default storybook => {
               }
             ]}
             studioUrl=""
-            provider={OAuthSectionTypes.google_classroom}
+            rosterProvider={OAuthSectionTypes.google_classroom}
           />
         </ExampleDialogButton>
       )
@@ -52,7 +52,7 @@ export default storybook => {
         <ExampleDialogButton closeCallbacks={ROSTER_DIALOG_CLOSE_CALLBACKS}>
           <RosterDialog
             studioUrl=""
-            provider={OAuthSectionTypes.google_classroom}
+            rosterProvider={OAuthSectionTypes.google_classroom}
           />
         </ExampleDialogButton>
       )
@@ -66,7 +66,7 @@ export default storybook => {
           <RosterDialog
             classrooms={[]}
             studioUrl=""
-            provider={OAuthSectionTypes.google_classroom}
+            rosterProvider={OAuthSectionTypes.google_classroom}
           />
         </ExampleDialogButton>
       )
@@ -79,7 +79,7 @@ export default storybook => {
           <RosterDialog
             loadError={{status: 403, message: 'Sample error message.'}}
             studioUrl=""
-            provider={OAuthSectionTypes.google_classroom}
+            rosterProvider={OAuthSectionTypes.google_classroom}
           />
         </ExampleDialogButton>
       )
@@ -90,7 +90,7 @@ export default storybook => {
       story: () => (
         <ExampleDialogButton closeCallbacks={ROSTER_DIALOG_CLOSE_CALLBACKS}>
           <RosterDialog
-            provider={OAuthSectionTypes.clever}
+            rosterProvider={OAuthSectionTypes.clever}
             classrooms={[
               {
                 id: '123',
@@ -129,7 +129,7 @@ export default storybook => {
       story: () => (
         <ExampleDialogButton closeCallbacks={ROSTER_DIALOG_CLOSE_CALLBACKS}>
           <RosterDialog
-            provider={OAuthSectionTypes.clever}
+            rosterProvider={OAuthSectionTypes.clever}
             classrooms={[]}
             studioUrl=""
           />

--- a/apps/src/templates/teacherDashboard/RosterDialog.story.jsx
+++ b/apps/src/templates/teacherDashboard/RosterDialog.story.jsx
@@ -1,18 +1,19 @@
 import React from 'react';
 import {UnconnectedRosterDialog as RosterDialog} from './RosterDialog';
 import {OAuthSectionTypes} from './shapes';
-import ExampleDialogButton from '../../util/ExampleDialogButton';
-
-const ROSTER_DIALOG_CLOSE_CALLBACKS = ['handleImport', 'handleCancel'];
 
 export default storybook => {
-  return storybook.storiesOf('Dialogs/RosterDialog', module).addStoryTable([
-    {
-      name: 'Select a Classroom',
-      description: 'Dialog for choosing a Google Classroom from the API.',
-      story: () => (
-        <ExampleDialogButton closeCallbacks={ROSTER_DIALOG_CLOSE_CALLBACKS}>
+  storybook = storybook
+    .storiesOf('Dialogs/RosterDialog', module)
+    .addDecorator(dialogIsOpen);
+
+  // Add stories for every provider type
+  [OAuthSectionTypes.google_classroom, OAuthSectionTypes.clever].forEach(
+    provider => {
+      storybook = storybook
+        .add(`${provider}: Select a section`, () => (
           <RosterDialog
+            rosterProvider={provider}
             classrooms={[
               {
                 id: '123',
@@ -39,102 +40,27 @@ export default storybook => {
                 enrollment_code: '12gjl42'
               }
             ]}
-            studioUrl=""
-            rosterProvider={OAuthSectionTypes.google_classroom}
           />
-        </ExampleDialogButton>
-      )
-    },
-    {
-      name: 'Classrooms loading',
-      description: 'Dialog shown when data is loading from the API.',
-      story: () => (
-        <ExampleDialogButton closeCallbacks={ROSTER_DIALOG_CLOSE_CALLBACKS}>
+        ))
+        .add(`${provider}: Loading...`, () => (
+          <RosterDialog rosterProvider={provider} />
+        ))
+        .add(`${provider}: No sections found`, () => (
+          <RosterDialog rosterProvider={provider} classrooms={[]} />
+        ))
+        .add(`${provider}: Load error`, () => (
           <RosterDialog
-            studioUrl=""
-            rosterProvider={OAuthSectionTypes.google_classroom}
-          />
-        </ExampleDialogButton>
-      )
-    },
-    {
-      name: 'No Google Classrooms found',
-      description:
-        'Dialog shown when no Google Classrooms are returned from the API.',
-      story: () => (
-        <ExampleDialogButton closeCallbacks={ROSTER_DIALOG_CLOSE_CALLBACKS}>
-          <RosterDialog
-            classrooms={[]}
-            studioUrl=""
-            rosterProvider={OAuthSectionTypes.google_classroom}
-          />
-        </ExampleDialogButton>
-      )
-    },
-    {
-      name: 'Failed to load classrooms',
-      description: 'Dialog shown when an error is returned from the API.',
-      story: () => (
-        <ExampleDialogButton closeCallbacks={ROSTER_DIALOG_CLOSE_CALLBACKS}>
-          <RosterDialog
+            rosterProvider={provider}
             loadError={{status: 403, message: 'Sample error message.'}}
-            studioUrl=""
-            rosterProvider={OAuthSectionTypes.google_classroom}
           />
-        </ExampleDialogButton>
-      )
-    },
-    {
-      name: 'Clever Classroom',
-      description: 'Dialog for choosing a Clever section from the API.',
-      story: () => (
-        <ExampleDialogButton closeCallbacks={ROSTER_DIALOG_CLOSE_CALLBACKS}>
-          <RosterDialog
-            rosterProvider={OAuthSectionTypes.clever}
-            classrooms={[
-              {
-                id: '123',
-                name: 'New Test Classroom',
-                section: '321',
-                enrollment_code: '1000'
-              },
-              {
-                id: '456',
-                name: 'Other Test Classroom',
-                section: '3A',
-                enrollment_code: '1001'
-              },
-              {
-                id: '101',
-                name: 'Intro to CS',
-                section: '45',
-                enrollment_code: '1002'
-              },
-              {
-                id: '102',
-                name: 'Intro to CS',
-                section: '55',
-                enrollment_code: '1003'
-              }
-            ]}
-            studioUrl=""
-          />
-        </ExampleDialogButton>
-      )
-    },
-    {
-      name: 'No Clever sections found',
-      description:
-        'Dialog shown when no Clever sections are returned from the API.',
-      story: () => (
-        <ExampleDialogButton closeCallbacks={ROSTER_DIALOG_CLOSE_CALLBACKS}>
-          <RosterDialog
-            rosterProvider={OAuthSectionTypes.clever}
-            classrooms={[]}
-            studioUrl=""
-          />
-        </ExampleDialogButton>
-      )
+        ));
     }
-  ]);
+  );
+  return storybook;
 };
+
+// Sets the isOpen prop to true for each story, so that the dialog is
+// open by default when the story is viewed.
+function dialogIsOpen(story) {
+  return React.cloneElement(story(), {isOpen: true});
+}

--- a/apps/src/templates/teacherDashboard/teacherSectionsRedux.js
+++ b/apps/src/templates/teacherDashboard/teacherSectionsRedux.js
@@ -386,6 +386,15 @@ export const beginImportRosterFlow = () => (dispatch, getState) => {
 export const cancelImportRosterFlow = () => ({type: IMPORT_ROSTER_FLOW_CANCEL});
 
 /**
+ * Start the process of importing a section from Google Classroom by opening
+ * the RosterDialog and loading the list of classrooms available for import.
+ */
+export const beginGoogleImportRosterFlow = () => dispatch => {
+  dispatch(setRosterProvider(OAuthSectionTypes.google_classroom));
+  dispatch(beginImportRosterFlow());
+};
+
+/**
  * Import the course with the given courseId from a third-party provider
  * (like Google Classroom or Clever), creating a new section. If the course
  * in question has already been imported, update the existing section already

--- a/apps/test/unit/templates/studioHomepages/TeacherHomepageTest.js
+++ b/apps/test/unit/templates/studioHomepages/TeacherHomepageTest.js
@@ -2,7 +2,7 @@ import React from 'react';
 import {shallow} from 'enzyme';
 import sinon from 'sinon';
 import {assert} from 'chai';
-import TeacherHomepage from '@cdo/apps/templates/studioHomepages/TeacherHomepage';
+import {UnconnectedTeacherHomepage as TeacherHomepage} from '@cdo/apps/templates/studioHomepages/TeacherHomepage';
 import TeacherSections from '@cdo/apps/templates/studioHomepages/TeacherSections';
 import {courses, topCourse} from './homepagesTestData';
 

--- a/dashboard/app/controllers/home_controller.rb
+++ b/dashboard/app/controllers/home_controller.rb
@@ -99,7 +99,6 @@ class HomeController < ApplicationController
     @homepage_data[:locale] = Script.locale_english_name_map[request.locale]
     @homepage_data[:canViewAdvancedTools] = !(current_user.under_13? && current_user.terms_version.nil?)
     @homepage_data[:providers] = current_user.providers
-    @homepage_data[:authenticityToken] = form_authenticity_token
 
     @force_race_interstitial = params[:forceRaceInterstitial]
     @force_school_info_confirmation_dialog = params[:forceSchoolInfoConfirmationDialog]

--- a/dashboard/app/controllers/home_controller.rb
+++ b/dashboard/app/controllers/home_controller.rb
@@ -99,6 +99,7 @@ class HomeController < ApplicationController
     @homepage_data[:locale] = Script.locale_english_name_map[request.locale]
     @homepage_data[:canViewAdvancedTools] = !(current_user.under_13? && current_user.terms_version.nil?)
     @homepage_data[:providers] = current_user.providers
+    @homepage_data[:authenticityToken] = form_authenticity_token
 
     @force_race_interstitial = params[:forceRaceInterstitial]
     @force_school_info_confirmation_dialog = params[:forceSchoolInfoConfirmationDialog]


### PR DESCRIPTION
Reverses https://github.com/code-dot-org/code-dot-org/pull/35734 and updates the Google Classroom reauthorization flow to be compatible with CSRF-protected OAuth.

![image](https://user-images.githubusercontent.com/1615761/87332975-490d6b00-c4f1-11ea-9630-43342ed0e13a.png)

You can think of this PR as containing four changes:

#### 1. Restore OAuth CSRF protection.

Entirely encapsulated in [the first commit](https://github.com/code-dot-org/code-dot-org/pull/35752/commits/0bc755e307f4fe107a04656ce2365a6b0bbcde5b), which reverts #35734 

#### 2. Reauthorize Google Classroom by POST

Encapsulated in [this commit](https://github.com/code-dot-org/code-dot-org/pull/35752/commits/5b93902d0e22d674939aed47ccfc77f80cd9216f), we replace the reauth hyperlink in our load failure view (pictured above) with with an awesome orange button that submits a hidden form with an auth token, giving us CSRF-protected reauthorization.

#### 3. Fix the reauthorization flow

There was an independent bug, that's been around a long time now, where we stopped auto-launching the import section flow after reauthorization!  [That's fixed here.](https://github.com/code-dot-org/code-dot-org/pull/35752/commits/6c8b737a5090dd608208779e906b6884893685f1)

#### 4. Clean up RosterDialog's storybook

At some point RosterDialog's prop interface changed significantly, but its stories were not updated to match.  I've fixed up the stories to reflect how we use RosterDialog now, and also done some cleanup on the story file so we generate all stories for all providers and use a decorator to open the dialogs by default in the story view.

## Testing story

I did manual testing locally by forcing a Google Classroom auth failure using the technique described on https://github.com/code-dot-org/code-dot-org/pull/35734. (Note, this requires you to have [OAuth set up on your local machine.](https://docs.google.com/document/d/1QfHFWQ1mN8deGJz6CW9F3UTgReYGADO2P7aRGo0monU/edit))

Here's a screencast of the whole rostering reauth flow.  Note, we get a second load error at the end of the flow because I've hard-coded this for testing.

![roster-reauth](https://user-images.githubusercontent.com/1615761/87338844-9e9a4580-c4fa-11ea-89bb-a651b994c6b6.gif)


# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
