### PR TITLE
Update styles on progression display in lesson

### DIFF
--- a/apps/src/templates/lessonOverview/activities/ActivitySection.jsx
+++ b/apps/src/templates/lessonOverview/activities/ActivitySection.jsx
@@ -11,7 +11,8 @@ import i18n from '@cdo/locale';
 const styles = {
   activitySection: {
     display: 'flex',
-    flexDirection: 'row'
+    flexDirection: 'row',
+    width: '100%'
   },
   tipIcons: {
     display: 'flex',
@@ -21,8 +22,7 @@ const styles = {
   },
   tips: {
     display: 'flex',
-    flexDirection: 'column',
-    width: '40%'
+    flexDirection: 'column'
   },
   remarksHeader: {
     marginLeft: 5,
@@ -39,6 +39,8 @@ export default class ActivitySection extends Component {
     const {section} = this.props;
 
     const isProgressionSection = section.levels.length > 0;
+
+    const sectionHasTips = section.tips.length > 0;
 
     return (
       <div>
@@ -72,7 +74,7 @@ export default class ActivitySection extends Component {
           </div>
           {!isProgressionSection && <SafeMarkdown markdown={section.text} />}
           {isProgressionSection && <ProgressionDetails progression={section} />}
-          <div style={styles.tips}>
+          <div style={{...styles.tips, ...(sectionHasTips && {width: '40%'})}}>
             {section.tips.map((tip, index) => {
               return <LessonTip key={`tip-${index}`} tip={tip} />;
             })}

--- a/apps/src/templates/lessonOverview/activities/ProgressionDetails.jsx
+++ b/apps/src/templates/lessonOverview/activities/ProgressionDetails.jsx
@@ -2,13 +2,20 @@ import PropTypes from 'prop-types';
 import React, {Component} from 'react';
 import SafeMarkdown from '@cdo/apps/templates/SafeMarkdown';
 import ProgressLevelSet from '@cdo/apps/templates/progress/ProgressLevelSet';
+import color from '@cdo/apps/util/color';
 
 const styles = {
   progressionBox: {
-    borderWidth: 1,
+    borderWidth: 2,
     borderStyle: 'solid',
-    margin: 10,
-    width: '100%'
+    borderColor: color.lighter_gray,
+    margin: '10px, 0px',
+    width: '100%',
+    backgroundColor: color.lightest_gray,
+    padding: 20
+  },
+  description: {
+    marginTop: 10
   }
 };
 
@@ -28,7 +35,9 @@ export default class ProgressionDetails extends Component {
           disabled={true}
           selectedSectionId={null}
         />
-        <SafeMarkdown markdown={progression.text} />
+        <div style={styles.description}>
+          <SafeMarkdown markdown={progression.text} />
+        </div>
       </div>
     );
   }


### PR DESCRIPTION
Update the styles of the progression display in the teacher facing lesson plan to match the [spec](https://www.figma.com/proto/vxVFVZMV51xFzsyD8QOcPq/CB--%3E-LB-move?node-id=399%3A107&viewport=-135%2C-51%2C0.5&scaling=min-zoom)
<img width="983" alt="Screen Shot 2020-09-25 at 10 27 31 PM" src="https://user-images.githubusercontent.com/208083/94328195-6f826480-ff7e-11ea-9e3f-298f23b3f5f5.png">

## Links

<!--
  Any relevant links to external resources; ie, specification documents, jira
  items, related PRs, honeybadger errors, etc
-->

- [spec](https://docs.google.com/document/d/1SaZRs36uEkJIJUDe4nB1KoGAmhHvmgmSEcYtysGReUE/edit)
- [jira](https://codedotorg.atlassian.net/browse/PLAT-336)

## Testing story

Just tested that it looked right on the screen manually

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
