### PR TITLE
Header: fix progress status

### DIFF
--- a/apps/src/code-studio/components/progress/LessonProgress.jsx
+++ b/apps/src/code-studio/components/progress/LessonProgress.jsx
@@ -104,6 +104,19 @@ class LessonProgress extends Component {
   }
 
   shouldComponentUpdate(nextProps, nextState) {
+    for (
+      let levelIndex = 0;
+      levelIndex < this.props.levels.length;
+      levelIndex++
+    ) {
+      if (
+        this.props.levels[levelIndex].status !==
+        nextProps.levels[levelIndex].status
+      ) {
+        return true;
+      }
+    }
+
     return this.props.width !== nextProps.width;
   }
 


### PR DESCRIPTION
While reviewing Eyes differences for https://github.com/code-dot-org/code-dot-org/pull/34551 I noticed a subtle regression.  It's possible for a level progress bubble to change while viewing a level, for example when an attempt has been made or when the level succeeds.  We were no longer allowing these updates to render, but now they do again.