### PR TITLE
AYW Surveys: Enable all pre and post links

### DIFF
--- a/dashboard/lib/pd/workshop_survey_foorm_constants.rb
+++ b/dashboard/lib/pd/workshop_survey_foorm_constants.rb
@@ -13,15 +13,24 @@ module Pd
       SUBJECT_CSF_101 => 'surveys/pd/workshop_csf_intro_post',
       SUBJECT_CSP_FOR_RETURNING_TEACHERS => 'surveys/pd/csp_wfrt_post_survey',
       SUBJECT_CSF_201 => 'surveys/pd/csf_deep_dive_post',
-      # TODO: update with rest of AYW subjects
-      SUBJECT_WORKSHOP_4 => 'surveys/pd/ayw_workshop_post_survey'
+      SUBJECT_WORKSHOP_1 => 'surveys/pd/ayw_workshop_post_survey',
+      SUBJECT_WORKSHOP_2 => 'surveys/pd/ayw_workshop_post_survey',
+      SUBJECT_WORKSHOP_3 => 'surveys/pd/ayw_workshop_post_survey',
+      SUBJECT_WORKSHOP_4 => 'surveys/pd/ayw_workshop_post_survey',
+      SUBJECT_WORKSHOP_1_2 => 'surveys/pd/ayw_workshop_post_survey',
+      SUBJECT_WORKSHOP_3_4 => 'surveys/pd/ayw_workshop_post_survey',
+      SUBJECT_VIRTUAL_KICKOFF => 'surveys/pd/ayw_kickoff_call'
     }
 
     PRE_SURVEY_CONFIG_PATHS = {
       SUBJECT_SUMMER_WORKSHOP => 'surveys/pd/summer_workshop_pre_survey',
       SUBJECT_CSF_201 => 'surveys/pd/csf_deep_dive_pre',
-      # TODO: update with real survey and add rest of AYW subjects
-      SUBJECT_WORKSHOP_4 => 'surveys/pd/ayw_workshop_post_survey'
+      SUBJECT_WORKSHOP_1 => 'surveys/pd/ayw_workshop_pre_survey',
+      SUBJECT_WORKSHOP_2 => 'surveys/pd/ayw_workshop_pre_survey',
+      SUBJECT_WORKSHOP_3 => 'surveys/pd/ayw_workshop_pre_survey',
+      SUBJECT_WORKSHOP_4 => 'surveys/pd/ayw_workshop_pre_survey',
+      SUBJECT_WORKSHOP_1_2 => 'surveys/pd/ayw_workshop_pre_survey',
+      SUBJECT_WORKSHOP_3_4 => 'surveys/pd/ayw_workshop_pre_survey'
     }
 
     FOORM_SUBMIT_API = '/api/v1/pd/foorm/workshop_survey_submission'

--- a/dashboard/test/controllers/pd/workshop_daily_survey_controller_test.rb
+++ b/dashboard/test/controllers/pd/workshop_daily_survey_controller_test.rb
@@ -1049,8 +1049,8 @@ module Pd
         teacher: @enrolled_academic_year_teacher,
         enrollment: @academic_year_enrollment
 
-      pre_survey_links = %w(/pd/AYW1/post/in_person /pd/AYW1/post/module/1 /pd/AYW1/post/module/2 /pd/AYW1/pre/module/1_2)
-      pre_survey_links.each do |link|
+      post_survey_links = %w(/pd/AYW1/post/in_person /pd/AYW1/post/module/1 /pd/AYW1/post/module/2 /pd/AYW1/post/module/1_2)
+      post_survey_links.each do |link|
         get link
         assert_response :success
         assert_template :new_general_foorm
@@ -1061,8 +1061,8 @@ module Pd
       setup_academic_year_workshop
       sign_in @enrolled_academic_year_teacher
 
-      pre_survey_links = %w(/pd/AYW1/post/in_person /pd/AYW1/post/module/1 /pd/AYW1/post/module/2 /pd/AYW1/post/module/1_2)
-      pre_survey_links.each do |link|
+      post_survey_links = %w(/pd/AYW1/post/in_person /pd/AYW1/post/module/1 /pd/AYW1/post/module/2 /pd/AYW1/post/module/1_2)
+      post_survey_links.each do |link|
         get link
         assert_response :success
         assert_no_attendance
@@ -1091,7 +1091,7 @@ module Pd
       assert_template :new_general_foorm
     end
 
