### PR TITLE
Revert "Bump blockly to 3.5.28"

### DIFF
--- a/apps/package.json
+++ b/apps/package.json
@@ -49,7 +49,7 @@
     "@babel/preset-react": "^7.0.0",
     "@cdo/interpreted": "link:../dashboard/config/libraries",
     "@code-dot-org/artist": "0.2.1",
-    "@code-dot-org/blockly": "3.5.28",
+    "@code-dot-org/blockly": "3.5.26",
     "@code-dot-org/bramble": "0.1.26",
     "@code-dot-org/craft": "0.2.2",
     "@code-dot-org/dance-party": "1.0.1",

--- a/apps/yarn.lock
+++ b/apps/yarn.lock
@@ -1526,10 +1526,10 @@
   version "0.2.1"
   resolved "https://registry.yarnpkg.com/@code-dot-org/artist/-/artist-0.2.1.tgz#fcfe7ea5cfb3f19ddb6b912e70e922ba4b7ef0b1"
 
-"@code-dot-org/blockly@3.5.28":
-  version "3.5.28"
-  resolved "https://registry.yarnpkg.com/@code-dot-org/blockly/-/blockly-3.5.28.tgz#b5a267b02747a72b2c9c6cf2f9dc4cd110d6b07e"
-  integrity sha512-b7DgFzlQeJpzDOc+xvnqkmbrikU/piDbpXMfaa3fUYgmif3yjeYqSWvpodf9iJ4EG1yOT1AKb8PGfiEv7KUDig==
+"@code-dot-org/blockly@3.5.26":
+  version "3.5.26"
+  resolved "https://registry.yarnpkg.com/@code-dot-org/blockly/-/blockly-3.5.26.tgz#83ca5ebceaa531d8334a93a1db886480ea4d1bf7"
+  integrity sha512-U5p5YDfCZa9gibiL/ybH0sA6rxDDiInBgrL/lqpeqkJlJsJS6yRl61zWROho23K/7rmaoYjqPwG/3pHKLakcng==
 
 "@code-dot-org/bramble@0.1.26":
   version "0.1.26"


### PR DESCRIPTION
Reverts code-dot-org/code-dot-org#36065

[Slack thread](https://codedotorg.slack.com/archives/C1B3PNDL7/p1596136365443500)

Reverting because the associated change does not work for RTL languages:
![Screen Shot 2020-07-30 at 1 02 28 PM](https://user-images.githubusercontent.com/9812299/88969166-46d33c80-d265-11ea-910f-09e22487343f.png)
