### PR TITLE
Re-enable test: Facilitator View of dashboard is as expected

### DIFF
--- a/dashboard/test/ui/features/plc/pd/dashboard_view.feature
+++ b/dashboard/test/ui/features/plc/pd/dashboard_view.feature
@@ -3,13 +3,14 @@
 
 Feature: Basic appearance for Facilitator Survey UI
 
-@skip
-Scenario: Facilitator View of surveys is as expected
-  Given I am a facilitator with completed courses
-  And I am on "http://studio.code.org/pd/workshop_dashboard/survey_results"
-  And I wait to see "#surveyResultsTable"
-  And I open my eyes to test "facilitator survey results"
-  And I see no difference for "viewing facilitator survey results"
+Scenario: Facilitator View of dashboard is as expected
+  Given I am a facilitator with started and completed courses
+  And I am on "http://studio.code.org/pd/workshop_dashboard"
+  And I wait to see element with ID "endedWorkshopsTable"
+  And I wait to see element with ID "inProgressWorkshopsTable"
+  And I wait to see element with ID "notStartedWorkshopsTable"
+  And I open my eyes to test "facilitator dashboard"
+  And I see no difference for "viewing facilitator dashboard"
   And I close my eyes
 
 Scenario: Organizer View of dashboard is as expected

--- a/dashboard/test/ui/features/step_definitions/pd.rb
+++ b/dashboard/test/ui/features/step_definitions/pd.rb
@@ -105,7 +105,7 @@ Given(/^I am a teacher who has just followed a workshop certificate link$/) do
     :pd_enrollment,
     :with_attendance,
     :from_user,
-    user: User.find_by(email: @users[test_teacher_name][:email])
+    user: find_test_user_by_name(test_teacher_name)
   )
   steps %Q{
     And I am on "http://studio.code.org/pd/generate_workshop_certificate/#{enrollment.code}"
@@ -115,7 +115,7 @@ end
 Given(/^I navigate to the principal approval page for "([^"]*)"$/) do |name|
   require_rails_env
 
-  user = User.find_by_email @users[name][:email]
+  user = find_test_user_by_name(name)
   application = Pd::Application::ActiveApplicationModels::TEACHER_APPLICATION_CLASS.find_by(user: user)
 
   # TODO(Andrew) ensure regional partner in the original application, and remove this:
@@ -147,7 +147,7 @@ end
 And(/^I make the teacher named "([^"]*)" a facilitator for course "([^"]*)"$/) do |name, course|
   require_rails_env
 
-  user = User.find_by(email: @users[name][:email])
+  user = find_test_user_by_name(name)
   user.permission = UserPermission::FACILITATOR
   Pd::CourseFacilitator.create(facilitator_id: user.id, course: course)
 end
@@ -155,14 +155,14 @@ end
 And(/^I make the teacher named "([^"]*)" a workshop organizer$/) do |name|
   require_rails_env
 
-  user = User.find_by(email: @users[name][:email])
+  user = find_test_user_by_name(name)
   user.permission = UserPermission::WORKSHOP_ORGANIZER
 end
 
 And(/^I make the teacher named "([^"]*)" a workshop admin$/) do |name|
   require_rails_env
 
-  user = User.find_by(email: @users[name][:email])
+  user = find_test_user_by_name(name)
   user.permission = UserPermission::WORKSHOP_ADMIN
 end
 
