### PR TITLE
Temporarily pin Firefox on SauceLabs to version 79

### DIFF
--- a/dashboard/test/ui/browsers.json
+++ b/dashboard/test/ui/browsers.json
@@ -25,7 +25,7 @@
   {
     "name": "Firefox",
     "browserName": "firefox",
-    "version": "latest",
+    "version": "79",
     "platform": "Windows 10",
     "w3c": true
   },


### PR DESCRIPTION
SauceLabs updated the "latest" version of FF to 80, which seems to have caused a bunch of tests to fail:

- https://cucumber-logs.s3.amazonaws.com/test/test/Firefox_learning_platform_teacher_dashboard_progress_standards_view_output.html?versionId=JdarXxAb2Eb0_L6r3UE37FXy6LPL0b8f
- https://cucumber-logs.s3.amazonaws.com/test/test/Firefox_learning_platform_teacher_dashboard_teacher_dashboard_output.html?versionId=02gkj4gFDH6eGsxbrPOqtG8SHh1wACP7
- https://cucumber-logs.s3.amazonaws.com/test/test/Firefox_star_labs_applab_embed_output.html?versionId=aDUwhYwzk75U5HMjv4RnOJThLXfTZfKm

Example stack trace:

    Expected "handle" to be a string, got [object Undefined] undefined (Selenium::WebDriver::Error::InvalidArgumentError)

    WebDriverError@chrome://marionette/content/error.js:175:5
    InvalidArgumentError@chrome://marionette/content/error.js:304:5
    assert.that/<@chrome://marionette/content/assert.js:479:13
    assert.string@chrome://marionette/content/assert.js:383:53
    GeckoDriver.prototype.switchToWindow@chrome://marionette/content/driver.js:1645:10
    despatch@chrome://marionette/content/server.js:305:40
    execute@chrome://marionette/content/server.js:275:16
    onPacket/<@chrome://marionette/content/server.js:248:20
    onPacket@chrome://marionette/content/server.js:249:9
    _onJSONObjectReady/<@chrome://marionette/content/transport.js:501:20
    ./utils/selenium_browser.rb:38:in `create_response'
    ./features/step_definitions/steps.rb:49:in `page_load'
    ./features/step_definitions/steps.rb:500:in `/^I click selector "([^"]*)"(?: to load a new (page|tab))?$/'
    ./features/support/hooks.rb:28:in `block in '
    features/star_labs/applab/embed.feature:28:in `And I click selector "a:contains('How it Works (View Code)')" to load a new tab'

The temporary solution is to pin to version 79 until we can track down the nature of the failure.