### PR TITLE
Shorten label for email suppression

### DIFF
--- a/apps/src/code-studio/pd/workshop_dashboard/components/workshop_form.jsx
+++ b/apps/src/code-studio/pd/workshop_dashboard/components/workshop_form.jsx
@@ -479,7 +479,7 @@ export class WorkshopForm extends React.Component {
           <Col sm={5}>
             <FormGroup validationState={validation.style.suppress_email}>
               <ControlLabel>
-                Enable workshop reminder notifications?
+                Enable workshop reminders?
                 <HelpTip>
                   <p>
                     <strong>


### PR DESCRIPTION
Shorten label for email suppression option to fit on one line on 1024px wide screens.

## Testing story

Tested manually by resizing my browser to 1024px wide.