### PR TITLE
Modify outbound email scheduled process to more reliably only run one at a time

### DIFF
--- a/bin/cron/deliver_poste_messages
+++ b/bin/cron/deliver_poste_messages
@@ -1,4 +1,7 @@
 #!/usr/bin/env ruby
+require_relative '../../lib/cdo/only_one'
+exit unless only_one_running?(__FILE__)
+
 require File.expand_path('../../../pegasus/src/env', __FILE__)
 require 'retryable'
 require 'cdo/only_one'
@@ -112,4 +115,4 @@ def main
   end
 end
 
-main if only_one_running?(__FILE__)
+main


### PR DESCRIPTION
Multiple instances of the `deliver_poste_messages` job - which transmits outbound email - were running concurrently. Many of these instances had piled up from Friday July 17, 2020 2:30PM PDT through Monday July 20 2020 9:30AM PDT. Improve the reliability of the check that ensures only one instance of the job is running to help prevent this type of problem from recurring.


# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
