### PR TITLE
Enabled time-spent logging on oceans levels

### DIFF
--- a/apps/src/fish/Fish.js
+++ b/apps/src/fish/Fish.js
@@ -56,6 +56,7 @@ Fish.prototype.init = function(config) {
   const onMount = () => {
     // NOTE: Other apps call studioApp.init(), except WebLab. Fish is imitating WebLab
     this.studioApp_.setConfigValues_(config);
+    this.studioApp_.initTimeSpent();
 
     // NOTE: if we called studioApp_.init(), the code here would be executed
     // automatically since pinWorkspaceToBottom is true...


### PR DESCRIPTION
This sets up time_spent logging for oceans levels - the last level type where we currently plan to enable it.


<!-- ### Background -->
<!-- ### Privacy -->
<!--
1.	Does the Project involve the collection, use or sharing of new Personal Data?

2.	Does the Project involve a new or changed use or sharing of existing Personal Data?
-->
<!-- ### Security -->
<!--
Link to Jira Task where sensitive security issues are discussed privately.
-->
<!-- ### Caching -->
<!-- ### Deployment strategy -->
<!-- ### Future work -->

## Links

<!--
  Any relevant links to external resources; ie, specification documents, jira
  items, related PRs, honeybadger errors, etc
-->

- [Dev Doc: Recording Time Spent Plan](https://docs.google.com/document/d/1sSxS1C0XHokLh34ObposdzI0I1FwCY7qJXmn0mtpwi0/edit?ts=5d8932a9&pli=1)
- [Spec: Improvements to the progress tab](https://docs.google.com/document/d/11vid6ZWkpUV5TJm3swI6kbdSpg5_93UHDxnod58r_Zc/edit#)
- [Finishes: LP-1582](https://codedotorg.atlassian.net/browse/LP-1582)
- [No longer needed: LP-1580](https://codedotorg.atlassian.net/browse/LP-1580)
- [No longer needed: LP-1584](https://codedotorg.atlassian.net/browse/LP-1584)

## Testing story

<!--
  Does your change include appropriate tests?

  If so, please describe how the tests included in this PR are sufficient

  If not, please explain why this change does not need to be tested.
-->

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
