### PR TITLE
AYW In Person Survey Clean Up

### DIFF
--- a/dashboard/config/foorm/library/surveys/pd/ayw_inperson_1.0.json
+++ b/dashboard/config/foorm/library/surveys/pd/ayw_inperson_1.0.json
@@ -166,7 +166,10 @@
          "value": "collaboration_unit4",
          "text": "Collaboration and Independent Work in Unit 4"
         },
-        "Wrap Up"
+        {
+         "value": "wrap_up",
+         "text": "Wrap Up"
+        }
        ]
       },
       {

--- a/dashboard/config/foorm/library/surveys/pd/ayw_inperson_2.0.json
+++ b/dashboard/config/foorm/library/surveys/pd/ayw_inperson_2.0.json
@@ -10,7 +10,7 @@
       {
        "type": "html",
        "name": "question1",
-       "html": "<h2>How useful was this acdemic year workshop? XX?</h2>\n<p>We're interested in your feedback about how useful the activities were for you."
+       "html": "<h2>How useful was this academic year workshop? XX?</h2>\n<p>We're interested in your feedback about how useful the activities were for you."
       }
      ]
     }


### PR DESCRIPTION
One of the rows in the Academic Year Workshop In Person post-survey was missing a key (noticed by [this honeybadger error](https://app.honeybadger.io/projects/3240/faults/67292795)). This survey hasn't been used yet since there have not been any in person workshops so it is safe to add a key. I also fixed a typo in another yet-unused survey.

<!-- ### Background -->
<!-- ### Privacy -->
<!-- ### Security -->
<!-- ### Caching -->
<!-- ### Deployment strategy -->
<!-- ### Future work -->


## Testing story
Tested locally that the matrix will now use the key "wrap_up" instead of the value "Wrap Up" to store the answer to that question.

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
