### PR TITLE
Test a different level for the dropdown UI test

### DIFF
--- a/dashboard/test/ui/features/star_labs/dropdown.feature
+++ b/dashboard/test/ui/features/star_labs/dropdown.feature
@@ -1,7 +1,7 @@
 Feature: Dropdowns work as expected
 
 Background:
-  Given I am on "http://studio.code.org/s/basketball/stage/1/puzzle/5"
+  Given I am on "http://studio.code.org/s/sports/stage/1/puzzle/5"
 
 Scenario: Drag a dropdown and select a different option.
   When I rotate to landscape

--- a/dashboard/test/ui/features/star_labs/dropdown.feature
+++ b/dashboard/test/ui/features/star_labs/dropdown.feature
@@ -1,15 +1,15 @@
 Feature: Dropdowns work as expected
 
 Background:
-  Given I am on "http://studio.code.org/flappy/1?noautoplay=true"
+  Given I am on "http://studio.code.org/s/basketball/stage/1/puzzle/5"
 
 Scenario: Drag a dropdown and select a different option.
   When I rotate to landscape
   And I wait for the page to fully load
-  And I drag the play sound block to offset "200, 100"
-  And I press dropdown number 6
+  And I drag block "4" to offset "250, 100"
+  And I press dropdown number 11
   Then the dropdown is visible
-  Then I select item 9 from the dropdown
+  Then I select item 2 from the dropdown
   And I wait for 1 seconds
   Then the dropdown is hidden
-  And the dropdown field has text "crash ▼"
+  And the dropdown field has text "whistle ▼"

--- a/dashboard/test/ui/features/star_labs/dropdown.feature
+++ b/dashboard/test/ui/features/star_labs/dropdown.feature
@@ -1,7 +1,7 @@
 Feature: Dropdowns work as expected
 
 Background:
-  Given I am on "http://studio.code.org/s/sports/stage/1/puzzle/5"
+  Given I am on "http://studio.code.org/s/sports/stage/1/puzzle/5?noautoplay=true"
 
 Scenario: Drag a dropdown and select a different option.
   When I rotate to landscape

--- a/dashboard/test/ui/features/step_definitions/dropdown.rb
+++ b/dashboard/test/ui/features/step_definitions/dropdown.rb
@@ -33,6 +33,7 @@ end
 
 Then /^the dropdown field has text "(.*?)"$/ do |text|
   id_selector = get_id_selector
+  # This step definition is only used in dropdown.feature, where the relevant dropdown is on the 9th block.
   element_has_text("[#{id_selector}='9'] .blocklyEditableText", text)
 end
 

--- a/dashboard/test/ui/features/step_definitions/dropdown.rb
+++ b/dashboard/test/ui/features/step_definitions/dropdown.rb
@@ -46,7 +46,7 @@ end
 
 Then /^the dropdown field has text "(.*?)"$/ do |text|
   id_selector = get_id_selector
-  element_has_text("[#{id_selector}='4'] .blocklyEditableText", text)
+  element_has_text("[#{id_selector}='9'] .blocklyEditableText", text)
 end
 
 And /^I press the image dropdown$/ do

--- a/dashboard/test/ui/features/step_definitions/dropdown.rb
+++ b/dashboard/test/ui/features/step_definitions/dropdown.rb
@@ -13,19 +13,6 @@ And /^I press dropdown number (\d+)$/ do |n|
   end
 end
 
-Then /^the Google Blockly dropdown is (.*)$/ do |visibility|
-  if visibility == "visible"
-    expected = 1
-  elsif visibility == "hidden"
-    expected = 0
-  else
-    raise "unexpected visibility"
-  end
-
-  element = @browser.find_element(:class, 'blocklyDropDownDiv')
-  expect(element.attribute('style').match(Regexp.new("opacity: #{expected}"))).not_to eq(nil)
-end
-
 Then /^the dropdown is (.*)$/ do |visibility|
   if visibility == "visible"
     expected = 'block'


### PR DESCRIPTION
Ok so this test starts failing on IE11 when we try to switch over to the new Blockly. After much digging, I think there's just not a good way to simulate click events on the dropdown field with the new Blockly.
I think this is okay for a couple reasons:
- Once we're switched over to Google Blockly, we can rely on their test coverage for some things. They support IE11, and this test just changes the value in a dropdown. This is a super basic Blockly feature (no customizations on our end), so I think it's a pretty safe bet that they wouldn't ship a release that breaks this.
- The choice of what level this tests against is fairly arbitrary to begin with. We still have the same coverage of our Blockly code.

Before:
![image](https://user-images.githubusercontent.com/8787187/97769720-a9e5a100-1aea-11eb-9255-fbdee037f983.png)

After:
![image](https://user-images.githubusercontent.com/8787187/97769714-9f2b0c00-1aea-11eb-85da-fcb68031c7db.png)


Passes on Chrome and IE11
![image](https://user-images.githubusercontent.com/8787187/97769726-b669f980-1aea-11eb-88c7-0f95e4531c31.png)
