### PR TITLE
Update design element event handlers to have empty callback param

### DIFF
--- a/apps/src/applab/designElements/button.jsx
+++ b/apps/src/applab/designElements/button.jsx
@@ -160,15 +160,8 @@ class ButtonEvents extends React.Component {
 
   getClickEventCode() {
     const id = elementUtils.getId(this.props.element);
-    const code =
-      'onEvent("' +
-      id +
-      '", "click", function(event) {\n' +
-      '  console.log("' +
-      id +
-      ' clicked!");\n' +
-      '});\n';
-    return code;
+    const callback = `function( ) {\n\tconsole.log("${id} clicked!");\n}`;
+    return `onEvent("${id}", "click", ${callback});`;
   }
 
   insertClick = () => this.props.onInsertEvent(this.getClickEventCode());

--- a/apps/src/applab/designElements/button.jsx
+++ b/apps/src/applab/designElements/button.jsx
@@ -16,7 +16,6 @@ import {ICON_PREFIX_REGEX} from '../constants';
 import * as elementUtils from './elementUtils';
 import designMode from '../designMode';
 import elementLibrary from './library';
-import {generateEventHandler} from './utils';
 
 class ButtonProperties extends React.Component {
   static propTypes = {
@@ -161,7 +160,15 @@ class ButtonEvents extends React.Component {
 
   getClickEventCode() {
     const id = elementUtils.getId(this.props.element);
-    return generateEventHandler(id, 'click');
+    const code =
+      'onEvent("' +
+      id +
+      '", "click", function(event) {\n' +
+      '  console.log("' +
+      id +
+      ' clicked!");\n' +
+      '});\n';
+    return code;
   }
 
   insertClick = () => this.props.onInsertEvent(this.getClickEventCode());

--- a/apps/src/applab/designElements/button.jsx
+++ b/apps/src/applab/designElements/button.jsx
@@ -16,6 +16,7 @@ import {ICON_PREFIX_REGEX} from '../constants';
 import * as elementUtils from './elementUtils';
 import designMode from '../designMode';
 import elementLibrary from './library';
+import {generateEventHandler} from './utils';
 
 class ButtonProperties extends React.Component {
   static propTypes = {
@@ -160,15 +161,7 @@ class ButtonEvents extends React.Component {
 
   getClickEventCode() {
     const id = elementUtils.getId(this.props.element);
-    const code =
-      'onEvent("' +
-      id +
-      '", "click", function(event) {\n' +
-      '  console.log("' +
-      id +
-      ' clicked!");\n' +
-      '});\n';
-    return code;
+    return generateEventHandler(id, 'click');
   }
 
   insertClick = () => this.props.onInsertEvent(this.getClickEventCode());

--- a/apps/src/applab/designElements/canvas.jsx
+++ b/apps/src/applab/designElements/canvas.jsx
@@ -73,19 +73,13 @@ class CanvasEvents extends React.Component {
 
   getClickEventCode() {
     const id = elementUtils.getId(this.props.element);
-    const code =
-      'onEvent("' +
-      id +
-      '", "click", function(event) {\n' +
-      '  console.log("' +
-      id +
-      ' clicked at x:" + event.offsetX + " y:" + event.offsetY);\n' +
-      '  setActiveCanvas("' +
-      id +
-      '");\n' +
-      '  circle(event.offsetX, event.offsetY, 10);\n' +
-      '});\n';
-    return code;
+    const commands = [
+      `console.log("${id} clicked at x: " + event.offsetX + " y: " + event.offsetY);`,
+      `setActiveCanvas("${id}");`,
+      `circle(event.offsetX, event.offsetY, 10);`
+    ];
+    const callback = `function(event) {\n\t${commands.join('\n\t')}\n}`;
+    return `onEvent("${id}", "click", ${callback});`;
   }
 
   insertClick = () => this.props.onInsertEvent(this.getClickEventCode());

--- a/apps/src/applab/designElements/canvas.jsx
+++ b/apps/src/applab/designElements/canvas.jsx
@@ -7,6 +7,7 @@ import EventHeaderRow from './EventHeaderRow';
 import EventRow from './EventRow';
 import * as elementUtils from './elementUtils';
 import $ from 'jquery';
+import {generateEventHandler} from './utils';
 
 class CanvasProperties extends React.Component {
   static propTypes = {
@@ -73,19 +74,7 @@ class CanvasEvents extends React.Component {
 
   getClickEventCode() {
     const id = elementUtils.getId(this.props.element);
-    const code =
-      'onEvent("' +
-      id +
-      '", "click", function(event) {\n' +
-      '  console.log("' +
-      id +
-      ' clicked at x:" + event.offsetX + " y:" + event.offsetY);\n' +
-      '  setActiveCanvas("' +
-      id +
-      '");\n' +
-      '  circle(event.offsetX, event.offsetY, 10);\n' +
-      '});\n';
-    return code;
+    return generateEventHandler(id, 'click');
   }
 
   insertClick = () => this.props.onInsertEvent(this.getClickEventCode());

--- a/apps/src/applab/designElements/canvas.jsx
+++ b/apps/src/applab/designElements/canvas.jsx
@@ -7,7 +7,6 @@ import EventHeaderRow from './EventHeaderRow';
 import EventRow from './EventRow';
 import * as elementUtils from './elementUtils';
 import $ from 'jquery';
-import {generateEventHandler} from './utils';
 
 class CanvasProperties extends React.Component {
   static propTypes = {
@@ -74,7 +73,19 @@ class CanvasEvents extends React.Component {
 
   getClickEventCode() {
     const id = elementUtils.getId(this.props.element);
-    return generateEventHandler(id, 'click');
+    const code =
+      'onEvent("' +
+      id +
+      '", "click", function(event) {\n' +
+      '  console.log("' +
+      id +
+      ' clicked at x:" + event.offsetX + " y:" + event.offsetY);\n' +
+      '  setActiveCanvas("' +
+      id +
+      '");\n' +
+      '  circle(event.offsetX, event.offsetY, 10);\n' +
+      '});\n';
+    return code;
   }
 
   insertClick = () => this.props.onInsertEvent(this.getClickEventCode());

--- a/apps/src/applab/designElements/checkbox.jsx
+++ b/apps/src/applab/designElements/checkbox.jsx
@@ -81,17 +81,8 @@ class CheckboxEvents extends React.Component {
 
   getChangeEventCode() {
     const id = elementUtils.getId(this.props.element);
-    const code =
-      'onEvent("' +
-      id +
-      '", "change", function(event) {\n' +
-      '  console.log("' +
-      id +
-      ' checked? " + getChecked("' +
-      id +
-      '"));\n' +
-      '});\n';
-    return code;
+    const callback = `function( ) {\n\tconsole.log("${id} checked? " + getChecked("${id}"));\n}`;
+    return `onEvent("${id}", "change", ${callback});`;
   }
 
   insertChange = () => {

--- a/apps/src/applab/designElements/checkbox.jsx
+++ b/apps/src/applab/designElements/checkbox.jsx
@@ -7,7 +7,6 @@ import ZOrderRow from './ZOrderRow';
 import EventHeaderRow from './EventHeaderRow';
 import EventRow from './EventRow';
 import * as elementUtils from './elementUtils';
-import {generateEventHandler} from './utils';
 
 class CheckboxProperties extends React.Component {
   static propTypes = {
@@ -82,7 +81,17 @@ class CheckboxEvents extends React.Component {
 
   getChangeEventCode() {
     const id = elementUtils.getId(this.props.element);
-    return generateEventHandler(id, 'change');
+    const code =
+      'onEvent("' +
+      id +
+      '", "change", function(event) {\n' +
+      '  console.log("' +
+      id +
+      ' checked? " + getChecked("' +
+      id +
+      '"));\n' +
+      '});\n';
+    return code;
   }
 
   insertChange = () => {

--- a/apps/src/applab/designElements/checkbox.jsx
+++ b/apps/src/applab/designElements/checkbox.jsx
@@ -7,6 +7,7 @@ import ZOrderRow from './ZOrderRow';
 import EventHeaderRow from './EventHeaderRow';
 import EventRow from './EventRow';
 import * as elementUtils from './elementUtils';
+import {generateEventHandler} from './utils';
 
 class CheckboxProperties extends React.Component {
   static propTypes = {
@@ -81,17 +82,7 @@ class CheckboxEvents extends React.Component {
 
   getChangeEventCode() {
     const id = elementUtils.getId(this.props.element);
-    const code =
-      'onEvent("' +
-      id +
-      '", "change", function(event) {\n' +
-      '  console.log("' +
-      id +
-      ' checked? " + getChecked("' +
-      id +
-      '"));\n' +
-      '});\n';
-    return code;
+    return generateEventHandler(id, 'change');
   }
 
   insertChange = () => {

--- a/apps/src/applab/designElements/dropdown.jsx
+++ b/apps/src/applab/designElements/dropdown.jsx
@@ -140,15 +140,8 @@ class DropdownEvents extends React.Component {
 
   getChangeEventCode() {
     const id = elementUtils.getId(this.props.element);
-    const code =
-      'onEvent("' +
-      id +
-      '", "change", function(event) {\n' +
-      '  console.log("Selected option: " + getText("' +
-      id +
-      '"));\n' +
-      '});\n';
-    return code;
+    const callback = `function( ) {\n\tconsole.log("Selected option: " + getText("${id}"));\n}`;
+    return `onEvent("${id}", "change", ${callback});`;
   }
 
   insertChange = () => {

--- a/apps/src/applab/designElements/dropdown.jsx
+++ b/apps/src/applab/designElements/dropdown.jsx
@@ -16,6 +16,7 @@ import * as elementUtils from './elementUtils';
 import designMode from '../designMode';
 import elementLibrary from './library';
 import RGBColor from 'rgbcolor';
+import {generateEventHandler} from './utils';
 
 class DropdownProperties extends React.Component {
   static propTypes = {
@@ -140,15 +141,7 @@ class DropdownEvents extends React.Component {
 
   getChangeEventCode() {
     const id = elementUtils.getId(this.props.element);
-    const code =
-      'onEvent("' +
-      id +
-      '", "change", function(event) {\n' +
-      '  console.log("Selected option: " + getText("' +
-      id +
-      '"));\n' +
-      '});\n';
-    return code;
+    return generateEventHandler(id, 'change');
   }
 
   insertChange = () => {

--- a/apps/src/applab/designElements/dropdown.jsx
+++ b/apps/src/applab/designElements/dropdown.jsx
@@ -16,7 +16,6 @@ import * as elementUtils from './elementUtils';
 import designMode from '../designMode';
 import elementLibrary from './library';
 import RGBColor from 'rgbcolor';
-import {generateEventHandler} from './utils';
 
 class DropdownProperties extends React.Component {
   static propTypes = {
@@ -141,7 +140,15 @@ class DropdownEvents extends React.Component {
 
   getChangeEventCode() {
     const id = elementUtils.getId(this.props.element);
-    return generateEventHandler(id, 'change');
+    const code =
+      'onEvent("' +
+      id +
+      '", "change", function(event) {\n' +
+      '  console.log("Selected option: " + getText("' +
+      id +
+      '"));\n' +
+      '});\n';
+    return code;
   }
 
   insertChange = () => {

--- a/apps/src/applab/designElements/image.jsx
+++ b/apps/src/applab/designElements/image.jsx
@@ -130,15 +130,8 @@ class ImageEvents extends React.Component {
 
   getClickEventCode() {
     const id = elementUtils.getId(this.props.element);
-    const code =
-      'onEvent("' +
-      id +
-      '", "click", function(event) {\n' +
-      '  console.log("' +
-      id +
-      ' clicked!");\n' +
-      '});\n';
-    return code;
+    const callback = `function( ) {\n\tconsole.log("${id} clicked!");\n}`;
+    return `onEvent("${id}", "click", ${callback});`;
   }
 
   insertClick = () => {

--- a/apps/src/applab/designElements/image.jsx
+++ b/apps/src/applab/designElements/image.jsx
@@ -13,6 +13,7 @@ import {ICON_PREFIX_REGEX} from '../constants';
 import EnumPropertyRow from './EnumPropertyRow';
 import BorderProperties from './BorderProperties';
 import * as elementUtils from './elementUtils';
+import {generateEventHandler} from './utils';
 
 class ImageProperties extends React.Component {
   static propTypes = {
@@ -130,15 +131,7 @@ class ImageEvents extends React.Component {
 
   getClickEventCode() {
     const id = elementUtils.getId(this.props.element);
-    const code =
-      'onEvent("' +
-      id +
-      '", "click", function(event) {\n' +
-      '  console.log("' +
-      id +
-      ' clicked!");\n' +
-      '});\n';
-    return code;
+    return generateEventHandler(id, 'click');
   }
 
   insertClick = () => {

--- a/apps/src/applab/designElements/image.jsx
+++ b/apps/src/applab/designElements/image.jsx
@@ -13,7 +13,6 @@ import {ICON_PREFIX_REGEX} from '../constants';
 import EnumPropertyRow from './EnumPropertyRow';
 import BorderProperties from './BorderProperties';
 import * as elementUtils from './elementUtils';
-import {generateEventHandler} from './utils';
 
 class ImageProperties extends React.Component {
   static propTypes = {
@@ -131,7 +130,15 @@ class ImageEvents extends React.Component {
 
   getClickEventCode() {
     const id = elementUtils.getId(this.props.element);
-    return generateEventHandler(id, 'click');
+    const code =
+      'onEvent("' +
+      id +
+      '", "click", function(event) {\n' +
+      '  console.log("' +
+      id +
+      ' clicked!");\n' +
+      '});\n';
+    return code;
   }
 
   insertClick = () => {

--- a/apps/src/applab/designElements/label.jsx
+++ b/apps/src/applab/designElements/label.jsx
@@ -142,15 +142,8 @@ class LabelEvents extends React.Component {
 
   getClickEventCode() {
     const id = elementUtils.getId(this.props.element);
-    const code =
-      'onEvent("' +
-      id +
-      '", "click", function(event) {\n' +
-      '  console.log("' +
-      id +
-      ' clicked!");\n' +
-      '});\n';
-    return code;
+    const callback = `function( ) {\n\tconsole.log("${id} clicked!");\n}`;
+    return `onEvent("${id}", "click", ${callback});`;
   }
 
   insertClick = () => {

--- a/apps/src/applab/designElements/label.jsx
+++ b/apps/src/applab/designElements/label.jsx
@@ -16,6 +16,7 @@ import * as gridUtils from '../gridUtils';
 import designMode from '../designMode';
 import themeValues from '../themeValues';
 import elementLibrary from './library';
+import {generateEventHandler} from './utils';
 
 class LabelProperties extends React.Component {
   static propTypes = {
@@ -142,15 +143,7 @@ class LabelEvents extends React.Component {
 
   getClickEventCode() {
     const id = elementUtils.getId(this.props.element);
-    const code =
-      'onEvent("' +
-      id +
-      '", "click", function(event) {\n' +
-      '  console.log("' +
-      id +
-      ' clicked!");\n' +
-      '});\n';
-    return code;
+    return generateEventHandler(id, 'click');
   }
 
   insertClick = () => {

--- a/apps/src/applab/designElements/label.jsx
+++ b/apps/src/applab/designElements/label.jsx
@@ -16,7 +16,6 @@ import * as gridUtils from '../gridUtils';
 import designMode from '../designMode';
 import themeValues from '../themeValues';
 import elementLibrary from './library';
-import {generateEventHandler} from './utils';
 
 class LabelProperties extends React.Component {
   static propTypes = {
@@ -143,7 +142,15 @@ class LabelEvents extends React.Component {
 
   getClickEventCode() {
     const id = elementUtils.getId(this.props.element);
-    return generateEventHandler(id, 'click');
+    const code =
+      'onEvent("' +
+      id +
+      '", "click", function(event) {\n' +
+      '  console.log("' +
+      id +
+      ' clicked!");\n' +
+      '});\n';
+    return code;
   }
 
   insertClick = () => {

--- a/apps/src/applab/designElements/photoSelect.jsx
+++ b/apps/src/applab/designElements/photoSelect.jsx
@@ -110,8 +110,12 @@ class PhotoChooserEvents extends React.Component {
 
   getPhotoSelectedEventCode() {
     const id = elementUtils.getId(this.props.element);
-    const code = `onEvent("${id}", "change", function() {\n  console.log("${id} photo selected!");\n  console.log(getImageURL("${id}"));\n});\n`;
-    return code;
+    const commands = [
+      `console.log("${id} photo selected!");`,
+      `console.log(getImageURL("${id}"));`
+    ];
+    const callback = `function( ) {\n\t${commands.join('\n\t')}\n}`;
+    return `onEvent("${id}", "change", ${callback});`;
   }
 
   insertPhotoSelected = () =>

--- a/apps/src/applab/designElements/photoSelect.jsx
+++ b/apps/src/applab/designElements/photoSelect.jsx
@@ -13,7 +13,6 @@ import * as elementUtils from './elementUtils';
 import designMode from '../designMode';
 import elementLibrary from './library';
 import i18n from '@cdo/applab/locale';
-import {generateEventHandler} from './utils';
 
 class PhotoChooserProperties extends React.Component {
   static propTypes = {
@@ -111,7 +110,8 @@ class PhotoChooserEvents extends React.Component {
 
   getPhotoSelectedEventCode() {
     const id = elementUtils.getId(this.props.element);
-    return generateEventHandler(id, 'change');
+    const code = `onEvent("${id}", "change", function() {\n  console.log("${id} photo selected!");\n  console.log(getImageURL("${id}"));\n});\n`;
+    return code;
   }
 
   insertPhotoSelected = () =>

--- a/apps/src/applab/designElements/photoSelect.jsx
+++ b/apps/src/applab/designElements/photoSelect.jsx
@@ -13,6 +13,7 @@ import * as elementUtils from './elementUtils';
 import designMode from '../designMode';
 import elementLibrary from './library';
 import i18n from '@cdo/applab/locale';
+import {generateEventHandler} from './utils';
 
 class PhotoChooserProperties extends React.Component {
   static propTypes = {
@@ -110,8 +111,7 @@ class PhotoChooserEvents extends React.Component {
 
   getPhotoSelectedEventCode() {
     const id = elementUtils.getId(this.props.element);
-    const code = `onEvent("${id}", "change", function() {\n  console.log("${id} photo selected!");\n  console.log(getImageURL("${id}"));\n});\n`;
-    return code;
+    return generateEventHandler(id, 'change');
   }
 
   insertPhotoSelected = () =>

--- a/apps/src/applab/designElements/radioButton.jsx
+++ b/apps/src/applab/designElements/radioButton.jsx
@@ -89,17 +89,8 @@ class RadioButtonEvents extends React.Component {
 
   getChangeEventCode() {
     const id = elementUtils.getId(this.props.element);
-    const code =
-      'onEvent("' +
-      id +
-      '", "change", function(event) {\n' +
-      '  console.log("' +
-      id +
-      ' checked? " + getChecked("' +
-      id +
-      '"));\n' +
-      '});\n';
-    return code;
+    const callback = `function( ) {\n\tconsole.log("${id} checked? " + getChecked("${id}"));\n}`;
+    return `onEvent("${id}", "change", ${callback});`;
   }
 
   insertChange = () => {

--- a/apps/src/applab/designElements/radioButton.jsx
+++ b/apps/src/applab/designElements/radioButton.jsx
@@ -7,6 +7,7 @@ import ZOrderRow from './ZOrderRow';
 import EventHeaderRow from './EventHeaderRow';
 import EventRow from './EventRow';
 import * as elementUtils from './elementUtils';
+import {generateEventHandler} from './utils';
 
 // Prefix used to generate default group ids
 const GROUP_ID_PREFIX = 'radio_group';
@@ -89,17 +90,7 @@ class RadioButtonEvents extends React.Component {
 
   getChangeEventCode() {
     const id = elementUtils.getId(this.props.element);
-    const code =
-      'onEvent("' +
-      id +
-      '", "change", function(event) {\n' +
-      '  console.log("' +
-      id +
-      ' checked? " + getChecked("' +
-      id +
-      '"));\n' +
-      '});\n';
-    return code;
+    return generateEventHandler(id, 'change');
   }
 
   insertChange = () => {

--- a/apps/src/applab/designElements/radioButton.jsx
+++ b/apps/src/applab/designElements/radioButton.jsx
@@ -7,7 +7,6 @@ import ZOrderRow from './ZOrderRow';
 import EventHeaderRow from './EventHeaderRow';
 import EventRow from './EventRow';
 import * as elementUtils from './elementUtils';
-import {generateEventHandler} from './utils';
 
 // Prefix used to generate default group ids
 const GROUP_ID_PREFIX = 'radio_group';
@@ -90,7 +89,17 @@ class RadioButtonEvents extends React.Component {
 
   getChangeEventCode() {
     const id = elementUtils.getId(this.props.element);
-    return generateEventHandler(id, 'change');
+    const code =
+      'onEvent("' +
+      id +
+      '", "change", function(event) {\n' +
+      '  console.log("' +
+      id +
+      ' checked? " + getChecked("' +
+      id +
+      '"));\n' +
+      '});\n';
+    return code;
   }
 
   insertChange = () => {

--- a/apps/src/applab/designElements/screen.jsx
+++ b/apps/src/applab/designElements/screen.jsx
@@ -86,15 +86,8 @@ class ScreenEvents extends React.Component {
   // event.targetId === "<id>" here, at the expense of added complexity.
   getClickEventCode() {
     const id = elementUtils.getId(this.props.element);
-    const code =
-      'onEvent("' +
-      id +
-      '", "click", function(event) {\n' +
-      '  console.log("' +
-      id +
-      ' clicked!");\n' +
-      '});\n';
-    return code;
+    const callback = `function( ) {\n\tconsole.log("${id} clicked!");\n}`;
+    return `onEvent("${id}", "click", ${callback});`;
   }
 
   insertClick = () => {
@@ -103,13 +96,8 @@ class ScreenEvents extends React.Component {
 
   getKeyEventCode() {
     const id = elementUtils.getId(this.props.element);
-    const code =
-      'onEvent("' +
-      id +
-      '", "keydown", function(event) {\n' +
-      '  console.log("Key: " + event.key);\n' +
-      '});\n';
-    return code;
+    const callback = `function(event) {\n\tconsole.log("Key pressed: " + event.key);\n}`;
+    return `onEvent("${id}", "keydown", ${callback});`;
   }
 
   insertKey = () => {

--- a/apps/src/applab/designElements/screen.jsx
+++ b/apps/src/applab/designElements/screen.jsx
@@ -12,6 +12,7 @@ import * as applabConstants from '../constants';
 import * as elementUtils from './elementUtils';
 import themeValues from '../themeValues';
 import {getStore} from '../../redux';
+import {generateEventHandler} from './utils';
 
 class ScreenProperties extends React.Component {
   static propTypes = {
@@ -86,15 +87,7 @@ class ScreenEvents extends React.Component {
   // event.targetId === "<id>" here, at the expense of added complexity.
   getClickEventCode() {
     const id = elementUtils.getId(this.props.element);
-    const code =
-      'onEvent("' +
-      id +
-      '", "click", function(event) {\n' +
-      '  console.log("' +
-      id +
-      ' clicked!");\n' +
-      '});\n';
-    return code;
+    return generateEventHandler(id, 'click');
   }
 
   insertClick = () => {
@@ -103,13 +96,7 @@ class ScreenEvents extends React.Component {
 
   getKeyEventCode() {
     const id = elementUtils.getId(this.props.element);
-    const code =
-      'onEvent("' +
-      id +
-      '", "keydown", function(event) {\n' +
-      '  console.log("Key: " + event.key);\n' +
-      '});\n';
-    return code;
+    return generateEventHandler(id, 'keydown');
   }
 
   insertKey = () => {

--- a/apps/src/applab/designElements/screen.jsx
+++ b/apps/src/applab/designElements/screen.jsx
@@ -12,7 +12,6 @@ import * as applabConstants from '../constants';
 import * as elementUtils from './elementUtils';
 import themeValues from '../themeValues';
 import {getStore} from '../../redux';
-import {generateEventHandler} from './utils';
 
 class ScreenProperties extends React.Component {
   static propTypes = {
@@ -87,7 +86,15 @@ class ScreenEvents extends React.Component {
   // event.targetId === "<id>" here, at the expense of added complexity.
   getClickEventCode() {
     const id = elementUtils.getId(this.props.element);
-    return generateEventHandler(id, 'click');
+    const code =
+      'onEvent("' +
+      id +
+      '", "click", function(event) {\n' +
+      '  console.log("' +
+      id +
+      ' clicked!");\n' +
+      '});\n';
+    return code;
   }
 
   insertClick = () => {
@@ -96,7 +103,13 @@ class ScreenEvents extends React.Component {
 
   getKeyEventCode() {
     const id = elementUtils.getId(this.props.element);
-    return generateEventHandler(id, 'keydown');
+    const code =
+      'onEvent("' +
+      id +
+      '", "keydown", function(event) {\n' +
+      '  console.log("Key: " + event.key);\n' +
+      '});\n';
+    return code;
   }
 
   insertKey = () => {

--- a/apps/src/applab/designElements/slider.jsx
+++ b/apps/src/applab/designElements/slider.jsx
@@ -97,17 +97,8 @@ class SliderEvents extends React.Component {
 
   getInputEventCode() {
     const id = elementUtils.getId(this.props.element);
-    const code =
-      'onEvent("' +
-      id +
-      '", "input", function(event) {\n' +
-      '  console.log("' +
-      id +
-      ' value: " + getNumber("' +
-      id +
-      '"));\n' +
-      '});\n';
-    return code;
+    const callback = `function( ) {\n\tconsole.log("${id} value: " + getNumber("${id}"));\n}`;
+    return `onEvent("${id}", "input", ${callback});`;
   }
 
   insertInput = () => {

--- a/apps/src/applab/designElements/slider.jsx
+++ b/apps/src/applab/designElements/slider.jsx
@@ -7,7 +7,6 @@ import ZOrderRow from './ZOrderRow';
 import EventHeaderRow from './EventHeaderRow';
 import EventRow from './EventRow';
 import * as elementUtils from './elementUtils';
-import {generateEventHandler} from './utils';
 
 class SliderProperties extends React.Component {
   static propTypes = {
@@ -98,7 +97,17 @@ class SliderEvents extends React.Component {
 
   getInputEventCode() {
     const id = elementUtils.getId(this.props.element);
-    return generateEventHandler(id, 'input');
+    const code =
+      'onEvent("' +
+      id +
+      '", "input", function(event) {\n' +
+      '  console.log("' +
+      id +
+      ' value: " + getNumber("' +
+      id +
+      '"));\n' +
+      '});\n';
+    return code;
   }
 
   insertInput = () => {

--- a/apps/src/applab/designElements/slider.jsx
+++ b/apps/src/applab/designElements/slider.jsx
@@ -7,6 +7,7 @@ import ZOrderRow from './ZOrderRow';
 import EventHeaderRow from './EventHeaderRow';
 import EventRow from './EventRow';
 import * as elementUtils from './elementUtils';
+import {generateEventHandler} from './utils';
 
 class SliderProperties extends React.Component {
   static propTypes = {
@@ -97,17 +98,7 @@ class SliderEvents extends React.Component {
 
   getInputEventCode() {
     const id = elementUtils.getId(this.props.element);
-    const code =
-      'onEvent("' +
-      id +
-      '", "input", function(event) {\n' +
-      '  console.log("' +
-      id +
-      ' value: " + getNumber("' +
-      id +
-      '"));\n' +
-      '});\n';
-    return code;
+    return generateEventHandler(id, 'input');
   }
 
   insertInput = () => {

--- a/apps/src/applab/designElements/textInput.jsx
+++ b/apps/src/applab/designElements/textInput.jsx
@@ -129,17 +129,8 @@ class TextInputEvents extends React.Component {
 
   getChangeEventCode() {
     const id = elementUtils.getId(this.props.element);
-    const code =
-      'onEvent("' +
-      id +
-      '", "change", function(event) {\n' +
-      '  console.log("' +
-      id +
-      ' entered text: " + getText("' +
-      id +
-      '"));\n' +
-      '});\n';
-    return code;
+    const callback = `function( ) {\n\tconsole.log("${id} entered text: " + getText("${id}"));\n}`;
+    return `onEvent("${id}", "change", ${callback});`;
   }
 
   insertChange = () => {
@@ -148,17 +139,8 @@ class TextInputEvents extends React.Component {
 
   getInputEventCode() {
     const id = elementUtils.getId(this.props.element);
-    const code =
-      'onEvent("' +
-      id +
-      '", "input", function(event) {\n' +
-      '  console.log("' +
-      id +
-      ' current text: " + getText("' +
-      id +
-      '"));\n' +
-      '});\n';
-    return code;
+    const callback = `function( ) {\n\tconsole.log("${id} current text: " + getText("${id}"));\n}`;
+    return `onEvent("${id}", "input", ${callback});`;
   }
 
   insertInput = () => {

--- a/apps/src/applab/designElements/textInput.jsx
+++ b/apps/src/applab/designElements/textInput.jsx
@@ -15,6 +15,7 @@ import designMode from '../designMode';
 import {themeOptions, CLASSIC_THEME_INDEX} from '../constants';
 import themeValues, {CLASSIC_TEXT_INPUT_PADDING} from '../themeValues';
 import elementLibrary from './library';
+import {generateEventHandler} from './utils';
 
 class TextInputProperties extends React.Component {
   static propTypes = {
@@ -129,17 +130,7 @@ class TextInputEvents extends React.Component {
 
   getChangeEventCode() {
     const id = elementUtils.getId(this.props.element);
-    const code =
-      'onEvent("' +
-      id +
-      '", "change", function(event) {\n' +
-      '  console.log("' +
-      id +
-      ' entered text: " + getText("' +
-      id +
-      '"));\n' +
-      '});\n';
-    return code;
+    return generateEventHandler(id, 'change');
   }
 
   insertChange = () => {
@@ -148,17 +139,7 @@ class TextInputEvents extends React.Component {
 
   getInputEventCode() {
     const id = elementUtils.getId(this.props.element);
-    const code =
-      'onEvent("' +
-      id +
-      '", "input", function(event) {\n' +
-      '  console.log("' +
-      id +
-      ' current text: " + getText("' +
-      id +
-      '"));\n' +
-      '});\n';
-    return code;
+    return generateEventHandler(id, 'input');
   }
 
   insertInput = () => {

--- a/apps/src/applab/designElements/textInput.jsx
+++ b/apps/src/applab/designElements/textInput.jsx
@@ -15,7 +15,6 @@ import designMode from '../designMode';
 import {themeOptions, CLASSIC_THEME_INDEX} from '../constants';
 import themeValues, {CLASSIC_TEXT_INPUT_PADDING} from '../themeValues';
 import elementLibrary from './library';
-import {generateEventHandler} from './utils';
 
 class TextInputProperties extends React.Component {
   static propTypes = {
@@ -130,7 +129,17 @@ class TextInputEvents extends React.Component {
 
   getChangeEventCode() {
     const id = elementUtils.getId(this.props.element);
-    return generateEventHandler(id, 'change');
+    const code =
+      'onEvent("' +
+      id +
+      '", "change", function(event) {\n' +
+      '  console.log("' +
+      id +
+      ' entered text: " + getText("' +
+      id +
+      '"));\n' +
+      '});\n';
+    return code;
   }
 
   insertChange = () => {
@@ -139,7 +148,17 @@ class TextInputEvents extends React.Component {
 
   getInputEventCode() {
     const id = elementUtils.getId(this.props.element);
-    return generateEventHandler(id, 'input');
+    const code =
+      'onEvent("' +
+      id +
+      '", "input", function(event) {\n' +
+      '  console.log("' +
+      id +
+      ' current text: " + getText("' +
+      id +
+      '"));\n' +
+      '});\n';
+    return code;
   }
 
   insertInput = () => {

--- a/apps/src/applab/designElements/textarea.jsx
+++ b/apps/src/applab/designElements/textarea.jsx
@@ -147,17 +147,8 @@ class TextAreaEvents extends React.Component {
 
   getChangeEventCode() {
     const id = elementUtils.getId(this.props.element);
-    const code =
-      'onEvent("' +
-      id +
-      '", "change", function(event) {\n' +
-      '  console.log("' +
-      id +
-      ' entered text: " + getText("' +
-      id +
-      '"));\n' +
-      '});\n';
-    return code;
+    const callback = `function( ) {\n\tconsole.log("${id} entered text: " + getText("${id}"));\n}`;
+    return `onEvent("${id}", "change", ${callback});`;
   }
 
   insertChange = () => {

--- a/apps/src/applab/designElements/textarea.jsx
+++ b/apps/src/applab/designElements/textarea.jsx
@@ -15,6 +15,7 @@ import EnumPropertyRow from './EnumPropertyRow';
 import designMode from '../designMode';
 import themeValues, {CLASSIC_TEXT_AREA_PADDING} from '../themeValues';
 import elementLibrary from './library';
+import {generateEventHandler} from './utils';
 
 class TextAreaProperties extends React.Component {
   static propTypes = {
@@ -147,17 +148,7 @@ class TextAreaEvents extends React.Component {
 
   getChangeEventCode() {
     const id = elementUtils.getId(this.props.element);
-    const code =
-      'onEvent("' +
-      id +
-      '", "change", function(event) {\n' +
-      '  console.log("' +
-      id +
-      ' entered text: " + getText("' +
-      id +
-      '"));\n' +
-      '});\n';
-    return code;
+    return generateEventHandler(id, 'change');
   }
 
   insertChange = () => {

--- a/apps/src/applab/designElements/textarea.jsx
+++ b/apps/src/applab/designElements/textarea.jsx
@@ -15,7 +15,6 @@ import EnumPropertyRow from './EnumPropertyRow';
 import designMode from '../designMode';
 import themeValues, {CLASSIC_TEXT_AREA_PADDING} from '../themeValues';
 import elementLibrary from './library';
-import {generateEventHandler} from './utils';
 
 class TextAreaProperties extends React.Component {
   static propTypes = {
@@ -148,7 +147,17 @@ class TextAreaEvents extends React.Component {
 
   getChangeEventCode() {
     const id = elementUtils.getId(this.props.element);
-    return generateEventHandler(id, 'change');
+    const code =
+      'onEvent("' +
+      id +
+      '", "change", function(event) {\n' +
+      '  console.log("' +
+      id +
+      ' entered text: " + getText("' +
+      id +
+      '"));\n' +
+      '});\n';
+    return code;
   }
 
   insertChange = () => {

--- a/apps/src/applab/designElements/utils.js
+++ b/apps/src/applab/designElements/utils.js
@@ -1,0 +1,3 @@
+export const generateEventHandler = (id, eventType) => {
+  return `onEvent("${id}", "${eventType}", function( ) {\n\n});`;
+};

--- a/apps/src/applab/designElements/utils.js
+++ b/apps/src/applab/designElements/utils.js
@@ -1,3 +1,0 @@
-export const generateEventHandler = (id, eventType) => {
-  return `onEvent("${id}", "${eventType}", function( ) {\n\n});`;
-};


### PR DESCRIPTION
Request from curriculum/users ([Slack](https://codedotorg.slack.com/archives/C01764GEKGS/p1603741018002400)) to remove the `event` param from the `onEvent` callback. The only exception being the canvas since the `event` param is used widely for that design element.

**Before:**
<img width="526" alt="Screen Shot 2020-10-26 at 1 56 34 PM" src="https://user-images.githubusercontent.com/9812299/97227686-12ebb280-1793-11eb-943e-2a3e338d9e2e.png">


**After:**
![Screen Shot 2020-10-26 at 5 52 45 PM](https://user-images.githubusercontent.com/9812299/97243686-193e5680-17b4-11eb-8411-fa0647114aae.png)

## Testing story

Manually tested.

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
