### PR TITLE
allow rake seed:single_script to accept a file pattern glob

### DIFF
--- a/dashboard/lib/tasks/seed.rake
+++ b/dashboard/lib/tasks/seed.rake
@@ -188,13 +188,16 @@ namespace :seed do
     :libraries,
   ].freeze
 
-  # Do the minimum amount of work to seed a single script, without seeding
-  # levels or other dependencies. For use in development. Example:
+  # Do the minimum amount of work to seed a single script or glob, without
+  # seeding levels or other dependencies. For use in development. Examples:
   # rake seed:single_script SCRIPT_NAME=express-2019
+  # rake seed:single_script SCRIPT_NAME="csp*-2020"
   timed_task single_script: :environment do
     script_name = ENV['SCRIPT_NAME']
     raise "must specify SCRIPT_NAME=" unless script_name
-    script_files = ["config/scripts/#{script_name}.script"]
+    script_files = Dir.glob("config/scripts/#{script_name}.script")
+    raise "no matching scripts found" unless script_files.present?
+    puts "seeding only scripts:\n#{script_files.join("\n")}"
     update_scripts(script_files: script_files)
   end
 


### PR DESCRIPTION
The name of this task becomes a little inaccurate, but this seems better than either creating a new task or renaming an existing one which developers might have "bookmarked". This will make it a little easier to reseed only certain scripts on the adhoc for testing CB import.

This task is not used by CI, only by developers.

## Testing story

no scripts:
![Screen Shot 2020-11-19 at 9 35 38 AM](https://user-images.githubusercontent.com/8001765/99703470-fe29d400-2a4b-11eb-9c93-f42926373a74.png)

one script:
![Screen Shot 2020-11-19 at 9 43 19 AM](https://user-images.githubusercontent.com/8001765/99703497-0550e200-2a4c-11eb-8219-d0f37076e900.png)

many scripts:
![Screen Shot 2020-11-19 at 9 42 58 AM](https://user-images.githubusercontent.com/8001765/99703512-08e46900-2a4c-11eb-98d9-fcb576073372.png)
