### PR TITLE
Let lesson edit page use the full width of the screen

### DIFF
--- a/apps/src/lib/levelbuilder/CollapsibleEditorSection.jsx
+++ b/apps/src/lib/levelbuilder/CollapsibleEditorSection.jsx
@@ -33,11 +33,12 @@ export default class CollapsibleEditorSection extends Component {
 
   render() {
     const {title, fullWidth} = this.props;
-    const wrapperStyle = {
+    const editorsStyle = {
+      ...styles.editors,
       width: fullWidth ? null : styleConstants['content-width']
     };
     return (
-      <div style={wrapperStyle}>
+      <div>
         <div style={styles.header}>
           <h2
             onClick={() => {
@@ -51,7 +52,7 @@ export default class CollapsibleEditorSection extends Component {
             {title}
           </h2>
         </div>
-        <div style={styles.editors} hidden={this.state.collapsed}>
+        <div style={editorsStyle} hidden={this.state.collapsed}>
           {this.props.children}
         </div>
       </div>

--- a/apps/src/lib/levelbuilder/CollapsibleEditorSection.jsx
+++ b/apps/src/lib/levelbuilder/CollapsibleEditorSection.jsx
@@ -1,6 +1,7 @@
 import PropTypes from 'prop-types';
 import React, {Component} from 'react';
 import FontAwesome from '@cdo/apps/templates/FontAwesome';
+import styleConstants from '@cdo/apps/styleConstants';
 
 const styles = {
   header: {
@@ -17,6 +18,7 @@ const styles = {
 export default class CollapsibleEditorSection extends Component {
   static propTypes = {
     title: PropTypes.string,
+    fullWidth: PropTypes.bool,
     collapsed: PropTypes.bool,
     children: PropTypes.any
   };
@@ -30,9 +32,12 @@ export default class CollapsibleEditorSection extends Component {
   }
 
   render() {
-    const {title} = this.props;
+    const {title, fullWidth} = this.props;
+    const wrapperStyle = {
+      width: fullWidth ? null : styleConstants['content-width']
+    };
     return (
-      <div>
+      <div style={wrapperStyle}>
         <div style={styles.header}>
           <h2
             onClick={() => {

--- a/apps/src/lib/levelbuilder/TextareaWithMarkdownPreview.jsx
+++ b/apps/src/lib/levelbuilder/TextareaWithMarkdownPreview.jsx
@@ -4,10 +4,24 @@ import SafeMarkdown from '@cdo/apps/templates/SafeMarkdown';
 import color from '@cdo/apps/util/color';
 
 const styles = {
-  box: {
+  wrapper: {
     marginTop: 10,
     marginBottom: 10,
     border: '1px solid ' + color.light_gray,
+    padding: 5,
+    display: 'flex',
+    alignItems: 'flex-start',
+    flexWrap: 'wrap'
+  },
+  container: {
+    flex: '1 1 500px',
+    maxWidth: 970,
+    margin: 5
+  },
+  preview: {
+    marginTop: 5,
+    marginBottom: 0,
+    border: '1px solid ' + color.lighter_gray,
     padding: 10
   },
   input: {
@@ -48,21 +62,25 @@ export default class TextareaWithMarkdownPreview extends React.Component {
     return (
       <label>
         {this.props.label}
-        <div style={styles.box}>
-          <div style={{marginBottom: 5}}>Markdown:</div>
-          <textarea
-            name={this.props.name}
-            defaultValue={this.state.markdown}
-            rows={this.props.inputRows || 5}
-            style={styles.input}
-            onChange={this.handleMarkdownChange}
-          />
-          <div style={{marginBottom: 5}}>Preview:</div>
-          <div style={styles.box}>
-            <SafeMarkdown
-              openExternalLinksInNewTab={true}
-              markdown={this.state.markdown}
+        <div style={styles.wrapper}>
+          <div style={styles.container}>
+            <div style={{marginBottom: 5}}>Markdown:</div>
+            <textarea
+              name={this.props.name}
+              defaultValue={this.state.markdown}
+              rows={this.props.inputRows || 5}
+              style={styles.input}
+              onChange={this.handleMarkdownChange}
             />
+          </div>
+          <div style={styles.container}>
+            <div style={{marginBottom: 5}}>Preview:</div>
+            <div style={styles.preview}>
+              <SafeMarkdown
+                openExternalLinksInNewTab={true}
+                markdown={this.state.markdown}
+              />
+            </div>
           </div>
         </div>
       </label>

--- a/apps/src/lib/levelbuilder/lesson-editor/LessonEditor.jsx
+++ b/apps/src/lib/levelbuilder/lesson-editor/LessonEditor.jsx
@@ -147,7 +147,11 @@ export default class LessonEditor extends Component {
           />
         </CollapsibleEditorSection>
 
-        <CollapsibleEditorSection title="Overviews" collapsed={true}>
+        <CollapsibleEditorSection
+          title="Overviews"
+          collapsed={true}
+          fullWidth={true}
+        >
           <TextareaWithMarkdownPreview
             markdown={overview}
             label={'Overview'}
@@ -162,7 +166,11 @@ export default class LessonEditor extends Component {
           />
         </CollapsibleEditorSection>
 
-        <CollapsibleEditorSection title="Purpose and Prep" collapsed={true}>
+        <CollapsibleEditorSection
+          title="Purpose and Prep"
+          collapsed={true}
+          fullWidth={true}
+        >
           <TextareaWithMarkdownPreview
             markdown={purpose}
             label={'Purpose'}

--- a/apps/src/lib/levelbuilder/lesson-editor/LessonEditor.jsx
+++ b/apps/src/lib/levelbuilder/lesson-editor/LessonEditor.jsx
@@ -181,7 +181,7 @@ export default class LessonEditor extends Component {
           <ResourcesEditor resources={this.props.resources} />
         </CollapsibleEditorSection>
 
-        <CollapsibleEditorSection title="Activities & Levels">
+        <CollapsibleEditorSection title="Activities & Levels" fullWidth={true}>
           <ActivitiesEditor />
         </CollapsibleEditorSection>
 

--- a/apps/test/unit/lib/levelbuilder/CollapsibleEditorSectionTest.jsx
+++ b/apps/test/unit/lib/levelbuilder/CollapsibleEditorSectionTest.jsx
@@ -22,7 +22,9 @@ describe('CollapsibleEditorSection', () => {
     expect(wrapper.find('span').length).to.equal(1);
     expect(wrapper.find('FontAwesome').length).to.equal(1);
     expect(wrapper.state().collapsed).to.equal(false);
-    expect(wrapper.props().style.width).to.equal(970);
+
+    const editorsWrapper = wrapper.children().last();
+    expect(editorsWrapper.props().style.width).to.equal(970);
   });
 
   it('renders in full width', () => {
@@ -31,7 +33,8 @@ describe('CollapsibleEditorSection', () => {
         <span>Child</span>
       </CollapsibleEditorSection>
     );
-    expect(wrapper.props().style.width).to.equal(null);
+    const editorsWrapper = wrapper.children().last();
+    expect(editorsWrapper.props().style.width).to.equal(null);
   });
 
   it('clicking h2 collapses area', () => {

--- a/apps/test/unit/lib/levelbuilder/CollapsibleEditorSectionTest.jsx
+++ b/apps/test/unit/lib/levelbuilder/CollapsibleEditorSectionTest.jsx
@@ -22,6 +22,16 @@ describe('CollapsibleEditorSection', () => {
     expect(wrapper.find('span').length).to.equal(1);
     expect(wrapper.find('FontAwesome').length).to.equal(1);
     expect(wrapper.state().collapsed).to.equal(false);
+    expect(wrapper.props().style.width).to.equal(970);
+  });
+
+  it('renders in full width', () => {
+    const wrapper = shallow(
+      <CollapsibleEditorSection {...defaultProps} fullWidth={true}>
+        <span>Child</span>
+      </CollapsibleEditorSection>
+    );
+    expect(wrapper.props().style.width).to.equal(null);
   });
 
   it('clicking h2 collapses area', () => {

--- a/dashboard/app/controllers/lessons_controller.rb
+++ b/dashboard/app/controllers/lessons_controller.rb
@@ -37,6 +37,7 @@ class LessonsController < ApplicationController
   def edit
     @lesson_data = @lesson.summarize_for_lesson_edit
     @related_lessons = @lesson.summarize_related_lessons
+    view_options(full_width: true)
   end
 
   # PATCH/PUT /lessons/1


### PR DESCRIPTION
Finishes [PLAT-343]. Because only the activities editor needs the full width, I've only expanded the width of that section. 

## Screenshots

### before

![Screen Shot 2020-10-20 at 9 44 39 AM](https://user-images.githubusercontent.com/8001765/96621384-69ea1700-12bd-11eb-8c16-1070e727c305.png)

### after

![wide-lesson](https://user-images.githubusercontent.com/8001765/96621423-71112500-12bd-11eb-990b-5919cc017a19.gif)

![wide-lesson-responsive](https://user-images.githubusercontent.com/8001765/96621763-dfee7e00-12bd-11eb-9c85-2348fb31c07b.gif)


## Testing story

New unit test for CollapsibleEditorSection fullWidth param. existing test coverage verifies the page still renders.

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked


[PLAT-343]: https://codedotorg.atlassian.net/browse/PLAT-343