### PR TITLE
Explicitly cast session.id to a string everywhere we directly use it

### DIFF
--- a/dashboard/app/helpers/levels_helper.rb
+++ b/dashboard/app/helpers/levels_helper.rb
@@ -798,7 +798,7 @@ module LevelsHelper
   def session_id
     # session.id may not be available on the first visit unless we write to the session first.
     session['init'] = true
-    session.id
+    session.id.to_s
   end
 
   def user_or_session_id

--- a/dashboard/lib/pd/payment/payment_calculator_base.rb
+++ b/dashboard/lib/pd/payment/payment_calculator_base.rb
@@ -100,7 +100,7 @@ module Pd::Payment
     # @return [Array<SessionAttendanceSummary>] summary of attendance for each session.
     def get_session_attendance_summaries(workshop)
       workshop.sessions.map do |session|
-        session_attendances = Pd::Attendance.where(pd_session_id: session.id)
+        session_attendances = Pd::Attendance.where(pd_session_id: session.id.to_s)
         enrollment_ids = session_attendances.all.map(&:resolve_enrollment).compact.map(&:id).uniq
         SessionAttendanceSummary.new session.hours, enrollment_ids
       end

--- a/dashboard/test/controllers/api/v1/pd/workshops_controller_test.rb
+++ b/dashboard/test/controllers/api/v1/pd/workshops_controller_test.rb
@@ -783,7 +783,7 @@ class Api::V1::Pd::WorkshopsControllerTest < ::ActionController::TestCase
     session_updated_start = session_initial_start + 2.days
     session_updated_end = session_initial_end + 2.days + 2.hours
     params = {
-      sessions_attributes: [{id: session.id, start: session_updated_start, end: session_updated_end}]
+      sessions_attributes: [{id: session.id.to_s, start: session_updated_start, end: session_updated_end}]
     }
 
     put :update, params: {id: @organizer_workshop.id, pd_workshop: params}
@@ -808,7 +808,7 @@ class Api::V1::Pd::WorkshopsControllerTest < ::ActionController::TestCase
     session_updated_start = session_initial_start + 2.days
     session_updated_end = session_initial_end + 2.days + 2.hours
     params = {
-      sessions_attributes: [{id: session.id, start: session_updated_start, end: session_updated_end}]
+      sessions_attributes: [{id: session.id.to_s, start: session_updated_start, end: session_updated_end}]
     }
     put :update, params: {id: workshop.id, pd_workshop: params}
     assert_response :success
@@ -827,7 +827,7 @@ class Api::V1::Pd::WorkshopsControllerTest < ::ActionController::TestCase
     @organizer_workshop.save!
     assert_equal 1, @organizer_workshop.sessions.count
 
-    params = {sessions_attributes: [{id: session.id, _destroy: true}]}
+    params = {sessions_attributes: [{id: session.id.to_s, _destroy: true}]}
 
     put :update, params: {id: @organizer_workshop.id, pd_workshop: params}
     assert_response :success
@@ -841,7 +841,7 @@ class Api::V1::Pd::WorkshopsControllerTest < ::ActionController::TestCase
     session = workshop.sessions.first
 
     sign_in program_manager
-    params = {sessions_attributes: [{id: session.id, _destroy: true}]}
+    params = {sessions_attributes: [{id: session.id.to_s, _destroy: true}]}
     put :update, params: {id: workshop.id, pd_workshop: params}
     assert_response :success
 


### PR DESCRIPTION
Follow-up to https://github.com/code-dot-org/code-dot-org/pull/37756, which covered one relevant use case, but not all.

See that PR for more details

## Testing story

This was originally caught by a UI test, so mostly relying on that. Also did some basic manual testing.

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
