### PR TITLE
initial version of script to merge data from curriculum builder into code studio

### DIFF
--- a/bin/oneoff/import_unit_details.rb
+++ b/bin/oneoff/import_unit_details.rb
@@ -65,7 +65,7 @@ def parse_options
 end
 
 def main(options)
-  cb_url_prefix = options.local ? 'http://localhost:8000' : 'https://www.codecurricula.com'
+  cb_url_prefix = options.local ? 'http://localhost:8000' : 'https://curriculum.code.org'
 
   options.unit_names.each do |unit_name|
     script = Script.find_by_name!(unit_name)

--- a/bin/oneoff/import_unit_details.rb
+++ b/bin/oneoff/import_unit_details.rb
@@ -7,6 +7,14 @@ require_relative '../../deployment'
 # Once this script is ready, only levelbuilder should be added to this list.
 raise unless [:development, :adhoc].include? rack_env
 
+# Wait until after initial error checking before loading the rails environment.
+def require_rails_env
+  puts "loading rails environment..."
+  start_time = Time.now
+  require_relative '../../dashboard/config/environment'
+  puts "rails environment loaded in #{(Time.now - start_time).to_i} seconds."
+end
+
 def parse_options
   OpenStruct.new.tap do |options|
     options.local = false
@@ -14,10 +22,15 @@ def parse_options
     options.dry_run = false
 
     opt_parser = OptionParser.new do |opts|
-      opts.banner = "\nUsage: #{$0} [options] \n\
-        Example: runner.rb -u coursea-2021 \n\
-        Example: runner.rb -l -u csd1-2021 \n\
-        Example: runner.rb -l -u csp2-2020,csp3-2021,csp4-2021"
+      opts.banner = <<~BANNER
+
+        Usage: #{$0} [options]
+
+        Example: runner.rb -u coursea-2021
+        Example: runner.rb -l -u csd1-2021
+        Example: runner.rb -l -u csp2-2020,csp3-2021,csp4-2021
+      BANNER
+
       opts.separator ""
 
       opts.on('-l', '--local', 'Use local curriculum builder running on localhost:8000.') do
@@ -67,10 +80,5 @@ end
 options = parse_options
 raise "unit name is required. Use -h for options." unless options.unit_names.present?
 
-# Wait until after initial error checking before loading the rails environment.
-puts "loading rails environment..."
-start_time = Time.now
-require_relative '../../dashboard/config/environment'
-puts "rails environment loaded in #{(Time.now - start_time).to_i} seconds."
-
+require_rails_env
 main(options)

--- a/bin/oneoff/import_unit_details.rb
+++ b/bin/oneoff/import_unit_details.rb
@@ -33,7 +33,7 @@ def parse_options
 
         Example: runner.rb -u coursea-2021
         Example: runner.rb -l -u csd1-2021
-        Example: runner.rb -l -u csp2-2020,csp3-2021,csp4-2021
+        Example: runner.rb -l -u csp2-2021,csp3-2021,csp4-2021
       BANNER
 
       opts.separator ""

--- a/bin/oneoff/import_unit_details.rb
+++ b/bin/oneoff/import_unit_details.rb
@@ -24,8 +24,8 @@ def parse_options
         options.local = true
       end
 
-      opts.on('-u', '--unit_name UnitName1,UnitName2', Array, 'Unit names to import') do |f|
-        options.unit_name = f
+      opts.on('-u', '--unit_names UnitName1,UnitName2', Array, 'Unit names to import') do |unit_names|
+        options.unit_names = unit_names
       end
 
       opts.on('-n', '--dry-run', 'Perform basic validation without importing any data.') do
@@ -43,12 +43,14 @@ def parse_options
 end
 
 def main(options)
-  script = Script.find_by_name!(options.unit_name)
-  puts "found code studio script name #{script.name} with id #{script.id}"
+  options.unit_names.each do |unit_name|
+    script = Script.find_by_name!(unit_name)
+    puts "found code studio script name #{script.name} with id #{script.id}"
+  end
 end
 
 options = parse_options
-raise "unit name is required. Use -h for options." unless options.unit_name
+raise "unit name is required. Use -h for options." unless options.unit_names.present?
 
 # Wait until after initial error checking before loading the rails environment.
 puts "loading rails environment..."

--- a/bin/oneoff/import_unit_details.rb
+++ b/bin/oneoff/import_unit_details.rb
@@ -43,9 +43,16 @@ def parse_options
 end
 
 def main(options)
