### PR TITLE
Upgrade ActiveModelSerializers gem to 10.x, take 2

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -235,7 +235,7 @@ gem 'paranoia'
 gem 'petit', github: 'code-dot-org/petit'  # For URL shortening
 
 # JSON model serializer for REST APIs.
-gem 'active_model_serializers', github: 'rails-api/active_model_serializers', ref: '2962f3f64e7c672bfb5a13a8f739b5db073e5473'
+gem 'active_model_serializers', '~> 0.10.0'
 
 # AWS SDK and associated service APIs.
 gem 'aws-sdk-acm'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -55,14 +55,6 @@ GIT
     full-name-splitter (0.1.2)
 
 GIT
-  remote: https://github.com/rails-api/active_model_serializers.git
-  revision: 2962f3f64e7c672bfb5a13a8f739b5db073e5473
-  ref: 2962f3f64e7c672bfb5a13a8f739b5db073e5473
-  specs:
-    active_model_serializers (0.10.0.pre)
-      activemodel (>= 4.0)
-
-GIT
   remote: https://github.com/wjordan/gctools.git
   revision: 729c6bbb32c4bcc2ebfed16543991e4d126f09cc
   ref: ruby-2.5
@@ -235,6 +227,11 @@ GEM
       erubis (~> 2.7.0)
       rails-dom-testing (~> 2.0)
       rails-html-sanitizer (~> 1.0, >= 1.0.3)
+    active_model_serializers (0.10.10)
+      actionpack (>= 4.1, < 6.1)
+      activemodel (>= 4.1, < 6.1)
+      case_transform (>= 0.2)
+      jsonapi-renderer (>= 0.1.1.beta1, < 0.3)
     active_record_query_trace (1.5.3)
     active_record_union (1.3.0)
       activerecord (>= 4.0)
@@ -343,6 +340,8 @@ GEM
     brakeman (4.5.0)
     builder (3.2.3)
     cancancan (1.15.0)
+    case_transform (0.2)
+      activesupport
     childprocess (0.9.0)
       ffi (~> 1.0, >= 1.0.11)
     chronic (0.10.2)
@@ -526,6 +525,7 @@ GEM
       bindata
     json-schema (2.8.1)
       addressable (>= 2.4)
+    jsonapi-renderer (0.2.2)
     jsonapi-serializers (1.0.0)
       activesupport
     jumphash (0.1.0)
@@ -903,7 +903,7 @@ PLATFORMS
 DEPENDENCIES
   StreetAddress
   acmesmith (~> 2.3.1)
-  active_model_serializers!
+  active_model_serializers (~> 0.10.0)
   active_record_query_trace
   active_record_union
   activerecord-import

--- a/dashboard/app/controllers/api/v1/pd/applications_controller.rb
+++ b/dashboard/app/controllers/api/v1/pd/applications_controller.rb
@@ -63,12 +63,8 @@ module Api::V1::Pd
 
       respond_to do |format|
         format.json do
-          serialized_applications = prefetch_and_serialize(
-            applications,
-            role: role,
-            serializer: ApplicationQuickViewSerializer
-          )
-          render json: serialized_applications
+          prefetched_applications = prefetch(applications, role: role)
+          render json: prefetched_applications, each_serializer: ApplicationQuickViewSerializer
         end
         format.csv do
           csv_text = get_csv_text applications, role
@@ -97,13 +93,8 @@ module Api::V1::Pd
 
       respond_to do |format|
         format.json do
-          serialized_applications = prefetch_and_serialize(
-            applications,
-            role: role,
-            serializer: serializer,
-            scope: {user: current_user}
-          )
-          render json: serialized_applications
+          prefetched_applications = prefetch(applications, role: role)
+          render json: prefetched_applications, each_serializer: serializer, scope: {user: current_user}
         end
         format.csv do
           csv_text = get_csv_text applications, role
@@ -209,8 +200,7 @@ module Api::V1::Pd
         user: user
       )
 
-      serialized_applications = filtered_applications.map {|a| ApplicationSearchSerializer.new(a).attributes}
-      render json: serialized_applications
+      render json: filtered_applications, each_serializer: ApplicationSearchSerializer
     end
 
     private
