### PR TITLE
add test for adding activity section in lesson edit ui

### DIFF
--- a/apps/src/lib/levelbuilder/lesson-editor/ActivitiesEditor.jsx
+++ b/apps/src/lib/levelbuilder/lesson-editor/ActivitiesEditor.jsx
@@ -134,7 +134,7 @@ class ActivitiesEditor extends Component {
           ))}
           <button
             onMouseDown={this.handleAddActivity}
-            className="btn"
+            className="btn add-activity"
             style={styles.addActivity}
             type="button"
           >

--- a/apps/src/lib/levelbuilder/lesson-editor/ActivityCard.jsx
+++ b/apps/src/lib/levelbuilder/lesson-editor/ActivityCard.jsx
@@ -206,7 +206,7 @@ class ActivityCard extends Component {
           ))}
           <button
             onMouseDown={this.handleAddActivitySection.bind()}
-            className="btn"
+            className="btn add-activity-section"
             style={styles.addButton}
             type="button"
           >

--- a/apps/src/lib/levelbuilder/lesson-editor/activitiesEditorRedux.js
+++ b/apps/src/lib/levelbuilder/lesson-editor/activitiesEditorRedux.js
@@ -309,11 +309,9 @@ function activities(state = [], action) {
       return action.activities;
     case ADD_ACTIVITY: {
       newState.push({
+        ...emptyActivity,
         key: action.activityKey,
-        displayName: '',
-        position: action.activityPosition,
-        duration: 0,
-        activitySections: []
+        position: action.activityPosition
       });
       updateActivityPositions(newState);
       break;

--- a/apps/src/lib/levelbuilder/lesson-editor/activitiesEditorRedux.js
+++ b/apps/src/lib/levelbuilder/lesson-editor/activitiesEditorRedux.js
@@ -358,7 +358,8 @@ function activities(state = [], action) {
         tips: [],
         remarks: false,
         slide: false,
-        text: ''
+        text: '',
+        scriptLevels: []
       });
       updateActivitySectionPositions(newState);
       break;

--- a/apps/src/lib/levelbuilder/lesson-editor/activitiesEditorRedux.js
+++ b/apps/src/lib/levelbuilder/lesson-editor/activitiesEditorRedux.js
@@ -352,14 +352,8 @@ function activities(state = [], action) {
       const activitySections =
         newState[action.activityPosition - 1].activitySections;
       activitySections.push({
-        key: action.activitySectionKey,
-        displayName: '',
-        levels: [],
-        tips: [],
-        remarks: false,
-        slide: false,
-        text: '',
-        scriptLevels: []
+        ...emptyActivitySection,
+        key: action.activitySectionKey
       });
       updateActivitySectionPositions(newState);
       break;

--- a/apps/test/unit/lib/levelbuilder/lesson-editor/LessonEditorTest.js
+++ b/apps/test/unit/lib/levelbuilder/lesson-editor/LessonEditorTest.js
@@ -70,6 +70,16 @@ describe('LessonEditor', () => {
     expect(wrapper.find('CollapsibleEditorSection').length).to.equal(6);
   });
 
+  it('can add activity', () => {
+    const wrapper = createWrapper({});
+    expect(wrapper.find('Connect(ActivitiesEditor)').length).to.equal(1);
+    expect(wrapper.find('Activity').length, 'Activity').to.equal(1);
+    const button = wrapper.find('.add-activity');
+    expect(button.length, 'button').to.equal(1);
+    button.simulate('mousedown');
+    expect(wrapper.find('Activity', 'Activity').length).to.equal(2);
+  });
+
   it('can add activity section', () => {
     const wrapper = createWrapper({});
     expect(wrapper.find('Connect(ActivitiesEditor)').length).to.equal(1);

--- a/apps/test/unit/lib/levelbuilder/lesson-editor/LessonEditorTest.js
+++ b/apps/test/unit/lib/levelbuilder/lesson-editor/LessonEditorTest.js
@@ -69,4 +69,17 @@ describe('LessonEditor', () => {
     expect(wrapper.find('AnnouncementsEditor').length).to.equal(1);
     expect(wrapper.find('CollapsibleEditorSection').length).to.equal(6);
   });
+
+  it('can add activity section', () => {
+    const wrapper = createWrapper({});
+    expect(wrapper.find('Connect(ActivitiesEditor)').length).to.equal(1);
+    expect(wrapper.find('Activity').length, 'Activity').to.equal(1);
+    expect(wrapper.find('ActivitySection').length, 'ActivitySection').to.equal(
+      3
+    );
+    const button = wrapper.find('.add-activity-section');
+    expect(button.length, 'button').to.equal(1);
+    button.simulate('click');
+    expect(wrapper.find('ActivitySection').length).to.equal(4);
+  });
 });

--- a/apps/test/unit/lib/levelbuilder/lesson-editor/LessonEditorTest.js
+++ b/apps/test/unit/lib/levelbuilder/lesson-editor/LessonEditorTest.js
@@ -74,10 +74,16 @@ describe('LessonEditor', () => {
     const wrapper = createWrapper({});
     expect(wrapper.find('Connect(ActivitiesEditor)').length).to.equal(1);
     expect(wrapper.find('Activity').length, 'Activity').to.equal(1);
+    expect(wrapper.find('ActivitySection').length, 'ActivitySection').to.equal(
+      3
+    );
     const button = wrapper.find('.add-activity');
     expect(button.length, 'button').to.equal(1);
     button.simulate('mousedown');
     expect(wrapper.find('Activity', 'Activity').length).to.equal(2);
+    expect(wrapper.find('ActivitySection').length, 'ActivitySection').to.equal(
+      4
+    );
   });
 
   it('can add activity section', () => {

--- a/apps/test/unit/lib/levelbuilder/lesson-editor/LessonEditorTest.js
+++ b/apps/test/unit/lib/levelbuilder/lesson-editor/LessonEditorTest.js
@@ -79,7 +79,7 @@ describe('LessonEditor', () => {
     );
     const button = wrapper.find('.add-activity-section');
     expect(button.length, 'button').to.equal(1);
-    button.simulate('click');
+    button.simulate('mousedown');
     expect(wrapper.find('ActivitySection').length).to.equal(4);
   });
 });


### PR DESCRIPTION
I noticed the button to add an Activity Section was broken because the activity section it tries to add does not have scriptLevels. This PR does the following:

* fixes "add Activity Section" button
* adds unit tests for adding Activity and Activity Section
* eliminates one place we list Activity and Activity Section props by moving onto emptyActivity / emptyActivitySection
* as a result, it also now adds an empty activity section when adding an empty activity

## Testing story

new apps unit / integration test

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
