### PR TITLE
Add a download link to the Aloe Blacc text compression video

### DIFF
--- a/pegasus/sites.v3/code.org/public/educate/resources/videos.md.erb
+++ b/pegasus/sites.v3/code.org/public/educate/resources/videos.md.erb
@@ -149,7 +149,7 @@ twitter = {:url=>'https://www.youtube.com/watch?t=66&v=15aqFQQVBWU', :related=>'
 
 <% facebook = {:u=>'https://youtu.be/By30SCp-Tsw'}
 twitter = {:url=>'https://youtu.be/By30SCp-Tsw', :related=>'codeorg', :text=>'Aloe Blacc explains DIGITAL COMPRESSION @codeorg'} %>
-<%=view :display_video_thumbnail, id: "compression", video_code: "By30SCp-Tsw", caption: "Aloe Blacc explains DIGITAL COMPRESSION", play_button: 'center', facebook: facebook, twitter: twitter %>
+<%=view :display_video_thumbnail, id: "compression", video_code: "By30SCp-Tsw", caption: "Aloe Blacc explains DIGITAL COMPRESSION", play_button: 'center', facebook: facebook, twitter: twitter, download_path: "//videos.code.org/2015/csp/textcompression_blacc_short.mp4"%>
 
 [/col-50]
 


### PR DESCRIPTION
This version of the Aloe Blacc text compression video on our videos page (https://code.org/educate/resources/videos) is shorter than the version we use in our curriculum, and did not have a fallback version or download link.  We've just uploaded this version of the video to videos.code.org and need to update the code here to make the appropriate download link appear.

With YouTube access, notice that there's now a download button in the lower-right-hand corner of the video:

| Before | After |
| --- | --- |
| ![image](https://user-images.githubusercontent.com/1615761/89469284-f6a91e00-d72d-11ea-9c61-19bfb4db1a86.png) | ![image](https://user-images.githubusercontent.com/1615761/89469254-e85b0200-d72d-11ea-8e36-04af5d2405b4.png) |

With YouTube blocked, the video simply didn't load.  Now it will:

| Before | After |
| --- | --- |
| ![image](https://user-images.githubusercontent.com/1615761/89469515-6f0fdf00-d72e-11ea-9106-c56a7e92a46c.png) | ![image](https://user-images.githubusercontent.com/1615761/89469546-82bb4580-d72e-11ea-9f0b-5d072b4c6dcb.png) |

## Testing story

Checked manually, as recorded in screenshots above.

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
