### PR TITLE
remove jbuilder

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -153,9 +153,6 @@ gem 'phantomjs', '~> 1.9.7.1'
 # For emoji in utility output.
 gem 'gemoji'
 
-# Build JSON APIs with ease. Read more: https://github.com/rails/jbuilder
-gem 'jbuilder', '~> 2.5'
-
 # Authentication and permissions.
 gem 'cancancan', '~> 1.15.0'
 gem 'devise', '~> 4.4.0'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -508,9 +508,6 @@ GEM
       concurrent-ruby (~> 1.0)
     image_size (1.5.0)
     in_threads (1.4.0)
-    jbuilder (2.5.0)
-      activesupport (>= 3.0.0, < 5.1)
-      multi_json (~> 1.2)
     jmespath (1.4.0)
     jquery-rails (4.1.1)
       rails-dom-testing (>= 1, < 3)
@@ -971,7 +968,6 @@ DEPENDENCIES
   image_optim_rails!
   image_size
   ims-lti!
-  jbuilder (~> 2.5)
   jquery-rails
   jquery-ui-rails (~> 6.0.1)
   jumphash


### PR DESCRIPTION
It's causing problems for the Rails upgrade:

```
    jbuilder (~> 2.5) was resolved to 2.5.0, which depends on
          activesupport (< 5.1, >= 3.0.0)
```

And it doesn't appear to be used anywhere.

## Testing story

Relying on existing tests

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
