### PR TITLE
SSM Session Manager permissions and Slack audit-log integration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,7 +18,7 @@ jsconfig.json
 npm-debug.log
 /.dropbox.cache
 /.gdrive_session
-/.ruby-version
+.ruby-version
 /apps/.babel-cache
 /apps/build
 /apps/build-times.log

--- a/aws/.gitignore
+++ b/aws/.gitignore
@@ -11,3 +11,4 @@ deploy-*.log
 /.website-ci-built
 /.websites-built
 /.websites-test-built
+vendor/

--- a/aws/cloudformation/cloud_formation_stack.yml.erb
+++ b/aws/cloudformation/cloud_formation_stack.yml.erb
@@ -110,7 +110,7 @@ Resources:
   image_id: IMAGE_ID,
   ssh_key_name: SSH_KEY_NAME,
   subnets: subnets(azs(AVAILABILITY_ZONES - ['us-east-1e'])), # us-east-1e doesn't support m5 instance types.
-  frontend_policies: [Ref: 'CDOPolicy'],
+  frontend_policies: [{Ref: 'CDOPolicy'}, {ImportValue: 'IAM-SessionPermissions'}],
   frontend_properties: {TargetGroupARNs: [Ref: 'ALBTargetGroup']},
   frontend_volume_size: 64,
   ami_timeout: 'PT120M',
@@ -405,7 +405,9 @@ Resources:
                   - dms:StartReplicationTask
                 Resource: !Sub "arn:aws:dms:${AWS::Region}:${AWS::AccountId}:task:*"
 <% end -%>
-      ManagedPolicyArns: [!Ref CDOPolicy]
+      ManagedPolicyArns:
+        - !Ref CDOPolicy
+        - !ImportValue IAM-SessionPermissions
       PermissionsBoundary: !ImportValue IAM-DevPermissions
   DaemonInstanceProfile:
     Type: AWS::IAM::InstanceProfile

--- a/aws/cloudformation/data.yml.erb
+++ b/aws/cloudformation/data.yml.erb
@@ -555,3 +555,46 @@ Resources:
                 Value: <%=environment%>-dashboard-cdn/
               - Name: suffix
                 Value: .gz
+  AuditLogs:
+    Type: AWS::Logs::LogGroup
+    Properties:
+      LogGroupName: /admin/auditlogs
+      # TODO Manually configured for now, uncomment when official resource support has been deployed.
+      # Ref: https://github.com/aws-cloudformation/aws-cloudformation-coverage-roadmap/issues/128
+      # KMSKeyId: !Ref AuditLogsKey
+  AuditLogsKey:
+    Type: AWS::KMS::Key
+    Properties:
+      Description: 'Used for encrypting audit logs.'
+      EnableKeyRotation: true
+      # See: https://docs.aws.amazon.com/AmazonCloudWatch/latest/logs/encrypt-log-data-kms.html#cmk-permissions
+      KeyPolicy:
+        Version: 2012-10-17
+        Id: key-policy-1
+        Statement:
+          - Sid: Enable IAM policies in source account for managing key access.
+            Effect: Allow
+            Principal: {AWS: [!Sub "arn:aws:iam::${AWS::AccountId}:root"]}
+            Action: 'kms:*'
+            Resource: '*'
+          - Sid: Restrict use of key to specific log groups.
+            Effect: Allow
+            Principal:
+              Service:
+                - !Sub "logs.${AWS::Region}.amazonaws.com"
+                - ssm.amazonaws.com
+            Action:
+              - 'kms:Encrypt'
+              - 'kms:Decrypt'
+              - 'kms:ReEncrypt*'
+              - 'kms:GenerateDataKey*'
+              - 'kms:DescribeKey'
+            Resource: '*'
+            Condition:
+              ArnEquals:
+                kms:EncryptionContext:aws:logs:arn: !Sub "arn:aws:logs:${AWS::Region}:${AWS::AccountId}:log-group:${AuditLogs}"
+  AuditLogsKeyAlias:
+    Type: AWS::KMS::Alias
+    Properties:
+      AliasName: alias/auditlogs
+      TargetKeyId: !Ref AuditLogsKey

