### PR TITLE
HOC: Fix test_deliverer for new emails

### DIFF
--- a/lib/test/fixtures/deliverer/expected/hoc_signup_2020_receipt_en/body.html
+++ b/lib/test/fixtures/deliverer/expected/hoc_signup_2020_receipt_en/body.html
@@ -1,0 +1,45 @@
+<!DOCTYPE html PUBLIC "-//W3C//DTD HTML 4.0 Transitional//EN" "http://www.w3.org/TR/REC-html40/loose.dtd">
+<html><body>
+<h3>Thank you for signing up for the Hour of Code!</h3>
+
+<p>Your event is now registered. By volunteering to host an Hour of Code, you’re making it possible for more students to get the chance to learn computer science. While Hour of Code events are held all over the world during the celebration of Computer Science Education Week, you can choose to organize an Hour of Code any time! </p>
+
+<h2>Here are some steps to get started:</h2>
+
+<h3>1. Start planning your event</h3>
+
+<p>Explore our library of <a href="https://test.hourofcode.com/learn">Hour of Code activities</a> and <a href="https://test.hourofcode.com/how-to">review this how-to guide</a> for helpful tips on how to inspire students, determine your technology needs, and more. </p>
+
+<h3>2. Spread the word and recruit more people</h3>
+
+<p>We need your help to inspire volunteers and organizers from across the globe. Tell your friends about the #HourOfCode and <a href="https://test.hourofcode.com/promote/resources">use these helpful resources</a> to promote your event.</p>
+
+<p>You can also help recruit more people from your school and community by <a href="https://test.hourofcode.com/promote/resources#sample-emails">sending our sample emails</a> to your principal, a local group, or even some friends.</p>
+
+<h3>3. Invite a local volunteer to inspire your students</h3>
+
+<p><a href="https://test.code.org/volunteer/local">Search our volunteer map</a> to find volunteers who can visit your classroom or video chat remotely to inspire your students about the breadth of possibilities with computer science.</p>
+
+<h3>4. Check-out Hour of Code swag</h3>
+
+<p>Swag is a great way to get students excited about the Hour of Code and reward them for completing their activity. At the Code.org <a href="https://www.amazon.com/stores/page/8557B2A6-EBF2-4C9F-95C5-C3256FBA0220">Amazon store</a>, you can <a href="https://www.amazon.com/dp/B07J6T18DH?m=A2ZEA2ORKPFEVK">order posters</a> with inspirational role models, Hour of Code kits, fun stickers, and more! But hurry, supplies are limited.</p>
+
+<h3>Encourage kids to continue learning</h3>
+
+<p>An Hour of Code is just the beginning! We hear over and over again how much students love the Hour of Code and discover a newfound interest in computer science. Encourage them to continue learning. Whether you’re an administrator, teacher, or advocate, we have professional learning, curriculum, and resources to help you <a href="https://test.code.org/yourschool">bring computer science classes to your school</a> or expand your offerings.  </p>
+
+<p>Many of the organizations offering activities on HourofCode.com also have curriculum and professional learning available as well. We've highlighted <a href="https://test.hourofcode.com/beyond">curriculum providers that can help you or your students go beyond an hour.</a> </p>
+
+<p>Thank you for leading the movement to give every student the chance to learn foundational computer science skills.</p>
+
+<p>Hadi Partovi<br>
+Founder, Code.org<br></p>
+
+<hr>
+
+<p><small>
+You're receiving this email because you signed up for the Hour of Code, supported by more than 200 partners and organized by Code.org. Code.org is a 501c3 non-profit. Our address is <a href="https://maps.google.com/?q=1501+4th+Avenue,+Suite+900,+Seattle,+WA+98101&amp;entry=gmail&amp;source=g">1501 4th Avenue, Suite 900, Seattle, WA 98101</a>. Don't want these emails? <a href="">Unsubscribe</a>.
+</small></p>
+
+<p><img src="" alt=""></p>
+</body></html>

--- a/lib/test/fixtures/deliverer/expected/hoc_signup_2020_receipt_en/header.yaml
+++ b/lib/test/fixtures/deliverer/expected/hoc_signup_2020_receipt_en/header.yaml
@@ -1,0 +1,3 @@
+---
+from: Hadi Partovi (Code.org) <hadi_partovi@code.org>
+subject: You’re signed up for the Hour of Code!

