### PR TITLE
add redirect_to option to test_user_gets_response_for test helper

### DIFF
--- a/dashboard/test/controllers/lessons_controller_test.rb
+++ b/dashboard/test/controllers/lessons_controller_test.rb
@@ -38,7 +38,7 @@ class LessonsControllerTest < ActionController::TestCase
   end
 
   # only levelbuilders can edit
-  test_user_gets_response_for :edit, params: -> {{id: @lesson.id}}, user: nil, response: :redirect
+  test_user_gets_response_for :edit, params: -> {{id: @lesson.id}}, user: nil, response: :redirect, redirected_to: '/users/sign_in'
   test_user_gets_response_for :edit, params: -> {{id: @lesson.id}}, user: :student, response: :forbidden
   test_user_gets_response_for :edit, params: -> {{id: @lesson.id}}, user: :teacher, response: :forbidden
   test_user_gets_response_for :edit, params: -> {{id: @lesson.id}}, user: :levelbuilder, response: :success
@@ -54,7 +54,7 @@ class LessonsControllerTest < ActionController::TestCase
   end
 
   # only levelbuilders can update
-  test_user_gets_response_for :update, params: -> {@update_params}, user: nil, response: :redirect
+  test_user_gets_response_for :update, params: -> {{id: @lesson.id}}, user: nil, response: :redirect, redirected_to: '/users/sign_in'
   test_user_gets_response_for :update, params: -> {@update_params}, user: :student, response: :forbidden
   test_user_gets_response_for :update, params: -> {@update_params}, user: :teacher, response: :forbidden
   test_user_gets_response_for :update, params: -> {@update_params}, user: :levelbuilder, response: :redirect

--- a/dashboard/test/test_helper.rb
+++ b/dashboard/test/test_helper.rb
@@ -445,7 +445,7 @@ class ActionController::TestCase
   #     assert_equal :admin, assigns(:permission)
   #   end
   def self.test_user_gets_response_for(action, method: :get, response: :success,
-    user: nil, params: {}, name: nil, queries: nil, &block)
+    user: nil, params: {}, name: nil, queries: nil, redirected_to: nil, &block)
 
     unless name.present?
       raise 'name is required when a block is provided' if block
@@ -457,6 +457,7 @@ class ActionController::TestCase
         end
 
       name = "#{user_display_name} calling #{method} #{action} should receive #{response}"
+      name += " to #{redirected_to}"
     end
 
     test name do
@@ -476,6 +477,8 @@ class ActionController::TestCase
         send method, action, params: params
         assert_response response
       end
+
+      assert_redirected_to redirected_to if redirected_to
 
       # Run additional test logic, if supplied
       instance_exec(&block) if block


### PR DESCRIPTION
there was already a way to do this using a block: https://github.com/code-dot-org/code-dot-org/blob/6b19697c501d574ab0de373775b5cc16d5030ad5/dashboard/test/controllers/courses_controller_test.rb#L155-L159 but testing the redirect seems common enough that it seems worth adding.

## Testing story

The test helper is covered by the tests which have been modified to use it.

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
