### PR TITLE
[Google Blockly] Use getGenerator() in all labs

### DIFF
--- a/apps/src/block_utils.js
+++ b/apps/src/block_utils.js
@@ -875,7 +875,7 @@ exports.createJsWrapperBlockCreator = function(
 ) {
   const {ORDER_FUNCTION_CALL, ORDER_MEMBER, ORDER_NONE} = Blockly.JavaScript;
 
-  const generator = blockly.Generator.get('JavaScript');
+  const generator = blockly.getGenerator();
 
   const inputTypes = {
     ...STANDARD_INPUT_TYPES,

--- a/apps/src/bounce/blocks.js
+++ b/apps/src/bounce/blocks.js
@@ -22,7 +22,7 @@ var generateSetterCode = function(ctx, name) {
 exports.install = function(blockly, blockInstallOptions) {
   var skin = blockInstallOptions.skin;
 
-  var generator = blockly.Generator.get('JavaScript');
+  var generator = blockly.getGenerator();
   blockly.JavaScript = generator;
 
   blockly.Blocks.bounce_whenLeft = {

--- a/apps/src/calc/blocks.js
+++ b/apps/src/calc/blocks.js
@@ -27,7 +27,7 @@ var sharedFunctionalBlocks = require('../sharedFunctionalBlocks');
 
 // Install extensions to Blockly's language and JavaScript generator.
 exports.install = function(blockly, blockInstallOptions) {
-  var generator = blockly.Generator.get('JavaScript');
+  var generator = blockly.getGenerator();
   blockly.JavaScript = generator;
 
   var gensym = function(name) {

--- a/apps/src/craft/agent/blocks.js
+++ b/apps/src/craft/agent/blocks.js
@@ -76,7 +76,7 @@ exports.install = function(blockly, blockInstallOptions) {
     }
   };
 
-  blockly.Generator.get('JavaScript').craft_moveForward = function() {
+  blockly.getGenerator().craft_moveForward = function() {
     return "moveForward('block_id_" + this.id + "');\n";
   };
 
@@ -92,7 +92,7 @@ exports.install = function(blockly, blockInstallOptions) {
     }
   };
 
-  blockly.Generator.get('JavaScript').craft_moveBackward = function() {
+  blockly.getGenerator().craft_moveBackward = function() {
     return "moveBackward('block_id_" + this.id + "');\n";
   };
 
@@ -115,7 +115,7 @@ exports.install = function(blockly, blockInstallOptions) {
     [i18n.blockTurnRight() + ' \u21BB', 'right']
   ];
 
-  blockly.Generator.get('JavaScript').craft_turn = function() {
+  blockly.getGenerator().craft_turn = function() {
     // Generate JavaScript for turning left or right.
     var dir = this.getTitleValue('DIR');
     var methodCall = dir === 'left' ? 'turnLeft' : 'turnRight';
@@ -134,7 +134,7 @@ exports.install = function(blockly, blockInstallOptions) {
     }
   };
 
-  blockly.Generator.get('JavaScript').craft_destroyBlock = function() {
+  blockly.getGenerator().craft_destroyBlock = function() {
     return "destroyBlock('block_id_" + this.id + "');\n";
   };
 
@@ -157,11 +157,8 @@ exports.install = function(blockly, blockInstallOptions) {
     }
   };
 
-  blockly.Generator.get('JavaScript').craft_ifBlockAhead = function() {
-    var innerCode = blockly.Generator.get('JavaScript').statementToCode(
-      this,
-      'DO'
-    );
+  blockly.getGenerator().craft_ifBlockAhead = function() {
+    var innerCode = blockly.getGenerator().statementToCode(this, 'DO');
     var blockType = this.getTitleValue('TYPE');
     return (
       'ifBlockAhead("' +
@@ -185,11 +182,8 @@ exports.install = function(blockly, blockInstallOptions) {
     }
   };
 
-  blockly.Generator.get('JavaScript').craft_ifLavaAhead = function() {
-    var innerCode = blockly.Generator.get('JavaScript').statementToCode(
-      this,
-      'DO'
-    );
+  blockly.getGenerator().craft_ifLavaAhead = function() {
+    var innerCode = blockly.getGenerator().statementToCode(this, 'DO');
     return (
       'ifLavaAhead(function() {\n' +
       innerCode +
@@ -217,7 +211,7 @@ exports.install = function(blockly, blockInstallOptions) {
     }
   };
 
-  blockly.Generator.get('JavaScript').craft_placeBlock = function() {
+  blockly.getGenerator().craft_placeBlock = function() {
     var blockType = this.getTitleValue('TYPE');
     return 'placeBlock("' + blockType + '", \'block_id_' + this.id + "');\n";
   };
@@ -249,7 +243,7 @@ exports.install = function(blockly, blockInstallOptions) {
     }
   };
 
-  blockly.Generator.get('JavaScript').craft_placeBlockDirection = function() {
+  blockly.getGenerator().craft_placeBlockDirection = function() {
     var blockType = this.getTitleValue('TYPE');
     var direction = this.getTitleValue('DIR');
     return (

--- a/apps/src/craft/designer/blocks.js
+++ b/apps/src/craft/designer/blocks.js
@@ -189,7 +189,7 @@ export const install = (blockly, blockInstallOptions) => {
     [i18n.blockTurnRight() + ' \u21BB', 'right']
   ];
 
-  blockly.Generator.get('JavaScript').craft_entityTurn = function() {
+  blockly.getGenerator().craft_entityTurn = function() {
     // Generate JavaScript for turning left or right.
     const dir = this.getTitleValue('DIR');
     const methodCalls = {
@@ -224,7 +224,7 @@ export const install = (blockly, blockInstallOptions) => {
     [i18n.turnRandom(), 'random']
   ];
 
-  blockly.Generator.get('JavaScript').craft_entityTurnLR = function() {
+  blockly.getGenerator().craft_entityTurnLR = function() {
     // Generate JavaScript for turning left or right.
     const dir = this.getTitleValue('DIR');
     const methodCalls = {
@@ -263,7 +263,7 @@ export const install = (blockly, blockInstallOptions) => {
     [i18n.blockTurnRight() + ' \u21BB', 'right']
   ];
 
-  blockly.Generator.get('JavaScript').craft_turn = function() {
+  blockly.getGenerator().craft_turn = function() {
     // Generate JavaScript for turning left or right.
     const dir = this.getTitleValue('DIR');
     const methodCall = dir === 'left' ? 'turnLeft' : 'turnRight';
@@ -317,7 +317,8 @@ export const install = (blockly, blockInstallOptions) => {
     return function() {
       return statementNames
         .map(statementName => {
-          const callback = blockly.Generator.get('JavaScript')
+          const callback = blockly
+            .getGenerator()
             .statementToCode(this, statementName)
             .replace(/\n/g, '');
           return `onEventTriggered("${blockType}", ${
@@ -330,9 +331,7 @@ export const install = (blockly, blockInstallOptions) => {
 
   function createEventBlockForEntity(entityID, displayName) {
     blockly.Blocks[`craft_${entityID}`] = blockFor(displayName);
-    blockly.Generator.get('JavaScript')[`craft_${entityID}`] = generatorFor(
-      entityID
-    );
+    blockly.getGenerator()[`craft_${entityID}`] = generatorFor(entityID);
   }
 
   function createLimitedEventBlockForEntity(
@@ -342,7 +341,7 @@ export const install = (blockly, blockInstallOptions) => {
     statementNames
   ) {
     blockly.Blocks[`craft_${entityID}`] = blockFor(displayName, statementNames);
-    blockly.Generator.get('JavaScript')[`craft_${entityID}`] = generatorFor(
+    blockly.getGenerator()[`craft_${entityID}`] = generatorFor(
       entityType,
       statementNames
     );
@@ -433,8 +432,9 @@ export const install = (blockly, blockInstallOptions) => {
       }
     };
 
-    blockly.Generator.get('JavaScript')[`craft_${functionName}`] = function() {
-      const callback = blockly.Generator.get('JavaScript')
+    blockly.getGenerator()[`craft_${functionName}`] = function() {
+      const callback = blockly
+        .getGenerator()
         .statementToCode(this, 'DO')
         .replace(/\n/g, '');
       return `onGlobalEventTriggered(${eventType}, "${callback}", 'block_id_${
@@ -480,9 +480,7 @@ export const install = (blockly, blockInstallOptions) => {
       }
     };
 
-    blockly.Generator.get('JavaScript')[
-      `craft_${simpleFunctionName}`
-    ] = function() {
+    blockly.getGenerator()[`craft_${simpleFunctionName}`] = function() {
       const dropdownValue = this.getTitleValue('TYPE');
       return `${simpleFunctionName}('${dropdownValue}', event.targetIdentifier, 'block_id_${
         this.id
@@ -501,9 +499,7 @@ export const install = (blockly, blockInstallOptions) => {
       }
     };
 
-    blockly.Generator.get('JavaScript')[
-      `craft_${simpleFunctionName}`
-    ] = function() {
+    blockly.getGenerator()[`craft_${simpleFunctionName}`] = function() {
       return `${simpleFunctionName}(event.targetIdentifier, 'block_id_${
         this.id
       }');\n`;
@@ -532,7 +528,7 @@ export const install = (blockly, blockInstallOptions) => {
       }
     };
 
-    blockly.Generator.get('JavaScript')[`craft_${blockName}`] = function() {
+    blockly.getGenerator()[`craft_${blockName}`] = function() {
       const thingToTarget = this.getTitleValue('TYPE');
       return `${simpleFunctionName}(event.targetIdentifier, '${thingToTarget}', 'block_id_${
         this.id
@@ -587,11 +583,8 @@ export const install = (blockly, blockInstallOptions) => {
     }
   };
 
-  blockly.Generator.get('JavaScript').craft_forever = function() {
-    const innerCode = blockly.Generator.get('JavaScript').statementToCode(
-      this,
-      'DO'
-    );
+  blockly.getGenerator().craft_forever = function() {
+    const innerCode = blockly.getGenerator().statementToCode(this, 'DO');
     return `repeat('block_id_${
       this.id
     }', function(event) { ${innerCode} }, -1, event.targetIdentifier);`;
@@ -616,12 +609,9 @@ export const install = (blockly, blockInstallOptions) => {
     }
   };
 
-  blockly.Generator.get('JavaScript').craft_repeatTimes = function() {
+  blockly.getGenerator().craft_repeatTimes = function() {
     const times = this.getTitleValue('TIMES');
-    const innerCode = blockly.Generator.get('JavaScript').statementToCode(
-      this,
-      'DO'
-    );
+    const innerCode = blockly.getGenerator().statementToCode(this, 'DO');
     return `repeat('block_id_${
       this.id
     }', function(event) { ${innerCode} }, ${times}, event.targetIdentifier);`;
@@ -638,11 +628,8 @@ export const install = (blockly, blockInstallOptions) => {
     }
   };
 
-  blockly.Generator.get('JavaScript').craft_repeatRandom = function() {
-    const innerCode = blockly.Generator.get('JavaScript').statementToCode(
-      this,
-      'DO'
-    );
+  blockly.getGenerator().craft_repeatRandom = function() {
+    const innerCode = blockly.getGenerator().statementToCode(this, 'DO');
     return `repeatRandom('block_id_${
       this.id
     }', function(event) { ${innerCode} }, event.targetIdentifier);`;
@@ -668,12 +655,9 @@ export const install = (blockly, blockInstallOptions) => {
     }
   };
 
-  blockly.Generator.get('JavaScript').craft_repeatDropdown = function() {
+  blockly.getGenerator().craft_repeatDropdown = function() {
     const times = this.getTitleValue('TIMES');
-    const innerCode = blockly.Generator.get('JavaScript').statementToCode(
-      this,
-      'DO'
-    );
+    const innerCode = blockly.getGenerator().statementToCode(this, 'DO');
     return `repeat('block_id_${
       this.id
     }', function(event) { ${innerCode} }, ${times}, event.targetIdentifier);`;
@@ -710,7 +694,7 @@ export const install = (blockly, blockInstallOptions) => {
     }
   };
 
-  blockly.Generator.get('JavaScript')[`craft_spawnEntity`] = function() {
+  blockly.getGenerator()[`craft_spawnEntity`] = function() {
     const type = this.getTitleValue('TYPE');
     const direction = this.getTitleValue('DIRECTION');
     return `spawnEntity('${type}', '${direction}', 'block_id_${this.id}');\n`;
@@ -736,7 +720,7 @@ export const install = (blockly, blockInstallOptions) => {
     }
   };
 
-  blockly.Generator.get('JavaScript')[`craft_spawnEntityRandom`] = function() {
+  blockly.getGenerator()[`craft_spawnEntityRandom`] = function() {
     const type = this.getTitleValue('TYPE');
     return `spawnEntityRandom('${type}', 'block_id_${this.id}');\n`;
   };
@@ -751,7 +735,7 @@ export const install = (blockly, blockInstallOptions) => {
     }
   };
 
-  blockly.Generator.get('JavaScript').craft_moveEntityNorth = function() {
+  blockly.getGenerator().craft_moveEntityNorth = function() {
     return "moveEntityNorth(block, 'block_id_" + this.id + "');\n";
   };
 
@@ -765,7 +749,7 @@ export const install = (blockly, blockInstallOptions) => {
     }
   };
 
-  blockly.Generator.get('JavaScript').craft_moveEntitySouth = function() {
+  blockly.getGenerator().craft_moveEntitySouth = function() {
     return "moveEntitySouth(block, 'block_id_" + this.id + "');\n";
   };
 
@@ -779,7 +763,7 @@ export const install = (blockly, blockInstallOptions) => {
     }
   };
 
-  blockly.Generator.get('JavaScript').craft_moveEntityEast = function() {
+  blockly.getGenerator().craft_moveEntityEast = function() {
     return "moveEntityEast(block, 'block_id_" + this.id + "');\n";
   };
 
@@ -793,7 +777,7 @@ export const install = (blockly, blockInstallOptions) => {
     }
   };
 
-  blockly.Generator.get('JavaScript').craft_moveEntityWest = function() {
+  blockly.getGenerator().craft_moveEntityWest = function() {
     return "moveEntityWest(block, 'block_id_" + this.id + "');\n";
   };
 
@@ -826,7 +810,7 @@ export const install = (blockly, blockInstallOptions) => {
     }
   };
 
-  blockly.Generator.get('JavaScript').craft_playSound = function() {
+  blockly.getGenerator().craft_playSound = function() {
     const blockType = this.getTitleValue('TYPE');
     return `playSound('${blockType}', event.targetIdentifier, 'block_id_${
       this.id
@@ -852,7 +836,7 @@ export const install = (blockly, blockInstallOptions) => {
     }
   };
 
-  blockly.Generator.get('JavaScript').craft_addScore = function() {
+  blockly.getGenerator().craft_addScore = function() {
     const score = this.getTitleValue('SCORE');
     return `addScore('${score}', 'block_id_${this.id}');\n`;
   };

--- a/apps/src/craft/simple/blocks.js
+++ b/apps/src/craft/simple/blocks.js
@@ -76,7 +76,7 @@ exports.install = function(blockly, blockInstallOptions) {
     }
   };
 
-  blockly.Generator.get('JavaScript').craft_moveForward = function() {
+  blockly.getGenerator().craft_moveForward = function() {
     return "moveForward('block_id_" + this.id + "');\n";
   };
 
@@ -99,7 +99,7 @@ exports.install = function(blockly, blockInstallOptions) {
     [i18n.blockTurnRight() + ' \u21BB', 'right']
   ];
 
-  blockly.Generator.get('JavaScript').craft_turn = function() {
+  blockly.getGenerator().craft_turn = function() {
     // Generate JavaScript for turning left or right.
     var dir = this.getTitleValue('DIR');
     var methodCall = dir === 'left' ? 'turnLeft' : 'turnRight';
@@ -118,7 +118,7 @@ exports.install = function(blockly, blockInstallOptions) {
     }
   };
 
-  blockly.Generator.get('JavaScript').craft_destroyBlock = function() {
+  blockly.getGenerator().craft_destroyBlock = function() {
     return "destroyBlock('block_id_" + this.id + "');\n";
   };
 
@@ -134,7 +134,7 @@ exports.install = function(blockly, blockInstallOptions) {
     }
   };
 
-  blockly.Generator.get('JavaScript').craft_shear = function() {
+  blockly.getGenerator().craft_shear = function() {
     return "shear('block_id_" + this.id + "');\n";
   };
 
@@ -157,11 +157,8 @@ exports.install = function(blockly, blockInstallOptions) {
     }
   };
 
-  blockly.Generator.get('JavaScript').craft_ifBlockAhead = function() {
-    var innerCode = blockly.Generator.get('JavaScript').statementToCode(
-      this,
-      'DO'
-    );
+  blockly.getGenerator().craft_ifBlockAhead = function() {
+    var innerCode = blockly.getGenerator().statementToCode(this, 'DO');
     var blockType = this.getTitleValue('TYPE');
     return (
       'ifBlockAhead("' +
@@ -185,11 +182,8 @@ exports.install = function(blockly, blockInstallOptions) {
     }
   };
 
-  blockly.Generator.get('JavaScript').craft_ifLavaAhead = function() {
-    var innerCode = blockly.Generator.get('JavaScript').statementToCode(
-      this,
-      'DO'
-    );
+  blockly.getGenerator().craft_ifLavaAhead = function() {
+    var innerCode = blockly.getGenerator().statementToCode(this, 'DO');
     return (
       'ifLavaAhead(function() {\n' +
       innerCode +
@@ -217,7 +211,7 @@ exports.install = function(blockly, blockInstallOptions) {
     }
   };
 
-  blockly.Generator.get('JavaScript').craft_placeBlock = function() {
+  blockly.getGenerator().craft_placeBlock = function() {
     var blockType = this.getTitleValue('TYPE');
     return 'placeBlock("' + blockType + '", \'block_id_' + this.id + "');\n";
   };
@@ -232,7 +226,7 @@ exports.install = function(blockly, blockInstallOptions) {
     }
   };
 
-  blockly.Generator.get('JavaScript').craft_placeTorch = function() {
+  blockly.getGenerator().craft_placeTorch = function() {
     return "placeTorch('block_id_" + this.id + "');\n";
   };
 
@@ -246,7 +240,7 @@ exports.install = function(blockly, blockInstallOptions) {
     }
   };
 
-  blockly.Generator.get('JavaScript').craft_plantCrop = function() {
+  blockly.getGenerator().craft_plantCrop = function() {
     return "plantCrop('block_id_" + this.id + "');\n";
   };
 
@@ -260,7 +254,7 @@ exports.install = function(blockly, blockInstallOptions) {
     }
   };
 
-  blockly.Generator.get('JavaScript').craft_tillSoil = function() {
+  blockly.getGenerator().craft_tillSoil = function() {
     return "tillSoil('block_id_" + this.id + "');\n";
   };
 
@@ -283,7 +277,7 @@ exports.install = function(blockly, blockInstallOptions) {
     }
   };
 
-  blockly.Generator.get('JavaScript').craft_placeBlockAhead = function() {
+  blockly.getGenerator().craft_placeBlockAhead = function() {
     var blockType = this.getTitleValue('TYPE');
     return (
       'placeBlockAhead("' + blockType + '", \'block_id_' + this.id + "');\n"

--- a/apps/src/dance/blocks.js
+++ b/apps/src/dance/blocks.js
@@ -92,7 +92,7 @@ export default {
   customInputTypes,
   install(blockly, blockInstallOptions) {
     // Legacy style block definitions :(
-    const generator = blockly.Generator.get('JavaScript');
+    const generator = blockly.getGenerator();
 
     const behaviorEditor = (Blockly.behaviorEditor = new Blockly.FunctionEditor(
       {

--- a/apps/src/eval/blocks.js
+++ b/apps/src/eval/blocks.js
@@ -26,7 +26,7 @@ var sharedFunctionalBlocks = require('../sharedFunctionalBlocks');
 
 // Install extensions to Blockly's language and JavaScript generator.
 exports.install = function(blockly, blockInstallOptions) {
-  var generator = blockly.Generator.get('JavaScript');
+  var generator = blockly.getGenerator();
   blockly.JavaScript = generator;
 
   var gensym = function(name) {

--- a/apps/src/jigsaw/blocks.js
+++ b/apps/src/jigsaw/blocks.js
@@ -185,7 +185,7 @@ exports.install = function(blockly, blockInstallOptions) {
 
   // Go through all added blocks, and add empty generators for those that
   // weren't already given generators
-  var generator = blockly.Generator.get('JavaScript');
+  var generator = blockly.getGenerator();
   blockly.JavaScript = generator;
   Object.keys(blockly.Blocks).forEach(function(block) {
     if (existingBlocks.indexOf(block) === -1 && !generator[block]) {

--- a/apps/src/maze/beeBlocks.js
+++ b/apps/src/maze/beeBlocks.js
@@ -19,7 +19,7 @@ exports.install = function(blockly, blockInstallOptions) {
   var skin = blockInstallOptions.skin;
   var isK1 = blockInstallOptions.isK1;
 
-  var generator = blockly.Generator.get('JavaScript');
+  var generator = blockly.getGenerator();
   blockly.JavaScript = generator;
 
   addIfOnlyFlower(blockly, generator);

--- a/apps/src/maze/blocks.js
+++ b/apps/src/maze/blocks.js
@@ -32,7 +32,7 @@ var msg = require('./locale');
 // Install extensions to Blockly's language and JavaScript generator.
 exports.install = function(blockly, blockInstallOptions) {
   var skin = blockInstallOptions.skin;
-  var generator = blockly.Generator.get('JavaScript');
+  var generator = blockly.getGenerator();
   blockly.JavaScript = generator;
 
   if (mazeUtils.isBeeSkin(skin.id)) {

--- a/apps/src/maze/collectorBlocks.js
+++ b/apps/src/maze/collectorBlocks.js
@@ -6,7 +6,7 @@ exports.install = function(blockly, blockInstallOptions) {
   var skin = blockInstallOptions.skin;
   var isK1 = blockInstallOptions.isK1;
 
-  var generator = blockly.Generator.get('JavaScript');
+  var generator = blockly.getGenerator();
   blockly.JavaScript = generator;
 
   // Block for collecting collectibles. Comes in both regular and K1

--- a/apps/src/maze/harvesterBlocks.js
+++ b/apps/src/maze/harvesterBlocks.js
@@ -196,7 +196,7 @@ exports.install = function(blockly, blockInstallOptions) {
   var skin = blockInstallOptions.skin;
   var isK1 = blockInstallOptions.isK1;
 
-  var generator = blockly.Generator.get('JavaScript');
+  var generator = blockly.getGenerator();
   blockly.JavaScript = generator;
 
   CROPS.forEach(crop => {

--- a/apps/src/maze/planterBlocks.js
+++ b/apps/src/maze/planterBlocks.js
@@ -5,7 +5,7 @@ var msg = require('./locale');
 var blockUtils = require('../block_utils');
 
 exports.install = function(blockly, blockInstallOptions) {
-  var generator = blockly.Generator.get('JavaScript');
+  var generator = blockly.getGenerator();
   blockly.JavaScript = generator;
 
   blockUtils.generateSimpleBlock(blockly, generator, {

--- a/apps/src/p5lab/spritelab/blocks.js
+++ b/apps/src/p5lab/spritelab/blocks.js
@@ -374,7 +374,7 @@ export default {
   customInputTypes,
   install(blockly, blockInstallOptions) {
     // Legacy style block definitions :(
-    const generator = blockly.Generator.get('JavaScript');
+    const generator = blockly.getGenerator();
 
     const behaviorEditor = (Blockly.behaviorEditor = new Blockly.FunctionEditor(
       {

--- a/apps/src/studio/blocks.js
+++ b/apps/src/studio/blocks.js
@@ -135,7 +135,7 @@ function getSpriteOrDropdownIndex(
 exports.install = function(blockly, blockInstallOptions) {
   var skin = blockInstallOptions.skin;
   var isK1 = blockInstallOptions.isK1;
-  var generator = blockly.Generator.get('JavaScript');
+  var generator = blockly.getGenerator();
   blockly.JavaScript = generator;
   msg = {...msg, ...skin.msgOverrides};
 

--- a/apps/src/turtle/blocks.js
+++ b/apps/src/turtle/blocks.js
@@ -77,7 +77,7 @@ const DIRECTION_VALUES = [
 exports.install = function(blockly, blockInstallOptions) {
   var skin = blockInstallOptions.skin;
 
-  var generator = blockly.Generator.get('JavaScript');
+  var generator = blockly.getGenerator();
   blockly.JavaScript = generator;
 
   var gensym = function(name) {


### PR DESCRIPTION
This was the only change I needed to make in Flappy-specific code.
getGenerator as defined in the CDO Blockly wrapper is
```
  blocklyWrapper.getGenerator = function() {
    return blocklyWrapper.Generator.get('JavaScript');
  };
```
Making this a no-op change while we use CDO Blockly.

Doing this everywhere now will allow us to start poking around at other labs with Google Blockly and see what works/what breaks.
For example, I loaded a very simple Maze level and it at least renders correctly:
![image](https://user-images.githubusercontent.com/8787187/98013714-91f27380-1daf-11eb-82fe-6bf2eabba3ba.png)


<!--
  Other aspects to consider. uncomment and add detail for any that seem necessary:
-->

<!-- ### Background -->
<!-- ### Privacy -->
<!--
1.	Does the Project involve the collection, use or sharing of new Personal Data?

2.	Does the Project involve a new or changed use or sharing of existing Personal Data?
-->
<!-- ### Security -->
<!--
Link to Jira Task where sensitive security issues are discussed privately.
-->
<!-- ### Caching -->
<!-- ### Deployment strategy -->
<!-- ### Future work -->

## Links

## Testing story
Relying on existing tests

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
