### PR TITLE
Make it safe to call PartialRegistration.delete

### DIFF
--- a/dashboard/app/models/concerns/partial_registration.rb
+++ b/dashboard/app/models/concerns/partial_registration.rb
@@ -35,6 +35,7 @@ module PartialRegistration
   end
 
   def self.delete(session)
+    return unless in_progress? session
     CDO.shared_cache.delete(session[SESSION_KEY])
     session.delete(SESSION_KEY)
   end

--- a/dashboard/app/models/concerns/partial_registration.rb
+++ b/dashboard/app/models/concerns/partial_registration.rb
@@ -35,6 +35,8 @@ module PartialRegistration
   end
 
   def self.delete(session)
+    # On production, it's unsafe to delete(nil) from the cache, so check that
+    # we actually have a partial registration before we try to clear it.
     return unless in_progress? session
     CDO.shared_cache.delete(session[SESSION_KEY])
     session.delete(SESSION_KEY)

--- a/dashboard/test/models/concerns/partial_registration_test.rb
+++ b/dashboard/test/models/concerns/partial_registration_test.rb
@@ -142,6 +142,16 @@ class PartialRegistrationTest < ActiveSupport::TestCase
     refute CDO.shared_cache.exist? cache_key
   end
 
+  test 'delete can be called safely when no partial registration is in progress' do
+    # Cache#delete(nil) throws on production (where we're using memcached)
+    # but not in other environments (where we're using a file cache).
+    # Force failure if we call this method with nil.
+    CDO.shared_cache.stubs(:delete).with(nil).raises(Exception, "Can't delete nil key.")
+
+    refute PartialRegistration.in_progress? @session
+    PartialRegistration.delete @session
+  end
+
   test 'get_provider returns nil when partial registration is not in progress' do
     assert_nil PartialRegistration.get_provider @session
   end


### PR DESCRIPTION
Immediately after deploying [PartialRegistration gets a smaller session cookie footprint](https://github.com/code-dot-org/code-dot-org/pull/35915) we started seeing [errors from calls to PartialRegistration.delete](https://app.honeybadger.io/projects/3240/faults/66466286) when a partial registration was not in progress.

This adds a guard for this case and a test covering the offending behavior.

A sample of the error rate immediately after deploy:

![image](https://user-images.githubusercontent.com/1615761/89584876-abf0da00-d7f1-11ea-8612-5fbb1251e78a.png)

This happened for users trying to complete an in-progress registration when we deployed our change.  They would have seen a 500 error (sad bee) upon trying to complete registration; however, their account is successfully created at they _should_ be signed in next time they navigate on the site.

## Testing story

Leaning on automated tests.

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
