### PR TITLE
omit NEW_LEVEL_ID when saving new script levels to the server

### DIFF
--- a/apps/src/lib/levelbuilder/lesson-editor/ActivitiesEditor.jsx
+++ b/apps/src/lib/levelbuilder/lesson-editor/ActivitiesEditor.jsx
@@ -4,7 +4,10 @@ import color from '@cdo/apps/util/color';
 import ActivityCard from '@cdo/apps/lib/levelbuilder/lesson-editor/ActivityCard';
 import Activity from '@cdo/apps/templates/lessonOverview/activities/Activity';
 import {connect} from 'react-redux';
-import {addActivity} from '@cdo/apps/lib/levelbuilder/lesson-editor/activitiesEditorRedux';
+import {
+  addActivity,
+  NEW_LEVEL_ID
+} from '@cdo/apps/lib/levelbuilder/lesson-editor/activitiesEditorRedux';
 import _ from 'lodash';
 
 const styles = {
@@ -101,6 +104,12 @@ class ActivitiesEditor extends Component {
         delete activitySection.text;
 
         activitySection.scriptLevels.forEach(scriptLevel => {
+          // The server expects id to be absent if a new script level is to be
+          // created.
+          if (scriptLevel.id === NEW_LEVEL_ID) {
+            delete scriptLevel.id;
+          }
+
           // The position within the activity section
           scriptLevel.activitySectionPosition = scriptLevel.position;
 


### PR DESCRIPTION
Quick follow-up to #37157. Makes it so that newly-added levels can be saved to the server.

## Testing story

Not covered yet. I will follow up with a UI test.

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
