### PR TITLE
Add reload in add_lessons

### DIFF
--- a/dashboard/app/models/lesson.rb
+++ b/dashboard/app/models/lesson.rb
@@ -89,6 +89,7 @@ class Lesson < ActiveRecord::Base
 
       lesson.script_levels = ScriptLevel.add_script_levels(script, lesson, raw_lesson[:script_levels], counters, new_suffix, editor_experiment)
       lesson.save!
+      lesson.reload
 
       Lesson.prevent_multi_page_assessment_outside_final_level(lesson)
 

--- a/dashboard/app/models/lesson.rb
+++ b/dashboard/app/models/lesson.rb
@@ -63,6 +63,7 @@ class Lesson < ActiveRecord::Base
   include CodespanOnlyMarkdownHelper
 
   def self.add_lessons(script, lesson_group, raw_lessons, counters, new_suffix, editor_experiment)
+    script.lessons.reload
     raw_lessons.map do |raw_lesson|
       Lesson.prevent_empty_lesson(raw_lesson)
       Lesson.prevent_blank_display_name(raw_lesson)


### PR DESCRIPTION
Fixes this seeding issue on levelbuilder: https://codedotorg.slack.com/archives/C0T0PNTM3/p1601424059064700

More details from the investigation:

Reproed the error consistently with:
```
RAILS_ENV=levelbuilder rake seed:single_script SCRIPT_NAME=csp1-2017
...
Error adding script named 'csp1-2017': Only the final level in a lesson may be a multi-page assessment.  Lesson: Unit 1 Chapter 2 Assessment
/home/ubuntu/levelbuilder/dashboard/app/models/lesson.rb:125:in `block in prevent_multi_page_assessment_outside_final_level'
```

This was unexpected because `csp1-2017` hasn't been changed in a while. The state in the DB of those ScriptLevels also is correct - the assessment is the final level in the lesson.

After debugging with some `pry` statements it appeared that the ScriptLevels returned from `ScriptLevel.add_script_levels` were in the wrong order. Without the reload, they're used as-is, so the check in a`prevent_multi_page_assessment_outside_final_level` fails. However, they're correct in the DB because their chapter/position values are correct. So reloading lesson seems to get them back in the order they should be.

I don't know why they're in the wrong order in memory initially, or why this just started failing now.

## Testing story

* Made this change manually on levelbuilder, and confirmed it fixed the error. This unblocked the deployment this morning, and I checked out the file to get rid of the local change.
* existing unit tests

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
