### PR TITLE
Fix test_should_get_filters in levels_controller_test

### DIFF
--- a/dashboard/test/controllers/levels_controller_test.rb
+++ b/dashboard/test/controllers/levels_controller_test.rb
@@ -89,9 +89,8 @@ class LevelsControllerTest < ActionController::TestCase
       "coursed-2017", "coursee-2017", "coursef-2017", "express-2017", "flappy",
       "frozen", "hourofcode", "jigsaw", "playlab", "pre-express-2017", "starwars"
     ]
-    puts scripts - JSON.parse(@response.body)["scriptOptions"].map {|option| option[0]}
     assert (scripts - JSON.parse(@response.body)["scriptOptions"].map {|option| option[0]}).empty?
-    assert_equal JSON.parse(@response.body)["ownerOptions"].map {|option| option[0]}, ["Any owner"]
+    assert (["Any owner"] - JSON.parse(@response.body)["ownerOptions"].map {|option| option[0]}).empty?
   end
 
   test "should get filtered levels with just page param" do


### PR DESCRIPTION
The `test_should_get_filters` in `levels_controller_test.rb` failed today for the DOTD.

```
==[0m[1000D[K FAIL["test_should_get_filters", "LevelsControllerTest", 31.26643103500828]
 test_should_get_filters#LevelsControllerTest (31.27s)
        --- expected
        +++ actual
        @@ -1 +1 @@
        -["Any owner", "User178 Codeberg"]
        +["Any owner"]
        test/controllers/levels_controller_test.rb:94:in `block in <class:LevelsControllerTest>'
        test/testing/setup_all_and_teardown_all.rb:22:in `run'

```

I updated the test to check that the output includes Any owner instead of being only any owner.
