### PR TITLE
Check activities against activityShape in activity editor redux

### DIFF
--- a/apps/src/lib/levelbuilder/lesson-editor/activitiesEditorRedux.js
+++ b/apps/src/lib/levelbuilder/lesson-editor/activitiesEditorRedux.js
@@ -1,4 +1,6 @@
 import _ from 'lodash';
+import PropTypes from 'prop-types';
+import {activityShape} from '@cdo/apps/lib/levelbuilder/shapes';
 
 const INIT = 'activitiesEditor/INIT';
 const ADD_ACTIVITY = 'activitiesEditor/ADD_ACTIVITY';
@@ -273,6 +275,7 @@ function activities(state = [], action) {
 
   switch (action.type) {
     case INIT:
+      validateActivities(action.activities, action.type);
       return action.activities;
     case ADD_ACTIVITY: {
       newState.push({
@@ -518,6 +521,13 @@ function levelNameToIdMap(state = {}, action) {
     }
   }
   return state;
+}
+
+// Use PropTypes.checkPropTypes to enforce that each entry in the array of
+// activities matches the shape defined in activityShape.
+function validateActivities(activities, location) {
+  const propTypes = {activities: PropTypes.arrayOf(activityShape)};
+  PropTypes.checkPropTypes(propTypes, {activities}, 'property', location);
 }
 
 export default {


### PR DESCRIPTION
starts [PLAT-297]. the idea is to take advantage of the shapes we have defined in shapes.jsx, and enforce that data passed into redux matches those shapes. 

Without this, we'll still get a proptype error in most cases, because redux will ultimately pass the bogus data to a react component, which will enforce its own proptypes. 

However, this PR helps show that the problem exists in the caller which passed bad data into redux, as opposed to somewhere inside redux, allowing us to narrow down where the bad data is coming from.

For example, the activities editor UI is currently pulling dummy data from here:
https://github.com/code-dot-org/code-dot-org/blob/1e037fb93cd6f67458c4ebf5dc0d0cab6887caaa/apps/src/sites/studio/pages/lessons/edit.js#L14-L15

With this change, if I introduce a bad property type:
![Screen Shot 2020-09-24 at 4 59 44 PM](https://user-images.githubusercontent.com/8001765/94212109-2354f880-fe88-11ea-8639-e8cfab105757.png)

Then when I load the page, I get a new JS error:
![Screen Shot 2020-09-24 at 4 48 25 PM](https://user-images.githubusercontent.com/8001765/94212128-2ea82400-fe88-11ea-8d1b-62c2e3ef9412.png)


## Testing story

* manual verification steps shown above
* manually verified that lesson / activity editor loads without errors
* also verified that apps tests pass locally. 

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked


[PLAT-297]: https://codedotorg.atlassian.net/browse/PLAT-297