### PR TITLE
[WIP] Purify HOC events

### DIFF
--- a/bin/cron/update_hoc_map
+++ b/bin/cron/update_hoc_map
@@ -15,6 +15,7 @@ abort 'Script already running' unless only_one_running?(__FILE__)
 require File.expand_path('../../../pegasus/src/env', __FILE__)
 require src_dir 'database'
 require 'cdo/properties'
+require 'cdo/profanity_filter'
 require 'dynamic_config/dcdo'
 require 'open3'
 require 'tempfile'
@@ -44,6 +45,9 @@ def main
       else
         data['organization_name_s']
       end
+
+    # Skip if organization or school name contains a profanity
+    next if ProfanityFilter.find_potential_profanity_in_any_language(organization_name)
 
     coordinates = processed_data['location_p'].split(',')
     long = coordinates[1].to_f

--- a/lib/cdo/profanity_filter.rb
+++ b/lib/cdo/profanity_filter.rb
@@ -1,6 +1,26 @@
 require 'cdo/web_purify'
 
 class ProfanityFilter
+  # List of languages that Web Purify supports according to
+  # https://www.webpurify.com/documentation/additional/language
+  WEB_PURIFY_SUPPORTED_LANGUAGES = {
+    ar: "Arabic",
+    de: "German",
+    en: "English",
+    es: "Spanish",
+    fr: "French",
+    hi: "Hindi",
+    it: "Italian",
+    ja: "Japanese",
+    ko: "Korean", # in beta
+    pa: "Punjabi", # in beta
+    pt: "Portuguese",
+    ru: "Russian",
+    th: "Thai",
+    tr: "Turkish",
+    zh: "Chinese (Simplified and Traditional)" # in beta
+  }
+
   # List of words that should be allowed only in specific languages.
   #
   # Entries are in the format
@@ -17,6 +37,19 @@ class ProfanityFilter
     fick: %w(sv) # "got" in Swedish
   }
 
+  # Look for profanities in a given text, return true if any expletive found
+  # or false if no profanities found. Checks against all locales.
+  #
+  # @param [String] text to check for profanity
+  # @return [String, nil] The first instance of profanity (if any) or nil (if none)
+  def self.find_potential_profanity_in_any_language(text)
+    WEB_PURIFY_SUPPORTED_LANGUAGES.each do |language_code|
+      expletive = find_potential_profanity(text, language_code)
+      break unless expletive.nil?
+    end
+    expletive
+  end
+
   # Look for profanity in a given text, return the first expletive found
   # or nil if no profanity is found.
   #
@@ -28,10 +61,10 @@ class ProfanityFilter
     expletive.is_a?(Array) ? expletive.first : expletive
   end
 
-  # Look for profanities in a given text, return the expletives found
+  # Look for profanities in a given text, return all expletives found
   # or nil if no profanities are found.
   #
-  # @param [String] text to check for profanity
+  # @param [String] text to check for profanities
   # @param [String] language_code a two-character ISO 639-1 language code
   # @return [Array<String>, nil] The profanities (if any) or nil (if none)
   def self.find_potential_profanities(text, language_code)


### PR DESCRIPTION
This change takes the most conservative approach. If the organization or school name of a HOC event contains a profanity in _any_ language supported by Web Purify, then we will hide it from the HOC map and [list of events](http://hourofcode.com/events). For example, if `shit` is considered profane only in English, all events with `shit` in the organization or school name will be blocked from showing publicly no matter what language the event is in.

This only checks organization and school name as these are the only user-entered fields that are displayed publicly. City is determined by geocoding the user-entered address and is considered low-risk to be profane. This also only checks the languages currently supported by Web Purify, and the list of supported languages must be updated manually.

### Requirements
- [ ] This change hides all HOC events with any detected profanity in any language
- [ ] Send an email to support@code.org with events that were blocked so they can
     - Reference it if a partner complains that their event is missing (may have been considered profane in _any_ language)
     - Take further action like deleting the event from the database or blocking/reporting a repeat offender


### Not Requirements
- [ ] This change will not prevent submissions to the HOC form
- [ ] This change will not delete profane submissions from our database
- [ ] We could identify the user's locale when submitting the event so that we can check the event's info only against this locale. Still, I think it would be best to always check every event against all languages so that if it's profane in at least one language the event will be hidden from everyone.

### To Do
- [ ] Confirm we want to go ahead with a feature like this
- [ ] Confirm requirements and level of restriction
- [x] Hide from HOC map
- [ ] Hide from events page
- [ ] Send an email to support@code.org with info of blocked events
- [ ] Add test cases and E2E testing with form data

### Future Work / Alternative Solutions
* We could test this profanity check against 2019 hoc events to see how many false positives there are. If it's significant, we could add the ability to respect exceptions. These exceptions can be added per language in LANGUAGE_SPECIFIC_ALLOWLIST, then each event must be mark as unprocessed so it can be re-processed by the `update_hoc_map` cron job. If we want to support this, we would need to know the locale of each hoc event so that we could show it when the user is visiting the site in Spanish but hide it when the user is visiting the site in English, for example.
* We could also add the check immediately after the event is submitted and before the event is added to the database. We could have a new field in the form like `blocked_for_profanity` and have the `update_hoc_map` cronjob check against that field.

## Links
- [Web Purify supported languages](https://www.webpurify.com/documentation/additional/language)

## Testing story
- See To Do

# Reviewer Checklist:
- [ ] Tests provide adequate coverage
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
