### PR TITLE
Add CloudWatch Alarm to detect no outbound emails being sent.

### DIFF
--- a/aws/cloudformation/components/alarms.yml.erb
+++ b/aws/cloudformation/components/alarms.yml.erb
@@ -55,6 +55,6 @@
       EvaluationPeriods: 4
       Statistic: Sum
       Threshold: 1
-      TreatMissingData: missing
+      TreatMissingData: breaching
 <%  end -%>
 

--- a/aws/cloudformation/components/alarms.yml.erb
+++ b/aws/cloudformation/components/alarms.yml.erb
@@ -38,3 +38,23 @@
       Statistic: Maximum
       Threshold: 87
       TreatMissingData: missing
+<%  if environment == :production -%>
+  # Detect problems with the bin/cron/deliver_poste_messages scheduled job by monitoring outbound emails sent by AWS SES.
+  OutboundEmailAlarm:
+    Type: "AWS::CloudWatch::Alarm"
+    Properties:
+      AlarmActions:
+        - "arn:aws:sns:${AWS::Region}:${AWS::AccountId}:CDO-Urgent"
+      AlarmDescription: Send page if number of outbound transactional emails sent drops below threshold.
+      AlarmName: <%="#{stack_name}_no_outbound_emails_sent" %>
+      ComparisonOperator: Lower
+            MetricName: Send
+      Namespace: 'AWS/SES'
+      # No outbound transactional emails (password reset, new account welcome, etc.) sent per hour for 4 consecutive hours.
+      Period: 3600
+      EvaluationPeriods: 4
+      Statistic: Sum
+      Threshold: 1
+      TreatMissingData: missing
+<%  end -%>
+


### PR DESCRIPTION
Add a CloudWatch Alarm that detects an outage with our outbound, transactional email system.
https://codedotorg.atlassian.net/browse/INF-355

### Background

Cause of Event - [Outbound Transactional Emails Stopped Working July 17-20, 2020](https://docs.google.com/document/d/1chetH4oP98HUroTXtxS8pDv8X4vczq_h2ffT_3xOiYg/edit#heading=h.m9yszarvxp3i)

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
