### PR TITLE
retain only one active level when cloning script levels with variants

### DIFF
--- a/dashboard/app/models/script_level.rb
+++ b/dashboard/app/models/script_level.rb
@@ -63,7 +63,7 @@ class ScriptLevel < ActiveRecord::Base
 
       # variants are deprecated. when cloning a script, retain only the first
       # active level in each script level, discarding any variants.
-      if new_suffix && (raw_levels.length > 1 || properties[:variants])
+      if new_suffix && raw_levels.length > 1
         first_active_level = raw_levels.find do |raw_level|
           variant = properties[:variants].try(:[], raw_level[:name])
           !(variant && variant[:active] == false)

--- a/dashboard/app/models/script_level.rb
+++ b/dashboard/app/models/script_level.rb
@@ -65,9 +65,8 @@ class ScriptLevel < ActiveRecord::Base
       end
 
       properties = raw_script_level.delete(:properties) || {}
-      raw_levels = raw_script_level[:levels]
 
-      levels = Level.add_levels(raw_levels, script, new_suffix, editor_experiment)
+      levels = Level.add_levels(raw_script_level[:levels], script, new_suffix, editor_experiment)
 
       script_level_attributes = {
         script_id: script.id,

--- a/dashboard/app/models/script_level.rb
+++ b/dashboard/app/models/script_level.rb
@@ -58,19 +58,19 @@ class ScriptLevel < ActiveRecord::Base
     raw_script_levels.map do |raw_script_level|
       raw_script_level.symbolize_keys!
 
-      properties = raw_script_level.delete(:properties) || {}
-      raw_levels = raw_script_level[:levels]
-
       # variants are deprecated. when cloning a script, retain only the first
       # active level in each script level, discarding any variants.
-      if new_suffix && raw_levels.length > 1
-        first_active_level = raw_levels.find do |raw_level|
-          variant = properties[:variants].try(:[], raw_level[:name])
+      if new_suffix && raw_script_level[:levels].length > 1
+        first_active_level = raw_script_level[:levels].find do |raw_level|
+          variant = raw_script_level[:properties][:variants].try(:[], raw_level[:name])
           !(variant && variant[:active] == false)
         end
-        raw_levels = [first_active_level]
-        properties.delete(:variants)
+        raw_script_level[:levels] = [first_active_level]
+        raw_script_level[:properties].delete(:variants)
       end
+
+      properties = raw_script_level.delete(:properties) || {}
+      raw_levels = raw_script_level[:levels]
 
       levels = Level.add_levels(raw_levels, script, new_suffix, editor_experiment)
 

--- a/dashboard/app/models/script_level.rb
+++ b/dashboard/app/models/script_level.rb
@@ -61,12 +61,7 @@ class ScriptLevel < ActiveRecord::Base
       # variants are deprecated. when cloning a script, retain only the first
       # active level in each script level, discarding any variants.
       if new_suffix && raw_script_level[:levels].length > 1
-        first_active_level = raw_script_level[:levels].find do |raw_level|
-          variant = raw_script_level[:properties][:variants].try(:[], raw_level[:name])
-          !(variant && variant[:active] == false)
-        end
-        raw_script_level[:levels] = [first_active_level]
-        raw_script_level[:properties].delete(:variants)
+        remove_variants(raw_script_level)
       end
 
       properties = raw_script_level.delete(:properties) || {}
@@ -95,6 +90,15 @@ class ScriptLevel < ActiveRecord::Base
       script_level.save! if script_level.changed?
       script_level
     end
+  end
+
+  def self.remove_variants(raw_script_level)
+    first_active_level = raw_script_level[:levels].find do |raw_level|
+      variant = raw_script_level[:properties][:variants].try(:[], raw_level[:name])
+      !(variant && variant[:active] == false)
+    end
+    raw_script_level[:levels] = [first_active_level]
+    raw_script_level[:properties].delete(:variants)
   end
 
   def script

--- a/dashboard/test/controllers/scripts_controller_test.rb
+++ b/dashboard/test/controllers/scripts_controller_test.rb
@@ -797,7 +797,7 @@ class ScriptsControllerTest < ActionController::TestCase
     sign_in @levelbuilder
     Rails.application.config.stubs(:levelbuilder_mode).returns true
 
-    (1..2).map {|n| create(:level, name: "Level #{n}")}
+    (1..8).map {|n| create(:level, name: "Level #{n}")}
     script_file = File.join(self.class.fixture_path, "test-fixture-experiments.script")
     Script.setup([script_file])
 

--- a/dashboard/test/fixtures/test-fixture-experiments.script
+++ b/dashboard/test/fixtures/test-fixture-experiments.script
@@ -1,5 +1,17 @@
 lesson 'lesson1', display_name: 'lesson1'
 variants
-  level 'Level 1', active: true, experiments: ["control"]
-  level 'Level 2',  experiments: ["hypothesis"]
+  level 'Level 1'
+  level 'Level 2', active: false
+endvariants
+variants
+  level 'Level 3', active: false
+  level 'Level 4'
+endvariants
+variants
+  level 'Level 5'
+  level 'Level 6'
+endvariants
+variants
+  level 'Level 7', experiments: ['experiment']
+  level 'Level 8'
 endvariants

--- a/dashboard/test/fixtures/test-fixture-variants.script
+++ b/dashboard/test/fixtures/test-fixture-variants.script
@@ -3,15 +3,3 @@ variants
   level 'Level 1'
   level 'Level 2', active: false
 endvariants
-variants
-  level 'Level 3', active: false
-  level 'Level 4'
-endvariants
-variants
-  level 'Level 5'
-  level 'Level 6'
-endvariants
-variants
-  level 'Level 7', experiments: ['experiment']
-  level 'Level 8'
-endvariants

--- a/dashboard/test/fixtures/test-fixture-variants.script
+++ b/dashboard/test/fixtures/test-fixture-variants.script
@@ -3,3 +3,7 @@ variants
   level 'Level 1'
   level 'Level 2', active: false
 endvariants
+variants
+  level 'Level 3', active: false
+  level 'Level 4'
+endvariants

--- a/dashboard/test/fixtures/test-fixture-variants.script
+++ b/dashboard/test/fixtures/test-fixture-variants.script
@@ -7,3 +7,7 @@ variants
   level 'Level 3', active: false
   level 'Level 4'
 endvariants
+variants
+  level 'Level 5'
+  level 'Level 6'
+endvariants

--- a/dashboard/test/fixtures/test-fixture-variants.script
+++ b/dashboard/test/fixtures/test-fixture-variants.script
@@ -11,3 +11,7 @@ variants
   level 'Level 5'
   level 'Level 6'
 endvariants
+variants
+  level 'Level 7', experiments: ['experiment']
+  level 'Level 8'
+endvariants

--- a/dashboard/test/models/script_test.rb
+++ b/dashboard/test/models/script_test.rb
@@ -1603,30 +1603,14 @@ class ScriptTest < ActiveSupport::TestCase
     assert_equal 'test-fixture-variants-copy', script_copy.name
 
     assert_equal 4, script_copy.script_levels.count
-
-    sl = script_copy.script_levels[0]
-    assert_equal 1, sl.levels.count
-    assert_equal 'Level 1_copy', sl.levels.first.name
-    assert sl.active?(sl.levels.first)
-    refute sl.variants?
-
-    sl = script_copy.script_levels[1]
-    assert_equal 1, sl.levels.count
-    assert_equal 'Level 4_copy', sl.levels.first.name
-    assert sl.active?(sl.levels.first)
-    refute sl.variants?
-
-    sl = script_copy.script_levels[2]
-    assert_equal 1, sl.levels.count
-    assert_equal 'Level 5_copy', sl.levels.first.name
-    assert sl.active?(sl.levels.first)
-    refute sl.variants?
-
-    sl = script_copy.script_levels[3]
-    assert_equal 1, sl.levels.count
-    assert_equal 'Level 8_copy', sl.levels.first.name
-    assert sl.active?(sl.levels.first)
-    refute sl.variants?
+    script_copy.script_levels.each do |sl|
+      assert_equal 1, sl.levels.count
+      assert sl.active?(sl.levels.first)
+      refute sl.variants?
+    end
+    expected_level_names = ['Level 1_copy', 'Level 4_copy', 'Level 5_copy', 'Level 8_copy']
+    actual_level_names = script_copy.script_levels.map(&:levels).map(&:first).map(&:name)
+    assert_equal expected_level_names, actual_level_names
 
     new_dsl = <<~SCRIPT
       lesson 'lesson1', display_name: 'lesson1'

--- a/dashboard/test/models/script_test.rb
+++ b/dashboard/test/models/script_test.rb
@@ -1602,17 +1602,24 @@ class ScriptTest < ActiveSupport::TestCase
     script_copy = script.clone_with_suffix('copy')
     assert_equal 'test-fixture-variants-copy', script_copy.name
 
-    assert_equal 1, script_copy.script_levels.count
-    sl = script_copy.script_levels.first
-    assert_equal 1, sl.levels.count
+    assert_equal 2, script_copy.script_levels.count
 
+    sl = script_copy.script_levels[0]
+    assert_equal 1, sl.levels.count
     assert_equal 'Level 1_copy', sl.levels.first.name
+    assert sl.active?(sl.levels.first)
+    refute sl.variants?
+
+    sl = script_copy.script_levels[1]
+    assert_equal 1, sl.levels.count
+    assert_equal 'Level 4_copy', sl.levels.first.name
     assert sl.active?(sl.levels.first)
     refute sl.variants?
 
     new_dsl = <<~SCRIPT
       lesson 'lesson1', display_name: 'lesson1'
       level 'Level 1_copy'
+      level 'Level 4_copy'
 
     SCRIPT
 

--- a/dashboard/test/models/script_test.rb
+++ b/dashboard/test/models/script_test.rb
@@ -11,7 +11,7 @@ class ScriptTest < ActiveSupport::TestCase
     @game = create(:game)
     @script_file = File.join(self.class.fixture_path, "test-fixture.script")
     # Level names match those in 'test.script'
-    @levels = (1..5).map {|n| create(:level, name: "Level #{n}", game: @game, level_num: 'custom')}
+    @levels = (1..6).map {|n| create(:level, name: "Level #{n}", game: @game, level_num: 'custom')}
 
     @unit_group = create(:unit_group)
     @script_in_unit_group = create(:script, hidden: true)
@@ -1602,7 +1602,7 @@ class ScriptTest < ActiveSupport::TestCase
     script_copy = script.clone_with_suffix('copy')
     assert_equal 'test-fixture-variants-copy', script_copy.name
 
-    assert_equal 2, script_copy.script_levels.count
+    assert_equal 3, script_copy.script_levels.count
 
     sl = script_copy.script_levels[0]
     assert_equal 1, sl.levels.count
@@ -1616,10 +1616,21 @@ class ScriptTest < ActiveSupport::TestCase
     assert sl.active?(sl.levels.first)
     refute sl.variants?
 
+    sl = script_copy.script_levels[2]
+    assert_equal 2, sl.levels.count
+    assert_equal 'Level 5_copy', sl.levels.first.name
+    assert_equal 'Level 6_copy', sl.levels.last.name
+    assert sl.active?(sl.levels.first)
+    assert sl.active?(sl.levels.last)
+
     new_dsl = <<~SCRIPT
       lesson 'lesson1', display_name: 'lesson1'
       level 'Level 1_copy'
       level 'Level 4_copy'
+      variants
+        level 'Level 5_copy'
+        level 'Level 6_copy'
+      endvariants
 
     SCRIPT
 

--- a/dashboard/test/models/script_test.rb
+++ b/dashboard/test/models/script_test.rb
@@ -1593,14 +1593,14 @@ class ScriptTest < ActiveSupport::TestCase
     assert_equal true, script_copy.hidden
   end
 
-  test 'clone script with inactive variant' do
-    script_file = File.join(self.class.fixture_path, "test-fixture-variants.script")
+  test 'clone script with variants' do
+    script_file = File.join(self.class.fixture_path, "test-fixture-experiments.script")
     scripts, _ = Script.setup([script_file])
     script = scripts[0]
 
     Script.stubs(:script_directory).returns(self.class.fixture_path)
     script_copy = script.clone_with_suffix('copy')
-    assert_equal 'test-fixture-variants-copy', script_copy.name
+    assert_equal 'test-fixture-experiments-copy', script_copy.name
 
     assert_equal 4, script_copy.script_levels.count
     script_copy.script_levels.each do |sl|

--- a/dashboard/test/models/script_test.rb
+++ b/dashboard/test/models/script_test.rb
@@ -1604,19 +1604,15 @@ class ScriptTest < ActiveSupport::TestCase
 
     assert_equal 1, script_copy.script_levels.count
     sl = script_copy.script_levels.first
+    assert_equal 1, sl.levels.count
 
     assert_equal 'Level 1_copy', sl.levels.first.name
     assert sl.active?(sl.levels.first)
-
-    assert_equal 'Level 2_copy', sl.levels.last.name
-    refute sl.active?(sl.levels.last)
+    refute sl.variants?
 
     new_dsl = <<~SCRIPT
       lesson 'lesson1', display_name: 'lesson1'
-      variants
-        level 'Level 1_copy'
-        level 'Level 2_copy', active: false
-      endvariants
+      level 'Level 1_copy'
 
     SCRIPT
 

--- a/dashboard/test/models/script_test.rb
+++ b/dashboard/test/models/script_test.rb
@@ -11,7 +11,7 @@ class ScriptTest < ActiveSupport::TestCase
     @game = create(:game)
     @script_file = File.join(self.class.fixture_path, "test-fixture.script")
     # Level names match those in 'test.script'
-    @levels = (1..5).map {|n| create(:level, name: "Level #{n}", game: @game)}
+    @levels = (1..5).map {|n| create(:level, name: "Level #{n}", game: @game, level_num: 'custom')}
 
     @unit_group = create(:unit_group)
     @script_in_unit_group = create(:script, hidden: true)
@@ -1611,17 +1611,16 @@ class ScriptTest < ActiveSupport::TestCase
     assert_equal 'Level 2_copy', sl.levels.last.name
     refute sl.active?(sl.levels.last)
 
-    # Ignore level names, since we are just testing whether the
-    # variants / active / endvariants structure is correct.
-    new_dsl_regex = <<-SCRIPT
-lesson 'lesson1', display_name: 'lesson1'
-variants
-  level '[^']+'
-  level '[^']+', active: false
-endvariants
+    new_dsl = <<~SCRIPT
+      lesson 'lesson1', display_name: 'lesson1'
+      variants
+        level 'Level 1_copy'
+        level 'Level 2_copy', active: false
+      endvariants
+
     SCRIPT
 
