### PR TITLE
Rename AddResourceDialog to FindResourceDialog

### DIFF
--- a/apps/src/lib/levelbuilder/lesson-editor/ActivitySectionCardButtons.jsx
+++ b/apps/src/lib/levelbuilder/lesson-editor/ActivitySectionCardButtons.jsx
@@ -2,7 +2,7 @@ import React, {Component} from 'react';
 import PropTypes from 'prop-types';
 import AddLevelDialog from '@cdo/apps/lib/levelbuilder/lesson-editor/AddLevelDialog';
 import LessonTipIconWithTooltip from '@cdo/apps/lib/levelbuilder/lesson-editor/LessonTipIconWithTooltip';
-import AddResourceDialog from '@cdo/apps/lib/levelbuilder/lesson-editor/AddResourceDialog';
+import FindResourceDialog from '@cdo/apps/lib/levelbuilder/lesson-editor/FindResourceDialog';
 import EditTipDialog from '@cdo/apps/lib/levelbuilder/lesson-editor/EditTipDialog';
 import {activitySectionShape} from '@cdo/apps/lib/levelbuilder/shapes';
 import {connect} from 'react-redux';
@@ -165,7 +165,7 @@ class ActivitySectionCardButtons extends Component {
             </span>
           )}
         </div>
-        <AddResourceDialog
+        <FindResourceDialog
           isOpen={this.state.addResourceOpen}
           handleConfirm={this.handleCloseAddResource}
         />

--- a/apps/src/lib/levelbuilder/lesson-editor/FindResourceDialog.jsx
+++ b/apps/src/lib/levelbuilder/lesson-editor/FindResourceDialog.jsx
@@ -15,7 +15,7 @@ const styles = {
 
 // TODO: Hook up adding a resource when resources are associated with lessons
 
-export default class AddResourceDialog extends Component {
+export default class FindResourceDialog extends Component {
   static propTypes = {
     isOpen: PropTypes.bool.isRequired,
     handleConfirm: PropTypes.func.isRequired

--- a/apps/test/unit/lib/levelbuilder/lesson-editor/ActivitySectionCardButtonsTest.jsx
+++ b/apps/test/unit/lib/levelbuilder/lesson-editor/ActivitySectionCardButtonsTest.jsx
@@ -24,7 +24,7 @@ describe('ActivitySectionCardButtons', () => {
   it('renders default props', () => {
     const wrapper = shallow(<ActivitySectionCardButtons {...defaultProps} />);
     expect(wrapper.find('button').length).to.equal(3);
-    expect(wrapper.find('AddResourceDialog').length).to.equal(1);
+    expect(wrapper.find('FindResourceDialog').length).to.equal(1);
     expect(wrapper.find('AddLevelDialog').length).to.equal(1);
     expect(wrapper.find('LessonTipIconWithTooltip').length).to.equal(2);
     // Don't render this component until add tip button or tip icon are clicked

--- a/apps/test/unit/lib/levelbuilder/lesson-editor/FindResourceDialogTest.jsx
+++ b/apps/test/unit/lib/levelbuilder/lesson-editor/FindResourceDialogTest.jsx
@@ -1,10 +1,10 @@
 import React from 'react';
 import {shallow} from 'enzyme';
 import {expect} from '../../../../util/reconfiguredChai';
-import AddResourceDialog from '@cdo/apps/lib/levelbuilder/lesson-editor/AddResourceDialog';
+import FindResourceDialog from '@cdo/apps/lib/levelbuilder/lesson-editor/FindResourceDialog';
 import sinon from 'sinon';
 
-describe('AddResourceDialog', () => {
+describe('FindResourceDialog', () => {
   let defaultProps;
   beforeEach(() => {
     defaultProps = {
@@ -14,7 +14,7 @@ describe('AddResourceDialog', () => {
   });
 
   it('renders default props', () => {
-    const wrapper = shallow(<AddResourceDialog {...defaultProps} />);
+    const wrapper = shallow(<FindResourceDialog {...defaultProps} />);
     expect(wrapper.contains('Add Resource')).to.be.true;
     expect(wrapper.find('BaseDialog').length).to.equal(1);
     expect(wrapper.find('select').length).to.equal(1);


### PR DESCRIPTION
https://github.com/code-dot-org/code-dot-org/pull/37280/files#r508843745

I wasn't sure what to name this that was descriptive but also concise, so I picked `FindResourceDialog`. Definitely open to other names.


<!-- ### Background -->
<!-- ### Privacy -->
<!--
1.	Does the Project involve the collection, use or sharing of new Personal Data?

2.	Does the Project involve a new or changed use or sharing of existing Personal Data?
-->
<!-- ### Security -->
<!--
Link to Jira Task where sensitive security issues are discussed privately.
-->
<!-- ### Caching -->
<!-- ### Deployment strategy -->
<!-- ### Future work -->

## Links

<!--
  Any relevant links to external resources; ie, specification documents, jira
  items, related PRs, honeybadger errors, etc
-->

- [spec]()
- [jira]()

## Testing story

<!--
  Does your change include appropriate tests?

  If so, please describe how the tests included in this PR are sufficient

  If not, please explain why this change does not need to be tested.
-->

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
