### PR TITLE
[Animation Library] Add S3 folder and API endpoint for custom assets

### DIFF
--- a/shared/middleware/animation_library_api.rb
+++ b/shared/middleware/animation_library_api.rb
@@ -23,13 +23,13 @@ class AnimationLibraryApi < Sinatra::Base
   # GET /api/v1/animation-library/levelbuilder/<version-id>/<filename>
   # Retrieve an animation that was uploaded by a levelbuilder (for use in level start_animations)
   #
-  get %r{/api/v1/animation-library/levelbuilder/([^/]+)/(.+)} do |version_id, animation_name|
+  get %r{/api/v1/animation-library/level_animations/([^/]+)/(.+)} do |version_id, animation_name|
     not_found if version_id.empty? || animation_name.empty?
 
     begin
       result = Aws::S3::Bucket.
         new(ANIMATION_LIBRARY_BUCKET, client: AWS::S3.create_client).
-        object("levelbuilder/#{animation_name}").
+        object("level_animations/#{animation_name}").
         get(version_id: version_id)
       content_type result.content_type
       cache_for 3600

--- a/shared/middleware/animation_library_api.rb
+++ b/shared/middleware/animation_library_api.rb
@@ -20,6 +20,26 @@ class AnimationLibraryApi < Sinatra::Base
   end
 
   #
+  # GET /api/v1/animation-library/levelbuilder/<version-id>/<filename>
+  # Retrieve an animation that was uploaded by a levelbuilder (for use in level start_animations)
+  #
+  get %r{/api/v1/animation-library/levelbuilder/([^/]+)/(.+)} do |version_id, animation_name|
+    not_found if version_id.empty? || animation_name.empty?
+
+    begin
+      result = Aws::S3::Bucket.
+        new(ANIMATION_LIBRARY_BUCKET, client: AWS::S3.create_client).
+        object("levelbuilder/#{animation_name}").
+        get(version_id: version_id)
+      content_type result.content_type
+      cache_for 3600
+      result.body
+    rescue
+      not_found
+    end
+  end
+
+  #
   # GET /api/v1/animation-library/(spritelab|gamelab)/<version-id>/<filename>
   #
   # Retrieve a file from the animation library for the given app type

--- a/shared/middleware/animation_library_api.rb
+++ b/shared/middleware/animation_library_api.rb
@@ -59,6 +59,8 @@ class AnimationLibraryApi < Sinatra::Base
   end
 
   #
+  # Legacy animation API, but do not delete, because old Gamelab and Spritelab projects will still
+  # have animations that use this api.
   # GET /api/v1/animation-library/<version-id>/<filename>
   #
   # Retrieve a file from the animation library

--- a/shared/middleware/animation_library_api.rb
+++ b/shared/middleware/animation_library_api.rb
@@ -20,7 +20,7 @@ class AnimationLibraryApi < Sinatra::Base
   end
 
   #
-  # GET /api/v1/animation-library/levelbuilder/<version-id>/<filename>
+  # GET /api/v1/animation-library/level_animations/<version-id>/<filename>
   # Retrieve an animation that was uploaded by a levelbuilder (for use in level start_animations)
   #
   get %r{/api/v1/animation-library/level_animations/([^/]+)/(.+)} do |version_id, animation_name|


### PR DESCRIPTION
These are assets that are not in the spritelab/gamelab animation libraries, but are used for start animations for some levels. Currently, the levels rely on production projects owned by individual levelbuilder accounts. Instead, we should put them in S3. I added a folder called `levelbuilder` nested under `cdo-animation-library`
![image](https://user-images.githubusercontent.com/8787187/88243836-8cc94880-cc46-11ea-8237-7e37446ee749.png)

These assets can then be added as start_animations using the URL `/api/v1/animation-library/levelbuilder/<version>/<filename>`, instead of a v3 url.
![image](https://user-images.githubusercontent.com/8787187/88243998-209b1480-cc47-11ea-9177-a2998b22fb66.png)


<!--
  Other aspects to consider. uncomment and add detail for any that seem necessary:
-->

<!-- ### Background -->
<!-- ### Privacy -->
<!-- ### Security -->
<!-- ### Caching -->
<!-- ### Deployment strategy -->
<!-- ### Future work -->

## Links

<!--
  Any relevant links to external resources; ie, specification documents, jira
  items, related PRs, honeybadger errors, etc
-->

- [jira](https://codedotorg.atlassian.net/browse/STAR-1153)

## Testing story

<!--
  Does your change include appropriate tests?

  If so, please describe how the tests included in this PR are sufficient

  If not, please explain why this change does not need to be tested.
-->

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
