### PR TITLE
Ignore test262 submodule when linting

### DIFF
--- a/apps/.eslintignore
+++ b/apps/.eslintignore
@@ -5,3 +5,5 @@
 /lib
 /build
 node_modules
+
+/test/interpreter/test262


### PR DESCRIPTION
we have not been explicitly ignoring the `test262` submodule from our linting, which is only fine as long as the submodule is not actually initialized. if the submodule gets checked out (perhaps with an accidental `--recursive`), it will cause linting to take a very long time and spit out thousands of errors. to prevent this from happening to the next developer who unintentionally checks out the submodule, i am explicitly adding it to `.eslintignore`. 

<!-- ### Background -->
<!-- ### Privacy -->
<!-- ### Security -->
<!-- ### Caching -->
<!-- ### Deployment strategy -->
<!-- ### Future work -->

## Links

<!--
  Any relevant links to external resources; ie, specification documents, jira
  items, related PRs, honeybadger errors, etc
-->

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
