### PR TITLE
Refactor '2019' field to 'yearIntroduced'

### DIFF
--- a/dashboard/app/models/levels/dancelab.rb
+++ b/dashboard/app/models/levels/dancelab.rb
@@ -56,12 +56,14 @@ class Dancelab < GamelabJr
   def common_blocks(type)
   end
 
+  # Used by levelbuilders to set a default song on a Dance Party level.
   def self.hoc_songs
     manifest_json = AWS::S3.create_client.get_object(bucket: 'cdo-sound-library', key: 'hoc_song_meta/songManifest2019.json')[:body].read
     manifest = JSON.parse(manifest_json)
     manifest['songs'].map do |song|
-      name = "#{song['text']}#{song['pg13'] ? ' (PG-13)' : ''}"
-      name = "#{song['2019'] ? '(2019) ' : ''}#{name}"
+      name = song['text']
+      name.prepend("(#{song['yearIntroduced']}) ") if song['yearIntroduced']
+      name.concat(" (PG-13)") if song['pg13']
       [name, song['id']]
     end
   end


### PR DESCRIPTION
Last year, we needed a way to tell Levelbuilders that a Dance Party song was new, so we added a "2019" boolean field to the song manifest. Now that we're adding more new songs, we've decided to change that field from "2019" to "yearIntroduced" (an integer field).

```javascript
// before
{"id": "introtoshamstep_47SOUL", "text": "47SOUL - Intro to Shamstep", "pg13": false, "url": "introtoshamstep_47SOUL", "2019" true}

// after
{"id": "introtoshamstep_47SOUL", "text": "47SOUL - Intro to Shamstep", "pg13": false, "url": "introtoshamstep_47SOUL", "yearIntroduced": 2019}
```

Songs introduced in 2018 will not have "yearIntroduced" since that was the first year of Dance Party, and we only use this field to highlight new songs added after 2018.

This field is only used to set the default song for a Dance Party level:
![Screen Shot 2020-10-07 at 3 52 09 PM](https://user-images.githubusercontent.com/9812299/95396158-218e2a80-08b5-11eb-829c-325d458f6bc0.png)
![Screen Shot 2020-10-07 at 3 51 56 PM](https://user-images.githubusercontent.com/9812299/95396162-2226c100-08b5-11eb-90b9-db51a57d3b00.png)

Not showing the 2020 songs because they are \~secret\~

## Links

<!--
  Any relevant links to external resources; ie, specification documents, jira
  items, related PRs, honeybadger errors, etc
-->

- [STAR-1289](https://codedotorg.atlassian.net/browse/STAR-1289)

## Testing story

<!--
  Does your change include appropriate tests?

  If so, please describe how the tests included in this PR are sufficient

  If not, please explain why this change does not need to be tested.
-->

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
