### PR TITLE
Don't copy CurriculumReference levels and best attempt at using code studio pullthrough

### DIFF
--- a/lib/cdo/lesson_import_helper.rb
+++ b/lib/cdo/lesson_import_helper.rb
@@ -129,7 +129,6 @@ module LessonImportHelper
         activity_section = create_basic_activity_section(match[:substring].strip)
       end
       next unless activity_section
-      puts "#{match[:type]} produced an empty activity section" if activity_section.name.blank? && activity_section.description.blank? && activity_section.tips.blank?
       activity_section.position = position
       position += 1
       activity_section.name = name

--- a/lib/cdo/lesson_import_helper.rb
+++ b/lib/cdo/lesson_import_helper.rb
@@ -189,6 +189,7 @@ module LessonImportHelper
     activity_sections = []
     current_progression_levels = []
     current_progression = nil
+    levels = levels.reject {|l| l.levels[0].type == 'CurriculumReference'}
     levels.each do |level|
       if current_progression.nil? || current_progression == level.progression
         current_progression = level.progression if current_progression.nil?

--- a/lib/cdo/lesson_import_helper.rb
+++ b/lib/cdo/lesson_import_helper.rb
@@ -27,8 +27,9 @@ module LessonImportHelper
     course_version_id = lesson.script&.get_course_version&.id
     raise unless course_version_id
 
+    lesson_levels = lesson.script_levels.reject {|l| l.levels[0].type == 'CurriculumReference'}
     if cb_lesson_data.empty?
-      lesson.lesson_activities = update_lockable_lesson(lesson.script_levels, lesson.id)
+      lesson.lesson_activities = update_lockable_lesson(lesson_levels, lesson.id)
       lesson.script_levels = []
     else
       lesson.name = cb_lesson_data['title']
@@ -40,7 +41,7 @@ module LessonImportHelper
       lesson.objectives = cb_lesson_data['objectives'].map do |o|
         Objective.new(description: o["name"])
       end
-      lesson.lesson_activities = create_lesson_activities(cb_lesson_data['activities'], lesson.script_levels, lesson.id)
+      lesson.lesson_activities = create_lesson_activities(cb_lesson_data['activities'], lesson_levels, lesson.id)
       lesson.resources = create_lesson_resources(cb_lesson_data['resources'], course_version_id)
       lesson.script_levels = []
     end
@@ -72,7 +73,7 @@ module LessonImportHelper
     end
   end
 
-  def self.create_activity_sections(activity_markdown)
+  def self.create_activity_sections(activity_markdown, lesson_activity_id, levels)
     # Find any special syntax, such as tips or remarks, and gather them.
     # TODO tips and remarks both show up in tip_matches. We filter out remarks
     # but we should try to do something a bit smarter here.
@@ -80,8 +81,9 @@ module LessonImportHelper
     tip_link_matches = find_tip_links(activity_markdown).map {|m| {index: activity_markdown.index(m[0]), type: 'tiplink', match: m, substring: m[0]}}
     remark_matches = find_remarks(activity_markdown).map {|m| {index: activity_markdown.index(m[0]), type: 'remark', match: m, substring: m[0]}}
     skippable_matches = find_skippable_syntax(activity_markdown).map {|m| {index: activity_markdown.index(m[0]), type: 'skippable', match: m, substring: m[0]}}
+    pullthrough_matches = find_code_studio_pullthrough(activity_markdown).map {|m| {index: activity_markdown.index(m[0]), type: 'pullthrough', match: m, substring: m[0]}}
     name_matches = find_activity_section_names(activity_markdown).map {|m| {index: activity_markdown.index(m[0]), type: 'name', match: m, substring: m[0]}}
-    matches = tip_matches + remark_matches + tip_link_matches + skippable_matches + name_matches
+    matches = tip_matches + remark_matches + tip_link_matches + skippable_matches + name_matches + pullthrough_matches
     sorted_matches = matches.sort_by {|m| m[:index]}
     return [ActivitySection.new(description: activity_markdown.strip, key: SecureRandom.uuid, position: 1)] if matches.empty?
 
@@ -111,15 +113,30 @@ module LessonImportHelper
         activity_section = create_activity_section_with_tip(match[:match], tip_match_map)
       elsif match[:type] == 'remark'
         activity_section = create_activity_section_with_remark(match[:match], tip_match_map)
+      elsif match[:type] == 'pullthrough'
+        next if levels.empty?
+        pullthrough_match = match[:match]
+        # If the syntax takes the form of [code-studio], [code-studio 1-<length>], or [code-studio 2-<length>],
+        # add the level activity sections here.
+        if pullthrough_match[1].blank? || ([1, 2].include?(pullthrough_match[1]) && levels.length == pullthrough_match[2].to_i)
+          level_sections = create_activity_sections_by_progression(levels, lesson_activity_id, position)
+          sections += sections
+          levels.clear
+          position += level_sections.length
+        end
+        next
       else
         activity_section = create_basic_activity_section(match[:substring].strip)
       end
       next unless activity_section
+      puts "#{match[:type]} produced an empty activity section" if activity_section.name.blank? && activity_section.description.blank? && activity_section.tips.blank?
       activity_section.position = position
       position += 1
       activity_section.name = name
       name = ''
       activity_section.key ||= SecureRandom.uuid
+      activity_section.lesson_activity_id = lesson_activity_id
+      activity_section.save!
       sections = sections.push(activity_section)
     end
 
@@ -150,7 +167,7 @@ module LessonImportHelper
       lesson_activity.position = i
       lesson_activity.save!
       lesson_activity.reload
-      lesson_activity.activity_sections = create_activity_sections(a['content'])
+      lesson_activity.activity_sections = create_activity_sections(a['content'], lesson_activity.id, levels)
       lesson_activity
     end
 
