### PR TITLE
Removed reliance on hard-coded value for png size

### DIFF
--- a/apps/test/unit/code-studio/initApp/loadAppTest.js
+++ b/apps/test/unit/code-studio/initApp/loadAppTest.js
@@ -186,10 +186,10 @@ describe('loadApp.js', () => {
         expect(writtenLevelId).to.be.undefined;
         expect(name).to.equal('_share_image.png');
         expect(blob).to.have.property('type', 'image/png');
-        const expectedPngSize = /PhantomJS/.test(window.navigator.userAgent)
-          ? 523181 // PhantomJS
-          : 38961; // ChromeHeadless
-        expect(blob).to.have.property('size', expectedPngSize);
+        // const expectedPngSize = /PhantomJS/.test(window.navigator.userAgent)
+        //   ? 523181 // PhantomJS
+        //   : 38961; // ChromeHeadless
+        // expect(blob).to.have.property('size', expectedPngSize);
         done();
       });
 


### PR DESCRIPTION
Drone runs with changes to the apps directory were consistently failing after the latest Chrome upgrade. Expected PNG sizes changed from 38961 to 38893. Rather than update the value, we decided to comment the assertion as it could change again at any point. 

A follow-up task has been added to the star-labs backlog to re-enable this assertion with a more upgrade-resilient design.

<!--
  Other aspects to consider. uncomment and add detail for any that seem necessary:
-->

<!-- ### Background -->
<!-- ### Privacy -->
<!-- ### Security -->
<!-- ### Caching -->
<!-- ### Deployment strategy -->
<!-- ### Future work -->

## Links

<!--
  Any relevant links to external resources; ie, specification documents, jira
  items, related PRs, honeybadger errors, etc
-->

- [slack conversation thread](https://codedotorg.slack.com/archives/C0T0PNTM3/p1600189827366000?thread_ts=1599833556.302300&cid=C0T0PNTM3) 
- [Star-Labs task](https://codedotorg.atlassian.net/browse/STAR-1249)

## Testing story

<!--
  Does your change include appropriate tests?

  If so, please describe how the tests included in this PR are sufficient

  If not, please explain why this change does not need to be tested.
-->

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
