### PR TITLE
AILab: adjust container layout

### DIFF
--- a/apps/src/ailab/AilabView.jsx
+++ b/apps/src/ailab/AilabView.jsx
@@ -5,14 +5,15 @@ import {connect} from 'react-redux';
 import StudioAppWrapper from '../templates/StudioAppWrapper';
 import InstructionsWithWorkspace from '../templates/instructions/InstructionsWithWorkspace';
 import CodeWorkspaceContainer from '../templates/CodeWorkspaceContainer';
-import _ from 'lodash';
 
 const styles = {
   container: {
     position: 'relative',
     margin: '0 auto',
     userSelect: 'none',
-    overflow: 'scroll'
+    overflow: 'scroll',
+    width: '100%',
+    height: 'calc(100% - 35px)'
   },
   containerReact: {
     position: 'absolute',
@@ -22,18 +23,6 @@ const styles = {
     fontFamily: '"Gotham 4r", arial, sans-serif',
     color: 'rgb(30,30,30)',
     lineHeight: 1.3
-  },
-  backgroundCanvas: {
-    position: 'absolute',
-    left: 0,
-    width: '100%',
-    zIndex: -1,
-    borderRadius: '10px'
-  },
-  activityCanvas: {
-    width: '100%',
-    borderRadius: '10px',
-    border: 'none'
   }
 };
 
@@ -51,126 +40,19 @@ class AilabView extends React.Component {
     super(props);
 
     this.codeAppRef = document.getElementById('codeApp');
-
-    // We have seen on Android devices that window.innerHeight will always be the
-    // same whether in landscape or portrait orientation.  Given that we tell
-    // users to rotate to landscape, adjust to match what we see on iOS devices.
-    const windowWidth = Math.max(window.innerWidth, window.innerHeight);
-    const windowHeight = Math.min(window.innerWidth, window.innerHeight);
-
-    // Set these values so that the first render can work with them.
-    // Note that appWidth/Height are the dimensions of the "codeApp" div
-    // which is the space allocated for an app.
-    this.state = {
-      windowWidth,
-      windowHeight,
-      appWidth: this.codeAppRef.offsetWidth,
-      appHeight: this.codeAppRef.offsetHeight
-    };
   }
 
   componentDidMount() {
     this.props.onMount();
-
-    const windowWidth = Math.max(window.innerWidth, window.innerHeight);
-    const windowHeight = Math.min(window.innerWidth, window.innerHeight);
-
-    this.setState({
-      windowWidth,
-      windowHeight,
-      appWidth: this.codeAppRef.offsetWidth,
-      appHeight: this.codeAppRef.offsetHeight
-    });
-
-    const resizeThrottleWaitTime = 100;
-    this.resizeListener = _.throttle(this.onResize, resizeThrottleWaitTime);
-    window.addEventListener('resize', this.resizeListener);
-    if (window.visualViewport) {
-      window.visualViewport.addEventListener('resize', this.resizeListener);
-      window.visualViewport.addEventListener('scroll', this.resizeListener);
-    }
   }
 
-  onResize = () => {
-    const windowWidth = Math.max(window.innerWidth, window.innerHeight);
-    const windowHeight = Math.min(window.innerWidth, window.innerHeight);
-
-    // Check that the window dimensions have actually changed to avoid
-    // unnecessary event-processing on iOS Safari.
-    if (
-      this.state.windowWidth !== windowWidth ||
-      this.state.windowHeight !== windowHeight
-    ) {
-      const appWidth = this.codeAppRef.offsetWidth;
-      const appHeight = this.codeAppRef.offsetHeight;
-
-      this.setState({windowWidth, windowHeight, appWidth, appHeight});
-    }
-  };
-
   render() {
-    // The tutorial has a width:height ratio of 16:9.
-    const aspectRatio = 16 / 9;
-
-    // Let's minimize the tutorial width at 320px.
-    const minAppWidth = 320;
-
-    // Let's maximize the tutorial width at 1280px.
-    const maxAppWidth = 1280;
-
-    // Leave space above the small footer.
-    const reduceAppHeight = 36;
-
-    // Specify a baseline font at a baseline width.
-    const baselineFontSize = 18;
-    const baselineAppWidth = 930;
-
-    let containerWidth, containerHeight;
-
-    // Constrain tutorial to maximum width.
-    const maxContainerWidth = Math.min(this.state.appWidth, maxAppWidth);
-
-    // Use the smaller of the space allocated for the app and the window height,
-    // and leave space above the small footer.
-    const maxContainerHeight =
-      Math.min(this.state.appHeight, this.state.windowHeight) - reduceAppHeight;
-
-    if (maxContainerWidth / maxContainerHeight > aspectRatio) {
-      // Constrain by height.
-      containerWidth = maxContainerHeight * aspectRatio;
-    } else {
-      // Constrain by width.
-      containerWidth = maxContainerWidth;
-    }
-
-    // Constrain tutorial to minimum width;
-    if (containerWidth < minAppWidth) {
-      containerWidth = minAppWidth;
-    }
-
-    // Calculate the height.
-    containerHeight = containerWidth / aspectRatio;
-
-    // The tutorial shows 18px fonts when 930px wide.
-    const baseFontSize = (baselineFontSize * containerWidth) / baselineAppWidth;
-
     return (
       <StudioAppWrapper>
         <InstructionsWithWorkspace>
           <CodeWorkspaceContainer topMargin={0}>
-            <div
-              id="ailab-container"
-              style={{
-                ...styles.container,
-                width: Math.round(containerWidth),
-                height: Math.round(containerHeight)
-              }}
-              dir="ltr"
-            >
-              <div
-                id="root"
-                style={{...styles.containerReact, fontSize: baseFontSize}}
-              />
+            <div style={styles.container}>
+              <div id="root" style={styles.containerReact} />
             </div>
           </CodeWorkspaceContainer>
         </InstructionsWithWorkspace>


### PR DESCRIPTION
The content always fits the available space, and doesn't go behind the footer.  Nothing complicated is needed for now.

![Screen Shot 2020-11-02 at 6 00 48 PM](https://user-images.githubusercontent.com/2205926/97938160-8b271a80-1d35-11eb-83b4-949b529407a3.png)
