### PR TITLE
Update banner on code.org/learn

### DIFF
--- a/pegasus/sites.v3/code.org/public/learn/index.haml
+++ b/pegasus/sites.v3/code.org/public/learn/index.haml
@@ -30,40 +30,30 @@ style_min: false
   #fullwidth {
     overflow: hidden;
     background-size: cover;
-    background-image: url(/images/learn/hoc2019_background.png)
   }
   .banner {
-    color: white;
+    color: black;
     text-align: center;
-    padding-left: 12px;
-    padding-right: 12px;
+    margin-bottom: 10px;
   }
   .banner a {
-    color: white;
+    color: black;
     text-decoration: underline;
     font-family: 'Gotham 5r', sans-serif;
   }
   .bannerHeading {
     font-family: 'Gotham 5r', sans-serif;
-    font-size: 40px;
-    line-height: 40px;
+    font-size: 45px;
+    line-height: 45px;
     padding: 20px 0px 20px 0px;
   }
   .bannerBeyond {
     padding-top: 15px;
   }
   .bannerTeachers {
-    padding-top: 30px;
+    padding-top: 15px;
     padding-bottom: 10px;
     opacity: 0;
-  }
-  .bannerTeacherIcon {
-    height: 26px;
-    padding-right: 5px;
-    vertical-align: top;
-  }
-  #studentImage {
-    height: 278px;
   }
 
   /* Center the foreground image when it's below the header text. */
@@ -73,6 +63,28 @@ style_min: false
       transform: translateX(-50%);
       left: 50%;
       height: 278px;
+    }
+  }
+
+  @media screen and (min-width: 992px) {
+    #fullwidth {
+      background-image: url(#{CDO.code_org_url('/images/learn/hoc2020_background.png')});
+      background-position: 70% 70%;
+    }
+  }
+  @media screen and (min-width: 768px) and (max-width: 991px) {
+    #fullwidth {
+      background-image: url(#{CDO.code_org_url('/images/learn/hoc2020_background_tablet.png')});
+      background-position: 67% 50%;
+      padding-bottom: 200px;
+    }
+  }
+  /* Use the narrow image for narrower screens */
+  @media screen and (max-width: 767px) {
+    #fullwidth {
+      background-image: url(#{CDO.code_org_url('/images/learn/hoc2020_background_narrow.png')});
+      background-position: 50% 80%;
+      padding-bottom: 160px;
     }
   }
 
@@ -89,15 +101,14 @@ style_min: false
         = view :mobile_header_responsive
 
   .banner.container_responsive
-    .col-50
+    .col-sm-12.col-md-6{style: "text-align: center"}
       .bannerHeading= hoc_s(:learn_banner_heading)
       = hoc_s(:learn_banner_blurb)
       .bannerBeyond
         != hoc_s(:learn_banner_beyond_markdown, markdown: :inline, locals: {url: "https://hourofcode.com/beyond"})
       .bannerTeachers
-        %img.bannerTeacherIcon{src: "/images/learn/teacher_icon.png"}
+        %i{:class=>"fa fa-graduation-cap", :style=>"font-size: larger"}
         != hoc_s(:learn_banner_teachers_markdown, markdown: :inline, locals: {host_url: "https://hourofcode.com/#join", howto_url: "https://hourofcode.com/how-to"})
-    #studentImage.col-50.tablet-feature
 
   .clear{style: "clear:both"}
 
@@ -135,15 +146,6 @@ style_min: false
       defaultSortByPopularity: #{Tutorials.sort_by_popularity?(request.site, DCDO.get("hoc_mode", CDO.default_hoc_mode))}
     });
     tutorialExplorerManager.renderToElement(document.getElementById('tutorials'));
-
-    var studentImage = '/images/learn/hoc2019_foreground.png';
-    var img = $('<img>');
-    img.attr('src', studentImage);
-    img.attr('style', 'opacity: 0');
-    img.appendTo('#studentImage');
-    img.on('load', function() {
-      img.fadeTo('normal', 1);
-    });
 
     // Open banner links in new tab; we render them with markdown, so we can't do this in the haml
     // Add the rel tag to attempt to mitigate the inherent danger in opening


### PR DESCRIPTION
In my initial banner [PR](https://github.com/code-dot-org/code-dot-org/pull/37215) I did not update code.org/learn to use the new banner. This updates that banner to use the same background and styling as hourofcode.com/learn
Banner looks like this:
Desktop
<img width="1779" alt="Screen Shot 2020-11-04 at 3 41 37 PM" src="https://user-images.githubusercontent.com/33666587/98180046-02cf8380-1eb5-11eb-950b-e27f1c590953.png">

Mobile
![Screen Shot 2020-11-04 at 3 44 33 PM](https://user-images.githubusercontent.com/33666587/98180029-fc410c00-1eb4-11eb-80c2-c260bfffc112.png)


## Testing story
Tested locally on multiple browsers and sizes.

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
