### PR TITLE
Drag level and scroll

### DIFF
--- a/apps/src/lib/levelbuilder/lesson-editor/ActivitiesEditor.jsx
+++ b/apps/src/lib/levelbuilder/lesson-editor/ActivitiesEditor.jsx
@@ -90,6 +90,13 @@ class ActivitiesEditor extends Component {
     });
   };
 
+  clearTargetActivitySection = () => {
+    this.setState({
+      targetActivityPos: null,
+      targetActivitySectionPos: null
+    });
+  };
+
   // Given a clientY value of a location on the screen, find the ActivityCard
   // and ActivitySectionCard corresponding to that location, and update
   // targetActivityPos and targetActivitySectionPos to match.
@@ -118,6 +125,7 @@ class ActivitiesEditor extends Component {
             activitiesCount={activities.length}
             setActivitySectionRef={this.setActivitySectionRef}
             updateTargetActivitySection={this.updateTargetActivitySection}
+            clearTargetActivitySection={this.clearTargetActivitySection}
             targetActivityPos={this.state.targetActivityPos}
             targetActivitySectionPos={this.state.targetActivitySectionPos}
             activitySectionMetrics={this.sectionMetrics}

--- a/apps/src/lib/levelbuilder/lesson-editor/ActivityCard.jsx
+++ b/apps/src/lib/levelbuilder/lesson-editor/ActivityCard.jsx
@@ -72,6 +72,7 @@ class ActivityCard extends Component {
     activitiesCount: PropTypes.number.isRequired,
     setActivitySectionRef: PropTypes.func.isRequired,
     updateTargetActivitySection: PropTypes.func.isRequired,
+    clearTargetActivitySection: PropTypes.func.isRequired,
     targetActivityPos: PropTypes.number,
     targetActivitySectionPos: PropTypes.number,
     activitySectionMetrics: PropTypes.array.isRequired,
@@ -144,6 +145,7 @@ class ActivityCard extends Component {
       activity,
       setActivitySectionRef,
       updateTargetActivitySection,
+      clearTargetActivitySection,
       updateActivitySectionMetrics
     } = this.props;
 
@@ -199,6 +201,7 @@ class ActivityCard extends Component {
               }}
               activitySectionMetrics={this.props.activitySectionMetrics}
               updateTargetActivitySection={updateTargetActivitySection}
+              clearTargetActivitySection={clearTargetActivitySection}
               targetActivityPos={this.props.targetActivityPos}
               targetActivitySectionPos={this.props.targetActivitySectionPos}
               updateActivitySectionMetrics={updateActivitySectionMetrics}

--- a/apps/src/lib/levelbuilder/lesson-editor/ActivityCardAndPreview.jsx
+++ b/apps/src/lib/levelbuilder/lesson-editor/ActivityCardAndPreview.jsx
@@ -33,6 +33,7 @@ export default class ActivityCardAndPreview extends Component {
     activitiesCount: PropTypes.number,
     setActivitySectionRef: PropTypes.func.isRequired,
     updateTargetActivitySection: PropTypes.func.isRequired,
+    clearTargetActivitySection: PropTypes.func.isRequired,
     targetActivityPos: PropTypes.number,
     targetActivitySectionPos: PropTypes.number,
     activitySectionMetrics: PropTypes.array.isRequired,
@@ -62,6 +63,7 @@ export default class ActivityCardAndPreview extends Component {
             activitiesCount={this.props.activitiesCount}
             setActivitySectionRef={this.props.setActivitySectionRef}
             updateTargetActivitySection={this.props.updateTargetActivitySection}
+            clearTargetActivitySection={this.props.clearTargetActivitySection}
             targetActivityPos={this.props.targetActivityPos}
             targetActivitySectionPos={this.props.targetActivitySectionPos}
             activitySectionMetrics={this.props.activitySectionMetrics}

--- a/apps/src/lib/levelbuilder/lesson-editor/ActivitySectionCard.jsx
+++ b/apps/src/lib/levelbuilder/lesson-editor/ActivitySectionCard.jsx
@@ -25,7 +25,7 @@ const SCROLL_THRESHOLD = 100;
 
 // WHen the scroll threshold is reached, scroll this many pixels for each pixel
 // the cursor has moved beyond the threshold.
-const SCROLL_RATIO = 0.1;
+const SCROLL_RATIO = 0.2;
 
 const styles = {
   checkbox: {

--- a/apps/src/lib/levelbuilder/lesson-editor/ActivitySectionCard.jsx
+++ b/apps/src/lib/levelbuilder/lesson-editor/ActivitySectionCard.jsx
@@ -191,14 +191,14 @@ class ActivitySectionCard extends Component {
   triggerScroll = clientY => {
     if (clientY < SCROLL_THRESHOLD) {
       const step = (SCROLL_THRESHOLD - clientY) * SCROLL_RATIO;
-      const scrollY = $(window).scrollTop();
-      $(window).scrollTop(scrollY - step);
+      const scrollTop = $(window).scrollTop();
+      $(window).scrollTop(scrollTop - step);
     }
     const bottom = $(window).height() - clientY;
     if (bottom < SCROLL_THRESHOLD) {
       const step = (SCROLL_THRESHOLD - bottom) * SCROLL_RATIO;
-      const scrollY = $(window).scrollTop();
-      $(window).scrollTop(scrollY + step);
+      const scrollTop = $(window).scrollTop();
+      $(window).scrollTop(scrollTop + step);
     }
   };
 

--- a/apps/src/lib/levelbuilder/lesson-editor/ActivitySectionCard.jsx
+++ b/apps/src/lib/levelbuilder/lesson-editor/ActivitySectionCard.jsx
@@ -173,10 +173,19 @@ class ActivitySectionCard extends Component {
     );
     this.setState({currentPositions, newPosition});
     this.props.updateTargetActivitySection(clientY);
+    this.triggerScroll(clientY);
   };
 
   handleScroll = () => {
     this.props.updateActivitySectionMetrics();
+  };
+
+  triggerScroll = clientY => {
+    if (clientY < 100) {
+      const step = (100 - clientY) / 10;
+      var scrollY = $(window).scrollTop();
+      $(window).scrollTop(scrollY - step);
+    }
   };
 
   handleDragStop = () => {

--- a/apps/src/lib/levelbuilder/lesson-editor/ActivitySectionCard.jsx
+++ b/apps/src/lib/levelbuilder/lesson-editor/ActivitySectionCard.jsx
@@ -19,6 +19,14 @@ import ReactDOM from 'react-dom';
 import color from '@cdo/apps/util/color';
 import {activitySectionShape} from '@cdo/apps/lib/levelbuilder/shapes';
 
+// When dragging within this many pixels of the top or bottom of the screen,
+// start scrolling the page.
+const SCROLL_THRESHOLD = 100;
+
+// WHen the scroll threshold is reached, scroll this many pixels for each pixel
+// the cursor has moved beyond the threshold.
+const SCROLL_RATIO = 0.1;
+
 const styles = {
   checkbox: {
     margin: '0 0 0 7px'
@@ -181,14 +189,14 @@ class ActivitySectionCard extends Component {
   };
 
   triggerScroll = clientY => {
-    if (clientY < 100) {
-      const step = (100 - clientY) / 10;
+    if (clientY < SCROLL_THRESHOLD) {
+      const step = (SCROLL_THRESHOLD - clientY) * SCROLL_RATIO;
       const scrollY = $(window).scrollTop();
       $(window).scrollTop(scrollY - step);
     }
     const bottom = $(window).height() - clientY;
-    if (bottom < 100) {
-      const step = (100 - bottom) / 10;
+    if (bottom < SCROLL_THRESHOLD) {
+      const step = (SCROLL_THRESHOLD - bottom) * SCROLL_RATIO;
       const scrollY = $(window).scrollTop();
       $(window).scrollTop(scrollY + step);
     }

--- a/apps/src/lib/levelbuilder/lesson-editor/ActivitySectionCard.jsx
+++ b/apps/src/lib/levelbuilder/lesson-editor/ActivitySectionCard.jsx
@@ -90,6 +90,7 @@ class ActivitySectionCard extends Component {
     activitiesCount: PropTypes.number.isRequired,
     activitySectionMetrics: PropTypes.array.isRequired,
     updateTargetActivitySection: PropTypes.func.isRequired,
+    clearTargetActivitySection: PropTypes.func.isRequired,
     targetActivityPos: PropTypes.number,
     targetActivitySectionPos: PropTypes.number,
     updateActivitySectionMetrics: PropTypes.func.isRequired,
@@ -209,8 +210,7 @@ class ActivitySectionCard extends Component {
       );
     }
 
-    // shortcut to clear target activity section
-    this.props.updateTargetActivitySection(-1);
+    this.props.clearTargetActivitySection();
 
     this.setState({
       draggedLevelPos: null,

--- a/apps/src/lib/levelbuilder/lesson-editor/ActivitySectionCard.jsx
+++ b/apps/src/lib/levelbuilder/lesson-editor/ActivitySectionCard.jsx
@@ -141,6 +141,7 @@ class ActivitySectionCard extends Component {
       );
       window.addEventListener('selectstart', this.preventSelect);
       window.addEventListener('mousemove', this.handleDrag);
+      window.addEventListener('scroll', this.handleScroll);
       window.addEventListener('mouseup', this.handleDragStop);
     });
   };
@@ -171,6 +172,10 @@ class ActivitySectionCard extends Component {
     );
     this.setState({currentPositions, newPosition});
     this.props.updateTargetActivitySection(clientY);
+  };
+
+  handleScroll = () => {
+    this.props.updateActivitySectionMetrics();
   };
 
   handleDragStop = () => {
@@ -214,6 +219,7 @@ class ActivitySectionCard extends Component {
     });
     window.removeEventListener('selectstart', this.preventSelect);
     window.removeEventListener('mousemove', this.handleDrag);
+    window.removeEventListener('scroll', this.handleScroll);
     window.removeEventListener('mouseup', this.handleDragStop);
   };
 

--- a/apps/src/lib/levelbuilder/lesson-editor/ActivitySectionCard.jsx
+++ b/apps/src/lib/levelbuilder/lesson-editor/ActivitySectionCard.jsx
@@ -183,8 +183,14 @@ class ActivitySectionCard extends Component {
   triggerScroll = clientY => {
     if (clientY < 100) {
       const step = (100 - clientY) / 10;
-      var scrollY = $(window).scrollTop();
+      const scrollY = $(window).scrollTop();
       $(window).scrollTop(scrollY - step);
+    }
+    const bottom = $(window).height() - clientY;
+    if (bottom < 100) {
+      const step = (100 - bottom) / 10;
+      const scrollY = $(window).scrollTop();
+      $(window).scrollTop(scrollY + step);
     }
   };
 

--- a/apps/test/unit/lib/levelbuilder/lesson-editor/ActivityCardAndPreviewTest.jsx
+++ b/apps/test/unit/lib/levelbuilder/lesson-editor/ActivityCardAndPreviewTest.jsx
@@ -9,16 +9,19 @@ describe('ActivityCardAndPreview', () => {
   let defaultProps,
     setActivitySectionRef,
     updateTargetActivitySection,
+    clearTargetActivitySection,
     updateActivitySectionMetrics;
   beforeEach(() => {
     setActivitySectionRef = sinon.spy();
     updateTargetActivitySection = sinon.spy();
+    clearTargetActivitySection = sinon.spy();
     updateActivitySectionMetrics = sinon.spy();
     defaultProps = {
       activity: sampleActivities[0],
       activitiesCount: 1,
       setActivitySectionRef,
       updateTargetActivitySection,
+      clearTargetActivitySection,
       updateActivitySectionMetrics,
       targetActivitySectionPos: 1,
       activitySectionMetrics: []

--- a/apps/test/unit/lib/levelbuilder/lesson-editor/ActivityCardTest.jsx
+++ b/apps/test/unit/lib/levelbuilder/lesson-editor/ActivityCardTest.jsx
@@ -13,6 +13,7 @@ describe('ActivityCard', () => {
     updateActivityField,
     setActivitySectionRef,
     updateTargetActivitySection,
+    clearTargetActivitySection,
     handleCollapse,
     updateActivitySectionMetrics;
   beforeEach(() => {
@@ -22,6 +23,7 @@ describe('ActivityCard', () => {
     updateActivityField = sinon.spy();
     setActivitySectionRef = sinon.spy();
     updateTargetActivitySection = sinon.spy();
+    clearTargetActivitySection = sinon.spy();
     updateActivitySectionMetrics = sinon.spy();
     handleCollapse = sinon.spy();
     defaultProps = {
@@ -33,6 +35,7 @@ describe('ActivityCard', () => {
       updateActivityField,
       setActivitySectionRef,
       updateTargetActivitySection,
+      clearTargetActivitySection,
       updateActivitySectionMetrics,
       targetActivitySectionPos: 1,
       activitySectionMetrics: [],

--- a/apps/test/unit/lib/levelbuilder/lesson-editor/ActivitySectionCardTest.jsx
+++ b/apps/test/unit/lib/levelbuilder/lesson-editor/ActivitySectionCardTest.jsx
@@ -9,6 +9,7 @@ describe('ActivitySectionCard', () => {
   let defaultProps,
     setTargetActivitySection,
     updateTargetActivitySection,
+    clearTargetActivitySection,
     updateActivitySectionMetrics,
     moveActivitySection,
     removeActivitySection,
@@ -19,6 +20,7 @@ describe('ActivitySectionCard', () => {
   beforeEach(() => {
     setTargetActivitySection = sinon.spy();
     updateTargetActivitySection = sinon.spy();
+    clearTargetActivitySection = sinon.spy();
     updateActivitySectionMetrics = sinon.spy();
     moveActivitySection = sinon.spy();
     removeActivitySection = sinon.spy();
@@ -33,6 +35,7 @@ describe('ActivitySectionCard', () => {
       activitiesCount: 1,
       activitySectionMetrics: [],
       updateTargetActivitySection,
+      clearTargetActivitySection,
       updateActivitySectionMetrics,
       setTargetActivitySection,
       targetActivitySectionPos: 1,


### PR DESCRIPTION
## Background

Starts [PLAT-430]. Previously, https://github.com/code-dot-org/code-dot-org/pull/37384 moved the `sectionMetrics` state up to `ActivitiesEditor` and made sure to update so that dragging would work when the page was scrolled _before_ dragging starts. This PR deals with a related problem of making sure that dragging will work when scrolling happens _after_ dragging starts.

This PR tackles two specific problems:

1. "drop" target does not follow the cursor (I had to use a mouse with a scrollwheel to capture this behavior)
![drag-wrong-drop-target](https://user-images.githubusercontent.com/8001765/100007733-57ae3d80-2d81-11eb-886f-27e1019defb4.gif)

2. dragging doesn't cause the page to scroll
![drag-no-scroll](https://user-images.githubusercontent.com/8001765/100007746-5b41c480-2d81-11eb-82c9-9bd7dbe5d1e9.gif)

## Description

Here's what this PR does:
* af741dc "call updateActivitySectionMetrics on scroll while level is being dragged". this recomputes the position (clientY) of the drop targets / ActivitySectionCards within the window, which become stale after scrolling, fixing problem 1.
* 381297b explicitly clear targetActivitySection. This is a minor fix to un-highlight the drop target after the LevelToken is dropped.
* the rest of the commits cause the page to scroll progressively faster when dragging within 100px of the top or bottom of the window (problem 2).

Here is how it looks:
![scroll-and-drop-working](https://user-images.githubusercontent.com/8001765/100009101-3cdcc880-2d83-11eb-92d2-832cff2941bd.gif)

## Future work

The following problems are tackled in the next PR:
3. the dragged element does not follow the cursor
4. the logic for reordering levels within the original activity section is broken

## Testing story

Manual testing only for drag and drop behavior. Existing test coverage guards against regressions in other features within the lesson editor.

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked


[PLAT-430]: https://codedotorg.atlassian.net/browse/PLAT-430