### PR TITLE
remove eyes tests for csedweek.org

### DIFF
--- a/dashboard/test/ui/features/other_sites.feature
+++ b/dashboard/test/ui/features/other_sites.feature
@@ -12,6 +12,4 @@ Scenario Outline: Simple page view
 Examples:
   | url                                                               | test_name                  |
   | http://advocacy.code.org/                                         | advocacy.code.org home     |
-  | http://csedweek.org/                                              | csedweek.org home          |
-  | http://csedweek.org/about                                         | csedweek.org about         |
   | http://code.org/curriculum/unplugged                              | code.org curriculum        |


### PR DESCRIPTION
our `other_sites.feature` eyes test is failing trying to load csedweek.org. now that we no longer operate that site, i'm removing it from the test.