### PR TITLE
Course edit pages

### DIFF
--- a/apps/src/templates/courseOverview/CourseEditor.js
+++ b/apps/src/templates/courseOverview/CourseEditor.js
@@ -58,6 +58,7 @@ export default class CourseEditor extends Component {
       courseFamilies,
       versionYearOptions
     } = this.props;
+    const urlPath = `/courses/${name}`;
     return (
       <div>
         <h1>{name}</h1>
@@ -68,6 +69,15 @@ export default class CourseEditor extends Component {
             name="title"
             defaultValue={title}
             style={styles.input}
+          />
+        </label>
+        <label>
+          Course URL
+          <input
+            type="text"
+            value={urlPath}
+            style={styles.input}
+            disabled={true}
           />
         </label>
         <label>

--- a/apps/src/templates/courseOverview/CourseEditor.js
+++ b/apps/src/templates/courseOverview/CourseEditor.js
@@ -81,6 +81,49 @@ export default class CourseEditor extends Component {
           />
         </label>
         <label>
+          Short Description (used in course cards on homepage)
+          <textarea
+            name="description_short"
+            defaultValue={descriptionShort}
+            rows={5}
+            style={styles.input}
+          />
+        </label>
+        <label>
+          Student Description
+          <textarea
+            name="description_student"
+            defaultValue={descriptionStudent}
+            rows={5}
+            style={styles.input}
+          />
+        </label>
+        <label>
+          Teacher Description
+          <textarea
+            name="description_teacher"
+            defaultValue={descriptionTeacher}
+            rows={5}
+            style={styles.input}
+          />
+        </label>
+        <h2>Basic settings</h2>
+        <label>
+          Verified Resources
+          <input
+            name="has_verified_resources"
+            type="checkbox"
+            defaultChecked={this.props.hasVerifiedResources}
+            style={styles.checkbox}
+          />
+          <p>
+            Check if this course has resources (such as lockable lessons and
+            answer keys) for verified teachers, and we want to notify
+            non-verified teachers that this is the case.
+          </p>
+        </label>
+        <h2>Publishing settings</h2>
+        <label>
           Family Name
           <select
             name="family_name"
@@ -129,49 +172,8 @@ export default class CourseEditor extends Component {
             recommended version.
           </p>
         </label>
+        <h2>Units</h2>
         <label>
-          Short Description (used in course cards on homepage)
-          <textarea
-            name="description_short"
-            defaultValue={descriptionShort}
-            rows={5}
-            style={styles.input}
-          />
-        </label>
-        <label>
-          Student Description
-          <textarea
-            name="description_student"
-            defaultValue={descriptionStudent}
-            rows={5}
-            style={styles.input}
-          />
-        </label>
-        <label>
-          Teacher Description
-          <textarea
-            name="description_teacher"
-            defaultValue={descriptionTeacher}
-            rows={5}
-            style={styles.input}
-          />
-        </label>
-        <label>
-          Verified Resources
-          <input
-            name="has_verified_resources"
-            type="checkbox"
-            defaultChecked={this.props.hasVerifiedResources}
-            style={styles.checkbox}
-          />
-          <p>
-            Check if this course has resources (such as lockable lessons and
-            answer keys) for verified teachers, and we want to notify
-            non-verified teachers that this is the case.
-          </p>
-        </label>
-        <label>
-          <h4>Scripts</h4>
           <div>
             The dropdown(s) below represent the ordered set of scripts in this
             course. To remove a script, just set the dropdown to the default
@@ -184,7 +186,7 @@ export default class CourseEditor extends Component {
           />
         </label>
         <div>
-          <h4>Teacher Resources</h4>
+          <h2>Teacher Resources</h2>
           <div>
             Select up to three Teacher Resources buttons you'd like to have show
             up on the top of the course overview page

--- a/apps/src/templates/courseOverview/CourseEditor.js
+++ b/apps/src/templates/courseOverview/CourseEditor.js
@@ -58,7 +58,6 @@ export default class CourseEditor extends Component {
       courseFamilies,
       versionYearOptions
     } = this.props;
-    const urlPath = `/courses/${name}`;
     return (
       <div>
         <h1>{name}</h1>
@@ -72,10 +71,10 @@ export default class CourseEditor extends Component {
           />
         </label>
         <label>
-          Course URL
+          URL slug
           <input
             type="text"
-            value={urlPath}
+            value={name}
             style={styles.input}
             disabled={true}
           />

--- a/apps/src/templates/courseOverview/CourseEditor.js
+++ b/apps/src/templates/courseOverview/CourseEditor.js
@@ -62,7 +62,7 @@ export default class CourseEditor extends Component {
       <div>
         <h1>{name}</h1>
         <label>
-          Title
+          Display Name
           <input
             type="text"
             name="title"

--- a/dashboard/app/views/courses/new.html.haml
+++ b/dashboard/app/views/courses/new.html.haml
@@ -9,9 +9,10 @@
       - unit_group.errors.full_messages.each do |msg|
         %li= msg
 
-%h1= t('crud.new_model', model: UnitGroup.model_name.human)
+%h1
+  New Course
 = form_for(unit_group || :course, unit_group ? {url: course_path(unit_group)} : {url: courses_path}) do |f|
   .field
-    = f.label :name
-    = f.text_field :name
-  %button.btn.btn-primary{type: 'submit', style: 'margin: 0'} Save Changes
+    = f.label 'URL slug'
+    = f.text_field :name, placeholder: 'e.g. csp-2019'
+  %button.btn.btn-primary{type: 'submit', style: 'margin: 0'} Create

--- a/dashboard/app/views/courses/show.html.haml
+++ b/dashboard/app/views/courses/show.html.haml
@@ -20,4 +20,8 @@
   = render layout: 'shared/extra_links' do
     %strong= unit_group.name
     %ul
-      %li= link_to "Edit", edit_course_path(unit_group)
+      - if Rails.application.config.levelbuilder_mode
+        %li= link_to "Edit", edit_course_path(unit_group)
+      - else
+        - lb_path = "https://levelbuilder-studio.code.org#{course_path(unit_group)}"
+        %li= link_to "View on levelbuilder", lb_path

--- a/dashboard/app/views/courses/show.html.haml
+++ b/dashboard/app/views/courses/show.html.haml
@@ -15,3 +15,9 @@
   %script{ src: webpack_asset_path('js/courses/show.js'), data: {courses_show: data.to_json}}
 
 #course_overview
+
+- if can? :edit, unit_group
+  = render layout: 'shared/extra_links' do
+    %strong= unit_group.name
+    %ul
+      %li= link_to "Edit", edit_course_path(unit_group)

--- a/dashboard/app/views/scripts/show.html.haml
+++ b/dashboard/app/views/scripts/show.html.haml
@@ -56,7 +56,11 @@
     = render layout: 'shared/extra_links' do
       %strong= @script.name
       %ul
-        %li= link_to "Edit", edit_script_path(@script)
+        - if Rails.application.config.levelbuilder_mode
+          %li= link_to "Edit", edit_script_path(@script)
+        - else
+          - lb_path = "https://levelbuilder-studio.code.org#{script_path(@script)}"
+          %li= link_to "View on levelbuilder", lb_path
       - unless @script.unit_groups.empty?
         = "This script is in #{@script.unit_groups.length} course#{'s' unless @script.unit_groups.length == 1}:"
         %ul


### PR DESCRIPTION
## Background

Starts [PLAT-259] . Also see [spec](https://docs.google.com/document/d/1wubJ6xRhdmuV9d25i5SgEzrCKcR1VjuErcv7GzL0Y0Y/edit#heading=h.jl29htiuqe0x).

## Description

* Completes requirements 2-4 in the [levelbuilder course editing page section of the spec](https://docs.google.com/document/d/1wubJ6xRhdmuV9d25i5SgEzrCKcR1VjuErcv7GzL0Y0Y/edit#heading=h.jl29htiuqe0x)

  * Req. 2: Add a url field to the course edit page so curriculum writers can see what the url is

  * Req. 3: Clean up the course page to match some of the changes we made to the unit page

  * Req. 4 (P2 - could wait): Make sure the “Extra links” dialog can appear on course pages too

* also fixes up "extra links" box on script and course overview pages so that when viewed on production, they link to the same overview page on levelbuilder, rather than to a blank "edit" page on production

## Screenshots

| before | after |
|---|---|
| new course page | |
| ![Screen Shot 2020-08-12 at 11 25 49 AM](https://user-images.githubusercontent.com/8001765/90060352-72104f80-dc99-11ea-8168-c6c379d0b267.png) |  ![Screen Shot 2020-08-12 at 11 26 45 AM](https://user-images.githubusercontent.com/8001765/90060396-82282f00-dc99-11ea-9a95-1f48dcb25d19.png) |
| course edit page |  |
| ![levelbuilder-studio code org_courses_csp-2020_edit](https://user-images.githubusercontent.com/8001765/90060445-966c2c00-dc99-11ea-9dde-e303bff31ccd.png) | ![localhost-studio code org_3000_courses_csp-2020_edit](https://user-images.githubusercontent.com/8001765/90060470-a08e2a80-dc99-11ea-9e7e-492669a97b98.png) |
| course overview page (levelbuilder permissions + levelbuilder_mode) | |
| N/A | ![Screen Shot 2020-08-12 at 12 23 58 PM](https://user-images.githubusercontent.com/8001765/90060687-f2cf4b80-dc99-11ea-9f4f-2da00a02c2d6.png) |
| course overview page (levelbuilder permissions, no levelbuilder_mode) | |
| N/A | ![Screen Shot 2020-08-12 at 12 35 58 PM](https://user-images.githubusercontent.com/8001765/90060719-febb0d80-dc99-11ea-8a6d-659830d3ca74.png) |
| script overview page(levelbuilder permissions, no levelbuilder-mode) |  |
| ![Screen Shot 2020-08-12 at 12 38 26 PM](https://user-images.githubusercontent.com/8001765/90060965-55284c00-dc9a-11ea-819a-4239d8f70ee5.png) | ![Screen Shot 2020-08-12 at 12 40 12 PM](https://user-images.githubusercontent.com/8001765/90060979-5c4f5a00-dc9a-11ea-9509-27923d53b6d0.png) |

## Testing story

There is no automated test coverage on these changes. We could add a UI test for the course edit page if we wanted.

Manual test coverage:

* checked "extra links" work in all configurations
* course "new" and "edit" pages still work

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked


[PLAT-259]: https://codedotorg.atlassian.net/browse/PLAT-259