### PR TITLE
Pass recorded time_spent to the teacher section progress redux store

### DIFF
--- a/apps/src/templates/sectionProgress/sectionProgressLoader.js
+++ b/apps/src/templates/sectionProgress/sectionProgressLoader.js
@@ -37,6 +37,7 @@ export function loadScript(scriptId, sectionId) {
   let sectionProgress = {
     studentLevelProgressByScript: {},
     studentTimestampsByScript: {},
+    studentLevelTimeSpentByScript: {},
     studentLevelPairingByScript: {},
     scriptDataByScript: {}
   };
@@ -95,6 +96,13 @@ export function loadScript(scriptId, sectionId) {
           [scriptId]: {
             ...sectionProgress.studentTimestampsByScript,
             ...processStudentTimestamps(data.student_timestamps)
+          }
+        };
+
+        sectionProgress.studentLevelTimeSpentByScript = {
+          [scriptId]: {
+            ...sectionProgress.studentLevelTimeSpentByScript,
+            ...getInfoByStudentByLevel(data.students, level => level.time_spent)
           }
         };
 
@@ -158,6 +166,8 @@ function postProcessDataByScript(scriptData) {
 function postProcessLevelsByLesson(scriptId, progress) {
   const studentLevelProgress =
     progress.studentLevelProgressByScript[scriptId] || {};
+  const studentTimeSpent =
+    progress.studentLevelTimeSpentByScript[scriptId] || {};
   const pairing = progress.studentLevelPairingByScript[scriptId];
   const scriptData = progress.scriptDataByScript[scriptId];
   let levelsByLessonByStudent = {};
@@ -165,6 +175,7 @@ function postProcessLevelsByLesson(scriptId, progress) {
     levelsByLessonByStudent[studentId] = levelsByLesson({
       stages: scriptData.stages,
       levelProgress: studentLevelProgress[studentId],
+      levelTimeSpent: studentTimeSpent[studentId],
       levelPairing: pairing[studentId],
       currentLevelId: null
     });

--- a/apps/src/templates/sectionProgress/sectionProgressRedux.js
+++ b/apps/src/templates/sectionProgress/sectionProgressRedux.js
@@ -38,6 +38,7 @@ const initialState = {
   studentLevelProgressByScript: {},
   studentLevelPairingByScript: {},
   studentTimestampsByScript: {},
+  studentLevelTimeSpentByScript: {},
   levelsByLessonByScript: {},
   lessonOfInterest: INITIAL_LESSON_OF_INTEREST,
   isLoadingProgress: true
@@ -102,8 +103,12 @@ export default function sectionProgress(state = initialState, action) {
         ...action.data.studentLevelPairingByScript
       },
       studentTimestampsByScript: {
-        ...state.studentTimestampsByScript, // double check that this line should be here... it wasn't before the refactor
+        ...state.studentTimestampsByScript,
         ...action.data.studentTimestampsByScript
+      },
+      studentLevelTimeSpentByScript: {
+        ...state.studentLevelTimeSpentByScript,
+        ...action.data.studentLevelTimeSpentByScript
       }
     };
   }

--- a/apps/test/unit/templates/sectionProgress/sectionProgressLoaderTest.js
+++ b/apps/test/unit/templates/sectionProgress/sectionProgressLoaderTest.js
@@ -33,10 +33,10 @@ const serverProgressResponse = {
     100: {},
     101: {
       2000: {status: 'locked'},
-      2001: {status: 'perfect', result: 30, paired: true}
+      2001: {status: 'perfect', result: 30, paired: true, time_spent: 12345}
     },
     102: {
-      2000: {status: 'perfect', result: 100}
+      2000: {status: 'perfect', result: 100, time_spent: 6789}
     }
   }
 };
@@ -82,6 +82,18 @@ const fullExpectedResult = {
       },
       102: {
         2000: 100
+      }
+    }
+  },
+  studentLevelTimeSpentByScript: {
+    123: {
+      100: {},
+      101: {
+        2000: undefined,
+        2001: 12345
+      },
+      102: {
+        2000: 6789
       }
     }
   },
