### PR TITLE
Teacher Facing Lesson Plan: Add Agenda Section

### DIFF
--- a/apps/i18n/common/en_us.json
+++ b/apps/i18n/common/en_us.json
@@ -50,6 +50,7 @@
   "administrators": "Administrators",
   "advancedShare": "Show advanced options",
   "age": "Age",
+  "agenda": "Agenda",
   "all": "All",
   "allHandouts": "All Handouts",
   "allowEditing": "Allow editing",

--- a/apps/i18n/common/en_us.json
+++ b/apps/i18n/common/en_us.json
@@ -1116,6 +1116,7 @@
   "minecraftAquaticPromoButton": "Start",
   "minecraftAquaticPromoDesc": "Minecraft is back for the Hour of Code with a brand new activity! Use your creativity and problem solving skills to explore and build underwater worlds with code.",
   "minecraftAquaticPromoTitle": "Minecraft: Voyage Aquatic",
+  "minutes": "minutes",
   "missingRecommendedBlocksErrorMsg": "Not quite. Try using a block you aren’t using yet.",
   "missingRequiredBlocksErrorMsg": "Not quite. You have to use a block you aren’t using yet.",
   "missionStatement": "**Code.org®** is a nonprofit dedicated to expanding access to computer science in schools and increasing participation by women and underrepresented minorities. Our vision is that every student in every school has the opportunity to learn computer science, just like biology, chemistry or algebra. Code.org provides the leading curriculum for K-12 computer science in the largest school districts in the United States and Code.org also organizes the annual Hour of Code campaign which has engaged 15% of all students in the world. Code.org is supported by generous donors including Amazon, Facebook, Google, the Infosys Foundation, Microsoft, and many more.",

--- a/apps/src/templates/lessonOverview/LessonAgenda.jsx
+++ b/apps/src/templates/lessonOverview/LessonAgenda.jsx
@@ -1,0 +1,32 @@
+import PropTypes from 'prop-types';
+import React, {Component} from 'react';
+import i18n from '@cdo/locale';
+
+export default class LessonAgenda extends Component {
+  static propTypes = {
+    activities: PropTypes.array.isRequired
+  };
+
+  render() {
+    return (
+      <div>
+        {this.props.activities.map(activity => (
+          <ul key={activity.key} style={{listStyleType: 'none'}}>
+            <li>
+              <a href={`#activity-${activity.key}`}>{`${
+                activity.displayName
+              } (${activity.duration} ${i18n.minutes()})`}</a>
+            </li>
+            {activity.activitySections.map(section => (
+              <li style={{marginLeft: 15}} key={section.key}>
+                <a href={`#activity-section-${section.key}`}>
+                  {section.displayName}
+                </a>
+              </li>
+            ))}
+          </ul>
+        ))}
+      </div>
+    );
+  }
+}

--- a/apps/src/templates/lessonOverview/LessonAgenda.jsx
+++ b/apps/src/templates/lessonOverview/LessonAgenda.jsx
@@ -1,6 +1,7 @@
 import PropTypes from 'prop-types';
 import React, {Component} from 'react';
 import i18n from '@cdo/locale';
