### PR TITLE
Fixing unit test broken when 'activity_section_position' added

### DIFF
--- a/dashboard/test/models/script_level_test.rb
+++ b/dashboard/test/models/script_level_test.rb
@@ -802,12 +802,12 @@ class ScriptLevelTest < ActiveSupport::TestCase
     assert_nil script_level.activity_section
 
     # can create script level with matching lessons
-    script_level = create :script_level, lesson: lesson, activity_section: activity_section
+    script_level = create :script_level, lesson: lesson, activity_section: activity_section, activity_section_position: 1
     assert_equal lesson, script_level.activity_section.lesson
 
     # cannot create script level with mismatched lessons
     assert_raises ActiveRecord::RecordInvalid do
-      create :script_level, lesson: other_lesson, activity_section: activity_section
+      create :script_level, lesson: other_lesson, activity_section: activity_section, activity_section_position: 1
     end
   end
 


### PR DESCRIPTION
A unit test was missed when the `activity_section_position` attribute was added in [this PR](https://github.com/code-dot-org/code-dot-org/pull/37143)

## Links
- [Bug introduced](https://github.com/code-dot-org/code-dot-org/pull/37143)

## Testing story

<!--
  Does your change include appropriate tests?

  If so, please describe how the tests included in this PR are sufficient

  If not, please explain why this change does not need to be tested.
-->

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
