### PR TITLE
remove flaky check that has_many assignment performs deletion

### DIFF
--- a/dashboard/test/controllers/lessons_controller_test.rb
+++ b/dashboard/test/controllers/lessons_controller_test.rb
@@ -134,7 +134,7 @@ class LessonsControllerTest < ActionController::TestCase
       position: 1,
       seeding_key: 'key_a'
     ).id
-    id_b = @lesson.lesson_activities.create(
+    @lesson.lesson_activities.create(
       name: 'activity B',
       position: 2,
       seeding_key: 'key_b'
@@ -172,8 +172,6 @@ class LessonsControllerTest < ActionController::TestCase
     assert_equal 'activity C', activities.last.name
     assert_equal 2, activities.last.position
     assert_equal id_c, activities.last.id
-
-    assert_equal 0, LessonActivity.where(id: id_b).count
   end
 
   test 'add activity section via lesson update' do
@@ -224,7 +222,7 @@ class LessonsControllerTest < ActionController::TestCase
       position: 1,
       seeding_key: 'activity-key'
     )
-    id_a = activity.activity_sections.create(
+    activity.activity_sections.create(
       name: 'section A',
       position: 1,
       seeding_key: 'key_a'
@@ -262,7 +260,5 @@ class LessonsControllerTest < ActionController::TestCase
     assert_equal 'section B', section.name
     assert_equal 1, section.position
     assert_equal id_b, section.id
-
-    assert_equal 0, LessonActivity.where(id: id_a).count
   end
 end


### PR DESCRIPTION
Background: https://codedotorg.slack.com/archives/C03CM903Y/p1602204535093000?thread_ts=1602204213.092600&cid=C03CM903Y

I couldn't get this to reproduce. we're already checking the contents of the has_many association, so I am just going to remove the flaky check.

a tiny bit more context - this is where we attempt to delete items from the has_many association via assignment: https://github.com/code-dot-org/code-dot-org/blob/284c3edb99204458853195025484c57aa368ac37/dashboard/app/models/lesson_activity.rb#L42-L43