-    test 'invalid AYW survey links show appropriate errors' do
+    test 'User cannot access AYW survey if they are not enrolled' do
       setup_two_day_academic_year_workshop
       sign_in @enrolled_two_day_academic_year_teacher
 

--- a/dashboard/test/controllers/pd/workshop_daily_survey_controller_test.rb
+++ b/dashboard/test/controllers/pd/workshop_daily_survey_controller_test.rb
@@ -1029,6 +1029,77 @@ module Pd
       assert_select 'h1', text: 'Thank you for submitting today’s survey.'
     end
 
+    test 'AYW1 pre-survey link shows foorm survey' do
+      setup_academic_year_workshop
+      sign_in @enrolled_academic_year_teacher
+
+      pre_survey_links = %w(/pd/AYW1/pre /pd/AYW1/pre/module/1 /pd/AYW1/pre/module/2)
+      pre_survey_links.each do |link|
+        get link
+        assert_response :success
+        assert_template :new_general_foorm
+      end
+    end
+
+    test 'AYW1 post-survey link shows foorm survey for attended teacher' do
+      setup_academic_year_workshop
+      sign_in @enrolled_academic_year_teacher
+      create :pd_attendance,
+        session: @academic_year_workshop.sessions[0],
+        teacher: @enrolled_academic_year_teacher,
+        enrollment: @academic_year_enrollment
+
+      pre_survey_links = %w(/pd/AYW1/post/in_person /pd/AYW1/post/module/1 /pd/AYW1/post/module/2 /pd/AYW1/pre/module/1_2)
+      pre_survey_links.each do |link|
+        get link
+        assert_response :success
+        assert_template :new_general_foorm
+      end
+    end
+
+    test 'AYW1 post-survey link shows no attendance for teacher with no attendance' do
+      setup_academic_year_workshop
+      sign_in @enrolled_academic_year_teacher
+
+      pre_survey_links = %w(/pd/AYW1/post/in_person /pd/AYW1/post/module/1 /pd/AYW1/post/module/2 /pd/AYW1/post/module/1_2)
+      pre_survey_links.each do |link|
+        get link
+        assert_response :success
+        assert_no_attendance
+      end
+    end
+
+    test 'AYW1_2 pre-survey link shows foorm survey' do
+      setup_two_day_academic_year_workshop
+      sign_in @enrolled_two_day_academic_year_teacher
+
+      get '/pd/AYW1_2/pre'
+      assert_response :success
+      assert_template :new_general_foorm
+    end
+
+    test 'AYW1_2 post-survey link shows foorm survey for attended teacher' do
+      setup_two_day_academic_year_workshop
+      sign_in @enrolled_two_day_academic_year_teacher
+
+      create :pd_attendance,
+        session: @two_day_academic_year_workshop.sessions[0],
+        teacher: @enrolled_two_day_academic_year_teacher,
+        enrollment: @two_day_academic_year_enrollment
+      get '/pd/AYW1_2/post/in_person'
+      assert_response :success
+      assert_template :new_general_foorm
+    end
+
+    test 'invalid AYW survey links show appropriate errors' do
+      setup_two_day_academic_year_workshop
+      sign_in @enrolled_two_day_academic_year_teacher
+
+      # two day workshop enrollee should not be able to load 1 day survey
+      get '/pd/AYW1/pre'
+      assert_not_enrolled
+    end
+
     private
 
     def setup_summer_workshop


### PR DESCRIPTION
Enable pre and post workshop links for all AYW (academic year workshop) surveys. Pre-surveys and kickoff post survey have been fully proofread and are ready to go. Post surveys are still in progress but the first workshop is not until 8/29 so it is safe to enable them now.

<!-- ### Background -->
<!-- ### Privacy -->
<!-- ### Security -->
<!-- ### Caching -->
<!-- ### Deployment strategy -->
 ### Future work 
- update survey results view for academic year workshops to show foorm view
- deprecate old AYW links and clean up the workshop_daily_survey_controller (will be done in separate PR)
 
## Links

- [spec - link descriptions](https://docs.google.com/document/d/1uYKpTUS3eJOna9008p_6-30fEeX_vdPc0dEDEDc-MXU/edit)
- [jira](https://codedotorg.atlassian.net/browse/PLC-954)

## Testing story
Added unit tests for the new links and tested locally that an enrolled teacher can access the links as expected.

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
