### PR TITLE
Rollback level group issue

### DIFF
--- a/dashboard/app/models/lesson_group.rb
+++ b/dashboard/app/models/lesson_group.rb
@@ -132,8 +132,8 @@ class LessonGroup < ApplicationRecord
     I18n.t("data.script.name.#{script.name}.lesson_groups.#{key}.big_questions", default: nil)
   end
 
-  def summarize(include_lessons = true, user = nil, include_bonus_levels = false)
-    summary = {
+  def summarize
+    {
       id: id,
       key: key,
       display_name: localized_display_name,
@@ -142,17 +142,10 @@ class LessonGroup < ApplicationRecord
       user_facing: user_facing,
       position: position
     }
-
-    # Filter out lessons that have a visible_after date in the future
-    filtered_lessons = lessons.select {|lesson| lesson.published?(user)}
-    summary[:lessons] = filtered_lessons.map {|lesson| lesson.summarize(include_bonus_levels)} if include_lessons
-
-    summary
   end
 
   def summarize_for_edit
-    include_lessons = false
-    summary = summarize(include_lessons)
+    summary = summarize
     summary[:lessons] = lessons.map(&:summarize_for_edit)
     summary
   end

--- a/dashboard/app/models/levels/level_group.rb
+++ b/dashboard/app/models/levels/level_group.rb
@@ -74,11 +74,11 @@ class LevelGroup < DSLDefined
     attr_reader :levels_offset
 
     def levels
-      levels_and_texts&.reject {|l| l.is_a?(External)}
+      levels_and_texts.reject {|l| l.is_a?(External)}
     end
 
     def texts
-      levels_and_texts&.select {|l| l.is_a?(External)}
+      levels_and_texts.select {|l| l.is_a?(External)}
     end
   end
 
@@ -110,7 +110,7 @@ class LevelGroup < DSLDefined
       levels_and_texts = all_levels_and_texts[levels_and_texts_offset..(levels_and_texts_offset + page_size - 1)]
       page_object = LevelGroupPage.new(page_number, levels_and_texts_offset, levels_and_texts, levels_offset)
       levels_and_texts_offset += page_size
-      levels_offset += page_object.levels.length if page_object.levels
+      levels_offset += page_object.levels.length
       page_object
     end
   end

--- a/dashboard/app/models/script.rb
+++ b/dashboard/app/models/script.rb
@@ -1246,7 +1246,7 @@ class Script < ActiveRecord::Base
     }
 
     #TODO: lessons should be summarized through lesson groups in the future
-    summary[:lessonGroups] = lesson_groups.map {|lesson_group| lesson_group.summarize(include_lessons, user, include_bonus_levels)}
+    summary[:lessonGroups] = lesson_groups.map(&:summarize)
 
     # Filter out stages that have a visible_after date in the future
     filtered_lessons = lessons.select {|lesson| lesson.published?(user)}

--- a/dashboard/config/locales/scripts.en.yml
+++ b/dashboard/config/locales/scripts.en.yml
@@ -16050,6 +16050,7 @@ en:
           lesson_groups:
             csd3_1:
               display_name: 'Chapter 1: Images and Animations'
+              description: This is a description
             csd3_2:
               display_name: 'Chapter 2: Building Games'
             cspSurvey:

--- a/dashboard/config/locales/scripts.en.yml
+++ b/dashboard/config/locales/scripts.en.yml
@@ -16050,7 +16050,6 @@ en:
           lesson_groups:
             csd3_1:
               display_name: 'Chapter 1: Images and Animations'
-              description: This is a description
             csd3_2:
               display_name: 'Chapter 2: Building Games'
             cspSurvey:

--- a/dashboard/config/scripts/csd3-2020.script
+++ b/dashboard/config/scripts/csd3-2020.script
@@ -2,6 +2,7 @@ hidden false
 login_required true
 hideable_lessons true
 student_detail_progress_view true
+teacher_resources [["lessonPlans", "https://curriculum.code.org/csd-20/unit3/"], ["teacherForum", "https://forum.code.org/c/csd3"], ["vocabulary", "https://curriculum.code.org/csd-20/unit3/vocab/"], ["standardMappings", "https://curriculum.code.org/csd-20/unit3/standards/"], ["codeIntroduced", "https://curriculum.code.org/csd-20/unit3/code/"]]
 has_verified_resources true
 has_lesson_plan true
 curriculum_path 'https://curriculum.code.org/csd-20/unit3/{LESSON}'
@@ -11,7 +12,6 @@ curriculum_umbrella 'CSD'
 tts true
 
 lesson_group 'csd3_1', display_name: 'Chapter 1: Images and Animations'
-lesson_group_description 'This is a description'
 lesson 'Programming for Entertainment', display_name: 'Programming for Entertainment'
 level 'CSD U3L01 TFMD_2020', progression: 'Lesson Overview'
 level 'CSD U3 Entertainment_2018_2019_pilot_2020', progression: 'Exploring CS in Entertainment'

--- a/dashboard/config/scripts/csd3-2020.script
+++ b/dashboard/config/scripts/csd3-2020.script
@@ -2,7 +2,6 @@ hidden false
 login_required true
 hideable_lessons true
 student_detail_progress_view true
