### PR TITLE
[Google Blockly] Implement fireUiEvent on the wrapper

### DIFF
--- a/apps/src/sites/studio/pages/googleBlocklyWrapper.js
+++ b/apps/src/sites/studio/pages/googleBlocklyWrapper.js
@@ -77,7 +77,6 @@ function initializeBlocklyWrapper(blocklyInstance) {
   blocklyWrapper.wrapReadOnlyProperty('FieldRectangularDropdown');
   blocklyWrapper.wrapReadOnlyProperty('FieldTextInput');
   blocklyWrapper.wrapReadOnlyProperty('FieldVariable');
-  blocklyWrapper.wrapReadOnlyProperty('fireUiEvent');
   blocklyWrapper.wrapReadOnlyProperty('fish_locale');
   blocklyWrapper.wrapReadOnlyProperty('Flyout');
   blocklyWrapper.wrapReadOnlyProperty('FunctionalBlockUtils');
@@ -85,6 +84,7 @@ function initializeBlocklyWrapper(blocklyInstance) {
   blocklyWrapper.wrapReadOnlyProperty('FunctionEditor');
   blocklyWrapper.wrapReadOnlyProperty('functionEditor');
   blocklyWrapper.wrapReadOnlyProperty('gamelab_locale');
+  blocklyWrapper.wrapReadOnlyProperty('getMainWorkspace');
   blocklyWrapper.wrapReadOnlyProperty('Generator');
   blocklyWrapper.wrapReadOnlyProperty('geras');
   blocklyWrapper.wrapReadOnlyProperty('getRelativeXY');
@@ -103,6 +103,7 @@ function initializeBlocklyWrapper(blocklyInstance) {
   blocklyWrapper.wrapReadOnlyProperty('RTL');
   blocklyWrapper.wrapReadOnlyProperty('Scrollbar');
   blocklyWrapper.wrapReadOnlyProperty('selected');
+  blocklyWrapper.wrapReadOnlyProperty('svgResize');
   blocklyWrapper.wrapReadOnlyProperty('tutorialExplorer_locale');
   blocklyWrapper.wrapReadOnlyProperty('useContractEditor');
   blocklyWrapper.wrapReadOnlyProperty('useModalFunctionEditor');
@@ -257,6 +258,13 @@ function initializeBlocklyWrapper(blocklyInstance) {
       Blockly.Xml.deleteNext(blockXml);
     }
     return blockXml;
+  };
+
+  // Used by StudioApp to tell Blockly to resize for Mobile Safari.
+  blocklyWrapper.fireUiEvent = function(element, eventName, opt_properties) {
+    if (eventName === 'resize') {
+      blocklyWrapper.svgResize(blocklyWrapper.getMainWorkspace());
+    }
   };
 
   // Aliasing Google's domToBlock() so that we can override it, but still be able

--- a/apps/test/unit/sites/studio/pages/googleBlocklyWrapperTest.js
+++ b/apps/test/unit/sites/studio/pages/googleBlocklyWrapperTest.js
@@ -48,7 +48,6 @@ describe('Google Blockly Wrapper', () => {
       'FieldRectangularDropdown',
       'FieldTextInput',
       'FieldVariable',
-      'fireUiEvent',
       'fish_locale',
       'Flyout',
       'FunctionalBlockUtils',


### PR DESCRIPTION
Google Blockly removed `fireUiEvent` in https://github.com/google/blockly/commit/217c681b86b0f2df76c479c9efae62e6e5abcede. Instead, we should just call `svgResize` directly. See also https://github.com/google/blockly/issues/399

Though our fork of Blockly uses `fireUiEvent` extensively, we only have one call in the CDO repo:
![image](https://user-images.githubusercontent.com/8787187/97035015-93ec4500-151a-11eb-8cfd-8a2f4365bdbd.png)
This was added by https://github.com/code-dot-org/code-dot-org/pull/18937 to manually trigger a resize event on Mobile Safari. See also https://openradar.appspot.com/31725316, which describes the issue with Mobile Safari sending resize events too early. 

The solution here is just to implement `fireUiEvent` on the wrapper and pass through to `Blockly.svgResize`.

I tested on the iOS Simulator, and it seems to solve the issue we were seeing with workspaces.
Before
![Simulator Screen Shot - iPad Pro (9 7-inch) - 2020-10-23 at 10 33 03](https://user-images.githubusercontent.com/8787187/97035405-2391f380-151b-11eb-8ebc-dd1fae353b3f.png)

After
![Simulator Screen Shot - iPad Pro (9 7-inch) - 2020-10-23 at 10 31 55](https://user-images.githubusercontent.com/8787187/97035377-18d75e80-151b-11eb-8b34-d62df454e4f2.png)

Brendan tested on iPhone, and it looks like it loads too small at first then jumps to fit the right size. However, it looks like our existing Blockly apps also repro this behavior, so I'm not considering it blocking for the Google Blockly work.
![Oct-23-2020 11-48-59](https://user-images.githubusercontent.com/8787187/97042369-c64f6f80-1525-11eb-8357-97d2d94facd5.gif)





<!--
  Other aspects to consider. uncomment and add detail for any that seem necessary:
-->

<!-- ### Background -->
<!-- ### Privacy -->
<!--
1.	Does the Project involve the collection, use or sharing of new Personal Data?

2.	Does the Project involve a new or changed use or sharing of existing Personal Data?
-->
<!-- ### Security -->
<!--
Link to Jira Task where sensitive security issues are discussed privately.
-->
<!-- ### Caching -->
<!-- ### Deployment strategy -->
<!-- ### Future work -->

## Links

<!--
  Any relevant links to external resources; ie, specification documents, jira
  items, related PRs, honeybadger errors, etc
-->

- [jira](https://codedotorg.atlassian.net/browse/STAR-1284)

## Testing story

<!--
  Does your change include appropriate tests?

  If so, please describe how the tests included in this PR are sufficient

  If not, please explain why this change does not need to be tested.
-->

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
