### PR TITLE
Rename unit group unit associations and methods

### DIFF
--- a/dashboard/app/models/script.rb
+++ b/dashboard/app/models/script.rb
@@ -1437,7 +1437,7 @@ class Script < ActiveRecord::Base
   # return nil.
   def alternate_script(user)
     unit_group_units.each do |cs|
-      alternate_cs = cs.unit_group.select_course_script(user, cs)
+      alternate_cs = cs.unit_group.select_unit_group_unit(user, cs)
       return alternate_cs.script if cs != alternate_cs
     end
     nil

--- a/dashboard/app/models/sections/section.rb
+++ b/dashboard/app/models/sections/section.rb
@@ -205,7 +205,7 @@ class Section < ActiveRecord::Base
   # @return [Script, nil]
   def default_script
     return script if script
-    return unit_group.try(:default_course_scripts).try(:first).try(:script)
+    return unit_group.try(:default_unit_group_units).try(:first).try(:script)
   end
 
   def summarize_without_students

--- a/dashboard/app/models/unit_group.rb
+++ b/dashboard/app/models/unit_group.rb
@@ -351,7 +351,7 @@ class UnitGroup < ApplicationRecord
   # @return [Array<Script>]
   def scripts_for_user(user)
     default_unit_group_units.map do |cs|
-      select_course_script(user, cs).script
+      select_unit_group_unit(user, cs).script
     end
   end
 
@@ -374,7 +374,7 @@ class UnitGroup < ApplicationRecord
   # @param user [User|nil]
   # @param default_course_script [UnitGroupUnit]
   # @return [UnitGroupUnit]
-  def select_course_script(user, default_course_script)
+  def select_unit_group_unit(user, default_course_script)
     return default_course_script unless user
 
     alternates = alternate_unit_group_units.where(default_script: default_course_script.script).all

--- a/dashboard/app/models/unit_group.rb
+++ b/dashboard/app/models/unit_group.rb
@@ -19,14 +19,14 @@ class UnitGroup < ApplicationRecord
 
   # Some Courses will have an associated Plc::Course, most will not
   has_one :plc_course, class_name: 'Plc::Course', foreign_key: 'course_id'
-  has_many :default_course_scripts, -> {where(experiment_name: nil).order('position ASC')}, class_name: 'UnitGroupUnit', dependent: :destroy, foreign_key: 'course_id'
-  has_many :default_scripts, through: :default_course_scripts, source: :script
+  has_many :default_unit_group_units, -> {where(experiment_name: nil).order('position ASC')}, class_name: 'UnitGroupUnit', dependent: :destroy, foreign_key: 'course_id'
+  has_many :default_scripts, through: :default_unit_group_units, source: :script
   has_many :alternate_course_scripts, -> {where.not(experiment_name: nil)}, class_name: 'UnitGroupUnit', dependent: :destroy, foreign_key: 'course_id'
   has_one :course_version, as: :content_root
 
   after_save :write_serialization
 
