### PR TITLE
Adding the ImmersiveReader button in level instructions

### DIFF
--- a/apps/package.json
+++ b/apps/package.json
@@ -218,6 +218,7 @@
   },
   "dependencies": {
     "@code-dot-org/js-interpreter": "1.3.13",
+    "@microsoft/immersive-reader-sdk": "^1.1.0",
     "crypto-js": "^3.1.9-1",
     "details-element-polyfill": "https://github.com/javan/details-element-polyfill",
     "filesaver.js": "0.2.0",

--- a/apps/src/templates/instructions/ImmersiveReaderButton.jsx
+++ b/apps/src/templates/instructions/ImmersiveReaderButton.jsx
@@ -1,0 +1,40 @@
+import React, {Component} from 'react';
+import PropTypes from 'prop-types';
+import handleLaunchImmersiveReader from '@cdo/apps/util/immersive_reader';
+import {renderButtons} from '@microsoft/immersive-reader-sdk';
+import cookies from 'js-cookie';
+import experiments from '@cdo/apps/util/experiments';
+
+class ImmersiveReaderButton extends Component {
+  static propTypes = {
+    title: PropTypes.string,
+    text: PropTypes.string
+  };
+
+  componentDidMount() {
+    // Applies inline styling to the .immersive-reader-button elements
+    renderButtons();
+  }
+
+  render() {
+    const {title, text} = this.props;
+    // Get the current language from the language cookie.
+    const locale = cookies.get('language_') || 'en-US';
+
+    // Hide the button if the experiment is not enabled.
+    const enabled = experiments.isEnabled(experiments.IMMERSIVE_READER);
+    return (
+      <div
+        style={enabled ? {} : {display: 'none'}}
+        className={'immersive-reader-button'}
+        data-button-style={'icon'}
+        data-locale={locale}
+        onClick={function() {
+          handleLaunchImmersiveReader(locale, title, text);
+        }}
+      />
+    );
+  }
+}
+
+export default ImmersiveReaderButton;

--- a/apps/src/templates/instructions/Instructions.jsx
+++ b/apps/src/templates/instructions/Instructions.jsx
@@ -4,6 +4,8 @@ import MarkdownInstructions from './MarkdownInstructions';
 import NonMarkdownInstructions from './NonMarkdownInstructions';
 import InputOutputTable from './InputOutputTable';
 import AniGifPreview from './AniGifPreview';
+import ImmersiveReaderButton from './ImmersiveReaderButton';
+import i18n from '@cdo/locale';
 
 const styles = {
   inTopPane: {
@@ -73,6 +75,10 @@ class Instructions extends React.Component {
       <div
         style={this.props.inTopPane ? styles.inTopPane : styles.notInTopPane}
       >
+        <ImmersiveReaderButton
+          title={this.props.puzzleTitle || i18n.instructions()}
+          text={this.props.longInstructions || this.props.shortInstructions}
+        />
         {this.renderMainBody()}
 
         {this.props.inputOutputTable && (

--- a/apps/src/util/experiments.js
+++ b/apps/src/util/experiments.js
@@ -29,7 +29,7 @@ experiments.TEACHER_DASHBOARD_SECTION_BUTTONS_ALTERNATE_TEXT =
   'teacher-dashboard-section-buttons-alternate-text';
 experiments.TEXT_TO_SPEECH_BLOCK = 'text-to-speech-block';
 experiments.FINISH_DIALOG_METRICS = 'finish-dialog-metrics';
-
+experiments.IMMERSIVE_READER = 'immersive-reader';
 /**
  * Get our query string. Provided as a method so that tests can mock this.
  */

--- a/apps/src/util/immersive_reader.js
+++ b/apps/src/util/immersive_reader.js
@@ -1,0 +1,61 @@
+import {launchAsync} from '@microsoft/immersive-reader-sdk';
+
+/**
+ * Generates a temporary authentication token which can be used to call the Immersive Reader API.
+ * @returns {Promise<unknown>} { token: <auth_token>, subdomain: <azure_subdomain> }
+ */
+function getTokenAndSubdomainAsync() {
+  return new Promise(function(resolve, reject) {
+    $.ajax({
+      url: '/api/immersive_reader_token',
+      type: 'GET',
+      success: function(data) {
+        if (data.error) {
+          reject(data.error);
+        } else {
+          resolve(data);
+        }
+      }
+    });
+  });
+}
+
+/**
+ * Click handler for the Immersive Reader Button which will take the given text and launch the Microsoft Immersive
+ * Reader interface. This interface gives student's many tools to control how the text is presented them.
+ * @param locale The locale of the text e.g. 'en-US', 'ar-SA', etc.
+ * @param title The optional title to show above the given text in the Immersive Reader.
+ * @param text The text the user the wants to read more easily.
+ */
+export default function handleLaunchImmersiveReader(locale, title, text) {
+  getTokenAndSubdomainAsync()
+    .then(function(response) {
+      const token = response.token;
+      const subdomain = response.subdomain;
+      const data = {
+        title: title,
+        chunks: [
+          {
+            content: sanitizeText(text),
+            lang: locale
+          }
+        ]
+      };
+      launchAsync(token, subdomain, data, {});
+    })
+    .catch(function(error) {
+      console.error(error);
+    });
+}
+
+function sanitizeText(text) {
+  if (!text) {
+    return text;
+  }
+  // Strip XML
+  text = text.replace(/<[^>]*>/g, '');
+
+  // Strip markdown characters
+  text = text.replace(/[`*]/g, '');
+  return text;
+}

--- a/apps/yarn.lock
+++ b/apps/yarn.lock
@@ -1789,6 +1789,11 @@
   dependencies:
     unist-util-visit "^1.3.0"
 
+"@microsoft/immersive-reader-sdk@^1.1.0":
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/@microsoft/immersive-reader-sdk/-/immersive-reader-sdk-1.1.0.tgz#8e8dc0789f552d3fedea22716c5b4843bf95a708"
+  integrity sha512-ULNUKUzb2WzcXv3Ot8yK8LX28C23uCifOYIlAQHE7QKCIPzIMq3ncaO8ymuO59njd7imFjU0DluizLuDzh2B0g==
+
 "@mrmlnc/readdir-enhanced@^2.2.1":
   version "2.2.1"
   resolved "https://registry.yarnpkg.com/@mrmlnc/readdir-enhanced/-/readdir-enhanced-2.2.1.tgz#524af240d1a360527b730475ecfa1344aa540dde"

--- a/dashboard/app/assets/stylesheets/application.scss
+++ b/dashboard/app/assets/stylesheets/application.scss
@@ -3528,3 +3528,30 @@ h2.danger {
     display: none;
   }
 }
+
+.immersive-reader-button {
+  /* !important is used to override the default styling from the Microsoft immersive-reader-sdk */
+  background-color: $lightest_purple !important;
+  float: right;
+  margin-top: 1px !important;
+  height: 16px !important;
+  padding: 8px !important;
+  border-radius: 4px !important;
+
+  html[dir=rtl] & {
+    float: left;
+  }
+
+  &:hover {
+    background-color: $cyan !important;
+    border-radius: 4px !important;
+
+    /* The TTS buttons overlap this button, so make this button's z-index higher as a temp fix */
+    position: relative;
+    z-index: 1000;
+  }
+
+  img {
+    filter: grayscale(1);
+  }
+}

--- a/dashboard/app/controllers/api_controller.rb
+++ b/dashboard/app/controllers/api_controller.rb
@@ -16,6 +16,65 @@ class ApiController < ApplicationController
     end
   end
 
+  # Calls Azure Cognitive Services in order to get a temporary OAuth token with access to the Immersive Reader API.
+  # Requires the following configurations
+  #   CDO.imm_reader_tenant_id
+  #   CDO.imm_reader_client_id
+  #   CDO.imm_reader_subdomain
+  #   CDO.imm_reader_client_secret
+  # @return [Hash] {token: 'string', subdomain: 'string'}
+  # @return [Hash] {error: 'string'}
+  def immersive_reader_token
+    tenant_id = CDO.imm_reader_tenant_id
+    client_id = CDO.imm_reader_client_id
+    subdomain = CDO.imm_reader_subdomain
+    client_secret = CDO.imm_reader_client_secret # Do not log this secret
+    if tenant_id.blank? || client_id.blank? || subdomain.blank? || client_secret.blank?
+      return render status: :internal_server_error, json: {error: 'Environment not configured for Immersive Reader.'}
+    end
+
+    begin
+      headers = {
+        'content-type' => 'application/x-www-form-urlencoded'
+      }
+      url = "https://login.windows.net/#{tenant_id}/oauth2/token"
+      form = {
+        'grant_type' => 'client_credentials',
+        'client_id' => client_id,
+        'client_secret' => client_secret, # Do not log this secret
+        'resource' => 'https://cognitiveservices.azure.com/'
+      }
+      auth_response = JSON.parse(RestClient.post(url, form, headers))
+      response = {
+        token: auth_response['access_token'],
+        subdomain: subdomain,
+      }
+      render json: response
+    rescue RestClient::Exception => e
+      Honeybadger.notify(
+        e,
+        error_message: "Failed to retrieve OAuth token from Azure for use with the Immersive Reader API.",
+        context: {
+          client_id: tenant_id,
+          tenant_id: client_id,
+          subdomain: subdomain,
+        }
+      )
+      render status: :failed_dependency, json: {error: 'Unable to get token from Azure.'}
+    rescue JSON::JSONError => e
+      Honeybadger.notify(
+        e,
+        error_message: "Failed to parse response from Azure when trying to get OAuth token for use with the Immersive Reader API.",
+        context: {
+          client_id: tenant_id,
+          tenant_id: client_id,
+          subdomain: subdomain,
+        }
+      )
+      render status: :internal_server_error, json: {error: 'Unable to get token from Azure.'}
+    end
+  end
+
   def clever_classrooms
     return head :forbidden unless current_user
 


### PR DESCRIPTION
As a student, I have trouble reading the text in the instructions for a level and I would like to be able to easily control the display of the content.

This PR adds a button to the Instructions section of a level which launches Microsoft's Immersive Reader interface. This will let students have a lot of control over the content:
* Font size
* Letter spacing
* Font/background colors
* Font family
* Translation
* Picture dictionary
* Text to speech
* Reading Ruler

Here are the changes introduced in this PR
* Add yarn dependency on `immersive-reader-sdk`
* Add experiment flag `immersive-reader`
* Add ruby api `immersive_reader_token` which calls the Azure Active Directory API in order to get an OAuth token so we can make calls to the Azure Cognitive Services API.
* Add `<ImmersiveReaderButton>` React component which is responsible for rendering the Immersive Reader button.

## Screenshots
![immersive_reader_prototype](https://user-images.githubusercontent.com/1372238/90424351-82fffd00-e0ad-11ea-9b33-567d16f95578.gif)

## Links
- [jira](https://codedotorg.atlassian.net/browse/FND-1257)

## Testing story
* Tested on localhost
  * http://localhost-studio.code.org:3000/s/coursec-2019/stage/15/puzzle/4?enableExperiments=immersive-reader
* Adhoc being setup now...

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
