### PR TITLE
More unit group unit renames

### DIFF
--- a/dashboard/app/models/script.rb
+++ b/dashboard/app/models/script.rb
@@ -1436,9 +1436,9 @@ class Script < ActiveRecord::Base
   # due to existing progress or a course experiment, return that script. Otherwise,
   # return nil.
   def alternate_script(user)
-    unit_group_units.each do |cs|
-      alternate_cs = cs.unit_group.select_unit_group_unit(user, cs)
-      return alternate_cs.script if cs != alternate_cs
+    unit_group_units.each do |ugu|
+      alternate_ugu = ugu.unit_group.select_unit_group_unit(user, ugu)
+      return alternate_ugu.script if ugu != alternate_ugu
     end
     nil
   end

--- a/dashboard/app/models/unit_group.rb
+++ b/dashboard/app/models/unit_group.rb
@@ -166,10 +166,10 @@ class UnitGroup < ApplicationRecord
 
     new_scripts.each_with_index do |script_name, index|
       script = Script.find_by_name!(script_name)
-      course_script = UnitGroupUnit.find_or_create_by!(unit_group: self, script: script) do |cs|
+      unit_group_unit = UnitGroupUnit.find_or_create_by!(unit_group: self, script: script) do |cs|
         cs.position = index + 1
       end
-      course_script.update!(position: index + 1)
+      unit_group_unit.update!(position: index + 1)
     end
 
     alternate_scripts.each do |hash|
@@ -177,12 +177,12 @@ class UnitGroup < ApplicationRecord
       default_script = Script.find_by_name!(hash['default_script'])
       # alternate scripts should have the same position as the script they replace.
       position = default_unit_group_units.find_by(script: default_script).position
-      course_script = UnitGroupUnit.find_or_create_by!(unit_group: self, script: alternate_script) do |cs|
+      unit_group_unit = UnitGroupUnit.find_or_create_by!(unit_group: self, script: alternate_script) do |cs|
         cs.position = position
         cs.experiment_name = hash['experiment_name']
         cs.default_script = default_script
       end
