### PR TITLE
Thank donors on first sign in (3rd attempt)

### DIFF
--- a/apps/Gruntfile.js
+++ b/apps/Gruntfile.js
@@ -516,6 +516,8 @@ describe('entry tests', () => {
       './src/sites/studio/pages/layouts/_small_footer.js',
     'layouts/_terms_interstitial':
       './src/sites/studio/pages/layouts/_terms_interstitial.js',
+    'layouts/_thank_donors_interstitial':
+      './src/sites/studio/pages/layouts/_thank_donors_interstitial.js',
     'levels/_bubble_choice':
       './src/sites/studio/pages/levels/_bubble_choice.js',
     'levels/_content': './src/sites/studio/pages/levels/_content.js',

--- a/apps/src/sites/studio/pages/layouts/_thank_donors_interstitial.js
+++ b/apps/src/sites/studio/pages/layouts/_thank_donors_interstitial.js
@@ -1,0 +1,23 @@
+import $ from 'jquery';
+import cookies from 'js-cookie';
+import firehoseClient from '@cdo/apps/lib/util/firehose';
+
+$(document).ready(function() {
+  var already_shown = !!cookies.get('has_seen_thank_donors');
+  if (!already_shown && window.innerWidth > 800 && window.innerHeight > 600) {
+    $('#thank-donors-modal').modal('show');
+    cookies.set('has_seen_thank_donors', '1');
+
+    firehoseClient.putRecord(
+      {
+        study: 'thank-donors-interstitial',
+        event: 'saw-thank-donors-interstitial'
+      },
+      {includeUserId: true}
+    );
+  }
+
+  $('#dismiss-thank-donors').click(function() {
+    $('#thank-donors-modal').modal('hide');
+  });
+});

--- a/dashboard/app/assets/stylesheets/interstitial.scss
+++ b/dashboard/app/assets/stylesheets/interstitial.scss
@@ -2,12 +2,14 @@
 @import 'font';
 
 #terms-modal,
+#thank-donors-modal,
 #school-info-modal,
 #race-modal {
   text-align: left;
   top: 20px;
 }
 #terms-modal .modal-content,
+#thank-donors-modal .modal-content,
 #school-info-modal .modal-content,
 #race-modal .modal-content {
   margin: 0 20px;
@@ -18,6 +20,10 @@
 #race-modal .modal-content p {
   font-size: 12px;
   color: $default_text;
+}
+#thank-donors-modal .modal-content p {
+  font-size: 13px;
+  color: $default_text;
   line-height: 18px;
 }
 #terms-modal .left,
@@ -25,7 +31,8 @@
 #race-modal .left {
   float: left;
 }
-#terms-modal .right {
+#terms-modal .right,
+#thank-donors-modal .right, {
   float: right;
 }
 #school-info-modal .right,
@@ -64,6 +71,7 @@
   margin: 0 5px 0 0;
 }
 #terms-modal .primary-button,
+#thank-donors-modal .primary-button,
 #school-info-modal .primary-button,
 #race-modal .primary-button {
   background-color: $orange;
@@ -115,4 +123,60 @@ $almost_white: #eee;
   #terms-modal .scroll-box {
     height: 200px;
   }
+}
+
+#thank-donors-modal {
+  width: 700px;
+  margin-left: 0;
+  left: 50%;
+  transform: translateX(-50%);
+}
+
+#thank-donors-modal .donor-container {
+  display: flex;
+  flex-wrap: wrap;
+  width: 642px;
+  height: 224px;
+  border-top: 1px solid $border_gray;
+  border-bottom: 1px solid $border_gray;
+  padding: 0;
+  overflow: hidden;
+}
+
+#thank-donors-modal .donor {
+  height: 40px;
+  width: 190px;
+  padding: 8px 12px;
+  text-align: center;
+  font-family: $gotham-bold;
+  font-size: 14px;
+  line-height: 40px;
+}
+
+#thank-donors-modal .donor-subheader {
+  text-align: center;
+  font-size: 20px;
+  color: $purple;
+  margin-top: 12px;
+  margin-bottom: 8px;
+}
+
+#thank-donors-modal .donor-header {
+  font-size: 24px;
+  color: $purple;
+  margin-bottom: 14px;
+}
+
+#thank-donors-modal .support-codeorg-container {
+  margin-top: 8px;
+  margin-bottom: 8px;
+}
+
+#dismiss-thank-donors {
+  margin-top: 0;
+  margin-bottom: 16px;
+}
+
+#close-thank-donors-dialog {
+  margin: 10px;
 }