-  scope :with_associated_models, -> {includes([:plc_course, :default_course_scripts])}
+  scope :with_associated_models, -> {includes([:plc_course, :default_unit_group_units])}
 
   FAMILY_NAMES = [
     CSD = 'csd'.freeze,
@@ -109,7 +109,7 @@ class UnitGroup < ApplicationRecord
     JSON.pretty_generate(
       {
         name: name,
-        script_names: default_course_scripts.map(&:script).map(&:name),
+        script_names: default_unit_group_units.map(&:script).map(&:name),
         alternate_scripts: summarize_alternate_scripts,
         properties: properties
       }.compact
@@ -161,7 +161,7 @@ class UnitGroup < ApplicationRecord
     alternate_scripts ||= []
     new_scripts = new_scripts.reject(&:empty?)
     # we want to delete existing course scripts that aren't in our new list
-    scripts_to_delete = default_course_scripts.map(&:script).map(&:name) - new_scripts
+    scripts_to_delete = default_unit_group_units.map(&:script).map(&:name) - new_scripts
     scripts_to_delete -= alternate_scripts.map {|hash| hash['alternate_script']}
 
     new_scripts.each_with_index do |script_name, index|
@@ -176,7 +176,7 @@ class UnitGroup < ApplicationRecord
       alternate_script = Script.find_by_name!(hash['alternate_script'])
       default_script = Script.find_by_name!(hash['default_script'])
       # alternate scripts should have the same position as the script they replace.
-      position = default_course_scripts.find_by(script: default_script).position
+      position = default_unit_group_units.find_by(script: default_script).position
       course_script = UnitGroupUnit.find_or_create_by!(unit_group: self, script: alternate_script) do |cs|
         cs.position = position
         cs.experiment_name = hash['experiment_name']
@@ -193,7 +193,7 @@ class UnitGroup < ApplicationRecord
       script = Script.find_by_name!(script_name)
       UnitGroupUnit.where(unit_group: self, script: script).destroy_all
     end
-    # Reload model so that default_course_scripts is up to date
+    # Reload model so that default_unit_group_units is up to date
     transaction {reload}
   end
 
@@ -215,7 +215,7 @@ class UnitGroup < ApplicationRecord
     info[:category_priority] = -1
     info[:script_ids] = user ?
       scripts_for_user(user).map(&:id) :
-      default_course_scripts.map(&:script_id)
+      default_unit_group_units.map(&:script_id)
     info
   end
 
@@ -350,7 +350,7 @@ class UnitGroup < ApplicationRecord
   # @param user [User]
   # @return [Array<Script>]
   def scripts_for_user(user)
-    default_course_scripts.map do |cs|
+    default_unit_group_units.map do |cs|
       select_course_script(user, cs).script
     end
   end
@@ -478,7 +478,7 @@ class UnitGroup < ApplicationRecord
   def has_progress?(user)
     return nil unless user
     user_script_ids = user.user_scripts.pluck(:script_id)
-    course_scripts_with_progress = default_course_scripts.where('course_scripts.script_id' => user_script_ids)
+    course_scripts_with_progress = default_unit_group_units.where('course_scripts.script_id' => user_script_ids)
 
     course_scripts_with_progress.count > 0
   end
@@ -490,7 +490,7 @@ class UnitGroup < ApplicationRecord
     user_script_ids = user.user_scripts.pluck(:script_id)
 
     UnitGroup.
-      joins(:default_course_scripts).
+      joins(:default_unit_group_units).
       # select only courses in the same course family.
       where("properties -> '$.family_name' = ?", family_name).
       # select only older versions

--- a/dashboard/app/models/unit_group.rb
+++ b/dashboard/app/models/unit_group.rb
@@ -372,12 +372,12 @@ class UnitGroup < ApplicationRecord
   # 4. Otherwise, show the default course script.
   #
   # @param user [User|nil]
-  # @param default_course_script [UnitGroupUnit]
+  # @param default_unit_group_unit [UnitGroupUnit]
   # @return [UnitGroupUnit]
-  def select_unit_group_unit(user, default_course_script)
-    return default_course_script unless user
+  def select_unit_group_unit(user, unit_group_unit)
+    return unit_group_unit unless user
 
-    alternates = alternate_unit_group_units.where(default_script: default_course_script.script).all
+    alternates = alternate_unit_group_units.where(default_script: unit_group_unit.script).all
 
     if user.teacher?
       alternates.each do |cs|
@@ -392,7 +392,7 @@ class UnitGroup < ApplicationRecord
           return cs if SingleUserExperiment.enabled?(user: section.teacher, experiment_name: cs.experiment_name)
         end
       end
-      return default_course_script
+      return unit_group_unit
     end
 
     if user.student?
@@ -404,7 +404,7 @@ class UnitGroup < ApplicationRecord
       end
     end
 
-    default_course_script
+    unit_group_unit
   end
 
   # @param user [User]

--- a/dashboard/app/models/unit_group.rb
+++ b/dashboard/app/models/unit_group.rb
@@ -21,7 +21,7 @@ class UnitGroup < ApplicationRecord
   has_one :plc_course, class_name: 'Plc::Course', foreign_key: 'course_id'
   has_many :default_unit_group_units, -> {where(experiment_name: nil).order('position ASC')}, class_name: 'UnitGroupUnit', dependent: :destroy, foreign_key: 'course_id'
   has_many :default_scripts, through: :default_unit_group_units, source: :script
-  has_many :alternate_course_scripts, -> {where.not(experiment_name: nil)}, class_name: 'UnitGroupUnit', dependent: :destroy, foreign_key: 'course_id'
+  has_many :alternate_unit_group_units, -> {where.not(experiment_name: nil)}, class_name: 'UnitGroupUnit', dependent: :destroy, foreign_key: 'course_id'
   has_one :course_version, as: :content_root
 
   after_save :write_serialization
@@ -117,7 +117,7 @@ class UnitGroup < ApplicationRecord
   end
 
   def summarize_alternate_scripts
-    alternates = alternate_course_scripts.all
+    alternates = alternate_unit_group_units.all
     return nil if alternates.empty?
     alternates.map do |cs|
       {
@@ -377,7 +377,7 @@ class UnitGroup < ApplicationRecord
   def select_course_script(user, default_course_script)
     return default_course_script unless user
 
-    alternates = alternate_course_scripts.where(default_script: default_course_script.script).all
+    alternates = alternate_unit_group_units.where(default_script: default_course_script.script).all
 
     if user.teacher?
       alternates.each do |cs|

--- a/dashboard/app/models/user.rb
+++ b/dashboard/app/models/user.rb
@@ -1621,7 +1621,7 @@ class User < ActiveRecord::Base
     primary_script_id = Queries::ScriptActivity.primary_script(self).try(:id)
 
     # Filter out user_scripts that are already covered by a course
-    course_scripts_script_ids = courses_as_student.map(&:default_course_scripts).flatten.pluck(:script_id).uniq
+    course_scripts_script_ids = courses_as_student.map(&:default_unit_group_units).flatten.pluck(:script_id).uniq
 
     user_scripts = Queries::ScriptActivity.in_progress_and_completed_scripts(self).
       select {|user_script| !course_scripts_script_ids.include?(user_script.script_id)}

--- a/dashboard/db/migrate/20170706223224_assign_sections_to_courses.rb
+++ b/dashboard/db/migrate/20170706223224_assign_sections_to_courses.rb
@@ -6,8 +6,8 @@ class AssignSectionsToCourses < ActiveRecord::Migration[5.0]
     # In some scenarios, csd/csp might not have been seeded yet. In that case,
     # there should be no need to run this migration.
     if csp && csd
-      csp_script_ids = csp.default_course_scripts.map(&:script_id)
-      csd_script_ids = csd.default_course_scripts.map(&:script_id)
+      csp_script_ids = csp.default_unit_group_units.map(&:script_id)
+      csd_script_ids = csd.default_unit_group_units.map(&:script_id)
 
       Section.where(script_id: csp_script_ids).update_all(course_id: csp.id)
       Section.where(script_id: csd_script_ids).update_all(course_id: csd.id)

--- a/dashboard/test/controllers/courses_controller_test.rb
+++ b/dashboard/test/controllers/courses_controller_test.rb
@@ -222,7 +222,7 @@ class CoursesControllerTest < ActionController::TestCase
     assert_response 403
   end
 
-  test "update: persists changes to default_course_scripts" do
+  test "update: persists changes to default_unit_group_units" do
     sign_in @levelbuilder
     Rails.application.config.stubs(:levelbuilder_mode).returns true
     create :unit_group, name: 'csp'
@@ -230,9 +230,9 @@ class CoursesControllerTest < ActionController::TestCase
     create :script, name: 'script2'
 
     post :update, params: {course_name: 'csp', scripts: ['script1', 'script2']}
-    default_course_scripts = UnitGroup.find_by_name('csp').default_course_scripts
-    assert_equal 2, default_course_scripts.length
-    assert_equal ['script1', 'script2'], default_course_scripts.map(&:script).map(&:name)
+    default_unit_group_units = UnitGroup.find_by_name('csp').default_unit_group_units
+    assert_equal 2, default_unit_group_units.length
+    assert_equal ['script1', 'script2'], default_unit_group_units.map(&:script).map(&:name)
 
     assert_redirected_to '/courses/csp'
   end
@@ -258,8 +258,8 @@ class CoursesControllerTest < ActionController::TestCase
       ]
     }
     course = UnitGroup.find_by_name('csp')
-    assert_equal 3, course.default_course_scripts.length
-    assert_equal ['script1', 'script2', 'script3'], course.default_course_scripts.map(&:script).map(&:name)
+    assert_equal 3, course.default_unit_group_units.length
+    assert_equal ['script1', 'script2', 'script3'], course.default_unit_group_units.map(&:script).map(&:name)
 
     assert_equal 1, course.alternate_course_scripts.length
     alternate_course_script = course.alternate_course_scripts.first
@@ -268,7 +268,7 @@ class CoursesControllerTest < ActionController::TestCase
     assert_equal 'my_experiment', alternate_course_script.experiment_name
 
     default_script = Script.find_by(name: 'script2')
-    expected_position = course.default_course_scripts.find_by(script: default_script).position
+    expected_position = course.default_unit_group_units.find_by(script: default_script).position
     assert_equal expected_position, alternate_course_script.position,
       'an alternate script must have the same position as the default script it replaces'
 

--- a/dashboard/test/controllers/courses_controller_test.rb
+++ b/dashboard/test/controllers/courses_controller_test.rb
@@ -237,7 +237,7 @@ class CoursesControllerTest < ActionController::TestCase
     assert_redirected_to '/courses/csp'
   end
 
-  test "update: persists changes to alternate_course_scripts" do
+  test "update: persists changes to alternate_unit_group_units" do
     sign_in @levelbuilder
     Rails.application.config.stubs(:levelbuilder_mode).returns true
     create :unit_group, name: 'csp'
@@ -261,8 +261,8 @@ class CoursesControllerTest < ActionController::TestCase
     assert_equal 3, course.default_unit_group_units.length
     assert_equal ['script1', 'script2', 'script3'], course.default_unit_group_units.map(&:script).map(&:name)
 
-    assert_equal 1, course.alternate_course_scripts.length
-    alternate_course_script = course.alternate_course_scripts.first
+    assert_equal 1, course.alternate_unit_group_units.length
+    alternate_course_script = course.alternate_unit_group_units.first
     assert_equal 'script2-alt', alternate_course_script.script.name
     assert_equal 'script2', alternate_course_script.default_script.name
     assert_equal 'my_experiment', alternate_course_script.experiment_name

--- a/dashboard/test/controllers/courses_controller_test.rb
+++ b/dashboard/test/controllers/courses_controller_test.rb
@@ -262,14 +262,14 @@ class CoursesControllerTest < ActionController::TestCase
     assert_equal ['script1', 'script2', 'script3'], course.default_unit_group_units.map(&:script).map(&:name)
 
     assert_equal 1, course.alternate_unit_group_units.length
-    alternate_course_script = course.alternate_unit_group_units.first
-    assert_equal 'script2-alt', alternate_course_script.script.name
-    assert_equal 'script2', alternate_course_script.default_script.name
-    assert_equal 'my_experiment', alternate_course_script.experiment_name
+    alternate_unit_group_unit = course.alternate_unit_group_units.first
+    assert_equal 'script2-alt', alternate_unit_group_unit.script.name
+    assert_equal 'script2', alternate_unit_group_unit.default_script.name
+    assert_equal 'my_experiment', alternate_unit_group_unit.experiment_name
 
     default_script = Script.find_by(name: 'script2')
     expected_position = course.default_unit_group_units.find_by(script: default_script).position
-    assert_equal expected_position, alternate_course_script.position,
+    assert_equal expected_position, alternate_unit_group_unit.position,
       'an alternate script must have the same position as the default script it replaces'
 
     assert_redirected_to '/courses/csp'

--- a/dashboard/test/models/unit_group_test.rb
+++ b/dashboard/test/models/unit_group_test.rb
@@ -107,11 +107,11 @@ class UnitGroupTest < ActiveSupport::TestCase
       course.update_scripts(['script1', 'script2'])
 
       course.reload
-      assert_equal 2, course.default_course_scripts.length
-      assert_equal 1, course.default_course_scripts[0].position
-      assert_equal 'script1', course.default_course_scripts[0].script.name
-      assert_equal 2, course.default_course_scripts[1].position
-      assert_equal 'script2', course.default_course_scripts[1].script.name
+      assert_equal 2, course.default_unit_group_units.length
+      assert_equal 1, course.default_unit_group_units[0].position
+      assert_equal 'script1', course.default_unit_group_units[0].script.name
+      assert_equal 2, course.default_unit_group_units[1].position
+      assert_equal 'script2', course.default_unit_group_units[1].script.name
     end
 
     test "remove CourseScripts" do
@@ -123,9 +123,9 @@ class UnitGroupTest < ActiveSupport::TestCase
       course.update_scripts(['script2'])
 
       course.reload
-      assert_equal 1, course.default_course_scripts.length
-      assert_equal 1, course.default_course_scripts[0].position
-      assert_equal 'script2', course.default_course_scripts[0].script.name
+      assert_equal 1, course.default_unit_group_units.length
+      assert_equal 1, course.default_unit_group_units[0].position
+      assert_equal 'script2', course.default_unit_group_units[0].script.name
     end
   end
 

--- a/dashboard/test/models/unit_group_test.rb
+++ b/dashboard/test/models/unit_group_test.rb
@@ -226,7 +226,7 @@ class UnitGroupTest < ActiveSupport::TestCase
 
       create :unit_group_unit, unit_group: @course, script: @script1, position: 1
 
-      @default_course_script = create :unit_group_unit, unit_group: @course, script: @script2, position: 2
+      @unit_group_unit = create :unit_group_unit, unit_group: @course, script: @script2, position: 2
       @alternate_course_script = create :unit_group_unit,
         unit_group: @course,
         script: @script2a,
@@ -245,8 +245,8 @@ class UnitGroupTest < ActiveSupport::TestCase
 
     test 'select default course script for teacher without experiment' do
       assert_equal(
-        @default_course_script,
-        @course.select_unit_group_unit(@other_teacher, @default_course_script)
+        @unit_group_unit,
+        @course.select_unit_group_unit(@other_teacher, @unit_group_unit)
       )
     end
 
@@ -254,15 +254,15 @@ class UnitGroupTest < ActiveSupport::TestCase
       experiment = create :single_user_experiment, min_user_id: @other_teacher.id, name: 'my-experiment'
       assert_equal(
         @alternate_course_script,
-        @course.select_unit_group_unit(@other_teacher, @default_course_script)
+        @course.select_unit_group_unit(@other_teacher, @unit_group_unit)
       )
       experiment.destroy
     end
 
     test 'select default course script for student by default' do
       assert_equal(
-        @default_course_script,
-        @course.select_unit_group_unit(@student, @default_course_script)
+        @unit_group_unit,
+        @course.select_unit_group_unit(@student, @unit_group_unit)
       )
     end
 
@@ -271,7 +271,7 @@ class UnitGroupTest < ActiveSupport::TestCase
       experiment = create :single_user_experiment, min_user_id: @course_teacher.id, name: 'my-experiment'
       assert_equal(
         @alternate_course_script,
-        @course.select_unit_group_unit(@student, @default_course_script)
+        @course.select_unit_group_unit(@student, @unit_group_unit)
       )
       experiment.destroy
     end
@@ -280,8 +280,8 @@ class UnitGroupTest < ActiveSupport::TestCase
       create :follower, section: @other_section, student_user: @student
       experiment = create :single_user_experiment, min_user_id: @other_teacher.id, name: 'my-experiment'
       assert_equal(
-        @default_course_script,
-        @course.select_unit_group_unit(@student, @default_course_script)
+        @unit_group_unit,
+        @course.select_unit_group_unit(@student, @unit_group_unit)
       )
       experiment.destroy
     end
@@ -290,7 +290,7 @@ class UnitGroupTest < ActiveSupport::TestCase
       create :user_script, user: @student, script: @script2a
       assert_equal(
         @alternate_course_script,
-        @course.select_unit_group_unit(@student, @default_course_script)
+        @course.select_unit_group_unit(@student, @unit_group_unit)
       )
     end
 
@@ -298,8 +298,8 @@ class UnitGroupTest < ActiveSupport::TestCase
       create :follower, section: @course_section, student_user: @student
       create :user_script, user: @student, script: @script2a
       assert_equal(
-        @default_course_script,
-        @course.select_unit_group_unit(@student, @default_course_script)
+        @unit_group_unit,
+        @course.select_unit_group_unit(@student, @unit_group_unit)
       )
     end
   end

--- a/dashboard/test/models/unit_group_test.rb
+++ b/dashboard/test/models/unit_group_test.rb
@@ -227,7 +227,7 @@ class UnitGroupTest < ActiveSupport::TestCase
       create :unit_group_unit, unit_group: @course, script: @script1, position: 1
 
       @unit_group_unit = create :unit_group_unit, unit_group: @course, script: @script2, position: 2
-      @alternate_course_script = create :unit_group_unit,
+      @alternate_unit_group_unit = create :unit_group_unit,
         unit_group: @course,
         script: @script2a,
         position: 2,
@@ -253,7 +253,7 @@ class UnitGroupTest < ActiveSupport::TestCase
     test 'select alternate course script for teacher with experiment' do
       experiment = create :single_user_experiment, min_user_id: @other_teacher.id, name: 'my-experiment'
       assert_equal(
-        @alternate_course_script,
+        @alternate_unit_group_unit,
         @course.select_unit_group_unit(@other_teacher, @unit_group_unit)
       )
       experiment.destroy
@@ -270,7 +270,7 @@ class UnitGroupTest < ActiveSupport::TestCase
       create :follower, section: @course_section, student_user: @student
       experiment = create :single_user_experiment, min_user_id: @course_teacher.id, name: 'my-experiment'
       assert_equal(
-        @alternate_course_script,
+        @alternate_unit_group_unit,
         @course.select_unit_group_unit(@student, @unit_group_unit)
       )
       experiment.destroy
@@ -289,7 +289,7 @@ class UnitGroupTest < ActiveSupport::TestCase
     test 'select alternate course script for student with progress' do
       create :user_script, user: @student, script: @script2a
       assert_equal(
-        @alternate_course_script,
+        @alternate_unit_group_unit,
         @course.select_unit_group_unit(@student, @unit_group_unit)
       )
     end

--- a/dashboard/test/models/unit_group_test.rb
+++ b/dashboard/test/models/unit_group_test.rb
@@ -246,7 +246,7 @@ class UnitGroupTest < ActiveSupport::TestCase
     test 'select default course script for teacher without experiment' do
       assert_equal(
         @default_course_script,
-        @course.select_course_script(@other_teacher, @default_course_script)
+        @course.select_unit_group_unit(@other_teacher, @default_course_script)
       )
     end
 
@@ -254,7 +254,7 @@ class UnitGroupTest < ActiveSupport::TestCase
       experiment = create :single_user_experiment, min_user_id: @other_teacher.id, name: 'my-experiment'
       assert_equal(
         @alternate_course_script,
-        @course.select_course_script(@other_teacher, @default_course_script)
+        @course.select_unit_group_unit(@other_teacher, @default_course_script)
       )
       experiment.destroy
     end
@@ -262,7 +262,7 @@ class UnitGroupTest < ActiveSupport::TestCase
     test 'select default course script for student by default' do
       assert_equal(
         @default_course_script,
-        @course.select_course_script(@student, @default_course_script)
+        @course.select_unit_group_unit(@student, @default_course_script)
       )
     end
 
@@ -271,7 +271,7 @@ class UnitGroupTest < ActiveSupport::TestCase
       experiment = create :single_user_experiment, min_user_id: @course_teacher.id, name: 'my-experiment'
       assert_equal(
         @alternate_course_script,
-        @course.select_course_script(@student, @default_course_script)
+        @course.select_unit_group_unit(@student, @default_course_script)
       )
       experiment.destroy
     end
@@ -281,7 +281,7 @@ class UnitGroupTest < ActiveSupport::TestCase
       experiment = create :single_user_experiment, min_user_id: @other_teacher.id, name: 'my-experiment'
       assert_equal(
         @default_course_script,
-        @course.select_course_script(@student, @default_course_script)
+        @course.select_unit_group_unit(@student, @default_course_script)
       )
       experiment.destroy
     end
@@ -290,7 +290,7 @@ class UnitGroupTest < ActiveSupport::TestCase
       create :user_script, user: @student, script: @script2a
       assert_equal(
         @alternate_course_script,
-        @course.select_course_script(@student, @default_course_script)
+        @course.select_unit_group_unit(@student, @default_course_script)
       )
     end
 
@@ -299,7 +299,7 @@ class UnitGroupTest < ActiveSupport::TestCase
       create :user_script, user: @student, script: @script2a
       assert_equal(
         @default_course_script,
-        @course.select_course_script(@student, @default_course_script)
+        @course.select_unit_group_unit(@student, @default_course_script)
       )
     end
   end

--- a/dashboard/test/models/unit_group_test.rb
+++ b/dashboard/test/models/unit_group_test.rb
@@ -240,7 +240,7 @@ class UnitGroupTest < ActiveSupport::TestCase
     test 'course script test data is properly initialized' do
       assert_equal 'my-course', @course.name
       assert_equal %w(script1 script2 script3), @course.default_scripts.map(&:name)
-      assert_equal %w(script2a), @course.alternate_course_scripts.map(&:script).map(&:name)
+      assert_equal %w(script2a), @course.alternate_unit_group_units.map(&:script).map(&:name)
     end
 
     test 'select default course script for teacher without experiment' do


### PR DESCRIPTION
These 3 PRs rename CourseScript to UnitGroupUnit everywhere I can find in ruby code, finishing [PLAT-235](https://codedotorg.atlassian.net/browse/PLAT-235). These PRs to not rename the database table, and they do not rename things like default_script which actually refer to a script object.

* Step 1: #36063
* Step 2: #36066 <-- this PR
* Step 3: #36067

##  Testing story

I am relying on existing test coverage to validate these changes.

## Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
