### PR TITLE
Significantly reducing the number of accounts scanned when purging old accounts

### DIFF
--- a/dashboard/lib/expired_deleted_account_purger.rb
+++ b/dashboard/lib/expired_deleted_account_purger.rb
@@ -34,8 +34,8 @@ class ExpiredDeletedAccountPurger
     raise ArgumentError.new('dry_run must be boolean') unless [true, false].include? @dry_run
 
     # Only purge accounts soft-deleted after this date.
-    # The default is when we released the updated messaging about hard-deletes.
-    @deleted_after = options[:deleted_after] || Time.parse('2018-07-31 4:18pm PDT')
+    # The default is 60 days ago.
+    @deleted_after = options[:deleted_after] || 60.days.ago
     raise ArgumentError.new('deleted_after must be Time') unless @deleted_after.is_a? Time
 
     # Only purge accounts soft-deleted this long ago.

--- a/dashboard/test/lib/expired_deleted_account_purger_test.rb
+++ b/dashboard/test/lib/expired_deleted_account_purger_test.rb
@@ -34,7 +34,7 @@ class ExpiredDeletedAccountPurgerTest < ActiveSupport::TestCase
   test 'can construct with no arguments - all defaults' do
     edap = ExpiredDeletedAccountPurger.new
     assert_equal false, edap.dry_run?
-    assert_equal Time.parse('2018-07-31 4:18pm PDT'), edap.deleted_after
+    assert_equal 60.days.ago, edap.deleted_after
     assert_equal 28.days.ago, edap.deleted_before
     assert_equal 200, edap.max_teachers_to_purge
     assert_equal 4000, edap.max_accounts_to_purge


### PR DESCRIPTION
**Bug** - The daily cron job which purges accounts that were soft-deleted 28 days ago recently started [timing out](https://codedotorg.slack.com/archives/C6B838SB0/p1601107368000600) because it is taking longer than 30 seconds when making a SQL query.
**Cause** - *ExpiredDeletedAccountPurger* scans all deleted accounts since 2018. This is a large number of accounts and a waste of processing time because we are purging accounts daily.
**Fix** - Update the account purger to only look for soft-deleted accounts up to 60 days ago. This gives us 30 days to fix any issues.

## Links
- [slack error message](https://codedotorg.slack.com/archives/C6B838SB0/p1601107368000600)

## Testing story
Updated unit test.

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
