### PR TITLE
Replace therubyracer with mini_racer

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -216,9 +216,10 @@ gem 'naturally' # for sorting string naturally
 
 gem 'retryable' # retry code blocks when they throw exceptions
 
-# Used by a build script.
+# Used by `uglifier` to minify JS assets in the Asset Pipeline.
 gem 'execjs'
-gem 'therubyracer', '~> 0.12.2', platforms: :ruby
+# JavaScript runtime used by ExecJS.
+gem 'mini_racer'
 
 gem 'jwt' # single signon for zendesk
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -537,7 +537,7 @@ GEM
     launchy (2.4.3)
       addressable (~> 2.3)
     le (2.7.2)
-    libv8 (3.16.14.15)
+    libv8 (8.4.255.0)
     listen (3.1.5)
       rb-fsevent (~> 0.9, >= 0.9.4)
       rb-inotify (~> 0.9, >= 0.9.7)
@@ -557,6 +557,8 @@ GEM
     mini_magick (4.9.5)
     mini_mime (1.0.1)
     mini_portile2 (2.4.0)
+    mini_racer (0.3.1)
+      libv8 (~> 8.4.255)
     minitest (5.11.3)
     minitest-around (0.4.1)
       minitest (~> 5.0)
@@ -721,7 +723,6 @@ GEM
       json
     redcarpet (3.3.4)
     redis (3.3.3)
-    ref (2.0.0)
     representable (3.0.4)
       declarative (< 0.1.0)
       declarative-option (< 0.2.0)
@@ -831,9 +832,6 @@ GEM
       json (>= 1.4.3)
     sysexits (1.2.0)
     temple (0.8.0)
-    therubyracer (0.12.3)
-      libv8 (~> 3.16.14.15)
-      ref
     thin (1.7.2)
       daemons (~> 1.0, >= 1.0.9)
       eventmachine (~> 1.0, >= 1.0.4)
@@ -984,6 +982,7 @@ DEPENDENCIES
   loofah (~> 2.2.1)
   memory_profiler
   mini_magick (>= 4.9.4)
+  mini_racer
   minitest (~> 5.5)
   minitest-around
   minitest-reporters (~> 1.2.0.beta3)
@@ -1061,7 +1060,6 @@ DEPENDENCIES
   sqlite3
   sshkit
   stringex (~> 2.5.2)
-  therubyracer (~> 0.12.2)
   thin
   timecop
   twilio-ruby


### PR DESCRIPTION
`mini_racer` is an alternative [ExecJS runtime](https://github.com/rails/execjs#execjs) with an up-to-date [`libv8`](https://github.com/rubyjs/libv8) dependency, which should offer better performance and compatibility with current development-workstation installations.