### PR TITLE
Make unit description able to use markdown and preview in editor

### DIFF
--- a/apps/src/code-studio/components/progress/ScriptOverviewHeader.jsx
+++ b/apps/src/code-studio/components/progress/ScriptOverviewHeader.jsx
@@ -24,6 +24,7 @@ import AssignmentVersionSelector, {
 import {assignmentVersionShape} from '@cdo/apps/templates/teacherDashboard/shapes';
 import StudentFeedbackNotification from '@cdo/apps/templates/feedback/StudentFeedbackNotification';
 import VerifiedResourcesNotification from '@cdo/apps/templates/courseOverview/VerifiedResourcesNotification';
+import SafeMarkdown from '@cdo/apps/templates/SafeMarkdown';
 
 const SCRIPT_OVERVIEW_WIDTH = 1100;
 
@@ -258,7 +259,11 @@ class ScriptOverviewHeader extends Component {
                 />
               )}
             </div>
-            <p style={styles.description}>{scriptDescription}</p>
+            <SafeMarkdown
+              style={styles.description}
+              openExternalLinksInNewTab={true}
+              markdown={scriptDescription}
+            />
           </div>
           <ProtectedStatefulDiv ref={element => (this.protected = element)} />
         </div>

--- a/apps/src/lib/script-editor/ScriptEditor.jsx
+++ b/apps/src/lib/script-editor/ScriptEditor.jsx
@@ -175,14 +175,12 @@ export default class ScriptEditor extends React.Component {
             style={styles.input}
             onChange={this.handleDescriptionChange}
           />
-          <div style={{marginLeft: 10}}>
-            <div style={{marginBottom: 5}}>Preview:</div>
-            <div style={styles.box}>
-              <SafeMarkdown
-                openExternalLinksInNewTab={true}
-                markdown={this.state.description}
-              />
-            </div>
+          <div style={{marginBottom: 5}}>Preview:</div>
+          <div style={styles.box}>
+            <SafeMarkdown
+              openExternalLinksInNewTab={true}
+              markdown={this.state.description}
+            />
           </div>
         </label>
         <h2>Basic Settings</h2>

--- a/apps/src/lib/script-editor/ScriptEditor.jsx
+++ b/apps/src/lib/script-editor/ScriptEditor.jsx
@@ -15,6 +15,8 @@ import {announcementShape} from '@cdo/apps/code-studio/scriptAnnouncementsRedux'
 import VisibleAndPilotExperiment from './VisibleAndPilotExperiment';
 import HelpTip from '@cdo/apps/lib/ui/HelpTip';
 import LessonExtrasEditor from './LessonExtrasEditor';
+import SafeMarkdown from '@cdo/apps/templates/SafeMarkdown';
+import color from '@cdo/apps/util/color';
 
 const styles = {
   input: {
@@ -30,6 +32,12 @@ const styles = {
   },
   dropdown: {
     margin: '0 6px'
+  },
+  box: {
+    marginTop: 10,
+    marginBottom: 10,
+    border: '1px solid ' + color.light_gray,
+    padding: 10
   }
 };
 
@@ -82,7 +90,8 @@ export default class ScriptEditor extends React.Component {
     super(props);
 
     this.state = {
-      curriculumUmbrella: this.props.curriculumUmbrella
+      curriculumUmbrella: this.props.curriculumUmbrella,
+      description: this.props.i18nData.description
     };
   }
 
@@ -114,6 +123,10 @@ export default class ScriptEditor extends React.Component {
         e.preventDefault();
       }
     }
+  };
+
+  handleDescriptionChange = event => {
+    this.setState({description: event.target.value});
   };
 
   render() {
@@ -157,10 +170,20 @@ export default class ScriptEditor extends React.Component {
           Description
           <textarea
             name="description"
-            defaultValue={this.props.i18nData.description}
+            defaultValue={this.state.description}
             rows={5}
             style={styles.input}
+            onChange={this.handleDescriptionChange}
           />
+          <div style={{marginLeft: 10}}>
+            <div style={{marginBottom: 5}}>Preview:</div>
+            <div style={styles.box}>
+              <SafeMarkdown
+                openExternalLinksInNewTab={true}
+                markdown={this.state.description}
+              />
+            </div>
+          </div>
         </label>
         <h2>Basic Settings</h2>
         <label>

--- a/apps/test/unit/code-studio/components/progress/ScriptOverviewHeaderTest.js
+++ b/apps/test/unit/code-studio/components/progress/ScriptOverviewHeaderTest.js
@@ -16,7 +16,8 @@ const defaultProps = {
   scriptId: 99,
   scriptName: 'course1',
   scriptTitle: 'Course One',
-  scriptDescription: 'The first course',
+  scriptDescription:
+    '# Title \n This is the unit description with [link](https://studio.code.org/home) **Bold** *italics*',
   versions: []
 };
 
@@ -287,5 +288,14 @@ describe('ScriptOverviewHeader', () => {
     assert.equal(true, coursea2017.isRecommended);
     const coursea2018 = renderedVersions.find(v => v.name === 'coursea-2018');
     assert.equal(true, coursea2018.isSelected);
+  });
+
+  it('has correct unit description', () => {
+    const wrapper = shallow(<ScriptOverviewHeader {...defaultProps} />, {
+      disableLifecycleMethods: true
+    });
+    expect(wrapper.find('SafeMarkdown').prop('markdown')).to.equal(
+      '# Title \n This is the unit description with [link](https://studio.code.org/home) **Bold** *italics*'
+    );
   });
 });

