### PR TITLE
Double frontend EC2 volume size from 64 to 128gb

### DIFF
--- a/aws/cloudformation/components/ami.yml.erb
+++ b/aws/cloudformation/components/ami.yml.erb
@@ -152,7 +152,7 @@ frontend_device_name ||= '/dev/sda1'
       BlockDeviceMappings:
         - DeviceName: <%=frontend_device_name%>
           Ebs:
-            VolumeSize: <%=frontend_volume_size%>
+            VolumeSize: <%=frontend_volume_size * 2%> # Double volume size to leave room for logs written to disk
             VolumeType: gp2
       UserData:
         Fn::Base64: !Sub |


### PR DESCRIPTION
Modifies the CloudFormation stack template controlling the `Frontends` auto scaling group to increase EBS volume size from 64 to 128 gb, to leave extra room for logs written to disk.