### PR TITLE
Update i18n instruction on security risks

### DIFF
--- a/dashboard/app/views/levels/_external_link.html.haml
+++ b/dashboard/app/views/levels/_external_link.html.haml
@@ -10,7 +10,7 @@
   .external-link-disclaimer
     %h2= t('external_links.disclaimer')
     %strong= t('external_links.leaving_domain')
-    %p!= t('external_links.disclaimer_text', support_url: 'https://support.code.org', markdown: true)
+    %p!= t('external_links.disclaimer_text', support_url: 'https://support.code.org', markdown: inline)
 
   = render partial: 'levels/teacher_markdown', locals: {data: {'teacher_markdown' => @level.teacher_markdown}}
 

--- a/dashboard/app/views/levels/_external_link.html.haml
+++ b/dashboard/app/views/levels/_external_link.html.haml
@@ -10,7 +10,7 @@
   .external-link-disclaimer
     %h2= t('external_links.disclaimer')
     %strong= t('external_links.leaving_domain')
-    %p!= t('external_links.disclaimer_text', support_url: 'https://support.code.org')
+    %p!= t('external_links.disclaimer_text', support_url: 'https://support.code.org', markdown: true)
 
   = render partial: 'levels/teacher_markdown', locals: {data: {'teacher_markdown' => @level.teacher_markdown}}
 

--- a/i18n/README.md
+++ b/i18n/README.md
@@ -21,7 +21,9 @@ If you want your string to support embedded HTML you **must** render it as Markd
 This is because translation strings come from unstruted sources and our Markdown
 renderer will remove any potentially-dangerous HTML.
 You can render a string as Markdown by passing `markdown: true` or `markdown: :inline`
-to the `I18n.t` method.
+to the `I18n.t` method. With `markdown: true` option, Markdown will handle its own
+block-level elements like paragraphs and lists, while the `markdown: inline` option
+will produce content suitable for embedding inside an existing block-level element.
 
 ### Pegasus
 

--- a/i18n/README.md
+++ b/i18n/README.md
@@ -13,13 +13,15 @@ they will be handled.
 When adding a string, please make the key as descriptive as possible because
 this is used as context for translators.
 
-Make sure your string value only has plain text and simple HTML.
+Make sure your string value only has plain text, Markdown-formatted text, and/or
+simple HTML. Try to always use plain text. If you want to add formatting, use Markdown.
+If you want to do something that Markdown can't do, you can add HTML.
 
-When using a translation string, please be aware that the it comes from an untrusted 
-source like a translator and may contain security risks. If the translation string 
-contains HTML elements, you should pass `markdown: true` or `markdown: :inline` to the 
-`I18n.t` method to have it parse the translation string as markdown instead. (Markdown 
-is a safe alternative to HTML.)
+If you want your string to support embedded HTML you **must** render it as Markdown.
+This is because translation strings come from unstruted sources and our Markdown
+renderer will remove any potentially-dangerous HTML.
+You can render a string as Markdown by passing `markdown: true` or `markdown: :inline`
+to the `I18n.t` method.
 
 ### Pegasus
 
@@ -31,7 +33,7 @@ is a safe alternative to HTML.)
 
 #### Adding a new string
 
--   Add a unique key and your string value to the [i18n Gsheet][0]. 
+-   Add a unique key and your string value to the [i18n Gsheet][0].
 
     -   Organization is
         by category/page; try to prepend each string of a common category with

--- a/i18n/README.md
+++ b/i18n/README.md
@@ -13,6 +13,14 @@ they will be handled.
 When adding a string, please make the key as descriptive as possible because
 this is used as context for translators.
 
+Make sure your string value only has plain text and simple HTML.
+
+When using a translation string, please be aware that the it comes from an untrusted 
+source like a translator and may contain security risks. If the translation string 
+contains HTML elements, you should pass `markdown: true` or `markdown: :inline` to the 
+`I18n.t` method to have it parse the translation string as markdown instead. (Markdown 
+is a safe alternative to HTML.)
+
 ### Pegasus
 
 #### Modifying an existing string
@@ -25,7 +33,7 @@ this is used as context for translators.
 
 -   Add a unique key and your string value to the [i18n Gsheet][0]. 
 
-    -   NOTE: Make sure your string value only has plain HTML. Organization is
+    -   Organization is
         by category/page; try to prepend each string of a common category with
         the same key. For example, all teacher dashboard strings begin with 'dashboard'
         so they're easier to find.


### PR DESCRIPTION
Task [FND-1259](https://codedotorg.atlassian.net/browse/FND-1259): 
* Update i18n README file to raise awareness about security risks when showing translation string that contains HTML elements.
* Also safely un-escaping a translation string which has an URL by using `markdown: true`.

## Links
Slack discussions
[From Ben 8/12/2020](https://codedotorg.slack.com/archives/C0T0UQH0R/p1597173532205900)
[From Elijah 7/16/2020](https://codedotorg.slack.com/archives/C0T0UQH0R/p1594846525154300) 
