### PR TITLE
Update CanCanCan to 2.2.0

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -153,7 +153,7 @@ gem 'phantomjs', '~> 1.9.7.1'
 gem 'gemoji'
 
 # Authentication and permissions.
-gem 'cancancan', '~> 1.15.0'
+gem 'cancancan', '~> 2.2.0'
 gem 'devise', '~> 4.7.0'
 gem 'devise_invitable', '~> 1.6.0'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -324,7 +324,7 @@ GEM
       sass (~> 3.2)
     brakeman (4.5.0)
     builder (3.2.3)
-    cancancan (1.15.0)
+    cancancan (2.2.0)
     case_transform (0.2)
       activesupport
     childprocess (0.9.0)
@@ -921,7 +921,7 @@ DEPENDENCIES
   binding_of_caller
   bootstrap-sass (~> 2.3.2.2)
   brakeman
-  cancancan (~> 1.15.0)
+  cancancan (~> 2.2.0)
   chronic (~> 0.10.2)
   codecov
   colorize


### PR DESCRIPTION
Required for the Rails 5.2 upgrade; specifically, https://github.com/CanCanCommunity/cancancan/pull/479 is required to fix an ActiveRecord query issue that we're seeing on controllers with autoloaded resources.

Reading through the changelog, it looks like the only major changes between this and our previous version are [several deprecations](https://github.com/CanCanCommunity/cancancan/blob/develop/CHANGELOG.md#200-may-18th-2017) for situations we aren't using.

## Testing story

Did some manual testing, but a relatively minor amount compared to how much this library is used throughout our system. Relying mostly on existing unit tests for this.

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
