### PR TITLE
End Workshop Panel: Remove references to survey

### DIFF
--- a/apps/src/code-studio/pd/workshop_dashboard/EndWorkshopPanel.jsx
+++ b/apps/src/code-studio/pd/workshop_dashboard/EndWorkshopPanel.jsx
@@ -14,20 +14,16 @@ const warningStyle = {
 const earlyCloseWarning = (
   <div>
     <span style={warningStyle}>Warning: </span>There are still sessions
-    remaining for this workshop. Once you end a workshop:
-    <ul>
-      <li>The post-workshop survey is automatically sent to attendees.</li>
-      <li>Surveys can’t be unsent and will not be resent.</li>
-      <li>Attendance is locked.</li>
-    </ul>
+    remaining for this workshop. Once you end a workshop, attendance is locked.
+    <br />
+    <br />
     Are you sure you want to end this workshop now?
   </div>
 );
 
 const normalCloseWarning = (
   <div>
-    Ending this workshop will close the attendance and send the end of workshop
-    survey to participants.
+    Ending this workshop will close the attendance.
     <br />
     <br />
     Are you sure you want to end this workshop now?
@@ -90,20 +86,14 @@ export default class EndWorkshopPanel extends React.Component {
     return (
       <WorkshopPanel header="End Workshop:">
         <div>
-          <p>
-            After the last day of your workshop, you must end the workshop. This
-            will generate a report to Code.org as well as email teachers a
-            survey regarding the workshop.
-          </p>
-          <Button onClick={this.handleEndWorkshopClick}>
-            End Workshop and Send Survey
-          </Button>
+          <p>After the last day of your workshop, you must end the workshop.</p>
+          <Button onClick={this.handleEndWorkshopClick}>End Workshop</Button>
           <ConfirmationDialog
             show={this.state.showEndWorkshopConfirmation}
             onOk={this.handleEndWorkshopConfirmed}
             okText={'Yes, end this workshop'}
             onCancel={this.handleEndWorkshopCancel}
-            headerText="End workshop and send survey"
+            headerText="End workshop"
             bodyText={isReadyToClose ? normalCloseWarning : earlyCloseWarning}
             width={isReadyToClose ? 500 : 800}
           />

--- a/apps/test/unit/code-studio/pd/workshop_dashboard/EndWorkshopPanelTest.jsx
+++ b/apps/test/unit/code-studio/pd/workshop_dashboard/EndWorkshopPanelTest.jsx
@@ -47,7 +47,7 @@ describe('EndWorkshopPanel', () => {
     );
 
     // Click the 'End workshop' button to display the confirmation dialog
-    clickButton(wrapper, 'End Workshop and Send Survey');
+    clickButton(wrapper, 'End Workshop');
     assertDialogIsShowing(wrapper);
 
     // Simulate clicking the 'Cancel' button to close the confirmation dialog
@@ -67,7 +67,7 @@ describe('EndWorkshopPanel', () => {
     server.respondWith('POST', `/api/v1/pd/workshops/1/end`, [204, {}, '']);
 
     // Click the 'End workshop' button to display the confirmation dialog
-    clickButton(wrapper, 'End Workshop and Send Survey');
+    clickButton(wrapper, 'End Workshop');
     assertDialogIsShowing(wrapper);
 
     // Simulate clicking the 'Confirm' button to close the workshop


### PR DESCRIPTION
[PLC-1010](https://codedotorg.atlassian.net/browse/PLC-1010)
Workshops now do not always automatically send surveys due to complications with academic year workshops. Update the end workshop panel and popup to remove references to automatically sending surveys.
New panel language:
![Screen Shot 2020-09-29 at 12 57 57 PM](https://user-images.githubusercontent.com/33666587/94609609-e441f100-0253-11eb-9090-bfb65b69e68e.png)

Popup if there are sessions remaining in the workshop:
![Screen Shot 2020-09-29 at 12 58 11 PM](https://user-images.githubusercontent.com/33666587/94609621-e60bb480-0253-11eb-9038-79463ffaf1a7.png)

Popup if there are no more sessions remaining in the workshop:

![Screen Shot 2020-09-29 at 12 58 30 PM](https://user-images.githubusercontent.com/33666587/94609634-ea37d200-0253-11eb-890f-e61ab2a45e97.png)


<!-- ### Background -->
<!-- ### Privacy -->
<!-- ### Security -->
<!-- ### Caching -->
<!-- ### Deployment strategy -->
<!-- ### Future work -->

## Links

- [jira](https://codedotorg.atlassian.net/browse/PLC-1010)

## Testing story
Tested locally.

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
