### PR TITLE
[MERGE ON 12/2] Update dance manifest to songManifest2020_v2.json

### DIFF
--- a/apps/src/dance/songs.js
+++ b/apps/src/dance/songs.js
@@ -13,7 +13,7 @@ import Sounds from '../Sounds';
 export async function getSongManifest(useRestrictedSongs, manifestFilename) {
   if (!manifestFilename || manifestFilename.length === 0) {
     manifestFilename = useRestrictedSongs
-      ? 'songManifest2020.json'
+      ? 'songManifest2020_v2.json'
       : 'testManifest.json';
   }
 

--- a/dashboard/app/models/levels/dancelab.rb
+++ b/dashboard/app/models/levels/dancelab.rb
@@ -58,7 +58,7 @@ class Dancelab < GamelabJr
 
   # Used by levelbuilders to set a default song on a Dance Party level.
   def self.hoc_songs
-    manifest_json = AWS::S3.create_client.get_object(bucket: 'cdo-sound-library', key: 'hoc_song_meta/songManifest2020.json')[:body].read
+    manifest_json = AWS::S3.create_client.get_object(bucket: 'cdo-sound-library', key: 'hoc_song_meta/songManifest2020_v2.json')[:body].read
     manifest = JSON.parse(manifest_json)
     manifest['songs'].map do |song|
       name = song['text']


### PR DESCRIPTION
Releases new Dance Party songs available in `songManifest2020_v2.json` ([view manifest in S3](https://s3.console.aws.amazon.com/s3/buckets/cdo-sound-library?region=us-east-1&prefix=hoc_song_meta/)) to users and levelbuilders.

Confirming with marketing when exactly this change should be deployed, and this PR should not be merged in the meantime.

## Links

<!--
  Any relevant links to external resources; ie, specification documents, jira
  items, related PRs, honeybadger errors, etc
-->

- [STAR-1255](https://codedotorg.atlassian.net/browse/STAR-1255)

## Testing story

<!--
  Does your change include appropriate tests?

  If so, please describe how the tests included in this PR are sufficient

  If not, please explain why this change does not need to be tested.
-->

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
