### PR TITLE
Filter users with no name from Level.search_options

### DIFF
--- a/dashboard/app/models/levels/level.rb
+++ b/dashboard/app/models/levels/level.rb
@@ -790,7 +790,7 @@ class Level < ActiveRecord::Base
       ],
       ownerOptions: [
         ['Any owner', ''],
-        *Level.joins(:user).distinct.pluck('users.name, users.id').sort_by {|a| a[0]}
+        *Level.joins(:user).distinct.pluck('users.name, users.id').select {|a| !a[0].blank? && !a[1].blank?}.sort_by {|a| a[0]}
       ]
     }
   end

--- a/dashboard/test/ui/features/curriculum_platform/levelbuilder/lesson_edit_page.feature
+++ b/dashboard/test/ui/features/curriculum_platform/levelbuilder/lesson_edit_page.feature
@@ -1,5 +1,7 @@
 # We need "press keys" to type into the React form's fields, but that doesn't work on IE.
 @no_ie
+@no_firefox
+@no_safari
 @no_mobile
 Feature: Using the Lesson Edit Page
   Scenario: Save changes using the lesson edit page

--- a/dashboard/test/ui/features/curriculum_platform/levelbuilder/lesson_edit_page.feature
+++ b/dashboard/test/ui/features/curriculum_platform/levelbuilder/lesson_edit_page.feature
@@ -1,7 +1,6 @@
 # We need "press keys" to type into the React form's fields, but that doesn't work on IE.
 @no_ie
 @no_mobile
-@skip
 Feature: Using the Lesson Edit Page
   Scenario: Save changes using the lesson edit page
     Given I create a levelbuilder named "Levi"

--- a/dashboard/test/ui/features/curriculum_platform/levelbuilder/script_edit_page.feature
+++ b/dashboard/test/ui/features/curriculum_platform/levelbuilder/script_edit_page.feature
@@ -1,5 +1,4 @@
 @no_mobile
-@skip
 Feature: Using the Script Edit Page
 
 Scenario: View the script edit page


### PR DESCRIPTION
If a user owns a level but doesn't have a name, the sorting would crash. We don't want to show an option for a name-less user, so let's filter them out.

<!-- ### Background -->
<!-- ### Privacy -->
<!--
1.	Does the Project involve the collection, use or sharing of new Personal Data?

2.	Does the Project involve a new or changed use or sharing of existing Personal Data?
-->
<!-- ### Security -->
<!--
Link to Jira Task where sensitive security issues are discussed privately.
-->
<!-- ### Caching -->
<!-- ### Deployment strategy -->
<!-- ### Future work -->

## Links

<!--
  Any relevant links to external resources; ie, specification documents, jira
  items, related PRs, honeybadger errors, etc
-->

- [spec]()
- [jira]()

## Testing story

<!--
  Does your change include appropriate tests?

  If so, please describe how the tests included in this PR are sufficient

  If not, please explain why this change does not need to be tested.
-->

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
