### PR TITLE
Make Buffer#schedule_flush thread safe

### DIFF
--- a/lib/test/cdo/test_buffer.rb
+++ b/lib/test/cdo/test_buffer.rb
@@ -1,5 +1,6 @@
 require_relative '../test_helper'
 require 'cdo/buffer'
+require 'benchmark'
 
 class BufferTest < Minitest::Test
   class TestBuffer < Cdo::Buffer
@@ -81,16 +82,14 @@ class BufferTest < Minitest::Test
   end
 
   def test_min_interval
-    b = TestBuffer.new(batch_count: 1, min_interval: 0.1)
-    start = Concurrent.monotonic_time
-    4.times {b.buffer('foo')}
-    b.flush!
-    finish = Concurrent.monotonic_time
-    assert_equal 4, b.flushes
-    time_taken = finish - start
-    # Given a min_interval of 1 second and 4 flushes, assert the flush! takes 3-4 seconds.
-    assert_operator time_taken, :>, 0.3
-    assert_operator time_taken, :<, 0.4
+    n = 4
+    interval = 0.1
+
+    b = TestBuffer.new(batch_count: 1, min_interval: interval)
+    Array.new(n) {Thread.new {b.buffer('foo')}}.each(&:join)
+    # Assert the flush! takes the expected amount of time to complete.
+    assert_in_delta (n - 1) * interval, Benchmark.realtime {b.flush!}, interval / 2
+    assert_equal n, b.flushes
   end
 
   def test_min_interval_no_flush


### PR DESCRIPTION
Fixes two thread-safety bugs in `Buffer#schedule_flush`:

- If an asynchronous buffer flush occurs between lines 96 and 97 (below), an unnecessary flush may occur: https://github.com/code-dot-org/code-dot-org/blob/0c75d04525e6682c7b223235f888080e34d7bd76/lib/cdo/buffer.rb#L96-L97
- If multiple threads call `#buffer` concurrently, unnecessary flush may occur.

## Links

- [INF-354](https://codedotorg.atlassian.net/browse/INF-354)

## Testing story

Manually ran `test_min_interval` in a tight loop to reproduce the first thread-safety issue as a test failure, and confirmed it no longer occurs with this fix.
Also updated [`test_min_interval`](https://github.com/code-dot-org/code-dot-org/pull/36072/files#diff-bf9349c792dae82036b12816c70eb070L83-L94) to call `#buffer` from multiple threads to cover the second issue.