### PR TITLE
Fix UI test browser config for Firefox

### DIFF
--- a/dashboard/test/ui/browsers.json
+++ b/dashboard/test/ui/browsers.json
@@ -25,7 +25,7 @@
   {
     "name": "Firefox",
     "browserName": "firefox",
-    "version": "79.0",
+    "browserVersion": "79.0",
     "platform": "Windows 10",
     "w3c": true
   },


### PR DESCRIPTION
Saucelabs config is weird. Maybe they changed it at some point, but somehow we were using the wrong key for setting the browser version, and it was defaulting to latest instead of throwing an error.

Test run before this change (FF 80): https://app.saucelabs.com/tests/3b2b40248735446493f7d034f1230c69
After (FF 79): https://app.saucelabs.com/tests/2507a2c349ee48ee92e4762f874dfa58

Tested locally with:
```
bundle exec runner.rb -c Firefox -f features/learning_platform/teacher_dashboard/teacher_dashboard.feature
```