### PR TITLE
Link to the archived wiki page for oauth help

### DIFF
--- a/dashboard/app/views/devise/shared/_oauth_links.haml
+++ b/dashboard/app/views/devise/shared/_oauth_links.haml
@@ -17,8 +17,8 @@
       %strong
         Hi! If you are having trouble with OAuth features on
         = Rails.env
-        %a{href: 'http://wiki.code.org/display/PROD/Developer+Oauth+setup'}
-          check the wiki.
+        %a{href: 'https://docs.google.com/document/d/1QfHFWQ1mN8deGJz6CW9F3UTgReYGADO2P7aRGo0monU/edit'}
+          check this document.
 
     - [:google_oauth2, :facebook, :microsoft_v2_auth].each do |provider|
       = button_to omniauth_authorize_path(resource_name, provider), class: "oauth-sign-in with-#{provider}" do


### PR DESCRIPTION
Update the broken link in our developer OAuth setup help link (only visible in development).

| Before | After |
| --- | --- |
| ![before](https://user-images.githubusercontent.com/1615761/87337579-86c1c200-c4f8-11ea-816d-94276d9be6b1.png) | ![after](https://user-images.githubusercontent.com/1615761/87337585-888b8580-c4f8-11ea-9626-88683502a3e7.png) |

We were still linking to our old wiki, which went down years ago.  The page in question [has been archived here](https://docs.google.com/document/d/1QfHFWQ1mN8deGJz6CW9F3UTgReYGADO2P7aRGo0monU/edit).

## Testing story

Tested manually on local machine by signing out and visiting `/users/sign_in`.

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
