### PR TITLE
[Google Blockly] Unregister context menu options

### DIFF
--- a/apps/src/sites/studio/pages/googleBlocklyWrapper.js
+++ b/apps/src/sites/studio/pages/googleBlocklyWrapper.js
@@ -134,6 +134,11 @@ function initializeBlocklyWrapper(blocklyInstance) {
   blocklyWrapper.blockly_.Trashcan = CdoTrashcan;
   blocklyWrapper.blockly_.WorkspaceSvg = CdoWorkspaceSvg;
 
+  const disabledContextMenuOptions = ['blockCollapseExpand'];
+  disabledContextMenuOptions.forEach(optionId =>
+    blocklyWrapper.blockly_.ContextMenuRegistry.registry.unregister(optionId)
+  );
+
   // These are also wrapping read only properties, but can't use wrapReadOnlyProperty
   // because the alias name is not the same as the underlying property name.
   Object.defineProperty(blocklyWrapper, 'mainBlockSpace', {

--- a/apps/src/sites/studio/pages/googleBlocklyWrapper.js
+++ b/apps/src/sites/studio/pages/googleBlocklyWrapper.js
@@ -134,7 +134,15 @@ function initializeBlocklyWrapper(blocklyInstance) {
   blocklyWrapper.blockly_.Trashcan = CdoTrashcan;
   blocklyWrapper.blockly_.WorkspaceSvg = CdoWorkspaceSvg;
 
-  const disabledContextMenuOptions = ['blockCollapseExpand'];
+  const disabledContextMenuOptions = [
+    'blockCollapseExpand',
+    'blockComment',
+    'blockDisable',
+    'blockHelp',
+    'blockInline',
+    'collapseWorkspace',
+    'expandWorkspace'
+  ];
   disabledContextMenuOptions.forEach(optionId =>
     blocklyWrapper.blockly_.ContextMenuRegistry.registry.unregister(optionId)
   );


### PR DESCRIPTION
The default options in the context menu are defined here: https://github.com/google/blockly/blob/master/core/contextmenu_items.js
Some of these options are really helpful (duplicate, delete, undo/redo, etc), but some are probably too complicated for our uses.

Each option has a `precondition` that determines whether it will be shown. It seems like currently for Flappy, many of the preconditions are not met, so not all of these options currently show in the context menus. For example, the precondition function for the `"blockInline"` option is that the block is in the workspace, movable, not collapsed, and has two inputs next to each other, and lets you configure whether the inputs are rendered inline or externally:
![image](https://user-images.githubusercontent.com/8787187/98145441-c0d81a80-1e7f-11eb-99d0-727bce4b7ab3.png)

This is almost certainly not an option we want to expose to users, so I think it's worth being explicit about disabling the ones we don't want so that they don't accidentally pop up later if the precondition is met. Also worth noting it would be really easy to add/remove options from this list if we change our minds

Current workspace options:
![image](https://user-images.githubusercontent.com/8787187/98143121-8ec5b900-1e7d-11eb-995f-83237b5f72aa.png)

Current Block options:
![image](https://user-images.githubusercontent.com/8787187/98143179-9dac6b80-1e7d-11eb-93aa-33ec212d160f.png)

After workspace options:
![image](https://user-images.githubusercontent.com/8787187/98143345-d2202780-1e7d-11eb-87b7-8b7a7813f251.png)

After Block options:
![image](https://user-images.githubusercontent.com/8787187/98143280-bfa5ee00-1e7d-11eb-8830-fe00d1bbb67b.png)