@@ -304,16 +294,10 @@ module Api::V1::Pd
       {registered_workshop: false}
     end
 
-    def prefetch_and_serialize(applications, role: nil, serializer:, scope: {})
-      prefetch applications, role: role
-      applications.map do |application|
-        serializer.new(application, scope: scope).attributes
-      end
-    end
-
     def prefetch(applications, role: nil)
       type = TYPES_BY_ROLE[role.try(&:to_sym)]
       type.prefetch_associated_models applications
+      applications
     end
   end
 end

--- a/dashboard/app/controllers/api/v1/pd/workshop_enrollments_controller.rb
+++ b/dashboard/app/controllers/api/v1/pd/workshop_enrollments_controller.rb
@@ -21,13 +21,12 @@ class Api::V1::Pd::WorkshopEnrollmentsController < ApplicationController
 
   # GET /api/v1/pd/workshops/1/enrollments
   def index
-    response = render_to_json @workshop.enrollments, each_serializer: Api::V1::Pd::WorkshopEnrollmentSerializer
-
     respond_to do |format|
       format.json do
-        render json: response
+        render json: @workshop.enrollments, each_serializer: Api::V1::Pd::WorkshopEnrollmentSerializer
       end
       format.csv do
+        response = render_to_json @workshop.enrollments, each_serializer: Api::V1::Pd::WorkshopEnrollmentSerializer
         send_as_csv_attachment response, 'workshop_enrollments.csv'
       end
     end
@@ -81,8 +80,7 @@ class Api::V1::Pd::WorkshopEnrollmentsController < ApplicationController
   # POST /api/v1/pd/enrollment/:enrollment_id/scholarship_info
   def update_scholarship_info
     @enrollment.update_scholarship_status(params[:scholarship_status])
-    serialized_enrollment = Api::V1::Pd::WorkshopEnrollmentSerializer.new(@enrollment).attributes
-    render json: serialized_enrollment
+    render json: @enrollment, serializer: Api::V1::Pd::WorkshopEnrollmentSerializer
   end
 
   # DELETE /api/v1/pd/workshops/1/enrollments/1

--- a/dashboard/app/controllers/api/v1/teacher_feedbacks_controller.rb
+++ b/dashboard/app/controllers/api/v1/teacher_feedbacks_controller.rb
@@ -49,7 +49,7 @@ class Api::V1::TeacherFeedbacksController < Api::V1::JsonApiController
       User.find(feedback.teacher_id).authorized_teacher?
     end
 
-    render json: @all_unseen_feedbacks.count, each_serializer: Api::V1::TeacherFeedbackSerializer
+    render json: @all_unseen_feedbacks.count
   end
 
   # POST /teacher_feedbacks

--- a/dashboard/app/controllers/api/v1/users_controller.rb
+++ b/dashboard/app/controllers/api/v1/users_controller.rb
@@ -60,7 +60,7 @@ class Api::V1::UsersController < Api::V1::JsonApiController
 
   # GET /api/v1/users/<user_id>/school_donor_name
   def get_school_donor_name
-    render json: @user.school_donor_name
+    render json: @user.school_donor_name.nil? ? 'null' : @user.school_donor_name.inspect
   end
 
   # POST /api/v1/users/<user_id>/using_text_mode

--- a/dashboard/app/controllers/script_levels_controller.rb
+++ b/dashboard/app/controllers/script_levels_controller.rb
@@ -160,7 +160,7 @@ class ScriptLevelsController < ApplicationController
 
     stage_ids = current_user ? current_user.get_hidden_stage_ids(params[:script_id]) : []
 
-    render json: stage_ids
+    render json: stage_ids.map(&:to_s)
   end
 
   # toggles whether or not a stage is hidden for a section

--- a/dashboard/app/controllers/script_levels_controller.rb
+++ b/dashboard/app/controllers/script_levels_controller.rb
@@ -160,7 +160,7 @@ class ScriptLevelsController < ApplicationController
 
     stage_ids = current_user ? current_user.get_hidden_stage_ids(params[:script_id]) : []
 
-    render json: stage_ids.map(&:to_s)
+    render json: stage_ids
   end
 
   # toggles whether or not a stage is hidden for a section

