### PR TITLE
Revert "[Droplet] Move console.log to functions"

### DIFF
--- a/apps/src/applab/dropletConfig.js
+++ b/apps/src/applab/dropletConfig.js
@@ -810,7 +810,7 @@ export var blocks = [
   {
     func: 'console.log',
     parent: consoleApi,
-    category: 'Functions',
+    category: 'Variables',
     paletteParams: ['message'],
     params: ['"message"']
   },

--- a/apps/src/p5lab/gamelab/dropletConfig.js
+++ b/apps/src/p5lab/gamelab/dropletConfig.js
@@ -1907,19 +1907,17 @@ draw() - USEFUL?
 
   // Variables
   {
+    func: 'console.log',
+    parent: consoleApi,
+    category: 'Variables',
+    paletteParams: ['message'],
+    params: ['"message"']
+  },
+  {
     func: 'comment_Variables',
     block: '// Comment',
     expansion: '// ',
     category: 'Variables'
-  },
-
-  // Functions
-  {
-    func: 'console.log',
-    parent: consoleApi,
-    category: 'Functions',
-    paletteParams: ['message'],
-    params: ['"message"']
   },
 
   // Data


### PR DESCRIPTION
Turns out we don't want this change at this point as it's pretty disruptive for curriculum (changes screenshots, instructions, etc).

Reverts code-dot-org/code-dot-org#35878