### PR TITLE
Revert flappy with google blockly

### DIFF
--- a/dashboard/app/helpers/levels_helper.rb
+++ b/dashboard/app/helpers/levels_helper.rb
@@ -311,7 +311,7 @@ module LevelsHelper
     use_blockly = !use_droplet && !use_netsim && !use_weblab
     use_p5 = @level.is_a?(Gamelab)
     hide_source = app_options[:hideSource]
-    use_google_blockly = @level.is_a?(Flappy) || view_options[:useGoogleBlockly]
+    use_google_blockly = view_options[:useGoogleBlockly]
     render partial: 'levels/apps_dependencies',
       locals: {
         app: app_options[:app],

--- a/dashboard/test/ui/features/star_labs/blocklayout.feature
+++ b/dashboard/test/ui/features/star_labs/blocklayout.feature
@@ -8,12 +8,12 @@ Background:
 Scenario: Auto-placing malformed start blocks
   When I've initialized the workspace with an auto-positioned flappy puzzle with extra newlines
   Then block "18" is near offset "16, 16"
-  And block "21" is near offset "16, 114"
+  And block "21" is near offset "16, 107"
 
 Scenario: Auto-placing blocks
   When I've initialized the workspace with an auto-positioned flappy puzzle
   Then block "18" is near offset "16, 16"
-  And block "21" is near offset "16, 114"
+  And block "21" is near offset "16, 107"
 
 Scenario: Auto-placing blocks with XML positioning
   Given I am on "http://studio.code.org/s/allthethings/stage/5/puzzle/4?noautoplay=true"

--- a/dashboard/test/ui/features/star_labs/dropdown.feature
+++ b/dashboard/test/ui/features/star_labs/dropdown.feature
@@ -7,9 +7,9 @@ Scenario: Drag a dropdown and select a different option.
   When I rotate to landscape
   And I wait for the page to fully load
   And I drag the play sound block to offset "200, 100"
-  And I press dropdown number 2
-  Then the Google Blockly dropdown is visible
+  And I press dropdown number 6
+  Then the dropdown is visible
   Then I select item 9 from the dropdown
   And I wait for 1 seconds
-  Then the Google Blockly dropdown is hidden
-  And the dropdown field has text "crash ▾"
+  Then the dropdown is hidden
+  And the dropdown field has text "crash ▼"

--- a/dashboard/test/ui/features/star_labs/flappydrag.feature
+++ b/dashboard/test/ui/features/star_labs/flappydrag.feature
@@ -8,4 +8,4 @@ Scenario: Connect two blocks from toolbox
   And I drag block "1" to block "3"
   And I drag block "1" to block "4"
   And I wait for 1 seconds
-  Then block "6" is child of block "4"
+  Then block "5" is child of block "4"


### PR DESCRIPTION
https://github.com/code-dot-org/code-dot-org/pull/37459 made Google Blockly the default for all Flappy levels.
Prepping this PR now just in case we need it...