### PR TITLE
rename course to unit group in courses controller and views

### DIFF
--- a/dashboard/app/controllers/courses_controller.rb
+++ b/dashboard/app/controllers/courses_controller.rb
@@ -44,65 +44,65 @@ class CoursesController < ApplicationController
       return
     end
 
-    course = UnitGroup.get_from_cache(params[:course_name])
-    raise ActiveRecord::RecordNotFound unless course
+    unit_group = UnitGroup.get_from_cache(params[:course_name])
+    raise ActiveRecord::RecordNotFound unless unit_group
 
-    if course.plc_course
+    if unit_group.plc_course
       authorize! :show, Plc::UserCourseEnrollment
-      user_course_enrollments = [Plc::UserCourseEnrollment.find_by(user: current_user, plc_course: course.plc_course)]
+      user_course_enrollments = [Plc::UserCourseEnrollment.find_by(user: current_user, plc_course: unit_group.plc_course)]
       render 'plc/user_course_enrollments/index', locals: {user_course_enrollments: user_course_enrollments}
       return
     end
 
-    if course.pilot?
+    if unit_group.pilot?
       authenticate_user!
-      unless course.has_pilot_access?(current_user)
+      unless unit_group.has_pilot_access?(current_user)
         render :no_access
         return
       end
     end
 
     # Attempt to redirect user if we think they ended up on the wrong course overview page.
-    override_redirect = VersionRedirectOverrider.override_course_redirect?(session, course)
-    if !override_redirect && redirect_course = redirect_course(course)
-      redirect_to "/courses/#{redirect_course.name}/?redirect_warning=true"
+    override_redirect = VersionRedirectOverrider.override_course_redirect?(session, unit_group)
+    if !override_redirect && redirect_unit_group = redirect_unit_group(unit_group)
+      redirect_to "/courses/#{redirect_unit_group.name}/?redirect_warning=true"
       return
     end
 
     sections = current_user.try {|u| u.sections.where(hidden: false).select(:id, :name, :course_id, :script_id)}
-    @sections_with_assigned_info = sections&.map {|section| section.attributes.merge!({"isAssigned" => section[:course_id] == course.id})}
+    @sections_with_assigned_info = sections&.map {|section| section.attributes.merge!({"isAssigned" => section[:course_id] == unit_group.id})}
 
-    render 'show', locals: {course: course, redirect_warning: params[:redirect_warning] == 'true'}
+    render 'show', locals: {course: unit_group, redirect_warning: params[:redirect_warning] == 'true'}
   end
 
   def new
   end
 
   def create
-    course = UnitGroup.new(name: params.require(:course).require(:name))
-    if course.save
-      redirect_to action: :edit, course_name: course.name
+    unit_group = UnitGroup.new(name: params.require(:course).require(:name))
+    if unit_group.save
+      redirect_to action: :edit, course_name: unit_group.name
     else
-      render 'new', locals: {course: course}
+      render 'new', locals: {course: unit_group}
     end
   end
 
   def update
-    course = UnitGroup.find_by_name!(params[:course_name])
-    course.persist_strings_and_scripts_changes(params[:scripts], params[:alternate_scripts], i18n_params)
-    course.update_teacher_resources(params[:resourceTypes], params[:resourceLinks])
+    unit_group = UnitGroup.find_by_name!(params[:course_name])
+    unit_group.persist_strings_and_scripts_changes(params[:scripts], params[:alternate_scripts], i18n_params)
+    unit_group.update_teacher_resources(params[:resourceTypes], params[:resourceLinks])
     # Convert checkbox values from a string ("on") to a boolean.
     [:has_verified_resources, :visible, :is_stable].each {|key| params[key] = !!params[key]}
-    course.update(course_params)
-    redirect_to course_path(course)
+    unit_group.update(course_params)
+    redirect_to course_path(unit_group)
   end
 
   def edit
-    course = UnitGroup.find_by_name!(params[:course_name])
+    unit_group = UnitGroup.find_by_name!(params[:course_name])
 
     # We don't support an edit experience for plc courses
-    raise ActiveRecord::ReadOnlyRecord if course.try(:plc_course)
-    render 'edit', locals: {course: course}
+    raise ActiveRecord::ReadOnlyRecord if unit_group.try(:plc_course)
+    render 'edit', locals: {course: unit_group}
   end
 
   def i18n_params
@@ -126,18 +126,18 @@ class CoursesController < ApplicationController
     end
   end
 
-  def redirect_course(course)
-    # Return nil if course is nil or we know the user can view the version requested.
-    return nil if !course || course.can_view_version?(current_user)
+  def redirect_unit_group(unit_group)
+    # Return nil if unit_group is nil or we know the user can view the version requested.
+    return nil if !unit_group || unit_group.can_view_version?(current_user)
 
