### PR TITLE
Add slack logging to 'return to staging' logic

### DIFF
--- a/experimental/i18n-dev.crontab
+++ b/experimental/i18n-dev.crontab
@@ -44,4 +44,4 @@ HOME=/home/ubuntu
 
 # Periodically check to see if the I18n Sync PRs have been merged and attempt
 # to return to staging.
-0 */1 * * * cd /home/ubuntu/code-dot-org && git fetch && bundle exec ./bin/i18n/sync-all -c return-to-staging
+0 */1 * * * cd /home/ubuntu/code-dot-org && git fetch && (bundle exec ./bin/i18n/sync-all.rb -c return-to-staging | ./bin/i18n/slack_log) 2>&1 | ./bin/i18n/slack_error


### PR DESCRIPTION
It's been silently failing because a gem wasn't installed. It should now fail noisily.

## Testing story

Tested manually on the i18n server

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
