### PR TITLE
Added wait on page load to prevent flakiness in Safari.

### DIFF
--- a/dashboard/test/ui/features/learning_platform/pairing.feature
+++ b/dashboard/test/ui/features/learning_platform/pairing.feature
@@ -18,6 +18,8 @@ Feature: Student pairing
     Then I wait to see ".modal"
     And I wait until element "#confirm-button" is visible
     And I click selector "#confirm-button"
+    # safari sometimes doesn't wait for the page load to initiate before checking if it's finished
+    And I wait for 5 seconds
     And I wait until I am on "http://studio.code.org/s/allthethings/stage/18/puzzle/8"
     And I wait for the page to fully load
     And I verify progress in the header of the current page is "perfect_assessment" for level 7


### PR DESCRIPTION
A new test was added to test the end-to-end pair programming scenario. When it started being run in our daily test runs, became apparent that the test is flaky in Safari. In this test, we rely on the `And I wait until I am on "http://studio.code.org/s/allthethings/stage/18/puzzle/8"` and the `And I wait for the page to fully load` commands. The second of these commands waits until the run button is visible. In Safari, however, the call to `And I wait until I am on...` will pass almost instantly, usually before the page actually begins to transition to the next level. To mitigate this, we add a 5 second wait to allow the page to start loading. This will likely not add any time to the test run because loading http://studio.code.org/s/allthethings/stage/18/puzzle/8 from the previous puzzle generally takes longer than 5 seconds.

<!--
  Your description goes here: A summary of the change, including any relevant motivation and context.

  If relevant, include a description both of the existing behavior and of the new behavior.
-->

<!--
  Other aspects to consider. uncomment and add detail for any that seem necessary:
-->

<!-- ### Background -->
<!-- ### Privacy -->
<!-- ### Security -->
<!-- ### Caching -->
<!-- ### Deployment strategy -->
<!-- ### Future work -->

## Links

<!--
  Any relevant links to external resources; ie, specification documents, jira
  items, related PRs, honeybadger errors, etc
-->

- [slack thread](https://codedotorg.slack.com/archives/CA3KCSGTD/p1596047531226800)
- [previous PR](https://github.com/code-dot-org/code-dot-org/pull/35945)

## Testing story

<!--
  Does your change include appropriate tests?

  If so, please describe how the tests included in this PR are sufficient

  If not, please explain why this change does not need to be tested.
-->

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
