### PR TITLE
RailsAuthenticityToken is test-aware

### DIFF
--- a/apps/src/templates/teacherDashboard/RosterDialog.story.jsx
+++ b/apps/src/templates/teacherDashboard/RosterDialog.story.jsx
@@ -1,11 +1,13 @@
 import React from 'react';
 import {UnconnectedRosterDialog as RosterDialog} from './RosterDialog';
 import {OAuthSectionTypes} from './shapes';
+import {stubRailsAuthenticityToken} from '../../../test/util/stubRailsAuthenticityToken';
 
 export default storybook => {
   storybook = storybook
     .storiesOf('Dialogs/RosterDialog', module)
-    .addDecorator(dialogIsOpen);
+    .addDecorator(dialogIsOpen)
+    .addDecorator(railsAuthenticityTokenIsStubbed);
 
   // Add stories for every provider type
   [OAuthSectionTypes.google_classroom, OAuthSectionTypes.clever].forEach(
@@ -48,23 +50,12 @@ export default storybook => {
         .add(`${provider}: No sections found`, () => (
           <RosterDialog rosterProvider={provider} classrooms={[]} />
         ))
-        .add(`${provider}: Load error`, () => {
-          // Stub CSRF meta tags into the document so we can render the reauthorization
-          // button successfully.
-          const csrfParam = document.createElement('meta');
-          const csrfToken = document.createElement('meta');
-          csrfParam.setAttribute('name', 'csrf-param');
-          csrfToken.setAttribute('name', 'csrf-token');
-          document.head.appendChild(csrfParam);
-          document.head.appendChild(csrfToken);
-
-          return (
-            <RosterDialog
-              rosterProvider={provider}
-              loadError={{status: 403, message: 'Sample error message.'}}
-            />
-          );
-        });
+        .add(`${provider}: Load error`, () => (
+          <RosterDialog
+            rosterProvider={provider}
+            loadError={{status: 403, message: 'Sample error message.'}}
+          />
+        ));
     }
   );
   return storybook;
@@ -74,4 +65,10 @@ export default storybook => {
 // open by default when the story is viewed.
 function dialogIsOpen(story) {
   return React.cloneElement(story(), {isOpen: true});
+}
+
+// Stubs the DOM-dependent behavior of the RailsAuthenticityToken component
+function railsAuthenticityTokenIsStubbed(story) {
+  stubRailsAuthenticityToken();
+  return story();
 }

--- a/apps/test/unit/lib/util/RailsAuthenticityTokenTest.jsx
+++ b/apps/test/unit/lib/util/RailsAuthenticityTokenTest.jsx
@@ -1,0 +1,65 @@
+import React from 'react';
+import sinon from 'sinon';
+import {assert} from 'chai';
+import {shallow} from 'enzyme';
+import RailsAuthenticityToken from '@cdo/apps/lib/util/RailsAuthenticityToken';
+import logToCloud from '@cdo/apps/logToCloud';
+
+const TEST_CSRF_PARAM_NAME = 'fake-csrf-param-name';
+const TEST_CSRF_PARAM_VALUE = 'fake-csrf-token';
+
+describe('RailsAuthenticityToken', () => {
+  beforeEach(() => {
+    sinon.stub(logToCloud, 'logError');
+    destroyCsrfMetaTags();
+  });
+
+  afterEach(() => {
+    logToCloud.logError.restore();
+    destroyCsrfMetaTags();
+  });
+
+  it('renders a hidden field with values found in the DOM', () => {
+    createCsrfMetaTags();
+
+    const wrapper = shallow(<RailsAuthenticityToken />);
+    assert(
+      wrapper.matchesElement(
+        <input
+          type="hidden"
+          name={TEST_CSRF_PARAM_NAME}
+          value={TEST_CSRF_PARAM_VALUE}
+        />
+      ),
+      'rendered the hidden field as expected'
+    );
+    assert(logToCloud.logError.notCalled, 'logged nothing to New Relic');
+  });
+
+  it('renders empty and logs to cloud when meta tags are not found', () => {
+    destroyCsrfMetaTags();
+
+    const wrapper = shallow(<RailsAuthenticityToken />);
+    assert(wrapper.isEmptyRender(), 'rendered nothing');
+    assert(logToCloud.logError.calledOnce, 'logged an error to New Relic');
+  });
+});
+
+function createCsrfMetaTags() {
+  const csrfParam = document.createElement('meta');
+  csrfParam.setAttribute('name', 'csrf-param');
+  csrfParam.setAttribute('content', TEST_CSRF_PARAM_NAME);
+  document.head.appendChild(csrfParam);
+
+  const csrfToken = document.createElement('meta');
+  csrfToken.setAttribute('name', 'csrf-token');
+  csrfToken.setAttribute('content', TEST_CSRF_PARAM_VALUE);
+  document.head.appendChild(csrfToken);
+}
+
+function destroyCsrfMetaTags() {
+  for (let selector of ['meta[name="csrf-param"]', 'meta[name="csrf-token"]']) {
+    const tag = document.querySelector(selector);
+    tag && tag.remove();
+  }
+}

--- a/apps/test/util/stubRailsAuthenticityToken.js
+++ b/apps/test/util/stubRailsAuthenticityToken.js
@@ -1,0 +1,19 @@
+import sinon from 'sinon';
+import RailsAuthenticityToken from '@cdo/apps/lib/util/RailsAuthenticityToken';
+
+// Stub the DOM-dependent behavior of the RailsAuthenticityToken component, so
+// we don't have to actually build meta tags in our tests.
+export function stubRailsAuthenticityToken() {
+  // Ignore redundant calls to this function, which makes it easier to use in storybook
+  if (
+    'function' !== typeof RailsAuthenticityToken.getRailsCSRFMetaTags.restore
+  ) {
+    sinon
+      .stub(RailsAuthenticityToken, 'getRailsCSRFMetaTags')
+      .returns({param: undefined, token: undefined});
+  }
+}
+
+export function unstubRailsAuthenticityToken() {
+  RailsAuthenticityToken.getRailsCSRFMetaTags.restore();
+}


### PR DESCRIPTION
In https://github.com/code-dot-org/code-dot-org/pull/35752 I established a pattern of pulling the Rails authenticity token (used for CSRF protection) from meta tags in the document head, instead of passing them down from the controller through several layers of React.  I would like reuse this approach elsewhere, but doing so would be easier with a different approach to our tests.

In that prior change, I made the test responsible for performing appropriate setup.  This setup can be fairly verbose because the core idea of this component is that it's taking a dependency on the DOM. Also the presence/accuracy of an authenticity token is usually peripheral to the behavior we're trying to cover in our unit tests.  For that reason, I propose that it's useful to make this component test-aware (something we usually avoid) - effectively it becomes a [fake](https://blog.pragmatists.com/test-doubles-fakes-mocks-and-stubs-1a7491dfa3da) when our JavaScript unit tests are run.

An alternative approach might be to add a custom module resolution rule to our webpack/karma config that loads a fake in place of this component, without using the `IN_UNIT_TEST` constant in our production code.

https://github.com/code-dot-org/code-dot-org/blob/c6f2dd801c76cbd733d9c98fe84b003c75fa1cae/apps/webpack.js#L254-L256

I've opted for `IN_UNIT_TEST` because IMO it's a less surprising and action-at-a-distancey behavior than custom build configuration.

## Next steps

I will follow this with a series of changes that convert existing code over to use `<RailsAuthenticityToken />`: #35877, #35879, #35880 

## Testing story

Manual testing:  Tested on local server with OAuth providers configured using the following steps:

1. Modified `ApiController#query_google_classroom_service` to pass nil tokens
2. Signed in to my local environment using a Google Account set up as a Google Classroom teacher.
3. Tried to create a section, using the "Import from Google Classroom" option.  This reaches an expected load error due to the code change in step 1.
4. Open developer tools to the network tab and enable "preserve log."
5. Click the reauthorize button.
6. Observe in developer tools that an authenticity token has been sent along with the `POST /users/auth/google_oauth2` request, and that I've successfully redirected to a Google auth flow.
7. Finish the Google auth flow and confirm that I end up back at the rostering dialog.

For more details on manual testing, see https://github.com/code-dot-org/code-dot-org/pull/35752.

Automated testing: I'm leaning on existing tests.

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
