### PR TITLE
Seeding for CourseVersions for .script files

### DIFF
--- a/dashboard/app/dsl/script_dsl.rb
+++ b/dashboard/app/dsl/script_dsl.rb
@@ -334,7 +334,7 @@ class ScriptDSL < BaseDSL
     s << 'project_sharing true' if script.project_sharing
     s << "curriculum_umbrella '#{script.curriculum_umbrella}'" if script.curriculum_umbrella
     s << 'tts true' if script.tts
-    s << 'course true' if script.is_course
+    s << 'is_course true' if script.is_course
 
     s << '' unless s.empty?
     s << serialize_lesson_groups(script)

--- a/dashboard/app/dsl/script_dsl.rb
+++ b/dashboard/app/dsl/script_dsl.rb
@@ -30,6 +30,7 @@ class ScriptDSL < BaseDSL
     @project_sharing = nil
     @curriculum_umbrella = nil
     @tts = false
+    @is_course = false
   end
 
   integer :id
@@ -47,6 +48,7 @@ class ScriptDSL < BaseDSL
   boolean :is_stable
   boolean :project_sharing
   boolean :tts
+  boolean :is_course
 
   string :wrapup_video
   string :script_announcements
@@ -148,7 +150,8 @@ class ScriptDSL < BaseDSL
       project_sharing: @project_sharing,
       curriculum_umbrella: @curriculum_umbrella,
       tts: @tts,
-      lesson_groups: @lesson_groups
+      lesson_groups: @lesson_groups,
+      is_course: @is_course
     }
   end
 
@@ -331,6 +334,7 @@ class ScriptDSL < BaseDSL
     s << 'project_sharing true' if script.project_sharing
     s << "curriculum_umbrella '#{script.curriculum_umbrella}'" if script.curriculum_umbrella
     s << 'tts true' if script.tts
+    s << 'course true' if script.is_course
 
     s << '' unless s.empty?
     s << serialize_lesson_groups(script)

--- a/dashboard/app/models/course_version.rb
+++ b/dashboard/app/models/course_version.rb
@@ -24,6 +24,9 @@ class CourseVersion < ApplicationRecord
     # unique index will be on (course_id, key).
     key = "#{content_root.family_name}-#{content_root.version_year}"
 
+    # If content_root is not designated as the content root of a CourseVersion (in its .script or .course file),
+    # delete its associated CourseVersion object if it exists. This handles the case where a .script or .course file
+    # had "is_course true" at one point, and then later "is_course true" is removed.
     unless content_root.is_course?
       CourseVersion.find_by(key: key)&.destroy
       content_root.course_version = nil

--- a/dashboard/app/models/course_version.rb
+++ b/dashboard/app/models/course_version.rb
@@ -19,7 +19,18 @@
 class CourseVersion < ApplicationRecord
   belongs_to :content_root, polymorphic: true
 
-  def self.update_course_version(content_root)
+  # Seeding method for creating / updating / deleting the CourseVersion for the given
+  # potential content root, i.e. a Script or UnitGroup.
+  #
+  # Examples:
+  #
+  # coursea-2019.script represents the content root for Course A, Version 2019.
+  # Therefore, it should contain "is_course true", which will cause this method to create the
+  # corresponding CourseVersion object.
+  #
+  # csp1-2019.script does not represent a content root (the root for CSP, Version 2019 is a UnitGroup).
+  # Therefore, it does not contain "is_course true". so this method will not create a CourseVersion object for it.
+  def self.add_course_version(content_root)
     # TODO: Once the Course model is added, change this to just be version_year, since then the
     # unique index will be on (course_id, key).
     key = "#{content_root.family_name}-#{content_root.version_year}"

--- a/dashboard/app/models/course_version.rb
+++ b/dashboard/app/models/course_version.rb
@@ -17,6 +17,11 @@
 #
 
 class CourseVersion < ApplicationRecord
