### PR TITLE
Normalize i18n string tracking URLs

### DIFF
--- a/lib/cdo/i18n_string_url_tracker.rb
+++ b/lib/cdo/i18n_string_url_tracker.rb
@@ -14,7 +14,7 @@ class I18nStringUrlTracker
   def log(string_key, url, source)
     return unless DCDO.get(I18N_STRING_TRACKING_DCDO_KEY, false)
 
-    url = I18nStringUrlTracker.normalize_url(url)
+    url = normalize_url(url)
     return unless string_key && url && source
 
     # record the string : url association.
@@ -24,7 +24,9 @@ class I18nStringUrlTracker
     )
   end
 
-  def self.normalize_url(url)
+  private
+
+  def normalize_url(url)
     return unless url
 
     parsed_url = URI(url)

--- a/lib/cdo/i18n_string_url_tracker.rb
+++ b/lib/cdo/i18n_string_url_tracker.rb
@@ -1,5 +1,6 @@
 require 'cdo/firehose'
 require 'dynamic_config/dcdo'
+require 'uri'
 
 class I18nStringUrlTracker
   include Singleton
@@ -19,5 +20,12 @@ class I18nStringUrlTracker
       :i18n,
       {url: url, string_key: string_key, source: source}
     )
+  end
+
+  def self.normalize_url(url)
+    parsed_url = URI(url)
+    parsed_url.query = nil
+    parsed_url.fragment = nil
+    parsed_url.to_s
   end
 end

--- a/lib/cdo/i18n_string_url_tracker.rb
+++ b/lib/cdo/i18n_string_url_tracker.rb
@@ -12,8 +12,10 @@ class I18nStringUrlTracker
   # @param url [String] The url which required the translation of the given string_key.
   # @param source [String] Context about where the string lives e.g. 'ruby', 'maze', 'turtle', etc
   def log(string_key, url, source)
-    return unless string_key && url && source
     return unless DCDO.get(I18N_STRING_TRACKING_DCDO_KEY, false)