--- a/dashboard/app/controllers/application_controller.rb
+++ b/dashboard/app/controllers/application_controller.rb
@@ -115,6 +115,14 @@ class ApplicationController < ActionController::Base
     :school_name_other
   ].freeze
 
+  # We create users via HTTP requests in UI tests.
+  # This list includes attributes we might want to
+  # set in accounts created/updated in tests, but do not
+  # want to be set via account creates/updates otherwise.
+  UI_TEST_ATTRIBUTES = [
+    :sign_in_count
+  ].freeze
+
   PERMITTED_USER_FIELDS = [
     :name,
     :username,
@@ -125,7 +133,8 @@ class ApplicationController < ActionController::Base
     :gender,
     :login,
     :remember_me,
-    :age, :school,
+    :age,
+    :school,
     :full_address,
     :user_type,
     :hashed_email,
@@ -137,7 +146,10 @@ class ApplicationController < ActionController::Base
     :parent_email_preference_opt_in,
     :parent_email_preference_email,
     school_info_attributes: SCHOOL_INFO_ATTRIBUTES,
-  ].freeze
+  ]
+
+  PERMITTED_USER_FIELDS.concat(UI_TEST_ATTRIBUTES) if rack_env?(:test, :development)
+  PERMITTED_USER_FIELDS.freeze
 
   def configure_permitted_parameters
     devise_parameter_sanitizer.permit(:account_update) {|u| u.permit PERMITTED_USER_FIELDS}

--- a/dashboard/app/helpers/gdpr_dialog_helper.rb
+++ b/dashboard/app/helpers/gdpr_dialog_helper.rb
@@ -1,0 +1,10 @@
+module GdprDialogHelper
+  def self.show?(user, request)
+    return false if user.data_transfer_agreement_accepted == true
+
+    return true if request.params['force_in_eu'].present?
+    return true if request.gdpr?
+
+    return false
+  end
+end

--- a/dashboard/app/helpers/race_interstitial_helper.rb
+++ b/dashboard/app/helpers/race_interstitial_helper.rb
@@ -5,7 +5,11 @@ module RaceInterstitialHelper
     return false if user.races
     return false if user.teacher?
     return false if user.under_13?
-    return false if user.days_since_first_sign_in && user.days_since_first_sign_in < 7
+
+    # Covers test cases if we don't have sign in records for a user
+    return false if user.days_since_first_sign_in.nil?
+    # Covers actual behavior we want in our application
+    return false if user.days_since_first_sign_in < 7
 
     # Restrict to cases where we can successfully geolocate to the US
     return false if user.current_sign_in_ip.nil?

--- a/dashboard/app/helpers/thank_donors_interstitial_helper.rb
+++ b/dashboard/app/helpers/thank_donors_interstitial_helper.rb
@@ -1,0 +1,14 @@
+module ThankDonorsInterstitialHelper
+  # Determine whether or not to show the thank donors interstitial popup to a user
+  # We only show the interstitial to signed in users on their first login,
+  # and also do not want to show it when it might conflict with other dialogs.
+  def self.show?(user, request)
+    return false if user.nil?
+    return false unless user.sign_in_count == 1
+    return false if user.age.nil? # Age dialog
+    return false if user && user.teacher? && !user.accepted_latest_terms? # Terms of Service dialog
+    return false if GdprDialogHelper.show?(user, request)
+
+    return true
+  end
+end

--- a/dashboard/app/views/home/index.html.haml
+++ b/dashboard/app/views/home/index.html.haml
@@ -19,6 +19,9 @@
 - elsif SchoolInfoInterstitialHelper.show?(current_user) || @force_school_info_interstitial
   = render partial: 'layouts/school_info_interstitial', locals: {show_header: false, user: current_user, form_name: "user[school_info_attributes]"}
 
