### PR TITLE
Script Edit Page Clean Up

### DIFF
--- a/apps/src/lib/levelbuilder/script-editor/LessonGroupCard.jsx
+++ b/apps/src/lib/levelbuilder/script-editor/LessonGroupCard.jsx
@@ -255,7 +255,7 @@ class LessonGroupCard extends Component {
   handleChangeLessonGroupName = event => {
     this.props.updateLessonGroupField(
       this.props.lessonGroup.position,
-      'name',
+      'displayName',
       event.target.value
     );
   };
@@ -272,53 +272,49 @@ class LessonGroupCard extends Component {
             : styles.lessonGroupCard
         }
       >
-        <div style={styles.lessonGroupCardHeader}>
-          {lessonGroup.userFacing && (
-            <span>
+        {lessonGroup.userFacing && (
+          <div>
+            <div style={styles.lessonGroupCardHeader}>
               <span style={styles.title}>Lesson Group Name:</span>
               <input
                 value={this.props.lessonGroup.displayName}
                 onChange={this.handleChangeLessonGroupName}
                 style={{width: 300}}
               />
-            </span>
-          )}
-          {lessonGroup.userFacing && (
-            <OrderControls
-              name={lessonGroup.key || '(none)'}
-              move={this.handleMoveLessonGroup}
-              remove={this.handleRemoveLessonGroup}
-            />
-          )}
-        </div>
-        {lessonGroup.userFacing && (
-          <div>
-            <label>
-              Description
-              <textarea
-                value={this.props.lessonGroup.description}
-                rows={Math.max(
-                  this.props.lessonGroup.description.split(/\r\n|\r|\n/)
-                    .length + 1,
-                  2
-                )}
-                style={styles.input}
-                onChange={this.handleChangeDescription}
+              <OrderControls
+                name={lessonGroup.key || '(none)'}
+                move={this.handleMoveLessonGroup}
+                remove={this.handleRemoveLessonGroup}
               />
-            </label>
-            <label>
-              Big Questions
-              <textarea
-                value={this.props.lessonGroup.bigQuestions}
-                rows={Math.max(
-                  this.props.lessonGroup.bigQuestions.split(/\r\n|\r|\n/)
-                    .length + 1,
-                  2
-                )}
-                style={styles.input}
-                onChange={this.handleChangeBigQuestions}
-              />
-            </label>
+            </div>
+            <div>
+              <label>
+                Description
+                <textarea
+                  value={this.props.lessonGroup.description}
+                  rows={Math.max(
+                    this.props.lessonGroup.description.split(/\r\n|\r|\n/)
+                      .length + 1,
+                    2
+                  )}
+                  style={styles.input}
+                  onChange={this.handleChangeDescription}
+                />
+              </label>
+              <label>
+                Big Questions
+                <textarea
+                  value={this.props.lessonGroup.bigQuestions}
+                  rows={Math.max(
+                    this.props.lessonGroup.bigQuestions.split(/\r\n|\r|\n/)
+                      .length + 1,
+                    2
+                  )}
+                  style={styles.input}
+                  onChange={this.handleChangeBigQuestions}
+                />
+              </label>
+            </div>
           </div>
         )}
         {lessonGroup.lessons.map(lesson => (

--- a/apps/src/lib/levelbuilder/script-editor/ScriptEditor.jsx
+++ b/apps/src/lib/levelbuilder/script-editor/ScriptEditor.jsx
@@ -251,9 +251,11 @@ export default class ScriptEditor extends React.Component {
           <label>
             Supported locales
             <p>
-              Select additional locales supported by this script. Select
+              <span>
+                {'Select additional locales supported by this script. Select '}
+              </span>
               <a onClick={this.handleClearSupportedLocalesSelectClick}>none</a>
-              or shift-click or cmd-click to select multiple.
+              <span>{' or shift-click or cmd-click to select multiple.'}</span>
             </p>
             <select
               name="supported_locales[]"


### PR DESCRIPTION
Fixes a couple quick wins from the feedback @tess323 gave on the Script Edit Page [here](https://docs.google.com/document/d/1LTP1_UwCtJ8n_ju5qspeBSYgrh-t7MHCwKGboPKSg5A/edit#).

## Fix spacing around link in the supported locales

<img width="737" alt="Screen Shot 2020-10-21 at 9 07 29 PM" src="https://user-images.githubusercontent.com/208083/96806608-8df34880-13e2-11eb-9c15-d65089340755.png">

## Make Lesson Group Name editable

![lesson-group-name](https://user-images.githubusercontent.com/208083/96806695-d3b01100-13e2-11eb-899c-7d1bf70e2b74.gif)