--- a/lib/test/fixtures/deliverer/expected/hoc_signup_2020_receipt_es/body.html
+++ b/lib/test/fixtures/deliverer/expected/hoc_signup_2020_receipt_es/body.html
@@ -1,0 +1,39 @@
+<!DOCTYPE html PUBLIC "-//W3C//DTD HTML 4.0 Transitional//EN" "http://www.w3.org/TR/REC-html40/loose.dtd">
+<html><body>
+<h1>¡Gracias por inscribirte para ser anfitrión de una Hora de Código!</h1>
+
+<p>Usted está haciendo posible para que los estudiantes de todo el mundo aprendan una Hora de Código que puede cambiar el resto de sus vidas, desde el 1ro de octubre hasta el 18 de diciembre. Estaremos en contacto sobre nuevos tutoriales y otras noticias interesantes. ¿Qué puede usted hacer ahora?</p>
+
+<h2>1. Encuentre a un voluntario local para ayudarle con su evento.</h2>
+
+<p><a href="https://test.code.org/volunteer/local">Buscar en nuestro mapa del voluntariado</a> para que los voluntarios puedan visitar tu aula o hagan un videochat remotamente para inspirar a tus estudiantes acerca de la amplitud de posibilidades con las Ciencias de la Computación.</p>
+
+<h2>2. Corre la voz</h2>
+
+<p>Necesitamos su ayuda para llegar a los organizadores en todo el mundo. ¡Habla a tus amigos de la #HoraDeCódigo! <a href="https://test.hourofcode.com/promote/resources">Use estos recursos útiles</a> para promocionar tu evento.</p>
+
+<h2>3. Pídele a tu escuela que ofrezca una Hora de Código</h2>
+
+<p><a href="https://test.hourofcode.com/promote/resources#sample-emails">Envíe este correo electrónico</a> o <a href="https://test.hourofcode.com/promote/resources">comparte estos folletos</a> a su director y desafíe a cada clase de su escuela para que se inscriba.</p>
+
+<h2>4. Pídele a tu compañía que se involucre</h2>
+
+<p><a href="https://test.hourofcode.com/promote/resources#sample-emails">Envia este correo electrónico</a> a tu gerente o director general.</p>
+
+<h2>5. Promociona la Hora de Código en tu comunidad</h2>
+
+<p>Recluta a un grupo local o incluso algunos amigos. <a href="https://test.hourofcode.com/promote/resources#sample-emails">Enviar este correo electrónico</a>.</p>
+
+<p>Gracias por dirigir el movimiento para dar a cada estudiante la oportunidad de aprender habilidades informáticas fundacionales.</p>
+
+<p>Hadi Partovi<br>
+Fundador, Code.org</p>
+
+<hr>
+
+<p><small>
+Estás recibiendo este correo electrónico porque usted se registro para la Hora de Código, apoyado por más de 200 socios y organizado por Code.org. Code.org es una 501c3 sin fines de lucro. Nuestra dirección es 1501 4th Avenue, Suite 900, Seattle, WA 98101. ¿No quieres estos correos? <a href="">Darse de baja</a>.
+</small></p>
+
+<p><img src="" alt=""></p>
+</body></html>

--- a/lib/test/fixtures/deliverer/expected/hoc_signup_2020_receipt_es/header.yaml
+++ b/lib/test/fixtures/deliverer/expected/hoc_signup_2020_receipt_es/header.yaml
@@ -1,0 +1,3 @@
+---
+from: Hadi Partovi (Code.org) <hadi_partovi@code.org>
+subject: "¡Gracias por inscribirte para ser anfitrión de una Hora de Código!"

