### PR TITLE
Update cron jobs for daylight savings time ending - Fall 2020

### DIFF
--- a/cookbooks/cdo-apps/templates/default/crontab.erb
+++ b/cookbooks/cdo-apps/templates/default/crontab.erb
@@ -67,17 +67,17 @@
 
     if node.chef_environment == 'test' && node.name == 'test' # 'real' test only
       # This should be run shortly after the commit_content job run on levelbuilder.
-      cronjob at:'20 22 * * 1-5', do:deploy_dir('bin', 'cron', 'deploy_to_levelbuilder')
+      cronjob at:'20 23 * * 1-5', do:deploy_dir('bin', 'cron', 'deploy_to_levelbuilder')
       cronjob at:'*/2 * * * 1-5', do:deploy_dir('bin', 'cron', 'deploy_to_test')
       cronjob at:'*/5 * * * *', do:deploy_dir('bin', 'snapshot')
     end
 
     if node.chef_environment == 'levelbuilder'
-      cronjob at:'0 19 * * 1-5', do:deploy_dir('bin', 'cron', 'commit_content')
-      cronjob at:'18 22 * * 1-5', do:deploy_dir('bin', 'cron', 'commit_content')
+      cronjob at:'0 20 * * 1-5', do:deploy_dir('bin', 'cron', 'commit_content')
+      cronjob at:'18 23 * * 1-5', do:deploy_dir('bin', 'cron', 'commit_content')
       # This should be run shortly after the commit_content job, running on both levelbuilder and
       # staging.
-      cronjob at:'5 19 * * 1-5', do:deploy_dir('bin', 'cron', 'merge_lb_to_staging')
+      cronjob at:'5 20 * * 1-5', do:deploy_dir('bin', 'cron', 'merge_lb_to_staging')
     end
 
     if node.chef_environment == 'production' # production daemon

--- a/cookbooks/cdo-apps/templates/default/crontab.erb
+++ b/cookbooks/cdo-apps/templates/default/crontab.erb
@@ -56,7 +56,7 @@
       cronjob at:'*/2 * * * *', do:pegasus_dir('sites','virtual','collate_pdfs')
       cronjob at:'30 16,17 * * *', do:deploy_dir('bin', 'cron', 'update_dotd')
       cronjob at:'0 * * * *', do:deploy_dir('bin', 'cron', 'start_broken_link_checker'), notify:'dev+crontab@code.org'
-      cronjob at:'0 19 * * 1-5', do:deploy_dir('bin', 'cron', 'commit_content')
+      cronjob at:'0 20 * * 1-5', do:deploy_dir('bin', 'cron', 'commit_content')
       cronjob at:'*/1 * * * *', do:deploy_dir('bin', 'cron', 'update_dts')
       cronjob at:'0 17 * * *', do:deploy_dir('bin', 'cron', 'commit_trusted_proxies')
     end
@@ -97,7 +97,7 @@
       cronjob at:'0 7 * * *', do:deploy_dir('bin', 'cron', 'stop_inactive_adhoc_instances')
       cronjob at:'0 10 * * *', do:deploy_dir('bin', 'cron', 'redshift_rollups')
       cronjob at:'1 7 * * 6', do:deploy_dir('bin', 'cron', 'cleanup_workshop_attendance_codes')
-      cronjob at:'31 16 * * 1-5', do:deploy_dir('bin', 'cron', 'zendesk_slack_report')
+      cronjob at:'31 17 * * 1-5', do:deploy_dir('bin', 'cron', 'zendesk_slack_report')
       cronjob at:'0 12 * * *', do:deploy_dir('bin', 'cron', 'applab_datasets', 'daily_weather')
       cronjob at:'0 12 * * *', do:deploy_dir('bin', 'cron', 'applab_datasets', 'spotify')
       cronjob at:'0 12 * * *', do:deploy_dir('bin', 'cron', 'applab_datasets', 'covid19')


### PR DESCRIPTION
Reverts code-dot-org/code-dot-org#33569 which was used in March to update all the cron jobs times for the time change. 