### PR TITLE
Make Course Overview Page and Editor Page Use Same Teacher Resources Button as Script

### DIFF
--- a/apps/src/code-studio/components/progress/ScriptOverviewTopRow.jsx
+++ b/apps/src/code-studio/components/progress/ScriptOverviewTopRow.jsx
@@ -3,17 +3,14 @@ import React from 'react';
 import {connect} from 'react-redux';
 import i18n from '@cdo/locale';
 import Button from '@cdo/apps/templates/Button';
-import DropdownButton from '@cdo/apps/templates/DropdownButton';
 import ProgressDetailToggle from '@cdo/apps/templates/progress/ProgressDetailToggle';
 import {ViewType} from '@cdo/apps/code-studio/viewAsRedux';
-import {
-  stringForType,
-  resourceShape
-} from '@cdo/apps/templates/courseOverview/resourceType';
+import {resourceShape} from '@cdo/apps/templates/courseOverview/resourceType';
 import SectionAssigner from '@cdo/apps/templates/teacherDashboard/SectionAssigner';
 import Assigned from '@cdo/apps/templates/Assigned';
 import {sectionForDropdownShape} from '@cdo/apps/templates/teacherDashboard/shapes';
 import {sectionsForDropdown} from '@cdo/apps/templates/teacherDashboard/teacherSectionsRedux';
+import TeacherResourcesDropdown from '@cdo/apps/code-studio/components/progress/TeacherResourcesDropdown';
 
 export const NOT_STARTED = 'NOT_STARTED';
 export const IN_PROGRESS = 'IN_PROGRESS';
