### PR TITLE
Google Classroom Share Button Instrumentation

### DIFF
--- a/apps/src/sites/studio/pages/scripts/show.js
+++ b/apps/src/sites/studio/pages/scripts/show.js
@@ -4,6 +4,7 @@ import {
   setVerified,
   setVerifiedResources
 } from '@cdo/apps/code-studio/verifiedTeacherRedux';
+import {setCurrentUserId} from '@cdo/apps/templates/currentUserRedux';
 import {getStore} from '@cdo/apps/code-studio/redux';
 import {registerReducers} from '@cdo/apps/redux';
 import plcHeaderReducer, {
@@ -40,6 +41,10 @@ function initPage() {
 
   if (scriptData.is_verified_teacher) {
     store.dispatch(setVerified());
+  }
+
+  if (scriptData.user_id) {
+    store.dispatch(setCurrentUserId(scriptData.user_id));
   }
 
   if (scriptData.script_announcements) {

--- a/apps/src/sites/studio/pages/scripts/show.js
+++ b/apps/src/sites/studio/pages/scripts/show.js
@@ -4,7 +4,6 @@ import {
   setVerified,
   setVerifiedResources
 } from '@cdo/apps/code-studio/verifiedTeacherRedux';
-import {setCurrentUserId} from '@cdo/apps/templates/currentUserRedux';
 import {getStore} from '@cdo/apps/code-studio/redux';
 import {registerReducers} from '@cdo/apps/redux';
 import plcHeaderReducer, {
@@ -41,10 +40,6 @@ function initPage() {
 
   if (scriptData.is_verified_teacher) {
     store.dispatch(setVerified());
-  }
-
-  if (scriptData.user_id) {
-    store.dispatch(setCurrentUserId(scriptData.user_id));
   }
 
   if (scriptData.script_announcements) {

--- a/apps/src/templates/progress/GoogleClassroomShareButton.jsx
+++ b/apps/src/templates/progress/GoogleClassroomShareButton.jsx
@@ -2,6 +2,7 @@ import PropTypes from 'prop-types';
 import React from 'react';
 import Button from '../Button';
 import i18n from '@cdo/locale';
+import firehoseClient from '@cdo/apps/lib/util/firehose';
 
 // https://developers.google.com/classroom/brand
 const styles = {
@@ -23,7 +24,8 @@ export default class GoogleClassroomShareButton extends React.Component {
     itemtype: PropTypes.string.isRequired,
     title: PropTypes.string,
     height: PropTypes.number,
-    courseid: PropTypes.number
+    courseid: PropTypes.number,
+    analyticsData: PropTypes.object
   };
 
   static defaultProps = {
@@ -42,6 +44,7 @@ export default class GoogleClassroomShareButton extends React.Component {
 
     this.onShareStart = this.onShareStart.bind(this);
     this.onShareComplete = this.onShareComplete.bind(this);
+    this.logEvent = this.logEvent.bind(this);
   }
 
   buttonRef = null;
@@ -63,16 +66,29 @@ export default class GoogleClassroomShareButton extends React.Component {
     this.resizeObserver.disconnect();
   }
 
-  onShareStartName = () => 'onShareStart_' + this.props.buttonId;
+  onShareStartName() {
+    return 'onShareStart_' + this.props.buttonId;
+  }
 
-  onShareCompleteName = () => 'onShareComplete_' + this.props.buttonId;
+  onShareCompleteName() {
+    return 'onShareComplete_' + this.props.buttonId;
+  }
 
   onShareStart() {
-    console.log('on share start: ' + this.props.title);
+    this.logEvent('share_started');
   }
 
   onShareComplete() {
-    console.log('on share complete: ' + this.props.title);
+    this.logEvent('share_completed');
+  }
+
+  logEvent(event) {
+    firehoseClient.putRecord({
+      study: 'google-classroom-share-button',
+      study_group: 'v0',
+      event: event,
+      data_json: JSON.stringify(this.props.analyticsData)
+    });
   }
 
   // https://developers.google.com/classroom/guides/sharebutton

--- a/apps/src/templates/progress/GoogleClassroomShareButton.jsx
+++ b/apps/src/templates/progress/GoogleClassroomShareButton.jsx
@@ -39,6 +39,9 @@ export default class GoogleClassroomShareButton extends React.Component {
     super(props);
     this.onButtonResize = this.onButtonResize.bind(this);
     this.resizeObserver = new ResizeObserver(this.onButtonResize);
+
+    this.onShareStart = this.onShareStart.bind(this);
+    this.onShareComplete = this.onShareComplete.bind(this);
   }
 
   buttonRef = null;
@@ -49,11 +52,27 @@ export default class GoogleClassroomShareButton extends React.Component {
   componentDidMount() {
     this.renderButton();
     this.resizeObserver.observe(this.buttonRef);
+
+    // Use unique callback names since we're adding to the global namespace
+    window[this.onShareStartName()] = this.onShareStart;
+    window[this.onShareCompleteName()] = this.onShareComplete;
   }
 
   onButtonResize() {
     this.setState({buttonRendered: true});
     this.resizeObserver.disconnect();
+  }
+
+  onShareStartName = () => 'onShareStart_' + this.props.buttonId;
+
+  onShareCompleteName = () => 'onShareComplete_' + this.props.buttonId;
+
+  onShareStart() {
+    console.log('on share start: ' + this.props.title);
+  }
+
+  onShareComplete() {
+    console.log('on share complete: ' + this.props.title);
   }
 
   // https://developers.google.com/classroom/guides/sharebutton
@@ -64,7 +83,9 @@ export default class GoogleClassroomShareButton extends React.Component {
       itemtype: this.props.itemtype,
       title: this.props.title,
       size: this.props.height,
-      courseid: this.props.courseid
+      courseid: this.props.courseid,
+      onsharestart: `${this.onShareStartName()}`,
+      onsharecomplete: `${this.onShareCompleteName()}`
     });
   }
 

--- a/apps/src/templates/progress/GoogleClassroomShareButton.jsx
+++ b/apps/src/templates/progress/GoogleClassroomShareButton.jsx
@@ -3,6 +3,7 @@ import React from 'react';
 import Button from '../Button';
 import i18n from '@cdo/locale';
 import firehoseClient from '@cdo/apps/lib/util/firehose';
+import {isIE11} from '@cdo/apps/util/browser-detector';
 
 // https://developers.google.com/classroom/brand
 const styles = {
@@ -69,8 +70,7 @@ export default class GoogleClassroomShareButton extends React.Component {
     // The button callbacks are not supported in IE, so in IE we use click
     // events to record analytics. The button is rendered in an iframe though,
     // so to detect the click events we need to use the 'blur' event.
-    const isIE = /*@cc_on!@*/ false || !!document.documentMode;
-    if (isIE) {
+    if (isIE11) {
       window.addEventListener('blur', this.blur);
     }
   }
@@ -112,12 +112,15 @@ export default class GoogleClassroomShareButton extends React.Component {
   }
 
   logEvent(event) {
-    firehoseClient.putRecord({
-      study: 'google-classroom-share-button',
-      study_group: 'v0',
-      event: event,
-      data_json: JSON.stringify(this.props.analyticsData)
-    });
+    firehoseClient.putRecord(
+      {
+        study: 'google-classroom-share-button',
+        study_group: 'v0',
+        event: event,
+        data_json: JSON.stringify(this.props.analyticsData)
+      },
+      {includeUserId: true}
+    );
   }
 
   // https://developers.google.com/classroom/guides/sharebutton

--- a/apps/src/templates/progress/ProgressLessonTeacherInfo.jsx
+++ b/apps/src/templates/progress/ProgressLessonTeacherInfo.jsx
@@ -41,6 +41,7 @@ class ProgressLessonTeacherInfo extends React.Component {
 
     // redux provided
     section: sectionShape,
+    userId: PropTypes.number,
     scriptAllowsHiddenStages: PropTypes.bool.isRequired,
     hiddenStageState: PropTypes.object.isRequired,
     scriptName: PropTypes.string.isRequired,
@@ -57,13 +58,19 @@ class ProgressLessonTeacherInfo extends React.Component {
       study: 'hidden-lessons',
       study_group: 'v0',
       event: value,
-      data_json: JSON.stringify({
-        script_name: scriptName,
-        section_id: sectionId,
-        lesson_id: lesson.id,
-        lesson_name: lesson.name
-      })
+      data_json: JSON.stringify(this.firehoseData())
     });
+  };
+
+  firehoseData = () => {
+    const {userId, scriptName, section, lesson} = this.props;
+    return {
+      user_id: userId,
+      script_name: scriptName,
+      section_id: section.id,
+      lesson_id: lesson.id,
+      lesson_name: lesson.name
+    };
   };
 
   render() {
@@ -127,6 +134,7 @@ class ProgressLessonTeacherInfo extends React.Component {
               url={levelUrl}
               title={lesson.name}
               courseid={courseId}
+              analyticsData={this.firehoseData()}
             />
           </div>
         )}
@@ -141,6 +149,7 @@ export default connect(
   state => ({
     section:
       state.teacherSections.sections[state.teacherSections.selectedSectionId],
+    userId: state.currentUser.userId,
     scriptAllowsHiddenStages: state.hiddenStage.hideableStagesAllowed,
     hiddenStageState: state.hiddenStage,
     scriptName: state.progress.scriptName,

--- a/apps/src/templates/progress/ProgressLessonTeacherInfo.jsx
+++ b/apps/src/templates/progress/ProgressLessonTeacherInfo.jsx
@@ -41,7 +41,6 @@ class ProgressLessonTeacherInfo extends React.Component {
 
     // redux provided
     section: sectionShape,
-    userId: PropTypes.number,
     scriptAllowsHiddenStages: PropTypes.bool.isRequired,
     hiddenStageState: PropTypes.object.isRequired,
     scriptName: PropTypes.string.isRequired,
@@ -54,20 +53,22 @@ class ProgressLessonTeacherInfo extends React.Component {
     const {scriptName, section, lesson, toggleHiddenStage} = this.props;
     const sectionId = section.id.toString();
     toggleHiddenStage(scriptName, sectionId, lesson.id, value === 'hidden');
-    firehoseClient.putRecord({
-      study: 'hidden-lessons',
-      study_group: 'v0',
-      event: value,
-      data_json: JSON.stringify(this.firehoseData())
-    });
+    firehoseClient.putRecord(
+      {
+        study: 'hidden-lessons',
+        study_group: 'v0',
+        event: value,
+        data_json: JSON.stringify(this.firehoseData())
+      },
+      {includeUserId: true}
+    );
   };
 
   firehoseData = () => {
-    const {userId, scriptName, section, lesson} = this.props;
+    const {scriptName, section, lesson} = this.props;
     return {
-      user_id: userId,
       script_name: scriptName,
-      section_id: section.id,
+      section_id: section && section.id,
       lesson_id: lesson.id,
       lesson_name: lesson.name
     };
@@ -149,7 +150,6 @@ export default connect(
   state => ({
     section:
       state.teacherSections.sections[state.teacherSections.selectedSectionId],
-    userId: state.currentUser.userId,
     scriptAllowsHiddenStages: state.hiddenStage.hideableStagesAllowed,
     hiddenStageState: state.hiddenStage,
     scriptName: state.progress.scriptName,


### PR DESCRIPTION
this adds analytics logging to #36512.

the share callbacks provided by the google api aren't supported in IE, and since the button is embedded in an iframe we can't detect click events in the usual way because they're only delivered to the document in the iframe, so a workaround i found is to use the 'blur' event to detect when our window loses focus, and use mouseover/mouseout to detect if the mouse is over our button when that happens. note that is won't work on mobile because mobile doesn't receive mouse events, but the number of teachers using our site on IE on mobile is hopefully negligible.

this is just a draft PR for now because #36512 is still pending sign-off from product. once that PR is merged, this PR will only contain the last three commits.

<!-- ### Background -->
<!-- ### Privacy -->
<!-- ### Security -->
<!-- ### Caching -->
<!-- ### Deployment strategy -->
<!-- ### Future work -->

## Links

<!--
  Any relevant links to external resources; ie, specification documents, jira
  items, related PRs, honeybadger errors, etc
-->

- [LP-1521]



[LP-1521]: https://codedotorg.atlassian.net/browse/LP-1521