### PR TITLE
Adding configurations for use of the Immersive Reader API

### DIFF
--- a/config.yml.erb
+++ b/config.yml.erb
@@ -544,7 +544,7 @@ pegasus_reporting_db_reader:   '<%="#{reporting_db_reader}#{pegasus_db_name}"%>'
 pegasus_reporting_db_writer:   '<%="#{reporting_db_writer}#{pegasus_db_name}"%>'
 
 # Configurations for making calls to the Immersive Reader API on Azure
-imm_reader_tenant_id:
+imm_reader_tenant_id:     '01521c57-6696-4ac9-b8ba-d2f2955893bd'
 imm_reader_client_id:
 imm_reader_client_secret: !Secret
-imm_reader_subdomain:
+imm_reader_subdomain:     cdo-immersive-reader-<%=env%>

--- a/config.yml.erb
+++ b/config.yml.erb
@@ -542,3 +542,9 @@ dashboard_reporting_db_reader: '<%="#{reporting_db_reader}#{dashboard_db_name}"%
 dashboard_reporting_db_writer: '<%="#{reporting_db_writer}#{dashboard_db_name}"%>'
 pegasus_reporting_db_reader:   '<%="#{reporting_db_reader}#{pegasus_db_name}"%>'
 pegasus_reporting_db_writer:   '<%="#{reporting_db_writer}#{pegasus_db_name}"%>'
+
+# Configurations for making calls to the Immersive Reader API on Azure
+imm_reader_tenant_id:
+imm_reader_client_id:
+imm_reader_client_secret: !Secret
+imm_reader_subdomain:

--- a/config/levelbuilder.yml.erb
+++ b/config/levelbuilder.yml.erb
@@ -20,4 +20,3 @@ custom_error_response: false
 
 # Configurations for making calls to the Immersive Reader API on Azure
 imm_reader_client_id:     '4fa6b522-6e6d-44c6-b023-98816b54566d'
-imm_reader_client_secret: !Secret

--- a/config/levelbuilder.yml.erb
+++ b/config/levelbuilder.yml.erb
@@ -17,3 +17,9 @@ acapela_storage_password: !Secret
 
 # Curriculum team needs to be able to see raw HTTP error pages so they can debug the content they are implementing.
 custom_error_response: false
+
+# Configurations for making calls to the Immersive Reader API on Azure
+imm_reader_tenant_id:     '01521c57-6696-4ac9-b8ba-d2f2955893bd'
+imm_reader_client_id:     '4fa6b522-6e6d-44c6-b023-98816b54566d'
+imm_reader_client_secret: !Secret
+imm_reader_subdomain:     'cdo-immersive-reader-levelbuilder'

--- a/config/levelbuilder.yml.erb
+++ b/config/levelbuilder.yml.erb
@@ -19,7 +19,5 @@ acapela_storage_password: !Secret
 custom_error_response: false
 
 # Configurations for making calls to the Immersive Reader API on Azure
-imm_reader_tenant_id:     '01521c57-6696-4ac9-b8ba-d2f2955893bd'
 imm_reader_client_id:     '4fa6b522-6e6d-44c6-b023-98816b54566d'
 imm_reader_client_secret: !Secret
-imm_reader_subdomain:     'cdo-immersive-reader-levelbuilder'

--- a/config/production.yml.erb
+++ b/config/production.yml.erb
@@ -32,5 +32,4 @@ afe_pardot_form_handler_url: !Secret
 
 # Configurations for making calls to the Immersive Reader API on Azure
 imm_reader_client_id:     '06d74083-9d25-43e4-acf6-0377f381a1e5'
-imm_reader_client_secret: !Secret
 imm_reader_subdomain:     'cdo-immersive-reader-prod'

--- a/config/production.yml.erb
+++ b/config/production.yml.erb
@@ -29,3 +29,9 @@ enrollments_summer_2020_gsheet_key: !Secret
 
 # Amazon Future Engineer integration
 afe_pardot_form_handler_url: !Secret
+
+# Configurations for making calls to the Immersive Reader API on Azure
+imm_reader_tenant_id:     '01521c57-6696-4ac9-b8ba-d2f2955893bd'
+imm_reader_client_id:     '06d74083-9d25-43e4-acf6-0377f381a1e5'
+imm_reader_client_secret: !Secret
+imm_reader_subdomain:     'cdo-immersive-reader-prod'

--- a/config/production.yml.erb
+++ b/config/production.yml.erb
@@ -31,7 +31,6 @@ enrollments_summer_2020_gsheet_key: !Secret
 afe_pardot_form_handler_url: !Secret
 
 # Configurations for making calls to the Immersive Reader API on Azure
-imm_reader_tenant_id:     '01521c57-6696-4ac9-b8ba-d2f2955893bd'
 imm_reader_client_id:     '06d74083-9d25-43e4-acf6-0377f381a1e5'
 imm_reader_client_secret: !Secret
 imm_reader_subdomain:     'cdo-immersive-reader-prod'

