### PR TITLE
International dance party page style fixes

### DIFF
--- a/pegasus/sites.v3/code.org/public/dance.haml
+++ b/pegasus/sites.v3/code.org/public/dance.haml
@@ -13,6 +13,7 @@ theme: responsive
 %script{src: webpack_asset_path("js/#{js_locale}/common_locale.js")}
 %script{src: webpack_asset_path('js/code.org/public/dance.js')}
 
+%link{href: "/css/tutorial-promo.css", type: "text/css", rel: "stylesheet"}
 %link{href: "/css/dance-landing/dance.css", type: "text/css", rel: "stylesheet"}
 
 =view :dance_tutorial_section

--- a/pegasus/sites.v3/code.org/views/dance_sponsor_logo.haml
+++ b/pegasus/sites.v3/code.org/views/dance_sponsor_logo.haml
@@ -1,7 +1,6 @@
 - afe_link = request.country == 'FR' ? 'https://www.amazonfutureengineer.fr/' : 'https://www.amazonfutureengineer.com'
 
 - if request.language == 'en'
-  %link{href: "/css/dance-landing/dance.css", type: "text/css", rel: "stylesheet"}
 
   .sponsor-logo-with-text{style: "justify-content: center;"}
     = I18n.t(:hoc2018_dance_amazon_sponsor_section_with_logo_title)

--- a/pegasus/sites.v3/code.org/views/dance_tutorial_section.haml
+++ b/pegasus/sites.v3/code.org/views/dance_tutorial_section.haml
@@ -1,7 +1,5 @@
 - hide_keep_on_dancing_tile = DCDO.get('hide_dance_followup', nil)
 
-%link{href: "/css/tutorial-promo.css", type: "text/css", rel: "stylesheet"}
-
 .dance-clear-element
 .tutorial-promo-container.dance-party-container
   .img-container

--- a/pegasus/sites.v3/code.org/views/dance_tutorial_section.haml
+++ b/pegasus/sites.v3/code.org/views/dance_tutorial_section.haml
@@ -16,14 +16,14 @@
     .new-announcement-mobile.mobile-only.highlight-strong
       != hoc_s(:codeorg_homepage_hoc2019_dance_heading_markdown, markdown: :inline)
 
-  .col-25.specific-tutorial.right-tutorial.dance-tutorial{style: "top: 15px"}
+  .col-25.specific-tutorial.right-tutorial.dance-tutorial
     .tutorial-box
       %h2.specific-tutorial-heading.dance-party-h2= I18n.t(:hoc2018_dance_party_box_title)
       .tutorial-details
         %p.tutorial-description= I18n.t(:hoc2018_dance_party_box_description)
       %a{href: CDO.studio_url('/s/dance-2019/reset'), target: '_self'}
         %button.tutorial-button.dance-try-button= I18n.t(:hoc2018_dance_party_button)
-  .col-25.specific-tutorial.left-tutorial.dance-tutorial{style: "top: 15px"}
+  .col-25.specific-tutorial.left-tutorial.dance-tutorial
     - unless hide_keep_on_dancing_tile
       .tutorial-box
         %h2.specific-tutorial-heading.dance-party-h2= I18n.t(:hoc2018_dance_keep_on_dancing_box_title)

--- a/pegasus/sites.v3/code.org/views/dance_tutorial_section.haml
+++ b/pegasus/sites.v3/code.org/views/dance_tutorial_section.haml
@@ -16,14 +16,14 @@
     .new-announcement-mobile.mobile-only.highlight-strong
       != hoc_s(:codeorg_homepage_hoc2019_dance_heading_markdown, markdown: :inline)
 
-  .col-25.specific-tutorial.right-tutorial.dance-tutorial
+  .col-25.specific-tutorial.right-tutorial.dance-tutorial{style: "top: 15px"}
     .tutorial-box
       %h2.specific-tutorial-heading.dance-party-h2= I18n.t(:hoc2018_dance_party_box_title)
       .tutorial-details
         %p.tutorial-description= I18n.t(:hoc2018_dance_party_box_description)
       %a{href: CDO.studio_url('/s/dance-2019/reset'), target: '_self'}
         %button.tutorial-button.dance-try-button= I18n.t(:hoc2018_dance_party_button)
-  .col-25.specific-tutorial.left-tutorial.dance-tutorial
+  .col-25.specific-tutorial.left-tutorial.dance-tutorial{style: "top: 15px"}
     - unless hide_keep_on_dancing_tile
       .tutorial-box
         %h2.specific-tutorial-heading.dance-party-h2= I18n.t(:hoc2018_dance_keep_on_dancing_box_title)


### PR DESCRIPTION
The boxes that hold the dance tutorial links were sliding down the page for the international version of the dance party homepage. It turns out that for requests in English, we were re-including dance.css, so when looking at the page in English, you saw the correct styling, but for other languages, a different stylesheet was winning out that shouldn't have. I removed the extra inclusion and changed the order so that the CSS is applied as intended for all languages.

**before** (non-English):
<img width="1016" alt="Screen Shot 2020-09-28 at 1 07 31 PM" src="https://user-images.githubusercontent.com/224089/94480756-99f53d00-018b-11eb-9767-745ea35869d3.png">

**after** (non-English):

<img width="1030" alt="Screen Shot 2020-09-28 at 11 05 55 AM" src="https://user-images.githubusercontent.com/224089/94480769-9f528780-018b-11eb-87d6-ea47ec5570b1.png">

**after** (English):

<img width="1021" alt="Screen Shot 2020-09-28 at 1 03 39 PM" src="https://user-images.githubusercontent.com/224089/94480763-9e215a80-018b-11eb-96c3-66a32688e9fa.png">


<!--
  Your description goes here: A summary of the change, including any relevant motivation and context.

  If relevant, include a description both of the existing behavior and of the new behavior.
-->

<!--
  Other aspects to consider. uncomment and add detail for any that seem necessary:
-->

<!-- ### Background -->
<!-- ### Privacy -->
<!-- ### Security -->
<!-- ### Caching -->
<!-- ### Deployment strategy -->
<!-- ### Future work -->

## Links

<!--
  Any relevant links to external resources; ie, specification documents, jira
  items, related PRs, honeybadger errors, etc
-->

- [spec]()
- [jira]()

## Testing story

<!--
  Does your change include appropriate tests?

  If so, please describe how the tests included in this PR are sufficient

  If not, please explain why this change does not need to be tested.
-->

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
