### PR TITLE
[Google Blockly] Wrap FieldDropdown constructor

### DIFF
--- a/apps/src/sites/studio/pages/googleBlocklyWrapper.js
+++ b/apps/src/sites/studio/pages/googleBlocklyWrapper.js
@@ -54,7 +54,6 @@ function initializeBlocklyWrapper(blocklyInstance) {
   blocklyWrapper.wrapReadOnlyProperty('FieldButton');
   blocklyWrapper.wrapReadOnlyProperty('FieldColour');
   blocklyWrapper.wrapReadOnlyProperty('FieldColourDropdown');
-  blocklyWrapper.wrapReadOnlyProperty('FieldDropdown');
   blocklyWrapper.wrapReadOnlyProperty('FieldIcon');
   blocklyWrapper.wrapReadOnlyProperty('FieldImage');
   blocklyWrapper.wrapReadOnlyProperty('FieldImageDropdown');
@@ -87,12 +86,33 @@ function initializeBlocklyWrapper(blocklyInstance) {
   blocklyWrapper.wrapReadOnlyProperty('Procedures');
   blocklyWrapper.wrapReadOnlyProperty('removeChangeListener');
   blocklyWrapper.wrapReadOnlyProperty('RTL');
+  blocklyWrapper.wrapReadOnlyProperty('selected');
   blocklyWrapper.wrapReadOnlyProperty('tutorialExplorer_locale');
   blocklyWrapper.wrapReadOnlyProperty('useContractEditor');
   blocklyWrapper.wrapReadOnlyProperty('useModalFunctionEditor');
   blocklyWrapper.wrapReadOnlyProperty('Variables');
   blocklyWrapper.wrapReadOnlyProperty('weblab_locale');
   blocklyWrapper.wrapReadOnlyProperty('Workspace');
+
+  blocklyWrapper.FieldDropdown = function(
+    menuGenerator,
+    opt_changeHandler,
+    opt_alwaysCallChangeHandler
+  ) {
+    let validator;
+    if (opt_changeHandler) {
+      validator = function(val) {
+        if (
+          this.getSourceBlock() &&
+          !this.getSourceBlock().isInsertionMarker_ &&
+          this.value_ !== val
+        ) {
+          opt_changeHandler(val);
+        }
+      };
+    }
+    return new blocklyWrapper.blockly_.FieldDropdown(menuGenerator, validator);
+  };
 
   // These are also wrapping read only properties, but can't use wrapReadOnlyProperty
   // because the alias name is not the same as the underlying property name.


### PR DESCRIPTION
CDO Blockly FieldDropdown constructor:
`Blockly.FieldDropdown = function(menuGenerator, opt_changeHandler, opt_alwaysCallChangeHandler) {...}`
The `opt_changeHandler` callback is called whenever a value is selected from the dropdown. 

Google Blockly FieldDropdown constructor:
`Blockly.FieldDropdown = function(menuGenerator, opt_validator, opt_config) {...}`
The `opt_validator` callback is called whenever the selected option changes (for any reason, whether or not the change was triggered by a user action).

Usage in Flappy:
```
function onSoundSelected(soundValue) {
  if (soundValue === RANDOM_VALUE) {
    return;
  }
  studioApp().playAudio(utils.stripQuotes(soundValue));
}
var soundDropdown = new blockly.FieldDropdown(this.VALUES, onSoundSelected);
```

The sound is only supposed to play when the user selects an option from the dropdown (the sound just plays once as a preview so the user knows what it will sound like at runtime). However, since the callback was now being treated as a validator function, the sound was playing many many times (basically every time the user interacted with the block, not just when they select a new value).

This is in part due to a new feature in Google Blockly called insertion markers or shadow blocks (the gray block showing where the playSound block will fall): 
![Sep-01-2020 12-30-53](https://user-images.githubusercontent.com/8787187/91897388-0f362680-ec4f-11ea-960e-42a41a37e1ee.gif)
Shadow blocks are created when you start dragging a block and deleted when you stop. They call through the same initialization path as the real block. So we were hitting the validator function every time you drag the block (since it creates a shadow block and sets the value of it), resulting in the sound being played every time you interact with the block, not just when a new value is chosen.

The solution is to add a layer in the `GoogleBlocklyWrapper` wrapping the FieldDropdown constructor. This way, we can make sure we only call the callback when something has actually changed. 

- [jira](https://codedotorg.atlassian.net/browse/STAR-1200)