+  cb_url_prefix = options.local ? 'http://localhost:8000' : 'https://www.codecurricula.com'
+
   options.unit_names.each do |unit_name|
     script = Script.find_by_name!(unit_name)
     puts "found code studio script name #{script.name} with id #{script.id}"
+
+    url = "#{cb_url_prefix}/export/unit/#{unit_name}.json?format=json"
+    puts "fetching unit json from #{url}"
+    cb_unit_json = `curl #{url}`
+    puts "received #{cb_unit_json.length} bytes of unit json."
   end
 end
 

--- a/bin/oneoff/import_unit_details.rb
+++ b/bin/oneoff/import_unit_details.rb
@@ -72,14 +72,19 @@ def main(options)
     log "found code studio script name #{script.name} with id #{script.id}"
 
     url = "#{cb_url_prefix}/export/unit/#{unit_name}.json?format=json"
-    log "fetching unit json from #{url}"
-    curl_opts = $verbose ? '' : ' -s'
-    cb_unit_json = `curl#{curl_opts} #{url}`
-    log "received #{cb_unit_json.length} bytes of unit json."
+    cb_unit_json = fetch(url)
 
     cb_unit = JSON.parse(cb_unit_json)
     validate_unit(script, cb_unit)
   end
+end
+
+def fetch(url)
+  log "fetching unit json from #{url}"
+  curl_opts = $verbose ? '' : ' -s'
+  cb_unit_json = `curl#{curl_opts} #{url}`
+  log "received #{cb_unit_json.length} bytes of unit json."
+  cb_unit_json
 end
 
 def validate_unit(script, cb_unit)

--- a/bin/oneoff/import_unit_details.rb
+++ b/bin/oneoff/import_unit_details.rb
@@ -1,0 +1,59 @@
+#!/usr/bin/env ruby
+
+require 'json'
+require 'optparse'
+require_relative '../../deployment'
+
+# Once this script is ready, only levelbuilder should be added to this list.
+raise unless [:development, :adhoc].include? rack_env
+
+def parse_options
+  OpenStruct.new.tap do |options|
+    options.local = false
+    options.unit_name = nil
+    options.dry_run = false
+
+    opt_parser = OptionParser.new do |opts|
+      opts.banner = "\nUsage: #{$0} [options] \n\
+        Example: runner.rb -u coursea-2021 \n\
+        Example: runner.rb -l -u csd1-2021 \n\
+        Example: runner.rb -l -u csp2-2020,csp3-2021,csp4-2021"
+      opts.separator ""
+
+      opts.on('-l', '--local', 'Use local curriculum builder running on localhost:8000.') do
+        options.local = true
+      end
+
+      opts.on('-u', '--unit_name UnitName1,UnitName2', Array, 'Unit names to import') do |f|
+        options.unit_name = f
+      end
+
+      opts.on('-n', '--dry-run', 'Perform basic validation without importing any data.') do
+        options.dry_run = true
+      end
+
+      opts.on_tail("-h", "--help", "Show this message") do
+        puts opts
+        exit
+      end
+    end
+
+    opt_parser.parse!(ARGV)
+  end
+end
+
+def main(options)
+  script = Script.find_by_name!(options.unit_name)
+  puts "found code studio script name #{script.name} with id #{script.id}"
+end
+
+options = parse_options
+raise "unit name is required. Use -h for options." unless options.unit_name
+
+# Wait until after initial error checking before loading the rails environment.
+puts "loading rails environment..."
+start_time = Time.now
+require_relative '../../dashboard/config/environment'
+puts "rails environment loaded in #{(Time.now - start_time).to_i} seconds."
+
+main(options)

--- a/bin/oneoff/import_unit_details.rb
+++ b/bin/oneoff/import_unit_details.rb
@@ -53,7 +53,15 @@ def main(options)
     puts "fetching unit json from #{url}"
     cb_unit_json = `curl #{url}`
     puts "received #{cb_unit_json.length} bytes of unit json."
+
+    cb_unit_data = JSON.parse(cb_unit_json)
+    validate_unit(script, cb_unit_data)
   end
+end
+
+def validate_unit(script, cb_unit_data)
+  raise "unexpected unit_name #{cb_unit_data['unit_name']}" unless cb_unit_data['unit_name'] == script.name
+  puts "validated unit data for #{script.name}"
 end
 
 options = parse_options

--- a/bin/oneoff/import_unit_details.rb
+++ b/bin/oneoff/import_unit_details.rb
@@ -7,12 +7,17 @@ require_relative '../../deployment'
 # Once this script is ready, only levelbuilder should be added to this list.
 raise unless [:development, :adhoc].include? rack_env
 
