### PR TITLE
Minor CSS fix for header on workshop and hidden_stage pages

### DIFF
--- a/apps/src/code-studio/pd/components/header.jsx
+++ b/apps/src/code-studio/pd/components/header.jsx
@@ -82,7 +82,7 @@ export default class Header extends React.Component {
 
   render() {
     return (
-      <div>
+      <div className={'breadcrumbHeader'}>
         <Breadcrumb>{this.renderBreadcrumbItems()}</Breadcrumb>
         {this.props.children}
       </div>

--- a/apps/src/code-studio/pd/components/header.jsx
+++ b/apps/src/code-studio/pd/components/header.jsx
@@ -82,7 +82,7 @@ export default class Header extends React.Component {
 
   render() {
     return (
-      <div className={'breadcrumbHeader'}>
+      <div className={'breadcrumb-header'}>
         <Breadcrumb>{this.renderBreadcrumbItems()}</Breadcrumb>
         {this.props.children}
       </div>

--- a/dashboard/app/assets/stylesheets/application.scss
+++ b/dashboard/app/assets/stylesheets/application.scss
@@ -3256,6 +3256,10 @@ code {
   }
 }
 
+.breadcrumbHeader {
+  margin-top: 10px;
+}
+
 #survey-submission-thankyou {
   color: $purple;
   font-size: 18px;

--- a/dashboard/app/assets/stylesheets/application.scss
+++ b/dashboard/app/assets/stylesheets/application.scss
@@ -3256,7 +3256,7 @@ code {
   }
 }
 
-.breadcrumbHeader {
+.breadcrumb-header {
   margin-top: 10px;
 }
 

--- a/dashboard/app/views/levels/_hidden_stage.haml
+++ b/dashboard/app/views/levels/_hidden_stage.haml
@@ -1,7 +1,7 @@
 - hidden = local_assigns[:hidden]
 - unless @script.nil?
   #hidden-stage{style: hidden ? 'display: none' : '' }
-    %div{style: 'margin-bottom: 15px' }
+    %div{style: 'margin-bottom: 15px; margin-top: 10px' }
       =t('hidden_stage')
     %a{href: script_path(@script)}
       %button.btn.btn-large.btn-primary


### PR DESCRIPTION
**Bug** - On the workshop pages and hidden_stage pages, there is no margin/padding/space between the Code.org header bar and the content of the page.
**Cause** - Some recent CSS changes to the Code.org header CSS removed the `10px` margin below it for every page. Most pages were fixed, but these two were missed.
**Fix** - Add a `10px` margin to the top of the content on the workshop and hidden_stage pages.

## Eyes failures
Here are the Eyes failures this PR addresses. The left side of the screenshot is the original, correct page. The right side of the screenshot is the regression/bug.

### Hidden stage
Note the lack of space between the teal Code.org header at the top and the text below it.
![image](https://user-images.githubusercontent.com/1372238/89954770-389bfd80-dc21-11ea-9f79-668d412a3299.png)

### Workshop
Note the lack of space between the teal Code.org header at the top and the gray breadcrumb header below it.
![image](https://user-images.githubusercontent.com/1372238/89955139-e0b1c680-dc21-11ea-96d6-70440596ab6d.png)

## Links
- [Offending PR](https://github.com/code-dot-org/code-dot-org/pull/36220/files)

## Testing story
* Manually verified on local host.

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
