### PR TITLE
Hackathon 2020: jobs page refresh, initial placeholder

### DIFF
--- a/pegasus/sites.v3/code.org/public/about/work-with-us.md.erb
+++ b/pegasus/sites.v3/code.org/public/about/work-with-us.md.erb
@@ -1,0 +1,24 @@
+---
+title: Code.org - work with us
+nav: about_nav
+video_player: true
+theme: responsive
+---
+<link rel="stylesheet" type="text/css" rel= "stylesheet" href="/css/jobs.css" />
+
+# How will you change the world?
+
+Code.org is a nonprofit organization dedicated to expanding participation in computer science by making it available in more schools, and increasing participation by women and underrepresented students of color.
+
+## Our vision is that every student in every school should have the opportunity to learn computer science.
+
+**We are currently hiring for:**
+<div id='lever-jobs-container'></div>
+<script type='text/javascript'>
+
+  window.leverJobsOptions = {accountName: 'Code.org'};
+
+</script>
+<script type='text/javascript' src='https://andreasmb.github.io/lever-jobs-embed/index.js'></script>
+
+_**COVID-19 update:** We are continuing to closely monitor the evolving situation and we appreciate your understanding and flexibility with any related changes to our interviewing process._


### PR DESCRIPTION
In an effort to increase recruitment of diverse and high-quality applicants across teams and better reflect who we are as an organization, we're revamping and expanding the content on code.org/about/jobs. The new and improved version of this page will live at code.org/about/work-with-us.  I built a placeholder for that page and moved over the Lever job postings integration. Once merged to staging, this change will allow content editors to draft work-with-us.  Then we can redirect jobs to work-with-us once the new content is ready to go.  We won't be linking to work-with-us yet or posting any sensitive or time-specific information on that page so it seems reasonable to not hide this work behind a flag. 

<img width="1257" alt="Screen Shot 2020-08-04 at 6 31 44 PM" src="https://user-images.githubusercontent.com/12300669/89362484-0546f500-d69c-11ea-8e99-19647a1aa0ed.png">
