### PR TITLE
improve comments on get_lesson_group_pairs

### DIFF
--- a/bin/oneoff/import_unit_details.rb
+++ b/bin/oneoff/import_unit_details.rb
@@ -220,39 +220,41 @@ def get_validated_lesson_pairs(script, cb_unit)
   validated_lesson_pairs
 end
 
-# Validates the following preconditions:
-
-# 1. Every CB chapter has a corresponding LessonGroup in Code Studio.
-# 2. If the CB unit uses chapters, then for each Code Studio chapter containing
-# lessons which have lesson plans, there is a corresponding CB chapter.
-# 3. For each LessonGroup with a corresponding CB chapter, the number of Lessons
-# in the Lesson Group which have lesson plans equals the number of lessons in
-# the CB chapter.
-# 4. we do not validate that the lesson names match like we did earlier, to
-# avoid duplicate warnings.
+# Given a Code Studio Script/Unit:
 #
-# Then, returns an array of pairs of LessonGroups and corresponding CB chapters.
+# 1. Filter out any LessonGroups which do not contain any lessons with
+# corresponding lessons in CB, because these LessonGroups should not have
+# corresponding chapters on CB.
+# 2. verify that there is now a 1-to-1 correspondence between the remaining
+# LessonGroups and CB chapters.
+# 3. For each remaining LessonGroup, filter out any Lessons which do not have
+# corresponding lessons in CB.
+# 4. For each remaining LessonGroup, verify that the remaining number of lessons
+# is the same as the number of lessons in the corresponding CB chapter. We
+# already did more detailed checks to pair up lessons between CB and Code Studio,
+# so this is just a heuristic to confirm these lessons are distributed similarly.
+# 5. Warn if any lesson group names differ from the corresponding CB chapter name.
+# 6. Return a list of pairs of LessonGroups and CB chapters.
 #
 # @param [Script] script - Code Studio Script/Unit object.
 # @param [Array<Hash>] - Array of CB chapters
 # @param [Array<Array.<Lesson, Hash>>] - Array of pairs of Code Studio Lesson
 #   objects and CB lessons.
-# @return [Array<Array<LessonGroup, Hash>>] lesson_pairs - Array of pairs of
-#   Code Studio LessonGroup objects and CB chapters.
+# @return [Array<Array<LessonGroup, Hash>>] lesson_group_pairs - Array of pairs
+#   of Code Studio LessonGroup objects and CB chapters.
 def get_lesson_group_pairs(script, cb_chapters, lesson_pairs)
   return [] unless cb_chapters.present?
 
-  # Compute a list of all code studio lessons embedded in the lesson_pairs array.
+  # Compute a list of code studio lessons which have corresponding lessons in CB.
   paired_lessons = lesson_pairs.map(&:first)
 
-  # Filter out any Code Studio lesson groups which do not contain any lessons
-  # which were paired with lesson plans.
+  # 1. Filter out any LessonGroups which do not contain any lessons with
+  # corresponding lessons in CB.
   filtered_lesson_groups = script.lesson_groups.all.select do |lg|
     lg.lessons.any? {|lesson| paired_lessons.include?(lesson)}
   end
 
-  # Now we expect the filtered lesson groups to have a one-to-one correspondence
-  # with CB chapters.
+  # 2. verify a 1-to-1 correspondence between remaining LessonGroups and CB chapters.
   unless filtered_lesson_groups.count == cb_chapters.count
     raise "unexpected chapter count for unit #{script.name}: #{filtered_lesson_groups.count} != #{cb_chapters.count}."
   end
@@ -260,11 +262,12 @@ def get_lesson_group_pairs(script, cb_chapters, lesson_pairs)
   lesson_group_pairs = []
   mismatched_names = []
   filtered_lesson_groups.each.with_index do |lesson_group, index|
-    # Of those lesson groups which contained any lessons which have lesson plans,
-    # only look at the subset of lessons which have lesson plans.
+    # 3. Filter out any Lessons which do not have corresponding lessons in CB.
     filtered_lessons = lesson_group.lessons.all.select {|lesson| paired_lessons.include?(lesson)}
     cb_chapter = cb_chapters[index]
 
+    # 4. Verify that the remaining number of lessons is now the same as the
+    # number of lessons in the corresponding CB chapter.
     unless filtered_lessons.count == cb_chapter['lessons'].count
       raise "lesson count mismatch for lesson group #{lesson_group.display_name}: "\
               "#{filtered_lessons.count} != #{cb_chapter['lessons'].count}"
@@ -276,6 +279,7 @@ def get_lesson_group_pairs(script, cb_chapters, lesson_pairs)
     end
   end
 
+  # 5. warn if any lesson group names differ from the corresponding CB chapter name.
   if mismatched_names.any?
     mismatch_summary = mismatched_names.map do |left, right|
       "  '#{left}' --> '#{right}'"
@@ -283,6 +287,7 @@ def get_lesson_group_pairs(script, cb_chapters, lesson_pairs)
     warn "WARNING: some lesson group names differ for unit #{script.name}:\n#{mismatch_summary}"
   end
 
+  # 6. return a list of pairs of LessonGroups and CB chapters.
   lesson_group_pairs
 end
 


### PR DESCRIPTION
Follow-on to https://github.com/code-dot-org/code-dot-org/pull/37772 which I accidentally left this commit out of. 