### PR TITLE
PartialRegistration gets a smaller session cookie footprint

### DIFF
--- a/dashboard/app/controllers/registrations_controller.rb
+++ b/dashboard/app/controllers/registrations_controller.rb
@@ -115,9 +115,11 @@ class RegistrationsController < Devise::RegistrationsController
     TeacherMailer.new_teacher_email(current_user).deliver_now if should_send_new_teacher_email
     should_send_parent_email = current_user && current_user.parent_email.present?
     ParentMailer.parent_email_added_to_student_account(current_user.parent_email, current_user).deliver_now if should_send_parent_email
-    if current_user
+
+    if current_user # successful registration
       storage_id = take_storage_id_ownership_from_cookie(current_user.id)
       current_user.generate_progress_from_storage_id(storage_id) if storage_id
+      PartialRegistration.delete session
     end
 
     SignUpTracking.log_sign_up_result resource, session

--- a/dashboard/app/controllers/registrations_controller.rb
+++ b/dashboard/app/controllers/registrations_controller.rb
@@ -63,6 +63,10 @@ class RegistrationsController < Devise::RegistrationsController
   # Cancels the in-progress partial user registration and redirects to sign-up page.
   #
   def cancel
+    provider = PartialRegistration.get_provider(session) || 'email'
+    SignUpTracking.log_cancel_finish_sign_up(session, provider)
+    SignUpTracking.end_sign_up_tracking(session)
+
     PartialRegistration.cancel(session)
     redirect_to new_user_registration_path
   end

--- a/dashboard/app/controllers/registrations_controller.rb
+++ b/dashboard/app/controllers/registrations_controller.rb
@@ -67,7 +67,7 @@ class RegistrationsController < Devise::RegistrationsController
     SignUpTracking.log_cancel_finish_sign_up(session, provider)
     SignUpTracking.end_sign_up_tracking(session)
 
-    PartialRegistration.cancel(session)
+    PartialRegistration.delete(session)
     redirect_to new_user_registration_path
   end
 

--- a/dashboard/app/models/concerns/partial_registration.rb
+++ b/dashboard/app/models/concerns/partial_registration.rb
@@ -7,125 +7,53 @@ require 'cdo/shared_cache'
 module PartialRegistration
   extend ActiveSupport::Concern
 
-  USER_ATTRIBUTES_SESSION_KEY = 'devise.user_attributes'
-
-  # A common error during registration, especially when OAuth is involved, is a
-  # Cookie Overflow.  This module stores attributes for a partially-created user
-  # in the _learn_session cookie, which cannot exceed 4KB.  In fact, it we seem
-  # to encounter issues when the cookie is more than 2KB, since Devise and other
-  # parts of our application may also be using the session.
-  # To work around this, we keep known large values out of the session and
-  # instead store them in the shared application cache.
-  ATTRIBUTES_TO_KEEP_IN_CACHE = %w(
-    school
-    full_address
-  )
-  # also these large values from the user serialized properties blob
-  PROPERTIES_TO_KEEP_IN_CACHE = %w(
-    oauth_token
-    oauth_refresh_token
-  )
-  # We also drop some user model attributes that we know we don't need to preserve
-  # if we haven't created a user yet.
-  ATTRIBUTES_TO_DROP = %w(
-    id
-    studio_person_id
-    reset_password_token
-    reset_password_sent_at
-    remember_created_at
-    sign_in_count
-    current_sign_in_at
-    last_sign_in_at
-    current_sign_in_ip
-    last_sign_in_ip
-    created_at
-    updated_at
-    username
-    admin
-    total_lines
-    secret_picture_id
-    secret_words
-    active
-    deleted_at
-    purged_at
-    invitation_token
-    invitation_created_at
-    invitation_sent_at
-    invitation_accepted_at
-    invitation_limit
-    invited_by_id
-    invited_by_type
-    invitations_count
-  )
+  SESSION_KEY = 'partial_registration'
 
   module ClassMethods
-    def new_from_partial_registration(session)
+    def new_from_partial_registration(session, &block)
       raise 'No partial registration was in progress' unless PartialRegistration.in_progress? session
-      new(session[USER_ATTRIBUTES_SESSION_KEY]) do |user|
-        cache = CDO.shared_cache
-        [*ATTRIBUTES_TO_KEEP_IN_CACHE, *PROPERTIES_TO_KEEP_IN_CACHE].each do |param|
-          next if user.send(param)
-          # Grab the value from memcached if it's there
-          cache_key = PartialRegistration.cache_key(param, user)
-          user.send("#{param}=", cache.read(cache_key)) if cache
-        end
-        yield user if block_given?
-      end
+      cache_key = session[SESSION_KEY]
+      json = CDO.shared_cache.read(cache_key)
+      attributes = JSON.parse(json)
+      new(attributes, &block)
     end
   end
 
   def self.in_progress?(session)
-    !!session[USER_ATTRIBUTES_SESSION_KEY]
+    session[SESSION_KEY] && CDO.shared_cache.exist?(session[SESSION_KEY])
   end
 
   def self.persist_attributes(session, user)
-    user = user.dup
-    user_attributes = user.attributes.to_h
+    # Push the potential user's attributes into our application cache.
+    cache_key = PartialRegistration.cache_key(user)
+    CDO.shared_cache.write(cache_key, user.attributes.compact.to_json)
 
