### PR TITLE
Disassociate programming pairs after a teacher disables pairing for a class section

### DIFF
--- a/apps/src/code-studio/components/pairing/Pairing.jsx
+++ b/apps/src/code-studio/components/pairing/Pairing.jsx
@@ -62,7 +62,7 @@ export default class Pairing extends React.Component {
 
     $.ajax({
       url: this.props.source,
-      data: JSON.stringify({pairings}),
+      data: JSON.stringify({pairings, sectionId: this.selectedSection().id}),
       contentType: 'application/json; charset=utf-8',
       method: 'PUT',
       dataType: 'json',

--- a/apps/test/unit/code-studio/components/pairing/PairingTest.js
+++ b/apps/test/unit/code-studio/components/pairing/PairingTest.js
@@ -184,7 +184,9 @@ describe('Pairing component', function() {
 
       // verify that the right data is sent to the server
       let data = server.requests[server.requests.length - 1].requestBody;
-      expect('{"pairings":[{"id":11,"name":"First student"}]}').to.equal(data);
+      expect(
+        '{"pairings":[{"id":11,"name":"First student"}],"sectionId":1}'
+      ).to.equal(data);
     });
   });
 

--- a/dashboard/app/controllers/api/v1/sections_controller.rb
+++ b/dashboard/app/controllers/api/v1/sections_controller.rb
@@ -97,6 +97,12 @@ class Api::V1::SectionsController < Api::V1::JsonApiController
     fields[:pairing_allowed] = params[:pairing_allowed] unless params[:pairing_allowed].nil?
     fields[:hidden] = params[:hidden] unless params[:hidden].nil?
 
+    unless params[:pairing_allowed] == section.pairing_allowed
+      section.students.each do |student|
+        # clear pairing here?
+      end
+    end
+
     section.update!(fields)
     if script_id
       section.students.each do |student|

--- a/dashboard/app/controllers/api/v1/sections_controller.rb
+++ b/dashboard/app/controllers/api/v1/sections_controller.rb
@@ -97,12 +97,6 @@ class Api::V1::SectionsController < Api::V1::JsonApiController
     fields[:pairing_allowed] = params[:pairing_allowed] unless params[:pairing_allowed].nil?
     fields[:hidden] = params[:hidden] unless params[:hidden].nil?
 
-    unless params[:pairing_allowed] == section.pairing_allowed
-      section.students.each do |student|
-        # clear pairing here?
-      end
-    end
-
     section.update!(fields)
     if script_id
       section.students.each do |student|

--- a/dashboard/app/controllers/api_controller.rb
+++ b/dashboard/app/controllers/api_controller.rb
@@ -108,7 +108,7 @@ class ApiController < ApplicationController
     @user_header_options = {}
     @user_header_options[:current_user] = current_user
     @user_header_options[:show_pairing_dialog] = show_pairing_dialog
-    @user_header_options[:session_pairings] = session[:pairings]
+    @user_header_options[:session_pairings] = pairing_user_ids
     @user_header_options[:loc_prefix] = 'nav.user.'
   end
 

--- a/dashboard/app/controllers/application_controller.rb
+++ b/dashboard/app/controllers/application_controller.rb
@@ -267,19 +267,21 @@ class ApplicationController < ActionController::Base
   end
 
   def pairings
-    unless session[:pairing_section_id] && Section.find(session[:pairing_section_id]).pairing_allowed
-      self.pairings = {pairings: []}
-    end
-
     return [] if session[:pairings].blank?
-
-    User.find(session[:pairings])
+    if pairing_still_enabled
+      User.find(session[:pairings])
+    else
+      # clear the pairing data from the session cookie
+      self.pairings = {pairings: []}
+      return []
+    end
   end
 
   # @return [Array of Integers] an array of user IDs of users paired with the
   #   current user.
   def pairing_user_ids
-    unless session[:pairing_section_id] && Section.find(session[:pairing_section_id]).pairing_allowed
+    unless pairing_still_enabled
+      # clear the pairing data from the session cookie
       self.pairings = {pairings: []}
     end
 
@@ -293,5 +295,11 @@ class ApplicationController < ActionController::Base
       session.delete(:sign_up_type)
       session.delete(:sign_up_tracking_expiration)
     end
+  end
+
+  private
+
+  def pairing_still_enabled
+    session[:pairing_section_id] && Section.find(session[:pairing_section_id]).pairing_allowed
   end
 end

--- a/dashboard/app/controllers/application_controller.rb
+++ b/dashboard/app/controllers/application_controller.rb
@@ -263,7 +263,7 @@ class ApplicationController < ActionController::Base
       end
     end.compact
 
-    session[:pairing_section_id] = pairings_from_params[:section_id]
+    session[:pairing_section_id] = pairings_from_params[:section_id].to_i
   end
 
   def pairings

--- a/dashboard/app/controllers/pairings_controller.rb
+++ b/dashboard/app/controllers/pairings_controller.rb
@@ -7,7 +7,7 @@ class PairingsController < ApplicationController
   end
 
   def update
-    self.pairings = params[:pairings]
+    self.pairings = {pairings: params[:pairings], section_id: params[:sectionId]}
 
     render json: {pairings: pairings_summary, sections: sections_summary}
   end
@@ -23,7 +23,8 @@ class PairingsController < ApplicationController
   end
 
   def sections_summary
-    current_user.sections_as_student.map do |section|
+    pairing_sections = current_user.sections_as_student.select(&:pairing_allowed)
+    pairing_sections.map do |section|
       {
         id: section.id,
         name: section.name,

--- a/dashboard/test/controllers/activities_controller_test.rb
+++ b/dashboard/test/controllers/activities_controller_test.rb
@@ -940,6 +940,7 @@ class ActivitiesControllerTest < ActionController::TestCase
     section = create(:follower, student_user: @user).section
     pairing = create(:follower, section: section).student_user
     session[:pairings] = [pairing.id]
+    session[:pairing_section_id] = section.id
 
     assert_difference('UserLevel.count', 2) do # both get a UserLevel
       assert_creates(PairedUserLevel) do # there is one PairedUserLevel to link them
@@ -957,6 +958,7 @@ class ActivitiesControllerTest < ActionController::TestCase
     section = create(:follower, student_user: @user).section
     pairings = 3.times.map {create(:follower, section: section).student_user}
     session[:pairings] = pairings.map(&:id)
+    session[:pairing_section_id] = section.id
 
     assert_difference('UserLevel.count', 4) do # all 4 people
       assert_difference('PairedUserLevel.count', 3) do # there are 3 PairedUserLevel links
@@ -977,6 +979,7 @@ class ActivitiesControllerTest < ActionController::TestCase
     section = create(:follower, student_user: @user).section
     pairing = create(:follower, section: section).student_user
     session[:pairings] = [pairing.id]
+    session[:pairing_section_id] = section.id
 
     existing_navigator_user_level = create :user_level, user: pairing, script: @script, level: @level, best_result: 10
 
@@ -997,6 +1000,7 @@ class ActivitiesControllerTest < ActionController::TestCase
     section = create(:follower, student_user: @user).section
     pairing = create(:follower, section: section).student_user
     session[:pairings] = [pairing.id]
+    session[:pairing_section_id] = section.id
 
     existing_driver_user_level = create :user_level, user: @user, script: @script, level: @level, best_result: 10
 

--- a/dashboard/test/controllers/authored_hint_view_requests_controller_test.rb
+++ b/dashboard/test/controllers/authored_hint_view_requests_controller_test.rb
@@ -64,7 +64,7 @@ class AuthoredHintViewRequestsControllerTest < ActionController::TestCase
     section.add_student driver
     section.add_student navigator
 
-    @controller.send :pairings=, [navigator]
+    @controller.send :pairings=, {pairings: [navigator], section_id: section.id}
 
     assert_difference 'AuthoredHintViewRequest.where(user: driver).count' do
       assert_difference 'AuthoredHintViewRequest.where(user: navigator).count' do

--- a/dashboard/test/controllers/hint_view_requests_controller_test.rb
+++ b/dashboard/test/controllers/hint_view_requests_controller_test.rb
@@ -41,6 +41,7 @@ class HintViewRequestsControllerTest < ActionController::TestCase
     classmate_1 = create(:follower, section: section).student_user
     classmate_2 = create(:follower, section: section).student_user
     session[:pairings] = [classmate_1.id, classmate_2.id]
+    session[:pairing_section_id] = section.id
 
     params = {
       script_id: 1,
@@ -89,7 +90,7 @@ class HintViewRequestsControllerTest < ActionController::TestCase
     navigator_initial = HintViewRequest.where(user: navigator).count
 
     sign_in driver
-    @controller.send :pairings=, [navigator]
+    @controller.send :pairings=, {pairings: [navigator], section_id: section.id}
     post :create, params: {
       script_id: Script.first.id,
       level_id: Script.first.script_levels.first.level,

--- a/dashboard/test/controllers/pairings_controller_test.rb
+++ b/dashboard/test/controllers/pairings_controller_test.rb
@@ -33,10 +33,28 @@ class PairingsControllerTest < ActionController::TestCase
     assert_equal expected_response, JSON.parse(response.body)
   end
 
+  test 'should show only sections with pairing enabled' do
+    section = create(:follower, student_user: @user).section
+    no_pairing_section = create(:follower, student_user: @user).section
+    no_pairing_section.update!(pairing_allowed: false)
+
+    get :show, xhr: true
+    assert_response :success
+
+    expected_response = {
+      'pairings' => [],
+      'sections' => [
+        {'id' => section.id, 'name' => section.name, 'students' => []},
+      ]
+    }
+    assert_equal expected_response, JSON.parse(response.body)
+  end
+
   test 'should get show for logged in user with sections and pairings' do
     section = create(:follower, student_user: @user).section
     classmate = create(:follower, section: section).student_user
     session[:pairings] = [classmate.id]
+    session[:pairing_section_id] = section.id
 
     get :show, xhr: true
     assert_response :success
@@ -57,10 +75,11 @@ class PairingsControllerTest < ActionController::TestCase
     classmate_1 = create(:follower, section: section).student_user
     classmate_2 = create(:follower, section: section).student_user
 
-    put :update, xhr: true, params: {pairings: [{id: classmate_1.id}, {id: classmate_2.id}]}
+    put :update, xhr: true, params: {pairings: [{id: classmate_1.id}, {id: classmate_2.id}], sectionId: section.id}
 
     assert_response :success
     assert_equal [classmate_1.id, classmate_2.id], session[:pairings]
+    assert_equal section.id, session[:pairing_section_id]
   end
 
   test 'should not set pairings in session if they are not valid classmates' do
@@ -68,21 +87,24 @@ class PairingsControllerTest < ActionController::TestCase
     classmate = create(:follower, section: section).student_user
     invalid_user = create(:student)
 
-    put :update, xhr: true, params: {pairings: [{id: classmate.id}, {id: invalid_user.id}]}
+    put :update, xhr: true, params: {pairings: [{id: classmate.id}, {id: invalid_user.id}], sectionId: section.id}
 
     assert_response :success
     # the invalid user is silently rejected
     assert_equal [classmate.id], session[:pairings]
+    assert_equal section.id, session[:pairing_section_id]
   end
 
   test 'should remove pairings in session' do
     section = create(:follower, student_user: @user).section
     classmate = create(:follower, section: section).student_user
     session[:pairings] = [classmate.id]
+    session[:pairing_section_id] = section.id
 
     put :update, xhr: true, params: {pairings: []}
 
     assert_response :success
     assert_equal [], session[:pairings]
+    assert_equal nil, session[:pairpairing_section_idngs]
   end
 end

--- a/dashboard/test/controllers/projects_controller_test.rb
+++ b/dashboard/test/controllers/projects_controller_test.rb
@@ -19,9 +19,9 @@ class ProjectsControllerTest < ActionController::TestCase
   setup_all do
     @driver = create :user
     @navigator = create :user
-    section = create :section
-    section.add_student @driver
-    section.add_student @navigator
+    @section = create :section
+    @section.add_student @driver
+    @section.add_student @navigator
   end
 
   test "index" do
@@ -169,7 +169,7 @@ class ProjectsControllerTest < ActionController::TestCase
     @driver.update(age: 10)
     @navigator.update(age: 18)
     sign_in_with_request @driver
-    @controller.send :pairings=, [@navigator]
+    @controller.send :pairings=, {pairings: [@navigator], section_id: @section.id}
 
     %w(applab gamelab).each do |lab|
       get :load, params: {key: lab}
@@ -182,7 +182,7 @@ class ProjectsControllerTest < ActionController::TestCase
     @driver.update(age: 18)
     @navigator.update(age: 10)
     sign_in_with_request @driver
-    @controller.send :pairings=, [@navigator]
+    @controller.send :pairings=, {pairings: [@navigator], section_id: @section.id}
 
     %w(applab gamelab).each do |lab|
       get :load, params: {key: lab}
@@ -196,7 +196,7 @@ class ProjectsControllerTest < ActionController::TestCase
     @navigator.update(age: 10)
     create :follower, user: (create :terms_of_service_teacher), student_user: @navigator
     sign_in_with_request @driver
-    @controller.send :pairings=, [@navigator]
+    @controller.send :pairings=, {pairings: [@navigator], section_id: @section.id}
 
     %w(applab gamelab).each do |lab|
       get :load, params: {key: lab}


### PR DESCRIPTION
In the past, when teachers disabled pairing for their class, students would remain paired until their session refreshed (which happens when the browser window is closed and re-opened). Now, when teachers disable pairing, their paired students are disassociated the next time their progress saves. This will become visible in their window the next time they load a page. 

<!--
  Your description goes here: A summary of the change, including any relevant motivation and context.

  If relevant, include a description both of the existing behavior and of the new behavior.
-->

<!--
  Other aspects to consider. uncomment and add detail for any that seem necessary:
-->

<!-- ### Background -->
<!-- ### Privacy -->
<!-- ### Security -->
<!-- ### Caching -->
<!-- ### Deployment strategy -->
<!-- ### Future work -->

## Links

<!--
  Any relevant links to external resources; ie, specification documents, jira
  items, related PRs, honeybadger errors, etc
-->

- [zendesk](https://codeorg.zendesk.com/agent/tickets/267743)
- [jira](https://codedotorg.atlassian.net/browse/LP-1244)

## Testing story

<!--
  Does your change include appropriate tests?

  If so, please describe how the tests included in this PR are sufficient

  If not, please explain why this change does not need to be tested.
-->

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
