### PR TITLE
Lesson Edit: Student Overview Help Tip

### DIFF
--- a/apps/src/lib/levelbuilder/TextareaWithMarkdownPreview.jsx
+++ b/apps/src/lib/levelbuilder/TextareaWithMarkdownPreview.jsx
@@ -2,6 +2,7 @@ import PropTypes from 'prop-types';
 import React from 'react';
 import SafeMarkdown from '@cdo/apps/templates/SafeMarkdown';
 import color from '@cdo/apps/util/color';
+import HelpTip from '@cdo/apps/lib/ui/HelpTip';
 
 const styles = {
   wrapper: {
@@ -43,7 +44,8 @@ export default class TextareaWithMarkdownPreview extends React.Component {
     markdown: PropTypes.string,
     label: PropTypes.string.isRequired,
     name: PropTypes.string.isRequired,
-    inputRows: PropTypes.number
+    inputRows: PropTypes.number,
+    helpTip: PropTypes.string
   };
 
   constructor(props) {
@@ -62,6 +64,11 @@ export default class TextareaWithMarkdownPreview extends React.Component {
     return (
       <label>
         {this.props.label}
+        {this.props.helpTip && (
+          <HelpTip>
+            <p>{this.props.helpTip}</p>
+          </HelpTip>
+        )}
         <div style={styles.wrapper}>
           <div style={styles.container}>
             <div style={{marginBottom: 5}}>Markdown:</div>

--- a/apps/src/lib/levelbuilder/lesson-editor/LessonEditor.jsx
+++ b/apps/src/lib/levelbuilder/lesson-editor/LessonEditor.jsx
@@ -182,6 +182,9 @@ export default class LessonEditor extends Component {
             label={'Student Overview'}
             name={'studentOverview'}
             inputRows={5}
+            helpTip={
+              'This overview will appear on the students Lessons Resources page.'
+            }
           />
         </CollapsibleEditorSection>
 

--- a/apps/test/unit/lib/levelbuilder/TextareaWithMarkdownPreviewTest.jsx
+++ b/apps/test/unit/lib/levelbuilder/TextareaWithMarkdownPreviewTest.jsx
@@ -7,7 +7,8 @@ const DEFAULT_PROPS = {
   label: 'Section Name',
   name: 'name',
   markdown:
-    '# Title \n This is the unit description with [link](https://studio.code.org/home) **Bold** *italics*'
+    '# Title \n This is the unit description with [link](https://studio.code.org/home) **Bold** *italics*',
+  helpTip: 'Helpful information so you know what to do'
 };
 
 describe('TextareaWithMarkdownPreview', () => {
@@ -24,9 +25,19 @@ describe('TextareaWithMarkdownPreview', () => {
       '# Title \n This is the unit description with [link](https://studio.code.org/home) **Bold** *italics*'
     );
 
+    expect(wrapper.find('HelpTip').length).to.equal(1);
+
     wrapper
       .find('textarea[name="name"]')
       .simulate('change', {target: {value: '## Title'}});
     expect(wrapper.find('SafeMarkdown').prop('markdown')).to.equal('## Title');
+  });
+
+  it('has no HelpTip if non passed in to props', () => {
+    const wrapper = mount(
+      <TextareaWithMarkdownPreview {...DEFAULT_PROPS} helpTip={null} />
+    );
+
+    expect(wrapper.find('HelpTip').length).to.equal(0);
   });
 });


### PR DESCRIPTION
Adds the ability to add HelpTips to TextareaWithMarkdownPreview components.  Then adds a help tip to the Student Overview on the Lesson Edit page which was part of the [CPlat internal bug bash items](https://docs.google.com/document/d/1LTP1_UwCtJ8n_ju5qspeBSYgrh-t7MHCwKGboPKSg5A/edit#). 

![Screen Shot 2020-10-23 at 4 11 00 PM](https://user-images.githubusercontent.com/208083/97054141-3d026200-1552-11eb-9f28-7558ac3fc037.png)


## Testing story

Added new test for TextareaWithMarkdownPreview

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