-    # Because some user attributes (especially oauth tokens) are quite large, we pass
-    # them through via the application cache instead of the session cookie.
-    # They are pulled out again in new_from_partial_registration
-    cache = CDO.shared_cache
-    if cache
-      ATTRIBUTES_TO_KEEP_IN_CACHE.each do |attr_name|
-        attr_value = user_attributes.delete(attr_name)
-        cache_key = PartialRegistration.cache_key(attr_name, user)
-        cache.write(cache_key, attr_value)
-      end
-
-      PROPERTIES_TO_KEEP_IN_CACHE.each do |param|
-        param_value = user_attributes['properties'].delete(param)
-        cache_key = PartialRegistration.cache_key(param, user)
-        cache.write(cache_key, param_value)
-      end
-    end
-
-    # Because we want to keep the session cookie as small as possible, we also drop these
-    # user attributes that we don't need to preserve from a partial registration
-    ATTRIBUTES_TO_DROP.each do |attr_name|
-      user_attributes.delete(attr_name)
-    end
-
-    session[USER_ATTRIBUTES_SESSION_KEY] = user_attributes
-  end
-
-  def self.get_provider(session)
-    in_progress?(session) ? session[USER_ATTRIBUTES_SESSION_KEY]['provider'] : nil
+    # Put the cache key into the session, to
+    # 1. track that a partial registration is in progress
+    # 2. retrieve the attributes later when we're ready to persist the user
+    session[SESSION_KEY] = cache_key
   end
 
   def self.cancel(session)
     provider = get_provider(session) || 'email'
     SignUpTracking.log_cancel_finish_sign_up(session, provider)
     SignUpTracking.end_sign_up_tracking(session)
-    session.delete(USER_ATTRIBUTES_SESSION_KEY)
-    session
+    session.delete(SESSION_KEY)
   end
 
-  def self.cache_key(param_name, user)
+  def self.get_provider(session)
+    # Extract the provider name from the cache key to avoid actually
+    # interacting with the cache or doing deserialization.
+    # Assumption: Provider names will not contain hyphens
+    cache_key = session[SESSION_KEY]
+    /^([^-]+)-.+-partial-sso$/.match(cache_key)&.[](1)
+  end
+
+  def self.cache_key(user)
     if user.uid.present?
-      "#{user.provider}-#{user.uid}-#{param_name}"
+      "#{user.provider}-#{user.uid}-partial-sso"
     else
-      "#{User.hash_email(user.email)}-#{param_name}"
+      "#{User.hash_email(user.email)}-partial-email"
     end
   end
 end

--- a/dashboard/app/models/concerns/partial_registration.rb
+++ b/dashboard/app/models/concerns/partial_registration.rb
@@ -46,7 +46,7 @@ module PartialRegistration
     # interacting with the cache or doing deserialization.
     # Assumption: Provider names will not contain hyphens
     cache_key = session[SESSION_KEY]
-    /^([^-]+)-.+-partial-sso$/.match(cache_key)&.[](1)
+    /^([^-]+)-.+-partial-sso$/.match(cache_key)&.captures&.first
   end
 
   def self.cache_key(user)

--- a/dashboard/app/models/concerns/partial_registration.rb
+++ b/dashboard/app/models/concerns/partial_registration.rb
@@ -35,9 +35,6 @@ module PartialRegistration
   end
 
   def self.cancel(session)
-    provider = get_provider(session) || 'email'
-    SignUpTracking.log_cancel_finish_sign_up(session, provider)
-    SignUpTracking.end_sign_up_tracking(session)
     session.delete(SESSION_KEY)
   end
 

--- a/dashboard/app/models/concerns/partial_registration.rb
+++ b/dashboard/app/models/concerns/partial_registration.rb
@@ -34,7 +34,7 @@ module PartialRegistration
     session[SESSION_KEY] = cache_key
   end
 
-  def self.cancel(session)
+  def self.delete(session)
     CDO.shared_cache.delete(session[SESSION_KEY])
     session.delete(SESSION_KEY)
   end

--- a/dashboard/app/models/concerns/partial_registration.rb
+++ b/dashboard/app/models/concerns/partial_registration.rb
@@ -35,6 +35,7 @@ module PartialRegistration
   end
 
   def self.cancel(session)
+    CDO.shared_cache.delete(session[SESSION_KEY])
     session.delete(SESSION_KEY)
   end
 

--- a/dashboard/app/models/concerns/partial_registration.rb
+++ b/dashboard/app/models/concerns/partial_registration.rb
@@ -8,16 +8,64 @@ module PartialRegistration
   extend ActiveSupport::Concern
 
   USER_ATTRIBUTES_SESSION_KEY = 'devise.user_attributes'
