### PR TITLE
Use AWS secret for chef config overrides

### DIFF
--- a/aws/cloudformation/bootstrap_chef_stack.sh.erb
+++ b/aws/cloudformation/bootstrap_chef_stack.sh.erb
@@ -10,7 +10,7 @@ REGION=${AWS::Region}
 BRANCH=${Branch}
 S3_BUCKET=<%=S3_BUCKET%>
 ENVIRONMENT=<%=environment%>
-RUN_LIST='<%=run_list.to_json%>'
+RUN_LIST='<%=run_list.join(',')%>'
 INSTANCE_ID=$(curl -s http://169.254.169.254/latest/meta-data/instance-id)
 NODE_NAME=<%=node_name%>
 RESOURCE_ID=<%=resource_id%>
@@ -126,14 +126,36 @@ cat <<JSON > $FIRST_BOOT
     "daemon": true
   },
 <% end -%>
-  "run_list": $RUN_LIST
+  "run_list": []
 }
 JSON
 
-# Provision via Chef.
-OPTIONS="<%=cookbooks_path ? '-z ' : ''%> -b $BRANCH -n $NODE_NAME -r '$RUN_LIST' -e $ENVIRONMENT -v $CHEF_VERSION"
+# Bootstrap Chef configuration: Install Chef, run chef-client with empty run-list to create node with first-boot config.
+OPTIONS="<%=cookbooks_path ? '-z ' : ''%> -b $BRANCH -n $NODE_NAME -r '' -e $ENVIRONMENT -v $CHEF_VERSION"
 sudo -u ubuntu bash -c "aws s3 cp <%=bootstrap_script_path%> - | sudo bash -s -- $OPTIONS"
 [ $? -eq 0 ] && STATUS=SUCCESS || STATUS=<%=daemon ? 'SUCCESS' : 'FAILURE'%>
+
+# Bash script that invokes chef-client with fetched config attributes and provided run-list.
+CHEF_CLIENT_BIN=<%=CHEF_CLIENT_BIN%>
+cat <<SH > $CHEF_CLIENT_BIN
+#!/bin/bash
+CHEF_CONFIG=\$(mktemp)
+aws secretsmanager get-secret-value \\
+  --region $REGION \\
+  --secret-id ${ChefConfig} \\
+  --version-stage AWSCURRENT \\
+  --query SecretString \\
+  --output text \\
+  > \$CHEF_CONFIG
+/opt/chef/bin/chef-client \\
+  --runlist '$RUN_LIST' \\
+  --chef-license accept-silent \\
+  --json-attributes \$CHEF_CONFIG
+rm -f "\$CHEF_CONFIG"
+SH
+chmod +x $CHEF_CLIENT_BIN
+# Run chef-client as root with SUDO_USER set to `ubuntu`.
+sudo -u ubuntu bash -c "sudo $CHEF_CLIENT_BIN"
 
 <% unless daemon -%>
 # Workaround for version-controlled files modified by seed.

--- a/aws/cloudformation/bootstrap_chef_stack.sh.erb
+++ b/aws/cloudformation/bootstrap_chef_stack.sh.erb
@@ -135,10 +135,11 @@ OPTIONS="<%=cookbooks_path ? '-z ' : ''%> -b $BRANCH -n $NODE_NAME -r '' -e $ENV
 sudo -u ubuntu bash -c "aws s3 cp <%=bootstrap_script_path%> - | sudo bash -s -- $OPTIONS"
 [ $? -eq 0 ] && STATUS=SUCCESS || STATUS=<%=daemon ? 'SUCCESS' : 'FAILURE'%>
 
-# Bash script that invokes chef-client with fetched config attributes and provided run-list.
-CHEF_CLIENT_BIN=<%=CHEF_CLIENT_BIN%>
-cat <<SH > $CHEF_CLIENT_BIN
+CHEF_CDO_APP=<%=CdoApp::CHEF_BIN%>
+cat <<SH > $CHEF_CDO_APP
 #!/bin/bash
+# Provisions the Code.org application using Chef.
+# Invokes chef-client with fetched config attributes and provided run-list.
 CHEF_CONFIG=\$(mktemp)
 aws secretsmanager get-secret-value \\
   --region $REGION \\
@@ -153,9 +154,9 @@ aws secretsmanager get-secret-value \\
   --json-attributes \$CHEF_CONFIG
 rm -f "\$CHEF_CONFIG"
 SH
