### PR TITLE
fix editing on non-external markdown levels

### DIFF
--- a/dashboard/app/views/levels/editors/fields/_dsl_fields.html.haml
+++ b/dashboard/app/views/levels/editors/fields/_dsl_fields.html.haml
@@ -30,8 +30,8 @@
   .script_text
     = text_area_tag('level[dsl_text]', @level.dsl_text || (@level.dsl_default))
 
-  - if @level.is_a?(External)
-    %p< If you want to embed blocks in this level, you can do so by adding associated_blocks 'block type' to the DSL field. Available block types are: #{External.possible_associated_blocks.join(', ')}
+    - if @level.is_a?(External)
+      %p< If you want to embed blocks in this level, you can do so by adding associated_blocks 'block type' to the DSL field. Available block types are: #{External.possible_associated_blocks.join(', ')}
 
     .markdown
       %p Edit Markdown:


### PR DESCRIPTION
editing of multi levels was reported here: https://codedotorg.slack.com/archives/CA3KCSGTD/p1603994532318000 the page does not navigate after clicking save, but the edits made appear persist:
![test](https://user-images.githubusercontent.com/8001765/97644809-86e2c080-1a08-11eb-9dd5-f54bc9ac42ea.gif)

This PR fixes the regression, which was introduced in https://github.com/code-dot-org/code-dot-org/pull/35683/files#diff-eefd248014f6b9740cc3067f810e31bb979e3369f3d2abf425f93e3af759229bR35 , by fixing the parts of that PR that broke things. That PR wiped out the editor components needed for markdown editor fields on DSL-defined levels. without those fields, the initialization code failed:
![Screen Shot 2020-10-29 at 5 01 13 PM](https://user-images.githubusercontent.com/8001765/97644763-70d50000-1a08-11eb-9dc4-2ef5c3211d41.png)

This caused the ajax-handling code here never to execute: https://github.com/code-dot-org/code-dot-org/blob/1cad5ac667f9ed1a3aa31063e6d06bd21a78e2bd/apps/src/code-studio/ajaxSubmit.js#L3-L5

presumably leading to the navigation not happening after save.

## Testing story

I will follow up with an attempt to add a UI test to cover saving of a multi level.