### PR TITLE
[Google Blockly] Fix override for trashcan png

### DIFF
--- a/apps/src/blocklyAddons/cdoTrashcan.js
+++ b/apps/src/blocklyAddons/cdoTrashcan.js
@@ -13,7 +13,7 @@ export default class CdoTrashcan extends GoogleBlockly.Trashcan {
      * https://developer.mozilla.org/en-US/docs/Web/API/NodeList/forEach
      */
     Array.prototype.forEach.call(this.svgGroup_.childNodes, function(node) {
-      if (node.name === 'image') {
+      if (node.nodeName === 'image') {
         node.setAttributeNS(
           Blockly.utils.dom.XLINK_NS,
           'xlink:href',


### PR DESCRIPTION
this regressed in https://github.com/code-dot-org/code-dot-org/pull/37547
Just a simple typo- should be checking `nodeName` not `name`
Before:
![image](https://user-images.githubusercontent.com/8787187/97751563-be587800-1aaf-11eb-8332-8b81c813df8e.png)

After:
![image](https://user-images.githubusercontent.com/8787187/97751638-daf4b000-1aaf-11eb-8c2d-7a2df9a79892.png)
