### PR TITLE
Fix some of the script edit saving issues

### DIFF
--- a/apps/src/lib/levelbuilder/script-editor/LessonGroupCard.jsx
+++ b/apps/src/lib/levelbuilder/script-editor/LessonGroupCard.jsx
@@ -69,6 +69,7 @@ class LessonGroupCard extends Component {
     lessonGroupMetrics: PropTypes.object,
     setTargetLessonGroup: PropTypes.func,
     targetLessonGroupPos: PropTypes.number,
+    lessonKeys: PropTypes.array,
 
     // from redux
     addLesson: PropTypes.func.isRequired,
@@ -214,11 +215,7 @@ class LessonGroupCard extends Component {
 
   generateLessonKey = () => {
     let lessonNumber = this.props.lessonGroup.lessons.length + 1;
-    while (
-      this.props.lessonGroup.lessons.some(
-        lesson => lesson.key === `lesson-${lessonNumber}`
-      )
-    ) {
+    while (this.props.lessonKeys.includes(`lesson-${lessonNumber}`)) {
       lessonNumber++;
     }
 

--- a/apps/src/lib/levelbuilder/script-editor/LessonGroupCard.jsx
+++ b/apps/src/lib/levelbuilder/script-editor/LessonGroupCard.jsx
@@ -69,7 +69,7 @@ class LessonGroupCard extends Component {
     lessonGroupMetrics: PropTypes.object,
     setTargetLessonGroup: PropTypes.func,
     targetLessonGroupPos: PropTypes.number,
-    lessonKeys: PropTypes.array,
+    lessonKeys: PropTypes.array.isRequired,
 
     // from redux
     addLesson: PropTypes.func.isRequired,

--- a/apps/src/lib/levelbuilder/script-editor/UnitCard.jsx
+++ b/apps/src/lib/levelbuilder/script-editor/UnitCard.jsx
@@ -226,6 +226,13 @@ class UnitCard extends Component {
   render() {
     const {lessonGroups} = this.props;
 
+    let lessonKeys = [];
+    lessonGroups.forEach(lessonGroup => {
+      lessonGroup.lessons.forEach(lesson => {
+        lessonKeys.push(lesson.key);
+      });
+    });
+
     return (
       <div>
         <div style={styles.unitHeader}>Unit</div>
@@ -234,6 +241,7 @@ class UnitCard extends Component {
             <LessonGroupCard
               key={`lesson-group-${index}`}
               lessonGroupsCount={lessonGroups.length}
+              lessonKeys={lessonKeys}
               lessonGroup={lessonGroup}
               ref={lessonGroupCard => {
                 if (lessonGroupCard) {

--- a/apps/src/lib/levelbuilder/script-editor/UnitCard.jsx
+++ b/apps/src/lib/levelbuilder/script-editor/UnitCard.jsx
@@ -116,7 +116,7 @@ class UnitCard extends Component {
    */
   serializeLesson = lesson => {
     let s = [];
-    let t = `lesson '${escape(lesson.name)}'`;
+    let t = `lesson '${escape(lesson.key)}'`;
     if (lesson.name) {
       t += `, display_name: '${escape(lesson.name)}'`;
     }

--- a/apps/test/unit/lib/levelbuilder/script-editor/LessonGroupCardTest.jsx
+++ b/apps/test/unit/lib/levelbuilder/script-editor/LessonGroupCardTest.jsx
@@ -11,7 +11,6 @@ export const nonUserFacingGroup = {
   userFacing: false,
   description: '',
   bigQuestions: '',
-  lessonKeys: [],
   lessons: [
     {
       id: 100,
@@ -63,6 +62,7 @@ describe('LessonGroupCard', () => {
       lessonGroupsCount: 1,
       lessonGroupMetrics: {},
       targetLessonGroupPos: null,
+      lessonKeys: [],
       lessonGroup: {
         key: 'lg-key',
         displayName: 'Display Name',

--- a/apps/test/unit/lib/levelbuilder/script-editor/LessonGroupCardTest.jsx
+++ b/apps/test/unit/lib/levelbuilder/script-editor/LessonGroupCardTest.jsx
@@ -11,6 +11,7 @@ export const nonUserFacingGroup = {
   userFacing: false,
   description: '',
   bigQuestions: '',
+  lessonKeys: [],
   lessons: [
     {
       id: 100,


### PR DESCRIPTION
Follows up on script editing bugs listed [here](https://docs.google.com/document/d/1LTP1_UwCtJ8n_ju5qspeBSYgrh-t7MHCwKGboPKSg5A/edit#).

Found 2 key things that were causing issues with saving on the script edit page:
- When serializing lessons we were putting name where key should have been
- When generating new keys for lessons we were checking only if there was another lesson in the same lesson group with that key when we need to check against all the lesson keys in the unit


![script-edit-saving](https://user-images.githubusercontent.com/208083/96948523-ddee1000-14b3-11eb-8a94-e7f2b9a6ad4c.gif)
