### PR TITLE
Improve UI test with covered button

### DIFF
--- a/dashboard/test/ui/features/step_definitions/steps.rb
+++ b/dashboard/test/ui/features/step_definitions/steps.rb
@@ -1150,8 +1150,8 @@ end
 
 And /^I dismiss the teacher panel$/ do
   steps %Q{
-    And I click selector ".fa-chevron-right"
-    And I wait until I see selector ".fa-chevron-left"
+    And I click selector ".teacher-panel > .hide-handle > .fa-chevron-right"
+    And I wait until I see selector ".teacher-panel > .show-handle > .fa-chevron-left"
   }
 end
 


### PR DESCRIPTION
Followup to https://github.com/code-dot-org/code-dot-org/pull/36231.  This improves the selectors for the teacher panel's show/hide icons to avoid any inadvertent mismatches.