### PR TITLE
CourseOffering seeding

### DIFF
--- a/dashboard/app/models/course_offering.rb
+++ b/dashboard/app/models/course_offering.rb
@@ -34,8 +34,13 @@ class CourseOffering < ApplicationRecord
     raise "family_name must be set, since is_course is true, for: #{content_root.name}" if content_root.family_name.nil_or_empty?
     raise "version_year must be set, since is_course is true, for: #{content_root.name}" if content_root.version_year.nil_or_empty?
 
+    original_offering = content_root.course_version&.course_offering
     offering = CourseOffering.find_or_create_by(key: content_root.family_name, display_name: content_root.family_name)
     CourseVersion.add_course_version(offering, content_root)
+
+    # If changes to content_root's family name and/or version year have resulted in its previous CourseOffering having no versions,
+    # destroy the old CourseOffering.
+    original_offering&.destroy if original_offering != offering && original_offering&.course_versions&.empty?
 
     # TODO: add relevant properties from content root to course_version
 

--- a/dashboard/app/models/course_offering.rb
+++ b/dashboard/app/models/course_offering.rb
@@ -16,4 +16,27 @@
 
 class CourseOffering < ApplicationRecord
   has_many :course_versions
+
+  def self.add_course_offering(content_root)
+    # If content_root is not designated as the content root of a CourseVersion (in its .script or .course file),
+    # delete its associated CourseVersion object if it exists. This handles the case where a .script or .course file
+    # had "is_course true" at one point, and then later "is_course true" is removed.
+    unless content_root.is_course?
+      if content_root.course_version
+        content_root.course_version.destroy
+        content_root.reload
+      end
+      return nil
+    end
+
+    raise "family_name must be set, since is_course is true, for: #{content_root.name}" if content_root.family_name.nil_or_empty?
+    raise "version_year must be set, since is_course is true, for: #{content_root.name}" if content_root.version_year.nil_or_empty?
+
+    offering = CourseOffering.find_or_create_by(key: content_root.family_name, display_name: content_root.family_name)
+    CourseVersion.add_course_version(offering, content_root)
+
+    # TODO: add relevant properties from content root to course_version
+
+    offering
+  end
 end

--- a/dashboard/app/models/course_offering.rb
+++ b/dashboard/app/models/course_offering.rb
@@ -19,8 +19,8 @@ class CourseOffering < ApplicationRecord
 
   def self.add_course_offering(content_root)
     # If content_root is not designated as the content root of a CourseVersion (in its .script or .course file),
-    # delete its associated CourseVersion object if it exists. This handles the case where a .script or .course file
-    # had "is_course true" at one point, and then later "is_course true" is removed.
+    # delete its associated CourseVersion object if it exists, and then the CourseOffering object if it has no versions remaining.
+    # This handles the case where a .script or .course file had "is_course true" at one point, and then later "is_course true" is removed.
     unless content_root.is_course?
       if content_root.course_version
         existing_offering = content_root.course_version.course_offering

--- a/dashboard/app/models/course_offering.rb
+++ b/dashboard/app/models/course_offering.rb
@@ -23,7 +23,9 @@ class CourseOffering < ApplicationRecord
     # had "is_course true" at one point, and then later "is_course true" is removed.
     unless content_root.is_course?
       if content_root.course_version
+        existing_offering = content_root.course_version.course_offering
         content_root.course_version.destroy
+        existing_offering.destroy if existing_offering.course_versions.empty?
         content_root.reload
       end
       return nil

--- a/dashboard/app/models/course_offering.rb
+++ b/dashboard/app/models/course_offering.rb
@@ -34,7 +34,6 @@ class CourseOffering < ApplicationRecord
   def self.add_course_offering(content_root)
     if content_root.is_course?
       raise "family_name must be set, since is_course is true, for: #{content_root.name}" if content_root.family_name.nil_or_empty?
-      raise "version_year must be set, since is_course is true, for: #{content_root.name}" if content_root.version_year.nil_or_empty?
 
       offering = CourseOffering.find_or_create_by!(key: content_root.family_name, display_name: content_root.family_name)
     else

--- a/dashboard/app/models/course_version.rb
+++ b/dashboard/app/models/course_version.rb
@@ -62,11 +62,7 @@ class CourseVersion < ApplicationRecord
     )
 
     # Delete old CourseVersion if the key has been changed to something else
