### PR TITLE
Fix outbound email cloudwatch alarm

### DIFF
--- a/aws/cloudformation/components/alarms.yml.erb
+++ b/aws/cloudformation/components/alarms.yml.erb
@@ -44,7 +44,7 @@
     Type: "AWS::CloudWatch::Alarm"
     Properties:
       AlarmActions:
-        - "arn:aws:sns:${AWS::Region}:${AWS::AccountId}:CDO-Urgent"
+        - !Sub "arn:aws:sns:${AWS::Region}:${AWS::AccountId}:CDO-Urgent"
       AlarmDescription: Send page if number of outbound transactional emails sent drops below threshold.
       AlarmName: <%="#{stack_name}_no_outbound_emails_sent" %>
       ComparisonOperator: Lower

--- a/aws/cloudformation/components/alarms.yml.erb
+++ b/aws/cloudformation/components/alarms.yml.erb
@@ -38,7 +38,7 @@
       Statistic: Maximum
       Threshold: 87
       TreatMissingData: missing
-<%  if environment == :production -%>
+<% if environment == :production -%>
   # Detect problems with the bin/cron/deliver_poste_messages scheduled job by monitoring outbound emails sent by AWS SES.
   OutboundEmailAlarm:
     Type: "AWS::CloudWatch::Alarm"
@@ -48,7 +48,7 @@
       AlarmDescription: Send page if number of outbound transactional emails sent drops below threshold.
       AlarmName: <%="#{stack_name}_no_outbound_emails_sent" %>
       ComparisonOperator: Lower
-            MetricName: Send
+      MetricName: Send
       Namespace: 'AWS/SES'
       # No outbound transactional emails (password reset, new account welcome, etc.) sent per hour for 4 consecutive hours.
       Period: 3600


### PR DESCRIPTION
Fixes a YAML syntax error and a CloudFormation syntax error in #35982 


## Testing story

Running the validation task locally on a development environment detects more changes than expected,.
```
$ bundle exec rake stack:validate RAILS_ENV=productio
Listing changes to existing stack `autoscale-prod`:
Add AMICreatec2c0d [AWS::CloudFormation::WaitCondition]
Remove AMICreatecddb0 [AWS::CloudFormation::WaitCondition]
Add AMIc2c0d [Custom::AMIManager]
Remove AMIcddb0 [Custom::AMIManager]
Modify ASGCount [Custom::CountASG] Properties Replacement: Conditional (LaunchConfiguration)
Modify CPUScalingPolicy [AWS::AutoScaling::ScalingPolicy] Properties Replacement: Conditional (AutoScalingGroupName)
Modify ClassroomScaleDown [AWS::AutoScaling::ScheduledAction] Properties Replacement: Conditional (AutoScalingGroupName)
Modify ClassroomScaleUp [AWS::AutoScaling::ScheduledAction] Properties Replacement: Conditional (AutoScalingGroupName)
Modify FastSnapshotRestore [Custom::FastSnapshotRestore] Properties Replacement: Conditional (ImageIds, ImageIds)
Modify FrontendLaunchConfig [AWS::AutoScaling::LaunchConfiguration] Properties Replacement: True (ImageId, UserData, ImageId)
Modify Frontends [AWS::AutoScaling::AutoScalingGroup] UpdatePolicy, CreationPolicy, Properties Replacement: Conditional (MaxSize, DesiredCapacity, MinSize, , , LaunchConfigurationName)
Add OutboundEmailAlarm [AWS::CloudWatch::Alarm]
Modify WebServerAMI [AWS::EC2::Instance] Properties Replacement: Conditional (UserData)
Modify WebServerHookEventPermission [AWS::Lambda::Permission] Properties Replacement: Conditional (SourceArn)
Modify WebServerHookEventRule [AWS::Events::Rule] Properties (EventPattern)
Modify WebServerHook [AWS::AutoScaling::LifecycleHook] Properties Replacement: Conditional (AutoScalingGroupName)
Modify WeekendScaleDown [AWS::AutoScaling::ScheduledAction] Properties Replacement: Conditional (AutoScalingGroupName)
Modify WeekendScaleUp [AWS::AutoScaling::ScheduledAction] Properties Replacement: Conditional (AutoScalingGroupName)
```

[Here's an adhoc](https://console.aws.amazon.com/cloudformation/home?region=us-east-1#/stacks/stackinfo?filteringText=&filteringStatus=active&viewNested=true&hideStacks=false&stackId=arn%3Aaws%3Acloudformation%3Aus-east-1%3A475661607190%3Astack%2Fadhoc-fix-outbound-email-cloudwatch-alarm%2F0fea5ff0-d0f3-11ea-9086-0a4fdb0c1726) provisioning from this feature branch.

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
