### PR TITLE
Hints: add hint prompt attempts threshold override field for levelbuilders

### DIFF
--- a/dashboard/app/helpers/levels_helper.rb
+++ b/dashboard/app/helpers/levels_helper.rb
@@ -349,6 +349,9 @@ module LevelsHelper
   end
 
   def set_hint_prompt_options(level_options)
+    # Default was selected based on analysis of calculated thresholds for
+    # levels in Courses 2, 3, 4 and the 2017 versions of Courses A-F. See PR
+    # #36507 for more details.
     default_hint_prompt_attempts_threshold = 6.5
     if @script&.hint_prompt_enabled?
       level_options[:hintPromptAttemptsThreshold] = @level.hint_prompt_attempts_threshold || default_hint_prompt_attempts_threshold

--- a/dashboard/app/models/levels/level.rb
+++ b/dashboard/app/models/levels/level.rb
@@ -734,7 +734,7 @@ class Level < ActiveRecord::Base
   # hint_prompt_enabled for the sake of the level editing experience if any of
   # the scripts associated with the level are hint_prompt_enabled.
   def hint_prompt_enabled?
-    !script_levels.map(&:script).select(&:hint_prompt_enabled?).empty?
+    script_levels.map(&:script).select(&:hint_prompt_enabled?).any?
   end
 
   private

--- a/dashboard/app/models/levels/level.rb
+++ b/dashboard/app/models/levels/level.rb
@@ -731,7 +731,8 @@ class Level < ActiveRecord::Base
   end
 
   # There's a bit of trickery here. We consider a level to be
-  # hint_prompt_enabled for the sake of the level editing experience if any of # the scripts associated with the level are hint_prompt_enabled.
+  # hint_prompt_enabled for the sake of the level editing experience if any of
+  # the scripts associated with the level are hint_prompt_enabled.
   def hint_prompt_enabled?
     !script_levels.map(&:script).select(&:hint_prompt_enabled?).empty?
   end

--- a/dashboard/app/models/levels/level.rb
+++ b/dashboard/app/models/levels/level.rb
@@ -730,6 +730,12 @@ class Level < ActiveRecord::Base
     (contained_levels + [project_template_level] - [self]).compact
   end
 
+  # There's a bit of trickery here. We consider a level to be
+  # hint_prompt_enabled for the sake of the level editing experience if any of # the scripts associated with the level are hint_prompt_enabled.
+  def hint_prompt_enabled?
+    !script_levels.map(&:script).select(&:hint_prompt_enabled?).empty?
+  end
+
   private
 
   # Returns the level name, removing the name_suffix first (if present).

--- a/dashboard/app/views/levels/editors/fields/_authored_hints.haml
+++ b/dashboard/app/views/levels/editors/fields/_authored_hints.haml
@@ -41,6 +41,11 @@
     %div{style: '-webkit-user-select: text'}
     = f.text_area :authored_hints, rows: 4
 
+  .field
+    = f.label :hint_prompt_attempts_threshold, "How many times does a student need to attempt this level before being shown the hint prompt dialog? If you leave this field blank, the default is 7 attempts."
+    %div{style: '-webkit-user-select: text'}
+    = f.text_area :hint_prompt_attempts_threshold, rows: 1
+
 - content_for :body_scripts do
   :javascript
     $(document).ready(function () {

--- a/dashboard/app/views/levels/editors/fields/_authored_hints.haml
+++ b/dashboard/app/views/levels/editors/fields/_authored_hints.haml
@@ -41,10 +41,11 @@
     %div{style: '-webkit-user-select: text'}
     = f.text_area :authored_hints, rows: 4
 
-  .field
-    = f.label :hint_prompt_attempts_threshold, "How many times does a student need to attempt this level before being shown the hint prompt dialog? If you leave this field blank, the default is 7 attempts."
-    %div{style: '-webkit-user-select: text'}
-    = f.select :hint_prompt_attempts_threshold, options_for_select([*1..30], @level.properties["hint_prompt_attempts_threshold"])
+  - if @level.hint_prompt_enabled?
+    .field
+      = f.label :hint_prompt_attempts_threshold, "How many times does a student need to attempt this level before being shown the hint prompt dialog? If you leave this field blank, the default is 7 attempts."
+      %div{style: '-webkit-user-select: text'}
+      = f.select :hint_prompt_attempts_threshold, options_for_select([*1..30], @level.properties["hint_prompt_attempts_threshold"])
 
 - content_for :body_scripts do
   :javascript

--- a/dashboard/app/views/levels/editors/fields/_authored_hints.haml
+++ b/dashboard/app/views/levels/editors/fields/_authored_hints.haml
@@ -44,7 +44,7 @@
   .field
     = f.label :hint_prompt_attempts_threshold, "How many times does a student need to attempt this level before being shown the hint prompt dialog? If you leave this field blank, the default is 7 attempts."
     %div{style: '-webkit-user-select: text'}
-    = f.text_area :hint_prompt_attempts_threshold, rows: 1
+    = f.select :hint_prompt_attempts_threshold, options_for_select([*1..30], @level.properties["hint_prompt_attempts_threshold"])
 
 - content_for :body_scripts do
   :javascript

--- a/dashboard/test/models/level_test.rb
+++ b/dashboard/test/models/level_test.rb
@@ -1064,4 +1064,31 @@ class LevelTest < ActiveSupport::TestCase
 
     assert_equal [], level.all_descendant_levels, 'omit self from descendant levels'
   end
+
+  test 'hint_prompt_enabled is true for levels in a script where hint_prompt_enabled is true' do
+    script = create :csf_script
+    assert script.hint_prompt_enabled?
+    level = create :level
+    script_level = create :script_level, levels: [level], script: script
+    assert level.hint_prompt_enabled?
+  end
+
+  test 'hint_prompt_enabled is true for levels in many scripts if at least one script is hint_prompt_enabled' do
+    hint_script = create :csf_script
+    assert hint_script.hint_prompt_enabled?
+    no_hint_script = create :csp_script
+    refute no_hint_script.hint_prompt_enabled?
+    level = create :level
+    script_level = create :script_level, levels: [level], script: hint_script
+    script_level = create :script_level, levels: [level], script: no_hint_script
+    assert level.hint_prompt_enabled?
+  end
+
+  test 'hint_prompt_enabled is false for levels in scripts where hint_prompt_enabled is false' do
+    no_hint_script = create :csp_script
+    refute no_hint_script.hint_prompt_enabled?
+    level = create :level
+    script_level = create :script_level, levels: [level], script: no_hint_script
+    refute level.hint_prompt_enabled?
+  end
 end


### PR DESCRIPTION
[STAR-1205](https://codedotorg.atlassian.net/browse/STAR-1205)
Follow up to #36488 and #36507 

We suspect that the default `hint_prompt_attempts_threshold` will be good enough (at least for the interim) for most levels, but we might find the 7 attempts threshold for some levels to be wildly too high or too low.  In those cases, levelbuilders can re-set the `hint_prompt_attempts_threshold` to a more appropriate number. 

<img width="1014" alt="Screen Shot 2020-09-03 at 2 39 41 PM" src="https://user-images.githubusercontent.com/12300669/92154215-7096fa80-edf3-11ea-96b4-8b67a7599f9c.png">

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