-  OAUTH_PARAMS_TO_STRIP = %w(oauth_token oauth_refresh_token)
+
+  # A common error during registration, especially when OAuth is involved, is a
+  # Cookie Overflow.  This module stores attributes for a partially-created user
+  # in the _learn_session cookie, which cannot exceed 4KB.  In fact, it we seem
+  # to encounter issues when the cookie is more than 2KB, since Devise and other
+  # parts of our application may also be using the session.
+  # To work around this, we keep known large values out of the session and
+  # instead store them in the shared application cache.
+  ATTRIBUTES_TO_KEEP_IN_CACHE = %w(
+    school
+    full_address
+  )
+  # also these large values from the user serialized properties blob
+  PROPERTIES_TO_KEEP_IN_CACHE = %w(
+    oauth_token
+    oauth_refresh_token
+  )
+  # We also drop some user model attributes that we know we don't need to preserve
+  # if we haven't created a user yet.
+  ATTRIBUTES_TO_DROP = %w(
+    id
+    studio_person_id
+    reset_password_token
+    reset_password_sent_at
+    remember_created_at
+    sign_in_count
+    current_sign_in_at
+    last_sign_in_at
+    current_sign_in_ip
+    last_sign_in_ip
+    created_at
+    updated_at
+    username
+    admin
+    total_lines
+    secret_picture_id
+    secret_words
+    active
+    deleted_at
+    purged_at
+    invitation_token
+    invitation_created_at
+    invitation_sent_at
+    invitation_accepted_at
+    invitation_limit
+    invited_by_id
+    invited_by_type
+    invitations_count
+  )
 
   module ClassMethods
     def new_from_partial_registration(session)
       raise 'No partial registration was in progress' unless PartialRegistration.in_progress? session
       new(session[USER_ATTRIBUTES_SESSION_KEY]) do |user|
         cache = CDO.shared_cache
-        OAUTH_PARAMS_TO_STRIP.each do |param|
+        [*ATTRIBUTES_TO_KEEP_IN_CACHE, *PROPERTIES_TO_KEEP_IN_CACHE].each do |param|
           next if user.send(param)
-          # Grab the oauth token from memcached if it's there
+          # Grab the value from memcached if it's there
           cache_key = PartialRegistration.cache_key(param, user)
           user.send("#{param}=", cache.read(cache_key)) if cache
         end
@@ -32,18 +80,33 @@ module PartialRegistration
 
   def self.persist_attributes(session, user)
     user = user.dup
-    # Because some oauth tokens are quite large, we strip them from the session
-    # variables and pass them through via the cache instead - they are pulled out again
-    # in new_from_partial_registration
+    user_attributes = user.attributes.to_h
+
+    # Because some user attributes (especially oauth tokens) are quite large, we pass
+    # them through via the application cache instead of the session cookie.
+    # They are pulled out again in new_from_partial_registration
     cache = CDO.shared_cache
     if cache
-      OAUTH_PARAMS_TO_STRIP.each do |param|
-        param_value = user.attributes['properties'].delete(param)
+      ATTRIBUTES_TO_KEEP_IN_CACHE.each do |attr_name|
+        attr_value = user_attributes.delete(attr_name)
+        cache_key = PartialRegistration.cache_key(attr_name, user)
+        cache.write(cache_key, attr_value)
+      end
+
+      PROPERTIES_TO_KEEP_IN_CACHE.each do |param|
+        param_value = user_attributes['properties'].delete(param)
         cache_key = PartialRegistration.cache_key(param, user)
         cache.write(cache_key, param_value)
       end
     end
-    session[USER_ATTRIBUTES_SESSION_KEY] = user.attributes
+
+    # Because we want to keep the session cookie as small as possible, we also drop these
+    # user attributes that we don't need to preserve from a partial registration
+    ATTRIBUTES_TO_DROP.each do |attr_name|
+      user_attributes.delete(attr_name)
+    end
+
+    session[USER_ATTRIBUTES_SESSION_KEY] = user_attributes
   end
 
   def self.get_provider(session)

--- a/dashboard/test/controllers/omniauth_callbacks_controller_test.rb
+++ b/dashboard/test/controllers/omniauth_callbacks_controller_test.rb
@@ -42,10 +42,9 @@ class OmniauthCallbacksControllerTest < ActionController::TestCase
     end
 
     assert_redirected_to 'http://test.host/users/sign_up'
-    attributes = session['devise.user_attributes']
-
-    assert_nil attributes['email']
-    assert_nil attributes['age']
+    partial_user = User.new_from_partial_registration(session)
+    assert_empty partial_user.email
+    assert_nil partial_user.age
   end
 
   test "login: authorizing with unknown clever teacher account" do
@@ -156,9 +155,8 @@ class OmniauthCallbacksControllerTest < ActionController::TestCase
     end
 
     assert_redirected_to 'http://test.host/users/sign_up'
-    attributes = session['devise.user_attributes']
-
-    assert_nil attributes['email']
+    partial_user = User.new_from_partial_registration(session)
+    assert_empty partial_user.email
   end
 
   test "login: authorizing with unknown clever student account creates student" do
@@ -723,9 +721,9 @@ class OmniauthCallbacksControllerTest < ActionController::TestCase
 
     # Then I go to the registration page to finish signing up
     assert_redirected_to 'http://test.host/users/sign_up'
-    attributes = session['devise.user_attributes']
-    assert_equal AuthenticationOption::GOOGLE, attributes['provider']
-    assert_equal uid, attributes['uid']
+    partial_user = User.new_from_partial_registration(session)
+    assert_equal AuthenticationOption::GOOGLE, partial_user.provider
+    assert_equal uid, partial_user.uid
   end
 
   test 'google_oauth2: sets tokens in session/cache when redirecting to complete registration' do

