### PR TITLE
Match imported cb chapter data to corresponding lesson groups

### DIFF
--- a/bin/oneoff/import_unit_details.rb
+++ b/bin/oneoff/import_unit_details.rb
@@ -119,6 +119,10 @@ def validate_unit(script, cb_unit)
   raise "unexpected unit_name #{cb_unit['unit_name']}" unless cb_unit['unit_name'] == script.name
 end
 
+# Retrieves all lessons from the CB unit, which could either be in the lessons
+# field or nested within various chapters.
+# @param [Hash] cb_unit - Curriculum Builder Unit
+# @return [Array.<Hash>] - Array of CB Lessons
 def get_cb_lessons(cb_unit)
   # In 2020 on Curriculum Builder, CSF and CSD lessons are all inside chapters,
   # and CSP does not use chapters. Therefore, we can simplify the merge logic by

--- a/bin/oneoff/import_unit_details.rb
+++ b/bin/oneoff/import_unit_details.rb
@@ -91,8 +91,7 @@ def main(options)
 
     cb_unit = JSON.parse(cb_unit_json)
     validate_unit(script, cb_unit)
-    cb_chapters = get_validated_cb_chapters(cb_unit)
-    lesson_pairs = get_validated_lesson_pairs(script, cb_chapters)
+    lesson_pairs = get_validated_lesson_pairs(script, cb_unit)
 
     if options.dry_run
       log "validated #{lesson_pairs.count} lessons in unit #{script.name}"
@@ -145,11 +144,13 @@ end
 #    CB lesson data to update them with.
 #
 # @param [Script] script - Code Studio Script/Unit object.
-# @param [Array<Hash>] - Array of CB chapters
+# @param [Hash] - Curriculum Builder Unit
 # @return [Array<Array.<Lesson, Hash>>] - Array of pairs of Code Studio Lesson
 #   objects and CB lesson data objects.
-def get_validated_lesson_pairs(script, cb_chapters)
+def get_validated_lesson_pairs(script, cb_unit)
   validated_lesson_pairs = []
+
+  cb_chapters = get_validated_cb_chapters(cb_unit)
 
   cb_lessons = cb_chapters.map {|ch| ch['lessons']}.flatten
 

--- a/bin/oneoff/import_unit_details.rb
+++ b/bin/oneoff/import_unit_details.rb
@@ -92,9 +92,10 @@ def main(options)
     cb_unit = JSON.parse(cb_unit_json)
     validate_unit(script, cb_unit)
     lesson_pairs = get_validated_lesson_pairs(script, cb_unit)
+    lesson_group_pairs = get_lesson_group_pairs(script, cb_unit['chapters'], lesson_pairs)
 
     if options.dry_run
-      log "validated #{lesson_pairs.count} lessons in unit #{script.name}"
+      log "validated #{lesson_pairs.count} lessons and #{lesson_group_pairs.count} lesson groups in unit #{script.name}"
       next
     end
 
@@ -102,7 +103,7 @@ def main(options)
       lesson.update_from_curriculum_builder(cb_lesson)
     end
 
-    log "updated #{lesson_pairs.count} lessons in unit #{script.name}"
+    log "updated #{lesson_pairs.count} lessons and #{lesson_group_pairs.count} lesson groups in unit #{script.name}"
   end
 end
 
@@ -210,6 +211,72 @@ def get_validated_lesson_pairs(script, cb_unit)
   end
 
   validated_lesson_pairs
