### PR TITLE
Purging user deletes the associated Census Inaccuracy Investigations

### DIFF
--- a/dashboard/test/factories/census_factories.rb
+++ b/dashboard/test/factories/census_factories.rb
@@ -535,9 +535,9 @@ FactoryGirl.define do
   end
 
   factory :census_inaccuracy_investigation, class: 'Census::CensusInaccuracyInvestigation' do
-    user {build :user}
+    user {build :teacher}
     notes "Some notes from my investigation"
-    census_submission {build :census_your_school2017v7}
+    census_submission {build :census_your_school2017v7, submitter_email_address: user&.email}
 
     trait :without_submission do
       census_submission nil

--- a/dashboard/test/helpers/delete_accounts_helper_test.rb
+++ b/dashboard/test/helpers/delete_accounts_helper_test.rb
@@ -659,6 +659,21 @@ class DeleteAccountsHelperTest < ActionView::TestCase
     assert_logged "Removed 1 CensusSubmissionFormMap"
   end
 
+  test "deletes census_inaccuracy_investigation associated census_submissions associated with user email" do
+    census_inaccuracy_investigation = create :census_inaccuracy_investigation
+    id = census_inaccuracy_investigation.id
+    user = census_inaccuracy_investigation.user
+    refute_empty Census::CensusInaccuracyInvestigation.where(id: id),
+      "Expected at least one CensusInaccuracyInvestigation under this email"
+
+    purge_user user
+
+    assert_empty Census::CensusInaccuracyInvestigation.where(id: id),
+      "Rows are actually gone, not just anonymized"
+
+    assert_logged "Removed 1 CensusInaccuracyInvestigation"
+  end
+
   test "leaves no SchoolInfos referring to the deleted CensusSubmissions" do
     user = create :teacher
     email = user.email

--- a/lib/cdo/delete_accounts_helper.rb
+++ b/lib/cdo/delete_accounts_helper.rb
@@ -225,8 +225,11 @@ class DeleteAccountsHelper
     @log.puts "Removing CensusSubmission"
     census_submissions = Census::CensusSubmission.where(submitter_email_address: email)
     csfms = Census::CensusSubmissionFormMap.where(census_submission_id: census_submissions.pluck(:id))
+    ciis = Census::CensusInaccuracyInvestigation.where(census_submission_id: census_submissions.pluck(:id))
+    deleted_cii_count = ciis.delete_all
     deleted_csfm_count = csfms.delete_all
     deleted_submissions_count = census_submissions.delete_all
+    @log.puts "Removed #{deleted_cii_count} CensusInaccuracyInvestigation" if deleted_cii_count > 0
     @log.puts "Removed #{deleted_csfm_count} CensusSubmissionFormMap" if deleted_csfm_count > 0
     @log.puts "Removed #{deleted_submissions_count} CensusSubmission" if deleted_submissions_count > 0
   end


### PR DESCRIPTION
**Bug** - Some soft-deleted teacher accounts failed to be purged.
**Cause** - Deleting the _CensusSubmissions_ associated with the teach account failed because there was still a _CensusInaccuracyInvestigation_ associated with the teacher's _CensusSubmission_.
**Fix** - Delete associated _CensusInaccuracyInvestigations_ before deleting the _CensusSubmissions_.

## Links
- [jira](https://codedotorg.atlassian.net/browse/FND-1269)

## Testing story
* Unit test.

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
