### PR TITLE
Migrations to create the resource model

### DIFF
--- a/dashboard/app/models/resource.rb
+++ b/dashboard/app/models/resource.rb
@@ -4,11 +4,15 @@
 #
 #  id         :integer          not null, primary key
 #  name       :string(255)
-#  url        :string(255)
-#  embed_slug :string(255)
+#  url        :string(255)      not null
+#  key        :string(255)      not null
 #  properties :string(255)
 #  created_at :datetime         not null
 #  updated_at :datetime         not null
+#
+# Indexes
+#
+#  index_resources_on_key  (key) UNIQUE
 #
 
 class Resource < ApplicationRecord

--- a/dashboard/app/models/resource.rb
+++ b/dashboard/app/models/resource.rb
@@ -15,5 +15,10 @@
 #  index_resources_on_key  (key) UNIQUE
 #
 
+# A Resource represents a link to external material for a lesson
+# #
+# @attr [String] name - The user-visisble name of the resource
+# @attr [String] url - The URL pointing to the resource
+# @attr [String] key - A unique identifier for the resource
 class Resource < ApplicationRecord
 end

--- a/dashboard/app/models/resource.rb
+++ b/dashboard/app/models/resource.rb
@@ -1,0 +1,15 @@
+# == Schema Information
+#
+# Table name: resources
+#
+#  id         :integer          not null, primary key
+#  name       :string(255)
+#  url        :string(255)
+#  embed_slug :string(255)
+#  properties :string(255)
+#  created_at :datetime         not null
+#  updated_at :datetime         not null
+#
+
+class Resource < ApplicationRecord
+end

--- a/dashboard/db/migrate/20200928223748_create_resources.rb
+++ b/dashboard/db/migrate/20200928223748_create_resources.rb
@@ -1,0 +1,12 @@
+class CreateResources < ActiveRecord::Migration[5.0]
+  def change
+    create_table :resources do |t|
+      t.string :name
+      t.string :url
+      t.string :embed_slug
+      t.string :properties
+
+      t.timestamps
+    end
+  end
+end

--- a/dashboard/db/migrate/20200928223748_create_resources.rb
+++ b/dashboard/db/migrate/20200928223748_create_resources.rb
@@ -2,9 +2,11 @@ class CreateResources < ActiveRecord::Migration[5.0]
   def change
     create_table :resources do |t|
       t.string :name
-      t.string :url
-      t.string :embed_slug
+      t.string :url, null: false
+      t.string :key, null: false
       t.string :properties
+
+      t.index :key, unique: true
 
       t.timestamps
     end

--- a/dashboard/db/migrate/20200928224602_create_join_table_lesson_resource.rb
+++ b/dashboard/db/migrate/20200928224602_create_join_table_lesson_resource.rb
@@ -1,0 +1,8 @@
+class CreateJoinTableLessonResource < ActiveRecord::Migration[5.0]
+  def change
+    create_join_table :lessons, :resources do |t|
+      # t.index [:lesson_id, :resource_id]
+      # t.index [:resource_id, :lesson_id]
+    end
+  end
+end

--- a/dashboard/db/migrate/20200928224602_create_join_table_lesson_resource.rb
+++ b/dashboard/db/migrate/20200928224602_create_join_table_lesson_resource.rb
@@ -1,8 +1,8 @@
 class CreateJoinTableLessonResource < ActiveRecord::Migration[5.0]
   def change
     create_join_table :lessons, :resources do |t|
-      # t.index [:lesson_id, :resource_id]
-      # t.index [:resource_id, :lesson_id]
+      t.index [:lesson_id, :resource_id]
+      t.index [:resource_id, :lesson_id]
     end
   end
 end

--- a/dashboard/db/schema.rb
+++ b/dashboard/db/schema.rb
@@ -555,6 +555,8 @@ ActiveRecord::Schema.define(version: 20200928224602) do
   create_table "lessons_resources", id: false, force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci" do |t|
     t.integer "lesson_id",   null: false
     t.integer "resource_id", null: false
+    t.index ["lesson_id", "resource_id"], name: "index_lessons_resources_on_lesson_id_and_resource_id", using: :btree
+    t.index ["resource_id", "lesson_id"], name: "index_lessons_resources_on_resource_id_and_lesson_id", using: :btree
   end
 
   create_table "level_concept_difficulties", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci" do |t|
