### PR TITLE
Finish EC2 instance import

### DIFF
--- a/aws/cloudformation/cloud_formation_stack.yml.erb
+++ b/aws/cloudformation/cloud_formation_stack.yml.erb
@@ -191,8 +191,7 @@ Resources:
           Value: 30
 <%   unless frontends -%>
       Targets:
-        - Id: <%=daemon_instance_id%>
-          Port: 80
+        - {Id: !Ref <%=daemon%>, Port: 80}
 <%   end -%>
 <% end -%>
 
@@ -414,7 +413,7 @@ Resources:
 <% if daemon -%>
   <%=daemon%>:
     Type: AWS::EC2::Instance
-<% if @daemon_instance_id -%>
+<% unless rack_env?(:adhoc) -%>
     DeletionPolicy: Retain
 <% end -%>
     CreationPolicy:
@@ -426,7 +425,7 @@ Resources:
       IamInstanceProfile: !Ref DaemonInstanceProfile
       KeyName: <%=SSH_KEY_NAME%>
       Tags:
-        - {Key: Name, Value: <%=frontends ? "#{environment}-daemon" : '!Ref AWS::StackName'%>}
+        - {Key: Name, Value: <%=frontends ? "#{environment}-daemon" : "!Ref 'AWS::StackName'"%>}
       BlockDeviceMappings:
         - DeviceName: /dev/sda1
           Ebs:

--- a/aws/cloudformation/components/alarms.yml.erb
+++ b/aws/cloudformation/components/alarms.yml.erb
@@ -24,8 +24,7 @@
       AlarmName: <%="#{stack_name}_daemon_high_memory_utilization" %>
       ComparisonOperator: GreaterThanThreshold
       Dimensions:
-        - Name: InstanceId
-          Value: <%= daemon_instance_id || "!Ref #{daemon}" %>
+        - {Name: InstanceId, Value: !Ref <%=daemon%>}
       EvaluationPeriods: 5
       MetricName: MemoryUtilization
       Namespace: 'System/Linux'

--- a/lib/cdo/cloud_formation/cdo_app.rb
+++ b/lib/cdo/cloud_formation/cdo_app.rb
@@ -38,7 +38,7 @@ module Cdo::CloudFormation
     # number of seconds to configure as Time To Live for DNS record
     DNS_TTL = 60
 
-    attr_reader :daemon, :daemon_instance_id
+    attr_reader :daemon
 
     # Struct providing arbitrary configuration options used by the template.
     # @return [OpenStruct]
@@ -66,17 +66,6 @@ module Cdo::CloudFormation
       stack_name << "-#{branch}" if stack_name == 'adhoc'
       raise "Stack name must not include 'dashboard'" if stack_name.include?('dashboard')
 
-      # Don't provision daemon where manually-provisioned daemon instances already exist.
-      # Track Instance ID of manually-provisioned daemon instances that already exist and can't be referenced dynamically
-      # TODO import manually-provisioned instances into cloudformation stacks.
-      if %w(autoscale-prod test staging levelbuilder).include? stack_name
-        @daemon_instance_id = {
-          'autoscale-prod' => 'i-08f5f8ace0a473b8d',
-          'test' => 'i-004727200191f3251',
-          'staging' => 'i-02e6cdc765421ab34',
-          'levelbuilder' => 'i-0907b146f7e6503f6'
-        }[stack_name]
-      end
       # Use alternate legacy EC2 instance resource name for standalone-adhoc stack.
       @daemon = rack_env?(:adhoc) && !frontends ?
                   'WebServer' :


### PR DESCRIPTION
Followup to #36514, #36680, #36693:

- Fix typo in `!Ref 'AWS::StackName'` reference
- Remove obsolete `daemon_instance_id` values from template to simplify template logic