### PR TITLE
Stop validating email match on oauth upgrade

### DIFF
--- a/dashboard/app/models/user.rb
+++ b/dashboard/app/models/user.rb
@@ -441,19 +441,6 @@ class User < ActiveRecord::Base
   validates_confirmation_of :password, if: :password_required?
   validates_length_of       :password, within: 6..128, allow_blank: true
 
-  validate :email_matches_for_oauth_upgrade, if: -> {oauth? && user_type_changed?}, on: :update
-
-  def email_matches_for_oauth_upgrade
-    if user_type == User::TYPE_TEACHER
-      # The stored email must match the passed email
-      unless hashed_email == hashed_email_was
-        errors.add :base, I18n.t('devise.registrations.user.user_type_change_email_mismatch')
-        errors.add :email_mismatch, "Email mismatch" # only used to check for this error's existence
-      end
-    end
-    true
-  end
-
   validates_presence_of :email_preference_opt_in, if: :email_preference_opt_in_required
   validates_presence_of :email_preference_request_ip, if: -> {email_preference_opt_in.present?}
   validates_presence_of :email_preference_source, if: -> {email_preference_opt_in.present?}


### PR DESCRIPTION
Originally added in https://github.com/code-dot-org/code-dot-org/pull/16507, this validation logic is attempting to confirm that when a user upgrades from student to teacher, the new email matches the old email.

This should go away for a couple of reasons:

1. We no longer require users to confirm their email when attempting to upgrade from student to teacher. Instead, since the new Authentication Option system allows for us to store multiple emails for a user we now just ask for them to give us _an_ email, either old or new.
2. The test is not actually testing what it claims to test. It's using `hashed_email_was` to retrieve the "old" hashed email, but that method actually just calls the existing `hashed_email` method and so it will always pass trivially. This is why the test continues to pass even though we no longer conform to the behavior it's attempting to enforce.
3. It starts breaking in the Rails 5.2 upgrade, which made some minor changes to the way the `_was` helpers work. Specifically, whereas before this helper wasn't doing what we thought it was, after 5.2 it _will_ be doing what we think it was but of course as per point 1 above, that's now a bad thing.

## Testing story

Manually tested that the "confirm your email" workflow no longer happens

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
