### PR TITLE
Revert "Revert "Remove deprecated :text option to render""

### DIFF
--- a/dashboard/app/controllers/admin_reports_controller.rb
+++ b/dashboard/app/controllers/admin_reports_controller.rb
@@ -127,7 +127,7 @@ class AdminReportsController < ApplicationController
     rescue ActiveRecord::RecordNotFound
       render(
         layout: 'application',
-        text: "Script #{script_id_or_name} not found.",
+        plain: "Script #{script_id_or_name} not found.",
         status: 404
       ) && return
     end
@@ -142,7 +142,7 @@ class AdminReportsController < ApplicationController
         )
         render(
           layout: 'application',
-          text: "PD progress data not found for #{sanitized_script_name}.",
+          plain: "PD progress data not found for #{sanitized_script_name}.",
           status: 404
         )
       end

--- a/dashboard/app/controllers/admin_reports_controller.rb
+++ b/dashboard/app/controllers/admin_reports_controller.rb
@@ -127,7 +127,7 @@ class AdminReportsController < ApplicationController
     rescue ActiveRecord::RecordNotFound
       render(
         layout: 'application',
-        plain: "Script #{script_id_or_name} not found.",
+        html: "Script #{script_id_or_name} not found.",
         status: 404
       ) && return
     end
@@ -142,7 +142,7 @@ class AdminReportsController < ApplicationController
         )
         render(
           layout: 'application',
-          plain: "PD progress data not found for #{sanitized_script_name}.",
+          html: "PD progress data not found for #{sanitized_script_name}.",
           status: 404
         )
       end

--- a/dashboard/app/controllers/dynamic_config_controller.rb
+++ b/dashboard/app/controllers/dynamic_config_controller.rb
@@ -10,7 +10,7 @@ class DynamicConfigController < ApplicationController
     gk_yaml = Gatekeeper.to_yaml
     dcdo_yaml = DCDO.to_yaml
     output = "# Gatekeeper Config\n #{gk_yaml}\n\n# DCDO Config\n#{dcdo_yaml}"
-    render text: output, content_type: 'text/yaml'
+    render plain: output, content_type: 'text/yaml'
   end
 
   def gatekeeper_show

--- a/dashboard/app/controllers/home_controller.rb
+++ b/dashboard/app/controllers/home_controller.rb
@@ -32,12 +32,12 @@ class HomeController < ApplicationController
     if current_user
       render 'index', layout: false, formats: [:html]
     else
-      render text: ''
+      render plain: ''
     end
   end
 
   def health_check
-    render text: 'healthy!'
+    render plain: 'healthy!'
   end
 
   # Signed in student, with an assigned course/script: redirect to course overview page

--- a/dashboard/app/controllers/lessons_controller.rb
+++ b/dashboard/app/controllers/lessons_controller.rb
@@ -57,7 +57,7 @@ class LessonsController < ApplicationController
 
     redirect_to lesson_path(id: @lesson.id)
   rescue ActiveRecord::RecordNotFound, ActiveRecord::RecordInvalid => e
-    render(status: :not_acceptable, text: e.message)
+    render(status: :not_acceptable, plain: e.message)
   end
 
   private

--- a/dashboard/app/controllers/levels_controller.rb
+++ b/dashboard/app/controllers/levels_controller.rb
@@ -291,9 +291,9 @@ class LevelsController < ApplicationController
     begin
       @level = type_class.create_from_level_builder(params, create_level_params)
     rescue ArgumentError => e
-      render(status: :not_acceptable, text: e.message) && return
+      render(status: :not_acceptable, plain: e.message) && return
     rescue ActiveRecord::RecordInvalid => invalid
-      render(status: :not_acceptable, text: invalid) && return
+      render(status: :not_acceptable, plain: invalid) && return
     end
     if params[:do_not_redirect]
       render json: @level
@@ -363,9 +363,9 @@ class LevelsController < ApplicationController
       render json: {redirect: edit_level_url(@new_level)}
     end
   rescue ArgumentError => e
-    render(status: :not_acceptable, text: e.message)
+    render(status: :not_acceptable, plain: e.message)
   rescue ActiveRecord::RecordInvalid => invalid
-    render(status: :not_acceptable, text: invalid)
+    render(status: :not_acceptable, plain: invalid)
   end
 
   # GET /levels/:id/embed_level

--- a/dashboard/app/controllers/script_levels_controller.rb
+++ b/dashboard/app/controllers/script_levels_controller.rb
@@ -373,7 +373,7 @@ class ScriptLevelsController < ApplicationController
     return if params[:user_id].blank?
 
     if current_user.nil?
-      render plain: 'Teacher view is not available for this puzzle', layout: true
+      render html: 'Teacher view is not available for this puzzle', layout: true
       return
     end
 

