### PR TITLE
Add bin/reset_flakiness

### DIFF
--- a/bin/reset_flakiness
+++ b/bin/reset_flakiness
@@ -4,7 +4,7 @@
 # This timestamp corresponds to the "from" parameter when requesting jobs from
 # SauceLabs in bin/test_flakiness: https://wiki.saucelabs.com/display/DOCS/Job+Methods
 #
-# Recommended usage: Run this script, then commit the artifact file, describing why
+# Recommended usage: Run this script and commit the artifact file, describing why
 # you are resetting UI test flakiness in your commit message.
 
 require_relative '../deployment'

--- a/bin/reset_flakiness
+++ b/bin/reset_flakiness
@@ -3,6 +3,9 @@
 # Resets the timestamp for checking UI test flakiness in SauceLabs.
 # This timestamp corresponds to the "from" parameter when requesting jobs from
 # SauceLabs in bin/test_flakiness: https://wiki.saucelabs.com/display/DOCS/Job+Methods
+#
+# Recommended usage: Run this script, then commit the artifact file, describing why
+# you are resetting UI test flakiness in your commit message.
 
 require_relative '../deployment'
 require 'cdo/test_flakiness'

--- a/bin/reset_flakiness
+++ b/bin/reset_flakiness
@@ -1,0 +1,23 @@
+#!/usr/bin/env ruby
+
+# Resets the timestamp for checking UI test flakiness in SauceLabs.
+# This timestamp corresponds to the "from" parameter when requesting jobs from
+# SauceLabs in bin/test_flakiness: https://wiki.saucelabs.com/display/DOCS/Job+Methods
+
+require_relative '../deployment'
+require 'cdo/test_flakiness'
+require 'optparse'
+
+options = {timestamp: Time.now.to_i}
+OptionParser.new do |opts|
+  opts.banner = "Usage: #{File.basename(__FILE__)} [options]"
+  opts.on('-t', '--timestamp T', 'Unix timestamp to begin tracking flakiness. Optional, defaults to now.') do |t|
+    options[:timestamp] = Integer(t)
+  end
+  opts.on('-h', '--help', 'Prints this help') do
+    puts opts
+    exit
+  end
+end.parse!
+
+TestFlakiness.reset(options[:timestamp])

--- a/lib/cdo/test_flakiness.rb
+++ b/lib/cdo/test_flakiness.rb
@@ -81,8 +81,7 @@ class TestFlakiness
   # for calculating flakiness.
   # @param timestamp [Integer] Unix timestamp (e.g., Time.now.to_i)
   def self.reset(timestamp)
-    file_data = {timestamp: timestamp}.to_json
-    File.open(FLAKINESS_TIMESTAMP_FILENAME, "w") {|f| f.write(file_data)}
+    File.open(FLAKINESS_TIMESTAMP_FILENAME, "w") {|f| f.write({timestamp: timestamp}.to_json)}
   end
 
   CACHE_FILENAME = (File.dirname(__FILE__) + "/../../dashboard/tmp/cache/test_summary.json").freeze

--- a/lib/cdo/test_flakiness.rb
+++ b/lib/cdo/test_flakiness.rb
@@ -138,6 +138,9 @@ class TestFlakiness
   cached def self.from_timestamp
     return nil unless File.exist?(FLAKINESS_TIMESTAMP_FILENAME)
     timestamp = JSON.parse(File.read(FLAKINESS_TIMESTAMP_FILENAME))['timestamp']
-    timestamp.is_a?(Integer) ? timestamp : nil
+    return nil unless timestamp.is_a?(Integer)
+    current_time = Time.now.to_i
+    raise "Timestamp #{timestamp} is in the future. Current server time is #{current_time}." if timestamp > current_time
+    timestamp
   end
 end

--- a/lib/cdo/test_flakiness.rb
+++ b/lib/cdo/test_flakiness.rb
@@ -49,7 +49,9 @@ class TestFlakiness
         skip: jobs.count,
         from: from_timestamp
       }.compact
-      jobs += get_jobs(options)
+      new_jobs = get_jobs(options)
+      break if new_jobs.empty?
+      jobs += new_jobs
     end
     jobs.group_by {|job| job['name']}.map do |name, samples|
       passed = samples.select {|job| job['passed']}

--- a/lib/test/cdo/test_test_flakiness.rb
+++ b/lib/test/cdo/test_test_flakiness.rb
@@ -1,0 +1,24 @@
+require_relative '../test_helper'
+require 'cdo/test_flakiness'
+
+class TestFlakinessTest < Minitest::Test
+  def test_from_timestamp
+    File.stubs(:exist?).returns(true)
+    File.stubs(:read).returns("{\"timestamp\":123}")
+    assert_equal 123, TestFlakiness.from_timestamp
+    CDO.cache.clear
+  end
+
+  def test_from_timestamp_nonexistent_file
+    File.stubs(:exist?).returns(false)
+    assert_nil TestFlakiness.from_timestamp
+    CDO.cache.clear
+  end
+
+  def test_from_timestamp_invalid_timestamp
+    File.stubs(:exist?).returns(true)
+    File.stubs(:read).returns("{\"timestamp\":\"hello\"}")
+    assert_nil TestFlakiness.from_timestamp
+    CDO.cache.clear
+  end
+end


### PR DESCRIPTION
[Background/context doc](https://docs.google.com/document/d/1PaU9Ki0xUMrv8MyfxcJm4zkUgo-bq9irkkzq1_IET08/edit#)

Adds a script that allows us to set a timestamp that corresponds to the oldest results we will request from SauceLabs when determining UI test flakiness. This is useful for pipeline issues that cause a test to be incorrectly reported as flaky. Example: User creation was intermittently failing due to username overflow ([generated length was > the max char limit](https://github.com/code-dot-org/code-dot-org/blob/e5a0f05ade30921af9acf807c1e0d045a4f71ce5/lib/cdo/user_helpers.rb#L59)), which caused a lot of unrelated UI tests to fail.

Usage:

1. Run `bin/reset_flakiness -t <unix timestamp>` on your dev machine (`-t` param is optional, will default to `Time.now.to_i`).
2. Step 1 will create or update a file that tracks this timestamp (`ui_test_flakiness_timestamp.json`). The contents of that file should look something like `{"timestamp": 123456}`.
3. Commit that file, explaining why you are resetting the timestamp in your commit message.
4. Once this change reaches the test machine, the `bin/test_flakiness` script will filter test job results from SauceLabs based on this timestamp (using the `from` param in [saucelabs.com/rest/v1/USERNAME/jobs?from=timestamp](https://wiki.saucelabs.com/display/DOCS/Job+Methods))

## Links

- [doc](https://docs.google.com/document/d/1PaU9Ki0xUMrv8MyfxcJm4zkUgo-bq9irkkzq1_IET08/edit#)

## Testing story

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
