### PR TITLE
Fix multiple immersive reader button bug

### DIFF
--- a/apps/src/templates/instructions/ImmersiveReaderButton.jsx
+++ b/apps/src/templates/instructions/ImmersiveReaderButton.jsx
@@ -12,7 +12,9 @@ class ImmersiveReaderButton extends Component {
 
   componentDidMount() {
     // Applies inline styling to the .immersive-reader-button elements
-    renderButtons();
+    renderButtons({
+      elements: [this.container]
+    });
   }
 
   render() {
@@ -21,6 +23,7 @@ class ImmersiveReaderButton extends Component {
     const locale = cookies.get('language_') || 'en-US';
     return (
       <div
+        ref={el => (this.container = el)}
         className={'immersive-reader-button'}
         data-button-style={'icon'}
         data-locale={locale}

--- a/apps/src/templates/instructions/ImmersiveReaderButton.jsx
+++ b/apps/src/templates/instructions/ImmersiveReaderButton.jsx
@@ -11,16 +11,23 @@ class ImmersiveReaderButton extends Component {
   };
 
   componentDidMount() {
-    // Applies inline styling to the .immersive-reader-button elements
-    renderButtons({
-      elements: [this.container]
-    });
+    if (this.shouldRender()) {
+      // Applies inline styling to the .immersive-reader-button elements
+      renderButtons({
+        elements: [this.container]
+      });
+    }
   }
 
   render() {
     const {title, text} = this.props;
     // Get the current language from the language cookie.
     const locale = cookies.get('language_') || 'en-US';
+
+    if (!this.shouldRender()) {
+      return null;
+    }
+
     return (
       <div
         ref={el => (this.container = el)}
@@ -32,6 +39,12 @@ class ImmersiveReaderButton extends Component {
         }}
       />
     );
+  }
+
+  // Determines if this button should be rendered.
+  shouldRender() {
+    // If there is no text, then skip rendering it.
+    return !!this.props.text;
   }
 }
 


### PR DESCRIPTION
*bug* - Opening a pop-up caused the ImmersiveReaderButton duplicates itself.
*cause* - When the pop-up is rendered, it has an ImmersiveReaderButton and tries to add the button icon to all ImmersiveReaderButtons on the page.
*fix* - Tell `renderButtons` to only add the ImmersiveReaderButton icon to the button currently being rendered.

* `renderButtons` now specifies which button is being rendered.
* `render` now only renders an ImmersiveReaderButton if there is actual text to be read.

## Links
- [Immersive Reader renderButtons API](https://docs.microsoft.com/en-us/azure/cognitive-services/immersive-reader/reference#renderbuttons)
- [Slack bug report](https://codedotorg.slack.com/archives/CA3KCSGTD/p1603901371305100)
- [Jira](https://codedotorg.atlassian.net/browse/FND-1338)
## Testing story
* Manually tested on localhost

## Screenshots
### Before
![2020-10-28 12-07-29 2020-10-28 12_08_51](https://user-images.githubusercontent.com/1372238/97505442-d5448080-1970-11eb-854f-1c21378b7378.gif)

### After
![immersive_reader_button_fix](https://user-images.githubusercontent.com/1372238/97505761-5f8ce480-1971-11eb-90a5-41d4917aee74.gif)

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
