### PR TITLE
Test out YARD doc on LessonGroup [ci skip]

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -356,3 +356,5 @@ gem 'require_all', require: false
 gem 'dotiw'
 
 gem 'datapackage'
+
+gem 'yard'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -885,6 +885,7 @@ GEM
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.4)
     xxhash (0.4.0)
+    yard (0.9.25)
     youtube-dl.rb (0.3.1.2016.08.19)
       cocaine (>= 0.5.4)
 
@@ -1066,6 +1067,7 @@ DEPENDENCIES
   webdrivers (~> 3.0)
   webmock
   xxhash
+  yard
   youtube-dl.rb
 
 RUBY VERSION

--- a/dashboard/.gitignore
+++ b/dashboard/.gitignore
@@ -24,3 +24,6 @@
 
 /public/code-studio-package
 /public/apps-package
+
+.yardoc
+doc

--- a/dashboard/app/models/lesson_group.rb
+++ b/dashboard/app/models/lesson_group.rb
@@ -16,6 +16,14 @@
 #  index_lesson_groups_on_script_id_and_key  (script_id,key) UNIQUE
 #
 
+# An ordered group of Lessons. For example, on https://studio.code.org/s/coursea-2020, "Digital Citizenship"
+# and "Sequencing" are LessonGroups. Sometimes also known as a `Chapter`.
+#
+# Every Unit (Script) has at least one LessonGroup. However, for some units, the LessonGroup is a non-user-facing
+# default LessonGroup which is hidden in the UI. For example, see http://studio.code.org/s/20-hour
+#
+# @attr [String] display_name - The user-facing name of this LessonGroup; only used for display purposes.
+# @attr [String] description - A description for this LessonGroup.
 class LessonGroup < ApplicationRecord
   include SerializedProperties
 


### PR DESCRIPTION
Here's one possible documentation convention we could follow - [YARD](https://yardoc.org/). If we follow this syntax, then with the `yard doc` command, it generates HTML docs that look like:

![image](https://user-images.githubusercontent.com/6564873/92048000-70d3bf00-ed3b-11ea-8b02-10e122bdd2ba.png)

One downside of this approach is that it wants all the attribute comments to be at the top of the file. Maybe it'd be better to ignore that and put them inline with the properties for convenience and discoverability.

To be honest, I don't expect that we'll use the generated docs if we have to generate them manually, but it at least provides an existing convention to follow for documentation. It would also be possible and probably not *too* difficult to add doc generation to our CI process, in which case the generated docs might be more practical.

Either way though, I think the most valuable thing would be to consistently have comments in the source files which are informative and also easy enough to write so we can actually do it consistently.