### PR TITLE
Adding i18n string tracking API to support javascript strings tracking

### DIFF
--- a/dashboard/app/controllers/i18n_controller.rb
+++ b/dashboard/app/controllers/i18n_controller.rb
@@ -1,5 +1,7 @@
 class I18nController < ApplicationController
-  # The max number of i18n string keys which can be recorded in one request
+  # The max number of i18n string keys which can be recorded in one request.
+  # This is to protect us from malicious API calls where thousands or millions of items are given in a single request.
+  # It doesn't stop us from receiving it, but it does stop us from doing anything with it.
   I18N_KEY_COUNT_LIMIT = 500
 
   # POST /i18n/track_string_usage

--- a/dashboard/app/controllers/i18n_controller.rb
+++ b/dashboard/app/controllers/i18n_controller.rb
@@ -1,0 +1,29 @@
+class I18nController < ApplicationController
+  # The max number of i18n string keys which can be recorded in one request
+  I18N_KEY_COUNT_LIMIT = 500
+
+  # POST /i18n/track_string_usage
+  # Records the given i18n string usage information
+  # {
+  #   'string_keys': ['stringkey1', ...],
+  #   'url': 'https://code.org/some/page',
+  #   'source': 'maze',
+  # }
+  # string_keys [Array[String]] The i18n string keys which were used and need to be recorded.
+  # url [String] The URL where the i18n strings were used.
+  # source [String] Context for where the i18n strings came from.
+  def track_string_usage
+    string_keys = params.require(:string_keys)
+    url = params.require(:url)
+    source = params.require(:source)
+
+    # Limit the number of strings we will handle in one call.
+    return render status: :bad_request, json: {error: 'Too many strings.'}  if string_keys.count > I18N_KEY_COUNT_LIMIT
+
+    string_keys.each do |string_key|
+      I18nStringUrlTracker.instance.log(string_key, url, source)
+    end
+
+    head :ok
+  end
+end

--- a/dashboard/config/routes.rb
+++ b/dashboard/config/routes.rb
@@ -741,4 +741,6 @@ Dashboard::Application.routes.draw do
   get '/help', to: redirect("https://support.code.org")
 
   get '/form/:misc_form_path', to: 'foorm/misc_survey#new'
+
+  post '/i18n/track_string_usage', action: :track_string_usage, controller: :i18n
 end

--- a/dashboard/test/controllers/i18n_controller_test.rb
+++ b/dashboard/test/controllers/i18n_controller_test.rb
@@ -1,0 +1,36 @@
+require 'test_helper'
+require 'i18n_controller'
+
+class I18nControllerTest < ActionController::TestCase
+  test "post track_string_usage should succeed" do
+    string_keys = (1..100).map(&:to_s)
+    url = 'http://code.org/test/level'
+    source = 'test'
+    args = {
+      'string_keys' => string_keys,
+      'url' => url,
+      'source' => source
+    }
+
+    string_keys.each do |string_key|
+      I18nStringUrlTracker.instance.expects(:log).with(string_key, url, source)
+    end
+
+    post :track_string_usage, params: args
+    assert_response :success
+  end
+
+  test "post track_string_usage should fail given over #{I18nController::I18N_KEY_COUNT_LIMIT} strings" do
+    string_keys = (1..(I18nController::I18N_KEY_COUNT_LIMIT + 1)).map(&:to_s)
+    url = 'http://code.org/test/level'
+    source = 'test'
+    args = {
+      'string_keys' => string_keys,
+      'url' => url,
+      'source' => source
+    }
+
+    post :track_string_usage, params: args
+    assert_response 400
+  end
+end

--- a/lib/cdo/i18n_backend.rb
+++ b/lib/cdo/i18n_backend.rb
@@ -152,7 +152,7 @@ module Cdo
         separator = options[:separator] || ::I18n.default_separator
         # We don't pass in a locale because we want the union of all string keys across all locales.
         normalized_key = ::I18n.normalize_keys(nil, key, scope, separator).join(separator)
-        I18nStringUrlTracker.instance.log(normalized_key, url) if key && url
+        I18nStringUrlTracker.instance.log(normalized_key, url, 'ruby') if normalized_key && url
         result
       end
     end

