### PR TITLE
Lesson numbering

### DIFF
--- a/apps/src/templates/lessonOverview/LessonOverview.jsx
+++ b/apps/src/templates/lessonOverview/LessonOverview.jsx
@@ -54,6 +54,8 @@ class LessonOverview extends Component {
           })
         ).isRequired
       }).isRequired,
+      position: PropTypes.string.isRequired,
+      lockable: PropTypes.bool.isRequired,
       displayName: PropTypes.string.isRequired,
       overview: PropTypes.string.isRequired,
       purpose: PropTypes.string.isRequired,
@@ -139,7 +141,12 @@ class LessonOverview extends Component {
             viewAs={viewAs}
           />
         )}
-        <h1>{lesson.displayName}</h1>
+        <h1>{lesson.lockable
+            ? lesson.displayName : i18n.lessonNumbered({
+                lessonNumber: lesson.position,
+                lessonName: lesson.displayName
+              })
+        }</h1>
 
         <div style={styles.frontPage}>
           <div style={styles.left}>

--- a/apps/src/templates/lessonOverview/LessonOverview.jsx
+++ b/apps/src/templates/lessonOverview/LessonOverview.jsx
@@ -141,12 +141,14 @@ class LessonOverview extends Component {
             viewAs={viewAs}
           />
         )}
-        <h1>{lesson.lockable
-            ? lesson.displayName : i18n.lessonNumbered({
+        <h1>
+          {lesson.lockable
+            ? lesson.displayName
+            : i18n.lessonNumbered({
                 lessonNumber: lesson.position,
                 lessonName: lesson.displayName
-              })
-        }</h1>
+              })}
+        </h1>
 
         <div style={styles.frontPage}>
           <div style={styles.left}>

--- a/apps/src/templates/lessonOverview/LessonOverview.jsx
+++ b/apps/src/templates/lessonOverview/LessonOverview.jsx
@@ -50,11 +50,13 @@ class LessonOverview extends Component {
         lessons: PropTypes.arrayOf(
           PropTypes.shape({
             displayName: PropTypes.string.isRequired,
-            link: PropTypes.string.isRequired
+            link: PropTypes.string.isRequired,
+            position: PropTypes.number.isRequired,
+            lockable: PropTypes.bool.isRequired
           })
         ).isRequired
       }).isRequired,
-      position: PropTypes.string.isRequired,
+      position: PropTypes.number.isRequired,
       lockable: PropTypes.bool.isRequired,
       displayName: PropTypes.string.isRequired,
       overview: PropTypes.string.isRequired,

--- a/apps/src/templates/lessonOverview/LessonOverview.jsx
+++ b/apps/src/templates/lessonOverview/LessonOverview.jsx
@@ -128,7 +128,9 @@ class LessonOverview extends Component {
             >
               {lesson.unit.lessons.map((l, index) => (
                 <a key={index} href={this.linkWithQueryParams(l.link)}>
-                  {`${index + 1} ${l.displayName}`}
+                  {l.lockable
+                    ? l.displayName
+                    : `${l.position} ${l.displayName}`}
                 </a>
               ))}
             </DropdownButton>

--- a/apps/test/unit/templates/lessonOverview/LessonOverviewTest.js
+++ b/apps/test/unit/templates/lessonOverview/LessonOverviewTest.js
@@ -21,15 +21,21 @@ describe('LessonOverview', () => {
           lessons: [
             {
               displayName: 'Lesson 1',
-              link: '/lessons/1'
+              link: '/lessons/1',
+              position: 1,
+              lockable: false
             },
             {
               displayName: 'Lesson 2',
-              link: '/lessons/2'
+              link: '/lessons/2',
+              position: 2,
+              lockable: false
             }
           ]
         },
-        displayName: 'Lesson Name',
+        position: 1,
+        lockable: false,
+        displayName: 'Lesson 1',
         overview: 'Lesson Overview',
         purpose: 'The purpose of the lesson is for people to learn',
         preparation: '- One',
@@ -70,7 +76,7 @@ describe('LessonOverview', () => {
     const dropdown = wrapper.find('DropdownButton');
     expect(dropdown.find('a').length).to.equal(2);
 
-    expect(wrapper.contains('Lesson Name'), 'Lesson Name').to.be.true;
+    expect(wrapper.contains('Lesson 1: Lesson 1'), 'Lesson Name').to.be.true;
 
     const safeMarkdowns = wrapper.find('SafeMarkdown');
     expect(safeMarkdowns.at(0).props().markdown).to.contain('Lesson Overview');

--- a/dashboard/app/controllers/lessons_controller.rb
+++ b/dashboard/app/controllers/lessons_controller.rb
@@ -24,6 +24,8 @@ class LessonsController < ApplicationController
         link: @lesson.script.link,
         lessons: @lesson.script.lessons.map {|lesson| {displayName: lesson.localized_name, link: lesson_path(id: lesson.id)}}
       },
+      position: @lesson.relative_position,
+      lockable: @lesson.lockable,
       displayName: @lesson.name,
       overview: @lesson.overview || '',
       announcements: @lesson.announcements,

--- a/dashboard/app/controllers/lessons_controller.rb
+++ b/dashboard/app/controllers/lessons_controller.rb
@@ -22,7 +22,7 @@ class LessonsController < ApplicationController
       unit: {
         displayName: @lesson.script.localized_title,
         link: @lesson.script.link,
-        lessons: @lesson.script.lessons.map {|lesson| {displayName: lesson.localized_name, link: lesson_path(id: lesson.id)}}
+        lessons: @lesson.script.lessons.map {|lesson| {displayName: lesson.localized_name, link: lesson_path(id: lesson.id), position: lesson.relative_position, lockable: lesson.lockable}}
       },
       position: @lesson.relative_position,
       lockable: @lesson.lockable,


### PR DESCRIPTION
Added Lesson number to the Teacher Facing Lesson Plan using the `relative_position` and not showing the lesson number for `lockable` lessons. There is a bug with updating the numbering of lockable lessons which is tracked [here](https://codedotorg.atlassian.net/browse/PLAT-470). I also updated the dropdown for navigating between lessons which was not numbering based on relative position and ignoring lockable lessons.

![Screen Shot 2020-10-28 at 8 52 11 PM](https://user-images.githubusercontent.com/208083/97512269-76c2d680-195f-11eb-9f77-a3aa2f4e412d.png)

## Links
- [jira](https://codedotorg.atlassian.net/browse/PLAT-468)

## Testing story

Updated the LessonOverviewTest

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked