### PR TITLE
Update set of silenced deprecation warnings

### DIFF
--- a/dashboard/config/initializers/backtrace_silencers.rb
+++ b/dashboard/config/initializers/backtrace_silencers.rb
@@ -8,8 +8,9 @@
 
 # In addition to backtrace silencing, we also want to silence annoying deprecations:
 silenced = [
-  # Added in https://github.com/rails/rails/pull/25337 for Rails 5.1; will be removed in Rails 5.2
-  /The behavior of `[\w\?]*` inside of after callbacks will be changing in the next version of Rails./,
+  /Single arity template handlers are deprecated/,
+  /Dangerous query method \(method whose arguments are used as raw SQL\) called with non-attribute argument\(s\)/,
+  /SourceAnnotationExtractor is deprecated! Use Rails::SourceAnnotationExtractor instead/,
 ]
 
 silenced_expr = Regexp.new(silenced.join('|'))


### PR DESCRIPTION
- Removed a warning for a feature that was already deprecated in Rails 5.2
- Added three new warnings added in 5.2 for features that will be deprecated in 6.0

## Testing story

N/A

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
