### PR TITLE
Move CSF Deep Dive Surveys to Foorm

### DIFF
--- a/apps/src/code-studio/pd/workshop_dashboard/workshop_summary_utils.js
+++ b/apps/src/code-studio/pd/workshop_dashboard/workshop_summary_utils.js
@@ -7,12 +7,15 @@ import {CSF, CSD, CSP} from '../application/ApplicationConstants';
 export function useFoormSurvey(subject, lastSessionDate) {
   // Local summer workshop, CSF Intro workshop, CSP workshop for returning teachers, and academic year workshops for CSP and CSD
   // after 5/8/2020 will use Foorm for survey completion.
+  // CSF Deep Dive workshops after 9/1 will also use Foorm
   return (
-    lastSessionDate >= new Date('2020-05-08') &&
-    (subject === SubjectNames.SUBJECT_SUMMER_WORKSHOP ||
-      subject === SubjectNames.SUBJECT_CSF_101 ||
-      subject === SubjectNames.SUBJECT_CSP_FOR_RETURNING_TEACHERS ||
-      AcademicYearWorkshopSubjects.includes(subject))
+    (lastSessionDate >= new Date('2020-05-08') &&
+      (subject === SubjectNames.SUBJECT_SUMMER_WORKSHOP ||
+        subject === SubjectNames.SUBJECT_CSF_101 ||
+        subject === SubjectNames.SUBJECT_CSP_FOR_RETURNING_TEACHERS ||
+        AcademicYearWorkshopSubjects.includes(subject))) ||
+    (lastSessionDate >= new Date('2020-09-01') &&
+      subject === SubjectNames.SUBJECT_CSF_201)
   );
 }
 

--- a/dashboard/app/controllers/pd/workshop_daily_survey_controller.rb
+++ b/dashboard/app/controllers/pd/workshop_daily_survey_controller.rb
@@ -1,12 +1,8 @@
 module Pd
   class WorkshopDailySurveyController < ApplicationController
     include WorkshopConstants
-    include JotForm::EmbedHelper
     include WorkshopSurveyConstants
     include WorkshopSurveyFoormConstants
-
-    # The POST submit route will be redirected to from JotForm, after form submission
-    skip_before_action :verify_authenticity_token, only: %w(submit_general submit_facilitator)
 
     # Require login
     authorize_resource class: 'Pd::Enrollment'
@@ -99,105 +95,6 @@ module Pd
       render_survey_foorm(survey_name: survey_name, workshop: workshop, session: nil, day: day, workshop_agenda: agenda)
     end
 
