### PR TITLE
Revert "Revert "[Google Blockly] Add context menu for levelbuilders""

### DIFF
--- a/apps/src/blocklyAddons/cdoBlockSvg.js
+++ b/apps/src/blocklyAddons/cdoBlockSvg.js
@@ -9,6 +9,62 @@ export default class BlockSvg extends GoogleBlockly.BlockSvg {
     this.unusedSvg_.render(this.svgGroup_);
   }
 
+  setCanDisconnectFromParent(canDisconnect) {
+    this.canDisconnectFromParent_ = canDisconnect;
+  }
+
+  customContextMenu(menuOptions) {
+    // Only show context menu for levelbuilders
+    if (Blockly.editBlocks) {
+      const deletable = {
+        text: this.deletable_
+          ? 'Make Undeletable to Users'
+          : 'Make Deletable to Users',
+        enabled: true,
+        callback: function() {
+          this.setDeletable(!this.isDeletable());
+          Blockly.ContextMenu.hide();
+        }.bind(this)
+      };
+      const movable = {
+        text: this.movable_
+          ? 'Make Immovable to Users'
+          : 'Make Movable to Users',
+        enabled: true,
+        callback: function() {
+          this.setMovable(!this.isMovable());
+          Blockly.ContextMenu.hide();
+        }.bind(this)
+      };
+      const editable = {
+        text: this.editable_ ? 'Make Uneditable' : 'Make editable',
+        enabled: true,
+        callback: function() {
+          this.setEditable(!this.isEditable());
+          Blockly.ContextMenu.hide();
+        }.bind(this)
+      };
+      const lockToParent = {
+        text: this.canDisconnectFromParent_
+          ? 'Lock to Parent Block'
+          : 'Unlock from Parent Block',
+        enabled: true,
+        callback: function() {
+          this.setCanDisconnectFromParent(!this.canDisconnectFromParent_);
+          Blockly.ContextMenu.hide();
+        }.bind(this)
+      };
+      menuOptions.push(deletable);
+      menuOptions.push(movable);
+      menuOptions.push(editable);
+      menuOptions.push(lockToParent);
+    } else {
+      while (menuOptions) {
+        menuOptions.pop();
+      }
+    }
+  }
+
   dispose() {
     super.dispose();
     this.removeUnusedBlockFrame();
@@ -30,6 +86,13 @@ export default class BlockSvg extends GoogleBlockly.BlockSvg {
 
   isUserVisible() {
     return false; // TODO
+  }
+
+  onMouseDown_(e) {
+    if (!Blockly.utils.isRightButton(e) && !this.canDisconnectFromParent_) {
+      return;
+    }
+    super.onMouseDown_(e);
   }
 
   render() {

--- a/apps/src/blocklyAddons/cdoBlockSvg.js
+++ b/apps/src/blocklyAddons/cdoBlockSvg.js
@@ -2,6 +2,11 @@ import GoogleBlockly from 'blockly/core';
 import BlockSvgUnused from './blockSvgUnused';
 
 export default class BlockSvg extends GoogleBlockly.BlockSvg {
+  constructor(workspace, prototypeName, opt_id) {
+    super(workspace, prototypeName, opt_id);
+    this.canDisconnectFromParent_ = true;
+  }
+
   addUnusedBlockFrame(helpClickFunc) {
     if (!this.unusedSvg_) {
       this.unusedSvg_ = new BlockSvgUnused(this, helpClickFunc);
@@ -58,10 +63,6 @@ export default class BlockSvg extends GoogleBlockly.BlockSvg {
       menuOptions.push(movable);
       menuOptions.push(editable);
       menuOptions.push(lockToParent);
-    } else {
-      while (menuOptions) {
-        menuOptions.pop();
-      }
     }
   }
 

--- a/apps/src/sites/studio/pages/googleBlocklyWrapper.js
+++ b/apps/src/sites/studio/pages/googleBlocklyWrapper.js
@@ -54,6 +54,7 @@ function initializeBlocklyWrapper(blocklyInstance) {
   blocklyWrapper.wrapReadOnlyProperty('BlockValueType');
   blocklyWrapper.wrapReadOnlyProperty('common_locale');
   blocklyWrapper.wrapReadOnlyProperty('Connection');
+  blocklyWrapper.wrapReadOnlyProperty('ContextMenu');
   blocklyWrapper.wrapReadOnlyProperty('contractEditor');
   blocklyWrapper.wrapReadOnlyProperty('createSvgElement');
   blocklyWrapper.wrapReadOnlyProperty('Css');
@@ -216,6 +217,7 @@ function initializeBlocklyWrapper(blocklyInstance) {
       theme: CdoTheme,
       trashcan: true
     };
+    blocklyWrapper.editBlocks = opt_options.editBlocks;
     return blocklyWrapper.blockly_.inject(container, options);
   };
 
@@ -224,10 +226,27 @@ function initializeBlocklyWrapper(blocklyInstance) {
   blocklyWrapper.Xml.originalBlockToDom = blocklyWrapper.Xml.blockToDom;
   blocklyWrapper.Xml.blockToDom = function(block, ignoreChildBlocks) {
     const blockXml = blocklyWrapper.Xml.originalBlockToDom(block);
+    if (!block.canDisconnectFromParent_) {
+      blockXml.setAttribute('can_disconnect_from_parent', false);
+    }
     if (ignoreChildBlocks) {
       Blockly.Xml.deleteNext(blockXml);
     }
     return blockXml;
+  };
+
+  // Aliasing Google's domToBlock() so that we can override it, but still be able
+  // to call Google's domToBlock() in the override function.
+  blocklyWrapper.Xml.originalDomToBlock = blocklyWrapper.Xml.domToBlock;
+  blocklyWrapper.Xml.domToBlock = function(xmlBlock, workspace) {
+    const block = blocklyWrapper.Xml.originalDomToBlock(xmlBlock, workspace);
+    const can_disconnect_from_parent = xmlBlock.getAttribute(
+      'can_disconnect_from_parent'
+    );
+    if (can_disconnect_from_parent) {
+      block.canDisconnectFromParent_ = can_disconnect_from_parent === 'true';
+    }
+    return block;
   };
 
   blocklyWrapper.Xml.fieldToDom_ = function(field) {

--- a/dashboard/app/controllers/levels_controller.rb
+++ b/dashboard/app/controllers/levels_controller.rb
@@ -145,7 +145,8 @@ class LevelsController < ApplicationController
     view_options(
       full_width: true,
       small_footer: @game.uses_small_footer? || @level.enable_scrolling?,
-      has_i18n: @game.has_i18n?
+      has_i18n: @game.has_i18n?,
+      useGoogleBlockly: params[:blocklyVersion] == "Google"
     )
   end
 


### PR DESCRIPTION
Reverts code-dot-org/code-dot-org#37088
There were two issues here:
1. I wasn't initializing `canDisconnectFromParent_` to `true`, and since `undefined` is falsy, it was acting like *all* blocks were locked to their parents
2. I was emptying out the contextMenu when it's not start_blocks mode, but this was leading to some weird behavior when you right click on blocks. The default contextMenu looks like this:
![image](https://user-images.githubusercontent.com/8787187/95370173-41115d00-088d-11eb-90fa-e4749a204430.png).
I didn't really investigate what was going on here, but if we do end up wanting to get rid of the context menu entirely for students, we'll have to figure out a better way to do it.