### PR TITLE
HoC LATAM customization

### DIFF
--- a/lib/country_codes.rb
+++ b/lib/country_codes.rb
@@ -292,6 +292,13 @@ EEA_COUNTRY_CODES = EU_COUNTRY_CODES +
     NO
   )
 
+LATAM_COUNTRY_CODES = %w(
+  AR
+  BR
+  CO
+  PE
+)
+
 # Returns the name of the country whose two character country code is code.
 # If code is not a valid two character country code, returns code.
 def country_name_from_code(code)
@@ -312,4 +319,8 @@ end
 def gdpr_country_code?(code)
   return false if code.nil?
   EEA_COUNTRY_CODES.include?(code.to_s.strip.upcase)
+end
+
+def latam_country_code?(code)
+  LATAM_COUNTRY_CODES.include? code.to_s.strip.upcase
 end

--- a/lib/country_codes.rb
+++ b/lib/country_codes.rb
@@ -1,5 +1,7 @@
 # coding: utf-8
 require 'sort_alphabetical'
+require_relative 'country_regions'
+
 # coding: utf-8
 COUNTRY_CODE_TO_COUNTRY_NAME = {
   "AD" => "Andorra",
@@ -292,12 +294,7 @@ EEA_COUNTRY_CODES = EU_COUNTRY_CODES +
     NO
   )
 
-LATAM_COUNTRY_CODES = %w(
-  AR
-  BR
-  CO
-  PE
-)
+LATAM_COUNTRY_CODES = LATAM_ES_COUNTRY_CODES + LATAM_PT_COUNTRY_CODES
 
 # Returns the name of the country whose two character country code is code.
 # If code is not a valid two character country code, returns code.

--- a/lib/country_regions.rb
+++ b/lib/country_regions.rb
@@ -45,11 +45,11 @@ LATAM_ES_COUNTRY_CODE_TO_NAME = {
   vg: 'Virgin Islands, British',
   vi: 'Virgin Islands, U.S.'
 }.freeze
-LATAM_ES_COUNTRY_CODES = LATAM_ES_COUNTRY_CODE_TO_NAME.keys.map(&:to_s).freeze
+LATAM_ES_COUNTRY_CODES = LATAM_ES_COUNTRY_CODE_TO_NAME.keys.map(&:to_s).map(&:upcase).freeze
 LATAM_ES_COUNTRY_NAMES = LATAM_ES_COUNTRY_CODE_TO_NAME.values.freeze
 
 LATAM_PT_COUNTRY_CODE_TO_NAME = {
   br: 'Brazil'
 }.freeze
-LATAM_PT_COUNTRY_CODES = LATAM_PT_COUNTRY_CODE_TO_NAME.keys.map(&:to_s).freeze
+LATAM_PT_COUNTRY_CODES = LATAM_PT_COUNTRY_CODE_TO_NAME.keys.map(&:to_s).map(&:upcase).freeze
 LATAM_PT_COUNTRY_NAMES = LATAM_PT_COUNTRY_CODE_TO_NAME.values.freeze

--- a/pegasus/sites.v3/hourofcode.com/views/header.haml
+++ b/pegasus/sites.v3/hourofcode.com/views/header.haml
@@ -2,7 +2,7 @@
   .container
     #hoc-header-branding
       %a{href:resolve_url('/')}
-        - if latam_country_code?(@country)
+        - if @language == 'es' || @language == 'la'
           %img{src: localized_image('/images/hora-del-codigo-logo.png'), alt: hoc_s(:hour_of_code)}
         -else
           %img{src: localized_image('/images/hour-of-code-logo.png'), alt: hoc_s(:hour_of_code)}

--- a/pegasus/sites.v3/hourofcode.com/views/header.haml
+++ b/pegasus/sites.v3/hourofcode.com/views/header.haml
@@ -2,7 +2,10 @@
   .container
     #hoc-header-branding
       %a{href:resolve_url('/')}
-        %img{src: localized_image('/images/hour-of-code-logo.png'), alt: hoc_s(:hour_of_code)}
+        - if latam_country_code?(@country)
+          %img{src: localized_image('/images/hora-del-codigo-logo.png'), alt: hoc_s(:hour_of_code)}
+        -else
+          %img{src: localized_image('/images/hour-of-code-logo.png'), alt: hoc_s(:hour_of_code)}
     #hoc-header-main
       #language-dropdown
         = view :language_dropdown

--- a/pegasus/sites.v3/hourofcode.com/views/home_highlights.haml
+++ b/pegasus/sites.v3/hourofcode.com/views/home_highlights.haml
@@ -43,8 +43,11 @@
         .clear
         %a{href: "/highlights"}
           %button See more highlights
--elsif latam_country_code?(@country)
-  -# For LATAM countries, show only the HoC Spanish Twitter feed
+-elsif latam_country_code?(@country) || @country == 'la'
+  -# For LATAM countries, show only the HoC Spanish Twitter feed.
+  -# For historical reasons, we also use 'la' code to represent LATAM countries in
+  -# i18n/countries.json. Unfortunately, it is a real country code for Laos Republic
+  -# (ISO_3166-1_alpha-2 codes). We should change it to a different code later.
   .row
     .col-md-8
       %br/

--- a/pegasus/sites.v3/hourofcode.com/views/home_highlights.haml
+++ b/pegasus/sites.v3/hourofcode.com/views/home_highlights.haml
@@ -44,7 +44,7 @@
         %a{href: "/highlights"}
           %button See more highlights
 -elsif latam_country_code?(@country) || @country == 'la'
