### PR TITLE
Explicitly cast session id to a string in milestone log

### DIFF
--- a/dashboard/app/controllers/activities_controller.rb
+++ b/dashboard/app/controllers/activities_controller.rb
@@ -250,7 +250,7 @@ class ActivitiesController < ApplicationController
     log_string = 'Milestone Report:'
     log_string +=
       if current_user || session.id
-        "\t#{(current_user ? current_user.id.to_s : ('s:' + session.id))}"
+        "\t#{(current_user ? current_user.id.to_s : ('s:' + session.id.to_s))}"
       else
         "\tanon"
       end


### PR DESCRIPTION
Required for Rails 5.2; as of https://github.com/rails/rails/commit/2a52a38cb51b65d71cf91fc960777213cf96f962 `session.id` is no longer a basic datatype, and must be explicitly cast to a string to be used as one

<!--
  Your description goes here: A summary of the change, including any relevant motivation and context.

  If relevant, include a description both of the existing behavior and of the new behavior.
-->

<!--
  Other aspects to consider. uncomment and add detail for any that seem necessary:
-->

<!-- ### Background -->
<!-- ### Privacy -->
<!--
1.	Does the Project involve the collection, use or sharing of new Personal Data?

2.	Does the Project involve a new or changed use or sharing of existing Personal Data?
-->
<!-- ### Security -->
<!--
Link to Jira Task where sensitive security issues are discussed privately.
-->
<!-- ### Caching -->
<!-- ### Deployment strategy -->
<!-- ### Future work -->

## Testing story

This was caught by https://github.com/code-dot-org/code-dot-org/blob/96775c48fc689c2c714c1a713884100a84fae86b/dashboard/test/integration/caching_test.rb#L54-L62 and I expect will continue to be covered by it

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
