### PR TITLE
Eyes: fix a flaky test by disabling stitch mode

### DIFF
--- a/dashboard/test/ui/features/star_labs/gamelab/eyes.feature
+++ b/dashboard/test/ui/features/star_labs/gamelab/eyes.feature
@@ -3,7 +3,7 @@
 Feature: Game Lab Eyes
 
 Scenario: Basic GameLab level
-  When I open my eyes to test "gamelab eyes" using stitch mode "none"
+  When I open my eyes to test "gamelab eyes"
   And I start a new Game Lab project
   Then I see no difference for "initial load" using stitch mode "none"
   When I switch to the animation tab

--- a/dashboard/test/ui/features/star_labs/gamelab/eyes.feature
+++ b/dashboard/test/ui/features/star_labs/gamelab/eyes.feature
@@ -3,17 +3,17 @@
 Feature: Game Lab Eyes
 
 Scenario: Basic GameLab level
-  When I open my eyes to test "gamelab eyes"
+  When I open my eyes to test "gamelab eyes" using stitch mode "none"
   And I start a new Game Lab project
-  Then I see no difference for "initial load"
+  Then I see no difference for "initial load" using stitch mode "none"
   When I switch to the animation tab
-  Then I see no difference for "animation tab"
+  Then I see no difference for "animation tab" using stitch mode "none"
   And I press ".animationList .newListItem" using jQuery
-  Then I see no difference for "new animation"
+  Then I see no difference for "new animation" using stitch mode "none"
   And I close my eyes
 
 Scenario: Game Lab Embed Level
   Given I am on the 3rd Game Lab test level
   When I open my eyes to test "Game Lab Embed Level"
-  Then I see no difference for "initial load"
+  Then I see no difference for "initial load" using stitch mode "none"
   And I close my eyes


### PR DESCRIPTION
This fixes another test that has the issue of extra space at the bottom sometimes, at least according to Eyes:

![Screen Shot 2020-09-09 at 9 57 17 PM](https://user-images.githubusercontent.com/2205926/92683457-ca159280-f2e7-11ea-9c42-455d7242b295.png)
