### PR TITLE
Make schema cache dump binary data more consistent

### DIFF
--- a/dashboard/config/initializers/schema_cache_dedup.rb
+++ b/dashboard/config/initializers/schema_cache_dedup.rb
@@ -1,0 +1,149 @@
+# frozen_string_literal: true
+
+# This is a backport-patch of https://github.com/rails/rails/pull/35891,
+# "Deduplicate various Active Record schema cache structures".
+#
+# Though the PR's original use-case was to improve performance with large sharded schemas,
+# our use-case is to produce a schema cache dump that maintains identical binary data when re-serialized.
+#
+# The inconsistent deduplication of table-column Strings used as hash keys made the binary output inconsistent,
+# and this patch seems to help fix the issue.
+module SchemaCacheDedup
+  def primary_keys(table_name)
+    @primary_keys.fetch(table_name) do
+      if data_source_exists?(table_name)
+        @primary_keys[deep_deduplicate(table_name)] = deep_deduplicate(connection.primary_key(table_name))
+      end
+    end
+  end
+
+  def data_source_exists?(name)
+    prepare_data_sources if @data_sources.empty?
+    return @data_sources[name] if @data_sources.key? name
+
+    @data_sources[deep_deduplicate(name)] = connection.data_source_exists?(name)
+  end
+
+  def columns(table_name)
+    @columns.fetch(table_name) do
+      @columns[deep_deduplicate(table_name)] = deep_deduplicate(connection.columns(table_name))
+    end
+  end
+
+  def columns_hash(table_name)
+    @columns_hash.fetch(table_name) do
+      @columns_hash[deep_deduplicate(table_name)] = columns(table_name).index_by(&:name).freeze
+    end
+  end
+
+  def marshal_dump
+    derive_columns_hash_and_deduplicate_values
+    @version = ActiveRecord::Migrator.current_version
+    [@version, @columns, {}, @primary_keys, @data_sources]
+  end
+
+  def marshal_load(array)
+    @version, @columns, _columns_hash, @primary_keys, @data_sources = array
+
+    derive_columns_hash_and_deduplicate_values
+  end
+
+  private
+
+  def derive_columns_hash_and_deduplicate_values
+    @columns      = deep_deduplicate(@columns)
+    @columns_hash = @columns.transform_values {|columns| columns.index_by(&:name)}
+    @primary_keys = deep_deduplicate(@primary_keys)
+    @data_sources = deep_deduplicate(@data_sources)
+  end
+
+  def deep_deduplicate(value)
+    case value
+    when Hash
+      value.transform_keys(&method(:deep_deduplicate)).transform_values(&method(:deep_deduplicate))
+    when Array
+      value.map(&method(:deep_deduplicate))
+    when String, Deduplicable
+      # Marshal#load taints objects, and tainted objects can't be deduplicated.
+      # Taint mechanism is deprecated in Ruby 2.7.
+      value = value.dup.untaint if value.tainted?
+      -value
+    else
+      value
+    end
+  end
+
+  module Deduplicable
+    module ClassMethods
+      def registry
+        @registry ||= {}
+      end
+
+      def new(*)
+        super.deduplicate
+      end
+    end
+
+    def deduplicate
+      self.class.registry[self] ||= deduplicated
+    end
+    alias :-@ :deduplicate
+
+    private
+
+    def deduplicated
+      freeze
+    end
+  end
+
+  module ColumnDedup
+    include Deduplicable
+
+    private
+
+    def deduplicated
+      @name = -name
+      @table_name = -table_name if table_name
+      @sql_type_metadata = sql_type_metadata.deduplicate if sql_type_metadata
+      @default = -default if default
+      @default_function = -default_function if default_function
+      @collation = -collation if collation
+      @comment = -comment if comment
+      super
+    end
+  end
+  ActiveRecord::ConnectionAdapters::Column.prepend ColumnDedup
+  ActiveRecord::ConnectionAdapters::Column.singleton_class.prepend Deduplicable::ClassMethods
+
+  module SqlTypeMetadataDedup
+    include Deduplicable
+
+    private
+
+    def deduplicated
+      @sql_type = -sql_type
+      super
+    end
+  end
+  ActiveRecord::ConnectionAdapters::SqlTypeMetadata.prepend SqlTypeMetadataDedup
+  ActiveRecord::ConnectionAdapters::SqlTypeMetadata.singleton_class.prepend Deduplicable::ClassMethods
+
+  module MySQLTypeDedup
+    include Deduplicable
+
+    def initialize(type_metadata, extra: nil, strict: false)
+      super
+    end
+
+    private
+
+    def deduplicated
+      __setobj__(__getobj__.deduplicate)
+      @extra = -extra if extra
+      super
+    end
+  end
+  ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata.prepend MySQLTypeDedup
+  ActiveRecord::ConnectionAdapters::MySQL::TypeMetadata.singleton_class.prepend Deduplicable::ClassMethods
+end
+ActiveRecord::ConnectionAdapters::SchemaCache.prepend SchemaCacheDedup

