### PR TITLE
Seed scripts one at a time fix

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -58,7 +58,6 @@ gem 'rack-mini-profiler'
 group :development do
   gem 'annotate'
   gem 'pry'
-  gem 'ruby-progressbar', require: false
   gem 'web-console'
 end
 
@@ -354,3 +353,5 @@ gem 'require_all', require: false
 gem 'dotiw'
 
 gem 'datapackage'
+
+gem 'ruby-progressbar'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -762,7 +762,7 @@ GEM
       unicode-display_width (~> 1.0, >= 1.0.1)
     ruby-openid (2.7.0)
     ruby-prof (0.15.9)
-    ruby-progressbar (1.9.0)
+    ruby-progressbar (1.10.1)
     ruby-rc4 (0.1.5)
     ruby_dep (1.3.1)
     ruby_parser (3.11.0)

--- a/SETUP.md
+++ b/SETUP.md
@@ -35,9 +35,7 @@ You can do Code.org development using OSX, Ubuntu, or Windows (running Ubuntu in
     </details>
 
 1. `bundle exec rake install`
-    * This can take a LONG time. You can see if progress is being made by opening up a second shell and starting `mysql -u root`. Run the following command twice, with approximately a 5-10 second delay between
-  each run `select table_schema, table_name, table_rows from information_schema.tables where table_schema like 'dashboard_development' order by table_rows;`  If you see a change in the last couple of rows, the
-  install is working correctly.
+    * This can take a long time, ~30 minutes or more. The most expensive are the "seeding" tasks, where your local DB is populated from data in the repository. Some of the seeding rake tasks can take several minutes. The longest one, `seed:scripts`, can take > 10 minutes, but it should at least print out progress as it goes.
 1. `bundle exec rake build`
     * This may fail if your are on a Mac and your OSX XCode Command Line Tools were not installed properly. See Bundle Install Tips for more information.
 1. (Optional, Code.org engineers only) Setup AWS - Ask a Code.org engineer how to complete this step

--- a/dashboard/app/models/script.rb
+++ b/dashboard/app/models/script.rb
@@ -888,7 +888,7 @@ class Script < ActiveRecord::Base
   # script file definitions. If new_suffix is specified, create a copy of the
   # script and any associated levels, appending new_suffix to the name when
   # copying. Any new_properties are merged into the properties of the new script.
-  def self.setup(custom_files, new_suffix: nil, new_properties: {})
+  def self.setup(custom_files, new_suffix: nil, new_properties: {}, show_progress: false)
     scripts_to_add = []
 
     custom_i18n = {}
@@ -919,15 +919,12 @@ class Script < ActiveRecord::Base
       }, lesson_groups]
     end
 
-    if Rake.application.options.trace
-      puts "Seeding #{scripts_to_add.length} Scripts"
-      progressbar = ProgressBar.create(total: scripts_to_add.length, format: '%t (%c/%C): |%B|')
-    end
+    progressbar = ProgressBar.create(total: scripts_to_add.length, format: '%t (%c/%C): |%B|') if show_progress
 
     # Stable sort by ID then add each script, ensuring scripts with no ID end up at the end
     added_script_names = scripts_to_add.sort_by.with_index {|args, idx| [args[0][:id] || Float::INFINITY, idx]}.map do |options, raw_lesson_groups|
       added_script = add_script(options, raw_lesson_groups, new_suffix: new_suffix, editor_experiment: new_properties[:editor_experiment])
-      progressbar.increment if Rake.application.options.trace
+      progressbar.increment if show_progress
       added_script.name
     rescue => e
       raise e, "Error adding script named '#{options[:name]}': #{e}", e.backtrace

--- a/dashboard/app/models/script.rb
+++ b/dashboard/app/models/script.rb
@@ -24,6 +24,7 @@
 
 require 'cdo/script_constants'
 require 'cdo/shared_constants'
+require 'ruby-progressbar'
 
 TEXT_RESPONSE_TYPES = [TextMatch, FreeResponse]
 
