### PR TITLE
AFE: fix school stats percentages

### DIFF
--- a/dashboard/app/models/school.rb
+++ b/dashboard/app/models/school.rb
@@ -81,7 +81,7 @@ class School < ActiveRecord::Base
 
     # To align with maker_high_needs? definition above,
     # returning false if we don't have all data for a given school.
-    stats.title_i_eligible? || (stats.urm_percent || 0) >= 0.4 || (stats.frl_eligible_percent || 0) >= 0.4
+    stats.title_i_eligible? || (stats.urm_percent || 0) >= 40 || (stats.frl_eligible_percent || 0) >= 40
   end
 
   # Public school ids from NCES are always 12 digits, possibly with

--- a/dashboard/app/models/school_stats_by_year.rb
+++ b/dashboard/app/models/school_stats_by_year.rb
@@ -76,11 +76,13 @@ class SchoolStatsByYear < ActiveRecord::Base
   end
 
   # Percentage of underrepresented minorities students
+  # Note these are values between 0-100, not 0-1!
   def urm_percent
     percent_of_students([student_am_count, student_hi_count, student_bl_count, student_hp_count].compact.reduce(:+))
   end
 
   # Percentage of free/reduced lunch eligible students
+  # Note these are values between 0-100, not 0-1!
   def frl_eligible_percent
     percent_of_students(frl_eligible_total)
   end
@@ -109,7 +111,7 @@ class SchoolStatsByYear < ActiveRecord::Base
     %w(1 2 3 4 5).include? title_i_status
   end
 
-  # returns what percent "count" is of the total student enrollment
+  # returns what percent "count" is of the total student enrollment (0-100)
   def percent_of_students(count)
     return nil unless count && students_total
     (100.0 * count / students_total).round(2)

--- a/dashboard/test/models/school_test.rb
+++ b/dashboard/test/models/school_test.rb
@@ -55,7 +55,7 @@ class SchoolTest < ActiveSupport::TestCase
       {
         school_id: school.id,
         school_year: '1998-1999',
-        students_total: 4
+        students_total: 100
       }
     )
     school.save!
@@ -68,8 +68,8 @@ class SchoolTest < ActiveSupport::TestCase
       {
         school_id: school.id,
         school_year: '1998-1999',
-        students_total: 1000,
-        frl_eligible_total: 499
+        students_total: 100,
+        frl_eligible_total: 49
       }
     )
     school.save!
@@ -127,8 +127,8 @@ class SchoolTest < ActiveSupport::TestCase
       {
         school_id: school.id,
         school_year: '1998-1999',
-        students_total: 1000,
-        frl_eligible_total: 401
+        students_total: 100,
+        frl_eligible_total: 41
       }
     )
     school.save!
@@ -141,12 +141,26 @@ class SchoolTest < ActiveSupport::TestCase
       {
         school_id: school.id,
         school_year: '1998-1999',
-        students_total: 4,
-        student_bl_count: 2
+        students_total: 100,
+        student_bl_count: 50
       }
     )
     school.save!
     assert school.afe_high_needs?
+  end
+
+  test 'AFE high needs false when urm percent below 40 percent of students' do
+    school = create :school
+    school.school_stats_by_year << SchoolStatsByYear.new(
+      {
+        school_id: school.id,
+        school_year: '1998-1999',
+        students_total: 100,
+        student_bl_count: 25
+      }
+    )
+    school.save!
+    refute school.afe_high_needs?
   end
 
   test 'AFE high needs true when title_i_status is yes' do
@@ -168,12 +182,12 @@ class SchoolTest < ActiveSupport::TestCase
       {
         school_id: school.id,
         school_year: '1998-1999',
-        students_total: 5,
-        student_bl_count: 0,
+        students_total: 100,
+        student_bl_count: 5,
         student_am_count: 0,
         student_hi_count: 0,
-        student_hp_count: 0,
-        frl_eligible_total: 0,
+        student_hp_count: 5,
+        frl_eligible_total: 20,
         title_i_status: '6'
       }
     )
@@ -187,8 +201,8 @@ class SchoolTest < ActiveSupport::TestCase
       school.school_stats_by_year << SchoolStatsByYear.new(
         school_id: school.id,
         school_year: '1998-1999',
-        students_total: 4,
-        student_bl_count: 2
+        students_total: 100,
+        student_bl_count: 50
       )
     school.save!
     assert_equal(50.0, stats_by_year.first.urm_percent)


### PR DESCRIPTION
🤦 I thought the school stats percentages we use to determine eligibility for AFE benefits were 0-1. They are...0-100.

## Testing story

Added a new test to cover a school that has a non-zero percentage of underrepresented students, which would have caught this issue had it existed previously. Also standardized the # of students used in other tests to always be out of 100 for simplicity, and made school data more realistic in one test (ie, don't use 0 for all demographic groups, which is unlikely in real data and would have caught this bug if I had used it earlier).

## Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
