### PR TITLE
Fix progress table so it can display multiple pages of students

### DIFF
--- a/apps/src/templates/sectionProgress/sectionProgressLoader.js
+++ b/apps/src/templates/sectionProgress/sectionProgressLoader.js
@@ -87,28 +87,28 @@ export function loadScript(scriptId, sectionId) {
       .then(data => {
         sectionProgress.studentLevelProgressByScript = {
           [scriptId]: {
-            ...sectionProgress.studentLevelProgressByScript,
+            ...sectionProgress.studentLevelProgressByScript[scriptId],
             ...getInfoByStudentByLevel(data.students, getLevelResult)
           }
         };
 
         sectionProgress.studentTimestampsByScript = {
           [scriptId]: {
-            ...sectionProgress.studentTimestampsByScript,
+            ...sectionProgress.studentTimestampsByScript[scriptId],
             ...processStudentTimestamps(data.student_timestamps)
           }
         };
 
         sectionProgress.studentLevelTimeSpentByScript = {
           [scriptId]: {
-            ...sectionProgress.studentLevelTimeSpentByScript,
+            ...sectionProgress.studentLevelTimeSpentByScript[scriptId],
             ...getInfoByStudentByLevel(data.students, level => level.time_spent)
           }
         };
 
         sectionProgress.studentLevelPairingByScript = {
           [scriptId]: {
-            ...sectionProgress.studentLevelPairingByScript,
+            ...sectionProgress.studentLevelPairingByScript[scriptId],
             ...processStudentPairing(data.students)
           }
         };


### PR DESCRIPTION
After the [refactor of section progress](https://github.com/code-dot-org/code-dot-org/pull/36192/files), we could only display the first page of students (50 students) on the section progress teacher view. This fixes the bug introduced in that refactor.
<!--
  Other aspects to consider. uncomment and add detail for any that seem necessary:
-->

<!-- ### Background -->
<!-- ### Privacy -->
<!-- ### Security -->
<!-- ### Caching -->
<!-- ### Deployment strategy -->
<!-- ### Future work -->

## Links

<!--
  Any relevant links to external resources; ie, specification documents, jira
  items, related PRs, honeybadger errors, etc
-->

- [zendesk](https://codeorg.zendesk.com/agent/tickets/290634)
- [jira](https://codedotorg.atlassian.net/browse/LP-1534)

## Testing story

<!--
  Does your change include appropriate tests?

  If so, please describe how the tests included in this PR are sufficient

  If not, please explain why this change does not need to be tested.
-->

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
