### PR TITLE
Limit pair programming sessions to 4 students

### DIFF
--- a/apps/i18n/common/en_us.json
+++ b/apps/i18n/common/en_us.json
@@ -1143,6 +1143,7 @@
   "noMenuItemsAvailable": "No menu items available.",
   "nominateATeacher": "Nominate a Teacher",
   "noStudentsInSection": "There are no other students in this section.",
+  "exceededPairProgrammingMax": "You cannot pair with more than 4 people.",
   "noPersonalProjects": "You currently have no projects. Click on one of the buttons above to start a project.",
   "noTablesInProject": "You have no tables in your project. Try adding one from the Data Library.",
   "none": "None",

--- a/apps/src/code-studio/components/pairing/StudentSelector.jsx
+++ b/apps/src/code-studio/components/pairing/StudentSelector.jsx
@@ -2,17 +2,17 @@ import PropTypes from 'prop-types';
 import React from 'react';
 import {studentsShape} from './types';
 import i18n from '@cdo/locale';
+import color from '@cdo/apps/util/color';
 
-const cyan = '#0094ca';
 const styles = {
   buttonLeft: {
     marginLeft: 0
   },
   enabled: {
     backgroundColor: 'white',
-    color: cyan,
+    color: color.cyan,
     border: '2px solid',
-    borderColor: cyan,
+    borderColor: color.cyan,
     fontFamily: "'Gotham 4r', sans-serif",
     fontSize: '13px'
   },
@@ -25,8 +25,8 @@ const styles = {
   disabled: {
     opacity: 0.5
   },
-  clicked: {
-    backgroundColor: cyan,
+  selected: {
+    backgroundColor: color.cyan,
     color: 'white'
   }
 };
@@ -69,21 +69,22 @@ export default class StudentSelector extends React.Component {
     } else if (this.props.students.length === 0) {
       return <span>{i18n.noStudentsInSection()}</span>;
     }
+
     const exceededMaximum = this.state.selectedStudentIds.length >= 4;
     const studentBtns = this.props.students.map(student => {
-      let className = 'selectable';
-      if (this.state.selectedStudentIds.indexOf(student.id) !== -1) {
-        className = 'selected';
+      let className = 'selected';
+      let disabled = false;
+      if (this.state.selectedStudentIds.indexOf(student.id) === -1) {
+        className = 'selectable';
+        disabled = exceededMaximum;
       }
-      let btnStyle = styles.enabled;
-      const unselectable = exceededMaximum && className === 'selectable';
+      let buttonStyle = styles.enabled;
 
       //Adjust styles for disabled and selected buttons
-      let baseStyles = {...btnStyle};
-      if (unselectable) {
-        btnStyle = {...baseStyles, ...styles.disabled};
+      if (disabled) {
+        buttonStyle = {...buttonStyle, ...styles.disabled};
       } else if (className === 'selected') {
-        btnStyle = {...baseStyles, ...styles.clicked};
+        buttonStyle = {...buttonStyle, ...styles.selected};
       }
 
       return (
@@ -93,8 +94,8 @@ export default class StudentSelector extends React.Component {
           data-id={student.id}
           className={className}
           onClick={this.handleStudentClicked}
-          style={btnStyle}
-          disabled={unselectable}
+          style={buttonStyle}
+          disabled={disabled}
         >
           {student.name}
         </button>

--- a/apps/src/code-studio/components/pairing/StudentSelector.jsx
+++ b/apps/src/code-studio/components/pairing/StudentSelector.jsx
@@ -3,9 +3,21 @@ import React from 'react';
 import {studentsShape} from './types';
 import i18n from '@cdo/locale';
 
+const cyan = '#0094ca';
 const styles = {
   buttonLeft: {
     marginLeft: 0
+  },
+  selectable: {
+    backgroundColor: 'white',
+    color: cyan,
+    border: '1px solid',
+    borderColor: cyan,
+    fontFamily: "'Gotham 4r', sans-serif",
+    fontSize: '13px'
+  },
+  warning: {
+    color: 'red'
   }
 };
 
@@ -47,28 +59,46 @@ export default class StudentSelector extends React.Component {
     } else if (this.props.students.length === 0) {
       return <span>{i18n.noStudentsInSection()}</span>;
     }
-
-    const studentDivs = this.props.students.map(student => {
-      let className = 'student selectable';
+    const exceededMaximum = this.state.selectedStudentIds.length >= 4;
+    const studentBtns = this.props.students.map(student => {
+      let className = 'selectable';
       if (this.state.selectedStudentIds.indexOf(student.id) !== -1) {
-        className = 'student selectable selected';
+        className = 'selected';
       }
+      let btnStyle = styles.selectable;
+      const unselectable = exceededMaximum && className === 'selectable';
+
+      //Adjust styles for disabled and selected buttons
+      let baseStyles = {...btnStyle};
+      if (unselectable) {
+        baseStyles['opacity'] = 0.5;
+      } else if (className === 'selected') {
+        baseStyles['backgroundColor'] = cyan;
+        baseStyles['color'] = 'white';
+      }
+      btnStyle = baseStyles;
+
       return (
-        <div
+        <button
+          type="button"
           key={student.id}
           data-id={student.id}
           className={className}
           onClick={this.handleStudentClicked}
+          style={btnStyle}
+          disabled={unselectable}
         >
           {student.name}
-        </div>
+        </button>
       );
     });
-
     return (
       <div>
-        {studentDivs}
+        {studentBtns}
         <div className="clear" />
+        {exceededMaximum && (
+          <p style={styles.warning}>You cannot pair with more than 4 people.</p>
+        )}
         {this.state.selectedStudentIds.length !== 0 && (
           <button
             style={styles.buttonLeft}

--- a/apps/src/code-studio/components/pairing/StudentSelector.jsx
+++ b/apps/src/code-studio/components/pairing/StudentSelector.jsx
@@ -69,12 +69,14 @@ export default class StudentSelector extends React.Component {
     } else if (this.props.students.length === 0) {
       return <span>{i18n.noStudentsInSection()}</span>;
     }
+    const {students} = this.props;
+    const {selectedStudentIds} = this.state;
+    const exceededMaximum = selectedStudentIds.length >= 4;
 
-    const exceededMaximum = this.state.selectedStudentIds.length >= 4;
-    const studentBtns = this.props.students.map(student => {
+    const studentBtns = students.map(student => {
       let className = 'selected';
       let disabled = false;
-      if (this.state.selectedStudentIds.indexOf(student.id) === -1) {
+      if (selectedStudentIds.indexOf(student.id) === -1) {
         className = 'selectable';
         disabled = exceededMaximum;
       }
@@ -108,7 +110,7 @@ export default class StudentSelector extends React.Component {
         {exceededMaximum && (
           <p style={styles.warning}>{i18n.exceededPairProgrammingMax()}</p>
         )}
-        {this.state.selectedStudentIds.length !== 0 && (
+        {selectedStudentIds.length !== 0 && (
           <button
             style={styles.buttonLeft}
             type="button"

--- a/apps/src/code-studio/components/pairing/StudentSelector.jsx
+++ b/apps/src/code-studio/components/pairing/StudentSelector.jsx
@@ -8,16 +8,26 @@ const styles = {
   buttonLeft: {
     marginLeft: 0
   },
-  selectable: {
+  enabled: {
     backgroundColor: 'white',
     color: cyan,
-    border: '1px solid',
+    border: '2px solid',
     borderColor: cyan,
     fontFamily: "'Gotham 4r', sans-serif",
     fontSize: '13px'
   },
   warning: {
-    color: 'red'
+    color: 'red',
+    fontFamily: "'Gotham 4r', sans-serif",
+    fontSize: '12px',
+    paddingTop: '5px'
+  },
+  disabled: {
+    opacity: 0.5
+  },
+  clicked: {
+    backgroundColor: cyan,
+    color: 'white'
   }
 };
 
@@ -65,18 +75,16 @@ export default class StudentSelector extends React.Component {
       if (this.state.selectedStudentIds.indexOf(student.id) !== -1) {
         className = 'selected';
       }
-      let btnStyle = styles.selectable;
+      let btnStyle = styles.enabled;
       const unselectable = exceededMaximum && className === 'selectable';
 
       //Adjust styles for disabled and selected buttons
       let baseStyles = {...btnStyle};
       if (unselectable) {
-        baseStyles['opacity'] = 0.5;
+        btnStyle = {...baseStyles, ...styles.disabled};
       } else if (className === 'selected') {
-        baseStyles['backgroundColor'] = cyan;
-        baseStyles['color'] = 'white';
+        btnStyle = {...baseStyles, ...styles.clicked};
       }
-      btnStyle = baseStyles;
 
       return (
         <button
@@ -97,7 +105,7 @@ export default class StudentSelector extends React.Component {
         {studentBtns}
         <div className="clear" />
         {exceededMaximum && (
-          <p style={styles.warning}>You cannot pair with more than 4 people.</p>
+          <p style={styles.warning}>{i18n.exceededPairProgrammingMax()}</p>
         )}
         {this.state.selectedStudentIds.length !== 0 && (
           <button

--- a/apps/src/code-studio/components/pairing/StudentSelector.jsx
+++ b/apps/src/code-studio/components/pairing/StudentSelector.jsx
@@ -74,10 +74,10 @@ export default class StudentSelector extends React.Component {
     const exceededMaximum = selectedStudentIds.length >= 4;
 
     const studentBtns = students.map(student => {
-      let className = 'selected';
+      let className = 'student selected';
       let disabled = false;
       if (selectedStudentIds.indexOf(student.id) === -1) {
-        className = 'selectable';
+        className = 'student selectable';
         disabled = exceededMaximum;
       }
       let buttonStyle = styles.enabled;
@@ -85,7 +85,7 @@ export default class StudentSelector extends React.Component {
       //Adjust styles for disabled and selected buttons
       if (disabled) {
         buttonStyle = {...buttonStyle, ...styles.disabled};
-      } else if (className === 'selected') {
+      } else if (className.includes('selected')) {
         buttonStyle = {...buttonStyle, ...styles.selected};
       }
 

--- a/apps/src/code-studio/components/pairing/StudentSelector.jsx
+++ b/apps/src/code-studio/components/pairing/StudentSelector.jsx
@@ -4,16 +4,13 @@ import {studentsShape} from './types';
 import i18n from '@cdo/locale';
 import color from '@cdo/apps/util/color';
 
+// see pairing.scss for general button styling
 const styles = {
   buttonLeft: {
     marginLeft: 0
   },
   enabled: {
     backgroundColor: 'white',
-    color: color.cyan,
-    border: '1px solid',
-    borderColor: color.cyan,
-    fontFamily: "'Gotham 4r', sans-serif",
     fontSize: '13px'
   },
   warning: {

--- a/apps/src/code-studio/components/pairing/StudentSelector.jsx
+++ b/apps/src/code-studio/components/pairing/StudentSelector.jsx
@@ -11,7 +11,7 @@ const styles = {
   enabled: {
     backgroundColor: 'white',
     color: color.cyan,
-    border: '2px solid',
+    border: '1px solid',
     borderColor: color.cyan,
     fontFamily: "'Gotham 4r', sans-serif",
     fontSize: '13px'

--- a/apps/test/unit/code-studio/components/pairing/StudentSelectorTest.js
+++ b/apps/test/unit/code-studio/components/pairing/StudentSelectorTest.js
@@ -1,0 +1,42 @@
+import React from 'react';
+import {expect} from '../../../../util/reconfiguredChai';
+import StudentSelector from '@cdo/apps/code-studio/components/pairing/StudentSelector';
+import {shallow} from 'enzyme';
+
+describe('StudentSelector', () => {
+  describe('with more than 4 students selected', () => {
+    const students = [
+      {id: 1, name: 'a'},
+      {id: 2, name: 'b'},
+      {id: 3, name: 'c'},
+      {id: 4, name: 'd'},
+      {id: 5, name: 'e'}
+    ];
+
+    it('displays warning message', () => {
+      const wrapper = shallow(
+        <StudentSelector students={students} handleSubmit={() => {}} />
+      );
+      expect(wrapper.find('p')).to.have.lengthOf(0);
+      wrapper.setState({selectedStudentIds: [1, 2, 3, 4]});
+      expect(wrapper.find('p')).to.have.lengthOf(1);
+    });
+
+    it('disables remaining buttons', () => {
+      const wrapper = shallow(
+        <StudentSelector students={students} handleSubmit={() => {}} />
+      );
+      expect(
+        wrapper.find('button').filterWhere(item => {
+          return item.prop('disabled') === true;
+        })
+      ).to.have.lengthOf(0);
+      wrapper.setState({selectedStudentIds: [1, 2, 3, 4]});
+      expect(
+        wrapper.find('button').filterWhere(item => {
+          return item.prop('disabled') === true;
+        })
+      ).to.have.lengthOf(1);
+    });
+  });
+});

--- a/apps/test/unit/code-studio/components/pairing/StudentSelectorTest.js
+++ b/apps/test/unit/code-studio/components/pairing/StudentSelectorTest.js
@@ -38,5 +38,32 @@ describe('StudentSelector', () => {
         })
       ).to.have.lengthOf(1);
     });
+
+    it('assigns class names to buttons correctly', () => {
+      const wrapper = shallow(
+        <StudentSelector students={students} handleSubmit={() => {}} />
+      );
+      expect(wrapper.find('.selectable')).to.have.lengthOf(5);
+      wrapper.setState({selectedStudentIds: [1, 2, 3]});
+      expect(wrapper.find('.selectable')).to.have.lengthOf(2);
+      expect(wrapper.find('.selected')).to.have.lengthOf(3);
+    });
+
+    it('assigns updated styles to clicked buttons', () => {
+      const wrapper = shallow(
+        <StudentSelector students={students} handleSubmit={() => {}} />
+      );
+      let btnBackground = wrapper
+        .find('button')
+        .at(0)
+        .props().style.backgroundColor;
+      expect(btnBackground).to.equal('white');
+      wrapper.setState({selectedStudentIds: [1]});
+      btnBackground = wrapper
+        .find('button')
+        .at(0)
+        .props().style.backgroundColor;
+      expect(btnBackground).to.equal('#0094ca');
+    });
   });
 });

--- a/dashboard/app/assets/stylesheets/pairing.scss
+++ b/dashboard/app/assets/stylesheets/pairing.scss
@@ -4,7 +4,7 @@
   .student {
     color: $cyan;
     padding: 10px;
-    border: 2px solid $cyan;
+    border: 1px solid $cyan;
     float: left;
     border-radius: 5px;
     margin: 10px 10px 10px 0;

--- a/dashboard/app/assets/stylesheets/pairing.scss
+++ b/dashboard/app/assets/stylesheets/pairing.scss
@@ -8,16 +8,5 @@
     float: left;
     border-radius: 5px;
     margin: 10px 10px 10px 0;
-    &.selectable {
-      cursor: pointer;
-      &:hover {
-        background-color: $lightest_cyan;
-      }
-    }
-
-    &.selected {
-      background-color: $cyan;
-      color: $white;
-    }
   }
 }


### PR DESCRIPTION
These changes limit how many classmates a student can select to pair with in the pair programming dialog to 4.

### Background

Before the changes, students had no limit on the number of other students that they could pair with. Now, students can pair with a maximum of 4 other people. 

Once a student has selected 4 people in the pair programming dialog, the remaining buttons will become disabled and a piece of red text saying "You cannot pair with more than 4 people" will appear. Students can re-enable the buttons by unselecting one of their classmates. After unselecting a button, the red text will disappear. 

Additionally, the students' names were previously contained within clickable divs. They are now rendered as HTML buttons.

## Links

- [jira](https://codedotorg.atlassian.net/browse/LP-1487)

## Testing story

New file created: `StudentSelectorTest.js`. Includes four unit tests that check for the warning message, the correct class names, the various styles, and the disabled prop on buttons.

## Screenshot

<img width="553" alt="Screen Shot 2020-10-01 at 8 22 32 PM" src="https://user-images.githubusercontent.com/17502635/94875963-4d785e80-0424-11eb-90b1-748e3c869210.png">

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