@@ -888,66 +889,75 @@ class Script < ActiveRecord::Base
   # script and any associated levels, appending new_suffix to the name when
   # copying. Any new_properties are merged into the properties of the new script.
   def self.setup(custom_files, new_suffix: nil, new_properties: {})
-    transaction do
-      scripts_to_add = []
+    scripts_to_add = []
 
-      custom_i18n = {}
-      # Load custom scripts from Script DSL format
-      custom_files.map do |script|
-        name = File.basename(script, '.script')
-        base_name = Script.base_name(name)
-        name = "#{base_name}-#{new_suffix}" if new_suffix
-        script_data, i18n =
-          begin
-            ScriptDSL.parse_file(script, name)
-          rescue => e
-            raise e, "Error parsing script file #{script}: #{e}"
-          end
+    custom_i18n = {}
+    # Load custom scripts from Script DSL format
+    custom_files.map do |script|
+      name = File.basename(script, '.script')
+      base_name = Script.base_name(name)
+      name = "#{base_name}-#{new_suffix}" if new_suffix
+      script_data, i18n =
+        begin
+          ScriptDSL.parse_file(script, name)
+        rescue => e
+          raise e, "Error parsing script file #{script}: #{e}"
+        end
 
-        lesson_groups = script_data[:lesson_groups]
-        custom_i18n.deep_merge!(i18n)
-        # TODO: below is duplicated in update_text. and maybe can be refactored to pass script_data?
-        scripts_to_add << [{
-          id: script_data[:id],
-          name: name,
-          hidden: script_data[:hidden].nil? ? true : script_data[:hidden], # default true
-          login_required: script_data[:login_required].nil? ? false : script_data[:login_required], # default false
-          wrapup_video: script_data[:wrapup_video],
-          new_name: script_data[:new_name],
-          family_name: script_data[:family_name],
-          properties: Script.build_property_hash(script_data).merge(new_properties)
-        }, lesson_groups]
-      end
-
-      # Stable sort by ID then add each script, ensuring scripts with no ID end up at the end
-      added_scripts = scripts_to_add.sort_by.with_index {|args, idx| [args[0][:id] || Float::INFINITY, idx]}.map do |options, raw_lesson_groups|
-        add_script(options, raw_lesson_groups, new_suffix: new_suffix, editor_experiment: new_properties[:editor_experiment])
-      rescue => e
-        raise e, "Error adding script named '#{options[:name]}': #{e}", e.backtrace
-      end
-      [added_scripts, custom_i18n]
+      lesson_groups = script_data[:lesson_groups]
+      custom_i18n.deep_merge!(i18n)
+      # TODO: below is duplicated in update_text. and maybe can be refactored to pass script_data?
+      scripts_to_add << [{
+        id: script_data[:id],
+        name: name,
+        hidden: script_data[:hidden].nil? ? true : script_data[:hidden], # default true
+        login_required: script_data[:login_required].nil? ? false : script_data[:login_required], # default false
+        wrapup_video: script_data[:wrapup_video],
+        new_name: script_data[:new_name],
+        family_name: script_data[:family_name],
+        properties: Script.build_property_hash(script_data).merge(new_properties)
+      }, lesson_groups]
     end
+
+    # TODO: replace this with configuration option
+    debug = [:adhoc, :development].include?(rack_env)
+    if debug
+      puts "Seeding #{scripts_to_add.length} Scripts"
+      progressbar = ProgressBar.create(total: scripts_to_add.length)
+    end
+
+    # Stable sort by ID then add each script, ensuring scripts with no ID end up at the end
+    added_script_names = scripts_to_add.sort_by.with_index {|args, idx| [args[0][:id] || Float::INFINITY, idx]}.map do |options, raw_lesson_groups|
+      added_script = add_script(options, raw_lesson_groups, new_suffix: new_suffix, editor_experiment: new_properties[:editor_experiment])
+      progressbar.increment if debug
+      added_script.name
+    rescue => e
+      raise e, "Error adding script named '#{options[:name]}': #{e}", e.backtrace
+    end
+    [added_script_names, custom_i18n]
   end
 
   # if new_suffix is specified, copy the script, hide it, and copy all its
   # levelbuilder-defined levels.
   def self.add_script(options, raw_lesson_groups, new_suffix: nil, editor_experiment: nil)
