### PR TITLE
fix initial activity section position on import

### DIFF
--- a/lib/cdo/lesson_import_helper.rb
+++ b/lib/cdo/lesson_import_helper.rb
@@ -221,7 +221,7 @@ module LessonImportHelper
     activity_section.position = 0
     activity_section.lesson_activity_id = lesson_activity_id
     activity_section.save!
-    sl_data = script_levels.each_with_index.map {|l, i| JSON.parse({id: l.id, assessment: l.assessment, bonus: l.bonus, challenge: l.challenge, levels: l.levels, activitySectionPosition: i}.to_json)}
+    sl_data = script_levels.map.with_index(1) {|l, pos| JSON.parse({id: l.id, assessment: l.assessment, bonus: l.bonus, challenge: l.challenge, levels: l.levels, activitySectionPosition: pos}.to_json)}
     activity_section.update_script_levels(sl_data) unless sl_data.blank?
     activity_section
   end


### PR DESCRIPTION
FInishes [PLAT-562]

Before, dragging did not work on the first try:

![drag-attempt-short](https://user-images.githubusercontent.com/8001765/99919158-920bd200-2cd0-11eb-9ef7-eef4638e0018.gif)

this appeared to be because the first script level in each activity section had activity_section_position 0 rather than 1.

## Testing story

Re-imported a few scripts and verified the first script level has activity_section_position: 1

Also verified that dragging works on the first try now:

![drag-success](https://user-images.githubusercontent.com/8001765/99919119-4822ec00-2cd0-11eb-8c24-a73cb6fea92a.gif)


# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked


[PLAT-562]: https://codedotorg.atlassian.net/browse/PLAT-562