### PR TITLE
Add new Daily Zendesk filters

### DIFF
--- a/bin/cron/zendesk_slack_report
+++ b/bin/cron/zendesk_slack_report
@@ -31,19 +31,30 @@ STATUSES_TO_REPORT = %w(new open)
 # Slack room -> Zendesk group mappings to report on
 MONITORING_GROUPS = {
   # 'slack-room-name' => ['Zendesk group name', 'Zendesk group name', ...]
+  'csf-curriculum' => ['CSF'],
+  'cspalooza' => ['CSP'],
   'developers' => ['Developers'],
+  'disco-party' => ['CSD'],
+  'foundations' => ['Accounts'],
+  'international' => ['International'],
   'learning-platform' => ['Learning Platform'],
+  'marketing' => ['Media'],
   'plc-engineering' => ['PLC Tools'],
   'product' => ['Product'],
-  'star-labs-cabal' => ['*Labs'],
-  # 'privacy' => ['Privacy'],
-  # 'user-accounts' => ['Accounts'],
+  'reaching-out' => ['Outreach'],
+  'star-labs-cabal' => ['*Labs']
 }
 
 # Zendesk group -> Zendesk filter id mappings for helpful links (optional)
 GROUP_FILTERS = {
+  'Account' => '360086130792',
+  'CSD' => '83142177',
+  'CSF' => '278602768',
+  'CSP' => '45749787',
   'Developers' => '47222126',
+  'International' => '360086130812',
   'Learning Platform' => '360082967212',
+  'Media' => '47756566',
   'PLC Tools' => '114103940251',
   'Product' => '360007773991',
   '*Labs' => '301129028',


### PR DESCRIPTION
With the new Zendesk procedures, more teams want the the Daily Zendesk. Josh Schulte gathered requests for a couple weeks and this PR adds all the ones he's collected (so far).

Overall, this was easy to do, but adding a couple of my lessons learned:
- You need the zendesk token out of secrets manager in order to do any interesting tests
- The filters are a bit of a guessing game -- I'm fairly confident on them but not 100% (and I couldn't find a filter for one group)

<!-- ### Background -->
<!-- ### Privacy -->
<!-- ### Security -->
<!-- ### Caching -->
<!-- ### Deployment strategy -->
<!-- ### Future work -->

## Links

<!--
  Any relevant links to external resources; ie, specification documents, jira
  items, related PRs, honeybadger errors, etc
-->

- [spec]()
- [jira]()

## Testing story

<!--
  Does your change include appropriate tests?

  If so, please describe how the tests included in this PR are sufficient

  If not, please explain why this change does not need to be tested.
-->

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
