### PR TITLE
Update Tip Styling on Lesson Plan

### DIFF
--- a/apps/src/templates/lessonOverview/activities/ActivitySection.jsx
+++ b/apps/src/templates/lessonOverview/activities/ActivitySection.jsx
@@ -43,6 +43,18 @@ export default class ActivitySection extends Component {
 
     const sectionHasTips = section.tips.length > 0;
 
+    let tipsTotalLength = 0;
+    section.tips.forEach(tip => {
+      tipsTotalLength += tip.markdown.length;
+    });
+    const totalLengthOfSectionText = section.text.length + tipsTotalLength;
+    // The width of the tip based on the length of the text of the tip and the activity section
+    // The minimum width the activity section can have is 25
+    const tipWidth = Math.min(
+      Math.round((tipsTotalLength / totalLengthOfSectionText) * 100),
+      75
+    );
+
     return (
       <div>
         {!isProgressionSection && (
@@ -76,9 +88,22 @@ export default class ActivitySection extends Component {
               );
             })}
           </div>
-          {!isProgressionSection && <SafeMarkdown markdown={section.text} />}
-          {isProgressionSection && <ProgressionDetails progression={section} />}
-          <div style={{...styles.tips, ...(sectionHasTips && {width: '40%'})}}>
+          {!isProgressionSection && (
+            <div style={{width: `${100 - tipWidth}%`}}>
+              <SafeMarkdown markdown={section.text} />
+            </div>
+          )}
+          {isProgressionSection && (
+            <div style={{width: `${100 - tipWidth}%`}}>
+              <ProgressionDetails progression={section} />
+            </div>
+          )}
+          <div
+            style={{
+              ...styles.tips,
+              ...(sectionHasTips && {width: `${tipWidth}%`, marginLeft: 5})
+            }}
+          >
             {section.tips.map((tip, index) => {
               return <LessonTip key={`tip-${index}`} tip={tip} />;
             })}

--- a/apps/src/templates/lessonOverview/activities/ActivitySection.jsx
+++ b/apps/src/templates/lessonOverview/activities/ActivitySection.jsx
@@ -18,6 +18,7 @@ const styles = {
     display: 'flex',
     flexDirection: 'column',
     width: 20,
+    padding: 5,
     alignItems: 'center'
   },
   tips: {

--- a/apps/src/templates/lessonOverview/activities/ActivitySection.jsx
+++ b/apps/src/templates/lessonOverview/activities/ActivitySection.jsx
@@ -70,6 +70,7 @@ export default class ActivitySection extends Component {
                 <FontAwesome
                   key={`tipIcon-${index}`}
                   icon={tipTypes[tip.type].icon}
+                  style={{color: tipTypes[tip.type].color}}
                 />
               );
             })}


### PR DESCRIPTION
- Tip icon are colored the correct tip color
- Add padding on the tip icon
- Try to better space the tips and activity section markdown 

Updated based on feedback from the [bug bash](https://docs.google.com/document/d/1OKoxDQtYfFPEbUEIv5IWUPL9IoEl8t-NwfIKgZc3THE/edit#)

<img width="514" alt="Screen Shot 2020-11-02 at 10 09 55 PM" src="https://user-images.githubusercontent.com/208083/97946488-98093580-1d58-11eb-86c0-50c54cbb69d1.png">
