### PR TITLE
rename course to plc_course in ruby variable names

### DIFF
--- a/dashboard/app/controllers/peer_reviews_controller.rb
+++ b/dashboard/app/controllers/peer_reviews_controller.rb
@@ -15,12 +15,12 @@ class PeerReviewsController < ApplicationController
   end
 
   def dashboard
-    courses = Plc::Course.all.select {|course| course.plc_course_units.map(&:script).any?(&:peer_reviews_to_complete?)}
+    plc_courses = Plc::Course.all.select {|course| course.plc_course_units.map(&:script).any?(&:peer_reviews_to_complete?)}
 
-    @course_list = courses.map {|course| [course.name, course.id]}
+    @course_list = plc_courses.map {|course| [course.name, course.id]}
 
     @course_unit_map = {}.tap do |course_unit_map|
-      courses.each do |course|
+      plc_courses.each do |course|
         course_unit_map[course.id] = course.plc_course_units.map {|course_unit| [course_unit.name, course_unit.id]}
       end
     end

--- a/dashboard/app/controllers/plc/user_course_enrollments_controller.rb
+++ b/dashboard/app/controllers/plc/user_course_enrollments_controller.rb
@@ -9,7 +9,7 @@ class Plc::UserCourseEnrollmentsController < ApplicationController
 
   def group_view
     # This is a method to view many different people's course enrollments
-    @courses = Plc::Course.all
+    @plc_courses = Plc::Course.all
 
     if current_user.admin?
       # This should be okay with a thousand enrollments but it's really just a placeholder while we develop this

--- a/dashboard/app/models/plc/user_course_enrollment.rb
+++ b/dashboard/app/models/plc/user_course_enrollment.rb
@@ -37,7 +37,7 @@ class Plc::UserCourseEnrollment < ActiveRecord::Base
   # @param course_id: course_id to enroll users in
   # @returns list of enrolled users, user_keys that did not correspond to extant users, user_keys that belonged to students, or user_emails that failed for other reasons
   def self.enroll_users(user_keys, course_id)
-    course = Plc::Course.find(course_id)
+    plc_course = Plc::Course.find(course_id)
     enrolled_users = []
     nonexistent_users = []
     nonteacher_users = []
@@ -54,7 +54,7 @@ class Plc::UserCourseEnrollment < ActiveRecord::Base
       elsif !user.teacher?
         nonteacher_users << user_key
       else
-        enrollment = find_or_create_by(user: user, plc_course: course)
+        enrollment = find_or_create_by(user: user, plc_course: plc_course)
         if enrollment.valid?
           enrolled_users << email
         else

--- a/dashboard/app/views/plc/user_course_enrollments/group_view.html.haml
+++ b/dashboard/app/views/plc/user_course_enrollments/group_view.html.haml
@@ -3,7 +3,7 @@
 - if @user_course_enrollments.empty?
   %p Course enrollments for the users you manage will show up here. Right now, you do not have any.
 -else
-  - @courses.each do |course|
+  - @plc_courses.each do |course|
     - enrollments = @user_course_enrollments.where(plc_course: course)
     - next if enrollments.empty?
 

--- a/dashboard/app/views/plc/user_course_enrollments/group_view.html.haml
+++ b/dashboard/app/views/plc/user_course_enrollments/group_view.html.haml
@@ -3,18 +3,18 @@
 - if @user_course_enrollments.empty?
   %p Course enrollments for the users you manage will show up here. Right now, you do not have any.
 -else
-  - @plc_courses.each do |course|
-    - enrollments = @user_course_enrollments.where(plc_course: course)
+  - @plc_courses.each do |plc_course|
+    - enrollments = @user_course_enrollments.where(plc_course: plc_course)
     - next if enrollments.empty?
 
     %h3
-      Viewing progress for #{course.name}
+      Viewing progress for #{plc_course.name}
 
     %table
       %thead
         %th
           Teacher Name
-        - course.plc_course_units.each do |course_unit|
+        - plc_course.plc_course_units.each do |course_unit|
           %th
             #{course_unit.unit_name}
       %tbody

