### PR TITLE
Hour of Code Date Helper: Try to use detected language

### DIFF
--- a/pegasus/helpers/hourofcode_helpers.rb
+++ b/pegasus/helpers/hourofcode_helpers.rb
@@ -153,7 +153,7 @@ end
 def campaign_date(format)
   @country ||= hoc_detect_country
   type = HOC_COUNTRIES[@country]['type'] || 'default'
-  language = HOC_COUNTRIES[@country]['default_language']
+  language = @language || HOC_COUNTRIES[@country]['default_language']
   id = 'campaign_date_full'
 
   case format


### PR DESCRIPTION
In the hour of code campaign_date helper method we were always using the default language for the country even if the user had specified a different language. Update to use the user-specified/detected language (set by an instance variable) instead of always using the default.

<!-- ### Background -->
<!-- ### Privacy -->
<!-- ### Security -->
<!-- ### Caching -->
<!-- ### Deployment strategy -->
<!-- ### Future work -->

## Testing story
Tested locally--now if you change the language on the page but are in the US the dates will be properly translated, where before they would still be in English.

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
