### PR TITLE
Pass IDs rather than objects to `.destroy`

### DIFF
--- a/dashboard/lib/services/script_seed.rb
+++ b/dashboard/lib/services/script_seed.rb
@@ -235,7 +235,7 @@ module ScriptSeed
   def self.destroy_outdated_objects(model_class, all_objects, imported_objects, seed_context)
     objects_to_keep_by_seeding_key = imported_objects.index_by {|o| o.seeding_key(seed_context)}
     should_keep = all_objects.group_by {|o| objects_to_keep_by_seeding_key.include?(o.seeding_key(seed_context))}
-    model_class.destroy(should_keep[false]) if should_keep.include?(false)
+    model_class.destroy(should_keep[false].pluck(:id)) if should_keep.include?(false)
     should_keep[true]
   end
 


### PR DESCRIPTION
This raises an error in Rails 5.2:

> You are passing an instance of ActiveRecord::Base to `find`. Please pass the id of the object by calling `.id`.

## Testing story

ran relevant tests manually

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
