### PR TITLE
CB link tutorial fix

### DIFF
--- a/apps/src/tutorialExplorer/tutorialDetail.jsx
+++ b/apps/src/tutorialExplorer/tutorialDetail.jsx
@@ -113,7 +113,9 @@ export default class TutorialDetail extends React.Component {
     changeTutorial: PropTypes.func.isRequired,
     localeEnglish: PropTypes.bool.isRequired,
     disabledTutorial: PropTypes.bool.isRequired,
-    grade: PropTypes.string.isRequired
+    grade: PropTypes.string.isRequired,
+    locale: PropTypes.string.isRequired,
+    cbPrefix: PropTypes.string.isRequired
   };
 
   componentDidMount() {
@@ -209,6 +211,16 @@ export default class TutorialDetail extends React.Component {
       </div>
     );
 
+    //Make the CB lesson plan locale-specific where relevant
+    const cbDomain = 'https://curriculum.code.org/';
+    const localeLowercase = this.props.locale.toLowerCase();
+    const teachersNotes =
+      this.props.item.teachers_notes &&
+      this.props.item.teachers_notes.includes(cbDomain) &&
+      !this.props.item.teachers_notes.includes(localeLowercase)
+        ? this.props.item.teachers_notes.replace(cbDomain, this.props.cbPrefix)
+        : this.props.item.teachers_notes;
+
     return (
       <div id="tutorialPopupFullWidth" style={styles.popupFullWidth}>
         <div
@@ -298,16 +310,13 @@ export default class TutorialDetail extends React.Component {
                 <div style={{clear: 'both'}} />
                 <table style={styles.tutorialDetailsTable}>
                   <tbody>
-                    {this.props.item.teachers_notes && (
+                    {teachersNotes && (
                       <tr key={0}>
                         <td style={styles.tutorialDetailsTableTitle}>
                           {i18n.tutorialDetailsMoreResources()}
                         </td>
                         <td style={styles.tutorialDetailsTableBody}>
-                          <a
-                            href={this.props.item.teachers_notes}
-                            target="_blank"
-                          >
+                          <a href={teachersNotes} target="_blank">
                             <i
                               className="fa fa-external-link"
                               aria-hidden={true}

--- a/apps/src/tutorialExplorer/tutorialExplorer.js
+++ b/apps/src/tutorialExplorer/tutorialExplorer.js
@@ -58,7 +58,8 @@ export default class TutorialExplorer extends React.Component {
     showSortDropdown: PropTypes.bool.isRequired,
     disabledTutorials: PropTypes.arrayOf(PropTypes.string).isRequired,
     defaultSortBy: PropTypes.oneOf(Object.keys(TutorialsSortByOptions))
-      .isRequired
+      .isRequired,
+    cbPrefix: PropTypes.string.isRequired
   };
 
   constructor(props) {
@@ -573,6 +574,8 @@ export default class TutorialExplorer extends React.Component {
                   localeEnglish={false}
                   disabledTutorials={this.props.disabledTutorials}
                   grade={grade}
+                  locale={this.props.locale}
+                  cbPrefix={this.props.cbPrefix}
                 />
               )}
             </div>
@@ -637,6 +640,8 @@ export default class TutorialExplorer extends React.Component {
                     localeEnglish={this.isLocaleEnglish()}
                     disabledTutorials={this.props.disabledTutorials}
                     grade={grade}
+                    locale={this.props.locale}
+                    cbPrefix={this.props.cbPrefix}
                   />
                 )}
               </div>
@@ -863,6 +868,7 @@ window.TutorialExplorerManager = function(options) {
         showSortDropdown={options.showSortDropdown}
         disabledTutorials={options.disabledTutorials}
         defaultSortBy={defaultSortBy}
+        cbPrefix={options.cbPrefix}
       />,
       element
     );

--- a/apps/src/tutorialExplorer/tutorialSet.jsx
+++ b/apps/src/tutorialExplorer/tutorialSet.jsx
@@ -22,7 +22,9 @@ export default class TutorialSet extends React.Component {
     tutorials: PropTypes.arrayOf(shapes.tutorial.isRequired).isRequired,
     localeEnglish: PropTypes.bool.isRequired,
     disabledTutorials: PropTypes.arrayOf(PropTypes.string).isRequired,
-    grade: PropTypes.string.isRequired
+    grade: PropTypes.string.isRequired,
+    locale: PropTypes.string.isRequired,
+    cbPrefix: PropTypes.string.isRequired
   };
 
   state = {
@@ -60,6 +62,8 @@ export default class TutorialSet extends React.Component {
           disabledTutorial={disabledTutorial}
           changeTutorial={this.changeTutorial}
           grade={this.props.grade}
+          locale={this.props.locale}
+          cbPrefix={this.props.cbPrefix}
         />
         {this.props.tutorials.map(item => (
           <Tutorial

--- a/pegasus/sites.v3/code.org/public/learn/index.haml
+++ b/pegasus/sites.v3/code.org/public/learn/index.haml
@@ -143,7 +143,8 @@ style_min: false
       roboticsButtonUrl: "/learn/robotics",
       showSortDropdown: #{DCDO.get('learn_show_sort_dropdown', true)},
       disabledTutorials: #{raw DCDO.get('learn_hide_tutorials', [])},
-      defaultSortByPopularity: #{Tutorials.sort_by_popularity?(request.site, DCDO.get("hoc_mode", CDO.default_hoc_mode))}
+      defaultSortByPopularity: #{Tutorials.sort_by_popularity?(request.site, DCDO.get("hoc_mode", CDO.default_hoc_mode))},
+      cbPrefix: "#{CDO.curriculum_url(locale_code)}"
     });
     tutorialExplorerManager.renderToElement(document.getElementById('tutorials'));
 

--- a/pegasus/sites.v3/code.org/public/learn/robotics.haml
+++ b/pegasus/sites.v3/code.org/public/learn/robotics.haml
@@ -97,7 +97,8 @@ social:
       robotics: true,
       showSortDropdown: #{DCDO.get('learn_show_sort_dropdown', true)},
       backButton: true,
-      disabledTutorials: #{raw DCDO.get('learn_hide_tutorials', [])}
+      disabledTutorials: #{raw DCDO.get('learn_hide_tutorials', [])},
+      cbPrefix: "#{CDO.curriculum_url(locale_code)}"
     });
     tutorialExplorerManager.renderToElement(document.getElementById('tutorials'));
   });

--- a/pegasus/sites.v3/hourofcode.com/public/learn/index.haml
+++ b/pegasus/sites.v3/hourofcode.com/public/learn/index.haml
@@ -127,7 +127,8 @@ social:
       roboticsButtonUrl: "#{resolve_url('/learn/robotics')}",
       showSortDropdown: #{DCDO.get('learn_show_sort_dropdown', true)},
       disabledTutorials: #{raw DCDO.get('learn_hide_tutorials', [])},
-      defaultSortByPopularity: #{Tutorials.sort_by_popularity?(request.site, DCDO.get("hoc_mode", CDO.default_hoc_mode))}
+      defaultSortByPopularity: #{Tutorials.sort_by_popularity?(request.site, DCDO.get("hoc_mode", CDO.default_hoc_mode))},
+      cbPrefix: "#{CDO.curriculum_url(locale_code)}"
     });
     tutorialExplorerManager.renderToElement(document.getElementById('tutorials'));
 


### PR DESCRIPTION
<!--
  Your description goes here: A summary of the change, including any relevant motivation and context.

  If relevant, include a description both of the existing behavior and of the new behavior.
-->
Updating tutorial links to display locale-aware CB links where relevant.

Tutorials are specified in a marketing Google sheet, and not all links for lesson plans are CB links. This solution checks whether a lesson plan link is a CB link and whether it is locale-aware, and updates if it is not locale-aware.

Before:
<img width="615" alt="Screen Shot 2020-11-10 at 3 22 13 PM" src="https://user-images.githubusercontent.com/16494556/98745730-f04bc300-2368-11eb-8e33-a842b4cb4240.png">


After (note the CB link on hover):
<img width="626" alt="Screen Shot 2020-11-10 at 3 21 49 PM" src="https://user-images.githubusercontent.com/16494556/98745742-f477e080-2368-11eb-8cb2-ef5fb62f0e61.png">

*Note: the Italian translation for Teacher Notes includes "(in inglese)" in the link, but after this change, it will link to the lesson plan in Italian.
<img width="609" alt="Screen Shot 2020-11-10 at 3 32 00 PM" src="https://user-images.githubusercontent.com/16494556/98746543-8df3c200-236a-11eb-8b43-ed37ddd2239a.png">


<!--
  Other aspects to consider. uncomment and add detail for any that seem necessary:
-->

<!-- ### Background -->
<!-- ### Privacy -->
<!--
1.	Does the Project involve the collection, use or sharing of new Personal Data?

2.	Does the Project involve a new or changed use or sharing of existing Personal Data?
-->
<!-- ### Security -->
<!--
Link to Jira Task where sensitive security issues are discussed privately.
-->
<!-- ### Caching -->
<!-- ### Deployment strategy -->
<!-- ### Future work -->

## Links

<!--
  Any relevant links to external resources; ie, specification documents, jira
  items, related PRs, honeybadger errors, etc
-->

- [spec]()
- [jira]()

## Testing story

- Open http://localhost.hourofcode.com:3000/la/learn to see the list of tutorials in Spanish (LATAM)
- Click the first tile for Dance Party
- Open the link for Teacher Notes ("Notas del Profesor")
- Verify that the link opens the CB lesson plan in Spanish
- Verify that the links for other tutorials without CB links are the same as before
- Repeat test with Italian 

<!--
  Does your change include appropriate tests?

  If so, please describe how the tests included in this PR are sufficient

  If not, please explain why this change does not need to be tested.
-->

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
