### PR TITLE
db migration adding script_levels.activity_section_position

### DIFF
--- a/dashboard/db/migrate/20201006172430_add_activity_section_position_to_script_levels.rb
+++ b/dashboard/db/migrate/20201006172430_add_activity_section_position_to_script_levels.rb
@@ -1,0 +1,5 @@
+class AddActivitySectionPositionToScriptLevels < ActiveRecord::Migration[5.0]
+  def change
+    add_column :script_levels, :activity_section_position, :integer
+  end
+end

--- a/dashboard/db/schema.rb
+++ b/dashboard/db/schema.rb
@@ -1377,18 +1377,19 @@ ActiveRecord::Schema.define(version: 20201006202706) do
   end
 
   create_table "script_levels", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci" do |t|
-    t.integer  "script_id",                         null: false
+    t.integer  "script_id",                               null: false
     t.integer  "chapter"
     t.datetime "created_at"
     t.datetime "updated_at"
     t.integer  "stage_id"
     t.integer  "position"
     t.boolean  "assessment"
-    t.text     "properties",          limit: 65535
+    t.text     "properties",                limit: 65535
     t.boolean  "named_level"
     t.boolean  "bonus"
     t.integer  "activity_section_id"
     t.string   "seed_key"
+    t.integer  "activity_section_position"
     t.index ["activity_section_id"], name: "index_script_levels_on_activity_section_id", using: :btree
     t.index ["script_id"], name: "index_script_levels_on_script_id", using: :btree
     t.index ["seed_key"], name: "index_script_levels_on_seed_key", unique: true, using: :btree


### PR DESCRIPTION
Today an activity section has many script levels:
* https://github.com/code-dot-org/code-dot-org/blob/d0de4198ed3d1e4ae16c1d21cd8fdc6a885d13f1/dashboard/app/models/script_level.rb#L16
* https://github.com/code-dot-org/code-dot-org/blob/f8689289cc295b4e1ec03d710244b08715f5dc69/dashboard/app/models/activity_section.rb#L34

However the association is unordered. For us to show script levels in order, we need to add a position column.

The name for this column is weirdly specific (not just "position") because we already have two 😱  other position columns on the script level:
* position within script: https://github.com/code-dot-org/code-dot-org/blob/d0de4198ed3d1e4ae16c1d21cd8fdc6a885d13f1/dashboard/app/models/script_level.rb#L7
* position within lesson: https://github.com/code-dot-org/code-dot-org/blob/d0de4198ed3d1e4ae16c1d21cd8fdc6a885d13f1/dashboard/app/models/script_level.rb#L11

The work to get rid of `chapter` and `position`, replacing it with `activity_section_position`, is tracked in the Q1 Tech Debt section of the [Roadmap](https://docs.google.com/document/d/1bJPhdwX7QZHRT12dQBJcXrYDKGSdobMp1c_6qAuvUEM/edit#).

## Testing story

existing test coverage.

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
