### PR TITLE
Revert "Remove deprecated :text option to render"

### DIFF
--- a/dashboard/app/controllers/admin_reports_controller.rb
+++ b/dashboard/app/controllers/admin_reports_controller.rb
@@ -127,7 +127,7 @@ class AdminReportsController < ApplicationController
     rescue ActiveRecord::RecordNotFound
       render(
         layout: 'application',
-        plain: "Script #{script_id_or_name} not found.",
+        text: "Script #{script_id_or_name} not found.",
         status: 404
       ) && return
     end
@@ -142,7 +142,7 @@ class AdminReportsController < ApplicationController
         )
         render(
           layout: 'application',
-          plain: "PD progress data not found for #{sanitized_script_name}.",
+          text: "PD progress data not found for #{sanitized_script_name}.",
           status: 404
         )
       end

--- a/dashboard/app/controllers/dynamic_config_controller.rb
+++ b/dashboard/app/controllers/dynamic_config_controller.rb
@@ -10,7 +10,7 @@ class DynamicConfigController < ApplicationController
     gk_yaml = Gatekeeper.to_yaml
     dcdo_yaml = DCDO.to_yaml
     output = "# Gatekeeper Config\n #{gk_yaml}\n\n# DCDO Config\n#{dcdo_yaml}"
-    render plain: output, content_type: 'text/yaml'
+    render text: output, content_type: 'text/yaml'
   end
 
   def gatekeeper_show

--- a/dashboard/app/controllers/home_controller.rb
+++ b/dashboard/app/controllers/home_controller.rb
@@ -32,12 +32,12 @@ class HomeController < ApplicationController
     if current_user
       render 'index', layout: false, formats: [:html]
     else
-      render plain: ''
+      render text: ''
     end
   end
 
   def health_check
-    render plain: 'healthy!'
+    render text: 'healthy!'
   end
 
   # Signed in student, with an assigned course/script: redirect to course overview page

--- a/dashboard/app/controllers/lessons_controller.rb
+++ b/dashboard/app/controllers/lessons_controller.rb
@@ -57,7 +57,7 @@ class LessonsController < ApplicationController
 
     redirect_to lesson_path(id: @lesson.id)
   rescue ActiveRecord::RecordNotFound, ActiveRecord::RecordInvalid => e
-    render(status: :not_acceptable, plain: e.message)
+    render(status: :not_acceptable, text: e.message)
   end
 
   private

--- a/dashboard/app/controllers/levels_controller.rb
+++ b/dashboard/app/controllers/levels_controller.rb
@@ -291,9 +291,9 @@ class LevelsController < ApplicationController
     begin
       @level = type_class.create_from_level_builder(params, create_level_params)
     rescue ArgumentError => e
-      render(status: :not_acceptable, plain: e.message) && return
+      render(status: :not_acceptable, text: e.message) && return
     rescue ActiveRecord::RecordInvalid => invalid
-      render(status: :not_acceptable, plain: invalid) && return
+      render(status: :not_acceptable, text: invalid) && return
     end
     if params[:do_not_redirect]
       render json: @level
@@ -363,9 +363,9 @@ class LevelsController < ApplicationController
       render json: {redirect: edit_level_url(@new_level)}
     end
   rescue ArgumentError => e
-    render(status: :not_acceptable, plain: e.message)
+    render(status: :not_acceptable, text: e.message)
   rescue ActiveRecord::RecordInvalid => invalid
-    render(status: :not_acceptable, plain: invalid)
+    render(status: :not_acceptable, text: invalid)
   end
 
   # GET /levels/:id/embed_level

--- a/dashboard/app/controllers/script_levels_controller.rb
+++ b/dashboard/app/controllers/script_levels_controller.rb
@@ -373,7 +373,7 @@ class ScriptLevelsController < ApplicationController
     return if params[:user_id].blank?
 
     if current_user.nil?
-      render plain: 'Teacher view is not available for this puzzle', layout: true
+      render text: 'Teacher view is not available for this puzzle', layout: true
       return
     end
 

--- a/dashboard/app/controllers/videos_controller.rb
+++ b/dashboard/app/controllers/videos_controller.rb
@@ -20,7 +20,7 @@ class VideosController < ApplicationController
         require 'cdo/video/youtube'
         Youtube.process @video.key
       rescue Exception => e
-        render(layout: false, plain: "Error processing video: #{e}. Contact an engineer for support.", status: 500) && return
+        render(layout: false, text: "Error processing video: #{e}. Contact an engineer for support.", status: 500) && return
       end
     end
     video_info = @video.summarize(params.key?(:autoplay))

--- a/dashboard/config/initializers/backtrace_silencers.rb
+++ b/dashboard/config/initializers/backtrace_silencers.rb
@@ -10,6 +10,7 @@
 silenced = [
   /ActionController::TestCase HTTP request methods/,
   /ActionDispatch::IntegrationTest HTTP request methods/,
+  /`render :text` is deprecated/,
   /alias_method_chain is deprecated/
 ]
 


### PR DESCRIPTION
Reverts code-dot-org/code-dot-org#37509

[Slack Discussion](https://codedotorg.slack.com/archives/CA3KCSGTD/p1604015614333200)
[Slack Discussion 2](https://codedotorg.slack.com/archives/CNZP84FJ5/p1604017895258700)
[HoneyBadger](https://app.honeybadger.io/projects/3240/faults/69296627#notice-trace)

Repro steps:
"I repro. If I assign dance party 2019 to my class and go look at the student progress, clicking on one of the bubbles shows me the same 500 error. This doesn't seem like expected behavior."