### PR TITLE
Add zoom buttons to volunteer maps

### DIFF
--- a/pegasus/sites.v3/code.org/public/js/volunteer-local.js
+++ b/pegasus/sites.v3/code.org/public/js/volunteer-local.js
@@ -285,6 +285,10 @@ function loadMap(locations) {
             "icon-allow-overlap": true
           }
         });
+        mapboxMap.addControl(
+          new mapboxgl.NavigationControl({ showCompass: false }),
+          "bottom-right"
+        );
 
         if (mapOptions.locations && mapOptions.locations.length > 0) {
           addMarkers(mapboxStores);


### PR DESCRIPTION
Adds the zoom buttons to the bottom left of the map on /volunteer/local and /volunteer/remote as part of the follow ups to gmaps replacement.
<img width="1440" alt="Screen Shot 2020-10-08 at 4 29 50 PM" src="https://user-images.githubusercontent.com/17147070/96189536-81a85080-0ef5-11eb-85d9-e84eb62e3891.png">


<!-- ### Background -->
<!-- ### Privacy -->
<!--
1.	Does the Project involve the collection, use or sharing of new Personal Data?

2.	Does the Project involve a new or changed use or sharing of existing Personal Data?
-->
<!-- ### Security -->
<!--
Link to Jira Task where sensitive security issues are discussed privately.
-->
<!-- ### Caching -->
<!-- ### Deployment strategy -->
<!-- ### Future work -->

## Links

<!--
  Any relevant links to external resources; ie, specification documents, jira
  items, related PRs, honeybadger errors, etc
-->

- [gmaps replacement follow ups](https://docs.google.com/document/d/1cY6eMPwYgk3LQkDXS13cNqj-lmnJaas78YyfzFG-keo/edit)

## Testing story

<!--
  Does your change include appropriate tests?

  If so, please describe how the tests included in this PR are sufficient

  If not, please explain why this change does not need to be tested.
-->

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
