### PR TITLE
Access most recently updated auth tokens instead of first created

### DIFF
--- a/dashboard/lib/user_multi_auth_helper.rb
+++ b/dashboard/lib/user_multi_auth_helper.rb
@@ -3,10 +3,12 @@ require 'cdo/honeybadger'
 module UserMultiAuthHelper
   def oauth_tokens_for_provider(provider)
     if migrated?
-      authentication_option = AuthenticationOption.find_by(
+      # Grab the most recently updated authentication option with the
+      # given credential type
+      authentication_option = AuthenticationOption.where(
         credential_type: provider,
         user_id: id
-      )
+      ).order(updated_at: :desc).first
       authentication_option_data = authentication_option&.data_hash || {}
       {
         oauth_token: authentication_option_data[:oauth_token],


### PR DESCRIPTION
Some users have multiple Clever accounts associated with their account, which causes errors when they try to pull their sections. Let's use the most recently updated auth option to try to make sure we grab the one they signed in as.

<!-- ### Background -->
<!-- ### Privacy -->
<!-- ### Security -->
<!-- ### Caching -->
<!-- ### Deployment strategy -->
<!-- ### Future work -->

## Links

<!--
  Any relevant links to external resources; ie, specification documents, jira
  items, related PRs, honeybadger errors, etc
-->

- [spec]()
- [jira]()

## Testing story

<!--
  Does your change include appropriate tests?

  If so, please describe how the tests included in this PR are sufficient

  If not, please explain why this change does not need to be tested.
-->

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
