### PR TITLE
Improvements to slides and activity section names

### DIFF
--- a/dashboard/lib/services/lesson_import_helper.rb
+++ b/dashboard/lib/services/lesson_import_helper.rb
@@ -63,7 +63,7 @@ module Services::LessonImportHelper
       elsif match[:type] == 'tiplink'
         activity_section = create_activity_section_with_tip(match[:match], tip_match_map)
       elsif match[:type] == 'remark'
-        activity_section = create_activity_section_with_remark(match[:match])
+        activity_section = create_activity_section_with_remark(match[:match], tip_match_map)
       else
         activity_section = create_basic_activity_section(match[:substring].strip)
       end
@@ -190,17 +190,16 @@ module Services::LessonImportHelper
     markdown.to_enum(:scan, regex).map {Regexp.last_match}
   end
 
-  def self.create_activity_section_with_remark(match)
-    activity_section = ActivitySection.new
-    activity_section.remarks = true
-    description = match[1].strip
-    slide_matches = find_slides(description)
-    if slide_matches.empty? || description.index(slide_matches[0][0]) != 0
+  def self.create_activity_section_with_remark(match, tip_match_map)
+    tip_link_matches = find_tip_links(match[1].strip)
+    if tip_link_matches.empty?
+      description = match[1].strip
+      activity_section = ActivitySection.new
       activity_section.description = unindent_markdown(description).strip
     else
-      activity_section.description = unindent_markdown(description.delete_prefix(slide_matches[0][0])).strip
-      activity_section.slide = true
+      activity_section = create_activity_section_with_tip(tip_link_matches[0], tip_match_map)
     end
+    activity_section.remarks = true
     activity_section
   end
 


### PR DESCRIPTION
- Look for markdown headings on their own and make them the name of the next activity section. While still imperfect, this produces more activity sections with names
- Major improvements to the way the slide icon is handled. The slide and tip icons are strange because in curriculum builder, they functioned as a placeholder for an icon, whereas in levelbuilder they're more of a property of a section of text. Meaning, there will never be a one-to-one mapping here.

CSP lessons saw the most improvement because they make good use of the slide icon which was apparently quite broken.
![Screenshot 2020-11-19 at 8 33 31 AM](https://user-images.githubusercontent.com/46464143/99696779-ee0df680-2a43-11eb-8f17-dcf49c54520a.png)


<!-- ### Background -->
<!-- ### Privacy -->
<!--
1.	Does the Project involve the collection, use or sharing of new Personal Data?

2.	Does the Project involve a new or changed use or sharing of existing Personal Data?
-->
<!-- ### Security -->
<!--
Link to Jira Task where sensitive security issues are discussed privately.
-->
<!-- ### Caching -->
<!-- ### Deployment strategy -->
<!-- ### Future work -->

## Links

<!--
  Any relevant links to external resources; ie, specification documents, jira
  items, related PRs, honeybadger errors, etc
-->

- [spec]()
- [jira]()

## Testing story

<!--
  Does your change include appropriate tests?

  If so, please describe how the tests included in this PR are sufficient

  If not, please explain why this change does not need to be tested.
-->

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
