### PR TITLE
Use generic - rather than region-specific - regional partner in test

### DIFF
--- a/dashboard/test/models/regional_partner_test.rb
+++ b/dashboard/test/models/regional_partner_test.rb
@@ -212,7 +212,7 @@ class RegionalPartnerTest < ActiveSupport::TestCase
   test 'regional_partner_summer_workshop_open' do
     regional_partner = nil
     Timecop.freeze Time.zone.local(2018, 9, 27, 21, 25) do
-      regional_partner = create :regional_partner_alabama, :with_apps_priority_deadline_date
+      regional_partner = create :regional_partner_with_summer_workshops, :with_apps_priority_deadline_date
 
       assert_equal "Contact Name", regional_partner.contact_name
       assert_equal "contact@code.org", regional_partner.contact_email


### PR DESCRIPTION
It's not 100% clear why this is necessary, but here's what we do know:

- https://github.com/rails/rails/pull/33673 changed something about the way child records are persisted when created as a part of their parents.
- Regional Partner Mappings should be unique, and this Regional Parter was invalid as created, because a Regional Partner for Alabama already exists in our test database as a result of seeding.
- On Rails 5.2, attempting to join sessions to workshops with `regional_partner.pd_workshops.joins(:sessions` fails when `regional_parter` is invalid.

Like I said, it's not entirely clear why these things are connected but a `git bisect` indicates that they are. A simple - if uninformed - fix is to simply not use a regional partner mapping here when that's not what we are actually testing.

<!--
  Your description goes here: A summary of the change, including any relevant motivation and context.

  If relevant, include a description both of the existing behavior and of the new behavior.
-->

<!--
  Other aspects to consider. uncomment and add detail for any that seem necessary:
-->

<!-- ### Background -->
<!-- ### Privacy -->
<!--
1.	Does the Project involve the collection, use or sharing of new Personal Data?

2.	Does the Project involve a new or changed use or sharing of existing Personal Data?
-->
<!-- ### Security -->
<!--
Link to Jira Task where sensitive security issues are discussed privately.
-->
<!-- ### Caching -->
<!-- ### Deployment strategy -->
<!-- ### Future work -->

## Testing story

Tested manually.

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
