### PR TITLE
Adding IAM permissions for new Firehose stream

### DIFF
--- a/aws/cloudformation/cloud_formation_stack.yml.erb
+++ b/aws/cloudformation/cloud_formation_stack.yml.erb
@@ -71,13 +71,15 @@ Resources:
             Resource:
               - !Sub "arn:aws:dynamodb:${AWS::Region}:${AWS::AccountId}:table/<%=CDO.dcdo_table_name%>"
               - !Sub "arn:aws:dynamodb:${AWS::Region}:${AWS::AccountId}:table/<%=CDO.gatekeeper_table_name%>"
-          # Write analysis events to Firehose.
+          # Write to our Firehose streams
           # TODO: Import resources into stack.
           - Effect: Allow
             Action:
             - 'firehose:PutRecord'
             - 'firehose:PutRecordBatch'
-            Resource: !Sub "arn:aws:firehose:${AWS::Region}:${AWS::AccountId}:deliverystream/analysis-events"
+            Resource:
+              - !Sub "arn:aws:firehose:${AWS::Region}:${AWS::AccountId}:deliverystream/analysis-events"
+              - !Sub "arn:aws:firehose:${AWS::Region}:${AWS::AccountId}:deliverystream/i18n-string-tracking-events"
           # S3 access for student-libraries bucket
           - Effect: Allow
             Action:


### PR DESCRIPTION
Adds the new Firehose stream to our IAM permissions list. This stream supports the new i18n String : URL tracking feature.

## Links
- [Honeybadger](https://app.honeybadger.io/projects/3240/faults/65945015)

## Testing story
* Grepped  the codebase for existing usages of `deliverystream/analysis-events`

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
