### PR TITLE
Find similar lessons

### DIFF
--- a/apps/src/sites/studio/pages/lessons/edit.js
+++ b/apps/src/sites/studio/pages/lessons/edit.js
@@ -14,6 +14,11 @@ import {levelKeyList} from '@cdo/apps/lib/levelbuilder/lesson-editor/SampleActiv
 
 $(document).ready(function() {
   const lessonData = getScriptData('lesson');
+  const relatedLessons = getScriptData('relatedLessons');
+  relatedLessons.forEach(lesson => {
+    const type = lesson.lockable ? 'lockable' : 'lesson';
+    console.log(`${lesson.scriptName} ${type} ${lesson.relativePosition}`);
+  });
   const activities = lessonData.activities;
 
   // Rename any keys that are different on the backend.

--- a/apps/src/sites/studio/pages/lessons/edit.js
+++ b/apps/src/sites/studio/pages/lessons/edit.js
@@ -17,7 +17,7 @@ $(document).ready(function() {
   const relatedLessons = getScriptData('relatedLessons');
   relatedLessons.forEach(lesson => {
     const type = lesson.lockable ? 'lockable' : 'lesson';
-    const url = `/lessons/${lesson.lessonId}/edit`;
+    const url = lesson.lessonEditUrl;
     console.log(
       `${lesson.scriptName} ${type} ${lesson.relativePosition} ${url}`
     );

--- a/apps/src/sites/studio/pages/lessons/edit.js
+++ b/apps/src/sites/studio/pages/lessons/edit.js
@@ -15,6 +15,8 @@ import {levelKeyList} from '@cdo/apps/lib/levelbuilder/lesson-editor/SampleActiv
 $(document).ready(function() {
   const lessonData = getScriptData('lesson');
   const relatedLessons = getScriptData('relatedLessons');
+
+  // TODO(dave): move this output into the lesson edit UI
   relatedLessons.forEach(lesson => {
     const type = lesson.lockable ? 'lockable' : 'lesson';
     const url = lesson.lessonEditUrl;

--- a/apps/src/sites/studio/pages/lessons/edit.js
+++ b/apps/src/sites/studio/pages/lessons/edit.js
@@ -17,7 +17,10 @@ $(document).ready(function() {
   const relatedLessons = getScriptData('relatedLessons');
   relatedLessons.forEach(lesson => {
     const type = lesson.lockable ? 'lockable' : 'lesson';
-    console.log(`${lesson.scriptName} ${type} ${lesson.relativePosition}`);
+    const url = `/lessons/${lesson.lessonId}/edit`;
+    console.log(
+      `${lesson.scriptName} ${type} ${lesson.relativePosition} ${url}`
+    );
   });
   const activities = lessonData.activities;
 

--- a/dashboard/app/controllers/lessons_controller.rb
+++ b/dashboard/app/controllers/lessons_controller.rb
@@ -17,10 +17,7 @@ class LessonsController < ApplicationController
   # GET /lessons/1/edit
   def edit
     @lesson_data = @lesson.summarize_for_lesson_edit
-    @related_lessons = @lesson.summarize_related_lessons.map do |lesson|
-      lesson[:lessonEditUrl] = edit_lesson_path(id: lesson[:lessonId])
-      lesson
-    end
+    @related_lessons = @lesson.summarize_related_lessons
   end
 
   # PATCH/PUT /lessons/1

--- a/dashboard/app/controllers/lessons_controller.rb
+++ b/dashboard/app/controllers/lessons_controller.rb
@@ -17,7 +17,10 @@ class LessonsController < ApplicationController
   # GET /lessons/1/edit
   def edit
     @lesson_data = @lesson.summarize_for_lesson_edit
-    @related_lessons = @lesson.summarize_related_lessons
+    @related_lessons = @lesson.summarize_related_lessons.map do |lesson|
+      lesson[:lessonEditUrl] = edit_lesson_path(id: lesson[:lessonId])
+      lesson
+    end
   end
 
   # PATCH/PUT /lessons/1

--- a/dashboard/app/controllers/lessons_controller.rb
+++ b/dashboard/app/controllers/lessons_controller.rb
@@ -17,6 +17,7 @@ class LessonsController < ApplicationController
   # GET /lessons/1/edit
   def edit
     @lesson_data = @lesson.summarize_for_lesson_edit
+    @related_lessons = @lesson.summarize_related_lessons
   end
 
   # PATCH/PUT /lessons/1

--- a/dashboard/app/models/course_version.rb
+++ b/dashboard/app/models/course_version.rb
@@ -34,6 +34,8 @@ class CourseVersion < ApplicationRecord
   #   False for the CSP1-2019 Unit.
   belongs_to :content_root, polymorphic: true
 
+  alias_attribute :version_year, :key
+
   # Seeding method for creating / updating / deleting the CourseVersion for the given
   # potential content root, i.e. a Script or UnitGroup.
   #

--- a/dashboard/app/models/course_version.rb
+++ b/dashboard/app/models/course_version.rb
@@ -23,6 +23,10 @@ class CourseVersion < ApplicationRecord
   belongs_to :course_offering
   has_many :resources
 
+  def units
+    content_root_type == 'UnitGroup' ? content_root.default_scripts : [content_root]
+  end
+
   # "Interface" for content_root:
   #
   # is_course? - used during seeding to determine whether this object represents the content root for a CourseVersion.

--- a/dashboard/app/models/lesson.rb
+++ b/dashboard/app/models/lesson.rb
@@ -435,6 +435,12 @@ class Lesson < ActiveRecord::Base
     my_key.stringify_keys
   end
 
+  def related_lessons
+    return [] unless script.curriculum_umbrella
+    lessons = Lesson.joins(:script).where("scripts.properties -> '$.curriculum_umbrella' = ?", script.curriculum_umbrella).where(key: key)
+    lessons - [self]
+  end
+
   private
 
   # Finds the LessonActivity by id, or creates a new one if id is not specified.

--- a/dashboard/app/models/lesson.rb
+++ b/dashboard/app/models/lesson.rb
@@ -463,8 +463,11 @@ class Lesson < ActiveRecord::Base
     related_units = course_offering.course_versions.map(&:units).flatten
     lessons = Lesson.includes(:script).joins(:script).
       where(script: related_units).
-      where(key: key).
-      order("scripts.properties -> '$.version_year'", 'scripts.name')
+      where(key: key)
+    lessons = lessons.all.sort_by do |lesson|
+      version_year = lesson.script&.get_course_version&.version_year
+      [version_year, lesson.script.name]
+    end
     lessons - [self]
   end
 

--- a/dashboard/app/models/lesson.rb
+++ b/dashboard/app/models/lesson.rb
@@ -468,7 +468,7 @@ class Lesson < ActiveRecord::Base
         scriptName: lesson.script.name,
         lockable: lesson.lockable,
         relativePosition: lesson.relative_position,
-        lessonId: lesson.id
+        lessonEditUrl: edit_lesson_path(id: lesson.id)
       }
     end
   end

--- a/dashboard/app/models/lesson.rb
+++ b/dashboard/app/models/lesson.rb
@@ -437,8 +437,19 @@ class Lesson < ActiveRecord::Base
 
   def related_lessons
     return [] unless script.curriculum_umbrella
-    lessons = Lesson.joins(:script).where("scripts.properties -> '$.curriculum_umbrella' = ?", script.curriculum_umbrella).where(key: key)
+    lessons = Lesson.includes(:script).joins(:script).where("scripts.properties -> '$.curriculum_umbrella' = ?", script.curriculum_umbrella).where(key: key)
     lessons - [self]
+  end
+
+  def summarize_related_lessons
+    related_lessons.map do |lesson|
+      {
+        scriptName: lesson.script.name,
+        versionYear: lesson.script.version_year,
+        lockable: lesson.lockable,
+        relativePosition: lesson.relative_position,
+      }
+    end
   end
 
   private

--- a/dashboard/app/models/lesson.rb
+++ b/dashboard/app/models/lesson.rb
@@ -435,6 +435,23 @@ class Lesson < ActiveRecord::Base
     my_key.stringify_keys
   end
 
+  # Finds all other lessons which match the following criteria:
+  # 1. in the same curriculum umbrella (CSF/CSD/CSP) as this lesson
+  # 2. same lesson key (untranslated lesson name)
+  # The results are sorted first by version year and then by script name.
+  #
+  # This method is intended only to be used in levelbuilder mode, when script
+  # caching is disabled.
+  #
+  # The purpose of this method is to help curriculum writers find lessons
+  # related to the one they are currently editing in which they might want to
+  # make similar edits. The heuristic used by this method is that the lesson key
+  # will not change when a script is deep-copied into a new version year, or
+  # when a lesson is shared across CSF courses within the same version year. If
+  # this heuristic proves to be inadequate, we could consider adding an explicit
+  # link between related lessons.
+  #
+  # @return [Array<Lesson>]
   def related_lessons
     return [] unless script.curriculum_umbrella
     lessons = Lesson.includes(:script).joins(:script).
@@ -444,6 +461,7 @@ class Lesson < ActiveRecord::Base
     lessons - [self]
   end
 
+  # @return [Array<Hash>]
   def summarize_related_lessons
     related_lessons.map do |lesson|
       {

--- a/dashboard/app/models/lesson.rb
+++ b/dashboard/app/models/lesson.rb
@@ -448,9 +448,9 @@ class Lesson < ActiveRecord::Base
     related_lessons.map do |lesson|
       {
         scriptName: lesson.script.name,
-        versionYear: lesson.script.version_year,
         lockable: lesson.lockable,
         relativePosition: lesson.relative_position,
+        lessonId: lesson.id
       }
     end
   end

--- a/dashboard/app/models/lesson.rb
+++ b/dashboard/app/models/lesson.rb
@@ -456,19 +456,7 @@ class Lesson < ActiveRecord::Base
   # @return [Array<Lesson>]
   def related_lessons
     return related_csf_lessons if script&.curriculum_umbrella == 'CSF'
-
-    course_offering = script&.get_course_version&.course_offering
-    return [] unless course_offering
-    # all units in this course offering, including this lesson's unit
-    related_units = course_offering.course_versions.map(&:units).flatten
-    lessons = Lesson.includes(:script).joins(:script).
-      where(script: related_units).
-      where(key: key)
-    lessons = lessons.all.sort_by do |lesson|
-      version_year = lesson.script&.get_course_version&.version_year
-      [version_year, lesson.script.name]
-    end
-    lessons - [self]
+    script&.is_course ? related_unit_lessons : related_unit_group_lessons
   end
 
   def related_csf_lessons
@@ -481,6 +469,28 @@ class Lesson < ActiveRecord::Base
       where("scripts.properties -> '$.curriculum_umbrella' = ?", script.curriculum_umbrella).
       where(key: key).
       order("scripts.properties -> '$.version_year'", 'scripts.name')
+    lessons - [self]
+  end
+
+  def related_unit_lessons
+    course_offering = script&.get_course_version&.course_offering
+    return [] unless course_offering
+    lessons = Lesson.joins(script: :course_version).
+      where("course_versions.course_offering_id = ?", course_offering.id).
+      where(key: key).
+      order("course_versions.key", 'scripts.name').
+      to_a
+    lessons - [self]
+  end
+
+  def related_unit_group_lessons
+    course_offering = script&.get_course_version&.course_offering
+    return [] unless course_offering
+    lessons = Lesson.joins(script: {unit_group_units: {unit_group: :course_version}}).
+      where("course_versions.course_offering_id = ?", course_offering.id).
+      where(key: key).
+      order("course_versions.key", 'scripts.name').
+      to_a
     lessons - [self]
   end
 

--- a/dashboard/app/models/lesson.rb
+++ b/dashboard/app/models/lesson.rb
@@ -437,7 +437,10 @@ class Lesson < ActiveRecord::Base
 
   def related_lessons
     return [] unless script.curriculum_umbrella
-    lessons = Lesson.includes(:script).joins(:script).where("scripts.properties -> '$.curriculum_umbrella' = ?", script.curriculum_umbrella).where(key: key)
+    lessons = Lesson.includes(:script).joins(:script).
+      where("scripts.properties -> '$.curriculum_umbrella' = ?", script.curriculum_umbrella).
+      where(key: key).
+      order("scripts.properties -> '$.version_year'", 'scripts.name')
     lessons - [self]
   end
 

--- a/dashboard/app/models/lesson.rb
+++ b/dashboard/app/models/lesson.rb
@@ -437,7 +437,7 @@ class Lesson < ActiveRecord::Base
 
   # Finds all other lessons which match the following criteria:
   # 1. the other lesson is in the same course offering as this lesson. Or, if
-  # this is lesson is in a CSF course offering, the other lesson may also be in
+  # this lesson is in a CSF course offering, the other lesson may also be in
   # any other CSF course offering.
   # 2. same lesson key (untranslated lesson name)
   # The results are sorted first by version year and then by script name.

--- a/dashboard/app/models/script.rb
+++ b/dashboard/app/models/script.rb
@@ -1465,6 +1465,14 @@ class Script < ActiveRecord::Base
     UnitGroup.get_from_cache(unit_group_units[0].course_id)
   end
 
+  # If this unit is a standalone course, returns its CourseVersion. Otherwise,
+  # if this unit belongs to a UnitGroup, returns the UnitGroup's CourseVersion,
+  # if there is one.
+  # @return [CourseVersion]
+  def get_course_version
+    course_version || unit_group&.course_version
+  end
+
   # @return {String|nil} path to the course overview page for this script if there
   #   is one.
   def course_link(section_id = nil)

--- a/dashboard/app/views/lessons/edit.html.haml
+++ b/dashboard/app/views/lessons/edit.html.haml
@@ -1,5 +1,5 @@
 %script{src: webpack_asset_path('js/lessons/edit.js'),
-        data: {lesson: @lesson_data.to_json}}
+        data: {lesson: @lesson_data.to_json, relatedLessons: @related_lessons.to_json}}
 
 = form_for @lesson, {url: lesson_path(id: @lesson.id)} do |f|
   #edit-container

--- a/dashboard/test/models/lesson_test.rb
+++ b/dashboard/test/models/lesson_test.rb
@@ -313,6 +313,18 @@ class LessonTest < ActiveSupport::TestCase
 
       assert_equal [lesson2], lesson1.related_lessons
     end
+
+    test 'no related lessons without curriculum umbrella' do
+      script1 = create :script
+      lesson_group1 = create :lesson_group, script: script1
+      lesson1 = create :lesson, script: script1, lesson_group: lesson_group1, key: 'foo'
+
+      script2 = create :script
+      lesson_group2 = create :lesson_group, script: script2
+      create :lesson, script: script2, lesson_group: lesson_group2, key: 'foo'
+
+      assert_equal [], lesson1.related_lessons
+    end
   end
 
   def create_swapped_lockable_lesson

--- a/dashboard/test/models/lesson_test.rb
+++ b/dashboard/test/models/lesson_test.rb
@@ -293,6 +293,26 @@ class LessonTest < ActiveSupport::TestCase
       refute @lesson_future_visible_after.published?(@student)
       refute @lesson_future_visible_after.published?(nil)
     end
+
+    test 'find related lessons within curriculum umbrella' do
+      script1 = create :script, curriculum_umbrella: 'same'
+      lesson_group1 = create :lesson_group, script: script1
+      lesson1 = create :lesson, script: script1, lesson_group: lesson_group1, key: 'foo'
+
+      script2 = create :script, curriculum_umbrella: 'same'
+      lesson_group2 = create :lesson_group, script: script2
+      lesson2 = create :lesson, script: script2, lesson_group: lesson_group2, key: 'foo'
+
+      script3 = create :script, curriculum_umbrella: 'same'
+      lesson_group3 = create :lesson_group, script: script3
+      create :lesson, script: script3, lesson_group: lesson_group3, key: 'bar'
+
+      script4 = create :script, curriculum_umbrella: 'other'
+      lesson_group4 = create :lesson_group, script: script4
+      create :lesson, script: script4, lesson_group: lesson_group4, key: 'foo'
+
+      assert_equal [lesson2], lesson1.related_lessons
+    end
   end
 
   def create_swapped_lockable_lesson

--- a/dashboard/test/models/lesson_test.rb
+++ b/dashboard/test/models/lesson_test.rb
@@ -348,9 +348,14 @@ class LessonTest < ActiveSupport::TestCase
     create :course_version, course_offering: other_course_offering, content_root: script5, key: '3000'
     create :lesson, script: script5, key: 'foo'
 
+    # measure the query count of the summarize method before checking the result
+    # of related_lessons, so that the count is not artificially reduced by
+    # anything being cached from the call to related_lessons.
     assert_queries(8) do
-      assert_equal [lesson4, lesson2], lesson1.related_lessons
+      lesson1.summarize_related_lessons
     end
+
+    assert_equal [lesson4, lesson2], lesson1.related_lessons
   end
 
   test 'find related lessons within a course offering with unit groups' do
@@ -395,9 +400,14 @@ class LessonTest < ActiveSupport::TestCase
     create :unit_group_unit, unit_group: unit_group_c, script: script6, position: 1
     create :lesson, script: script6, key: 'foo'
 
+    # measure the query count of the summarize method before checking the result
+    # of related_lessons, so that the count is not artificially reduced by
+    # anything being cached from the call to related_lessons.
     assert_queries(11) do
-      assert_equal [lesson4, lesson0, lesson2], lesson1.related_lessons
+      lesson1.summarize_related_lessons
     end
+
+    assert_equal [lesson4, lesson0, lesson2], lesson1.related_lessons
   end
 
   test 'no related lessons without course offering' do

--- a/dashboard/test/models/lesson_test.rb
+++ b/dashboard/test/models/lesson_test.rb
@@ -293,46 +293,46 @@ class LessonTest < ActiveSupport::TestCase
       refute @lesson_future_visible_after.published?(@student)
       refute @lesson_future_visible_after.published?(nil)
     end
+  end
 
-    test 'find related lessons within curriculum umbrella' do
-      script1 = create :script, curriculum_umbrella: 'same'
-      lesson1 = create :lesson, script: script1, key: 'foo'
+  test 'find related lessons within curriculum umbrella' do
+    script1 = create :script, curriculum_umbrella: 'same'
+    lesson1 = create :lesson, script: script1, key: 'foo'
 
-      script2 = create :script, curriculum_umbrella: 'same'
-      lesson2 = create :lesson, script: script2, key: 'foo'
+    script2 = create :script, curriculum_umbrella: 'same'
+    lesson2 = create :lesson, script: script2, key: 'foo'
 
-      script3 = create :script, curriculum_umbrella: 'same'
-      create :lesson, script: script3, key: 'bar'
+    script3 = create :script, curriculum_umbrella: 'same'
+    create :lesson, script: script3, key: 'bar'
 
-      script4 = create :script, curriculum_umbrella: 'other'
-      create :lesson, script: script4, key: 'foo'
+    script4 = create :script, curriculum_umbrella: 'other'
+    create :lesson, script: script4, key: 'foo'
 
-      script5 = create :script, curriculum_umbrella: 'same'
-      lesson5 = create :lesson, script: script5, key: 'foo'
+    script5 = create :script, curriculum_umbrella: 'same'
+    lesson5 = create :lesson, script: script5, key: 'foo'
 
-      script6 = create :script, curriculum_umbrella: 'same'
-      lesson6 = create :lesson, script: script6, key: 'foo'
+    script6 = create :script, curriculum_umbrella: 'same'
+    lesson6 = create :lesson, script: script6, key: 'foo'
 
-      assert_queries(1) do
-        assert_equal [lesson2, lesson5, lesson6], lesson1.related_lessons
-      end
-
-      assert_queries(1) do
-        assert_equal 3, lesson1.summarize_related_lessons.count
-      end
+    assert_queries(1) do
+      assert_equal [lesson2, lesson5, lesson6], lesson1.related_lessons
     end
 
-    test 'no related lessons without curriculum umbrella' do
-      script1 = create :script
-      lesson_group1 = create :lesson_group, script: script1
-      lesson1 = create :lesson, script: script1, lesson_group: lesson_group1, key: 'foo'
-
-      script2 = create :script
-      lesson_group2 = create :lesson_group, script: script2
-      create :lesson, script: script2, lesson_group: lesson_group2, key: 'foo'
-
-      assert_equal [], lesson1.related_lessons
+    assert_queries(1) do
+      assert_equal 3, lesson1.summarize_related_lessons.count
     end
+  end
+
+  test 'no related lessons without curriculum umbrella' do
+    script1 = create :script
+    lesson_group1 = create :lesson_group, script: script1
+    lesson1 = create :lesson, script: script1, lesson_group: lesson_group1, key: 'foo'
+
+    script2 = create :script
+    lesson_group2 = create :lesson_group, script: script2
+    create :lesson, script: script2, lesson_group: lesson_group2, key: 'foo'
+
+    assert_equal [], lesson1.related_lessons
   end
 
   def create_swapped_lockable_lesson

--- a/dashboard/test/models/lesson_test.rb
+++ b/dashboard/test/models/lesson_test.rb
@@ -311,7 +311,21 @@ class LessonTest < ActiveSupport::TestCase
       lesson_group4 = create :lesson_group, script: script4
       create :lesson, script: script4, lesson_group: lesson_group4, key: 'foo'
 
-      assert_equal [lesson2], lesson1.related_lessons
+      script5 = create :script, curriculum_umbrella: 'same'
+      lesson_group5 = create :lesson_group, script: script5
+      lesson5 = create :lesson, script: script5, lesson_group: lesson_group5, key: 'foo'
+
+      script6 = create :script, curriculum_umbrella: 'same'
+      lesson_group6 = create :lesson_group, script: script6
+      lesson6 = create :lesson, script: script6, lesson_group: lesson_group6, key: 'foo'
+
+      assert_queries(1) do
+        assert_equal [lesson2, lesson5, lesson6], lesson1.related_lessons
+      end
+
+      assert_queries(1) do
+        assert_equal 3, lesson1.summarize_related_lessons.count
+      end
     end
 
     test 'no related lessons without curriculum umbrella' do

--- a/dashboard/test/models/lesson_test.rb
+++ b/dashboard/test/models/lesson_test.rb
@@ -348,7 +348,7 @@ class LessonTest < ActiveSupport::TestCase
     create :course_version, course_offering: other_course_offering, content_root: script5, key: '3000'
     create :lesson, script: script5, key: 'foo'
 
-    assert_queries(3) do
+    assert_queries(10) do
       assert_equal [lesson4, lesson2], lesson1.related_lessons
     end
   end
@@ -395,7 +395,7 @@ class LessonTest < ActiveSupport::TestCase
     create :unit_group_unit, unit_group: unit_group_c, script: script6, position: 1
     create :lesson, script: script6, key: 'foo'
 
-    assert_queries(6) do
+    assert_queries(17) do
       assert_equal [lesson4, lesson0, lesson2], lesson1.related_lessons
     end
   end

--- a/dashboard/test/models/lesson_test.rb
+++ b/dashboard/test/models/lesson_test.rb
@@ -348,7 +348,7 @@ class LessonTest < ActiveSupport::TestCase
     create :course_version, course_offering: other_course_offering, content_root: script5, key: '3000'
     create :lesson, script: script5, key: 'foo'
 
-    assert_queries(10) do
+    assert_queries(3) do
       assert_equal [lesson4, lesson2], lesson1.related_lessons
     end
   end
@@ -395,7 +395,7 @@ class LessonTest < ActiveSupport::TestCase
     create :unit_group_unit, unit_group: unit_group_c, script: script6, position: 1
     create :lesson, script: script6, key: 'foo'
 
-    assert_queries(17) do
+    assert_queries(6) do
       assert_equal [lesson4, lesson0, lesson2], lesson1.related_lessons
     end
   end

--- a/dashboard/test/models/lesson_test.rb
+++ b/dashboard/test/models/lesson_test.rb
@@ -296,28 +296,22 @@ class LessonTest < ActiveSupport::TestCase
 
     test 'find related lessons within curriculum umbrella' do
       script1 = create :script, curriculum_umbrella: 'same'
-      lesson_group1 = create :lesson_group, script: script1
-      lesson1 = create :lesson, script: script1, lesson_group: lesson_group1, key: 'foo'
+      lesson1 = create :lesson, script: script1, key: 'foo'
 
       script2 = create :script, curriculum_umbrella: 'same'
-      lesson_group2 = create :lesson_group, script: script2
-      lesson2 = create :lesson, script: script2, lesson_group: lesson_group2, key: 'foo'
+      lesson2 = create :lesson, script: script2, key: 'foo'
 
       script3 = create :script, curriculum_umbrella: 'same'
-      lesson_group3 = create :lesson_group, script: script3
-      create :lesson, script: script3, lesson_group: lesson_group3, key: 'bar'
+      create :lesson, script: script3, key: 'bar'
 
       script4 = create :script, curriculum_umbrella: 'other'
-      lesson_group4 = create :lesson_group, script: script4
-      create :lesson, script: script4, lesson_group: lesson_group4, key: 'foo'
+      create :lesson, script: script4, key: 'foo'
 
       script5 = create :script, curriculum_umbrella: 'same'
-      lesson_group5 = create :lesson_group, script: script5
-      lesson5 = create :lesson, script: script5, lesson_group: lesson_group5, key: 'foo'
+      lesson5 = create :lesson, script: script5, key: 'foo'
 
       script6 = create :script, curriculum_umbrella: 'same'
-      lesson_group6 = create :lesson_group, script: script6
-      lesson6 = create :lesson, script: script6, lesson_group: lesson_group6, key: 'foo'
+      lesson6 = create :lesson, script: script6, key: 'foo'
 
       assert_queries(1) do
         assert_equal [lesson2, lesson5, lesson6], lesson1.related_lessons

--- a/dashboard/test/models/lesson_test.rb
+++ b/dashboard/test/models/lesson_test.rb
@@ -348,7 +348,7 @@ class LessonTest < ActiveSupport::TestCase
     create :course_version, course_offering: other_course_offering, content_root: script5, key: '3000'
     create :lesson, script: script5, key: 'foo'
 
-    assert_queries(10) do
+    assert_queries(8) do
       assert_equal [lesson4, lesson2], lesson1.related_lessons
     end
   end
@@ -395,7 +395,7 @@ class LessonTest < ActiveSupport::TestCase
     create :unit_group_unit, unit_group: unit_group_c, script: script6, position: 1
     create :lesson, script: script6, key: 'foo'
 
-    assert_queries(17) do
+    assert_queries(11) do
       assert_equal [lesson4, lesson0, lesson2], lesson1.related_lessons
     end
   end

--- a/dashboard/test/models/lesson_test.rb
+++ b/dashboard/test/models/lesson_test.rb
@@ -326,26 +326,30 @@ class LessonTest < ActiveSupport::TestCase
   test 'find related lessons within a course offering without unit groups' do
     course_offering = create :course_offering
 
-    script1 = create :script, name: 'script1', is_course: true, version_year: '2099'
-    create :course_version, course_offering: course_offering, content_root: script1, key: '2099'
+    script1 = create :script, name: 'script1', is_course: true
+    create :course_version, course_offering: course_offering, content_root: script1, key: '3000'
     lesson1 = create :lesson, script: script1, key: 'foo'
 
-    script2 = create :script, name: 'script2', is_course: true, version_year: '3000'
-    create :course_version, course_offering: course_offering, content_root: script2, key: '3000'
+    script2 = create :script, name: 'script2', is_course: true
+    create :course_version, course_offering: course_offering, content_root: script2, key: '3001'
     lesson2 = create :lesson, script: script2, key: 'foo'
 
-    script3 = create :script, name: 'script3', is_course: true, version_year: '3001'
-    create :course_version, course_offering: course_offering, content_root: script3, key: '3001'
+    script3 = create :script, name: 'script3', is_course: true
+    create :course_version, course_offering: course_offering, content_root: script3, key: '3002'
     create :lesson, script: script3, key: 'bar'
+
+    script4 = create :script, name: 'script4', is_course: true
+    create :course_version, course_offering: course_offering, content_root: script4, key: '2999'
+    lesson4 = create :lesson, script: script4, key: 'foo'
 
     other_course_offering = create :course_offering
 
-    script4 = create :script, name: 'script4', is_course: true, version_year: '2099'
-    create :course_version, course_offering: other_course_offering, content_root: script4, key: '2099'
-    create :lesson, script: script4, key: 'foo'
+    script5 = create :script, name: 'script5', is_course: true
+    create :course_version, course_offering: other_course_offering, content_root: script5, key: '3000'
+    create :lesson, script: script5, key: 'foo'
 
-    assert_queries(7) do
-      assert_equal [lesson2], lesson1.related_lessons
+    assert_queries(10) do
+      assert_equal [lesson4, lesson2], lesson1.related_lessons
     end
   end
 
@@ -353,7 +357,7 @@ class LessonTest < ActiveSupport::TestCase
     course_offering = create :course_offering
 
     unit_group_a = create :unit_group
-    create :course_version, course_offering: course_offering, content_root: unit_group_a, key: '2099'
+    create :course_version, course_offering: course_offering, content_root: unit_group_a, key: '3000'
 
     script1 = create :script, name: 'script1'
     create :unit_group_unit, unit_group: unit_group_a, script: script1, position: 1
@@ -367,8 +371,12 @@ class LessonTest < ActiveSupport::TestCase
     create :unit_group_unit, unit_group: unit_group_a, script: script3, position: 3
     create :lesson, script: script3, key: 'bar'
 
+    script0 = create :script, name: 'script0'
+    create :unit_group_unit, unit_group: unit_group_a, script: script0, position: 4
+    lesson0 = create :lesson, script: script0, key: 'foo'
+
     unit_group_b = create :unit_group
-    create :course_version, course_offering: course_offering, content_root: unit_group_b, key: '3000'
+    create :course_version, course_offering: course_offering, content_root: unit_group_b, key: '2999'
 
     script4 = create :script, name: 'script4'
     create :unit_group_unit, unit_group: unit_group_b, script: script4, position: 1
@@ -381,14 +389,14 @@ class LessonTest < ActiveSupport::TestCase
     other_course_offering = create :course_offering
 
     unit_group_c = create :unit_group
-    create :course_version, course_offering: other_course_offering, content_root: unit_group_c, key: '2999'
+    create :course_version, course_offering: other_course_offering, content_root: unit_group_c, key: '3000'
 
     script6 = create :script, name: 'script6'
     create :unit_group_unit, unit_group: unit_group_c, script: script6, position: 1
     create :lesson, script: script6, key: 'foo'
 
-    assert_queries(10) do
-      assert_equal [lesson2, lesson4], lesson1.related_lessons
+    assert_queries(17) do
+      assert_equal [lesson4, lesson0, lesson2], lesson1.related_lessons
     end
   end
 

--- a/dashboard/test/models/lesson_test.rb
+++ b/dashboard/test/models/lesson_test.rb
@@ -296,26 +296,26 @@ class LessonTest < ActiveSupport::TestCase
   end
 
   test 'find related lessons within curriculum umbrella' do
-    script1 = create :script, curriculum_umbrella: 'same'
+    script1 = create :script, name: 'script1', curriculum_umbrella: 'same', version_year: '2099'
     lesson1 = create :lesson, script: script1, key: 'foo'
 
-    script2 = create :script, curriculum_umbrella: 'same'
+    script2 = create :script, name: 'script2', curriculum_umbrella: 'same', version_year: '3000'
     lesson2 = create :lesson, script: script2, key: 'foo'
 
-    script3 = create :script, curriculum_umbrella: 'same'
+    script3 = create :script, name: 'script3', curriculum_umbrella: 'same', version_year: '2099'
     create :lesson, script: script3, key: 'bar'
 
-    script4 = create :script, curriculum_umbrella: 'other'
+    script4 = create :script, name: 'script4', curriculum_umbrella: 'other', version_year: '2099'
     create :lesson, script: script4, key: 'foo'
 
-    script5 = create :script, curriculum_umbrella: 'same'
+    script5 = create :script, name: 'script5', curriculum_umbrella: 'same', version_year: '2099'
     lesson5 = create :lesson, script: script5, key: 'foo'
 
-    script6 = create :script, curriculum_umbrella: 'same'
-    lesson6 = create :lesson, script: script6, key: 'foo'
+    script0 = create :script, name: 'script0', curriculum_umbrella: 'same', version_year: '2099'
+    lesson0 = create :lesson, script: script0, key: 'foo'
 
     assert_queries(1) do
-      assert_equal [lesson2, lesson5, lesson6], lesson1.related_lessons
+      assert_equal [lesson0, lesson5, lesson2], lesson1.related_lessons
     end
 
     assert_queries(1) do


### PR DESCRIPTION
Starts [PLAT-311]. Does the following:
* finds all lessons in the same "curriullum umbrella" (CSF, CSP or CSD) with the same `key`
* orders the data by version year and then script name
* for now, prints to the debug console on the lesson edit page

Future work to finish this item includes displaying this info on the lesson edit page.

## Screenshots

editing this lesson:
![Screen Shot 2020-10-11 at 10 53 09 PM](https://user-images.githubusercontent.com/8001765/95710449-92b34200-0c15-11eb-9766-a329c6232576.png)

shows this debug output:
![Screen Shot 2020-10-11 at 10 58 57 PM](https://user-images.githubusercontent.com/8001765/95710463-9b0b7d00-0c15-11eb-8125-da631ee72d19.png)

## Testing story

New unit test verifying contents, ordering and query counts.

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked


[PLAT-311]: https://codedotorg.atlassian.net/browse/PLAT-311