### PR TITLE
ManageLinkedAccounts uses RailsAuthenticityToken

### DIFF
--- a/apps/src/lib/ui/accounts/ManageLinkedAccounts.jsx
+++ b/apps/src/lib/ui/accounts/ManageLinkedAccounts.jsx
@@ -7,6 +7,7 @@ import color from '@cdo/apps/util/color';
 import {tableLayoutStyles} from '@cdo/apps/templates/tables/tableConstants';
 import BootstrapButton from './BootstrapButton';
 import {connect} from 'react-redux';
+import RailsAuthenticityToken from '../../util/RailsAuthenticityToken';
 
 const OAUTH_PROVIDERS = {
   GOOGLE: 'google_oauth2',
@@ -35,7 +36,6 @@ class ManageLinkedAccounts extends React.Component {
   static propTypes = {
     // Provided by redux
     authenticationOptions: PropTypes.objectOf(authOptionPropType),
-    authenticityToken: PropTypes.string.isRequired,
     userHasPassword: PropTypes.bool.isRequired,
     isGoogleClassroomStudent: PropTypes.bool.isRequired,
     isCleverStudent: PropTypes.bool.isRequired
@@ -155,7 +155,6 @@ class ManageLinkedAccounts extends React.Component {
               return (
                 <OauthConnection
                   key={option.id || _.uniqueId('empty_')}
-                  authenticityToken={this.props.authenticityToken}
                   displayName={this.getDisplayName(option.credentialType)}
                   id={option.id}
                   email={this.formatEmail(option)}
@@ -178,7 +177,6 @@ export const UnconnectedManageLinkedAccounts = ManageLinkedAccounts;
 
 export default connect(state => ({
   authenticationOptions: state.manageLinkedAccounts.authenticationOptions,
-  authenticityToken: state.manageLinkedAccounts.authenticityToken,
   userHasPassword: state.manageLinkedAccounts.userHasPassword,
   isGoogleClassroomStudent: state.manageLinkedAccounts.isGoogleClassroomStudent,
   isCleverStudent: state.manageLinkedAccounts.isCleverStudent
@@ -189,7 +187,6 @@ class OauthConnection extends React.Component {
     displayName: PropTypes.string.isRequired,
     id: PropTypes.number,
     credentialType: PropTypes.string.isRequired,
-    authenticityToken: PropTypes.string.isRequired,
     email: PropTypes.string,
     disconnectDisabledStatus: PropTypes.string,
     error: PropTypes.string
@@ -208,7 +205,6 @@ class OauthConnection extends React.Component {
 
   render() {
     const {
-      authenticityToken,
       credentialType,
       disconnectDisabledStatus,
       displayName,
@@ -253,11 +249,7 @@ class OauthConnection extends React.Component {
                 text={buttonText}
                 disabled={!!disconnectDisabledStatus}
               />
-              <input
-                type="hidden"
-                name="authenticity_token"
-                value={authenticityToken}
-              />
+              <RailsAuthenticityToken />
             </form>
             {disconnectDisabledStatus && (
               <ReactTooltip

--- a/apps/src/lib/ui/accounts/ManageLinkedAccounts.story.jsx
+++ b/apps/src/lib/ui/accounts/ManageLinkedAccounts.story.jsx
@@ -4,7 +4,6 @@ import {UnconnectedManageLinkedAccounts as ManageLinkedAccounts} from './ManageL
 
 const DEFAULT_PROPS = {
   userType: 'student',
-  authenticityToken: 'fake CSRF token',
   authenticationOptions: {},
   connect: action('connect'),
   disconnect: action('disconnect'),

--- a/apps/src/lib/ui/accounts/ManageLinkedAccountsController.js
+++ b/apps/src/lib/ui/accounts/ManageLinkedAccountsController.js
@@ -14,8 +14,7 @@ export default class ManageLinkedAccountsController {
     authenticationOptions,
     userHasPassword,
     isGoogleClassroomStudent,
-    isCleverStudent,
-    authenticityToken
+    isCleverStudent
   ) {
     registerReducers({manageLinkedAccounts});
     const store = getStore();
@@ -25,8 +24,7 @@ export default class ManageLinkedAccountsController {
         authenticationOptions,
         userHasPassword,
         isGoogleClassroomStudent,
-        isCleverStudent,
-        authenticityToken
+        isCleverStudent
       })
     );
 

--- a/apps/src/lib/ui/accounts/manageLinkedAccountsRedux.js
+++ b/apps/src/lib/ui/accounts/manageLinkedAccountsRedux.js
@@ -19,7 +19,6 @@ export default function manageLinkedAccounts(state = initialState, action) {
   if (action.type === INITIALIZE_STATE) {
     const {
       authenticationOptions,
-      authenticityToken,
       userHasPassword,
       isGoogleClassroomStudent,
       isCleverStudent
@@ -27,7 +26,6 @@ export default function manageLinkedAccounts(state = initialState, action) {
     return {
       ...state,
       authenticationOptions,
-      authenticityToken,
       userHasPassword,
       isGoogleClassroomStudent,
       isCleverStudent

--- a/apps/src/sites/studio/pages/devise/registrations/edit.js
+++ b/apps/src/sites/studio/pages/devise/registrations/edit.js
@@ -25,8 +25,7 @@ const {
   isCleverStudent,
   dependedUponForLogin,
   dependentStudents,
-  studentCount,
-  authenticityToken
+  studentCount
 } = scriptData;
 
 $(document).ready(() => {
@@ -87,8 +86,7 @@ $(document).ready(() => {
       authenticationOptions,
       isPasswordRequired,
       isGoogleClassroomStudent,
-      isCleverStudent,
-      authenticityToken
+      isCleverStudent
     );
   }
 

--- a/apps/test/unit/lib/ui/accounts/ManageLinkedAccountsTest.jsx
+++ b/apps/test/unit/lib/ui/accounts/ManageLinkedAccountsTest.jsx
@@ -8,7 +8,6 @@ import {
 
 const DEFAULT_PROPS = {
   userType: 'student',
-  authenticityToken: 'fake CSRF token',
   authenticationOptions: {},
   disconnect: () => {},
   userHasPassword: true,

--- a/dashboard/app/views/devise/registrations/edit.html.haml
+++ b/dashboard/app/views/devise/registrations/edit.html.haml
@@ -226,8 +226,7 @@
       isGoogleClassroomStudent: current_user.google_classroom_student?,
       isCleverStudent: current_user.clever_student?,
       dependentStudents: current_user.dependent_students,
-      studentCount: current_user.students.count,
-      authenticityToken: form_authenticity_token
+      studentCount: current_user.students.count
     }.to_json
   }
 %script{src: webpack_asset_path('js/devise/registrations/edit.js'), data: script_data}


### PR DESCRIPTION
Reuse the `RailsAuthenticityToken` component introduced in https://github.com/code-dot-org/code-dot-org/pull/35752 to simplify the authenticity token code surrounding the `ManageLinkedAccounts` component.

## Testing story

Manually test on local by opening the edit account page with a migrated, Google-linked account with a password; unlinking Google; re-linking Google; confirming through the whole process that no prop validation errors or other console errors appear.

![Peek 2020-07-17 16-46](https://user-images.githubusercontent.com/1615761/87838878-4c845780-c84d-11ea-8d45-d2312b7354a1.gif)


# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
