### PR TITLE
Get Rails authenticity tokens from meta tags

### DIFF
--- a/apps/Gruntfile.js
+++ b/apps/Gruntfile.js
@@ -547,6 +547,8 @@ describe('entry tests', () => {
     'maker/setup': './src/sites/studio/pages/maker/setup.js',
     'projects/featured': './src/sites/studio/pages/projects/featured.js',
     'projects/index': './src/sites/studio/pages/projects/index.js',
+    'report_abuse/report_abuse_form':
+      './src/sites/studio/pages/report_abuse/report_abuse_form.js',
     'scripts/show': './src/sites/studio/pages/scripts/show.js',
     'scripts/stage_extras': './src/sites/studio/pages/scripts/stage_extras.js',
     'sections/show': './src/sites/studio/pages/sections/show.js',

--- a/apps/src/code-studio/components/ReportAbuseForm.jsx
+++ b/apps/src/code-studio/components/ReportAbuseForm.jsx
@@ -7,6 +7,7 @@ import AgeDropdown from '@cdo/apps/templates/AgeDropdown';
 import SafeMarkdown from '@cdo/apps/templates/SafeMarkdown';
 import msg from '@cdo/locale';
 import {getChannelIdFromUrl} from '@cdo/apps/reportAbuse';
+import RailsAuthenticityToken from '../../lib/util/RailsAuthenticityToken';
 
 /**
  * A component containing some text/links for projects that have had abuse
@@ -23,7 +24,6 @@ const alert = window.alert;
 
 export default class ReportAbuseForm extends React.Component {
   static propTypes = {
-    csrfToken: PropTypes.string.isRequired,
     abuseUrl: PropTypes.string.isRequired,
     name: PropTypes.string,
     email: PropTypes.string,
@@ -83,11 +83,7 @@ export default class ReportAbuseForm extends React.Component {
         <p>{msg.reportAbuseIntro()}</p>
         <br />
         <form action="/report_abuse" method="post">
-          <input
-            type="hidden"
-            name="authenticity_token"
-            value={this.props.csrfToken}
-          />
+          <RailsAuthenticityToken />
           <input type="hidden" name="channel_id" value={this.getChannelId()} />
           <input type="hidden" name="name" value={this.props.name} />
           <div style={{display: this.props.email ? 'none' : 'block'}}>

--- a/apps/src/code-studio/components/ReportAbuseForm.jsx
+++ b/apps/src/code-studio/components/ReportAbuseForm.jsx
@@ -168,7 +168,3 @@ export default class ReportAbuseForm extends React.Component {
     );
   }
 }
-
-// TODO - just expose renderer on dashboard?
-window.dashboard = window.dashboard || {};
-window.dashboard.ReportAbuseForm = ReportAbuseForm;

--- a/apps/src/code-studio/components/ReportAbuseForm.jsx
+++ b/apps/src/code-studio/components/ReportAbuseForm.jsx
@@ -84,8 +84,12 @@ export default class ReportAbuseForm extends React.Component {
         <br />
         <form action="/report_abuse" method="post">
           <RailsAuthenticityToken />
-          <input type="hidden" name="channel_id" value={this.getChannelId()} />
-          <input type="hidden" name="name" value={this.props.name} />
+          <input
+            type="hidden"
+            name="channel_id"
+            defaultValue={this.getChannelId()}
+          />
+          <input type="hidden" name="name" defaultValue={this.props.name} />
           <div style={{display: this.props.email ? 'none' : 'block'}}>
             <div>{msg.email()}</div>
             <input

--- a/apps/src/lib/script-editor/NewScriptForm.jsx
+++ b/apps/src/lib/script-editor/NewScriptForm.jsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import PropTypes from 'prop-types';
+import RailsAuthenticityToken from '../util/RailsAuthenticityToken';
 
 const buttonStyle = {
   marginLeft: 0,
@@ -7,10 +7,10 @@ const buttonStyle = {
   marginBottom: 20
 };
 
-export default function NewScriptForm({csrfToken}) {
+export default function NewScriptForm() {
   return (
     <form action="/s" method="post">
-      <input type="hidden" name="authenticity_token" value={csrfToken} />
+      <RailsAuthenticityToken />
       <label>Name</label>
       <input name="script[name]" />
       <br />
@@ -20,7 +20,3 @@ export default function NewScriptForm({csrfToken}) {
     </form>
   );
 }
-
-NewScriptForm.propTypes = {
-  csrfToken: PropTypes.string.isRequired
-};

--- a/apps/src/lib/ui/accounts/ManageLinkedAccounts.jsx
+++ b/apps/src/lib/ui/accounts/ManageLinkedAccounts.jsx
@@ -8,6 +8,7 @@ import {tableLayoutStyles} from '@cdo/apps/templates/tables/tableConstants';
 import BootstrapButton from './BootstrapButton';
 import {connect} from 'react-redux';
 import {disconnect} from './manageLinkedAccountsRedux';
+import RailsAuthenticityToken from '../../util/RailsAuthenticityToken';
 
 const OAUTH_PROVIDERS = {
   GOOGLE: 'google_oauth2',
@@ -36,7 +37,6 @@ class ManageLinkedAccounts extends React.Component {
   static propTypes = {
     // Provided by redux
     authenticationOptions: PropTypes.objectOf(authOptionPropType),
-    authenticityToken: PropTypes.string.isRequired,
     userHasPassword: PropTypes.bool.isRequired,
     isGoogleClassroomStudent: PropTypes.bool.isRequired,
     isCleverStudent: PropTypes.bool.isRequired,
@@ -157,7 +157,6 @@ class ManageLinkedAccounts extends React.Component {
               return (
                 <OauthConnection
                   key={option.id || _.uniqueId('empty_')}
-                  authenticityToken={this.props.authenticityToken}
                   displayName={this.getDisplayName(option.credentialType)}
                   id={option.id}
                   email={this.formatEmail(option)}
@@ -181,7 +180,6 @@ export const UnconnectedManageLinkedAccounts = ManageLinkedAccounts;
 export default connect(
   state => ({
     authenticationOptions: state.manageLinkedAccounts.authenticationOptions,
-    authenticityToken: state.manageLinkedAccounts.authenticityToken,
     userHasPassword: state.manageLinkedAccounts.userHasPassword,
     isGoogleClassroomStudent:
       state.manageLinkedAccounts.isGoogleClassroomStudent,
@@ -199,7 +197,6 @@ class OauthConnection extends React.Component {
     displayName: PropTypes.string.isRequired,
     id: PropTypes.number,
     credentialType: PropTypes.string.isRequired,
-    authenticityToken: PropTypes.string.isRequired,
     email: PropTypes.string,
     disconnectDisabledStatus: PropTypes.string,
     error: PropTypes.string
@@ -218,7 +215,6 @@ class OauthConnection extends React.Component {
 
   render() {
     const {
-      authenticityToken,
       credentialType,
       disconnectDisabledStatus,
       displayName,
@@ -263,11 +259,7 @@ class OauthConnection extends React.Component {
                 text={buttonText}
                 disabled={!!disconnectDisabledStatus}
               />
-              <input
-                type="hidden"
-                name="authenticity_token"
-                value={authenticityToken}
-              />
+              <RailsAuthenticityToken />
             </form>
             {disconnectDisabledStatus && (
               <ReactTooltip

--- a/apps/src/lib/ui/accounts/ManageLinkedAccounts.story.jsx
+++ b/apps/src/lib/ui/accounts/ManageLinkedAccounts.story.jsx
@@ -4,7 +4,6 @@ import {UnconnectedManageLinkedAccounts as ManageLinkedAccounts} from './ManageL
 
 const DEFAULT_PROPS = {
   userType: 'student',
-  authenticityToken: 'fake CSRF token',
   authenticationOptions: {},
   connect: action('connect'),
   disconnect: action('disconnect'),

--- a/apps/src/lib/ui/accounts/ManageLinkedAccountsController.js
+++ b/apps/src/lib/ui/accounts/ManageLinkedAccountsController.js
@@ -14,8 +14,7 @@ export default class ManageLinkedAccountsController {
     authenticationOptions,
     userHasPassword,
     isGoogleClassroomStudent,
-    isCleverStudent,
-    authenticityToken
+    isCleverStudent
   ) {
     registerReducers({manageLinkedAccounts});
     const store = getStore();
@@ -25,8 +24,7 @@ export default class ManageLinkedAccountsController {
         authenticationOptions,
         userHasPassword,
         isGoogleClassroomStudent,
-        isCleverStudent,
-        authenticityToken
+        isCleverStudent
       })
     );
 

--- a/apps/src/lib/ui/accounts/manageLinkedAccountsRedux.js
+++ b/apps/src/lib/ui/accounts/manageLinkedAccountsRedux.js
@@ -30,7 +30,6 @@ export default function manageLinkedAccounts(state = initialState, action) {
   if (action.type === INITIALIZE_STATE) {
     const {
       authenticationOptions,
-      authenticityToken,
       userHasPassword,
       isGoogleClassroomStudent,
       isCleverStudent
@@ -38,7 +37,6 @@ export default function manageLinkedAccounts(state = initialState, action) {
     return {
       ...state,
       authenticationOptions,
-      authenticityToken,
       userHasPassword,
       isGoogleClassroomStudent,
       isCleverStudent

--- a/apps/src/lib/util/RailsAuthenticityToken.jsx
+++ b/apps/src/lib/util/RailsAuthenticityToken.jsx
@@ -8,6 +8,10 @@ import React from 'react';
  * that have CSRF protection enabled.
  */
 export default function RailsAuthenticityToken() {
+  if (IN_UNIT_TEST) {
+    return <input type="hidden" name="authenticity_token" value="fake_token" />;
+  }
+
   const csrfParam = document.querySelector('meta[name="csrf-param"]');
   const csrfToken = document.querySelector('meta[name="csrf-token"]');
   if (csrfParam && csrfToken) {
@@ -15,6 +19,7 @@ export default function RailsAuthenticityToken() {
       <input type="hidden" name={csrfParam.content} value={csrfToken.content} />
     );
   }
+
   console.error(
     'Tried to render an authenticity token into the form but no CSRF meta tags were found in the document.'
   );

--- a/apps/src/sites/studio/pages/code-studio.js
+++ b/apps/src/sites/studio/pages/code-studio.js
@@ -35,7 +35,6 @@ window.Radium = require('radium');
 // TODO (bbuchanan): Stop including these components in a global way, just
 //                   require them specifically where needed.
 require('@cdo/apps/code-studio/components/AbuseError');
-require('@cdo/apps/code-studio/components/ReportAbuseForm');
 require('@cdo/apps/code-studio/components/SendToPhone');
 require('@cdo/apps/code-studio/components/SmallFooter');
 require('@cdo/apps/code-studio/components/Attachments');

--- a/apps/src/sites/studio/pages/devise/registrations/edit.js
+++ b/apps/src/sites/studio/pages/devise/registrations/edit.js
@@ -25,8 +25,7 @@ const {
   isCleverStudent,
   dependedUponForLogin,
   dependentStudents,
-  studentCount,
-  authenticityToken
+  studentCount
 } = scriptData;
 
 $(document).ready(() => {
@@ -87,8 +86,7 @@ $(document).ready(() => {
       authenticationOptions,
       isPasswordRequired,
       isGoogleClassroomStudent,
-      isCleverStudent,
-      authenticityToken
+      isCleverStudent
     );
   }
 

--- a/apps/src/sites/studio/pages/report_abuse/report_abuse_form.js
+++ b/apps/src/sites/studio/pages/report_abuse/report_abuse_form.js
@@ -1,0 +1,14 @@
+import $ from 'jquery';
+import React from 'react';
+import ReactDOM from 'react-dom';
+import getScriptData from '@cdo/apps/util/getScriptData';
+import ReportAbuseForm from '@cdo/apps/code-studio/components/ReportAbuseForm';
+
+$(document).ready(function() {
+  const props = getScriptData('abuse');
+  props.abuseUrl = document.referrer;
+  ReactDOM.render(
+    <ReportAbuseForm {...props} />,
+    document.getElementById('report-abuse-form')
+  );
+});

--- a/apps/src/sites/studio/pages/scripts/new.js
+++ b/apps/src/sites/studio/pages/scripts/new.js
@@ -3,11 +3,5 @@ import ReactDOM from 'react-dom';
 import NewScriptForm from '@cdo/apps/lib/script-editor/NewScriptForm';
 
 $(document).ready(() => {
-  const script = document.querySelector('script[data-csrftoken]');
-  const csrfToken = script.dataset.csrftoken;
-
-  ReactDOM.render(
-    <NewScriptForm csrfToken={csrfToken} />,
-    document.getElementById('form')
-  );
+  ReactDOM.render(<NewScriptForm />, document.getElementById('form'));
 });

--- a/apps/src/templates/teacherDashboard/RosterDialog.story.jsx
+++ b/apps/src/templates/teacherDashboard/RosterDialog.story.jsx
@@ -48,23 +48,12 @@ export default storybook => {
         .add(`${provider}: No sections found`, () => (
           <RosterDialog rosterProvider={provider} classrooms={[]} />
         ))
-        .add(`${provider}: Load error`, () => {
-          // Stub CSRF meta tags into the document so we can render the reauthorization
-          // button successfully.
-          const csrfParam = document.createElement('meta');
-          const csrfToken = document.createElement('meta');
-          csrfParam.setAttribute('name', 'csrf-param');
-          csrfToken.setAttribute('name', 'csrf-token');
-          document.head.appendChild(csrfParam);
-          document.head.appendChild(csrfToken);
-
-          return (
-            <RosterDialog
-              rosterProvider={provider}
-              loadError={{status: 403, message: 'Sample error message.'}}
-            />
-          );
-        });
+        .add(`${provider}: Load error`, () => (
+          <RosterDialog
+            rosterProvider={provider}
+            loadError={{status: 403, message: 'Sample error message.'}}
+          />
+        ));
     }
   );
   return storybook;

--- a/apps/test/unit/lib/ui/accounts/ManageLinkedAccountsTest.jsx
+++ b/apps/test/unit/lib/ui/accounts/ManageLinkedAccountsTest.jsx
@@ -8,7 +8,6 @@ import {
 
 const DEFAULT_PROPS = {
   userType: 'student',
-  authenticityToken: 'fake CSRF token',
   authenticationOptions: {},
   disconnect: () => {},
   userHasPassword: true,

--- a/dashboard/app/controllers/report_abuse_controller.rb
+++ b/dashboard/app/controllers/report_abuse_controller.rb
@@ -90,7 +90,6 @@ class ReportAbuseController < ApplicationController
 
   def report_abuse_form
     @react_props = {
-      csrfToken: form_authenticity_token,
       name: (current_user.name unless current_user.nil?),
       email: (current_user.email unless current_user.nil?),
       age: (current_user.age unless current_user.nil?),

--- a/dashboard/app/views/devise/registrations/edit.html.haml
+++ b/dashboard/app/views/devise/registrations/edit.html.haml
@@ -226,8 +226,7 @@
       isGoogleClassroomStudent: current_user.google_classroom_student?,
       isCleverStudent: current_user.clever_student?,
       dependentStudents: current_user.dependent_students,
-      studentCount: current_user.students.count,
-      authenticityToken: form_authenticity_token
+      studentCount: current_user.students.count
     }.to_json
   }
 %script{src: webpack_asset_path('js/devise/registrations/edit.js'), data: script_data}

--- a/dashboard/app/views/report_abuse/report_abuse_form.html.haml
+++ b/dashboard/app/views/report_abuse/report_abuse_form.html.haml
@@ -1,12 +1,3 @@
 - @page_title = "Report Abuse"
-
 #report-abuse-form
-
-:javascript
-  $(document).ready(function () {
-    var props = #{@react_props.to_json};
-    props.abuseUrl = document.referrer;
-    ReactDOM.render(
-      React.createElement(window.dashboard.ReportAbuseForm, props),
-      document.getElementById('report-abuse-form'));
-  });
+%script{src: webpack_asset_path('js/report_abuse/report_abuse_form.js'), data: {abuse: @react_props.to_json}}

--- a/dashboard/app/views/scripts/new.html.haml
+++ b/dashboard/app/views/scripts/new.html.haml
@@ -1,4 +1,4 @@
 %h1= t('crud.new_model', model: Script.model_name.human)
-%script{src: webpack_asset_path('js/scripts/new.js'), data: {csrftoken: form_authenticity_token}}
+%script{src: webpack_asset_path('js/scripts/new.js')}
 #form
 = link_to t('crud.back'), scripts_path


### PR DESCRIPTION
Following a pattern established in https://github.com/code-dot-org/code-dot-org/pull/35752, have forms rendered by React that need to submit to dashboard APIs retrieve a Rails authenticity token from meta tags in the DOM instead of plumbing one through specifically for the form.

<!--
  Your description goes here: A summary of the change, including any relevant motivation and context.

  If relevant, include a description both of the existing behavior and of the new behavior.
-->

<!--
  Other aspects to consider. uncomment and add detail for any that seem necessary:
-->

<!-- ### Background -->
<!-- ### Privacy -->
<!-- ### Security -->
<!-- ### Caching -->
<!-- ### Deployment strategy -->
<!-- ### Future work -->

## Links

<!--
  Any relevant links to external resources; ie, specification documents, jira
  items, related PRs, honeybadger errors, etc
-->

- [spec]()
- [jira]()

## Testing story

<!--
  Does your change include appropriate tests?

  If so, please describe how the tests included in this PR are sufficient

  If not, please explain why this change does not need to be tested.
-->

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
