### PR TITLE
Foorm: Maintain ids across seeds

### DIFF
--- a/dashboard/app/models/foorm/form.rb
+++ b/dashboard/app/models/foorm/form.rb
@@ -31,7 +31,7 @@ class Foorm::Form < ActiveRecord::Base
   end
 
   def self.setup
-    forms = Dir.glob('config/foorm/forms/**/*.json').sort.map.with_index(1) do |path, id|
+    Dir.glob('config/foorm/forms/**/*.json').each do |path|
       # Given: "config/foorm/forms/surveys/pd/pre_workshop_survey.0.json"
       # we get full_name: "surveys/pd/pre_workshop_survey"
       #      and version: 0
@@ -46,18 +46,10 @@ class Foorm::Form < ActiveRecord::Base
       # if published is not provided, default to true
       published = questions['published'].nil? ? true : questions['published']
 
-      {
-        id: id,
-        name: full_name,
-        version: version,
-        questions: questions,
-        published: published
-      }
-    end
-
-    transaction do
-      Foorm::Form.delete_all
-      Foorm::Form.import! forms
+      form = Foorm::Form.find_or_initialize_by(name: full_name, version: version)
+      form.questions = questions
+      form.published = published
+      form.save! if form.changed?
     end
   end
 


### PR DESCRIPTION
Update seed step for `Foorm::Form` and `Foorm:LibraryQuestion` to keep the same ids across seeds. This will enable us to access forms by ids and know those ids won't change if a seed is run. This will make apis to create/update forms much simpler.

The change is instead of deleting and recreating forms on seed, we find the form by name and version if it exists, and create otherwise. The only downside to this approach is forms will not be deleted automatically if the configuration is deleted. We can add a delete api in the future if we think it is necessary, but so far deleting forms is not a concern.

## Testing story
Tested seeding locally with the same data in the database as the configuration, with one new form/library configuration, and with empty databases. All worked as expected.

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