+- if ThankDonorsInterstitialHelper.show?(current_user, request)
+  = render partial: 'layouts/thank_donors_interstitial'
+
 - if current_user
   = render partial: 'home/homepage'
 

--- a/dashboard/app/views/layouts/_thank_donors_interstitial.html.haml
+++ b/dashboard/app/views/layouts/_thank_donors_interstitial.html.haml
@@ -1,0 +1,24 @@
+-# Note this partial assumes the presence of a signed in user.
+#thank-donors-modal.modal{style: 'display: none;'}
+  %button#close-thank-donors-dialog.close{'data-dismiss' => 'modal', 'aria-label' => 'Close'}
+    %span{'aria-hidden' => 'true'}= '&times;'.html_safe
+  .modal-dialog
+    .modal-content.no-modal-icon
+      %h2.donor-header= t('donor_interstitial.title')
+      %p= t('donor_interstitial.subtitle', donors_url: CDO.code_org_url('/about/donors'), markdown: :inline).html_safe
+      %h2.donor-subheader= t('donor_interstitial.global_supporters')
+      .clear
+      .scroll-box
+        .donor-container
+          - Donor.where(level: %w(platinum diamond)).order(:weight).pluck(:name).each do |donor|
+            .donor= donor
+      - if current_user.student?
+        %p.support-codeorg-container
+          = t('donor_interstitial.support_codeorg_1')
+          %br
+          = t('donor_interstitial.support_codeorg_2', donate_url: CDO.code_org_url('/donate'), markdown: :inline).html_safe
+      .right
+        = button_tag t('donor_interstitial.get_started'), id: 'dismiss-thank-donors', type: 'button', class: 'btn primary-button'
+      .clear
+
+%script{src: webpack_asset_path('js/layouts/_thank_donors_interstitial.js')}

--- a/dashboard/app/views/layouts/application.html.haml
+++ b/dashboard/app/views/layouts/application.html.haml
@@ -49,9 +49,7 @@
 
     - gdpr_data = {}
     - if current_user
-      - already_accepted = current_user.data_transfer_agreement_accepted == true
-      - force_eu = request.params['force_in_eu'].present?
-      - gdpr_data[:show_gdpr_dialog] = (request.gdpr? || force_eu) && !already_accepted
+      - gdpr_data[:show_gdpr_dialog] = GdprDialogHelper.show?(current_user, request)
       - gdpr_data[:current_user_id] = current_user.id
 
     #gdpr-dialog

--- a/dashboard/config/locales/en.yml
+++ b/dashboard/config/locales/en.yml
@@ -809,6 +809,14 @@ en:
     reminder_desc: 'We have updated our <a href="%{tos_url}" target="_blank">Terms of Service</a> and <a href="%{privacy_url}" target="_blank">Privacy Policy</a>. Please read these carefully before accepting them. Note that our tools teaching JavaScript may be unavailable to your students before explicitly accepting the updated terms.'
     reminder_desc_markdown: We have updated our [Terms of Service](%{tos_url}) and [Privacy Policy](%{privacy_url}). Please read these carefully before accepting them. Note that our tools teaching JavaScript may be unavailable to your students before explicitly accepting the updated terms.
     review_terms: "Review updated terms"
+  donor_interstitial:
+    title: "Your free CS courses are made possible by..."
+    subtitle: "We’d like to thank the generous donors whose support has made Code.org’s success possible. We are committed to keeping Code.org free for schools and students, globally, thanks to the continued generosity of our [donors](%{donors_url})!"
+    local_supporters: "Local Supporters"
+    global_supporters: "Global Supporters"
+    support_codeorg_1: "Every dollar given to Code.org brings opportunity to more students."
+    support_codeorg_2: "[Donate now](%{donate_url}) to support Code.org."
+    get_started: "Get started on Code.org"
   school_info_interstitial:
     title: "We want to bring Computer Science to every student - help us track our progress!"
     message: "Please enter your school information below."

