### PR TITLE
Increase timeout for soft delete script

### DIFF
--- a/bin/oneoff/deprecate_unused_poste_urls.rb
+++ b/bin/oneoff/deprecate_unused_poste_urls.rb
@@ -7,12 +7,24 @@ require_relative './poste_urls_constants'
 
 # mark all poste_urls that are not in urls_to_keep as deleted_at = now
 # this will take a long time to run as it updates the entire poste_urls table
+
+# Production database has a global max query execution timeout setting. This 5 minute setting can be used
+# to override the timeout for a specific session or query.
+MAX_EXECUTION_TIME_SEC = 300
+
+# Connection to write to Pegasus production database.
+PEGASUS_DB_WRITER = sequel_connect(
+  CDO.pegasus_db_writer,
+  CDO.pegasus_db_reader,
+  query_timeout: MAX_EXECUTION_TIME_SEC
+)
+
 puts "Starting update..."
 
-DB[:poste_urls].update(deleted_at: DateTime.now)
+PEGASUS_DB_WRITER[:poste_urls].update(deleted_at: DateTime.now)
 
 puts "Marked all urls as deleted..."
 
-DB[:poste_urls].where(id: POSTE_URLS_TO_KEEP).update(deleted_at: nil)
+PEGASUS_DB_WRITER[:poste_urls].where(id: POSTE_URLS_TO_KEEP).update(deleted_at: nil)
 
 puts "Un-deleted specific urls. Update complete!"


### PR DESCRIPTION
Increase the timeout to 5 minutes for the `deprecate_unused_poste_url` script. The table is too big for the default timeout, and is lightly used so a long-running query should not be impactful.

<!-- ### Background -->
<!-- ### Privacy -->
<!-- ### Security -->
<!-- ### Caching -->
<!-- ### Deployment strategy -->
<!-- ### Future work -->

## Links

- [jira](https://codedotorg.atlassian.net/browse/PLC-937)

## Testing story
Tested the script still works locally.

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
