### PR TITLE
allow moving script level to a later activity section

### DIFF
--- a/dashboard/app/models/activity_section.rb
+++ b/dashboard/app/models/activity_section.rb
@@ -89,15 +89,11 @@ class ActivitySection < ApplicationRecord
   private
 
   def fetch_script_level(sl_data)
-    script_level = sl_data['id'] && ScriptLevel.find_by_id(sl_data['id'])
-    if script_level
-      unless script_level.activity_section.lesson == lesson
-        # add a safeguard to make sure we never take a script level from another
-        # lesson. this case should not be possible to hit using our editing UI.
-        raise "cannot move script level #{script_level.id} between lessons"
-      end
-      return script_level
-    end
+    # Do not try to find the script level id if it was moved here from another
+    # activity section. Create a new one here, and let the old script level be
+    # destroyed when we update the other activity section.
+    script_level = sl_data['id'] && script_levels.where(id: sl_data['id']).first
+    return script_level if script_level
 
     script_levels.create(
       position: 0,

--- a/dashboard/app/models/activity_section.rb
+++ b/dashboard/app/models/activity_section.rb
@@ -90,13 +90,15 @@ class ActivitySection < ApplicationRecord
 
   def fetch_script_level(sl_data)
     if sl_data['id']
-      script_level = ScriptLevel.find(sl_data['id'])
-      unless script_level.activity_section.lesson == lesson
-        # add a safeguard to make sure we never take a script level from another
-        # lesson. this case should not be possible to hit using our editing UI.
-        raise "cannot move script level #{script_level.id} between lessons"
+      script_level = ScriptLevel.find_by_id(sl_data['id'])
+      if script_level
+        unless script_level.activity_section.lesson == lesson
+          # add a safeguard to make sure we never take a script level from another
+          # lesson. this case should not be possible to hit using our editing UI.
+          raise "cannot move script level #{script_level.id} between lessons"
+        end
+        return script_level
       end
-      return script_level
     end
 
     script_levels.create(

--- a/dashboard/app/models/activity_section.rb
+++ b/dashboard/app/models/activity_section.rb
@@ -89,16 +89,14 @@ class ActivitySection < ApplicationRecord
   private
 
   def fetch_script_level(sl_data)
-    if sl_data['id']
-      script_level = ScriptLevel.find_by_id(sl_data['id'])
-      if script_level
-        unless script_level.activity_section.lesson == lesson
-          # add a safeguard to make sure we never take a script level from another
-          # lesson. this case should not be possible to hit using our editing UI.
-          raise "cannot move script level #{script_level.id} between lessons"
-        end
-        return script_level
+    script_level = sl_data['id'] && ScriptLevel.find_by_id(sl_data['id'])
+    if script_level
+      unless script_level.activity_section.lesson == lesson
+        # add a safeguard to make sure we never take a script level from another
+        # lesson. this case should not be possible to hit using our editing UI.
+        raise "cannot move script level #{script_level.id} between lessons"
       end
+      return script_level
     end
 
     script_levels.create(


### PR DESCRIPTION
Follow-on to https://github.com/code-dot-org/code-dot-org/pull/37520. Actually finishes [PLAT-463].

During the bug bash, curriculum writers saw this problem:
![move-level-down](https://user-images.githubusercontent.com/8001765/97761258-742cc200-1ac2-11eb-85a2-483b274375bc.gif)

The problem with the previous fix in https://github.com/code-dot-org/code-dot-org/pull/37520 is that I only tested moving a level to an _earlier_ activity section. in that case, the script level id still existed at the time we were looking for it, so everything worked. Conversely, moving a script level _later_ does not work, because it would be destroyed when we updated the activity section it was removed from, and then looking for it by id later would fail.

This PR solves the problem by always destroying and re-creating a script level when moving it between activity sections. This option seemed a lot simpler than trying to preserve script levels when they are moved around within a lesson, because the `dependent: :destroy` clause both makes it easy to make sure stray script levels are not left behind, and also makes it hard to move script levels without destroying them. Arguably, this also points us in the right direction of treating activity section (rather than lesson or script) as the owner of script levels, since they sit just below Activity Section in the hierarchy.

## Testing story

Added new unit test, and verified that is was failing before the code change and passing after.

Manually verified the previously failing scenario is working:
![move-level-down-correctly](https://user-images.githubusercontent.com/8001765/97761589-4d22c000-1ac3-11eb-9f15-563ea1a10b54.gif)

Manually verified moving many levels around works:
![move-level-all-over](https://user-images.githubusercontent.com/8001765/97761732-b86c9200-1ac3-11eb-879f-adbf08a4c9bd.gif)

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked


[PLAT-463]: https://codedotorg.atlassian.net/browse/PLAT-463