### PR TITLE
Auto-validation checkbox in level builder

### DIFF
--- a/apps/Gruntfile.js
+++ b/apps/Gruntfile.js
@@ -594,6 +594,8 @@ describe('entry tests', () => {
       './src/sites/studio/pages/levels/editors/fields/_preload_assets.js',
     'levels/editors/fields/_special_level_types':
       './src/sites/studio/pages/levels/editors/fields/_special_level_types.js',
+    'levels/editors/fields/_validation_code':
+      './src/sites/studio/pages/levels/editors/fields/_validation_code.js',
     'levels/editors/fields/_video':
       './src/sites/studio/pages/levels/editors/fields/_video.js',
     'levels/editors/_gamelab':

--- a/apps/src/applab/applab.js
+++ b/apps/src/applab/applab.js
@@ -683,6 +683,7 @@ Applab.init = function(config) {
       !!config.level.isProjectLevel || config.level.showDebugWatch,
     showMakerToggle:
       !!config.level.isProjectLevel || config.level.makerlabEnabled,
+    validationEnabled: !!config.level.validationEnabled,
     widgetMode: config.level.widgetMode
   });
 

--- a/apps/src/p5lab/P5Lab.js
+++ b/apps/src/p5lab/P5Lab.js
@@ -440,7 +440,8 @@ P5Lab.prototype.init = function(config) {
     isProjectLevel: !!config.level.isProjectLevel,
     isSubmittable: !!config.level.submittable,
     isSubmitted: !!config.level.submitted,
-    librariesEnabled: !!config.level.librariesEnabled
+    librariesEnabled: !!config.level.librariesEnabled,
+    validationEnabled: !!config.level.validationEnabled
   });
 
   if (startInAnimationTab(getStore().getState())) {

--- a/apps/src/p5lab/gamelab/GameLab.js
+++ b/apps/src/p5lab/gamelab/GameLab.js
@@ -21,6 +21,11 @@ GameLab.prototype.init = function(config) {
     }));
   }
 
+  // Push initial level properties into the Redux store
+  this.studioApp_.setPageConstants(config, {
+    validationEnabled: !!config.level.validationEnabled
+  });
+
   return P5Lab.prototype.init.call(this, config);
 };
 

--- a/apps/src/p5lab/gamelab/GameLab.js
+++ b/apps/src/p5lab/gamelab/GameLab.js
@@ -21,11 +21,6 @@ GameLab.prototype.init = function(config) {
     }));
   }
 
-  // Push initial level properties into the Redux store
-  this.studioApp_.setPageConstants(config, {
-    validationEnabled: !!config.level.validationEnabled
-  });
-
   return P5Lab.prototype.init.call(this, config);
 };
 

