### PR TITLE
CSEdWeek footer remove stray :

### DIFF
--- a/pegasus/sites.v3/csedweek.org/views/footer.haml
+++ b/pegasus/sites.v3/csedweek.org/views/footer.haml
@@ -1,13 +1,13 @@
 %div{:style=>'width: 100%; height: 80px; padding: 20px; overflow: hidden; background-color: rgb(4, 126, 188)'}
   %div{:class=>'whitefooter', :style=>'width: 970px; margin: 0 auto;'}
     %div{:style=>'float:left'}
-      %a{:href=>"https://code.org/privacy", :class=>"whitefooterlink", :target=>"_blank"} Privacy Policy
+      %a{:href=>"https://code.org/privacy", :class=>"whitefooterlink", :target=>"_blank", :rel=>"noopener noreferrer"} Privacy Policy
       &nbsp; &nbsp; | &nbsp; &nbsp;
       %a{:href=>"/about", :class=>"whitefooterlink"} About
       &nbsp; &nbsp; | &nbsp; &nbsp;
       %a{:href=>"/partners", :class=>"whitefooterlink"} Partners
       &nbsp; &nbsp; | &nbsp; &nbsp;
-      %a{:href=>"https://medium.com/@codeorg", :class=>"whitefooterlink", :target=>"_blank"} Blog
+      %a{:href=>"https://medium.com/@codeorg", :class=>"whitefooterlink", :target=>"_blank", :rel=>"noopener noreferrer"} Blog
       &nbsp; &nbsp; | &nbsp; &nbsp;
       %a{:href=>"/resource-kit", :class=>"whitefooterlink"} Resource Kit
       &nbsp; &nbsp; | &nbsp; &nbsp;

--- a/pegasus/sites.v3/csedweek.org/views/footer.haml
+++ b/pegasus/sites.v3/csedweek.org/views/footer.haml
@@ -1,7 +1,7 @@
 %div{:style=>'width: 100%; height: 80px; padding: 20px; overflow: hidden; background-color: rgb(4, 126, 188)'}
   %div{:class=>'whitefooter', :style=>'width: 970px; margin: 0 auto;'}
     %div{:style=>'float:left'}
-      %a{:href=>"https://code.org/privacy", :class=>"whitefooterlink", :target=>"_blank"} Privacy Policy:
+      %a{:href=>"https://code.org/privacy", :class=>"whitefooterlink", :target=>"_blank"} Privacy Policy
       &nbsp; &nbsp; | &nbsp; &nbsp;
       %a{:href=>"/about", :class=>"whitefooterlink"} About
       &nbsp; &nbsp; | &nbsp; &nbsp;

--- a/pegasus/sites.v3/csedweek.org/views/footer.haml
+++ b/pegasus/sites.v3/csedweek.org/views/footer.haml
@@ -1,8 +1,6 @@
 %div{:style=>'width: 100%; height: 80px; padding: 20px; overflow: hidden; background-color: rgb(4, 126, 188)'}
   %div{:class=>'whitefooter', :style=>'width: 970px; margin: 0 auto;'}
     %div{:style=>'float:left'}
-      %a{:href=>"https://code.org/privacy", :class=>"whitefooterlink", :target=>"_blank", :rel=>"noopener noreferrer"} Privacy Policy
-      &nbsp; &nbsp; | &nbsp; &nbsp;
       %a{:href=>"/about", :class=>"whitefooterlink"} About
       &nbsp; &nbsp; | &nbsp; &nbsp;
       %a{:href=>"/partners", :class=>"whitefooterlink"} Partners
@@ -16,6 +14,8 @@
       %a{:href=>"http://forums.code.org/", :class=>"whitefooterlink"} Forums
       &nbsp; &nbsp; | &nbsp; &nbsp;
       %a{:href=>"http://support.code.org/", :class=>"whitefooterlink"} Support
+      &nbsp; &nbsp; | &nbsp; &nbsp;
+      %a{:href=>"https://code.org/privacy", :class=>"whitefooterlink", :target=>"_blank", :rel=>"noopener noreferrer"} Privacy Policy
       %br
       %small.dim
         !="&copy; Computer Science Education Week, #{Time.now.year}. Hour of Code&reg; is a trademark of Code.org"


### PR DESCRIPTION
Content editors added "Privacy Policy" as a link to the footer for CSEdWeek.  In doing so there was a linter error on staging. I fixed that error, but also left behind a stray `:` because 🤷 vim. Removing.