### PR TITLE
allow moving script levels between activity sections

### DIFF
--- a/dashboard/app/models/activity_section.rb
+++ b/dashboard/app/models/activity_section.rb
@@ -90,9 +90,13 @@ class ActivitySection < ApplicationRecord
 
   def fetch_script_level(sl_data)
     if sl_data['id']
-      script_level = script_levels.find(sl_data['id'])
-      return script_level if script_level
-      raise ActiveRecord::RecordNotFound.new("ScriptLevel id #{sl_data['id']} not found in ActivitySection id #{id}")
+      script_level = ScriptLevel.find(sl_data['id'])
+      unless script_level.activity_section.lesson == lesson
+        # add a safeguard to make sure we never take a script level from another
+        # lesson. this case should not be possible to hit using our editing UI.
+        raise "cannot move script level #{script_level.id} between lessons"
+      end
+      return script_level
     end
 
     script_levels.create(

--- a/dashboard/test/controllers/lessons_controller_test.rb
+++ b/dashboard/test/controllers/lessons_controller_test.rb
@@ -587,6 +587,62 @@ class LessonsControllerTest < ActionController::TestCase
     assert script_level.assessment
   end
 
+  test 'move script level between activity sections' do
+    sign_in @levelbuilder
+
+    # create the following structure:
+    # activity 1
+    #   section 1
+    #     sl 1
+    # activity 2
+    #   section 2
+    #     sl 2
+    [1, 2].each do |i|
+      activity = @lesson.lesson_activities.create(
+        name: 'activity name',
+        position: i,
+        seeding_key: "activity-key-#{i}"
+      )
+      section = activity.activity_sections.create(
+        name: 'section name',
+        position: 1,
+        seeding_key: "section-key-#{i}"
+      )
+      section.script_levels.create(
+        position: i,
+        activity_section_position: 1,
+        lesson: @lesson,
+        script: @lesson.script,
+        levels: [create(:level, name: "my-level-#{i}")]
+      )
+    end
+
+    # update the structure to:
+    # activity 1
+    #   section 1
+    #     sl 1
+    #     sl 2
+    # activity 2
+    #   section 2
+    activities_data = @lesson.lesson_activities.map(&:summarize_for_edit)
+    assert_equal 2, activities_data.count
+    script_level_data = activities_data.last[:activitySections].first[:scriptLevels].pop
+    script_level_data[:activitySectionPosition] = 2
+    activities_data.first[:activitySections].first[:scriptLevels].push(script_level_data)
+
+    @update_params['activities'] = activities_data.to_json
+
+    put :update, params: @update_params
+    assert_redirected_to "/lessons/#{@lesson.id}"
+
+    @lesson.reload
+    script_levels = @lesson.lesson_activities.first.activity_sections.first.script_levels
+    assert_equal 2, script_levels.count
+    assert_equal ['my-level-1', 'my-level-2'], script_levels.map(&:levels).map(&:first).map(&:name)
+    script_levels = @lesson.lesson_activities.last.activity_sections.first.script_levels
+    assert_equal 0, script_levels.count
+  end
+
   test 'remove script level via lesson update' do
     sign_in @levelbuilder
 


### PR DESCRIPTION
Finishes [PLAT-463]. The problem only repros with script levels which already existed prior to opening the lesson edit page. I missed this when implementing level movement in a previous PR because I was creating new levels each time I tested it, and those saved fine.

## before
![save-reordered-levels](https://user-images.githubusercontent.com/8001765/97506803-0903b400-1939-11eb-813c-36e39582a17c.gif)

## after 
![save-reordered-levels-success](https://user-images.githubusercontent.com/8001765/97506809-0b660e00-1939-11eb-9c8c-bbb41651a613.gif)

## Testing story

Manually verified that moving script levels around between activities and activity sections works. Added a new unit test, and verified that the test fails without the corresponding code change.

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked


[PLAT-416]: https://codedotorg.atlassian.net/browse/PLAT-416

[PLAT-463]: https://codedotorg.atlassian.net/browse/PLAT-463