### PR TITLE
LP-1413 Fix headers in dropdown list on edit section and progress pages

### DIFF
--- a/apps/src/templates/teacherDashboard/AssignmentSelector.jsx
+++ b/apps/src/templates/teacherDashboard/AssignmentSelector.jsx
@@ -42,12 +42,12 @@ const categorizeAssignmentFamilies = assignmentFamilies =>
   _(assignmentFamilies)
     .values()
     .orderBy([
-      'category_priority',
-      'category',
+      'assignment_family_category_priority',
+      'assignment_family_category_title',
       'position',
       'assignment_family_title'
     ])
-    .groupBy('category')
+    .groupBy('assignment_family_category_title')
     .value();
 
 const getVersion = assignment => ({
@@ -302,9 +302,9 @@ export default class AssignmentSelector extends Component {
               </option>
             )}
             {Object.keys(assignmentFamiliesByCategory).map(
-              (categoryName, index) => (
-                <optgroup key={index} label={categoryName}>
-                  {assignmentFamiliesByCategory[categoryName].map(
+              (categoryTitle, index) => (
+                <optgroup key={index} label={categoryTitle}>
+                  {assignmentFamiliesByCategory[categoryTitle].map(
                     assignmentFamily =>
                       assignmentFamily !== undefined && (
                         <option

--- a/apps/src/templates/teacherDashboard/shapes.jsx
+++ b/apps/src/templates/teacherDashboard/shapes.jsx
@@ -73,8 +73,8 @@ export const assignmentShape = PropTypes.shape({
 // "course" is already used to refer to a specific version of a course such as
 // csd-2018.
 export const assignmentFamilyShape = PropTypes.shape({
-  category_priority: PropTypes.number.isRequired,
-  category: PropTypes.string.isRequired,
+  assignment_family_category_priority: PropTypes.number.isRequired,
+  assignment_family_category_title: PropTypes.string.isRequired,
   position: PropTypes.number,
   assignment_family_title: PropTypes.string.isRequired,
   assignment_family_name: PropTypes.string.isRequired

--- a/apps/src/templates/teacherDashboard/teacherSectionsRedux.js
+++ b/apps/src/templates/teacherDashboard/teacherSectionsRedux.js
@@ -502,8 +502,8 @@ const defaultStageExtras = false;
 
 // Fields to copy from the assignmentInfo when creating an assignmentFamily.
 export const assignmentFamilyFields = [
-  'category_priority',
-  'category',
+  'assignment_family_category_title',
+  'assignment_family_category_priority',
   'position',
   'assignment_family_title',
   'assignment_family_name'
@@ -588,6 +588,10 @@ export default function teacherSections(state = initialState, action) {
 
       // Put each script in its own assignment family with the default version
       // year, unless those values were provided by the server.
+      const assignmentFamilyCategoryTitle =
+        script.assignment_family_category_title || script.category;
+      const assignmentFamilyCategoryPriority =
+        script.assignment_family_category_priority || script.category_priority;
       const assignmentFamilyName =
         script.assignment_family_name || script.script_name;
       const assignmentFamilyTitle =
@@ -615,6 +619,8 @@ export default function teacherSections(state = initialState, action) {
         if (versionYear === defaultVersionYear) {
           assignmentFamilies.push({
             ..._.pick(script, assignmentFamilyFields),
+            assignment_family_category_title: assignmentFamilyCategoryTitle,
+            assignment_family_category_priority: assignmentFamilyCategoryPriority,
             assignment_family_title: assignmentFamilyTitle,
             assignment_family_name: assignmentFamilyName
           });

--- a/dashboard/app/models/script.rb
+++ b/dashboard/app/models/script.rb
@@ -1510,6 +1510,13 @@ class Script < ActiveRecord::Base
     end
     info[:is_stable] = true if is_stable
 
+    # For CSF scripts, set the assignment family category so the CSF courses will be
+    # grouped together under the 'CS Fundamentals' heading in the course assignment dropdown.
+    if ScriptConstants.csf_script?(self)
+      info[:assignment_family_category_title] = I18n.t("data.script.category_heading.csf_category_heading", "CS Fundamentals")
+      info[:assignment_family_category_priority] = info[:category_priority]
+    end
+
     info[:category] = I18n.t("data.script.category.#{info[:category]}_category_name", default: info[:category])
     info[:supported_locales] = supported_locale_names
     info[:lesson_extras_available] = lesson_extras_available

--- a/dashboard/app/models/unit_group.rb
+++ b/dashboard/app/models/unit_group.rb
@@ -60,6 +60,11 @@ class UnitGroup < ApplicationRecord
     I18n.t("data.course.name.#{name}.title", default: name)
   end
 
+  # Localized string used as the header for all full courses in course assignment dialog.
+  def localized_assignment_family_category_title
+    I18n.t("courses_category", default: "Full Courses")
+  end
+
   def localized_assignment_family_title
     I18n.t("data.course.name.#{name}.assignment_family_title", default: localized_title)
   end
@@ -214,9 +219,9 @@ class UnitGroup < ApplicationRecord
     info[:version_title] = localized_version_title
     info[:is_stable] = stable?
     info[:pilot_experiment] = pilot_experiment
-    info[:category] = I18n.t('courses_category')
-    # Dropdown is sorted by category_priority ascending. "Full courses" should appear at the top.
-    info[:category_priority] = -1
+    info[:assignment_family_category_title] = localized_assignment_family_category_title
+    # Dropdown is sorted by assignment_family_category_priority ascending. "Full courses" should appear at the top.
+    info[:assignment_family_category_priority] = -1
     info[:script_ids] = user ?
       scripts_for_user(user).map(&:id) :
       default_unit_group_units.map(&:script_id)

--- a/dashboard/config/locales/scripts.en.yml
+++ b/dashboard/config/locales/scripts.en.yml
@@ -3,13 +3,15 @@
 en:
   data:
     script:
+      category_heading:
+        csf_category_heading: CS Fundamentals
       category:
         csd_category_name: CS Discoveries ('17-'18)
         csd_2018_category_name: CS Discoveries ('18-'19)
         csd_2019_category_name: CS Discoveries ('19-'20)
         csd_2020_category_name: CS Discoveries ('20-'21)
         csd_pilot_category_name: CS Discoveries Pilot
-        csf_category_name: CS Fundamentals
+        csf_category_name: CS Fundamentals ('17-'18)
         csf_2018_category_name: CS Fundamentals ('18-'19)
         csf_2019_category_name: CS Fundamentals ('19-'20)
         csf_2020_category_name: CS Fundamentals ('20-'21)

--- a/lib/cdo/script_constants.rb
+++ b/lib/cdo/script_constants.rb
@@ -409,4 +409,8 @@ module ScriptConstants
       JIGSAW_NAME == script ||
       ADDITIONAL_I18N_SCRIPTS.include?(script)
   end
+
+  def self.csf_script?(script)
+    CSF_COURSE_PATTERNS.map {|r| r =~ script.name}.any?
+  end
 end


### PR DESCRIPTION
<!--
  Your description goes here: A summary of the change, including any relevant motivation and context.

  If relevant, include a description both of the existing behavior and of the new behavior.
-->
After a bit of a struggle, I have a working fix for [LP-1413](https://codedotorg.atlassian.net/browse/LP-1413).  This change does not yet include new and updated tests so it's incomplete but I wanted to get some feedback on (1) whether or not I'm on the right track, and (2) whether we want to fix this at all given the risk of the change (which I'm not able to determine yet).

### Background
There are two dropdowns with course/script information:
1. The course assignment dropdown in the the edit section dialog.  This list contains courses/scripts, or more precisely, the course/script _families_ (as the year is put in a separate dropdown).  The server sends the course/script family for each course/script but the jsx code extracts the family from only the 2017 version of each course/script. 
2. The course dropdown in the progress page.  This list contains only scripts.

The crux of the bug is that the headings for both dropdowns use the category -- even though the course assignment dropdown does not have years in the heading and the progress page dropdown does.  Prior to this change, the category for 2017 CSF courses was "CS Fundamentals" (without a year) so it would appear correctly in the course assignment dropdown but incorrectly in the progress page dropdown.

### Changes
This change introduces new fields for assignment_family_category_title and assignment_family_category_priority that is used by the course assignment dropdown to render headings.    (The progress page dropdown is unchanged.)

The course model (a.k.a. UnitGroup) now returns assignment_family_category instead of category.  The script model now returns assignment_family_category just for CSF (all other scripts omit assignment_family_category and the front end has logic that uses the script's name and category as the default assignment_family_category).

### Notes
This all still seems more confusing than I would like but I think further improvement would take deeper changes to the terminology and/or the way these two dropdowns are populated.

<!--
  Other aspects to consider. uncomment and add detail for any that seem necessary:
-->

<!-- ### Privacy -->
<!--
1.	Does the Project involve the collection, use or sharing of new Personal Data?

2.	Does the Project involve a new or changed use or sharing of existing Personal Data?
-->
<!-- ### Security -->
<!--
Link to Jira Task where sensitive security issues are discussed privately.
-->
<!-- ### Caching -->
<!-- ### Deployment strategy -->
<!-- ### Future work -->

## Links

<!--
  Any relevant links to external resources; ie, specification documents, jira
  items, related PRs, honeybadger errors, etc
-->

- [jira](https://codedotorg.atlassian.net/browse/LP-1413)

## Testing story

<!--
  Does your change include appropriate tests?

  If so, please describe how the tests included in this PR are sufficient

  If not, please explain why this change does not need to be tested.
-->

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
