### PR TITLE
Add lesson/resource association and resource properties

### DIFF
--- a/dashboard/app/models/lesson.rb
+++ b/dashboard/app/models/lesson.rb
@@ -35,6 +35,7 @@ class Lesson < ActiveRecord::Base
   has_many :lesson_activities, -> {order(:position)}, dependent: :destroy
   has_many :script_levels, -> {order(:chapter)}, foreign_key: 'stage_id', dependent: :destroy
   has_many :levels, through: :script_levels
+  has_and_belongs_to_many :resources, join_table: :lessons_resources
 
   has_one :plc_learning_module, class_name: 'Plc::LearningModule', inverse_of: :lesson, foreign_key: 'stage_id', dependent: :destroy
   has_and_belongs_to_many :standards, foreign_key: 'stage_id'

--- a/dashboard/app/models/resource.rb
+++ b/dashboard/app/models/resource.rb
@@ -16,7 +16,10 @@
 #
 
 # A Resource represents a link to external material for a lesson
-# #
+#
+# @attr [String] name - The user-visisble name of the resource
+# @attr [String] url - The URL pointing to the resource
+# @attr [String] key - A unique identifier for the resource
 # @attr [String] type - type of resource (eg video, handout, etc)
 # @attr [Boolean] assessment - indicates whether this resource is an assessment
 # @attr [String] audience - who this resource is targeted toward (eg teacher, student, etc)

--- a/dashboard/app/models/resource.rb
+++ b/dashboard/app/models/resource.rb
@@ -21,4 +21,5 @@
 # @attr [String] url - The URL pointing to the resource
 # @attr [String] key - A unique identifier for the resource
 class Resource < ApplicationRecord
+  has_and_belongs_to_many :lessons, join_table: :lessons_resources
 end

--- a/dashboard/app/models/resource.rb
+++ b/dashboard/app/models/resource.rb
@@ -17,9 +17,21 @@
 
 # A Resource represents a link to external material for a lesson
 # #
-# @attr [String] name - The user-visisble name of the resource
-# @attr [String] url - The URL pointing to the resource
-# @attr [String] key - A unique identifier for the resource
+# @attr [String] type - type of resource (eg video, handout, etc)
+# @attr [Boolean] assessment - indicates whether this resource is an assessment
+# @attr [String] audience - who this resource is targeted toward (eg teacher, student, etc)
+# @attr [String] download_url - URL that can download the file
+# @attr [Boolean] printable_student_handout - indicates whether the file will be included in a PDF handout
 class Resource < ApplicationRecord
+  include SerializedProperties
+
   has_and_belongs_to_many :lessons, join_table: :lessons_resources
+
+  serialized_attrs %(
+    type
+    assessment
+    audience
+    download_url
+    printable_student_handout
+  )
 end

--- a/dashboard/test/factories/factories.rb
+++ b/dashboard/test/factories/factories.rb
@@ -784,7 +784,6 @@ FactoryGirl.define do
     sequence(:name) {|n| "Bogus Lesson #{n}"}
     sequence(:key) {|n| "Bogus-Lesson-#{n}"}
     script
-    resources {[create(:resource)]}
 
     absolute_position do |lesson|
       (lesson.script.lessons.maximum(:absolute_position) || 0) + 1
@@ -799,6 +798,7 @@ FactoryGirl.define do
 
   factory :resource do
     url 'fake.url'
+    key 'fake key'
   end
 
   factory :callout do

--- a/dashboard/test/factories/factories.rb
+++ b/dashboard/test/factories/factories.rb
@@ -798,7 +798,7 @@ FactoryGirl.define do
 
   factory :resource do
     url 'fake.url'
-    key 'fake key'
+    sequence(:key) {|n| "key-#{n}"}
   end
 
   factory :callout do

--- a/dashboard/test/factories/factories.rb
+++ b/dashboard/test/factories/factories.rb
@@ -784,6 +784,7 @@ FactoryGirl.define do
     sequence(:name) {|n| "Bogus Lesson #{n}"}
     sequence(:key) {|n| "Bogus-Lesson-#{n}"}
     script
+    resources {[create(:resource)]}
 
     absolute_position do |lesson|
       (lesson.script.lessons.maximum(:absolute_position) || 0) + 1

--- a/dashboard/test/models/resource_test.rb
+++ b/dashboard/test/models/resource_test.rb
@@ -6,10 +6,17 @@ class ResourceTest < ActiveSupport::TestCase
     assert_equal 'my key', resource.key
   end
 
-  test "resource can belong to lessons" do
-    resource = create :resource, key: 'my key'
+  test "resource can be in multiple lessons" do
+    resource = create :resource
     lesson1 = create :lesson, resources: [resource]
     lesson2 = create :lesson, resources: [resource]
     assert_equal [lesson1, lesson2], resource.lessons
+  end
+
+  test "multiple resources can be in a lesson" do
+    lesson = create :lesson
+    resource1 = create :resource, lessons: [lesson]
+    resource2 = create :resource, lessons: [lesson]
+    assert_equal [resource1, resource2], lesson.resources
   end
 end

--- a/dashboard/test/models/resource_test.rb
+++ b/dashboard/test/models/resource_test.rb
@@ -5,4 +5,11 @@ class ResourceTest < ActiveSupport::TestCase
     resource = create :resource, key: 'my key'
     assert_equal 'my key', resource.key
   end
+
+  test "resource can belong to lessons" do
+    resource = create :resource, key: 'my key'
+    lesson1 = create :lesson, resources: [resource]
+    lesson2 = create :lesson, resources: [resource]
+    assert_equal [lesson1, lesson2], resource.lessons
+  end
 end


### PR DESCRIPTION
The join table for this was merged in #36949, so this just adds the association in the models. I also added the rest of the properties for resources and fixed the YARD docs.

<!-- ### Background -->
<!-- ### Privacy -->
<!-- ### Security -->
<!-- ### Caching -->
<!-- ### Deployment strategy -->
<!-- ### Future work -->

## Links

<!--
  Any relevant links to external resources; ie, specification documents, jira
  items, related PRs, honeybadger errors, etc
-->

- [spec]()
- [jira]()

## Testing story

<!--
  Does your change include appropriate tests?

  If so, please describe how the tests included in this PR are sufficient

  If not, please explain why this change does not need to be tested.
-->

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