+import _ from 'lodash';
 
 export default class LessonAgenda extends Component {
   static propTypes = {
@@ -9,7 +10,8 @@ export default class LessonAgenda extends Component {
 
   render() {
     // Do not link to sections that are progressions and sections without a displayName
-    this.props.activities.forEach(activity => {
+    let filteredActivitiesList = _.cloneDeep(this.props.activities);
+    filteredActivitiesList.forEach(activity => {
       let filteredActivitySections = [];
       activity.activitySections.forEach(section => {
         if (section.displayName !== '' && section.scriptLevels.length < 1) {
@@ -21,7 +23,7 @@ export default class LessonAgenda extends Component {
 
     return (
       <div>
-        {this.props.activities.map(activity => (
+        {filteredActivitiesList.map(activity => (
           <ul key={activity.key} style={{listStyleType: 'none'}}>
             <li>
               <a href={`#activity-${activity.key}`}>{`${

--- a/apps/src/templates/lessonOverview/LessonAgenda.jsx
+++ b/apps/src/templates/lessonOverview/LessonAgenda.jsx
@@ -8,6 +8,17 @@ export default class LessonAgenda extends Component {
   };
 
   render() {
+    // Do not link to sections that are progressions and sections without a displayName
+    this.props.activities.forEach(activity => {
+      let filteredActivitySections = [];
+      activity.activitySections.forEach(section => {
+        if (section.displayName !== '' && section.scriptLevels.length < 1) {
+          filteredActivitySections.push(section);
+        }
+      });
+      activity.activitySections = filteredActivitySections;
+    });
+
     return (
       <div>
         {this.props.activities.map(activity => (

--- a/apps/src/templates/lessonOverview/LessonAgenda.jsx
+++ b/apps/src/templates/lessonOverview/LessonAgenda.jsx
@@ -12,13 +12,9 @@ export default class LessonAgenda extends Component {
     // Do not link to sections that are progressions and sections without a displayName
     let filteredActivitiesList = _.cloneDeep(this.props.activities);
     filteredActivitiesList.forEach(activity => {
-      let filteredActivitySections = [];
-      activity.activitySections.forEach(section => {
-        if (section.displayName !== '' && section.scriptLevels.length < 1) {
-          filteredActivitySections.push(section);
-        }
-      });
-      activity.activitySections = filteredActivitySections;
+      activity.activitySections = activity.activitySections.filter(
+        section => section.displayName !== '' && section.scriptLevels.length < 1
+      );
     });
 
     return (

--- a/apps/src/templates/lessonOverview/LessonOverview.jsx
+++ b/apps/src/templates/lessonOverview/LessonOverview.jsx
@@ -12,6 +12,7 @@ import styleConstants from '@cdo/apps/styleConstants';
 import color from '@cdo/apps/util/color';
 import Button from '@cdo/apps/templates/Button';
 import DropdownButton from '@cdo/apps/templates/DropdownButton';
+import LessonAgenda from '@cdo/apps/templates/lessonOverview/LessonAgenda';
 
 const styles = {
   frontPage: {
@@ -113,20 +114,7 @@ class LessonOverview extends Component {
             <SafeMarkdown markdown={lesson.purpose} />
 
             <h2>{i18n.agenda()}</h2>
-            {this.props.activities.map(activity => (
-              <ul key={activity.key} style={{listStyleType: 'none'}}>
-                <li>
-                  <a>{`${activity.displayName} (${
-                    activity.duration
-                  } ${i18n.minutes()})`}</a>
-                </li>
-                {activity.activitySections.map(section => (
-                  <li style={{marginLeft: 15}} key={section.key}>
-                    <a>{section.displayName}</a>
-                  </li>
-                ))}
-              </ul>
-            ))}
+            <LessonAgenda activities={this.props.activities} />
           </div>
           <div style={styles.right}>
             <h2>{i18n.preparation()}</h2>

--- a/apps/src/templates/lessonOverview/LessonOverview.jsx
+++ b/apps/src/templates/lessonOverview/LessonOverview.jsx
@@ -114,12 +114,14 @@ class LessonOverview extends Component {
 
             <h2>{i18n.agenda()}</h2>
             {this.props.activities.map(activity => (
-              <ul style={{listStyleType: 'none'}}>
+              <ul key={activity.key} style={{listStyleType: 'none'}}>
                 <li>
-                  <a>{activity.displayName}</a>
+                  <a>{`${activity.displayName} (${
+                    activity.duration
+                  } ${i18n.minutes()})`}</a>
                 </li>
                 {activity.activitySections.map(section => (
-                  <li style={{marginLeft: 15}}>
+                  <li style={{marginLeft: 15}} key={section.key}>
                     <a>{section.displayName}</a>
                   </li>
                 ))}

--- a/apps/src/templates/lessonOverview/LessonOverview.jsx
+++ b/apps/src/templates/lessonOverview/LessonOverview.jsx
@@ -111,6 +111,20 @@ class LessonOverview extends Component {
 
             <h2>{i18n.purpose()}</h2>
             <SafeMarkdown markdown={lesson.purpose} />
+
+            <h2>{i18n.agenda()}</h2>
+            {this.props.activities.map(activity => (
+              <ul style={{listStyleType: 'none'}}>
+                <li>
+                  <a>{activity.displayName}</a>
+                </li>
+                {activity.activitySections.map(section => (
+                  <li style={{marginLeft: 15}}>
+                    <a>{section.displayName}</a>
+                  </li>
+                ))}
+              </ul>
+            ))}
           </div>
           <div style={styles.right}>
             <h2>{i18n.preparation()}</h2>

--- a/apps/src/templates/lessonOverview/activities/Activity.jsx
+++ b/apps/src/templates/lessonOverview/activities/Activity.jsx
@@ -20,7 +20,7 @@ export default class Activity extends Component {
 
     return (
       <div>
-        <h2 style={styles.activityHeader}>
+        <h2 style={styles.activityHeader} id={`activity-${activity.key}`}>
           {i18n.activityHeader({
             activityName: activity.displayName,
             activityDuration: activity.duration

--- a/apps/src/templates/lessonOverview/activities/ActivitySection.jsx
+++ b/apps/src/templates/lessonOverview/activities/ActivitySection.jsx
@@ -44,7 +44,9 @@ export default class ActivitySection extends Component {
 
     return (
       <div>
-        {!isProgressionSection && <h4>{section.displayName}</h4>}
+        {!isProgressionSection && (
+          <h4 id={`activity-section-${section.key}`}>{section.displayName}</h4>
+        )}
         {section.remarks && (
           <div>
             <h4>

--- a/apps/test/unit/templates/lessonOverview/LessonAgendaTest.jsx
+++ b/apps/test/unit/templates/lessonOverview/LessonAgendaTest.jsx
@@ -1,0 +1,109 @@
+import React from 'react';
+import {shallow} from 'enzyme';
+import {expect} from '../../../util/reconfiguredChai';
+import LessonAgenda from '@cdo/apps/templates/lessonOverview/LessonAgenda';
+
+describe('LessonAgenda', () => {
+  let defaultProps;
+  beforeEach(() => {
+    defaultProps = {
+      activities: [
+        {
+          key: 'activity-1',
+          displayName: 'Main Activity',
+          duration: 20,
+          activitySections: [
+            {
+              key: 'section-1',
+              displayName: 'Making programs',
+              scriptLevels: []
+            },
+            {
+              key: 'section-2',
+              displayName: '',
+              scriptLevels: [{id: 10}]
+            },
+            {
+              key: 'section-3',
+              displayName: 'Non Programming Progression',
+              scriptLevels: []
+            }
+          ]
+        },
+        {
+          key: 'activity-2',
+          displayName: '2nd Activity',
+          duration: 30,
+          activitySections: [
+            {
+              key: 'section-4',
+              displayName: 'Section 4',
+              scriptLevels: [{id: 11}]
+            },
+            {
+              key: 'section-5',
+              displayName: '',
+              scriptLevels: []
+            },
+            {
+              key: 'section-6',
+              displayName: 'Section 6',
+              scriptLevels: []
+            }
+          ]
+        }
+      ]
+    };
+  });
+
+  it('renders default props', () => {
+    const wrapper = shallow(<LessonAgenda {...defaultProps} />);
+    expect(wrapper.find('a').length).to.equal(5);
+
+    expect(
+      wrapper
+        .find('a')
+        .at(0)
+        .props().href
+    ).to.equal('#activity-activity-1');
+    expect(
+      wrapper
+        .find('a')
+        .at(0)
+        .contains('Main Activity (20 minutes)')
+    ).to.be.true;
+
+    expect(
+      wrapper
+        .find('a')
+        .at(1)
+        .props().href
+    ).to.equal('#activity-section-section-1');
+    expect(
+      wrapper
+        .find('a')
+        .at(2)
+        .props().href
+    ).to.equal('#activity-section-section-3');
+
+    expect(
+      wrapper
+        .find('a')
+        .at(3)
+        .props().href
+    ).to.equal('#activity-activity-2');
+    expect(
+      wrapper
+        .find('a')
+        .at(3)
+        .contains('2nd Activity (30 minutes)')
+    ).to.be.true;
+
+    expect(
+      wrapper
+        .find('a')
+        .at(4)
+        .props().href
+    ).to.equal('#activity-section-section-6');
+  });
+});

--- a/apps/test/unit/templates/lessonOverview/LessonOverviewTest.js
+++ b/apps/test/unit/templates/lessonOverview/LessonOverviewTest.js
@@ -59,6 +59,8 @@ describe('LessonOverview', () => {
       'The purpose of the lesson is for people to learn'
     );
     expect(safeMarkdowns.at(2).props().markdown).to.contain('- One');
+
+    expect(wrapper.find('LessonAgenda').length).to.equal(1);
   });
 
   it('renders correct number of activities', () => {


### PR DESCRIPTION
Creates the Agenda for the Teacher Facing Lesson Plan which links to the activities and activity sections below.

In order to make the agenda act like the agenda on curriculumbuilder did we:
- Don't link to any activity section that does not have a display
- Don't link to activity sections that are level progressions (we might find we want this but this was the thing most similar to what we have now)

<img width="1077" alt="Screen Shot 2020-10-23 at 10 28 54 PM" src="https://user-images.githubusercontent.com/208083/97065955-2aeae880-157f-11eb-9aac-2ca1a4399775.png">


![lesson-agenda](https://user-images.githubusercontent.com/208083/97065880-a39d7500-157e-11eb-886d-5375aac28008.gif)
## Links

<!--
  Any relevant links to external resources; ie, specification documents, jira
  items, related PRs, honeybadger errors, etc
-->
-[spec](https://docs.google.com/document/d/1SaZRs36uEkJIJUDe4nB1KoGAmhHvmgmSEcYtysGReUE/edit#)
- [jira](https://codedotorg.atlassian.net/browse/PLAT-340)

## Testing story

- Update LessonOverviewTest
- Created new test for LessonAgenda

- Manually tested this locally

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
