### PR TITLE
Teacher Apps 21-22: Allow RPs to delete applications

### DIFF
--- a/apps/src/code-studio/pd/application_dashboard/detail_view_contents.jsx
+++ b/apps/src/code-studio/pd/application_dashboard/detail_view_contents.jsx
@@ -622,14 +622,6 @@ export class DetailViewContents extends React.Component {
             >
               Delete Application
             </MenuItem>
-            <ConfirmationDialog
-              show={this.state.showDeleteApplicationConfirmation}
-              onOk={this.handleDeleteApplicationConfirmed}
-              onCancel={this.handleDeleteApplicationCancel}
-              headerText="Delete Application"
-              bodyText="Are you sure you want to delete this application? You will not be able to undo this."
-              okText="Delete"
-            />
             {this.props.applicationData.registered_fit_weekend && (
               <MenuItem
                 style={styles.delete}
@@ -652,7 +644,18 @@ export class DetailViewContents extends React.Component {
         </div>
       );
     } else {
-      return <Button onClick={this.handleEditClick}>Edit</Button>;
+      return [
+        <Button id="edit" key="edit" onClick={this.handleEditClick}>
+          Edit
+        </Button>,
+        <Button
+          id="delete"
+          key="delete"
+          onClick={this.handleDeleteApplicationClick}
+        >
+          Delete
+        </Button>
+      ];
     }
   };
 
@@ -703,6 +706,14 @@ export class DetailViewContents extends React.Component {
         {selectControl}
         <InputGroup.Button style={styles.editButton}>
           {this.renderEditButtons()}
+          <ConfirmationDialog
+            show={this.state.showDeleteApplicationConfirmation}
+            onOk={this.handleDeleteApplicationConfirmed}
+            onCancel={this.handleDeleteApplicationCancel}
+            headerText="Delete Application"
+            bodyText="Are you sure you want to delete this application? You will not be able to undo this."
+            okText="Delete"
+          />
         </InputGroup.Button>
       </InputGroup>
     );

--- a/apps/test/unit/code-studio/pd/application_dashboard/detail_view_contentsTest.js
+++ b/apps/test/unit/code-studio/pd/application_dashboard/detail_view_contentsTest.js
@@ -120,8 +120,8 @@ describe('DetailViewContents', () => {
 
       // click edit
       detailView
-        .find('#DetailViewHeader Button')
-        .last()
+        .find('button#edit')
+        .first()
         .simulate('click');
 
       // lock button is disabled for all statuses except "finalized"
@@ -147,8 +147,8 @@ describe('DetailViewContents', () => {
 
       // click edit
       detailView
-        .find('#DetailViewHeader Button')
-        .last()
+        .find('button#edit')
+        .first()
         .simulate('click');
 
       // change status to approved
@@ -291,7 +291,9 @@ describe('DetailViewContents', () => {
         const detailView = mountDetailView(applicationType);
 
         let expectedButtons =
-          applicationType === 'Facilitator' ? ['Lock', 'Edit'] : ['Edit'];
+          applicationType === 'Facilitator'
+            ? ['Lock', 'Edit', 'Delete']
+            : ['Edit', 'Delete'];
         expect(
           detailView.find('#DetailViewHeader Button').map(button => {
             return button.text();
@@ -308,8 +310,8 @@ describe('DetailViewContents', () => {
             ? ['Lock', 'Save', 'Cancel']
             : ['Save', 'Cancel'];
         detailView
-          .find('#DetailViewHeader Button')
-          .last()
+          .find('button#edit')
+          .first()
           .simulate('click');
         expect(
           detailView.find('#DetailViewHeader Button').map(button => {
@@ -335,6 +337,16 @@ describe('DetailViewContents', () => {
       });
     });
   }
+
+  describe('Regional Partner View', () => {
+    it('has delete button', () => {
+      const detailView = mountDetailView(applicationType, {
+        isWorkshopAdmin: false
+      });
+      const deleteButton = detailView.find('button#delete');
+      expect(deleteButton).to.have.length(2);
+    });
+  });
 
   describe('Scholarship Teacher? row', () => {
     it('on teacher applications', () => {

--- a/dashboard/app/models/ability.rb
+++ b/dashboard/app/models/ability.rb
@@ -143,13 +143,12 @@ class Ability
         if user.regional_partners.any?
           # regional partners by default have read, quick_view, and update
           # permissions
-          can [:read, :quick_view, :cohort_view, :update, :search], Pd::Application::ApplicationBase, regional_partner_id: user.regional_partners.pluck(:id)
+          can [:read, :quick_view, :cohort_view, :update, :search, :destroy], Pd::Application::ApplicationBase, regional_partner_id: user.regional_partners.pluck(:id)
 
           # G3 regional partners should have full management permission
           group_3_partner_ids = user.regional_partners.where(group: 3).pluck(:id)
           unless group_3_partner_ids.empty?
             can :manage, Pd::Application::ApplicationBase, regional_partner_id: group_3_partner_ids
-            cannot :delete, Pd::Application::ApplicationBase, regional_partner_id: group_3_partner_ids
           end
           can [:send_principal_approval, :principal_approval_not_required], TEACHER_APPLICATION_CLASS, regional_partner_id: user.regional_partners.pluck(:id)
         end


### PR DESCRIPTION
Enable regional partners to delete individual teacher applications from the application detail view page. The page previously just had an edit button for RPs, now there is also a delete button:
![Screen Shot 2020-10-14 at 9 08 48 AM](https://user-images.githubusercontent.com/33666587/96015986-0a8f9100-0dfd-11eb-9e9a-cd8cff69cdd2.png)

The admin view of this page is unchanged.

## Links

- [jira](https://codedotorg.atlassian.net/browse/PLC-1007)

## Testing story
Tested locally.

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
