### PR TITLE
AFE: privacy copy changes

### DIFF
--- a/apps/src/templates/amazonFutureEngineerEligibility/amazonFutureEngineerEligibilityForm.jsx
+++ b/apps/src/templates/amazonFutureEngineerEligibility/amazonFutureEngineerEligibilityForm.jsx
@@ -23,7 +23,6 @@ const AFE_CONSENT_BODY = (
     <a href={AMAZON_PRIVACY_POLICY_URL} target="_blank">
       Amazon’s Privacy Policy
     </a>
-    .
   </span>
 );
 
@@ -273,7 +272,11 @@ export default class AmazonFutureEngineerEligibilityForm extends React.Component
               </div>
               <SingleCheckbox
                 name="consentCSTA"
-                label="I give Code.org permission to share my name, email address, and school name, address, and NCES ID with the Computer Science Teachers Association. I provide my consent to the use of my personal data as described in the CSTA Privacy Policy (required if you want a CSTA Plus membership)."
+                label="I give Code.org permission to share my name and email address, and my
+                school's name, address, and NCES ID with the Computer Science Teachers
+                Association. I provide my consent to the use of my personal data as
+                described in the CSTA Privacy Policy (required if you want a CSTA Plus
+                membership)."
                 onChange={this.handleChange}
                 value={this.state.consentCSTA}
                 validationState={

--- a/apps/src/templates/amazonFutureEngineerEligibility/amazonFutureEngineerEligibilityForm.jsx
+++ b/apps/src/templates/amazonFutureEngineerEligibility/amazonFutureEngineerEligibilityForm.jsx
@@ -13,6 +13,20 @@ import {STATES} from '@cdo/apps/geographyConstants';
 
 const VALIDATION_STATE_ERROR = 'error';
 
+const AMAZON_PRIVACY_POLICY_URL =
+  'https://www.amazon.com/gp/help/customer/display.html?ie=UTF8&nodeId=468496';
+const AFE_CONSENT_BODY = (
+  <span>
+    I give Code.org permission to share my name and email address, and my
+    school's name, address, and NCES ID, with Amazon.com (required to
+    participate). Use of your personal information is subject to{' '}
+    <a href={AMAZON_PRIVACY_POLICY_URL} target="_blank">
+      Amazon’s Privacy Policy
+    </a>
+    .
+  </span>
+);
+
 const styles = {
   wrong_school: {
     textAlign: 'right'
@@ -28,7 +42,6 @@ const styles = {
     color: color.white
   }
 };
-
 export default class AmazonFutureEngineerEligibilityForm extends React.Component {
   static propTypes = {
     email: PropTypes.string,
@@ -241,9 +254,7 @@ export default class AmazonFutureEngineerEligibilityForm extends React.Component
           )}
           <SingleCheckbox
             name="csta"
-            label="Send me a free annual Computer Science Teachers Association (CSTA)
-              Plus membership - which includes access to Amazon expert-led
-              webinars and other exclusive content."
+            label="Send me a free annual Computer Science Teachers Association Plus (CSTA+) membership - which includes access to Amazon expert-led webinars and other exclusive content."
             onChange={this.handleChange}
             value={this.state.csta}
           />
@@ -253,7 +264,10 @@ export default class AmazonFutureEngineerEligibilityForm extends React.Component
                 Since you checked the box above, please consent to the sharing
                 and use of your personal data with the CSTA. Your information
                 will be shared as described in accordance with the{' '}
-                <a href="https://csteachers.org/privacy-policy/">
+                <a
+                  href="https://csteachers.org/privacy-policy/"
+                  target="_blank"
+                >
                   CSTA Privacy Policy.
                 </a>
               </div>
@@ -281,10 +295,7 @@ export default class AmazonFutureEngineerEligibilityForm extends React.Component
           <hr style={styles.sectionBreak} />
           <SingleCheckbox
             name="consentAFE"
-            label="I give Code.org permission to share my name, email address, and
-              school name, address, and ID with Amazon.com (required to
-              participate). Use of your personal information is subject to
-              Amazon’s Privacy Policy."
+            label={AFE_CONSENT_BODY}
             onChange={this.handleChange}
             value={this.state.consentAFE}
             validationState={
@@ -297,9 +308,9 @@ export default class AmazonFutureEngineerEligibilityForm extends React.Component
           <div>
             By clicking Continue, you will receive an email from Amazon Future
             Engineer to claim your benefits. You will also receive occasional
-            emails from Amazon Future Engineer about new opportunities. You
-            always have the choice to adjust your interest settings or
-            unsubscribe.
+            emails from Amazon Future Engineer about new opportunities, such as
+            Amazon Future Engineer scholarships and grants. You always have the
+            choice to adjust your interest settings or unsubscribe.
           </div>
           <Button id="continue" onClick={this.onContinue} style={styles.button}>
             Continue

--- a/apps/src/templates/amazonFutureEngineerEligibility/amazonFutureEngineerEligibilityForm.jsx
+++ b/apps/src/templates/amazonFutureEngineerEligibility/amazonFutureEngineerEligibilityForm.jsx
@@ -274,18 +274,21 @@ export default class AmazonFutureEngineerEligibilityForm extends React.Component
             value={this.state.csta}
           />
           {this.state.csta && (
-            <SingleCheckbox
-              name="consentCSTA"
-              label={CSTA_CONSENT_BODY}
-              style={styles.consentIndent}
-              onChange={this.handleChange}
-              value={this.state.consentCSTA}
-              validationState={
-                this.state.errors.hasOwnProperty('consentCSTA')
-                  ? VALIDATION_STATE_ERROR
-                  : null
-              }
-            />
+            <div style={styles.consentIndent}>
+              Since you checked the box above, please consent to sharing your
+              information with the CSTA.
+              <SingleCheckbox
+                name="consentCSTA"
+                label={CSTA_CONSENT_BODY}
+                onChange={this.handleChange}
+                value={this.state.consentCSTA}
+                validationState={
+                  this.state.errors.hasOwnProperty('consentCSTA')
+                    ? VALIDATION_STATE_ERROR
+                    : null
+                }
+              />
+            </div>
           )}
           <SingleCheckbox
             name="awsEducate"

--- a/apps/src/templates/amazonFutureEngineerEligibility/amazonFutureEngineerEligibilityForm.jsx
+++ b/apps/src/templates/amazonFutureEngineerEligibility/amazonFutureEngineerEligibilityForm.jsx
@@ -23,6 +23,21 @@ const AFE_CONSENT_BODY = (
     <a href={AMAZON_PRIVACY_POLICY_URL} target="_blank">
       Amazon’s Privacy Policy
     </a>
+    .
+  </span>
+);
+
+const CSTA_PRIVACY_POLICY_URL = 'https://csteachers.org/privacy-policy/';
+const CSTA_CONSENT_BODY = (
+  <span>
+    I give Code.org permission to share my name and email address, and my
+    school's name, address, and NCES ID, with the Computer Science Teachers
+    Association (required if you want a CSTA+ membership). I provide my consent
+    to the use of my personal data as described in the{' '}
+    <a href={CSTA_PRIVACY_POLICY_URL} target="_blank">
+      CSTA Privacy Policy
+    </a>
+    .
   </span>
 );
 
@@ -41,6 +56,7 @@ const styles = {
     color: color.white
   }
 };
+
 export default class AmazonFutureEngineerEligibilityForm extends React.Component {
   static propTypes = {
     email: PropTypes.string,
@@ -258,34 +274,18 @@ export default class AmazonFutureEngineerEligibilityForm extends React.Component
             value={this.state.csta}
           />
           {this.state.csta && (
-            <div style={styles.consentIndent}>
-              <div>
-                Since you checked the box above, please consent to the sharing
-                and use of your personal data with the CSTA. Your information
-                will be shared as described in accordance with the{' '}
-                <a
-                  href="https://csteachers.org/privacy-policy/"
-                  target="_blank"
-                >
-                  CSTA Privacy Policy.
-                </a>
-              </div>
-              <SingleCheckbox
-                name="consentCSTA"
-                label="I give Code.org permission to share my name and email address, and my
-                school's name, address, and NCES ID, with the Computer Science Teachers
-                Association. I provide my consent to the use of my personal data as
-                described in the CSTA Privacy Policy (required if you want a CSTA Plus
-                membership)."
-                onChange={this.handleChange}
-                value={this.state.consentCSTA}
-                validationState={
-                  this.state.errors.hasOwnProperty('consentCSTA')
-                    ? VALIDATION_STATE_ERROR
-                    : null
-                }
-              />
-            </div>
+            <SingleCheckbox
+              name="consentCSTA"
+              label={CSTA_CONSENT_BODY}
+              style={styles.consentIndent}
+              onChange={this.handleChange}
+              value={this.state.consentCSTA}
+              validationState={
+                this.state.errors.hasOwnProperty('consentCSTA')
+                  ? VALIDATION_STATE_ERROR
+                  : null
+              }
+            />
           )}
           <SingleCheckbox
             name="awsEducate"

--- a/apps/src/templates/amazonFutureEngineerEligibility/amazonFutureEngineerEligibilityForm.jsx
+++ b/apps/src/templates/amazonFutureEngineerEligibility/amazonFutureEngineerEligibilityForm.jsx
@@ -273,7 +273,7 @@ export default class AmazonFutureEngineerEligibilityForm extends React.Component
               <SingleCheckbox
                 name="consentCSTA"
                 label="I give Code.org permission to share my name and email address, and my
-                school's name, address, and NCES ID with the Computer Science Teachers
+                school's name, address, and NCES ID, with the Computer Science Teachers
                 Association. I provide my consent to the use of my personal data as
                 described in the CSTA Privacy Policy (required if you want a CSTA Plus
                 membership)."


### PR DESCRIPTION
Some tweaks to copy for privacy consent in AFE eligibility form.

**Updated 7/13**

![image](https://user-images.githubusercontent.com/25372625/87341506-993efa00-c4fe-11ea-9dd1-e529d83e71af.png)

## Testing story

Tested new links locally.

## Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
