### PR TITLE
Created new MultipleChoiceSurveyQuestionDialog

### DIFF
--- a/apps/src/templates/sectionAssessments/MultipleChoiceSurveyOverviewContainer.jsx
+++ b/apps/src/templates/sectionAssessments/MultipleChoiceSurveyOverviewContainer.jsx
@@ -1,8 +1,7 @@
 import PropTypes from 'prop-types';
 import React, {Component} from 'react';
-import MultipleChoiceSurveyOverviewTable, {
-  multipleChoiceSurveyDataPropType
-} from './MultipleChoiceSurveyOverviewTable';
+import MultipleChoiceSurveyOverviewTable from './MultipleChoiceSurveyOverviewTable';
+import {multipleChoiceDataPropType} from './assessmentDataShapes';
 import {
   getMultipleChoiceSurveyResults,
   countSubmissionsForCurrentAssessment
@@ -13,12 +12,9 @@ import {getTotalStudentCount} from '@cdo/apps/redux/sectionDataRedux';
 
 class MultipleChoiceSurveyOverviewContainer extends Component {
   static propTypes = {
-    multipleChoiceSurveyData: PropTypes.arrayOf(
-      multipleChoiceSurveyDataPropType
-    ),
+    multipleChoiceSurveyData: PropTypes.arrayOf(multipleChoiceDataPropType),
     totalStudentCount: PropTypes.number,
-    totalStudentSubmissions: PropTypes.number,
-    openDialog: PropTypes.func.isRequired
+    totalStudentSubmissions: PropTypes.number
   };
 
   render() {
@@ -38,7 +34,6 @@ class MultipleChoiceSurveyOverviewContainer extends Component {
         {multipleChoiceSurveyData.length > 0 && (
           <MultipleChoiceSurveyOverviewTable
             multipleChoiceSurveyData={multipleChoiceSurveyData}
-            openDialog={this.props.openDialog}
           />
         )}
       </div>

--- a/apps/src/templates/sectionAssessments/MultipleChoiceSurveyOverviewTable.story.jsx
+++ b/apps/src/templates/sectionAssessments/MultipleChoiceSurveyOverviewTable.story.jsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import {UnconnectedMultipleChoiceSurveyOverviewTable} from './MultipleChoiceSurveyOverviewTable';
+import MultipleChoiceSurveyOverviewTable from './MultipleChoiceSurveyOverviewTable';
 import i18n from '@cdo/locale';
 
 const multipleChoiceSurveyData = [
@@ -13,7 +13,8 @@ const multipleChoiceSurveyData = [
       {multipleChoiceOption: i18n.answerOptionC(), percentAnswered: 20},
       {multipleChoiceOption: i18n.answerOptionD(), percentAnswered: 20}
     ],
-    notAnswered: 10
+    notAnswered: 10,
+    totalAnswered: 20
   },
   {
     id: 2,
@@ -27,7 +28,8 @@ const multipleChoiceSurveyData = [
       {multipleChoiceOption: i18n.answerOptionE(), percentAnswered: 20},
       {multipleChoiceOption: i18n.answerOptionF(), percentAnswered: 10}
     ],
-    notAnswered: 30
+    notAnswered: 30,
+    totalAnswered: 20
   },
   {
     id: 3,
@@ -40,7 +42,8 @@ const multipleChoiceSurveyData = [
       {multipleChoiceOption: i18n.answerOptionD(), percentAnswered: 5},
       {multipleChoiceOption: i18n.answerOptionE(), percentAnswered: 5}
     ],
-    notAnswered: 5
+    notAnswered: 5,
+    totalAnswered: 20
   },
   {
     id: 4,
@@ -56,7 +59,8 @@ const multipleChoiceSurveyData = [
       {multipleChoiceOption: i18n.answerOptionF(), percentAnswered: 32},
       {multipleChoiceOption: i18n.answerOptionG(), percentAnswered: 5}
     ],
-    notAnswered: 0
+    notAnswered: 0,
+    totalAnswered: 20
   }
 ];
 
@@ -68,10 +72,8 @@ export default storybook => {
         name: 'Assessment multiple choice with 7 answers',
         description: 'Ability to see assessment overview for a section',
         story: () => (
-          <UnconnectedMultipleChoiceSurveyOverviewTable
+          <MultipleChoiceSurveyOverviewTable
             multipleChoiceSurveyData={multipleChoiceSurveyData}
-            openDialog={() => {}}
-            setQuestionIndex={() => {}}
           />
         )
       },
@@ -79,15 +81,13 @@ export default storybook => {
         name: 'Assessment multiple choice with 3 answers',
         description: 'Ability to see assessment overview for a section',
         story: () => (
-          <UnconnectedMultipleChoiceSurveyOverviewTable
+          <MultipleChoiceSurveyOverviewTable
             multipleChoiceSurveyData={multipleChoiceSurveyData.map(question => {
               return {
                 ...question,
                 answers: question.answers.slice(0, 2)
               };
             })}
-            openDialog={() => {}}
-            setQuestionIndex={() => {}}
           />
         )
       }

--- a/apps/src/templates/sectionAssessments/MultipleChoiceSurveyQuestionDialog.jsx
+++ b/apps/src/templates/sectionAssessments/MultipleChoiceSurveyQuestionDialog.jsx
@@ -1,0 +1,99 @@
+import PropTypes from 'prop-types';
+import React, {Component} from 'react';
+import Button from '@cdo/apps/templates/Button';
+import BaseDialog from '@cdo/apps/templates/BaseDialog';
+import i18n from '@cdo/locale';
+import DialogFooter from '@cdo/apps/templates/teacherDashboard/DialogFooter';
+import color from '@cdo/apps/util/color';
+import SafeMarkdown from '@cdo/apps/templates/SafeMarkdown';
+import {multipleChoiceDataPropType} from './assessmentDataShapes';
+
+const styles = {
+  dialog: {
+    paddingLeft: 20,
+    paddingRight: 20,
+    paddingBottom: 20
+  },
+  instructions: {
+    marginTop: 20
+  },
+  answers: {
+    float: 'left',
+    width: 550
+  },
+  icon: {
+    color: color.level_perfect
+  },
+  iconSpace: {
+    width: 40,
+    float: 'left'
+  },
+  answerBlock: {
+    width: '100%'
+  },
+  answerLetter: {
+    width: 30,
+    float: 'left',
+    fontWeight: 'bold'
+  }
+};
+
+class MultipleChoiceSurveyQuestionDialog extends Component {
+  static propTypes = {
+    isDialogOpen: PropTypes.bool.isRequired,
+    closeDialog: PropTypes.func.isRequired,
+    questionData: multipleChoiceDataPropType.isRequired
+  };
+
+  render() {
+    const {questionData} = this.props;
+
+    // Questions are in markdown format and should not display as plain text in the dialog.
+
+    return (
+      <BaseDialog
+        useUpdatedStyles
+        isOpen={this.props.isDialogOpen}
+        style={styles.dialog}
+        handleClose={this.props.closeDialog}
+      >
+        <div>
+          <h2>{i18n.questionDetails()}</h2>
+          <div style={styles.instructions}>
+            <SafeMarkdown markdown={questionData.question} />
+          </div>
+          {questionData.answers && questionData.answers.length > 0 && (
+            <div>
+              {questionData.answers.map((answer, index) => {
+                return (
+                  <div key={index} style={styles.answerBlock}>
+                    <div style={styles.answerLetter}>
+                      {answer.multipleChoiceOption}
+                    </div>
+                    <div style={styles.answers} />
+                    <SafeMarkdown
+                      markdown={
+                        answer.text + ' (' + answer.percentAnswered + '%)'
+                      }
+                    />
+                    <div style={{clear: 'both'}} />
+                  </div>
+                );
+              })}
+            </div>
+          )}
+        </div>
+        <DialogFooter>
+          <Button
+            __useDeprecatedTag
+            text={i18n.done()}
+            onClick={this.props.closeDialog}
+            color={Button.ButtonColor.gray}
+          />
+        </DialogFooter>
+      </BaseDialog>
+    );
+  }
+}
+
+export default MultipleChoiceSurveyQuestionDialog;

--- a/apps/src/templates/sectionAssessments/SectionAssessments.jsx
+++ b/apps/src/templates/sectionAssessments/SectionAssessments.jsx
@@ -265,9 +265,7 @@ class SectionAssessments extends Component {
                     >
                       <div>{i18n.downloadAssessmentCSV()}</div>
                     </CSVLink>
-                    <MultipleChoiceSurveyOverviewContainer
-                      openDialog={this.showMulitpleChoiceDetailDialog}
-                    />
+                    <MultipleChoiceSurveyOverviewContainer />
                     <FreeResponsesSurveyContainer
                       openDialog={this.showFreeResponseDetailDialog}
                     />

--- a/apps/src/templates/sectionAssessments/assessmentDataShapes.js
+++ b/apps/src/templates/sectionAssessments/assessmentDataShapes.js
@@ -19,7 +19,9 @@ export const freeResponsesDataPropType = PropTypes.shape({
 const multipleChoiceAnswerDataPropType = PropTypes.shape({
   multipleChoiceOption: PropTypes.string,
   numAnswered: PropTypes.number,
-  isCorrect: PropTypes.bool
+  isCorrect: PropTypes.bool,
+  percentAnswered: PropTypes.number,
+  text: PropTypes.string
 });
 
 // Represents a single question and a section summary of answers

--- a/apps/src/templates/sectionAssessments/sectionAssessmentsRedux.js
+++ b/apps/src/templates/sectionAssessments/sectionAssessmentsRedux.js
@@ -630,7 +630,7 @@ export const getSurveyFreeResponseQuestions = state => {
 };
 
 /**
- * Returns an array of objects, each of type multipleChoiceSurveyDataPropType
+ * Returns an array of objects, each of type multipleChoiceDataPropType
  * indicating a multiple choice question and the percent of responses received
  * for each answer.
  */
@@ -680,10 +680,12 @@ export const getMultipleChoiceSurveyResults = state => {
             multipleChoiceOption: ANSWER_LETTERS[index],
             percentAnswered: Math.floor(
               (answerTotals[index] / totalAnswered) * 100
-            )
+            ),
+            text: answer
           };
         }),
-        notAnswered: Math.floor((notAnswered / totalAnswered) * 100)
+        notAnswered: Math.floor((notAnswered / totalAnswered) * 100),
+        totalAnswered: totalAnswered
       };
     });
 };

