### PR TITLE
Update capture_queries cache detection logic

### DIFF
--- a/dashboard/test/testing/capture_queries.rb
+++ b/dashboard/test/testing/capture_queries.rb
@@ -58,7 +58,6 @@ module CaptureQueries
       # whole name.
       #
       # Once we update to Rails 5.1, we can remove the `include?` line.
-      #next if %w(CACHE SCHEMA).include? payload[:name]
       next if payload[:name] == "CACHE"
       next if payload.fetch(:cached, false)
 

--- a/dashboard/test/testing/capture_queries.rb
+++ b/dashboard/test/testing/capture_queries.rb
@@ -50,7 +50,18 @@ module CaptureQueries
     queries = []
     query = lambda do |_name, start, finish, _id, payload|
       duration = finish - start
-      next if %w(CACHE SCHEMA).include? payload[:name]
+
+      # Accomodate both Rails 5.0 and 5.1 methods for determining payload caching.
+      #
+      # payload[:cached] was added in Rails 5.1, and the naming scheme was
+      # changed to prepend "CACHE" to the name rather than overwriting the
+      # whole name.
+      #
+      # Once we update to Rails 5.1, we can remove the `include?` line.
+      #next if %w(CACHE SCHEMA).include? payload[:name]
+      next if payload[:name] == "CACHE"
+      next if payload.fetch(:cached, false)
+
       cleaner = Rails::BacktraceCleaner.new
       cleaner.add_silencer {|line| line.include?(__dir__.sub("#{Rails.root}/", ''))}
       cleaner.add_silencer {|line| line =~ /application_controller.*with_locale/}


### PR DESCRIPTION
To accomodate both Rails 5.0 and 5.1 methods.

Note that we also remove the logic that's detecting schema payloads, as those are already ignored for us by the underlying implementation:

https://github.com/rails/rails/blob/c4d3e202e10ae627b3b9c34498afb45450652421/activerecord/lib/active_record/log_subscriber.rb#L3

https://github.com/rails/rails/blob/c4d3e202e10ae627b3b9c34498afb45450652421/activerecord/lib/active_record/log_subscriber.rb#L29

<!--
  Your description goes here: A summary of the change, including any relevant motivation and context.

  If relevant, include a description both of the existing behavior and of the new behavior.
-->

<!--
  Other aspects to consider. uncomment and add detail for any that seem necessary:
-->

<!-- ### Background -->
<!-- ### Privacy -->
<!--
1.	Does the Project involve the collection, use or sharing of new Personal Data?

2.	Does the Project involve a new or changed use or sharing of existing Personal Data?
-->
<!-- ### Security -->
<!--
Link to Jira Task where sensitive security issues are discussed privately.
-->
<!-- ### Caching -->
<!-- ### Deployment strategy -->
<!-- ### Future work -->

## Links

<!--
  Any relevant links to external resources; ie, specification documents, jira
  items, related PRs, honeybadger errors, etc
-->

- [spec]()
- [jira]()

## Testing story

<!--
  Does your change include appropriate tests?

  If so, please describe how the tests included in this PR are sufficient

  If not, please explain why this change does not need to be tested.
-->

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
