### PR TITLE
[Google Blockly] Automatic Block Layout instead of storing absolute position in Block XML

### DIFF
--- a/apps/src/blocklyAddons/cdoBlockSvg.js
+++ b/apps/src/blocklyAddons/cdoBlockSvg.js
@@ -14,6 +14,12 @@ export default class BlockSvg extends GoogleBlockly.BlockSvg {
     this.unusedSvg_.render(this.svgGroup_);
   }
 
+  isVisible() {
+    // TODO (eventually), but all Flappy blocks are visible, so this won't be a problem
+    // until we convert other labs
+    return true;
+  }
+
   setCanDisconnectFromParent(canDisconnect) {
     this.canDisconnectFromParent_ = canDisconnect;
   }

--- a/apps/src/blocklyAddons/cdoXml.js
+++ b/apps/src/blocklyAddons/cdoXml.js
@@ -43,4 +43,7 @@ export default function initializeBlocklyXml(blocklyWrapper) {
     return blocklyWrapper.Xml.domToWorkspace(xml, blockSpace);
   };
   blocklyWrapper.Xml.blockSpaceToDom = blocklyWrapper.Xml.workspaceToDom;
+
+  // We don't want to save absolute position in the block XML
+  blocklyWrapper.Xml.blockToDomWithXY = blocklyWrapper.Xml.blockToDom;
 }

