### PR TITLE
Set the activity section name before adding script levels

### DIFF
--- a/dashboard/lib/services/lesson_import_helper.rb
+++ b/dashboard/lib/services/lesson_import_helper.rb
@@ -147,8 +147,7 @@ module Services::LessonImportHelper
         current_progression = level.progression if current_progression.nil?
         current_progression_levels.push(level)
       else
-        section = create_activity_section_with_levels(current_progression_levels, lesson_activity.id)
-        section.name = current_progression
+        section = create_activity_section_with_levels(current_progression_levels, lesson_activity.id, current_progression)
         section.position = activity_sections.length + 1
         section.save!
         activity_sections.push(section)
@@ -157,7 +156,7 @@ module Services::LessonImportHelper
       end
     end
     unless current_progression_levels.empty?
-      section = create_activity_section_with_levels(current_progression_levels, lesson_activity.id)
+      section = create_activity_section_with_levels(current_progression_levels, lesson_activity.id, current_progression)
       section.name = current_progression
       section.position = activity_sections.length + 1
       section.save!
@@ -167,9 +166,10 @@ module Services::LessonImportHelper
     lesson_activity
   end
 
-  def self.create_activity_section_with_levels(script_levels, lesson_activity_id)
+  def self.create_activity_section_with_levels(script_levels, lesson_activity_id, progression_name="")
     return nil if script_levels.empty?
     activity_section = ActivitySection.new
+    activity_section.name = progression_name
     activity_section.key ||= SecureRandom.uuid
     activity_section.position = 0
     activity_section.lesson_activity_id = lesson_activity_id


### PR DESCRIPTION
The activity section name is used to [set the progression name](https://github.com/code-dot-org/code-dot-org/blob/285fc51111c2564337b2ce9c319c9294ae19091b/dashboard/app/models/activity_section.rb#L81). Before, the activity section name was being set after script levels were added, so the progression wasn't being set correctly.

~I filed a [ticket](https://codedotorg.atlassian.net/browse/PLAT-526) to find the longer term fix here. It will likely be confusing for a levelbuilder to change the name of the activity section (say because of a typo) and not have that change reflected on the script overview page.~ Never mind this is incorrect.

<!-- ### Background -->
<!-- ### Privacy -->
<!--
1.	Does the Project involve the collection, use or sharing of new Personal Data?

2.	Does the Project involve a new or changed use or sharing of existing Personal Data?
-->
<!-- ### Security -->
<!--
Link to Jira Task where sensitive security issues are discussed privately.
-->
<!-- ### Caching -->
<!-- ### Deployment strategy -->
<!-- ### Future work -->

## Links

<!--
  Any relevant links to external resources; ie, specification documents, jira
  items, related PRs, honeybadger errors, etc
-->

- [spec]()
- [jira]()

## Testing story

<!--
  Does your change include appropriate tests?

  If so, please describe how the tests included in this PR are sufficient

  If not, please explain why this change does not need to be tested.
-->

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
