### PR TITLE
AILab: levelbuilder editing & instructions at top

### DIFF
--- a/apps/src/ailab/Ailab.js
+++ b/apps/src/ailab/Ailab.js
@@ -51,6 +51,16 @@ Ailab.prototype.init = function(config) {
   config.wireframeShare = true;
   config.noHowItWorks = true;
 
+  // We don't want icons in instructions
+  config.skin.staticAvatar = null;
+  config.skin.smallStaticAvatar = null;
+  config.skin.failureAvatar = null;
+  config.skin.winAvatar = null;
+
+  // Provide a way for us to have top pane instructions disabled by default, but
+  // able to turn them on.
+  config.noInstructionsWhenCollapsed = true;
+
   config.pinWorkspaceToBottom = true;
 
   const onMount = () => {

--- a/apps/src/ailab/AilabView.jsx
+++ b/apps/src/ailab/AilabView.jsx
@@ -3,6 +3,7 @@ import PropTypes from 'prop-types';
 import React from 'react';
 import {connect} from 'react-redux';
 import StudioAppWrapper from '../templates/StudioAppWrapper';
+import InstructionsWithWorkspace from '../templates/instructions/InstructionsWithWorkspace';
 import CodeWorkspaceContainer from '../templates/CodeWorkspaceContainer';
 import _ from 'lodash';
 
@@ -155,22 +156,24 @@ class AilabView extends React.Component {
 
     return (
       <StudioAppWrapper>
-        <CodeWorkspaceContainer topMargin={0}>
-          <div
-            id="ailab-container"
-            style={{
-              ...styles.container,
-              width: Math.round(containerWidth),
-              height: Math.round(containerHeight)
-            }}
-            dir="ltr"
-          >
+        <InstructionsWithWorkspace>
+          <CodeWorkspaceContainer topMargin={0}>
             <div
-              id="root"
-              style={{...styles.containerReact, fontSize: baseFontSize}}
-            />
-          </div>
-        </CodeWorkspaceContainer>
+              id="ailab-container"
+              style={{
+                ...styles.container,
+                width: Math.round(containerWidth),
+                height: Math.round(containerHeight)
+              }}
+              dir="ltr"
+            >
+              <div
+                id="root"
+                style={{...styles.containerReact, fontSize: baseFontSize}}
+              />
+            </div>
+          </CodeWorkspaceContainer>
+        </InstructionsWithWorkspace>
       </StudioAppWrapper>
     );
   }

--- a/dashboard/app/views/levels/edit.html.haml
+++ b/dashboard/app/views/levels/edit.html.haml
@@ -41,6 +41,7 @@
     = render partial: 'levels/editors/gamelab', locals: {f: f} if @level.instance_of?(Gamelab)
     = render partial: 'levels/editors/spritelab', locals: {f: f} if @level.instance_of?(GamelabJr)
     = render partial: 'levels/editors/weblab', locals: {f: f} if @level.is_a? Weblab
+    = render partial: 'levels/editors/ailab', locals: {f: f} if @level.is_a? Ailab
     -# Widgets
     = render partial: 'levels/editors/frequency_analysis', locals: {f: f} if @level.is_a? FrequencyAnalysis
     = render partial: 'levels/editors/netsim', locals: {f: f} if @level.is_a? NetSim

--- a/dashboard/app/views/levels/editors/_ailab.html.haml
+++ b/dashboard/app/views/levels/editors/_ailab.html.haml
@@ -3,7 +3,6 @@
 = render partial: 'levels/editors/fields/code_area', locals: {f: f}
 = render partial: 'levels/editors/fields/video', locals: {f: f}
 = render partial: 'levels/editors/fields/bubble_choice_sublevel', locals: {f: f}
-= render partial: 'levels/editors/fields/special_level_types', locals: {f: f}
 
 = render partial: 'levels/editors/fields/sharing', locals: {f: f}
 = render partial: 'levels/editors/fields/callouts', locals: {f: f}

--- a/dashboard/app/views/levels/editors/_ailab.html.haml
+++ b/dashboard/app/views/levels/editors/_ailab.html.haml
@@ -1,0 +1,10 @@
+= render partial: 'levels/editors/fields/instructions_area', locals: {f: f}
+= render partial: 'levels/editors/fields/teacher_only_markdown', locals: {f: f}
+= render partial: 'levels/editors/fields/code_area', locals: {f: f}
+= render partial: 'levels/editors/fields/video', locals: {f: f}
+= render partial: 'levels/editors/fields/bubble_choice_sublevel', locals: {f: f}
+= render partial: 'levels/editors/fields/special_level_types', locals: {f: f}
+
+= render partial: 'levels/editors/fields/sharing', locals: {f: f}
+= render partial: 'levels/editors/fields/callouts', locals: {f: f}
+= render partial: 'levels/editors/fields/audit_log', locals: {f: f}

--- a/dashboard/app/views/levels/new.html.haml
+++ b/dashboard/app/views/levels/new.html.haml
@@ -43,6 +43,7 @@
   %li= link_to 'Build an Applab Droplet Level', new_level_path(type: 'Applab')
   %li= link_to 'Build a Gamelab Droplet Level', new_level_path(type: 'Gamelab')
   %li= link_to 'Build a Weblab Level', new_level_path(type: 'Weblab')
+  %li= link_to 'Build an AI Lab level', new_level_path(type: 'Ailab')
   %li= link_to 'Build a NetSim Level', new_level_path(type: 'NetSim')
   %li= link_to 'Build a Pixelation Level', new_level_path(type: 'Pixelation')
   %li= link_to 'Build a Text Compression Level', new_level_path(type: 'TextCompression')


### PR DESCRIPTION
AI Lab levels can now be created and modified on levelbuilder.  Instructions can be provided and are then shown on the level.

### /levels/new
![Screen Shot 2020-10-29 at 11 46 23 AM](https://user-images.githubusercontent.com/2205926/97620516-eaf08f00-19de-11eb-94c1-c582b90a45b5.png)

### /levels/[level_id]/edit
![Screen Shot 2020-10-29 at 12 07 09 PM](https://user-images.githubusercontent.com/2205926/97620827-4f135300-19df-11eb-8553-b63bfe6af0dd.png)

### a level
![Screen Shot 2020-10-29 at 12 05 37 PM](https://user-images.githubusercontent.com/2205926/97620660-196e6a00-19df-11eb-9839-b06602a7836b.png)
