### PR TITLE
Adding margin above standalone video levels

### DIFF
--- a/dashboard/app/assets/stylesheets/application.scss
+++ b/dashboard/app/assets/stylesheets/application.scss
@@ -2360,7 +2360,7 @@ a.download-video {
 
 .standalone-video {
   width: 853px;
-  margin: auto;
+  margin: 25px auto 0 auto;
 
   .video-link, .slides-link, #fallback-player-caption-dialog-link {
     display: inline-block;


### PR DESCRIPTION
Adding back a small space between the Code.org header and videos on standalone video levels. This was accidentally removed in a previous PR which made banner and header changes.

## Testing story
* localhost

## Screenshots
### Before
Note the lack of space between the teal code.org header and the youtube video.
![image](https://user-images.githubusercontent.com/1372238/91257137-a6cfdc80-e758-11ea-9057-e9949328afdf.png)

### After
![image](https://user-images.githubusercontent.com/1372238/91257113-97509380-e758-11ea-8688-3fc08a71ef88.png)

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
