### PR TITLE
Add a brew command to install Java 8 JDK

### DIFF
--- a/SETUP.md
+++ b/SETUP.md
@@ -115,7 +115,7 @@ After setup, read about our [code styleguide](./STYLEGUIDE.md), our [test suites
 
     </details>
 
-1. Install the [Java 8 JDK](http://www.oracle.com/technetwork/java/javase/downloads/index.html)
+1. Install the Java 8 JDK: `brew cask install adoptopenjdk/openjdk/adoptopenjdk8`. More info [here](http://www.oracle.com/technetwork/java/javase/downloads/index.html).
 
 1. [Download](https://www.google.com/chrome/) and install Google Chrome, if you have not already. This is needed in order to be able to run apps tests locally.
 


### PR DESCRIPTION
The current link takes you to Oracle and you have to have an account to download (even though it's free.) Running this brew command speeds up the process, no account needed.

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
