### PR TITLE
Make ScriptEditor a connected component in prep for saving

### DIFF
--- a/apps/src/lib/levelbuilder/script-editor/ScriptEditor.jsx
+++ b/apps/src/lib/levelbuilder/script-editor/ScriptEditor.jsx
@@ -14,6 +14,9 @@ import CollapsibleEditorSection from '@cdo/apps/lib/levelbuilder/CollapsibleEdit
 import ResourceType, {
   resourceShape
 } from '@cdo/apps/templates/courseOverview/resourceType';
+import {connect} from 'react-redux';
+import {init} from '@cdo/apps/lib/levelbuilder/script-editor/scriptEditorRedux';
+import {lessonGroupShape} from '@cdo/apps/lib/levelbuilder/shapes';
 
 const styles = {
   input: {
@@ -62,7 +65,7 @@ const CURRICULUM_UMBRELLAS = ['CSF', 'CSD', 'CSP', ''];
 /**
  * Component for editing course scripts.
  */
-export default class ScriptEditor extends React.Component {
+class ScriptEditor extends React.Component {
   static propTypes = {
     beta: PropTypes.bool,
     betaWarning: PropTypes.string,
@@ -99,7 +102,12 @@ export default class ScriptEditor extends React.Component {
     isLevelbuilder: PropTypes.bool,
     initialTts: PropTypes.bool,
     hasCourse: PropTypes.bool,
-    initialIsCourse: PropTypes.bool
+    initialIsCourse: PropTypes.bool,
+
+    // from redux
+    lessonGroups: PropTypes.arrayOf(lessonGroupShape).isRequired,
+    levelKeyList: PropTypes.object.isRequired,
+    init: PropTypes.func.isRequired
   };
 
   constructor(props) {
@@ -769,3 +777,15 @@ export default class ScriptEditor extends React.Component {
     );
   }
 }
+
+export const UnconnectedScriptEditor = ScriptEditor;
+
+export default connect(
+  state => ({
+    lessonGroups: state.lessonGroups,
+    levelKeyList: state.levelKeyList
+  }),
+  {
+    init
+  }
+)(ScriptEditor);

--- a/apps/test/unit/lib/levelbuilder/script-editor/ScriptEditorTest.jsx
+++ b/apps/test/unit/lib/levelbuilder/script-editor/ScriptEditorTest.jsx
@@ -1,76 +1,125 @@
 import React from 'react';
-import {mount, shallow} from 'enzyme';
+import {mount} from 'enzyme';
 import ScriptEditor from '@cdo/apps/lib/levelbuilder/script-editor/ScriptEditor';
 import {assert, expect} from '../../../../util/reconfiguredChai';
 import ResourceType from '@cdo/apps/templates/courseOverview/resourceType';
+import {Provider} from 'react-redux';
+import isRtl from '@cdo/apps/code-studio/isRtlRedux';
+import reducers, {
+  init
+} from '@cdo/apps/lib/levelbuilder/script-editor/scriptEditorRedux';
+import {
+  stubRedux,
+  restoreRedux,
+  getStore,
+  registerReducers
+} from '@cdo/apps/redux';
+import sinon from 'sinon';
+import * as utils from '@cdo/apps/utils';
 
 describe('ScriptEditor', () => {
-  const DEFAULT_PROPS = {
-    initialAnnouncements: [],
-    curriculumUmbrella: 'CSF',
-    i18nData: {
-      stageDescriptions: [],
-      description:
-        '# Title \n This is the unit description with [link](https://studio.code.org/home) **Bold** *italics*'
-    },
-    isLevelbuilder: true,
-    locales: [],
-    name: 'test-script',
-    scriptFamilies: [],
-    teacherResources: [],
-    versionYearOptions: [],
-    initialFamilyName: '',
-    initialTeacherResources: [],
-    initialProjectSharing: false,
-    initialLocales: []
+  let defaultProps, store;
+  beforeEach(() => {
+    sinon.stub(utils, 'navigateToHref');
+    stubRedux();
+
+    registerReducers({...reducers, isRtl});
+    store = getStore();
+    store.dispatch(init([], {}));
+
+    defaultProps = {
+      id: 1,
+      initialAnnouncements: [],
+      curriculumUmbrella: 'CSF',
+      i18nData: {
+        stageDescriptions: [],
+        description:
+          '# Title \n This is the unit description with [link](https://studio.code.org/home) **Bold** *italics*'
+      },
+      isLevelbuilder: true,
+      locales: [],
+      name: 'test-script',
+      scriptFamilies: [],
+      teacherResources: [],
+      versionYearOptions: [],
+      initialFamilyName: '',
+      initialTeacherResources: [],
+      initialProjectSharing: false,
+      initialLocales: [],
+      initialLessonLevelData:
+        "lesson_group 'lesson group', display_name: 'lesson group display name'\nlesson 'new lesson', display_name: 'lesson display name'\n"
+    };
+  });
+
+  afterEach(() => {
+    restoreRedux();
+    utils.navigateToHref.restore();
+  });
+
+  const createWrapper = overrideProps => {
+    const combinedProps = {...defaultProps, ...overrideProps};
+    return mount(
+      <Provider store={store}>
+        <ScriptEditor {...combinedProps} />
+      </Provider>
+    );
   };
 
   describe('Script Editor', () => {
     describe('Teacher Resources', () => {
       it('adds empty resources if passed none', () => {
-        const wrapper = shallow(<ScriptEditor {...DEFAULT_PROPS} />);
-        assert.deepEqual(wrapper.state('teacherResources'), [
-          {type: '', link: ''},
-          {type: '', link: ''},
-          {type: '', link: ''},
-          {type: '', link: ''},
-          {type: '', link: ''},
-          {type: '', link: ''},
-          {type: '', link: ''},
-          {type: '', link: ''},
-          {type: '', link: ''},
-          {type: '', link: ''}
-        ]);
+        const wrapper = createWrapper({
+          initialTeacherResources: [
+            {type: ResourceType.curriculum, link: '/foo'}
+          ]
+        });
+
+        assert.deepEqual(
+          wrapper.find('ScriptEditor').state('teacherResources'),
+          [
+            {type: ResourceType.curriculum, link: '/foo'},
+            {type: '', link: ''},
+            {type: '', link: ''},
+            {type: '', link: ''},
+            {type: '', link: ''},
+            {type: '', link: ''},
+            {type: '', link: ''},
+            {type: '', link: ''},
+            {type: '', link: ''},
+            {type: '', link: ''}
+          ]
+        );
       });
 
       it('adds empty resources if passed fewer than max', () => {
-        const wrapper = shallow(
-          <ScriptEditor
-            {...DEFAULT_PROPS}
-            initialTeacherResources={[
-              {type: ResourceType.curriculum, link: '/foo'}
-            ]}
-          />
+        const wrapper = createWrapper({
+          initialTeacherResources: [
+            {type: ResourceType.curriculum, link: '/foo'}
+          ]
+        });
+
+        assert.deepEqual(
+          wrapper.find('ScriptEditor').state('teacherResources'),
+          [
+            {type: ResourceType.curriculum, link: '/foo'},
+            {type: '', link: ''},
+            {type: '', link: ''},
+            {type: '', link: ''},
+            {type: '', link: ''},
+            {type: '', link: ''},
+            {type: '', link: ''},
+            {type: '', link: ''},
+            {type: '', link: ''},
+            {type: '', link: ''}
+          ]
         );
-        assert.deepEqual(wrapper.state('teacherResources'), [
-          {type: ResourceType.curriculum, link: '/foo'},
-          {type: '', link: ''},
-          {type: '', link: ''},
-          {type: '', link: ''},
-          {type: '', link: ''},
-          {type: '', link: ''},
-          {type: '', link: ''},
-          {type: '', link: ''},
-          {type: '', link: ''},
-          {type: '', link: ''}
-        ]);
       });
     });
 
     it('has the correct number of each editor field type', () => {
-      const wrapper = mount(
-        <ScriptEditor {...DEFAULT_PROPS} initialHidden={false} />
-      );
+      const wrapper = createWrapper({
+        initialHidden: false
+      });
       expect(wrapper.find('input').length).to.equal(23);
       expect(wrapper.find('input[type="checkbox"]').length).to.equal(11);
       expect(wrapper.find('textarea').length).to.equal(2);
@@ -79,9 +128,9 @@ describe('ScriptEditor', () => {
     });
 
     it('has correct markdown for preview of unit description', () => {
-      const wrapper = mount(
-        <ScriptEditor {...DEFAULT_PROPS} initialHidden={false} />
-      );
+      const wrapper = createWrapper({
+        initialHidden: false
+      });
       expect(wrapper.find('TextareaWithMarkdownPreview').length).to.equal(1);
       expect(
         wrapper.find('TextareaWithMarkdownPreview').prop('markdown')
@@ -91,9 +140,9 @@ describe('ScriptEditor', () => {
     });
 
     it('must set family name in order to check standalone course', () => {
-      const wrapper = mount(
-        <ScriptEditor {...DEFAULT_PROPS} initialHidden={false} />
-      );
+      const wrapper = createWrapper({
+        initialHidden: false
+      });
       let courseCheckbox = wrapper.find('input[name="is_course"]');
       let familyNameSelect = wrapper.find('select[name="family_name"]');
 
@@ -113,17 +162,17 @@ describe('ScriptEditor', () => {
 
   describe('VisibleInTeacherDashboard', () => {
     it('is checked when hidden is false', () => {
-      const wrapper = mount(
-        <ScriptEditor {...DEFAULT_PROPS} initialHidden={false} />
-      );
+      const wrapper = createWrapper({
+        initialHidden: false
+      });
       const checkbox = wrapper.find('input[name="visible_to_teachers"]');
       expect(checkbox.prop('checked')).to.be.true;
     });
 
     it('is unchecked when hidden is true', () => {
-      const wrapper = mount(
-        <ScriptEditor {...DEFAULT_PROPS} initialHidden={true} />
-      );
+      const wrapper = createWrapper({
+        initialHidden: true
+      });
       const checkbox = wrapper.find('input[name="visible_to_teachers"]');
       expect(checkbox.prop('checked')).to.be.false;
     });

--- a/apps/test/unit/lib/levelbuilder/script-editor/ScriptEditorTest.jsx
+++ b/apps/test/unit/lib/levelbuilder/script-editor/ScriptEditorTest.jsx
@@ -68,16 +68,12 @@ describe('ScriptEditor', () => {
   describe('Script Editor', () => {
     describe('Teacher Resources', () => {
       it('adds empty resources if passed none', () => {
-        const wrapper = createWrapper({
-          initialTeacherResources: [
-            {type: ResourceType.curriculum, link: '/foo'}
-          ]
-        });
+        const wrapper = createWrapper({});
 
         assert.deepEqual(
           wrapper.find('ScriptEditor').state('teacherResources'),
           [
-            {type: ResourceType.curriculum, link: '/foo'},
+            {type: '', link: ''},
             {type: '', link: ''},
             {type: '', link: ''},
             {type: '', link: ''},


### PR DESCRIPTION
Connects ScriptEditor component to redux so that we can get the LessonGroup information for saving with AJAX in a future PR.

## Testing story

Updated the ScriptEditorTest

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
