### PR TITLE
Reapply Dance Party twitter handles

### DIFF
--- a/apps/src/code-studio/components/ShareAllowedDialog.jsx
+++ b/apps/src/code-studio/components/ShareAllowedDialog.jsx
@@ -280,23 +280,16 @@ class ShareAllowedDialog extends React.Component {
     const facebookShareUrl =
       'https://www.facebook.com/sharer/sharer.php?u=' +
       encodeURIComponent(this.props.shareUrl);
-    const twitterShareUrlDefault =
-      'https://twitter.com/intent/tweet?url=' +
-      encodeURIComponent(this.props.shareUrl) +
-      '&amp;text=Check%20out%20what%20I%20made%20@codeorg' +
-      '&amp;hashtags=HourOfCode&amp;related=codeorg';
-    // Check out the dance I made featuring @artist on @codeorg! URL #HourOfCode
-    const twitterShareUrlDance =
-      'https://twitter.com/intent/tweet?url=' +
-      '&amp;text=Check%20out%20the%20dance%20I%20made%20featuring%20@' +
-      artistTwitterHandle +
-      '%20on%20@codeorg!%20' +
-      encodeURIComponent(this.props.shareUrl) +
-      '&amp;hashtags=HourOfCode&amp;related=codeorg';
 
-    const twitterShareUrl = artistTwitterHandle
-      ? twitterShareUrlDance
-      : twitterShareUrlDefault;
+    const tweetText = artistTwitterHandle
+      ? `Check out the dance I made featuring @${artistTwitterHandle} on @codeorg!`
+      : 'Check out what I made on @codeorg!';
+    const twitterShareUrl =
+      'https://twitter.com/intent/tweet?text=' +
+      encodeURIComponent(tweetText) +
+      '&url=' +
+      encodeURIComponent(this.props.shareUrl) +
+      '&hashtags=HourOfCode&related=codeorg';
 
     const showShareWarning = !this.props.canShareSocial && isDroplet;
     let embedOptions;

--- a/apps/src/code-studio/dancePartySongArtistTags.js
+++ b/apps/src/code-studio/dancePartySongArtistTags.js
@@ -1,7 +1,9 @@
-// Dance Party song titles mapped to the artist's Twitter handle to use in the // ShareDialog share links. Not all songs are available in all environments,
-// and the full list of in-use Dance Party songs can be found at: https://s3.console.aws.amazon.com/s3/buckets/cdo-sound-library/hoc_song_meta/?region=us-east-1&tab=overview
-//Full list of songs including potential (reflected here) can be found at:
-// https://tinyurl.com/y9r5xx5d
+/**
+ * Dance Party song titles mapped to the artist's Twitter handle to use in the
+ * <ShareDialog/> share links. Not all songs are available in all environments.
+ * The full list of in-use Dance Party songs can be found at:
+ * https://s3.console.aws.amazon.com/s3/buckets/cdo-sound-library/hoc_song_meta/?region=us-east-1&tab=overview
+ */
 
 export const SongTitlesToArtistTwitterHandle = {
   backtoyou_selenagomez: 'SelenaGomez',
@@ -35,7 +37,7 @@ export const SongTitlesToArtistTwitterHandle = {
   wenospeakamericano_yolandabecool: 'YolandaBeCool',
   ymca_villagepeople: 'VillagePeople',
   firework_katyperry: 'KatyPerry',
-  //2019 Songs
+  // 2019 Songs
   calma_pedrocapo: 'PedroCapo',
   highhopes_panicatthedisco: 'PanicAtTheDisco',
   ificanthaveyou_shawnmendes: 'ShawnMendes',
@@ -47,6 +49,9 @@ export const SongTitlesToArtistTwitterHandle = {
   oldtownroadremix_lilnasx_long: 'LilNasX',
   starships_nickiminaj: 'NICKIMINAJ',
   sucker_jonasbrothers: 'JonasBrothers',
+  // 2020 Songs
+  ilkadimisenat_kenandogulu: 'kenandogulu',
+  odetocode_brendandominicpaolini: 'CodeWeekEU',
   // These tracks available locally, tweet @codeorg to avoid spamming anyone.
   jazzy_beats: 'codeorg',
   synthesize: 'codeorg',


### PR DESCRIPTION
Reapplies changes from #37147, which here accidentally reverted in #37165.