### PR TITLE
Fix call to `chef-cdo-app` in `ci.rake`

### DIFF
--- a/lib/rake/ci.rake
+++ b/lib/rake/ci.rake
@@ -33,7 +33,7 @@ namespace :ci do
         RakeUtils.bundle_exec 'berks', 'apply', rack_env
 
         ChatClient.log 'Applying <b>chef</b> profile...'
-        RakeUtils.sudo Cdo::CloudFormation::CdoApp::CHEF_BIN
+        RakeUtils.sudo 'chef-cdo-app'
       end
     end
   end
@@ -118,7 +118,7 @@ end
 # Returns true if upgrade succeeded, false if failed.
 def upgrade_frontend(name, hostname)
   ChatClient.log "Upgrading <b>#{name}</b> (#{hostname})..."
-  command = "sudo #{Cdo::CloudFormation::CdoApp::CHEF_BIN}"
+  command = "sudo chef-cdo-app"
   log_path = aws_dir "deploy-#{name}.log"
   begin
     RakeUtils.system "ssh -i ~/.ssh/deploy-id_rsa #{hostname} '#{command} 2>&1' >> #{log_path}"


### PR DESCRIPTION
Fixes constant not found error, since the `Cdo::CloudFormation::CdoApp` may not be loaded at the time the `:ci` rake task is called. (This PR chooses not to load the module, since it could increase the load time for any script in our repo slightly.)
Followup to #36366.