+end
+
+# Validates the following preconditions:
+
+# 1. Every CB chapter has a corresponding LessonGroup in Code Studio.
+# 2. If the CB unit uses chapters, then for each Code Studio chapter containing
+# lessons which have lesson plans, there is a corresponding CB chapter.
+# 3. For each LessonGroup with a corresponding CB chapter, the number of Lessons
+# in the Lesson Group which have lesson plans equals the number of lessons in
+# the CB chapter.
+# 4. we do not validate that the lesson names match like we did earlier, to
+# avoid duplicate warnings.
+#
+# Then, returns an array of pairs of LessonGroups and corresponding CB chapters.
+#
+# @param [Script] script - Code Studio Script/Unit object.
+# @param [Array<Hash>] - Array of CB chapters
+# @param [Array<Array.<Lesson, Hash>>] - Array of pairs of Code Studio Lesson
+#   objects and CB lessons.
+# @return [Array<Array<LessonGroup, Hash>>] lesson_pairs - Array of pairs of
+#   Code Studio LessonGroup objects and CB chapters.
+def get_lesson_group_pairs(script, cb_chapters, lesson_pairs)
+  return [] unless cb_chapters.present?
+
+  # Compute a list of all code studio lessons embedded in the lesson_pairs array.
+  paired_lessons = lesson_pairs.map(&:first)
+
+  # Filter out any Code Studio lesson groups which do not contain any lessons
+  # which were paired with lesson plans.
+  filtered_lesson_groups = script.lesson_groups.all.select do |lg|
+    lg.lessons.any? {|lesson| paired_lessons.include?(lesson)}
+  end
+
+  # Now we expect the filtered lesson groups to have a one-to-one correspondence
+  # with CB chapters.
+  unless filtered_lesson_groups.count == cb_chapters.count
+    raise "unexpected chapter count for unit #{script.name}: #{filtered_lesson_groups.count} != #{cb_chapters.count}."
+  end
+
+  lesson_group_pairs = []
+  mismatched_names = []
+  filtered_lesson_groups.each.with_index do |lesson_group, index|
+    # Of those lesson groups which contained any lessons which have lesson plans,
+    # only look at the subset of lessons which have lesson plans.
+    filtered_lessons = lesson_group.lessons.all.select {|lesson| paired_lessons.include?(lesson)}
+    cb_chapter = cb_chapters[index]
+
+    unless filtered_lessons.count == cb_chapter['lessons'].count
+      raise "lesson count mismatch for lesson group #{lesson_group.display_name}: "\
+              "#{filtered_lessons.count} != #{cb_chapter['lessons'].count}"
+    end
+
+    lesson_group_pairs.push([lesson_group, cb_chapter])
+    unless lesson_group.display_name == cb_chapter['title']
+      mismatched_names.push([lesson_group.display_name, cb_chapter['title']])
+    end
+  end
+
+  if mismatched_names.any?
+    mismatch_summary = mismatched_names.map do |left, right|
+      "  '#{left}' --> '#{right}'"
+    end.join("\n")
+    warn "WARNING: some lesson group names differ for unit #{script.name}:\n#{mismatch_summary}"
+  end
+
+  lesson_group_pairs
 end
 
 options = parse_options

--- a/bin/oneoff/import_unit_details.rb
+++ b/bin/oneoff/import_unit_details.rb
@@ -103,6 +103,13 @@ def main(options)
       lesson.update_from_curriculum_builder(cb_lesson)
     end
 
+    lesson_group_pairs.each do |lesson_group, cb_chapter|
+      # Make sure the lesson group update does not also try to update lessons.
+      cb_chapter = cb_chapter.reject {|k, _| k == 'lessons'}
+
+      lesson_group.update_from_curriculum_builder(cb_chapter)
+    end
+
     log "updated #{lesson_pairs.count} lessons and #{lesson_group_pairs.count} lesson groups in unit #{script.name}"
   end
 end

--- a/bin/oneoff/import_unit_details.rb
+++ b/bin/oneoff/import_unit_details.rb
@@ -133,6 +133,19 @@ def get_validated_cb_chapters(cb_unit)
   cb_unit['chapters'].presence || [{'lessons' => cb_unit['lessons']}]
 end
 
+# Because not all lockable lessons in code studio have lesson plans in
+# Curriculum Builder, there may be a mismatch between the number of lessons in
+# CB and Code Studio. This method does the following:
+# 1. Verifies that every non-lockable lesson in Code Studio has a lesson plan in CB.
+# 2. Verifies that every lesson plan in CB has a corresponding lesson in Code Studio,
+#    including any lesson plans for lockable lessons.
+# 3. Returns a list of pairs of all Code Studio Lessons with corresponding
+#    CB lesson data to update them with.
+#
+# @param [Script] script - Code Studio Script/Unit object.
+# @param [Array<Hash>] - Array of CB chapters
+# @return [Array<Array.<Lesson, Hash>>] - Array of pairs of Code Studio Lesson
+#   objects and CB lesson data objects.
 def get_validated_lesson_pairs(script, cb_chapters)
   validated_lesson_pairs = []
 

--- a/bin/oneoff/import_unit_details.rb
+++ b/bin/oneoff/import_unit_details.rb
@@ -146,9 +146,7 @@ def get_validated_lesson_pairs(script, cb_unit)
     raise "no chapters or lessons found"
   end
 
