### PR TITLE
Address unsafe SQL in ActiveRecord queries

### DIFF
--- a/dashboard/app/controllers/api/v1/peer_review_submissions_controller.rb
+++ b/dashboard/app/controllers/api/v1/peer_review_submissions_controller.rb
@@ -54,7 +54,7 @@ class Api::V1::PeerReviewSubmissionsController < ApplicationController
     reviews = reviews.
       page(page).
       per(per).
-      order('id DESC').
+      order(id: :desc).
       group(:submitter_id, :level_id).
       select('max(peer_reviews.id) id, submitter_id, level_id')
 

--- a/dashboard/app/controllers/concerns/pd/workshop_filters.rb
+++ b/dashboard/app/controllers/concerns/pd/workshop_filters.rb
@@ -127,17 +127,17 @@ module Pd::WorkshopFilters
         field, direction = parsed[1..2]
         case field
           when 'location_name'
-            workshops = workshops.order("location_name #{direction}".strip)
+            workshops = workshops.order(location_name: direction)
           when 'on_map'
-            workshops = workshops.order("on_map #{direction}".strip)
+            workshops = workshops.order(on_map: direction)
           when 'funded'
-            workshops = workshops.order("funded #{direction}".strip)
+            workshops = workshops.order(funded: direction)
           when 'course'
-            workshops = workshops.order("course #{direction}".strip)
+            workshops = workshops.order(course: direction)
           when 'subject'
-            workshops = workshops.order("subject #{direction}".strip)
+            workshops = workshops.order(subject: direction)
           when 'virtual'
-            workshops = workshops.order("virtual #{direction}".strip)
+            workshops = workshops.order(virtual: direction)
           when 'date'
             workshops = workshops.order_by_scheduled_start(desc: direction == 'desc')
           when 'enrollments'

--- a/dashboard/app/models/lesson.rb
+++ b/dashboard/app/models/lesson.rb
@@ -561,9 +561,9 @@ class Lesson < ActiveRecord::Base
     # CourseOffering, this implementation will need to change to be more like
     # related_lessons.
     lessons = Lesson.eager_load(script: :course_version).
-      where(Arel.sql("scripts.properties -> '$.curriculum_umbrella' = ?", script.curriculum_umbrella)).
+      where(Arel.sql("scripts.properties -> '$.curriculum_umbrella' = #{script.curriculum_umbrella}")).
       where(key: key).
-      order(Arel.sql("scripts.properties -> '$.version_year'", 'scripts.name'))
+      order(Arel.sql("scripts.properties -> '$.version_year'"), 'scripts.name')
     lessons - [self]
   end
 

--- a/dashboard/app/models/lesson.rb
+++ b/dashboard/app/models/lesson.rb
@@ -561,9 +561,9 @@ class Lesson < ActiveRecord::Base
     # CourseOffering, this implementation will need to change to be more like
     # related_lessons.
     lessons = Lesson.eager_load(script: :course_version).
-      where("scripts.properties -> '$.curriculum_umbrella' = ?", script.curriculum_umbrella).
+      where(Arel.sql("scripts.properties -> '$.curriculum_umbrella' = ?", script.curriculum_umbrella)).
       where(key: key).
-      order("scripts.properties -> '$.version_year'", 'scripts.name')
+      order(Arel.sql("scripts.properties -> '$.version_year'", 'scripts.name'))
     lessons - [self]
   end
 

--- a/dashboard/app/models/levels/level.rb
+++ b/dashboard/app/models/levels/level.rb
@@ -44,7 +44,7 @@ class Level < ActiveRecord::Base
   has_many :levels_parent_levels, class_name: 'ParentLevelsChildLevel', foreign_key: :child_level_id
   has_many :parent_levels, through: :levels_parent_levels, inverse_of: :child_levels
 
-  has_many :levels_child_levels, -> {order('position ASC')}, class_name: 'ParentLevelsChildLevel', foreign_key: :parent_level_id
+  has_many :levels_child_levels, -> {order(position: :asc)}, class_name: 'ParentLevelsChildLevel', foreign_key: :parent_level_id
   has_many :child_levels, through: :levels_child_levels, inverse_of: :parent_levels
 
   before_validation :strip_name

--- a/dashboard/app/models/regional_partner.rb
+++ b/dashboard/app/models/regional_partner.rb
@@ -167,7 +167,7 @@ class RegionalPartner < ActiveRecord::Base
       end
 
     # prefer match by zip code when multiple partners cover the same state
-    return find_by_region_query.order('pd_regional_partner_mappings.zip_code IS NOT NULL DESC').first
+    return find_by_region_query.order(Arel.sql('pd_regional_partner_mappings.zip_code IS NOT NULL DESC')).first
   end
 
   # Find a Regional Partner that services a particular ZIP.

--- a/dashboard/app/models/script.rb
+++ b/dashboard/app/models/script.rb
@@ -464,7 +464,7 @@ class Script < ActiveRecord::Base
   end
 
   def self.get_family_without_cache(family_name)
