### PR TITLE
Change Tip to Callout in the user facing locations of the editor

### DIFF
--- a/apps/src/lib/levelbuilder/lesson-editor/ActivitySectionCardButtons.jsx
+++ b/apps/src/lib/levelbuilder/lesson-editor/ActivitySectionCardButtons.jsx
@@ -145,7 +145,7 @@ class ActivitySectionCardButtons extends Component {
               type="button"
             >
               <i style={{marginRight: 7}} className="fa fa-plus-circle" />
-              Tip
+              Callout
             </button>
             <button
               onMouseDown={this.handleOpenAddResource}

--- a/apps/src/lib/levelbuilder/lesson-editor/EditTipDialog.jsx
+++ b/apps/src/lib/levelbuilder/lesson-editor/EditTipDialog.jsx
@@ -83,7 +83,7 @@ export default class EditTipDialog extends Component {
         style={styles.dialog}
       >
         <div style={styles.dialogContent}>
-          <h2>Add Tip</h2>
+          <h2>Add Callout</h2>
           <select
             onChange={this.handleTipTypeChange}
             value={this.state.tip.type}
@@ -109,7 +109,7 @@ export default class EditTipDialog extends Component {
         </div>
         <DialogFooter>
           <ConfirmDeleteButton
-            title={'Delete Tip?'}
+            title={'Delete Callout?'}
             body={`Are you sure you want to remove the ${
               tipTypes[this.state.tip.type].displayName
             } with key "${this.state.tip.key}" from the Activity?`}

--- a/apps/test/unit/lib/levelbuilder/lesson-editor/ActivitySectionCardButtonsTest.jsx
+++ b/apps/test/unit/lib/levelbuilder/lesson-editor/ActivitySectionCardButtonsTest.jsx
@@ -55,7 +55,7 @@ describe('ActivitySectionCardButtons', () => {
     const wrapper = shallow(<ActivitySectionCardButtons {...defaultProps} />);
 
     const button = wrapper.find('button').at(1);
-    expect(button.text()).to.include('Tip');
+    expect(button.text()).to.include('Callout');
     button.simulate('mouseDown');
     expect(wrapper.state().tipToEdit).to.not.be.null;
   });

--- a/apps/test/unit/lib/levelbuilder/lesson-editor/EditTipDialogTest.jsx
+++ b/apps/test/unit/lib/levelbuilder/lesson-editor/EditTipDialogTest.jsx
@@ -23,7 +23,7 @@ describe('EditTipDialog', () => {
 
   it('renders default props', () => {
     const wrapper = shallow(<EditTipDialog {...defaultProps} />);
-    expect(wrapper.contains('Add Tip')).to.be.true;
+    expect(wrapper.contains('Add Callout')).to.be.true;
     expect(wrapper.find('LessonTip').length).to.equal(1);
     expect(wrapper.find('select').length).to.equal(1);
     expect(wrapper.find('textarea').length).to.equal(1);


### PR DESCRIPTION
[Curriculum team said that Tip was not clear enough and that Callout would be a better word](https://docs.google.com/document/d/1OKoxDQtYfFPEbUEIv5IWUPL9IoEl8t-NwfIKgZc3THE/edit?ts=5fa319f0#) for Teaching Tips, Discussion Goals, Content Corners, and Assessment Opportunities.  I have changed the text in user facing settings to say callout but left all the other references to tip alone. 

![Screen Shot 2020-11-05 at 1 49 50 PM](https://user-images.githubusercontent.com/208083/98283535-c744c000-1f6d-11eb-9114-b09b18a9c643.png)
![Screen Shot 2020-11-05 at 1 49 44 PM](https://user-images.githubusercontent.com/208083/98283547-cc097400-1f6d-11eb-8f00-5813076e19e3.png)
