### PR TITLE
Capitalized Facilitators in facilitator-specific section of Foorms

### DIFF
--- a/dashboard/config/foorm/library/surveys/pd/facilitator_panel.0.json
+++ b/dashboard/config/foorm/library/surveys/pd/facilitator_panel.0.json
@@ -12,13 +12,14 @@
    {
      "type": "paneldynamic",
      "name": "facilitators",
+     "title": "Facilitators",
      "allowAddPanel": false,
      "allowRemovePanel": false,
      "templateElements": [
       {
        "type": "html",
        "name": "facilitator_name_heading",
-       "html": "<p>Below please leave feedback for <strong>{panel.facilitator_name}</strong></p>" 
+       "html": "<p>Below please leave feedback for <strong>{panel.facilitator_name}</strong></p>"
      },
      {
        "type": "matrix",


### PR DESCRIPTION
Capitalize "Facilitator" at top of section of surveys with facilitator-specific questions:

![image](https://user-images.githubusercontent.com/25372625/90564115-ab453580-e159-11ea-95b0-a621624909dd.png)


## Testing story

Made this change locally to a survey with facilitator-specific questions via /foorm/editor.
