### PR TITLE
remove unused sass-rails gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -137,10 +137,6 @@ gem 'unicorn', '~> 5.1.0'
 
 gem 'chronic', '~> 0.10.2'
 
-# Use SCSS for stylesheets.
-# Ref: https://github.com/rails/sass-rails/pull/386
-gem 'sass-rails', github: 'wjordan/sass-rails', ref: 'frozen-array-fix'
-
 # Use Uglifier as compressor for JavaScript assets.
 gem 'uglifier', '>= 1.3.0'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -163,18 +163,6 @@ GIT
     puma (3.12.0)
 
 GIT
-  remote: https://github.com/wjordan/sass-rails.git
-  revision: 06e833d92d083fbcb137364ffebc597b2577db23
-  ref: frozen-array-fix
-  specs:
-    sass-rails (5.0.6)
-      railties (>= 4.0.0, < 6)
-      sass (~> 3.1)
-      sprockets (>= 2.8, < 4.0)
-      sprockets-rails (>= 2.0, < 4.0)
-      tilt (>= 1.1, < 3)
-
-GIT
   remote: https://github.com/wjordan/seamless_database_pool.git
   revision: c9a5c2bc92efc1f87a2aa065283e15283dbb9425
   ref: cdo
@@ -1034,7 +1022,6 @@ DEPENDENCIES
   ruby-prof
   ruby-progressbar
   ruby_dep (~> 1.3.1)
-  sass-rails!
   scenic
   scenic-mysql_adapter
   scss_lint


### PR DESCRIPTION
According to [the gem's README](https://github.com/rails/sass-rails#installing), the version of rails we're on is already configured to use sass. Also, I don't think we're actually using sass anywhere; we primarily use scss.

## Testing story

Relying on existing unit tests.

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
