### PR TITLE
Always Show CSF Examples Button

### DIFF
--- a/dashboard/app/views/levels/_teacher_panel.html.haml
+++ b/dashboard/app/views/levels/_teacher_panel.html.haml
@@ -31,7 +31,7 @@
         - send("#{"playlab"}_project_view_projects_url".to_sym, channel_id: example, host: 'studio.code.org', port: 443, protocol: :https)
       - else
         - send("#{@level.game.app}_project_view_projects_url".to_sym, channel_id: example, host: 'studio.code.org', port: 443, protocol: :https)
-  - elsif @script && (@level.ideal_level_source_id || @script.csf?)  # old style 'solutions' for blockly-type levels
+  - elsif @level.ideal_level_source_id && @script # old style 'solutions' for blockly-type levels
     -level_example_links = []
     -level_example_links.push(build_script_level_url(@script_level, {solution: true}.merge(@section ? {section_id: @section.id} : {})))
 

--- a/dashboard/app/views/levels/_teacher_panel.html.haml
+++ b/dashboard/app/views/levels/_teacher_panel.html.haml
@@ -13,7 +13,7 @@
   - data[:page_type] = 'level' if @level.present?
 
 - if @level && @script_level
-  - if @level.try(:examples).present? && current_user.authorized_teacher? # 'solutions' for applab-type levels
+  - if @level.try(:examples).present? && (@current_user.authorized_teacher? || @script.csf?)# 'solutions' for applab-type levels
     - level_example_links = @level.examples.map do |example|
       // We treat Sprite Lab levels as a sub-set of game lab levels right now which breaks their examples solutions
       // as level.game.app gets "gamelab" which makes the examples for sprite lab try to open in game lab.
@@ -31,7 +31,7 @@
         - send("#{"playlab"}_project_view_projects_url".to_sym, channel_id: example, host: 'studio.code.org', port: 443, protocol: :https)
       - else
         - send("#{@level.game.app}_project_view_projects_url".to_sym, channel_id: example, host: 'studio.code.org', port: 443, protocol: :https)
-  - elsif @level.ideal_level_source_id && @script # old style 'solutions' for blockly-type levels
+  - elsif @script && (@level.ideal_level_source_id || @script.csf?)  # old style 'solutions' for blockly-type levels
     -level_example_links = []
     -level_example_links.push(build_script_level_url(@script_level, {solution: true}.merge(@section ? {section_id: @section.id} : {})))
 


### PR DESCRIPTION
we don't require CSF teachers to be verified, but our "examples" button in the teacher panel was previously only displaying for verified teachers in applab-type levels.

the fix was to add a `@script.csf?` check in the teacher panel view to always show examples when true.

<!-- ### Background -->
<!-- ### Privacy -->
<!-- ### Security -->
<!-- ### Caching -->
<!-- ### Deployment strategy -->
<!-- ### Future work -->

## Links

<!--
  Any relevant links to external resources; ie, specification documents, jira
  items, related PRs, honeybadger errors, etc
-->

- [jira](https://codedotorg.atlassian.net/browse/LP-1446)

## Testing story
i'm still working on getting tests to run locally but going ahead and creating PR to run automated test suite and get feedback.

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
