### PR TITLE
extract translatable string for lessons without levels

### DIFF
--- a/apps/i18n/common/en_us.json
+++ b/apps/i18n/common/en_us.json
@@ -920,6 +920,7 @@
   "lessAllCaps": "LESS",
   "lesson": "Lesson",
   "lessons": "Lessons",
+  "lessonContainsNoLevels": "This lesson contains no levels.",
   "lessonExtras": "Lesson Extras are turned off for the selected section",
   "lessonExtrasButton": "Go to Teacher Dashboard",
   "lessonExtrasDetails": "Your students won’t see this page unless you turn them on. You can turn Lesson Extras on by editing section details from your Teacher Dashboard.",

--- a/apps/src/templates/progress/ProgressLessonContent.jsx
+++ b/apps/src/templates/progress/ProgressLessonContent.jsx
@@ -5,6 +5,7 @@ import ProgressBubbleSet from './ProgressBubbleSet';
 import {levelType} from './progressTypes';
 import {progressionsFromLevels} from '@cdo/apps/code-studio/progressRedux';
 import SafeMarkdown from '@cdo/apps/templates/SafeMarkdown';
+import i18n from '@cdo/locale';
 
 const styles = {
   summary: {
@@ -34,7 +35,7 @@ export default class ProgressLessonContent extends React.Component {
     if (progressions.length === 0) {
       bubbles = (
         <span style={styles.noLevelsWarning}>
-          This lesson contains no levels.
+          {i18n.lessonContainsNoLevels()}
         </span>
       );
     } else if (progressions.length === 1 && !progressions[0].name) {

--- a/apps/src/templates/progress/SummaryProgressRow.jsx
+++ b/apps/src/templates/progress/SummaryProgressRow.jsx
@@ -188,7 +188,7 @@ export default class SummaryProgressRow extends React.Component {
           }}
         >
           {levels.length === 0 ? (
-            'This lesson contains no levels.'
+            i18n.lessonContainsNoLevels()
           ) : (
             <ProgressBubbleSet
               levels={levels}


### PR DESCRIPTION
Quick follow-up to https://github.com/code-dot-org/code-dot-org/pull/37266, making it so that if this string ever ends up in a published course it will be translatable.

## Testing story

verified no visual change in summary or details view

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
