### PR TITLE
pin firefox version to a float, not an int

### DIFF
--- a/dashboard/test/ui/browsers.json
+++ b/dashboard/test/ui/browsers.json
@@ -25,7 +25,7 @@
   {
     "name": "Firefox",
     "browserName": "firefox",
-    "version": "79",
+    "version": "79.0",
     "platform": "Windows 10",
     "w3c": true
   },


### PR DESCRIPTION
Pinning to just "79" didn't work, so trying "79.0" since [previous values](https://github.com/code-dot-org/code-dot-org/commit/481e3afc11ae05914c6993e783f88b16ae0765ae#diff-12d90292993a3b61b189a9c8f7a86fae) have used that level of precision