### PR TITLE
Adding more location types for hourofcode.com event registration

### DIFF
--- a/apps/src/sites/hourofcode.com/pages/public/index.js
+++ b/apps/src/sites/hourofcode.com/pages/public/index.js
@@ -52,7 +52,8 @@ $(document).ready(function() {
   if (hocEventLocationElement) {
     const mapboxGeocoder = new MapboxGeocoder({
       accessToken: mapboxgl.accessToken,
-      types: 'address',
+      types:
+        'address,country,region,place,postcode,locality,district,neighborhood',
       placeholder: 'Event location address'
     });
     mapboxGeocoder.addTo('#hoc-event-location-selector');


### PR DESCRIPTION
We are getting customer reports that they can't select the location where they will be hosting their hourofcode event. The cause of this is because they want to put in inputs such as Cities or Provinces but the Mapbox location suggester only shows full addresses.

The fix is to expand the number of types available to be searched for: https://docs.mapbox.com/api/search/#data-types

## Links
- [slack](https://codedotorg.slack.com/archives/C0T0UQH0R/p1602691637069000)

## Testing story
* Manually tested

## Screenshots
![image](https://user-images.githubusercontent.com/1372238/96032993-fffde780-0e4e-11eb-8b40-8665283ad343.png)

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