--- a/aws/cloudformation/geocoder.yml
+++ b/aws/cloudformation/geocoder.yml
@@ -228,3 +228,7 @@ Outputs:
   Version:
     Description: ECS Cloudformation template version
     Value: 3.0.0
+  DNSName:
+    Description: Internal DNS name of the service.
+    Value: !GetAtt EcsElasticLoadBalancer.DNSName
+    Export: {Name: !Sub "${AWS::StackName}-DNSName"}

--- a/aws/cloudformation/iam.yml.erb
+++ b/aws/cloudformation/iam.yml.erb
@@ -193,6 +193,13 @@ Resources:
             - secretsmanager:GetSecretValue
             - secretsmanager:DeleteSecret
             NotResource: !Sub "arn:aws:secretsmanager:${AWS::Region}:${AWS::AccountId}:secret:development/*"
+      # Deny all access to /admin logs.
+      - PolicyName: DenyAdminLogs
+        PolicyDocument:
+          Statement:
+          - Effect: Deny
+            Action: logs:*
+            Resource: !Sub 'arn:aws:logs:${AWS::Region}:${AWS::AccountId}:log-group:/admin/*'
       ManagedPolicyArns: [!Ref DevPermissions]
   # Used by FirehoseMicroservice Lambda function.
   # TODO move to Data stack
@@ -272,6 +279,34 @@ Resources:
       Path: /
       ManagedPolicyArns:
         - 'arn:aws:iam::aws:policy/service-role/AmazonECSTaskExecutionRolePolicy'
+  SessionPermissions:
+    Type: AWS::IAM::ManagedPolicy
+    Properties:
+      Description: Allows opening Session Manager sessions and writing to the audit log.
+      PolicyDocument:
+        Version: 2012-10-17
+        Statement:
+          - Sid: DescribeLogs
+            Effect: Allow
+            Action: logs:DescribeLogGroups
+            Resource: '*'
+          - Sid: PublishAuditEvents
+            Effect: Allow
+            Action:
+              - logs:PutLogEvents
+              - logs:DescribeLogStreams
+              - logs:CreateLogStream
+            Resource:
+              !Sub "arn:aws:logs:${AWS::Region}:${AWS::AccountId}:log-group:/admin/auditlogs:log-stream:*"
+          - Sid: AllowSession
+            Effect: Allow
+            Action:
+              - ssmmessages:CreateControlChannel
+              - ssmmessages:CreateDataChannel
+              - ssmmessages:OpenControlChannel
+              - ssmmessages:OpenDataChannel
+              - ssm:UpdateInstanceInformation
+            Resource: '*'
 Outputs:
   DevPermissions:
     Description: Developer Permissions
@@ -281,3 +316,7 @@ Outputs:
     Description: Firehose Lambda Role ARN
     Value: !GetAtt FirehoseLambdaRole.Arn
     Export: {Name: !Sub "${AWS::StackName}-FirehoseLambdaRoleARN"}
+  SessionPermissions:
+    Description: Session Permissions
+    Value: !Ref SessionPermissions
+    Export: {Name: !Sub "${AWS::StackName}-SessionPermissions"}

--- a/aws/cloudformation/lambda.yml.erb
+++ b/aws/cloudformation/lambda.yml.erb
@@ -1,12 +1,16 @@
+<%
+require 'cdo/cloud_formation/vpc'
+self.class.include VPC
+-%>
 ---
 AWSTemplateFormatVersion: 2010-09-09
 Description: >-
   Lambda layer for functions used in CloudFormation Custom Resources.
   Note: Admin permissions are required to manage this stack.
 Parameters:
-  SlackEndpoint:
+  SessionChannel:
+    Description: Channel to post Slack session audit messages.
     Type: String
-    NoEcho: true
 Resources:
   AMIManager:
     Type: AWS::Lambda::Function
@@ -121,7 +125,7 @@ Resources:
       Code: <%=js_zip ['slackCloudWatchEvent.js']%>
       Environment:
         Variables:
