### PR TITLE
Allow emojis in teacher feedback

### DIFF
--- a/dashboard/db/migrate/20201112042305_convert_teacher_feedback_to_utf8mb4.rb
+++ b/dashboard/db/migrate/20201112042305_convert_teacher_feedback_to_utf8mb4.rb
@@ -1,0 +1,10 @@
+class ConvertTeacherFeedbackToUtf8mb4 < ActiveRecord::Migration[5.1]
+  def up
+    execute 'alter table teacher_feedbacks convert to charset utf8mb4 collate utf8mb4_unicode_ci'
+    change_column :teacher_feedbacks, :comment, :text, limit: 65535
+  end
+
+  def down
+    execute 'alter table teacher_feedbacks convert to charset utf8 collate utf8_unicode_ci'
+  end
+end

--- a/dashboard/db/schema.rb
+++ b/dashboard/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20201029231229) do
+ActiveRecord::Schema.define(version: 20201112042305) do
 
   create_table "activities", id: :integer, force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci" do |t|
     t.integer "user_id"
@@ -1583,7 +1583,7 @@ ActiveRecord::Schema.define(version: 20201029231229) do
     t.index ["user_id"], name: "index_survey_results_on_user_id"
   end
 
-  create_table "teacher_feedbacks", id: :integer, force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci" do |t|
+  create_table "teacher_feedbacks", id: :integer, force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci" do |t|
     t.text "comment"
     t.integer "student_id"
     t.integer "level_id", null: false


### PR DESCRIPTION
Corrected version of #37504 - resolved issues with database charset. This PR contains a migration that modifies the teacher_feedbacks table to allow for emojis in teacher comments.

![Screen Shot 2020-11-11 at 11 43 53 PM](https://user-images.githubusercontent.com/17502635/98896770-c33a0600-2477-11eb-9077-44ba438c78b0.png)

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