+  # "Interface" for content_root:
+  #
+  # is_course? - used during seeding to determine whether this object represents the content root for a CourseVersion.
+  #   For example, this should return True for the CourseA-2019 Unit and the CSP-2019 UnitGroup. This should return
+  #   False for the CSP1-2019 Unit.
   belongs_to :content_root, polymorphic: true
 
   # Seeding method for creating / updating / deleting the CourseVersion for the given

--- a/dashboard/app/models/course_version.rb
+++ b/dashboard/app/models/course_version.rb
@@ -42,8 +42,8 @@ class CourseVersion < ApplicationRecord
       return nil
     end
 
-    raise "family_name must be set, since is_course is true, for: #{content_root.name}" if family_name.nil_or_empty?
-    raise "version_year must be set, since is_course is true, for: #{content_root.name}" if version_year.nil_or_empty?
+    raise "family_name must be set, since is_course is true, for: #{content_root.name}" if content_root.family_name.nil_or_empty?
+    raise "version_year must be set, since is_course is true, for: #{content_root.name}" if content_root.version_year.nil_or_empty?
 
     # TODO: Once the Course model is added, change this to just be version_year, since then the
     # unique index will be on (course_id, key).

--- a/dashboard/app/models/course_version.rb
+++ b/dashboard/app/models/course_version.rb
@@ -31,10 +31,6 @@ class CourseVersion < ApplicationRecord
   # csp1-2019.script does not represent a content root (the root for CSP, Version 2019 is a UnitGroup).
   # Therefore, it does not contain "is_course true". so this method will not create a CourseVersion object for it.
   def self.add_course_version(content_root)
-    # TODO: Once the Course model is added, change this to just be version_year, since then the
-    # unique index will be on (course_id, key).
-    key = "#{content_root.family_name}-#{content_root.version_year}"
-
     # If content_root is not designated as the content root of a CourseVersion (in its .script or .course file),
     # delete its associated CourseVersion object if it exists. This handles the case where a .script or .course file
     # had "is_course true" at one point, and then later "is_course true" is removed.
@@ -45,6 +41,13 @@ class CourseVersion < ApplicationRecord
       end
       return nil
     end
+
+    raise "family_name must be set, since is_course is true, for: #{content_root.name}" if family_name.nil_or_empty?
+    raise "version_year must be set, since is_course is true, for: #{content_root.name}" if version_year.nil_or_empty?
+
+    # TODO: Once the Course model is added, change this to just be version_year, since then the
+    # unique index will be on (course_id, key).
+    key = "#{content_root.family_name}-#{content_root.version_year}"
 
     course_version = CourseVersion.find_or_create_by(
       key: key,

--- a/dashboard/app/models/course_version.rb
+++ b/dashboard/app/models/course_version.rb
@@ -39,9 +39,10 @@ class CourseVersion < ApplicationRecord
     # delete its associated CourseVersion object if it exists. This handles the case where a .script or .course file
     # had "is_course true" at one point, and then later "is_course true" is removed.
     unless content_root.is_course?
-      CourseVersion.find_by(key: key)&.destroy
-      content_root.course_version = nil
-      content_root.save
+      if content_root.course_version
+        content_root.course_version.destroy
+        content_root.reload
+      end
       return nil
     end
 

--- a/dashboard/app/models/course_version.rb
+++ b/dashboard/app/models/course_version.rb
@@ -18,4 +18,23 @@
 
 class CourseVersion < ApplicationRecord
   belongs_to :content_root, polymorphic: true
+
+  def self.update_course_version(content_root)
+    # TODO: should we delete the existing CourseVersion and Course if is_course is removed from a script?
+    return nil unless content_root.is_course?
+
+    # TODO: Once the Course model is added, change this to just be version_year, since then the
+    # unique index will be on (course_id, key).
+    key = "#{content_root.family_name}-#{content_root.version_year}"
+
+    course_version = CourseVersion.find_or_create_by(
+      key: key,
+      display_name: content_root.version_year,
+      content_root: content_root,
+    )
+
+    # TODO: add relevant properties from content root to course_version
+
+    course_version
+  end
 end

--- a/dashboard/app/models/course_version.rb
+++ b/dashboard/app/models/course_version.rb
@@ -20,18 +20,25 @@ class CourseVersion < ApplicationRecord
   belongs_to :content_root, polymorphic: true
 
   def self.update_course_version(content_root)
-    # TODO: should we delete the existing CourseVersion and Course if is_course is removed from a script?
-    return nil unless content_root.is_course?
-
     # TODO: Once the Course model is added, change this to just be version_year, since then the
     # unique index will be on (course_id, key).
     key = "#{content_root.family_name}-#{content_root.version_year}"
+
+    unless content_root.is_course?
+      CourseVersion.find_by(key: key)&.destroy
+      content_root.course_version = nil
+      content_root.save
+      return nil
+    end
 
     course_version = CourseVersion.find_or_create_by(
       key: key,
       display_name: content_root.version_year,
       content_root: content_root,
     )
+
+    content_root.course_version.destroy if course_version != content_root.course_version
+    content_root.course_version = course_version
 
     # TODO: add relevant properties from content root to course_version
 

--- a/dashboard/app/models/course_version.rb
+++ b/dashboard/app/models/course_version.rb
@@ -37,6 +37,7 @@ class CourseVersion < ApplicationRecord
       content_root: content_root,
     )
 
