### PR TITLE
Add Cuantrix to iframe allow list

### DIFF
--- a/config.yml.erb
+++ b/config.yml.erb
@@ -327,7 +327,7 @@ app_servers: {}
 rack_mini_profiler_enabled:
 https_development:
 default_scheme: '<%=(env == 'development') || ci ? 'http:' : 'https:'%>'
-allowed_iframe_ancestors: http://*.disney.com http://*.diznee.net <%=pegasus_hostname%> <%=dashboard_hostname%> curriculum.code.org codecurricula.com
+allowed_iframe_ancestors: http://*.disney.com http://*.diznee.net cuantrix.mx <%=pegasus_hostname%> <%=dashboard_hostname%> curriculum.code.org codecurricula.com
 skip_locales:
 secret_pictures_csv:
 no_https_store:


### PR DESCRIPTION
Add Cuantrix to list of domains that can embed Code.org within an iframe.
https://codedotorg.atlassian.net/browse/INF-363

The `allowed_iframe_ancestors` attribute is not configured in Chef and there isn't an `allowed_iframe_ancestors` key in DCDO for any environment.

## Testing story

This has been tested on the `adhoc-cuantrix` adhoc with the Cuantrix test site (cuantrix.gilasw.com).

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
