### PR TITLE
[Spritelab] atTime block

### DIFF
--- a/apps/src/p5lab/spritelab/commands.js
+++ b/apps/src/p5lab/spritelab/commands.js
@@ -117,6 +117,10 @@ export const commands = {
   },
 
   // Event commands
+  atTime(n, unit, callback) {
+    eventCommands.atTime(n, unit, callback);
+  },
+
   checkTouching(condition, sprite1, sprite2, callback) {
     eventCommands.checkTouching(condition, sprite1, sprite2, callback);
   },

--- a/apps/src/p5lab/spritelab/commands/eventCommands.js
+++ b/apps/src/p5lab/spritelab/commands/eventCommands.js
@@ -1,6 +1,10 @@
 import * as coreLibrary from '../coreLibrary';
 
 export const commands = {
+  atTime(n, unit, callback) {
+    coreLibrary.addEvent('atTime', {n, unit}, callback);
+  },
+
   checkTouching(condition, sprite1, sprite2, callback) {
     if (condition === 'when' || condition === 'while') {
       coreLibrary.addEvent(

--- a/apps/src/p5lab/spritelab/coreLibrary.js
+++ b/apps/src/p5lab/spritelab/coreLibrary.js
@@ -149,6 +149,29 @@ export function addEvent(type, args, callback) {
   inputEvents.push({type: type, args: args, callback: callback});
 }
 
+function atTimeEvent(inputEvent, p5Inst) {
+  if (inputEvent.args.unit === 'seconds') {
+    const previousTime = inputEvent.previousTime || 0;
+    inputEvent.previousTime = p5Inst.World.seconds;
+    // There are many ticks per second, but we only want to fire the event once (on the first tick where
+    // World.seconds matches the event argument)
+    if (
+      p5Inst.World.seconds === inputEvent.args.n &&
+      previousTime !== inputEvent.args.n
+    ) {
+      // Call callback with no extra args
+      return [{}];
+    }
+  } else if (inputEvent.args.unit === 'frames') {
+    if (p5Inst.frameCount === inputEvent.args.n) {
+      // Call callback with no extra args
+      return [{}];
+    }
+  }
+  // Don't call callback
+  return [];
+}
+
 function whenPressEvent(inputEvent, p5Inst) {
   if (p5Inst.keyWentDown(inputEvent.args.key)) {
     // Call callback with no extra args
@@ -263,6 +286,8 @@ function whileClickEvent(inputEvent, p5Inst) {
 
 function checkEvent(inputEvent, p5Inst) {
   switch (inputEvent.type) {
+    case 'atTime':
+      return atTimeEvent(inputEvent, p5Inst);
     case 'whenpress':
       return whenPressEvent(inputEvent, p5Inst);
     case 'whilepress':

--- a/dashboard/config/blocks/GamelabJr/gamelab_atTime.json
+++ b/dashboard/config/blocks/GamelabJr/gamelab_atTime.json
@@ -1,0 +1,35 @@
+{
+  "category": "Events",
+  "config": {
+    "color": [
+      140,
+      1,
+      0.74
+    ],
+    "func": "atTime",
+    "blockText": "at {N} {UNIT}",
+    "callbackParams": [
+      "extraArgs"
+    ],
+    "args": [
+      {
+        "name": "N",
+        "type": "Number"
+      },
+      {
+        "name": "UNIT",
+        "options": [
+          [
+            "seconds",
+            "\"seconds\""
+          ],
+          [
+            "frames",
+            "\"frames\""
+          ]
+        ]
+      }
+    ],
+    "eventBlock": true
+  }
+}


### PR DESCRIPTION
Another low-lift new block to raise the ceiling in Sprite Lab- a time-based event using either frames or seconds
![image](https://user-images.githubusercontent.com/8787187/87575785-493e6f80-c685-11ea-8943-a34f264ca0c9.png)
![image](https://user-images.githubusercontent.com/8787187/87575818-59564f00-c685-11ea-8470-d2f1a9b3a6ba.png)
![image](https://user-images.githubusercontent.com/8787187/87575878-6bd08880-c685-11ea-99e3-1effa8079844.png)


<!-- ### Background -->
<!-- ### Privacy -->
<!-- ### Security -->
<!-- ### Caching -->
<!-- ### Deployment strategy -->
<!-- ### Future work -->

## Links
## Testing story

<!--
  Does your change include appropriate tests?

  If so, please describe how the tests included in this PR are sufficient

  If not, please explain why this change does not need to be tested.
-->

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
