### PR TITLE
Revert "Created migration to add 'time_spent' to 'user_levels' table"

### DIFF
--- a/dashboard/app/models/user_level.rb
+++ b/dashboard/app/models/user_level.rb
@@ -14,7 +14,6 @@
 #  submitted        :boolean
 #  readonly_answers :boolean
 #  unlocked_at      :datetime
-#  time_spent       :integer
 #
 # Indexes
 #

--- a/dashboard/db/migrate/20200730194330_add_time_spent_to_user_levels.rb
+++ b/dashboard/db/migrate/20200730194330_add_time_spent_to_user_levels.rb
@@ -1,7 +1,0 @@
-class AddTimeSpentToUserLevels < ActiveRecord::Migration[5.0]
-  def change
-    # This change will be implemented on production using the MySQL gh-ost tool.
-    return if Rails.env.production?
-    add_column :user_levels, :time_spent, :integer
-  end
-end

--- a/dashboard/db/schema.rb
+++ b/dashboard/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20200730194330) do
+ActiveRecord::Schema.define(version: 20200728201407) do
 
   create_table "activities", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci" do |t|
     t.integer  "user_id"
@@ -1588,7 +1588,6 @@ ActiveRecord::Schema.define(version: 20200730194330) do
     t.boolean  "submitted"
     t.boolean  "readonly_answers"
     t.datetime "unlocked_at"
-    t.integer  "time_spent"
     t.index ["user_id", "level_id", "script_id"], name: "index_user_levels_on_user_id_and_level_id_and_script_id", unique: true, using: :btree
   end
 


### PR DESCRIPTION
Having some issues with the build pipeline, so I am reverting recent changes to see what fixes it.
