### PR TITLE
Prevent progress "leakage" by clearing the sessionStorage progress when we get a DB response

### DIFF
--- a/apps/src/code-studio/clientState.js
+++ b/apps/src/code-studio/clientState.js
@@ -4,6 +4,7 @@
  */
 import {trySetSessionStorage} from '../utils';
 import cookies from 'js-cookie';
+// Note: sessionStorage is not shared between tabs.
 var sessionStorage = window.sessionStorage;
 
 import {mergeActivityResult} from './activityUtils';

--- a/apps/src/code-studio/initApp/loadApp.js
+++ b/apps/src/code-studio/initApp/loadApp.js
@@ -33,6 +33,7 @@ import queryString from 'query-string';
 import * as imageUtils from '@cdo/apps/imageUtils';
 import trackEvent from '../../util/trackEvent';
 import msg from '@cdo/locale';
+import _ from 'lodash';
 
 // Max milliseconds to wait for last attempt data from the server
 var LAST_ATTEMPT_TIMEOUT = 5000;
@@ -60,7 +61,13 @@ function mergeProgressData(scriptName, serverProgress) {
   // Note: Changes to the progressRedux also update the sessionStorage,
   // so this will clear and update the sessionStorage too.
   store.dispatch(clearProgress());
-  store.dispatch(mergeProgress(serverProgress));
+  store.dispatch(
+    mergeProgress(
+      _.mapValues(serverProgress, level =>
+        level.submitted ? TestResults.SUBMITTED_RESULT : level.result
+      )
+    )
+  );
 
   Object.keys(serverProgress).forEach(levelId => {
     // Write down new progress in sessionStorage

--- a/apps/src/code-studio/progressRedux.js
+++ b/apps/src/code-studio/progressRedux.js
@@ -302,7 +302,7 @@ const userProgressFromServer = (state, dispatch, userId = null) => {
   // If we have a userId, we can clear any progress in redux and request all progress
   // from the server.
   if (userId) {
-    dispatch({type: CLEAR_PROGRESS});
+    dispatch(clearProgress());
   }
 
   return $.ajax({
@@ -387,6 +387,10 @@ export const initProgress = ({
   betaTitle,
   courseId,
   isFullProgress
+});
+
+export const clearProgress = () => ({
+  type: CLEAR_PROGRESS
 });
 
 export const mergeProgress = levelProgress => ({

--- a/dashboard/app/controllers/api_controller.rb
+++ b/dashboard/app/controllers/api_controller.rb
@@ -430,6 +430,7 @@ class ApiController < ApplicationController
       user_level = current_user.last_attempt(level, script)
       level_source = user_level.try(:level_source).try(:data)
 
+      # Temporarily return the full set of progress so we can overwrite what the sessionStorage changed
       response[:progress] = summarize_user_progress(script, current_user)[:levels]
 
       if user_level

--- a/dashboard/app/controllers/api_controller.rb
+++ b/dashboard/app/controllers/api_controller.rb
@@ -430,11 +430,7 @@ class ApiController < ApplicationController
       user_level = current_user.last_attempt(level, script)
       level_source = user_level.try(:level_source).try(:data)
 
-      response[:progress] = current_user.
-        user_levels.
-        by_stage(stage).
-        pluck(:level_id, :best_result).
-        to_h
+      response[:progress] = summarize_user_progress(script, current_user)[:levels]
 
       if user_level
         response[:lastAttempt] = {

--- a/dashboard/test/controllers/api_controller_test.rb
+++ b/dashboard/test/controllers/api_controller_test.rb
@@ -621,7 +621,7 @@ class ApiControllerTest < ActionController::TestCase
     assert_response :success
     body = JSON.parse(response.body)
     assert_equal nil, body['disableSocialShare']
-    assert_equal 100, body['progress'][level.id.to_s]
+    assert_equal '{"status"=>"perfect", "result"=>100}', body['progress'][level.id.to_s]
     assert_equal 'level source', body['lastAttempt']['source']
 
     assert_equal(

--- a/dashboard/test/controllers/api_controller_test.rb
+++ b/dashboard/test/controllers/api_controller_test.rb
@@ -618,10 +618,11 @@ class ApiControllerTest < ActionController::TestCase
       stage_position: 1,
       level_position: 1
     }
+    result = {"status" => "perfect", "result" => 100}
     assert_response :success
     body = JSON.parse(response.body)
     assert_equal nil, body['disableSocialShare']
-    assert_equal '{"status"=>"perfect", "result"=>100}', body['progress'][level.id.to_s]
+    assert_equal result, body['progress'][level.id.to_s]
     assert_equal 'level source', body['lastAttempt']['source']
 
     assert_equal(

--- a/dashboard/test/integration/db_query_test.rb
+++ b/dashboard/test/integration/db_query_test.rb
@@ -51,7 +51,7 @@ class DBQueryTest < ActionDispatch::IntegrationTest
       level: level.id
     )
 
-    assert_cached_queries(7) do
+    assert_cached_queries(10) do
       get user_progress_path,
         headers: {'HTTP_USER_AGENT': 'test'}
       assert_response :success

--- a/dashboard/test/ui/features/hour_of_code/hour_of_code_signed_in.feature
+++ b/dashboard/test/ui/features/hour_of_code/hour_of_code_signed_in.feature
@@ -40,6 +40,7 @@ Scenario: Failing at puzzle 6, refreshing puzzle 6, bubble should show up as att
   When element "#runButton" is visible
   Then I verify progress in the header of the current page is "attempted" for level 6
 
+# The server should be the source of truth. If we have a stale read, that means we haven't saved the user progress.
 Scenario: Async progress write followed by a stale read
   Given I am on "http://studio.code.org/hoc/20?noautoplay=true"
   And I wait for the page to fully load
@@ -47,10 +48,10 @@ Scenario: Async progress write followed by a stale read
   Then mark the current level as completed on the client
   And I wait for 3 seconds
   And I reload the page
-  And I verify progress in the header of the current page is "perfect" for level 20
+  And I verify progress in the header of the current page is "not_tried" for level 20
   And I wait for 3 seconds
   And I navigate to the course page for "hourofcode"
-  And I verify progress for stage 1 level 20 is "perfect"
+  And I verify progress for stage 1 level 20 is "not_tried"
 
 Scenario: Progress on the server that is not on the client
   Given I am on "http://studio.code.org/hoc/20?noautoplay=true"


### PR DESCRIPTION
Previously, user progress could leak between tabs if a user started their tab sessions in different login states. Specifically:
Tab 1: User is not logged in. User completes levels 1, 2
Tab 2: User logs in. User completes levels 3, 4
User goes back to Tab 1, refreshes, and sees levels 1, 2, 3, and 4 completed
User goes back to Tab 2, refreshes, and sees only levels 3 and 4 completed

This same issue could happen if the user followed the same steps, but with two different accounts.

These two manifestations of this issue are fixed by this change.

Additional details from a similar change: https://github.com/code-dot-org/code-dot-org/pull/29386

Note: A third manifestation of this issue is **not** fixed by this change
Tab 1: User is logged in. User completes levels 1, 2
Tab 2: User logs out.
User goes back to Tab 1, refreshes, and still sees levels 1, 2 completed, despite being logged out.

That will be solved as a [follow-up change](https://codedotorg.atlassian.net/browse/LP-1541) involving one of two options:
1. Update the SessionStorage to use a key/id when a user is logged in and nothing when a user is logged out
2. Update the surrounding code to use SessionStorage when logged out and use the DB when logged in

<!--
  Your description goes here: A summary of the change, including any relevant motivation and context.

  If relevant, include a description both of the existing behavior and of the new behavior.
-->

<!--
  Other aspects to consider. uncomment and add detail for any that seem necessary:
-->

### Background
Most of these details are recorded in this [slack conversation](https://codedotorg.slack.com/archives/C03CK49G9/p1598478696049400). Copying here for documentation purposes.

SessionStorage is session-specific. That means it is not shared between tabs and is deleted when a tab or browser window is closed.

We use SessionStorage for user progress when the user is logged out. This is because we don't have any information stored in the DB for the user's progress. The SessionStorage is the "source of truth." Once the user logs in, the SessionStorage becomes obsolete. The DB is the new "source of truth." However, we continue to use SessionStorage even once the user logs in for historical reasons (below). This is no longer needed. One option that is now available to us is to only use SessionStorage when the user is logged out.

#### Historical Reasons for SessionStorage

- In Oct 2013, we added support for tracking progress for anonymous users via session[:progress] in Rails controller (using the Rails session cookie): https://github.com/code-dot-org/dashboard/pull/90
- In Sep 2015, various PRs migrated the session-progress tracking out of the Rails session-cookie into an unencrypted progress cookie, with a few related helper functions. This was a transition step making it possible to manipulate the session state from client-side JavaScript in the future: https://github.com/code-dot-org/code-dot-org/pull/4032 https://github.com/code-dot-org/code-dot-org/pull/4060 https://github.com/code-dot-org/code-dot-org/pull/4170 https://github.com/code-dot-org/code-dot-org/pull/4256
- In Oct 2015 (continuing the above work), we moved the progress-tracking logic setting the progress-cookie state from Rails server (in ActivitiesController#track_progress_in_session) to the client (in sendReport): https://github.com/code-dot-org/code-dot-org/pull/4383 https://github.com/code-dot-org/code-dot-org/pull/4452. This made it possible to cache the rendered script-level page for anonymous users and serve it efficiently over CDN, since the set-cookie was no longer being done on the server  response. This also introduced a behavior change to start tracking client-side for logged-in users, since track_progress_in_session was only ever called by anonymous users but sendReport is called by any user.
- In Nov 2015 we started intentionally combining client level progress and UserLevel-based progress when displaying progress for logged-in users: https://github.com/code-dot-org/code-dot-org/pull/5640 ***Based on the comment ('this unblocks async writes') it seems this change was used as a graceful fallback for the HoC scale-mode feature where UserLevel database writes were throttled/queued and persisted asynchronously (hours/days later).***
- In Nov 2015 (a day later) we changed progress-tracking to use sessionStorage instead of a cookie to fix cookie-overflow issues when progress data grows larger than the 4k a cookie can hold: https://github.com/code-dot-org/code-dot-org/pull/5676
- In the future this logic was migrated to React/redux (progress.js linked above) but I think the underlying behavior remained the same. 

The critical line from this description is here: 
> Based on the comment ('this unblocks async writes') it seems this change was used as a graceful fallback for the HoC scale-mode feature where UserLevel database writes were throttled/queued and persisted asynchronously (hours/days later).

This "HoC scale-mode feature" is no longer in use. It was deemed too difficult/complex to maintain.

<!-- ### Privacy -->
<!-- ### Security -->
<!-- ### Caching -->
<!-- ### Deployment strategy -->
<!-- ### Future work -->

## Links

<!--
  Any relevant links to external resources; ie, specification documents, jira
  items, related PRs, honeybadger errors, etc
-->

- [LP-1471](https://codedotorg.atlassian.net/browse/LP-1471)
- [LP-576](https://codedotorg.atlassian.net/browse/LP-576)

## Testing story

<!--
  Does your change include appropriate tests?

  If so, please describe how the tests included in this PR are sufficient

  If not, please explain why this change does not need to be tested.
-->

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