-    if course_version != content_root.course_version
-      original_course_offering = content_root.course_version.course_offering
-      content_root.course_version.destroy
-      original_course_offering.destroy if original_course_offering.course_versions.empty?
-    end
+    content_root.course_version&.destroy if course_version != content_root.course_version
     content_root.course_version = course_version
 
     # TODO: add relevant properties from content root to course_version

--- a/dashboard/app/models/course_version.rb
+++ b/dashboard/app/models/course_version.rb
@@ -40,7 +40,7 @@ class CourseVersion < ApplicationRecord
   #
   # csp1-2019.script does not represent a content root (the root for CSP, Version 2019 is a UnitGroup).
   # Therefore, it does not contain "is_course true". so this method will not create a CourseVersion object for it.
-  def self.add_course_version(content_root)
+  def self.add_course_version(course_offering, content_root)
     # If content_root is not designated as the content root of a CourseVersion (in its .script or .course file),
     # delete its associated CourseVersion object if it exists. This handles the case where a .script or .course file
     # had "is_course true" at one point, and then later "is_course true" is removed.
@@ -52,15 +52,11 @@ class CourseVersion < ApplicationRecord
       return nil
     end
 
-    raise "family_name must be set, since is_course is true, for: #{content_root.name}" if content_root.family_name.nil_or_empty?
     raise "version_year must be set, since is_course is true, for: #{content_root.name}" if content_root.version_year.nil_or_empty?
 
-    # TODO: Once the Course model is added, change this to just be version_year, since then the
-    # unique index will be on (course_id, key).
-    key = "#{content_root.family_name}-#{content_root.version_year}"
-
     course_version = CourseVersion.find_or_create_by(
-      key: key,
+      course_offering: course_offering,
+      key: content_root.version_year,
       display_name: content_root.version_year,
       content_root: content_root,
     )

--- a/dashboard/app/models/course_version.rb
+++ b/dashboard/app/models/course_version.rb
@@ -62,7 +62,11 @@ class CourseVersion < ApplicationRecord
     )
 
     # Delete old CourseVersion if the key has been changed to something else
-    content_root.course_version.destroy if course_version != content_root.course_version
+    if course_version != content_root.course_version
+      original_course_offering = content_root.course_version.course_offering
+      content_root.course_version.destroy
+      original_course_offering.destroy if original_course_offering.course_versions.empty?
+    end
     content_root.course_version = course_version
 
     # TODO: add relevant properties from content root to course_version

--- a/dashboard/app/models/course_version.rb
+++ b/dashboard/app/models/course_version.rb
@@ -41,32 +41,34 @@ class CourseVersion < ApplicationRecord
   # csp1-2019.script does not represent a content root (the root for CSP, Version 2019 is a UnitGroup).
   # Therefore, it does not contain "is_course true". so this method will not create a CourseVersion object for it.
   def self.add_course_version(course_offering, content_root)
-    # If content_root is not designated as the content root of a CourseVersion (in its .script or .course file),
-    # delete its associated CourseVersion object if it exists. This handles the case where a .script or .course file
-    # had "is_course true" at one point, and then later "is_course true" is removed.
-    unless content_root.is_course?
-      if content_root.course_version
-        content_root.course_version.destroy
-        content_root.reload
-      end
-      return nil
+    if content_root.is_course?
+      raise "version_year must be set, since is_course is true, for: #{content_root.name}" if content_root.version_year.nil_or_empty?
+
+      course_version = CourseVersion.find_or_create_by!(
+        course_offering: course_offering,
+        key: content_root.version_year,
+        display_name: content_root.version_year,
+        content_root: content_root,
+      )
+    else
+      course_version = nil
     end
 
-    raise "version_year must be set, since is_course is true, for: #{content_root.name}" if content_root.version_year.nil_or_empty?
-
-    course_version = CourseVersion.find_or_create_by(
-      course_offering: course_offering,
-      key: content_root.version_year,
-      display_name: content_root.version_year,
-      content_root: content_root,
-    )
-
-    # Delete old CourseVersion if the key has been changed to something else
-    content_root.course_version&.destroy if course_version != content_root.course_version
+    # Destroy the previously associated CourseVersion and CourseOffering if appropriate. This can happen if either:
+    #   - family_name or version_year was changed
+    #   - is_course? changed from true to false, such as if "is_course true" was removed from a .script file, or
+    #     family_name or version_year was removed from a .course file.
+    content_root.course_version.destroy_and_destroy_parent_if_empty if content_root.course_version != course_version
     content_root.course_version = course_version
 
     # TODO: add relevant properties from content root to course_version
 
     course_version