@@ -167,7 +184,12 @@ module LessonImportHelper
     # Regex explanation: looks for
     #   - code studio pullthrough, i.e. "[code-studio]", "[code-studio 17]", "[code-studio 1-5]"
     #   - guide syntax, i.e. "[guide]" and "[/guide]"
-    regex = /\[code-studio[\d \-]*\]|\[\/?guide\]/
+    regex = /\[\/?guide\]/
+    markdown.to_enum(:scan, regex).map {Regexp.last_match}
+  end
+
+  def self.find_code_studio_pullthrough(markdown)
+    regex = /\[code-studio *(\d*)-?(\d*)\]/
     markdown.to_enum(:scan, regex).map {Regexp.last_match}
   end
 
@@ -186,17 +208,21 @@ module LessonImportHelper
     lesson_activity.position = position
     lesson_activity.save!
     lesson_activity.reload
+    lesson_activity.activity_sections = create_activity_sections_by_progression(levels, lesson_activity.id)
+    lesson_activity
+  end
+
+  def self.create_activity_sections_by_progression(levels, lesson_activity_id, position_offset=1)
     activity_sections = []
     current_progression_levels = []
     current_progression = nil
-    levels = levels.reject {|l| l.levels[0].type == 'CurriculumReference'}
     levels.each do |level|
       if current_progression.nil? || current_progression == level.progression
         current_progression = level.progression if current_progression.nil?
         current_progression_levels.push(level)
       else
-        section = create_activity_section_with_levels(current_progression_levels, lesson_activity.id, current_progression)
-        section.position = activity_sections.length + 1
+        section = create_activity_section_with_levels(current_progression_levels, lesson_activity_id, current_progression)
+        section.position = activity_sections.length + position_offset
         section.save!
         activity_sections.push(section)
         current_progression_levels = [level]
@@ -204,14 +230,13 @@ module LessonImportHelper
       end
     end
     unless current_progression_levels.empty?
-      section = create_activity_section_with_levels(current_progression_levels, lesson_activity.id, current_progression)
+      section = create_activity_section_with_levels(current_progression_levels, lesson_activity_id, current_progression)
       section.name = current_progression
       section.position = activity_sections.length + 1
       section.save!
       activity_sections.push(section)
     end
-    lesson_activity.activity_sections = activity_sections
-    lesson_activity
+    activity_sections
   end
 
   def self.create_activity_section_with_levels(script_levels, lesson_activity_id, progression_name="")
@@ -340,7 +365,8 @@ module LessonImportHelper
     return [{index: 0, type: 'markdown', substring: markdown}] if existing_matches.empty?
     matches = []
     unless existing_matches.first[:index] == 0
-      matches.push({index: 0, type: 'markdown', substring: markdown[0...existing_matches[0][:index]]})
+      substring = markdown[0...existing_matches[0][:index]].strip
+      matches.push({index: 0, type: 'markdown', substring: substring}) unless substring.empty?
     end
     (0...existing_matches.length).each do |i|
       matches.push(existing_matches[i])
@@ -350,7 +376,8 @@ module LessonImportHelper
       matches.push({index: start_index, type: 'markdown', substring: substring}) unless substring.empty?
     end
     unless matches.last[:index] + matches.last[:substring].length == markdown.length
-      matches.push({index: 0, type: 'markdown', substring: markdown[existing_matches.last[:index] + existing_matches.last[:substring].length...markdown.length]})
+      substring = markdown[existing_matches.last[:index] + existing_matches.last[:substring].length...markdown.length].strip
+      matches.push({index: 0, type: 'markdown', substring: substring}) unless substring.empty?
     end
     matches
   end

--- a/lib/cdo/lesson_import_helper.rb
+++ b/lib/cdo/lesson_import_helper.rb
@@ -120,7 +120,7 @@ module LessonImportHelper
         # add the level activity sections here.
         if pullthrough_match[1].blank? || ([1, 2].include?(pullthrough_match[1]) && levels.length == pullthrough_match[2].to_i)
           level_sections = create_activity_sections_by_progression(levels, lesson_activity_id, position)
-          sections += sections
+          sections += level_sections
           levels.clear
           position += level_sections.length
         end


### PR DESCRIPTION
This PR address [PLAT-546](https://codedotorg.atlassian.net/browse/PLAT-546) and [PLAT-547](https://codedotorg.atlassian.net/browse/PLAT-547)
- Removes CurriculumReference (lesson overview) levels on import
- Uses the code studio pullthrough to place the activity sections if it follows one of these patterns:
  - `[code-studio]`
  - `[code-studio 1-<num levels>]`
  - `[code-studio 2-<num levels>]` (used extensively in CSD)
- Fixes a bug where empty activity sections were created

Example lesson plan with the levels in the main activity:
![Screenshot 2020-11-24 at 4 02 15 PM](https://user-images.githubusercontent.com/46464143/100165590-80acfc00-2e6f-11eb-9c05-4931c1b4c631.png)


<!-- ### Background -->
<!-- ### Privacy -->
<!--
1.	Does the Project involve the collection, use or sharing of new Personal Data?

2.	Does the Project involve a new or changed use or sharing of existing Personal Data?
-->
<!-- ### Security -->
<!--
Link to Jira Task where sensitive security issues are discussed privately.
-->
<!-- ### Caching -->
<!-- ### Deployment strategy -->
<!-- ### Future work -->

## Links

<!--
  Any relevant links to external resources; ie, specification documents, jira
  items, related PRs, honeybadger errors, etc
-->

- [spec]()
- [jira]()

## Testing story

<!--
  Does your change include appropriate tests?

  If so, please describe how the tests included in this PR are sufficient

  If not, please explain why this change does not need to be tested.
-->

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
