### PR TITLE
Update Course Description to allow for markdown and preview it on course edit page

### DIFF
--- a/apps/src/templates/courseOverview/CourseEditor.js
+++ b/apps/src/templates/courseOverview/CourseEditor.js
@@ -6,6 +6,8 @@ import CourseOverviewTopRow from './CourseOverviewTopRow';
 import {resourceShape} from './resourceType';
 import VisibleAndPilotExperiment from '../../lib/script-editor/VisibleAndPilotExperiment';
 import HelpTip from '@cdo/apps/lib/ui/HelpTip';
+import SafeMarkdown from '@cdo/apps/templates/SafeMarkdown';
+import color from '@cdo/apps/util/color';
 
 const styles = {
   input: {
@@ -21,6 +23,12 @@ const styles = {
   },
   dropdown: {
     margin: '0 6px'
+  },
+  box: {
+    marginTop: 10,
+    marginBottom: 10,
+    border: '1px solid ' + color.light_gray,
+    padding: 10
   }
 };
 
@@ -45,6 +53,23 @@ export default class CourseEditor extends Component {
     versionYearOptions: PropTypes.arrayOf(PropTypes.string).isRequired
   };
 
+  constructor(props) {
+    super(props);
+
+    this.state = {
+      descriptionStudent: this.props.descriptionStudent,
+      descriptionTeacher: this.props.descriptionTeacher
+    };
+  }
+
+  handleTeacherDescriptionChange = event => {
+    this.setState({descriptionTeacher: event.target.value});
+  };
+
+  handleStudentDescriptionChange = event => {
+    this.setState({descriptionStudent: event.target.value});
+  };
+
   render() {
     const {
       name,
@@ -53,8 +78,6 @@ export default class CourseEditor extends Component {
       familyName,
       versionYear,
       descriptionShort,
-      descriptionStudent,
-      descriptionTeacher,
       scriptsInCourse,
       scriptNames,
       teacherResources,
@@ -98,19 +121,35 @@ export default class CourseEditor extends Component {
           Student Description
           <textarea
             name="description_student"
-            defaultValue={descriptionStudent}
+            defaultValue={this.state.descriptionStudent}
             rows={5}
             style={styles.input}
+            onChange={this.handleStudentDescriptionChange}
           />
+          <div style={{marginBottom: 5}}>Preview:</div>
+          <div style={styles.box}>
+            <SafeMarkdown
+              openExternalLinksInNewTab={true}
+              markdown={this.state.descriptionStudent}
+            />
+          </div>
         </label>
         <label>
           Teacher Description
           <textarea
             name="description_teacher"
-            defaultValue={descriptionTeacher}
+            defaultValue={this.state.descriptionTeacher}
             rows={5}
             style={styles.input}
+            onChange={this.handleTeacherDescriptionChange}
           />
+          <div style={{marginBottom: 5}}>Preview:</div>
+          <div style={styles.box}>
+            <SafeMarkdown
+              openExternalLinksInNewTab={true}
+              markdown={this.state.descriptionTeacher}
+            />
+          </div>
         </label>
         <label>
           Version Year Display Name

--- a/apps/src/templates/courseOverview/CourseOverview.js
+++ b/apps/src/templates/courseOverview/CourseOverview.js
@@ -29,6 +29,7 @@ import AssignmentVersionSelector, {
 } from '@cdo/apps/templates/teacherDashboard/AssignmentVersionSelector';
 import StudentFeedbackNotification from '@cdo/apps/templates/feedback/StudentFeedbackNotification';
 import {sectionsForDropdown} from '@cdo/apps/templates/teacherDashboard/teacherSectionsRedux';
+import SafeMarkdown from '../SafeMarkdown';
 
 const styles = {
   main: {
@@ -222,11 +223,15 @@ class CourseOverview extends Component {
             />
           )}
         </div>
-        <div style={styles.description}>
-          {viewAs === ViewType.Student
-            ? descriptionStudent
-            : descriptionTeacher}
-        </div>
+        <SafeMarkdown
+          style={styles.description}
+          openExternalLinksInNewTab={true}
+          markdown={
+            viewAs === ViewType.Student
+              ? descriptionStudent
+              : descriptionTeacher
+          }
+        />
         {showNotification && <VerifiedResourcesNotification />}
         {isTeacher && (
           <div>

--- a/apps/test/unit/templates/courseOverview/CourseEditorTest.js
+++ b/apps/test/unit/templates/courseOverview/CourseEditorTest.js
@@ -19,8 +19,10 @@ const defaultProps = {
   visible: false,
   isStable: false,
   descriptionShort: 'Desc here',
-  descriptionStudent: 'Desc here',
-  descriptionTeacher: 'Desc here',
+  descriptionStudent:
+    '# Student description \n This is the course description with [link](https://studio.code.org/home) **Bold** *italics* ',
+  descriptionTeacher:
+    '# Teacher description \n This is the course description with [link](https://studio.code.org/home) **Bold** *italics* ',
   scriptsInCourse: ['CSP Unit 1', 'CSP Unit 2'],
   scriptNames: ['CSP Unit 1', 'CSP Unit 2'],
   teacherResources: [],
@@ -54,6 +56,46 @@ describe('CourseEditor', () => {
     assert.equal(wrapper.find('CourseScriptsEditor').length, 1);
     assert.equal(wrapper.find('ResourcesEditor').length, 1);
     assert.equal(wrapper.find('CourseOverviewTopRow').length, 1);
+  });
+
+  it('has correct markdown for preview of course teacher and student description', () => {
+    const wrapper = createWrapper({});
+    expect(wrapper.find('SafeMarkdown').length).to.equal(2);
+    expect(
+      wrapper
+        .find('SafeMarkdown')
+        .at(0)
+        .prop('markdown')
+    ).to.equal(
+      '# Student description \n This is the course description with [link](https://studio.code.org/home) **Bold** *italics* '
+    );
+    expect(
+      wrapper
+        .find('SafeMarkdown')
+        .at(1)
+        .prop('markdown')
+    ).to.equal(
+      '# Teacher description \n This is the course description with [link](https://studio.code.org/home) **Bold** *italics* '
+    );
+
+    wrapper
+      .find('textarea[name="description_student"]')
+      .simulate('change', {target: {value: '## Title 1'}});
+    expect(
+      wrapper
+        .find('SafeMarkdown')
+        .at(0)
+        .prop('markdown')
+    ).to.equal('## Title 1');
+    wrapper
+      .find('textarea[name="description_teacher"]')
+      .simulate('change', {target: {value: '## Title 2'}});
+    expect(
+      wrapper
+        .find('SafeMarkdown')
+        .at(1)
+        .prop('markdown')
+    ).to.equal('## Title 2');
   });
 
   describe('VisibleInTeacherDashboard', () => {

--- a/apps/test/unit/templates/courseOverview/CourseOverviewTest.js
+++ b/apps/test/unit/templates/courseOverview/CourseOverviewTest.js
@@ -11,8 +11,10 @@ const defaultProps = {
   title: 'Computer Science Principles 2017',
   assignmentFamilyTitle: 'Computer Science Principles',
   id: 30,
-  descriptionStudent: 'Desc here',
-  descriptionTeacher: 'Desc here',
+  descriptionStudent:
+    '# Student description \n This is the course description with [link](https://studio.code.org/home) **Bold** *italics* ',
+  descriptionTeacher:
+    '# Teacher description \n This is the course description with [link](https://studio.code.org/home) **Bold** *italics* ',
   sectionsInfo: [],
   teacherResources: [],
   isTeacher: true,
@@ -40,6 +42,26 @@ const defaultProps = {
 };
 
 describe('CourseOverview', () => {
+  it('has correct course description for teacher', () => {
+    const wrapper = shallow(<CourseOverview {...defaultProps} />);
+    expect(wrapper.find('SafeMarkdown').prop('markdown')).to.equal(
+      '# Teacher description \n This is the course description with [link](https://studio.code.org/home) **Bold** *italics* '
+    );
+  });
+
+  it('has correct course description for student', () => {
+    const wrapper = shallow(
+      <CourseOverview
+        {...defaultProps}
+        isTeacher={false}
+        viewAs={ViewType.Student}
+      />
+    );
+    expect(wrapper.find('SafeMarkdown').prop('markdown')).to.equal(
+      '# Student description \n This is the course description with [link](https://studio.code.org/home) **Bold** *italics* '
+    );
+  });
+
   it('renders a top row for teachers', () => {
     const wrapper = shallow(
       <CourseOverview {...defaultProps} isTeacher={true} />


### PR DESCRIPTION
Does the same thing for Course that https://github.com/code-dot-org/code-dot-org/pull/36346 did for Unit.

## Course Overview description shows markdown
![Screen Shot 2020-08-19 at 6 02 32 PM](https://user-images.githubusercontent.com/208083/90695480-84196180-e248-11ea-94bd-8e6fcc474070.png)


## Course Edit page previews descriptions

![Screen Shot 2020-08-19 at 6 01 58 PM](https://user-images.githubusercontent.com/208083/90695658-cf337480-e248-11ea-952b-86714e9e85ef.png)

## Links

<!--
  Any relevant links to external resources; ie, specification documents, jira
  items, related PRs, honeybadger errors, etc
-->

- [spec](https://docs.google.com/document/d/1wubJ6xRhdmuV9d25i5SgEzrCKcR1VjuErcv7GzL0Y0Y/edit#)
- [jira](https://codedotorg.atlassian.net/browse/PLAT-259)

## Testing story

- Added tests to CourseEditor and CourseOverview

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
