### PR TITLE
Use session length for workshop last valid day to avoid Jotform errors

### DIFF
--- a/dashboard/app/models/pd/workshop.rb
+++ b/dashboard/app/models/pd/workshop.rb
@@ -872,9 +872,15 @@ class Pd::Workshop < ActiveRecord::Base
 
   def last_valid_day
     last_day = sessions.size
-    unless VALID_DAYS[CATEGORY_MAP[subject]].include? last_day
+
+    # If we don't have Jotform survey constants set up for this workshop,
+    # return the session size to avoid erroring out in the next step.
+    return last_day if VALID_DAYS[CATEGORY_MAP[subject]].nil?
+
+    unless VALID_DAYS[CATEGORY_MAP[subject]].include?(last_day)
       last_day = VALID_DAYS[CATEGORY_MAP[subject]].last
     end
+
     last_day
   end
 


### PR DESCRIPTION
Fix for this [Honeybadger error](https://app.honeybadger.io/projects/45435/faults/66886021), which occurs when we don't have Jotform daily survey constants set up for a given workshop subject.

## Testing story

I tested manually that this method works for a "Virtual Workshop Kickoff" subject workshop that I created locally, which we believe is what caused the HB error.