### PR TITLE
Foorm: Add date filter to csv export

### DIFF
--- a/apps/src/code-studio/pd/workshop_dashboard/reports/foorm/submissions_download_form.jsx
+++ b/apps/src/code-studio/pd/workshop_dashboard/reports/foorm/submissions_download_form.jsx
@@ -1,10 +1,20 @@
 // Pop-up modal for downloading all Foorm submissions for a single form as a csv.
 import React from 'react';
 import PropTypes from 'prop-types';
-import {Modal, Button} from 'react-bootstrap';
+import {
+  Modal,
+  Button,
+  FormGroup,
+  ControlLabel,
+  Col,
+  Row
+} from 'react-bootstrap';
 import 'react-select/dist/react-select.css';
 import Select from 'react-select/lib/Select';
+import ReactTooltip from 'react-tooltip';
 import {SelectStyleProps} from '../../../constants.js';
+import DatePicker from '../../components/date_picker.jsx';
+import FontAwesome from '../../../../../templates/FontAwesome.jsx';
 
 const styles = {
   modalHeader: {
@@ -22,8 +32,8 @@ const styles = {
     margin: '25px 0px 25px 0px',
     float: 'right'
   },
-  select: {
-    marginTop: 5
+  selectRow: {
+    margin: '5px 0px 5px 0px'
   }
 };
 
@@ -42,7 +52,9 @@ export default class SubmissionsDownloadForm extends React.Component {
       loadingFormNames: false,
       selectedForm: {name: '', version: ''},
       selectedFormValue: null,
-      showing: false
+      showing: false,
+      startDate: null,
+      endDate: null
     };
   }
 
@@ -84,9 +96,26 @@ export default class SubmissionsDownloadForm extends React.Component {
   };
 
   getQueryParams() {
-    return `?name=${this.state.selectedForm.name}&version=${
-      this.state.selectedForm.version
-    }`;
+    if (this.props.workshopId) {
+      return `?name=${this.state.selectedForm.name}&version=${
+        this.state.selectedForm.version
+      }`;
+    } else {
+      let queryParams = `?name=${this.state.selectedForm.name}&version=${
+        this.state.selectedForm.version
+      }`;
+      if (this.state.startDate) {
+        queryParams = `${queryParams}&start_date=${this.formatStartDate(
+          this.state.startDate
+        )}`;
+      }
+      if (this.state.endDate) {
+        queryParams = `${queryParams}&end_date=${this.formatEndDate(
+          this.state.endDate
+        )}`;
+      }
+      return queryParams;
+    }
   }
 
   onSelectChange = change => {
@@ -97,6 +126,30 @@ export default class SubmissionsDownloadForm extends React.Component {
         version: selectedFormNameVersion[1]
       },
       selectedFormValue: change.value
+    });
+  };
+
+  formatStartDate(date) {
+    return date ? date.toISOString() : null;
+  }
+
+  formatEndDate(date) {
+    if (date) {
+      // set end date to end of day
+      date = new Date(date.year(), date.month(), date.date(), 23, 59, 59, 999);
+    }
+    return date ? date.toISOString() : null;
+  }
+
+  handleStartChange = date => {
+    this.setState({
+      startDate: date
+    });
+  };
+
+  handleEndChange = date => {
+    this.setState({
+      endDate: date
     });
   };
 
