### PR TITLE
Cap the time_spent recorded per milestone to one hour

### DIFF
--- a/dashboard/app/controllers/activities_controller.rb
+++ b/dashboard/app/controllers/activities_controller.rb
@@ -12,6 +12,7 @@ class ActivitiesController < ApplicationController
   protect_from_forgery except: :milestone
 
   MAX_INT_MILESTONE = 2_147_483_647
+  MAX_INT_TIME_SPENT = 3600
 
   MIN_LINES_OF_CODE = 0
   MAX_LINES_OF_CODE = 1000
@@ -179,7 +180,7 @@ class ActivitiesController < ApplicationController
     end
     if @script_level
       # convert milliseconds to seconds
-      time_since_last_milestone = [(params[:timeSinceLastMilestone].to_f / 1000).ceil.to_i, MAX_INT_MILESTONE].min
+      time_since_last_milestone = [(params[:timeSinceLastMilestone].to_f / 1000).ceil.to_i, MAX_INT_TIME_SPENT].min
       @user_level, @new_level_completed = User.track_level_progress(
         user_id: current_user.id,
         level_id: @level.id,


### PR DESCRIPTION
We have had some cases where a student spends an extreme amount of time on a level between recording milestones. In some cases, a student will even record more time on a level than was physically possible (see "Example" below). In order to prevent such outliers, we are capping the time_spent per milestone to 1 hour.

### Example
(Slack Conversation)[https://codedotorg.slack.com/archives/CA3KCSGTD/p1597952388014200]

On Aug 20th, 2020, time_spent recording had been enabled for ~24 hours. During that time, however, we had one student record approximately 19 days worth of time_spent on a single level. This was not possible and was likely due to an issue with the user's system clock. 

Additionally, there is some worry that students who leave their browser open overnight or for multiple days will record extremely long time_spent without actually interacting with the site.

These two types of scenarios can erroneously cause large amounts of time_spent recorded for users.

<!--
  Other aspects to consider. uncomment and add detail for any that seem necessary:
-->

<!-- ### Background -->
<!-- ### Privacy -->
<!-- ### Security -->
<!-- ### Caching -->
<!-- ### Deployment strategy -->
<!-- ### Future work -->

## Links

<!--
  Any relevant links to external resources; ie, specification documents, jira
  items, related PRs, honeybadger errors, etc
-->

- [LP-1542](https://codedotorg.atlassian.net/browse/LP-1542)

## Testing story

<!--
  Does your change include appropriate tests?

  If so, please describe how the tests included in this PR are sufficient

  If not, please explain why this change does not need to be tested.
-->

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
