### PR TITLE
Hide redundant announcement on the Teacher Homepage

### DIFF
--- a/apps/src/templates/studioHomepages/TeacherHomepage.jsx
+++ b/apps/src/templates/studioHomepages/TeacherHomepage.jsx
@@ -176,8 +176,8 @@ export class UnconnectedTeacherHomepage extends Component {
       specialAnnouncement
     } = this.props;
 
-    // Show the regular announcement/notification for now.
-    const showAnnouncement = true;
+    // Whether we show the regular announcement/notification
+    const showAnnouncement = false;
 
     // Verify background image works for both LTR and RTL languages.
     const backgroundUrl = '/shared/images/banners/teacher-homepage-hero.jpg';
@@ -212,6 +212,7 @@ export class UnconnectedTeacherHomepage extends Component {
               <div style={styles.clear} />
             </div>
           )}
+          {!showAnnouncement && <br />}
           {isEnglish && <SpecialAnnouncement isTeacher={true} />}
           {this.state.showCensusBanner && (
             <div>


### PR DESCRIPTION
Signed-in teachers in English saw two banners with very similar information. We are hiding the smaller banner, so now teachers in English see the big banner and non-English teachers don't see a banner.

**Before:**

<img width="1446" alt="Screen Shot 2020-09-25 at 10 46 55 AM" src="https://user-images.githubusercontent.com/224089/94299431-855f3d80-ff1c-11ea-99c5-afa6590a19df.png">

**After, English:**

<img width="1445" alt="Screen Shot 2020-09-25 at 10 42 28 AM" src="https://user-images.githubusercontent.com/224089/94299450-8b551e80-ff1c-11ea-87fe-4a11daf67800.png">


**After, non-English:**

<img width="1442" alt="Screen Shot 2020-09-25 at 10 43 23 AM" src="https://user-images.githubusercontent.com/224089/94299446-898b5b00-ff1c-11ea-9f6c-1724bd076d73.png">

<!--
  Your description goes here: A summary of the change, including any relevant motivation and context.

  If relevant, include a description both of the existing behavior and of the new behavior.
-->

<!--
  Other aspects to consider. uncomment and add detail for any that seem necessary:
-->

<!-- ### Background -->
<!-- ### Privacy -->
<!-- ### Security -->
<!-- ### Caching -->
<!-- ### Deployment strategy -->
<!-- ### Future work -->

## Links

<!--
  Any relevant links to external resources; ie, specification documents, jira
  items, related PRs, honeybadger errors, etc
-->

- [spec]()
- [jira]()

## Testing story

<!--
  Does your change include appropriate tests?

  If so, please describe how the tests included in this PR are sufficient

  If not, please explain why this change does not need to be tested.
-->

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
