### PR TITLE
Buffer reschedule task

### DIFF
--- a/lib/test/cdo/test_buffer.rb
+++ b/lib/test/cdo/test_buffer.rb
@@ -1,5 +1,6 @@
 require_relative '../test_helper'
 require 'cdo/buffer'
+require 'benchmark'
 
 class BufferTest < Minitest::Test
   class TestBuffer < Cdo::Buffer
@@ -81,13 +82,16 @@ class BufferTest < Minitest::Test
   end
 
   def test_min_interval
-    b = TestBuffer.new(batch_count: 1, min_interval: 0.1)
-    start = Concurrent.monotonic_time
-    4.times {b.buffer('foo')}
-    b.flush!
-    finish = Concurrent.monotonic_time
-    assert_equal 4, b.flushes
-    time_taken = finish - start
+    n = 4
+    interval = 0.1
+
+    b = TestBuffer.new(batch_count: 1, min_interval: interval)
+    time_taken = Benchmark.realtime do
+      Array.new(n) {Thread.new {b.buffer('foo')}}.each(&:join)
+      b.flush!
+    end
+    assert_equal n, b.flushes
+
     # Given a min_interval of 1 second and 4 flushes, assert the flush! takes 3-4 seconds.
     assert_operator time_taken, :>, 0.3
     assert_operator time_taken, :<, 0.4


### PR DESCRIPTION
Alternate approach to #36072 to fix thread-safety issues in `Buffer#schedule_flush`. This PR extends the `Concurrent::ScheduledTask` class in `RescheduledTask` to support rescheduling a task after it has already been executed, so a single instance can be reused for multiple executions (instead of multiple immutable instances, one representing each individual task execution). I think this better matches how tasks are scheduled for flushing by `Buffer` since all flushes are drawing from the same shared buffer, and makes it a little easier to reason about the implementation since only a single instance of `RescheduledTask` is ever created during initialization.

I also made a slight change to use `with_observer` to call the subsequent `schedule_flush` instead of within the task block- this gets called after the task has completed and is no longer in the `:processing` state so the same task can get rescheduled cleanly.

## Links

- [INF-354](https://codedotorg.atlassian.net/browse/INF-354)

## Testing story

Same tests as in #36072:
Manually ran `test_min_interval` in a tight loop to reproduce the first thread-safety issue as a test failure, and confirmed it no longer occurs with this fix.
Also updated [`test_min_interval`](https://github.com/code-dot-org/code-dot-org/pull/36072/files#diff-bf9349c792dae82036b12816c70eb070L83-L94) to call `#buffer` from multiple threads to cover the second issue.