### PR TITLE
Only show edit button if the lesson has an id

### DIFF
--- a/apps/src/lib/levelbuilder/script-editor/LessonToken.jsx
+++ b/apps/src/lib/levelbuilder/script-editor/LessonToken.jsx
@@ -142,18 +142,20 @@ export default class LessonToken extends Component {
                 )}
               </span>
             </span>
-            <div
-              style={styles.edit}
-              onClick={() => {
-                const win = window.open(
-                  `/lessons/${this.props.lesson.id}/edit`,
-                  '_blank'
-                );
-                win.focus();
-              }}
-            >
-              <i className="fa fa-pencil" />
-            </div>
+            {this.props.lesson.id && (
+              <div
+                style={styles.edit}
+                onClick={() => {
+                  const win = window.open(
+                    `/lessons/${this.props.lesson.id}/edit`,
+                    '_blank'
+                  );
+                  win.focus();
+                }}
+              >
+                <i className="fa fa-pencil" />
+              </div>
+            )}
             <div style={styles.remove} onMouseDown={this.handleRemove}>
               <i className="fa fa-times" />
             </div>

--- a/apps/test/unit/lib/levelbuilder/script-editor/LessonTokenTest.jsx
+++ b/apps/test/unit/lib/levelbuilder/script-editor/LessonTokenTest.jsx
@@ -17,9 +17,12 @@ describe('LessonToken', () => {
       handleDragStart,
       removeLesson,
       lesson: {
+        id: 10,
+        key: 'lesson-1',
         name: 'Lesson 1',
         levels: [],
         position: 1,
+        relative_position: 1,
         lockable: false,
         unplugged: false,
         assessment: false
@@ -33,5 +36,22 @@ describe('LessonToken', () => {
     expect(wrapper.find('Motion').length).to.equal(1);
     expect(wrapper.contains('Lesson 1')).to.be.true;
     expect(wrapper.find('i').length).to.equal(3);
+  });
+
+  it('renders newly added lesson without edit button', () => {
+    let wrapper = mount(
+      <LessonToken
+        {...defaultProps}
+        lesson={{
+          key: 'new-lesson',
+          name: 'New Lesson',
+          levels: [],
+          position: 1
+        }}
+      />
+    );
+    expect(wrapper.find('Motion').length).to.equal(1);
+    expect(wrapper.contains('New Lesson')).to.be.true;
+    expect(wrapper.find('i').length).to.equal(2);
   });
 });

--- a/apps/test/unit/lib/levelbuilder/script-editor/LessonTokenTest.jsx
+++ b/apps/test/unit/lib/levelbuilder/script-editor/LessonTokenTest.jsx
@@ -36,6 +36,7 @@ describe('LessonToken', () => {
     expect(wrapper.find('Motion').length).to.equal(1);
     expect(wrapper.contains('Lesson 1')).to.be.true;
     expect(wrapper.find('i').length).to.equal(3);
+    expect(wrapper.find('.fa-pencil').length).to.equal(1);
   });
 
   it('renders newly added lesson without edit button', () => {
@@ -53,5 +54,6 @@ describe('LessonToken', () => {
     expect(wrapper.find('Motion').length).to.equal(1);
     expect(wrapper.contains('New Lesson')).to.be.true;
     expect(wrapper.find('i').length).to.equal(2);
+    expect(wrapper.find('.fa-pencil').length).to.equal(0);
   });
 });


### PR DESCRIPTION
When you hit Add Lesson on the Script Edit page the Lesson has not actually be added in the database so it does not have an id which means we don't have a way to go to the Lesson edit page for that lesson yet. A curriculum writer would need to save the page and then they would have an id for the lesson which would allow them to go to the lesson edit page from the script edit page.  This PR just hides the edit button if there is no id for a lesson (aka it was added since the last save).

![Screen Shot 2020-10-13 at 4 13 17 PM](https://user-images.githubusercontent.com/208083/95911690-cdc98880-0d6f-11eb-8b52-5860ee290de9.png)

## Links

<!--
  Any relevant links to external resources; ie, specification documents, jira
  items, related PRs, honeybadger errors, etc
-->

- [jira](https://codedotorg.atlassian.net/browse/PLAT-384)

## Testing story

Added a test for rendering the LessonToken for a lesson without an id.

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
