### PR TITLE
Fixing container for workshop links on /home

### DIFF
--- a/dashboard/app/views/home/_homepage.html.haml
+++ b/dashboard/app/views/home/_homepage.html.haml
@@ -25,7 +25,7 @@
 
 #homepage-container
 
-#workshop-links
+#workshop-links.container.main
   -if can? :read, Pd::Application::ApplicationBase
     %h1
       Application Dashboard


### PR DESCRIPTION
**Bug** - The workshop links on the `/home` page had no margin on the left side.
**Cause** - A change was made recently to the container on the `/home` page which removed the left margin. Other content on the page had the margins adjusted but the workshop links were missed because testing was not done with a user who has workshop permissions.
**Fix** - Apply the same container CSS styles which the rest of the page are using to the workshop links container.

## Screenshots
### Before
![image](https://user-images.githubusercontent.com/1372238/90198002-ee04b780-ddbf-11ea-82dd-1cb0dfc8eef3.png)

### After
![image](https://user-images.githubusercontent.com/1372238/90197981-e04f3200-ddbf-11ea-8c15-48be87998252.png)

## Testing story
* Ran on localhost

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
