### PR TITLE
Azure Speech Service API error handling

### DIFF
--- a/dashboard/app/controllers/projects_controller.rb
+++ b/dashboard/app/controllers/projects_controller.rb
@@ -320,9 +320,9 @@ class ProjectsController < ApplicationController
       small_footer: !iframe_embed_app_and_code && !sharing && (@game.uses_small_footer? || @level.enable_scrolling?),
       has_i18n: @game.has_i18n?,
       game_display_name: data_t("game.name", @game.name),
-      azure_speech_service_token: azure_speech_service[:azureSpeechServiceToken],
-      azure_speech_service_region: azure_speech_service[:azureSpeechServiceRegion],
-      azure_speech_service_languages: azure_speech_service[:azureSpeechServiceLanguages]
+      azure_speech_service_token: azure_speech_service[:token],
+      azure_speech_service_region: azure_speech_service[:region],
+      azure_speech_service_languages: azure_speech_service[:languages]
     )
 
     if params[:key] == 'artist'

--- a/dashboard/app/helpers/levels_helper.rb
+++ b/dashboard/app/helpers/levels_helper.rb
@@ -472,7 +472,8 @@ module LevelsHelper
     token_http_request = Net::HTTP.new(token_uri.host, token_uri.port)
     token_http_request.use_ssl = true
     token_http_request.verify_mode = OpenSSL::SSL::VERIFY_PEER
-    token_http_request.write_timeout = timeout
+    # TODO: Change read_timeout to write_timeout when we upgrade to Ruby 2.6+.
+    token_http_request.read_timeout = timeout
     token_request = Net::HTTP::Post.new(token_uri.request_uri, {'Ocp-Apim-Subscription-Key': api_key})
 
     token_http_request.request(token_request)&.body

--- a/dashboard/app/helpers/levels_helper.rb
+++ b/dashboard/app/helpers/levels_helper.rb
@@ -467,7 +467,7 @@ module LevelsHelper
     fb_options
   end
 
-  def request_azure_speech_service_token(region, api_key, timeout)
+  def get_azure_speech_service_token(region, api_key, timeout)
     token_uri = URI.parse("https://#{region}.api.cognitive.microsoft.com/sts/v1.0/issueToken")
     token_http_request = Net::HTTP.new(token_uri.host, token_uri.port)
     token_http_request.use_ssl = true
@@ -507,7 +507,7 @@ module LevelsHelper
     # First, get the token and region
     options = {}
     timeout = DCDO.get('azure_speech_service_timeout', 5)
-    options[:token] = request_azure_speech_service_token(CDO.azure_speech_service_region, CDO.azure_speech_service_key, timeout)
+    options[:token] = get_azure_speech_service_token(CDO.azure_speech_service_region, CDO.azure_speech_service_key, timeout)
     return {} unless options[:token].present?
     options[:region] = CDO.azure_speech_service_region
 

--- a/dashboard/app/helpers/levels_helper.rb
+++ b/dashboard/app/helpers/levels_helper.rb
@@ -492,9 +492,9 @@ module LevelsHelper
     voice_request = Net::HTTP::Get.new(voice_uri.request_uri, {'Authorization': 'Bearer ' + token})
 
     response = voice_http_request.request(voice_request)&.body
-    response.length >= 2 ? JSON.parse(response) : {}
+    response.length >= 2 ? JSON.parse(response) : []
   rescue => e
-    Honeybadger.notify(e, 'Request for list of voices from Azure Speech Service failed')
+    Honeybadger.notify(e, error_message: 'Request for list of voices from Azure Speech Service failed')
     nil
   end
 
@@ -513,7 +513,7 @@ module LevelsHelper
 
     # Then, get the list of voices and languages
     voices = get_azure_speech_service_voices(options[:region], options[:token], timeout)
-    return {} unless voices.present?
+    return {} unless (voices&.length || 0) > 0
     language_dictionary = {}
     voices.each do |voice|
       native_locale_name = Languages.get_native_name_by_locale(voice["Locale"])