-      course_script.update!(
+      unit_group_unit.update!(
         position: position,
         experiment_name: hash['experiment_name'],
         default_script: default_script
@@ -478,9 +478,9 @@ class UnitGroup < ApplicationRecord
   def has_progress?(user)
     return nil unless user
     user_script_ids = user.user_scripts.pluck(:script_id)
-    course_scripts_with_progress = default_unit_group_units.where('course_scripts.script_id' => user_script_ids)
+    unit_group_units_with_progress = default_unit_group_units.where('course_scripts.script_id' => user_script_ids)
 
-    course_scripts_with_progress.count > 0
+    unit_group_units_with_progress.count > 0
   end
 
   # @param user [User]

--- a/dashboard/app/models/unit_group.rb
+++ b/dashboard/app/models/unit_group.rb
@@ -160,7 +160,7 @@ class UnitGroup < ApplicationRecord
   def update_scripts(new_scripts, alternate_scripts = nil)
     alternate_scripts ||= []
     new_scripts = new_scripts.reject(&:empty?)
-    # we want to delete existing course scripts that aren't in our new list
+    # we want to delete existing unit group units that aren't in our new list
     scripts_to_delete = default_unit_group_units.map(&:script).map(&:name) - new_scripts
     scripts_to_delete -= alternate_scripts.map {|hash| hash['alternate_script']}
 
@@ -255,7 +255,7 @@ class UnitGroup < ApplicationRecord
 
   # @param user [User]
   # @returns [Boolean] Whether the user has any experiment enabled which is
-  #   associated with an alternate course script.
+  #   associated with an alternate unit group unit.
   def self.has_any_course_experiments?(user)
     Experiment.any_enabled?(user: user, experiment_names: UnitGroupUnit.experiments)
   end
@@ -355,21 +355,21 @@ class UnitGroup < ApplicationRecord
     end
   end
 
-  # Return an alternate course script associated with the specified default
-  # course script (or the default course script itself) by evaluating these
+  # Return an alternate unit group unit associated with the specified default
+  # unit group unit (or the default unit group unit itself) by evaluating these
   # rules in order:
   #
   # 1. If the user is a teacher, and they have a course experiment enabled,
-  # show the corresponding alternate course script.
+  # show the corresponding alternate unit group unit.
   #
   # 2. If the user is in a section assigned to this course: show an alternate
-  # course script if any section's teacher is in a corresponding course
-  # experiment, otherwise show the default course script.
+  # unit group unit if any section's teacher is in a corresponding course
+  # experiment, otherwise show the default unit group unit.
   #
-  # 3. If the user is a student and has progress in an alternate course script,
-  # show the alternate course script.
+  # 3. If the user is a student and has progress in an alternate unit group unit,
+  # show the alternate unit group unit.
   #
-  # 4. Otherwise, show the default course script.
+  # 4. Otherwise, show the default unit group unit.
   #
   # @param user [User|nil]
   # @param default_unit_group_unit [UnitGroupUnit]

--- a/dashboard/app/models/user.rb
+++ b/dashboard/app/models/user.rb
@@ -1621,10 +1621,10 @@ class User < ActiveRecord::Base
     primary_script_id = Queries::ScriptActivity.primary_script(self).try(:id)
 
     # Filter out user_scripts that are already covered by a course
-    course_scripts_script_ids = courses_as_student.map(&:default_unit_group_units).flatten.pluck(:script_id).uniq
+    unit_group_units_script_ids = courses_as_student.map(&:default_unit_group_units).flatten.pluck(:script_id).uniq
 
     user_scripts = Queries::ScriptActivity.in_progress_and_completed_scripts(self).
-      select {|user_script| !course_scripts_script_ids.include?(user_script.script_id)}
+      select {|user_script| !unit_group_units_script_ids.include?(user_script.script_id)}
 
     user_script_data = user_scripts.map do |user_script|
       # Skip this script if we are excluding the primary script and this is the

--- a/dashboard/test/models/script_test.rb
+++ b/dashboard/test/models/script_test.rb
@@ -636,7 +636,7 @@ class ScriptTest < ActiveSupport::TestCase
     assert script.can_view_version?(student)
   end
 
-  test 'can_view_version? is true if student has progress in course script belongs to' do
+  test 'can_view_version? is true if student has progress in unit group unit belongs to' do
     unit_group = create :unit_group, family_name: 'script-fam'
     script1 = create :script, name: 'script1', family_name: 'script-fam'
     create :unit_group_unit, unit_group: unit_group, script: script1, position: 1

--- a/dashboard/test/models/unit_group_test.rb
+++ b/dashboard/test/models/unit_group_test.rb
@@ -237,20 +237,20 @@ class UnitGroupTest < ActiveSupport::TestCase
       create :unit_group_unit, unit_group: @course, script: @script3, position: 3
     end
 
-    test 'course script test data is properly initialized' do
+    test 'unit group unit test data is properly initialized' do
       assert_equal 'my-course', @course.name
       assert_equal %w(script1 script2 script3), @course.default_scripts.map(&:name)
       assert_equal %w(script2a), @course.alternate_unit_group_units.map(&:script).map(&:name)
     end
 
-    test 'select default course script for teacher without experiment' do
+    test 'select default unit group unit for teacher without experiment' do
       assert_equal(
         @unit_group_unit,
         @course.select_unit_group_unit(@other_teacher, @unit_group_unit)
       )
     end
 
-    test 'select alternate course script for teacher with experiment' do
+    test 'select alternate unit group unit for teacher with experiment' do
       experiment = create :single_user_experiment, min_user_id: @other_teacher.id, name: 'my-experiment'
       assert_equal(
         @alternate_unit_group_unit,
@@ -259,14 +259,14 @@ class UnitGroupTest < ActiveSupport::TestCase
       experiment.destroy
     end
 
-    test 'select default course script for student by default' do
+    test 'select default unit group unit for student by default' do
       assert_equal(
         @unit_group_unit,
         @course.select_unit_group_unit(@student, @unit_group_unit)
       )
     end
 
-    test 'select alternate course script for student when course teacher has experiment' do
+    test 'select alternate unit group unit for student when course teacher has experiment' do
       create :follower, section: @course_section, student_user: @student
       experiment = create :single_user_experiment, min_user_id: @course_teacher.id, name: 'my-experiment'
       assert_equal(
@@ -276,7 +276,7 @@ class UnitGroupTest < ActiveSupport::TestCase
       experiment.destroy
     end
 
-    test 'select default course script for student when other teacher has experiment' do
+    test 'select default unit group unit for student when other teacher has experiment' do
       create :follower, section: @other_section, student_user: @student
       experiment = create :single_user_experiment, min_user_id: @other_teacher.id, name: 'my-experiment'
       assert_equal(
@@ -286,7 +286,7 @@ class UnitGroupTest < ActiveSupport::TestCase
       experiment.destroy
     end
 
-    test 'select alternate course script for student with progress' do
+    test 'select alternate unit group unit for student with progress' do
       create :user_script, user: @student, script: @script2a
       assert_equal(
         @alternate_unit_group_unit,

--- a/dashboard/test/models/user_test.rb
+++ b/dashboard/test/models/user_test.rb
@@ -3311,9 +3311,9 @@ class UserTest < ActiveSupport::TestCase
       teacher = create :teacher
 
       course = create :unit_group, name: 'testcourse'
-      course_script1 = create :unit_group_unit, unit_group: course, script: (create :script, name: 'testscript1'), position: 1
+      unit_group_unit1 = create :unit_group_unit, unit_group: course, script: (create :script, name: 'testscript1'), position: 1
       create :unit_group_unit, unit_group: course, script: (create :script, name: 'testscript2'), position: 2
-      create :user_script, user: student, script: course_script1.script, started_at: (Time.now - 1.day)
+      create :user_script, user: student, script: unit_group_unit1.script, started_at: (Time.now - 1.day)
 
       other_script = create :script, name: 'otherscript'
       create :user_script, user: student, script: other_script, started_at: (Time.now - 1.hour)


### PR DESCRIPTION
These 3 PRs rename CourseScript to UnitGroupUnit everywhere I can find in ruby code, finishing [PLAT-235](https://codedotorg.atlassian.net/browse/PLAT-235). These PRs to not rename the database table, and they do not rename things like default_script which actually refer to a script object.

* Step 1: #36063
* Step 2: #36066
* Step 3: #36067 <-- this PR

##  Testing story

I am relying on existing test coverage to validate these changes.

## Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
