### PR TITLE
Prevent multiple instances of cron to deliver transactional email

### DIFF
--- a/bin/cron/deliver_poste_messages
+++ b/bin/cron/deliver_poste_messages
@@ -1,7 +1,9 @@
 #!/usr/bin/env ruby
+require_relative '../../lib/cdo/only_one'
+exit unless only_one_running?(__FILE__)
+
 require File.expand_path('../../../pegasus/src/env', __FILE__)
 require 'retryable'
-require 'cdo/only_one'
 require 'cdo/poste'
 require 'honeybadger/ruby'
 require 'base64'
@@ -112,4 +114,4 @@ def main
   end
 end
 
-main if only_one_running?(__FILE__)
+main


### PR DESCRIPTION
In the past 24 hours, we've twice ran into issues where transactional emails were not being sent. We've noticed that multiple instances of this process were running on `production-daemon` (which is supposed to be prevented using the `only_one` helper), and that email sends resumed once those processes were stopped.

This fix hopefully will prevent multiple processes from running at the same time.

## Testing story

Tested that I could run the script locally via `bundle exec ./deliver_poste_messages` without errors.

## Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
