### PR TITLE
Fix Hoc Event Review Test

### DIFF
--- a/pegasus/test/test_hoc_event_review.rb
+++ b/pegasus/test/test_hoc_event_review.rb
@@ -7,6 +7,10 @@ require_relative '../helpers/form_helpers'
 class HocEventReviewTest < Minitest::Test
   describe 'HocEventReview' do
     before do
+      events = HocEventReview.events
+      if events.count > 0
+        PEGASUS_DB[:forms].where(kind: HocEventReview.kind).delete
+      end
       assert_empty HocEventReview.events, 'Precondition: No HOC events in test DB'
     end
 

--- a/pegasus/test/test_hoc_event_review.rb
+++ b/pegasus/test/test_hoc_event_review.rb
@@ -7,8 +7,7 @@ require_relative '../helpers/form_helpers'
 class HocEventReviewTest < Minitest::Test
   describe 'HocEventReview' do
     before do
-      events = HocEventReview.events
-      if events.count > 0
+      if HocEventReview.events.count > 0
         PEGASUS_DB[:forms].where(kind: HocEventReview.kind).delete
       end
       assert_empty HocEventReview.events, 'Precondition: No HOC events in test DB'


### PR DESCRIPTION
Hoc Event Review test was conflicting with test_deliverer on our test build due to us now running test and lib. This deletes hoc events in the setup step of Hoc Event Review so that the test can pass.

<!-- ### Background -->
<!-- ### Privacy -->
<!-- ### Security -->
<!-- ### Caching -->
<!-- ### Deployment strategy -->
<!-- ### Future work -->


## Testing story
Reproduced the issue locally and ensured the fix fixes the issue.

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
