### PR TITLE
Bubble Choice Level Redirects

### DIFF
--- a/apps/src/code-studio/components/BubbleChoice.jsx
+++ b/apps/src/code-studio/components/BubbleChoice.jsx
@@ -34,7 +34,7 @@ export default class BubbleChoice extends React.Component {
       display_name: PropTypes.string.isRequired,
       description: PropTypes.string.isRequired,
       previous_level_url: PropTypes.string,
-      next_level_url: PropTypes.string,
+      redirect_url: PropTypes.string,
       script_url: PropTypes.string,
       sublevels: PropTypes.arrayOf(
         PropTypes.shape({
@@ -58,7 +58,7 @@ export default class BubbleChoice extends React.Component {
   renderButtons = () => {
     const {level} = this.props;
     const backButtonUrl = level.previous_level_url || level.script_url;
-    const continueButtonUrl = level.next_level_url || level.script_url;
+    const finishButtonUrl = level.redirect_url || level.script_url;
 
     return (
       <div>
@@ -71,13 +71,13 @@ export default class BubbleChoice extends React.Component {
             {i18n.back()}
           </button>
         )}
-        {continueButtonUrl && (
+        {finishButtonUrl && (
           <button
             type="button"
-            onClick={() => this.goToUrl(continueButtonUrl)}
+            onClick={() => this.goToUrl(finishButtonUrl)}
             style={{...styles.btn, ...styles.btnOrange}}
           >
-            {level.next_level_url ? i18n.continue() : i18n.finish()}
+            {i18n.finish()}
           </button>
         )}
       </div>

--- a/apps/test/unit/code-studio/components/BubbleChoiceTest.js
+++ b/apps/test/unit/code-studio/components/BubbleChoiceTest.js
@@ -34,7 +34,7 @@ const DEFAULT_PROPS = {
     description: 'Choose one or more levels!',
     sublevels: fakeSublevels,
     previous_level_url: '/s/script/stage/1/puzzle/1',
-    next_level_url: '/s/script/stage/1/puzzle/3',
+    redirect_url: '/s/script/stage/1/puzzle/3',
     script_url: '/s/script',
     name: 'Bubble Choice',
     type: 'BubbleChoice',
@@ -48,7 +48,7 @@ describe('BubbleChoice', () => {
     assert.equal(2, wrapper.find('SublevelCard').length);
   });
 
-  describe('back and continue buttons', () => {
+  describe('back and finish buttons', () => {
     beforeEach(() => {
       sinon.stub(utils, 'navigateToHref');
     });
@@ -69,19 +69,19 @@ describe('BubbleChoice', () => {
         DEFAULT_PROPS.level.previous_level_url + window.location.search
       );
 
-      const continueButton = wrapper.find('button').at(1);
-      assert.equal('Continue', continueButton.text());
-      continueButton.simulate('click');
+      const finishButton = wrapper.find('button').at(1);
+      assert.equal('Finish', finishButton.text());
+      finishButton.simulate('click');
       expect(utils.navigateToHref).to.have.been.calledWith(
-        DEFAULT_PROPS.level.next_level_url + window.location.search
+        DEFAULT_PROPS.level.redirect_url + window.location.search
       );
     });
 
-    it('redirect to script page if no previous/next levels', () => {
+    it('redirect to script page if no previous_level/redirect urls', () => {
       const level = {
         ...DEFAULT_PROPS.level,
         previous_level_url: null,
-        next_level_url: null
+        redirect_url: null
       };
       const wrapper = mount(<BubbleChoice {...DEFAULT_PROPS} level={level} />);
 
@@ -116,18 +116,18 @@ describe('BubbleChoice', () => {
       assert.notEqual('Back', buttons.at(1).text());
     });
 
-    it('hides continue button if no next level or script url', () => {
+    it('hides finish button if no redirect or script url', () => {
       const level = {
         ...DEFAULT_PROPS.level,
-        next_level_url: null,
+        redirect_url: null,
         script_url: null
       };
       const wrapper = mount(<BubbleChoice {...DEFAULT_PROPS} level={level} />);
       const buttons = wrapper.find('button');
 
       assert.equal(2, buttons.length);
-      assert(!['Finish', 'Continue'].includes(buttons.at(0).text()));
-      assert(!['Finish', 'Continue'].includes(buttons.at(1).text()));
+      assert.notEqual('Finish', buttons.at(0).text());
+      assert.notEqual('Finish', buttons.at(1).text());
     });
   });
 });

--- a/dashboard/app/controllers/script_levels_controller.rb
+++ b/dashboard/app/controllers/script_levels_controller.rb
@@ -80,6 +80,10 @@ class ScriptLevelsController < ApplicationController
     authorize! :read, ScriptLevel
     @script = ScriptLevelsController.get_script(request)
 
+    # @view_as_user is used to determine redirect path for bubble choice levels
+    view_as_other = params[:user_id] && params[:user_id] != current_user.id
+    @view_as_user = view_as_other ? User.find(params[:user_id]) : current_user
+
     # Redirect to the same script level within @script.redirect_to.
     # There are too many variations of the script level path to use
     # a path helper, so use a regex to compute the new path.

--- a/dashboard/app/models/levels/bubble_choice.rb
+++ b/dashboard/app/models/levels/bubble_choice.rb
@@ -74,7 +74,8 @@ class BubbleChoice < DSLDefined
   # @param [Integer] user_id. Optional. If provided, the "perfect" field will be calculated
   # in the sublevel summary.
   # @return [Hash]
-  def summarize(script_level: nil, user_id: nil)
+  def summarize(script_level: nil, user: nil)
+    user_id = user ? user.id : nil
     summary = {
       display_name: display_name,
       description: description,
@@ -86,12 +87,12 @@ class BubbleChoice < DSLDefined
 
     if script_level
       previous_level_url = script_level.previous_level ? build_script_level_url(script_level.previous_level) : nil
-      next_level_url = script_level.next_level ? build_script_level_url(script_level.next_level) : nil
+      redirect_url = script_level.next_level_or_redirect_path_for_user(user, nil, true)
 
       summary.merge!(
         {
           previous_level_url: previous_level_url,
-          next_level_url: next_level_url,
+          redirect_url: redirect_url,
           script_url: script_url(script_level.script)
         }
       )

--- a/dashboard/app/models/script_level.rb
+++ b/dashboard/app/models/script_level.rb
@@ -157,9 +157,13 @@ class ScriptLevel < ActiveRecord::Base
     !has_another_level_to_go_to?
   end
 
-  def next_level_or_redirect_path_for_user(user, extras_lesson=nil)
-    if bubble_choice?
-      # Redirect user back to the BubbleChoice activity page.
+  def next_level_or_redirect_path_for_user(
+    user,
+    extras_lesson=nil,
+    bubble_choice_parent=false
+  )
+    if bubble_choice? && !bubble_choice_parent
+      # Redirect user back to the BubbleChoice activity page from sublevels.
       level_to_follow = self
     elsif valid_progression_level?(user)
       # if we're coming from an unplugged level, it's ok to continue to unplugged

--- a/dashboard/app/views/levels/_bubble_choice.html.haml
+++ b/dashboard/app/views/levels/_bubble_choice.html.haml
@@ -8,6 +8,6 @@
 
 - data = {}
 - user_id = request.params["user_id"] || current_user&.id
-- data[:level] = @level.summarize(script_level: @script_level, user_id: user_id)
+- data[:level] = @level.summarize(script_level: @script_level, user: @view_as_user)
 
 %script{src: webpack_asset_path('js/levels/_bubble_choice.js'), data: {bubblechoice: data.to_json}}

--- a/dashboard/test/models/levels/bubble_choice_test.rb
+++ b/dashboard/test/models/levels/bubble_choice_test.rb
@@ -110,15 +110,14 @@ DSL
     summary = @bubble_choice.summarize(script_level: @script_level)
 
     assert_nil summary[:previous_level_url]
-    assert_nil summary[:next_level_url]
+    refute_nil summary[:redirect_url]
     refute_nil summary[:script_url]
 
     @script_level.stubs(:previous_level).returns(create(:script_level))
-    @script_level.stubs(:next_level).returns(create(:script_level))
     summary = @bubble_choice.summarize(script_level: @script_level)
 
     refute_nil summary[:previous_level_url]
-    refute_nil summary[:next_level_url]
+    refute_nil summary[:redirect_url]
     refute_nil summary[:script_url]
   end
 


### PR DESCRIPTION
This PR addresses two issues that occur when a bubble choice level is the last level in a lesson:

1) If last lesson in unit, the finish button would redirect back to the lesson overview instead of to the congrats page
2) The finish button would redirect to the first level of the next lesson, even if that lesson is hidden

The finish button in studio levels does not exhibit these problems, so the solution was to use the same method for determining the redirect path used by those levels in bubble choice levels.

Tracing the flow of code use to determine the redirect path for studio levels turned out to be quite a task, so I additionally documented that flow as part of this PR.

Also, the button used to complete a studio level always says "Finish" regardless of where the user will be redirected to, so for consistency I updated the BubbleChoice component to do likewise, instead of conditionally showing "Continue" vs. "Finish" depending on whether the level is the last in the lesson.

<!--
  Other aspects to consider. uncomment and add detail for any that seem necessary:
-->

<!-- ### Background -->
<!-- ### Privacy -->
<!-- ### Security -->
<!-- ### Caching -->
<!-- ### Deployment strategy -->
<!-- ### Future work -->

## Links

<!--
  Any relevant links to external resources; ie, specification documents, jira
  items, related PRs, honeybadger errors, etc
-->

- jira: [LP-1497], [LP-1518]

## Testing story

The tests for the BubbleChoice component use mock data, so while I updated those, testing to make sure the finish button properly redirects to the congrats page and ignores hidden lessons would require setting up quite a bit of scaffolding, so if we think that's important I will probably need some help with that.

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked


[LP-1497]: https://codedotorg.atlassian.net/browse/LP-1497
[LP-1518]: https://codedotorg.atlassian.net/browse/LP-1518