### PR TITLE
Disable Drive operations in the i18n sync

### DIFF
--- a/bin/i18n/sync-all.rb
+++ b/bin/i18n/sync-all.rb
@@ -29,7 +29,6 @@ require_relative 'sync-in'
 require_relative 'sync-up'
 require_relative 'sync-down'
 require_relative 'sync-out'
-require_relative 'upload_i18n_translation_percentages_to_gdrive'
 
 require 'optparse'
 
@@ -50,7 +49,6 @@ class I18nSync
       sync_down if should_i "sync down"
       sync_out if should_i "sync out"
       create_down_out_pr if @options[:with_pull_request]
-      upload_i18n_stats if should_i "upload translation stats"
       checkout_staging
     elsif @options[:command]
       case @options[:command]

--- a/bin/i18n/sync-out.rb
+++ b/bin/i18n/sync-out.rb
@@ -103,7 +103,6 @@ def restore_redacted_files
       end
       find_malformed_links_images(locale, translated_path)
     end
-    I18nScriptUtils.upload_malformed_restorations(locale)
   end
 end
 


### PR DESCRIPTION
Our credentials expired and we can't renew them due to some [actions on Google's part](https://security.googleblog.com/2019/04/better-protection-against-man-in-middle.html). I'd like to explore using a service account key in the future. I've created a [Jira task](https://codedotorg.atlassian.net/browse/FND-1234) for that follow up work.

This blocks the i18n sync every weekend so I would prefer the sync to actually run than to sync to Drive.

<!-- ### Background -->
<!-- ### Privacy -->
<!-- ### Security -->
<!-- ### Caching -->
<!-- ### Deployment strategy -->
<!-- ### Future work -->

## Links

<!--
  Any relevant links to external resources; ie, specification documents, jira
  items, related PRs, honeybadger errors, etc
-->

- [spec]()
- [jira]()

## Testing story

<!--
  Does your change include appropriate tests?

  If so, please describe how the tests included in this PR are sufficient

  If not, please explain why this change does not need to be tested.
-->

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
