### PR TITLE
Stringify announcements before passing them in for saving

### DIFF
--- a/apps/src/lib/levelbuilder/lesson-editor/LessonEditor.jsx
+++ b/apps/src/lib/levelbuilder/lesson-editor/LessonEditor.jsx
@@ -88,8 +88,6 @@ class LessonEditor extends Component {
 
     this.setState({isSaving: true, lastSaved: null, error: null});
 
-    console.log(this.state.announcements);
-
     $.ajax({
       url: `/lessons/${this.props.id}`,
       method: 'PUT',

--- a/apps/src/lib/levelbuilder/lesson-editor/LessonEditor.jsx
+++ b/apps/src/lib/levelbuilder/lesson-editor/LessonEditor.jsx
@@ -88,6 +88,8 @@ class LessonEditor extends Component {
 
     this.setState({isSaving: true, lastSaved: null, error: null});
 
+    console.log(this.state.announcements);
+
     $.ajax({
       url: `/lessons/${this.props.id}`,
       method: 'PUT',
@@ -106,10 +108,11 @@ class LessonEditor extends Component {
         objectives: JSON.stringify(this.state.objectives),
         activities: getSerializedActivities(this.props.activities),
         resources: JSON.stringify(this.props.resources.map(r => r.key)),
-        announcements: this.state.announcements
+        announcements: JSON.stringify(this.state.announcements)
       })
     })
       .done(data => {
+        console.log(data);
         if (shouldCloseAfterSave) {
           navigateToHref(`/lessons/${this.props.id}${window.location.search}`);
         } else {

--- a/apps/src/lib/levelbuilder/script-editor/ScriptEditor.jsx
+++ b/apps/src/lib/levelbuilder/script-editor/ScriptEditor.jsx
@@ -218,7 +218,7 @@ class ScriptEditor extends React.Component {
       family_name: this.state.familyName,
       is_course: this.state.isCourse,
       description: this.state.description,
-      announcements: this.state.announcements,
+      announcements: JSON.stringify(this.state.announcements),
       visible_to_teachers: !this.state.hidden,
       is_stable: this.state.isStable,
       login_required: this.state.loginRequired,


### PR DESCRIPTION
During bug bash it was reported that announcements were not saving. I traced down that we used to stringify the announcements before passing them in. I am now doing that again and it worked locally to save announcements.

