### PR TITLE
Remove old uniqueness condition for lesson now that we have key

### DIFF
--- a/dashboard/app/models/lesson.rb
+++ b/dashboard/app/models/lesson.rb
@@ -49,7 +49,6 @@ class Lesson < ActiveRecord::Base
   # by a non-lockable lesson, the third lesson will have an absolute_position of 3 but a relative_position of 1
   acts_as_list scope: :script, column: :absolute_position
 
-  #validates_uniqueness_of :name, scope: :script_id TODO: Add this back after we have moved over to new key/name systems for lesson
   validates_uniqueness_of :key, scope: :script_id
 
   include CodespanOnlyMarkdownHelper


### PR DESCRIPTION
Removing a commented out line that checked for the uniqueness of lesson name back when name was used as the key. Now that we have a separate key we no longer need it.