### PR TITLE
Fix isRequired warnings in editors

### DIFF
--- a/apps/src/lib/levelbuilder/lesson-editor/LessonEditor.jsx
+++ b/apps/src/lib/levelbuilder/lesson-editor/LessonEditor.jsx
@@ -8,7 +8,6 @@ import HelpTip from '@cdo/apps/lib/ui/HelpTip';
 import {announcementShape} from '@cdo/apps/code-studio/announcementsRedux';
 import AnnouncementsEditor from '@cdo/apps/lib/levelbuilder/announcementsEditor/AnnouncementsEditor';
 import CollapsibleEditorSection from '@cdo/apps/lib/levelbuilder/CollapsibleEditorSection';
-import {resourceShape} from '@cdo/apps/lib/levelbuilder/shapes';
 import RelatedLessons from './RelatedLessons';
 import {relatedLessonShape} from '../shapes';
 import color from '@cdo/apps/util/color';
@@ -62,7 +61,6 @@ export default class LessonEditor extends Component {
     purpose: PropTypes.string,
     preparation: PropTypes.string,
     announcements: PropTypes.arrayOf(announcementShape),
-    resources: PropTypes.arrayOf(resourceShape).isRequired,
     relatedLessons: PropTypes.arrayOf(relatedLessonShape).isRequired,
     objectives: PropTypes.arrayOf(PropTypes.object).isRequired
   };

--- a/apps/src/lib/levelbuilder/shapes.jsx
+++ b/apps/src/lib/levelbuilder/shapes.jsx
@@ -34,7 +34,7 @@ export const scriptLevelShape = PropTypes.shape({
   levels: PropTypes.arrayOf(levelShape).isRequired,
 
   // whether this LevelToken is expanded in the UI.
-  expand: PropTypes.bool.isRequired,
+  expand: PropTypes.bool,
 
   // information determined at script level
   kind: PropTypes.string,

--- a/apps/test/unit/lib/levelbuilder/lesson-editor/LessonEditorTest.js
+++ b/apps/test/unit/lib/levelbuilder/lesson-editor/LessonEditorTest.js
@@ -43,8 +43,7 @@ describe('LessonEditor', () => {
       preparation: '- One',
       announcements: [],
       relatedLessons: [],
-      objectives: [],
-      resources: []
+      objectives: []
     };
   });
 


### PR DESCRIPTION
After adding isRequired to a bunch of things in the editors Dave noticed the following warnings.

![](https://user-images.githubusercontent.com/8001765/98047885-9172d080-1de1-11eb-8d64-8310600470e5.png)

1) The resources were required by the LessonEditor but were no longer being passed to the Lesson Editor because they are now stored in the resources redux instead
2) Make expand not be required