### PR TITLE
Clear lines of code from the session storage when a user is logged in

### DIFF
--- a/apps/src/code-studio/clientState.js
+++ b/apps/src/code-studio/clientState.js
@@ -3,6 +3,7 @@
  *       combination of cookies and HTML5 web storage.
  */
 import {trySetSessionStorage} from '../utils';
+import {getStore} from './redux';
 // Note: sessionStorage is not shared between tabs.
 var sessionStorage = window.sessionStorage;
 
@@ -38,6 +39,7 @@ clientState.reset = function() {
 
 clientState.clearProgress = function() {
   sessionStorage.removeItem('progress');
+  sessionStorage.removeItem('lines');
 };
 
 /**
@@ -91,12 +93,16 @@ clientState.writeSourceForLevel = function(
 
 /**
  * Tracks the lines of code written after the user clicks run if their
- * solution is successful.
+ * solution is successful. Skips if the user is logged in.
  * @param {boolean} result - Whether the user's solution is successful
  * @param {number} lines - Number of lines of code user wrote in this solution
  */
 clientState.trackLines = function(result, lines) {
-  if (result && isFinite(lines)) {
+  if (
+    result &&
+    isFinite(lines) &&
+    !getStore().getState().progress.usingDbProgress
+  ) {
     addLines(lines);
   }
 };

--- a/apps/src/code-studio/header.js
+++ b/apps/src/code-studio/header.js
@@ -13,6 +13,7 @@ import {
   setShowTryAgainDialog
 } from './headerRedux';
 import {useDbProgress} from './progressRedux';
+import clientState from './clientState';
 
 import React from 'react';
 import ReactDOM from 'react-dom';
@@ -77,6 +78,7 @@ header.build = function(
   const store = getStore();
   if (progressData) {
     store.dispatch(useDbProgress());
+    clientState.clearProgress();
   }
   scriptData = scriptData || {};
   lessonGroupData = lessonGroupData || {};

--- a/apps/src/code-studio/initApp/loadApp.js
+++ b/apps/src/code-studio/initApp/loadApp.js
@@ -59,6 +59,7 @@ function mergeProgressData(scriptName, serverProgress) {
 
   // The server returned progress. This is the source of truth.
   store.dispatch(useDbProgress());
+  clientState.clearProgress();
 
   // Clear any existing redux state.
   store.dispatch(

--- a/apps/src/code-studio/progressRedux.js
+++ b/apps/src/code-studio/progressRedux.js
@@ -10,7 +10,6 @@ import {ViewType, SET_VIEW_TYPE} from './viewAsRedux';
 import {processedLevel} from '@cdo/apps/templates/progress/progressHelpers';
 import {setVerified} from '@cdo/apps/code-studio/verifiedTeacherRedux';
 import {authorizeLockable} from './stageLockRedux';
-import clientState from './clientState';
 
 // Action types
 export const INIT_PROGRESS = 'progress/INIT_PROGRESS';
@@ -419,12 +418,9 @@ export const clearProgress = () => ({
   type: CLEAR_PROGRESS
 });
 
-export const useDbProgress = () => {
-  return dispatch => {
-    clientState.clearProgress();
-    dispatch({type: USE_DB_PROGRESS});
-  };
-};
+export const useDbProgress = () => ({
+  type: USE_DB_PROGRESS
+});
 
 export const mergeProgress = levelProgress => ({
   type: MERGE_PROGRESS,

--- a/apps/test/unit/code-studio/progressReduxTest.js
+++ b/apps/test/unit/code-studio/progressReduxTest.js
@@ -3,8 +3,6 @@ import sinon from 'sinon';
 import {TestResults} from '@cdo/apps/constants';
 import {LevelStatus, LevelKind} from '@cdo/apps/util/sharedConstants';
 import {ViewType, setViewType} from '@cdo/apps/code-studio/viewAsRedux';
-import clientState from '@cdo/apps/code-studio/clientState';
-import {expect} from '../../util/reconfiguredChai';
 import reducer, {
   initProgress,
   isPerfect,
@@ -26,7 +24,6 @@ import reducer, {
   lessonExtrasUrl,
   setStageExtrasEnabled,
   getLevelResult,
-  useDbProgress,
   __testonly__
 } from '@cdo/apps/code-studio/progressRedux';
 
@@ -1456,14 +1453,6 @@ describe('progressReduxTest', () => {
         assert.deepEqual(expectedDispatchActions, getDispatchActions());
         assert.deepEqual(responseData, serverResponseData);
       });
-    });
-  });
-
-  describe('useDbProgress', () => {
-    it('clears the client progress', () => {
-      var clearProgressSpy = sinon.spy(clientState, 'clearProgress');
-      useDbProgress()(sinon.stub());
-      expect(clearProgressSpy).to.have.been.calledOnce;
     });
   });
 });


### PR DESCRIPTION
Follow-up to this PR: https://github.com/code-dot-org/code-dot-org/pull/37376

In the above PR, we migrated 'total lines written' to be tracked in the same way as user progress. This PR further adjusts 'total lines written' to be set or cleared in the same way as user progress.

See https://github.com/code-dot-org/code-dot-org/pull/36474 for full details of this approach.

<!--
  Other aspects to consider. uncomment and add detail for any that seem necessary:
-->

<!-- ### Background -->
<!-- ### Privacy -->
<!--
1.	Does the Project involve the collection, use or sharing of new Personal Data?

2.	Does the Project involve a new or changed use or sharing of existing Personal Data?
-->
<!-- ### Security -->
<!--
Link to Jira Task where sensitive security issues are discussed privately.
-->
<!-- ### Caching -->
<!-- ### Deployment strategy -->
<!-- ### Future work -->

## Links

<!--
  Any relevant links to external resources; ie, specification documents, jira
  items, related PRs, honeybadger errors, etc
-->

- continues [LP-1564](https://codedotorg.atlassian.net/browse/LP-1564)

## Testing story

<!--
  Does your change include appropriate tests?

  If so, please describe how the tests included in this PR are sufficient

  If not, please explain why this change does not need to be tested.
-->

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