-chmod +x $CHEF_CLIENT_BIN
+chmod +x $CHEF_CDO_APP
 # Run chef-client as root with SUDO_USER set to `ubuntu`.
-sudo -u ubuntu bash -c "sudo $CHEF_CLIENT_BIN"
+sudo -u ubuntu bash -c "sudo $CHEF_CDO_APP"
 
 <% unless daemon -%>
 # Workaround for version-controlled files modified by seed.

--- a/aws/cloudformation/cloud_formation_stack.yml.erb
+++ b/aws/cloudformation/cloud_formation_stack.yml.erb
@@ -28,6 +28,7 @@ Resources:
             Action: 'secretsmanager:GetSecretValue'
             Resource:
               - !Sub "arn:aws:secretsmanager:${AWS::Region}:${AWS::AccountId}:secret:<%=environment%>/cdo/*"
+              - !Ref ChefConfig
 <% if database -%>
               - !Ref DatabaseSecret
 <% end -%>
@@ -458,6 +459,12 @@ Resources:
 <% if database-%>
 <%=  component 'database'%>
 <% end -%>
+  ChefConfig:
+    Type: AWS::SecretsManager::Secret
+    Properties:
+      Description: !Sub "Custom Chef attributes for ${AWS::StackName} CloudFormation stack"
+      Name: !Sub "CfnStack/${AWS::StackName}/chef"
+      SecretString: '{}'
 Outputs:
   DashboardURL:
     Value: "https://<%=studio_subdomain%>"

--- a/aws/cloudformation/cloud_formation_stack.yml.erb
+++ b/aws/cloudformation/cloud_formation_stack.yml.erb
@@ -464,6 +464,8 @@ Resources:
     Properties:
       Description: !Sub "Custom Chef attributes for ${AWS::StackName} CloudFormation stack"
       Name: !Sub "CfnStack/${AWS::StackName}/chef"
+      # Update this secret manually after the stack is created to customize Chef configuration.
+      # The value should never be changed in the stack itself, since it would clobber all other changes.
       SecretString: '{}'
 Outputs:
   DashboardURL:

--- a/lib/cdo/cloud_formation/cdo_app.rb
+++ b/lib/cdo/cloud_formation/cdo_app.rb
@@ -24,6 +24,7 @@ module Cdo::CloudFormation
     end
 
     # Hard-coded constants and default values.
+    CHEF_CLIENT_BIN = '/usr/local/bin/chef-client'
     CHEF_KEY = rack_env?(:adhoc) ? 'adhoc/chef' : 'chef'
     IMAGE_ID = ENV['IMAGE_ID'] || 'ami-07d0cf3af28718ef8' # ubuntu/images/hvm-ssd/ubuntu-bionic-18.04-amd64-server-20190722.1
     INSTANCE_TYPE = rack_env?(:production) ? 'm5.12xlarge' : 't2.2xlarge'

--- a/lib/cdo/cloud_formation/cdo_app.rb
+++ b/lib/cdo/cloud_formation/cdo_app.rb
@@ -24,7 +24,7 @@ module Cdo::CloudFormation
     end
 
     # Hard-coded constants and default values.
-    CHEF_CLIENT_BIN = '/usr/local/bin/chef-client'
+    CHEF_BIN = '/usr/local/bin/chef-cdo-app'
     CHEF_KEY = rack_env?(:adhoc) ? 'adhoc/chef' : 'chef'
     IMAGE_ID = ENV['IMAGE_ID'] || 'ami-07d0cf3af28718ef8' # ubuntu/images/hvm-ssd/ubuntu-bionic-18.04-amd64-server-20190722.1
     INSTANCE_TYPE = rack_env?(:production) ? 'm5.12xlarge' : 't2.2xlarge'

--- a/lib/rake/ci.rake
+++ b/lib/rake/ci.rake
@@ -33,7 +33,7 @@ namespace :ci do
         RakeUtils.bundle_exec 'berks', 'apply', rack_env
 
         ChatClient.log 'Applying <b>chef</b> profile...'
-        RakeUtils.sudo Cdo::CloudFormation::CdoApp::CHEF_CLIENT_BIN
+        RakeUtils.sudo Cdo::CloudFormation::CdoApp::CHEF_BIN
       end
     end
   end
@@ -118,7 +118,7 @@ end
 # Returns true if upgrade succeeded, false if failed.
 def upgrade_frontend(name, hostname)
   ChatClient.log "Upgrading <b>#{name}</b> (#{hostname})..."
