### PR TITLE
Replace alias_method_chain in StiFactory

### DIFF
--- a/dashboard/app/models/concerns/sti_factory.rb
+++ b/dashboard/app/models/concerns/sti_factory.rb
@@ -4,7 +4,10 @@ module StiFactory
   extend ActiveSupport::Concern
   included do
     class << self
-      alias_method_chain :new, :factory unless method_defined?(:new_without_factory)
+      unless method_defined?(:new_without_factory)
+        alias_method :new_without_factory, :new
+        alias_method :new, :new_with_factory
+      end
     end
 
     def with_type(type)


### PR DESCRIPTION
Since it has been deprecated. The new reccommended process is to use `prepend`, but we're doing some funky stuff here, and it's not clear to me that is actually what we want to do. Specifically, in the `new_with_factory` method we are explicitly calling `klass.new_without_factory`, and I'm not sure of the best way to reimplement that pattern when using `prepend`.

Instead, I'm simply unwrapping `alias_method_chain`, and using the underlying `alias_method` method instead.

## Testing story

Tested out the process of creating levels locally, and it seems to be working!

It doesn't look like we have any existing unit tests in this area. I think tests would probably be valuable, but given the complexity of this feature (and my own lack of familiarity with it) they would also definitely be time-consuming. I'm open to input on whether you think they would be worthwhile!

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
