### PR TITLE
Foorm: Add character limit to free responses

### DIFF
--- a/apps/src/code-studio/pd/foorm/Foorm.jsx
+++ b/apps/src/code-studio/pd/foorm/Foorm.jsx
@@ -138,6 +138,8 @@ export default class Foorm extends React.Component {
           css={this.customCss}
           requiredText={'(Required)'}
           showCompletedPage={false}
+          maxTextLength={4000}
+          maxOthersLength={4000}
         />
         {this.state.statusMessage && (
           <div style={styles.statusMessage}>


### PR DESCRIPTION
In our bug bash we noticed there was no character limit on free response questions in Foorm. Added a character limit of 4000 based on [this guidance](https://help.surveymonkey.com/articles/en_US/kb/Are-there-limits-in-SurveyMonkey-such-as-survey-design-or-character-limits)

<!-- ### Background -->
<!-- ### Privacy -->
<!-- ### Security -->
<!-- ### Caching -->
<!-- ### Deployment strategy -->
<!-- ### Future work -->

## Links


- [bug bash doc which discussed this](https://docs.google.com/document/d/1N_EN3i-7tpcTxhp9wTzLp926g_3tb0eifS9Ib9136Dg/edit#)

## Testing story
Tested free response questions are now limited to 4000 characters.

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