--- a/dashboard/lib/tasks/setup_or_migrate.rake
+++ b/dashboard/lib/tasks/setup_or_migrate.rake
@@ -21,18 +21,24 @@ namespace :db do
     end
   end
 
-  task :round_trip_schema_cache do
-    Rake::Task['environment'].invoke
-
-    # This should be a no-op, but on staging we sometimes get a cache dump that changes when round-tripped through Marshal.
-    schema_cache_file = dashboard_dir('db/schema_cache.dump')
-    2.times do
-      data = File.binread(schema_cache_file)
-      checksum = Digest::MD5.hexdigest data
-      open(schema_cache_file, 'wb') do |f|
-        f.write(Marshal.dump(Marshal.load(data)))
+  namespace :schema do
+    namespace :cache do
+      # Normalize schema cache dump by re-processing the binary output through Marshal.
+      # This should be a no-op, but sometimes the output changes when round-tripped through Marshal
+      # (e.g., from subtle differences in how Ruby de-duplicates String objects in hash keys).
+      # See also SchemaCacheDedup patch.
+      task :dump do
+        file = 'schema_cache.dump'
+        path = File.join(ActiveRecord::Tasks::DatabaseTasks.db_dir, file)
+        old = File.binread(path)
+        new = Marshal.dump(Marshal.load(old))
+        unless old == new
+          ChatClient.log "#{file} changed from " \
+            "#{Digest::MD5.hexdigest(old)[0..4]} (#{old.bytesize} bytes) to " \
+            "#{Digest::MD5.hexdigest(new)[0..4]} (#{new.bytesize} bytes) after reprocessing."
+          File.binwrite(path, new)
+        end
       end
-      ChatClient.log "Can the schema cache dump #{checksum} be round-tripped through Marshal? #{(data == Marshal.dump(Marshal.load(data)))}"
     end
   end
 end

--- a/lib/rake/build.rake
+++ b/lib/rake/build.rake
@@ -54,7 +54,6 @@ namespace :build do
         unless rack_env?(:production)
           schema_cache_file = dashboard_dir('db/schema_cache.dump')
           RakeUtils.rake 'db:schema:cache:dump'
-          RakeUtils.rake 'db:round_trip_schema_cache'
           if GitUtils.file_changed_from_git?(schema_cache_file)
             # Staging is responsible for committing the authoritative schema cache dump.
             if rack_env?(:staging)


### PR DESCRIPTION
This PR tries to improve the consistency of binary data generated by `db:schema:cache:dump`, and improves the logic of the task that verifies the correctness of the data by round-tripping the data through `Marshal` serialization.

## Background

The [schema cache](https://kirshatrov.com/2016/12/13/schema-cache/) is a Rails feature we have used since #6586 that avoids redundant `SCHEMA` queries to the database from each application process by persisting the queried database structure to a file on disk that's committed to our repository.

As an extra layer of security, as part of our CI build process we add a check to verify that the schema cache dump in the repository matches the generated schema-cache dump from the application server, to ensure there is no unexpected inconsistency in the database schema across environments. This check requires a consistent mapping between the generated binary contents and the database schema structure (so that the same schema will always produce the same binary output).

Over the years, we have encountered various situations where the serialized binary file would intermittently change without any corresponding difference in the schema structure. As a workaround, #23851 added a 'round-trip' step that de-serializes and re-serializes the binary dump which seemed to make the contents more stable.

After thorough debugging, it seems the source of the intermittent binary differences is related to edge-cases around how and when Ruby de-duplicates `String`s, specifically when they are used as keys in `Hash` objects (as they are in the `SchemaCache` object). The Marshal format encodes references to an object having the same `object_id` so whether a String ends up being deduplicated impacts the final binary output. This PR backports an existing patch that manually deduplicates many of these Strings, and this seems to improve the consistency of the binary output as a result.

# Results

Before PR - `schema_cache.dump` grows from **177272** bytes to **194507** bytes after round-trip:
```
$ bundle exec rake db:schema:cache:dump
$ stat -c '%s' db/schema_cache.dump
177272
$ bundle exec rake db:round_trip_schema_cache
INFO -- : [development] Can the schema cache dump ffefe98b01436ccbac7a12b82a3cb2e7 be round-tripped through Marshal? false
INFO -- : [development] Can the schema cache dump 8b5419afb3d1463a86b0abf22df1e6f0 be round-tripped through Marshal? true
$ stat -c '%s' db/schema_cache.dump
194507
```

After PR - `schema_cache.dump` stays consistent at **82791** bytes after round-trip (which now happens automatically as part of the `db:schema:cache:dump` task):
```
$ bundle exec rake db:schema:cache:dump
$ stat -c '%s' db/schema_cache.dump
82791
```