### PR TITLE
[Spritelab] New Blocks

### DIFF
--- a/apps/src/p5lab/spritelab/commands.js
+++ b/apps/src/p5lab/spritelab/commands.js
@@ -190,6 +190,10 @@ export const commands = {
     worldCommands.comment(text);
   },
 
+  getTime(unit) {
+    return worldCommands.getTime.apply(this, [unit]);
+  },
+
   hideTitleScreen() {
     worldCommands.hideTitleScreen();
   },

--- a/apps/src/p5lab/spritelab/commands.js
+++ b/apps/src/p5lab/spritelab/commands.js
@@ -147,8 +147,10 @@ export const commands = {
   },
 
   // Sprite commands
-  countByAnimation(animation) {
-    return spriteCommands.countByAnimation(animation);
+  countByAnimation(spriteArg) {
+    if (spriteArg.costume) {
+      return spriteCommands.countByAnimation(spriteArg.costume);
+    }
   },
 
   createNewSprite(name, animation, location) {

--- a/apps/src/p5lab/spritelab/commands/worldCommands.js
+++ b/apps/src/p5lab/spritelab/commands/worldCommands.js
@@ -7,6 +7,15 @@ export const commands = {
     /* no-op */
   },
 
+  getTime(unit) {
+    if (unit === 'seconds') {
+      return this.World.seconds || 0;
+    } else if (unit === 'frames') {
+      return this.World.frameCount || 0;
+    }
+    return 0;
+  },
+
   hideTitleScreen() {
     coreLibrary.title = coreLibrary.subtitle = '';
   },

--- a/apps/src/p5lab/spritelab/coreLibrary.js
+++ b/apps/src/p5lab/spritelab/coreLibrary.js
@@ -41,9 +41,13 @@ export function getSpriteArray(spriteArg) {
     }
   }
   if (spriteArg.costume) {
-    return Object.values(nativeSpriteMap).filter(
-      sprite => sprite.getAnimationLabel() === spriteArg.costume
-    );
+    if (spriteArg.costume === 'all') {
+      return Object.values(nativeSpriteMap);
+    } else {
+      return Object.values(nativeSpriteMap).filter(
+        sprite => sprite.getAnimationLabel() === spriteArg.costume
+      );
+    }
   }
   return [];
 }

--- a/dashboard/config/blocks/GamelabJr/gamelab_countByAnimation.json
+++ b/dashboard/config/blocks/GamelabJr/gamelab_countByAnimation.json
@@ -1,0 +1,14 @@
+{
+  "category": "Sprites",
+  "config": {
+    "func": "countByAnimation",
+    "blockText": "number of {SPRITE}",
+    "returnType": "Number",
+    "args": [
+      {
+        "name": "SPRITE",
+        "type": "Sprite"
+      }
+    ]
+  }
+}

--- a/dashboard/config/blocks/GamelabJr/gamelab_getAllSprites.json
+++ b/dashboard/config/blocks/GamelabJr/gamelab_getAllSprites.json
@@ -1,0 +1,18 @@
+{
+  "category": "Sprites",
+  "config": {
+    "name": "getAllSprites",
+    "expression": "{costume: \"all\"}",
+    "inline": false,
+    "blockText": "all sprites",
+    "returnType": "Sprite",
+    "color": [
+      355,
+      ".7",
+      ".7"
+    ],
+    "args": [
+
+    ]
+  }
+}

--- a/dashboard/config/blocks/GamelabJr/gamelab_getTime.json
+++ b/dashboard/config/blocks/GamelabJr/gamelab_getTime.json
@@ -1,0 +1,23 @@
+{
+  "category": "World",
+  "config": {
+    "func": "getTime",
+    "blockText": "time in {UNIT}",
+    "returnType": "Number",
+    "args": [
+      {
+        "name": "UNIT",
+        "options": [
+          [
+            "seconds",
+            "\"seconds\""
+          ],
+          [
+            "frames",
+            "\"frames\""
+          ]
+        ]
+      }
+    ]
+  }
+}

--- a/dashboard/config/libraries/NativeSpriteLab.interpreted.js
+++ b/dashboard/config/libraries/NativeSpriteLab.interpreted.js
@@ -249,7 +249,7 @@ function setupSim(
   addBehaviorSimple({id: 0}, new Behavior(collectBehavior));
 
   function checkSimulationEnd() {
-    if (countByAnimation(s3costume) === 0) {
+    if (countByAnimation({costume: s3costume}) === 0) {
       destroy({costume: s1costume});
       destroy({costume: s2costume});
       printText('The simulation has ended after ' + World.seconds + ' seconds');


### PR DESCRIPTION
Some easy wins for raising the ceiling and lowering the floor in Sprite Lab based on conversations with Mike Harvey.

### all sprites
Generates the code `{costume: "all"}`, which in the core library will effectively return the list of all sprites.
![image](https://user-images.githubusercontent.com/8787187/87486981-5ad63780-c5f1-11ea-97fd-9322035e2df7.png)

![image](https://user-images.githubusercontent.com/8787187/87486869-1cd91380-c5f1-11ea-95be-6e7a32874b43.png)
![image](https://user-images.githubusercontent.com/8787187/87486910-337f6a80-c5f1-11ea-9f8d-1d2716d7d9d7.png)

### count by animation
Returns the number of sprites with the given animation
![image](https://user-images.githubusercontent.com/8787187/87487010-675a9000-c5f1-11ea-96a2-a56e6897a111.png)

![image](https://user-images.githubusercontent.com/8787187/87486776-e26f7680-c5f0-11ea-8ba0-79fda938f5d5.png)
![image](https://user-images.githubusercontent.com/8787187/87486893-2a8e9900-c5f1-11ea-81c3-7081a173e6e7.png)


### get time in seconds/frames
Returns the elapsed time, in either seconds or frames.
![image](https://user-images.githubusercontent.com/8787187/87487025-75101580-c5f1-11ea-9f49-66abb1a780f8.png)

![image](https://user-images.githubusercontent.com/8787187/87486930-3c703c00-c5f1-11ea-8181-5ea177544f54.png)

This PR also includes a small change in `NativeSpriteLab.interpreted.js` because the `setupSim` function had previously been using the `countByAnimation` function, and this changes that API slightly (`countByAnimation("bear")` => `countByAnimation({costume: "bear"})`).