### PR TITLE
Update Regional Partner Fields

### DIFF
--- a/dashboard/app/controllers/regional_partners_controller.rb
+++ b/dashboard/app/controllers/regional_partners_controller.rb
@@ -55,10 +55,9 @@ class RegionalPartnersController < ApplicationController
   def update
     update_params = regional_partner_params.to_h
     %w(csd csp).each do |course|
-      %w(teacher facilitator).each do |role|
+      %w(facilitator).each do |role|
         %w(open close).each do |state|
           key = "apps_#{state}_date_#{course}_#{role}".to_sym
-
           # Do a date validation.  An exception will result if invalid.
           Date.parse(regional_partner_params[key]) if regional_partner_params[key].presence
         end
@@ -66,6 +65,8 @@ class RegionalPartnersController < ApplicationController
     end
 
     # Do a date validation.  An exception will result if invalid.
+    Date.parse(regional_partner_params[:apps_open_date_teacher]) if regional_partner_params[:apps_open_date_teacher].presence
+    Date.parse(regional_partner_params[:apps_close_date_teacher]) if regional_partner_params[:apps_close_date_teacher].presence
     Date.parse(regional_partner_params[:apps_priority_deadline_date]) if regional_partner_params[:apps_priority_deadline_date].presence
 
     if @regional_partner.update(update_params)
@@ -152,13 +153,11 @@ class RegionalPartnersController < ApplicationController
       urban
       cohort_capacity_csd
       cohort_capacity_csp
-      apps_open_date_csd_teacher
+      apps_open_date_teacher
+      apps_close_date_teacher
       apps_open_date_csd_facilitator
-      apps_open_date_csp_teacher
       apps_open_date_csp_facilitator
-      apps_close_date_csd_teacher
       apps_close_date_csd_facilitator
-      apps_close_date_csp_teacher
       apps_close_date_csp_facilitator
       apps_priority_deadline_date
       applications_principal_approval

