### PR TITLE
Simplify Adhoc#start_inactive_instance logic

### DIFF
--- a/aws/cloudformation/bootstrap_chef_stack.sh.erb
+++ b/aws/cloudformation/bootstrap_chef_stack.sh.erb
@@ -20,6 +20,9 @@ export AWS_METADATA_SERVICE_TIMEOUT=30
 export AWS_METADATA_SERVICE_NUM_ATTEMPTS=30
 
 <% if environment == :adhoc -%>
+<%   if options[:start_inactive_instance] -%>
+# <%= Time.now %> - trigger an EC2-instance restart by changing user-data contents.
+<%   end -%>
 # Redirect copy of stdout/stderr to a log file for later auditing.
 LOG=<%=TailLogs::LOG_NAME%>
 exec >> >(tee -i $LOG)

--- a/lib/cdo/cloud_formation/adhoc.rb
+++ b/lib/cdo/cloud_formation/adhoc.rb
@@ -1,99 +1,50 @@
 require 'aws-sdk-ec2'
-require 'aws-sdk-route53'
 
 module Cdo::CloudFormation
   # Helper functions related to adhoc instances of CdoApp,
   # included AWS::CloudFormation in adhoc environment.
   module Adhoc
     def start_inactive_instance
-      cloudformation_resource = Aws::CloudFormation::Resource.new
-      stack = cloudformation_resource.stack(stack_name)
-      instance = Aws::EC2::Instance.new(id: stack.resource('WebServer').physical_resource_id)
-      if instance.state.code != 80
+      if instance.state.name != 'stopped'
         log.info "Instance #{instance.id} in Stack #{stack_name} can't be started because it is not" \
-            " currently stopped.  Current state - #{instance.state.code}:#{instance.state.name}"
+            " currently stopped.  Current state - #{instance.state.name}"
       else
         log.info "Starting Instance #{instance.id} ..."
-        instance.start
-        instance.wait_until_running
-        log.info "Instance #{instance.id} is started."
-
-        public_ip_address = instance.reload.public_ip_address
-        dashboard_url = stack.outputs.detect {|output| output.output_key == 'DashboardURL'}.output_value
-        pegasus_url = stack.outputs.detect {|output| output.output_key == 'PegasusURL'}.output_value
-
-        # suffix period to construct fully qualified domain name
-        pegasus_domain_name = URI.parse(pegasus_url).host + '.'
-        dashboard_domain_name = URI.parse(dashboard_url).host + '.'
-
-        route53_client = Aws::Route53::Client.new
-
-        # this lookup may stop working if/when there are more than 100 zones
-        # prefix zone name with a period to prevent partial match (don't let zone "code.org." match "foo.cdn-code.org.")
-        hosted_zone_id = route53_client.
-          list_hosted_zones.
-          hosted_zones.
-          select {|zone| pegasus_domain_name.end_with?('.' + zone.name)}.
-          first.
-          id
-
-        change_resource_response = route53_client.change_resource_record_sets(
-          hosted_zone_id: hosted_zone_id,
-          change_batch: {
-            changes: [pegasus_domain_name, dashboard_domain_name].map do |domain_name|
-              {
-                action: "UPSERT",
-                resource_record_set: {
-                  name: domain_name,
-                  resource_records: [{value: public_ip_address}],
-                  ttl: CdoApp::DNS_TTL,
-                  type: "A"
-                }
-              }
-            end,
-            comment: "Web server for adhoc environment #{pegasus_domain_name}",
-          }
-        )
-        change_status = change_resource_response.change_info.status
-        change_id = change_resource_response.change_info.id
-        log.info "DNS update status - #{change_status}"
-        log.info "Waiting for AWS Route53 to apply updated DNS records to all of its servers."
-        route53_client.wait_until(:resource_record_sets_changed, {id: change_id})
-        change_status = route53_client.get_change({id: change_id}).change_info.status
-        log.info "DNS update status - #{change_status}"
-        log.info "Wait up to the configured Time To Live (#{CdoApp::DNS_TTL} seconds) to lookup new IP address."
+        options[:quiet] = true
+        options[:start_inactive_instance] = true
+        create_or_update
       end
