### PR TITLE
Downgrade Eyes a bit

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -96,7 +96,7 @@ group :development, :test do
 
   # For UI testing.
   gem 'cucumber'
-  gem 'eyes_selenium', '3.17.20'
+  gem 'eyes_selenium', '3.17.19'
   gem 'minitest', '~> 5.5'
   gem 'minitest-around'
   gem 'minitest-reporters', '~> 1.2.0.beta3'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -404,17 +404,17 @@ GEM
     eventmachine (1.2.5)
     execjs (2.7.0)
     exifr (1.2.5)
-    eyes_core (3.17.20)
+    eyes_core (3.17.19)
       chunky_png (= 1.3.6)
       faraday
       faraday-cookie_jar
       faraday_middleware
       oily_png (~> 1.2)
       oj
-    eyes_selenium (3.17.20)
+    eyes_selenium (3.17.19)
       crass
       css_parser
-      eyes_core (= 3.17.20)
+      eyes_core (= 3.17.19)
       nokogiri
       selenium-webdriver
       state_machine
@@ -940,7 +940,7 @@ DEPENDENCIES
   devise_invitable (~> 1.6.0)
   dotiw
   execjs
-  eyes_selenium (= 3.17.20)
+  eyes_selenium (= 3.17.19)
   factory_girl_rails
   fakeredis
   firebase


### PR DESCRIPTION
Downgrade the Eyes gem from 3.17.20 -> 3.17.19.

This is to avoid the debug spew introduced by https://github.com/applitools/eyes.sdk.ruby/pull/264.

Followup to https://github.com/code-dot-org/code-dot-org/pull/36563.