--- a/dashboard/app/helpers/levels_helper.rb
+++ b/dashboard/app/helpers/levels_helper.rb
@@ -499,8 +499,8 @@ module LevelsHelper
   end
 
   def azure_speech_service_options
-    # TODO: add Gatekeeper flag
-    return {} unless @level.game.use_azure_speech_service? &&
+    return {} unless Gatekeeper.allows('azure_speech_service', default: true) &&
+      @level.game.use_azure_speech_service? &&
       CDO.azure_speech_service_region.present? &&
       CDO.azure_speech_service_key.present?
 

--- a/dashboard/test/helpers/levels_helper_test.rb
+++ b/dashboard/test/helpers/levels_helper_test.rb
@@ -1,4 +1,5 @@
 require 'test_helper'
+require 'webmock/minitest'
 
 class LevelsHelperTest < ActionView::TestCase
   include Devise::Test::ControllerHelpers
@@ -324,6 +325,95 @@ class LevelsHelperTest < ActionView::TestCase
     app_options = question_options
 
     assert_not app_options[:level]['submittable']
+  end
+
+  test 'get_azure_speech_service_token returns token on success' do
+    region = 'westus'
+    api_key = 'abc123'
+    mock_token = 'a1b2c3d4'
+    stub_request(:post, "https://#{region}.api.cognitive.microsoft.com/sts/v1.0/issueToken").
+      with(headers: {'Ocp-Apim-Subscription-Key' => api_key}).
+      to_return(status: 200, body: mock_token)
+    assert_equal mock_token, get_azure_speech_service_token(region, api_key, 1)
+  end
+
+  test 'get_azure_speech_service_token returns nil on error' do
+    region = 'westus'
+    api_key = 'abc123'
+    stub_request(:post, "https://#{region}.api.cognitive.microsoft.com/sts/v1.0/issueToken").
+      with(headers: {'Ocp-Apim-Subscription-Key' => api_key}).
+      to_raise(ArgumentError)
+    Honeybadger.expects(:notify).once
+    assert_nil get_azure_speech_service_token(region, api_key, 1)
+  end
+
+  test 'get_azure_speech_service_voices returns voices array on success' do
+    region = 'eastus'
+    mock_token = 'a1b2c3d4'
+
+    # Empty response
+    stub_request(:get, "https://#{region}.tts.speech.microsoft.com/cognitiveservices/voices/list").
+      with(headers: {'Authorization' => "Bearer #{mock_token}"}).
+      to_return(status: 200, body: '')
+    assert_equal [], get_azure_speech_service_voices(region, mock_token, 1)
+
+    # Voices list response
+    mock_voices = [{'Locale': 'en-US', 'Gender': 'female'}].to_json
+    stub_request(:get, "https://#{region}.tts.speech.microsoft.com/cognitiveservices/voices/list").
+      with(headers: {'Authorization' => "Bearer #{mock_token}"}).
+      to_return(status: 200, body: mock_voices)
+    assert_equal JSON.parse(mock_voices), get_azure_speech_service_voices(region, mock_token, 1)
+  end
+
+  test 'get_azure_speech_service_voices returns nil on error' do
+    region = 'eastus'
+    mock_token = 'a1b2c3'
+    stub_request(:get, "https://#{region}.tts.speech.microsoft.com/cognitiveservices/voices/list").
+      with(headers: {'Authorization' => "Bearer #{mock_token}"}).
+      to_raise(ArgumentError)
+    assert_nil get_azure_speech_service_voices(region, mock_token, 1)
+  end
+
+  test 'azure_speech_service_options returns options object on success' do
+    @level.game.expects(:use_azure_speech_service?).returns(true)
+    CDO.stubs(:azure_speech_service_region).returns('westus')
+    CDO.stubs(:azure_speech_service_key).returns('abc123')
+    stubs(:get_azure_speech_service_token).returns('a1b2c3')
+    Languages.expects(:get_native_name_by_locale).with('en-US').returns([{native_name_s: 'English'}]).twice
+    Languages.expects(:get_native_name_by_locale).with('it-IT').returns([{native_name_s: 'Italian'}]).once
+    mock_voices = [
+      {'Locale' => 'en-US', 'Gender' => 'Female', 'ShortName' => 'Alice'},
+      {'Locale' => 'en-US', 'Gender' => 'Male', 'ShortName' => 'Bob'},
+      {'Locale' => 'it-IT', 'Gender' => 'Male', 'ShortName' => 'Dan'}, # Will be filtered out
+    ]
+    stubs(:get_azure_speech_service_voices).returns(mock_voices)
+
+    expected_options = {
+      token: 'a1b2c3',
+      region: 'westus',
+      languages: {'English' => {'female' => 'Alice', 'languageCode' => 'en-US', 'male' => 'Bob'}}
+    }
+    assert_equal expected_options, azure_speech_service_options
+  end
+
+  test 'azure_speech_service_options returns empty object if any responses are empty' do
+    @level.game.stubs(:use_azure_speech_service?).returns(true)
+    CDO.stubs(:azure_speech_service_region).returns('westus')
+    CDO.stubs(:azure_speech_service_key).returns('abc123')
+
+    # Empty token response
+    stubs(:get_azure_speech_service_token).returns(nil)
+    assert_empty azure_speech_service_options
+
+    # Empty voices response
+    stubs(:get_azure_speech_service_token).returns('a1b2c3')
+    stubs(:get_azure_speech_service_voices).returns([])
+    assert_empty azure_speech_service_options
+
+    # Nil voices response
+    stubs(:get_azure_speech_service_token).returns('a1b2c3')
+    stubs(:get_azure_speech_service_voices).returns(nil)
+    assert_empty azure_speech_service_options
   end
 
   test 'submittable level is submittable for student with teacher' do