+  end
+
+  # Destroys this CourseVersion. Then, if its parent CourseOffering now has no CourseVersions, destroy it too.
+  def destroy_and_destroy_parent_if_empty
+    destroy!
+    course_offering.destroy if course_offering.course_versions.empty?
   end
 end

--- a/dashboard/app/models/script.rb
+++ b/dashboard/app/models/script.rb
@@ -944,7 +944,7 @@ class Script < ActiveRecord::Base
 
     script.generate_plc_objects
 
-    CourseVersion.add_course_version(script)
+    CourseOffering.add_course_offering(script)
 
     script
   end

--- a/dashboard/app/models/script.rb
+++ b/dashboard/app/models/script.rb
@@ -988,7 +988,8 @@ class Script < ActiveRecord::Base
     new_properties = {
       is_stable: false,
       tts: false,
-      script_announcements: nil
+      script_announcements: nil,
+      is_course: false
     }.merge(options)
     if /^[0-9]{4}$/ =~ (new_suffix)
       new_properties[:version_year] = new_suffix

--- a/dashboard/app/models/unit_group.rb
+++ b/dashboard/app/models/unit_group.rb
@@ -86,6 +86,8 @@ class UnitGroup < ApplicationRecord
     unit_group.update_scripts(hash['script_names'], hash['alternate_scripts'])
     unit_group.properties = hash['properties']
     unit_group.save!
+
+    CourseVersion.add_course_version(unit_group)
   rescue Exception => e
     # print filename for better debugging
     new_e = Exception.new("in course: #{path}: #{e.message}")
@@ -611,4 +613,10 @@ class UnitGroup < ApplicationRecord
     return true if user.permission?(UserPermission::LEVELBUILDER)
     all_courses.any? {|unit_group| unit_group.has_pilot_experiment?(user)}
   end
+
+  # rubocop:disable Naming/PredicateName
+  def is_course?
+    return !!family_name && !!version_year
+  end
+  # rubocop:enable Naming/PredicateName
 end

--- a/dashboard/app/models/unit_group.rb
+++ b/dashboard/app/models/unit_group.rb
@@ -87,7 +87,8 @@ class UnitGroup < ApplicationRecord
     unit_group.properties = hash['properties']
     unit_group.save!
 
-    CourseVersion.add_course_version(unit_group)
+    CourseOffering.add_course_offering(unit_group)
+    unit_group
   rescue Exception => e
     # print filename for better debugging
     new_e = Exception.new("in course: #{path}: #{e.message}")

--- a/dashboard/config/courses/csd-pilot.course
+++ b/dashboard/config/courses/csd-pilot.course
@@ -16,7 +16,7 @@
         "https://forum.code.org/c/csd"
       ]
     ],
-    "version_year": "2020",
+    "version_year": "2020-pilot",
     "family_name": "csd",
     "has_verified_resources": true
   }

--- a/dashboard/test/factories/factories.rb
+++ b/dashboard/test/factories/factories.rb
@@ -18,7 +18,11 @@ FactoryGirl.define do
     end
 
     trait :with_unit do
-      association(:content_root, factory: :script)
+      association(:content_root, factory: :script, is_course: true)
+    end
+
+    trait :with_course_offering do
+      association :course_offering
     end
   end
 
@@ -677,7 +681,7 @@ FactoryGirl.define do
     level_source {create :level_source, level: level}
   end
 
-  factory :script do
+  factory :script, aliases: [:unit] do
     sequence(:name) {|n| "bogus-script-#{n}"}
 
     factory :csf_script do

