### PR TITLE
Lesson group removal

### DIFF
--- a/apps/src/lib/levelbuilder/script-editor/scriptEditorRedux.js
+++ b/apps/src/lib/levelbuilder/script-editor/scriptEditorRedux.js
@@ -148,6 +148,7 @@ function lessonGroups(state = [], action) {
       if (newState.length === 0) {
         newState.push(emptyNonUserFacingGroup);
       }
+      updateGroupPositions(newState);
       updateLessonPositions(newState);
       break;
     }

--- a/apps/src/lib/levelbuilder/script-editor/scriptEditorRedux.js
+++ b/apps/src/lib/levelbuilder/script-editor/scriptEditorRedux.js
@@ -145,11 +145,9 @@ function lessonGroups(state = [], action) {
     }
     case REMOVE_GROUP: {
       newState.splice(action.groupPosition - 1, 1);
-      console.log(newState);
       if (newState.length === 0) {
         newState.push(emptyNonUserFacingGroup);
       }
-      updateGroupPositions(newState);
       updateLessonPositions(newState);
       break;
     }

--- a/apps/src/lib/levelbuilder/script-editor/scriptEditorRedux.js
+++ b/apps/src/lib/levelbuilder/script-editor/scriptEditorRedux.js
@@ -145,9 +145,11 @@ function lessonGroups(state = [], action) {
     }
     case REMOVE_GROUP: {
       newState.splice(action.groupPosition - 1, 1);
+      console.log(newState);
       if (newState.length === 0) {
         newState.push(emptyNonUserFacingGroup);
       }
+      updateGroupPositions(newState);
       updateLessonPositions(newState);
       break;
     }

--- a/apps/test/unit/code-studio/scriptEditorReduxTest.js
+++ b/apps/test/unit/code-studio/scriptEditorReduxTest.js
@@ -57,6 +57,7 @@ describe('scriptEditorRedux reducer tests', () => {
     let nextState = reducer(initialState, removeGroup(1));
     let lessonGroups = nextState.lessonGroups;
     assert.equal(lessonGroups.length, 1);
+    assert.equal(lessonGroups[0].position, 1);
     assert.equal(lessonGroups[0].key, 'lg-key-2');
 
     // Remove lesson group when there is only one lesson group left
@@ -65,6 +66,7 @@ describe('scriptEditorRedux reducer tests', () => {
     lessonGroups = nextState.lessonGroups;
     assert.equal(lessonGroups.length, 1);
     assert.equal(lessonGroups[0].key, emptyNonUserFacingGroup.key);
+    assert.equal(lessonGroups[0].position, 1);
     assert.equal(lessonGroups[0].userFacing, false);
   });
 


### PR DESCRIPTION
Fixes [PLAT-437](https://codedotorg.atlassian.net/browse/PLAT-437).  We were not updating the group position values when removing groups which was causing weird behavior when you removed more than one group.  Updating the group position values after removing a group fixes this issue.

Added to the scriptEditorReduxTests to check position when removing group. The test failed on current staging and passes on the new branch.
