### PR TITLE
Set max width on the tooltip with LessonTip Preview

### DIFF
--- a/apps/src/lib/levelbuilder/lesson-editor/LessonTipIconWithTooltip.jsx
+++ b/apps/src/lib/levelbuilder/lesson-editor/LessonTipIconWithTooltip.jsx
@@ -37,7 +37,9 @@ export default class LessonTipIconWithTooltip extends Component {
           effect="solid"
           disable={false}
         >
-          <LessonTip tip={tip} />
+          <div style={{maxWidth: 400}}>
+            <LessonTip tip={tip} />
+          </div>
         </ReactTooltip>
       </span>
     );


### PR DESCRIPTION
Fixes issue where tip would get really wide sometimes which was reported during [bug bash](https://docs.google.com/document/d/1OKoxDQtYfFPEbUEIv5IWUPL9IoEl8t-NwfIKgZc3THE/edit#).

![Screen Shot 2020-11-02 at 4 54 02 PM](https://user-images.githubusercontent.com/208083/97923639-4fd41e00-1d2c-11eb-9224-8843c994d97c.png)