--- a/lib/test/fixtures/deliverer/expected/hoc_signup_2020_receipt_pt/body.html
+++ b/lib/test/fixtures/deliverer/expected/hoc_signup_2020_receipt_pt/body.html
@@ -1,0 +1,39 @@
+<!DOCTYPE html PUBLIC "-//W3C//DTD HTML 4.0 Transitional//EN" "http://www.w3.org/TR/REC-html40/loose.dtd">
+<html><body>
+<h1>Obrigado por se inscrever para organizar um evento da Hora do Código!</h1>
+
+<p>Você está possibilitando que alunos de todo o mundo aprendam uma Hora do Código que pode mudar suas vidas, desde o 1ro de outubro ate o 18 de dezembro. Entraremos em contato para falar sobre novos tutoriais e outras atualizações. Então, o que você pode fazer agora?</p>
+
+<h2>1. Encontre um voluntário para ajudá-lo no evento.</h2>
+
+<p><a href="https://test.code.org/volunteer/local">Busque em nosso mapa de voluntários</a> voluntários que possam visitar sua sala de aula ou fazer um chat de vídeo remotamente para inspirar seus alunos, falando sobre a imensidão de possibilidades que a Ciência da Computação proporciona.</p>
+
+<h2>2. Divulgue</h2>
+
+<p>Precisamos da sua ajuda para alcançar organizadores do mundo todo. Fale para os seus amigos sobre a #HoraDoCodigo. <a href="https://test.hourofcode.com/promote/resources">Use estes recursos</a> para promover seu evento.</p>
+
+<h2>3. Convide sua escola inteira para participar da Hora do Código</h2>
+
+<p><a href="https://test.hourofcode.com/promote/resources#sample-emails">Envie este e-mail</a> para o diretor ou <a href="https://test.hourofcode.com/promote/resources">compartilhe estes materiais</a>.</p>
+
+<h2>4. Peça para que sua empresa participe</h2>
+
+<p><a href="https://test.hourofcode.com/promote/resources#sample-emails">Envie este e-mail</a> para seu gerente ou CEO.</p>
+
+<h2>5. Promova a Hora do Código na sua comunidade</h2>
+
+<p>Reúna um grupo da sua região ou mesmo alguns amigos. <a href="https://test.hourofcode.com/promote/resources#sample-emails">Envie este e-mail</a>.</p>
+
+<p>Obrigado por participar deste movimento e por dar aos alunos a chance de aprender as habilidades básicas da Ciência da Computação.</p>
+
+<p>Hadi Partovi<br>
+Fundador da Code.org</p>
+
+<hr>
+
+<p><small>
+Você está recebendo este e-mail porque você se cadastrou na Hora do Código, apoiada por mais de 200 parceiros e organizada pela Code.org. A Code.org é uma organização sem fins lucrativos. Nosso endereço é: 1501 4th Avenue, Suite 900, Seattle, WA 98101. Não quer receber esses e-mails? <a href="">Cancele sua assinatura</a>.
+</small></p>
+
+<p><img src="" alt=""></p>
+</body></html>

--- a/lib/test/fixtures/deliverer/expected/hoc_signup_2020_receipt_pt/header.yaml
+++ b/lib/test/fixtures/deliverer/expected/hoc_signup_2020_receipt_pt/header.yaml
@@ -1,0 +1,3 @@
+---
+from: Hadi Partovi (Code.org) <hadi_partovi@code.org>
+subject: Obrigado por se inscrever para sediar a Hora do Código!

--- a/lib/test/fixtures/deliverer/forms/HocSignup2020.json
+++ b/lib/test/fixtures/deliverer/forms/HocSignup2020.json
@@ -1,0 +1,27 @@
+{
+  "data": {
+    "name_s": "Fake Name",
+    "email_s": "name.fake@fabricated.edu",
+    "event_type_s": "out_of_school",
+    "hoc_company_s": null,
+    "hoc_country_s": "us",
+    "nces_school_s": null,
+    "school_name_s": "Fabricated Elementary",
+    "event_location_s": "School",
+    "hoc_event_country_s": "US",
+    "organization_name_s": "Imaginary Education Org",
+    "send_posters_flag_b": "0",
+    "entire_school_flag_b": "0",
+    "special_event_flag_b": "0",
+    "match_volunteer_flag_b": "",
+    "send_posters_address_s": "",
+    "special_event_details_s": "",
+    "email_preference_opt_in_s": "yes"
+  },
+  "processed_data": {
+    "location_p": "12.3456789,-98.7654321",
+    "location_country_s": "United States",
+    "nces_school_name_s": "",
+    "location_country_code_s": "US"
+  }
+}

--- a/lib/test/fixtures/deliverer/params/hoc_signup_2020_receipt_en.json
+++ b/lib/test/fixtures/deliverer/params/hoc_signup_2020_receipt_en.json
@@ -1,0 +1,3 @@
+{
+  "form_kind": "HocSignup2020"
+}