-    # POST /pd/workshop_survey/submit
-    def submit_general
-      WorkshopDailySurvey.create_placeholder!(
-        user_id: key_params[:userId],
-        pd_workshop_id: key_params[:workshopId],
-        day: key_params[:day],
-        form_id: key_params[:formId],
-        submission_id: params[:submission_id]
-      )
-
-      key_params[:enrollmentCode].present? ? redirect_post(key_params) : redirect_general(key_params)
-    end
-
-    # Facilitator-specific questions
-    # GET /pd/workshop_survey/facilitators/:session_id(/:facilitator_index)
-    # :session_id is the id of the workshop session.
-    # :facilitator_index is the optional (default 0, first) index in sorted session.workshop.facilitators
-    #
-    # The JotForm survey, on submit, will redirect back to this same route, but with
-    # facilitatorPosition as facilitator_index, thus incrementing it by 1.
-    def new_facilitator
-      session = Session.find(params[:session_id])
-      workshop = session.workshop
-      day = workshop.sessions.index(session) + 1
-
-      # Post workshop survey (last day) does not need to be taken while the session is still open,
-      # and has less strict attendance requirements.
-      unless day == workshop.sessions.size
-        return render :too_late unless session.open_for_attendance?
-
-        attendance = session.attendances.find_by(teacher: current_user)
-        return render :no_attendance unless attendance
-      end
-
-      facilitator_index = params[:facilitator_index]&.to_i || 0
-      facilitators = workshop.facilitators.order(:name, :id)
-      facilitator = facilitators[facilitator_index]
-
-      # Out of facilitators? Done.
-      return redirect_to action: :thanks unless facilitator
-
-      @form_id = WorkshopFacilitatorDailySurvey.form_id workshop.subject
-
-      # Pass these params to the form and to the submit redirect to identify unique responses
-      key_params = {
-        environment: Rails.env,
-        userId: current_user.id,
-        day: day,
-        sessionId: session.id,
-        facilitatorId: facilitator.id,
-        facilitatorIndex: facilitator_index,
-        formId: @form_id,
-      }
-
-      return redirect_facilitator(key_params) if response_exists_facilitator?(key_params)
-
-      @form_params = key_params.merge(
-        workshopId: workshop.id,
-        userName: current_user.name,
-        userEmail: current_user.email,
-        workshopCourse: workshop.course,
-        workshopSubject: workshop.subject,
-        regionalPartnerName: workshop.regional_partner&.name,
-        facilitatorPosition: facilitator_index + 1,
-        facilitatorName: facilitator.name,
-        numFacilitators: facilitators.size,
-        submitRedirect: url_for(action: 'submit_facilitator', params: {key: key_params})
-      )
-
-      return if experimental_redirect! @form_id, @form_params
-
-      if CDO.newrelic_logging
-        NewRelic::Agent.record_custom_event(
-          "RenderJotFormView",
-          {
-            route: "GET /pd/workshop_survey/facilitators/#{session.id}/#{facilitator_index}",
-            form_id: @form_id,
-            workshop_course: workshop.course,
-            workshop_subject: workshop.subject,
-            regional_partner_name: workshop.regional_partner&.name,
-          }
-        )
-      end
-    end
-
-    # POST /pd/workshop_survey/facilitators/submit
-    def submit_facilitator
-      WorkshopFacilitatorDailySurvey.create_placeholder!(
-        user_id: key_params[:userId],
-        day: key_params[:day],
-        pd_session_id: key_params[:sessionId],
-        facilitator_id: key_params[:facilitatorId],
-        form_id: key_params[:formId],
-        submission_id: params[:submission_id]
-      )
-
-      redirect_facilitator(key_params)
-    end
-
     # Post workshop survey. This one will be emailed and displayed in the my PL page,
     # and can persist for more than a day, so it uses an enrollment code to be tied to a specific workshop.
     # GET /pd/workshop_survey/post/:enrollment_code
@@ -206,25 +103,9 @@ module Pd
       return new_post_foorm
     end
 
-    # Display CSF201 (Deep Dive) pre-workshop survey.
+    # Display CSF201 (Deep Dive) pre-workshop survey using Foorm.
     # GET workshop_survey/csf/pre201
     def new_csf_pre201
