### PR TITLE
Guarantee immersive-reader-sdk.renderButtons() only called once

### DIFF
--- a/apps/src/templates/instructions/ImmersiveReaderButton.jsx
+++ b/apps/src/templates/instructions/ImmersiveReaderButton.jsx
@@ -11,11 +11,13 @@ class ImmersiveReaderButton extends Component {
   };
 
   componentDidMount() {
-    if (this.shouldRender()) {
+    if (this.shouldRender() && !this.renderButtonsCalled) {
       // Applies inline styling to the .immersive-reader-button elements
       renderButtons({
         elements: [this.container]
       });
+      // Make sure renderButtons() is only called once.
+      this.renderButtonsCalled = true;
     }
   }
 


### PR DESCRIPTION
Received a Zendesk ticket where the ImmersiveReaderButton keeps duplicating. This PR adds a flag to make sure the code which adds styling to the ImmersiveReaderButton only happens once.

## Links
- [Zendesk ticket](https://codeorg.zendesk.com/agent/tickets/300542)

## Testing story
* Couldn't reproduce the bug :(
* Visited http://localhost-studio.code.org:3000/s/express-2020/stage/2/puzzle/6 to verify the ImmersiveReaderButton still works normally.

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
