### PR TITLE
Make dropdowns taller in Foorms to fit text

### DIFF
--- a/apps/src/code-studio/pd/foorm/Foorm.jsx
+++ b/apps/src/code-studio/pd/foorm/Foorm.jsx
@@ -46,7 +46,10 @@ export default class Foorm extends React.Component {
       next: 'sv_next_button foorm-button foorm-button-right',
       complete: 'sv_complete_btn foorm-button'
     },
-    row: 'sv_row foorm-adjust-row'
+    row: 'sv_row foorm-adjust-row',
+    dropdown: {
+      control: 'sv_q_dropdown_control foorm-adjust-dropdown-height'
+    }
   };
 
   constructor(props) {

--- a/dashboard/app/assets/stylesheets/application.scss
+++ b/dashboard/app/assets/stylesheets/application.scss
@@ -3418,6 +3418,10 @@ h2.danger {
   text-align: center;
 }
 
+.foorm-adjust-dropdown-height {
+  height: calc(2em + 10px) !important;
+}
+
 #parent-email-banner {
   position: fixed;
   bottom: 0;


### PR DESCRIPTION
Makes dropdowns a bit taller in Foorms, in order to better fit text. Before:

![image](https://user-images.githubusercontent.com/25372625/91351180-b83ad800-e79c-11ea-833a-c680eddcab34.png)

After:

![image](https://user-images.githubusercontent.com/25372625/91351199-c12ba980-e79c-11ea-8fb6-4f47ab494f1e.png)

I'm admittedly basically just pattern matching what was done in a [previous PR](https://github.com/code-dot-org/code-dot-org/pull/33852) for foorm formatting, so worth a second glance to see if I've done anything egregious from a CSS perspective here.

## Testing story

I tested this change locally on /foorm/preview. I did a bit of random clicking around to other surveys to get a sense of whether anything else was affected. Didn't see anything, but not quite a comprehensive check.