### PR TITLE
Cleanup survey overview layout

### DIFF
--- a/apps/src/templates/sectionAssessments/PercentAnsweredCell.jsx
+++ b/apps/src/templates/sectionAssessments/PercentAnsweredCell.jsx
@@ -10,9 +10,7 @@ const styles = {
     justifyContent: 'space-between',
     flexDirection: 'row',
     alignItems: 'center',
-    height: '100%'
-  },
-  overviewMain: {
+    height: '100%',
     padding: 10
   },
   icon: {
@@ -20,8 +18,7 @@ const styles = {
   },
   value: {
     color: color.charcoal,
-    fontFamily: '"Gotham 5r", sans-serif',
-    marginRight: 10
+    fontFamily: '"Gotham 5r", sans-serif'
   }
 };
 
@@ -34,7 +31,9 @@ class PercentAnsweredCell extends Component {
     percentValue: PropTypes.number.isRequired,
     isCorrectAnswer: PropTypes.bool,
     displayAnswer: PropTypes.string,
-    isSurvey: PropTypes.bool
+    isSurvey: PropTypes.bool,
+    mainLayoutStyle: PropTypes.object,
+    valueLayoutStyle: PropTypes.object
   };
 
   getBackgroundColor = percentValue => {
@@ -67,8 +66,8 @@ class PercentAnsweredCell extends Component {
       backgroundColor: this.getBackgroundColor(percentValue)
     };
     return (
-      <div style={{...styles.main, ...backgroundCSS, ...styles.overviewMain}}>
-        <div style={styles.value}>
+      <div style={{...this.props.mainLayoutStyle, ...backgroundCSS}}>
+        <div style={{...styles.value, ...this.props.valueLayoutStyle}}>
           {percentValue >= 0 && <span>{`${percentValue}%`}</span>}
           {percentValue < 0 && <span>{'-'}</span>}
         </div>
@@ -83,7 +82,9 @@ class PercentAnsweredCell extends Component {
 }
 
 PercentAnsweredCell.defaultProps = {
-  percentValue: -1
+  percentValue: -1,
+  mainLayoutStyle: styles.main,
+  valueLayoutStyle: {marginRight: 10}
 };
 
 export default PercentAnsweredCell;

--- a/apps/src/templates/sectionAssessments/sectionAssessmentsRedux.js
+++ b/apps/src/templates/sectionAssessments/sectionAssessmentsRedux.js
@@ -52,7 +52,7 @@ const MultiAnswerStatus = {
   INCORRECT: 'incorrect'
 };
 
-const ANSWER_LETTERS = ['A', 'B', 'C', 'D', 'E', 'F', 'G', 'H'];
+const ANSWER_LETTERS = ['A', 'B', 'C', 'D', 'E', 'F', 'G', 'H', 'I', 'J', 'K'];
 
 export const ASSESSMENT_FEEDBACK_OPTION_ID = 0;
 


### PR DESCRIPTION
**before:**
<img width="1093" alt="Screen Shot 2020-07-17 at 12 42 34 PM" src="https://user-images.githubusercontent.com/4986878/87985538-a163e000-ca90-11ea-8927-3e4aa1a88cc4.png">

**after:**
<img width="1000" alt="Screen Shot 2020-07-17 at 12 01 09 PM" src="https://user-images.githubusercontent.com/4986878/87985577-ae80cf00-ca90-11ea-92f0-ed5638ef53c1.png">

while looking into the missing data in the question detail dialog on the survey overview page, i noticed that the overview data was not visible because the question cells weren't wrapping text so to see the data you had to scroll way to the right.

once i resized everything to fit into our regular content width, i needed to refactor the `PercentAnsweredCell` to properly center text when we're not including an icon.

<!-- ### Background -->
<!-- ### Privacy -->
<!-- ### Security -->
<!-- ### Caching -->
<!-- ### Deployment strategy -->
<!-- ### Future work -->

## Testing story

I manually tested these changes on the CSD Unit 1 Pre-survey, and verified that the changes to `PercentAnsweredCell` did not impact how that component is used for a non-survey assessment.

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
