### PR TITLE
Update the z-index of dialog footer to show over the level tokens

### DIFF
--- a/apps/src/templates/teacherDashboard/DialogFooter.jsx
+++ b/apps/src/templates/teacherDashboard/DialogFooter.jsx
@@ -13,7 +13,7 @@ const style = {
     right: '0',
     bottom: '0',
     background: 'white',
-    zIndex: '50'
+    zIndex: '500'
   },
   buttonRow: {
     display: 'flex',


### PR DESCRIPTION
In the AddLevelDialog the LevelTokens were showing up over the DialogFooter because they had an higher z-index. I increased the z-index of the DialogFooter so that it shows up over the LevelTokens now.

# Before

![Screen Shot 2020-10-23 at 4 23 14 PM](https://user-images.githubusercontent.com/208083/97050821-0fb2b580-154c-11eb-8c68-35b915cb2642.png)


# After

![Screen Shot 2020-10-23 at 4 21 02 PM](https://user-images.githubusercontent.com/208083/97050729-e72abb80-154b-11eb-80de-d9537fa359cf.png)
