### PR TITLE
[Google Blockly] Load GoogleBlockly directly in test

### DIFF
--- a/apps/test/unit/sites/studio/pages/googleBlocklyWrapperTest.js
+++ b/apps/test/unit/sites/studio/pages/googleBlocklyWrapperTest.js
@@ -1,11 +1,13 @@
-/* global Blockly GoogleBlockly */
+/* global Blockly */
+import GoogleBlockly from 'blockly/core';
+import initializeGoogleBlocklyWrapper from '@cdo/apps/sites/studio/pages/googleBlocklyWrapper';
 import {expect} from '../../../../util/reconfiguredChai';
 import '@cdo/apps/flappy/flappy'; // Importing the app forces the test to load Blockly
 
 describe('Google Blockly Wrapper', () => {
   const cdoBlockly = Blockly;
   beforeEach(() => {
-    Blockly = GoogleBlockly; // eslint-disable-line no-global-assign
+    Blockly = initializeGoogleBlocklyWrapper(GoogleBlockly); // eslint-disable-line no-global-assign
   });
   afterEach(() => {
     // reset Blockly for other tests

--- a/apps/test/util/frame.js
+++ b/apps/test/util/frame.js
@@ -1,8 +1,3 @@
-import GoogleBlockly from 'blockly/core';
-import locale from 'blockly/msg/en';
-import 'blockly/blocks';
-import 'blockly/javascript';
-
 /**
  * Provides the basic frame for running Blockly.  In particular, this will
  * create a basic dom, load blockly.js  and put the contents into the global
@@ -16,10 +11,6 @@ function setGlobals() {
   var blockly = require('@code-dot-org/blockly');
   var initializeCdoBlocklyWrapper = require('../../src/sites/studio/pages/cdoBlocklyWrapper');
   window.Blockly = initializeCdoBlocklyWrapper(blockly);
-
-  GoogleBlockly.setLocale(locale);
-  var initializeGoogleBlocklyWrapper = require('../../src/sites/studio/pages/googleBlocklyWrapper');
-  window.GoogleBlockly = initializeGoogleBlocklyWrapper(GoogleBlockly);
 
   try {
     require('../../lib/blockly/en_us');


### PR DESCRIPTION
Some tests were failing with 
![image](https://user-images.githubusercontent.com/8787187/97374846-8ca89c80-1876-11eb-9097-701e95ad3d1f.png)
I'm not exactly sure why this was happening, but we can just load GoogleBlockly only in the tests where we need it.
See also [slack thread](https://codedotorg.slack.com/archives/CHZR21TLY/p1603841430023900)