### PR TITLE
Fix The Daily Zendesk

### DIFF
--- a/bin/cron/zendesk_slack_report
+++ b/bin/cron/zendesk_slack_report
@@ -21,6 +21,7 @@ exit(1) unless only_one_running?(__FILE__)
 require 'httparty'
 require 'uri'
 require_relative '../../deployment'
+require 'cdo/chat_client'
 
 # CONFIGURATION
 


### PR DESCRIPTION
Nine days ago [this cronjob started failing](https://app.honeybadger.io/projects/45435/faults/66270510) because it couldn't find ChatClient.  I believe we were getting it implicitly through deployment.rb before.  I'm not sure what changed, but the fix is simple: Explicitly require this dependency.

## Testing story

I ran `bin/cron/zendesk_slack_report` locally (I have the required API keys configured in my environment) and it successfully queried Zendesk and posted to various rooms.

![image](https://user-images.githubusercontent.com/1615761/90056143-40948580-dc93-11ea-93a7-e31574d99390.png)

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
