### PR TITLE
Import cb tweaks

### DIFF
--- a/bin/oneoff/import_unit_details.rb
+++ b/bin/oneoff/import_unit_details.rb
@@ -76,7 +76,7 @@ def parse_options
 end
 
 def main(options)
-  cb_url_prefix = options.local ? 'http://localhost:8000' : 'https://curriculum.code.org'
+  cb_url_prefix = options.local ? 'http://localhost:8000' : 'http://www.codecurricula.com'
 
   options.unit_names.each do |unit_name|
     script = Script.find_by_name!(unit_name)

--- a/dashboard/app/models/lesson.rb
+++ b/dashboard/app/models/lesson.rb
@@ -310,7 +310,7 @@ class Lesson < ActiveRecord::Base
       position: relative_position,
       lockable: lockable,
       key: key,
-      displayName: localized_title,
+      displayName: localized_name,
       overview: overview || '',
       announcements: announcements,
       purpose: purpose || '',


### PR DESCRIPTION
These are the tweaks that were necessary to get lesson plans to show up correctly on the adhocs.

1. I never got exporting to https://curriculum.code.org working, so we need to be able to hit codecurricula.com instead. While the imports were running today, I did some editing on CB, including viewing slow pages like https://www.codecurricula.com/admin/pages/page/, and didn't see any degraded performance.

2. 04a9c8f prevents double-prefixed lesson numbers like this one on the new lesson plan page:
![Screen Shot 2020-11-18 at 2 49 59 PM](https://user-images.githubusercontent.com/8001765/99607338-76e34e80-29c0-11eb-9d10-2d06823b17ea.png)

The problem is not with the data -- it's that we were adding the `Lesson N:` prefix in two places:
1. https://github.com/code-dot-org/code-dot-org/blob/a166ee811c460369e0e3ab567af621371b8a71c5/dashboard/app/models/lesson.rb#L165-L171
2. https://github.com/code-dot-org/code-dot-org/blob/aed9f148f6071c00dc90a8b86300bd436c4f813c/apps/src/templates/lessonOverview/LessonOverview.jsx#L118-L125
