### PR TITLE
Protect against WebPurify outage 

### DIFF
--- a/lib/cdo/web_purify.rb
+++ b/lib/cdo/web_purify.rb
@@ -27,7 +27,15 @@ module WebPurify
       "&text=#{URI.encode(text)}" \
       "&lang=#{language_codes}" \
       "&format=json"
-    result = JSON.parse(open(url, open_timeout: 5, read_timeout: 10).read)
+    result = JSON.
+      parse(
+        open(
+          url,
+          open_timeout: DCDO.get('webpurify_tcp_connect_timeout', 5),
+          read_timeout: DCDO.get('webpurify_http_read_timeout', 10)
+        ).
+        read
+      )
 
     expletive = result['rsp'] && result['rsp']['expletive']
     return nil unless expletive

--- a/lib/cdo/web_purify.rb
+++ b/lib/cdo/web_purify.rb
@@ -14,7 +14,7 @@ module WebPurify
   # @param [Array[String]] language_codes The set of languages to search for profanity in.
   # @return [Array<String>, nil] The profanities (if any) or nil (if none).
   def self.find_potential_profanities(text, language_codes = ['en'])
-    return nil unless CDO.webpurify_key
+    return nil unless CDO.webpurify_key && Gatekeeper.allows('webpurify', default: true)
     # Convert language codes to a list of two character codes, comma separated.
     language_codes = language_codes.
       map {|language_code| language_code[0..1]}.
@@ -27,7 +27,7 @@ module WebPurify
       "&text=#{URI.encode(text)}" \
       "&lang=#{language_codes}" \
       "&format=json"
-    result = JSON.parse(open(url).read)
+    result = JSON.parse(open(url, open_timeout: 5, read_timeout: 10).read)
 
     expletive = result['rsp'] && result['rsp']['expletive']
     return nil unless expletive


### PR DESCRIPTION
Set TCP connect and HTTP read timeout on WebPurify API calls and ensure that a Gatekeeper flag can be used to manually disable the calls. Together these changes ensure that performance and availability issues with this 3rd party WebService do not tie up all puma worker threads in our web application servers and cause an outage on our systems.

There are Gatekeeper checks [on some](https://github.com/code-dot-org/code-dot-org/blob/c2b29e9a75cc6ca56d00cf8fa85b1ea3957676cd/lib/cdo/share_filtering.rb#L58-L74), [but not all](https://github.com/code-dot-org/code-dot-org/blob/89f8b98fb6b7414d49bfc420c011016020454ca7/dashboard/app/controllers/profanity_controller.rb#L15), of the components that invoke this method.

[NewRelic metrics indicate](https://one.newrelic.com/launcher/nr1-core.explorer?pane=eyJuZXJkbGV0SWQiOiJhcG0tbmVyZGxldHMuZXh0ZXJuYWxzIiwiZW50aXR5SWQiOiJOVEF4TkRZemZFRlFUWHhCVUZCTVNVTkJWRWxQVG53ek56ZzNNelkwIiwic2VsZWN0ZWRTZXJpZXMiOiJiZmI1ZWY1ZjQ5NDg5Y2NjOTdiODhhOTM3NzFkMjcxNDhkMDU0NmUzIiwiZHJpbGxkb3duIjp7ImV4dGVybmFsLmhvc3QiOiJhcGkxLndlYnB1cmlmeS5jb20ifX0=&sidebars[0]=eyJuZXJkbGV0SWQiOiJucjEtY29yZS5hY3Rpb25zIiwiZW50aXR5SWQiOiJOVEF4TkRZemZFRlFUWHhCVUZCTVNVTkJWRWxQVG53ek56ZzNNelkwIiwic2VsZWN0ZWROZXJkbGV0Ijp7Im5lcmRsZXRJZCI6ImFwbS1uZXJkbGV0cy5leHRlcm5hbHMifX0=&platform[timeRange][duration]=604800000&platform[$isFallbackTimeRange]=false) that requests to this WebService rarely exceed 200ms, so 5 second TCP connect and 10 second HTTP read timeout should be sufficient

<img width="761" alt="image" src="https://user-images.githubusercontent.com/2157034/98882496-4429db00-2441-11eb-91e9-ca0159477d10.png">


### Background

https://codedotorg.atlassian.net/browse/INF-396

<!-- ### Privacy -->
<!--
1.	Does the Project involve the collection, use or sharing of new Personal Data?

2.	Does the Project involve a new or changed use or sharing of existing Personal Data?
-->
<!-- ### Security -->
<!--
Link to Jira Task where sensitive security issues are discussed privately.
-->
<!-- ### Caching -->
<!-- ### Deployment strategy -->
<!-- ### Future work -->

## Links

<!--
  Any relevant links to external resources; ie, specification documents, jira
  items, related PRs, honeybadger errors, etc
-->

- [spec]()
- [jira]()

## Testing story

<!--
  Does your change include appropriate tests?

  If so, please describe how the tests included in this PR are sufficient

  If not, please explain why this change does not need to be tested.
-->

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
