### PR TITLE
Fixing blank volunteer name

### DIFF
--- a/pegasus/sites.v3/code.org/public/js/volunteer-local.js
+++ b/pegasus/sites.v3/code.org/public/js/volunteer-local.js
@@ -152,12 +152,7 @@ function getLocations(results) {
       var id = volunteers[index].id;
       var html = compileHTML(index, volunteers[index]);
       var contact_title = compileContact(index, volunteers[index]);
-      var contact_link =
-        '<a id="contact-trigger-' +
-        index +
-        '" class="contact-trigger" onclick="return contactVolunteer(' +
-        id +
-        ')">Contact</a>';
+      var contact_link = `<a id="contact-trigger-${index}" class="contact-trigger" onclick="return contactVolunteer(${id}, '${title}')">Contact</a>`;
 
       var location = {
         lat: lat,
@@ -586,7 +581,8 @@ function compileContact(index, location) {
 }
 
 /* eslint-disable no-unused-vars */
-function contactVolunteer(id) {
+function contactVolunteer(id, name) {
+  $("#name").text(name);
   $("#name").show();
   $("#volunteer-contact").show();
   $("#success-message").hide();


### PR DESCRIPTION
*bug* - On https://code.org/volunteer/local , when someone clicks "Contact" in order to contact a volunteer, the volunteer's name is blank in the contact Form.
*cause* - During some recent refactoring of this page, the name was accidentally removed.
*fix* - Pass the volunteer's name to the form.

## Links
- [jira](https://codedotorg.atlassian.net/browse/FND-1325)

## Testing story
* Manually tested on http://localhost.code.org:3000/volunteer/local

## Screenshot
Note that "Dayne Wagner" is visible. Before this PR, it was blank.
![image](https://user-images.githubusercontent.com/1372238/96793902-c1d36b80-13ec-11eb-95c2-aa58e1463bf9.png)


# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
