### PR TITLE
Update hourofcode.com button styling

### DIFF
--- a/pegasus/sites.v3/hourofcode.com/views/hoc_action_buttons.haml
+++ b/pegasus/sites.v3/hourofcode.com/views/hoc_action_buttons.haml
@@ -1,22 +1,22 @@
 -if ["post-hoc", false].include?(hoc_mode)
   %a#tryitbutton.ctabuttonatag{href: resolve_url('/learn')}
-    %button.ctabutton-white
+    %button.ctabutton
       = hoc_s(:front_join_us_try)
   &nbsp;
   %a#videobutton.ctabuttontag{onclick: "adjustScroll('homepage-video');", style: "text-decoration: none;"}
-    %button.ctabutton-white-inverse
+    %button.ctabutton-white
       = hoc_s(:front_watch_regular_video)
 -elsif ["pre-hoc", "soon-hoc"].include?(hoc_mode)
   %a#signupbutton.ctabuttonatag{onclick: "adjustScroll('join');", style: "text-decoration: none;"}
-    %button.ctabutton-white
+    %button.ctabutton
       = hoc_s(:front_join_us_button)
   &nbsp;
   %a#tryitbutton.ctabuttonatag{href: resolve_url('/learn')}
-    %button.ctabutton-white-inverse
+    %button.ctabutton-white
       = hoc_s(:front_join_us_try)
 -elsif ["actual-hoc"].include?(hoc_mode)
   %a#tryitbutton.ctabuttonatag{href: resolve_url('/learn')}
-    %button.ctabutton-white
+    %button.ctabutton
       = hoc_s(:front_join_us_try)
 
 :javascript


### PR DESCRIPTION
This improves the styling of the call-to-action buttons on hourofcode.com to improve visibility on very wide displays.

On very wide displays, it was difficult to see the second button:

![Screen Shot 2020-08-12 at 1 43 44 PM](https://user-images.githubusercontent.com/2205926/90065942-df27e300-dca1-11ea-9c95-07379a334520.png)

So we have changed it to this:

![Screen Shot 2020-08-12 at 1 49 22 PM](https://user-images.githubusercontent.com/2205926/90066612-d1bf2880-dca2-11ea-9b93-f3b208cbbac2.png)

The full set of variants is as follows...

**post-hoc/none**

![Screen Shot 2020-08-12 at 1 34 14 PM](https://user-images.githubusercontent.com/2205926/90066076-18f8e980-dca2-11ea-9620-3fe88a3a7233.png)

**pre-hoc/soon-hoc**

![Screen Shot 2020-08-12 at 1 36 16 PM](https://user-images.githubusercontent.com/2205926/90066097-24e4ab80-dca2-11ea-8621-c8b7f5233bc6.png)

**actual-hoc**

![Screen Shot 2020-08-12 at 1 37 01 PM](https://user-images.githubusercontent.com/2205926/90066123-2dd57d00-dca2-11ea-8988-60d66a90681c.png)

