### PR TITLE
Don't seed all scripts in one transaction + Don't keep all seeded objects in memory

### DIFF
--- a/SETUP.md
+++ b/SETUP.md
@@ -35,9 +35,7 @@ You can do Code.org development using OSX, Ubuntu, or Windows (running Ubuntu in
     </details>
 
 1. `bundle exec rake install`
-    * This can take a LONG time. You can see if progress is being made by opening up a second shell and starting `mysql -u root`. Run the following command twice, with approximately a 5-10 second delay between
-  each run `select table_schema, table_name, table_rows from information_schema.tables where table_schema like 'dashboard_development' order by table_rows;`  If you see a change in the last couple of rows, the
-  install is working correctly.
+    * This can take a long time, ~30 minutes or more. The most expensive are the "seeding" tasks, where your local DB is populated from data in the repository. Some of the seeding rake tasks can take several minutes. The longest one, `seed:scripts`, can take > 10 minutes, but it should at least print out progress as it goes.
 1. `bundle exec rake build`
     * This may fail if your are on a Mac and your OSX XCode Command Line Tools were not installed properly. See Bundle Install Tips for more information.
 1. (Optional, Code.org engineers only) Setup AWS - Ask a Code.org engineer how to complete this step

--- a/dashboard/app/models/script.rb
+++ b/dashboard/app/models/script.rb
@@ -1007,8 +1007,8 @@ class Script < ActiveRecord::Base
     if /^[0-9]{4}$/ =~ (new_suffix)
       new_properties[:version_year] = new_suffix
     end
-    scripts, _ = Script.setup([script_filename], new_suffix: new_suffix, new_properties: new_properties)
-    new_script = scripts.first
+    script_names, _ = Script.setup([script_filename], new_suffix: new_suffix, new_properties: new_properties)
+    new_script = Script.find_by!(name: script_names.first)
 
     # Make sure we don't modify any files in unit tests.
     if Rails.application.config.levelbuilder_mode

--- a/dashboard/app/models/script.rb
+++ b/dashboard/app/models/script.rb
@@ -888,79 +888,78 @@ class Script < ActiveRecord::Base
   # script and any associated levels, appending new_suffix to the name when
   # copying. Any new_properties are merged into the properties of the new script.
   def self.setup(custom_files, new_suffix: nil, new_properties: {})
-    transaction do
-      scripts_to_add = []
+    scripts_to_add = []
 
-      custom_i18n = {}
-      # Load custom scripts from Script DSL format
-      custom_files.map do |script|
-        name = File.basename(script, '.script')
-        base_name = Script.base_name(name)
-        name = "#{base_name}-#{new_suffix}" if new_suffix
-        script_data, i18n =
-          begin
-            ScriptDSL.parse_file(script, name)
-          rescue => e
-            raise e, "Error parsing script file #{script}: #{e}"
-          end
+    custom_i18n = {}
+    # Load custom scripts from Script DSL format
+    custom_files.map do |script|
+      name = File.basename(script, '.script')
+      base_name = Script.base_name(name)
+      name = "#{base_name}-#{new_suffix}" if new_suffix
+      script_data, i18n =
+        begin
+          ScriptDSL.parse_file(script, name)
+        rescue => e
+          raise e, "Error parsing script file #{script}: #{e}"
+        end
 
-        lesson_groups = script_data[:lesson_groups]
-        custom_i18n.deep_merge!(i18n)
-        # TODO: below is duplicated in update_text. and maybe can be refactored to pass script_data?
-        scripts_to_add << [{
-          id: script_data[:id],
-          name: name,
-          hidden: script_data[:hidden].nil? ? true : script_data[:hidden], # default true
-          login_required: script_data[:login_required].nil? ? false : script_data[:login_required], # default false
-          wrapup_video: script_data[:wrapup_video],
-          new_name: script_data[:new_name],
-          family_name: script_data[:family_name],
-          properties: Script.build_property_hash(script_data).merge(new_properties)
-        }, lesson_groups]
-      end
-
-      # Print progress for dev environments and adhocs
-      debug = [:adhoc, :development].include?(rack_env)
-      if debug
-        $stdout.sync = true
-        puts "Seeding #{scripts_to_add.length} Scripts"
-        print "Seeded... "
-      end
-
-      n = 0
-      # Stable sort by ID then add each script, ensuring scripts with no ID end up at the end
-      added_script_names = scripts_to_add.sort_by.with_index {|args, idx| [args[0][:id] || Float::INFINITY, idx]}.map do |options, raw_lesson_groups|
-        added_script = add_script(options, raw_lesson_groups, new_suffix: new_suffix, editor_experiment: new_properties[:editor_experiment])
-        n += 1
-        print "#{n}, " if debug
-        added_script.name
-      rescue => e
-        raise e, "Error adding script named '#{options[:name]}': #{e}", e.backtrace
-      end
-      puts added_script_names
-      [added_script_names, custom_i18n]
+      lesson_groups = script_data[:lesson_groups]
+      custom_i18n.deep_merge!(i18n)
+      # TODO: below is duplicated in update_text. and maybe can be refactored to pass script_data?
+      scripts_to_add << [{
+        id: script_data[:id],
+        name: name,
+        hidden: script_data[:hidden].nil? ? true : script_data[:hidden], # default true
+        login_required: script_data[:login_required].nil? ? false : script_data[:login_required], # default false
+        wrapup_video: script_data[:wrapup_video],
+        new_name: script_data[:new_name],
+        family_name: script_data[:family_name],
+        properties: Script.build_property_hash(script_data).merge(new_properties)
+      }, lesson_groups]
     end
+
+    # Print progress for dev environments and adhocs
+    debug = [:adhoc, :development].include?(rack_env)
+    if debug
+      $stdout.sync = true
+      puts "Seeding #{scripts_to_add.length} Scripts"
+      print "Seeded... "
+    end
+
+    n = 0
+    # Stable sort by ID then add each script, ensuring scripts with no ID end up at the end
+    added_script_names = scripts_to_add.sort_by.with_index {|args, idx| [args[0][:id] || Float::INFINITY, idx]}.map do |options, raw_lesson_groups|
+      added_script = add_script(options, raw_lesson_groups, new_suffix: new_suffix, editor_experiment: new_properties[:editor_experiment])
+      n += 1
+      print "#{n}, " if debug
+      added_script.name
+    rescue => e
+      raise e, "Error adding script named '#{options[:name]}': #{e}", e.backtrace
+    end
+    [added_script_names, custom_i18n]
   end
 
   # if new_suffix is specified, copy the script, hide it, and copy all its
   # levelbuilder-defined levels.
   def self.add_script(options, raw_lesson_groups, new_suffix: nil, editor_experiment: nil)
-    script = fetch_script(options)
-    script.update!(hidden: true) if new_suffix
+    transaction do
+      script = fetch_script(options)
+      script.update!(hidden: true) if new_suffix
 
-    script.prevent_duplicate_lesson_groups(raw_lesson_groups)
-    Script.prevent_some_lessons_in_lesson_groups_and_some_not(raw_lesson_groups)
+      script.prevent_duplicate_lesson_groups(raw_lesson_groups)
+      Script.prevent_some_lessons_in_lesson_groups_and_some_not(raw_lesson_groups)
 
-    temp_lgs = LessonGroup.add_lesson_groups(raw_lesson_groups, script, new_suffix, editor_experiment)
-    script.reload
-    script.lesson_groups = temp_lgs
-    script.save!
+      temp_lgs = LessonGroup.add_lesson_groups(raw_lesson_groups, script, new_suffix, editor_experiment)
+      script.reload
+      script.lesson_groups = temp_lgs
+      script.save!
 
-    script.generate_plc_objects
+      script.generate_plc_objects
 
-    CourseOffering.add_course_offering(script)
+      CourseOffering.add_course_offering(script)
 
-    script
+      script
+    end
   end
 
   # If there is more than 1 lesson group then the key should never

--- a/dashboard/app/models/script.rb
+++ b/dashboard/app/models/script.rb
@@ -929,14 +929,16 @@ class Script < ActiveRecord::Base
 
       n = 0
       # Stable sort by ID then add each script, ensuring scripts with no ID end up at the end
-      scripts_to_add.sort_by.with_index {|args, idx| [args[0][:id] || Float::INFINITY, idx]}.each do |options, raw_lesson_groups|
-        add_script(options, raw_lesson_groups, new_suffix: new_suffix, editor_experiment: new_properties[:editor_experiment])
+      added_script_names = scripts_to_add.sort_by.with_index {|args, idx| [args[0][:id] || Float::INFINITY, idx]}.map do |options, raw_lesson_groups|
+        added_script = add_script(options, raw_lesson_groups, new_suffix: new_suffix, editor_experiment: new_properties[:editor_experiment])
         n += 1
         print "#{n}, " if debug
+        added_script.name
       rescue => e
         raise e, "Error adding script named '#{options[:name]}': #{e}", e.backtrace
       end
-      custom_i18n
+      puts added_script_names
+      [added_script_names, custom_i18n]
     end
   end
 

--- a/dashboard/app/models/script.rb
+++ b/dashboard/app/models/script.rb
@@ -921,17 +921,19 @@ class Script < ActiveRecord::Base
     # Print progress for dev environments and adhocs
     debug = [:adhoc, :development].include?(rack_env)
     if debug
-      $stdout.sync = true
       puts "Seeding #{scripts_to_add.length} Scripts"
       print "Seeded... "
+      n = 0
     end
 
-    n = 0
     # Stable sort by ID then add each script, ensuring scripts with no ID end up at the end
     added_script_names = scripts_to_add.sort_by.with_index {|args, idx| [args[0][:id] || Float::INFINITY, idx]}.map do |options, raw_lesson_groups|
       added_script = add_script(options, raw_lesson_groups, new_suffix: new_suffix, editor_experiment: new_properties[:editor_experiment])
-      n += 1
-      print "#{n}, " if debug
+      if debug
+        n += 1
+        print "#{n}, "
+        STDOUT.flush
+      end
       added_script.name
     rescue => e
       raise e, "Error adding script named '#{options[:name]}': #{e}", e.backtrace

--- a/dashboard/app/models/script.rb
+++ b/dashboard/app/models/script.rb
@@ -919,13 +919,24 @@ class Script < ActiveRecord::Base
         }, lesson_groups]
       end
 
