### PR TITLE
HOC: Update default_hoc_mode to pre-hoc

### DIFF
--- a/config.yml.erb
+++ b/config.yml.erb
@@ -426,7 +426,7 @@ proxy: false # If true, generated URLs will not include explicit port numbers in
 # Run dashboard-server with the level editing interface enabled (for admins)
 levelbuilder_mode:
 
-default_hoc_mode:   post-hoc # overridden by 'hoc_mode' DCDO param, except in :test
+default_hoc_mode:   pre-hoc # overridden by 'hoc_mode' DCDO param, except in :test
 default_hoc_launch: ''       # overridden by 'hoc_launch' DCDO param, except in :test
 
 localize_apps: false


### PR DESCRIPTION
This change will only affect the test environment. This updates `default_hoc_mode` to `pre-hoc` which we will be switching over to soon.
<!-- ### Background -->
<!-- ### Privacy -->
<!-- ### Security -->
<!-- ### Caching -->
<!-- ### Deployment strategy -->
<!-- ### Future work -->

## Links

- [jira](https://codedotorg.atlassian.net/browse/PLC-934)


# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
