### PR TITLE
Remove randomness from generated student's first name

### DIFF
--- a/dashboard/test/ui/features/support/hooks.rb
+++ b/dashboard/test/ui/features/support/hooks.rb
@@ -1,17 +1,17 @@
 Before('@as_student') do
-  steps "Given I create a student named \"#{rand(100000)}_Student\""
+  steps "Given I create a student named \"Student #{rand(100000)}\""
 end
 
 Before('@as_young_student') do
-  steps "Given I create a young student named \"#{rand(100000)}_Student\""
+  steps "Given I create a young student named \"Student #{rand(100000)}\""
 end
 
 Before('@as_taught_student') do
-  steps "Given I create a teacher-associated student named \"#{rand(100000)}_Student\""
+  steps "Given I create a teacher-associated student named \"Student #{rand(100000)}\""
 end
 
 Before('@as_authorized_taught_student') do
-  steps "Given I create an authorized teacher-associated student named \"#{rand(100000)}_Student\""
+  steps "Given I create an authorized teacher-associated student named \"Student #{rand(100000)}\""
 end
 
 Before('@as_teacher') do


### PR DESCRIPTION
Follow-up to #35846.

The fix I made to shorten generated usernames was insufficient because it caused randomness in a user's "first name":
<img width="1040" alt="Screen Shot 2020-07-20 at 12 07 34 PM" src="https://user-images.githubusercontent.com/9812299/87976237-9fdeeb80-ca81-11ea-93df-81cd327410dd.png">

I added a bunch of ignore regions and floating regions throughout our eyes test suite, but the original change was still disruptive. This change makes it so that the generated first name is always the same ("Student" rather than "#{random_int}_Student") and we don't have to worry about unnecessary eyes test failures.