### PR TITLE
Return default image when image moderation fails

### DIFF
--- a/lib/cdo/image_moderation.rb
+++ b/lib/cdo/image_moderation.rb
@@ -7,7 +7,7 @@ module ImageModeration
   # @param [IO] image_data - binary image data to be rated
   # @param [String] content_type - image/bmp, image/gif, image/jpeg, image/png
   # @param [String] image_url (optional) - Only used for metrics (for now).
-  # @return [:everyone|:racy|:adult] Whether the image is suitable for everyone
+  # @return [:everyone|:racy|:adult|:unknown] Whether the image is suitable for everyone
   def self.rate_image(image_data, content_type, image_url = nil)
     return :everyone unless CDO.azure_content_moderation_key
     AzureContentModerator.new(
@@ -30,6 +30,6 @@ module ImageModeration
         data_string: err
       }
     )
-    :everyone
+    :unknown
   end
 end

--- a/lib/test/cdo/test_image_moderation.rb
+++ b/lib/test/cdo/test_image_moderation.rb
@@ -27,11 +27,11 @@ class ImageModerationTest < Minitest::Test
     assert_equal :racy, ImageModeration.rate_image(@image_body, @content_type, test_image_url)
   end
 
-  def test_allow_everything_when_moderation_fails
+  def test_returns_unknown_when_moderation_fails
     test_err = AzureContentModerator::AzureError.new('Test error')
     AzureContentModerator.any_instance.stubs(:rate_image).raises(test_err)
     Honeybadger.expects(:notify).once.with(test_err)
     FirehoseClient.any_instance.expects(:put_record).with(:analysis, {study: 'azure-content-moderation', study_group: 'v1', event: 'moderation-error', data_string: test_err})
-    assert_equal :everyone, ImageModeration.rate_image(@image_body, @content_type)
+    assert_equal :unknown, ImageModeration.rate_image(@image_body, @content_type)
   end
 end