-    script = fetch_script(options)
-    script.update!(hidden: true) if new_suffix
+    transaction do
+      script = fetch_script(options)
+      script.update!(hidden: true) if new_suffix
 
-    script.prevent_duplicate_lesson_groups(raw_lesson_groups)
-    Script.prevent_some_lessons_in_lesson_groups_and_some_not(raw_lesson_groups)
+      script.prevent_duplicate_lesson_groups(raw_lesson_groups)
+      Script.prevent_some_lessons_in_lesson_groups_and_some_not(raw_lesson_groups)
 
-    temp_lgs = LessonGroup.add_lesson_groups(raw_lesson_groups, script, new_suffix, editor_experiment)
-    script.reload
-    script.lesson_groups = temp_lgs
-    script.save!
+      temp_lgs = LessonGroup.add_lesson_groups(raw_lesson_groups, script, new_suffix, editor_experiment)
+      script.reload
+      script.lesson_groups = temp_lgs
+      script.save!
 
-    script.generate_plc_objects
+      script.generate_plc_objects
 
-    CourseOffering.add_course_offering(script)
+      CourseOffering.add_course_offering(script)
 
-    script
+      script
+    end
   end
 
   # If there is more than 1 lesson group then the key should never
@@ -995,8 +1005,8 @@ class Script < ActiveRecord::Base
     if /^[0-9]{4}$/ =~ (new_suffix)
       new_properties[:version_year] = new_suffix
     end
-    scripts, _ = Script.setup([script_filename], new_suffix: new_suffix, new_properties: new_properties)
-    new_script = scripts.first
+    script_names, _ = Script.setup([script_filename], new_suffix: new_suffix, new_properties: new_properties)
+    new_script = Script.find_by!(name: script_names.first)
 
     # Make sure we don't modify any files in unit tests.
     if Rails.application.config.levelbuilder_mode

--- a/dashboard/app/models/script.rb
+++ b/dashboard/app/models/script.rb
@@ -919,17 +919,15 @@ class Script < ActiveRecord::Base
       }, lesson_groups]
     end
 
-    # TODO: replace this with configuration option
-    debug = [:adhoc, :development].include?(rack_env)
-    if debug
+    if Rake.application.options.trace
       puts "Seeding #{scripts_to_add.length} Scripts"
-      progressbar = ProgressBar.create(total: scripts_to_add.length)
+      progressbar = ProgressBar.create(total: scripts_to_add.length, format: '%t (%c/%C): |%B|')
     end
 
     # Stable sort by ID then add each script, ensuring scripts with no ID end up at the end
     added_script_names = scripts_to_add.sort_by.with_index {|args, idx| [args[0][:id] || Float::INFINITY, idx]}.map do |options, raw_lesson_groups|
       added_script = add_script(options, raw_lesson_groups, new_suffix: new_suffix, editor_experiment: new_properties[:editor_experiment])
-      progressbar.increment if debug
+      progressbar.increment if Rake.application.options.trace
       added_script.name
     rescue => e
       raise e, "Error adding script named '#{options[:name]}': #{e}", e.backtrace

--- a/dashboard/lib/tasks/seed.rake
+++ b/dashboard/lib/tasks/seed.rake
@@ -173,7 +173,7 @@ namespace :seed do
       _, custom_i18n = Script.setup(custom_scripts)
       Script.merge_and_write_i18n(custom_i18n)
     rescue
-      rm SEEDED # if we failed to do any of that stuff we didn't seed anything, did we
+      rm SEEDED # if we failed somewhere in the process, we may have seeded some Scripts, but not all that we were supposed to.
       raise
     end
   end

