### PR TITLE
Show a level as in progress when a student starts interacting with it

### DIFF
--- a/apps/src/StudioApp.js
+++ b/apps/src/StudioApp.js
@@ -1860,7 +1860,8 @@ StudioApp.prototype.silentlyReport = function() {
   this.report({
     app: getStore().getState().pageConstants.appType,
     level: this.config.level.id,
-    skipSuccessCallback: true
+    skipSuccessCallback: true,
+    testResult: TestResults.LEVEL_STARTED
   });
   this.hasReported = false;
 };

--- a/apps/src/StudioApp.js
+++ b/apps/src/StudioApp.js
@@ -1857,12 +1857,19 @@ StudioApp.prototype.clearAndAttachRuntimeAnnotations = function() {
  * the server responds.
  */
 StudioApp.prototype.silentlyReport = function() {
-  this.report({
+  var options = {
     app: getStore().getState().pageConstants.appType,
     level: this.config.level.id,
-    skipSuccessCallback: true,
-    testResult: TestResults.LEVEL_STARTED
-  });
+    skipSuccessCallback: true
+  };
+
+  // Some DB-backed levels (such as craft) only save the user's code when the user
+  // successfully finishes the level. Opening the level in a new tab will make the level
+  // appear freshly started. Therefore, we mark only channel-backed levels "started" here.
+  if (this.config.channel) {
+    options.testResult = TestResults.LEVEL_STARTED;
+  }
+  this.report(options);
   this.hasReported = false;
 };
 

--- a/apps/src/constants.js
+++ b/apps/src/constants.js
@@ -69,6 +69,7 @@ export const TestResults = {
   UNSUBMITTED_ATTEMPT: -50, // Progress was saved without submitting for review, or was unsubmitted.
 
   SKIPPED: -100, // Skipped, e.g. they used the skip button on a challenge level
+  LEVEL_STARTED: -150, // The user has clicked run and reset at least once
 
   // Numbers below 20 are generally considered some form of failure.
   // Numbers >= 20 generally indicate some form of success (although again there

--- a/apps/src/constants.js
+++ b/apps/src/constants.js
@@ -69,7 +69,7 @@ export const TestResults = {
   UNSUBMITTED_ATTEMPT: -50, // Progress was saved without submitting for review, or was unsubmitted.
 
   SKIPPED: -100, // Skipped, e.g. they used the skip button on a challenge level
-  LEVEL_STARTED: -150, // The user has clicked run and reset at least once
+  LEVEL_STARTED: -150, // The user has triggered the reset action at least once (ex: by clicking the reset button)
 
   // Numbers below 20 are generally considered some form of failure.
   // Numbers >= 20 generally indicate some form of success (although again there

--- a/apps/test/integration/levelSolutions/applab2/ec_simple.js
+++ b/apps/test/integration/levelSolutions/applab2/ec_simple.js
@@ -46,7 +46,7 @@ module.exports = {
       expected: [
         {
           result: undefined,
-          testResult: undefined
+          testResult: TestResults.LEVEL_STARTED
         },
         {
           result: true,


### PR DESCRIPTION
Non-validated levels currently never show an "in-progress" state, shown to the user as a green outline on the progress bubble. They are marked as "not started" until the user clicks the "complete" button. Once the "complete" button is clicked, the level transitions to the "complete" state, shown to the user as a filled-in green progress bubble. This would happen because no milestones were being recorded until the "complete" button was clicked.

Now, we record milestones on every (debounced) click of the reset button. With this change, we add an additional feature to this click - we record the level as "in-progress."

### Background

We started recording milestones once per run-reset cycle as part of this PR: https://github.com/code-dot-org/code-dot-org/pull/36606

This task is part of the larger auto-validation feature (see link below).

In the past, we did not record intermediate milestones for non-validated levels because the DB load was too high on the UserLevels table. Now the load capacity has been significantly increased and milestones can be safely recorded every time the reset button is clicked.

The TestResult is set at -150 because any other state should be able to overwrite it. This is the bare minimum "in progress" state. It only indicates that the user has interacted with the level (by clicking the Reset button). Any other result will contain more information. 

The TestResult that is passed to the DB gets calculated like this (pseudocode)
```
record Max(existingTestResult, newTestResult)
```
Therefore, -150 will always be overwritten by a higher result and will never overwrite a higher result.

<!--
  Other aspects to consider. uncomment and add detail for any that seem necessary:
-->

<!-- ### Background -->
<!-- ### Privacy -->
<!-- ### Security -->
<!-- ### Caching -->
<!-- ### Deployment strategy -->
<!-- ### Future work -->

## Links

<!--
  Any relevant links to external resources; ie, specification documents, jira
  items, related PRs, honeybadger errors, etc
-->

- [spec](https://docs.google.com/document/d/1hF-wvav0MXLnH49x0WBeO8TcUibMaCUegZiDr8-6l-c/edit#)
- [Dev Doc](https://docs.google.com/document/d/1xUgybM56dV5kmqOukKVPW1d88a9HGhphUs2r0tWlC_4/edit#)
- [Slack discussion about this topic](https://codedotorg.slack.com/archives/CA3KCSGTD/p1600876009003900)
- [jira](https://codedotorg.atlassian.net/browse/LP-1543)

## Testing story

<!--
  Does your change include appropriate tests?

  If so, please describe how the tests included in this PR are sufficient

  If not, please explain why this change does not need to be tested.
-->

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