-      # Find the closest CSF 201 workshop the current user enrolled in.
-      workshop = Pd::Workshop.
-        where(course: COURSE_CSF, subject: SUBJECT_CSF_201).
-        enrolled_in_by(current_user).nearest
-
-      return render :not_enrolled unless workshop
-      return render :too_late unless workshop.state != STATE_ENDED
-
-      render_csf_survey(PRE_DEEPDIVE_SURVEY, workshop)
-    end
-
-    # Display CSF201 (Deep Dive) pre-workshop survey using Foorm.
-    # Temporary separate method for testing--will eventually replace new_csf_pre201
-    # once all CSF201 surveys are converted to Foorm
-    # GET workshop_survey/foorm/csf/pre201
-    def new_csf_pre201_foorm
       # Find the closest CSF 201 workshop the current user enrolled in.
       workshop = get_workshop_by_course_and_subject(
         course: COURSE_CSF,
@@ -257,28 +138,9 @@ module Pd
       render_survey_foorm(survey_name: survey_name, workshop: attended_workshop, session: nil, day: nil)
     end
 
-    # Display CSF201 (Deep Dive) post-workshop survey.
-    # The JotForm survey, on submit, will redirect to the new_facilitator route for user
-    # to submit facilitator surveys.
+    # Display CSF201 (Deep Dive) post-workshop survey using Foorm.
     # GET workshop_survey/csf/post201(/:enrollment_code)
     def new_csf_post201
-      # Use enrollment_code to find a specific workshop
-      # or search all CSF201 workshops the current user is enrolled in and attended.
-      attended_workshop = get_workshop_by_enrollment_or_course_and_subject(
-        enrollment_code: params[:enrollment_code],
-        course: COURSE_CSF,
-        subject: SUBJECT_CSF_201
-      )
-      return unless attended_workshop
-
-      render_csf_survey(POST_DEEPDIVE_SURVEY, attended_workshop)
-    end
-
-    # Display CSF201 (Deep Dive) post-workshop survey using Foorm.
-    # Temporary separate method for testing--will eventually replace new_csf_post201
-    # once all CSF201 surveys are converted to Foorm
-    # GET workshop_survey/foorm/csf/post201
-    def new_csf_post201_foorm
       # Use enrollment_code to find a specific workshop
       # or search all CSF201 workshops the current user is enrolled in and attended.
       attended_workshop = get_workshop_by_enrollment_or_course_and_subject(
@@ -372,103 +234,6 @@ module Pd
       workshop
     end
 
-    def response_exists_general?(key_params)
-      WorkshopDailySurvey.response_exists?(
-        user_id: key_params[:userId],
-        pd_workshop_id: key_params[:workshopId],
-        day: key_params[:day],
-        form_id: key_params[:formId]
-      )
-    end
-
-    def redirect_general(key_params)
-      session_id = key_params[:sessionId]
-
-      if session_id.present?
-        redirect_to action: :new_facilitator, session_id: session_id, facilitator_index: 0
-      else
-        redirect_to action: :thanks
-      end
-    end
-
-    def response_exists_facilitator?(key_params)
-      WorkshopFacilitatorDailySurvey.response_exists?(
-        user_id: key_params[:userId],
-        pd_session_id: key_params[:sessionId],
-        facilitator_id: key_params[:facilitatorId],
-        form_id: key_params[:formId]
-      )
-    end
-
-    def redirect_facilitator(key_params)
-      session = Session.find(key_params[:sessionId])
-      session_size = session.workshop.sessions.size
-      next_facilitator_index = key_params[:facilitatorIndex].to_i + 1
-
-      if next_facilitator_index.between?(1, session.workshop.facilitators.size - 1)
-        redirect_to action: :new_facilitator,
-          session_id: session.id, facilitator_index: next_facilitator_index
-      # No facilitators left. Academic workshops redirect to post if its the last day.
-      # Summer workshops and CSF 201 workshops redirect to thanks.
-      elsif !session.workshop.summer? &&
-        !session.workshop.csf_201? && key_params[:day].to_i == session_size
-        enrollment_code = Pd::Enrollment.find_by(user: current_user, workshop: session.workshop).code
-        redirect_to action: :new_post, enrollment_code: enrollment_code
-      else
-        redirect_to action: :thanks
-      end
-    end
-
-    def redirect_post(key_params)
-      session = Session.find(key_params[:sessionId])
-      if session.workshop.summer?
-        redirect_to action: :new_facilitator, session_id: session.id, facilitator_index: 0
-      else
-        redirect_to action: :thanks
-      end
-    end
-
-    def render_csf_survey(survey_name, workshop)
-      @form_id = WorkshopDailySurvey.get_form_id CSF_CATEGORY, survey_name
-
-      # There are facilitator surveys after post workshop survey.
-      # Use sessionId to create URL query to those facilitator surveys.
-      session_id = survey_name == POST_DEEPDIVE_SURVEY ? workshop.sessions.first&.id : nil
-
-      key_params = {
-        environment: Rails.env,
-        userId: current_user.id,
-        workshopId: workshop.id,
-        day: CSF_SURVEY_INDEXES[survey_name],
-        sessionId: session_id,
-        formId: @form_id
-      }
-
-      @form_params = key_params.merge(
-        userName: current_user.name,
-        userEmail: current_user.email,
-        submitRedirect: url_for(action: 'submit_general', params: {key: key_params})
-      )
-
-      return redirect_general(key_params) if response_exists_general?(key_params)
-      return if experimental_redirect! @form_id, @form_params
-
-      if CDO.newrelic_logging
-        NewRelic::Agent.record_custom_event(
-          "RenderJotFormView",
-          {
-            route: "GET /pd/workshop_survey/csf/#{survey_name}",
-            form_id: @form_id,
-            workshop_course: workshop.course,
-            workshop_subject: workshop.subject,
-            regional_partner_name: workshop.regional_partner&.name,
-          }
-        )
-      end
-
-      render :new_general
-    end
-
     def ayw_helper(survey_names:, day:)
       # get workshop (based on url/user)
       workshop_subject = ACADEMIC_YEAR_WORKSHOPS[params[:workshop_subject]]
@@ -512,12 +277,6 @@ module Pd
       }
 
       render :new_general_foorm
-    end
-
-    def key_params
-      @key_params ||= params.require(:key).tap do |key_params|
-        raise ActiveRecord::RecordNotFound unless key_params[:environment] == Rails.env
-      end
     end
 
     def get_session_for_workshop_and_day(workshop, day)

--- a/dashboard/app/models/pd/enrollment.rb
+++ b/dashboard/app/models/pd/enrollment.rb
@@ -164,15 +164,11 @@ class Pd::Enrollment < ActiveRecord::Base
     raise 'Expected enrollments to be an Enumerable list of Pd::Enrollment objects' unless
         enrollments.is_a?(Enumerable) && enrollments.all? {|e| e.is_a?(Pd::Enrollment)}
 
-    # only CSF Deep Dive uses JotForm
-    jotform_enrollments, other_enrollments = enrollments.partition do |enrollment|
-      enrollment.workshop.csf_201?
-    end
-
     # Local summer, CSP Workshop for Returning Teachers, or CSF Intro after 5/8/2020 will use Foorm for survey completion
-    foorm_enrollments, other_enrollments = other_enrollments.partition do |enrollment|
-      enrollment.workshop.workshop_ending_date >= Date.new(2020, 5, 8) &&
-        (enrollment.workshop.csf_intro? || enrollment.workshop.local_summer? || enrollment.workshop.csp_wfrt?)
+    foorm_enrollments, other_enrollments = enrollments.partition do |enrollment|
+      (enrollment.workshop.workshop_ending_date >= Date.new(2020, 5, 8) &&
+        (enrollment.workshop.csf_intro? || enrollment.workshop.local_summer? || enrollment.workshop.csp_wfrt?)) ||
+        (enrollment.workshop.workshop_ending_date >= Date.new(2020, 9, 1) && enrollment.workshop.csf_201?)
     end
 
     # Admin and Counselor still use Pegasus form
@@ -184,7 +180,6 @@ class Pd::Enrollment < ActiveRecord::Base
     # and CSF Intro (surveys would be too out of date), teachercon (deprecated), or any academic year workshop
     # (there are multiple post-survey options, therefore the facilitators must provide a link themselves).
     (
-      filter_for_jotform_survey_completion(jotform_enrollments, select_completed) +
       filter_for_pegasus_survey_completion(pegasus_enrollments, select_completed) +
       filter_for_foorm_survey_completion(foorm_enrollments, select_completed)
     )
@@ -389,21 +384,6 @@ class Pd::Enrollment < ActiveRecord::Base
                      ids_without_processed_surveys - ids_with_unprocessed_surveys
 
     enrollments.select {|e| filtered_ids.include? e.id}
-  end
-
-  private_class_method def self.filter_for_jotform_survey_completion(enrollments, select_completed)
-    completed_surveys, uncompleted_surveys = enrollments.partition do |enrollment|
-      workshop = enrollment.workshop
-      begin
-        Pd::WorkshopDailySurvey.exists?(pd_workshop: workshop, user: enrollment.user, form_id: Pd::WorkshopDailySurvey.get_form_id_for_subject_and_day(workshop.subject, POST_WORKSHOP_FORM_KEY))
-      # if we can't find the expected form id we will get a key error. Consider this to be a completed survey as there
-      # is no survey.
-      rescue KeyError
-        true
-      end
-    end
-
-    select_completed ? completed_surveys : uncompleted_surveys
   end
 
   private_class_method def self.filter_for_foorm_survey_completion(enrollments, select_completed)

--- a/dashboard/app/models/pd/enrollment.rb
+++ b/dashboard/app/models/pd/enrollment.rb
@@ -164,7 +164,8 @@ class Pd::Enrollment < ActiveRecord::Base
     raise 'Expected enrollments to be an Enumerable list of Pd::Enrollment objects' unless
         enrollments.is_a?(Enumerable) && enrollments.all? {|e| e.is_a?(Pd::Enrollment)}
 
-    # Local summer, CSP Workshop for Returning Teachers, or CSF Intro after 5/8/2020 will use Foorm for survey completion
+    # Local summer, CSP Workshop for Returning Teachers, or CSF Intro after 5/8/2020 will use Foorm for survey completion.
+    # CSF Deep Dive after 9/1 also uses Foorm
     foorm_enrollments, other_enrollments = enrollments.partition do |enrollment|
       (enrollment.workshop.workshop_ending_date >= Date.new(2020, 5, 8) &&
         (enrollment.workshop.csf_intro? || enrollment.workshop.local_summer? || enrollment.workshop.csp_wfrt?)) ||
@@ -176,8 +177,8 @@ class Pd::Enrollment < ActiveRecord::Base
       enrollment.workshop.course == COURSE_ADMIN || enrollment.workshop.course == COURSE_COUNSELOR
     end
 
-    # We do not want to check survey completion for the following workshop types: Legacy (non-Foorm) summer
-    # and CSF Intro (surveys would be too out of date), teachercon (deprecated), or any academic year workshop
+    # We do not want to check survey completion for the following workshop types: Legacy (non-Foorm) summer,
+    # CSF Intro, and CSF Deep Dive (surveys would be too out of date), teachercon (deprecated), or any academic year workshop
     # (there are multiple post-survey options, therefore the facilitators must provide a link themselves).
     (
       filter_for_pegasus_survey_completion(pegasus_enrollments, select_completed) +

--- a/dashboard/config/foorm/forms/surveys/pd/csf_deep_dive_pre.0.json
+++ b/dashboard/config/foorm/forms/surveys/pd/csf_deep_dive_pre.0.json
@@ -230,7 +230,7 @@
     {
      "type": "comment",
      "name": "teaching_strategy_fr",
-     "title": "What is a teaching strategy or approach that has helped you teach CS Fundamentals to your students in the way in which you want them to experience?"
+     "title": "What is a teaching strategy or approach that has helped you teach CS Fundamentals in a way in which you want your students to experience the course?"
     }
    ],
    "title": "CS Fundamentals Teaching Practices and Course Materials"

--- a/dashboard/config/foorm/forms/surveys/pd/csf_deep_dive_pre.0.json
+++ b/dashboard/config/foorm/forms/surveys/pd/csf_deep_dive_pre.0.json
@@ -1,5 +1,5 @@
 {
- "title": "CS Fundamentals Deep Dive Pre-survey",
+ "title": "CS Fundamentals Deep Dive Pre Survey",
  "pages": [
   {
    "name": "overview",


### PR DESCRIPTION
Flip CSF Deep Dive urls to use Foorm instead of JotForm. Work to set up the surveys was mostly done in [this PR](https://github.com/code-dot-org/code-dot-org/pull/35912) for the pre-survey and [this PR](https://github.com/code-dot-org/code-dot-org/pull/35834) for the post-survey. This PR updates the links so that the link that used to direct to JotForm now directs to Foorm. All workshops on or after 9/1 will also show the Foorm results page. There are no Deep Dive workshops between 8/27-9/12, so there is no risk of a workshop getting caught using both JotForm and Foorm.

This was the last survey served by `workshop_daily_survey_controller` to use JotForm, so I removed the JotForm specific code from that file.

<!-- ### Background -->
<!-- ### Privacy -->
<!-- ### Security -->
<!-- ### Caching -->
<!-- ### Deployment strategy -->
<!-- ### Future work -->

## Links

- [jira](https://codedotorg.atlassian.net/browse/PLC-963)

## Testing story
Updated the `workshop_daily_survey_controller` unit tests to reflect the new Foorm version of the survey. I was also able to remove a lot of old tests that validated JotForm-specific code in that controller. I also manually tested the pre and post surveys get linked properly from the dashboard and the results page shows the correct results.

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
