### PR TITLE
Simplify and skip UI test step for viewing survey results

### DIFF
--- a/dashboard/test/ui/features/plc/pd/daily_survey_results.feature
+++ b/dashboard/test/ui/features/plc/pd/daily_survey_results.feature
@@ -1,5 +1,6 @@
 @dashboard_db_access
 @eyes
+@skip
 
 Feature: Basic appearance for Daily Survey UI
 

--- a/dashboard/test/ui/features/step_definitions/pd.rb
+++ b/dashboard/test/ui/features/step_definitions/pd.rb
@@ -184,13 +184,12 @@ end
 And(/^I am viewing a workshop with fake survey results$/) do
   require_rails_env
 
-  workshop = FactoryGirl.create :summer_workshop, :ended,
-    organizer: FactoryGirl.create(:workshop_organizer, email: "test_organizer#{SecureRandom.hex}@code.org"),
-    num_sessions: 5, enrolled_and_attending_users: 10,
-    facilitators: [
-      (FactoryGirl.create :facilitator, email: "test_facilitator#{SecureRandom.hex}@code.org", name: 'F1'),
-      (FactoryGirl.create :facilitator, email: "test_facilitator#{SecureRandom.hex}@code.org", name: 'F2')
-    ]
+  workshop = FactoryGirl.create :summer_workshop,
+    :ended,
+    num_sessions: 5,
+    enrolled_and_attending_users: 10,
+    num_facilitators: 2
+
   create_fake_survey_questions workshop
   create_fake_daily_survey_results workshop
 


### PR DESCRIPTION
Made some simplifications to this flaky test -- however, ended up just skipping it as it covers legacy behavior that we'll be deprecating in the near term.