### PR TITLE
Adding I18n string tracking decorator

### DIFF
--- a/apps/src/applab/locale-do-not-import.js
+++ b/apps/src/applab/locale-do-not-import.js
@@ -8,4 +8,9 @@
  */
 // locale for applab
 
-export default window.locales.applab_locale;
+import safeLoadLocale from '@cdo/apps/util/safeLoadLocale';
+import localeWithI18nStringTracker from '@cdo/apps/util/i18nStringTracker';
+
+let locale = safeLoadLocale('applab_locale');
+locale = localeWithI18nStringTracker(locale, 'applab_locale');
+module.exports = locale;

--- a/apps/src/bounce/locale.js
+++ b/apps/src/bounce/locale.js
@@ -1,4 +1,8 @@
 // locale for bounce
 
 import safeLoadLocale from '@cdo/apps/util/safeLoadLocale';
-module.exports = safeLoadLocale('bounce_locale');
+import localeWithI18nStringTracker from '@cdo/apps/util/i18nStringTracker';
+
+let locale = safeLoadLocale('bounce_locale');
+locale = localeWithI18nStringTracker(locale, 'bounce_locale');
+module.exports = locale;

--- a/apps/src/calc/locale.js
+++ b/apps/src/calc/locale.js
@@ -1,4 +1,8 @@
 // locale for calc
 
 import safeLoadLocale from '@cdo/apps/util/safeLoadLocale';
-module.exports = safeLoadLocale('calc_locale');
+import localeWithI18nStringTracker from '@cdo/apps/util/i18nStringTracker';
+
+let locale = safeLoadLocale('calc_locale');
+locale = localeWithI18nStringTracker(locale, 'calc_locale');
+module.exports = locale;

--- a/apps/src/craft/locale.js
+++ b/apps/src/craft/locale.js
@@ -1,2 +1,6 @@
 import safeLoadLocale from '@cdo/apps/util/safeLoadLocale';
-module.exports = safeLoadLocale('craft_locale');
+import localeWithI18nStringTracker from '@cdo/apps/util/i18nStringTracker';
+
+let locale = safeLoadLocale('craft_locale');
+locale = localeWithI18nStringTracker(locale, 'craft_locale');
+module.exports = locale;

--- a/apps/src/dance/locale.js
+++ b/apps/src/dance/locale.js
@@ -1,2 +1,6 @@
 import safeLoadLocale from '@cdo/apps/util/safeLoadLocale';
-module.exports = safeLoadLocale('dance_locale');
+import localeWithI18nStringTracker from '@cdo/apps/util/i18nStringTracker';
+
+let locale = safeLoadLocale('dance_locale');
+locale = localeWithI18nStringTracker(locale, 'dance_locale');
+module.exports = locale;

--- a/apps/src/eval/locale.js
+++ b/apps/src/eval/locale.js
@@ -1,4 +1,8 @@
 // locale for eval
 
 import safeLoadLocale from '@cdo/apps/util/safeLoadLocale';
-module.exports = safeLoadLocale('eval_locale');
+import localeWithI18nStringTracker from '@cdo/apps/util/i18nStringTracker';
+
+let locale = safeLoadLocale('eval_locale');
+locale = localeWithI18nStringTracker(locale, 'eval_locale');
+module.exports = locale;

--- a/apps/src/fish/locale-do-not-import.js
+++ b/apps/src/fish/locale-do-not-import.js
@@ -8,4 +8,9 @@
  */
 // locale for fish
 
-export default window.locales.fish_locale;
+import safeLoadLocale from '@cdo/apps/util/safeLoadLocale';
+import localeWithI18nStringTracker from '@cdo/apps/util/i18nStringTracker';
+
+let locale = safeLoadLocale('fish_locale');
+locale = localeWithI18nStringTracker(locale, 'fish_locale');
+module.exports = locale;

--- a/apps/src/fish/locale.js
+++ b/apps/src/fish/locale.js
@@ -1,3 +1,8 @@
 // locale for fish