--- a/shared/test/fixtures/vcr/publicthumbnails/unknown_thumbnail.yml
+++ b/shared/test/fixtures/vcr/publicthumbnails/unknown_thumbnail.yml
@@ -1,0 +1,199 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://cdo-v3-files.s3.amazonaws.com/?encoding-type=url&prefix=files_test/1/1/
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      Content-Length:
+      - '0'
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 19 Nov 2020 06:00:06 GMT
+      X-Amz-Bucket-Region:
+      - us-east-1
+      Content-Type:
+      - application/xml
+      Transfer-Encoding:
+      - chunked
+      Server:
+      - AmazonS3
+    body:
+      encoding: UTF-8
+      string: |-
+        <?xml version="1.0" encoding="UTF-8"?>
+        <ListBucketResult xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Name>cdo-v3-files</Name><Prefix>files_test/1/1/</Prefix><Marker></Marker><MaxKeys>1000</MaxKeys><EncodingType>url</EncodingType><IsTruncated>false</IsTruncated><Contents><Key>files_test/1/1/alpha_file.html</Key><LastModified>2019-09-13T17:58:52.000Z</LastModified><ETag>&quot;6132295fcf5570fb8b0a944ef322a598&quot;</ETag><Size>5</Size><Owner><ID>cf6bd5437eaccbf2d79d5d40694e94c727ef59eb29caa52acbc32daffeb8e9e4</ID><DisplayName>site</DisplayName></Owner><StorageClass>STANDARD</StorageClass></Contents><Contents><Key>files_test/1/1/alpha_fileac0a7f8c2faac49775a6.html</Key><LastModified>2019-09-13T17:20:52.000Z</LastModified><ETag>&quot;6132295fcf5570fb8b0a944ef322a598&quot;</ETag><Size>5</Size><Owner><ID>cf6bd5437eaccbf2d79d5d40694e94c727ef59eb29caa52acbc32daffeb8e9e4</ID><DisplayName>site</DisplayName></Owner><StorageClass>STANDARD</StorageClass></Contents><Contents><Key>files_test/1/1/beta_file.html</Key><LastModified>2019-09-13T17:58:54.000Z</LastModified><ETag>&quot;0b87d66b88c72957dfea8c9605016442&quot;</ETag><Size>4</Size><Owner><ID>cf6bd5437eaccbf2d79d5d40694e94c727ef59eb29caa52acbc32daffeb8e9e4</ID><DisplayName>site</DisplayName></Owner><StorageClass>STANDARD</StorageClass></Contents><Contents><Key>files_test/1/1/beta_filec0cc21d843b34e9afb52.html</Key><LastModified>2019-09-13T17:20:53.000Z</LastModified><ETag>&quot;0b87d66b88c72957dfea8c9605016442&quot;</ETag><Size>4</Size><Owner><ID>cf6bd5437eaccbf2d79d5d40694e94c727ef59eb29caa52acbc32daffeb8e9e4</ID><DisplayName>site</DisplayName></Owner><StorageClass>STANDARD</StorageClass></Contents><Contents><Key>files_test/1/1/hamsterc3767d8b677de5d809a4.jpg</Key><LastModified>2020-01-16T23:38:19.000Z</LastModified><ETag>&quot;b74f443337bac8d8b7a9245d24fbec0e&quot;</ETag><Size>21</Size><Owner><ID>cf6bd5437eaccbf2d79d5d40694e94c727ef59eb29caa52acbc32daffeb8e9e4</ID><DisplayName>site</DisplayName></Owner><StorageClass>STANDARD</StorageClass></Contents><Contents><Key>files_test/1/1/hamsterc3767d8b677de5d809a4.png</Key><LastModified>2020-01-16T23:33:34.000Z</LastModified><ETag>&quot;b74f443337bac8d8b7a9245d24fbec0e&quot;</ETag><Size>21</Size><Owner><ID>cf6bd5437eaccbf2d79d5d40694e94c727ef59eb29caa52acbc32daffeb8e9e4</ID><DisplayName>site</DisplayName></Owner><StorageClass>STANDARD</StorageClass></Contents><Contents><Key>files_test/1/1/temp.json</Key><LastModified>2019-09-13T21:16:00.000Z</LastModified><ETag>&quot;d751713988987e9331980363e24189ce&quot;</ETag><Size>2</Size><Owner><ID>cf6bd5437eaccbf2d79d5d40694e94c727ef59eb29caa52acbc32daffeb8e9e4</ID><DisplayName>site</DisplayName></Owner><StorageClass>STANDARD</StorageClass></Contents></ListBucketResult>
+    http_version: 
+  recorded_at: Thu, 19 Nov 2020 06:00:05 GMT
+- request:
+    method: put
+    uri: https://cdo-v3-files.s3.amazonaws.com/files_test/1/1/.metadata/thumbnail.png
+    body:
+      encoding: ASCII-8BIT
+      string: stub-thumbnail-body
+    headers:
+      X-Amz-Meta-Abuse-Score:
+      - '0'
+      Expect:
+      - 100-continue
+      Content-Md5:
+      - 04+ScXDCwvvm3GtTkSCZvA==
+      Content-Length:
+      - '19'
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 19 Nov 2020 06:00:06 GMT
+      X-Amz-Version-Id:
+      - sBUtEHE9F36AJkLEUiH_ZHgp1y76A0yz
+      Etag:
+      - '"d38f927170c2c2fbe6dc6b53912099bc"'
+      Content-Length:
+      - '0'
+      Server:
+      - AmazonS3
+    body:
+      encoding: UTF-8
+      string: ''
+    http_version: 
+  recorded_at: Thu, 19 Nov 2020 06:00:05 GMT
+- request:
+    method: get
+    uri: https://cdo-v3-files.s3.amazonaws.com/files_test/1/1/.metadata/thumbnail.png
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      Content-Length:
+      - '0'
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 19 Nov 2020 06:00:07 GMT
+      Last-Modified:
+      - Thu, 19 Nov 2020 06:00:06 GMT
+      Etag:
+      - '"d38f927170c2c2fbe6dc6b53912099bc"'
+      X-Amz-Meta-Abuse-Score:
+      - '0'
+      X-Amz-Version-Id:
+      - sBUtEHE9F36AJkLEUiH_ZHgp1y76A0yz
+      Accept-Ranges:
+      - bytes
+      Content-Type:
+      - ''
+      Content-Length:
+      - '19'
+      Server:
+      - AmazonS3
+    body:
+      encoding: UTF-8
+      string: stub-thumbnail-body
+    http_version: 
+  recorded_at: Thu, 19 Nov 2020 06:00:06 GMT
+- request:
+    method: get
+    uri: https://cdo-v3-files.s3.amazonaws.com/files_test/1/1/.metadata/thumbnail.png
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      Content-Length:
+      - '0'
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 19 Nov 2020 06:00:07 GMT
+      Last-Modified:
+      - Thu, 19 Nov 2020 06:00:06 GMT
+      Etag:
+      - '"d38f927170c2c2fbe6dc6b53912099bc"'
+      X-Amz-Meta-Abuse-Score:
+      - '0'
+      X-Amz-Version-Id:
+      - sBUtEHE9F36AJkLEUiH_ZHgp1y76A0yz
+      Accept-Ranges:
+      - bytes
+      Content-Type:
+      - ''
+      Content-Length:
+      - '19'
+      Server:
+      - AmazonS3
+    body:
+      encoding: UTF-8
+      string: stub-thumbnail-body
+    http_version: 
+  recorded_at: Thu, 19 Nov 2020 06:00:06 GMT
+- request:
+    method: delete
+    uri: https://cdo-v3-files.s3.amazonaws.com/files_test/1/1/.metadata/thumbnail.png
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      Content-Length:
+      - '0'
+  response:
+    status:
+      code: 204
+      message: No Content
+    headers:
+      Date:
+      - Thu, 19 Nov 2020 06:00:07 GMT
+      X-Amz-Version-Id:
+      - hJ.v0wjh7KqHZJ.zqkq166irrGmsg_oZ
+      X-Amz-Delete-Marker:
+      - 'true'
+      Server:
+      - AmazonS3
+    body:
+      encoding: UTF-8
+      string: ''
+    http_version: 
+  recorded_at: Thu, 19 Nov 2020 06:00:07 GMT
+- request:
+    method: get
+    uri: https://cdo-v3-files.s3.amazonaws.com/files_test/1/1/manifest.json
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      Content-Length:
+      - '0'
+  response:
+    status:
+      code: 404
+      message: Not Found
+    headers:
+      Content-Type:
+      - application/xml
+      Transfer-Encoding:
+      - chunked
+      Date:
+      - Thu, 19 Nov 2020 06:00:06 GMT
+      Server:
+      - AmazonS3
+    body:
+      encoding: UTF-8
+      string: |-
+        <?xml version="1.0" encoding="UTF-8"?>
+        <Error><Code>NoSuchKey</Code><Message>The specified key does not exist.</Message><Key>files_test/1/1/manifest.json</Key><RequestId>1C4E1F450C69E67E</RequestId><HostId>Htqed4sDSebuEFLHYpAflfGKBeLEgKQT3WgvgRYoZeLVFy1wnxuMFhkjFVJXt9wBBRlbJqdXzgA=</HostId></Error>
+    http_version: 
+  recorded_at: Thu, 19 Nov 2020 06:00:07 GMT
+recorded_with: VCR 3.0.3

