### PR TITLE
Use activity section position to order ActivitySection script_levels

### DIFF
--- a/dashboard/app/models/activity_section.rb
+++ b/dashboard/app/models/activity_section.rb
@@ -31,7 +31,7 @@ class ActivitySection < ApplicationRecord
   belongs_to :lesson_activity
   has_one :lesson, through: :lesson_activity
 
-  has_many :script_levels
+  has_many :script_levels, -> {order(:activity_section_position)}
 
   serialized_attrs %w(
     name

--- a/dashboard/app/models/script_level.rb
+++ b/dashboard/app/models/script_level.rb
@@ -49,6 +49,7 @@ class ScriptLevel < ActiveRecord::Base
 
   validate :anonymous_must_be_assessment
   validate :validate_activity_section_lesson
+  validate :validate_activity_section_position
 
   # Make sure we never create a level that is not an assessment, but is anonymous,
   # as in that case it wouldn't actually be treated as anonymous
@@ -61,6 +62,12 @@ class ScriptLevel < ActiveRecord::Base
   def validate_activity_section_lesson
     if activity_section && activity_section.lesson != lesson
       errors.add(:script_level, 'activity_section.lesson does not match lesson')
+    end
+  end
+
+  def validate_activity_section_position
+    if activity_section && !activity_section_position
+      errors.add(:script_level, 'activity_section_position is required when activity_section is present')
     end
   end
 

--- a/dashboard/test/models/activity_section_test.rb
+++ b/dashboard/test/models/activity_section_test.rb
@@ -7,4 +7,22 @@ class ActivitySectionTest < ActiveSupport::TestCase
     activity_section2 = create :activity_section, lesson_activity: lesson_activity
     assert_equal [activity_section1, activity_section2], lesson_activity.activity_sections
   end
+
+  test "script levels are ordered by activity section position" do
+    activity_section = create :activity_section
+    lesson = activity_section.lesson_activity.lesson
+    script = lesson.script
+
+    level1 = create :maze, name: 'level 1'
+    level2 = create :maze, name: 'level 2'
+    level3 = create :maze, name: 'level 3'
+    sl1 = create :script_level, script: script, lesson: lesson, levels: [level1],
+      activity_section: activity_section, activity_section_position: 2
+    sl2 = create :script_level, script: script, lesson: lesson, levels: [level2],
+      activity_section: activity_section, activity_section_position: 3
+    sl3 = create :script_level, script: script, lesson: lesson, levels: [level3],
+      activity_section: activity_section, activity_section_position: 1
+
+    assert_equal [sl3, sl1, sl2], activity_section.script_levels
+  end
 end

--- a/dashboard/test/models/activity_section_test.rb
+++ b/dashboard/test/models/activity_section_test.rb
@@ -25,4 +25,17 @@ class ActivitySectionTest < ActiveSupport::TestCase
 
     assert_equal [sl3, sl1, sl2], activity_section.script_levels
   end
+
+  test 'script levels must be ordered' do
+    activity_section = create :activity_section
+    lesson = activity_section.lesson_activity.lesson
+    script = lesson.script
+
+    level1 = create :maze, name: 'level 1'
+    error = assert_raises do
+      create :script_level, script: script, lesson: lesson, levels: [level1],
+             activity_section: activity_section
+    end
+    assert_includes error.message, 'activity_section_position is required'
+  end
 end


### PR DESCRIPTION
Follow-on to migration in https://github.com/code-dot-org/code-dot-org/pull/37142 . 

## Testing story

added a new unit test. there's nothing to test in the app yet because we are still using stub data in the UI.

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
