### PR TITLE
assert_nil instead of assert_equal nil

### DIFF
--- a/dashboard/test/controllers/api_controller_test.rb
+++ b/dashboard/test/controllers/api_controller_test.rb
@@ -621,7 +621,7 @@ class ApiControllerTest < ActionController::TestCase
     result = {"status" => "perfect", "result" => 100}
     assert_response :success
     body = JSON.parse(response.body)
-    assert_equal nil, body['disableSocialShare']
+    assert_nil body['disableSocialShare']
     assert_equal result, body['progress'][level.id.to_s]
     assert_equal 'level source', body['lastAttempt']['source']
 

--- a/dashboard/test/controllers/pairings_controller_test.rb
+++ b/dashboard/test/controllers/pairings_controller_test.rb
@@ -105,6 +105,6 @@ class PairingsControllerTest < ActionController::TestCase
 
     assert_response :success
     assert_equal [], session[:pairings]
-    assert_equal nil, session[:pairpairing_section_idngs]
+    assert_nil session[:pairpairing_section_idngs]
   end
 end

--- a/dashboard/test/models/user_test.rb
+++ b/dashboard/test/models/user_test.rb
@@ -1157,7 +1157,7 @@ class UserTest < ActiveSupport::TestCase
     user_level = UserLevel.find_by(user: user, script: script_level.script, level: script_level.level)
     assert_equal 100, user_level.best_result
     partner_level = UserLevel.find_by(user: partner, script: script_level.script, level: script_level.level)
-    assert_equal nil, partner_level
+    assert_nil partner_level
   end
 
   test 'track_level_progress records progress for partner when pairing' do

--- a/lib/test/cdo/contact_rollups/test_pardot_v2.rb
+++ b/lib/test/cdo/contact_rollups/test_pardot_v2.rb
@@ -15,7 +15,7 @@ class PardotV2Test < Minitest::Test
     result = PardotV2.retrieve_prospects(0, ['id']) {|mappings| yielded_result = mappings}
 
     assert_equal 0, result
-    assert_equal nil, yielded_result
+    assert_nil yielded_result
   end
 
   def test_retrieve_prospects_with_result


### PR DESCRIPTION
A tiny update... Drone spews out warnings related to tests that use `assert_equal nil` rather than `assert_nil`.  AFAIK these warnings are harmless and we don't have intention of doing any updates that would actually cause tests to break (at least not soon?). However, I tend to search for the output for "fail" when figuring out why Drone tests failed, and it would be nice to clear up some of the cluttered warnings. 
 
![Screen Shot 2020-11-24 at 10 15 10 AM](https://user-images.githubusercontent.com/12300669/100117387-bdaec980-2e42-11eb-8b35-522ae71d26bc.png)
