### PR TITLE
Update HSTS header

### DIFF
--- a/dashboard/config.ru
+++ b/dashboard/config.ru
@@ -23,7 +23,7 @@ use Rack::ContentLength
 require 'rack/ssl-enforcer'
 use Rack::SslEnforcer,
   # Add HSTS header to all HTTPS responses in all environments.
-  hsts: {expires: 31_536_000, subdomains: false},
+  hsts: true,
   # HTTPS redirect is handled at the HTTP-cache layer (CloudFront/Varnish).
   # The only exception is in :development, where no HTTP-cache layer is present.
   only_environments: 'development',

--- a/pegasus/config.ru
+++ b/pegasus/config.ru
@@ -21,8 +21,9 @@ use Rack::Csrf, check_only: ['POST:/v2/poste/send-message']
 
 require 'rack/ssl-enforcer'
 use Rack::SslEnforcer,
-  # Add HSTS header to all HTTPS responses in all environments.
-  hsts: {expires: 31_536_000, subdomains: false},
+  # Add HSTS header to all HTTPS responses in all environments,
+  # adding `preload` directive to the root domain.
+  hsts: {preload: rack_env?(:production)},
   # HTTPS redirect is handled at the HTTP-cache layer (CloudFront/Varnish).
   # The only exception is in :development, where no HTTP-cache layer is present.
   only_environments: 'development',


### PR DESCRIPTION
This PR makes some slight changes to the [`Strict-Transport-Security`](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Strict-Transport-Security) header returned by application responses, which is handled through the [`hsts`](https://github.com/tobmatth/rack-ssl-enforcer#http-strict-transport-security-hsts) option of the [`rack-ssl-enforcer`](https://github.com/tobmatth/rack-ssl-enforcer) middleware.
- Add `includeSubdomains` directive to all response headers, which will ensure HTTPS is enforced across all subdomains.
- Add `preload` to the root domain response, which will make the domain eligible for inclusion in the [HSTS preload](https://hstspreload.org/) list.