+      # Print progress for dev environments and adhocs
+      debug = [:adhoc, :development].include?(rack_env)
+      if debug
+        $stdout.sync = true
+        puts "Seeding #{scripts_to_add.length} Scripts"
+        print "Seeded... "
+      end
+
+      n = 0
       # Stable sort by ID then add each script, ensuring scripts with no ID end up at the end
-      added_scripts = scripts_to_add.sort_by.with_index {|args, idx| [args[0][:id] || Float::INFINITY, idx]}.map do |options, raw_lesson_groups|
+      scripts_to_add.sort_by.with_index {|args, idx| [args[0][:id] || Float::INFINITY, idx]}.each do |options, raw_lesson_groups|
         add_script(options, raw_lesson_groups, new_suffix: new_suffix, editor_experiment: new_properties[:editor_experiment])
+        n += 1
+        print "#{n}, " if debug
       rescue => e
         raise e, "Error adding script named '#{options[:name]}': #{e}", e.backtrace
       end
-      [added_scripts, custom_i18n]
+      custom_i18n
     end
   end
 

--- a/dashboard/lib/tasks/seed.rake
+++ b/dashboard/lib/tasks/seed.rake
@@ -173,7 +173,7 @@ namespace :seed do
       _, custom_i18n = Script.setup(custom_scripts)
       Script.merge_and_write_i18n(custom_i18n)
     rescue