-      stack.outputs.each do |output|
+      cfn_stack.outputs.each do |output|
         log.info "#{output.output_key}: #{output.output_value}"
       end
     end
 
     def stop
-      if stack_exists?
-        log.info "Finding EC2 Instance for CloudFormation Stack #{stack_name} ..."
-        cloudformation_resource = Aws::CloudFormation::Resource.new
-        stack = cloudformation_resource.stack(stack_name)
-        instance_id = stack.resource('WebServer').physical_resource_id
-        instance = Aws::EC2::Instance.new(id: instance_id)
-        if instance.nil?
-          log.info "Instance #{instance_id} does not exist or has been terminated."\
-                "Delete this unrecoverable CloudFormation stack: rake adhoc:delete STACK_NAME=#{stack_name}"
-        elsif instance.state.code == 80 # already Stopped
-          log.info "Instance #{instance.id} is already Stopped."
-        elsif instance.state.code == 16 # Running
-          log.info "Stopping Instance #{instance.id} ..."
-          stop_result = instance.stop
-          log.info "Instance Status - #{stop_result.stopping_instances[0].current_state.name}"
-          log.info "Waiting until Stopped ..."
-          instance.wait_until_stopped
-          log.info "Instance Status - #{instance.reload.state.name}"
-          log.info "To start instance: rake adhoc:start_inactive_instance STACK_NAME=#{stack_name}"
-        else
-          log.info "Cannot stop Instance because its state is #{instance.state.name}"
-        end
+      log.info "Finding EC2 Instance for CloudFormation Stack #{stack_name} ..."
+      if !instance.exists?
+        log.info "Instance #{instance_id} does not exist or has been terminated."\
+              "Delete this unrecoverable CloudFormation stack: rake adhoc:delete STACK_NAME=#{stack_name}"
+      elsif instance.state.name == 'stopped'
+        log.info "Instance #{instance.id} is already Stopped."
+      elsif instance.state.name == 'running'
+        log.info "Stopping Instance #{instance.id} ..."
+        stop_result = instance.stop
+        log.info "Instance Status - #{stop_result.stopping_instances[0].current_state.name}"
+        log.info "Waiting until Stopped ..."
+        instance.wait_until_stopped
+        log.info "Instance Status - #{instance.reload.state.name}"
+        log.info "To start instance: rake adhoc:start_inactive_instance STACK_NAME=#{stack_name}"
       else
-        log.warn "Stack #{stack_name} does not exist."
+        log.info "Cannot stop Instance because its state is #{instance.state.name}"
       end
+    end
+
+    def cfn_stack
+      @cfn_stack ||= Aws::CloudFormation::Stack.new(stack_name)
+    end
+
+    def instance
+      @instance ||= Aws::EC2::Instance.new(id: cfn_stack.resource('WebServer').physical_resource_id)
     end
   end
 end


### PR DESCRIPTION
When starting a stopped EC2 instance [its public IP address changes](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/using-instance-addressing.html#concepts-public-addresses), because IPv4 addresses are not retained for inactive network interfaces. In order for an `adhoc` instance (which does not use a CDN or load-balancer) to continue serving public traffic, its DNS entries need to be updated to point to the new IP addresses when the instance is started again.

Previously, the `adhoc:start_inactive_instance` rake task would call `#start` on the EC2 instance, then manually update the DNS entries linked from the CloudFormation stack via `change_resource_record_sets`. This had an issue where it would prevent the DNS records from deleting when the stack is deleted, because the `AWS::Route53::RecordSetGroup` CloudFormation resources would become out of sync with the actual entries. The issue prevents adhoc stacks from being deleted and re-created due to the left-over DNS entry.

This PR fixes the issue and simplifies the `start_inactive_instance` implementation by modifying the `UserData` property of the daemon instance and updating the stack. This triggers a reboot of the EC2 instance (causing it to start), and also triggers the `RecordSetGroup` resources to be updated to the instance's new values.