### PR TITLE
Add health-check test to frontend bootstrap script

### DIFF
--- a/aws/cloudformation/bootstrap_frontend.sh.erb
+++ b/aws/cloudformation/bootstrap_frontend.sh.erb
@@ -19,3 +19,8 @@ ps aux | grep "cluster worker" | grep dashboard | head -n 3 | tr --squeeze-repea
 # Increase EC2 instance metadata service retries/timeouts.
 export AWS_METADATA_SERVICE_TIMEOUT=30
 export AWS_METADATA_SERVICE_NUM_ATTEMPTS=30
+
+# Make sure server passes health check.
+# The status code determines success/failure of the instance launch.
+curl --silent --show-error --fail --retry 10 --retry-connrefused --retry-max-time 60 \
+  localhost:80/health_check > /dev/null

--- a/aws/cloudformation/components/ami.yml.erb
+++ b/aws/cloudformation/components/ami.yml.erb
@@ -166,12 +166,21 @@ frontend_device_name ||= '/dev/sda1'
 
           INSTANCE_ID=$(curl -s http://169.254.169.254/latest/meta-data/instance-id)
           <%=indent(build_frontend, 10)%>
+          if [ $? -eq 0 ]
+          then
+            CFN_STATUS=SUCCESS
+            LIFECYCLE_ACTION=CONTINUE
+          else
+            CFN_STATUS=FAILURE
+            LIFECYCLE_ACTION=ABANDON
+          fi
+
           # Signal CompleteLifecycleAction, in case this instance was launched from an Auto Scaling process.
           LIFECYCLE_HOOK=WebServerHook-${AWS::StackName}
           AUTO_SCALING_GROUP=Frontends-${AWS::StackName}
           if [ -n "$LIFECYCLE_HOOK" ] && [ -n "$AUTO_SCALING_GROUP" ]; then
             aws autoscaling complete-lifecycle-action \
-              --lifecycle-action-result CONTINUE \
+              --lifecycle-action-result $LIFECYCLE_ACTION \
               --instance-id $INSTANCE_ID \
               --lifecycle-hook-name $LIFECYCLE_HOOK \
               --auto-scaling-group-name $AUTO_SCALING_GROUP \
@@ -182,7 +191,7 @@ frontend_device_name ||= '/dev/sda1'
           # Signal CloudFormation, in case this instance was launched from a CloudFormation stack update.
           RESOURCE_ID=Frontends
           aws cloudformation signal-resource \
-            --status SUCCESS \
+            --status $CFN_STATUS \
             --unique-id $INSTANCE_ID \
             --stack-name $STACK \
             --logical-resource-id $RESOURCE_ID \


### PR DESCRIPTION
This PR adds a health-check test (using `curl`) to the frontend bootstrap script. It will make sure that the server is running with a successful health check before completing the Auto Scaling Group lifecycle action that will add the instance to the load-balancer.

This should prevent faulty frontend instances (e.g., a bad deploy causing a critical web-application service to fail to start correctly) from allowing the deploy to proceed, allowing it to rollback before causing any issues in production.

### Testing

Verified the test on an `adhoc:full_stack` deployment. Confirmed via logs that the added `curl` command completed successfully on a new frontend node being launched, and set the status variables to mark the instance-launch successful to the rest of the deployment.