### PR TITLE
Update UI test: Saving Applab project when signed out

### DIFF
--- a/dashboard/test/ui/features/learning_platform/projects/applab_project.feature
+++ b/dashboard/test/ui/features/learning_platform/projects/applab_project.feature
@@ -103,8 +103,6 @@ Scenario: Save Project After Signing Out
   When I sign out using jquery
   And I add code "// comment 2" to ace editor
   And ace editor code is equal to "// comment 1// comment 2"
-  And I press "resetButton"
-  And I click selector "#runButton" once I see it
   Then I get redirected to "/users/sign_in" via "dashboard"
 
   When I sign in as "Sally Student" from the sign in page

--- a/dashboard/test/ui/features/learning_platform/projects/applab_project.feature
+++ b/dashboard/test/ui/features/learning_platform/projects/applab_project.feature
@@ -101,8 +101,6 @@ Scenario: Save Project After Signing Out
   And element ".project_updated_at" eventually contains text "Saved"
 
   When I sign out using jquery
-  And I add code "// comment 2" to ace editor
-  And ace editor code is equal to "// comment 1// comment 2"
   Then I get redirected to "/users/sign_in" via "dashboard"
 
   When I sign in as "Sally Student" from the sign in page


### PR DESCRIPTION
This test was failing because the redirect was happening before the Reset button was clicked, which caused the test to fail when looking for the reset button. Updated the test to reflect the actual behavior.

<!--
  Your description goes here: A summary of the change, including any relevant motivation and context.

  If relevant, include a description both of the existing behavior and of the new behavior.
-->

<!--
  Other aspects to consider. uncomment and add detail for any that seem necessary:
-->

<!-- ### Background -->
<!-- ### Privacy -->
<!-- ### Security -->
<!-- ### Caching -->
<!-- ### Deployment strategy -->
<!-- ### Future work -->

## Links

<!--
  Any relevant links to external resources; ie, specification documents, jira
  items, related PRs, honeybadger errors, etc
-->

- [spec]()
- [jira]()

## Testing story

<!--
  Does your change include appropriate tests?

  If so, please describe how the tests included in this PR are sufficient

  If not, please explain why this change does not need to be tested.
-->

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
