### PR TITLE
Enable auto-validation in Web Lab

### DIFF
--- a/apps/src/StudioApp.js
+++ b/apps/src/StudioApp.js
@@ -2768,7 +2768,8 @@ StudioApp.prototype.enableBreakpoints = function() {
  * specified in levelbuilder. If the level has disabled this functionality,
  * by turning `validationEnabled` off, this will always return true.
  */
-StudioApp.prototype.validateCodeChanged = function(level = this.config.level) {
+StudioApp.prototype.validateCodeChanged = function() {
+  const level = this.config.level;
   if (!level.validationEnabled) {
     return true;
   }

--- a/apps/src/StudioApp.js
+++ b/apps/src/StudioApp.js
@@ -2763,8 +2763,7 @@ StudioApp.prototype.enableBreakpoints = function() {
  * specified in levelbuilder. If the level has disabled this functionality,
  * by turning `validationEnabled` off, this will always return true.
  */
-StudioApp.prototype.validateCodeChanged = function() {
-  const level = this.config.level;
+StudioApp.prototype.validateCodeChanged = function(level = this.config.level) {
   if (!level.validationEnabled) {
     return true;
   }
@@ -3440,6 +3439,7 @@ StudioApp.prototype.setPageConstants = function(config, appSpecificConstants) {
       isReadOnlyWorkspace: !!config.readonlyWorkspace,
       isDroplet: !!level.editCode,
       isBlockly: this.isUsingBlockly(),
+      isBramble: config.app && config.app === 'weblab',
       hideSource: !!config.hideSource,
       isChallengeLevel: !!config.isChallengeLevel,
       isEmbedView: !!config.embed,

--- a/apps/src/StudioApp.js
+++ b/apps/src/StudioApp.js
@@ -294,7 +294,8 @@ function showWarnings(config) {
 }
 
 /**
- * Common startup tasks for all apps. Happens after configure.
+ * Common startup tasks for all blockly and droplet apps. Happens
+ * after configure.
  * @param {AppOptionsConfig}
  */
 StudioApp.prototype.init = function(config) {
@@ -1652,9 +1653,13 @@ StudioApp.prototype.displayFeedback = function(options) {
 
   // Write updated progress to Redux.
   const store = getStore();
-  store.dispatch(
-    mergeProgress({[this.config.serverLevelId]: options.feedbackType})
-  );
+  if (this.config) {
+    // Some apps (Weblab, Oceans) don't have a config. Skip this step
+    // for those.
+    store.dispatch(
+      mergeProgress({[this.config.serverLevelId]: options.feedbackType})
+    );
+  }
 
   if (experiments.isEnabled('bubbleDialog')) {
     // Track whether this experiment is in use. If not, delete this and similar
@@ -1744,7 +1749,7 @@ StudioApp.prototype.displayFeedback = function(options) {
 
   // If this level is enabled with a hint prompt threshold, check it and some
   // other state values to see if we should show the hint prompt
-  if (this.config.level.hintPromptAttemptsThreshold) {
+  if (this.config && this.config.level.hintPromptAttemptsThreshold) {
     this.authoredHintsController_.considerShowingOnetimeHintPrompt();
   }
 

--- a/apps/src/feedback.js
+++ b/apps/src/feedback.js
@@ -650,7 +650,9 @@ FeedbackUtils.prototype.getNumBlocksUsed = function() {
  */
 FeedbackUtils.prototype.getNumCountableBlocks = function() {
   var i;
-  if (this.studioApp_.editCode) {
+  if (getStore().getState().pageConstants.isBramble) {
+    return 0;
+  } else if (this.studioApp_.editCode) {
     var codeLines = 0;
     // quick and dirty method to count non-blank lines that don't start with //
     var lines = this.getGeneratedCodeString_().split('\n');
@@ -660,8 +662,9 @@ FeedbackUtils.prototype.getNumCountableBlocks = function() {
       }
     }
     return codeLines;
+  } else {
+    return this.getCountableBlocks_().length;
   }
-  return this.getCountableBlocks_().length;
 };
 
 /**
@@ -1185,7 +1188,9 @@ FeedbackUtils.prototype.shouldPromptForHint = function(feedbackType) {
  * Retrieve a string containing the user's generated Javascript code.
  */
 FeedbackUtils.prototype.getGeneratedCodeString_ = function() {
-  if (this.studioApp_.editCode) {
+  if (getStore().getState().pageConstants.isBramble) {
+    return '';
+  } else if (this.studioApp_.editCode) {
     return this.studioApp_.editor ? this.studioApp_.editor.getValue() : '';
   } else {
     return codegen.workspaceCode(Blockly);
@@ -1663,7 +1668,10 @@ FeedbackUtils.prototype.getMissingBlocks_ = function(blocks, maxBlocksToFlag) {
  * @return {boolean}
  */
 FeedbackUtils.prototype.hasExtraTopBlocks = function() {
-  if (this.studioApp_.editCode) {
+  if (
+    this.studioApp_.editCode ||
+    getStore().getState().pageConstants.isBramble
+  ) {
     return false;
   }
   var topBlocks = Blockly.mainBlockSpace.getTopBlocks();
@@ -1706,6 +1714,9 @@ FeedbackUtils.prototype.getTestResults = function(
   options
 ) {
   options = options || {};
+  if (getStore().getState().pageConstants.isBramble) {
+    return TestResults.FREE_PLAY;
+  }
   if (this.studioApp_.editCode) {
     if (levelComplete) {
       return TestResults.ALL_PASS;

--- a/apps/src/redux/pageConstants.js
+++ b/apps/src/redux/pageConstants.js
@@ -33,6 +33,7 @@ var ALLOWED_KEYS = new Set([
   'hasContainedLevels',
   'isDroplet',
   'isBlockly',
+  'isBramble',
   'isMinecraft',
   'runButtonText',
   'visualizationHasPadding',

--- a/apps/src/weblab/WebLab.js
+++ b/apps/src/weblab/WebLab.js
@@ -308,10 +308,14 @@ WebLab.prototype.reportResult = function(submit, validated) {
       : this.studioApp_.onContinue.bind(this.studioApp_);
   } else {
     testResult = TestResults.FREE_PLAY_UNCHANGED_FAIL;
-    onComplete = this.studioApp_.displayFeedback({
-      feedbackType: testResult,
-      level: this.level
-    });
+    onComplete = submit
+      ? onSubmitComplete
+      : () => {
+          this.studioApp_.displayFeedback({
+            feedbackType: testResult,
+            level: this.level
+          });
+        };
   }
 
   project.autosave(() => {

--- a/apps/src/weblab/WebLab.js
+++ b/apps/src/weblab/WebLab.js
@@ -299,7 +299,7 @@ WebLab.prototype.init = function(config) {
 };
 
 WebLab.prototype.reportResult = function(submit, validated) {
-  var onComplete, testResult;
+  let onComplete, testResult;
 
   if (validated) {
     testResult = TestResults.FREE_PLAY;

--- a/apps/src/weblab/WebLab.js
+++ b/apps/src/weblab/WebLab.js
@@ -299,16 +299,28 @@ WebLab.prototype.init = function(config) {
 };
 
 WebLab.prototype.onFinish = function(submit) {
-  const onComplete = submit
-    ? onSubmitComplete
-    : this.studioApp_.onContinue.bind(this.studioApp_);
+  var onComplete, testResult;
+  const isSuccessful = this.studioApp_.validateCodeChanged(this.level);
+
+  if (isSuccessful) {
+    testResult = TestResults.FREE_PLAY;
+    onComplete = submit
+      ? onSubmitComplete
+      : this.studioApp_.onContinue.bind(this.studioApp_);
+  } else {
+    testResult = TestResults.FREE_PLAY_UNCHANGED_FAIL;
+    onComplete = this.studioApp_.displayFeedback({
+      feedbackType: testResult,
+      level: this.level
+    });
+  }
 
   project.autosave(() => {
     this.studioApp_.report({
       app: 'weblab',
       level: this.level.id,
-      result: true,
-      testResult: TestResults.FREE_PLAY,
+      result: isSuccessful,
+      testResult: testResult,
       program: this.getCurrentFilesVersionId() || '',
       submitted: submit,
       onComplete: onComplete

--- a/apps/src/weblab/WebLab.js
+++ b/apps/src/weblab/WebLab.js
@@ -328,18 +328,12 @@ WebLab.prototype.reportResult = function(submit, validated) {
 };
 
 WebLab.prototype.onFinish = function(submit) {
-  var validated = true;
   if (this.level.validationEnabled) {
-    this.brambleHost.getAllFileDataFromBramble((result, error) => {
-      // Don't let an error from bramble block the student from progressing.
-      if (!error) {
-        validated =
-          JSON.stringify(result) !== JSON.stringify(this.getStartSources());
-      }
-      this.reportResult(submit, validated);
-    });
+    this.brambleHost.validateProjectChanged(validated =>
+      this.reportResult(submit, validated)
+    );
   } else {
-    this.reportResult(submit, validated);
+    this.reportResult(submit, true /* validated */);
   }
 };
 

--- a/apps/src/weblab/brambleHost.js
+++ b/apps/src/weblab/brambleHost.js
@@ -320,6 +320,7 @@ function validateProjectChanged(callback) {
       // like `url`), this is an image and is stored differently in the
       // startSources than in bramble. Check for a matching file name, but
       // don't compare data.
+      // Regex: Compare without whitespace.
       return (
         !matchingFile ||
         (startFile.data &&

--- a/apps/test/integration/feedbackTests.js
+++ b/apps/test/integration/feedbackTests.js
@@ -5,6 +5,8 @@ import {setupTestBlockly, getStudioAppSingleton} from './util/testBlockly';
 var testCollectionUtils = require('./util/testCollectionUtils');
 var sharedFunctionalBlocks = require('@cdo/apps/sharedFunctionalBlocks');
 import {TestResults} from '@cdo/apps/constants';
+import * as redux from '@cdo/apps/redux';
+import sinon from 'sinon';
 
 /**
  * Loads blocks into the workspace, then calls
@@ -828,11 +830,14 @@ describe('getCountableBlocks_', function() {
 });
 
 describe('unusedBlocks', function() {
-  var studioApp;
+  var studioApp, reduxStub;
   var blockXml = '<xml><block type="text_print"></block></xml>';
 
   // create our environment
   beforeEach(function() {
+    reduxStub = sinon.stub(redux, 'getStore').returns({
+      getState: sinon.stub().returns({pageConstants: {isBramble: false}})
+    });
     setupTestBlockly();
     var blockInstallOptions = {isK1: false};
     var blocksCommon = require('@cdo/apps/blocksCommon');
@@ -842,6 +847,7 @@ describe('unusedBlocks', function() {
   });
 
   afterEach(function() {
+    reduxStub.restore();
     Blockly.showUnusedBlocks = false;
   });
 

--- a/apps/test/unit/weblab/weblabTest.js
+++ b/apps/test/unit/weblab/weblabTest.js
@@ -6,7 +6,7 @@ import project from '@cdo/apps/code-studio/initApp/project';
 import {onSubmitComplete} from '@cdo/apps/submitHelper';
 
 describe('Web Lab', () => {
-  var reportStub, weblab;
+  let reportStub, weblab;
   describe('onFinish', () => {
     beforeEach(() => {
       weblab = new WebLab();
@@ -36,7 +36,7 @@ describe('Web Lab', () => {
   });
 
   describe('reportResult', () => {
-    var reportStub;
+    let reportStub;
     const defaultValues = {
       app: 'weblab',
       level: 123,

--- a/apps/test/unit/weblab/weblabTest.js
+++ b/apps/test/unit/weblab/weblabTest.js
@@ -1,0 +1,84 @@
+import sinon from 'sinon';
+import {expect} from '../../util/reconfiguredChai';
+import WebLab from '@cdo/apps/weblab/WebLab';
+import {TestResults} from '@cdo/apps/constants';
+import project from '@cdo/apps/code-studio/initApp/project';
+import {onSubmitComplete} from '@cdo/apps/submitHelper';
+
+describe('Web Lab', () => {
+  var reportStub, weblab;
+  describe('onFinish', () => {
+    beforeEach(() => {
+      weblab = new WebLab();
+      reportStub = sinon.stub(weblab, 'reportResult');
+    });
+
+    afterEach(() => {
+      reportStub.restore();
+    });
+
+    it('skips validation if validationEnabled is set to false', () => {
+      weblab.level = {validationEnabled: false};
+      weblab.onFinish(true);
+      expect(reportStub).to.have.been.calledWith(true, true);
+    });
+
+    it('reports the result from validateProjectChanged if validation is enabled', () => {
+      weblab.level = {validationEnabled: true};
+      weblab.brambleHost = {
+        validateProjectChanged: callback => {
+          callback(false);
+        }
+      };
+      weblab.onFinish(false);
+      expect(reportStub).to.have.been.calledWith(false, false);
+    });
+  });
+
+  describe('reportResult', () => {
+    var reportStub;
+    const defaultValues = {
+      app: 'weblab',
+      level: 123,
+      program: '',
+      submitted: true,
+      onComplete: onSubmitComplete
+    };
+    beforeEach(() => {
+      weblab = new WebLab();
+      sinon.stub(project, 'autosave').callsArg(0);
+      reportStub = sinon.stub();
+      weblab.studioApp_ = {report: reportStub};
+      weblab.level = {id: 123};
+    });
+
+    afterEach(() => {
+      weblab = new WebLab();
+      project.autosave.restore();
+    });
+
+    it('calls report with success conditions if validated is true', () => {
+      weblab.reportResult(true, true);
+      expect(reportStub).to.have.been.calledWith({
+        ...defaultValues,
+        ...{
+          result: true,
+          testResult: TestResults.FREE_PLAY
+        }
+      });
+    });
+
+    it('calls report with failure conditions if validated is false', () => {
+      const feedbackStub = sinon.stub();
+      weblab.studioApp_.displayFeedback = feedbackStub;
+      weblab.reportResult(true, false);
+      expect(reportStub).to.have.been.calledWith({
+        ...defaultValues,
+        ...{
+          result: false,
+          testResult: TestResults.FREE_PLAY_UNCHANGED_FAIL
+        }
+      });
+    });
+  });
+});

--- a/dashboard/config/scripts/levels/CSDU2 - Type Anything_2020.level
+++ b/dashboard/config/scripts/levels/CSDU2 - Type Anything_2020.level
@@ -15,6 +15,7 @@
     "name_suffix": "_2020",
     "encrypted": "false",
     "mini_rubric": "false",
+    "validation_enabled": "true",
     "teacher_markdown": "After giving students some time to explore the tool, ask them to share out anything that they have discovered.  The video on the next level will give them a short tour, so it's okay if they don't notice everything."
   },
   "published": true,


### PR DESCRIPTION
This is part of a larger feature to enable auto-validation for all CSD and CSP levels where a code change is expected.

There are two things that needed to happen in order to enable auto-validation in Web Lab

1. Web Lab needed to support error dialogs (in the past Web Lab would progress to the next level no matter what and would display no success/failure dialog)
2. Web Lab needed a diff tool that would allow us to determine whether the code had changed from the initial code on the level.

As part of this change, I also enabled auto-validation on one level in Web Lab corresponding to https://studio.code.org/s/csd2-2020/stage/2/puzzle/2

### Error dialog
The feedback module is what controls error and success dialog. In the past, feedback.js assumed that an app was either droplet or blockly and would follow code paths accordingly. Since bramble is fundamentally different than both, the would cause errors to be thrown. To handle this, I added another constant to the pageConstants. isBlockly and isDroplet already existed. I added isBramble so conditions could be evaluated on this case.

Additionally, StudioApp, from where the feedback dialog is created, expects all apps to use the init function and create a StudioApp config. Web Lab and other non-droplet/blockly apps do not do this, however. (Currently, Fish/Oceans is the only other app that does not use init or the StudioApp config). Since the feedback feature was previously never used by Web Lab, I needed to adjust it to no longer require the StudioApp config.

### Diff Tool
Other apps use project.js to manage their code and asset storage. For those other apps, project.js knows about their code and can perform a diff against the level code. Web Lab, however, uses bramble. To diff the web lab code, we need to use bramble. In this PR, additional functionality is added to bramble to get all files from the file system and serialize them to JSON (the original form that the files are in when the level is created). From here, we can diff the existing code from the original level code.

*Note:* Images are passed to Bramble as URLs but are stored as data strings. It is not possible to go from a data string back to the original URL. Therefore, rather than diffing the data in an image, we instead check for a different image name. This diff tool, therefore, cannot be used to reliably diff images - only code. We will only enable it on levels where code changes are expected or where a student is expected to change image names.

<!-- ### Background -->
<!-- ### Privacy -->
<!--
1.	Does the Project involve the collection, use or sharing of new Personal Data?

2.	Does the Project involve a new or changed use or sharing of existing Personal Data?
-->
<!-- ### Security -->
<!--
Link to Jira Task where sensitive security issues are discussed privately.
-->
<!-- ### Caching -->
<!-- ### Deployment strategy -->
<!-- ### Future work -->

## Links

- [spec](https://docs.google.com/document/d/1hF-wvav0MXLnH49x0WBeO8TcUibMaCUegZiDr8-6l-c/edit#)
- [Dev-Doc](https://docs.google.com/document/d/1xUgybM56dV5kmqOukKVPW1d88a9HGhphUs2r0tWlC_4/edit#)
- [LP-1551](https://codedotorg.atlassian.net/browse/LP-1551)
- Unblocks [LP-1549](https://codedotorg.atlassian.net/browse/LP-1549)
- Starts [LP-1550](https://codedotorg.atlassian.net/browse/LP-1550)

## Testing story

I went ahead and added tests for WebLab.js. There are, however, significant problems with brambleHost that require a refactor before testing can happen. Internal folks can see this slack thread for a discussion around these problems: https://codedotorg.slack.com/archives/C1B3PNDL7/p1603143998153300

Copying some of the details here:
* brambleHost relies on multiple window variables that are added by something else in the dependency chain. Example: window.requirejs.config. As a first step, I set up some if(IN_UNIT_TEST) conditions to handle these, but I ran into a second problem.
* Functions are not exported. brambleHost, instead, injects its exports directly into WebLab with webLab_.setBrambleHost. webLab_ is created by a call to parent.getWebLab() - I couldn't find an easy way to mock this, so I set a couple more if(IN_UNIT_TEST) conditions as a temporary option, but I ran into yet another problem.
* Functions can't be mocked. It was very convenient while testing WebLab.js to mock some properties in order to test just one specific function. brambleHost example: validateProjectChanged calls getAllFileDataFromBramble. I would have liked to mock getAllFileDataFromBramble, but since these aren't set up as class properties, it wasn't possible. Granted, getAllFileDataFromBramble is really more of a private function, so maybe I shouldn't be trying to mock it anyway, but one can wish :slightly_smiling_face: That being said, I ran into a final problem and finally decided to throw in the towel.
* bramble_, which gets used in many places, is injected by a load operation. This then ends up with a bunch of side effects which would require a lot of setup for a simple unit test. At this point, I realized the best path forward would be to refactor brambleHost (the first idea that came to mind was to move it to a class model and make the global variables/functions class properties).


# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