--- a/apps/test/unit/lib/script-editor/ScriptEditorTest.jsx
+++ b/apps/test/unit/lib/script-editor/ScriptEditorTest.jsx
@@ -8,7 +8,9 @@ describe('ScriptEditor', () => {
     announcements: [],
     curriculumUmbrella: 'CSF',
     i18nData: {
-      stageDescriptions: []
+      stageDescriptions: [],
+      description:
+        '# Title \n This is the unit description with [link](https://studio.code.org/home) **Bold** *italics*'
     },
     isLevelbuilder: true,
     locales: [],
@@ -25,6 +27,21 @@ describe('ScriptEditor', () => {
       expect(wrapper.find('input[type="checkbox"]').length).to.equal(10);
       expect(wrapper.find('textarea').length).to.equal(2);
       expect(wrapper.find('select').length).to.equal(5);
+    });
+
+    it('has correct markdown for preview of unit description', () => {
+      const wrapper = mount(<ScriptEditor {...DEFAULT_PROPS} hidden={false} />);
+      expect(wrapper.find('SafeMarkdown').length).to.equal(1);
+      expect(wrapper.find('SafeMarkdown').prop('markdown')).to.equal(
+        '# Title \n This is the unit description with [link](https://studio.code.org/home) **Bold** *italics*'
+      );
+
+      wrapper
+        .find('textarea[name="description"]')
+        .simulate('change', {target: {value: '## Title'}});
+      expect(wrapper.find('SafeMarkdown').prop('markdown')).to.equal(
+        '## Title'
+      );
     });
   });
 

--- a/apps/test/unit/sites/studio/pages/levelbuilder_edit_script.js
+++ b/apps/test/unit/sites/studio/pages/levelbuilder_edit_script.js
@@ -16,7 +16,9 @@ describe('the level builder page init script', () => {
         stages: []
       },
       i18n: {
-        stageDescriptions: []
+        stageDescriptions: [],
+        description:
+          '# Title \n This is the unit description with [link](https://studio.code.org/home) **Bold** *italics*'
       },
       beta: false,
       levelKeyList: [],


### PR DESCRIPTION
## Background

As part of preparing to starting writing curriculum all on LB (CB->LB) we want the description of a unit on the Script Overview page to support markdown.

## Edit experience:

Added a preview area for the description similar to the preview of the Teacher Resources button lower down on the page.

<img width="1260" alt="Screen Shot 2020-08-19 at 11 37 40 AM" src="https://user-images.githubusercontent.com/208083/90656750-734cf980-e210-11ea-9ba8-0fe69f67ad78.png">

## Script Overview Page

Now shows the description as markdown.

<img width="1313" alt="Screen Shot 2020-08-18 at 10 52 21 PM" src="https://user-images.githubusercontent.com/208083/90586796-056be800-e1a6-11ea-96ff-48c3f04327a5.png">

## Links

<!--
  Any relevant links to external resources; ie, specification documents, jira
  items, related PRs, honeybadger errors, etc
-->

- [spec](https://docs.google.com/document/d/13ZQuoNKMR0sgJsIVjHRSUVgfRnpIadfHwG8-DONoyxE/edit#)
- [PLAT-246](https://codedotorg.atlassian.net/browse/PLAT-246)
- [PLAT-247](https://codedotorg.atlassian.net/browse/PLAT-247)

## Testing story

<!--
  Does your change include appropriate tests?

  If so, please describe how the tests included in this PR are sufficient

  If not, please explain why this change does not need to be tested.
-->

- Added tests to ScriptOverviewHeaderTest and ScriptEditor to check that the markdown makes it to the SafeMarkdown component correctly

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