-    assert_match Regexp.new(new_dsl_regex), ScriptDSL.serialize_to_string(script_copy)
+    assert_equal new_dsl, ScriptDSL.serialize_to_string(script_copy)
   end
 
   test 'clone with suffix and add editor experiment' do

--- a/dashboard/test/models/script_test.rb
+++ b/dashboard/test/models/script_test.rb
@@ -11,7 +11,7 @@ class ScriptTest < ActiveSupport::TestCase
     @game = create(:game)
     @script_file = File.join(self.class.fixture_path, "test-fixture.script")
     # Level names match those in 'test.script'
-    @levels = (1..6).map {|n| create(:level, name: "Level #{n}", game: @game, level_num: 'custom')}
+    @levels = (1..8).map {|n| create(:level, name: "Level #{n}", game: @game, level_num: 'custom')}
 
     @unit_group = create(:unit_group)
     @script_in_unit_group = create(:script, hidden: true)
@@ -1602,7 +1602,7 @@ class ScriptTest < ActiveSupport::TestCase
     script_copy = script.clone_with_suffix('copy')
     assert_equal 'test-fixture-variants-copy', script_copy.name
 
-    assert_equal 3, script_copy.script_levels.count
+    assert_equal 4, script_copy.script_levels.count
 
     sl = script_copy.script_levels[0]
     assert_equal 1, sl.levels.count
