### PR TITLE
Stop summer workshop cron jobs

### DIFF
--- a/cookbooks/cdo-apps/templates/default/crontab.erb
+++ b/cookbooks/cdo-apps/templates/default/crontab.erb
@@ -93,8 +93,6 @@
       cronjob at:'*/10 * * * *', do:deploy_dir('bin', 'cron', 'delete_twilio_data')
       cronjob at:'* * * * *', do:deploy_dir('bin', 'cron', 'confirm_usage')
       cronjob at:'0 */2 * * *', do:deploy_dir('bin', 'cron', 'teacher_applications_to_gdrive')
-      cronjob at:'45 */2 * * *', do:deploy_dir('bin', 'cron', 'summer_workshop_enrollments_to_gdrive')
-      cronjob at:'30 */2 * * *', do:deploy_dir('bin', 'cron', 'summer_workshops_to_gdrive')
       cronjob at:'0 7 * * *', do:deploy_dir('bin', 'cron', 'stop_inactive_adhoc_instances')
       cronjob at:'0 10 * * *', do:deploy_dir('bin', 'cron', 'redshift_rollups')
       cronjob at:'1 7 * * 6', do:deploy_dir('bin', 'cron', 'cleanup_workshop_attendance_codes')


### PR DESCRIPTION
`summer_workshops_to_gdrive` and `summer_workshop_enrollments_to_gdrive` cronjobs do not need to run anymore. They were running every 2 hours and rewriting the same information since summer workshops are over. When it comes time to restart these we will need to update the dates and secrets and add them back to `crontab.erb`.

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
