### PR TITLE
Show Script URL on Script Edit Page

### DIFF
--- a/apps/src/lib/script-editor/ScriptEditor.jsx
+++ b/apps/src/lib/script-editor/ScriptEditor.jsx
@@ -23,7 +23,8 @@ const styles = {
     padding: '4px 6px',
     color: '#555',
     border: '1px solid #ccc',
-    borderRadius: 4
+    borderRadius: 4,
+    margin: 0
   },
   checkbox: {
     margin: '0 0 0 7px'
@@ -129,6 +130,15 @@ export default class ScriptEditor extends React.Component {
             name="title"
             defaultValue={this.props.i18nData.title}
             style={styles.input}
+          />
+        </label>
+        <label>
+          Unit URL (Slug)
+          <input
+            type="text"
+            value={this.props.name}
+            style={styles.input}
+            disabled={true}
           />
         </label>
         <label>

--- a/apps/test/unit/lib/script-editor/ScriptEditorTest.jsx
+++ b/apps/test/unit/lib/script-editor/ScriptEditorTest.jsx
@@ -21,7 +21,7 @@ describe('ScriptEditor', () => {
   describe('Script Editor', () => {
     it('has the correct number of each editor field type', () => {
       const wrapper = mount(<ScriptEditor {...DEFAULT_PROPS} hidden={false} />);
-      expect(wrapper.find('input').length).to.equal(21);
+      expect(wrapper.find('input').length).to.equal(22);
       expect(wrapper.find('input[type="checkbox"]').length).to.equal(10);
       expect(wrapper.find('textarea').length).to.equal(2);
       expect(wrapper.find('select').length).to.equal(5);


### PR DESCRIPTION
Shows the Script URL on the edit page disabled.

<img width="1244" alt="Screen Shot 2020-08-19 at 1 30 19 PM" src="https://user-images.githubusercontent.com/208083/90669766-21ac6b00-e220-11ea-925b-58485a38cf0f.png">

## Links

<!--
  Any relevant links to external resources; ie, specification documents, jira
  items, related PRs, honeybadger errors, etc
-->

- [spec](https://docs.google.com/document/d/13ZQuoNKMR0sgJsIVjHRSUVgfRnpIadfHwG8-DONoyxE/edit#)
- [jira](https://codedotorg.atlassian.net/browse/PLAT-246)

## Testing story

<!--
  Does your change include appropriate tests?

  If so, please describe how the tests included in this PR are sufficient

  If not, please explain why this change does not need to be tested.
-->

Updated the ScriptEditorTest

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
