### PR TITLE
Add unit test on ScriptLevelsController#hidden_stage_ids for teacher

### DIFF
--- a/dashboard/test/controllers/script_levels_controller_test.rb
+++ b/dashboard/test/controllers/script_levels_controller_test.rb
@@ -1486,7 +1486,7 @@ class ScriptLevelsControllerTest < ActionController::TestCase
     assert_equal [], hidden
   end
 
-  test "hidden_stage_ids for user signed in" do
+  test "hidden_stage_ids for student signed in" do
     SectionHiddenLesson.create(section_id: @section.id, stage_id: @custom_lesson_1.id)
 
     sign_in @student
@@ -1495,6 +1495,18 @@ class ScriptLevelsControllerTest < ActionController::TestCase
 
     hidden = JSON.parse(response.body)
     assert_equal [@custom_lesson_1.id.to_s], hidden
+  end
+
+  test "hidden_stage_ids for teacher signed in" do
+    SectionHiddenLesson.create(section_id: @section.id, stage_id: @custom_lesson_1.id)
+
+    sign_in @teacher
+    response = get :hidden_stage_ids, params: {script_id: @script.name}
+    assert_response :success
+
+    hidden = JSON.parse(response.body)
+    expected = {@section.id.to_s => [@custom_lesson_1.id]}
+    assert_equal expected, hidden
   end
 
   def put_student_in_section(student, teacher, script)


### PR DESCRIPTION
Adds missing test. The shape of the response returned is different for teachers compared to students.

This was one of the things broken by: https://github.com/code-dot-org/code-dot-org/pull/36560

That PR has been reverted; I'm adding unit tests for the affected APIs, then I'll fix the behavior on that branch and make a new PR.

I *think* this is the only thing that broke in the two failing eyes tests (hiding lessons).