### PR TITLE
Added tracker for bubbleDialog experiment

### DIFF
--- a/apps/src/StudioApp.js
+++ b/apps/src/StudioApp.js
@@ -1633,7 +1633,7 @@ StudioApp.prototype.displayFeedback = function(options) {
     trackEvent(
       'experiment',
       'Feedback bubbleDialog',
-      `AppType ${this.config.app}. Level ${this.config.level.id}`
+      `AppType ${this.config.app}. Level ${this.config.serverLevelId}`
     );
     const {response, preventDialog, feedbackType, feedbackImage} = options;
 

--- a/apps/src/StudioApp.js
+++ b/apps/src/StudioApp.js
@@ -1628,6 +1628,13 @@ StudioApp.prototype.displayFeedback = function(options) {
   );
 
   if (experiments.isEnabled('bubbleDialog')) {
+    // Track whether this experiment is in use. If not, delete this and similar
+    // sections of code. If it is, create a non-experiment flag.
+    trackEvent(
+      'experiment',
+      'Feedback bubbleDialog',
+      `AppType ${this.config.app}. Level ${this.config.level.id}`
+    );
     const {response, preventDialog, feedbackType, feedbackImage} = options;
 
     const newFinishDialogApps = {


### PR DESCRIPTION
I'm not sure whether this experiment is still in use. Therefore, I'm creating Google Analytics tracked event for it. If it's not in use, we can delete code associated with this experiment.

Once this goes live, it will be accessible on this dashboard: https://analytics.google.com/analytics/web/#/report/content-event-events/a37745279w66217109p68074336/_u.date00=20200916&_u.date01=20200930&_r.drilldown=analytics.eventCategory:Research,analytics.eventAction:RanMigration/ 

<!--
  Other aspects to consider. uncomment and add detail for any that seem necessary:
-->

<!-- ### Background -->
<!-- ### Privacy -->
<!--
1.	Does the Project involve the collection, use or sharing of new Personal Data?

2.	Does the Project involve a new or changed use or sharing of existing Personal Data?
-->
<!-- ### Security -->
<!--
Link to Jira Task where sensitive security issues are discussed privately.
-->
<!-- ### Caching -->
<!-- ### Deployment strategy -->
<!-- ### Future work -->

## Links

<!--
  Any relevant links to external resources; ie, specification documents, jira
  items, related PRs, honeybadger errors, etc
-->


## Testing story

<!--
  Does your change include appropriate tests?

  If so, please describe how the tests included in this PR are sufficient

  If not, please explain why this change does not need to be tested.
-->

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