+    # Delete old CourseVersion if the key has been changed to something else
     content_root.course_version.destroy if course_version != content_root.course_version
     content_root.course_version = course_version
 

--- a/dashboard/app/models/script.rb
+++ b/dashboard/app/models/script.rb
@@ -942,7 +942,7 @@ class Script < ActiveRecord::Base
 
     script.generate_plc_objects
 
-    CourseVersion.update_course_version(script)
+    CourseVersion.add_course_version(script)
 
     script
   end

--- a/dashboard/app/models/script.rb
+++ b/dashboard/app/models/script.rb
@@ -920,7 +920,7 @@ class Script < ActiveRecord::Base
       added_scripts = scripts_to_add.sort_by.with_index {|args, idx| [args[0][:id] || Float::INFINITY, idx]}.map do |options, raw_lesson_groups|
         add_script(options, raw_lesson_groups, new_suffix: new_suffix, editor_experiment: new_properties[:editor_experiment])
       rescue => e
-        raise e, "Error adding script named '#{options[:name]}': #{e}"
+        raise e, "Error adding script named '#{options[:name]}': #{e}", e.backtrace
       end
       [added_scripts, custom_i18n]
     end

--- a/dashboard/app/models/script.rb
+++ b/dashboard/app/models/script.rb
@@ -942,6 +942,8 @@ class Script < ActiveRecord::Base
 
     script.generate_plc_objects
 
+    CourseVersion.update_course_version(script)
+
     script
   end
 

--- a/dashboard/app/models/script.rb
+++ b/dashboard/app/models/script.rb
@@ -144,6 +144,7 @@ class Script < ActiveRecord::Base
     project_sharing
     curriculum_umbrella
     tts
+    is_course
   )
 
   def self.twenty_hour_script
@@ -1396,7 +1397,8 @@ class Script < ActiveRecord::Base
       :has_lesson_plan,
       :is_stable,
       :project_sharing,
-      :tts
+      :tts,
+      :is_course
     ]
     not_defaulted_keys = [
       :teacher_resources, # teacher_resources gets updated from the script edit UI through its own code path

--- a/dashboard/config/scripts/valentine.script
+++ b/dashboard/config/scripts/valentine.script
@@ -1,3 +1,6 @@
+version_year 2019
+is_course true
+
 lesson 'Valentine Puzzles'
 level 'Valentine_playlab_01'
 level 'Valentine_artist_01'

--- a/dashboard/config/scripts/valentine.script
+++ b/dashboard/config/scripts/valentine.script
@@ -1,6 +1,3 @@
-version_year 2019
-is_course true
-
 lesson 'Valentine Puzzles'
 level 'Valentine_playlab_01'
 level 'Valentine_artist_01'

--- a/dashboard/test/dsl/script_dsl_test.rb
+++ b/dashboard/test/dsl/script_dsl_test.rb
@@ -34,7 +34,8 @@ class ScriptDslTest < ActiveSupport::TestCase
     editor_experiment: nil,
     project_sharing: nil,
     curriculum_umbrella: nil,
-    tts: false
+    tts: false,
+    is_course: false
   }
 
   test 'test Script DSL' do