-    Script.where(family_name: family_name).order("properties -> '$.version_year' DESC")
+    Script.where(family_name: family_name).order(Arel.sql("properties -> '$.version_year' DESC"))
   end
 
   # Returns all scripts within a family from the Rails cache.
@@ -627,7 +627,7 @@ class Script < ActiveRecord::Base
       # select only scripts in the same family.
       where(family_name: family_name).
       # order by version year descending.
-      order("properties -> '$.version_year' DESC")&.
+      order(Arel.sql("properties -> '$.version_year' DESC"))&.
       first
   end
 
@@ -702,8 +702,8 @@ class Script < ActiveRecord::Base
 
   def self.scripts_with_standards
     Script.
-      where("properties -> '$.curriculum_umbrella' = 'CSF'").
-      where("properties -> '$.version_year' >= '2019'").
+      where(Arel.sql("properties -> '$.curriculum_umbrella' = 'CSF'")).
+      where(Arel.sql("properties -> '$.version_year' >= '2019'")).
       map {|script| [script.title_for_display, script.name]}
   end
 

--- a/dashboard/app/models/sections/section.rb
+++ b/dashboard/app/models/sections/section.rb
@@ -54,7 +54,7 @@ class Section < ActiveRecord::Base
   has_many :followers, dependent: :destroy
   accepts_nested_attributes_for :followers
 
-  has_many :students, -> {order('name')}, through: :followers, source: :student_user
+  has_many :students, -> {order(:name)}, through: :followers, source: :student_user
   accepts_nested_attributes_for :students
 
   validates :name, presence: true, unless: -> {deleted?}

--- a/dashboard/app/models/unit_group.rb
+++ b/dashboard/app/models/unit_group.rb
@@ -18,7 +18,7 @@ require 'cdo/script_constants'
 class UnitGroup < ApplicationRecord
   # Some Courses will have an associated Plc::Course, most will not
   has_one :plc_course, class_name: 'Plc::Course', foreign_key: 'course_id'
-  has_many :default_unit_group_units, -> {where(experiment_name: nil).order(Arel.sql("position ASC"))}, class_name: 'UnitGroupUnit', dependent: :destroy, foreign_key: 'course_id'
+  has_many :default_unit_group_units, -> {where(experiment_name: nil).order('position')}, class_name: 'UnitGroupUnit', dependent: :destroy, foreign_key: 'course_id'
   has_many :default_scripts, through: :default_unit_group_units, source: :script
   has_many :alternate_unit_group_units, -> {where.not(experiment_name: nil)}, class_name: 'UnitGroupUnit', dependent: :destroy, foreign_key: 'course_id'
   has_one :course_version, as: :content_root

--- a/dashboard/app/models/unit_group.rb
+++ b/dashboard/app/models/unit_group.rb
@@ -457,7 +457,7 @@ class UnitGroup < ApplicationRecord
 
     UnitGroup.
       # select only courses in the same course family.
-      where(Arel.sql("properties -> '$.family_name' = ?", family_name)).
+      where(Arel.sql("properties -> '$.family_name' = #{family_name}")).
       # select only stable courses.
       where(Arel.sql("properties -> '$.is_stable'")).
       # order by version year.
@@ -476,7 +476,7 @@ class UnitGroup < ApplicationRecord
       # select only courses assigned to this user.
       where(id: assigned_course_ids).
       # select only courses in the same course family.
-      where(Arel.sql("properties -> '$.family_name' = ?", family_name)).
+      where(Arel.sql("properties -> '$.family_name' = #{family_name}")).
       # order by version year.
       order(Arel.sql("properties -> '$.version_year' DESC"))&.
       first

--- a/dashboard/app/models/unit_group.rb
+++ b/dashboard/app/models/unit_group.rb
@@ -18,7 +18,7 @@ require 'cdo/script_constants'
 class UnitGroup < ApplicationRecord
   # Some Courses will have an associated Plc::Course, most will not
   has_one :plc_course, class_name: 'Plc::Course', foreign_key: 'course_id'
-  has_many :default_unit_group_units, -> {where(experiment_name: nil).order('position ASC')}, class_name: 'UnitGroupUnit', dependent: :destroy, foreign_key: 'course_id'
+  has_many :default_unit_group_units, -> {where(experiment_name: nil).order(Arel.sql("position ASC"))}, class_name: 'UnitGroupUnit', dependent: :destroy, foreign_key: 'course_id'
   has_many :default_scripts, through: :default_unit_group_units, source: :script
   has_many :alternate_unit_group_units, -> {where.not(experiment_name: nil)}, class_name: 'UnitGroupUnit', dependent: :destroy, foreign_key: 'course_id'
   has_one :course_version, as: :content_root
@@ -457,11 +457,11 @@ class UnitGroup < ApplicationRecord
 
     UnitGroup.
       # select only courses in the same course family.
-      where("properties -> '$.family_name' = ?", family_name).
+      where(Arel.sql("properties -> '$.family_name' = ?", family_name)).
       # select only stable courses.
-      where("properties -> '$.is_stable'").
+      where(Arel.sql("properties -> '$.is_stable'")).
       # order by version year.