--- a/apps/src/redux/pageConstants.js
+++ b/apps/src/redux/pageConstants.js
@@ -69,7 +69,8 @@ var ALLOWED_KEYS = new Set([
   'expoCancelApkBuild',
   'allowExportExpo',
   'widgetMode',
-  'librariesEnabled'
+  'librariesEnabled',
+  'validationEnabled'
 ]);
 
 const initialState = {

--- a/apps/src/sites/studio/pages/levels/editors/fields/_validation_code.js
+++ b/apps/src/sites/studio/pages/levels/editors/fields/_validation_code.js
@@ -6,16 +6,17 @@ function initPage() {
   const freePlay = $('#level_free_play');
   const autoValidate = $('#level_validation_enabled');
   if (freePlay && autoValidate) {
-    freePlay.on('click', () => enforceMutualExclusion(freePlay, autoValidate));
-    autoValidate.on('click', () =>
-      enforceMutualExclusion(autoValidate, freePlay)
-    );
-
-    enforceMutualExclusion(freePlay, autoValidate);
-    enforceMutualExclusion(autoValidate, freePlay);
+    freePlay.on('click', syncWithValidate);
+    if (!freePlay.prop('checked')) {
+      syncWithValidate();
+    }
   }
 }
 
-function enforceMutualExclusion(clicked, other) {
-  other.prop('disabled', clicked.prop('checked'));
+function syncWithValidate() {
+  const freePlay = $('#level_free_play');
+  const autoValidate = $('#level_validation_enabled');
+  const checked = freePlay.prop('checked');
+  autoValidate.prop('checked', checked);
+  autoValidate.prop('disabled', !checked);
 }

--- a/apps/src/sites/studio/pages/levels/editors/fields/_validation_code.js
+++ b/apps/src/sites/studio/pages/levels/editors/fields/_validation_code.js
@@ -1,0 +1,21 @@
+import $ from 'jquery';
+
+$(initPage);
+
+function initPage() {
+  const freePlay = $('#level_free_play');
+  const autoValidate = $('#level_validation_enabled');
+  if (freePlay && autoValidate) {
+    freePlay.on('click', () => enforceMutualExclusion(freePlay, autoValidate));
+    autoValidate.on('click', () =>
+      enforceMutualExclusion(autoValidate, freePlay)
+    );
+
+    enforceMutualExclusion(freePlay, autoValidate);
+    enforceMutualExclusion(autoValidate, freePlay);
+  }
+}
+
+function enforceMutualExclusion(clicked, other) {
+  other.prop('disabled', clicked.prop('checked'));
+}

--- a/apps/src/turtle/artist.js
+++ b/apps/src/turtle/artist.js
@@ -334,6 +334,7 @@ Artist.prototype.init = function(config) {
     appSpecificConstants.smallStaticAvatar = config.skin.blankAvatar;
     appSpecificConstants.failureAvatar = config.skin.blankAvatar;
   }
+  appSpecificConstants.validationEnabled = !!config.level.validationEnabled;
   this.studioApp_.setPageConstants(config, appSpecificConstants);
 
   var iconPath =

--- a/apps/src/weblab/WebLab.js
+++ b/apps/src/weblab/WebLab.js
@@ -189,7 +189,8 @@ WebLab.prototype.init = function(config) {
     documentationUrl: 'https://studio.code.org/docs/weblab/',
     isProjectLevel: !!config.level.isProjectLevel,
     isSubmittable: !!config.level.submittable,
-    isSubmitted: !!config.level.submitted
+    isSubmitted: !!config.level.submitted,
+    validationEnabled: !!config.level.validationEnabled
   });
 
   this.readOnly = config.readonlyWorkspace;

--- a/apps/style/code-studio/levelbuilder.scss
+++ b/apps/style/code-studio/levelbuilder.scss
@@ -183,6 +183,11 @@ table.checkboxes {
   label {
     padding-left: 1%;
   }
+
+  input:disabled ~ label {
+    cursor: not-allowed;
+    color: #6c757d;
+  }
 }
 .collapsed_area_header{
   font-size: 1.5em;

--- a/dashboard/app/models/levels/applab.rb
+++ b/dashboard/app/models/levels/applab.rb
@@ -55,6 +55,7 @@ class Applab < Blockly
     starter_assets
     start_libraries
     libraries_enabled
+    validation_enabled
   )
 
   # List of possible skins, the first is used as a default.

--- a/dashboard/app/models/levels/artist.rb
+++ b/dashboard/app/models/levels/artist.rb
@@ -37,6 +37,7 @@ class Artist < Blockly
     disable_sharing
     solution_image_url
     auto_run
+    validation_enabled
   )
 
   def xml_blocks

--- a/dashboard/app/models/levels/gamelab.rb
+++ b/dashboard/app/models/levels/gamelab.rb
@@ -48,6 +48,7 @@ class Gamelab < Blockly
     helper_libraries
     start_libraries
     libraries_enabled
+    validation_enabled
   )
 
   # List of possible skins, the first is used as a default.

--- a/dashboard/app/models/levels/weblab.rb
+++ b/dashboard/app/models/levels/weblab.rb
@@ -33,6 +33,7 @@ class Weblab < Level
     is_project_level
     encrypted_examples
     submittable
+    validation_enabled
   )
 
   def self.create_from_level_builder(params, level_params)

--- a/dashboard/app/views/levels/editors/fields/_auto_validation_checkbox.html.haml
+++ b/dashboard/app/views/levels/editors/fields/_auto_validation_checkbox.html.haml
@@ -1,0 +1,7 @@
+= render partial: 'levels/editors/fields/checkboxes',
+  locals: {f: f, field_name: :validation_enabled,
+  description: "Code must change for the level to be show as 'complete'"}
+%p
+  If this setting is checked, students must change code on the level,
+  run that code, and hit 'Finish' before the level can be marked as complete.
+  If this box is unchecked, hitting 'Finish' will mark the level as complete.

--- a/dashboard/app/views/levels/editors/fields/_code_area.html.haml
+++ b/dashboard/app/views/levels/editors/fields/_code_area.html.haml
@@ -7,4 +7,4 @@
   = render partial: 'levels/editors/fields/weblab_code_area', locals: {f: f} if @level.is_a?(Weblab)
   = render partial: 'levels/editors/fields/block_pools', locals: {f: f} if @level.is_a?(GamelabJr) || @level.is_a?(Dancelab)
   = render partial: 'levels/editors/fields/helper_libraries', locals: {f: f} if @level.is_a?(GamelabJr) || @level.is_a?(Dancelab)
