### PR TITLE
Record when teachers assign/unassign a course

### DIFF
--- a/apps/src/templates/UnassignButton.jsx
+++ b/apps/src/templates/UnassignButton.jsx
@@ -4,7 +4,6 @@ import {connect} from 'react-redux';
 import Button from './Button';
 import i18n from '@cdo/locale';
 import {unassignSection} from '@cdo/apps/templates/teacherDashboard/teacherSectionsRedux';
-import firehoseClient from '@cdo/apps/lib/util/firehose';
 
 const styles = {
   buttonMargin: {
@@ -34,14 +33,6 @@ class UnassignButton extends React.Component {
 
   onClickUnassign = () => {
     const {sectionId, unassignSection} = this.props;
-    firehoseClient.putRecord(
-      {
-        study: 'teacher_course_page',
-        event: 'section-unassigned',
-        data_json: JSON.stringify({sectionId})
-      },
-      {includeUserId: true}
-    );
     unassignSection(sectionId);
   };
 

--- a/apps/src/templates/UnassignButton.jsx
+++ b/apps/src/templates/UnassignButton.jsx
@@ -4,6 +4,7 @@ import {connect} from 'react-redux';
 import Button from './Button';
 import i18n from '@cdo/locale';
 import {unassignSection} from '@cdo/apps/templates/teacherDashboard/teacherSectionsRedux';
+import firehoseClient from '@cdo/apps/lib/util/firehose';
 
 const styles = {
   buttonMargin: {
@@ -33,6 +34,14 @@ class UnassignButton extends React.Component {
 
   onClickUnassign = () => {
     const {sectionId, unassignSection} = this.props;
+    firehoseClient.putRecord(
+      {
+        study: 'teacher_course_page',
+        event: 'section-unassigned',
+        data_json: JSON.stringify({sectionId})
+      },
+      {includeUserId: true}
+    );
     unassignSection(sectionId);
   };
 

--- a/apps/src/templates/teacherDashboard/teacherSectionsRedux.js
+++ b/apps/src/templates/teacherDashboard/teacherSectionsRedux.js
@@ -155,6 +155,16 @@ export const toggleSectionHidden = sectionId => (dispatch, getState) => {
 };
 
 /**
+ * Removes null values from stringified object before sending firehose record
+ */
+function removeNullValues(key, val) {
+  if (val === null || typeof val === undefined) {
+    return undefined;
+  }
+  return val;
+}
+
+/**
  * Assigns a course to a given section, persisting these changes to
  * the server
  * @param {number} sectionId
@@ -162,6 +172,22 @@ export const toggleSectionHidden = sectionId => (dispatch, getState) => {
  * @param {number} scriptId
  */
 export const assignToSection = (sectionId, courseId, scriptId, pageType) => {
+  firehoseClient.putRecord(
+    {
+      study: 'assignment',
+      event: 'course-assigned-to-section',
+      data_json: JSON.stringify(
+        {
+          sectionId,
+          scriptId,
+          courseId,
+          date: new Date()
+        },
+        removeNullValues
+      )
+    },
+    {includeUserId: true}
+  );
   return (dispatch, getState) => {
     dispatch(beginEditingSection(sectionId, true));
     dispatch(
@@ -181,7 +207,24 @@ export const assignToSection = (sectionId, courseId, scriptId, pageType) => {
  */
 export const unassignSection = sectionId => (dispatch, getState) => {
   dispatch(beginEditingSection(sectionId, true));
+  const {initialCourseId, initialScriptId} = getState().teacherSections;
   dispatch(editSectionProperties({courseId: '', scriptId: ''}));
+  firehoseClient.putRecord(
+    {
+      study: 'assignment',
+      event: 'course-unassigned-from-section',
+      data_json: JSON.stringify(
+        {
+          sectionId,
+          scriptId: initialScriptId,
+          courseId: initialCourseId,
+          date: new Date()
+        },
+        removeNullValues
+      )
+    },
+    {includeUserId: true}
+  );
   return dispatch(finishEditingSection());
 };
 


### PR DESCRIPTION
Teachers are reporting that assigned courses for a section disappear on the teacher dashboard and are replaced by the "Find a Course" link. The issue here is that teachers are unintentionally clicking the unassign button on a course/unit, causing the assigned section to disappear from the teacher dashboard. To understanding the issue better, this PR includes instrumentation to track the assignment and unassignment of courses.

### Future work
Depending on the data collected, we may want to add a [confirmation dialog](https://docs.google.com/document/d/1yx_eGSTjKOtHIzxbT5XsRTnyY0LCkKLti0t8JbLSzfQ/edit) to lessen the probability that a teacher mistakenly unassigns a course from their section.

## Links

- [spec](https://docs.google.com/document/d/1vCmWJp_n85OW2MKgjYV9AT4KIdtZnbCYU4-TpvaUOSw/edit)
- [jira](https://codedotorg.atlassian.net/browse/LP-1611)

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
