### PR TITLE
expose all levels routes for testing

### DIFF
--- a/dashboard/app/controllers/levels_controller.rb
+++ b/dashboard/app/controllers/levels_controller.rb
@@ -8,8 +8,7 @@ class LevelsController < ApplicationController
   include LevelsHelper
   include ActiveSupport::Inflector
   before_action :authenticate_user!, except: [:show, :embed_level, :get_rubric]
-  before_action :require_levelbuilder_mode, except: [:show, :embed_level, :get_rubric, :get_filtered_levels]
-  before_action :require_levelbuilder_mode_or_test_env, only: [:get_filtered_levels]
+  before_action :require_levelbuilder_mode_or_test_env, except: [:show, :embed_level, :get_rubric]
   load_and_authorize_resource except: [:create]
 
   before_action :set_level, only: [:show, :edit, :update, :destroy]

--- a/dashboard/test/controllers/levels_controller_test.rb
+++ b/dashboard/test/controllers/levels_controller_test.rb
@@ -523,7 +523,8 @@ class LevelsControllerTest < ActionController::TestCase
   end
 
   # This should represent the behavior on production.
-  test "should not modify level if not in levelbuilder mode" do
+  test "should not modify level in production" do
+    CDO.stubs(:rack_env).returns(:production)
     Rails.application.config.stubs(:levelbuilder_mode).returns false
 
     post :create, params: {name: "NewCustomLevel", program: @program}


### PR DESCRIPTION
As a follow-up to #37567, I wanted to see if I could add a UI test for saving and adding a level. The first step is to make these routes accessible in the test environment. I want to do this as a separate step (1) to make sure nothing else breaks, and (2) since it will allow me to point my new UI test directly at the test machine and make sure it passes there before merging it.

## Testing story

Updated existing unit tests

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
