### PR TITLE
Adding nil/empty string check for to the Geocoder

### DIFF
--- a/lib/cdo/geocoder.rb
+++ b/lib/cdo/geocoder.rb
@@ -102,6 +102,8 @@ module Geocoder
   MIN_ADDRESS_LENGTH = 10
 
   def self.find_potential_street_address(text)
+    return nil unless text
+
     # Starting from the first number in the string, try parsing with Geocoder
     number_to_end_search = text.scan /([0-9]+.*)/
     return nil if number_to_end_search.empty?

--- a/pegasus/test/test_geocoder.rb
+++ b/pegasus/test/test_geocoder.rb
@@ -22,6 +22,8 @@ class GeocoderTest < Minitest::Test
     assert_nil(Geocoder.find_potential_street_address('1500000000'))
     assert_nil(Geocoder.find_potential_street_address('1500000001230b'))
     assert_nil(Geocoder.find_potential_street_address('1_Counter'))
+    assert_nil(Geocoder.find_potential_street_address(nil))
+    assert_nil(Geocoder.find_potential_street_address(''))
   end
 
   def test_with_errors


### PR DESCRIPTION
We received a Honeybadger error report that the Geocoder is being given `nil` or empty strings. This adds a check and tests for that.

## Links
- [Honeybadger](https://app.honeybadger.io/projects/3240/faults/68846610)

## Testing story
* Unit tests added

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
