### PR TITLE
Expand the locale-aware lesson plan links hack to include more pages

### DIFF
--- a/pegasus/helpers/page_helpers.rb
+++ b/pegasus/helpers/page_helpers.rb
@@ -88,3 +88,35 @@ def youtube_embed(youtube_url)
 
   %Q{<iframe title="YouTube video player" width="250" height="141" src="http://www.youtube.com/embed/#{youtube_id}" frameborder="0" allowfullscreen></iframe>}.html_safe
 end
+
+# A hacky method to generate locale-aware links to our lesson plans. This is
+# hacky primarily because we are forced to hardcode here a list of supported
+# languages; a list which we have no guarantee will remain accurate in the long
+# term.
+def hacky_localized_lesson_plan_url(path)
+  # This is the list of languages currently supported by the CurriculumBuilder
+  # i18n sync. This list should be kept in sync with the LANGUAGES settings
+  # variable in the curriculumbuilder project. (curriculumBuilder/settings.py)
+  curriculumbuilder_languages = [
+    'es-mx', 'es-es', 'hi-in', 'it-it', 'pl-pl', 'sk-sk', 'th-th'
+  ]
+
+  # This is a list of additional languages we want to support. These are
+  # languages for which there does exist content in that language on
+  # curriculum.code.org, but which aren't regularly synced.
+  # Be particularly cautious about adding languages to this list; not only is
+  # the content for that language not updated regularly, but new content is not
+  # added automatically. This means if you try to link to a recently-added
+  # lesson plan, it may not be there for any of these languages.
+  additional_languages = [
+    'et-ee', 'fr-fr', 'ko-kr', 'zh-tw'
+  ]
+
+  supported_languages = curriculumbuilder_languages + additional_languages
+  domain = "https://curriculum.code.org"
+  current_locale = I18n.locale.to_s.downcase
+
+  supported_languages.include?(current_locale) ?
+    File.join(domain, current_locale, path) :
+    File.join(domain, path)
+end

--- a/pegasus/helpers/page_helpers.rb
+++ b/pegasus/helpers/page_helpers.rb
@@ -109,7 +109,7 @@ def hacky_localized_lesson_plan_url(path)
   # added automatically. This means if you try to link to a recently-added
   # lesson plan, it may not be there for any of these languages.
   additional_languages = [
-    'et-ee', 'fr-fr', 'ko-kr', 'zh-tw'
+    'ar-sa', 'de-de', 'fr-fr', 'id-id', 'ko-kr', 'tr-tr', 'zh-cn', 'zh-tw'
   ]
 
   supported_languages = curriculumbuilder_languages + additional_languages

--- a/pegasus/sites.v3/code.org/public/hourofcode/overview.haml
+++ b/pegasus/sites.v3/code.org/public/hourofcode/overview.haml
@@ -48,7 +48,7 @@ social:
           %a{href: "/dance"}
             %button.tutorial-info-start.tutorial-gray= I18n.t(:go)
           .tutorial-info-guide
-            %a{href: "https://curriculum.code.org/hoc/plugged/8/"}
+            %a{href: hacky_localized_lesson_plan_url("/hoc/plugged/8/")}
               = I18n.t(:hoc_overview_view_teacher_guide)
 
   .col-50
@@ -63,7 +63,7 @@ social:
           %a{href: "/oceans"}
             %button.tutorial-info-start.tutorial-gray= I18n.t(:go)
           .tutorial-info-guide
-            %a{href: "https://curriculum.code.org/hoc/plugged/9/"}
+            %a{href: hacky_localized_lesson_plan_url("/hoc/plugged/9/")}
               = I18n.t(:hoc_overview_view_teacher_guide)
 
 .tile-container-responsive

--- a/pegasus/sites.v3/code.org/views/dance_teacher_resources.haml
+++ b/pegasus/sites.v3/code.org/views/dance_teacher_resources.haml
@@ -1,29 +1,20 @@
 %link{:rel=>'stylesheet', :type=>'text/css', :href=>'/css/dance-landing/dance-teacher-resources.css'}
 
 :ruby
