### PR TITLE
Fix the new 'return to staging' logic in the i18n sync

### DIFF
--- a/bin/i18n/sync-all.rb
+++ b/bin/i18n/sync-all.rb
@@ -146,6 +146,7 @@ class I18nSync
     when /^i18n-sync/
       # If we're on an i18n sync branch, only return to staging if the branch
       # has been merged.
+      `git fetch`
       return unless GitUtils.current_branch_merged_into? "staging"
     else
       # If we're on some other branch, then we're in some kind of weird state,


### PR DESCRIPTION
Specifically, instruct the server to do a `git fetch` before checking to see if the sync PR has been merged into staging.

I had mistakenly thought that this would be handled by the ci build, but of course it doesn't run if we aren't on the staging branch.

<!--
  Your description goes here: A summary of the change, including any relevant motivation and context.

  If relevant, include a description both of the existing behavior and of the new behavior.
-->

<!--
  Other aspects to consider. uncomment and add detail for any that seem necessary:
-->

<!-- ### Background -->
<!-- ### Privacy -->
<!--
1.	Does the Project involve the collection, use or sharing of new Personal Data?

2.	Does the Project involve a new or changed use or sharing of existing Personal Data?
-->
<!-- ### Security -->
<!--
Link to Jira Task where sensitive security issues are discussed privately.
-->
<!-- ### Caching -->
<!-- ### Deployment strategy -->
<!-- ### Future work -->

## Links

<!--
  Any relevant links to external resources; ie, specification documents, jira
  items, related PRs, honeybadger errors, etc
-->

- [spec]()
- [jira]()

## Testing story

<!--
  Does your change include appropriate tests?

  If so, please describe how the tests included in this PR are sufficient

  If not, please explain why this change does not need to be tested.
-->

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
