### PR TITLE
[Spritelab] makeNumSprites block

### DIFF
--- a/apps/src/p5lab/spritelab/commands.js
+++ b/apps/src/p5lab/spritelab/commands.js
@@ -181,6 +181,14 @@ export const commands = {
     ]);
   },
 
+  makeNumSprites(num, animation) {
+    for (let i = 0; i < num; i++) {
+      spriteCommands.makeSprite.apply(this, [
+        {animation: animation, location: locationCommands.randomLocation()}
+      ]);
+    }
+  },
+
   setAnimation(spriteArg, animation) {
     spriteCommands.setAnimation(spriteArg, animation);
   },

--- a/dashboard/config/blocks/GamelabJr/gamelab_makeNumSprites.json
+++ b/dashboard/config/blocks/GamelabJr/gamelab_makeNumSprites.json
@@ -1,0 +1,24 @@
+{
+  "category": "Sprites",
+  "config": {
+    "func": "makeNumSprites",
+    "inline": false,
+    "blockText": "make {NUM} new {ANIMATION_NAME} sprites",
+    "color": [
+      355,
+      ".7",
+      ".7"
+    ],
+    "args": [
+      {
+        "name": "NUM",
+        "type": "Number",
+        "field": true
+      },
+      {
+        "name": "ANIMATION_NAME",
+        "customInput": "costumePicker"
+      }
+    ]
+  }
+}


### PR DESCRIPTION
Another low-lift, ceiling-raising block for Sprite Lab.
![image](https://user-images.githubusercontent.com/8787187/87726879-bd0b7580-c774-11ea-80f4-1ebba5bf02d0.png)
Makes the specified number of sprites at random locations
![image](https://user-images.githubusercontent.com/8787187/87726826-a8c77880-c774-11ea-830a-b54da055200b.png)
