### PR TITLE
Fix CSV Props Validation

### DIFF
--- a/apps/src/templates/sectionAssessments/SubmissionStatusAssessmentsContainer.jsx
+++ b/apps/src/templates/sectionAssessments/SubmissionStatusAssessmentsContainer.jsx
@@ -21,12 +21,12 @@ const styles = {
 };
 
 export const studentExportableDataPropType = PropTypes.shape({
-  name: PropTypes.string.isRequired,
+  studentName: PropTypes.string.isRequired,
   numMultipleChoiceCorrect: PropTypes.number,
   numMultipleChoice: PropTypes.number,
   numMatchCorrect: PropTypes.number,
   numMatch: PropTypes.number,
-  submissionTimeStamp: PropTypes.string.isRequired
+  submissionTimestamp: PropTypes.instanceOf(Date).isRequired
 });
 
 const CSV_SUBMISSION_STATUS_HEADERS = [


### PR DESCRIPTION
While working on several components that are rendered by the `SectionAssessments` component, I noticed that this component kept dumping annoying red property validation warnings into my log so I decided to fix them. The failed validation wasn't actually causing any problems since apparently the `CSVLink` doesn't care about the keys passed to it, but still better to not be unnecessarily dumping warning into the console!

<!-- ### Background -->
<!-- ### Privacy -->
<!-- ### Security -->
<!-- ### Caching -->
<!-- ### Deployment strategy -->
<!-- ### Future work -->

## Testing story

I tested to make sure the CSV download is unaffected by this change.

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
