### PR TITLE
fix lesson edit page feature in safari and firefox

### DIFF
--- a/apps/src/lib/levelbuilder/lesson-editor/ActivitySectionCardButtons.jsx
+++ b/apps/src/lib/levelbuilder/lesson-editor/ActivitySectionCardButtons.jsx
@@ -126,7 +126,7 @@ class ActivitySectionCardButtons extends Component {
         <div style={styles.bottomControls}>
           <span>
             <button
-              onMouseDown={this.handleOpenAddLevel}
+              onClick={this.handleOpenAddLevel}
               className="btn uitest-open-add-level-button"
               style={styles.addButton}
               type="button"

--- a/apps/test/unit/lib/levelbuilder/lesson-editor/ActivitySectionCardButtonsTest.jsx
+++ b/apps/test/unit/lib/levelbuilder/lesson-editor/ActivitySectionCardButtonsTest.jsx
@@ -36,7 +36,7 @@ describe('ActivitySectionCardButtons', () => {
 
     const button = wrapper.find('button').at(0);
     expect(button.text()).to.include('Level');
-    button.simulate('mouseDown');
+    button.simulate('click');
     expect(wrapper.state().addLevelOpen).to.equal(true);
   });
 

--- a/dashboard/test/ui/features/curriculum_platform/levelbuilder/lesson_edit_page.feature
+++ b/dashboard/test/ui/features/curriculum_platform/levelbuilder/lesson_edit_page.feature
@@ -1,7 +1,5 @@
 # We need "press keys" to type into the React form's fields, but that doesn't work on IE.
 @no_ie
-@no_firefox
-@no_safari
 @no_mobile
 Feature: Using the Lesson Edit Page
   Scenario: Save changes using the lesson edit page

--- a/dashboard/test/ui/features/curriculum_platform/levelbuilder/lesson_edit_page.feature
+++ b/dashboard/test/ui/features/curriculum_platform/levelbuilder/lesson_edit_page.feature
@@ -40,8 +40,7 @@ Feature: Using the Lesson Edit Page
 
     # Open the Add Level dialog, search for an artist level and add the first one
 
-    # TODO: use regular click instead once button responds to click events
-    When execute JavaScript expression "$('.uitest-open-add-level-button').first().simulate('mousedown')"
+    And I press ".uitest-open-add-level-button:first" using jQuery
     And I wait until element "h2" contains text "Add Levels"
     And I wait until element "#add-level-type" is visible
     # If the next step fails, we should consider replacing "Artist" with any other
@@ -54,7 +53,7 @@ Feature: Using the Lesson Edit Page
     # confirmed earlier that there were no Artist levels in the initial view.
     And I wait until element ".uitest-level-dialog-content td" contains text "Artist"
     And element ".uitest-level-dialog-content td .fa-plus" is visible
-    And I press the first ".uitest-level-dialog-content td .fa-plus" element
+    And I press ".uitest-level-dialog-content td .fa-plus:first" using jQuery
     And I click selector ".save-add-levels-button"
     And I wait until element "h2" does not contain text "Add Levels"
 


### PR DESCRIPTION
The UI test for AddLevelDialog was likely never working in Safari or Firefox, since I failed to test it in all browsers before adding it initially.

## Testing story

The drone run is failing, but I checked that all the runs that load the lesson edit page are passing:
```
[curriculum_platform/levelbuilder/script_edit_page] UI tests for Firefox_curriculum_platform_levelbuilder_script_edit_page [0;32;49msucceeded[0m (3:01 minutes, 4 passed)
[curriculum_platform/levelbuilder/script_edit_page] UI tests for Safari_curriculum_platform_levelbuilder_script_edit_page [0;32;49msucceeded[0m (2:25 minutes, 4 passed)
[curriculum_platform/levelbuilder/script_edit_page] UI tests for IE11_curriculum_platform_levelbuilder_script_edit_page [0;32;49msucceeded[0m (2:35 minutes, 4 passed)
[curriculum_platform/levelbuilder/script_edit_page] UI tests for Chrome_curriculum_platform_levelbuilder_script_edit_page [0;32;49msucceeded[0m (2:10 minutes, 4 passed)
[curriculum_platform/levelbuilder/lesson_edit_page] UI tests for Firefox_curriculum_platform_levelbuilder_lesson_edit_page [0;32;49msucceeded[0m (1:39 minutes, 2 passed)
[curriculum_platform/levelbuilder/lesson_edit_page] UI tests for Safari_curriculum_platform_levelbuilder_lesson_edit_page [0;32;49msucceeded[0m (1:26 minutes, 2 passed)
[curriculum_platform/levelbuilder/lesson_edit_page] UI tests for Chrome_curriculum_platform_levelbuilder_lesson_edit_page [0;32;49msucceeded[0m (1:08 minutes, 2 passed)
```

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
