### PR TITLE
Lesson Edit Page Clean Up

### DIFF
--- a/apps/src/lib/levelbuilder/announcementsEditor/Announcement.jsx
+++ b/apps/src/lib/levelbuilder/announcementsEditor/Announcement.jsx
@@ -86,7 +86,11 @@ export default class Announcement extends Component {
             </select>
           </div>
         </label>
-        <button className="btn" type="button" onClick={() => onRemove(index)}>
+        <button
+          className="btn btn-danger"
+          type="button"
+          onClick={() => onRemove(index)}
+        >
           Remove
         </button>
       </div>

--- a/apps/src/lib/levelbuilder/announcementsEditor/AnnouncementsEditor.jsx
+++ b/apps/src/lib/levelbuilder/announcementsEditor/AnnouncementsEditor.jsx
@@ -88,7 +88,8 @@ export default class AnnouncementsEditor extends Component {
           />
         ))}
         <button className="btn" type="button" onClick={this.add}>
-          Additional Announcement
+          <i style={{marginRight: 7}} className="fa fa-plus-circle" />
+          Add Announcement
         </button>
         {announcements.length > 0 && (
           <div>

--- a/apps/src/lib/levelbuilder/lesson-editor/ActivityCard.jsx
+++ b/apps/src/lib/levelbuilder/lesson-editor/ActivityCard.jsx
@@ -50,7 +50,12 @@ const styles = {
     marginRight: 5
   },
   labelAndInput: {
-    marginLeft: 5,
+    marginLeft: 10,
+    display: 'flex',
+    alignItems: 'center',
+    justifyContent: 'flex-start'
+  },
+  inputsAndIcon: {
     display: 'flex',
     alignItems: 'center',
     justifyContent: 'flex-start'
@@ -148,33 +153,35 @@ class ActivityCard extends Component {
             ...(this.state.collapsed && {marginBottom: 10})
           }}
         >
-          <FontAwesome
-            icon={this.state.collapsed ? 'expand' : 'compress'}
-            onClick={() => {
-              this.setState({
-                collapsed: !this.state.collapsed
-              });
-            }}
-          />
-          <label style={styles.labelAndInput}>
-            <span style={styles.label}>{`Activity:`}</span>
-            <input
-              value={activity.displayName}
-              style={{width: 150}}
-              onChange={this.handleChangeDisplayName}
-              className="uitest-activity-name-input"
+          <div style={styles.inputsAndIcon}>
+            <FontAwesome
+              icon={this.state.collapsed ? 'expand' : 'compress'}
+              onClick={() => {
+                this.setState({
+                  collapsed: !this.state.collapsed
+                });
+              }}
             />
-          </label>
-          <label style={styles.labelAndInput}>
-            <span style={styles.label}>{`Duration:`}</span>
-            <input
-              value={activity.duration}
-              style={{width: 35}}
-              onChange={this.handleChangeDuration}
-              className="uitest-activity-duration-input"
-            />
-            <span style={{fontSize: 10}}>{'(mins)'}</span>
-          </label>
+            <label style={styles.labelAndInput}>
+              <span style={styles.label}>{`Activity:`}</span>
+              <input
+                value={activity.displayName}
+                style={{width: 200}}
+                onChange={this.handleChangeDisplayName}
+                className="uitest-activity-name-input"
+              />
+            </label>
+            <label style={styles.labelAndInput}>
+              <span style={styles.label}>{`Duration:`}</span>
+              <input
+                value={activity.duration}
+                style={{width: 35}}
+                onChange={this.handleChangeDuration}
+                className="uitest-activity-duration-input"
+              />
+              <span style={{fontSize: 10}}>{'(mins)'}</span>
+            </label>
+          </div>
           <OrderControls
             name={activity.key || '(none)'}
             move={this.handleMoveActivity}

--- a/apps/src/lib/levelbuilder/lesson-editor/AddLevelFilters.jsx
+++ b/apps/src/lib/levelbuilder/lesson-editor/AddLevelFilters.jsx
@@ -9,8 +9,12 @@ const styles = {
     flexDirection: 'row',
     alignItems: 'center'
   },
+  input: {
+    width: 195,
+    margin: 5
+  },
   dropdown: {
-    width: 125,
+    width: 150,
     margin: 5
   },
   label: {
@@ -69,7 +73,7 @@ export default class AddLevelFilters extends Component {
         <label style={styles.label}>
           By Name:
           <input
-            style={styles.dropdown}
+            style={styles.input}
             onChange={this.handleInputChange}
             value={this.state.levelName}
           />


### PR DESCRIPTION
Fixes a couple quick wins from the feedback @tess323 gave on the Lesson Edit Page [here](https://docs.google.com/document/d/1LTP1_UwCtJ8n_ju5qspeBSYgrh-t7MHCwKGboPKSg5A/edit#).

## Fix sizing of the input and filters in AddLevelDialog

<img width="1135" alt="Screen Shot 2020-10-21 at 8 18 04 PM" src="https://user-images.githubusercontent.com/208083/96806435-158c8780-13e2-11eb-816d-3ce3dec80fa4.png">

## Fix alignment of inputs on top of Activity Card

<img width="666" alt="Screen Shot 2020-10-21 at 8 26 02 PM" src="https://user-images.githubusercontent.com/208083/96806479-2c32de80-13e2-11eb-9c04-1990763cefbd.png">


## Improve buttons on Announcements Editor

<img width="1221" alt="Screen Shot 2020-10-21 at 9 13 40 PM" src="https://user-images.githubusercontent.com/208083/96806513-4d93ca80-13e2-11eb-9d28-6e055f93de42.png">
