### PR TITLE
[Applab/Gamelab] Check if callback is a function before calling

### DIFF
--- a/apps/src/applab/commands.js
+++ b/apps/src/applab/commands.js
@@ -802,7 +802,7 @@ applabCommands.drawImageURL = function(opts) {
   );
 
   var callback = function(success) {
-    if (opts.callback) {
+    if (typeof opts.callback === 'function') {
       opts.callback.call(null, success);
     }
   };
@@ -2118,7 +2118,7 @@ applabCommands.drawChart = function(opts) {
     chartApi.warnings.forEach(function(warning) {
       outputWarning(warning.message);
     });
-    if (opts.callback) {
+    if (typeof opts.callback === 'function') {
       opts.callback.call(null);
     }
   };
@@ -2225,7 +2225,7 @@ applabCommands.drawChartFromRecords = function(opts) {
     chartApi.warnings.forEach(function(warning) {
       outputWarning(warning.message);
     });
-    if (opts.callback) {
+    if (typeof opts.callback === 'function') {
       opts.callback.call(null);
     }
   };

--- a/apps/src/lib/util/timeoutApi.js
+++ b/apps/src/lib/util/timeoutApi.js
@@ -15,7 +15,7 @@ export function injectExecuteCmd(fn) {
 }
 
 function onTimerFired(opts) {
-  if (opts.callback) {
+  if (typeof opts.callback === 'function') {
     opts.callback.call(null);
   }
 }


### PR DESCRIPTION
For applab/gamelab functions that take callbacks, we were checking to see whether the callback was provided, but not checking to make sure the callback was a function. This was resulting in New Relic error `e.callback.call is not a function`.

Before
![image](https://user-images.githubusercontent.com/8787187/87809848-e7ab0c00-c810-11ea-9a1b-fdf22f02b20e.png)
There is a warning in the debug console, but we still try to call the callback
![image](https://user-images.githubusercontent.com/8787187/87809931-0b6e5200-c811-11ea-95a4-7df187732aaf.png)

After
![image](https://user-images.githubusercontent.com/8787187/87809989-22ad3f80-c811-11ea-8e28-4a62cd16f2b3.png)


<!--
  Other aspects to consider. uncomment and add detail for any that seem necessary:
-->

<!-- ### Background -->
<!-- ### Privacy -->
<!-- ### Security -->
<!-- ### Caching -->
<!-- ### Deployment strategy -->
<!-- ### Future work -->

## Links

<!--
  Any relevant links to external resources; ie, specification documents, jira
  items, related PRs, honeybadger errors, etc
-->

 - [New Relic](https://rpm.newrelic.com/accounts/501463/browser/3787364/errors/details#?tw_start=&tw_end=now&tw_offset=21600000&selectedItem=e.callback.call%20is%20not%20a%20function&selectedTab=instances)

## Testing story

<!--
  Does your change include appropriate tests?

  If so, please describe how the tests included in this PR are sufficient

  If not, please explain why this change does not need to be tested.
-->

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
