### PR TITLE
fix show link at bottom of lesson edit page

### DIFF
--- a/dashboard/app/views/lessons/edit.html.haml
+++ b/dashboard/app/views/lessons/edit.html.haml
@@ -4,4 +4,4 @@
 = form_for @lesson, {url: lesson_path(id: @lesson.id)} do |f|
   #edit-container
 
-= link_to t('crud.show'), @lesson
+= link_to t('crud.show'), lesson_path(id: @lesson.id)


### PR DESCRIPTION
super quick fix for the "show" link at the bottom of the script edit page.

link target before: `/lessons/1` (incorrect -- this lesson's position within its script)

link target after: `/lessons/6094` (correct  -- this lesson's id)

for most models, the existing syntax works because our system can compute the link to the object using rails defaults. unfortunately, rails defaults give us the wrong answer for lessons because we override this method: https://github.com/code-dot-org/code-dot-org/blob/9bf37fb553387c9ad500e66f50eec9ef202c2516/dashboard/app/models/lesson.rb#L140-L141

specifying the id gives the https://guides.rubyonrails.org/routing.html#path-and-url-helpers a stronger hint at how to generate the url.