### PR TITLE
Teacher Lesson Plan: Course and Unit Navigation Header

### DIFF
--- a/apps/src/sites/studio/pages/lessons/show.js
+++ b/apps/src/sites/studio/pages/lessons/show.js
@@ -13,6 +13,8 @@ import {Provider} from 'react-redux';
 $(document).ready(function() {
   const lessonData = getScriptData('lesson');
 
+  console.log(lessonData);
+
   const store = getStore();
 
   if (lessonData.announcements) {
@@ -33,11 +35,8 @@ $(document).ready(function() {
   ReactDOM.render(
     <Provider store={store}>
       <LessonOverview
-        displayName={lessonData.title}
-        overview={lessonData.overview}
+        lesson={lessonData}
         activities={sampleActivities} //TODO: Get real activities data getting passed here
-        purpose={lessonData.purpose}
-        preparation={lessonData.preparation}
       />
     </Provider>,
     document.getElementById('show-container')

--- a/apps/src/sites/studio/pages/lessons/show.js
+++ b/apps/src/sites/studio/pages/lessons/show.js
@@ -13,8 +13,6 @@ import {Provider} from 'react-redux';
 $(document).ready(function() {
   const lessonData = getScriptData('lesson');
 
-  console.log(lessonData);
-
   const store = getStore();
 
   if (lessonData.announcements) {

--- a/apps/src/templates/lessonOverview/LessonOverview.jsx
+++ b/apps/src/templates/lessonOverview/LessonOverview.jsx
@@ -39,12 +39,12 @@ class LessonOverview extends Component {
       unit: PropTypes.shape({
         displayName: PropTypes.string.isRequired,
         link: PropTypes.string.isRequired
-      }),
+      }).isRequired,
       displayName: PropTypes.string.isRequired,
-      overview: PropTypes.string,
-      purpose: PropTypes.string,
-      preparation: PropTypes.string
-    }),
+      overview: PropTypes.string.isRequired,
+      purpose: PropTypes.string.isRequired,
+      preparation: PropTypes.string.isRequired
+    }).isRequired,
     activities: PropTypes.array,
 
     // from redux

--- a/apps/src/templates/lessonOverview/LessonOverview.jsx
+++ b/apps/src/templates/lessonOverview/LessonOverview.jsx
@@ -26,21 +26,14 @@ const styles = {
   },
   nav: {
     margin: '10px 0px',
-    fontSize: 18
-  },
-  navLink: {
-    color: color.purple,
-    margin: '0px 5px'
+    fontSize: 18,
+    color: color.purple
   }
 };
 
 class LessonOverview extends Component {
   static propTypes = {
     lesson: PropTypes.shape({
-      course: PropTypes.shape({
-        displayName: PropTypes.string.isRequired,
-        link: PropTypes.string.isRequired
-      }),
       unit: PropTypes.shape({
         displayName: PropTypes.string.isRequired,
         link: PropTypes.string.isRequired
@@ -62,16 +55,9 @@ class LessonOverview extends Component {
     const {lesson, announcements, isSignedIn, viewAs} = this.props;
     return (
       <div>
-        <div style={styles.nav}>
-          <span>{'<'}</span>
-          <a href={lesson.course.link} style={styles.navLink}>
-            {lesson.course.displayName}
-          </a>
-          <span style={{color: color.lighter_gray}}>{'/'}</span>
-          <a href={lesson.unit.link} style={styles.navLink}>
-            {lesson.unit.displayName}
-          </a>
-        </div>
+        <a href={lesson.unit.link} style={styles.nav}>
+          {`< ${lesson.unit.displayName}`}
+        </a>
         {isSignedIn && (
           <Announcements
             announcements={announcements}

--- a/apps/src/templates/lessonOverview/LessonOverview.jsx
+++ b/apps/src/templates/lessonOverview/LessonOverview.jsx
@@ -24,8 +24,10 @@ const styles = {
     padding: 10,
     borderLeft: 'solid 1px black'
   },
-  nav: {
-    margin: '10px 0px',
+  header: {
+    margin: '10px 0px'
+  },
+  navLink: {
     fontSize: 18,
     color: color.purple
   }
@@ -55,9 +57,11 @@ class LessonOverview extends Component {
     const {lesson, announcements, isSignedIn, viewAs} = this.props;
     return (
       <div>
-        <a href={lesson.unit.link} style={styles.nav}>
-          {`< ${lesson.unit.displayName}`}
-        </a>
+        <div style={styles.header}>
+          <a href={lesson.unit.link} style={styles.navLink}>
+            {`< ${lesson.unit.displayName}`}
+          </a>
+        </div>
         {isSignedIn && (
           <Announcements
             announcements={announcements}

--- a/apps/src/templates/lessonOverview/LessonOverview.jsx
+++ b/apps/src/templates/lessonOverview/LessonOverview.jsx
@@ -37,8 +37,14 @@ const styles = {
 class LessonOverview extends Component {
   static propTypes = {
     lesson: PropTypes.shape({
-      course: PropTypes.object.isRequired,
-      unit: PropTypes.object.isRequired,
+      course: PropTypes.shape({
+        displayName: PropTypes.string.isRequired,
+        link: PropTypes.string.isRequired
+      }),
+      unit: PropTypes.shape({
+        displayName: PropTypes.string.isRequired,
+        link: PropTypes.string.isRequired
+      }),
       displayName: PropTypes.string.isRequired,
       overview: PropTypes.string,
       purpose: PropTypes.string,

--- a/apps/src/templates/lessonOverview/LessonOverview.jsx
+++ b/apps/src/templates/lessonOverview/LessonOverview.jsx
@@ -9,6 +9,7 @@ import {SignInState} from '@cdo/apps/templates/currentUserRedux';
 import {ViewType} from '@cdo/apps/code-studio/viewAsRedux';
 import SafeMarkdown from '@cdo/apps/templates/SafeMarkdown';
 import styleConstants from '@cdo/apps/styleConstants';
+import color from '@cdo/apps/util/color';
 
 const styles = {
   frontPage: {
@@ -22,16 +23,28 @@ const styles = {
     flexGrow: 1,
     padding: 10,
     borderLeft: 'solid 1px black'
+  },
+  nav: {
+    margin: '10px 0px',
+    fontSize: 18
+  },
+  navLink: {
+    color: color.purple,
+    margin: '0px 5px'
   }
 };
 
 class LessonOverview extends Component {
   static propTypes = {
-    displayName: PropTypes.string.isRequired,
-    overview: PropTypes.string,
+    lesson: PropTypes.shape({
+      course: PropTypes.object.isRequired,
+      unit: PropTypes.object.isRequired,
+      displayName: PropTypes.string.isRequired,
+      overview: PropTypes.string,
+      purpose: PropTypes.string,
+      preparation: PropTypes.string
+    }),
     activities: PropTypes.array,
-    purpose: PropTypes.string,
-    preparation: PropTypes.string,
 
     // from redux
     announcements: PropTypes.arrayOf(announcementShape),
@@ -40,17 +53,19 @@ class LessonOverview extends Component {
   };
 
   render() {
-    const {
-      displayName,
-      overview,
-      announcements,
-      isSignedIn,
-      viewAs,
-      purpose,
-      preparation
-    } = this.props;
+    const {lesson, announcements, isSignedIn, viewAs} = this.props;
     return (
       <div>
+        <div style={styles.nav}>
+          <span>{'<'}</span>
+          <a href={lesson.course.link} style={styles.navLink}>
+            {lesson.course.displayName}
+          </a>
+          <span style={{color: color.lighter_gray}}>{'/'}</span>
+          <a href={lesson.unit.link} style={styles.navLink}>
+            {lesson.unit.displayName}
+          </a>
+        </div>
         {isSignedIn && (
           <Announcements
             announcements={announcements}
@@ -58,19 +73,19 @@ class LessonOverview extends Component {
             viewAs={viewAs}
           />
         )}
-        <h1>{displayName}</h1>
+        <h1>{lesson.displayName}</h1>
 
         <div style={styles.frontPage}>
           <div style={styles.left}>
             <h2>{i18n.overview()}</h2>
-            <SafeMarkdown markdown={overview} />
+            <SafeMarkdown markdown={lesson.overview} />
 
             <h2>{i18n.purpose()}</h2>
-            <SafeMarkdown markdown={purpose} />
+            <SafeMarkdown markdown={lesson.purpose} />
           </div>
           <div style={styles.right}>
             <h2>{i18n.preparation()}</h2>
-            <SafeMarkdown markdown={preparation} />
+            <SafeMarkdown markdown={lesson.preparation} />
           </div>
         </div>
 

--- a/apps/test/unit/templates/lessonOverview/LessonOverviewTest.js
+++ b/apps/test/unit/templates/lessonOverview/LessonOverviewTest.js
@@ -35,7 +35,7 @@ describe('LessonOverview', () => {
     const wrapper = shallow(<LessonOverview {...defaultProps} />);
     const navLinks = wrapper.find('a');
     expect(navLinks.props().href).to.contain('/s/unit-1');
-    expect(navLinks.contains('Unit 1')).to.be.true;
+    expect(navLinks.contains('< Unit 1')).to.be.true;
 
     expect(wrapper.contains('Lesson Name'), 'Lesson Name').to.be.true;
 

--- a/apps/test/unit/templates/lessonOverview/LessonOverviewTest.js
+++ b/apps/test/unit/templates/lessonOverview/LessonOverviewTest.js
@@ -14,19 +14,35 @@ describe('LessonOverview', () => {
   let defaultProps;
   beforeEach(() => {
     defaultProps = {
-      displayName: 'Lesson Name',
-      overview: 'Lesson Overview',
+      lesson: {
+        course: {
+          displayName: 'Course 1',
+          link: '/courses/course-1'
+        },
+        unit: {
+          displayName: 'Unit 1',
+          link: '/s/unit-1'
+        },
+        displayName: 'Lesson Name',
+        overview: 'Lesson Overview',
+        purpose: 'The purpose of the lesson is for people to learn',
+        preparation: '- One'
+      },
       activities: [],
       announcements: [],
       viewAs: ViewType.Teacher,
-      isSignedIn: true,
-      purpose: 'The purpose of the lesson is for people to learn',
-      preparation: '- One'
+      isSignedIn: true
     };
   });
 
   it('renders default props', () => {
     const wrapper = shallow(<LessonOverview {...defaultProps} />);
+    const navLinks = wrapper.find('a');
+    expect(navLinks.at(0).props().href).to.contain('/courses/course-1');
+    expect(navLinks.at(0).contains('Course 1')).to.be.true;
+    expect(navLinks.at(1).props().href).to.contain('/s/unit-1');
+    expect(navLinks.at(1).contains('Unit 1')).to.be.true;
+
     expect(wrapper.contains('Lesson Name'), 'Lesson Name').to.be.true;
 
     const safeMarkdowns = wrapper.find('SafeMarkdown');

--- a/apps/test/unit/templates/lessonOverview/LessonOverviewTest.js
+++ b/apps/test/unit/templates/lessonOverview/LessonOverviewTest.js
@@ -15,10 +15,6 @@ describe('LessonOverview', () => {
   beforeEach(() => {
     defaultProps = {
       lesson: {
-        course: {
-          displayName: 'Course 1',
-          link: '/courses/course-1'
-        },
         unit: {
           displayName: 'Unit 1',
           link: '/s/unit-1'
@@ -38,10 +34,8 @@ describe('LessonOverview', () => {
   it('renders default props', () => {
     const wrapper = shallow(<LessonOverview {...defaultProps} />);
     const navLinks = wrapper.find('a');
-    expect(navLinks.at(0).props().href).to.contain('/courses/course-1');
-    expect(navLinks.at(0).contains('Course 1')).to.be.true;
-    expect(navLinks.at(1).props().href).to.contain('/s/unit-1');
-    expect(navLinks.at(1).contains('Unit 1')).to.be.true;
+    expect(navLinks.props().href).to.contain('/s/unit-1');
+    expect(navLinks.contains('Unit 1')).to.be.true;
 
     expect(wrapper.contains('Lesson Name'), 'Lesson Name').to.be.true;
 

--- a/dashboard/app/controllers/lessons_controller.rb
+++ b/dashboard/app/controllers/lessons_controller.rb
@@ -11,10 +11,10 @@ class LessonsController < ApplicationController
         link: @lesson.script.link
       },
       displayName: @lesson.localized_title,
-      overview: @lesson.overview,
+      overview: @lesson.overview || '',
       announcements: @lesson.announcements,
-      purpose: @lesson.purpose,
-      preparation: @lesson.preparation
+      purpose: @lesson.purpose || '',
+      preparation: @lesson.preparation || ''
     }
   end
 

--- a/dashboard/app/controllers/lessons_controller.rb
+++ b/dashboard/app/controllers/lessons_controller.rb
@@ -6,7 +6,15 @@ class LessonsController < ApplicationController
   # GET /lessons/1
   def show
     @lesson_data = {
-      title: @lesson.localized_title,
+      course: {
+        displayName: @lesson.script.unit_group.localized_title,
+        link: @lesson.script.course_link
+      },
+      unit: {
+        displayName: @lesson.script.localized_title,
+        link: @lesson.script.link
+      },
+      displayName: @lesson.localized_title,
       overview: @lesson.overview,
       announcements: @lesson.announcements,
       purpose: @lesson.purpose,

--- a/dashboard/app/controllers/lessons_controller.rb
+++ b/dashboard/app/controllers/lessons_controller.rb
@@ -6,10 +6,6 @@ class LessonsController < ApplicationController
   # GET /lessons/1
   def show
     @lesson_data = {
-      course: {
-        displayName: @lesson.script.unit_group.localized_title,
-        link: @lesson.script.course_link
-      },
       unit: {
         displayName: @lesson.script.localized_title,
         link: @lesson.script.link

--- a/dashboard/test/controllers/lessons_controller_test.rb
+++ b/dashboard/test/controllers/lessons_controller_test.rb
@@ -27,14 +27,22 @@ class LessonsControllerTest < ActionController::TestCase
       }
     )
 
+    @unit_group_title = 'Unit Group Display Name'
     @script_title = 'Script Display Name'
     @lesson_name = 'Lesson Display Name'
 
     custom_i18n = {
       'data' => {
+        'course' => {
+          'name' => {
+            @unit_group.name => {
+              'title' => @unit_group_title,
+            }
+          }
+        },
         'script' => {
           'name' => {
-            @lesson.script.name => {
+            @script.name => {
               'title' => @script_title,
               'lessons' => {
                 @lesson.name => {
@@ -78,6 +86,7 @@ class LessonsControllerTest < ActionController::TestCase
     assert(@response.body.include?(@unit_group.link))
     assert(@response.body.include?(@script.link))
     assert(@response.body.include?(@script_title))
+    assert(@response.body.include?(@unit_group_title))
   end
 
   # only levelbuilders can edit

--- a/dashboard/test/controllers/lessons_controller_test.rb
+++ b/dashboard/test/controllers/lessons_controller_test.rb
@@ -6,8 +6,20 @@ class LessonsControllerTest < ActionController::TestCase
   setup do
     Rails.application.config.stubs(:levelbuilder_mode).returns true
 
+    @unit_group = create(
+      :unit_group,
+      name: 'course-1'
+    )
+    @script = create(
+      :script,
+      name: 'unit-1'
+    )
+
+    create :unit_group_unit, unit_group: @unit_group, script: @script, position: 1
+
     @lesson = create(
       :lesson,
+      script_id: @script.id,
       name: 'lesson display name',
       properties: {
         overview: 'lesson overview',
@@ -63,6 +75,9 @@ class LessonsControllerTest < ActionController::TestCase
     assert_response :ok
     assert(@response.body.include?(@script_title))
     assert(@response.body.include?(@lesson.overview))
+    assert(@response.body.include?(@unit_group.link))
+    assert(@response.body.include?(@script.link))
+    assert(@response.body.include?(@script_title))
   end
 
   # only levelbuilders can edit

--- a/dashboard/test/controllers/lessons_controller_test.rb
+++ b/dashboard/test/controllers/lessons_controller_test.rb
@@ -6,16 +6,10 @@ class LessonsControllerTest < ActionController::TestCase
   setup do
     Rails.application.config.stubs(:levelbuilder_mode).returns true
 
-    @unit_group = create(
-      :unit_group,
-      name: 'course-1'
-    )
     @script = create(
       :script,
       name: 'unit-1'
     )
-
-    create :unit_group_unit, unit_group: @unit_group, script: @script, position: 1
 
     @lesson = create(
       :lesson,
@@ -27,19 +21,11 @@ class LessonsControllerTest < ActionController::TestCase
       }
     )
 
-    @unit_group_title = 'Unit Group Display Name'
     @script_title = 'Script Display Name'
     @lesson_name = 'Lesson Display Name'
 
     custom_i18n = {
       'data' => {
-        'course' => {
-          'name' => {
-            @unit_group.name => {
-              'title' => @unit_group_title,
-            }
-          }
-        },
         'script' => {
           'name' => {
             @script.name => {
@@ -83,10 +69,8 @@ class LessonsControllerTest < ActionController::TestCase
     assert_response :ok
     assert(@response.body.include?(@script_title))
     assert(@response.body.include?(@lesson.overview))
-    assert(@response.body.include?(@unit_group.link))
     assert(@response.body.include?(@script.link))
     assert(@response.body.include?(@script_title))
-    assert(@response.body.include?(@unit_group_title))
   end
 
   # only levelbuilders can edit

--- a/dashboard/test/integration/lessons_test.rb
+++ b/dashboard/test/integration/lessons_test.rb
@@ -4,9 +4,15 @@ class LessonsTest < ActionDispatch::IntegrationTest
   setup do
     Rails.application.config.stubs(:levelbuilder_mode).returns true
 
+    @script = create(
+      :script,
+      name: 'unit-1'
+    )
+
     @lesson = create(
       :lesson,
       name: 'lesson display name',
+      script_id: @script.id,
       properties: {
         overview: 'lesson overview',
         student_overview: 'student overview'
@@ -42,6 +48,7 @@ class LessonsTest < ActionDispatch::IntegrationTest
     assert_select 'script[data-lesson]', 1
     lesson_data = JSON.parse(css_select('script[data-lesson]').first.attribute('data-lesson').to_s)
     assert_equal 'lesson overview', lesson_data['overview']
+    assert_equal '/s/unit-1', lesson_data['unit']['link']
   end
 
   test 'lesson edit page contains expected data' do


### PR DESCRIPTION
This creates half of the new navigation header on the Teacher Lesson Plan. It adds link to unit pages for the lesson.

![Screen Shot 2020-10-14 at 2 37 28 PM](https://user-images.githubusercontent.com/208083/96031036-d03ce880-0e2a-11eb-9d56-1206498fefce.png)


Follow Up:
- Create the lessons dropdown to navigate to lessons plans for other lessons in the unit.


## Links

<!--
  Any relevant links to external resources; ie, specification documents, jira
  items, related PRs, honeybadger errors, etc
-->

- [spec](https://docs.google.com/document/d/1SaZRs36uEkJIJUDe4nB1KoGAmhHvmgmSEcYtysGReUE/edit#)
- [jira](https://codedotorg.atlassian.net/browse/PLAT-322)

## Testing story

Updates LessonOverviewTest to check for the navigation header.
Updated the lessons show test in lessons_controller_tests.rb

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
