### PR TITLE
[Google Blockly] Turn on scrollbars

### DIFF
--- a/apps/src/blocklyAddons/cdoBlockDragger.js
+++ b/apps/src/blocklyAddons/cdoBlockDragger.js
@@ -21,10 +21,23 @@ export default class BlockDragger extends GoogleBlockly.BlockDragger {
     }
   }
 
-  /** Hide trashcan when drag ends
+  /** Hide trashcan when drag ends.
+   * Also prevent blocks from ending with a negative position. Google allows the workspace to scroll in any direction,
+   * so negative block coordinates are valid, but we want to keep everything flowing down and to the right from (0,0).
    * @override
    */
   endBlockDrag(e, currentDragDeltaXY) {
+    // Don't let the block end with a negative position, unless it's getting deleted.
+    if (!this.draggedConnectionManager_.wouldDeleteBlock()) {
+      const endPosition = this.draggingBlock_.getRelativeToSurfaceXY();
+      if (endPosition.x < 0) {
+        currentDragDeltaXY.x -= endPosition.x;
+      }
+      if (endPosition.y < 0) {
+        currentDragDeltaXY.y -= endPosition.y;
+      }
+    }
+
     super.endBlockDrag(e, currentDragDeltaXY);
     this.workspace_.trashcan.setDisabled(false);
     this.workspace_.hideTrashcan();

--- a/apps/src/blocklyAddons/cdoScrollbar.js
+++ b/apps/src/blocklyAddons/cdoScrollbar.js
@@ -1,0 +1,54 @@
+import GoogleBlockly from 'blockly/core';
+
+export default class Scrollbar extends GoogleBlockly.Scrollbar {
+  /**
+   * @override The built-in function subtracts vertical space to make room for the
+   * horizontal scrollbar. We hide the horizontal scrollbar so we don't need to subtract
+   * that space.
+   */
+  resizeViewVertical(hostMetrics) {
+    this.setScrollViewSize_(Math.max(0, hostMetrics.viewHeight));
+
+    var xCoordinate = hostMetrics.absoluteLeft + 0.5;
+    if (!this.workspace_.RTL) {
+      xCoordinate +=
+        hostMetrics.viewWidth - Blockly.Scrollbar.scrollbarThickness - 1;
+    }
+    var yCoordinate = hostMetrics.absoluteTop + 0.5;
+    this.setPosition(xCoordinate, yCoordinate);
+
+    // If the view has been resized, a content resize will also be necessary.  The
+    // reverse is not true.
+    this.resizeContentVertical(hostMetrics);
+  }
+
+  /**
+   * @override Hide scrollbar if not needed
+   */
+  resizeContentVertical(hostMetrics) {
+    this.setVisible(this.scrollViewSize_ < hostMetrics.contentHeight);
+    super.resizeContentVertical(hostMetrics);
+  }
+
+  /**
+   * @override Hide horizontal scroll bar
+   */
+  resizeContentHorizontal(hostMetrics) {
+    this.setVisible(false);
+    super.resizeContentHorizontal(hostMetrics);
+  }
+
+  /**
+   * @override Enable hiding paired scrollbars. Google doesn't enable hiding paired scrollbars
+   * because it would cause problems with how they calculate spacing. We want to *always* hide
+   * the horizontal scrollbar, so there's no problem.
+   */
+  setVisible(visible) {
+    var visibilityChanged = visible !== this.isVisible();
+
+    this.isVisible_ = visible;
+    if (visibilityChanged) {
+      this.updateDisplay_();
+    }
+  }
+}

--- a/apps/src/blocklyAddons/cdoWorkspaceSvg.js
+++ b/apps/src/blocklyAddons/cdoWorkspaceSvg.js
@@ -70,3 +70,22 @@ WorkspaceSvg.prototype.blockSpaceEditor = {
   },
   svgResize: () => {} // TODO
 };
