### PR TITLE
Add support for CloudFormation Resource Import to CFn glue code

### DIFF
--- a/aws/cloudformation/cloud_formation_stack.yml.erb
+++ b/aws/cloudformation/cloud_formation_stack.yml.erb
@@ -281,6 +281,11 @@ Resources:
                 Action:
                   - 'cloudformation:UpdateStack'
                   - 'cloudformation:DescribeStacks'
+                  - 'cloudformation:CreateChangeSet'
+                  - 'cloudformation:DescribeChangeSet'
+                  - 'cloudformation:ExecuteChangeSet'
+                  - 'cloudformation:DeleteChangeSet'
+                  - 'cloudformation:GetTemplateSummary'
                 Resource: !Sub "arn:aws:cloudformation:${AWS::Region}:${AWS::AccountId}:stack/${AWS::StackName}/*"
               - Effect: Allow
                 Action: iam:PassRole

--- a/lib/cdo/cloud_formation/cdo_app.rb
+++ b/lib/cdo/cloud_formation/cdo_app.rb
@@ -64,8 +64,6 @@ module Cdo::CloudFormation
       stack_name << "-#{branch}" if stack_name == 'adhoc'
       raise "Stack name must not include 'dashboard'" if stack_name.include?('dashboard')
 
-      check_branch!
-
       # Don't provision daemon where manually-provisioned daemon instances already exist.
       # Track Instance ID of manually-provisioned daemon instances that already exist and can't be referenced dynamically
       # TODO import manually-provisioned instances into cloudformation stacks.
@@ -87,7 +85,13 @@ module Cdo::CloudFormation
       tags.push(key: 'owner', value: Aws::STS::Client.new.get_caller_identity.arn) if rack_env?(:adhoc)
     end
 
+    def render(*)
+      check_branch!
+      super
+    end
+
     def check_branch!
+      return if dry_run
       if rack_env?(:adhoc) && RakeUtils.git_branch == branch
         # Current branch is the one we're deploying to the adhoc server,
         # so check whether it's up-to-date with the remote before we get any further.

--- a/lib/rake/adhoc.rake
+++ b/lib/rake/adhoc.rake
@@ -17,6 +17,7 @@ namespace :adhoc do
       log: CDO.log,
       verbose: ENV['VERBOSE'],
       quiet: ENV['QUIET'],
+      import_resources: ENV['IMPORT_RESOURCES'],
     )
   end
 

--- a/lib/rake/stack.rake
+++ b/lib/rake/stack.rake
@@ -17,6 +17,7 @@ namespace :stack do
       log: CDO.log,
       verbose: ENV['VERBOSE'],
       quiet: ENV['QUIET'],
+      import_resources: ENV['IMPORT_RESOURCES'],
     )
   end
 
@@ -63,6 +64,7 @@ Note: Consumes AWS resources until `adhoc:stop` is called.'
           log: CDO.log,
           verbose: ENV['VERBOSE'],
           quiet: ENV['QUIET'],
+          import_resources: ENV['IMPORT_RESOURCES'],
         )
       end
 


### PR DESCRIPTION
This update to `AWS::CloudFormation` makes it possible to [import existing resources into a stack](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/resource-import-existing-stack.html) using the `IMPORT` type of the [`CreateChangeSet`](https://docs.aws.amazon.com/AWSCloudFormation/latest/APIReference/API_CreateChangeSet.html) API operation.

The implementation defines a new `import_resources` option to trigger importing resources, derived from the `IMPORT_RESOURCES` env variable via the `stack`/`adhoc` rake tasks.

For example, to import an `AWS::EC2::Instance` resource with a logical-id of `Daemon` and an instance id `i-0123456789abcdef`:
```
RAILS_ENV=staging bundle exec rake stack:start IMPORT_RESOURCES=Daemon:i-0123456789abcdef
```

Note the existing limitation of resource imports, which will cause the process to fail if not satisfied:
- An explicit `DeletionPolicy` must be specified for imported resources.
- The newly-imported resources must be the only change in the updated stack template, changes to any other resources are not permitted.

Since resource import is only possible through creating/executing a Change Set, I also had to change the implementation to apply stack updates through `ExecuteChangeSet` instead of `UpdateStack` directly, making this a much more substantial change. I added an extra `Proceed? [y/n]` confirmation dialog to `create_or_update` (`:start` rake tasks), so manually running `:validate` before running `:start` is now slightly less crucial to prevent accidental changes from being applied.