### PR TITLE
Invalidate script cache on test machine during ui tests

### DIFF
--- a/dashboard/app/controllers/test_controller.rb
+++ b/dashboard/app/controllers/test_controller.rb
@@ -100,6 +100,13 @@ class TestController < ApplicationController
     render json: {script_name: script.name, lesson_id: lesson.id}
   end
 
+  # invalidate the specified script from the script cache, so that it will be
+  # reloaded from the DB the next time it is requested.
+  def invalidate_script
+    Script.remove_from_cache(params[:script_name])
+    head :ok
+  end
+
   def destroy_script
     script = Script.find_by!(name: params[:script_name])
     script.destroy

--- a/dashboard/app/models/script.rb
+++ b/dashboard/app/models/script.rb
@@ -481,7 +481,7 @@ class Script < ActiveRecord::Base
   end
 
   def self.remove_from_cache(script_name)
-    script_cache.delete(script_name)
+    script_cache.delete(script_name) if script_cache
   end
 
   def self.get_script_family_redirect_for_user(family_name, user: nil, locale: 'en-US')

--- a/dashboard/app/models/script.rb
+++ b/dashboard/app/models/script.rb
@@ -480,6 +480,10 @@ class Script < ActiveRecord::Base
     end
   end
 
+  def self.remove_from_cache(script_name)
+    script_cache.delete(script_name)
+  end
+
   def self.get_script_family_redirect_for_user(family_name, user: nil, locale: 'en-US')
     return nil unless family_name
 

--- a/dashboard/test/ui/features/curriculum_platform/levelbuilder/script_edit_page.feature
+++ b/dashboard/test/ui/features/curriculum_platform/levelbuilder/script_edit_page.feature
@@ -31,18 +31,12 @@ Scenario: Save changes to a script
   And element "#script_text" contains text "level 'Applab test'"
   And I scroll the ".btn-primary" element into view
   And I type "lesson 'temp-lesson', display_name: 'Temp Lesson'\nlevel 'Standalone_Artist_1'\nlevel 'Standalone_Artist_2'\n" into "#script_text"
+  And I remove the temp script from the cache
   And I click selector ".btn-primary" to load a new page
   And I wait until element "#script-title" is visible
 
   Then element ".uitest-bubble" contains text "1"
-
-  # this check is disabled because the script cache is enabled on the test machine,
-  # which means that during a DTT the rails server may return a cached copy of the
-  # script on the script overview page which only has bubble "1" but not bubble "2".
-  # TODO(dave): re-enable once we have a way to update/invalidate the cache on
-  # script save.
-
-  # And element ".uitest-bubble" contains text "2"
+  And element ".uitest-bubble" contains text "2"
 
   And I delete the temp script and lesson
 

--- a/dashboard/test/ui/features/step_definitions/steps.rb
+++ b/dashboard/test/ui/features/step_definitions/steps.rb
@@ -1045,6 +1045,14 @@ Given(/^I view the temp lesson edit page$/) do
   }
 end
 
+Given (/^I remove the temp script from the cache$/) do
+  browser_request(
+    url: '/api/test/invalidate_script',
+    method: 'POST',
+    body: {script_name: @temp_script_name}
+  )
+end
+
 Given(/^I delete the temp script and lesson$/) do
   browser_request(
     url: '/api/test/destroy_script',


### PR DESCRIPTION
## Background

Finishes [PLAT-401]. See https://github.com/code-dot-org/code-dot-org/pull/37258 for additional background. 

In order to be able to test levelbuilder features, we make some tweaks to the test environment so that we can access certain routes that are otherwise levelbuilder-only. However, we don't want to disable caching in the test environment because we need it to be as close to production as possible. Caching makes it difficult to test the script edit page because we get a stale copy of the script object whenever we view the script overview page.

## Description

Adds a way in the test environment to invalidate a single script from the script cache. Use this in UI tests to invalidate a single script after making changes to a script via the script edit page.

## Testing story

Re-enables disabled UI test

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked


[PLAT-401]: https://codedotorg.atlassian.net/browse/PLAT-401