-teacher_resources [["lessonPlans", "https://curriculum.code.org/csd-20/unit3/"], ["teacherForum", "https://forum.code.org/c/csd3"], ["vocabulary", "https://curriculum.code.org/csd-20/unit3/vocab/"], ["standardMappings", "https://curriculum.code.org/csd-20/unit3/standards/"], ["codeIntroduced", "https://curriculum.code.org/csd-20/unit3/code/"]]
 has_verified_resources true
 has_lesson_plan true
 curriculum_path 'https://curriculum.code.org/csd-20/unit3/{LESSON}'
@@ -12,6 +11,7 @@ curriculum_umbrella 'CSD'
 tts true
 
 lesson_group 'csd3_1', display_name: 'Chapter 1: Images and Animations'
+lesson_group_description 'This is a description'
 lesson 'Programming for Entertainment', display_name: 'Programming for Entertainment'
 level 'CSD U3L01 TFMD_2020', progression: 'Lesson Overview'
 level 'CSD U3 Entertainment_2018_2019_pilot_2020', progression: 'Exploring CS in Entertainment'

--- a/dashboard/test/models/lesson_group_test.rb
+++ b/dashboard/test/models/lesson_group_test.rb
@@ -18,22 +18,9 @@ class LessonGroupTest < ActiveSupport::TestCase
   test 'should summarize lesson group' do
     script = create :script
     lesson_group = create :lesson_group, key: 'my-lesson-group', user_facing: true, position: 1, script: script
-    lesson = create :lesson, name: "Lesson1", script: script, lesson_group: lesson_group, absolute_position: 1
-    create(:script_level, script: script, lesson: lesson)
 
     summary = lesson_group.summarize
-
-    assert_equal 1, summary[:lessons].count
     assert_equal 'my-lesson-group', summary[:key]
-  end
-
-  test 'summarize should exclude lessons if include_lessons is false' do
-    script = create :script
-    lesson_group = create :lesson_group, key: 'my-lesson-group', user_facing: true, position: 1, script: script
-    lesson = create :lesson, name: "Lesson1", script: script, lesson_group: lesson_group, absolute_position: 1
-    create(:script_level, script: script, lesson: lesson)
-
-    assert_nil lesson_group.summarize(false)[:lessons]
   end
 
   test 'should summarize lesson groups for edit' do
@@ -47,6 +34,5 @@ class LessonGroupTest < ActiveSupport::TestCase
     assert_equal 'my-lesson-group', summary[:key]
     assert_equal 1, summary[:position]
     assert_equal true, summary[:user_facing]
-    assert_equal [lesson.summarize_for_edit], summary[:lessons]
   end
 end


### PR DESCRIPTION
`db_query_test.rb` was failing for `test_script_level_show` in https://github.com/code-dot-org/code-dot-org/pull/36298.  This was because of nil values for parts of the `level_group` model. 

Example:

```
> undefined method `length' for nil:NilClass
app/models/levels/level_group.rb, line 113
------------------------------------------
``` ruby
  108       @pages = properties['levels_and_texts_per_page'].map.with_index do |page_size, page_index|
  109         page_number = page_index + 1
  110         levels_and_texts = all_levels_and_texts[levels_and_texts_offset..(levels_and_texts_offset + page_size - 1)]
  111         page_object = LevelGroupPage.new(page_number, levels_and_texts_offset, levels_and_texts, levels_offset)
  112         levels_and_texts_offset += page_size
> 113         levels_offset += page_object.levels.length if page_object
  114         page_object
  115       end
  116     end
  117   
  118     def self.setup(data)
App backtrace
-------------
 - app/models/levels/level_group.rb:113:in `block in pages'
 - app/models/levels/level_group.rb:108:in `pages'
 - app/models/script_level.rb:403:in `summarize_extra_puzzle_pages'
 - app/models/lesson.rb:230:in `block in summarize'
 - app/models/lesson.rb:201:in `summarize'
 - app/models/lesson_group.rb:148:in `block in summarize'
 - app/models/lesson_group.rb:148:in `summarize'
 - app/views/layouts/_header.html.haml:116:in `_app_views_layouts__header_html_haml__3530793015255366934_70249878386600'
 - app/views/layouts/application.html.haml:61:in `_app_views_layouts_application_html_haml__4534971806343044391_70250065267380'
 - app/controllers/script_levels_controller.rb:498:in `present_level'
 - app/controllers/script_levels_controller.rb:154:in `show'
 - app/controllers/application_controller.rb:167:in `block in with_locale'
 - app/controllers/application_controller.rb:166:in `with_locale'
 - app/helpers/read_replica_helper.rb:20:in `set_read_only_connection_for_block'
 - test/integration/db_query_test.rb:24:in `block (2 levels) in <class:DBQueryTest>'
 - test/testing/capture_queries.rb:65:in `block in capture_queries'
 - test/testing/capture_queries.rb:64:in `capture_queries'
 - test/testing/capture_queries.rb:28:in `assert_queries'
 - test/testing/capture_queries.rb:34:in `block in assert_cached_queries'
 - test/testing/capture_queries.rb:33:in `assert_cached_queries'
 - test/integration/db_query_test.rb:23:in `block in <class:DBQueryTest>'
 - test/testing/setup_all_and_teardown_all.rb:22:in `run'
```

I made some changes to deal with the nil values in this commit https://github.com/code-dot-org/code-dot-org/pull/36298/commits/d67fbc21b47778633ac9a148d681c1fe7b826b6e but then when Dave pointed out some concerned I realized I was not actually using the code path causing the issue  (where lesson_groups summarize method was calling lessons summarize method) and instead could remove it and the changes.  This PR does that.