@@ -755,13 +756,15 @@ level 'Level 3'
     assert_equal expected, output
   end
 
-  test 'serialize new_name, family_name, version_year and is_stable' do
+  test 'serialize new_name, family_name, version_year, is_stable, tts, and is_course' do
     script = create :script,
       {
         new_name: 'new name',
         family_name: 'family name',
         version_year: '2001',
-        is_stable: true
+        is_stable: true,
+        tts: true,
+        is_course: true
       }
     script_text = ScriptDSL.serialize_to_string(script)
     expected = <<~SCRIPT
@@ -770,6 +773,8 @@ level 'Level 3'
       family_name 'family name'
       version_year '2001'
       is_stable true
+      tts true
+      is_course true
 
     SCRIPT
     assert_equal expected, script_text

--- a/dashboard/test/fixtures/test-all-properties.script
+++ b/dashboard/test/fixtures/test-all-properties.script
@@ -1,3 +1,5 @@
+family_name 'csd1'
+
 hideable_lessons true
 project_widget_visible true
 student_detail_progress_view true

--- a/dashboard/test/fixtures/test-all-properties.script
+++ b/dashboard/test/fixtures/test-all-properties.script
@@ -7,6 +7,7 @@ has_lesson_plan true
 is_stable true
 tts true
 project_sharing true
+is_course true
 
 peer_reviews_to_complete 1
 curriculum_path 'fake_curriculum_path'

--- a/dashboard/test/fixtures/test-script-course-version.script
+++ b/dashboard/test/fixtures/test-script-course-version.script
@@ -1,0 +1,3 @@
+family_name 'xyz'
+version_year '1234'
+is_course true

--- a/dashboard/test/models/course_version_test.rb
+++ b/dashboard/test/models/course_version_test.rb
@@ -26,14 +26,14 @@ class CourseVersionTest < ActiveSupport::TestCase
 
   test "update_course_version creates CourseVersion for script that doesn't have one if is_course is true" do
     script = create :script, family_name: 'csz', version_year: '2050', is_course: true
-    course_version = CourseVersion.update_course_version(script)
+    course_version = CourseVersion.add_course_version(script)
 
     assert_equal course_version, CourseVersion.find_by(key: 'csz-2050')
   end
 
   test "update_course_version updates existing CourseVersion for script if properties change" do
     script = create :script, family_name: 'csz', version_year: '2050', is_course: true
-    CourseVersion.update_course_version(script)
+    CourseVersion.add_course_version(script)
 
     assert_equal 'csz-2050', script.course_version.key
     assert_equal '2050', script.course_version.display_name
@@ -42,7 +42,7 @@ class CourseVersionTest < ActiveSupport::TestCase
     script.version_year = '2060'
     script.save
 
-    CourseVersion.update_course_version(script)
+    CourseVersion.add_course_version(script)
 
     assert_equal 'csx-2060', script.course_version.key
     assert_equal '2060', script.course_version.display_name
@@ -52,13 +52,13 @@ class CourseVersionTest < ActiveSupport::TestCase
 
   test "update_course_version deletes CourseVersion for script if is_course is changed to false" do
     script = create :script, family_name: 'csz', version_year: '2050', is_course: true
-    CourseVersion.update_course_version(script)
+    CourseVersion.add_course_version(script)
 
     assert_not_nil script.course_version
 
     script.is_course = false
     script.save
