### PR TITLE
Adding script to update time_spent to seconds from milliseconds

### DIFF
--- a/bin/oneoff/data_fix/time_spent_milliseconds_to_seconds
+++ b/bin/oneoff/data_fix/time_spent_milliseconds_to_seconds
@@ -19,18 +19,11 @@ require_relative '../../../dashboard/config/environment'
 # upper limit: 2811329000;
 # lower limit:   93221000;
 
-slice = 0
-
-UserLevel.find_in_batches(start: 93_221_000, finish: 2_811_329_000, batch_size: 5000) do |user_level_slice|
-  puts "PROCESSING: slice #{slice} with starting id #{user_level_slice.first.id}."
-  ActiveRecord::Base.transaction do
-    user_level_slice.each do |user_level|
-      if user_level.time_spent && user_level.time_spent > 0
-        user_level.time_spent = (user_level.time_spent.to_f / 1000).ceil.to_i
-        user_level.save(touch: false, validate: false)
-      end
-    end
+UserLevel.find_each(start: 93_221_000, finish: 2_811_329_000, batch_size: 5000) do |user_level|
+  if user_level.time_spent && user_level.time_spent > 0
+    user_level.time_spent = (user_level.time_spent.to_f / 1000).ceil.to_i
+    user_level.save(touch: false, validate: false)
   end
-  puts "PROCESSED: slice: #{slice}."
-  slice += 1
+rescue Exception => e
+  puts "Error with user_level #{user_level.id}. Skipping and continuing. Error message: #{e.message}"
 end

--- a/bin/oneoff/data_fix/time_spent_milliseconds_to_seconds
+++ b/bin/oneoff/data_fix/time_spent_milliseconds_to_seconds
@@ -24,8 +24,9 @@ UserLevel.find_each(start: 93_221_000, finish: 2_811_329_000, batch_size: 5000).
     puts "Starting transform of user_level with id #{user_level.id}"
   end
   if user_level.time_spent && user_level.time_spent > 0
-    user_level.time_spent = (user_level.time_spent.to_f / 1000).ceil.to_i
-    user_level.save(touch: false, validate: false)
+    new_time_spent = (user_level.time_spent.to_f / 1000).ceil.to_i
+    # update without validation, callbacks, or changes to updated_at
+    user_level.update_columns(time_spent: new_time_spent)
   end
 rescue Exception => e
   puts "Error with user_level #{user_level.id}. Skipping and continuing. Error message: #{e.message}"

--- a/bin/oneoff/data_fix/time_spent_milliseconds_to_seconds
+++ b/bin/oneoff/data_fix/time_spent_milliseconds_to_seconds
@@ -1,0 +1,22 @@
+#!/usr/bin/env ruby
+
+require_relative '../../../dashboard/config/environment'
+
+# The time_spent field in the user_levels table has been
+# recording time in milliseconds. This will cause time_spent
+# to max out at ~25 days. Instead we want to record time in
+# seconds. This will cause time_spent to max out at ~68 years
+#
+# Relevant entries include:
+# SELECT *
+# FROM user_levels
+# WHERE time_spent IS NOT NULL
+#   AND time_spent > 0;
+#
+# time_spent should be transformed as such
+# (time_spent.to_f/1000).ceil.to_i
+
+UserLevel.where("time_spent > ?", 0).where.not(time_spent: nil).each do |user_level|
+  user_level.time_spent = (user_level.time_spent.to_f / 1000).ceil.to_i
+  user_level.save!
+end

