### PR TITLE
omit self from descendant levels

### DIFF
--- a/dashboard/app/models/levels/level.rb
+++ b/dashboard/app/models/levels/level.rb
@@ -727,7 +727,7 @@ class Level < ActiveRecord::Base
   # project template levels, BubbleChoice sublevels, or LevelGroup sublevels.
   # This method may be overridden by subclasses.
   def all_child_levels
-    (contained_levels + [project_template_level]).compact
+    (contained_levels + [project_template_level] - [self]).compact
   end
 
   private

--- a/dashboard/test/models/level_test.rb
+++ b/dashboard/test/models/level_test.rb
@@ -1056,4 +1056,12 @@ class LevelTest < ActiveSupport::TestCase
     )
     assert_equal [child1, child2, child3], parent.child_levels
   end
+
+  test 'all_descendant_levels works on self-referential project template levels' do
+    level_name = 'project-template-level'
+    level = create :level, name: level_name, properties: {project_template_level_name: level_name}
+    assert_equal level, level.project_template_level
+
+    assert_equal [], level.all_descendant_levels, 'omit self from descendant levels'
+  end
 end


### PR DESCRIPTION
## Background

#36158 introduced a method `all_descendant_levels` on the Script and Level models, however it turns out this fails by infinite recursion when it encounters a level which is its own project template level.

## Description

The solution is to remove `self` from the list of all_child_levels and all_descendant_levels returned by a Level.



## Testing story

* added a new unit test, which fails prior to the fix in this PR
* ran `Script.all.each(&:all_descendant_levels)` successfully, which was failing prior to this PR

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
