### PR TITLE
Use fork of newrelic_rpm agent

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -191,7 +191,12 @@ gem 'highline', '~> 1.6.21'
 
 gem 'honeybadger' # error monitoring
 
-gem 'newrelic_rpm', group: [:staging, :development, :production] # perf/error/etc monitoring
+gem 'newrelic_rpm', group: [:staging, :development, :production], # perf/error/etc monitoring
+  # Ref:
+  # https://github.com/newrelic/newrelic-ruby-agent/pull/359
+  # https://github.com/newrelic/newrelic-ruby-agent/pull/372
+  # https://github.com/newrelic/newrelic-ruby-agent/issues/340
+  github: 'code-dot-org/newrelic-ruby-agent', ref: 'PR-359_prevent_reconnect_attempts_during_shutdowns'
 
 gem 'redcarpet', '~> 3.3.4'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -6,6 +6,13 @@ GIT
       omniauth-oauth2 (>= 1.1, <= 1.5)
 
 GIT
+  remote: https://github.com/code-dot-org/newrelic-ruby-agent.git
+  revision: 5a46cdf3f3f144018bca2edce6b008d464da18fa
+  ref: PR-359_prevent_reconnect_attempts_during_shutdowns
+  specs:
+    newrelic_rpm (6.12.0)
+
+GIT
   remote: https://github.com/code-dot-org/petit.git
   revision: bbe411d61d3f78fff59d9fa79d21c14b1c635750
   specs:
@@ -566,7 +573,6 @@ GEM
     net-ssh (5.2.0)
     net_http_ssl_fix (0.0.10)
     netrc (0.11.0)
-    newrelic_rpm (6.10.0.364)
     nio4r (2.3.1)
     nokogiri (1.10.3)
       mini_portile2 (~> 2.4.0)
@@ -979,7 +985,7 @@ DEPENDENCIES
   net-http-persistent
   net-scp
   net-ssh
-  newrelic_rpm
+  newrelic_rpm!
   nokogiri (>= 1.10.0)
   octokit
   oj


### PR DESCRIPTION
This fixes an issue causing the connecting agent thread to hang on shutdown.