### PR TITLE
Raise a more helpful exception when a library question fails to parse.

### DIFF
--- a/dashboard/app/models/foorm/library_question.rb
+++ b/dashboard/app/models/foorm/library_question.rb
@@ -32,17 +32,21 @@ class Foorm::LibraryQuestion < ApplicationRecord
       full_name = File.dirname(unique_path) + "/" + filename
 
       # Let's load the JSON text.
-      source_questions = JSON.parse(File.read(path))
+      begin
+        source_questions = JSON.parse(File.read(path))
 
-      source_questions["pages"].map do |page|
-        page["elements"].map do |element|
-          {
-            library_name: full_name,
-            library_version: version,
-            question_name: element["name"],
-            question: element.to_json
-          }
+        source_questions["pages"].map do |page|
+          page["elements"].map do |element|
+            {
+              library_name: full_name,
+              library_version: version,
+              question_name: element["name"],
+              question: element.to_json
+            }
+          end
         end
+      rescue
+        raise format('failed to parse %s', full_name)
       end
     end.flatten
 


### PR DESCRIPTION
a recent foorm PR failed to build due to a parsing error, but all we got in the build logs was a `NoMethodError`. this is a small update to catch any errors during parsing and raise an exception indicating the file that failed to parse.