### PR TITLE
Adhoc: fix typo in start_inactive_instance

### DIFF
--- a/lib/cdo/cloud_formation/adhoc.rb
+++ b/lib/cdo/cloud_formation/adhoc.rb
@@ -11,7 +11,7 @@ module Cdo::CloudFormation
       else
         log.info "Starting Instance #{instance.id} ..."
         options[:quiet] = true
-        options[:start_inactive_instance] = true
+        stack.options[:start_inactive_instance] = true
         create_or_update
       end
       cfn_stack.outputs.each do |output|


### PR DESCRIPTION
Followup to #36571, fixes a typo to make the fix actually work properly.