-          SLACK_ENDPOINT: !Ref SlackEndpoint
+          SLACK_ENDPOINT: '{{resolve:secretsmanager:production/cdo/slack_endpoint}}'
       Handler: slackCloudWatchEvent.handler
       Runtime: nodejs10.x
       Timeout: 30
@@ -269,6 +273,66 @@ Resources:
             - "ec2:DescribeImages"
             Resource: '*'
       PermissionsBoundary: !ImportValue IAM-DevPermissions
+  LambdaSecurityGroup:
+    Type: AWS::EC2::SecurityGroup
+    Properties:
+      GroupDescription: Security group for VPC-internal Lambda functions.
+      VpcId: !ImportValue VPC
+  SSMSessionSlack:
+    Type: AWS::Lambda::Function
+    Properties:
+      Description: 'SSM Session Slack event handler'
+      FunctionName: SSMSessionSlack
+      Code: <%=ruby_zip 'ssm_session_slack' %>
+      Environment:
+        Variables:
+          SLACK_API_TOKEN: '{{resolve:secretsmanager:lambda/ssm_session_slack_token}}'
+          SLACK_CHANNEL: !Ref SessionChannel
+          FREEGEOIP_HOST: !ImportValue geocoder-DNSName
+          AUDIT_LOG_PATH: /admin/auditlogs
+      Handler: ssm_session_slack.handler
+      Runtime: ruby2.7
+      MemorySize: 1024
+      Timeout: 30
+      Role: !GetAtt SSMSessionSlackRole.Arn
+      VpcConfig:
+        SecurityGroupIds: [!Ref LambdaSecurityGroup]
+        SubnetIds: <%=subnets.to_json%>
+  SSMSessionSlackRole:
+    Type: AWS::IAM::Role
+    Properties:
+      <%=service_role 'lambda'%>
+      Path: /
+      ManagedPolicyArns: ['arn:aws:iam::aws:policy/service-role/AWSLambdaVPCAccessExecutionRole']
+      Policies:
+        - PolicyName: root
+          PolicyDocument:
+            Statement:
+              - Effect: Allow
+                Action: ['ec2:DescribeTags']
+                Resource: '*'
+      PermissionsBoundary: !ImportValue IAM-DevPermissions
+  SessionEvent:
+    Type: AWS::Events::Rule
+    Properties:
+      Description: !Sub "Session events for ${AWS::StackName}."
+      EventPattern:
+        source: [aws.ssm]
+        detail-type: [AWS API Call via CloudTrail]
+        detail:
+          eventSource: [ssm.amazonaws.com]
+          eventName: [StartSession]
+          responseElements:
+            sessionId: [exists: true]
+      State: ENABLED
+      Targets: [{Id: SessionEventTarget, Arn: !GetAtt SSMSessionSlack.Arn}]
+  SessionEventPermission:
+    Type: AWS::Lambda::Permission
+    Properties:
+      FunctionName: !GetAtt SSMSessionSlack.Arn
+      Action: 'lambda:InvokeFunction'
+      Principal: events.amazonaws.com
+      SourceArn: !GetAtt SessionEvent.Arn
 Outputs:
   AMIManager:
     Value: !GetAtt AMIManager.Arn

--- a/aws/lambda/ssm_session_slack/Gemfile
+++ b/aws/lambda/ssm_session_slack/Gemfile
@@ -1,0 +1,6 @@
+source 'https://rubygems.org'
+ruby '~> 2.7'
+
+gem 'aws-sdk-ec2'
+gem 'geocoder'
+gem 'slack-ruby-client'

