### PR TITLE
Fix UI test with covered button

### DIFF
--- a/dashboard/test/ui/features/learning_platform/level_navigation.feature
+++ b/dashboard/test/ui/features/learning_platform/level_navigation.feature
@@ -3,6 +3,7 @@ Feature: Continue button on levels
 Scenario: External Video Level
   Given I am a teacher
   Given I am on "http://studio.code.org/s/coursec-2019/stage/14/puzzle/1"
+  And I dismiss the teacher panel
   And I wait to see ".video-download"
   And I wait to see ".submitButton"
   Then I click ".submitButton" to load a new page

--- a/dashboard/test/ui/features/step_definitions/steps.rb
+++ b/dashboard/test/ui/features/step_definitions/steps.rb
@@ -1148,6 +1148,13 @@ And /^I dismiss the language selector$/ do
   }
 end
 
+And /^I dismiss the teacher panel$/ do
+  steps %Q{
+    And I click selector ".fa-chevron-right"
+    And I wait until I see selector ".fa-chevron-left"
+  }
+end
+
 And(/^I give user "([^"]*)" authorized teacher permission$/) do |name|
   require_rails_env
   user = User.find_by_email_or_hashed_email(@users[name][:email])


### PR DESCRIPTION
The teacher panel was covering the submit button which was causing the test to fail in Firefox & Safari.  This is an attempt to fix by dismissing the teacher panel first.
