### PR TITLE
Change rerun command to run in background

### DIFF
--- a/dashboard/test/ui/test_status.haml
+++ b/dashboard/test/ui/test_status.haml
@@ -49,7 +49,7 @@
                 %td.status
                 %td.log-link
                 %td.rerun-command
-                  - rerun_command = "bundle exec ./runner.rb --html #{type == 'Eyes' ? '--eyes' : ''} -c #{browser} -f #{feature}"
+                  - rerun_command = "bundle exec ./runner.rb --html #{type == 'Eyes' ? '--eyes' : ''} -c #{browser} -f #{feature} &"
                   %button.copy-button{'data-clipboard-text': rerun_command}= "Copy Rerun Cmd"
       %div#help-text
         %p


### PR DESCRIPTION
Tiny change to the rerun command on the Eyes/UI test statuses page.
Adds `&` to the end of the command so that the test will run in the background. This makes it easier to re-run multiple tests, because you can just kick them all off at once instead of having to wait for each to finish.

<!--
  Does your change include appropriate tests?

  If so, please describe how the tests included in this PR are sufficient

  If not, please explain why this change does not need to be tested.
-->

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
