### PR TITLE
[Levelbuilder] Fix JS errors on level edit page

### DIFF
--- a/apps/Gruntfile.js
+++ b/apps/Gruntfile.js
@@ -582,6 +582,8 @@ describe('entry tests', () => {
     'levels/editors/_craft':
       './src/sites/studio/pages/levels/editors/_craft.js',
     'levels/editors/_dsl': './src/sites/studio/pages/levels/editors/_dsl.js',
+    'levels/editors/fields/_animation':
+      './src/sites/studio/pages/levels/editors/fields/_animation.js',
     'levels/editors/fields/_blockly':
       './src/sites/studio/pages/levels/editors/fields/_blockly.js',
     'levels/editors/fields/_callouts':

--- a/apps/src/p5lab/spritelab/blocks.js
+++ b/apps/src/p5lab/spritelab/blocks.js
@@ -485,6 +485,7 @@ export default {
         // blocks, disallow editing the behavior, because renaming the behavior
         // can break things.
         if (
+          appOptions && // appOptions is not available on level edit page
           appOptions.level.toolbox &&
           !appOptions.readonlyWorkspace &&
           !Blockly.hasCategories

--- a/apps/src/p5lab/spritelab/blocks.js
+++ b/apps/src/p5lab/spritelab/blocks.js
@@ -626,6 +626,7 @@ export default {
     // blockInstallOptions is undefined.
     if (
       !blockInstallOptions ||
+      !blockInstallOptions.level ||
       blockInstallOptions.level.editBlocks !== TOOLBOX_EDIT_MODE
     ) {
       Blockly.Flyout.configure(Blockly.BlockValueType.BEHAVIOR, {

--- a/apps/src/sites/studio/pages/levels/editors/_gamelab.js
+++ b/apps/src/sites/studio/pages/levels/editors/_gamelab.js
@@ -38,7 +38,4 @@ $(document).ready(function() {
   if (document.getElementById('level_custom_helper_library')) {
     initializeCodeMirror('level_custom_helper_library', 'javascript');
   }
-  if (document.getElementById('level_validation_code')) {
-    initializeCodeMirror('level_validation_code', 'javascript');
-  }
 });

--- a/apps/src/sites/studio/pages/levels/editors/_gamelab.js
+++ b/apps/src/sites/studio/pages/levels/editors/_gamelab.js
@@ -1,40 +1,8 @@
 /** @file JavaScript run only on the gamelab level edit page. */
 import $ from 'jquery';
 import initializeCodeMirror from '@cdo/apps/code-studio/initializeCodeMirror';
-import {throwIfSerializedAnimationListIsInvalid} from '@cdo/apps/p5lab/shapes';
-
-const VALID_COLOR = 'black';
-const INVALID_COLOR = '#d00';
 
 $(document).ready(function() {
-  // Live-validate animations JSON using same validation code we use in Gamelab
-  const levelStartAnimationsValidationDiv = $(
-    '#level-start-animations-validation'
-  );
-  const validateAnimationJSON = function(json) {
-    json = json.trim();
-    try {
-      if (json.length > 0) {
-        const animationList = JSON.parse(json);
-        throwIfSerializedAnimationListIsInvalid(animationList);
-      }
-      levelStartAnimationsValidationDiv.text('Animations JSON appears valid.');
-      levelStartAnimationsValidationDiv.css('color', VALID_COLOR);
-    } catch (err) {
-      levelStartAnimationsValidationDiv.text(err.toString());
-      levelStartAnimationsValidationDiv.css('color', INVALID_COLOR);
-    }
-  };
-  // Run validation at start, and then on every codeMirror change
-  validateAnimationJSON(
-    document.getElementById('level_start_animations').value
-  );
-  initializeCodeMirror('level_start_animations', 'json', {
-    callback: codeMirror => {
-      validateAnimationJSON(codeMirror.getValue());
-    }
-  });
-
   if (document.getElementById('level_custom_helper_library')) {
     initializeCodeMirror('level_custom_helper_library', 'javascript');
   }

--- a/apps/src/sites/studio/pages/levels/editors/fields/_animation.js
+++ b/apps/src/sites/studio/pages/levels/editors/fields/_animation.js
@@ -1,0 +1,40 @@
+import $ from 'jquery';
+import initializeCodeMirror from '@cdo/apps/code-studio/initializeCodeMirror';
+import {throwIfSerializedAnimationListIsInvalid} from '@cdo/apps/p5lab/shapes';
+
+const VALID_COLOR = 'black';
+const INVALID_COLOR = '#d00';
+
+$(document).ready(function() {
+  // Live-validate animations JSON using same validation code we use in Gamelab
+  const levelStartAnimationsValidationDiv = $(
+    '#level-start-animations-validation'
+  );
+  const validateAnimationJSON = function(json) {
+    json = json.trim();
+    try {
+      if (json.length > 0) {
+        const animationList = JSON.parse(json);
+        throwIfSerializedAnimationListIsInvalid(animationList);
+      }
+      levelStartAnimationsValidationDiv.text('Animations JSON appears valid.');
+      levelStartAnimationsValidationDiv.css('color', VALID_COLOR);
+    } catch (err) {
+      levelStartAnimationsValidationDiv.text(err.toString());
+      levelStartAnimationsValidationDiv.css('color', INVALID_COLOR);
+    }
+  };
+  // Run validation at start, and then on every codeMirror change
+  validateAnimationJSON(
+    document.getElementById('level_start_animations').value
+  );
+  initializeCodeMirror('level_start_animations', 'application/json', {
+    callback: codeMirror => {
+      validateAnimationJSON(codeMirror.getValue());
+    }
+  });
+
+  if (document.getElementById('level_custom_helper_library')) {
+    initializeCodeMirror('level_custom_helper_library', 'javascript');
+  }
+});

--- a/apps/src/sites/studio/pages/levels/editors/fields/_blockly.js
+++ b/apps/src/sites/studio/pages/levels/editors/fields/_blockly.js
@@ -9,8 +9,26 @@ const data = getScriptData('pageOptions');
 if (window.Blockly && !data.uses_droplet) {
   window.Blockly.assetUrl = path => `/assets/${path}`;
   Blockly.Css.inject(document);
-  const appBlocks = require('@cdo/apps/' + data.app + '/blocks');
-  const skinsModule = require('@cdo/apps/' + data.app + '/skins');
+  let blocksLocation = data.app;
+  if (data.app === 'spritelab') {
+    blocksLocation = 'p5lab/spritelab';
+  }
+  const appBlocks = require('@cdo/apps/' + blocksLocation + '/blocks');
+  let skinsLocation = '';
+  const customSkins = [
+    'applab',
+    'bounce',
+    'flappy',
+    'jigsaw',
+    'maze',
+    'netsim',
+    'studio',
+    'turtle'
+  ];
+  if (customSkins.includes(data.app)) {
+    skinsLocation = data.app + '/';
+  }
+  const skinsModule = require('@cdo/apps/' + skinsLocation + 'skins');
   const options = {
     skin: skinsModule.load(function() {}, data.skin_id),
     isK1: data.isK1
@@ -67,6 +85,10 @@ Object.keys(fieldConfig).forEach(key => {
   }
   const mode =
     config.codemirrorMode || (data.uses_droplet ? 'javascript' : 'xml');
+  const element = document.getElementById(config.codemirror);
+  if (!element) {
+    return;
+  }
   config.editor = initializeCodeMirror(config.codemirror, mode);
   if (config.blockPreview && !data.uses_droplet) {
     initializeBlockPreview(

--- a/apps/src/sites/studio/pages/levels/editors/fields/_validation_code.js
+++ b/apps/src/sites/studio/pages/levels/editors/fields/_validation_code.js
@@ -1,4 +1,5 @@
 import $ from 'jquery';
+import initializeCodeMirror from '@cdo/apps/code-studio/initializeCodeMirror';
 
 $(initPage);
 
@@ -9,6 +10,9 @@ function initPage() {
   if (autoValidate.length > 0) {
     embed.on('click', () => syncValidateWithElements(embed, widgetMode));
     widgetMode.on('click', () => syncValidateWithElements(embed, widgetMode));
+  }
+  if (document.getElementById('level_validation_code')) {
+    initializeCodeMirror('level_validation_code', 'javascript');
   }
 }
 

--- a/apps/src/sites/studio/pages/levels/editors/fields/_validation_code.js
+++ b/apps/src/sites/studio/pages/levels/editors/fields/_validation_code.js
@@ -11,7 +11,7 @@ function initPage() {
     embed.on('click', () => syncValidateWithElements(embed, widgetMode));
     widgetMode.on('click', () => syncValidateWithElements(embed, widgetMode));
   }
-  if (document.getElementById('level_validation_code')) {
+  if ($('#level_validation_code')) {
     initializeCodeMirror('level_validation_code', 'javascript');
   }
 }

--- a/dashboard/app/views/levels/editors/fields/_animation.html.haml
+++ b/dashboard/app/views/levels/editors/fields/_animation.html.haml
@@ -4,6 +4,7 @@
       padding: 0.2em;
       font-weight: bold;
     }
+  %script{src: webpack_asset_path('js/levels/editors/fields/_animation.js')}
 
 %h1.control-legend{data: {toggle: "collapse", target: "#animations"}}
   Animations


### PR DESCRIPTION
JS Errors on the level edit page were preventing some of the code mirrors from loading properly. Also adds a code mirror for the validation code and animation JSON text boxes. This formatting already existed for gamelab levels, but since the same fields exists in spritelab and dancelab levels, I moved the logic out of _gamelab.js and into the field-specific files. 
Before:
![image](https://user-images.githubusercontent.com/8787187/96800340-f2e67880-13b9-11eb-911c-24783a7e6e6c.png)
![image](https://user-images.githubusercontent.com/8787187/96800425-30e39c80-13ba-11eb-93ea-0357b6fbd7ea.png)
![image](https://user-images.githubusercontent.com/8787187/96908555-a64e7c00-1451-11eb-81d5-47251d9674c2.png)


After:
![image](https://user-images.githubusercontent.com/8787187/96800309-db0ef480-13b9-11eb-8a7d-976ea4002569.png)
![image](https://user-images.githubusercontent.com/8787187/96800415-26c19e00-13ba-11eb-9e21-2c62a957e7a3.png)
![image](https://user-images.githubusercontent.com/8787187/96908531-a0f13180-1451-11eb-83d1-44d23d63217c.png)
