### PR TITLE
[Spritelab] Add user input blocks for prototyping (behind experiment)

### DIFF
--- a/apps/src/block_utils.js
+++ b/apps/src/block_utils.js
@@ -1149,6 +1149,17 @@ exports.createJsWrapperBlockCreator = function(
         }
       }
 
+      if (this.type === 'gamelab_setQuestion') {
+        const input = this.getInput('VAR');
+        if (input) {
+          const targetBlock = input.connection.targetBlock();
+          if (targetBlock && targetBlock.type === 'variables_get') {
+            const varName = Blockly.JavaScript.blockToCode(targetBlock)[0];
+            values.push(`function(val) {${varName} = val;}`);
+          }
+        }
+      }
+
       if (expression) {
         // If the original expression has a value placeholder, replace it
         // with the selected value.

--- a/apps/src/p5lab/P5LabVisualizationColumn.jsx
+++ b/apps/src/p5lab/P5LabVisualizationColumn.jsx
@@ -56,8 +56,7 @@ class P5LabVisualizationColumn extends React.Component {
     cancelPicker: PropTypes.func.isRequired,
     selectPicker: PropTypes.func.isRequired,
     updatePicker: PropTypes.func.isRequired,
-    consoleMessages: PropTypes.array.isRequired,
-    question: PropTypes.string.isRequired
+    consoleMessages: PropTypes.array.isRequired
   };
 
   // Cache app-space mouse coordinates, which we get from the
@@ -183,7 +182,7 @@ class P5LabVisualizationColumn extends React.Component {
         </ProtectedVisualizationDiv>
         <TextConsole consoleMessages={this.props.consoleMessages} />
         {experiments.isEnabled(experiments.SPRITELAB_INPUT) && (
-          <SpritelabInput question={this.props.question} />
+          <SpritelabInput />
         )}
         <GameButtons>
           <ArrowButtons />
@@ -223,8 +222,7 @@ export default connect(
     awaitingContainedResponse: state.runState.awaitingContainedResponse,
     showGrid: state.gridOverlay,
     pickingLocation: isPickingLocation(state.locationPicker),
-    consoleMessages: state.textConsole,
-    question: state.spritelabInput || 'my test question'
+    consoleMessages: state.textConsole
   }),
   dispatch => ({
     toggleShowGrid: mode => dispatch(toggleGridOverlay(mode)),

--- a/apps/src/p5lab/P5LabVisualizationColumn.jsx
+++ b/apps/src/p5lab/P5LabVisualizationColumn.jsx
@@ -6,6 +6,7 @@ import classNames from 'classnames';
 import GameButtons from '@cdo/apps/templates/GameButtons';
 import ArrowButtons from '@cdo/apps/templates/ArrowButtons';
 import BelowVisualization from '@cdo/apps/templates/BelowVisualization';
+import experiments from '@cdo/apps/util/experiments';
 import {APP_HEIGHT, APP_WIDTH} from './constants';
 import {GAMELAB_DPAD_CONTAINER_ID} from './gamelab/constants';
 import CompletionButton from '@cdo/apps/templates/CompletionButton';
@@ -20,6 +21,7 @@ import i18n from '@cdo/locale';
 import {toggleGridOverlay} from './actions';
 import GridOverlay from './gamelab/GridOverlay';
 import TextConsole from './spritelab/TextConsole';
+import SpritelabInput from './spritelab/SpritelabInput';
 import {
   cancelLocationSelection,
   selectLocation,
@@ -54,7 +56,8 @@ class P5LabVisualizationColumn extends React.Component {
     cancelPicker: PropTypes.func.isRequired,
     selectPicker: PropTypes.func.isRequired,
     updatePicker: PropTypes.func.isRequired,
-    consoleMessages: PropTypes.array.isRequired
+    consoleMessages: PropTypes.array.isRequired,
+    question: PropTypes.string.isRequired
   };
 
   // Cache app-space mouse coordinates, which we get from the
@@ -179,6 +182,9 @@ class P5LabVisualizationColumn extends React.Component {
           </VisualizationOverlay>
         </ProtectedVisualizationDiv>
         <TextConsole consoleMessages={this.props.consoleMessages} />
+        {experiments.isEnabled(experiments.SPRITELAB_INPUT) && (
+          <SpritelabInput question={this.props.question} />
+        )}
         <GameButtons>
           <ArrowButtons />
 
@@ -217,7 +223,8 @@ export default connect(
     awaitingContainedResponse: state.runState.awaitingContainedResponse,
     showGrid: state.gridOverlay,
     pickingLocation: isPickingLocation(state.locationPicker),
-    consoleMessages: state.textConsole
+    consoleMessages: state.textConsole,
+    question: state.spritelabInput || 'my test question'
   }),
   dispatch => ({
     toggleShowGrid: mode => dispatch(toggleGridOverlay(mode)),

--- a/apps/src/p5lab/reducers.js
+++ b/apps/src/p5lab/reducers.js
@@ -12,7 +12,7 @@ import animationPicker from './AnimationPicker/animationPickerModule';
 import animationTab from './AnimationTab/animationTabModule';
 import locationPicker from './spritelab/locationPickerModule';
 import textConsole from './spritelab/textConsoleModule';
-import spritelabInput from './spritelab/spritelabInputModule';
+import spritelabInputList from './spritelab/spritelabInputModule';
 var errorDialogStack = require('./errorDialogStackModule').default;
 var P5LabInterfaceMode = require('./constants').P5LabInterfaceMode;
 
@@ -62,5 +62,5 @@ module.exports = {
   gridOverlay,
   locationPicker,
   textConsole,
-  spritelabInput
+  spritelabInputList
 };

--- a/apps/src/p5lab/reducers.js
+++ b/apps/src/p5lab/reducers.js
@@ -12,6 +12,7 @@ import animationPicker from './AnimationPicker/animationPickerModule';
 import animationTab from './AnimationTab/animationTabModule';
 import locationPicker from './spritelab/locationPickerModule';
 import textConsole from './spritelab/textConsoleModule';
+import spritelabInput from './spritelab/spritelabInputModule';
 var errorDialogStack = require('./errorDialogStackModule').default;
 var P5LabInterfaceMode = require('./constants').P5LabInterfaceMode;
 
@@ -60,5 +61,6 @@ module.exports = {
   animationJsonViewer,
   gridOverlay,
   locationPicker,
-  textConsole
+  textConsole,
+  spritelabInput
 };

--- a/apps/src/p5lab/spritelab/SpriteLab.js
+++ b/apps/src/p5lab/spritelab/SpriteLab.js
@@ -4,6 +4,7 @@ import * as coreLibrary from './coreLibrary';
 import Sounds from '@cdo/apps/Sounds';
 import {getStore} from '@cdo/apps/redux';
 import {clearConsole} from './textConsoleModule';
+import {clearQuestions} from './spritelabInputModule';
 
 var SpriteLab = function() {
   P5Lab.call(this);
@@ -46,5 +47,6 @@ SpriteLab.prototype.preview = function() {
 SpriteLab.prototype.reset = function() {
   P5Lab.prototype.reset.call(this);
   coreLibrary.reset();
+  getStore().dispatch(clearQuestions());
   this.preview();
 };

--- a/apps/src/p5lab/spritelab/SpritelabInput.jsx
+++ b/apps/src/p5lab/spritelab/SpritelabInput.jsx
@@ -1,0 +1,36 @@
+import PropTypes from 'prop-types';
+import React from 'react';
+import * as coreLibrary from './coreLibrary';
+
+export default class SpritelabInput extends React.Component {
+  static propTypes = {
+    question: PropTypes.string.isRequired
+  };
+
+  state = {
+    userInput: ''
+  };
+
+  userInputSubmit() {
+    console.log(this.state.userInput);
+    coreLibrary.onUserInputSubmit(this.state.userInput);
+  }
+
+  render() {
+    return (
+      <div id="spritelabInputArea">
+        <div>{`Question: ${this.props.question}`}</div>
+        <div>
+          Answer:
+          <input
+            type="text"
+            onChange={event => this.setState({userInput: event.target.value})}
+          />
+          <button type="button" onClick={() => this.userInputSubmit()}>
+            <i className="fa fa-check" />
+          </button>
+        </div>
+      </div>
+    );
+  }
+}

--- a/apps/src/p5lab/spritelab/SpritelabInput.jsx
+++ b/apps/src/p5lab/spritelab/SpritelabInput.jsx
@@ -1,10 +1,13 @@
 import PropTypes from 'prop-types';
+import {connect} from 'react-redux';
 import React from 'react';
+import {popQuestion} from './spritelabInputModule';
 import * as coreLibrary from './coreLibrary';
 
-export default class SpritelabInput extends React.Component {
+class SpritelabInput extends React.Component {
   static propTypes = {
-    question: PropTypes.string.isRequired
+    inputList: PropTypes.array.isRequired,
+    onQuestionAnswer: PropTypes.func.isRequired
   };
 
   state = {
@@ -12,19 +15,31 @@ export default class SpritelabInput extends React.Component {
   };
 
   userInputSubmit() {
-    console.log(this.state.userInput);
-    coreLibrary.onUserInputSubmit(this.state.userInput);
+    const variableName =
+      this.props.inputList[0] && this.props.inputList[0].variableName;
+    if (!variableName) {
+      return;
+    }
+    this.props.onQuestionAnswer();
+    coreLibrary.onQuestionAnswer(variableName, this.state.userInput);
+    this.setState({userInput: ''});
   }
 
   render() {
+    const questionText =
+      this.props.inputList[0] && this.props.inputList[0].questionText;
+    if (!questionText) {
+      return null;
+    }
     return (
       <div id="spritelabInputArea">
-        <div>{`Question: ${this.props.question}`}</div>
+        <div>{`Question: ${questionText}`}</div>
         <div>
           Answer:
           <input
             type="text"
             onChange={event => this.setState({userInput: event.target.value})}
+            value={this.state.userInput || ''}
           />
           <button type="button" onClick={() => this.userInputSubmit()}>
             <i className="fa fa-check" />
@@ -34,3 +49,12 @@ export default class SpritelabInput extends React.Component {
     );
   }
 }
+
+export default connect(
+  state => ({
+    inputList: state.spritelabInputList || []
+  }),
+  dispatch => ({
+    onQuestionAnswer: () => dispatch(popQuestion())
+  })
+)(SpritelabInput);

--- a/apps/src/p5lab/spritelab/blocks.js
+++ b/apps/src/p5lab/spritelab/blocks.js
@@ -349,6 +349,8 @@ const customInputTypes = {
       return `'${block.getTitleValue(arg.name)}'`;
     }
   },
+  // Custom input for a variable input that generates the name of the variable
+  // rather than the value of the variable.
   variableNamePicker: {
     addInputRow(blockly, block, inputConfig) {
       return block.appendValueInput(inputConfig.name);
@@ -359,7 +361,7 @@ const customInputTypes = {
       if (input) {
         const targetBlock = input.connection.targetBlock();
         if (targetBlock && targetBlock.type === 'variables_get') {
-          return `'${targetBlock.inputList[0].titleRow[0].value_}'`;
+          return `'${Blockly.JavaScript.blockToCode(targetBlock)[0]}'`;
         }
       }
       return '';

--- a/apps/src/p5lab/spritelab/blocks.js
+++ b/apps/src/p5lab/spritelab/blocks.js
@@ -348,6 +348,22 @@ const customInputTypes = {
     generateCode(block, arg) {
       return `'${block.getTitleValue(arg.name)}'`;
     }
+  },
+  variableNamePicker: {
+    addInputRow(blockly, block, inputConfig) {
+      return block.appendValueInput(inputConfig.name);
+    },
+
+    generateCode(block, arg) {
+      const input = block.getInput(arg.name);
+      if (input) {
+        const targetBlock = input.connection.targetBlock();
+        if (targetBlock && targetBlock.type === 'variables_get') {
+          return `'${targetBlock.inputList[0].titleRow[0].value_}'`;
+        }
+      }
+      return '';
+    }
   }
 };
 

--- a/apps/src/p5lab/spritelab/commands.js
+++ b/apps/src/p5lab/spritelab/commands.js
@@ -92,7 +92,7 @@ export const commands = {
   },
 
   setQuestion(questionText, variableName, callback) {
-    callback('IS THIS WORKING');
+    worldCommands.setQuestion(questionText, variableName, callback);
   },
 
   setTint(spriteArg, color) {
@@ -139,6 +139,10 @@ export const commands = {
 
   spriteClicked(condition, spriteArg, callback) {
     eventCommands.spriteClicked(condition, spriteArg, callback);
+  },
+
+  whenQuestionAnswered(variableName, callback) {
+    eventCommands.whenQuestionAnswered(variableName, callback);
   },
 
   // Location commands

--- a/apps/src/p5lab/spritelab/commands.js
+++ b/apps/src/p5lab/spritelab/commands.js
@@ -91,6 +91,10 @@ export const commands = {
     actionCommands.setProp.apply(this, [spriteArg, prop, val]);
   },
 
+  setQuestion(questionText, variableName, callback) {
+    callback('IS THIS WORKING');
+  },
+
   setTint(spriteArg, color) {
     actionCommands.setProp(spriteArg, 'tint', color);
   },

--- a/apps/src/p5lab/spritelab/commands/eventCommands.js
+++ b/apps/src/p5lab/spritelab/commands/eventCommands.js
@@ -25,5 +25,9 @@ export const commands = {
     if (condition === 'when' || condition === 'while') {
       coreLibrary.addEvent(condition + 'click', {sprite: spriteArg}, callback);
     }
+  },
+
+  whenQuestionAnswered(variableName, callback) {
+    coreLibrary.registerQuestionAnswerCallback(variableName, callback);
   }
 };

--- a/apps/src/p5lab/spritelab/commands/worldCommands.js
+++ b/apps/src/p5lab/spritelab/commands/worldCommands.js
@@ -1,6 +1,7 @@
 import * as coreLibrary from '../coreLibrary';
 import {getStore} from '@cdo/apps/redux';
 import {addConsoleMessage} from '../textConsoleModule';
+import {addQuestion} from '../spritelabInputModule';
 
 export const commands = {
   comment(text) {
@@ -33,6 +34,11 @@ export const commands = {
       let backgroundImage = this._preloadedBackgrounds[img];
       coreLibrary.background = backgroundImage;
     }
+  },
+
+  setQuestion(questionText, variableName, setterCallback) {
+    coreLibrary.registerQuestion(questionText, variableName, setterCallback);
+    getStore().dispatch(addQuestion(questionText, variableName));
   },
 
   showTitleScreen(title, subtitle) {

--- a/apps/src/p5lab/spritelab/coreLibrary.js
+++ b/apps/src/p5lab/spritelab/coreLibrary.js
@@ -2,6 +2,7 @@ var spriteId = 0;
 var nativeSpriteMap = {};
 var inputEvents = [];
 var behaviors = [];
+var userInputEventCallbacks = {};
 
 export var background;
 export var title = '';
@@ -14,6 +15,7 @@ export function reset() {
   behaviors = [];
   background = 'white';
   title = subtitle = '';
+  userInputEventCallbacks = {};
 }
 
 /**
@@ -147,6 +149,40 @@ function enforceUniqueSpriteName(name) {
  */
 export function deleteSprite(spriteId) {
   delete nativeSpriteMap[spriteId];
+}
+
+export function registerQuestion(questionText, variableName, setterCallback) {
+  if (!userInputEventCallbacks[variableName]) {
+    userInputEventCallbacks[variableName] = {
+      setterCallbacks: [],
+      userCallbacks: []
+    };
+  }
+  userInputEventCallbacks[variableName].setterCallbacks.push(setterCallback);
+}
+
+export function registerQuestionAnswerCallback(variableName, userCallback) {
+  if (!userInputEventCallbacks[variableName]) {
+    userInputEventCallbacks[variableName] = {
+      setterCallbacks: [],
+      userCallbacks: []
+    };
+  }
+  userInputEventCallbacks[variableName].userCallbacks.push(userCallback);
+}
+
+export function onQuestionAnswer(variableName, userInput) {
+  const callbacks = userInputEventCallbacks[variableName];
+  if (callbacks) {
+    // Make sure to call the setter callback to set the variable
+    // before the user callback, which may rely on the variable's new value
+    callbacks.setterCallbacks.forEach(callback => {
+      callback(userInput);
+    });
+    callbacks.userCallbacks.forEach(callback => {
+      callback();
+    });
+  }
 }
 
 export function addEvent(type, args, callback) {

--- a/apps/src/p5lab/spritelab/spritelabInputModule.js
+++ b/apps/src/p5lab/spritelab/spritelabInputModule.js
@@ -1,17 +1,39 @@
 const SET_QUESTION = 'spritelabInput/SET_QUESTION';
+const POP_QUESTION = 'spritelabInput/POP_QUESTION';
+const CLEAR_QUESTIONS = 'spritelabInput/CLEAR_QUESTIONS';
 
-export default function spritelabInput(state, action) {
+export default function spritelabInputList(state, action) {
+  state = state || [];
   switch (action.type) {
     case SET_QUESTION:
-      return action.question;
+      return [
+        ...state,
+        {
+          questionText: action.questionText,
+          variableName: action.variableName
+        }
+      ];
+    case POP_QUESTION:
+      return state.slice(1);
+    case CLEAR_QUESTIONS:
+      return [];
     default:
-      return '';
+      return state;
   }
 }
 
-export function setQuestion(question) {
+export function addQuestion(questionText, variableName) {
   return {
     type: SET_QUESTION,
-    question: question
+    questionText,
+    variableName
   };
+}
+
+export function popQuestion() {
+  return {type: POP_QUESTION};
+}
+
+export function clearQuestions() {
+  return {type: CLEAR_QUESTIONS};
 }

--- a/apps/src/p5lab/spritelab/spritelabInputModule.js
+++ b/apps/src/p5lab/spritelab/spritelabInputModule.js
@@ -1,0 +1,17 @@
+const SET_QUESTION = 'spritelabInput/SET_QUESTION';
+
+export default function spritelabInput(state, action) {
+  switch (action.type) {
+    case SET_QUESTION:
+      return action.question;
+    default:
+      return '';
+  }
+}
+
+export function setQuestion(question) {
+  return {
+    type: SET_QUESTION,
+    question: question
+  };
+}

--- a/apps/src/util/experiments.js
+++ b/apps/src/util/experiments.js
@@ -30,6 +30,7 @@ experiments.TEACHER_DASHBOARD_SECTION_BUTTONS_ALTERNATE_TEXT =
 experiments.TEXT_TO_SPEECH_BLOCK = 'text-to-speech-block';
 experiments.FINISH_DIALOG_METRICS = 'finish-dialog-metrics';
 experiments.I18N_TRACKING = 'i18n-tracking';
+experiments.SPRITELAB_INPUT = 'spritelabInput';
 
 /**
  * Get our query string. Provided as a method so that tests can mock this.

--- a/dashboard/config/blocks/GamelabJr/gamelab_setQuestion.json
+++ b/dashboard/config/blocks/GamelabJr/gamelab_setQuestion.json
@@ -1,0 +1,18 @@
+{
+  "category": "",
+  "config": {
+    "func": "setQuestion",
+    "inline": false,
+    "blockText": "ask question {QUESTION} for variable {VAR}",
+    "args": [
+      {
+        "name": "QUESTION",
+        "type": "String"
+      },
+      {
+        "name": "VAR",
+        "customInput": "variableNamePicker"
+      }
+    ]
+  }
+}

--- a/dashboard/config/blocks/GamelabJr/gamelab_whenQuestionAnswered.json
+++ b/dashboard/config/blocks/GamelabJr/gamelab_whenQuestionAnswered.json
@@ -1,0 +1,22 @@
+{
+  "category": "",
+  "config": {
+    "color": [
+      140,
+      1,
+      0.74
+    ],
+    "func": "whenQuestionAnswered",
+    "blockText": "when {VAR} is answered",
+    "args": [
+      {
+        "name": "VAR",
+        "customInput": "variableNamePicker"
+      }
+    ],
+    "callbackParams": [
+      "extraArgs"
+    ],
+    "eventBlock": true
+  }
+}


### PR DESCRIPTION
New blocks:

![image](https://user-images.githubusercontent.com/8787187/95790017-78b84480-0c93-11eb-8105-6a486b5922b5.png)
![image](https://user-images.githubusercontent.com/8787187/95790010-73f39080-0c93-11eb-8832-fa1bdc97c8aa.png)

Basic Usage:
![Oct-12-2020 14-04-58](https://user-images.githubusercontent.com/8787187/95790331-fe3bf480-0c93-11eb-9d27-275b397545fe.gif)

Caveats:
- For prototyping only at this point (hidden behind experiment flag `spritelabInput`)
- UI not yet finalized


<!-- ### Background -->
<!-- ### Privacy -->
<!--
1.	Does the Project involve the collection, use or sharing of new Personal Data?

2.	Does the Project involve a new or changed use or sharing of existing Personal Data?
-->
<!-- ### Security -->
<!--
Link to Jira Task where sensitive security issues are discussed privately.
-->
<!-- ### Caching -->
<!-- ### Deployment strategy -->
<!-- ### Future work -->

## Links

<!--
  Any relevant links to external resources; ie, specification documents, jira
  items, related PRs, honeybadger errors, etc
-->

- [spec](https://codedotorg.atlassian.net/browse/STAR-1302)
- [jira]()

## Testing story

<!--
  Does your change include appropriate tests?

  If so, please describe how the tests included in this PR are sufficient

  If not, please explain why this change does not need to be tested.
-->

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
