### PR TITLE
adding a URL flag to bypass modals that are not translatable

### DIFF
--- a/apps/src/code-studio/levels/dialogHelper.js
+++ b/apps/src/code-studio/levels/dialogHelper.js
@@ -5,6 +5,7 @@ import PlayZone from '../components/playzone';
 import ReactDOM from 'react-dom';
 import {getResult} from './codeStudioLevels';
 import LegacyDialog from '@cdo/apps/code-studio/LegacyDialog';
+import experiments from '@cdo/apps/util/experiments';
 import Sounds from '../../Sounds';
 import {
   ErrorDialog,
@@ -24,6 +25,9 @@ var adjustedScroll = false;
  * @param {function} onHidden - Method called when dialog is hidden/closed
  */
 export function showDialog(component, callback, onHidden) {
+  if (experiments.isEnabled(experiments.BYPASS_DIALOG_POPUP)) {
+    return;
+  }
   const div = document.createElement('div');
   ReactDOM.render(component, div);
   const content = div.childNodes[0];

--- a/apps/src/util/experiments.js
+++ b/apps/src/util/experiments.js
@@ -33,6 +33,7 @@ experiments.I18N_TRACKING = 'i18n-tracking';
 experiments.SPRITELAB_INPUT = 'spritelabInput';
 experiments.TIME_SPENT = 'time-spent';
 experiments.APPLAB_ML = 'applab-ml';
+experiments.BYPASS_DIALOG_POPUP = 'bypass-dialog-popup';
 
 /**
  * Get our query string. Provided as a method so that tests can mock this.


### PR DESCRIPTION
<!--
  Your description goes here: A summary of the change, including any relevant motivation and context.

  If relevant, include a description both of the existing behavior and of the new behavior.
-->

This change adds a URL flag that bypasses dialog popups when enabled. This is a workaround to avoid showing dialogs that are not translatable in different languages. One callout is that, because the specific dialog content is abstracted from the JS elements, this solution affects all dialogs, not just encryption ones.

Disabled:
<img width="1440" alt="Screen Shot 2020-11-23 at 11 55 56 AM" src="https://user-images.githubusercontent.com/16494556/100011236-4c114580-2d86-11eb-9812-1cc92140e10e.png">


Enabled:
<img width="1439" alt="Screen Shot 2020-11-23 at 11 55 42 AM" src="https://user-images.githubusercontent.com/16494556/100011249-50d5f980-2d86-11eb-98f3-723b8eee0ef9.png">

<!--
  Other aspects to consider. uncomment and add detail for any that seem necessary:
-->

<!-- ### Background -->
<!-- ### Privacy -->
<!--
1.	Does the Project involve the collection, use or sharing of new Personal Data?

2.	Does the Project involve a new or changed use or sharing of existing Personal Data?
-->
<!-- ### Security -->
<!--
Link to Jira Task where sensitive security issues are discussed privately.
-->
<!-- ### Caching -->
<!-- ### Deployment strategy -->
<!-- ### Future work -->

## Links

<!--
  Any relevant links to external resources; ie, specification documents, jira
  items, related PRs, honeybadger errors, etc
-->

- [spec]()
- [jira]()

## Testing story

<!--
  Does your change include appropriate tests?

  If so, please describe how the tests included in this PR are sufficient

  If not, please explain why this change does not need to be tested.
-->

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