-    course_version = CourseVersion.update_course_version(script)
+    course_version = CourseVersion.add_course_version(script)
 
     assert_nil course_version
     assert_nil script.course_version
@@ -67,7 +67,7 @@ class CourseVersionTest < ActiveSupport::TestCase
 
   test "update_course_version does nothing for script without CourseVersion if is_course is false" do
     script = create :script, family_name: 'csz', version_year: '2050'
-    course_version = CourseVersion.update_course_version(script)
+    course_version = CourseVersion.add_course_version(script)
 
     assert_nil course_version
     assert_nil script.course_version

--- a/dashboard/test/models/course_version_test.rb
+++ b/dashboard/test/models/course_version_test.rb
@@ -12,7 +12,7 @@ class CourseVersionTest < ActiveSupport::TestCase
   end
 
   # One "integration test" of seeding from DSL creating a CourseVersion for a Script with is_course true.
-  # Other cases are covered by directly testing update_course_version below.
+  # Other cases are covered by directly testing add_course_version below.
   test "Script.setup creates CourseVersion if is_course is true" do
     script_file = File.join(self.class.fixture_path, 'test-script-course-version.script')
     scripts, _ = Script.setup([script_file])
@@ -24,14 +24,14 @@ class CourseVersionTest < ActiveSupport::TestCase
     assert_equal '1234', course_version.display_name
   end
 
-  test "update_course_version creates CourseVersion for script that doesn't have one if is_course is true" do
+  test "add_course_version creates CourseVersion for script that doesn't have one if is_course is true" do
     script = create :script, family_name: 'csz', version_year: '2050', is_course: true
     course_version = CourseVersion.add_course_version(script)
 
     assert_equal course_version, CourseVersion.find_by(key: 'csz-2050')
   end
 
-  test "update_course_version updates existing CourseVersion for script if properties change" do
+  test "add_course_version updates existing CourseVersion for script if properties change" do
     script = create :script, family_name: 'csz', version_year: '2050', is_course: true
     CourseVersion.add_course_version(script)
 
@@ -50,7 +50,7 @@ class CourseVersionTest < ActiveSupport::TestCase
     assert_nil CourseVersion.find_by(key: 'csz-2050') # old CourseVersion should be deleted
   end
 
-  test "update_course_version deletes CourseVersion for script if is_course is changed to false" do
+  test "add_course_version deletes CourseVersion for script if is_course is changed to false" do
     script = create :script, family_name: 'csz', version_year: '2050', is_course: true
     CourseVersion.add_course_version(script)
 
@@ -65,7 +65,7 @@ class CourseVersionTest < ActiveSupport::TestCase
     assert_nil CourseVersion.find_by(key: 'csz-2050')
   end
 
-  test "update_course_version does nothing for script without CourseVersion if is_course is false" do
+  test "add_course_version does nothing for script without CourseVersion if is_course is false" do
     script = create :script, family_name: 'csz', version_year: '2050'
     course_version = CourseVersion.add_course_version(script)
 

--- a/dashboard/test/models/course_version_test.rb
+++ b/dashboard/test/models/course_version_test.rb
@@ -10,4 +10,58 @@ class CourseVersionTest < ActiveSupport::TestCase
     assert_instance_of Script, course_version.content_root
     assert_equal course_version, course_version.content_root.course_version
   end
