### PR TITLE
Validate exported CB lessons and pass them to corresponding Lessons in Code Studio

### DIFF
--- a/bin/oneoff/import_unit_details.rb
+++ b/bin/oneoff/import_unit_details.rb
@@ -93,7 +93,15 @@ def main(options)
     validate_unit(script, cb_unit)
     chapters = get_validated_chapters(cb_unit)
     lesson_pairs = get_validated_lesson_pairs(script, chapters)
-    log lesson_pairs.join("\n")
+
+    log "validated unit #{script.name} data"
+
+    next if options.dry_run
+
+    lesson_pairs.each do |lesson, cb_lesson|
+      lesson.update_from_curriculum_builder(cb_lesson)
+    end
+    log "updated #{lesson_pairs.count} lessons in unit #{script.name}"
   end
 end
 

--- a/bin/oneoff/import_unit_details.rb
+++ b/bin/oneoff/import_unit_details.rb
@@ -14,6 +14,11 @@ def log(str)
   puts str if $verbose
 end
 
+$quiet = false
+def warn(str)
+  puts str unless $quiet && !$verbose
+end
+
 # Wait until after initial error checking before loading the rails environment.
 def require_rails_env
   log "loading rails environment..."
@@ -50,6 +55,10 @@ def parse_options
 
       opts.on('-n', '--dry-run', 'Perform basic validation without importing any data.') do
         options.dry_run = true
+      end
+
+      opts.on('-q', '--quiet', 'Silence warnings.') do
+        $quiet = true
       end
 
       opts.on('-v', '--verbose', 'Use verbose debug logging.') do
@@ -154,9 +163,9 @@ def validate_unit(script, cb_unit)
 
   if mismatched_names.any?
     mismatch_summary = mismatched_names.map do |left, right|
-      "'#{left}' --> '#{right}'"
+      "  '#{left}' --> '#{right}'"
     end.join("\n")
-    puts "WARNING: some lesson names differ for unit #{script.name}:\n#{mismatch_summary}"
+    warn "WARNING: some lesson names differ for unit #{script.name}:\n#{mismatch_summary}"
   end
 
   log "validated unit data for #{script.name}"

--- a/bin/oneoff/import_unit_details.rb
+++ b/bin/oneoff/import_unit_details.rb
@@ -91,6 +91,8 @@ def main(options)
 
     cb_unit = JSON.parse(cb_unit_json)
     validate_unit(script, cb_unit)
+    chapters = get_validated_chapters(cb_unit)
+    validate_lessons(script, chapters)
   end
 end
 
@@ -105,11 +107,6 @@ end
 
 def validate_unit(script, cb_unit)
   raise "unexpected unit_name #{cb_unit['unit_name']}" unless cb_unit['unit_name'] == script.name
-
-  chapters = get_validated_chapters(cb_unit)
-  validate_lessons(script, chapters)
-
-  log "validated unit data for #{script.name}"
 end
 
 def get_validated_chapters(cb_unit)

--- a/bin/oneoff/import_unit_details.rb
+++ b/bin/oneoff/import_unit_details.rb
@@ -86,12 +86,11 @@ def main(options)
 end
 
 def fetch(url)
-  log "fetching unit json from #{url}"
   uri = URI(url)
   response = Net::HTTP.get_response(uri)
   raise "HTTP status #{response.code} fetching #{uri}" unless response.is_a? Net::HTTPSuccess
   body = response.body
-  log "received #{body.length} bytes of unit json."
+  log "fetched #{body.length} bytes of unit json from #{uri}"
   body
 end
 

--- a/bin/oneoff/import_unit_details.rb
+++ b/bin/oneoff/import_unit_details.rb
@@ -111,6 +111,10 @@ def validate_unit(script, cb_unit)
   log "validated unit data for #{script.name}"
 end
 
+def get_chapters(cb_unit)
+  cb_unit['chapters'].presence || [{'lessons' => cb_unit['lessons']}]
+end
+
 options = parse_options
 raise "unit name is required. Use -h for options." unless options.unit_names.present?
 

