### PR TITLE
Update 'no-transform' header logic

### DIFF
--- a/dashboard/config/initializers/no_transform_paths.rb
+++ b/dashboard/config/initializers/no_transform_paths.rb
@@ -10,17 +10,20 @@ module Cdo
     ).freeze
 
     def serve(request)
-      super(request).tap do |_, headers, _|
-        filter_headers(request.path_info, headers)
-      end
+      status, headers, body = super(request)
+      new_headers = filter_headers(request.path_info, headers)
+      return [status, new_headers, body]
     end
 
     def filter_headers(path, headers)
       if NO_TRANSFORM_PATHS.any?(&path.method(:include?))
+        headers ||= {}
         cache_control = Rack::Cache::CacheControl.new(headers[Rack::CACHE_CONTROL])
         cache_control['no-transform'] = true
         headers[Rack::CACHE_CONTROL] = cache_control.to_s
       end
+
+      headers
     end
   end
 end

--- a/dashboard/test/integration/no_transform_paths_test.rb
+++ b/dashboard/test/integration/no_transform_paths_test.rb
@@ -4,10 +4,9 @@ class NoTransformPathsTest < ActionDispatch::IntegrationTest
   def test_no_transform_paths
     path = '/blockly/media/skins/craft/images/fake_image.png'
 
-    ::Rack::File.any_instance.stubs(:call).returns(Rack::Response.new)
     ActionDispatch::FileHandler.any_instance.stubs(:match?).returns(path)
 
     get path
-    assert_match /no-transform/, @response.headers[Rack::CACHE_CONTROL]
+    assert_match(/no-transform/, @response.headers[Rack::CACHE_CONTROL])
   end
 end


### PR DESCRIPTION
For compatibility with Rails 5.2

Specifically, starting in Rails 5.2, `headers` in the response arguments will default to `nil` rather than an empty array if no headers have been set, so we have to tweak our logic to be able to define the headers dict if necessary, rather than just modifying the existing one.

<!--
  Your description goes here: A summary of the change, including any relevant motivation and context.

  If relevant, include a description both of the existing behavior and of the new behavior.
-->

<!--
  Other aspects to consider. uncomment and add detail for any that seem necessary:
-->

<!-- ### Background -->
<!-- ### Privacy -->
<!--
1.	Does the Project involve the collection, use or sharing of new Personal Data?

2.	Does the Project involve a new or changed use or sharing of existing Personal Data?
-->
<!-- ### Security -->
<!--
Link to Jira Task where sensitive security issues are discussed privately.
-->
<!-- ### Caching -->
<!-- ### Deployment strategy -->
<!-- ### Future work -->


## Testing story

Relying on existing unit test

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
