### PR TITLE
Disable safari for script_edit_page UI test

### DIFF
--- a/dashboard/test/ui/features/curriculum_platform/levelbuilder/script_edit_page.feature
+++ b/dashboard/test/ui/features/curriculum_platform/levelbuilder/script_edit_page.feature
@@ -2,6 +2,8 @@
 
 # We need "press keys" to type into the React form's fields, but that doesn't work on IE.
 @no_ie
+
+@no_safari
 Feature: Using the Script Edit Page
 
 Scenario: View the script edit page


### PR DESCRIPTION
Script_edit_page.feature failed on safari after changes made in #37843. While we debug the issue we are going to disable safari since this is an internal tool.  [Slack thread](https://codedotorg.slack.com/archives/C03CM903Y/p1605891888206600)
