### PR TITLE
[Google Blockly] Fix colors

### DIFF
--- a/apps/src/sites/studio/pages/googleBlocklyWrapper.js
+++ b/apps/src/sites/studio/pages/googleBlocklyWrapper.js
@@ -90,6 +90,7 @@ function initializeBlocklyWrapper(blocklyInstance) {
   blocklyWrapper.wrapReadOnlyProperty('tutorialExplorer_locale');
   blocklyWrapper.wrapReadOnlyProperty('useContractEditor');
   blocklyWrapper.wrapReadOnlyProperty('useModalFunctionEditor');
+  blocklyWrapper.wrapReadOnlyProperty('utils');
   blocklyWrapper.wrapReadOnlyProperty('Variables');
   blocklyWrapper.wrapReadOnlyProperty('weblab_locale');
   blocklyWrapper.wrapReadOnlyProperty('Workspace');
@@ -155,10 +156,10 @@ function initializeBlocklyWrapper(blocklyInstance) {
     blocklyWrapper.Block.prototype.getFieldValue;
   blocklyWrapper.Block.prototype.isUserVisible = () => false; // TODO
   // Google Blockly only allows you to set the hue, not saturation or value.
-  // TODO: determine if this will work for us, or if there's a workaround to
-  // allow us to keep our colors the same
+  // However, they also allow you to specify the color in #RRGGBB format, so we can
+  // just map our HSV value to hex using their util function.
   blocklyWrapper.Block.prototype.setHSV = function(h, s, v) {
-    return this.setColour(h);
+    return this.setColour(Blockly.utils.colour.hsvToHex(h, s, v * 255));
   };
 
   // This function was a custom addition in CDO Blockly, so we need to add it here


### PR DESCRIPTION
Quick fix to how we set block colors for Google Blockly. They encourage setting only the hue for each block (with saturation and value set globally) in order to achieve a consistent color palette. However, to keep our colors consistent between versions of Blockly, we need to be able to set arbitrary colors. The solution is to set colors in hex format instead of HSV. See  related discussion at https://github.com/google/blockly/issues/23

Before:
![image](https://user-images.githubusercontent.com/8787187/91903763-a3f15200-ec58-11ea-9839-993370135c01.png)

After:
![image](https://user-images.githubusercontent.com/8787187/91903394-09910e80-ec58-11ea-95b5-7aebb7ebbfb5.png)

CDO Blockly for reference: 
![image](https://user-images.githubusercontent.com/8787187/91904048-1bbf7c80-ec59-11ea-879c-23b42118848d.png)