+
+    url = I18nStringUrlTracker.normalize_url(url)
+    return unless string_key && url && source
 
     # record the string : url association.
     FirehoseClient.instance.put_record(
@@ -23,6 +25,8 @@ class I18nStringUrlTracker
   end
 
   def self.normalize_url(url)
+    return unless url
+
     parsed_url = URI(url)
 
     # strip query string

--- a/lib/cdo/i18n_string_url_tracker.rb
+++ b/lib/cdo/i18n_string_url_tracker.rb
@@ -24,8 +24,26 @@ class I18nStringUrlTracker
 
   def self.normalize_url(url)
     parsed_url = URI(url)
+
+    # strip query string
     parsed_url.query = nil
+
+    # strip anchor tags
     parsed_url.fragment = nil
+
+    # Aggregate /projects/<project_type>/<project_id> URLs because each project URL will have a unique identifier
+    # converts 'https://studio.code.org/projects/flappy/zjiufOp0h-9GS-DywevS0d3tKJyjdbQZZqZVaiuAjiU/view'
+    # into 'https://studio.code.org/projects/flappy'
+    # Regex explanation:
+    # \/projects\/ - The first major hint this this is a project URL is '/projects/' in the URL
+    # .*? - This matches the project type and the '?' is included to make the matching is non-greedy. Otherwise it would
+    # match to the end of the URL past the project type.
+    # (?=\/) - This is a "positive lookahead" for a '/'. We use it so the '/' is not included in the match. Otherwise
+    # there would be a trailing '/' in the URL.
+    projects_regex = /\/projects\/.*?(?=\/)/
+    if parsed_url.path&.match(projects_regex)
+      parsed_url.path = parsed_url.path[projects_regex]
+    end
     parsed_url.to_s
   end
 end

--- a/lib/cdo/i18n_string_url_tracker.rb
+++ b/lib/cdo/i18n_string_url_tracker.rb
@@ -39,16 +39,21 @@ class I18nStringUrlTracker
 
     # Aggregate /projects/<project_type>/<project_id> URLs because each project URL will have a unique identifier
     # converts 'https://studio.code.org/projects/flappy/zjiufOp0h-9GS-DywevS0d3tKJyjdbQZZqZVaiuAjiU/view'
-    # into 'https://studio.code.org/projects/flappy'
+    # into 'https://studio.code.org/projects/flappy/view'
     # Regex explanation:
-    # \/projects\/ - The first major hint this this is a project URL is '/projects/' in the URL
-    # .*? - This matches the project type and the '?' is included to make the matching is non-greedy. Otherwise it would
-    # match to the end of the URL past the project type.
-    # (?=\/) - This is a "positive lookahead" for a '/'. We use it so the '/' is not included in the match. Otherwise
-    # there would be a trailing '/' in the URL.
-    projects_regex = /\/projects\/.*?(?=\/)/
-    if parsed_url.path&.match(projects_regex)
-      parsed_url.path = parsed_url.path[projects_regex]
+    # (.*\/projects\/) - The first major hint this this is a project URL is '/projects/' in the URL. The parenthesis around
+    # the expression make it a "capture group". Matches a string like "https://code.org/projects/"
+    # .*?\/ - This matches the project type and the '?' is included to make the matching is non-greedy. Otherwise it would
+    # match to the end of the URL past the project type. Matches a string like "maze/"
+    # .*?\/ - This matches the unique project ID. This is the part we want to omit. Matches a string like
+    # "zjiufOp0h-9GS-DywevS0d3tKJyjdbQZZqZVaiuAjiU/"
+    # (.*) - This matches the rest of the path. The parenthesis around the expression make it a "capture group". Matches
+    # a string like "view".
+    projects_regex = /(.*\/projects\/.*?\/).*?\/(.*)/
+    parsed_url.path&.match(projects_regex) do |m|
+      # capture group m[1] is the part of the URL before the project ID.
+      # capture group m[2] is the part of the URL after the project ID.
+      parsed_url.path = m[1] + m[2]
     end
     parsed_url.to_s
   end

--- a/lib/test/cdo/test_i18n_string_url_tracker.rb
+++ b/lib/test/cdo/test_i18n_string_url_tracker.rb
@@ -89,7 +89,7 @@ class TestI18nStringUrlTracker < Minitest::Test
 
   def test_log_given_projects_url_should_only_log_the_project_type
     test_record = {string_key: 'string.key', url: 'https://studio.code.org/projects/flappy/zjiufOp0h-9GS-DywevS0d3tKJyjdbQZZqZVaiuAjiU/view', source: 'test'}
-    expected_record = {string_key: 'string.key', url: 'https://studio.code.org/projects/flappy', source: 'test'}
+    expected_record = {string_key: 'string.key', url: 'https://studio.code.org/projects/flappy/view', source: 'test'}
     I18nStringUrlTracker.instance.log(test_record[:string_key], test_record[:url], test_record[:source])
     assert_equal(:i18n, @firehose_stream)
     assert_equal(expected_record, @firehose_record)

--- a/lib/test/cdo/test_i18n_string_url_tracker.rb
+++ b/lib/test/cdo/test_i18n_string_url_tracker.rb
@@ -79,4 +79,18 @@ class TestI18nStringUrlTracker < Minitest::Test
     test_record = {string_key: 'string.key', url: 'http://some.url.com/', source: 'test'}
     I18nStringUrlTracker.instance.log(test_record[:string_key], test_record[:url], test_record[:source])
   end
+
+  def test_normalize_url_should_strip_query_string
+    url = 'https://studio.code.org/test/page?querystring=true'
+    expected_url = 'https://studio.code.org/test/page'
+    normalized_url = I18nStringUrlTracker.normalize_url(url)
+    assert_equal(expected_url, normalized_url)
+  end
+
+  def test_normalize_url_should_strip_anchor_tags
+    url = 'https://studio.code.org/test/page#tag-youre-it'
+    expected_url = 'https://studio.code.org/test/page'
+    normalized_url = I18nStringUrlTracker.normalize_url(url)
+    assert_equal(expected_url, normalized_url)
+  end
 end

--- a/lib/test/cdo/test_i18n_string_url_tracker.rb
+++ b/lib/test/cdo/test_i18n_string_url_tracker.rb
@@ -93,4 +93,11 @@ class TestI18nStringUrlTracker < Minitest::Test
     normalized_url = I18nStringUrlTracker.normalize_url(url)
     assert_equal(expected_url, normalized_url)
   end
+
+  def test_normalize_url_should_aggregate_project_urls
+    url = 'https://studio.code.org/projects/flappy/zjiufOp0h-9GS-DywevS0d3tKJyjdbQZZqZVaiuAjiU/view'
+    expected_url = 'https://studio.code.org/projects/flappy'
+    normalized_url = I18nStringUrlTracker.normalize_url(url)
+    assert_equal(expected_url, normalized_url)
+  end
 end

--- a/lib/test/cdo/test_i18n_string_url_tracker.rb
+++ b/lib/test/cdo/test_i18n_string_url_tracker.rb
@@ -71,6 +71,14 @@ class TestI18nStringUrlTracker < Minitest::Test
     assert_equal(@firehose_record, test_record)
   end
 
+  def test_log_given_url_with_query_string_should_call_firehose_without_query_string
+    test_record = {string_key: 'string.key', url: 'http://some.url.com/?query=true', source: 'test'}
+    expected_record = {string_key: 'string.key', url: 'http://some.url.com/', source: 'test'}
+    I18nStringUrlTracker.instance.log(test_record[:string_key], test_record[:url], test_record[:source])
+    assert_equal(:i18n, @firehose_stream)
+    assert_equal(expected_record, @firehose_record)
+  end
+
   def test_log_given_false_dcdo_flag_should_not_call_firehose
     unstub_firehose
     unstub_dcdo
@@ -78,6 +86,14 @@ class TestI18nStringUrlTracker < Minitest::Test
     FirehoseClient.instance.expects(:put_record).never
     test_record = {string_key: 'string.key', url: 'http://some.url.com/', source: 'test'}
     I18nStringUrlTracker.instance.log(test_record[:string_key], test_record[:url], test_record[:source])
+  end
+
+  def test_normalize_url_given_nil_returns_nil
+    assert_nil(I18nStringUrlTracker.normalize_url(nil))
+  end
+
+  def test_normalize_url_given_blank_url_returns_blank_url
+    assert_equal('', I18nStringUrlTracker.normalize_url(''))
   end
 
   def test_normalize_url_should_strip_query_string


### PR DESCRIPTION
The I18n String Tracking system logs which URLs our i18n strings are used. One issue is that we are logging too many URLs and we want to try and aggregate some of them.
* Ignore the query string of a URL:
```
http://some.url.com/?query=true 
becomes
http://some.url.com/
```
* Ignore the anchor tag in a URL:
```
http://some.url.com/#heading
becomes
http://some.url.com/
```
* Ignore the unique ID in a project URL:
```
https://studio.code.org/projects/flappy/zjiufOp0h-9GS-DywevS0d3tKJyjdbQZZqZVaiuAjiU/view 
becomes
https://studio.code.org/projects/flappy
```

## Links
- [jira](https://codedotorg.atlassian.net/browse/FND-1287)
- [jira](https://codedotorg.atlassian.net/browse/FND-1288)

## Testing story
* Unit tests

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