@@ -125,6 +178,12 @@ export default class SubmissionsDownloadForm extends React.Component {
   }
 
   render() {
+    let isDownloadButtonDisabled = this.props.workshopId
+      ? this.state.selectedFormValue === null
+      : this.state.selectedFormValue === null ||
+        this.state.startDate === null ||
+        this.state.endDate === null;
+
     return (
       <div style={this.props.style}>
         <span onClick={this.open}>{this.props.children}</span>
@@ -136,19 +195,77 @@ export default class SubmissionsDownloadForm extends React.Component {
             <div>
               {this.state.formNamesAndVersions && (
                 <div>
-                  Form
-                  <Select
-                    options={this.getFormattedFormNameSelectOptions()}
-                    value={this.state.selectedFormValue}
-                    onChange={this.onSelectChange}
-                    style={styles.select}
-                    {...SelectStyleProps}
-                  />
+                  <Row style={styles.selectRow}>
+                    <FormGroup>
+                      <ControlLabel>Form</ControlLabel>
+                      <Select
+                        options={this.getFormattedFormNameSelectOptions()}
+                        value={this.state.selectedFormValue}
+                        onChange={this.onSelectChange}
+                        {...SelectStyleProps}
+                      />
+                    </FormGroup>
+                  </Row>
+                  {!this.props.workshopId && (
+                    <div>
+                      <Row className="submission-download-datepicker">
+                        <Col md={6}>
+                          <FormGroup>
+                            <ControlLabel>
+                              From
+                              <span data-for="date-tooltip" data-tip>
+                                <FontAwesome
+                                  icon="question-circle-o"
+                                  style={{
+                                    cursor: 'pointer',
+                                    marginLeft: '0.5em',
+                                    marginRight: '0.5em'
+                                  }}
+                                />
+                                <ReactTooltip
+                                  role="tooltip"
+                                  id="date-tooltip"
+                                  effect="solid"
+                                >
+                                  <div style={{maxWidth: 200}}>
+                                    You must provide a date range in order to
+                                    download submissions. If the download times
+                                    out, please shorten the date range.
+                                  </div>
+                                </ReactTooltip>
+                              </span>
+                            </ControlLabel>
+                            <DatePicker
+                              date={this.state.startDate}
+                              onChange={this.handleStartChange}
+                              selectsStart
+                              startDate={this.state.startDate}
+                              endDate={this.state.endDate}
+                              clearable
+                            />
+                          </FormGroup>
+                        </Col>
+                        <Col md={6}>
+                          <FormGroup>
+                            <ControlLabel>To</ControlLabel>
+                            <DatePicker
+                              date={this.state.endDate}
+                              onChange={this.handleEndChange}
+                              selectsEnd
+                              startDate={this.state.startDate}
+                              endDate={this.state.endDate}
+                              clearable
+                            />
+                          </FormGroup>
+                        </Col>
+                      </Row>
+                    </div>
+                  )}
                   <div>
                     <Button
                       onClick={this.handleDownloadCsvClick}
                       style={styles.downloadButton}
-                      disabled={this.state.selectedFormValue === null}
+                      disabled={isDownloadButtonDisabled}
                     >
                       Download as CSV
                     </Button>

--- a/apps/src/code-studio/pd/workshop_dashboard/reports/foorm/submissions_download_form.jsx
+++ b/apps/src/code-studio/pd/workshop_dashboard/reports/foorm/submissions_download_form.jsx
@@ -34,6 +34,14 @@ const styles = {
   },
   selectRow: {
     margin: '5px 0px 5px 0px'
+  },
+  questionTooltip: {
+    cursor: 'pointer',
+    marginLeft: '0.5em',
+    marginRight: '0.5em'
+  },
+  tooltipText: {
+    maxWidth: 200
   }
 };
 
@@ -216,18 +224,14 @@ export default class SubmissionsDownloadForm extends React.Component {
                               <span data-for="date-tooltip" data-tip>
                                 <FontAwesome
                                   icon="question-circle-o"
-                                  style={{
-                                    cursor: 'pointer',
-                                    marginLeft: '0.5em',
-                                    marginRight: '0.5em'
-                                  }}
+                                  style={styles.questionTooltip}
                                 />
                                 <ReactTooltip
                                   role="tooltip"
                                   id="date-tooltip"
                                   effect="solid"
                                 >
-                                  <div style={{maxWidth: 200}}>
+                                  <div style={styles.tooltipText}>
                                     You must provide a date range in order to
                                     download submissions. If the download times
                                     out, please shorten the date range.

--- a/apps/style/code-studio/pd.scss
+++ b/apps/style/code-studio/pd.scss
@@ -193,3 +193,8 @@ form .form-required-field {
     padding: 10px 20px 10px 20px;
   }
 }
+
+.submission-download-datepicker .form-control {
+    z-index: -1 !important;
+}
+

--- a/dashboard/app/controllers/api/v1/pd/foorm_controller.rb
+++ b/dashboard/app/controllers/api/v1/pd/foorm_controller.rb
@@ -35,9 +35,19 @@ class Api::V1::Pd::FoormController < ::ApplicationController
 
     form_name = params[:name]
     form_version = params[:version]
+    start_date = params[:start_date]
+    end_date = params[:end_date]
     form = Foorm::Form.where(name: form_name, version: form_version).first
     filename = "#{form_name}_submissions.csv"
-    csv = form.submissions_to_csv
+    submissions = nil
+    if start_date || end_date
+      # we did not start using foorm until May 2020, if no start date was provided use 5/1/2020
+      start_date = start_date ? DateTime.parse(start_date) : DateTime.new(2020, 5, 1, 0, 0, 0)
+      end_date = end_date ? DateTime.parse(end_date) : DateTime.now
+      time_range = start_date..end_date
+      submissions = form.submissions.where(created_at: time_range)
+    end
+    csv = form.submissions_to_csv(submissions)
     send_csv_attachment(csv, filename)
   end
 end

--- a/dashboard/app/models/foorm/form.rb
+++ b/dashboard/app/models/foorm/form.rb
@@ -178,7 +178,6 @@ class Foorm::Form < ActiveRecord::Base
   # to the csv.
   # @return csv text
   def submissions_to_csv(submissions_to_report=nil)
-    start_time = Time.now
     submissions_to_report ||= submissions
     calculated_readable_questions = readable_questions
     headers = calculated_readable_questions[:general]
@@ -192,12 +191,8 @@ class Foorm::Form < ActiveRecord::Base
       end
     end
 
-    filter_time = Time.now
-    puts "time to filter: #{filter_time - start_time} seconds"
     # Default headers are the non-facilitator specific set of questions.
-
     parsed_answers = []
-    start_submission_parsing = Time.now
     filtered_submissions.each do |submission|
       next if submission.form_name != name || submission.form_version != version
       answers = submission.formatted_answers
@@ -261,8 +256,6 @@ class Foorm::Form < ActiveRecord::Base
       parsed_answers << answers
     end
 
-    puts "time to parse submissions: #{Time.now - start_submission_parsing}"
-
     # Now we know all the headers, create comma_separated_submissions with answers for all headers (filling in with
     # nil where necessary)
     comma_separated_submissions = []
@@ -276,7 +269,6 @@ class Foorm::Form < ActiveRecord::Base
       rows_to_write.each {|row| csv << row}
     end
 
-    puts "total time: #{Time.now - start_time}"
     csv_result
   end
 

--- a/dashboard/app/models/foorm/form.rb
+++ b/dashboard/app/models/foorm/form.rb
@@ -178,17 +178,16 @@ class Foorm::Form < ActiveRecord::Base
   # to the csv.
   # @return csv text
   def submissions_to_csv(submissions_to_report=nil)
-    submissions_to_report ||= submissions
     calculated_readable_questions = readable_questions
     headers = calculated_readable_questions[:general]
     has_facilitator_questions = !(calculated_readable_questions[:facilitator].nil_or_empty?)
-    filtered_submissions = submissions_to_report
+    filtered_submissions = submissions_to_report || submissions
 
     if has_facilitator_questions
-      filtered_submissions = submissions_to_report.
+      filtered_submissions = filtered_submissions.
         reject do |submission|
-        submission.workshop_metadata&.facilitator_specific?
-      end
+          submission.workshop_metadata&.facilitator_specific?
+        end
     end
 
     # Default headers are the non-facilitator specific set of questions.
@@ -213,6 +212,7 @@ class Foorm::Form < ActiveRecord::Base
 
       headers = potential_new_headers.merge headers
 
+      # look for associated facilitator questions if the form has facilitator questions.
       if has_facilitator_questions
         associated_facilitator_submissions = submission.associated_facilitator_submissions
 

--- a/dashboard/app/models/foorm/submission.rb
+++ b/dashboard/app/models/foorm/submission.rb
@@ -86,9 +86,10 @@ class Foorm::Submission < ActiveRecord::Base
     return {} if workshop_metadata.nil? || workshop_metadata.facilitator_specific?
 
     {
+      'created_at' => created_at,
       'user_id' => workshop_metadata.user&.id,
       'pd_workshop_id' => workshop_metadata.pd_workshop&.id,
-      'pd_session_id' => workshop_metadata.pd_session&.id
+      'pd_session_id' => workshop_metadata.pd_session&.id,
     }
   end
 

--- a/dashboard/app/models/foorm/submission.rb
+++ b/dashboard/app/models/foorm/submission.rb
@@ -89,7 +89,7 @@ class Foorm::Submission < ActiveRecord::Base
       'created_at' => created_at,
       'user_id' => workshop_metadata.user&.id,
       'pd_workshop_id' => workshop_metadata.pd_workshop&.id,
-      'pd_session_id' => workshop_metadata.pd_session&.id,
+      'pd_session_id' => workshop_metadata.pd_session&.id
     }
   end
 

--- a/dashboard/test/factories/foorm_factories.rb
+++ b/dashboard/test/factories/foorm_factories.rb
@@ -171,6 +171,28 @@ FactoryGirl.define do
     end
   end
 
+  factory :pd_pre_workshop_foorm_submission, class: 'Pd::WorkshopSurveyFoormSubmission' do
+    association :pd_workshop, factory: :csd_summer_workshop
+    association :user, factory: :teacher
+    day 0
+
+    association :foorm_submission, factory: :pre_workshop_foorm_submission
+  end
+
+  # this factory uses the real summer workshop pre survey.
+  factory :pre_workshop_foorm_submission, class: 'Foorm::Submission' do
+    form_name "surveys/pd/summer_workshop_pre_survey"
+    foorm_submission_metadata
+
+    answers '{"workshop_course":"CS Discoveries","workshop_subject":"5-day Summer","regional_partner_name":"Partner1",
+              "is_virtual":"true","num_facilitators":"1","day":"0","is_friday_institute":"false","workshop_agenda":"",
+              "required_course_status":"required","course_length_weeks":"11_15","section_time_minutes":"50_less",
+              "grade_levels_csd":["11","9"],"total_pd_time":"16_35","cs_community":{"someone_to_turn_to":"6",
+              "know_teacher_leaders":"6"},"lead_learner":"4","recruit_responsibility":"2",
+              "highest_level_cs_education":"college_courses","assigned_or_chose_to_teach":"assigned",
+              "gender_identity":"female","racial_ethnic_identity":["white"]}'
+  end
+
   factory :day_0_workshop_foorm_submission, class: 'Pd::WorkshopSurveyFoormSubmission' do
     association :pd_workshop, factory: :csd_summer_workshop
     association :user, factory: :teacher

--- a/dashboard/test/models/foorm/form_test.rb
+++ b/dashboard/test/models/foorm/form_test.rb
@@ -56,6 +56,7 @@ class Foorm::FormTest < ActiveSupport::TestCase
     submission = submission_workshop_metadata.foorm_submission
 
     other_headers = {
+      'created_at' => 'created_at',
       'user_id' => 'user_id',
       'pd_workshop_id' => 'pd_workshop_id',
       'pd_session_id' => 'pd_session_id'
@@ -91,6 +92,7 @@ class Foorm::FormTest < ActiveSupport::TestCase
     general_submission = general_submission_workshop_metadata.foorm_submission
 
     other_general_headers = {
+      'created_at' => 'created_at',
       'user_id' => 'user_id',
       'pd_workshop_id' => 'pd_workshop_id',
       'pd_session_id' => 'pd_session_id'
@@ -98,7 +100,7 @@ class Foorm::FormTest < ActiveSupport::TestCase
 
     expected_headers = other_general_headers.
       merge(form.readable_questions[:general]).
-      merge(form.readable_questions_with_facilitator_number(1))
+      merge(form.readable_questions_with_facilitator_number(form.readable_questions, 1))
 
     expected_response = general_submission.formatted_answers
 
@@ -117,6 +119,7 @@ class Foorm::FormTest < ActiveSupport::TestCase
     facilitator_submission = facilitator_submission_workshop_metadata.foorm_submission
 
     other_general_headers = {
+      'created_at' => 'created_at',
       'user_id' => 'user_id',
       'pd_workshop_id' => 'pd_workshop_id',
       'pd_session_id' => 'pd_session_id'
@@ -130,7 +133,7 @@ class Foorm::FormTest < ActiveSupport::TestCase
     expected_headers = other_general_headers.
       merge(form.readable_questions[:general]).
       merge(other_facilitator_headers).
-      merge(form.readable_questions_with_facilitator_number(1))
+      merge(form.readable_questions_with_facilitator_number(form.readable_questions, 1))
 
     expected_response = general_submission.formatted_answers.
       merge(facilitator_submission.formatted_answers_with_facilitator_number(1))
@@ -152,6 +155,7 @@ class Foorm::FormTest < ActiveSupport::TestCase
     general_submission_2 = general_submission_workshop_metadata_2.foorm_submission
 
     other_general_headers = {
+      'created_at' => 'created_at',
       'user_id' => 'user_id',
       'pd_workshop_id' => 'pd_workshop_id',
       'pd_session_id' => 'pd_session_id'
@@ -165,7 +169,7 @@ class Foorm::FormTest < ActiveSupport::TestCase
     expected_headers = other_general_headers.
       merge(form.readable_questions[:general]).
       merge(other_facilitator_headers).
-      merge(form.readable_questions_with_facilitator_number(1))
+      merge(form.readable_questions_with_facilitator_number(form.readable_questions, 1))
 
     expected_response_1 = general_submission_1.formatted_answers.
       merge(facilitator_submission_1.formatted_answers_with_facilitator_number(1))
@@ -195,6 +199,7 @@ class Foorm::FormTest < ActiveSupport::TestCase
     facilitator_submission_1 = facilitator_submission_workshop_metadata_1.foorm_submission
 
     other_general_headers = {
+      'created_at' => 'created_at',
       'user_id' => 'user_id',
       'pd_workshop_id' => 'pd_workshop_id',
       'pd_session_id' => 'pd_session_id'
@@ -208,7 +213,7 @@ class Foorm::FormTest < ActiveSupport::TestCase
     expected_headers = other_general_headers.
       merge(form.readable_questions[:general]).
       merge(other_facilitator_headers).
-      merge(form.readable_questions_with_facilitator_number(1))
+      merge(form.readable_questions_with_facilitator_number(form.readable_questions, 1))
 
     expected_response_1 = general_submission_1.formatted_answers.
       merge(facilitator_submission_1.formatted_answers_with_facilitator_number(1))
@@ -237,6 +242,7 @@ class Foorm::FormTest < ActiveSupport::TestCase
     other_submission = other_form_workshop_metadata.foorm_submission
 
     other_general_headers = {
+      'created_at' => 'created_at',
       'user_id' => 'user_id',
       'pd_workshop_id' => 'pd_workshop_id',
       'pd_session_id' => 'pd_session_id'
@@ -250,7 +256,7 @@ class Foorm::FormTest < ActiveSupport::TestCase
     expected_headers = other_general_headers.
       merge(form.readable_questions[:general]).
       merge(other_facilitator_headers).
-      merge(form.readable_questions_with_facilitator_number(1))
+      merge(form.readable_questions_with_facilitator_number(form.readable_questions, 1))
 
     expected_response_1 = general_submission_1.formatted_answers.
       merge(facilitator_submission_1.formatted_answers_with_facilitator_number(1))


### PR DESCRIPTION
The overall, per-form, foorm csv download currently times out for large datasets. For these, add a date filter to enable smaller csv downloads. This PR also includes some perf improvements to our csv export. However, we still need the date filter as the time to download increases linearly with the number of forms and will eventually time out. This is also a helpful tool for workshop admins, as they can just download the responses they are interested in.

The performance improvements are:
- Avoid some duplicate calculations. For example we were re-parsing the form for every submission, which we do not need to do. Now the form will only be parsed one time. This one change saved about 6 seconds for 1500 submissions.
- Don't try to look for facilitator submissions if we know the form doesn't have facilitator questions (avoids extra queries).

The per-workshop export behavior and UI is unchanged. The overall workshop export modal now looks like this (all fields are required in order for the download button to be enabled):
![Screen Shot 2020-10-23 at 4 29 36 PM](https://user-images.githubusercontent.com/33666587/97061974-ba77a380-154d-11eb-9f7e-17f2c20758b6.png)

There is a help tip for the date range to explain that it is required and advises to shorten the range if the request times out:
![Screen Shot 2020-10-23 at 4 29 48 PM](https://user-images.githubusercontent.com/33666587/97061994-ccf1dd00-154d-11eb-9db7-adf64715d50f.png)


<!-- ### Background -->
<!-- ### Privacy -->
<!--
1.	Does the Project involve the collection, use or sharing of new Personal Data?

2.	Does the Project involve a new or changed use or sharing of existing Personal Data?
-->
<!-- ### Security -->
<!--
Link to Jira Task where sensitive security issues are discussed privately.
-->
<!-- ### Caching -->
<!-- ### Deployment strategy -->
<!-- ### Future work -->

## Links

- [jira](https://codedotorg.atlassian.net/browse/PLC-1035)

## Testing story
Tested locally.

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
