### PR TITLE
Upgrade activerecord-import to 0.28.2

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -340,7 +340,7 @@ install_if require_pg do
 end
 
 gem 'active_record_union'
-gem 'activerecord-import'
+gem 'activerecord-import', '~> 0.26'
 gem 'scenic'
 gem 'scenic-mysql_adapter'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -244,7 +244,7 @@ GEM
       activemodel (= 5.0.7.2)
       activesupport (= 5.0.7.2)
       arel (~> 7.0)
-    activerecord-import (0.22.0)
+    activerecord-import (0.28.2)
       activerecord (>= 3.2)
     activesupport (5.0.7.2)
       concurrent-ruby (~> 1.0, >= 1.0.2)
@@ -901,7 +901,7 @@ DEPENDENCIES
   active_model_serializers (~> 0.10.0)
   active_record_query_trace
   active_record_union
-  activerecord-import
+  activerecord-import (~> 0.26)
   acts_as_list
   addressable
   annotate

--- a/dashboard/lib/level_loader.rb
+++ b/dashboard/lib/level_loader.rb
@@ -113,7 +113,13 @@ class LevelLoader
     # Delete entries for all other attributes that may no longer be specified in the xml.
     # Fixes issue #75863324 (delete removed level properties on import)
     level.send(:write_attribute, 'properties', {})
-    level.assign_attributes(level.load_level_xml(xml_node))
+    loaded_attributes = level.load_level_xml(xml_node)
+
+    # activerecord-import 0.28.2 doesn't play nicely with the datetime values serialized in our .level files for some reason.
+    # Without this line, it passes the serialized String value directly into the SQL insert statement as-is, which fails
+    # since it's not the format MySQL wants. Parsing it into a TimeWithZone object first seems to make it work.
+    loaded_attributes['created_at'] = Time.zone.parse(loaded_attributes['created_at']) if loaded_attributes['created_at']
+    level.assign_attributes(loaded_attributes)
 
     level
   end


### PR DESCRIPTION
The upgrade is needed for https://github.com/code-dot-org/code-dot-org/pull/36733, which uses the feature of passing in `all` to `on_duplicate_key_update`. 

Without the little hack I added to `LevelLoader.load_custom_level_xml`, importing levels was failing with this error:

```
ERROR["test_creates_Bee_Fixture", "LevelLoaderTest", 0.15133799996692687]
 test_creates_Bee_Fixture#LevelLoaderTest (0.15s)
ActiveRecord::StatementInvalid:         ActiveRecord::StatementInvalid: Mysql2::Error: Incorrect datetime value: '2014-05-13T17:00:56.000Z' for column 'created_at' at row 1: INSERT INTO `levels` (`id`,`game_id`,`name`,`created_at`,`updated_at`,`level_num`,`ideal_level_source_id`,`user_id`,`properties`,`type`,`md5`,`published`,`notes`,`audit_log`) VALUES (20,25,'Bee Fixture','2014-05-13T17:00:56.000Z','2020-09-23 02:14:38','custom',19,19,'{\"toolbox_blocks\":\"\\u003cxml\\u003e\\u003cblock type=\\\"maze_moveNorth\\\"/\\u003e\\u003cblock type=\\\"maze_moveSouth\\\"/\\u003e\\u003cblock type=\\\"maze_moveEast\\\"/\\u003e\\u003cblock type=\\\"maze_moveWest\\\"/\\u003e\\u003cblock type=\\\"maze_nectar\\\"/\\u003e\\u003cblock type=\\\"maze_honey\\\"/\\u003e\\u003c/xml\\u003e\",\"recommended_blocks\":\"\\u003cxml\\u003e\\u003cblock type=\\\"maze_moveSouth\\\"/\\u003e\\u003cblock type=\\\"maze_nectar\\\"/\\u003e\\u003cblock type=\\\"maze_moveEast\\\"/\\u003e\\u003cblock type=\\\"maze_honey\\\"/\\u003e\\u003c/xml\\u003e\",\"solution_blocks\":\"\\u003cxml\\u003e\\u003cblock type=\\\"when_run\\\" deletable=\\\"false\\\" movable=\\\"false\\\"\\u003e\\u003cnext\\u003e\\u003cblock type=\\\"maze_moveSouth\\\"\\u003e\\u003cnext\\u003e\\u003cblock type=\\\"maze_moveSouth\\\"\\u003e\\u003cnext\\u003e\\u003cblock type=\\\"maze_nectar\\\"\\u003e\\u003cnext\\u003e\\u003cblock type=\\\"maze_moveEast\\\"\\u003e\\u003cnext\\u003e\\u003cblock type=\\\"maze_moveEast\\\"\\u003e\\u003cnext\\u003e\\u003cblock type=\\\"maze_honey\\\"/\\u003e\\u003c/next\\u003e\\u003c/block\\u003e\\u003c/next\\u003e\\u003c/block\\u003e\\u003c/next\\u003e\\u003c/block\\u003e\\u003c/next\\u003e\\u003c/block\\u003e\\u003c/next\\u003e\\u003c/block\\u003e\\u003c/next\\u003e\\u003c/block\\u003e\\u003c/xml\\u003e\",\"maze\":\"[[0,0,0,0,0,0,0,0],[0,0,0,0,0,0,0,0],[0,0,0,2,0,0,0,0],[0,0,0,1,0,0,0,0],[0,0,0,1,1,1,0,0],[0,0,0,0,0,0,0,0],[0,0,0,0,0,0,0,0],[0,0,0,0,0,0,0,0]]\",\"initial_dirt\":\"[[0,0,0,0,0,0,0,0],[0,0,0,0,0,0,0,0],[0,0,0,0,0,0,0,0],[0,0,0,0,0,0,0,0],[0,0,0,1,0,-1,0,0],[0,0,0,0,0,0,0,0],[0,0,0,0,0,0,0,0],[0,0,0,0,0,0,0,0]]\",\"final_dirt\":\"[[0,0,0,0,0,0,0,0],[0,0,0,0,0,0,0,0],[0,0,0,0,0,0,0,0],[0,0,0,0,0,0,0,0],[0,0,0,0,0,0,0,0],[0,0,0,0,0,0,0,0],[0,0,0,0,0,0,0,0],[0,0,0,0,0,0,0,0]]\",\"skin\":\"bee\",\"short_instructions\":\"Move me to the flower, get the nectar, then move me to the honeycomb, and make honey\",\"start_direction\":\"2\",\"step_mode\":\"1\",\"is_k1\":\"true\",\"nectar_goal\":\"1\",\"honey_goal\":\"1\",\"flower_type\":\"redWithNectar\",\"ani_gif_url\":\"/script_assets/k_1_images/instruction_gifs/22_V1.gif\",\"skip_instructions_popup\":\"true\",\"ideal\":\"7\",\"never_autoplay_video\":\"false\",\"disable_param_editing\":\"true\",\"disable_variable_editing\":\"false\",\"use_modal_function_editor\":\"false\",\"use_contract_editor\":\"false\",\"contract_highlight\":\"false\",\"contract_collapse\":\"false\",\"examples_highlight\":\"false\",\"examples_collapse\":\"false\",\"examples_required\":\"false\",\"definition_highlight\":\"false\",\"definition_collapse\":\"false\",\"disable_examples\":\"false\",\"fast_get_nectar_animation\":\"false\",\"preload_asset_list\":null,\"contained_level_names\":null}','Karel','4675b97f1d743b657c883129acc4fc35',0,NULL,NULL) ON DUPLICATE KEY UPDATE `levels`.`game_id`=VALUES(`game_id`),`levels`.`updated_at`=VALUES(`updated_at`),`levels`.`level_num`=VALUES(`level_num`),`levels`.`ideal_level_source_id`=VALUES(`ideal_level_source_id`),`levels`.`user_id`=VALUES(`user_id`),`levels`.`properties`=VALUES(`properties`),`levels`.`type`=VALUES(`type`),`levels`.`md5`=VALUES(`md5`),`levels`.`published`=VALUES(`published`),`levels`.`notes`=VALUES(`notes`),`levels`.`audit_log`=VALUES(`audit_log`)
            lib/level_loader.rb:70:in `block in import_levels'
            lib/level_loader.rb:27:in `import_levels'
            test/lib/level_loader_test.rb:9:in `block in <class:LevelLoaderTest>'
            test/testing/setup_all_and_teardown_all.rb:22:in `run'
```

Note that it was trying to insert the value `2014-05-13T17:00:56.000Z` in for `created_at`, which is the string literal from the file. Not sure why it works that way TBH - when inspecting the Level object using pry, its `.created_at` field seemed to be a valid `TimeWithZone` object, not a String... 🤷‍♀️
In any case, explicitly parsing the string works around this.

I opted for this surgical fix which preserves the created_at data in our .level files, over updating the files themselves, since there are ~16k of them. Another option could also do a bulk edit of the files to remove that line from all of them, but it didn't seem worth the hassle to me. We could also just `nil` out the created_at value, since this piece of data isn't very valuable, but I figured if we can keep it, why not.

## Testing story

- LevelLoader unit tests pass
- Tested with `bundle exec rake db:reset && date && bundle exec rake seed:ui_test --trace`

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
