### PR TITLE
show more detailed name info for blockly levels in LevelToken

### DIFF
--- a/apps/src/lib/levelbuilder/lesson-editor/LevelToken.jsx
+++ b/apps/src/lib/levelbuilder/lesson-editor/LevelToken.jsx
@@ -183,7 +183,7 @@ class LevelToken extends Component {
                     level={progressBubbleLevel}
                     disabled={true}
                   />
-                  <span style={styles.levelTitle}>{activeLevel.name}</span>
+                  <span style={styles.levelTitle}>{scriptLevel.key}</span>
                 </span>
                 {activeLevel.assessment && (
                   <span style={styles.tag}>assessment</span>


### PR DESCRIPTION
Curriculum Writers commented that it is important to have good level names, since it can be hard to see what changed after dragging and dropping a level. With this in mind, I noticed that levels which are defined in levels.js files all appear as "blockly" in the Lesson editor:
![Screen Shot 2020-11-22 at 10 04 56 PM](https://user-images.githubusercontent.com/8001765/99933164-18470900-2d0f-11eb-949a-676853d0f119.png)

This PR makes a simple fix which is to use the level "key" instead of the name. This is the same as the level name for levelbuilder-created levels, but gives more detail than just "blockly" for levels defined in levels.js files: https://github.com/code-dot-org/code-dot-org/blob/76a05d388fb0814ba467b83a2e0272443b4a6f31/dashboard/app/models/levels/level.rb#L491-L497

![Screen Shot 2020-11-22 at 10 04 28 PM](https://user-images.githubusercontent.com/8001765/99933231-46c4e400-2d0f-11eb-8e40-d46512ba8768.png)

This is where the key is getting set: https://github.com/code-dot-org/code-dot-org/blob/ab81d45729ed8e2e5581340591af7eb8cdfeb623/dashboard/app/models/script_level.rb#L402

## Testing story

This seems like a small enough change that I just did manual testing to verify. I confirmed the improvement in the screenshots  above, and also checked that levelbuilder-defined levels in other lessons are still showing up as they did previously:

![Screen Shot 2020-11-22 at 10 09 52 PM](https://user-images.githubusercontent.com/8001765/99933296-7bd13680-2d0f-11eb-9300-8fe858263625.png)

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
