### PR TITLE
remove unused codemirror-rails gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -220,8 +220,6 @@ gem 'mini_racer'
 
 gem 'jwt' # single signon for zendesk
 
-gem 'codemirror-rails' # edit code in textarea
-
 gem 'twilio-ruby' # SMS API for send-to-phone feature
 
 # We also serve a copy of one of these font files from the public directory

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -353,8 +353,6 @@ GEM
     codecov (0.2.8)
       json
       simplecov
-    codemirror-rails (5.16.0)
-      railties (>= 3.0, < 6.0)
     coderay (1.1.1)
     colorize (0.8.1)
     composite_primary_keys (9.0.10)
@@ -931,7 +929,6 @@ DEPENDENCIES
   cancancan (~> 1.15.0)
   chronic (~> 0.10.2)
   codecov
-  codemirror-rails
   colorize
   composite_primary_keys
   cucumber


### PR DESCRIPTION
It's incompatible with Rails 6 (https://github.com/fixlr/codemirror-rails/blob/cb5e9eee1bac8b8b6933d330591a5f83100094d8/codemirror-rails.gemspec#L15), and according to the maintainer there are no plans to update (https://github.com/fixlr/codemirror-rails/issues/61). It also looks like we aren't actually using it; we just include codemirror via npm right now, as the maintainer recommends.

## Testing story

Grepped around in the codebase a bit looking for places we might be using this and found none

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
