### PR TITLE
Do not show thank donors interstitial when asking for school info

### DIFF
--- a/dashboard/app/helpers/school_info_interstitial_helper.rb
+++ b/dashboard/app/helpers/school_info_interstitial_helper.rb
@@ -5,7 +5,7 @@ module SchoolInfoInterstitialHelper
 
     return false if user.account_age_days < 7
 
-    # Interstitial should pop up the first time for the teacher if it has been at least 30 days since the teacher signed
+    # Interstitial should pop up the first time for the teacher if it has been at least 7 days since the teacher signed
     # up for an account AND the teacher hasn’t previously filled out all the fields already (e.g. as part
     # of workshop registration).
     return false if Queries::SchoolInfo.last_complete(user)

--- a/dashboard/app/helpers/school_info_interstitial_helper.rb
+++ b/dashboard/app/helpers/school_info_interstitial_helper.rb
@@ -15,11 +15,6 @@ module SchoolInfoInterstitialHelper
       return false if days_since_interstitial_seen < 7
     end
 
-    # We skip validation as some of our users (particularly teachers) do not pass our own
-    # validations (often because they are missing an email).
-    user.last_seen_school_info_interstitial = DateTime.now
-    user.save(validate: false)
-
     return true
   end
 
@@ -44,14 +39,13 @@ module SchoolInfoInterstitialHelper
     check_last_seen_school_info_interstitial = user.last_seen_school_info_interstitial&.to_datetime.nil? ||
       user.last_seen_school_info_interstitial.to_datetime < 7.days.ago
 
-    show_dialog = check_last_seen_school_info_interstitial && check_last_confirmation_date && check_school_type
+    check_last_seen_school_info_interstitial && check_last_confirmation_date && check_school_type
+  end
 
-    if show_dialog
-      # Check to ensure last seen school info interstitial is saved.
-      user.last_seen_school_info_interstitial = DateTime.now
-      user.save(validate: false)
-    end
-
-    show_dialog
+  def self.update_last_seen_timestamp(user)
+    # We skip validation as some of our users (particularly teachers) do not pass our own
+    # validations (often because they are missing an email).
+    user.last_seen_school_info_interstitial = DateTime.now
+    user.save(validate: false)
   end
 end

--- a/dashboard/app/helpers/thank_donors_interstitial_helper.rb
+++ b/dashboard/app/helpers/thank_donors_interstitial_helper.rb
@@ -8,6 +8,8 @@ module ThankDonorsInterstitialHelper
     return false if user.age.nil? # Age dialog
     return false if user && user.teacher? && !user.accepted_latest_terms? # Terms of Service dialog
     return false if GdprDialogHelper.show?(user, request)
+    return false if SchoolInfoInterstitialHelper.show?(user)
+    return false if SchoolInfoInterstitialHelper.show_confirmation_dialog?(user)
 
     return true
   end

--- a/dashboard/app/views/home/index.html.haml
+++ b/dashboard/app/views/home/index.html.haml
@@ -15,8 +15,10 @@
 - if current_user && current_user.teacher? && !current_user.accepted_latest_terms?
   = render partial: 'layouts/terms_interstitial'
 - elsif SchoolInfoInterstitialHelper.show_confirmation_dialog?(current_user) || @force_school_info_confirmation_dialog
+  - SchoolInfoInterstitialHelper.update_last_seen_timestamp(current_user)
   = render partial: 'layouts/school_info_confirmation_dialog'
 - elsif SchoolInfoInterstitialHelper.show?(current_user) || @force_school_info_interstitial
+  - SchoolInfoInterstitialHelper.update_last_seen_timestamp(current_user)
   = render partial: 'layouts/school_info_interstitial', locals: {show_header: false, user: current_user, form_name: "user[school_info_attributes]"}
 
 - if ThankDonorsInterstitialHelper.show?(current_user, request)

--- a/dashboard/app/views/pd/misc_survey/new.haml
+++ b/dashboard/app/views/pd/misc_survey/new.haml
@@ -1,4 +1,5 @@
 - if SchoolInfoInterstitialHelper.show?(current_user) || @force_school_info_interstitial
+  - SchoolInfoInterstitialHelper.update_last_seen_timestamp(current_user)
   = render partial: 'layouts/school_info_interstitial', locals: {show_header: false, user: current_user, form_name: "user[school_info_attributes]"}
 
 = render partial: 'pd/jotform_loader'

--- a/dashboard/test/helpers/thank_donors_interstitial_helper_test.rb
+++ b/dashboard/test/helpers/thank_donors_interstitial_helper_test.rb
@@ -5,6 +5,9 @@ class ThankDonorsInterstitialHelperTest < ActionView::TestCase
     @request = ActionDispatch::Request.new({})
     @request.stubs(:gdpr?).returns(false)
     @request.stubs(:params).returns({})
+
+    SchoolInfoInterstitialHelper.stubs(:show?).returns(false)
+    SchoolInfoInterstitialHelper.stubs(:show_confirmation_dialog?).returns(false)
   end
 
   test 'do not show thank donors interstitial if user is not signed in' do
@@ -21,6 +24,20 @@ class ThankDonorsInterstitialHelperTest < ActionView::TestCase
     student = build :user, birthday: nil
 
     refute ThankDonorsInterstitialHelper.show?(student, @request)
+  end
+
+  test 'do not show thank donors interstitial to teacher who will see school info interstitial' do
+    teacher = build :teacher, sign_in_count: 1, terms_of_service_version: 1
+
+    SchoolInfoInterstitialHelper.stubs(:show?).returns(true)
+    refute ThankDonorsInterstitialHelper.show?(teacher, @request)
+  end
+
+  test 'do not show thank donors interstitial to teacher who will see school info confirmation dialog' do
+    teacher = build :teacher, sign_in_count: 1, terms_of_service_version: 1
+
+    SchoolInfoInterstitialHelper.stubs(:show_confirmation_dialog?).returns(true)
+    refute ThankDonorsInterstitialHelper.show?(teacher, @request)
   end
 
   test 'do not show thank donors interstitial to teacher who has not accepted terms of service' do


### PR DESCRIPTION
@bethanyaconnor saw this one coming -- if a teacher signs up and a) did not provide school information, b) logged in once and c) never logs out, they can see both the school info and the thank donors interstitials at the same time:

![image](https://user-images.githubusercontent.com/25372625/90688015-a7311a80-e222-11ea-964a-37bb39ca59b2.png)

My change is to pref the school info dialog over thanking donors.

## Testing story

Added new unit tests to cover this change. Also created a new account and confirmed I see the dialog without error, and also logged in with an older account confirm I don't see the dialog.
