### PR TITLE
Create SaveBar component for re-use

### DIFF
--- a/apps/src/lib/levelbuilder/SaveBar.jsx
+++ b/apps/src/lib/levelbuilder/SaveBar.jsx
@@ -1,0 +1,86 @@
+import PropTypes from 'prop-types';
+import React, {Component} from 'react';
+import color from '@cdo/apps/util/color';
+import FontAwesome from '@cdo/apps/templates/FontAwesome';
+
+const styles = {
+  saveButtonBackground: {
+    margin: 0,
+    position: 'fixed',
+    bottom: 0,
+    left: 0,
+    backgroundColor: color.lightest_gray,
+    borderColor: color.lightest_gray,
+    height: 50,
+    width: '100%',
+    zIndex: 900,
+    display: 'flex',
+    justifyContent: 'flex-end'
+  },
+  saveButton: {
+    margin: '10px 50px 10px 20px'
+  },
+  spinner: {
+    fontSize: 25,
+    padding: 10
+  },
+  lastSaved: {
+    fontSize: 14,
+    color: color.level_perfect,
+    padding: 15
+  },
+  error: {
+    fontSize: 14,
+    color: color.red,
+    padding: 15
+  }
+};
+
+export default class SaveBar extends Component {
+  static propTypes = {
+    lastSaved: PropTypes.string,
+    error: PropTypes.string,
+    handleSave: PropTypes.func.isRequired,
+    isSaving: PropTypes.bool
+  };
+
+  render() {
+    return (
+      <div style={styles.saveButtonBackground} className="saveBar">
+        {this.props.lastSaved && !this.props.error && (
+          <div style={styles.lastSaved} className="lastSavedMessage">
+            {`Last saved at: ${new Date(
+              this.props.lastSaved
+            ).toLocaleString()}`}
+          </div>
+        )}
+        {this.props.error && (
+          <div style={styles.error}>{`Error Saving: ${this.props.error}`}</div>
+        )}
+        {this.props.isSaving && (
+          <div style={styles.spinner}>
+            <FontAwesome icon="spinner" className="fa-spin" />
+          </div>
+        )}
+        <button
+          className="btn"
+          type="button"
+          style={styles.saveButton}
+          onClick={e => this.props.handleSave(e, false)}
+          disabled={this.props.isSaving}
+        >
+          Save and Keep Editing
+        </button>
+        <button
+          className="btn btn-primary"
+          type="submit"
+          style={styles.saveButton}
+          onClick={e => this.props.handleSave(e, true)}
+          disabled={this.props.isSaving}
+        >
+          Save and Close
+        </button>
+      </div>
+    );
+  }
+}

--- a/apps/src/lib/levelbuilder/lesson-editor/LessonEditor.jsx
+++ b/apps/src/lib/levelbuilder/lesson-editor/LessonEditor.jsx
@@ -14,12 +14,11 @@ import {
   activityShape,
   resourceShape
 } from '@cdo/apps/lib/levelbuilder/shapes';
-import color from '@cdo/apps/util/color';
 import $ from 'jquery';
 import {connect} from 'react-redux';
 import {getSerializedActivities} from '@cdo/apps/lib/levelbuilder/lesson-editor/activitiesEditorRedux';
-import FontAwesome from '@cdo/apps/templates/FontAwesome';
 import {navigateToHref} from '@cdo/apps/utils';
