### PR TITLE
Import EC2 daemon instance into CloudFormation stacks

### DIFF
--- a/aws/cloudformation/cloud_formation_stack.yml.erb
+++ b/aws/cloudformation/cloud_formation_stack.yml.erb
@@ -405,6 +405,9 @@ Resources:
 <% if daemon -%>
   <%=daemon%>:
     Type: AWS::EC2::Instance
+<% if @daemon_instance_id -%>
+    DeletionPolicy: Retain
+<% end -%>
     CreationPolicy:
       ResourceSignal:
         Timeout: PT2H

--- a/lib/cdo/cloud_formation/cdo_app.rb
+++ b/lib/cdo/cloud_formation/cdo_app.rb
@@ -76,6 +76,10 @@ module Cdo::CloudFormation
           'staging' => 'i-02e6cdc765421ab34',
           'levelbuilder' => 'i-0907b146f7e6503f6'
         }[stack_name]
+        # These stacks will have their EC2 resource imported before the next CI stack update.
+        if %w(staging test levelbuilder).include?(stack_name)
+          @daemon = 'Daemon'
+        end
       else
         @daemon = 'Daemon'
       end


### PR DESCRIPTION
Preparation to import all manually-provisioned instances except for production (`staging`, `test`, `levelbuilder`).
