### PR TITLE
hack: warn before saving script edit page if lesson edit page has been opened

### DIFF
--- a/apps/src/lib/levelbuilder/script-editor/LessonToken.jsx
+++ b/apps/src/lib/levelbuilder/script-editor/LessonToken.jsx
@@ -146,6 +146,7 @@ export default class LessonToken extends Component {
               <div
                 style={styles.edit}
                 onClick={() => {
+                  window.lessonEditorOpened = true;
                   const win = window.open(
                     `/lessons/${this.props.lesson.id}/edit`,
                     '_blank'

--- a/apps/src/lib/levelbuilder/script-editor/ScriptEditor.jsx
+++ b/apps/src/lib/levelbuilder/script-editor/ScriptEditor.jsx
@@ -136,6 +136,19 @@ export default class ScriptEditor extends React.Component {
         e.preventDefault();
       }
     }
+    // HACK: until the script edit page no longer overwrites changes to the
+    // arrangement of levels within lessons, give the user a warning
+    if (
+      window.lessonEditorOpened &&
+      !confirm(
+        'WARNING: It looks like you opened a lesson edit page from this script edit page. ' +
+          'If you made any changes on the lesson edit page which you do not ' +
+          'wish to lose, please click cancel now and reload this page before ' +
+          'saving any changes to this script edit page.'
+      )
+    ) {
+      e.preventDefault();
+    }
   };
 
   render() {


### PR DESCRIPTION
Partially addresses [PLAT-441]. We think this is throwaway work, so I've implemented a hacky solution that should nonetheless be safe and did not take long to implement. It works as follows:
* on the script edit gui page, store a global boolean if the user opens a lesson edit page
* when the script edit gui page is saved, if the boolean is set, warn them about the risk of losing any changes that were on the lesson edit page:
![Screen Shot 2020-10-27 at 6 14 42 PM](https://user-images.githubusercontent.com/8001765/97379043-0fcef000-1881-11eb-8d8d-73eaa9bd1df7.png)
* do not show any warning if the boolean was not set.

## Testing story

Manually verified 3 scenarios:
1. save without opening lesson edit page --> save happens
1. save after opening lesson edit page --> cancel --> no save happens
1. save after opening lesson edit page --> confirm --> save happens
1. save non-gui script edit page --> save happens (there is no lesson edit button in this case)

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked

[PLAT-441]: https://codedotorg.atlassian.net/browse/PLAT-441