### PR TITLE
Don't deduplicate the 'table_name' attribute on columns

### DIFF
--- a/dashboard/config/initializers/schema_cache_dedup.rb
+++ b/dashboard/config/initializers/schema_cache_dedup.rb
@@ -103,7 +103,6 @@ module SchemaCacheDedup
 
     def deduplicated
       @name = -name
-      @table_name = -table_name if table_name
       @sql_type_metadata = sql_type_metadata.deduplicate if sql_type_metadata
       @default = -default if default
       @default_function = -default_function if default_function


### PR DESCRIPTION
Since it got removed in https://github.com/rails/rails/pull/35890.

## Testing story

Haven't done any testing beyond just verifying that this change allows rails to initialize without error. This is primarily because I don't fully understanding what all this initializer is trying to do. Very open to feedback on the right testing strategy to employ here!

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
