### PR TITLE
Make UserSchoolInfo tests slightly more resilient

### DIFF
--- a/dashboard/test/controllers/api/v1/user_school_infos_controller_test.rb
+++ b/dashboard/test/controllers/api/v1/user_school_infos_controller_test.rb
@@ -360,15 +360,16 @@ class UserSchoolInfosControllerTest < ActionDispatch::IntegrationTest
 
   test 'confirmation, partial previous, blank, manual' do
     complete_school_info = SchoolInfo.create({country: 'United States', school_type: 'public', school_name: 'Philly High Harmony', full_address: 'Seattle, Washington', validation_type: SchoolInfo::VALIDATION_COMPLETE})
-    @teacher.update(school_info: complete_school_info)
+    assert @teacher.update(school_info: complete_school_info)
 
     Timecop.travel 1.year
+    @teacher.reload
 
     partial_school_info = SchoolInfo.create({country: 'United States', school_type: 'public', school_name: nil, full_address: 'Seattle, Washington', validation_type: SchoolInfo::VALIDATION_COMPLETE})
-    result = @teacher.update(school_info: partial_school_info)
-    assert_equal false, result
+    refute @teacher.update(school_info: partial_school_info)
 
     Timecop.travel 7.days
+    @teacher.reload
 
     sign_in @teacher
     submit_blank_school_info
@@ -380,14 +381,16 @@ class UserSchoolInfosControllerTest < ActionDispatch::IntegrationTest
 
   test 'confirmation, partial previous, unchanged, manual' do
     complete_school_info = SchoolInfo.create({country: 'US', school_type: 'public', school_name: 'Philly High Harmony', full_address: 'Seattle, Washington', validation_type: SchoolInfo::VALIDATION_COMPLETE})
-    @teacher.update(school_info: complete_school_info)
+    assert @teacher.update(school_info: complete_school_info)
 
     Timecop.travel 1.year
+    @teacher.reload
 
     partial_school_info = SchoolInfo.create({country: 'US', school_type: 'public', school_name: nil, full_address: 'Seattle, Washington', validation_type: SchoolInfo::VALIDATION_COMPLETE})
-    @teacher.update(school_info: partial_school_info)
+    refute @teacher.update(school_info: partial_school_info)
 
     Timecop.travel 7.days
+    @teacher.reload
 
     sign_in @teacher
     submit_unchanged_school_info partial_school_info
@@ -401,14 +404,16 @@ class UserSchoolInfosControllerTest < ActionDispatch::IntegrationTest
 
   test 'confirmation, partial previous, partial, manual' do
     complete_school_info = SchoolInfo.create({country: 'United States', school_type: 'public', school_name: 'Philly High Harmony', full_address: 'Seattle, Washington', validation_type: SchoolInfo::VALIDATION_COMPLETE})
-    @teacher.update(school_info: complete_school_info)
+    assert @teacher.update(school_info: complete_school_info)
 
     Timecop.travel 1.year
+    @teacher.reload
 
     partial_school_info = SchoolInfo.create({country: 'United States', school_type: 'public', school_name: nil, full_address: 'Seattle, Washington', validation_type: SchoolInfo::VALIDATION_COMPLETE})
-    @teacher.update(school_info: partial_school_info)
+    refute @teacher.update(school_info: partial_school_info)
 
     Timecop.travel 7.days
+    @teacher.reload
 
     sign_in @teacher
     submit_partial_school_info
@@ -425,14 +430,16 @@ class UserSchoolInfosControllerTest < ActionDispatch::IntegrationTest
     new_school = create :school
 
     complete_school_info = SchoolInfo.create({country: 'United States', school_type: 'public', school_name: 'Philly High Harmony', full_address: 'Seattle, Washington', validation_type: SchoolInfo::VALIDATION_COMPLETE})
-    @teacher.update(school_info: complete_school_info)
+    assert @teacher.update(school_info: complete_school_info)
 
     Timecop.travel 1.year
