### PR TITLE
Downcase resource names and strip whitespace for key generation

### DIFF
--- a/dashboard/app/models/resource.rb
+++ b/dashboard/app/models/resource.rb
@@ -62,7 +62,7 @@ class Resource < ApplicationRecord
   private
 
   def generate_key_from_name
-    key_prefix = name.gsub(/[^a-z0-9\-\_\.]+/, '_')
+    key_prefix = name.downcase.gsub(/[^a-z0-9\-\_\.]+/, '_')
     potential_clashes = course_version_id ? Resource.where(course_version_id: course_version_id) : Resource.all
     potential_clashes = potential_clashes.where("resources.key like '#{key_prefix}%'").pluck(:key)
     return key_prefix unless potential_clashes.include?(key_prefix)

--- a/dashboard/app/models/resource.rb
+++ b/dashboard/app/models/resource.rb
@@ -62,7 +62,7 @@ class Resource < ApplicationRecord
   private
 
   def generate_key_from_name
-    key_prefix = name.downcase.gsub(/[^a-z0-9\-\_\.]+/, '_')
+    key_prefix = name.strip.downcase.gsub(/[^a-z0-9\-\_\.]+/, '_')
     potential_clashes = course_version_id ? Resource.where(course_version_id: course_version_id) : Resource.all
     potential_clashes = potential_clashes.where("resources.key like '#{key_prefix}%'").pluck(:key)
     return key_prefix unless potential_clashes.include?(key_prefix)

--- a/dashboard/test/models/resource_test.rb
+++ b/dashboard/test/models/resource_test.rb
@@ -47,6 +47,11 @@ class ResourceTest < ActiveSupport::TestCase
     assert_equal 'my_students_projects_code.org', resource.key
   end
 
+  test "resource names downcased for key generation" do
+    resource = create :resource, key: nil, name: "Plotting Shapes"
+    assert_equal 'plotting_shapes', resource.key
+  end
+
   test "summarize for lesson plan" do
     resource = create :resource, key: 'my key', name: 'test resource', url: 'test.url',  audience: 'Teacher', type: 'Activity Guide'
     assert_equal(

--- a/dashboard/test/models/resource_test.rb
+++ b/dashboard/test/models/resource_test.rb
@@ -47,8 +47,8 @@ class ResourceTest < ActiveSupport::TestCase
     assert_equal 'my_students_projects_code.org', resource.key
   end
 
-  test "resource names downcased for key generation" do
-    resource = create :resource, key: nil, name: "Plotting Shapes"
+  test "resource downcases and strips whitespace for key generation" do
+    resource = create :resource, key: nil, name: "   Plotting Shapes "
     assert_equal 'plotting_shapes', resource.key
   end
 


### PR DESCRIPTION
Dave noticed that this happened with a resource names "Plotting Shapes"
![Screen Shot 2020-10-29 at 1 21 06 PM](https://user-images.githubusercontent.com/46464143/97629047-c39fbf00-19ea-11eb-888c-ce0473d0cffb.png)

Easy fix is just to downcase the name.

<!-- ### Background -->
<!-- ### Privacy -->
<!--
1.	Does the Project involve the collection, use or sharing of new Personal Data?

2.	Does the Project involve a new or changed use or sharing of existing Personal Data?
-->
<!-- ### Security -->
<!--
Link to Jira Task where sensitive security issues are discussed privately.
-->
<!-- ### Caching -->
<!-- ### Deployment strategy -->
<!-- ### Future work -->

## Links

<!--
  Any relevant links to external resources; ie, specification documents, jira
  items, related PRs, honeybadger errors, etc
-->

- [spec]()
- [jira]()

## Testing story

added unit test

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