-  locale = I18n.locale.to_s.downcase
-  translated_languages = ["es-es", "es-mx", "et-ee", "fr-fr", "ko-kr", "pl-pl", "tr-tr", "zh-tw"]
-  lesson_link = translated_languages.include?(locale) ?
-  "https://curriculum.code.org/#{locale}/hoc/plugged/8" :
-  "https://curriculum.code.org/hoc/plugged/8"
-  unplugged_link = translated_languages.include?(locale) ?
-  "https://curriculum.code.org/#{locale}/hoc/unplugged/4" :
-  "https://curriculum.code.org/hoc/unplugged/4"
-
   resources = [
     {
       title: I18n.t(:hoc2018_dance_teacher_resources_title),
       description: I18n.t(:hoc2018_dance_teacher_resources_tile1_description),
       image: "/images/dance-hoc/dance_party_dance.gif",
       button_text: I18n.t(:hoc2018_dance_teacher_resources_tile1_button),
-      link: lesson_link
+      link: hacky_localized_lesson_plan_url("/hoc/unplugged/8")
     },
     {
       title: I18n.t(:hoc2018_dance_teacher_resources_tile2_title),
       description: I18n.t(:hoc2018_dance_teacher_resources_tile2_description),
       image: "/images/dance-hoc/dance_party_2019_unplugged_portrait.png",
       button_text: I18n.t(:hoc2018_dance_teacher_resources_tile2_button),
-      link: unplugged_link
+      link: hacky_localized_lesson_plan_url("/hoc/unplugged/4")
     },
   ]
 

--- a/pegasus/sites.v3/code.org/views/top_hoc_tutorial_applab.haml
+++ b/pegasus/sites.v3/code.org/views/top_hoc_tutorial_applab.haml
@@ -19,4 +19,4 @@
         %a{href: CDO.studio_url("/s/applab-intro/reset")}
           %button.tutorial-info-start.tutorial-gray= I18n.t(:go)
         .tutorial-info-guide
-          %a{href: "https://curriculum.code.org/hoc/plugged/7/"}= I18n.t(:applab_tile_teacher_guide)
+          %a{href: hacky_localized_lesson_plan_url("/hoc/plugged/7/")}= I18n.t(:applab_tile_teacher_guide)

--- a/pegasus/test/test_page_helpers.rb
+++ b/pegasus/test/test_page_helpers.rb
@@ -1,0 +1,23 @@
+require_relative './test_helper'
+require_relative '../src/env'
+require_relative '../helpers/page_helpers'
+require 'minitest/autorun'
+
+class PageHelpersTest < Minitest::Test
+  def test_hacky_localized_lesson_plan_url
+    # method will generate locale-aware link for supported languages
+    I18n.locale = :"es-MX"
+    assert_equal hacky_localized_lesson_plan_url("/test"),
+      "https://curriculum.code.org/es-mx/test"
+
+    # method will generate locale-aware link for additional languages
+    I18n.locale = :"fr-FR"
+    assert_equal hacky_localized_lesson_plan_url("test"),
+      "https://curriculum.code.org/fr-fr/test"
+
+    # method will generate unmodified link for unknown languages
+    I18n.locale = :"fa-KE"
+    assert_equal hacky_localized_lesson_plan_url("test"),
+      "https://curriculum.code.org/test"
+  end
+end


### PR DESCRIPTION
Per request from the international team, we take the existing hack from https://code.org/dance for displaying locale-aware links to lesson plans (originally added in https://github.com/code-dot-org/code-dot-org/pull/26193), move it into a reusable method, add some tests, and start using it for the hardcoded links on https://code.org/hourofcode/overview

Also opened a PR in CurriculmBuilder to add a comment calling out this baked-in dependency: https://github.com/code-dot-org/curriculumbuilder/pull/310

Future work to build this feature in a less-hacky way is in the process of being scheduled.

## Links

- [jira](https://codedotorg.atlassian.net/browse/FND-15)

## Testing story

Manually tested locally, also added a new unit test.

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
