### PR TITLE
Minecraft Decorative Stone Fix

### DIFF
--- a/dashboard/config/blocks/craft/craft_placeBlock.json
+++ b/dashboard/config/blocks/craft/craft_placeBlock.json
@@ -29,7 +29,7 @@
           ],
           [
             "decorative stone bricks",
-            "\"decorativeStoneBricks\""
+            "\"chiseledStoneBricks\""
           ],
           [
             "blue coral block",

--- a/i18n/locales/source/dashboard/blocks.yml
+++ b/i18n/locales/source/dashboard/blocks.yml
@@ -1881,7 +1881,6 @@ en:
             '"mossyStoneBricks"': mossy stone bricks
             '"crackedStoneBricks"': cracked stone bricks
             '"decorativeStoneBricks"': decorative stone bricks
-            '"chisledStoneBricks"': decorative stone bricks
             '"blueCoralBlock"': blue coral block
             '"pinkCoralBlock"': pink coral block
             '"magentaCoralBlock"': magenta coral block

--- a/i18n/locales/source/dashboard/blocks.yml
+++ b/i18n/locales/source/dashboard/blocks.yml
@@ -1881,6 +1881,7 @@ en:
             '"mossyStoneBricks"': mossy stone bricks
             '"crackedStoneBricks"': cracked stone bricks
             '"decorativeStoneBricks"': decorative stone bricks
+            '"chisledStoneBricks"': decorative stone bricks
             '"blueCoralBlock"': blue coral block
             '"pinkCoralBlock"': pink coral block
             '"magentaCoralBlock"': magenta coral block


### PR DESCRIPTION
Reported via Zendesk: https://codeorg.zendesk.com/agent/tickets/298053

Issue: When users added 'placeBlock(decorativeStoneBrick)', the tab would freeze and need to be refreshed.
Cause: We refer to decorativeStoneBrick in Code.org material but it's called chiseledStoneBrick in Minecraft world, so our code was getting lost when trying to find decorativeStoneBrick.
Fix: Point our decorativeStoneBrick to Minecraft's chiseledStoneBrick.

Note: This doesn't fix old projects that refer to decorativeStoneBrick. Those projects will still be broken, but can be fixed if the user re-selects decorativeStoneBrick.

Here is the current situation on prod:
![current](https://user-images.githubusercontent.com/2959170/97763943-59f6e200-1aca-11eb-8bc2-5afab95dd1dd.gif)


After this change - new project:
![newproject](https://user-images.githubusercontent.com/2959170/97763969-67ac6780-1aca-11eb-8e38-97261dbecabb.gif)


After this change - old project:
![oldproject](https://user-images.githubusercontent.com/2959170/97763997-6f6c0c00-1aca-11eb-8b46-a42d991015a9.gif)


## Testing story

Tested locally.

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
