### PR TITLE
Temporarily re-enable Aurora binary logging

### DIFF
--- a/aws/cloudformation/data.yml.erb
+++ b/aws/cloudformation/data.yml.erb
@@ -59,8 +59,7 @@ Resources:
       KmsKeyId: alias/aws/redshift
       MasterUsername: {Ref: RedshiftUsername}
       MasterUserPassword: {Ref: RedshiftPassword}
-      NodeType: ra3.4xlarge
-      NumberOfNodes: 3
+      NodeType: dc1.large
       PubliclyAccessible: true
       VpcSecurityGroupIds: [!ImportValue VPC-RedshiftSecurityGroup]
   TableauSync:

--- a/aws/cloudformation/db_parameters.yml.erb
+++ b/aws/cloudformation/db_parameters.yml.erb
@@ -143,8 +143,16 @@ Reporting:
 
 # System variables for the Aurora DB cluster.
 AuroraCluster: &aurora
-  # Disable binary logging to improve write performance.
-  binlog_format: 'OFF'
+  # When using row-based logging, the master writes events to the binary log that indicate how individual table rows are changed.
+  # Replication of the master to the slave works by copying the events representing the changes to the table rows to the slave.
+  # ROW required for DMS Change Data Capture:
+  # https://docs.aws.amazon.com/dms/latest/userguide/CHAP_Source.MySQL.html#CHAP_Source.MySQL.AmazonManaged
+  binlog_format: ROW
+  # When enabled, this variable causes the master to write a checksum for each event in the binary log.
+  # When disabled (value NONE), write and check the event length (rather than a checksum) for each event.
+  # NONE required for DMS Change Data Capture:
+  # https://docs.aws.amazon.com/dms/latest/userguide/CHAP_Source.MySQL.html#CHAP_Source.MySQL.AmazonManaged
+  binlog_checksum: NONE
 
   # Enable GTIDs: https://aws.amazon.com/blogs/database/amazon-aurora-for-mysql-compatibility-now-supports-global-transaction-identifiers-gtids-replication/
   gtid-mode: ON_PERMISSIVE


### PR DESCRIPTION
Temporarily re-enable binary logging during a low-traffic time period (summer) so that we can use [gh-ost](https://github.com/github/gh-ost) to apply an online schema change to large table (#36082).

## Test

```
$bundle exec rake stack:data:validate RAILS_ENV=production

Listing changes to existing stack `DATA-production`:
Modify AuroraClusterDBParameters [AWS::RDS::DBClusterParameterGroup] Properties (Parameters)
Modify AuroraReportingClusterDBParameters [AWS::RDS::DBClusterParameterGroup] Properties (Parameters)
```

## Deployment Steps
[AWS guidance](https://aws.amazon.com/premiumsupport/knowledge-center/enable-binary-logging-aurora/) is to restart the writer after applying the ParameterGroup update. This will trigger restart of the readers as well.