### PR TITLE
Fix Progesss tab scrolling performance for Lesson and Level views

### DIFF
--- a/apps/src/templates/sectionProgress/detail/VirtualizedDetailView.jsx
+++ b/apps/src/templates/sectionProgress/detail/VirtualizedDetailView.jsx
@@ -18,7 +18,6 @@ import {
   progressStyles,
   ROW_HEIGHT,
   LAST_ROW_MARGIN_HEIGHT,
-  MAX_TABLE_SIZE,
   PROGRESS_BUBBLE_WIDTH,
   DIAMOND_BUBBLE_WIDTH,
   tooltipIdForLessonNumber
@@ -251,10 +250,7 @@ class VirtualizedDetailView extends Component {
     // Add 1 to account for the student name column
     const columnCount = scriptData.stages.length + 1;
     // Calculate height based on the number of rows
-    const tableHeightFromRowCount =
-      ROW_HEIGHT * rowCount + LAST_ROW_MARGIN_HEIGHT;
-    // Use a 'maxHeight' of 680 for when there are many rows
-    const tableHeight = Math.min(tableHeightFromRowCount, MAX_TABLE_SIZE);
+    const tableHeight = ROW_HEIGHT * rowCount + LAST_ROW_MARGIN_HEIGHT;
 
     return (
       <MultiGrid

--- a/apps/src/templates/sectionProgress/summary/VirtualizedSummaryView.jsx
+++ b/apps/src/templates/sectionProgress/summary/VirtualizedSummaryView.jsx
@@ -17,7 +17,6 @@ import {
   ROW_HEIGHT,
   LAST_ROW_MARGIN_HEIGHT,
   NAME_COLUMN_WIDTH,
-  MAX_TABLE_SIZE,
   tooltipIdForLessonNumber
 } from '@cdo/apps/templates/sectionProgress/multiGridConstants';
 import i18n from '@cdo/locale';
@@ -146,10 +145,7 @@ class VirtualizedSummaryView extends Component {
     // Add 1 to account for the student name column
     const columnCount = scriptData.stages.length + 1;
     // Calculate height based on the number of rows
-    const tableHeightFromRowCount =
-      ROW_HEIGHT * rowCount + LAST_ROW_MARGIN_HEIGHT;
-    // Use a 'maxHeight' of 680 for when there are many rows
-    const tableHeight = Math.min(tableHeightFromRowCount, MAX_TABLE_SIZE);
+    const tableHeight = ROW_HEIGHT * rowCount + LAST_ROW_MARGIN_HEIGHT;
 
     return (
       <div>


### PR DESCRIPTION
Scrolling through data in the Lesson and Level views under the Progress tab was
very slow for large sections. This was because the graphing dependancy we use,
react-virtualize multigrid, has a performance limitation around de-rendering
and re-rending rows if the number of rows is large and each row takes a long
time to render, if using multigrid's native functionality to only render a
subsection of a grid at a time.

This diff works around this issue by having react-virtualize multigrid render
all rows for our tables at once, rather than only rendering only a subsection
of rows at a time. This removes the need to de-render and re-render rows, and
thus removes our performance problem

<!--
  Your description goes here: A summary of the change, including any relevant motivation and context.

  If relevant, include a description both of the existing behavior and of the new behavior.
-->

<!--
  Other aspects to consider. uncomment and add detail for any that seem necessary:
-->

<!-- ### Background -->
Scrolling before change:
![mega_levels_old](https://user-images.githubusercontent.com/58449474/91605036-a71cd300-e924-11ea-8b84-43a938ed4a88.gif)
![mega_lessons_old](https://user-images.githubusercontent.com/58449474/91605047-ab48f080-e924-11ea-892e-47ae6ce830a6.gif)
Scrolling after change:
![mega_progress](https://user-images.githubusercontent.com/58449474/91605081-bbf96680-e924-11ea-9689-e332d5926ffe.gif)
![small_levels](https://user-images.githubusercontent.com/58449474/91617028-e4d92600-e93b-11ea-8cb6-ff42ff82dbe4.gif)




<!-- ### Privacy -->
<!-- ### Security -->
<!-- ### Caching -->
<!-- ### Deployment strategy -->
<!-- ### Future work -->

## Links

<!--
  Any relevant links to external resources; ie, specification documents, jira
  items, related PRs, honeybadger errors, etc
-->

- [jira](https://codedotorg.atlassian.net/browse/LP-764)

## Testing story

<!--
  Does your change include appropriate tests?

  If so, please describe how the tests included in this PR are sufficient

  If not, please explain why this change does not need to be tested.
-->

# Reviewer Checklist:



- [ ] Tests provide adequate coverage
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
