### PR TITLE
Removed feature that auto updates progress when the progress changes on the server

### DIFF
--- a/apps/src/code-studio/reporting.js
+++ b/apps/src/code-studio/reporting.js
@@ -5,8 +5,6 @@ import _ from 'lodash';
 import {TestResults} from '@cdo/apps/constants';
 import {PostMilestoneMode} from '@cdo/apps/util/sharedConstants';
 var clientState = require('./clientState');
-import {getStore} from '../redux';
-import {mergeProgress} from './progressRedux';
 
 var lastAjaxRequest;
 var lastServerResponse = {};
@@ -253,9 +251,6 @@ reporting.sendReport = function(report) {
     queryItems.push(key + '=' + report[key]);
   }
   const queryString = queryItems.join('&');
-  const levelId = report.serverLevelId || appOptions.serverLevelId;
-  const store = getStore();
-  store.dispatch(mergeProgress({[levelId]: report.testResult}));
   clientState.trackLines(report.result, report.lines);
 
   // Post milestone iff the server tells us.


### PR DESCRIPTION
https://github.com/code-dot-org/code-dot-org/pull/36782
^ This PR caused eyes failures on levels that are auto correct and on certain quiz levels.

This happened because along with changing the way we use session storage, we also changed when we update the redux store. This PR reverts the change to when we update the redux store.

Full results can be found on this [applitools run](https://eyes.applitools.com/app/test-results/00000251801315194168/?accountId=mG4DoRfv0ntEgI3XIYBulrKxlZqrHtGwbP3V103ojvLFU110&hideBatchList=true)

Discussion to remove this section of code can be found on this [slack message](https://codedotorg.slack.com/archives/CA3KCSGTD/p1600989488013500)

Example auto-green
http://localhost-studio.code.org:3000/s/allthethings/stage/18/puzzle/14
![image](https://user-images.githubusercontent.com/8324574/94214902-c52c1380-fe8f-11ea-8ee7-bfaac140153b.png)

Example quiz
http://localhost-studio.code.org:3000/s/allthethings/stage/41/puzzle/3
![image](https://user-images.githubusercontent.com/8324574/94214945-e260e200-fe8f-11ea-9fec-1f6995694e81.png)

### Background

**Transcript from discussion to make this change**

_Ask_
I wanted to do a quick pulse check on a change I made:
In the past when a user loaded certain levels, the levels were marked "finished" in our DB immediately when the page was loaded. But they wouldn't show up in the UI as "finished" until the user reloaded the page or accessed their progress in some other way. Now, as soon as we record the user's progress in the DB, we display it in the UI. This syncing with the DB will also be true for levels where we didn't immediately sync in the past (such as quiz levels).
I wanted to check in because the "auto green" might end up feeling a little odd in certain levels (notice the green diamond on page load for the test environment):
New version: https://test-studio.code.org/s/allthethings/stage/35/puzzle/1
Old version: https://studio.code.org/s/allthethings/stage/35/puzzle/1
The experience feels better to me since the behavior is consistent no matter how you view your progress, but I wanted to get a gut check

_Response_
if you’re cool with it, can we check in first thing Monday? I’m a little worried about the non programming level case and need to understand the quiz case a little better and want to sit with both.

_Resolution_
Sounds good. I'm going to go ahead and remove that section of the code to unblock the build pipeline and let the rest of this PR ship.

<!--
  Your description goes here: A summary of the change, including any relevant motivation and context.

  If relevant, include a description both of the existing behavior and of the new behavior.
-->

<!--
  Other aspects to consider. uncomment and add detail for any that seem necessary:
-->

<!-- ### Background -->
<!-- ### Privacy -->
<!-- ### Security -->
<!-- ### Caching -->
<!-- ### Deployment strategy -->
<!-- ### Future work -->

## Links

<!--
  Any relevant links to external resources; ie, specification documents, jira
  items, related PRs, honeybadger errors, etc
-->

## Testing story

<!--
  Does your change include appropriate tests?

  If so, please describe how the tests included in this PR are sufficient

  If not, please explain why this change does not need to be tested.
-->

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
