### PR TITLE
[Spritelab] add repeat forever block

### DIFF
--- a/apps/src/p5lab/spritelab/commands.js
+++ b/apps/src/p5lab/spritelab/commands.js
@@ -137,6 +137,10 @@ export const commands = {
     eventCommands.keyPressed(condition, key, callback);
   },
 
+  repeatForever(callback) {
+    eventCommands.repeatForever(callback);
+  },
+
   spriteClicked(condition, spriteArg, callback) {
     eventCommands.spriteClicked(condition, spriteArg, callback);
   },

--- a/apps/src/p5lab/spritelab/commands/eventCommands.js
+++ b/apps/src/p5lab/spritelab/commands/eventCommands.js
@@ -21,6 +21,10 @@ export const commands = {
     }
   },
 
+  repeatForever(callback) {
+    coreLibrary.addEvent('repeatForever', {}, callback);
+  },
+
   spriteClicked(condition, spriteArg, callback) {
     if (condition === 'when' || condition === 'while') {
       coreLibrary.addEvent(condition + 'click', {sprite: spriteArg}, callback);

--- a/apps/src/p5lab/spritelab/coreLibrary.js
+++ b/apps/src/p5lab/spritelab/coreLibrary.js
@@ -212,6 +212,11 @@ function atTimeEvent(inputEvent, p5Inst) {
   return [];
 }
 
+function repeatForeverEvent(inputEvent, p5Inst) {
+  // No condition to check, just always call callback with no extra args
+  return [{}];
+}
+
 function whenPressEvent(inputEvent, p5Inst) {
   if (p5Inst.keyWentDown(inputEvent.args.key)) {
     // Call callback with no extra args
@@ -324,10 +329,21 @@ function whileClickEvent(inputEvent, p5Inst) {
   return callbackArgList;
 }
 
-function checkEvent(inputEvent, p5Inst) {
+/**
+ * @param {Object} inputEvent
+ * @param p5Inst - the running P5 instance
+ * Checks whether the condition of the event is met, and if so gives the arguments to pass to the user's
+ * callback function. An event can trigger multiple invocations of the callback in a single tick of the
+ * draw loop, so this will return an array of callback arguments.
+ * @return {Array.<Object>} Each element of this array gives the arguments that will be passed
+ * to the event callback.
+ */
+function getCallbackArgListForEvent(inputEvent, p5Inst) {
   switch (inputEvent.type) {
     case 'atTime':
       return atTimeEvent(inputEvent, p5Inst);
+    case 'repeatForever':
+      return repeatForeverEvent(inputEvent, p5Inst);
     case 'whenpress':
       return whenPressEvent(inputEvent, p5Inst);
     case 'whilepress':
@@ -345,7 +361,7 @@ function checkEvent(inputEvent, p5Inst) {
 
 export function runEvents(p5Inst) {
   inputEvents.forEach(inputEvent => {
-    let callbackArgList = checkEvent(inputEvent, p5Inst);
+    let callbackArgList = getCallbackArgListForEvent(inputEvent, p5Inst);
     callbackArgList.forEach(args => {
       inputEvent.callback(args);
     });

--- a/apps/src/p5lab/spritelab/coreLibrary.js
+++ b/apps/src/p5lab/spritelab/coreLibrary.js
@@ -332,7 +332,7 @@ function whileClickEvent(inputEvent, p5Inst) {
 /**
  * @param {Object} inputEvent
  * @param p5Inst - the running P5 instance
- * Checks whether the condition of the event is met, and if so gives the arguments to pass to the user's
+ * Checks whether the condition of the event is met, and if so, returns the arguments to pass to the user's
  * callback function. An event can trigger multiple invocations of the callback in a single tick of the
  * draw loop, so this will return an array of callback arguments.
  * @return {Array.<Object>} Each element of this array gives the arguments that will be passed

--- a/dashboard/config/blocks/GamelabJr/gamelab_repeatForever.json
+++ b/dashboard/config/blocks/GamelabJr/gamelab_repeatForever.json
@@ -1,0 +1,16 @@
+{
+  "category": "Loops",
+  "config": {
+    "color": [
+      322,
+      0.9,
+      0.95
+    ],
+    "func": "repeatForever",
+    "blockText": "repeat forever",
+    "args": [
+
+    ],
+    "eventLoopBlock": true
+  }
+}


### PR DESCRIPTION

![image](https://user-images.githubusercontent.com/8787187/96056588-dbe4db00-0e3b-11eb-83d8-fe5c5763771c.png)
This is essentially just an event block where the "condition" of the event is always true, so we invoke the user's callback once per tick.

Examples:
![Oct-14-2020 16-43-20](https://user-images.githubusercontent.com/8787187/96056820-66c5d580-0e3c-11eb-87c3-ce5c3d63f08e.gif)

![Oct-14-2020 16-47-14](https://user-images.githubusercontent.com/8787187/96057057-f4a1c080-0e3c-11eb-81dc-7d6e9774f41e.gif)

Here, the sprite never changes size (it grows 1 **and** shrinks 1 each tick)
![image](https://user-images.githubusercontent.com/8787187/96056656-09318900-0e3c-11eb-9604-8b0b2cdf6355.png)

- [sprite lab block requests](https://docs.google.com/document/d/1aU4N4K-_8y_iHB7Jmu88rZpgR_vfHHihdcYma-CnBKA/edit?ts=5f8626aa#)