### PR TITLE
Enable send lesson dialog [test all browsers]

### DIFF
--- a/apps/src/code-studio/progress.js
+++ b/apps/src/code-studio/progress.js
@@ -4,7 +4,6 @@ import ReactDOM from 'react-dom';
 import {Provider} from 'react-redux';
 import _ from 'lodash';
 import queryString from 'query-string';
-import experiments from '@cdo/apps/util/experiments';
 import clientState from './clientState';
 import {convertAssignmentVersionShapeFromServer} from '@cdo/apps/templates/teacherDashboard/shapes';
 import ScriptOverview from './components/progress/ScriptOverview.jsx';
@@ -36,10 +35,6 @@ import googlePlatformApi, {
   loadGooglePlatformApi
 } from '@cdo/apps/templates/progress/googlePlatformApiRedux';
 import {queryLockStatus, renderTeacherPanel} from './teacherPanelHelpers';
-import {
-  OAuthSectionTypes,
-  OAuthProviders
-} from '@cdo/apps/lib/ui/accounts/constants';
 
 var progress = module.exports;
 
@@ -150,13 +145,7 @@ progress.renderCourseProgress = function(scriptData) {
   const store = getStore();
   initializeStoreWithProgress(store, scriptData, null, true);
   initializeStoreWithSections(store, scriptData);
-
-  // Initialize google platform api for teachers if we're using the new send
-  // lesson dialog.  (Otherwise, it's intialized in initializeStoreWithSections.)
-  if (
-    experiments.isEnabled(experiments.SEND_LESSON_DIALOG) &&
-    scriptData.user_type === 'teacher'
-  ) {
+  if (scriptData.user_type === 'teacher') {
     initializeGooglePlatformApi(store);
   }
 
@@ -365,18 +354,6 @@ function initializeStoreWithSections(store, scriptData) {
   }
   store.dispatch(setSections(sections));
   store.dispatch(selectSection(currentSection.id.toString()));
-
-  // If our current section is a google classroom and teacher is conntected
-  // to google, load the google classroom share button api.
-  if (
-    !experiments.isEnabled(experiments.SEND_LESSON_DIALOG) &&
-    currentSection.login_type === OAuthSectionTypes.google_classroom &&
-    scriptData.user_providers &&
-    scriptData.user_providers.includes(OAuthProviders.google)
-  ) {
-    registerReducers({googlePlatformApi});
-    store.dispatch(loadGooglePlatformApi()).catch(e => console.warn(e));
-  }
 }
 
 function initializeGooglePlatformApi(store) {

--- a/apps/src/templates/progress/ProgressLesson.jsx
+++ b/apps/src/templates/progress/ProgressLesson.jsx
@@ -153,7 +153,8 @@ class ProgressLesson extends React.Component {
 
     // There's no url for a lesson so use the url of the first level of the lesson
     // as the url for the lesson.
-    // TODO: Make the back-end support lesson urls and redirect to the first level.
+    // TODO: Make the back-end return a lesson url as part of the lesson metadata so we
+    // don't need to pass it separately from lesson here and in ProgressLessonTeacherInfo.
     const lessonUrl = levels[0] && levels[0].url;
     return (
       <div

--- a/apps/src/templates/progress/ProgressLessonTeacherInfo.jsx
+++ b/apps/src/templates/progress/ProgressLessonTeacherInfo.jsx
@@ -7,7 +7,6 @@ import PropTypes from 'prop-types';
 import React from 'react';
 import {connect} from 'react-redux';
 import i18n from '@cdo/locale';
-import experiments from '@cdo/apps/util/experiments';
 import {lessonType} from './progressTypes';
 import HiddenForSectionToggle from './HiddenForSectionToggle';
 import StageLock from './StageLock';
@@ -19,8 +18,6 @@ import {sectionShape} from '@cdo/apps/templates/teacherDashboard/shapes';
 import Button from '../Button';
 import TeacherInfoBox from './TeacherInfoBox';
 import firehoseClient from '@cdo/apps/lib/util/firehose';
-import GoogleClassroomShareButton from './GoogleClassroomShareButton';
-import {canShowGoogleShareButton} from './googlePlatformApiRedux';
 import SendLesson from './SendLesson';
 
 const styles = {
@@ -33,9 +30,6 @@ const styles = {
     width: '100%',
     paddingLeft: 0,
     paddingRight: 0
-  },
-  googleButtonMargin: {
-    marginBottom: 5
   }
 };
 
@@ -50,8 +44,7 @@ class ProgressLessonTeacherInfo extends React.Component {
     hiddenStageState: PropTypes.object.isRequired,
     scriptName: PropTypes.string.isRequired,
     hasNoSections: PropTypes.bool.isRequired,
-    toggleHiddenStage: PropTypes.func.isRequired,
-    showGoogleClassroomButton: PropTypes.bool.isRequired
+    toggleHiddenStage: PropTypes.func.isRequired
   };
 
   constructor(props) {
@@ -92,8 +85,7 @@ class ProgressLessonTeacherInfo extends React.Component {
       hiddenStageState,
       hasNoSections,
       lesson,
-      lessonUrl,
-      showGoogleClassroomButton
+      lessonUrl
     } = this.props;
 
     const sectionId = (section && section.id.toString()) || '';
@@ -103,17 +95,13 @@ class ProgressLessonTeacherInfo extends React.Component {
       scriptAllowsHiddenStages &&
       isStageHiddenForSection(hiddenStageState, sectionId, lesson.id);
     const courseId =
-      (showGoogleClassroomButton &&
-        section &&
-        section.code &&
-        parseInt(section.code.substring(2))) ||
-      null;
+      (section && section.code && parseInt(section.code.substring(2))) || null;
     const loginRequiredLessonUrl = lessonUrl + '?login_required=true';
     const shouldRender =
       lesson.lesson_plan_html_url ||
       (lesson.lockable && !hasNoSections) ||
-      showHiddenForSectionToggle ||
-      showGoogleClassroomButton;
+      lessonUrl ||
+      showHiddenForSectionToggle;
     if (!shouldRender) {
       return null;
     }
@@ -134,13 +122,7 @@ class ProgressLessonTeacherInfo extends React.Component {
           </div>
         )}
         {lesson.lockable && !hasNoSections && <StageLock lesson={lesson} />}
-        {showHiddenForSectionToggle && (
-          <HiddenForSectionToggle
-            hidden={!!isHidden}
-            onChange={this.onClickHiddenToggle}
-          />
-        )}
-        {experiments.isEnabled(experiments.SEND_LESSON_DIALOG) && lessonUrl && (
+        {lessonUrl && (
           <div style={styles.buttonContainer}>
             <SendLesson
               lessonUrl={loginRequiredLessonUrl}
@@ -151,20 +133,12 @@ class ProgressLessonTeacherInfo extends React.Component {
             />
           </div>
         )}
-        {!experiments.isEnabled(experiments.SEND_LESSON_DIALOG) &&
-          showGoogleClassroomButton &&
-          lessonUrl && (
-            <div
-              style={{...styles.buttonContainer, ...styles.googleButtonMargin}}
-            >
-              <GoogleClassroomShareButton
-                url={lessonUrl}
-                title={lesson.name}
-                courseid={courseId}
-                analyticsData={JSON.stringify(this.firehoseData())}
-              />
-            </div>
-          )}
+        {showHiddenForSectionToggle && (
+          <HiddenForSectionToggle
+            hidden={!!isHidden}
+            onChange={this.onClickHiddenToggle}
+          />
+        )}
       </TeacherInfoBox>
     );
   }
@@ -181,8 +155,7 @@ export default connect(
     scriptName: state.progress.scriptName,
     hasNoSections:
       state.teacherSections.sectionsAreLoaded &&
-      state.teacherSections.sectionIds.length === 0,
-    showGoogleClassroomButton: canShowGoogleShareButton(state)
+      state.teacherSections.sectionIds.length === 0
   }),
   {toggleHiddenStage}
 )(ProgressLessonTeacherInfo);

--- a/apps/src/templates/progress/ProgressLessonTeacherInfo.story.jsx
+++ b/apps/src/templates/progress/ProgressLessonTeacherInfo.story.jsx
@@ -18,10 +18,6 @@ import teacherSections, {
   setSections,
   selectSection
 } from '@cdo/apps/templates/teacherDashboard/teacherSectionsRedux';
-import googlePlatformApi, {
-  loadGooglePlatformApi
-} from '@cdo/apps/templates/progress/googlePlatformApiRedux';
-import {OAuthSectionTypes} from '@cdo/apps/lib/ui/accounts/constants';
 
 const lockableStage = {
   id: 123,
@@ -55,12 +51,8 @@ const nonLockableNoLessonPlan = {
   lockable: false
 };
 
-const createStore = ({
-  preload = false,
-  allowHidden = true,
-  showGoogleButton = false
-} = {}) => {
-  registerReducers({teacherSections, googlePlatformApi});
+const createStore = ({preload = false, allowHidden = true} = {}) => {
+  registerReducers({teacherSections});
   const store = createStoreWithReducers();
   const stages = [
     lockableStage,
@@ -96,17 +88,6 @@ const createStore = ({
         code: 'TQGSJR',
         providerManaged: false,
         stages: {}
-      },
-      '12': {
-        id: 12,
-        name: 'google section',
-        lesson_extras: true,
-        pairing_allowed: true,
-        studentCount: 4,
-        code: 'G-149414657094',
-        providerManaged: true,
-        login_type: OAuthSectionTypes.google_classroom,
-        stages: {}
       }
     };
     stages.forEach(stage => {
@@ -115,19 +96,10 @@ const createStore = ({
         name: `student${id}`,
         readonly_answers: false
       }));
-      sections[12].stages[stage.id] = [0, 1, 2].map(id => ({
-        locked: true,
-        name: `student${id}`,
-        readonly_answers: false
-      }));
     });
-    store.dispatch(setSections([sections[11], sections[12]]));
+    store.dispatch(setSections([sections[11]]));
     store.dispatch(setSectionLockStatus(sections));
-    if (showGoogleButton) {
-      store.dispatch(loadGooglePlatformApi());
-    }
-    const section = showGoogleButton ? '12' : '11';
-    store.dispatch(selectSection(section));
+    store.dispatch(selectSection('11'));
   }
   return store;
 };
@@ -142,7 +114,7 @@ export default storybook => {
     .storiesOf('Progress/ProgressLessonTeacherInfo', module)
     .addStoryTable([
       {
-        name: 'loading (with google, without google)',
+        name: 'loading',
         story: () => {
           const store = createStore({preload: true});
           const state = store.getState();
@@ -151,7 +123,7 @@ export default storybook => {
               <div style={style}>
                 <ProgressLessonTeacherInfo
                   lesson={lessons(state.progress)[0]}
-                  levelUrl="code.org"
+                  lessonUrl="https://studio.code.org/s/csd3-2020/stage/5/puzzle/1?login_required=true"
                 />
               </div>
             </Provider>
@@ -160,7 +132,7 @@ export default storybook => {
       },
       {
         name:
-          'hideable allowed, lockable lesson with no lesson plan, without google',
+          'hideable allowed, lockable lesson with no lesson plan, without lesson url',
         story: () => {
           const store = createStore();
           const state = store.getState();
@@ -169,7 +141,6 @@ export default storybook => {
               <div style={style}>
                 <ProgressLessonTeacherInfo
                   lesson={lessons(state.progress)[0]}
-                  levelUrl="code.org"
                 />
               </div>
             </Provider>
@@ -178,18 +149,16 @@ export default storybook => {
       },
       {
         name:
-          'hideable allowed, lockable lesson with no lesson plan, with google',
-        description:
-          'google share button requires google section and google oath',
+          'hideable allowed, lockable lesson with no lesson plan, with lesson url',
         story: () => {
-          const store = createStore({showGoogleButton: true});
+          const store = createStore();
           const state = store.getState();
           return (
             <Provider store={store}>
               <div style={style}>
                 <ProgressLessonTeacherInfo
                   lesson={lessons(state.progress)[0]}
-                  levelUrl="code.org"
+                  lessonUrl="https://studio.code.org/s/csd3-2020/stage/5/puzzle/1?login_required=true"
                 />
               </div>
             </Provider>
@@ -198,7 +167,7 @@ export default storybook => {
       },
       {
         name:
-          'hideable allowed, lockable lesson with lesson plan, without google',
+          'hideable allowed, lockable lesson with lesson plan, without lesson url',
         story: () => {
           const store = createStore();
           const state = store.getState();
@@ -207,26 +176,6 @@ export default storybook => {
               <div style={style}>
                 <ProgressLessonTeacherInfo
                   lesson={lessons(state.progress)[2]}
-                  levelUrl="code.org"
-                />
-              </div>
-            </Provider>
-          );
-        }
-      },
-      {
-        name: 'hideable allowed, lockable lesson with lesson plan, with google',
-        description:
-          'google share button requires google section and google oath',
-        story: () => {
-          const store = createStore({showGoogleButton: true});
-          const state = store.getState();
-          return (
-            <Provider store={store}>
-              <div style={style}>
-                <ProgressLessonTeacherInfo
-                  lesson={lessons(state.progress)[2]}
-                  levelUrl="code.org"
                 />
               </div>
             </Provider>
@@ -235,7 +184,25 @@ export default storybook => {
       },
       {
         name:
-          'hideable allowed, nonlockable lesson with lesson plan, without google',
+          'hideable allowed, lockable lesson with lesson plan, with lesson url',
+        story: () => {
+          const store = createStore();
+          const state = store.getState();
+          return (
+            <Provider store={store}>
+              <div style={style}>
+                <ProgressLessonTeacherInfo
+                  lesson={lessons(state.progress)[2]}
+                  lessonUrl="https://studio.code.org/s/csd3-2020/stage/5/puzzle/1?login_required=true"
+                />
+              </div>
+            </Provider>
+          );
+        }
+      },
+      {
+        name:
+          'hideable allowed, nonlockable lesson with lesson plan, without lesson url',
         story: () => {
           const store = createStore();
           const state = store.getState();
@@ -244,7 +211,6 @@ export default storybook => {
               <div style={style}>
                 <ProgressLessonTeacherInfo
                   lesson={lessons(state.progress)[1]}
-                  levelUrl="code.org"
                 />
               </div>
             </Provider>
@@ -253,18 +219,16 @@ export default storybook => {
       },
       {
         name:
-          'hideable allowed, nonlockable lesson with lesson plan, with google',
-        description:
-          'google share button requires google section and google oath',
+          'hideable allowed, nonlockable lesson with lesson plan, with lesson url',
         story: () => {
-          const store = createStore({showGoogleButton: true});
+          const store = createStore();
           const state = store.getState();
           return (
             <Provider store={store}>
               <div style={style}>
                 <ProgressLessonTeacherInfo
                   lesson={lessons(state.progress)[1]}
-                  levelUrl="code.org"
+                  lessonUrl="https://studio.code.org/s/csd3-2020/stage/5/puzzle/1?login_required=true"
                 />
               </div>
             </Provider>
@@ -273,7 +237,7 @@ export default storybook => {
       },
       {
         name:
-          'hideable not allowed, nonlockable lesson with no lesson plan, without google',
+          'hideable not allowed, nonlockable lesson with no lesson plan, without lesson url',
         description: "shouldn't render anything",
         story: () => {
           const store = createStore({allowHidden: false});
@@ -283,7 +247,6 @@ export default storybook => {
               <div style={style}>
                 <ProgressLessonTeacherInfo
                   lesson={lessons(state.progress)[3]}
-                  levelUrl="code.org"
                 />
               </div>
             </Provider>
@@ -292,21 +255,16 @@ export default storybook => {
       },
       {
         name:
-          'hideable not allowed, nonlockable lesson with no lesson plan, with google',
-        description:
-          'google share button requires google section and google oath',
+          'hideable not allowed, nonlockable lesson with no lesson plan, with lesson url',
         story: () => {
-          const store = createStore({
-            allowHidden: false,
-            showGoogleButton: true
-          });
+          const store = createStore({allowHidden: false});
           const state = store.getState();
           return (
             <Provider store={store}>
               <div style={style}>
                 <ProgressLessonTeacherInfo
                   lesson={lessons(state.progress)[3]}
-                  levelUrl="code.org"
+                  lessonUrl="https://studio.code.org/s/csd3-2020/stage/5/puzzle/1?login_required=true"
                 />
               </div>
             </Provider>

--- a/apps/src/templates/progress/SendLesson.jsx
+++ b/apps/src/templates/progress/SendLesson.jsx
@@ -43,7 +43,7 @@ export default class SendLesson extends React.Component {
 
   render() {
     return (
-      <div>
+      <div className="uitest-sendlesson">
         <Button
           __useDeprecatedTag
           onClick={this.openDialog}

--- a/apps/src/templates/progress/SendLessonDialog.jsx
+++ b/apps/src/templates/progress/SendLessonDialog.jsx
@@ -91,7 +91,7 @@ class SendLessonDialog extends Component {
     return (
       <div style={styles.row}>
         <Button
-          id="ui-test-copy-button"
+          id="uitest-copy-button"
           text=""
           icon="link"
           iconStyle={styles.buttonIcon}

--- a/apps/src/util/experiments.js
+++ b/apps/src/util/experiments.js
@@ -31,7 +31,6 @@ experiments.TEXT_TO_SPEECH_BLOCK = 'text-to-speech-block';
 experiments.FINISH_DIALOG_METRICS = 'finish-dialog-metrics';
 experiments.I18N_TRACKING = 'i18n-tracking';
 experiments.SPRITELAB_INPUT = 'spritelabInput';
-experiments.SEND_LESSON_DIALOG = 'send-lesson-dialog';
 experiments.TIME_SPENT = 'time-spent';
 
 /**

--- a/apps/test/unit/templates/progress/ProgressLessonTeacherInfoTest.js
+++ b/apps/test/unit/templates/progress/ProgressLessonTeacherInfoTest.js
@@ -4,20 +4,8 @@ import Immutable from 'immutable';
 import {shallow} from 'enzyme';
 import {UnconnectedProgressLessonTeacherInfo as ProgressLessonTeacherInfo} from '@cdo/apps/templates/progress/ProgressLessonTeacherInfo';
 import {fakeLesson} from '@cdo/apps/templates/progress/progressTestHelpers';
-import {OAuthSectionTypes} from '@cdo/apps/lib/ui/accounts/constants';
 
-const MOCK_GOOGLE_SECTION = {
-  id: 1,
-  name: 'intro to computer science I',
-  stageExtras: true,
-  pairingAllowed: true,
-  studentCount: 6,
-  code: 'G-149414657094',
-  providerManaged: true,
-  loginType: OAuthSectionTypes.google_classroom
-};
-
-const MOCK_NON_GOOGLE_SECTION = {
+const MOCK_SECTION = {
   id: 2,
   name: 'intro to computer science II',
   stageExtras: true,
@@ -42,7 +30,7 @@ describe('ProgressLessonTeacherInfo', () => {
       shallow(
         <ProgressLessonTeacherInfo
           lesson={lesson}
-          section={MOCK_NON_GOOGLE_SECTION}
+          section={MOCK_SECTION}
           lessonUrl={'code.org'}
           scriptAllowsHiddenStages={false}
           hiddenStageState={Immutable.fromJS({
@@ -51,7 +39,6 @@ describe('ProgressLessonTeacherInfo', () => {
           scriptName="My Script"
           hasNoSections={false}
           toggleHiddenStage={() => {}}
-          showGoogleClassroomButton={false}
         />
       )
     );
@@ -71,7 +58,7 @@ describe('ProgressLessonTeacherInfo', () => {
       shallow(
         <ProgressLessonTeacherInfo
           lesson={lesson}
-          section={MOCK_NON_GOOGLE_SECTION}
+          section={MOCK_SECTION}
           lessonUrl={'code.org'}
           scriptAllowsHiddenStages={false}
           hiddenStageState={Immutable.fromJS({
@@ -80,7 +67,6 @@ describe('ProgressLessonTeacherInfo', () => {
           scriptName="My Script"
           hasNoSections={false}
           toggleHiddenStage={() => {}}
-          showGoogleClassroomButton={false}
         />
       )
     );
@@ -95,7 +81,7 @@ describe('ProgressLessonTeacherInfo', () => {
     const wrapper = shallow(
       <ProgressLessonTeacherInfo
         lesson={lockableLesson}
-        section={MOCK_NON_GOOGLE_SECTION}
+        section={MOCK_SECTION}
         lessonUrl={'code.org'}
         scriptAllowsHiddenStages={false}
         hiddenStageState={Immutable.fromJS({
@@ -104,46 +90,40 @@ describe('ProgressLessonTeacherInfo', () => {
         scriptName="My Script"
         hasNoSections={true}
         toggleHiddenStage={() => {}}
-        showGoogleClassroomButton={false}
       />
     );
 
     assert.equal(wrapper.find('Connect(StageLock)').length, 0);
   });
 
-  it('renders our HiddenForSectionToggle when we have a section', () => {
-    const [withSection, withoutSection] = [
-      MOCK_NON_GOOGLE_SECTION,
-      undefined
-    ].map(section =>
-      shallow(
-        <ProgressLessonTeacherInfo
-          lesson={fakeLesson('Maze', 1)}
-          section={section}
-          lessonUrl={'code.org'}
-          scriptAllowsHiddenStages={true}
-          hiddenStageState={Immutable.fromJS({
-            stagesBySection: {11: {}}
-          })}
-          scriptName="My Script"
-          hasNoSections={false}
-          toggleHiddenStage={() => {}}
-          showGoogleClassroomButton={false}
-        />
-      )
+  it('renders SendLessonDialog when there is a lessonUrl', () => {
+    const lesson = fakeLesson('Maze', 1);
+
+    const wrapper = shallow(
+      <ProgressLessonTeacherInfo
+        lesson={lesson}
+        section={MOCK_SECTION}
+        lessonUrl={'code.org'}
+        scriptAllowsHiddenStages={false}
+        hiddenStageState={Immutable.fromJS({
+          stagesBySection: {11: {}}
+        })}
+        scriptName="My Script"
+        hasNoSections={true}
+        toggleHiddenStage={() => {}}
+      />
     );
 
-    assert.equal(withSection.find('HiddenForSectionToggle').length, 1);
-    assert.equal(withoutSection.find('HiddenForSectionToggle').length, 0);
+    assert.equal(wrapper.find('SendLesson').length, 1);
   });
 
-  it('only renders google share button when showGoogleClassroomButton is true', () => {
-    const [shouldShow, shouldNotShow] = [true, false].map(
-      showGoogleClassroomButton =>
+  it('renders our HiddenForSectionToggle when we have a section', () => {
+    const [withSection, withoutSection] = [MOCK_SECTION, undefined].map(
+      section =>
         shallow(
           <ProgressLessonTeacherInfo
             lesson={fakeLesson('Maze', 1)}
-            section={MOCK_GOOGLE_SECTION}
+            section={section}
             lessonUrl={'code.org'}
             scriptAllowsHiddenStages={true}
             hiddenStageState={Immutable.fromJS({
@@ -152,13 +132,11 @@ describe('ProgressLessonTeacherInfo', () => {
             scriptName="My Script"
             hasNoSections={false}
             toggleHiddenStage={() => {}}
-            showGoogleClassroomButton={showGoogleClassroomButton}
           />
         )
     );
 
-    const button = 'GoogleClassroomShareButton';
-    assert.equal(shouldShow.find(button).length, 1);
-    assert.equal(shouldNotShow.find(button).length, 0);
+    assert.equal(withSection.find('HiddenForSectionToggle').length, 1);
+    assert.equal(withoutSection.find('HiddenForSectionToggle').length, 0);
   });
 });

--- a/apps/test/unit/templates/progress/SendLessonDialogTest.js
+++ b/apps/test/unit/templates/progress/SendLessonDialogTest.js
@@ -11,10 +11,10 @@ describe('SendLessonDialog', () => {
       <SendLessonDialog lessonUrl={lessonUrl} showGoogleButton={false} />
     );
 
-    assert.equal(wrapper.find('#ui-test-copy-button').length, 1);
+    assert.equal(wrapper.find('#uitest-copy-button').length, 1);
     assert.equal(
       wrapper
-        .find('#ui-test-copy-button')
+        .find('#uitest-copy-button')
         .at(0)
         .props().icon,
       'link'

--- a/dashboard/test/ui/features/learning_platform/send_lesson.feature
+++ b/dashboard/test/ui/features/learning_platform/send_lesson.feature
@@ -1,0 +1,13 @@
+@as_teacher
+Feature: Send Lesson
+
+@eyes
+Scenario: Send Lesson Dialog
+  When I open my eyes to test "send lesson dialog"
+  Given I am on "http://studio.code.org/s/csp3-2018"
+  And I see no difference for "unit overview"
+  Then I open the send lesson dialog for lesson 4
+  And I wait until element "span:contains(Google)" is visible
+  And I see no difference for "send lesson dialog"
+  And I close my eyes
+  

--- a/dashboard/test/ui/features/learning_platform/send_lesson.feature
+++ b/dashboard/test/ui/features/learning_platform/send_lesson.feature
@@ -2,12 +2,30 @@
 Feature: Send Lesson
 
 @eyes
-Scenario: Send Lesson Dialog
-  When I open my eyes to test "send lesson dialog"
-  Given I am on "http://studio.code.org/s/csp3-2018"
-  And I see no difference for "unit overview"
-  Then I open the send lesson dialog for lesson 4
+Scenario: Send lesson dialog renders properly
+  Given I open my eyes to test "send lesson dialog"
+  When I am on "http://studio.code.org/s/csp3-2018"
+  And I dismiss the teacher panel
+  Then I see no difference for "unit overview"
+  When I open the send lesson dialog for lesson 4
   And I wait until element "span:contains(Google)" is visible
-  And I see no difference for "send lesson dialog"
-  And I close my eyes
-  
+  Then I see no difference for "send lesson dialog"
+  Then I close my eyes
+
+Scenario: Send lesson dialog opens and closes
+  Given I am on "http://studio.code.org/s/csp3-2018"
+  When I open the send lesson dialog for lesson 4
+  Then I wait until element ".modal" is visible
+  And I wait until element "span:contains(Google)" is visible
+  When I click selector "button:contains(Done)"
+  Then I wait until element ".modal" is not visible
+
+Scenario: Send lesson dialog copy link button works
+  Given I am on "http://studio.code.org/s/coursec-2017"
+  When I open the send lesson dialog for lesson 2
+  Then I wait until element ".modal" is visible
+  And I wait until element "#uitest-copy-button" is visible
+  When I click selector "#uitest-copy-button"
+  Then I wait until element "div:contains(Link copied!)" is visible
+  # Ideally, we would also verify that the link is on the clipboard here,
+  # but have not found a good way to do that.

--- a/dashboard/test/ui/features/step_definitions/steps.rb
+++ b/dashboard/test/ui/features/step_definitions/steps.rb
@@ -1654,6 +1654,13 @@ Then /^I open the stage lock dialog$/ do
   wait_short_until {jquery_is_element_visible('.modal-body')}
 end
 
+Then /^I open the send lesson dialog for lesson (\d+)$/ do |lesson_num|
+  wait_for_jquery
+  wait_short_until {@browser.execute_script("return $('.uitest-sendlesson').length") > lesson_num}
+  @browser.execute_script("$('.uitest-sendlesson').eq(#{lesson_num}-1).children().first().click()")
+  wait_short_until {jquery_is_element_visible('.modal')}
+end
+
 Then /^I unlock the stage for students$/ do
   # allow editing
   @browser.execute_script("$('.modal-body button').first().click()")


### PR DESCRIPTION
<!--
  Your description goes here: A summary of the change, including any relevant motivation and context.

  If relevant, include a description both of the existing behavior and of the new behavior.
-->
This should be the final commit for the send lesson dialog.  The only functional change is to move where the button appears in ProgressLessonTeacherInfo and to turn the feature on.  The other changes are all either test-related or to remove code that is no longer needed.

Changes:
- Remove send-lesson-dialog experiment and enable the feature for everyone
- Move send lesson dialog button above the hidden/visible toggle
- Clean up code that is no longer needed
- Add eyes test to verify that dialog renders properly
- Add UI tests to get basic coverage across more browsers

<!--
  Other aspects to consider. uncomment and add detail for any that seem necessary:
-->

<!-- ### Background -->
<!-- ### Privacy -->
<!--
1.	Does the Project involve the collection, use or sharing of new Personal Data?

2.	Does the Project involve a new or changed use or sharing of existing Personal Data?
-->
<!-- ### Security -->
<!--
Link to Jira Task where sensitive security issues are discussed privately.
-->
<!-- ### Caching -->
<!-- ### Deployment strategy -->
<!-- ### Future work -->

## Links

<!--
  Any relevant links to external resources; ie, specification documents, jira
  items, related PRs, honeybadger errors, etc
-->

- [spec](https://docs.google.com/document/d/1k9U-ulkQR2bNZ_BBzRi4PCyjwUAXyn4QzEzdUI4tWbE/edit)
- [jira epic](https://codedotorg.atlassian.net/browse/LP-1574)
- This commit turns on functionality implemented in the following PRs:
    - https://github.com/code-dot-org/code-dot-org/pull/37358
    - https://github.com/code-dot-org/code-dot-org/pull/37429
    - https://github.com/code-dot-org/code-dot-org/pull/37588
    - https://github.com/code-dot-org/code-dot-org/pull/37784

## Testing story

<!--
  Does your change include appropriate tests?

  If so, please describe how the tests included in this PR are sufficient

  If not, please explain why this change does not need to be tested.
-->

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
