### PR TITLE
[Spritelab] Fix rounding inconsistencies between locationPicker and TooltipOverlay

### DIFF
--- a/apps/src/p5lab/P5LabVisualizationColumn.jsx
+++ b/apps/src/p5lab/P5LabVisualizationColumn.jsx
@@ -69,7 +69,11 @@ class P5LabVisualizationColumn extends React.Component {
   pickerPointerMove = e => {
     if (this.props.pickingLocation) {
       this.props.updatePicker(
-        calculateOffsetCoordinates(this.divGameLab, e.clientX, e.clientY)
+        calculateOffsetCoordinates(
+          this.divGameLab,
+          Math.floor(e.clientX),
+          Math.floor(e.clientY)
+        )
       );
     }
   };

--- a/apps/src/templates/TooltipOverlay.jsx
+++ b/apps/src/templates/TooltipOverlay.jsx
@@ -163,6 +163,6 @@ export function textProvider(label) {
 export function coordinatesProvider(flip) {
   return props => {
     const y = flip ? props.height - props.mouseY : props.mouseY;
-    return `x: ${Math.floor(props.mouseX)}, y: ${Math.floor(y)}`;
+    return `x: ${Math.round(props.mouseX)}, y: ${Math.round(y)}`;
   };
 }

--- a/apps/test/unit/applab/AppLabTooltipOverlayTest.js
+++ b/apps/test/unit/applab/AppLabTooltipOverlayTest.js
@@ -58,7 +58,7 @@ describe('AppLabTooltipOverlay', () => {
       expect(result.props().providers.length).to.equal(1);
       expect(result.props().providers[0]).to.be.a('function');
       expect(result.props().providers[0](result.props())).to.equal(
-        `x: ${Math.floor(TEST_MOUSE_X)}, y: ${Math.floor(TEST_MOUSE_Y)}`
+        `x: ${Math.round(TEST_MOUSE_X)}, y: ${Math.round(TEST_MOUSE_Y)}`
       );
     });
   });

--- a/apps/test/unit/templates/TooltipOverlayTest.js
+++ b/apps/test/unit/templates/TooltipOverlayTest.js
@@ -159,12 +159,12 @@ describe('TooltipOverlay', () => {
       );
     });
 
-    it('floors the given coordinates', function() {
+    it('rounds the given coordinates', function() {
       const props = {
         mouseX: 1.3,
         mouseY: 2.9
       };
-      expect(coordinatesProvider()(props)).to.equal('x: 1, y: 2');
+      expect(coordinatesProvider()(props)).to.equal('x: 1, y: 3');
     });
   });
 


### PR DESCRIPTION
This is sort of a papercut bug that's been in Spritelab for a long time (my guess is, it's been this way since the location picker was first added).
The problem is basically that the TooltipOverlay and the LocationPicker both calculate a (x,y) location within [(0,0), (400,400)] but they do it using fully separate logic. 

I'm not 1000% sure about this math, but it definitely won't make it worse, and from playing around with it, it seems to solve the issue.

It's a little hard to see in the screenshots because of the gray tint over the background, but if you look closely, you can see that the coordinates in the tooltip do *not* match the value on the yellow location block.
Before:
![Nov-16-2020 17-26-09](https://user-images.githubusercontent.com/8787187/99328411-de6a9400-2830-11eb-9d41-d24816513f4e.gif)

After:
![Nov-16-2020 17-26-51](https://user-images.githubusercontent.com/8787187/99328444-f2ae9100-2830-11eb-9b2b-17864e5b48b9.gif)



<!--
  Other aspects to consider. uncomment and add detail for any that seem necessary:
-->

<!-- ### Background -->
<!-- ### Privacy -->
<!--
1.	Does the Project involve the collection, use or sharing of new Personal Data?

2.	Does the Project involve a new or changed use or sharing of existing Personal Data?
-->
<!-- ### Security -->
<!--
Link to Jira Task where sensitive security issues are discussed privately.
-->
<!-- ### Caching -->
<!-- ### Deployment strategy -->
<!-- ### Future work -->

## Links

<!--
  Any relevant links to external resources; ie, specification documents, jira
  items, related PRs, honeybadger errors, etc
-->

- [jira](https://codedotorg.atlassian.net/browse/STAR-1259)

## Testing story

<!--
  Does your change include appropriate tests?

  If so, please describe how the tests included in this PR are sufficient

  If not, please explain why this change does not need to be tested.
-->

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