+
 import safeLoadLocale from '@cdo/apps/util/safeLoadLocale';
-module.exports = safeLoadLocale('fish_locale');
+import localeWithI18nStringTracker from '@cdo/apps/util/i18nStringTracker';
+
+let locale = safeLoadLocale('fish_locale');
+locale = localeWithI18nStringTracker(locale, 'fish_locale');
+module.exports = locale;

--- a/apps/src/flappy/locale.js
+++ b/apps/src/flappy/locale.js
@@ -1,4 +1,8 @@
 // locale for flappy
 
 import safeLoadLocale from '@cdo/apps/util/safeLoadLocale';
-module.exports = safeLoadLocale('flappy_locale');
+import localeWithI18nStringTracker from '@cdo/apps/util/i18nStringTracker';
+
+let locale = safeLoadLocale('flappy_locale');
+locale = localeWithI18nStringTracker(locale, 'flappy_locale');
+module.exports = locale;

--- a/apps/src/jigsaw/locale.js
+++ b/apps/src/jigsaw/locale.js
@@ -1,4 +1,8 @@
 // locale for jigsaw
 
 import safeLoadLocale from '@cdo/apps/util/safeLoadLocale';
-module.exports = safeLoadLocale('jigsaw_locale');
+import localeWithI18nStringTracker from '@cdo/apps/util/i18nStringTracker';
+
+let locale = safeLoadLocale('jigsaw_locale');
+locale = localeWithI18nStringTracker(locale, 'jigsaw_locale');
+module.exports = locale;

--- a/apps/src/maze/locale.js
+++ b/apps/src/maze/locale.js
@@ -1,3 +1,7 @@
 // locale for maze
 import safeLoadLocale from '@cdo/apps/util/safeLoadLocale';
-module.exports = safeLoadLocale('maze_locale');
+import localeWithI18nStringTracker from '@cdo/apps/util/i18nStringTracker';
+
+let locale = safeLoadLocale('maze_locale');
+locale = localeWithI18nStringTracker(locale, 'maze_locale');
+module.exports = locale;

--- a/apps/src/netsim/locale-do-not-import.js
+++ b/apps/src/netsim/locale-do-not-import.js
@@ -9,4 +9,8 @@
 // locale for netsim
 
 import safeLoadLocale from '@cdo/apps/util/safeLoadLocale';
-module.exports = safeLoadLocale('netsim_locale');
+import localeWithI18nStringTracker from '@cdo/apps/util/i18nStringTracker';
+
+let locale = safeLoadLocale('netsim_locale');
+locale = localeWithI18nStringTracker(locale, 'netsim_locale');
+module.exports = locale;

--- a/apps/src/p5lab/gamelab/locale-do-not-import.js
+++ b/apps/src/p5lab/gamelab/locale-do-not-import.js
@@ -7,5 +7,10 @@
  * which is important for making locale setup work seamlessly in tests.
  */
 // locale for gamelab
+
 import safeLoadLocale from '@cdo/apps/util/safeLoadLocale';
-module.exports = safeLoadLocale('gamelab_locale');
+import localeWithI18nStringTracker from '@cdo/apps/util/i18nStringTracker';
+
+let locale = safeLoadLocale('gamelab_locale');
+locale = localeWithI18nStringTracker(locale, 'gamelab_locale');
+module.exports = locale;

--- a/apps/src/p5lab/spritelab/locale-do-not-import.js
+++ b/apps/src/p5lab/spritelab/locale-do-not-import.js
@@ -1,4 +1,8 @@
 // locale for Spritelab
 
 import safeLoadLocale from '@cdo/apps/util/safeLoadLocale';
-module.exports = safeLoadLocale('spritelab_locale');
+import localeWithI18nStringTracker from '@cdo/apps/util/i18nStringTracker';
+
+let locale = safeLoadLocale('spritelab_locale');
+locale = localeWithI18nStringTracker(locale, 'spritelab_locale');
+module.exports = locale;

