### PR TITLE
[PLAT-231] validate that lesson name is copied when script is cloned

### DIFF
--- a/dashboard/test/fixtures/test-fixture.script
+++ b/dashboard/test/fixtures/test-fixture.script
@@ -1,10 +1,10 @@
 script_announcements [{"notice"=>"foo", "details"=>"bar", "link"=>"", "type"=>"information"}]
 
-lesson 'lesson1', display_name: 'lesson1'
+lesson 'lesson1', display_name: 'Lesson One'
 level 'Level 1'
 level 'Level 2'
 level 'Level 3'
 
-lesson 'lesson2', display_name: 'lesson2'
+lesson 'lesson2', display_name: 'Lesson Two'
 level 'Level 4', progression: 'MyProgression'
 level 'Level 5', progression: 'MyProgression'

--- a/dashboard/test/models/script_test.rb
+++ b/dashboard/test/models/script_test.rb
@@ -67,7 +67,7 @@ class ScriptTest < ActiveSupport::TestCase
     scripts, _ = Script.setup([@script_file])
     script = scripts[0]
     assert_equal 'Level 1', script.levels[0].name
-    assert_equal 'lesson2', script.script_levels[3].lesson.name
+    assert_equal 'Lesson Two', script.script_levels[3].lesson.name
 
     assert_equal 'MyProgression', script.script_levels[3].progression
     assert_equal 'MyProgression', script.script_levels[4].progression

--- a/dashboard/test/models/script_test.rb
+++ b/dashboard/test/models/script_test.rb
@@ -1533,12 +1533,18 @@ class ScriptTest < ActiveSupport::TestCase
     # Validate lessons. We've already done some validation of level contents, so
     # this time just validate their names.
     assert_equal 2, script_copy.lessons.count
+
     lesson1 = script_copy.lessons.first
-    lesson2 = script_copy.lessons.last
+    assert_equal 'lesson1', lesson1.key
+    assert_equal 'Lesson One', lesson1.name
     assert_equal(
       'Level 1_copy,Level 2_copy,Level 3_copy',
       lesson1.script_levels.map(&:levels).flatten.map(&:name).join(',')
     )
+
+    lesson2 = script_copy.lessons.last
+    assert_equal 'lesson2', lesson2.key
+    assert_equal 'Lesson Two', lesson2.name
     assert_equal(
       'Level 4_copy,Level 5_copy',
       lesson2.script_levels.map(&:levels).flatten.map(&:name).join(',')


### PR DESCRIPTION
Finishes [PLAT-231]

The work for this was done by @dmcavoy as part of https://github.com/code-dot-org/code-dot-org/pull/36020 . All this PR does is add a unit test confirming that the correct benavior.

## Testing story

updated unit test

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked


[PLAT-231]: https://codedotorg.atlassian.net/browse/PLAT-231