--- a/bin/oneoff/data_fix/time_spent_milliseconds_to_seconds
+++ b/bin/oneoff/data_fix/time_spent_milliseconds_to_seconds
@@ -27,7 +27,7 @@ UserLevel.find_in_batches(start: 93_221_000, finish: 2_811_329_000, batch_size: 
     user_level_slice.each do |user_level|
       if user_level.time_spent && user_level.time_spent > 0
         user_level.time_spent = (user_level.time_spent.to_f / 1000).ceil.to_i
-        user_level.save!
+        user_level.save(touch: false, validate: false)
       end
     end
   end

--- a/bin/oneoff/data_fix/time_spent_milliseconds_to_seconds
+++ b/bin/oneoff/data_fix/time_spent_milliseconds_to_seconds
@@ -19,7 +19,10 @@ require_relative '../../../dashboard/config/environment'
 # upper limit: 2811329000;
 # lower limit:   93221000;
 
-UserLevel.find_each(start: 93_221_000, finish: 2_811_329_000, batch_size: 5000) do |user_level|
+UserLevel.find_each(start: 93_221_000, finish: 2_811_329_000, batch_size: 5000).with_index do |user_level, index|
+  if index % 10000 == 0
+    puts "Starting transform of user_level with id #{user_level.id}"
+  end
   if user_level.time_spent && user_level.time_spent > 0
     user_level.time_spent = (user_level.time_spent.to_f / 1000).ceil.to_i
     user_level.save(touch: false, validate: false)
@@ -27,3 +30,5 @@ UserLevel.find_each(start: 93_221_000, finish: 2_811_329_000, batch_size: 5000) 
 rescue Exception => e
   puts "Error with user_level #{user_level.id}. Skipping and continuing. Error message: #{e.message}"
 end
+
+puts "Finished!"

--- a/bin/oneoff/data_fix/time_spent_milliseconds_to_seconds
+++ b/bin/oneoff/data_fix/time_spent_milliseconds_to_seconds
@@ -21,12 +21,14 @@ require_relative '../../../dashboard/config/environment'
 
 slice = 0
 
-UserLevel.where.not(time_spent: nil).where("time_spent > ?", 0).find_in_batches(start: 93_221_000, finish: 2_811_329_000, batch_size: 5000) do |user_level_slice|
+UserLevel.find_in_batches(start: 93_221_000, finish: 2_811_329_000, batch_size: 5000) do |user_level_slice|
   puts "PROCESSING: slice #{slice} with starting id #{user_level_slice.first.id}."
   ActiveRecord::Base.transaction do
     user_level_slice.each do |user_level|
-      user_level.time_spent = (user_level.time_spent.to_f / 1000).ceil.to_i
-      user_level.save!
+      if user_level.time_spent && user_level.time_spent > 0
+        user_level.time_spent = (user_level.time_spent.to_f / 1000).ceil.to_i
+        user_level.save!
+      end
     end
   end
   puts "PROCESSED: slice: #{slice}."

--- a/bin/oneoff/data_fix/time_spent_milliseconds_to_seconds
+++ b/bin/oneoff/data_fix/time_spent_milliseconds_to_seconds
@@ -16,7 +16,19 @@ require_relative '../../../dashboard/config/environment'
 # time_spent should be transformed as such
 # (time_spent.to_f/1000).ceil.to_i
 
-UserLevel.where("time_spent > ?", 0).where.not(time_spent: nil).each do |user_level|
-  user_level.time_spent = (user_level.time_spent.to_f / 1000).ceil.to_i
-  user_level.save!
+# upper limit: 2811329000;
+# lower limit:   93221000;
+
+slice = 0
+
+UserLevel.where.not(time_spent: nil).where("time_spent > ?", 0).find_in_batches(start: 93_221_000, finish: 2_811_329_000, batch_size: 5000) do |user_level_slice|
+  puts "PROCESSING: slice #{slice} with starting id #{user_level_slice.first.id}."
+  ActiveRecord::Base.transaction do
+    user_level_slice.each do |user_level|
+      user_level.time_spent = (user_level.time_spent.to_f / 1000).ceil.to_i
+      user_level.save!
+    end
+  end
+  puts "PROCESSED: slice: #{slice}."
+  slice += 1
 end


### PR DESCRIPTION
The time_spent field in the user_levels table has been recording time in milliseconds. This will cause time_spent to max out at ~25 days due to mysql's integer size. Instead we want to record time in seconds. This will cause time_spent to max out at ~68 years.

Recording time_spent was temporarily disabled by [this pr](https://github.com/code-dot-org/code-dot-org/pull/36380) so we can make this change on all existing UserLevel records.

<!--
  Other aspects to consider. uncomment and add detail for any that seem necessary:
-->

<!-- ### Background -->
<!-- ### Privacy -->
<!-- ### Security -->
<!-- ### Caching -->
<!-- ### Deployment strategy -->
<!-- ### Future work -->

## Links

<!--
  Any relevant links to external resources; ie, specification documents, jira
  items, related PRs, honeybadger errors, etc
-->

- [jira](https://codedotorg.atlassian.net/browse/LP-1532)

## Testing story

<!--
  Does your change include appropriate tests?

  If so, please describe how the tests included in this PR are sufficient

  If not, please explain why this change does not need to be tested.
-->

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
