### PR TITLE
Allow the progress view to update when it re-renders

### DIFF
--- a/apps/i18n/common/en_us.json
+++ b/apps/i18n/common/en_us.json
@@ -1783,6 +1783,7 @@
   "updateFirmwareExplanation": "This board is not using the most up-to-date version of the firmware. ",
   "updateFirmwareExplanationClassic": "For best results, please update the firmware by clicking on the button below.",
   "updateFirmwareExplanationExpress": "For best results, please update the firmware by clicking on the button below and following the instructions on the Adafruit website.",
+  "updating": "updating",
   "updateLibraryConfirmation": "Are you sure you want to update {libraryName}?",
   "updateUnpluggedLessonProgress": "Update unplugged lesson progress",
   "updateUnpluggedLessonProgressSubHeading": "Make sure your report accurately reflects the unplugged lessons* your class has worked on.",

--- a/apps/src/templates/sectionProgress/ProgressViewHeader.jsx
+++ b/apps/src/templates/sectionProgress/ProgressViewHeader.jsx
@@ -10,6 +10,7 @@ import firehoseClient from '../../lib/util/firehose';
 import color from '../../util/color';
 import {h3Style} from '../../lib/ui/Headings';
 import StandardsViewHeaderButtons from './standards/StandardsViewHeaderButtons';
