### PR TITLE
Fix GemNotFound errors in ci_build after gem updates

### DIFF
--- a/aws/ci_build
+++ b/aws/ci_build
@@ -77,11 +77,12 @@ def build
     git_revision_short = GitUtils.git_revision_short
 
     ChatClient.log "https://github.com/code-dot-org/code-dot-org/commit/#{git_revision}", message_format: 'text', color: 'purple'
-    Honeybadger.notify_new_release(rack_env, git_revision)
     write_build_status rack_env, git_revision_short, :start
 
     # Ensure updated Gemfile.lock dependencies are installed.
     RakeUtils.bundle_install
+
+    Honeybadger.notify_new_release(rack_env, git_revision)
 
     status = begin
       result = RakeUtils.rake_stream_output 'ci'


### PR DESCRIPTION
`GemNotFound` error messages would occur because a call to `Honeybadger.notify_new_release` (which calls `bundle exec honeybadger deploy`) comes before `RakeUtils.bundle_install` in the `ci_build` script, moving it to come after the bundle install step should fix.