### PR TITLE
Foorm Editor: Make only available on levelbuilder or test

### DIFF
--- a/dashboard/app/controllers/foorm_editor_controller.rb
+++ b/dashboard/app/controllers/foorm_editor_controller.rb
@@ -1,3 +1,4 @@
+# Foorm Editor is only available on levelbuilder or test, for those with levelbuilder permissions.
 class FoormEditorController < ApplicationController
   before_action :require_levelbuilder_mode_or_test_env
   before_action :authenticate_user!

--- a/dashboard/app/controllers/foorm_editor_controller.rb
+++ b/dashboard/app/controllers/foorm_editor_controller.rb
@@ -2,11 +2,10 @@
 class FoormEditorController < ApplicationController
   before_action :require_levelbuilder_mode_or_test_env
   before_action :authenticate_user!
+  authorize_resource class: false
 
   # GET '/foorm/editor/'
   def index
-    return render_404 unless current_user && current_user.levelbuilder?
-
     formatted_names_and_versions = Foorm::Form.all.map {|form| {name: form.name, version: form.version}}
 
     @script_data = {

--- a/dashboard/app/controllers/foorm_editor_controller.rb
+++ b/dashboard/app/controllers/foorm_editor_controller.rb
@@ -1,8 +1,10 @@
 class FoormEditorController < ApplicationController
+  before_action :require_levelbuilder_mode_or_test_env
+  before_action :authenticate_user!
+
   # GET '/foorm/editor/'
   def index
-    # only show for admins on non-production
-    return render_404 if Rails.env.production? || !current_user.admin?
+    return render_404 unless current_user && current_user.levelbuilder?
 
     formatted_names_and_versions = Foorm::Form.all.map {|form| {name: form.name, version: form.version}}
 

--- a/dashboard/app/models/ability.rb
+++ b/dashboard/app/models/ability.rb
@@ -49,7 +49,8 @@ class Ability
       Pd::InternationalOptIn,
       :maker_discount,
       :edit_manifest,
-      :update_manifest
+      :update_manifest,
+      :foorm_editor
     ]
     cannot :index, Level
 
@@ -233,6 +234,7 @@ class Ability
         Script,
         ScriptLevel,
         Video,
+        :foorm_editor
       ]
 
       # Only custom levels are editable.

--- a/dashboard/app/views/home/_levelbuilder.html.haml
+++ b/dashboard/app/views/home/_levelbuilder.html.haml
@@ -9,3 +9,4 @@
     %li= link_to 'Shared Functions', shared_blockly_functions_path
     %li= link_to 'Helper Libraries', libraries_path
     %li= link_to 'Gallery', 'projects/public'
+    %li= link_to 'Foorm Editor', 'foorm/editor'

--- a/dashboard/app/views/home/_levelbuilder.html.haml
+++ b/dashboard/app/views/home/_levelbuilder.html.haml
@@ -9,4 +9,4 @@
     %li= link_to 'Shared Functions', shared_blockly_functions_path
     %li= link_to 'Helper Libraries', libraries_path
     %li= link_to 'Gallery', 'projects/public'
-    %li= link_to 'Foorm Editor', 'foorm/editor'
+    %li= link_to 'Foorm Surveys (preview)', 'foorm/editor'

--- a/dashboard/test/controllers/foorm_editor_controller_test.rb
+++ b/dashboard/test/controllers/foorm_editor_controller_test.rb
@@ -1,0 +1,7 @@
+require 'test_helper'
+
+class FoormEditorControllerTest < ActionController::TestCase
+  test_redirect_to_sign_in_for :index
+  test_user_gets_response_for :index, user: :student, response: :forbidden
+  test_user_gets_response_for :index, user: :levelbuilder, response: :success
+end


### PR DESCRIPTION
We are moving the Foorm Editor to levelbuilder in order to allow saving of edits by survey editors. The first step of this is to change the foorm editor page to be only available on levelbuilder or test mode, to those with levelbuilder permissions. I also added a link to the levelbuilder panel on the homepage to make accessing the editor easier. The link currently has the text `Foorm Surveys (preview)` to indicate this is still in progress.


## Links

- [spec](https://docs.google.com/document/d/1jnkpC_lCpnfFYSl_Hk_RPjdspyGYAspwy44NCUZpvlI/edit#)
- [jira](https://codedotorg.atlassian.net/browse/PLC-1040)

## Testing story
Tested locally that when my local instance is in levelbuilder mode I can see the page (as a levelbuilder), otherwise it gives an authorization error.

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
