### PR TITLE
Update properties columns from string to text for activity and activity sections

### DIFF
--- a/dashboard/app/models/activity_section.rb
+++ b/dashboard/app/models/activity_section.rb
@@ -6,7 +6,7 @@
 #  lesson_activity_id :integer          not null
 #  seeding_key        :string(255)      not null
 #  position           :integer          not null
-#  properties         :string(255)
+#  properties         :text(65535)
 #  created_at         :datetime         not null
 #  updated_at         :datetime         not null
 #

--- a/dashboard/app/models/lesson_activity.rb
+++ b/dashboard/app/models/lesson_activity.rb
@@ -6,7 +6,7 @@
 #  lesson_id   :integer          not null
 #  seeding_key :string(255)      not null
 #  position    :integer          not null
-#  properties  :string(255)
+#  properties  :text(65535)
 #  created_at  :datetime         not null
 #  updated_at  :datetime         not null
 #

--- a/dashboard/db/migrate/20201023025847_update_size_of_properties.rb
+++ b/dashboard/db/migrate/20201023025847_update_size_of_properties.rb
@@ -1,0 +1,11 @@
+class UpdateSizeOfProperties < ActiveRecord::Migration[5.0]
+  def up
+    change_column :activity_sections, :properties, :text, limit: 65535
+    change_column :lesson_activities, :properties, :text, limit: 65535
+  end
+
+  def down
+    change_column :activity_sections, :properties, :string, limit: 255
+    change_column :lesson_activities, :properties, :string, limit: 255
+  end
+end

--- a/dashboard/db/schema.rb
+++ b/dashboard/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20201016003134) do
+ActiveRecord::Schema.define(version: 20201023025847) do
 
   create_table "activities", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci" do |t|
     t.integer  "user_id"
@@ -29,12 +29,12 @@ ActiveRecord::Schema.define(version: 20201016003134) do
   end
 
   create_table "activity_sections", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci" do |t|
-    t.integer  "lesson_activity_id", null: false
-    t.string   "seeding_key",        null: false, comment: "unique key which is stable across environments for seeding purposes"
-    t.integer  "position",           null: false
-    t.string   "properties"
-    t.datetime "created_at",         null: false
-    t.datetime "updated_at",         null: false
+    t.integer  "lesson_activity_id",               null: false
+    t.string   "seeding_key",                      null: false, comment: "unique key which is stable across environments for seeding purposes"
+    t.integer  "position",                         null: false
+    t.text     "properties",         limit: 65535
+    t.datetime "created_at",                       null: false
+    t.datetime "updated_at",                       null: false
     t.index ["lesson_activity_id"], name: "index_activity_sections_on_lesson_activity_id", using: :btree
     t.index ["seeding_key"], name: "index_activity_sections_on_seeding_key", unique: true, using: :btree
   end
@@ -531,12 +531,12 @@ ActiveRecord::Schema.define(version: 20201016003134) do
   end
 
   create_table "lesson_activities", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci" do |t|
-    t.integer  "lesson_id",   null: false
-    t.string   "seeding_key", null: false, comment: "unique key which is stable across environments for seeding purposes"
-    t.integer  "position",    null: false
-    t.string   "properties"
-    t.datetime "created_at",  null: false
-    t.datetime "updated_at",  null: false
+    t.integer  "lesson_id",                 null: false
+    t.string   "seeding_key",               null: false, comment: "unique key which is stable across environments for seeding purposes"
+    t.integer  "position",                  null: false
+    t.text     "properties",  limit: 65535
+    t.datetime "created_at",                null: false
+    t.datetime "updated_at",                null: false
     t.index ["lesson_id"], name: "index_lesson_activities_on_lesson_id", using: :btree
     t.index ["seeding_key"], name: "index_lesson_activities_on_seeding_key", unique: true, using: :btree
   end


### PR DESCRIPTION
When bug bashing the new lesson edit page we ran into an issue with saving large teaching tips which are saving into the properties of activity sections. It looks like properties for other models all use text instead of string for the type of the properties column. This updates the properties column for LessonActivity and ActivitySection to be of type text. This will give more space to save properties information.  
