### PR TITLE
Export parent_levels_child_levels table to Redshift dashboard schema

### DIFF
--- a/aws/dms/tasks.yml
+++ b/aws/dms/tasks.yml
@@ -108,7 +108,7 @@ cron-user-hierarchy:
 cron-user-hierarchy-pii:
 - dashboard.studio_people
 - dashboard.teacher_profiles
-- dashboard.users
+- dashboard.users:
     remove_column:
         - encrypted_password
 - dashboard.user_geos

--- a/aws/dms/tasks.yml
+++ b/aws/dms/tasks.yml
@@ -47,6 +47,7 @@ cron:
 - dashboard.levels
 - dashboard.script_levels
 - dashboard.levels_script_levels
+- dashboard.parent_levels_child_levels
 - dashboard.courses
 - dashboard.course_scripts
 - dashboard.survey_results
@@ -108,6 +109,8 @@ cron-user-hierarchy-pii:
 - dashboard.studio_people
 - dashboard.teacher_profiles
 - dashboard.users
+    remove_column:
+        - encrypted_password
 - dashboard.user_geos
 - dashboard.user_school_infos
 cron-user-levels:

--- a/aws/dms/tasks.yml
+++ b/aws/dms/tasks.yml
@@ -111,6 +111,9 @@ cron-user-hierarchy-pii:
 - dashboard.users:
     remove_column:
         - encrypted_password
+        - reset_password_token
+        - secret_picture_id
+        - secret_words
 - dashboard.user_geos
 - dashboard.user_school_infos
 cron-user-levels:


### PR DESCRIPTION
RED (data) team requests an additional dashboard table that does not contain any sensitive data to be exported to Redshift.

<!-- ### Background -->
<!-- ### Privacy -->
<!--
1.	Does the Project involve the collection, use or sharing of new Personal Data?

2.	Does the Project involve a new or changed use or sharing of existing Personal Data?
-->
<!-- ### Security -->
<!--
Link to Jira Task where sensitive security issues are discussed privately.
-->
<!-- ### Caching -->
<!-- ### Deployment strategy -->
<!-- ### Future work -->


## Testing story

``` bash
$ bundle exec rake stack:data:validate RAILS_ENV=production

Pending update for stack `DATA-production`:
Remove AuditLogsKeyAlias [AWS::KMS::Alias]
Remove AuditLogsKey [AWS::KMS::Key]
Remove AuditLogs [AWS::Logs::LogGroup]
Modify DMSCronUserHierarchyPii [AWS::DMS::ReplicationTask] Properties Replacement: Conditional (TableMappings)
Modify DMSCron [AWS::DMS::ReplicationTask] Properties Replacement: Conditional (TableMappings)
```
# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
