### PR TITLE
Added e2e pairing test

### DIFF
--- a/dashboard/test/ui/features/foundations/user_menu.feature
+++ b/dashboard/test/ui/features/foundations/user_menu.feature
@@ -52,32 +52,6 @@ Scenario: Student Signed In - shows display name with correct links
   And I wait until element "#signin_button" is visible
   And I wait until element ".display_name" is not visible
 
-Scenario: Pair Programming
-  Given I create a teacher named "Dr_Seuss"
-  And I create a new section
-  Given I create a student named "Thing_One"
-  And I join the section
-  Given I create a student named "Thing_Two"
-  And I join the section
-  Given I am on "http://studio.code.org/s/allthethings/stage/18/puzzle/7?noautoplay=true"
-  And I wait for the page to fully load
-  And I wait until element ".display_name" is visible
-  And element ".display_name" contains text "Thing_Two"
-  And I click selector ".display_name"
-  And I wait until element "#pairing_link" is visible
-  And I press "pairing_link"
-  And I wait until element ".student" is visible
-  And I click selector ".student"
-  And I wait until element ".addPartners" is visible
-  And I click selector ".addPartners"
-  And I wait for 5 seconds
-  And I wait until element ".user_menu" is visible
-  And I wait until element ".pairing_name" is visible
-  And element ".pairing_name" contains text "Team"
-  And I wait until element ".fa-users" is visible
-  And I click selector ".pairing_name"
-  And I wait until element ".pairing_summary" is visible
-
 Scenario: Unicode in display name
   Given I create a student named "Caoimhín" and go home
   And I wait until element ".display_name" is visible

--- a/dashboard/test/ui/features/learning_platform/pairing.feature
+++ b/dashboard/test/ui/features/learning_platform/pairing.feature
@@ -1,0 +1,52 @@
+Feature: Student pairing
+  Scenario: Pair Programming submits levels for both students
+    Given I create a teacher named "Dr_Seuss"
+    And I create a new section
+    Given I create a student named "Thing_One"
+    And I join the section
+    Given I create a student named "Thing_Two"
+    And I join the section
+    Given I am on "http://studio.code.org/s/allthethings/stage/18/puzzle/7"
+    And I rotate to landscape
+    And I wait for the page to fully load
+    Then I initiate pairing
+    # complete the level
+    And I wait until element "#runButton" is visible
+    And I click selector "#runButton"
+    And I wait until element "#submitButton" is visible
+    And I click selector "#submitButton"
+    Then I wait to see ".modal"
+    And I wait until element "#confirm-button" is visible
+    And I click selector "#confirm-button"
+    And I wait until I am on "http://studio.code.org/s/allthethings/stage/18/puzzle/8"
+    And I wait for the page to fully load
+    And I verify progress in the header of the current page is "perfect_assessment" for level 7
+    And I sign out
+    # verify the level is completed for the other student
+    When I sign in as "Thing_One"
+    Given I am on "http://studio.code.org/s/allthethings/stage/18/puzzle/7"
+    And I wait for the page to fully load
+    And I verify progress in the header of the current page is "perfect_assessment" for level 7
+
+  Scenario: Pair Programming attempts levels for both students
+    Given I create a teacher named "Dr_Seuss"
+    And I create a new section
+    Given I create a student named "Thing_One"
+    And I join the section
+    Given I create a student named "Thing_Two"
+    And I join the section
+    Given I am on "http://studio.code.org/s/allthethings/stage/2/puzzle/2"
+    And I rotate to landscape
+    And I wait for the page to fully load
+    Then I initiate pairing
+    # complete the level
+    And I wait until element "#runButton" is visible
+    And I click selector "#runButton"
+    And I wait until element ".uitest-topInstructions-inline-feedback" is visible
+    And I verify progress in the header of the current page is "attempted" for level 2
+    And I sign out
+    # verify the level is completed for the other student
+    When I sign in as "Thing_One"
+    Given I am on "http://studio.code.org/s/allthethings/stage/2/puzzle/2"
+    And I wait for the page to fully load
+    And I verify progress in the header of the current page is "attempted" for level 2

--- a/dashboard/test/ui/features/step_definitions/header_steps.rb
+++ b/dashboard/test/ui/features/step_definitions/header_steps.rb
@@ -1,0 +1,20 @@
+
+Then /^I initiate pairing$/ do
+  steps <<-STEPS
+    And I wait until element ".display_name" is visible
+    And I click selector ".display_name"
+    And I wait until element "#pairing_link" is visible
+    And I press "pairing_link"
+    And I wait until element ".student" is visible
+    And I click selector ".student"
+    And I wait until element ".addPartners" is visible
+    And I click selector ".addPartners"
+    And I wait for 5 seconds
+    And I wait until element ".user_menu" is visible
+    And I wait until element ".pairing_name" is visible
+    And element ".pairing_name" contains text "Team"
+    And I wait until element ".fa-users" is visible
+    And I click selector ".pairing_name"
+    And I wait until element ".pairing_summary" is visible
+  STEPS
+end


### PR DESCRIPTION
After a bug was shipped that broke pairing on Web Lab (still in Beta), we discovered that we have no end-to-end pair programming test on any of our labs - including our labs that are not in beta. Here, we add a pair programming test to two of our highest-usage labs. App Lab (CSP/D) and Maze (CSF & HOC). 

This test performs the following actions
- Creates 2 students in the same section
- Creates a pairing relationship between those students.
- Attempts or completes a level as one of those students
- Verifies that the level has been marked as attempted or completed by both students.

<!--
  Your description goes here: A summary of the change, including any relevant motivation and context.

  If relevant, include a description both of the existing behavior and of the new behavior.
-->

<!--
  Other aspects to consider. uncomment and add detail for any that seem necessary:
-->

<!-- ### Background -->
<!-- ### Privacy -->
<!-- ### Security -->
<!-- ### Caching -->
<!-- ### Deployment strategy -->
<!-- ### Future work -->

## Links

<!--
  Any relevant links to external resources; ie, specification documents, jira
  items, related PRs, honeybadger errors, etc
-->

- [Slack thread regarding the break of pair-programming in web lab](https://codedotorg.slack.com/archives/CA3KCSGTD/p1594236466483800)
- [jira](https://codedotorg.atlassian.net/browse/LP-1498)

## Testing story

<!--
  Does your change include appropriate tests?

  If so, please describe how the tests included in this PR are sufficient

  If not, please explain why this change does not need to be tested.
-->

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
