### PR TITLE
Don't translate form keys in International Opt In form

### DIFF
--- a/apps/src/code-studio/pd/form_components/ButtonList.jsx
+++ b/apps/src/code-studio/pd/form_components/ButtonList.jsx
@@ -28,12 +28,12 @@ class ButtonList extends React.Component {
     groupName: PropTypes.string.isRequired,
     answers: PropTypes.arrayOf(
       PropTypes.oneOfType([
-        // Standard string answer
-        // See typedef SimpleAnswer in utils
+        // Standard string answer ...
+        // (see typedef SimpleAnswer in utils)
         PropTypes.string,
 
-        // or an answer followed by an input for additional text
-        // See typedef ExtraInputAnswer in utils
+        // ... or an answer followed by an input for additional text ...
+        // (see typedef ExtraInputAnswer in utils)
         PropTypes.shape({
           answerText: PropTypes.string.isRequired,
           inputId: PropTypes.string,
@@ -41,8 +41,8 @@ class ButtonList extends React.Component {
           onInputChange: PropTypes.func
         }),
 
-        // or an answer with different strings for display vs value
-        // See typedef Answer in utils
+        // ... or an answer with different strings for display vs value.
+        // (see typedef Answer in utils)
         PropTypes.shape({
           answerText: PropTypes.string.isRequired,
           answerValue: PropTypes.string.isRequired

--- a/apps/src/code-studio/pd/form_components/ButtonList.jsx
+++ b/apps/src/code-studio/pd/form_components/ButtonList.jsx
@@ -9,6 +9,8 @@ import {
   HelpBlock
 } from 'react-bootstrap';
 
+import utils from './utils';
+
 const otherString = 'Other:';
 
 const styles = {
@@ -27,15 +29,20 @@ class ButtonList extends React.Component {
     answers: PropTypes.arrayOf(
       PropTypes.oneOfType([
         // Standard string answer
+        // See typedef SimpleAnswer in utils
         PropTypes.string,
 
         // or an answer followed by an input for additional text
+        // See typedef ExtraInputAnswer in utils
         PropTypes.shape({
           answerText: PropTypes.string.isRequired,
           inputId: PropTypes.string,
           inputValue: PropTypes.string,
           onInputChange: PropTypes.func
         }),
+
+        // or an answer with different strings for display vs value
+        // See typedef Answer in utils
         PropTypes.shape({
           answerText: PropTypes.string.isRequired,
           answerValue: PropTypes.string.isRequired
@@ -94,10 +101,7 @@ class ButtonList extends React.Component {
     }
 
     const options = answers.map((answer, i) => {
-      const answerText =
-        typeof answer === 'string' ? answer : answer.answerText;
-      const answerValue =
-        typeof answer === 'string' ? answer : answer.answerValue || answerText;
+      const {answerText, answerValue} = utils.normalizeAnswer(answer);
 
       const checked =
         this.props.type === 'radio'

--- a/apps/src/code-studio/pd/form_components/FormComponent.jsx
+++ b/apps/src/code-studio/pd/form_components/FormComponent.jsx
@@ -128,9 +128,10 @@ export default class FormComponent extends React.Component {
    * @param {String} [placeholder] - if specified, will add a valueless option
    *        with the specified placeholder text
    * @param {boolean} [required=false]
-   * @param {String[]|Object} options - can be specified as either an array (in which case
-   *        the values and display name will be the same) or an object (in which case
-   *        we'll use the keys for the values and the values for the display names)
+   * @param {Answer[]|SimpleAnswer[]|Object} options - can be specified as
+   *        either an array (of either Answers or SimpleAnswers, as defined in
+   *        utils.js) or an object (in which case we'll use the keys for the
+   *        values and the values for the display names)
    *
    * @returns {FieldGroup}
    */

--- a/apps/src/code-studio/pd/form_components/FormComponent.jsx
+++ b/apps/src/code-studio/pd/form_components/FormComponent.jsx
@@ -4,6 +4,7 @@ import {ButtonList} from '../form_components/ButtonList.jsx';
 import FieldGroup from '../form_components/FieldGroup';
 import UsPhoneNumberInput from '../form_components/UsPhoneNumberInput';
 import SingleCheckbox from '../form_components/SingleCheckbox';
+import utils from './utils';
 
 /**
  * Helper class for dashboard forms. Provides helper methods for easily
@@ -143,11 +144,14 @@ export default class FormComponent extends React.Component {
   }) {
     let renderedOptions;
     if (Array.isArray(options)) {
-      renderedOptions = options.map(value => (
-        <option key={value} value={value}>
-          {value}
-        </option>
-      ));
+      renderedOptions = options.map(value => {
+        const {answerText, answerValue} = utils.normalizeAnswer(value);
+        return (
+          <option key={answerValue} value={answerValue}>
+            {answerText}
+          </option>
+        );
+      });
     } else {
       renderedOptions = Object.keys(options).map(key => (
         <option key={key} value={key}>

--- a/apps/src/code-studio/pd/form_components/utils.js
+++ b/apps/src/code-studio/pd/form_components/utils.js
@@ -1,0 +1,51 @@
+module.exports = {};
+
+/**
+ * The most standard kind of answer, simply provides for a way to specify the
+ * display text and form value individually
+ * @typedef Answer
+ * @type {object}
+ * @property {string} answerText - the display text of the answer; used to
+ *     label the input
+ * @property {string} [answerValue] - the form value of the answer; used in the
+ *     "value" attribute of the input. Defaults to 'answerText' if undefined.
+ */
+
+/**
+ * The most basic kind of answer, used for those situations where the display
+ * text and form value are identical.
+ * @typedef SimpleAnswer
+ * @type {string}
+ */
+
+/**
+ * A complex kind of answer which will add an additional input element to
+ * existing form elements. Most commonly used to add a text input to the
+ * "other" option in a radio input.
+ *
+ * Notably, this kind does not include an "answerValue" property; the value of
+ * this input is expected to come from the additional input.
+ *
+ * @typedef ExtraInputAnswer
+ * @type {object}
+ * @property {string} answerText - the display text of the answer; used to
+ *     label the input
+ * @property {string} inputId - the value to assign to the "id" param of the
+ *     additional input element.
+ * @property {string} [inputValue] - the form value to assign to the "value"
+ *     attribute of the additional input element.
+ * @property {function} [onChange] - an optional listener to assign to the
+ *     "onChange" attribute of the additional input element.
+ */
+
+/**
+ * Simple utility to normalize either Answers or SimpleAnswers to just Answers.
+ * @param {(Answer|SimpleAnswer)} answer
+ * @returns {(Answer)}
+ */
+module.exports.normalizeAnswer = answer => {
+  const answerText = typeof answer === 'string' ? answer : answer.answerText;
+  const answerValue =
+    typeof answer === 'string' ? answer : answer.answerValue || answerText;
+  return {answerText, answerValue};
+};

--- a/apps/src/code-studio/pd/international_opt_in/InternationalOptIn.jsx
+++ b/apps/src/code-studio/pd/international_opt_in/InternationalOptIn.jsx
@@ -2,6 +2,7 @@ import PropTypes from 'prop-types';
 import React from 'react';
 import FormController from '../form_components/FormController';
 import FormComponent from '../form_components/FormComponent';
+import formComponentUtils from '../form_components/utils';
 import DatePicker from '../workshop_dashboard/components/date_picker';
 import moment from 'moment';
 import {DATE_FORMAT} from '../workshop_dashboard/workshopConstants';
@@ -71,13 +72,19 @@ class InternationalOptInComponent extends FormComponent {
   render() {
     const labels = this.props.labels;
 
-    const lastSubjectsKey = this.props.options.subjects.slice(-1)[0];
+    const lastSubjectsKey = formComponentUtils.normalizeAnswer(
+      this.props.options.subjects[this.props.options.subjects.length - 1]
+    ).answerValue;
     const textFieldMapSubjects = {[lastSubjectsKey]: 'other'};
 
-    const lastResourcesKey = this.props.options.resources.slice(-1)[0];
+    const lastResourcesKey = formComponentUtils.normalizeAnswer(
+      this.props.options.resources[this.props.options.resources.length - 1]
+    ).answerValue;
     const textFieldMapResources = {[lastResourcesKey]: 'other'};
 
-    const lastRoboticsKey = this.props.options.robotics.slice(-1)[0];
+    const lastRoboticsKey = formComponentUtils.normalizeAnswer(
+      this.props.options.robotics[this.props.options.robotics.length - 1]
+    ).answerValue;
     const textFieldMapRobotics = {[lastRoboticsKey]: 'other'};
 
     return (

--- a/apps/test/unit/code-studio/pd/form_components/utilsTest.js
+++ b/apps/test/unit/code-studio/pd/form_components/utilsTest.js
@@ -1,0 +1,35 @@
+import utils from '@cdo/apps/code-studio/pd/form_components/utils';
+import {expect} from '../../../../util/reconfiguredChai';
+
+describe('FormComponents Utils', () => {
+  it('normalizes SimpleAnswer to Answer', () => {
+    const input = 'simple answer';
+    const output = utils.normalizeAnswer(input);
+    const expected = {
+      answerText: 'simple answer',
+      answerValue: 'simple answer'
+    };
+    expect(output).to.deep.equal(expected);
+  });
+
+  it('normalizes Answer to Answer', () => {
+    const input = {
+      answerText: 'display text',
+      answerValue: 'form value'
+    };
+    const output = utils.normalizeAnswer(input);
+    expect(output).to.deep.equal(input);
+  });
+
+  it('explicitly defines optional answerValue if left undefined', () => {
+    const input = {
+      answerText: 'display text'
+    };
+    const expected = {
+      answerText: 'display text',
+      answerValue: 'display text'
+    };
+    const output = utils.normalizeAnswer(input);
+    expect(output).to.deep.equal(expected);
+  });
+});

--- a/dashboard/app/models/pd/international_opt_in.rb
+++ b/dashboard/app/models/pd/international_opt_in.rb
@@ -64,7 +64,19 @@ class Pd::InternationalOptIn < ApplicationRecord
       legalOptIn: %w(opt_in_yes opt_in_no)
     }
 
-    entries = Hash[entry_keys.map {|k, v| [k, v.map {|s| I18n.t("pd.form_entries.#{k.to_s.underscore}.#{s.underscore}")}]}]
+    # Convert all entry keys to objects which define the form value and display
+    # text (in this case, _translated_ display text) separately.
+    #
+    # See the definition of the "Answer" object in
+    # apps/src/code-studio/pd/form_components/utils.js
+    entries = Hash[entry_keys.map do |key, values|
+      [key, values.map do |value|
+        {
+          answerText: I18n.t("pd.form_entries.#{key.to_s.underscore}.#{value.underscore}"),
+          answerValue: value
+        }
+      end]
+    end]
 
     entries[:workshopOrganizer] = INTERNATIONAL_OPT_IN_PARTNERS
     entries[:workshopFacilitator] = INTERNATIONAL_OPT_IN_FACILITATORS

--- a/dashboard/app/models/pd/international_opt_in.rb
+++ b/dashboard/app/models/pd/international_opt_in.rb
@@ -40,6 +40,20 @@ class Pd::InternationalOptIn < ApplicationRecord
     ]
   end
 
+  def validate_with(options)
+    # Because we're using the special "answerText/answerValue" format in
+    # self.options, we need to normalize to just answerValue here for
+    # validation.
+    normalized_options = options.map do |key, values|
+      normalized_values = values.map do |value|
+        return value.fetch(:answerValue, nil) if value.is_a? Hash
+        value
+      end
+      [key, normalized_values]
+    end.to_h
+    super(normalized_options)
+  end
+
   def validate_required_fields
     super
 


### PR DESCRIPTION
We want to display a translated version of the International Opt In form when accessing the site in a non-english language, but we want the actual answers we store to be consistent regardless of language. This change does two things:

1. Fixes some slight inconsistency in the clientside form logic, where the existing pattern we have for defining display text and form values separately was inconsistently supported.
2. Updates the serverside generation of form options to utilize this logic.

**Note** there will be some followup work needed to normalize the data we've received so far.

**Before (English)**:

```html
<input type="radio" value="Male" label="Male" name="gender">
```

**Before (Spanish):**

```html
<input type="radio" value="Hombre" label="Hombre" name="gender">
```

**After (English)**:

```html
<input type="radio" value="male" label="Male" name="gender">
```

**After (Spanish):**

```html
<input type="radio" value="male" label="Hombre" name="gender">
```
## Links

<!--
  Any relevant links to external resources; ie, specification documents, jira
  items, related PRs, honeybadger errors, etc
-->

- [jira](https://codedotorg.atlassian.net/browse/FND-1205)

## Testing story

Manually tested that the existing form still works, given this change; also added a basic unit test for the new utils method.

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
