### PR TITLE
Teacher Applications: Enable Scholarship Dropdown

### DIFF
--- a/apps/src/code-studio/pd/components/scholarshipDropdown.jsx
+++ b/apps/src/code-studio/pd/components/scholarshipDropdown.jsx
@@ -21,7 +21,7 @@ export class ScholarshipDropdown extends React.Component {
           onChange={this.props.onChange}
           options={this.props.dropdownOptions}
           // Only workshop admins can change scholarship status now
-          disabled={this.props.disabled || !this.props.isWorkshopAdmin}
+          disabled={this.props.disabled}
         />
       </FormGroup>
     );

--- a/apps/src/code-studio/pd/components/scholarshipDropdown.jsx
+++ b/apps/src/code-studio/pd/components/scholarshipDropdown.jsx
@@ -20,7 +20,6 @@ export class ScholarshipDropdown extends React.Component {
           value={this.props.scholarshipStatus}
           onChange={this.props.onChange}
           options={this.props.dropdownOptions}
-          // Only workshop admins can change scholarship status now
           disabled={this.props.disabled}
         />
       </FormGroup>


### PR DESCRIPTION
We disabled the scholarship dropdown for everyone except workshop admins back in [September](https://github.com/code-dot-org/code-dot-org/pull/36489). Now that we are on the new teacher application season, re-enable the dropdown for all valid users (such as regional partner program managers). I kept the isWorkshopAdmin prop to the scholarship dropdown component so it will be quick to lock it down again next year.

## Testing story
Tested locally.

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