--- a/apps/test/unit/templates/sectionAssessments/sectionAssessmentsReduxTest.js
+++ b/apps/test/unit/templates/sectionAssessments/sectionAssessmentsReduxTest.js
@@ -693,14 +693,14 @@ describe('sectionAssessmentsRedux', () => {
                       type: 'multi',
                       question_index: 0,
                       question: 'question1',
-                      answer_texts: [{text: 'agree'}, {text: 'disagree'}],
+                      answer_texts: ['agree', 'disagree'],
                       results: [{answer_index: 0}]
                     },
                     {
                       type: 'multi',
                       question_index: 1,
                       question: 'question2',
-                      answer_texts: [{text: 'agree'}, {text: 'disagree'}],
+                      answer_texts: ['agree', 'disagree'],
                       results: [{answer_index: 1}]
                     }
                   ]
@@ -716,20 +716,26 @@ describe('sectionAssessmentsRedux', () => {
             questionNumber: 1,
             question: 'question1',
             answers: [
-              {multipleChoiceOption: 'A', percentAnswered: 100},
-              {multipleChoiceOption: 'B', percentAnswered: 0}
+              {multipleChoiceOption: 'A', percentAnswered: 100, text: 'agree'},
+              {multipleChoiceOption: 'B', percentAnswered: 0, text: 'disagree'}
             ],
-            notAnswered: 0
+            notAnswered: 0,
+            totalAnswered: 1
           },
           {
             id: 1,
             questionNumber: 2,
             question: 'question2',
             answers: [
-              {multipleChoiceOption: 'A', percentAnswered: 0},
-              {multipleChoiceOption: 'B', percentAnswered: 100}
+              {multipleChoiceOption: 'A', percentAnswered: 0, text: 'agree'},
+              {
+                multipleChoiceOption: 'B',
+                percentAnswered: 100,
+                text: 'disagree'
+              }
             ],
-            notAnswered: 0
+            notAnswered: 0,
+            totalAnswered: 1
           }
         ]);
       });


