### PR TITLE
Signed out homepage banner highlights the alternative classrooms page

### DIFF
--- a/pegasus/sites.v3/code.org/views/homepage_below_hero_special2020_banner.haml
+++ b/pegasus/sites.v3/code.org/views/homepage_below_hero_special2020_banner.haml
@@ -1,12 +1,12 @@
 - if Homepage.show_special2020_banner(request)
-  %a{href: "/athome", style: "color: white; font-family: 'Gotham 4r', sans-serif"}
+  %a{href: "/alternative-classrooms", style: "color: white; font-family: 'Gotham 4r', sans-serif"}
     .special_2020_announcement{style: "text-align: center; background-color: #0094ca; color: white; font-size: 18px; padding: 16px; overflow: hidden"}
       .container_responsive
         .col-66
           .icon.tablet-feature{style: "float: left; font-size: 60px; padding-right: 30px"}
             %i{:class=>"fa fa-home"}
           .texts{style: "text-align: left; padding-top: 7px; padding-bottom: 5px"}
-            = hoc_s(:codeorg_homepage_special2020_body)
+            = hoc_s(:codeorg_homepage_remote2020_body)
         .col-33
           %button{style: "color: white; font-size: 18px; background-color: initial; border-color: white; min-width: 230px; height: 40px; padding: 0 30px;"}
             = hoc_s(:codeorg_homepage_special2020_link_text)

--- a/pegasus/sites.v3/hourofcode.com/i18n/en.yml
+++ b/pegasus/sites.v3/hourofcode.com/i18n/en.yml
@@ -129,6 +129,7 @@
   codeorg_homepage_special2020_body1: "Support for parents and teachers facing school closures."
   codeorg_homepage_special2020_body2: "See our suggested learning resources."
   codeorg_homepage_special2020_body: "Keep learning this summer! Take a look at our resources for learning at home."
+  codeorg_homepage_remote2020_body: "Are you teaching in a remote or socially-distanced classroom this semester? View our resources."
   codeorg_homepage_special2020_link_text: "Get started"
   codeorg_homepage_code_break_body: "Take a Code Break! Your weekly dose of inspiration, community, and computer science."
   codeorg_homepage_code_break_link_text: "Learn more"


### PR DESCRIPTION
The signed out homepage banner now links to the alternative classrooms page with resources for back to school

<img width="1156" alt="Screen Shot 2020-08-25 at 12 41 13 AM" src="https://user-images.githubusercontent.com/224089/91146948-7743a600-e66c-11ea-9205-59591173113f.png">


<!--
  Your description goes here: A summary of the change, including any relevant motivation and context.

  If relevant, include a description both of the existing behavior and of the new behavior.
-->

<!--
  Other aspects to consider. uncomment and add detail for any that seem necessary:
-->

<!-- ### Background -->
<!-- ### Privacy -->
<!-- ### Security -->
<!-- ### Caching -->
<!-- ### Deployment strategy -->
<!-- ### Future work -->

## Links

<!--
  Any relevant links to external resources; ie, specification documents, jira
  items, related PRs, honeybadger errors, etc
-->

- [jira](https://codedotorg.atlassian.net/browse/PLC-966?atlOrigin=eyJpIjoiZDdlNjMyN2I3MTBjNGI2ZjgwYWRhMDRkY2FmYmUxN2UiLCJwIjoiaiJ9)

## Testing story

<!--
  Does your change include appropriate tests?

  If so, please describe how the tests included in this PR are sufficient

  If not, please explain why this change does not need to be tested.
-->

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
