### PR TITLE
Create MarkdownPreview component for edit pages

### DIFF
--- a/apps/src/lib/script-editor/MarkdownPreview.jsx
+++ b/apps/src/lib/script-editor/MarkdownPreview.jsx
@@ -1,0 +1,36 @@
+import PropTypes from 'prop-types';
+import React from 'react';
+import SafeMarkdown from '@cdo/apps/templates/SafeMarkdown';
+import color from '@cdo/apps/util/color';
+
+const styles = {
+  box: {
+    marginTop: 10,
+    marginBottom: 10,
+    border: '1px solid ' + color.light_gray,
+    padding: 10
+  }
+};
+
+/**
+ * Component for previewing Markdown for a edit field
+ */
+export default class MarkdownPreview extends React.Component {
+  static propTypes = {
+    markdown: PropTypes.string.isRequired
+  };
+
+  render() {
+    return (
+      <div>
+        <div style={{marginBottom: 5}}>Preview:</div>
+        <div style={styles.box}>
+          <SafeMarkdown
+            openExternalLinksInNewTab={true}
+            markdown={this.props.markdown}
+          />
+        </div>
+      </div>
+    );
+  }
+}

--- a/apps/src/lib/script-editor/ScriptEditor.jsx
+++ b/apps/src/lib/script-editor/ScriptEditor.jsx
@@ -15,8 +15,8 @@ import {announcementShape} from '@cdo/apps/code-studio/scriptAnnouncementsRedux'
 import VisibleAndPilotExperiment from './VisibleAndPilotExperiment';
 import HelpTip from '@cdo/apps/lib/ui/HelpTip';
 import LessonExtrasEditor from './LessonExtrasEditor';
-import SafeMarkdown from '@cdo/apps/templates/SafeMarkdown';
 import color from '@cdo/apps/util/color';
