### PR TITLE
Add HOC link to welcome email

### DIFF
--- a/dashboard/app/views/teacher_mailer/new_teacher_email.html.haml
+++ b/dashboard/app/views/teacher_mailer/new_teacher_email.html.haml
@@ -10,7 +10,8 @@
   On Code.org,
   %a{href:"https://studio.code.org/courses?view=teacher"}you’ll find courses for all grade levels
   \- from pre-readers to seniors in high school, and everyone in between. All our courses
-  are available at no cost. Looking for a quick activity? Try starting with an Hour of Code.
+  are available at no cost. Looking for a quick activity? Try starting with an
+  %a{href:"https://hourofcode.com"}Hour of Code.
 %h3
   Step 2: Set up your classroom section
 %p


### PR DESCRIPTION
In the welcome email to teachers after making an account, the phrase "Hour of Code" now links to https://hourofcode.com.

<!--
  Your description goes here: A summary of the change, including any relevant motivation and context.

  If relevant, include a description both of the existing behavior and of the new behavior.
-->

<!--
  Other aspects to consider. uncomment and add detail for any that seem necessary:
-->

<!-- ### Background -->
<!-- ### Privacy -->
<!--
1.	Does the Project involve the collection, use or sharing of new Personal Data?

2.	Does the Project involve a new or changed use or sharing of existing Personal Data?
-->
<!-- ### Security -->
<!--
Link to Jira Task where sensitive security issues are discussed privately.
-->
<!-- ### Caching -->
<!-- ### Deployment strategy -->
<!-- ### Future work -->

## Links

<!--
  Any relevant links to external resources; ie, specification documents, jira
  items, related PRs, honeybadger errors, etc
-->

- [jira](https://codedotorg.atlassian.net/browse/PLC-1022?atlOrigin=eyJpIjoiMTU2NTgxMDg5YWUyNDJiODlkNDk2ZjM0NWU4MWNkN2MiLCJwIjoiaiJ9)

## Testing story

Tested locally using Mailcatcher

<!--
  Does your change include appropriate tests?

  If so, please describe how the tests included in this PR are sufficient

  If not, please explain why this change does not need to be tested.
-->

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