--- a/dashboard/test/helpers/levels_helper_test.rb
+++ b/dashboard/test/helpers/levels_helper_test.rb
@@ -396,6 +396,12 @@ class LevelsHelperTest < ActionView::TestCase
     assert_equal expected_options, azure_speech_service_options
   end
 
+  test 'azure_speech_service_options returns an empty object if gatekeeper disallows it' do
+    expects(:get_azure_speech_service_token).never
+    Gatekeeper.expects(:allows).with('azure_speech_service', default: true).returns(false)
+    assert_empty azure_speech_service_options
+  end
+
   test 'azure_speech_service_options returns empty object if any responses are empty' do
     @level.game.stubs(:use_azure_speech_service?).returns(true)
     CDO.stubs(:azure_speech_service_region).returns('westus')


### PR DESCRIPTION
This PR is a pure refactor with improvements in how we handle errors from Azure's Speech Service API (aka Cognitive Services).

Specifically, an influx of [this Honeybadger error](https://app.honeybadger.io/projects/3240/faults/66859534) has occurred twice in the past ~3 months and has caused Applab and Gamelab projects to return 500s on load (more in the COE below).

Improvements in this PR:
- Rescue errors gracefully for both API Requests to the Speech Service
- Log any errors to Honeybadger
- Adds a Gatekeeper flag so we can turn off all requests to the Speech Service without a deploy
- Lowers the HTTP request timeouts from the default (60s) to a configurable DCDO flag (which defaults to 5s)

## Links

- [COE: Azure token request failure in Applab/Gamelab](https://docs.google.com/document/d/145pKXoXEHmh51zQMdmYYiUSQIJe3fyad0XnFoahd7rE/edit#)
- [STAR-1219](https://codedotorg.atlassian.net/browse/STAR-1219)
- Also does some prep work for [STAR-1221](https://codedotorg.atlassian.net/browse/STAR-1221) and [STAR-1299](https://codedotorg.atlassian.net/browse/STAR-1299)

## Testing story

Adds unit tests.

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
