### PR TITLE
Convert "english fallback" test from UI to Unit

### DIFF
--- a/dashboard/test/config/application_test.rb
+++ b/dashboard/test/config/application_test.rb
@@ -1,0 +1,34 @@
+require 'test_helper'
+
+class ApplicationTest < ActiveSupport::TestCase
+  test 'untranslated i18n strings fall back to english' do
+    # First, load string into English
+    english_strings = {
+      "data" => {
+        "test" => {
+          "example": "english"
+        }
+      }
+    }
+    I18n.backend.store_translations I18n.default_locale, english_strings
+    assert_equal I18n.t("data.test.example"), "english"
+
+    # Second, verify that we get the English string back even from another
+    # locale
+    test_locale = :"te-ST"
+    I18n.locale = test_locale
+    assert_equal I18n.t("data.test.example"), "english"
+
+    # Third, load a translation in and verify that we now get the translation
+    # back rather than English.
+    translated_strings = {
+      "data" => {
+        "test" => {
+          "example": "translated"
+        }
+      }
+    }
+    I18n.backend.store_translations test_locale, translated_strings
+    assert_equal I18n.t("data.test.example"), "translated"
+  end
+end

--- a/dashboard/test/ui/features/foundations/i18n.feature
+++ b/dashboard/test/ui/features/foundations/i18n.feature
@@ -157,19 +157,3 @@ Scenario: Toolbox Categories in Arabic (RTL)
   Then element ".blocklyTreeRoot #\\:7" has "ar-SA" text from key "data.block_categories.Logic"
   Then element ".blocklyTreeRoot #\\:8" has "ar-SA" text from key "data.block_categories.Math"
   Then element ".blocklyTreeRoot #\\:9" has "ar-SA" text from key "data.block_categories.Text"
-
-Scenario: English fallback for missing dashboard or pegasus strings in Azerbaijani
-  Given I am on "http://studio.code.org/lang/az-az"
-  And I wait to see ".headerlink"
-  Then element "#header-non-en-projects" contains text "Layihə qalereyası"
-  But element "#header-non-en-courses" contains text "Course Catalog"
-  Given I am on "http://code.org"
-  And I wait to see ".headerlink"
-  Then element "#header-non-en-projects" contains text "Layihə qalereyası"
-  But element "#header-non-en-courses" contains text "Course Catalog"
-
-Scenario: English fallback for missing apps string in Azerbaijani
-  Given I am on "http://studio.code.org/s/sports/stage/1/puzzle/8/lang/az-az"
-  And I wait for the page to fully load
-  Then block "7" contains text "yeni top at"
-  But block "8" contains text "set basketball scene"


### PR DESCRIPTION
Because the former was relying on the strings to actually remain untranslated in our system. This assumption broke in https://github.com/code-dot-org/code-dot-org/pull/37603 when we translated those strings.

Instead of continuing to rely on existing strings, I'm converting this over to use a unit test which adds its own strings.

<!--
  Your description goes here: A summary of the change, including any relevant motivation and context.

  If relevant, include a description both of the existing behavior and of the new behavior.
-->

<!--
  Other aspects to consider. uncomment and add detail for any that seem necessary:
-->

<!-- ### Background -->
<!-- ### Privacy -->
<!--
1.	Does the Project involve the collection, use or sharing of new Personal Data?

2.	Does the Project involve a new or changed use or sharing of existing Personal Data?
-->
<!-- ### Security -->
<!--
Link to Jira Task where sensitive security issues are discussed privately.
-->
<!-- ### Caching -->
<!-- ### Deployment strategy -->
<!-- ### Future work -->

## Links

<!--
  Any relevant links to external resources; ie, specification documents, jira
  items, related PRs, honeybadger errors, etc
-->

Tests originally added in https://github.com/code-dot-org/code-dot-org/pull/23948

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
