### PR TITLE
make LevelGroup use child_levels relationship with its sublevels

### DIFF
--- a/dashboard/app/dsl/level_group_dsl.rb
+++ b/dashboard/app/dsl/level_group_dsl.rb
@@ -6,8 +6,8 @@ class LevelGroupDSL < LevelDSL
     @description_short = nil
     @description = nil
     @hash[:options] = {skip_dialog: true, skip_sound: true}
-    @current_page_level_names = []
-    @level_names = []
+    @current_page_level_and_text_names = []
+    @level_and_text_names = []
     @pages = []
   end
 
@@ -33,16 +33,16 @@ class LevelGroupDSL < LevelDSL
   def title(text) @hash[:title] = text end
 
   def page
-    @current_page_level_names = []
-    @pages << {levels: @current_page_level_names}
+    @current_page_level_and_text_names = []
+    @pages << {levels: @current_page_level_and_text_names}
   end
 
   def text(name)
     # Ensure level name hasn't already been used.
-    if @level_names.include? name
+    if @level_and_text_names.include? name
       raise "Don't use the same level twice in a LevelGroup (#{name})."
     end
-    @level_names << name
+    @level_and_text_names << name
 
     # Ensure level is appropriate type.
     level = Script.cache_find_level(name)
@@ -54,15 +54,15 @@ class LevelGroupDSL < LevelDSL
       raise "LevelGroup text must be a level of type external. (#{name})"
     end
 
-    @current_page_level_names << name
+    @current_page_level_and_text_names << name
   end
 
   def level(name)
     # Ensure level name hasn't already been used.
-    if @level_names.include? name
+    if @level_and_text_names.include? name
       raise "Don't use the same level twice in a LevelGroup (#{name})."
     end
-    @level_names << name
+    @level_and_text_names << name
 
     # Ensure level is appropriate type.
     level = Level.where(name: name).first # For some reason find_by_name doesn't always work here!
@@ -77,7 +77,7 @@ class LevelGroupDSL < LevelDSL
       raise "LevelGroup cannot contain level type #{level_class}"
     end
 
-    @current_page_level_names << name
+    @current_page_level_and_text_names << name
   end
 
   def submittable(text)

--- a/dashboard/app/dsl/level_group_dsl.rb
+++ b/dashboard/app/dsl/level_group_dsl.rb
@@ -5,7 +5,6 @@ class LevelGroupDSL < LevelDSL
     @title = nil
     @description_short = nil
     @description = nil
-    @hash[:texts] = []
     @hash[:options] = {skip_dialog: true, skip_sound: true}
     @current_page_level_names = []
     @level_names = []
@@ -49,9 +48,7 @@ class LevelGroupDSL < LevelDSL
       raise "LevelGroup text must be a level of type external. (#{name})"
     end
 
-    # Record the name of the external level, as well as the index of the actual level
-    # it appears immediately before.
-    @hash[:texts] << {level_name: name, index: @level_names.length}
+    @current_page_level_names << name
   end
 
   def level(name)
@@ -95,14 +92,11 @@ class LevelGroupDSL < LevelDSL
     new_dsl << "\nsubmittable '#{properties['submittable']}'" if properties['submittable']
     new_dsl << "\nanonymous '#{properties['anonymous']}'" if properties['anonymous']
 
-    texts = properties['texts'] || []
     level.pages.each do |page|
       new_dsl << "\n\npage"
-      page.levels.each_with_index do |sublevel, index|
-        texts.select {|text| text['index'] == page.offset + index}.each do |text|
-          new_dsl << "\ntext '#{text['level_name']}'"
-        end
-        new_dsl << "\nlevel '#{sublevel.name}'"
+      page.levels_and_texts.each do |sublevel|
+        command = sublevel.is_a?(External) ? 'text' : 'level'
+        new_dsl << "\n#{command} '#{sublevel.name}'"
       end
     end
     new_dsl

--- a/dashboard/app/dsl/level_group_dsl.rb
+++ b/dashboard/app/dsl/level_group_dsl.rb
@@ -38,6 +38,12 @@ class LevelGroupDSL < LevelDSL
   end
 
   def text(name)
