### PR TITLE
Add option to filter by virtual status in workshop dashboard

### DIFF
--- a/apps/src/code-studio/pd/workshop_dashboard/components/workshop_table.jsx
+++ b/apps/src/code-studio/pd/workshop_dashboard/components/workshop_table.jsx
@@ -162,6 +162,15 @@ export default class WorkshopTable extends React.Component {
         }
       },
       {
+        property: 'virtual',
+        header: {
+          label: 'Virtual'
+        },
+        cell: {
+          formatters: [this.formatBoolean]
+        }
+      },
+      {
         property: 'enrollments',
         header: {
           label: 'Signups',

--- a/apps/src/code-studio/pd/workshop_dashboard/components/workshop_table.jsx
+++ b/apps/src/code-studio/pd/workshop_dashboard/components/workshop_table.jsx
@@ -164,7 +164,8 @@ export default class WorkshopTable extends React.Component {
       {
         property: 'virtual',
         header: {
-          label: 'Virtual'
+          label: 'Virtual',
+          transforms: [sortable]
         },
         cell: {
           formatters: [this.formatBoolean]

--- a/apps/src/code-studio/pd/workshop_dashboard/workshop_filter.jsx
+++ b/apps/src/code-studio/pd/workshop_dashboard/workshop_filter.jsx
@@ -176,6 +176,11 @@ export class WorkshopFilter extends React.Component {
     this.updateLocationAndSetFilters({subject});
   };
 
+  handleVirtualChange = selected => {
+    const virtual = selected ? selected.value : null;
+    this.updateLocationAndSetFilters({virtual});
+  };
+
   handleFacilitatorChange = selected => {
     const facilitator_id = selected ? selected.value : null;
     this.updateLocationAndSetFilters({facilitator_id});
@@ -263,6 +268,7 @@ export class WorkshopFilter extends React.Component {
       state: urlParams.state,
       course: urlParams.course,
       subject: urlParams.subject,
+      virtual: urlParams.virtual,
       facilitator_id: urlParams.facilitator_id,
       organizer_id: urlParams.organizer_id,
       teacher_email: urlParams.teacher_email,
@@ -423,6 +429,23 @@ export class WorkshopFilter extends React.Component {
                   onChange={this.handleSubjectChange}
                   placeholder={null}
                   options={this.subjectOptions[filters.course]}
+                  {...SelectStyleProps}
+                />
+              </FormGroup>
+            </Col>
+          )}
+          {this.props.permission.has(WorkshopAdmin) && (
+            <Col sm={3}>
+              <FormGroup>
+                <ControlLabel>Virtual</ControlLabel>
+                <Select
+                  value={filters.virtual}
+                  options={[
+                    {value: 'no', label: 'No'},
+                    {value: 'yes', label: 'Yes'}
+                  ]}
+                  onChange={this.handleVirtualChange}
+                  placeholder={null}
                   {...SelectStyleProps}
                 />
               </FormGroup>

--- a/apps/src/code-studio/pd/workshop_dashboard/workshop_filter.jsx
+++ b/apps/src/code-studio/pd/workshop_dashboard/workshop_filter.jsx
@@ -435,7 +435,7 @@ export class WorkshopFilter extends React.Component {
             </Col>
           )}
           {this.props.permission.has(WorkshopAdmin) && (
-            <Col sm={3}>
+            <Col md={3} sm={4}>
               <FormGroup>
                 <ControlLabel>Virtual</ControlLabel>
                 <Select

--- a/dashboard/app/controllers/concerns/pd/workshop_filters.rb
+++ b/dashboard/app/controllers/concerns/pd/workshop_filters.rb
@@ -92,7 +92,9 @@ module Pd::WorkshopFilters
           # via the typical ActiveRecord where method.
           virtual_status = params[:virtual] == 'yes'
           workshops_array = workshops.select {|workshop| workshop.virtual? == virtual_status}
-          workshops = workshops.where(id: workshops_array.map(&:id))
+          workshops = workshops_array.empty? ?
+            workshops.none :
+            workshops.where(id: workshops_array.map(&:id))
         end
         workshops = workshops.where(organizer_id: params[:organizer_id]) if params[:organizer_id]
         workshops = workshops.facilitated_by(User.find_by(id: params[:facilitator_id])) if params[:facilitator_id]

--- a/dashboard/app/controllers/concerns/pd/workshop_filters.rb
+++ b/dashboard/app/controllers/concerns/pd/workshop_filters.rb
@@ -131,6 +131,8 @@ module Pd::WorkshopFilters
             workshops = workshops.order("course #{direction}".strip)
           when 'subject'
             workshops = workshops.order("subject #{direction}".strip)
+          when 'virtual'
+            workshops = workshops.order("virtual #{direction}".strip)
           when 'date'
             workshops = workshops.order_by_scheduled_start(desc: direction == 'desc')
           when 'enrollments'

--- a/dashboard/app/controllers/concerns/pd/workshop_filters.rb
+++ b/dashboard/app/controllers/concerns/pd/workshop_filters.rb
@@ -91,9 +91,7 @@ module Pd::WorkshopFilters
           # a serialized attribute, which cannot be queried easily
           # via the typical ActiveRecord where method.
           virtual_status = params[:virtual] == 'yes'
-          workshops_array = workshops.select do |workshop|
-            workshop.virtual? == virtual_status
-          end
+          workshops_array = workshops.select {|workshop| workshop.virtual? == virtual_status}
           workshops = workshops.where(id: workshops_array.map(&:id))
         end
         workshops = workshops.where(organizer_id: params[:organizer_id]) if params[:organizer_id]

--- a/dashboard/app/controllers/concerns/pd/workshop_filters.rb
+++ b/dashboard/app/controllers/concerns/pd/workshop_filters.rb
@@ -85,6 +85,9 @@ module Pd::WorkshopFilters
       workshops = workshops.where(subject: params[:subject]) if params[:subject]
 
       if current_user.permission?(UserPermission::WORKSHOP_ADMIN)
+        workshops = workshops.where(organizer_id: params[:organizer_id]) if params[:organizer_id]
+        workshops = workshops.facilitated_by(User.find_by(id: params[:facilitator_id])) if params[:facilitator_id]
+
         if params[:virtual]
           # Note this is an inefficient workaround required
           # because we store a workshop's virtual status as
@@ -96,8 +99,6 @@ module Pd::WorkshopFilters
             workshops.none :
             workshops.where(id: workshops_array.map(&:id))
         end
-        workshops = workshops.where(organizer_id: params[:organizer_id]) if params[:organizer_id]
-        workshops = workshops.facilitated_by(User.find_by(id: params[:facilitator_id])) if params[:facilitator_id]
       end
 
       if params[:regional_partner_id] && params[:regional_partner_id] != 'all'

--- a/dashboard/app/controllers/concerns/pd/workshop_filters.rb
+++ b/dashboard/app/controllers/concerns/pd/workshop_filters.rb
@@ -85,6 +85,13 @@ module Pd::WorkshopFilters
       workshops = workshops.where(subject: params[:subject]) if params[:subject]
 
       if current_user.permission?(UserPermission::WORKSHOP_ADMIN)
+        if params[:virtual]
+          virtual_status = params[:virtual] == 'yes'
+          workshops_array = workshops.select do |workshop|
+            workshop.virtual? == virtual_status
+          end
+          workshops = workshops.where(id: workshops_array.map(&:id))
+        end
         workshops = workshops.where(organizer_id: params[:organizer_id]) if params[:organizer_id]
         workshops = workshops.facilitated_by(User.find_by(id: params[:facilitator_id])) if params[:facilitator_id]
       end
@@ -147,6 +154,7 @@ module Pd::WorkshopFilters
       :end,
       :course,
       :subject,
+      :virtual,
       :facilitator_id,
       :organizer_id,
       :teacher_email,

--- a/dashboard/app/controllers/concerns/pd/workshop_filters.rb
+++ b/dashboard/app/controllers/concerns/pd/workshop_filters.rb
@@ -86,6 +86,10 @@ module Pd::WorkshopFilters
 
       if current_user.permission?(UserPermission::WORKSHOP_ADMIN)
         if params[:virtual]
+          # Note this is an inefficient workaround required
+          # because we store a workshop's virtual status as
+          # a serialized attribute, which cannot be queried easily
+          # via the typical ActiveRecord where method.
           virtual_status = params[:virtual] == 'yes'
           workshops_array = workshops.select do |workshop|
             workshop.virtual? == virtual_status

--- a/dashboard/test/controllers/concerns/pd/workshop_filters_test.rb
+++ b/dashboard/test/controllers/concerns/pd/workshop_filters_test.rb
@@ -131,6 +131,23 @@ class Pd::WorkshopFiltersTest < ActionController::TestCase
     @controller.filter_workshops @workshop_query
   end
 
+  test 'filter_workshops with virtual status' do
+    # WIP, doesn't work yet.
+
+    # Without virtual workshop, check where gets called with blank array.
+    # Once virtual workshop is created, check where gets called with array with
+    #   ID from workshop that was created.
+    params virtual: 'yes'
+    @controller.filter_workshops @workshop_query
+
+    create :workshop,
+      virtual: true,
+      suppress_email: true
+    @workshop_query.expects(:where)
+
+    @controller.filter_workshops @workshop_query
+  end
+
   test 'filter_workshops with facilitator_id' do
     User.stubs(:find_by).with(id: 789).returns(@user)
     expects(:facilitated_by).with(@user)
@@ -251,6 +268,7 @@ class Pd::WorkshopFiltersTest < ActionController::TestCase
       :end,
       :course,
       :subject,
+      :virtual,
       :organizer_id,
       :teacher_email,
       :only_attended,

--- a/dashboard/test/controllers/concerns/pd/workshop_filters_test.rb
+++ b/dashboard/test/controllers/concerns/pd/workshop_filters_test.rb
@@ -132,18 +132,23 @@ class Pd::WorkshopFiltersTest < ActionController::TestCase
   end
 
   test 'filter_workshops with virtual status' do
-    # WIP, doesn't work yet.
-
-    # Without virtual workshop, check where gets called with blank array.
-    # Once virtual workshop is created, check where gets called with array with
-    #   ID from workshop that was created.
     params virtual: 'yes'
+
+    # No virtual workshops found, uses none to return empty set of records.
+    @workshop_query.expects(:select).returns([])
+    expects(:none)
+
     @controller.filter_workshops @workshop_query
 
-    create :workshop,
+    virtual_workshop = create :workshop,
       virtual: true,
       suppress_email: true
-    @workshop_query.expects(:where)
+
+    # Need to override expects method used elsewhere in this test file
+    # to set the return value to an array, instead of the mock @workshop_query
+    # object.
+    @workshop_query.expects(:select).returns([virtual_workshop])
+    expects(:where).with(id: [virtual_workshop.id])
 
     @controller.filter_workshops @workshop_query
   end


### PR DESCRIPTION
Adds an option for workshop admins to filter workshops by whether they are being conducted virtually or not. It also adds a column for whether a workshop is virtual or not to the WorkshopTable component, which is also sortable:

![image](https://user-images.githubusercontent.com/25372625/98045057-bd3f8780-1ddc-11eb-8f27-32bcd33fbe79.png)

The weirdness here is that we store a workshop's virtual status as a serialized attribute, which is typically not recommended for model attributes that you'd like to be able to filter on. This is slow bc it requires converting each workshop from its database entry into Ruby objects, and then back again for the subsequent filter steps that require that the collection of workshops be anActiveRecord collection. The workaround I have here is to get an array of workshops that meet the virtual filter requirement, then use the IDs for these workshops to get the appropriate ActiveRecord collection. I think this may be ok because this is an admin only feature, and if it becomes a performance issue with production data, we can revert it.

## Links

- [jira](https://codedotorg.atlassian.net/browse/PLC-968)

## Testing story

I tested this change manually, and added a new unit test covering the new filter behavior.

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
