### PR TITLE
Teacher App gsheet export: Update to 21-22

### DIFF
--- a/bin/cron/teacher_applications_to_gdrive
+++ b/bin/cron/teacher_applications_to_gdrive
@@ -13,7 +13,7 @@ def get_rows
   applications = [%w(course regional_partner status scholarship_status school_type pay_fee email created_at
                      meets_minimum_requirements meets_scholarship_criteria registered_for_workshop rural_status
                      free_reduced_lunch_percent urm_percent accepted_at)]
-  Pd::Application::Teacher2021Application.find_each do |app|
+  Pd::Application::Teacher2122Application.find_each do |app|
     stats = app.get_latest_school_stats(app.school_id)
     pay_fee = app.sanitize_form_data_hash[:principal_pay_fee] || app.sanitize_form_data_hash[:pay_fee]
     frl_percent = stats&.frl_eligible_percent
@@ -54,8 +54,8 @@ def main
   allowed_list = DCDO.get('external_emails_with_application_data_access', [])
 
   # Uses a Google Cloud service account to access Google Drive
-  sheet = Google::Sheet.new CDO.applications_2020_2021_gsheet_key
-  sheet.export(tab_name: 'all_apps', rows: get_rows)
+  sheet = Google::Sheet.new CDO.applications_2021_2022_gsheet_key
+  sheet.export(tab_name: 'all_apps_21_22', rows: get_rows)
   sheet.notify_of_external_sharing(allowed_list)
 end
 

--- a/config.yml.erb
+++ b/config.yml.erb
@@ -464,6 +464,7 @@ image_optim: <%=chef_managed && !ci_test%>
 # Used to export data on professional learning to gsheets
 applications_2020_2021_gsheet_key: !Secret
 enrollments_summer_2020_gsheet_key:
+applications_2021_2022_gsheet_key: !Secret
 
 # Referenced in Chef config, but not sure if they are still used anywhere?
 # TODO: verify these are intentionally no longer used and remove references from Chef config.


### PR DESCRIPTION
Update teacher application gsheet export to go to new gsheet and write the 2021-2022 application data. 
See [work from last year](https://github.com/code-dot-org/code-dot-org/pull/32597) for details on how the gsheet writing works. 
The 2021-2022 applications will go to [this gsheet (private)](https://docs.google.com/spreadsheets/d/1he4iaFHl61fikFMOXSTG3yGwvHZWIsEcxo0fGaRAh4Q/).  The new application data will be written to tabs called `all_apps_21_22 (auto)` and `all_apps_21_22_meta (auto)`. If we want to switch back to `all_apps` like last year we can do that as a follow-up PR. I wanted to be super-safe and not accidentally overwrite last year's data--once we have the cronjob running satisfactorily in prod we can update the tab names.
I have set the gsheet up to give write permissions to our production service account. While testing I shared with our non-production service account and everything worked as expected.

<!-- ### Background -->
### Privacy
This process does involve writing PII to a google sheet. The script will already emit a warning if the sheet it writes to is shared with anyone outside our allow-list. The new sheet is only shared with code.org emails and the production service account. This process is not a change from our existing application export process.
<!-- ### Caching -->
<!-- ### Deployment strategy -->
<!-- ### Future work -->

## Links

- [jira](https://codedotorg.atlassian.net/browse/PLC-1009)

## Testing story
I followed the testing process laid out in [this PR](https://github.com/code-dot-org/code-dot-org/pull/32609). 

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
