### PR TITLE
SETUP.md changes for OS X Catalina

### DIFF
--- a/SETUP.md
+++ b/SETUP.md
@@ -33,6 +33,13 @@ You can do Code.org development using OSX, Ubuntu, or Windows (running Ubuntu in
         $> gem uninstall rake
         $> bundle update rake
     </details>
+    <details>
+        <summary>Troubleshoot: can't find gem bundler (>= 0.a) with executable bundle </summary>
+
+        If you have the issue "in `find_spec_for_exe': can't find gem bundler (>= 0.a) with executable bundle (Gem::GemNotFoundException)"
+
+        $> gem update --system
+    </details>
 
 1. `bundle exec rake install`
     * This can take a LONG time. You can see if progress is being made by opening up a second shell and starting `mysql -u root`. Run the following command twice, with approximately a 5-10 second delay between
@@ -50,6 +57,17 @@ After setup, read about our [code styleguide](./STYLEGUIDE.md), our [test suites
 ## OS-specific prerequisites
 
 ### OS X Mojave / Mavericks / Yosemite / El Capitan / Sierra
+<details>
+    <summary>Note: Additional information for those that use OS X Catalina</summary>
+
+    If you are using OS X Catalina, please note that zsh is the default shell, instead of bash.
+
+    The current OS X instructions assume that bash is the shell.
+
+    In order to use bash as the shell, please run:
+
+    chsh -s /bin/bash
+</details>
 
 1. Install Homebrew: `ruby -e "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install)"`
 1. Install Redis: `brew install redis`


### PR DESCRIPTION
<!--
  Your description goes here: A summary of the change, including any relevant motivation and context.

  If relevant, include a description both of the existing behavior and of the new behavior.
-->
Add Setup instructions for OS X Catalina

I use OS X Catalina, and I added a note that the instructions work if you set bash as the shell, as opposed to zsh.

Also, add debugging instructions for another issue that I encountered.

<!--
  Other aspects to consider. uncomment and add detail for any that seem necessary:
-->

<!-- ### Background -->
<!-- ### Privacy -->
<!-- ### Security -->
<!-- ### Caching -->
<!-- ### Deployment strategy -->
<!-- ### Future work -->

## Links

<!--
  Any relevant links to external resources; ie, specification documents, jira
  items, related PRs, honeybadger errors, etc
-->

- [spec]()
- [jira]()

## Testing story

<!--
  Does your change include appropriate tests?

  If so, please describe how the tests included in this PR are sufficient

  If not, please explain why this change does not need to be tested.
-->

I did not add tests because I only changed the SETUP.md file.

http://localhost-studio.code.org:3000/ still loads correctly.

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
