### PR TITLE
Disable Git gc.autoDetach

### DIFF
--- a/cookbooks/cdo-github-access/files/default/gitconfig
+++ b/cookbooks/cdo-github-access/files/default/gitconfig
@@ -3,3 +3,10 @@
 [user]
 	name = Continuous Integration
 	email = dev@code.org
+
+# https://git-scm.com/docs/git-gc#_configuration
+[gc]
+    # Make git gc --auto return immediately and run in background if the system supports it. Default is true.
+    #
+    # Set false to prevent gc --auto from being interrupted by server shutdown, leaving behind large temp files.
+    autoDetach = false


### PR DESCRIPTION
The [`gc.autoDetach` config option](https://git-scm.com/docs/git-gc#_configuration) (default enabled) makes `git gc --auto` return immediately and run in background.

This PR sets this option to `false` in our chef-managed server's global git configs to prevent `git gc --auto` from being interrupted by server shutdown, leaving behind large temp files.

This setting should address the issue where a server shuts down while a backgrounded `git gc` operation is in progress, causing the half-finished `tmp_*` pack file to remain on the filesystem taking up large amounts of disk space. (When the gc doesn't finish, any future git operation triggers another `git gc`, which can fill up the entire disk in a short amount of time.)