@@ -471,7 +471,7 @@ And(/^I create a workshop for course "([^"]*)" ([a-z]+) by "([^"]*)" with (\d+) 
   # Organizer
   organizer =
     if role == 'organized'
-      User.find_by(name: name)
+      find_test_user_by_name(name)
     else
       User.find_or_create_teacher(
         {name: 'Organizer', email: "organizer#{SecureRandom.hex[0..5]}@code.org"}, nil, 'workshop_organizer'
@@ -497,7 +497,7 @@ And(/^I create a workshop for course "([^"]*)" ([a-z]+) by "([^"]*)" with (\d+) 
       workshop.facilitators << create_facilitator(course)
     end
   else
-    facilitator = role == 'facilitated' ? User.find_by(name: name) : create_facilitator(course)
+    facilitator = role == 'facilitated' ? find_test_user_by_name(name) : create_facilitator(course)
     workshop.facilitators << facilitator
   end
 

--- a/dashboard/test/ui/features/step_definitions/pd.rb
+++ b/dashboard/test/ui/features/step_definitions/pd.rb
@@ -126,24 +126,6 @@ Given(/^I navigate to the principal approval page for "([^"]*)"$/) do |name|
   }
 end
 
-Given(/^I am a facilitator with completed courses$/) do
-  random_name = "TestFacilitator" + SecureRandom.hex[0..9]
-  steps %Q{
-    And I create a teacher named "#{random_name}"
-    And I make the teacher named "#{random_name}" a facilitator for course "CS Fundamentals"
-    And I create a workshop for course "CS Fundamentals" facilitated by "#{random_name}" with 5 people and end it
-  }
-end
-
-Given(/^I am an organizer with completed courses$/) do
-  random_name = "TestOrganizer" + SecureRandom.hex[0..9]
-  steps %Q{
-    And I create a teacher named "#{random_name}"
-    And I make the teacher named "#{random_name}" a workshop organizer
-    And I create a workshop for course "CS Fundamentals" organized by "#{random_name}" with 5 people and end it
-  }
-end
-
 And(/^I make the teacher named "([^"]*)" a facilitator for course "([^"]*)"$/) do |name, course|
   require_rails_env
 

--- a/dashboard/test/ui/features/step_definitions/steps.rb
+++ b/dashboard/test/ui/features/step_definitions/steps.rb
@@ -1062,6 +1062,10 @@ def generate_user(name)
   return email, password
 end
 
+def find_test_user_by_name(name)
+  User.find_by(email: @users[name][:email])
+end
+
 And /^I check the pegasus URL$/ do
   pegasus_url = @browser.execute_script('return window.dashboard.CODE_ORG_URL')
   puts "Pegasus URL is #{pegasus_url}"


### PR DESCRIPTION
Enables the eyes test disabled in https://github.com/code-dot-org/code-dot-org/pull/35749, and fixes a performance issue that we believe caused the flakiness in the first place.

### Which test are we talking about?

Here is the scenario in question:

https://github.com/code-dot-org/code-dot-org/blob/4008770ce7c309df7ddb39ff5064e104d1222545/dashboard/test/ui/features/plc/pd/dashboard_view.feature#L6-L14

At first glance, there's not a whole lot going on here, except I suspect that first step `I am a facilitator with started and completed courses` is doing the heavy lifting.  We'll come back to that.

### How often does it fail?

Here's the last 30 days of Sauce Labs' history on this test, from our test environment.  You can see that the test gradually gets more flaky over time, then suddenly stops failing two days ago.

![image](https://user-images.githubusercontent.com/1615761/87210021-eafe3f00-c2c8-11ea-8be2-2c6be698e824.png)

The test has been passing consistently in our Drone environment.  This suggested that our failures were somehow related to persistent state on the test environment, which wouldn't be a problem on Drone.  Given that it recently started succeeding again, maybe we didn't need to skip it?  Still, it seems like a good idea to investigate, since it got so bad that it was only passing 20% of the time.

### How does it fail?

We looked at several sample failures and they are very consistent. Here's a sample cucumber log:

![image](https://user-images.githubusercontent.com/1615761/87210326-f9008f80-c2c9-11ea-957c-1db2524b888f.png)

When you open the Sauce Labs test log, you are greeted with this message:

![image](https://user-images.githubusercontent.com/1615761/87210354-159cc780-c2ca-11ea-9484-188ae21b34f5.png)

The last cucumber step in the SL log is `I am a facilitator with started and completed courses` and the last selenium command is this `execute_async` which successfully creates a teacher account:

![image](https://user-images.githubusercontent.com/1615761/87210407-4846c000-c2ca-11ea-9ea7-c5bfe9189853.png)

The video record also shows that the browser stays up for 60 seconds at this point, without receiving a command.  **Conclusion: Our test client is doing something that takes longer than 60 seconds, so Sauce Labs gives up and closes the remote browser.  Next time our test tries to send a command to Sauce Labs, it discovers that the test session has expired.**

Another observation: Although this is an "eyes" test, we don't need to check Applitools logs because the test is consistently failing before it reaches any Applitools steps.

### What is the test doing that takes so long?

To understand this, we need to dig down into our step definitions.

`I am a facilitator with started and completed courses` invokes several other steps in turn.

https://github.com/code-dot-org/code-dot-org/blob/d671161f7c32e5d277b50c753fd803fe11881794/dashboard/test/ui/features/step_definitions/pd.rb#L73-L82

Ben and I looked at these steps one at a time and tried to identify potentially slow code.

#### And I create a teacher named "#{random_name}"

https://github.com/code-dot-org/code-dot-org/blob/d671161f7c32e5d277b50c753fd803fe11881794/dashboard/test/ui/features/step_definitions/steps.rb#L1285-L1288

https://github.com/code-dot-org/code-dot-org/blob/d671161f7c32e5d277b50c753fd803fe11881794/dashboard/test/ui/features/step_definitions/steps.rb#L1249-L1270

This step does interact with the remote browser. It accounts for the navigation to `/reset_session` and for the successful POST request we observed in the Sauce Labs log.  I think it's safe to say this step completes successfully.

#### And I make the teacher named "#{random_name}" a facilitator for course "CS Fundamentals"

https://github.com/code-dot-org/code-dot-org/blob/d671161f7c32e5d277b50c753fd803fe11881794/dashboard/test/ui/features/step_definitions/pd.rb#L147-L153

The `require_rails_env` step is known to be slow, but we do use it in other places.  I'd also expect these tests to be failing on Drone if that was the only issue.  We'll keep it in mind.

Everything else here looks fine - we're finding a user by email, granting them a permission, and inserting a CourseFacilitator row.

Note that this step does not interact with the remote browser.

#### And I create a workshop for course "CS Fundamentals" facilitated by "#{random_name}" with 5 people and start it

The last three steps are actually all the same, heavily-parameterized step:

https://github.com/code-dot-org/code-dot-org/blob/d671161f7c32e5d277b50c753fd803fe11881794/dashboard/test/ui/features/step_definitions/pd.rb#L470-L523

There's a lot going on here.  First, notice that this code also does not interact with the remote browser.

Second, there are two `User.find_by(name: name)` calls, and one of them (line 500) is invoked by all three steps we are investigating.  Our `users` table does not contain an index on `name`, so this accounts for at least three table scans during this step.  On Drone that's probably fine - our database will only contain users we've created for tests.  In our test environment, however, we can have millions of rows in the users table.

Today there were more than three million rows in `users` on test, which was sufficient to make this query take several seconds.  We haven't yet uncovered whether this number was higher two days ago.

Third, this method invokes `create_enrollment` for each of the three steps in our parent step:

https://github.com/code-dot-org/code-dot-org/blob/d671161f7c32e5d277b50c753fd803fe11881794/dashboard/test/ui/features/step_definitions/pd.rb#L436-L459

`create_enrollment` in turn contains a `School.find_or_create_by` call that doesn't use any of the `schools` table's indexes, resulting in another table scan.  There are about 100 thousand rows in `schools` on test today.

### Conclusion

This test will fail if the `require_rails_env` call and the six table scans we found take more than 60 seconds all together.  It seems likely that the slow queries are the main issue here, since this has been a problem on test but not Drone.

It looks like something (we're not sure what) happened two days ago to make these queries faster on test.  Despite this, we're going ahead and fixing the `users` table scans here, to avoid similar issues in the future.

## Links

- [Investigation notes](https://docs.google.com/document/d/1rI58UTWZSXBwavz1zMw5B9_4CJHlTiomhkUw_dtzOmI/edit) (Code.org-internal)
- Example failing run:
  - [Cucumber log](https://cucumber-logs.s3.amazonaws.com/test/test/Chrome_plc_pd_dashboard_view_eyes_output.html?versionId=yzLTU9jRq5k82CnZBxA_ptP3CxEirb3Q)
  - [Sauce Labs](https://app.saucelabs.com/tests/52ca1d56d2934f96a40ae091733e5352#8)
- Example successful run:
  - [Sauce Labs](https://app.saucelabs.com/tests/1992e1a672e242bd9954b774a8768a4c#8)

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
