### PR TITLE
Hook up toggleExpand for LevelToken in ActivitiesEditor

### DIFF
--- a/apps/src/lib/levelbuilder/lesson-editor/ActivitySectionCard.jsx
+++ b/apps/src/lib/levelbuilder/lesson-editor/ActivitySectionCard.jsx
@@ -342,7 +342,8 @@ class ActivitySectionCard extends Component {
         conceptDifficulty: '',
         named: false,
         assessment: false,
-        challenge: false
+        challenge: false,
+        expand: false
       }
     );
   };

--- a/apps/src/lib/levelbuilder/lesson-editor/LevelToken.jsx
+++ b/apps/src/lib/levelbuilder/lesson-editor/LevelToken.jsx
@@ -10,7 +10,7 @@ import {
 import {levelShape} from '@cdo/apps/lib/levelbuilder/shapes';
 import ProgressBubble from '@cdo/apps/templates/progress/ProgressBubble';
 import LevelTokenDetails from '@cdo/apps/lib/levelbuilder/lesson-editor/LevelTokenDetails';
-import {toggleExpand} from '@cdo/apps/lib/levelbuilder/script-editor/editorRedux';
+import {toggleExpand} from '@cdo/apps/lib/levelbuilder/lesson-editor/activitiesEditorRedux';
 
 const styles = {
   levelToken: {
@@ -105,20 +105,16 @@ class LevelToken extends Component {
     removeLevel: PropTypes.func.isRequired
   };
 
-  constructor(props) {
-    super(props);
-
-    this.state = {
-      expand: false
-    };
-  }
-
   handleDragStart = e => {
     this.props.handleDragStart(this.props.level.position, e);
   };
 
   toggleExpand = () => {
-    this.setState({expand: !this.state.expand});
+    this.props.toggleExpand(
+      this.props.activityPosition,
+      this.props.activitySectionPosition,
+      this.props.level.position
+    );
   };
 
   handleRemove = () => {
@@ -190,7 +186,7 @@ class LevelToken extends Component {
             <div style={styles.remove} onMouseDown={this.handleRemove}>
               <i className="fa fa-times" />
             </div>
-            {this.state.expand && (
+            {this.props.level.expand && (
               <LevelTokenDetails
                 level={this.props.level}
                 activitySectionPosition={this.props.activitySectionPosition}

--- a/apps/test/unit/lib/levelbuilder/lesson-editor/activitiesTestData.js
+++ b/apps/test/unit/lib/levelbuilder/lesson-editor/activitiesTestData.js
@@ -60,7 +60,8 @@ export const sampleActivities = [
             skin: null,
             videoKey: null,
             concepts: '',
-            conceptDifficulty: ''
+            conceptDifficulty: '',
+            expand: false
           },
           {
             name: 'Level 2',
@@ -82,7 +83,8 @@ export const sampleActivities = [
             skin: null,
             videoKey: null,
             concepts: '',
-            conceptDifficulty: ''
+            conceptDifficulty: '',
+            expand: false
           }
         ]
       }


### PR DESCRIPTION
Follow up work to setting up the ActivitiesEditor. I originally set up the LevelToken expand to be done based on state in the component but realized that it was being expanded based on redux state in the script edit gui. This switches over to that method of tracking the state of expanding the LevelToken.

## Links

<!--
  Any relevant links to external resources; ie, specification documents, jira
  items, related PRs, honeybadger errors, etc
-->

- [jira](https://codedotorg.atlassian.net/browse/PLAT-291)

## Testing story

Tests already exist for toggleExpand in activitiesEditorRedux tests.

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
