### PR TITLE
Index lessons on script and key

### DIFF
--- a/dashboard/app/models/lesson.rb
+++ b/dashboard/app/models/lesson.rb
@@ -12,11 +12,12 @@
 #  relative_position :integer          not null
 #  properties        :text(65535)
 #  lesson_group_id   :integer
-#  key               :string(255)
+#  key               :string(255)      not null
 #
 # Indexes
 #
-#  index_stages_on_script_id  (script_id)
+#  index_stages_on_lesson_group_id_and_key  (lesson_group_id,key) UNIQUE
+#  index_stages_on_script_id_and_key        (script_id,key) UNIQUE
 #
 
 require 'cdo/shared_constants'

--- a/dashboard/db/migrate/20201009221300_add_key_script_index_to_lessons.rb
+++ b/dashboard/db/migrate/20201009221300_add_key_script_index_to_lessons.rb
@@ -1,0 +1,7 @@
+class AddKeyScriptIndexToLessons < ActiveRecord::Migration[5.0]
+  def change
+    change_column :stages, :key, :string, null: false
+    remove_index :stages, :script_id
+    add_index :stages, [:script_id, :key], unique: true
+  end
+end

--- a/dashboard/db/schema.rb
+++ b/dashboard/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20201006202706) do
+ActiveRecord::Schema.define(version: 20201009221300) do
 
   create_table "activities", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci" do |t|
     t.integer  "user_id"
@@ -1502,9 +1502,9 @@ ActiveRecord::Schema.define(version: 20201006202706) do
     t.integer  "relative_position",                               null: false
     t.text     "properties",        limit: 65535
     t.integer  "lesson_group_id"
-    t.string   "key"
+    t.string   "key",                                             null: false
     t.index ["lesson_group_id", "key"], name: "index_stages_on_lesson_group_id_and_key", unique: true, using: :btree
-    t.index ["script_id"], name: "index_stages_on_script_id", using: :btree
+    t.index ["script_id", "key"], name: "index_stages_on_script_id_and_key", unique: true, using: :btree
   end
 
   create_table "stages_standards", id: false, force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci" do |t|

--- a/dashboard/test/models/script_test.rb
+++ b/dashboard/test/models/script_test.rb
@@ -347,7 +347,7 @@ class ScriptTest < ActiveSupport::TestCase
       [{
         key: "my_key",
         display_name: "Content",
-        lessons: [{name: "Lesson1", script_levels: [{levels: [{name: 'New App Lab Project'}]}]}]
+        lessons: [{name: "Lesson1", key: 'lesson1', script_levels: [{levels: [{name: 'New App Lab Project'}]}]}]
       }] # From level.yml fixture# From level.yml fixture
     )
     Script.add_script(
@@ -355,7 +355,7 @@ class ScriptTest < ActiveSupport::TestCase
       [{
         key: "my_key",
         display_name: "Content",
-        lessons: [{name: "Lesson1", script_levels: [{levels: [{name: 'New Game Lab Project'}]}]}]
+        lessons: [{name: "Lesson1", key: 'lesson1', script_levels: [{levels: [{name: 'New Game Lab Project'}]}]}]
       }] # From level.yml fixture
     )
   end
@@ -366,7 +366,7 @@ class ScriptTest < ActiveSupport::TestCase
       [{
         key: "my_key",
         display_name: "Content",
-        lessons: [{name: "Lesson1", script_levels: [{levels: [{name: 'New App Lab Project'}]}]}]
+        lessons: [{name: "Lesson1", key: 'lesson1', script_levels: [{levels: [{name: 'New App Lab Project'}]}]}]
       }] # From level.yml fixture# From level.yml fixture
     )
     Script.add_script(
@@ -374,7 +374,7 @@ class ScriptTest < ActiveSupport::TestCase
       [{
         key: "my_key",
         display_name: "Content",
-        lessons: [{name: "Lesson1", script_levels: [{levels: [{name: 'New Game Lab Project'}]}]}]
+        lessons: [{name: "Lesson1", key: 'lesson1', script_levels: [{levels: [{name: 'New Game Lab Project'}]}]}]
       }] # From level.yml fixture
     )
   end


### PR DESCRIPTION
FInishes [PLAT-293]. 

For a bit of background, we are already enforcing uniqueness of a lesson's script + key here: https://github.com/code-dot-org/code-dot-org/blob/94aeb1ac07fade8d3989bc85083250607488c20d/dashboard/app/models/lesson.rb#L61

However, making the index unique in the database provides a stronger level of protection, as discussed here: https://thoughtbot.com/blog/validation-database-constraint-or-both

since we are requiring uniqueness, I thought it made sense to also make the `key` field required as well, which required updating a couple of tests.

## Testing story

ran `rake seed:scripts` locally, which exercises the codepath linked in the Jira item. this codepath also gets hit by drone.

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked


[PLAT-293]: https://codedotorg.atlassian.net/browse/PLAT-293