-  = render partial: 'levels/editors/fields/validation_code', locals: {f: f} unless @level.is_a?(Weblab)
+  = render partial: 'levels/editors/fields/validation_code', locals: {f: f}

--- a/dashboard/app/views/levels/editors/fields/_special_level_types.html.haml
+++ b/dashboard/app/views/levels/editors/fields/_special_level_types.html.haml
@@ -15,10 +15,6 @@
       it).
   - if @level.respond_to? :free_play
     .field
-      = render partial: 'levels/editors/fields/checkboxes', locals: {f: f, field_name: :free_play, description: "Free Play"}
-      %p Free Play levels are not checked for correctness (any solution is accepted), can be shared, and can be saved to the public and private gallery
-
-    .field
       = render partial: 'levels/editors/fields/checkboxes', locals: {f: f, field_name: :embed, description: "Embed"}
       %p Embedded levels hide the Blockly workspace, only showing the visualization area (and the 'finish' button, if 'freeplay' is also set).
 

--- a/dashboard/app/views/levels/editors/fields/_validation_code.html.haml
+++ b/dashboard/app/views/levels/editors/fields/_validation_code.html.haml
@@ -16,3 +16,7 @@
 
   = render partial: 'levels/editors/fields/applab_validations', locals: {f: f} if @level.is_a?(Applab)
   = render partial: 'levels/editors/fields/studio_validations', locals: {f: f} if @level.is_a?(Studio) || @level.is_a?(Bounce) || @level.is_a?(Flappy)
+
+  - if (defined?(@level.validation_enabled))
+    = render partial: 'levels/editors/fields/checkboxes', locals: {f: f, field_name: :validation_enabled, description: "Enable Basic Validation"}
+

--- a/dashboard/app/views/levels/editors/fields/_validation_code.html.haml
+++ b/dashboard/app/views/levels/editors/fields/_validation_code.html.haml
@@ -1,3 +1,6 @@
+- content_for :body_scripts do
+  %script{src: webpack_asset_path('js/levels/editors/fields/_validation_code.js')}
+
 %h1.control-legend{data: {toggle: "collapse", target: "#validation"}}
   Validation
 
@@ -17,6 +20,22 @@
   = render partial: 'levels/editors/fields/applab_validations', locals: {f: f} if @level.is_a?(Applab)
   = render partial: 'levels/editors/fields/studio_validations', locals: {f: f} if @level.is_a?(Studio) || @level.is_a?(Bounce) || @level.is_a?(Flappy)
 
-  - if (defined?(@level.validation_enabled))
-    = render partial: 'levels/editors/fields/checkboxes', locals: {f: f, field_name: :validation_enabled, description: "Enable Basic Validation"}
+  - if @level.respond_to? :free_play
+    .field
+      = render partial: 'levels/editors/fields/checkboxes',
+        locals: {f: f, field_name: :free_play, description: "Free Play"}
+      %p
+        Free Play levels are not checked for correctness (any solution is
+        accepted), can be shared, and can be saved to the public and private
+        gallery
+  - if @level.respond_to? :validation_enabled
+    .field
+      = render partial: 'levels/editors/fields/checkboxes',
+        locals: {f: f, field_name: :validation_enabled,
+        description: "Code must change for the level to be show as 'complete"}
+      %p
+        If this setting is checked, students must change code on the level,
+        run that code, and hit 'Finish' before the level can be marked as
+        complete. If this box is unchecked, hitting 'Finish' will mark the
+        level as complete.
 


### PR DESCRIPTION
this is preliminary work in the auto-validation epic. it adds a checkbox in level builder to enable auto-validation for game lab, app lab, artist lab, and web lab, and adds the `autoValidation` property to page constants in redux for those level types.

<!--
  Other aspects to consider. uncomment and add detail for any that seem necessary:
-->

<!-- ### Background -->
<!-- ### Privacy -->
<!--
1.	Does the Project involve the collection, use or sharing of new Personal Data?

2.	Does the Project involve a new or changed use or sharing of existing Personal Data?
-->
<!-- ### Security -->
<!--
Link to Jira Task where sensitive security issues are discussed privately.
-->
<!-- ### Caching -->
<!-- ### Deployment strategy -->
<!-- ### Future work -->

## Links

<!--
  Any relevant links to external resources; ie, specification documents, jira
  items, related PRs, honeybadger errors, etc
-->

- [spec](https://docs.google.com/document/d/1hF-wvav0MXLnH49x0WBeO8TcUibMaCUegZiDr8-6l-c/edit#)
- jira: [LP-1546]

[LP-1546]: https://codedotorg.atlassian.net/browse/LP-1546