### PR TITLE
Update Blockly to 3.5.30

### DIFF
--- a/apps/package.json
+++ b/apps/package.json
@@ -48,7 +48,7 @@
     "@babel/preset-react": "^7.0.0",
     "@cdo/interpreted": "link:../dashboard/config/libraries",
     "@code-dot-org/artist": "0.2.1",
-    "@code-dot-org/blockly": "3.5.29",
+    "@code-dot-org/blockly": "3.5.30",
     "@code-dot-org/bramble": "0.1.26",
     "@code-dot-org/craft": "0.2.2",
     "@code-dot-org/dance-party": "1.0.1",

--- a/apps/yarn.lock
+++ b/apps/yarn.lock
@@ -1526,10 +1526,10 @@
   version "0.2.1"
   resolved "https://registry.yarnpkg.com/@code-dot-org/artist/-/artist-0.2.1.tgz#fcfe7ea5cfb3f19ddb6b912e70e922ba4b7ef0b1"
 
-"@code-dot-org/blockly@3.5.29":
-  version "3.5.29"
-  resolved "https://registry.yarnpkg.com/@code-dot-org/blockly/-/blockly-3.5.29.tgz#2bac489f2e4262e1615084cb6e557e3e678466bf"
-  integrity sha512-ZYRFrhOvvdeabVLKp5+SH216vBbroeWNIueGXOzm2LSbyWQD2qHQVS+NKr+z2DOdVwU8O2xEBVudWoME34cEwA==
+"@code-dot-org/blockly@3.5.30":
+  version "3.5.30"
+  resolved "https://registry.yarnpkg.com/@code-dot-org/blockly/-/blockly-3.5.30.tgz#5ed3d3b48da28907d3b116ef9f8ef701d0c8acdb"
+  integrity sha512-atYxVM4710hwY+7mPr4kC9xO7bXvTCeeEV5LSZN+QP93iUzYdjUv1PLCnGJ2tI3cFKSQ08VNKtsUM79uoTVbeQ==
 
 "@code-dot-org/bramble@0.1.26":
   version "0.1.26"


### PR DESCRIPTION
Includes the following changes:

- [Use standard cursor for general mousing](https://github.com/code-dot-org/blockly/pull/245)
- [make the blockly i18n sync quieter](https://github.com/code-dot-org/blockly/pull/250)
- [Update to Node 8](https://github.com/code-dot-org/blockly/pull/251)

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
