### PR TITLE
Academic Year Workshops: don't show survey buttons on dashboard

### DIFF
--- a/dashboard/app/models/pd/enrollment.rb
+++ b/dashboard/app/models/pd/enrollment.rb
@@ -385,8 +385,8 @@ class Pd::Enrollment < ActiveRecord::Base
     end
 
     filtered_ids = select_completed ?
-                   ids_with_processed_surveys + ids_with_unprocessed_surveys :
-                   ids_without_processed_surveys - ids_with_unprocessed_surveys
+                     ids_with_processed_surveys + ids_with_unprocessed_surveys :
+                     ids_without_processed_surveys - ids_with_unprocessed_surveys
 
     enrollments.select {|e| filtered_ids.include? e.id}
   end

--- a/dashboard/app/models/pd/enrollment.rb
+++ b/dashboard/app/models/pd/enrollment.rb
@@ -153,7 +153,7 @@ class Pd::Enrollment < ActiveRecord::Base
     end
   end
 
-  # Filters a list of enrollments for survey completion, for the workshop types we want to know about
+  # Filters a list of enrollments for survey completion, for the workshop types we are able to filter for
   # survey completion: CSD/CSP Summer, CSP Workshop for Returning Teachers, CSF Intro/Deep Dive, Counselor
   # and Admin. We will always return [] for Academic year workshops as we want facilitators to handle those surveys.
   # @param enrollments [Enumerable<Pd::Enrollment>] list of enrollments to filter.
@@ -175,6 +175,7 @@ class Pd::Enrollment < ActiveRecord::Base
         (enrollment.workshop.csf_intro? || enrollment.workshop.local_summer? || enrollment.workshop.csp_wfrt?)
     end
 
+    # Admin and Counselor still use Pegasus form
     pegasus_enrollments, _ = other_enrollments.partition do |enrollment|
       enrollment.workshop.course == COURSE_ADMIN || enrollment.workshop.course == COURSE_COUNSELOR
     end
@@ -384,8 +385,8 @@ class Pd::Enrollment < ActiveRecord::Base
     end
 
     filtered_ids = select_completed ?
-                     ids_with_processed_surveys + ids_with_unprocessed_surveys :
-                     ids_without_processed_surveys - ids_with_unprocessed_surveys
+                   ids_with_processed_surveys + ids_with_unprocessed_surveys :
+                   ids_without_processed_surveys - ids_with_unprocessed_surveys
 
     enrollments.select {|e| filtered_ids.include? e.id}
   end

--- a/dashboard/app/models/pd/enrollment.rb
+++ b/dashboard/app/models/pd/enrollment.rb
@@ -221,7 +221,7 @@ class Pd::Enrollment < ActiveRecord::Base
       CDO.code_org_url "/pd-workshop-survey/counselor-admin/#{code}", CDO.default_scheme
     elsif workshop.csf? && workshop.subject == Pd::Workshop::SUBJECT_CSF_201
       CDO.studio_url "/pd/workshop_survey/csf/post201/#{code}", CDO.default_scheme
-    # any othr non-academic year workshop uses foorm. We don't automatically provide survey urls for AYW
+    # any other non-academic year workshop uses foorm. We don't automatically provide survey urls for AYW
     elsif !ACADEMIC_YEAR_WORKSHOP_SUBJECTS.include?(workshop.subject)
       CDO.studio_url "/pd/workshop_post_survey?enrollmentCode=#{code}", CDO.default_scheme
     end

--- a/dashboard/app/models/pd/workshop.rb
+++ b/dashboard/app/models/pd/workshop.rb
@@ -806,7 +806,9 @@ class Pd::Workshop < ActiveRecord::Base
   end
 
   def pre_survey?
-    return false if subject == SUBJECT_CSP_FOR_RETURNING_TEACHERS
+    # CSP for returning teachers does not have a pre-survey. Academic year workshops have multiple pre-survey options,
+    # so we do not show any to teachers ourselves.
+    return false if subject == SUBJECT_CSP_FOR_RETURNING_TEACHERS || ACADEMIC_YEAR_WORKSHOP_SUBJECTS.include?(subject)
     PRE_SURVEY_BY_COURSE.key? course
   end
 


### PR DESCRIPTION
Academic year workshop have multiple possible pre and post surveys per workshop. Therefore we are not going to show buttons for the teacher to take the surveys in the dashboard. This PR makes it so that teachers enrolled in AYW will still see the workshop in the professional learning dashboard, but they won't be prompted to take a survey on their dashboard.

<!-- ### Background -->
<!-- ### Privacy -->
<!-- ### Security -->
<!-- ### Caching -->
<!-- ### Deployment strategy -->
<!-- ### Future work -->

## Links

- [spec - survey links](https://docs.google.com/document/d/1uYKpTUS3eJOna9008p_6-30fEeX_vdPc0dEDEDc-MXU/edit)

## Testing story
Tested locally that teachers do not see the survey links anymore, but they can still see them for other workshop types.


# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
