### PR TITLE
Fix script level recreation bugs

### DIFF
--- a/dashboard/app/models/lesson.rb
+++ b/dashboard/app/models/lesson.rb
@@ -91,8 +91,16 @@ class Lesson < ActiveRecord::Base
       lesson.save!
 
       Lesson.prevent_multi_page_assessment_outside_final_level(lesson)
+      Lesson.prevent_level_in_lesson_multiple_times(script, lesson)
 
       lesson
+    end
+  end
+
+  def self.prevent_level_in_lesson_multiple_times(script, lesson)
+    script_levels_by_level_ids = lesson.script_levels.group_by {|sl| sl.levels.map(&:id).sort}
+    if script_levels_by_level_ids.any? {|_, v| v.length > 1}
+      raise "Level cannot be added multiple times to one lesson. Lesson key: #{lesson.key} Script name: #{script.name}"
     end
   end
 

--- a/dashboard/test/models/script_test.rb
+++ b/dashboard/test/models/script_test.rb
@@ -185,6 +185,7 @@ class ScriptTest < ActiveSupport::TestCase
     assert_equal 1, first.absolute_position
     assert_equal 2, second.absolute_position
     assert_equal 3, third.absolute_position
+    original_script_level_ids = script.script_levels.map(&:id)
 
     # Reupload a script of the same filename / name, but lacking the middle lesson.
     script_names, _ = Script.setup([script_file_middle_missing_reversed])
@@ -198,6 +199,10 @@ class ScriptTest < ActiveSupport::TestCase
     assert_equal 2, second.absolute_position
     assert_equal 'lesson3', first.name
     assert_equal 'lesson1', second.name
+    # One Lesson / ScriptLevel removed, the rest reordered
+    expected_script_level_ids = [original_script_level_ids[3], original_script_level_ids[4],
+                                 original_script_level_ids[0], original_script_level_ids[1]]
+    assert_equal expected_script_level_ids, script.script_levels.map(&:id)
   end
 
   test 'all fields can be set and then removed on reseed' do
@@ -1384,6 +1389,7 @@ class ScriptTest < ActiveSupport::TestCase
       ScriptDSL.parse(old_dsl, 'a filename')[0][:lesson_groups]
     )
     assert script.script_levels.first.challenge
+    original_script_level_id = script.script_levels.first.id
 
     script = Script.add_script(
       {name: 'challengeTestScript'},
@@ -1391,6 +1397,7 @@ class ScriptTest < ActiveSupport::TestCase
     )
 
     refute script.script_levels.first.challenge
+    assert_equal original_script_level_id, script.script_levels.first.id
   end
 
   test 'can make a bonus level not a bonus level' do
@@ -1408,6 +1415,7 @@ class ScriptTest < ActiveSupport::TestCase
       ScriptDSL.parse(old_dsl, 'a filename')[0][:lesson_groups]
     )
     assert script.script_levels.first.bonus
+    original_script_level_id = script.script_levels.first.id
 
     script = Script.add_script(
       {name: 'challengeTestScript'},
@@ -1415,6 +1423,7 @@ class ScriptTest < ActiveSupport::TestCase
     )
 
     refute script.script_levels.first.bonus
+    assert_equal original_script_level_id, script.script_levels.first.id
   end
 
   test 'can unset the project_widget_visible attribute' do

--- a/dashboard/test/models/script_test.rb
+++ b/dashboard/test/models/script_test.rb
@@ -2556,6 +2556,24 @@ class ScriptTest < ActiveSupport::TestCase
     assert_equal script.lesson_groups[1].lessons[0].absolute_position, 3
   end
 
+  test 'level can only be added once to a lesson' do
+    level = create :level
+    dsl = <<~SCRIPT
+      lesson 'lesson1', display_name: 'lesson1'
+      level '#{level.name}'
+      level '#{level.name}'
+    SCRIPT
+
+    error = assert_raises do
+      Script.add_script(
+        {name: 'level-included-multiple-times'},
+        ScriptDSL.parse(dsl, 'a filename')[0][:lesson_groups]
+      )
+    end
+    expected_message = 'Level cannot be added multiple times to one lesson. Lesson key: lesson1 Script name: level-included-multiple-times'
+    assert_equal expected_message, error.message
+  end
+
   test 'seeding_key' do
     script = create :script
 


### PR DESCRIPTION
Fixes bugs described in https://github.com/code-dot-org/code-dot-org/pull/36984

From our standup discussion, we decided to only use Script, Lesson, and Levels to find existing ScriptLevels. This means moving levels around in the .script file, or changing properties like challenge/bonus, won't cause new ScriptLevels to be created. This also means that this won't work if a level is included multiple times in the same lesson.

## Testing story

* Updated tests to repro the bugs, they fail before the code change
* Code change should fix the unit tests
* Manually seeded all using `staging` branch, stored the list of all script level IDs, then seeded using this branch, and compared all the script level IDs after. They were all the same, except for 9 missing script level IDs, which were all from duplicate levels within a lesson. We've since cleaned up those duplicate levels.

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
