### PR TITLE
Insert spinner while classroom sections are loading

### DIFF
--- a/apps/src/templates/teacherDashboard/OwnedSections.jsx
+++ b/apps/src/templates/teacherDashboard/OwnedSections.jsx
@@ -21,6 +21,7 @@ import SetUpSections from '../studioHomepages/SetUpSections';
 import {recordOpenEditSectionDetails} from './sectionHelpers';
 import experiments from '@cdo/apps/util/experiments';
 import {recordImpression} from './impressionHelpers';
+import Spinner from '@cdo/apps/code-studio/pd/components/spinner';
 
 const styles = {
   button: {
@@ -37,6 +38,9 @@ const styles = {
     fontSize: 14,
     paddingBottom: 5,
     color: color.charcoal
+  },
+  spinner: {
+    marginTop: '10px'
   }
 };
 
@@ -93,7 +97,7 @@ class OwnedSections extends React.Component {
     const {viewHidden} = this.state;
 
     if (!asyncLoadComplete) {
-      return null;
+      return <Spinner size="large" style={styles.spinner} />;
     }
 
     const hasSections = sectionIds.length > 0;

--- a/apps/test/unit/templates/teacherDashboard/OwnedSectionsTest.js
+++ b/apps/test/unit/templates/teacherDashboard/OwnedSectionsTest.js
@@ -7,6 +7,7 @@ import RosterDialog from '@cdo/apps/templates/teacherDashboard/RosterDialog';
 import AddSectionDialog from '@cdo/apps/templates/teacherDashboard/AddSectionDialog';
 import EditSectionDialog from '@cdo/apps/templates/teacherDashboard/EditSectionDialog';
 import SetUpSections from '@cdo/apps/templates/studioHomepages/SetUpSections';
+import Spinner from '@cdo/apps/code-studio/pd/components/spinner';
 
 const defaultProps = {
   sectionIds: [11, 12, 13],
@@ -30,6 +31,12 @@ describe('OwnedSections', () => {
         <EditSectionDialog />
       </div>
     );
+  });
+
+  it('renders spinner when sections have not yet loaded', () => {
+    const props = {...defaultProps, asyncLoadComplete: false};
+    const wrapper = shallow(<OwnedSections {...props} />);
+    expect(wrapper).to.containMatchingElement(<Spinner />);
   });
 
   it('renders a OwnedSectionsTable with no extra button if no archived sections', () => {


### PR DESCRIPTION
Prior to this change, the "Classroom Sections" portion of the teacher homepage was blank while loading. Teachers reported that the initially blank list of sections felt like a bug. To resolve the issue, we will render a spinner under the Classroom Sections header while the fetch request is completed.

## Links

- [spec](https://docs.google.com/document/d/1TDh6-U71b9jajOrrcx4XSBp7wlXhAWYzCgfI-rTOP6k/edit)
- [jira](https://codedotorg.atlassian.net/browse/LP-1567)

## Testing story

To test, I added an additional unit test to `OwnedSectionsTest.js` to confirm that the `<Spinner />` component is rendered while asynchronous fetch request is incomplete.

## Screenshot
<img width="1401" alt="Screen Shot 2020-10-01 at 8 30 53 PM" src="https://user-images.githubusercontent.com/17502635/94876318-5289dd80-0425-11eb-8eb0-c7a823fd1cf0.png">


# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
