### PR TITLE
Remove unused file administrators.js

### DIFF
--- a/apps/Gruntfile.js
+++ b/apps/Gruntfile.js
@@ -614,8 +614,6 @@ describe('entry tests', () => {
 
   var pegasusEntries = {
     // code.org
-    'code.org/public/administrators':
-      './src/sites/code.org/pages/public/administrators.js',
     'code.org/public/dance': './src/sites/code.org/pages/public/dance.js',
     'code.org/public/educate/curriculum/courses':
       './src/sites/code.org/pages/public/educate/curriculum/courses.js',

--- a/apps/src/sites/code.org/pages/public/administrators.js
+++ b/apps/src/sites/code.org/pages/public/administrators.js
@@ -1,3 +1,0 @@
-import {initCourseExplorer} from '@cdo/apps/courseExplorer/courseExplorer';
-
-$(document).ready(initCourseExplorer);


### PR DESCRIPTION
Per this [Slack discussion](https://codedotorg.slack.com/archives/C0T0PNTM3/p1602097252202400), `pegasus/sites.v3/code.org/public/administrators.md.erb` was deleted and replaced by `administrators.erb`, which no longer use `apps/src/sites/code.org/pages/public/administrators.js`. 

The `administrators.js` file is no longer used in any file, causing staging and test builds to fail with this error
```
Running "lint-entry-points" task
âœ˜ code.org/public/administrators âžœ ./src/sites/code.org/pages/public/administrators.js
  âœ˜ Entry points should only be used by one template but this one is used by 0!
[117 passed] [30 silenced] [1 failed]
Warning: 1 entry points do not conform to naming conventions.
Run grunt check-entry-points for details.
 Use --force to continue.
```

The fix is to remove `administrators.js` completely.