### PR TITLE
Created migration to add 'time_spent' to 'user_levels' table

### DIFF
--- a/dashboard/app/models/user_level.rb
+++ b/dashboard/app/models/user_level.rb
@@ -14,6 +14,7 @@
 #  submitted        :boolean
 #  readonly_answers :boolean
 #  unlocked_at      :datetime
+#  time_spent       :integer
 #
 # Indexes
 #

--- a/dashboard/db/migrate/20200730194330_add_time_spent_to_user_levels.rb
+++ b/dashboard/db/migrate/20200730194330_add_time_spent_to_user_levels.rb
@@ -1,0 +1,7 @@
+class AddTimeSpentToUserLevels < ActiveRecord::Migration[5.0]
+  def change
+    # This change will be implemented on production using the MySQL gh-ost tool.
+    return if Rails.env.production?
+    add_column :user_levels, :time_spent, :integer
+  end
+end

--- a/dashboard/db/schema.rb
+++ b/dashboard/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20200728201407) do
+ActiveRecord::Schema.define(version: 20200730194330) do
 
   create_table "activities", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci" do |t|
     t.integer  "user_id"
@@ -1588,6 +1588,7 @@ ActiveRecord::Schema.define(version: 20200728201407) do
     t.boolean  "submitted"
     t.boolean  "readonly_answers"
     t.datetime "unlocked_at"
+    t.integer  "time_spent"
     t.index ["user_id", "level_id", "script_id"], name: "index_user_levels_on_user_id_and_level_id_and_script_id", unique: true, using: :btree
   end
 


### PR DESCRIPTION
This is part of a larger effort to make various [improvements to the progress tab](https://docs.google.com/document/d/11vid6ZWkpUV5TJm3swI6kbdSpg5_93UHDxnod58r_Zc/edit#) to start displaying more data to teachers about their students' progress.

`time_spent` will allow teachers to see how long a student has been working on a level. This will help teachers identify which students are struggling. Additionally, it will help us identify which levels are difficult and which are easy.

The user_levels table is massive. There are more than 2 billion entries in the table. More than half of these refer to levels where would want to start tracking time spent.

The `time_spent` field needs to be query-able so we can run analysis on it. Additionally, it needs to be recorded for at least half of new `user_level` entries. Therefore, it made sense to directly add it as a column on `user_levels`.

Since the table is so large on production, we can't directly add a column via a normal DB migration. Doing so could cause downtime and has been [unsuccessful so far in load tests](https://codedotorg.slack.com/archives/C03CK49G9/p1595882733257900). Instead, we plan to use `gh-ost` to add this column safely on production. The DB tables for the other environments are much smaller and therefore do not have this same concern.

<!--
  Your description goes here: A summary of the change, including any relevant motivation and context.

  If relevant, include a description both of the existing behavior and of the new behavior.
-->

<!--
  Other aspects to consider. uncomment and add detail for any that seem necessary:
-->

<!-- ### Background -->
<!-- ### Privacy -->
<!-- ### Security -->
<!-- ### Caching -->
<!-- ### Deployment strategy -->
<!-- ### Future work -->

## Links

<!--
  Any relevant links to external resources; ie, specification documents, jira
  items, related PRs, honeybadger errors, etc
-->

- [LP-818](https://codedotorg.atlassian.net/browse/LP-818)
- [Recording Time Spent Plan](https://docs.google.com/document/d/1sSxS1C0XHokLh34ObposdzI0I1FwCY7qJXmn0mtpwi0/edit?ts=5d8932a9&pli=1)
- [Slack thread regarding load tests](https://codedotorg.slack.com/archives/C03CK49G9/p1595882733257900)
- [improvements to the progress tab](https://docs.google.com/document/d/11vid6ZWkpUV5TJm3swI6kbdSpg5_93UHDxnod58r_Zc/edit#)
- [previous attempt of this PR](https://github.com/code-dot-org/code-dot-org/pull/31231)

## Testing story

<!--
  Does your change include appropriate tests?

  If so, please describe how the tests included in this PR are sufficient

  If not, please explain why this change does not need to be tested.
-->

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
