### PR TITLE
Add disk-usage CloudWatch Alarms for all EC2 instances

### DIFF
--- a/aws/cloudformation/components/alarms.yml.erb
+++ b/aws/cloudformation/components/alarms.yml.erb
@@ -1,5 +1,5 @@
-  Critical: {Type: AWS::SNS::Topic}
-  Warning: {Type: AWS::SNS::Topic}
+  Critical: {Type: 'AWS::SNS::Topic'}
+  Warning: {Type: 'AWS::SNS::Topic'}
 <%{Warning: 70, Critical: 90}.each do |name, threshold| -%>
   DiskUsed<%=name%>:
     Type: AWS::CloudWatch::Alarm

--- a/aws/cloudformation/components/alarms.yml.erb
+++ b/aws/cloudformation/components/alarms.yml.erb
@@ -1,25 +1,20 @@
-  DaemonStorageUtilizationAlarm:
-    Type: "AWS::CloudWatch::Alarm"
+  Critical: {Type: AWS::SNS::Topic}
+  Warning: {Type: AWS::SNS::Topic}
+<%{Warning: 70, Critical: 90}.each do |name, threshold| -%>
+  DiskUsed<%=name%>:
+    Type: AWS::CloudWatch::Alarm
     Properties:
-      AlarmActions:
-        - !Sub "arn:aws:sns:${AWS::Region}:${AWS::AccountId}:CDO-<%= rack_env?(:production) ? 'Urgent' : 'LowPriority'%>"
-      AlarmDescription: Send page if daemon storage utilization exceeds 80% for an hour
-      AlarmName: <%="#{stack_name}_daemon_high_storage_utilization" %>
-      ComparisonOperator: GreaterThanThreshold
-      Dimensions:
-        - Name: Filesystem
-          Value: '/dev/xvda1'
-        - Name: MountPath
-          Value: '/'
-        - Name: InstanceId
-          Value: <%= daemon_instance_id || "!Ref #{daemon}" %>
-      EvaluationPeriods: 60
-      MetricName: DiskSpaceUtilization
-      Namespace: 'System/Linux'
+      AlarmActions: [!Ref '<%=name%>']
+      AlarmDescription: Max disk usage in <%=environment%> env exceeds <%=threshold%>%
+      Dimensions: [{Name: Environment, Value: <%=environment%>}]
+      Namespace: CWAgent
+      MetricName: disk_used_percent
+      Statistic: Maximum
+      EvaluationPeriods: 1
       Period: 60
-      Statistic: Average
-      Threshold: 80
-      TreatMissingData: missing
+      ComparisonOperator: GreaterThanThreshold
+      Threshold: <%=threshold%>
+<%end -%>
   DaemonMemoryUtilizationAlarm:
     Type: "AWS::CloudWatch::Alarm"
     Properties:

--- a/cookbooks/cdo-cloudwatch-agent/templates/default/amazon-cloudwatch-agent.json.erb
+++ b/cookbooks/cdo-cloudwatch-agent/templates/default/amazon-cloudwatch-agent.json.erb
@@ -31,7 +31,8 @@
         ],
         "append_dimensions": {
           "Environment": "<%=node.chef_environment%>"
-        }
+        },
+        "aggregation_dimensions": [["Environment"], ["Environment", "InstanceId"]]
       },
       "swap": {
         "measurement": [

--- a/cookbooks/cdo-cloudwatch-agent/templates/default/amazon-cloudwatch-agent.json.erb
+++ b/cookbooks/cdo-cloudwatch-agent/templates/default/amazon-cloudwatch-agent.json.erb
@@ -4,7 +4,7 @@
       "AutoScalingGroupName":"${aws:AutoScalingGroupName}",
       "InstanceId":"${aws:InstanceId}"
     },
-    "aggregation_dimensions": [["AutoScalingGroupName"]],
+    "aggregation_dimensions": [["AutoScalingGroupName"], ["Environment"]],
     "metrics_collected": {
       "statsd": {},
       "cpu": {
@@ -31,8 +31,7 @@
         ],
         "append_dimensions": {
           "Environment": "<%=node.chef_environment%>"
-        },
-        "aggregation_dimensions": [["Environment"], ["Environment", "InstanceId"]]
+        }
       },
       "swap": {
         "measurement": [

--- a/lib/rake/adhoc.rake
+++ b/lib/rake/adhoc.rake
@@ -12,7 +12,8 @@ namespace :adhoc do
         branch: ENV['BRANCH'] || ENV['branch'],
         database: ENV['DATABASE'],
         frontends: ENV['FRONTENDS'],
-        cdn_enabled: ENV['CDN_ENABLED']
+        cdn_enabled: ENV['CDN_ENABLED'],
+        alarms: ENV['ALARMS']
       )),
       log: CDO.log,
       verbose: ENV['VERBOSE'],


### PR DESCRIPTION
This PR contains updates to CloudWatch Alarms configuration to extend disk-utilization alarm coverage across all EC2 instances in an environment, and to add separate low-urgency 'Warning' and high-urgency 'Critical' alarms with separate thresholds (that can be wired up to separate intensities of alarms):

- Add [`aggregation_dimensions`](https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/CloudWatch-Agent-Configuration-File-Details.html#CloudWatch-Agent-Configuration-File-Metricssection) to the existing CloudWatch Agent config that will aggregate all `disk_used_percent` metrics across the entire Environment
- Create 'Warning' and 'Critical' SNS topics where alarm notifications will be published
- Change `DaemonStorageUtilizationAlarm` into two CloudWatch alarms (`DiskUsedWarning` and `DiskUsedCritical`), which will trigger the SNS topics on lower and higher thresholds of max disk usage in the environment.

### Testing

Test process:
- [x] Deploying an adhoc instance
- [x] Confirm the new aggregate CloudWatch metrics are being published from the instance
- [x] Confirm the CloudWatch Alarm monitoring the appropriate metrics has been created for the stack
- [x] Confirm the Alarm is configured to publish its alerts to the newly-added SNS topic