### PR TITLE
Use a service account key to upload malformed restorations to Drive

### DIFF
--- a/bin/i18n/i18n_script_utils.rb
+++ b/bin/i18n/i18n_script_utils.rb
@@ -94,7 +94,8 @@ class I18nScriptUtils
   def self.upload_malformed_restorations(locale)
     return if @malformed_restorations.blank?
     if CDO.gdrive_export_secret
-      Google::Drive.new(service_account_key: StringIO.new(CDO.gdrive_export_secret.to_json)).add_sheet_to_spreadsheet(@malformed_restorations, "i18n_bad_translations", locale)
+      @google_drive ||= Google::Drive.new(service_account_key: StringIO.new(CDO.gdrive_export_secret.to_json))
+      @google_drive.add_sheet_to_spreadsheet(@malformed_restorations, "i18n_bad_translations", locale)
     end
     @malformed_restorations = nil
   end

--- a/bin/i18n/i18n_script_utils.rb
+++ b/bin/i18n/i18n_script_utils.rb
@@ -93,7 +93,9 @@ class I18nScriptUtils
 
   def self.upload_malformed_restorations(locale)
     return if @malformed_restorations.blank?
-    Google::Drive.new.add_sheet_to_spreadsheet(@malformed_restorations, "i18n_bad_translations", locale)
+    if CDO.gdrive_export_secret
+      Google::Drive.new(service_account_key: StringIO.new(CDO.gdrive_export_secret.to_json)).add_sheet_to_spreadsheet(@malformed_restorations, "i18n_bad_translations", locale)
+    end
     @malformed_restorations = nil
   end
 

--- a/bin/i18n/sync-out.rb
+++ b/bin/i18n/sync-out.rb
@@ -145,8 +145,8 @@ def restore_redacted_files
       end
       find_malformed_links_images(locale, translated_path)
     end
+    I18nScriptUtils.upload_malformed_restorations(locale)
   end
-
   puts "Restoration finished!"
 end
 


### PR DESCRIPTION
I couldn't think of a better way to do this so I'm restoring this functionality. Definitely open to suggestions or ways to make this data more accessible!

[slightly outdated spreadsheet](https://docs.google.com/spreadsheets/d/1V_x1htL9TvrKHTrK899LSL587W4oJyLHoDUc-8DqJhQ)

<!-- ### Background -->
<!-- ### Privacy -->
<!-- ### Security -->
<!-- ### Caching -->
<!-- ### Deployment strategy -->
<!-- ### Future work -->

## Links

<!--
  Any relevant links to external resources; ie, specification documents, jira
  items, related PRs, honeybadger errors, etc
-->

- [spec]()
- [jira]()

## Testing story

<!--
  Does your change include appropriate tests?

  If so, please describe how the tests included in this PR are sufficient

  If not, please explain why this change does not need to be tested.
-->

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
