### PR TITLE
Gracefully handle null startBlocks in auto-validation

### DIFF
--- a/apps/src/code-studio/initApp/project.js
+++ b/apps/src/code-studio/initApp/project.js
@@ -968,9 +968,11 @@ var projects = (module.exports = {
    * Tests whether provided sample code is different from the current project code.
    * This also normalizes the code so incidental differences in line endings or
    * empty xml tags are not recognized as differences.
-   * @param {string} sampleCode the code to diff against the current project code
+   * @param {string} sampleCodeInput the code to diff against the current project code
    */
-  isCurrentCodeDifferent(sampleCode = '') {
+  isCurrentCodeDifferent(sampleCodeInput) {
+    // We can't use a default param here because we need to check for null and undefined
+    const sampleCode = sampleCodeInput || '';
     const currentCode = currentSources.source || '';
     let normalizedSample, normalizedCurrent;
     const parser = new DOMParser();

--- a/apps/test/unit/code-studio/initApp/projectTest.js
+++ b/apps/test/unit/code-studio/initApp/projectTest.js
@@ -987,6 +987,11 @@ describe('project.js', () => {
       expect(project.isCurrentCodeDifferent('')).to.be.false;
     });
 
+    it('compares null inputs as if they were an empty string', () => {
+      setSources({source: ''});
+      expect(project.isCurrentCodeDifferent(null)).to.be.false;
+    });
+
     it('compares unset input sources as if they were an empty string', () => {
       setSources({source: ''});
       expect(project.isCurrentCodeDifferent()).to.be.false;


### PR DESCRIPTION
This fixes a bug in auto-validate for levels that don't specify startBlocks.

Example level: https://studio.code.org/s/csd3-2020/stage/10/puzzle/3

Although we were checking for "undefined," we weren't checking for "null." Students would click the "finish" button and nothing would happen because the validation code would error.

[Zendesk Report](https://codeorg.zendesk.com/agent/tickets/299205)

<!--
  Other aspects to consider. uncomment and add detail for any that seem necessary:
-->

<!-- ### Background -->
<!-- ### Privacy -->
<!--
1.	Does the Project involve the collection, use or sharing of new Personal Data?

2.	Does the Project involve a new or changed use or sharing of existing Personal Data?
-->
<!-- ### Security -->
<!--
Link to Jira Task where sensitive security issues are discussed privately.
-->
<!-- ### Caching -->
<!-- ### Deployment strategy -->
<!-- ### Future work -->

## Links

<!--
  Any relevant links to external resources; ie, specification documents, jira
  items, related PRs, honeybadger errors, etc
-->


## Testing story

<!--
  Does your change include appropriate tests?

  If so, please describe how the tests included in this PR are sufficient

  If not, please explain why this change does not need to be tested.
-->

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
