### PR TITLE
Update Contained Levels Eyes Test to Close Eyes at End of Scenario

### DIFF
--- a/dashboard/test/ui/features/learning_platform/level_types/contained_levels.feature
+++ b/dashboard/test/ui/features/learning_platform/level_types/contained_levels.feature
@@ -42,6 +42,7 @@ Scenario: GameLab with a submittable contained level
   And I press "submitButton"
   And I press "confirm-button"
   And I wait until current URL contains "/stage/41/puzzle/8"
+  Then I close my eyes
 
 Scenario: Gamelab with multiple choice contained level
   When I open my eyes to test "gamelab contained level"


### PR DESCRIPTION
The `gamelab contained level` Scenario in the `Contained Levels` Eyes test always shows as `Running` in Applitools even when the Feature has completed execution successfully. This is possibly because the Scenario does not end the Eyes session.

<img width="399" alt="fix contained levels test to close eyes" src="https://user-images.githubusercontent.com/2157034/91082181-25b00280-e5fd-11ea-826d-65ba59f82bba.png">
<img width="251" alt="fix contained levels test to close Eyes - batch" src="https://user-images.githubusercontent.com/2157034/91082182-26e12f80-e5fd-11ea-8dd8-bd943765e692.png">


<!-- ### Background -->
<!-- ### Privacy -->
<!-- ### Security -->
<!-- ### Caching -->
<!-- ### Deployment strategy -->
<!-- ### Future work -->


# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
