### PR TITLE
Temporarily disable Aurora binlog filtering for gh-ost

### DIFF
--- a/aws/cloudformation/db_parameters.yml.erb
+++ b/aws/cloudformation/db_parameters.yml.erb
@@ -174,6 +174,9 @@ AuroraCluster: &aurora
   # IAM role ARN used to select data into AWS S3.
   aurora_select_into_s3_role: {'Fn::GetAtt': [AuroraS3Role, Arn]}
 
+  # Temporarily disable binlog filtering so that gh-ost can be used to modify the schema of a large table.
+  aurora_enable_repl_bin_log_filtering: 0
+
 # Aurora Reporting cluster parameters.
 AuroraReportingCluster:
   <<: *aurora


### PR DESCRIPTION
Temporarily disable Aurora binlog filtering on production Aurora cluster because it [must be disabled so the gh-ost utility can](https://github.com/github/gh-ost/blob/master/doc/rds.md) be used to modify the schema of a large table (#36110).


## Testing story

```
Listing changes to existing stack `DATA-production`:
Modify AuroraClusterDBParameters [AWS::RDS::DBClusterParameterGroup] Properties (Parameters)
Modify AuroraReportingClusterDBParameters [AWS::RDS::DBClusterParameterGroup] Properties (Parameters)
```


# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
