### PR TITLE
Disable scholarship dropdown for non-admins

### DIFF
--- a/apps/src/code-studio/pd/application_dashboard/detail_view_contents.jsx
+++ b/apps/src/code-studio/pd/application_dashboard/detail_view_contents.jsx
@@ -584,6 +584,7 @@ export class DetailViewContents extends React.Component {
         }
         onChange={this.handleScholarshipStatusChange}
         disabled={!this.state.editing}
+        isWorkshopAdmin={this.props.isWorkshopAdmin}
       />
     );
   };

--- a/apps/src/code-studio/pd/components/scholarshipDropdown.jsx
+++ b/apps/src/code-studio/pd/components/scholarshipDropdown.jsx
@@ -8,7 +8,8 @@ export class ScholarshipDropdown extends React.Component {
     scholarshipStatus: PropTypes.string,
     dropdownOptions: PropTypes.array,
     onChange: PropTypes.func,
-    disabled: PropTypes.bool
+    disabled: PropTypes.bool,
+    isWorkshopAdmin: PropTypes.bool.isRequired
   };
 
   render() {
@@ -19,7 +20,8 @@ export class ScholarshipDropdown extends React.Component {
           value={this.props.scholarshipStatus}
           onChange={this.props.onChange}
           options={this.props.dropdownOptions}
-          disabled={this.props.disabled}
+          // Only workshop admins can change scholarship status now
+          disabled={this.props.disabled || !this.props.isWorkshopAdmin}
         />
       </FormGroup>
     );

--- a/apps/src/code-studio/pd/workshop_dashboard/components/workshop_enrollment_school_info.jsx
+++ b/apps/src/code-studio/pd/workshop_dashboard/components/workshop_enrollment_school_info.jsx
@@ -131,6 +131,7 @@ export class WorkshopEnrollmentSchoolInfo extends React.Component {
             scholarshipStatus={enrollment.scholarship_status}
             dropdownOptions={dropdownOptions}
             onChange={this.handleScholarshipStatusChange.bind(this, enrollment)}
+            isWorkshopAdmin={this.props.permissionList.has(WorkshopAdmin)}
           />
         </td>
       );

--- a/apps/test/unit/code-studio/pd/application_dashboard/detail_view_contentsTest.js
+++ b/apps/test/unit/code-studio/pd/application_dashboard/detail_view_contentsTest.js
@@ -71,7 +71,8 @@ describe('DetailViewContents', () => {
       canLock: true,
       applicationId: '1',
       applicationData: defaultApplicationData,
-      viewType: 'facilitator'
+      viewType: 'facilitator',
+      isWorkshopAdmin: false
     };
 
     // No-op router context
@@ -337,7 +338,10 @@ describe('DetailViewContents', () => {
 
   describe('Scholarship Teacher? row', () => {
     it('on teacher applications', () => {
-      const detailView = mountDetailView('Teacher');
+      const detailView = mountDetailView('Teacher', {
+        isWorkshopAdmin: true,
+        regionalPartners: [{id: 1, name: 'test'}]
+      });
       const getLastRow = () =>
         detailView
           .find('tr')
@@ -353,6 +357,7 @@ describe('DetailViewContents', () => {
       // Click "Edit"
       detailView
         .find('#DetailViewHeader Button')
+        .not('#admin-edit')
         .last()
         .simulate('click');
 


### PR DESCRIPTION
[PLC-965](https://codedotorg.atlassian.net/browse/PLC-965)
Disables the scholarship dropdown for everyone except workshop admins. The dropdown is disabled on both the workshop and application dashboards. When we want to undo this change we will only need to update the logic for `disabled` in `scholarshipDropdown.jsx`.

<!-- ### Background -->
<!-- ### Privacy -->
<!-- ### Security -->
<!-- ### Caching -->
<!-- ### Deployment strategy -->
<!-- ### Future work -->

## Links

- [jira](https://codedotorg.atlassian.net/browse/PLC-965)

## Testing story
Tested locally that a non-workshop admin sees the dropdown as disabled, while a workshop admin can still use the dropdown.

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