+    # Ensure level name hasn't already been used.
+    if @level_names.include? name
+      raise "Don't use the same level twice in a LevelGroup (#{name})."
+    end
+    @level_names << name
+
     # Ensure level is appropriate type.
     level = Script.cache_find_level(name)
     if level.nil?

--- a/dashboard/app/models/levels/level_group.rb
+++ b/dashboard/app/models/levels/level_group.rb
@@ -108,10 +108,6 @@ class LevelGroup < DSLDefined
   def self.setup(data)
     level = super(data)
 
-    # old way: store pages in property hash
-    level.update!(properties: {pages: data[:pages]})
-
-    # new way: store pages in levels_and_texts_per_page and child_levels.
     levels_and_texts_by_page = data[:pages].map do |page|
       page[:levels].map do |level_name|
         Level.find_by_name!(level_name)

--- a/dashboard/app/models/levels/level_group.rb
+++ b/dashboard/app/models/levels/level_group.rb
@@ -89,6 +89,16 @@ class LevelGroup < DSLDefined
   #   levels_offset: the count of levels on prior pages.
   #   levels: an array of levels on this page.
   #   texts: an array of texts on this page.
+  #
+  # In this context, a "level" is a Level object of one of the following types:
+  #   multi match text_match free_response evaluation_multi
+  # These "levels" contain questions which the end user can answer.
+  #
+  # A "text" is a Level object of type external. These show text on
+  # the page but do not accept an answer and are excluded from numbering.
+  #
+  # Under the hood, "levels" and "texts" are both referred to as "sublevels",
+  # which live in the parent_levels_child_levels table.
 
   def pages
     levels_and_texts_offset = 0

--- a/dashboard/app/views/levels/_level_group.haml
+++ b/dashboard/app/views/levels/_level_group.haml
@@ -23,19 +23,20 @@
       #survey-submission-thankyou
         = I18n.t('level_group.survey_submission_thankyou')
 
-    - page.levels_and_texts.each_with_index do |level, index|
+    - page.levels_and_texts.each do |level|
       - level_class = level.class.to_s.underscore
       - if level_class == 'external'
         -# Show any text from an external level.
         .level-group-content
           = render partial: 'levels/external', locals: {in_level_group: true, level: level}
       - else
+        - level_index = page.levels.find_index(level)
         -# Don't show last attempt for submitted surveys, even for the current user, otherwise teachers
         -# could access student responses
         - sublevel_last_attempt = LevelGroup.get_sublevel_last_attempt(current_user, @user, level, @script) unless submitted_survey
 
         -# Embed the multi/match/free_response level.
-        .level-group-number= "#{page.levels_offset + index + 1}. "
+        .level-group-number= "#{page.levels_offset + level_index + 1}. "
         .level-group-content
           - if ['multi', 'evaluation_multi'].include? level_class
             = render partial: 'levels/single_multi', locals: {standalone: false, level: level, last_attempt: sublevel_last_attempt, tight_layout: true}

--- a/dashboard/app/views/levels/_level_group.haml
+++ b/dashboard/app/views/levels/_level_group.haml
@@ -23,35 +23,31 @@
       #survey-submission-thankyou
         = I18n.t('level_group.survey_submission_thankyou')
 
-    - page.levels.each_with_index do |level, index|
-      -# Don't show last attempt for submitted surveys, even for the current user, otherwise teachers
-      -# could access student responses
-      - sublevel_last_attempt = LevelGroup.get_sublevel_last_attempt(current_user, @user, level, @script) unless submitted_survey
-
-      -# Show any text from an external level.
-      - if data["texts"]
-        - data["texts"].select {|text| text["index"] == page.offset + index}.each do |text_level_info|
-          - text_level = Script.cache_find_level(text_level_info["level_name"])
-          .level-group-content
-            = render partial: 'levels/external', locals: {in_level_group: true, level: text_level}
-
-      -# Embed the multi/match/free_response level.
-
+    - page.levels_and_texts.each_with_index do |level, index|
       - level_class = level.class.to_s.underscore
+      - if level_class == 'external'
+        -# Show any text from an external level.
+        .level-group-content
+          = render partial: 'levels/external', locals: {in_level_group: true, level: level}
+      - else
+        -# Don't show last attempt for submitted surveys, even for the current user, otherwise teachers
+        -# could access student responses
+        - sublevel_last_attempt = LevelGroup.get_sublevel_last_attempt(current_user, @user, level, @script) unless submitted_survey
 
