### PR TITLE
[Google Blockly] Always use Google Blockly for Flappy levels

### DIFF
--- a/dashboard/app/helpers/levels_helper.rb
+++ b/dashboard/app/helpers/levels_helper.rb
@@ -311,7 +311,7 @@ module LevelsHelper
     use_blockly = !use_droplet && !use_netsim && !use_weblab
     use_p5 = @level.is_a?(Gamelab)
     hide_source = app_options[:hideSource]
-    use_google_blockly = view_options[:useGoogleBlockly]
+    use_google_blockly = @level.is_a?(Flappy) || view_options[:useGoogleBlockly]
     render partial: 'levels/apps_dependencies',
       locals: {
         app: app_options[:app],

--- a/dashboard/test/ui/features/star_labs/blocklayout.feature
+++ b/dashboard/test/ui/features/star_labs/blocklayout.feature
@@ -8,12 +8,12 @@ Background:
 Scenario: Auto-placing malformed start blocks
   When I've initialized the workspace with an auto-positioned flappy puzzle with extra newlines
   Then block "18" is near offset "16, 16"
-  And block "21" is near offset "16, 107"
+  And block "21" is near offset "16, 114"
 
 Scenario: Auto-placing blocks
   When I've initialized the workspace with an auto-positioned flappy puzzle
   Then block "18" is near offset "16, 16"
-  And block "21" is near offset "16, 107"
+  And block "21" is near offset "16, 114"
 
 Scenario: Auto-placing blocks with XML positioning
   Given I am on "http://studio.code.org/s/allthethings/stage/5/puzzle/4?noautoplay=true"

--- a/dashboard/test/ui/features/star_labs/dropdown.feature
+++ b/dashboard/test/ui/features/star_labs/dropdown.feature
@@ -1,7 +1,7 @@
 Feature: Dropdowns work as expected
 
 Background:
-  Given I am on "http://studio.code.org/s/basketball/stage/1/puzzle/5"
+  Given I am on "http://studio.code.org/s/sports/stage/1/puzzle/5"
 
 Scenario: Drag a dropdown and select a different option.
   When I rotate to landscape

--- a/dashboard/test/ui/features/star_labs/dropdown.feature
+++ b/dashboard/test/ui/features/star_labs/dropdown.feature
@@ -1,7 +1,7 @@
 Feature: Dropdowns work as expected
 
 Background:
-  Given I am on "http://studio.code.org/s/sports/stage/1/puzzle/5"
+  Given I am on "http://studio.code.org/s/sports/stage/1/puzzle/5?noautoplay=true"
 
 Scenario: Drag a dropdown and select a different option.
   When I rotate to landscape

--- a/dashboard/test/ui/features/star_labs/dropdown.feature
+++ b/dashboard/test/ui/features/star_labs/dropdown.feature
@@ -7,9 +7,9 @@ Scenario: Drag a dropdown and select a different option.
   When I rotate to landscape
   And I wait for the page to fully load
   And I drag the play sound block to offset "200, 100"
-  And I press dropdown number 6
-  Then the dropdown is visible
+  And I press dropdown number 2
+  Then the Google Blockly dropdown is visible
   Then I select item 9 from the dropdown
   And I wait for 1 seconds
-  Then the dropdown is hidden
-  And the dropdown field has text "crash ▼"
+  Then the Google Blockly dropdown is hidden
+  And the dropdown field has text "crash ▾"

--- a/dashboard/test/ui/features/star_labs/dropdown.feature
+++ b/dashboard/test/ui/features/star_labs/dropdown.feature
@@ -1,15 +1,15 @@
 Feature: Dropdowns work as expected
 
 Background:
-  Given I am on "http://studio.code.org/flappy/1?noautoplay=true"
+  Given I am on "http://studio.code.org/s/basketball/stage/1/puzzle/5"
 
 Scenario: Drag a dropdown and select a different option.
   When I rotate to landscape
   And I wait for the page to fully load
-  And I drag the play sound block to offset "200, 100"
-  And I press dropdown number 2
-  Then the Google Blockly dropdown is visible
-  Then I select item 9 from the dropdown
+  And I drag block "4" to offset "250, 100"
+  And I press dropdown number 11
+  Then the dropdown is visible
+  Then I select item 2 from the dropdown
   And I wait for 1 seconds
-  Then the Google Blockly dropdown is hidden
-  And the dropdown field has text "crash ▾"
+  Then the dropdown is hidden
+  And the dropdown field has text "whistle ▼"

--- a/dashboard/test/ui/features/star_labs/flappydrag.feature
+++ b/dashboard/test/ui/features/star_labs/flappydrag.feature
@@ -8,4 +8,4 @@ Scenario: Connect two blocks from toolbox
   And I drag block "1" to block "3"
   And I drag block "1" to block "4"
   And I wait for 1 seconds
-  Then block "5" is child of block "4"
+  Then block "6" is child of block "4"

--- a/dashboard/test/ui/features/step_definitions/dropdown.rb
+++ b/dashboard/test/ui/features/step_definitions/dropdown.rb
@@ -33,6 +33,7 @@ end
 
 Then /^the dropdown field has text "(.*?)"$/ do |text|
   id_selector = get_id_selector
+  # This step definition is only used in dropdown.feature, where the relevant dropdown is on the 9th block.
   element_has_text("[#{id_selector}='9'] .blocklyEditableText", text)
 end
 

--- a/dashboard/test/ui/features/step_definitions/dropdown.rb
+++ b/dashboard/test/ui/features/step_definitions/dropdown.rb
@@ -46,7 +46,7 @@ end
 
 Then /^the dropdown field has text "(.*?)"$/ do |text|
   id_selector = get_id_selector
-  element_has_text("[#{id_selector}='4'] .blocklyEditableText", text)
+  element_has_text("[#{id_selector}='9'] .blocklyEditableText", text)
 end
 
 And /^I press the image dropdown$/ do

--- a/dashboard/test/ui/features/step_definitions/dropdown.rb
+++ b/dashboard/test/ui/features/step_definitions/dropdown.rb
@@ -13,19 +13,6 @@ And /^I press dropdown number (\d+)$/ do |n|
   end
 end
 
-Then /^the Google Blockly dropdown is (.*)$/ do |visibility|
-  if visibility == "visible"
-    expected = 1
-  elsif visibility == "hidden"
-    expected = 0
-  else
-    raise "unexpected visibility"
-  end
-
-  element = @browser.find_element(:class, 'blocklyDropDownDiv')
-  expect(element.attribute('style').match(Regexp.new("opacity: #{expected}"))).not_to eq(nil)
-end
-
 Then /^the dropdown is (.*)$/ do |visibility|
   if visibility == "visible"
     expected = 'block'


### PR DESCRIPTION
This is a 4th attempt at shipping Flappy with Google Blockly

1st attempt: https://github.com/code-dot-org/code-dot-org/pull/37459
Reverted: https://github.com/code-dot-org/code-dot-org/pull/37542
This failed because UI tests caught a major regression on IE. That regression was fixed with https://github.com/code-dot-org/code-dot-org/pull/37547

2nd attempt: https://github.com/code-dot-org/code-dot-org/pull/37549
Reverted: https://github.com/code-dot-org/code-dot-org/pull/37555
This failed because the Block ID was not available on the SVG element in IE. I opened an [issue with Blockly](https://github.com/google/blockly/issues/4419), and added the workaround [here](https://github.com/code-dot-org/code-dot-org/blob/staging/apps/src/blocklyAddons/cdoBlockSvg.js#L9)

3rd attempt: https://github.com/code-dot-org/code-dot-org/pull/37559
Revert: https://github.com/code-dot-org/code-dot-org/pull/37583
This failed because click events issued by Selenium are not working for Google Blockly blocks in IE. I fixed this test issue with https://github.com/code-dot-org/code-dot-org/pull/37601

Some screenshots of the tests that had been failing passing via Saucelabs tunnel:
![image](https://user-images.githubusercontent.com/8787187/97903577-1bdd0680-1cf4-11eb-820d-35057814685f.png)



