### PR TITLE
trigger i18n load before stubbing File.read in unit tests

### DIFF
--- a/dashboard/test/models/levels/bubble_choice_test.rb
+++ b/dashboard/test/models/levels/bubble_choice_test.rb
@@ -229,6 +229,9 @@ DSL
       level 'sublevel_3_copy'
     DSL
 
+    # access a translation, to trigger any file reads, before we stub File.read
+    I18n.t('auth.signed_in')
+
     File.stubs(:exist?).returns(true)
     File.stubs(:read).with {|filepath| filepath.to_s.end_with?('bubble_choice.bubble_choice')}.returns(input_dsl).once
 

--- a/dashboard/test/models/levels/bubble_choice_test.rb
+++ b/dashboard/test/models/levels/bubble_choice_test.rb
@@ -229,7 +229,9 @@ DSL
       level 'sublevel_3_copy'
     DSL
 
-    # access a translation, to trigger any file reads, before we stub File.read
+    # Access a translation, to trigger any file reads, before we stub File.read.
+    # According to https://guides.rubyonrails.org/i18n.html, The translation
+    # files are lazy-loaded when a translation is looked up for the first time.
     I18n.t('auth.signed_in')
 
     File.stubs(:exist?).returns(true)


### PR DESCRIPTION
Attempts to deflake a bubble choice test which appears to unexpectedly load various i18n files after stubbing File.read. For context, see: https://codedotorg.slack.com/archives/CNZP84FJ5/p1596134943136000

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