--- a/shared/test/middleware/files_api/test_public_thumbnails.rb
+++ b/shared/test/middleware/files_api/test_public_thumbnails.rb
@@ -96,6 +96,36 @@ class PublicThumbnailsTest < FilesApiTestBase
     end
   end
 
+  def test_unknown_thumbnail
+    ImageModeration.stubs(:rate_image).once.returns :unknown
+
+    with_project_type('applab') do |channel_id|
+      get "/v3/files-public/#{channel_id}/#{@thumbnail_filename}"
+      assert successful?
+
+      # Returns cache timeout between 60-120 seconds, proxy timeout between 30-60 seconds
+      assert last_response['Cache-Control'] =~ /public, max-age=(\d+), s-maxage=(\d+)/
+      max_age = $1.to_i
+      s_maxage = $2.to_i
+      assert max_age.between?(60, 120)
+      assert s_maxage.between?(30, 60)
+
+      # Returns project_default.png instead of the actual image
+      refute_equal @thumbnail_body, last_response.body
+
+      # Does not flag the project as abusive
+      get "/v3/channels/#{channel_id}/abuse"
+      assert successful?
+      assert_equal 0, JSON.parse(last_response.body)['abuse_score']
+
+      # Does not flag the thumbnail as abusive
+      thumbnail = FileBucket.new.get(channel_id, @thumbnail_filename)
+      metadata = thumbnail[:metadata]
+      thumbnail_abuse = [metadata['abuse_score'].to_i, metadata['abuse-score'].to_i].max
+      assert_equal 0, thumbnail_abuse
+    end
+  end
+
   def test_bad_channel_thumbnail
     ImageModeration.expects(:rate_image).never
 


### PR DESCRIPTION
<!--
  Your description goes here: A summary of the change, including any relevant motivation and context.

  If relevant, include a description both of the existing behavior and of the new behavior.
-->
Small change to return a default placeholder image when the Azure Content Moderation service returns a failure, usually because we've exceeded our request rate limit.  The default placeholder image has a variable cache timeout of 60-120 seconds to help spread out future requests to the moderation service.

Note that while the thumbnail is no longer shown to the student, the student can still click and load the project.
<!--
  Other aspects to consider. uncomment and add detail for any that seem necessary:
-->

<!-- ### Background -->
<!-- ### Privacy -->
<!--
1.	Does the Project involve the collection, use or sharing of new Personal Data?

2.	Does the Project involve a new or changed use or sharing of existing Personal Data?
-->
<!-- ### Security -->
<!--
Link to Jira Task where sensitive security issues are discussed privately.
-->
<!-- ### Caching -->
<!-- ### Deployment strategy -->
<!-- ### Future work -->

## Links

<!--
  Any relevant links to external resources; ie, specification documents, jira
  items, related PRs, honeybadger errors, etc
-->

- [jira](https://codedotorg.atlassian.net/browse/LP-260)

## Testing story

<!--
  Does your change include appropriate tests?

  If so, please describe how the tests included in this PR are sufficient

  If not, please explain why this change does not need to be tested.
-->

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