--- a/dashboard/app/views/plc/user_course_enrollments/group_view.html.haml
+++ b/dashboard/app/views/plc/user_course_enrollments/group_view.html.haml
@@ -23,4 +23,4 @@
             %td
               = link_to enrollment.user.name, '/plc/user_course_enrollments/manager_view/' + enrollment.id.to_s
             - enrollment.plc_unit_assignments.each do |unit_assignment|
-              %td #{unit_assignment.status.titleize}
+              %td= unit_assignment.status.titleize

--- a/dashboard/test/controllers/plc/enrollment_evaluations_controller_test.rb
+++ b/dashboard/test/controllers/plc/enrollment_evaluations_controller_test.rb
@@ -10,8 +10,8 @@ class Plc::EnrollmentEvaluationsControllerTest < ActionController::TestCase
 
     # I used the dialogue from Monty Python because it's actually a decent example of an evaluation quiz that isn't
     # the same for everyone. Not all users taking an examination will answer the exact same questions.
-    @course = create(:plc_course)
-    @course_unit = create(:plc_course_unit, plc_course: @course)
+    @plc_course = create(:plc_course)
+    @course_unit = create(:plc_course_unit, plc_course: @plc_course)
 
     @module_required = create(:plc_learning_module, name: 'Required', plc_course_unit: @course_unit, module_type: Plc::LearningModule::REQUIRED_MODULE)
 
@@ -24,7 +24,7 @@ class Plc::EnrollmentEvaluationsControllerTest < ActionController::TestCase
     @user = create :teacher
     sign_in(@user)
 
-    @enrollment = create(:plc_user_course_enrollment, user: @user, plc_course: @course)
+    @enrollment = create(:plc_user_course_enrollment, user: @user, plc_course: @plc_course)
     @unit_assignment = @enrollment.plc_unit_assignments.first
   end
 

--- a/dashboard/test/models/plc/course_unit_module_selection_test.rb
+++ b/dashboard/test/models/plc/course_unit_module_selection_test.rb
@@ -3,9 +3,9 @@ require 'test_helper'
 class CourseUnitModuleSelectionTest < ActionView::TestCase
   setup do
     @user = create :teacher
-    course = create :plc_course
+    plc_course = create :plc_course
 
-    @course_unit = create(:plc_course_unit, plc_course: course)
+    @course_unit = create(:plc_course_unit, plc_course: plc_course)
 
     @content_lesson_group = create(:lesson_group, key: Plc::LearningModule::CONTENT_MODULE, script: @course_unit.script)
     @practice_lesson_group = create(:lesson_group, key: Plc::LearningModule::PRACTICE_MODULE, script: @course_unit.script)

--- a/dashboard/test/models/plc/course_unit_test.rb
+++ b/dashboard/test/models/plc/course_unit_test.rb
@@ -2,14 +2,14 @@ require 'test_helper'
 
 class CourseUnitTest < ActionView::TestCase
   setup do
-    @course = create :plc_course
+    @plc_course = create :plc_course
     @user = create :teacher
   end
 
   test 'Launching course units works with no created unit assignments' do
     # Simulates a unit that was created after people were enrolled
-    @enrollment = Plc::UserCourseEnrollment.create(user: @user, plc_course: @course)
-    @course_unit = create(:plc_course_unit, plc_course: @course, started: false)
+    @enrollment = Plc::UserCourseEnrollment.create(user: @user, plc_course: @plc_course)
+    @course_unit = create(:plc_course_unit, plc_course: @plc_course, started: false)
 
     @course_unit.launch
 
@@ -18,8 +18,8 @@ class CourseUnitTest < ActionView::TestCase
 
   test 'Launching course units with with already created assignments' do
     # Simulates a unit that people were enrolled in but was locked
-    @course_unit = create(:plc_course_unit, plc_course: @course, started: false)
-    @enrollment = Plc::UserCourseEnrollment.create(user: @user, plc_course: @course)
+    @course_unit = create(:plc_course_unit, plc_course: @plc_course, started: false)
+    @enrollment = Plc::UserCourseEnrollment.create(user: @user, plc_course: @plc_course)
 
     @course_unit.launch
 

--- a/dashboard/test/models/plc/enrollment_unit_assignment_test.rb
+++ b/dashboard/test/models/plc/enrollment_unit_assignment_test.rb
@@ -3,10 +3,10 @@ require 'test_helper'
 class Plc::EnrollmentUnitAssignmentTest < ActiveSupport::TestCase
   setup do
     @teacher = create :teacher
