### PR TITLE
Use replace with global option rather than replaceAll

### DIFF
--- a/apps/src/code-studio/initApp/project.js
+++ b/apps/src/code-studio/initApp/project.js
@@ -983,8 +983,8 @@ var projects = (module.exports = {
       parsedSample.getElementsByTagName('parsererror').length > 0
     ) {
       // Normalize line endings between unix and Windows OS.
-      normalizedSample = sampleCode.replaceAll('\r\n', '\n');
-      normalizedCurrent = currentCode.replaceAll('\r\n', '\n');
+      normalizedSample = sampleCode.replace(/\r\n/g, '\n');
+      normalizedCurrent = currentCode.replace(/\r\n/g, '\n');
     } else {
       // Normalize XML to ignore differences in closing tags.
       const serializer = new XMLSerializer();

--- a/apps/test/unit/code-studio/initApp/projectTest.js
+++ b/apps/test/unit/code-studio/initApp/projectTest.js
@@ -993,8 +993,8 @@ describe('project.js', () => {
     });
 
     it('ignores differences in line endings', () => {
-      setSources({source: 'foo\r\nbar'});
-      expect(project.isCurrentCodeDifferent('foo\nbar')).to.be.false;
+      setSources({source: 'foo\r\n\r\nbar'});
+      expect(project.isCurrentCodeDifferent('foo\n\nbar')).to.be.false;
     });
 
     it('ignores differences in xml closing tags', () => {


### PR DESCRIPTION
Quick fix-forward to unblock the test environment.

replaceAll is not supported on our test environment. Using replace with regex and the global option instead. This is the same method we use in StudioApp to solve this issue: https://github.com/code-dot-org/code-dot-org/blob/2ebd913c43ba17f905e88db95c91421129eac3a8/apps/src/StudioApp.js#L2528

https://codedotorg.slack.com/archives/C0T0PNTM3/p1601515567088600?thread_ts=1601515262.088100&cid=C0T0PNTM3

<!--
  Your description goes here: A summary of the change, including any relevant motivation and context.

  If relevant, include a description both of the existing behavior and of the new behavior.
-->

<!--
  Other aspects to consider. uncomment and add detail for any that seem necessary:
-->

<!-- ### Background -->
<!-- ### Privacy -->
<!--
1.	Does the Project involve the collection, use or sharing of new Personal Data?

2.	Does the Project involve a new or changed use or sharing of existing Personal Data?
-->
<!-- ### Security -->
<!--
Link to Jira Task where sensitive security issues are discussed privately.
-->
<!-- ### Caching -->
<!-- ### Deployment strategy -->
<!-- ### Future work -->

## Links

<!--
  Any relevant links to external resources; ie, specification documents, jira
  items, related PRs, honeybadger errors, etc
-->


## Testing story

<!--
  Does your change include appropriate tests?

  If so, please describe how the tests included in this PR are sufficient

  If not, please explain why this change does not need to be tested.
-->

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
