### PR TITLE
Update HoC promote/resources page with Hora del Código logo

### DIFF
--- a/pegasus/sites.v3/hourofcode.com/public/promote/resources.md.partial
+++ b/pegasus/sites.v3/hourofcode.com/public/promote/resources.md.partial
@@ -50,8 +50,14 @@ A new poster set is available featuring Malala, Stephen Curry, Shakira and more!
 **"Hour of Code" and "Hora del Código" are trademarked. We don't want to prevent their usage, but we do want to make sure usage fits within a few limits:**
 
 1. Any reference to "Hour of Code" or "Hora del Código" should be used in a fashion that doesn't suggest that it's your own brand name, but rather referencing the Hour of Code as a grassroots movement.
-    * **Good example**: "Participate in the Hour of Code™ at YOUR-COMPANY.com." 
-    * **Bad example**: "Try Hour of Code by YOUR-COMPANY."
+  <ul style="margin-top: 0px">
+    <li>
+      <strong>Good example</strong>: "Participate in the Hour of Code™ at YOUR-COMPANY.com." 
+    </li>
+    <li>
+      <strong>Bad example</strong>: "Try Hour of Code by YOUR-COMPANY."
+    </li>
+  </ul>
 2. Use a "TM" superscript in the most prominent places you mention "Hour of Code" and a "Ⓡ" superscript in the most prominent places you mention "Hora del Código", both on your web site and in app descriptions.
 3. Include language on your page (or in the footer), including links to the CSEdWeek and [Code.org]({{ codeorg_link }}) websites, that says the following:
 

--- a/pegasus/sites.v3/hourofcode.com/public/promote/resources.md.partial
+++ b/pegasus/sites.v3/hourofcode.com/public/promote/resources.md.partial
@@ -43,17 +43,20 @@ A new poster set is available featuring Malala, Stephen Curry, Shakira and more!
 <a id="logo"></a>
 ## Use the Hour of Code logo to spread the word
 [![image]({{ hoc_logo_fit_200 }})]({{ hoc_logo }})
+[![image]({{ hdc_logo_fit_200 }})]({{ hdc_logo }})
 
 [Download hi-res versions](http://images.code.org/share/hour-of-code-logo.zip)
 
-**"Hour of Code" is trademarked. We don't want to prevent its usage, but we want to make sure it fits within a few limits:**
+**"Hour of Code" and "Hora del Código" are trademarked. We don't want to prevent their usage, but we do want to make sure usage fits within a few limits:**
 
-1. Any reference to "Hour of Code" should be used in a fashion that doesn't suggest that it's your own brand name, but rather referencing the Hour of Code as a grassroots movement. **Good example**: "Participate in the Hour of Code™ at ACMECorp.com." **Bad example**: "Try Hour of Code by ACME Corp."
-2. Use a "TM" superscript in the most prominent places you mention "Hour of Code," both on your web site and in app descriptions.
+1. Any reference to "Hour of Code" or "Hora del Código" should be used in a fashion that doesn't suggest that it's your own brand name, but rather referencing the Hour of Code as a grassroots movement.
+    * **Good example**: "Participate in the Hour of Code™ at YOUR-COMPANY.com." 
+    * **Bad example**: "Try Hour of Code by YOUR-COMPANY."
+2. Use a "TM" superscript in the most prominent places you mention "Hour of Code" and a "Ⓡ" superscript in the most prominent places you mention "Hora del Código", both on your web site and in app descriptions.
 3. Include language on your page (or in the footer), including links to the CSEdWeek and [Code.org]({{ codeorg_link }}) websites, that says the following:
 
-	*“The 'Hour of Code™' is a nationwide initiative by Computer Science Education Week [csedweek.org] and Code.org [code.org] to introduce millions of students to one hour of computer science and computer programming.”*
-4. No use of "Hour of Code" in app names.
+	*“The 'Hour of Code™'/'Hora del Código®' is a global initiative by Computer Science Education Week [csedweek.org] and Code.org [code.org] to introduce millions of students to one hour of computer science and computer programming.”*
+4. No use of "Hour of Code" or "Hora del Código" in app names.
 
 <a id="stickers"></a>
 ## Print these stickers to give to your students

--- a/pegasus/sites.v3/hourofcode.com/public/promote/resources.md.partial
+++ b/pegasus/sites.v3/hourofcode.com/public/promote/resources.md.partial
@@ -52,7 +52,7 @@ A new poster set is available featuring Malala, Stephen Curry, Shakira and more!
 1. Any reference to "Hour of Code" or "Hora del Código" should be used in a fashion that doesn't suggest that it's your own brand name, but rather referencing the Hour of Code as a grassroots movement.
   <ul style="margin-top: 0px">
     <li>
-      <strong>Good example</strong>: "Participate in the Hour of Code™ at YOUR-COMPANY.com." 
+      <strong>Good example</strong>: "Participate in the Hour of Code™ at YOUR-COMPANY.com."
     </li>
     <li>
       <strong>Bad example</strong>: "Try Hour of Code by YOUR-COMPANY."

--- a/pegasus/sites.v3/hourofcode.com/views/hdc_logo.erb
+++ b/pegasus/sites.v3/hourofcode.com/views/hdc_logo.erb
@@ -1,0 +1,1 @@
+<%= localized_image('/images/hora-del-codigo-logo.png') %>

--- a/pegasus/sites.v3/hourofcode.com/views/hdc_logo_fit_200.erb
+++ b/pegasus/sites.v3/hourofcode.com/views/hdc_logo_fit_200.erb
@@ -1,0 +1,1 @@
+<%= localized_image('/images/fit-200/hora-del-codigo-logo.png') %>


### PR DESCRIPTION
...and update usage guidelines with references to said logo.

We recently trademarked Hora del Código in Mexico. We already offered the logo as a download previously; this change makes that availability more visible. Language changes were cleared with Cameron.

I took the opportunity to also update the language in the usage guidelines to be less US-centric.

## Links

<!--
  Any relevant links to external resources; ie, specification documents, jira
  items, related PRs, honeybadger errors, etc
-->

- Jira: [FND-1272]

## Testing story

Tested on localhost

**Before**
![image](https://user-images.githubusercontent.com/2933346/91928072-f0a44f80-ec8f-11ea-8f89-63b893c5604a.png)

**After**
![image](https://user-images.githubusercontent.com/2933346/91928056-e7b37e00-ec8f-11ea-9ba9-109d07d866b3.png)

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked


[FND-1272]: https://codedotorg.atlassian.net/browse/FND-1272