### PR TITLE
Header: fix advocacy logo

### DIFF
--- a/pegasus/sites.v3/advocacy.code.org/views/header.haml
+++ b/pegasus/sites.v3/advocacy.code.org/views/header.haml
@@ -8,7 +8,7 @@
         #left
           #logo-wrapper
             %a.linktag#logo-signedin{href: "/"}
-              %img#logo{src: '/images/fit-350/logo.svg'}
+              %img#logo{src: '/images/fit-350/logo.png'}
 
         #right
           %a{href: CDO.code_org_url("/")}

--- a/pegasus/sites.v3/advocacy.code.org/views/mobile_header_responsive.haml
+++ b/pegasus/sites.v3/advocacy.code.org/views/mobile_header_responsive.haml
@@ -3,4 +3,4 @@
     #logo-wrapper
       #left
         %a{:href=>'/'}
-          %img#logo{:src=>'/images/fit-350/logo.svg'}
+          %img#logo{:src=>'/images/fit-350/logo.png'}


### PR DESCRIPTION
This restores the advocacy.code.org logo, regressed in https://github.com/code-dot-org/code-dot-org/pull/36115.
