### PR TITLE
Accomodate unrecognized "project" urls in i18n sync

### DIFF
--- a/bin/i18n/i18n_script_utils.rb
+++ b/bin/i18n/i18n_script_utils.rb
@@ -174,7 +174,7 @@ class I18nScriptUtils
       level =
         case route_params[:controller]
         when "projects"
-          Level.find_by_name(ProjectsController::STANDALONE_PROJECTS[route_params[:key]][:name])
+          Level.find_by_name(ProjectsController::STANDALONE_PROJECTS.dig(route_params[:key], :name))
         when "script_levels"
           get_script_level(route_params, new_url)
         else


### PR DESCRIPTION
Right now, if the `key` is not a valid key in the hash, trying to retrieve the name fails with an error. We're rather just return `nil` in that case.

## Testing story

Tested manually

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