--- a/aws/lambda/ssm_session_slack/Gemfile.lock
+++ b/aws/lambda/ssm_session_slack/Gemfile.lock
@@ -1,0 +1,47 @@
+GEM
+  remote: https://rubygems.org/
+  specs:
+    aws-eventstream (1.1.0)
+    aws-partitions (1.371.0)
+    aws-sdk-core (3.107.0)
+      aws-eventstream (~> 1, >= 1.0.2)
+      aws-partitions (~> 1, >= 1.239.0)
+      aws-sigv4 (~> 1.1)
+      jmespath (~> 1.0)
+    aws-sdk-ec2 (1.195.0)
+      aws-sdk-core (~> 3, >= 3.99.0)
+      aws-sigv4 (~> 1.1)
+    aws-sigv4 (1.2.2)
+      aws-eventstream (~> 1, >= 1.0.2)
+    faraday (1.0.1)
+      multipart-post (>= 1.2, < 3)
+    faraday_middleware (1.0.0)
+      faraday (~> 1.0)
+    geocoder (1.6.3)
+    gli (2.19.2)
+    hashie (4.1.0)
+    jmespath (1.4.0)
+    multipart-post (2.1.1)
+    slack-ruby-client (0.15.1)
+      faraday (>= 1.0)
+      faraday_middleware
+      gli
+      hashie
+      websocket-driver
+    websocket-driver (0.7.3)
+      websocket-extensions (>= 0.1.0)
+    websocket-extensions (0.1.5)
+
+PLATFORMS
+  ruby
+
+DEPENDENCIES
+  aws-sdk-ec2
+  geocoder
+  slack-ruby-client
+
+RUBY VERSION
+   ruby 2.7.1p83
+
+BUNDLED WITH
+   2.1.4

--- a/aws/lambda/ssm_session_slack/ssm_session_slack.rb
+++ b/aws/lambda/ssm_session_slack/ssm_session_slack.rb
@@ -1,0 +1,102 @@
+# Lambda function to notify a Slack channel when an SSM Session Manager session is created.
+# This function is triggered by a CloudWatch Events rule monitoring the ssm:StartSession API call.
+# To format friendly Slack-message output, it looks up:
+# - EC2 instance name by tag
+# - Location (city/state/country) by IP address
+# - Slack username by email address (derived from the session ID, which is derived from the role session name)
+
+require 'aws-sdk-ec2'
+require 'geocoder'
+require 'slack-ruby-client'
+
+EC2 = Aws::EC2::Client.new
+
+Geocoder.configure(
+  cache: Hash.new,
+  timeout: 10,
+  ip_lookup: :freegeoip,
+  freegeoip: {host: ENV['FREEGEOIP_HOST']}
+)
+
+require 'geocoder/lookups/freegeoip'
+# Force Freegeoip to use HTTP protocol.
+Geocoder::Lookup::Freegeoip.prepend(Module.new do
+  def supported_protocols
+    [:http]
+  end
+end)
+
+def handler(event:, context:)
+  puts "Incoming event: #{event}"
+  detail = event['detail']
+  slack = Slack::Web::Client.new(token: ENV['SLACK_API_TOKEN'])
+  session_id = detail.dig('responseElements', 'sessionId')
+  username = session_id
+
+  log_link = "https://console.aws.amazon.com/cloudwatch/home#logEventViewer:group=#{ENV['AUDIT_LOG_PATH']};stream=#{session_id}"
+  log_text = "<#{log_link}|:cloud: Log>"
+
+  begin
+    if (session_name = session_id&.match(/(.*)-.*$/)&.captures&.first)
+      user_id = slack.users_lookupByEmail(email: session_name)&.user&.id
+      username = user_id ? "<@#{user_id}>" : session_name
+    end
+  rescue => e
+    puts e # Log Slack exceptions
+  end
+
+  instance_id = detail.dig('requestParameters', 'target')
+  instance_link = "https://console.aws.amazon.com/ec2/v2/home#InstanceDetails:instanceId=#{instance_id}"
+  instance_name = nil
+
+  begin
+    tags = EC2.describe_tags(
+      filters: [{name: 'resource-id', values: [instance_id]}]
+    ).tags.map {|x| [x.key, x.value]}.to_h
+    instance_name = tags['Name']
+    unless instance_name
+      stack_name = tags['aws:cloudformation:stack-name']
+      logical_id = tags['aws:cloudformation:logical-id']
+      instance_name = "#{stack_name}:#{logical_id}" if stack_name && logical_id
+    end
+  rescue => e
+    puts e # Log EC2 exceptions
+  end
+
+  ip = detail['sourceIPAddress']
+  begin
+    if (loc = Geocoder.search(ip).first)
+      ip += " (#{loc.address})"
+    end
+  rescue => e
+    puts e # Log geocoder exceptions
+  end
+
+  message = {
+    channel: ENV['SLACK_CHANNEL'],
+    blocks: [
+      {
+        type: 'section',
+        text: {
+          type: 'mrkdwn',
+          text: "Session started for <#{instance_link}|`#{instance_name || instance_id}`> #{log_text}"
+        }
+      },
+      {
+        type: 'context',
+        elements: [
+          {
+            type: 'mrkdwn',
+            text: username
+          },
+          {
+            'type': 'mrkdwn',
+            'text': ip
+          }
+        ]
+      }
+    ]
+  }
+  puts "Message: #{message}"
+  slack.chat_postMessage(message)
+end

