### PR TITLE
Add lesson groups to object set up in tests

### DIFF
--- a/dashboard/test/controllers/api_controller_test.rb
+++ b/dashboard/test/controllers/api_controller_test.rb
@@ -38,7 +38,7 @@ class ApiControllerTest < ActionController::TestCase
     sign_in @teacher
   end
 
-  private def create_script_with_lockable_stage
+  private def create_script_with_lockable_lesson
     script = create :script
     lesson_group = create :lesson_group, script: script
 
@@ -48,12 +48,12 @@ class ApiControllerTest < ActionController::TestCase
     level.properties['submittable'] = true
     level.save!
 
-    stage = create :lesson, name: 'Stage1', script: script, lockable: true, lesson_group: lesson_group
+    lesson = create :lesson, name: 'Stage1', script: script, lockable: true, lesson_group: lesson_group
 
     # Create a ScriptLevel joining this level to the script.
-    create :script_level, script: script, levels: [level], assessment: true, lesson: stage
+    create :script_level, script: script, levels: [level], assessment: true, lesson: lesson
 
-    [script, level, stage]
+    [script, level, lesson]
   end
 
   private def make_text_progress_in_script(script, student)
@@ -79,7 +79,7 @@ class ApiControllerTest < ActionController::TestCase
 
     response = JSON.parse(@response.body)
 
-    # make sure our response has stage from allthethingsscript
+    # make sure our response has lesson from allthethingsscript
     assert /\/s\/allthethings\// =~ response[0]['url']
   end
 
@@ -102,7 +102,7 @@ class ApiControllerTest < ActionController::TestCase
 
     response = JSON.parse(@response.body)
 
-    # make sure our response has stage from allthethings
+    # make sure our response has lesson from allthethings
     assert /\/s\/allthethings\// =~ response[0]['url']
   end
 
@@ -128,19 +128,19 @@ class ApiControllerTest < ActionController::TestCase
   test "should get text_responses for section with script with text response" do
     script = create :script, name: 'text-response-script'
     lesson_group = create :lesson_group, script: script
-    stage1 = create :lesson, script: script, name: 'First Stage', lesson_group: lesson_group
-    stage2 = create :lesson, script: script, name: 'Second Stage', lesson_group: lesson_group
+    lesson1 = create :lesson, script: script, name: 'First Stage', lesson_group: lesson_group
+    lesson2 = create :lesson, script: script, name: 'Second Stage', lesson_group: lesson_group
 
     # create 2 text_match levels
     level1 = create :text_match
     level1.properties['title'] = 'Text Match 1'
     level1.save!
-    create :script_level, script: script, levels: [level1], lesson: stage1
+    create :script_level, script: script, levels: [level1], lesson: lesson1
 
     level2 = create :text_match
     level2.properties['title'] = 'Text Match 2'
     level2.save!
-    create :script_level, script: script, levels: [level2], lesson: stage2
+    create :script_level, script: script, levels: [level2], lesson: lesson2
     # create some other random levels
     5.times do
       create :script_level, script: script
@@ -212,7 +212,7 @@ class ApiControllerTest < ActionController::TestCase
   end
 
   test "should get lock state when no user_level" do
