### PR TITLE
improve detection of similar lesson and lesson group names

### DIFF
--- a/bin/oneoff/import_unit_details.rb
+++ b/bin/oneoff/import_unit_details.rb
@@ -289,6 +289,11 @@ end
 # Canonicalize a lesson name or lesson group name to increase the chances of a
 # match when names are compared across CB and Code Studio.
 def canonicalize(str)
+  match = /^(Lesson|Chapter) \d+: (.*)/.match(str)
+  str = match&.captures&.last if match
+  str.gsub!(/[-:]/, ' ')
+  # deduplicate spaces
+  str = str.split(' ').compact.join(' ')
   str.downcase.strip
 end
 

--- a/bin/oneoff/import_unit_details.rb
+++ b/bin/oneoff/import_unit_details.rb
@@ -288,6 +288,9 @@ end
 
 # Canonicalize a lesson name or lesson group name to increase the chances of a
 # match when names are compared across CB and Code Studio.
+# * ignores prefixes like "Lesson 1: " or "Chapter 12: "
+# * ignores - and : characters
+# * ignores differences in case and whitespace
 def canonicalize(str)
   match = /^(Lesson|Chapter) \d+: (.*)/.match(str)
   str = match&.captures&.last if match

--- a/bin/oneoff/import_unit_details.rb
+++ b/bin/oneoff/import_unit_details.rb
@@ -189,7 +189,7 @@ def get_validated_lesson_pairs(script, cb_unit)
     # having been pulled through to CB. If the lesson name matches that name
     # exactly, then do not warn, because that's a strong signal that we found
     # the right lesson.
-    unless [cb_lesson['stage_name'], cb_lesson['title']].any? {|name| name.strip.downcase == lesson.name.strip.downcase}
+    unless [cb_lesson['stage_name'], cb_lesson['title']].any? {|name| canonicalize(name) == canonicalize(lesson.name)}
       mismatched_names.push([lesson.name, cb_lesson['title']])
     end
   end
@@ -205,7 +205,7 @@ def get_validated_lesson_pairs(script, cb_unit)
     end
     lesson = script.lessons.find_by!(lockable: true, relative_position: lockable_position)
     validated_lesson_pairs.push([lesson, cb_lesson])
-    unless lesson.name.downcase.strip == cb_lesson['title'].downcase.strip
+    unless canonicalize(lesson.name) == canonicalize(cb_lesson['title'])
       mismatched_names.push([lesson.name, cb_lesson['title']])
     end
   end
@@ -271,7 +271,7 @@ def get_lesson_group_pairs(script, cb_chapters, lesson_pairs)
     end
 
     lesson_group_pairs.push([lesson_group, cb_chapter])
-    unless lesson_group.display_name == cb_chapter['title']
+    unless canonicalize(lesson_group.display_name) == canonicalize(cb_chapter['title'])
       mismatched_names.push([lesson_group.display_name, cb_chapter['title']])
     end
   end
@@ -284,6 +284,12 @@ def get_lesson_group_pairs(script, cb_chapters, lesson_pairs)
   end
 
   lesson_group_pairs
+end
+
+# Canonicalize a lesson name or lesson group name to increase the chances of a
+# match when names are compared across CB and Code Studio.
+def canonicalize(str)
+  str.downcase.strip
 end
 
 options = parse_options


### PR DESCRIPTION
Follow-on to https://github.com/code-dot-org/code-dot-org/pull/37772. Improve duplicate name detection during import of CB data to help reduce the volume of debug output.

| before | after |
|---|---|
| ![Screen Shot 2020-11-10 at 7 39 47 AM](https://user-images.githubusercontent.com/8001765/98696182-55cb8f80-2328-11eb-89bb-717174adf830.png) | ![Screen Shot 2020-11-10 at 7 44 39 AM](https://user-images.githubusercontent.com/8001765/98696453-acd16480-2328-11eb-861a-84059655564c.png) |