### PR TITLE
Add ?manifest= query param to specify song manifest for dance party

### DIFF
--- a/apps/src/dance/Dance.js
+++ b/apps/src/dance/Dance.js
@@ -41,6 +41,7 @@ import {
 import {SongTitlesToArtistTwitterHandle} from '../code-studio/dancePartySongArtistTags';
 import firehoseClient from '@cdo/apps/lib/util/firehose';
 import {showArrowButtons} from '@cdo/apps/templates/arrowDisplayRedux';
+import queryString from 'query-string';
 
 const ButtonState = {
   UP: 0,
@@ -182,7 +183,12 @@ Dance.prototype.awaitTimingMetrics = function() {
 };
 
 Dance.prototype.initSongs = async function(config) {
-  const songManifest = await getSongManifest(config.useRestrictedSongs);
+  // Check for a user-specified manifest file.
+  const manifest = queryString.parse(window.location.search).manifest;
+  const songManifest = await getSongManifest(
+    config.useRestrictedSongs,
+    manifest
+  );
   const songData = parseSongOptions(songManifest);
   const selectedSong = getSelectedSong(songManifest, config);
 

--- a/apps/src/dance/songs.js
+++ b/apps/src/dance/songs.js
@@ -6,12 +6,16 @@ import Sounds from '../Sounds';
  * @param useRestrictedSongs {boolean} if true, request signed cloudfront
  * cookies in parallel with the request for the manifest, and use /restricted/
  * urls instead of curriculum.code.org urls for music files.
+ * @param manifestFilename {string} Optional. Specify the name of the manifest
+ * to request from S3. Must be located in cdo-sound-library/hoc_song_meta.
  * @returns {Promise<*>} The song manifest.
  */
-export async function getSongManifest(useRestrictedSongs) {
-  let manifestFilename = useRestrictedSongs
-    ? 'songManifest2019.json'
-    : 'testManifest.json';
+export async function getSongManifest(useRestrictedSongs, manifestFilename) {
+  if (!manifestFilename || manifestFilename.length === 0) {
+    manifestFilename = useRestrictedSongs
+      ? 'songManifest2019.json'
+      : 'testManifest.json';
+  }
 
   const songManifestPromise = fetch(
     `/api/v1/sound-library/hoc_song_meta/${manifestFilename}`


### PR DESCRIPTION
Adds the ability to specify `?manifest=` on Dance Party levels so that a user can specify which song manifest to use.

Scenario: We're adding new songs, so I create a manifest called `maddieTest.json` in S3 in the cdo-sound-library/hoc_song_meta bucket. To test this manifest before releasing, I can go to any Dance Party level with `?manifest=maddieTest` or `?manifest=maddieTest.json` to override the default manifest.

This is useful because the .mp3s in `cdo-restricted/restricted` (where all Dance Party songs live) are only available on production (all other environments return a 403), and it allows us to test new songs internally without adding a new experiment for each test manifest.

## Links

<!--
  Any relevant links to external resources; ie, specification documents, jira
  items, related PRs, honeybadger errors, etc
-->

- [STAR-1289](https://codedotorg.atlassian.net/browse/STAR-1289)

## Testing story

<!--
  Does your change include appropriate tests?

  If so, please describe how the tests included in this PR are sufficient

  If not, please explain why this change does not need to be tested.
-->

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
