### PR TITLE
Shorten user display name to prevent username overflowing 20-char max

### DIFF
--- a/dashboard/test/ui/features/support/hooks.rb
+++ b/dashboard/test/ui/features/support/hooks.rb
@@ -1,17 +1,17 @@
 Before('@as_student') do
-  steps "Given I create a student named \"Test #{rand(100000)}_Student\""
+  steps "Given I create a student named \"#{rand(100000)}_Student\""
 end
 
 Before('@as_young_student') do
-  steps "Given I create a young student named \"Test #{rand(100000)}_Student\""
+  steps "Given I create a young student named \"#{rand(100000)}_Student\""
 end
 
 Before('@as_taught_student') do
-  steps "Given I create a teacher-associated student named \"Taught #{rand(100000)}_Student\""
+  steps "Given I create a teacher-associated student named \"#{rand(100000)}_Student\""
 end
 
 Before('@as_authorized_taught_student') do
-  steps "Given I create an authorized teacher-associated student named \"Taught #{rand(100000)}_Student\""
+  steps "Given I create an authorized teacher-associated student named \"#{rand(100000)}_Student\""
 end
 
 Before('@as_teacher') do


### PR DESCRIPTION
UI tests began failing last night because the generated usernames for teachers (created via an associated student) were [overflowing the 20-char max](https://github.com/code-dot-org/code-dot-org/blob/e5a0f05ade30921af9acf807c1e0d045a4f71ce5/lib/cdo/user_helpers.rb#L59). This shortens the display names (from which usernames are generated) to mitigate this issue. 

This was only happening for tests with the `@as_taught_student` before-hook, but I updated the `@as_student` hook as well for consistency.

It's difficult to test whether or not this will actually fix the issue on the test machine, so follow-up fixes or truncating the Users table on the test machine may also be necessary.

## Links

- [Slack thread](https://codedotorg.slack.com/archives/C0T0PNTM3/p1594916865378800)


# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
