### PR TITLE
Remove 'escaped cookies' test

### DIFF
--- a/shared/test/test_cookie_whitelist.rb
+++ b/shared/test/test_cookie_whitelist.rb
@@ -4,8 +4,6 @@ require 'cdo/rack/allowlist'
 class CookieAllowlistTest < Minitest::Test
   include Rack::Test::Methods
 
-  ESCAPED_KEY = '1;2&3=4%'.freeze
-  ESCAPED_VALUE = '3;4&5=6%'.freeze
   HEADERS = REMOVED_HEADERS.map {|x| x.split(':')[0]}.freeze
   COOKIE_CONFIG = {
     behaviors: [
@@ -17,11 +15,6 @@ class CookieAllowlistTest < Minitest::Test
       {
         path: '/some/*',
         cookies: %w(one two),
-        headers: HEADERS
-      },
-      {
-        path: '/weird/*',
-        cookies: %w(one two) << ESCAPED_KEY,
         headers: HEADERS
       }
     ],
@@ -49,7 +42,6 @@ class CookieAllowlistTest < Minitest::Test
     session.set_cookie('one=1')
     session.set_cookie('two=2')
     session.set_cookie('three=3')
-    session.set_cookie(Rack::Utils.escape(ESCAPED_KEY) + '=' + Rack::Utils.escape(ESCAPED_VALUE))
   end
 
   def test_allowlisted_cookies
@@ -67,12 +59,6 @@ class CookieAllowlistTest < Minitest::Test
   def test_all_cookies
     get '/all/'
     refute_nil @request_env['HTTP_COOKIE'].match(/three/)
-    assert_equal @request_cookies, {'one' => '1', 'two' => '2', 'three' => '3', ESCAPED_KEY => ESCAPED_VALUE}
-  end
-
-  def test_allowlist_escaped_cookie
-    get '/weird/'
-    assert_nil @request_env['HTTP_COOKIE'].match(/three/)
-    assert_equal @request_cookies, {'one' => '1', 'two' => '2', ESCAPED_KEY => ESCAPED_VALUE}
+    assert_equal @request_cookies, {'one' => '1', 'two' => '2', 'three' => '3'}
   end
 end


### PR DESCRIPTION
The latest version of Rack includes a change to this behavior (https://github.com/rack/rack/commit/5ccca4722668083732ea2d35c56565fcc25312f8) which caused this test to start failing. We could simply update the test to conform to the new behavior, but because we don't actually rely on this behavior anywhere and to reduce future potential noise, it seems better to just remove the test.

## Testing story

n/a

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