--- a/bin/ssm
+++ b/bin/ssm
@@ -1,0 +1,23 @@
+#!/bin/bash
+
+# Starts an SSM Session Manager session to the EC2 instance, specified by Name (tag) or ID.
+
+INSTANCE_NAME="${1?
+Usage: $0 INSTANCE_NAME [OPTION]...}"
+
+if [[ "$INSTANCE_NAME" =~ ^i-.* ]]; then
+  INSTANCE_ID="$INSTANCE_NAME"
+else
+  INSTANCE_ID=$(aws ec2 describe-instances \
+    --filters "Name=tag:Name,Values=$INSTANCE_NAME" \
+    --query Reservations[].Instances[].[InstanceId] \
+    --output text \
+    | head -n1
+  )
+fi
+if [ -z "$INSTANCE_ID" ]; then
+  echo "Instance '$INSTANCE_NAME' not found."
+  exit 1
+fi
+
+aws ssm start-session --target "$INSTANCE_ID" "${@:2}"

--- a/bin/ssm-completion
+++ b/bin/ssm-completion
@@ -1,0 +1,31 @@
+#!/bin/bash
+
+# Bash tab-completion script for `ssm`, calls ec2.DescribeInstances using the AWS CLI to find
+# running EC2 instances by InstanceId or Name (tag).
+# Caches results of the API call locally for 1 minute, for quicker repeat completions.
+
+# To install, copy this script into `/etc/bash_completion.d/`.
+# To apply to a running shell session, run `source ssm-completion`.
+
+_ssm() {
+  if [ "${#COMP_WORDS[@]}" != "2" ]; then
+    return
+  fi
+
+  CACHE_DIR="$HOME/.cache/ssm"
+  mkdir -p "$CACHE_DIR"
+  CACHE_FILE="$CACHE_DIR/ssm.cache"
+
+  if [ ! "$(find "$CACHE_FILE" -mmin -1 2>/dev/null)" ]; then
+    aws ec2 describe-instances \
+      --filters Name=tag-key,Values=Name \
+                Name=instance-state-name,Values=running \
+      --query "Reservations[].Instances[].[[InstanceId], Tags[?Key == 'Name'].[Value]]" \
+      --output text \
+      > "$CACHE_FILE"
+  fi
+  mapfile -t COMPREPLY < <(IFS=$'\n' compgen -W "$(cat "$CACHE_FILE")" -- "${COMP_WORDS[1]}")
+}
+
+complete -F _ssm ssm
+complete -F _ssm bin/ssm

