### PR TITLE
Stringify all uses of class_name

### DIFF
--- a/dashboard/app/models/follower.rb
+++ b/dashboard/app/models/follower.rb
@@ -22,7 +22,7 @@ class Follower < ActiveRecord::Base
 
   belongs_to :section
   has_one :user, through: :section
-  belongs_to :student_user, foreign_key: "student_user_id", class_name: User
+  belongs_to :student_user, foreign_key: "student_user_id", class_name: 'User'
 
   accepts_nested_attributes_for :student_user
 

--- a/dashboard/app/models/regional_partner.rb
+++ b/dashboard/app/models/regional_partner.rb
@@ -31,7 +31,7 @@ class RegionalPartner < ActiveRecord::Base
     through: :regional_partner_program_managers
 
   has_many :pd_workshops_organized, class_name: 'Pd::Workshop', through: :regional_partner_program_managers
-  has_many :mappings, -> {order :state, :zip_code}, class_name: Pd::RegionalPartnerMapping, dependent: :destroy
+  has_many :mappings, -> {order :state, :zip_code}, class_name: 'Pd::RegionalPartnerMapping', dependent: :destroy
 
   has_many :pd_workshops, class_name: 'Pd::Workshop', foreign_key: 'regional_partner_id'
 

--- a/dashboard/app/models/user.rb
+++ b/dashboard/app/models/user.rb
@@ -147,7 +147,7 @@ class User < ActiveRecord::Base
 
   # courses a facilitator is able to teach
   has_many :courses_as_facilitator,
-    class_name: Pd::CourseFacilitator,
+    class_name: 'Pd::CourseFacilitator',
     foreign_key: :facilitator_id,
     dependent: :destroy
 


### PR DESCRIPTION
Part of the ongoing work to upgrade to Rails 6.

It looks like support for passing an actual class (as opposed to a string representation of a class) was dropped: https://github.com/rails/rails/pull/27551

## Testing story

Relying on existing unit tests.

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