--- a/dashboard/lib/tasks/seed.rake
+++ b/dashboard/lib/tasks/seed.rake
@@ -170,7 +170,7 @@ namespace :seed do
     begin
       custom_scripts = script_files.select {|script| File.mtime(script) > scripts_seeded_mtime}
       LevelLoader.update_unplugged if File.mtime('config/locales/unplugged.en.yml') > scripts_seeded_mtime
-      _, custom_i18n = Script.setup(custom_scripts)
+      _, custom_i18n = Script.setup(custom_scripts, show_progress: Rake.application.options.trace)
       Script.merge_and_write_i18n(custom_i18n)
     rescue
       rm SEEDED # if we failed somewhere in the process, we may have seeded some Scripts, but not all that we were supposed to.

--- a/dashboard/test/models/course_offering_test.rb
+++ b/dashboard/test/models/course_offering_test.rb
@@ -15,8 +15,8 @@ class CourseOfferingTest < ActiveSupport::TestCase
   # Other cases are covered by directly testing add_course_offering below.
   test "Script.setup creates CourseOffering and CourseVersion if is_course is true" do
     script_file = File.join(self.class.fixture_path, 'test-script-course-version.script')
-    scripts, _ = Script.setup([script_file])
-    script = scripts.first
+    script_names, _ = Script.setup([script_file])
+    script = Script.find_by!(name: script_names.first)
 
     offering = script.course_version.course_offering
     assert_equal 'xyz', offering.key

--- a/dashboard/test/models/script_test.rb
+++ b/dashboard/test/models/script_test.rb
@@ -52,9 +52,9 @@ class ScriptTest < ActiveSupport::TestCase
   test 'login required setting in script file' do
     file = File.join(self.class.fixture_path, "login_required.script")
 
-    scripts, _ = Script.setup([file])
+    script_names, _ = Script.setup([file])
+    script = Script.find_by!(name: script_names.first)
 
-    script = scripts[0]
     assert script.login_required?
     assert_equal 'Level 1', script.levels[0].name
 
@@ -64,8 +64,8 @@ class ScriptTest < ActiveSupport::TestCase
   end
 
   test 'create script from DSL' do
-    scripts, _ = Script.setup([@script_file])
-    script = scripts[0]
+    script_names, _ = Script.setup([@script_file])
+    script = Script.find_by!(name: script_names.first)
     assert_equal 'Level 1', script.levels[0].name
     assert_equal 'Lesson Two', script.script_levels[3].lesson.name
 
@@ -74,20 +74,22 @@ class ScriptTest < ActiveSupport::TestCase
   end
 
   test 'should not change Script[Level] ID when reseeding' do
-    scripts, _ = Script.setup([@script_file])
-    script = scripts[0]
+    script_names, _ = Script.setup([@script_file])
+    script = Script.find_by!(name: script_names.first)
     script_id = script.script_levels[4].script_id
     script_level_id = script.script_levels[4].id
 
-    scripts, _ = Script.setup([@script_file])
-    assert_equal script_id, scripts[0].script_levels[4].script_id
-    assert_equal script_level_id, scripts[0].script_levels[4].id
+    script_names, _ = Script.setup([@script_file])
+    script = Script.find_by!(name: script_names.first)
+    assert_equal script_id, script.script_levels[4].script_id
+    assert_equal script_level_id, script.script_levels[4].id
   end
 
   test 'should not change Script ID when changing script levels and options' do
-    scripts, _ = Script.setup([@script_file])
-    script_id = scripts[0].script_levels[4].script_id
-    script_level_id = scripts[0].script_levels[4].id
+    script_names, _ = Script.setup([@script_file])
+    script = Script.find_by!(name: script_names.first)
+    script_id = script.script_levels[4].script_id
+    script_level_id = script.script_levels[4].id
 
     parsed_script = ScriptDSL.parse_file(@script_file)[0][:lesson_groups]
 
@@ -155,25 +157,28 @@ class ScriptTest < ActiveSupport::TestCase
   end
 
   test 'should remove empty lessons' do
