### PR TITLE
Activities Editor: AddLevelsTable with Real Level Data

### DIFF
--- a/apps/src/lib/levelbuilder/lesson-editor/ActivitySectionCard.jsx
+++ b/apps/src/lib/levelbuilder/lesson-editor/ActivitySectionCard.jsx
@@ -295,35 +295,34 @@ class ActivitySectionCard extends Component {
   }
 
   //TODO: Hook up being able to actually pick a level to add instead of holding place level
-  handleAddLevel = level => {
+  handleAddLevel = () => {
     const newLevelPosition = this.props.activitySection.levels.length + 1;
-    const newLevel = {
-      ids: [NEW_LEVEL_ID],
-      activeId: NEW_LEVEL_ID,
-      status: 'not started',
-      url: `https://levelbuilder-studio.code.org/levels/${level.id}/edit`,
-      icon: 'fa-desktop',
-      name: level.name,
-      isUnplugged: false,
-      levelNumber: newLevelPosition,
-      isCurrentLevel: false,
-      isConceptLevel: false,
-      sublevels: level.properties.sublevels,
-      position: newLevelPosition,
-      kind: 'puzzle',
-      skin: null,
-      videoKey: null,
-      concepts: '',
-      conceptDifficulty: '',
-      named: false,
-      assessment: false,
-      challenge: false,
-      expand: false
-    };
     this.props.addLevel(
       this.props.activityPosition,
       this.props.activitySection.position,
-      newLevel
+      {
+        ids: [NEW_LEVEL_ID],
+        activeId: NEW_LEVEL_ID,
+        status: 'not started',
+        url: 'https://levelbuilder-studio.code.org/levels/598/edit',
+        icon: 'fa-desktop',
+        name: `Level ${newLevelPosition}`,
+        isUnplugged: false,
+        levelNumber: newLevelPosition,
+        isCurrentLevel: false,
+        isConceptLevel: false,
+        sublevels: [],
+        position: newLevelPosition,
+        kind: 'puzzle',
+        skin: null,
+        videoKey: null,
+        concepts: '',
+        conceptDifficulty: '',
+        named: false,
+        assessment: false,
+        challenge: false,
+        expand: false
+      }
     );
   };
 

--- a/apps/src/lib/levelbuilder/lesson-editor/ActivitySectionCard.jsx
+++ b/apps/src/lib/levelbuilder/lesson-editor/ActivitySectionCard.jsx
@@ -295,34 +295,35 @@ class ActivitySectionCard extends Component {
   }
 
   //TODO: Hook up being able to actually pick a level to add instead of holding place level
-  handleAddLevel = () => {
+  handleAddLevel = level => {
     const newLevelPosition = this.props.activitySection.levels.length + 1;
+    const newLevel = {
+      ids: [NEW_LEVEL_ID],
+      activeId: NEW_LEVEL_ID,
+      status: 'not started',
+      url: `https://levelbuilder-studio.code.org/levels/${level.id}/edit`,
+      icon: 'fa-desktop',
+      name: level.name,
+      isUnplugged: false,
+      levelNumber: newLevelPosition,
+      isCurrentLevel: false,
+      isConceptLevel: false,
+      sublevels: level.properties.sublevels,
+      position: newLevelPosition,
+      kind: 'puzzle',
+      skin: null,
+      videoKey: null,
+      concepts: '',
+      conceptDifficulty: '',
+      named: false,
+      assessment: false,
+      challenge: false,
+      expand: false
+    };
     this.props.addLevel(
       this.props.activityPosition,
       this.props.activitySection.position,
-      {
-        ids: [NEW_LEVEL_ID],
-        activeId: NEW_LEVEL_ID,
-        status: 'not started',
-        url: 'https://levelbuilder-studio.code.org/levels/598/edit',
-        icon: 'fa-desktop',
-        name: `Level ${newLevelPosition}`,
-        isUnplugged: false,
-        levelNumber: newLevelPosition,
-        isCurrentLevel: false,
-        isConceptLevel: false,
-        sublevels: [],
-        position: newLevelPosition,
-        kind: 'puzzle',
-        skin: null,
-        videoKey: null,
-        concepts: '',
-        conceptDifficulty: '',
-        named: false,
-        assessment: false,
-        challenge: false,
-        expand: false
-      }
+      newLevel
     );
   };
 

--- a/apps/src/lib/levelbuilder/lesson-editor/AddLevelDialog.jsx
+++ b/apps/src/lib/levelbuilder/lesson-editor/AddLevelDialog.jsx
@@ -17,6 +17,7 @@ const styles = {
     paddingLeft: 20,
     paddingRight: 20,
     paddingBottom: 20,
+    width: 950,
     fontFamily: '"Gotham 4r", sans-serif, sans-serif'
   },
   dialogContent: {
@@ -146,7 +147,10 @@ export default class AddLevelDialog extends Component {
                   searchFields={this.state.searchFields}
                   handleSearch={this.handleSearch}
                 />
-                <AddLevelTable addLevel={this.props.addLevel} />
+                <AddLevelTable
+                  addLevel={this.props.addLevel}
+                  levels={this.state.levels}
+                />
               </div>
             )}
             {this.state.methodOfAddingLevel === 'Create New Level' && (

--- a/apps/src/lib/levelbuilder/lesson-editor/AddLevelDialog.jsx
+++ b/apps/src/lib/levelbuilder/lesson-editor/AddLevelDialog.jsx
@@ -17,8 +17,9 @@ const styles = {
     paddingLeft: 20,
     paddingRight: 20,
     paddingBottom: 20,
-    width: 950,
-    fontFamily: '"Gotham 4r", sans-serif, sans-serif'
+    width: 1100,
+    fontFamily: '"Gotham 4r", sans-serif, sans-serif',
+    marginLeft: -600
   },
   dialogContent: {
     display: 'flex',

--- a/apps/src/lib/levelbuilder/lesson-editor/AddLevelFilters.jsx
+++ b/apps/src/lib/levelbuilder/lesson-editor/AddLevelFilters.jsx
@@ -12,6 +12,9 @@ const styles = {
   dropdown: {
     width: 125,
     margin: 5
+  },
+  label: {
+    marginRight: 15
   }
 };
 
@@ -63,7 +66,7 @@ export default class AddLevelFilters extends Component {
   render() {
     return (
       <div style={styles.filters}>
-        <label>
+        <label style={styles.label}>
           By Name:
           <input
             style={styles.dropdown}
@@ -71,7 +74,7 @@ export default class AddLevelFilters extends Component {
             value={this.state.levelName}
           />
         </label>
-        <label>
+        <label style={styles.label}>
           By Type:
           <select
             style={styles.dropdown}
@@ -85,7 +88,7 @@ export default class AddLevelFilters extends Component {
             ))}
           </select>
         </label>
-        <label>
+        <label style={styles.label}>
           By Script:
           <select
             style={styles.dropdown}
@@ -99,7 +102,7 @@ export default class AddLevelFilters extends Component {
             ))}
           </select>
         </label>
-        <label>
+        <label style={styles.label}>
           By Owner:
           <select
             style={styles.dropdown}

--- a/apps/src/lib/levelbuilder/lesson-editor/AddLevelTable.jsx
+++ b/apps/src/lib/levelbuilder/lesson-editor/AddLevelTable.jsx
@@ -1,5 +1,4 @@
 import React, {Component} from 'react';
-import Button, {ButtonColor, ButtonSize} from '@cdo/apps/templates/Button';
 import FontAwesome from '@cdo/apps/templates/FontAwesome';
 import PropTypes from 'prop-types';
 
@@ -29,47 +28,32 @@ export default class AddLevelTable extends Component {
           <thead>
             <tr>
               <th style={{width: '13%'}}>Actions</th>
-              <th style={{width: '33%'}}>
-                Name
-                <FontAwesome icon="sort" style={styles.orderIcon} />
-              </th>
-              <th style={{width: '18%'}}>
-                Type
-                <FontAwesome icon="sort" style={styles.orderIcon} />
-              </th>
-              <th style={{width: '15%'}}>
-                Owner
-                <FontAwesome icon="sort" style={styles.orderIcon} />
-              </th>
-              <th style={{width: '20%'}}>
-                Last Updated
-                <FontAwesome icon="sort" style={styles.orderIcon} />
-              </th>
+              <th style={{width: '33%'}}>Name</th>
+              <th style={{width: '18%'}}>Type</th>
+              <th style={{width: '15%'}}>Owner</th>
+              <th style={{width: '20%'}}>Last Updated</th>
             </tr>
           </thead>
           <tbody>
             {this.props.levels.map(level => (
               <tr key={level.id}>
                 <td>
-                  <Button
-                    icon="plus"
-                    text={''}
+                  <button
+                    type="button"
                     onClick={() => {
                       console.log('Add');
                     }}
-                    //onClick={this.handleAddLevel}
-                    color={ButtonColor.blue}
-                    size={ButtonSize.narrow}
-                  />
-                  <Button
-                    icon="files-o"
-                    text={''}
+                  >
+                    <FontAwesome icon="plus" />
+                  </button>
+                  <button
+                    type="button"
                     onClick={() => {
-                      console.log('Clone Level and Add');
+                      console.log('Clone and Add');
                     }}
-                    color={ButtonColor.blue}
-                    size={ButtonSize.narrow}
-                  />
+                  >
+                    <FontAwesome icon="files-o" />
+                  </button>
                 </td>
                 <td>
                   <div>{level.name}</div>

--- a/apps/src/lib/levelbuilder/lesson-editor/AddLevelTable.jsx
+++ b/apps/src/lib/levelbuilder/lesson-editor/AddLevelTable.jsx
@@ -4,9 +4,6 @@ import FontAwesome from '@cdo/apps/templates/FontAwesome';
 import PropTypes from 'prop-types';
 
 const styles = {
-  th: {
-    width: '20%'
-  },
   orderIcon: {
     float: 'right'
   },
@@ -15,12 +12,14 @@ const styles = {
   }
 };
 
-//TODO Change the table to something more dynamic like used on teacher dashboard
-//And pull in real level data
-
 export default class AddLevelTable extends Component {
   static propTypes = {
-    addLevel: PropTypes.func
+    addLevel: PropTypes.func,
+    levels: PropTypes.array
+  };
+
+  handleAddLevel = level => {
+    this.props.addLevel(level);
   };
 
   render() {
@@ -29,92 +28,63 @@ export default class AddLevelTable extends Component {
         <table>
           <thead>
             <tr>
-              <th>Actions</th>
-              <th style={styles.th}>
+              <th style={{width: '13%'}}>Actions</th>
+              <th style={{width: '33%'}}>
                 Name
                 <FontAwesome icon="sort" style={styles.orderIcon} />
               </th>
-              <th style={styles.th}>
+              <th style={{width: '18%'}}>
                 Type
                 <FontAwesome icon="sort" style={styles.orderIcon} />
               </th>
-              <th style={styles.th}>
+              <th style={{width: '15%'}}>
                 Owner
                 <FontAwesome icon="sort" style={styles.orderIcon} />
               </th>
-              <th style={styles.th}>
+              <th style={{width: '20%'}}>
                 Last Updated
                 <FontAwesome icon="sort" style={styles.orderIcon} />
               </th>
             </tr>
           </thead>
           <tbody>
-            <tr>
-              <td>
-                <Button
-                  icon="plus"
-                  text={''}
-                  onClick={this.props.addLevel}
-                  color={ButtonColor.blue}
-                  size={ButtonSize.narrow}
-                />
-                <Button
-                  icon="files-o"
-                  text={''}
-                  onClick={() => {
-                    console.log('Clone Level and Add');
-                  }}
-                  color={ButtonColor.blue}
-                  size={ButtonSize.narrow}
-                />
-              </td>
-              <td>
-                <div>My Level</div>
-              </td>
-              <td>
-                <div>App Lab</div>
-              </td>
-              <td>
-                <div>Hannah</div>
-              </td>
-              <td>
-                <div>Tuesday at 5 pm</div>
-              </td>
-            </tr>
-            <tr>
-              <td>
-                <Button
-                  icon="plus"
-                  text={''}
-                  onClick={() => {
-                    console.log('Add level');
-                  }}
-                  color={ButtonColor.blue}
-                  size={ButtonSize.narrow}
-                />
-                <Button
-                  icon="files-o"
-                  text={''}
-                  onClick={() => {
-                    console.log('Clone Level and Add');
-                  }}
-                  color={ButtonColor.blue}
-                  size={ButtonSize.narrow}
-                />
-              </td>
-              <td>
-                <div>Super Awesome Level</div>
-              </td>
-              <td>
-                <div>Sprite Lab</div>
-              </td>
-              <td>
-                <div>Mike</div>
-              </td>
-              <td>
-                <div>5 minutes ago</div>
-              </td>
-            </tr>
+            {this.props.levels.map(level => (
+              <tr key={level.id}>
+                <td>
+                  <Button
+                    icon="plus"
+                    text={''}
+                    onClick={() => {
+                      console.log('Add');
+                    }}
+                    //onClick={this.handleAddLevel}
+                    color={ButtonColor.blue}
+                    size={ButtonSize.narrow}
+                  />
+                  <Button
+                    icon="files-o"
+                    text={''}
+                    onClick={() => {
+                      console.log('Clone Level and Add');
+                    }}
+                    color={ButtonColor.blue}
+                    size={ButtonSize.narrow}
+                  />
+                </td>
+                <td>
+                  <div>{level.name}</div>
+                </td>
+                <td>
+                  <div>{level.type}</div>
+                </td>
+                <td>
+                  <div>{level.user_id}</div>
+                </td>
+                <td>
+                  <div>{level.updated_at}</div>
+                </td>
+              </tr>
+            ))}
           </tbody>
         </table>
         <div style={styles.pages}>

--- a/apps/src/lib/levelbuilder/lesson-editor/AddLevelTable.jsx
+++ b/apps/src/lib/levelbuilder/lesson-editor/AddLevelTable.jsx
@@ -78,7 +78,7 @@ export default class AddLevelTable extends Component {
                   <div>{level.type}</div>
                 </td>
                 <td>
-                  <div>{level.user_id}</div>
+                  <div>{level.owner}</div>
                 </td>
                 <td>
                   <div>{level.updated_at}</div>

--- a/apps/src/lib/levelbuilder/lesson-editor/AddLevelTable.jsx
+++ b/apps/src/lib/levelbuilder/lesson-editor/AddLevelTable.jsx
@@ -17,10 +17,6 @@ export default class AddLevelTable extends Component {
     levels: PropTypes.array
   };
 
-  handleAddLevel = level => {
-    this.props.addLevel(level);
-  };
-
   render() {
     return (
       <div>

--- a/apps/src/lib/levelbuilder/lesson-editor/AddLevelTable.jsx
+++ b/apps/src/lib/levelbuilder/lesson-editor/AddLevelTable.jsx
@@ -24,7 +24,7 @@ export default class AddLevelTable extends Component {
   render() {
     return (
       <div>
-        <table>
+        <table style={{width: '100%'}}>
           <thead>
             <tr>
               <th style={{width: '13%'}}>Actions</th>

--- a/apps/src/lib/levelbuilder/shapes.jsx
+++ b/apps/src/lib/levelbuilder/shapes.jsx
@@ -19,9 +19,9 @@ export const levelShape = PropTypes.shape({
   position: PropTypes.number.isRequired,
 
   // level id, or -1 if no level is selected.
-  activeId: PropTypes.number.isRequired,
+  activeId: PropTypes.number, //.isRequired,
   // level ids for all variants of this level
-  ids: PropTypes.arrayOf(PropTypes.number).isRequired,
+  ids: PropTypes.arrayOf(PropTypes.number), //.isRequired,
 
   // whether this LevelToken is expanded in the UI.
   expand: PropTypes.bool,

--- a/apps/src/lib/levelbuilder/shapes.jsx
+++ b/apps/src/lib/levelbuilder/shapes.jsx
@@ -19,9 +19,9 @@ export const levelShape = PropTypes.shape({
   position: PropTypes.number.isRequired,
 
   // level id, or -1 if no level is selected.
-  activeId: PropTypes.number, //.isRequired,
+  activeId: PropTypes.number,
   // level ids for all variants of this level
-  ids: PropTypes.arrayOf(PropTypes.number), //.isRequired,
+  ids: PropTypes.arrayOf(PropTypes.number),
 
   // whether this LevelToken is expanded in the UI.
   expand: PropTypes.bool,

--- a/apps/test/unit/lib/levelbuilder/lesson-editor/AddLevelTableTest.jsx
+++ b/apps/test/unit/lib/levelbuilder/lesson-editor/AddLevelTableTest.jsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import {mount} from 'enzyme';
+import {shallow} from 'enzyme';
 import {expect} from '../../../../util/reconfiguredChai';
 import AddLevelTable from '@cdo/apps/lib/levelbuilder/lesson-editor/AddLevelTable';
 import sinon from 'sinon';
@@ -43,7 +43,7 @@ describe('AddLevelTable', () => {
   });
 
   it('renders default props', () => {
-    const wrapper = mount(<AddLevelTable {...defaultProps} />);
+    const wrapper = shallow(<AddLevelTable {...defaultProps} />);
     expect(wrapper.contains('Actions')).to.be.true;
     expect(wrapper.contains('Name')).to.be.true;
     expect(wrapper.contains('Type')).to.be.true;

--- a/apps/test/unit/lib/levelbuilder/lesson-editor/AddLevelTableTest.jsx
+++ b/apps/test/unit/lib/levelbuilder/lesson-editor/AddLevelTableTest.jsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import {shallow} from 'enzyme';
+import {mount} from 'enzyme';
 import {expect} from '../../../../util/reconfiguredChai';
 import AddLevelTable from '@cdo/apps/lib/levelbuilder/lesson-editor/AddLevelTable';
 import sinon from 'sinon';
@@ -8,17 +8,48 @@ describe('AddLevelTable', () => {
   let defaultProps;
   beforeEach(() => {
     defaultProps = {
-      addLevel: sinon.spy()
+      addLevel: sinon.spy(),
+      levels: [
+        {
+          id: 1,
+          name: 'Level 1',
+          type: 'Applab',
+          owner: 'Islay',
+          updated_at: '09/30/20 at 08:37:04 PM'
+        },
+        {
+          id: 2,
+          name: 'Level 2',
+          type: 'Applab',
+          owner: 'Tonka',
+          updated_at: '09/2/20 at 08:37:04 PM'
+        },
+        {
+          id: 3,
+          name: 'Level 3',
+          type: 'Multi',
+          owner: 'Islay',
+          updated_at: '09/30/17 at 01:37:04 PM'
+        },
+        {
+          id: 4,
+          name: 'Level 4',
+          type: 'Multi',
+          owner: 'Tonka',
+          updated_at: '01/2/18 at 08:37:04 AM'
+        }
+      ]
     };
   });
 
   it('renders default props', () => {
-    const wrapper = shallow(<AddLevelTable {...defaultProps} />);
+    const wrapper = mount(<AddLevelTable {...defaultProps} />);
     expect(wrapper.contains('Actions')).to.be.true;
     expect(wrapper.contains('Name')).to.be.true;
     expect(wrapper.contains('Type')).to.be.true;
     expect(wrapper.contains('Owner')).to.be.true;
     expect(wrapper.contains('Last Updated')).to.be.true;
-    expect(wrapper.find('Button').length).to.equal(4);
+    expect(wrapper.find('button').length).to.equal(8); // 2 buttons for each level
+    expect(wrapper.find('tr').length).to.equal(5); // 1 for the headers and 1 for each level
   });
 });

--- a/dashboard/app/controllers/levels_controller.rb
+++ b/dashboard/app/controllers/levels_controller.rb
@@ -103,6 +103,7 @@ class LevelsController < ApplicationController
   def get_filtered_levels
     filter_levels(params)
     @levels = @levels.page(params[:page]).per(8)
+    @levels = @levels.map(&:summarize_for_edit)
     render json: @levels
   end
 

--- a/dashboard/app/controllers/levels_controller.rb
+++ b/dashboard/app/controllers/levels_controller.rb
@@ -89,6 +89,7 @@ class LevelsController < ApplicationController
     ]
 
     filter_levels(params)
+    @levels = @levels.page(params[:page]).per(LEVELS_PER_PAGE)
   end
 
   # GET /levels/get_filters/
@@ -101,6 +102,7 @@ class LevelsController < ApplicationController
   # Get all the information for levels after filtering
   def get_filtered_levels
     filter_levels(params)
+    @levels = @levels.page(params[:page]).per(8)
     render json: @levels
   end
 
@@ -129,7 +131,6 @@ class LevelsController < ApplicationController
     @levels = @levels.where('levels.type = ?', params[:level_type]) if params[:level_type].present?
     @levels = @levels.joins(:script_levels).where('script_levels.script_id = ?', params[:script_id]) if params[:script_id].present?
     @levels = @levels.left_joins(:user).where('levels.user_id = ?', params[:owner_id]) if params[:owner_id].present?
-    @levels = @levels.page(params[:page]).per(LEVELS_PER_PAGE)
   end
 
   # GET /levels/1

--- a/dashboard/app/controllers/levels_controller.rb
+++ b/dashboard/app/controllers/levels_controller.rb
@@ -102,7 +102,7 @@ class LevelsController < ApplicationController
   # Get all the information for levels after filtering
   def get_filtered_levels
     filter_levels(params)
-    @levels = @levels.page(params[:page]).per(8)
+    @levels = @levels.page(params[:page]).per(7)
     @levels = @levels.map(&:summarize_for_edit)
     render json: @levels
   end

--- a/dashboard/app/models/levels/level.rb
+++ b/dashboard/app/models/levels/level.rb
@@ -600,6 +600,16 @@ class Level < ActiveRecord::Base
     }
   end
 
+  def summarize_for_edit
+    {
+      id: id,
+      type: self.class.to_s,
+      name: name,
+      updated_at: updated_at.localtime.strftime("%D at %r"),
+      owner: user&.name
+    }
+  end
+
   def summary_for_lesson_plans
     summary = summarize
 

--- a/dashboard/test/controllers/levels_controller_test.rb
+++ b/dashboard/test/controllers/levels_controller_test.rb
@@ -96,7 +96,7 @@ class LevelsControllerTest < ActionController::TestCase
 
   test "should get filtered levels with just page param" do
     get :get_filtered_levels, params: {page: 1}
-    assert_equal JSON.parse(@response.body).length, 30
+    assert_equal JSON.parse(@response.body).length, 7
   end
 
   test "should get filtered levels with level_type" do
@@ -107,7 +107,7 @@ class LevelsControllerTest < ActionController::TestCase
 
   test "should get filtered levels with script_id" do
     get :get_filtered_levels, params: {page: 1, script_id: 2}
-    assert_equal JSON.parse(@response.body).length, 20
+    assert_equal JSON.parse(@response.body).length, 7
   end
 
   test "should get filtered levels with owner_id" do

--- a/dashboard/test/models/level_test.rb
+++ b/dashboard/test/models/level_test.rb
@@ -149,6 +149,19 @@ class LevelTest < ActiveSupport::TestCase
     assert_nil(summary[:display_name])
   end
 
+  test "summarize_for_edit returns object with expected fields" do
+    user = User.create(name: 'Best Curriculum Writer')
+    level = Level.create!(name: 'test_level', type: 'Maze', user: user, updated_at: Time.new(2020, 3, 27, 0, 0, 0, "-07:00"))
+
+    summary = level.summarize_for_edit
+
+    assert_equal(summary[:id], level.id)
+    assert_equal(summary[:type], 'Maze')
+    assert_equal(summary[:name], 'test_level')
+    assert_equal(summary[:owner], 'Best Curriculum Writer')
+    assert_equal(summary[:updated_at], "03/27/20 at 03:00:00 AM")
+  end
+
   test "get_question_text returns question text for free response level" do
     free_response_level = create :level, name: 'A question', long_instructions: 'Answer this question.',
       type: 'FreeResponse'

--- a/dashboard/test/models/level_test.rb
+++ b/dashboard/test/models/level_test.rb
@@ -159,7 +159,7 @@ class LevelTest < ActiveSupport::TestCase
     assert_equal(summary[:type], 'Maze')
     assert_equal(summary[:name], 'test_level')
     assert_equal(summary[:owner], 'Best Curriculum Writer')
-    assert_equal(summary[:updated_at], "03/27/20 at 03:00:00 AM")
+    assert(summary[:updated_at].include?("03/27/20 at")) # The time is different locally than on drone
   end
 
   test "get_question_text returns question text for free response level" do


### PR DESCRIPTION
Shows the real filtered search results data in the AddLevelsDialog. This is the dialog used in the Activities Editor to add levels to Activity Sections.

Follow Up Work:
- Pagination
- Add and Clone Buttons working

<img width="1128" alt="Screen Shot 2020-10-01 at 8 08 45 PM" src="https://user-images.githubusercontent.com/208083/94875147-ece82200-0421-11eb-8827-f7b6229f8b80.png">

## Links

<!--
  Any relevant links to external resources; ie, specification documents, jira
  items, related PRs, honeybadger errors, etc
-->

- [spec](https://docs.google.com/document/d/1LVwA7VtxkkIFZSi7StwAtgHfxFUIAN1E3nbDRjEXWP4/edit#heading=h.3lytjaku1623)
- [jira](https://codedotorg.atlassian.net/browse/PLAT-290)

## Testing story

Updated AddLevelsTableTest
Created test for summarize_for_edit
Updated tests for get_filtered_levels

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
