### PR TITLE
Revert "Better AuthenticationOption duplicate detection"

### DIFF
--- a/dashboard/app/models/authentication_option.rb
+++ b/dashboard/app/models/authentication_option.rb
@@ -33,8 +33,7 @@ class AuthenticationOption < ApplicationRecord
   validates_email_format_of :email, allow_blank: true, if: :email_changed?, unless: -> {email.to_s.utf8mb4?}
 
   validate :email_must_be_unique, :hashed_email_must_be_unique, unless: -> {UNTRUSTED_EMAIL_CREDENTIAL_TYPES.include? credential_type}
-
-  validates :authentication_id, uniqueness: {scope: [:credential_type, :deleted_at]}
+  validate :cred_type_and_auth_id_must_be_unique
 
   after_create :set_primary_contact_info
 
@@ -182,6 +181,18 @@ class AuthenticationOption < ApplicationRecord
     other = User.find_by_hashed_email(hashed_email)
     if other && other != user
       errors.add :email, I18n.t('errors.messages.taken')
+    end
+  end
+
+  private def cred_type_and_auth_id_must_be_unique
+    # skip the db lookup if possible
+    return unless authentication_id.present? &&
+      (credential_type_changed? || authentication_id_changed?) &&
+      errors.blank?
+
+    other = User.find_by_credential(type: credential_type, id: authentication_id)
+    if other && other != user
+      errors.add :credential_type, I18n.t('errors.messages.taken')
     end
   end
 end

--- a/dashboard/test/factories/factories.rb
+++ b/dashboard/test/factories/factories.rb
@@ -72,7 +72,7 @@ FactoryGirl.define do
 
   factory :user do
     birthday Time.zone.today - 21.years
-    sequence(:email) {|n| "#{user_type}_#{n}@code.org"}
+    email {("#{user_type}_#{(User.maximum(:id) || 0) + 1}@code.org")}
     password "00secret"
     locale 'en-US'
     sequence(:name) {|n| "User#{n} Codeberg"}
@@ -386,7 +386,7 @@ FactoryGirl.define do
           email: user.email,
           hashed_email: user.hashed_email,
           credential_type: AuthenticationOption::GOOGLE,