+import SaveBar from '@cdo/apps/lib/levelbuilder/SaveBar';
 
 const styles = {
   editor: {
@@ -40,36 +39,6 @@ const styles = {
   dropdown: {
     margin: '0 6px',
     width: 300
-  },
-  saveButtonBackground: {
-    margin: 0,
-    position: 'fixed',
-    bottom: 0,
-    left: 0,
-    backgroundColor: color.lightest_gray,
-    borderColor: color.lightest_gray,
-    height: 50,
-    width: '100%',
-    zIndex: 900,
-    display: 'flex',
-    justifyContent: 'flex-end'
-  },
-  saveButton: {
-    margin: '10px 50px 10px 20px'
-  },
-  spinner: {
-    fontSize: 25,
-    padding: 10
-  },
-  lastSaved: {
-    fontSize: 14,
-    color: color.level_perfect,
-    padding: 15
-  },
-  error: {
-    fontSize: 14,
-    color: color.red,
-    padding: 15
   }
 };
 
@@ -335,43 +304,12 @@ class LessonEditor extends Component {
           <ActivitiesEditor />
         </CollapsibleEditorSection>
 
-        <div style={styles.saveButtonBackground} className="saveBar">
-          {this.state.lastSaved && !this.state.error && (
-            <div style={styles.lastSaved} className="lastSavedMessage">
-              {`Last saved at: ${new Date(
-                this.state.lastSaved
-              ).toLocaleString()}`}
-            </div>
-          )}
-          {this.state.error && (
-            <div style={styles.error}>
-              {`Error Saving: ${this.state.error}`}
-            </div>
-          )}
-          {this.state.isSaving && (
-            <div style={styles.spinner}>
-              <FontAwesome icon="spinner" className="fa-spin" />
-            </div>
-          )}
-          <button
-            className="btn"
-            type="button"
-            style={styles.saveButton}
-            onClick={e => this.handleSave(e, false)}
-            disabled={this.state.isSaving}
-          >
-            Save and Keep Editing
-          </button>
-          <button
-            className="btn btn-primary"
-            type="submit"
-            style={styles.saveButton}
-            onClick={e => this.handleSave(e, true)}
-            disabled={this.state.isSaving}
-          >
-            Save and Close
-          </button>
-        </div>
+        <SaveBar
+          handleSave={this.handleSave}
+          error={this.state.error}
+          isSaving={this.state.isSaving}
+          lastSaved={this.state.lastSaved}
+        />
       </div>
     );
   }

--- a/apps/test/unit/lib/levelbuilder/SaveBarTest.jsx
+++ b/apps/test/unit/lib/levelbuilder/SaveBarTest.jsx
@@ -1,0 +1,72 @@
+import React from 'react';
+import {mount} from 'enzyme';
+import {expect} from '../../../util/reconfiguredChai';
+import sinon from 'sinon';
+import SaveBar from '@cdo/apps/lib/levelbuilder/SaveBar';
+
+describe('SaveBar', () => {
+  let defaultProps, handleSave;
+  beforeEach(() => {
+    handleSave = sinon.spy();
+    defaultProps = {
+      isSaving: false,
+      error: null,
+      lastSaved: null,
+      handleSave
+    };
+  });
+
+  it('renders default props', () => {
+    const wrapper = mount(<SaveBar {...defaultProps} />);
+    expect(wrapper.find('button').length).to.equal(2);
+    expect(wrapper.find('FontAwesome').length).to.equal(0); //spinner isn't showing
+  });
+
+  it('can save and keep editing', () => {
+    const wrapper = mount(<SaveBar {...defaultProps} />);
+
+    const saveAndKeepEditingButton = wrapper.find('button').at(0);
+    expect(saveAndKeepEditingButton.contains('Save and Keep Editing')).to.be
+      .true;
+    saveAndKeepEditingButton.simulate('click');
+
+    expect(handleSave).to.have.been.calledOnce;
+  });
+
+  it('shows spinner when isSaving is true', () => {
+    const wrapper = mount(<SaveBar {...defaultProps} isSaving={true} />);
+
+    // check the the spinner is showing
+    expect(wrapper.find('FontAwesome').length).to.equal(1);
+  });
+
+  it('shows lastSaved when there is no error', () => {
+    const wrapper = mount(
+      <SaveBar {...defaultProps} lastSaved={'2020-11-06T21:33:32.000Z'} />
+    );
+
+    expect(wrapper.find('.lastSavedMessage').text()).to.include(
+      'Last saved at:'
+    );
+  });
+
+  it('shows error when props error is set', () => {
+    const wrapper = mount(
+      <SaveBar {...defaultProps} error={'There was an error'} />
+    );
+    expect(wrapper.find('.saveBar').find('FontAwesome').length).to.equal(0);
+    expect(
+      wrapper.find('.saveBar').contains('Error Saving: There was an error')
+    ).to.be.true;
+  });
+
+  it('can save and close', () => {
+    const wrapper = mount(<SaveBar {...defaultProps} />);
+
+    const saveAndCloseButton = wrapper.find('button').at(1);
+    expect(saveAndCloseButton.contains('Save and Close')).to.be.true;
+    saveAndCloseButton.simulate('click');
+
+    expect(handleSave).to.have.been.calledOnce;
+  });
+});

--- a/apps/test/unit/lib/levelbuilder/lesson-editor/LessonEditorTest.js
+++ b/apps/test/unit/lib/levelbuilder/lesson-editor/LessonEditorTest.js
@@ -127,7 +127,7 @@ describe('LessonEditor', () => {
       JSON.stringify(returnData)
     ]);
 
-    const saveBar = wrapper.find('.saveBar');
+    const saveBar = wrapper.find('SaveBar');
 
     const saveAndKeepEditingButton = saveBar.find('button').at(0);
     expect(saveAndKeepEditingButton.contains('Save and Keep Editing')).to.be
@@ -160,7 +160,7 @@ describe('LessonEditor', () => {
       returnData
     ]);
 
-    const saveBar = wrapper.find('.saveBar');
+    const saveBar = wrapper.find('SaveBar');
 
     const saveAndKeepEditingButton = saveBar.find('button').at(0);
     expect(saveAndKeepEditingButton.contains('Save and Keep Editing')).to.be
@@ -196,7 +196,7 @@ describe('LessonEditor', () => {
       JSON.stringify(returnData)
     ]);
 
-    const saveBar = wrapper.find('.saveBar');
+    const saveBar = wrapper.find('SaveBar');
 
     const saveAndCloseButton = saveBar.find('button').at(1);
     expect(saveAndCloseButton.contains('Save and Close')).to.be.true;
@@ -227,7 +227,7 @@ describe('LessonEditor', () => {
       returnData
     ]);
 
-    const saveBar = wrapper.find('.saveBar');
+    const saveBar = wrapper.find('SaveBar');
 
     const saveAndCloseButton = saveBar.find('button').at(1);
     expect(saveAndCloseButton.contains('Save and Close')).to.be.true;

--- a/apps/test/unit/lib/levelbuilder/lesson-editor/LessonEditorTest.js
+++ b/apps/test/unit/lib/levelbuilder/lesson-editor/LessonEditorTest.js
@@ -84,6 +84,7 @@ describe('LessonEditor', () => {
     expect(wrapper.find('AnnouncementsEditor').length).to.equal(1);
     expect(wrapper.find('CollapsibleEditorSection').length).to.equal(7);
     expect(wrapper.find('ResourcesEditor').length).to.equal(1);
+    expect(wrapper.find('SaveBar').length).to.equal(1);
   });
 
   it('can add activity', () => {


### PR DESCRIPTION
Since the same Save Bar is used on both the Script and Lesson edit page (and the future probably the Course Edit page) this extracts it into its own component.

Added tests for the new SaveBar component and updated the Lesson Editor Component.

<img width="1365" alt="Screen Shot 2020-11-17 at 11 41 25 PM" src="https://user-images.githubusercontent.com/208083/99484440-6bdfde00-292e-11eb-9381-2b3a417d425b.png">
