### PR TITLE
Cleanup use of button constants

### DIFF
--- a/apps/src/lib/kits/maker/ui/SetupGuide.jsx
+++ b/apps/src/lib/kits/maker/ui/SetupGuide.jsx
@@ -12,7 +12,7 @@ import {
   isWindows,
   isLinux
 } from '../util/browserChecks';
-import Button, {ButtonColor, ButtonSize} from '../../../../templates/Button';
+import Button from '../../../../templates/Button';
 import ToggleGroup from '../../../../templates/ToggleGroup';
 import FontAwesome from '../../../../templates/FontAwesome';
 
@@ -130,8 +130,8 @@ class WindowsDownloads extends React.Component {
               installer.version
             })`}
             icon="download"
-            color={ButtonColor.orange}
-            size={ButtonSize.large}
+            color={Button.ButtonColor.orange}
+            size={Button.ButtonSize.large}
             style={downloadButtonStyle}
             href={DOWNLOAD_PREFIX + installer.filename}
           />
@@ -180,8 +180,8 @@ class MacDownloads extends React.Component {
             __useDeprecatedTag
             text={`Download Code.org Maker App for Mac (${installer.version})`}
             icon="download"
-            color={ButtonColor.orange}
-            size={ButtonSize.large}
+            color={Button.ButtonColor.orange}
+            size={Button.ButtonSize.large}
             style={downloadButtonStyle}
             href={DOWNLOAD_PREFIX + installer.filename}
           />
@@ -233,8 +233,8 @@ class LinuxDownloads extends React.Component {
               installer.version
             })`}
             icon="download"
-            color={ButtonColor.orange}
-            size={ButtonSize.large}
+            color={Button.ButtonColor.orange}
+            size={Button.ButtonSize.large}
             style={downloadButtonStyle}
             href={DOWNLOAD_PREFIX + installer.filename}
           />

--- a/apps/src/lib/ui/SyncOmniAuthSectionControl.jsx
+++ b/apps/src/lib/ui/SyncOmniAuthSectionControl.jsx
@@ -10,7 +10,7 @@ import {
   sectionProvider,
   sectionName
 } from '../../templates/teacherDashboard/teacherSectionsRedux';
-import Button, {ButtonColor, ButtonSize} from '../../templates/Button';
+import Button from '../../templates/Button';
 import firehoseClient from '@cdo/apps/lib/util/firehose';
 
 const PROVIDER_NAME = {
@@ -131,8 +131,8 @@ export function SyncOmniAuthSectionButton({provider, buttonState, onClick}) {
     <Button
       __useDeprecatedTag
       text={buttonText(buttonState, providerName)}
-      color={ButtonColor.gray}
-      size={ButtonSize.default}
+      color={Button.ButtonColor.gray}
+      size={Button.ButtonSize.default}
       disabled={buttonState === IN_PROGRESS}
       onClick={onClick}
       {...iconProps(buttonState)}

--- a/apps/src/templates/Button.jsx
+++ b/apps/src/templates/Button.jsx
@@ -25,6 +25,12 @@ const ButtonSize = {
   narrow: 'narrow'
 };
 
+const ButtonHeight = {
+  default: 34,
+  large: 40,
+  narrow: 40
+};
+
 const styles = {
   main: {
     display: 'inline-block',
@@ -140,19 +146,19 @@ const styles = {
   },
   sizes: {
     [ButtonSize.default]: {
-      height: 34,
+      height: ButtonHeight.default,
       paddingLeft: 24,
       paddingRight: 24,
       lineHeight: '34px'
     },
     [ButtonSize.large]: {
-      height: 40,
+      height: ButtonHeight.large,
       paddingLeft: 30,
       paddingRight: 30,
       lineHeight: '40px'
     },
     [ButtonSize.narrow]: {
-      height: 40,
+      height: ButtonHeight.narrow,
       paddingLeft: 10,
       paddingRight: 10,
       lineHeight: '40px'
@@ -260,5 +266,6 @@ class Button extends React.Component {
 
 Button.ButtonColor = ButtonColor;
 Button.ButtonSize = ButtonSize;
+Button.ButtonHeight = ButtonHeight;
 
 export default Radium(Button);


### PR DESCRIPTION
This is a small PR to resolve an issue I encountered in [LP-1522]. I'm putting it in its own PR to create a record of the issue.

I needed to reuse the default height of our `Button` component in a new button, but when I exported the button heights, that broke the `SyncOmniAuthSectionControl` component. Long story short, @Hamms helped me figure out that if we are setting class vars on the button (e.g. `Button.ButtonColor = ButtonColor;`) and we add a non-default export, the class vars are no longer able to be imported individually (e.g. `import Button, {ButtonColor, ButtonSize}`) unless they are also exported.

Most of are coded references these constants through the class vars, so for consistency we decided to update the two files that were using individual imports. I was then able to add my new `ButtonHeight` class var without breaking things.


[LP-1522]: https://codedotorg.atlassian.net/browse/LP-1522