-    # Redirect the user to the latest assigned course in this family, or to the latest course in this family if none
+    # Redirect the user to the latest assigned unit_group in this family, or to the latest unit_group in this family if none
     # are assigned.
-    redirect_course = UnitGroup.latest_assigned_version(course.family_name, current_user)
-    redirect_course ||= UnitGroup.latest_stable_version(course.family_name)
+    redirect_unit_group = UnitGroup.latest_assigned_version(unit_group.family_name, current_user)
+    redirect_unit_group ||= UnitGroup.latest_stable_version(unit_group.family_name)
 
-    # Do not redirect if we are already on the correct course.
-    return nil if redirect_course == course
+    # Do not redirect if we are already on the correct unit_group.
+    return nil if redirect_unit_group == unit_group
 
-    redirect_course
+    redirect_unit_group
   end
 end

--- a/dashboard/app/controllers/courses_controller.rb
+++ b/dashboard/app/controllers/courses_controller.rb
@@ -102,7 +102,7 @@ class CoursesController < ApplicationController
 
     # We don't support an edit experience for plc courses
     raise ActiveRecord::ReadOnlyRecord if unit_group.try(:plc_course)
-    render 'edit', locals: {course: unit_group}
+    render 'edit', locals: {unit_group: unit_group}
   end
 
   def i18n_params

--- a/dashboard/app/controllers/courses_controller.rb
+++ b/dashboard/app/controllers/courses_controller.rb
@@ -83,7 +83,7 @@ class CoursesController < ApplicationController
     if unit_group.save
       redirect_to action: :edit, course_name: unit_group.name
     else
-      render 'new', locals: {course: unit_group}
+      render 'new', locals: {unit_group: unit_group}
     end
   end
 

--- a/dashboard/app/controllers/courses_controller.rb
+++ b/dashboard/app/controllers/courses_controller.rb
@@ -72,7 +72,7 @@ class CoursesController < ApplicationController
     sections = current_user.try {|u| u.sections.where(hidden: false).select(:id, :name, :course_id, :script_id)}
     @sections_with_assigned_info = sections&.map {|section| section.attributes.merge!({"isAssigned" => section[:course_id] == unit_group.id})}
 
-    render 'show', locals: {course: unit_group, redirect_warning: params[:redirect_warning] == 'true'}
+    render 'show', locals: {unit_group: unit_group, redirect_warning: params[:redirect_warning] == 'true'}
   end
 
   def new

