### PR TITLE
Fix reordering of lessons via drag-and-drop on the script edit gui page

### DIFF
--- a/apps/src/lib/levelbuilder/script-editor/LessonGroupCard.jsx
+++ b/apps/src/lib/levelbuilder/script-editor/LessonGroupCard.jsx
@@ -6,7 +6,6 @@ import ReactDOM from 'react-dom';
 import {borderRadius, tokenMargin} from '@cdo/apps/lib/levelbuilder/constants';
 import OrderControls from '@cdo/apps/lib/levelbuilder/OrderControls';
 import {
-  moveLesson,
   moveGroup,
   removeLesson,
   addLesson,
@@ -75,7 +74,6 @@ class LessonGroupCard extends Component {
     addLesson: PropTypes.func.isRequired,
     moveGroup: PropTypes.func.isRequired,
     removeGroup: PropTypes.func.isRequired,
-    moveLesson: PropTypes.func.isRequired,
     removeLesson: PropTypes.func.isRequired,
     setLessonGroup: PropTypes.func.isRequired,
     reorderLesson: PropTypes.func.isRequired,
@@ -355,7 +353,6 @@ export const UnconnectedLessonGroupCard = LessonGroupCard;
 export default connect(
   state => ({}),
   {
-    moveLesson,
     moveGroup,
     removeLesson,
     removeGroup,

--- a/apps/src/lib/levelbuilder/script-editor/scriptEditorRedux.js
+++ b/apps/src/lib/levelbuilder/script-editor/scriptEditorRedux.js
@@ -115,17 +115,15 @@ function updateGroupPositions(lessonGroups) {
 
 function updateLessonPositions(lessonGroups) {
   let relativePosition = 1;
-  let absolutePosition = 1;
   lessonGroups.forEach(lessonGroup => {
-    lessonGroup.lessons.forEach(lesson => {
-      lesson.position = absolutePosition;
+    lessonGroup.lessons.forEach((lesson, lessonIndex) => {
+      lesson.position = lessonIndex + 1;
       if (lesson.lockable) {
         lesson.relativePosition = undefined;
       } else {
         lesson.relativePosition = relativePosition;
         relativePosition++;
       }
-      absolutePosition++;
     });
   });
 }

--- a/apps/src/lib/levelbuilder/script-editor/scriptEditorRedux.js
+++ b/apps/src/lib/levelbuilder/script-editor/scriptEditorRedux.js
@@ -153,7 +153,7 @@ function lessonGroups(state = [], action) {
     }
     case REMOVE_LESSON: {
       const lessons = newState[action.groupPosition - 1].lessons;
-      lessons.splice(action.lessonPosition - lessons[0].position, 1);
+      lessons.splice(action.lessonPosition - 1, 1);
       updateLessonPositions(newState);
       break;
     }
@@ -176,10 +176,7 @@ function lessonGroups(state = [], action) {
     case SET_LESSON_GROUP: {
       // Remove the lesson from the old lesson group
       const oldLessons = newState[action.oldGroupPosition - 1].lessons;
-      const curLesson = oldLessons.splice(
-        action.lessonPosition - oldLessons[0].position,
-        1
-      )[0];
+      const curLesson = oldLessons.splice(action.lessonPosition - 1, 1)[0];
 
       // add lesson to the new lesson group
       const newLessons = newState[action.newGroupPosition - 1].lessons;

--- a/apps/src/lib/levelbuilder/script-editor/scriptEditorRedux.js
+++ b/apps/src/lib/levelbuilder/script-editor/scriptEditorRedux.js
@@ -251,8 +251,13 @@ function lessonGroups(state = [], action) {
     }
     case REORDER_LESSON: {
       const lessons = newState[action.groupPosition - 1].lessons;
-      const temp = lessons.splice(action.originalLessonPosition - 1, 1);
-      lessons.splice(action.newLessonPosition - 1, 0, temp[0]);
+
+      const positionOffset = lessons[0].position;
+      const oldIndex = action.originalLessonPosition - positionOffset;
+      const temp = lessons.splice(oldIndex, 1);
+      const newIndex = action.newLessonPosition - positionOffset;
+      lessons.splice(newIndex, 0, temp[0]);
+
       updateLessonPositions(newState);
       break;
     }

--- a/apps/src/lib/levelbuilder/script-editor/scriptEditorRedux.js
+++ b/apps/src/lib/levelbuilder/script-editor/scriptEditorRedux.js
@@ -114,16 +114,9 @@ function updateGroupPositions(lessonGroups) {
 }
 
 function updateLessonPositions(lessonGroups) {
-  let relativePosition = 1;
   lessonGroups.forEach(lessonGroup => {
     lessonGroup.lessons.forEach((lesson, lessonIndex) => {
       lesson.position = lessonIndex + 1;
-      if (lesson.lockable) {
-        lesson.relativePosition = undefined;
-      } else {
-        lesson.relativePosition = relativePosition;
-        relativePosition++;
-      }
     });
   });
 }

--- a/apps/src/lib/levelbuilder/script-editor/scriptEditorRedux.js
+++ b/apps/src/lib/levelbuilder/script-editor/scriptEditorRedux.js
@@ -251,13 +251,8 @@ function lessonGroups(state = [], action) {
     }
     case REORDER_LESSON: {
       const lessons = newState[action.groupPosition - 1].lessons;
-
-      const positionOffset = lessons[0].position;
-      const oldIndex = action.originalLessonPosition - positionOffset;
-      const temp = lessons.splice(oldIndex, 1);
-      const newIndex = action.newLessonPosition - positionOffset;
-      lessons.splice(newIndex, 0, temp[0]);
-
+      const temp = lessons.splice(action.originalLessonPosition - 1, 1);
+      lessons.splice(action.newLessonPosition - 1, 0, temp[0]);
       updateLessonPositions(newState);
       break;
     }

--- a/apps/src/lib/levelbuilder/script-editor/scriptEditorRedux.js
+++ b/apps/src/lib/levelbuilder/script-editor/scriptEditorRedux.js
@@ -6,7 +6,6 @@ const INIT = 'scriptEditor/INIT';
 const ADD_GROUP = 'scriptEditor/ADD_GROUP';
 const ADD_LESSON = 'scriptEditor/ADD_LESSON';
 const MOVE_GROUP = 'scriptEditor/MOVE_GROUP';
-const MOVE_LESSON = 'scriptEditor/MOVE_LESSON';
 const REMOVE_GROUP = 'scriptEditor/REMOVE_GROUP';
 const REMOVE_LESSON = 'scriptEditor/REMOVE_LESSON';
 const SET_LESSON_GROUP = 'scriptEditor/SET_LESSON_GROUP';
@@ -41,13 +40,6 @@ export const addLesson = (groupPosition, lessonKey, lessonName) => ({
 export const moveGroup = (groupPosition, direction) => ({
   type: MOVE_GROUP,
   groupPosition,
-  direction
-});
-
-export const moveLesson = (groupPosition, lessonPosition, direction) => ({
-  type: MOVE_LESSON,
-  groupPosition,
-  lessonPosition,
   direction
 });
 
@@ -178,37 +170,6 @@ function lessonGroups(state = [], action) {
       newState[index] = newState[swap];
       newState[swap] = tempGroup;
       updateGroupPositions(newState);
-      updateLessonPositions(newState);
-      break;
-    }
-    case MOVE_LESSON: {
-      const groupIndex = action.groupPosition - 1;
-
-      const lessons = newState[groupIndex].lessons;
-
-      const lessonIndex = action.lessonPosition - lessons[0].position;
-      const lessonSwapIndex =
-        action.direction === 'up' ? lessonIndex - 1 : lessonIndex + 1;
-
-      if (lessonSwapIndex >= 0 && lessonSwapIndex <= lessons.length - 1) {
-        //if lesson is staying in the same lesson group
-        const tempLesson = lessons[lessonIndex];
-        lessons[lessonIndex] = lessons[lessonSwapIndex];
-        lessons[lessonSwapIndex] = tempLesson;
-      } else {
-        const groupSwapIndex =
-          action.direction === 'up' ? groupIndex - 1 : groupIndex + 1;
-
-        // Remove the lesson from the old lesson group
-        const oldLessons = newState[groupIndex].lessons;
-        const curLesson = oldLessons.splice(lessonIndex, 1)[0];
-
-        // add lesson to the new lesson group
-        const newLessons = newState[groupSwapIndex].lessons;
-        action.direction === 'up'
-          ? newLessons.push(curLesson)
-          : newLessons.unshift(curLesson);
-      }
       updateLessonPositions(newState);
       break;
     }

--- a/apps/src/sites/studio/pages/scripts/edit.js
+++ b/apps/src/sites/studio/pages/scripts/edit.js
@@ -31,7 +31,6 @@ export default function initPage(scriptEditorData) {
           id: lesson.id,
           key: lesson.key,
           position: lessonIndex + 1,
-          relativePosition: lesson.relative_position,
           lockable: lesson.lockable,
           assessment: lesson.assessment,
           unplugged: lesson.unplugged,

--- a/apps/src/sites/studio/pages/scripts/edit.js
+++ b/apps/src/sites/studio/pages/scripts/edit.js
@@ -27,10 +27,10 @@ export default function initPage(scriptEditorData) {
       bigQuestions: lesson_group.big_questions || '',
       lessons: lesson_group.lessons
         .filter(lesson => lesson.id)
-        .map(lesson => ({
+        .map((lesson, lessonIndex) => ({
           id: lesson.id,
           key: lesson.key,
-          position: lesson.position,
+          position: lessonIndex + 1,
           relativePosition: lesson.relative_position,
           lockable: lesson.lockable,
           assessment: lesson.assessment,

--- a/apps/test/unit/code-studio/scriptEditorReduxTest.js
+++ b/apps/test/unit/code-studio/scriptEditorReduxTest.js
@@ -20,24 +20,9 @@ const getInitialState = () => ({
       position: 1,
       userFacing: true,
       lessons: [
-        {
-          id: 100,
-          key: 'a',
-          name: 'A',
-          position: 1
-        },
-        {
-          name: 'B',
-          key: 'b',
-          id: 101,
-          position: 2
-        },
-        {
-          name: 'C',
-          key: 'c',
-          id: 102,
-          position: 3
-        }
+        {id: 100, key: 'a', name: 'A', position: 1},
+        {name: 'B', key: 'b', id: 101, position: 2},
+        {name: 'C', key: 'c', id: 102, position: 3}
       ]
     },
     {
@@ -46,24 +31,9 @@ const getInitialState = () => ({
       position: 2,
       userFacing: true,
       lessons: [
-        {
-          id: 104,
-          key: 'd',
-          name: 'D',
-          position: 1
-        },
-        {
-          id: 105,
-          key: 'e',
-          name: 'E',
-          position: 2
-        },
-        {
-          id: 106,
-          key: 'f',
-          name: 'F',
-          position: 3
-        }
+        {id: 104, key: 'd', name: 'D', position: 1},
+        {id: 105, key: 'e', name: 'E', position: 2},
+        {id: 106, key: 'f', name: 'F', position: 3}
       ]
     }
   ]
@@ -187,14 +157,8 @@ describe('scriptEditorRedux reducer tests', () => {
               displayName: 'X',
               position: 1,
               lessons: [
-                {
-                  id: 101,
-                  position: 1
-                },
-                {
-                  id: 102,
-                  position: 2
-                },
+                {id: 101, position: 1},
+                {id: 102, position: 2},
                 {id: 104, position: 3}
               ]
             },

--- a/apps/test/unit/code-studio/scriptEditorReduxTest.js
+++ b/apps/test/unit/code-studio/scriptEditorReduxTest.js
@@ -113,10 +113,40 @@ describe('scriptEditorRedux reducer tests', () => {
   });
 
   describe('reorderLesson', () => {
-    it('reorders lessons within first lesson group', () => {
-      const nextState = reducer(initialState, reorderLesson(1, 1, 3))
+    it('move lesson up within first lesson group', () => {
+      const nextState = reducer(initialState, reorderLesson(1, 3, 1))
         .lessonGroups;
-      assert.deepEqual(nextState[0].lessons.map(l => l.key), ['b', 'c', 'a']);
+      assert.deepEqual(nextState[0].lessons.map(l => l.key), ['c', 'a', 'b']);
+    });
+
+    it('move lesson down within first lesson group', () => {
+      const nextState = reducer(initialState, reorderLesson(1, 1, 2))
+        .lessonGroups;
+      assert.deepEqual(nextState[0].lessons.map(l => l.key), ['b', 'a', 'c']);
+    });
+
+    it('move lesson to same position within first lesson group', () => {
+      const nextState = reducer(initialState, reorderLesson(1, 2, 2))
+        .lessonGroups;
+      assert.deepEqual(nextState[0].lessons.map(l => l.key), ['a', 'b', 'c']);
+    });
+
+    it('move lesson up within second lesson group', () => {
+      const nextState = reducer(initialState, reorderLesson(2, 6, 5))
+        .lessonGroups;
+      assert.deepEqual(nextState[1].lessons.map(l => l.key), ['d', 'f', 'e']);
+    });
+
+    it('move lesson to same position within second lesson group', () => {
+      const nextState = reducer(initialState, reorderLesson(2, 5, 5))
+        .lessonGroups;
+      assert.deepEqual(nextState[1].lessons.map(l => l.key), ['d', 'e', 'f']);
+    });
+
+    it('move lesson down within second lesson group', () => {
+      const nextState = reducer(initialState, reorderLesson(2, 4, 5))
+        .lessonGroups;
+      assert.deepEqual(nextState[1].lessons.map(l => l.key), ['e', 'd', 'f']);
     });
   });
 

--- a/apps/test/unit/code-studio/scriptEditorReduxTest.js
+++ b/apps/test/unit/code-studio/scriptEditorReduxTest.js
@@ -82,10 +82,36 @@ describe('scriptEditorRedux reducer tests', () => {
   });
 
   describe('reorderLesson', () => {
-    it('reorders lessons within first lesson group', () => {
-      const nextState = reducer(initialState, reorderLesson(1, 1, 3))
+    it('move lesson up within first lesson group', () => {
+      const nextState = reducer(initialState, reorderLesson(1, 3, 2))
         .lessonGroups;
-      assert.deepEqual(nextState[0].lessons.map(l => l.key), ['b', 'c', 'a']);
+      assert.deepEqual(nextState[0].lessons.map(l => l.key), ['a', 'c', 'b']);
+    });
+    it('move lesson down within first lesson group', () => {
+      const nextState = reducer(initialState, reorderLesson(1, 1, 2))
+        .lessonGroups;
+      assert.deepEqual(nextState[0].lessons.map(l => l.key), ['b', 'a', 'c']);
+    });
+    it('move lesson to same position within first lesson group', () => {
+      const nextState = reducer(initialState, reorderLesson(1, 2, 2))
+        .lessonGroups;
+      assert.deepEqual(nextState[0].lessons.map(l => l.key), ['a', 'b', 'c']);
+    });
+
+    it('move lesson up within second lesson group', () => {
+      const nextState = reducer(initialState, reorderLesson(2, 3, 2))
+        .lessonGroups;
+      assert.deepEqual(nextState[1].lessons.map(l => l.key), ['d', 'f', 'e']);
+    });
+    it('move lesson to same position within second lesson group', () => {
+      const nextState = reducer(initialState, reorderLesson(2, 2, 2))
+        .lessonGroups;
+      assert.deepEqual(nextState[1].lessons.map(l => l.key), ['d', 'e', 'f']);
+    });
+    it('move lesson down within second lesson group', () => {
+      const nextState = reducer(initialState, reorderLesson(2, 1, 2))
+        .lessonGroups;
+      assert.deepEqual(nextState[1].lessons.map(l => l.key), ['e', 'd', 'f']);
     });
   });
 

--- a/apps/test/unit/code-studio/scriptEditorReduxTest.js
+++ b/apps/test/unit/code-studio/scriptEditorReduxTest.js
@@ -52,6 +52,18 @@ const getInitialState = () => ({
           key: 'd',
           name: 'D',
           position: 4
+        },
+        {
+          id: 105,
+          key: 'e',
+          name: 'E',
+          position: 5
+        },
+        {
+          id: 106,
+          key: 'f',
+          name: 'F',
+          position: 6
         }
       ]
     }

--- a/apps/test/unit/code-studio/scriptEditorReduxTest.js
+++ b/apps/test/unit/code-studio/scriptEditorReduxTest.js
@@ -129,19 +129,13 @@ describe('scriptEditorRedux reducer tests', () => {
           key: 'x',
           displayName: 'X',
           position: 1,
-          lessons: [
-            {id: 101, position: 1, relativePosition: 1},
-            {id: 102, position: 2, relativePosition: 2}
-          ]
+          lessons: [{id: 101, position: 1}, {id: 102, position: 2}]
         },
         {
           key: 'y',
           displayName: 'Y',
           position: 2,
-          lessons: [
-            {id: 103, position: 3, relativePosition: 3},
-            {id: 104, position: 4, relativePosition: 4}
-          ]
+          lessons: [{id: 103, position: 3}, {id: 104, position: 4}]
         }
       ];
       initialState.lessonGroups = initialLessonGroups;
@@ -177,19 +171,13 @@ describe('scriptEditorRedux reducer tests', () => {
             key: 'x',
             displayName: 'X',
             position: 1,
-            lessons: [
-              {id: 101, position: 1, relativePosition: 1},
-              {id: 102, position: 2, relativePosition: 2}
-            ]
+            lessons: [{id: 101, position: 1}, {id: 102, position: 2}]
           },
           {
             key: 'y',
             displayName: 'Y',
             position: 2,
-            lessons: [
-              {id: 104, position: 1, relativePosition: 3},
-              {id: 103, position: 2, relativePosition: 4}
-            ]
+            lessons: [{id: 104, position: 1}, {id: 103, position: 2}]
           }
         ],
         state.lessonGroups,
@@ -210,16 +198,16 @@ describe('scriptEditorRedux reducer tests', () => {
             displayName: 'X',
             position: 1,
             lessons: [
-              {id: 101, position: 1, relativePosition: 1},
-              {id: 102, position: 2, relativePosition: 2},
-              {id: 104, position: 3, relativePosition: 3}
+              {id: 101, position: 1},
+              {id: 102, position: 2},
+              {id: 104, position: 3}
             ]
           },
           {
             key: 'y',
             displayName: 'Y',
             position: 2,
-            lessons: [{id: 103, position: 1, relativePosition: 4}]
+            lessons: [{id: 103, position: 1}]
           }
         ],
         state.lessonGroups,
@@ -240,16 +228,16 @@ describe('scriptEditorRedux reducer tests', () => {
             displayName: 'X',
             position: 1,
             lessons: [
-              {id: 101, position: 1, relativePosition: 1},
-              {id: 104, position: 2, relativePosition: 2},
-              {id: 102, position: 3, relativePosition: 3}
+              {id: 101, position: 1},
+              {id: 104, position: 2},
+              {id: 102, position: 3}
             ]
           },
           {
             key: 'y',
             displayName: 'Y',
             position: 2,
-            lessons: [{id: 103, position: 1, relativePosition: 4}]
+            lessons: [{id: 103, position: 1}]
           }
         ],
         state.lessonGroups,
@@ -266,16 +254,16 @@ describe('scriptEditorRedux reducer tests', () => {
               key: 'x',
               displayName: 'X',
               position: 1,
-              lessons: [{id: 101, position: 1, relativePosition: 1}]
+              lessons: [{id: 101, position: 1}]
             },
             {
               key: 'y',
               displayName: 'Y',
               position: 2,
               lessons: [
-                {id: 103, position: 1, relativePosition: 2},
-                {id: 104, position: 2, relativePosition: 3},
-                {id: 102, position: 3, relativePosition: 4}
+                {id: 103, position: 1},
+                {id: 104, position: 2},
+                {id: 102, position: 3}
               ]
             }
           ],
@@ -294,22 +282,20 @@ describe('scriptEditorRedux reducer tests', () => {
               lessons: [
                 {
                   id: 101,
-                  position: 1,
-                  relativePosition: 1
+                  position: 1
                 },
                 {
                   id: 102,
-                  position: 2,
-                  relativePosition: 2
+                  position: 2
                 },
-                {id: 104, position: 3, relativePosition: 3}
+                {id: 104, position: 3}
               ]
             },
             {
               key: 'y',
               displayName: 'Y',
               position: 2,
-              lessons: [{id: 103, position: 1, relativePosition: 4}]
+              lessons: [{id: 103, position: 1}]
             }
           ],
           newState.lessonGroups

--- a/apps/test/unit/code-studio/scriptEditorReduxTest.js
+++ b/apps/test/unit/code-studio/scriptEditorReduxTest.js
@@ -113,40 +113,10 @@ describe('scriptEditorRedux reducer tests', () => {
   });
 
   describe('reorderLesson', () => {
-    it('move lesson up within first lesson group', () => {
-      const nextState = reducer(initialState, reorderLesson(1, 3, 1))
+    it('reorders lessons within first lesson group', () => {
+      const nextState = reducer(initialState, reorderLesson(1, 1, 3))
         .lessonGroups;
-      assert.deepEqual(nextState[0].lessons.map(l => l.key), ['c', 'a', 'b']);
-    });
-
-    it('move lesson down within first lesson group', () => {
-      const nextState = reducer(initialState, reorderLesson(1, 1, 2))
-        .lessonGroups;
-      assert.deepEqual(nextState[0].lessons.map(l => l.key), ['b', 'a', 'c']);
-    });
-
-    it('move lesson to same position within first lesson group', () => {
-      const nextState = reducer(initialState, reorderLesson(1, 2, 2))
-        .lessonGroups;
-      assert.deepEqual(nextState[0].lessons.map(l => l.key), ['a', 'b', 'c']);
-    });
-
-    it('move lesson up within second lesson group', () => {
-      const nextState = reducer(initialState, reorderLesson(2, 6, 5))
-        .lessonGroups;
-      assert.deepEqual(nextState[1].lessons.map(l => l.key), ['d', 'f', 'e']);
-    });
-
-    it('move lesson to same position within second lesson group', () => {
-      const nextState = reducer(initialState, reorderLesson(2, 5, 5))
-        .lessonGroups;
-      assert.deepEqual(nextState[1].lessons.map(l => l.key), ['d', 'e', 'f']);
-    });
-
-    it('move lesson down within second lesson group', () => {
-      const nextState = reducer(initialState, reorderLesson(2, 4, 5))
-        .lessonGroups;
-      assert.deepEqual(nextState[1].lessons.map(l => l.key), ['e', 'd', 'f']);
+      assert.deepEqual(nextState[0].lessons.map(l => l.key), ['b', 'c', 'a']);
     });
   });
 

--- a/apps/test/unit/code-studio/scriptEditorReduxTest.js
+++ b/apps/test/unit/code-studio/scriptEditorReduxTest.js
@@ -51,19 +51,19 @@ const getInitialState = () => ({
           id: 104,
           key: 'd',
           name: 'D',
-          position: 4
+          position: 1
         },
         {
           id: 105,
           key: 'e',
           name: 'E',
-          position: 5
+          position: 2
         },
         {
           id: 106,
           key: 'f',
           name: 'F',
-          position: 6
+          position: 3
         }
       ]
     }
@@ -187,8 +187,8 @@ describe('scriptEditorRedux reducer tests', () => {
             displayName: 'Y',
             position: 2,
             lessons: [
-              {id: 104, position: 3, relativePosition: 3},
-              {id: 103, position: 4, relativePosition: 4}
+              {id: 104, position: 1, relativePosition: 3},
+              {id: 103, position: 2, relativePosition: 4}
             ]
           }
         ],
@@ -219,7 +219,7 @@ describe('scriptEditorRedux reducer tests', () => {
             key: 'y',
             displayName: 'Y',
             position: 2,
-            lessons: [{id: 103, position: 4, relativePosition: 4}]
+            lessons: [{id: 103, position: 1, relativePosition: 4}]
           }
         ],
         state.lessonGroups,
@@ -249,7 +249,7 @@ describe('scriptEditorRedux reducer tests', () => {
             key: 'y',
             displayName: 'Y',
             position: 2,
-            lessons: [{id: 103, position: 4, relativePosition: 4}]
+            lessons: [{id: 103, position: 1, relativePosition: 4}]
           }
         ],
         state.lessonGroups,
@@ -273,9 +273,9 @@ describe('scriptEditorRedux reducer tests', () => {
               displayName: 'Y',
               position: 2,
               lessons: [
-                {id: 103, position: 2, relativePosition: 2},
-                {id: 104, position: 3, relativePosition: 3},
-                {id: 102, position: 4, relativePosition: 4}
+                {id: 103, position: 1, relativePosition: 2},
+                {id: 104, position: 2, relativePosition: 3},
+                {id: 102, position: 3, relativePosition: 4}
               ]
             }
           ],
@@ -292,8 +292,16 @@ describe('scriptEditorRedux reducer tests', () => {
               displayName: 'X',
               position: 1,
               lessons: [
-                {id: 101, position: 1, relativePosition: 1},
-                {id: 102, position: 2, relativePosition: 2},
+                {
+                  id: 101,
+                  position: 1,
+                  relativePosition: 1
+                },
+                {
+                  id: 102,
+                  position: 2,
+                  relativePosition: 2
+                },
                 {id: 104, position: 3, relativePosition: 3}
               ]
             },
@@ -301,7 +309,7 @@ describe('scriptEditorRedux reducer tests', () => {
               key: 'y',
               displayName: 'Y',
               position: 2,
-              lessons: [{id: 103, position: 4, relativePosition: 4}]
+              lessons: [{id: 103, position: 1, relativePosition: 4}]
             }
           ],
           newState.lessonGroups

--- a/apps/test/unit/code-studio/scriptEditorReduxTest.js
+++ b/apps/test/unit/code-studio/scriptEditorReduxTest.js
@@ -21,8 +21,8 @@ const getInitialState = () => ({
       userFacing: true,
       lessons: [
         {id: 100, key: 'a', name: 'A', position: 1},
-        {name: 'B', key: 'b', id: 101, position: 2},
-        {name: 'C', key: 'c', id: 102, position: 3}
+        {id: 101, key: 'b', name: 'B', position: 2},
+        {id: 102, key: 'c', name: 'C', position: 3}
       ]
     },
     {

--- a/apps/test/unit/code-studio/scriptEditorReduxTest.js
+++ b/apps/test/unit/code-studio/scriptEditorReduxTest.js
@@ -112,10 +112,12 @@ describe('scriptEditorRedux reducer tests', () => {
     ]);
   });
 
-  it('reorder lessons', () => {
-    const nextState = reducer(initialState, reorderLesson(1, 1, 3))
-      .lessonGroups;
-    assert.deepEqual(nextState[0].lessons.map(l => l.key), ['b', 'c', 'a']);
+  describe('reorderLesson', () => {
+    it('reorders lessons within first lesson group', () => {
+      const nextState = reducer(initialState, reorderLesson(1, 1, 3))
+        .lessonGroups;
+      assert.deepEqual(nextState[0].lessons.map(l => l.key), ['b', 'c', 'a']);
+    });
   });
 
   describe('lesson groups', () => {

--- a/apps/test/unit/code-studio/scriptEditorReduxTest.js
+++ b/apps/test/unit/code-studio/scriptEditorReduxTest.js
@@ -134,7 +134,7 @@ describe('scriptEditorRedux reducer tests', () => {
           key: 'y',
           displayName: 'Y',
           position: 2,
-          lessons: [{id: 103, position: 3}, {id: 104, position: 4}]
+          lessons: [{id: 103, position: 1}, {id: 104, position: 2}]
         }
       ];
       initialState.lessonGroups = initialLessonGroups;
@@ -179,7 +179,7 @@ describe('scriptEditorRedux reducer tests', () => {
       });
 
       it('groups with others in same lesson group', () => {
-        const newState = reducer(initialState, setLessonGroup(4, 2, 1));
+        const newState = reducer(initialState, setLessonGroup(2, 2, 1));
         assert.deepEqual(
           [
             {

--- a/apps/test/unit/code-studio/scriptEditorReduxTest.js
+++ b/apps/test/unit/code-studio/scriptEditorReduxTest.js
@@ -113,7 +113,7 @@ describe('scriptEditorRedux reducer tests', () => {
   });
 
   it('reorder lessons', () => {
-    const nextState = reducer(initialState, reorderLesson(1, 1, 3, 1))
+    const nextState = reducer(initialState, reorderLesson(1, 1, 3))
       .lessonGroups;
     assert.deepEqual(nextState[0].lessons.map(l => l.key), ['b', 'c', 'a']);
   });

--- a/apps/test/unit/code-studio/scriptEditorReduxTest.js
+++ b/apps/test/unit/code-studio/scriptEditorReduxTest.js
@@ -3,7 +3,6 @@ import {combineReducers} from 'redux';
 import reducers, {
   addGroup,
   addLesson,
-  moveLesson,
   setLessonGroup,
   reorderLesson,
   updateLessonGroupField,
@@ -151,98 +150,6 @@ describe('scriptEditorRedux reducer tests', () => {
       expectedState[0].description = 'Overview of the lesson group';
 
       assert.deepEqual(expectedState, state.lessonGroups);
-    });
-
-    it('moves a lesson up three times', () => {
-      const id = 104;
-      let groupPosition = initialState.lessonGroups.find(lessonGroup =>
-        lessonGroup.lessons.find(lesson => lesson.id === id)
-      ).position;
-      let lessonPosition = initialState.lessonGroups[
-        groupPosition - 1
-      ].lessons.find(lesson => lesson.id === id).position;
-      let state = reducer(
-        initialState,
-        moveLesson(groupPosition, lessonPosition, 'up')
-      );
-      assert.deepEqual(
-        [
-          {
-            key: 'x',
-            displayName: 'X',
-            position: 1,
-            lessons: [{id: 101, position: 1}, {id: 102, position: 2}]
-          },
-          {
-            key: 'y',
-            displayName: 'Y',
-            position: 2,
-            lessons: [{id: 104, position: 1}, {id: 103, position: 2}]
-          }
-        ],
-        state.lessonGroups,
-        'first move changes position but not group'
-      );
-
-      groupPosition = state.lessonGroups.find(lessonGroup =>
-        lessonGroup.lessons.find(lesson => lesson.id === id)
-      ).position;
-      lessonPosition = state.lessonGroups[groupPosition - 1].lessons.find(
-        lesson => lesson.id === id
-      ).position;
-      state = reducer(state, moveLesson(groupPosition, lessonPosition, 'up'));
-      assert.deepEqual(
-        [
-          {
-            key: 'x',
-            displayName: 'X',
-            position: 1,
-            lessons: [
-              {id: 101, position: 1},
-              {id: 102, position: 2},
-              {id: 104, position: 3}
-            ]
-          },
-          {
-            key: 'y',
-            displayName: 'Y',
-            position: 2,
-            lessons: [{id: 103, position: 1}]
-          }
-        ],
-        state.lessonGroups,
-        'second move changes group but not position'
-      );
-
-      groupPosition = state.lessonGroups.find(lessonGroup =>
-        lessonGroup.lessons.find(lesson => lesson.id === id)
-      ).position;
-      lessonPosition = state.lessonGroups[groupPosition - 1].lessons.find(
-        lesson => lesson.id === id
-      ).position;
-      state = reducer(state, moveLesson(groupPosition, lessonPosition, 'up'));
-      assert.deepEqual(
-        [
-          {
-            key: 'x',
-            displayName: 'X',
-            position: 1,
-            lessons: [
-              {id: 101, position: 1},
-              {id: 104, position: 2},
-              {id: 102, position: 3}
-            ]
-          },
-          {
-            key: 'y',
-            displayName: 'Y',
-            position: 2,
-            lessons: [{id: 103, position: 1}]
-          }
-        ],
-        state.lessonGroups,
-        'third move changes position but not group'
-      );
     });
 
     describe('set lesson group', () => {


### PR DESCRIPTION
Fixes the issue where reordering lessons doesn't work. the root cause is that the lesson ordering code expects position to be relative to the lesson group (parent), but the lesson position is currently set relative to the unit (grandparent). 

Specific changes:
* set lesson position relative to lesson group, not unit
* remove unused `relativePosition` field
* remove unused `moveLesson` redux action
* eliminate unnecessary references to lesson position, now that the first lesson in each lesson group has position 1

## Testing story

* added test cases for `reorderLesson` redux action.
* manually verified that various dragging scenarios work when multiple lesson groups are present.

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
