### PR TITLE
Fix friendly_name to include format param

### DIFF
--- a/dashboard/app/controllers/level_starter_assets_controller.rb
+++ b/dashboard/app/controllers/level_starter_assets_controller.rb
@@ -21,7 +21,7 @@ class LevelStarterAssetsController < ApplicationController
   # GET /level_starter_assets/:level_name/:filename
   # Returns requested file body as an IO stream.
   def file
-    friendly_name = params[:filename]
+    friendly_name = "#{params[:filename]}.#{params[:format]}"
     uuid_name = @level.starter_assets[friendly_name]
     file_obj = get_object(uuid_name)
     content_type = file_content_type(File.extname(uuid_name))

--- a/dashboard/config/routes.rb
+++ b/dashboard/config/routes.rb
@@ -263,7 +263,7 @@ Dashboard::Application.routes.draw do
 
   resources :level_starter_assets, only: [:show], param: 'level_name', constraints: {level_name: /[^\/]+/} do
     member do
-      get '/:filename', to: 'level_starter_assets#file'
+      get '/:filename', to: 'level_starter_assets#file', format: true
       post '', to: 'level_starter_assets#upload'
       delete '/:filename', to: 'level_starter_assets#destroy'
     end

--- a/dashboard/test/controllers/level_starter_assets_controller_test.rb
+++ b/dashboard/test/controllers/level_starter_assets_controller_test.rb
@@ -64,7 +64,7 @@ class LevelStarterAssetsControllerTest < ActionController::TestCase
     }
     level = create(:applab, starter_assets: level_starter_assets)
 
-    get :file, params: {level_name: level.name, filename: 'ty.png'}
+    get :file, params: {level_name: level.name, filename: 'ty', format: 'png'}
 
     assert_equal 'hello, world!', response.body
     assert_equal 'image/png', response.headers['Content-Type']


### PR DESCRIPTION
Fixes `GET /level_starter_assets/:level_name/:filename`, which was failing because the format (in this case, the file extension) was missing, which meant we could never find a matching filename in a level's starter_assets.

Example of what was happening:
```ruby
@level.starter_assets
=> {"starfish.png"=>"3826dbeb-0ffe-4af4-8fec-8799f17c20d4.png"}
params[:filename]
=> "starfish"

# BROKEN
friendly_name = params[:filename]
# friendly_name is always "starfish" and doesn't match any of the level's starter_assets

# FIXED
friendly_name = "#{params[:filename]}.#{params[:format]}"
# now, friendly_name is "starfish.png" which is what we expect
```

Also added `format: true` to the request route to guarantee that the format is always included in the request (otherwise the route won't match and the request will 404).

## Links

<!--
  Any relevant links to external resources; ie, specification documents, jira
  items, related PRs, honeybadger errors, etc
-->

- [Reported in Slack from Hannah](https://codedotorg.slack.com/archives/C1B3PNDL7/p1603846508232200)

## Testing story

<!--
  Does your change include appropriate tests?

  If so, please describe how the tests included in this PR are sufficient

  If not, please explain why this change does not need to be tested.
-->

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
