### PR TITLE
[drone test] Insert spinner while classroom sections are loading

### DIFF
--- a/apps/src/templates/teacherDashboard/OwnedSections.jsx
+++ b/apps/src/templates/teacherDashboard/OwnedSections.jsx
@@ -21,6 +21,7 @@ import SetUpSections from '../studioHomepages/SetUpSections';
 import {recordOpenEditSectionDetails} from './sectionHelpers';
 import experiments from '@cdo/apps/util/experiments';
 import {recordImpression} from './impressionHelpers';
+import Spinner from '@cdo/apps/code-studio/pd/components/spinner';
 
 const styles = {
   button: {
@@ -37,6 +38,9 @@ const styles = {
     fontSize: 14,
     paddingBottom: 5,
     color: color.charcoal
+  },
+  spinner: {
+    marginTop: '10px'
   }
 };
 
@@ -93,7 +97,7 @@ class OwnedSections extends React.Component {
     const {viewHidden} = this.state;
 
     if (!asyncLoadComplete) {
-      return null;
+      return <Spinner size="large" style={styles.spinner} />;
     }
 
     const hasSections = sectionIds.length > 0;

--- a/apps/test/unit/templates/teacherDashboard/OwnedSectionsTest.js
+++ b/apps/test/unit/templates/teacherDashboard/OwnedSectionsTest.js
@@ -7,6 +7,7 @@ import RosterDialog from '@cdo/apps/templates/teacherDashboard/RosterDialog';
 import AddSectionDialog from '@cdo/apps/templates/teacherDashboard/AddSectionDialog';
 import EditSectionDialog from '@cdo/apps/templates/teacherDashboard/EditSectionDialog';
 import SetUpSections from '@cdo/apps/templates/studioHomepages/SetUpSections';
+import Spinner from '@cdo/apps/code-studio/pd/components/spinner';
 
 const defaultProps = {
   sectionIds: [11, 12, 13],
@@ -30,6 +31,12 @@ describe('OwnedSections', () => {
         <EditSectionDialog />
       </div>
     );
+  });
+
+  it('renders spinner when sections have not yet loaded', () => {
+    const props = {...defaultProps, asyncLoadComplete: false};
+    const wrapper = shallow(<OwnedSections {...props} />);
+    expect(wrapper).to.containMatchingElement(<Spinner />);
   });
 
   it('renders a OwnedSectionsTable with no extra button if no archived sections', () => {


### PR DESCRIPTION
Running drone tests for this contributor PR: https://github.com/code-dot-org/code-dot-org/pull/37012

<!--
  Other aspects to consider. uncomment and add detail for any that seem necessary:
-->

<!-- ### Background -->
<!-- ### Privacy -->
<!--
1.	Does the Project involve the collection, use or sharing of new Personal Data?

2.	Does the Project involve a new or changed use or sharing of existing Personal Data?
-->
<!-- ### Security -->
<!--
Link to Jira Task where sensitive security issues are discussed privately.
-->
<!-- ### Caching -->
<!-- ### Deployment strategy -->
<!-- ### Future work -->

## Links

<!--
  Any relevant links to external resources; ie, specification documents, jira
  items, related PRs, honeybadger errors, etc
-->


## Testing story

<!--
  Does your change include appropriate tests?

  If so, please describe how the tests included in this PR are sufficient

  If not, please explain why this change does not need to be tested.
-->

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
