### PR TITLE
Fix Contained Levels Eyes Feature

### DIFF
--- a/dashboard/test/ui/features/learning_platform/level_types/contained_levels.feature
+++ b/dashboard/test/ui/features/learning_platform/level_types/contained_levels.feature
@@ -30,7 +30,7 @@ Scenario: Applab with free response contained level
   Then I close my eyes
 
 Scenario: GameLab with a submittable contained level
-  When I open my eyes to test "gamelab contained level"
+  When I open my eyes to test "gamelab submittable contained level"
   Given I am on "http://studio.code.org/s/allthethings/stage/41/puzzle/7"
   And I rotate to landscape
   And I wait for the page to fully load
@@ -45,7 +45,7 @@ Scenario: GameLab with a submittable contained level
   Then I close my eyes
 
 Scenario: Gamelab with multiple choice contained level
-  When I open my eyes to test "gamelab contained level"
+  When I open my eyes to test "gamelab multiple choice contained level"
   Given I am on "http://studio.code.org/s/allthethings/stage/41/puzzle/2"
   And I rotate to landscape
   And I wait for the page to fully load


### PR DESCRIPTION
A fix #36416 to close Eyes at end of a Scenario uncovered a problem where two different Scenarios were using the same Eyes test name, causing the image checkpoints within those 2 Scenarios to potentially overwrite or conflict with each other.

<!-- ### Background -->
<!-- ### Privacy -->
<!-- ### Security -->
<!-- ### Caching -->
<!-- ### Deployment strategy -->
<!-- ### Future work -->

## Links

<!--
  Any relevant links to external resources; ie, specification documents, jira
  items, related PRs, honeybadger errors, etc
-->

- [spec]()
- [jira]()

## Testing story

<!--
  Does your change include appropriate tests?

  If so, please describe how the tests included in this PR are sufficient

  If not, please explain why this change does not need to be tested.
-->

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
