### PR TITLE
sectionProgressRedux refactor

### DIFF
--- a/apps/src/code-studio/components/progress/MiniView.jsx
+++ b/apps/src/code-studio/components/progress/MiniView.jsx
@@ -62,6 +62,7 @@ class MiniView extends React.Component {
             excludeCsfColumnInLegend={false}
             teacherResources={[]}
             minimal={minimal}
+            versions={[]}
           />
         </div>
       );

--- a/apps/src/code-studio/components/progress/TeacherPanelProgressBubble.jsx
+++ b/apps/src/code-studio/components/progress/TeacherPanelProgressBubble.jsx
@@ -70,7 +70,7 @@ export class TeacherPanelProgressBubble extends React.Component {
     const style = {
       ...styles.main,
       ...(level.isConceptLevel && styles.diamond),
-      ...levelProgressStyle(level, false)
+      ...levelProgressStyle(level.status, false)
     };
 
     // Outer div here is used to make sure our bubbles all take up equivalent

--- a/apps/src/code-studio/progressRedux.js
+++ b/apps/src/code-studio/progressRedux.js
@@ -573,7 +573,7 @@ const levelWithStatus = (
     }
   }
   return {
-    ...processedLevel(level),
+    ...processedLevel(level, isSublevel),
     status: statusForLevel(level, levelProgress),
     isCurrentLevel: isCurrentLevel(currentLevelId, level),
     paired: levelPairing[level.activeId],

--- a/apps/src/redux/sectionDataRedux.js
+++ b/apps/src/redux/sectionDataRedux.js
@@ -35,7 +35,7 @@ export const SET_SECTION = 'sectionData/SET_SECTION';
 export const setSection = section => {
   // Sort section.students by name.
   const sortedStudents = section.students.sort((a, b) =>
-    a.name.localeCompare(b.name)
+    a.name.localeCompare(b.name, undefined, {numeric: true})
   );
 
   // Filter data to match sectionDataPropType

--- a/apps/src/templates/progress/ProgressBubble.jsx
+++ b/apps/src/templates/progress/ProgressBubble.jsx
@@ -7,7 +7,7 @@ import i18n from '@cdo/locale';
 import color from '@cdo/apps/util/color';
 import FontAwesome from '../FontAwesome';
 import {getIconForLevel, isLevelAssessment} from './progressHelpers';
-import {levelType} from './progressTypes';
+import {levelType, levelStatusType} from './progressTypes';
 import {
   DOT_SIZE,
   DIAMOND_DOT_SIZE,
@@ -88,6 +88,7 @@ const styles = {
 class ProgressBubble extends React.Component {
   static propTypes = {
     level: levelType.isRequired,
+    levelStatus: levelStatusType,
     disabled: PropTypes.bool.isRequired,
     smallBubble: PropTypes.bool,
     //TODO: (ErinB) probably change to use just number during post launch clean-up.
@@ -132,6 +133,7 @@ class ProgressBubble extends React.Component {
   render() {
     const {
       level,
+      levelStatus,
       smallBubble,
       selectedSectionId,
       selectedStudentId,
@@ -147,10 +149,12 @@ class ProgressBubble extends React.Component {
     const url = level.url;
     const levelName = level.name || level.progressionDisplayName;
     const levelIcon = getIconForLevel(level);
+    const paired = levelStatus && levelStatus.paired;
+    const status = levelStatus && levelStatus.status;
 
     const disabled = this.props.disabled || levelIcon === 'lock';
     const hideNumber =
-      level.letter || levelIcon === 'lock' || level.paired || level.bonus;
+      level.letter || levelIcon === 'lock' || paired || level.bonus;
 
     const style = {
       ...styles.main,
@@ -158,7 +162,7 @@ class ProgressBubble extends React.Component {
       ...(smallBubble && styles.small),
       ...(level.isConceptLevel &&
         (smallBubble ? styles.smallDiamond : styles.largeDiamond)),
-      ...levelProgressStyle(level, disabled),
+      ...levelProgressStyle(status, disabled),
       ...(disabled && level.bonus && styles.disabledStageExtras)
     };
 
@@ -203,7 +207,9 @@ class ProgressBubble extends React.Component {
     if (level.isUnplugged && !smallBubble) {
       return (
         <ProgressPill
-          levels={[level]}
+          level={level}
+          levelStatus={status}
+          multilevel={false}
           text={i18n.unpluggedActivity()}
           tooltip={this.props.hideToolTips ? null : tooltip}
           progressStyle={true}
@@ -229,7 +235,7 @@ class ProgressBubble extends React.Component {
           <div style={style} className="uitest-bubble">
             <div
               style={{
-                fontSize: level.paired || level.bonus ? 14 : 16,
+                fontSize: paired || level.bonus ? 14 : 16,
                 ...styles.contents,
                 ...(level.isConceptLevel && styles.diamondContents)
               }}
@@ -238,9 +244,7 @@ class ProgressBubble extends React.Component {
                 <span id="test-bubble-letter"> {level.letter} </span>
               )}
               {levelIcon === 'lock' && <FontAwesome icon="lock" />}
-              {pairingIconEnabled && level.paired && (
-                <FontAwesome icon="users" />
-              )}
+              {pairingIconEnabled && paired && <FontAwesome icon="users" />}
               {level.bonus && <FontAwesome icon="flag-checkered" />}
               {!hideNumber && (
                 <span>

--- a/apps/src/templates/progress/ProgressBubbleSet.jsx
+++ b/apps/src/templates/progress/ProgressBubbleSet.jsx
@@ -6,7 +6,7 @@ import PropTypes from 'prop-types';
 import Radium from 'radium';
 import ProgressBubble from './ProgressBubble';
 import color from '@cdo/apps/util/color';
-import {levelType} from './progressTypes';
+import {levelType, levelStatusType} from './progressTypes';
 import {DOT_SIZE, DIAMOND_DOT_SIZE} from './progressStyles';
 
 const styles = {
@@ -60,6 +60,7 @@ const styles = {
 class ProgressBubbleSet extends React.Component {
   static propTypes = {
     levels: PropTypes.arrayOf(levelType).isRequired,
+    levelStatuses: PropTypes.objectOf(levelStatusType),
     disabled: PropTypes.bool.isRequired,
     style: PropTypes.object,
     //TODO: (ErinB) probably change to use just number during post launch clean-up.
@@ -92,11 +93,12 @@ class ProgressBubbleSet extends React.Component {
   renderBubble = (level, index, isSublevel) => {
     const {
       levels,
+      levelStatuses,
       selectedSectionId,
       selectedStudentId,
       hideAssessmentIcon
     } = this.props;
-
+    const levelStatus = levelStatuses && levelStatuses[level.id];
     return (
       <div style={styles.withBackground} key={index}>
         <div
@@ -120,6 +122,7 @@ class ProgressBubbleSet extends React.Component {
         >
           <ProgressBubble
             level={level}
+            levelStatus={levelStatus}
             disabled={this.bubbleDisabled(level)}
             smallBubble={isSublevel}
             selectedSectionId={selectedSectionId}

--- a/apps/src/templates/progress/ProgressLegend.jsx
+++ b/apps/src/templates/progress/ProgressLegend.jsx
@@ -157,10 +157,10 @@ export default class ProgressLegend extends Component {
               <div style={styles.center}>
                 <ProgressBubble
                   level={{
-                    status: LevelStatus.not_tried,
                     isConceptLevel: true,
                     name: `${i18n.concept()}: ${i18n.notStarted()}`
                   }}
+                  levelStatus={{status: LevelStatus.not_tried}}
                   disabled={false}
                 />
               </div>
@@ -169,10 +169,10 @@ export default class ProgressLegend extends Component {
               <div style={styles.center}>
                 <ProgressBubble
                   level={{
-                    status: LevelStatus.attempted,
                     isConceptLevel: true,
                     name: `${i18n.concept()}: ${i18n.inProgress()}`
                   }}
+                  levelStatus={{status: LevelStatus.attempted}}
                   disabled={false}
                 />
               </div>
@@ -182,10 +182,11 @@ export default class ProgressLegend extends Component {
               <div style={styles.center}>
                 <ProgressBubble
                   level={{
-                    status: LevelStatus.perfect,
+                    levelStatus: {status: LevelStatus.perfect},
                     isConceptLevel: true,
                     name: `${i18n.concept()}: ${i18n.completed()} (${i18n.perfect()})`
                   }}
+                  levelStatus={{status: LevelStatus.perfect}}
                   disabled={false}
                 />
               </div>
@@ -230,10 +231,10 @@ export default class ProgressLegend extends Component {
               <div style={styles.center}>
                 <ProgressBubble
                   level={{
-                    status: LevelStatus.not_tried,
                     isConceptLevel: false,
                     name: `${i18n.activity()}: ${i18n.notStarted()}`
                   }}
+                  levelStatus={{status: LevelStatus.not_tried}}
                   disabled={false}
                 />
               </div>
@@ -242,10 +243,10 @@ export default class ProgressLegend extends Component {
               <div style={styles.center}>
                 <ProgressBubble
                   level={{
-                    status: LevelStatus.attempted,
                     isConceptLevel: false,
                     name: `${i18n.activity()}: ${i18n.inProgress()}`
                   }}
+                  levelStatus={{status: LevelStatus.attempted}}
                   disabled={false}
                 />
               </div>
@@ -255,10 +256,10 @@ export default class ProgressLegend extends Component {
                 <div style={styles.center}>
                   <ProgressBubble
                     level={{
-                      status: LevelStatus.passed,
                       isConceptLevel: false,
                       name: `${i18n.activity()}: ${i18n.completed()} (${i18n.tooManyBlocks()})`
                     }}
+                    levelStatus={{status: LevelStatus.passed}}
                     disabled={false}
                   />
                 </div>
@@ -268,10 +269,10 @@ export default class ProgressLegend extends Component {
               <div style={styles.center}>
                 <ProgressBubble
                   level={{
-                    status: LevelStatus.perfect,
                     isConceptLevel: false,
                     name: `${i18n.activity()}: ${i18n.completed()} (${i18n.perfect()})`
                   }}
+                  levelStatus={{status: LevelStatus.perfect}}
                   disabled={false}
                 />
               </div>
@@ -280,10 +281,10 @@ export default class ProgressLegend extends Component {
               <div style={styles.center}>
                 <ProgressBubble
                   level={{
-                    status: LevelStatus.submitted,
                     isConceptLevel: false,
                     name: `${i18n.activity()}: ${i18n.submitted()}`
                   }}
+                  levelStatus={{status: LevelStatus.submitted}}
                   disabled={false}
                 />
               </div>

--- a/apps/src/templates/progress/ProgressLevelSet.jsx
+++ b/apps/src/templates/progress/ProgressLevelSet.jsx
@@ -90,7 +90,8 @@ class ProgressLevelSet extends React.Component {
           <tr>
             <td style={styles.col1}>
               <ProgressPill
-                levels={levels}
+                level={levels[0]}
+                multilevel={multiLevelStep}
                 icon={getIconForLevel(levels[0])}
                 text={pillText}
                 disabled={disabled}

--- a/apps/src/templates/progress/ProgressPill.jsx
+++ b/apps/src/templates/progress/ProgressPill.jsx
@@ -58,7 +58,9 @@ const styles = {
  */
 class ProgressPill extends React.Component {
   static propTypes = {
-    levels: PropTypes.arrayOf(levelType),
+    level: levelType,
+    levelStatus: PropTypes.string,
+    multilevel: PropTypes.bool,
     icon: PropTypes.string,
     text: PropTypes.string,
     tooltip: PropTypes.element,
@@ -69,7 +71,9 @@ class ProgressPill extends React.Component {
 
   render() {
     const {
-      levels,
+      level,
+      levelStatus,
+      multilevel,
       icon,
       text,
       tooltip,
@@ -78,8 +82,7 @@ class ProgressPill extends React.Component {
       progressStyle
     } = this.props;
 
-    const multiLevelStep = levels.length > 1;
-    let url = multiLevelStep || disabled ? undefined : levels[0].url;
+    let url = multilevel || disabled ? undefined : level.url;
     if (url && selectedSectionId) {
       url += stringifyQueryParams({section_id: selectedSectionId});
     }
@@ -87,7 +90,7 @@ class ProgressPill extends React.Component {
     let style = {
       ...styles.levelPill,
       ...(url && hoverStyle),
-      ...(!multiLevelStep && levelProgressStyle(levels[0], false))
+      ...(!multilevel && levelProgressStyle(levelStatus, false))
     };
 
     // If we're passed a tooltip, we also need to reference it from our div
@@ -100,8 +103,7 @@ class ProgressPill extends React.Component {
     }
 
     // Only put the assessment icon on if its a single assessment level (not set)
-    const levelIsAssessment =
-      isLevelAssessment(levels[0]) && levels.length === 1;
+    const showAssessmentIcon = !multilevel && isLevelAssessment(level);
 
     const textStyle = progressStyle ? styles.textProgressStyle : styles.text;
 
@@ -125,7 +127,7 @@ class ProgressPill extends React.Component {
             </div>
           )}
           {tooltip}
-          {levelIsAssessment && <SmallAssessmentIcon />}
+          {showAssessmentIcon && <SmallAssessmentIcon />}
         </div>
       </a>
     );

--- a/apps/src/templates/progress/ProgressPill.story.jsx
+++ b/apps/src/templates/progress/ProgressPill.story.jsx
@@ -8,12 +8,10 @@ export default storybook => {
       name: 'single level pill',
       story: () => (
         <ProgressPill
-          levels={[
-            {
-              url: '/level1',
-              status: LevelStatus.perfect
-            }
-          ]}
+          level={{
+            url: '/level1'
+          }}
+          levelStatus={LevelStatus.perfect}
           icon="desktop"
           text="1"
         />
@@ -23,16 +21,11 @@ export default storybook => {
       name: 'multi level pill',
       story: () => (
         <ProgressPill
-          levels={[
-            {
-              url: '/level1',
-              status: LevelStatus.perfect
-            },
-            {
-              url: '/level2',
-              status: LevelStatus.not_tried
-            }
-          ]}
+          level={{
+            url: '/level1'
+          }}
+          levelStatus={LevelStatus.perfect}
+          multilevel={true}
           icon="desktop"
           text="1-4"
         />
@@ -42,12 +35,10 @@ export default storybook => {
       name: 'unplugged pill',
       story: () => (
         <ProgressPill
-          levels={[
-            {
-              url: '/level1',
-              status: LevelStatus.perfect
-            }
-          ]}
+          level={{
+            url: '/level1'
+          }}
+          levelStatus={LevelStatus.perfect}
           text="Unplugged Activity"
         />
       )

--- a/apps/src/templates/progress/progressStyles.js
+++ b/apps/src/templates/progress/progressStyles.js
@@ -65,28 +65,25 @@ const statusStyle = {
  * Given a level object, figure out styling related to its color, border color,
  * and background color
  */
-export const levelProgressStyle = (level, disabled) => {
+export const levelProgressStyle = (levelStatus, disabled) => {
   let style = {
     borderWidth: 2,
     color: color.charcoal,
     backgroundColor: color.level_not_tried
   };
 
-  if (disabled) {
-    style = {
-      ...style,
-      ...(!disabled && hoverStyle)
-    };
-  } else {
-    if (level.status !== LevelStatus.not_tried) {
-      style.borderColor = color.level_perfect;
-    }
-
-    style = {
-      ...style,
-      ...statusStyle[level.status]
-    };
+  if (disabled || !levelStatus) {
+    return style;
   }
+
+  if (levelStatus !== LevelStatus.not_tried) {
+    style.borderColor = color.level_perfect;
+  }
+
+  style = {
+    ...style,
+    ...statusStyle[levelStatus]
+  };
 
   return style;
 };

--- a/apps/src/templates/progress/progressTestHelpers.js
+++ b/apps/src/templates/progress/progressTestHelpers.js
@@ -26,7 +26,6 @@ export const fakeLesson = (
 export const fakeLevel = overrides => {
   const levelNumber = overrides.levelNumber;
   return {
-    status: LevelStatus.not_tried,
     url: `/level${levelNumber}`,
     name: `Level ${levelNumber}`,
     ...overrides
@@ -36,6 +35,7 @@ export const fakeLevel = overrides => {
 export const fakeLevels = (numLevels, {startLevel = 1, named = true} = {}) =>
   _.range(numLevels).map(index => {
     let overrideData = {
+      id: index,
       levelNumber: index + startLevel
     };
     if (!named) {
@@ -43,6 +43,17 @@ export const fakeLevels = (numLevels, {startLevel = 1, named = true} = {}) =>
     }
     return fakeLevel(overrideData);
   });
+
+export const fakeStatusesForLevels = (
+  levels,
+  status = LevelStatus.not_tried
+) => {
+  const statuses = {};
+  levels.forEach(level => {
+    statuses[level.id] = {status: status};
+  });
+  return statuses;
+};
 
 /**
  * Creates the shell of a redux store with the provided lessonId being hidden

--- a/apps/src/templates/progress/progressTypes.js
+++ b/apps/src/templates/progress/progressTypes.js
@@ -1,7 +1,6 @@
 import PropTypes from 'prop-types';
 
 export const levelType = PropTypes.shape({
-  status: PropTypes.string.isRequired,
   url: PropTypes.string,
   name: PropTypes.string,
   icon: PropTypes.string,
@@ -10,6 +9,13 @@ export const levelType = PropTypes.shape({
   isCurrentLevel: PropTypes.bool,
   isConceptLevel: PropTypes.bool,
   sublevels: PropTypes.arrayOf(PropTypes.object)
+});
+
+export const levelStatusType = PropTypes.shape({
+  status: PropTypes.string,
+  result: PropTypes.number,
+  paired: PropTypes.bool,
+  time_spent: PropTypes.number
 });
 
 /**

--- a/apps/src/templates/sectionProgress/SectionProgress.jsx
+++ b/apps/src/templates/sectionProgress/SectionProgress.jsx
@@ -12,7 +12,6 @@ import {connect} from 'react-redux';
 import i18n from '@cdo/locale';
 import {h3Style} from '../../lib/ui/Headings';
 import {
-  getCurrentProgress,
   getCurrentScriptData,
   setLessonOfInterest,
   setCurrentView
@@ -282,11 +281,10 @@ export default connect(
     validScripts: state.scriptSelection.validScripts,
     currentView: state.sectionProgress.currentView,
     scriptData: getCurrentScriptData(state),
-    studentLevelProgress: getCurrentProgress(state),
     isLoadingProgress: state.sectionProgress.isLoadingProgress,
     showStandardsIntroDialog: !state.currentUser.hasSeenStandardsReportInfo,
     studentTimestamps:
-      state.sectionProgress.studentTimestampsByScript[
+      state.sectionProgress.studentLastUpdateByScript[
         state.scriptSelection.scriptId
       ],
     localeCode: state.locales.localeCode

--- a/apps/src/templates/sectionProgress/detail/StudentProgressDetailCell.jsx
+++ b/apps/src/templates/sectionProgress/detail/StudentProgressDetailCell.jsx
@@ -1,6 +1,10 @@
 import PropTypes from 'prop-types';
 import React, {Component} from 'react';
 import ProgressBubbleSet from '@cdo/apps/templates/progress/ProgressBubbleSet';
+import {
+  levelType,
+  levelStatusType
+} from '@cdo/apps/templates/progress/progressTypes';
 
 const styles = {
   bubbles: {
@@ -16,7 +20,8 @@ export default class StudentProgressDetailCell extends Component {
     studentId: PropTypes.number.isRequired,
     stageId: PropTypes.number.isRequired,
     sectionId: PropTypes.number.isRequired,
-    levelsWithStatus: PropTypes.arrayOf(PropTypes.object),
+    levels: PropTypes.arrayOf(levelType).isRequired,
+    levelStatuses: PropTypes.objectOf(levelStatusType),
     stageExtrasEnabled: PropTypes.bool
   };
 
@@ -25,7 +30,8 @@ export default class StudentProgressDetailCell extends Component {
       <div style={styles.cell} className="uitest-detail-cell">
         <div style={styles.bubbles}>
           <ProgressBubbleSet
-            levels={this.props.levelsWithStatus}
+            levels={this.props.levels}
+            levelStatuses={this.props.levelStatuses}
             disabled={false}
             hideToolTips={true}
             selectedSectionId={this.props.sectionId}

--- a/apps/src/templates/sectionProgress/detail/VirtualizedDetailView.jsx
+++ b/apps/src/templates/sectionProgress/detail/VirtualizedDetailView.jsx
@@ -104,7 +104,8 @@ class VirtualizedDetailView extends Component {
   componentDidUpdate(prevProps) {
     if (
       !_.isEqual(
-        this.props.levelStatusByStudent !== prevProps.levelStatusByStudent
+        this.props.levelStatusByStudent,
+        prevProps.levelStatusByStudent
       )
     ) {
       this.detailView.forceUpdateGrids();

--- a/apps/src/templates/sectionProgress/sectionProgressConstants.js
+++ b/apps/src/templates/sectionProgress/sectionProgressConstants.js
@@ -18,7 +18,8 @@ export const scriptDataPropType = PropTypes.shape({
     })
   ),
   family_name: PropTypes.string,
-  version_year: PropTypes.string
+  version_year: PropTypes.string,
+  name: PropTypes.string
 });
 
 // Types of views of the progress tab

--- a/apps/src/templates/sectionProgress/sectionProgressRedux.js
+++ b/apps/src/templates/sectionProgress/sectionProgressRedux.js
@@ -44,11 +44,8 @@ const initialState = {
   section: {},
   currentView: ViewType.SUMMARY,
   scriptDataByScript: {},
-  studentLevelProgressByScript: {},
-  studentLevelPairingByScript: {},
-  studentTimestampsByScript: {},
-  studentLevelTimeSpentByScript: {},
-  levelsByLessonByScript: {},
+  studentLevelStatusByScript: {},
+  studentLastUpdateByScript: {},
   lessonOfInterest: INITIAL_LESSON_OF_INTEREST,
   isLoadingProgress: false,
   isRefreshingProgress: false
@@ -112,25 +109,13 @@ export default function sectionProgress(state = initialState, action) {
         ...state.scriptDataByScript,
         ...action.data.scriptDataByScript
       },
-      levelsByLessonByScript: {
-        ...state.levelsByLessonByScript,
-        ...action.data.levelsByLessonByScript
+      studentLevelStatusByScript: {
+        ...state.studentLevelStatusByScript,
+        ...action.data.studentLevelStatusByScript
       },
-      studentLevelProgressByScript: {
-        ...state.studentLevelProgressByScript,
-        ...action.data.studentLevelProgressByScript
-      },
-      studentLevelPairingByScript: {
-        ...state.studentLevelPairingByScript,
-        ...action.data.studentLevelPairingByScript
-      },
-      studentTimestampsByScript: {
-        ...state.studentTimestampsByScript,
-        ...action.data.studentTimestampsByScript
-      },
-      studentLevelTimeSpentByScript: {
-        ...state.studentLevelTimeSpentByScript,
-        ...action.data.studentLevelTimeSpentByScript
+      studentLastUpdateByScript: {
+        ...state.studentLastUpdateByScript,
+        ...action.data.studentLastUpdateByScript
       }
     };
   }
@@ -163,17 +148,6 @@ export const jumpToLessonDetails = lessonOfInterest => {
 // Selector functions
 
 /**
- * Retrieves the progress for the section in the selected script
- * @returns {number} keys are student ids, values are
- * objects of {levelIds: LevelStatus}
- */
-export const getCurrentProgress = state => {
-  return state.sectionProgress.studentLevelProgressByScript[
-    state.scriptSelection.scriptId
-  ];
-};
-
-/**
  * Retrieves the script data for the section in the selected script
  * @returns {scriptDataPropType} object containing metadata about the script structure
  */
@@ -181,23 +155,6 @@ export const getCurrentScriptData = state => {
   return state.sectionProgress.scriptDataByScript[
     state.scriptSelection.scriptId
   ];
-};
-
-/**
- * Retrieves the combined script and progress data for the current scriptId for the entire section.
- */
-export const getLevelsByLesson = state => {
-  return state.sectionProgress.levelsByLessonByScript[
-    state.scriptSelection.scriptId
-  ];
-};
-
-/**
- * Retrieves the combined script and progress data for student for the stage.
- * This represents the data for a single cell.
- */
-export const getLevels = (state, studentId, stageId) => {
-  return getLevelsByLesson(state)[studentId][stageId];
 };
 
 /**

--- a/apps/src/templates/sectionProgress/standards/sectionStandardsProgressRedux.js
+++ b/apps/src/templates/sectionProgress/standards/sectionStandardsProgressRedux.js
@@ -294,8 +294,8 @@ export function getPluggedLessonCompletionStatus(state, lesson) {
   if (
     state.scriptSelection.scriptId &&
     state.sectionProgress.scriptDataByScript &&
-    state.sectionProgress.studentLevelProgressByScript &&
-    state.sectionProgress.studentLevelProgressByScript[
+    state.sectionProgress.studentLevelStatusByScript &&
+    state.sectionProgress.studentLevelStatusByScript[
       state.scriptSelection.scriptId
     ] &&
     state.teacherSections.sections &&
@@ -305,20 +305,18 @@ export function getPluggedLessonCompletionStatus(state, lesson) {
     const numberStudentsInSection =
       state.teacherSections.sections[state.teacherSections.selectedSectionId]
         .studentCount;
-    const levelResultsByStudent =
-      state.sectionProgress.studentLevelProgressByScript[scriptId];
+    const levelStatusesByStudent =
+      state.sectionProgress.studentLevelStatusByScript[scriptId];
 
-    const studentIds = Object.keys(levelResultsByStudent);
-    const levelIds = _.map(lesson.levels, 'activeId');
+    const studentIds = Object.keys(levelStatusesByStudent);
+    const levelIds = _.map(lesson.levels, 'id');
     let numStudentsCompletedLesson = 0;
     let numStudentsInProgressLesson = 0;
     studentIds.forEach(studentId => {
       let numLevelsInLessonCompletedByStudent = 0;
       levelIds.forEach(levelId => {
-        if (
-          levelResultsByStudent[studentId][levelId] >=
-          TestResults.MINIMUM_PASS_RESULT
-        ) {
+        const status = levelStatusesByStudent[studentId][levelId];
+        if (status && status.result >= TestResults.MINIMUM_PASS_RESULT) {
           numLevelsInLessonCompletedByStudent++;
         }
       });

--- a/apps/src/templates/sectionProgress/standards/standardsTestHelpers.js
+++ b/apps/src/templates/sectionProgress/standards/standardsTestHelpers.js
@@ -154,7 +154,7 @@ const scriptDataByScript = {
         title: 'Lesson 2: Learn to Drag and Drop',
         lesson_group_display_name: 'Sequencing',
         lockable: false,
-        levels: [{activeId: 10001}, {activeId: 10002}, {activeId: 10003}],
+        levels: [{id: 10001}, {id: 10002}, {id: 10003}],
         description_student: 'Click and drag to finish the puzzles.',
         description_teacher:
           'This lesson will give students an idea of what to expect when they head to the computer lab. It begins with a brief discussion introducing them to computer lab manners, then they will progress into using a computer to complete online puzzles.',
@@ -197,22 +197,22 @@ export const pluggedLesson = scriptDataByScript[scriptId].stages[1];
 const sectionCompletedLesson = {
   92: {
     100001: {
-      10001: 20,
-      10002: 20,
-      10003: 20
+      10001: {result: 20},
+      10002: {result: 20},
+      10003: {result: 20}
     },
     100002: {
-      10001: 20,
-      10002: 20,
-      10003: 20
+      10001: {result: 20},
+      10002: {result: 20},
+      10003: {result: 20}
     },
     100003: {
-      10001: 20,
-      10002: 20
+      10001: {result: 20},
+      10002: {result: 20}
     },
     100004: {
-      10001: 20,
-      10002: 20
+      10001: {result: 20},
+      10002: {result: 20}
     }
   }
 };
@@ -220,14 +220,14 @@ const sectionCompletedLesson = {
 const sectionPartialCompletedLesson = {
   92: {
     100001: {
-      10001: 20,
-      10002: 20,
-      10003: 20
+      10001: {result: 20},
+      10002: {result: 20},
+      10003: {result: 20}
     },
     100002: {
-      10001: 20,
-      10002: 20,
-      10003: 20
+      10001: {result: 20},
+      10002: {result: 20},
+      10003: {result: 20}
     }
   }
 };
@@ -254,7 +254,7 @@ const selectedLessons = [
 export const fakeState = {
   sectionProgress: {
     scriptDataByScript: scriptDataByScript,
-    studentLevelProgressByScript: {92: {}}
+    studentLevelStatusByScript: {92: {}}
   },
   scriptSelection: {
     scriptId: 92
@@ -269,7 +269,7 @@ export const fakeState = {
 export const stateForPartiallyCompletedLesson = {
   sectionProgress: {
     scriptDataByScript: scriptDataByScript,
-    studentLevelProgressByScript: sectionPartialCompletedLesson
+    studentLevelStatusByScript: sectionPartialCompletedLesson
   },
   scriptSelection: {
     scriptId: 92
@@ -283,7 +283,7 @@ export const stateForPartiallyCompletedLesson = {
 export const stateForCompletedLesson = {
   sectionProgress: {
     scriptDataByScript: scriptDataByScript,
-    studentLevelProgressByScript: sectionCompletedLesson
+    studentLevelStatusByScript: sectionCompletedLesson
   },
   scriptSelection: {
     scriptId: 92
@@ -297,7 +297,7 @@ export const stateForCompletedLesson = {
 export const stateForTeacherMarkedCompletedLesson = {
   sectionProgress: {
     scriptDataByScript: scriptDataByScript,
-    studentLevelProgressByScript: sectionCompletedLesson
+    studentLevelStatusByScript: sectionCompletedLesson
   },
   scriptSelection: {
     scriptId: 92
@@ -313,7 +313,7 @@ export const stateForTeacherMarkedCompletedLesson = {
 export const stateForTeacherMarkedIncompletedLesson = {
   sectionProgress: {
     scriptDataByScript: scriptDataByScript,
-    studentLevelProgressByScript: sectionCompletedLesson
+    studentLevelStatusByScript: sectionCompletedLesson
   },
   scriptSelection: {
     scriptId: 92
@@ -329,7 +329,7 @@ export const stateForTeacherMarkedIncompletedLesson = {
 export const stateForTeacherMarkedAndProgress = {
   sectionProgress: {
     scriptDataByScript: scriptDataByScript,
-    studentLevelProgressByScript: sectionCompletedLesson
+    studentLevelStatusByScript: sectionCompletedLesson
   },
   scriptSelection: {
     scriptId: 92

--- a/apps/src/templates/sectionProgress/summary/StudentProgressSummaryCell.jsx
+++ b/apps/src/templates/sectionProgress/summary/StudentProgressSummaryCell.jsx
@@ -1,9 +1,5 @@
 import React, {Component} from 'react';
 import ProgressBox from '@cdo/apps/templates/sectionProgress/ProgressBox';
-import {
-  summarizeProgressInStage,
-  stageIsAllAssessment
-} from '@cdo/apps/templates/progress/progressHelpers';
 import PropTypes from 'prop-types';
 import Radium from 'radium';
 
@@ -11,20 +7,26 @@ class StudentProgressSummaryCell extends Component {
   static propTypes = {
     studentId: PropTypes.number.isRequired,
     style: PropTypes.object,
-    levelsWithStatus: PropTypes.arrayOf(PropTypes.object),
+    statusCounts: PropTypes.object,
+    assessmentStage: PropTypes.bool,
     onSelectDetailView: PropTypes.func
   };
 
   render() {
     const totalPixels = 20;
-    const statusCounts = summarizeProgressInStage(this.props.levelsWithStatus);
-    const assessmentStage = stageIsAllAssessment(this.props.levelsWithStatus);
-    const perfectPixels = Math.floor(
-      (statusCounts.completed / statusCounts.total) * totalPixels
-    );
-    const imperfectPixels = Math.floor(
-      (statusCounts.imperfect / statusCounts.total) * totalPixels
-    );
+    const {statusCounts, assessmentStage} = this.props;
+    const perfectPixels =
+      statusCounts.total > 0
+        ? Math.floor(
+            (statusCounts.completed / statusCounts.total) * totalPixels
+          )
+        : 0;
+    const imperfectPixels =
+      statusCounts.total > 0
+        ? Math.floor(
+            (statusCounts.imperfect / statusCounts.total) * totalPixels
+          )
+        : 0;
     const incompletePixels = totalPixels - perfectPixels - imperfectPixels;
     const started =
       statusCounts.attempted > 0 ||

--- a/apps/test/unit/code-studio/progressReduxTest.js
+++ b/apps/test/unit/code-studio/progressReduxTest.js
@@ -631,6 +631,7 @@ describe('progressReduxTest', () => {
       const expected = [
         [
           {
+            id: 2106,
             status: 'not_tried',
             url:
               'http://localhost-studio.code.org:3000/s/course3/stage/1/puzzle/1',
@@ -649,6 +650,7 @@ describe('progressReduxTest', () => {
             sublevels: []
           },
           {
+            id: 323,
             status: 'not_tried',
             url:
               'http://localhost-studio.code.org:3000/s/course3/stage/1/puzzle/2',
@@ -667,6 +669,7 @@ describe('progressReduxTest', () => {
             sublevels: []
           },
           {
+            id: 322,
             status: 'not_tried',
             url:
               'http://localhost-studio.code.org:3000/s/course3/stage/1/puzzle/3',
@@ -687,6 +690,7 @@ describe('progressReduxTest', () => {
         ],
         [
           {
+            id: 330,
             status: 'not_tried',
             url:
               'http://localhost-studio.code.org:3000/s/course3/stage/2/puzzle/1',
@@ -705,6 +709,7 @@ describe('progressReduxTest', () => {
             sublevels: []
           },
           {
+            id: 339,
             status: 'perfect',
             url:
               'http://localhost-studio.code.org:3000/s/course3/stage/2/puzzle/2',
@@ -723,6 +728,7 @@ describe('progressReduxTest', () => {
             sublevels: []
           },
           {
+            id: 341,
             status: 'attempted',
             url:
               'http://localhost-studio.code.org:3000/s/course3/stage/2/puzzle/3',

--- a/apps/test/unit/templates/progress/ProgressBubbleTest.js
+++ b/apps/test/unit/templates/progress/ProgressBubbleTest.js
@@ -8,12 +8,12 @@ import {LevelStatus, LevelKind} from '@cdo/apps/util/sharedConstants';
 const defaultProps = {
   level: {
     levelNumber: 1,
-    status: LevelStatus.perfect,
     url: '/foo/bar',
     name: 'level_name',
     progression: 'progression_name',
     progressionDisplayName: 'progression_display_name'
   },
+  levelStatus: {status: LevelStatus.perfect},
   disabled: false
 };
 
@@ -74,9 +74,9 @@ describe('ProgressBubble', () => {
         {...defaultProps}
         level={{
           ...defaultProps.level,
-          kind: LevelKind.assessment,
-          status: LevelStatus.completed_assessment
+          kind: LevelKind.assessment
         }}
+        levelStatus={{status: LevelStatus.completed_assessment}}
       />
     );
 
@@ -99,10 +99,7 @@ describe('ProgressBubble', () => {
     const wrapper = shallow(
       <ProgressBubble
         {...defaultProps}
-        level={{
-          ...defaultProps.level,
-          status: LevelStatus.attempted
-        }}
+        levelStatus={{status: LevelStatus.attempted}}
       />
     );
     const tooltipDiv = wrapper.find('div').at(1);
@@ -115,10 +112,7 @@ describe('ProgressBubble', () => {
     const wrapper = shallow(
       <ProgressBubble
         {...defaultProps}
-        level={{
-          ...defaultProps.level,
-          status: LevelStatus.passed
-        }}
+        levelStatus={{status: LevelStatus.passed}}
       />
     );
     const tooltipDiv = wrapper.find('div').at(1);
@@ -133,9 +127,9 @@ describe('ProgressBubble', () => {
         {...defaultProps}
         level={{
           ...defaultProps.level,
-          kind: LevelKind.assessment,
-          status: LevelStatus.submitted
+          kind: LevelKind.assessment
         }}
+        levelStatus={{status: LevelStatus.submitted}}
       />
     );
     const tooltipDiv = wrapper.find('div').at(1);
@@ -151,9 +145,9 @@ describe('ProgressBubble', () => {
         {...defaultProps}
         level={{
           ...defaultProps.level,
-          kind: LevelKind.peer_review,
-          status: LevelStatus.review_rejected
+          kind: LevelKind.peer_review
         }}
+        levelStatus={{status: LevelStatus.review_rejected}}
       />
     );
     const tooltipDiv = wrapper.find('div').at(1);
@@ -172,9 +166,9 @@ describe('ProgressBubble', () => {
         {...defaultProps}
         level={{
           ...defaultProps.level,
-          kind: LevelKind.peer_review,
-          status: LevelStatus.review_accepted
+          kind: LevelKind.peer_review
         }}
+        levelStatus={{status: LevelStatus.review_accepted}}
       />
     );
     const tooltipDiv = wrapper.find('div').at(1);

--- a/apps/test/unit/templates/progress/ProgressPillTest.js
+++ b/apps/test/unit/templates/progress/ProgressPillTest.js
@@ -7,14 +7,12 @@ import ReactTooltip from 'react-tooltip';
 
 const unpluggedLevel = {
   kind: LevelKind.unplugged,
-  isUnplugged: true,
-  status: LevelStatus.perfect
+  isUnplugged: true
 };
 
 const assessmentLevel = {
   kind: LevelKind.assessment,
-  isUnplugged: false,
-  status: LevelStatus.perfect
+  isUnplugged: false
 };
 
 const levelWithUrl = {
@@ -23,7 +21,7 @@ const levelWithUrl = {
 };
 
 const DEFAULT_PROPS = {
-  levels: [],
+  levelStatus: LevelStatus.perfect,
   icon: 'desktop',
   text: '1',
   fontSize: 12,
@@ -33,7 +31,11 @@ const DEFAULT_PROPS = {
 describe('ProgressPill', () => {
   it('can render an unplugged pill', () => {
     shallow(
-      <ProgressPill levels={[unpluggedLevel]} text="Unplugged Activity" />
+      <ProgressPill
+        level={unpluggedLevel}
+        levelStatus={LevelStatus.perfect}
+        text="Unplugged Activity"
+      />
     );
   });
 
@@ -42,7 +44,8 @@ describe('ProgressPill', () => {
 
     const wrapper = shallow(
       <ProgressPill
-        levels={[unpluggedLevel]}
+        level={unpluggedLevel}
+        levelStatus={LevelStatus.perfect}
         text="Unplugged Activity"
         tooltip={tooltip}
       />
@@ -66,7 +69,11 @@ describe('ProgressPill', () => {
 
   it('has an href when single level with url', () => {
     const wrapper = shallow(
-      <ProgressPill levels={[levelWithUrl]} text="Unplugged Activity" />
+      <ProgressPill
+        level={levelWithUrl}
+        levelStatus={LevelStatus.perfect}
+        text="Unplugged Activity"
+      />
     );
     assert.equal(wrapper.find('a').props().href, '/foo/bar');
   });
@@ -74,7 +81,8 @@ describe('ProgressPill', () => {
   it('does not have an href when disabled', () => {
     const wrapper = shallow(
       <ProgressPill
-        levels={[levelWithUrl]}
+        level={levelWithUrl}
+        levelStatus={LevelStatus.perfect}
         text="Unplugged Activity"
         disabled={true}
       />
@@ -82,25 +90,26 @@ describe('ProgressPill', () => {
     assert.equal(wrapper.find('a').props().href, undefined);
   });
 
-  it('has an assessment icon when single level is assessment', () => {
+  it('has an assessment icon when level is assessment and multilevel is false', () => {
     const wrapper = shallow(
-      <ProgressPill {...DEFAULT_PROPS} levels={[assessmentLevel]} />
+      <ProgressPill {...DEFAULT_PROPS} level={assessmentLevel} />
     );
     expect(wrapper.find('SmallAssessmentIcon')).to.have.lengthOf(1);
   });
 
   it('does not have an assessment icon when single level is not assessment', () => {
     const wrapper = shallow(
-      <ProgressPill {...DEFAULT_PROPS} levels={[unpluggedLevel]} />
+      <ProgressPill {...DEFAULT_PROPS} level={unpluggedLevel} />
     );
     expect(wrapper.find('SmallAssessmentIcon')).to.have.lengthOf(0);
   });
 
-  it('does not have an assessment icon when multiple assessment levels', () => {
+  it('does not have an assessment icon when level is assessment and multilevel is true', () => {
     const wrapper = shallow(
       <ProgressPill
         {...DEFAULT_PROPS}
-        levels={[assessmentLevel, assessmentLevel]}
+        level={assessmentLevel}
+        multilevel={true}
       />
     );
     expect(wrapper.find('SmallAssessmentIcon')).to.have.lengthOf(0);

--- a/apps/test/unit/templates/progress/progressHelpersTest.js
+++ b/apps/test/unit/templates/progress/progressHelpersTest.js
@@ -2,7 +2,8 @@ import {assert} from '../../../util/reconfiguredChai';
 import Immutable from 'immutable';
 import {
   fakeLesson,
-  fakeLevels
+  fakeLevels,
+  fakeStatusesForLevels
 } from '@cdo/apps/templates/progress/progressTestHelpers';
 import {LevelKind, LevelStatus} from '@cdo/apps/util/sharedConstants';
 import {
@@ -257,7 +258,8 @@ describe('progressHelpers', () => {
   describe('summarizeProgressInStage', () => {
     it('summarizes all untried levels', () => {
       const levels = fakeLevels(3);
-      const summarizedStage = summarizeProgressInStage(levels);
+      const levelStatuses = fakeStatusesForLevels(levels);
+      const summarizedStage = summarizeProgressInStage(levelStatuses, levels);
       assert.equal(summarizedStage.total, 3);
       assert.equal(summarizedStage.incomplete, 3);
       assert.equal(summarizedStage.completed, 0);
@@ -265,11 +267,12 @@ describe('progressHelpers', () => {
 
     it('summarizes all completed levels', () => {
       const levels = fakeLevels(3);
-      levels[0].status = LevelStatus.perfect;
-      levels[1].status = LevelStatus.submitted;
-      levels[2].status = LevelStatus.readonly;
+      const levelStatuses = fakeStatusesForLevels(levels);
+      levelStatuses[0].status = LevelStatus.perfect;
+      levelStatuses[1].status = LevelStatus.submitted;
+      levelStatuses[2].status = LevelStatus.readonly;
 
-      const summarizedStage = summarizeProgressInStage(levels);
+      const summarizedStage = summarizeProgressInStage(levelStatuses, levels);
       assert.equal(summarizedStage.total, 3);
       assert.equal(summarizedStage.incomplete, 0);
       assert.equal(summarizedStage.completed, 3);
@@ -277,11 +280,12 @@ describe('progressHelpers', () => {
     });
 
     it('summarizes all attempted levels', () => {
-      const levels = fakeLevels(2).map(level => ({
-        ...level,
-        status: LevelStatus.attempted
-      }));
-      const summarizedStage = summarizeProgressInStage(levels);
+      const levels = fakeLevels(2);
+      const levelStatuses = fakeStatusesForLevels(
+        levels,
+        LevelStatus.attempted
+      );
+      const summarizedStage = summarizeProgressInStage(levelStatuses, levels);
       assert.equal(summarizedStage.total, 2);
       assert.equal(summarizedStage.incomplete, 2);
       assert.equal(summarizedStage.completed, 0);
@@ -290,14 +294,15 @@ describe('progressHelpers', () => {
 
     it('summarizes a mix of levels', () => {
       const levels = fakeLevels(7);
-      levels[0].status = LevelStatus.submitted;
-      levels[1].status = LevelStatus.perfect;
-      levels[2].status = LevelStatus.attempted;
-      levels[3].status = LevelStatus.passed;
-      levels[4].status = LevelStatus.free_play_complete;
-      levels[5].status = 'other';
+      const levelStatuses = fakeStatusesForLevels(levels);
+      levelStatuses[0].status = LevelStatus.submitted;
+      levelStatuses[1].status = LevelStatus.perfect;
+      levelStatuses[2].status = LevelStatus.attempted;
+      levelStatuses[3].status = LevelStatus.passed;
+      levelStatuses[4].status = LevelStatus.free_play_complete;
+      levelStatuses[5].status = 'other';
 
-      const summarizedStage = summarizeProgressInStage(levels);
+      const summarizedStage = summarizeProgressInStage(levelStatuses, levels);
       assert.equal(summarizedStage.total, 7);
       assert.equal(summarizedStage.incomplete, 3);
       assert.equal(summarizedStage.completed, 3);
@@ -307,10 +312,11 @@ describe('progressHelpers', () => {
 
     it('does not summarize bonus levels', () => {
       const levels = fakeLevels(1);
-      levels[0].status = LevelStatus.submitted;
+      const levelStatuses = fakeStatusesForLevels(levels);
+      levelStatuses[0].status = LevelStatus.submitted;
       levels[0].bonus = true;
 
-      const summarizedStage = summarizeProgressInStage(levels);
+      const summarizedStage = summarizeProgressInStage(levelStatuses, levels);
       assert.equal(summarizedStage.total, 0);
       assert.equal(summarizedStage.incomplete, 0);
       assert.equal(summarizedStage.completed, 0);

--- a/apps/test/unit/templates/sectionProgress/VirtualizedDetailViewTest.js
+++ b/apps/test/unit/templates/sectionProgress/VirtualizedDetailViewTest.js
@@ -27,15 +27,15 @@ describe('VirtualizedSummaryView', () => {
     stubRedux();
     registerReducers({sectionProgress, scriptSelection, currentUser});
     defaultProps = {
-      levelsByLesson: {
+      levelStatusByStudent: {
         0: {
-          0: [{id: 789, status: 'perfect'}]
+          789: {status: 'perfect'}
         },
         1: {
-          0: [{id: 789, status: 'perfect'}]
+          789: {status: 'perfect'}
         },
         3: {
-          0: [{id: 789, status: 'perfect'}]
+          789: {status: 'perfect'}
         }
       },
       lessonOfInterest: 1,

--- a/apps/test/unit/templates/sectionProgress/VirtualizedSummaryViewTest.js
+++ b/apps/test/unit/templates/sectionProgress/VirtualizedSummaryViewTest.js
@@ -27,15 +27,15 @@ describe('VirtualizedSummaryView', () => {
     stubRedux();
     registerReducers({sectionProgress, scriptSelection, currentUser});
     defaultProps = {
-      levelsByLesson: {
+      levelStatusByStudent: {
         0: {
-          0: [{id: 789, status: 'perfect'}]
+          789: {status: 'perfect'}
         },
         1: {
-          0: [{id: 789, status: 'perfect'}]
+          789: {status: 'perfect'}
         },
         3: {
-          0: [{id: 789, status: 'perfect'}]
+          789: {status: 'perfect'}
         }
       },
       lessonOfInterest: 1,
@@ -92,13 +92,13 @@ describe('VirtualizedSummaryView', () => {
     expect(wrapper.find('StudentProgressSummaryCell')).to.have.length(3);
   });
 
-  it('updates the grid when the levels change', () => {
+  it('updates the grid when progress changes', () => {
     const forceUpdateGridsSpy = sinon.spy();
     const wrapper = shallow(
       <UnconnectedVirtualizedSummaryView {...defaultProps} />
     );
     wrapper.instance().summaryView = {forceUpdateGrids: forceUpdateGridsSpy};
-    wrapper.setProps({levelsByLesson: {}});
+    wrapper.setProps({levelStatusByStudent: {}});
     expect(forceUpdateGridsSpy).to.have.been.calledOnce;
   });
 });

--- a/apps/test/unit/templates/sectionProgress/sectionProgressLoaderTest.js
+++ b/apps/test/unit/templates/sectionProgress/sectionProgressLoaderTest.js
@@ -9,6 +9,7 @@ import * as redux from '@cdo/apps/redux';
 const serverScriptResponse = {
   csf: true,
   family_name: 'courseb',
+  name: 'courseb-2020',
   hasStandards: false,
   id: 123,
   path: 'test/url',
@@ -17,26 +18,31 @@ const serverScriptResponse = {
   version_year: '2020'
 };
 
-const timeInSeconds = Date.now() / 1000;
+const timeInSeconds = 321;
 const serverProgressResponse = {
   pagination: {
     page: 1,
     per: 50,
     total_pages: 1
   },
-  student_timestamps: {
+  students_last_update: {
     100: null,
     101: timeInSeconds,
     102: timeInSeconds + 1
   },
-  students: {
+  students_status: {
     100: {},
     101: {
-      2000: {status: 'locked'},
+      2000: {
+        status: 'locked',
+        result: 1001,
+        paired: false,
+        time_spent: undefined
+      },
       2001: {status: 'perfect', result: 30, paired: true, time_spent: 12345}
     },
     102: {
-      2000: {status: 'perfect', result: 100, time_spent: 6789}
+      2000: {status: 'perfect', result: 100, paired: false, time_spent: 6789}
     }
   }
 };
@@ -47,14 +53,19 @@ const firstServerProgressResponse = {
     per: 2,
     total_pages: 2
   },
-  student_timestamps: {
+  students_last_update: {
     100: null,
     101: timeInSeconds
   },
-  students: {
+  students_status: {
     100: {},
     101: {
-      2000: {status: 'locked'},
+      2000: {
+        status: 'locked',
+        result: 1001,
+        paired: false,
+        time_spent: undefined
+      },
       2001: {status: 'perfect', result: 30, paired: true, time_spent: 12345}
     }
   }
@@ -66,28 +77,22 @@ const secondServerProgressResponse = {
     per: 2,
     total_pages: 2
   },
-  student_timestamps: {
+  students_last_update: {
     102: timeInSeconds + 1
   },
-  students: {
+  students_status: {
     102: {
-      2000: {status: 'perfect', result: 100, time_spent: 6789}
+      2000: {status: 'perfect', result: 100, paired: false, time_spent: 6789}
     }
   }
 };
 
 const fullExpectedResult = {
-  levelsByLessonByScript: {
-    123: {
-      100: {},
-      101: {},
-      102: {}
-    }
-  },
   scriptDataByScript: {
     123: {
       csf: true,
       family_name: 'courseb',
+      name: 'courseb-2020',
       hasStandards: false,
       id: 123,
       path: 'test/url',
@@ -96,43 +101,24 @@ const fullExpectedResult = {
       version_year: '2020'
     }
   },
-  studentLevelPairingByScript: {
+  studentLevelStatusByScript: {
     123: {
       100: {},
       101: {
-        2000: false,
-        2001: true
+        2000: {
+          status: 'locked',
+          result: 1001,
+          paired: false,
+          time_spent: undefined
+        },
+        2001: {status: 'perfect', result: 30, paired: true, time_spent: 12345}
       },
       102: {
-        2000: false
+        2000: {status: 'perfect', result: 100, paired: false, time_spent: 6789}
       }
     }
   },
-  studentLevelProgressByScript: {
-    123: {
-      100: {},
-      101: {
-        2000: 1001,
-        2001: 30
-      },
-      102: {
-        2000: 100
-      }
-    }
-  },
-  studentLevelTimeSpentByScript: {
-    123: {
-      100: {},
-      101: {
-        2000: undefined,
-        2001: 12345
-      },
-      102: {
-        2000: 6789
-      }
-    }
-  },
-  studentTimestampsByScript: {
+  studentLastUpdateByScript: {
     123: {
       100: 0,
       101: timeInSeconds * 1000,
@@ -171,7 +157,7 @@ describe('sectionProgressLoader.loadScript', () => {
         return {
           sectionProgress: {
             isRefreshingProgress: true,
-            studentLevelProgressByScript: [true],
+            studentLevelStatusByScript: [true],
             scriptDataByScript: [true],
             currentView: 0
           },
@@ -212,7 +198,7 @@ describe('sectionProgressLoader.loadScript', () => {
         getState: () => {
           return {
             sectionProgress: {
-              studentLevelProgressByScript: [true],
+              studentLevelStatusByScript: [true],
               scriptDataByScript: [true],
               currentView: 0
             },
@@ -244,7 +230,7 @@ describe('sectionProgressLoader.loadScript', () => {
         getState: () => {
           return {
             sectionProgress: {
-              studentLevelProgressByScript: [],
+              studentLevelStatusByScript: [],
               scriptDataByScript: [],
               currentView: 0
             },
@@ -259,7 +245,6 @@ describe('sectionProgressLoader.loadScript', () => {
       });
 
       sinon.stub(progressHelpers, 'processedLevel');
-      sinon.stub(progress, 'levelsByLesson').returns({});
       addDataByScriptStub = sinon.spy(sectionProgress, 'addDataByScript');
       fetchStub.onCall(0).returns({
         then: sinon.stub().returns({
@@ -279,7 +264,6 @@ describe('sectionProgressLoader.loadScript', () => {
       loadScript(123, 0);
       expect(addDataByScriptStub).to.have.been.calledWith(fullExpectedResult);
       progressHelpers.processedLevel.restore();
-      progress.levelsByLesson.restore();
     });
 
     describe('the first time', () => {
@@ -288,7 +272,7 @@ describe('sectionProgressLoader.loadScript', () => {
           getState: () => {
             return {
               sectionProgress: {
-                studentLevelProgressByScript: [],
+                studentLevelStatusByScript: [],
                 scriptDataByScript: [],
                 currentView: 0
               },
@@ -326,11 +310,11 @@ describe('sectionProgressLoader.loadScript', () => {
           lessons: [{levels: ['fail']}]
         };
         const expectedResult = {
-          levelsByLessonByScript: {0: {}},
           scriptDataByScript: {
             0: {
               csf: undefined,
               family_name: undefined,
+              name: undefined,
               hasStandards: undefined,
               id: undefined,
               path: undefined,
@@ -339,10 +323,8 @@ describe('sectionProgressLoader.loadScript', () => {
               version_year: undefined
             }
           },
-          studentLevelPairingByScript: {0: {}},
-          studentLevelProgressByScript: {0: {}},
-          studentLevelTimeSpentByScript: {0: {}},
-          studentTimestampsByScript: {0: {}}
+          studentLevelStatusByScript: {0: {}},
+          studentLastUpdateByScript: {0: {}}
         };
 
         fetchStub.onCall(0).returns({

--- a/apps/test/unit/templates/sectionProgress/sectionProgressReduxTest.js
+++ b/apps/test/unit/templates/sectionProgress/sectionProgressReduxTest.js
@@ -5,7 +5,6 @@ import sectionProgress, {
   setLessonOfInterest,
   startLoadingProgress,
   finishLoadingProgress,
-  getCurrentProgress,
   getCurrentScriptData,
   startRefreshingProgress,
   finishRefreshingProgress
@@ -84,9 +83,8 @@ describe('sectionProgressRedux', () => {
       const action = setSection(fakeSectionData);
       const nextState = sectionProgress(initialState, action);
       assert.deepEqual(nextState.scriptDataByScript, {});
-      assert.deepEqual(nextState.studentLevelProgressByScript, {});
-      assert.deepEqual(nextState.levelsByLessonByScript, {});
-      assert.deepEqual(nextState.studentTimestampsByScript, {});
+      assert.deepEqual(nextState.studentLevelStatusByScript, {});
+      assert.deepEqual(nextState.studentLastUpdateByScript, {});
     });
   });
 
@@ -157,23 +155,6 @@ describe('sectionProgressRedux', () => {
       const action = setLessonOfInterest(lessonOfInterest);
       const nextState = sectionProgress(initialState, action);
       assert.deepEqual(nextState.lessonOfInterest, lessonOfInterest);
-    });
-  });
-
-  describe('getCurrentProgress', () => {
-    it('gets the progress for the current script', () => {
-      const stateWithProgress = {
-        scriptSelection: {scriptId: 123},
-        sectionProgress: {
-          studentLevelProgressByScript: {
-            123: 'fake progress 1',
-            456: 'fake progress 2'
-          }
-        }
-      };
-      expect(getCurrentProgress(stateWithProgress)).to.deep.equal(
-        'fake progress 1'
-      );
     });
   });
 

--- a/dashboard/app/controllers/api_controller.rb
+++ b/dashboard/app/controllers/api_controller.rb
@@ -332,8 +332,8 @@ class ApiController < ApplicationController
 
     # Get the level progress for each student
     render json: {
-      students: student_progress,
-      student_timestamps: student_timestamps,
+      students_status: student_progress,
+      students_last_update: student_timestamps,
       pagination: {
         total_pages: paged_students.total_pages,
         page: page,

--- a/dashboard/test/controllers/api_controller_test.rb
+++ b/dashboard/test/controllers/api_controller_test.rb
@@ -837,19 +837,19 @@ class ApiControllerTest < ActionController::TestCase
     get :section_level_progress, params: {section_id: @section.id, page: 1, per: 2}
     assert_response :success
     data = JSON.parse(@response.body)
-    assert_equal 2, data['students'].keys.length
+    assert_equal 2, data['students_status'].keys.length
     assert_equal 3, data['pagination']['total_pages']
 
     get :section_level_progress, params: {section_id: @section.id, page: 2, per: 2}
     assert_response :success
     data = JSON.parse(@response.body)
-    assert_equal 2, data['students'].keys.length
+    assert_equal 2, data['students_status'].keys.length
 
     # third page has only one student (of 5 total)
     get :section_level_progress, params: {section_id: @section.id, page: 3, per: 2}
     assert_response :success
     data = JSON.parse(@response.body)
-    assert_equal 1, data['students'].keys.length
+    assert_equal 1, data['students_status'].keys.length
 
     # if we request 1 per page, page 6 should still work (because page 5 gave
     # us a full page of data), but page 7 should fail
@@ -874,22 +874,22 @@ class ApiControllerTest < ActionController::TestCase
     get :section_level_progress, params: {section_id: @section.id, script_id: script.id, page: 1, per: 2}
     assert_response :success
     data = JSON.parse(@response.body)
-    assert_equal 2, data['students'].keys.length
-    assert_equal 2, data['student_timestamps'].keys.length
+    assert_equal 2, data['students_status'].keys.length
+    assert_equal 2, data['students_last_update'].keys.length
     assert_equal 3, data['pagination']['total_pages']
 
     get :section_level_progress, params: {section_id: @section.id, script_id: script.id, page: 2, per: 2}
     assert_response :success
     data = JSON.parse(@response.body)
-    assert_equal 2, data['students'].keys.length
-    assert_equal 2, data['student_timestamps'].keys.length
+    assert_equal 2, data['students_status'].keys.length
+    assert_equal 2, data['students_last_update'].keys.length
 
     # third page has only one student (of 5 total)
     get :section_level_progress, params: {section_id: @section.id, script_id: script.id, page: 3, per: 2}
     assert_response :success
     data = JSON.parse(@response.body)
-    assert_equal 1, data['students'].keys.length
-    assert_equal 1, data['student_timestamps'].keys.length
+    assert_equal 1, data['students_status'].keys.length
+    assert_equal 1, data['students_last_update'].keys.length
   end
 
   test "should get paired icons for paired user levels" do


### PR DESCRIPTION
this is laying the foundation for the rest of [LP-764].

as i started digging into progress scrolling performance, i discovered that we were creating a lot of unnecessary duplicate data in our redux store. specifically, we fetch script data and student progress data, then perform a bunch of joins on that data, which resulted in level data duplicated for each student, which gets very costly in sections with many students.

the focus of this PR is to remove those joins and the corresponding data processing. this requires updating a lot of components that expect to find student progress data inside a `level` object, to instead accept an additional `levelStatus` object.

i also stopped splitting the per-level student data into separate objects for time spent, pairing, progress, etc. since the object returned by the server is perfect for our purposes as-is.

BEFORE:
with 250 students, redux store was 109,343 lines and 3.9 MB
```
scriptDataByScript: {},
studentLevelProgressByScript: {},
studentLevelPairingByScript: {},
studentTimestampsByScript: {},
studentLevelTimeSpentByScript: {},
levelsByLessonByScript: {}
```

AFTER: 
with 250 students, redux store is 12,889 lines and 412 KB
```
scriptDataByScript: {},
studentLevelStatusByScript: {},
studentLastUpdateByScript: {}
```

<!-- ### Caching -->
<!-- ### Deployment strategy -->
<!-- ### Future work -->

## Links

<!--
  Any relevant links to external resources; ie, specification documents, jira
  items, related PRs, honeybadger errors, etc
-->

- jira: [LP-1603]

## Testing story

this refactor should result in exact feature parity with the previous code, so i didn't add any new tests. apps tests are all passing locally.


[LP-764]: https://codedotorg.atlassian.net/browse/LP-764
[LP-1603]: https://codedotorg.atlassian.net/browse/LP-1603