### PR TITLE
Enable public AppLab datasets in Drone builds

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -136,6 +136,8 @@ steps:
       from_secret: FIREBASE_NAME
     FIREBASE_SECRET:
       from_secret: FIREBASE_SECRET
+    FIREBASE_SHARED_SECRET:
+      from_secret: FIREBASE_SHARED_SECRET
     SAUCE_USERNAME:
       from_secret: SAUCE_USERNAME
     SAUCE_ACCESS_KEY:
@@ -183,6 +185,6 @@ trigger:
   - pull_request
 ---
 kind: signature
-hmac: 9a6c116088e71ecaa8d68ed2bb5108763bb6dd1f45aa8568fb13df8616dd9495
+hmac: 87512ba110e67854732dcf411a11d4e968c7c4a6b666095885a0bb0621f3fec5
 
 ...


### PR DESCRIPTION
Enable access to public datasets in Drone Builds.

<!-- ### Background -->
### Privacy

A single Google Firebase database `cdo-shared` stored public datasets for AppLab. These datasets do not contain any sensitive data.

<!-- ### Security -->
<!--
Link to Jira Task where sensitive security issues are discussed privately.
-->
<!-- ### Caching -->
<!-- ### Deployment strategy -->
<!-- ### Future work -->

## Links

<!--
  Any relevant links to external resources; ie, specification documents, jira
  items, related PRs, honeybadger errors, etc
-->

- [spec]()
- [jira]()

## Testing story

<!--
  Does your change include appropriate tests?

  If so, please describe how the tests included in this PR are sufficient

  If not, please explain why this change does not need to be tested.
-->

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
