### PR TITLE
Fix bugs in milestone reporting

### DIFF
--- a/apps/src/StudioApp.js
+++ b/apps/src/StudioApp.js
@@ -186,6 +186,12 @@ class StudioApp extends EventEmitter {
     this.milestoneStartTime = undefined;
 
     /**
+     * Whether we've reported a milestone yet for this run/reset cycle
+     * @type {boolean}
+     */
+    this.hasReported = false;
+
+    /**
      * If true, we don't show blockspace. Used when viewing shared levels
      */
     this.hideSource = false;

--- a/apps/src/StudioApp.js
+++ b/apps/src/StudioApp.js
@@ -292,7 +292,10 @@ StudioApp.prototype.init = function(config) {
 
   config.getCode = this.getCode.bind(this);
   copyrightStrings = config.copyrightStrings;
-  this.debouncedReport = _.debounce(this.report.bind(this), 1000);
+  this.resetClickedReport = _.debounce(options => {
+    this.report(options);
+    this.hasReported = false;
+  }, 1000);
 
   if (config.legacyShareStyle && config.hideSource) {
     $('body').addClass('legacy-share-view');
@@ -1848,12 +1851,11 @@ StudioApp.prototype.resetButtonClick = function() {
   if (!this.hasReported) {
     // Use the debounced version of report so we don't make dozens of
     // server calls if the user mashes the reset button
-    this.debouncedReport({
+    this.resetClickedReport({
       app: getStore().getState().pageConstants.appType,
       level: this.config.level.id
     });
   }
-  this.hasReported = false;
   this.toggleRunReset('run');
   this.clearHighlighting();
   getStore().dispatch(setFeedback(null));

--- a/apps/src/code-studio/clientState.js
+++ b/apps/src/code-studio/clientState.js
@@ -84,6 +84,9 @@ clientState.writeSourceForLevel = function(
   timestamp,
   source
 ) {
+  if (source === undefined) {
+    return;
+  }
   trySetSessionStorage(
     createKey(scriptName, levelId, 'source'),
     JSON.stringify({

--- a/apps/src/code-studio/initApp/loadApp.js
+++ b/apps/src/code-studio/initApp/loadApp.js
@@ -203,6 +203,9 @@ export function setupApp(appOptions) {
         );
       }
     },
+    onResetPressed: function() {
+      reporting.cancelReport();
+    },
     onContinue: function() {
       var lastServerResponse = reporting.getLastServerResponse();
       if (lastServerResponse.videoInfo) {

--- a/apps/src/code-studio/initApp/loadApp.js
+++ b/apps/src/code-studio/initApp/loadApp.js
@@ -150,7 +150,10 @@ export function setupApp(appOptions) {
         // already stored in the channels API.)
         delete report.program;
         delete report.image;
-      } else if (report.testResult !== TestResults.SKIPPED) {
+      } else if (
+        report.testResult !== TestResults.SKIPPED &&
+        report.program !== undefined
+      ) {
         // Only locally cache non-channel-backed levels. Use a client-generated
         // timestamp initially (it will be updated with a timestamp from the server
         // if we get a response.
@@ -199,9 +202,6 @@ export function setupApp(appOptions) {
           lastSavedProgram
         );
       }
-    },
-    onResetPressed: function() {
-      reporting.cancelReport();
     },
     onContinue: function() {
       var lastServerResponse = reporting.getLastServerResponse();

--- a/apps/src/code-studio/reporting.js
+++ b/apps/src/code-studio/reporting.js
@@ -87,6 +87,9 @@ function validateReport(report) {
       case 'allowMultipleSends':
         validateType('allowMultipleSends', value, 'boolean');
         break;
+      case 'skipSuccessCallback':
+        validateType('skipSuccessCallback', value, 'boolean');
+        break;
       case 'level':
         if (value !== null) {
           if (report.app === 'level_group' || isContainedLevel) {
@@ -193,6 +196,7 @@ function validateReport(report) {
  * @property {boolean} allowMultipleSends - ??
  * @property {number} lines - number of lines of code written.
  * @property {number} serverLevelId - ??
+ * @property {boolean} skipSuccessCallback - Whether we should ignore the success result from ajax
  * @property {?} submitted - ??
  * @property {?} time - ??
  * @property {number} timeSinceLastMilestone- The time since navigating to this page or since the last
@@ -297,6 +301,10 @@ reporting.sendReport = function(report) {
         );
       },
       success: function(response) {
+        if (report.skipSuccessCallback === true) {
+          reportComplete(report, getFallbackResponse(report));
+          return;
+        }
         if (!report.allowMultipleSends && thisAjax !== lastAjaxRequest) {
           return;
         }

--- a/apps/test/integration/levelSolutions/applab1/ec_design.js
+++ b/apps/test/integration/levelSolutions/applab1/ec_design.js
@@ -362,23 +362,10 @@ module.exports = {
 
         Applab.onPuzzleComplete();
       },
-      expected: [
-        {
-          // codeModeButton clicked
-          result: undefined,
-          testResult: undefined
-        },
-        {
-          // resetButton clicked
-          result: undefined,
-          testResult: undefined
-        },
-        {
-          // onPuzzleComplete
-          result: true,
-          testResult: TestResults.FREE_PLAY
-        }
-      ]
+      expected: {
+        result: true,
+        testResult: TestResults.FREE_PLAY
+      }
     },
 
     {
@@ -479,23 +466,10 @@ module.exports = {
 
         Applab.onPuzzleComplete();
       },
-      expected: [
-        {
-          // codeModeButton clicked
-          result: undefined,
-          testResult: undefined
-        },
-        {
-          // resetButton clicked
-          result: undefined,
-          testResult: undefined
-        },
-        {
-          // onPuzzleComplete
-          result: true,
-          testResult: TestResults.FREE_PLAY
-        }
-      ]
+      expected: {
+        result: true,
+        testResult: TestResults.FREE_PLAY
+      }
     },
 
     {
@@ -581,18 +555,10 @@ module.exports = {
 
         Applab.onPuzzleComplete();
       },
-      expected: [
-        {
-          // resetButton clicked
-          result: undefined,
-          testResult: undefined
-        },
-        {
-          // onPuzzleComplete
-          result: true,
-          testResult: TestResults.FREE_PLAY
-        }
-      ]
+      expected: {
+        result: true,
+        testResult: TestResults.FREE_PLAY
+      }
     },
 
     {
@@ -1616,18 +1582,10 @@ module.exports = {
 
         Applab.onPuzzleComplete();
       },
-      expected: [
-        {
-          // resetButton clicked
-          result: undefined,
-          testResult: undefined
-        },
-        {
-          // onPuzzleComplete
-          result: true,
-          testResult: TestResults.FREE_PLAY
-        }
-      ]
+      expected: {
+        result: true,
+        testResult: TestResults.FREE_PLAY
+      }
     },
 
     {

--- a/apps/test/integration/levelSolutions/applab2/ec_screens.js
+++ b/apps/test/integration/levelSolutions/applab2/ec_screens.js
@@ -114,18 +114,10 @@ module.exports = {
           Applab.onPuzzleComplete();
         });
       },
-      expected: [
-        {
-          // change from design mode
-          result: undefined,
-          testResult: undefined
-        },
-        {
-          // onPuzzleComplete
-          result: true,
-          testResult: TestResults.FREE_PLAY
-        }
-      ]
+      expected: {
+        result: true,
+        testResult: TestResults.FREE_PLAY
+      }
     },
     {
       description: 'add a screen',
@@ -756,18 +748,10 @@ module.exports = {
 
         Applab.onPuzzleComplete();
       },
-      expected: [
-        {
-          // resetButton clicked
-          result: undefined,
-          testResult: undefined
-        },
-        {
-          // onPuzzleComplete
-          result: true,
-          testResult: TestResults.FREE_PLAY
-        }
-      ]
+      expected: {
+        result: true,
+        testResult: TestResults.FREE_PLAY
+      }
     },
 
     {

--- a/apps/test/integration/levelSolutions/applab2/ec_simple.js
+++ b/apps/test/integration/levelSolutions/applab2/ec_simple.js
@@ -25,6 +25,36 @@ module.exports = {
       }
     },
 
+    {
+      description: 'Reset logs milestones.',
+      editCode: true,
+      xml: '',
+      runBeforeClick: function(assert) {
+        $('#runButton').click();
+        $('#resetButton').click();
+
+        // Add wait for debouncing
+        setTimeout(function() {
+          $('#runButton').click();
+          $('#resetButton').click();
+          // Add wait for debouncing
+          setTimeout(function() {
+            Applab.onPuzzleComplete();
+          }, 1100);
+        }, 300);
+      },
+      expected: [
+        {
+          result: undefined,
+          testResult: undefined
+        },
+        {
+          result: true,
+          testResult: TestResults.FREE_PLAY
+        }
+      ]
+    },
+
     // Missing coverage of the data category here.
     // Most data blocks make network calls and modify data records. To get
     // test coverage of these here, we would probably need to mock portions of that.

--- a/apps/test/unit/StudioAppTest.js
+++ b/apps/test/unit/StudioAppTest.js
@@ -120,7 +120,7 @@ describe('StudioApp', () => {
         studio.reset = () => {};
 
         reportSpy = sinon.spy();
-        studio.report = reportSpy;
+        studio.debouncedSilentlyReport = reportSpy;
       });
 
       it('Sets hasReported to false', () => {

--- a/apps/test/unit/code-studio/initApp/loadAppTest.js
+++ b/apps/test/unit/code-studio/initApp/loadAppTest.js
@@ -62,7 +62,7 @@ describe('loadApp.js', () => {
 
   it('stores attempts for logged-out users against the server level id', () => {
     setupApp(appOptions);
-    appOptions.onAttempt({});
+    appOptions.onAttempt({program: 'program'});
 
     expect(writtenLevelId).to.equal(SERVER_LEVEL_ID);
   });
@@ -70,7 +70,7 @@ describe('loadApp.js', () => {
   it('stores attempts for logged-out users against the server project level id for template backed level', () => {
     appOptions.serverProjectLevelId = SERVER_PROJECT_LEVEL_ID;
     setupApp(appOptions);
-    appOptions.onAttempt({});
+    appOptions.onAttempt({program: 'program'});
 
     expect(writtenLevelId).to.equal(SERVER_PROJECT_LEVEL_ID);
   });


### PR DESCRIPTION
This fixes 2 bugs in milestone reporting

1. When a milestone was reported via onResetButtonClicked, it would clear the user's recorded code from the SessionStorage on levels such as studio.code.org/s/dance/stage/1/puzzle/2. This would happen because loadApp would naively copy any value of `report.program` into the SessionStorage, including `undefined`. We fix this by adding input validation in loadApp. (see change to loadApp, line 153)
1. onResetPressed in onResetButtonClicked is a one line function in loadApp that has one effect: it aborts the most recent milestone report. This means every time a milestone was reported in onResetButtonClicked, it would be aborted almost immediately. Now, we only abort milestones that were triggered before onResetButtonClicked.
    - Details regarding why we abort when the reset button is clicked are below in the Background section
    - An image showing what this abort looks like is in the "Links" section

### Background
**What is abort?**
```
// sends the request to the server
request = $.ajax({}) 

// Triggers the error callback with code 0 and ignores successful results from the server.
// If the request hasn't reached the server, cancels the request.
request.abort() 
```
Example: https://thisinterestsme.com/aborting-jquery-ajax-request/

**Why do we abort when the reset button is clicked?**

There are two important parts here
- In some apps (maze, dance, ...) the success/failure of the level is handled in the success callback of the milestone api request
- The reset button clears feedback messages and resets the state of the app

If we don't abort milestone api requests, we sometimes end up in a race condition where the success callback happens _after_ the user clicks the reset button. When this happens, the reset button has already cleared feedback messages and reset the state of the app _then_ the success callback sets new feedback messages and a different finish state.

When the user clicks reset, they expect the app to be in a clean, fresh state. To guarantee we always accomplish this, we abort any in-progress milestones.

Without Abort (note that after the reset button is clicked the 1st and 3rd times, the feedback message is visible. The state here should be "reset" to no feedback after all clicks of the reset button)
![inconsistent](https://user-images.githubusercontent.com/8324574/94075980-026da400-fdb1-11ea-9b42-903843202cfa.gif)

With Abort (note that the feedback message is never visible after the reset button is clicked)
![consistent](https://user-images.githubusercontent.com/8324574/94075988-04cffe00-fdb1-11ea-94a2-cb5f5474caa6.gif)

**What about now?**

Now that we're reporting milestones when the reset button is clicked, we need to maintain this same user experience. Now, we pass `skipSuccessCallback` when reporting milestones from the reset button click. This allows us to skip all the side effects from the server's response to the milestone API request.

<!--
  Other aspects to consider. uncomment and add detail for any that seem necessary:
-->

<!-- ### Background -->
<!-- ### Privacy -->
<!-- ### Security -->
<!-- ### Caching -->
<!-- ### Deployment strategy -->
<!-- ### Future work -->

## Links
- [jira](https://codedotorg.atlassian.net/browse/LP-1571)

<!--
  Any relevant links to external resources; ie, specification documents, jira
  items, related PRs, honeybadger errors, etc
-->

![Screen Shot 2020-09-21 at 9 09 21 AM](https://user-images.githubusercontent.com/8324574/93937943-64f57000-fcdd-11ea-84a7-21db56e49fd9.png)


## Testing story

<!--
  Does your change include appropriate tests?

  If so, please describe how the tests included in this PR are sufficient

  If not, please explain why this change does not need to be tested.
-->

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
