### PR TITLE
Add teacher_id index to teacher_feedbacks table

### DIFF
--- a/dashboard/db/migrate/20201124184316_add_index_to_teacher_feedbacks.rb
+++ b/dashboard/db/migrate/20201124184316_add_index_to_teacher_feedbacks.rb
@@ -1,0 +1,5 @@
+class AddIndexToTeacherFeedbacks < ActiveRecord::Migration[5.2]
+  def change
+    add_index :teacher_feedbacks, :teacher_id
+  end
+end

--- a/dashboard/db/schema.rb
+++ b/dashboard/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_11_13_054822) do
+ActiveRecord::Schema.define(version: 2020_11_24_184316) do
 
   create_table "activities", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci", force: :cascade do |t|
     t.integer "user_id"
@@ -1598,6 +1598,7 @@ ActiveRecord::Schema.define(version: 2020_11_13_054822) do
     t.integer "script_level_id", null: false
     t.datetime "seen_on_feedback_page_at"
     t.index ["student_id", "level_id", "teacher_id"], name: "index_feedback_on_student_and_level_and_teacher_id"
+    t.index ["teacher_id"], name: "index_teacher_feedbacks_on_teacher_id"
   end
 
   create_table "teacher_profiles", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci", force: :cascade do |t|


### PR DESCRIPTION
Improve query for `User#teacher_feedbacks` association, which is used (at least) by `RegistrationsController#destroy_users` (via its implicit dependent-destroy on the `User` model).

Explain plan for association in Rails console (using #31760) - note `[NO INDEX]` on `TeacherFeedback Load`:

```
[development] dashboard > user.teacher_feedbacks.explain
  TeacherFeedback Load [NO INDEX] (0.4ms)  SELECT `teacher_feedbacks`.* FROM `teacher_feedbacks` WHERE `teacher_feedbacks`.`deleted_at` IS NULL AND `teacher_feedbacks`.`teacher_id` = 1
=> EXPLAIN for: SELECT `teacher_feedbacks`.* FROM `teacher_feedbacks` WHERE `teacher_feedbacks`.`deleted_at` IS NULL AND `teacher_feedbacks`.`teacher_id` = 1
+----+-------------+-------------------+------------+------+---------------+------+---------+------+------+----------+-------------+
| id | select_type | table             | partitions | type | possible_keys | key  | key_len | ref  | rows | filtered | Extra       |
+----+-------------+-------------------+------------+------+---------------+------+---------+------+------+----------+-------------+
|  1 | SIMPLE      | teacher_feedbacks | NULL       | ALL  | NULL          | NULL | NULL    | NULL |    1 |    100.0 | Using where |
+----+-------------+-------------------+------------+------+---------------+------+---------+------+------+----------+-------------+
```

Explain plan after index added:
```
[development] dashboard > user.teacher_feedbacks.explain
  TeacherFeedback Load (6.3ms)  SELECT `teacher_feedbacks`.* FROM `teacher_feedbacks` WHERE `teacher_feedbacks`.`deleted_at` IS NULL AND `teacher_feedbacks`.`teacher_id` = 1
=> EXPLAIN for: SELECT `teacher_feedbacks`.* FROM `teacher_feedbacks` WHERE `teacher_feedbacks`.`deleted_at` IS NULL AND `teacher_feedbacks`.`teacher_id` = 1
+----+-------------+-------------------+------------+------+---------------------------------------+---------------------------------------+---------+-------+------+----------+-------------+
| id | select_type | table             | partitions | type | possible_keys                         | key                                   | key_len | ref   | rows | filtered | Extra       |
+----+-------------+-------------------+------------+------+---------------------------------------+---------------------------------------+---------+-------+------+----------+-------------+
|  1 | SIMPLE      | teacher_feedbacks | NULL       | ref  | index_teacher_feedbacks_on_teacher_id | index_teacher_feedbacks_on_teacher_id | 4       | const |    1 |    100.0 | Using where |
+----+-------------+-------------------+------------+------+---------------------------------------+---------------------------------------+---------+-------+------+----------+-------------+
```


Test adding index on a production clone took about 9 seconds, which should be quick enough to apply without any special attention:

```
mysql> alter table `teacher_feedbacks` add index `index_feedback_on_teacher_id` (`teacher_id`);
Query OK, 0 rows affected (9.17 sec)
Records: 0  Duplicates: 0  Warnings: 0
```