--- a/dashboard/test/controllers/home_controller_test.rb
+++ b/dashboard/test/controllers/home_controller_test.rb
@@ -280,6 +280,63 @@ class HomeControllerTest < ActionController::TestCase
     assert_select '#age-modal', false
   end
 
+  test 'anonymous does not get thank donors dialog' do
+    assert_nil current_user
+
+    get :home
+
+    assert_select '#thank-donors-modal', false
+  end
+
+  test 'student on first login gets thank donors dialog' do
+    # Devise does not run callbacks (eg, increment sign in count)
+    # when using sign_in according to this 2014 discussion:
+    # https://github.com/heartcombo/devise/issues/2905
+    student = create(:user, sign_in_count: 1)
+
+    sign_in student
+    get :home
+
+    assert_select '#thank-donors-modal', true
+  end
+
+  test 'teacher on first login gets thank donors dialog' do
+    teacher = create(
+      :teacher,
+      :with_terms_of_service,
+      sign_in_count: 1
+    )
+
+    sign_in teacher
+    get :home
+
+    assert_select '#thank-donors-modal', true
+  end
+
+  test 'student on second login does not get thank donors dialog' do
+    # Devise does not run callbacks (eg, increment sign in count)
+    # when using sign_in.
+    student = create(:user, sign_in_count: 2)
+
+    sign_in student
+    get :home
+
+    assert_select '#thank-donors-modal', false
+  end
+
+  test 'teacher on second login does not get thank donors dialog' do
+    teacher = create(
+      :teacher,
+      :with_terms_of_service,
+      sign_in_count: 2
+    )
+
+    sign_in teacher
+    get :home
+
+    assert_select '#thank-donors-modal', false
+  end
+
   # This exception is actually annoying to handle because it never gets to
   # ActionController (so we can't use the rescue in ApplicationController).
   # test "bad http methods are rejected" do

--- a/dashboard/test/helpers/gdpr_dialog_helper_test.rb
+++ b/dashboard/test/helpers/gdpr_dialog_helper_test.rb
@@ -1,0 +1,37 @@
+require 'test_helper'
+
+class GdprDialogHelperTest < ActionView::TestCase
+  setup do
+    @user = build :user
+
+    @request = ActionDispatch::Request.new({})
+    @request.stubs(:gdpr?).returns(false)
+    @request.stubs(:params).returns({})
+  end
+
+  test 'do not show GDPR dialog if no conditions met' do
+    refute GdprDialogHelper.show?(@user, @request)
+  end
+
+  test 'do not show GDPR dialog if user has accepted data transfer agreement' do
+    accepted_user = build :user, data_transfer_agreement_accepted: true
+
+    refute GdprDialogHelper.show?(accepted_user, @request)
+  end
+
+  test 'show GDPR dialog if force show in params' do
+    force_eu_request = ActionDispatch::Request.new({})
+    force_eu_request.stubs(:gdpr?).returns(false)
+    force_eu_request.stubs(:params).returns({'force_in_eu' => 'true'})
+
+    assert GdprDialogHelper.show?(@user, force_eu_request)
+  end
+
+  test 'show GDPR dialog if in GDPR country' do
+    eu_request = ActionDispatch::Request.new({})
+    eu_request.stubs(:params).returns({})
+    eu_request.stubs(:gdpr?).returns(true)
+
+    assert GdprDialogHelper.show?(@user, eu_request)
+  end
+end

--- a/dashboard/test/helpers/race_interstitial_helper_test.rb
+++ b/dashboard/test/helpers/race_interstitial_helper_test.rb
@@ -32,6 +32,15 @@ class RaceInterstitialHelperTest < ActionView::TestCase
     refute RaceInterstitialHelper.show?(@user)
   end
 
