### PR TITLE
Revert "Revert "allow lesson name to be updated""

### DIFF
--- a/dashboard/app/controllers/lessons_controller.rb
+++ b/dashboard/app/controllers/lessons_controller.rb
@@ -24,7 +24,7 @@ class LessonsController < ApplicationController
         link: @lesson.script.link,
         lessons: @lesson.script.lessons.map {|lesson| {displayName: lesson.localized_name, link: lesson_path(id: lesson.id)}}
       },
-      displayName: @lesson.localized_title,
+      displayName: @lesson.name,
       overview: @lesson.overview || '',
       announcements: @lesson.announcements,
       purpose: @lesson.purpose || '',
@@ -65,6 +65,7 @@ class LessonsController < ApplicationController
     # for now, only allow editing of fields that cannot be edited on the
     # script edit page.
     lp = lp.permit(
+      :name,
       :overview,
       :student_overview,
       :assessment,

--- a/dashboard/app/models/lesson.rb
+++ b/dashboard/app/models/lesson.rb
@@ -269,7 +269,7 @@ class Lesson < ActiveRecord::Base
   def summarize_for_script_edit
     summary = summarize.dup
     # Do not let script name override lesson name when there is only one lesson
-    summary[:name] = I18n.t("data.script.name.#{script.name}.lessons.#{key}.name")
+    summary[:name] = name
     summary.freeze
   end
 

--- a/dashboard/test/integration/lessons_test.rb
+++ b/dashboard/test/integration/lessons_test.rb
@@ -115,6 +115,7 @@ class LessonsTest < ActionDispatch::IntegrationTest
     get edit_lesson_path(id: @lesson.id)
     assert_response :success
     lesson_data = JSON.parse(css_select('script[data-lesson]').first.attribute('data-lesson').to_s)
+    lesson_data['name'] = 'new lesson name'
     lesson_data['studentOverview'] = 'new student overview'
 
     activity_data = lesson_data['activities'].first
@@ -148,6 +149,7 @@ class LessonsTest < ActionDispatch::IntegrationTest
     patch lesson_path(id: @lesson.id, as: :json, params: lesson_data)
     assert_response :redirect
     @lesson.reload
+    assert_equal 'new lesson name', @lesson.name
     assert_equal 'lesson overview', @lesson.overview
     assert_equal 'new student overview', @lesson.student_overview
 


### PR DESCRIPTION
Reverts code-dot-org/code-dot-org#37448, restoring #37431, which it turns out didn't need to be reverted in the first place.