### PR TITLE
21-22 Teacher Apps: Add more constants

### DIFF
--- a/apps/src/code-studio/pd/application/principalApproval/PrincipalApprovalComponent.jsx
+++ b/apps/src/code-studio/pd/application/principalApproval/PrincipalApprovalComponent.jsx
@@ -9,7 +9,11 @@ import PrivacyDialog from '../PrivacyDialog';
 import {PrivacyDialogMode} from '../../constants';
 import SchoolAutocompleteDropdown from '@cdo/apps/templates/SchoolAutocompleteDropdown';
 import {isInt, isPercent, isZipCode} from '@cdo/apps/util/formatValidation';
-import {styles} from '../teacher/TeacherApplicationConstants';
+import {
+  YEAR,
+  SUMMER_YEAR,
+  styles
+} from '../teacher/TeacherApplicationConstants';
 
 const MANUAL_SCHOOL_FIELDS = [
   'schoolName',
@@ -51,8 +55,6 @@ const REPLACE_COURSE_FIELDS = [
   'replaceWhichCourseCsp',
   'replaceWhichCourseCsd'
 ];
-const YEAR = '2021-22';
-const SUMMER_YEAR = '2021';
 const YES = 'Yes';
 
 export default class PrincipalApprovalComponent extends LabeledFormComponent {

--- a/apps/src/code-studio/pd/application/teacher/ChooseYourProgram.jsx
+++ b/apps/src/code-studio/pd/application/teacher/ChooseYourProgram.jsx
@@ -6,7 +6,7 @@ import {
   TextFields
 } from '@cdo/apps/generated/pd/teacherApplicationConstants';
 import {FormGroup, Row, Col} from 'react-bootstrap';
-import {PROGRAM_CSD, PROGRAM_CSP} from './TeacherApplicationConstants';
+import {PROGRAM_CSD, PROGRAM_CSP, YEAR} from './TeacherApplicationConstants';
 
 export default class ChooseYourProgram extends LabeledFormComponent {
   static labels = PageLabels.chooseYourProgram;
@@ -142,7 +142,7 @@ export default class ChooseYourProgram extends LabeledFormComponent {
             Note: 50 or more hours of instruction per CS Principles section are
             strongly recommended. We suggest checking with your school
             administration to see if additional time can be allotted for this
-            course in 2021-22.
+            course in {YEAR}.
           </p>
         )}
         {this.props.data.program === PROGRAM_CSD &&

--- a/apps/src/code-studio/pd/application/teacher/ProfessionalLearningProgramRequirements.jsx
+++ b/apps/src/code-studio/pd/application/teacher/ProfessionalLearningProgramRequirements.jsx
@@ -10,7 +10,9 @@ import {FormGroup} from 'react-bootstrap';
 import {
   styles as defaultStyles,
   PROGRAM_CSD,
-  PROGRAM_CSP
+  PROGRAM_CSP,
+  YEAR,
+  SUMMER_YEAR
 } from './TeacherApplicationConstants';
 import Spinner from '../../components/spinner';
 import color from '@cdo/apps/util/color';
@@ -270,9 +272,9 @@ export default class SummerWorkshop extends LabeledFormComponent {
             , including:
           </p>
           <ul>
-            <li>One summer workshop in 2021</li>
+            <li>One summer workshop in {SUMMER_YEAR}</li>
             <li>
-              Up to four one-day workshops during the 2021-22 school year
+              Up to four one-day workshops during the {YEAR} school year
               (typically held on Saturdays)
             </li>
           </ul>
@@ -319,11 +321,11 @@ export default class SummerWorkshop extends LabeledFormComponent {
                 <p style={{color: 'red'}}>
                   Note: To meet our implementation guidance and our scholarship
                   recommendations, you should plan to teach this course in the
-                  upcoming school year (2021-22). We suggest checking with your
+                  upcoming school year ({YEAR}). We suggest checking with your
                   administrators to ensure that the course will be offered in
-                  2021-22 before updating your answer to "
+                  {YEAR} before updating your answer to "
                   <strong>
-                    Do you plan to personally teach this course in the 2021-22
+                    Do you plan to personally teach this course in the {YEAR}
                     school year?
                   </strong>
                   " on page 3 and submitting your application.

--- a/apps/src/code-studio/pd/application/teacher/TeacherApplicationConstants.js
+++ b/apps/src/code-studio/pd/application/teacher/TeacherApplicationConstants.js
@@ -5,6 +5,9 @@ const PROGRAM_CSD =
 const PROGRAM_CSP =
   'Computer Science Principles (appropriate for 9th - 12th grade, and can be implemented as an AP or introductory course)';
 
+const YEAR = '2021-22';
+const SUMMER_YEAR = '2021';
+
 const styles = {
   indented: {
     marginLeft: 20
@@ -33,4 +36,4 @@ const styles = {
   }
 };
 
-export {PROGRAM_CSD, PROGRAM_CSP, styles};
+export {PROGRAM_CSD, PROGRAM_CSP, YEAR, SUMMER_YEAR, styles};

--- a/dashboard/app/controllers/pd/application/principal_approval_application_controller.rb
+++ b/dashboard/app/controllers/pd/application/principal_approval_application_controller.rb
@@ -41,6 +41,8 @@ module Pd::Application
         teacher_application
       ).school_stats.transform_values {|v| v.to_i.to_s}
 
+      @year = APPLICATION_CURRENT_YEAR
+
       @script_data = {
         props: {
           options: PRINCIPAL_APPROVAL_APPLICATION_CLASS.options.camelize_keys,

--- a/dashboard/app/controllers/pd/application/teacher_application_controller.rb
+++ b/dashboard/app/controllers/pd/application/teacher_application_controller.rb
@@ -19,6 +19,8 @@ module Pd::Application
       @application = TEACHER_APPLICATION_CLASS.find_by(user: current_user)
       return render :submitted if @application
 
+      @year = APPLICATION_CURRENT_YEAR
+
       @script_data = {
         props: {
           options: TEACHER_APPLICATION_CLASS.options.camelize_keys,

--- a/dashboard/app/models/pd/application/active_application_models.rb
+++ b/dashboard/app/models/pd/application/active_application_models.rb
@@ -4,6 +4,7 @@ module Pd
       include ApplicationConstants
 
       APPLICATION_CURRENT_YEAR = YEAR_21_22
+      APPLICATION_CURRENT_YEAR_SHORT = YEAR_21_22_SHORT
 
       # Active (this year's) application classes and factories
       TEACHER_APPLICATION_CLASS = Teacher2122Application

--- a/dashboard/app/models/pd/application/application_constants.rb
+++ b/dashboard/app/models/pd/application/application_constants.rb
@@ -13,6 +13,11 @@ module Pd::Application
       YEAR_21_22 = '2021-2022'.freeze
     ].freeze
 
+    APPLICATION_YEARS_SHORT = [
+      YEAR_21_22_SHORT = '2021-22'.freeze,
+      YEAR_22_23_SHORT = '2022-23'.freeze
+    ].freeze
+
     COURSE_NAMES = {
       csd: 'Computer Science Discoveries',
       csp: 'Computer Science Principles'

--- a/dashboard/app/models/pd/application/principal_approval2122_application.rb
+++ b/dashboard/app/models/pd/application/principal_approval2122_application.rb
@@ -53,6 +53,10 @@ module Pd::Application
       YEAR_21_22
     end
 
+    def self.next_year
+      YEAR_22_23_SHORT
+    end
+
     def self.create_placeholder_and_send_mail(teacher_application)
       teacher_application.queue_email :principal_approval, deliver_now: true
 
@@ -79,7 +83,7 @@ module Pd::Application
           "Yes, I plan to include this course in the #{year} master schedule",
           "Yes, I plan to include this course in the #{year} master schedule, but not taught by this teacher",
           "I hope to include this course in the #{year} master schedule",
-          "No, I do not plan to include this course in the #{year} master schedule but hope to the following year (2022-23)",
+          "No, I do not plan to include this course in the #{year} master schedule but hope to the following year (#{next_year})",
           "I don’t know if I will be able to include this course in the #{year} master schedule",
           TEXT_FIELDS[:other_with_text]
         ],

--- a/dashboard/app/models/pd/application/teacher2122_application.rb
+++ b/dashboard/app/models/pd/application/teacher2122_application.rb
@@ -323,7 +323,7 @@ module Pd::Application
         plan_to_teach: [
           "Yes, I plan to teach this course this year (#{year})",
           "I hope to teach this course this year (#{year})",
-          "No, I don’t plan to teach this course this year (#{year}), but I hope to teach this course the following year (2022-23)",
+          "No, I don’t plan to teach this course this year (#{year}), but I hope to teach this course the following year (#{next_year})",
           "No, someone else from my school will teach this course this year (#{year})",
           TEXT_FIELDS[:dont_know_if_i_will_teach_explain]
         ],
@@ -524,6 +524,10 @@ module Pd::Application
 
     def self.year
       YEAR_21_22
+    end
+
+    def self.next_year
+      YEAR_22_23_SHORT
     end
 
     # @override

--- a/dashboard/app/views/pd/application/principal_approval_application/new.html.haml
+++ b/dashboard/app/views/pd/application/principal_approval_application/new.html.haml
@@ -2,7 +2,8 @@
 %script{src: webpack_asset_path('js/pd/application/principal_approval_application/new.js'), data: @script_data}
 
 %h1
-  2021-2022 Code.org Principal Approval Form
+  = @year
+  Code.org Principal Approval Form
 
 #application-container
   -# populated by React

--- a/dashboard/app/views/pd/application/teacher_application/new.html.haml
+++ b/dashboard/app/views/pd/application/teacher_application/new.html.haml
@@ -8,7 +8,8 @@
   }
 
 %h1
-  2021-22 Professional Learning Program Teacher Application
+  = @year
+  Professional Learning Program Teacher Application
 
 #application-container
   -# populated by React

--- a/dashboard/test/ui/features/plc/pd/teacher_application.feature
+++ b/dashboard/test/ui/features/plc/pd/teacher_application.feature
@@ -6,7 +6,7 @@ Feature: Teacher Application
 Scenario: Basic teacher application submission
   Given I create a teacher named "Severus"
     And I am on "http://studio.code.org/pd/application/teacher"
-    And I wait until element "h1" contains text "2021-22 Professional Learning Program Teacher Application"
+    And I wait until element "h1" contains text "Professional Learning Program Teacher Application"
     And I open my eyes to test "Teacher Application"
 
   # Section 1
@@ -92,7 +92,7 @@ Scenario: Basic teacher application submission
   # Principal approval
   Then I sign out
   Then I navigate to the principal approval page for "Severus"
-  Then I wait until element "h1" contains text "2021-2022 Code.org Principal Approval Form"
+  Then I wait until element "h1" contains text "Code.org Principal Approval Form"
   Then I press the first "input[name='doYouApprove'][value='Yes']" element
 
   And I press keys "nonexistent" for element "#nces_school"

--- a/lib/cdo/shared_constants/pd/teacher2122_application_constants.rb
+++ b/lib/cdo/shared_constants/pd/teacher2122_application_constants.rb
@@ -1,11 +1,15 @@
 module Pd
   module Teacher2122ApplicationConstants
+    include Pd::Application::ApplicationConstants
+
     YES_NO = %w(Yes No).freeze
 
     # Remove newlines and leading whitespace from multiline strings
     def self.clean_multiline(string)
       string.gsub(/\n\s*/, ' ')
     end
+
+    SHORT_YEAR = YEAR_21_22_SHORT
 
     SECTION_HEADERS = {
       about_you: 'About You',
@@ -54,23 +58,23 @@ module Pd
       },
       choose_your_program: {
         program: clean_multiline(
-          'Which professional learning program would you like to join for the 2021-22
+          "Which professional learning program would you like to join for the #{SHORT_YEAR}
           school year? Note: this application is only for Computer Science Discoveries and
           Computer Science Principles. If you are interested in teaching Advanced
           Placement CS A (in Java), visit this
           [AP CS A overview](https://code.org/educate/curriculum/apcsa). Review our
           [guidance documents](https://docs.google.com/document/d/1DhvzoNElJcfGYLrp5sVnnqp0ShvsePUpp3JK7ihjFGM/edit)
-          to see whether your course implementation plans meet our program guidelines.'
+          to see whether your course implementation plans meet our program guidelines."
         ),
         csd_which_grades: clean_multiline(
-          'To which grades does your school plan to offer CS Discoveries in the 2021-22 school year?
+          "To which grades does your school plan to offer CS Discoveries in the #{SHORT_YEAR} school year?
            Please note that the CS Discoveries Professional Learning Program
-           is not available for grades K-5. (select all that apply)'
+           is not available for grades K-5. (select all that apply)"
         ),
         csp_which_grades: clean_multiline(
-          'To which grades does your school plan to offer CS Principles in the 2021-22
+          "To which grades does your school plan to offer CS Principles in the #{SHORT_YEAR}
           school year? Please note that the CS Principles Professional Learning Program
-          is not available for grades K-8. (select all that apply)'
+          is not available for grades K-8. (select all that apply)"
         ),
         csp_how_offer: 'How will you offer CS Principles?',
         cs_how_many_minutes: clean_multiline(
@@ -82,9 +86,9 @@ module Pd
         cs_how_many_days_per_week: 'How many days per week will your CS program class be offered to one section of students?',
         cs_how_many_weeks_per_year: 'How many weeks during the year will this course be taught to one section of students?',
         cs_total_course_hours: 'Computed total course hours',
-        csd_which_units: 'Which CS Discoveries units do you intend to teach in the 2021-22 school year?',
-        csp_which_units: 'Which CS Principles units do you intend to teach in the 2021-22 school year?',
-        plan_to_teach: "Do you plan to personally teach this course in the 2021-22 school year?",
+        csd_which_units: "Which CS Discoveries units do you intend to teach in the #{SHORT_YEAR} school year?",
+        csp_which_units: "Which CS Principles units do you intend to teach in the #{SHORT_YEAR} school year?",
+        plan_to_teach: "Do you plan to personally teach this course in the #{SHORT_YEAR} school year?",
         replace_existing: 'Will this course replace an existing computer science course in the master schedule? If yes, please list the course(s) that will be replaced.',
         replace_which_course: 'Which existing course or curriculum will it replace? Mark all that apply.'
       },
@@ -123,8 +127,8 @@ module Pd
         native_hawaiian_or_pacific_islander_percent: 'Percentage of student enrollment by race: Native Hawaiian or Pacific Islander',
         white_percent: 'Percentage of student enrollment by race: White',
         other_races_percent: 'Percentage of student enrollment by race: Other',
-        principal_approval: "Do you approve of <Teacher Name> participating in Code.org's 2021-22 Professional Learning Program?",
-        principal_schedule_confirmed: 'Are you committed to including Computer Science <Program> on the master schedule in 2021-22 if <Teacher Name> is accepted into the program?',
+        principal_approval: "Do you approve of <Teacher Name> participating in Code.org's #{SHORT_YEAR} Professional Learning Program?",
+        principal_schedule_confirmed: "Are you committed to including Computer Science <Program> on the master schedule in #{SHORT_YEAR} if <Teacher Name> is accepted into the program?",
         principal_diversity_recruitment: 'Do you commit to recruiting and enrolling a diverse group of students in this course, representative of the overall demographics of your school?',
         contact_invoicing: "Contact name for invoicing",
         contact_invoicing_detail: "Contact email or phone number for invoicing",
@@ -132,7 +136,7 @@ module Pd
     }.freeze
 
     LABEL_OVERRIDES = {
-      program: 'Which professional learning program would you like to join for the 2021-22 school year?',
+      program: "Which professional learning program would you like to join for the #{SHORT_YEAR} school year?",
       cs_how_many_minutes: 'How many minutes will your class last?'
     }.freeze
 
@@ -161,8 +165,8 @@ module Pd
         school_zip_code: "School zip code",
         current_role: "Current role",
         program: LABEL_OVERRIDES[:program],
-        csd_which_grades: "To which grades does your school plan to offer CS Discoveries in the 2021-22 school year?",
-        csp_which_grades: "To which grades does your school plan to offer CS Principles in the 2021-22 school year?",
+        csd_which_grades: "To which grades does your school plan to offer CS Discoveries in the #{SHORT_YEAR} school year?",
+        csp_which_grades: "To which grades does your school plan to offer CS Principles in the #{SHORT_YEAR} school year?",
         cs_how_many_minutes: "How many minutes will your CS Program class last?",
         cs_total_course_hours: "Total course hours",
         replace_existing: "Will this course replace an existing computer science course in the master schedule? (Teacher's response)",
@@ -181,7 +185,7 @@ module Pd
         email: PAGE_LABELS[:about_you][:principal_email] + " (provided by principal)",
         school_name: PAGE_LABELS[:about_you][:school_name] + " (provided by principal)",
         district_name: PAGE_LABELS[:about_you][:school_district_name] + " (provided by principal)",
-        do_you_approve: "Do you approve of this teacher participating in Code.org's 2021-22 Professional Learning Program?",
+        do_you_approve: "Do you approve of this teacher participating in Code.org's #{SHORT_YEAR} Professional Learning Program?",
         total_student_enrollment: "Total student enrollment",
         free_lunch_percent: "Percentage of students who are eligible to receive free or reduced lunch (Principal's response)",
         underrepresented_minority_percent: "Percentage of underrepresented minority students (Principal's response)",
@@ -192,7 +196,7 @@ module Pd
         pacific_islander: "Percentage of student enrollment by race - Native Hawaiian or other Pacific Islander",
         american_indian: "Percentage of student enrollment by race - American Indian or Native Alaskan",
         other: "Percentage of student enrollment by race - Other",
-        committed_to_master_schedule: "Are you committed to including this course on the master schedule in 2021-22 if this teacher is accepted into the program?",
+        committed_to_master_schedule: "Are you committed to including this course on the master schedule in #{SHORT_YEAR} if this teacher is accepted into the program?",
         replace_course: "Will this course replace an existing computer science course in the master schedule? (Principal's response)",
         replace_which_course_csp: "Which existing course or curriculum will CS Principles replace?",
         replace_which_course_csd: "Which existing course or curriculum will CS Discoveries replace?",


### PR DESCRIPTION
There is some duplicated copy/pasting of the application year on both the frontend and backend code for teacher apps. Added some constants to make the process less painful in future years.
Note: this should only be merged into the feature branch.

<!-- ### Background -->
<!-- ### Privacy -->
<!-- ### Security -->
<!-- ### Caching -->
<!-- ### Deployment strategy -->
<!-- ### Future work -->


## Testing story
Verified all tests pass and application still shows the correct year.

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
