### PR TITLE
Disable recording of time_spent while we convert current records from milliseconds to seconds

### DIFF
--- a/dashboard/app/controllers/activities_controller.rb
+++ b/dashboard/app/controllers/activities_controller.rb
@@ -178,7 +178,8 @@ class ActivitiesController < ApplicationController
       @activity = Activity.new(attributes).tap(&:atomic_save!)
     end
     if @script_level
-      time_since_last_milestone = [params[:timeSinceLastMilestone].to_i, MAX_INT_MILESTONE].min
+      # convert milliseconds to seconds
+      time_since_last_milestone = [(params[:timeSinceLastMilestone].to_f / 1000).ceil.to_i, MAX_INT_MILESTONE].min
       @user_level, @new_level_completed = User.track_level_progress(
         user_id: current_user.id,
         level_id: @level.id,

--- a/dashboard/app/models/user.rb
+++ b/dashboard/app/models/user.rb
@@ -1780,8 +1780,9 @@ class User < ActiveRecord::Base
         user_level.level_source_id = level_source_id
       end
 
-      total_time_spent = user_level.calculate_total_time_spent(time_spent)
-      user_level.time_spent = total_time_spent if total_time_spent
+      # Temporarily disabling while we convert current records from milliseconds to seconds
+      # total_time_spent = user_level.calculate_total_time_spent(time_spent)
+      # user_level.time_spent = total_time_spent if total_time_spent
 
       user_level.atomic_save!
     end

--- a/dashboard/test/controllers/activities_controller_test.rb
+++ b/dashboard/test/controllers/activities_controller_test.rb
@@ -161,6 +161,7 @@ class ActivitiesControllerTest < ActionController::TestCase
   end
 
   test "milestone updates existing user_level with time_spent" do
+    skip 'temporarily disabling while we convert time_spent from milliseconds to seconds'
     @level = create(:level, :blockly, :with_ideal_level_source)
     @script = create(:script)
     @script.update(curriculum_umbrella: 'CSF')
@@ -1021,7 +1022,8 @@ class ActivitiesControllerTest < ActionController::TestCase
 
     existing_navigator_user_level.reload
     assert_equal 100, existing_navigator_user_level.best_result
-    assert_equal 2000, existing_navigator_user_level.time_spent
+    # temporarily disabling while we convert time_spent from milliseconds to seconds
+    # assert_equal 2000, existing_navigator_user_level.time_spent
 
     assert_equal [@user], existing_navigator_user_level.driver_user_levels.map(&:user)
   end
@@ -1043,7 +1045,8 @@ class ActivitiesControllerTest < ActionController::TestCase
 
     existing_driver_user_level.reload
     assert_equal 100, existing_driver_user_level.best_result
-    assert_equal 2000, existing_driver_user_level.time_spent
+    # temporarily disabling while we convert time_spent from milliseconds to seconds
+    # assert_equal 2000, existing_driver_user_level.time_spent
 
     assert_equal [pairing], existing_driver_user_level.navigator_user_levels.map(&:user)
   end


### PR DESCRIPTION
This PR temporarily disables recording of time_spent to the user_levels table. (PR That implemented: https://github.com/code-dot-org/code-dot-org/pull/36121)

Given that the mysql limit for an integer is 2,147,483,648 (roughly 25 days when measured in milliseconds), we realized we needed capacity for longer periods of time to be recorded in the time_spent field. It is reasonable to expect a student may spent more than 25 days of total time on a long-term project. Additionally, we continue recording time_spent if the student leaves their browser window open but is not actively working on their computer, which could also increase the time a student spends on their project.

time_spent is currently recording milliseconds. Intervals of time less than one second are not useful for these purposes. Instead, we will record seconds. This will give us capacity to record over 68 years of time_spent on a user_level.

To migrate to recording seconds, we need to take two actions. 
1. Divide the time sent from the client by 1000
1. Migrate all existing records to seconds
    a. Stop recording time_spent
    b. Migrate all existing records from milliseconds to seconds
    c. Re-enable recording time_spent

This PR achieves steps 1 and 2a

Internal folks can read more details in this [slack thread](https://codedotorg.slack.com/archives/CA3KCSGTD/p1597953122018000).
<!--
  Your description goes here: A summary of the change, including any relevant motivation and context.

  If relevant, include a description both of the existing behavior and of the new behavior.
-->

<!--
  Other aspects to consider. uncomment and add detail for any that seem necessary:
-->

<!-- ### Background -->
<!-- ### Privacy -->
<!-- ### Security -->
<!-- ### Caching -->
<!-- ### Deployment strategy -->
<!-- ### Future work -->

## Links

- [Jira](https://codedotorg.atlassian.net/browse/LP-1532)

<!--
  Any relevant links to external resources; ie, specification documents, jira
  items, related PRs, honeybadger errors, etc
-->


## Testing story

<!--
  Does your change include appropriate tests?

  If so, please describe how the tests included in this PR are sufficient

  If not, please explain why this change does not need to be tested.
-->

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
