### PR TITLE
Misc Survey: Allow multiple submissions for facilitator post survey

### DIFF
--- a/dashboard/app/models/pd/misc_survey.rb
+++ b/dashboard/app/models/pd/misc_survey.rb
@@ -39,7 +39,7 @@ module Pd
         {tag: "virt_ay_m1_1920",    form_id: "92175136628158", allow_embed: false}, # 2019-20 Virtual Academic Year Survey Module 1
         {tag: "612_f_ay_post",      form_id: "91564407894165", allow_multiple_submissions: true, allow_embed: false}, # 6-12 Facilitator Academic Year post-workshop survey
         {tag: "summer_prep_post",   form_id: "201285758257160", allow_embed: true}, # Summer Prep Sessions Post Survey
-        {tag: "facilitator_post",   form_id: "201595646393161", allow_embed: true}
+        {tag: "facilitator_post",   form_id: "201595646393161", allow_multiple_submissions: true, allow_embed: true}
       ]
     end
 


### PR DESCRIPTION
The facilitator post survey is implemented as a Jotform misc survey. Add the flag allow_multiple_submissions so facilitators can fill out the survey after each of their workshops.
<!-- ### Background -->
<!-- ### Privacy -->
<!-- ### Security -->
<!-- ### Caching -->
<!-- ### Deployment strategy -->
<!-- ### Future wo

## Testing story
Validated that one account can now fill out the survey multiple times.

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
