### PR TITLE
Revert "add afe france link to banner"

### DIFF
--- a/pegasus/cache/i18n/en-US.yml
+++ b/pegasus/cache/i18n/en-US.yml
@@ -1675,7 +1675,6 @@
   hoc2018_dance_amazon_sponsor_section_with_logo_title: "In partnership with"
   hoc2018_dance_amazon_sponsor_section_with_logo_description_with_link: "Amazon Future Engineer* is a comprehensive childhood-to-career program to inspire, educate, and train low-income and other disadvantaged children and young people to pursue careers in computer science. <a href='%{amazon_future_engineer_link}' target='_blank'>Learn more</a>"
   hoc2018_dance_amazon_sponsor_section_with_logo_description_with_link_markdown: "Amazon Future Engineer* is a comprehensive childhood-to-career program to inspire, educate, and train low-income and other disadvantaged children and young people to pursue careers in computer science. [Learn more](%{amazon_future_engineer_link})"
-  hoc2018_dance_amazon_sponsor_section_france_link_markdown: "If you are a student or teacher in France, visit [Amazon Future Engineer - France](%{amazon_future_engineer_france_link})"
   hoc2018_dance_amazon_learn_more_future_engineer_subheading_title: "Learn more about Amazon Future Engineer"
   hoc2018_dance_amazon_about_future_engineer_title: "About Amazon Future Engineer"
   hoc2018_dance_amazon_about_future_engineer_description: "Learn about Amazon’s kindergarten to career program to increase access to computer science education. Find information on how to get involved in our summer camps, high school CS classes, scholarships, and internships."

--- a/pegasus/cache/i18n/fr-FR.yml
+++ b/pegasus/cache/i18n/fr-FR.yml
@@ -2454,9 +2454,6 @@ fr-FR:
     de l’informatique. Ce programme sera destiné aux enfants défavorisés du primaire
     au supérieur avec une attention toute particulière pour les jeunes filles. [Learn
     more](%{amazon_future_engineer_link})
-  hoc2018_dance_amazon_sponsor_section_france_link_markdown: 
-    Si on est professeur ou élève française, visite [Amazon Future Engineer - 
-    France](%{amazon_future_engineer_france_link})
   hoc2018_dance_amazon_learn_more_future_engineer_subheading_title: Pour en savoir
     plus sur Amazon Future Engineer
   hoc2018_dance_amazon_about_future_engineer_title: À propos d'Amazon Future Engineer

--- a/pegasus/sites.v3/code.org/views/dance_sponsor_logo.haml
+++ b/pegasus/sites.v3/code.org/views/dance_sponsor_logo.haml
@@ -23,8 +23,6 @@
   .full-resource-block{style: "margin-top: 20px;"}
     %a{href: afe_link, target: "_blank"}
       %img.full-resource-image{src: "/images/AFE-person-2019.jpg"}
-    .tutorial-info{style: "padding: 25px;"}
+    .tutorial-info{style: "padding: 30px;"}
       %span
         != I18n.t(:hoc2018_dance_amazon_sponsor_section_with_logo_description_with_link_markdown, markdown: :inline, amazon_future_engineer_link: afe_link)
-      %span
-        != I18n.t(:hoc2018_dance_amazon_sponsor_section_france_link_markdown, markdown: :inline, amazon_future_engineer_france_link: 'https://www.amazonfutureengineer.fr')


### PR DESCRIPTION
Since #36886 worked to detect user's location (see screenshot), this reverts commit 34f9d0aa2fb26ec417c9afd2a8b9cae249d51f62 and removes the extra AFE-France link in the banner.
![image](https://user-images.githubusercontent.com/2933346/94534873-c2198600-01f5-11eb-82e8-e22043e9d922.png)

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
