### PR TITLE
Update curriculum reference level links from cspilot to csp-20

### DIFF
--- a/dashboard/config/scripts/levels/CSP U10L1 SFLP 20-21.level
+++ b/dashboard/config/scripts/levels/CSP U10L1 SFLP 20-21.level
@@ -7,7 +7,7 @@
   "properties": {
     "instructions_important": "false",
     "display_name": "Lesson Overview",
-    "reference": "/curriculum/cspilot/unit10/1/overview/index.html",
+    "reference": "/curriculum/csp-20/unit10/1/overview/index.html",
     "parent_level_id": 19255,
     "name_suffix": "_2019",
     "encrypted": "false"

--- a/dashboard/config/scripts/levels/CSP U10L10 SFLP 20-21.level
+++ b/dashboard/config/scripts/levels/CSP U10L10 SFLP 20-21.level
@@ -7,7 +7,7 @@
   "properties": {
     "instructions_important": "false",
     "display_name": "Lesson Overview",
-    "reference": "/curriculum/cspilot/unit10/10/overview/index.html",
+    "reference": "/curriculum/csp-20/unit10/10/overview/index.html",
     "parent_level_id": 19626,
     "name_suffix": "_2019",
     "encrypted": "false"

--- a/dashboard/config/scripts/levels/CSP U10L11 SFLP 20-21.level
+++ b/dashboard/config/scripts/levels/CSP U10L11 SFLP 20-21.level
@@ -7,7 +7,7 @@
   "properties": {
     "instructions_important": "false",
     "display_name": "Lesson Overview",
-    "reference": "/curriculum/cspilot/unit10/11/overview/index.html",
+    "reference": "/curriculum/csp-20/unit10/11/overview/index.html",
     "parent_level_id": 19664,
     "name_suffix": "_2019",
     "encrypted": "false"

--- a/dashboard/config/scripts/levels/CSP U10L12 SFLP 20-21.level
+++ b/dashboard/config/scripts/levels/CSP U10L12 SFLP 20-21.level
@@ -7,7 +7,7 @@
   "properties": {
     "instructions_important": "false",
     "display_name": "Lesson Overview",
-    "reference": "/curriculum/cspilot/unit10/12/overview/index.html",
+    "reference": "/curriculum/csp-20/unit10/12/overview/index.html",
     "parent_level_id": 19665,
     "name_suffix": "_2019",
     "encrypted": "false"

--- a/dashboard/config/scripts/levels/CSP U10L13 SFLP 20-21.level
+++ b/dashboard/config/scripts/levels/CSP U10L13 SFLP 20-21.level
@@ -7,7 +7,7 @@
   "properties": {
     "instructions_important": "false",
     "display_name": "Lesson Overview",
-    "reference": "/curriculum/cspilot/unit10/13/overview/index.html",
+    "reference": "/curriculum/csp-20/unit10/13/overview/index.html",
     "parent_level_id": 19666,
     "name_suffix": "_2019",
     "encrypted": "false"

--- a/dashboard/config/scripts/levels/CSP U10L14 SFLP 20-21.level
+++ b/dashboard/config/scripts/levels/CSP U10L14 SFLP 20-21.level
@@ -7,7 +7,7 @@
   "properties": {
     "instructions_important": "false",
     "display_name": "Lesson Overview",
-    "reference": "/curriculum/cspilot/unit10/14/overview/index.html",
+    "reference": "/curriculum/csp-20/unit10/14/overview/index.html",
     "parent_level_id": 19220,
     "name_suffix": "_2019",
     "encrypted": "false"

--- a/dashboard/config/scripts/levels/CSP U10L2 SFLP 20-21.level
+++ b/dashboard/config/scripts/levels/CSP U10L2 SFLP 20-21.level
@@ -7,7 +7,7 @@
   "properties": {
     "instructions_important": "false",
     "display_name": "Lesson Overview",
-    "reference": "/curriculum/cspilot/unit10/2/overview/index.html",
+    "reference": "/curriculum/csp-20/unit10/2/overview/index.html",
     "parent_level_id": 19501,
     "name_suffix": "_2019",
     "encrypted": "false"

--- a/dashboard/config/scripts/levels/CSP U10L3 SFLP 20-21.level
+++ b/dashboard/config/scripts/levels/CSP U10L3 SFLP 20-21.level
@@ -7,7 +7,7 @@
   "properties": {
     "instructions_important": "false",
     "display_name": "Lesson Overview",
-    "reference": "/curriculum/cspilot/unit10/3/overview/index.html",
+    "reference": "/curriculum/csp-20/unit10/3/overview/index.html",
     "parent_level_id": 19505,
     "name_suffix": "_2019",
     "encrypted": "false"

--- a/dashboard/config/scripts/levels/CSP U10L4 SFLP 20-21.level
+++ b/dashboard/config/scripts/levels/CSP U10L4 SFLP 20-21.level
@@ -7,7 +7,7 @@
   "properties": {
     "instructions_important": "false",
     "display_name": "Lesson Overview",
-    "reference": "/curriculum/cspilot/unit10/4/overview/index.html",
+    "reference": "/curriculum/csp-20/unit10/4/overview/index.html",
     "parent_level_id": 19598,
     "name_suffix": "_2019",
     "encrypted": "false"

--- a/dashboard/config/scripts/levels/CSP U10L5 SFLP 20-21.level
+++ b/dashboard/config/scripts/levels/CSP U10L5 SFLP 20-21.level
@@ -7,7 +7,7 @@
   "properties": {
     "instructions_important": "false",
     "display_name": "Lesson Overview",
-    "reference": "/curriculum/cspilot/unit10/5/overview/index.html",
+    "reference": "/curriculum/csp-20/unit10/5/overview/index.html",
     "parent_level_id": 19599,
     "name_suffix": "_2019",
     "encrypted": "false"

--- a/dashboard/config/scripts/levels/CSP U10L6 SFLP 20-21.level
+++ b/dashboard/config/scripts/levels/CSP U10L6 SFLP 20-21.level
@@ -7,7 +7,7 @@
   "properties": {
     "instructions_important": "false",
     "display_name": "Lesson Overview",
-    "reference": "/curriculum/cspilot/unit10/6/overview/index.html",
+    "reference": "/curriculum/csp-20/unit10/6/overview/index.html",
     "parent_level_id": 19505,
     "name_suffix": "_2019",
     "encrypted": "false"

--- a/dashboard/config/scripts/levels/CSP U10L7 SFLP 20-21.level
+++ b/dashboard/config/scripts/levels/CSP U10L7 SFLP 20-21.level
@@ -7,7 +7,7 @@
   "properties": {
     "instructions_important": "false",
     "display_name": "Lesson Overview",
-    "reference": "/curriculum/cspilot/unit10/7/overview/index.html",
+    "reference": "/curriculum/csp-20/unit10/7/overview/index.html",
     "parent_level_id": 19506,
     "name_suffix": "_2019",
     "encrypted": "false"

--- a/dashboard/config/scripts/levels/CSP U10L8 SFLP 20-21.level
+++ b/dashboard/config/scripts/levels/CSP U10L8 SFLP 20-21.level
@@ -7,7 +7,7 @@
   "properties": {
     "instructions_important": "false",
     "display_name": "Lesson Overview",
-    "reference": "/curriculum/cspilot/unit10/8/overview/index.html",
+    "reference": "/curriculum/csp-20/unit10/8/overview/index.html",
     "parent_level_id": 19607,
     "name_suffix": "_2019",
     "encrypted": "false"

--- a/dashboard/config/scripts/levels/CSP U10L9 SFLP 20-21.level
+++ b/dashboard/config/scripts/levels/CSP U10L9 SFLP 20-21.level
@@ -7,7 +7,7 @@
   "properties": {
     "instructions_important": "false",
     "display_name": "Lesson Overview",
-    "reference": "/curriculum/cspilot/unit10/9/overview/index.html",
+    "reference": "/curriculum/csp-20/unit10/9/overview/index.html",
     "parent_level_id": 19526,
     "name_suffix": "_2019",
     "encrypted": "false"

--- a/dashboard/config/scripts/levels/CSP U1L1 SFLP 20-21.level
+++ b/dashboard/config/scripts/levels/CSP U1L1 SFLP 20-21.level
@@ -7,7 +7,7 @@
   "properties": {
     "instructions_important": "false",
     "display_name": "Lesson Overview",
-    "reference": "/curriculum/cspilot/unit1/1/overview/index.html",
+    "reference": "/curriculum/csp-20/unit1/1/overview/index.html",
     "parent_level_id": 16820,
     "name_suffix": "_2019",
     "encrypted": "false"

--- a/dashboard/config/scripts/levels/CSP U1L10 SFLP 20-21.level
+++ b/dashboard/config/scripts/levels/CSP U1L10 SFLP 20-21.level
@@ -7,7 +7,7 @@
   "properties": {
     "instructions_important": "false",
     "display_name": "Lesson Overview",
-    "reference": "/curriculum/cspilot/unit1/9/overview/index.html",
+    "reference": "/curriculum/csp-20/unit1/9/overview/index.html",
     "parent_level_id": 18910,
     "name_suffix": "_2019",
     "encrypted": "false"

--- a/dashboard/config/scripts/levels/CSP U1L11 SFLP 20-21.level
+++ b/dashboard/config/scripts/levels/CSP U1L11 SFLP 20-21.level
@@ -7,7 +7,7 @@
   "properties": {
     "instructions_important": "false",
     "display_name": "Lesson Overview",
-    "reference": "/curriculum/cspilot/unit1/10/overview/index.html",
+    "reference": "/curriculum/csp-20/unit1/10/overview/index.html",
     "parent_level_id": 18911,
     "name_suffix": "_2019",
     "encrypted": "false"

--- a/dashboard/config/scripts/levels/CSP U1L12 SFLP 20-21.level
+++ b/dashboard/config/scripts/levels/CSP U1L12 SFLP 20-21.level
@@ -7,7 +7,7 @@
   "properties": {
     "instructions_important": "false",
     "display_name": "Lesson Overview",
-    "reference": "/curriculum/cspilot/unit1/11/overview/index.html",
+    "reference": "/curriculum/csp-20/unit1/11/overview/index.html",
     "parent_level_id": 18912,
     "name_suffix": "_2019",
     "encrypted": "false"

--- a/dashboard/config/scripts/levels/CSP U1L13 SFLP 20-21.level
+++ b/dashboard/config/scripts/levels/CSP U1L13 SFLP 20-21.level
@@ -7,7 +7,7 @@
   "properties": {
     "instructions_important": "false",
     "display_name": "Lesson Overview",
-    "reference": "/curriculum/cspilot/unit1/12/overview/index.html",
+    "reference": "/curriculum/csp-20/unit1/12/overview/index.html",
     "parent_level_id": 18913,
     "name_suffix": "_2019",
     "encrypted": "false"

--- a/dashboard/config/scripts/levels/CSP U1L14 SFLP 20-21.level
+++ b/dashboard/config/scripts/levels/CSP U1L14 SFLP 20-21.level
@@ -7,7 +7,7 @@
   "properties": {
     "instructions_important": "false",
     "display_name": "Lesson Overview",
-    "reference": "/curriculum/cspilot/unit1/13/overview/index.html",
+    "reference": "/curriculum/csp-20/unit1/13/overview/index.html",
     "parent_level_id": 18914,
     "name_suffix": "_2019",
     "encrypted": "false",

--- a/dashboard/config/scripts/levels/CSP U1L15 SFLP 20-21.level
+++ b/dashboard/config/scripts/levels/CSP U1L15 SFLP 20-21.level
@@ -7,7 +7,7 @@
   "properties": {
     "instructions_important": "false",
     "display_name": "Lesson Overview",
-    "reference": "/curriculum/cspilot/unit1/15/overview/index.html",
+    "reference": "/curriculum/csp-20/unit1/15/overview/index.html",
     "parent_level_id": 18915,
     "name_suffix": "_2019",
     "encrypted": "false"

--- a/dashboard/config/scripts/levels/CSP U1L2 SFLP 20-21.level
+++ b/dashboard/config/scripts/levels/CSP U1L2 SFLP 20-21.level
@@ -7,7 +7,7 @@
   "properties": {
     "instructions_important": "false",
     "display_name": "Lesson Overview",
-    "reference": "/curriculum/cspilot/unit1/2/overview/index.html",
+    "reference": "/curriculum/csp-20/unit1/2/overview/index.html",
     "parent_level_id": 18902,
     "name_suffix": "_2019",
     "encrypted": "false"

--- a/dashboard/config/scripts/levels/CSP U1L3 SFLP 20-21.level
+++ b/dashboard/config/scripts/levels/CSP U1L3 SFLP 20-21.level
@@ -7,7 +7,7 @@
   "properties": {
     "instructions_important": "false",
     "display_name": "Lesson Overview",
-    "reference": "/curriculum/cspilot/unit1/3/overview/index.html",
+    "reference": "/curriculum/csp-20/unit1/3/overview/index.html",
     "parent_level_id": 18903,
     "name_suffix": "_2019",
     "encrypted": "false"

--- a/dashboard/config/scripts/levels/CSP U1L4 SFLP 20-21.level
+++ b/dashboard/config/scripts/levels/CSP U1L4 SFLP 20-21.level
@@ -7,7 +7,7 @@
   "properties": {
     "instructions_important": "false",
     "display_name": "Lesson Overview",
-    "reference": "/curriculum/cspilot/unit1/3/overview/index.html",
+    "reference": "/curriculum/csp-20/unit1/3/overview/index.html",
     "parent_level_id": 18904,
     "name_suffix": "_2019",
     "encrypted": "false"

--- a/dashboard/config/scripts/levels/CSP U1L5 SFLP 20-21.level
+++ b/dashboard/config/scripts/levels/CSP U1L5 SFLP 20-21.level
@@ -7,7 +7,7 @@
   "properties": {
     "instructions_important": "false",
     "display_name": "Lesson Overview",
-    "reference": "/curriculum/cspilot/unit1/4/overview/index.html",
+    "reference": "/curriculum/csp-20/unit1/4/overview/index.html",
     "parent_level_id": 18905,
     "name_suffix": "_2019",
     "encrypted": "false",

--- a/dashboard/config/scripts/levels/CSP U1L6 SFLP 20-21.level
+++ b/dashboard/config/scripts/levels/CSP U1L6 SFLP 20-21.level
@@ -7,7 +7,7 @@
   "properties": {
     "instructions_important": "false",
     "display_name": "Lesson Overview",
-    "reference": "/curriculum/cspilot/unit1/5/overview/index.html",
+    "reference": "/curriculum/csp-20/unit1/5/overview/index.html",
     "parent_level_id": 18906,
     "name_suffix": "_2019",
     "encrypted": "false"

--- a/dashboard/config/scripts/levels/CSP U1L7 SFLP 20-21.level
+++ b/dashboard/config/scripts/levels/CSP U1L7 SFLP 20-21.level
@@ -7,7 +7,7 @@
   "properties": {
     "instructions_important": "false",
     "display_name": "Lesson Overview",
-    "reference": "/curriculum/cspilot/unit1/6/overview/index.html",
+    "reference": "/curriculum/csp-20/unit1/6/overview/index.html",
     "parent_level_id": 18907,
     "name_suffix": "_2019",
     "encrypted": "false"

--- a/dashboard/config/scripts/levels/CSP U1L8 SFLP 20-21.level
+++ b/dashboard/config/scripts/levels/CSP U1L8 SFLP 20-21.level
@@ -7,7 +7,7 @@
   "properties": {
     "instructions_important": "false",
     "display_name": "Lesson Overview",
-    "reference": "/curriculum/cspilot/unit1/7/overview/index.html",
+    "reference": "/curriculum/csp-20/unit1/7/overview/index.html",
     "parent_level_id": 18908,
     "name_suffix": "_2019",
     "encrypted": "false",

--- a/dashboard/config/scripts/levels/CSP U1L9 SFLP 20-21.level
+++ b/dashboard/config/scripts/levels/CSP U1L9 SFLP 20-21.level
@@ -7,7 +7,7 @@
   "properties": {
     "instructions_important": "false",
     "display_name": "Lesson Overview",
-    "reference": "/curriculum/cspilot/unit1/8/overview/index.html",
+    "reference": "/curriculum/csp-20/unit1/8/overview/index.html",
     "parent_level_id": 18909,
     "name_suffix": "_2019",
     "encrypted": "false"

--- a/dashboard/config/scripts/levels/CSP U2L1 SFLP 20-21.level
+++ b/dashboard/config/scripts/levels/CSP U2L1 SFLP 20-21.level
@@ -7,7 +7,7 @@
   "properties": {
     "instructions_important": "false",
     "display_name": "Lesson Overview",
-    "reference": "/curriculum/cspilot/unit2/1/overview/index.html",
+    "reference": "/curriculum/csp-20/unit2/1/overview/index.html",
     "parent_level_id": 18902,
     "name_suffix": "_2019",
     "encrypted": "false"

--- a/dashboard/config/scripts/levels/CSP U2L2 SFLP 20-21.level
+++ b/dashboard/config/scripts/levels/CSP U2L2 SFLP 20-21.level
@@ -7,7 +7,7 @@
   "properties": {
     "instructions_important": "false",
     "display_name": "Lesson Overview",
-    "reference": "/curriculum/cspilot/unit2/2/overview/index.html",
+    "reference": "/curriculum/csp-20/unit2/2/overview/index.html",
     "parent_level_id": 18997,
     "name_suffix": "_2019",
     "encrypted": "false"

--- a/dashboard/config/scripts/levels/CSP U2L3 SFLP 20-21.level
+++ b/dashboard/config/scripts/levels/CSP U2L3 SFLP 20-21.level
@@ -7,7 +7,7 @@
   "properties": {
     "instructions_important": "false",
     "display_name": "Lesson Overview",
-    "reference": "/curriculum/cspilot/unit2/3/overview/index.html",
+    "reference": "/curriculum/csp-20/unit2/3/overview/index.html",
     "parent_level_id": 19002,
     "name_suffix": "_2019",
     "encrypted": "false"

--- a/dashboard/config/scripts/levels/CSP U2L4 SFLP 20-21.level
+++ b/dashboard/config/scripts/levels/CSP U2L4 SFLP 20-21.level
@@ -7,7 +7,7 @@
   "properties": {
     "instructions_important": "false",
     "display_name": "Lesson Overview",
-    "reference": "/curriculum/cspilot/unit2/4/overview/index.html",
+    "reference": "/curriculum/csp-20/unit2/4/overview/index.html",
     "parent_level_id": 19008,
     "name_suffix": "_2019",
     "encrypted": "false"

--- a/dashboard/config/scripts/levels/CSP U2L5 SFLP 20-21.level
+++ b/dashboard/config/scripts/levels/CSP U2L5 SFLP 20-21.level
@@ -7,7 +7,7 @@
   "properties": {
     "instructions_important": "false",
     "display_name": "Lesson Overview",
-    "reference": "/curriculum/cspilot/unit2/5/overview/index.html",
+    "reference": "/curriculum/csp-20/unit2/5/overview/index.html",
     "parent_level_id": 19011,
     "name_suffix": "_2019",
     "encrypted": "false"

--- a/dashboard/config/scripts/levels/CSP U2L6 SFLP 20-21.level
+++ b/dashboard/config/scripts/levels/CSP U2L6 SFLP 20-21.level
@@ -7,7 +7,7 @@
   "properties": {
     "instructions_important": "false",
     "display_name": "Lesson Overview",
-    "reference": "/curriculum/cspilot/unit2/6/overview/index.html",
+    "reference": "/curriculum/csp-20/unit2/6/overview/index.html",
     "parent_level_id": 19016,
     "name_suffix": "_2019",
     "encrypted": "false"

--- a/dashboard/config/scripts/levels/CSP U2L7 SFLP 20-21.level
+++ b/dashboard/config/scripts/levels/CSP U2L7 SFLP 20-21.level
@@ -7,7 +7,7 @@
   "properties": {
     "instructions_important": "false",
     "display_name": "Lesson Overview",
-    "reference": "/curriculum/cspilot/unit2/7/overview/index.html",
+    "reference": "/curriculum/csp-20/unit2/7/overview/index.html",
     "parent_level_id": 19029,
     "name_suffix": "_2019",
     "encrypted": "false",

--- a/dashboard/config/scripts/levels/CSP U2L8 SFLP 20-21.level
+++ b/dashboard/config/scripts/levels/CSP U2L8 SFLP 20-21.level
@@ -7,7 +7,7 @@
   "properties": {
     "instructions_important": "false",
     "display_name": "Lesson Overview",
-    "reference": "/curriculum/cspilot/unit2/8/overview/index.html",
+    "reference": "/curriculum/csp-20/unit2/8/overview/index.html",
     "parent_level_id": 19030,
     "name_suffix": "_2019",
     "encrypted": "false"

--- a/dashboard/config/scripts/levels/CSP U2L9 SFLP 20-21.level
+++ b/dashboard/config/scripts/levels/CSP U2L9 SFLP 20-21.level
@@ -7,7 +7,7 @@
   "properties": {
     "instructions_important": "false",
     "display_name": "Lesson Overview",
-    "reference": "/curriculum/cspilot/unit2/8/overview/index.html",
+    "reference": "/curriculum/csp-20/unit2/8/overview/index.html",
     "parent_level_id": 18997,
     "name_suffix": "_2019",
     "encrypted": "false",

--- a/dashboard/config/scripts/levels/CSP U3L1 SFLP 20-21.level
+++ b/dashboard/config/scripts/levels/CSP U3L1 SFLP 20-21.level
@@ -7,7 +7,7 @@
   "properties": {
     "instructions_important": "false",
     "display_name": "Lesson Overview",
-    "reference": "/curriculum/cspilot/unit3/1/overview/index.html",
+    "reference": "/curriculum/csp-20/unit3/1/overview/index.html",
     "parent_level_id": 18902,
     "name_suffix": "_2019",
     "encrypted": "false"

--- a/dashboard/config/scripts/levels/CSP U3L10 SFLP 20-21.level
+++ b/dashboard/config/scripts/levels/CSP U3L10 SFLP 20-21.level
@@ -7,7 +7,7 @@
   "properties": {
     "instructions_important": "false",
     "display_name": "Lesson Overview",
-    "reference": "/curriculum/cspilot/unit3/9/overview/index.html",
+    "reference": "/curriculum/csp-20/unit3/9/overview/index.html",
     "parent_level_id": 19147,
     "name_suffix": "_2019",
     "encrypted": "false",

--- a/dashboard/config/scripts/levels/CSP U3L2 SFLP 20-21.level
+++ b/dashboard/config/scripts/levels/CSP U3L2 SFLP 20-21.level
@@ -7,7 +7,7 @@
   "properties": {
     "instructions_important": "false",
     "display_name": "Lesson Overview",
-    "reference": "/curriculum/cspilot/unit3/2/overview/index.html",
+    "reference": "/curriculum/csp-20/unit3/2/overview/index.html",
     "parent_level_id": 19139,
     "name_suffix": "_2019",
     "encrypted": "false"

--- a/dashboard/config/scripts/levels/CSP U3L3 SFLP 20-21.level
+++ b/dashboard/config/scripts/levels/CSP U3L3 SFLP 20-21.level
@@ -7,7 +7,7 @@
   "properties": {
     "instructions_important": "false",
     "display_name": "Lesson Overview",
-    "reference": "/curriculum/cspilot/unit3/3/overview/index.html",
+    "reference": "/curriculum/csp-20/unit3/3/overview/index.html",
     "parent_level_id": 19140,
     "name_suffix": "_2019",
     "encrypted": "false"

--- a/dashboard/config/scripts/levels/CSP U3L4 SFLP 20-21.level
+++ b/dashboard/config/scripts/levels/CSP U3L4 SFLP 20-21.level
@@ -7,7 +7,7 @@
   "properties": {
     "instructions_important": "false",
     "display_name": "Lesson Overview",
-    "reference": "/curriculum/cspilot/unit3/4/overview/index.html",
+    "reference": "/curriculum/csp-20/unit3/4/overview/index.html",
     "parent_level_id": 19141,
     "name_suffix": "_2019",
     "encrypted": "false"

--- a/dashboard/config/scripts/levels/CSP U3L5 SFLP 20-21.level
+++ b/dashboard/config/scripts/levels/CSP U3L5 SFLP 20-21.level
@@ -7,7 +7,7 @@
   "properties": {
     "instructions_important": "false",
     "display_name": "Lesson Overview",
-    "reference": "/curriculum/cspilot/unit3/5/overview/index.html",
+    "reference": "/curriculum/csp-20/unit3/5/overview/index.html",
     "parent_level_id": 19142,
     "name_suffix": "_2019",
     "encrypted": "false"

--- a/dashboard/config/scripts/levels/CSP U3L6 SFLP 20-21.level
+++ b/dashboard/config/scripts/levels/CSP U3L6 SFLP 20-21.level
@@ -7,7 +7,7 @@
   "properties": {
     "instructions_important": "false",
     "display_name": "Lesson Overview",
-    "reference": "/curriculum/cspilot/unit3/6/overview/index.html",
+    "reference": "/curriculum/csp-20/unit3/6/overview/index.html",
     "parent_level_id": 19143,
     "name_suffix": "_2019",
     "encrypted": "false"

--- a/dashboard/config/scripts/levels/CSP U3L7 SFLP 20-21.level
+++ b/dashboard/config/scripts/levels/CSP U3L7 SFLP 20-21.level
@@ -7,7 +7,7 @@
   "properties": {
     "instructions_important": "false",
     "display_name": "Lesson Overview",
-    "reference": "/curriculum/cspilot/unit3/7/overview/index.html",
+    "reference": "/curriculum/csp-20/unit3/7/overview/index.html",
     "parent_level_id": 19144,
     "name_suffix": "_2019",
     "encrypted": "false"

--- a/dashboard/config/scripts/levels/CSP U3L8 SFLP 20-21.level
+++ b/dashboard/config/scripts/levels/CSP U3L8 SFLP 20-21.level
@@ -7,7 +7,7 @@
   "properties": {
     "instructions_important": "false",
     "display_name": "Lesson Overview",
-    "reference": "/curriculum/cspilot/unit3/8/overview/index.html",
+    "reference": "/curriculum/csp-20/unit3/8/overview/index.html",
     "parent_level_id": 19145,
     "name_suffix": "_2019",
     "encrypted": "false"

--- a/dashboard/config/scripts/levels/CSP U3L9 SFLP 20-21.level
+++ b/dashboard/config/scripts/levels/CSP U3L9 SFLP 20-21.level
@@ -7,7 +7,7 @@
   "properties": {
     "instructions_important": "false",
     "display_name": "Lesson Overview",
-    "reference": "/curriculum/cspilot/unit3/9/overview/index.html",
+    "reference": "/curriculum/csp-20/unit3/9/overview/index.html",
     "parent_level_id": 19146,
     "name_suffix": "_2019",
     "encrypted": "false"

--- a/dashboard/config/scripts/levels/CSP U4L1 SFLP 20-21.level
+++ b/dashboard/config/scripts/levels/CSP U4L1 SFLP 20-21.level
@@ -7,7 +7,7 @@
   "properties": {
     "instructions_important": "false",
     "display_name": "Lesson Overview",
-    "reference": "/curriculum/cspilot/unit4/1/overview/index.html",
+    "reference": "/curriculum/csp-20/unit4/1/overview/index.html",
     "parent_level_id": 19139,
     "name_suffix": "_2019",
     "encrypted": "false"

--- a/dashboard/config/scripts/levels/CSP U4L10 SFLP 20-21.level
+++ b/dashboard/config/scripts/levels/CSP U4L10 SFLP 20-21.level
@@ -7,7 +7,7 @@
   "properties": {
     "instructions_important": "false",
     "display_name": "Lesson Overview",
-    "reference": "/curriculum/cspilot/unit4/10/overview/index.html",
+    "reference": "/curriculum/csp-20/unit4/10/overview/index.html",
     "parent_level_id": 19214,
     "name_suffix": "_2019",
     "encrypted": "false"

--- a/dashboard/config/scripts/levels/CSP U4L11 SFLP 20-21.level
+++ b/dashboard/config/scripts/levels/CSP U4L11 SFLP 20-21.level
@@ -7,7 +7,7 @@
   "properties": {
     "instructions_important": "false",
     "display_name": "Lesson Overview",
-    "reference": "/curriculum/cspilot/unit4/11/overview/index.html",
+    "reference": "/curriculum/csp-20/unit4/11/overview/index.html",
     "parent_level_id": 19215,
     "name_suffix": "_2019",
     "encrypted": "false"

--- a/dashboard/config/scripts/levels/CSP U4L12 SFLP 20-21.level
+++ b/dashboard/config/scripts/levels/CSP U4L12 SFLP 20-21.level
@@ -7,7 +7,7 @@
   "properties": {
     "instructions_important": "false",
     "display_name": "Lesson Overview",
-    "reference": "/curriculum/cspilot/unit4/12/overview/index.html",
+    "reference": "/curriculum/csp-20/unit4/12/overview/index.html",
     "parent_level_id": 19216,
     "name_suffix": "_2019",
     "encrypted": "false"

--- a/dashboard/config/scripts/levels/CSP U4L13 SFLP 20-21.level
+++ b/dashboard/config/scripts/levels/CSP U4L13 SFLP 20-21.level
@@ -7,7 +7,7 @@
   "properties": {
     "instructions_important": "false",
     "display_name": "Lesson Overview",
-    "reference": "/curriculum/cspilot/unit4/13/overview/index.html",
+    "reference": "/curriculum/csp-20/unit4/13/overview/index.html",
     "parent_level_id": 19217,
     "name_suffix": "_2019",
     "encrypted": "false"

--- a/dashboard/config/scripts/levels/CSP U4L14 SFLP 20-21.level
+++ b/dashboard/config/scripts/levels/CSP U4L14 SFLP 20-21.level
@@ -7,7 +7,7 @@
   "properties": {
     "instructions_important": "false",
     "display_name": "Lesson Overview",
-    "reference": "/curriculum/cspilot/unit4/14/overview/index.html",
+    "reference": "/curriculum/csp-20/unit4/14/overview/index.html",
     "parent_level_id": 19218,
     "name_suffix": "_2019",
     "encrypted": "false",

--- a/dashboard/config/scripts/levels/CSP U4L15 SFLP 20-21.level
+++ b/dashboard/config/scripts/levels/CSP U4L15 SFLP 20-21.level
@@ -7,7 +7,7 @@
   "properties": {
     "instructions_important": "false",
     "display_name": "Lesson Overview",
-    "reference": "/curriculum/cspilot/unit4/15/overview/index.html",
+    "reference": "/curriculum/csp-20/unit4/15/overview/index.html",
     "parent_level_id": 19219,
     "name_suffix": "_2019",
     "encrypted": "false"

--- a/dashboard/config/scripts/levels/CSP U4L2 SFLP 20-21.level
+++ b/dashboard/config/scripts/levels/CSP U4L2 SFLP 20-21.level
@@ -7,7 +7,7 @@
   "properties": {
     "instructions_important": "false",
     "display_name": "Lesson Overview",
-    "reference": "/curriculum/cspilot/unit4/2/overview/index.html",
+    "reference": "/curriculum/csp-20/unit4/2/overview/index.html",
     "parent_level_id": 19206,
     "name_suffix": "_2019",
     "encrypted": "false"

--- a/dashboard/config/scripts/levels/CSP U4L3 SFLP 20-21.level
+++ b/dashboard/config/scripts/levels/CSP U4L3 SFLP 20-21.level
@@ -7,7 +7,7 @@
   "properties": {
     "instructions_important": "false",
     "display_name": "Lesson Overview",
-    "reference": "/curriculum/cspilot/unit4/3/overview/index.html",
+    "reference": "/curriculum/csp-20/unit4/3/overview/index.html",
     "parent_level_id": 19207,
     "name_suffix": "_2019",
     "encrypted": "false"

--- a/dashboard/config/scripts/levels/CSP U4L4 SFLP 20-21.level
+++ b/dashboard/config/scripts/levels/CSP U4L4 SFLP 20-21.level
@@ -7,7 +7,7 @@
   "properties": {
     "instructions_important": "false",
     "display_name": "Lesson Overview",
-    "reference": "/curriculum/cspilot/unit4/4/overview/index.html",
+    "reference": "/curriculum/csp-20/unit4/4/overview/index.html",
     "parent_level_id": 19208,
     "name_suffix": "_2019",
     "encrypted": "false"

--- a/dashboard/config/scripts/levels/CSP U4L5 SFLP 20-21.level
+++ b/dashboard/config/scripts/levels/CSP U4L5 SFLP 20-21.level
@@ -7,7 +7,7 @@
   "properties": {
     "instructions_important": "false",
     "display_name": "Lesson Overview",
-    "reference": "/curriculum/cspilot/unit4/5/overview/index.html",
+    "reference": "/curriculum/csp-20/unit4/5/overview/index.html",
     "parent_level_id": 19209,
     "name_suffix": "_2019",
     "encrypted": "false"

--- a/dashboard/config/scripts/levels/CSP U4L6 SFLP 20-21.level
+++ b/dashboard/config/scripts/levels/CSP U4L6 SFLP 20-21.level
@@ -7,7 +7,7 @@
   "properties": {
     "instructions_important": "false",
     "display_name": "Lesson Overview",
-    "reference": "/curriculum/cspilot/unit4/6/overview/index.html",
+    "reference": "/curriculum/csp-20/unit4/6/overview/index.html",
     "parent_level_id": 19210,
     "name_suffix": "_2019",
     "encrypted": "false"

--- a/dashboard/config/scripts/levels/CSP U4L7 SFLP 20-21.level
+++ b/dashboard/config/scripts/levels/CSP U4L7 SFLP 20-21.level
@@ -7,7 +7,7 @@
   "properties": {
     "instructions_important": "false",
     "display_name": "Lesson Overview",
-    "reference": "/curriculum/cspilot/unit4/7/overview/index.html",
+    "reference": "/curriculum/csp-20/unit4/7/overview/index.html",
     "parent_level_id": 19211,
     "name_suffix": "_2019",
     "encrypted": "false"

--- a/dashboard/config/scripts/levels/CSP U4L8 SFLP 20-21.level
+++ b/dashboard/config/scripts/levels/CSP U4L8 SFLP 20-21.level
@@ -7,7 +7,7 @@
   "properties": {
     "instructions_important": "false",
     "display_name": "Lesson Overview",
-    "reference": "/curriculum/cspilot/unit4/8/overview/index.html",
+    "reference": "/curriculum/csp-20/unit4/8/overview/index.html",
     "parent_level_id": 19212,
     "name_suffix": "_2019",
     "encrypted": "false"

--- a/dashboard/config/scripts/levels/CSP U4L9 SFLP 20-21.level
+++ b/dashboard/config/scripts/levels/CSP U4L9 SFLP 20-21.level
@@ -7,7 +7,7 @@
   "properties": {
     "instructions_important": "false",
     "display_name": "Lesson Overview",
-    "reference": "/curriculum/cspilot/unit4/9/overview/index.html",
+    "reference": "/curriculum/csp-20/unit4/9/overview/index.html",
     "parent_level_id": 19213,
     "name_suffix": "_2019",
     "encrypted": "false"

--- a/dashboard/config/scripts/levels/CSP U5L1 SFLP 20-21.level
+++ b/dashboard/config/scripts/levels/CSP U5L1 SFLP 20-21.level
@@ -7,7 +7,7 @@
   "properties": {
     "instructions_important": "false",
     "display_name": "Lesson Overview",
-    "reference": "/curriculum/cspilot/unit5/1/overview/index.html",
+    "reference": "/curriculum/csp-20/unit5/1/overview/index.html",
     "parent_level_id": 18902,
     "name_suffix": "_2019",
     "encrypted": "false"

--- a/dashboard/config/scripts/levels/CSP U5L10 SFLP 20-21.level
+++ b/dashboard/config/scripts/levels/CSP U5L10 SFLP 20-21.level
@@ -7,7 +7,7 @@
   "properties": {
     "instructions_important": "false",
     "display_name": "Lesson Overview",
-    "reference": "/curriculum/cspilot/unit5/10/overview/index.html",
+    "reference": "/curriculum/csp-20/unit5/10/overview/index.html",
     "parent_level_id": 19360,
     "name_suffix": "_2019",
     "encrypted": "false"

--- a/dashboard/config/scripts/levels/CSP U5L11 SFLP 20-21.level
+++ b/dashboard/config/scripts/levels/CSP U5L11 SFLP 20-21.level
@@ -7,7 +7,7 @@
   "properties": {
     "instructions_important": "false",
     "display_name": "Lesson Overview",
-    "reference": "/curriculum/cspilot/unit5/11/overview/index.html",
+    "reference": "/curriculum/csp-20/unit5/11/overview/index.html",
     "parent_level_id": 19361,
     "name_suffix": "_2019",
     "encrypted": "false"

--- a/dashboard/config/scripts/levels/CSP U5L12 SFLP 20-21.level
+++ b/dashboard/config/scripts/levels/CSP U5L12 SFLP 20-21.level
@@ -7,7 +7,7 @@
   "properties": {
     "instructions_important": "false",
     "display_name": "Lesson Overview",
-    "reference": "/curriculum/cspilot/unit5/12/overview/index.html",
+    "reference": "/curriculum/csp-20/unit5/12/overview/index.html",
     "parent_level_id": 19362,
     "name_suffix": "_2019",
     "encrypted": "false"

--- a/dashboard/config/scripts/levels/CSP U5L13 SFLP 20-21.level
+++ b/dashboard/config/scripts/levels/CSP U5L13 SFLP 20-21.level
@@ -7,7 +7,7 @@
   "properties": {
     "instructions_important": "false",
     "display_name": "Lesson Overview",
-    "reference": "/curriculum/cspilot/unit5/13/overview/index.html",
+    "reference": "/curriculum/csp-20/unit5/13/overview/index.html",
     "parent_level_id": 19363,
     "name_suffix": "_2019",
     "encrypted": "false"

--- a/dashboard/config/scripts/levels/CSP U5L14 SFLP 20-21.level
+++ b/dashboard/config/scripts/levels/CSP U5L14 SFLP 20-21.level
@@ -7,7 +7,7 @@
   "properties": {
     "instructions_important": "false",
     "display_name": "Lesson Overview",
-    "reference": "/curriculum/cspilot/unit5/14/overview/index.html",
+    "reference": "/curriculum/csp-20/unit5/14/overview/index.html",
     "parent_level_id": 19364,
     "name_suffix": "_2019",
     "encrypted": "false"

--- a/dashboard/config/scripts/levels/CSP U5L15 SFLP 20-21.level
+++ b/dashboard/config/scripts/levels/CSP U5L15 SFLP 20-21.level
@@ -7,7 +7,7 @@
   "properties": {
     "instructions_important": "false",
     "display_name": "Lesson Overview",
-    "reference": "/curriculum/cspilot/unit5/15/overview/index.html",
+    "reference": "/curriculum/csp-20/unit5/15/overview/index.html",
     "parent_level_id": 19365,
     "name_suffix": "_2019",
     "encrypted": "false"

--- a/dashboard/config/scripts/levels/CSP U5L16 SFLP 20-21.level
+++ b/dashboard/config/scripts/levels/CSP U5L16 SFLP 20-21.level
@@ -7,7 +7,7 @@
   "properties": {
     "instructions_important": "false",
     "display_name": "Lesson Overview",
-    "reference": "/curriculum/cspilot/unit5/16/overview/index.html",
+    "reference": "/curriculum/csp-20/unit5/16/overview/index.html",
     "parent_level_id": 19366,
     "name_suffix": "_2019",
     "encrypted": "false"

--- a/dashboard/config/scripts/levels/CSP U5L17 SFLP 20-21.level
+++ b/dashboard/config/scripts/levels/CSP U5L17 SFLP 20-21.level
@@ -7,7 +7,7 @@
   "properties": {
     "instructions_important": "false",
     "display_name": "Lesson Overview",
-    "reference": "/curriculum/cspilot/unit5/17/overview/index.html",
+    "reference": "/curriculum/csp-20/unit5/17/overview/index.html",
     "parent_level_id": 19367,
     "name_suffix": "_2019",
     "encrypted": "false",

--- a/dashboard/config/scripts/levels/CSP U5L18 SFLP 20-21.level
+++ b/dashboard/config/scripts/levels/CSP U5L18 SFLP 20-21.level
@@ -7,7 +7,7 @@
   "properties": {
     "instructions_important": "false",
     "display_name": "Lesson Overview",
-    "reference": "/curriculum/cspilot/unit5/18/overview/index.html",
+    "reference": "/curriculum/csp-20/unit5/18/overview/index.html",
     "parent_level_id": 19368,
     "name_suffix": "_2019",
     "encrypted": "false"

--- a/dashboard/config/scripts/levels/CSP U5L2 SFLP 20-21.level
+++ b/dashboard/config/scripts/levels/CSP U5L2 SFLP 20-21.level
@@ -7,7 +7,7 @@
   "properties": {
     "instructions_important": "false",
     "display_name": "Lesson Overview",
-    "reference": "/curriculum/cspilot/unit5/2/overview/index.html",
+    "reference": "/curriculum/csp-20/unit5/2/overview/index.html",
     "parent_level_id": 19313,
     "name_suffix": "_2019",
     "encrypted": "false"

--- a/dashboard/config/scripts/levels/CSP U5L3 SFLP 20-21.level
+++ b/dashboard/config/scripts/levels/CSP U5L3 SFLP 20-21.level
@@ -7,7 +7,7 @@
   "properties": {
     "instructions_important": "false",
     "display_name": "Lesson Overview",
-    "reference": "/curriculum/cspilot/unit5/3/overview/index.html",
+    "reference": "/curriculum/csp-20/unit5/3/overview/index.html",
     "parent_level_id": 19314,
     "name_suffix": "_2019",
     "encrypted": "false"

--- a/dashboard/config/scripts/levels/CSP U5L4 SFLP 20-21.level
+++ b/dashboard/config/scripts/levels/CSP U5L4 SFLP 20-21.level
@@ -7,7 +7,7 @@
   "properties": {
     "instructions_important": "false",
     "display_name": "Lesson Overview",
-    "reference": "/curriculum/cspilot/unit5/4/overview/index.html",
+    "reference": "/curriculum/csp-20/unit5/4/overview/index.html",
     "parent_level_id": 19315,
     "name_suffix": "_2019",
     "encrypted": "false"

--- a/dashboard/config/scripts/levels/CSP U5L5 SFLP 20-21.level
+++ b/dashboard/config/scripts/levels/CSP U5L5 SFLP 20-21.level
@@ -7,7 +7,7 @@
   "properties": {
     "instructions_important": "false",
     "display_name": "Lesson Overview",
-    "reference": "/curriculum/cspilot/unit5/5/overview/index.html",
+    "reference": "/curriculum/csp-20/unit5/5/overview/index.html",
     "parent_level_id": 19316,
     "name_suffix": "_2019",
     "encrypted": "false"

--- a/dashboard/config/scripts/levels/CSP U5L6 SFLP 20-21.level
+++ b/dashboard/config/scripts/levels/CSP U5L6 SFLP 20-21.level
@@ -7,7 +7,7 @@
   "properties": {
     "instructions_important": "false",
     "display_name": "Lesson Overview",
-    "reference": "/curriculum/cspilot/unit5/6/overview/index.html",
+    "reference": "/curriculum/csp-20/unit5/6/overview/index.html",
     "parent_level_id": 19317,
     "name_suffix": "_2019",
     "encrypted": "false"

--- a/dashboard/config/scripts/levels/CSP U5L7 SFLP 20-21.level
+++ b/dashboard/config/scripts/levels/CSP U5L7 SFLP 20-21.level
@@ -7,7 +7,7 @@
   "properties": {
     "instructions_important": "false",
     "display_name": "Lesson Overview",
-    "reference": "/curriculum/cspilot/unit5/7/overview/index.html",
+    "reference": "/curriculum/csp-20/unit5/7/overview/index.html",
     "parent_level_id": 19318,
     "name_suffix": "_2019",
     "encrypted": "false"

--- a/dashboard/config/scripts/levels/CSP U5L8 SFLP 20-21.level
+++ b/dashboard/config/scripts/levels/CSP U5L8 SFLP 20-21.level
@@ -7,7 +7,7 @@
   "properties": {
     "instructions_important": "false",
     "display_name": "Lesson Overview",
-    "reference": "/curriculum/cspilot/unit5/8/overview/index.html",
+    "reference": "/curriculum/csp-20/unit5/8/overview/index.html",
     "parent_level_id": 19316,
     "name_suffix": "_2019",
     "encrypted": "false"

--- a/dashboard/config/scripts/levels/CSP U5L9 SFLP 20-21.level
+++ b/dashboard/config/scripts/levels/CSP U5L9 SFLP 20-21.level
@@ -7,7 +7,7 @@
   "properties": {
     "instructions_important": "false",
     "display_name": "Lesson Overview",
-    "reference": "/curriculum/cspilot/unit5/9/overview/index.html",
+    "reference": "/curriculum/csp-20/unit5/9/overview/index.html",
     "parent_level_id": 19350,
     "name_suffix": "_2019",
     "encrypted": "false"

--- a/dashboard/config/scripts/levels/CSP U6L1 SFLP 20-21.level
+++ b/dashboard/config/scripts/levels/CSP U6L1 SFLP 20-21.level
@@ -7,7 +7,7 @@
   "properties": {
     "instructions_important": "false",
     "display_name": "Lesson Overview",
-    "reference": "/curriculum/cspilot/unit6/1/overview/index.html",
+    "reference": "/curriculum/csp-20/unit6/1/overview/index.html",
     "parent_level_id": 19206,
     "name_suffix": "_2019",
     "encrypted": "false"

--- a/dashboard/config/scripts/levels/CSP U6L2 SFLP 20-21.level
+++ b/dashboard/config/scripts/levels/CSP U6L2 SFLP 20-21.level
@@ -7,7 +7,7 @@
   "properties": {
     "instructions_important": "false",
     "display_name": "Lesson Overview",
-    "reference": "/curriculum/cspilot/unit6/2/overview/index.html",
+    "reference": "/curriculum/csp-20/unit6/2/overview/index.html",
     "parent_level_id": 19255,
     "name_suffix": "_2019",
     "encrypted": "false"

--- a/dashboard/config/scripts/levels/CSP U6L3 SFLP 20-21.level
+++ b/dashboard/config/scripts/levels/CSP U6L3 SFLP 20-21.level
@@ -7,7 +7,7 @@
   "properties": {
     "instructions_important": "false",
     "display_name": "Lesson Overview",
-    "reference": "/curriculum/cspilot/unit6/3/overview/index.html",
+    "reference": "/curriculum/csp-20/unit6/3/overview/index.html",
     "parent_level_id": 19256,
     "name_suffix": "_2019",
     "encrypted": "false"

--- a/dashboard/config/scripts/levels/CSP U6L4 SFLP 20-21.level
+++ b/dashboard/config/scripts/levels/CSP U6L4 SFLP 20-21.level
@@ -7,7 +7,7 @@
   "properties": {
     "instructions_important": "false",
     "display_name": "Lesson Overview",
-    "reference": "/curriculum/cspilot/unit6/4/overview/index.html",
+    "reference": "/curriculum/csp-20/unit6/4/overview/index.html",
     "parent_level_id": 19264,
     "name_suffix": "_2019",
     "encrypted": "false"

--- a/dashboard/config/scripts/levels/CSP U6L5 SFLP 20-21.level
+++ b/dashboard/config/scripts/levels/CSP U6L5 SFLP 20-21.level
@@ -7,7 +7,7 @@
   "properties": {
     "instructions_important": "false",
     "display_name": "Lesson Overview",
-    "reference": "/curriculum/cspilot/unit6/5/overview/index.html",
+    "reference": "/curriculum/csp-20/unit6/5/overview/index.html",
     "parent_level_id": 19265,
     "name_suffix": "_2019",
     "encrypted": "false"

--- a/dashboard/config/scripts/levels/CSP U6L6 SFLP 20-21.level
+++ b/dashboard/config/scripts/levels/CSP U6L6 SFLP 20-21.level
@@ -7,7 +7,7 @@
   "properties": {
     "instructions_important": "false",
     "display_name": "Lesson Overview",
-    "reference": "/curriculum/cspilot/unit6/6/overview/index.html",
+    "reference": "/curriculum/csp-20/unit6/6/overview/index.html",
     "parent_level_id": 19309,
     "name_suffix": "_2019",
     "encrypted": "false"

--- a/dashboard/config/scripts/levels/CSP U7L1 SFLP 20-21.level
+++ b/dashboard/config/scripts/levels/CSP U7L1 SFLP 20-21.level
@@ -7,7 +7,7 @@
   "properties": {
     "instructions_important": "false",
     "display_name": "Lesson Overview",
-    "reference": "/curriculum/cspilot/unit7/1/overview/index.html",
+    "reference": "/curriculum/csp-20/unit7/1/overview/index.html",
     "parent_level_id": 19206,
     "name_suffix": "_2019",
     "encrypted": "false"

--- a/dashboard/config/scripts/levels/CSP U7L10 SFLP 20-21.level
+++ b/dashboard/config/scripts/levels/CSP U7L10 SFLP 20-21.level
@@ -7,7 +7,7 @@
   "properties": {
     "instructions_important": "false",
     "display_name": "Lesson Overview",
-    "reference": "/curriculum/cspilot/unit7/10/overview/index.html",
+    "reference": "/curriculum/csp-20/unit7/10/overview/index.html",
     "parent_level_id": 19866,
     "name_suffix": "_2019",
     "encrypted": "false",

--- a/dashboard/config/scripts/levels/CSP U7L11 SFLP 20-21.level
+++ b/dashboard/config/scripts/levels/CSP U7L11 SFLP 20-21.level
@@ -7,7 +7,7 @@
   "properties": {
     "instructions_important": "false",
     "display_name": "Lesson Overview",
-    "reference": "/curriculum/cspilot/unit7/11/overview/index.html",
+    "reference": "/curriculum/csp-20/unit7/11/overview/index.html",
     "parent_level_id": 19867,
     "name_suffix": "_2019",
     "encrypted": "false"

--- a/dashboard/config/scripts/levels/CSP U7L12 SFLP 20-21.level
+++ b/dashboard/config/scripts/levels/CSP U7L12 SFLP 20-21.level
@@ -7,7 +7,7 @@
   "properties": {
     "instructions_important": "false",
     "display_name": "Lesson Overview",
-    "reference": "/curriculum/cspilot/unit7/12/overview/index.html",
+    "reference": "/curriculum/csp-20/unit7/12/overview/index.html",
     "parent_level_id": 19868,
     "name_suffix": "_2019",
     "encrypted": "false"

--- a/dashboard/config/scripts/levels/CSP U7L13 SFLP 20-21.level
+++ b/dashboard/config/scripts/levels/CSP U7L13 SFLP 20-21.level
@@ -7,7 +7,7 @@
   "properties": {
     "instructions_important": "false",
     "display_name": "Lesson Overview",
-    "reference": "/curriculum/cspilot/unit7/13/overview/index.html",
+    "reference": "/curriculum/csp-20/unit7/13/overview/index.html",
     "parent_level_id": 19869,
     "name_suffix": "_2019",
     "encrypted": "false"

--- a/dashboard/config/scripts/levels/CSP U7L2 SFLP 20-21.level
+++ b/dashboard/config/scripts/levels/CSP U7L2 SFLP 20-21.level
@@ -7,7 +7,7 @@
   "properties": {
     "instructions_important": "false",
     "display_name": "Lesson Overview",
-    "reference": "/curriculum/cspilot/unit7/2/overview/index.html",
+    "reference": "/curriculum/csp-20/unit7/2/overview/index.html",
     "parent_level_id": 19858,
     "name_suffix": "_2019",
     "encrypted": "false"

--- a/dashboard/config/scripts/levels/CSP U7L3 SFLP 20-21.level
+++ b/dashboard/config/scripts/levels/CSP U7L3 SFLP 20-21.level
@@ -7,7 +7,7 @@
   "properties": {
     "instructions_important": "false",
     "display_name": "Lesson Overview",
-    "reference": "/curriculum/cspilot/unit7/3/overview/index.html",
+    "reference": "/curriculum/csp-20/unit7/3/overview/index.html",
     "parent_level_id": 19859,
     "name_suffix": "_2019",
     "encrypted": "false"

--- a/dashboard/config/scripts/levels/CSP U7L4 SFLP 20-21.level
+++ b/dashboard/config/scripts/levels/CSP U7L4 SFLP 20-21.level
@@ -7,7 +7,7 @@
   "properties": {
     "instructions_important": "false",
     "display_name": "Lesson Overview",
-    "reference": "/curriculum/cspilot/unit7/4/overview/index.html",
+    "reference": "/curriculum/csp-20/unit7/4/overview/index.html",
     "parent_level_id": 19860,
     "name_suffix": "_2019",
     "encrypted": "false"

--- a/dashboard/config/scripts/levels/CSP U7L5 SFLP 20-21.level
+++ b/dashboard/config/scripts/levels/CSP U7L5 SFLP 20-21.level
@@ -7,7 +7,7 @@
   "properties": {
     "instructions_important": "false",
     "display_name": "Lesson Overview",
-    "reference": "/curriculum/cspilot/unit7/5/overview/index.html",
+    "reference": "/curriculum/csp-20/unit7/5/overview/index.html",
     "parent_level_id": 19861,
     "name_suffix": "_2019",
     "encrypted": "false"

--- a/dashboard/config/scripts/levels/CSP U7L6 SFLP 20-21.level
+++ b/dashboard/config/scripts/levels/CSP U7L6 SFLP 20-21.level
@@ -7,7 +7,7 @@
   "properties": {
     "instructions_important": "false",
     "display_name": "Lesson Overview",
-    "reference": "/curriculum/cspilot/unit7/6/overview/index.html",
+    "reference": "/curriculum/csp-20/unit7/6/overview/index.html",
     "parent_level_id": 19862,
     "name_suffix": "_2019",
     "encrypted": "false"

--- a/dashboard/config/scripts/levels/CSP U7L7 SFLP 20-21.level
+++ b/dashboard/config/scripts/levels/CSP U7L7 SFLP 20-21.level
@@ -7,7 +7,7 @@
   "properties": {
     "instructions_important": "false",
     "display_name": "Lesson Overview",
-    "reference": "/curriculum/cspilot/unit7/7/overview/index.html",
+    "reference": "/curriculum/csp-20/unit7/7/overview/index.html",
     "parent_level_id": 19863,
     "name_suffix": "_2019",
     "encrypted": "false"

--- a/dashboard/config/scripts/levels/CSP U7L8 SFLP 20-21.level
+++ b/dashboard/config/scripts/levels/CSP U7L8 SFLP 20-21.level
@@ -7,7 +7,7 @@
   "properties": {
     "instructions_important": "false",
     "display_name": "Lesson Overview",
-    "reference": "/curriculum/cspilot/unit7/8/overview/index.html",
+    "reference": "/curriculum/csp-20/unit7/8/overview/index.html",
     "parent_level_id": 19864,
     "name_suffix": "_2019",
     "encrypted": "false"

--- a/dashboard/config/scripts/levels/CSP U7L9 SFLP 20-21.level
+++ b/dashboard/config/scripts/levels/CSP U7L9 SFLP 20-21.level
@@ -7,7 +7,7 @@
   "properties": {
     "instructions_important": "false",
     "display_name": "Lesson Overview",
-    "reference": "/curriculum/cspilot/unit7/9/overview/index.html",
+    "reference": "/curriculum/csp-20/unit7/9/overview/index.html",
     "parent_level_id": 19865,
     "name_suffix": "_2019",
     "encrypted": "false"

--- a/dashboard/config/scripts/levels/CSP U9L1 SFLP 20-21.level
+++ b/dashboard/config/scripts/levels/CSP U9L1 SFLP 20-21.level
@@ -7,7 +7,7 @@
   "properties": {
     "instructions_important": "false",
     "display_name": "Lesson Overview",
-    "reference": "/curriculum/cspilot/unit9/1/overview/index.html",
+    "reference": "/curriculum/csp-20/unit9/1/overview/index.html",
     "parent_level_id": 19313,
     "name_suffix": "_2019",
     "encrypted": "false"

--- a/dashboard/config/scripts/levels/CSP U9L10 SFLP 20-21.level
+++ b/dashboard/config/scripts/levels/CSP U9L10 SFLP 20-21.level
@@ -7,7 +7,7 @@
   "properties": {
     "instructions_important": "false",
     "display_name": "Lesson Overview",
-    "reference": "/curriculum/cspilot/unit9/9/overview/index.html",
+    "reference": "/curriculum/csp-20/unit9/9/overview/index.html",
     "parent_level_id": 19981,
     "name_suffix": "_2019",
     "encrypted": "false"

--- a/dashboard/config/scripts/levels/CSP U9L2 SFLP 20-21.level
+++ b/dashboard/config/scripts/levels/CSP U9L2 SFLP 20-21.level
@@ -7,7 +7,7 @@
   "properties": {
     "instructions_important": "false",
     "display_name": "Lesson Overview",
-    "reference": "/curriculum/cspilot/unit9/2/overview/index.html",
+    "reference": "/curriculum/csp-20/unit9/2/overview/index.html",
     "parent_level_id": 19973,
     "name_suffix": "_2019",
     "encrypted": "false"

--- a/dashboard/config/scripts/levels/CSP U9L3 SFLP 20-21.level
+++ b/dashboard/config/scripts/levels/CSP U9L3 SFLP 20-21.level
@@ -7,7 +7,7 @@
   "properties": {
     "instructions_important": "false",
     "display_name": "Lesson Overview",
-    "reference": "/curriculum/cspilot/unit9/3/overview/index.html",
+    "reference": "/curriculum/csp-20/unit9/3/overview/index.html",
     "parent_level_id": 19974,
     "name_suffix": "_2019",
     "encrypted": "false"

--- a/dashboard/config/scripts/levels/CSP U9L4 SFLP 20-21.level
+++ b/dashboard/config/scripts/levels/CSP U9L4 SFLP 20-21.level
@@ -7,7 +7,7 @@
   "properties": {
     "instructions_important": "false",
     "display_name": "Lesson Overview",
-    "reference": "/curriculum/cspilot/unit9/4/overview/index.html",
+    "reference": "/curriculum/csp-20/unit9/4/overview/index.html",
     "parent_level_id": 19975,
     "name_suffix": "_2019",
     "encrypted": "false"

--- a/dashboard/config/scripts/levels/CSP U9L5 SFLP 20-21.level
+++ b/dashboard/config/scripts/levels/CSP U9L5 SFLP 20-21.level
@@ -7,7 +7,7 @@
   "properties": {
     "instructions_important": "false",
     "display_name": "Lesson Overview",
-    "reference": "/curriculum/cspilot/unit9/5/overview/index.html",
+    "reference": "/curriculum/csp-20/unit9/5/overview/index.html",
     "parent_level_id": 19976,
     "name_suffix": "_2019",
     "encrypted": "false"

--- a/dashboard/config/scripts/levels/CSP U9L6 SFLP 20-21.level
+++ b/dashboard/config/scripts/levels/CSP U9L6 SFLP 20-21.level
@@ -7,7 +7,7 @@
   "properties": {
     "instructions_important": "false",
     "display_name": "Lesson Overview",
-    "reference": "/curriculum/cspilot/unit9/5/overview/index.html",
+    "reference": "/curriculum/csp-20/unit9/5/overview/index.html",
     "parent_level_id": 19977,
     "name_suffix": "_2019",
     "encrypted": "false"

--- a/dashboard/config/scripts/levels/CSP U9L7 SFLP 20-21.level
+++ b/dashboard/config/scripts/levels/CSP U9L7 SFLP 20-21.level
@@ -7,7 +7,7 @@
   "properties": {
     "instructions_important": "false",
     "display_name": "Lesson Overview",
-    "reference": "/curriculum/cspilot/unit9/6/overview/index.html",
+    "reference": "/curriculum/csp-20/unit9/6/overview/index.html",
     "parent_level_id": 19978,
     "name_suffix": "_2019",
     "encrypted": "false"

--- a/dashboard/config/scripts/levels/CSP U9L8 SFLP 20-21.level
+++ b/dashboard/config/scripts/levels/CSP U9L8 SFLP 20-21.level
@@ -7,7 +7,7 @@
   "properties": {
     "instructions_important": "false",
     "display_name": "Lesson Overview",
-    "reference": "/curriculum/cspilot/unit9/7/overview/index.html",
+    "reference": "/curriculum/csp-20/unit9/7/overview/index.html",
     "parent_level_id": 19979,
     "name_suffix": "_2019",
     "encrypted": "false"

--- a/dashboard/config/scripts/levels/CSP U9L9 SFLP 20-21.level
+++ b/dashboard/config/scripts/levels/CSP U9L9 SFLP 20-21.level
@@ -7,7 +7,7 @@
   "properties": {
     "instructions_important": "false",
     "display_name": "Lesson Overview",
-    "reference": "/curriculum/cspilot/unit9/8/overview/index.html",
+    "reference": "/curriculum/csp-20/unit9/8/overview/index.html",
     "parent_level_id": 19980,
     "name_suffix": "_2019",
     "encrypted": "false"

--- a/dashboard/config/scripts/levels/CSP Variables Make Test Level 1.level
+++ b/dashboard/config/scripts/levels/CSP Variables Make Test Level 1.level
@@ -7,7 +7,7 @@
   "properties": {
     "instructions_important": "false",
     "display_name": "Lesson Overview",
-    "reference": "/curriculum/cspilot/unit4/4/overview/index.html",
+    "reference": "/curriculum/csp-20/unit4/4/overview/index.html",
     "parent_level_id": 19209,
     "name_suffix": "_2019",
     "encrypted": "false"


### PR DESCRIPTION
Curriculum reference levels across CSP 2020-2021 were pointing to the Pilot course instead of the actual course. This was noticed when a link was updated in the lesson but was not updating in the level. This updates all levels that point to the pilot to point to the current course which Hannah thought was fine to do. 