### PR TITLE
use camel case in lesson edit and update APIs

### DIFF
--- a/apps/src/lib/levelbuilder/lesson-editor/LessonEditor.jsx
+++ b/apps/src/lib/levelbuilder/lesson-editor/LessonEditor.jsx
@@ -109,7 +109,7 @@ export default class LessonEditor extends Component {
           <label>
             Creative Commons Image
             <select
-              name="creative_commons_license"
+              name="creativeCommonsLicense"
               style={styles.dropdown}
               defaultValue={creativeCommonsLicense}
             >
@@ -143,7 +143,7 @@ export default class LessonEditor extends Component {
           <TextareaWithMarkdownPreview
             markdown={studentOverview}
             label={'Student Overview'}
-            name={'student_overview'}
+            name={'studentOverview'}
             inputRows={5}
           />
           <TextareaWithMarkdownPreview

--- a/apps/src/sites/studio/pages/lessons/edit.js
+++ b/apps/src/sites/studio/pages/lessons/edit.js
@@ -15,7 +15,7 @@ import {
 } from '@cdo/apps/lib/levelbuilder/lesson-editor/SampleActivitiesData';
 
 $(document).ready(function() {
-  const lessonData = getScriptData('lesson');
+  const lessonData = getScriptData('lesson').editableData;
 
   registerReducers({...reducers});
   const store = getStore();

--- a/apps/src/sites/studio/pages/lessons/edit.js
+++ b/apps/src/sites/studio/pages/lessons/edit.js
@@ -15,7 +15,7 @@ import {
 } from '@cdo/apps/lib/levelbuilder/lesson-editor/SampleActivitiesData';
 
 $(document).ready(function() {
-  const lessonData = getScriptData('lesson').lesson;
+  const lessonData = getScriptData('lesson').editableData;
 
   registerReducers({...reducers});
   const store = getStore();

--- a/apps/src/sites/studio/pages/lessons/edit.js
+++ b/apps/src/sites/studio/pages/lessons/edit.js
@@ -15,7 +15,7 @@ import {
 } from '@cdo/apps/lib/levelbuilder/lesson-editor/SampleActivitiesData';
 
 $(document).ready(function() {
-  const lessonData = getScriptData('lesson').editableData;
+  const lessonData = getScriptData('lesson').lesson;
 
   registerReducers({...reducers});
   const store = getStore();

--- a/dashboard/app/controllers/lessons_controller.rb
+++ b/dashboard/app/controllers/lessons_controller.rb
@@ -45,7 +45,7 @@ class LessonsController < ApplicationController
     # script edit page.
     lp = params.permit(
       :overview,
-      :student_overview,
+      :studentOverview,
       :assessment,
       :unplugged,
       :creativeCommonsLicense,
@@ -53,7 +53,7 @@ class LessonsController < ApplicationController
       :purpose,
       :preparation,
       :announcements
-    )
+    ).to_h.deep_transform_keys(&:underscore)
     lp[:announcements] = JSON.parse(lp[:announcements]) if lp[:announcements]
     lp
   end

--- a/dashboard/app/controllers/lessons_controller.rb
+++ b/dashboard/app/controllers/lessons_controller.rb
@@ -18,16 +18,18 @@ class LessonsController < ApplicationController
   def edit
     @lesson_data = {
       id: @lesson.id,
-      name: @lesson.name,
-      overview: @lesson.overview,
-      studentOverview: @lesson.student_overview,
-      assessment: @lesson.assessment,
-      unplugged: @lesson.unplugged,
-      lockable: @lesson.lockable,
-      creativeCommonsLicense: @lesson.creative_commons_license,
-      purpose: @lesson.purpose,
-      preparation: @lesson.preparation,
-      announcements: @lesson.announcements
+      editableData: {
+        name: @lesson.name,
+        overview: @lesson.overview,
+        studentOverview: @lesson.student_overview,
+        assessment: @lesson.assessment,
+        unplugged: @lesson.unplugged,
+        lockable: @lesson.lockable,
+        creativeCommonsLicense: @lesson.creative_commons_license,
+        purpose: @lesson.purpose,
+        preparation: @lesson.preparation,
+        announcements: @lesson.announcements
+      }
     }
   end
 

--- a/dashboard/app/controllers/lessons_controller.rb
+++ b/dashboard/app/controllers/lessons_controller.rb
@@ -53,7 +53,10 @@ class LessonsController < ApplicationController
       :purpose,
       :preparation,
       :announcements
-    ).to_h.deep_transform_keys(&:underscore)
+    ).to_h
+    unexpected_keys = params.keys - lp.keys - ['id', 'controller', 'action']
+    raise "unexpected parameter: #{unexpected_keys}" unless unexpected_keys.empty?
+    lp.deep_transform_keys!(&:underscore)
     lp[:announcements] = JSON.parse(lp[:announcements]) if lp[:announcements]
     lp
   end

--- a/dashboard/app/controllers/lessons_controller.rb
+++ b/dashboard/app/controllers/lessons_controller.rb
@@ -17,7 +17,7 @@ class LessonsController < ApplicationController
   # GET /lessons/1/edit
   def edit
     @lesson_data = {
-      lesson: {
+      editableData: {
         name: @lesson.name,
         overview: @lesson.overview,
         studentOverview: @lesson.student_overview,

--- a/dashboard/app/controllers/lessons_controller.rb
+++ b/dashboard/app/controllers/lessons_controller.rb
@@ -41,22 +41,26 @@ class LessonsController < ApplicationController
   private
 
   def lesson_params
+    # Convert camelCase params to snake_case. Right now this only works on
+    # top-level key names. This lets us do the transformation before calling
+    # .permit, so that we can use snake_case key names in our parameter list,
+    # because transform_keys returns a params object while deep_transform_keys
+    # returns a plain Hash.
+    lp = params.transform_keys(&:underscore)
+
     # for now, only allow editing of fields that cannot be edited on the
     # script edit page.
-    lp = params.permit(
+    lp = lp.permit(
       :overview,
-      :studentOverview,
+      :student_overview,
       :assessment,
       :unplugged,
-      :creativeCommonsLicense,
+      :creative_commons_license,
       :lockable,
       :purpose,
       :preparation,
       :announcements
-    ).to_h
-    unexpected_keys = params.keys - lp.keys - ['id', 'controller', 'action']
-    raise "unexpected parameter: #{unexpected_keys}" unless unexpected_keys.empty?
-    lp.deep_transform_keys!(&:underscore)
+    )
     lp[:announcements] = JSON.parse(lp[:announcements]) if lp[:announcements]
     lp
   end

--- a/dashboard/app/controllers/lessons_controller.rb
+++ b/dashboard/app/controllers/lessons_controller.rb
@@ -18,7 +18,7 @@ class LessonsController < ApplicationController
   def edit
     @lesson_data = {
       id: @lesson.id,
-      editableData: {
+      lesson: {
         name: @lesson.name,
         overview: @lesson.overview,
         studentOverview: @lesson.student_overview,

--- a/dashboard/app/controllers/lessons_controller.rb
+++ b/dashboard/app/controllers/lessons_controller.rb
@@ -17,7 +17,6 @@ class LessonsController < ApplicationController
   # GET /lessons/1/edit
   def edit
     @lesson_data = {
-      id: @lesson.id,
       lesson: {
         name: @lesson.name,
         overview: @lesson.overview,

--- a/dashboard/test/controllers/lessons_controller_test.rb
+++ b/dashboard/test/controllers/lessons_controller_test.rb
@@ -9,7 +9,10 @@ class LessonsControllerTest < ActionController::TestCase
     @lesson = create(
       :lesson,
       name: 'lesson display name',
-      properties: {overview: 'lesson overview'}
+      properties: {
+        overview: 'lesson overview',
+        student_overview: 'student overview'
+      }
     )
 
     @script_title = 'Script Display Name'
@@ -37,7 +40,8 @@ class LessonsControllerTest < ActionController::TestCase
 
     @update_params = {
       id: @lesson.id,
-      overview: 'new overview'
+      overview: 'new overview',
+      student_overview: 'new student overview',
     }
 
     @levelbuilder = create :levelbuilder
@@ -74,6 +78,11 @@ class LessonsControllerTest < ActionController::TestCase
       id: @lesson.id
     }
     assert_response :ok
+
+    # verify the lesson fields appear in camelCase in the DOM.
+    lesson_data = JSON.parse(css_select('script[data-lesson]').first.attribute('data-lesson').to_s)
+    assert_equal 'lesson overview', lesson_data['overview']
+    assert_equal 'student overview', lesson_data['studentOverview']
   end
 
   # only levelbuilders can update
@@ -90,5 +99,6 @@ class LessonsControllerTest < ActionController::TestCase
     assert_redirected_to "/lessons/#{@lesson.id}"
     @lesson.reload
     assert_equal 'new overview', @lesson.overview
+    assert_equal 'new student overview', @lesson.student_overview
   end
 end

--- a/dashboard/test/controllers/lessons_controller_test.rb
+++ b/dashboard/test/controllers/lessons_controller_test.rb
@@ -41,7 +41,7 @@ class LessonsControllerTest < ActionController::TestCase
     @update_params = {
       id: @lesson.id,
       overview: 'new overview',
-      student_overview: 'new student overview',
+      studentOverview: 'new student overview',
     }
 
     @levelbuilder = create :levelbuilder

--- a/dashboard/test/controllers/lessons_controller_test.rb
+++ b/dashboard/test/controllers/lessons_controller_test.rb
@@ -81,8 +81,9 @@ class LessonsControllerTest < ActionController::TestCase
 
     # verify the lesson fields appear in camelCase in the DOM.
     lesson_data = JSON.parse(css_select('script[data-lesson]').first.attribute('data-lesson').to_s)
-    assert_equal 'lesson overview', lesson_data['overview']
-    assert_equal 'student overview', lesson_data['studentOverview']
+    editable_data = lesson_data['editableData']
+    assert_equal 'lesson overview', editable_data['overview']
+    assert_equal 'student overview', editable_data['studentOverview']
   end
 
   # only levelbuilders can update

--- a/dashboard/test/controllers/lessons_controller_test.rb
+++ b/dashboard/test/controllers/lessons_controller_test.rb
@@ -81,7 +81,7 @@ class LessonsControllerTest < ActionController::TestCase
 
     # verify the lesson fields appear in camelCase in the DOM.
     lesson_data = JSON.parse(css_select('script[data-lesson]').first.attribute('data-lesson').to_s)
-    editable_data = lesson_data['lesson']
+    editable_data = lesson_data['editableData']
     assert_equal 'lesson overview', editable_data['overview']
     assert_equal 'student overview', editable_data['studentOverview']
   end

--- a/dashboard/test/controllers/lessons_controller_test.rb
+++ b/dashboard/test/controllers/lessons_controller_test.rb
@@ -81,7 +81,7 @@ class LessonsControllerTest < ActionController::TestCase
 
     # verify the lesson fields appear in camelCase in the DOM.
     lesson_data = JSON.parse(css_select('script[data-lesson]').first.attribute('data-lesson').to_s)
-    editable_data = lesson_data['editableData']
+    editable_data = lesson_data['lesson']
     assert_equal 'lesson overview', editable_data['overview']
     assert_equal 'student overview', editable_data['studentOverview']
   end

--- a/dashboard/test/integration/lessons_test.rb
+++ b/dashboard/test/integration/lessons_test.rb
@@ -1,8 +1,6 @@
 require 'test_helper'
 
 class LessonsTest < ActionDispatch::IntegrationTest
-  self.use_transactional_test_case = true
-
   setup do
     Rails.application.config.stubs(:levelbuilder_mode).returns true
 

--- a/dashboard/test/integration/lessons_test.rb
+++ b/dashboard/test/integration/lessons_test.rb
@@ -31,21 +31,23 @@ class LessonsTest < ActionDispatch::IntegrationTest
     get edit_lesson_path(id: @lesson.id)
     assert_response :success
     assert_select 'script[data-lesson]', 1
-    lesson_data = JSON.parse(css_select('script[data-lesson]').first.attribute('data-lesson').to_s)['lesson']
-    assert_equal 'lesson overview', lesson_data['overview']
-    assert_equal 'student overview', lesson_data['studentOverview']
+    lesson_data = JSON.parse(css_select('script[data-lesson]').first.attribute('data-lesson').to_s)
+    editable_data = lesson_data['editableData']
+    assert_equal 'lesson overview', editable_data['overview']
+    assert_equal 'student overview', editable_data['studentOverview']
   end
 
   test 'update lesson using data from edit page' do
     sign_in @levelbuilder
     get edit_lesson_path(id: @lesson.id)
     assert_response :success
-    lesson_data = JSON.parse(css_select('script[data-lesson]').first.attribute('data-lesson').to_s)['lesson']
-    lesson_data['studentOverview'] = 'new student overview'
+    lesson_data = JSON.parse(css_select('script[data-lesson]').first.attribute('data-lesson').to_s)
+    editable_data = lesson_data['editableData']
+    editable_data['studentOverview'] = 'new student overview'
 
     # Make sure the update api accepts the data in the same format as
     # the data in the edit response.
-    patch lesson_path(id: @lesson.id, as: :json, params: lesson_data)
+    patch lesson_path(id: @lesson.id, as: :json, params: editable_data)
     @lesson.reload
     assert_equal 'lesson overview', @lesson.overview
     assert_equal 'new student overview', @lesson.student_overview

--- a/dashboard/test/integration/lessons_test.rb
+++ b/dashboard/test/integration/lessons_test.rb
@@ -1,0 +1,53 @@
+require 'test_helper'
+
+class LessonsTest < ActionDispatch::IntegrationTest
+  self.use_transactional_test_case = true
+
+  setup do
+    Rails.application.config.stubs(:levelbuilder_mode).returns true
+
+    @lesson = create(
+      :lesson,
+      name: 'lesson display name',
+      properties: {
+        overview: 'lesson overview',
+        student_overview: 'student overview'
+      }
+    )
+
+    @levelbuilder = create :levelbuilder
+  end
+
+  test 'lesson show page contains expected data' do
+    get lesson_path(id: @lesson.id)
+    assert_response :success
+    assert_select 'script[data-lesson]', 1
+    lesson_data = JSON.parse(css_select('script[data-lesson]').first.attribute('data-lesson').to_s)
+    assert_equal 'lesson overview', lesson_data['overview']
+  end
+
+  test 'lesson edit page contains expected data' do
+    sign_in @levelbuilder
+    get edit_lesson_path(id: @lesson.id)
+    assert_response :success
+    assert_select 'script[data-lesson]', 1
+    lesson_data = JSON.parse(css_select('script[data-lesson]').first.attribute('data-lesson').to_s)['lesson']
+    assert_equal 'lesson overview', lesson_data['overview']
+    assert_equal 'student overview', lesson_data['studentOverview']
+  end
+
+  test 'update lesson using data from edit page' do
+    sign_in @levelbuilder
+    get edit_lesson_path(id: @lesson.id)
+    assert_response :success
+    lesson_data = JSON.parse(css_select('script[data-lesson]').first.attribute('data-lesson').to_s)['lesson']
+    lesson_data['studentOverview'] = 'new student overview'
+
+    # Make sure the update api accepts the data in the same format as
+    # the data in the edit response.
+    patch lesson_path(id: @lesson.id, as: :json, params: lesson_data)
+    @lesson.reload
+    assert_equal 'lesson overview', @lesson.overview
+    assert_equal 'new student overview', @lesson.student_overview
+  end
+end


### PR DESCRIPTION
Per recommendations in @uponthesun 's  [Edit UI APIs](https://docs.google.com/document/d/19_aYMPAQaCSfngZHBNH8J7NAetuz2xOsjT8FnPXTbsY/edit), this PR changes the edit and update APIs for Lesson objects to follow the following rules:
* edit response and update request uses camelCase param names
* edit response wraps editable fields under the `lesson` key
* The client can pass all data under the `lesson` key back to the update API 

## Testing story

* more unit test coverage
* integration test verifies that data returned by `edit` can be passed back to `update`
* manually verified that the lesson edit page still works

## Future work

* [PLAT-350] write a UI test for the lesson edit page

## potential future work

we aren't sure if we want to do this work yet, but these are next steps we could take if a need arises.

* use deep_transform_keys to handle updates with nested data (see fad81817d609907577a0b4a80ae2b1d23b4c67bc)
* raise if any unexpected params exist in the call to `update` (see fad81817d609907577a0b4a80ae2b1d23b4c67bc)
* use an ActiveModel serializer to generate `@lesson_data`  (draft PR: https://github.com/code-dot-org/code-dot-org/pull/36894)

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked


[PLAT-350]: https://codedotorg.atlassian.net/browse/PLAT-350