### PR TITLE
Foorm: Add published column for forms and libraries (migration)

### DIFF
--- a/dashboard/app/models/foorm/form.rb
+++ b/dashboard/app/models/foorm/form.rb
@@ -8,6 +8,7 @@
 #  questions  :text(65535)      not null
 #  created_at :datetime         not null
 #  updated_at :datetime         not null
+#  published  :boolean          default(TRUE), not null
 #
 # Indexes
 #

--- a/dashboard/app/models/foorm/library_question.rb
+++ b/dashboard/app/models/foorm/library_question.rb
@@ -9,6 +9,7 @@
 #  question        :text(65535)      not null
 #  created_at      :datetime         not null
 #  updated_at      :datetime         not null
+#  published       :boolean          default(TRUE), not null
 #
 # Indexes
 #

--- a/dashboard/db/migrate/20201029221258_add_published_to_foorm_forms.rb
+++ b/dashboard/db/migrate/20201029221258_add_published_to_foorm_forms.rb
@@ -1,0 +1,5 @@
+class AddPublishedToFoormForms < ActiveRecord::Migration[5.0]
+  def change
+    add_column :foorm_forms, :published, :boolean, default: true, null: false
+  end
+end

--- a/dashboard/db/migrate/20201029231229_add_published_to_foorm_library_questions.rb
+++ b/dashboard/db/migrate/20201029231229_add_published_to_foorm_library_questions.rb
@@ -1,0 +1,5 @@
+class AddPublishedToFoormLibraryQuestions < ActiveRecord::Migration[5.0]
+  def change
+    add_column :foorm_library_questions, :published, :boolean, default: true, null: false
+  end
+end

--- a/dashboard/db/schema.rb
+++ b/dashboard/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20201023025847) do
+ActiveRecord::Schema.define(version: 20201029231229) do
 
   create_table "activities", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci" do |t|
     t.integer  "user_id"
@@ -455,21 +455,23 @@ ActiveRecord::Schema.define(version: 20201023025847) do
   end
 
   create_table "foorm_forms", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci" do |t|
-    t.string   "name",                     null: false
-    t.integer  "version",                  null: false
-    t.text     "questions",  limit: 65535, null: false
-    t.datetime "created_at",               null: false
-    t.datetime "updated_at",               null: false
+    t.string   "name",                                    null: false
+    t.integer  "version",                                 null: false
+    t.text     "questions",  limit: 65535,                null: false
+    t.datetime "created_at",                              null: false
+    t.datetime "updated_at",                              null: false
+    t.boolean  "published",                default: true, null: false
     t.index ["name", "version"], name: "index_foorm_forms_on_name_and_version", unique: true, using: :btree
   end
 
   create_table "foorm_library_questions", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci" do |t|
-    t.string   "library_name",                  null: false
-    t.integer  "library_version",               null: false
-    t.string   "question_name",                 null: false
-    t.text     "question",        limit: 65535, null: false
-    t.datetime "created_at",                    null: false
-    t.datetime "updated_at",                    null: false
+    t.string   "library_name",                                 null: false
+    t.integer  "library_version",                              null: false
+    t.string   "question_name",                                null: false
+    t.text     "question",        limit: 65535,                null: false
+    t.datetime "created_at",                                   null: false
+    t.datetime "updated_at",                                   null: false
+    t.boolean  "published",                     default: true, null: false
     t.index ["library_name", "library_version", "question_name"], name: "index_foorm_library_questions_on_multiple_fields", unique: true, using: :btree
   end
 


### PR DESCRIPTION
We are adding the concept of a `published` state for Foorm forms and library questions. This state will be defined as a true/false and added to the json configurations in a follow-up PR. This will be used in the V2 version of the editor to give appropriate warnings/errors when a user tries to edit a published survey. The new editor will take care of adding this value to the configuration, so survey editors don't need to know the syntax. Currently the published state does nothing, and is defaulted to true since all the existing forms are 'published'. 

This PR adds the new columns via migrations.

## Links

- [spec](https://docs.google.com/document/d/1jnkpC_lCpnfFYSl_Hk_RPjdspyGYAspwy44NCUZpvlI/edit#)
- [jira](https://codedotorg.atlassian.net/browse/PLC-1037)

## Testing story
Tested running and rolling back the migrations and ensured the tables looked as expected. Also tested seeding forms after the migration and the forms seeded correctly.

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
