### PR TITLE
Header: restore popup logging

### DIFF
--- a/apps/src/code-studio/components/header/HeaderPopup.jsx
+++ b/apps/src/code-studio/components/header/HeaderPopup.jsx
@@ -4,6 +4,7 @@ import color from '@cdo/apps/util/color';
 import progress from '../../progress';
 import MiniView from '../progress/MiniView';
 import i18n from '@cdo/locale';
+import firehoseClient from '@cdo/apps/lib/util/firehose';
 
 const styles = {
   container: {
@@ -51,6 +52,17 @@ export default class HeaderPopup extends Component {
       this.props.scriptData,
       this.props.currentLevelId
     );
+
+    firehoseClient.putRecord(
+      {
+        study: 'mini_view',
+        event: 'mini_view_opened',
+        data_json: JSON.stringify({
+          current_level_id: this.props.currentLevelId
+        })
+      },
+      {includeUserId: true}
+    );
   };
 
   handleClickClose = () => {
@@ -64,8 +76,6 @@ export default class HeaderPopup extends Component {
   };
 
   render() {
-    console.log('HeaderPopup render');
-
     return (
       <div style={styles.container}>
         {!this.state.open && (


### PR DESCRIPTION
Restores the logging of MiniView opens that had been added in https://github.com/code-dot-org/code-dot-org/pull/34014 but removed in https://github.com/code-dot-org/code-dot-org/pull/34551.
