### PR TITLE
Re-enable auto-validation after the change was accidentally removed on staging.

### DIFF
--- a/apps/src/feedback.js
+++ b/apps/src/feedback.js
@@ -748,6 +748,7 @@ FeedbackUtils.prototype.getFeedbackMessage = function(options) {
     // Otherwise, the message will depend on the test result.
     switch (options.feedbackType) {
       case TestResults.FREE_PLAY_UNCHANGED_FAIL:
+        logDialogActions('level_unchanged_failure', options, null);
         message = options.useDialog
           ? msg.freePlayUnchangedFail()
           : msg.freePlayUnchangedFailInline();

--- a/apps/src/sites/studio/pages/levels/editors/fields/_validation_code.js
+++ b/apps/src/sites/studio/pages/levels/editors/fields/_validation_code.js
@@ -3,20 +3,18 @@ import $ from 'jquery';
 $(initPage);
 
 function initPage() {
-  const freePlay = $('#level_free_play');
+  const widgetMode = $('#level_widget_mode');
+  const embed = $('#level_embed');
   const autoValidate = $('#level_validation_enabled');
-  if (freePlay && autoValidate) {
-    freePlay.on('click', syncWithValidate);
-    if (!freePlay.prop('checked')) {
-      syncWithValidate();
-    }
+  if (autoValidate.length > 0) {
+    embed.on('click', () => syncValidateWithElements(embed, widgetMode));
+    widgetMode.on('click', () => syncValidateWithElements(embed, widgetMode));
   }
 }
 
-function syncWithValidate() {
-  const freePlay = $('#level_free_play');
+function syncValidateWithElements(element1, element2) {
   const autoValidate = $('#level_validation_enabled');
-  const checked = freePlay.prop('checked');
-  autoValidate.prop('checked', checked);
-  autoValidate.prop('disabled', !checked);
+  const eitherChecked = element1.prop('checked') || element2.prop('checked');
+  autoValidate.prop('checked', !eitherChecked);
+  autoValidate.prop('disabled', eitherChecked);
 }

--- a/dashboard/app/models/levels/applab.rb
+++ b/dashboard/app/models/levels/applab.rb
@@ -81,7 +81,8 @@ class Applab < Blockly
         level_num: 'custom',
         properties: {
           code_functions: JSON.parse(palette),
-        }
+        },
+        validation_enabled: true
       )
     )
   end

--- a/dashboard/app/models/levels/artist.rb
+++ b/dashboard/app/models/levels/artist.rb
@@ -55,6 +55,7 @@ class Artist < Blockly
         user: params[:user],
         game: Game.custom_artist,
         level_num: 'custom',
+        validation_enabled: true
       )
     )
   end

--- a/dashboard/app/models/levels/gamelab.rb
+++ b/dashboard/app/models/levels/gamelab.rb
@@ -70,7 +70,8 @@ class Gamelab < Blockly
         properties: {
           code_functions: JSON.parse(palette),
           show_debug_watch: true
-        }
+        },
+        validation_enabled: true
       )
     )
   end

--- a/dashboard/app/models/levels/weblab.rb
+++ b/dashboard/app/models/levels/weblab.rb
@@ -42,7 +42,8 @@ class Weblab < Level
         user: params[:user],
         game: Game.weblab,
         level_num: 'custom',
-        properties: {}
+        properties: {},
+        validation_enabled: true
       )
     )
   end

--- a/dashboard/config/scripts/levels/CSD games sidescroll background.level
+++ b/dashboard/config/scripts/levels/CSD games sidescroll background.level
@@ -96,7 +96,7 @@
     "encrypted": "false",
     "libraries_enabled": "false",
     "preload_asset_list": null,
-    "validation_enabled": "false"
+    "validation_enabled": "true"
   },
   "published": true,
   "notes": "",

--- a/dashboard/config/scripts/levels/CourseE_Project_SpriteLab_2020.level
+++ b/dashboard/config/scripts/levels/CourseE_Project_SpriteLab_2020.level
@@ -36,6 +36,7 @@
     "hide_share_and_remix": "false",
     "disable_if_else_editing": "false",
     "free_play": "true",
+    "validation_enabled": "true",
     "hide_view_data_button": "false",
     "expand_debugger": "false",
     "debugger_disabled": "false",

--- a/dashboard/config/scripts/levels/U5 L03 Lists Practice 1.level
+++ b/dashboard/config/scripts/levels/U5 L03 Lists Practice 1.level
@@ -20,6 +20,7 @@
     "droplet_tooltips_disabled": "false",
     "lock_zero_param_functions": "false",
     "free_play": "false",
+    "validation_enabled": "true",
     "show_turtle_before_run": "false",
     "autocomplete_palette_apis_only": "true",
     "execute_palette_apis_only": "false",

--- a/dashboard/config/scripts/levels/courseE_aboutme_3_2020.level
+++ b/dashboard/config/scripts/levels/courseE_aboutme_3_2020.level
@@ -30,6 +30,7 @@
     "hide_share_and_remix": "false",
     "disable_if_else_editing": "false",
     "free_play": "false",
+    "validation_enabled": "true",
     "start_in_animation_tab": "false",
     "all_animations_single_frame": "true",
     "hide_view_data_button": "false",


### PR DESCRIPTION
Documentation for this change can be found here: https://github.com/code-dot-org/code-dot-org/pull/37124

This change was unintentionally removed from staging. This PR re-implements that change.
Details about the situation that removed this change: https://codedotorg.slack.com/archives/C0T0PNTM3/p1602486391281300

<!-- ### Background -->
<!-- ### Privacy -->
<!--
1.	Does the Project involve the collection, use or sharing of new Personal Data?

2.	Does the Project involve a new or changed use or sharing of existing Personal Data?
-->
<!-- ### Security -->
<!--
Link to Jira Task where sensitive security issues are discussed privately.
-->
<!-- ### Caching -->
<!-- ### Deployment strategy -->
<!-- ### Future work -->

## Links

<!--
  Any relevant links to external resources; ie, specification documents, jira
  items, related PRs, honeybadger errors, etc
-->


## Testing story

<!--
  Does your change include appropriate tests?

  If so, please describe how the tests included in this PR are sufficient

  If not, please explain why this change does not need to be tested.
-->

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
