### PR TITLE
Add new facilitator survey to post-email for CSD/CSP

### DIFF
--- a/dashboard/app/controllers/foorm/misc_survey_controller.rb
+++ b/dashboard/app/controllers/foorm/misc_survey_controller.rb
@@ -6,6 +6,10 @@ module Foorm
     # GET '/form/:misc_form_path'
     # misc_form_path references the configuration in foorm/misc_survey, which maps a
     # form path to a set of survey variables and a form name.
+    # Survey variables can be provided in the following format:
+    # '/form/:misc_form_path?survey_data[variable1]=value1&survey_data[variable2]=value2'
+    # If no variables are provided, will use survey variables from the configuration in foorm/misc_survey,
+    # or use no variables if there are none in the configuration.
     def new
       return render :logged_out unless current_user
       return render :not_teacher unless current_user.teacher?
@@ -34,7 +38,7 @@ module Foorm
           formQuestions: form_questions,
           formName: form_data[:form_name],
           formVersion: latest_version,
-          surveyData: form_data[:survey_data],
+          surveyData: params[:survey_data] || form_data[:survey_data],
           submitApi: MISC_FOORM_SUBMIT_API,
           submitParams: key_params
         }.to_json

--- a/dashboard/app/mailers/pd/workshop_mailer.rb
+++ b/dashboard/app/mailers/pd/workshop_mailer.rb
@@ -154,7 +154,14 @@ class Pd::WorkshopMailer < ActionMailer::Base
   def facilitator_post_workshop(user, workshop)
     @user = user
     @workshop = workshop
-    @survey_url = CDO.studio_url "/pd/misc_survey/facilitator_post", CDO.default_scheme
+    # TODO: After 9/5/2020 move all workshops to the new survey (9/5 is last 2020 Summer Workshop)
+    if @workshop.local_summer?
+      @survey_url = CDO.studio_url "/pd/misc_survey/facilitator_post", CDO.default_scheme
+    else
+      survey_params = "survey_data[workshop_course]=#{workshop.course}&survey_data[workshop_subject]=#{workshop.subject}"
+      @survey_url = CDO.studio_url "form/facilitator_post_survey?#{survey_params}", CDO.default_scheme
+    end
+
     @regional_partner_name = @workshop.regional_partner&.name
     @deadline = (Time.now + 10.days).strftime('%B %-d, %Y').strip
     @workshop_date = @workshop.sessions.size == 1 ?

--- a/dashboard/app/mailers/pd/workshop_mailer.rb
+++ b/dashboard/app/mailers/pd/workshop_mailer.rb
@@ -158,7 +158,8 @@ class Pd::WorkshopMailer < ActionMailer::Base
     if @workshop.local_summer?
       @survey_url = CDO.studio_url "/pd/misc_survey/facilitator_post", CDO.default_scheme
     else
-      survey_params = "survey_data[workshop_course]=#{workshop.course}&survey_data[workshop_subject]=#{workshop.subject}"
+      survey_params = "survey_data[workshop_course]=#{workshop.course}&survey_data[workshop_subject]=#{workshop.subject}"\
+                      "&survey_data[workshop_id]=#{workshop.id}"
       @survey_url = CDO.studio_url "form/facilitator_post_survey?#{survey_params}", CDO.default_scheme
     end
 

--- a/dashboard/app/models/foorm/misc_survey.rb
+++ b/dashboard/app/models/foorm/misc_survey.rb
@@ -56,6 +56,11 @@ class Foorm::MiscSurvey < ActiveRecord::Base
         misc_form_path: 'csp_post_course_pd',
         survey_data: {course: 'CS Principles', pd: true},
         allow_multiple_submissions: false
+      },
+      {
+        form_name: 'surveys/pd/csd_csp_facilitator_post_survey',
+        misc_form_path: 'facilitator_post_survey',
+        allow_multiple_submissions: true
       }
     ]
   end

--- a/dashboard/test/mailers/previews/pd_workshop_mailer_preview.rb
+++ b/dashboard/test/mailers/previews/pd_workshop_mailer_preview.rb
@@ -229,7 +229,7 @@ class Pd::WorkshopMailerPreview < ActionMailer::Preview
     # the way we set up workshops for mailers means they won't have an id.
     # We want to test that this mailer can extract the workshop id correctly--find
     # an unused id and assign it to this workshop.
-    highest_workshop_id = Pd::Workshop.last.id
+    highest_workshop_id = Pd::Workshop.last&.id || 0
     mail :facilitator_post_workshop,
       Pd::Workshop::COURSE_CSD,
       Pd::Workshop::SUBJECT_CSD_WORKSHOP_1,

--- a/dashboard/test/mailers/previews/pd_workshop_mailer_preview.rb
+++ b/dashboard/test/mailers/previews/pd_workshop_mailer_preview.rb
@@ -226,12 +226,17 @@ class Pd::WorkshopMailerPreview < ActionMailer::Preview
   end
 
   def facilitator_post_workshop_no_rp_csd_workshop_1
+    # the way we set up workshops for mailers means they won't have an id.
+    # We want to test that this mailer can extract the workshop id correctly--find
+    # an unused id and assign it to this workshop.
+    highest_workshop_id = Pd::Workshop.last.id
     mail :facilitator_post_workshop,
       Pd::Workshop::COURSE_CSD,
       Pd::Workshop::SUBJECT_CSD_WORKSHOP_1,
       target: :facilitator,
       workshop_params: {
-        num_sessions: 1
+        num_sessions: 1,
+        id: highest_workshop_id + 5
       }
   end
 


### PR DESCRIPTION
Update our Facilitator post-workshop auto-email to send the new Foorm survey for any non-summer CSD/CSP workshop (we don't send the email for CSF). The survey will be populated with workshop course, workshop subject, and workshop id. This PR also adds the ability to send any variable to a Foorm misc survey via a url parameter.
 
<!-- ### Background -->
<!-- ### Privacy -->
<!-- ### Security -->
<!-- ### Caching -->
<!-- ### Deployment strategy -->

### Future work
After 9/5/2020 we will want to deprecate the old JotForm version of the survey, but we have one more summer workshop before then that we want to have survey data in the same bucket as the other workshops this summer.

## Links

- [jira](https://codedotorg.atlassian.net/browse/PLC-962)

## Testing story
Validated via the mailer previews that an academic year workshop will show the new survey with the correct variables and a summer workshop will show the old survey.

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