-  -# For LATAM countries, show only the HoC Spanish Twitter feed.
+  -# For LATAM countries, show only the LATAM HoC Twitter Feed.
   -# For historical reasons, we also use 'la' code to represent LATAM countries in
   -# i18n/countries.json. Unfortunately, it is a real country code for Laos Republic
   -# (ISO_3166-1_alpha-2 codes). We should change it to a different code later.

--- a/pegasus/sites.v3/hourofcode.com/views/home_highlights.haml
+++ b/pegasus/sites.v3/hourofcode.com/views/home_highlights.haml
@@ -43,8 +43,11 @@
         .clear
         %a{href: "/highlights"}
           %button See more highlights
--elsif latam_country_code?(@country)
-  -# For LATAM countries, show only the LATAM HoC Twitter Feed.
+-elsif latam_country_code?(@country) || @country == 'la'
+  -# For LATAM countries, show only the HoC Spanish Twitter feed.
+  -# For historical reasons, we also use 'la' code to represent LATAM countries in
+  -# i18n/countries.json. Unfortunately, it is a real country code for Laos Republic
+  -# (ISO_3166-1_alpha-2 codes). We should change it to a different code later.
   .row
     .col-md-8
       %br/

--- a/pegasus/sites.v3/hourofcode.com/views/home_highlights.haml
+++ b/pegasus/sites.v3/hourofcode.com/views/home_highlights.haml
@@ -43,11 +43,8 @@
         .clear
         %a{href: "/highlights"}
           %button See more highlights
--elsif latam_country_code?(@country) || @country == 'la'
-  -# For LATAM countries, show only the HoC Spanish Twitter feed.
-  -# For historical reasons, we also use 'la' code to represent LATAM countries in
-  -# i18n/countries.json. Unfortunately, it is a real country code for Laos Republic
-  -# (ISO_3166-1_alpha-2 codes). We should change it to a different code later.
+-elsif latam_country_code?(@country)
+  -# For LATAM countries, show only the LATAM HoC Twitter Feed.
   .row
     .col-md-8
       %br/

--- a/pegasus/sites.v3/hourofcode.com/views/home_highlights.haml
+++ b/pegasus/sites.v3/hourofcode.com/views/home_highlights.haml
@@ -43,6 +43,16 @@
         .clear
         %a{href: "/highlights"}
           %button See more highlights
+-elsif latam_country_code?(@country)
+  -# For LATAM countries, show only the HoC Spanish Twitter feed
+  .row
+    .col-md-8
+      %br/
+      %h2
+        Hour of Code Highlights
+      %a.twitter-grid{data: {tweet: {limit: "1"}, chrome: "noheader nofooter"}, href: "https://twitter.com/codeorg/timelines/1299406095904116742"}
+        Hour of Code Highlights
+      %script{async: "", charset: "utf-8", src: "//platform.twitter.com/widgets.js"}
 -else
   -# Highlights
   %br/


### PR DESCRIPTION
Task [FND-1284](https://codedotorg.atlassian.net/browse/FND-1284): Customizing the HoC landing page for several LATAM countries. 

Currently, our system recognizes only [4 LATAM country codes](https://github.com/code-dot-org/code-dot-org/blob/60f9679c082e0f90305e16712185fbbae9f2a79c/pegasus/sites.v3/hourofcode.com/i18n/countries.json#L50) (`AR`, `BR`, `CO` and `PE`). It also uses a generic `LA` code to represent all LATAM countries (which is unfortunately also the country code for Laos Republic in [ISO_3166-1_alpha-2](https://en.wikipedia.org/wiki/ISO_3166-1_alpha-2#Current_codes)). The following changes apply to the corresponding landing HoC pages for those countries (e.g. hourofcode.com/ar or hourofcode.com/la).
1. Uses HoC Spanish Twitter feed.
2. Omits the "Highlights from the previous years" section.
3. Replaces the "Hour of Code" logo by the "Hora del Codigo" logo for all Spanish-speaking countries.

Expanding the list of LATAM countries (if we decide to do so) will be in a separate PR.

## Screenshots
Using the en-US locale http://localhost.hourofcode.com:3000/us/en as a baseline, a LATAM locale (AR in this case) shows all the changes we expect. While a non-en and non-LATAM locale (e.g. Italy) doesn't show any recently implemented changes.

US-version|LATAM-version|non-LATAM, non-English version
--|--|--
<img width="297" alt="Screen Shot 2020-10-06 at 12 09 48 AM" src="https://user-images.githubusercontent.com/46507039/95110862-826e0500-06f3-11eb-9686-dc5aeeb2e7df.png"> | <img width="306" alt="Screen Shot 2020-10-06 at 12 11 16 AM" src="https://user-images.githubusercontent.com/46507039/95110868-8568f580-06f3-11eb-9d4e-1fbad417c3b2.png"> | <img width="302" alt="Screen Shot 2020-10-06 at 12 12 17 AM" src="https://user-images.githubusercontent.com/46507039/95110873-8863e600-06f3-11eb-9ab5-fd7cd9718660.png">

## Links
[Slack discussion](https://codedotorg.slack.com/archives/C0T0PNTM3/p1601919712140500) on hourofcode.com/la page.

Hour of Code landing page shows different things based on user locations.
- For US: https://hourofcode.com/us
- For LATAM: https://hourofcode.com/ar or https://hourofcode.com/br
- For non-US, non-LATAM: https://hourofcode.com/it

## Testing story
Local tests
- Verify that http://localhost.hourofcode.com:3000/ar shows **all** the changes just implemented. Argentina is one of the LATAM countries.
- Verify that http://localhost.hourofcode.com:3000/us/en shows **none** of the changes just implemented. en-US is an English and non-LATAM locale.
- Verify that http://localhost.hourofcode.com:3000/it/it shows **none** of the changes just implemented. it-IT is a non-English and non-LATAM locale. 

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