+
+/** Force content to start in top-left corner, not scroll in all directions.
+ * @override
+ */
+WorkspaceSvg.getContentDimensionsBounded_ = function(ws, svgSize) {
+  const content = Blockly.WorkspaceSvg.getContentDimensionsExact_(ws);
+
+  // View height and width are both in pixels, and are the same as the SVG size.
+  const viewWidth = svgSize.width;
+  const viewHeight = svgSize.height;
+
+  const dimensions = {
+    left: 0,
+    top: 0,
+    height: Math.max(content.bottom + viewHeight / 2, viewHeight),
+    width: viewWidth // No horizontal scroll
+  };
+  return dimensions;
+};

--- a/apps/src/blocklyAddons/cdoWorkspaceSvg.js
+++ b/apps/src/blocklyAddons/cdoWorkspaceSvg.js
@@ -78,14 +78,22 @@ WorkspaceSvg.getContentDimensionsBounded_ = function(ws, svgSize) {
   const content = Blockly.WorkspaceSvg.getContentDimensionsExact_(ws);
 
   // View height and width are both in pixels, and are the same as the SVG size.
-  const viewWidth = svgSize.width;
-  const viewHeight = svgSize.height;
+  const containerWidth = svgSize.width;
+  const containerHeight = svgSize.height;
+
+  // Add extra vertical space beneath the last block
+  const extraVerticalSpace = 100;
+  content.bottom += extraVerticalSpace;
+
+  // Workspace height is either the length of the blocks or the height of the container,
+  // whichever is greater.
+  const height = Math.max(content.bottom, containerHeight);
 
   const dimensions = {
     left: 0,
     top: 0,
-    height: Math.max(content.bottom + viewHeight / 2, viewHeight),
-    width: viewWidth // No horizontal scroll
+    height: height,
+    width: containerWidth // No horizontal scroll
   };
   return dimensions;
 };

--- a/apps/src/sites/studio/pages/googleBlocklyWrapper.js
+++ b/apps/src/sites/studio/pages/googleBlocklyWrapper.js
@@ -5,6 +5,7 @@ import CdoBlockSvg from '@cdo/apps/blocklyAddons/cdoBlockSvg';
 import CdoFieldDropdown from '@cdo/apps/blocklyAddons/cdoFieldDropdown';
 import CdoInput from '@cdo/apps/blocklyAddons/cdoInput';
 import CdoPathObject from '@cdo/apps/blocklyAddons/cdoPathObject';
+import CdoScrollbar from '@cdo/apps/blocklyAddons/cdoScrollbar';
 import CdoTheme from '@cdo/apps/blocklyAddons/cdoTheme';
 import CdoTrashcan from '@cdo/apps/blocklyAddons/cdoTrashcan';
 import CdoWorkspaceSvg from '@cdo/apps/blocklyAddons/cdoWorkspaceSvg';