--- a/apps/src/blocklyAddons/cdoXml.js
+++ b/apps/src/blocklyAddons/cdoXml.js
@@ -46,12 +46,11 @@ export default function initializeBlocklyXml(blocklyWrapper) {
     const verticalSpaceBetweenBlocks = 10;
 
     // Block positioning rules:
-    //  if the block has been given an absolute X coordinate, use it
-    //  (taking into account that RTL languages position from the left)
-    //  if the block has been given an absolute Y coordinate, use it
-    //  otherwise, the block "flows" with the other blocks from top to
-    //  bottom. Any block positioned absolutely with Y does not influence
-    //  the flow of the other blocks.
+    // If the block XML has X/Y coordinates, use them to set the block
+    // position. Note that RTL languages position from the left.
+    // Otherwise, position the block in line with other blocks,
+    // flowing from top to bottom. Blocks with absolute Y positions
+    // do not influence the placement of other blocks.
     let cursor = {
       x: blockSpace.RTL ? width - padding : padding,
       y: padding

--- a/apps/src/blocklyAddons/cdoXml.js
+++ b/apps/src/blocklyAddons/cdoXml.js
@@ -1,0 +1,46 @@
+export default function initializeBlocklyXml(blocklyWrapper) {
+  // Aliasing Google's blockToDom() so that we can override it, but still be able
+  // to call Google's blockToDom() in the override function.
+  blocklyWrapper.Xml.originalBlockToDom = blocklyWrapper.Xml.blockToDom;
+  blocklyWrapper.Xml.blockToDom = function(block, ignoreChildBlocks) {
+    const blockXml = blocklyWrapper.Xml.originalBlockToDom(block);
+    if (!block.canDisconnectFromParent_) {
+      blockXml.setAttribute('can_disconnect_from_parent', false);
+    }
+    if (ignoreChildBlocks) {
+      Blockly.Xml.deleteNext(blockXml);
+    }
+    return blockXml;
+  };
+
+  // Aliasing Google's domToBlock() so that we can override it, but still be able
+  // to call Google's domToBlock() in the override function.
+  blocklyWrapper.Xml.originalDomToBlock = blocklyWrapper.Xml.domToBlock;
+  blocklyWrapper.Xml.domToBlock = function(xmlBlock, workspace) {
+    const block = blocklyWrapper.Xml.originalDomToBlock(xmlBlock, workspace);
+    const can_disconnect_from_parent = xmlBlock.getAttribute(
+      'can_disconnect_from_parent'
+    );
+    if (can_disconnect_from_parent) {
+      block.canDisconnectFromParent_ = can_disconnect_from_parent === 'true';
+    }
+    return block;
+  };
+
+  blocklyWrapper.Xml.fieldToDom_ = function(field) {
+    if (field.isSerializable()) {
+      // Titles were renamed to fields in 2013, but CDO Blockly and
+      // all existing student code uses titles, so to keep everything
+      // consistent, we should continue using titles here.
+      var container = Blockly.utils.xml.createElement('title');
+      container.setAttribute('name', field.name || '');
+      return field.toXml(container);
+    }
+    return null;
+  };
+  blocklyWrapper.Xml.domToBlockSpace = function(blockSpace, xml) {
+    // Switch argument order
+    return blocklyWrapper.Xml.domToWorkspace(xml, blockSpace);
+  };
+  blocklyWrapper.Xml.blockSpaceToDom = blocklyWrapper.Xml.workspaceToDom;
+}

--- a/apps/src/sites/studio/pages/googleBlocklyWrapper.js
+++ b/apps/src/sites/studio/pages/googleBlocklyWrapper.js
@@ -9,6 +9,7 @@ import CdoScrollbar from '@cdo/apps/blocklyAddons/cdoScrollbar';
 import CdoTheme from '@cdo/apps/blocklyAddons/cdoTheme';
 import CdoTrashcan from '@cdo/apps/blocklyAddons/cdoTrashcan';
 import CdoWorkspaceSvg from '@cdo/apps/blocklyAddons/cdoWorkspaceSvg';
+import initializeBlocklyXml from '@cdo/apps/blocklyAddons/cdoXml';
 
 /**
  * Wrapper class for https://github.com/google/blockly
@@ -246,20 +247,6 @@ function initializeBlocklyWrapper(blocklyInstance) {
     return blocklyWrapper.blockly_.inject(container, options);
   };
 
-  // Aliasing Google's blockToDom() so that we can override it, but still be able
-  // to call Google's blockToDom() in the override function.
-  blocklyWrapper.Xml.originalBlockToDom = blocklyWrapper.Xml.blockToDom;
-  blocklyWrapper.Xml.blockToDom = function(block, ignoreChildBlocks) {
-    const blockXml = blocklyWrapper.Xml.originalBlockToDom(block);
-    if (!block.canDisconnectFromParent_) {
-      blockXml.setAttribute('can_disconnect_from_parent', false);
-    }
-    if (ignoreChildBlocks) {
-      Blockly.Xml.deleteNext(blockXml);
-    }
-    return blockXml;
-  };
-
   // Used by StudioApp to tell Blockly to resize for Mobile Safari.
   blocklyWrapper.fireUiEvent = function(element, eventName, opt_properties) {
     if (eventName === 'resize') {
@@ -267,37 +254,7 @@ function initializeBlocklyWrapper(blocklyInstance) {
     }
   };
 
-  // Aliasing Google's domToBlock() so that we can override it, but still be able
-  // to call Google's domToBlock() in the override function.
-  blocklyWrapper.Xml.originalDomToBlock = blocklyWrapper.Xml.domToBlock;
-  blocklyWrapper.Xml.domToBlock = function(xmlBlock, workspace) {
-    const block = blocklyWrapper.Xml.originalDomToBlock(xmlBlock, workspace);
-    const can_disconnect_from_parent = xmlBlock.getAttribute(
-      'can_disconnect_from_parent'
-    );
-    if (can_disconnect_from_parent) {
-      block.canDisconnectFromParent_ = can_disconnect_from_parent === 'true';
-    }
-    return block;
-  };
-
-  blocklyWrapper.Xml.fieldToDom_ = function(field) {
-    if (field.isSerializable()) {
-      // Titles were renamed to fields in 2013, but CDO Blockly and
-      // all existing student code uses titles, so to keep everything
-      // consistent, we should continue using titles here.
-      var container = Blockly.utils.xml.createElement('title');
-      container.setAttribute('name', field.name || '');
-      return field.toXml(container);
-    }
-    return null;
-  };
-
-  blocklyWrapper.Xml.domToBlockSpace = function(blockSpace, xml) {
-    // Switch argument order
-    return blocklyWrapper.Xml.domToWorkspace(xml, blockSpace);
-  };
-  blocklyWrapper.Xml.blockSpaceToDom = blocklyWrapper.Xml.workspaceToDom;
+  initializeBlocklyXml(blocklyWrapper);
 
   return blocklyWrapper;
 }


### PR DESCRIPTION
1st commit just extract the XML overrides into their own file, so probably doesn't need to be reviewed carefully.

2nd commit makes it so we *don't* save blocks' X/Y position in the block XML. This is to match the current Blockly behavior, which automatically lays out the blocks instead of persisting user layout changes.

3rd commit implements this auto-layout functionality. Copied pretty much entirely from https://github.com/code-dot-org/blockly/blob/main/core/utils/xml.js#L244

Before:
position code like this:
![image](https://user-images.githubusercontent.com/8787187/97500285-8c6ad880-192c-11eb-8e69-d3f96cc66863.png)
then save and refresh the page:
![image](https://user-images.githubusercontent.com/8787187/97500304-95f44080-192c-11eb-9093-5e1d86286ee0.png)

After:
position code like this:
![image](https://user-images.githubusercontent.com/8787187/97500402-bcb27700-192c-11eb-86df-112aa5f3e026.png)
then save and refresh the page:
![image](https://user-images.githubusercontent.com/8787187/97500430-c89e3900-192c-11eb-97d8-7ad554e273df.png)
(This matches the CDO Blockly behavior)


Auto Layout:
Before:
![image](https://user-images.githubusercontent.com/8787187/97500536-026f3f80-192d-11eb-9d1c-f70d483e8d98.png)
After:
![image](https://user-images.githubusercontent.com/8787187/97500566-0ef39800-192d-11eb-906d-34b53e9f4baa.png)
(This matches the CDO Blockly behavior)
