### PR TITLE
Disable azure_speech_service_options request

### DIFF
--- a/dashboard/app/controllers/projects_controller.rb
+++ b/dashboard/app/controllers/projects_controller.rb
@@ -308,7 +308,11 @@ class ProjectsController < ApplicationController
     # for sharing pages, the app will display the footer inside the playspace instead
     # if the game doesn't own the sharing footer, treat it as a legacy share
     @legacy_share_style = sharing && !@game.owns_footer_for_share?
-    azure_speech_service = azure_speech_service_options
+
+    # TODO: (madelynkasula) Re-enable this Azure request once we have root-caused this Honeybadger error:
+    # https://app.honeybadger.io/projects/3240/faults/66859534
+    # azure_speech_service = azure_speech_service_options
+
     view_options(
       readonly_workspace: sharing || readonly,
       full_width: true,
@@ -319,10 +323,7 @@ class ProjectsController < ApplicationController
       no_header: sharing || iframe_embed_app_and_code,
       small_footer: !iframe_embed_app_and_code && !sharing && (@game.uses_small_footer? || @level.enable_scrolling?),
       has_i18n: @game.has_i18n?,
-      game_display_name: data_t("game.name", @game.name),
-      azure_speech_service_token: azure_speech_service[:azureSpeechServiceToken],
-      azure_speech_service_region: azure_speech_service[:azureSpeechServiceRegion],
-      azure_speech_service_languages: azure_speech_service[:azureSpeechServiceLanguages]
+      game_display_name: data_t("game.name", @game.name)
     )
 
     if params[:key] == 'artist'


### PR DESCRIPTION
Disabling the request to Azure for a token for their text-to-speech service, as it's currently causing 500 errors for students visiting Applab and Gamelab: https://app.honeybadger.io/projects/3240/faults/66859534

I haven't diagnosed _why_ this request is failing yet, but this feature is hidden behind a feature flag, so I am disabling to reduce user impact while we investigate further.

## Links

- [Slack thread](https://codedotorg.slack.com/archives/C0T0PNTM3/p1597787415411500)

## Testing story

<!--
  Does your change include appropriate tests?

  If so, please describe how the tests included in this PR are sufficient

  If not, please explain why this change does not need to be tested.
-->

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
