### PR TITLE
Fix Progesss tab scrolling performance for Lesson and Level views

### DIFF
--- a/apps/package.json
+++ b/apps/package.json
@@ -236,6 +236,7 @@
     "react-dom-confetti": "^0.0.8",
     "react-hot-loader": "^1.3.1",
     "react-portal": "^3.2.0",
+    "react-progressive-list": "^0.1.2",
     "react-router-dom": "^4.3.1",
     "react-transition-group": "2.9.0",
     "rehype-stringify": "^7.0.0",

--- a/apps/src/templates/sectionProgress/detail/VirtualizedDetailView.jsx
+++ b/apps/src/templates/sectionProgress/detail/VirtualizedDetailView.jsx
@@ -18,7 +18,6 @@ import {
   progressStyles,
   ROW_HEIGHT,
   LAST_ROW_MARGIN_HEIGHT,
-  MAX_TABLE_SIZE,
   PROGRESS_BUBBLE_WIDTH,
   DIAMOND_BUBBLE_WIDTH,
   tooltipIdForLessonNumber
@@ -251,10 +250,7 @@ class VirtualizedDetailView extends Component {
     // Add 1 to account for the student name column
     const columnCount = scriptData.stages.length + 1;
     // Calculate height based on the number of rows
-    const tableHeightFromRowCount =
-      ROW_HEIGHT * rowCount + LAST_ROW_MARGIN_HEIGHT;
-    // Use a 'maxHeight' of 680 for when there are many rows
-    const tableHeight = Math.min(tableHeightFromRowCount, MAX_TABLE_SIZE);
+    const tableHeight = ROW_HEIGHT * rowCount + LAST_ROW_MARGIN_HEIGHT;
 
     return (
       <MultiGrid

--- a/apps/src/templates/sectionProgress/summary/VirtualizedSummaryView.jsx
+++ b/apps/src/templates/sectionProgress/summary/VirtualizedSummaryView.jsx
@@ -17,7 +17,6 @@ import {
   ROW_HEIGHT,
   LAST_ROW_MARGIN_HEIGHT,
   NAME_COLUMN_WIDTH,
-  MAX_TABLE_SIZE,
   tooltipIdForLessonNumber
 } from '@cdo/apps/templates/sectionProgress/multiGridConstants';
 import i18n from '@cdo/locale';
@@ -146,10 +145,7 @@ class VirtualizedSummaryView extends Component {
     // Add 1 to account for the student name column
     const columnCount = scriptData.stages.length + 1;
     // Calculate height based on the number of rows
-    const tableHeightFromRowCount =
-      ROW_HEIGHT * rowCount + LAST_ROW_MARGIN_HEIGHT;
-    // Use a 'maxHeight' of 680 for when there are many rows
-    const tableHeight = Math.min(tableHeightFromRowCount, MAX_TABLE_SIZE);
+    const tableHeight = ROW_HEIGHT * rowCount + LAST_ROW_MARGIN_HEIGHT;
 
     return (
       <div>

--- a/apps/yarn.lock
+++ b/apps/yarn.lock
@@ -13152,6 +13152,13 @@ react-portal@^3.2.0:
   dependencies:
     prop-types "^15.5.8"
 
+react-progressive-list@^0.1.2:
+  version "0.1.2"
+  resolved "https://registry.yarnpkg.com/react-progressive-list/-/react-progressive-list-0.1.2.tgz#a01285687f88c98984daaa9eb14151abf7db9ca8"
+  integrity sha512-sjgX+TqHKoZgIfJeV0Gv3cMJceLIABFAUVZtftOkGKfu8cMh1FZvr7wkbchF1GNmLXKsb/6vkcIyGhafuHZvqQ==
+  dependencies:
+    lodash "^4.17.4"
+
 react-prop-types@^0.4.0:
   version "0.4.0"
   resolved "https://registry.yarnpkg.com/react-prop-types/-/react-prop-types-0.4.0.tgz#f99b0bfb4006929c9af2051e7c1414a5c75b93d0"


### PR DESCRIPTION
<!--
  Your description goes here: A summary of the change, including any relevant motivation and context.

  If relevant, include a description both of the existing behavior and of the new behavior.
-->

<!--
  Other aspects to consider. uncomment and add detail for any that seem necessary:
-->

<!-- ### Background -->
    
Scrolling through data in the Lesson and Level views under the Progress tab was
very slow for large sections. This was because the graphing dependancy we use,
react-virtualize multigrid, has a performance limitation around de-rendering
and re-rending rows if the number of rows is large and each row takes a long
time to render, if using multigrid's native functionality to only render a
subsection of a grid at a time.
    
This diff works around this issue by having react-virtualize multigrid render
all rows for our tables at once, rather than only rendering only a subsection
of rows at a time. This removes the need to de-render and re-render rows, and
thus removes our performance problem
<!-- ### Privacy -->
<!-- ### Security -->
<!-- ### Caching -->
<!-- ### Deployment strategy -->
<!-- ### Future work -->

## Links

<!--
  Any relevant links to external resources; ie, specification documents, jira
  items, related PRs, honeybadger errors, etc
-->

- [jira](https://codedotorg.atlassian.net/browse/LP-764)

## Testing story

<!--
  Does your change include appropriate tests?

  If so, please describe how the tests included in this PR are sufficient

  If not, please explain why this change does not need to be tested.
-->

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