--- a/bin/ssm-ssh
+++ b/bin/ssm-ssh
@@ -1,0 +1,38 @@
+#!/bin/bash
+
+# Starts an SSH session to the specified EC2 instance through SSM Session Manager,
+# using a temporary SSH key sent through EC2 Instance Connect.
+
+if [ "$#" -ne 4 ]; then
+  echo "Usage: $0 INSTANCE_ID PORT USER KEY_PATH"
+  exit 1
+fi
+
+INSTANCE_ID=${1}
+PORT=${2}
+INSTANCE_OS_USER=${3}
+KEY_PATH=${4}
+
+# Create a temporary SSH key at the provided path.
+rm -f "${KEY_PATH}"
+ssh-keygen -q -t rsa -f "${KEY_PATH}" -N ''
+
+# Lookup Availability Zone of EC2 instance.
+AZ=$(aws ec2 describe-instances \
+  --instance-ids "$INSTANCE_ID" \
+  --query 'Reservations[].Instances[].Placement.AvailabilityZone' \
+  --output text
+)
+
+# Call ec2-instance-connect.SendSSHPublicKey to authorize the public key.
+aws ec2-instance-connect send-ssh-public-key \
+  --instance-id "$INSTANCE_ID" \
+  --availability-zone "$AZ" \
+  --instance-os-user "$INSTANCE_OS_USER" \
+  --ssh-public-key "file://${KEY_PATH}.pub"
+
+# Call ssm to start the SSH port-forwarding session via SSM Session Manager.
+aws ssm start-session \
+  --target "$INSTANCE_ID" \
+  --document-name AWS-StartSSHSession \
+  --parameters "portNumber=$PORT"