@@ -1623,6 +1623,11 @@ class ScriptTest < ActiveSupport::TestCase
     assert sl.active?(sl.levels.first)
     assert sl.active?(sl.levels.last)
 
+    sl = script_copy.script_levels[3]
+    assert_equal 1, sl.levels.count
+    assert_equal 'Level 8_copy', sl.levels.first.name
+    assert sl.active?(sl.levels.first)
+
     new_dsl = <<~SCRIPT
       lesson 'lesson1', display_name: 'lesson1'
       level 'Level 1_copy'
@@ -1631,6 +1636,7 @@ class ScriptTest < ActiveSupport::TestCase
         level 'Level 5_copy'
         level 'Level 6_copy'
       endvariants
+      level 'Level 8_copy'
 
     SCRIPT
 

--- a/dashboard/test/models/script_test.rb
+++ b/dashboard/test/models/script_test.rb
@@ -1617,25 +1617,22 @@ class ScriptTest < ActiveSupport::TestCase
     refute sl.variants?
 
     sl = script_copy.script_levels[2]
-    assert_equal 2, sl.levels.count
+    assert_equal 1, sl.levels.count
     assert_equal 'Level 5_copy', sl.levels.first.name
-    assert_equal 'Level 6_copy', sl.levels.last.name
     assert sl.active?(sl.levels.first)
-    assert sl.active?(sl.levels.last)
+    refute sl.variants?
 
     sl = script_copy.script_levels[3]
     assert_equal 1, sl.levels.count
     assert_equal 'Level 8_copy', sl.levels.first.name
     assert sl.active?(sl.levels.first)
+    refute sl.variants?
 
     new_dsl = <<~SCRIPT
       lesson 'lesson1', display_name: 'lesson1'
       level 'Level 1_copy'
       level 'Level 4_copy'
-      variants
-        level 'Level 5_copy'
-        level 'Level 6_copy'
-      endvariants
+      level 'Level 5_copy'
       level 'Level 8_copy'
 
     SCRIPT


### PR DESCRIPTION
Finishes [PLAT-284]

https://github.com/code-dot-org/code-dot-org/blob/14de84ad2dba2c88338ece30c2a80edffa193c30/dashboard/app/models/script_level.rb#L64-L65

## Testing story

Added script unit tests verifying that various configurations of variants all result in retaining only one active level when the script that contains them is cloned.

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked


[PLAT-284]: https://codedotorg.atlassian.net/browse/PLAT-284