### PR TITLE
Make sure every lesson has a key that matches its name.

### DIFF
--- a/dashboard/app/models/lesson.rb
+++ b/dashboard/app/models/lesson.rb
@@ -59,6 +59,7 @@ class Lesson < ActiveRecord::Base
       lesson = script.lessons.detect {|s| s.name == raw_lesson[:name]} ||
         Lesson.find_or_create_by(
           name: raw_lesson[:name],
+          key: raw_lesson[:name],
           script: script
         ) do |s|
           s.relative_position = 0 # will be updated below, but cant be null

--- a/dashboard/db/migrate/20200812210939_copy_lesson_name_to_key_take2.rb
+++ b/dashboard/db/migrate/20200812210939_copy_lesson_name_to_key_take2.rb
@@ -1,0 +1,14 @@
+class CopyLessonNameToKeyTake2 < ActiveRecord::Migration[5.0]
+  # We are doing this a second time because new lessons were created between the time the last
+  # one was run and when we figured out there was another change we need to make to make
+  # sure new lessons got their key value set.
+  def up
+    Lesson.all.each do |lesson|
+      lesson.key = lesson.name
+      lesson.save!
+    end
+  end
+
+  def down
+  end
+end

--- a/dashboard/db/schema.rb
+++ b/dashboard/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20200803211022) do
+ActiveRecord::Schema.define(version: 20200812210939) do
 
   create_table "activities", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci" do |t|
     t.integer  "user_id"


### PR DESCRIPTION
In trying to release https://github.com/code-dot-org/code-dot-org/pull/36020, we realized that we should have been adding keys to new lessons as they were made after we did the migration to add keys to all lessons. In order to catch the new lessons that have been made since we initially did the migration to copy the lesson name values to the lesson key values, this PR adds that migration a second time. It also starts adding key values to new lessons which are created so we won't hit this problem again.
