### PR TITLE
Use translated string in highlights template

### DIFF
--- a/pegasus/sites.v3/hourofcode.com/i18n/en.yml
+++ b/pegasus/sites.v3/hourofcode.com/i18n/en.yml
@@ -631,7 +631,8 @@
   highlights_title: Highlights
   highlights_header: Hour of Code Highlights
   highlights_description: Some of our favorite moments from the Hour of Code campaign.
-  higlights_see_more: See more highlights
+  highlights_previous: Highlights from previous years
+  highlights_see_more: See more highlights
   highlights_readmore: Read more
   highlights_watchvideo: Watch the video
   highlights_facebook: Share on Facebook

--- a/pegasus/sites.v3/hourofcode.com/views/home_highlights.haml
+++ b/pegasus/sites.v3/hourofcode.com/views/home_highlights.haml
@@ -31,18 +31,20 @@
     .col-md-8
       %br/
       %h2
-        Hour of Code Highlights
+        =hoc_s(:highlights_header)
       %a.twitter-grid{data: {tweet: {limit: "1"}, chrome: "noheader nofooter"}, href: "https://twitter.com/codeorg/timelines/925449654308704256"}
-        Hour of Code Highlights
+        =hoc_s(:highlights_header)
       %script{async: "", charset: "utf-8", src: "//platform.twitter.com/widgets.js"}
     .col-md-3.highlights-column
-      %h2 Highlights from previous years
+      %h2 
+        =hoc_s(:highlights_previous)
       %div.highlight-tiles
         - highlights.each do |item|
           = view :highlight_item, item: item
         .clear
         %a{href: "/highlights"}
-          %button See more highlights
+          %button 
+            =hoc_s(:highlights_see_more)
 -elsif latam_country_code?(@country) || @country == 'la'
   -# For LATAM countries, show only the LATAM HoC Twitter Feed.
   -# For historical reasons, we also use 'la' code to represent LATAM countries in
@@ -52,9 +54,9 @@
     .col-md-8
       %br/
       %h2
-        Hour of Code Highlights
+        =hoc_s(:highlights_header)
       %a.twitter-grid{data: {tweet: {limit: "1"}, chrome: "noheader nofooter"}, href: "https://twitter.com/codeorg/timelines/1299406095904116742"}
-        Hour of Code Highlights
+        =hoc_s(:highlights_header)
       %script{async: "", charset: "utf-8", src: "//platform.twitter.com/widgets.js"}
 -else
   -# Highlights


### PR DESCRIPTION
Previously we were using the string literal in the Hour of Code Highlights section. This change updates those strings to use the string key and enables the rendering of the translated string.

I've applied the same change to the en-only section just in case we decide to open that up to displaying in non-English language modes (the argument could be made that even if the tweets or articles are in English, users could still get value out of them)

<!-- ### Background -->
<!-- ### Privacy -->
<!--
1.	Does the Project involve the collection, use or sharing of new Personal Data?

2.	Does the Project involve a new or changed use or sharing of existing Personal Data?
-->
<!-- ### Security -->
<!--
Link to Jira Task where sensitive security issues are discussed privately.
-->
<!-- ### Caching -->
<!-- ### Deployment strategy -->
<!-- ### Future work -->

## Testing story
Tested locally:
English (no change):
![image](https://user-images.githubusercontent.com/2933346/95638230-ba08e400-0a48-11eb-9727-6c62b8b5c68d.png)

Brazil (Portuguese renders correctly):
![image](https://user-images.githubusercontent.com/2933346/95638255-cc831d80-0a48-11eb-8dbd-bb78acec8405.png)

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
