### PR TITLE
Foorm: Clean up CSF Deep Dive Post survey

### DIFF
--- a/dashboard/config/foorm/forms/surveys/pd/csf_deep_dive_post.0.json
+++ b/dashboard/config/foorm/forms/surveys/pd/csf_deep_dive_post.0.json
@@ -183,15 +183,15 @@
           "rows": [
             {
               "value": "work_collaboratively",
-              "text": "I can ensure that students work collaboratively when writing code. \t\t\t\t\t\t\t"
+              "text": "I can ensure that students work collaboratively when writing code."
             },
             {
               "value": "share_ideas",
-              "text": "I can ensure that every student has a daily opportunity to share ideas and be heard by classmates through partnered conversations, small-group or large-group discussion. \t\t\t\t\t\t\t"
+              "text": "I can ensure that every student has a daily opportunity to share ideas and be heard by classmates through partnered conversations, small-group or large-group discussion."
             },
             {
               "value": "failure_normalized",
-              "text": "I can create a culture in which problems or failures are normalized and welcomed as a natural part of the problem solving process. \t\t\t\t\t\t\t"
+              "text": "I can create a culture in which problems or failures are normalized and welcomed as a natural part of the problem solving process."
             },
             {
               "value": "support_problem_solving",
@@ -241,23 +241,23 @@
           "rows": [
             {
               "value": "access_lesson_plans",
-              "text": "access teacher-facing lesson plans online for CS Fundamentals courses. \t\t\t\t\t\t\t\t"
+              "text": "access teacher-facing lesson plans online for CS Fundamentals courses."
             },
             {
               "value": "view_student_work",
-              "text": "view student work through the teacher dashboard on the Code.org website. \t\t\t\t\t\t\t\t"
+              "text": "view student work through the teacher dashboard on the Code.org website."
             },
             {
               "value": "access_sample_solutions",
-              "text": "access sample solutions to programming puzzles on the Code.org website.\t\t\t\t\t"
+              "text": "access sample solutions to programming puzzles on the Code.org website."
             },
             {
               "value": "create_student_sections",
-              "text": "create sections of students on the Code.org website \t\t\t\t\t\t\t\t"
+              "text": "create sections of students on the Code.org website."
             },
             {
               "value": "manage_student_sections",
-              "text": "manage sections of students on the Code.org website (move students between sections, reset passwords, etc). "
+              "text": "manage sections of students on the Code.org website (move students between sections, reset passwords, etc)."
             }
           ]
         }

--- a/dashboard/config/foorm/forms/surveys/pd/csf_deep_dive_post.0.json
+++ b/dashboard/config/foorm/forms/surveys/pd/csf_deep_dive_post.0.json
@@ -2,24 +2,149 @@
   "title": "CS Fundamentals Deep Dive Post Survey",
   "pages": [
     {
-      "name": "overview",
+      "name":"preamble_page",
       "elements": [
         {
           "type": "html",
           "name": "overview_text",
           "hideNumber": true,
           "html": "<p>Thank you for spending the day with us at the CS Fundamentals Deep Dive workshop. Your participation in the workshop and responses to this post workshop survey will help Code.org and your facilitator(s) continue to reflect and adjust.</p>\n\n<p>The purpose of this survey is to:</p>\n<ul>\n    <li>Help us understand if the workshop supported your needs and development.</li>\n    <li>Give us ideas about how we might improve the workshop for the future.</li>\n</ul>\n<p>\nYour <strong>honesty and candor</strong> are appreciated. This survey should take about 10 minutes to complete.\n</p>"
-        },
+        }
+      ]
+    },
+    {
+      "name": "workshop_effectiveness",
+      "elements": [
         {
-          "type": "html",
-          "name": "understand_plans_heading",
-          "hideNumber": true,
-          "html": "<h2>Understanding your plans for CS Fundamentals</h2>"
+          "type": "matrix",
+          "name": "overall_success",
+          "title": "Please rate how much you agree or disagree with the following statements.",
+          "columns": [
+            {
+              "value": "1",
+              "text": "Strongly Disagree"
+            },
+            {
+              "value": "2",
+              "text": "Disagree"
+            },
+            {
+              "value": "3",
+              "text": "Slightly Disagree"
+            },
+            {
+              "value": "4",
+              "text": "Neutral"
+            },
+            {
+              "value": "5",
+              "text": "Slightly Agree"
+            },
+            {
+              "value": "6",
+              "text": "Agree"
+            },
+            {
+              "value": "7",
+              "text": "Strongly Agree"
+            }
+          ],
+          "rows": [
+            {
+              "value": "more_prepared",
+              "text": "I feel more prepared to teach the material covered in this workshop than before I came."
+            },
+            {
+              "value": "where_to_go",
+              "text": "I know where to go if I need help preparing to teach this material."
+            },
+            {
+              "value": "suitable_my_level",
+              "text": "This professional development was suitable for my level of experience with teaching CS."
+            },
+            {
+              "value": "feel_community",
+              "text": "I feel like I am a part of a community of teachers."
+            },
+            {
+              "value": "would_recommend",
+              "text": "I would recommend this professional development to others."
+            }
+          ]
         },
         {
           "type": "matrix",
+          "name": "teacher_engagement",
+          "title": "Please rate the how much you agree or disagree with the following statements.",
+          "columns": [
+            {
+              "value": "1",
+              "text": "Strongly Disagree"
+            },
+            {
+              "value": "2",
+              "text": "Disagree"
+            },
+            {
+              "value": "3",
+              "text": "Slightly Disagree"
+            },
+            {
+              "value": "4",
+              "text": "Neutral"
+            },
+            {
+              "value": "5",
+              "text": "Slightly Agree"
+            },
+            {
+              "value": "6",
+              "text": "Agree"
+            },
+            {
+              "value": "7",
+              "text": "Strongly Agree"
+            }
+          ],
+          "rows": [
+            {
+              "value": "engaging",
+              "text": "I found the activities we did in this workshop interesting and engaging."
+            },
+            {
+              "value": "active",
+              "text": "I was highly active and participated a lot in the workshop activities."
+            },
+            {
+              "value": "talk_about_workshop",
+              "text": "When I'm not in Code.org workshops, I frequently talk about ideas or content from the workshop with others."
+            },
+            {
+              "value": "ideas",
+              "text": "I am definitely planning to make use of ideas and content covered in this workshop in my classroom."
+            }
+          ]
+        },
+        {
+          "type": "comment",
+          "name": "helped_learn_most_FR",
+          "title": "What helped you learn the most in this workshop and why?"
+        },
+        {
+          "type": "comment",
+          "name": "detracted_learning_FR",
+          "title": "What detracted from your learning in this workshop and why?"
+        }
+      ],
+      "title": "Workshop Effectiveness"
+    },
+    {
+      "name": "understanding_plans",
+      "elements": [
+        {
+          "type": "matrix",
           "name": "how_much_plan_teach",
-          "title": "During the workshop you set a goal for how much CS Fundamentals you would like to teach with your students. As a result of the workshop, how much of the CS Fundamentals curriculum are you now planning to use with students? ",
+          "title": "During the workshop you set a goal for how much CS Fundamentals you would like to teach with your students. As a result of the workshop, how much of the CS Fundamentals curriculum are you now planning to use with students?",
           "columns": [
             {
               "value": "none",
@@ -40,27 +165,27 @@
           ],
           "rows": [
             {
-              "value": "course_a ",
+              "value": "course_a",
               "text": " Course A"
             },
             {
-              "value": "course_b ",
+              "value": "course_b",
               "text": " Course B"
             },
             {
-              "value": "course_c ",
+              "value": "course_c",
               "text": " Course C"
             },
             {
-              "value": "course_d ",
+              "value": "course_d",
               "text": " Course D"
             },
             {
-              "value": "course_e ",
+              "value": "course_e",
               "text": " Course E"
             },
             {
-              "value": "course_f ",
+              "value": "course_f",
               "text": " Course F"
             },
             {
@@ -76,9 +201,10 @@
         {
           "type": "comment",
           "name": "thinking_differently_FR",
-          "title": "As a result of the conversations and activities during the workshop, in what ways are you thinking differently about *how* you will teach CS Fundamentals lessons? "
+          "title": "As a result of the conversations and activities during the workshop, in what ways are you thinking differently about *how* you will teach CS Fundamentals lessons?"
         }
-      ]
+      ],
+      "title": "Understanding your plans for CS Fundamentals"
     },
     {
       "name": "barriers_to_teaching",
@@ -86,19 +212,19 @@
         {
           "type": "radiogroup",
           "name": "acquired_strategies",
-          "title": "During our workshop, did you acquire any strategies or ideas that will help you address the barriers you've experienced implementing CS Fundamentals? ",
+          "title": "During our workshop, did you acquire any strategies or ideas that will help you address the barriers you've experienced implementing CS Fundamentals?",
           "choices": [
             {
               "value": "yes_lots",
-              "text": "Yes! I walked away with a lot of new strategies that I'm going to try to help confront my implementation barriers. "
+              "text": "Yes! I walked away with a lot of new strategies that I'm going to try to help confront my implementation barriers."
             },
             {
               "value": "yes_couple",
-              "text": "Yes! I have one or two new strategies that I'll try out. "
+              "text": "Yes! I have one or two new strategies that I'll try out."
             },
             {
               "value": "not_really",
-              "text": "Not really. I don't have new ideas for how to how address barriers. "
+              "text": "Not really. I don't have new ideas for how to how address barriers."
             }
           ],
           "hasOther": true,
@@ -112,16 +238,16 @@
         {
           "type": "comment",
           "name": "new_different_barriers_FR",
-          "title": "Now that you've completed the Deep Dive workshop, are there any *new or different barriers* that you're thinking about that you hadn't considered before? If so, please share them below. "
+          "title": "Now that you've completed the Deep Dive workshop, are there any *new or different barriers* that you're thinking about that you hadn't considered before? If so, please share them below."
         },
         {
           "type": "radiogroup",
           "name": "able_help_others_barriers_FR",
-          "title": "During the Deep Dive workshop, did you feel you were able to help others by sharing ideas and strategies for addressing their barriers? ",
+          "title": "During the Deep Dive workshop, did you feel you were able to help others by sharing ideas and strategies for addressing their barriers?",
           "choices": [
             {
               "value": "yes",
-              "text": "Yes! I felt like I was able to give other people new ideas that will help. "
+              "text": "Yes! I felt like I was able to give other people new ideas that will help."
             },
             {
               "value": "think_so",
@@ -129,7 +255,7 @@
             },
             {
               "value": "no",
-              "text": "No, I don't think so. "
+              "text": "No, I don't think so."
             }
           ],
           "hasOther": true,
@@ -195,7 +321,7 @@
             },
             {
               "value": "support_problem_solving",
-              "text": "I can support students in solving the various problems they encounter while working on programming activities. "
+              "text": "I can support students in solving the various problems they encounter while working on programming activities."
             }
           ]
         },
@@ -262,7 +388,7 @@
           ]
         }
       ],
-      "title": "Computer Science Fundamentals Teaching Practices and Course Resources "
+      "title": "Computer Science Fundamentals Teaching Practices and Course Resources"
     },
     {
       "name": "feedback",
@@ -270,7 +396,7 @@
         {
           "type": "checkbox",
           "name": "most_useful_activites",
-          "title": "Which activities did you find MOST useful during the workshop? (select up to 2) ",
+          "title": "Which activities did you find MOST useful during the workshop? (select up to 2)",
           "choices": [
             {
               "value": "identifying_barriers",
@@ -309,7 +435,7 @@
         {
           "type": "checkbox",
           "name": "least_useful_activities",
-          "title": " Which activities did you find LEAST useful during the workshop? (select up to 2) ",
+          "title": " Which activities did you find LEAST useful during the workshop? (select up to 2)",
           "choices": [
             {
               "value": "identifying_barriers",
@@ -348,12 +474,12 @@
         {
           "type": "comment",
           "name": "any_other_feedback_FR",
-          "title": "Is there anything you want to tell us about the workshop sessions? "
+          "title": "Is there anything you want to tell us about the workshop sessions?"
         },
         {
           "type": "radiogroup",
           "name": "would_you_recommend",
-          "title": "Would you recommend this workshop to a colleague? ",
+          "title": "Would you recommend this workshop to a colleague?",
           "choices": [
             {
               "value": "yes",
@@ -374,137 +500,11 @@
         {
           "type": "comment",
           "name": "anything_else_FR",
-          "title": "Is there anything else you would like to tell us about your experience in the Deep Dive workshop? "
+          "title": "Is there anything else you would like to tell us about your experience in the Deep Dive workshop?"
         }
       ],
       "title": "Workshop Feedback",
       "description": "The following questions are designed to gather your feelings about the workshop flow and activities."
-    },
-    {
-      "name": "workshop_effectiveness",
-      "elements": [
-        {
-          "type": "matrix",
-          "name": "overall_success",
-          "title": "Please rate how much you agree or disagree with the following statements. ",
-          "columns": [
-            {
-              "value": "1",
-              "text": "Strongly Disagree"
-            },
-            {
-              "value": "2",
-              "text": "Disagree"
-            },
-            {
-              "value": "3",
-              "text": "Slightly Disagree"
-            },
-            {
-              "value": "4",
-              "text": "Neutral"
-            },
-            {
-              "value": "5",
-              "text": "Slightly Agree"
-            },
-            {
-              "value": "6",
-              "text": "Agree"
-            },
-            {
-              "value": "7",
-              "text": "Strongly Agree"
-            }
-          ],
-          "rows": [
-            {
-              "value": "more_prepared",
-              "text": "I feel more prepared to teach the material covered in this workshop than before I came."
-            },
-            {
-              "value": "where_to_go",
-              "text": "I know where to go if I need help preparing to teach this material."
-            },
-            {
-              "value": "suitable_my_level",
-              "text": "This professional development was suitable for my level of experience with teaching CS."
-            },
-            {
-              "value": "feel_community",
-              "text": "I feel like I am a part of a community of teachers. "
-            },
-            {
-              "value": "would_recommend",
-              "text": "I would recommend this professional development to others."
-            }
-          ]
-        },
-        {
-          "type": "matrix",
-          "name": "teacher_engagement",
-          "title": "Please rate the how much you agree or disagree with the following statements. ",
-          "columns": [
-            {
-              "value": "1",
-              "text": "Strongly Disagree"
-            },
-            {
-              "value": "2",
-              "text": "Disagree"
-            },
-            {
-              "value": "3",
-              "text": "Slightly Disagree"
-            },
-            {
-              "value": "4",
-              "text": "Neutral"
-            },
-            {
-              "value": "5",
-              "text": "Slightly Agree"
-            },
-            {
-              "value": "6",
-              "text": "Agree"
-            },
-            {
-              "value": "7",
-              "text": "Strongly Agree"
-            }
-          ],
-          "rows": [
-            {
-              "value": "engaging",
-              "text": "I found the activities we did in this workshop interesting and engaging."
-            },
-            {
-              "value": "active",
-              "text": "I was highly active and participated a lot in the workshop activities."
-            },
-            {
-              "value": "talk_about_workshop",
-              "text": "When I'm not in Code.org workshops, I frequently talk about ideas or content from the workshop with others."
-            },
-            {
-              "value": "ideas",
-              "text": "I am definitely planning to make use of ideas and content covered in this workshop in my classroom."
-            }
-          ]
-        },
-        {
-          "type": "comment",
-          "name": "helped_learn_most_FR",
-          "title": "What helped you learn the most in this workshop and why? "
-        },
-        {
-          "type": "comment",
-          "name": "detracted_learning_FR",
-          "title": "What detracted from your learning in this workshop and why? "
-        }
-      ],
-      "title": "Workshop Effectiveness"
     },
     {
       "name": "facilitator_feedback_page",
@@ -512,7 +512,7 @@
         {
           "type": "html",
           "name": "facilitator_feedback_intro",
-          "html": "<h2>Facilitator Feedback</h2>\n<p>Below we present the same sets of questions for each facilitator of your workshop.  Please be thoughtful in your responses for each individual."
+          "html": "<h2>Facilitator Feedback</h2>\n<p>Below we present the same set of questions for each facilitator of your workshop.  Please be thoughtful in your responses for each individual."
         },
         {
           "type": "paneldynamic",


### PR DESCRIPTION
A couple updates to the CSF Deep Dive Post survey in Foorm:
- move the workshop effectiveness page to be the first page of questions in the survey (as requested by Baker/MeganH)
- remove extra whitespace at the end of questions
- put the preamble as the first page in the survey instead of as with the first page of questions.

<!-- ### Background -->
<!-- ### Privacy -->
<!-- ### Security -->
<!-- ### Caching -->
<!-- ### Deployment strategy -->
<!-- ### Future work -->


## Testing story
Seeded the survey locally and validated it works as expected

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
