### PR TITLE
Require family name to be set into order to set standalone course

### DIFF
--- a/apps/src/lib/levelbuilder/script-editor/ScriptEditor.jsx
+++ b/apps/src/lib/levelbuilder/script-editor/ScriptEditor.jsx
@@ -104,7 +104,6 @@ export default class ScriptEditor extends React.Component {
     super(props);
 
     this.state = {
-      curriculumUmbrella: this.props.curriculumUmbrella,
       familyName: this.props.familyName
     };
   }
@@ -113,11 +112,6 @@ export default class ScriptEditor extends React.Component {
     $(this.supportedLocaleSelect)
       .children('option')
       .removeAttr('selected', true);
-  };
-
-  handleUmbrellaSelectChange = event => {
-    const curriculumUmbrella = event.target.value;
-    this.setState({curriculumUmbrella});
   };
 
   handleFamilyNameChange = event => {
@@ -316,7 +310,6 @@ export default class ScriptEditor extends React.Component {
                   name="curriculum_umbrella"
                   style={styles.dropdown}
                   defaultValue={this.props.curriculumUmbrella}
-                  onChange={this.handleUmbrellaSelectChange}
                 >
                   <option value="">(None)</option>
                   {CURRICULUM_UMBRELLAS.map(curriculumUmbrella => (
@@ -344,7 +337,7 @@ export default class ScriptEditor extends React.Component {
                 Family Name
                 <select
                   name="family_name"
-                  defaultValue={this.state.familyName}
+                  value={this.state.familyName}
                   style={styles.dropdown}
                   disabled={this.props.hasCourse}
                   onChange={this.handleFamilyNameChange}

--- a/apps/src/lib/levelbuilder/script-editor/ScriptEditor.jsx
+++ b/apps/src/lib/levelbuilder/script-editor/ScriptEditor.jsx
@@ -405,7 +405,7 @@ export default class ScriptEditor extends React.Component {
                   name="is_course"
                   type="checkbox"
                   checked={this.state.isCourse}
-                  disabled={!this.state.familyName || this.props.hasCourse}
+                  disabled={!this.state.familyName}
                   style={styles.checkbox}
                   onChange={this.handleStandaloneCourseChange}
                 />

--- a/apps/src/lib/levelbuilder/script-editor/ScriptEditor.jsx
+++ b/apps/src/lib/levelbuilder/script-editor/ScriptEditor.jsx
@@ -104,7 +104,8 @@ export default class ScriptEditor extends React.Component {
     super(props);
 
     this.state = {
-      familyName: this.props.familyName
+      familyName: this.props.familyName || '',
+      isCourse: this.props.isCourse
     };
   }
 
@@ -116,6 +117,10 @@ export default class ScriptEditor extends React.Component {
 
   handleFamilyNameChange = event => {
     this.setState({familyName: event.target.value});
+  };
+
+  handleStandaloneCourseChange = () => {
+    this.setState({isCourse: !this.state.isCourse});
   };
 
   presubmit = e => {
@@ -342,7 +347,7 @@ export default class ScriptEditor extends React.Component {
                   disabled={this.props.hasCourse}
                   onChange={this.handleFamilyNameChange}
                 >
-                  <option value="">(None)</option>
+                  {!this.state.isCourse && <option value="">(None)</option>}
                   {this.props.scriptFamilies.map(familyOption => (
                     <option key={familyOption} value={familyOption}>
                       {familyOption}
@@ -356,6 +361,14 @@ export default class ScriptEditor extends React.Component {
                       a course, and redirecting to the latest version of a
                       specific unit within a course is deprecated. Please go to
                       the course page to edit this field.
+                    </p>
+                  </HelpTip>
+                )}
+                {this.state.isCourse && (
+                  <HelpTip>
+                    <p>
+                      If you want to clear the family name you need to uncheck
+                      standalone course.
                     </p>
                   </HelpTip>
                 )}
@@ -387,6 +400,42 @@ export default class ScriptEditor extends React.Component {
                 )}
               </label>
               <label>
+                Is a Standalone Course
+                <input
+                  name="is_course"
+                  type="checkbox"
+                  checked={this.state.isCourse}
+                  disabled={!this.state.familyName || this.props.hasCourse}
+                  style={styles.checkbox}
+                  onChange={this.handleStandaloneCourseChange}
+                />
+                {this.state.familyName && !this.props.hasCourse && (
+                  <HelpTip>
+                    <p>
+                      (Still in development) If checked, indicates that this
+                      Unit represents a standalone course. Examples of such
+                      Units include CourseA-F, Express, and Pre-Express.
+                    </p>
+                  </HelpTip>
+                )}
+                {!this.state.familyName && !this.props.hasCourse && (
+                  <HelpTip>
+                    <p>
+                      You must select a family name in order to mark something
+                      as a standalone course.
+                    </p>
+                  </HelpTip>
+                )}
+                {this.props.hasCourse && (
+                  <HelpTip>
+                    <p>
+                      This unit is already part of a course so it can not be a
+                      standalone course.
+                    </p>
+                  </HelpTip>
+                )}
+              </label>
+              <label>
                 Can be recommended (aka stable)
                 <input
                   name="is_stable"
@@ -406,27 +455,6 @@ export default class ScriptEditor extends React.Component {
                 visible={!this.props.hidden}
                 pilotExperiment={this.props.pilotExperiment}
               />
-              <label>
-                Is a Standalone Course
-                <input
-                  name="is_course"
-                  type="checkbox"
-                  defaultChecked={this.props.isCourse}
-                  disabled={!this.state.familyName}
-                  style={styles.checkbox}
-                />
-                <HelpTip>
-                  <p>
-                    (Still in development) If checked, indicates that this Unit
-                    represents a standalone course. Examples of such Units
-                    include CourseA-F, Express, and Pre-Express.
-                  </p>
-                  <p>
-                    You must select a family name in order to mark something as
-                    a standalone course.
-                  </p>
-                </HelpTip>
-              </label>
             </div>
           )}
         </CollapsibleEditorSection>

--- a/apps/src/lib/levelbuilder/script-editor/ScriptEditor.jsx
+++ b/apps/src/lib/levelbuilder/script-editor/ScriptEditor.jsx
@@ -104,7 +104,8 @@ export default class ScriptEditor extends React.Component {
     super(props);
 
     this.state = {
-      curriculumUmbrella: this.props.curriculumUmbrella
+      curriculumUmbrella: this.props.curriculumUmbrella,
+      familyName: this.props.familyName
     };
   }
 
@@ -117,6 +118,10 @@ export default class ScriptEditor extends React.Component {
   handleUmbrellaSelectChange = event => {
     const curriculumUmbrella = event.target.value;
     this.setState({curriculumUmbrella});
+  };
+
+  handleFamilyNameChange = event => {
+    this.setState({familyName: event.target.value});
   };
 
   presubmit = e => {
@@ -339,9 +344,10 @@ export default class ScriptEditor extends React.Component {
                 Family Name
                 <select
                   name="family_name"
-                  defaultValue={this.props.familyName}
+                  defaultValue={this.state.familyName}
                   style={styles.dropdown}
                   disabled={this.props.hasCourse}
+                  onChange={this.handleFamilyNameChange}
                 >
                   <option value="">(None)</option>
                   {this.props.scriptFamilies.map(familyOption => (
@@ -413,6 +419,7 @@ export default class ScriptEditor extends React.Component {
                   name="is_course"
                   type="checkbox"
                   defaultChecked={this.props.isCourse}
+                  disabled={!this.state.familyName}
                   style={styles.checkbox}
                 />
                 <HelpTip>
@@ -420,6 +427,10 @@ export default class ScriptEditor extends React.Component {
                     (Still in development) If checked, indicates that this Unit
                     represents a standalone course. Examples of such Units
                     include CourseA-F, Express, and Pre-Express.
+                  </p>
+                  <p>
+                    You must select a family name in order to mark something as
+                    a standalone course.
                   </p>
                 </HelpTip>
               </label>

--- a/apps/src/lib/levelbuilder/script-editor/scriptEditorRedux.js
+++ b/apps/src/lib/levelbuilder/script-editor/scriptEditorRedux.js
@@ -145,11 +145,9 @@ function lessonGroups(state = [], action) {
     }
     case REMOVE_GROUP: {
       newState.splice(action.groupPosition - 1, 1);
-      console.log(newState);
       if (newState.length === 0) {
         newState.push(emptyNonUserFacingGroup);
       }
-      updateGroupPositions(newState);
       updateLessonPositions(newState);
       break;
     }

--- a/apps/src/lib/levelbuilder/script-editor/scriptEditorRedux.js
+++ b/apps/src/lib/levelbuilder/script-editor/scriptEditorRedux.js
@@ -145,9 +145,11 @@ function lessonGroups(state = [], action) {
     }
     case REMOVE_GROUP: {
       newState.splice(action.groupPosition - 1, 1);
+      console.log(newState);
       if (newState.length === 0) {
         newState.push(emptyNonUserFacingGroup);
       }
+      updateGroupPositions(newState);
       updateLessonPositions(newState);
       break;
     }

--- a/apps/test/unit/lib/levelbuilder/script-editor/ScriptEditorTest.jsx
+++ b/apps/test/unit/lib/levelbuilder/script-editor/ScriptEditorTest.jsx
@@ -17,7 +17,8 @@ describe('ScriptEditor', () => {
     name: 'test-script',
     scriptFamilies: [],
     teacherResources: [],
-    versionYearOptions: []
+    versionYearOptions: [],
+    familyName: ''
   };
 
   describe('Script Editor', () => {
@@ -38,6 +39,24 @@ describe('ScriptEditor', () => {
       ).to.equal(
         '# Title \n This is the unit description with [link](https://studio.code.org/home) **Bold** *italics*'
       );
+    });
+
+    it('must set family name in order to check standalone course', () => {
+      const wrapper = mount(<ScriptEditor {...DEFAULT_PROPS} hidden={false} />);
+      let courseCheckbox = wrapper.find('input[name="is_course"]');
+      let familyNameSelect = wrapper.find('select[name="family_name"]');
+
+      expect(courseCheckbox.props().disabled).to.be.true;
+      expect(familyNameSelect.props().value).to.equal('');
+
+      familyNameSelect.simulate('change', {target: {value: 'Family'}});
+
+      // have to re-find the items inorder to see updates
+      courseCheckbox = wrapper.find('input[name="is_course"]');
+      familyNameSelect = wrapper.find('select[name="family_name"]');
+
+      expect(familyNameSelect.props().value).to.equal('Family');
+      expect(courseCheckbox.props().disabled).to.be.false;
     });
   });
 


### PR DESCRIPTION
Requires that you select a family name before you can check that a unit is a standalone course. Added help text to the existing help tip.

Added a test to check that you can't set the standalone course until you set family name.

Completes [PLAT-450](https://codedotorg.atlassian.net/browse/PLAT-450)

![stand-alone-course](https://user-images.githubusercontent.com/208083/97438635-6c6ef100-18fb-11eb-89cc-a5206847e290.gif)

