### PR TITLE
Survey Results: Remove all course average column

### DIFF
--- a/apps/src/code-studio/pd/workshop_dashboard/components/survey_results/survey_rollup_table_foorm.jsx
+++ b/apps/src/code-studio/pd/workshop_dashboard/components/survey_results/survey_rollup_table_foorm.jsx
@@ -33,7 +33,7 @@ const styles = {
   }
 };
 
-const INCLUDE_OVERALL = true;
+const INCLUDE_OVERALL = false;
 
 export default class SurveyRollupTableFoorm extends React.Component {
   static propTypes = {
@@ -72,49 +72,47 @@ export default class SurveyRollupTableFoorm extends React.Component {
     const thisWorkshop = this.props.workshopRollups.single_workshop;
     const overallFacilitator = this.props.workshopRollups.overall_facilitator;
     const questions = this.props.workshopRollups.questions;
-    if (thisWorkshop && thisWorkshop.averages) {
-      for (const questionId in thisWorkshop.averages) {
-        const questionData = questions[questionId];
-        let overallQuestionAverages = {};
-        if (overall && overall.averages) {
-          overallQuestionAverages = overall.averages[questionId];
-        }
-        let thisWorkshopAverages = this.props.isPerFacilitator
-          ? {}
-          : thisWorkshop.averages[questionId];
-        let overallFacilitatorAverages = this.getFacilitatorAveragesForQuestion(
-          overallFacilitator,
+    for (const questionId in questions) {
+      const questionData = questions[questionId];
+      let overallQuestionAverages = {};
+      if (overall && overall.averages) {
+        overallQuestionAverages = overall.averages[questionId];
+      }
+      let thisWorkshopAverages = this.props.isPerFacilitator
+        ? {}
+        : thisWorkshop.averages[questionId];
+      let overallFacilitatorAverages = this.getFacilitatorAveragesForQuestion(
+        overallFacilitator,
+        questionId
+      );
+      if (this.props.isPerFacilitator && thisWorkshop) {
+        thisWorkshopAverages = this.getFacilitatorAveragesForQuestion(
+          thisWorkshop,
           questionId
         );
-        if (this.props.isPerFacilitator && thisWorkshop) {
-          thisWorkshopAverages = this.getFacilitatorAveragesForQuestion(
-            thisWorkshop,
-            questionId
-          );
-        }
-        if (questionData.type === 'matrix') {
-          this.parseMatrixData(
-            rows,
-            questionData,
-            questionId,
-            thisWorkshopAverages,
-            overallFacilitatorAverages,
-            overallQuestionAverages
-          );
-        } else if (
-          questionData.type === 'scale' ||
-          questionData.type === 'singleSelect' ||
-          questionData.type === 'multiSelect'
-        ) {
-          this.parseSelectData(
-            rows,
-            questionData,
-            questionId,
-            thisWorkshopAverages,
-            overallFacilitatorAverages,
-            overallQuestionAverages
-          );
-        }
+      }
+      if (questionData.type === 'matrix') {
+        this.parseMatrixData(
+          rows,
+          questionData,
+          questionId,
+          thisWorkshopAverages,
+          overallFacilitatorAverages,
+          overallQuestionAverages
+        );
+      } else if (
+        questionData.type === 'scale' ||
+        questionData.type === 'singleSelect' ||
+        questionData.type === 'multiSelect'
+      ) {
+        this.parseSelectData(
+          rows,
+          questionData,
+          questionId,
+          thisWorkshopAverages,
+          overallFacilitatorAverages,
+          overallQuestionAverages
+        );
       }
     }
     return rows;
@@ -183,7 +181,7 @@ export default class SurveyRollupTableFoorm extends React.Component {
 
     // add individual rows
     const denominator = questionData.column_count;
-    for (const rowId in thisWorkshopAverages.rows) {
+    for (const rowId in questionData.rows) {
       let rowData = {
         question: {
           text: questionData.rows[rowId],

--- a/apps/test/unit/code-studio/pd/workshop_dashboard/components/survey_results/survey_rollup_table_foormTest.js
+++ b/apps/test/unit/code-studio/pd/workshop_dashboard/components/survey_results/survey_rollup_table_foormTest.js
@@ -84,13 +84,12 @@ describe('Survey Rollup Table Foorm', () => {
     // 5 expected columns: Question, Average for this workshop,
     // Average for facilitator 1, Average for facilitator 1,
     // Average for this course
-    expect(headerCells).to.have.length(5);
+    expect(headerCells).to.have.length(4);
 
-    // 6 rows are total response count, average for the matrix,
-    // question header and averages for the 3 sub-questions
-    // with answers
+    // 7 rows are total response count, average for the matrix,
+    // question header and averages for all 4 sub-questions
     const bodyRows = rollupTable.find('BodyRow');
-    expect(bodyRows).to.have.length(6);
+    expect(bodyRows).to.have.length(7);
 
     const totalResponsesForThisWorkshop = bodyRows
       .first()

--- a/dashboard/lib/pd/foorm/survey_reporter.rb
+++ b/dashboard/lib/pd/foorm/survey_reporter.rb
@@ -12,6 +12,7 @@ module Pd::Foorm
     #   If all facilitator data can be viewed, facilitator_id_filter is nil
     # @return workshop report in format specified in README
     def self.get_workshop_report(workshop_id, facilitator_id_filter)
+      start_time = Time.now
       return unless workshop_id
 
       # get workshop summary
@@ -42,7 +43,7 @@ module Pd::Foorm
         facilitators,
         split_by_facilitator: true
       )
-      # get overall rollup
+      # get overall rollup per facilitator
       overall_rollup = get_rollup_for_course(ws_data.course, rollup_question_details, facilitators)
       overall_rollup_per_facilitator = facilitators ?
                                          get_facilitator_rollup_for_course(
@@ -62,7 +63,7 @@ module Pd::Foorm
           overall: overall_rollup[key]
         }
       end
-
+      puts "total time: #{Time.now - start_time}"
       result_data
     end
 

--- a/dashboard/lib/pd/foorm/survey_reporter.rb
+++ b/dashboard/lib/pd/foorm/survey_reporter.rb
@@ -12,7 +12,6 @@ module Pd::Foorm
     #   If all facilitator data can be viewed, facilitator_id_filter is nil
     # @return workshop report in format specified in README
     def self.get_workshop_report(workshop_id, facilitator_id_filter)
-      start_time = Time.now
       return unless workshop_id
 
       # get workshop summary
@@ -44,7 +43,6 @@ module Pd::Foorm
         split_by_facilitator: true
       )
       # get overall rollup per facilitator
-      overall_rollup = get_rollup_for_course(ws_data.course, rollup_question_details, facilitators)
       overall_rollup_per_facilitator = facilitators ?
                                          get_facilitator_rollup_for_course(
                                            facilitators,
@@ -60,10 +58,9 @@ module Pd::Foorm
           questions: questions,
           single_workshop: rollup[key],
           overall_facilitator: facilitators ? overall_rollup_per_facilitator[key] : {},
-          overall: overall_rollup[key]
+          overall: {}
         }
       end
-      puts "total time: #{Time.now - start_time}"
       result_data
     end
 

--- a/dashboard/test/controllers/api/v1/pd/workshop_survey_foorm_report_controller_test.rb
+++ b/dashboard/test/controllers/api/v1/pd/workshop_survey_foorm_report_controller_test.rb
@@ -144,12 +144,6 @@ module Api::V1::Pd
       assert_response :success
       response = JSON.parse(@response.body, symbolize_names: true)
 
-      overall_rollup_general = response[:workshop_rollups][:general][:overall]
-      assert_equal 11, overall_rollup_general[:response_count]
-      assert_equal 5.36, overall_rollup_general[:averages][:teacher_engagement][:rows][:engaging]
-      overall_rollup_facilitator = response[:workshop_rollups][:facilitator][:overall]
-      assert_equal 11, overall_rollup_facilitator[:response_count]
-      assert_equal 5.36, overall_rollup_facilitator[:averages][:facilitator_effectiveness][:rows][:demonstrated_knowledge]
       overall_facilitator_rollup_facilitator = response[:workshop_rollups][:facilitator][:overall_facilitator]
       csf_workshop_1_facilitator = csf_workshop_1.facilitators.pluck(:id).first.to_s.to_sym
       assert_equal 5, overall_facilitator_rollup_facilitator[csf_workshop_1_facilitator][:response_count]


### PR DESCRIPTION
The survey results page is timing out on CS Discoveries results pages. The heaviest operation for the results is doing rollups across all surveys for a given course--when run locally on a small data set, the time difference for including vs not including this calculation was 0.67 seconds to 0.17 seconds. Therefore we are removing this column and calculation from the rollup view to enable the results page. To get this data back we should likely add a nightly cron job to calculate the all-up rollup.

I have kept the logic for calculating and showing the overall rollup in the code, just removed it from the general rollup method and added a flag on the UI side to show or hide the overall column.

I would recommend [viewing with whitespace ignored](https://github.com/code-dot-org/code-dot-org/pull/35793/files?diff=split&w=1), because I removed an if statement in `survey_rollup_table_foorm.jsx` which causes the diff to look much bigger than it is.

<!-- ### Background -->
<!-- ### Privacy -->
<!-- ### Security -->
<!-- ### Caching -->
<!-- ### Deployment strategy -->
<!-- ### Future work -->

## Testing story
I validated that removing the column saves more than 50% of the total runtime. I also validated manually that the results page still shows the other columns correctly.

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