--- a/dashboard/test/integration/omniauth/google_oauth2_test.rb
+++ b/dashboard/test/integration/omniauth/google_oauth2_test.rb
@@ -183,6 +183,7 @@ module OmniauthCallbacksControllerTests
       assert_redirected_to '/users/sign_up'
       follow_redirect!
       assert_template partial: '_finish_sign_up'
+      assert PartialRegistration.in_progress? session
 
       get '/users/cancel'
 
@@ -196,6 +197,7 @@ module OmniauthCallbacksControllerTests
           google_oauth2-cancel-finish-sign-up
         )
       )
+      refute PartialRegistration.in_progress? session
     end
 
     test "fail to finish sign-up (new sign-up flow)" do

--- a/dashboard/test/integration/omniauth/google_oauth2_test.rb
+++ b/dashboard/test/integration/omniauth/google_oauth2_test.rb
@@ -23,12 +23,14 @@ module OmniauthCallbacksControllerTests
       assert_redirected_to '/users/sign_up'
       follow_redirect!
       assert_template partial: '_finish_sign_up'
+      assert PartialRegistration.in_progress? session
 
       assert_creates(User) {finish_sign_up auth_hash, User::TYPE_STUDENT}
       assert_redirected_to '/'
       follow_redirect!
       assert_redirected_to '/home'
       assert_equal I18n.t('devise.registrations.signed_up'), flash[:notice]
+      refute PartialRegistration.in_progress? session
 
       created_user = User.find signed_in_user_id
       assert_valid_student created_user, expected_email: auth_hash.info.email
@@ -55,10 +57,12 @@ module OmniauthCallbacksControllerTests
       assert_redirected_to '/users/sign_up'
       follow_redirect!
       assert_template partial: '_finish_sign_up'
+      assert PartialRegistration.in_progress? session
 
       assert_creates(User) {finish_sign_up auth_hash, User::TYPE_TEACHER}
       assert_redirected_to '/home'
       assert_equal I18n.t('devise.registrations.signed_up'), flash[:notice]
+      refute PartialRegistration.in_progress? session
 
       created_user = User.find signed_in_user_id
       assert_valid_teacher created_user, expected_email: auth_hash.info.email
@@ -85,15 +89,18 @@ module OmniauthCallbacksControllerTests
       assert_redirected_to '/users/sign_up'
       follow_redirect!
       assert_template partial: '_finish_sign_up'
+      assert PartialRegistration.in_progress? session
 
       refute_creates(User) {fail_sign_up auth_hash, User::TYPE_TEACHER}
       assert_response :success
       assert_template partial: '_finish_sign_up'
+      assert PartialRegistration.in_progress? session
 
       # Let's try that one more time...
       refute_creates(User) {fail_sign_up auth_hash, User::TYPE_TEACHER}
       assert_response :success
       assert_template partial: '_finish_sign_up'
