### PR TITLE
Remove interpolation in Polish translation

### DIFF
--- a/dashboard/config/locales/pl-PL.yml
+++ b/dashboard/config/locales/pl-PL.yml
@@ -203,7 +203,7 @@ pl:
     student_terms_markdown: Adresy e-mail nie są przechowywane w postaci, która pozwalałaby
       nam kontaktować się z uczniami. Uczniowie nigdy nie będą otrzymywać e-maili
       od Code.org, z wyjątkiem odzyskiwania hasła. Więcej informacji znajduje się
-      w naszej [Polityce prywatności](%{privacy_policy_url}).
+      w naszej [Polityce prywatności](http://code.org/privacy).
     additional_information: Potrzebujemy dodatkowych informacji, aby móc Ciebie zarejestrować.
     user_type_button: Zaktualizuj typ konta
     user_type_label: Typ konta


### PR DESCRIPTION
I replaced the interpolation with the URL in the source string (both here and in Crowdin) and let Jorge know. I want to merge this ahead of the next sync to resolve the [HB error](https://app.honeybadger.io/projects/3240/faults/66866405) we're getting.
<!-- ### Background -->
<!-- ### Privacy -->
<!-- ### Security -->
<!-- ### Caching -->
<!-- ### Deployment strategy -->
<!-- ### Future work -->

## Links

<!--
  Any relevant links to external resources; ie, specification documents, jira
  items, related PRs, honeybadger errors, etc
-->

- [spec]()
- [jira]()

## Testing story

<!--
  Does your change include appropriate tests?

  If so, please describe how the tests included in this PR are sufficient

  If not, please explain why this change does not need to be tested.
-->

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
