### PR TITLE
Call original chef-client from CI build

### DIFF
--- a/lib/rake/ci.rake
+++ b/lib/rake/ci.rake
@@ -33,7 +33,7 @@ namespace :ci do
         RakeUtils.bundle_exec 'berks', 'apply', rack_env
 
         ChatClient.log 'Applying <b>chef</b> profile...'
-        RakeUtils.sudo 'chef-cdo-app'
+        RakeUtils.sudo '/opt/chef/bin/chef-client --chef-license accept-silent'
       end
     end
   end
@@ -118,7 +118,7 @@ end
 # Returns true if upgrade succeeded, false if failed.
 def upgrade_frontend(name, hostname)
   ChatClient.log "Upgrading <b>#{name}</b> (#{hostname})..."
-  command = "sudo chef-cdo-app"
+  command = 'sudo /opt/chef/bin/chef-client --chef-license accept-silent'
   log_path = aws_dir "deploy-#{name}.log"
   begin
     RakeUtils.system "ssh -i ~/.ssh/deploy-id_rsa #{hostname} '#{command} 2>&1' >> #{log_path}"


### PR DESCRIPTION
Partial revert of #36366, due to errors at CI build time.
The script needs to be created on existing environments by rebooting existing instances before the path can be safely updated in the CI rake task.