+
+  test "update_course_version creates CourseVersion for script that doesn't have one if is_course is true" do
+    # Case: "is_course true" added to a .script file
+    script = create :script, family_name: 'csz', version_year: '2050', is_course: true
+    course_version = CourseVersion.update_course_version(script)
+
+    assert_equal course_version, script.course_version
+    assert_equal course_version, CourseVersion.find_by(key: 'csz-2050')
+    assert_equal 'csz-2050', course_version.key
+    assert_equal '2050', course_version.display_name
+  end
+
+  test "update_course_version updates existing CourseVersion for script if properties change" do
+    script = create :script, family_name: 'csz', version_year: '2050', is_course: true
+    CourseVersion.update_course_version(script)
+
+    assert_equal 'csz-2050', script.course_version.key
+    assert_equal '2050', script.course_version.display_name
+
+    script.family_name = 'csx'
+    script.version_year = '2060'
+    script.save
+
+    CourseVersion.update_course_version(script)
+
+    assert_equal 'csx-2060', script.course_version.key
+    assert_equal '2060', script.course_version.display_name
+    assert_equal script.course_version, CourseVersion.find_by(key: 'csx-2060')
+    assert_nil CourseVersion.find_by(key: 'csz-2050') # old CourseVersion should be deleted
+  end
+
+  test "update_course_version deletes CourseVersion for script if is_course is changed to false" do
+    script = create :script, family_name: 'csz', version_year: '2050', is_course: true
+    CourseVersion.update_course_version(script)
+
+    assert_not_nil script.course_version
+
+    script.is_course = false
+    script.save
+    course_version = CourseVersion.update_course_version(script)
+
+    assert_nil course_version
+    assert_nil script.course_version
+    assert_nil CourseVersion.find_by(key: 'csz-2050')
+  end
+
+  test "update_course_version does nothing for script without CourseVersion if is_course is false" do
+    script = create :script, family_name: 'csz', version_year: '2050'
+    course_version = CourseVersion.update_course_version(script)
+
+    assert_nil course_version
+    assert_nil script.course_version
+    assert_nil CourseVersion.find_by(key: 'csz-2050')
+  end
 end

--- a/dashboard/test/models/course_version_test.rb
+++ b/dashboard/test/models/course_version_test.rb
@@ -11,15 +11,24 @@ class CourseVersionTest < ActiveSupport::TestCase
     assert_equal course_version, course_version.content_root.course_version
   end
 
+  # One "integration test" of seeding from DSL creating a CourseVersion for a Script with is_course true.
+  # Other cases are covered by directly testing update_course_version below.
+  test "Script.setup creates CourseVersion if is_course is true" do
+    script_file = File.join(self.class.fixture_path, 'test-script-course-version.script')
+    scripts, _ = Script.setup([script_file])
+    script = scripts.first
+
+    course_version = CourseVersion.find_by(key: 'xyz-1234')
+    assert_equal course_version, script.course_version
+    assert_equal 'xyz-1234', course_version.key
+    assert_equal '1234', course_version.display_name
+  end
+
   test "update_course_version creates CourseVersion for script that doesn't have one if is_course is true" do
-    # Case: "is_course true" added to a .script file
     script = create :script, family_name: 'csz', version_year: '2050', is_course: true
     course_version = CourseVersion.update_course_version(script)
 
-    assert_equal course_version, script.course_version
     assert_equal course_version, CourseVersion.find_by(key: 'csz-2050')
-    assert_equal 'csz-2050', course_version.key
-    assert_equal '2050', course_version.display_name
   end
 
   test "update_course_version updates existing CourseVersion for script if properties change" do

--- a/dashboard/test/models/script_test.rb
+++ b/dashboard/test/models/script_test.rb
@@ -222,7 +222,7 @@ class ScriptTest < ActiveSupport::TestCase
     scripts, _ = Script.setup([script_file_all_properties])
     script = scripts.first
 
-    assert_equal 20, script.properties.keys.length
+    assert_equal 21, script.properties.keys.length
     script.properties.values.each {|v| assert v}
 
     # Seed using an empty .script file with the same name. Verify that this sets all properties values back to defaults.


### PR DESCRIPTION
Create, update, and delete CourseVersions during seeding process, based on the presence of `is_course true` in the .script file. Does not handle .course files yet, but it should work similarly for them.

## Future work

- Change the key format, for example, from `csp-2020` to just `2020`, once the new Course model is added.
- Seeding for CourseVersions for .course files
- Add other properties to the CourseVersion object during seeding as appropriate

## Testing story

- added unit tests

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
