### PR TITLE
Fix NoMethodError in assessments controller

### DIFF
--- a/dashboard/app/controllers/api/v1/assessments_controller.rb
+++ b/dashboard/app/controllers/api/v1/assessments_controller.rb
@@ -24,7 +24,7 @@ class Api::V1::AssessmentsController < Api::V1::JsonApiController
   # GET '/dashboardapi/assessments'
   def index
     # Only authorized teachers have access to locked question and answer data.
-    render status: :forbidden unless current_user.authorized_teacher?
+    render status: :forbidden unless current_user && current_user.authorized_teacher?
 
     assessment_script_levels = @script.get_assessment_script_levels
 

--- a/dashboard/app/controllers/api/v1/assessments_controller.rb
+++ b/dashboard/app/controllers/api/v1/assessments_controller.rb
@@ -24,7 +24,7 @@ class Api::V1::AssessmentsController < Api::V1::JsonApiController
   # GET '/dashboardapi/assessments'
   def index
     # Only authorized teachers have access to locked question and answer data.
-    render status: :forbidden unless current_user && current_user.authorized_teacher?
+    render status: :forbidden unless current_user&.authorized_teacher?
 
     assessment_script_levels = @script.get_assessment_script_levels
 


### PR DESCRIPTION
This was causing an [HB error](https://app.honeybadger.io/projects/3240/faults/38750961) when `current_user` was `nil` - now we check that we have a current user before verifying that the current user is an authorized teacher.

<!--
  Your description goes here: A summary of the change, including any relevant motivation and context.

  If relevant, include a description both of the existing behavior and of the new behavior.
-->

<!--
  Other aspects to consider. uncomment and add detail for any that seem necessary:
-->

<!-- ### Background -->
<!-- ### Privacy -->
<!-- ### Security -->
<!-- ### Caching -->
<!-- ### Deployment strategy -->
<!-- ### Future work -->

## Links

<!--
  Any relevant links to external resources; ie, specification documents, jira
  items, related PRs, honeybadger errors, etc
-->

- [spec]()
- [jira]()

## Testing story

<!--
  Does your change include appropriate tests?

  If so, please describe how the tests included in this PR are sufficient

  If not, please explain why this change does not need to be tested.
-->

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
