### PR TITLE
Add an "unfinished" state to the finish dialog for lab levels

### DIFF
--- a/apps/i18n/common/en_us.json
+++ b/apps/i18n/common/en_us.json
@@ -806,6 +806,7 @@
   "formErrorsBelow": "Please correct the errors below.",
   "formServerError": "Something went wrong on our end; please try again later.",
   "forTeachersOnly": "For Teachers Only",
+  "freePlayUnchangedFail": "Are you finished? It looks like you haven't finished working on this level yet, are you sure you want to move on? If you choose to continue, this level will be marked as \"In progress\" so you can come back to finish it later.",
   "fromWhen": "(From {when}):",
   "gdprDialogHeader": "Do you agree to using a website based in the United States?",
   "gdprDialogDetails": "Data from your use of this site may be sent to and stored or processed in the United States.",

--- a/apps/i18n/common/en_us.json
+++ b/apps/i18n/common/en_us.json
@@ -807,6 +807,7 @@
   "formServerError": "Something went wrong on our end; please try again later.",
   "forTeachersOnly": "For Teachers Only",
   "freePlayUnchangedFail": "Are you finished? It looks like you haven't finished working on this level yet, are you sure you want to move on? If you choose to continue, this level will be marked as \"In progress\" so you can come back to finish it later.",
+  "freePlayUnchangedFailInline": "It looks like you haven't finished working on this level yet. Try adding some more blocks!",
   "fromWhen": "(From {when}):",
   "gdprDialogHeader": "Do you agree to using a website based in the United States?",
   "gdprDialogDetails": "Data from your use of this site may be sent to and stored or processed in the United States.",

--- a/apps/src/StudioApp.js
+++ b/apps/src/StudioApp.js
@@ -1678,12 +1678,11 @@ StudioApp.prototype.displayFeedback = function(options) {
       project.getShareUrl();
   } catch (e) {}
 