@@ -100,6 +101,7 @@ function initializeBlocklyWrapper(blocklyInstance) {
   blocklyWrapper.wrapReadOnlyProperty('Procedures');
   blocklyWrapper.wrapReadOnlyProperty('removeChangeListener');
   blocklyWrapper.wrapReadOnlyProperty('RTL');
+  blocklyWrapper.wrapReadOnlyProperty('Scrollbar');
   blocklyWrapper.wrapReadOnlyProperty('selected');
   blocklyWrapper.wrapReadOnlyProperty('tutorialExplorer_locale');
   blocklyWrapper.wrapReadOnlyProperty('useContractEditor');
@@ -117,6 +119,7 @@ function initializeBlocklyWrapper(blocklyInstance) {
   blocklyWrapper.blockly_.FieldDropdown = CdoFieldDropdown;
   blocklyWrapper.blockly_.Input = CdoInput;
   blocklyWrapper.geras.PathObject = CdoPathObject;
+  blocklyWrapper.blockly_.Scrollbar = CdoScrollbar;
   blocklyWrapper.blockly_.Trashcan = CdoTrashcan;
   blocklyWrapper.blockly_.WorkspaceSvg = CdoWorkspaceSvg;
 

--- a/apps/src/sites/studio/pages/googleBlocklyWrapper.js
+++ b/apps/src/sites/studio/pages/googleBlocklyWrapper.js
@@ -226,7 +226,12 @@ function initializeBlocklyWrapper(blocklyInstance) {
     const options = {
       ...opt_options,
       theme: CdoTheme,
-      trashcan: true
+      trashcan: true,
+      move: {
+        wheel: true,
+        drag: true,
+        scrollbars: true
+      }
     };
     blocklyWrapper.editBlocks = opt_options.editBlocks;
     return blocklyWrapper.blockly_.inject(container, options);

--- a/apps/src/sites/studio/pages/googleBlocklyWrapper.js
+++ b/apps/src/sites/studio/pages/googleBlocklyWrapper.js
@@ -1,4 +1,5 @@
 import {BlocklyVersion} from '@cdo/apps/constants';
+import styleConstants from '@cdo/apps/styleConstants';
 import CdoBlockDragger from '@cdo/apps/blocklyAddons/cdoBlockDragger';
 import CdoBlockSvg from '@cdo/apps/blocklyAddons/cdoBlockSvg';
 import CdoFieldDropdown from '@cdo/apps/blocklyAddons/cdoFieldDropdown';
@@ -233,6 +234,10 @@ function initializeBlocklyWrapper(blocklyInstance) {
         scrollbars: true
       }
     };
+    // Shrink container to make room for the workspace header
+    container.style.height = `calc(100% - ${
+      styleConstants['workspace-headers-height']
+    }px)`;
     blocklyWrapper.editBlocks = opt_options.editBlocks;
     return blocklyWrapper.blockly_.inject(container, options);
   };


### PR DESCRIPTION
Adds blockly option to enable workspace scrollbars. 
Customizations needed:
- Hide the horizontal scrollbar. Doing this mostly to match our current Blockly behavior.
- Hide the vertical scrollbar when it's not needed
![Oct-20-2020 15-48-09](https://user-images.githubusercontent.com/8787187/96652407-b0ef0100-12eb-11eb-84f1-070cd710178f.gif)

- Prevent workspace from scrolling in all directions:
Blockly treats the workspace as infinitely expandable in every direction, with the origin in the middle. As a result, the default view starts halfway down the page:
![image](https://user-images.githubusercontent.com/8787187/96520022-08756a00-1223-11eb-9de7-a2eee997fe7b.png)
so that you can scroll up and to the left of your first block:
![image](https://user-images.githubusercontent.com/8787187/96520058-1925e000-1223-11eb-8086-5b3d5573b664.png)

We want the first block to always sit in the top-left corner of the workspace. To do this, I just had to override the `getContentDimensionsBounded_` function. This is a private function, but there's no officially-supported way to get the functionality we want. This isn't our first customization of a private function, so we'll have to be careful when updating versions regardless.
![image](https://user-images.githubusercontent.com/8787187/96520116-38247200-1223-11eb-8939-bd9cab41b73f.png)

- The other customization I had to make was for blocks being placed in negative locations. With the infinite-scroll workspace, negative block coordinates are perfectly valid, but since we keep (0,0) locked to the top-left corner, we don't want to allow placing blocks in negative locations. This was causing weird behavior when you tried to delete undeletable blocks- instead of being bumped back into the workspace, they were being placed underneath the toolbox (since the negative X location was treated as valid). To fix this, I added a check to the beginning of `endBlockDrag` to bump the block back into view.
Before:
![Oct-19-2020 16-00-21](https://user-images.githubusercontent.com/8787187/96520580-42933b80-1224-11eb-96ce-31ddb3cdd233.gif)

After:
![Oct-19-2020 15-58-34](https://user-images.githubusercontent.com/8787187/96520587-458e2c00-1224-11eb-8dd6-2facc6c1d467.gif)


This PR also fixes an issue where the bottom of the workspace was getting clipped:
Before:
![image](https://user-images.githubusercontent.com/8787187/96652211-4f2e9700-12eb-11eb-9e45-c95e9c324679.png)

After:
![image](https://user-images.githubusercontent.com/8787187/96652194-48078900-12eb-11eb-9910-6154aac460d6.png)