-  cb_chapters = cb_unit['chapters'].presence || [{'lessons' => cb_unit['lessons']}]
-
-  cb_lessons = cb_chapters.map {|ch| ch['lessons']}.flatten
+  cb_lessons = cb_unit['lessons'].presence || cb_unit['chapters'].map {|ch| ch['lessons']}.flatten
 
   # Compare non-lockable lessons from CB and Code Studio.
   lessons_nonlockable = script.lessons.reject(&:lockable)

--- a/bin/oneoff/import_unit_details.rb
+++ b/bin/oneoff/import_unit_details.rb
@@ -95,7 +95,7 @@ def main(options)
     lesson_group_pairs = get_lesson_group_pairs(script, cb_unit['chapters'], lesson_pairs)
 
     if options.dry_run
-      log "validated #{lesson_pairs.count} lessons and #{lesson_group_pairs.count} lesson groups in unit #{script.name}"
+      puts "validated #{lesson_pairs.count} lessons and #{lesson_group_pairs.count} lesson groups in unit #{script.name}"
       next
     end
 
@@ -110,7 +110,7 @@ def main(options)
       lesson_group.update_from_curriculum_builder(cb_chapter)
     end
 
-    log "updated #{lesson_pairs.count} lessons and #{lesson_group_pairs.count} lesson groups in unit #{script.name}"
+    puts "updated #{lesson_pairs.count} lessons and #{lesson_group_pairs.count} lesson groups in unit #{script.name}"
   end
 end
 

--- a/bin/oneoff/import_unit_details.rb
+++ b/bin/oneoff/import_unit_details.rb
@@ -119,21 +119,6 @@ def validate_unit(script, cb_unit)
   raise "unexpected unit_name #{cb_unit['unit_name']}" unless cb_unit['unit_name'] == script.name
 end
 
-def get_validated_cb_chapters(cb_unit)
-  # In 2020 on Curriculum Builder, CSF and CSD lessons are all inside chapters,
-  # and CSP does not use chapters. Therefore, we can simplify the merge logic by
-  # assuming that lessons are all inside chapters when chapters are present.
-  if cb_unit['chapters'].present? && cb_unit['lessons'].present?
-    raise "found #{cb_unit['lessons'].count} unexpected lessons outside of chapters"
-  end
-
-  if cb_unit['chapters'].blank? && cb_unit['lessons'].blank?
-    raise "no chapters or lessons found"
-  end
-
-  cb_unit['chapters'].presence || [{'lessons' => cb_unit['lessons']}]
-end
-
 # Because not all lockable lessons in code studio have lesson plans in
 # Curriculum Builder, there may be a mismatch between the number of lessons in
 # CB and Code Studio. This method does the following:
@@ -150,7 +135,18 @@ end
 def get_validated_lesson_pairs(script, cb_unit)
   validated_lesson_pairs = []
 
-  cb_chapters = get_validated_cb_chapters(cb_unit)
+  # In 2020 on Curriculum Builder, CSF and CSD lessons are all inside chapters,
+  # and CSP does not use chapters. Therefore, we can simplify the merge logic by
+  # assuming that lessons are all inside chapters when chapters are present.
+  if cb_unit['chapters'].present? && cb_unit['lessons'].present?
+    raise "found #{cb_unit['lessons'].count} unexpected lessons outside of chapters"
+  end
+
+  if cb_unit['chapters'].blank? && cb_unit['lessons'].blank?
+    raise "no chapters or lessons found"
+  end
+
+  cb_chapters = cb_unit['chapters'].presence || [{'lessons' => cb_unit['lessons']}]
 
   cb_lessons = cb_chapters.map {|ch| ch['lessons']}.flatten
 

--- a/bin/oneoff/import_unit_details.rb
+++ b/bin/oneoff/import_unit_details.rb
@@ -94,13 +94,15 @@ def main(options)
     cb_chapters = get_validated_cb_chapters(cb_unit)
     lesson_pairs = get_validated_lesson_pairs(script, cb_chapters)
 
-    log "validated unit #{script.name} data"
-
-    next if options.dry_run
+    if options.dry_run
+      log "validated #{lesson_pairs.count} lessons in unit #{script.name}"
+      next
+    end
 
     lesson_pairs.each do |lesson, cb_lesson|
       lesson.update_from_curriculum_builder(cb_lesson)
     end
