### PR TITLE
link to lesson plans from gray box on script overview page

### DIFF
--- a/dashboard/app/views/scripts/show.html.haml
+++ b/dashboard/app/views/scripts/show.html.haml
@@ -76,6 +76,11 @@
         %ul
           - @script.unit_groups.each do |course|
             %li= link_to course_path(course)
+      -# use a heuristic to infer whether lesson plans are present for all lessons
+      - if @script.lessons.first&.lesson_activities.present?
+        Lessons:
+        - @script.lessons.map do |lesson|
+          %li= link_to lesson.localized_title, lesson_path(id: lesson.id)
       - levels = Script.get_from_cache(@script.name).lessons.map{ |stage| stage.script_levels.map{ |sl| sl.level }}.flatten
       .row
         .span1


### PR DESCRIPTION
Quick fix to make the bug bash go smoother on Friday. 

![Screen Shot 2020-11-18 at 2 02 03 PM](https://user-images.githubusercontent.com/8001765/99593561-b309b580-29a6-11eb-8c1a-6cfd50cc254d.png)

![lesson-plan-links](https://user-images.githubusercontent.com/8001765/99593406-7a69dc00-29a6-11eb-93b6-bd5711e5904c.gif)

## Testing story

After importing activties from CB, I tried out a few lesson links on a few CSF/CSD/CSP 2020 script overview pages to make sure they work, including some lockable lessons in CSP. I also verified these links to not show up for pages like /s/dance which have not had lesson plans imported from CB.

