### PR TITLE
Revert activerecord-import upgrade

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -340,7 +340,7 @@ install_if require_pg do
 end
 
 gem 'active_record_union'
-gem 'activerecord-import', '~> 0.26'
+gem 'activerecord-import'
 gem 'scenic'
 gem 'scenic-mysql_adapter'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -244,7 +244,7 @@ GEM
       activemodel (= 5.0.7.2)
       activesupport (= 5.0.7.2)
       arel (~> 7.0)
-    activerecord-import (0.28.2)
+    activerecord-import (0.22.0)
       activerecord (>= 3.2)
     activesupport (5.0.7.2)
       concurrent-ruby (~> 1.0, >= 1.0.2)
@@ -901,7 +901,7 @@ DEPENDENCIES
   active_model_serializers (~> 0.10.0)
   active_record_query_trace
   active_record_union
-  activerecord-import (~> 0.26)
+  activerecord-import
   acts_as_list
   addressable
   annotate

--- a/dashboard/lib/level_loader.rb
+++ b/dashboard/lib/level_loader.rb
@@ -113,13 +113,7 @@ class LevelLoader
     # Delete entries for all other attributes that may no longer be specified in the xml.
     # Fixes issue #75863324 (delete removed level properties on import)
     level.send(:write_attribute, 'properties', {})
-    loaded_attributes = level.load_level_xml(xml_node)
-
-    # activerecord-import 0.28.2 doesn't play nicely with the datetime values serialized in our .level files for some reason.
-    # Without this line, it passes the serialized String value directly into the SQL insert statement as-is, which fails
-    # since it's not the format MySQL wants. Parsing it into a TimeWithZone object first seems to make it work.
-    loaded_attributes['created_at'] = Time.zone.parse(loaded_attributes['created_at']) if loaded_attributes['created_at']
-    level.assign_attributes(loaded_attributes)
+    level.assign_attributes(level.load_level_xml(xml_node))
 
     level
   end


### PR DESCRIPTION
Reverts https://github.com/code-dot-org/code-dot-org/pull/36884 again.

Seems like this change causes a signficant performance regression: https://codedotorg.slack.com/archives/C03CK49G9/p1601007521011300

From some local testing, it doesn't seem to be a problem with the `TimeWithZone` workaround, but with that version of activerecord-import. The regression still occurs if I just drop the `created_at` field.

I can figure out how to proceed (upgrade to a different version? Just stay on the current version?) later.