### PR TITLE
Prevent nil params in controller tests

### DIFF
--- a/dashboard/test/controllers/pd/workshop_admins_controller_test.rb
+++ b/dashboard/test/controllers/pd/workshop_admins_controller_test.rb
@@ -1,7 +1,7 @@
 require 'test_helper'
 
 class Pd::WorkshopAdminsControllerTest < ActionController::TestCase
-  def self.test_workshop_admin_only(method, action, params = nil)
+  def self.test_workshop_admin_only(method, action, params = {})
     %i(student teacher facilitator workshop_organizer program_manager).each do |user_type|
       test_user_gets_response_for action, user: user_type, method: method, params: params, response: :forbidden
     end

--- a/dashboard/test/controllers/pd/workshop_user_management_controller_test.rb
+++ b/dashboard/test/controllers/pd/workshop_user_management_controller_test.rb
@@ -11,7 +11,7 @@ class Pd::WorkshopUserManagementControllerTest < ActionController::TestCase
     @facilitator_with_course = create(:pd_course_facilitator, course: Pd::Workshop::COURSE_CSF).facilitator
   end
 
-  def self.test_workshop_admin_only(method, action, params = nil)
+  def self.test_workshop_admin_only(method, action, params = {})
     test_user_gets_response_for action, user: :student, method: method, params: params, response: :forbidden
     test_user_gets_response_for action, user: -> {@teacher}, method: method, params: params, response: :forbidden
     test_user_gets_response_for action, user: -> {@workshop_admin}, method: method, params: params, response: :success

--- a/dashboard/test/controllers/regional_partners_controller_test.rb
+++ b/dashboard/test/controllers/regional_partners_controller_test.rb
@@ -10,7 +10,7 @@ class RegionalPartnersControllerTest < ActionController::TestCase
     @regional_partner = create :regional_partner
   end
 
-  def self.test_workshop_admin_only(method, action, params = nil)
+  def self.test_workshop_admin_only(method, action, params = {})
     %i(student teacher facilitator workshop_organizer).each do |user_type|
       test_user_gets_response_for action, user: user_type, method: method, params: params, response: :forbidden
     end

--- a/dashboard/test/test_helper.rb
+++ b/dashboard/test/test_helper.rb
@@ -447,6 +447,8 @@ class ActionController::TestCase
   def self.test_user_gets_response_for(action, method: :get, response: :success,
     user: nil, params: {}, name: nil, queries: nil, redirected_to: nil, &block)
 
+    refute_nil params, "params in controller tests cannot be nil"
+
     unless name.present?
       raise 'name is required when a block is provided' if block
       user_display_name =

--- a/dashboard/test/test_helper.rb
+++ b/dashboard/test/test_helper.rb
@@ -447,8 +447,6 @@ class ActionController::TestCase
   def self.test_user_gets_response_for(action, method: :get, response: :success,
     user: nil, params: {}, name: nil, queries: nil, redirected_to: nil, &block)
 
-    refute_nil params, "params in controller tests cannot be nil"
-
     unless name.present?
       raise 'name is required when a block is provided' if block
       user_display_name =
@@ -464,6 +462,7 @@ class ActionController::TestCase
 
     test name do
       # params can be a hash, or a proc that returns a hash at runtime
+      refute_nil params, "params in controller tests cannot be nil"
       params = instance_exec(&params) if params.is_a? Proc
 
       if user


### PR DESCRIPTION
This is to add clarity for Rails 5.1, in which passing `nil` for params starts failing due to its inability to symbolize the keys:

https://github.com/rails/rails/blob/4f66945cd038bda638fc6729e0d54663d0dfbf22/actionpack/lib/action_controller/test_case.rb#L485

<!--
  Your description goes here: A summary of the change, including any relevant motivation and context.

  If relevant, include a description both of the existing behavior and of the new behavior.
-->

<!--
  Other aspects to consider. uncomment and add detail for any that seem necessary:
-->

<!-- ### Background -->
<!-- ### Privacy -->
<!--
1.	Does the Project involve the collection, use or sharing of new Personal Data?

2.	Does the Project involve a new or changed use or sharing of existing Personal Data?
-->
<!-- ### Security -->
<!--
Link to Jira Task where sensitive security issues are discussed privately.
-->
<!-- ### Caching -->
<!-- ### Deployment strategy -->
<!-- ### Future work -->



## Testing story

This is a change to test functionality, so I am 100% relying on existing tests

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