--- a/apps/src/studio/locale.js
+++ b/apps/src/studio/locale.js
@@ -1,4 +1,8 @@
 // locale for studio
 
 import safeLoadLocale from '@cdo/apps/util/safeLoadLocale';
-module.exports = safeLoadLocale('studio_locale');
+import localeWithI18nStringTracker from '@cdo/apps/util/i18nStringTracker';
+
+let locale = safeLoadLocale('studio_locale');
+locale = localeWithI18nStringTracker(locale, 'studio_locale');
+module.exports = locale;

--- a/apps/src/turtle/locale.js
+++ b/apps/src/turtle/locale.js
@@ -1,3 +1,8 @@
 // locale for turtle
+
 import safeLoadLocale from '@cdo/apps/util/safeLoadLocale';
-module.exports = safeLoadLocale('turtle_locale');
+import localeWithI18nStringTracker from '@cdo/apps/util/i18nStringTracker';
+
+let locale = safeLoadLocale('turtle_locale');
+locale = localeWithI18nStringTracker(locale, 'turtle_locale');
+module.exports = locale;

--- a/apps/src/tutorialExplorer/locale-do-not-import.js
+++ b/apps/src/tutorialExplorer/locale-do-not-import.js
@@ -6,4 +6,10 @@
  * This allows the webpack config to determine how locales should be loaded,
  * which is important for making locale setup work seamlessly in tests.
  */
-export default window.locales.tutorialExplorer_locale;
+
+import safeLoadLocale from '@cdo/apps/util/safeLoadLocale';
+import localeWithI18nStringTracker from '@cdo/apps/util/i18nStringTracker';
+
+let locale = safeLoadLocale('tutorialExplorer_locale');
+locale = localeWithI18nStringTracker(locale, 'tutorialExplorer_locale');
+module.exports = locale;

--- a/apps/src/util/experiments.js
+++ b/apps/src/util/experiments.js
@@ -30,6 +30,8 @@ experiments.TEACHER_DASHBOARD_SECTION_BUTTONS_ALTERNATE_TEXT =
 experiments.TEXT_TO_SPEECH_BLOCK = 'text-to-speech-block';
 experiments.FINISH_DIALOG_METRICS = 'finish-dialog-metrics';
 experiments.IMMERSIVE_READER = 'immersive-reader';
+experiments.I18N_TRACKING = 'i18n-tracking';
+
 /**
  * Get our query string. Provided as a method so that tests can mock this.
  */

--- a/apps/src/util/i18nStringTracker.js
+++ b/apps/src/util/i18nStringTracker.js
@@ -13,11 +13,11 @@ export default function localeWithI18nStringTracker(locale, source) {
     return locale;
   }
 