--- a/bin/oneoff/import_unit_details.rb
+++ b/bin/oneoff/import_unit_details.rb
@@ -97,6 +97,18 @@ end
 
 def validate_unit(script, cb_unit)
   raise "unexpected unit_name #{cb_unit['unit_name']}" unless cb_unit['unit_name'] == script.name
+
+  # In 2020, CSF and CSD lessons are all inside chapters, and CSP does not use
+  # chapters. Therefore, we can simplify the merge logic by assuming that
+  # lessons are all inside chapters when chapters are present.
+  if cb_unit['chapters'].present? && cb_unit['lessons'].present?
+    raise "found #{cb_unit['lessons'].count} unexpected lessons outside of chapters"
+  end
+
+  if cb_unit['chapters'].blank? && cb_unit['lessons'].blank?
+    raise "no chapters or lessons found"
+  end
+
   log "validated unit data for #{script.name}"
 end
 

--- a/bin/oneoff/import_unit_details.rb
+++ b/bin/oneoff/import_unit_details.rb
@@ -106,18 +106,7 @@ end
 def validate_unit(script, cb_unit)
   raise "unexpected unit_name #{cb_unit['unit_name']}" unless cb_unit['unit_name'] == script.name
 
-  # In 2020, CSF and CSD lessons are all inside chapters, and CSP does not use
-  # chapters. Therefore, we can simplify the merge logic by assuming that
-  # lessons are all inside chapters when chapters are present.
-  if cb_unit['chapters'].present? && cb_unit['lessons'].present?
-    raise "found #{cb_unit['lessons'].count} unexpected lessons outside of chapters"
-  end
-
-  if cb_unit['chapters'].blank? && cb_unit['lessons'].blank?
-    raise "no chapters or lessons found"
-  end
-
-  chapters = get_chapters(cb_unit)
+  chapters = get_validated_chapters(cb_unit)
   cb_lessons = chapters.map {|ch| ch['lessons']}.flatten
 
   # Compare non-lockable lessons from CB and Code Studio.
@@ -171,7 +160,18 @@ def validate_unit(script, cb_unit)
   log "validated unit data for #{script.name}"
 end
 
-def get_chapters(cb_unit)
+def get_validated_chapters(cb_unit)
+  # In 2020, CSF and CSD lessons are all inside chapters, and CSP does not use
+  # chapters. Therefore, we can simplify the merge logic by assuming that
+  # lessons are all inside chapters when chapters are present.
+  if cb_unit['chapters'].present? && cb_unit['lessons'].present?
+    raise "found #{cb_unit['lessons'].count} unexpected lessons outside of chapters"
+  end
+
+  if cb_unit['chapters'].blank? && cb_unit['lessons'].blank?
+    raise "no chapters or lessons found"
+  end
+
   cb_unit['chapters'].presence || [{'lessons' => cb_unit['lessons']}]
 end
 

--- a/bin/oneoff/import_unit_details.rb
+++ b/bin/oneoff/import_unit_details.rb
@@ -109,18 +109,17 @@ def validate_unit(script, cb_unit)
   end
 
   chapters = get_chapters(cb_unit)
+  cb_lessons = chapters.map {|ch| ch['lessons']}.flatten
 
   # Compare non-lockable lessons from CB and Code Studio.
-  lessons = script.lessons.reject(&:lockable)
-  cb_lessons = chapters.map {|ch| ch['lessons']}.
-    flatten.
-    # In 2020, a code_studio_url indicates a lockable lesson in CSP.
-    reject {|lesson| lesson['code_studio_url'].present?}
-  unless lessons.count == cb_lessons.count
+  lessons_nonlockable = script.lessons.reject(&:lockable)
+  # In 2020, a code_studio_url indicates a lockable lesson in CSP.
+  cb_lessons_nonlockable = cb_lessons.reject {|lesson| lesson['code_studio_url'].present?}
+  unless lessons_nonlockable.count == cb_lessons_nonlockable.count
     raise "mismatched lesson counts for unit #{script.name} CS: #{lesson_names.count} CB: #{cb_lesson_names.count}"
   end
   mismatched_names = []
