### PR TITLE
Test drone trigger from fork.

### DIFF
--- a/apps/src/noop.js
+++ b/apps/src/noop.js
@@ -3,5 +3,8 @@
  * include a bunch of modules that we don't want to end up in our webpack bundle
  * In those cases, we can alias to this noop export, so that something like
  * require('repl') ends up with an empty object.
+ *
+ * Trigger apps test to run.
+ *
  */
 module.exports = {};

--- a/apps/src/noop.js
+++ b/apps/src/noop.js
@@ -3,8 +3,5 @@
  * include a bunch of modules that we don't want to end up in our webpack bundle
  * In those cases, we can alias to this noop export, so that something like
  * require('repl') ends up with an empty object.
- *
- * Trigger apps test to run.
- *
  */
 module.exports = {};

--- a/dashboard/app/controllers/admin_users_controller.rb
+++ b/dashboard/app/controllers/admin_users_controller.rb
@@ -1,4 +1,5 @@
 require 'cdo/activity_constants'
+# Change to a file to trigger dashboard unit tests.
 
 class AdminUsersController < ApplicationController
   include Pd::PageHelper

--- a/dashboard/app/controllers/admin_users_controller.rb
+++ b/dashboard/app/controllers/admin_users_controller.rb
@@ -1,5 +1,6 @@
 require 'cdo/activity_constants'
 # Change to a file to trigger dashboard unit tests.
+# Create a commit in the fork that does not exist in the source repository.
 
 class AdminUsersController < ApplicationController
   include Pd::PageHelper

--- a/lib/cdo/aws/dms.rb
+++ b/lib/cdo/aws/dms.rb
@@ -2,6 +2,7 @@ require_relative '../../../deployment'
 require 'aws-sdk-databasemigrationservice'
 require 'ostruct'
 require 'cdo/redshift_import'
+# trigger lib tests to run.
 
 module Cdo
   class DMS

--- a/pegasus/forms/hoc_signup_2014.rb
+++ b/pegasus/forms/hoc_signup_2014.rb
@@ -1,5 +1,6 @@
 require 'honeybadger/ruby'
 require_relative '../helpers/hourofcode_helpers'
+# Trigger Pegasus unit tests.
 
 class HocSignup2014 < Form
   def self.normalize(data)

--- a/shared/middleware/helpers/bucket_helper.rb
+++ b/shared/middleware/helpers/bucket_helper.rb
@@ -4,6 +4,7 @@ require 'active_support/core_ext/module/attribute_accessors'
 require 'cdo/aws/s3'
 require 'honeybadger/ruby'
 require 'cdo/firehose'
+# Trigger shared unit tests.
 
 #
 # BucketHelper


### PR DESCRIPTION
Ensure that Drone does not run a Build for Pull Requests created from a fork.

<!-- ### Background -->
<!-- ### Privacy -->
<!-- ### Security -->
<!-- ### Caching -->
<!-- ### Deployment strategy -->
<!-- ### Future work -->

## Links

<!--
  Any relevant links to external resources; ie, specification documents, jira
  items, related PRs, honeybadger errors, etc
-->

- [spec]()
- [jira]()

## Testing story

Drone correctly ignored the GitHub web hook for this Pull Request:
``` JSON
{"commit":"657af274c085fc620fb1dd577ea316178d394884","event":"pull_request","level":"info","msg":"trigger: skipping hook. project ignores forks","ref":"refs/pull/36744/head","repo":"code-dot-org/code-dot-org","time":"2020-09-14T17:44:12Z"}
```

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
