### PR TITLE
Cleanup: Stop including components on window.dashboard

### DIFF
--- a/apps/Gruntfile.js
+++ b/apps/Gruntfile.js
@@ -512,6 +512,8 @@ describe('entry tests', () => {
       './src/sites/studio/pages/layouts/_school_info_confirmation_dialog.js',
     'layouts/_school_info_interstitial':
       './src/sites/studio/pages/layouts/_school_info_interstitial.js',
+    'layouts/_small_footer':
+      './src/sites/studio/pages/layouts/_small_footer.js',
     'layouts/_terms_interstitial':
       './src/sites/studio/pages/layouts/_terms_interstitial.js',
     'levels/_bubble_choice':

--- a/apps/src/code-studio/components/Attachments.jsx
+++ b/apps/src/code-studio/components/Attachments.jsx
@@ -103,6 +103,3 @@ export default class Attachments extends React.Component {
     );
   }
 }
-
-window.dashboard = window.dashboard || {};
-window.dashboard.Attachments = Attachments;

--- a/apps/src/code-studio/components/SendToPhone.jsx
+++ b/apps/src/code-studio/components/SendToPhone.jsx
@@ -144,7 +144,3 @@ export default class SendToPhone extends React.Component {
     );
   }
 }
-
-// We put this on the dashboard namespace so that it's accessible to apps
-window.dashboard = window.dashboard || {};
-window.dashboard.SendToPhone = SendToPhone;

--- a/apps/src/code-studio/components/SmallFooter.jsx
+++ b/apps/src/code-studio/components/SmallFooter.jsx
@@ -314,6 +314,3 @@ export default class SmallFooter extends React.Component {
     );
   }
 }
-
-window.dashboard = window.dashboard || {};
-window.dashboard.SmallFooter = SmallFooter;

--- a/apps/src/sites/studio/pages/code-studio.js
+++ b/apps/src/sites/studio/pages/code-studio.js
@@ -34,7 +34,6 @@ window.Radium = require('radium');
 
 // TODO (bbuchanan): Stop including these components in a global way, just
 //                   require them specifically where needed.
-require('@cdo/apps/code-studio/components/AbuseError');
 require('@cdo/apps/code-studio/components/SendToPhone');
 require('@cdo/apps/code-studio/components/SmallFooter');
 require('@cdo/apps/code-studio/components/Attachments');

--- a/apps/src/sites/studio/pages/code-studio.js
+++ b/apps/src/sites/studio/pages/code-studio.js
@@ -32,9 +32,8 @@ window.React = require('react');
 window.ReactDOM = require('react-dom');
 window.Radium = require('radium');
 
-// TODO (bbuchanan): Stop including these components in a global way, just
-//                   require them specifically where needed.
-require('@cdo/apps/code-studio/components/SmallFooter');
+// TODO (bbuchanan): Stop including this component in a global way, just
+//                   require it specifically where needed.
 require('@cdo/apps/code-studio/components/Attachments');
 
 // Prevent callstack exceptions when opening multiple dialogs

--- a/apps/src/sites/studio/pages/code-studio.js
+++ b/apps/src/sites/studio/pages/code-studio.js
@@ -34,7 +34,6 @@ window.Radium = require('radium');
 
 // TODO (bbuchanan): Stop including these components in a global way, just
 //                   require them specifically where needed.
-require('@cdo/apps/code-studio/components/SendToPhone');
 require('@cdo/apps/code-studio/components/SmallFooter');
 require('@cdo/apps/code-studio/components/Attachments');
 

--- a/apps/src/sites/studio/pages/code-studio.js
+++ b/apps/src/sites/studio/pages/code-studio.js
@@ -32,10 +32,6 @@ window.React = require('react');
 window.ReactDOM = require('react-dom');
 window.Radium = require('radium');
 
