### PR TITLE
Switch back to mainline seamless_database_pool

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -28,9 +28,8 @@ gem 'responders', '~> 3.0'
 gem 'sinatra', '2.0.2', require: 'sinatra/base'
 
 gem 'mysql2', '>= 0.4.1'
-# Ref: https://github.com/bdurand/seamless_database_pool/issues/38
-# Ref: https://github.com/bdurand/seamless_database_pool/pull/39
-gem 'seamless_database_pool', github: 'wjordan/seamless_database_pool', ref: 'cdo'
+
+gem 'seamless_database_pool', '>= 1.0.20'
 
 gem 'dalli' # memcached
 gem 'dalli-elasticache' # ElastiCache Auto Discovery memcached nodes

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -175,14 +175,6 @@ GIT
     puma (3.12.0)
 
 GIT
-  remote: https://github.com/wjordan/seamless_database_pool.git
-  revision: c9a5c2bc92efc1f87a2aa065283e15283dbb9425
-  ref: cdo
-  specs:
-    seamless_database_pool (1.0.19)
-      activerecord (>= 3.2.0)
-
-GIT
   remote: https://github.com/wjordan/sprockets.git
   revision: 35caa45a78b739362b7db087b141f89e27d107c7
   ref: concurrent_asset_bundle_3.x
@@ -789,6 +781,8 @@ GEM
     sdoc (0.4.1)
       json (~> 1.7, >= 1.7.7)
       rdoc (~> 4.0)
+    seamless_database_pool (1.0.20)
+      activerecord (>= 3.2.0)
     selenium-webdriver (3.141.0)
       childprocess (~> 0.5)
       rubyzip (~> 1.2, >= 1.2.2)
@@ -1046,7 +1040,7 @@ DEPENDENCIES
   scenic-mysql_adapter
   scss_lint
   sdoc
-  seamless_database_pool!
+  seamless_database_pool (>= 1.0.20)
   selenium-webdriver (= 3.141.0)
   sequel
   shotgun


### PR DESCRIPTION
The [change for which we've been on a custom fork](https://github.com/bdurand/seamless_database_pool/pull/39) has been merged, as has [another change](https://github.com/bdurand/seamless_database_pool/pull/37) which updates the library to account for some features which were deprecated in Rails 5

According to [the changelog](https://github.com/bdurand/seamless_database_pool/blob/master/CHANGELOG.md#1020), literally the only changes included in this upgrade are the two specific changes we want!

## Testing story

Relying on existing unit tests here; I'm open to feedback on other things I should test, but lack the necessary context for this change to know what those are myself.

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