-    @course = create :plc_course
-    @course_unit = create(:plc_course_unit, plc_course: @course)
+    @plc_course = create :plc_course
+    @course_unit = create(:plc_course_unit, plc_course: @plc_course)
     @script = @course_unit.script
-    @script.update(professional_learning_course: @course.name)
+    @script.update(professional_learning_course: @plc_course.name)
 
     @required_lesson_group = create(:lesson_group, key: Plc::LearningModule::REQUIRED_MODULE, script: @script)
     @content_lesson_group = create(:lesson_group, key: Plc::LearningModule::CONTENT_MODULE, script: @script)
@@ -22,7 +22,7 @@ class Plc::EnrollmentUnitAssignmentTest < ActiveSupport::TestCase
 
     Plc::EnrollmentModuleAssignment.any_instance.stubs(:status).returns(Plc::EnrollmentModuleAssignment::NOT_STARTED)
 
-    @enrollment = Plc::UserCourseEnrollment.find_or_create_by(user: @teacher, plc_course: @course)
+    @enrollment = Plc::UserCourseEnrollment.find_or_create_by(user: @teacher, plc_course: @plc_course)
     @unit_enrollment = @enrollment.plc_unit_assignments.first
   end
 

--- a/dashboard/test/models/plc/user_course_enrollment_test.rb
+++ b/dashboard/test/models/plc/user_course_enrollment_test.rb
@@ -81,8 +81,8 @@ class Plc::UserCourseEnrollmentTest < ActiveSupport::TestCase
 
   test 'unenrolling a user from one of multiple course enrollments does not remove their authorized teacher user permission' do
     create(:plc_user_course_enrollment, user: @user, plc_course: @plc_course)
-    course2 = create :plc_course, name: 'course2'
-    enrollment2 = create(:plc_user_course_enrollment, user: @user, plc_course: course2)
+    plc_course2 = create :plc_course, name: 'plc_course2'
+    enrollment2 = create(:plc_user_course_enrollment, user: @user, plc_course: plc_course2)
     assert UserPermission.exists?(user_id: @user.id, permission: UserPermission::AUTHORIZED_TEACHER)
 
     enrollment2.destroy

--- a/dashboard/test/models/plc/user_course_enrollment_test.rb
+++ b/dashboard/test/models/plc/user_course_enrollment_test.rb
@@ -3,14 +3,14 @@ require 'test_helper'
 class Plc::UserCourseEnrollmentTest < ActiveSupport::TestCase
   setup do
     @user = create :teacher
-    @course = create :plc_course
+    @plc_course = create :plc_course
     # Create course units out of order to make sure that unit_order is respected
-    @course_unit2 = create(:plc_course_unit, plc_course: @course, unit_order: 2)
-    @course_unit1 = create(:plc_course_unit, plc_course: @course, unit_order: 1)
+    @course_unit2 = create(:plc_course_unit, plc_course: @plc_course, unit_order: 2)
+    @course_unit1 = create(:plc_course_unit, plc_course: @plc_course, unit_order: 1)
   end
 
   test 'Enrolling user in a course creates unit enrollments' do
-    enrollment = Plc::UserCourseEnrollment.create(user: @user, plc_course: @course)
+    enrollment = Plc::UserCourseEnrollment.create(user: @user, plc_course: @plc_course)
 
     assert_equal [@course_unit2, @course_unit1], enrollment.plc_unit_assignments.map(&:plc_course_unit)
     assert_equal [Plc::EnrollmentUnitAssignment::START_BLOCKED], enrollment.plc_unit_assignments.map(&:status).uniq
@@ -23,7 +23,7 @@ class Plc::UserCourseEnrollmentTest < ActiveSupport::TestCase
     nonexistent_email = 'wrong-email@wrong.com'
 
     created_enrollments, nonexistent_users, nonteacher_users, other_failure_users =
-      Plc::UserCourseEnrollment.enroll_users([@user.email, user_from_id.id.to_s, nonexistent_email, student_email], @course.id)
+      Plc::UserCourseEnrollment.enroll_users([@user.email, user_from_id.id.to_s, nonexistent_email, student_email], @plc_course.id)
 
     assert_equal created_enrollments, [@user.email, user_from_id.email]
     assert_equal nonexistent_users, [nonexistent_email]
