### PR TITLE
Remove deprecated :text option to render

### DIFF
--- a/dashboard/app/controllers/admin_reports_controller.rb
+++ b/dashboard/app/controllers/admin_reports_controller.rb
@@ -127,7 +127,7 @@ class AdminReportsController < ApplicationController
     rescue ActiveRecord::RecordNotFound
       render(
         layout: 'application',
-        text: "Script #{script_id_or_name} not found.",
+        plain: "Script #{script_id_or_name} not found.",
         status: 404
       ) && return
     end
@@ -142,7 +142,7 @@ class AdminReportsController < ApplicationController
         )
         render(
           layout: 'application',
-          text: "PD progress data not found for #{sanitized_script_name}.",
+          plain: "PD progress data not found for #{sanitized_script_name}.",
           status: 404
         )
       end

--- a/dashboard/app/controllers/dynamic_config_controller.rb
+++ b/dashboard/app/controllers/dynamic_config_controller.rb
@@ -10,7 +10,7 @@ class DynamicConfigController < ApplicationController
     gk_yaml = Gatekeeper.to_yaml
     dcdo_yaml = DCDO.to_yaml
     output = "# Gatekeeper Config\n #{gk_yaml}\n\n# DCDO Config\n#{dcdo_yaml}"
-    render text: output, content_type: 'text/yaml'
+    render plain: output, content_type: 'text/yaml'
   end
 
   def gatekeeper_show

--- a/dashboard/app/controllers/home_controller.rb
+++ b/dashboard/app/controllers/home_controller.rb
@@ -32,12 +32,12 @@ class HomeController < ApplicationController
     if current_user
       render 'index', layout: false, formats: [:html]
     else
-      render text: ''
+      render plain: ''
     end
   end
 
   def health_check
-    render text: 'healthy!'
+    render plain: 'healthy!'
   end
 
   # Signed in student, with an assigned course/script: redirect to course overview page

--- a/dashboard/app/controllers/lessons_controller.rb
+++ b/dashboard/app/controllers/lessons_controller.rb
@@ -54,7 +54,7 @@ class LessonsController < ApplicationController
 
     redirect_to lesson_path(id: @lesson.id)
   rescue ActiveRecord::RecordNotFound, ActiveRecord::RecordInvalid => e
-    render(status: :not_acceptable, text: e.message)
+    render(status: :not_acceptable, plain: e.message)
   end
 
   private

--- a/dashboard/app/controllers/levels_controller.rb
+++ b/dashboard/app/controllers/levels_controller.rb
@@ -290,9 +290,9 @@ class LevelsController < ApplicationController
     begin
       @level = type_class.create_from_level_builder(params, create_level_params)
     rescue ArgumentError => e
-      render(status: :not_acceptable, text: e.message) && return
+      render(status: :not_acceptable, plain: e.message) && return
     rescue ActiveRecord::RecordInvalid => invalid
-      render(status: :not_acceptable, text: invalid) && return
+      render(status: :not_acceptable, plain: invalid) && return
     end
     if params[:do_not_redirect]
       render json: @level
@@ -360,9 +360,9 @@ class LevelsController < ApplicationController
       render json: {redirect: edit_level_url(@new_level)}
     end
   rescue ArgumentError => e
-    render(status: :not_acceptable, text: e.message)
+    render(status: :not_acceptable, plain: e.message)
   rescue ActiveRecord::RecordInvalid => invalid
-    render(status: :not_acceptable, text: invalid)
+    render(status: :not_acceptable, plain: invalid)
   end
 
   # GET /levels/:id/embed_level

--- a/dashboard/app/controllers/script_levels_controller.rb
+++ b/dashboard/app/controllers/script_levels_controller.rb
@@ -373,7 +373,7 @@ class ScriptLevelsController < ApplicationController
     return if params[:user_id].blank?
 
     if current_user.nil?
-      render text: 'Teacher view is not available for this puzzle', layout: true
+      render plain: 'Teacher view is not available for this puzzle', layout: true
       return
     end
 

--- a/dashboard/app/controllers/videos_controller.rb
+++ b/dashboard/app/controllers/videos_controller.rb
@@ -20,7 +20,7 @@ class VideosController < ApplicationController
         require 'cdo/video/youtube'
         Youtube.process @video.key
       rescue Exception => e
-        render(layout: false, text: "Error processing video: #{e}. Contact an engineer for support.", status: 500) && return
+        render(layout: false, plain: "Error processing video: #{e}. Contact an engineer for support.", status: 500) && return
       end
     end
     video_info = @video.summarize(params.key?(:autoplay))

--- a/dashboard/config/initializers/backtrace_silencers.rb
+++ b/dashboard/config/initializers/backtrace_silencers.rb
@@ -10,7 +10,6 @@
 silenced = [
   /ActionController::TestCase HTTP request methods/,
   /ActionDispatch::IntegrationTest HTTP request methods/,
-  /`render :text` is deprecated/,
   /alias_method_chain is deprecated/
 ]
 


### PR DESCRIPTION
Replace with new `:plain` option.

Also stop silencing the deprecation warning.

See https://github.com/rails/rails/commit/79a5ea9eadb4d43b62afacedc0706cbe88c54496

## Testing story

Relying on existing unit tests; I'd also consider this a generally low-risk change, since this is simply applying the expected and recommended change.

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