-      rm SEEDED # if we failed to do any of that stuff we didn't seed anything, did we
+      rm SEEDED # if we failed somewhere in the process, we may have seeded some Scripts, but not all that we were supposed to.
       raise
     end
   end

--- a/dashboard/lib/tasks/seed.rake
+++ b/dashboard/lib/tasks/seed.rake
@@ -170,7 +170,7 @@ namespace :seed do
     begin
       custom_scripts = script_files.select {|script| File.mtime(script) > scripts_seeded_mtime}
       LevelLoader.update_unplugged if File.mtime('config/locales/unplugged.en.yml') > scripts_seeded_mtime
-      custom_i18n = Script.setup(custom_scripts)
+      _, custom_i18n = Script.setup(custom_scripts)
       Script.merge_and_write_i18n(custom_i18n)
     rescue
       rm SEEDED # if we failed to do any of that stuff we didn't seed anything, did we

--- a/dashboard/lib/tasks/seed.rake
+++ b/dashboard/lib/tasks/seed.rake
@@ -170,7 +170,7 @@ namespace :seed do
     begin
       custom_scripts = script_files.select {|script| File.mtime(script) > scripts_seeded_mtime}
       LevelLoader.update_unplugged if File.mtime('config/locales/unplugged.en.yml') > scripts_seeded_mtime