@@ -34,17 +34,17 @@ class Plc::UserCourseEnrollmentTest < ActiveSupport::TestCase
   test 'enrolling in a started course creates unit enrollments that are in progress' do
     @course_unit1.update(started: true)
 
-    enrollment = Plc::UserCourseEnrollment.create(user: @user, plc_course: @course)
+    enrollment = Plc::UserCourseEnrollment.create(user: @user, plc_course: @plc_course)
 
     assert_equal [@course_unit2, @course_unit1], enrollment.plc_unit_assignments.map(&:plc_course_unit)
     assert_equal [Plc::EnrollmentUnitAssignment::START_BLOCKED, Plc::EnrollmentUnitAssignment::IN_PROGRESS], enrollment.plc_unit_assignments.map(&:status)
   end
 
   test 'summarize works as expected' do
-    enrollment = Plc::UserCourseEnrollment.create(user: @user, plc_course: @course)
+    enrollment = Plc::UserCourseEnrollment.create(user: @user, plc_course: @plc_course)
     expected_summary = {
-      courseName: @course.name,
-      link: Rails.application.routes.url_helpers.course_path(@course.unit_group),
+      courseName: @plc_course.name,
+      link: Rails.application.routes.url_helpers.course_path(@plc_course.unit_group),
       status: enrollment.status,
       courseUnits: [
         {
@@ -66,13 +66,13 @@ class Plc::UserCourseEnrollmentTest < ActiveSupport::TestCase
 
   test 'enrolling a non-authorized user in a course creates an authorized teacher user permission' do
     refute UserPermission.exists?(user_id: @user.id, permission: UserPermission::AUTHORIZED_TEACHER)
-    create(:plc_user_course_enrollment, user: @user, plc_course: @course)
+    create(:plc_user_course_enrollment, user: @user, plc_course: @plc_course)
     assert UserPermission.exists?(user_id: @user.id, permission: UserPermission::AUTHORIZED_TEACHER)
   end
 
   test 'unenrolling a user from their only course removes their authorized teacher user permission' do
     refute Plc::UserCourseEnrollment.exists?(user_id: @user.id)
-    enrollment = create(:plc_user_course_enrollment, user: @user, plc_course: @course)
+    enrollment = create(:plc_user_course_enrollment, user: @user, plc_course: @plc_course)
     assert UserPermission.exists?(user_id: @user.id, permission: UserPermission::AUTHORIZED_TEACHER)
 
     enrollment.destroy
@@ -80,7 +80,7 @@ class Plc::UserCourseEnrollmentTest < ActiveSupport::TestCase
   end
 
   test 'unenrolling a user from one of multiple course enrollments does not remove their authorized teacher user permission' do
-    create(:plc_user_course_enrollment, user: @user, plc_course: @course)
+    create(:plc_user_course_enrollment, user: @user, plc_course: @plc_course)
     course2 = create :plc_course, name: 'course2'
     enrollment2 = create(:plc_user_course_enrollment, user: @user, plc_course: course2)
     assert UserPermission.exists?(user_id: @user.id, permission: UserPermission::AUTHORIZED_TEACHER)


### PR DESCRIPTION
As part of renaming the Course model to UnitGroup ([PLAT-234](https://codedotorg.atlassian.net/browse/PLAT-234)), there are a few variables with "course" in the name which refer to `Plc::Course`. Rather than repeatedly excluding these from my search, I think it will be better for everyone if I renamed these from `course` to `plc_course`.

Caveat: For now, I'm only trying to rename instances of `course` which are variable names pointing to a `Plc::Course` object or objects. (excludes strings which might hold a string representing a course, for example). Hopefully this results in a readability improvement for PLC engineers in addition to making my current task easier. EDIT: I'm also not renaming any associations on PLC models named `course` as that seems like substantially more work.

## Testing story

I am relying on existing unit test coverage to validate these changes. If there is one line I don't have high confidence in receiving test coverage, it is this line which I changed to satisfy the linter: https://github.com/code-dot-org/code-dot-org/blob/1655f0991e20a5fa744f16b4a10f4129c276e5c1/dashboard/app/views/plc/user_course_enrollments/group_view.html.haml#L26

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
