### PR TITLE
Use struct to hold all the counters for add_script methods

### DIFF
--- a/dashboard/app/models/lesson.rb
+++ b/dashboard/app/models/lesson.rb
@@ -51,7 +51,7 @@ class Lesson < ActiveRecord::Base
 
   include CodespanOnlyMarkdownHelper
 
-  def self.add_lessons(script, lesson_group, raw_lessons, lockable_count, non_lockable_count, lesson_position, chapter, new_suffix, editor_experiment)
+  def self.add_lessons(script, lesson_group, raw_lessons, counters, new_suffix, editor_experiment)
     raw_lessons.map do |raw_lesson|
       Lesson.prevent_empty_lesson(raw_lesson)
 
@@ -64,18 +64,16 @@ class Lesson < ActiveRecord::Base
         end
 
       lesson.assign_attributes(
-        absolute_position: (lesson_position += 1),
+        absolute_position: (counters.lesson_position += 1),
         lesson_group: lesson_group,
         lockable: !!raw_lesson[:lockable],
         visible_after: raw_lesson[:visible_after],
-        relative_position: !!raw_lesson[:lockable] ? (lockable_count += 1) : (non_lockable_count += 1)
+        relative_position: !!raw_lesson[:lockable] ? (counters.lockable_count += 1) : (counters.non_lockable_count += 1)
       )
       lesson.save! if lesson.changed?
 
-      lesson.script_levels = ScriptLevel.add_script_levels(script, lesson, raw_lesson[:script_levels], chapter, new_suffix, editor_experiment)
+      lesson.script_levels = ScriptLevel.add_script_levels(script, lesson, raw_lesson[:script_levels], counters, new_suffix, editor_experiment)
       lesson.save!
-
-      chapter += lesson.script_levels.length
 
       Lesson.prevent_multi_page_assessment_outside_final_level(lesson)
 

--- a/dashboard/app/models/script_level.rb
+++ b/dashboard/app/models/script_level.rb
@@ -52,7 +52,7 @@ class ScriptLevel < ActiveRecord::Base
   )
 
   # Chapter values order all the script_levels in a script.
-  def self.add_script_levels(script, lesson, raw_script_levels, chapter, new_suffix, editor_experiment)
+  def self.add_script_levels(script, lesson, raw_script_levels, counters, new_suffix, editor_experiment)
     script_level_position = 0
 
     raw_script_levels.map do |raw_script_level|
@@ -71,7 +71,7 @@ class ScriptLevel < ActiveRecord::Base
       script_level_attributes = {
         script_id: script.id,
         stage_id: lesson.id,
-        chapter: (chapter += 1),
+        chapter: (counters.chapter += 1),
         position: (script_level_position += 1),
         named_level: raw_script_level[:named_level],
         bonus: raw_script_level[:bonus],


### PR DESCRIPTION
Responding to feedback https://github.com/code-dot-org/code-dot-org/pull/35884#discussion_r457745725 from #35884.

Use a struct to pass all the counters down between `add_lesson_group` and `add_lesson` and `add_script_level` so that we don't have to update the value of these counters it two places.