@@ -200,6 +212,7 @@ describe('sectionProgressLoader.loadScript', () => {
         },
         studentLevelPairingByScript: {0: {}},
         studentLevelProgressByScript: {0: {}},
+        studentLevelTimeSpentByScript: {0: {}},
         studentTimestampsByScript: {0: {}}
       };
 

--- a/dashboard/app/helpers/users_helper.rb
+++ b/dashboard/app/helpers/users_helper.rb
@@ -197,7 +197,8 @@ module UsersHelper
               readonly_answers: readonly_answers ? true : nil,
               paired: (paired_user_levels.include? ul.try(:id)) ? true : nil,
               locked: locked ? true : nil,
-              last_progress_at: include_timestamp ? ul&.updated_at&.to_i : nil
+              last_progress_at: include_timestamp ? ul&.updated_at&.to_i : nil,
+              time_spent: ul&.time_spent&.to_i
             }.compact
           end
         end
@@ -228,7 +229,8 @@ module UsersHelper
           readonly_answers: readonly_answers ? true : nil,
           paired: (paired_user_levels.include? ul.try(:id)) ? true : nil,
           locked: locked ? true : nil,
-          last_progress_at: include_timestamp ? ul&.updated_at&.to_i : nil
+          last_progress_at: include_timestamp ? ul&.updated_at&.to_i : nil,
+          time_spent: ul&.time_spent&.to_i
         }.compact
 
         # Just in case this level has multiple pages, in which case we add an additional


### PR DESCRIPTION
In a [previous PR](https://github.com/code-dot-org/code-dot-org/pull/36121), we started recording how much time a user spends on a level. Now, we pass that information to the teacher's section progress view. 

### Background

In the past, we only wanted to record the time spent on validated levels, now, we want to record the time spent on all levels. ([Pivot details here](https://codedotorg.slack.com/archives/CA3KCSGTD/p1596234043244300]))

This is part of a larger effort to make various [improvements to the progress tab](https://docs.google.com/document/d/11vid6ZWkpUV5TJm3swI6kbdSpg5_93UHDxnod58r_Zc/edit#) to start displaying more data to teachers about their students' progress.

time_spent will allow teachers to see how long a student has been working on a level. This will help teachers identify which students are struggling. Additionally, it will help us identify which levels are difficult and which are easy.

This is a re-implementation of an earlier PR:https://github.com/code-dot-org/code-dot-org/pull/31661

<!--
  Your description goes here: A summary of the change, including any relevant motivation and context.

  If relevant, include a description both of the existing behavior and of the new behavior.
-->

<!--
  Other aspects to consider. uncomment and add detail for any that seem necessary:
-->

<!-- ### Background -->
<!-- ### Privacy -->
<!-- ### Security -->
<!-- ### Caching -->
<!-- ### Deployment strategy -->
<!-- ### Future work -->

## Links

<!--
  Any relevant links to external resources; ie, specification documents, jira
  items, related PRs, honeybadger errors, etc
-->

- [Pivot to record time_spent for all levels](https://codedotorg.slack.com/archives/CA3KCSGTD/p1596234043244300])
- [Dev Doc: Recording Time Spent Plan](https://docs.google.com/document/d/1sSxS1C0XHokLh34ObposdzI0I1FwCY7qJXmn0mtpwi0/edit?ts=5d8932a9&pli=1)
- [Spec: Improvements to the progress tab](https://docs.google.com/document/d/11vid6ZWkpUV5TJm3swI6kbdSpg5_93UHDxnod58r_Zc/edit#)
- [Previous PR attempt](https://github.com/code-dot-org/code-dot-org/pull/31661)
- Edits to the DB: https://github.com/code-dot-org/code-dot-org/pull/36082 & https://github.com/code-dot-org/code-dot-org/pull/36110

## Testing story

<!--
  Does your change include appropriate tests?

  If so, please describe how the tests included in this PR are sufficient

  If not, please explain why this change does not need to be tested.
-->

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