-// TODO (bbuchanan): Stop including this component in a global way, just
-//                   require it specifically where needed.
-require('@cdo/apps/code-studio/components/Attachments');
-
 // Prevent callstack exceptions when opening multiple dialogs
 // http://stackoverflow.com/a/15856139/2506748
 if ($.fn.modal) {

--- a/apps/src/sites/studio/pages/layouts/_small_footer.js
+++ b/apps/src/sites/studio/pages/layouts/_small_footer.js
@@ -1,0 +1,11 @@
+import React from 'react';
+import ReactDOM from 'react-dom';
+import getScriptData from '@cdo/apps/util/getScriptData';
+import SmallFooter from '@cdo/apps/code-studio/components/SmallFooter';
+
+// Note: We're not waiting for document.ready; we expect this script to be inlined into
+// the DOM immediately after the necessary #page-small-footer markup.
+ReactDOM.render(
+  <SmallFooter {...getScriptData('smallfooter')} />,
+  document.getElementById('page-small-footer')
+);

--- a/apps/src/sites/studio/pages/levels/_free_response.js
+++ b/apps/src/sites/studio/pages/levels/_free_response.js
@@ -1,18 +1,39 @@
+/* global dashboard appOptions */
 import $ from 'jquery';
 import React from 'react';
-import ReactDom from 'react-dom';
+import ReactDOM from 'react-dom';
+import getScriptData from '@cdo/apps/util/getScriptData';
 import SafeMarkdown from '@cdo/apps/templates/SafeMarkdown';
+import Attachments from '@cdo/apps/code-studio/components/Attachments';
 
 $(document).ready(() => {
+  const data = getScriptData('freeresponse');
+
   $('.free-response > .markdown-container').each(function() {
     const container = this;
     if (!container.dataset.markdown) {
       return;
     }
 
-    ReactDom.render(
+    ReactDOM.render(
       React.createElement(SafeMarkdown, container.dataset, null),
       container
     );
   });
+
+  const attachmentsMountPoint = document.querySelector('#free-response-upload');
+  const attachmentsProps = data.attachments_props;
+  if (attachmentsMountPoint && attachmentsProps) {
+    dashboard.project.getCurrentId = function() {
+      return appOptions.channel;
+    };
+
+    ReactDOM.render(
+      <Attachments
+        showUnderageWarning={!appOptions.is13Plus}
+        {...attachmentsProps}
+      />,
+      attachmentsMountPoint
+    );
+  }
 });

--- a/dashboard/app/views/layouts/_small_footer.html.haml
+++ b/dashboard/app/views/layouts/_small_footer.html.haml
@@ -1,5 +1,3 @@
-#page-small-footer
-
 :ruby
   full_width = local_assigns[:full_width]
   channel = local_assigns[:channel]
@@ -17,7 +15,5 @@
     channel: channel
   }
 
-:javascript
-  // Render the footer on the non-share pages
-  ReactDOM.render(React.createElement(window.dashboard.SmallFooter, #{reactProps.to_json}),
-    document.getElementById('page-small-footer'));
+#page-small-footer
+%script{src: webpack_asset_path('js/layouts/_small_footer.js'), data: {smallfooter: reactProps.to_json}}

--- a/dashboard/app/views/levels/_free_response.html.haml
+++ b/dashboard/app/views/levels/_free_response.html.haml
@@ -1,11 +1,10 @@
-- content_for(:head) do
-  %script{src: webpack_asset_path('js/levels/_free_response.js')}
-
-- level ||= @level
-- last_attempt = @last_attempt unless local_assigns.has_key? :last_attempt
-- in_level_group ||= false
-- left_align = local_assigns[:left_align]
-- is_contained_level ||= false
+:ruby
+  js_data = {}
+  level ||= @level
+  last_attempt = @last_attempt unless local_assigns.has_key? :last_attempt
+  in_level_group ||= false
+  left_align = local_assigns[:left_align]
+  is_contained_level ||= false
 
 - if level.solution.present? && is_contained_level && can_view_teacher_markdown?
   %div{id: "containedLevelAnswer0"}
@@ -44,12 +43,10 @@
     %script{src: webpack_asset_path('js/fileupload/jquery.iframe-transport.js')}
     %script{src: webpack_asset_path('js/fileupload/jquery.fileupload.js')}
     %p#free-response-upload
-    :javascript
-      dashboard.project.getCurrentId = function () {
-        return appOptions.channel;
-      };
-
-      ReactDOM.render(React.createElement(dashboard.Attachments, {showUnderageWarning: !appOptions.is13Plus, readonly: #{!!@view_options.readonly_workspace}}), document.querySelector('#free-response-upload'));
+    :ruby
+      js_data[:attachments_props] = {
+        readonly: !!@view_options.readonly_workspace
+      }
 
   - height = level.height || '80'
   - placeholder = level.get_property(:placeholder) || I18n.t('free_response.placeholder')
@@ -58,3 +55,6 @@
   -# Don't render the dialog partial if we're inside a LevelGroup.
   = render partial: 'levels/dialog', locals: {app: 'free_response'} unless in_level_group
   = render partial: 'levels/teacher_markdown', locals: {data: {'teacher_markdown' => level.solution}} unless is_contained_level
+
+- content_for(:head) do
+  %script{src: webpack_asset_path('js/levels/_free_response.js'), data: {freeresponse: js_data.to_json}}


### PR DESCRIPTION
Cleans up this old TODO:

https://github.com/code-dot-org/code-dot-org/blob/68c6ec22498a943ead4faa7be4c6a47c529558e1/apps/src/sites/studio/pages/code-studio.js#L35-L40

`AbuseError` and `SendToPhone` didn't require any special cleanup, they were already explicitly required everywhere they were used.

`SmallFooter` was used by some JavaScript inlined into the `_small_footer.html.haml` partial.  I've given this partial its own JS entry point so we can do an explicit require.

`Attachments` was used by some JavaScript inlined into the `_free_response.html.haml` partial.  There's quite a bit of inline JS in this partial, even though it already had its own JS entry point as well.  I've only moved the initialization for the `Attachments` component over to the entry point; there's room for further cleanup here.  Since this was the only use of `Attachments`, it also got pulled into this rarely-used bundle; a tiny bit less to load on every other page of our site.

![Screenshot from 2020-08-06 11-47-06](https://user-images.githubusercontent.com/1615761/89570795-89ec5d00-d7db-11ea-95d6-8cff273f1025.png)
_The `_free_response.js` uncompressed bundle size before (above) and after (below)._

## Testing story

Manually tested the `SmallFooter` change with http://localhost-studio.code.org:3000/s/frozen/stage/1/puzzle/7.  Visually checked that the small footer rendered correctly and is interactable. Verified using devtools that the bundle downloaded and looked like I expected it would, and that no console errors were generated.

![image](https://user-images.githubusercontent.com/1615761/89571270-3cbcbb00-d7dc-11ea-8c10-ee93ccae410e.png)

Manually tested the `Attachments` change with http://localhost-studio.code.org:3000/s/csp1-support/stage/5/puzzle/6 (while signed in as a teacher). Visually checked that the attachments component shows up as expected and that you can upload attachments.  Verified using devtools that the bundle contains the code I expected and that no console errors were generated.

![image](https://user-images.githubusercontent.com/1615761/89571178-1b5bcf00-d7dc-11ea-8f70-cb6a6dc68ed0.png)


# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