-      .level-group-number= "#{page.offset + index + 1}. "
-      .level-group-content
-        - if ['multi', 'evaluation_multi'].include? level_class
-          = render partial: 'levels/single_multi', locals: {standalone: false, level: level, last_attempt: sublevel_last_attempt, tight_layout: true}
-        - elsif level_class == "text_match"
-          -# For students (or teachers doing PD), clear out all answers.
-          - unless Policies::InlineAnswer.visible?(current_user, @script_level)
-            - level.properties['answers'] = nil
-          = render partial: 'levels/single_text_match', locals: {standalone: false, level: level, last_attempt: sublevel_last_attempt }
-        - elsif level_class == "free_response"
-          = render partial: 'levels/free_response', locals: {in_level_group: true, level: level, last_attempt: sublevel_last_attempt}
-        - elsif level_class == "match"
-          = render partial: 'levels/single_match', locals: {standalone: false, level: level, last_attempt: sublevel_last_attempt}
+        -# Embed the multi/match/free_response level.
+        .level-group-number= "#{page.levels_offset + index + 1}. "
+        .level-group-content
+          - if ['multi', 'evaluation_multi'].include? level_class
+            = render partial: 'levels/single_multi', locals: {standalone: false, level: level, last_attempt: sublevel_last_attempt, tight_layout: true}
+          - elsif level_class == "text_match"
+            -# For students (or teachers doing PD), clear out all answers.
+            - unless Policies::InlineAnswer.visible?(current_user, @script_level)
+              - level.properties['answers'] = nil
+            = render partial: 'levels/single_text_match', locals: {standalone: false, level: level, last_attempt: sublevel_last_attempt }
+          - elsif level_class == "free_response"
+            = render partial: 'levels/free_response', locals: {in_level_group: true, level: level, last_attempt: sublevel_last_attempt}
+          - elsif level_class == "match"
+            = render partial: 'levels/single_match', locals: {standalone: false, level: level, last_attempt: sublevel_last_attempt}
 
     - unless @script_level.nil?
       = render partial: 'levels/dialog', locals: {app: app, previous_button: page.page_number > 1, next_button: page.page_number < @total_page_count}

--- a/dashboard/config/scripts/csp_assessment_hex_interstitial_copy.external
+++ b/dashboard/config/scripts/csp_assessment_hex_interstitial_copy.external
@@ -1,0 +1,17 @@
+name 'CSP assessment Hex interstitial copy'
+title 'Hexadecimal'
+description 'description here'
+href 'path/to/html/in/asset/folder'
+markdown <<MARKDOWN
+The next question refers to *hexadecimal* which is a base-16 number system - a number system that uses one of 16 possible digits for each place value.  You may not have explicitly covered hexadecimal in your class yet, that's okay.  Consider this a challenge question and try your best using your intuition about what you already know.
+
+
+The 16 digits used in hexadecimal are: **0 1 2 3 4 5 6 7 8 9 A B C D E F**.  These represent the decimal values 0-15, respectively.  Hex is just another number system so, for example the value "fourteen" can be represented in  Decimal, Binary and Hexadecimal like so:
+
+<pre>
+    Decimal: 14
+     Binary: 1110
+Hexadecimal: E
+</pre>
+
+MARKDOWN

--- a/dashboard/config/scripts/csp_unit_1_ch1_cumulative_assessment_mc_group.level_group
+++ b/dashboard/config/scripts/csp_unit_1_ch1_cumulative_assessment_mc_group.level_group
@@ -16,7 +16,7 @@ page
 level 'CSPFinal_Question_1'
 level 'CSPFinal_Question_2'
 level 'CSP Unit 1 Ch 1 MC bits to make 512'
-text 'CSP assessment Hex interstitial'
+text 'CSP assessment Hex interstitial copy'
 level 'CB_Question_3'
 level 'CB_Question_1'
 

--- a/dashboard/test/factories/factories.rb
+++ b/dashboard/test/factories/factories.rb
@@ -863,8 +863,8 @@ FactoryGirl.define do
     # create real sublevels, and update pages to match.
     trait :with_sublevels do
       after(:create) do |lg|
