### PR TITLE
Added a test for teacher dashboard multiple page load

### DIFF
--- a/apps/test/unit/templates/sectionProgress/sectionProgressLoaderTest.js
+++ b/apps/test/unit/templates/sectionProgress/sectionProgressLoaderTest.js
@@ -41,6 +41,41 @@ const serverProgressResponse = {
   }
 };
 
+const firstServerProgressResponse = {
+  pagination: {
+    page: 1,
+    per: 2,
+    total_pages: 2
+  },
+  student_timestamps: {
+    100: null,
+    101: timeInSeconds
+  },
+  students: {
+    100: {},
+    101: {
+      2000: {status: 'locked'},
+      2001: {status: 'perfect', result: 30, paired: true, time_spent: 12345}
+    }
+  }
+};
+
+const secondServerProgressResponse = {
+  pagination: {
+    page: 2,
+    per: 2,
+    total_pages: 2
+  },
+  student_timestamps: {
+    102: timeInSeconds + 1
+  },
+  students: {
+    102: {
+      2000: {status: 'perfect', result: 100, time_spent: 6789}
+    }
+  }
+};
+
 const fullExpectedResult = {
   levelsByLessonByScript: {
     123: {
@@ -202,6 +237,49 @@ describe('sectionProgressLoader.loadScript', () => {
       expect(addDataByScriptStub).to.have.been.calledOnce;
       expect(finishLoadingProgressStub).to.have.been.calledOnce;
       expect(finishRefreshingProgressStub).to.have.been.calledOnce;
+    });
+
+    it('handles multiple pages of data', () => {
+      reduxStub.returns({
+        getState: () => {
+          return {
+            sectionProgress: {
+              studentLevelProgressByScript: [],
+              scriptDataByScript: [],
+              currentView: 0
+            },
+            sectionData: {
+              section: {
+                students: new Array(60)
+              }
+            }
+          };
+        },
+        dispatch: () => {}
+      });
+
+      sinon.stub(progressHelpers, 'processedLevel');
+      sinon.stub(progress, 'levelsByLesson').returns({});
+      addDataByScriptStub = sinon.spy(sectionProgress, 'addDataByScript');
+      fetchStub.onCall(0).returns({
+        then: sinon.stub().returns({
+          then: sinon.stub().callsArgWith(0, serverScriptResponse)
+        })
+      });
+      fetchStub.onCall(1).returns({
+        then: sinon.stub().returns({
+          then: sinon.stub().callsArgWith(0, firstServerProgressResponse)
+        })
+      });
+      fetchStub.onCall(2).returns({
+        then: sinon.stub().returns({
+          then: sinon.stub().callsArgWith(0, secondServerProgressResponse)
+        })
+      });
+      loadScript(123, 0);
+      expect(addDataByScriptStub).to.have.been.calledWith(fullExpectedResult);
+      progressHelpers.processedLevel.restore();
+      progress.levelsByLesson.restore();
     });
 
     describe('the first time', () => {


### PR DESCRIPTION
Bringing this hotfix full circle: https://github.com/code-dot-org/code-dot-org/pull/36428

Prior to that hotfix, we could only load a single page (50) students. This creates a test for that behavior.

<!--
  Other aspects to consider. uncomment and add detail for any that seem necessary:
-->

<!-- ### Background -->
<!-- ### Privacy -->
<!--
1.	Does the Project involve the collection, use or sharing of new Personal Data?

2.	Does the Project involve a new or changed use or sharing of existing Personal Data?
-->
<!-- ### Security -->
<!--
Link to Jira Task where sensitive security issues are discussed privately.
-->
<!-- ### Caching -->
<!-- ### Deployment strategy -->
<!-- ### Future work -->

## Links

<!--
  Any relevant links to external resources; ie, specification documents, jira
  items, related PRs, honeybadger errors, etc
-->

- [jira](https://codedotorg.atlassian.net/browse/LP-1537)

## Testing story

<!--
  Does your change include appropriate tests?

  If so, please describe how the tests included in this PR are sufficient

  If not, please explain why this change does not need to be tested.
-->

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
