### PR TITLE
Ending Immersive Reader experiment and keeping enabled

### DIFF
--- a/apps/src/templates/instructions/ImmersiveReaderButton.jsx
+++ b/apps/src/templates/instructions/ImmersiveReaderButton.jsx
@@ -3,7 +3,6 @@ import PropTypes from 'prop-types';
 import handleLaunchImmersiveReader from '@cdo/apps/util/immersive_reader';
 import {renderButtons} from '@microsoft/immersive-reader-sdk';
 import cookies from 'js-cookie';
-import experiments from '@cdo/apps/util/experiments';
 
 class ImmersiveReaderButton extends Component {
   static propTypes = {
@@ -20,12 +19,8 @@ class ImmersiveReaderButton extends Component {
     const {title, text} = this.props;
     // Get the current language from the language cookie.
     const locale = cookies.get('language_') || 'en-US';
-
-    // Hide the button if the experiment is not enabled.
-    const enabled = experiments.isEnabled(experiments.IMMERSIVE_READER);
     return (
       <div
-        style={enabled ? {} : {display: 'none'}}
         className={'immersive-reader-button'}
         data-button-style={'icon'}
         data-locale={locale}

--- a/apps/src/util/experiments.js
+++ b/apps/src/util/experiments.js
@@ -29,7 +29,6 @@ experiments.TEACHER_DASHBOARD_SECTION_BUTTONS_ALTERNATE_TEXT =
   'teacher-dashboard-section-buttons-alternate-text';
 experiments.TEXT_TO_SPEECH_BLOCK = 'text-to-speech-block';
 experiments.FINISH_DIALOG_METRICS = 'finish-dialog-metrics';
-experiments.IMMERSIVE_READER = 'immersive-reader';
 experiments.I18N_TRACKING = 'i18n-tracking';
 
 /**


### PR DESCRIPTION
We are ready to enabled the Immersive Reader feature permanently. This PR removes the experiment checks.

## Testing story
* Manually tested on localhost

## Follow-up tasks
* After this is pushed to production I will disable the Optimizley experiment.
# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
