### PR TITLE
Fix applab export

### DIFF
--- a/apps/tasks/messages.js
+++ b/apps/tasks/messages.js
@@ -76,8 +76,10 @@ module.exports = function(grunt) {
       }
     }
 
-    return mf
-      .compile(json)
-      .toString('(window.blockly = window.blockly || {}).' + namespace);
+    return (
+      mf
+        .compile(json)
+        .toString('(window.blockly = window.blockly || {}).' + namespace) + ';'
+    );
   }
 };


### PR DESCRIPTION
Prior to #35111, there was a semicolon at the end of the locale object. For the most part, this diff didn't matter but when a user exports the project, these objects are put in the same file in sequence. This causes the user to see:
![Screenshot 2020-07-28 at 6 00 15 PM](https://user-images.githubusercontent.com/46464143/88744444-3c496380-d0fc-11ea-802e-8228e8ff71cb.png)

Googling this error leads to [this stackoverflow](https://stackoverflow.com/questions/42036349/uncaught-typeerror-intermediate-value-is-not-a-function), which is how I came to this solution.

I tested this locally and it works for me.

<!-- ### Background -->
<!-- ### Privacy -->
<!-- ### Security -->
<!-- ### Caching -->
<!-- ### Deployment strategy -->
<!-- ### Future work -->

## Links

<!--
  Any relevant links to external resources; ie, specification documents, jira
  items, related PRs, honeybadger errors, etc
-->

- [spec]()
- [jira]()

## Testing story

<!--
  Does your change include appropriate tests?

  If so, please describe how the tests included in this PR are sufficient

  If not, please explain why this change does not need to be tested.
-->

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
