### PR TITLE
Remove format_solutions.sh

### DIFF
--- a/apps/script/format_solutions.sh
+++ b/apps/script/format_solutions.sh
@@ -1,6 +1,0 @@
-#!/bin/bash
-
-for xml in $(find test/solutions -name '*.xml'); do
-  xmllint --format $xml | sed '1d' > $xml.tmp
-  mv $xml.tmp $xml
-done


### PR DESCRIPTION
I noticed today that this script is no longer owned by anyone in our organization, isn't called anywhere, and also definitely doesn't work anymore (we don't have a test/solutions folder at all now).

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
