### PR TITLE
Use window.locales instead of window.blockly for i18n

### DIFF
--- a/apps/Gruntfile.js
+++ b/apps/Gruntfile.js
@@ -1129,7 +1129,7 @@ describe('entry tests', () => {
           '/*' +
           item +
           '*/ ' +
-          'module.exports = window.blockly.' +
+          'module.exports = window.locales.' +
           localeType +
           ';';
         fs.writeFileSync(path.join(current, item + '.js'), localeString);

--- a/apps/src/applab/locale-do-not-import.js
+++ b/apps/src/applab/locale-do-not-import.js
@@ -8,4 +8,4 @@
  */
 // locale for applab
 
-export default window.blockly.applab_locale;
+export default window.locales.applab_locale;

--- a/apps/src/fish/locale-do-not-import.js
+++ b/apps/src/fish/locale-do-not-import.js
@@ -8,4 +8,4 @@
  */
 // locale for fish
 
-export default window.blockly.fish_locale;
+export default window.locales.fish_locale;

--- a/apps/src/tutorialExplorer/locale-do-not-import.js
+++ b/apps/src/tutorialExplorer/locale-do-not-import.js
@@ -6,4 +6,4 @@
  * This allows the webpack config to determine how locales should be loaded,
  * which is important for making locale setup work seamlessly in tests.
  */
-export default window.blockly.tutorialExplorer_locale;
+export default window.locales.tutorialExplorer_locale;

--- a/apps/src/util/safeLoadLocale.js
+++ b/apps/src/util/safeLoadLocale.js
@@ -8,8 +8,8 @@
  *     "applab_locale", etc.
  */
 export default function safeLoadLocale(localeKey) {
-  if (window.blockly && window.blockly[localeKey]) {
-    return window.blockly[localeKey];
+  if (window.locales && window.locales[localeKey]) {
+    return window.locales[localeKey];
   } else {
     console.warn(
       'Loading translations can only be done in a context where blockly is ' +

--- a/apps/src/util/safeLoadLocale.js
+++ b/apps/src/util/safeLoadLocale.js
@@ -1,6 +1,6 @@
 /**
- * Helper method for loading the locale from blockly, which will detect if
- * blockly is not present in the environment and fall back to an empty locale
+ * Helper method for loading the locale from the global scope, which will detect if
+ * translations are not present in the environment and fall back to an empty locale
  * object.
  *
  * @param localeKey {String} The name of the locale on the global blockly
@@ -12,10 +12,8 @@ export default function safeLoadLocale(localeKey) {
     return window.locales[localeKey];
   } else {
     console.warn(
-      'Loading translations can only be done in a context where blockly is ' +
-        'available, but blockly was not found in the global scope. Falling ' +
-        'back on an empty translation object. The page may break due to ' +
-        'missing translations.'
+      'Translations must be loaded into the global scope before access. ' +
+        'Falling back on an empty translation object. This page may break due to missing translations.'
     );
 
     // Return an empty object, so i18n methods throw where they are called and

--- a/apps/src/weblab/locale-do-not-import.js
+++ b/apps/src/weblab/locale-do-not-import.js
@@ -8,4 +8,4 @@
  */
 // locale for weblab
 
-export default window.blockly.weblab_locale;
+export default window.locales.weblab_locale;

--- a/apps/tasks/messages.js
+++ b/apps/tasks/messages.js
@@ -79,7 +79,7 @@ module.exports = function(grunt) {
     return (
       mf
         .compile(json)
-        .toString('(window.blockly = window.blockly || {}).' + namespace) + ';'
+        .toString('(window.locales = window.locales || {}).' + namespace) + ';'
     );
   }
 };

--- a/apps/test/util/applab/locale-do-not-import.js
+++ b/apps/test/util/applab/locale-do-not-import.js
@@ -10,4 +10,4 @@
 require('../frame')();
 require('../../../build/package/js/en_us/applab_locale.js');
 
-module.exports = window.blockly.applab_locale;
+module.exports = window.locales.applab_locale;

--- a/apps/test/util/gamelab/locale-do-not-import.js
+++ b/apps/test/util/gamelab/locale-do-not-import.js
@@ -10,4 +10,4 @@
 require('../frame')();
 require('../../../build/package/js/en_us/gamelab_locale.js');
 
-module.exports = window.blockly.gamelab_locale;
+module.exports = window.locales.gamelab_locale;

--- a/apps/test/util/locale-do-not-import.js
+++ b/apps/test/util/locale-do-not-import.js
@@ -16,4 +16,4 @@ var context = require.context(
 );
 context.keys().forEach(context);
 
-module.exports = window.blockly.common_locale;
+module.exports = window.locales.common_locale;

--- a/apps/test/util/netsim/locale-do-not-import.js
+++ b/apps/test/util/netsim/locale-do-not-import.js
@@ -10,4 +10,4 @@
 require('../frame')();
 require('../../../build/package/js/en_us/netsim_locale.js');
 
-module.exports = window.blockly.netsim_locale;
+module.exports = window.locales.netsim_locale;

--- a/apps/test/util/tutorialExplorer/locale-do-not-import.js
+++ b/apps/test/util/tutorialExplorer/locale-do-not-import.js
@@ -9,4 +9,4 @@
 // make sure Blockly is loaded
 require('../frame')();
 require('../../../build/package/js/en_us/tutorialExplorer_locale.js');
-export default window.blockly.tutorialExplorer_locale;
+export default window.locales.tutorialExplorer_locale;

--- a/apps/test/util/weblab/locale-do-not-import.js
+++ b/apps/test/util/weblab/locale-do-not-import.js
@@ -10,4 +10,4 @@
 require('../frame')();
 require('../../../build/package/js/en_us/weblab_locale.js');
 
-module.exports = window.blockly.weblab_locale;
+module.exports = window.locales.weblab_locale;


### PR DESCRIPTION
`window.blockly` is deceptive as our locales build actually doesn't depend on Blockly. Let's rename the namespace to something more descriptive (I chose `window.locale` but am open for feedback).

## Testing story

I poked around the site a bit. This change would likely break horribly in tests so the fact that it doesn't is a good sign.

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
