### PR TITLE
Use fetch API when deleting rows during browser unload event

### DIFF
--- a/apps/src/netsim/NetSimApi.js
+++ b/apps/src/netsim/NetSimApi.js
@@ -150,11 +150,8 @@ var tableApi = {
    * Remove multiple rows at once.
    * @param {number[]} ids - The row IDs to remove.
    * @param {NodeStyleCallback} callback - Expected result is TRUE.
-   * @param {boolean} [async] default TRUE.
    */
-  deleteRows: function(ids, callback, async) {
-    async = async !== false; // `undefined` maps to true
-
+  deleteRows: function(ids, callback) {
     // Generate query string in the form "id[]=1&id[]=2&..."
     var queryString = ids
       .map(function(id) {
@@ -165,8 +162,7 @@ var tableApi = {
     $.ajax({
       url: this.baseUrl + '?' + queryString,
       type: 'delete',
-      dataType: 'json',
-      async: async
+      dataType: 'json'
     })
       .done(function(data, text) {
         callback(null, true);
@@ -174,6 +170,33 @@ var tableApi = {
       .fail(function(request, status, error) {
         callback(new NetSimApiError(request), false);
       });
+  },
+
+  /**
+   * Remove multiple rows at once while user is navigating away from the page.
+   * Uses the fetch API for its 'keepalive' property as browsers have deprecated
+   * synchronous calls during unload events: https://www.chromestatus.com/feature/4664843055398912
+   * @param {number[]} ids - The row IDs to remove.
+   * @param {NodeStyleCallback} callback - Expected result is TRUE.
+   */
+  deleteRowsOnUnload: function(ids, callback) {
+    // Generate query string in the form "id[]=1&id[]=2&..."
+    var queryString = ids
+      .map(function(id) {
+        return 'id[]=' + id;
+      })
+      .join('&');
+
+    fetch(this.baseUrl + '?' + queryString, {
+      method: 'DELETE',
+      keepalive: true
+    }).then(response => {
+      if (response.ok) {
+        callback(null, true);
+      } else {
+        callback(new NetSimApiError(response), false);
+      }
+    });
   },
 
   /**

--- a/apps/src/netsim/NetSimApi.js
+++ b/apps/src/netsim/NetSimApi.js
@@ -187,6 +187,12 @@ var tableApi = {
       })
       .join('&');
 
+    /**
+     * Caveat: This request may be cancelled in IE. We use whatwg-fetch as a polyfill
+     * for the fetch API, which doesn't support the 'keepalive' property. This is still
+     * an improvement because currently rows aren't deleted at all when a user navigates
+     * away from the page.
+     */
     fetch(this.baseUrl + '?' + queryString, {
       method: 'DELETE',
       keepalive: true

--- a/apps/src/netsim/NetSimEntity.js
+++ b/apps/src/netsim/NetSimEntity.js
@@ -99,13 +99,11 @@ NetSimEntity.prototype.destroy = function(onComplete) {
 };
 
 /**
- * Remove entity from remote storage, using a synchronous call.
- * For use when navigating away from the page; otherwise, async version
- * is preferred.
+ * Remove entity from remote storage while user is navigating away from the page.
  * @returns {Error|null} error if entity delete fails
  */
-NetSimEntity.prototype.synchronousDestroy = function() {
-  return this.getTable().synchronousDelete(this.entityID);
+NetSimEntity.prototype.destroyOnUnload = function() {
+  return this.getTable().deleteOnUnload(this.entityID);
 };
 
 /** Get storage table for this entity type. */

--- a/apps/src/netsim/NetSimLocalClientNode.js
+++ b/apps/src/netsim/NetSimLocalClientNode.js
@@ -324,19 +324,24 @@ NetSimLocalClientNode.prototype.disconnectRemote = function(onComplete) {
   this.cleanUpBeforeDestroyingWire_();
 
   // destroy wire on API
-  wire.destroy(
-    function(err) {
-      // We're not going to stop if an error occurred here; the error might
-      // just be that the wire was already cleaned up by another node.
-      // As long as we make a good-faith disconnect effort, the cleanup system
-      // will correct any mistakes and we won't lock up our client trying to
-      // re-disconnect.
-      if (err) {
-        logger.info('Error while disconnecting: ' + err.message);
-      }
-      onComplete(null);
-    }.bind(this)
-  );
+  if (wire) {
+    wire.destroy(
+      function(err) {
+        // We're not going to stop if an error occurred here; the error might
+        // just be that the wire was already cleaned up by another node.
+        // As long as we make a good-faith disconnect effort, the cleanup system
+        // will correct any mistakes and we won't lock up our client trying to
+        // re-disconnect.
+        if (err) {
+          logger.info('Error while disconnecting: ' + err.message);
+        }
+        onComplete(null);
+      }.bind(this)
+    );
+  } else {
+    // Wire may have been cleaned up by another node. Invoke onComplete anyways.
+    onComplete(null);
+  }
 };
 
 /**

--- a/apps/src/netsim/NetSimTable.js
+++ b/apps/src/netsim/NetSimTable.js
@@ -414,13 +414,11 @@ NetSimTable.prototype.deleteMany = function(ids, callback) {
 };
 
 /**
- * Delete a row using a synchronous call. For use when navigating away from
- * the page; most of the time an asynchronous call is preferred.
+ * Delete a row while user is navigating away from the page.
  * @param {!number} id
  */
-NetSimTable.prototype.synchronousDelete = function(id) {
-  var async = false; // Force synchronous request
-  this.api_.deleteRows(
+NetSimTable.prototype.deleteOnUnload = function(id) {
+  this.api_.deleteRowsOnUnload(
     [id],
     function(err) {
       if (err) {
@@ -430,8 +428,7 @@ NetSimTable.prototype.synchronousDelete = function(id) {
         throw err;
       }
       this.removeRowsFromCache_([id]);
-    }.bind(this),
-    async
+    }.bind(this)
   );
 };
 

--- a/apps/src/netsim/netsim.js
+++ b/apps/src/netsim/netsim.js
@@ -470,7 +470,7 @@ NetSim.prototype.onBeforeUnload_ = function(event) {
  */
 NetSim.prototype.onUnload_ = function() {
   if (this.isConnectedToShard()) {
-    this.synchronousDisconnectFromShard_();
+    this.disconnectFromShardOnUnload_();
   }
 };
 
@@ -548,12 +548,12 @@ NetSim.prototype.createMyClientNode_ = function(displayName, onComplete) {
 };
 
 /**
- * Synchronous disconnect, for use when navigating away from the page
+ * Disconnect, for use when navigating away from the page.
  * @private
  */
-NetSim.prototype.synchronousDisconnectFromShard_ = function() {
+NetSim.prototype.disconnectFromShardOnUnload_ = function() {
   this.myNode.stopSimulation();
-  this.myNode.synchronousDestroy();
+  this.myNode.destroyOnUnload();
   this.myNode = null;
   // Attempt to unsubscribe from Pusher as we navigate away
   this.shard_.disconnect();


### PR DESCRIPTION
(Most of the useful information is in the Jira ticket.)

Rows weren't being deleted from NetSim if a user didn't explicitly disconnect from the simulation (e.g., if they refreshed the page or opened a new tab/window instead of clicking the "disconnect" button). This is because we were making a synchronous call during the browser's unload event, which is no longer supported: https://www.chromestatus.com/feature/4664843055398912

Using the fetch API with `keepalive: true` solves this issue. This means the request is async now, but the browser won't cancel it during unload like it normally would.

## Links

<!--
  Any relevant links to external resources; ie, specification documents, jira
  items, related PRs, honeybadger errors, etc
-->

- [STAR-1186](https://codedotorg.atlassian.net/browse/STAR-1186)

## Testing story

Existing test coverage.

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
