### PR TITLE
add a basic firehose study to monitor breakpoints usage

### DIFF
--- a/apps/src/StudioApp.js
+++ b/apps/src/StudioApp.js
@@ -78,6 +78,7 @@ import {
   setFeedback
 } from './redux/instructions';
 import {addCallouts} from '@cdo/apps/code-studio/callouts';
+import {queryParams} from '@cdo/apps/code-studio/utils';
 import {RESIZE_VISUALIZATION_EVENT} from './lib/ui/VisualizationResizeBar';
 import {userAlreadyReportedAbuse} from '@cdo/apps/reportAbuse';
 import {setArrowButtonDisabled} from '@cdo/apps/templates/arrowDisplayRedux';
@@ -2679,6 +2680,7 @@ StudioApp.prototype.enableBreakpoints = function() {
             scriptId: this.config.scriptId,
             scriptLevelId: this.config.serverScriptLevelId,
             scriptName: this.config.scriptName,
+            studentUserId: queryParams('user_id'),
             url: window.location.toString()
           })
         },

--- a/apps/src/StudioApp.js
+++ b/apps/src/StudioApp.js
@@ -2673,6 +2673,7 @@ StudioApp.prototype.enableBreakpoints = function() {
         {
           study: 'droplet-breakpoints',
           study_group: userType,
+          event: 'guttermousedown',
           data_json: JSON.stringify({
             levelId: this.config.serverLevelId,
             lineNumber: e.line,

--- a/apps/src/StudioApp.js
+++ b/apps/src/StudioApp.js
@@ -2667,12 +2667,12 @@ StudioApp.prototype.enableBreakpoints = function() {
       // inline teacher comments; we want to get a sense of how much
       // breakpoints are used and in what scenarios, so we can reason about the
       // feasibility of repurposing line number clicks for this feature.
-      const isTeacher =
-        getStore().getState().currentUser.userType === 'teacher';
+      const currentUser = getStore().getState().currentUser;
+      const userType = currentUser && currentUser.userType;
       firehoseClient.putRecord(
         {
           study: 'droplet-breakpoints',
-          study_group: isTeacher ? 'teacher' : 'student',
+          study_group: userType,
           data_json: JSON.stringify({
             levelId: this.config.serverLevelId,
             lineNumber: e.line,

--- a/apps/src/StudioApp.js
+++ b/apps/src/StudioApp.js
@@ -2656,8 +2656,9 @@ StudioApp.prototype.enableBreakpoints = function() {
   this.editor.on(
     'guttermousedown',
     function(e) {
-      var bps = this.editor.getBreakpoints();
-      if (bps[e.line]) {
+      const bps = this.editor.getBreakpoints();
+      const activeBreakpoint = bps[e.line];
+      if (activeBreakpoint) {
         this.editor.clearBreakpoint(e.line);
       } else {
         this.editor.setBreakpoint(e.line);
@@ -2677,6 +2678,7 @@ StudioApp.prototype.enableBreakpoints = function() {
           data_json: JSON.stringify({
             levelId: this.config.serverLevelId,
             lineNumber: e.line,
+            activeBreakpoint,
             projectLevelId: this.config.serverProjectLevelId,
             scriptId: this.config.scriptId,
             scriptLevelId: this.config.serverScriptLevelId,


### PR DESCRIPTION
Part of the ongoing teacher comments work! We'd like to be able to connect the teacher comments UI to the droplet line numbers, so we'd like to get a better understanding of how the line numbers are currently being used to create breakpoints. In particular, we suspect that teachers don't actually use this feature all that much. If we can confirm that, then we can safely replace breakpoints for teachers with the teacher comment UI.

## Links

- [jira](https://codedotorg.atlassian.net/browse/FND-1262)

## Testing story

Tested manually.

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
