### PR TITLE
Fix drag and drop to allow moving levels to other activity sections

### DIFF
--- a/apps/src/lib/levelbuilder/lesson-editor/ActivitiesEditor.jsx
+++ b/apps/src/lib/levelbuilder/lesson-editor/ActivitiesEditor.jsx
@@ -102,6 +102,26 @@ class ActivitiesEditor extends Component {
     });
   };
 
+  // Given a clientY value of a location on the screen, find the ActivitySectionCard
+  // corresponding to that location, and update targetActivitySectionPos to match.
+  updateTargetActivitySection = y => {
+    const activitySectionPos = Object.keys(this.activitySectionMetrics).find(
+      activitySectionPos => {
+        const activitySectionRect = this.activitySectionMetrics[
+          activitySectionPos
+        ];
+        return (
+          y > activitySectionRect.top &&
+          y < activitySectionRect.top + activitySectionRect.height
+        );
+      }
+    );
+    const targetActivitySectionPos = activitySectionPos
+      ? Number(activitySectionPos)
+      : null;
+    this.setTargetActivitySection(targetActivitySectionPos);
+  };
+
   // Serialize the activities into JSON, renaming any keys which are different
   // on the backend.
   serializeActivities = () => {
@@ -150,7 +170,7 @@ class ActivitiesEditor extends Component {
               activitiesCount={activities.length}
               key={activity.key}
               setActivitySectionRef={this.setActivitySectionRef}
-              setTargetActivitySection={this.setTargetActivitySection}
+              updateTargetActivitySection={this.updateTargetActivitySection}
               targetActivitySectionPos={this.state.targetActivitySectionPos}
               activitySectionMetrics={this.activitySectionMetrics}
               updateActivitySectionMetrics={this.updateActivitySectionMetrics}

--- a/apps/src/lib/levelbuilder/lesson-editor/ActivitiesEditor.jsx
+++ b/apps/src/lib/levelbuilder/lesson-editor/ActivitiesEditor.jsx
@@ -9,6 +9,7 @@ import {
   NEW_LEVEL_ID
 } from '@cdo/apps/lib/levelbuilder/lesson-editor/activitiesEditorRedux';
 import _ from 'lodash';
+import ReactDOM from 'react-dom';
 
 const styles = {
   activityEditAndPreview: {
@@ -81,11 +82,24 @@ class ActivitiesEditor extends Component {
     this.setState({targetActivitySectionPos});
   };
 
-  // To be populated with the bounding client rect of each ActivitySectionCard element.
-  activitySectionMetrics = {};
+  // To be populated with the react ref of each ActivitySectionCard element.
+  activitySectionRefs = [];
 
-  setActivitySectionMetrics = (metrics, activitySectionPosition) => {
-    this.activitySectionMetrics[activitySectionPosition] = metrics;
+  setActivitySectionRef = (activitySectionRef, activitySectionPosition) => {
+    this.activitySectionRefs[activitySectionPosition] = activitySectionRef;
+  };
+
+  // To be populated with the bounding client rect of each ActivitySectionCard element.
+  activitySectionMetrics = [];
+
+  // populate activitySectionMetrics from activitySectionRefs.
+  updateActivitySectionMetrics = () => {
+    this.activitySectionMetrics = [];
+    this.activitySectionRefs.forEach((ref, position) => {
+      const node = ReactDOM.findDOMNode(ref);
+      const rect = !!node && node.getBoundingClientRect();
+      this.activitySectionMetrics[position] = rect;
+    });
   };
 
   // Serialize the activities into JSON, renaming any keys which are different
@@ -135,10 +149,11 @@ class ActivitiesEditor extends Component {
               activity={activity}
               activitiesCount={activities.length}
               key={activity.key}
-              setActivitySectionMetrics={this.setActivitySectionMetrics}
+              setActivitySectionRef={this.setActivitySectionRef}
               setTargetActivitySection={this.setTargetActivitySection}
               targetActivitySectionPos={this.state.targetActivitySectionPos}
               activitySectionMetrics={this.activitySectionMetrics}
+              updateActivitySectionMetrics={this.updateActivitySectionMetrics}
             />
           ))}
           <button

--- a/apps/src/lib/levelbuilder/lesson-editor/ActivitiesEditor.jsx
+++ b/apps/src/lib/levelbuilder/lesson-editor/ActivitiesEditor.jsx
@@ -78,10 +78,6 @@ class ActivitiesEditor extends Component {
     return `activity-${activityNumber}`;
   };
 
-  setTargetActivitySection = targetActivitySectionPos => {
-    this.setState({targetActivitySectionPos});
-  };
-
   // To be populated with the react ref of each ActivitySectionCard element.
   activitySectionRefs = [];
 
@@ -106,20 +102,15 @@ class ActivitiesEditor extends Component {
   // corresponding to that location, and update targetActivitySectionPos to match.
   updateTargetActivitySection = y => {
     const activitySectionPos = Object.keys(this.activitySectionMetrics).find(
-      activitySectionPos => {
-        const activitySectionRect = this.activitySectionMetrics[
-          activitySectionPos
-        ];
-        return (
-          y > activitySectionRect.top &&
-          y < activitySectionRect.top + activitySectionRect.height
-        );
+      sectionPos => {
+        const rect = this.activitySectionMetrics[sectionPos];
+        return y > rect.top && y < rect.top + rect.height;
       }
     );
     const targetActivitySectionPos = activitySectionPos
       ? Number(activitySectionPos)
       : null;
-    this.setTargetActivitySection(targetActivitySectionPos);
+    this.setState({targetActivitySectionPos});
   };
 
   // Serialize the activities into JSON, renaming any keys which are different

--- a/apps/src/lib/levelbuilder/lesson-editor/ActivitiesEditor.jsx
+++ b/apps/src/lib/levelbuilder/lesson-editor/ActivitiesEditor.jsx
@@ -82,8 +82,9 @@ class ActivitiesEditor extends Component {
   // To be populated with the react ref of each ActivitySectionCard element.
   sectionRefs = [];
 
-  setActivitySectionRef = (sectionRef, sectionPos) => {
-    this.sectionRefs[sectionPos] = sectionRef;
+  setActivitySectionRef = (sectionRef, activityPos, sectionPos) => {
+    this.sectionRefs[activityPos] = this.sectionRefs[activityPos] || [];
+    this.sectionRefs[activityPos][sectionPos] = sectionRef;
   };
 
   // To be populated with the bounding client rect of each ActivitySectionCard element.
@@ -92,10 +93,14 @@ class ActivitiesEditor extends Component {
   // populate sectionMetrics from sectionRefs.
   updateActivitySectionMetrics = () => {
     this.sectionMetrics = [];
-    this.sectionRefs.forEach((ref, position) => {
-      const node = ReactDOM.findDOMNode(ref);
-      const rect = !!node && node.getBoundingClientRect();
-      this.sectionMetrics[position] = rect;
+    this.sectionRefs.forEach((sectionRefs, activityPos) => {
+      sectionRefs.forEach((ref, sectionPos) => {
+        const node = ReactDOM.findDOMNode(ref);
+        const rect = !!node && node.getBoundingClientRect();
+        this.sectionMetrics[activityPos] =
+          this.sectionMetrics[activityPos] || [];
+        this.sectionMetrics[activityPos][sectionPos] = rect;
+      });
     });
   };
 
@@ -103,12 +108,16 @@ class ActivitiesEditor extends Component {
   // and ActivitySectionCard corresponding to that location, and update
   // targetActivityPos and targetActivitySectionPos to match.
   updateTargetActivitySection = y => {
-    const sectionPos = Object.keys(this.sectionMetrics).find(sectionPos => {
-      const rect = this.sectionMetrics[sectionPos];
-      return y > rect.top && y < rect.top + rect.height;
+    this.sectionMetrics.forEach((sectionMetrics, activityPos) => {
+      sectionMetrics.forEach((rect, sectionPos) => {
+        if (y > rect.top && y < rect.top + rect.height) {
+          this.setState({
+            targetActivityPos: activityPos,
+            targetActivitySectionPos: sectionPos
+          });
+        }
+      });
     });
-    const targetActivitySectionPos = sectionPos ? Number(sectionPos) : null;
-    this.setState({targetActivitySectionPos});
   };
 
   // Serialize the activities into JSON, renaming any keys which are different

--- a/apps/src/lib/levelbuilder/lesson-editor/ActivitiesEditor.jsx
+++ b/apps/src/lib/levelbuilder/lesson-editor/ActivitiesEditor.jsx
@@ -54,6 +54,7 @@ class ActivitiesEditor extends Component {
     super(props);
 
     this.state = {
+      targetActivityPos: null,
       targetActivitySectionPos: null
     };
   }
@@ -79,37 +80,34 @@ class ActivitiesEditor extends Component {
   };
 
   // To be populated with the react ref of each ActivitySectionCard element.
-  activitySectionRefs = [];
+  sectionRefs = [];
 
-  setActivitySectionRef = (activitySectionRef, activitySectionPosition) => {
-    this.activitySectionRefs[activitySectionPosition] = activitySectionRef;
+  setActivitySectionRef = (sectionRef, sectionPos) => {
+    this.sectionRefs[sectionPos] = sectionRef;
   };
 
   // To be populated with the bounding client rect of each ActivitySectionCard element.
-  activitySectionMetrics = [];
+  sectionMetrics = [];
 
-  // populate activitySectionMetrics from activitySectionRefs.
+  // populate sectionMetrics from sectionRefs.
   updateActivitySectionMetrics = () => {
-    this.activitySectionMetrics = [];
-    this.activitySectionRefs.forEach((ref, position) => {
+    this.sectionMetrics = [];
+    this.sectionRefs.forEach((ref, position) => {
       const node = ReactDOM.findDOMNode(ref);
       const rect = !!node && node.getBoundingClientRect();
-      this.activitySectionMetrics[position] = rect;
+      this.sectionMetrics[position] = rect;
     });
   };
 
-  // Given a clientY value of a location on the screen, find the ActivitySectionCard
-  // corresponding to that location, and update targetActivitySectionPos to match.
+  // Given a clientY value of a location on the screen, find the ActivityCard
+  // and ActivitySectionCard corresponding to that location, and update
+  // targetActivityPos and targetActivitySectionPos to match.
   updateTargetActivitySection = y => {
-    const activitySectionPos = Object.keys(this.activitySectionMetrics).find(
-      sectionPos => {
-        const rect = this.activitySectionMetrics[sectionPos];
-        return y > rect.top && y < rect.top + rect.height;
-      }
-    );
-    const targetActivitySectionPos = activitySectionPos
-      ? Number(activitySectionPos)
-      : null;
+    const sectionPos = Object.keys(this.sectionMetrics).find(sectionPos => {
+      const rect = this.sectionMetrics[sectionPos];
+      return y > rect.top && y < rect.top + rect.height;
+    });
+    const targetActivitySectionPos = sectionPos ? Number(sectionPos) : null;
     this.setState({targetActivitySectionPos});
   };
 
@@ -163,7 +161,7 @@ class ActivitiesEditor extends Component {
               setActivitySectionRef={this.setActivitySectionRef}
               updateTargetActivitySection={this.updateTargetActivitySection}
               targetActivitySectionPos={this.state.targetActivitySectionPos}
-              activitySectionMetrics={this.activitySectionMetrics}
+              activitySectionMetrics={this.sectionMetrics}
               updateActivitySectionMetrics={this.updateActivitySectionMetrics}
             />
           ))}

--- a/apps/src/lib/levelbuilder/lesson-editor/ActivitiesEditor.jsx
+++ b/apps/src/lib/levelbuilder/lesson-editor/ActivitiesEditor.jsx
@@ -169,6 +169,7 @@ class ActivitiesEditor extends Component {
               key={activity.key}
               setActivitySectionRef={this.setActivitySectionRef}
               updateTargetActivitySection={this.updateTargetActivitySection}
+              targetActivityPos={this.state.targetActivityPos}
               targetActivitySectionPos={this.state.targetActivitySectionPos}
               activitySectionMetrics={this.sectionMetrics}
               updateActivitySectionMetrics={this.updateActivitySectionMetrics}

--- a/apps/src/lib/levelbuilder/lesson-editor/ActivityCard.jsx
+++ b/apps/src/lib/levelbuilder/lesson-editor/ActivityCard.jsx
@@ -67,6 +67,7 @@ class ActivityCard extends Component {
     activitiesCount: PropTypes.number,
     setActivitySectionRef: PropTypes.func.isRequired,
     updateTargetActivitySection: PropTypes.func.isRequired,
+    targetActivityPos: PropTypes.number,
     targetActivitySectionPos: PropTypes.number,
     activitySectionMetrics: PropTypes.array.isRequired,
     updateActivitySectionMetrics: PropTypes.func,
@@ -200,6 +201,7 @@ class ActivityCard extends Component {
               updateTargetActivitySection={
                 this.props.updateTargetActivitySection
               }
+              targetActivityPos={this.props.targetActivityPos}
               targetActivitySectionPos={this.props.targetActivitySectionPos}
               updateActivitySectionMetrics={
                 this.props.updateActivitySectionMetrics

--- a/apps/src/lib/levelbuilder/lesson-editor/ActivityCard.jsx
+++ b/apps/src/lib/levelbuilder/lesson-editor/ActivityCard.jsx
@@ -190,7 +190,11 @@ class ActivityCard extends Component {
               activitySectionsCount={activity.activitySections.length}
               activitiesCount={this.props.activitiesCount}
               ref={ref => {
-                this.props.setActivitySectionRef(ref, section.position);
+                this.props.setActivitySectionRef(
+                  ref,
+                  activity.position,
+                  section.position
+                );
               }}
               activitySectionMetrics={this.props.activitySectionMetrics}
               updateTargetActivitySection={

--- a/apps/src/lib/levelbuilder/lesson-editor/ActivityCard.jsx
+++ b/apps/src/lib/levelbuilder/lesson-editor/ActivityCard.jsx
@@ -66,7 +66,7 @@ class ActivityCard extends Component {
     activity: activityShape,
     activitiesCount: PropTypes.number,
     setActivitySectionRef: PropTypes.func.isRequired,
-    setTargetActivitySection: PropTypes.func.isRequired,
+    updateTargetActivitySection: PropTypes.func.isRequired,
     targetActivitySectionPos: PropTypes.number,
     activitySectionMetrics: PropTypes.array.isRequired,
     updateActivitySectionMetrics: PropTypes.func,
@@ -193,7 +193,9 @@ class ActivityCard extends Component {
                 this.props.setActivitySectionRef(ref, section.position);
               }}
               activitySectionMetrics={this.props.activitySectionMetrics}
-              setTargetActivitySection={this.props.setTargetActivitySection}
+              updateTargetActivitySection={
+                this.props.updateTargetActivitySection
+              }
               targetActivitySectionPos={this.props.targetActivitySectionPos}
               updateActivitySectionMetrics={
                 this.props.updateActivitySectionMetrics

--- a/apps/src/lib/levelbuilder/lesson-editor/ActivityCard.jsx
+++ b/apps/src/lib/levelbuilder/lesson-editor/ActivityCard.jsx
@@ -12,7 +12,6 @@ import {
   removeActivity,
   updateActivityField
 } from '@cdo/apps/lib/levelbuilder/lesson-editor/activitiesEditorRedux';
-import ReactDOM from 'react-dom';
 import {activityShape} from '@cdo/apps/lib/levelbuilder/shapes';
 
 const styles = {
@@ -66,10 +65,11 @@ class ActivityCard extends Component {
   static propTypes = {
     activity: activityShape,
     activitiesCount: PropTypes.number,
-    setActivitySectionMetrics: PropTypes.func.isRequired,
+    setActivitySectionRef: PropTypes.func.isRequired,
     setTargetActivitySection: PropTypes.func.isRequired,
     targetActivitySectionPos: PropTypes.number,
-    activitySectionMetrics: PropTypes.object.isRequired,
+    activitySectionMetrics: PropTypes.array.isRequired,
+    updateActivitySectionMetrics: PropTypes.func,
 
     //redux
     addActivitySection: PropTypes.func,
@@ -189,20 +189,15 @@ class ActivityCard extends Component {
               activityPosition={activity.position}
               activitySectionsCount={activity.activitySections.length}
               activitiesCount={this.props.activitiesCount}
-              ref={activitySectionCard => {
-                if (activitySectionCard) {
-                  const metrics = ReactDOM.findDOMNode(
-                    activitySectionCard
-                  ).getBoundingClientRect();
-                  this.props.setActivitySectionMetrics(
-                    metrics,
-                    section.position
-                  );
-                }
+              ref={ref => {
+                this.props.setActivitySectionRef(ref, section.position);
               }}
               activitySectionMetrics={this.props.activitySectionMetrics}
               setTargetActivitySection={this.props.setTargetActivitySection}
               targetActivitySectionPos={this.props.targetActivitySectionPos}
+              updateActivitySectionMetrics={
+                this.props.updateActivitySectionMetrics
+              }
             />
           ))}
           <button

--- a/apps/src/lib/levelbuilder/lesson-editor/ActivityCard.jsx
+++ b/apps/src/lib/levelbuilder/lesson-editor/ActivityCard.jsx
@@ -70,7 +70,7 @@ class ActivityCard extends Component {
     targetActivityPos: PropTypes.number,
     targetActivitySectionPos: PropTypes.number,
     activitySectionMetrics: PropTypes.array.isRequired,
-    updateActivitySectionMetrics: PropTypes.func,
+    updateActivitySectionMetrics: PropTypes.func.isRequired,
 
     //redux
     addActivitySection: PropTypes.func,
@@ -139,7 +139,12 @@ class ActivityCard extends Component {
   };
 
   render() {
-    const {activity} = this.props;
+    const {
+      activity,
+      setActivitySectionRef,
+      updateTargetActivitySection,
+      updateActivitySectionMetrics
+    } = this.props;
 
     return (
       <div className="uitest-activity-card">
@@ -191,21 +196,13 @@ class ActivityCard extends Component {
               activitySectionsCount={activity.activitySections.length}
               activitiesCount={this.props.activitiesCount}
               ref={ref => {
-                this.props.setActivitySectionRef(
-                  ref,
-                  activity.position,
-                  section.position
-                );
+                setActivitySectionRef(ref, activity.position, section.position);
               }}
               activitySectionMetrics={this.props.activitySectionMetrics}
-              updateTargetActivitySection={
-                this.props.updateTargetActivitySection
-              }
+              updateTargetActivitySection={updateTargetActivitySection}
               targetActivityPos={this.props.targetActivityPos}
               targetActivitySectionPos={this.props.targetActivitySectionPos}
-              updateActivitySectionMetrics={
-                this.props.updateActivitySectionMetrics
-              }
+              updateActivitySectionMetrics={updateActivitySectionMetrics}
             />
           ))}
           <button

--- a/apps/src/lib/levelbuilder/lesson-editor/ActivitySectionCard.jsx
+++ b/apps/src/lib/levelbuilder/lesson-editor/ActivitySectionCard.jsx
@@ -88,9 +88,10 @@ class ActivitySectionCard extends Component {
     activityPosition: PropTypes.number,
     activitySectionsCount: PropTypes.number,
     activitiesCount: PropTypes.number,
-    activitySectionMetrics: PropTypes.object,
+    activitySectionMetrics: PropTypes.array,
     setTargetActivitySection: PropTypes.func,
     targetActivitySectionPos: PropTypes.number,
+    updateActivitySectionMetrics: PropTypes.func,
 
     //redux
     moveActivitySection: PropTypes.func,
@@ -127,13 +128,18 @@ class ActivitySectionCard extends Component {
           return metrics.top + metrics.height / 2;
         }
       );
-      this.setState({
-        draggedLevelPos: position,
-        dragHeight: this.metrics[position].height + tokenMargin,
-        initialClientY: clientY,
-        newPosition: position,
-        startingPositions
-      });
+      this.setState(
+        {
+          draggedLevelPos: position,
+          dragHeight: this.metrics[position].height + tokenMargin,
+          initialClientY: clientY,
+          newPosition: position,
+          startingPositions
+        },
+        () => {
+          this.props.updateActivitySectionMetrics();
+        }
+      );
       window.addEventListener('selectstart', this.preventSelect);
       window.addEventListener('mousemove', this.handleDrag);
       window.addEventListener('mouseup', this.handleDragStop);

--- a/apps/src/lib/levelbuilder/lesson-editor/ActivitySectionCard.jsx
+++ b/apps/src/lib/levelbuilder/lesson-editor/ActivitySectionCard.jsx
@@ -90,6 +90,7 @@ class ActivitySectionCard extends Component {
     activitiesCount: PropTypes.number,
     activitySectionMetrics: PropTypes.array,
     updateTargetActivitySection: PropTypes.func,
+    targetActivityPos: PropTypes.number,
     targetActivitySectionPos: PropTypes.number,
     updateActivitySectionMetrics: PropTypes.func,
 
@@ -178,9 +179,13 @@ class ActivitySectionCard extends Component {
     const {
       activitySection,
       activityPosition,
+      targetActivityPos,
       targetActivitySectionPos
     } = this.props;
-    if (targetActivitySectionPos === activitySection.position) {
+    if (
+      targetActivityPos === activityPosition &&
+      targetActivitySectionPos === activitySection.position
+    ) {
       // When dragging within a activitySection, reorder the level within that activitySection.
       if (this.state.draggedLevelPos !== this.state.newPosition) {
         this.props.reorderLevel(
@@ -190,12 +195,22 @@ class ActivitySectionCard extends Component {
           this.state.newPosition
         );
       }
-    } else if (targetActivitySectionPos) {
+    } else if (
+      targetActivityPos === activityPosition &&
+      targetActivitySectionPos
+    ) {
       // When dragging between activitySections, move it to the end of the new activitySection.
       this.props.moveLevelToActivitySection(
         activityPosition,
         activitySection.position,
         this.state.draggedLevelPos,
+        targetActivitySectionPos
+      );
+    } else if (targetActivityPos && targetActivitySectionPos) {
+      console.log(
+        'TODO: move to activity',
+        targetActivityPos,
+        'section',
         targetActivitySectionPos
       );
     }
@@ -318,11 +333,13 @@ class ActivitySectionCard extends Component {
   render() {
     const {
       activitySection,
+      targetActivityPos,
       targetActivitySectionPos,
       activityPosition
     } = this.props;
     const {draggedLevelPos, levelPosToRemove} = this.state;
     const isTargetActivitySection =
+      targetActivityPos === activityPosition &&
       targetActivitySectionPos === activitySection.position;
     return (
       <div

--- a/apps/src/lib/levelbuilder/lesson-editor/ActivitySectionCard.jsx
+++ b/apps/src/lib/levelbuilder/lesson-editor/ActivitySectionCard.jsx
@@ -89,7 +89,7 @@ class ActivitySectionCard extends Component {
     activitySectionsCount: PropTypes.number,
     activitiesCount: PropTypes.number,
     activitySectionMetrics: PropTypes.array,
-    setTargetActivitySection: PropTypes.func,
+    updateTargetActivitySection: PropTypes.func,
     targetActivitySectionPos: PropTypes.number,
     updateActivitySectionMetrics: PropTypes.func,
 
@@ -171,25 +171,7 @@ class ActivitySectionCard extends Component {
       }
     );
     this.setState({currentPositions, newPosition});
-    const targetActivitySectionPos = this.getTargetActivitySection(clientY);
-    this.props.setTargetActivitySection(targetActivitySectionPos);
-  };
-
-  // Given a clientY value of a location on the screen, find the ActivitySectionCard
-  // corresponding to that location, and return the position of the
-  // corresponding activity section within the script.
-  getTargetActivitySection = y => {
-    const {activitySectionMetrics} = this.props;
-    const activitySectionPos = Object.keys(activitySectionMetrics).find(
-      activitySectionPos => {
-        const activitySectionRect = activitySectionMetrics[activitySectionPos];
-        return (
-          y > activitySectionRect.top &&
-          y < activitySectionRect.top + activitySectionRect.height
-        );
-      }
-    );
-    return activitySectionPos ? Number(activitySectionPos) : null;
+    this.props.updateTargetActivitySection(clientY);
   };
 
   handleDragStop = () => {
@@ -217,7 +199,9 @@ class ActivitySectionCard extends Component {
         targetActivitySectionPos
       );
     }
-    this.props.setTargetActivitySection(null);
+
+    // shortcut to clear target activity section
+    this.props.updateTargetActivitySection(-1);
 
     this.setState({
       draggedLevelPos: null,

--- a/apps/src/lib/levelbuilder/lesson-editor/ActivitySectionCard.jsx
+++ b/apps/src/lib/levelbuilder/lesson-editor/ActivitySectionCard.jsx
@@ -88,11 +88,11 @@ class ActivitySectionCard extends Component {
     activityPosition: PropTypes.number,
     activitySectionsCount: PropTypes.number,
     activitiesCount: PropTypes.number,
-    activitySectionMetrics: PropTypes.array,
-    updateTargetActivitySection: PropTypes.func,
+    activitySectionMetrics: PropTypes.array.isRequired,
+    updateTargetActivitySection: PropTypes.func.isRequired,
     targetActivityPos: PropTypes.number,
     targetActivitySectionPos: PropTypes.number,
-    updateActivitySectionMetrics: PropTypes.func,
+    updateActivitySectionMetrics: PropTypes.func.isRequired,
 
     //redux
     moveActivitySection: PropTypes.func,
@@ -137,9 +137,7 @@ class ActivitySectionCard extends Component {
           newPosition: position,
           startingPositions
         },
-        () => {
-          this.props.updateActivitySectionMetrics();
-        }
+        () => this.props.updateActivitySectionMetrics()
       );
       window.addEventListener('selectstart', this.preventSelect);
       window.addEventListener('mousemove', this.handleDrag);

--- a/apps/src/lib/levelbuilder/lesson-editor/ActivitySectionCard.jsx
+++ b/apps/src/lib/levelbuilder/lesson-editor/ActivitySectionCard.jsx
@@ -195,22 +195,13 @@ class ActivitySectionCard extends Component {
           this.state.newPosition
         );
       }
-    } else if (
-      targetActivityPos === activityPosition &&
-      targetActivitySectionPos
-    ) {
+    } else if (targetActivityPos && targetActivitySectionPos) {
       // When dragging between activitySections, move it to the end of the new activitySection.
       this.props.moveLevelToActivitySection(
         activityPosition,
         activitySection.position,
         this.state.draggedLevelPos,
-        targetActivitySectionPos
-      );
-    } else if (targetActivityPos && targetActivitySectionPos) {
-      console.log(
-        'TODO: move to activity',
         targetActivityPos,
-        'section',
         targetActivitySectionPos
       );
     }

--- a/apps/src/lib/levelbuilder/lesson-editor/activitiesEditorRedux.js
+++ b/apps/src/lib/levelbuilder/lesson-editor/activitiesEditorRedux.js
@@ -485,11 +485,15 @@ function activities(state = [], action) {
       // add level to new activitySection
       let newActivityPosition = null;
       newState.forEach(activity => {
-        activity.activitySections.forEach(activitySection => {
-          if (activitySection.position === action.newActivitySectionPosition) {
-            newActivityPosition = activity.position;
-          }
-        });
+        if (activity.position === action.activityPosition) {
+          activity.activitySections.forEach(activitySection => {
+            if (
+              activitySection.position === action.newActivitySectionPosition
+            ) {
+              newActivityPosition = activity.position;
+            }
+          });
+        }
       });
       const newActivitySections =
         newState[newActivityPosition - 1].activitySections;

--- a/apps/src/lib/levelbuilder/lesson-editor/activitiesEditorRedux.js
+++ b/apps/src/lib/levelbuilder/lesson-editor/activitiesEditorRedux.js
@@ -195,12 +195,14 @@ export const moveLevelToActivitySection = (
   activityPosition,
   activitySectionPosition,
   scriptLevelPosition,
+  newActivityPosition,
   newActivitySectionPosition
 ) => ({
   type: MOVE_LEVEL_TO_ACTIVITY_SECTION,
   activityPosition,
   activitySectionPosition,
   scriptLevelPosition,
+  newActivityPosition,
   newActivitySectionPosition
 });
 
@@ -483,20 +485,8 @@ function activities(state = [], action) {
       updateScriptLevelPositions(scriptLevels);
 
       // add level to new activitySection
-      let newActivityPosition = null;
-      newState.forEach(activity => {
-        if (activity.position === action.activityPosition) {
-          activity.activitySections.forEach(activitySection => {
-            if (
-              activitySection.position === action.newActivitySectionPosition
-            ) {
-              newActivityPosition = activity.position;
-            }
-          });
-        }
-      });
       const newActivitySections =
-        newState[newActivityPosition - 1].activitySections;
+        newState[action.newActivityPosition - 1].activitySections;
       const newScriptLevels =
         newActivitySections[action.newActivitySectionPosition - 1].scriptLevels;
       newScriptLevels.push(scriptLevel);

--- a/apps/test/unit/lib/levelbuilder/lesson-editor/ActivityCardTest.jsx
+++ b/apps/test/unit/lib/levelbuilder/lesson-editor/ActivityCardTest.jsx
@@ -11,15 +11,15 @@ describe('ActivityCard', () => {
     removeActivity,
     moveActivity,
     updateActivityField,
-    setActivitySectionMetrics,
-    setTargetActivitySection;
+    setActivitySectionRef,
+    updateTargetActivitySection;
   beforeEach(() => {
     addActivitySection = sinon.spy();
     removeActivity = sinon.spy();
     moveActivity = sinon.spy();
     updateActivityField = sinon.spy();
-    setActivitySectionMetrics = sinon.spy();
-    setTargetActivitySection = sinon.spy();
+    setActivitySectionRef = sinon.spy();
+    updateTargetActivitySection = sinon.spy();
     defaultProps = {
       activity: sampleActivities[0],
       activitiesCount: 1,
@@ -27,10 +27,10 @@ describe('ActivityCard', () => {
       removeActivity,
       moveActivity,
       updateActivityField,
-      setActivitySectionMetrics,
-      setTargetActivitySection,
+      setActivitySectionRef,
+      updateTargetActivitySection,
       targetActivitySectionPos: 1,
-      activitySectionMetrics: {}
+      activitySectionMetrics: []
     };
   });
 

--- a/apps/test/unit/lib/levelbuilder/lesson-editor/ActivityCardTest.jsx
+++ b/apps/test/unit/lib/levelbuilder/lesson-editor/ActivityCardTest.jsx
@@ -12,7 +12,8 @@ describe('ActivityCard', () => {
     moveActivity,
     updateActivityField,
     setActivitySectionRef,
-    updateTargetActivitySection;
+    updateTargetActivitySection,
+    updateActivitySectionMetrics;
   beforeEach(() => {
     addActivitySection = sinon.spy();
     removeActivity = sinon.spy();
@@ -20,6 +21,7 @@ describe('ActivityCard', () => {
     updateActivityField = sinon.spy();
     setActivitySectionRef = sinon.spy();
     updateTargetActivitySection = sinon.spy();
+    updateActivitySectionMetrics = sinon.spy();
     defaultProps = {
       activity: sampleActivities[0],
       activitiesCount: 1,
@@ -29,6 +31,7 @@ describe('ActivityCard', () => {
       updateActivityField,
       setActivitySectionRef,
       updateTargetActivitySection,
+      updateActivitySectionMetrics,
       targetActivitySectionPos: 1,
       activitySectionMetrics: []
     };

--- a/apps/test/unit/lib/levelbuilder/lesson-editor/ActivitySectionCardTest.jsx
+++ b/apps/test/unit/lib/levelbuilder/lesson-editor/ActivitySectionCardTest.jsx
@@ -27,7 +27,7 @@ describe('ActivitySectionCard', () => {
       activityPosition: 1,
       activitySectionsCount: 3,
       activitiesCount: 1,
-      activitySectionMetrics: {},
+      activitySectionMetrics: [],
       setTargetActivitySection,
       targetActivitySectionPos: 1,
 

--- a/apps/test/unit/lib/levelbuilder/lesson-editor/ActivitySectionCardTest.jsx
+++ b/apps/test/unit/lib/levelbuilder/lesson-editor/ActivitySectionCardTest.jsx
@@ -8,6 +8,8 @@ import {sampleActivities} from './activitiesTestData';
 describe('ActivitySectionCard', () => {
   let defaultProps,
     setTargetActivitySection,
+    updateTargetActivitySection,
+    updateActivitySectionMetrics,
     moveActivitySection,
     removeActivitySection,
     updateActivitySectionField,
@@ -16,6 +18,8 @@ describe('ActivitySectionCard', () => {
     addLevel;
   beforeEach(() => {
     setTargetActivitySection = sinon.spy();
+    updateTargetActivitySection = sinon.spy();
+    updateActivitySectionMetrics = sinon.spy();
     moveActivitySection = sinon.spy();
     removeActivitySection = sinon.spy();
     updateActivitySectionField = sinon.spy();
@@ -28,6 +32,8 @@ describe('ActivitySectionCard', () => {
       activitySectionsCount: 3,
       activitiesCount: 1,
       activitySectionMetrics: [],
+      updateTargetActivitySection,
+      updateActivitySectionMetrics,
       setTargetActivitySection,
       targetActivitySectionPos: 1,
 

--- a/apps/test/unit/lib/levelbuilder/lesson-editor/activitiesEditorReduxTest.js
+++ b/apps/test/unit/lib/levelbuilder/lesson-editor/activitiesEditorReduxTest.js
@@ -27,7 +27,7 @@ import _ from 'lodash';
 
 const getInitialState = () => ({
   levelKeyList: {},
-  activities: sampleActivities
+  activities: _.cloneDeep(sampleActivities)
 });
 
 const reducer = combineReducers(reducers);

--- a/apps/test/unit/lib/levelbuilder/lesson-editor/activitiesEditorReduxTest.js
+++ b/apps/test/unit/lib/levelbuilder/lesson-editor/activitiesEditorReduxTest.js
@@ -94,6 +94,25 @@ describe('activitiesEditorRedux reducer tests', () => {
     });
 
     it('moves level to activitySection', () => {
+      initialState.activities.push({
+        key: 'activity-2',
+        displayName: 'Second Activity',
+        position: 2,
+        duration: 30,
+        activitySections: [
+          {
+            key: 'section-4',
+            position: 1,
+            displayName: 'Making drawings',
+            remarks: true,
+            slide: false,
+            scriptLevels: [],
+            text: 'Drawing text',
+            tips: []
+          }
+        ]
+      });
+
       const nextState = reducer(
         initialState,
         moveLevelToActivitySection(1, 3, 2, 2)

--- a/apps/test/unit/lib/levelbuilder/lesson-editor/activitiesEditorReduxTest.js
+++ b/apps/test/unit/lib/levelbuilder/lesson-editor/activitiesEditorReduxTest.js
@@ -141,6 +141,44 @@ describe('activitiesEditorRedux reducer tests', () => {
         );
         assert.deepEqual([[], [2], [1]], levelIdsBySection);
       });
+
+      it('moves level to activitySection in a different activity', () => {
+        const oldActivities = initialState.activities;
+        let levelIdsBySection = oldActivities[0].activitySections.map(section =>
+          section.scriptLevels.map(l => l.activeId)
+        );
+        assert.deepEqual([[], [], [1, 2]], levelIdsBySection);
+
+        levelIdsBySection = oldActivities[1].activitySections.map(section =>
+          section.scriptLevels.map(l => l.activeId)
+        );
+        assert.deepEqual([[]], levelIdsBySection);
+
+        const activityPos = 1;
+        const sectionPos = 3;
+        const levelPos = 2;
+        const newActivityPos = 2;
+        const newSectionPos = 1;
+        const newActivities = reducer(
+          initialState,
+          moveLevelToActivitySection(
+            activityPos,
+            sectionPos,
+            levelPos,
+            newActivityPos,
+            newSectionPos
+          )
+        ).activities;
+        levelIdsBySection = newActivities[0].activitySections.map(section =>
+          section.scriptLevels.map(l => l.activeId)
+        );
+        assert.deepEqual([[], [], [1]], levelIdsBySection);
+
+        levelIdsBySection = newActivities[1].activitySections.map(section =>
+          section.scriptLevels.map(l => l.activeId)
+        );
+        assert.deepEqual([[2]], levelIdsBySection);
+      });
     });
 
     it('add level', () => {

--- a/apps/test/unit/lib/levelbuilder/lesson-editor/activitiesEditorReduxTest.js
+++ b/apps/test/unit/lib/levelbuilder/lesson-editor/activitiesEditorReduxTest.js
@@ -113,11 +113,17 @@ describe('activitiesEditorRedux reducer tests', () => {
         ]
       });
 
+      const oldActivities = initialState.activities;
+      let levelIdsBySection = oldActivities[0].activitySections.map(section =>
+        section.scriptLevels.map(l => l.activeId)
+      );
+      assert.deepEqual([[], [], [1, 2]], levelIdsBySection);
+
       const activityPos = 1;
       const sectionPos = 3;
       const levelPos = 2;
       const newSectionPos = 2;
-      const nextState = reducer(
+      const newActivities = reducer(
         initialState,
         moveLevelToActivitySection(
           activityPos,
@@ -127,14 +133,10 @@ describe('activitiesEditorRedux reducer tests', () => {
           newSectionPos
         )
       ).activities;
-      assert.deepEqual(
-        nextState[0].activitySections[1].scriptLevels.map(l => l.activeId),
-        [2]
+      levelIdsBySection = newActivities[0].activitySections.map(section =>
+        section.scriptLevels.map(l => l.activeId)
       );
-      assert.deepEqual(
-        nextState[0].activitySections[2].scriptLevels.map(l => l.activeId),
-        [1]
-      );
+      assert.deepEqual([[], [2], [1]], levelIdsBySection);
     });
 
     it('add level', () => {

--- a/apps/test/unit/lib/levelbuilder/lesson-editor/activitiesEditorReduxTest.js
+++ b/apps/test/unit/lib/levelbuilder/lesson-editor/activitiesEditorReduxTest.js
@@ -115,12 +115,18 @@ describe('activitiesEditorRedux reducer tests', () => {
         });
       });
 
-      it('moves level to activitySection within the same activity', () => {
-        const oldActivities = initialState.activities;
-        let levelIdsBySection = oldActivities[0].activitySections.map(section =>
+      /**
+       * Return a 2D array containing a list of active level ids for each
+       * activity section in the specified activity.
+       */
+      const activeLevelIdMap = activity =>
+        activity.activitySections.map(section =>
           section.scriptLevels.map(l => l.activeId)
         );
-        assert.deepEqual([[], [], [1, 2]], levelIdsBySection);
+
+      it('moves level to activitySection within the same activity', () => {
+        const oldActivities = initialState.activities;
+        assert.deepEqual([[], [], [1, 2]], activeLevelIdMap(oldActivities[0]));
 
         const activityPos = 1;
         const sectionPos = 3;
@@ -136,23 +142,13 @@ describe('activitiesEditorRedux reducer tests', () => {
             newSectionPos
           )
         ).activities;
-        levelIdsBySection = newActivities[0].activitySections.map(section =>
-          section.scriptLevels.map(l => l.activeId)
-        );
-        assert.deepEqual([[], [2], [1]], levelIdsBySection);
+        assert.deepEqual([[], [2], [1]], activeLevelIdMap(newActivities[0]));
       });
 
       it('moves level to activitySection in a different activity', () => {
         const oldActivities = initialState.activities;
-        let levelIdsBySection = oldActivities[0].activitySections.map(section =>
-          section.scriptLevels.map(l => l.activeId)
-        );
-        assert.deepEqual([[], [], [1, 2]], levelIdsBySection);
-
-        levelIdsBySection = oldActivities[1].activitySections.map(section =>
-          section.scriptLevels.map(l => l.activeId)
-        );
-        assert.deepEqual([[]], levelIdsBySection);
+        assert.deepEqual([[], [], [1, 2]], activeLevelIdMap(oldActivities[0]));
+        assert.deepEqual([[]], activeLevelIdMap(oldActivities[1]));
 
         const activityPos = 1;
         const sectionPos = 3;
@@ -169,15 +165,8 @@ describe('activitiesEditorRedux reducer tests', () => {
             newSectionPos
           )
         ).activities;
-        levelIdsBySection = newActivities[0].activitySections.map(section =>
-          section.scriptLevels.map(l => l.activeId)
-        );
-        assert.deepEqual([[], [], [1]], levelIdsBySection);
-
-        levelIdsBySection = newActivities[1].activitySections.map(section =>
-          section.scriptLevels.map(l => l.activeId)
-        );
-        assert.deepEqual([[2]], levelIdsBySection);
+        assert.deepEqual([[], [], [1]], activeLevelIdMap(newActivities[0]));
+        assert.deepEqual([[2]], activeLevelIdMap(newActivities[1]));
       });
     });
 

--- a/apps/test/unit/lib/levelbuilder/lesson-editor/activitiesEditorReduxTest.js
+++ b/apps/test/unit/lib/levelbuilder/lesson-editor/activitiesEditorReduxTest.js
@@ -93,50 +93,54 @@ describe('activitiesEditorRedux reducer tests', () => {
       );
     });
 
-    it('moves level to activitySection', () => {
-      initialState.activities.push({
-        key: 'activity-2',
-        displayName: 'Second Activity',
-        position: 2,
-        duration: 30,
-        activitySections: [
-          {
-            key: 'section-4',
-            position: 1,
-            displayName: 'Making drawings',
-            remarks: true,
-            slide: false,
-            scriptLevels: [],
-            text: 'Drawing text',
-            tips: []
-          }
-        ]
+    describe('moveLevelToActivitySection', () => {
+      beforeEach(() => {
+        initialState.activities.push({
+          key: 'activity-2',
+          displayName: 'Second Activity',
+          position: 2,
+          duration: 30,
+          activitySections: [
+            {
+              key: 'section-4',
+              position: 1,
+              displayName: 'Making drawings',
+              remarks: true,
+              slide: false,
+              scriptLevels: [],
+              text: 'Drawing text',
+              tips: []
+            }
+          ]
+        });
       });
 
-      const oldActivities = initialState.activities;
-      let levelIdsBySection = oldActivities[0].activitySections.map(section =>
-        section.scriptLevels.map(l => l.activeId)
-      );
-      assert.deepEqual([[], [], [1, 2]], levelIdsBySection);
+      it('moves level to activitySection within the same activity', () => {
+        const oldActivities = initialState.activities;
+        let levelIdsBySection = oldActivities[0].activitySections.map(section =>
+          section.scriptLevels.map(l => l.activeId)
+        );
+        assert.deepEqual([[], [], [1, 2]], levelIdsBySection);
 
-      const activityPos = 1;
-      const sectionPos = 3;
-      const levelPos = 2;
-      const newSectionPos = 2;
-      const newActivities = reducer(
-        initialState,
-        moveLevelToActivitySection(
-          activityPos,
-          sectionPos,
-          levelPos,
-          activityPos,
-          newSectionPos
-        )
-      ).activities;
-      levelIdsBySection = newActivities[0].activitySections.map(section =>
-        section.scriptLevels.map(l => l.activeId)
-      );
-      assert.deepEqual([[], [2], [1]], levelIdsBySection);
+        const activityPos = 1;
+        const sectionPos = 3;
+        const levelPos = 2;
+        const newSectionPos = 2;
+        const newActivities = reducer(
+          initialState,
+          moveLevelToActivitySection(
+            activityPos,
+            sectionPos,
+            levelPos,
+            activityPos,
+            newSectionPos
+          )
+        ).activities;
+        levelIdsBySection = newActivities[0].activitySections.map(section =>
+          section.scriptLevels.map(l => l.activeId)
+        );
+        assert.deepEqual([[], [2], [1]], levelIdsBySection);
+      });
     });
 
     it('add level', () => {

--- a/apps/test/unit/lib/levelbuilder/lesson-editor/activitiesEditorReduxTest.js
+++ b/apps/test/unit/lib/levelbuilder/lesson-editor/activitiesEditorReduxTest.js
@@ -113,9 +113,19 @@ describe('activitiesEditorRedux reducer tests', () => {
         ]
       });
 
+      const activityPos = 1;
+      const sectionPos = 3;
+      const levelPos = 2;
+      const newSectionPos = 2;
       const nextState = reducer(
         initialState,
-        moveLevelToActivitySection(1, 3, 2, 2)
+        moveLevelToActivitySection(
+          activityPos,
+          sectionPos,
+          levelPos,
+          activityPos,
+          newSectionPos
+        )
       ).activities;
       assert.deepEqual(
         nextState[0].activitySections[1].scriptLevels.map(l => l.activeId),


### PR DESCRIPTION
## Background

Finishes [PLAT-412] and [PLAT-413]. There were two problems:
1. The bounding boxes are computed for each ActivitySectionCard at the time they are rendered, but they become inaccurate once the user scrolls the page.
2. The logic for moving a LevelToken to a new ActivitySectionCard did not account for the presence of multiple activities.

## Description

This PR solves the problem 1 in the following way:

* on each render, store React refs to each ActivitySectionCard via `setActivitySectionRef`
* on drag start, compute bounding boxes of each ActivitySectionCard via `updateActivitySectionMetrics`
* on drag (on each mousemove while dragging), update the target activity and activity section via `updateTargetActivitySection`

The rest of the logic for actually moving the card remains mostly the same, with some small tweaks to address problem (2) above.

The reason for only computing bounding boxes on drag start, rather than on every mousemove, is for performance. computing bounding boxes can be expensive, because the interact with the DOM. However, one downside of this approach is that if the user scrolls the page while dragging is happening, then the bounding boxes would become invalid again. if we run into this situation, we can deal with it by updating the bounding boxes in response to the scroll event, which should happen much less frequently than the mousemove event.

## Alternatives

There are various other approaches which turned out not to work very well. here are a few notes on each of them:

### alternative: mouse events

instead of using mathematical comparisons and bounding boxes, it seems like we should be able to keep track of when a dragged element moves inside another ActivitySectionCard based on mouse events like mouseEnter, mouseOver or mouseMove. Unfortunately though, while a LevelToken is being dragged, the pointer is usually over the LevelToken, which means all these mouse events bubble up through its current parent, not the one it is being dragged over. Therefore we might never get a mouse event on the desired target ActivitySectionCard.

### alternative: forced update

you can see here that a similar problem for LevelTokens is addressed by forcing React to re-render them, which re-triggers their logic for computing their own bounding boxes: https://github.com/code-dot-org/code-dot-org/blob/bdd84f801ee63f1f51cbee64f9372e67feee8b41/apps/src/lib/levelbuilder/lesson-editor/ActivitySectionCard.jsx#L121-L125

This is a viable approach but is a bit overkill since we do not really need to re-render, we just need to recompute bounding boxes. In the future the forceUpdate approach could be replaced with something more like what's shown in this PR.

## Screenshots

This shows that dragging across activities is working:

![drag-and-drop-levels](https://user-images.githubusercontent.com/8001765/96927411-da369b00-146b-11eb-9007-3ec9e60cc7e1.gif)

However, it's worth noting that this minimal example takes up all the vertical space on my 27-inch monitor.  in order for editors to be able to easily move levels around, we will probably need to (1) reduce our usage of horizontal space, (2) make dragging scroll-safe and (3) make dragging scroll the page.

## Testing story

new and existing unit tests on `moveLevelToActivitySection` redux action. No tests covering dragging behavior, though these could be added later as UI tests or possibly apps unit tests.

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked


[PLAT-412]: https://codedotorg.atlassian.net/browse/PLAT-412
[PLAT-413]: https://codedotorg.atlassian.net/browse/PLAT-413