### PR TITLE
Add a new IAM Policy to grant CurriculumBuilder access to DCDO

### DIFF
--- a/aws/cloudformation/iam.yml.erb
+++ b/aws/cloudformation/iam.yml.erb
@@ -125,6 +125,43 @@ Resources:
             Condition:
               StringEquals:
                 secretsmanager:VersionStage: AWSCURRENT
+  # Permissions which grant the CurriculumBuilder project read-only acces to
+  # the DCDO database, so select configuration variables can be shared between
+  # the two projects.
+  CurriculumBuilderDCDO:
+    Type: AWS::IAM::ManagedPolicy
+    Properties:
+      ManagedPolicyName: CurriculumBuilderDCDO
+      PolicyDocument:
+        Version: 2012-10-17
+        Statement:
+          - Effect: Allow
+            Action:
+              - dynamodb:BatchGetItem
+              - dynamodb:ConditionCheckItem
+              - dynamodb:DescribeContributorInsights
+              - dynamodb:Scan
+              - dynamodb:ListTagsOfResource
+              - dynamodb:Query
+              - dynamodb:DescribeStream
+              - dynamodb:DescribeTimeToLive
+              - dynamodb:DescribeGlobalTableSettings
+              - dynamodb:DescribeTable
+              - dynamodb:GetShardIterator
+              - dynamodb:DescribeGlobalTable
+              - dynamodb:GetItem
+              - dynamodb:DescribeContinuousBackups
+              - dynamodb:DescribeBackup
+              - dynamodb:GetRecords
+              - dynamodb:DescribeTableReplicaAutoScaling
+            Resource: !sub "arn:aws:dynamodb:${AWS::Region}:${AWS::AccountId}:table/dcdo_production"
+          - Effect: Allow
+            Action:
+              - dynamodb:DescribeReservedCapacityOfferings
+              - dynamodb:DescribeReservedCapacity
+              - dynamodb:DescribeLimits
+              - dynamodb:ListStreams
+            Resource: *
   Developer:
     Type: AWS::IAM::Role
     Properties:

--- a/aws/cloudformation/iam.yml.erb
+++ b/aws/cloudformation/iam.yml.erb
@@ -137,31 +137,8 @@ Resources:
         Statement:
           - Effect: Allow
             Action:
-              - dynamodb:BatchGetItem
-              - dynamodb:ConditionCheckItem
-              - dynamodb:DescribeContributorInsights
-              - dynamodb:Scan
-              - dynamodb:ListTagsOfResource
-              - dynamodb:Query
-              - dynamodb:DescribeStream
-              - dynamodb:DescribeTimeToLive
-              - dynamodb:DescribeGlobalTableSettings
-              - dynamodb:DescribeTable
-              - dynamodb:GetShardIterator
-              - dynamodb:DescribeGlobalTable
               - dynamodb:GetItem
-              - dynamodb:DescribeContinuousBackups
-              - dynamodb:DescribeBackup
-              - dynamodb:GetRecords
-              - dynamodb:DescribeTableReplicaAutoScaling
             Resource: !sub "arn:aws:dynamodb:${AWS::Region}:${AWS::AccountId}:table/dcdo_production"
-          - Effect: Allow
-            Action:
-              - dynamodb:DescribeReservedCapacityOfferings
-              - dynamodb:DescribeReservedCapacity
-              - dynamodb:DescribeLimits
-              - dynamodb:ListStreams
-            Resource: *
   Developer:
     Type: AWS::IAM::Role
     Properties:


### PR DESCRIPTION
So we can store shared config values there.

This configuration was generated by going through the web interface, and copying the JSON generated there

<!--
  Your description goes here: A summary of the change, including any relevant motivation and context.

  If relevant, include a description both of the existing behavior and of the new behavior.
-->

<!--
  Other aspects to consider. uncomment and add detail for any that seem necessary:
-->

<!-- ### Background -->
<!-- ### Privacy -->
<!--
1.	Does the Project involve the collection, use or sharing of new Personal Data?

2.	Does the Project involve a new or changed use or sharing of existing Personal Data?
-->
<!-- ### Security -->
<!--
Link to Jira Task where sensitive security issues are discussed privately.
-->
<!-- ### Caching -->
<!-- ### Deployment strategy -->
<!-- ### Future work -->

## Links

<!--
  Any relevant links to external resources; ie, specification documents, jira
  items, related PRs, honeybadger errors, etc
-->

- [spec]()
- [jira]()

## Testing story

<!--
  Does your change include appropriate tests?

  If so, please describe how the tests included in this PR are sufficient

  If not, please explain why this change does not need to be tested.
-->

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
