### PR TITLE
Extract and translate placeholder texts

### DIFF
--- a/bin/i18n/sync-in.rb
+++ b/bin/i18n/sync-in.rb
@@ -98,6 +98,19 @@ def get_i18n_strings(level)
         name = behavior.at_xpath('./title[@name="NAME"]')
         i18n_strings['behavior_names'][name.content] = name.content if name
       end
+
+      text_blocks = blocks.xpath("//block[@type=\"text\"]")
+      i18n_strings['placeholder_texts'] = Hash.new unless text_blocks.empty?
+      text_blocks.each do |text_block|
+        text_title = text_block.at_xpath('./title[@name="TEXT"]')
+        # Skip empty or untranslatable string.
+        # A translatable string must have at least 3 consecutive alphabetic characters.
+        next unless text_title&.content =~ /[a-zA-Z]{3,}/
+
+        # Use only alphanumeric characters in lower cases as string key
+        text_key = text_title.content.gsub(/[^a-zA-Z0-9_ ]/, '').split.join('_').downcase
+        i18n_strings['placeholder_texts'][text_key] = text_title.content
+      end
     end
   end
 

--- a/bin/i18n/sync-in.rb
+++ b/bin/i18n/sync-in.rb
@@ -8,6 +8,7 @@
 require File.expand_path('../../../dashboard/config/environment', __FILE__)
 require 'fileutils'
 require 'json'
+require 'digest/md5'
 
 require_relative 'hoc_sync_utils'
 require_relative 'i18n_script_utils'
@@ -108,7 +109,7 @@ def get_i18n_strings(level)
         next unless text_title&.content =~ /[a-zA-Z]{3,}/
 
         # Use only alphanumeric characters in lower cases as string key
-        text_key = text_title.content.gsub(/[^a-zA-Z0-9_ ]/, '').split.join('_').downcase
+        text_key = Digest::MD5.hexdigest text_title.content
         i18n_strings['placeholder_texts'][text_key] = text_title.content
       end
     end

--- a/dashboard/app/models/levels/blockly.rb
+++ b/dashboard/app/models/levels/blockly.rb
@@ -581,7 +581,7 @@ class Blockly < Level
 
       # Must generate text_key in the same way it is created in
       # the get_i18n_strings function in sync-in.rb script.
-      text_key = text_title.content.gsub(/[^a-zA-Z0-9_ ]/, '').split.join('_').downcase
+      text_key = Digest::MD5.hexdigest text_title.content
       localized_text = I18n.t(
         text_key,
         scope: [:data, :placeholder_texts, name],

--- a/dashboard/app/models/levels/blockly.rb
+++ b/dashboard/app/models/levels/blockly.rb
@@ -309,6 +309,7 @@ class Blockly < Level
           ).each do |xml_block_prop|
             next unless level_options.key? xml_block_prop
             set_unless_nil(level_options, xml_block_prop, localized_function_blocks(level_options[xml_block_prop]))
+            set_unless_nil(level_options, xml_block_prop, localized_text_blocks(level_options[xml_block_prop]))
           end
         end
       end
@@ -568,6 +569,29 @@ class Blockly < Level
 
     localize_behaviors(block_xml)
     return block_xml.serialize(save_with: XML_OPTIONS).strip
+  end
+
+  # Localize placeholder texts in text blocks
+  def localized_text_blocks(blocks)
+    return if blocks.nil?
+    block_xml = Nokogiri::XML(blocks, &:noblanks)
+    block_xml.xpath("//block[@type=\"text\"]").each do |text_block|
+      text_title = text_block.at_xpath('./title[@name="TEXT"]')
+      next unless text_title&.content&.present?
+
+      # Must generate text_key in the same way it is created in
+      # the get_i18n_strings function in sync-in.rb script.
+      text_key = text_title.content.gsub(/[^a-zA-Z0-9_ ]/, '').split.join('_').downcase
+      localized_text = I18n.t(
+        text_key,
+        scope: [:data, :placeholder_texts, name],
+        default: nil,
+        smart: true
+      )
+      text_title.content = localized_text if localized_text
+    end
+
+    block_xml.serialize(save_with: XML_OPTIONS).strip
   end
 
   def self.base_url


