### PR TITLE
Fix for audio issues when the same file is played multiple times

### DIFF
--- a/apps/src/Sound.js
+++ b/apps/src/Sound.js
@@ -77,9 +77,7 @@ Sound.prototype.play = function(options) {
       this.isPlayingCount--;
       if (this.isPlayingCount === 0) {
         this.isPlaying_ = false;
-        if (options.onEnded) {
-          options.onEnded();
-        }
+        options.onEnded && options.onEnded();
       }
     }.bind(this);
 

--- a/apps/src/Sound.js
+++ b/apps/src/Sound.js
@@ -33,7 +33,8 @@ export default function Sound(config, audioContext) {
   this.audioContext = audioContext;
   this.audioElement = null; // if HTML5 Audio
   this.reusableBuffer = null; // if Web Audio
-  this.playableBuffer = null; // if Web Audio
+  this.playableBuffers = []; // if Web Audio
+  this.isPlayingCount = 0; // if Web Audio
 
   /**
    * @private {boolean} Whether the sound is currently playing - sadly, neither
@@ -66,24 +67,27 @@ Sound.prototype.play = function(options) {
   }
 
   if (this.reusableBuffer) {
-    this.playableBuffer = this.newPlayableBufferSource(
-      this.reusableBuffer,
-      options
-    );
+    let index =
+      this.playableBuffers.push(
+        this.newPlayableBufferSource(this.reusableBuffer, options)
+      ) - 1;
 
     // Hook up on-ended callback, although browser support may be limited.
-    this.playableBuffer.onended = function() {
-      this.isPlaying_ = false;
-      if (options.onEnded) {
-        options.onEnded();
+    this.playableBuffers[index].onended = function() {
+      this.isPlayingCount--;
+      if (this.isPlayingCount === 0) {
+        this.isPlaying_ = false;
+        if (options.onEnded) {
+          options.onEnded();
+        }
       }
     }.bind(this);
 
     // Play sound, supporting older versions of the Web Audio API which used noteOn(Off).
-    if (this.playableBuffer.start) {
-      this.playableBuffer.start(0);
+    if (this.playableBuffers[index].start) {
+      this.playableBuffers[index].start(0);
     } else {
-      this.playableBuffer.noteOn(0);
+      this.playableBuffers[index].noteOn(0);
     }
     this.handlePlayStarted(options);
     return;
@@ -148,6 +152,7 @@ Sound.prototype.handleLoadFailed = function(status) {
 };
 
 Sound.prototype.handlePlayStarted = function(options) {
+  this.isPlayingCount++;
   this.isPlaying_ = true;
   if (options.callback) {
     options.callback(true);
@@ -156,13 +161,16 @@ Sound.prototype.handlePlayStarted = function(options) {
 
 Sound.prototype.stop = function() {
   try {
-    if (this.playableBuffer) {
-      if (this.playableBuffer.stop) {
-        // Newest web audio pseudo-standard.
-        this.playableBuffer.stop(0);
-      } else if (this.playableBuffer.noteOff) {
-        // Older web audio.
-        this.playableBuffer.noteOff(0);
+    if (this.playableBuffers.length) {
+      for (let index in this.playableBuffers) {
+        if (this.playableBuffers[index].stop) {
+          // Newest web audio pseudo-standard.
+          this.playableBuffers[index].stop(0);
+        } else if (this.playableBuffers[index].noteOff) {
+          // Older web audio.
+          this.playableBuffers[index].noteOff(0);
+        }
+        this.isPlayingCount--;
       }
     } else if (this.audioElement) {
       // html 5 audio.

--- a/apps/test/unit/SoundTest.js
+++ b/apps/test/unit/SoundTest.js
@@ -1,4 +1,4 @@
-import {expect} from '../util/deprecatedChai';
+import {expect} from '../util/reconfiguredChai';
 import Sound from '@cdo/apps/Sound';
 import sinon from 'sinon';
 
@@ -9,7 +9,8 @@ describe('Sound', () => {
     beforeEach(() => {
       sound = new Sound({});
     });
-    it('should call handlePlayFailed when there is no method to play audio', () => {
+
+    it('calls handlePlayFailed when there is no method to play audio', () => {
       expect(sound.audioElement).to.be.null;
       expect(sound.reusableBuffer).to.be.null;
       sinon.stub(sound, 'handlePlayFailed');
@@ -17,7 +18,8 @@ describe('Sound', () => {
       expect(sound.handlePlayFailed).to.have.been.calledOnce;
       sinon.restore();
     });
-    it('should use the reusable audio buffer when available', () => {
+
+    it('uses the reusable audio buffer when available', () => {
       let fakeStartMethod = sinon.fake();
       sound.reusableBuffer = sinon.fake();
       sinon
@@ -29,7 +31,8 @@ describe('Sound', () => {
       expect(fakeStartMethod).to.have.been.calledOnce;
       sinon.restore();
     });
-    it('should use HTML5 audio when there is no reusable audio buffer', () => {
+
+    it('uses HTML5 audio when there is no reusable audio buffer', () => {
       sound.audioElement = {
         addEventListener: sinon.fake(),
         removeEventListener: sinon.fake(),
@@ -41,6 +44,7 @@ describe('Sound', () => {
       sinon.restore();
     });
   });
+
   describe('playAfterLoad method', () => {
     it('sets config.playAfterLoad to true', () => {
       sound = new Sound({playAfterLoad: false});
@@ -49,55 +53,64 @@ describe('Sound', () => {
       expect(sound.config.playAfterLoad).to.be.true;
     });
   });
+
   describe('handlePlayFailed method', () => {
-    it('should call callback', () => {
+    it('calls callback', () => {
       let fakeCallback = sinon.fake();
       sound = new Sound({});
       sound.handlePlayFailed({callback: fakeCallback});
       expect(fakeCallback).to.have.been.calledOnce;
     });
   });
+
   describe('handleLoadFailed method', () => {
-    it('should call config.onPreloadError', () => {
+    it('calls config.onPreloadError', () => {
       sound = new Sound({onPreloadError: sinon.fake()});
       sound.handleLoadFailed();
       expect(sound.config.onPreloadError).to.have.been.calledOnce;
     });
-    it('should call config.playAfterLoadOptions.callback', () => {
+
+    it('calls config.playAfterLoadOptions.callback', () => {
       sound = new Sound({playAfterLoadOptions: {callback: sinon.fake()}});
       sound.handleLoadFailed();
       expect(sound.config.playAfterLoadOptions.callback).to.have.been
         .calledOnce;
     });
   });
+
   describe('handlePlayStarted method', () => {
     beforeEach(() => {
       sound = new Sound({});
     });
-    it('should increment isPlaying property', () => {
+
+    it('increments isPlaying property', () => {
       expect(sound.isPlayingCount).to.equal(0);
       sound.handlePlayStarted({});
       expect(sound.isPlayingCount).to.equal(1);
       sound.handlePlayStarted({});
       expect(sound.isPlayingCount).to.equal(2);
     });
-    it('should call callback when passed in options', () => {
+
+    it('calls callback when passed in options', () => {
       let fakeCallback = sinon.fake();
       sound.handlePlayStarted({callback: fakeCallback});
       expect(fakeCallback).to.have.been.calledOnce;
     });
   });
+
   describe('stop method', () => {
     beforeEach(() => {
       sound = new Sound({});
     });
-    it('should call stop on all playableBuffers', () => {
+
+    it('calls stop on all playableBuffers', () => {
       let fakeStopMethod = sinon.fake();
       sound.playableBuffers = [{stop: fakeStopMethod}, {stop: fakeStopMethod}];
       sound.stop();
       expect(fakeStopMethod).to.have.been.calledTwice;
     });
-    it('should call pause on audioElement', () => {
+
+    it('calls pause on audioElement', () => {
       let fakePauseMethod = sinon.fake();
       sound.audioElement = {pause: fakePauseMethod};
       sound.stop();
@@ -105,8 +118,9 @@ describe('Sound', () => {
       expect(sound.audioElement.currentTime).to.equal(0);
     });
   });
+
   describe('isPlaying method', () => {
-    it('should return value of isPlaying_ property', () => {
+    it('returns value of isPlaying_ property', () => {
       sound = new Sound({});
       sound.isPlaying_ = true;
       expect(sound.isPlaying()).to.equal.true;
@@ -114,8 +128,9 @@ describe('Sound', () => {
       expect(sound.isPlaying()).to.equal.false;
     });
   });
+
   describe('isLoaded method', () => {
-    it('should return value of isLoaded_ property', () => {
+    it('returns value of isLoaded_ property', () => {
       sound = new Sound({});
       sound.isLoaded_ = true;
       expect(sound.isLoaded()).to.equal.true;
@@ -123,8 +138,9 @@ describe('Sound', () => {
       expect(sound.isLoaded()).to.equal.false;
     });
   });
+
   describe('didLoadFail method', () => {
-    it('should return value of didLoadFail_ property', () => {
+    it('returns value of didLoadFail_ property', () => {
       sound = new Sound({});
       sound.didLoadFail_ = true;
       expect(sound.didLoadFail()).to.equal.true;
@@ -132,50 +148,59 @@ describe('Sound', () => {
       expect(sound.didLoadFail()).to.equal.false;
     });
   });
+
   describe('preloadFile method', () => {
     beforeEach(() => {
       sound = new Sound({});
       sinon.stub(sound, 'getPlayableFile').returns('/path/to/file');
     });
+
     afterEach(() => {
       sinon.restore();
     });
-    it('should call preloadViaWebAudio when AudioContext is provided', () => {
+
+    it('calls preloadViaWebAudio when AudioContext is provided', () => {
       sound.audioContext = new AudioContext();
       sinon.stub(sound, 'preloadViaWebAudio');
       sound.preloadFile();
       expect(sound.preloadViaWebAudio).to.have.been.calledOnce;
     });
-    it('should call preloadAudioElement when AudioContext is not provided', () => {
+
+    it('calls preloadAudioElement when AudioContext is not provided', () => {
       sound.audioContext = null;
       sinon.stub(sound, 'preloadAudioElement');
       sound.preloadFile();
       expect(sound.preloadAudioElement).to.have.been.calledOnce;
     });
   });
+
   describe('preloadBytes method', () => {
     beforeEach(() => {
       sound = new Sound({});
       sinon.stub(sound, 'getPlayableBytes').returns('bytes');
     });
+
     afterEach(() => {
       sinon.restore();
     });
-    it('should call audioContext.decodeAudioData when AudioContext is provided', () => {
+
+    it('calls audioContext.decodeAudioData when AudioContext is provided', () => {
       sound.audioContext = new AudioContext();
       sinon.stub(sound.audioContext, 'decodeAudioData');
       sound.preloadBytes();
       expect(sound.audioContext.decodeAudioData).to.have.been.calledOnce;
     });
-    it('should call preloadAudioElement when no AudioContext is provided', () => {
+
+    it('calls preloadAudioElement when no AudioContext is provided', () => {
       sound.audioContext = null;
       sinon.stub(sound, 'preloadAudioElement');
       sound.preloadBytes();
       expect(sound.preloadAudioElement).to.have.been.calledOnce;
     });
   });
+
   describe('getPlayableFile method', () => {
-    it('should return file location from config preferring mp3 > ogg > wav', () => {
+    it('returns file location from config preferring mp3 > ogg > wav', () => {
       let canPlayTypeStub = sinon.stub(window.Audio.prototype, 'canPlayType');
       let config = {mp3: 'file.mp3', ogg: 'file.ogg', wav: 'file.wav'};
       sound = new Sound(config);
@@ -192,19 +217,23 @@ describe('Sound', () => {
       sinon.restore();
     });
   });
+
   describe('getPlayableBytes method', () => {
     beforeEach(() => {
       sound = new Sound({});
       sound.config.bytes = 'bytes';
     });
+
     afterEach(() => {
       sinon.restore();
     });
-    it('should return this.config.bytes when browser can play audio/mp3', () => {
+
+    it('returns this.config.bytes when browser can play audio/mp3', () => {
       sinon.stub(window.Audio.prototype, 'canPlayType').returns(true);
       expect(sound.getPlayableBytes()).to.equal(sound.config.bytes);
     });
-    it('should return false when browser cannot play audio/mp3', () => {
+
+    it('returns false when browser cannot play audio/mp3', () => {
       sinon.stub(window.Audio.prototype, 'canPlayType').returns(false);
       expect(sound.getPlayableBytes()).to.equal(false);
     });

--- a/apps/test/unit/SoundTest.js
+++ b/apps/test/unit/SoundTest.js
@@ -1,0 +1,212 @@
+import {expect} from '../util/deprecatedChai';
+import Sound from '@cdo/apps/Sound';
+import sinon from 'sinon';
+
+describe('Sound', () => {
+  let sound;
+
+  describe('play method', () => {
+    beforeEach(() => {
+      sound = new Sound({});
+    });
+    it('should call handlePlayFailed when there is no method to play audio', () => {
+      expect(sound.audioElement).to.be.null;
+      expect(sound.reusableBuffer).to.be.null;
+      sinon.stub(sound, 'handlePlayFailed');
+      sound.play();
+      expect(sound.handlePlayFailed).to.have.been.calledOnce;
+      sinon.restore();
+    });
+    it('should use the reusable audio buffer when available', () => {
+      let fakeStartMethod = sinon.fake();
+      sound.reusableBuffer = sinon.fake();
+      sinon
+        .stub(sound, 'newPlayableBufferSource')
+        .returns({start: fakeStartMethod});
+      sound.play();
+      expect(sound.newPlayableBufferSource).to.have.been.calledOnce;
+      expect(sound.playableBuffers).to.have.length(1);
+      expect(fakeStartMethod).to.have.been.calledOnce;
+      sinon.restore();
+    });
+    it('should use HTML5 audio when there is no reusable audio buffer', () => {
+      sound.audioElement = {
+        addEventListener: sinon.fake(),
+        removeEventListener: sinon.fake(),
+        play: sinon.fake()
+      };
+      expect(sound.reusableBuffer).to.be.null;
+      sound.play();
+      expect(sound.audioElement.play).to.have.been.calledOnce;
+      sinon.restore();
+    });
+  });
+  describe('playAfterLoad method', () => {
+    it('sets config.playAfterLoad to true', () => {
+      sound = new Sound({playAfterLoad: false});
+      expect(sound.config.playAfterLoad).to.be.false;
+      sound.playAfterLoad();
+      expect(sound.config.playAfterLoad).to.be.true;
+    });
+  });
+  describe('handlePlayFailed method', () => {
+    it('should call callback', () => {
+      let fakeCallback = sinon.fake();
+      sound = new Sound({});
+      sound.handlePlayFailed({callback: fakeCallback});
+      expect(fakeCallback).to.have.been.calledOnce;
+    });
+  });
+  describe('handleLoadFailed method', () => {
+    it('should call config.onPreloadError', () => {
+      sound = new Sound({onPreloadError: sinon.fake()});
+      sound.handleLoadFailed();
+      expect(sound.config.onPreloadError).to.have.been.calledOnce;
+    });
+    it('should call config.playAfterLoadOptions.callback', () => {
+      sound = new Sound({playAfterLoadOptions: {callback: sinon.fake()}});
+      sound.handleLoadFailed();
+      expect(sound.config.playAfterLoadOptions.callback).to.have.been
+        .calledOnce;
+    });
+  });
+  describe('handlePlayStarted method', () => {
+    beforeEach(() => {
+      sound = new Sound({});
+    });
+    it('should increment isPlaying property', () => {
+      expect(sound.isPlayingCount).to.equal(0);
+      sound.handlePlayStarted({});
+      expect(sound.isPlayingCount).to.equal(1);
+      sound.handlePlayStarted({});
+      expect(sound.isPlayingCount).to.equal(2);
+    });
+    it('should call callback when passed in options', () => {
+      let fakeCallback = sinon.fake();
+      sound.handlePlayStarted({callback: fakeCallback});
+      expect(fakeCallback).to.have.been.calledOnce;
+    });
+  });
+  describe('stop method', () => {
+    beforeEach(() => {
+      sound = new Sound({});
+    });
+    it('should call stop on all playableBuffers', () => {
+      let fakeStopMethod = sinon.fake();
+      sound.playableBuffers = [{stop: fakeStopMethod}, {stop: fakeStopMethod}];
+      sound.stop();
+      expect(fakeStopMethod).to.have.been.calledTwice;
+    });
+    it('should call pause on audioElement', () => {
+      let fakePauseMethod = sinon.fake();
+      sound.audioElement = {pause: fakePauseMethod};
+      sound.stop();
+      expect(fakePauseMethod).to.have.been.calledOnce;
+      expect(sound.audioElement.currentTime).to.equal(0);
+    });
+  });
+  describe('isPlaying method', () => {
+    it('should return value of isPlaying_ property', () => {
+      sound = new Sound({});
+      sound.isPlaying_ = true;
+      expect(sound.isPlaying()).to.equal.true;
+      sound.isPlaying_ = false;
+      expect(sound.isPlaying()).to.equal.false;
+    });
+  });
+  describe('isLoaded method', () => {
+    it('should return value of isLoaded_ property', () => {
+      sound = new Sound({});
+      sound.isLoaded_ = true;
+      expect(sound.isLoaded()).to.equal.true;
+      sound.isLoaded_ = false;
+      expect(sound.isLoaded()).to.equal.false;
+    });
+  });
+  describe('didLoadFail method', () => {
+    it('should return value of didLoadFail_ property', () => {
+      sound = new Sound({});
+      sound.didLoadFail_ = true;
+      expect(sound.didLoadFail()).to.equal.true;
+      sound.didLoadFail_ = false;
+      expect(sound.didLoadFail()).to.equal.false;
+    });
+  });
+  describe('preloadFile method', () => {
+    beforeEach(() => {
+      sound = new Sound({});
+      sinon.stub(sound, 'getPlayableFile').returns('/path/to/file');
+    });
+    afterEach(() => {
+      sinon.restore();
+    });
+    it('should call preloadViaWebAudio when AudioContext is provided', () => {
+      sound.audioContext = new AudioContext();
+      sinon.stub(sound, 'preloadViaWebAudio');
+      sound.preloadFile();
+      expect(sound.preloadViaWebAudio).to.have.been.calledOnce;
+    });
+    it('should call preloadAudioElement when AudioContext is not provided', () => {
+      sound.audioContext = null;
+      sinon.stub(sound, 'preloadAudioElement');
+      sound.preloadFile();
+      expect(sound.preloadAudioElement).to.have.been.calledOnce;
+    });
+  });
+  describe('preloadBytes method', () => {
+    beforeEach(() => {
+      sound = new Sound({});
+      sinon.stub(sound, 'getPlayableBytes').returns('bytes');
+    });
+    afterEach(() => {
+      sinon.restore();
+    });
+    it('should call audioContext.decodeAudioData when AudioContext is provided', () => {
+      sound.audioContext = new AudioContext();
+      sinon.stub(sound.audioContext, 'decodeAudioData');
+      sound.preloadBytes();
+      expect(sound.audioContext.decodeAudioData).to.have.been.calledOnce;
+    });
+    it('should call preloadAudioElement when no AudioContext is provided', () => {
+      sound.audioContext = null;
+      sinon.stub(sound, 'preloadAudioElement');
+      sound.preloadBytes();
+      expect(sound.preloadAudioElement).to.have.been.calledOnce;
+    });
+  });
+  describe('getPlayableFile method', () => {
+    it('should return file location from config preferring mp3 > ogg > wav', () => {
+      let canPlayTypeStub = sinon.stub(window.Audio.prototype, 'canPlayType');
+      let config = {mp3: 'file.mp3', ogg: 'file.ogg', wav: 'file.wav'};
+      sound = new Sound(config);
+      canPlayTypeStub.withArgs('audio/mp3').returns(true);
+      canPlayTypeStub.withArgs('audio/ogg').returns(true);
+      canPlayTypeStub.withArgs('audio/wav').returns(true);
+      expect(sound.getPlayableFile()).to.equal(config.mp3);
+      canPlayTypeStub.withArgs('audio/mp3').returns(false);
+      expect(sound.getPlayableFile()).to.equal(config.ogg);
+      canPlayTypeStub.withArgs('audio/ogg').returns(false);
+      expect(sound.getPlayableFile()).to.equal(config.wav);
+      canPlayTypeStub.withArgs('audio/wav').returns(false);
+      expect(sound.getPlayableFile()).to.equal(false);
+      sinon.restore();
+    });
+  });
+  describe('getPlayableBytes method', () => {
+    beforeEach(() => {
+      sound = new Sound({});
+      sound.config.bytes = 'bytes';
+    });
+    afterEach(() => {
+      sinon.restore();
+    });
+    it('should return this.config.bytes when browser can play audio/mp3', () => {
+      sinon.stub(window.Audio.prototype, 'canPlayType').returns(true);
+      expect(sound.getPlayableBytes()).to.equal(sound.config.bytes);
+    });
+    it('should return false when browser cannot play audio/mp3', () => {
+      sinon.stub(window.Audio.prototype, 'canPlayType').returns(false);
+      expect(sound.getPlayableBytes()).to.equal(false);
+    });
+  });
+});


### PR DESCRIPTION
Fixes an issue where we are unable to stop audio in applab when the same audio file is played multiple times. Before this change we were clobbering `this.playableBuffer` each time a sound is played. As a result, calling `stopSound` would only stop playing the newest instance.

To repro the issue 
1. Load [this app](https://studio.code.org/projects/applab/fiXejQ__NXLN-CP0dmlybsF-OKsa9qFOyEvcq1XLbG4/view) 
1. click play multiple times
1. click stop one or more times 
1. Observe the audio track will continue to play.

Alternatives to this fix would be to disallow the same audio file from ever playing concurrently or trying to handle this change in Sounds.js. I considered the latter path initially but was leery of making a change to the [soundsById](https://github.com/code-dot-org/code-dot-org/blob/staging/apps/src/Sounds.js#L268) structure in there. Happy to discuss further if there's consensus that could be a more appropriate change here or otherwise be more beneficial to the app.

<!--
  Your description goes here: A summary of the change, including any relevant motivation and context.

  If relevant, include a description both of the existing behavior and of the new behavior.
-->

<!--
  Other aspects to consider. uncomment and add detail for any that seem necessary:
-->

<!-- ### Background -->
<!-- ### Privacy -->
<!--
1.	Does the Project involve the collection, use or sharing of new Personal Data?

2.	Does the Project involve a new or changed use or sharing of existing Personal Data?
-->
<!-- ### Security -->
<!--
Link to Jira Task where sensitive security issues are discussed privately.
-->
<!-- ### Caching -->
<!-- ### Deployment strategy -->
<!-- ### Future work -->

## Links

<!--
  Any relevant links to external resources; ie, specification documents, jira
  items, related PRs, honeybadger errors, etc
-->

- JIRA: [STAR-1212](https://codedotorg.atlassian.net/browse/STAR-1212) and [STAR-1239](https://codedotorg.atlassian.net/browse/STAR-1239)


## Testing story

<!--
  Does your change include appropriate tests?

  If so, please describe how the tests included in this PR are sufficient

  If not, please explain why this change does not need to be tested.
-->

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
