### PR TITLE
Update the logic which detects if caching is disabled

### DIFF
--- a/dashboard/test/test_helper.rb
+++ b/dashboard/test/test_helper.rb
@@ -304,8 +304,7 @@ class ActiveSupport::TestCase
     expected_directives = [
       'no-cache',
       'no-store',
-      'must-revalidate',
-      'max-age=0'
+      'private'
     ]
     assert_cache_control_match expected_directives, cache_control_header
   end


### PR DESCRIPTION
To reflect the new rails functionality. Specifically, in https://github.com/rails/rails/pull/30367 the cache control headers were normalized more aggressively, which results in the headers we examine to determine whether or not caching is enabled having slightly different content.

I'm not 100% clear on exactly which headers here are or are not important to us, but according to [the relevant documentation](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Cache-Control) the removed headers seem unnecessary:

> **`no-store`**
>
> The response may **not** be stored in _any_ cache. Although other directives may be set, this alone is _the only directive you need in preventing cached responses_ on modern browsers. `max-age=0` **is already implied. Setting** `must-revalidate` **does not make sense** because in order to go through revalidation you need the response to be stored in a cache, which `no-store` prevents.

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
