### PR TITLE
Ensure we report a milestone at least once per run/reset cycle.

### DIFF
--- a/apps/src/StudioApp.js
+++ b/apps/src/StudioApp.js
@@ -1778,6 +1778,7 @@ StudioApp.prototype.builderForm_ = function(onAttemptCallback) {
  * @param {MilestoneReport} options
  */
 StudioApp.prototype.report = function(options) {
+  // We don't need to report again on reset.
   this.hasReported = true;
   const currentTime = new Date().getTime();
   // copy from options: app, level, result, testResult, program, onComplete
@@ -1843,6 +1844,7 @@ StudioApp.prototype.clearAndAttachRuntimeAnnotations = function() {
  * Click the reset button.  Reset the application.
  */
 StudioApp.prototype.resetButtonClick = function() {
+  // If we haven't reported yet, report now.
   if (!this.hasReported) {
     this.report({
       app: getStore().getState().pageConstants.appType,

--- a/apps/src/StudioApp.js
+++ b/apps/src/StudioApp.js
@@ -1778,6 +1778,7 @@ StudioApp.prototype.builderForm_ = function(onAttemptCallback) {
  * @param {MilestoneReport} options
  */
 StudioApp.prototype.report = function(options) {
+  this.hasReported = true;
   const currentTime = new Date().getTime();
   // copy from options: app, level, result, testResult, program, onComplete
   var report = Object.assign({}, options, {
@@ -1842,6 +1843,13 @@ StudioApp.prototype.clearAndAttachRuntimeAnnotations = function() {
  * Click the reset button.  Reset the application.
  */
 StudioApp.prototype.resetButtonClick = function() {
+  if (!this.hasReported) {
+    this.report({
+      app: getStore().getState().pageConstants.appType,
+      level: this.config.level.id
+    });
+  }
+  this.hasReported = false;
   this.onResetPressed();
   this.toggleRunReset('run');
   this.clearHighlighting();

--- a/apps/test/integration/levelSolutions/applab1/ec_design.js
+++ b/apps/test/integration/levelSolutions/applab1/ec_design.js
@@ -362,10 +362,23 @@ module.exports = {
 
         Applab.onPuzzleComplete();
       },
-      expected: {
-        result: true,
-        testResult: TestResults.FREE_PLAY
-      }
+      expected: [
+        {
+          // codeModeButton clicked
+          result: undefined,
+          testResult: undefined
+        },
+        {
+          // resetButton clicked
+          result: undefined,
+          testResult: undefined
+        },
+        {
+          // onPuzzleComplete
+          result: true,
+          testResult: TestResults.FREE_PLAY
+        }
+      ]
     },
 
     {
@@ -466,10 +479,23 @@ module.exports = {
 
         Applab.onPuzzleComplete();
       },
-      expected: {
-        result: true,
-        testResult: TestResults.FREE_PLAY
-      }
+      expected: [
+        {
+          // codeModeButton clicked
+          result: undefined,
+          testResult: undefined
+        },
+        {
+          // resetButton clicked
+          result: undefined,
+          testResult: undefined
+        },
+        {
+          // onPuzzleComplete
+          result: true,
+          testResult: TestResults.FREE_PLAY
+        }
+      ]
     },
 
     {
@@ -555,10 +581,18 @@ module.exports = {
 
         Applab.onPuzzleComplete();
       },
-      expected: {
-        result: true,
-        testResult: TestResults.FREE_PLAY
-      }
+      expected: [
+        {
+          // resetButton clicked
+          result: undefined,
+          testResult: undefined
+        },
+        {
+          // onPuzzleComplete
+          result: true,
+          testResult: TestResults.FREE_PLAY
+        }
+      ]
     },
 
     {
@@ -1582,10 +1616,18 @@ module.exports = {
 
         Applab.onPuzzleComplete();
       },
-      expected: {
-        result: true,
-        testResult: TestResults.FREE_PLAY
-      }
+      expected: [
+        {
+          // resetButton clicked
+          result: undefined,
+          testResult: undefined
+        },
+        {
+          // onPuzzleComplete
+          result: true,
+          testResult: TestResults.FREE_PLAY
+        }
+      ]
     },
 
     {

--- a/apps/test/integration/levelSolutions/applab2/ec_screens.js
+++ b/apps/test/integration/levelSolutions/applab2/ec_screens.js
@@ -114,10 +114,18 @@ module.exports = {
           Applab.onPuzzleComplete();
         });
       },
-      expected: {
-        result: true,
-        testResult: TestResults.FREE_PLAY
-      }
+      expected: [
+        {
+          // change from design mode
+          result: undefined,
+          testResult: undefined
+        },
+        {
+          // onPuzzleComplete
+          result: true,
+          testResult: TestResults.FREE_PLAY
+        }
+      ]
     },
     {
       description: 'add a screen',
@@ -748,10 +756,18 @@ module.exports = {
 
         Applab.onPuzzleComplete();
       },
-      expected: {
-        result: true,
-        testResult: TestResults.FREE_PLAY
-      }
+      expected: [
+        {
+          // resetButton clicked
+          result: undefined,
+          testResult: undefined
+        },
+        {
+          // onPuzzleComplete
+          result: true,
+          testResult: TestResults.FREE_PLAY
+        }
+      ]
     },
 
     {

--- a/apps/test/integration/util/runLevelTest.js
+++ b/apps/test/integration/util/runLevelTest.js
@@ -57,25 +57,24 @@ module.exports = function(testCollection, testData, dataItem, done) {
   level.levelHtml = testData.levelHtml;
 
   level.hideViewDataButton = testData.hideViewDataButton;
+  var validationCallCount = 0;
 
   // Validate successful solution.
   var validateResult = function(report) {
     try {
       assert(testData.expected, 'Have expectations');
-      assert(
-        Object.keys(testData.expected).length > 0,
-        'No expected keys specified'
-      );
-      Object.keys(testData.expected).forEach(function(key) {
-        if (report[key] !== testData.expected[key]) {
-          var failureMsg =
-            'Failure for key: ' +
-            key +
-            '. Expected: ' +
-            testData.expected[key] +
-            '. Got: ' +
-            report[key] +
-            '\n';
+      var expected;
+      if (Array.isArray(testData.expected)) {
+        expected = testData.expected[validationCallCount++];
+      } else {
+        expected = testData.expected;
+      }
+      assert(Object.keys(expected).length > 0, 'No expected keys specified');
+      Object.keys(expected).forEach(function(key) {
+        if (report[key] !== expected[key]) {
+          var failureMsg = `Failure for key: ${key}. Expected: ${
+            expected[key]
+          }. Got: ${report[key]}\n`;
           assert(false, failureMsg);
         }
       });

--- a/apps/test/unit/StudioAppTest.js
+++ b/apps/test/unit/StudioAppTest.js
@@ -107,6 +107,39 @@ describe('StudioApp', () => {
       });
     });
 
+    describe('The StudioApp.resetButtonClick function', () => {
+      let studio, reportSpy;
+      beforeEach(() => {
+        studio = studioApp();
+        studio.onResetPressed = () => {};
+        studio.toggleRunReset = () => {};
+        studio.clearHighlighting = () => {};
+        studio.isUsingBlockly = () => {
+          return false;
+        };
+        studio.reset = () => {};
+
+        reportSpy = sinon.spy();
+        studio.report = reportSpy;
+      });
+
+      it('Sets hasReported to false', () => {
+        studio.hasReported = true;
+        studio.resetButtonClick();
+        expect(studio.hasReported).to.be.false;
+        expect(reportSpy).to.have.not.been.called;
+      });
+
+      it('Calls `report` if it has not yet been called', () => {
+        studio.hasReported = false;
+        studio.config = {level: {}};
+        studio.resetButtonClick();
+        expect(studio.hasReported).to.be.false;
+        expect(reportSpy).to.have.been.calledOnce;
+        delete studio.config;
+      });
+    });
+
     describe('The StudioApp.report function', () => {
       let clock, studio, onAttemptSpy;
       beforeEach(() => {
@@ -132,6 +165,12 @@ describe('StudioApp', () => {
         studio.report({});
 
         expect(studio.milestoneStartTime).to.equal(2000);
+      });
+
+      it('sets hasReported to true', () => {
+        studio.hasReported = false;
+        studio.report({});
+        expect(studio.hasReported).to.be.true;
       });
 
       it('calculates the timeSinceLastMilestone', () => {


### PR DESCRIPTION
Prior to this change, we recorded milestones inconsistently across apps.

On some CSF apps, we would record milestones every time the code was run. On others, we would record milestones after the code was run. On others, we would record milestones only when the level was completed or the finish button clicked.

On CSD/CSP apps, we would usually only record milestones when the finish button was clicked on the level.

This means for some levels, we wouldn't accurately record time_spent if the user completed some work, navigated away, and returned later.

Example level: https://studio.code.org/s/csp7-2020/stage/3/puzzle/3

Example scenario: 
A student works on a level for 5 minutes, running their code multiple times
Student navigates to a different page
Student returns to that level
Students works for 1 more minute
Student clicks the finish button
We'll record 1 minute of time_spent

With this change, across all apps, we are guaranteed to record a milestone at least once per every run/reset cycle.

Exception:
CSF lessons that use jigsaw do not use the run/reset button. These do, however, still record a milestone when the student completes the level. Since these levels don't have a clear point in which to record an intermediate milestone, maintaining the current behavior seems appropriate.

Example: https://studio.code.org/s/coursea-2020/stage/2/puzzle/1

<!--
  Other aspects to consider. uncomment and add detail for any that seem necessary:
-->

<!-- ### Background -->
<!-- ### Privacy -->
<!-- ### Security -->
<!-- ### Caching -->
<!-- ### Deployment strategy -->
<!-- ### Future work -->

## Links

<!--
  Any relevant links to external resources; ie, specification documents, jira
  items, related PRs, honeybadger errors, etc
-->

- [jira](https://codedotorg.atlassian.net/browse/LP-1510)

## Testing story

<!--
  Does your change include appropriate tests?

  If so, please describe how the tests included in this PR are sufficient

  If not, please explain why this change does not need to be tested.
-->

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