-    scripts, _ = Script.setup([@script_file])
-    assert_equal 2, scripts[0].lessons.count
+    script_names, _ = Script.setup([@script_file])
+    script = Script.find_by!(name: script_names.first)
+    assert_equal 2, script.lessons.count
 
     # Reupload a script of the same filename / name, but lacking the second lesson.
-    lesson = scripts[0].lessons.last
+    lesson = script.lessons.last
     script_file_empty_lesson = File.join(self.class.fixture_path, "duplicate_scripts", "test-fixture.script")
-    scripts, _ = Script.setup([script_file_empty_lesson])
-    assert_equal 1, scripts[0].lessons.count
+    script_names, _ = Script.setup([script_file_empty_lesson])
+    script = Script.find_by!(name: script_names.first)
+    assert_equal 1, script.lessons.count
     assert_not Lesson.exists?(lesson.id)
   end
 
   test 'should remove empty lessons, reordering lessons' do
     script_file_3_lessons = File.join(self.class.fixture_path, "test-fixture-3-stages.script")
     script_file_middle_missing_reversed = File.join(self.class.fixture_path, "duplicate_scripts", "test-fixture-3-stages.script")
-    scripts, _ = Script.setup([script_file_3_lessons])
-    assert_equal 3, scripts[0].lessons.count
-    first = scripts[0].lessons[0]
-    second = scripts[0].lessons[1]
-    third = scripts[0].lessons[2]
+    script_names, _ = Script.setup([script_file_3_lessons])
+    script = Script.find_by!(name: script_names.first)
+    assert_equal 3, script.lessons.count
+    first = script.lessons[0]
+    second = script.lessons[1]
+    third = script.lessons[2]
     assert_equal 'lesson1', first.name
     assert_equal 'lesson2', second.name
     assert_equal 'lesson3', third.name
@@ -182,12 +187,13 @@ class ScriptTest < ActiveSupport::TestCase
     assert_equal 3, third.absolute_position
 
     # Reupload a script of the same filename / name, but lacking the middle lesson.
-    scripts, _ = Script.setup([script_file_middle_missing_reversed])
-    assert_equal 2, scripts[0].lessons.count
+    script_names, _ = Script.setup([script_file_middle_missing_reversed])
+    script = Script.find_by!(name: script_names.first)
+    assert_equal 2, script.lessons.count
     assert_not Lesson.exists?(second.id)
 
-    first = scripts[0].lessons[0]
-    second = scripts[0].lessons[1]
+    first = script.lessons[0]
+    second = script.lessons[1]
     assert_equal 1, first.absolute_position
     assert_equal 2, second.absolute_position
     assert_equal 'lesson3', first.name
@@ -198,8 +204,8 @@ class ScriptTest < ActiveSupport::TestCase
     # First, seed using a .script file that sets something explicitly for all fields, i.e. everything that's not in
     # the properties hash.
     script_file_all_fields = File.join(self.class.fixture_path, 'test-all-fields.script')
-    scripts, _ = Script.setup([script_file_all_fields])
-    script = scripts.first
+    script_names, _ = Script.setup([script_file_all_fields])
+    script = Script.find_by!(name: script_names.first)
 
     # Not testing new_name since it causes a new script to be created.
     assert_equal false, script.hidden? # defaults to true, so we want to verify it was explicitly set to false
@@ -219,8 +225,8 @@ class ScriptTest < ActiveSupport::TestCase
   test 'all properties can be set and then removed on reseed' do
     # First, seed using a .script file that sets something explicitly for everything in the properties hash.
     script_file_all_properties = File.join(self.class.fixture_path, 'test-all-properties.script')
-    scripts, _ = Script.setup([script_file_all_properties])
-    script = scripts.first
+    script_names, _ = Script.setup([script_file_all_properties])
+    script = Script.find_by!(name: script_names.first)
 
     assert_equal 21, script.properties.keys.length
     script.properties.values.each {|v| assert v}
@@ -270,32 +276,36 @@ class ScriptTest < ActiveSupport::TestCase
   end
 
   test 'script_level positions should reset' do