+import MarkdownPreview from '@cdo/apps/lib/script-editor/MarkdownPreview';
 
 const styles = {
   input: {
@@ -185,13 +185,7 @@ export default class ScriptEditor extends React.Component {
             style={styles.input}
             onChange={this.handleDescriptionChange}
           />
-          <div style={{marginBottom: 5}}>Preview:</div>
-          <div style={styles.box}>
-            <SafeMarkdown
-              openExternalLinksInNewTab={true}
-              markdown={this.state.description}
-            />
-          </div>
+          <MarkdownPreview markdown={this.state.description} />
         </label>
         <h2>Basic Settings</h2>
         <label>

--- a/apps/src/templates/courseOverview/CourseEditor.js
+++ b/apps/src/templates/courseOverview/CourseEditor.js
@@ -6,6 +6,8 @@ import CourseOverviewTopRow from './CourseOverviewTopRow';
 import {resourceShape} from './resourceType';
 import VisibleAndPilotExperiment from '../../lib/script-editor/VisibleAndPilotExperiment';
 import HelpTip from '@cdo/apps/lib/ui/HelpTip';
+import SafeMarkdown from '@cdo/apps/templates/SafeMarkdown';
+import color from '@cdo/apps/util/color';
 
 const styles = {
   input: {
@@ -21,6 +23,12 @@ const styles = {
   },
   dropdown: {
     margin: '0 6px'
+  },
+  box: {
+    marginTop: 10,
+    marginBottom: 10,
+    border: '1px solid ' + color.light_gray,
+    padding: 10
   }
 };
 
@@ -45,6 +53,23 @@ export default class CourseEditor extends Component {
     versionYearOptions: PropTypes.arrayOf(PropTypes.string).isRequired
   };
 
+  constructor(props) {
+    super(props);
+
+    this.state = {
+      descriptionStudent: this.props.descriptionStudent,
+      descriptionTeacher: this.props.descriptionTeacher
+    };
+  }
+
+  handleTeacherDescriptionChange = event => {
+    this.setState({descriptionTeacher: event.target.value});
+  };
+
+  handleStudentDescriptionChange = event => {
+    this.setState({descriptionStudent: event.target.value});
+  };
+
   render() {
     const {
       name,
@@ -53,8 +78,6 @@ export default class CourseEditor extends Component {
       familyName,
       versionYear,
       descriptionShort,
-      descriptionStudent,
-      descriptionTeacher,
       scriptsInCourse,
       scriptNames,
       teacherResources,
@@ -98,19 +121,35 @@ export default class CourseEditor extends Component {
           Student Description
           <textarea
             name="description_student"
-            defaultValue={descriptionStudent}
+            defaultValue={this.state.descriptionStudent}
             rows={5}
             style={styles.input}
+            onChange={this.handleStudentDescriptionChange}
           />
+          <div style={{marginBottom: 5}}>Preview:</div>
+          <div style={styles.box}>
+            <SafeMarkdown
+              openExternalLinksInNewTab={true}
+              markdown={this.state.descriptionStudent}
+            />
+          </div>
         </label>
         <label>
           Teacher Description
           <textarea
             name="description_teacher"
-            defaultValue={descriptionTeacher}
+            defaultValue={this.state.descriptionTeacher}
             rows={5}
             style={styles.input}
+            onChange={this.handleTeacherDescriptionChange}
           />
+          <div style={{marginBottom: 5}}>Preview:</div>
+          <div style={styles.box}>
+            <SafeMarkdown
+              openExternalLinksInNewTab={true}
+              markdown={this.state.descriptionTeacher}
+            />
+          </div>
         </label>
         <label>
           Version Year Display Name

--- a/apps/src/templates/courseOverview/CourseEditor.js
+++ b/apps/src/templates/courseOverview/CourseEditor.js
@@ -6,8 +6,8 @@ import CourseOverviewTopRow from './CourseOverviewTopRow';
 import {resourceShape} from './resourceType';
 import VisibleAndPilotExperiment from '../../lib/script-editor/VisibleAndPilotExperiment';
 import HelpTip from '@cdo/apps/lib/ui/HelpTip';
-import SafeMarkdown from '@cdo/apps/templates/SafeMarkdown';
 import color from '@cdo/apps/util/color';
+import MarkdownPreview from '@cdo/apps/lib/script-editor/MarkdownPreview';
 
 const styles = {
   input: {
@@ -126,13 +126,7 @@ export default class CourseEditor extends Component {
             style={styles.input}
             onChange={this.handleStudentDescriptionChange}
           />
-          <div style={{marginBottom: 5}}>Preview:</div>
-          <div style={styles.box}>
-            <SafeMarkdown
-              openExternalLinksInNewTab={true}
-              markdown={this.state.descriptionStudent}
-            />
-          </div>
+          <MarkdownPreview markdown={this.state.descriptionStudent} />
         </label>
         <label>
           Teacher Description
@@ -143,13 +137,7 @@ export default class CourseEditor extends Component {
             style={styles.input}
             onChange={this.handleTeacherDescriptionChange}
           />
-          <div style={{marginBottom: 5}}>Preview:</div>
-          <div style={styles.box}>
-            <SafeMarkdown
-              openExternalLinksInNewTab={true}
-              markdown={this.state.descriptionTeacher}
-            />
-          </div>
+          <MarkdownPreview markdown={this.state.descriptionTeacher} />
         </label>
         <label>
           Version Year Display Name

--- a/apps/src/templates/courseOverview/CourseOverview.js
+++ b/apps/src/templates/courseOverview/CourseOverview.js
@@ -29,6 +29,7 @@ import AssignmentVersionSelector, {
 } from '@cdo/apps/templates/teacherDashboard/AssignmentVersionSelector';
 import StudentFeedbackNotification from '@cdo/apps/templates/feedback/StudentFeedbackNotification';
 import {sectionsForDropdown} from '@cdo/apps/templates/teacherDashboard/teacherSectionsRedux';
+import SafeMarkdown from '../SafeMarkdown';
 
 const styles = {
   main: {
@@ -222,11 +223,15 @@ class CourseOverview extends Component {
             />
           )}
         </div>
-        <div style={styles.description}>
-          {viewAs === ViewType.Student
-            ? descriptionStudent
-            : descriptionTeacher}
-        </div>
+        <SafeMarkdown
+          style={styles.description}
+          openExternalLinksInNewTab={true}
+          markdown={
+            viewAs === ViewType.Student
+              ? descriptionStudent
+              : descriptionTeacher
+          }
+        />
         {showNotification && <VerifiedResourcesNotification />}
         {isTeacher && (
           <div>

--- a/apps/test/unit/lib/script-editor/MarkdownPreviewTest.jsx
+++ b/apps/test/unit/lib/script-editor/MarkdownPreviewTest.jsx
@@ -1,0 +1,19 @@
+import {expect} from 'chai';
+import React from 'react';
+import {mount} from 'enzyme';
+import MarkdownPreview from '@cdo/apps/lib/script-editor/MarkdownPreview';
+
+const DEFAULT_PROPS = {
+  markdown:
+    '# Title \n This is the unit description with [link](https://studio.code.org/home) **Bold** *italics*'
+};
+
+describe('ScriptEditor', () => {
+  it('has correct markdown for preview of unit description', () => {
+    const wrapper = mount(<MarkdownPreview {...DEFAULT_PROPS} />);
+    expect(wrapper.find('SafeMarkdown').length).to.equal(1);
+    expect(wrapper.find('SafeMarkdown').prop('markdown')).to.equal(
+      '# Title \n This is the unit description with [link](https://studio.code.org/home) **Bold** *italics*'
+    );
+  });
+});

--- a/apps/test/unit/lib/script-editor/ScriptEditorTest.jsx
+++ b/apps/test/unit/lib/script-editor/ScriptEditorTest.jsx
@@ -31,15 +31,15 @@ describe('ScriptEditor', () => {
 
     it('has correct markdown for preview of unit description', () => {
       const wrapper = mount(<ScriptEditor {...DEFAULT_PROPS} hidden={false} />);
-      expect(wrapper.find('SafeMarkdown').length).to.equal(1);
-      expect(wrapper.find('SafeMarkdown').prop('markdown')).to.equal(
+      expect(wrapper.find('MarkdownPreview').length).to.equal(1);
+      expect(wrapper.find('MarkdownPreview').prop('markdown')).to.equal(
         '# Title \n This is the unit description with [link](https://studio.code.org/home) **Bold** *italics*'
       );
 
       wrapper
         .find('textarea[name="description"]')
         .simulate('change', {target: {value: '## Title'}});
-      expect(wrapper.find('SafeMarkdown').prop('markdown')).to.equal(
+      expect(wrapper.find('MarkdownPreview').prop('markdown')).to.equal(
         '## Title'
       );
     });

--- a/apps/test/unit/templates/courseOverview/CourseEditorTest.js
+++ b/apps/test/unit/templates/courseOverview/CourseEditorTest.js
@@ -19,8 +19,10 @@ const defaultProps = {
   visible: false,
   isStable: false,
   descriptionShort: 'Desc here',
-  descriptionStudent: 'Desc here',
-  descriptionTeacher: 'Desc here',
+  descriptionStudent:
+    '# Student description \n This is the course description with [link](https://studio.code.org/home) **Bold** *italics* ',
+  descriptionTeacher:
+    '# Teacher description \n This is the course description with [link](https://studio.code.org/home) **Bold** *italics* ',
   scriptsInCourse: ['CSP Unit 1', 'CSP Unit 2'],
   scriptNames: ['CSP Unit 1', 'CSP Unit 2'],
   teacherResources: [],
@@ -54,6 +56,46 @@ describe('CourseEditor', () => {
     assert.equal(wrapper.find('CourseScriptsEditor').length, 1);
     assert.equal(wrapper.find('ResourcesEditor').length, 1);
     assert.equal(wrapper.find('CourseOverviewTopRow').length, 1);
+  });
+
+  it('has correct markdown for preview of course teacher and student description', () => {
+    const wrapper = createWrapper({});
+    expect(wrapper.find('SafeMarkdown').length).to.equal(2);
+    expect(
+      wrapper
+        .find('SafeMarkdown')
+        .at(0)
+        .prop('markdown')
+    ).to.equal(
+      '# Student description \n This is the course description with [link](https://studio.code.org/home) **Bold** *italics* '
+    );
+    expect(
+      wrapper
+        .find('SafeMarkdown')
+        .at(1)
+        .prop('markdown')
+    ).to.equal(
+      '# Teacher description \n This is the course description with [link](https://studio.code.org/home) **Bold** *italics* '
+    );
+
+    wrapper
+      .find('textarea[name="description_student"]')
+      .simulate('change', {target: {value: '## Title 1'}});
+    expect(
+      wrapper
+        .find('SafeMarkdown')
+        .at(0)
+        .prop('markdown')
+    ).to.equal('## Title 1');
+    wrapper
+      .find('textarea[name="description_teacher"]')
+      .simulate('change', {target: {value: '## Title 2'}});
+    expect(
+      wrapper
+        .find('SafeMarkdown')
+        .at(1)
+        .prop('markdown')
+    ).to.equal('## Title 2');
   });
 
   describe('VisibleInTeacherDashboard', () => {

--- a/apps/test/unit/templates/courseOverview/CourseEditorTest.js
+++ b/apps/test/unit/templates/courseOverview/CourseEditorTest.js
@@ -60,10 +60,10 @@ describe('CourseEditor', () => {
 
   it('has correct markdown for preview of course teacher and student description', () => {
     const wrapper = createWrapper({});
-    expect(wrapper.find('SafeMarkdown').length).to.equal(2);
+    expect(wrapper.find('MarkdownPreview').length).to.equal(2);
     expect(
       wrapper
-        .find('SafeMarkdown')
+        .find('MarkdownPreview')
         .at(0)
         .prop('markdown')
     ).to.equal(
@@ -71,7 +71,7 @@ describe('CourseEditor', () => {
     );
     expect(
       wrapper
-        .find('SafeMarkdown')
+        .find('MarkdownPreview')
         .at(1)
         .prop('markdown')
     ).to.equal(
@@ -83,7 +83,7 @@ describe('CourseEditor', () => {
       .simulate('change', {target: {value: '## Title 1'}});
     expect(
       wrapper
-        .find('SafeMarkdown')
+        .find('MarkdownPreview')
         .at(0)
         .prop('markdown')
     ).to.equal('## Title 1');
@@ -92,7 +92,7 @@ describe('CourseEditor', () => {
       .simulate('change', {target: {value: '## Title 2'}});
     expect(
       wrapper
-        .find('SafeMarkdown')
+        .find('MarkdownPreview')
         .at(1)
         .prop('markdown')
     ).to.equal('## Title 2');

--- a/apps/test/unit/templates/courseOverview/CourseOverviewTest.js
+++ b/apps/test/unit/templates/courseOverview/CourseOverviewTest.js
@@ -11,8 +11,10 @@ const defaultProps = {
   title: 'Computer Science Principles 2017',
   assignmentFamilyTitle: 'Computer Science Principles',
   id: 30,
-  descriptionStudent: 'Desc here',
-  descriptionTeacher: 'Desc here',
+  descriptionStudent:
+    '# Student description \n This is the course description with [link](https://studio.code.org/home) **Bold** *italics* ',
+  descriptionTeacher:
+    '# Teacher description \n This is the course description with [link](https://studio.code.org/home) **Bold** *italics* ',
   sectionsInfo: [],
   teacherResources: [],
   isTeacher: true,
@@ -40,6 +42,26 @@ const defaultProps = {
 };
 
 describe('CourseOverview', () => {
+  it('has correct course description for teacher', () => {
+    const wrapper = shallow(<CourseOverview {...defaultProps} />);
+    expect(wrapper.find('SafeMarkdown').prop('markdown')).to.equal(
+      '# Teacher description \n This is the course description with [link](https://studio.code.org/home) **Bold** *italics* '
+    );
+  });
+
+  it('has correct course description for student', () => {
+    const wrapper = shallow(
+      <CourseOverview
+        {...defaultProps}
+        isTeacher={false}
+        viewAs={ViewType.Student}
+      />
+    );
+    expect(wrapper.find('SafeMarkdown').prop('markdown')).to.equal(
+      '# Student description \n This is the course description with [link](https://studio.code.org/home) **Bold** *italics* '
+    );
+  });
+
   it('renders a top row for teachers', () => {
     const wrapper = shallow(
       <CourseOverview {...defaultProps} isTeacher={true} />


### PR DESCRIPTION
Follow up to https://github.com/code-dot-org/code-dot-org/pull/36363 and https://github.com/code-dot-org/code-dot-org/pull/36346. Creates a simple component for the markdown preview that can be used on editing pages. Looks the same as what is in those PRs just extracts out the logic into one place.

## Testing story

-Updated ScriptEditorTest and CourseEditorTest
-Created test for MarkdownPreview

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
