### PR TITLE
Sending i18n string usage to 'track_string_usage' API

### DIFF
--- a/apps/src/util/i18nStringTracker.js
+++ b/apps/src/util/i18nStringTracker.js
@@ -1,12 +1,5 @@
 import experiments from '@cdo/apps/util/experiments';
-
-// A map of "string source" -> "list of strings used"
-// For example: window.stringUsageSources['maze'] = ['level_1.instruction.header']
-// The data recorded in this will periodically be uploaded.
-if (!window.stringUsageSources) {
-  // Initialize if it doesn't already exist.
-  window.stringUsageSources = {};
-}
+import {getI18nStringTrackerWorker} from '@cdo/apps/util/i18nStringTrackerWorker';
 
 export default function localeWithI18nStringTracker(locale, source) {
   if (!experiments.isEnabled(experiments.I18N_TRACKING)) {
@@ -26,15 +19,13 @@ export default function localeWithI18nStringTracker(locale, source) {
 }
 
 // Records the usage of the given i18n string key from the given source file.
-// @param stringKey [String] The string key used to look up the i18n value e.g. 'home.banner_text'
-// @param source [String] Context for where the given string key came from e.g. 'maze', 'dance', etc.
+// @param {string} stringKey  The string key used to look up the i18n value e.g. 'home.banner_text'
+// @param {string} source Context for where the given string key came from e.g. 'maze', 'dance', etc.
 function log(stringKey, source) {
   if (!stringKey || !source) {
     return;
   }
-  if (!window.stringUsageSources[source]) {
-    // Initialize the list of strings for the source if it doesn't already exist.
-    window.stringUsageSources[source] = new Set();
-  }
-  window.stringUsageSources[source].add(stringKey);
+
+  // Send the usage data to a background worker thread to be buffered and sent.
+  getI18nStringTrackerWorker().log(stringKey, source);
 }

--- a/apps/src/util/i18nStringTrackerWorker.js
+++ b/apps/src/util/i18nStringTrackerWorker.js
@@ -1,0 +1,93 @@
+import $ from 'jquery';
+
+/**
+ * Gets the singleton instance of an I18nStringTrackerWorker
+ * @returns {I18nStringTrackerWorker}
+ */
+export function getI18nStringTrackerWorker() {
+  return new I18nStringTrackerWorker();
+}
+
+/**
+ * A singleton class which buffers i18n string usage data and sends it in batches to the '/i18n/track_string_usage' API.
+ */
+class I18nStringTrackerWorker {
+  constructor() {
+    // Check if there is already a singleton instance.
+    const instance = this.constructor.instance;
+    if (instance) {
+      return instance;
+    }
+
+    // Set the singleton instance to this instance if it doesn't exist already.
+    this.constructor.instance = this;
+
+    /**
+     * A buffer of records to be sent in batches. Each key is the `source` file of the string and the values are the
+     * i18n `stringKey`s used to lookup the translated string.
+     * @typedef {Object.<string, Set>} I18nRecords
+     * Example:
+     * {
+     *   'common_locale': [ 'curriculum', 'teacherForum', 'professionalLearning', ...],
+     *   'fish_locale': ...
+     * }
+     */
+    this.buffer = {};
+  }
+
+  /**
+   * Buffers the given i18n string usage data to be sent later.
+   * @param {string} stringKey The key used to look up the i18n string value e.g. 'curriculum'
+   * @param {string} source Context about the file i18n value was looked up in e.g. 'common_locale'
+   */
+  log(stringKey, source) {
+    if (!stringKey || !source) {
+      return;
+    }
+
+    this.buffer[source] = this.buffer[source] || new Set();
+    this.buffer[source].add(stringKey);
+
+    // schedule a buffer flush if there isn't already one.
+    if (!this.pendingFlush) {
+      this.pendingFlush = setTimeout(() => this.flush(), 3000);
+    }
+  }
+
+  // Sends all the buffered records
+  flush() {
+    // Do nothing if there are no records to record.
+    if (Object.keys(this.buffer).length === 0) {
+      return;
+    }
+
+    // Grab the contents of the current buffer and clear the buffer.
+    const records = this.buffer;
+    this.buffer = {};
+    this.pendingFlush = null;
+
+    // Record the i18n string usage data.
+    sendRecords(records);
+  }
+}
+
+/**
+ * Asynchronously send the given records to the `/i18n/track_string_usage` API
+ * @param {I18nRecords} records The records of i18n string usage information to be sent.
+ */
+function sendRecords(records) {
+  const url = window.location.origin + window.location.pathname; //strip the query string from the URL
+  Object.keys(records).forEach(source => {
+    const stringKeys = Array.from(records[source]);
+    $.ajax({
+      url: '/i18n/track_string_usage',
+      type: 'post',
+      dataType: 'json',
+      data: {
+        url: url,
+        source: source,
+        string_keys: stringKeys
+      }
+    });
+  });
+}

--- a/cookbooks/cdo-varnish/libraries/http_cache.rb
+++ b/cookbooks/cdo-varnish/libraries/http_cache.rb
@@ -140,7 +140,7 @@ class HttpCache
             cookies: allowlisted_cookies
           },
           {
-            path: '/i18n/*',
+            path: '/i18n/track_string_usage',
             proxy: 'dashboard',
             headers: ALLOWLISTED_HEADERS,
             cookies: allowlisted_cookies

--- a/cookbooks/cdo-varnish/libraries/http_cache.rb
+++ b/cookbooks/cdo-varnish/libraries/http_cache.rb
@@ -138,6 +138,12 @@ class HttpCache
             proxy: 'dashboard',
             headers: ALLOWLISTED_HEADERS,
             cookies: allowlisted_cookies
+          },
+          {
+            path: '/i18n/*',
+            proxy: 'dashboard',
+            headers: ALLOWLISTED_HEADERS,
+            cookies: allowlisted_cookies
           }
         ],
         # Remaining Pegasus paths are cached, and vary only on language, country, and default cookies.

--- a/dashboard/app/controllers/i18n_controller.rb
+++ b/dashboard/app/controllers/i18n_controller.rb
@@ -1,4 +1,8 @@
 class I18nController < ApplicationController
+  # The CSRF token is not available on every code.org page, and this API needs to work on all page; therefore CSRF
+  # protections checks will be skipped for the i18n API.
+  protect_from_forgery except: [:track_string_usage]
+
   # The max number of i18n string keys which can be recorded in one request.
   # This is to protect us from malicious API calls where thousands or millions of items are given in a single request.
   # It doesn't stop us from receiving it, but it does stop us from doing anything with it.


### PR DESCRIPTION
## Context
The overall goal of the i18n string tracking project is to know which translatable strings are being used on a given URL. In a previous PR, we have added a new API `/i18n/track_string_usage` which takes i18n string usage information and records it to Redshift table. In another PR, we have added a hook called `i18nStringTracker.js` which enables us to know when a i18n string is being used.

This PR builds on the two previous PRs by having `i18nStringTracker.js` call the new `i18n/track_string_usage` API. 
* Adds `i18nStringTrackerWorker.js` which is responsible for making the API calls. It buffers the usage information and sends them in batches every 3 seconds.
* Adds an AJAX call to `/i18n/track_string_usage`.

## Experiments
`?enableExperiments=i18n-tracking`

## Links
- [spec](https://docs.google.com/document/d/1zbQNn83YOafVbAkxfc6MgBFPB8Em9EuBusXobaWiCbw/edit#heading=h.1rq9fero2ued)
- [jira](https://codedotorg.atlassian.net/browse/FND-1243)
## Testing story
* Manually verified on localhost

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