-  if (
-    this.shouldDisplayFeedbackDialog_(
-      options.preventDialog,
-      options.feedbackType
-    )
-  ) {
+  options.useDialog = this.shouldDisplayFeedbackDialog_(
+    options.preventDialog,
+    options.feedbackType
+  );
+  if (options.useDialog) {
     // let feedback handle creating the dialog
     this.feedback_.displayFeedback(
       options,

--- a/apps/src/feedback.js
+++ b/apps/src/feedback.js
@@ -747,6 +747,9 @@ FeedbackUtils.prototype.getFeedbackMessage = function(options) {
   } else {
     // Otherwise, the message will depend on the test result.
     switch (options.feedbackType) {
+      case TestResults.FREE_PLAY_UNCHANGED_FAIL:
+        message = msg.freePlayUnchangedFail();
+        break;
       case TestResults.RUNTIME_ERROR_FAIL:
         message = msg.runtimeErrorMsg({
           lineNumber: options.executionError.lineNumber

--- a/apps/src/feedback.js
+++ b/apps/src/feedback.js
@@ -748,7 +748,9 @@ FeedbackUtils.prototype.getFeedbackMessage = function(options) {
     // Otherwise, the message will depend on the test result.
     switch (options.feedbackType) {
       case TestResults.FREE_PLAY_UNCHANGED_FAIL:
-        message = msg.freePlayUnchangedFail();
+        message = options.useDialog
+          ? msg.freePlayUnchangedFail()
+          : msg.freePlayUnchangedFailInline();
         break;
       case TestResults.RUNTIME_ERROR_FAIL:
         message = msg.runtimeErrorMsg({

--- a/apps/src/p5lab/P5Lab.js
+++ b/apps/src/p5lab/P5Lab.js
@@ -76,6 +76,7 @@ import {
 } from '@cdo/apps/util/exporter';
 import project from '@cdo/apps/code-studio/initApp/project';
 import {setExportGeneratedProperties} from '@cdo/apps/code-studio/components/exportDialogRedux';
+import {hasInstructions} from '@cdo/apps/templates/instructions/utils';
 
 const defaultMobileControlsConfig = {
   spaceButtonVisible: true,
@@ -307,7 +308,14 @@ P5Lab.prototype.init = function(config) {
   // Display CSF-style instructions when using Blockly. Otherwise provide a way
   // for us to have top pane instructions disabled by default, but able to turn
   // them on.
-  config.noInstructionsWhenCollapsed = !this.isSpritelab;
+  config.noInstructionsWhenCollapsed =
+    !this.isSpritelab ||
+    (this.isSpritelab &&
+      !hasInstructions(
+        this.level.shortInstructions,
+        this.level.longInstructions,
+        config.hasContainedLevels
+      ));
 
   var breakpointsEnabled = !config.level.debuggerDisabled;
   config.enableShowCode = true;
@@ -818,10 +826,10 @@ P5Lab.prototype.onPuzzleComplete = function(submit, testResult, message) {
     this.testResults = this.studioApp_.getTestResults(levelComplete, {
       executionError: this.executionError
     });
-  } else if (sourcesUnchanged) {
-    this.testResults = TestResults.FREE_PLAY_UNCHANGED_FAIL;
   } else if (testResult) {
     this.testResults = testResult;
+  } else if (sourcesUnchanged) {
+    this.testResults = TestResults.FREE_PLAY_UNCHANGED_FAIL;
   } else {
     this.testResults = TestResults.FREE_PLAY;
   }

--- a/apps/src/p5lab/P5Lab.js
+++ b/apps/src/p5lab/P5Lab.js
@@ -305,9 +305,9 @@ P5Lab.prototype.init = function(config) {
     }.bind(this)
   };
 
-  // Display CSF-style instructions when using Blockly. Otherwise provide a way
-  // for us to have top pane instructions disabled by default, but able to turn
-  // them on.
+  // Display CSF-style instructions when using Blockly (unless there are no
+  // instructions to display). Otherwise provide a way for us to have top pane
+  // instructions disabled by default, but able to turn them on.
   config.noInstructionsWhenCollapsed =
     !this.isSpritelab ||
     (this.isSpritelab &&

--- a/apps/src/templates/instructions/TopInstructions.jsx
+++ b/apps/src/templates/instructions/TopInstructions.jsx
@@ -30,6 +30,7 @@ import queryString from 'query-string';
 import InstructionsCSF from './InstructionsCSF';
 import firehoseClient from '@cdo/apps/lib/util/firehose';
 import {WIDGET_WIDTH} from '@cdo/apps/applab/constants';
+import {hasInstructions} from './utils';
 
 const HEADER_HEIGHT = styleConstants['workspace-headers-height'];
 const RESIZER_HEIGHT = styleConstants['resize-bar-width'];
@@ -302,9 +303,11 @@ class TopInstructions extends Component {
       nextProps.height < nextProps.maxHeight &&
       !(
         nextProps.hidden ||
-        (!nextProps.shortInstructions &&
-          !nextProps.longInstructions &&
-          !nextProps.hasContainedLevels)
+        !hasInstructions(
+          nextProps.shortInstructions,
+          nextProps.longInstructions,
+          nextProps.hasContainedLevels
+        )
       )
     ) {
       this.props.setInstructionsRenderedHeight(
@@ -352,12 +355,19 @@ class TopInstructions extends Component {
    */
 
   adjustMaxNeededHeight = () => {
+    const {
+      hidden,
+      shortInstructions,
+      longInstructions,
+      hasContainedLevels,
+      maxHeight,
+      setInstructionsMaxHeightNeeded
+    } = this.props;
+
     // if not showing the instructions area the max needed height should be 0
     if (
-      this.props.hidden ||
-      (!this.props.shortInstructions &&
-        !this.props.longInstructions &&
-        !this.props.hasContainedLevels)
+      hidden ||
+      !hasInstructions(shortInstructions, longInstructions, hasContainedLevels)
     ) {
       return 0;
     }
@@ -382,8 +392,8 @@ class TopInstructions extends Component {
       HEADER_HEIGHT +
       RESIZER_HEIGHT;
 
-    if (this.props.maxHeight !== maxNeededHeight) {
-      this.props.setInstructionsMaxHeightNeeded(maxNeededHeight);
+    if (maxHeight !== maxNeededHeight) {
+      setInstructionsMaxHeightNeeded(maxNeededHeight);
     }
     return maxNeededHeight;
   };
@@ -578,7 +588,7 @@ class TopInstructions extends Component {
 
     if (
       hidden ||
-      (!shortInstructions && !longInstructions && !hasContainedLevels)
+      !hasInstructions(shortInstructions, longInstructions, hasContainedLevels)
     ) {
       return <div />;
     }

--- a/apps/src/templates/instructions/utils.js
+++ b/apps/src/templates/instructions/utils.js
@@ -2,6 +2,20 @@ import ReactDOM from 'react-dom';
 import $ from 'jquery';
 
 /**
+ * Checks the given inputs to determine whether the instruction panel should be displayed
+ * @param {string} shortInstructions
+ * @param {string} longInstructions
+ * @param {boolean} hasContainedLevels
+ */
+export function hasInstructions(
+  shortInstructions,
+  longInstructions,
+  hasContainedLevels
+) {
+  return !!(shortInstructions || longInstructions || hasContainedLevels);
+}
+
+/**
  * @param {ReactComponent} component
  * @param {boolean} includeMargin
  * @returns {number} The current computed height in pixels of the specified component,


### PR DESCRIPTION
When this feature is enabled, if a user has clicked the "finish" or "complete" button without changing the code on freeplay levels, the "unfinished" dialog will be displayed and the user will not be able to easily move to the next level.

This is most relevant on Game Lab and App Lab levels, where a student can currently click through and complete levels without changing any code.
Example: https://studio.code.org/s/csp5-2020/stage/3/puzzle/2 

Additionally, this will be enabled for freeplay Sprite Lab levels. Sprite Lab, by default displays error feedback in the instruction panel. 
Example: https://studio.code.org/s/coursee-2020/stage/9/puzzle/6

However, some Sprite Lab levels are completely open-ended with no instruction panel. These normally do not display error feedback. With this feature, however, these levels should display error feedback in the error dialog.
Example: https://studio.code.org/s/coursee-2019/stage/18/puzzle/2

Example error feedback in the instruction panel:
![image](https://user-images.githubusercontent.com/8324574/95121352-c8cb6000-0703-11eb-8b2e-e0cdf927a57a.png)

Example error feedback in the feedback dialog:
![image](https://user-images.githubusercontent.com/8324574/94977002-b7980e80-04cb-11eb-8c02-d0590b888013.png)


<!--
  Your description goes here: A summary of the change, including any relevant motivation and context.

  If relevant, include a description both of the existing behavior and of the new behavior.
-->

<!--
  Other aspects to consider. uncomment and add detail for any that seem necessary:
-->

<!-- ### Background -->
<!-- ### Privacy -->
<!--
1.	Does the Project involve the collection, use or sharing of new Personal Data?

2.	Does the Project involve a new or changed use or sharing of existing Personal Data?
-->
<!-- ### Security -->
<!--
Link to Jira Task where sensitive security issues are discussed privately.
-->
<!-- ### Caching -->
<!-- ### Deployment strategy -->
<!-- ### Future work -->

## Links

<!--
  Any relevant links to external resources; ie, specification documents, jira
  items, related PRs, honeybadger errors, etc
-->

- [spec](https://docs.google.com/document/d/1hF-wvav0MXLnH49x0WBeO8TcUibMaCUegZiDr8-6l-c/edit#)
- [dev-doc](https://docs.google.com/document/d/1xUgybM56dV5kmqOukKVPW1d88a9HGhphUs2r0tWlC_4/edit#)
- [LP-1547](https://codedotorg.atlassian.net/browse/LP-1547)

## Testing story

<!--
  Does your change include appropriate tests?

  If so, please describe how the tests included in this PR are sufficient

  If not, please explain why this change does not need to be tested.
-->

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