+
     log "updated #{lesson_pairs.count} lessons in unit #{script.name}"
   end
 end

--- a/dashboard/app/models/lesson_group.rb
+++ b/dashboard/app/models/lesson_group.rb
@@ -167,4 +167,22 @@ class LessonGroup < ApplicationRecord
     my_key.merge!(script_seeding_key) {|key, _, _| raise "Duplicate key when generating seeding_key: #{key}"}
     my_key.stringify_keys
   end
+
+  # This method takes chapter data exported from curriculum builder and updates
+  # corresponding fields of this LessonGroup to match it. Only fields on this
+  # LessonGroup will be updated. Lessons themselves are not updated here.
+  # The expected input format is as follows:
+  # {
+  #   "title": "CB Chapter Title",
+  #   "number": 1,
+  #   "questions": "Big Questions markdown",
+  # }
+  #
+  # @param [Hash] cb_chapter_data - Chapter data to import.
+  def update_from_curriculum_builder(cb_chapter_data)
+    # In the future, only levelbuilder should be added to this list.
+    raise unless [:development, :adhoc].include? rack_env
+
+    puts "TODO: update lesson group #{id} with cb chapter data: #{cb_chapter_data.to_json[0, 50]}..."
+  end
 end

--- a/dashboard/app/models/lesson_group.rb
+++ b/dashboard/app/models/lesson_group.rb
@@ -176,6 +176,7 @@ class LessonGroup < ApplicationRecord
   #   "title": "CB Chapter Title",
   #   "number": 1,
   #   "questions": "Big Questions markdown",
+  #   "description": "Description markdown"
   # }
   #
   # @param [Hash] cb_chapter_data - Chapter data to import.

--- a/dashboard/app/models/lesson_group.rb
+++ b/dashboard/app/models/lesson_group.rb
@@ -179,10 +179,10 @@ class LessonGroup < ApplicationRecord
   # }
   #
   # @param [Hash] cb_chapter_data - Chapter data to import.
-  def update_from_curriculum_builder(cb_chapter_data)
+  def update_from_curriculum_builder(_cb_chapter_data)
     # In the future, only levelbuilder should be added to this list.
     raise unless [:development, :adhoc].include? rack_env
 
-    puts "TODO: update lesson group #{id} with cb chapter data: #{cb_chapter_data.to_json[0, 50]}..."
+    # puts "TODO: update lesson group #{id} with cb chapter data: #{cb_chapter_data.to_json[0, 50]}..."
   end
 end


### PR DESCRIPTION
Starts [PLAT-249]. Depends on https://github.com/code-dot-org/curriculumbuilder/pull/322 . For each unit imported from Curriculum Builder, validates the chapter data against the LessonGroups in Code Studio. Then, calls a placeholder method to update the corresponding LessonGroup for each imported chapter. 

All of the real work described above is done in 5392fb3314d1b3b9b79b85668ab217a02d843009 and 2282d0bb258e83b0d129eea0a9ceda96b9b4d297. The rest of the PR is other cleanup which does not affect actual / eventual behavior: 
* improve comments and naming
* inline `get_validated_chapters` method, which turned out not to be needed
* tweak debug logging

## Testing story

I ran the script on all CSF/CSD/CSP 2020 units. All of the lesson group names in CSF and CSD appear to be close matches, and there are no matches at all in CSP units because there are CSP 2020 units do not have any chapters on CB.

For the following screenshots I disabled lesson name warnings so that you could more easily see the new lesson group name warnings.

![Screen Shot 2020-11-10 at 6 58 43 AM](https://user-images.githubusercontent.com/8001765/98692038-8a891800-2323-11eb-9048-d7eb846b5c19.png)

![Screen Shot 2020-11-10 at 6 59 48 AM](https://user-images.githubusercontent.com/8001765/98692051-8ceb7200-2323-11eb-8a7b-f7b68e286aad.png)

![Screen Shot 2020-11-10 at 7 08 49 AM](https://user-images.githubusercontent.com/8001765/98692111-9bd22480-2323-11eb-8091-8f052df0efce.png)

## Future work

I will follow up with another PR to cut down on some of the warnings for lesson and lesson group names.

## Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked


[PLAT-249]: https://codedotorg.atlassian.net/browse/PLAT-249