+      assert PartialRegistration.in_progress? session
 
       assert_sign_up_tracking(
         SignUpTracking::CONTROL_GROUP,
@@ -119,12 +126,14 @@ module OmniauthCallbacksControllerTests
       follow_redirect!
       assert_response :success
       assert_template partial: '_finish_sign_up'
+      assert PartialRegistration.in_progress? session
 
       assert_creates(User) {finish_sign_up auth_hash, User::TYPE_STUDENT}
       assert_redirected_to '/'
       follow_redirect!
       assert_redirected_to '/home'
       assert_equal I18n.t('devise.registrations.signed_up'), flash[:notice]
+      refute PartialRegistration.in_progress? session
 
       created_user = User.find signed_in_user_id
       assert_valid_student created_user, expected_email: auth_hash.info.email
@@ -152,10 +161,12 @@ module OmniauthCallbacksControllerTests
       assert_redirected_to '/users/sign_up'
       follow_redirect!
       assert_template partial: '_finish_sign_up'
+      assert PartialRegistration.in_progress? session
 
       assert_creates(User) {finish_sign_up auth_hash, User::TYPE_TEACHER}
       assert_redirected_to '/home'
       assert_equal I18n.t('devise.registrations.signed_up'), flash[:notice]
+      refute PartialRegistration.in_progress? session
 
       created_user = User.find signed_in_user_id
       assert_valid_teacher created_user, expected_email: auth_hash.info.email
@@ -209,15 +220,18 @@ module OmniauthCallbacksControllerTests
       assert_redirected_to '/users/sign_up'
       follow_redirect!
       assert_template partial: '_finish_sign_up'
+      assert PartialRegistration.in_progress? session
 
       refute_creates(User) {fail_sign_up auth_hash, User::TYPE_TEACHER}
       assert_response :success
       assert_template partial: '_finish_sign_up'
+      assert PartialRegistration.in_progress? session
 
       # Let's try that one more time...
       refute_creates(User) {fail_sign_up auth_hash, User::TYPE_TEACHER}
       assert_response :success
       assert_template partial: '_finish_sign_up'
+      assert PartialRegistration.in_progress? session
 
       assert_sign_up_tracking(
         SignUpTracking::NEW_SIGN_UP_GROUP,

--- a/dashboard/test/integration/registration/cancel_test.rb
+++ b/dashboard/test/integration/registration/cancel_test.rb
@@ -9,7 +9,7 @@ module RegistrationsControllerTests
     test 'cancels partial registration and redirects to signup' do
       SignUpTracking.expects(:log_cancel_finish_sign_up)
       SignUpTracking.expects(:end_sign_up_tracking)
-      PartialRegistration.expects(:cancel)
+      PartialRegistration.expects(:delete)
 
       get '/users/cancel'
       assert_redirected_to new_user_registration_path

--- a/dashboard/test/integration/registration/cancel_test.rb
+++ b/dashboard/test/integration/registration/cancel_test.rb
@@ -3,10 +3,14 @@ require 'test_helper'
 module RegistrationsControllerTests
   #
   # Tests over GET /users/cancel
+  # See also the cancel flow in GoogleOAuth2Test
   #
   class CancelTest < ActionDispatch::IntegrationTest
     test 'cancels partial registration and redirects to signup' do
+      SignUpTracking.expects(:log_cancel_finish_sign_up)
+      SignUpTracking.expects(:end_sign_up_tracking)
       PartialRegistration.expects(:cancel)
+
       get '/users/cancel'
       assert_redirected_to new_user_registration_path
       follow_redirect!

--- a/dashboard/test/integration/registration/email_test.rb
+++ b/dashboard/test/integration/registration/email_test.rb
@@ -30,12 +30,14 @@ module RegistrationsControllerTests
       assert_redirected_to '/users/sign_up'
       follow_redirect!
       assert_template partial: '_finish_sign_up'
+      assert PartialRegistration.in_progress? session
 
       assert_creates(User) {finish_email_sign_up(User::TYPE_STUDENT)}
       assert_redirected_to '/'
       follow_redirect!
       assert_redirected_to '/home'
       assert_equal I18n.t('devise.registrations.signed_up'), flash[:notice]
+      refute PartialRegistration.in_progress? session
 
       created_user = User.find signed_in_user_id
       assert_equal User.hash_email(email), created_user.hashed_email

--- a/dashboard/test/models/concerns/partial_registration_test.rb
+++ b/dashboard/test/models/concerns/partial_registration_test.rb
@@ -129,7 +129,7 @@ class PartialRegistrationTest < ActiveSupport::TestCase
     assert_equal user.oauth_refresh_token, result_user.oauth_refresh_token
   end
 
-  test 'cancel deletes the partial registration from the session and cache' do
+  test 'delete removes the partial registration from the session and cache' do
     user = build :user, :google_sso_provider
     cache_key = PartialRegistration.cache_key user
 
@@ -137,7 +137,7 @@ class PartialRegistrationTest < ActiveSupport::TestCase
     refute_nil @session[PartialRegistration::SESSION_KEY]
     assert CDO.shared_cache.exist? cache_key
 
-    PartialRegistration.cancel @session
+    PartialRegistration.delete @session
     assert_nil @session[PartialRegistration::SESSION_KEY]
     refute CDO.shared_cache.exist? cache_key
   end

--- a/dashboard/test/models/concerns/partial_registration_test.rb
+++ b/dashboard/test/models/concerns/partial_registration_test.rb
@@ -4,127 +4,121 @@ class PartialRegistrationTest < ActiveSupport::TestCase
   # The PartialRegistration concern is only included in User, so we
   # are testing against User.
 
-  test 'in_progress? is false when session has no user attributes' do
-    refute PartialRegistration.in_progress? fake_empty_session
+  setup do
+    @session = {}
   end
 
-  test 'in_progress? is true when session has user attributes' do
-    assert PartialRegistration.in_progress? fake_session
+  test 'persist_attributes does not push empty attributes into the cache' do
+    user = build :user
+    assert user.attributes.values.any?(&:nil?)
+
+    PartialRegistration.persist_attributes @session, user
+
+    cache_contents = CDO.shared_cache.read(PartialRegistration.cache_key(user))
+    deserialized = JSON.parse cache_contents
+    refute deserialized.values.any?(&:nil?)
+  end
+
+  test 'persist_attributes pushes less than 0.5KB into the cache for a sample user' do
+    user = build :user, :google_sso_provider
+    PartialRegistration.persist_attributes @session, user
+
+    cache_key = PartialRegistration.cache_key(user)
+    cache_contents = CDO.shared_cache.read(cache_key)
+    assert (cache_key + cache_contents).length < 512,
+      "Pushed #{cache_contents.length}B into the cache, expected less than 512B"
+  end
+
+  test 'in_progress? is false when session has no user attributes' do
+    refute PartialRegistration.in_progress? @session
+  end
+
+  test 'in_progress? is true when attributes have been persisted' do
+    PartialRegistration.persist_attributes @session, build(:user)
+    assert PartialRegistration.in_progress? @session
+  end
+
+  test 'in_progress? becomes false if attributes are lost from the cache' do
+    user = build :user
+    PartialRegistration.persist_attributes @session, user
+    CDO.shared_cache.delete(PartialRegistration.cache_key(user))
+    refute PartialRegistration.in_progress? @session
   end
 
   test 'new_from_partial_registration raises unless a partial registration is available' do
     exception = assert_raise RuntimeError do
-      User.new_from_partial_registration fake_empty_session
+      User.new_from_partial_registration @session
     end
     assert_equal 'No partial registration was in progress', exception.message
   end
 
-  test 'new_from_partial_registration returns a User' do
-    user = User.new_from_partial_registration fake_session
-    assert_kind_of User, user
+  test 'new_from_partial_registration raises on a missing cache entry' do
+    user = build :student
+    PartialRegistration.persist_attributes @session, user
+    CDO.shared_cache.delete(PartialRegistration.cache_key(user))
+
+    exception = assert_raise RuntimeError do
+      User.new_from_partial_registration @session
+    end
+    assert_equal 'No partial registration was in progress', exception.message
   end
 
-  test 'new_from_partial_registration applies attributes to new User' do
-    user = User.new_from_partial_registration fake_session(
-      user_type: 'student',
-      name: 'Fake Name',
-      email: 'fake@example.com',
-      password: 'fake password',
-      age: 15,
-    )
-    assert user.student?
-    assert_equal 'Fake Name', user.name
-    assert_equal 'fake@example.com', user.email
-    assert_equal 'fake password', user.password
-    assert_equal 15, user.age
+  test 'new_from_partial_registration raises on a malformed cache entry' do
+    user = build :student
+    PartialRegistration.persist_attributes @session, user
+    CDO.shared_cache.write(PartialRegistration.cache_key(user), '{malformed_json:')
+
+    assert_raise JSON::ParserError do
+      User.new_from_partial_registration @session
+    end
+  end
+
+  test 'new_from_partial_registration returns a User' do
+    PartialRegistration.persist_attributes @session, build(:user)
+    assert_kind_of User, User.new_from_partial_registration(@session)
   end
 
   test 'new_from_partial_registration does not save the User' do
-    user = User.new_from_partial_registration fake_session(
-      user_type: 'student',
-      name: 'Fake Name',
-      email: 'fake@example.com',
-      password: 'fake password',
-      age: 15,
-    )
+    PartialRegistration.persist_attributes @session, build(:user)
+
+    user = User.new_from_partial_registration @session
     assert user.valid?
     refute user.persisted?
   end
 
   test 'new_from_partial_registration takes an optional block to modify the User' do
-    user = User.new_from_partial_registration fake_session(
-      user_type: 'student',
-      name: 'Fake Name',
-    ) do |u|
+    PartialRegistration.persist_attributes @session, build(:user, name: 'Fake Name')
+
+    user = User.new_from_partial_registration @session do |u|
       u.name = 'Different fake name'
     end
     assert_equal 'Different fake name', user.name
   end
 
-  test 'persist_attributes puts tokens in the cache' do
-    # Because some oauth tokens are quite large, we strip them from the session
-    # variables and pass them through via the cache instead - they are pulled
-    # out again in new_from_partial_registration.
-    # This avoids "cookie overflow" errors.
+  test 'round-trip preserves important attributes (email)' do
+    user = build :student
+    refute_nil user.email
+    refute_nil user.encrypted_password
+    PartialRegistration.persist_attributes @session, user
 
-    session = fake_empty_session
-    user = build :student, :google_sso_provider
-
-    PartialRegistration.persist_attributes session, user
-
-    # Tokens are in cache
-    assert_equal user.oauth_token,
-      CDO.shared_cache.read(PartialRegistration.cache_key('oauth_token', user))
-    assert_equal user.oauth_refresh_token,
-      CDO.shared_cache.read(PartialRegistration.cache_key('oauth_refresh_token', user))
-
-    # ...not in session
-    refute_equal user.oauth_token, session[PartialRegistration::USER_ATTRIBUTES_SESSION_KEY]['oauth_token']
-    refute_equal user.oauth_refresh_token, session[PartialRegistration::USER_ATTRIBUTES_SESSION_KEY]['oauth_refresh_token']
+    result_user = User.new_from_partial_registration @session
+    assert result_user.student?
+    assert_equal user.name, result_user.name
+    assert_equal user.email, result_user.email
+    assert_equal user.encrypted_password, result_user.encrypted_password
+    assert_equal user.age, result_user.age
   end
 
-  test 'persist_attributes puts other potentially large attributes into the cache' do
-    session = fake_empty_session
-    user = build :student, :google_sso_provider,
-      school: 'fake-school',
-      full_address: 'fake-full-address'
-
-    PartialRegistration.persist_attributes session, user
-
-    # Values are in cache
-    assert_equal user.school,
-      CDO.shared_cache.read(PartialRegistration.cache_key('school', user))
-    assert_equal user.full_address,
-      CDO.shared_cache.read(PartialRegistration.cache_key('full_address', user))
-
-    # ...not in session
-    refute session[PartialRegistration::USER_ATTRIBUTES_SESSION_KEY].key? 'school'
-    refute session[PartialRegistration::USER_ATTRIBUTES_SESSION_KEY].key? 'full_address'
-  end
-
-  test 'persist_attributes omits irrelevant attributes from the session and the cache' do
-    session = fake_empty_session
-    user = build :student, :google_sso_provider
-
-    PartialRegistration.persist_attributes session, user
-
-    PartialRegistration::ATTRIBUTES_TO_DROP.each do |attr_name|
-      # Values are not in the cache...
-      refute CDO.shared_cache.exist? PartialRegistration.cache_key(attr_name, user)
-
-      # ...nor in the session
-      refute session[PartialRegistration::USER_ATTRIBUTES_SESSION_KEY].key? attr_name
-    end
-  end
-
-  test 'round-trip preserves important attributes' do
-    session = fake_empty_session
+  test 'round-trip preserves important attributes (sso)' do
     user = build :user, :google_sso_provider
+    refute_nil user.provider
+    refute_nil user.uid
+    refute_nil user.oauth_token
+    refute_nil user.oauth_token_expiration
+    refute_nil user.oauth_refresh_token
+    PartialRegistration.persist_attributes @session, user
 
-    PartialRegistration.persist_attributes session, user
-
-    result_user = User.new_from_partial_registration session
-
+    result_user = User.new_from_partial_registration @session
     assert_equal user.user_type, result_user.user_type
     assert_equal user.name, result_user.name
     assert_equal user.email, result_user.email
@@ -137,24 +131,27 @@ class PartialRegistrationTest < ActiveSupport::TestCase
 
   test 'cancel ends signup tracking and deletes user attributes from the session' do
     user = build :user, :google_sso_provider
-    session = fake_session user.attributes
+    PartialRegistration.persist_attributes @session, user
+    refute_nil @session[PartialRegistration::SESSION_KEY]
 
-    SignUpTracking.expects(:log_cancel_finish_sign_up)
-    SignUpTracking.expects(:end_sign_up_tracking)
-    new_session = PartialRegistration.cancel(session)
-
-    assert_nil new_session[PartialRegistration::USER_ATTRIBUTES_SESSION_KEY]
+    SignUpTracking.expects(:log_cancel_finish_sign_up).with(@session, user.provider)
+    SignUpTracking.expects(:end_sign_up_tracking).with(@session)
+    PartialRegistration.cancel @session
+    assert_nil @session[PartialRegistration::SESSION_KEY]
   end
 
-  private
-
-  def fake_empty_session
-    {}
+  test 'get_provider returns nil when partial registration is not in progress' do
+    assert_nil PartialRegistration.get_provider @session
   end
 
-  def fake_session(user_attributes = {})
-    {
-      PartialRegistration::USER_ATTRIBUTES_SESSION_KEY => user_attributes
-    }
+  test 'get_provider returns nil when an email registration is in progress' do
+    PartialRegistration.persist_attributes @session, build(:user)
+    assert_nil PartialRegistration.get_provider @session
+  end
+
+  test 'get_provider returns the provider name when an sso registration is in progress' do
+    user = build :user, :google_sso_provider
+    PartialRegistration.persist_attributes @session, user
+    assert_equal user.provider, PartialRegistration.get_provider(@session)
   end
 end

--- a/dashboard/test/models/concerns/partial_registration_test.rb
+++ b/dashboard/test/models/concerns/partial_registration_test.rb
@@ -129,13 +129,17 @@ class PartialRegistrationTest < ActiveSupport::TestCase
     assert_equal user.oauth_refresh_token, result_user.oauth_refresh_token
   end
 
-  test 'cancel deletes the partial registration from the session' do
+  test 'cancel deletes the partial registration from the session and cache' do
     user = build :user, :google_sso_provider
+    cache_key = PartialRegistration.cache_key user
+
     PartialRegistration.persist_attributes @session, user
     refute_nil @session[PartialRegistration::SESSION_KEY]
+    assert CDO.shared_cache.exist? cache_key
 
     PartialRegistration.cancel @session
     assert_nil @session[PartialRegistration::SESSION_KEY]
+    refute CDO.shared_cache.exist? cache_key
   end
 
   test 'get_provider returns nil when partial registration is not in progress' do

--- a/dashboard/test/models/concerns/partial_registration_test.rb
+++ b/dashboard/test/models/concerns/partial_registration_test.rb
@@ -129,13 +129,11 @@ class PartialRegistrationTest < ActiveSupport::TestCase
     assert_equal user.oauth_refresh_token, result_user.oauth_refresh_token
   end
 
-  test 'cancel ends signup tracking and deletes user attributes from the session' do
+  test 'cancel deletes the partial registration from the session' do
     user = build :user, :google_sso_provider
     PartialRegistration.persist_attributes @session, user
     refute_nil @session[PartialRegistration::SESSION_KEY]
 
-    SignUpTracking.expects(:log_cancel_finish_sign_up).with(@session, user.provider)
-    SignUpTracking.expects(:end_sign_up_tracking).with(@session)
     PartialRegistration.cancel @session
     assert_nil @session[PartialRegistration::SESSION_KEY]
   end


### PR DESCRIPTION
Reduces the likelihood of CookieOverflow errors during our sign-up flow by reducing the amount of cookie storage used during registration.

## Background

For years we have been battling with [a low volume of ActionDispatch::Cookies::CookieOverflow errors](https://app.honeybadger.io/projects/3240/faults?q=class:%22ActionDispatch::Cookies::CookieOverflow%22).  This error is caused by storing too much data in our session cookie, which has a strict limit of 4KB (when encrypted).

We have poor session hygiene in a few places, but one of the most obvious ones is in our sign-up flow, which receives a large portion of these errors (a few hundred per month).

![image](https://user-images.githubusercontent.com/1615761/87998743-a1bea400-caad-11ea-8392-b804eb99943c.png)

We can probably blame this on our "partial registration" system, which builds a User object from our first interaction with a user (say, an OAuth callback or the first page of our registration form) then serializes it into the session, retrieving it again when the user submits our "finish sign up" form.  If you browse [a relevant error on HoneyBadger](https://app.honeybadger.io/projects/3240/faults/51743266) you will find a nearly-complete user attributes hash buried in the session.

![image](https://user-images.githubusercontent.com/1615761/87998881-0aa61c00-caae-11ea-9297-50ad2dd786e0.png)
_(Image intentionally truncated to avoid including PII)_

I say "nearly" because we've worked around a _worse_ version of this issue before: Some OAuth providers use tokens that are large enough that they were consistently causing this issue.  So we already had a system for keeping these tokens in the shared application cache (memcached) instead of the session cookie.  See #17106 and #25002 for more history on this approach.

However, there's a lot more we can do to shrink the footprint of PartialRegistration within the session.

Remember: This isn't the whole picture.  Other known large value in our session is the "callouts_seen" list, and other smaller values contribute toward the 4KB total as well. It's the combination of these things that causes a CookieOverflow error; each one we address will reduce the overall volume of these issues, but they probably won't go away entirely until we've dealt with both of them.

## A new approach

As of this PR, we now store only a single cache key in the session to track whether a partial registration is in progress. _All_ of the user attributes are now persisted into the application cache.

This should cut the typical session cookie space consumed by a partial registration by more than 90%, from about 1KB of structured data down to a ~70B key-value pair similar to this:

```
partial_registration:google_oauth2-111111111111111111111-partial-sso
```

## Testing story

**Automated testing:** I've checked that our existing PartialRegistration tests still pass, and added two new test cases checking the expected behavior regarding newly-offloaded-to-memcached and newly-omitted values.  Our UI tests also interact with PartialRegistration when they create a user.

**Manual testing:** I've gone through multi-step registration flows for both email+password signup and Google OAuth signup, stopping in the middle to confirm that a matching partial registration can be found in the application cache (which in development is located in the filesystem at `dashboard/tmp/cache`) and that registration can be completed, preserving details provided in the first registration step.

## Other consequences of shipping this change

_A few registrations in progress will be abandoned, and must start over._  I'll explain why this should affect very few people.

I have not provided a method to migrate old partial registrations over to the new system.  For successful sign-ups, [there is an average window of two minutes between creating a partial registration and successful sign-up](https://github.com/code-dot-org/code-dot-org/pull/35915#issuecomment-665163505). I believe that approximately 20 people will be in this window when we deploy.

- In the month of July, we recorded on average about 7k successful multi-step sign-up flows per day. This number is derived from our sign up tracking experiment; this is lower than total new sign-ups per day, which includes any single-step signups (a legacy flow) and accounts created via other systems like rostering.
- If the majority of a day's sign-ups are evenly distributed in an 12-hour window, we can estimate a rough sign-up rate of (7000 / (12 * 60)) = ~10 sign-ups per minute.

I did some testing of different scenarios for these 20ish users, switching from our old implementation to our new implementation and identified a couple of outcomes:

- During an OAuth signup flow, when the implementation changes while the user is on the OAuth provider's site, sign-up continues successfuly because the PartialRegistration is not created until we return from the third party.
- When the implementation changes while the user is on the finish_sign_up page, trying to finish sign-up will direct the user back to the beginning of the sign-up flow.

_This change does not include any session cleanup._  As Dave pointed out, some users will have the old `devise.user_attributes` session entry left in their session.  I haven't settled on the best place to clean this up (since users won't be going through the registration flow again), and am of the opinion that it wouldn't block this improvement.  However, we may want to follow up with clean-up of that session value.

## Links

Here are the open CookieOverflow Honeybadger errors:

**Probably related to PartialRegistration** which I believe will be significantly reduced if not resolved by this change.

- [omniauth_callbacks # microsoft_v2_auth](https://app.honeybadger.io/projects/3240/faults/51743266) Has been the highest volume recently, started my investigation today.
- [sessions # create](https://app.honeybadger.io/projects/3240/faults/55391869)
- [registrations # begin_sign_up](https://app.honeybadger.io/projects/3240/faults/63916422)
- [registrations # new](https://app.honeybadger.io/projects/3240/faults/52959033)
- [Another OAuth callback](https://app.honeybadger.io/projects/3240/faults/54371154)

**Probably related to an overlong "callouts_seen" list**

- [script_levels # show](https://app.honeybadger.io/projects/3240/faults/51842779) suspected to be irregular user behavior.
- [scripts # show](https://app.honeybadger.io/projects/3240/faults/52170940) 
- [courses # show](https://app.honeybadger.io/projects/3240/faults/59437258)
- [home # home](https://app.honeybadger.io/projects/3240/faults/51780960)
- [levels # index](https://app.honeybadger.io/projects/3240/faults/64108805)
- [libraries # index](https://app.honeybadger.io/projects/3240/faults/64108773)
- [teacher_feedbacks # index](https://app.honeybadger.io/projects/3240/faults/64108707)
- [sections # log_in](https://app.honeybadger.io/projects/3240/faults/56342555)
- [too_young # index](https://app.honeybadger.io/projects/3240/faults/54115467)
- [projects # create_new](https://app.honeybadger.io/projects/3240/faults/51846797)

**Other issues**

- [Looks like a paste error](https://app.honeybadger.io/projects/3240/faults/54430504) with an extremely long section code
- [pairings # update](https://app.honeybadger.io/projects/3240/faults/57983500) looks like a long request body.

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