-  let localeWithTracker = {};
+  const localeWithTracker = {};
   // Iterates each function in the given locale object and creates a wrapper function.
   Object.keys(locale).forEach(function(stringKey, index) {
     localeWithTracker[stringKey] = function(d) {
-      let value = locale[stringKey](d);
+      const value = locale[stringKey](d);
       log(stringKey, source);
       return value;
     };

--- a/apps/src/util/i18nStringTracker.js
+++ b/apps/src/util/i18nStringTracker.js
@@ -1,0 +1,40 @@
+import experiments from '@cdo/apps/util/experiments';
+
+// A map of "string source" -> "list of strings used"
+// For example: window.stringUsageSources['maze'] = ['level_1.instruction.header']
+// The data recorded in this will periodically be uploaded.
+if (!window.stringUsageSources) {
+  // Initialize if it doesn't already exist.
+  window.stringUsageSources = {};
+}
+
+export default function localeWithI18nStringTracker(locale, source) {
+  if (!experiments.isEnabled(experiments.I18N_TRACKING)) {
+    return locale;
+  }
+
+  let localeWithTracker = {};
+  // Iterates each function in the given locale object and creates a wrapper function.
+  Object.keys(locale).forEach(function(stringKey, index) {
+    localeWithTracker[stringKey] = function(d) {
+      let value = locale[stringKey](d);
+      log(stringKey, source);
+      return value;
+    };
+  });
+  return localeWithTracker;
+}
+
+// Records the usage of the given i18n string key from the given source file.
+// @param stringKey [String] The string key used to look up the i18n value e.g. 'home.banner_text'
+// @param source [String] Context for where the given string key came from e.g. 'maze', 'dance', etc.
+function log(stringKey, source) {
+  if (!stringKey || !source) {
+    return;
+  }
+  if (!window.stringUsageSources[source]) {
+    // Initialize the list of strings for the source if it doesn't already exist.
+    window.stringUsageSources[source] = new Set();
+  }
+  window.stringUsageSources[source].add(stringKey);
+}

--- a/apps/src/util/locale-do-not-import.js
+++ b/apps/src/util/locale-do-not-import.js
@@ -6,7 +6,11 @@
  * This allows the webpack config to determine how locales should be loaded,
  * which is important for making locale setup work seemlessly in tests.
  */
-
 // base locale
+
 import safeLoadLocale from '@cdo/apps/util/safeLoadLocale';
-module.exports = safeLoadLocale('common_locale');
+import localeWithI18nStringTracker from '@cdo/apps/util/i18nStringTracker';
+
+let locale = safeLoadLocale('common_locale');
+locale = localeWithI18nStringTracker(locale, 'common_locale');
+module.exports = locale;

--- a/apps/src/weblab/locale-do-not-import.js
+++ b/apps/src/weblab/locale-do-not-import.js
@@ -8,4 +8,9 @@
  */
 // locale for weblab
 
-export default window.locales.weblab_locale;
+import safeLoadLocale from '@cdo/apps/util/safeLoadLocale';
+import localeWithI18nStringTracker from '@cdo/apps/util/i18nStringTracker';
+
+let locale = safeLoadLocale('weblab_locale');
+locale = localeWithI18nStringTracker(locale, 'weblab_locale');
+module.exports = locale;

--- a/apps/src/weblab/locale.js
+++ b/apps/src/weblab/locale.js
@@ -1,3 +1,8 @@
 // locale for weblab
+
 import safeLoadLocale from '@cdo/apps/util/safeLoadLocale';
-module.exports = safeLoadLocale('weblab_locale');
+import localeWithI18nStringTracker from '@cdo/apps/util/i18nStringTracker';
+
+let locale = safeLoadLocale('weblab_locale');
+locale = localeWithI18nStringTracker(locale, 'weblab_locale');
+module.exports = locale;


### PR DESCRIPTION
As a code.org developer, I want to record what I18n strings we are using in our Javascript code.

This PR adds a decorator to our i18n strings (*_locale.js files) which stores the string key and the file it came from to `window.stringUsageSources`. The records stored in this object will periodically be uploaded by a worker thread to our webservers and uploaded to Firehose (the worker thread will be implemented in a future PR).
* Adds `i18nStringTracker.js` which decorates a given *_locale.js object so its usage can be recorded.
* Records string usage to a new global context object called `window.stringUsageSources`

## Example
`window.stringUsageSources`
```
{ 
  common_locale: [ "curriculum", "teacherForum", "professionalLearning", ...],
  maze_locale: [...]
}
```

## Links
- [jira](https://codedotorg.atlassian.net/browse/FND-1243)
- [design doc](https://docs.google.com/document/d/1zbQNn83YOafVbAkxfc6MgBFPB8Em9EuBusXobaWiCbw/edit)

## Testing story
* Manually tested on localhost
  * Iterated through all the levels types on http://localhost-studio.code.org:3000/s/allthethings
  * In the javascript console I compared `window.locales.<locale_file>` to `window.stringUsageSources`

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