--- a/dashboard/test/fixtures/test-course-offering.course
+++ b/dashboard/test/fixtures/test-course-offering.course
@@ -1,5 +1,5 @@
 {
-  "name": "allthethingscourse",
+  "name": "test-course-offering-course",
   "script_names": [],
   "properties": {
     "family_name": "xyz",

--- a/dashboard/test/fixtures/test-course-offering.course
+++ b/dashboard/test/fixtures/test-course-offering.course
@@ -1,0 +1,8 @@
+{
+  "name": "allthethingscourse",
+  "script_names": [],
+  "properties": {
+    "family_name": "xyz",
+    "version_year": "1234"
+  }
+}

--- a/dashboard/test/models/course_offering_test.rb
+++ b/dashboard/test/models/course_offering_test.rb
@@ -22,4 +22,32 @@ class CourseOfferingTest < ActiveSupport::TestCase
     assert_equal offering, CourseOffering.find_by(key: family_name)
     assert_equal offering.course_versions, [CourseVersion.find_by(course_offering: offering, key: version_year)]
   end
+
+  test "add_course_offering updates existing CourseOffering and CourseVersion for script if properties change" do
+    family_name = 'csz'
+    version_year = '2050'
+    script = create :script, family_name: 'csz', version_year: '2050', is_course: true
+    original_course_offering = CourseOffering.add_course_offering(script)
+
+    assert_equal version_year, script.course_version.key
+    assert_equal version_year, script.course_version.display_name
+    assert_equal family_name, script.course_version.course_offering.key
+    assert_equal family_name, script.course_version.course_offering.display_name
+
+    family_name_new = 'csx'
+    version_year_new = '2060'
+    script.family_name = family_name_new
+    script.version_year = version_year_new
+    script.save
+
+    CourseOffering.add_course_offering(script)
+
+    assert_equal version_year_new, script.course_version.key
+    assert_equal version_year_new, script.course_version.display_name
+    assert_equal family_name_new, script.course_version.course_offering.key
+    assert_equal family_name_new, script.course_version.course_offering.display_name
+
+    assert_nil CourseVersion.find_by(course_offering: original_course_offering, key: version_year) # old CourseVersion should be deleted
+    assert_nil CourseOffering.find_by(key: family_name) # old CourseOffering should be deleted
+  end
 end

--- a/dashboard/test/models/course_offering_test.rb
+++ b/dashboard/test/models/course_offering_test.rb
@@ -11,43 +11,103 @@ class CourseOfferingTest < ActiveSupport::TestCase
     assert_equal course_offering, version2.course_offering
   end
 
-  test "add_course_offering creates CourseOffering and CourseVersion for new script if is_course is true" do
-    family_name = 'csz'
-    version_year = '2050'
-    script = create :script, family_name: family_name, version_year: version_year, is_course: true
-    offering = CourseOffering.add_course_offering(script)
+  # One "integration test" of seeding from DSL creating a CourseVersion for a Script with is_course true.
+  # Other cases are covered by directly testing add_course_version below.
+  test "Script.setup creates CourseOffering and CourseVersion if is_course is true" do
+    script_file = File.join(self.class.fixture_path, 'test-script-course-version.script')
+    scripts, _ = Script.setup([script_file])
+    script = scripts.first
 
-    assert_equal offering.key, family_name
-    assert_equal offering.display_name, family_name
-    assert_equal offering, CourseOffering.find_by(key: family_name)
-    assert_equal offering.course_versions, [CourseVersion.find_by(course_offering: offering, key: version_year)]
+    offering = script.course_version.course_offering
+    assert_equal 'xyz', offering.key
+    assert_equal [CourseVersion.find_by(key: '1234')], offering.course_versions
   end
 
-  test "add_course_offering updates existing CourseOffering and CourseVersion for script if properties change" do
-    family_name = 'csz'
-    version_year = '2050'
-    script = create :script, family_name: 'csz', version_year: '2050', is_course: true
-    original_course_offering = CourseOffering.add_course_offering(script)
+  [:unit, :unit_group].each do |content_root_type|
+    test "add_course_offering creates CourseOffering and CourseVersion for #{content_root_type}" do
+      family_name = 'csz'
+      version_year = '2050'
+      content_root = create content_root_type, family_name: family_name, version_year: version_year
+      content_root.is_course = true if content_root_type == :unit
 
-    assert_equal version_year, script.course_version.key
-    assert_equal version_year, script.course_version.display_name
-    assert_equal family_name, script.course_version.course_offering.key
-    assert_equal family_name, script.course_version.course_offering.display_name
+      offering = CourseOffering.add_course_offering(content_root)
 
-    family_name_new = 'csx'
-    version_year_new = '2060'
-    script.family_name = family_name_new
-    script.version_year = version_year_new
-    script.save
+      assert_equal offering.key, family_name
+      assert_equal offering.display_name, family_name
+      assert_equal offering, CourseOffering.find_by(key: family_name)
+      assert_equal offering.course_versions, [CourseVersion.find_by(course_offering: offering, key: version_year)]
+    end
 
-    CourseOffering.add_course_offering(script)
+    test "add_course_offering updates existing CourseOffering and CourseVersion for #{content_root_type}" do
+      offering = course_offering_with_versions(1, "with_#{content_root_type}".to_sym)
+      content_root = offering.course_versions.first.content_root
+      old_offering_key = offering.key
+      old_version_year = offering.course_versions.first.key
 
-    assert_equal version_year_new, script.course_version.key
-    assert_equal version_year_new, script.course_version.display_name
-    assert_equal family_name_new, script.course_version.course_offering.key
-    assert_equal family_name_new, script.course_version.course_offering.display_name
+      content_root.family_name = 'csz'
+      content_root.version_year = '2050'
+      content_root.save
+      CourseOffering.add_course_offering(content_root)
+      content_root.reload
 
-    assert_nil CourseVersion.find_by(course_offering: original_course_offering, key: version_year) # old CourseVersion should be deleted
-    assert_nil CourseOffering.find_by(key: family_name) # old CourseOffering should be deleted
+      assert_equal content_root.version_year, content_root.course_version.key
+      assert_equal content_root.family_name, content_root.course_version.course_offering.key
+      assert_nil CourseVersion.find_by(course_offering: offering, key: old_version_year) # old CourseVersion should be deleted
+      assert_nil CourseOffering.find_by(key: old_offering_key) # old CourseOffering should be deleted
+    end
+
+    test "add_course_offering updates existing CourseOffering with multiple CourseVersion for #{content_root_type}" do
+      offering = course_offering_with_versions(2, "with_#{content_root_type}".to_sym)
+      content_root = offering.course_versions.first.content_root
+      old_offering_key = offering.key
+      old_version_year = offering.course_versions.first.key
+
+      content_root.family_name = 'csz'
+      content_root.version_year = '2050'
+      content_root.save
+      CourseOffering.add_course_offering(content_root)
+      content_root.reload
+
+      assert_equal content_root.version_year, content_root.course_version.key
+      assert_equal content_root.family_name, content_root.course_version.course_offering.key
+      assert_nil CourseVersion.find_by(course_offering: offering, key: old_version_year) # old CourseVersion should be deleted
+      assert_equal 1, CourseOffering.find_by(key: old_offering_key).course_versions.length # old CourseOffering should have 1 version left
+    end
+
+    test "add_course_version deletes CourseOffering and CourseVersion if is_course is changed to false for #{content_root_type}" do
+      offering = course_offering_with_versions(1, "with_#{content_root_type}".to_sym)
+      content_root = offering.course_versions.first.content_root
+      old_offering_key = offering.key
+      old_version_year = offering.course_versions.first.key
+
+      content_root.family_name = content_root.version_year = nil
+      content_root.is_course = false if content_root_type == :unit
+      content_root.save
+      offering = CourseOffering.add_course_offering(content_root)
+
+      assert_nil offering
+      assert_nil content_root.course_version
+      assert_nil CourseVersion.find_by(key: old_version_year)
+      assert_nil CourseOffering.find_by(key: old_offering_key)
+    end
+
+    test "add_course_offering does nothing if is_course is false for #{content_root_type}" do
+      num_course_offerings = CourseOffering.count
+      num_course_versions = CourseVersion.count
+      content_root = create content_root_type
+
+      offering = CourseOffering.add_course_offering(content_root)
+
+      assert_nil offering
+      assert_nil content_root.course_version
+      assert_equal num_course_offerings, CourseOffering.count
+      assert_equal num_course_versions, CourseVersion.count
+    end
+  end
+
+  def course_offering_with_versions(num_versions, content_root_trait=:with_unit_group)
+    create :course_offering do |offering|
+      create_list :course_version, num_versions, content_root_trait, course_offering: offering
+    end
   end
 end

--- a/dashboard/test/models/course_offering_test.rb
+++ b/dashboard/test/models/course_offering_test.rb
@@ -10,4 +10,16 @@ class CourseOfferingTest < ActiveSupport::TestCase
     assert_equal course_offering, version1.course_offering
     assert_equal course_offering, version2.course_offering
   end
+
+  test "add_course_offering creates CourseOffering and CourseVersion for new script if is_course is true" do
+    family_name = 'csz'
+    version_year = '2050'
+    script = create :script, family_name: family_name, version_year: version_year, is_course: true
+    offering = CourseOffering.add_course_offering(script)
+
+    assert_equal offering.key, family_name
+    assert_equal offering.display_name, family_name
+    assert_equal offering, CourseOffering.find_by(key: family_name)
+    assert_equal offering.course_versions, [CourseVersion.find_by(course_offering: offering, key: version_year)]
+  end
 end

--- a/dashboard/test/models/course_offering_test.rb
+++ b/dashboard/test/models/course_offering_test.rb
@@ -11,8 +11,8 @@ class CourseOfferingTest < ActiveSupport::TestCase
     assert_equal course_offering, version2.course_offering
   end
 
-  # One "integration test" of seeding from DSL creating a CourseVersion for a Script with is_course true.
-  # Other cases are covered by directly testing add_course_version below.
+  # "Integration tests" of on seeding from .script and .course files.
+  # Other cases are covered by directly testing add_course_offering below.
   test "Script.setup creates CourseOffering and CourseVersion if is_course is true" do
     script_file = File.join(self.class.fixture_path, 'test-script-course-version.script')
     scripts, _ = Script.setup([script_file])
@@ -23,6 +23,16 @@ class CourseOfferingTest < ActiveSupport::TestCase
     assert_equal [CourseVersion.find_by(key: '1234')], offering.course_versions
   end
 
+  test "UnitGroup.load_from_path creates CourseOffering and CourseVersion if is_course is true" do
+    course_file = File.join(self.class.fixture_path, 'test-course-offering.course')
+    unit_group = UnitGroup.load_from_path(course_file)
+
+    offering = unit_group.course_version.course_offering
+    assert_equal 'xyz', offering.key
+    assert_equal [CourseVersion.find_by(key: '1234')], offering.course_versions
+  end
+
+  # "Unit tests", parameterized so they test both types of content roots (Scripts and UnitGroups).
   [:unit, :unit_group].each do |content_root_type|
     test "add_course_offering creates CourseOffering and CourseVersion for #{content_root_type}" do
       family_name = 'csz'

--- a/dashboard/test/models/course_version_test.rb
+++ b/dashboard/test/models/course_version_test.rb
@@ -20,31 +20,24 @@ class CourseVersionTest < ActiveSupport::TestCase
   end
 
   test "add_course_version updates existing CourseVersion for script if properties change" do
-    offering = create :course_offering
-    script = create :script, family_name: 'csz', version_year: '2050', is_course: true
-    CourseVersion.add_course_version(offering, script)
+    course_version = create :course_version, :with_unit, :with_course_offering
+    script = course_version.content_root
+    offering = course_version.course_offering
 
-    assert_equal '2050', script.course_version.key
-    assert_equal '2050', script.course_version.display_name
-
-    script.family_name = 'csx'
     script.version_year = '2060'
     script.save
-
     CourseVersion.add_course_version(offering, script)
 
     assert_equal '2060', script.course_version.key
     assert_equal '2060', script.course_version.display_name
-    assert_equal script.course_version, CourseVersion.find_by(course_offering: offering, key: '2060')
+    assert_equal script.course_version, CourseVersion.find_by(course_offering: course_version.course_offering, key: '2060')
     assert_nil CourseVersion.find_by(course_offering: offering, key: '2050') # old CourseVersion should be deleted
   end
 
   test "add_course_version deletes CourseVersion for script if is_course is changed to false" do
-    offering = create :course_offering
-    script = create :script, family_name: 'csz', version_year: '2050', is_course: true
-    CourseVersion.add_course_version(offering, script)
-
-    assert_not_nil script.course_version
+    course_version = create :course_version, :with_unit, :with_course_offering
+    script = course_version.content_root
+    offering = course_version.course_offering
 
     script.is_course = false
     script.save

--- a/dashboard/test/models/course_version_test.rb
+++ b/dashboard/test/models/course_version_test.rb
@@ -11,19 +11,6 @@ class CourseVersionTest < ActiveSupport::TestCase
     assert_equal course_version, course_version.content_root.course_version
   end
 
-  # One "integration test" of seeding from DSL creating a CourseVersion for a Script with is_course true.
-  # Other cases are covered by directly testing add_course_version below.
-  test "Script.setup creates CourseVersion if is_course is true" do
-    script_file = File.join(self.class.fixture_path, 'test-script-course-version.script')
-    scripts, _ = Script.setup([script_file])
-    script = scripts.first
-
-    course_version = CourseVersion.find_by(key: 'xyz-1234')
-    assert_equal course_version, script.course_version
-    assert_equal 'xyz-1234', course_version.key
-    assert_equal '1234', course_version.display_name
-  end
-
   test "add_course_version creates CourseVersion for script that doesn't have one if is_course is true" do
     script = create :script, family_name: 'csz', version_year: '2050', is_course: true
     course_version = CourseVersion.add_course_version(script)

--- a/dashboard/test/models/course_version_test.rb
+++ b/dashboard/test/models/course_version_test.rb
@@ -12,52 +12,56 @@ class CourseVersionTest < ActiveSupport::TestCase
   end
 
   test "add_course_version creates CourseVersion for script that doesn't have one if is_course is true" do
+    offering = create :course_offering
     script = create :script, family_name: 'csz', version_year: '2050', is_course: true
-    course_version = CourseVersion.add_course_version(script)
+    course_version = CourseVersion.add_course_version(offering, script)
 
-    assert_equal course_version, CourseVersion.find_by(key: 'csz-2050')
+    assert_equal course_version, CourseVersion.find_by(course_offering: offering, key: '2050')
   end
 
   test "add_course_version updates existing CourseVersion for script if properties change" do
+    offering = create :course_offering
     script = create :script, family_name: 'csz', version_year: '2050', is_course: true
-    CourseVersion.add_course_version(script)
+    CourseVersion.add_course_version(offering, script)
 
-    assert_equal 'csz-2050', script.course_version.key
+    assert_equal '2050', script.course_version.key
     assert_equal '2050', script.course_version.display_name
 
     script.family_name = 'csx'
     script.version_year = '2060'
     script.save
 
-    CourseVersion.add_course_version(script)
+    CourseVersion.add_course_version(offering, script)
 
-    assert_equal 'csx-2060', script.course_version.key
+    assert_equal '2060', script.course_version.key
     assert_equal '2060', script.course_version.display_name
-    assert_equal script.course_version, CourseVersion.find_by(key: 'csx-2060')
-    assert_nil CourseVersion.find_by(key: 'csz-2050') # old CourseVersion should be deleted
+    assert_equal script.course_version, CourseVersion.find_by(course_offering: offering, key: '2060')
+    assert_nil CourseVersion.find_by(course_offering: offering, key: '2050') # old CourseVersion should be deleted
   end
 
   test "add_course_version deletes CourseVersion for script if is_course is changed to false" do
+    offering = create :course_offering
     script = create :script, family_name: 'csz', version_year: '2050', is_course: true
-    CourseVersion.add_course_version(script)
+    CourseVersion.add_course_version(offering, script)
 
     assert_not_nil script.course_version
 
     script.is_course = false
     script.save
-    course_version = CourseVersion.add_course_version(script)
+    course_version = CourseVersion.add_course_version(offering, script)
 
     assert_nil course_version
     assert_nil script.course_version
-    assert_nil CourseVersion.find_by(key: 'csz-2050')
+    assert_nil CourseVersion.find_by(course_offering: offering, key: '2050')
   end
 
   test "add_course_version does nothing for script without CourseVersion if is_course is false" do
+    offering = create :course_offering
     script = create :script, family_name: 'csz', version_year: '2050'
-    course_version = CourseVersion.add_course_version(script)
+    course_version = CourseVersion.add_course_version(offering, script)
 
     assert_nil course_version
     assert_nil script.course_version
-    assert_nil CourseVersion.find_by(key: 'csz-2050')
+    assert_nil CourseVersion.find_by(course_offering: offering, key: '2050')
   end
 end

--- a/dashboard/test/models/script_test.rb
+++ b/dashboard/test/models/script_test.rb
@@ -1556,6 +1556,7 @@ class ScriptTest < ActiveSupport::TestCase
     assert script.tts
     assert script.is_stable
     assert script.script_announcements
+    assert script.is_course
 
     # some properties that should not change
     assert script.curriculum_path
@@ -1569,6 +1570,7 @@ class ScriptTest < ActiveSupport::TestCase
     refute script_copy.tts
     refute script_copy.is_stable
     refute script_copy.script_announcements
+    refute script_copy.is_course
 
     # some properties that should not change
     assert script_copy.curriculum_path


### PR DESCRIPTION
Updates seeding logic for both .course and .script files to create CourseOffering and CourseVersion objects as appropriate:

- For .script files, only create them when `is_course true` is set.
- For .course files, create them when `family_name` and `version_year` are set. (This is evaluated in the `is_course?` method on UnitGroup)

Both the code and the tests feel like they might be a little more complex than they need to be; I'll keep working on that, but it's not obvious to me how to best simplify yet. In particular there's very similar logic in both `add_course_offering` and `add_course_version`. Suggestions welcome.  EDIT: I think I've gotten it to a good place now.

I believe this should be the last of the major work on adding the new CourseOffering and CourseVersion models.

## Testing story

- unit tests
- manual testing - `db:reset` followed by `seed:all`. Verified in the console:

```
ActiveRecord::Base.logger = nil # disable SQL query logging to make output readable

CourseOffering.all.each do |co|
	puts "CourseOffering: #{co.key}"
	puts co.course_versions.map {|cv| "CourseVersion: #{cv.key} ContentRoot: #{cv.content_root.name}"}
	puts ""
end
```

Output:
```
CourseOffering: coursea
CourseVersion: 2017 ContentRoot: coursea-2017
CourseVersion: 2018 ContentRoot: coursea-2018
CourseVersion: 2019 ContentRoot: coursea-2019
CourseVersion: 2020 ContentRoot: coursea-2020

CourseOffering: courseb
CourseVersion: 2017 ContentRoot: courseb-2017
CourseVersion: 2018 ContentRoot: courseb-2018
CourseVersion: 2019 ContentRoot: courseb-2019
CourseVersion: 2020 ContentRoot: courseb-2020

CourseOffering: coursec
CourseVersion: 2017 ContentRoot: coursec-2017
CourseVersion: 2018 ContentRoot: coursec-2018
CourseVersion: 2019 ContentRoot: coursec-2019
CourseVersion: 2020 ContentRoot: coursec-2020

CourseOffering: coursed
CourseVersion: 2017 ContentRoot: coursed-2017
CourseVersion: 2018 ContentRoot: coursed-2018
CourseVersion: 2019 ContentRoot: coursed-2019
CourseVersion: 2020 ContentRoot: coursed-2020

CourseOffering: coursee
CourseVersion: 2017 ContentRoot: coursee-2017
CourseVersion: 2018 ContentRoot: coursee-2018
CourseVersion: 2019 ContentRoot: coursee-2019
CourseVersion: 2020 ContentRoot: coursee-2020

CourseOffering: coursef
CourseVersion: 2017 ContentRoot: coursef-2017
CourseVersion: 2018 ContentRoot: coursef-2018
CourseVersion: 2019 ContentRoot: coursef-2019
CourseVersion: 2020 ContentRoot: coursef-2020

CourseOffering: express
CourseVersion: 2017 ContentRoot: express-2017
CourseVersion: 2018 ContentRoot: express-2018
CourseVersion: 2019 ContentRoot: express-2019
CourseVersion: 2020 ContentRoot: express-2020

CourseOffering: pre-express
CourseVersion: 2017 ContentRoot: pre-express-2017
CourseVersion: 2018 ContentRoot: pre-express-2018
CourseVersion: 2019 ContentRoot: pre-express-2019
CourseVersion: 2020 ContentRoot: pre-express-2020

CourseOffering: csd
CourseVersion: 2017 ContentRoot: csd-2017
CourseVersion: 2018 ContentRoot: csd-2018
CourseVersion: 2019 ContentRoot: csd-2019
CourseVersion: 2020 ContentRoot: csd-2020
CourseVersion: 2020-pilot ContentRoot: csd-pilot

CourseOffering: csp
CourseVersion: 2017 ContentRoot: csp-2017
CourseVersion: 2018 ContentRoot: csp-2018
CourseVersion: 2019 ContentRoot: csp-2019
CourseVersion: 2020 ContentRoot: csp-2020
```

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
