### PR TITLE
Allow spaces and special characters in the DOTD name in the #developers channel

### DIFF
--- a/lib/cdo/developers_topic.rb
+++ b/lib/cdo/developers_topic.rb
@@ -21,7 +21,7 @@ module DevelopersTopic
   # @return [String] The DOTD (without the '@' symbol), as per the Slack#developers topic.
   def self.dotd
     current_topic = Slack.get_topic 'developers'
-    dotd = /DOTD: @?([a-z.]+);/i.match(current_topic)
+    dotd = /DOTD: @?(.+);/i.match(current_topic)
     raise 'developers topic not propertly formatted' unless dotd
     dotd[1]
   end

--- a/lib/cdo/developers_topic.rb
+++ b/lib/cdo/developers_topic.rb
@@ -21,7 +21,7 @@ module DevelopersTopic
   # @return [String] The DOTD (without the '@' symbol), as per the Slack#developers topic.
   def self.dotd
     current_topic = Slack.get_topic 'developers'
-    dotd = /DOTD: @?(.+);/i.match(current_topic)
+    dotd = /DOTD: @?([^;]+);/i.match(current_topic)
     raise 'developers topic not propertly formatted' unless dotd
     dotd[1]
   end

--- a/lib/test/cdo/test_developers_topic.rb
+++ b/lib/test/cdo/test_developers_topic.rb
@@ -21,6 +21,12 @@ class DevelopersTopicTest < Minitest::Test
       assert_equal 'erin.bond', DevelopersTopic.dotd
     end
 
+    it 'handles usernames with special characters and spaces in them' do
+      Slack.stubs(:get_topic).returns('DOTD: @Jessie (she/her); DTS: yes; DTT: yes; DTP: yes; DTL: yes')
+
+      assert_equal 'Jessie (she/her)', DevelopersTopic.dotd
+    end
+
     it 'raises an exception if topic is malformed' do
       Slack.stubs(:get_topic).returns('DTS: yes; DTT: yes; DTP: yes; DTL: yes')
 


### PR DESCRIPTION
On 8/20/2020, several successful DTTs failed to be automatically marked green. This prevented new changes from being passed into a DTT and even delayed the DTP with content. This happened because spaces in the DOTD name caused an error to be thrown in the DOTD script. Slack usernames can have special characters and spaces in them. The only requirement we have in our script is that we break on semicolons. This PR updates the DOTD script to allow names with spaces and special characters.


### Background
Helpful note: If you change the status in #developers (i.e. to open or close staging) slack may auto-fill your name to the tagged version of @name. This seems to cause the DTT auto-green process to fail. 

Example: 
<img src="https://user-images.githubusercontent.com/8324574/95130207-14383b00-0711-11eb-868d-0f633bd2fca0.png" width="500" />

After fixing the failed DTS, I re-opened staging. I didn't notice at the time, but when I replaced "DTS: no" with "DTS: yes," the other section of the channel topic auto-updated to use the tagged version of my name
<img src="https://user-images.githubusercontent.com/8324574/95130237-2023fd00-0711-11eb-92df-99304fbbf47f.png" width="400" />

After this point, successful DTTs stopped being set to green automatically. For example, here is the DTT that included the content scoop.
<img src="https://user-images.githubusercontent.com/8324574/95130266-2ade9200-0711-11eb-924e-2ab667933798.png" width="500" />

It wasn't until after I started the DTP around 2:40 that I noticed this hadn't been set to green. After a couple more DTTs that should have automatically been marked green, I took a guess and changed the status in #developers.
<img src="https://user-images.githubusercontent.com/8324574/95130281-30d47300-0711-11eb-8f07-2ea88bf96188.png" width="400" />

After this point, the auto-green functionality started working again.
<img src="https://user-images.githubusercontent.com/8324574/95130295-35009080-0711-11eb-95bc-9288cc46a843.png" width="500" />

After this, I did a second DTP to get out 2 urgent fixes and the content scoop.


<!-- ### Privacy -->
<!--
1.	Does the Project involve the collection, use or sharing of new Personal Data?

2.	Does the Project involve a new or changed use or sharing of existing Personal Data?
-->
<!-- ### Security -->
<!--
Link to Jira Task where sensitive security issues are discussed privately.
-->
<!-- ### Caching -->
<!-- ### Deployment strategy -->
<!-- ### Future work -->

## Links

<!--
  Any relevant links to external resources; ie, specification documents, jira
  items, related PRs, honeybadger errors, etc
-->

- [jira](https://codedotorg.atlassian.net/browse/LP-1533)

## Testing story

<!--
  Does your change include appropriate tests?

  If so, please describe how the tests included in this PR are sufficient

  If not, please explain why this change does not need to be tested.
-->

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
