### PR TITLE
Update dance party string for 2020

### DIFF
--- a/pegasus/sites.v3/code.org/public/dance.haml
+++ b/pegasus/sites.v3/code.org/public/dance.haml
@@ -27,7 +27,7 @@ theme: responsive
 =view :dance_teacher_resources
 
 .dance-text-versions-container
-  !=I18n.t(:hoc2019_dance_previous_versions, dance_2018_link: CDO.studio_url('/s/dance/reset'), dance_extras_2018_link: CDO.studio_url('/s/dance-extras/reset'), markdown: true)
+  !=I18n.t(:hoc2020_dance_previous_versions, dance_2018_link: CDO.studio_url('/s/dance/reset'), dance_extras_2018_link: CDO.studio_url('/s/dance-extras/reset'), markdown: true)
 
 =view :dance_sponsor_logo
 


### PR DESCRIPTION
Since 2018 is no longer "last year", update this string. The new string has been added to the gsheet for translation.

**Before:**
<img width="1020" alt="Screen Shot 2020-11-10 at 11 52 10 AM" src="https://user-images.githubusercontent.com/224089/98726310-2f6b1b80-234b-11eb-8d88-95cd2fce356f.png">

**After:**
<img width="1029" alt="Screen Shot 2020-11-10 at 11 51 10 AM" src="https://user-images.githubusercontent.com/224089/98726243-14001080-234b-11eb-89f2-b4710805b77c.png">

<!--
  Your description goes here: A summary of the change, including any relevant motivation and context.

  If relevant, include a description both of the existing behavior and of the new behavior.
-->

<!--
  Other aspects to consider. uncomment and add detail for any that seem necessary:
-->

<!-- ### Background -->
<!-- ### Privacy -->
<!--
1.	Does the Project involve the collection, use or sharing of new Personal Data?

2.	Does the Project involve a new or changed use or sharing of existing Personal Data?
-->
<!-- ### Security -->
<!--
Link to Jira Task where sensitive security issues are discussed privately.
-->
<!-- ### Caching -->
<!-- ### Deployment strategy -->
<!-- ### Future work -->

## Links

<!--
  Any relevant links to external resources; ie, specification documents, jira
  items, related PRs, honeybadger errors, etc
-->

- [spec]()
- [jira]()

## Testing story

<!--
  Does your change include appropriate tests?

  If so, please describe how the tests included in this PR are sufficient

  If not, please explain why this change does not need to be tested.
-->

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
