### PR TITLE
skip tests on firefox

### DIFF
--- a/dashboard/test/ui/features/learning_platform/projects/prevent_report_abuse_spam.feature
+++ b/dashboard/test/ui/features/learning_platform/projects/prevent_report_abuse_spam.feature
@@ -1,4 +1,5 @@
 @no_mobile
+@no_firefox # these tests fail on Firefox 79. Learning Platform is tracking the issue
 Feature: Prevent Report Abuse Spam
 
 # If someone has already reported abuse on a specific project, we hide the


### PR DESCRIPTION
These tests began failing in Firefox 79, so we are skipping Firefox to unblock us for now, and tracking the issue [here](https://github.com/code-dot-org/code-dot-org/blob/staging/dashboard/test/ui/features/learning_platform/projects/prevent_report_abuse_spam.feature).

<!--
  Your description goes here: A summary of the change, including any relevant motivation and context.

  If relevant, include a description both of the existing behavior and of the new behavior.
-->

<!--
  Other aspects to consider. uncomment and add detail for any that seem necessary:
-->

<!-- ### Background -->
<!-- ### Privacy -->
<!-- ### Security -->
<!-- ### Caching -->
<!-- ### Deployment strategy -->
<!-- ### Future work -->

## Links

<!--
  Any relevant links to external resources; ie, specification documents, jira
  items, related PRs, honeybadger errors, etc
-->

- [spec]()
- [jira]()

## Testing story

<!--
  Does your change include appropriate tests?

  If so, please describe how the tests included in this PR are sufficient

  If not, please explain why this change does not need to be tested.
-->

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
