### PR TITLE
Fix Cdo::Metrics#put dimension arguments

### DIFF
--- a/lib/cdo/app_server_metrics.rb
+++ b/lib/cdo/app_server_metrics.rb
@@ -62,6 +62,7 @@ module Cdo
     end
 
     # Collect current snapshot of tcp/unix listener stats.
+    # @return [Hash{Symbol => Number}]
     def collect_listener_stats
       stats = {}
       stats.merge! Raindrops::Linux.tcp_listener_stats(@tcp.uniq) if @tcp

--- a/lib/cdo/lighthouse.rb
+++ b/lib/cdo/lighthouse.rb
@@ -56,7 +56,7 @@ module Lighthouse
 
     perf = (JSON.parse(json).dig('categories', 'performance', 'score') * 100).to_i
     ChatClient.log "#{url} Page Speed: <a href='#{html_url}'>#{perf}</a>"
-    Cdo::Metrics.instance.put 'Website/PageSpeed', perf,
+    Cdo::Metrics.put 'Website/PageSpeed', perf,
       Environment: CDO.rack_env, URL: url.to_s
   rescue => e
     ChatClient.log "Page speed report failed: #{e}"

--- a/lib/test/cdo/aws/test_metrics.rb
+++ b/lib/test/cdo/aws/test_metrics.rb
@@ -1,0 +1,26 @@
+require_relative '../../test_helper'
+require 'cdo/aws/metrics'
+
+class CdoMetricsTest < Minitest::Test
+  def setup
+    Cdo::Metrics.client = Aws::CloudWatch::Client.new(stub_responses: true)
+  end
+
+  def test_put
+    Cdo::Metrics.put('App Server/WorkerBoot', 1, Host: 'localhost.code.org')
+    Cdo::Metrics.flush!
+    refute_empty Cdo::Metrics.client.api_requests
+    assert_equal(
+      {
+        namespace: 'App Server',
+        metric_data: [
+          metric_name: 'WorkerBoot',
+          dimensions: [
+            name: 'Host', value: 'localhost.code.org'
+          ],
+          value: 1.0
+        ]
+      }, Cdo::Metrics.client.api_requests.first[:params].tap {|p| p[:metric_data].first.delete(:timestamp)}
+    )
+  end
+end


### PR DESCRIPTION
Fixes `ArgumentError: unexpected value at params[:metric_data][0][:Host]` triggered by a metric sent by this line:
https://github.com/code-dot-org/code-dot-org/blob/0c75d04525e6682c7b223235f888080e34d7bd76/lib/cdo/app_server_hooks.rb#L29

The problem turned out to be an ambiguity in the signature of `Cdo::Metrics#put`: `put(name, value, dimensions={}, **options)`
When the last argument is optional, the last hash passed to the method end up going into `options` instead of `dimensions` as expected. The fix is to make `dimensions` non-optional since it was always being passed anyway, and will make the use of this method a bit clearer.

Added a unit test for coverage of this bug, and also refactored `Cdo::Metrics` from singleton class to module functions.