### PR TITLE
avoid errors when adding/updating anonymous surveys in lesson editor

### DIFF
--- a/dashboard/app/models/activity_section.rb
+++ b/dashboard/app/models/activity_section.rb
@@ -74,7 +74,8 @@ class ActivitySection < ApplicationRecord
       sl.update!(
         # position and chapter will be updated based on activity_section_position later
         activity_section_position: sl_data['activitySectionPosition'] || 0,
-        assessment: !!sl_data['assessment'],
+        # Script levels containing anonymous levels must be assessments.
+        assessment: !!sl_data['assessment'] || sl.anonymous?,
         bonus: !!sl_data['bonus'],
         challenge: !!sl_data['challenge'],
       )

--- a/dashboard/app/models/script_level.rb
+++ b/dashboard/app/models/script_level.rb
@@ -659,8 +659,15 @@ class ScriptLevel < ActiveRecord::Base
 
   # @param [Array<Hash>] levels_data - Array of hashes each representing a level
   def update_levels(levels_data)
-    self.levels = levels_data.map do |level_data|
+    levels = levels_data.map do |level_data|
       Level.find(level_data['id'])
     end
+
+    # Script levels containing anonymous levels must be assessments.
+    if levels.any? {|l| l.properties["anonymous"] == "true"}
+      self.assessment = true
+      save! if changed?
+    end
+    self.levels = levels
   end
 end


### PR DESCRIPTION
FInishes [PLAT-418]. 

## Background

When a script level in the activities editor contains an anonymous survey but is not marked as an assessment, and the user presses save, we were getting an error like this:
![anonymous-validation-failed](https://user-images.githubusercontent.com/8001765/97456995-9671e480-18f6-11eb-8c72-fb3ded683d34.png)

the user would then lose any changes they had made on the lesson page.This happens in two separate cases:

1. a new level is added via AddLevelDialog
![Screen Shot 2020-10-28 at 8 22 10 AM](https://user-images.githubusercontent.com/8001765/97457254-d33ddb80-18f6-11eb-8174-309b3c0a1c0d.png)
and then saved without checking the assessment checkbox.

2. an existing script level is updated by unchecking the box in the ActivitySectionCard
![Screen Shot 2020-10-28 at 8 23 00 AM](https://user-images.githubusercontent.com/8001765/97457286-d89b2600-18f6-11eb-9fe5-003df88506f8.png)

## new behavior

the server now silently sets the assessment flag in both scenarios, so that we can pass validations. 

## future work

Ideally, in both scenarios, the checkbox would be checked and disabled whenever the script level contains an anonymous survey. This is tracked as future work in [PLAT-457].

## Testing story

New unit tests covering both cases. Also manually verified both user scenarios are working end to end.

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked


[PLAT-418]: https://codedotorg.atlassian.net/browse/PLAT-418
[PLAT-457]: https://codedotorg.atlassian.net/browse/PLAT-457