--- a/dashboard/app/views/courses/edit.html.haml
+++ b/dashboard/app/views/courses/edit.html.haml
@@ -1,10 +1,10 @@
-- course = local_assigns[:course]
-- course_editor_data = {course_summary: course.summarize,
+- unit_group = local_assigns[:unit_group]
+- course_editor_data = {course_summary: unit_group.summarize,
                         script_names: Script.all.map(&:name),
                         course_families: UnitGroup::FAMILY_NAMES,
                         version_year_options: UnitGroup.get_version_year_options}
 - content_for(:head) do
   %script{ src: webpack_asset_path('js/courses/edit.js'), data: {course_editor: course_editor_data.to_json}}
-= form_for(course, {url: course_path(course)}) do |f|
+= form_for(unit_group, {url: course_path(unit_group)}) do |f|
   #course_editor
   %button.btn.btn-primary{type: 'submit', style: 'margin: 0'} Save Changes

--- a/dashboard/app/views/courses/new.html.haml
+++ b/dashboard/app/views/courses/new.html.haml
@@ -1,16 +1,16 @@
-- course = local_assigns[:course]
+- unit_group = local_assigns[:unit_group]
 
-- if course && course.errors.any?
+- if unit_group && unit_group.errors.any?
   #error_explanation
     %h2
-      = pluralize(course.errors.count, 'error')
+      = pluralize(unit_group.errors.count, 'error')
       prohibited this course from being saved:
     %ul
-      - course.errors.full_messages.each do |msg|
+      - unit_group.errors.full_messages.each do |msg|
         %li= msg
 
 %h1= t('crud.new_model', model: UnitGroup.model_name.human)
-= form_for(course || :course, course ? {url: course_path(course)} : {url: courses_path}) do |f|
+= form_for(unit_group || :course, unit_group ? {url: course_path(unit_group)} : {url: courses_path}) do |f|
   .field
     = f.label :name
     = f.text_field :name

--- a/dashboard/app/views/courses/show.html.haml
+++ b/dashboard/app/views/courses/show.html.haml
@@ -1,14 +1,14 @@
-- course = local_assigns[:course]
+- unit_group = local_assigns[:unit_group]
 
 - data = {}
-- data[:course_summary] = course.summarize(@current_user)
+- data[:course_summary] = unit_group.summarize(@current_user)
 - data[:sections] = @sections_with_assigned_info || []
 - data[:is_teacher] = @current_user.try(:teacher?) || false
 - data[:is_verified_teacher] = @current_user.try(:authorized_teacher?) || false
-- data[:hidden_scripts] = @current_user.try(:get_hidden_script_ids, course)
-- data[:show_version_warning] = course.has_older_version_progress?(@current_user) && !course.has_dismissed_version_warning?(@current_user)
+- data[:hidden_scripts] = @current_user.try(:get_hidden_script_ids, unit_group)
+- data[:show_version_warning] = unit_group.has_older_version_progress?(@current_user) && !unit_group.has_dismissed_version_warning?(@current_user)
 - data[:show_redirect_warning] = redirect_warning
-- data[:redirect_to_course_url] = course.redirect_to_course_url(@current_user)
+- data[:redirect_to_course_url] = unit_group.redirect_to_course_url(@current_user)
 - data[:user_id] = @current_user.try(:id)
 
 - content_for(:head) do

--- a/dashboard/test/controllers/courses_controller_test.rb
+++ b/dashboard/test/controllers/courses_controller_test.rb
@@ -10,8 +10,8 @@ class CoursesControllerTest < ActionController::TestCase
     @levelbuilder = create :levelbuilder
 
     @pilot_teacher = create :teacher, pilot_experiment: 'my-experiment'
-    @pilot_course = create :unit_group, pilot_experiment: 'my-experiment'
-    @pilot_section = create :section, user: @pilot_teacher, unit_group: @pilot_course
+    @pilot_unit_group = create :unit_group, pilot_experiment: 'my-experiment'
+    @pilot_section = create :section, user: @pilot_teacher, unit_group: @pilot_unit_group
     @pilot_student = create(:follower, section: @pilot_section).student_user
 
     Script.stubs(:should_cache?).returns true
@@ -149,37 +149,37 @@ class CoursesControllerTest < ActionController::TestCase
   no_access_msg = "You don&#39;t have access to this course."
 
   test_user_gets_response_for :show, response: :redirect, user: nil,
-                              params: -> {{course_name: @pilot_course.name}},
+                              params: -> {{course_name: @pilot_unit_group.name}},
                               name: 'signed out user cannot view pilot script'
 
   test_user_gets_response_for(:show, response: :success, user: :student,
-                              params: -> {{course_name: @pilot_course.name}}, name: 'student cannot view pilot course'
+                              params: -> {{course_name: @pilot_unit_group.name}}, name: 'student cannot view pilot course'
   ) do
     assert response.body.include? no_access_msg
   end
 
   test_user_gets_response_for(:show, response: :success, user: :teacher,
-                              params: -> {{course_name: @pilot_course.name}},
+                              params: -> {{course_name: @pilot_unit_group.name}},
                               name: 'teacher without pilot access cannot view pilot course'
   ) do
     assert response.body.include? no_access_msg
   end
 
   test_user_gets_response_for(:show, response: :success, user: -> {@pilot_teacher},
-                              params: -> {{course_name: @pilot_course.name, section_id: @pilot_section.id}},
+                              params: -> {{course_name: @pilot_unit_group.name, section_id: @pilot_section.id}},
                               name: 'pilot teacher can view pilot course'
   ) do
     refute response.body.include? no_access_msg
   end
 
   test_user_gets_response_for(:show, response: :success, user: -> {@pilot_student},
-                              params: -> {{course_name: @pilot_course.name}}, name: 'pilot student can view pilot course'
+                              params: -> {{course_name: @pilot_unit_group.name}}, name: 'pilot student can view pilot course'
   ) do
     refute response.body.include? no_access_msg
   end
 
   test_user_gets_response_for(:show, response: :success, user: :levelbuilder,
-                              params: -> {{course_name: @pilot_course.name}}, name: 'levelbuilder can view pilot course'
+                              params: -> {{course_name: @pilot_unit_group.name}}, name: 'levelbuilder can view pilot course'
   ) do
     refute response.body.include? no_access_msg
   end
@@ -257,18 +257,18 @@ class CoursesControllerTest < ActionController::TestCase
         }
       ]
     }
-    course = UnitGroup.find_by_name('csp')
-    assert_equal 3, course.default_unit_group_units.length
-    assert_equal ['script1', 'script2', 'script3'], course.default_unit_group_units.map(&:script).map(&:name)
+    unit_group = UnitGroup.find_by_name('csp')
+    assert_equal 3, unit_group.default_unit_group_units.length
+    assert_equal ['script1', 'script2', 'script3'], unit_group.default_unit_group_units.map(&:script).map(&:name)
 
