### PR TITLE
update paranoia gem to 2.4.2

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -232,7 +232,7 @@ gem 'font-awesome-rails', '~> 4.7.0.5'
 gem 'sequel'
 gem 'user_agent_parser'
 
-gem 'paranoia'
+gem 'paranoia', '~> 2.4.2'
 gem 'petit', github: 'code-dot-org/petit'  # For URL shortening
 
 # JSON model serializer for REST APIs.

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -629,8 +629,8 @@ GEM
     parallel (1.12.1)
     parallel_tests (2.27.0)
       parallel
-    paranoia (2.3.1)
-      activerecord (>= 4.0, < 5.2)
+    paranoia (2.4.2)
+      activerecord (>= 4.0, < 6.1)
     parser (2.4.0.2)
       ast (~> 2.3)
     pdf-reader (1.4.0)
@@ -1002,7 +1002,7 @@ DEPENDENCIES
   os
   parallel
   parallel_tests
-  paranoia
+  paranoia (~> 2.4.2)
   pdf-reader
   petit!
   pg


### PR DESCRIPTION
From version 2.3.1, as part of the ongoing work to upgrade to Rails 6.

Glancing through [the changelog](https://github.com/rubysherpas/paranoia/blob/core/CHANGELOG.md#242), I don't see anything particularly worrying here.

## Testing story

Relying on existing unit tests

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
