### PR TITLE
Update our "Ignore X-Forwarded-Host" patch to Rack 2.2.3

### DIFF
--- a/lib/cdo/rack/request.rb
+++ b/lib/cdo/rack/request.rb
@@ -42,9 +42,10 @@ module Cdo
     end
 
     # Patch: don't use X_FORWARDED_HOST header when determining host from request headers.
-    def host_with_port
-      get_header(Rack::HTTP_HOST) ||
-        "#{get_header(Rack::SERVER_NAME) || get_header(Rack::SERVER_ADDR)}:#{get_header(Rack::SERVER_PORT)}"
+    # Specifically, here we patch the upstream authority method to ignore the "forwarded" authority option
+    # See https://github.com/rack/rack/blob/1741c580d71cfca8e541e96cc372305c8892ee74/lib/rack/request.rb#L222-L229
+    def authority
+      host_authority || server_authority
     end
 
     def site_from_host


### PR DESCRIPTION
The method we're patching to override this behavior was updated a couple of times since our previous version of rack; first in https://github.com/rack/rack/pull/1435, then presumably a couple more times because the relevant logic ends up looking like this in 2.2.3:

https://github.com/rack/rack/blob/1741c580d71cfca8e541e96cc372305c8892ee74/lib/rack/request.rb#L222-L229

We therefore in this PR update the logic of our patch to better match the current internal structure of Rack.

## Testing story

Relying on the existing unit test which caught this in the first place.

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
