### PR TITLE
Allow updating of the display name of lessons groups

### DIFF
--- a/dashboard/app/models/lesson_group.rb
+++ b/dashboard/app/models/lesson_group.rb
@@ -65,18 +65,11 @@ class LessonGroup < ApplicationRecord
         LessonGroup.prevent_changing_plc_display_name(raw_lesson_group)
         LessonGroup.prevent_blank_display_name(raw_lesson_group)
 
-        new_lesson_group = false
-
         lesson_group = LessonGroup.find_or_create_by(
           key: raw_lesson_group[:key],
           script: script,
           user_facing: true
-        ) do
-          # if you got in here, this is a new lesson_group
-          new_lesson_group = true
-        end
-
-        LessonGroup.prevent_changing_display_name_for_existing_key(new_lesson_group, raw_lesson_group, lesson_group)
+        )
 
         lesson_group.assign_attributes(position: position += 1, properties: {display_name: raw_lesson_group[:display_name]})
         lesson_group.save! if lesson_group.changed?

--- a/dashboard/app/models/lesson_group.rb
+++ b/dashboard/app/models/lesson_group.rb
@@ -105,12 +105,6 @@ class LessonGroup < ApplicationRecord
     end
   end
 
-  def self.prevent_changing_display_name_for_existing_key(new_lesson_group, raw_lesson_group, lesson_group)
-    if !new_lesson_group && lesson_group.localized_display_name != raw_lesson_group[:display_name]
-      raise "Expect key and display name to match. The Lesson Group with key: #{raw_lesson_group[:key]} has display_name: #{lesson_group&.localized_display_name}"
-    end
-  end
-
   # All lesson groups should have lessons in them
   def self.prevent_lesson_group_with_no_lessons(lesson_group, num_lessons)
     raise "Every lesson group should have at least one lesson. Lesson Group #{lesson_group.key} has no lessons." if num_lessons < 1

--- a/dashboard/app/models/script.rb
+++ b/dashboard/app/models/script.rb
@@ -1138,7 +1138,7 @@ class Script < ActiveRecord::Base
     end
 
     lessons_i18n = {'en' => {'data' => {'script' => {'name' => lessons_i18n}}}}
-    existing_i18n.deep_merge(lessons_i18n) {|_, old, _| old}.deep_merge!(metadata_i18n)
+    existing_i18n.deep_merge(lessons_i18n).deep_merge!(metadata_i18n)
   end
 
   def hoc_finish_url

--- a/dashboard/test/models/script_test.rb
+++ b/dashboard/test/models/script_test.rb
@@ -2035,26 +2035,6 @@ endvariants
     assert_equal 'Expect all lesson groups to have display names. The following lesson group does not have a display name: content1', raise.message
   end
 
-  test 'raises error if lesson group key already exists and try to change the display name' do
-    l1 = create :level
-    script = create :script, name: "lesson-group-test-script"
-    create :lesson_group, key: 'content1', script: script
-    dsl = <<-SCRIPT
-      lesson_group 'content1', display_name: 'not content'
-      lesson 'Lesson1'
-      level '#{l1.name}'
-
-    SCRIPT
-
-    raise = assert_raises do
-      Script.add_script(
-        {name: 'lesson-group-test-script'},
-        ScriptDSL.parse(dsl, 'a filename')[0][:lesson_groups]
-      )
-    end
-    assert_equal 'Expect key and display name to match. The Lesson Group with key: content1 has display_name: Content', raise.message
-  end
-
   test 'raises error if some lessons have lesson groups and some do not' do
     l1 = create :level
     l2 = create :level


### PR DESCRIPTION
## Background

Currently we are preventing someone from updating the display name of a lesson group with an existing key. This was because it seemed that everything that was added to the scripts.en.yml file was additive so I didn't think updating an existing key was ok. 

In talking to @Hamms, he did not know of a reason that this was the case but said there might be one.

## Overview

This PR updates the merging of the new data in to the scripts.en.yml to allow someone to update an existing key.  This means that someone could update the display name for a lesson group without updating the key. 

## Links

<!--
  Any relevant links to external resources; ie, specification documents, jira
  items, related PRs, honeybadger errors, etc
-->

- [jira](https://codedotorg.atlassian.net/browse/PLAT-242)

## Testing story

I tested updating a lesson group locally and it worked correctly.
I tested updating a lesson name and that worked fine as well. (Is there anything to worry about with lesson names that have been updated in scripts.en.yml in the past? Seems like if someone updated that name it would just create a new entry into scripts.en.yml. That seems ok?)
Update the description, short description, title and audience and they all just update the value. 

It seems like this is safe to me but interested in others thoughts.

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
