### PR TITLE
parallelize the two slowest steps in the sync out

### DIFF
--- a/bin/i18n/sync-out.rb
+++ b/bin/i18n/sync-out.rb
@@ -11,6 +11,7 @@ require 'cdo/crowdin/project'
 
 require 'fileutils'
 require 'json'
+require 'parallel'
 require 'tempfile'
 require 'yaml'
 
@@ -104,7 +105,7 @@ def find_malformed_links_images(locale, file_path)
 end
 
 def restore_redacted_files
-  total_locales = Languages.get_locale.count
+  locales = Languages.get_locale
   original_dir = "i18n/locales/original"
   original_files = Dir.glob("#{original_dir}/**/*.*").to_a
   if original_files.empty?
@@ -116,20 +117,20 @@ def restore_redacted_files
       corresponding sync-in.
     ERR
   end
-  Languages.get_locale.each_with_index do |prop, locale_index|
+
+  puts "Restoring redacted files in #{locales.count} locales, parallelized between #{Parallel.processor_count} processes"
+
+  Parallel.each(locales) do |prop|
     locale = prop[:locale_s]
     next if locale == 'en-US'
     next unless File.directory?("i18n/locales/#{locale}/")
 
-    puts "Restoring #{locale} (#{locale_index}/#{total_locales})"
     original_files.each do |original_path|
       relative_path = original_path.delete_prefix(original_dir)
       next unless file_changed?(locale, relative_path)
 
       translated_path = original_path.sub("original", locale)
       next unless File.file?(translated_path)
-
-      $stdout.flush
 
       if original_path.include? "course_content"
         restored_data = RedactRestoreUtils.restore_file(original_path, translated_path, ['blockly'])
@@ -145,6 +146,8 @@ def restore_redacted_files
       find_malformed_links_images(locale, translated_path)
     end
   end
+
+  puts "Restoration finished!"
 end
 
 # Recursively run through the data received from crowdin, sanitizing it for
@@ -250,12 +253,12 @@ end
 # Distribute downloaded translations from i18n/locales
 # back to blockly, apps, pegasus, and dashboard.
 def distribute_translations(upload_manifests)
-  total_locales = Languages.get_locale.count
-  Languages.get_locale.each_with_index do |prop, i|
+  locales = Languages.get_locale
+  puts "Distributing translations in #{locales.count} locales, parallelized between #{Parallel.processor_count} processes"
+
+  Parallel.each(locales) do |prop|
     locale = prop[:locale_s]
     locale_dir = File.join("i18n/locales", locale)
-    puts "Distributing #{locale} (#{i}/#{total_locales})"
-    $stdout.flush
     next if locale == 'en-US'
     next unless File.directory?(locale_dir)
 


### PR DESCRIPTION
Part of our ongoing work to speed up the sync out.

On my local machine with 8 cores, this has a significant speedup. See these results:

### Before

```
                 user     system      total        real
rename       0.013404   0.004098   0.017502 (  0.019095)
restore      4.802004   0.328715 160.035807 (137.836081)
distribute 465.446141  14.723658 480.169799 (511.983090)
copy apps    0.029910   0.040080   0.069990 (  0.123882)
blockly      0.006614   0.000230  70.797939 ( 53.947998)
markdown     0.813416   0.076131   0.889547 (  0.889439)
hourofcode   2.553534   0.352502   2.906036 (  2.906916)
```

### After

```
                 user     system      total        real
rename       0.013888   0.003831   0.017719 (  0.019417)
restore      0.020309   0.100317 268.485802 ( 45.147419)
distribute  0.021499   0.108865 1497.125935 (297.122393)
copy apps    0.009859   0.039870   0.049729 (  0.049799)
blockly      0.006497   0.000547  69.314957 ( 52.540062)
markdown     1.073464   0.174946   1.248410 (  1.528806)
hourofcode   3.636642   0.358930   3.995572 (  4.024528)
```

The i18n-dev machine _currently_ only has two cores so I expect there to be less of a speedup there, but this opens us up to the possibility of speeding up the sync out by sizing up the ec2 instance.

Note that as a side effect, we lose the individual locale-by-locale progress reports. I think this is fine, as those resulted in more noise than I think we need. But! If we decide we want those back, we could achieve that by telling Parallel to use threads rather than processes.

## Testing story

Tested manually. Specifically, I ran the sync out both with and without the changes and compared the results to confirm that there is no difference other than in execution time.

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
