### PR TITLE
[Applab Data] Show data entry error above scroll

### DIFF
--- a/apps/src/storage/dataBrowser/DataEntryError.jsx
+++ b/apps/src/storage/dataBrowser/DataEntryError.jsx
@@ -5,12 +5,18 @@ import color from '../../util/color';
 import SafeMarkdown from '../../templates/SafeMarkdown';
 
 const styles = {
+  container: {
+    height: 40,
+    paddingTop: 12
+  },
   visible: {
     background: color.lighter_yellow,
-    padding: '1em'
+    paddingLeft: 12,
+    paddingRight: 12,
+    paddingBottom: 0
   },
-  hidden: {
-    height: '3em'
+  test: {
+    paddingBottom: 8
   }
 };
 
@@ -21,12 +27,14 @@ class DataEntryError extends React.Component {
 
   render() {
     return this.props.isVisible ? (
-      <div style={styles.visible}>
-        <SafeMarkdown markdown={msg.invalidDataEntryTypeError()} />
+      <div style={styles.test}>
+        <div style={{...styles.container, ...styles.visible}}>
+          <SafeMarkdown markdown={msg.invalidDataEntryTypeError()} />
+        </div>
       </div>
     ) : (
       // Blank space so layout stays the same whether or not error is visible.
-      <div style={styles.hidden} />
+      <div style={{...styles.container, ...styles.test}} />
     );
   }
 }

--- a/apps/src/storage/dataBrowser/DataEntryError.jsx
+++ b/apps/src/storage/dataBrowser/DataEntryError.jsx
@@ -15,7 +15,7 @@ const styles = {
     paddingRight: 12,
     paddingBottom: 0
   },
-  test: {
+  bottom: {
     paddingBottom: 8
   }
 };
@@ -27,14 +27,14 @@ class DataEntryError extends React.Component {
 
   render() {
     return this.props.isVisible ? (
-      <div style={styles.test}>
+      <div style={styles.bottom}>
         <div style={{...styles.container, ...styles.visible}}>
           <SafeMarkdown markdown={msg.invalidDataEntryTypeError()} />
         </div>
       </div>
     ) : (
       // Blank space so layout stays the same whether or not error is visible.
-      <div style={{...styles.container, ...styles.test}} />
+      <div style={{...styles.container, ...styles.bottom}} />
     );
   }
 }

--- a/apps/src/storage/dataBrowser/DataTable.jsx
+++ b/apps/src/storage/dataBrowser/DataTable.jsx
@@ -29,11 +29,7 @@ const styles = {
     }
   ],
   table: {
-    minWidth: MIN_TABLE_WIDTH,
-    overflow: 'scroll'
-  },
-  pagination: {
-    overflow: 'auto'
+    minWidth: MIN_TABLE_WIDTH
   },
   plusIcon: {
     alignItems: 'center',
@@ -222,85 +218,78 @@ class DataTable extends React.Component {
     return (
       <div>
         <DataEntryError isVisible={this.state.showError} />
-        {numPages > 1 && (
-          <div style={styles.pagination}>
-            <PaginationWrapper
-              totalPages={numPages}
-              currentPage={this.state.currentPage + 1}
-              onChangePage={this.onChangePageNumber}
-              label={msg.paginationLabel()}
-            />
-          </div>
-        )}
-        <table style={styles.table}>
-          <tbody>
-            <tr>
-              {columnNames.map(columnName => (
-                <ColumnHeader
-                  key={columnName}
-                  coerceColumn={this.coerceColumn}
-                  columnName={columnName}
+        <div style={{overflow: 'auto', height: 'calc(100vh - 300px)'}}>
+          <table style={styles.table}>
+            <tbody>
+              <tr>
+                {columnNames.map(columnName => (
+                  <ColumnHeader
+                    key={columnName}
+                    coerceColumn={this.coerceColumn}
+                    columnName={columnName}
+                    columnNames={columnNames}
+                    deleteColumn={this.deleteColumn}
+                    editColumn={this.editColumn}
+                    /* hide gear icon if an operation is pending on another column */
+                    isEditable={
+                      columnName !== 'id' &&
+                      !(
+                        this.state.pendingColumn &&
+                        this.state.pendingColumn !== columnName
+                      ) &&
+                      !this.state.pendingAdd
+                    }
+                    isEditing={editingColumn === columnName}
+                    isPending={this.state.pendingColumn === columnName}
+                    readOnly={this.props.readOnly}
+                    renameColumn={this.renameColumn}
+                  />
+                ))}
+                {!this.props.readOnly && (
+                  <th style={styles.addColumnHeader}>
+                    {this.state.pendingAdd ? (
+                      <FontAwesome icon="spinner" className="fa-spin" />
+                    ) : (
+                      <FontAwesome
+                        id="addColumnButton"
+                        icon="plus"
+                        style={styles.plusIcon}
+                        onClick={this.addColumn}
+                      />
+                    )}
+                  </th>
+                )}
+                {!this.props.readOnly && (
+                  <th style={dataStyles.headerCell}>Actions</th>
+                )}
+              </tr>
+
+              {!this.props.readOnly && (
+                <AddTableRow
+                  tableName={this.props.tableName}
                   columnNames={columnNames}
-                  deleteColumn={this.deleteColumn}
-                  editColumn={this.editColumn}
-                  /* hide gear icon if an operation is pending on another column */
-                  isEditable={
-                    columnName !== 'id' &&
-                    !(
-                      this.state.pendingColumn &&
-                      this.state.pendingColumn !== columnName
-                    ) &&
-                    !this.state.pendingAdd
-                  }
-                  isEditing={editingColumn === columnName}
-                  isPending={this.state.pendingColumn === columnName}
+                  showError={this.showError}
+                  hideError={this.hideError}
+                />
+              )}
+
+              {Object.keys(rows).map(id => (
+                <EditTableRow
+                  columnNames={columnNames}
+                  tableName={this.props.tableName}
+                  record={JSON.parse(rows[id])}
+                  key={id}
                   readOnly={this.props.readOnly}
-                  renameColumn={this.renameColumn}
+                  showError={this.showError}
+                  hideError={this.hideError}
                 />
               ))}
-              {!this.props.readOnly && (
-                <th style={styles.addColumnHeader}>
-                  {this.state.pendingAdd ? (
-                    <FontAwesome icon="spinner" className="fa-spin" />
-                  ) : (
-                    <FontAwesome
-                      id="addColumnButton"
-                      icon="plus"
-                      style={styles.plusIcon}
-                      onClick={this.addColumn}
-                    />
-                  )}
-                </th>
-              )}
-              {!this.props.readOnly && (
-                <th style={dataStyles.headerCell}>Actions</th>
-              )}
-            </tr>
+            </tbody>
+          </table>
+        </div>
 
-            {!this.props.readOnly && (
-              <AddTableRow
-                tableName={this.props.tableName}
-                columnNames={columnNames}
-                showError={this.showError}
-                hideError={this.hideError}
-              />
-            )}
-
-            {Object.keys(rows).map(id => (
-              <EditTableRow
-                columnNames={columnNames}
-                tableName={this.props.tableName}
-                record={JSON.parse(rows[id])}
-                key={id}
-                readOnly={this.props.readOnly}
-                showError={this.showError}
-                hideError={this.hideError}
-              />
-            ))}
-          </tbody>
-        </table>
         {numPages > 1 && (
-          <div style={styles.pagination}>
+          <div>
             <PaginationWrapper
               totalPages={numPages}
               currentPage={this.state.currentPage + 1}

--- a/apps/src/storage/dataBrowser/DataTableView.jsx
+++ b/apps/src/storage/dataBrowser/DataTableView.jsx
@@ -173,11 +173,7 @@ class DataTableView extends React.Component {
           readOnly={readOnly}
         />
         <div style={debugDataStyle}>{this.getTableJson()}</div>
-        {!this.state.showDebugView && (
-          <div style={{overflow: 'auto'}}>
-            <DataTable readOnly={readOnly} />
-          </div>
-        )}
+        {!this.state.showDebugView && <DataTable readOnly={readOnly} />}
       </div>
     );
   }


### PR DESCRIPTION
This PR makes just the table scroll, so that you can still see the pagination control and the data entry error message if you're scrolled halfway down the page. 
Before:
![image](https://user-images.githubusercontent.com/8787187/87471209-d5438f00-c5d2-11ea-8ba1-eb56888f2022.png)

After:
![image](https://user-images.githubusercontent.com/8787187/87471252-e5f40500-c5d2-11ea-95b5-630d3d9b7189.png)

<!--
  Other aspects to consider. uncomment and add detail for any that seem necessary:
-->

<!-- ### Background -->
<!-- ### Privacy -->
<!-- ### Security -->
<!-- ### Caching -->
<!-- ### Deployment strategy -->
<!-- ### Future work -->

## Links

<!--
  Any relevant links to external resources; ie, specification documents, jira
  items, related PRs, honeybadger errors, etc
-->

- [jira](https://codedotorg.atlassian.net/browse/STAR-1121)

## Testing story

<!--
  Does your change include appropriate tests?

  If so, please describe how the tests included in this PR are sufficient

  If not, please explain why this change does not need to be tested.
-->

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
