### PR TITLE
Course offering seeding fix

### DIFF
--- a/dashboard/app/models/course_version.rb
+++ b/dashboard/app/models/course_version.rb
@@ -69,6 +69,6 @@ class CourseVersion < ApplicationRecord
   # Destroys this CourseVersion. Then, if its parent CourseOffering now has no CourseVersions, destroy it too.
   def destroy_and_destroy_parent_if_empty
     destroy!
-    course_offering.destroy if course_offering.course_versions.empty?
+    course_offering.destroy if course_offering && course_offering.course_versions.empty?
   end
 end


### PR DESCRIPTION
Fixes this staging seeding failure: https://codedotorg.slack.com/archives/C03CK8E51/p1598249784076000

Which occurred because CourseVerisons exist in the DB that don't have associated CourseOfferings, and this case wasn't handled in the `destroy_and_destroy_parent_if_empty` method before. This state shouldn't normally exist, but it did because I added logic to seed CourseVersions before adding the CourseOffering model and seeding logic.