-        pages = [[create(:sublevel), create(:sublevel)], [create(:sublevel)]]
-        lg.update_pages(pages)
+        levels_by_page = [[create(:sublevel), create(:sublevel)], [create(:sublevel)]]
+        lg.update_levels_by_page(levels_by_page)
       end
     end
   end

--- a/dashboard/test/factories/factories.rb
+++ b/dashboard/test/factories/factories.rb
@@ -863,11 +863,8 @@ FactoryGirl.define do
     # create real sublevels, and update pages to match.
     trait :with_sublevels do
       after(:create) do |lg|
-        sublevels = [create(:sublevel), create(:sublevel), create(:sublevel)]
-        lg.properties['pages'] = [
-          {levels: [sublevels[0].name, sublevels[1].name]},
-          {levels: [sublevels[2].name]}
-        ]
+        pages = [[create(:sublevel), create(:sublevel)], [create(:sublevel)]]
+        lg.update_pages(pages)
       end
     end
   end

--- a/dashboard/test/factories/factories.rb
+++ b/dashboard/test/factories/factories.rb
@@ -863,8 +863,8 @@ FactoryGirl.define do
     # create real sublevels, and update pages to match.
     trait :with_sublevels do
       after(:create) do |lg|
-        levels_by_page = [[create(:sublevel), create(:sublevel)], [create(:sublevel)]]
-        lg.update_levels_by_page(levels_by_page)
+        levels_and_texts_by_page = [[create(:sublevel), create(:sublevel)], [create(:sublevel)]]
+        lg.update_levels_and_texts_by_page(levels_and_texts_by_page)
       end
     end
   end

--- a/dashboard/test/models/level_group_test.rb
+++ b/dashboard/test/models/level_group_test.rb
@@ -76,10 +76,13 @@ MARKDOWN
     # Validate the page offsets and page_numbers.
     pages = level_group.pages
     assert_equal 'Long Assessment', level_group.properties['title']
+    assert_equal pages[0].levels_and_texts_offset, 0
     assert_equal pages[0].levels_offset, 0
     assert_equal pages[0].page_number, 1
+    assert_equal pages[1].levels_and_texts_offset, 3
     assert_equal pages[1].levels_offset, 3
     assert_equal pages[1].page_number, 2
+    assert_equal pages[2].levels_and_texts_offset, 6
     assert_equal pages[2].levels_offset, 5
     assert_equal pages[2].page_number, 3
   end

--- a/dashboard/test/models/level_group_test.rb
+++ b/dashboard/test/models/level_group_test.rb
@@ -76,16 +76,12 @@ MARKDOWN
     # Validate the page offsets and page_numbers.
     pages = level_group.pages
     assert_equal 'Long Assessment', level_group.properties['title']
-    assert_equal pages[0].offset, 0
+    assert_equal pages[0].levels_offset, 0
     assert_equal pages[0].page_number, 1
-    assert_equal pages[1].offset, 3
+    assert_equal pages[1].levels_offset, 3
     assert_equal pages[1].page_number, 2
-    assert_equal pages[2].offset, 5
+    assert_equal pages[2].levels_offset, 5
     assert_equal pages[2].page_number, 3
-
-    # Validate the text index.
-    texts = level_group.properties["texts"]
-    assert_equal texts[0]["index"], 4
   end
 
   # Test that a level_group can't be created if it has duplicate levels.
@@ -396,8 +392,7 @@ level 'level1 copy2'"
     assert_equal level_group_copy1_dsl, level_group_copy1.dsl_text
     assert_equal 'level_group_test assessment copy1', level_group_copy1.name
     assert_equal 'level1 copy1', level_group_copy1.pages.first.levels.first.name
-    assert_equal 'external1 copy1', level_group_copy1.properties['texts'].first['level_name']
-    refute_nil Level.find_by_name('external1 copy1')
+    assert_equal 'external1 copy1', level_group_copy1.pages.first.texts.first.name
 
     # Copy the level group again. copy2 suffix replaces copy1 suffix throughout,
     # rather than being concatenated, due to name_suffix field.