--- a/config/staging.yml.erb
+++ b/config/staging.yml.erb
@@ -13,4 +13,3 @@ custom_error_response: false
 
 # Configurations for making calls to the Immersive Reader API on Azure
 imm_reader_client_id:     '74937af0-55ee-411a-867a-57eefadec7d9'
-imm_reader_client_secret: !Secret

--- a/config/staging.yml.erb
+++ b/config/staging.yml.erb
@@ -10,3 +10,9 @@ poste_attachment_dir:              /home/ubuntu/poste_attachments
 
 # Developer of the Day needs to see raw HTTP error pages so they can debug an issue with a staging build.
 custom_error_response: false
+
+# Configurations for making calls to the Immersive Reader API on Azure
+imm_reader_tenant_id:     '01521c57-6696-4ac9-b8ba-d2f2955893bd'
+imm_reader_client_id:     '74937af0-55ee-411a-867a-57eefadec7d9'
+imm_reader_client_secret: !Secret
+imm_reader_subdomain:     'cdo-immersive-reader-staging'

--- a/config/staging.yml.erb
+++ b/config/staging.yml.erb
@@ -12,7 +12,5 @@ poste_attachment_dir:              /home/ubuntu/poste_attachments
 custom_error_response: false
 
 # Configurations for making calls to the Immersive Reader API on Azure
-imm_reader_tenant_id:     '01521c57-6696-4ac9-b8ba-d2f2955893bd'
 imm_reader_client_id:     '74937af0-55ee-411a-867a-57eefadec7d9'
 imm_reader_client_secret: !Secret
-imm_reader_subdomain:     'cdo-immersive-reader-staging'

--- a/config/test.yml.erb
+++ b/config/test.yml.erb
@@ -7,7 +7,6 @@ saucelabs_username: !Secret
 
 # Configurations for making calls to the Immersive Reader API on Azure
 imm_reader_client_id:     '92ef2120-f523-41fe-a995-f9720bf70b81'
-imm_reader_client_secret: !Secret
 
 # Disable Secrets for CI, unit-test runs,
 # and other non-chef_managed environments (e.g., preloading Spring for Rails tests).

--- a/config/test.yml.erb
+++ b/config/test.yml.erb
@@ -46,7 +46,5 @@ disable_s3_image_uploads: true
 firebase_channel_id_suffix: '<%=ci ? "-#{circle_run_identifier}" : ''%>'
 
 # Configurations for making calls to the Immersive Reader API on Azure
-imm_reader_tenant_id:     '01521c57-6696-4ac9-b8ba-d2f2955893bd'
 imm_reader_client_id:     '92ef2120-f523-41fe-a995-f9720bf70b81'
 imm_reader_client_secret: !Secret
-imm_reader_subdomain:     'cdo-immersive-reader-test'

--- a/config/test.yml.erb
+++ b/config/test.yml.erb
@@ -44,3 +44,9 @@ disable_s3_image_uploads: true
 
 # provide a unique path for firebase channels data for ci, to avoid conflicts in channel ids.
 firebase_channel_id_suffix: '<%=ci ? "-#{circle_run_identifier}" : ''%>'
+
+# Configurations for making calls to the Immersive Reader API on Azure
+imm_reader_tenant_id:     '01521c57-6696-4ac9-b8ba-d2f2955893bd'
+imm_reader_client_id:     '92ef2120-f523-41fe-a995-f9720bf70b81'
+imm_reader_client_secret: !Secret
+imm_reader_subdomain:     'cdo-immersive-reader-test'

--- a/config/test.yml.erb
+++ b/config/test.yml.erb
@@ -5,6 +5,10 @@ azure_content_moderation_key: !Secret
 saucelabs_authkey: !Secret
 saucelabs_username: !Secret
 
+# Configurations for making calls to the Immersive Reader API on Azure
+imm_reader_client_id:     '92ef2120-f523-41fe-a995-f9720bf70b81'
+imm_reader_client_secret: !Secret
+
 # Disable Secrets for CI, unit-test runs,
 # and other non-chef_managed environments (e.g., preloading Spring for Rails tests).
 <% if ci_test || !chef_managed -%>
@@ -44,7 +48,3 @@ disable_s3_image_uploads: true
 
 # provide a unique path for firebase channels data for ci, to avoid conflicts in channel ids.
 firebase_channel_id_suffix: '<%=ci ? "-#{circle_run_identifier}" : ''%>'
-
-# Configurations for making calls to the Immersive Reader API on Azure
-imm_reader_client_id:     '92ef2120-f523-41fe-a995-f9720bf70b81'
-imm_reader_client_secret: !Secret


### PR DESCRIPTION
Adding configurations to be used when calling the Azure Immersive Reader API. The configuration `imm_reader_client_secret` should not be checked into github, so I ran `./bin/update_secrets` to upload the secrets directly to AWS Secrets Manager.

## Links
- [jira](https://codedotorg.atlassian.net/browse/FND-1257)
- [updating secrets doc](https://github.com/code-dot-org/code-dot-org/blob/staging/config/secrets.md#creatingupdating-a-secret)

## Testing story
* Ran dashboard to confirm it still works.
* Went into AWS Secrets Manager and confirmed the `imm_reader_client_secret` secrets were uploaded for each stage.

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
