### PR TITLE
Don't unnecessarily CGI-escape already-urlsafe strings

### DIFF
--- a/pegasus/test/test_hoc_routes.rb
+++ b/pegasus/test/test_hoc_routes.rb
@@ -50,7 +50,7 @@ class HocRoutesTest < Minitest::Test
 
     it 'ends given tutorial, providing script ID to congrats page' do
       assert_redirects_from_to '/api/hour/finish/mc', '/congrats'
-      assert_includes @pegasus.last_request.url, "&s=#{CGI.escape(Base64.urlsafe_encode64('mc'))}"
+      assert_includes @pegasus.last_request.url, "&s=#{Base64.urlsafe_encode64('mc')}"
     end
 
     it 'has certificate share page' do
@@ -96,7 +96,7 @@ class HocRoutesTest < Minitest::Test
         assert after_start_row[:started_at]
 
         assert_redirects_from_to '/api/hour/finish/mc', '/congrats'
-        assert_includes @pegasus.last_request.url, "&s=#{CGI.escape(Base64.urlsafe_encode64('mc'))}"
+        assert_includes @pegasus.last_request.url, "&s=#{Base64.urlsafe_encode64('mc')}"
         assert_includes @pegasus.last_request.url, '&co=testcompany'
 
         after_end_row = get_session_hoc_activity_entry
@@ -123,7 +123,7 @@ class HocRoutesTest < Minitest::Test
         assert after_start_row[:started_at]
 
         assert_redirects_from_to '/api/hour/finish/mc', '/congrats'
-        assert_includes @pegasus.last_request.url, "&s=#{CGI.escape(Base64.urlsafe_encode64('mc'))}"
+        assert_includes @pegasus.last_request.url, "&s=#{Base64.urlsafe_encode64('mc')}"
         assert_includes @pegasus.last_request.url, '&co=testcompany'
 
         after_end_row = get_session_hoc_activity_entry
@@ -152,7 +152,7 @@ class HocRoutesTest < Minitest::Test
         assert after_start_row[:started_at]
 
         assert_redirects_from_to '/api/hour/finish/mc', '/congrats'
-        assert_includes @pegasus.last_request.url, "&s=#{CGI.escape(Base64.urlsafe_encode64('mc'))}"
+        assert_includes @pegasus.last_request.url, "&s=#{Base64.urlsafe_encode64('mc')}"
         assert_includes @pegasus.last_request.url, '&co=testcompany'
 
         after_end_row = get_session_hoc_activity_entry


### PR DESCRIPTION
We don't do this in the code itself, and there's no reason to do it in tests.

Also, for some reason, this started failing when I tried to upgrade Rails to 5.1

<!--
  Your description goes here: A summary of the change, including any relevant motivation and context.

  If relevant, include a description both of the existing behavior and of the new behavior.
-->

<!--
  Other aspects to consider. uncomment and add detail for any that seem necessary:
-->

<!-- ### Background -->
<!-- ### Privacy -->
<!--
1.	Does the Project involve the collection, use or sharing of new Personal Data?

2.	Does the Project involve a new or changed use or sharing of existing Personal Data?
-->
<!-- ### Security -->
<!--
Link to Jira Task where sensitive security issues are discussed privately.
-->
<!-- ### Caching -->
<!-- ### Deployment strategy -->
<!-- ### Future work -->

## Links

<!--
  Any relevant links to external resources; ie, specification documents, jira
  items, related PRs, honeybadger errors, etc
-->

- [spec]()
- [jira]()

## Testing story

<!--
  Does your change include appropriate tests?

  If so, please describe how the tests included in this PR are sufficient

  If not, please explain why this change does not need to be tested.
-->

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
