### PR TITLE
Re-enable time_spent logging in the user_levels table

### DIFF
--- a/dashboard/app/models/user.rb
+++ b/dashboard/app/models/user.rb
@@ -1780,9 +1780,8 @@ class User < ActiveRecord::Base
         user_level.level_source_id = level_source_id
       end
 
-      # Temporarily disabling while we convert current records from milliseconds to seconds
-      # total_time_spent = user_level.calculate_total_time_spent(time_spent)
-      # user_level.time_spent = total_time_spent if total_time_spent
+      total_time_spent = user_level.calculate_total_time_spent(time_spent)
+      user_level.time_spent = total_time_spent if total_time_spent
 
       user_level.atomic_save!
     end

--- a/dashboard/test/controllers/activities_controller_test.rb
+++ b/dashboard/test/controllers/activities_controller_test.rb
@@ -56,7 +56,7 @@ class ActivitiesControllerTest < ActionController::TestCase
       result: 'true',
       testResult: '100',
       time: '1000',
-      timeSinceLastMilestone: '2000',
+      timeSinceLastMilestone: '20',
       app: 'test',
       program: '<hey>'
     }
@@ -161,7 +161,6 @@ class ActivitiesControllerTest < ActionController::TestCase
   end
 
   test "milestone updates existing user_level with time_spent" do
-    skip 'temporarily disabling while we convert time_spent from milliseconds to seconds'
     @level = create(:level, :blockly, :with_ideal_level_source)
     @script = create(:script)
     @script.update(curriculum_umbrella: 'CSF')
@@ -170,7 +169,7 @@ class ActivitiesControllerTest < ActionController::TestCase
     params = @milestone_params
     params[:script_level_id] = @script_level.id
 
-    user_level = UserLevel.create(level: @script_level.level, user: @user, script: @script_level.script, time_spent: 1000)
+    user_level = UserLevel.create(level: @script_level.level, user: @user, script: @script_level.script, time_spent: 30)
 
     assert_does_not_create(UserLevel) do
       post :milestone, params: @milestone_params
@@ -178,7 +177,7 @@ class ActivitiesControllerTest < ActionController::TestCase
 
     assert_response :success
     user_level.reload
-    assert_equal 3000, user_level.time_spent
+    assert_equal 50, user_level.time_spent
   end
 
   test "milestone creates userlevel with specified level when scriptlevel has multiple levels" do
@@ -1022,8 +1021,7 @@ class ActivitiesControllerTest < ActionController::TestCase
 
     existing_navigator_user_level.reload
     assert_equal 100, existing_navigator_user_level.best_result
-    # temporarily disabling while we convert time_spent from milliseconds to seconds
-    # assert_equal 2000, existing_navigator_user_level.time_spent
+    assert_equal 20, existing_navigator_user_level.time_spent
 
     assert_equal [@user], existing_navigator_user_level.driver_user_levels.map(&:user)
   end
@@ -1045,8 +1043,7 @@ class ActivitiesControllerTest < ActionController::TestCase
 
     existing_driver_user_level.reload
     assert_equal 100, existing_driver_user_level.best_result
-    # temporarily disabling while we convert time_spent from milliseconds to seconds
-    # assert_equal 2000, existing_driver_user_level.time_spent
+    assert_equal 20, existing_driver_user_level.time_spent
 
     assert_equal [pairing], existing_driver_user_level.navigator_user_levels.map(&:user)
   end

--- a/dashboard/test/controllers/activities_controller_test.rb
+++ b/dashboard/test/controllers/activities_controller_test.rb
@@ -56,7 +56,7 @@ class ActivitiesControllerTest < ActionController::TestCase
       result: 'true',
       testResult: '100',
       time: '1000',
-      timeSinceLastMilestone: '20',
+      timeSinceLastMilestone: '20000',
       app: 'test',
       program: '<hey>'
     }


### PR DESCRIPTION
time_spent logging was disabled by this PR (https://github.com/code-dot-org/code-dot-org/pull/36380) so we could convert milliseconds to seconds for existing time_spent records. Now that is finished, and time_spent logging can be re-enabled.

### Background
Given that the mysql limit for an integer is 2,147,483,648 (roughly 25 days when measured in milliseconds), we realized we needed capacity for longer periods of time to be recorded in the time_spent field. It is reasonable to expect a student may spent more than 25 days of total time on a long-term project. Additionally, we continue recording time_spent if the student leaves their browser window open but is not actively working on their computer, which could also increase the time a student spends on their project.

time_spent is currently recording milliseconds. Intervals of time less than one second are not useful for these purposes. Instead, we will record seconds. This will give us capacity to record over 68 years of time_spent on a user_level.

To migrate to recording seconds, we need to take two actions.

1. Divide the time sent from the client by 1000
1. Migrate all existing records to seconds
    a. Stop recording time_spent
    b. Migrate all existing records from milliseconds to seconds
    c. Re-enable recording time_spent

This PR achieves step 2c

1 and 2a were achieved by this pr: https://github.com/code-dot-org/code-dot-org/pull/36380
2b was achieved by this pr: https://github.com/code-dot-org/code-dot-org/pull/36398

<!--
  Other aspects to consider. uncomment and add detail for any that seem necessary:
-->

<!-- ### Background -->
<!-- ### Privacy -->
<!-- ### Security -->
<!-- ### Caching -->
<!-- ### Deployment strategy -->
<!-- ### Future work -->

## Links

<!--
  Any relevant links to external resources; ie, specification documents, jira
  items, related PRs, honeybadger errors, etc
-->

- [LP-1540](https://codedotorg.atlassian.net/browse/LP-1540)

## Testing story

<!--
  Does your change include appropriate tests?

  If so, please describe how the tests included in this PR are sufficient

  If not, please explain why this change does not need to be tested.
-->

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
