### PR TITLE
Add sourceUrl to sprite-use metrics logging

### DIFF
--- a/apps/src/p5lab/AnimationPicker/animationPickerModule.js
+++ b/apps/src/p5lab/AnimationPicker/animationPickerModule.js
@@ -202,9 +202,12 @@ export function pickNewAnimation() {
 export function pickLibraryAnimation(animation) {
   firehoseClient.putRecord({
     study: 'sprite-use',
-    study_group: 'before-update',
+    study_group: 'before-update-v2',
     event: 'select-sprite',
-    data_string: animation.name
+    data_json: JSON.stringify({
+      name: animation.name,
+      sourceUrl: animation.sourceUrl
+    })
   });
   return (dispatch, getState) => {
     const goal = getState().animationPicker.goal;


### PR DESCRIPTION
Follow-up to #35612.

This makes it so that we can distinguish animations with the same name when analyzing this data -- e.g., `category_generic_items/pepper.png` (a pepper shaker) and `category_food/pepper.png` (a bell pepper) won't be lumped together.

Adding the sourceUrl makes it so that we can:
- separate animations with the same base filename
- determine which animations are popular in spritelab vs. gamelab
- display the image when looking at animation usage metrics

## Testing story

No testing change needed.

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