-  command = "sudo #{Cdo::CloudFormation::CdoApp::CHEF_CLIENT_BIN}"
+  command = "sudo #{Cdo::CloudFormation::CdoApp::CHEF_BIN}"
   log_path = aws_dir "deploy-#{name}.log"
   begin
     RakeUtils.system "ssh -i ~/.ssh/deploy-id_rsa #{hostname} '#{command} 2>&1' >> #{log_path}"

--- a/lib/rake/ci.rake
+++ b/lib/rake/ci.rake
@@ -33,7 +33,7 @@ namespace :ci do
         RakeUtils.bundle_exec 'berks', 'apply', rack_env
 
         ChatClient.log 'Applying <b>chef</b> profile...'
-        RakeUtils.sudo '/opt/chef/bin/chef-client --chef-license accept-silent'
+        RakeUtils.sudo Cdo::CloudFormation::CdoApp::CHEF_CLIENT_BIN
       end
     end
   end
@@ -118,7 +118,7 @@ end
 # Returns true if upgrade succeeded, false if failed.
 def upgrade_frontend(name, hostname)
   ChatClient.log "Upgrading <b>#{name}</b> (#{hostname})..."
-  command = 'sudo /opt/chef/bin/chef-client --chef-license accept-silent'
+  command = "sudo #{Cdo::CloudFormation::CdoApp::CHEF_CLIENT_BIN}"
   log_path = aws_dir "deploy-#{name}.log"
   begin
     RakeUtils.system "ssh -i ~/.ssh/deploy-id_rsa #{hostname} '#{command} 2>&1' >> #{log_path}"


### PR DESCRIPTION
# Use AWS secret for chef config overrides
## Overview

This PR adds a Secrets Manager secret to the Code.org application CloudFormation stack. The secret is a JSON string containing stack-wide Chef cookbook attributes. The value contained in this secret is passed as an argument to `chef-client` whenever our system invokes Chef, whether as part of its bootstrapping process or through a CI build.

## Background

This AWS secret providing chef-config attributes will help transition existing cookbooks comprising our application's provisioning process from hosted to local-mode Chef. Specifically, the Chef [Environment Attributes](https://docs.chef.io/environments/#environment-attributes) and [Role Attributes](https://docs.chef.io/roles/#role-attributes) currently stored in Hosted Chef Server will be manually merged and stored in this secret, then eventually deleted from the Hosted Chef resources.

This is the last part of our Chef provisioning depending on state stored in the Hosted Chef Server repo.

## Implementation details

- The `SecretsManager::Secret` resource's logical id is ChefConfig, and the secret name is `CfnStack/[StackName]/chef`.
- To ensure the secret can be passed as an argument to `chef-client` whenever our system runs Chef, a new shell script is written to `Cdo::CloudFormation::CdoApp::CHEF_CLIENT_BIN` (a constant equal to `'/usr/local/bin/chef-client'`) which fetches the secret (via [`aws secretsmanager get-secret-value`](https://docs.aws.amazon.com/cli/latest/reference/secretsmanager/get-secret-value.html)) and passes it to [`chef-client`](https://docs.chef.io/ctl_chef_client/) (via the `--json-attributes` [option](https://docs.chef.io/ctl_chef_client/#options)). Existing calls to `/opt/chef/bin/chef-client` in our CI build scripts have been updated to call this helper script instead.
- Our bootstrap also sets a number of Chef attributes through a `first-boot.json` file it creates. In order to ensure these first-boot attributes are applied in addition to the secret attributes, a separate call to `chef-client` with an empty runlist is now done first to persist the first-boot attributes to the newly-created Chef node.

## Test Story

- Deployed a new adhoc instance and verified it provisions correctly
- Modified a Chef attribute within the created secret on the adhoc stack
- Manually ran an additional CI build on the adhoc instance and verified it ran correctly and used the Chef attribute from the updated secret

## Migration Plan

- [ ] Merge this PR which will update the bootstrap scripts and create an empty secret in each application-stack (each infrastructure-managed environment)
  - [ ] Verify deploy without issue
- [ ] Copy attributes from Hosted Chef resources to secret (merging Environment-specific attributes with the `baseline` role attributes for each stack/environment)
  - [ ] Verify deploy without issue
- [ ] Remove attributes from Hosted Chef resources
  - [ ] Verify deploy without issue