### PR TITLE
[Spritelab] sin/cos blocks for prototyping

### DIFF
--- a/apps/src/p5lab/spritelab/commands.js
+++ b/apps/src/p5lab/spritelab/commands.js
@@ -158,6 +158,21 @@ export const commands = {
     return locationCommands.randomLocation();
   },
 
+  // Math commands
+  cos(angleDegrees) {
+    if (angleDegrees === undefined) {
+      angleDegrees = 0;
+    }
+    return parseFloat(Math.cos((angleDegrees * Math.PI) / 180).toFixed(4));
+  },
+
+  sin(angleDegrees) {
+    if (angleDegrees === undefined) {
+      angleDegrees = 0;
+    }
+    return parseFloat(Math.sin((angleDegrees * Math.PI) / 180).toFixed(4));
+  },
+
   // Sprite commands
   countByAnimation(spriteArg) {
     return spriteCommands.countByAnimation(spriteArg);

--- a/dashboard/config/blocks/GamelabJr/gamelab_cos.json
+++ b/dashboard/config/blocks/GamelabJr/gamelab_cos.json
@@ -1,0 +1,14 @@
+{
+  "category": "Math",
+  "config": {
+    "func": "cos",
+    "blockText": "cos {NUM}",
+    "returnType": "Number",
+    "args": [
+      {
+        "name": "NUM",
+        "type": "Number"
+      }
+    ]
+  }
+}

--- a/dashboard/config/blocks/GamelabJr/gamelab_sin.json
+++ b/dashboard/config/blocks/GamelabJr/gamelab_sin.json
@@ -1,0 +1,14 @@
+{
+  "category": "Math",
+  "config": {
+    "func": "sin",
+    "blockText": "sin {NUM}",
+    "returnType": "Number",
+    "args": [
+      {
+        "name": "NUM",
+        "type": "Number"
+      }
+    ]
+  }
+}


### PR DESCRIPTION
`sin` and `cos` blocks for Sprite Lab, per request from Mike Harvey. To be used for prototyping, not intended for student use.
I rounded the results to 4 points to avoid floating point imprecision (ie to make sure `cos(90)` is 0 not 6.123233995736766e-17)
![image](https://user-images.githubusercontent.com/8787187/94085585-6007ed80-fdbd-11ea-9efe-8fcfe8ede3b0.png)
