### PR TITLE
[Data Viz] Prevent buttons from overflowing modal

### DIFF
--- a/apps/src/storage/dataBrowser/dataVisualizer/Snapshot.jsx
+++ b/apps/src/storage/dataBrowser/dataVisualizer/Snapshot.jsx
@@ -136,7 +136,7 @@ class Snapshot extends React.Component {
         >
           <div ref="snapshot">
             <h1>{this.props.chartTitle}</h1>
-            <img src={this.state.imageSrc} />
+            <img style={{maxHeight: '50vh'}} src={this.state.imageSrc} />
             <p>
               {msg.dataVisualizerSnapshotDescription({
                 date: moment().format('YYYY/MM/DD'),


### PR DESCRIPTION
This only happens if you resize the window after the snapshot modal is opened, but either way, we want to make sure everything stays nicely contained inside the modal. 
Before:
![image](https://user-images.githubusercontent.com/8787187/87472886-864b2900-c5d5-11ea-8d29-8b51fd20aea4.png)

After:
![image](https://user-images.githubusercontent.com/8787187/87472973-a4188e00-c5d5-11ea-9d8a-7d78a92287dc.png)


<!--
  Other aspects to consider. uncomment and add detail for any that seem necessary:
-->

<!-- ### Background -->
<!-- ### Privacy -->
<!-- ### Security -->
<!-- ### Caching -->
<!-- ### Deployment strategy -->
<!-- ### Future work -->

## Links

<!--
  Any relevant links to external resources; ie, specification documents, jira
  items, related PRs, honeybadger errors, etc
-->

- [jira](https://codedotorg.atlassian.net/browse/STAR-1123)

## Testing story

<!--
  Does your change include appropriate tests?

  If so, please describe how the tests included in this PR are sufficient

  If not, please explain why this change does not need to be tested.
-->

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
