### PR TITLE
Add count to progress bar + use --trace to show progress bar

### DIFF
--- a/dashboard/app/models/script.rb
+++ b/dashboard/app/models/script.rb
@@ -919,17 +919,15 @@ class Script < ActiveRecord::Base
       }, lesson_groups]
     end
 
-    # TODO: replace this with configuration option
-    debug = [:adhoc, :development].include?(rack_env)
-    if debug
+    if Rake.application.options.trace
       puts "Seeding #{scripts_to_add.length} Scripts"
-      progressbar = ProgressBar.create(total: scripts_to_add.length)
+      progressbar = ProgressBar.create(total: scripts_to_add.length, format: '%t (%c/%C): |%B|')
     end
 
     # Stable sort by ID then add each script, ensuring scripts with no ID end up at the end
     added_script_names = scripts_to_add.sort_by.with_index {|args, idx| [args[0][:id] || Float::INFINITY, idx]}.map do |options, raw_lesson_groups|
       added_script = add_script(options, raw_lesson_groups, new_suffix: new_suffix, editor_experiment: new_properties[:editor_experiment])
-      progressbar.increment if debug
+      progressbar.increment if Rake.application.options.trace
       added_script.name
     rescue => e
       raise e, "Error adding script named '#{options[:name]}': #{e}", e.backtrace

--- a/lib/rake/install.rake
+++ b/lib/rake/install.rake
@@ -45,7 +45,7 @@ namespace :install do
           # yet because doing so would break unit tests.
           RakeUtils.rake 'db:create db:test:prepare'
         else
-          RakeUtils.rake 'dashboard:setup_db'
+          RakeUtils.rake_stream_output 'dashboard:setup_db', ([:adhoc, :development].include?(rack_env) ? '--trace' : nil)
         end
       end
     end


### PR DESCRIPTION
Followups to https://github.com/code-dot-org/code-dot-org/pull/36856.

* Progress bar is now controlled by passing `--trace` to the rake task as suggested.
* Changed the `rake install` task to pass `--trace` to `dashboard:setup_db` for development and adhoc environments. Also changed it to stream output. Is this ok? My goal is that the progress bar will be shown when developers follow the SETUP.md instructions for initial setup.
* Added a counter to the progress bar. looks something like this:

```
Seeding 1 Scripts
Progress (1/1): |===============================================================|

```

## Testing story

Tested:
* `bundle exec rake install`
* `bundle exec rake seed:single_script SCRIPT_NAME=valentine --trace`

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
