### PR TITLE
NetSim: Re-enable old tests

### DIFF
--- a/apps/test/unit/netsim/NetSimTable.js
+++ b/apps/test/unit/netsim/NetSimTable.js
@@ -485,12 +485,7 @@ describe('NetSimTable', function() {
     assert.equal(notifyCount, 1);
   });
 
-  // A number of NetSim tests are failing intermittently, but semi-frequently
-  // for me. Some initial investigation pointed to the issue possibly being with
-  // makeThrottledRefresh_ causing us not to hit NetSimTable.prototype.refresh
-  // when we expect. Disabling these tests until Brad has a chance to investigate
-  // further
-  describe.skip('polling', function() {
+  describe('polling', function() {
     it('polls table on tick', function() {
       // Initial tick always triggers a poll event.
       netsimTable.tick();
@@ -511,7 +506,7 @@ describe('NetSimTable', function() {
     });
   });
 
-  describe.skip('initial delay coalescing', function() {
+  describe('initial delay coalescing', function() {
     const COALESCE_WINDOW = 100; // ms
 
     beforeEach(function() {
@@ -563,7 +558,7 @@ describe('NetSimTable', function() {
     });
   });
 
-  describe.skip('refresh throttling', function() {
+  describe('refresh throttling', function() {
     beforeEach(function() {
       // Re-enable 50ms refreshTable_ throttle to test throttling feature
       netsimTable.setMinimumDelayBetweenRefreshes(50);
@@ -681,7 +676,7 @@ describe('NetSimTable', function() {
     });
   });
 
-  describe.skip('incremental update', function() {
+  describe('incremental update', function() {
     beforeEach(function() {
       // New table configured for incremental refresh
       netsimTable = NetSimTestUtils.overrideNetSimTableApi(


### PR DESCRIPTION
These tests, [disabled by Brent in August 2017](https://github.com/code-dot-org/code-dot-org/commit/7c0cec2ae1288d9dde3b52c947039e7e448c57d3) for failing intermittently, don't seem to be an issue anymore.  I've re-enabled them with no modifications and have observed no failures in more than ten local test runs.

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
