### PR TITLE
Fix support for public Firebase datasets in Drone builds

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -34,6 +34,7 @@ steps:
   - name: mysql
     path: /var/lib/mysql
   environment:
+    # Each Drone secret below must be explicitly written to locals.yml in /docker/unit_tests.sh
     CLOUDFRONT_KEY_PAIR_ID:
       from_secret: CLOUDFRONT_KEY_PAIR_ID
     CLOUDFRONT_PRIVATE_KEY:
@@ -126,6 +127,7 @@ steps:
   - name: mysql
     path: /var/lib/mysql
   environment:
+    # Each Drone secret below must be explicitly written to locals.yml in /docker/ui_tests.sh
     CLOUDFRONT_KEY_PAIR_ID:
       from_secret: CLOUDFRONT_KEY_PAIR_ID
     CLOUDFRONT_PRIVATE_KEY:
@@ -185,6 +187,6 @@ trigger:
   - pull_request
 ---
 kind: signature
-hmac: 87512ba110e67854732dcf411a11d4e968c7c4a6b666095885a0bb0621f3fec5
+hmac: 1eb7f310b1ec6c67a0f6fa5b24ad6daab49a401ac9ed2bd908d3da4436003adc
 
 ...

--- a/docker/ui_tests.sh
+++ b/docker/ui_tests.sh
@@ -44,6 +44,7 @@ ignore_eyes_mismatches: true
 disable_all_eyes_running: true
 firebase_name: $FIREBASE_NAME
 firebase_secret: $FIREBASE_SECRET
+firebase_shared_secret: $FIREBASE_SHARED_SECRET
 use_my_apps: true
 build_dashboard: true
 build_pegasus: true


### PR DESCRIPTION
I didn't edit the shell script that passes the Drone secret environment variables to locals.yml when adding the support for public Firebase data sets to Drone in #37757

<!-- ### Background -->
<!-- ### Privacy -->
<!--
1.	Does the Project involve the collection, use or sharing of new Personal Data?

2.	Does the Project involve a new or changed use or sharing of existing Personal Data?
-->
<!-- ### Security -->
<!--
Link to Jira Task where sensitive security issues are discussed privately.
-->
<!-- ### Caching -->
<!-- ### Deployment strategy -->
<!-- ### Future work -->

## Links

<!--
  Any relevant links to external resources; ie, specification documents, jira
  items, related PRs, honeybadger errors, etc
-->

- [spec]()
- [jira]()

## Testing story

<!--
  Does your change include appropriate tests?

  If so, please describe how the tests included in this PR are sufficient

  If not, please explain why this change does not need to be tested.
-->

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
