### PR TITLE
Add objectives to the lesson front page

### DIFF
--- a/apps/i18n/common/en_us.json
+++ b/apps/i18n/common/en_us.json
@@ -1191,6 +1191,8 @@
   "numBlocksUsedLabel": "Blocks",
   "numLanguages": "{numLanguages} Languages",
   "numLinesOfCodeWritten": "You just wrote {numLines, plural, one {1 line} other {# lines}} of code!",
+  "objectives": "Objectives",
+  "objectivesSubheading": "Students will be able to:",
   "ok": "OK",
   "okay": "Okay",
   "online": "Online",

--- a/apps/src/templates/lessonOverview/LessonOverview.jsx
+++ b/apps/src/templates/lessonOverview/LessonOverview.jsx
@@ -8,6 +8,7 @@ import {connect} from 'react-redux';
 import {SignInState} from '@cdo/apps/templates/currentUserRedux';
 import {ViewType} from '@cdo/apps/code-studio/viewAsRedux';
 import SafeMarkdown from '@cdo/apps/templates/SafeMarkdown';
+import InlineMarkdown from '@cdo/apps/templates/InlineMarkdown';
 import styleConstants from '@cdo/apps/styleConstants';
 import color from '@cdo/apps/util/color';
 import Button from '@cdo/apps/templates/Button';
@@ -58,7 +59,8 @@ class LessonOverview extends Component {
       overview: PropTypes.string.isRequired,
       purpose: PropTypes.string.isRequired,
       preparation: PropTypes.string.isRequired,
-      resources: PropTypes.object
+      resources: PropTypes.object.isRequired,
+      objectives: PropTypes.arrayOf(PropTypes.object).isRequired
     }).isRequired,
     activities: PropTypes.array,
 
@@ -153,9 +155,22 @@ class LessonOverview extends Component {
             <LessonAgenda activities={this.props.activities} />
           </div>
           <div style={styles.right}>
+            {lesson.objectives.length > 0 && (
+              <div>
+                <h2>{i18n.objectives()}</h2>
+                <h3>{i18n.objectivesSubheading()}</h3>
+                <ul>
+                  {lesson.objectives.map(objective => (
+                    <li key={objective.id}>
+                      <InlineMarkdown markdown={objective.description} />
+                    </li>
+                  ))}
+                </ul>
+              </div>
+            )}
             <h2>{i18n.preparation()}</h2>
             <SafeMarkdown markdown={lesson.preparation} />
-            {lesson.resources && (
+            {Object.keys(lesson.resources).length > 0 && (
               <div id="resource-section">
                 <h2>{i18n.links()}</h2>
                 {lesson.resources['Teacher'] && (

--- a/apps/test/unit/templates/lessonOverview/LessonOverviewTest.js
+++ b/apps/test/unit/templates/lessonOverview/LessonOverviewTest.js
@@ -51,7 +51,8 @@ describe('LessonOverview', () => {
               type: 'Activity Guide'
             }
           ]
-        }
+        },
+        objectives: [{id: 1, description: 'what students will learn'}]
       },
       activities: [],
       announcements: [],
@@ -78,6 +79,11 @@ describe('LessonOverview', () => {
       'The purpose of the lesson is for people to learn'
     );
     expect(safeMarkdowns.at(2).props().markdown).to.contain('- One');
+
+    const inlineMarkdowns = wrapper.find('InlineMarkdown');
+    expect(inlineMarkdowns.at(0).props().markdown).to.contain(
+      'what students will learn'
+    );
 
     expect(wrapper.find('LessonAgenda').length).to.equal(1);
   });

--- a/dashboard/app/controllers/lessons_controller.rb
+++ b/dashboard/app/controllers/lessons_controller.rb
@@ -30,7 +30,8 @@ class LessonsController < ApplicationController
       purpose: @lesson.purpose || '',
       preparation: @lesson.preparation || '',
       activities: @lesson.lesson_activities.map(&:summarize_for_lesson_show),
-      resources: @lesson.resources_for_lesson_plan(@current_user&.authorized_teacher?)
+      resources: @lesson.resources_for_lesson_plan(@current_user&.authorized_teacher?),
+      objectives: @lesson.objectives.map(&:summarize_for_lesson_show)
     }
   end
 

--- a/dashboard/app/models/objective.rb
+++ b/dashboard/app/models/objective.rb
@@ -28,4 +28,15 @@ class Objective < ActiveRecord::Base
   def summarize_for_edit
     {id: id, description: description}
   end
+
+  def summarize_for_lesson_show
+    {id: id, description: localized_description}
+  end
+
+  private
+
+  def localized_description
+    # TODO: localize the descriptions
+    description
+  end
 end

--- a/dashboard/app/models/objective.rb
+++ b/dashboard/app/models/objective.rb
@@ -30,12 +30,12 @@ class Objective < ActiveRecord::Base
   end
 
   def summarize_for_lesson_show
-    {id: id, description: localized_description}
+    {id: id, description: display_description}
   end
 
   private
 
-  def localized_description
+  def display_description
     # TODO: localize the descriptions
     description
   end

--- a/dashboard/test/models/objective_test.rb
+++ b/dashboard/test/models/objective_test.rb
@@ -9,12 +9,13 @@ class ObjectiveTest < ActiveSupport::TestCase
     assert_equal 'what I will learn', objective.description
   end
 
-  test "summarize for edit" do
+  test "summarize" do
     objective = Objective.new
     objective.description = 'what I will learn'
     objective.save!
     objective.reload
     expected_summary = {id: objective.id, description: 'what I will learn'}
     assert_equal expected_summary, objective.summarize_for_edit
+    assert_equal expected_summary, objective.summarize_for_lesson_show
   end
 end


### PR DESCRIPTION
Adds objectives, if a lesson has them, to the lesson front page:

![Screenshot 2020-10-27 at 4 33 07 PM](https://user-images.githubusercontent.com/46464143/97372995-20c43500-1872-11eb-8c6b-10790e34acf3.png)

<!-- ### Background -->
<!-- ### Privacy -->
<!--
1.	Does the Project involve the collection, use or sharing of new Personal Data?

2.	Does the Project involve a new or changed use or sharing of existing Personal Data?
-->
<!-- ### Security -->
<!--
Link to Jira Task where sensitive security issues are discussed privately.
-->
<!-- ### Caching -->
<!-- ### Deployment strategy -->
<!-- ### Future work -->

## Links

<!--
  Any relevant links to external resources; ie, specification documents, jira
  items, related PRs, honeybadger errors, etc
-->

- [jira](https://codedotorg.atlassian.net/browse/PLAT-323)

## Testing story

<!--
  Does your change include appropriate tests?

  If so, please describe how the tests included in this PR are sufficient

  If not, please explain why this change does not need to be tested.
-->

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
