### PR TITLE
AILab: Parameterisation, with levelbuilder support

### DIFF
--- a/apps/src/ailab/Ailab.js
+++ b/apps/src/ailab/Ailab.js
@@ -122,12 +122,8 @@ Ailab.prototype.onContinue = function() {
 };
 
 Ailab.prototype.initMLActivities = function() {
-  const {mode} = this.level;
+  const mode = JSON.parse(this.level.mode);
   const onContinue = this.onContinue.bind(this);
-
-  // Set up initial state
-  const canvas = document.getElementById('activity-canvas');
-  const backgroundCanvas = document.getElementById('background-canvas');
 
   setAssetPath('/blockly/media/skins/ailab/');
 
@@ -135,12 +131,8 @@ Ailab.prototype.initMLActivities = function() {
 
   // Set initial state for UI elements.
   initAll({
-    canvas,
-    backgroundCanvas,
-    appMode: mode,
+    mode,
     onContinue,
-    registerSound: this.studioApp_.registerAudio.bind(this.studioApp_),
-    playSound: this.studioApp_.playAudio.bind(this.studioApp_),
     i18n: ailabMsg
   });
 };

--- a/dashboard/app/models/levels/ailab.rb
+++ b/dashboard/app/models/levels/ailab.rb
@@ -68,4 +68,13 @@ class Ailab < Level
     end
     options.freeze
   end
+
+  # Attributes that are stored as JSON strings but should be passed through to the app as
+  # actual JSON objects.  You can list attributes in snake_case here for consistency, but this method
+  # returns camelCase properties because of where it's used in the pipeline.
+  def self.json_object_attrs
+    %w(
+      mode
+    ).map {|x| x.camelize(:lower)}
+  end
 end

--- a/dashboard/app/views/levels/editors/_ailab.html.haml
+++ b/dashboard/app/views/levels/editors/_ailab.html.haml
@@ -3,6 +3,7 @@
 = render partial: 'levels/editors/fields/code_area', locals: {f: f}
 = render partial: 'levels/editors/fields/video', locals: {f: f}
 = render partial: 'levels/editors/fields/bubble_choice_sublevel', locals: {f: f}
+= render partial: 'levels/editors/fields/ailab_mode', locals: {f: f}
 
 = render partial: 'levels/editors/fields/sharing', locals: {f: f}
 = render partial: 'levels/editors/fields/callouts', locals: {f: f}

--- a/dashboard/app/views/levels/editors/fields/_ailab_mode.html.haml
+++ b/dashboard/app/views/levels/editors/fields/_ailab_mode.html.haml
@@ -1,0 +1,6 @@
+%h1.control-legend{data: {toggle: "collapse", target: "#mode"}}
+  Mode
+
+#mode.in.collapse
+  = f.label :ailab_mode, 'Mode JSON'
+  = f.text_area :mode, placeholder: 'Insert JSON Data', rows: 10, style: 'width: 50%', value: @level.mode


### PR DESCRIPTION
When editing an AI Lab level in levelbuilder, a "mode" JSON string can be provided which is then parsed and passed to AI Lab at startup.

![Screen Shot 2020-11-05 at 9 10 36 PM](https://user-images.githubusercontent.com/2205926/98328791-663bdd00-1fab-11eb-955c-603b53c44902.png)

This pairs nicely with https://github.com/code-dot-org/ml-playground/pull/32.