-      _, custom_i18n = Script.setup(custom_scripts)
+      custom_i18n = Script.setup(custom_scripts)
       Script.merge_and_write_i18n(custom_i18n)
     rescue
       rm SEEDED # if we failed to do any of that stuff we didn't seed anything, did we

--- a/dashboard/test/models/course_offering_test.rb
+++ b/dashboard/test/models/course_offering_test.rb
@@ -15,8 +15,8 @@ class CourseOfferingTest < ActiveSupport::TestCase
   # Other cases are covered by directly testing add_course_offering below.
   test "Script.setup creates CourseOffering and CourseVersion if is_course is true" do
     script_file = File.join(self.class.fixture_path, 'test-script-course-version.script')
-    scripts, _ = Script.setup([script_file])
-    script = scripts.first
+    script_names, _ = Script.setup([script_file])
+    script = Script.find_by!(name: script_names.first)
 
     offering = script.course_version.course_offering
     assert_equal 'xyz', offering.key

--- a/dashboard/test/models/script_test.rb
+++ b/dashboard/test/models/script_test.rb
@@ -1011,7 +1011,8 @@ class ScriptTest < ActiveSupport::TestCase
 
   test 'should generate PLC objects' do
     script_file = File.join(self.class.fixture_path, 'test-plc.script')