### PR DESCRIPTION
**before:**
<img width="742" alt="Screen Shot 2020-07-20 at 2 04 44 PM" src="https://user-images.githubusercontent.com/4986878/87986604-33201d00-ca92-11ea-879b-ccfb12acfe42.png">

**after:**
<img width="747" alt="Screen Shot 2020-07-20 at 2 05 17 PM" src="https://user-images.githubusercontent.com/4986878/87986628-39ae9480-ca92-11ea-8b15-435ebd077994.png">

previously, clicking on a question in the survey overview table would open the `MultipleChoiceDetailsDialog`, which wasn't designed to fetch or display survey data. the easiest solution was to create a new `MultipleChoiceSurveyQuestionDialog` (largely copied from the previous dialog) which is designed specifically to display details for a multiple choice survey question.

<!-- ### Background -->
<!-- ### Privacy -->
<!-- ### Security -->
<!-- ### Caching -->
<!-- ### Deployment strategy -->
 ### Future work
This code needs cleanup: [jira](https://codedotorg.atlassian.net/browse/LP-1524)

## Links

<!--
  Any relevant links to external resources; ie, specification documents, jira
  items, related PRs, honeybadger errors, etc
-->

- [jira](https://codedotorg.atlassian.net/browse/LP-1505)

## Testing story

<!--
  Does your change include appropriate tests?

  If so, please describe how the tests included in this PR are sufficient

  If not, please explain why this change does not need to be tested.
-->

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
