### PR TITLE
AppLab: remove debug console when in readonly workspace

### DIFF
--- a/apps/src/applab/applab.js
+++ b/apps/src/applab/applab.js
@@ -467,9 +467,12 @@ Applab.init = function(config) {
     config.level.sliderSpeed = 1.0;
   }
 
-  var showDebugButtons = !config.hideSource && !config.level.debuggerDisabled;
+  var showDebugButtons =
+    !config.hideSource &&
+    !config.level.debuggerDisabled &&
+    !config.readonlyWorkspace;
   var breakpointsEnabled = !config.level.debuggerDisabled;
-  var showDebugConsole = !config.hideSource;
+  var showDebugConsole = !config.hideSource && !config.readonlyWorkspace;
 
   // Construct a logging observer for interpreter events
   if (!config.hideSource) {


### PR DESCRIPTION
This removes the debug console in applab readonly mode since it isn't necessary and is a security issue.

Before, readonly looked like this with the debug console at the bottom:
<img width="1440" alt="Screen Shot 2020-11-23 at 3 53 38 PM" src="https://user-images.githubusercontent.com/17147070/100028563-18ddaf00-2da4-11eb-8455-c6e6e1a061f6.png">


Now, it looks like this without the debug console:
<img width="1440" alt="Screen Shot 2020-11-23 at 3 52 57 PM" src="https://user-images.githubusercontent.com/17147070/100028500-f77cc300-2da3-11eb-909f-1f7025921765.png">


<!-- ### Background -->
<!-- ### Privacy -->
<!--
1.	Does the Project involve the collection, use or sharing of new Personal Data?
no
2.	Does the Project involve a new or changed use or sharing of existing Personal Data?
no
-->
<!-- ### Security -->
<!--
Link to Jira Task where sensitive security issues are discussed privately.
-->
<!-- ### Caching -->
<!-- ### Deployment strategy -->
<!-- ### Future work -->

## Links

<!--
  Any relevant links to external resources; ie, specification documents, jira
  items, related PRs, honeybadger errors, etc
-->

- [jira](https://codedotorg.atlassian.net/browse/STAR-1316?atlOrigin=eyJpIjoiMjkxYjIwNGM0ZjEzNDc5MmE2NzNiMzhhOGZlN2JlYTIiLCJwIjoiaiJ9)
- [slack conversation](https://codedotorg.slack.com/archives/C1B3PNDL7/p1606162668420100)

## Testing story

<!--
  Does your change include appropriate tests?

  If so, please describe how the tests included in this PR are sufficient

  If not, please explain why this change does not need to be tested.
-->

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
