### PR TITLE
Copy name value into new key column for lessons

### DIFF
--- a/dashboard/app/models/lesson.rb
+++ b/dashboard/app/models/lesson.rb
@@ -65,6 +65,7 @@ class Lesson < ActiveRecord::Base
         end
 
       lesson.assign_attributes(
+        key: raw_lesson[:name], #TODO: once key has been added to all the lessons update to use key in the find
         absolute_position: (counters.lesson_position += 1),
         lesson_group: lesson_group,
         lockable: !!raw_lesson[:lockable],

--- a/dashboard/app/models/lesson.rb
+++ b/dashboard/app/models/lesson.rb
@@ -61,6 +61,7 @@ class Lesson < ActiveRecord::Base
           name: raw_lesson[:name],
           script: script
         ) do |s|
+          s.key = "" # will be updated below, but cant be null
           s.relative_position = 0 # will be updated below, but cant be null
         end
 


### PR DESCRIPTION
# Background

For a long time we have used the the name of the lesson as both the key for the lesson and then display name. This leads to challenges. One example of these challenges is in translation. In order to keep the key consistent for translations we don't want levelbuilders to change the name in the Script DSL. Instead an engineer needs to update the display name in scripts.en.yml.

# Change

In order to get away from using the name as both the key and the value we are going to add a separate key value to lessons. This is going to take a couple steps:

1. **Done** _Migrations to add key column to lesson(stages) table_ (See https://github.com/code-dot-org/code-dot-org/pull/36013)
2. Copy the value in the name column to the key column for all lessons **<--- We are here**
3. Update the Script DSL to use new format where a levelbuilder specifies both the key and name. Update all the existing script files to use this new format. 
4. Allow updating the display name of lessons (and lesson groups) but prevent levelbuilder from adding/deleting/changing the key of lessons and lesson groups in scripts which are marked as stable and included in the i18n pipeline. 

- [PLAT-242](https://codedotorg.atlassian.net/browse/PLAT-242)
- [PLAT-254](https://codedotorg.atlassian.net/browse/PLAT-254)

# Testing

I ran seeding locally and checked some lessons in my database to make sure the key value matched the name value.
