### PR TITLE
Add CourseVersion model

### DIFF
--- a/dashboard/app/models/course_version.rb
+++ b/dashboard/app/models/course_version.rb
@@ -1,0 +1,21 @@
+# == Schema Information
+#
+# Table name: course_versions
+#
+#  id                :integer          not null, primary key
+#  key               :string(255)      not null
+#  display_name      :string(255)      not null
+#  properties        :text(65535)
+#  content_root_type :string(255)      not null
+#  content_root_id   :integer          not null
+#  created_at        :datetime         not null
+#  updated_at        :datetime         not null
+#
+# Indexes
+#
+#  index_course_versions_on_content_root_type_and_content_root_id  (content_root_type,content_root_id)
+#
+
+class CourseVersion < ApplicationRecord
+  belongs_to :content_root, polymorphic: true
+end

--- a/dashboard/app/models/script.rb
+++ b/dashboard/app/models/script.rb
@@ -46,6 +46,7 @@ class Script < ActiveRecord::Base
   belongs_to :user
   has_many :course_scripts
   has_many :unit_groups, through: :course_scripts
+  has_one :course_version, as: :content_root
 
   scope :with_associated_models, -> do
     includes(

--- a/dashboard/app/models/unit_group.rb
+++ b/dashboard/app/models/unit_group.rb
@@ -22,6 +22,7 @@ class UnitGroup < ApplicationRecord
   has_many :default_course_scripts, -> {where(experiment_name: nil).order('position ASC')}, class_name: 'CourseScript', dependent: :destroy, foreign_key: 'course_id'
   has_many :default_scripts, through: :default_course_scripts, source: :script
   has_many :alternate_course_scripts, -> {where.not(experiment_name: nil)}, class_name: 'CourseScript', dependent: :destroy, foreign_key: 'course_id'
+  has_one :course_version, as: :content_root
 
   after_save :write_serialization
 

--- a/dashboard/db/migrate/20200722061339_create_course_versions.rb
+++ b/dashboard/db/migrate/20200722061339_create_course_versions.rb
@@ -1,0 +1,12 @@
+class CreateCourseVersions < ActiveRecord::Migration[5.0]
+  def change
+    create_table :course_versions do |t|
+      t.string :key, null: false
+      t.string :display_name, null: false
+      t.text :properties
+      t.references :content_root, polymorphic: true, null: false
+
+      t.timestamps
+    end
+  end
+end

--- a/dashboard/db/schema.rb
+++ b/dashboard/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20200701201654) do
+ActiveRecord::Schema.define(version: 20200722061339) do
 
   create_table "activities", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci" do |t|
     t.integer  "user_id"
@@ -341,6 +341,17 @@ ActiveRecord::Schema.define(version: 20200701201654) do
     t.index ["course_id"], name: "index_course_scripts_on_course_id", using: :btree
     t.index ["default_script_id"], name: "index_course_scripts_on_default_script_id", using: :btree
     t.index ["script_id"], name: "index_course_scripts_on_script_id", using: :btree
+  end
+
+  create_table "course_versions", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci" do |t|
+    t.string   "key",                             null: false
+    t.string   "display_name",                    null: false
+    t.text     "properties",        limit: 65535
+    t.string   "content_root_type",               null: false
+    t.integer  "content_root_id",                 null: false
+    t.datetime "created_at",                      null: false
+    t.datetime "updated_at",                      null: false
+    t.index ["content_root_type", "content_root_id"], name: "index_course_versions_on_content_root_type_and_content_root_id", using: :btree
   end
 
   create_table "courses", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci" do |t|

--- a/dashboard/test/factories/factories.rb
+++ b/dashboard/test/factories/factories.rb
@@ -4,8 +4,8 @@ FactoryGirl.allow_class_lookup = false
 
 FactoryGirl.define do
   factory :course_version do
-    sequence(:key) {|n| "202#{n-1}"}
-    sequence(:display_name) {|n| "2#{n-1}-2#{n}"}
+    sequence(:key) {|n| "202#{n - 1}"}
+    sequence(:display_name) {|n| "2#{n - 1}-2#{n}"}
     with_unit_group
 
     trait :with_unit_group do

--- a/dashboard/test/factories/factories.rb
+++ b/dashboard/test/factories/factories.rb
@@ -3,6 +3,16 @@ require 'cdo/activity_constants'
 FactoryGirl.allow_class_lookup = false
 
 FactoryGirl.define do
+  factory :course_version do
+    sequence(:key) {|n| "202#{n-1}"}
+    sequence(:display_name) {|n| "2#{n-1}-2#{n}"}
+    with_unit_group
+
+    trait :with_unit_group do
+      association(:content_root, factory: :unit_group)
+    end
+  end
+
   factory :course_script do
   end
 

--- a/dashboard/test/factories/factories.rb
+++ b/dashboard/test/factories/factories.rb
@@ -11,6 +11,10 @@ FactoryGirl.define do
     trait :with_unit_group do
       association(:content_root, factory: :unit_group)
     end
+
+    trait :with_unit do
+      association(:content_root, factory: :script)
+    end
   end
 
   factory :course_script do

--- a/dashboard/test/models/course_version_test.rb
+++ b/dashboard/test/models/course_version_test.rb
@@ -5,5 +5,9 @@ class CourseVersionTest < ActiveSupport::TestCase
     course_version = create :course_version
     assert_instance_of UnitGroup, course_version.content_root
     assert_equal course_version, course_version.content_root.course_version
+
+    course_version = create :course_version, :with_unit
+    assert_instance_of Script, course_version.content_root
+    assert_equal course_version, course_version.content_root.course_version
   end
 end

--- a/dashboard/test/models/course_version_test.rb
+++ b/dashboard/test/models/course_version_test.rb
@@ -1,0 +1,9 @@
+require 'test_helper'
+
+class CourseVersionTest < ActiveSupport::TestCase
+  test "course version associations" do
+    course_version = create :course_version
+    assert_instance_of UnitGroup, course_version.content_root
+    assert_equal course_version, course_version.content_root.course_version
+  end
+end


### PR DESCRIPTION
Add CourseVersion model.

- I used separate `key` and `display_name` fields as suggested. How do those names sound?
- I made everything besides `properties` not null; this seems like it makes sense to me, but I'm not sure if there are downsides here. Thoughts?

Also, for future reference, here's how to generate a model with a polymorphic association:

```
bin/rails g model CourseVersion version_name:string properties:text content_root:references{polymorphic}
```

## Future work

Will add the new Course model and its relevant associations once the current Course model and table are renamed. That model + associations will look like the `CourseOffering` model from https://github.com/code-dot-org/code-dot-org/pull/35858

## Links

- [design doc](https://docs.google.com/document/d/1mS7sPCBE9pUCQsPDeTHmwZStiOcZRrkYUvPtZ9I3hDM/edit#)

## Testing story

* Unit test tests out the new factory and associations

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