--- a/dashboard/app/serializers/api/v1/pd/cohort_view_serializer_base.rb
+++ b/dashboard/app/serializers/api/v1/pd/cohort_view_serializer_base.rb
@@ -1,26 +1,23 @@
 class Api::V1::Pd::CohortViewSerializerBase < ActiveModel::Serializer
-  attributes(
-    :id,
-    :date_accepted,
-    :applicant_name,
-    :district_name,
-    :school_name,
-    :email,
-    :assigned_workshop,
-    :registered_workshop,
-    :status,
-    :notes,
-    :notes_2,
-    :notes_3,
-    :notes_4,
-    :notes_5
-  )
+  # Declare attributes individually so we can make :locked a conditional attribute
+  attribute :id
+  attribute :date_accepted
+  attribute :applicant_name
+  attribute :district_name
+  attribute :school_name
+  attribute :email
+  attribute :assigned_workshop
+  attribute :registered_workshop
+  attribute :status
+  attribute :notes
+  attribute :notes_2
+  attribute :notes_3
+  attribute :notes_4
+  attribute :notes_5
+  attribute :locked, if: :include_locked?
 
-  # Dynamically add locked where applicable
-  def attributes(attrs = {})
-    super(attrs).tap do |data|
-      data[:locked] = object.locked? if object.class.can_see_locked_status?(@scope[:user])
-    end
+  def locked
+    object.locked?
   end
 
   def email
@@ -35,5 +32,9 @@ class Api::V1::Pd::CohortViewSerializerBase < ActiveModel::Serializer
     if object.workshop.try(:local_summer?)
       object.registered_workshop? ? 'Yes' : 'No'
     end
+  end
+
+  def include_locked?
+    object.class.can_see_locked_status?(scope[:user])
   end
 end

--- a/dashboard/app/serializers/api/v1/pd/enrollment_flat_attendance_serializer.rb
+++ b/dashboard/app/serializers/api/v1/pd/enrollment_flat_attendance_serializer.rb
@@ -1,6 +1,6 @@
 # Write a flat list of workshop attendance by session for the enrollment
 class Api::V1::Pd::EnrollmentFlatAttendanceSerializer < ActiveModel::Serializer
-  attributes :first_name, :last_name, :email, :district_name, :school, :role, :grades_teaching
+  attributes :first_name, :last_name, :email, :district_name, :school, :role, :grades_teaching, :cdo_scholarship, :other_scholarship
 
   def district_name
     object.school_info&.school_district&.name
@@ -10,15 +10,21 @@ class Api::V1::Pd::EnrollmentFlatAttendanceSerializer < ActiveModel::Serializer
     object.school_info&.school&.name || object.school_info&.school_name || object.school
   end
 
+  def cdo_scholarship
+    object.scholarship_status == Pd::ScholarshipInfoConstants::YES_CDO ? 'Yes' : ''
+  end
+
+  def other_scholarship
+    object.scholarship_status == Pd::ScholarshipInfoConstants::YES_OTHER ? 'Yes' : ''
+  end
+
   # Add dynamic attributes for each session's date and attendance
-  def attributes(attrs = {})
-    super(attrs).tap do |data|
+  def attributes(requested_attrs = nil, reload = false)
+    super(requested_attrs, reload).tap do |data|
       object.workshop.sessions.each_with_index do |session, i|
         data["session_#{i + 1}_date".to_sym] = session.formatted_date
         data["session_#{i + 1}_attendance".to_sym] = session.attendances.where(pd_enrollment_id: object.id).exists?
       end
-      data[:cdo_scholarship] = object.scholarship_status == Pd::ScholarshipInfoConstants::YES_CDO ? 'Yes' : ''
-      data[:other_scholarship] = object.scholarship_status == Pd::ScholarshipInfoConstants::YES_OTHER ? 'Yes' : ''
     end
   end
 end

--- a/dashboard/app/serializers/api/v1/pd/facilitator_application_cohort_view_serializer.rb
+++ b/dashboard/app/serializers/api/v1/pd/facilitator_application_cohort_view_serializer.rb
@@ -1,10 +1,9 @@
 module Api::V1::Pd
   class FacilitatorApplicationCohortViewSerializer < CohortViewSerializerBase