-    assert_equal 1, course.alternate_unit_group_units.length
-    alternate_unit_group_unit = course.alternate_unit_group_units.first
+    assert_equal 1, unit_group.alternate_unit_group_units.length
+    alternate_unit_group_unit = unit_group.alternate_unit_group_units.first
     assert_equal 'script2-alt', alternate_unit_group_unit.script.name
     assert_equal 'script2', alternate_unit_group_unit.default_script.name
     assert_equal 'my_experiment', alternate_unit_group_unit.experiment_name
 
     default_script = Script.find_by(name: 'script2')
-    expected_position = course.default_unit_group_units.find_by(script: default_script).position
+    expected_position = unit_group.default_unit_group_units.find_by(script: default_script).position
     assert_equal expected_position, alternate_unit_group_unit.position,
       'an alternate script must have the same position as the default script it replaces'
 
@@ -287,29 +287,29 @@ class CoursesControllerTest < ActionController::TestCase
   test "update: persists changes to course_params" do
     sign_in @levelbuilder
     Rails.application.config.stubs(:levelbuilder_mode).returns true
-    course = create :unit_group, name: 'csp-2019'
+    unit_group = create :unit_group, name: 'csp-2019'
 
-    assert_nil course.version_year
-    assert_nil course.family_name
-    refute course.has_verified_resources
-    refute course.visible?
-    refute course.is_stable?
+    assert_nil unit_group.version_year
+    assert_nil unit_group.family_name
+    refute unit_group.has_verified_resources
+    refute unit_group.visible?
+    refute unit_group.is_stable?
 
     post :update, params: {
-      course_name: course.name,
+      course_name: unit_group.name,
       version_year: '2019',
       family_name: 'csp',
       has_verified_resources: 'on',
       visible: 'on',
       is_stable: 'on'
     }
-    course.reload
+    unit_group.reload
 
-    assert_equal '2019', course.version_year
-    assert_equal 'csp', course.family_name
-    assert course.has_verified_resources
-    assert course.visible?
-    assert course.is_stable?
+    assert_equal '2019', unit_group.version_year
+    assert_equal 'csp', unit_group.family_name
+    assert unit_group.has_verified_resources
+    assert unit_group.visible?
+    assert unit_group.is_stable?
   end
 
   # tests for edit

--- a/dashboard/test/controllers/courses_controller_test.rb
+++ b/dashboard/test/controllers/courses_controller_test.rb
@@ -17,7 +17,7 @@ class CoursesControllerTest < ActionController::TestCase
     Script.stubs(:should_cache?).returns true
     Script.clear_cache
 
-    @course_regular = create :unit_group, name: 'non-plc-course'
+    @unit_group_regular = create :unit_group, name: 'non-plc-course'
 
     # stub writes so that we dont actually make updates to filesystem
     File.stubs(:write)
@@ -38,7 +38,7 @@ class CoursesControllerTest < ActionController::TestCase
   # Tests for show
 
   test "show: regular courses get sent to show" do
-    get :show, params: {course_name: @course_regular.name}
+    get :show, params: {course_name: @unit_group_regular.name}
     assert_template 'courses/show'
   end
 
@@ -48,9 +48,9 @@ class CoursesControllerTest < ActionController::TestCase
     end
   end
 
-  test_user_gets_response_for :show, response: :success, user: :teacher, params: -> {{course_name: @course_regular.name}}, queries: 8
+  test_user_gets_response_for :show, response: :success, user: :teacher, params: -> {{course_name: @unit_group_regular.name}}, queries: 8
 
-  test_user_gets_response_for :show, response: :forbidden, user: :admin, params: -> {{course_name: @course_regular.name}}, queries: 2
+  test_user_gets_response_for :show, response: :forbidden, user: :admin, params: -> {{course_name: @unit_group_regular.name}}, queries: 2
 
   test "show: redirect to latest stable version in course family" do
     create :unit_group, name: 'csp-2018', family_name: 'csp', version_year: '2018', is_stable: true


### PR DESCRIPTION

## Description

Continues work on https://codedotorg.atlassian.net/browse/PLAT-234 by renaming local variable names from course to unit group.

## Testing story

relies on existing test coverage. courses_controller_test.rb is passing locally.

# Reviewer Checklist:

- [x] Tests provide adequate coverage
- [x] Code is well-commented
- [x] New features are translatable or updates will not break translations
- [x] Relevant documentation has been added or updated
- [x] User impact is well-understood and desirable
- [x] Pull Request is labeled appropriately
- [x] Follow-up work items (including potential tech debt) are tracked and linked
