### PR TITLE
Mocked netsim in lobby test

### DIFF
--- a/apps/test/unit/netsim/NetSimLobbyTest.js
+++ b/apps/test/unit/netsim/NetSimLobbyTest.js
@@ -4,7 +4,6 @@ import {expect} from '../../util/reconfiguredChai';
 import NetSimLobby from '../../../src/netsim/NetSimLobby.js';
 import * as userSectionClient from '@cdo/apps/util/userSectionClient';
 var NetSimTestUtils = require('../../util/netsimTestUtils');
-import NetSim from '@cdo/apps/netsim/netsim';
 
 const SIGNED_IN_USER = {
   user: {
@@ -18,7 +17,13 @@ describe('NetSimLobby', () => {
     getUserSectionsStub = sinon.stub(userSectionClient, 'getUserSections');
     NetSimTestUtils.initializeGlobalsToDefaultValues();
     rootDiv = $('<div>');
-    netsim = new NetSim();
+    netsim = {
+      debouncedResizeFooter: () => {},
+      shardChange: {register: () => {}},
+      isConnectedToShardID: () => {
+        return true;
+      }
+    };
   });
 
   afterEach(function() {


### PR DESCRIPTION
Discussion: https://codedotorg.slack.com/archives/C0T0PNTM3/p1604412684156600

Netsim tests were intermittently failing because of state leak caused by the NetsimLobbyTest. This was fixed by mocking the netsim object rather than creating a new netsim object.

<!--
  Other aspects to consider. uncomment and add detail for any that seem necessary:
-->

<!-- ### Background -->
<!-- ### Privacy -->
<!--
1.	Does the Project involve the collection, use or sharing of new Personal Data?

2.	Does the Project involve a new or changed use or sharing of existing Personal Data?
-->
<!-- ### Security -->
<!--
Link to Jira Task where sensitive security issues are discussed privately.
-->
<!-- ### Caching -->
<!-- ### Deployment strategy -->
<!-- ### Future work -->

## Links

<!--
  Any relevant links to external resources; ie, specification documents, jira
  items, related PRs, honeybadger errors, etc
-->

## Testing story

<!--
  Does your change include appropriate tests?

  If so, please describe how the tests included in this PR are sufficient

  If not, please explain why this change does not need to be tested.
-->

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