-      order("properties -> '$.version_year' DESC")&.
+      order(Arel.sql("properties -> '$.version_year' DESC"))&.
       first
   end
 
@@ -476,9 +476,9 @@ class UnitGroup < ApplicationRecord
       # select only courses assigned to this user.
       where(id: assigned_course_ids).
       # select only courses in the same course family.
-      where("properties -> '$.family_name' = ?", family_name).
+      where(Arel.sql("properties -> '$.family_name' = ?", family_name)).
       # order by version year.
-      order("properties -> '$.version_year' DESC")&.
+      order(Arel.sql("properties -> '$.version_year' DESC"))&.
       first
   end
 

--- a/dashboard/app/models/user.rb
+++ b/dashboard/app/models/user.rb
@@ -416,7 +416,7 @@ class User < ActiveRecord::Base
   before_create :update_default_share_setting
 
   # a bit of trickery to sort most recently started/assigned/progressed scripts first and then completed
-  has_many :user_scripts, -> {order "-completed_at asc, greatest(coalesce(started_at, 0), coalesce(assigned_at, 0), coalesce(last_progress_at, 0)) desc, user_scripts.id asc"}
+  has_many :user_scripts, -> {order Arel.sql("-completed_at asc, greatest(coalesce(started_at, 0), coalesce(assigned_at, 0), coalesce(last_progress_at, 0)) desc, user_scripts.id asc")}
   has_many :scripts, -> {where hidden: false}, through: :user_scripts, source: :script
 
   validates :name, presence: true, unless: -> {purged_at}
@@ -1215,7 +1215,7 @@ class User < ActiveRecord::Base
   def last_attempt(level, script = nil)
     query = UserLevel.where(user_id: id, level_id: level.id)
     query = query.where(script_id: script.id) unless script.nil?
-    query.order('updated_at DESC').first
+    query.order(updated_at: :desc).first
   end
 
   # Returns the most recent (via updated_at) user_level for any of the specified

--- a/dashboard/app/models/video.rb
+++ b/dashboard/app/models/video.rb
@@ -21,7 +21,7 @@ class Video < ActiveRecord::Base
 
   default_scope {order(:key)}
   scope :english_locale, -> {where(locale: 'en-US')}
-  scope :current_locale, -> {where(locale: I18n.locale.to_s).or(Video.english_locale).unscope(:order).order("(case when locale = 'en-US' then 0 else 1 end) desc")}
+  scope :current_locale, -> {where(locale: I18n.locale.to_s).or(Video.english_locale).unscope(:order).order(Arel.sql("(case when locale = 'en-US' then 0 else 1 end) desc"))}
 
   validates_uniqueness_of :key, scope: [:locale]
   validates :key, format: {with: /\A[a-zA-Z0-9\-_]+\z/}

--- a/dashboard/lib/api/v1/school_autocomplete.rb
+++ b/dashboard/lib/api/v1/school_autocomplete.rb
@@ -18,7 +18,7 @@ class Api::V1::SchoolAutocomplete < AutocompleteHelper
       matches = match_terms.join ' + '
       rows = rows.
         where("MATCH(name, city) AGAINST(? IN BOOLEAN MODE)", terms.join(' ')).
-        order("(#{matches}) DESC, state, city, name")
+        order(Arel.sql("(#{matches}) DESC, state, city, name"))
     elsif search_by_zip?((query = query.strip))
       query = "#{query[0, 5]}%"
       rows = rows.where("zip LIKE ?", query)


### PR DESCRIPTION
Rails 5.2 adds deprecation warnings for several forms of SQL in ActiveRecord queries, which Rails 6 will no longer allow. As part of the ongoing work to upgrade to Rails 6, we want to address these warnings.

Mostly, this involves wrapping SQL calls which we know are safe (ie, calls that don't reference any user-editable model fields) in `Arel.sql`; in some cases, we're also able to replace the SQL with built-in ActiveRecord methods.

<!--
  Your description goes here: A summary of the change, including any relevant motivation and context.

  If relevant, include a description both of the existing behavior and of the new behavior.
-->

<!--
  Other aspects to consider. uncomment and add detail for any that seem necessary:
-->

<!-- ### Background -->
<!-- ### Privacy -->
<!--
1.	Does the Project involve the collection, use or sharing of new Personal Data?

2.	Does the Project involve a new or changed use or sharing of existing Personal Data?
-->
<!-- ### Security -->
<!--
Link to Jira Task where sensitive security issues are discussed privately.
-->
<!-- ### Caching -->
<!-- ### Deployment strategy -->
<!-- ### Future work -->

## Links

<!--
  Any relevant links to external resources; ie, specification documents, jira
  items, related PRs, honeybadger errors, etc
-->

- [Rails 5.2 stops some raw SQL, prevents SQL injections](https://blog.bigbinary.com/2018/10/16/rails-5-2-disallows-raw-sql-in-active-record.html)
- [Disallow raw SQL in dangerous AR methods](https://github.com/rails/rails/pull/27947)

## Testing story

<!--
  Does your change include appropriate tests?

  If so, please describe how the tests included in this PR are sufficient

  If not, please explain why this change does not need to be tested.
-->

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
