### PR TITLE
HoC 2020 Banner Update

### DIFF
--- a/pegasus/sites.v3/code.org/public/css/homepage.css
+++ b/pegasus/sites.v3/code.org/public/css/homepage.css
@@ -133,15 +133,11 @@ body.modal-open .supreme-container{
   line-height: 44px;
   color: #00ADBC;
   margin-top: 0px;
-  margin-bottom: 0px;
+  margin-bottom: 20px;
 }
 
-#homepage .hero-message-second {
-  font-family: 'Gotham 5r', sans-serif !important;
-  font-size: 44px;
-  line-height: 44px;
-  color: #00ADBC;
-  margin-bottom: 20px;
+#homepage .hero-message p {
+  margin-bottom: 0px;
 }
 
 #homepage .hero-sub-message {

--- a/pegasus/sites.v3/code.org/views/homepage_hero.haml
+++ b/pegasus/sites.v3/code.org/views/homepage_hero.haml
@@ -32,9 +32,7 @@
       = hoc_s(:codeorg_homepage_hoc2018_header_line1)
   - elsif show_single_hero == "hoc2020"
     .hero-message
-      = hoc_s(:hoc2020_header_line1)
-    .hero-message-second
-      = hoc_s(:hoc2020_header_line2)
+      = hoc_s(:hoc2020_header_with_line_break_markdown, markdown: true)
     .hero-sub-message
       = hoc_s(:codeorg_homepage_hoc2018_header_line1)
   .action_buttons

--- a/pegasus/sites.v3/hourofcode.com/i18n/en.yml
+++ b/pegasus/sites.v3/hourofcode.com/i18n/en.yml
@@ -34,8 +34,7 @@
   africa_campaign_date_full_year: "October 1-31, 2020"
 
   hoc2020_header: 'Learn today, build a brighter tomorrow.'
-  hoc2020_header_line1: 'Learn today,'
-  hoc2020_header_line2: 'build a brighter tomorrow.'
+  hoc2020_header_with_line_break_markdown: "Learn today,\n\nbuild a brighter tomorrow."
   social_hoc2020_cs_important: 'CS is more important than ever. Let''s build the future we want. #CSforGood'
   social_hoc2020_hoc_is_about_csforgood: 'The #HourOfCode is about #CSforGood. Learn today, build a brighter tomorrow.'
   social_hoc2020_global_movement: 'The Hour of Code is a global movement reaching tens of millions of students. One-hour tutorials are available in 45+ languages for all ages.'

--- a/pegasus/sites.v3/hourofcode.com/public/css/front-page.css
+++ b/pegasus/sites.v3/hourofcode.com/public/css/front-page.css
@@ -150,8 +150,9 @@ a.category-link {
     max-width: 45%;
   }
 
-  .front-header-banner h4 {
+  .front-header-banner .front-header-title p {
     font-size: 34px;
+    line-height: 34px;
   }
 
   .front-header-description {
@@ -178,8 +179,9 @@ a.category-link {
     max-width: 40%;
   }
 
-  .front-header-banner h4 {
+  .front-header-banner .front-header-title p {
     font-size: 44px;
+    line-height: 44px;
   }
 
   .front-header-description {
@@ -206,8 +208,9 @@ a.category-link {
     width: 22%;
   }
 
-  .front-header-banner h4 {
+  .front-header-banner .front-header-title p {
     font-size: 44px;
+    line-height: 44px;
   }
 
   .front-header-description {
@@ -251,6 +254,17 @@ a.category-link {
 .front-header-banner {
   color: white;
   margin-top: 0px;
+}
+
+.front-header-banner .front-header-title {
+  color: #00ADBC;
+  margin-top: 0px;
+  margin-bottom: 20px;
+}
+
+.front-header-banner .front-header-title p {
+  font-family: 'Gotham 5r', sans-serif !important;
+  margin-bottom: 0px;
 }
 
 .front-header-description {

--- a/pegasus/sites.v3/hourofcode.com/public/index.haml
+++ b/pegasus/sites.v3/hourofcode.com/public/index.haml
@@ -80,10 +80,8 @@ social:
         .col-12
           #textbacking
             .front-header-banner
-              %h4
-                = hoc_s(:hoc2020_header_line1)
-                %br/
-                = hoc_s(:hoc2020_header_line2)
+              .front-header-title
+                = hoc_s(:hoc2020_header_with_line_break_markdown, markdown: true)
               .front-header-description
                 = hoc_s(:hourofcode_homepage_hoc2018_header_line1)
             %br/


### PR DESCRIPTION
Follow up to [37173](https://github.com/code-dot-org/code-dot-org/pull/37173).

For our new hour of code banners we have a one-sentence slogan we want split into two lines. Instead of storing this as two separate strings for translation (which could cause issues in other languages), store as one string with a line break. The best way to do this and keep the same formatting as before was to use markdown to make the sentence two "paragraphs" and style the paragraphs appropriately.

The `code.org` homepage should look exactly the same with this change. The `hourofcode.com` homepage has a couple small tweaks. When doing this I noticed that `hourofcode.com` was using a different font color for the slogan than `code.org` and we actually want them to use the same color. The spacing is also a little different between lines--we were previously using an `h4` tag for this text which we can't nest paragraphs inside. Updated the spacing to match hourofcode.com, so the lines are a little closer together now.

Hour of Code banners:
Desktop
<img width="1774" alt="Screen Shot 2020-10-12 at 3 46 03 PM" src="https://user-images.githubusercontent.com/33666587/95797112-81b11200-0ca3-11eb-8a86-80d37a13180a.png">

Mobile
<img width="359" alt="Screen Shot 2020-10-12 at 3 46 28 PM" src="https://user-images.githubusercontent.com/33666587/95797109-7fe74e80-0ca3-11eb-811f-ad1052cee771.png"> 

Code.org banners:
Desktop
<img width="1778" alt="Screen Shot 2020-10-12 at 3 47 39 PM" src="https://user-images.githubusercontent.com/33666587/95797235-d5236000-0ca3-11eb-984a-7911e2757c64.png">

Mobile
<img width="359" alt="Screen Shot 2020-10-12 at 3 46 42 PM" src="https://user-images.githubusercontent.com/33666587/95797242-da80aa80-0ca3-11eb-985a-2ea511215837.png">

## Links

- [jira](https://codedotorg.atlassian.net/browse/PLC-1031)

## Testing story
Tested locally.

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
