### PR TITLE
populate redshift courses table from dashboard unit_groups table

### DIFF
--- a/aws/dms/tasks.yml
+++ b/aws/dms/tasks.yml
@@ -47,7 +47,8 @@ cron:
 - dashboard.levels
 - dashboard.script_levels
 - dashboard.levels_script_levels
-- dashboard.courses
+- dashboard.unit_groups
+    rename: courses
 - dashboard.course_scripts
 - dashboard.survey_results
 - dashboard.sections

--- a/aws/dms/tasks.yml
+++ b/aws/dms/tasks.yml
@@ -47,7 +47,7 @@ cron:
 - dashboard.levels
 - dashboard.script_levels
 - dashboard.levels_script_levels
-- dashboard.unit_groups
+- dashboard.unit_groups:
     rename: courses
 - dashboard.course_scripts
 - dashboard.survey_results

--- a/lib/cdo/aws/dms.rb
+++ b/lib/cdo/aws/dms.rb
@@ -38,28 +38,15 @@ module Cdo
             'rule-action': 'include'
           }
 
-          if properties && properties['rename']
-            rules << {
-              'rule-type': 'transformation',
-              'rule-action': 'add-prefix',
-              'rule-target': 'table',
-              'object-locator': {
-                'schema-name': schema,
-                'table-name': table,
-              },
-              'value': RedshiftImport::TEMP_TABLE_PREFIX
-            }
-          end
-
           # Add transformation rule to prefix target table name with '_import_', so we import each production MySQL
           # table to a staging Redshift table, which is later swapped into the target table when the FULL LOAD is
           # complete.
 
           # Optionally, the configuration file can specify a new target table name.
-          target_table_name = properties['rename'] ? properties['rename'] : table
+          target_table_name = properties && properties['rename'] ? properties['rename'] : table
 
           # Optionally, the configuration file can specify that no temp/staging prefix should be used.
-          prefix = properties['skip_staging_table'] ? '' : RedshiftImport::TEMP_TABLE_PREFIX
+          prefix = properties && properties['skip_staging_table'] ? '' : RedshiftImport::TEMP_TABLE_PREFIX
 
           rules << {
             'rule-type': 'transformation',


### PR DESCRIPTION
Follow-on to #35949. To be merged alongside #35952.

Discussion with Infra team: https://codedotorg.slack.com/archives/C03CK49G9/p1596053230287400 

Discussion with data team: https://codedotorg.slack.com/archives/C0SUN2W3D/p1595878192355900

## Testing story

partial output from `bundle exec rake stack:data:validate RAILS_ENV=production VERBOSE=1`:

```
Listing changes to existing stack `DATA-production`:
Modify DMSCronLevelSourcesPii [AWS::DMS::ReplicationTask] Properties Replacement: Conditional (TableMappings)
Modify DMSCronPii [AWS::DMS::ReplicationTask] Properties Replacement: Conditional (TableMappings)
Modify DMSCronUserHierarchyPii [AWS::DMS::ReplicationTask] Properties Replacement: Conditional (TableMappings)
Modify DMSCronUserHierarchy [AWS::DMS::ReplicationTask] Properties Replacement: Conditional (TableMappings)
Modify DMSCronUserLevels [AWS::DMS::ReplicationTask] Properties Replacement: Conditional (TableMappings)
Modify DMSCron [AWS::DMS::ReplicationTask] Properties Replacement: Conditional (TableMappings)
```

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