@@ -104,18 +101,7 @@ class ScriptOverviewTopRow extends React.Component {
         {!professionalLearningCourse &&
           viewAs === ViewType.Teacher &&
           resources.length > 0 && (
-            <div style={styles.dropdown}>
-              <DropdownButton
-                text={i18n.teacherResources()}
-                color={Button.ButtonColor.blue}
-              >
-                {resources.map(({type, link}, index) => (
-                  <a key={index} href={link} target="_blank">
-                    {stringForType[type]}
-                  </a>
-                ))}
-              </DropdownButton>
-            </div>
+            <TeacherResourcesDropdown resources={resources} />
           )}
         {!professionalLearningCourse && viewAs === ViewType.Teacher && (
           <SectionAssigner

--- a/apps/src/code-studio/components/progress/TeacherResourcesDropdown.jsx
+++ b/apps/src/code-studio/components/progress/TeacherResourcesDropdown.jsx
@@ -1,0 +1,40 @@
+import PropTypes from 'prop-types';
+import React from 'react';
+import i18n from '@cdo/locale';
+import Button from '@cdo/apps/templates/Button';
+import DropdownButton from '@cdo/apps/templates/DropdownButton';
+import {
+  stringForType,
+  resourceShape
+} from '@cdo/apps/templates/courseOverview/resourceType';
+
+const styles = {
+  dropdown: {
+    display: 'inline-block'
+  }
+};
+
+export default class TeacherResourcesDropdown extends React.Component {
+  static propTypes = {
+    resources: PropTypes.arrayOf(resourceShape).isRequired
+  };
+
+  render() {
+    const {resources} = this.props;
+
+    return (
+      <div style={styles.dropdown}>
+        <DropdownButton
+          text={i18n.teacherResources()}
+          color={Button.ButtonColor.blue}
+        >
+          {resources.map(({type, link}, index) => (
+            <a key={index} href={link} target="_blank">
+              {stringForType[type]}
+            </a>
+          ))}
+        </DropdownButton>
+      </div>
+    );
+  }
+}

--- a/apps/src/lib/script-editor/ScriptEditor.jsx
+++ b/apps/src/lib/script-editor/ScriptEditor.jsx
@@ -14,7 +14,6 @@ import HelpTip from '@cdo/apps/lib/ui/HelpTip';
 import LessonExtrasEditor from './LessonExtrasEditor';
 import color from '@cdo/apps/util/color';
 import MarkdownPreview from '@cdo/apps/lib/script-editor/MarkdownPreview';
-import TeacherResourcesDropdown from '@cdo/apps/code-studio/components/progress/TeacherResourcesDropdown';
 
 const styles = {
   input: {
@@ -474,9 +473,6 @@ export default class ScriptEditor extends React.Component {
             inputStyle={styles.input}
             resources={this.props.teacherResources}
             maxResources={Object.keys(ResourceType).length}
-            renderPreview={resources => (
-              <TeacherResourcesDropdown resources={resources} />
-            )}
           />
         </div>
         <h2>Professional Learning Settings</h2>

--- a/apps/src/lib/script-editor/ScriptEditor.jsx
+++ b/apps/src/lib/script-editor/ScriptEditor.jsx
@@ -5,9 +5,7 @@ import LessonDescriptions from './LessonDescriptions';
 import ScriptAnnouncementsEditor from './ScriptAnnouncementsEditor';
 import $ from 'jquery';
 import ResourcesEditor from '@cdo/apps/templates/courseOverview/ResourcesEditor';
-import ResourceType, {
-  resourceShape
-} from '@cdo/apps/templates/courseOverview/resourceType';
+import {resourceShape} from '@cdo/apps/templates/courseOverview/resourceType';
 import {announcementShape} from '@cdo/apps/code-studio/scriptAnnouncementsRedux';
 import VisibleAndPilotExperiment from './VisibleAndPilotExperiment';
 import HelpTip from '@cdo/apps/lib/ui/HelpTip';
@@ -472,7 +470,6 @@ export default class ScriptEditor extends React.Component {
           <ResourcesEditor
             inputStyle={styles.input}
             resources={this.props.teacherResources}
-            maxResources={Object.keys(ResourceType).length}
           />
         </div>
         <h2>Professional Learning Settings</h2>

--- a/apps/src/lib/script-editor/ScriptEditor.jsx
+++ b/apps/src/lib/script-editor/ScriptEditor.jsx
@@ -5,11 +5,8 @@ import LessonDescriptions from './LessonDescriptions';
 import ScriptAnnouncementsEditor from './ScriptAnnouncementsEditor';
 import $ from 'jquery';
 import ResourcesEditor from '@cdo/apps/templates/courseOverview/ResourcesEditor';
-import DropdownButton from '@cdo/apps/templates/DropdownButton';
-import Button from '@cdo/apps/templates/Button';
 import ResourceType, {
-  resourceShape,
-  stringForType
+  resourceShape
 } from '@cdo/apps/templates/courseOverview/resourceType';
 import {announcementShape} from '@cdo/apps/code-studio/scriptAnnouncementsRedux';
 import VisibleAndPilotExperiment from './VisibleAndPilotExperiment';
@@ -17,6 +14,7 @@ import HelpTip from '@cdo/apps/lib/ui/HelpTip';
 import LessonExtrasEditor from './LessonExtrasEditor';
 import color from '@cdo/apps/util/color';
 import MarkdownPreview from '@cdo/apps/lib/script-editor/MarkdownPreview';
+import TeacherResourcesDropdown from '@cdo/apps/code-studio/components/progress/TeacherResourcesDropdown';
 
 const styles = {
   input: {
@@ -477,16 +475,7 @@ export default class ScriptEditor extends React.Component {
             resources={this.props.teacherResources}
             maxResources={Object.keys(ResourceType).length}
             renderPreview={resources => (
-              <DropdownButton
-                text="Teacher resources"
-                color={Button.ButtonColor.blue}
-              >
-                {resources.map(({type, link}, index) => (
-                  <a key={index} href={link}>
-                    {stringForType[type]}
-                  </a>
-                ))}
-              </DropdownButton>
+              <TeacherResourcesDropdown resources={resources} />
             )}
           />
         </div>

--- a/apps/src/templates/courseOverview/CourseEditor.js
+++ b/apps/src/templates/courseOverview/CourseEditor.js
@@ -3,15 +3,13 @@ import React, {Component} from 'react';
 import CourseScriptsEditor from './CourseScriptsEditor';
 import ResourcesEditor from './ResourcesEditor';
 import ResourceType, {
-  resourceShape,
-  stringForType
+  resourceShape
 } from '@cdo/apps/templates/courseOverview/resourceType';
 import VisibleAndPilotExperiment from '../../lib/script-editor/VisibleAndPilotExperiment';
 import HelpTip from '@cdo/apps/lib/ui/HelpTip';
 import color from '@cdo/apps/util/color';
 import MarkdownPreview from '@cdo/apps/lib/script-editor/MarkdownPreview';
-import DropdownButton from '@cdo/apps/templates/DropdownButton';
-import Button from '@cdo/apps/templates/Button';
+import TeacherResourcesDropdown from '@cdo/apps/code-studio/components/progress/TeacherResourcesDropdown';
 
 const styles = {
   input: {
@@ -251,16 +249,7 @@ export default class CourseEditor extends Component {
             resources={teacherResources}
             maxResources={Object.keys(ResourceType).length}
             renderPreview={resources => (
-              <DropdownButton
-                text="Teacher resources"
-                color={Button.ButtonColor.blue}
-              >
-                {resources.map(({type, link}, index) => (
-                  <a key={index} href={link}>
-                    {stringForType[type]}
-                  </a>
-                ))}
-              </DropdownButton>
+              <TeacherResourcesDropdown resources={resources} />
             )}
           />
         </div>

--- a/apps/src/templates/courseOverview/CourseEditor.js
+++ b/apps/src/templates/courseOverview/CourseEditor.js
@@ -9,7 +9,6 @@ import VisibleAndPilotExperiment from '../../lib/script-editor/VisibleAndPilotEx
 import HelpTip from '@cdo/apps/lib/ui/HelpTip';
 import color from '@cdo/apps/util/color';
 import MarkdownPreview from '@cdo/apps/lib/script-editor/MarkdownPreview';
-import TeacherResourcesDropdown from '@cdo/apps/code-studio/components/progress/TeacherResourcesDropdown';
 
 const styles = {
   input: {
@@ -248,9 +247,6 @@ export default class CourseEditor extends Component {
             inputStyle={styles.input}
             resources={teacherResources}
             maxResources={Object.keys(ResourceType).length}
-            renderPreview={resources => (
-              <TeacherResourcesDropdown resources={resources} />
-            )}
           />
         </div>
       </div>

--- a/apps/src/templates/courseOverview/CourseEditor.js
+++ b/apps/src/templates/courseOverview/CourseEditor.js
@@ -2,9 +2,7 @@ import PropTypes from 'prop-types';
 import React, {Component} from 'react';
 import CourseScriptsEditor from './CourseScriptsEditor';
 import ResourcesEditor from './ResourcesEditor';
-import ResourceType, {
-  resourceShape
-} from '@cdo/apps/templates/courseOverview/resourceType';
+import {resourceShape} from '@cdo/apps/templates/courseOverview/resourceType';
 import VisibleAndPilotExperiment from '../../lib/script-editor/VisibleAndPilotExperiment';
 import HelpTip from '@cdo/apps/lib/ui/HelpTip';
 import color from '@cdo/apps/util/color';
@@ -246,7 +244,6 @@ export default class CourseEditor extends Component {
           <ResourcesEditor
             inputStyle={styles.input}
             resources={teacherResources}
-            maxResources={Object.keys(ResourceType).length}
           />
         </div>
       </div>

--- a/apps/src/templates/courseOverview/CourseEditor.js
+++ b/apps/src/templates/courseOverview/CourseEditor.js
@@ -2,12 +2,16 @@ import PropTypes from 'prop-types';
 import React, {Component} from 'react';
 import CourseScriptsEditor from './CourseScriptsEditor';
 import ResourcesEditor from './ResourcesEditor';
-import CourseOverviewTopRow from './CourseOverviewTopRow';
-import {resourceShape} from './resourceType';
+import ResourceType, {
+  resourceShape,
+  stringForType
+} from '@cdo/apps/templates/courseOverview/resourceType';
 import VisibleAndPilotExperiment from '../../lib/script-editor/VisibleAndPilotExperiment';
 import HelpTip from '@cdo/apps/lib/ui/HelpTip';
 import color from '@cdo/apps/util/color';
 import MarkdownPreview from '@cdo/apps/lib/script-editor/MarkdownPreview';
+import DropdownButton from '@cdo/apps/templates/DropdownButton';
+import Button from '@cdo/apps/templates/Button';
 
 const styles = {
   input: {
@@ -239,20 +243,24 @@ export default class CourseEditor extends Component {
         <div>
           <h2>Teacher Resources</h2>
           <div>
-            Select up to three Teacher Resources buttons you'd like to have show
-            up on the top of the course overview page
+            Select the Teacher Resources buttons you'd like to have show up on
+            the top of the course overview page
           </div>
           <ResourcesEditor
             inputStyle={styles.input}
             resources={teacherResources}
-            maxResources={3}
+            maxResources={Object.keys(ResourceType).length}
             renderPreview={resources => (
-              <CourseOverviewTopRow
-                sectionsForDropdown={[]}
-                id={-1}
-                resources={resources}
-                showAssignButton={false}
-              />
+              <DropdownButton
+                text="Teacher resources"
+                color={Button.ButtonColor.blue}
+              >
+                {resources.map(({type, link}, index) => (
+                  <a key={index} href={link}>
+                    {stringForType[type]}
+                  </a>
+                ))}
+              </DropdownButton>
             )}
           />
         </div>

--- a/apps/src/templates/courseOverview/CourseOverviewTopRow.js
+++ b/apps/src/templates/courseOverview/CourseOverviewTopRow.js
@@ -1,11 +1,9 @@
 import PropTypes from 'prop-types';
 import React, {Component} from 'react';
-import Button from '@cdo/apps/templates/Button';
-import {stringForType, resourceShape} from './resourceType';
+import {resourceShape} from './resourceType';
 import SectionAssigner from '@cdo/apps/templates/teacherDashboard/SectionAssigner';
 import {sectionForDropdownShape} from '@cdo/apps/templates/teacherDashboard/shapes';
-import i18n from '@cdo/locale';
-import DropdownButton from '@cdo/apps/templates/DropdownButton';
+import TeacherResourcesDropdown from '@cdo/apps/code-studio/components/progress/TeacherResourcesDropdown';
 
 const styles = {
   main: {
@@ -31,18 +29,7 @@ export default class CourseOverviewTopRow extends Component {
     return (
       <div style={styles.main}>
         {resources.length > 0 && (
-          <div style={styles.dropdown}>
-            <DropdownButton
-              text={i18n.teacherResources()}
-              color={Button.ButtonColor.blue}
-            >
-              {resources.map(({type, link}, index) => (
-                <a key={index} href={link} target="_blank">
-                  {stringForType[type]}
-                </a>
-              ))}
-            </DropdownButton>
-          </div>
+          <TeacherResourcesDropdown resources={resources} />
         )}
         <SectionAssigner
           sections={sectionsForDropdown}

--- a/apps/src/templates/courseOverview/CourseOverviewTopRow.js
+++ b/apps/src/templates/courseOverview/CourseOverviewTopRow.js
@@ -4,11 +4,16 @@ import Button from '@cdo/apps/templates/Button';
 import {stringForType, resourceShape} from './resourceType';
 import SectionAssigner from '@cdo/apps/templates/teacherDashboard/SectionAssigner';
 import {sectionForDropdownShape} from '@cdo/apps/templates/teacherDashboard/shapes';
+import i18n from '@cdo/locale';
+import DropdownButton from '@cdo/apps/templates/DropdownButton';
 
 const styles = {
   main: {
     marginBottom: 10,
     position: 'relative'
+  },
+  dropdown: {
+    display: 'inline-block'
   }
 };
 
@@ -25,17 +30,20 @@ export default class CourseOverviewTopRow extends Component {
 
     return (
       <div style={styles.main}>
-        {resources.map(({type, link}) => (
-          <Button
-            __useDeprecatedTag
-            key={type}
-            style={{marginRight: 10}}
-            text={stringForType[type]}
-            href={link}
-            target="blank"
-            color={Button.ButtonColor.blue}
-          />
-        ))}
+        {resources.length > 0 && (
+          <div style={styles.dropdown}>
+            <DropdownButton
+              text={i18n.teacherResources()}
+              color={Button.ButtonColor.blue}
+            >
+              {resources.map(({type, link}, index) => (
+                <a key={index} href={link} target="_blank">
+                  {stringForType[type]}
+                </a>
+              ))}
+            </DropdownButton>
+          </div>
+        )}
         <SectionAssigner
           sections={sectionsForDropdown}
           showAssignButton={showAssignButton}

--- a/apps/src/templates/courseOverview/ResourcesEditor.js
+++ b/apps/src/templates/courseOverview/ResourcesEditor.js
@@ -33,9 +33,7 @@ const defaultLinks = {
 export default class ResourcesEditor extends Component {
   static propTypes = {
     inputStyle: PropTypes.object.isRequired,
-    resources: PropTypes.arrayOf(resourceShape).isRequired,
-    maxResources: PropTypes.number.isRequired,
-    renderPreview: PropTypes.func.isRequired
+    resources: PropTypes.arrayOf(resourceShape).isRequired
   };
 
   constructor(props) {
@@ -43,7 +41,7 @@ export default class ResourcesEditor extends Component {
 
     const resources = [...props.resources];
     // add empty entries to get to max
-    while (resources.length < props.maxResources) {
+    while (resources.length < Object.keys(ResourceType).length) {
       resources.push({type: '', link: ''});
     }
 

--- a/apps/src/templates/courseOverview/ResourcesEditor.js
+++ b/apps/src/templates/courseOverview/ResourcesEditor.js
@@ -3,6 +3,7 @@ import React, {Component} from 'react';
 import _ from 'lodash';
 import color from '@cdo/apps/util/color';
 import ResourceType, {stringForType, resourceShape} from './resourceType';
+import TeacherResourcesDropdown from '@cdo/apps/code-studio/components/progress/TeacherResourcesDropdown';
 
 const styles = {
   box: {
@@ -106,7 +107,9 @@ export default class ResourcesEditor extends Component {
         <div style={styles.box}>
           <div style={styles.error}>{errorString}</div>
           <div style={{marginBottom: 5}}>Preview:</div>
-          {this.props.renderPreview(resources.filter(x => !!x.type))}
+          <TeacherResourcesDropdown
+            resources={resources.filter(x => !!x.type)}
+          />
         </div>
       </div>
     );

--- a/apps/test/unit/code-studio/components/progress/ScriptOverviewTopRowTest.jsx
+++ b/apps/test/unit/code-studio/components/progress/ScriptOverviewTopRowTest.jsx
@@ -10,10 +10,10 @@ import {
   COMPLETED
 } from '@cdo/apps/code-studio/components/progress/ScriptOverviewTopRow';
 import Button from '@cdo/apps/templates/Button';
-import DropdownButton from '@cdo/apps/templates/DropdownButton';
 import SectionAssigner from '@cdo/apps/templates/teacherDashboard/SectionAssigner';
 import ResourceType from '@cdo/apps/templates/courseOverview/resourceType';
 import ProgressDetailToggle from '@cdo/apps/templates/progress/ProgressDetailToggle';
+import TeacherResourcesDropdown from '@cdo/apps/code-studio/components/progress/TeacherResourcesDropdown';
 
 const defaultProps = {
   sectionsForDropdown: [],
@@ -150,19 +150,18 @@ describe('ScriptOverviewTopRow', () => {
     );
     expect(
       wrapper.containsMatchingElement(
-        <div>
-          <DropdownButton
-            text={i18n.teacherResources()}
-            color={Button.ButtonColor.blue}
-          >
-            <a href="https://example.com/a" target="_blank">
-              {i18n.curriculum()}
-            </a>
-            <a href="https://example.com/b" target="_blank">
-              {i18n.vocabulary()}
-            </a>
-          </DropdownButton>
-        </div>
+        <TeacherResourcesDropdown
+          resources={[
+            {
+              type: ResourceType.curriculum,
+              link: 'https://example.com/a'
+            },
+            {
+              type: ResourceType.vocabulary,
+              link: 'https://example.com/b'
+            }
+          ]}
+        />
       )
     ).to.be.true;
   });

--- a/apps/test/unit/code-studio/components/progress/TeacherResourcesDropdownTest.jsx
+++ b/apps/test/unit/code-studio/components/progress/TeacherResourcesDropdownTest.jsx
@@ -1,0 +1,44 @@
+import {expect} from '../../../../util/reconfiguredChai';
+import React from 'react';
+import {shallow} from 'enzyme';
+import ResourceType from '@cdo/apps/templates/courseOverview/resourceType';
+import TeacherResourcesDropdown from '@cdo/apps/code-studio/components/progress/TeacherResourcesDropdown';
+import DropdownButton from '@cdo/apps/templates/DropdownButton';
+import i18n from '@cdo/locale';
+import Button from '@cdo/apps/templates/Button';
+
+describe('TeacherResourcesDropdown', () => {
+  it('renders resources for teacher', () => {
+    const wrapper = shallow(
+      <TeacherResourcesDropdown
+        resources={[
+          {
+            type: ResourceType.curriculum,
+            link: 'https://example.com/a'
+          },
+          {
+            type: ResourceType.vocabulary,
+            link: 'https://example.com/b'
+          }
+        ]}
+      />
+    );
+    expect(
+      wrapper.containsMatchingElement(
+        <div>
+          <DropdownButton
+            text={i18n.teacherResources()}
+            color={Button.ButtonColor.blue}
+          >
+            <a href="https://example.com/a" target="_blank">
+              {i18n.curriculum()}
+            </a>
+            <a href="https://example.com/b" target="_blank">
+              {i18n.vocabulary()}
+            </a>
+          </DropdownButton>
+        </div>
+      )
+    ).to.be.true;
+  });
+});

--- a/apps/test/unit/templates/courseOverview/CourseEditorTest.js
+++ b/apps/test/unit/templates/courseOverview/CourseEditorTest.js
@@ -55,7 +55,7 @@ describe('CourseEditor', () => {
     assert.equal(wrapper.find('textarea').length, 3);
     assert.equal(wrapper.find('CourseScriptsEditor').length, 1);
     assert.equal(wrapper.find('ResourcesEditor').length, 1);
-    assert.equal(wrapper.find('CourseOverviewTopRow').length, 1);
+    assert.equal(wrapper.find('TeacherResourcesDropdown').length, 1);
   });
 
   it('has correct markdown for preview of course teacher and student description', () => {

--- a/apps/test/unit/templates/courseOverview/CourseOverviewTopRowTest.js
+++ b/apps/test/unit/templates/courseOverview/CourseOverviewTopRowTest.js
@@ -31,50 +31,31 @@ describe('CourseOverviewTopRow', () => {
     assert.equal(wrapper.find('Connect(SectionAssigner)').length, 1);
   });
 
-  it('has a button for each resource', () => {
+  it('renders teacher resource dropdown', () => {
     const wrapper = shallow(<CourseOverviewTopRow {...defaultProps} />);
-    assert.equal(wrapper.find('Button').length, 3);
+    assert.equal(wrapper.find('TeacherResourcesDropdown').length, 1);
     assert.equal(
-      wrapper
-        .find('Button')
-        .at(0)
-        .props().text,
-      'Curriculum'
+      wrapper.find('TeacherResourcesDropdown').props().resources[0].type,
+      ResourceType.curriculum
     );
     assert.equal(
-      wrapper
-        .find('Button')
-        .at(1)
-        .props().text,
-      'Professional Learning'
-    );
-    assert.equal(
-      wrapper
-        .find('Button')
-        .at(2)
-        .props().text,
-      'Teacher Forum'
-    );
-
-    assert.equal(
-      wrapper
-        .find('Button')
-        .at(0)
-        .props().href,
+      wrapper.find('TeacherResourcesDropdown').props().resources[0].link,
       '/link/to/curriculum'
     );
     assert.equal(
-      wrapper
-        .find('Button')
-        .at(1)
-        .props().href,
+      wrapper.find('TeacherResourcesDropdown').props().resources[1].type,
+      ResourceType.professionalLearning
+    );
+    assert.equal(
+      wrapper.find('TeacherResourcesDropdown').props().resources[1].link,
       '/link/to/professional/learning'
     );
     assert.equal(
-      wrapper
-        .find('Button')
-        .at(2)
-        .props().href,
+      wrapper.find('TeacherResourcesDropdown').props().resources[2].type,
+      ResourceType.teacherForum
+    );
+    assert.equal(
+      wrapper.find('TeacherResourcesDropdown').props().resources[2].link,
       'https://forum.code.org/'
     );
   });

--- a/apps/test/unit/templates/courseOverview/ResourcesEditorTest.js
+++ b/apps/test/unit/templates/courseOverview/ResourcesEditorTest.js
@@ -6,15 +6,20 @@ import ResourceType from '@cdo/apps/templates/courseOverview/resourceType';
 
 const defaultProps = {
   inputStyle: {},
-  resources: [],
-  maxResources: 3,
-  renderPreview: resources => null
+  resources: []
 };
 
 describe('ResourcesEditor', () => {
   it('adds empty resources if passed none', () => {
     const wrapper = shallow(<ResourcesEditor {...defaultProps} />);
     assert.deepEqual(wrapper.state('resources'), [
+      {type: '', link: ''},
+      {type: '', link: ''},
+      {type: '', link: ''},
+      {type: '', link: ''},
+      {type: '', link: ''},
+      {type: '', link: ''},
+      {type: '', link: ''},
       {type: '', link: ''},
       {type: '', link: ''},
       {type: '', link: ''}
@@ -30,6 +35,13 @@ describe('ResourcesEditor', () => {
     );
     assert.deepEqual(wrapper.state('resources'), [
       {type: ResourceType.curriculum, link: '/foo'},
+      {type: '', link: ''},
+      {type: '', link: ''},
+      {type: '', link: ''},
+      {type: '', link: ''},
+      {type: '', link: ''},
+      {type: '', link: ''},
+      {type: '', link: ''},
       {type: '', link: ''},
       {type: '', link: ''}
     ]);


### PR DESCRIPTION
We used to limit the number of teacher resources for the Course Overview Page to just 3 resources and we would show each resource as its own button. This makes it so we use the same Teacher Resources Dropdown we use on the Script Overview Page. We now have a TeacherResourceDropdown component that is used both on the editor pages for preview and the overview pages for display. 

### Course Edit Page After Change
<img width="1253" alt="Screen Shot 2020-08-20 at 10 33 42 PM" src="https://user-images.githubusercontent.com/208083/90846145-9624fe00-e335-11ea-9460-305b5f4d1587.png">

### Course Overview Page After Change
<img width="997" alt="Screen Shot 2020-08-20 at 10 33 30 PM" src="https://user-images.githubusercontent.com/208083/90846148-97562b00-e335-11ea-9d17-ead59c7573bd.png">

## Follow Up Work
- Allow curriculum writers to put in their own types for teacher resources
- Instrumentation for the TeacherResourcesDropdown component

## Links

<!--
  Any relevant links to external resources; ie, specification documents, jira
  items, related PRs, honeybadger errors, etc
-->

- [spec](https://docs.google.com/document/d/1wubJ6xRhdmuV9d25i5SgEzrCKcR1VjuErcv7GzL0Y0Y/edit#bookmark=id.q9vlh0irno05)
- [jira](https://codedotorg.atlassian.net/browse/PLAT-269)

## Testing story

<!--
  Does your change include appropriate tests?

  If so, please describe how the tests included in this PR are sufficient

  If not, please explain why this change does not need to be tested.
-->

- Updated tests for all existing components
- Created test for new component

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
