### PR TITLE
Create Activities Editor Redux

### DIFF
--- a/apps/src/lib/levelbuilder/lesson-editor/activitiesEditorRedux.js
+++ b/apps/src/lib/levelbuilder/lesson-editor/activitiesEditorRedux.js
@@ -202,6 +202,13 @@ function updateLevelPositions(levels) {
 
 export const NEW_LEVEL_ID = -1;
 
+function getLevels(newState, action) {
+  const activitySections =
+    newState[action.activityPosition - 1].activitySections;
+
+  return activitySections[action.activitySectionPosition - 1].levels;
+}
+
 function activities(state = [], action) {
   let newState = _.cloneDeep(state);
 
@@ -209,10 +216,7 @@ function activities(state = [], action) {
     case INIT:
       return action.activities;
     case REORDER_LEVEL: {
-      const activitySections =
-        newState[action.activityPosition - 1].activitySections;
-      const levels =
-        activitySections[action.activitySectionPosition - 1].levels;
+      const levels = getLevels(newState, action);
       const temp = levels.splice(action.originalLevelPosition - 1, 1);
       levels.splice(action.newLevelPosition - 1, 0, temp[0]);
       updateLevelPositions(levels);
@@ -220,10 +224,7 @@ function activities(state = [], action) {
     }
     case MOVE_LEVEL_TO_ACTIVITY_SECTION: {
       //remove level from old activitySection
-      const activitySections =
-        newState[action.activityPosition - 1].activitySections;
-      const levels =
-        activitySections[action.activitySectionPosition - 1].levels;
+      const levels = getLevels(newState, action);
       const level = levels.splice(action.levelPosition - 1, 1)[0];
       updateLevelPositions(levels);
 
@@ -239,9 +240,7 @@ function activities(state = [], action) {
       const newActivitySections =
         newState[newActivityPosition - 1].activitySections;
       const newLevels =
-        newActivitySections[
-          action.newActivitySectionPosition - newActivitySections[0].position
-        ].levels;
+        newActivitySections[action.newActivitySectionPosition - 1].levels;
       newLevels.push(level);
       updateLevelPositions(newLevels);
       break;
@@ -286,48 +285,32 @@ function activities(state = [], action) {
     }
 
     case ADD_LEVEL: {
-      const activitySections =
-        newState[action.activityPosition - 1].activitySections;
-      const levels =
-        activitySections[action.activitySectionPosition - 1].levels;
+      const levels = getLevels(newState, action);
       levels.push(action.level);
       updateLevelPositions(levels);
       break;
     }
     case ADD_VARIANT: {
-      const activitySections =
-        newState[action.activityPosition - 1].activitySections;
-      activitySections[action.activitySectionPosition - 1].levels[
-        action.levelPosition - 1
-      ].ids.push(NEW_LEVEL_ID);
+      const levels = getLevels(newState, action);
+      levels[action.levelPosition - 1].ids.push(NEW_LEVEL_ID);
       break;
     }
     case REMOVE_VARIANT: {
-      const activitySections =
-        newState[action.activityPosition - 1].activitySections;
-      const levelIds =
-        activitySections[action.activitySectionPosition - 1].levels[
-          action.levelPosition - 1
-        ].ids;
+      const levels = getLevels(newState, action);
+      const levelIds = levels[action.levelPosition - 1].ids;
       const i = levelIds.indexOf(action.levelId);
       levelIds.splice(i, 1);
       break;
     }
     case SET_ACTIVE_VARIANT: {
-      const activitySections =
-        newState[action.activityPosition - 1].activitySections;
-      activitySections[action.activitySectionPosition - 1].levels[
-        action.levelPosition - 1
-      ].activeId = action.id;
+      const levels = getLevels(newState, action);
+      levels[action.levelPosition - 1].activeId = action.id;
       break;
     }
     case SET_FIELD: {
       const type = Object.keys(action.modifier)[0];
-      const activitySections =
-        newState[action.activityPosition - 1].activitySections;
-      activitySections[action.activitySectionPosition - 1].levels[
-        action.levelPosition - 1
-      ][type] = action.modifier[type];
+      const levels = getLevels(newState, action);
+      levels[action.levelPosition - 1][type] = action.modifier[type];
       break;
     }
     case REMOVE_ACTIVITY: {
@@ -344,21 +327,14 @@ function activities(state = [], action) {
       break;
     }
     case REMOVE_LEVEL: {
-      const activitySections =
-        newState[action.activityPosition - 1].activitySections;
-      const levels =
-        activitySections[action.activitySectionPosition - 1].levels;
+      const levels = getLevels(newState, action);
       levels.splice(action.levelPosition - 1, 1);
       updateLevelPositions(levels);
       break;
     }
     case CHOOSE_LEVEL: {
-      const activitySections =
-        newState[action.activityPosition - 1].activitySections;
-      const level =
-        activitySections[action.activitySectionPosition - 1].levels[
-          action.levelPosition - 1
-        ];
+      const levels = getLevels(newState, action);
+      const level = levels[action.levelPosition - 1];
       if (level.ids[action.variant] === level.activeId) {
         level.activeId = action.value;
       }
@@ -366,12 +342,8 @@ function activities(state = [], action) {
       break;
     }
     case TOGGLE_EXPAND: {
-      const activitySections =
-        newState[action.activityPosition - 1].activitySections;
-      const level =
-        activitySections[action.activitySectionPosition - 1].levels[
-          action.levelPosition - 1
-        ];
+      const levels = getLevels(newState, action);
+      const level = levels[action.levelPosition - 1];
       level.expand = !level.expand;
       break;
     }

--- a/apps/src/lib/levelbuilder/lesson-editor/activitiesEditorRedux.js
+++ b/apps/src/lib/levelbuilder/lesson-editor/activitiesEditorRedux.js
@@ -1,5 +1,15 @@
 import _ from 'lodash';
 
+function makeActionCreator(type, ...argNames) {
+  return function(...args) {
+    const action = {type};
+    argNames.forEach((arg, index) => {
+      action[argNames[index]] = args[index];
+    });
+    return action;
+  };
+}
+
 const INIT = 'activitiesEditor/INIT';
 const ADD_ACTIVITY = 'activitiesEditor/ADD_ACTIVITY';
 const MOVE_ACTIVITY = 'activitiesEditor/MOVE_ACTIVITY';
@@ -26,216 +36,147 @@ const TOGGLE_EXPAND = 'activitiesEditor/TOGGLE_EXPAND';
 
 // NOTE: Position for Activities, Activity Sections and Levels is 1 based.
 
-export const init = (activities, levelKeyList) => ({
-  type: INIT,
-  activities,
-  levelKeyList
-});
+export const init = makeActionCreator(INIT, 'activities', 'levelkeyList');
+export const addActivity = makeActionCreator(
+  ADD_ACTIVITY,
+  'activityPosition',
+  'activityKey'
+);
+export const updateActivityField = makeActionCreator(
+  UPDATE_ACTIVITY_FIELD,
+  'activityPosition',
+  'fieldName',
+  'fieldValue'
+);
 
-export const addActivity = (activityPosition, activityKey) => ({
-  type: ADD_ACTIVITY,
-  activityPosition,
-  activityKey
-});
+export const updateActivitySectionField = makeActionCreator(
+  UPDATE_ACTIVITY_SECTION_FIELD,
+  'activityPosition',
+  'activitySectionPosition',
+  'fieldName',
+  'fieldValue'
+);
 
-export const updateActivityField = (
-  activityPosition,
-  fieldName,
-  fieldValue
-) => ({
-  type: UPDATE_ACTIVITY_FIELD,
-  activityPosition,
-  fieldName,
-  fieldValue
-});
+export const addActivitySection = makeActionCreator(
+  ADD_ACTIVITY_SECTION,
+  'activityPosition',
+  'activitySectionKey'
+);
 
-export const updateActivitySectionField = (
-  activityPosition,
-  activitySectionPosition,
-  fieldName,
-  fieldValue
-) => ({
-  type: UPDATE_ACTIVITY_SECTION_FIELD,
-  activityPosition,
-  activitySectionPosition,
-  fieldName,
-  fieldValue
-});
+export const toggleExpand = makeActionCreator(
+  TOGGLE_EXPAND,
+  'activityPosition',
+  'activitySectionPosition',
+  'levelPosition'
+);
 
-export const addActivitySection = (activityPosition, activitySectionKey) => ({
-  type: ADD_ACTIVITY_SECTION,
-  activityPosition,
-  activitySectionKey
-});
+export const removeLevel = makeActionCreator(
+  REMOVE_LEVEL,
+  'activityPosition',
+  'activitySectionPosition',
+  'levelPosition'
+);
 
-export const toggleExpand = (
-  activityPosition,
-  activitySectionPosition,
-  levelPosition
-) => ({
-  type: TOGGLE_EXPAND,
-  activityPosition,
-  activitySectionPosition,
-  levelPosition
-});
+export const chooseLevel = makeActionCreator(
+  CHOOSE_LEVEL,
+  'activityPosition',
+  'activitySectionPosition',
+  'levelPosition',
+  'variant',
+  'value'
+);
 
-export const removeLevel = (
-  activityPosition,
-  activitySectionPosition,
-  levelPosition
-) => ({
-  type: REMOVE_LEVEL,
-  activityPosition,
-  activitySectionPosition,
-  levelPosition
-});
+export const addVariant = makeActionCreator(
+  ADD_VARIANT,
+  'activityPosition',
+  'activitySectionPosition',
+  'levelPosition'
+);
 
-export const chooseLevel = (
-  activityPosition,
-  activitySectionPosition,
-  levelPosition,
-  variant,
-  value
-) => ({
-  type: CHOOSE_LEVEL,
-  activityPosition,
-  activitySectionPosition,
-  levelPosition,
-  variant,
-  value
-});
+export const removeVariant = makeActionCreator(
+  REMOVE_VARIANT,
+  'activityPosition',
+  'activitySectionPosition',
+  'levelPosition',
+  'levelId'
+);
 
-export const addVariant = (
-  activityPosition,
-  activitySectionPosition,
-  levelPosition
-) => ({
-  type: ADD_VARIANT,
-  activityPosition,
-  activitySectionPosition,
-  levelPosition
-});
+export const setActiveVariant = makeActionCreator(
+  SET_ACTIVE_VARIANT,
+  'activityPosition',
+  'activitySectionPosition',
+  'levelPosition',
+  'id'
+);
 
-export const removeVariant = (
-  activityPosition,
-  activitySectionPosition,
-  levelPosition,
-  levelId
-) => ({
-  type: REMOVE_VARIANT,
-  activityPosition,
-  activitySectionPosition,
-  levelPosition,
-  levelId
-});
+export const setField = makeActionCreator(
+  SET_FIELD,
+  'activityPosition',
+  'activitySectionPosition',
+  'levelPosition',
+  'modifier'
+);
 
-export const setActiveVariant = (
-  activityPosition,
-  activitySectionPosition,
-  levelPosition,
-  id
-) => ({
-  type: SET_ACTIVE_VARIANT,
-  activityPosition,
-  activitySectionPosition,
-  levelPosition,
-  id
-});
+export const reorderLevel = makeActionCreator(
+  REORDER_LEVEL,
+  'activityPosition',
+  'activitySectionPosition',
+  'originalLevelPosition',
+  'newLevelPosition'
+);
 
-export const setField = (
-  activityPosition,
-  activitySectionPosition,
-  levelPosition,
-  modifier
-) => ({
-  type: SET_FIELD,
-  activityPosition,
-  activitySectionPosition,
-  levelPosition,
-  modifier
-});
+export const moveLevelToActivitySection = makeActionCreator(
+  MOVE_LEVEL_TO_ACTIVITY_SECTION,
+  'activityPosition',
+  'activitySectionPosition',
+  'levelPosition',
+  'newActivitySectionPosition'
+);
 
-export const reorderLevel = (
-  activityPosition,
-  activitySectionPosition,
-  originalLevelPosition,
-  newLevelPosition
-) => ({
-  type: REORDER_LEVEL,
-  activityPosition,
-  activitySectionPosition,
-  originalLevelPosition,
-  newLevelPosition
-});
+export const addLevel = makeActionCreator(
+  ADD_LEVEL,
+  'activityPosition',
+  'activitySectionPosition',
+  'level'
+);
 
-export const moveLevelToActivitySection = (
-  activityPosition,
-  activitySectionPosition,
-  levelPosition,
-  newActivitySectionPosition
-) => ({
-  type: MOVE_LEVEL_TO_ACTIVITY_SECTION,
-  activityPosition,
-  activitySectionPosition,
-  levelPosition,
-  newActivitySectionPosition
-});
+export const moveActivity = makeActionCreator(
+  MOVE_ACTIVITY,
+  'activityPosition',
+  'direction'
+);
 
-export const addLevel = (activityPosition, activitySectionPosition, level) => ({
-  type: ADD_LEVEL,
-  activityPosition,
-  activitySectionPosition,
-  level
-});
+export const moveActivitySection = makeActionCreator(
+  MOVE_ACTIVITY_SECTION,
+  'activityPosition',
+  'activitySectionPosition',
+  'direction'
+);
 
-export const moveActivity = (activityPosition, direction) => ({
-  type: MOVE_ACTIVITY,
-  activityPosition,
-  direction
-});
+export const removeActivity = makeActionCreator(
+  REMOVE_ACTIVITY,
+  'activityPosition'
+);
 
-export const moveActivitySection = (
-  activityPosition,
-  activitySectionPosition,
-  direction
-) => ({
-  type: MOVE_ACTIVITY_SECTION,
-  activityPosition,
-  activitySectionPosition,
-  direction
-});
+export const removeActivitySection = makeActionCreator(
+  REMOVE_ACTIVITY_SECTION,
+  'activityPosition',
+  'activitySectionPosition'
+);
 
-export const removeActivity = activityPosition => ({
-  type: REMOVE_ACTIVITY,
-  activityPosition
-});
+export const setActivity = makeActionCreator(
+  SET_ACTIVITY,
+  'activitySectionPosition',
+  'oldActivityPosition',
+  'newActivityPosition'
+);
 
-export const removeActivitySection = (
-  activityPosition,
-  activitySectionPosition
-) => ({
-  type: REMOVE_ACTIVITY_SECTION,
-  activityPosition,
-  activitySectionPosition
-});
-
-export const setActivity = (
-  activitySectionPosition,
-  oldActivityPosition,
-  newActivityPosition
-) => ({
-  type: SET_ACTIVITY,
-  activitySectionPosition,
-  oldActivityPosition,
-  newActivityPosition
-});
-
-export const addTip = (activityPosition, activitySectionPosition, tip) => ({
-  type: ADD_TIP,
-  activityPosition,
-  activitySectionPosition,
-  tip
-});
+export const addTip = makeActionCreator(
+  ADD_TIP,
+  'activityPosition',
+  'activitySectionPosition',
+  'tip'
+);
 
 function updateActivityPositions(activities) {
   for (let i = 0; i < activities.length; i++) {

--- a/apps/src/lib/levelbuilder/lesson-editor/activitiesEditorRedux.js
+++ b/apps/src/lib/levelbuilder/lesson-editor/activitiesEditorRedux.js
@@ -1,0 +1,555 @@
+import _ from 'lodash';
+
+const INIT = 'activitiesEditor/INIT';
+const ADD_ACTIVITY = 'activitiesEditor/ADD_ACTIVITY';
+const MOVE_ACTIVITY = 'activitiesEditor/MOVE_ACTIVITY';
+const SET_ACTIVITY = 'activitiesEditor/SET_ACTIVITY';
+const REMOVE_ACTIVITY = 'activitiesEditor/REMOVE_ACTIVITY';
+const UPDATE_ACTIVITY_FIELD = 'activitiesEditor/UPDATE_ACTIVITY_FIELD';
+const ADD_ACTIVITY_SECTION = 'activitiesEditor/ADD_ACTIVITY_SECTION';
+const MOVE_ACTIVITY_SECTION = 'activitiesEditor/MOVE_ACTIVITY_SECTION';
+const REMOVE_ACTIVITY_SECTION = 'activitiesEditor/REMOVE_ACTIVITY_SECTION';
+const UPDATE_ACTIVITY_SECTION_FIELD =
+  'activitiesEditor/UPDATE_ACTIVITY_SECTION_FIELD';
+const ADD_TIP = 'activitiesEditor/ADD_TIP';
+const ADD_LEVEL = 'activitiesEditor/ADD_LEVEL';
+const REMOVE_LEVEL = 'activitiesEditor/REMOVE_LEVEL';
+const CHOOSE_LEVEL = 'activitiesEditor/CHOOSE_LEVEL';
+const REORDER_LEVEL = 'activitiesEditor/REORDER_LEVEL';
+const MOVE_LEVEL_TO_ACTIVITY_SECTION =
+  'activitiesEditor/MOVE_LEVEL_TO_ACTIVITY_SECTION';
+const ADD_VARIANT = 'activitiesEditor/ADD_VARIANT';
+const SET_ACTIVE_VARIANT = 'activitiesEditor/SET_ACTIVE_VARIANT';
+const REMOVE_VARIANT = 'activitiesEditor/REMOVE_VARIANT';
+const SET_FIELD = 'activitiesEditor/SET_FIELD';
+const TOGGLE_EXPAND = 'activitiesEditor/TOGGLE_EXPAND';
+
+// NOTE: Position for Activities, Activity Sections and Levels is 1 based.
+
+export const init = (activities, levelKeyList) => ({
+  type: INIT,
+  activities,
+  levelKeyList
+});
+
+export const addActivity = (activityPosition, activityKey) => ({
+  type: ADD_ACTIVITY,
+  activityPosition,
+  activityKey
+});
+
+export const updateActivityField = (
+  activityPosition,
+  fieldName,
+  fieldValue
+) => ({
+  type: UPDATE_ACTIVITY_FIELD,
+  activityPosition,
+  fieldName,
+  fieldValue
+});
+
+export const updateActivitySectionField = (
+  activityPosition,
+  activitySectionPosition,
+  fieldName,
+  fieldValue
+) => ({
+  type: UPDATE_ACTIVITY_SECTION_FIELD,
+  activityPosition,
+  activitySectionPosition,
+  fieldName,
+  fieldValue
+});
+
+export const addActivitySection = (activityPosition, activitySectionKey) => ({
+  type: ADD_ACTIVITY_SECTION,
+  activityPosition,
+  activitySectionKey
+});
+
+export const toggleExpand = (
+  activityPosition,
+  activitySectionPosition,
+  levelPosition
+) => ({
+  type: TOGGLE_EXPAND,
+  activityPosition,
+  activitySectionPosition,
+  levelPosition
+});
+
+export const removeLevel = (
+  activityPosition,
+  activitySectionPosition,
+  levelPosition
+) => ({
+  type: REMOVE_LEVEL,
+  activityPosition,
+  activitySectionPosition,
+  levelPosition
+});
+
+export const chooseLevel = (
+  activityPosition,
+  activitySectionPosition,
+  levelPosition,
+  variant,
+  value
+) => ({
+  type: CHOOSE_LEVEL,
+  activityPosition,
+  activitySectionPosition,
+  levelPosition,
+  variant,
+  value
+});
+
+export const addVariant = (
+  activityPosition,
+  activitySectionPosition,
+  levelPosition
+) => ({
+  type: ADD_VARIANT,
+  activityPosition,
+  activitySectionPosition,
+  levelPosition
+});
+
+export const removeVariant = (
+  activityPosition,
+  activitySectionPosition,
+  levelPosition,
+  levelId
+) => ({
+  type: REMOVE_VARIANT,
+  activityPosition,
+  activitySectionPosition,
+  levelPosition,
+  levelId
+});
+
+export const setActiveVariant = (
+  activityPosition,
+  activitySectionPosition,
+  levelPosition,
+  id
+) => ({
+  type: SET_ACTIVE_VARIANT,
+  activityPosition,
+  activitySectionPosition,
+  levelPosition,
+  id
+});
+
+export const setField = (
+  activityPosition,
+  activitySectionPosition,
+  levelPosition,
+  modifier
+) => ({
+  type: SET_FIELD,
+  activityPosition,
+  activitySectionPosition,
+  levelPosition,
+  modifier
+});
+
+export const reorderLevel = (
+  activityPosition,
+  activitySectionPosition,
+  originalLevelPosition,
+  newLevelPosition
+) => ({
+  type: REORDER_LEVEL,
+  activityPosition,
+  activitySectionPosition,
+  originalLevelPosition,
+  newLevelPosition
+});
+
+export const moveLevelToActivitySection = (
+  activityPosition,
+  activitySectionPosition,
+  levelPosition,
+  newActivitySectionPosition
+) => ({
+  type: MOVE_LEVEL_TO_ACTIVITY_SECTION,
+  activityPosition,
+  activitySectionPosition,
+  levelPosition,
+  newActivitySectionPosition
+});
+
+export const addLevel = (activityPosition, activitySectionPosition, level) => ({
+  type: ADD_LEVEL,
+  activityPosition,
+  activitySectionPosition,
+  level
+});
+
+export const moveActivity = (activityPosition, direction) => ({
+  type: MOVE_ACTIVITY,
+  activityPosition,
+  direction
+});
+
+export const moveActivitySection = (
+  activityPosition,
+  activitySectionPosition,
+  direction
+) => ({
+  type: MOVE_ACTIVITY_SECTION,
+  activityPosition,
+  activitySectionPosition,
+  direction
+});
+
+export const removeActivity = activityPosition => ({
+  type: REMOVE_ACTIVITY,
+  activityPosition
+});
+
+export const removeActivitySection = (
+  activityPosition,
+  activitySectionPosition
+) => ({
+  type: REMOVE_ACTIVITY_SECTION,
+  activityPosition,
+  activitySectionPosition
+});
+
+export const setActivity = (
+  activitySectionPosition,
+  oldActivityPosition,
+  newActivityPosition
+) => ({
+  type: SET_ACTIVITY,
+  activitySectionPosition,
+  oldActivityPosition,
+  newActivityPosition
+});
+
+export const addTip = (activityPosition, activitySectionPosition, tip) => ({
+  type: ADD_TIP,
+  activityPosition,
+  activitySectionPosition,
+  tip
+});
+
+function updateActivityPositions(activities) {
+  for (let i = 0; i < activities.length; i++) {
+    activities[i].position = i + 1;
+  }
+}
+
+function updateActivitySectionPositions(activities) {
+  activities.forEach(activity => {
+    let position = 1;
+    activity.activitySections.forEach(activitySection => {
+      activitySection.position = position;
+      position++;
+    });
+  });
+}
+
+function updateLevelPositions(levels) {
+  for (let i = 0; i < levels.length; i++) {
+    levels[i].position = i + 1;
+  }
+}
+
+export const NEW_LEVEL_ID = -1;
+
+function activities(state = [], action) {
+  let newState = _.cloneDeep(state);
+
+  switch (action.type) {
+    case INIT:
+      return action.activities;
+    case REORDER_LEVEL: {
+      const activitySections =
+        newState[action.activityPosition - 1].activitySections;
+      const levels =
+        activitySections[action.activitySectionPosition - 1].levels;
+      const temp = levels.splice(action.originalLevelPosition - 1, 1);
+      levels.splice(action.newLevelPosition - 1, 0, temp[0]);
+      updateLevelPositions(levels);
+      break;
+    }
+    case MOVE_LEVEL_TO_ACTIVITY_SECTION: {
+      //remove level from old activitySection
+      const activitySections =
+        newState[action.activityPosition - 1].activitySections;
+      const levels =
+        activitySections[action.activitySectionPosition - 1].levels;
+      const level = levels.splice(action.levelPosition - 1, 1)[0];
+      updateLevelPositions(levels);
+
+      // add level to new activitySection
+      let newActivityPosition = null;
+      newState.forEach(activity => {
+        activity.activitySections.forEach(activitySection => {
+          if (activitySection.position === action.newActivitySectionPosition) {
+            newActivityPosition = activity.position;
+          }
+        });
+      });
+      const newActivitySections =
+        newState[newActivityPosition - 1].activitySections;
+      const newLevels =
+        newActivitySections[
+          action.newActivitySectionPosition - newActivitySections[0].position
+        ].levels;
+      newLevels.push(level);
+      updateLevelPositions(newLevels);
+      break;
+    }
+    case ADD_ACTIVITY: {
+      newState.push({
+        key: action.activityKey,
+        displayName: '',
+        position: action.activityPosition,
+        time: 0,
+        activitySections: []
+      });
+      updateActivityPositions(newState);
+      break;
+    }
+    case UPDATE_ACTIVITY_FIELD: {
+      newState[action.activityPosition - 1][action.fieldName] =
+        action.fieldValue;
+      break;
+    }
+    case UPDATE_ACTIVITY_SECTION_FIELD: {
+      const activitySections =
+        newState[action.activityPosition - 1].activitySections;
+      activitySections[action.activitySectionPosition - 1][action.fieldName] =
+        action.fieldValue;
+      break;
+    }
+    case ADD_ACTIVITY_SECTION: {
+      const activitySections =
+        newState[action.activityPosition - 1].activitySections;
+      activitySections.push({
+        key: action.activitySectionKey,
+        title: '',
+        levels: [],
+        tips: [],
+        remarks: false,
+        slide: false,
+        text: ''
+      });
+      updateActivitySectionPositions(newState);
+      break;
+    }
+
+    case ADD_LEVEL: {
+      const activitySections =
+        newState[action.activityPosition - 1].activitySections;
+      const levels =
+        activitySections[action.activitySectionPosition - 1].levels;
+      levels.push(action.level);
+      updateLevelPositions(levels);
+      break;
+    }
+    case ADD_VARIANT: {
+      const activitySections =
+        newState[action.activityPosition - 1].activitySections;
+      activitySections[action.activitySectionPosition - 1].levels[
+        action.levelPosition - 1
+      ].ids.push(NEW_LEVEL_ID);
+      break;
+    }
+    case REMOVE_VARIANT: {
+      const activitySections =
+        newState[action.activityPosition - 1].activitySections;
+      const levelIds =
+        activitySections[action.activitySectionPosition - 1].levels[
+          action.levelPosition - 1
+        ].ids;
+      const i = levelIds.indexOf(action.levelId);
+      levelIds.splice(i, 1);
+      break;
+    }
+    case SET_ACTIVE_VARIANT: {
+      const activitySections =
+        newState[action.activityPosition - 1].activitySections;
+      activitySections[action.activitySectionPosition - 1].levels[
+        action.levelPosition - 1
+      ].activeId = action.id;
+      break;
+    }
+    case SET_FIELD: {
+      const type = Object.keys(action.modifier)[0];
+      const activitySections =
+        newState[action.activityPosition - 1].activitySections;
+      activitySections[action.activitySectionPosition - 1].levels[
+        action.levelPosition - 1
+      ][type] = action.modifier[type];
+      break;
+    }
+    case REMOVE_ACTIVITY: {
+      newState.splice(action.activityPosition - 1, 1);
+      updateActivityPositions(newState);
+      updateActivitySectionPositions(newState);
+      break;
+    }
+    case REMOVE_ACTIVITY_SECTION: {
+      const activitySections =
+        newState[action.activityPosition - 1].activitySections;
+      activitySections.splice(action.activitySectionPosition - 1, 1);
+      updateActivitySectionPositions(newState);
+      break;
+    }
+    case REMOVE_LEVEL: {
+      const activitySections =
+        newState[action.activityPosition - 1].activitySections;
+      const levels =
+        activitySections[action.activitySectionPosition - 1].levels;
+      levels.splice(action.levelPosition - 1, 1);
+      updateLevelPositions(levels);
+      break;
+    }
+    case CHOOSE_LEVEL: {
+      const activitySections =
+        newState[action.activityPosition - 1].activitySections;
+      const level =
+        activitySections[action.activitySectionPosition - 1].levels[
+          action.levelPosition - 1
+        ];
+      if (level.ids[action.variant] === level.activeId) {
+        level.activeId = action.value;
+      }
+      level.ids[action.variant] = action.value;
+      break;
+    }
+    case TOGGLE_EXPAND: {
+      const activitySections =
+        newState[action.activityPosition - 1].activitySections;
+      const level =
+        activitySections[action.activitySectionPosition - 1].levels[
+          action.levelPosition - 1
+        ];
+      level.expand = !level.expand;
+      break;
+    }
+    case MOVE_ACTIVITY: {
+      if (
+        action.direction !== 'up' &&
+        action.activityPosition === newState.length
+      ) {
+        break;
+      }
+      const index = action.activityPosition - 1;
+      const swap = action.direction === 'up' ? index - 1 : index + 1;
+      const tempActivity = newState[index];
+      newState[index] = newState[swap];
+      newState[swap] = tempActivity;
+      updateActivityPositions(newState);
+      updateActivitySectionPositions(newState);
+      break;
+    }
+    case MOVE_ACTIVITY_SECTION: {
+      const activityIndex = action.activityPosition - 1;
+
+      const activitySections = newState[activityIndex].activitySections;
+
+      const activitySectionIndex = action.activitySectionPosition - 1;
+      const activitySectionSwapIndex =
+        action.direction === 'up'
+          ? activitySectionIndex - 1
+          : activitySectionIndex + 1;
+
+      if (
+        activitySectionSwapIndex >= 0 &&
+        activitySectionSwapIndex <= activitySections.length - 1
+      ) {
+        //if activitySection is staying in the same activity
+        const tempActivitySection = activitySections[activitySectionIndex];
+        activitySections[activitySectionIndex] =
+          activitySections[activitySectionSwapIndex];
+        activitySections[activitySectionSwapIndex] = tempActivitySection;
+      } else {
+        const activitySwapIndex =
+          action.direction === 'up' ? activityIndex - 1 : activityIndex + 1;
+
+        // Remove the activitySection from the old activity
+        const oldActivitySections = newState[activityIndex].activitySections;
+        const curActivitySection = oldActivitySections.splice(
+          activitySectionIndex,
+          1
+        )[0];
+
+        // add activitySection to the new activity
+        const newActivitySections =
+          newState[activitySwapIndex].activitySections;
+        action.direction === 'up'
+          ? newActivitySections.push(curActivitySection)
+          : newActivitySections.unshift(curActivitySection);
+      }
+      updateActivitySectionPositions(newState);
+      break;
+    }
+    case SET_ACTIVITY: {
+      // Remove the activitySection from the old activity
+      const oldActivitySections =
+        newState[action.oldActivityPosition - 1].activitySections;
+      const curActivitySection = oldActivitySections.splice(
+        action.activitySectionPosition - 1,
+        1
+      )[0];
+
+      // add activitySection to the new activity
+      const newActivitySections =
+        newState[action.newActivityPosition - 1].activitySections;
+      newActivitySections.push(curActivitySection);
+      updateActivitySectionPositions(newState);
+
+      break;
+    }
+    case ADD_TIP: {
+      const activitySections =
+        newState[action.activityPosition - 1].activitySections;
+      activitySections[action.activitySectionPosition - 1].tips.push(
+        action.tip
+      );
+      break;
+    }
+  }
+
+  return newState;
+}
+
+function levelKeyList(state = {}, action) {
+  switch (action.type) {
+    case INIT:
+      return action.levelKeyList;
+  }
+  return state;
+}
+
+function levelNameToIdMap(state = {}, action) {
+  switch (action.type) {
+    case INIT: {
+      if (!action.levelKeyList) {
+        // This can be falsy if the new editor experiment is not enabled
+        return state;
+      }
+
+      const levelNameToIdMap = {};
+      Object.keys(action.levelKeyList).forEach(levelId => {
+        const levelKey = action.levelKeyList[levelId];
+        levelNameToIdMap[levelKey] = +levelId;
+      });
+      return levelNameToIdMap;
+    }
+  }
+  return state;
+}
+
+export default {
+  activities,
+  levelKeyList,
+  levelNameToIdMap
+};

--- a/apps/src/lib/levelbuilder/lesson-editor/activitiesEditorRedux.js
+++ b/apps/src/lib/levelbuilder/lesson-editor/activitiesEditorRedux.js
@@ -1,15 +1,5 @@
 import _ from 'lodash';
 
-function makeActionCreator(type, ...argNames) {
-  return function(...args) {
-    const action = {type};
-    argNames.forEach((arg, index) => {
-      action[argNames[index]] = args[index];
-    });
-    return action;
-  };
-}
-
 const INIT = 'activitiesEditor/INIT';
 const ADD_ACTIVITY = 'activitiesEditor/ADD_ACTIVITY';
 const MOVE_ACTIVITY = 'activitiesEditor/MOVE_ACTIVITY';
@@ -36,147 +26,216 @@ const TOGGLE_EXPAND = 'activitiesEditor/TOGGLE_EXPAND';
 
 // NOTE: Position for Activities, Activity Sections and Levels is 1 based.
 
-export const init = makeActionCreator(INIT, 'activities', 'levelkeyList');
-export const addActivity = makeActionCreator(
-  ADD_ACTIVITY,
-  'activityPosition',
-  'activityKey'
-);
-export const updateActivityField = makeActionCreator(
-  UPDATE_ACTIVITY_FIELD,
-  'activityPosition',
-  'fieldName',
-  'fieldValue'
-);
+export const init = (activities, levelKeyList) => ({
+  type: INIT,
+  activities,
+  levelKeyList
+});
 
-export const updateActivitySectionField = makeActionCreator(
-  UPDATE_ACTIVITY_SECTION_FIELD,
-  'activityPosition',
-  'activitySectionPosition',
-  'fieldName',
-  'fieldValue'
-);
+export const addActivity = (activityPosition, activityKey) => ({
+  type: ADD_ACTIVITY,
+  activityPosition,
+  activityKey
+});
 
-export const addActivitySection = makeActionCreator(
-  ADD_ACTIVITY_SECTION,
-  'activityPosition',
-  'activitySectionKey'
-);
+export const updateActivityField = (
+  activityPosition,
+  fieldName,
+  fieldValue
+) => ({
+  type: UPDATE_ACTIVITY_FIELD,
+  activityPosition,
+  fieldName,
+  fieldValue
+});
 
-export const toggleExpand = makeActionCreator(
-  TOGGLE_EXPAND,
-  'activityPosition',
-  'activitySectionPosition',
-  'levelPosition'
-);
+export const updateActivitySectionField = (
+  activityPosition,
+  activitySectionPosition,
+  fieldName,
+  fieldValue
+) => ({
+  type: UPDATE_ACTIVITY_SECTION_FIELD,
+  activityPosition,
+  activitySectionPosition,
+  fieldName,
+  fieldValue
+});
 
-export const removeLevel = makeActionCreator(
-  REMOVE_LEVEL,
-  'activityPosition',
-  'activitySectionPosition',
-  'levelPosition'
-);
+export const addActivitySection = (activityPosition, activitySectionKey) => ({
+  type: ADD_ACTIVITY_SECTION,
+  activityPosition,
+  activitySectionKey
+});
 
-export const chooseLevel = makeActionCreator(
-  CHOOSE_LEVEL,
-  'activityPosition',
-  'activitySectionPosition',
-  'levelPosition',
-  'variant',
-  'value'
-);
+export const toggleExpand = (
+  activityPosition,
+  activitySectionPosition,
+  levelPosition
+) => ({
+  type: TOGGLE_EXPAND,
+  activityPosition,
+  activitySectionPosition,
+  levelPosition
+});
 
-export const addVariant = makeActionCreator(
-  ADD_VARIANT,
-  'activityPosition',
-  'activitySectionPosition',
-  'levelPosition'
-);
+export const removeLevel = (
+  activityPosition,
+  activitySectionPosition,
+  levelPosition
+) => ({
+  type: REMOVE_LEVEL,
+  activityPosition,
+  activitySectionPosition,
+  levelPosition
+});
 
-export const removeVariant = makeActionCreator(
-  REMOVE_VARIANT,
-  'activityPosition',
-  'activitySectionPosition',
-  'levelPosition',
-  'levelId'
-);
+export const chooseLevel = (
+  activityPosition,
+  activitySectionPosition,
+  levelPosition,
+  variant,
+  value
+) => ({
+  type: CHOOSE_LEVEL,
+  activityPosition,
+  activitySectionPosition,
+  levelPosition,
+  variant,
+  value
+});
 
-export const setActiveVariant = makeActionCreator(
-  SET_ACTIVE_VARIANT,
-  'activityPosition',
-  'activitySectionPosition',
-  'levelPosition',
-  'id'
-);
+export const addVariant = (
+  activityPosition,
+  activitySectionPosition,
+  levelPosition
+) => ({
+  type: ADD_VARIANT,
+  activityPosition,
+  activitySectionPosition,
+  levelPosition
+});
 
-export const setField = makeActionCreator(
-  SET_FIELD,
-  'activityPosition',
-  'activitySectionPosition',
-  'levelPosition',
-  'modifier'
-);
+export const removeVariant = (
+  activityPosition,
+  activitySectionPosition,
+  levelPosition,
+  levelId
+) => ({
+  type: REMOVE_VARIANT,
+  activityPosition,
+  activitySectionPosition,
+  levelPosition,
+  levelId
+});
 
-export const reorderLevel = makeActionCreator(
-  REORDER_LEVEL,
-  'activityPosition',
-  'activitySectionPosition',
-  'originalLevelPosition',
-  'newLevelPosition'
-);
+export const setActiveVariant = (
+  activityPosition,
+  activitySectionPosition,
+  levelPosition,
+  id
+) => ({
+  type: SET_ACTIVE_VARIANT,
+  activityPosition,
+  activitySectionPosition,
+  levelPosition,
+  id
+});
 
-export const moveLevelToActivitySection = makeActionCreator(
-  MOVE_LEVEL_TO_ACTIVITY_SECTION,
-  'activityPosition',
-  'activitySectionPosition',
-  'levelPosition',
-  'newActivitySectionPosition'
-);
+export const setField = (
+  activityPosition,
+  activitySectionPosition,
+  levelPosition,
+  modifier
+) => ({
+  type: SET_FIELD,
+  activityPosition,
+  activitySectionPosition,
+  levelPosition,
+  modifier
+});
 
-export const addLevel = makeActionCreator(
-  ADD_LEVEL,
-  'activityPosition',
-  'activitySectionPosition',
-  'level'
-);
+export const reorderLevel = (
+  activityPosition,
+  activitySectionPosition,
+  originalLevelPosition,
+  newLevelPosition
+) => ({
+  type: REORDER_LEVEL,
+  activityPosition,
+  activitySectionPosition,
+  originalLevelPosition,
+  newLevelPosition
+});
 
-export const moveActivity = makeActionCreator(
-  MOVE_ACTIVITY,
-  'activityPosition',
-  'direction'
-);
+export const moveLevelToActivitySection = (
+  activityPosition,
+  activitySectionPosition,
+  levelPosition,
+  newActivitySectionPosition
+) => ({
+  type: MOVE_LEVEL_TO_ACTIVITY_SECTION,
+  activityPosition,
+  activitySectionPosition,
+  levelPosition,
+  newActivitySectionPosition
+});
 
-export const moveActivitySection = makeActionCreator(
-  MOVE_ACTIVITY_SECTION,
-  'activityPosition',
-  'activitySectionPosition',
-  'direction'
-);
+export const addLevel = (activityPosition, activitySectionPosition, level) => ({
+  type: ADD_LEVEL,
+  activityPosition,
+  activitySectionPosition,
+  level
+});
 
-export const removeActivity = makeActionCreator(
-  REMOVE_ACTIVITY,
-  'activityPosition'
-);
+export const moveActivity = (activityPosition, direction) => ({
+  type: MOVE_ACTIVITY,
+  activityPosition,
+  direction
+});
 
-export const removeActivitySection = makeActionCreator(
-  REMOVE_ACTIVITY_SECTION,
-  'activityPosition',
-  'activitySectionPosition'
-);
+export const moveActivitySection = (
+  activityPosition,
+  activitySectionPosition,
+  direction
+) => ({
+  type: MOVE_ACTIVITY_SECTION,
+  activityPosition,
+  activitySectionPosition,
+  direction
+});
 
-export const setActivity = makeActionCreator(
-  SET_ACTIVITY,
-  'activitySectionPosition',
-  'oldActivityPosition',
-  'newActivityPosition'
-);
+export const removeActivity = activityPosition => ({
+  type: REMOVE_ACTIVITY,
+  activityPosition
+});
 
-export const addTip = makeActionCreator(
-  ADD_TIP,
-  'activityPosition',
-  'activitySectionPosition',
-  'tip'
-);
+export const removeActivitySection = (
+  activityPosition,
+  activitySectionPosition
+) => ({
+  type: REMOVE_ACTIVITY_SECTION,
+  activityPosition,
+  activitySectionPosition
+});
+
+export const setActivity = (
+  activitySectionPosition,
+  oldActivityPosition,
+  newActivityPosition
+) => ({
+  type: SET_ACTIVITY,
+  activitySectionPosition,
+  oldActivityPosition,
+  newActivityPosition
+});
+
+export const addTip = (activityPosition, activitySectionPosition, tip) => ({
+  type: ADD_TIP,
+  activityPosition,
+  activitySectionPosition,
+  tip
+});
 
 function updateActivityPositions(activities) {
   for (let i = 0; i < activities.length; i++) {

--- a/apps/test/unit/lib/levelbuilder/lesson-editor/activitiesEditorReduxTest.js
+++ b/apps/test/unit/lib/levelbuilder/lesson-editor/activitiesEditorReduxTest.js
@@ -1,0 +1,705 @@
+import {assert} from 'chai';
+import {combineReducers} from 'redux';
+import reducers, {
+  addActivity,
+  moveActivity,
+  setActivity,
+  removeActivity,
+  updateActivityField,
+  addActivitySection,
+  moveActivitySection,
+  removeActivitySection,
+  updateActivitySectionField,
+  addTip,
+  addLevel,
+  removeLevel,
+  setActiveVariant,
+  setField,
+  reorderLevel,
+  moveLevelToActivitySection,
+  NEW_LEVEL_ID
+} from '@cdo/apps/lib/levelbuilder/lesson-editor/activitiesEditorRedux';
+import {sampleActivities} from './activitiesTestData';
+
+const getInitialState = () => ({
+  levelKeyList: {},
+  activities: sampleActivities
+});
+
+const reducer = combineReducers(reducers);
+
+describe('activitiesEditorRedux reducer tests', () => {
+  let initialState;
+  beforeEach(() => (initialState = getInitialState()));
+
+  it('add tip', () => {
+    const nextState = reducer(
+      initialState,
+      addTip(1, 2, {
+        type: 'contentCorner',
+        markdown: 'Programming is about solving puzzles.'
+      })
+    ).activities;
+    assert.deepEqual(nextState[0].activitySections[1].tips.map(s => s.type), [
+      'teachingTip',
+      'contentCorner'
+    ]);
+  });
+
+  describe('levels', () => {
+    it('reorder levels', () => {
+      const nextState = reducer(initialState, reorderLevel(1, 3, 2, 1))
+        .activities;
+      assert.deepEqual(
+        nextState[0].activitySections[2].levels.map(l => l.activeId),
+        [2, 1]
+      );
+    });
+
+    it('moves level to activitySection', () => {
+      const nextState = reducer(
+        initialState,
+        moveLevelToActivitySection(1, 3, 2, 2)
+      ).activities;
+      assert.deepEqual(
+        nextState[0].activitySections[1].levels.map(l => l.activeId),
+        [2]
+      );
+      assert.deepEqual(
+        nextState[0].activitySections[2].levels.map(l => l.activeId),
+        [1]
+      );
+    });
+
+    it('add level', () => {
+      const nextState = reducer(
+        initialState,
+        addLevel(1, 3, {
+          name: 'Level 3',
+          levelNumber: 3,
+          position: 3,
+          icon: 'fa-desktop',
+          ids: [NEW_LEVEL_ID],
+          activeId: NEW_LEVEL_ID,
+          kind: 'puzzle',
+          status: 'not started',
+          url: 'https://levelbuilder-studio.code.org/levels/598/edit',
+          isUnplugged: false,
+          isCurrentLevel: false,
+          isConceptLevel: false,
+          named: false,
+          assessment: false,
+          challenge: false,
+          sublevels: [],
+          skin: null,
+          videoKey: null,
+          concepts: '',
+          conceptDifficulty: ''
+        })
+      ).activities;
+      assert.deepEqual(
+        nextState[0].activitySections[2].levels.map(s => s.name),
+        ['Level 1', 'Level 2', 'Level 3']
+      );
+    });
+
+    it('remove level', () => {
+      const nextState = reducer(initialState, removeLevel(1, 3, 1)).activities;
+      assert.deepEqual(
+        nextState[0].activitySections[2].levels.map(s => s.name),
+        ['Level 2']
+      );
+    });
+
+    it('set active variant', () => {
+      const nextState = reducer(initialState, setActiveVariant(1, 3, 1, 2))
+        .activities;
+      assert.equal(nextState[0].activitySections[2].levels[0].activeId, 2);
+    });
+
+    it('set level field', () => {
+      let nextState = reducer(
+        initialState,
+        setField(1, 3, 1, {videoKey: '_a_'})
+      );
+      assert.equal(
+        nextState.activities[0].activitySections[2].levels[0].videoKey,
+        '_a_'
+      );
+      nextState = reducer(nextState, setField(1, 3, 1, {skin: '_b_'}));
+      assert.equal(
+        nextState.activities[0].activitySections[2].levels[0].skin,
+        '_b_'
+      );
+      nextState = reducer(
+        nextState,
+        setField(1, 3, 1, {conceptDifficulty: '_c_'})
+      );
+      assert.equal(
+        nextState.activities[0].activitySections[2].levels[0].conceptDifficulty,
+        '_c_'
+      );
+      nextState = reducer(nextState, setField(1, 3, 1, {concepts: '_d_'}));
+      assert.equal(
+        nextState.activities[0].activitySections[2].levels[0].concepts,
+        '_d_'
+      );
+    });
+  });
+
+  describe('activities', () => {
+    let initialActivities = [];
+
+    beforeEach(() => {
+      initialActivities = [
+        {
+          key: 'x',
+          displayName: 'X',
+          position: 1,
+          activitySections: [
+            {key: 'a', position: 1, displayName: 'A'},
+            {key: 'b', position: 2, displayName: 'B'}
+          ]
+        },
+        {
+          key: 'y',
+          displayName: 'Y',
+          position: 2,
+          activitySections: [
+            {key: 'c', position: 1, displayName: 'C'},
+            {key: 'd', position: 2, displayName: 'D'}
+          ]
+        }
+      ];
+      initialState.activities = initialActivities;
+    });
+
+    it('add activity', () => {
+      const nextState = reducer(initialState, addActivity(3, 'key')).activities;
+      assert.equal(nextState[nextState.length - 1].displayName, '');
+      assert.equal(nextState[nextState.length - 1].key, 'key');
+    });
+
+    it('update activity field', () => {
+      let state = reducer(initialState, updateActivityField(1, 'time', 100));
+      assert.deepEqual(
+        [
+          {
+            key: 'x',
+            displayName: 'X',
+            position: 1,
+            time: 100,
+            activitySections: [
+              {key: 'a', position: 1, displayName: 'A'},
+              {key: 'b', position: 2, displayName: 'B'}
+            ]
+          },
+          {
+            key: 'y',
+            displayName: 'Y',
+            position: 2,
+            activitySections: [
+              {key: 'c', position: 1, displayName: 'C'},
+              {key: 'd', position: 2, displayName: 'D'}
+            ]
+          }
+        ],
+        state.activities
+      );
+    });
+
+    it('removes activity', () => {
+      let state = reducer(initialState, removeActivity(1));
+      assert.deepEqual(
+        [
+          {
+            key: 'y',
+            displayName: 'Y',
+            position: 1,
+            activitySections: [
+              {key: 'c', position: 1, displayName: 'C'},
+              {key: 'd', position: 2, displayName: 'D'}
+            ]
+          }
+        ],
+        state.activities
+      );
+    });
+
+    it('moves activity', () => {
+      let state = reducer(initialState, moveActivity(2, 'up'));
+      assert.deepEqual(
+        [
+          {
+            key: 'y',
+            displayName: 'Y',
+            position: 1,
+            activitySections: [
+              {key: 'c', position: 1, displayName: 'C'},
+              {key: 'd', position: 2, displayName: 'D'}
+            ]
+          },
+          {
+            key: 'x',
+            displayName: 'X',
+            position: 2,
+            activitySections: [
+              {key: 'a', position: 1, displayName: 'A'},
+              {key: 'b', position: 2, displayName: 'B'}
+            ]
+          }
+        ],
+        state.activities
+      );
+
+      state = reducer(state, moveActivity(1, 'down'));
+      assert.deepEqual(
+        [
+          {
+            key: 'x',
+            displayName: 'X',
+            position: 1,
+            activitySections: [
+              {key: 'a', position: 1, displayName: 'A'},
+              {key: 'b', position: 2, displayName: 'B'}
+            ]
+          },
+          {
+            key: 'y',
+            displayName: 'Y',
+            position: 2,
+            activitySections: [
+              {key: 'c', position: 1, displayName: 'C'},
+              {key: 'd', position: 2, displayName: 'D'}
+            ]
+          }
+        ],
+        state.activities
+      );
+    });
+
+    it('moves a activitySection up three times', () => {
+      const key = 'd';
+      let activityPosition = initialState.activities.find(activity =>
+        activity.activitySections.find(
+          activitySection => activitySection.key === key
+        )
+      ).position;
+      let activitySectionPosition = initialState.activities[
+        activityPosition - 1
+      ].activitySections.find(activitySection => activitySection.key === key)
+        .position;
+      let state = reducer(
+        initialState,
+        moveActivitySection(activityPosition, activitySectionPosition, 'up')
+      );
+      assert.deepEqual(
+        [
+          {
+            key: 'x',
+            displayName: 'X',
+            position: 1,
+            activitySections: [
+              {key: 'a', position: 1, displayName: 'A'},
+              {key: 'b', position: 2, displayName: 'B'}
+            ]
+          },
+          {
+            key: 'y',
+            displayName: 'Y',
+            position: 2,
+            activitySections: [
+              {key: 'd', position: 1, displayName: 'D'},
+              {key: 'c', position: 2, displayName: 'C'}
+            ]
+          }
+        ],
+        state.activities,
+        'first move changes position but not activity'
+      );
+
+      activityPosition = state.activities.find(activity =>
+        activity.activitySections.find(
+          activitySection => activitySection.key === key
+        )
+      ).position;
+      activitySectionPosition = state.activities[
+        activityPosition - 1
+      ].activitySections.find(activitySection => activitySection.key === key)
+        .position;
+      state = reducer(
+        state,
+        moveActivitySection(activityPosition, activitySectionPosition, 'up')
+      );
+      assert.deepEqual(
+        [
+          {
+            key: 'x',
+            displayName: 'X',
+            position: 1,
+            activitySections: [
+              {key: 'a', position: 1, displayName: 'A'},
+              {key: 'b', position: 2, displayName: 'B'},
+              {key: 'd', position: 3, displayName: 'D'}
+            ]
+          },
+          {
+            key: 'y',
+            displayName: 'Y',
+            position: 2,
+            activitySections: [{key: 'c', position: 1, displayName: 'C'}]
+          }
+        ],
+        state.activities,
+        'second move changes activity but not position'
+      );
+
+      activityPosition = state.activities.find(activity =>
+        activity.activitySections.find(
+          activitySection => activitySection.key === key
+        )
+      ).position;
+      activitySectionPosition = state.activities[
+        activityPosition - 1
+      ].activitySections.find(activitySection => activitySection.key === key)
+        .position;
+      state = reducer(
+        state,
+        moveActivitySection(activityPosition, activitySectionPosition, 'up')
+      );
+      assert.deepEqual(
+        [
+          {
+            key: 'x',
+            displayName: 'X',
+            position: 1,
+            activitySections: [
+              {key: 'a', position: 1, displayName: 'A'},
+              {key: 'd', position: 2, displayName: 'D'},
+              {key: 'b', position: 3, displayName: 'B'}
+            ]
+          },
+          {
+            key: 'y',
+            displayName: 'Y',
+            position: 2,
+            activitySections: [{key: 'c', position: 1, displayName: 'C'}]
+          }
+        ],
+        state.activities,
+        'third move changes position but not activity'
+      );
+    });
+
+    it('remove activity section', () => {
+      let state = reducer(initialState, removeActivitySection(1, 2));
+      assert.deepEqual(
+        [
+          {
+            key: 'x',
+            displayName: 'X',
+            position: 1,
+            activitySections: [{key: 'a', position: 1, displayName: 'A'}]
+          },
+          {
+            key: 'y',
+            displayName: 'Y',
+            position: 2,
+            activitySections: [
+              {key: 'c', position: 1, displayName: 'C'},
+              {key: 'd', position: 2, displayName: 'D'}
+            ]
+          }
+        ],
+        state.activities
+      );
+    });
+
+    it('update activity section field', () => {
+      let state = reducer(
+        initialState,
+        updateActivitySectionField(1, 2, 'displayName', 'My Display Name')
+      );
+      assert.deepEqual(
+        [
+          {
+            key: 'x',
+            displayName: 'X',
+            position: 1,
+            activitySections: [
+              {key: 'a', position: 1, displayName: 'A'},
+              {key: 'b', position: 2, displayName: 'My Display Name'}
+            ]
+          },
+          {
+            key: 'y',
+            displayName: 'Y',
+            position: 2,
+            activitySections: [
+              {key: 'c', position: 1, displayName: 'C'},
+              {key: 'd', position: 2, displayName: 'D'}
+            ]
+          }
+        ],
+        state.activities
+      );
+    });
+
+    it('set the activity for an activity section', () => {
+      let state = reducer(initialState, setActivity(2, 1, 2));
+      assert.deepEqual(
+        [
+          {
+            key: 'x',
+            displayName: 'X',
+            position: 1,
+            activitySections: [{key: 'a', position: 1, displayName: 'A'}]
+          },
+          {
+            key: 'y',
+            displayName: 'Y',
+            position: 2,
+            activitySections: [
+              {key: 'c', position: 1, displayName: 'C'},
+              {key: 'd', position: 2, displayName: 'D'},
+              {key: 'b', position: 3, displayName: 'B'}
+            ]
+          }
+        ],
+        state.activities
+      );
+    });
+  });
+
+  describe('activity section', () => {
+    let initialActivities = [];
+
+    beforeEach(() => {
+      initialActivities = [
+        {
+          key: 'x',
+          displayName: 'X',
+          position: 1,
+          activitySections: [
+            {key: 'a', position: 1, displayName: 'A'},
+            {key: 'b', position: 2, displayName: 'B'}
+          ]
+        },
+        {
+          key: 'y',
+          displayName: 'Y',
+          position: 2,
+          activitySections: [
+            {key: 'c', position: 1, displayName: 'C'},
+            {key: 'd', position: 2, displayName: 'D'}
+          ]
+        }
+      ];
+      initialState.activities = initialActivities;
+    });
+
+    it('moves a activitySection up three times', () => {
+      const key = 'd';
+      let activityPosition = initialState.activities.find(activity =>
+        activity.activitySections.find(
+          activitySection => activitySection.key === key
+        )
+      ).position;
+      let activitySectionPosition = initialState.activities[
+        activityPosition - 1
+      ].activitySections.find(activitySection => activitySection.key === key)
+        .position;
+      let state = reducer(
+        initialState,
+        moveActivitySection(activityPosition, activitySectionPosition, 'up')
+      );
+      assert.deepEqual(
+        [
+          {
+            key: 'x',
+            displayName: 'X',
+            position: 1,
+            activitySections: [
+              {key: 'a', position: 1, displayName: 'A'},
+              {key: 'b', position: 2, displayName: 'B'}
+            ]
+          },
+          {
+            key: 'y',
+            displayName: 'Y',
+            position: 2,
+            activitySections: [
+              {key: 'd', position: 1, displayName: 'D'},
+              {key: 'c', position: 2, displayName: 'C'}
+            ]
+          }
+        ],
+        state.activities,
+        'first move changes position but not activity'
+      );
+
+      activityPosition = state.activities.find(activity =>
+        activity.activitySections.find(
+          activitySection => activitySection.key === key
+        )
+      ).position;
+      activitySectionPosition = state.activities[
+        activityPosition - 1
+      ].activitySections.find(activitySection => activitySection.key === key)
+        .position;
+      state = reducer(
+        state,
+        moveActivitySection(activityPosition, activitySectionPosition, 'up')
+      );
+      assert.deepEqual(
+        [
+          {
+            key: 'x',
+            displayName: 'X',
+            position: 1,
+            activitySections: [
+              {key: 'a', position: 1, displayName: 'A'},
+              {key: 'b', position: 2, displayName: 'B'},
+              {key: 'd', position: 3, displayName: 'D'}
+            ]
+          },
+          {
+            key: 'y',
+            displayName: 'Y',
+            position: 2,
+            activitySections: [{key: 'c', position: 1, displayName: 'C'}]
+          }
+        ],
+        state.activities,
+        'second move changes activity but not position'
+      );
+
+      activityPosition = state.activities.find(activity =>
+        activity.activitySections.find(
+          activitySection => activitySection.key === key
+        )
+      ).position;
+      activitySectionPosition = state.activities[
+        activityPosition - 1
+      ].activitySections.find(activitySection => activitySection.key === key)
+        .position;
+      state = reducer(
+        state,
+        moveActivitySection(activityPosition, activitySectionPosition, 'up')
+      );
+      assert.deepEqual(
+        [
+          {
+            key: 'x',
+            displayName: 'X',
+            position: 1,
+            activitySections: [
+              {key: 'a', position: 1, displayName: 'A'},
+              {key: 'd', position: 2, displayName: 'D'},
+              {key: 'b', position: 3, displayName: 'B'}
+            ]
+          },
+          {
+            key: 'y',
+            displayName: 'Y',
+            position: 2,
+            activitySections: [{key: 'c', position: 1, displayName: 'C'}]
+          }
+        ],
+        state.activities,
+        'third move changes position but not activity'
+      );
+    });
+
+    it('remove activity section', () => {
+      let state = reducer(initialState, removeActivitySection(1, 2));
+      assert.deepEqual(
+        [
+          {
+            key: 'x',
+            displayName: 'X',
+            position: 1,
+            activitySections: [{key: 'a', position: 1, displayName: 'A'}]
+          },
+          {
+            key: 'y',
+            displayName: 'Y',
+            position: 2,
+            activitySections: [
+              {key: 'c', position: 1, displayName: 'C'},
+              {key: 'd', position: 2, displayName: 'D'}
+            ]
+          }
+        ],
+        state.activities
+      );
+    });
+
+    it('update activity section field', () => {
+      let state = reducer(
+        initialState,
+        updateActivitySectionField(1, 2, 'displayName', 'My Display Name')
+      );
+      assert.deepEqual(
+        [
+          {
+            key: 'x',
+            displayName: 'X',
+            position: 1,
+            activitySections: [
+              {key: 'a', position: 1, displayName: 'A'},
+              {key: 'b', position: 2, displayName: 'My Display Name'}
+            ]
+          },
+          {
+            key: 'y',
+            displayName: 'Y',
+            position: 2,
+            activitySections: [
+              {key: 'c', position: 1, displayName: 'C'},
+              {key: 'd', position: 2, displayName: 'D'}
+            ]
+          }
+        ],
+        state.activities
+      );
+    });
+
+    it('set the activity for an activity section', () => {
+      let state = reducer(initialState, setActivity(2, 1, 2));
+      assert.deepEqual(
+        [
+          {
+            key: 'x',
+            displayName: 'X',
+            position: 1,
+            activitySections: [{key: 'a', position: 1, displayName: 'A'}]
+          },
+          {
+            key: 'y',
+            displayName: 'Y',
+            position: 2,
+            activitySections: [
+              {key: 'c', position: 1, displayName: 'C'},
+              {key: 'd', position: 2, displayName: 'D'},
+              {key: 'b', position: 3, displayName: 'B'}
+            ]
+          }
+        ],
+        state.activities
+      );
+    });
+
+    it('add activitySection', () => {
+      const nextState = reducer(
+        initialState,
+        addActivitySection(1, 'activitySection-key')
+      ).activities;
+      assert.deepEqual(nextState[0].activitySections.map(s => s.key), [
+        'a',
+        'b',
+        'activitySection-key'
+      ]);
+    });
+  });
+});

--- a/apps/test/unit/lib/levelbuilder/lesson-editor/activitiesTestData.js
+++ b/apps/test/unit/lib/levelbuilder/lesson-editor/activitiesTestData.js
@@ -1,0 +1,91 @@
+export const sampleActivities = [
+  {
+    key: 'activity-1',
+    displayName: 'Main Activity',
+    position: 1,
+    time: 20,
+    activitySections: [
+      {
+        key: 'section-3',
+        position: 1,
+        displayName: 'Making programs',
+        remarks: true,
+        slide: false,
+        levels: [],
+        text: 'Simple text',
+        tips: []
+      },
+      {
+        key: 'section-1',
+        position: 2,
+        displayName: '',
+        remarks: false,
+        slide: true,
+        levels: [],
+        text: 'Details about this section',
+        tips: [
+          {
+            key: 'tip-1',
+            type: 'teachingTip',
+            markdown: 'Teaching tip content'
+          }
+        ]
+      },
+      {
+        tips: [],
+        key: 'progression-1',
+        position: 3,
+        displayName: 'Programming Progression',
+        remarks: false,
+        slide: false,
+        text: 'This progression teaches you programming!',
+        levels: [
+          {
+            name: 'Level 1',
+            levelNumber: 1,
+            position: 1,
+            activeId: 1,
+            ids: [1],
+            kind: 'puzzle',
+            status: 'not started',
+            url: 'https://levelbuilder-studio.code.org/levels/598/edit',
+            icon: 'fa-desktop',
+            isUnplugged: false,
+            isCurrentLevel: false,
+            isConceptLevel: true,
+            named: false,
+            assessment: false,
+            challenge: false,
+            sublevels: [],
+            skin: null,
+            videoKey: null,
+            concepts: '',
+            conceptDifficulty: ''
+          },
+          {
+            name: 'Level 2',
+            levelNumber: 2,
+            position: 2,
+            activeId: 2,
+            ids: [2, 3],
+            kind: 'assessment',
+            status: 'not started',
+            url: 'https://levelbuilder-studio.code.org/levels/598/edit',
+            icon: 'fa-desktop',
+            isUnplugged: false,
+            isCurrentLevel: false,
+            isConceptLevel: false,
+            named: false,
+            assessment: true,
+            challenge: false,
+            sublevels: [],
+            skin: null,
+            videoKey: null,
+            concepts: '',
+            conceptDifficulty: ''
+          }
+        ]
+      }
+    ]
+  }
+];


### PR DESCRIPTION
Creates a redux store for the information used to edit activities in the activities editor GUI (to be added in later PR).  This store is based on the editorRedux store which is used by the Script Edit GUI. 

## Testing story

Added a bunch of unit tests for the activitiesEditorRedux store.

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
