### PR TITLE
[Spritelab] Identify behaviors by ID not name

### DIFF
--- a/apps/package.json
+++ b/apps/package.json
@@ -48,7 +48,7 @@
     "@babel/preset-react": "^7.0.0",
     "@cdo/interpreted": "link:../dashboard/config/libraries",
     "@code-dot-org/artist": "0.2.1",
-    "@code-dot-org/blockly": "3.5.30",
+    "@code-dot-org/blockly": "3.5.31",
     "@code-dot-org/bramble": "0.1.26",
     "@code-dot-org/craft": "0.2.2",
     "@code-dot-org/dance-party": "1.0.1",

--- a/apps/src/block_utils.js
+++ b/apps/src/block_utils.js
@@ -433,7 +433,7 @@ exports.cleanBlocks = function(blocksDom) {
 
 /**
  * Adds any functions from functionsXml to blocksXml. If a function with the
- * same name is already present in blocksXml, it won't be added again.
+ * same id is already present in blocksXml, it won't be added again.
  */
 exports.appendNewFunctions = function(blocksXml, functionsXml) {
   const startBlocksDom = xml.parseElement(blocksXml);
@@ -447,12 +447,12 @@ exports.appendNewFunctions = function(blocksXml, functionsXml) {
       ? startBlocksDom.ownerDocument
       : document;
     const name = ownerDocument.evaluate(
-      'title[@name="NAME"]/text()',
+      'title[@name="NAME"]',
       func,
       null,
-      XPathResult.STRING_TYPE,
+      XPathResult.FIRST_ORDERED_NODE_TYPE,
       null
-    ).stringValue;
+    ).singleNodeValue.id;
     const type = ownerDocument.evaluate(
       '@type',
       func,
@@ -462,7 +462,7 @@ exports.appendNewFunctions = function(blocksXml, functionsXml) {
     ).stringValue;
     const alreadyPresent =
       startBlocksDocument.evaluate(
-        `//block[@type="${type}"]/title[@name="NAME"][text()="${name}"]`,
+        `//block[@type="${type}"]/title[@id="${name}"]`,
         startBlocksDom,
         null,
         XPathResult.UNORDERED_NODE_SNAPSHOT_TYPE,

--- a/apps/src/block_utils.js
+++ b/apps/src/block_utils.js
@@ -446,13 +446,14 @@ exports.appendNewFunctions = function(blocksXml, functionsXml) {
     let startBlocksDocument = startBlocksDom.ownerDocument.evaluate
       ? startBlocksDom.ownerDocument
       : document;
-    const name = ownerDocument.evaluate(
+    const node = ownerDocument.evaluate(
       'title[@name="NAME"]',
       func,
       null,
       XPathResult.FIRST_ORDERED_NODE_TYPE,
       null
-    ).singleNodeValue.id;
+    ).singleNodeValue;
+    const name = node && node.id;
     const type = ownerDocument.evaluate(
       '@type',
       func,

--- a/apps/src/p5lab/spritelab/blocks.js
+++ b/apps/src/p5lab/spritelab/blocks.js
@@ -511,7 +511,7 @@ export default {
 
       openEditor(e) {
         e.stopPropagation();
-        behaviorEditor.openEditorForFunction(this, this.getTitleValue('VAR'));
+        behaviorEditor.openEditorForFunction(this, this.getTitle_('VAR').id);
       },
 
       getVars() {

--- a/apps/src/p5lab/spritelab/blocks.js
+++ b/apps/src/p5lab/spritelab/blocks.js
@@ -577,7 +577,7 @@ export default {
 
     generator.gamelab_behavior_get = function() {
       const name = Blockly.JavaScript.variableDB_.getName(
-        this.getTitleValue('VAR'),
+        this.getTitle_('VAR').id,
         Blockly.Procedures.NAME_TYPE
       );
       const extraArgs = [];

--- a/apps/src/p5lab/spritelab/blocks.js
+++ b/apps/src/p5lab/spritelab/blocks.js
@@ -515,9 +515,7 @@ export default {
       },
 
       getVars() {
-        return Blockly.Variables.getVars.bind(this)(
-          Blockly.BlockValueType.BEHAVIOR
-        );
+        return {};
       },
 
       renameVar(oldName, newName) {
@@ -606,9 +604,7 @@ export default {
         },
         overrides: {
           getVars(category) {
-            return {
-              Behavior: [this.getTitleValue('NAME')]
-            };
+            return {};
           },
           callType_: 'gamelab_behavior_get'
         }

--- a/apps/test/unit/blockUtilsTest.js
+++ b/apps/test/unit/blockUtilsTest.js
@@ -179,7 +179,7 @@ describe('block utils', () => {
             <arg name="this sprite" type="Sprite"/>
             <description/>
           </mutation>
-          <title name="NAME">acting</title>
+          <title name="NAME" id="acting">acting</title>
           <statement name="STACK"/>
         </block>
         <block type="behavior_definition" deletable="false" movable="false" editable="false">
@@ -187,7 +187,7 @@ describe('block utils', () => {
             <arg name="this sprite" type="Sprite"/>
             <description/>
           </mutation>
-          <title name="NAME">acting2</title>
+          <title name="NAME" id="acting2">acting2</title>
           <statement name="STACK"/>
         </block>
       `;
@@ -202,7 +202,7 @@ describe('block utils', () => {
               <arg name="this sprite" type="Sprite"/>
               <description/>
             </mutation>
-            <title name="NAME">acting</title>
+            <title name="NAME" id="acting">acting</title>
             <statement name="STACK"/>
           </block>
           <block type="behavior_definition" deletable="false" movable="false" editable="false">
@@ -210,7 +210,7 @@ describe('block utils', () => {
               <arg name="this sprite" type="Sprite"/>
               <description/>
             </mutation>
-            <title name="NAME">acting2</title>
+            <title name="NAME" id="acting2">acting2</title>
             <statement name="STACK"/>
           </block>
         </xml>
@@ -227,7 +227,7 @@ describe('block utils', () => {
               <arg name="this sprite" type="Sprite"/>
               <description/>
             </mutation>
-            <title name="NAME">acting</title>
+            <title name="NAME" id="acting">acting</title>
             <statement name="STACK"/>
           </block>
           <block type="behavior_definition" deletable="false" movable="false" editable="false">
@@ -235,7 +235,7 @@ describe('block utils', () => {
               <arg name="this sprite" type="Sprite"/>
               <description/>
             </mutation>
-            <title name="NAME">acting2</title>
+            <title name="NAME" id="acting2">acting2</title>
             <statement name="STACK"/>
           </block>
         </xml>
@@ -247,7 +247,7 @@ describe('block utils', () => {
             <arg name="this sprite" type="Sprite"/>
             <description/>
           </mutation>
-          <title name="NAME">acting</title>
+          <title name="NAME" id="acting">acting</title>
           <statement name="STACK"/>
         </block>
         <block type="behavior_definition" deletable="false" movable="false" editable="false">
@@ -255,7 +255,7 @@ describe('block utils', () => {
             <arg name="this sprite" type="Sprite"/>
             <description/>
           </mutation>
-          <title name="NAME">acting2</title>
+          <title name="NAME" id="acting2">acting2</title>
           <statement name="STACK">
             <block type="variables_set" inline="false">
               <title name="VAR">someVar</title>
@@ -283,7 +283,7 @@ describe('block utils', () => {
               <arg name="this sprite" type="Sprite"/>
               <description/>
             </mutation>
-            <title name="NAME">acting2</title>
+            <title name="NAME" id="acting2">acting2</title>
             <statement name="STACK"/>
           </block>
         </xml>
@@ -295,7 +295,7 @@ describe('block utils', () => {
             <arg name="this sprite" type="Sprite"/>
             <description/>
           </mutation>
-          <title name="NAME">acting</title>
+          <title name="NAME" id="acting">acting</title>
           <statement name="STACK"/>
         </block>
         <block type="behavior_definition" deletable="false" movable="false" editable="false">
@@ -303,7 +303,7 @@ describe('block utils', () => {
             <arg name="this sprite" type="Sprite"/>
             <description/>
           </mutation>
-          <title name="NAME">acting2</title>
+          <title name="NAME" id="acting2">acting2</title>
           <statement name="STACK">
             <block type="variables_set" inline="false">
               <title name="VAR">someVar</title>
@@ -327,7 +327,7 @@ describe('block utils', () => {
               <arg name="this sprite" type="Sprite"/>
               <description/>
             </mutation>
-            <title name="NAME">acting2</title>
+            <title name="NAME" id="acting2">acting2</title>
             <statement name="STACK"/>
           </block>
           <block type="behavior_definition" deletable="false" movable="false" editable="false">
@@ -335,7 +335,7 @@ describe('block utils', () => {
               <arg name="this sprite" type="Sprite"/>
               <description/>
             </mutation>
-            <title name="NAME">acting</title>
+            <title name="NAME" id="acting">acting</title>
             <statement name="STACK"/>
           </block>
         </xml>

--- a/apps/yarn.lock
+++ b/apps/yarn.lock
@@ -1526,10 +1526,10 @@
   version "0.2.1"
   resolved "https://registry.yarnpkg.com/@code-dot-org/artist/-/artist-0.2.1.tgz#fcfe7ea5cfb3f19ddb6b912e70e922ba4b7ef0b1"
 
-"@code-dot-org/blockly@3.5.30":
-  version "3.5.30"
-  resolved "https://registry.yarnpkg.com/@code-dot-org/blockly/-/blockly-3.5.30.tgz#5ed3d3b48da28907d3b116ef9f8ef701d0c8acdb"
-  integrity sha512-atYxVM4710hwY+7mPr4kC9xO7bXvTCeeEV5LSZN+QP93iUzYdjUv1PLCnGJ2tI3cFKSQ08VNKtsUM79uoTVbeQ==
+"@code-dot-org/blockly@3.5.31":
+  version "3.5.31"
+  resolved "https://registry.yarnpkg.com/@code-dot-org/blockly/-/blockly-3.5.31.tgz#97fe2e63d2480b51fe9d6b5f0c0ed48344e8dc47"
+  integrity sha512-cs5iaYb9npNt048gmC5LJm10TxxQlcTg6++CB5N775l7hgOs8lhqpSOaVvdCfFRByiL2l/SPJypgFLkVXYriFA==
 
 "@code-dot-org/bramble@0.1.26":
   version "0.1.26"

--- a/dashboard/app/models/shared_blockly_function.rb
+++ b/dashboard/app/models/shared_blockly_function.rb
@@ -53,7 +53,7 @@ class SharedBlocklyFunction < ApplicationRecord
           end
           xml.description description
         end
-        xml.title(name, name: 'NAME')
+        xml.title(name, name: 'NAME', id: name)
         xml.statement(name: 'STACK') do
           xml << stack.gsub(/\n */, '')
         end

--- a/dashboard/config/shared_functions/GamelabJr/driving with arrow keys.xml
+++ b/dashboard/config/shared_functions/GamelabJr/driving with arrow keys.xml
@@ -4,7 +4,7 @@
     <arg name="this sprite" type="Sprite"/>
     <description/>
   </mutation>
-  <title name="NAME">driving with arrow keys</title>
+  <title name="NAME" id="driving with arrow keys">driving with arrow keys</title>
   <statement name="STACK">
     <block type="controls_if">
       <value name="IF0">

--- a/dashboard/config/shared_functions/GamelabJr/growing.xml
+++ b/dashboard/config/shared_functions/GamelabJr/growing.xml
@@ -4,7 +4,7 @@
     <arg name="this sprite" type="Sprite"/>
     <description>change the size of a sprite</description>
   </mutation>
-  <title name="NAME">growing</title>
+  <title name="NAME" id="growing">growing</title>
   <statement name="STACK">
     <block type="gamelab_changePropBy">
       <title name="PROPERTY">"scale"</title>

--- a/dashboard/config/shared_functions/GamelabJr/jittering.xml
+++ b/dashboard/config/shared_functions/GamelabJr/jittering.xml
@@ -4,7 +4,7 @@
     <arg name="this sprite" type="Sprite"/>
     <description>randomly change the size of a sprite</description>
   </mutation>
-  <title name="NAME">jittering</title>
+  <title name="NAME" id="jittering">jittering</title>
   <statement name="STACK">
     <block type="gamelab_changePropBy">
       <title name="PROPERTY">"scale"</title>

--- a/dashboard/config/shared_functions/GamelabJr/moving east.xml
+++ b/dashboard/config/shared_functions/GamelabJr/moving east.xml
@@ -4,7 +4,7 @@
     <arg name="this sprite" type="Sprite"/>
     <description>move a sprite to the right across the screen</description>
   </mutation>
-  <title name="NAME">moving east</title>
+  <title name="NAME" id="moving east">moving east</title>
   <statement name="STACK">
     <block type="gamelab_moveInDirection">
       <title name="DIRECTION">"East"</title>

--- a/dashboard/config/shared_functions/GamelabJr/moving north.xml
+++ b/dashboard/config/shared_functions/GamelabJr/moving north.xml
@@ -4,7 +4,7 @@
     <arg name="this sprite" type="Sprite"/>
     <description>move a sprite upwards across the screen</description>
   </mutation>
-  <title name="NAME">moving north</title>
+  <title name="NAME" id="moving north">moving north</title>
   <statement name="STACK">
     <block type="gamelab_moveInDirection">
       <title name="DIRECTION">"North"</title>

--- a/dashboard/config/shared_functions/GamelabJr/moving south.xml
+++ b/dashboard/config/shared_functions/GamelabJr/moving south.xml
@@ -4,7 +4,7 @@
     <arg name="this sprite" type="Sprite"/>
     <description>move a sprite downwards across the screen</description>
   </mutation>
-  <title name="NAME">moving south</title>
+  <title name="NAME" id="moving south">moving south</title>
   <statement name="STACK">
     <block type="gamelab_moveInDirection">
       <title name="DIRECTION">"South"</title>

--- a/dashboard/config/shared_functions/GamelabJr/moving west.xml
+++ b/dashboard/config/shared_functions/GamelabJr/moving west.xml
@@ -4,7 +4,7 @@
     <arg name="this sprite" type="Sprite"/>
     <description>move a sprite to the left across the screen</description>
   </mutation>
-  <title name="NAME">moving west</title>
+  <title name="NAME" id="moving west">moving west</title>
   <statement name="STACK">
     <block type="gamelab_moveInDirection">
       <title name="DIRECTION">"West"</title>

--- a/dashboard/config/shared_functions/GamelabJr/moving with arrow keys.xml
+++ b/dashboard/config/shared_functions/GamelabJr/moving with arrow keys.xml
@@ -4,7 +4,7 @@
     <arg name="this sprite" type="Sprite"/>
     <description/>
   </mutation>
-  <title name="NAME">moving with arrow keys</title>
+  <title name="NAME" id="moving with arrow keys">moving with arrow keys</title>
   <statement name="STACK">
     <block type="controls_if">
       <value name="IF0">

--- a/dashboard/config/shared_functions/GamelabJr/patrolling.xml
+++ b/dashboard/config/shared_functions/GamelabJr/patrolling.xml
@@ -4,7 +4,7 @@
     <arg name="this sprite" type="Sprite"/>
     <description>move a sprite across the screen, reversing direction if it touches the edges</description>
   </mutation>
-  <title name="NAME">patrolling</title>
+  <title name="NAME" id="patrolling">patrolling</title>
   <statement name="STACK">
     <block type="gamelab_moveForward">
       <value name="SPRITE">

--- a/dashboard/config/shared_functions/GamelabJr/shrinking.xml
+++ b/dashboard/config/shared_functions/GamelabJr/shrinking.xml
@@ -4,7 +4,7 @@
     <arg name="this sprite" type="Sprite"/>
     <description>change the size of a sprite</description>
   </mutation>
-  <title name="NAME">shrinking</title>
+  <title name="NAME" id="shrinking">shrinking</title>
   <statement name="STACK">
     <block type="gamelab_changePropBy">
       <title name="PROPERTY">"scale"</title>

--- a/dashboard/config/shared_functions/GamelabJr/spinning left.xml
+++ b/dashboard/config/shared_functions/GamelabJr/spinning left.xml
@@ -4,7 +4,7 @@
     <arg name="this sprite" type="Sprite"/>
     <description>rotate a sprite to its left</description>
   </mutation>
-  <title name="NAME">spinning left</title>
+  <title name="NAME" id="spinning left">spinning left</title>
   <statement name="STACK">
     <block type="gamelab_turn">
       <title name="DIRECTION">"left"</title>

--- a/dashboard/config/shared_functions/GamelabJr/spinning right.xml
+++ b/dashboard/config/shared_functions/GamelabJr/spinning right.xml
@@ -4,7 +4,7 @@
     <arg name="this sprite" type="Sprite"/>
     <description>rotate a sprite to its right</description>
   </mutation>
-  <title name="NAME">spinning right</title>
+  <title name="NAME" id="spinning right">spinning right</title>
   <statement name="STACK">
     <block type="gamelab_turn">
       <title name="DIRECTION">"right"</title>

--- a/dashboard/config/shared_functions/GamelabJr/swimming left and right.xml
+++ b/dashboard/config/shared_functions/GamelabJr/swimming left and right.xml
@@ -4,7 +4,7 @@
     <arg name="this sprite" type="Sprite"/>
     <description>move a sprite horizontally, reversing direction if it touches the edges of the screen</description>
   </mutation>
-  <title name="NAME">swimming left and right</title>
+  <title name="NAME" id="swimming left and right">swimming left and right</title>
   <statement name="STACK">
     <block type="controls_if">
       <mutation elseif="1"/>

--- a/dashboard/config/shared_functions/GamelabJr/wandering.xml
+++ b/dashboard/config/shared_functions/GamelabJr/wandering.xml
@@ -4,7 +4,7 @@
     <arg name="this sprite" type="Sprite"/>
     <description>move a sprite, changing its direction randomly</description>
   </mutation>
-  <title name="NAME">wandering</title>
+  <title name="NAME" id="wandering">wandering</title>
   <statement name="STACK">
     <block type="controls_if">
       <value name="IF0">

--- a/dashboard/config/shared_functions/Mikelab/chasing.xml
+++ b/dashboard/config/shared_functions/Mikelab/chasing.xml
@@ -5,7 +5,7 @@
     <arg name="target" type="Sprite"/>
     <description/>
   </mutation>
-  <title name="NAME">chasing</title>
+  <title name="NAME" id="chasing">chasing</title>
   <statement name="STACK">
     <block type="gamelab_moveToward">
       <value name="SPRITE">

--- a/dashboard/config/shared_functions/RyanLab/acting goofy.xml
+++ b/dashboard/config/shared_functions/RyanLab/acting goofy.xml
@@ -4,6 +4,6 @@
     <arg name="this sprite" type="Sprite"/>
     <description/>
   </mutation>
-  <title name="NAME">acting goofy</title>
+  <title name="NAME" id="acting goofy">acting goofy</title>
   <statement name="STACK"/>
 </block>


### PR DESCRIPTION
*behaviors* refer to all the blocks in Sprite lab that look like this: 
![image](https://user-images.githubusercontent.com/8787187/100030972-79bbb600-2da9-11eb-858b-47ed9c25cec3.png).
*Shared functions* refer to all the behaviors defined in [levelbuilder](https://levelbuilder-studio.code.org/functions). There is a checkbox on levelbuilder that determines whether all of the shared functions will be pulled into the toolbox for a given level.

Depends on https://github.com/code-dot-org/blockly/pull/254

This will let us translate behaviors and fix the issue we had where renaming a behavior can break the project, which led to us removing the edit button from behaviors on levels with uncategorized toolboxes:
![image](https://user-images.githubusercontent.com/8787187/100030796-2e090c80-2da9-11eb-8573-5cb705734b8f.png)

This PR does not actually translate the behavior blocks nor does it re-enable behavior editing on those levels.

What it does is:
1. Add the id to the title field in each shared behavior- https://github.com/code-dot-org/code-dot-org/pull/37983/commits/01c707dc3a4c1725ec9de129cca72e903ef422e8
2. Change how we look up functions when we add shared functions. We used to look up by name, and only add the shared function if it wasn't already present. So if you rename `growing` -> `my growing`, the next time you load the toolbox, you will see both `growing` and `my growing`. Similarly, if you switch language, you will have all the shared functions in *both* languages. This is why we currently don't translate any behaviors. With this change, if you change the name of `growing` to `my growing` (or switch to another language), the underlying id doesn't change, so the next time you load the toolbox, you won't see the original `growing` behavior, you will *only* see `my growing` - https://github.com/code-dot-org/code-dot-org/pull/37983/commits/e62498f67864f667ab96d60eb3f68ecddc83d3a1
3. Don't register behaviors as variables in generated code. - https://github.com/code-dot-org/code-dot-org/pull/37983/commits/d152eef78e37dfca981a795b08c9b9784164cf6e
Before, we added the behavior name to the global namespace, which results in declaring vars at the top of the code like this: 
![image](https://user-images.githubusercontent.com/8787187/100031375-58a79500-2daa-11eb-9296-0a2f569cf0f0.png)
but then the actual function name would be `shrinking2` (for example) because `shrinking` had already been declared 
![image](https://user-images.githubusercontent.com/8787187/100031406-6c52fb80-2daa-11eb-9f84-09c34f0a40a4.png)
Now we don't have the variables declared, and the functions are named as expected: 
![image](https://user-images.githubusercontent.com/8787187/100031458-8bea2400-2daa-11eb-9864-9b16bc9af249.png)
4. Generate code and find the function definition for the modal editor using the title's id, not value. Now that we have the id field, we need to actually use it :) https://github.com/code-dot-org/code-dot-org/pull/37983/commits/bae56c0cf509a4f37dc129826c5fec359dd0c33e and https://github.com/code-dot-org/code-dot-org/pull/37983/commits/3a4f41f007ddb70bcab7404ac8cdbbd70c4a2a23

Next steps:
1. Change existing XML in levels to make sure behaviors have IDs
2. This will unblock the FND work to actually translate behaviors
3. Re-enable behavior editing on levels without categorized toolboxes

## Links

<!--
  Any relevant links to external resources; ie, specification documents, jira
  items, related PRs, honeybadger errors, etc
-->
- [jira](https://codedotorg.atlassian.net/browse/STAR-1345)

## Testing story

<!--
  Does your change include appropriate tests?

  If so, please describe how the tests included in this PR are sufficient

  If not, please explain why this change does not need to be tested.
-->

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