--- a/dashboard/app/controllers/script_levels_controller.rb
+++ b/dashboard/app/controllers/script_levels_controller.rb
@@ -373,7 +373,7 @@ class ScriptLevelsController < ApplicationController
     return if params[:user_id].blank?
 
     if current_user.nil?
-      render text: 'Teacher view is not available for this puzzle', layout: true
+      render plain: 'Teacher view is not available for this puzzle', layout: true
       return
     end
 

--- a/dashboard/app/controllers/videos_controller.rb
+++ b/dashboard/app/controllers/videos_controller.rb
@@ -20,7 +20,7 @@ class VideosController < ApplicationController
         require 'cdo/video/youtube'
         Youtube.process @video.key
       rescue Exception => e
-        render(layout: false, text: "Error processing video: #{e}. Contact an engineer for support.", status: 500) && return
+        render(layout: false, plain: "Error processing video: #{e}. Contact an engineer for support.", status: 500) && return
       end
     end
     video_info = @video.summarize(params.key?(:autoplay))

--- a/dashboard/config/initializers/backtrace_silencers.rb
+++ b/dashboard/config/initializers/backtrace_silencers.rb
@@ -10,7 +10,6 @@
 silenced = [
   /ActionController::TestCase HTTP request methods/,
   /ActionDispatch::IntegrationTest HTTP request methods/,
-  /`render :text` is deprecated/,
   /alias_method_chain is deprecated/
 ]
 

--- a/dashboard/test/controllers/admin_reports_controller_test.rb
+++ b/dashboard/test/controllers/admin_reports_controller_test.rb
@@ -15,7 +15,6 @@ class AdminReportsControllerTest < ActionController::TestCase
     get :pd_progress, params: {script: 'bogus-nonexistent-script-name'}
     assert_response :not_found
     assert_includes @response.body, "Script bogus-nonexistent-script-name not found"
-    assert_equal @response.body, "asdf"
   end
 
   test 'pd_progress should return 404 for unfound progress data' do
@@ -25,7 +24,6 @@ class AdminReportsControllerTest < ActionController::TestCase
     get :pd_progress, params: {script: script.name}
     assert_response :not_found
     assert_includes @response.body, "PD progress data not found for test-unfound-progress-data"
-    assert_equal @response.body, "asdf"
   end
 
   test 'pd_progress should sanitize script.name' do

--- a/dashboard/test/controllers/admin_reports_controller_test.rb
+++ b/dashboard/test/controllers/admin_reports_controller_test.rb
@@ -14,6 +14,18 @@ class AdminReportsControllerTest < ActionController::TestCase
   test 'pd_progress should return 404 for unfound script' do
     get :pd_progress, params: {script: 'bogus-nonexistent-script-name'}
     assert_response :not_found
+    assert_includes @response.body, "Script bogus-nonexistent-script-name not found"
+    assert_equal @response.body, "asdf"
+  end
+
+  test 'pd_progress should return 404 for unfound progress data' do
+    script = create :script, name: "test-unfound-progress-data"
+    Properties.stubs(:get).returns(nil)
+
+    get :pd_progress, params: {script: script.name}
+    assert_response :not_found
+    assert_includes @response.body, "PD progress data not found for test-unfound-progress-data"
+    assert_equal @response.body, "asdf"
   end
 
   test 'pd_progress should sanitize script.name' do

--- a/dashboard/test/controllers/script_levels_controller_test.rb
+++ b/dashboard/test/controllers/script_levels_controller_test.rb
@@ -1009,6 +1009,22 @@ class ScriptLevelsControllerTest < ActionController::TestCase
     assert_equal last_attempt_data, assigns(:last_attempt)
   end
 
+  test 'renders error message when attempting to view a student\'s work while not signed in' do
+    # Note that this also applies when trying to view a student's work for a
+    # cached page, as we tend to do for high-traffic levels.
+
+    get :show, params: {
+      script_id: @script,
+      stage_position: @script_level.lesson,
+      id: @script_level.position,
+      user_id: @student.id,
+      section_id: @section.id
+    }
+
+    assert_response :success
+    assert_includes response.body, 'Teacher view is not available for this puzzle'
+  end
+
   test 'loads applab if you are a teacher viewing your student and they have a channel id' do
     sign_in @teacher
 


### PR DESCRIPTION
Reverts code-dot-org/code-dot-org#37571, restoring https://github.com/code-dot-org/code-dot-org/pull/37509

It turns out I was slightly wrong about my understanding of the deprecation.

`render text` used to be able to either render just a raw text response OR render text into an html layout, with the use of the layout keyword. This behavior was confusing, so `render text` was broken up into `render plain` and `render html`; in my upgrade, I naively updated all uses of `render text` to `render plain`, breaking the single use of it that should have been `render html`.

That update has now been fixed, and a test case has been added that would have caught the regression.