### PR TITLE
Fixed the authorization rules for libraries.

### DIFF
--- a/dashboard/app/controllers/api/v1/section_libraries_controller.rb
+++ b/dashboard/app/controllers/api/v1/section_libraries_controller.rb
@@ -1,6 +1,6 @@
 class Api::V1::SectionLibrariesController < Api::V1::JsonApiController
   before_action :authenticate_user!
-  check_authorization
+  check_authorization unless: :no_sections?
 
   # gets the libraries from all members of all sections I am a part of
   # GET api/v1/section_libraries
@@ -12,5 +12,11 @@ class Api::V1::SectionLibrariesController < Api::V1::JsonApiController
       libraries += ProjectsList.fetch_section_libraries(section)
     end
     render json: libraries.uniq
+  end
+
+  private
+
+  def no_sections?
+    current_user.sections.empty? && current_user.sections_as_student.empty?
   end
 end


### PR DESCRIPTION
Previously, a user who was not a member of any section would see a "bad internet connection" error message when attempting to view libraries. This happened because of a bug in our authorization rules - if the was no section associated with the user, we would not run any authorization checks on the server call. However, if the user is not accessing any section, there is no reason to run an authorization check. This updates that rule.

![Screenshot 2020-07-16 09 27 32](https://user-images.githubusercontent.com/8324574/87730982-28a61080-c77e-11ea-9965-6d9e700f27bd.png)


<!--
  Your description goes here: A summary of the change, including any relevant motivation and context.

  If relevant, include a description both of the existing behavior and of the new behavior.
-->

<!--
  Other aspects to consider. uncomment and add detail for any that seem necessary:
-->

<!-- ### Background -->
<!-- ### Privacy -->
<!-- ### Security -->
<!-- ### Caching -->
<!-- ### Deployment strategy -->
<!-- ### Future work -->

## Links

<!--
  Any relevant links to external resources; ie, specification documents, jira
  items, related PRs, honeybadger errors, etc
-->

- [slack thread](https://codedotorg.slack.com/archives/C0T0UQPLZ/p1594916892003000)

## Testing story

<!--
  Does your change include appropriate tests?

  If so, please describe how the tests included in this PR are sufficient

  If not, please explain why this change does not need to be tested.
-->

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
