### PR TITLE
Ignore deleted_at index for RegistrationsController#destroy query

### DIFF
--- a/dashboard/app/controllers/registrations_controller.rb
+++ b/dashboard/app/controllers/registrations_controller.rb
@@ -528,7 +528,7 @@ class RegistrationsController < Devise::RegistrationsController
   def destroy_users(current_user, dependent_users)
     users = [current_user] + dependent_users
     user_ids_to_destroy = users.pluck(:id)
-    User.destroy(user_ids_to_destroy)
+    User.ignore_deleted_at_index.destroy(user_ids_to_destroy)
 
     log_account_deletion_to_firehose(current_user, dependent_users)
   end

--- a/dashboard/app/models/user.rb
+++ b/dashboard/app/models/user.rb
@@ -124,6 +124,8 @@ class User < ActiveRecord::Base
 
   acts_as_paranoid # use deleted_at column instead of deleting rows
 
+  scope :ignore_deleted_at_index, -> {from 'users IGNORE INDEX(index_users_on_deleted_at)'}
+
   PROVIDER_MANUAL = 'manual'.freeze # "old" user created by a teacher -- logs in w/ username + password
   PROVIDER_SPONSORED = 'sponsored'.freeze # "new" user created by a teacher -- logs in w/ name + secret picture/word
   PROVIDER_MIGRATED = 'migrated'.freeze
@@ -1008,7 +1010,7 @@ class User < ActiveRecord::Base
       return nil if login.size > max_credential_size || login.utf8mb4?
       # TODO: multi-auth (@eric, before merge!) have to handle this path, and make sure that whatever
       # indexing problems bit us on the users table don't affect the multi-auth table
-      from("users IGNORE INDEX(index_users_on_deleted_at)").where(
+      ignore_deleted_at_index.where(
         [
           'username = :value OR email = :value OR hashed_email = :hashed_value',
           {value: login.downcase, hashed_value: hash_email(login.downcase)}


### PR DESCRIPTION
The uneven distribution + high cardinality of `deleted_at` values (almost all `NULL`, all other values are unique) causes the
MySQL query planner to choose the wrong index (`index_users_on_deleted_at`) for this query, so we need to explicitly ignore this wrong index to avoid poor performance when deleting teachers with large sections.

See also #15394 for an earlier instance where we worked around this same issue in a similar fashion. This PR refactors that case to reuse the same code for both.

I'm not thrilled with this approach but for now, manually managing index selection for specific affected queries is the best we can do. Here are some other long-term options to consider in the future:

- We could add the `IGNORE INDEX` clause more globally to the default `User` scope, and un-scope this clause in the one case where we require this index for a query (the expired-account purger).
- We could use an extra virtual generated column to more explicitly separate indexed queries (only done by the expired-account purger) from all other user-table queries. Either add a duplicate (or lower-cardinality) `is_deleted` column and use this column instead to exclude soft-deleted rows, or add a duplicate `indexed_deleted_at` column only queried by the expired-account purger script and move the index to this column.
- If we upgrade to MySQL 8.0 in the future, we will be able to use the ['histogram statistics'](https://dev.mysql.com/doc/refman/8.0/en/optimizer-statistics.html) feature for more fine-grained  index statistics on this column which would better handle this uneven distribution.
- Another relevant MySQL 8.0 feature is invisible indexes. We could mark `index_users_on_deleted_at` as invisible most of the time, and temporarily enable it only when running the expired-account purger task.