### PR TITLE
Construct valid regional partner for test

### DIFF
--- a/dashboard/test/controllers/regional_partners_controller_test.rb
+++ b/dashboard/test/controllers/regional_partners_controller_test.rb
@@ -108,7 +108,10 @@ class RegionalPartnersControllerTest < ActionController::TestCase
   end
 
   test 'replace mappings on invalid mapping fails and does not delete old mapping' do
-    regional_partner_with_mapping = create :regional_partner_with_mappings
+    regional_partner_with_mapping = create(:regional_partner)
+    regional_partner_with_mapping.mappings << Pd::RegionalPartnerMapping.new(zip_code: 98143, regional_partner: regional_partner_with_mapping)
+    regional_partner_with_mapping.save!
+
     sign_in @workshop_admin
     mapping = fixture_file_upload('regional_partner_mappings_invalid.csv', 'text/csv')
     post :replace_mappings, params: {id: regional_partner_with_mapping.id, regions: mapping}


### PR DESCRIPTION
Required for the Rails 5.2 upgrade.

Similar to https://github.com/code-dot-org/code-dot-org/pull/37681, this is a product of the fact that the created regional partner was failing validation, which meant that it was failing to persist to the database, which means that the later steps of this test wasn't working.

It's not entirely clear to me why the factory was failing to create a valid instance, but the simple fix is to just create one manually.

<!--
  Your description goes here: A summary of the change, including any relevant motivation and context.

  If relevant, include a description both of the existing behavior and of the new behavior.
-->

<!--
  Other aspects to consider. uncomment and add detail for any that seem necessary:
-->

<!-- ### Background -->
<!-- ### Privacy -->
<!--
1.	Does the Project involve the collection, use or sharing of new Personal Data?

2.	Does the Project involve a new or changed use or sharing of existing Personal Data?
-->
<!-- ### Security -->
<!--
Link to Jira Task where sensitive security issues are discussed privately.
-->
<!-- ### Caching -->
<!-- ### Deployment strategy -->
<!-- ### Future work -->



# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