--- a/dashboard/app/models/regional_partner.rb
+++ b/dashboard/app/models/regional_partner.rb
@@ -42,13 +42,11 @@ class RegionalPartner < ActiveRecord::Base
   serialized_attrs %w(
     cohort_capacity_csd
     cohort_capacity_csp
-    apps_open_date_csd_teacher
+    apps_open_date_teacher
+    apps_close_date_teacher
     apps_open_date_csd_facilitator
-    apps_open_date_csp_teacher
     apps_open_date_csp_facilitator
-    apps_close_date_csd_teacher
     apps_close_date_csd_facilitator
-    apps_close_date_csp_teacher
     apps_close_date_csp_facilitator
     apps_priority_deadline_date
     applications_principal_approval
@@ -104,15 +102,11 @@ class RegionalPartner < ActiveRecord::Base
   end
 
   def summer_workshops_earliest_apps_open_date
-    if apps_open_date_csd_teacher || apps_open_date_csp_teacher
-      Date.parse([apps_open_date_csd_teacher, apps_open_date_csp_teacher].compact.min).strftime('%B %e, %Y')
-    end
+    apps_open_date_teacher && Date.parse(apps_open_date_teacher).strftime('%B %e, %Y')
   end
 
   def summer_workshops_latest_apps_close_date
-    if apps_close_date_csd_teacher || apps_close_date_csp_teacher
-      Date.parse([apps_close_date_csd_teacher, apps_close_date_csp_teacher].compact.max).strftime('%B %e, %Y')
-    end
+    apps_close_date_teacher && Date.parse(apps_close_date_teacher).strftime('%B %e, %Y')
   end
 
   def upcoming_summer_workshops

--- a/dashboard/app/views/regional_partners/_form.html.haml
+++ b/dashboard/app/views/regional_partners/_form.html.haml
@@ -14,17 +14,12 @@
   .field
     = f.label :urban
     = f.check_box :urban
-  - %w(csd csp).each do |course|
-    - %w(teacher facilitator).each do |role|
-      .field
-        = f.label nil, "Apps Open Date for #{course.upcase} #{role} (YYYY-MM-DD)"
-        = f.text_field "apps_open_date_#{course}_#{role}".to_sym
-      .field
-        = f.label nil, "Apps Close Date for #{course.upcase} #{role} (YYYY-MM-DD)"
-        = f.text_field "apps_close_date_#{course}_#{role}".to_sym
   .field
-    = f.label nil, "Apps Priority Deadline Date (YYYY-MM-DD)"
-    = f.text_field :apps_priority_deadline_date
+    = f.label nil, "Apps Open Date for Teachers (YYYY-MM-DD)"
+    = f.text_field :apps_open_date_teacher
+  .field
+    = f.label nil, "Apps Close Date for Teachers (YYYY-MM-DD)"
+    = f.text_field :apps_close_date_teacher
   .field
     = f.label nil, "Applications Principal Approval"
     .applications_principal_approval
@@ -46,10 +41,6 @@
   .field
     = f.label :link_to_partner_application
     = f.text_field :link_to_partner_application, {style: 'width: 500px'}
-  -%w(csd csp).each do |course|
-    .field
-      = f.label nil, "#{course.upcase} Cost"
-      = f.text_field "#{course}_cost".to_sym
   .field
     = f.label nil, "Program information"
     = f.text_area :cost_scholarship_information, {style: 'width: 500px'}
@@ -63,27 +54,6 @@
     = f.label :contact_email
     = f.text_field :contact_email
   .field
-    = f.label :attention
-    = f.text_field :attention
-  .field
-    = f.label :street
-    = f.text_field :street
-  .field
-    = f.label :apartment_or_suite
-    = f.text_field :apartment_or_suite
-  .field
-    = f.label :city
-    = f.text_field :city
-  .field
-    = f.label :state
-    = f.text_field :state
-  .field
-    = f.label :zip_code
-    = f.text_field :zip_code
-  .field
     = f.label :phone_number
     = f.text_field :phone_number
-  .field
-    = f.label :notes
-    = f.text_area :notes
   %button.btn.btn-primary{type: 'submit', style: 'margin: 0'} Save

--- a/dashboard/app/views/regional_partners/show.html.haml
+++ b/dashboard/app/views/regional_partners/show.html.haml
@@ -20,21 +20,12 @@
 %p
   %strong Urban:
   = @regional_partner.urban? ? 'Yes' : 'No'
-- %w(csd csp).each do |course|
-  - %w(teacher facilitator).each do |role|
-    - %w(open close).each do |state|
-      %p
-        %strong
-          = "Apps #{state} date for #{course.upcase} #{role.pluralize}"
-        = @regional_partner.send("apps_#{state}_date_#{course}_#{role}".to_sym)
 %p
-  %strong Apps Priority Deadline Date
-  = @regional_partner.apps_priority_deadline_date
-- %w(csd csp).each do |course|
-  %p
-    %strong
-      ="#{course.upcase} Cost"
-    = @regional_partner.send("#{course}_cost".to_sym)
+  %strong Apps open date for teachers
+  = @regional_partner.apps_open_date_teacher
+%p
+  %strong Apps close date for teachers
+  = @regional_partner.apps_close_date_teacher
 %p
   %strong
     ="Program information"
@@ -52,29 +43,8 @@
   %strong Contact Name:
   = @regional_partner.contact_name
 %p
-  %strong Ship Attention:
-  = @regional_partner.attention
-%p
-  %strong Street:
-  = @regional_partner.street
-%p
-  %strong Apartment/Suite:
-  = @regional_partner.apartment_or_suite
-%p
-  %strong City:
-  = @regional_partner.city
-%p
-  %strong State:
-  = @regional_partner.state
-%p
-  %strong Zip Code:
-  = @regional_partner.zip_code
-%p
   %strong Ship Phone Number:
   = @regional_partner.phone_number
-%p
-  %strong Notes:
-  = @regional_partner.notes
 %p
   %strong Created At:
   = @regional_partner.created_at.strftime('%F')

--- a/dashboard/test/factories/factories.rb
+++ b/dashboard/test/factories/factories.rb
@@ -1181,10 +1181,8 @@ FactoryGirl.define do
     contact_name "Contact Name"
     contact_email "contact@code.org"
     group 1
-    apps_open_date_csp_teacher {(Date.current - 1.day).strftime("%Y-%m-%d")}
-    apps_open_date_csd_teacher {(Date.current - 2.days).strftime("%Y-%m-%d")}
-    apps_close_date_csp_teacher {(Date.current + 3.days).strftime("%Y-%m-%d")}
-    apps_close_date_csd_teacher {(Date.current + 4.days).strftime("%Y-%m-%d")}
+    apps_open_date_teacher {(Date.current - 2.days).strftime("%Y-%m-%d")}
+    apps_close_date_teacher {(Date.current + 3.days).strftime("%Y-%m-%d")}
     csd_cost 10
     csp_cost 12
     cost_scholarship_information "Additional scholarship information will be here."

--- a/dashboard/test/factories/pd_factories.rb
+++ b/dashboard/test/factories/pd_factories.rb
@@ -19,10 +19,8 @@ FactoryGirl.define do
   # example zip: 42001
   factory :regional_partner_kentucky, parent: :regional_partner_with_summer_workshops do
     # Applications are closed.
-    apps_open_date_csp_teacher {(Date.current - 5.days).strftime("%Y-%m-%d")}
-    apps_open_date_csd_teacher {(Date.current - 6.days).strftime("%Y-%m-%d")}
-    apps_close_date_csp_teacher {(Date.current - 2.days).strftime("%Y-%m-%d")}
-    apps_close_date_csd_teacher {(Date.current - 3.days).strftime("%Y-%m-%d")}
+    apps_open_date_teacher {(Date.current - 6.days).strftime("%Y-%m-%d")}
+    apps_close_date_teacher {(Date.current - 3.days).strftime("%Y-%m-%d")}
     mappings {[create(:pd_regional_partner_mapping, state: "KY")]}
   end
 
@@ -31,10 +29,8 @@ FactoryGirl.define do
     # No contact details, no workshop application dates, and no workshops.
     contact_name nil
     contact_email nil
-    apps_open_date_csp_teacher nil
-    apps_open_date_csd_teacher nil
-    apps_close_date_csp_teacher nil
-    apps_close_date_csd_teacher nil
+    apps_open_date_teacher nil
+    apps_close_date_teacher nil
     mappings {[create(:pd_regional_partner_mapping, state: "NJ")]}
     pd_workshops {[]}
   end
@@ -42,20 +38,15 @@ FactoryGirl.define do
   # example zip: 97202
   factory :regional_partner_oregon, parent: :regional_partner_with_summer_workshops do
     # Opening at a specific date in the future.
-    apps_open_date_csp_teacher {(Date.current + 5.days).strftime("%Y-%m-%d")}
-    apps_open_date_csd_teacher {(Date.current + 6.days).strftime("%Y-%m-%d")}
-    apps_close_date_csp_teacher {(Date.current + 14.days).strftime("%Y-%m-%d")}
-    apps_close_date_csd_teacher {(Date.current + 15.days).strftime("%Y-%m-%d")}
+    apps_open_date_teacher {(Date.current + 5.days).strftime("%Y-%m-%d")}
+    apps_close_date_teacher {(Date.current + 15.days).strftime("%Y-%m-%d")}
     mappings {[create(:pd_regional_partner_mapping, state: "OR")]}
   end
 
   # example zip: 82001
   factory :regional_partner_wyoming, parent: :regional_partner_with_summer_workshops do
-    # CSD dates but no CSP dates.
-    apps_open_date_csp_teacher nil
-    apps_open_date_csd_teacher {(Date.current + 6.days).strftime("%Y-%m-%d")}
-    apps_close_date_csp_teacher nil
-    apps_close_date_csd_teacher {(Date.current + 15.days).strftime("%Y-%m-%d")}
+    apps_open_date_teacher {(Date.current + 6.days).strftime("%Y-%m-%d")}
+    apps_close_date_teacher {(Date.current + 15.days).strftime("%Y-%m-%d")}
     mappings {[create(:pd_regional_partner_mapping, state: "WY")]}
   end
 


### PR DESCRIPTION
Update available fields on regional partner page for 2021-22 application season. The changes are:
- replace CSD/CSP teacher app open/close date fields with one apps_open_date_teacher and one apps_close_date_teacher since we do not allow different dates for CSD and CSP
- hide the following fields: facilitator app open/close dates, app priority deadline date, cost, RP address fields, notes

<!-- ### Background -->
<!-- ### Privacy -->
<!-- ### Security -->
<!-- ### Caching -->
<!-- ### Deployment strategy -->
<!-- ### Future work -->

## Links

<!--
  Any relevant links to external resources; ie, specification documents, jira
  items, related PRs, honeybadger errors, etc
-->

- [spec](https://docs.google.com/document/d/1X9Vymfb45uiiZ9J4PZempuG4xY9KqMiXBxUT4wJ_G6Q/edit)
- [jira](https://codedotorg.atlassian.net/browse/PLC-984)

## Testing story
Tested the new date field controls the showing/hiding of applications on the regional partner landing page, and the other fields are now hidden.

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
