### PR TITLE
[Applab Datasets] Trim first/last instead of stripQuotes for getColumn dropdown

### DIFF
--- a/apps/src/storage/getColumnDropdown.js
+++ b/apps/src/storage/getColumnDropdown.js
@@ -38,7 +38,10 @@ export function getTables() {
 }
 
 function getTableNameFromColumnSocket(socket, editor) {
-  const paramValue = getFirstParam('getColumn', socket.parent);
+  const paramValue = getFirstParam('getColumn', socket.parent, editor);
+  // The socket value has an extra set of double quotes. Trim off the first
+  // and last characters to remove, but don't use utils.stripQuotes because
+  // there may be other quotes in the table name (for example, apostrophes)
   return paramValue.substring(1, paramValue.length - 1);
 }
 

--- a/apps/src/storage/getColumnDropdown.js
+++ b/apps/src/storage/getColumnDropdown.js
@@ -37,10 +37,14 @@ export function getTables() {
   };
 }
 
+function getTableNameFromColumnSocket(socket, editor) {
+  const paramValue = getFirstParam('getColumn', socket.parent);
+  return paramValue.substring(1, paramValue.length - 1);
+}
+
 export function getColumns() {
   return function(editor) {
-    const firstParam = getFirstParam('getColumn', this.parent, editor);
-    const tableName = firstParam.substring(1, firstParam.length - 1);
+    const tableName = getTableNameFromColumnSocket(this, editor);
     return [
       {
         text: msg.choosePrefix(),
@@ -53,3 +57,7 @@ export function getColumns() {
     ];
   };
 }
+
+export var __TestInterface = {
+  getTableNameFromColumnSocket: getTableNameFromColumnSocket
+};

--- a/apps/src/storage/getColumnDropdown.js
+++ b/apps/src/storage/getColumnDropdown.js
@@ -2,7 +2,6 @@ import React from 'react';
 import ReactDOM from 'react-dom';
 import msg from '@cdo/locale';
 import {getFirstParam} from '../dropletUtils';
-import {stripQuotes} from '../utils';
 import GetColumnParamPicker, {ParamType} from './GetColumnParamPicker';
 
 function openModal(type, callback, table) {
@@ -40,9 +39,8 @@ export function getTables() {
 
 export function getColumns() {
   return function(editor) {
-    const tableName = stripQuotes(
-      getFirstParam('getColumn', this.parent, editor)
-    );
+    const firstParam = getFirstParam('getColumn', this.parent, editor);
+    const tableName = firstParam.substring(1, firstParam.length - 1);
     return [
       {
         text: msg.choosePrefix(),

--- a/apps/test/unit/storage/getColumnsDropdownTest.js
+++ b/apps/test/unit/storage/getColumnsDropdownTest.js
@@ -1,0 +1,29 @@
+import {expect} from '../../util/reconfiguredChai';
+import {__TestInterface} from '@cdo/apps/storage/getColumnDropdown';
+
+describe('getTableNameFromColumnSocket', () => {
+  const makeFakeSocket = function(tableName) {
+    return {
+      parent: {
+        start: {
+          type: 'socketStart',
+          next: {
+            type: 'text',
+            value: `"${tableName}"`
+          }
+        }
+      }
+    };
+  };
+  it('gets the table name from the socket', () => {
+    let socket = makeFakeSocket('Table Name');
+    let tableName = __TestInterface.getTableNameFromColumnSocket(socket);
+    expect(tableName).to.equal('Table Name');
+  });
+
+  it('preserves apostrophes in table name', () => {
+    let socket = makeFakeSocket("FIFA Women's World Cup Results");
+    let tableName = __TestInterface.getTableNameFromColumnSocket(socket);
+    expect(tableName).to.equal("FIFA Women's World Cup Results");
+  });
+});

--- a/apps/test/unit/storage/getColumnsDropdownTest.js
+++ b/apps/test/unit/storage/getColumnsDropdownTest.js
@@ -9,6 +9,7 @@ describe('getTableNameFromColumnSocket', () => {
           type: 'socketStart',
           next: {
             type: 'text',
+            // The value in the socket has an extra set of double quotes
             value: `"${tableName}"`
           }
         }


### PR DESCRIPTION
Before:
![image](https://user-images.githubusercontent.com/8787187/99572850-23560e00-298a-11eb-81f8-3196f9f06164.png)

After:
![image](https://user-images.githubusercontent.com/8787187/99572891-31a42a00-298a-11eb-8dbe-f917f21edd31.png)

The issue was that I was using `utils.stripQuotes()` which also stripped out the apostrophe in the table name, so we couldn't find the column names because the table "FIFA Womens World Cup Results" (no apostrophe) doesn't exist.

Instead, we can just trim the first and last characters to remove the extra double quotes

<!-- ### Background -->
<!-- ### Privacy -->
<!--
1.	Does the Project involve the collection, use or sharing of new Personal Data?

2.	Does the Project involve a new or changed use or sharing of existing Personal Data?
-->
<!-- ### Security -->
<!--
Link to Jira Task where sensitive security issues are discussed privately.
-->
<!-- ### Caching -->
<!-- ### Deployment strategy -->
<!-- ### Future work -->

## Links

<!--
  Any relevant links to external resources; ie, specification documents, jira
  items, related PRs, honeybadger errors, etc
-->

- [zendesk ticket](https://codeorg.zendesk.com/agent/tickets/303662)

## Testing story

<!--
  Does your change include appropriate tests?

  If so, please describe how the tests included in this PR are sufficient

  If not, please explain why this change does not need to be tested.
-->

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
