### PR TITLE
Fix bootstrap-chef status response

### DIFF
--- a/aws/cloudformation/bootstrap_chef_stack.sh.erb
+++ b/aws/cloudformation/bootstrap_chef_stack.sh.erb
@@ -133,7 +133,6 @@ JSON
 # Bootstrap Chef configuration: Install Chef, run chef-client with empty run-list to create node with first-boot config.
 OPTIONS="<%=cookbooks_path ? '-z ' : ''%> -b $BRANCH -n $NODE_NAME -r '' -e $ENVIRONMENT -v $CHEF_VERSION"
 sudo -u ubuntu bash -c "aws s3 cp <%=bootstrap_script_path%> - | sudo bash -s -- $OPTIONS"
-[ $? -eq 0 ] && STATUS=SUCCESS || STATUS=<%=daemon ? 'SUCCESS' : 'FAILURE'%>
 
 CHEF_CDO_APP=<%=CdoApp::CHEF_BIN%>
 cat <<SH > $CHEF_CDO_APP
@@ -157,6 +156,7 @@ SH
 chmod +x $CHEF_CDO_APP
 # Run chef-client as root with SUDO_USER set to `ubuntu`.
 sudo -u ubuntu bash -c "sudo $CHEF_CDO_APP"
+[ $? -eq 0 ] && STATUS=SUCCESS || STATUS=<%=daemon ? 'SUCCESS' : 'FAILURE'%>
 
 <% unless daemon -%>
 # Workaround for version-controlled files modified by seed.


### PR DESCRIPTION
Fixes a bug in the bootstrap-chef status response introduced by #36366.

Our bootstrap-chef script sets `STATUS` to `SUCCESS` or `FAILURE` depending on whether the call to `chef-client` completes successfully. A change in that PR added an extra call to `chef-client`, but the value of `STATUS` was incorrectly set to the results of the _first_ call (which uses an empty run-list) instead of the second call (which uses the run-list that provisions the application).

This bug caused the production-deploy process to proceed to update frontends even though the CI build returned a compile-time error that should abort the deploy.