### PR TITLE
set progression on script level when activity section name is present

### DIFF
--- a/dashboard/app/models/activity_section.rb
+++ b/dashboard/app/models/activity_section.rb
@@ -78,6 +78,7 @@ class ActivitySection < ApplicationRecord
         assessment: !!sl_data['assessment'] || sl.anonymous?,
         bonus: !!sl_data['bonus'],
         challenge: !!sl_data['challenge'],
+        progression: name.present? && name
       )
       # TODO(dave): check and update script level variants
       sl.update_levels(sl_data['levels'] || [])

--- a/dashboard/test/controllers/lessons_controller_test.rb
+++ b/dashboard/test/controllers/lessons_controller_test.rb
@@ -497,6 +497,7 @@ class LessonsControllerTest < ActionController::TestCase
     script_level = section.script_levels.first
     assert script_level.assessment
     refute script_level.bonus
+    assert_equal 'section name', script_level.progression
     assert_equal ['level-to-add'], script_level.levels.map(&:name)
   end
 


### PR DESCRIPTION
Finishes [PLAT-462].

## Testing story

Added unit test showing that progression set based on activity section name. Also verified the following scenarios manually:

| lesson edit | lesson overview | script overview |
|---|---|---|
| ![Screen Shot 2020-10-28 at 1 00 28 PM](https://user-images.githubusercontent.com/8001765/97490058-95a07900-191d-11eb-8a94-b34e2223350c.png) | ![Screen Shot 2020-10-28 at 1 00 58 PM](https://user-images.githubusercontent.com/8001765/97490300-e3b57c80-191d-11eb-8d5d-1a245c349d78.png)  | ![Screen Shot 2020-10-28 at 1 01 27 PM](https://user-images.githubusercontent.com/8001765/97490323-e912c700-191d-11eb-8861-e0d1108d9012.png)  |
| ![Screen Shot 2020-10-28 at 1 23 05 PM](https://user-images.githubusercontent.com/8001765/97492682-20cf3e00-1921-11eb-84b1-e33bd6491cbb.png) | ![Screen Shot 2020-10-28 at 1 25 10 PM](https://user-images.githubusercontent.com/8001765/97492710-2c226980-1921-11eb-9188-fe44a66e53a9.png) | ![Screen Shot 2020-10-28 at 1 25 23 PM](https://user-images.githubusercontent.com/8001765/97492744-35133b00-1921-11eb-9689-458d0236eeea.png) |

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked


[PLAT-462]: https://codedotorg.atlassian.net/browse/PLAT-462