### PR TITLE
Show announcements on Lesson Plan for Teachers

### DIFF
--- a/apps/src/sites/studio/pages/lessons/show.js
+++ b/apps/src/sites/studio/pages/lessons/show.js
@@ -9,10 +9,12 @@ import {getStore} from '@cdo/apps/code-studio/redux';
 import {registerReducers} from '@cdo/apps/redux';
 import {Provider} from 'react-redux';
 import _ from 'lodash';
+import {setViewType, ViewType} from '@cdo/apps/code-studio/viewAsRedux';
 
 $(document).ready(function() {
   const lessonData = getScriptData('lesson');
   const activities = lessonData['activities'];
+  const isTeacher = lessonData['is_teacher'];
 
   // Rename any keys that are different on the backend.
   activities.forEach(activity => {
@@ -49,6 +51,10 @@ $(document).ready(function() {
   });
 
   const store = getStore();
+
+  if (isTeacher) {
+    store.dispatch(setViewType(ViewType.Teacher));
+  }
 
   if (lessonData.announcements) {
     registerReducers({announcements: announcementsReducer});

--- a/dashboard/app/controllers/lessons_controller.rb
+++ b/dashboard/app/controllers/lessons_controller.rb
@@ -34,7 +34,7 @@ class LessonsController < ApplicationController
       activities: @lesson.lesson_activities.map(&:summarize_for_lesson_show),
       resources: @lesson.resources_for_lesson_plan(@current_user&.authorized_teacher?),
       objectives: @lesson.objectives.map(&:summarize_for_lesson_show),
-      is_teacher: @current_user.teacher?
+      is_teacher: @current_user&.teacher?
     }
   end
 

--- a/dashboard/app/controllers/lessons_controller.rb
+++ b/dashboard/app/controllers/lessons_controller.rb
@@ -33,7 +33,8 @@ class LessonsController < ApplicationController
       preparation: @lesson.preparation || '',
       activities: @lesson.lesson_activities.map(&:summarize_for_lesson_show),
       resources: @lesson.resources_for_lesson_plan(@current_user&.authorized_teacher?),
-      objectives: @lesson.objectives.map(&:summarize_for_lesson_show)
+      objectives: @lesson.objectives.map(&:summarize_for_lesson_show),
+      is_teacher: @current_user.teacher?
     }
   end
 


### PR DESCRIPTION
Announcements were not showing during the bug bash for teacher accounts because we were not setting the viewAsRedux if the person is a teacher. This fixes that so announcements show for teachers and students now.

<img width="1183" alt="Screen Shot 2020-11-02 at 9 15 29 PM" src="https://user-images.githubusercontent.com/208083/97938867-8b80df00-1d50-11eb-9c90-c3fd019f1604.png">

## Links

<!--
  Any relevant links to external resources; ie, specification documents, jira
  items, related PRs, honeybadger errors, etc
-->

- [Bug Bash](https://docs.google.com/document/d/1OKoxDQtYfFPEbUEIv5IWUPL9IoEl8t-NwfIKgZc3THE/edit#)
- [jira](https://codedotorg.atlassian.net/browse/PLAT-487)

## Testing story

Should I add this to the UI test?

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
