### PR TITLE
[Google Blockly] Fix block highlighting

### DIFF
--- a/apps/src/blocklyAddons/blockSvgUnused.js
+++ b/apps/src/blocklyAddons/blockSvgUnused.js
@@ -62,9 +62,7 @@ export default class BlockSvgUnused {
         fill: '#c6cacd',
         rx: 15,
         ry: 15,
-        'clip-path': `url(#frameClip${this.block_.id
-          .replace(/\)/g, '\\)')
-          .replace(/\(/g, '\\(')})`
+        'clip-path': `url(#frameClip${this.block_.id})`
       },
       this.frameGroup_
     );

--- a/apps/src/blocklyAddons/cdoBlockSvg.js
+++ b/apps/src/blocklyAddons/cdoBlockSvg.js
@@ -3,7 +3,7 @@ import BlockSvgUnused from './blockSvgUnused';
 
 export default class BlockSvg extends GoogleBlockly.BlockSvg {
   constructor(workspace, prototypeName, opt_id) {
-    super(workspace, prototypeName, opt_id);
+    super(workspace, prototypeName, ++Blockly.uidCounter_);
     this.canDisconnectFromParent_ = true;
   }
 

--- a/apps/src/blocklyAddons/cdoBlockSvg.js
+++ b/apps/src/blocklyAddons/cdoBlockSvg.js
@@ -3,7 +3,7 @@ import BlockSvgUnused from './blockSvgUnused';
 
 export default class BlockSvg extends GoogleBlockly.BlockSvg {
   constructor(workspace, prototypeName, opt_id) {
-    super(workspace, prototypeName, ++Blockly.uidCounter_);
+    super(workspace, prototypeName, ++Blockly.uidCounter_); // Use counter instead of randomly generated IDs
     this.canDisconnectFromParent_ = true;
   }
 

--- a/apps/src/blocklyAddons/cdoPathObject.js
+++ b/apps/src/blocklyAddons/cdoPathObject.js
@@ -6,4 +6,10 @@ export default class CdoPathObject extends GoogleBlockly.geras.PathObject {
   updateDisabled_(disabled) {
     this.setClass_('blocklyDisabled', disabled);
   }
+
+  // The built-in function adds a light filter over the whole block. We want to match our old
+  // behavior where highlighting the block adds the same yellow outline as selecting.
+  updateHighlighted(highlighted) {
+    this.setClass_('blocklySelected', highlighted);
+  }
 }

--- a/apps/src/sites/studio/pages/googleBlocklyWrapper.js
+++ b/apps/src/sites/studio/pages/googleBlocklyWrapper.js
@@ -22,6 +22,12 @@ const BlocklyWrapper = function(blocklyInstance) {
   this.version = BlocklyVersion.GOOGLE;
   this.blockly_ = blocklyInstance;
 
+  /**
+   * If an id is not specified, the Block constructor will randomly generate a 20-character
+   * uid string. In UI tests, we want to be able to reference blocks by their id, which won't
+   * work if the ids are randomly generated. To get around this problem, we can just use a
+   * global counter as the block ids.
+   */
   this.uidCounter_ = 0;
 
   this.wrapReadOnlyProperty = function(propertyName) {

--- a/apps/src/sites/studio/pages/googleBlocklyWrapper.js
+++ b/apps/src/sites/studio/pages/googleBlocklyWrapper.js
@@ -21,6 +21,9 @@ import CdoWorkspaceSvg from '@cdo/apps/blocklyAddons/cdoWorkspaceSvg';
 const BlocklyWrapper = function(blocklyInstance) {
   this.version = BlocklyVersion.GOOGLE;
   this.blockly_ = blocklyInstance;
+
+  this.uidCounter_ = 0;
+
   this.wrapReadOnlyProperty = function(propertyName) {
     Object.defineProperty(this, propertyName, {
       get: function() {

--- a/apps/src/sites/studio/pages/googleBlocklyWrapper.js
+++ b/apps/src/sites/studio/pages/googleBlocklyWrapper.js
@@ -23,10 +23,10 @@ const BlocklyWrapper = function(blocklyInstance) {
   this.blockly_ = blocklyInstance;
 
   /**
-   * If an id is not specified, the Block constructor will randomly generate a 20-character
-   * uid string. In UI tests, we want to be able to reference blocks by their id, which won't
-   * work if the ids are randomly generated. To get around this problem, we can just use a
-   * global counter as the block ids.
+   * Google Blockly sets Block ids to randomly generated 20-character strings.
+   * CDO Blockly set Block ids using a global counter. There are several places in our code and
+   * tests that assume Block ids will be numbers, so we want to re-implement the global counter
+   * and pass the id in the Block constructor, rather than leaving it to Google Blockly.
    */
   this.uidCounter_ = 0;
 


### PR DESCRIPTION
There was a regression where the currently-executing block was no longer being highlighted.
The reason was that Google Blockly block IDs are 20-character UIDs, not numbers, so this wasn't working https://github.com/code-dot-org/code-dot-org/blob/staging/apps/src/StudioApp.js#L1622

For the work I was doing on UI tests, I wanted to change the IDs to be numbers anyways, but when I did so, I noticed that the block highlight now looks like this:
![Oct-28-2020 12-49-30](https://user-images.githubusercontent.com/8787187/97488877-12325800-191c-11eb-8190-4264d91fd27a.gif)

My assumption is that we don't want this, so I updated the corresponding path_object code to match our existing highlight behavior:
![Oct-28-2020 12-51-04](https://user-images.githubusercontent.com/8787187/97489038-4574e700-191c-11eb-8284-ed91821d0c97.gif)