### PR TITLE
Schema version change for updating academic year workshop subjects

### DIFF
--- a/dashboard/db/schema.rb
+++ b/dashboard/db/schema.rb
@@ -10,11 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-<<<<<<< Updated upstream
-ActiveRecord::Schema.define(version: 20200730231738) do
-=======
 ActiveRecord::Schema.define(version: 20200803211022) do
->>>>>>> Stashed changes
 
   create_table "activities", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci" do |t|
     t.integer  "user_id"

--- a/dashboard/db/schema.rb
+++ b/dashboard/db/schema.rb
@@ -10,7 +10,11 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
+<<<<<<< Updated upstream
 ActiveRecord::Schema.define(version: 20200730231738) do
+=======
+ActiveRecord::Schema.define(version: 20200803211022) do
+>>>>>>> Stashed changes
 
   create_table "activities", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci" do |t|
     t.integer  "user_id"


### PR DESCRIPTION
Follow-up to https://github.com/code-dot-org/code-dot-org/pull/36138, missed updating schema version.