### PR TITLE
Add math pow

### DIFF
--- a/lib/cdo/shared_constants.rb
+++ b/lib/cdo/shared_constants.rb
@@ -247,6 +247,7 @@ module SharedConstants
       "mathMax": null,
       "mathMin": null,
       "mathRandom": null,
+      "mathPow": null,
 
       // Variables
       "declareAssign_x": null,

--- a/lib/cdo/shared_constants.rb
+++ b/lib/cdo/shared_constants.rb
@@ -541,6 +541,7 @@ module SharedConstants
       "mathMax": null,
       "mathMin": null,
       "mathRandom": null,
+      "mathPow": null,
       "comment_Math": null,
 
       // Variables


### PR DESCRIPTION
Adding `Math.pow` to the list of default blocks for Applab and Gamelab standalone (or "sandbox") projects. This has been requested multiple times, but I put a link to the most recent request below.

This block already existed, but had to be explicitly included by levelbuilders on specific levels.

## Links

<!--
  Any relevant links to external resources; ie, specification documents, jira
  items, related PRs, honeybadger errors, etc
-->

- [Slack request](https://codedotorg.slack.com/archives/C01764GEKGS/p1604958812002700)

## Testing story

<!--
  Does your change include appropriate tests?

  If so, please describe how the tests included in this PR are sufficient

  If not, please explain why this change does not need to be tested.
-->

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
