### PR TITLE
Add unit test on response when no partner is found

### DIFF
--- a/dashboard/test/controllers/api/v1/pd/regional_partner_workshops_controller_test.rb
+++ b/dashboard/test/controllers/api/v1/pd/regional_partner_workshops_controller_test.rb
@@ -151,6 +151,14 @@ module Api::V1::Pd
       get :find, params: {state: 'Washington DC'}
     end
 
+    test 'find returns correctly when no partner is found' do
+      sign_in @teacher
+      get :find, params: {state: 'somewhere'}
+
+      expected = {id: nil, name: nil, group: nil, workshops: nil, has_csf: nil}.stringify_keys
+      assert_equal expected, JSON.parse(response.body)
+    end
+
     private
 
     def workshop_in_index_results(expected_workshop)


### PR DESCRIPTION
This will help us preserve existing behavior in https://github.com/code-dot-org/code-dot-org/pull/36560.