+import FontAwesome from '@cdo/apps/templates/FontAwesome';
 
 const styles = {
   heading: {
@@ -24,6 +25,12 @@ const styles = {
   },
   scriptLink: {
     color: color.teal
+  },
+  refreshing: {
+    color: color.orange
+  },
+  refreshSpinner: {
+    marginRight: 5
   }
 };
 
@@ -32,6 +39,7 @@ class ProgressViewHeader extends Component {
     scriptId: PropTypes.number,
     //redux
     currentView: PropTypes.oneOf(Object.values(ViewType)),
+    refreshing: PropTypes.bool,
     section: sectionDataPropType.isRequired,
     scriptFriendlyName: PropTypes.string.isRequired,
     scriptData: scriptDataPropType
@@ -58,7 +66,7 @@ class ProgressViewHeader extends Component {
   };
 
   render() {
-    const {currentView, scriptFriendlyName} = this.props;
+    const {currentView, scriptFriendlyName, refreshing} = this.props;
     const linkToOverview = this.getLinkToOverview();
     const headingText = {
       [ViewType.SUMMARY]: i18n.lessonsAttempted() + ' ',
@@ -77,6 +85,17 @@ class ProgressViewHeader extends Component {
             {scriptFriendlyName}
           </a>
         </span>
+        {refreshing && (
+          <span style={styles.refreshing}>
+            <FontAwesome
+              id="uitest-spinner"
+              icon="spinner"
+              className="fa-pulse"
+              style={styles.refreshSpinner}
+            />
+            {i18n.updating()}
+          </span>
+        )}
         {currentView === ViewType.STANDARDS && (
           <StandardsViewHeaderButtons sectionId={this.props.section.id} />
         )}
@@ -90,6 +109,7 @@ export const UnconnectedProgressViewHeader = ProgressViewHeader;
 export default connect(state => ({
   section: state.sectionData.section,
   currentView: state.sectionProgress.currentView,
+  refreshing: state.sectionProgress.isRefreshingProgress,
   scriptData: getCurrentScriptData(state),
   scriptFriendlyName: getSelectedScriptFriendlyName(state)
 }))(ProgressViewHeader);

--- a/apps/src/templates/sectionProgress/sectionProgressLoader.js
+++ b/apps/src/templates/sectionProgress/sectionProgressLoader.js
@@ -3,7 +3,9 @@ import {
   startLoadingProgress,
   setCurrentView,
   finishLoadingProgress,
-  addDataByScript
+  addDataByScript,
+  startRefreshingProgress,
+  finishRefreshingProgress
 } from './sectionProgressRedux';
 import {processedLevel} from '@cdo/apps/templates/progress/progressHelpers';
 import {
@@ -26,12 +28,16 @@ export function loadScript(scriptId, sectionId) {
   // Don't load data if it's already stored in redux.
   // TODO: Save Standards data in a way that allows us
   // not to reload all data to get correct standards data
-  if (
+  if (state.isRefreshingProgress || state.isLoadingProgress) {
+    return;
+  } else if (
     state.studentLevelProgressByScript[scriptId] &&
     state.scriptDataByScript[scriptId] &&
     state.currentView !== ViewType.STANDARDS
   ) {
-    return;
+    getStore().dispatch(startRefreshingProgress());
+  } else {
+    getStore().dispatch(startLoadingProgress());
   }
 
   let sectionProgress = {
@@ -43,7 +49,6 @@ export function loadScript(scriptId, sectionId) {
   };
 
   // Get the script data
-  getStore().dispatch(startLoadingProgress());
   const scriptRequest = fetch(`/dashboardapi/script_structure/${scriptId}`, {
     credentials: 'include'
   })
@@ -127,6 +132,7 @@ export function loadScript(scriptId, sectionId) {
     );
     getStore().dispatch(addDataByScript(sectionProgress));
     getStore().dispatch(finishLoadingProgress());
+    getStore().dispatch(finishRefreshingProgress());
   });
 }
 

--- a/apps/src/templates/sectionProgress/sectionProgressRedux.js
+++ b/apps/src/templates/sectionProgress/sectionProgressRedux.js
@@ -14,11 +14,19 @@ const SET_CURRENT_VIEW = 'sectionProgress/SET_CURRENT_VIEW';
 const SET_LESSON_OF_INTEREST = 'sectionProgress/SET_LESSON_OF_INTEREST';
 const START_LOADING_PROGRESS = 'sectionProgress/START_LOADING_PROGRESS';
 const FINISH_LOADING_PROGRESS = 'sectionProgress/FINISH_LOADING_PROGRESS';
+const START_REFRESHING_PROGRESS = 'sectionProgress/START_REFRESHING_PROGRESS';
+const FINISH_REFRESHING_PROGRESS = 'sectionProgress/FINISH_REFRESHING_PROGRESS';
 const ADD_DATA_BY_SCRIPT = 'sectionProgress/ADD_DATA_BY_SCRIPT';
 
 // Action creators
 export const startLoadingProgress = () => ({type: START_LOADING_PROGRESS});
 export const finishLoadingProgress = () => ({type: FINISH_LOADING_PROGRESS});
+export const startRefreshingProgress = () => ({
+  type: START_REFRESHING_PROGRESS
+});
+export const finishRefreshingProgress = () => ({
+  type: FINISH_REFRESHING_PROGRESS
+});
 export const setLessonOfInterest = lessonOfInterest => ({
   type: SET_LESSON_OF_INTEREST,
   lessonOfInterest
@@ -41,7 +49,8 @@ const initialState = {
   studentLevelTimeSpentByScript: {},
   levelsByLessonByScript: {},
   lessonOfInterest: INITIAL_LESSON_OF_INTEREST,
-  isLoadingProgress: true
+  isLoadingProgress: false,
+  isRefreshingProgress: false
 };
 
 export default function sectionProgress(state = initialState, action) {
@@ -67,6 +76,18 @@ export default function sectionProgress(state = initialState, action) {
     return {
       ...state,
       isLoadingProgress: false
+    };
+  }
+  if (action.type === START_REFRESHING_PROGRESS) {
+    return {
+      ...state,
+      isRefreshingProgress: true
+    };
+  }
+  if (action.type === FINISH_REFRESHING_PROGRESS) {
+    return {
+      ...state,
+      isRefreshingProgress: false
     };
   }
   if (action.type === SET_LESSON_OF_INTEREST) {

--- a/apps/test/unit/templates/sectionProgress/ProgressViewHeaderTest.jsx
+++ b/apps/test/unit/templates/sectionProgress/ProgressViewHeaderTest.jsx
@@ -36,10 +36,17 @@ describe('ProgressViewHeader', () => {
       wrapper.find('Connect(StandardsViewHeaderButtons)')
     ).to.have.lengthOf(1);
   });
+
   it('does not show buttons when in standards view', () => {
     const wrapper = shallow(<ProgressViewHeader {...DEFAULT_PROPS} />);
     expect(
       wrapper.find('Connect(StandardsViewHeaderButtons)')
     ).to.have.lengthOf(0);
+  });
+
+  it('displays a spinner when refreshing', () => {
+    let headerProps = {...DEFAULT_PROPS, ...{refreshing: true}};
+    const wrapper = shallow(<ProgressViewHeader {...headerProps} />);
+    expect(wrapper.find('FontAwesome')).to.have.lengthOf(1);
   });
 });

--- a/apps/test/unit/templates/sectionProgress/sectionProgressReduxTest.js
+++ b/apps/test/unit/templates/sectionProgress/sectionProgressReduxTest.js
@@ -6,7 +6,9 @@ import sectionProgress, {
   startLoadingProgress,
   finishLoadingProgress,
   getCurrentProgress,
-  getCurrentScriptData
+  getCurrentScriptData,
+  startRefreshingProgress,
+  finishRefreshingProgress
 } from '@cdo/apps/templates/sectionProgress/sectionProgressRedux';
 import {ViewType} from '@cdo/apps/templates/sectionProgress/sectionProgressConstants';
 import {setScriptId} from '@cdo/apps/redux/scriptSelectionRedux';
@@ -100,6 +102,24 @@ describe('sectionProgressRedux', () => {
         finishLoadingProgress()
       );
       assert.deepEqual(nextState.isLoadingProgress, false);
+    });
+  });
+
+  describe('isRefreshingProgress', () => {
+    it('startRefreshingProgress sets isRefreshingProgress to true', () => {
+      const nextState = sectionProgress(
+        initialState,
+        startRefreshingProgress()
+      );
+      assert.deepEqual(nextState.isRefreshingProgress, true);
+    });
+
+    it('finishRefreshingProgress sets isRefreshingProgress to false', () => {
+      const nextState = sectionProgress(
+        {isLoadingProgress: true},
+        finishRefreshingProgress()
+      );
+      assert.deepEqual(nextState.isRefreshingProgress, false);
     });
   });
 


### PR DESCRIPTION
In the past, teachers would see no updates to the progress view unless they manually refreshed the page or completely navigated away from the teacher dashboard. This caused significant confusion because teachers might have updated their class in one tab and expected to see the update happen in the other.

We fix this by adding a third state.
Initially loading (existing)
Up-to-date (existing
Updating (new)

Updating will be triggered every time the teacher returns to the progress tab.

![refreshingProgress](https://user-images.githubusercontent.com/8324574/91916531-3baf6a00-ec72-11ea-9c2f-7108d8d25f51.gif)


<!--
  Other aspects to consider. uncomment and add detail for any that seem necessary:
-->

<!-- ### Background -->
<!-- ### Privacy -->
<!-- ### Security -->
<!-- ### Caching -->
<!-- ### Deployment strategy -->
<!-- ### Future work -->

## Links

<!--
  Any relevant links to external resources; ie, specification documents, jira
  items, related PRs, honeybadger errors, etc
-->

- [jira](https://codedotorg.atlassian.net/browse/LP-1459)

## Testing story

<!--
  Does your change include appropriate tests?

  If so, please describe how the tests included in this PR are sufficient

  If not, please explain why this change does not need to be tested.
-->

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