--- a/lib/test/fixtures/deliverer/params/hoc_signup_2020_receipt_es.json
+++ b/lib/test/fixtures/deliverer/params/hoc_signup_2020_receipt_es.json
@@ -1,0 +1,3 @@
+{
+  "form_kind": "HocSignup2020"
+}

--- a/lib/test/fixtures/deliverer/params/hoc_signup_2020_receipt_pt.json
+++ b/lib/test/fixtures/deliverer/params/hoc_signup_2020_receipt_pt.json
@@ -1,0 +1,3 @@
+{
+  "form_kind": "HocSignup2020"
+}

--- a/pegasus/emails/hoc_signup_2020_receipt_en.md
+++ b/pegasus/emails/hoc_signup_2020_receipt_en.md
@@ -7,59 +7,35 @@ subject: "You’re signed up for the Hour of Code!"
   <% storedotcodedotorg = CDO.canonical_hostname('store.code.org') %>
 
 ### Thank you for signing up for the Hour of Code!
-Your event is now registered. By volunteering to host an Hour of Code, you’re making it possible for more students to
-get the chance to learn computer science. While Hour of Code events are held all over the world during the celebration
-of Computer Science Education Week, you can choose to organize an Hour of Code any time! 
+Your event is now registered. By volunteering to host an Hour of Code, you’re making it possible for more students to get the chance to learn computer science. While Hour of Code events are held all over the world during the celebration of Computer Science Education Week, you can choose to organize an Hour of Code any time! 
 
 ## Here are some steps to get started:
 
 ### 1. Start planning your event