-    scripts, _ = Script.setup([@script_file])
-    first = scripts[0].lessons[0].script_levels[0]
-    second = scripts[0].lessons[0].script_levels[1]
+    script_names, _ = Script.setup([@script_file])
+    script = Script.find_by!(name: script_names.first)
+    first = script.lessons[0].script_levels[0]
+    second = script.lessons[0].script_levels[1]
     assert_equal 1, first.position
     assert_equal 2, second.position
     promoted_level = second.level
     script_file_remove_level = File.join(self.class.fixture_path, "duplicate_scripts", "test-fixture.script")
 
-    scripts, _ = Script.setup([script_file_remove_level])
-    new_first_script_level = ScriptLevel.joins(:levels).where(script: scripts[0], levels: {id: promoted_level}).first
+    script_names, _ = Script.setup([script_file_remove_level])
+    script = Script.find_by!(name: script_names.first)
+    new_first_script_level = ScriptLevel.joins(:levels).where(script: script, levels: {id: promoted_level}).first
     assert_equal 1, new_first_script_level.position
   end
 
   test 'script import is idempotent w.r.t. positions and count' do
-    scripts, _ = Script.setup([@script_file])
+    script_names, _ = Script.setup([@script_file])
+    script = Script.find_by!(name: script_names.first)
     original_count = ScriptLevel.count
-    first = scripts[0].lessons[0].script_levels[0]
-    second = scripts[0].lessons[0].script_levels[1]
-    third = scripts[0].lessons[0].script_levels[2]
+    first = script.lessons[0].script_levels[0]
+    second = script.lessons[0].script_levels[1]
+    third = script.lessons[0].script_levels[2]
     assert_equal 1, first.position
     assert_equal 2, second.position
     assert_equal 3, third.position
-    scripts, _ = Script.setup([@script_file])
-    first = scripts[0].lessons[0].script_levels[0]
-    second = scripts[0].lessons[0].script_levels[1]
-    third = scripts[0].lessons[0].script_levels[2]
+    script_names, _ = Script.setup([@script_file])
+    script = Script.find_by!(name: script_names.first)
+    first = script.lessons[0].script_levels[0]
+    second = script.lessons[0].script_levels[1]
+    third = script.lessons[0].script_levels[2]
     assert_equal 1, first.position
     assert_equal 2, second.position
     assert_equal 3, third.position
@@ -304,8 +314,9 @@ class ScriptTest < ActiveSupport::TestCase
 
   test 'unplugged in script' do
     @script_file = File.join(self.class.fixture_path, 'test-unplugged.script')
-    scripts, _ = Script.setup([@script_file])
-    assert_equal 'Unplugged', scripts[0].script_levels[1].level['type']
+    script_names, _ = Script.setup([@script_file])
+    script = Script.find_by!(name: script_names.first)
+    assert_equal 'Unplugged', script.script_levels[1].level['type']
   end
 
   test 'blockly level in custom script' do
@@ -1000,7 +1011,8 @@ class ScriptTest < ActiveSupport::TestCase
 
   test 'should generate PLC objects' do
     script_file = File.join(self.class.fixture_path, 'test-plc.script')