--- a/docs/server-sessions.md
+++ b/docs/server-sessions.md
@@ -1,0 +1,50 @@
+# Server sessions
+
+Shell access to managed application servers is controlled by [AWS Systems Manager Session Manager](https://docs.aws.amazon.com/systems-manager/latest/userguide/session-manager.html), which uses AWS credentials to start shell sessions through the [`StartSession`](https://docs.aws.amazon.com/systems-manager/latest/APIReference/API_StartSession.html) API command.
+
+## AWS Console access
+
+You can connect to a server from your browser through the [Amazon EC2 console](https://docs.aws.amazon.com/systems-manager/latest/userguide/session-manager-working-with-sessions-start.html#start-ec2-console) by clicking the 'Connect' button from the EC2 Instances page.
+
+## Command-line Access
+
+In order to connect to a Session Manager Session using the AWS Command Line Interface, you need to first [install the plugin](https://docs.aws.amazon.com/systems-manager/latest/userguide/session-manager-working-with-install-plugin.html). (You may also need to [install the AWS CLI](https://docs.aws.amazon.com/cli/latest/userguide/cli-chap-install.html), or upgrade to v1.16.12 or later.)
+
+To connect to an named EC2 instance using the CLI, you can use the [`ssm`](../bin/ssm) helper script, which will help start a running instance by Name (tag).
+
+(Optional) You may also install the [`ssm-completion`](../bin/ssm-completion) bash completion script by copying it into the [`bash-completion`]() config directory (e.g., `/etc/bash_completion.d/`). The script will enable tab-completion on `ssm` for all running EC2 instance-ids and Name (tag) values.
+
+## Port Forwarding
+
+### Background
+
+[Port Forwarding](https://help.ubuntu.com/community/SSH/OpenSSH/PortForwarding) is an SSH feature that allows you to use a session as a tunnel for traffic to arbitrary services (e.g., a database listening on port 3306, or an HTTP server listening on port 80), on any host the remote server can access over its network. Port forwarding is typically used to control access to services not exposed to the public Internet by routing traffic forwarded over SSH through a central [Bastion Host](https://en.wikipedia.org/wiki/Bastion_host) ('gateway'), which listens to a public SSH port and also has access to the internal network.
+
+### Port Forwarding in Session Manager
+
+Session Manager [supports Port Forwarding sessions](https://aws.amazon.com/blogs/aws/new-port-forwarding-using-aws-system-manager-sessions-manager/) with a special `AWS-StartPortForwardingSession` document.
+
+However, it currently only lets you access services running on the EC2 instance itself (no forwarding ports from other reachable services in the network), and only supports a single open connection per forwarded port.
+
+For these reasons it's generally more convenient to use SSH connections through Session Manager to access internal network services.
+
+## SSH Connections through Session Manager
+
+Session Manager [supports SSH connections](https://docs.aws.amazon.com/systems-manager/latest/userguide/session-manager-getting-started-enable-ssh-connections.html) by forwarding the SSH port (22) through a Session Manager connection. Session Manager provides a special `AWS-StartSSHSession` document for this use-case.
+
+The best way to configure SSH connections through Session Manager is to add an entry in your local ssh config (`~/.ssh/config`) with a `ProxyCommand` that calls the `ssm-ssh` helper script:
+
+```ssh
+# SSH connection to EC2 instances through Session Manager.
+Match host i-*
+  ProxyCommand sh -c "ssm-ssh %h %p %r ~/.ssh/ssm_key"
+  User ubuntu
+  IdentityFile ~/.ssh/ssm_key
+
+  # Any SSH Port Forwarding configuration will also work here, e.g.:
+  LocalForward 3307 db-reporting.code.org:3306
+  LocalForward 8080 localhost:8080
+
+```
+
+With this configuration, all you need to do is run `ssh [instance-id]` and it should establish an SSH connection to the remote instance.

--- a/lib/cdo/cloud_formation/lambda.rb
+++ b/lib/cdo/cloud_formation/lambda.rb
@@ -60,6 +60,14 @@ module Cdo::CloudFormation
       lambda_zip(*files, 'node_modules', key_prefix: 'lambdajs')
     end
 
+    def ruby_zip(name)
+      dir = aws_dir('lambda', name)
+      Dir.chdir(dir) do
+        RakeUtils.bundle_install '--deployment'
+        lambda_zip("#{name}.rb", 'vendor', key_prefix: 'lambdarb')
+      end
+    end
+
     # Helper function to call a Lambda-function-based AWS::CloudFormation::CustomResource.
     # Ref: http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-cfn-customresource.html
     def lambda_fn(function_name, properties={})


### PR DESCRIPTION
## SSM Session Manager Integration

This PR adds support for [AWS Systems Manager Session Manager](https://docs.aws.amazon.com/systems-manager/latest/userguide/session-manager.html) to our managed EC2 instances. Session Manager allows developers to use their existing AWS developer role (backed by 2FA-mandated Google Account federated-user sessions) to start shell sessions through the [`StartSession`](https://docs.aws.amazon.com/systems-manager/latest/APIReference/API_StartSession.html) API command.

I've also included some [helper Bash scripts](https://github.com/code-dot-org/code-dot-org/pull/36853/files#diff-ee2ba1e2935fb085bd71b1d145d6dcc525e0e125192f8404e8e8b4072c328aca) and [documentation](https://github.com/code-dot-org/code-dot-org/pull/36853/files#diff-0b3b9b00a8518e699983f33390e2b83bebdea8379552c09f6015322d3f6c4882) (at [`docs/server-sessions.md`](https://github.com/code-dot-org/code-dot-org/blob/0afc267f07ca88092dff603fdae74ca4a9070155/docs/server-sessions.md)) to make the transition as seamless as possible from existing SSH workflows.

### Why

Using Session Manager will improve and simplify the security posture of our AWS-hosted infrastructure by changing how developers access private EC2 instances and other resources (such as managed database instances) within our AWS-internal network (VPC). Specifically:
- Maintaining a public-facing [Bastion Host](https://en.wikipedia.org/wiki/Bastion_host) ('gateway') will no longer be necessary, since Session Manager sessions can be established to internal EC2 instances directly. This simplifies our infrastructure, making it easier to maintain.
- SSH port will no longer be accessible to the public Internet, reducing security exposure (e.g., to any future exploitable SSH vulnerabilities).
- Maintaining long-lived, user-specific SSH keys on the bastion host will no longer be necessary, further reducing operational burden.
- New sessions are automatically tracked in CloudTrail, improving security. I've also added a Slack-integration Lambda function that posts a message when each new session is established, improving visibility on all shell access throughout our infrastructure.
- Full shell-session history is also recorded to an encrypted audit log in CloudWatch Logs.

### How

Rollout plan is as follows:

- [ ] Enable Session Manager access to EC2 instances in all environments (this PR)
- [ ] Share info with developers on how to connect using Session Manager; look for early-adopters to confirm the setup process works on a few standard environments (e.g., OSX)
- [ ] Confirm that MySQL Workbench connection to reporting DB is possible through Session Manager's SSH port forwarding
- [ ] Give advanced notice to developers on closing gateway and SSH port
- [ ] Close gateway and SSH port (future PR)