### PR TITLE
Fix ForbiddenAttributesError in registrations#new

### DIFF
--- a/dashboard/app/controllers/registrations_controller.rb
+++ b/dashboard/app/controllers/registrations_controller.rb
@@ -16,9 +16,9 @@ class RegistrationsController < Devise::RegistrationsController
   def new
     session[:user_return_to] ||= params[:user_return_to]
     if PartialRegistration.in_progress?(session)
-      user_params = params[:user] || {}
+      user_params = params[:user] || ActionController::Parameters.new
       user_params[:user_type] ||= session[:default_sign_up_user_type]
-      @user = User.new_with_session(user_params, session)
+      @user = User.new_with_session(user_params.permit(:user_type), session)
     else
       save_default_sign_up_user_type
       @already_hoc_registered = params[:already_hoc_registered]

--- a/dashboard/test/integration/registration/new_test.rb
+++ b/dashboard/test/integration/registration/new_test.rb
@@ -76,6 +76,18 @@ module RegistrationsControllerTests
       assert_nil assigns(:user).user_type
     end
 
+    test 'visting sign-up with a user_type queryparam when sign-up is in progress, the queryparam wins' do
+      get '/users/sign_up?user[user_type]=student'
+      start_email_password_signup
+      assert_template partial: '_finish_sign_up'
+      assert_equal 'student', assigns(:user).user_type
+
+      get '/users/sign_up?user[user_type]=teacher'
+      assert_response :success, response.body
+      assert_template partial: '_finish_sign_up'
+      assert_equal 'teacher', assigns(:user).user_type
+    end
+
     private
 
     def start_email_password_signup


### PR DESCRIPTION
Resolves [this Honeybadger error](https://app.honeybadger.io/projects/3240/faults/40094122) which has seen tens of incidents since June 1, 2020.

![image](https://user-images.githubusercontent.com/1615761/87974371-d404dd00-ca7e-11ea-844d-692e2ae195ac.png)

It seems this `ActiveModel::ForbiddenAttributesError` can occur when a PartialRegistration is in progress, and then the user clicks on a `sign_up` link that includes a `user[user_type]` queryparam.  This caused us to enter the finish registration case and initialize a user with an ActionController::Parameters object that has not been through a `permit` operation.

At first I thought this regression was introduced in https://github.com/code-dot-org/code-dot-org/pull/35637 but that only shipped a few weeks ago.  I believe this issue has been around quite a bit longer; the line that could set params to a `Parameters` or an empty hash was [added in September 2018](https://github.com/code-dot-org/code-dot-org/commit/e49d31b79a18223b9fb0cb155abf3df266a0a1a0#diff-6a8c633dd363e1c73252d8f3dac7cd50R16-R18).

I've written a unit test reproduced the error in question, and updated it to define a desired behavior in the above scenario: The user_type queryparam should "win" over a user_type stored in the session.

To prevent the error, I'm calling `permit(:user_type)` on the parameters object before we initialize a user with it.  I'm also initializing an empty params object instead of an empty hash in the fallback case, so we don't need to special-case our code later.

## Testing story

I've added a regression test for the particular error being fixed, and am leaning on our existing automated test coverage to verify that no other user account stories have been broken.

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
