### PR TITLE
Update self-hosted geocoder service

### DIFF
--- a/aws/cloudformation/geocoder.yml
+++ b/aws/cloudformation/geocoder.yml
@@ -175,8 +175,8 @@ Resources:
             Metric:
               Dimensions:
                 - Name: LoadBalancer
-                  Value: !Ref EcsElasticLoadBalancer
-              MetricName: RequestCount
+                  Value: 'app/ELB-geocoder/a026f133b72798cd'
+              MetricName: NewConnectionCount
               Namespace: 'AWS/ApplicationELB'
             Period: 300
             Stat: Sum
@@ -188,7 +188,7 @@ Resources:
             Metric:
               Dimensions:
                 - Name: LoadBalancer
-                  Value: !Ref EcsElasticLoadBalancer
+                  Value: 'app/ELB-geocoder/a026f133b72798cd'
               MetricName: HTTPCode_Target_5XX_Count
               Namespace: 'AWS/ApplicationELB'
             Period: 300
@@ -201,7 +201,7 @@ Resources:
             Metric:
               Dimensions:
                 - Name: LoadBalancer
-                  Value: !Ref EcsElasticLoadBalancer
+                  Value: 'app/ELB-geocoder/a026f133b72798cd'
               MetricName: HTTPCode_ELB_5XX_Count
               Namespace: 'AWS/ApplicationELB'
             Period: 300

--- a/aws/cloudformation/geocoder.yml
+++ b/aws/cloudformation/geocoder.yml
@@ -125,7 +125,7 @@ Resources:
       ContainerDefinitions:
       - Name: freegeoip
         Essential: true
-        Image: !Sub "${AWS::AccountId}.dkr.ecr.${AWS::Region}.amazonaws.com/freegeoip:latest"
+        Image: !Sub "${AWS::AccountId}.dkr.ecr.${AWS::Region}.amazonaws.com/vgeoip:latest"
         MemoryReservation: 512
         LogConfiguration:
           LogDriver: awslogs

--- a/aws/cloudformation/geocoder.yml
+++ b/aws/cloudformation/geocoder.yml
@@ -160,6 +160,61 @@ Resources:
             - !ImportValue VPC-SubnetB
             - !ImportValue VPC-SubnetC
       TaskDefinition: !Ref FreegeoipTaskDefinition
+  HTTPErrorRateAlarm:
+    Type: "AWS::CloudWatch::Alarm"
+    Properties:
+      AlarmActions:
+        - !Sub "arn:aws:sns:${AWS::Region}:${AWS::AccountId}:CDO-LowPriority"
+      AlarmDescription: Send low priority page if percent HTTP requests to geocoder service exceeds 5%
+      AlarmName: production_geocoder_http_error_rate
+      ComparisonOperator: GreaterThanThreshold
+      Metrics:
+        - Id: total
+          Label: RequestCount
+          MetricStat:
+            Metric:
+              Dimensions:
+                - Name: LoadBalancer
+                  Value: !Ref EcsElasticLoadBalancer
+              MetricName: RequestCount
+              Namespace: 'AWS/ApplicationELB'
+            Period: 300
+            Stat: Sum
+            Unit: Count
+          ReturnData: false
+        - Id: target_fail
+          Label: HTTPCode_Target_5XX_Count
+          MetricStat:
+            Metric:
+              Dimensions:
+                - Name: LoadBalancer
+                  Value: !Ref EcsElasticLoadBalancer
+              MetricName: HTTPCode_Target_5XX_Count
+              Namespace: 'AWS/ApplicationELB'
+            Period: 300
+            Stat: Sum
+            Unit: Count
+          ReturnData: false
+        - Id: elb_fail
+          Label: HTTPCode_ELB_5XX_Count
+          MetricStat:
+            Metric:
+              Dimensions:
+                - Name: LoadBalancer
+                  Value: !Ref EcsElasticLoadBalancer
+              MetricName: HTTPCode_ELB_5XX_Count
+              Namespace: 'AWS/ApplicationELB'
+            Period: 300
+            Stat: Sum
+            Unit: Count
+          ReturnData: false
+        - Id: fail_rate
+          Label: Percent Request Failure
+          Expression: '100*(elb_fail+target_fail)/total'
+          ReturnData: true
+      EvaluationPeriods: 5
+      Threshold: 5
+      TreatMissingData: missing
 Outputs:
   EcsService:
     Value: !Ref FreegeoipService

--- a/aws/cloudformation/geocoder.yml
+++ b/aws/cloudformation/geocoder.yml
@@ -125,6 +125,9 @@ Resources:
       ContainerDefinitions:
       - Name: freegeoip
         Essential: true
+        # Image was built from https://github.com/voyagin/freegeoip and contains our free MaxMind License Key.
+        # A copy of the key is stored in AWS Secrets Manager, and credentials to login to the MaxMind web console
+        # to provision a new key are shared securely within the organization.
         Image: !Sub "${AWS::AccountId}.dkr.ecr.${AWS::Region}.amazonaws.com/vgeoip:latest"
         MemoryReservation: 512
         LogConfiguration:

--- a/config.yml.erb
+++ b/config.yml.erb
@@ -252,9 +252,6 @@ afe_pardot_form_handler_url:
 csta_jotform_api_key: !Secret
 csta_jotform_form_id: !Secret
 
-# MaxMind License Key to access GeoLite2 database
-maxmind_license_key: !Secret
-
 ### Service configurations (urls, endpoints, etc)
 
 freegeoip_host:

--- a/config.yml.erb
+++ b/config.yml.erb
@@ -252,6 +252,9 @@ afe_pardot_form_handler_url:
 csta_jotform_api_key: !Secret
 csta_jotform_form_id: !Secret
 
+# MaxMind License Key to access GeoLite2 database
+maxmind_license_key: !Secret
+
 ### Service configurations (urls, endpoints, etc)
 
 freegeoip_host:


### PR DESCRIPTION
Update self-hosted geocoder service, which stopped working on July 8, 2020.
https://codedotorg.atlassian.net/browse/FND-1235

### Deployment strategy

1. Build a Docker image with our MaxMind License Key embedded in it [using a fork](https://github.com/voyagin/freegeoip) of the freegeoip repository.
2. Push that image to our private AWS Container Repository
3. Update our geocoder stack with the modified template in this Pull Request, referencing the forked freegeoip image.

### Future work

Backfill location data not set correctly due to our geocoder service being disabled.
Update geocoder template to include an alarm on the percentage of failed requests sent to this service via the load balancer.



## Testing story



# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