+  test 'do not show race interstitial to user if we do not have sign in information' do
+    SignIn.find_by(
+      user_id: @user.id,
+      sign_in_count: 1
+    ).delete
+
+    refute RaceInterstitialHelper.show?(@user)
+  end
+
   test 'do not show race interstitial to user accounts who signed in for the first time less than a week ago' do
     sign_in = SignIn.find_by(
       user_id: @user.id,

--- a/dashboard/test/helpers/thank_donors_interstitial_helper_test.rb
+++ b/dashboard/test/helpers/thank_donors_interstitial_helper_test.rb
@@ -1,0 +1,50 @@
+require 'test_helper'
+
+class ThankDonorsInterstitialHelperTest < ActionView::TestCase
+  setup do
+    @request = ActionDispatch::Request.new({})
+    @request.stubs(:gdpr?).returns(false)
+    @request.stubs(:params).returns({})
+  end
+
+  test 'do not show thank donors interstitial if user is not signed in' do
+    refute ThankDonorsInterstitialHelper.show?(nil, @request)
+  end
+
+  test 'do not show thank donors interstitial to student who has signed in multiple times' do
+    student = build :user, sign_in_count: 2
+
+    refute ThankDonorsInterstitialHelper.show?(student, @request)
+  end
+
+  test 'do not show thank donors interstitial to student with no age information' do
+    student = build :user, birthday: nil
+
+    refute ThankDonorsInterstitialHelper.show?(student, @request)
+  end
+
+  test 'do not show thank donors interstitial to teacher who has not accepted terms of service' do
+    teacher = build :teacher, terms_of_service_version: nil
+
+    refute ThankDonorsInterstitialHelper.show?(teacher, @request)
+  end
+
+  test 'do not show thank donors interstitial to a student who has not accepted GDPR terms' do
+    @request.stubs(:gdpr?).returns(true)
+
+    student = build :user, sign_in_count: 1
+    refute ThankDonorsInterstitialHelper.show?(student, @request)
+  end
+
+  test 'show thank donors interstitial to users on first login' do
+    student = build :user, sign_in_count: 1
+
+    assert ThankDonorsInterstitialHelper.show?(student, @request)
+  end
+
+  test 'show thank donors interstitial to teacher on first login' do
+    teacher = build :teacher, sign_in_count: 1, terms_of_service_version: 1
+
+    assert ThankDonorsInterstitialHelper.show?(teacher, @request)
+  end
+end

--- a/dashboard/test/ui/features/step_definitions/steps.rb
+++ b/dashboard/test/ui/features/step_definitions/steps.rb
@@ -1272,7 +1272,8 @@ def create_user(name, url: '/users.json', code: 201, **user_opts)
           password_confirmation: password,
           name: name,
           age: '16',
-          terms_of_service_version: '1'
+          terms_of_service_version: '1',
+          sign_in_count: 2
         }.merge(user_opts)
       },
       code: code
@@ -1280,9 +1281,11 @@ def create_user(name, url: '/users.json', code: 201, **user_opts)
   end
 end
 
-And(/^I create a (young )?student named "([^"]*)"( and go home)?$/) do |young, name, home|
+And(/^I create a (young )?student( who has never signed in)? named "([^"]*)"( and go home)?$/) do |young, new_account, name, home|
   age = young ? '10' : '16'
-  create_user(name, age: age)
+  sign_in_count = new_account ? 0 : 2
+
+  create_user(name, age: age, sign_in_count: sign_in_count)
   navigate_to replace_hostname('http://studio.code.org') if home
 end
 
@@ -1293,8 +1296,10 @@ And(/^I create a student in the eu named "([^"]*)"$/) do |name|
   )
 end
 
-And(/^I create a teacher named "([^"]*)"( and go home)?$/) do |name, home|
-  create_user(name, age: '21+', user_type: 'teacher', email_preference_opt_in: 'yes')
+And(/^I create a teacher( who has never signed in)? named "([^"]*)"( and go home)?$/) do |new_account, name, home|
+  sign_in_count = new_account ? 0 : 2
+
+  create_user(name, age: '21+', user_type: 'teacher', email_preference_opt_in: 'yes', sign_in_count: sign_in_count)
   navigate_to replace_hostname('http://studio.code.org') if home
 end
 