--- a/lib/cdo/i18n_string_url_tracker.rb
+++ b/lib/cdo/i18n_string_url_tracker.rb
@@ -9,14 +9,15 @@ class I18nStringUrlTracker
   # Records the given string_key and URL so we can analyze later what strings are present on what pages.
   # @param string_key [String] The key used to review the translated string from our i18n system.
   # @param url [String] The url which required the translation of the given string_key.
-  def log(string_key, url)
-    return unless string_key && url
+  # @param source [String] Context about where the string lives e.g. 'ruby', 'maze', 'turtle', etc
+  def log(string_key, url, source)
+    return unless string_key && url && source
     return unless DCDO.get(I18N_STRING_TRACKING_DCDO_KEY, false)
 
     # record the string : url association.
     FirehoseClient.instance.put_record(
       :i18n,
-      {url: url, string_key: string_key}
+      {url: url, string_key: string_key, source: source}
     )
   end
 end

--- a/lib/test/cdo/test_i18n_string_url_tracker.rb
+++ b/lib/test/cdo/test_i18n_string_url_tracker.rb
@@ -46,20 +46,27 @@ class TestI18nStringUrlTracker < Minitest::Test
   def test_log_given_no_string_key_should_not_call_firehose
     unstub_firehose
     FirehoseClient.instance.expects(:put_record).never
-    test_record = {string_key: nil, url: 'http://some.url.com/'}
-    I18nStringUrlTracker.instance.log(test_record[:string_key], test_record[:url])
+    test_record = {string_key: nil, url: 'http://some.url.com/', source: 'test'}
+    I18nStringUrlTracker.instance.log(test_record[:string_key], test_record[:url], test_record[:source])
   end
 
   def test_log_given_no_url_should_not_call_firehose
     unstub_firehose
     FirehoseClient.instance.expects(:put_record).never
-    test_record = {string_key: 'string.key', url: nil}
-    I18nStringUrlTracker.instance.log(test_record[:string_key], test_record[:url])
+    test_record = {string_key: 'string.key', url: nil, source: 'test'}
+    I18nStringUrlTracker.instance.log(test_record[:string_key], test_record[:url], test_record[:source])
+  end
+
+  def test_log_given_no_source_should_not_call_firehose
+    unstub_firehose
+    FirehoseClient.instance.expects(:put_record).never
+    test_record = {string_key: 'string.key', url: 'http://some.url.com/', source: nil}
+    I18nStringUrlTracker.instance.log(test_record[:string_key], test_record[:url], test_record[:source])
   end
 
   def test_log_given_data_should_call_firehose
-    test_record = {string_key: 'string.key', url: 'http://some.url.com/'}
-    I18nStringUrlTracker.instance.log(test_record[:string_key], test_record[:url])
+    test_record = {string_key: 'string.key', url: 'http://some.url.com/', source: 'test'}
+    I18nStringUrlTracker.instance.log(test_record[:string_key], test_record[:url], test_record[:source])
     assert_equal(:i18n, @firehose_stream)
     assert_equal(@firehose_record, test_record)
   end
@@ -69,7 +76,7 @@ class TestI18nStringUrlTracker < Minitest::Test
     unstub_dcdo
     stub_dcdo(false)
     FirehoseClient.instance.expects(:put_record).never
-    test_record = {string_key: 'string.key', url: 'http://some.url.com/'}
-    I18nStringUrlTracker.instance.log(test_record[:string_key], test_record[:url])
+    test_record = {string_key: 'string.key', url: 'http://some.url.com/', source: 'test'}
+    I18nStringUrlTracker.instance.log(test_record[:string_key], test_record[:url], test_record[:source])
   end
 end


### PR DESCRIPTION
As a Code.org engineer, I want to know what I18n strings are being access by our javascript code which is running on student and teacher computers.

Since the strings are only used when the javascript runs on the user's computer, need someway to send that information back to our servers so we can process it. The solution in this PR, is to add an API where the string usage information can be sent to.

* Adds a new RESTful API `POST /i18n/track_string_usage` which accepts a list of I18n string keys and the URL they were used on.  Then the API passes the information to the existing I18n string tracking Util.
* Adds `source` to the information recorded so we can know what javascript file the string came from.


## Links
- [jira](https://codedotorg.atlassian.net/browse/FND-1243)
- [design doc](https://docs.google.com/document/d/1zbQNn83YOafVbAkxfc6MgBFPB8Em9EuBusXobaWiCbw/edit)

## Testing story
* unit tests

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
