### PR TITLE
Hints: add a default hint prompt attempts threshold

### DIFF
--- a/dashboard/app/helpers/levels_helper.rb
+++ b/dashboard/app/helpers/levels_helper.rb
@@ -349,8 +349,10 @@ module LevelsHelper
   end
 
   def set_hint_prompt_options(level_options)
-    if @script && @script.hint_prompt_enabled? && @level.hint_prompt_attempts_threshold
-      level_options[:hintPromptAttemptsThreshold] = @level.hint_prompt_attempts_threshold
+    default_hint_prompt_attempts_threshold = 6.5
+    if @script && @script.hint_prompt_enabled?
+      level_options[:hintPromptAttemptsThreshold] = @level.hint_prompt_attempts_threshold ? @level.hint_prompt_attempts_threshold :
+      default_hint_prompt_attempts_threshold
     end
   end
 

--- a/dashboard/app/helpers/levels_helper.rb
+++ b/dashboard/app/helpers/levels_helper.rb
@@ -351,8 +351,7 @@ module LevelsHelper
   def set_hint_prompt_options(level_options)
     default_hint_prompt_attempts_threshold = 6.5
     if @script && @script.hint_prompt_enabled?
-      level_options[:hintPromptAttemptsThreshold] = @level.hint_prompt_attempts_threshold ? @level.hint_prompt_attempts_threshold :
-      default_hint_prompt_attempts_threshold
+      level_options[:hintPromptAttemptsThreshold] = @level.hint_prompt_attempts_threshold || default_hint_prompt_attempts_threshold
     end
   end
 

--- a/dashboard/app/helpers/levels_helper.rb
+++ b/dashboard/app/helpers/levels_helper.rb
@@ -350,7 +350,7 @@ module LevelsHelper
 
   def set_hint_prompt_options(level_options)
     default_hint_prompt_attempts_threshold = 6.5
-    if @script && @script.hint_prompt_enabled?
+    if @script&.hint_prompt_enabled?
       level_options[:hintPromptAttemptsThreshold] = @level.hint_prompt_attempts_threshold || default_hint_prompt_attempts_threshold
     end
   end

--- a/dashboard/test/helpers/levels_helper_test.rb
+++ b/dashboard/test/helpers/levels_helper_test.rb
@@ -815,14 +815,14 @@ class LevelsHelperTest < ActionView::TestCase
     assert_equal level_options[:hintPromptAttemptsThreshold], @level.hint_prompt_attempts_threshold
   end
 
-  test 'does not set hint prompt attempts threshold in options if unavailable' do
+  test 'sets hint prompt attempts threshold in options to default if not already set' do
     @script = create :csf_script
     @level = create :level
     @lesson = create :lesson
     @script_level = create :script_level, levels: [@level], lesson: @lesson
     level_options = {}
     set_hint_prompt_options(level_options)
-    assert_nil level_options[:hintPromptAttemptsThreshold]
+    assert_equal level_options[:hintPromptAttemptsThreshold], 6.5
   end
 
   test 'does not set hint prompt attempts threshold in options for level in csp script' do


### PR DESCRIPTION
Continuation of #36488 
[STAR-1205](https://codedotorg.atlassian.net/browse/STAR-1205)

While we determine how/if we're going to invest in setting the hint prompt attempts threshold based on the logic for the number of attempts at which 75% of students completed the level +1, we're setting a default of 6.5 for the threshold.  This means that levels in CSF courses that do not already have a hint prompt attempts threshold set, will display the hint prompt dialog after 7 runs. 

The number selected for the default is basically arbitrary.  I made it 6.5 so that it would be easily distinguishable from thresholds set programmatically. The distribution of thresholds for the levels shown below was calculated from the data in [thresholds.csv](https://github.com/code-dot-org/code-dot-org/blob/staging/dashboard/scripts/thresholds.csv) which covers levels in Course 2, 3, 4, and A-F 2017.

![Screen Shot 2020-08-28 at 3 31 20 PM](https://user-images.githubusercontent.com/12300669/91608440-916ad600-e943-11ea-8b69-219effc558a4.png)
 
7 seemed like the middle-ish of the biggest left-hand half and I opted for a lower number than a higher one since showing a dismissible hint prompt when not needed felt like less of a problem than not showing one to a student who was struggling and would benefit from the prompt.  Regardless, a default hint prompt attempts threshold no matter how to you figure it from the levels that currently have hint prompt attempts thresholds set has no real validity for the levels that don't have a hint prompt attempt threshold set because we don't know the relative difficulty of the latter levels nor do we know if they are intended to take more/less attempts to solve. This is a stop-gap solution that gets the hint prompt showing up more frequently than currently, but not optimally. 

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