-    attributes(
-      *superclass._attributes,
-      :assigned_fit,
-      :registered_fit
-    )
+    # Declare attributes individually instead of using attributes list, to preserve attributes declared on base class
+
+    attribute :assigned_fit
+    attribute :registered_fit
 
     def assigned_fit
       object.fit_workshop.try(&:date_and_location_name)

--- a/dashboard/app/serializers/api/v1/pd/regional_partner_workshops_serializer.rb
+++ b/dashboard/app/serializers/api/v1/pd/regional_partner_workshops_serializer.rb
@@ -2,17 +2,17 @@ class Api::V1::Pd::RegionalPartnerWorkshopsSerializer < ActiveModel::Serializer
   attributes :id, :name, :group, :workshops, :has_csf
 
   def workshops
-    object.try do |partner|
-      workshops = partner.pd_workshops.future
-      workshops = workshops.where(course: @scope[:course]) if @scope.try(:[], :course)
-      workshops = workshops.where(subject: @scope[:subject]) if @scope.try(:[], :subject)
-      workshops.map do |workshop|
-        {
-          id: workshop.id,
-          dates: workshop.friendly_date_range,
-          location: workshop.location_address
-        }
-      end
+    return nil if object.id.nil?
+
+    workshops = object.pd_workshops.future
+    workshops = workshops.where(course: @scope[:course]) if @scope.try(:[], :course)
+    workshops = workshops.where(subject: @scope[:subject]) if @scope.try(:[], :subject)
+    workshops.map do |workshop|
+      {
+        id: workshop.id,
+        dates: workshop.friendly_date_range,
+        location: workshop.location_address
+      }
     end
   end
 end

--- a/dashboard/app/serializers/api/v1/pd/teacher_application_cohort_view_serializer.rb
+++ b/dashboard/app/serializers/api/v1/pd/teacher_application_cohort_view_serializer.rb
@@ -1,6 +1,8 @@
 module Api::V1::Pd
   class TeacherApplicationCohortViewSerializer < CohortViewSerializerBase
-    attributes(*superclass._attributes, :friendly_scholarship_status, :registered_workshop_id)
+    # Declare attributes individually instead of using attributes list, to preserve attributes declared on base class
+    attribute :friendly_scholarship_status
+    attribute :registered_workshop_id
 
     def registered_workshop_id
       if object.workshop.try(:local_summer?)

--- a/dashboard/app/serializers/api/v1/teacher_feedback_serializer.rb
+++ b/dashboard/app/serializers/api/v1/teacher_feedback_serializer.rb
@@ -20,8 +20,6 @@
 class Api::V1::TeacherFeedbackSerializer < ActiveModel::Serializer
   attributes :id, :teacher_name, :student_id, :level_id, :script_level_id, :comment, :performance, :created_at
 
-  private
-
   def teacher_name
     object.teacher.name
   end

--- a/dashboard/config/initializers/active_model_serializers.rb
+++ b/dashboard/config/initializers/active_model_serializers.rb
@@ -1,15 +1,1 @@
-# Patch to allow serializing String and Hash objects by default
-class StringSerializer < ActiveModel::Serializer
-  def attributes(obj)
-    @object.to_s
-  end
-end
-class IntegerSerializer < StringSerializer; end
-class HashSerializer < ActiveModel::Serializer
-  def attributes(obj)
-    @object.as_json
-  end
-end
-class ActiveModel::ErrorsSerializer < HashSerializer; end
-
-ActiveModel::Serializer.config.adapter = :Json
+ActiveModel::Serializer.config.adapter = :attributes

--- a/dashboard/test/controllers/api/v1/pd/workshop_enrollments_controller_test.rb
+++ b/dashboard/test/controllers/api/v1/pd/workshop_enrollments_controller_test.rb
@@ -109,6 +109,18 @@ class Api::V1::Pd::WorkshopEnrollmentsControllerTest < ::ActionController::TestC
     assert_equal @enrollment.email, response_json[0]['email']
   end
 
