### PR TITLE
Set gem version for bcrypt

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -284,6 +284,7 @@ gem 'unf_ext', '0.0.7.2'
 gem 'acmesmith', '~> 2.3.1'
 
 gem 'addressable'
+# bcrypt version specified due to "Invalid Hash" error in Linux
 gem 'bcrypt', '3.1.13'
 gem 'firebase'
 gem 'firebase_token_generator'

--- a/Gemfile
+++ b/Gemfile
@@ -284,7 +284,7 @@ gem 'unf_ext', '0.0.7.2'
 gem 'acmesmith', '~> 2.3.1'
 
 gem 'addressable'
-gem 'bcrypt'
+gem 'bcrypt', '3.1.13'
 gem 'firebase'
 gem 'firebase_token_generator'
 gem 'sshkit'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -322,7 +322,7 @@ GEM
     aws-sigv4 (1.2.1)
       aws-eventstream (~> 1, >= 1.0.2)
     backports (3.11.3)
-    bcrypt (3.1.11)
+    bcrypt (3.1.13)
     benchmark-ips (2.7.2)
     better_errors (2.1.1)
       coderay (>= 1.0.0)
@@ -912,7 +912,7 @@ DEPENDENCIES
   aws-sdk-route53
   aws-sdk-s3
   aws-sdk-secretsmanager
-  bcrypt
+  bcrypt (= 3.1.13)
   benchmark-ips
   better_errors
   binding_of_caller


### PR DESCRIPTION
In the process of updating my OS to Pop OS 20.04, I was running into this problem (https://github.com/heartcombo/devise/issues/4861), which required setting the Bcrypt gem to a specific version.

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