+    @teacher.reload
 
     partial_school_info = SchoolInfo.create({country: 'United States', school_type: 'public', school_name: nil, full_address: 'Seattle, Washington', validation_type: SchoolInfo::VALIDATION_COMPLETE})
-    @teacher.update(school_info: partial_school_info)
+    refute @teacher.update(school_info: partial_school_info)
 
     Timecop.travel 7.days
+    @teacher.reload
 
     sign_in @teacher
     submit_complete_school_info_from_dropdown(new_school)
@@ -447,14 +454,16 @@ class UserSchoolInfosControllerTest < ActionDispatch::IntegrationTest
 
   test 'confirmation, partial previous, complete, manual' do
     complete_school_info = SchoolInfo.create({country: 'United States', school_type: 'public', school_name: 'Philly High Harmony', full_address: 'Seattle, Washington', validation_type: SchoolInfo::VALIDATION_COMPLETE})
-    @teacher.update(school_info: complete_school_info)
+    assert @teacher.update(school_info: complete_school_info)
 
     Timecop.travel 1.year
+    @teacher.reload
 
     partial_school_info = SchoolInfo.create({country: 'United States', school_type: 'public', school_name: nil, full_address: 'Seattle, Washington', validation_type: SchoolInfo::VALIDATION_COMPLETE})
-    @teacher.update(school_info: partial_school_info)
+    refute @teacher.update(school_info: partial_school_info)
 
     Timecop.travel 7.days
+    @teacher.reload
 
     sign_in @teacher
     submit_complete_school_info_manual
@@ -473,18 +482,20 @@ class UserSchoolInfosControllerTest < ActionDispatch::IntegrationTest
     new_school = create :school
 
     complete_school_info = SchoolInfo.create({country: 'United States', school_type: 'public', school_name: 'Philly High Harmony', full_address: 'Seattle, Washington', validation_type: SchoolInfo::VALIDATION_COMPLETE})
-    @teacher.update(school_info: complete_school_info)
+    assert @teacher.update(school_info: complete_school_info)
 
     second_teacher_complete_school_info = SchoolInfo.create({country: 'United States', school_type: 'public', school_name: 'School of Rock', full_address: 'Harrisburg, PA', validation_type: SchoolInfo::VALIDATION_COMPLETE})
-    @second_teacher.update(school_info: second_teacher_complete_school_info)
+    assert @second_teacher.update(school_info: second_teacher_complete_school_info)
 
     Timecop.travel 1.year
+    @teacher.reload
 
     partial_school_info = SchoolInfo.create({country: 'United States', school_type: 'public', school_name: nil, full_address: 'Seattle, Washington', validation_type: SchoolInfo::VALIDATION_COMPLETE})
-    @teacher.update(school_info: partial_school_info)
-    @second_teacher.update(school_info: partial_school_info)
+    refute @teacher.update(school_info: partial_school_info)
+    refute @second_teacher.update(school_info: partial_school_info)
 
     Timecop.travel 7.days
+    @teacher.reload
 
     sign_in @teacher
     submit_complete_school_info_from_dropdown(new_school)


### PR DESCRIPTION
There are two changes in this PR:

**First**, we explicitly reload the teacher objects being considered here after "time traveling" and before saving. The loose goal here is to more accurately represent the "real-world" user activity we're trying to emulate, in which we expect the user objects to be renewed from the database when the user starts a new session. The more-specific goal is to enable [the upgrade to Devise 4.7](https://github.com/code-dot-org/code-dot-org/pull/36860), which introduced a change to the way the sign-in process persists changes on the user object; that change causes these tests to fail.

**Second**, we add some assertions around the `update` calls used in these tests. These are just to add clarity to the test; when I first approached these tests to fix the issue above it wasn't clear to me whether the devise change was introducing an actual bug or if the tests themselves were expecting this data to not be persisted. Hopefully these new assertions should make things clearer for the next dev to come poking around.

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
