### PR TITLE
Fix readonlyWorkspace spelling

### DIFF
--- a/apps/src/StudioApp.js
+++ b/apps/src/StudioApp.js
@@ -583,7 +583,7 @@ StudioApp.prototype.init = function(config) {
     );
   }
 
-  if (!config.readOnlyWorkspace) {
+  if (!config.readonlyWorkspace) {
     this.addChangeHandler(this.editDuringRunAlertHandler.bind(this));
   }
 


### PR DESCRIPTION
Fixes camelcasing for `config.readonlyWorkspace`, which was causing the "your code may have changed" banner to display on projects you don't own.

## Links

<!--
  Any relevant links to external resources; ie, specification documents, jira
  items, related PRs, honeybadger errors, etc
-->

- [STAR-1251](https://codedotorg.atlassian.net/browse/STAR-1251)

## Testing story

Manually tested.

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
