### PR TITLE
Pass id to volunteer contact form

### DIFF
--- a/pegasus/sites.v3/code.org/public/js/volunteer-local.js
+++ b/pegasus/sites.v3/code.org/public/js/volunteer-local.js
@@ -155,7 +155,9 @@ function getLocations(results) {
       var contact_link =
         '<a id="contact-trigger-' +
         index +
-        '" class="contact-trigger" onclick="return contactVolunteer()">Contact</a>';
+        '" class="contact-trigger" onclick="return contactVolunteer(' +
+        id +
+        ')">Contact</a>';
 
       var location = {
         lat: lat,
@@ -585,12 +587,13 @@ function compileContact(index, location) {
 }
 
 /* eslint-disable no-unused-vars */
-function contactVolunteer() {
+function contactVolunteer(id) {
   $("#name").show();
   $("#volunteer-contact").show();
   $("#success-message").hide();
   $("#error-message").hide();
   adjustScroll("volunteer-contact");
+  $("#volunteer-id").val(id);
 
   return false;
 }


### PR DESCRIPTION
See [Slack thread](https://codedotorg.slack.com/archives/C01CDUW1S00/p1603133922001800)

The contact form started returning a 400 error on submit, likely as a result of [replacing Google Maps with Mapbox](https://github.com/code-dot-org/code-dot-org/pull/37159/files#diff-fc87f776e8c6fc654f2b6acf8e789a4bdf139ce04ea273ff07ee87263206121dL611). The request wasn't sending the volunteer ID, which was required.

![Screenshot 2020-10-19 at 11 50 41 AM](https://user-images.githubusercontent.com/46464143/96504632-cd1a7180-1209-11eb-9c99-d7ee41f1a438.png)

This fix tried to emulate the removed code, which was setting a hidden form field. It isn't a pretty fix, but I tested locally and I can submit the form. Definitely open to suggestions for improvements.

<!-- ### Background -->
<!-- ### Privacy -->
<!--
1.	Does the Project involve the collection, use or sharing of new Personal Data?

2.	Does the Project involve a new or changed use or sharing of existing Personal Data?
-->
<!-- ### Security -->
<!--
Link to Jira Task where sensitive security issues are discussed privately.
-->
<!-- ### Caching -->
<!-- ### Deployment strategy -->
<!-- ### Future work -->

## Links

<!--
  Any relevant links to external resources; ie, specification documents, jira
  items, related PRs, honeybadger errors, etc
-->

- [spec]()
- [jira]()

## Testing story

<!--
  Does your change include appropriate tests?

  If so, please describe how the tests included in this PR are sufficient

  If not, please explain why this change does not need to be tested.
-->

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
