### PR TITLE
Protected Projects, UI tests skip IE to unblock pipeline 

### DIFF
--- a/dashboard/test/ui/features/learning_platform/projects/prevent_report_abuse_spam.feature
+++ b/dashboard/test/ui/features/learning_platform/projects/prevent_report_abuse_spam.feature
@@ -62,6 +62,7 @@ Scenario: Report Abuse link hidden if the user already reported Game Lab project
   And element ".ui-test-how-it-works" is visible
   And element ".ui-test-report-abuse" is not visible
 
+@no_ie
 Scenario: Abuse reports block a project for other viewers
   Given I create a student named "Creator"
   And I make a "applab" project named "Regular Project"
@@ -92,6 +93,7 @@ Scenario: Abuse reports block a project for other viewers
   And I navigate to the last shared URL
   And I wait until element ".exclamation-abuse" is visible
 
+@no_ie
 Scenario: Projects made by project validators are protected from abuse reports
   Given I create a teacher named "Project Validator"
   And I give user "Project Validator" project validator permission


### PR DESCRIPTION
Follow up to #36909  I'll dig into diagnosing why these new tests were failing on IE. 