### PR TITLE
Volunteer map: scrollable dialog and fixed pin covering

### DIFF
--- a/pegasus/sites.v3/code.org/public/js/volunteer-local.js
+++ b/pegasus/sites.v3/code.org/public/js/volunteer-local.js
@@ -281,7 +281,6 @@ function loadMap(locations) {
           layout: {
             "icon-image": "dot-marker",
             "icon-size": 1.1,
-            "icon-anchor": "bottom",
             "icon-allow-overlap": true
           }
         });

--- a/pegasus/sites.v3/code.org/views/volunteer_map.haml
+++ b/pegasus/sites.v3/code.org/views/volunteer_map.haml
@@ -79,6 +79,11 @@
     color: #00a1e6;
   }
 
+  .mapboxgl-popup-content {
+    max-height: 180px;
+    overflow-y: scroll;
+  }
+
 :javascript
   mapboxgl.accessToken = "#{CDO.mapbox_access_token}";
 

--- a/pegasus/sites.v3/code.org/views/volunteer_map_remote.haml
+++ b/pegasus/sites.v3/code.org/views/volunteer_map_remote.haml
@@ -27,6 +27,12 @@
 %link{rel: "stylesheet", href: "https://api.tiles.mapbox.com/mapbox-gl-js/v1.1.1/mapbox-gl.css"}
 %script{type: "text/javascript", src: "https://api.tiles.mapbox.com/mapbox-gl-js/v1.1.1/mapbox-gl.js"}
 
+:css
+  .mapboxgl-popup-content {
+    max-height: 180px;
+    overflow-y: scroll;
+  }
+
 :javascript
   mapboxgl.accessToken = "#{CDO.mapbox_access_token}";
 


### PR DESCRIPTION
This adds a limit to the height of the pin dialogs so that it doesn't overflow and makes them scrollable. It also removes a parameter that was causing the pin to be covered by the dialog when it was open.
<img width="1440" alt="Screen Shot 2020-10-19 at 1 00 52 PM" src="https://user-images.githubusercontent.com/17147070/96507045-74e56e80-120d-11eb-9b17-939e04fa199f.png">


<!-- ### Background -->
<!-- ### Privacy -->
<!--
1.	Does the Project involve the collection, use or sharing of new Personal Data?

2.	Does the Project involve a new or changed use or sharing of existing Personal Data?
-->
<!-- ### Security -->
<!--
Link to Jira Task where sensitive security issues are discussed privately.
-->
<!-- ### Caching -->
<!-- ### Deployment strategy -->
<!-- ### Future work -->

## Links

<!--
  Any relevant links to external resources; ie, specification documents, jira
  items, related PRs, honeybadger errors, etc
-->

- [gmaps follow ups](https://docs.google.com/document/d/1cY6eMPwYgk3LQkDXS13cNqj-lmnJaas78YyfzFG-keo/edit)

## Testing story

<!--
  Does your change include appropriate tests?

  If so, please describe how the tests included in this PR are sufficient

  If not, please explain why this change does not need to be tested.
-->

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
