### PR TITLE
Use latest version of SauceConnect client

### DIFF
--- a/lib/rake/circle.rake
+++ b/lib/rake/circle.rake
@@ -187,10 +187,8 @@ def start_sauce_connect
   # pin the version we use to the last working version, while we schedule the task to get the upgraded version
   # working. You can do this by replacing `sc_download_url` with a hard-coded download url.
 
-  # Temporarily pinning sauceconnect version to 4.5.4 since 4.6.0 seems to have broken us.
-  #sc_version_info = JSON.parse(Net::HTTP.get(URI('https://saucelabs.com/versions.json')))
-  #sc_download_url = sc_version_info['Sauce Connect']['linux']['download_url']
-  sc_download_url = 'https://saucelabs.com/downloads/sc-4.5.4-linux.tar.gz'
+  sc_version_info = JSON.parse(Net::HTTP.get(URI('https://saucelabs.com/versions.json')))
+  sc_download_url = sc_version_info['Sauce Connect']['linux']['download_url']
   tar_name = sc_download_url.split('/')[-1]
   dir_name = tar_name.chomp('.tar.gz')
 

--- a/lib/rake/circle.rake
+++ b/lib/rake/circle.rake
@@ -196,7 +196,7 @@ def start_sauce_connect
   RakeUtils.system_stream_output "tar -xzf #{tar_name}"
   Dir.chdir(Dir.glob(dir_name)[0]) do
     # Run sauce connect a second time on failure, known periodic "Error bringing up tunnel VM." disconnection-after-connect issue, e.g. https://circleci.com/gh/code-dot-org/code-dot-org/20930
-    RakeUtils.exec_in_background "for i in 1 2; do ./bin/sc -l $CIRCLE_ARTIFACTS/sc.log -u $SAUCE_USERNAME -k $SAUCE_ACCESS_KEY -i #{CDO.circle_run_identifier} --tunnel-domains *.code.org,*.csedweek.org,*.hourofcode.com,*.codeprojects.org && break; done"
+    RakeUtils.exec_in_background "for i in 1 2; do ./bin/sc -P 4445 -l $CIRCLE_ARTIFACTS/sc.log -u $SAUCE_USERNAME -k $SAUCE_ACCESS_KEY -i #{CDO.circle_run_identifier} --tunnel-domains *.code.org,*.csedweek.org,*.hourofcode.com,*.codeprojects.org && break; done"
   end
 end
 


### PR DESCRIPTION
Ensure that continuous integration (Drone) builds get and install the latest version of the SauceConnect client with each build. Versions of SauceConnect prior to 4.6.x are reaching End Of Life on 10/5/2020 per SauceLabs.

<!-- ### Background -->
<!-- ### Privacy -->
<!-- ### Security -->
<!-- ### Caching -->
<!-- ### Deployment strategy -->
<!-- ### Future work -->

## Links

<!--
  Any relevant links to external resources; ie, specification documents, jira
  items, related PRs, honeybadger errors, etc
-->

- [spec]()
- [jira]()

## Testing story

<!--
  Does your change include appropriate tests?

  If so, please describe how the tests included in this PR are sufficient

  If not, please explain why this change does not need to be tested.
-->

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