### PR DESCRIPTION
Task [FND-1209](https://codedotorg.atlassian.net/browse/FND-1209):
This is the first step to enable translation of placeholder texts. We extract placeholder texts from `.level` files during the i18n `sync-in` step. 

Since placeholder texts can be empty strings, binary numbers or just several question marks, we require the strings to have at least 3 consecutive alphabetic characters.

## Example
A puzzle with placeholder texts https://studio.code.org/s/coursee-2020/stage/9/puzzle/1:
<img width="529" alt="Screen Shot 2020-09-30 at 11 05 41 AM" src="https://user-images.githubusercontent.com/46507039/94641940-8b944780-0297-11eb-8d95-f12caeb45a88.png">

Those texts are defined in a .level file:
https://github.com/code-dot-org/code-dot-org/blob/8e8171cfa117041f85241a2bb2ac7913285bc295/dashboard/config/scripts/levels/courseE_aboutme_1_2020.level#L129-L131

After `sync-in` step, placeholder texts are extracted to `i18n/locales/source/course_content/2020/coursee-2020.json`:
```json
{
  "https://studio.code.org/s/coursee-2020/stage/9/puzzle/1": {
    "placeholder_texts": {
      "b63151482630edd1589a9ac24d107c49": "That's me! Rikki! I like to code, hangout with Thuy, and eat ice cream!",
      "810896b14fc6615f0c76628b9b6a727e": "That's my best friend Thuy! She's really good at sports!",
      "5d48ecdd8e3baeb99c6a8dcb7faa13dd": "Ice cream is my favorite treat! But I probably shouldn't eat it on the couch...",
      "a50ec512bdd98483a7cdcd88cbe11933": "That's my pet rabbit, Ms. Lolipop! I have no idea why I named her that!",
      "6f97975a0bda0c9219915161149cbb26": "That's my computer! I code on it ALL the time!",
      "1c6636ce086fef9305c6e3d25e37d5b2": "Here's a secret: Thuy is extremely ticklish!",
      "fce3b93eaa64a8869c47ba25daa8887f": "Yummy!",
      "41a18649f969a00ec0b2feba20db997f": "I think I like this color better on you, Ms. Lolipop!",
      "756afb811df2eb3ec88a9e98f3dcaa8d": "This computer can't handle my mad coding skills!"
    }
  }
}
```

After `sync-down` step, translations for placeholder texts are downloaded to `i18n/locales/<locale>/course_content/2020/coursee-2020.json`.
```
{
  "https://studio.code.org/s/coursee-2020/stage/9/puzzle/1": {
    "placeholder_texts": {
      "b63151482630edd1589a9ac24d107c49": "toi la rikki",
      "810896b14fc6615f0c76628b9b6a727e": "day la ban Thuy!",
      "5d48ecdd8e3baeb99c6a8dcb7faa13dd": "kem rat ngon....",
      "a50ec512bdd98483a7cdcd88cbe11933": "day la tho!",
      "6f97975a0bda0c9219915161149cbb26": "day la may tinh!",
      "1c6636ce086fef9305c6e3d25e37d5b2": "day la bi mat",
      "fce3b93eaa64a8869c47ba25daa8887f": "ngon!",
      "41a18649f969a00ec0b2feba20db997f": "mau nay cool!",
      "756afb811df2eb3ec88a9e98f3dcaa8d": "toi qua gioi"
    }
  }
}
```

After `sync-out` step, the translations are distributed to `dashboard/config/locales/placeholder_texts.<locale>.json`.
Example of `dashboard/config/locales/placeholder_texts.vi-VN.json`:
```
{
  "vi-VN": {
    "data": {
      "placeholder_texts": {
        "courseE_aboutme_1_2020": {
          "b63151482630edd1589a9ac24d107c49": "toi la rikki",
          "810896b14fc6615f0c76628b9b6a727e": "day la ban Thuy!",
          "5d48ecdd8e3baeb99c6a8dcb7faa13dd": "kem rat ngon....",
          "a50ec512bdd98483a7cdcd88cbe11933": "day la tho!",
          "6f97975a0bda0c9219915161149cbb26": "day la may tinh!",
          "1c6636ce086fef9305c6e3d25e37d5b2": "day la bi mat",
          "fce3b93eaa64a8869c47ba25daa8887f": "ngon!",
          "41a18649f969a00ec0b2feba20db997f": "mau nay cool!",
          "756afb811df2eb3ec88a9e98f3dcaa8d": "toi qua gioi"
        }
      }
    }
  }
}
```

Rendering the translations:
English|Vietnamese
--|--
<img width="555" alt="Screen Shot 2020-10-02 at 8 06 27 AM" src="https://user-images.githubusercontent.com/46507039/94877968-ed2bf180-0410-11eb-86c3-73be82759bcd.png">|<img width="228" alt="Screen Shot 2020-10-02 at 8 05 02 AM" src="https://user-images.githubusercontent.com/46507039/94877981-f452ff80-0410-11eb-9464-ff85604d33f0.png">


## Testing story
- Run `bin/i18n/sync-in.rb` to extract placeholder strings from dashboard/config/scripts/levels/courseE_aboutme_1_2020.level file.
- Manually create a sync-down output at i18n/locales/vi-VN/course_content/2020/coursee-2020.json.
- Manually create `/tmp/codeorg_changes.json`, `/tmp/codeorg-markdown_changes.json`, `/tmp/hour-of-code_changes.json` with content.
- Run `bin/i18n/sync-out.rb` to distribute translations to dashboard/config/locales/placeholder_texts.vi-VN.json.
- Go to http://localhost-studio.code.org:3000/s/coursee-2020/stage/9/puzzle/1/lang/vi to see the translations in Vietnamese.

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