-Explore our library of [Hour of Code activities](https://<%= hourofcode %>/learn) and
-[review this how-to guide](https://<%= hourofcode %>/how-to) for helpful tips on how to inspire students, 
-determine your technology needs, and more. 
+Explore our library of [Hour of Code activities](https://<%= hourofcode %>/learn) and [review this how-to guide](https://<%= hourofcode %>/how-to) for helpful tips on how to inspire students, determine your technology needs, and more. 
 
 ### 2. Spread the word and recruit more people
-We need your help to inspire volunteers and organizers from across the globe. 
-Tell your friends about the #HourOfCode and [use these helpful resources](https://<%= hourofcode %>/promote/resources) 
-to promote your event.
+We need your help to inspire volunteers and organizers from across the globe. Tell your friends about the #HourOfCode and [use these helpful resources](https://<%= hourofcode %>/promote/resources) to promote your event.
 
-You can also help recruit more people from your school and community by 
-[sending our sample emails](https://<%= hourofcode %>/promote/resources#sample-emails) to your principal,
- a local group, or even some friends.
+You can also help recruit more people from your school and community by [sending our sample emails](https://<%= hourofcode %>/promote/resources#sample-emails) to your principal, a local group, or even some friends.
 
 
 ### 3. Invite a local volunteer to inspire your students
-[Search our volunteer map](https://<%= codedotorg %>/volunteer/local) to find volunteers who can visit your classroom
- or video chat remotely to inspire your students about the breadth of possibilities with computer science.
+[Search our volunteer map](https://<%= codedotorg %>/volunteer/local) to find volunteers who can visit your classroom or video chat remotely to inspire your students about the breadth of possibilities with computer science.
 
 ### 4. Check-out Hour of Code swag
-Swag is a great way to get students excited about the Hour of Code and reward them for completing their activity. 
-At the Code.org [Amazon store](https://www.amazon.com/stores/page/8557B2A6-EBF2-4C9F-95C5-C3256FBA0220), you can 
-[order posters](https://www.amazon.com/dp/B07J6T18DH?m=A2ZEA2ORKPFEVK) with inspirational role models, 
-Hour of Code kits, fun stickers, and more! But hurry, supplies are limited.
+Swag is a great way to get students excited about the Hour of Code and reward them for completing their activity. At the Code.org [Amazon store](https://www.amazon.com/stores/page/8557B2A6-EBF2-4C9F-95C5-C3256FBA0220), you can [order posters](https://www.amazon.com/dp/B07J6T18DH?m=A2ZEA2ORKPFEVK) with inspirational role models, Hour of Code kits, fun stickers, and more! But hurry, supplies are limited.
 
 ### Encourage kids to continue learning 
-<% if form.data["hoc_event_country_s"] == 'US' %> An Hour of Code is just the beginning! We hear over and over again 
-how much students love the Hour of Code and discover a newfound interest in computer science. Encourage them to 
-continue learning. Whether you’re an administrator, teacher, or advocate, we have professional learning, curriculum, 
-and resources to help you [bring computer science classes to your school](https://<%= codedotorg %>/yourschool) or 
-expand your offerings.  
+<% if form.data["hoc_event_country_s"] == 'US' %> An Hour of Code is just the beginning! We hear over and over again how much students love the Hour of Code and discover a newfound interest in computer science. Encourage them to continue learning. Whether you’re an administrator, teacher, or advocate, we have professional learning, curriculum, and resources to help you [bring computer science classes to your school](https://<%= codedotorg %>/yourschool) or expand your offerings.  
 
-Many of the organizations offering activities on HourofCode.com also have curriculum and professional learning 
-available as well. We've highlighted 
-[curriculum providers that can help you or your students go beyond an hour.](https://<%= hourofcode %>/beyond) 
+Many of the organizations offering activities on HourofCode.com also have curriculum and professional learning available as well. We've highlighted [curriculum providers that can help you or your students go beyond an hour.](https://<%= hourofcode %>/beyond) 
 
-<% else %> An Hour of Code is just the beginning! We hear over and over again how much students love the Hour of Code
- and discover a newfound interest in computer science. Encourage them to continue learning. 
+<% else %> An Hour of Code is just the beginning! We hear over and over again how much students love the Hour of Code and discover a newfound interest in computer science. Encourage them to continue learning. 
 
-Many of the organizations offering Hour of Code lessons also have curriculum available to go further.
-To help you get started, we've highlighted a number of [
-curriculum providers that will help you or your students go beyond an hour.](https://<%= hourofcode %>/beyond)
+Many of the organizations offering Hour of Code lessons also have curriculum available to go further. To help you get started, we've highlighted a number of [curriculum providers that will help you or your students go beyond an hour.](https://<%= hourofcode %>/beyond)
 
-Code.org also offers full 
-[introductory computer science courses](https://<%= codedotorg %>/educate/curriculum/cs-fundamentals-international) 
-translated into over 67 languages at no cost to you or your school. <% end %> Thank you for leading the movement 
-to give every student the chance to learn foundational computer science skills.
+Code.org also offers full [introductory computer science courses](https://<%= codedotorg %>/educate/curriculum/cs-fundamentals-international) translated into over 67 languages at no cost to you or your school. <% end %> Thank you for leading the movement to give every student the chance to learn foundational computer science skills.
 
 
 Hadi Partovi<br />
@@ -67,10 +43,7 @@ Founder, Code.org<br />
 
 <hr/>
 <small>
-You're receiving this email because you signed up for the Hour of Code, supported by more than 200 partners and 
-organized by Code.org. Code.org is a 501c3 non-profit. Our address is 
-[1501 4th Avenue, Suite 900, Seattle, WA 98101](https://maps.google.com/?q=1501+4th+Avenue,+Suite+900,+Seattle,+WA+98101&entry=gmail&source=g). 
-Don't want these emails? [Unsubscribe](<%= local_assigns.fetch(:unsubscribe_link, "") %>).
+You're receiving this email because you signed up for the Hour of Code, supported by more than 200 partners and organized by Code.org. Code.org is a 501c3 non-profit. Our address is [1501 4th Avenue, Suite 900, Seattle, WA 98101](https://maps.google.com/?q=1501+4th+Avenue,+Suite+900,+Seattle,+WA+98101&entry=gmail&source=g). Don't want these emails? [Unsubscribe](<%= local_assigns.fetch(:unsubscribe_link, "") %>).
 </small>
 
 ![](<%= local_assigns.fetch(:tracking_pixel, "") %>)


### PR DESCRIPTION
test_deliverer started failing due to new hour of code receipt emails. Add expected data for these new emails. Also removed new lines from english markdown of email because it made creating the sample data a headache.

<!-- ### Background -->
<!-- ### Privacy -->
<!-- ### Security -->
<!-- ### Caching -->
<!-- ### Deployment strategy -->
<!-- ### Future work -->

## Testing story
Validated test now passes locally

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