-    script, level, stage = create_script_with_lockable_stage
+    script, level, lesson = create_script_with_lockable_lesson
 
     get :lockable_state, params: {
       section_id: @section.id,
@@ -229,13 +229,13 @@ class ApiControllerTest < ActionController::TestCase
     assert_equal @section.name, section_response['section_name']
     assert_equal 1, section_response['stages'].length
 
-    stages_response = section_response['stages']
-    assert_equal 1, stages_response.keys.length, '1 stage in our script'
-    stage_response = stages_response[stage.id.to_s]
-    assert_equal 5, stage_response.length, "entry for each student in section"
+    lessons_response = section_response['stages']
+    assert_equal 1, lessons_response.keys.length, '1 lesson in our script'
+    lesson_response = lessons_response[lesson.id.to_s]
+    assert_equal 5, lesson_response.length, "entry for each student in section"
 
     @students.each_with_index do |student, index|
-      student_response = stage_response[index]
+      student_response = lesson_response[index]
       assert_equal(
         {
           "user_id" => student.id,
@@ -253,12 +253,12 @@ class ApiControllerTest < ActionController::TestCase
     # do a much more limited set of validation for the flappy section
     flappy_section_response = body[@flappy_section.id.to_s]
     assert_equal @flappy_section.id, flappy_section_response['section_id']
-    assert_equal 1, flappy_section_response['stages'][stage.id.to_s].length
-    assert_equal @student_flappy_1.name, flappy_section_response['stages'][stage.id.to_s][0]['name']
+    assert_equal 1, flappy_section_response['stages'][lesson.id.to_s].length
+    assert_equal @student_flappy_1.name, flappy_section_response['stages'][lesson.id.to_s][0]['name']
   end
 
   test "should get lock state when we have user_levels" do
-    script, level, stage = create_script_with_lockable_stage
+    script, level, lesson = create_script_with_lockable_lesson
 
     # student_1 is unlocked
     create :user_level, user: @student_1, script: script, level: level, submitted: false, unlocked_at: Time.now
@@ -279,7 +279,7 @@ class ApiControllerTest < ActionController::TestCase
     assert_response :success
     body = JSON.parse(response.body)
 
-    student_responses = body[@section.id.to_s]['stages'][stage.id.to_s]
+    student_responses = body[@section.id.to_s]['stages'][lesson.id.to_s]
     assert_equal 5, student_responses.length
 
     # student_1 is unlocked
@@ -349,7 +349,7 @@ class ApiControllerTest < ActionController::TestCase
   end
 
   test "should update lockable state for new user_levels" do
-    script, level, _ = create_script_with_lockable_stage
+    script, level, _ = create_script_with_lockable_lesson
 
     user_level_data = {user_id: @student_1.id, level_id: level.id, script_id: script.id}
     user_level_data2 = {user_id: @student_2.id, level_id: level.id, script_id: script.id}
@@ -417,7 +417,7 @@ class ApiControllerTest < ActionController::TestCase
 
   test "should update lockable state for existing levels" do
     Timecop.freeze do
-      script, level, _ = create_script_with_lockable_stage
+      script, level, _ = create_script_with_lockable_lesson
 
       user_level_data = {user_id: @student_1.id, level_id: level.id, script_id: script.id}
       user_level = create :user_level, user_level_data
@@ -502,7 +502,7 @@ class ApiControllerTest < ActionController::TestCase
   end
 
   test "should fail to update lockable state if given bad data" do
-    script, level, _ = create_script_with_lockable_stage
+    script, level, _ = create_script_with_lockable_lesson
 
     user_level_data = {user_id: @student_1.id, level_id: level.id, script_id: script.id}
     create :user_level, user_level_data
@@ -597,7 +597,7 @@ class ApiControllerTest < ActionController::TestCase
     assert_equal 100, body['levels'][level_id.to_s]['result']
   end
 
-  test "should get user progress for stage" do
+  test "should get user progress for lesson" do
     slogger = FakeSlogger.new
     CDO.set_slogger_for_test(slogger)
     script = Script.hoc_2014_script
@@ -644,10 +644,10 @@ class ApiControllerTest < ActionController::TestCase
     CDO.set_slogger_for_test(slogger)
     script = create :script
     lesson_group = create :lesson_group, script: script
-    stage = create :lesson, script: script, lesson_group: lesson_group
+    lesson = create :lesson, script: script, lesson_group: lesson_group
     contained_level = create :multi, name: 'multi level'
     level = create :maze, name: 'maze level', contained_level_names: ['multi level']
-    create :script_level, script: script, lesson: stage, levels: [level]
+    create :script_level, script: script, lesson: lesson, levels: [level]
 
     user = create :user
     sign_in user
@@ -661,7 +661,7 @@ class ApiControllerTest < ActionController::TestCase
     assert_equal(contained_level.id, slogger.records.first[:level_id])
   end
 
-  test "should get user progress for stage for signed-out user" do
+  test "should get user progress for lesson for signed-out user" do
     slogger = FakeSlogger.new
     CDO.set_slogger_for_test(slogger)
     script = Script.hoc_2014_script
@@ -694,7 +694,7 @@ class ApiControllerTest < ActionController::TestCase
     )
   end
 
-  test "should get user progress for stage with young student" do
+  test "should get user progress for lesson with young student" do
     script = Script.twenty_hour_script
     young_student = create :young_student
     sign_in young_student
@@ -724,15 +724,15 @@ class ApiControllerTest < ActionController::TestCase
     assert_response :success
   end
 
-  test "should get user progress for stage with swapped level" do
+  test "should get user progress for lesson with swapped level" do
     sign_in @student_1
     script = create :script
     lesson_group = create :lesson_group, script: script
-    stage = create :lesson, script: script, lesson_group: lesson_group
+    lesson = create :lesson, script: script, lesson_group: lesson_group
     level1a = create :maze, name: 'maze 1'
     level1b = create :maze, name: 'maze 1 new'
     level_source = create :level_source, level: level1a, data: 'level source'
-    create :script_level, script: script, lesson: stage, levels: [level1a, level1b], properties: {'maze 1': {'active': false}}
+    create :script_level, script: script, lesson: lesson, levels: [level1a, level1b], properties: {'maze 1': {'active': false}}
     create :user_level, user: @student_1, script: script, level: level1a, level_source: level_source
     create :activity, user: @student_1, level: level1a, level_source: level_source
 
@@ -936,9 +936,9 @@ class ApiControllerTest < ActionController::TestCase
   test "should not return progress for bonus levels" do
     script = create :script
     lesson_group = create :lesson_group, script: script
-    stage = create :lesson, script: script, lesson_group: lesson_group
-    create :script_level, script: script, lesson: stage
-    create :script_level, script: script, lesson: stage, bonus: true
+    lesson = create :lesson, script: script, lesson_group: lesson_group
+    create :script_level, script: script, lesson: lesson
+    create :script_level, script: script, lesson: lesson, bonus: true
 
     get :section_progress, params: {
       section_id: @flappy_section.id,

--- a/dashboard/test/controllers/api_controller_test.rb
+++ b/dashboard/test/controllers/api_controller_test.rb
@@ -643,7 +643,8 @@ class ApiControllerTest < ActionController::TestCase
     slogger = FakeSlogger.new
     CDO.set_slogger_for_test(slogger)
     script = create :script
-    stage = create :lesson, script: script
+    lesson_group = create :lesson_group, script: script
+    stage = create :lesson, script: script, lesson_group: lesson_group
     contained_level = create :multi, name: 'multi level'
     level = create :maze, name: 'maze level', contained_level_names: ['multi level']
     create :script_level, script: script, lesson: stage, levels: [level]
@@ -726,7 +727,8 @@ class ApiControllerTest < ActionController::TestCase
   test "should get user progress for stage with swapped level" do
     sign_in @student_1
     script = create :script
-    stage = create :lesson, script: script
+    lesson_group = create :lesson_group, script: script
+    stage = create :lesson, script: script, lesson_group: lesson_group
     level1a = create :maze, name: 'maze 1'
     level1b = create :maze, name: 'maze 1 new'
     level_source = create :level_source, level: level1a, data: 'level source'
@@ -890,7 +892,10 @@ class ApiControllerTest < ActionController::TestCase
   end
 
   test "should get paired icons for paired user levels" do
-    sl = create :script_level
+    script = create :script
+    lesson_group = create :lesson_group, script: script
+    lesson = create :lesson, script: script, lesson_group: lesson_group
+    sl = create :script_level, lesson: lesson, script: script
     driver_ul = create(
       :user_level,
       user: @student_4,

--- a/dashboard/test/controllers/maker_controller_test.rb
+++ b/dashboard/test/controllers/maker_controller_test.rb
@@ -478,7 +478,9 @@ class MakerControllerTest < ActionController::TestCase
   def ensure_script(script_name, version_year, is_stable=true)
     Script.find_by_name(script_name) ||
       create(:script, name: script_name, family_name: 'csd6', version_year: version_year, is_stable: is_stable).tap do |script|
-        create :script_level, script: script
+        lesson_group = create :lesson_group, script: script
+        lesson = create :lesson, script: script, lesson_group: lesson_group
+        create :script_level, script: script, lesson: lesson
       end
   end
 

--- a/dashboard/test/controllers/script_levels_controller_test.rb
+++ b/dashboard/test/controllers/script_levels_controller_test.rb
@@ -19,9 +19,10 @@ class ScriptLevelsControllerTest < ActionController::TestCase
     Follower.create!(section_id: @section.id, student_user_id: @student.id, user: @teacher)
 
     @custom_script = create(:script, name: 'laurel', hideable_lessons: true)
-    @custom_stage_1 = create(:lesson, script: @custom_script, name: 'Laurel Stage 1', absolute_position: 1, relative_position: '1')
-    @custom_stage_2 = create(:lesson, script: @custom_script, name: 'Laurel Stage 2', absolute_position: 2, relative_position: '2')
-    @custom_stage_3 = create(:lesson, script: @custom_script, name: 'Laurel Stage 3', absolute_position: 3, relative_position: '3')
+    @custom_lesson_group = create(:lesson_group, script: @custom_script)
+    @custom_stage_1 = create(:lesson, script: @custom_script, lesson_group: @custom_lesson_group, name: 'Laurel Stage 1', absolute_position: 1, relative_position: '1')
+    @custom_stage_2 = create(:lesson, script: @custom_script, lesson_group: @custom_lesson_group, name: 'Laurel Stage 2', absolute_position: 2, relative_position: '2')
+    @custom_stage_3 = create(:lesson, script: @custom_script, lesson_group: @custom_lesson_group, name: 'Laurel Stage 3', absolute_position: 3, relative_position: '3')
     @custom_s1_l1 = create(
       :script_level,
       script: @custom_script,
@@ -46,7 +47,9 @@ class ScriptLevelsControllerTest < ActionController::TestCase
     @script_level = @custom_s1_l1
 
     pilot_script = create(:script, pilot_experiment: 'pilot-experiment')
-    @pilot_script_level = create :script_level, script: pilot_script
+    pilot_lesson_group = create(:lesson_group, script: pilot_script)
+    pilot_lesson = create(:lesson, script: pilot_script, lesson_group: pilot_lesson_group)
+    @pilot_script_level = create :script_level, script: pilot_script, lesson: pilot_lesson
     @pilot_teacher = create :teacher, pilot_experiment: 'pilot-experiment'
     pilot_section = create :section, user: @pilot_teacher, script: pilot_script
     @pilot_student = create(:follower, section: pilot_section).student_user
@@ -137,8 +140,10 @@ class ScriptLevelsControllerTest < ActionController::TestCase
 
   test "should render sublevel for BubbleChoice script_level with sublevel_position param" do
     script = create :script
+    lesson_group = create(:lesson_group, script: script)
+    lesson = create(:lesson, script: script, lesson_group: lesson_group)
     level = create(:bubble_choice_level, :with_sublevels)
-    script_level = create :script_level, script: script, levels: [level]
+    script_level = create :script_level, script: script, levels: [level], lesson: lesson
     sublevel_position = 1
 
     get :show, params: {
@@ -152,6 +157,10 @@ class ScriptLevelsControllerTest < ActionController::TestCase
   end
 
   test 'project template level sets start blocks when defined' do
+    script = create(:script)
+    lesson_group = create(:lesson_group, script: script)
+    lesson = create(:lesson, script: script, lesson_group: lesson_group)
+
     template_level = create :level
     template_level.start_blocks = '<xml/>'
     template_level.save!
@@ -161,7 +170,7 @@ class ScriptLevelsControllerTest < ActionController::TestCase
     real_level.start_blocks = "<should:override/>"
     real_level.save!
 
-    sl = create :script_level, levels: [real_level]
+    sl = create :script_level, levels: [real_level], lesson: lesson, script: script
     get :show, params: {script_id: sl.script, stage_position: '1', id: '1'}
 
     assert_response :success
@@ -171,6 +180,10 @@ class ScriptLevelsControllerTest < ActionController::TestCase
   end
 
   test 'project template level does not set start blocks when not defined' do
+    script = create(:script)
+    lesson_group = create(:lesson_group, script: script)
+    lesson = create(:lesson, script: script, lesson_group: lesson_group)
+
     template_level = create :level
     template_level.save!
 
@@ -179,7 +192,7 @@ class ScriptLevelsControllerTest < ActionController::TestCase
     real_level.start_blocks = "<shouldnot:override/>"
     real_level.save!
 
-    sl = create :script_level, levels: [real_level]
+    sl = create :script_level, levels: [real_level], lesson: lesson, script: script
     get :show, params: {script_id: sl.script, stage_position: '1', id: '1'}
 
     assert_response :success
@@ -189,6 +202,10 @@ class ScriptLevelsControllerTest < ActionController::TestCase
   end
 
   test 'project template level sets start html when defined' do
+    script = create(:script)
+    lesson_group = create(:lesson_group, script: script)
+    lesson = create(:lesson, script: script, lesson_group: lesson_group)
+
     template_level = create :applab
     template_level.start_html = '<div><label id="label1">expected html</label></div>'
     template_level.save!
@@ -198,7 +215,7 @@ class ScriptLevelsControllerTest < ActionController::TestCase
     real_level.start_html = '<div><label id="label1">wrong html</label></div>'
     real_level.save!
 
-    sl = create :script_level, levels: [real_level]
+    sl = create :script_level, levels: [real_level], lesson: lesson, script: script
     get :show, params: {script_id: sl.script, stage_position: '1', id: '1'}
 
     assert_response :success
@@ -208,6 +225,10 @@ class ScriptLevelsControllerTest < ActionController::TestCase
   end
 
   test 'project template level does not set start html when not defined' do
+    script = create(:script)
+    lesson_group = create(:lesson_group, script: script)
+    lesson = create(:lesson, script: script, lesson_group: lesson_group)
+
     template_level = create :applab
     template_level.save!
 
@@ -216,7 +237,7 @@ class ScriptLevelsControllerTest < ActionController::TestCase
     real_level.start_html = '<div><label id="label1">real_level html</label></div>'
     real_level.save!
 
-    sl = create :script_level, levels: [real_level]
+    sl = create :script_level, levels: [real_level], lesson: lesson, script: script
     get :show, params: {script_id: sl.script, stage_position: '1', id: '1'}
 
     assert_response :success
@@ -226,6 +247,10 @@ class ScriptLevelsControllerTest < ActionController::TestCase
   end
 
   test 'project template level sets data tables when defined' do
+    script = create(:script)
+    lesson_group = create(:lesson_group, script: script)
+    lesson = create(:lesson, script: script, lesson_group: lesson_group)
+
     template_level = create :applab
     template_level.data_tables = '{"key":"expected"}'
     template_level.data_properties = '{"prop":"expected"}'
@@ -237,7 +262,7 @@ class ScriptLevelsControllerTest < ActionController::TestCase
     real_level.data_properties = '{"prop":"wrong"}'
     real_level.save!
 
-    sl = create :script_level, levels: [real_level]
+    sl = create :script_level, levels: [real_level], lesson: lesson, script: script
     get :show, params: {script_id: sl.script, stage_position: '1', id: '1'}
 
     assert_response :success
@@ -248,6 +273,10 @@ class ScriptLevelsControllerTest < ActionController::TestCase
   end
 
   test 'project template level does not set data tables when not defined' do
+    script = create(:script)
+    lesson_group = create(:lesson_group, script: script)
+    lesson = create(:lesson, script: script, lesson_group: lesson_group)
+
     template_level = create :applab
     template_level.save!
 
@@ -257,7 +286,7 @@ class ScriptLevelsControllerTest < ActionController::TestCase
     real_level.data_properties = '{"prop":"real"}'
     real_level.save!
 
-    sl = create :script_level, levels: [real_level]
+    sl = create :script_level, levels: [real_level], lesson: lesson, script: script
     get :show, params: {script_id: sl.script, stage_position: '1', id: '1'}
 
     assert_response :success
@@ -268,6 +297,10 @@ class ScriptLevelsControllerTest < ActionController::TestCase
   end
 
   test 'project template level sets start animations when defined' do
+    script = create(:script)
+    lesson_group = create(:lesson_group, script: script)
+    lesson = create(:lesson, script: script, lesson_group: lesson_group)
+
     template_animations_json = '{"orderedKeys":["expected"],"propsByKey":{"expected":{}}}'
     template_level = create :gamelab
     template_level.start_animations = template_animations_json
@@ -279,7 +312,7 @@ class ScriptLevelsControllerTest < ActionController::TestCase
     real_level.start_animations = real_animations_json
     real_level.save!
 
-    sl = create :script_level, levels: [real_level]
+    sl = create :script_level, levels: [real_level], lesson: lesson, script: script
     get :show, params: {script_id: sl.script, stage_position: '1', id: '1'}
 
     assert_response :success
@@ -289,6 +322,10 @@ class ScriptLevelsControllerTest < ActionController::TestCase
   end
 
   test 'project template level does not set start animations when not defined' do
+    script = create(:script)
+    lesson_group = create(:lesson_group, script: script)
+    lesson = create(:lesson, script: script, lesson_group: lesson_group)
+
     template_level = create :gamelab
     template_level.save!
 
@@ -298,7 +335,7 @@ class ScriptLevelsControllerTest < ActionController::TestCase
     real_level.start_animations = real_animations_json
     real_level.save!
 
-    sl = create :script_level, levels: [real_level]
+    sl = create :script_level, levels: [real_level], lesson: lesson, script: script
     get :show, params: {script_id: sl.script, stage_position: '1', id: '1'}
 
     assert_response :success
@@ -308,6 +345,10 @@ class ScriptLevelsControllerTest < ActionController::TestCase
   end
 
   test 'project template level sets toolbox blocks when defined' do
+    script = create(:script)
+    lesson_group = create(:lesson_group, script: script)
+    lesson = create(:lesson, script: script, lesson_group: lesson_group)
+
     template_level = create :level
     template_level.toolbox_blocks = '<xml><toolbox/></xml>'
     template_level.save!
@@ -317,7 +358,7 @@ class ScriptLevelsControllerTest < ActionController::TestCase
     real_level.toolbox_blocks = "<should:override/>"
     real_level.save!
 
-    sl = create :script_level, levels: [real_level]
+    sl = create :script_level, levels: [real_level], lesson: lesson, script: script
     get :show, params: {script_id: sl.script, stage_position: '1', id: '1'}
 
     assert_response :success
@@ -327,6 +368,10 @@ class ScriptLevelsControllerTest < ActionController::TestCase
   end
 
   test 'project template level does not set toolbox blocks when not defined' do
+    script = create(:script)
+    lesson_group = create(:lesson_group, script: script)
+    lesson = create(:lesson, script: script, lesson_group: lesson_group)
+
     template_level = create :level
     template_level.save!
 
@@ -335,7 +380,7 @@ class ScriptLevelsControllerTest < ActionController::TestCase
     real_level.toolbox_blocks = "<shouldnot:override/>"
     real_level.save!
 
-    sl = create :script_level, levels: [real_level]
+    sl = create :script_level, levels: [real_level], lesson: lesson, script: script
     get :show, params: {script_id: sl.script, stage_position: '1', id: '1'}
 
     assert_response :success
@@ -345,7 +390,10 @@ class ScriptLevelsControllerTest < ActionController::TestCase
   end
 
   test 'should not show concept video for non-legacy script level' do
-    non_legacy_script_level = create(:script_level)
+    script = create(:script)
+    lesson_group = create(:lesson_group, script: script)
+    lesson = create(:lesson, script: script, lesson_group: lesson_group)
+    non_legacy_script_level = create(:script_level, lesson: lesson, script: script)
     concept_with_video = Concept.find_by_name('sequence')
     non_legacy_script_level.level.concepts = [concept_with_video]
 
@@ -360,7 +408,10 @@ class ScriptLevelsControllerTest < ActionController::TestCase
   end
 
   test 'should show specified video for script level with video' do
-    non_legacy_script_level = create(:script_level, :with_autoplay_video)
+    script = create(:script)
+    lesson_group = create(:lesson_group, script: script)
+    lesson = create(:lesson, script: script, lesson_group: lesson_group)
+    non_legacy_script_level = create(:script_level, :with_autoplay_video, lesson: lesson, script: script)
     assert_empty(non_legacy_script_level.level.concepts)
     get :show, params: {
       script_id: non_legacy_script_level.script,
@@ -373,7 +424,10 @@ class ScriptLevelsControllerTest < ActionController::TestCase
   end
 
   test 'should have autoplay video when never_autoplay_video is false on level' do
-    level_with_autoplay_video = create(:script_level, :never_autoplay_video_false)
+    script = create(:script)
+    lesson_group = create(:lesson_group, script: script)
+    lesson = create(:lesson, script: script, lesson_group: lesson_group)
+    level_with_autoplay_video = create(:script_level, :never_autoplay_video_false, lesson: lesson, script: script)
     get :show, params: {
       script_id: level_with_autoplay_video.script,
       stage_position: '1',
@@ -385,7 +439,10 @@ class ScriptLevelsControllerTest < ActionController::TestCase
   end
 
   test 'should not have autoplay video when never_autoplay_video is true on level' do
-    level_with_autoplay_video = create(:script_level, :never_autoplay_video_true)
+    script = create(:script)
+    lesson_group = create(:lesson_group, script: script)
+    lesson = create(:lesson, script: script, lesson_group: lesson_group)
+    level_with_autoplay_video = create(:script_level, :never_autoplay_video_true, lesson: lesson, script: script)
     get :show, params: {
       script_id: level_with_autoplay_video.script,
       stage_position: '1',
@@ -397,7 +454,10 @@ class ScriptLevelsControllerTest < ActionController::TestCase
   end
 
   test "shouldn't show autoplay video when already seen" do
-    non_legacy_script_level = create(:script_level, :with_autoplay_video)
+    script = create(:script)
+    lesson_group = create(:lesson_group, script: script)
+    lesson = create(:lesson, script: script, lesson_group: lesson_group)
+    non_legacy_script_level = create(:script_level, :with_autoplay_video, lesson: lesson, script: script)
     client_state.add_video_seen(non_legacy_script_level.level.video_key)
     get :show, params: {
       script_id: non_legacy_script_level.script,
@@ -410,7 +470,11 @@ class ScriptLevelsControllerTest < ActionController::TestCase
   end
 
   test 'non-legacy script level with concepts should have related but not autoplay video' do
-    non_legacy_script_level = create(:script_level)
+    script = create(:script)
+    lesson_group = create(:lesson_group, script: script)
+    lesson = create(:lesson, script: script, lesson_group: lesson_group)
+
+    non_legacy_script_level = create(:script_level, lesson: lesson, script: script)
     non_legacy_script_level.level.concepts = [create(:concept, :with_video)]
     get :show, params: {
       script_id: non_legacy_script_level.script,
@@ -445,7 +509,8 @@ class ScriptLevelsControllerTest < ActionController::TestCase
     create :script, name: 'courseg-2018', family_name: 'courseg', version_year: '2018', is_stable: true
     create :script, name: 'courseg-2019', family_name: 'courseg', version_year: '2019'
 
-    courseg_2017_stage_1 = create :lesson, script: courseg_2017, name: 'Course G Stage 1', absolute_position: 1, relative_position: '1'
+    courseg_2017_lesson_group_1 = create :lesson_group, script: courseg_2017
+    courseg_2017_stage_1 = create :lesson, script: courseg_2017, lesson_group: courseg_2017_lesson_group_1, name: 'Course G Stage 1', absolute_position: 1, relative_position: '1'
     courseg_2017_stage_1_script_level = create :script_level, script: courseg_2017, lesson: courseg_2017_stage_1, position: 1
 
     get :show, params: {
@@ -464,7 +529,8 @@ class ScriptLevelsControllerTest < ActionController::TestCase
     create :script, name: 'courseg-2018', family_name: 'courseg', version_year: '2018', is_stable: true
     create :script, name: 'courseg-2019', family_name: 'courseg', version_year: '2019'
 
-    courseg_2017_stage_1 = create :lesson, script: courseg_2017, name: 'Course G Stage 1', absolute_position: 1, relative_position: '1'
+    courseg_2017_lesson_group_1 = create :lesson_group, script: courseg_2017
+    courseg_2017_stage_1 = create :lesson, script: courseg_2017, lesson_group: courseg_2017_lesson_group_1, name: 'Course G Stage 1', absolute_position: 1, relative_position: '1'
     courseg_2017_stage_1_script_level = create :script_level, script: courseg_2017, lesson: courseg_2017_stage_1, position: 1
 
     get :show, params: {
@@ -561,9 +627,10 @@ class ScriptLevelsControllerTest < ActionController::TestCase
 
   test "next redirects to first non-unplugged level for custom scripts" do
     custom_script = create(:script, name: 'coolscript')
-    unplugged_stage = create(:lesson, script: custom_script, name: 'unplugged stage', absolute_position: 1)
+    lesson_group = create(:lesson_group, script: custom_script)
+    unplugged_stage = create(:lesson, script: custom_script, lesson_group: lesson_group, name: 'unplugged stage', absolute_position: 1)
     create(:script_level, levels: [create(:unplugged)], script: custom_script, lesson: unplugged_stage, position: 1)
-    plugged_stage = create(:lesson, script: custom_script, name: 'plugged stage', absolute_position: 2)
+    plugged_stage = create(:lesson, script: custom_script, lesson_group: lesson_group, name: 'plugged stage', absolute_position: 2)
     create(:script_level, script: custom_script, lesson: plugged_stage, position: 1)
 
     get :next, params: {script_id: 'coolscript'}
@@ -574,7 +641,8 @@ class ScriptLevelsControllerTest < ActionController::TestCase
     sign_in @student
 
     custom_script = create(:script, name: 'coolscript')
-    custom_stage_1 = create(:lesson, script: custom_script, name: 'neat stage', absolute_position: 1)
+    lesson_group = create(:lesson_group, script: custom_script)
+    custom_stage_1 = create(:lesson, script: custom_script, lesson_group: lesson_group, name: 'neat stage', absolute_position: 1)
     first_level = create(:script_level, script: custom_script, lesson: custom_stage_1, position: 1)
     UserLevel.create(user: @student, level: first_level.level, script: custom_script, attempts: 1, best_result: Activity::MINIMUM_PASS_RESULT)
     second_level = create(:script_level, script: custom_script, lesson: custom_stage_1, position: 2)
@@ -588,11 +656,12 @@ class ScriptLevelsControllerTest < ActionController::TestCase
 
   test "next skips entire unplugged stage" do
     custom_script = create(:script, name: 'coolscript')
-    unplugged_stage = create(:lesson, script: custom_script, name: 'unplugged stage', absolute_position: 1)
+    lesson_group = create(:lesson_group, script: custom_script)
+    unplugged_stage = create(:lesson, script: custom_script, lesson_group: lesson_group, name: 'unplugged stage', absolute_position: 1)
     create(:script_level, levels: [create(:unplugged)], script: custom_script, lesson: unplugged_stage, position: 1)
     create(:script_level, script: custom_script, lesson: unplugged_stage, position: 2)
     create(:script_level, script: custom_script, lesson: unplugged_stage, position: 3)
-    plugged_stage = create(:lesson, script: custom_script, name: 'plugged stage', absolute_position: 2)
+    plugged_stage = create(:lesson, script: custom_script, lesson_group: lesson_group, name: 'plugged stage', absolute_position: 2)
     create(:script_level, script: custom_script, lesson: plugged_stage, position: 1)
 
     get :next, params: {script_id: 'coolscript'}
@@ -601,7 +670,8 @@ class ScriptLevelsControllerTest < ActionController::TestCase
 
   test "next when only unplugged level goes back to home" do
     custom_script = create(:script, name: 'coolscript')
-    custom_stage_1 = create(:lesson, script: custom_script, name: 'neat stage', absolute_position: 1)
+    lesson_group = create(:lesson_group, script: custom_script)
+    custom_stage_1 = create(:lesson, script: custom_script, lesson_group: lesson_group, name: 'neat stage', absolute_position: 1)
     create(:script_level, levels: [create(:unplugged)], script: custom_script, lesson: custom_stage_1, position: 1)
 
     assert_raises RuntimeError do
@@ -742,8 +812,9 @@ class ScriptLevelsControllerTest < ActionController::TestCase
 
   test "should render blockly partial for blockly levels" do
     script = create(:script)
+    lesson_group = create(:lesson_group, script: script)
     level = create(:level, :blockly)
-    stage = create(:lesson, script: script)
+    stage = create(:lesson, script: script, lesson_group: lesson_group)
     script_level = create(:script_level, script: script, levels: [level], lesson: stage)
 
     get :show, params: {
@@ -759,8 +830,9 @@ class ScriptLevelsControllerTest < ActionController::TestCase
 
   test "with callout defined should define callout JS" do
     script = create(:script)
+    lesson_group = create(:lesson_group, script: script)
     level = create(:level, :blockly, user_id: nil)
-    stage = create(:lesson, script: script)
+    stage = create(:lesson, script: script, lesson_group: lesson_group)
     script_level = create(:script_level, script: script, levels: [level], lesson: stage)
 
     create(:callout, script_level: script_level)
@@ -931,8 +1003,11 @@ class ScriptLevelsControllerTest < ActionController::TestCase
 
     user_storage_id = storage_id_for_user_id(@student.id)
 
+    script = create :script
+    lesson_group = create(:lesson_group, script: script)
+    lesson = create(:lesson, script: script, lesson_group: lesson_group)
     level = create :applab
-    script_level = create :script_level, levels: [level]
+    script_level = create :script_level, levels: [level], lesson: lesson, script: script
     create(:user_level,
       user: @student,
       script: script_level.script,
@@ -962,8 +1037,11 @@ class ScriptLevelsControllerTest < ActionController::TestCase
 
     user_storage_id = storage_id_for_user_id(@student.id)
 
+    script = create :script
+    lesson_group = create(:lesson_group, script: script)
+    lesson = create(:lesson, script: script, lesson_group: lesson_group)
     level = create :applab
-    script_level = create :script_level, levels: [level]
+    script_level = create :script_level, levels: [level], lesson: lesson, script: script
     create(:user_level,
       user: @student,
       script: script_level.script,
@@ -994,12 +1072,15 @@ class ScriptLevelsControllerTest < ActionController::TestCase
 
     fake_last_attempt = 'STUDENT_LAST_ATTEMPT_SOURCE'
 
+    script = create :script
+    lesson_group = create(:lesson_group, script: script)
+    lesson = create(:lesson, script: script, lesson_group: lesson_group)
     level = create :applab
-    script_level = create :script_level, levels: [level]
+    script_level = create :script_level, levels: [level], lesson: lesson, script: script
     create(:user_level,
       user: @student,
-      script: script_level.script,
-      level: script_level.level,
+      script: script,
+      level: level,
       level_source: create(:level_source, data: fake_last_attempt)
     )
 
@@ -1023,8 +1104,11 @@ class ScriptLevelsControllerTest < ActionController::TestCase
 
     fake_last_attempt = 'STUDENT_LAST_ATTEMPT_SOURCE'
 
+    script = create :script
+    lesson_group = create(:lesson_group, script: script)
+    lesson = create(:lesson, script: script, lesson_group: lesson_group)
     level = create :applab
-    script_level = create :script_level, levels: [level]
+    script_level = create :script_level, levels: [level], lesson: lesson, script: script
     create(:user_level,
       user: @student,
       script: script_level.script,
@@ -1064,8 +1148,9 @@ class ScriptLevelsControllerTest < ActionController::TestCase
   test 'teacher cannot view solution to plc script' do
     sign_in @teacher
     script = create :script
+    lesson_group = create(:lesson_group, script: script)
     script.update(professional_learning_course: true)
-    stage = create(:lesson, script: script)
+    stage = create(:lesson, script: script, lesson_group: lesson_group)
     level = Artist.first
     script_level = create(:script_level, script: script, lesson: stage, levels: [level])
 
@@ -1133,14 +1218,17 @@ class ScriptLevelsControllerTest < ActionController::TestCase
     sign_in @student
 
     last_attempt_data = 'test'
+    script = create(:script)
+    lesson_group = create(:lesson_group, script: script)
+    lesson = create(:lesson, script: script, lesson_group: lesson_group)
     level = create(:applab, submittable: true)
-    script_level = create(:script_level, levels: [level])
+    script_level = create(:script_level, levels: [level], lesson: lesson, script: script)
     Activity.create!(level: level, user: @student, level_source: LevelSource.find_identical_or_create(level, last_attempt_data))
     ul = UserLevel.create!(level: level, script: script_level.script, user: @student, best_result: ActivityConstants::FREE_PLAY_RESULT, submitted: true)
 
     get :show, params: {
-      script_id: script_level.script,
-      stage_position: script_level.lesson,
+      script_id: script,
+      stage_position: lesson,
       id: script_level
     }
     assert_response :success
@@ -1180,26 +1268,37 @@ class ScriptLevelsControllerTest < ActionController::TestCase
   end
 
   test "should present single available level for single-level scriptlevels" do
+    script = create(:script)
+    lesson_group = create(:lesson_group, script: script)
+    lesson = create(:lesson, script: script, lesson_group: lesson_group)
     level = create :maze
-    get_show_script_level_page(create(:script_level, levels: [level]))
+    get_show_script_level_page(create(:script_level, levels: [level], lesson: lesson, script: script))
 
     assert_equal assigns(:level), level
   end
 
   test "should present first available level if missing properties" do
+    script = create(:script)
+    lesson_group = create(:lesson_group, script: script)
+    lesson = create(:lesson, script: script, lesson_group: lesson_group)
     level = create :maze
     level2 = create :maze
-    get_show_script_level_page(create(:script_level, levels: [level, level2]))
+    get_show_script_level_page(create(:script_level, levels: [level, level2], lesson: lesson, script: script))
 
     assert_equal assigns(:level), level
   end
 
   test "should present first level if active" do
+    script = create(:script)
+    lesson_group = create(:lesson_group, script: script)
+    lesson = create(:lesson, script: script, lesson_group: lesson_group)
     level = create :maze, name: 'maze 1'
     level2 = create :maze, name: 'maze 2'
     get_show_script_level_page(
       create(
         :script_level,
+        lesson: lesson,
+        script: script,
         levels: [level, level2],
         properties: {variants: {'maze 2': {'active': false}}}
       )
@@ -1208,11 +1307,16 @@ class ScriptLevelsControllerTest < ActionController::TestCase
   end
 
   test "should present second level if first is inactive" do
+    script = create(:script)
+    lesson_group = create(:lesson_group, script: script)
+    lesson = create(:lesson, script: script, lesson_group: lesson_group)
     level = create :maze, name: 'maze 1'
     level2 = create :maze, name: 'maze 2'
     get_show_script_level_page(
       create(
         :script_level,
+        lesson: lesson,
+        script: script,
         levels: [level, level2],
         properties: {'variants': {'maze 1': {'active': false}}}
       )
@@ -1221,12 +1325,17 @@ class ScriptLevelsControllerTest < ActionController::TestCase
   end
 
   test "should raise if all levels inactive" do
+    script = create(:script)
+    lesson_group = create(:lesson_group, script: script)
+    lesson = create(:lesson, script: script, lesson_group: lesson_group)
     level = create :maze, name: 'maze 1'
     level2 = create :maze, name: 'maze 2'
     assert_raises do
       get_show_script_level_page(
         create(
           :script_level,
+          lesson: lesson,
+          script: script,
           levels: [level, level2],
           properties: {'variants': {'maze 1': {'active': false}, 'maze 2': {'active': false}}}
         )
@@ -1236,6 +1345,9 @@ class ScriptLevelsControllerTest < ActionController::TestCase
 
   test "should present level with activity" do
     sign_in @student
+    script = create(:script)
+    lesson_group = create(:lesson_group, script: script)
+    lesson = create(:lesson, script: script, lesson_group: lesson_group)
     level = create :maze, name: 'maze 1'
     level2 = create :maze, name: 'maze 2'
     level_source = create :level_source, level: level, data: 'level source'
@@ -1245,6 +1357,8 @@ class ScriptLevelsControllerTest < ActionController::TestCase
     get_show_script_level_page(
       create(
         :script_level,
+        lesson: lesson,
+        script: script,
         levels: [level, level2],
         properties: {'variants': {'maze 1': {'active': false}}}
       )
@@ -1254,6 +1368,9 @@ class ScriptLevelsControllerTest < ActionController::TestCase
 
   test "should present level with most recent activity" do
     sign_in @student
+    script = create(:script)
+    lesson_group = create(:lesson_group, script: script)
+    lesson = create(:lesson, script: script, lesson_group: lesson_group)
     level = create :maze, name: 'maze 1'
     level2 = create :maze, name: 'maze 2'
     level_source = create :level_source, level: level, data: 'level source'
@@ -1266,6 +1383,8 @@ class ScriptLevelsControllerTest < ActionController::TestCase
     get_show_script_level_page(
       create(
         :script_level,
+        lesson: lesson,
+        script: script,
         levels: [level, level2],
         properties: {'variants': {'maze 1': {'active': false}}}
       )
@@ -1275,12 +1394,17 @@ class ScriptLevelsControllerTest < ActionController::TestCase
 
   test "should present experiment level if in the experiment" do
     sign_in @student
+    script = create(:script)
+    lesson_group = create(:lesson_group, script: script)
+    lesson = create(:lesson, script: script, lesson_group: lesson_group)
     experiment = create :single_user_experiment, min_user_id: @student.id
     level = create :maze, name: 'maze 1'
     level2 = create :maze, name: 'maze 2'
     get_show_script_level_page(
       create(
         :script_level,
+        lesson: lesson,
+        script: script,
         levels: [level, level2],
         properties: {'variants': {'maze 1': {'active': false, 'experiments': [experiment.name]}}}
       )
@@ -1291,12 +1415,17 @@ class ScriptLevelsControllerTest < ActionController::TestCase
 
   test "should present experiment level if in the section experiment" do
     sign_in @student
+    script = create(:script)
+    lesson_group = create(:lesson_group, script: script)
+    lesson = create(:lesson, script: script, lesson_group: lesson_group)
     experiment = create :single_section_experiment, section: @section
     level = create :maze, name: 'maze 1'
     level2 = create :maze, name: 'maze 2'
     get_show_script_level_page(
       create(
         :script_level,
+        lesson: lesson,
+        script: script,
         levels: [level, level2],
         properties: {'variants': {'maze 1': {'active': false, 'experiments': [experiment.name]}}}
       )
@@ -1307,6 +1436,9 @@ class ScriptLevelsControllerTest < ActionController::TestCase
 
   test "should present experiment level if in one of the experiments" do
     sign_in @student
+    script = create(:script)
+    lesson_group = create(:lesson_group, script: script)
+    lesson = create(:lesson, script: script, lesson_group: lesson_group)
     experiment1 = create :single_user_experiment, min_user_id: @student.id + 1
     experiment2 = create :single_user_experiment, min_user_id: @student.id
     level = create :maze, name: 'maze 1'
@@ -1314,6 +1446,8 @@ class ScriptLevelsControllerTest < ActionController::TestCase
     get_show_script_level_page(
       create(
         :script_level,
+        lesson: lesson,
+        script: script,
         levels: [level, level2],
         properties: {'variants': {'maze 1': {'active': false, 'experiments': [experiment1.name, experiment2.name]}}}
       )
@@ -1325,12 +1459,17 @@ class ScriptLevelsControllerTest < ActionController::TestCase
 
   test "should not present experiment level if not in the experiment" do
     sign_in @student
+    script = create(:script)
+    lesson_group = create(:lesson_group, script: script)
+    lesson = create(:lesson, script: script, lesson_group: lesson_group)
     experiment = create :single_user_experiment, min_user_id: @student.id + 1
     level = create :maze, name: 'maze 1'
     level2 = create :maze, name: 'maze 2'
     get_show_script_level_page(
       create(
         :script_level,
+        lesson: lesson,
+        script: script,
         levels: [level, level2],
         properties: {'variants': {'maze 1': {'active': false, 'experiments': [experiment.name]}}}
       )
@@ -1505,9 +1644,13 @@ class ScriptLevelsControllerTest < ActionController::TestCase
   test "should redirect when script has a redirect_to property" do
     script = create :script
     new_script = create :script
-    create(:script_level, script: script)
-    create(:script_level, script: script)
-    create(:script_level, script: new_script)
+    lesson_group = create(:lesson_group, script: script)
+    new_lesson_group = create(:lesson_group, script: new_script)
+    lesson = create(:lesson, script: script, lesson_group: lesson_group)
+    new_lesson = create(:lesson, script: new_script, lesson_group: new_lesson_group)
+    create(:script_level, script: script, lesson: lesson)
+    create(:script_level, script: script, lesson: lesson)
+    create(:script_level, script: new_script, lesson: new_lesson)
     script.update(redirect_to: new_script.name)
 
     get :show, params: {script_id: script.name, stage_position: '1', id: '2'}
@@ -1535,7 +1678,10 @@ class ScriptLevelsControllerTest < ActionController::TestCase
   end
 
   test "should indicate challenge levels as challenge levels" do
-    script_level = create :script_level,
+    script = create :script
+    lesson_group = create(:lesson_group, script: script)
+    lesson = create(:lesson, script: script, lesson_group: lesson_group)
+    script_level = create :script_level, lesson: lesson, script: script,
       properties: {challenge: true}
     get :show, params: {
       script_id: script_level.script,
@@ -1547,7 +1693,10 @@ class ScriptLevelsControllerTest < ActionController::TestCase
   end
 
   test "should not indicate non-challenge levels as challenge levels" do
-    script_level = create :script_level
+    script = create :script
+    lesson_group = create(:lesson_group, script: script)
+    lesson = create(:lesson, script: script, lesson_group: lesson_group)
+    script_level = create :script_level, lesson: lesson, script: script
     get :show, params: {
       script_id: script_level.script,
       stage_position: 1,
@@ -1558,11 +1707,14 @@ class ScriptLevelsControllerTest < ActionController::TestCase
   end
 
   test "specifying a bonus level name will direct to that level" do
-    script_level = create :script_level
+    script = create :script
+    lesson_group = create(:lesson_group, script: script)
+    lesson = create(:lesson, script: script, lesson_group: lesson_group)
+    script_level = create :script_level, lesson: lesson, script: script
     script_level.bonus = true
     script_level.save!
     get :stage_extras, params: {
-      script_id: script_level.script,
+      script_id: script,
       stage_position: 1,
       level_name: script_level.level.name
     }
@@ -1571,8 +1723,11 @@ class ScriptLevelsControllerTest < ActionController::TestCase
   end
 
   test "a bonus scriptlevel id takes precedence over level name" do
-    script_level_by_id = create :script_level
-    script_level_by_name = create :script_level, script: script_level_by_id.script
+    script = create :script
+    lesson_group = create(:lesson_group, script: script)
+    lesson = create(:lesson, script: script, lesson_group: lesson_group)
+    script_level_by_id = create :script_level, lesson: lesson, script: script
+    script_level_by_name = create :script_level, lesson: lesson, script: script
     script_level_by_id.bonus = true
     script_level_by_name.bonus = true
     script_level_by_id.save!
@@ -1588,8 +1743,11 @@ class ScriptLevelsControllerTest < ActionController::TestCase
   end
 
   test "a bad bonus level name shows extras page" do
-    script_level_by_id = create :script_level
-    script_level_by_name = create :script_level, script: script_level_by_id.script
+    script = create :script
+    lesson_group = create(:lesson_group, script: script)
+    lesson = create(:lesson, script: script, lesson_group: lesson_group)
+    script_level_by_id = create :script_level, lesson: lesson, script: script
+    script_level_by_name = create :script_level, lesson: lesson, script: script
     script_level_by_id.bonus = true
     script_level_by_name.bonus = true
     script_level_by_id.save!
@@ -1630,7 +1788,8 @@ class ScriptLevelsControllerTest < ActionController::TestCase
   def create_visible_after_script_level
     level = create :maze, name: 'maze 1', level_num: 'custom'
     script = create :script
-    stage = create :lesson, name: 'stage 1', script: script, visible_after: '2020-04-01 08:00:00 -0700'
+    lesson_group = create(:lesson_group, script: script)
+    stage = create :lesson, name: 'stage 1', script: script, lesson_group: lesson_group, visible_after: '2020-04-01 08:00:00 -0700'
     script_level = create :script_level, levels: [level], lesson: stage, script: script
 
     script_level
@@ -1646,14 +1805,15 @@ class ScriptLevelsControllerTest < ActionController::TestCase
 
       level = create :maze, name: 'maze 1', level_num: 'custom'
       script_with_visible_after_stages = create :script
+      lesson_group = create :lesson_group, script: script_with_visible_after_stages
 
-      stage_future_visible_after = create :lesson, name: 'stage 1', script: script_with_visible_after_stages, visible_after: '2020-04-01 08:00:00 -0700'
+      stage_future_visible_after = create :lesson, name: 'stage 1', script: script_with_visible_after_stages, lesson_group: lesson_group, visible_after: '2020-04-01 08:00:00 -0700'
       @script_level_future_visible_after = create :script_level, levels: [level], lesson: stage_future_visible_after, script: script_with_visible_after_stages
 
-      stage_past_visible_after = create :lesson, name: 'stage 2', script: script_with_visible_after_stages, visible_after: '2020-03-01 08:00:00 -0700'
+      stage_past_visible_after = create :lesson, name: 'stage 2', script: script_with_visible_after_stages, lesson_group: lesson_group, visible_after: '2020-03-01 08:00:00 -0700'
       @script_level_past_visible_after = create :script_level, levels: [level], lesson: stage_past_visible_after, script: script_with_visible_after_stages
 
-      stage_no_visible_after = create :lesson, name: 'stage 3', script: script_with_visible_after_stages
+      stage_no_visible_after = create :lesson, name: 'stage 3', script: script_with_visible_after_stages, lesson_group: lesson_group
       @script_level_no_visible_after = create :script_level, levels: [level], lesson: stage_no_visible_after, script: script_with_visible_after_stages
     end
 

--- a/dashboard/test/controllers/script_levels_controller_test.rb
+++ b/dashboard/test/controllers/script_levels_controller_test.rb
@@ -20,28 +20,28 @@ class ScriptLevelsControllerTest < ActionController::TestCase
 
     @custom_script = create(:script, name: 'laurel', hideable_lessons: true)
     @custom_lesson_group = create(:lesson_group, script: @custom_script)
-    @custom_stage_1 = create(:lesson, script: @custom_script, lesson_group: @custom_lesson_group, name: 'Laurel Stage 1', absolute_position: 1, relative_position: '1')
-    @custom_stage_2 = create(:lesson, script: @custom_script, lesson_group: @custom_lesson_group, name: 'Laurel Stage 2', absolute_position: 2, relative_position: '2')
-    @custom_stage_3 = create(:lesson, script: @custom_script, lesson_group: @custom_lesson_group, name: 'Laurel Stage 3', absolute_position: 3, relative_position: '3')
+    @custom_lesson_1 = create(:lesson, script: @custom_script, lesson_group: @custom_lesson_group, name: 'Laurel Stage 1', absolute_position: 1, relative_position: '1')
+    @custom_lesson_2 = create(:lesson, script: @custom_script, lesson_group: @custom_lesson_group, name: 'Laurel Stage 2', absolute_position: 2, relative_position: '2')
+    @custom_lesson_3 = create(:lesson, script: @custom_script, lesson_group: @custom_lesson_group, name: 'Laurel Stage 3', absolute_position: 3, relative_position: '3')
     @custom_s1_l1 = create(
       :script_level,
       script: @custom_script,
-      lesson: @custom_stage_1,
+      lesson: @custom_lesson_1,
       position: 1
     )
     @custom_s2_l1 = create(
       :script_level,
       script: @custom_script,
-      lesson: @custom_stage_2,
+      lesson: @custom_lesson_2,
       position: 1
     )
     @custom_s2_l2 = create(
       :script_level,
       script: @custom_script,
-      lesson: @custom_stage_2,
+      lesson: @custom_lesson_2,
       position: 2
     )
-    create(:script_level, script: @custom_script, lesson: @custom_stage_3, position: 1)
+    create(:script_level, script: @custom_script, lesson: @custom_lesson_3, position: 1)
 
     @script = @custom_script
     @script_level = @custom_s1_l1
@@ -510,13 +510,13 @@ class ScriptLevelsControllerTest < ActionController::TestCase
     create :script, name: 'courseg-2019', family_name: 'courseg', version_year: '2019'
 
     courseg_2017_lesson_group_1 = create :lesson_group, script: courseg_2017
-    courseg_2017_stage_1 = create :lesson, script: courseg_2017, lesson_group: courseg_2017_lesson_group_1, name: 'Course G Stage 1', absolute_position: 1, relative_position: '1'
-    courseg_2017_stage_1_script_level = create :script_level, script: courseg_2017, lesson: courseg_2017_stage_1, position: 1
+    courseg_2017_lesson_1 = create :lesson, script: courseg_2017, lesson_group: courseg_2017_lesson_group_1, name: 'Course G Stage 1', absolute_position: 1, relative_position: '1'
+    courseg_2017_lesson_1_script_level = create :script_level, script: courseg_2017, lesson: courseg_2017_lesson_1, position: 1
 
     get :show, params: {
       script_id: courseg_2017.name,
-      stage_position: courseg_2017_stage_1.relative_position,
-      id: courseg_2017_stage_1_script_level.position,
+      stage_position: courseg_2017_lesson_1.relative_position,
+      id: courseg_2017_lesson_1_script_level.position,
     }
 
     assert_redirected_to '/s/courseg-2018?redirect_warning=true'
@@ -530,21 +530,21 @@ class ScriptLevelsControllerTest < ActionController::TestCase
     create :script, name: 'courseg-2019', family_name: 'courseg', version_year: '2019'
 
     courseg_2017_lesson_group_1 = create :lesson_group, script: courseg_2017
-    courseg_2017_stage_1 = create :lesson, script: courseg_2017, lesson_group: courseg_2017_lesson_group_1, name: 'Course G Stage 1', absolute_position: 1, relative_position: '1'
-    courseg_2017_stage_1_script_level = create :script_level, script: courseg_2017, lesson: courseg_2017_stage_1, position: 1
+    courseg_2017_lesson_1 = create :lesson, script: courseg_2017, lesson_group: courseg_2017_lesson_group_1, name: 'Course G Stage 1', absolute_position: 1, relative_position: '1'
+    courseg_2017_lesson_1_script_level = create :script_level, script: courseg_2017, lesson: courseg_2017_lesson_1, position: 1
 
     get :show, params: {
       script_id: courseg_2017.name,
-      stage_position: courseg_2017_stage_1.relative_position,
-      id: courseg_2017_stage_1_script_level.position,
+      stage_position: courseg_2017_lesson_1.relative_position,
+      id: courseg_2017_lesson_1_script_level.position,
     }
     assert_redirected_to '/s/courseg-2018?redirect_warning=true'
 
     # Does not redirect if no_redirect query param is provided.
     get :show, params: {
       script_id: courseg_2017.name,
-      stage_position: courseg_2017_stage_1.relative_position,
-      id: courseg_2017_stage_1_script_level.position,
+      stage_position: courseg_2017_lesson_1.relative_position,
+      id: courseg_2017_lesson_1_script_level.position,
       no_redirect: "true"
     }
     assert_response :ok
@@ -587,7 +587,7 @@ class ScriptLevelsControllerTest < ActionController::TestCase
     assert_equal "/s/jigsaw/stage/1/puzzle/3", build_script_level_path(jigsaw_level)
   end
 
-  test "routing for custom scripts with stage" do
+  test "routing for custom scripts with lesson" do
     assert_routing(
       {method: "get", path: "/s/laurel/stage/1/puzzle/1"},
       {controller: "script_levels", action: "show", script_id: 'laurel', stage_position: "1", id: "1"}
@@ -628,10 +628,10 @@ class ScriptLevelsControllerTest < ActionController::TestCase
   test "next redirects to first non-unplugged level for custom scripts" do
     custom_script = create(:script, name: 'coolscript')
     lesson_group = create(:lesson_group, script: custom_script)
-    unplugged_stage = create(:lesson, script: custom_script, lesson_group: lesson_group, name: 'unplugged stage', absolute_position: 1)
-    create(:script_level, levels: [create(:unplugged)], script: custom_script, lesson: unplugged_stage, position: 1)
-    plugged_stage = create(:lesson, script: custom_script, lesson_group: lesson_group, name: 'plugged stage', absolute_position: 2)
-    create(:script_level, script: custom_script, lesson: plugged_stage, position: 1)
+    unplugged_lesson = create(:lesson, script: custom_script, lesson_group: lesson_group, name: 'unplugged lesson', absolute_position: 1)
+    create(:script_level, levels: [create(:unplugged)], script: custom_script, lesson: unplugged_lesson, position: 1)
+    plugged_lesson = create(:lesson, script: custom_script, lesson_group: lesson_group, name: 'plugged lesson', absolute_position: 2)
+    create(:script_level, script: custom_script, lesson: plugged_lesson, position: 1)
 
     get :next, params: {script_id: 'coolscript'}
     assert_redirected_to "/s/coolscript/stage/2/puzzle/1"
@@ -642,27 +642,27 @@ class ScriptLevelsControllerTest < ActionController::TestCase
 
     custom_script = create(:script, name: 'coolscript')
     lesson_group = create(:lesson_group, script: custom_script)
-    custom_stage_1 = create(:lesson, script: custom_script, lesson_group: lesson_group, name: 'neat stage', absolute_position: 1)
-    first_level = create(:script_level, script: custom_script, lesson: custom_stage_1, position: 1)
+    custom_lesson_1 = create(:lesson, script: custom_script, lesson_group: lesson_group, name: 'neat lesson', absolute_position: 1)
+    first_level = create(:script_level, script: custom_script, lesson: custom_lesson_1, position: 1)
     UserLevel.create(user: @student, level: first_level.level, script: custom_script, attempts: 1, best_result: Activity::MINIMUM_PASS_RESULT)
-    second_level = create(:script_level, script: custom_script, lesson: custom_stage_1, position: 2)
+    second_level = create(:script_level, script: custom_script, lesson: custom_lesson_1, position: 2)
     UserLevel.create(user: @student, level: second_level.level, script: custom_script, attempts: 1, best_result: Activity::MINIMUM_PASS_RESULT)
-    create(:script_level, levels: [create(:unplugged)], script: custom_script, lesson: custom_stage_1, position: 3)
-    last_level = create(:script_level, script: custom_script, lesson: custom_stage_1, position: 4)
+    create(:script_level, levels: [create(:unplugged)], script: custom_script, lesson: custom_lesson_1, position: 3)
+    last_level = create(:script_level, script: custom_script, lesson: custom_lesson_1, position: 4)
 
     get :next, params: {script_id: 'coolscript'}
     assert_redirected_to "/s/coolscript/stage/#{last_level.lesson.absolute_position}/puzzle/#{last_level.position}"
   end
 
-  test "next skips entire unplugged stage" do
+  test "next skips entire unplugged lesson" do
     custom_script = create(:script, name: 'coolscript')
     lesson_group = create(:lesson_group, script: custom_script)
-    unplugged_stage = create(:lesson, script: custom_script, lesson_group: lesson_group, name: 'unplugged stage', absolute_position: 1)
-    create(:script_level, levels: [create(:unplugged)], script: custom_script, lesson: unplugged_stage, position: 1)
-    create(:script_level, script: custom_script, lesson: unplugged_stage, position: 2)
-    create(:script_level, script: custom_script, lesson: unplugged_stage, position: 3)
-    plugged_stage = create(:lesson, script: custom_script, lesson_group: lesson_group, name: 'plugged stage', absolute_position: 2)
-    create(:script_level, script: custom_script, lesson: plugged_stage, position: 1)
+    unplugged_lesson = create(:lesson, script: custom_script, lesson_group: lesson_group, name: 'unplugged lesson', absolute_position: 1)
+    create(:script_level, levels: [create(:unplugged)], script: custom_script, lesson: unplugged_lesson, position: 1)
+    create(:script_level, script: custom_script, lesson: unplugged_lesson, position: 2)
+    create(:script_level, script: custom_script, lesson: unplugged_lesson, position: 3)
+    plugged_lesson = create(:lesson, script: custom_script, lesson_group: lesson_group, name: 'plugged lesson', absolute_position: 2)
+    create(:script_level, script: custom_script, lesson: plugged_lesson, position: 1)
 
     get :next, params: {script_id: 'coolscript'}
     assert_redirected_to "/s/coolscript/stage/2/puzzle/1"
@@ -671,8 +671,8 @@ class ScriptLevelsControllerTest < ActionController::TestCase
   test "next when only unplugged level goes back to home" do
     custom_script = create(:script, name: 'coolscript')
     lesson_group = create(:lesson_group, script: custom_script)
-    custom_stage_1 = create(:lesson, script: custom_script, lesson_group: lesson_group, name: 'neat stage', absolute_position: 1)
-    create(:script_level, levels: [create(:unplugged)], script: custom_script, lesson: custom_stage_1, position: 1)
+    custom_lesson_1 = create(:lesson, script: custom_script, lesson_group: lesson_group, name: 'neat lesson', absolute_position: 1)
+    create(:script_level, levels: [create(:unplugged)], script: custom_script, lesson: custom_lesson_1, position: 1)
 
     assert_raises RuntimeError do
       get :next, params: {script_id: 'coolscript'}
@@ -711,7 +711,7 @@ class ScriptLevelsControllerTest < ActionController::TestCase
     assert_redirected_to '/flappy/2'
   end
 
-  test "should show script level by stage and puzzle position" do
+  test "should show script level by lesson and puzzle position" do
     # this works for custom scripts
 
     get :show, params: {script_id: @custom_script, stage_position: 2, id: 1}
@@ -814,12 +814,12 @@ class ScriptLevelsControllerTest < ActionController::TestCase
     script = create(:script)
     lesson_group = create(:lesson_group, script: script)
     level = create(:level, :blockly)
-    stage = create(:lesson, script: script, lesson_group: lesson_group)
-    script_level = create(:script_level, script: script, levels: [level], lesson: stage)
+    lesson = create(:lesson, script: script, lesson_group: lesson_group)
+    script_level = create(:script_level, script: script, levels: [level], lesson: lesson)
 
     get :show, params: {
       script_id: script,
-      stage_position: stage.absolute_position,
+      stage_position: lesson.absolute_position,
       id: script_level.position
     }
 
@@ -832,14 +832,14 @@ class ScriptLevelsControllerTest < ActionController::TestCase
     script = create(:script)
     lesson_group = create(:lesson_group, script: script)
     level = create(:level, :blockly, user_id: nil)
-    stage = create(:lesson, script: script, lesson_group: lesson_group)
-    script_level = create(:script_level, script: script, levels: [level], lesson: stage)
+    lesson = create(:lesson, script: script, lesson_group: lesson_group)
+    script_level = create(:script_level, script: script, levels: [level], lesson: lesson)
 
     create(:callout, script_level: script_level)
 
     get :show, params: {
       script_id: script,
-      stage_position: stage.absolute_position,
+      stage_position: lesson.absolute_position,
       id: script_level.position
     }
 
@@ -892,7 +892,7 @@ class ScriptLevelsControllerTest < ActionController::TestCase
   #   assert(@response.body.include?('hoc_wrapup'))
   # end
 
-  # test 'end of HoC for signed-in users has no wrapup video, does have stage change info' do
+  # test 'end of HoC for signed-in users has no wrapup video, does have lesson change info' do
   #   get :show, {script_id: Script::HOC_NAME, chapter: '20'}
   #   assert(!@response.body.include?('hoc_wrapup'))
   #   assert(@response.body.include?('/s/1/level/show?chapter=next'))
@@ -944,7 +944,7 @@ class ScriptLevelsControllerTest < ActionController::TestCase
     end
   end
 
-  test "should 404 for invalid stage for course1" do
+  test "should 404 for invalid lesson for course1" do
     assert_raises(ActiveRecord::RecordNotFound) do # renders a 404 in prod
       get :show, params: {script_id: 'course1', stage_position: 4000, id: 1}
     end
@@ -969,7 +969,7 @@ class ScriptLevelsControllerTest < ActionController::TestCase
 
     get :show, params: {
       script_id: @custom_script,
-      stage_position: @custom_stage_1.absolute_position,
+      stage_position: @custom_lesson_1.absolute_position,
       id: @custom_s1_l1.position
     }
     assert_equal last_attempt_data, assigns(:last_attempt)
@@ -987,7 +987,7 @@ class ScriptLevelsControllerTest < ActionController::TestCase
 
     get :show, params: {
       script_id: @custom_script,
-      stage_position: @custom_stage_1.absolute_position,
+      stage_position: @custom_lesson_1.absolute_position,
       id: @custom_s1_l1.position,
       user_id: @student.id,
       section_id: @section.id
@@ -1137,7 +1137,7 @@ class ScriptLevelsControllerTest < ActionController::TestCase
 
     get :show, params: {
       script_id: @custom_script,
-      stage_position: @custom_stage_1.absolute_position,
+      stage_position: @custom_lesson_1.absolute_position,
       id: @custom_s1_l1.position
     }
 
@@ -1150,13 +1150,13 @@ class ScriptLevelsControllerTest < ActionController::TestCase
     script = create :script
     lesson_group = create(:lesson_group, script: script)
     script.update(professional_learning_course: true)
-    stage = create(:lesson, script: script, lesson_group: lesson_group)
+    lesson = create(:lesson, script: script, lesson_group: lesson_group)
     level = Artist.first
-    script_level = create(:script_level, script: script, lesson: stage, levels: [level])
+    script_level = create(:script_level, script: script, lesson: lesson, levels: [level])
 
     get :show, params: {
       script_id: script,
-      stage_position: stage,
+      stage_position: lesson,
       id: script_level,
       solution: true
     }
@@ -1487,14 +1487,14 @@ class ScriptLevelsControllerTest < ActionController::TestCase
   end
 
   test "hidden_stage_ids for user signed in" do
-    SectionHiddenLesson.create(section_id: @section.id, stage_id: @custom_stage_1.id)
+    SectionHiddenLesson.create(section_id: @section.id, stage_id: @custom_lesson_1.id)
 
     sign_in @student
     response = get :hidden_stage_ids, params: {script_id: @script.name}
     assert_response :success
 
     hidden = JSON.parse(response.body)
-    assert_equal [@custom_stage_1.id.to_s], hidden
+    assert_equal [@custom_lesson_1.id.to_s], hidden
   end
 
   def put_student_in_section(student, teacher, script)
@@ -1503,21 +1503,21 @@ class ScriptLevelsControllerTest < ActionController::TestCase
     section
   end
 
-  test "teacher can hide and unhide stages in sections they own" do
+  test "teacher can hide and unhide lessons in sections they own" do
     teacher = create :teacher
     student = create :student
     sign_in teacher
 
     section = put_student_in_section(student, teacher, @custom_script)
-    stage1 = @custom_script.lessons[0]
+    lesson1 = @custom_script.lessons[0]
     assert @custom_script.hideable_lessons
 
-    # start with no hidden stages
+    # start with no hidden lessons
     assert_equal 0, SectionHiddenLesson.where(section_id: section.id).length
 
     post :toggle_hidden, params: {
       script_id: @custom_script.id,
-      stage_id: stage1.id,
+      stage_id: lesson1.id,
       section_id: section.id,
       hidden: true
     }
@@ -1526,7 +1526,7 @@ class ScriptLevelsControllerTest < ActionController::TestCase
 
     post :toggle_hidden, params: {
       script_id: @custom_script.id,
-      stage_id: stage1.id,
+      stage_id: lesson1.id,
       section_id: section.id,
       hidden: false
     }
@@ -1558,9 +1558,9 @@ class ScriptLevelsControllerTest < ActionController::TestCase
     assert_equal 0, SectionHiddenScript.where(section_id: section.id).length
   end
 
-  test "teacher can't hide stages if script has hideable_lessons false" do
+  test "teacher can't hide lessons if script has hideable_lessons false" do
     script = create(:script, hideable_lessons: false)
-    stage = create(:lesson, script: script)
+    lesson = create(:lesson, script: script)
 
     teacher = create :teacher
     student = create :student
@@ -1571,7 +1571,7 @@ class ScriptLevelsControllerTest < ActionController::TestCase
 
     post :toggle_hidden, params: {
       script_id: script.id,
-      stage_id: stage.id,
+      stage_id: lesson.id,
       section_id: section.id,
       hidden: true
     }
@@ -1579,31 +1579,31 @@ class ScriptLevelsControllerTest < ActionController::TestCase
     assert_equal 0, SectionHiddenLesson.where(section_id: section.id).length
   end
 
-  test "teacher can't hide or unhide stages in sections they don't own" do
+  test "teacher can't hide or unhide lessons in sections they don't own" do
     teacher = create :teacher
     other_teacher = create :teacher
     student = create :student
     sign_in teacher
 
     section = put_student_in_section(student, other_teacher, @custom_script)
-    stage1 = @custom_script.lessons[0]
+    lesson1 = @custom_script.lessons[0]
     assert @custom_script.hideable_lessons
 
     post :toggle_hidden, params: {
       script_id: @custom_script.id,
-      stage_id: stage1.id,
+      stage_id: lesson1.id,
       section_id: section.id,
       hidden: "true"
     }
     assert_response 403
 
     # add a SectionHiddenLesson directly
-    SectionHiddenLesson.create(stage_id: stage1.id, section_id: section.id)
+    SectionHiddenLesson.create(stage_id: lesson1.id, section_id: section.id)
 
     # try to unhide
     post :toggle_hidden, params: {
       script_id: @custom_script.id,
-      stage_id: stage1.id,
+      stage_id: lesson1.id,
       section_id: section.id,
       hidden: "false"
     }
@@ -1789,8 +1789,8 @@ class ScriptLevelsControllerTest < ActionController::TestCase
     level = create :maze, name: 'maze 1', level_num: 'custom'
     script = create :script
     lesson_group = create(:lesson_group, script: script)
-    stage = create :lesson, name: 'stage 1', script: script, lesson_group: lesson_group, visible_after: '2020-04-01 08:00:00 -0700'
-    script_level = create :script_level, levels: [level], lesson: stage, script: script
+    lesson = create :lesson, name: 'lesson 1', script: script, lesson_group: lesson_group, visible_after: '2020-04-01 08:00:00 -0700'
+    script_level = create :script_level, levels: [level], lesson: lesson, script: script
 
     script_level
   end
@@ -1804,24 +1804,24 @@ class ScriptLevelsControllerTest < ActionController::TestCase
       Timecop.freeze(Time.new(2020, 3, 27, 0, 0, 0, "-07:00"))
 
       level = create :maze, name: 'maze 1', level_num: 'custom'
-      script_with_visible_after_stages = create :script
-      lesson_group = create :lesson_group, script: script_with_visible_after_stages
+      script_with_visible_after_lessons = create :script
+      lesson_group = create :lesson_group, script: script_with_visible_after_lessons
 
-      stage_future_visible_after = create :lesson, name: 'stage 1', script: script_with_visible_after_stages, lesson_group: lesson_group, visible_after: '2020-04-01 08:00:00 -0700'
-      @script_level_future_visible_after = create :script_level, levels: [level], lesson: stage_future_visible_after, script: script_with_visible_after_stages
+      lesson_future_visible_after = create :lesson, name: 'lesson 1', script: script_with_visible_after_lessons, lesson_group: lesson_group, visible_after: '2020-04-01 08:00:00 -0700'
+      @script_level_future_visible_after = create :script_level, levels: [level], lesson: lesson_future_visible_after, script: script_with_visible_after_lessons
 
-      stage_past_visible_after = create :lesson, name: 'stage 2', script: script_with_visible_after_stages, lesson_group: lesson_group, visible_after: '2020-03-01 08:00:00 -0700'
-      @script_level_past_visible_after = create :script_level, levels: [level], lesson: stage_past_visible_after, script: script_with_visible_after_stages
+      lesson_past_visible_after = create :lesson, name: 'lesson 2', script: script_with_visible_after_lessons, lesson_group: lesson_group, visible_after: '2020-03-01 08:00:00 -0700'
+      @script_level_past_visible_after = create :script_level, levels: [level], lesson: lesson_past_visible_after, script: script_with_visible_after_lessons
 
-      stage_no_visible_after = create :lesson, name: 'stage 3', script: script_with_visible_after_stages, lesson_group: lesson_group
-      @script_level_no_visible_after = create :script_level, levels: [level], lesson: stage_no_visible_after, script: script_with_visible_after_stages
+      lesson_no_visible_after = create :lesson, name: 'lesson 3', script: script_with_visible_after_lessons, lesson_group: lesson_group
+      @script_level_no_visible_after = create :script_level, levels: [level], lesson: lesson_no_visible_after, script: script_with_visible_after_lessons
     end
 
     teardown do
       Timecop.return
     end
 
-    test 'levelbuilder can view level in stage with future visible after date' do
+    test 'levelbuilder can view level in lesson with future visible after date' do
       sign_in @levelbuilder
 
       get :show, params: {
@@ -1832,7 +1832,7 @@ class ScriptLevelsControllerTest < ActionController::TestCase
       assert_response :success
     end
 
-    test 'levelbuilder can view level in stage with past visible after date' do
+    test 'levelbuilder can view level in lesson with past visible after date' do
       sign_in @levelbuilder
 
       get :show, params: {
@@ -1843,7 +1843,7 @@ class ScriptLevelsControllerTest < ActionController::TestCase
       assert_response :success
     end
 
-    test 'teacher can not view level in stage with future visible after date' do
+    test 'teacher can not view level in lesson with future visible after date' do
       sign_in @teacher
 
       get :show, params: {
@@ -1854,7 +1854,7 @@ class ScriptLevelsControllerTest < ActionController::TestCase
       assert_response :forbidden
     end
 
-    test 'teacher can view level in stage with past visible after date' do
+    test 'teacher can view level in lesson with past visible after date' do
       sign_in @teacher
 
       get :show, params: {
@@ -1865,7 +1865,7 @@ class ScriptLevelsControllerTest < ActionController::TestCase
       assert_response :success
     end
 
-    test 'student can not view level in stage with future visible after date' do
+    test 'student can not view level in lesson with future visible after date' do
       sign_in @teacher
 
       get :show, params: {
@@ -1876,7 +1876,7 @@ class ScriptLevelsControllerTest < ActionController::TestCase
       assert_response :forbidden
     end
 
-    test 'student can view level in stage with past visible after date' do
+    test 'student can view level in lesson with past visible after date' do
       sign_in @teacher
 
       get :show, params: {
@@ -1887,7 +1887,7 @@ class ScriptLevelsControllerTest < ActionController::TestCase
       assert_response :success
     end
 
-    test 'unsigned in user can not view level in stage with future visible after date' do
+    test 'unsigned in user can not view level in lesson with future visible after date' do
       sign_out :user
 
       get :show, params: {
@@ -1898,7 +1898,7 @@ class ScriptLevelsControllerTest < ActionController::TestCase
       assert_response :forbidden
     end
 
-    test 'unsigned in user can view level in stage with past visible after date' do
+    test 'unsigned in user can view level in lesson with past visible after date' do
       sign_out :user
 
       get :show, params: {

--- a/dashboard/test/integration/callouts_test.rb
+++ b/dashboard/test/integration/callouts_test.rb
@@ -4,15 +4,18 @@ class CalloutsTest < ActionDispatch::IntegrationTest
   setup do
     Script.stubs(:should_cache?).returns true
     Rails.application.config.stubs(:levelbuilder_mode).returns false
+    @script = create :script
+    @lesson_group = create :lesson_group, script: @script
+    @lesson = create :lesson, script: @script, lesson_group: @lesson_group
     @maze_data = {game_id: 25, user_id: 1, name: '__bob4', level_num: 'custom', skin: 'birds', short_instructions: 'sdfdfs'}
     @level = Maze.create(@maze_data)
     @level.callout_json = '[{"localization_key": "run", "element_id": "#runButton"}]'
     @level.save!
-    @script_level = create(:script_level, levels: [@level])
+    @script_level = create(:script_level, levels: [@level], lesson: @lesson, script: @script)
     @level_path = "/levels/#{@level.id}"
-    @script_level_path = "/s/#{@script_level.script.name}/stage/1/puzzle/1"
-    Script.script_cache.delete @script_level.script.name
-    Script.script_cache.delete @script_level.script.id.to_s
+    @script_level_path = "/s/#{@script.name}/stage/1/puzzle/1"
+    Script.script_cache.delete @script.name
+    Script.script_cache.delete @script.id.to_s
 
     @expected_callouts = [{
       "id" => nil,

--- a/dashboard/test/models/plc/course_unit_module_selection_test.rb
+++ b/dashboard/test/models/plc/course_unit_module_selection_test.rb
@@ -7,8 +7,8 @@ class CourseUnitModuleSelectionTest < ActionView::TestCase
 
     @course_unit = create(:plc_course_unit, plc_course: course)
 
-    @content_lesson_group = create(:lesson_group, key: Plc::LearningModule::CONTENT_MODULE)
-    @practice_lesson_group = create(:lesson_group, key: Plc::LearningModule::PRACTICE_MODULE)
+    @content_lesson_group = create(:lesson_group, key: Plc::LearningModule::CONTENT_MODULE, script: @course_unit.script)
+    @practice_lesson_group = create(:lesson_group, key: Plc::LearningModule::PRACTICE_MODULE, script: @course_unit.script)
 
     @lesson_cliffs = create(:lesson, name: 'Cliff lesson', script: @course_unit.script, lesson_group: @content_lesson_group)
     @lesson_ornithology = create(:lesson, name: 'Ornithology lesson', script: @course_unit.script, lesson_group: @content_lesson_group)
@@ -86,7 +86,7 @@ class CourseUnitModuleSelectionTest < ActionView::TestCase
     DSL
 
     @evaluation = LevelGroup.create_from_level_builder({name: 'evaluation'}, {dsl_text: levelgroup_dsl})
-    create(:script_level, script: @course_unit.script, levels: [@evaluation])
+    create(:script_level, script: @course_unit.script, levels: [@evaluation], lesson: @lesson_honesty)
     @user_level = create(:user_level, user: @user, script: @course_unit.script, level: @evaluation)
     @activity = create(:activity, user: @user, level: @evaluation)
     @user_level = create(:user_level, user: @user, level: @evaluation)

--- a/dashboard/test/models/script_level_test.rb
+++ b/dashboard/test/models/script_level_test.rb
@@ -698,7 +698,7 @@ class ScriptLevelTest < ActiveSupport::TestCase
     @plc_script = @plc_course_unit.script
     @plc_script.update(professional_learning_course: 'My course name')
     @lesson_group = create(:lesson_group, script: @plc_script)
-    @lesson = create(:lesson, script: @plc_script)
+    @lesson = create(:lesson, script: @plc_script, lesson_group: @lesson_group)
     @level1 = create(:maze)
     create(:evaluation_multi, name: 'Evaluation Multi')
     evaluation_level_dsl = <<~DSL

--- a/dashboard/test/models/sections/section_test.rb
+++ b/dashboard/test/models/sections/section_test.rb
@@ -568,7 +568,8 @@ class SectionTest < ActiveSupport::TestCase
 
     def create_script_with_levels(name, level_type)
       script = Script.find_by_name(name) || create(:script, name: name)
-      stage = create :lesson, script: script
+      lesson_group = create :lesson_group, script: script
+      stage = create :lesson, script: script, lesson_group: lesson_group
       # 5 non-programming levels
       5.times do
         create :script_level, script: script, lesson: stage, levels: [create(:unplugged)]

--- a/dashboard/test/models/sections/section_test.rb
+++ b/dashboard/test/models/sections/section_test.rb
@@ -569,15 +569,15 @@ class SectionTest < ActiveSupport::TestCase
     def create_script_with_levels(name, level_type)
       script = Script.find_by_name(name) || create(:script, name: name)
       lesson_group = create :lesson_group, script: script
-      stage = create :lesson, script: script, lesson_group: lesson_group
+      lesson = create :lesson, script: script, lesson_group: lesson_group
       # 5 non-programming levels
       5.times do
-        create :script_level, script: script, lesson: stage, levels: [create(:unplugged)]
+        create :script_level, script: script, lesson: lesson, levels: [create(:unplugged)]
       end
 
       # 5 programming levels
       5.times do
-        create :script_level, script: script, lesson: stage, levels: [create(level_type)]
+        create :script_level, script: script, lesson: lesson, levels: [create(level_type)]
       end
       script
     end

--- a/dashboard/test/models/user_test.rb
+++ b/dashboard/test/models/user_test.rb
@@ -1007,11 +1007,13 @@ class UserTest < ActiveSupport::TestCase
   test 'can get next_unpassed_progression_level when most recent level is only followed by unplugged levels' do
     user = create :user
     script = create :script
+    lesson_group = create :lesson_group, script: script
+    lesson = create :lesson, script: script, lesson_group: lesson_group
 
     script_levels = [
-      create(:script_level, script: script, levels: [create(:maze)]),
-      create(:script_level, script: script, levels: [create(:maze)]),
-      create(:script_level, script: script, levels: [create(:unplugged)]),
+      create(:script_level, script: script, lesson: lesson, levels: [create(:maze)]),
+      create(:script_level, script: script, lesson: lesson, levels: [create(:maze)]),
+      create(:script_level, script: script, lesson: lesson, levels: [create(:unplugged)]),
     ]
     create :user_script, user: user, script: script
 
@@ -1032,12 +1034,14 @@ class UserTest < ActiveSupport::TestCase
   test 'can get next_unpassed_progression_level when most recent level not a progression level' do
     user = create :user
     script = create :script
+    lesson_group = create :lesson_group, script: script
+    lesson = create :lesson, script: script, lesson_group: lesson_group
 
     script_levels = [
-      create(:script_level, script: script, levels: [create(:maze)]),
-      create(:script_level, script: script, levels: [create(:unplugged)]),
-      create(:script_level, script: script, levels: [create(:unplugged)]),
-      create(:script_level, script: script, levels: [create(:maze)]),
+      create(:script_level, script: script, lesson: lesson, levels: [create(:maze)]),
+      create(:script_level, script: script, lesson: lesson, levels: [create(:unplugged)]),
+      create(:script_level, script: script, lesson: lesson, levels: [create(:unplugged)]),
+      create(:script_level, script: script, lesson: lesson, levels: [create(:maze)]),
     ]
     create :user_script, user: user, script: script
 
@@ -1057,9 +1061,11 @@ class UserTest < ActiveSupport::TestCase
   test 'can get next_unpassed_progression_level when we have no progress' do
     user = create :user
     script = create :script
+    lesson_group = create :lesson_group, script: script
+    lesson = create :lesson, script: script, lesson_group: lesson_group
 
-    create(:script_level, script: script, levels: [create(:maze)])
-    create(:script_level, script: script, levels: [create(:maze)])
+    create(:script_level, script: script, lesson: lesson, levels: [create(:maze)])
+    create(:script_level, script: script, lesson: lesson, levels: [create(:maze)])
     create :user_script, user: user, script: script
 
     # User's most recent progress is on unplugged level, that is followed by another

--- a/dashboard/test/models/user_test.rb
+++ b/dashboard/test/models/user_test.rb
@@ -3545,28 +3545,28 @@ class UserTest < ActiveSupport::TestCase
       @teacher = create :teacher
 
       @script = create(:script, hideable_lessons: true)
-      @stage1 = create(:lesson, script: @script, absolute_position: 1, relative_position: '1')
-      @stage2 = create(:lesson, script: @script, absolute_position: 2, relative_position: '2')
-      @stage3 = create(:lesson, script: @script, absolute_position: 3, relative_position: '3')
+      @lesson1 = create(:lesson, script: @script, absolute_position: 1, relative_position: '1')
+      @lesson2 = create(:lesson, script: @script, absolute_position: 2, relative_position: '2')
+      @lesson3 = create(:lesson, script: @script, absolute_position: 3, relative_position: '3')
       @custom_s1_l1 = create(
         :script_level,
         script: @script,
-        lesson: @stage1,
+        lesson: @lesson1,
         position: 1
       )
       @custom_s2_l1 = create(
         :script_level,
         script: @script,
-        lesson: @stage2,
+        lesson: @lesson2,
         position: 1
       )
       @custom_s2_l2 = create(
         :script_level,
         script: @script,
-        lesson: @stage2,
+        lesson: @lesson2,
         position: 2
       )
-      create(:script_level, script: @script, lesson: @stage3, position: 1)
+      create(:script_level, script: @script, lesson: @lesson3, position: 1)
 
       # explicitly disable LB mode so that we don't create a .course file
       Rails.application.config.stubs(:levelbuilder_mode).returns false
@@ -3585,20 +3585,20 @@ class UserTest < ActiveSupport::TestCase
       section
     end
 
-    # Helper method that sets up some hidden stages for our two sections
-    def hide_stages_in_sections(section1, section2)
-      # stage 1 hidden in both sections
-      SectionHiddenLesson.create(section_id: section1.id, stage_id: @stage1.id)
-      SectionHiddenLesson.create(section_id: section2.id, stage_id: @stage1.id)
+    # Helper method that sets up some hidden lessons for our two sections
+    def hide_lessons_in_sections(section1, section2)
+      # lesson 1 hidden in both sections
+      SectionHiddenLesson.create(section_id: section1.id, stage_id: @lesson1.id)
+      SectionHiddenLesson.create(section_id: section2.id, stage_id: @lesson1.id)
 
-      # stage 2 hidden in section 1
-      SectionHiddenLesson.create(section_id: section1.id, stage_id: @stage2.id)
+      # lesson 2 hidden in section 1
+      SectionHiddenLesson.create(section_id: section1.id, stage_id: @lesson2.id)
 
-      # stage 3 hidden in section 2
-      SectionHiddenLesson.create(section_id: section2.id, stage_id: @stage3.id)
+      # lesson 3 hidden in section 2
+      SectionHiddenLesson.create(section_id: section2.id, stage_id: @lesson3.id)
     end
 
-    # Same thing as hide_stages_in_sections, but hides scripts instead of stages
+    # Same thing as hide_lessons_in_sections, but hides scripts instead of lessons
     def hide_scripts_in_sections(section1, section2)
       # script hidden in both sections
       SectionHiddenScript.create(section_id: section1.id, script_id: @script.id)
@@ -3616,7 +3616,7 @@ class UserTest < ActiveSupport::TestCase
       teacher = create :teacher
       twenty_hour = Script.twenty_hour_script
 
-      # User completed the second stage
+      # User completed the second lesson
       twenty_hour.lessons[1].script_levels.each do |sl|
         UserLevel.create(
           user: student,
@@ -3627,16 +3627,16 @@ class UserTest < ActiveSupport::TestCase
         )
       end
 
-      # Hide the fifth lesson/stage
+      # Hide the fifth lesson/lesson
       SectionHiddenLesson.create(
         section_id: put_student_in_section(student, teacher, twenty_hour).id,
         stage_id: 5
       )
 
-      # Find the seventh stage, since the 5th is hidden and 6th is unplugged
-      next_visible_stage = twenty_hour.lessons.find {|stage| stage.relative_position == 7}
+      # Find the seventh lesson, since the 5th is hidden and 6th is unplugged
+      next_visible_lesson = twenty_hour.lessons.find {|lesson| lesson.relative_position == 7}
 
-      assert_equal(next_visible_stage.script_levels.first, student.next_unpassed_visible_progression_level(twenty_hour))
+      assert_equal(next_visible_lesson.script_levels.first, student.next_unpassed_visible_progression_level(twenty_hour))
     end
 
     test 'can get next_unpassed_visible_progression_level, last level complete, but script not complete, first hidden' do
@@ -3652,16 +3652,16 @@ class UserTest < ActiveSupport::TestCase
         best_result: Activity::MINIMUM_PASS_RESULT
       )
 
-      # Hide the first lesson/stage
+      # Hide the first lesson/lesson
       SectionHiddenLesson.create(
         section_id: put_student_in_section(student, teacher, twenty_hour).id,
         stage_id: 1
       )
 
-      # Find the second stage, since the 1st is hidden
-      next_visible_stage = twenty_hour.lessons.find {|stage| stage.relative_position == 2}
+      # Find the second lesson, since the 1st is hidden
+      next_visible_lesson = twenty_hour.lessons.find {|lesson| lesson.relative_position == 2}
 
-      assert_equal(next_visible_stage.script_levels.first, student.next_unpassed_visible_progression_level(twenty_hour))
+      assert_equal(next_visible_lesson.script_levels.first, student.next_unpassed_visible_progression_level(twenty_hour))
     end
 
     test "user in two sections, both attached to script" do
@@ -3670,15 +3670,15 @@ class UserTest < ActiveSupport::TestCase
       section1 = put_student_in_section(student, @teacher, @script)
       section2 = put_student_in_section(student, @teacher, @script)
 
-      hide_stages_in_sections(section1, section2)
+      hide_lessons_in_sections(section1, section2)
 
       # when attached to script, we should hide only if hidden in every section
-      assert_equal [@stage1.id], student.get_hidden_stage_ids(@script.name)
+      assert_equal [@lesson1.id], student.get_hidden_stage_ids(@script.name)
 
       # validate script_level_hidden? gives same result
-      assert_equal true, student.script_level_hidden?(@stage1.script_levels.first)
-      assert_equal false, student.script_level_hidden?(@stage2.script_levels.first)
-      assert_equal false, student.script_level_hidden?(@stage3.script_levels.first)
+      assert_equal true, student.script_level_hidden?(@lesson1.script_levels.first)
+      assert_equal false, student.script_level_hidden?(@lesson2.script_levels.first)
+      assert_equal false, student.script_level_hidden?(@lesson3.script_levels.first)
     end
 
     test "user in two sections, both attached to course" do
@@ -3732,15 +3732,15 @@ class UserTest < ActiveSupport::TestCase
       section1 = put_student_in_section(student, @teacher, unattached_script)
       section2 = put_student_in_section(student, @teacher, unattached_script)
 
-      hide_stages_in_sections(section1, section2)
+      hide_lessons_in_sections(section1, section2)
 
       # when not attached to script, we should hide when hidden in any section
-      assert_equal [@stage1.id, @stage2.id, @stage3.id], student.get_hidden_stage_ids(@script.name)
+      assert_equal [@lesson1.id, @lesson2.id, @lesson3.id], student.get_hidden_stage_ids(@script.name)
 
       # validate script_level_hidden? gives same result
-      assert_equal true, student.script_level_hidden?(@stage1.script_levels.first)
-      assert_equal true, student.script_level_hidden?(@stage2.script_levels.first)
-      assert_equal true, student.script_level_hidden?(@stage3.script_levels.first)
+      assert_equal true, student.script_level_hidden?(@lesson1.script_levels.first)
+      assert_equal true, student.script_level_hidden?(@lesson2.script_levels.first)
+      assert_equal true, student.script_level_hidden?(@lesson3.script_levels.first)
     end
 
     test "user in two sections, neither attached to course" do
@@ -3762,15 +3762,15 @@ class UserTest < ActiveSupport::TestCase
       attached_section = put_student_in_section(student, @teacher, @script)
       unattached_section = put_student_in_section(student, @teacher, create(:script))
 
-      hide_stages_in_sections(attached_section, unattached_section)
+      hide_lessons_in_sections(attached_section, unattached_section)
 
-      # only the stages hidden in the attached section are considered hidden
-      assert_equal [@stage1.id, @stage2.id], student.get_hidden_stage_ids(@script.name)
+      # only the lessons hidden in the attached section are considered hidden
+      assert_equal [@lesson1.id, @lesson2.id], student.get_hidden_stage_ids(@script.name)
 
       # validate script_level_hidden? gives same result
-      assert_equal true, student.script_level_hidden?(@stage1.script_levels.first)
-      assert_equal true, student.script_level_hidden?(@stage2.script_levels.first)
-      assert_equal false, student.script_level_hidden?(@stage3.script_levels.first)
+      assert_equal true, student.script_level_hidden?(@lesson1.script_levels.first)
+      assert_equal true, student.script_level_hidden?(@lesson2.script_levels.first)
+      assert_equal false, student.script_level_hidden?(@lesson3.script_levels.first)
     end
 
     test "user in two sections, one attached to course one not" do
@@ -3791,7 +3791,7 @@ class UserTest < ActiveSupport::TestCase
       assert_equal [], student.get_hidden_stage_ids(@script.name)
     end
 
-    test "teacher gets hidden stages for sections they own" do
+    test "teacher gets hidden lessons for sections they own" do
       teacher = create :teacher
       teacher_teacher = create :teacher
       student = create :student
@@ -3800,20 +3800,20 @@ class UserTest < ActiveSupport::TestCase
       teacher_owner_section2 = put_student_in_section(student, teacher, @script)
       teacher_member_section = put_student_in_section(teacher, teacher_teacher, @script)
 
-      # stage 1 is hidden in the first section owned by the teacher
-      SectionHiddenLesson.create(section_id: teacher_owner_section.id, stage_id: @stage1.id)
+      # lesson 1 is hidden in the first section owned by the teacher
+      SectionHiddenLesson.create(section_id: teacher_owner_section.id, stage_id: @lesson1.id)
 
-      # stage 1 and 2 are hidden in the second section owned by the teacher
-      SectionHiddenLesson.create(section_id: teacher_owner_section2.id, stage_id: @stage1.id)
-      SectionHiddenLesson.create(section_id: teacher_owner_section2.id, stage_id: @stage2.id)
+      # lesson 1 and 2 are hidden in the second section owned by the teacher
+      SectionHiddenLesson.create(section_id: teacher_owner_section2.id, stage_id: @lesson1.id)
+      SectionHiddenLesson.create(section_id: teacher_owner_section2.id, stage_id: @lesson2.id)
 
-      # stage 3 is hidden in the section in which the teacher is a member
-      SectionHiddenLesson.create(section_id: teacher_member_section.id, stage_id: @stage3.id)
+      # lesson 3 is hidden in the section in which the teacher is a member
+      SectionHiddenLesson.create(section_id: teacher_member_section.id, stage_id: @lesson3.id)
 
-      # only the stages hidden in the owned section are considered hidden
+      # only the lessons hidden in the owned section are considered hidden
       expected = {
-        teacher_owner_section.id => [@stage1.id],
-        teacher_owner_section2.id => [@stage1.id, @stage2.id]
+        teacher_owner_section.id => [@lesson1.id],
+        teacher_owner_section2.id => [@lesson1.id, @lesson2.id]
       }
       assert_equal expected, teacher.get_hidden_stage_ids(@script.id)
     end
@@ -3827,14 +3827,14 @@ class UserTest < ActiveSupport::TestCase
       teacher_owner_section2 = put_student_in_section(student, teacher, @script, @course)
       teacher_member_section = put_student_in_section(teacher, teacher_teacher, @script, @course)
 
-      # stage 1 is hidden in the first section owned by the teacher
+      # lesson 1 is hidden in the first section owned by the teacher
       SectionHiddenScript.create(section_id: teacher_owner_section.id, script_id: @script.id)
 
-      # stage 1 and 2 are hidden in the second section owned by the teacher
+      # lesson 1 and 2 are hidden in the second section owned by the teacher
       SectionHiddenScript.create(section_id: teacher_owner_section2.id, script_id: @script.id)
       SectionHiddenScript.create(section_id: teacher_owner_section2.id, script_id: @script2.id)
 
-      # stage 3 is hidden in the section in which the teacher is a member
+      # lesson 3 is hidden in the section in which the teacher is a member
       SectionHiddenScript.create(section_id: teacher_member_section.id, script_id: @script3.id)
 
       # only the scripts hidden in the owned section are considered hidden
@@ -3863,16 +3863,16 @@ class UserTest < ActiveSupport::TestCase
     # construct our fake applab-intro script
     script = create :script
     lesson_group = create :lesson_group, script: script
-    stage = create :lesson, script: script, lesson_group: lesson_group
+    lesson = create :lesson, script: script, lesson_group: lesson_group
     regular_level = create :level
-    create :script_level, script: script, lesson: stage, levels: [regular_level]
+    create :script_level, script: script, lesson: lesson, levels: [regular_level]
 
     # two different levels, backed by the same template level
     template_level = create :level
     template_backed_level1 = create :level, project_template_level_name: template_level.name
-    create :script_level, script: script, lesson: stage, levels: [template_backed_level1]
+    create :script_level, script: script, lesson: lesson, levels: [template_backed_level1]
     template_backed_level2 = create :level, project_template_level_name: template_level.name
-    create :script_level, script: script, lesson: stage, levels: [template_backed_level2]
+    create :script_level, script: script, lesson: lesson, levels: [template_backed_level2]
 
     # Whether we have a channel for a regular level in the script, or a template
     # level, we generate a UserScript


### PR DESCRIPTION
Started this work in: https://github.com/code-dot-org/code-dot-org/pull/35787

In preparation for setting up script to be associated with lessons through lesson groups this makes sure that tests that set up scripts, lessons, or script_levels also have lesson groups set up. In addition it makes sure all the script->lesson_group->lesson->script_level associations are specified if missing.

Also did some renaming of stage to lesson.