### PR TITLE
fix bubble number in activity section preview

### DIFF
--- a/apps/src/lib/levelbuilder/lesson-editor/activitiesEditorRedux.js
+++ b/apps/src/lib/levelbuilder/lesson-editor/activitiesEditorRedux.js
@@ -290,10 +290,16 @@ function updateActivitySectionPositions(activities) {
   });
 }
 
-function updateScriptLevelPositions(scriptLevels) {
-  for (let i = 0; i < scriptLevels.length; i++) {
-    scriptLevels[i].position = i + 1;
-  }
+function updateScriptLevelPositions(activities) {
+  let nextLevelNumber = 1;
+  activities.forEach(activity => {
+    activity.activitySections.forEach(section => {
+      section.scriptLevels.forEach((scriptLevel, index) => {
+        scriptLevel.position = index + 1;
+        scriptLevel.levelNumber = nextLevelNumber++;
+      });
+    });
+  });
 }
 
 function getScriptLevels(newState, action) {
@@ -457,13 +463,13 @@ function activities(state = [], action) {
       validateScriptLevel(action.level, action.type);
       const scriptLevels = getScriptLevels(newState, action);
       scriptLevels.push(action.level);
-      updateScriptLevelPositions(scriptLevels);
+      updateScriptLevelPositions(newState);
       break;
     }
     case REMOVE_LEVEL: {
       const scriptLevels = getScriptLevels(newState, action);
       scriptLevels.splice(action.scriptLevelPosition - 1, 1);
-      updateScriptLevelPositions(scriptLevels);
+      updateScriptLevelPositions(newState);
       break;
     }
     case REORDER_LEVEL: {
@@ -473,7 +479,7 @@ function activities(state = [], action) {
         1
       );
       scriptLevels.splice(action.newScriptLevelPosition - 1, 0, temp[0]);
-      updateScriptLevelPositions(scriptLevels);
+      updateScriptLevelPositions(newState);
       break;
     }
     case MOVE_LEVEL_TO_ACTIVITY_SECTION: {
@@ -483,7 +489,7 @@ function activities(state = [], action) {
         action.scriptLevelPosition - 1,
         1
       )[0];
-      updateScriptLevelPositions(scriptLevels);
+      updateScriptLevelPositions(newState);
 
       // add level to new activitySection
       const newActivitySections =
@@ -491,7 +497,7 @@ function activities(state = [], action) {
       const newScriptLevels =
         newActivitySections[action.newActivitySectionPosition - 1].scriptLevels;
       newScriptLevels.push(scriptLevel);
-      updateScriptLevelPositions(newScriptLevels);
+      updateScriptLevelPositions(newState);
       break;
     }
     case SET_SCRIPT_LEVEL_FIELD: {

--- a/apps/src/sites/studio/pages/lessons/show.js
+++ b/apps/src/sites/studio/pages/lessons/show.js
@@ -39,6 +39,12 @@ $(document).ready(function() {
         // React key
         tip.key = _.uniqueId();
       });
+
+      activitySection.scriptLevels.forEach(scriptLevel => {
+        // The position within the lesson
+        scriptLevel.levelNumber = scriptLevel.position;
+        delete scriptLevel.position;
+      });
     });
   });
 

--- a/apps/src/templates/lessonOverview/activities/ProgressionDetails.jsx
+++ b/apps/src/templates/lessonOverview/activities/ProgressionDetails.jsx
@@ -41,7 +41,7 @@ export default class ProgressionDetails extends Component {
       icon: activeLevel.icon,
       isConceptLevel: activeLevel.isConceptLevel,
       isUnplugged: scriptLevel.display_as_unplugged,
-      levelNumber: scriptLevel.position,
+      levelNumber: scriptLevel.levelNumber,
       bonus: scriptLevel.bonus
     };
   };

--- a/apps/test/unit/lib/levelbuilder/lesson-editor/activitiesTestData.js
+++ b/apps/test/unit/lib/levelbuilder/lesson-editor/activitiesTestData.js
@@ -62,6 +62,7 @@ export const sampleActivities = [
               }
             ],
             position: 1,
+            levelNumber: 1,
             activeId: 1,
             kind: 'puzzle',
             bonus: false,
@@ -98,6 +99,7 @@ export const sampleActivities = [
               }
             ],
             position: 2,
+            levelNumber: 2,
             activeId: 2,
             kind: 'assessment',
             bonus: false,


### PR DESCRIPTION
Finishes [PLAT-414]. Fixes bubble numbers in the preview pane in the Activities section of the Lesson Edit page. No change to what appears on the lesson overview page a.k.a. teacher facing lesson plan.

## before

![Screen Shot 2020-10-26 at 6 48 50 AM](https://user-images.githubusercontent.com/8001765/97180952-f8481800-1757-11eb-916e-36d19f3485e1.png)

## after

![Screen Shot 2020-10-26 at 6 47 15 AM](https://user-images.githubusercontent.com/8001765/97180966-fbdb9f00-1757-11eb-8496-a7ee8917c104.png)

## Testing story

Existing test coverage ensures the pages and components still render.

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked


[PLAT-414]: https://codedotorg.atlassian.net/browse/PLAT-414