### PR TITLE
[Google Blockly] Fix IE

### DIFF
--- a/apps/src/blocklyAddons/cdoTrashcan.js
+++ b/apps/src/blocklyAddons/cdoTrashcan.js
@@ -7,9 +7,13 @@ export default class CdoTrashcan extends GoogleBlockly.Trashcan {
   createDom() {
     super.createDom();
 
-    // Use our trashcan png instead of Google's
-    this.svgGroup_.childNodes.forEach(node => {
-      if (node.nodeName === 'image') {
+    /**
+     * Use our trashcan png instead of Google's
+     * NodeList.forEach() is not supported on IE. Use Array.prototype.forEach.call() as a workaround.
+     * https://developer.mozilla.org/en-US/docs/Web/API/NodeList/forEach
+     */
+    Array.prototype.forEach.call(this.svgGroup_.childNodes, function(node) {
+      if (node.name === 'image') {
         node.setAttributeNS(
           Blockly.utils.dom.XLINK_NS,
           'xlink:href',

--- a/apps/src/blocklyAddons/cdoWorkspaceSvg.js
+++ b/apps/src/blocklyAddons/cdoWorkspaceSvg.js
@@ -40,12 +40,27 @@ export default class WorkspaceSvg extends GoogleBlockly.WorkspaceSvg {
   // Use visibility:hidden not display:none to hide the trashcan so that it still takes up space, which is important
   // for how the lid opening works.
   hideTrashcan() {
-    document
-      .querySelectorAll('.blocklyFlyout .blocklyWorkspace')
-      .forEach(x => (x.style.visibility = 'visible'));
-    document
-      .querySelectorAll('.blocklyTrash')
-      .forEach(x => (x.style.visibility = 'hidden'));
+    /**
+     * NodeList.forEach() is not supported on IE. Use Array.prototype.forEach.call() as a workaround.
+     * https://developer.mozilla.org/en-US/docs/Web/API/NodeList/forEach
+     */
+    Array.prototype.forEach.call(
+      document.querySelectorAll('.blocklyFlyout .blocklyWorkspace'),
+      function(x) {
+        x.style.visibility = 'visible';
+      }
+    );
+
+    /**
+     * NodeList.forEach() is not supported on IE. Use Array.prototype.forEach.call() as a workaround.
+     * https://developer.mozilla.org/en-US/docs/Web/API/NodeList/forEach
+     */
+    Array.prototype.forEach.call(
+      document.querySelectorAll('.blocklyTrash'),
+      function(x) {
+        x.style.visibility = 'hidden';
+      }
+    );
   }
 
   isReadOnly() {
@@ -53,12 +68,27 @@ export default class WorkspaceSvg extends GoogleBlockly.WorkspaceSvg {
   }
   setEnableToolbox() {} // TODO
   showTrashcan() {
-    document
-      .querySelectorAll('.blocklyFlyout .blocklyWorkspace')
-      .forEach(x => (x.style.visibility = 'hidden'));
-    document
-      .querySelectorAll('.blocklyTrash')
-      .forEach(x => (x.style.visibility = 'visible'));
+    /**
+     * NodeList.forEach() is not supported on IE. Use Array.prototype.forEach.call() as a workaround.
+     * https://developer.mozilla.org/en-US/docs/Web/API/NodeList/forEach
+     */
+    Array.prototype.forEach.call(
+      document.querySelectorAll('.blocklyFlyout .blocklyWorkspace'),
+      function(x) {
+        x.style.visibility = 'hidden';
+      }
+    );
+
+    /**
+     * NodeList.forEach() is not supported on IE. Use Array.prototype.forEach.call() as a workaround.
+     * https://developer.mozilla.org/en-US/docs/Web/API/NodeList/forEach
+     */
+    Array.prototype.forEach.call(
+      document.querySelectorAll('.blocklyTrash'),
+      function(x) {
+        x.style.visibility = 'visible';
+      }
+    );
   }
   traceOn() {} // TODO
 }

--- a/apps/src/blocklyAddons/cdoXml.js
+++ b/apps/src/blocklyAddons/cdoXml.js
@@ -83,7 +83,11 @@ export default function initializeBlocklyXml(blocklyWrapper) {
     //  invisible blocks don't cause the visible blocks to flow
     //  differently, which could leave gaps between the visible blocks.
     const blocks = [];
-    xml.childNodes.forEach(xmlChild => {
+    /**
+     * NodeList.forEach() is not supported on IE. Use Array.prototype.forEach.call() as a workaround.
+     * https://developer.mozilla.org/en-US/docs/Web/API/NodeList/forEach
+     */
+    Array.prototype.forEach.call(xml.childNodes, function(xmlChild) {
       const blockly_block = Blockly.Xml.domToBlock(xmlChild, blockSpace);
       const x = parseInt(xmlChild.getAttribute('x'), 10);
       const y = parseInt(xmlChild.getAttribute('y'), 10);


### PR DESCRIPTION
Don't call `forEach` on `NodeList`s, which is not supported in IE.
Instead use `Array.prototype.forEach.call()`
https://developer.mozilla.org/en-US/docs/Web/API/NodeList/forEach
Before:
![image](https://user-images.githubusercontent.com/8787187/97617588-2d17d180-19db-11eb-825e-ba06ad7cfbc8.png)

After:
![image](https://user-images.githubusercontent.com/8787187/97617527-1b362e80-19db-11eb-8403-78ff96aacda7.png)


Also made sure that you can actually drag/drop, run/reset, load progress etc, and it looks good on IE.

<!-- ### Background -->
<!-- ### Privacy -->
<!--
1.	Does the Project involve the collection, use or sharing of new Personal Data?

2.	Does the Project involve a new or changed use or sharing of existing Personal Data?
-->
<!-- ### Security -->
<!--
Link to Jira Task where sensitive security issues are discussed privately.
-->
<!-- ### Caching -->
<!-- ### Deployment strategy -->
<!-- ### Future work -->

## Links

<!--
  Any relevant links to external resources; ie, specification documents, jira
  items, related PRs, honeybadger errors, etc
-->

- [spec]()
- [jira]()

## Testing story

<!--
  Does your change include appropriate tests?

  If so, please describe how the tests included in this PR are sufficient

  If not, please explain why this change does not need to be tested.
-->

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
