### PR TITLE
Hoc /learn: add hidden labels on dropdowns

### DIFF
--- a/apps/src/tutorialExplorer/filterGroupOrgNames.jsx
+++ b/apps/src/tutorialExplorer/filterGroupOrgNames.jsx
@@ -41,7 +41,7 @@ export default class FilterGroupOrgNames extends React.Component {
     return (
       <FilterGroupContainer text={i18n.filterOrgNames()}>
         <label htmlFor="created-by-dropdown" className="hidden-label">
-          Created By
+          {i18n.filterOrgNames()}
         </label>
         <select
           id="created-by-dropdown"

--- a/apps/src/tutorialExplorer/filterGroupOrgNames.jsx
+++ b/apps/src/tutorialExplorer/filterGroupOrgNames.jsx
@@ -40,7 +40,11 @@ export default class FilterGroupOrgNames extends React.Component {
   render() {
     return (
       <FilterGroupContainer text={i18n.filterOrgNames()}>
+        <label htmlFor="created-by-dropdown" className="hidden-label">
+          Created By
+        </label>
         <select
+          id="created-by-dropdown"
           value={this.props.orgName}
           onChange={this.handleChangeOrgName}
           style={styles.select}

--- a/apps/src/tutorialExplorer/filterGroupOrgNames.jsx
+++ b/apps/src/tutorialExplorer/filterGroupOrgNames.jsx
@@ -40,11 +40,11 @@ export default class FilterGroupOrgNames extends React.Component {
   render() {
     return (
       <FilterGroupContainer text={i18n.filterOrgNames()}>
-        <label htmlFor="created-by-dropdown" className="hidden-label">
+        <label htmlFor="filter-org-names-dropdown" className="hidden-label">
           {i18n.filterOrgNames()}
         </label>
         <select
-          id="created-by-dropdown"
+          id="filter-org-names-dropdown"
           value={this.props.orgName}
           onChange={this.handleChangeOrgName}
           style={styles.select}

--- a/apps/src/tutorialExplorer/filterGroupSortBy.jsx
+++ b/apps/src/tutorialExplorer/filterGroupSortBy.jsx
@@ -48,7 +48,11 @@ export default class FilterGroupSortBy extends React.Component {
 
     return (
       <FilterGroupContainer text={i18n.filterSortBy()}>
+        <label htmlFor="sort-by-dropdown" className="hidden-label">
+          Sort By
+        </label>
         <select
+          id="sort-by-dropdown"
           value={this.props.sortBy}
           onChange={this.handleChangeSort}
           style={styles.select}

--- a/apps/src/tutorialExplorer/filterGroupSortBy.jsx
+++ b/apps/src/tutorialExplorer/filterGroupSortBy.jsx
@@ -49,7 +49,7 @@ export default class FilterGroupSortBy extends React.Component {
     return (
       <FilterGroupContainer text={i18n.filterSortBy()}>
         <label htmlFor="sort-by-dropdown" className="hidden-label">
-          Sort By
+          {i18n.filterSortBy()}
         </label>
         <select
           id="sort-by-dropdown"

--- a/apps/src/tutorialExplorer/filterGroupSortBy.jsx
+++ b/apps/src/tutorialExplorer/filterGroupSortBy.jsx
@@ -48,11 +48,11 @@ export default class FilterGroupSortBy extends React.Component {
 
     return (
       <FilterGroupContainer text={i18n.filterSortBy()}>
-        <label htmlFor="sort-by-dropdown" className="hidden-label">
+        <label htmlFor="filter-sort-by-dropdown" className="hidden-label">
           {i18n.filterSortBy()}
         </label>
         <select
-          id="sort-by-dropdown"
+          id="filter-sort-by-dropdown"
           value={this.props.sortBy}
           onChange={this.handleChangeSort}
           style={styles.select}

--- a/apps/test/unit/tutorialExplorer/filterGroupOrgNamesTest.jsx
+++ b/apps/test/unit/tutorialExplorer/filterGroupOrgNamesTest.jsx
@@ -23,7 +23,14 @@ describe('FilterGroupOrgNames', () => {
     const wrapper = shallow(<FilterGroupOrgNames {...DEFAULT_PROPS} />);
     expect(wrapper).to.containMatchingElement(
       <FilterGroupContainer text={i18n.filterOrgNames()}>
-        <select value={TEST_ORG_NAME} className="noFocusButton">
+        <label htmlFor="created-by-dropdown" className="hidden-label">
+          {i18n.filterOrgNames()}
+        </label>
+        <select
+          id="created-by-dropdown"
+          value={TEST_ORG_NAME}
+          className="noFocusButton"
+        >
           <option key="all" value="all">
             {i18n.filterOrgNamesAll()}
           </option>

--- a/apps/test/unit/tutorialExplorer/filterGroupOrgNamesTest.jsx
+++ b/apps/test/unit/tutorialExplorer/filterGroupOrgNamesTest.jsx
@@ -23,11 +23,11 @@ describe('FilterGroupOrgNames', () => {
     const wrapper = shallow(<FilterGroupOrgNames {...DEFAULT_PROPS} />);
     expect(wrapper).to.containMatchingElement(
       <FilterGroupContainer text={i18n.filterOrgNames()}>
-        <label htmlFor="created-by-dropdown" className="hidden-label">
+        <label htmlFor="filter-org-names-dropdown" className="hidden-label">
           {i18n.filterOrgNames()}
         </label>
         <select
-          id="created-by-dropdown"
+          id="filter-org-names-dropdown"
           value={TEST_ORG_NAME}
           className="noFocusButton"
         >

--- a/pegasus/sites.v3/code.org/styles/040-page.css
+++ b/pegasus/sites.v3/code.org/styles/040-page.css
@@ -581,3 +581,12 @@ a.btn-default:active, a.btn-default:hover, a.btn-default:link, a.btn-default:vis
 .assign-confirm-modal .modal-buttons {
   margin-top: 15px
 }
+
+.hidden-label {
+  position: fixed;
+  left: -10000px;
+  top: auto;
+  width: 1px;
+  height: 1px;
+  overflow: hidden;
+}

--- a/pegasus/sites.v3/csedweek.org/styles/040-styling.css
+++ b/pegasus/sites.v3/csedweek.org/styles/040-styling.css
@@ -742,3 +742,12 @@ label {
 .video_caption_link {
   font-family: 'Gotham 4r', sans-serif;
 }
+
+.hidden-label {
+  position: fixed;
+  left: -10000px;
+  top: auto;
+  width: 1px;
+  height: 1px;
+  overflow: hidden;
+}

--- a/pegasus/sites.v3/hourofcode.com/i18n/en.yml
+++ b/pegasus/sites.v3/hourofcode.com/i18n/en.yml
@@ -6043,3 +6043,5 @@
   some: "Some"
   all: "All"
   dont_know: "I don't know"
+
+  language_label: "Language"

--- a/pegasus/sites.v3/hourofcode.com/styles/060-hoc-specific.css
+++ b/pegasus/sites.v3/hourofcode.com/styles/060-hoc-specific.css
@@ -216,3 +216,11 @@ iframe {
     margin-left: 1em;
   }
 }
+.hidden-label {
+  position:absolute;
+  left:-10000px;
+  top:auto;
+  width:1px;
+  height:1px;
+  overflow:hidden;
+}

--- a/pegasus/sites.v3/hourofcode.com/styles/060-hoc-specific.css
+++ b/pegasus/sites.v3/hourofcode.com/styles/060-hoc-specific.css
@@ -217,10 +217,10 @@ iframe {
   }
 }
 .hidden-label {
-  position:absolute;
-  left:-10000px;
-  top:auto;
-  width:1px;
-  height:1px;
-  overflow:hidden;
+  position: fixed;
+  left: -10000px;
+  top: auto;
+  width: 1px;
+  height: 1px;
+  overflow: hidden;
 }

--- a/pegasus/sites.v3/hourofcode.com/views/language_dropdown.haml
+++ b/pegasus/sites.v3/hourofcode.com/views/language_dropdown.haml
@@ -1,5 +1,6 @@
 -path = request.path_info
 -path = path[@language.length + 1..-1] if path[0..@language.length] == "/#{@language}"
-%select{onchange:"window.location.href = '/#{@country}/' + this.value + '#{path != '/' ? path : ''}';"}
+%label{class: 'hidden-label', for: 'language-dropdown-select'} Language
+%select{id: 'language-dropdown-select', onchange:"window.location.href = '/#{@country}/' + this.value + '#{path != '/' ? path : ''}';"}
   -DB[:cdo_languages].where(supported_hoc_b: 1).each do |i|
     %option{value:i[:unique_language_s], selected:i[:unique_language_s]==@language}= i[:native_name_s]

--- a/pegasus/sites.v3/hourofcode.com/views/language_dropdown.haml
+++ b/pegasus/sites.v3/hourofcode.com/views/language_dropdown.haml
@@ -1,6 +1,6 @@
 -path = request.path_info
 -path = path[@language.length + 1..-1] if path[0..@language.length] == "/#{@language}"
-%label{class: 'hidden-label', for: 'language-dropdown-select'} Language
+%label{class: 'hidden-label', for: 'language-dropdown-select'}=hoc_s(:language_label)
 %select{id: 'language-dropdown-select', onchange:"window.location.href = '/#{@country}/' + this.value + '#{path != '/' ? path : ''}';"}
   -DB[:cdo_languages].where(supported_hoc_b: 1).each do |i|
     %option{value:i[:unique_language_s], selected:i[:unique_language_s]==@language}= i[:native_name_s]


### PR DESCRIPTION
[STAR-1201](https://codedotorg.atlassian.net/browse/STAR-1201)
Fix some accessibility errors on hourofcode.com/learn related to dropdowns not having labels associated with them. Added hidden labels for the language dropdown, sort by dropdown and created by dropdown. The page will still look the same, but screenreaders will now have appropriate labels to read.

<!-- ### Background -->
<!-- ### Privacy -->
<!-- ### Security -->
<!-- ### Caching -->
<!-- ### Deployment strategy -->
<!-- ### Future work -->

## Links

- [jira](https://codedotorg.atlassian.net/browse/STAR-1201)

## Testing story
Tested locally that the page still looks the same and that the Koa11y errors related to select elements not having labels went away.

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
