### PR TITLE
For old levels/games, restrict the intro_video_id to always be the English version

### DIFF
--- a/dashboard/app/models/game.rb
+++ b/dashboard/app/models/game.rb
@@ -313,7 +313,7 @@ class Game < ActiveRecord::Base
   )
 
   def self.setup
-    videos_by_key = Video.all.index_by(&:key)
+    videos_by_key = Video.all.where(locale: 'en-US').index_by(&:key)
     games = GAMES_BY_INDEX.map.with_index(1) do |line, id|
       name, app, intro_video_key = line.split ':'
       {id: id, name: name, app: app, intro_video_id: videos_by_key[intro_video_key]&.id}


### PR DESCRIPTION
Recently, we uploaded a set of videos dubbed in French. Unfortunately, it turns out the old levels have the video database id hard coded into the object. This breaks localization, where multiple videos with the same key are in the database. In this case, English users were seeing French videos.

This is not the best solution but fixes this issue for the vast majority of users by explicitly choosing the English video to be played. It would be great to fix this properly (i.e. dynamically decide which video to show based on the user's locale).

<!-- ### Background -->
<!-- ### Privacy -->
<!--
1.	Does the Project involve the collection, use or sharing of new Personal Data?

2.	Does the Project involve a new or changed use or sharing of existing Personal Data?
-->
<!-- ### Security -->
<!--
Link to Jira Task where sensitive security issues are discussed privately.
-->
<!-- ### Caching -->
<!-- ### Deployment strategy -->
<!-- ### Future work -->

## Links

<!--
  Any relevant links to external resources; ie, specification documents, jira
  items, related PRs, honeybadger errors, etc
-->

- [spec]()
- [jira]()

## Testing story

tested locally

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
