### PR TITLE
disable Aurora binary logging"

### DIFF
--- a/aws/cloudformation/data.yml.erb
+++ b/aws/cloudformation/data.yml.erb
@@ -59,8 +59,7 @@ Resources:
       KmsKeyId: alias/aws/redshift
       MasterUsername: {Ref: RedshiftUsername}
       MasterUserPassword: {Ref: RedshiftPassword}
-      NodeType: ra3.4xlarge
-      NumberOfNodes: 3
+      NodeType: dc1.large
       PubliclyAccessible: true
       VpcSecurityGroupIds: [!ImportValue VPC-RedshiftSecurityGroup]
   TableauSync:

--- a/aws/cloudformation/data.yml.erb
+++ b/aws/cloudformation/data.yml.erb
@@ -59,7 +59,8 @@ Resources:
       KmsKeyId: alias/aws/redshift
       MasterUsername: {Ref: RedshiftUsername}
       MasterUserPassword: {Ref: RedshiftPassword}
-      NodeType: dc1.large
+      NodeType: ra3.4xlarge
+      NumberOfNodes: 3
       PubliclyAccessible: true
       VpcSecurityGroupIds: [!ImportValue VPC-RedshiftSecurityGroup]
   TableauSync:

--- a/aws/cloudformation/db_parameters.yml.erb
+++ b/aws/cloudformation/db_parameters.yml.erb
@@ -143,16 +143,8 @@ Reporting:
 
 # System variables for the Aurora DB cluster.
 AuroraCluster: &aurora
-  # When using row-based logging, the master writes events to the binary log that indicate how individual table rows are changed.
-  # Replication of the master to the slave works by copying the events representing the changes to the table rows to the slave.
-  # ROW required for DMS Change Data Capture:
-  # https://docs.aws.amazon.com/dms/latest/userguide/CHAP_Source.MySQL.html#CHAP_Source.MySQL.AmazonManaged
-  binlog_format: ROW
-  # When enabled, this variable causes the master to write a checksum for each event in the binary log.
-  # When disabled (value NONE), write and check the event length (rather than a checksum) for each event.
-  # NONE required for DMS Change Data Capture:
-  # https://docs.aws.amazon.com/dms/latest/userguide/CHAP_Source.MySQL.html#CHAP_Source.MySQL.AmazonManaged
-  binlog_checksum: NONE
+  # Disable binary logging to improve write performance.
+  binlog_format: 'OFF'
 
   # Enable GTIDs: https://aws.amazon.com/blogs/database/amazon-aurora-for-mysql-compatibility-now-supports-global-transaction-identifiers-gtids-replication/
   gtid-mode: ON_PERMISSIVE

--- a/aws/cloudformation/db_parameters.yml.erb
+++ b/aws/cloudformation/db_parameters.yml.erb
@@ -166,9 +166,6 @@ AuroraCluster: &aurora
   # IAM role ARN used to select data into AWS S3.
   aurora_select_into_s3_role: {'Fn::GetAtt': [AuroraS3Role, Arn]}
 
-  # Temporarily disable binlog filtering so that gh-ost can be used to modify the schema of a large table.
-  aurora_enable_repl_bin_log_filtering: 0
-
 # Aurora Reporting cluster parameters.
 AuroraReportingCluster:
   <<: *aurora


### PR DESCRIPTION
Disable binary logging now that gh-ost migration of `user_levels` table is complete (#36110 ), by reverting #36090 and #36116
 

TEST

```
$ bundle exec rake stack:data:validate RAILS_ENV=production

Listing changes to existing stack `DATA-production`:
Modify AuroraClusterDBParameters [AWS::RDS::DBClusterParameterGroup] Properties (Parameters)
Modify AuroraReportingClusterDBParameters [AWS::RDS::DBClusterParameterGroup] Properties (Parameters)
```