-    scripts, custom_i18n = Script.setup([script_file])
+    script_names, custom_i18n = Script.setup([script_file])
+    script = Script.find_by!(name: script_names.first)
     custom_i18n.deep_merge!(
       {
         'en' => {
@@ -1019,7 +1031,6 @@ class ScriptTest < ActiveSupport::TestCase
     )
     I18n.backend.store_translations I18n.locale, custom_i18n['en']
 
-    script = scripts.first
     script.save! # Need to trigger an update because i18n strings weren't loaded
     assert script.professional_learning_course?
     assert_equal 'Test plc course', script.professional_learning_course
@@ -1506,8 +1517,8 @@ class ScriptTest < ActiveSupport::TestCase
   end
 
   test 'clone script with suffix' do
-    scripts, _ = Script.setup([@script_file])
-    script = scripts[0]
+    script_names, _ = Script.setup([@script_file])
+    script = Script.find_by!(name: script_names.first)
     assert_equal 1, script.announcements.count
 
     Script.stubs(:script_directory).returns(self.class.fixture_path)
@@ -1555,8 +1566,8 @@ class ScriptTest < ActiveSupport::TestCase
   # updated under certain conditions). These are covered in other test cases.
   test 'clone with suffix clears certain properties' do
     script_file = File.join(self.class.fixture_path, "test-all-properties.script")
-    scripts, _ = Script.setup([script_file])
-    script = scripts.first
+    script_names, _ = Script.setup([script_file])
+    script = Script.find_by!(name: script_names.first)
 
     # all properties that should change
     assert script.tts
@@ -1585,8 +1596,8 @@ class ScriptTest < ActiveSupport::TestCase
 
   test 'clone versioned script with suffix' do
     script_file = File.join(self.class.fixture_path, "test-fixture-versioned-1801.script")
-    scripts, _ = Script.setup([script_file])
-    script = scripts[0]
+    script_names, _ = Script.setup([script_file])
+    script = Script.find_by!(name: script_names.first)
 
     Script.stubs(:script_directory).returns(self.class.fixture_path)
     script_copy = script.clone_with_suffix('1802')
@@ -1601,8 +1612,8 @@ class ScriptTest < ActiveSupport::TestCase
 
   test 'clone script with variants' do
     script_file = File.join(self.class.fixture_path, "test-fixture-experiments.script")
-    scripts, _ = Script.setup([script_file])
-    script = scripts[0]
+    script_names, _ = Script.setup([script_file])
+    script = Script.find_by!(name: script_names.first)
 
     Script.stubs(:script_directory).returns(self.class.fixture_path)
     script_copy = script.clone_with_suffix('copy')
@@ -1631,8 +1642,8 @@ class ScriptTest < ActiveSupport::TestCase
   end
 
   test 'clone with suffix and add editor experiment' do
-    scripts, _ = Script.setup([@script_file])
-    script = scripts[0]
+    script_names, _ = Script.setup([@script_file])
+    script = Script.find_by!(name: script_names.first)
     assert_equal 1, script.announcements.count
 
     Script.stubs(:script_directory).returns(self.class.fixture_path)
@@ -1846,8 +1857,8 @@ class ScriptTest < ActiveSupport::TestCase
     SCRIPT
 
     File.stubs(:read).returns(dsl)
-    scripts, _ = Script.setup(['pilot-script.script'])
-    script = scripts.first
+    script_names, _ = Script.setup(['pilot-script.script'])
+    script = Script.find_by!(name: script_names.first)
 
     assert_equal 'pilot-script', script.name
     assert_equal 'pilot-experiment', script.pilot_experiment

--- a/lib/rake/install.rake
+++ b/lib/rake/install.rake
@@ -45,7 +45,7 @@ namespace :install do
           # yet because doing so would break unit tests.
           RakeUtils.rake 'db:create db:test:prepare'
         else
-          RakeUtils.rake 'dashboard:setup_db'
+          RakeUtils.rake_stream_output 'dashboard:setup_db', ([:adhoc, :development].include?(rack_env) ? '--trace' : nil)
         end
       end
     end


### PR DESCRIPTION
Re-applying change after I had to revert it since it had broken production. The problem was `ruby-progressbar` was only a development dependency, and so wasn't guaranteed to be on other environments, and it wasn't present in production.

It's not great to have a dependency on something extraneous like that in a core model like Script, but... 🤷‍♀️ I don't feel like refactoring that now. Feel free to push back on this if you feel like it's important, though.

Original change: https://github.com/code-dot-org/code-dot-org/pull/36856
Revert: https://github.com/code-dot-org/code-dot-org/pull/36877
Also included these followup improvements: https://github.com/code-dot-org/code-dot-org/pull/36873

## Testing story

Ran:
```
bundle install
bundle exec rake seed:single_script SCRIPT_NAME=valentine --trace
```

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
