### PR TITLE
Pegasus DB: Add deleted_at column to poste_urls

### DIFF
--- a/pegasus/migrations/135_add_deleted_at_to_poste_urls.rb
+++ b/pegasus/migrations/135_add_deleted_at_to_poste_urls.rb
@@ -1,0 +1,7 @@
+Sequel.migration do
+  change do
+    alter_table(:poste_urls) do
+      add_column :deleted_at, DateTime
+    end
+  end
+end

--- a/pegasus/migrations/135_add_deleted_at_to_poste_urls.rb
+++ b/pegasus/migrations/135_add_deleted_at_to_poste_urls.rb
@@ -2,6 +2,7 @@ Sequel.migration do
   change do
     alter_table(:poste_urls) do
       add_column :deleted_at, DateTime
+      add_index :deleted_at
     end
   end
 end


### PR DESCRIPTION
Enable soft deletion of poste_urls. See [PLC-937](https://codedotorg.atlassian.net/browse/PLC-937) for more details.

<!-- ### Background -->
<!-- ### Privacy -->
<!-- ### Security -->
<!-- ### Caching -->
<!-- ### Deployment strategy -->
<!-- ### Future work -->

## Links

- [jira](https://codedotorg.atlassian.net/browse/PLC-937)

## Testing story
Tested that this column gets added as expected and existing rows have a deleted_at value of null.

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
