### PR TITLE
Enabled time_spent logging on Web Lab.

### DIFF
--- a/apps/src/StudioApp.js
+++ b/apps/src/StudioApp.js
@@ -308,10 +308,6 @@ StudioApp.prototype.init = function(config) {
 
   config.getCode = this.getCode.bind(this);
   copyrightStrings = config.copyrightStrings;
-  this.debouncedSilentlyReport = _.debounce(
-    this.silentlyReport.bind(this),
-    1000
-  );
 
   if (config.legacyShareStyle && config.hideSource) {
     $('body').addClass('legacy-share-view');
@@ -412,7 +408,7 @@ StudioApp.prototype.init = function(config) {
 
   // Record time at initialization.
   this.initTime = new Date().getTime();
-  this.milestoneStartTime = new Date().getTime();
+  this.initTimeSpent();
 
   // Fixes viewport for small screens.
   var viewport = document.querySelector('meta[name="viewport"]');
@@ -691,6 +687,14 @@ StudioApp.prototype.getVersionHistoryHandler = function(config) {
 
     dialog.show();
   };
+};
+
+StudioApp.prototype.initTimeSpent = function() {
+  this.milestoneStartTime = new Date().getTime();
+  this.debouncedSilentlyReport = _.debounce(
+    this.silentlyReport.bind(this),
+    1000
+  );
 };
 
 StudioApp.prototype.initVersionHistoryUI = function(config) {
@@ -1896,17 +1900,17 @@ StudioApp.prototype.clearAndAttachRuntimeAnnotations = function() {
  * Report milestones but don't trigger the success callback when
  * the server responds.
  */
-StudioApp.prototype.silentlyReport = function() {
+StudioApp.prototype.silentlyReport = function(level = this.config.level.id) {
   var options = {
     app: getStore().getState().pageConstants.appType,
-    level: this.config.level.id,
+    level: level,
     skipSuccessCallback: true
   };
 
   // Some DB-backed levels (such as craft) only save the user's code when the user
   // successfully finishes the level. Opening the level in a new tab will make the level
   // appear freshly started. Therefore, we mark only channel-backed levels "started" here.
-  if (this.config.channel) {
+  if (getStore().getState().pageConstants.channelId) {
     options.testResult = TestResults.LEVEL_STARTED;
   }
   this.report(options);

--- a/apps/src/weblab/WebLab.js
+++ b/apps/src/weblab/WebLab.js
@@ -168,6 +168,7 @@ WebLab.prototype.init = function(config) {
     this.studioApp_.initProjectTemplateWorkspaceIconCallout();
     this.studioApp_.alertIfCompletedWhilePairing(config);
     this.studioApp_.initVersionHistoryUI(config);
+    this.studioApp_.initTimeSpent();
 
     let finishButton = document.getElementById('finishButton');
     if (finishButton) {
@@ -235,6 +236,7 @@ WebLab.prototype.init = function(config) {
   }
 
   function onRefreshPreview() {
+    this.studioApp_.debouncedSilentlyReport(this.level.id);
     project.autosave(() => {
       if (this.brambleHost) {
         this.brambleHost.refreshPreview();


### PR DESCRIPTION
Web Lab does not automatically log time_spent because it does not have a 'reset' button. This adds time_spent logging when the 'Refresh and Save' button is clicked. time_spent logging was already enabled onFinish by this PR: https://github.com/code-dot-org/code-dot-org/pull/37305

<!--
  Other aspects to consider. uncomment and add detail for any that seem necessary:
-->

<!-- ### Background -->
<!-- ### Privacy -->
<!--
1.	Does the Project involve the collection, use or sharing of new Personal Data?

2.	Does the Project involve a new or changed use or sharing of existing Personal Data?
-->
<!-- ### Security -->
<!--
Link to Jira Task where sensitive security issues are discussed privately.
-->
<!-- ### Caching -->
<!-- ### Deployment strategy -->
<!-- ### Future work -->

## Links

<!--
  Any relevant links to external resources; ie, specification documents, jira
  items, related PRs, honeybadger errors, etc
-->

- [Dev Doc: Recording Time Spent Plan](https://docs.google.com/document/d/1sSxS1C0XHokLh34ObposdzI0I1FwCY7qJXmn0mtpwi0/edit?ts=5d8932a9&pli=1)
- [Spec: Improvements to the progress tab](https://docs.google.com/document/d/11vid6ZWkpUV5TJm3swI6kbdSpg5_93UHDxnod58r_Zc/edit#)
- [LP-1550](https://codedotorg.atlassian.net/browse/LP-1550)
- [LP-1581](https://codedotorg.atlassian.net/browse/LP-1581)

## Testing story

<!--
  Does your change include appropriate tests?

  If so, please describe how the tests included in this PR are sufficient

  If not, please explain why this change does not need to be tested.
-->

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
