### PR TITLE
NewScriptForm uses RailsAuthenticityToken

### DIFF
--- a/apps/src/lib/script-editor/NewScriptForm.jsx
+++ b/apps/src/lib/script-editor/NewScriptForm.jsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import PropTypes from 'prop-types';
+import RailsAuthenticityToken from '../util/RailsAuthenticityToken';
 
 const buttonStyle = {
   marginLeft: 0,
@@ -7,10 +7,10 @@ const buttonStyle = {
   marginBottom: 20
 };
 
-export default function NewScriptForm({csrfToken}) {
+export default function NewScriptForm() {
   return (
     <form action="/s" method="post">
-      <input type="hidden" name="authenticity_token" value={csrfToken} />
+      <RailsAuthenticityToken />
       <label>Name</label>
       <input name="script[name]" />
       <br />
@@ -20,7 +20,3 @@ export default function NewScriptForm({csrfToken}) {
     </form>
   );
 }
-
-NewScriptForm.propTypes = {
-  csrfToken: PropTypes.string.isRequired
-};

--- a/apps/src/sites/studio/pages/scripts/new.js
+++ b/apps/src/sites/studio/pages/scripts/new.js
@@ -3,11 +3,5 @@ import ReactDOM from 'react-dom';
 import NewScriptForm from '@cdo/apps/lib/script-editor/NewScriptForm';
 
 $(document).ready(() => {
-  const script = document.querySelector('script[data-csrftoken]');
-  const csrfToken = script.dataset.csrftoken;
-
-  ReactDOM.render(
-    <NewScriptForm csrfToken={csrfToken} />,
-    document.getElementById('form')
-  );
+  ReactDOM.render(<NewScriptForm />, document.getElementById('form'));
 });

--- a/dashboard/app/views/scripts/new.html.haml
+++ b/dashboard/app/views/scripts/new.html.haml
@@ -1,4 +1,4 @@
 %h1= t('crud.new_model', model: Script.model_name.human)
-%script{src: webpack_asset_path('js/scripts/new.js'), data: {csrftoken: form_authenticity_token}}
+%script{src: webpack_asset_path('js/scripts/new.js')}
 #form
 = link_to t('crud.back'), scripts_path


### PR DESCRIPTION
Reuse the RailsAuthenticityToken component introduced in #35752 to simplify the authenticity token code surrounding the NewScriptForm component.

## Testing story

Manual testing:

![Peek 2020-07-17 17-07](https://user-images.githubusercontent.com/1615761/87839526-07adf000-c850-11ea-83ef-9b5c8f94bdf4.gif)

1. Put your local environment into levelbuilder mode

   Add `levelbuilder_mode: true` to your locals.yml and restart your server (if you are not already in levelbuilder mode)

2. Sign in as a user with LEVELBUILDER permission

   You can grant levelbuilder permission to a user by running `bin/dashboard-console` and swapping their email into this command: `User.find_by_email('brad+levelbuilder@code.org').permission = UserPermission::LEVELBUILDER`

3. Navigate to `http://localhost-studio.code.org:3000/s/new` which loads the new script form.

   You can confirm in devtools that the `NewScriptForm` component is rendered, that it in turn renders `RailsAuthenticityToken`, that an authenticity token is rendered into the DOM and that no prop validation errors appear.

4. Enter a script name and click "Save Changes."  Confirm that a new script is created and you are redirected to the edit page.

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
