### PR TITLE
ReportAbuseForm uses RailsAuthenticityToken

### DIFF
--- a/apps/Gruntfile.js
+++ b/apps/Gruntfile.js
@@ -546,6 +546,8 @@ describe('entry tests', () => {
     'maker/setup': './src/sites/studio/pages/maker/setup.js',
     'projects/featured': './src/sites/studio/pages/projects/featured.js',
     'projects/index': './src/sites/studio/pages/projects/index.js',
+    'report_abuse/report_abuse_form':
+      './src/sites/studio/pages/report_abuse/report_abuse_form.js',
     'scripts/show': './src/sites/studio/pages/scripts/show.js',
     'scripts/stage_extras': './src/sites/studio/pages/scripts/stage_extras.js',
     'sections/show': './src/sites/studio/pages/sections/show.js',

--- a/apps/src/code-studio/components/ReportAbuseForm.jsx
+++ b/apps/src/code-studio/components/ReportAbuseForm.jsx
@@ -7,6 +7,7 @@ import AgeDropdown from '@cdo/apps/templates/AgeDropdown';
 import SafeMarkdown from '@cdo/apps/templates/SafeMarkdown';
 import msg from '@cdo/locale';
 import {getChannelIdFromUrl} from '@cdo/apps/reportAbuse';
+import RailsAuthenticityToken from '../../lib/util/RailsAuthenticityToken';
 
 /**
  * A component containing some text/links for projects that have had abuse
@@ -23,7 +24,6 @@ const alert = window.alert;
 
 export default class ReportAbuseForm extends React.Component {
   static propTypes = {
-    csrfToken: PropTypes.string.isRequired,
     abuseUrl: PropTypes.string.isRequired,
     name: PropTypes.string,
     email: PropTypes.string,
@@ -83,11 +83,7 @@ export default class ReportAbuseForm extends React.Component {
         <p>{msg.reportAbuseIntro()}</p>
         <br />
         <form action="/report_abuse" method="post">
-          <input
-            type="hidden"
-            name="authenticity_token"
-            value={this.props.csrfToken}
-          />
+          <RailsAuthenticityToken />
           <input type="hidden" name="channel_id" value={this.getChannelId()} />
           <input type="hidden" name="name" value={this.props.name} />
           <div style={{display: this.props.email ? 'none' : 'block'}}>

--- a/apps/src/code-studio/components/ReportAbuseForm.jsx
+++ b/apps/src/code-studio/components/ReportAbuseForm.jsx
@@ -168,7 +168,3 @@ export default class ReportAbuseForm extends React.Component {
     );
   }
 }
-
-// TODO - just expose renderer on dashboard?
-window.dashboard = window.dashboard || {};
-window.dashboard.ReportAbuseForm = ReportAbuseForm;

--- a/apps/src/code-studio/components/ReportAbuseForm.jsx
+++ b/apps/src/code-studio/components/ReportAbuseForm.jsx
@@ -84,8 +84,12 @@ export default class ReportAbuseForm extends React.Component {
         <br />
         <form action="/report_abuse" method="post">
           <RailsAuthenticityToken />
-          <input type="hidden" name="channel_id" value={this.getChannelId()} />
-          <input type="hidden" name="name" value={this.props.name} />
+          <input
+            type="hidden"
+            name="channel_id"
+            defaultValue={this.getChannelId()}
+          />
+          <input type="hidden" name="name" defaultValue={this.props.name} />
           <div style={{display: this.props.email ? 'none' : 'block'}}>
             <div>{msg.email()}</div>
             <input

--- a/apps/src/sites/studio/pages/code-studio.js
+++ b/apps/src/sites/studio/pages/code-studio.js
@@ -35,7 +35,6 @@ window.Radium = require('radium');
 // TODO (bbuchanan): Stop including these components in a global way, just
 //                   require them specifically where needed.
 require('@cdo/apps/code-studio/components/AbuseError');
-require('@cdo/apps/code-studio/components/ReportAbuseForm');
 require('@cdo/apps/code-studio/components/SendToPhone');
 require('@cdo/apps/code-studio/components/SmallFooter');
 require('@cdo/apps/code-studio/components/Attachments');

--- a/apps/src/sites/studio/pages/report_abuse/report_abuse_form.js
+++ b/apps/src/sites/studio/pages/report_abuse/report_abuse_form.js
@@ -1,0 +1,14 @@
+import $ from 'jquery';
+import React from 'react';
+import ReactDOM from 'react-dom';
+import getScriptData from '@cdo/apps/util/getScriptData';
+import ReportAbuseForm from '@cdo/apps/code-studio/components/ReportAbuseForm';
+
+$(document).ready(function() {
+  const props = getScriptData('abuse');
+  props.abuseUrl = document.referrer;
+  ReactDOM.render(
+    <ReportAbuseForm {...props} />,
+    document.getElementById('report-abuse-form')
+  );
+});

--- a/dashboard/app/controllers/report_abuse_controller.rb
+++ b/dashboard/app/controllers/report_abuse_controller.rb
@@ -90,7 +90,6 @@ class ReportAbuseController < ApplicationController
 
   def report_abuse_form
     @react_props = {
-      csrfToken: form_authenticity_token,
       name: (current_user.name unless current_user.nil?),
       email: (current_user.email unless current_user.nil?),
       age: (current_user.age unless current_user.nil?),

--- a/dashboard/app/views/report_abuse/report_abuse_form.html.haml
+++ b/dashboard/app/views/report_abuse/report_abuse_form.html.haml
@@ -1,12 +1,3 @@
 - @page_title = "Report Abuse"
-
 #report-abuse-form
-
-:javascript
-  $(document).ready(function () {
-    var props = #{@react_props.to_json};
-    props.abuseUrl = document.referrer;
-    ReactDOM.render(
-      React.createElement(window.dashboard.ReportAbuseForm, props),
-      document.getElementById('report-abuse-form'));
-  });
+%script{src: webpack_asset_path('js/report_abuse/report_abuse_form.js'), data: {abuse: @react_props.to_json}}


### PR DESCRIPTION
Reuse the `RailsAuthenticityToken` component introduced in #35752 to simplify the authenticity token code surrounding the `ReportAbuseForm` component.

...and while I was in there, also gave the report abuse form its own JavaScript entry point, removing JS from HAML and removing the ReportAbuseForm component from the `window.dashboard` global.  Hooray for making code boring!

## Testing story

Loaded https://localhost-studio.code.org:3000/report_abuse

![Screenshot from 2020-07-17 16-56-47](https://user-images.githubusercontent.com/1615761/87839211-b3eed700-c84e-11ea-87c0-f4d0c6f01e79.png)

Confirmed that an authenticity token was rendered into the DOM as part of the form:

![Screenshot from 2020-07-17 16-56-14](https://user-images.githubusercontent.com/1615761/87839229-c406b680-c84e-11ea-9d5f-13ca2c015a5b.png)

Submitted the form, and confirmed that the authenticity token was included in the submission:

![Screenshot from 2020-07-17 16-57-15](https://user-images.githubusercontent.com/1615761/87839238-cec14b80-c84e-11ea-9e89-ab25daf9812e.png)

Also confirmed that the request was accepted and I was redirected to support.code.org, rather than being rejected for an invalid authenticity token.

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
