### PR TITLE
Explicitly set Drone cache parameters

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -36,6 +36,7 @@ steps:
 - name: restore-cache
   image: plugins/s3-cache
   settings:
+    root: code-dot-org
     pull: true
     restore: true
     filename: unit-tests-cache.tar
@@ -75,6 +76,7 @@ steps:
   - name: rbenv
     path: /home/circleci/.rbenv
   settings:
+    root: code-dot-org
     pull: true
     rebuild: true
     filename: unit-tests-cache.tar
@@ -209,6 +211,6 @@ trigger:
   - pull_request
 ---
 kind: signature
-hmac: 8d29e9e443fff4f14af3366ac692d366c1da12420ccb2ab00915c86c375752bd
+hmac: 80869904a8ae95b51ee06dec1402a58b963bd8cb34d1505551c20a6f0de4a1a4
 
 ...

--- a/.drone.yml
+++ b/.drone.yml
@@ -37,7 +37,6 @@ steps:
   image: plugins/s3-cache
   settings:
     endpoint: s3://code-dot-org
-    root: /
     debug: true
     pull: true
     restore: true
@@ -79,7 +78,6 @@ steps:
     path: /home/circleci/.rbenv
   settings:
     endpoint: s3://code-dot-org
-    root: /
     debug: true
     pull: true
     rebuild: true
@@ -150,7 +148,6 @@ steps:
   image: plugins/s3-cache
   settings:
     endpoint: s3://code-dot-org
-    root: /
     debug: true
     pull: true
     restore: true
@@ -197,7 +194,6 @@ steps:
     path: /home/circleci/.rbenv
   settings:
     endpoint: s3://code-dot-org
-    root: /
     debug: true
     pull: true
     rebuild: true
@@ -221,6 +217,6 @@ trigger:
   - pull_request
 ---
 kind: signature
-hmac: 17f563ac1975c9dead0c4ffb6e49c74bdc9fab54d25aec6888d9b1761ec93bef
+hmac: c4b01d2892b7314cb674278450cd30e012f01b3d5289eed1d6a2c933947ec623
 
 ...

--- a/.drone.yml
+++ b/.drone.yml
@@ -36,7 +36,9 @@ steps:
 - name: restore-cache
   image: plugins/s3-cache
   settings:
-    root: code-dot-org
+    endpoint: s3://code-dot-org
+    root: /
+    debug: true
     pull: true
     restore: true
     filename: unit-tests-cache.tar
@@ -76,7 +78,9 @@ steps:
   - name: rbenv
     path: /home/circleci/.rbenv
   settings:
-    root: code-dot-org
+    endpoint: s3://code-dot-org
+    root: /
+    debug: true
     pull: true
     rebuild: true
     filename: unit-tests-cache.tar
@@ -145,6 +149,9 @@ steps:
 - name: restore-cache
   image: plugins/s3-cache
   settings:
+    endpoint: s3://code-dot-org
+    root: /
+    debug: true
     pull: true
     restore: true
 
@@ -189,6 +196,9 @@ steps:
   - name: rbenv
     path: /home/circleci/.rbenv
   settings:
+    endpoint: s3://code-dot-org
+    root: /
+    debug: true
     pull: true
     rebuild: true
     mount:
@@ -211,6 +221,6 @@ trigger:
   - pull_request
 ---
 kind: signature
-hmac: 80869904a8ae95b51ee06dec1402a58b963bd8cb34d1505551c20a6f0de4a1a4
+hmac: 17f563ac1975c9dead0c4ffb6e49c74bdc9fab54d25aec6888d9b1761ec93bef
 
 ...


### PR DESCRIPTION
All Drone continuous integration builds started failing around 1PM PDT 8/17/2020. It appears that Docker Image for the 3rd party Drone plugin [AWS S3 Cache](http://plugins.drone.io/drone-plugins/drone-s3-cache/) that our Drone build utilizes to speed up builds was updated in DockerHub to a version that now requires one or more Parameters to be explicitly set to specify where to store/retrieve the cache file. The simplest solution [appears to be](https://github.com/drone-plugins/drone-s3-cache/blob/bdb91747e936945cbd7c8d89ae9dc8536f6059f4/plugin/impl.go#L235-L241) to just specify the `root` Parameter to the bucket name. 

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