@@ -405,8 +400,7 @@ level 'level1 copy2'"
     assert_equal level_group_copy2_dsl, level_group_copy2.dsl_text
     assert_equal 'level_group_test assessment copy2', level_group_copy2.name
     assert_equal 'level1 copy2', level_group_copy2.pages.first.levels.first.name
-    assert_equal 'external1 copy2', level_group_copy2.properties['texts'].first['level_name']
-    refute_nil Level.find_by_name('external1 copy2')
+    assert_equal 'external1 copy2', level_group_copy2.pages.first.texts.first.name
 
     # clean up
     File.delete(level_group_copy1.filename)

--- a/dashboard/test/models/level_group_test.rb
+++ b/dashboard/test/models/level_group_test.rb
@@ -201,8 +201,16 @@ MARKDOWN
     script = create :script
     level1 = create :multi
     level2 = create :multi
-    properties = {pages: [{levels: [level1.name]}, {levels: [level2.name]}]}
-    create :level_group, name: 'level_group', properties: properties
+    level_group_dsl = <<~DSL
+      name 'level_group'
+
+      page
+      level '#{level1.name}'
+
+      page
+      level '#{level2.name}'
+    DSL
+    LevelGroup.create_from_level_builder({}, {name: 'level_group', dsl_text: level_group_dsl})
 
     teacher = create :teacher
     student = create :student

--- a/dashboard/test/ui/features/learning_platform/level_types/level_group_multi_page.feature
+++ b/dashboard/test/ui/features/learning_platform/level_types/level_group_multi_page.feature
@@ -8,6 +8,29 @@ Background:
   And I wait to see ".nextPageButton"
   And element ".nextPageButton" is visible
 
+Scenario: multi page level numbering
+  Then element ".level-group-number:nth(0)" contains text "1. "
+  And element ".level-group-content:nth(0) .multi-question" contains text "Which arrow gets"
+
+  And element ".level-group-number:nth(1)" contains text "2. "
+  And element ".level-group-content:nth(1) .multi-question" contains text "The standard QWERTY keyboard has"
+
+  When I press ".nextPageButton" using jQuery to load a new page
+  And I wait to see ".level-group-content"
+  And check that the URL contains "/page/2"
+
+  Then element ".level-group-number:nth(0)" contains text "4. "
+  And element ".level-group-content:nth(0) .multi-question" contains text "go at the beginning"
+
+  And element ".level-group-number:nth(3)" contains text "7. "
+  And element ".level-group-content:nth(3)" contains text "Reflecting on the ECS Curriculum"
+
+  # External level is not numbered
+  And element ".level-group-content:nth(4)" contains text "Sample external 2"
+
+  And element ".level-group-number:nth(4)" contains text "8. "
+  And element ".level-group-content:nth(5)" contains text "What are your goals"
+
 Scenario: Submit three pages.
   When element ".level-group-content:nth(0) .multi-question" contains text "Which arrow gets"
 


### PR DESCRIPTION
## Background

See https://github.com/code-dot-org/code-dot-org/pull/34677

## Description

1. move LevelGroup "levels" and "texts" out of level properties and into the parent_levels_child_levels table
2. as a result of (1), we can no longer have the same "text" appear twice in the same level group. 5431a5a2162293f33662c6d736fa4d12316372c7 fixes the only instance of this.

The following comment best explains the current terminology:
https://github.com/code-dot-org/code-dot-org/blob/e3d49ef3d8a2d80e13f0a9378d3cd45497acba24/dashboard/app/models/levels/level_group.rb#L85-L101

## Testing story
- [x] existing unit and UI tests are passing
- [x] added some unit test coverage for new implementation of texts and page internals
- [x] added ui test coverage for level numbers
- [x] manually verified texts are appearing in the right place throughout https://studio.code.org/s/csp-post-survey/stage/1/puzzle/1

## Future work

I chose to keep `page.levels` named the same and added `levels_and_texts` to maintain existing terminology and avoid lots of renames. However, the terminology is confusing because "levels" and "texts" both represent Level objects. If there is buy-in, here is one way we could improve the terminology" in a next PR:

| old name | new name |
|---|---|
| levels | questions |
| texts | texts |
| levels and texts | levels |

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
