### PR TITLE
CAUTION: Drop courses table

### DIFF
--- a/dashboard/db/migrate/20200722231459_drop_courses_table.rb
+++ b/dashboard/db/migrate/20200722231459_drop_courses_table.rb
@@ -1,5 +1,5 @@
 class DropCoursesTable < ActiveRecord::Migration[5.0]
-  def change
+  def up
     # As a final check, add foreign key constraints against the new table before
     # dropping the old table. In environments such as production and
     # levelbuilder where many sections are assigned to courses like csp and csd,
@@ -9,5 +9,24 @@ class DropCoursesTable < ActiveRecord::Migration[5.0]
     add_foreign_key :plc_courses, :unit_groups, column: :course_id
 
     drop_table :courses
+  end
+
+  def down
+    # create courses as an exact copy of the unit_groups table
+    execute 'CREATE TABLE courses LIKE unit_groups'
+    execute 'INSERT INTO courses SELECT * FROM unit_groups'
+
+    # fix the name of the index
+    remove_index :courses, :name
+    add_index :courses, :name
+
+    remove_foreign_key_if_exists :sections, :course_id
+    remove_foreign_key_if_exists :plc_courses, :course_id
+  end
+
+  private
+
+  def remove_foreign_key_if_exists(table, key)
+    remove_foreign_key table, column: key unless foreign_keys(table).find_index {|x| x.column == key.to_s}.nil?
   end
 end

--- a/dashboard/db/migrate/20200722231459_drop_courses_table.rb
+++ b/dashboard/db/migrate/20200722231459_drop_courses_table.rb
@@ -1,0 +1,5 @@
+class DropCoursesTable < ActiveRecord::Migration[5.0]
+  def change
+    drop_table :courses
+  end
+end

--- a/dashboard/db/migrate/20200722231459_drop_courses_table.rb
+++ b/dashboard/db/migrate/20200722231459_drop_courses_table.rb
@@ -1,5 +1,13 @@
 class DropCoursesTable < ActiveRecord::Migration[5.0]
   def change
+    # As a final check, add foreign key constraints against the new table before
+    # dropping the old table. In environments such as production and
+    # levelbuilder where many sections are assigned to courses like csp and csd,
+    # this step will fail if the new table is empty or has different ids than
+    # the old table.
+    add_foreign_key :sections, :unit_groups, column: :course_id
+    add_foreign_key :plc_courses, :unit_groups, column: :course_id
+
     drop_table :courses
   end
 end

--- a/dashboard/db/migrate/20200722231459_drop_courses_table.rb
+++ b/dashboard/db/migrate/20200722231459_drop_courses_table.rb
@@ -1,12 +1,8 @@
 class DropCoursesTable < ActiveRecord::Migration[5.0]
   def up
-    # As a final check, add foreign key constraints against the new table before
-    # dropping the old table. In environments such as production and
-    # levelbuilder where many sections are assigned to courses like csp and csd,
-    # this step will fail if the new table is empty or has different ids than
-    # the old table.
-    add_foreign_key :sections, :unit_groups, column: :course_id
-    add_foreign_key :plc_courses, :unit_groups, column: :course_id
+    # Do not add back foreign key constraints against the new table, because
+    # this step timed out when run against an adhoc with a production db clone,
+    # and the foreign keys aren't strictly necessary anyway.
 
     drop_table :courses
   end

--- a/dashboard/db/migrate/20200722231459_drop_courses_table.rb
+++ b/dashboard/db/migrate/20200722231459_drop_courses_table.rb
@@ -15,14 +15,5 @@ class DropCoursesTable < ActiveRecord::Migration[5.0]
     # fix the name of the index
     remove_index :courses, :name
     add_index :courses, :name
-
-    remove_foreign_key_if_exists :sections, :course_id
-    remove_foreign_key_if_exists :plc_courses, :course_id
-  end
-
-  private
-
-  def remove_foreign_key_if_exists(table, key)
-    remove_foreign_key table, column: key unless foreign_keys(table).find_index {|x| x.column == key.to_s}.nil?
   end
 end

--- a/dashboard/db/schema.rb
+++ b/dashboard/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20200722182927) do
+ActiveRecord::Schema.define(version: 20200722231459) do
 
   create_table "activities", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci" do |t|
     t.integer  "user_id"
@@ -352,14 +352,6 @@ ActiveRecord::Schema.define(version: 20200722182927) do
     t.datetime "created_at",                      null: false
     t.datetime "updated_at",                      null: false
     t.index ["content_root_type", "content_root_id"], name: "index_course_versions_on_content_root_type_and_content_root_id", using: :btree
-  end
-
-  create_table "courses", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci" do |t|
-    t.string   "name"
-    t.text     "properties", limit: 65535
-    t.datetime "created_at",               null: false
-    t.datetime "updated_at",               null: false
-    t.index ["name"], name: "index_courses_on_name", using: :btree
   end
 
   create_table "donor_schools", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci" do |t|
@@ -1798,12 +1790,14 @@ ActiveRecord::Schema.define(version: 20200722182927) do
   add_foreign_key "peer_reviews", "users", column: "reviewer_id"
   add_foreign_key "peer_reviews", "users", column: "submitter_id"
   add_foreign_key "plc_course_units", "scripts"
+  add_foreign_key "plc_courses", "unit_groups", column: "course_id"
   add_foreign_key "plc_learning_modules", "stages"
   add_foreign_key "queued_account_purges", "users"
   add_foreign_key "school_infos", "school_districts"
   add_foreign_key "school_infos", "schools"
   add_foreign_key "school_stats_by_years", "schools"
   add_foreign_key "schools", "school_districts"
+  add_foreign_key "sections", "unit_groups", column: "course_id"
   add_foreign_key "state_cs_offerings", "schools", column: "state_school_id", primary_key: "state_school_id"
   add_foreign_key "survey_results", "users"
   add_foreign_key "user_geos", "users"


### PR DESCRIPTION
## Background

One of many steps to complete [PLAT-234](https://codedotorg.atlassian.net/browse/PLAT-234).  Step 3 of 3 to rename the courses table to unit_groups. please see [courses table rename proposal](https://docs.google.com/document/d/1-Dxlk00DSFPa35SqvWL2YkHJ0kfUy2a50xBZkiD4pBI/edit#heading=h.xz5b9e31july) for context. 

* Step 1: #35949
* Step 2: #35952
* Step 3: #35953 (this PR)

## Description

Drops the courses table, and adds foreign key constraints on the new unit_groups table. 

CAVEAT: This migration is not reversible. If someone does need to reverse it, and needs to further reverse back to where the courses table had data in it, they might be able to use syntax from https://github.com/code-dot-org/code-dot-org/pull/35949 to copy the data from unit_groups back to courses, but I didn't have enough confidence in this working to include this syntax in the migration.

## Testing story

<!--
  Does your change include appropriate tests?

  If so, please describe how the tests included in this PR are sufficient

  If not, please explain why this change does not need to be tested.
-->

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