-  lessons.each.with_index do |lesson, index|
+  lessons_nonlockable.each.with_index do |lesson, index|
     cb_lesson = cb_lessons[index]
     position = index + 1
     raise "unexpected position for lesson '#{lesson.name}'" unless lesson.relative_position == position

--- a/dashboard/app/models/lesson.rb
+++ b/dashboard/app/models/lesson.rb
@@ -432,6 +432,31 @@ class Lesson < ActiveRecord::Base
     end
   end
 
+  # This method takes lesson and activity data exported from curriculum builder
+  # and updates corresponding fields of this lesson to match it. The expected
+  # input format is as follows:
+  # {
+  #   "title": "Lesson Title",
+  #   "number": 1,
+  #   "student_desc": "Student-facing description",
+  #   "teacher_desc": "Teacher-facing description",
+  #   "activities": [
+  #     {
+  #       "name": "Activity name",
+  #       "duration": "5-10 minutes",
+  #       "content": "Activity markdown"
+  #     },
+  #     ...
+  #   ]
+  # }
+  # @param [Hash] cb_lesson_data - Lesson and activity data to import.
+  def update_from_curriculum_builder(cb_lesson_data)
+    # In the future, only levelbuilder should be added to this list.
+    raise unless [:development, :adhoc].include? rack_env
+
+    puts "TODO: update lesson #{id} with cb lesson data: #{cb_lesson_data.to_json[0, 50]}..."
+  end
+
   # Used for seeding from JSON. Returns the full set of information needed to uniquely identify this object.
   # If the attributes of this object alone aren't sufficient, and associated objects are needed, then data from
   # the seeding_keys of those objects should be included as well.

--- a/dashboard/app/models/lesson.rb
+++ b/dashboard/app/models/lesson.rb
@@ -450,11 +450,11 @@ class Lesson < ActiveRecord::Base
   #   ]
   # }
   # @param [Hash] cb_lesson_data - Lesson and activity data to import.
-  def update_from_curriculum_builder(cb_lesson_data)
+  def update_from_curriculum_builder(_cb_lesson_data)
     # In the future, only levelbuilder should be added to this list.
     raise unless [:development, :adhoc].include? rack_env
 
-    puts "TODO: update lesson #{id} with cb lesson data: #{cb_lesson_data.to_json[0, 50]}..."
+    # puts "TODO: update lesson #{id} with cb lesson data: #{cb_lesson_data.to_json[0, 50]}..."
   end
 
   # Used for seeding from JSON. Returns the full set of information needed to uniquely identify this object.


### PR DESCRIPTION
FInishes [PLAT-498]. Builds on the existing script for importing CB data as follows:
* validates chapter data, and wraps any lessons owned directly by the unit in a single chapter
* matches and validates CB lessons with code studio lessons by comparing relative position, lockable state, lesson name, and the stage name from code studio pull-through if present
* calls new placeholder Level#update_from_curriculum_builder method for each code studio Level with corresponding CB data

Sample verbose output:
![Screen Shot 2020-11-06 at 11 36 19 AM](https://user-images.githubusercontent.com/8001765/98410850-eb65d700-2029-11eb-8c63-7f618397a1e2.png)

## Testing story

Lesson name warnings look mostly harmless:

![Screen Shot 2020-11-06 at 11 39 51 AM](https://user-images.githubusercontent.com/8001765/98410110-e8b6b200-2028-11eb-82a4-e9f5ad979b6b.png)

My unconfirmed suspicion as that mismatches are limited to express, pre-express and CSP because those courses do not actively use code studio pull-through, whereas Courses A-F and CSD do actively use it.

## Future work

Aside from other work tracked in the same Jira epic, we may want to add another option to the command line script which allows running against a specific lesson or list of lessons, so that the script can be used to test out import one lesson at a time.

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked


[PLAT-498]: https://codedotorg.atlassian.net/browse/PLAT-498