### PR TITLE
AILab: handle levels without a mode

### DIFF
--- a/apps/src/ailab/Ailab.js
+++ b/apps/src/ailab/Ailab.js
@@ -122,7 +122,7 @@ Ailab.prototype.onContinue = function() {
 };
 
 Ailab.prototype.initMLActivities = function() {
-  const mode = JSON.parse(this.level.mode);
+  const mode = this.level.mode ? JSON.parse(this.level.mode) : null;
   const onContinue = this.onContinue.bind(this);
 
   setAssetPath('/blockly/media/skins/ailab/');


### PR DESCRIPTION
Parameterisation support in https://github.com/code-dot-org/code-dot-org/pull/37715 accidentally regressed the case when the levelbuilder has not specified a mode.  It works again now.
