### PR TITLE
first pass at importing lesson resources from CB

### DIFF
--- a/dashboard/app/models/lesson.rb
+++ b/dashboard/app/models/lesson.rb
@@ -484,6 +484,10 @@ class Lesson < ActiveRecord::Base
     # In the future, only levelbuilder should be added to this list.
     raise unless [:development, :adhoc].include? rack_env
 
+    # course version id should always be present for CSF/CSD/CSP 2020 courses.
+    course_version_id = script&.get_course_version&.id
+    raise unless course_version_id
+
     if cb_lesson_data.empty?
       self.lesson_activities = Services::LessonImportHelper.update_lockable_lesson(script_levels, id)
       self.script_levels = []
@@ -494,9 +498,6 @@ class Lesson < ActiveRecord::Base
       self.creative_commons_license = cb_lesson_data['creative_commons_license']
       self.relative_position = cb_lesson_data['number'] || 1
       self.lesson_activities = Services::LessonImportHelper.create_lesson_activities(cb_lesson_data['activities'], script_levels, id)
-      course_version_id = script&.get_course_version&.id
-      # course version id should always be present for CSF/CSD/CSP 2020 courses.
-      raise unless course_version_id
       self.resources = Services::LessonImportHelper.create_lesson_resources(cb_lesson_data['resources'], course_version_id)
       self.script_levels = []
     end

--- a/dashboard/app/models/lesson.rb
+++ b/dashboard/app/models/lesson.rb
@@ -495,9 +495,9 @@ class Lesson < ActiveRecord::Base
       self.relative_position = cb_lesson_data['number'] || 1
       self.lesson_activities = Services::LessonImportHelper.create_lesson_activities(cb_lesson_data['activities'], script_levels, id)
       course_version_id = script&.get_course_version&.id
-      if course_version_id
-        self.resources = Services::LessonImportHelper.create_lesson_resources(cb_lesson_data['resources'], course_version_id)
-      end
+      # course version id should always be present for CSF/CSD/CSP 2020 courses.
+      raise unless course_version_id
+      self.resources = Services::LessonImportHelper.create_lesson_resources(cb_lesson_data['resources'], course_version_id)
       self.script_levels = []
     end
     save!

--- a/dashboard/app/models/lesson.rb
+++ b/dashboard/app/models/lesson.rb
@@ -494,6 +494,10 @@ class Lesson < ActiveRecord::Base
       self.creative_commons_license = cb_lesson_data['creative_commons_license']
       self.relative_position = cb_lesson_data['number'] || 1
       self.lesson_activities = Services::LessonImportHelper.create_lesson_activities(cb_lesson_data['activities'], script_levels, id)
+      course_version_id = script&.get_course_version&.id
+      if course_version_id
+        self.resources = Services::LessonImportHelper.create_lesson_resources(cb_lesson_data['resources'], course_version_id)
+      end
       self.script_levels = []
     end
     save!

--- a/dashboard/lib/services/lesson_import_helper.rb
+++ b/dashboard/lib/services/lesson_import_helper.rb
@@ -6,6 +6,25 @@ module Services::LessonImportHelper
     [create_activity_with_levels(script_levels, lesson_id, 1)]
   end
 
+  def self.create_lesson_resources(cb_resources, course_version_id)
+    cb_resources.map do |cb_resource|
+      raise unless cb_resource['slug']
+      resource = Resource.find_or_initialize_by(
+        course_version_id: course_version_id,
+        key: cb_resource['slug']
+      )
+      resource.name = cb_resource['name']
+      resource.url = cb_resource['url']
+      resource.type = cb_resource['type']
+      resource.audience = cb_resource['student'] ? 'Student' : 'Teacher'
+      resource.assessment = false
+      resource.download_url = cb_resource['dl_url']
+      resource.include_in_pdf = cb_resource['gd']
+      resource.save! if resource.changed?
+      resource
+    end
+  end
+
   def self.create_activity_sections(activity_markdown)
     # Find any special syntax, such as tips or remarks, and gather them.
     # TODO tips and remarks both show up in tip_matches. We filter out remarks


### PR DESCRIPTION
## Description

Continues work on [PLAT-517]. Depends on https://github.com/code-dot-org/curriculumbuilder/pull/326. Imports resources for each lesson when importing unit details from curriculum builder. There may be some future work depending on answers to inline questions.

## Screenshots

on CB: http://localhost:8000/csd-20/unit3/1/
![Screen Shot 2020-11-17 at 5 58 43 PM](https://user-images.githubusercontent.com/8001765/99473017-9b76f200-28fe-11eb-9d6b-93c5cecc3a81.png)

exported CB JSON:
![Screen Shot 2020-11-17 at 6 02 18 PM](https://user-images.githubusercontent.com/8001765/99473267-193afd80-28ff-11eb-86bd-2db10ace0de1.png)

lesson edit page:
![Screen Shot 2020-11-17 at 6 01 17 PM](https://user-images.githubusercontent.com/8001765/99473190-ee50a980-28fe-11eb-906b-b1b4703047b9.png)

lesson plan:
![Screen Shot 2020-11-17 at 6 03 19 PM](https://user-images.githubusercontent.com/8001765/99473326-37086280-28ff-11eb-9767-432b5ad9998b.png)

lesson plan with download link:
![Screen Shot 2020-11-17 at 6 04 22 PM](https://user-images.githubusercontent.com/8001765/99473401-5c956c00-28ff-11eb-969f-6b9d545b391a.png)

## Testing story

* Manually verified that import shows the expected resources for csd3-2020, as shown in screenshots.
* Verified there were no errors importing resources for all CSF/CSD/CSP 2020 units, and spot-checked a few other lessons

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked


[PLAT-517]: https://codedotorg.atlassian.net/browse/PLAT-517