@@ -1274,11 +1276,12 @@ ActiveRecord::Schema.define(version: 20200928224602) do
 
   create_table "resources", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci" do |t|
     t.string   "name"
-    t.string   "url"
-    t.string   "embed_slug"
+    t.string   "url",        null: false
+    t.string   "key",        null: false
     t.string   "properties"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.index ["key"], name: "index_resources_on_key", unique: true, using: :btree
   end
 
   create_table "school_districts", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci" do |t|

--- a/dashboard/db/schema.rb
+++ b/dashboard/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20200928223748) do
+ActiveRecord::Schema.define(version: 20200928224602) do
 
   create_table "activities", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci" do |t|
     t.integer  "user_id"
@@ -550,6 +550,11 @@ ActiveRecord::Schema.define(version: 20200928223748) do
     t.integer  "position"
     t.text     "properties",  limit: 65535
     t.index ["script_id", "key"], name: "index_lesson_groups_on_script_id_and_key", unique: true, using: :btree
+  end
+
+  create_table "lessons_resources", id: false, force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci" do |t|
+    t.integer "lesson_id",   null: false
+    t.integer "resource_id", null: false
   end
 
   create_table "level_concept_difficulties", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci" do |t|

--- a/dashboard/db/schema.rb
+++ b/dashboard/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20200916194417) do
+ActiveRecord::Schema.define(version: 20200928223748) do
 
   create_table "activities", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci" do |t|
     t.integer  "user_id"
@@ -1265,6 +1265,15 @@ ActiveRecord::Schema.define(version: 20200916194417) do
     t.string  "workshop_days",                    comment: "Days that the workshop will take place"
     t.index ["regional_partner_id"], name: "index_regional_partners_school_districts_on_partner_id", using: :btree
     t.index ["school_district_id"], name: "index_regional_partners_school_districts_on_school_district_id", using: :btree
+  end
+
+  create_table "resources", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci" do |t|
+    t.string   "name"
+    t.string   "url"
+    t.string   "embed_slug"
+    t.string   "properties"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
   end
 
   create_table "school_districts", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci" do |t|

--- a/dashboard/test/factories/factories.rb
+++ b/dashboard/test/factories/factories.rb
@@ -796,6 +796,10 @@ FactoryGirl.define do
     end
   end
 
+  factory :resource do
+    url 'fake.url'
+  end
+
   factory :callout do
     sequence(:element_id) {|n| "#pageElement#{n}"}
     localization_key 'drag_blocks'

--- a/dashboard/test/models/resource_test.rb
+++ b/dashboard/test/models/resource_test.rb
@@ -1,0 +1,7 @@
+require 'test_helper'
+
+class ResourceTest < ActiveSupport::TestCase
+  # test "the truth" do
+  #   assert true
+  # end
+end

--- a/dashboard/test/models/resource_test.rb
+++ b/dashboard/test/models/resource_test.rb
@@ -1,7 +1,8 @@
 require 'test_helper'
 
 class ResourceTest < ActiveSupport::TestCase
-  # test "the truth" do
-  #   assert true
-  # end
+  test "can create resource" do
+    resource = create :resource, key: 'my key'
+    assert_equal 'my key', resource.key
+  end
 end


### PR DESCRIPTION
This PR adds the first two migrations to create the resource model:
- efe56a7 is the output of running `rails generate model Resource name:string url:string embed_slug:string properties:string`, along with the corresponding schema change
- 215cda6 is the output of running `rails g migration CreateJoinTableLessonResource lessons resources`, along with the corresponding schema change

The fields were pulled from section 6 in the [spec](https://docs.google.com/document/d/1LVwA7VtxkkIFZSi7StwAtgHfxFUIAN1E3nbDRjEXWP4/edit#). The ones that aren't part of the table will be put in `properties`. 

Let me know if I should break these two commits into separate PRs. I added the model file because the `rails generate model` created it but I could remove that if there are any concerns.

- [jira](https://codedotorg.atlassian.net/browse/PLAT-298)

## Testing story

I ran the migration locally.

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
