### PR TITLE
Resize Redshift cluster.

### DIFF
--- a/aws/cloudformation/data.yml.erb
+++ b/aws/cloudformation/data.yml.erb
@@ -59,7 +59,8 @@ Resources:
       KmsKeyId: alias/aws/redshift
       MasterUsername: {Ref: RedshiftUsername}
       MasterUserPassword: {Ref: RedshiftPassword}
-      NodeType: dc1.large
+      NodeType: ra3.4xlarge
+      NumberOfNodes: 3
       PubliclyAccessible: true
       VpcSecurityGroupIds: [!ImportValue VPC-RedshiftSecurityGroup]
   TableauSync:


### PR DESCRIPTION
Switch to `ra3` node type, which decouples CPU/memory allocation from storage by offloading infrequently used data to S3.
https://codedotorg.atlassian.net/browse/INF-291


## Deployment

This change will be carried out by AWS as a [classic resize](https://docs.aws.amazon.com/redshift/latest/mgmt/managing-cluster-operations.html#classic-resize). Based on testing resizing with a test cluster, there will be about 4 hours of downtime. The RED (data) team has agreed to running this on a Friday evening.


## Testing story

```
$ bundle exec rake stack:data:validate RAILS_ENV=production VERBOSE=hellzyeah

Listing changes to existing stack `DATA-production`:
Modify DMSCronLevelSourcesPii [AWS::DMS::ReplicationTask] Properties Replacement: Conditional (TargetEndpointArn)
Modify DMSCronPii [AWS::DMS::ReplicationTask] Properties Replacement: Conditional (TargetEndpointArn)
Modify DMSCronUserHierarchyPii [AWS::DMS::ReplicationTask] Properties Replacement: Conditional (TargetEndpointArn)
Modify DMSCronUserHierarchy [AWS::DMS::ReplicationTask] Properties Replacement: Conditional (TargetEndpointArn)
Modify DMSCronUserLevels [AWS::DMS::ReplicationTask] Properties Replacement: Conditional (TargetEndpointArn)
Modify DMSCron [AWS::DMS::ReplicationTask] Properties Replacement: Conditional (TargetEndpointArn)
Modify RedshiftEndpoint [AWS::DMS::Endpoint] Properties Replacement: Conditional (ServerName, Port)
Modify Tableau [AWS::Redshift::Cluster] Properties (NumberOfNodes, NodeType)
```

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