-    scripts, custom_i18n = Script.setup([script_file])
+    script_names, custom_i18n = Script.setup([script_file])
+    script = Script.find_by!(name: script_names.first)
     custom_i18n.deep_merge!(
       {
         'en' => {
@@ -1030,7 +1031,6 @@ class ScriptTest < ActiveSupport::TestCase
     )
     I18n.backend.store_translations I18n.locale, custom_i18n['en']
 
-    script = scripts.first
     script.save! # Need to trigger an update because i18n strings weren't loaded
     assert script.professional_learning_course?
     assert_equal 'Test plc course', script.professional_learning_course

--- a/dashboard/test/models/script_test.rb
+++ b/dashboard/test/models/script_test.rb
@@ -52,9 +52,9 @@ class ScriptTest < ActiveSupport::TestCase
   test 'login required setting in script file' do
     file = File.join(self.class.fixture_path, "login_required.script")
 
-    scripts, _ = Script.setup([file])
+    script_names, _ = Script.setup([file])
+    script = Script.find_by!(name: script_names.first)
 
-    script = scripts[0]
     assert script.login_required?
     assert_equal 'Level 1', script.levels[0].name
 
@@ -64,8 +64,8 @@ class ScriptTest < ActiveSupport::TestCase
   end
 
   test 'create script from DSL' do
-    scripts, _ = Script.setup([@script_file])
-    script = scripts[0]
+    script_names, _ = Script.setup([@script_file])
+    script = Script.find_by!(name: script_names.first)
     assert_equal 'Level 1', script.levels[0].name
     assert_equal 'Lesson Two', script.script_levels[3].lesson.name
 
@@ -74,20 +74,22 @@ class ScriptTest < ActiveSupport::TestCase
   end
 
   test 'should not change Script[Level] ID when reseeding' do
-    scripts, _ = Script.setup([@script_file])
-    script = scripts[0]
+    script_names, _ = Script.setup([@script_file])
+    script = Script.find_by!(name: script_names.first)
     script_id = script.script_levels[4].script_id
     script_level_id = script.script_levels[4].id
 
-    scripts, _ = Script.setup([@script_file])
-    assert_equal script_id, scripts[0].script_levels[4].script_id
-    assert_equal script_level_id, scripts[0].script_levels[4].id
+    script_names, _ = Script.setup([@script_file])
+    script = Script.find_by!(name: script_names.first)
+    assert_equal script_id, script.script_levels[4].script_id
+    assert_equal script_level_id, script.script_levels[4].id
   end
 
   test 'should not change Script ID when changing script levels and options' do
-    scripts, _ = Script.setup([@script_file])
-    script_id = scripts[0].script_levels[4].script_id
-    script_level_id = scripts[0].script_levels[4].id
+    script_names, _ = Script.setup([@script_file])
+    script = Script.find_by!(name: script_names.first)
+    script_id = script.script_levels[4].script_id
+    script_level_id = script.script_levels[4].id
 
     parsed_script = ScriptDSL.parse_file(@script_file)[0][:lesson_groups]
 
@@ -155,25 +157,28 @@ class ScriptTest < ActiveSupport::TestCase
   end
 
   test 'should remove empty lessons' do
-    scripts, _ = Script.setup([@script_file])
-    assert_equal 2, scripts[0].lessons.count
+    script_names, _ = Script.setup([@script_file])
+    script = Script.find_by!(name: script_names.first)
+    assert_equal 2, script.lessons.count
 
     # Reupload a script of the same filename / name, but lacking the second lesson.
-    lesson = scripts[0].lessons.last
+    lesson = script.lessons.last
     script_file_empty_lesson = File.join(self.class.fixture_path, "duplicate_scripts", "test-fixture.script")
-    scripts, _ = Script.setup([script_file_empty_lesson])
-    assert_equal 1, scripts[0].lessons.count
+    script_names, _ = Script.setup([script_file_empty_lesson])
+    script = Script.find_by!(name: script_names.first)
+    assert_equal 1, script.lessons.count
     assert_not Lesson.exists?(lesson.id)
   end
 
   test 'should remove empty lessons, reordering lessons' do
     script_file_3_lessons = File.join(self.class.fixture_path, "test-fixture-3-stages.script")
     script_file_middle_missing_reversed = File.join(self.class.fixture_path, "duplicate_scripts", "test-fixture-3-stages.script")
-    scripts, _ = Script.setup([script_file_3_lessons])
-    assert_equal 3, scripts[0].lessons.count
-    first = scripts[0].lessons[0]
-    second = scripts[0].lessons[1]
-    third = scripts[0].lessons[2]
+    script_names, _ = Script.setup([script_file_3_lessons])
+    script = Script.find_by!(name: script_names.first)
+    assert_equal 3, script.lessons.count
+    first = script.lessons[0]
+    second = script.lessons[1]
+    third = script.lessons[2]
     assert_equal 'lesson1', first.name
     assert_equal 'lesson2', second.name
     assert_equal 'lesson3', third.name
@@ -182,12 +187,13 @@ class ScriptTest < ActiveSupport::TestCase
     assert_equal 3, third.absolute_position
 
     # Reupload a script of the same filename / name, but lacking the middle lesson.
-    scripts, _ = Script.setup([script_file_middle_missing_reversed])
-    assert_equal 2, scripts[0].lessons.count
+    script_names, _ = Script.setup([script_file_middle_missing_reversed])
+    script = Script.find_by!(name: script_names.first)
+    assert_equal 2, script.lessons.count
     assert_not Lesson.exists?(second.id)
 
-    first = scripts[0].lessons[0]
-    second = scripts[0].lessons[1]
+    first = script.lessons[0]
+    second = script.lessons[1]
     assert_equal 1, first.absolute_position
     assert_equal 2, second.absolute_position
     assert_equal 'lesson3', first.name
@@ -198,8 +204,8 @@ class ScriptTest < ActiveSupport::TestCase
     # First, seed using a .script file that sets something explicitly for all fields, i.e. everything that's not in
     # the properties hash.
     script_file_all_fields = File.join(self.class.fixture_path, 'test-all-fields.script')
-    scripts, _ = Script.setup([script_file_all_fields])
-    script = scripts.first
+    script_names, _ = Script.setup([script_file_all_fields])
+    script = Script.find_by!(name: script_names.first)
 
     # Not testing new_name since it causes a new script to be created.
     assert_equal false, script.hidden? # defaults to true, so we want to verify it was explicitly set to false
@@ -219,8 +225,8 @@ class ScriptTest < ActiveSupport::TestCase
   test 'all properties can be set and then removed on reseed' do
     # First, seed using a .script file that sets something explicitly for everything in the properties hash.
     script_file_all_properties = File.join(self.class.fixture_path, 'test-all-properties.script')
-    scripts, _ = Script.setup([script_file_all_properties])
-    script = scripts.first
+    script_names, _ = Script.setup([script_file_all_properties])
+    script = Script.find_by!(name: script_names.first)
 
     assert_equal 21, script.properties.keys.length
     script.properties.values.each {|v| assert v}
@@ -270,32 +276,36 @@ class ScriptTest < ActiveSupport::TestCase
   end
 
   test 'script_level positions should reset' do
-    scripts, _ = Script.setup([@script_file])
-    first = scripts[0].lessons[0].script_levels[0]
-    second = scripts[0].lessons[0].script_levels[1]
+    script_names, _ = Script.setup([@script_file])
+    script = Script.find_by!(name: script_names.first)
+    first = script.lessons[0].script_levels[0]
+    second = script.lessons[0].script_levels[1]
     assert_equal 1, first.position
     assert_equal 2, second.position
     promoted_level = second.level
     script_file_remove_level = File.join(self.class.fixture_path, "duplicate_scripts", "test-fixture.script")
 
-    scripts, _ = Script.setup([script_file_remove_level])
-    new_first_script_level = ScriptLevel.joins(:levels).where(script: scripts[0], levels: {id: promoted_level}).first
+    script_names, _ = Script.setup([script_file_remove_level])
+    script = Script.find_by!(name: script_names.first)
+    new_first_script_level = ScriptLevel.joins(:levels).where(script: script, levels: {id: promoted_level}).first
     assert_equal 1, new_first_script_level.position
   end
 
   test 'script import is idempotent w.r.t. positions and count' do
-    scripts, _ = Script.setup([@script_file])
+    script_names, _ = Script.setup([@script_file])
+    script = Script.find_by!(name: script_names.first)
     original_count = ScriptLevel.count
-    first = scripts[0].lessons[0].script_levels[0]
-    second = scripts[0].lessons[0].script_levels[1]
-    third = scripts[0].lessons[0].script_levels[2]
+    first = script.lessons[0].script_levels[0]
+    second = script.lessons[0].script_levels[1]
+    third = script.lessons[0].script_levels[2]
     assert_equal 1, first.position
     assert_equal 2, second.position
     assert_equal 3, third.position
-    scripts, _ = Script.setup([@script_file])
-    first = scripts[0].lessons[0].script_levels[0]
-    second = scripts[0].lessons[0].script_levels[1]
-    third = scripts[0].lessons[0].script_levels[2]
+    script_names, _ = Script.setup([@script_file])
+    script = Script.find_by!(name: script_names.first)
+    first = script.lessons[0].script_levels[0]
+    second = script.lessons[0].script_levels[1]
+    third = script.lessons[0].script_levels[2]
     assert_equal 1, first.position
     assert_equal 2, second.position
     assert_equal 3, third.position
@@ -304,8 +314,9 @@ class ScriptTest < ActiveSupport::TestCase
 
   test 'unplugged in script' do
     @script_file = File.join(self.class.fixture_path, 'test-unplugged.script')
-    scripts, _ = Script.setup([@script_file])
-    assert_equal 'Unplugged', scripts[0].script_levels[1].level['type']
+    script_names, _ = Script.setup([@script_file])
+    script = Script.find_by!(name: script_names.first)
+    assert_equal 'Unplugged', script.script_levels[1].level['type']
   end
 
   test 'blockly level in custom script' do
@@ -1506,8 +1517,8 @@ class ScriptTest < ActiveSupport::TestCase
   end
 
   test 'clone script with suffix' do
-    scripts, _ = Script.setup([@script_file])
-    script = scripts[0]
+    script_names, _ = Script.setup([@script_file])
+    script = Script.find_by!(name: script_names.first)
     assert_equal 1, script.announcements.count
 
     Script.stubs(:script_directory).returns(self.class.fixture_path)
@@ -1555,8 +1566,8 @@ class ScriptTest < ActiveSupport::TestCase
   # updated under certain conditions). These are covered in other test cases.
   test 'clone with suffix clears certain properties' do
     script_file = File.join(self.class.fixture_path, "test-all-properties.script")
-    scripts, _ = Script.setup([script_file])
-    script = scripts.first
+    script_names, _ = Script.setup([script_file])
+    script = Script.find_by!(name: script_names.first)
 
     # all properties that should change
     assert script.tts
@@ -1585,8 +1596,8 @@ class ScriptTest < ActiveSupport::TestCase
 
   test 'clone versioned script with suffix' do
     script_file = File.join(self.class.fixture_path, "test-fixture-versioned-1801.script")
-    scripts, _ = Script.setup([script_file])
-    script = scripts[0]
+    script_names, _ = Script.setup([script_file])
+    script = Script.find_by!(name: script_names.first)
 
     Script.stubs(:script_directory).returns(self.class.fixture_path)
     script_copy = script.clone_with_suffix('1802')
@@ -1601,8 +1612,8 @@ class ScriptTest < ActiveSupport::TestCase
 
   test 'clone script with variants' do
     script_file = File.join(self.class.fixture_path, "test-fixture-experiments.script")
-    scripts, _ = Script.setup([script_file])
-    script = scripts[0]
+    script_names, _ = Script.setup([script_file])
+    script = Script.find_by!(name: script_names.first)
 
     Script.stubs(:script_directory).returns(self.class.fixture_path)
     script_copy = script.clone_with_suffix('copy')
@@ -1631,8 +1642,8 @@ class ScriptTest < ActiveSupport::TestCase
   end
 
   test 'clone with suffix and add editor experiment' do
-    scripts, _ = Script.setup([@script_file])
-    script = scripts[0]
+    script_names, _ = Script.setup([@script_file])
+    script = Script.find_by!(name: script_names.first)
     assert_equal 1, script.announcements.count
 
     Script.stubs(:script_directory).returns(self.class.fixture_path)
@@ -1846,8 +1857,8 @@ class ScriptTest < ActiveSupport::TestCase
     SCRIPT
 
     File.stubs(:read).returns(dsl)
-    scripts, _ = Script.setup(['pilot-script.script'])
-    script = scripts.first
+    script_names, _ = Script.setup(['pilot-script.script'])
+    script = Script.find_by!(name: script_names.first)
 
     assert_equal 'pilot-script', script.name
     assert_equal 'pilot-experiment', script.pilot_experiment


### PR DESCRIPTION
This change somehow makes seeding all scripts from scratch go from about 1 hour down to about 11-13 minutes.

Most of the diff in the PR UI is just whitespace changes. There are two key changes:
* Instead of collecting a list of all seeded Script objects and returning it, we now collect and return a list of the names of the seeded Scripts. I think this lets us avoid keeping all the Script objects (and all their associated objects) we produce during seeding in memory. It seems like the returned script objects were only being used in unit tests, anyway.
* Instead of seeding all scripts in one transaction, we now use a transaction per script.

From trial and error it seems like both changes are needed to achieve the fast seeding. Not entirely sure on that, but I've been able to repro it several times at least.

Before this change, seeding would slow down drastically as it progressed. Scripts 1-100 went pretty fast, but then by the time it got to script 300+, it's taking > 30 seconds per script. Still not sure on the specific reasons why, though.

**Is it ok to not have the whole thing be one transaction?** It doesn't seem like a problem to me if it gets interrupted in the middle and the scripts are partially seeded, but looking for input on that.

Finally, added some logging output to help developers see seeding progress, since it often feels like it's frozen when seeding for the first time. It looks something like:

```
Seeding 444 scripts

Seeded... 1, 2, 3, 4, 
```
It'll print out numbers one at a time as it seeds.

## Testing story

Updated unit tests.

Manual testing, using `bin/rails console --sandbox`:

```
[LevelConceptDifficulty, ScriptLevel, Plc::LearningModule, Lesson, LessonGroup, Plc::CourseUnit, Script, CourseVersion, CourseOffering].map(&:delete_all)

ActiveRecord::Base.logger = nil

SCRIPTS_GLOB = Dir.glob('config/scripts/**/*.script').sort.flatten
puts "Started at: #{Time.now()}"
Benchmark.measure {
  Script.setup(SCRIPTS_GLOB)
}
```

Also tested using `bundle exec rake db:reset && bundle exec rake seed:all --trace`. Relevant part of output:

```
** Execute seed:scripts
Seeding 444 Scripts
Seeded... 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32, 33, 34, 35, 36, 37, 38, 39, 40, 41, 42, 43, 44, 45, 46, 47, 48, 49, 50, 51, 52, 53, 54, 55, 56, 57, 58, 59, 60, 61, 62, 63, 64, 65, 66, 67, 68, 69, 70, 71, 72, 73, 74, 75, 76, 77, 78, 79, 80, 81, 82, 83, 84, 85, 86, 87, 88, 89, 90, 91, 92, 93, 94, 95, 96, 97, 98, 99, 100, 101, 102, 103, 104, 105, 106, 107, 108, 109, 110, 111, 112, 113, 114, 115, 116, 117, 118, 119, 120, 121, 122, 123, 124, 125, 126, 127, 128, 129, 130, 131, 132, 133, 134, 135, 136, 137, 138, 139, 140, 141, 142, 143, 144, 145, 146, 147, 148, 149, 150, 151, 152, 153, 154, 155, 156, 157, 158, 159, 160, 161, 162, 163, 164, 165, 166, 167, 168, 169, 170, 171, 172, 173, 174, 175, 176, 177, 178, 179, 180, 181, 182, 183, 184, 185, 186, 187, 188, 189, 190, 191, 192, 193, 194, 195, 196, 197, 198, 199, 200, 201, 202, 203, 204, 205, 206, 207, 208, 209, 210, 211, 212, 213, 214, 215, 216, 217, 218, 219, 220, 221, 222, 223, 224, 225, 226, 227, 228, 229, 230, 231, 232, 233, 234, 235, 236, 237, 238, 239, 240, 241, 242, 243, 244, 245, 246, 247, 248, 249, 250, 251, 252, 253, 254, 255, 256, 257, 258, 259, 260, 261, 262, 263, 264, 265, 266, 267, 268, 269, 270, 271, 272, 273, 274, 275, 276, 277, 278, 279, 280, 281, 282, 283, 284, 285, 286, 287, 288, 289, 290, 291, 292, 293, 294, 295, 296, 297, 298, 299, 300, 301, 302, 303, 304, 305, 306, 307, 308, 309, 310, 311, 312, 313, 314, 315, 316, 317, 318, 319, 320, 321, 322, 323, 324, 325, 326, 327, 328, 329, 330, 331, 332, 333, 334, 335, 336, 337, 338, 339, 340, 341, 342, 343, 344, 345, 346, 347, 348, 349, 350, 351, 352, 353, 354, 355, 356, 357, 358, 359, 360, 361, 362, 363, 364, 365, 366, 367, 368, 369, 370, 371, 372, 373, 374, 375, 376, 377, 378, 379, 380, 381, 382, 383, 384, 385, 386, 387, 388, 389, 390, 391, 392, 393, 394, 395, 396, 397, 398, 399, 400, 401, 402, 403, 404, 405, 406, 407, 408, 409, 410, 411, 412, 413, 414, 415, 416, 417, 418, 419, 420, 421, 422, 423, 424, 425, 426, 427, 428, 429, 430, 431, 432, 433, 434, 435, 436, 437, 438, 439, 440, 441, 442, 443, 444,
Finished seed:scripts (12 minutes and 39 seconds)
```

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
