### PR TITLE
Format resource name in FindResourceDialog to include type and audience

### DIFF
--- a/apps/src/lib/levelbuilder/lesson-editor/FindResourceDialog.jsx
+++ b/apps/src/lib/levelbuilder/lesson-editor/FindResourceDialog.jsx
@@ -40,9 +40,6 @@ class FindResourceDialog extends Component {
     if (resource.properties.type) {
       formattedName += ` - ${resource.properties.type}`;
     }
-    if (resource.properties.audience) {
-      formattedName += ` - ${resource.properties.audience}`;
-    }
     return formattedName;
   };
 

--- a/apps/src/lib/levelbuilder/lesson-editor/FindResourceDialog.jsx
+++ b/apps/src/lib/levelbuilder/lesson-editor/FindResourceDialog.jsx
@@ -36,7 +36,6 @@ class FindResourceDialog extends Component {
   };
 
   formatResourceName = resource => {
-    console.log(resource);
     let formattedName = resource.name;
     if (resource.properties.type) {
       formattedName += ` - ${resource.properties.type} `;

--- a/apps/src/lib/levelbuilder/lesson-editor/FindResourceDialog.jsx
+++ b/apps/src/lib/levelbuilder/lesson-editor/FindResourceDialog.jsx
@@ -38,10 +38,10 @@ class FindResourceDialog extends Component {
   formatResourceName = resource => {
     let formattedName = resource.name;
     if (resource.properties.type) {
-      formattedName += ` - ${resource.properties.type} `;
+      formattedName += ` - ${resource.properties.type}`;
     }
     if (resource.properties.audience) {
-      formattedName += ` - ${resource.properties.audience} `;
+      formattedName += ` - ${resource.properties.audience}`;
     }
     return formattedName;
   };

--- a/apps/src/lib/levelbuilder/lesson-editor/FindResourceDialog.jsx
+++ b/apps/src/lib/levelbuilder/lesson-editor/FindResourceDialog.jsx
@@ -35,6 +35,18 @@ class FindResourceDialog extends Component {
     this.setState({selectedResourceKey: e.target.value});
   };
 
+  formatResourceName = resource => {
+    console.log(resource);
+    let formattedName = resource.name;
+    if (resource.properties.type) {
+      formattedName += ` - ${resource.properties.type} `;
+    }
+    if (resource.properties.audience) {
+      formattedName += ` - ${resource.properties.audience} `;
+    }
+    return formattedName;
+  };
+
   render() {
     return (
       <BaseDialog
@@ -52,7 +64,7 @@ class FindResourceDialog extends Component {
           >
             {this.props.resources.map(resource => (
               <option key={resource.key} value={resource.key}>
-                {resource.name}
+                {this.formatResourceName(resource)}
               </option>
             ))}
           </select>


### PR DESCRIPTION
This came out of the bug bash, as often times multiple resources have the same name.

![Screenshot 2020-11-03 at 8 03 53 AM](https://user-images.githubusercontent.com/46464143/98010373-75543c80-1dab-11eb-9808-7719fefbd32e.png)

## Links

- [jira](https://codedotorg.atlassian.net/browse/PLAT-491)

## Testing story

<!--
  Does your change include appropriate tests?

  If so, please describe how the tests included in this PR are sufficient

  If not, please explain why this change does not need to be tested.
-->

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
