### PR TITLE
[Spritelab Blocks] add locationModifier, fix countByAnimation

### DIFF
--- a/apps/src/p5lab/spritelab/commands.js
+++ b/apps/src/p5lab/spritelab/commands.js
@@ -142,6 +142,10 @@ export const commands = {
     return locationCommands.locationAt(x, y);
   },
 
+  locationModifier(distance, direction, location) {
+    return locationCommands.locationModifier(distance, direction, location);
+  },
+
   locationMouse() {
     return locationCommands.locationMouse.apply(this);
   },
@@ -156,9 +160,7 @@ export const commands = {
 
   // Sprite commands
   countByAnimation(spriteArg) {
-    if (spriteArg.costume) {
-      return spriteCommands.countByAnimation(spriteArg.costume);
-    }
+    return spriteCommands.countByAnimation(spriteArg);
   },
 
   createNewSprite(name, animation, location) {

--- a/apps/src/p5lab/spritelab/commands/locationCommands.js
+++ b/apps/src/p5lab/spritelab/commands/locationCommands.js
@@ -12,7 +12,12 @@ export const commands = {
       South: location => ({x: location.x, y: location.y + distance}),
       West: location => ({x: location.x - distance, y: location.y})
     };
-    if (!location || !location.x || !location.y || !dirs[direction]) {
+    if (
+      location === undefined ||
+      location.x === undefined ||
+      location.y === undefined ||
+      !dirs[direction]
+    ) {
       return;
     }
     return dirs[direction](location);

--- a/apps/src/p5lab/spritelab/commands/locationCommands.js
+++ b/apps/src/p5lab/spritelab/commands/locationCommands.js
@@ -5,6 +5,19 @@ export const commands = {
     return {x: x, y: 400 - y};
   },
 
+  locationModifier(distance, direction, location) {
+    let dirs = {
+      North: location => ({x: location.x, y: location.y - distance}),
+      East: location => ({x: location.x + distance, y: location.y}),
+      South: location => ({x: location.x, y: location.y + distance}),
+      West: location => ({x: location.x - distance, y: location.y})
+    };
+    if (!location || !location.x || !location.y || !dirs[direction]) {
+      return;
+    }
+    return dirs[direction](location);
+  },
+
   locationMouse() {
     return {x: this.World.mouseX, y: this.World.mouseY};
   },

--- a/apps/src/p5lab/spritelab/commands/spriteCommands.js
+++ b/apps/src/p5lab/spritelab/commands/spriteCommands.js
@@ -1,8 +1,8 @@
 import * as coreLibrary from '../coreLibrary';
 
 export const commands = {
-  countByAnimation(animation) {
-    let sprites = coreLibrary.getSpriteArray({costume: animation});
+  countByAnimation(spriteArg) {
+    let sprites = coreLibrary.getSpriteArray(spriteArg);
     return sprites.length;
   },
   destroy(spriteArg) {

--- a/apps/test/unit/spritelab/locationCommandsTest.js
+++ b/apps/test/unit/spritelab/locationCommandsTest.js
@@ -16,6 +16,39 @@ describe('Location Commands', () => {
     expect(commands.locationAt(50, 300)).to.deep.equal({x: 50, y: 100});
   });
 
+  describe('locationModifier', () => {
+    it('works with normal inputs', () => {
+      expect(
+        commands.locationModifier(25, 'North', {x: 100, y: 200})
+      ).to.deep.equal({x: 100, y: 175});
+      expect(
+        commands.locationModifier(25, 'South', {x: 100, y: 200})
+      ).to.deep.equal({x: 100, y: 225});
+      expect(
+        commands.locationModifier(25, 'East', {x: 100, y: 200})
+      ).to.deep.equal({x: 125, y: 200});
+      expect(
+        commands.locationModifier(25, 'West', {x: 100, y: 200})
+      ).to.deep.equal({x: 75, y: 200});
+    });
+
+    it('works with location (0, 0)', () => {
+      expect(
+        commands.locationModifier(15, 'North', {x: 0, y: 0})
+      ).to.deep.equal({
+        x: 0,
+        y: -15
+      });
+    });
+
+    it('returns undefined if given invalid inputs', () => {
+      expect(commands.locationModifier(15, 'North')).to.equal(undefined);
+      expect(
+        commands.locationModifier(15, 'Invalid Direction', {x: 10, y: 10})
+      ).to.equal(undefined);
+    });
+  });
+
   it('locationMouse', () => {
     let locationMouse = commands.locationMouse.bind(p5Wrapper.p5);
     p5Wrapper.p5.mouseX = 0;

--- a/apps/test/unit/spritelab/spriteCommandsTest.js
+++ b/apps/test/unit/spritelab/spriteCommandsTest.js
@@ -26,9 +26,11 @@ describe('Sprite Commands', () => {
     makeSprite({name: sprite2Name, animation: 'b'});
     makeSprite({name: sprite3Name, animation: 'a'});
 
-    expect(commands.countByAnimation('a')).to.equal(2);
-    expect(commands.countByAnimation('b')).to.equal(1);
-    expect(commands.countByAnimation('c')).to.equal(0);
+    expect(commands.countByAnimation({costume: 'a'})).to.equal(2);
+    expect(commands.countByAnimation({costume: 'b'})).to.equal(1);
+    expect(commands.countByAnimation({costume: 'c'})).to.equal(0);
+
+    expect(commands.countByAnimation({name: sprite1Name})).to.equal(1);
   });
 
   it('destroy single sprite', () => {

--- a/dashboard/config/blocks/GamelabJr/gamelab_locationModifier.json
+++ b/dashboard/config/blocks/GamelabJr/gamelab_locationModifier.json
@@ -1,0 +1,40 @@
+{
+  "category": "Location",
+  "config": {
+    "func": "locationModifier",
+    "blockText": "{DISTANCE} pixels {DIRECTION} of {LOCATION}",
+    "returnType": "Location",
+    "args": [
+      {
+        "name": "DISTANCE",
+        "type": "Number",
+        "field": true
+      },
+      {
+        "name": "DIRECTION",
+        "options": [
+          [
+            "North",
+            "\"North\""
+          ],
+          [
+            "East",
+            "\"East\""
+          ],
+          [
+            "South",
+            "\"South\""
+          ],
+          [
+            "West",
+            "\"West\""
+          ]
+        ]
+      },
+      {
+        "name": "LOCATION",
+        "type": "Location"
+      }
+    ]
+  }
+}


### PR DESCRIPTION
New block locationModifier:
![image](https://user-images.githubusercontent.com/8787187/90928441-b4c5dc00-e3ab-11ea-8ec4-482743448c1f.png)

![image](https://user-images.githubusercontent.com/8787187/90928414-abd50a80-e3ab-11ea-8757-c7452f54f421.png)



Fix countByAnimation to work with named sprites as well. Ideally we would have named this numberOf or something like that, but we didn't, and it's not really possible to change block names once they've been created (it would break for everyone who already has the block in a project).

Before:
![image](https://user-images.githubusercontent.com/8787187/90928539-e9399800-e3ab-11ea-8262-c56187c9766f.png)

After:
![image](https://user-images.githubusercontent.com/8787187/90928565-fbb3d180-e3ab-11ea-9be0-694a87b0394d.png)

<!--
  Other aspects to consider. uncomment and add detail for any that seem necessary:
-->

<!-- ### Background -->
<!-- ### Privacy -->
<!-- ### Security -->
<!-- ### Caching -->
<!-- ### Deployment strategy -->
<!-- ### Future work -->