+$verbose = false
+def log(str)
+  puts str if $verbose
+end
+
 # Wait until after initial error checking before loading the rails environment.
 def require_rails_env
-  puts "loading rails environment..."
+  log "loading rails environment..."
   start_time = Time.now
   require_relative '../../dashboard/config/environment'
-  puts "rails environment loaded in #{(Time.now - start_time).to_i} seconds."
+  log "rails environment loaded in #{(Time.now - start_time).to_i} seconds."
 end
 
 def parse_options
@@ -45,6 +50,10 @@ def parse_options
         options.dry_run = true
       end
 
+      opts.on('-v', '--verbose', 'Use verbose debug logging.') do
+        $verbose = true
+      end
+
       opts.on_tail("-h", "--help", "Show this message") do
         puts opts
         exit
@@ -60,12 +69,13 @@ def main(options)
 
   options.unit_names.each do |unit_name|
     script = Script.find_by_name!(unit_name)
-    puts "found code studio script name #{script.name} with id #{script.id}"
+    log "found code studio script name #{script.name} with id #{script.id}"
 
     url = "#{cb_url_prefix}/export/unit/#{unit_name}.json?format=json"
-    puts "fetching unit json from #{url}"
-    cb_unit_json = `curl #{url}`
-    puts "received #{cb_unit_json.length} bytes of unit json."
+    log "fetching unit json from #{url}"
+    curl_opts = $verbose ? '' : ' -s'
+    cb_unit_json = `curl#{curl_opts} #{url}`
+    log "received #{cb_unit_json.length} bytes of unit json."
 
     cb_unit_data = JSON.parse(cb_unit_json)
     validate_unit(script, cb_unit_data)
@@ -74,7 +84,7 @@ end
 
 def validate_unit(script, cb_unit_data)
   raise "unexpected unit_name #{cb_unit_data['unit_name']}" unless cb_unit_data['unit_name'] == script.name
-  puts "validated unit data for #{script.name}"
+  log "validated unit data for #{script.name}"
 end
 
 options = parse_options

--- a/bin/oneoff/import_unit_details.rb
+++ b/bin/oneoff/import_unit_details.rb
@@ -77,13 +77,13 @@ def main(options)
     cb_unit_json = `curl#{curl_opts} #{url}`
     log "received #{cb_unit_json.length} bytes of unit json."
 
-    cb_unit_data = JSON.parse(cb_unit_json)
-    validate_unit(script, cb_unit_data)
+    cb_unit = JSON.parse(cb_unit_json)
+    validate_unit(script, cb_unit)
   end
 end
 
-def validate_unit(script, cb_unit_data)
-  raise "unexpected unit_name #{cb_unit_data['unit_name']}" unless cb_unit_data['unit_name'] == script.name
+def validate_unit(script, cb_unit)
+  raise "unexpected unit_name #{cb_unit['unit_name']}" unless cb_unit['unit_name'] == script.name
   log "validated unit data for #{script.name}"
 end
 


### PR DESCRIPTION
Depends on https://github.com/code-dot-org/curriculumbuilder/pull/319 . This PR gets us to the point where we have access to curriculum builder data in json format in a place where we can also access to the Code Studio data model via ActiveRecord. Given a unit name:
1. finds the corresponding script in code studio using ActiveRecord
2. fetches the data for the same script from curriculum builder server as json 
3. validates that we got valid json from curriculum builder containing the correct unit name

when we whiteboarded, we talked about having step 2 pull in json from a file.  I'm deviating from that plan a little here by requesting the json directly from curriculum builder. this way seems a little easier to use since there is no need to keep track of a bunch of local files, and the json details can be viewed with nice formatting by looking at urls like http://www.codecurricula.com/export/unit/coursea-2020.json . 

In the future, if we decide that we do not want to hit the curriculum builder server each time the script is run, then we could publish the json to S3 and access it via curriculum.code.org instead. this is the approach used by standards here: https://github.com/code-dot-org/code-dot-org/blob/bb207e169d34fbb078422c7520edb34147865bfa/apps/src/sites/studio/pages/admin_standards/index.js#L4-L7

However, my initial thought is that the curriculum builder server can handle this load, and that it would be annoying to have to go and publish each unit just to be able to access this data.

## Testing story

![Screen Shot 2020-11-05 at 9 50 27 AM](https://user-images.githubusercontent.com/8001765/98278154-0ca4c580-1f4d-11eb-9b07-fdaf71ad1e49.png)

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