-          authentication_id: SecureRandom.uuid,
+          authentication_id: "abcd#{user.id}",
           data: {
             oauth_token: 'some-google-token',
             oauth_refresh_token: 'some-google-refresh-token',
@@ -403,7 +403,7 @@ FactoryGirl.define do
           email: user.email,
           hashed_email: user.hashed_email,
           credential_type: AuthenticationOption::CLEVER,
-          authentication_id: SecureRandom.uuid,
+          authentication_id: '456efgh',
           data: {
             oauth_token: 'some-clever-token'
           }.to_json
@@ -447,7 +447,7 @@ FactoryGirl.define do
     association :user
     sequence(:email) {|n| "testuser#{n}@example.com.xx"}
     credential_type AuthenticationOption::EMAIL
-    authentication_id SecureRandom.uuid
+    authentication_id {User.hash_email email}
 
     factory :google_authentication_option do
       credential_type AuthenticationOption::GOOGLE

--- a/dashboard/test/lib/user_multi_auth_helper_test.rb
+++ b/dashboard/test/lib/user_multi_auth_helper_test.rb
@@ -20,17 +20,13 @@ class UserMultiAuthHelperTest < ActiveSupport::TestCase
   test 'oauth_tokens_for_provider returns most recently updated tokens for migrated teacher' do
     Timecop.freeze do
       user = create :teacher
-      create :authentication_option,
-        authentication_id: "old-auth-id",
-        credential_type: AuthenticationOption::CLEVER,
-        user: user,
-        data: {oauth_token: 'old-clever-token'}.to_json
+      create :authentication_option, credential_type: AuthenticationOption::CLEVER, user: user, data: {
+        oauth_token: 'old-clever-token'
+      }.to_json
       Timecop.travel(1.minute) do
-        create :authentication_option,
-          authentication_id: "newer-auth-id",
-          credential_type: AuthenticationOption::CLEVER,
-          user: user,
-          data: {oauth_token: 'newer-clever-token'}.to_json
+        create :authentication_option, credential_type: AuthenticationOption::CLEVER, user: user, data: {
+          oauth_token: 'newer-clever-token'
+        }.to_json
         clever_token = user.oauth_tokens_for_provider(AuthenticationOption::CLEVER)[:oauth_token]
         assert_equal 'newer-clever-token', clever_token
       end

--- a/dashboard/test/models/authentication_option_test.rb
+++ b/dashboard/test/models/authentication_option_test.rb
@@ -29,7 +29,7 @@ class AuthenticationOptionTest < ActiveSupport::TestCase
     teacher_email = 'TESTcaseSANITIZATION@test.com'
     sanitized = 'testcasesanitization@test.com'
     teacher = create(:teacher, email: teacher_email)
-    email_auth = teacher.primary_contact_info
+    email_auth = create(:authentication_option, user: teacher, email: teacher_email)
     assert_equal sanitized, email_auth.email
     assert_equal email_auth.hashed_email, AuthenticationOption.hash_email(sanitized)
   end
@@ -37,7 +37,7 @@ class AuthenticationOptionTest < ActiveSupport::TestCase
   test 'student email is not stored but hashed_email is' do
     student_email = 'teststudent@test.com'
     student = create(:student, email: student_email)
-    email_auth = student.primary_contact_info
+    email_auth = create(:authentication_option, user: student, email: student_email)
     assert email_auth.user.student?
     assert_equal '', email_auth.email
     assert_equal student.hashed_email, email_auth.hashed_email
@@ -49,17 +49,7 @@ class AuthenticationOptionTest < ActiveSupport::TestCase
     create :authentication_option, credential_type: cred_type, authentication_id: auth_id
     new_auth_option = build :authentication_option, credential_type: cred_type, authentication_id: auth_id
     refute new_auth_option.valid?
-    assert_equal ['Authentication has already been taken'], new_auth_option.errors.full_messages
-  end
-
-  test 'deleted authentication options do not affect uniqueness' do
-    cred_type = AuthenticationOption::GOOGLE
-    auth_id = '54321'
-    first_auth_option = create :authentication_option, credential_type: cred_type, authentication_id: auth_id
-    new_auth_option = build :authentication_option, credential_type: cred_type, authentication_id: auth_id
-    refute new_auth_option.valid?
-    first_auth_option.delete
-    assert new_auth_option.valid?
+    assert_equal ['Credential type has already been taken'], new_auth_option.errors.full_messages
   end
 
   test 'user can have multiple authentication options' do

--- a/dashboard/test/models/user_test.rb
+++ b/dashboard/test/models/user_test.rb
@@ -2933,10 +2933,10 @@ class UserTest < ActiveSupport::TestCase
   end
 
   test "age is set exactly for Google OAuth users between ages 4 and 20" do
-    four_year_old = build :user, birthday: (Date.today - 4.years), provider: 'google_oauth2'
+    four_year_old = create :user, birthday: (Date.today - 4.years), provider: 'google_oauth2'
     assert_equal 4, four_year_old.age
 
-    twenty_year_old = build :user, birthday: (Date.today - 20.years), provider: 'google_oauth2'
+    twenty_year_old = create :user, birthday: (Date.today - 20.years), provider: 'google_oauth2'
     assert_equal 20, twenty_year_old.age
   end
 
@@ -2958,10 +2958,10 @@ class UserTest < ActiveSupport::TestCase
   end
 
   test "age is set exactly for Clever users between ages 4 and 20" do
-    four_year_old = build :user, birthday: (Date.today - 4.years), provider: 'clever'
+    four_year_old = create :user, birthday: (Date.today - 4.years), provider: 'clever'
     assert_equal 4, four_year_old.age
 
-    twenty_year_old = build :user, birthday: (Date.today - 20.years), provider: 'clever'
+    twenty_year_old = create :user, birthday: (Date.today - 20.years), provider: 'clever'
     assert_equal 20, twenty_year_old.age
   end
 


### PR DESCRIPTION
Reverts code-dot-org/code-dot-org#36555

Looks like this change (in particular, the tweak to email generation) caused an eyes failure.

More information:

https://codedotorg.slack.com/archives/CC4U03GA0/p1599593800006800
https://cucumber-logs.s3.amazonaws.com/test/test/Chrome_plc_pd_workshop_certificates_eyes_output.html?versionId=LSExmJAhiJbslXRQVJ0S_SVJv_s7AjI
