### PR TITLE
Order activity sections by position

### DIFF
--- a/dashboard/app/models/lesson_activity.rb
+++ b/dashboard/app/models/lesson_activity.rb
@@ -25,7 +25,7 @@ class LessonActivity < ApplicationRecord
   include SerializedProperties
 
   belongs_to :lesson
-  has_many :activity_sections, dependent: :destroy
+  has_many :activity_sections, -> {order(:position)}, dependent: :destroy
 
   serialized_attrs %w(
     name


### PR DESCRIPTION
I'm running into this bug while working on the import script as it doesn't guarantee saving activity sections in the correct order. 

This fix may overlap with other tickets so if someone else is already looking at this I can close this PR!

<!-- ### Background -->
<!-- ### Privacy -->
<!--
1.	Does the Project involve the collection, use or sharing of new Personal Data?

2.	Does the Project involve a new or changed use or sharing of existing Personal Data?
-->
<!-- ### Security -->
<!--
Link to Jira Task where sensitive security issues are discussed privately.
-->
<!-- ### Caching -->
<!-- ### Deployment strategy -->
<!-- ### Future work -->

## Links

<!--
  Any relevant links to external resources; ie, specification documents, jira
  items, related PRs, honeybadger errors, etc
-->

- [spec]()
- [jira]()

## Testing story

<!--
  Does your change include appropriate tests?

  If so, please describe how the tests included in this PR are sufficient

  If not, please explain why this change does not need to be tested.
-->

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
