### PR TITLE
Fix TTS for translated contained levels

### DIFF
--- a/dashboard/scripts/update_tts_i18n.rb
+++ b/dashboard/scripts/update_tts_i18n.rb
@@ -31,7 +31,7 @@ TextToSpeech::VOICES.keys.each do |lang|
 
       # Short Instructions
 
-      translated_text = TextToSpeech.sanitize(level.localized_short_instructions || "")
+      translated_text = level.tts_short_instructions_text
       english_text = TextToSpeech.sanitize(level.short_instructions || "")
 
       if text_translated?(translated_text, english_text)
@@ -41,7 +41,7 @@ TextToSpeech::VOICES.keys.each do |lang|
       # Long Instructions
 
       unless script.csf_international? || script.twenty_hour?
-        translated_text = TextToSpeech.sanitize(level.localized_long_instructions || "")
+        translated_text = level.tts_long_instructions_text
         english_text = TextToSpeech.sanitize(level.long_instructions || "")
 
         if text_translated?(translated_text, english_text)

--- a/dashboard/scripts/update_tts_i18n.rb
+++ b/dashboard/scripts/update_tts_i18n.rb
@@ -2,8 +2,6 @@
 require_relative('../config/environment')
 require 'cdo/properties'
 
-k1_scripts = Script.all.select(&:text_to_speech_enabled?)
-
 def clean(value)
   if value.nil?
     return ''
@@ -20,49 +18,57 @@ def text_translated?(left, right)
   clean(left) != clean(right)
 end
 
-TextToSpeech::VOICES.keys.each do |lang|
-  next if lang == :'en-US'
+def update_level_tts_i18n(level, script=nil)
+  # Short Instructions
 
-  I18n.locale = lang
-  puts "updating text-to-speech for #{I18n.locale}"
-  k1_scripts.each do |script|
-    script.levels.each do |level|
-      next unless level.is_a?(Blockly)
+  translated_text = level.tts_short_instructions_text
+  english_text = TextToSpeech.sanitize(level.short_instructions || "")
 
-      # Short Instructions
+  if translated_text.present? && text_translated?(translated_text, english_text)
+    level.tts_upload_to_s3(translated_text)
+  end
 
-      translated_text = level.tts_short_instructions_text
-      english_text = TextToSpeech.sanitize(level.short_instructions || "")
+  # Long Instructions
 
-      if text_translated?(translated_text, english_text)
-        level.tts_upload_to_s3(translated_text)
-      end
+  unless script && (script.csf_international? || script.twenty_hour?)
+    translated_text = level.tts_long_instructions_text
+    english_text = TextToSpeech.sanitize(level.long_instructions || "")
 
-      # Long Instructions
+    if translated_text.present? && text_translated?(translated_text, english_text)
+      level.tts_upload_to_s3(translated_text)
+    end
+  end
 
-      unless script.csf_international? || script.twenty_hour?
-        translated_text = level.tts_long_instructions_text
-        english_text = TextToSpeech.sanitize(level.long_instructions || "")
+  # Authored Hints
 
-        if text_translated?(translated_text, english_text)
-          level.tts_upload_to_s3(translated_text)
-        end
-      end
+  return unless level.localized_authored_hints
+  translated_hints = JSON.parse(level.localized_authored_hints)
+  english_hints = JSON.parse(level.authored_hints)
 
-      # Authored Hints
+  translated_hints.zip(english_hints).each do |translated_hint, english_hint|
+    translated_text = TextToSpeech.sanitize(translated_hint["hint_markdown"])
+    english_text = TextToSpeech.sanitize(english_hint["hint_markdown"])
 
-      next unless level.localized_authored_hints
-      translated_hints = JSON.parse(level.localized_authored_hints)
-      english_hints = JSON.parse(level.authored_hints)
+    if translated_text.present? && text_translated?(translated_text, english_text)
+      level.tts_upload_to_s3(translated_text)
+    end
+  end
+end
 
-      translated_hints.zip(english_hints).each do |translated_hint, english_hint|
-        translated_text = TextToSpeech.sanitize(translated_hint["hint_markdown"])
-        english_text = TextToSpeech.sanitize(english_hint["hint_markdown"])
+def main
+  k1_scripts = Script.all.select(&:text_to_speech_enabled?)
+  TextToSpeech::VOICES.keys.each do |lang|
+    next if lang == :'en-US'
 
-        if text_translated?(translated_text, english_text)
-          level.tts_upload_to_s3(translated_text)
-        end
+    I18n.locale = lang
+    puts "updating text-to-speech for #{I18n.locale}"
+    k1_scripts.each do |script|
+      script.levels.each do |level|
+        next unless level.is_a?(Blockly)
+        update_level_tts_i18n(level, script)
       end
     end
   end
 end
+
+main if __FILE__ == $0

--- a/dashboard/test/scripts/update_tts_i18n_test.rb
+++ b/dashboard/test/scripts/update_tts_i18n_test.rb
@@ -1,0 +1,39 @@
+require 'test_helper'
+
+require_relative File.join(Rails.root, 'scripts/update_tts_i18n')
+
+class UpdateTtsI18nTest < ActiveSupport::TestCase
+  test_locale = :'te-ST'
+
+  test 'levels with translations will generate audio for those translations' do
+    level = create(:level, :blockly, name: "translated level", short_instructions: "test short instructions")
+    custom_i18n = {
+      "data" => {
+        "short_instructions" => {
+          level.name => "translated short instructions"
+        }
+      }
+    }
+    I18n.backend.store_translations test_locale, custom_i18n
+
+    level.expects(:tts_upload_to_s3).with("translated short instructions\n")
+    I18n.locale = test_locale
+    update_level_tts_i18n(level)
+  end
+
+  test 'untranslated levels do not generate new audio' do
+    level = create(:level, :blockly, name: "untranslated level", short_instructions: "test short instructions")
+    level.expects(:tts_upload_to_s3).never
+    I18n.locale = test_locale
+    update_level_tts_i18n(level)
+  end
+
+  test 'contained levels are supported' do
+    create :multi, name: 'contained level', long_instructions: "contained level long instructions"
+    level = create :maze, name: 'containing level', contained_level_names: ['contained level']
+
+    level.expects(:tts_upload_to_s3).with("contained level long instructions\n")
+    I18n.locale = test_locale
+    update_level_tts_i18n(level)
+  end
+end


### PR DESCRIPTION
Specifically, update the script which generates non-English TTS audio to use the general `tts_*_text` methods, which enables them to see the new contained levels content added in #26381

I also rearranged the update script to break the logic up into smaller functions, in an effort to improve testability. Unfortunately, this does make the diff somewhat hard to read. I'd recommend reviewing this one commit-by-commit

## Links

- [jira](https://codedotorg.atlassian.net/browse/FND-1195)

## Testing story

added a new unit test

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