@@ -1373,6 +1378,12 @@ end
 
 When(/^I am not signed in/) do
   steps 'element ".header_user:contains(Sign in)" is visible'
+end
+
+And(/^I delete the cookie named "([^"]*)"$/) do |cookie_name|
+  if @browser.manage.all_cookies.any? {|cookie| cookie[:name] == cookie_name}
+    @browser.manage.delete_cookie cookie_name
+  end
 end
 
 When(/^I debug cookies$/) do

--- a/dashboard/test/ui/features/xteam/thank_donors_interstitial.feature
+++ b/dashboard/test/ui/features/xteam/thank_donors_interstitial.feature
@@ -1,0 +1,36 @@
+Feature: Thank Donors Interstitial
+
+  @no_phone
+  Scenario: New student sign in from code.org
+    Given I delete the cookie named "has_seen_thank_donors"
+    Then I create a student who has never signed in named "Beth" and go home
+    Then I wait to see "#thank-donors-modal"
+    And I click "#dismiss-thank-donors"
+    And I wait until element "#thank-donors-modal" is not visible
+
+  @no_phone
+  Scenario: New teacher sign in from code.org
+    Given I delete the cookie named "has_seen_thank_donors"
+    Then I create a teacher who has never signed in named "Alice" and go home
+    Then I wait to see "#thank-donors-modal"
+    And I click "#dismiss-thank-donors"
+    And I wait until element "#thank-donors-modal" is not visible
+
+  @only_phone
+  Scenario: New student sign in from code.org does not show donor interstitial on mobile
+    Given I delete the cookie named "has_seen_thank_donors"
+    Then I create a student who has never signed in named "Bob" and go home
+    Then element "#thank-donors-modal" is not visible
+
+  @eyes
+  Scenario: Thank Donors Interstitial
+    Given I delete the cookie named "has_seen_thank_donors"
+    Then I create a student who has never signed in named "Beth" and go home
+    When I open my eyes to test "Thank Donors Interstitial Shown And Dismissed"
+    Then I wait to see "#thank-donors-modal"
+    And I see no difference for "thank donors interstitial"
+
+    When I click "#dismiss-thank-donors"
+    Then I wait until element "#thank-donors-modal" is not visible
+    And I see no difference for "thank donors interstitial closed"
+    And I close my eyes

--- a/dashboard/test/ui/runner.rb
+++ b/dashboard/test/ui/runner.rb
@@ -645,6 +645,8 @@ def cucumber_arguments_for_browser(browser, options)
 
   arguments += skip_tag('@no_mobile') if browser['mobile']
   arguments += skip_tag('@only_mobile') unless browser['mobile']
+  arguments += skip_tag('@no_phone') if browser['name'] == 'iPhone'
+  arguments += skip_tag('@only_phone') unless browser['name'] == 'iPhone'
   arguments += skip_tag('@no_circle') if options.is_circle
   arguments += skip_tag('@no_ie') if browser['browserName'] == 'Internet Explorer'
 


### PR DESCRIPTION
This PR -> code-dot-org/code-dot-org#36276 (revert) -> https://github.com/code-dot-org/code-dot-org/pull/36195 (new code) -> https://github.com/code-dot-org/code-dot-org/pull/36169 (revert) -> https://github.com/code-dot-org/code-dot-org/pull/35914 (original PR)

In https://github.com/code-dot-org/code-dot-org/pull/35914, I set the normal test user being created in all other tests to have a sign_in_count of 2, to avoid them seeing the donor interstitial (it shows only on your first login).

When a user signs in for the first time after account creation in tests, their sign_in_count gets now incremented to 3, and a row in the sign_ins table is created with sign_in_count of 3, instead of 1 like it was previously.

Without a row for the first sign in, the logic that gates showing the race interstitial fails to prevent showing it. 

The fix in this PR is to make the logic gating showing the race interstitial “don’t show race interstitial if you can’t find a user’s first sign in”.

## Testing story

Added new unit test to cover the behavior that caused UI tests to fail before this PR was reverted (showing of race interstitial in places where it shouldn't have appeared). Added the test -> saw it fail -> made code changes -> saw it pass.