+  test 'facilitators can see enrollments in their workshops in csv format' do
+    sign_in @facilitator
+    get :index, params: {workshop_id: @workshop.id, format: :csv}
+    assert_response :success
+
+    response_csv = CSV.parse(@response.body)
+    assert_equal 2, response_csv.length
+    header_row = response_csv[0]
+    enrollment_row = response_csv[1]
+    assert_equal @enrollment.email, enrollment_row[header_row.find_index('Email')]
+  end
+
   test 'facilitators cannot see enrollments in workshops they are not facilitating' do
     sign_in @facilitator
     get :index, params: {workshop_id: @unrelated_workshop.id}

--- a/dashboard/test/controllers/api/v1/teacher_feedbacks_controller_test.rb
+++ b/dashboard/test/controllers/api/v1/teacher_feedbacks_controller_test.rb
@@ -137,7 +137,7 @@ class Api::V1::TeacherFeedbacksControllerTest < ActionDispatch::IntegrationTest
     sign_in @student
     get "#{API}/count"
 
-    assert_equal "0", formatted_response
+    assert_equal "0", response.body
   end
 
   test 'count is accurate when feedback is available' do
@@ -147,8 +147,7 @@ class Api::V1::TeacherFeedbacksControllerTest < ActionDispatch::IntegrationTest
 
     sign_in @student
     get "#{API}/count"
-
-    assert_equal "1", formatted_response
+    assert_equal "1", response.body
 
     teacher_sign_in_and_give_feedback(@teacher, @student, @level, @script_level, COMMENT2, PERFORMANCE2)
     sign_out @teacher
@@ -156,7 +155,7 @@ class Api::V1::TeacherFeedbacksControllerTest < ActionDispatch::IntegrationTest
     sign_in @student
     get "#{API}/count"
 
-    assert_equal "2", formatted_response
+    assert_equal "2", response.body
   end
 
   test 'count does not include already seen feedback' do
@@ -167,7 +166,7 @@ class Api::V1::TeacherFeedbacksControllerTest < ActionDispatch::IntegrationTest
     sign_in @student
     get "#{API}/count"
 
-    assert_equal "1", formatted_response
+    assert_equal "1", response.body
 
     TeacherFeedback.last.update_attribute(
       :seen_on_feedback_page_at,
@@ -175,7 +174,7 @@ class Api::V1::TeacherFeedbacksControllerTest < ActionDispatch::IntegrationTest
     )
 
     get "#{API}/count"
-    assert_equal "0", formatted_response
+    assert_equal "0", response.body
   end
 
   test 'count does not include feedback from a not authorized teacher' do
@@ -185,7 +184,7 @@ class Api::V1::TeacherFeedbacksControllerTest < ActionDispatch::IntegrationTest
     sign_in @student
     get "#{API}/count"
 
-    assert_equal "0", formatted_response
+    assert_equal "0", response.body
   end
 
   test 'bad request when student_id not provided - get_feedbacks' do
@@ -294,10 +293,6 @@ class Api::V1::TeacherFeedbacksControllerTest < ActionDispatch::IntegrationTest
 
   def parsed_response
     JSON.parse(@response.body)
-  end
-
-  def formatted_response
-    @response.body.delete!('\\"')
   end
 
   # Sign in as teacher and leave feedback for student on level.

--- a/dashboard/test/controllers/script_levels_controller_test.rb
+++ b/dashboard/test/controllers/script_levels_controller_test.rb
@@ -1494,7 +1494,7 @@ class ScriptLevelsControllerTest < ActionController::TestCase
     assert_response :success
 
     hidden = JSON.parse(response.body)
-    assert_equal [@custom_lesson_1.id.to_s], hidden
+    assert_equal [@custom_lesson_1.id], hidden
   end
 
   test "hidden_stage_ids for teacher signed in" do


### PR DESCRIPTION
Re-applies https://github.com/code-dot-org/code-dot-org/pull/36560, which was reverted here https://github.com/code-dot-org/code-dot-org/pull/36676 because it broke the ability for teachers to hide lessons.

The only change on top of that is this commit: https://github.com/code-dot-org/code-dot-org/commit/c0f7d1c6be1ffbd71c16782ee6bd5a3d03af0865 which fixes the behavior for `ScriptLevelsController#hidden_stage_ids`.

## Testing story

Manually tested hiding lessons on `/s/allthethings` locally as a Teacher, and viewing `/s/allthethings` as a Student in that teacher's section and verifying that the lesson is correctly hidden.

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
