### PR TITLE
Moving the Immersive Reader render flag to make sure it updated

### DIFF
--- a/apps/src/templates/instructions/ImmersiveReaderButton.jsx
+++ b/apps/src/templates/instructions/ImmersiveReaderButton.jsx
@@ -12,12 +12,12 @@ class ImmersiveReaderButton extends Component {
 
   componentDidMount() {
     if (this.shouldRender() && !this.renderButtonsCalled) {
+      // Make sure renderButtons() is only called once.
+      this.renderButtonsCalled = true;
       // Applies inline styling to the .immersive-reader-button elements
       renderButtons({
         elements: [this.container]
       });
-      // Make sure renderButtons() is only called once.
-      this.renderButtonsCalled = true;
     }
   }
 


### PR DESCRIPTION
Making a quick change to make sure `this.renderButtonsCalled = true;` is executed in order to guarantee `renderButtons` is not called more than once. There is a risk that `renderButtons` throws an exception and the flag is never updated.
<!--
  Your description goes here: A summary of the change, including any relevant motivation and context.

  If relevant, include a description both of the existing behavior and of the new behavior.
-->

<!--
  Other aspects to consider. uncomment and add detail for any that seem necessary:
-->

<!-- ### Background -->
<!-- ### Privacy -->
<!--
1.	Does the Project involve the collection, use or sharing of new Personal Data?

2.	Does the Project involve a new or changed use or sharing of existing Personal Data?
-->
<!-- ### Security -->
<!--
Link to Jira Task where sensitive security issues are discussed privately.
-->
<!-- ### Caching -->
<!-- ### Deployment strategy -->
<!-- ### Future work -->

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
