### PR TITLE
Update schedule for process_pd_workshop_ends

### DIFF
--- a/cookbooks/cdo-apps/templates/default/crontab.erb
+++ b/cookbooks/cdo-apps/templates/default/crontab.erb
@@ -84,7 +84,7 @@
       cronjob at:'20 */4 * * *', do:deploy_dir('bin', 'cron', 'activity-monitor')
       cronjob at:'30 14 * * *', do:dashboard_dir('bin','scheduled_pd_workshop_emails')
       cronjob at:'0 16 * * *', do:dashboard_dir('bin','scheduled_pd_application_emails')
-      cronjob at:'*/2 * * * *', do:dashboard_dir('bin', 'process_pd_workshop_ends')
+      cronjob at:'*/3 * * * *', do:dashboard_dir('bin', 'process_pd_workshop_ends')
       cronjob at:'*/5 * * * *', do:dashboard_dir('bin', 'fill_jotform_placeholders')
       cronjob at:'*/30 * * * *', do:dashboard_dir('bin', 'sync_jotforms')
       cronjob at:'25 7 * * *', do:deploy_dir('bin', 'cron', 'update_hoc_map')


### PR DESCRIPTION
We got a [honeybadger error](https://app.honeybadger.io/projects/45435/faults/52787853) that meant the schedule for `process_pd_workshop_ends` has too short of a schedule. Increased it to run every 3 minutes instead of every 2 minutes.

<!-- ### Background -->
<!-- ### Privacy -->
<!-- ### Security -->
<!-- ### Caching -->
<!-- ### Deployment strategy -->
<!-- ### Future work -->

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
