### PR TITLE
[Google Blockly] Open trashcan lid anywhere over toolbox

### DIFF
--- a/apps/src/blocklyAddons/cdoBlockDragger.js
+++ b/apps/src/blocklyAddons/cdoBlockDragger.js
@@ -1,6 +1,9 @@
 import GoogleBlockly from 'blockly/core';
 
 export default class BlockDragger extends GoogleBlockly.BlockDragger {
+  /** Show trashcan over toolbox while dragging
+   * @override
+   */
   dragBlock(e, currentDragDeltaXY) {
     super.dragBlock(e, currentDragDeltaXY);
     const isDraggingFromFlyout_ = !!Blockly.mainBlockSpace.currentGesture_
@@ -18,9 +21,22 @@ export default class BlockDragger extends GoogleBlockly.BlockDragger {
     }
   }
 
+  /** Hide trashcan when drag ends
+   * @override
+   */
   endBlockDrag(e, currentDragDeltaXY) {
     super.endBlockDrag(e, currentDragDeltaXY);
     this.workspace_.trashcan.setDisabled(false);
     this.workspace_.hideTrashcan();
+  }
+
+  /** Open trashcan lid whenever the block is over the toolbox, not only if it's over the trashcan itself.
+   * @override
+   */
+  updateCursorDuringBlockDrag_() {
+    super.updateCursorDuringBlockDrag_();
+    if (this.draggedConnectionManager_.wouldDeleteBlock()) {
+      this.workspace_.trashcan.setLidOpen(true);
+    }
   }
 }


### PR DESCRIPTION
Follow up to #37002 
We want to open the trashcan lid when you drag the block anywhere over the toolbox, not just over the trashcan image itself.
See also discussion in [this slack thread](https://codedotorg.slack.com/archives/C07TL2HV2/p16020194710282000)
Before:
![Oct-08-2020 12-25-00](https://user-images.githubusercontent.com/8787187/95504228-58217f00-0961-11eb-9e33-75054d2bb2da.gif)

After:
![Oct-08-2020 11-49-54](https://user-images.githubusercontent.com/8787187/95504148-358f6600-0961-11eb-9e8d-5058abbb5e7a.gif)

