### PR TITLE
Improve paginated loading in Animation Tab

### DIFF
--- a/apps/src/p5lab/AnimationPicker/AnimationPicker.jsx
+++ b/apps/src/p5lab/AnimationPicker/AnimationPicker.jsx
@@ -39,7 +39,7 @@ class AnimationPicker extends React.Component {
     // Provided externally
     channelId: PropTypes.string.isRequired,
     allowedExtensions: PropTypes.string,
-    getLibraryManifest: PropTypes.func.isRequired,
+    libraryManifest: PropTypes.object.isRequired,
     hideUploadOption: PropTypes.bool.isRequired,
     hideAnimationNames: PropTypes.bool.isRequired,
 
@@ -74,7 +74,7 @@ class AnimationPicker extends React.Component {
         onPickLibraryAnimation={this.props.onPickLibraryAnimation}
         onUploadClick={this.onUploadClick}
         playAnimations={this.props.playAnimations}
-        getLibraryManifest={this.props.getLibraryManifest}
+        libraryManifest={this.props.libraryManifest}
         hideUploadOption={this.props.hideUploadOption}
         hideAnimationNames={this.props.hideAnimationNames}
       />

--- a/apps/src/p5lab/AnimationPicker/AnimationPickerBody.jsx
+++ b/apps/src/p5lab/AnimationPicker/AnimationPickerBody.jsx
@@ -44,7 +44,7 @@ export default class AnimationPickerBody extends React.Component {
     onPickLibraryAnimation: PropTypes.func.isRequired,
     onUploadClick: PropTypes.func.isRequired,
     playAnimations: PropTypes.bool.isRequired,
-    getLibraryManifest: PropTypes.func.isRequired,
+    libraryManifest: PropTypes.object.isRequired,
     hideUploadOption: PropTypes.bool.isRequired,
     hideAnimationNames: PropTypes.bool.isRequired
   };
@@ -66,7 +66,7 @@ export default class AnimationPickerBody extends React.Component {
       categoryQuery = this.state.categoryQuery;
     }
     if (libraryManifest === undefined) {
-      libraryManifest = this.props.getLibraryManifest();
+      libraryManifest = this.props.libraryManifest;
     }
 
     return searchAssets(
@@ -126,8 +126,7 @@ export default class AnimationPickerBody extends React.Component {
   };
 
   animationCategoriesRendering() {
-    const libraryManifest = this.props.getLibraryManifest();
-    const categories = Object.keys(libraryManifest.categories);
+    const categories = Object.keys(this.props.libraryManifest.categories || []);
     categories.push('all');
     return categories.map(category => (
       <AnimationPickerListItem
@@ -156,8 +155,7 @@ export default class AnimationPickerBody extends React.Component {
   }
 
   render() {
-    const libraryManifest = this.props.getLibraryManifest();
-    if (!libraryManifest) {
+    if (!this.props.libraryManifest) {
       return <div>{msg.loading()}</div>;
     }
     const {searchQuery, categoryQuery, results} = this.state;

--- a/apps/src/p5lab/AnimationPicker/AnimationPickerListItem.jsx
+++ b/apps/src/p5lab/AnimationPicker/AnimationPickerListItem.jsx
@@ -67,15 +67,28 @@ class AnimationPickerListItem extends React.Component {
     category: PropTypes.string
   };
 
+  state = {
+    loaded: false
+  };
+
   render() {
     const rootStyle = [styles.root, !this.props.label && styles.noLabel];
 
     const thumbnailStyle = [
       styles.thumbnail,
-      this.props.icon && styles.thumbnailIcon
+      this.props.icon && styles.thumbnailIcon,
+      this.props.animationProps && {
+        display: this.state.loaded ? 'block' : 'none'
+      }
     ];
 
-    const labelStyle = [styles.label, this.props.icon && styles.labelIcon];
+    const labelStyle = [
+      styles.label,
+      this.props.icon && styles.labelIcon,
+      this.props.animationProps && {
+        display: this.state.loaded ? 'block' : 'none'
+      }
+    ];
 
     const iconImageSrc = this.props.category
       ? `/blockly/media/gamelab/animation-previews/category_${
@@ -99,6 +112,7 @@ class AnimationPickerListItem extends React.Component {
               playBehavior={
                 !this.props.playAnimations ? PlayBehavior.NEVER_PLAY : null
               }
+              onPreviewLoad={() => this.setState({loaded: true})}
             />
           )}
           {this.props.icon && <i className={'fa fa-' + this.props.icon} />}

--- a/apps/src/p5lab/AnimationPicker/AnimationPreview.jsx
+++ b/apps/src/p5lab/AnimationPicker/AnimationPreview.jsx
@@ -18,7 +18,8 @@ export default class AnimationPreview extends React.Component {
     playBehavior: PropTypes.oneOf([
       PlayBehavior.ALWAYS_PLAY,
       PlayBehavior.NEVER_PLAY
-    ])
+    ]),
+    onPreviewLoad: PropTypes.func
   };
 
   state = {
@@ -157,7 +158,11 @@ export default class AnimationPreview extends React.Component {
         }
       >
         <div style={cropStyle}>
-          <img src={this.props.sourceUrl || EMPTY_IMAGE} style={imageStyle} />
+          <img
+            onLoad={this.props.onPreviewLoad}
+            src={this.props.sourceUrl || EMPTY_IMAGE}
+            style={imageStyle}
+          />
         </div>
       </div>
     );

--- a/apps/src/p5lab/AnimationPicker/AnimationPreview.jsx
+++ b/apps/src/p5lab/AnimationPicker/AnimationPreview.jsx
@@ -27,7 +27,7 @@ export default class AnimationPreview extends React.Component {
     scaledSourceSize: {x: 0, y: 0},
     scaledFrameSize: {x: 0, y: 0},
     extraTopMargin: 0,
-    wrappedSourceUrl: ''
+    extraLeftMargin: 0
   };
 
   componentWillMount() {
@@ -90,7 +90,6 @@ export default class AnimationPreview extends React.Component {
     const yScale = innerHeight / nextAnimation.frameSize.y;
     const scale = Math.min(1, Math.min(xScale, yScale));
     const scaledFrameSize = scaleVector2(nextAnimation.frameSize, scale);
-    const sourceUrl = nextProps.sourceUrl ? nextProps.sourceUrl : EMPTY_IMAGE;
     const sourceSize = nextAnimation.sourceSize
       ? nextAnimation.sourceSize
       : {x: 1, y: 1};
@@ -99,7 +98,7 @@ export default class AnimationPreview extends React.Component {
       scaledSourceSize: scaleVector2(sourceSize, scale),
       scaledFrameSize: scaledFrameSize,
       extraTopMargin: Math.ceil((innerHeight - scaledFrameSize.y) / 2),
-      wrappedSourceUrl: `url('${sourceUrl}')`
+      extraLeftMargin: Math.ceil((innerWidth - scaledFrameSize.x) / 2)
     });
   }
 
@@ -110,7 +109,7 @@ export default class AnimationPreview extends React.Component {
       scaledSourceSize,
       scaledFrameSize,
       extraTopMargin,
-      wrappedSourceUrl
+      extraLeftMargin
     } = this.state;
 
     const row = Math.floor(currentFrame / framesPerRow);
@@ -123,17 +122,23 @@ export default class AnimationPreview extends React.Component {
       height: this.props.height,
       textAlign: 'center'
     };
-    const imageStyle = {
+    const cropStyle = {
       width: scaledFrameSize.x,
       height: scaledFrameSize.y,
+      overflow: 'hidden',
       marginTop: MARGIN_PX + extraTopMargin,
-      marginLeft: MARGIN_PX,
+      marginLeft: MARGIN_PX + extraLeftMargin,
       marginRight: MARGIN_PX,
-      marginBottom: MARGIN_PX,
-      backgroundImage: wrappedSourceUrl,
-      backgroundRepeat: 'no-repeat',
-      backgroundSize: scaledSourceSize.x,
-      backgroundPosition: xOffset + 'px ' + yOffset + 'px'
+      marginBottom: MARGIN_PX
+    };
+
+    const imageStyle = {
+      maxWidth: 'none',
+      maxHeight: 'none',
+      width: scaledSourceSize.x,
+      height: scaledSourceSize.y,
+      marginLeft: xOffset,
+      marginTop: yOffset
     };
 
     return (
@@ -151,7 +156,9 @@ export default class AnimationPreview extends React.Component {
             : null
         }
       >
-        <img src={EMPTY_IMAGE} style={imageStyle} />
+        <div style={cropStyle}>
+          <img src={this.props.sourceUrl || EMPTY_IMAGE} style={imageStyle} />
+        </div>
       </div>
     );
   }

--- a/apps/src/p5lab/AnimationTab/AnimationTab.jsx
+++ b/apps/src/p5lab/AnimationTab/AnimationTab.jsx
@@ -62,7 +62,7 @@ class AnimationTab extends React.Component {
   static propTypes = {
     channelId: PropTypes.string.isRequired,
     onColumnWidthsChange: PropTypes.func.isRequired,
-    getLibraryManifest: PropTypes.func.isRequired,
+    libraryManifest: PropTypes.object.isRequired,
     hideUploadOption: PropTypes.bool.isRequired,
     hideAnimationNames: PropTypes.bool.isRequired,
 
@@ -100,7 +100,7 @@ class AnimationTab extends React.Component {
           <AnimationPicker
             channelId={this.props.channelId}
             allowedExtensions=".png,.jpg,.jpeg"
-            getLibraryManifest={this.props.getLibraryManifest}
+            libraryManifest={this.props.libraryManifest}
             hideUploadOption={this.props.hideUploadOption}
             hideAnimationNames={this.props.hideAnimationNames}
           />

--- a/apps/src/p5lab/P5LabView.jsx
+++ b/apps/src/p5lab/P5LabView.jsx
@@ -53,10 +53,6 @@ class P5LabView extends React.Component {
     return undefined;
   }
 
-  getLibraryManifest = () => {
-    return this.state.libraryManifest;
-  };
-
   componentDidMount() {
     this.props.onMount();
     const locale = window.appOptions.locale;
@@ -105,7 +101,7 @@ class P5LabView extends React.Component {
             <AnimationPicker
               channelId={this.getChannelId()}
               allowedExtensions=".png,.jpg,.jpeg"
-              getLibraryManifest={this.getLibraryManifest}
+              libraryManifest={this.state.libraryManifest}
               hideUploadOption={this.props.spriteLab}
               hideAnimationNames={this.props.spriteLab}
             />
@@ -133,7 +129,7 @@ class P5LabView extends React.Component {
       interfaceMode === P5LabInterfaceMode.ANIMATION ? (
       <AnimationTab
         channelId={this.getChannelId()}
-        getLibraryManifest={this.getLibraryManifest}
+        libraryManifest={this.state.libraryManifest}
         hideUploadOption={this.props.spriteLab}
         hideAnimationNames={this.props.spriteLab}
       />

--- a/apps/src/p5lab/P5LabView.jsx
+++ b/apps/src/p5lab/P5LabView.jsx
@@ -42,6 +42,10 @@ class P5LabView extends React.Component {
     spriteLab: PropTypes.bool.isRequired
   };
 
+  state = {
+    libraryManifest: {}
+  };
+
   getChannelId() {
     if (dashboard && dashboard.project) {
       return dashboard.project.getCurrentId();

--- a/apps/test/unit/p5lab/AnimationPicker/AnimationPickerBodyTest.js
+++ b/apps/test/unit/p5lab/AnimationPicker/AnimationPickerBodyTest.js
@@ -17,7 +17,7 @@ describe('AnimationPickerBody', function() {
     onPickLibraryAnimation: emptyFunction,
     onUploadClick: emptyFunction,
     playAnimations: false,
-    getLibraryManifest: () => testAnimationLibrary,
+    libraryManifest: testAnimationLibrary,
     categories: CostumeCategories,
     hideUploadOption: false,
     hideAnimationNames: false

--- a/dashboard/test/ui/features/star_labs/gamelab/export_animations.feature
+++ b/dashboard/test/ui/features/star_labs/gamelab/export_animations.feature
@@ -5,8 +5,6 @@ Feature: Game Lab Export
 Scenario: Export library animation
   Given I start a new Game Lab project
   And I switch to the animation tab
-  # Wait to make sure library manifest has loaded
-  And I wait for 2 seconds
   And I add the bear animation from the library
   And I switch to the code tab in Game Lab
   And I press "runButton"

--- a/dashboard/test/ui/features/star_labs/gamelab/export_animations.feature
+++ b/dashboard/test/ui/features/star_labs/gamelab/export_animations.feature
@@ -5,6 +5,8 @@ Feature: Game Lab Export
 Scenario: Export library animation
   Given I start a new Game Lab project
   And I switch to the animation tab
+  # Wait to make sure library manifest has loaded
+  And I wait for 2 seconds
   And I add the bear animation from the library
   And I switch to the code tab in Game Lab
   And I press "runButton"

--- a/dashboard/test/ui/features/step_definitions/gamelab.rb
+++ b/dashboard/test/ui/features/step_definitions/gamelab.rb
@@ -57,11 +57,12 @@ Then /^I select a blank animation$/ do
 end
 
 Then /^I select the animal category of the animation library$/ do
-  @browser.execute_script("$(\"img[src*='/category_animals.png']\")[0].click();")
+  @browser.execute_script("$(\"img[src*='/category_animals.png']\")[1].click();")
 end
 
 Then /^I select the bear animation from the animal category$/ do
-  @browser.execute_script("$(\"img[style*='/category_animals/bear.png']\")[0].click();")
+  wait_until {@browser.execute_script("return $(\"img[src*='/category_animals/bear.png']\").length != 0;")}
+  @browser.execute_script("$(\"img[src*='/category_animals/bear.png']\")[0].click();")
 end
 
 Then /^I add a new, blank animation$/ do

--- a/dashboard/test/ui/features/step_definitions/gamelab.rb
+++ b/dashboard/test/ui/features/step_definitions/gamelab.rb
@@ -57,6 +57,7 @@ Then /^I select a blank animation$/ do
 end
 
 Then /^I select the animal category of the animation library$/ do
+  wait_until {@browser.execute_script("return $(\"img[src*='/category_animals.png']\").length != 0;")}
   @browser.execute_script("$(\"img[src*='/category_animals.png']\")[1].click();")
 end
 


### PR DESCRIPTION
Improves the loading experience by not showing the animation card in the modal until the image has loaded
![Jul-27-2020 14-22-07](https://user-images.githubusercontent.com/8787187/88593592-a686d900-d014-11ea-9878-e547eed7497d.gif)




<!--
  Other aspects to consider. uncomment and add detail for any that seem necessary:
-->

<!-- ### Background -->
<!-- ### Privacy -->
<!-- ### Security -->
<!-- ### Caching -->
<!-- ### Deployment strategy -->
<!-- ### Future work -->

## Links

<!--
  Any relevant links to external resources; ie, specification documents, jira
  items, related PRs, honeybadger errors, etc
-->
- [jira](https://codedotorg.atlassian.net/browse/STAR-1177)

## Testing story

<!--
  Does your change include appropriate tests?

  If so, please describe how the tests included in this PR are sufficient

  If not, please explain why this change does not need to be tested.
-->

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
