### PR TITLE
Dynamic banner size

### DIFF
--- a/apps/src/sites/studio/pages/projects/index.js
+++ b/apps/src/sites/studio/pages/projects/index.js
@@ -48,10 +48,12 @@ $(document).ready(() => {
           projectCount={projectsData.projectCount}
           specialAnnouncement={specialAnnouncement}
         />
-        <ProjectsGallery
-          limitedGallery={projectsData.limitedGallery}
-          canShare={projectsData.canShare}
-        />
+        <div className={'main container'}>
+          <ProjectsGallery
+            limitedGallery={projectsData.limitedGallery}
+            canShare={projectsData.canShare}
+          />
+        </div>
       </div>
     </Provider>,
     document.querySelector('#projects-page')

--- a/apps/src/templates/HeaderBanner.jsx
+++ b/apps/src/templates/HeaderBanner.jsx
@@ -7,87 +7,56 @@ import PropTypes from 'prop-types';
 import React from 'react';
 import color from '../util/color';
 import {connect} from 'react-redux';
+import styleConstants from '@cdo/apps/styleConstants';
 
 const styles = {
-  headerBanner: {
-    height: 260,
-    maxWidth: '60%',
-    marginTop: 25
+  headerBannerContainer: {
+    minHeight: 260,
+    maxWidth: styleConstants['content-width']
   },
-  headerBannerResponsive: {
-    marginBottom: 61,
-    maxWidth: '60%',
-    marginTop: 25
-  },
-  headerBannerShort: {
-    height: 140,
-    maxWidth: '60%',
-    marginTop: 25
-  },
-  headerBannerShortResponsive: {
-    marginBottom: 61,
-    maxWidth: '60%',
-    marginTop: 25
+  headerBannerContainerShort: {
+    minHeight: 140,
+    maxWidth: styleConstants['content-width']
   },
   bannerHeading: {
     fontFamily: '"Gotham 7r", sans-serif',
     color: color.white,
     fontSize: 32,
-    marginBottom: 10,
     lineHeight: '40px'
-  },
-  bannerHeadingResponsive: {
-    fontFamily: '"Gotham 7r", sans-serif',
-    color: color.white,
-    fontSize: 32,
-    marginBottom: 10,
-    lineHeight: '40px',
-    height: 240
   },
   bannerHeadingShort: {
     fontFamily: '"Gotham 7r", sans-serif',
     color: color.white,
     fontSize: 32,
-    marginBottom: 10,
-    lineHeight: '40px',
-    marginTop: -20
-  },
-  bannerHeadingShortResponsive: {
-    fontFamily: '"Gotham 7r", sans-serif',
-    color: color.white,
-    fontSize: 32,
-    marginBottom: 10,
-    lineHeight: '40px',
-    marginTop: -20,
-    height: 120
+    lineHeight: '40px'
   },
   bannerSubHeading: {
     fontFamily: '"Gotham 4r", sans-serif',
     color: color.white,
     fontSize: 16,
     lineHeight: '21px',
-    marginBottom: 10
+    marginTop: 16
   },
   bannerSubHeadingResponsive: {
     fontFamily: '"Gotham 4r", sans-serif',
     color: color.dark_charcoal,
     fontSize: 16,
     lineHeight: '21px',
-    marginBottom: 10
+    marginTop: 16
   },
   bannerDescription: {
     fontFamily: '"Gotham 4r", sans-serif',
     color: color.white,
     fontSize: 16,
     lineHeight: '21px',
-    marginBottom: 20
+    marginTop: 16
   },
   bannerDescriptionResponsive: {
     fontFamily: '"Gotham 4r", sans-serif',
     color: color.dark_charcoal,
     fontSize: 16,
     lineHeight: '21px',
-    marginBottom: 20
+    marginTop: 16
   }
 };
 
@@ -98,7 +67,8 @@ class HeaderBanner extends React.Component {
     description: PropTypes.string,
     children: PropTypes.node,
     short: PropTypes.bool,
-    responsiveSize: PropTypes.oneOf(['lg', 'md', 'sm', 'xs']).isRequired
+    responsiveSize: PropTypes.oneOf(['lg', 'md', 'sm', 'xs']).isRequired,
+    backgroundUrl: PropTypes.string
   };
 
   render() {
@@ -107,36 +77,79 @@ class HeaderBanner extends React.Component {
       headingText,
       subHeadingText,
       description,
-      responsiveSize
+      responsiveSize,
+      backgroundUrl
     } = this.props;
 
-    let headerStyle, headingStyle, subHeadingStyle, descriptionStyle;
-    if (responsiveSize === 'xs') {
-      headerStyle = short
-        ? styles.headerBannerShortResponsive
-        : styles.headerBannerResponsive;
-      headingStyle = short
-        ? styles.bannerHeadingShortResponsive
-        : styles.bannerHeadingResponsive;
+    let headerBannerContainerStyle,
+      headingStyle,
+      subHeadingStyle,
+      descriptionStyle;
+
+    const isSmallScreen = responsiveSize === 'xs';
+    headerBannerContainerStyle = short
+      ? styles.headerBannerContainerShort
+      : styles.headerBannerContainer;
+    headingStyle = short ? styles.bannerHeadingShort : styles.bannerHeading;
+    if (isSmallScreen) {
       subHeadingStyle = styles.bannerSubHeadingResponsive;
       descriptionStyle = styles.bannerDescriptionResponsive;
     } else {
-      headerStyle = short ? styles.headerBannerShort : styles.headerBanner;
-      headingStyle = short ? styles.bannerHeadingShort : styles.bannerHeading;
       subHeadingStyle = styles.bannerSubHeading;
       descriptionStyle = styles.bannerDescription;
     }
 
-    return (
-      <div style={headerStyle}>
-        <div style={headingStyle}>{headingText || <span>&nbsp;</span>}</div>
-        <div style={subHeadingStyle}>
-          {subHeadingText || <span>&nbsp;</span>}
+    const headerBannerStyle = {
+      backgroundImage: `url(${backgroundUrl})`
+    };
+
+    if (isSmallScreen) {
+      return (
+        <div>
+          <div id={'header-banner'} style={headerBannerStyle}>
+            <div
+              className={'bannerContentContainer'}
+              style={headerBannerContainerStyle}
+            >
+              <div className={'bannerContent'}>
+                <div style={headingStyle}>{headingText}</div>
+              </div>
+            </div>
+          </div>
+          <div id={'header-banner-overflow'}>
+            <div className={'bannerContent'}>
+              {subHeadingText && (
+                <div style={subHeadingStyle}>{subHeadingText}</div>
+              )}
+              {description && <div style={descriptionStyle}>{description}</div>}
+              {this.props.children && (
+                <div className={'children'}>{this.props.children}</div>
+              )}
+            </div>
+          </div>
         </div>
-        {description && <div style={descriptionStyle}>{description}</div>}
-        {this.props.children}
-      </div>
-    );
+      );
+    } else {
+      return (
+        <div id={'header-banner'} style={headerBannerStyle}>
+          <div
+            className={'bannerContentContainer'}
+            style={headerBannerContainerStyle}
+          >
+            <div className={'bannerContent'}>
+              <div style={headingStyle}>{headingText}</div>
+              {subHeadingText && (
+                <div style={subHeadingStyle}>{subHeadingText}</div>
+              )}
+              {description && <div style={descriptionStyle}>{description}</div>}
+              {this.props.children && (
+                <div className={'children'}>{this.props.children}</div>
+              )}
+            </div>
+          </div>
+        </div>
+      );
+    }
   }
 }
 

--- a/apps/src/templates/projects/ProjectHeader.jsx
+++ b/apps/src/templates/projects/ProjectHeader.jsx
@@ -16,6 +16,8 @@ export default class ProjectHeader extends React.Component {
   render() {
     const projectCountWithCommas = this.props.projectCount.toLocaleString();
 
+    // Verify background image works for both LTR and RTL languages.
+    const backgroundUrl = '/shared/images/banners/project-banner.jpg';
     return (
       <div>
         <HeaderBanner
@@ -24,16 +26,19 @@ export default class ProjectHeader extends React.Component {
           subHeadingText={i18n.projectsSubHeading({
             project_count: projectCountWithCommas
           })}
+          backgroundUrl={backgroundUrl}
         />
-        {this.props.specialAnnouncement && (
-          <SpecialAnnouncementActionBlock
-            announcement={this.props.specialAnnouncement}
+        <div className={'container main'}>
+          {this.props.specialAnnouncement && (
+            <SpecialAnnouncementActionBlock
+              announcement={this.props.specialAnnouncement}
+            />
+          )}
+          <StartNewProject
+            canViewFullList
+            canViewAdvancedTools={this.props.canViewAdvancedTools}
           />
-        )}
-        <StartNewProject
-          canViewFullList
-          canViewAdvancedTools={this.props.canViewAdvancedTools}
-        />
+        </div>
       </div>
     );
   }

--- a/apps/src/templates/studioHomepages/Courses.jsx
+++ b/apps/src/templates/studioHomepages/Courses.jsx
@@ -16,10 +16,7 @@ import shapes from './shapes';
 
 const styles = {
   content: {
-    width: '100%',
-    maxWidth: styleConstants['content-width'],
-    marginLeft: 'auto',
-    marginRight: 'auto'
+    maxWidth: styleConstants['content-width']
   }
 };
 
@@ -67,7 +64,6 @@ class Courses extends Component {
         ? i18n.coursesTeachHeroDescription()
         : i18n.coursesLearnHeroDescription();
     }
-
     return heroStrings;
   }
 
@@ -86,13 +82,20 @@ class Courses extends Component {
       description,
       buttonText
     } = this.getHeroStrings();
+
+    // Verify background image works for both LTR and RTL languages.
+    const backgroundUrl = isTeacher
+      ? '/shared/images/banners/courses-hero-teacher.jpg'
+      : '/shared/images/banners/courses-hero-student.jpg';
+
     return (
-      <div style={styles.content}>
+      <div>
         <HeaderBanner
           headingText={headingText}
           subHeadingText={subHeadingText}
           description={description}
           short={!isSignedOut}
+          backgroundUrl={backgroundUrl}
         >
           {isSignedOut && (
             <Button
@@ -103,36 +106,39 @@ class Courses extends Component {
             />
           )}
         </HeaderBanner>
+        <div className={'contentContainer'}>
+          <div className={'content'} style={styles.content}>
+            <ProtectedStatefulDiv ref="flashes" />
 
-        <ProtectedStatefulDiv ref="flashes" />
+            {/* English, teacher.  (Also can be shown when signed out.) */}
+            {isEnglish && isTeacher && (
+              <div className={'announcements'}>
+                {specialAnnouncement && (
+                  <SpecialAnnouncementActionBlock
+                    announcement={specialAnnouncement}
+                  />
+                )}
+                <CoursesTeacherEnglish />
+              </div>
+            )}
 
-        {/* English, teacher.  (Also can be shown when signed out.) */}
-        {isEnglish && isTeacher && (
-          <div>
-            {specialAnnouncement && (
-              <SpecialAnnouncementActionBlock
-                announcement={specialAnnouncement}
+            {/* English, student.  (Also the default to be shown when signed out.) */}
+            {isEnglish && !isTeacher && (
+              <div className={'announcements'}>
+                <SpecialAnnouncement isTeacher={isTeacher} />
+                <CoursesStudentEnglish />
+              </div>
+            )}
+
+            {/* Non-English */}
+            {!isEnglish && (
+              <CourseBlocksIntl
+                isTeacher={isTeacher}
+                showModernElementaryCourses={modernElementaryCoursesAvailable}
               />
             )}
-            <CoursesTeacherEnglish />
           </div>
-        )}
-
-        {/* English, student.  (Also the default to be shown when signed out.) */}
-        {isEnglish && !isTeacher && (
-          <div>
-            <SpecialAnnouncement isTeacher={isTeacher} />
-            <CoursesStudentEnglish />
-          </div>
-        )}
-
-        {/* Non-English */}
-        {!isEnglish && (
-          <CourseBlocksIntl
-            isTeacher={isTeacher}
-            showModernElementaryCourses={modernElementaryCoursesAvailable}
-          />
-        )}
+        </div>
       </div>
     );
   }

--- a/apps/src/templates/studioHomepages/StudentHomepage.jsx
+++ b/apps/src/templates/studioHomepages/StudentHomepage.jsx
@@ -33,24 +33,32 @@ export default class StudentHomepage extends Component {
   render() {
     const {courses, sections, topCourse, hasFeedback, isEnglish} = this.props;
     const {canViewAdvancedTools, studentId} = this.props;
+    // Verify background image works for both LTR and RTL languages.
+    const backgroundUrl = '/shared/images/banners/teacher-homepage-hero.jpg';
 
     return (
       <div>
-        <HeaderBanner headingText={i18n.homepageHeading()} short={true} />
-        <ProtectedStatefulDiv ref="flashes" />
-        {isEnglish && <SpecialAnnouncement isTeacher={false} />}
-        {hasFeedback && <StudentFeedbackNotification studentId={studentId} />}
-        <RecentCourses
-          courses={courses}
-          topCourse={topCourse}
-          isTeacher={false}
-          hasFeedback={hasFeedback}
+        <HeaderBanner
+          headingText={i18n.homepageHeading()}
+          short={true}
+          backgroundUrl={backgroundUrl}
         />
-        <ProjectWidgetWithData
-          canViewFullList={true}
-          canViewAdvancedTools={canViewAdvancedTools}
-        />
-        <StudentSections initialSections={sections} />
+        <div className={'container main'}>
+          <ProtectedStatefulDiv ref="flashes" />
+          {isEnglish && <SpecialAnnouncement isTeacher={false} />}
+          {hasFeedback && <StudentFeedbackNotification studentId={studentId} />}
+          <RecentCourses
+            courses={courses}
+            topCourse={topCourse}
+            isTeacher={false}
+            hasFeedback={hasFeedback}
+          />
+          <ProjectWidgetWithData
+            canViewFullList={true}
+            canViewAdvancedTools={canViewAdvancedTools}
+          />
+          <StudentSections initialSections={sections} />
+        </div>
       </div>
     );
   }

--- a/apps/src/templates/studioHomepages/TeacherHomepage.jsx
+++ b/apps/src/templates/studioHomepages/TeacherHomepage.jsx
@@ -177,77 +177,90 @@ export class UnconnectedTeacherHomepage extends Component {
 
     // Hide the regular announcement/notification for now.
     const showAnnouncement = false;
+    // Verify background image works for both LTR and RTL languages.
+    const backgroundUrl = '/shared/images/banners/teacher-homepage-hero.jpg';
 
     return (
       <div>
-        <HeaderBanner headingText={i18n.homepageHeading()} short={true} />
-        <ProtectedStatefulDiv ref="flashes" />
-        <ProtectedStatefulDiv ref="teacherReminders" />
-        {isEnglish && specialAnnouncement && (
-          <SpecialAnnouncementActionBlock announcement={specialAnnouncement} />
-        )}
-        {announcement && showAnnouncement && (
-          <div>
-            <Notification
-              type={announcement.type || 'bullhorn'}
-              notice={announcement.heading}
-              details={announcement.description}
-              dismissible={true}
-              buttonText={announcement.buttonText}
-              buttonLink={announcement.link}
-              newWindow={true}
-              analyticId={announcement.id}
-            />
-            <div style={styles.clear} />
-          </div>
-        )}
-        {this.state.showCensusBanner && (
-          <div>
-            <CensusTeacherBanner
-              ref={this.bindCensusBanner}
-              schoolYear={schoolYear}
-              ncesSchoolId={ncesSchoolId}
-              question={censusQuestion}
-              teaches={this.state.censusBannerTeachesSelection}
-              inClass={this.state.censusBannerInClassSelection}
-              teacherId={teacherId}
-              teacherName={teacherName}
-              teacherEmail={teacherEmail}
-              showInvalidError={this.state.showCensusInvalidError}
-              showUnknownError={this.state.showCensusUnknownError}
-              submittedSuccessfully={this.state.censusSubmittedSuccessfully}
-              onSubmit={() => this.handleCensusBannerSubmit()}
-              onDismiss={() => this.dismissAndHideCensusBanner()}
-              onPostpone={() => this.postponeCensusBanner()}
-              onTeachesChange={event =>
-                this.handleCensusBannerTeachesChange(event)
-              }
-              onInClassChange={event =>
-                this.handleCensusBannerInClassChange(event)
-              }
-            />
-            <br />
-          </div>
-        )}
-        {isEnglish && this.state.donorBannerName && (
-          <div>
-            <DonorTeacherBanner showPegasusLink={true} source="teacher_home" />
-            <div style={styles.clear} />
-          </div>
-        )}
-        <TeacherSections />
-        <RecentCourses
-          courses={courses}
-          topCourse={topCourse}
-          showAllCoursesLink={true}
-          isTeacher={true}
+        <HeaderBanner
+          headingText={i18n.homepageHeading()}
+          short={true}
+          backgroundUrl={backgroundUrl}
         />
-        <TeacherResources />
-        <ProjectWidgetWithData
-          canViewFullList={true}
-          canViewAdvancedTools={canViewAdvancedTools}
-        />
-        <StudentSections initialSections={joinedSections} isTeacher={true} />
+        <div className={'container main'}>
+          <ProtectedStatefulDiv ref="flashes" />
+          <ProtectedStatefulDiv ref="teacherReminders" />
+          {isEnglish && specialAnnouncement && (
+            <SpecialAnnouncementActionBlock
+              announcement={specialAnnouncement}
+            />
+          )}
+          {announcement && showAnnouncement && (
+            <div>
+              <Notification
+                type={announcement.type || 'bullhorn'}
+                notice={announcement.heading}
+                details={announcement.description}
+                dismissible={true}
+                buttonText={announcement.buttonText}
+                buttonLink={announcement.link}
+                newWindow={true}
+                analyticId={announcement.id}
+              />
+              <div style={styles.clear} />
+            </div>
+          )}
+          {this.state.showCensusBanner && (
+            <div>
+              <CensusTeacherBanner
+                ref={this.bindCensusBanner}
+                schoolYear={schoolYear}
+                ncesSchoolId={ncesSchoolId}
+                question={censusQuestion}
+                teaches={this.state.censusBannerTeachesSelection}
+                inClass={this.state.censusBannerInClassSelection}
+                teacherId={teacherId}
+                teacherName={teacherName}
+                teacherEmail={teacherEmail}
+                showInvalidError={this.state.showCensusInvalidError}
+                showUnknownError={this.state.showCensusUnknownError}
+                submittedSuccessfully={this.state.censusSubmittedSuccessfully}
+                onSubmit={() => this.handleCensusBannerSubmit()}
+                onDismiss={() => this.dismissAndHideCensusBanner()}
+                onPostpone={() => this.postponeCensusBanner()}
+                onTeachesChange={event =>
+                  this.handleCensusBannerTeachesChange(event)
+                }
+                onInClassChange={event =>
+                  this.handleCensusBannerInClassChange(event)
+                }
+              />
+              <br />
+            </div>
+          )}
+          {isEnglish && this.state.donorBannerName && (
+            <div>
+              <DonorTeacherBanner
+                showPegasusLink={true}
+                source="teacher_home"
+              />
+              <div style={styles.clear} />
+            </div>
+          )}
+          <TeacherSections />
+          <RecentCourses
+            courses={courses}
+            topCourse={topCourse}
+            showAllCoursesLink={true}
+            isTeacher={true}
+          />
+          <TeacherResources />
+          <ProjectWidgetWithData
+            canViewFullList={true}
+            canViewAdvancedTools={canViewAdvancedTools}
+          />
+          <StudentSections initialSections={joinedSections} isTeacher={true} />
+        </div>
       </div>
     );
   }

--- a/apps/test/unit/templates/HeaderBannerTest.js
+++ b/apps/test/unit/templates/HeaderBannerTest.js
@@ -7,6 +7,7 @@ import responsive, {
   setResponsiveSize,
   ResponsiveSize
 } from '@cdo/apps/code-studio/responsiveRedux';
+import styleConstants from '@cdo/apps/styleConstants';
 
 describe('HeaderBanner', () => {
   const store = createStore(combineReducers({responsive}));
@@ -17,10 +18,16 @@ describe('HeaderBanner', () => {
       context: {store}
     });
     expect(wrapper.dive()).to.containMatchingElement(
-      <div style={{height: 140, maxWidth: '60%', marginTop: 25}}>
-        <div>Home</div>
-        <div>
-          <span>&nbsp;</span>
+      <div>
+        <div
+          style={{
+            minHeight: 140,
+            maxWidth: styleConstants['content-width']
+          }}
+        >
+          <div>
+            <div>Home</div>
+          </div>
         </div>
       </div>
     );
@@ -36,9 +43,18 @@ describe('HeaderBanner', () => {
       {context: {store}}
     );
     expect(wrapper.dive()).to.containMatchingElement(
-      <div style={{height: 140, maxWidth: '60%', marginTop: 25}}>
-        <div>Home</div>
-        <div>This is where you can find useful information.</div>
+      <div>
+        <div
+          style={{
+            minHeight: 140,
+            maxWidth: styleConstants['content-width']
+          }}
+        >
+          <div>
+            <div>Home</div>
+            <div>This is where you can find useful information.</div>
+          </div>
+        </div>
       </div>
     );
   });
@@ -54,10 +70,21 @@ describe('HeaderBanner', () => {
       {context: {store}}
     );
     expect(wrapper.dive()).to.containMatchingElement(
-      <div style={{height: 260, maxWidth: '60%', marginTop: 25}}>
-        <div>Home</div>
-        <div>This is where you can find useful information.</div>
-        <div>Everything on the page is customized to you and easy to find.</div>
+      <div>
+        <div
+          style={{
+            minHeight: 260,
+            maxWidth: styleConstants['content-width']
+          }}
+        >
+          <div>
+            <div>Home</div>
+            <div>This is where you can find useful information.</div>
+            <div>
+              Everything on the page is customized to you and easy to find.
+            </div>
+          </div>
+        </div>
       </div>
     );
   });

--- a/apps/test/unit/templates/studioHomepages/StudentHomepageTest.js
+++ b/apps/test/unit/templates/studioHomepages/StudentHomepageTest.js
@@ -21,7 +21,8 @@ describe('StudentHomepage', () => {
     const headerBanner = wrapper.find(HeaderBanner);
     assert.deepEqual(headerBanner.props(), {
       headingText: 'My Dashboard',
-      short: true
+      short: true,
+      backgroundUrl: '/shared/images/banners/teacher-homepage-hero.jpg'
     });
   });
 

--- a/apps/test/unit/templates/studioHomepages/TeacherHomepageTest.js
+++ b/apps/test/unit/templates/studioHomepages/TeacherHomepageTest.js
@@ -35,7 +35,8 @@ describe('TeacherHomepage', () => {
     const headerBanner = wrapper.find('Connect(HeaderBanner)');
     assert.deepEqual(headerBanner.props(), {
       headingText: 'My Dashboard',
-      short: true
+      short: true,
+      backgroundUrl: '/shared/images/banners/teacher-homepage-hero.jpg'
     });
   });
 

--- a/dashboard/app/assets/stylesheets/application.scss
+++ b/dashboard/app/assets/stylesheets/application.scss
@@ -139,7 +139,7 @@ img.video_thumbnail {
 
 .header-wrapper {
   padding-top: 0;
-  min-height: 60px;
+  min-height: 50px;
   position: relative;
   user-select: none;
 
@@ -345,20 +345,69 @@ img.video_thumbnail {
 }
 
 #header-banner {
-  top: 0;
-  position: absolute;
-  width: 100%;
-  height: 320px;
-  z-index: -1000;
-  background-position: 90% 10%;
   background-size: cover;
+  background-position: 90% 30%;
+  display: flex;
+  justify-content: center;
 
-  &.header-banner-short {
-    height: 180px;
+  .bannerContent {
+    max-width: 60%;
   }
 
-  &.header-banner-courses {
-    background-position: 75% 10%;
+  /*
+    The banner background image leaves an open space for text on the left. Therefore, in Right-to-Left languages, the
+    banner needs to be flipped horizontally so the background image empty space is on the right.
+   */
+  html[dir=rtl] & {
+    transform: scaleX(-1);
+    /*
+      Since the whole banner was flipped horizontally, we need to un-flip all the content in the header. So the text and
+      layout is not backwards
+     */
+    .bannerContentContainer {
+      transform: scaleX(-1);
+    }
+  }
+
+  #projects-page & {
+    margin-bottom: 16px;
+  }
+}
+
+#header-banner-overflow {
+  margin: 16px;
+}
+
+#header-banner, #header-banner-overflow {
+  .children {
+    margin-top: 16px;
+  }
+}
+
+.bannerContentContainer {
+  display: flex;
+  align-items: center;
+  width: 100%;
+  margin: 16px;
+}
+#courses-container {
+  #header-banner {
+    background-position: 75% 40%;
+  }
+
+  .announcements {
+    margin-top: 16px;
+  }
+
+  .contentContainer {
+    display: flex;
+    justify-content: center;
+    margin-top: 16px;
+
+    .content {
+      width: 100%;
+      margin: 0 16px;
+    }
   }
 }
 
@@ -716,19 +765,15 @@ $small-footer-standard-width: 400px;
   line-height: 1.6em;
 }
 
-.full_container {
-  padding: 0 25px 25px 25px;
+.full_container, .responsive_full_container {
+  padding: 0;
 }
+
 body.embedded_iframe {
   .full_container {
     padding-left: 0;
   }
 }
-
-.responsive_full_container {
-  padding: 0 10px 10px 10px;
-}
-
 
 $default-modal-width: 640px;
 

--- a/dashboard/app/controllers/courses_controller.rb
+++ b/dashboard/app/controllers/courses_controller.rb
@@ -14,7 +14,6 @@ class CoursesController < ApplicationController
         @is_english = request.language == 'en'
         @is_signed_out = current_user.nil?
         @force_race_interstitial = params[:forceRaceInterstitial]
-        @header_banner_image_filename = !@is_teacher ? "courses-hero-student" : "courses-hero-teacher"
         @modern_elementary_courses_available = Script.modern_elementary_courses_available?(request.locale)
       end
       format.json do

--- a/dashboard/app/controllers/home_controller.rb
+++ b/dashboard/app/controllers/home_controller.rb
@@ -92,6 +92,8 @@ class HomeController < ApplicationController
   def init_homepage
     raise 'init_homepage can only be called when there is a current_user' unless current_user
 
+    view_options(full_width: true, responsive_content: false, has_i18n: true)
+
     @homepage_data = {}
     @homepage_data[:valid_grades] = Section.valid_grades
     @homepage_data[:lessonExtrasScriptIds] = Script.lesson_extras_script_ids

--- a/dashboard/app/controllers/projects_controller.rb
+++ b/dashboard/app/controllers/projects_controller.rb
@@ -151,6 +151,7 @@ class ProjectsController < ApplicationController
       return redirect_to '/', flash: {alert: 'Labs not allowed for admins.'} if current_user.admin
     end
 
+    view_options(full_width: true, responsive_content: false, has_i18n: true)
     @limited_gallery = limited_gallery?
     @current_tab = params[:tab_name]
   end

--- a/dashboard/app/views/layouts/_header.html.haml
+++ b/dashboard/app/views/layouts/_header.html.haml
@@ -93,14 +93,6 @@
         = render file: Rails.root.join('..', 'shared', 'haml', 'hamburger.haml'), locals: hamburger_options
   }
 
-- if request.path == "/home"
-  #header-banner{class: "header-banner-short", style: 'background-image: url("/shared/images/banners/teacher-homepage-hero.jpg")'}
-- elsif request.path == "/courses"
-  #header-banner.header-banner-courses{class: user_type ? "header-banner-short" : "", style: "background-image: url(\"/shared/images/banners/#{@header_banner_image_filename}.jpg\")"}
-
-- if ["/projects", "/projects/public", "/projects/libraries"].include? request.path
-  #header-banner.header-banner-short{style: 'background-image: url("/shared/images/banners/project-banner.jpg")'}
-
 :ruby
   if should_show_progress
     view_as = @user || current_user

--- a/dashboard/test/controllers/projects_controller_test.rb
+++ b/dashboard/test/controllers/projects_controller_test.rb
@@ -27,10 +27,14 @@ class ProjectsControllerTest < ActionController::TestCase
   test "index" do
     get :index
     assert_response :success
+  end
 
+  test "index/libraries" do
     get :index, params: {tab_name: 'libraries'}
     assert_response :success
+  end
 
+  test "index/public" do
     get :index, params: {tab_name: 'public'}
     assert_response :success
   end

--- a/dashboard/test/ui/features/learning_platform/level_navigation.feature
+++ b/dashboard/test/ui/features/learning_platform/level_navigation.feature
@@ -1,6 +1,7 @@
 Feature: Continue button on levels
 
 Scenario: External Video Level
+  Given I am a teacher
   Given I am on "http://studio.code.org/s/coursec-2019/stage/14/puzzle/1"
   And I wait to see ".video-download"
   And I wait to see ".submitButton"


### PR DESCRIPTION
- **Bug** - On the `/courses` page, for some languages, the content of the banner at the top of the screen overflows outside the banner box.
- **Cause** - The banner background is statically floating behind the content of the banner. It is not affected by the content of the banner at all and relies on a static `height` attribute.
- **Fix** - Remove the static & floating background div and instead have the `background-image` set directly on the banner content `div`.
### Changes
* Put all banner rendering into `HeaderBanner.jsx`
* Update margins and spacing to be more consistent.
* Fix the mobile experience for the banner.
* Fix the RTL experience by mirroring the banner background image.

## Links
- [jira](https://codedotorg.atlassian.net/browse/FND-1221)

## Testing story
### Adhoc
Try the following links as both students and teachers. Also, try increasing/decreasing your window width to simulate a mobile device experience. Also try a RTL language such as Arabic (append `/lang/ar-sa` to any of the URLs)
* [/courses](https://adhoc-fnd-1221-courses-banner-dynamic-size-studio.cdn-code.org/courses)
* [/home](https://adhoc-fnd-1221-courses-banner-dynamic-size-studio.cdn-code.org/home)
* [/projects](https://adhoc-fnd-1221-courses-banner-dynamic-size-studio.cdn-code.org/projects)
* [/public](https://adhoc-fnd-1221-courses-banner-dynamic-size-studio.cdn-code.org/projects/public)
* [/projects/libraries](https://adhoc-fnd-1221-courses-banner-dynamic-size-studio.cdn-code.org/projects/libraries)

## Screenshots
### Before
Note that the button is halfway below the banner background
![image](https://user-images.githubusercontent.com/1372238/88322946-fb72d880-cd10-11ea-868e-ca0e1dad1817.png)

### After
![image](https://user-images.githubusercontent.com/1372238/88322995-0e85a880-cd11-11ea-95e2-d3e28c568a51.png)

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
