### PR TITLE
Standardize category names in the category map for the animation manifests

### DIFF
--- a/tools/scripts/ManifestBuilder.rb
+++ b/tools/scripts/ManifestBuilder.rb
@@ -400,7 +400,8 @@ The animation has been skipped.
     animation_metadata.each do |name, metadata|
       categories = metadata['categories']
       categories.each do |category|
-        category_map[category] = (category_map[category] + [name]).uniq.sort
+        normalized_category = category.tr(' ', '_')
+        category_map[normalized_category] = (category_map[normalized_category] + [name]).uniq.sort
       end
       category_progress_bar.increment unless category_progress_bar.nil?
     end


### PR DESCRIPTION
We've hit an issue with the category map having `generic items` instead of `generic_items` as the key a couple of times. In the ManifestBuilder we should normalize those keys.


When comparing a recent diff between two spritelab manifests, there was an unintentional diff:
```
8063c7401
<     "generic items": [
---
>     "generic_items": [
```
This PR codifies the fact that we need that underscore or else we'll see a broken link on the animation picker:

![Screenshot 2020-11-03 at 2 48 33 PM](https://user-images.githubusercontent.com/46464143/98051883-a3f10800-1de9-11eb-8851-f53f1c0da80c.png)



<!-- ### Background -->
<!-- ### Privacy -->
<!--
1.	Does the Project involve the collection, use or sharing of new Personal Data?

2.	Does the Project involve a new or changed use or sharing of existing Personal Data?
-->
<!-- ### Security -->
<!--
Link to Jira Task where sensitive security issues are discussed privately.
-->
<!-- ### Caching -->
<!-- ### Deployment strategy -->
<!-- ### Future work -->

## Links

<!--
  Any relevant links to external resources; ie, specification documents, jira
  items, related PRs, honeybadger errors, etc
-->

- [spec]()
- [jira]()

## Testing story

<!--
  Does your change include appropriate tests?

  If so, please describe how the tests included in this PR are sufficient

  If not, please explain why this change does not need to be tested.
-->

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
