### PR TITLE
Update HelpTip for lockable

### DIFF
--- a/apps/src/lib/levelbuilder/lesson-editor/LessonEditor.jsx
+++ b/apps/src/lib/levelbuilder/lesson-editor/LessonEditor.jsx
@@ -105,9 +105,8 @@ export default class LessonEditor extends Component {
             />
             <HelpTip>
               <p>
-                Check this box if this lesson should be locked from teachers.
-                Only validated teachers will be able to see it and unlock the
-                materials.
+                Check this box if this lesson should be locked for students and
+                teachers can unlock it for their students.
               </p>
             </HelpTip>
           </label>

--- a/apps/src/lib/levelbuilder/lesson-editor/LessonEditor.jsx
+++ b/apps/src/lib/levelbuilder/lesson-editor/LessonEditor.jsx
@@ -105,8 +105,9 @@ export default class LessonEditor extends Component {
             />
             <HelpTip>
               <p>
-                Check this box if this lesson should be locked for students and
-                teachers can unlock it for their students.
+                Check this box if this lesson should be locked for students. If
+                checked, teachers will be able to unlock the lesson for their
+                students.
               </p>
             </HelpTip>
           </label>


### PR DESCRIPTION
Fixes the HelpTip for lockable on the Lesson Edit page which was reported to be confusing during the [bug bash](https://docs.google.com/document/d/1OKoxDQtYfFPEbUEIv5IWUPL9IoEl8t-NwfIKgZc3THE/edit#).

<img width="581" alt="Screen Shot 2020-11-02 at 9 38 26 PM" src="https://user-images.githubusercontent.com/208083/97944833-bfa9cf00-1d53-11eb-8f90-7f9a0c0ba555.png">
