### PR TITLE
Require CAPTCHA when users attempt to join more than 3 sections in 24 hours

### DIFF
--- a/dashboard/app/controllers/followers_controller.rb
+++ b/dashboard/app/controllers/followers_controller.rb
@@ -26,7 +26,7 @@ class FollowersController < ApplicationController
 
     if @user && @user.display_captcha? && !verify_recaptcha
       flash[:alert] = I18n.t('follower.captcha_required')
-      # Without concatenating the section code, user is forced to type in code again
+      # Concatenate section code so the user does not have to type in section code again
       # Note that @section will be always be defined due to validations in load_section
       redirection = request.path + '/' + @section.code
       redirect_to redirection

--- a/dashboard/app/models/user.rb
+++ b/dashboard/app/models/user.rb
@@ -124,6 +124,8 @@ class User < ActiveRecord::Base
 
   acts_as_paranoid # use deleted_at column instead of deleting rows
 
+  scope :ignore_deleted_at_index, -> {from 'users IGNORE INDEX(index_users_on_deleted_at)'}
+
   PROVIDER_MANUAL = 'manual'.freeze # "old" user created by a teacher -- logs in w/ username + password
   PROVIDER_SPONSORED = 'sponsored'.freeze # "new" user created by a teacher -- logs in w/ name + secret picture/word
   PROVIDER_MIGRATED = 'migrated'.freeze
@@ -1008,7 +1010,7 @@ class User < ActiveRecord::Base
       return nil if login.size > max_credential_size || login.utf8mb4?
       # TODO: multi-auth (@eric, before merge!) have to handle this path, and make sure that whatever
       # indexing problems bit us on the users table don't affect the multi-auth table
-      from("users IGNORE INDEX(index_users_on_deleted_at)").where(
+      ignore_deleted_at_index.where(
         [
           'username = :value OR email = :value OR hashed_email = :hashed_value',
           {value: login.downcase, hashed_value: hash_email(login.downcase)}

--- a/dashboard/app/models/user.rb
+++ b/dashboard/app/models/user.rb
@@ -124,8 +124,6 @@ class User < ActiveRecord::Base
 
   acts_as_paranoid # use deleted_at column instead of deleting rows
 
-  scope :ignore_deleted_at_index, -> {from 'users IGNORE INDEX(index_users_on_deleted_at)'}
-
   PROVIDER_MANUAL = 'manual'.freeze # "old" user created by a teacher -- logs in w/ username + password
   PROVIDER_SPONSORED = 'sponsored'.freeze # "new" user created by a teacher -- logs in w/ name + secret picture/word
   PROVIDER_MIGRATED = 'migrated'.freeze
@@ -1010,7 +1008,7 @@ class User < ActiveRecord::Base
       return nil if login.size > max_credential_size || login.utf8mb4?
       # TODO: multi-auth (@eric, before merge!) have to handle this path, and make sure that whatever
       # indexing problems bit us on the users table don't affect the multi-auth table
-      ignore_deleted_at_index.where(
+      from("users IGNORE INDEX(index_users_on_deleted_at)").where(
         [
           'username = :value OR email = :value OR hashed_email = :hashed_value',
           {value: login.downcase, hashed_value: hash_email(login.downcase)}
@@ -2259,6 +2257,40 @@ class User < ActiveRecord::Base
     else
       [provider]
     end
+  end
+
+  def num_failed_section_attempts
+    properties['section_attempts'] || 0
+  end
+
+  def reset_section_attempts?
+    num_failed_section_attempts == 0 || (DateTime.now - DateTime.parse(properties['section_attempts_last_reset'])).to_i > 0
+  end
+
+  # If 24 hours has passed, reset the section attempts value to zero.
+  # Initialize the key/value pair in properties if it does not yet exist.
+  def reset_failed_section_attempts
+    properties['section_attempts'] = 0
+    properties['section_attempts_last_reset'] = DateTime.now.to_s
+    save(validate: false)
+  end
+
+  # Force user to complete a captcha after 3 failed join section attempts within 24 hours
+  # Check to see if 24 hours have passed. If so, reset to zero.
+  def display_captcha?
+    if reset_section_attempts?
+      reset_failed_section_attempts
+    end
+    num_failed_section_attempts >= 3
+  end
+
+  # Failed section attemps reset every day
+  def increment_section_attempts
+    if reset_section_attempts?
+      reset_failed_section_attempts
+    end
+    properties.merge!({'section_attempts' => 1}) {|_, old_val, increment_val| old_val + increment_val}
+    save(validate: false)
   end
 
   private

--- a/dashboard/app/models/user.rb
+++ b/dashboard/app/models/user.rb
@@ -2262,7 +2262,7 @@ class User < ActiveRecord::Base
   end
 
   # The number of times a user has attempted to join a section in the last 24 hours
-  # Returns nil if not section join attempts.
+  # Returns nil if no section join attempts.
   def num_failed_section_attempts
     properties['section_attempts']
   end
@@ -2288,8 +2288,8 @@ class User < ActiveRecord::Base
     num_failed_section_attempts >= 3
   end
 
-  # Failed section attemps reset every day
   def increment_section_attempts
+    # Failed section attemps reset after 24 hours
     if reset_section_attempts?
       reset_failed_section_attempts
     end

--- a/dashboard/app/views/followers/student_user_new.html.haml
+++ b/dashboard/app/views/followers/student_user_new.html.haml
@@ -6,6 +6,8 @@
   %p= t('join_section.code.instructions')
   = form_tag(student_user_new_path) do
     = text_field_tag(:section_code, params[:section_code], placeholder: I18n.t('join_section.code.placeholder'))
+    - if current_user && current_user.display_captcha?
+      = recaptcha_tags
     %br/
     = submit_tag t('join_section.code.submit'), class: 'btn btn-primary'
 - else

--- a/dashboard/config/locales/en.yml
+++ b/dashboard/config/locales/en.yml
@@ -281,6 +281,7 @@ en:
     invite_sent: 'Invite sent'
     added_teacher: '%{name} added as your teacher'
     registered:  "You've registered for %{section_name}."
+    captcha_required: 'Please fill out the CAPTCHA to join this section.'
     error:
       signed_in: 'Please signout before proceeding'
       username_not_found: 'Username %{username} not found'

--- a/dashboard/config/locales/en.yml
+++ b/dashboard/config/locales/en.yml
@@ -170,8 +170,6 @@ en:
     invalid_password: "Password must be at least 6 characters"
     mismatch_password: "The two passwords you entered do not match"
     student_consent: "I confirm that I have my parent or legal guardian's permission to use the Code.org services."
-    agree_us_website: "I agree to using a website based in the United States."
-    my_data_to_us: "Data from my use of this site may be sent to and stored or processed in the United States."
     agree_us_data_transfer_student: '**I agree that Code.org may transfer data (including personal data) from my use of this site to the United States** for the purpose of hosting and processing such data.'
     agree_us_data_transfer_teacher: '**I agree that Code.org may transfer data (including personal data) from my use (and my students’ use) of this site to the United States** for the purpose of hosting and processing such data.'
     data_collection_us: "I understand that Code.org is a US-based not-for-profit website and that the laws governing data collection in the U.S. may differ from the laws in my country."
@@ -283,7 +281,6 @@ en:
     invite_sent: 'Invite sent'
     added_teacher: '%{name} added as your teacher'
     registered:  "You've registered for %{section_name}."
-    captcha_required: 'Please fill out the CAPTCHA to join this section.'
     error:
       signed_in: 'Please signout before proceeding'
       username_not_found: 'Username %{username} not found'
@@ -569,7 +566,9 @@ en:
     art_from_html: 'Minecraft&#8482; &copy; %{current_year} Microsoft. All Rights Reserved.<br />Star Wars&#8482; &copy; %{current_year} Disney and Lucasfilm. All Rights Reserved.<br />Frozen&#8482; &copy; %{current_year} Disney. All Rights Reserved.<br />Ice Age&#8482; &copy; %{current_year} 20th Century Fox. All Rights Reserved.<br />Angry Birds&#8482; &copy; 2009-%{current_year} Rovio Entertainment Ltd. All Rights Reserved.<br />Plants vs. Zombies&#8482; &copy; %{current_year} Electronic Arts Inc. All Rights Reserved.<br />The Amazing World of Gumball is trademark and &copy; %{current_year} Cartoon Network.'
     art_from_html_old: 'Minecraft&#8482; &copy; %{current_year} Microsoft. All Rights Reserved. Star Wars&#8482; &copy; %{current_year} Disney and Lucasfilm. All Rights Reserved. Frozen&#8482; &copy; %{current_year} Disney. All Rights Reserved. Ice Age&#8482; &copy; %{current_year} 20th Century Fox. All Rights Reserved. Angry Birds&#8482; &copy; 2009-%{current_year} Rovio Entertainment Ltd. All Rights Reserved. Plants vs. Zombies&#8482; &copy; %{current_year} Electronic Arts Inc. All Rights Reserved. The Amazing World of Gumball is trademark and &copy; %{current_year} Cartoon Network.'
     code_from_html: 'Code.org uses p5.play, which is licensed under <a href="http://www.gnu.org/licenses/old-licenses/lgpl-2.1-standalone.html">the GNU LGPL 2.1</a>.'
-    powered_by_aws: 'Powered by Amazon Web Services'
+    powered_by_aws: 'Amazon Web Services and the “Powered by AWS” logo are trademarks of Amazon.com, Inc. or its affiliates in the United States and/or other countries.'
+    built_on_github: 'Built on GitHub from Microsoft'
+    google_copyright: '&copy; Google Inc. used with permission. Google Classroom is a trademark of Google Inc.'
     trademark: '&copy; Code.org, %{current_year}. Code.org&reg;, the CODE logo and Hour of Code&reg; are trademarks of Code.org.'
     copyright: 'Copyright'
     more: 'More'

--- a/dashboard/config/locales/en.yml
+++ b/dashboard/config/locales/en.yml
@@ -170,6 +170,8 @@ en:
     invalid_password: "Password must be at least 6 characters"
     mismatch_password: "The two passwords you entered do not match"
     student_consent: "I confirm that I have my parent or legal guardian's permission to use the Code.org services."
+    agree_us_website: "I agree to using a website based in the United States."
+    my_data_to_us: "Data from my use of this site may be sent to and stored or processed in the United States."
     agree_us_data_transfer_student: '**I agree that Code.org may transfer data (including personal data) from my use of this site to the United States** for the purpose of hosting and processing such data.'
     agree_us_data_transfer_teacher: '**I agree that Code.org may transfer data (including personal data) from my use (and my students’ use) of this site to the United States** for the purpose of hosting and processing such data.'
     data_collection_us: "I understand that Code.org is a US-based not-for-profit website and that the laws governing data collection in the U.S. may differ from the laws in my country."
@@ -281,6 +283,7 @@ en:
     invite_sent: 'Invite sent'
     added_teacher: '%{name} added as your teacher'
     registered:  "You've registered for %{section_name}."
+    captcha_required: 'Please fill out the CAPTCHA to join this section.'
     error:
       signed_in: 'Please signout before proceeding'
       username_not_found: 'Username %{username} not found'
@@ -566,9 +569,7 @@ en:
     art_from_html: 'Minecraft&#8482; &copy; %{current_year} Microsoft. All Rights Reserved.<br />Star Wars&#8482; &copy; %{current_year} Disney and Lucasfilm. All Rights Reserved.<br />Frozen&#8482; &copy; %{current_year} Disney. All Rights Reserved.<br />Ice Age&#8482; &copy; %{current_year} 20th Century Fox. All Rights Reserved.<br />Angry Birds&#8482; &copy; 2009-%{current_year} Rovio Entertainment Ltd. All Rights Reserved.<br />Plants vs. Zombies&#8482; &copy; %{current_year} Electronic Arts Inc. All Rights Reserved.<br />The Amazing World of Gumball is trademark and &copy; %{current_year} Cartoon Network.'
     art_from_html_old: 'Minecraft&#8482; &copy; %{current_year} Microsoft. All Rights Reserved. Star Wars&#8482; &copy; %{current_year} Disney and Lucasfilm. All Rights Reserved. Frozen&#8482; &copy; %{current_year} Disney. All Rights Reserved. Ice Age&#8482; &copy; %{current_year} 20th Century Fox. All Rights Reserved. Angry Birds&#8482; &copy; 2009-%{current_year} Rovio Entertainment Ltd. All Rights Reserved. Plants vs. Zombies&#8482; &copy; %{current_year} Electronic Arts Inc. All Rights Reserved. The Amazing World of Gumball is trademark and &copy; %{current_year} Cartoon Network.'
     code_from_html: 'Code.org uses p5.play, which is licensed under <a href="http://www.gnu.org/licenses/old-licenses/lgpl-2.1-standalone.html">the GNU LGPL 2.1</a>.'
-    powered_by_aws: 'Amazon Web Services and the “Powered by AWS” logo are trademarks of Amazon.com, Inc. or its affiliates in the United States and/or other countries.'
-    built_on_github: 'Built on GitHub from Microsoft'
-    google_copyright: '&copy; Google Inc. used with permission. Google Classroom is a trademark of Google Inc.'
+    powered_by_aws: 'Powered by Amazon Web Services'
     trademark: '&copy; Code.org, %{current_year}. Code.org&reg;, the CODE logo and Hour of Code&reg; are trademarks of Code.org.'
     copyright: 'Copyright'
     more: 'More'

--- a/dashboard/test/controllers/followers_controller_test.rb
+++ b/dashboard/test/controllers/followers_controller_test.rb
@@ -92,25 +92,6 @@ class FollowersControllerTest < ActionController::TestCase
     assert_equal true, @new_student.display_captcha?
   end
 
-  test 'student_user_new displays error when joining 3 or more sections in 24 hours without completing captcha' do
-    Recaptcha.configuration.skip_verify_env.delete("test")
-    @new_student = create(:user)
-    sign_in @new_student
-    invalid_section_code = 'INVALID'
-    3.times do
-      assert_does_not_create(User) do
-        post :student_register, params: {section_code: invalid_section_code}
-        @new_student.reload
-      end
-    end
-    # TODO: you need to resolve the error raised when performing this request
-    post :student_register, params: {section_code: @chris_section.code}
-    post :student_register, params: {section_code: @chris_section.code}
-    #get :student_user_new, params: {section_code: @chris_section.code}
-    @new_student.reload
-    assert_equal(I18n.t('follower.captcha_required'), flash[:alert])
-  end
-
   test "student_user_new when signed in without section code" do
     sign_in @student
     assert_does_not_create(Follower) do
@@ -356,5 +337,17 @@ class FollowersControllerTest < ActionController::TestCase
     end
 
     assert_redirected_to admin_directory_path
+  end
+
+  # Place test at bottom to avoid reCAPTCHA issues with pre-existing tests
+  test 'student_user_new displays error when joining 3 or more sections in 24 hours without completing captcha' do
+    Recaptcha.configuration.skip_verify_env.delete("test")
+    @new_student = create(:user)
+    sign_in @new_student
+    4.times do
+      post :student_register, params: {section_code: @chris_section.code}
+      @new_student.reload
+    end
+    assert_equal(I18n.t('follower.captcha_required'), flash[:alert])
   end
 end

--- a/dashboard/test/controllers/followers_controller_test.rb
+++ b/dashboard/test/controllers/followers_controller_test.rb
@@ -346,7 +346,6 @@ class FollowersControllerTest < ActionController::TestCase
     sign_in @new_student
     4.times do
       post :student_register, params: {section_code: @chris_section.code}
-      @new_student.reload
     end
     assert_equal(I18n.t('follower.captcha_required'), flash[:alert])
   end

--- a/dashboard/test/controllers/followers_controller_test.rb
+++ b/dashboard/test/controllers/followers_controller_test.rb
@@ -72,7 +72,7 @@ class FollowersControllerTest < ActionController::TestCase
   test "student_user_new increments join section attempts when signed in" do
     refute @chris_section.students.include? @student
     sign_in @student
-    section_join_attempts = @student.num_failed_section_attempts
+    section_join_attempts = @student.num_failed_section_attempts || 0
     assert_does_not_create(User) do
       post :student_register, params: {section_code: @chris_section.code}
     end
@@ -90,6 +90,19 @@ class FollowersControllerTest < ActionController::TestCase
       @new_student.reload
     end
     assert_equal true, @new_student.display_captcha?
+  end
+
+  # Enable reCAPTCHA gem in test env for just this unit test.
+  # Restores original configuration after testing the assertion
+  test 'student_user_new displays error when joining 3 or more sections in 24 hours without completing captcha' do
+    Recaptcha.configuration.skip_verify_env.delete("test")
+    @new_student = create(:user)
+    sign_in @new_student
+    4.times do
+      post :student_register, params: {section_code: @chris_section.code}
+    end
+    assert_equal(I18n.t('follower.captcha_required'), flash[:alert])
+    Recaptcha.configuration.skip_verify_env.append("test")
   end
 
   test "student_user_new when signed in without section code" do
@@ -337,16 +350,5 @@ class FollowersControllerTest < ActionController::TestCase
     end
 
     assert_redirected_to admin_directory_path
-  end
-
-  # Place test at bottom to avoid reCAPTCHA issues with pre-existing tests
-  test 'student_user_new displays error when joining 3 or more sections in 24 hours without completing captcha' do
-    Recaptcha.configuration.skip_verify_env.delete("test")
-    @new_student = create(:user)
-    sign_in @new_student
-    4.times do
-      post :student_register, params: {section_code: @chris_section.code}
-    end
-    assert_equal(I18n.t('follower.captcha_required'), flash[:alert])
   end
 end

--- a/dashboard/test/models/user_test.rb
+++ b/dashboard/test/models/user_test.rb
@@ -4443,11 +4443,6 @@ class UserTest < ActiveSupport::TestCase
     end
   end
 
-  test 'number of section join attempts for new user defaults to zero' do
-    user = create :user
-    assert_equal 0, user.num_failed_section_attempts
-  end
-
   test 'join section attempts hash is initialized for a new user when calling display_captcha' do
     user = create :user
     assert_equal false, user.display_captcha?

--- a/dashboard/test/models/user_test.rb
+++ b/dashboard/test/models/user_test.rb
@@ -4458,6 +4458,7 @@ class UserTest < ActiveSupport::TestCase
   test 'section attempts last reset value resets if more than 24 hours has passed' do
     user = create :user
     user.properties = {'section_attempts': 5, 'section_attempts_last_reset': DateTime.now - 1}
+    # invoking display_captcha? will cause the section_attempts values to be reset
     assert_equal false, user.display_captcha?
     assert_equal 0, user.num_failed_section_attempts
   end

--- a/dashboard/test/models/user_test.rb
+++ b/dashboard/test/models/user_test.rb
@@ -4442,4 +4442,29 @@ class UserTest < ActiveSupport::TestCase
       assert migrated_teacher.reload.admin?
     end
   end
+
+  test 'number of section join attempts for new user defaults to zero' do
+    user = create :user
+    assert_equal 0, user.num_failed_section_attempts
+  end
+
+  test 'join section attempts hash is initialized for a new user when calling display_captcha' do
+    user = create :user
+    assert_equal false, user.display_captcha?
+    assert_equal 0, user.properties['section_attempts']
+    assert_equal Date.today, Date.parse(user.properties['section_attempts_last_reset'])
+  end
+
+  test 'section attempts last reset value resets if more than 24 hours has passed' do
+    user = create :user
+    user.properties = {'section_attempts': 5, 'section_attempts_last_reset': DateTime.now - 1}
+    assert_equal false, user.display_captcha?
+    assert_equal 0, user.num_failed_section_attempts
+  end
+
+  test 'section attempts value increments if less than 24 hours has passed' do
+    user = create :user
+    user.increment_section_attempts
+    assert_equal 1, user.properties['section_attempts']
+  end
 end


### PR DESCRIPTION
We want to require users to fill out a CAPTCHA if they attempt to join 3 or more sections in a day. This PR contains the backend methods needed to implement this task as well as the end-to-end user validation for the `/join/:section_code` endpoint.

 ### Security

- [Jira - Epic](https://codedotorg.atlassian.net/secure/RapidBoard.jspa?rapidView=21&modal=detail&selectedIssue=LP-1378)

### Future work

This PR will be followed by two additional PRs:

- An independent reCAPTCHA React component that can be used across the site where necessary
- The end-to-end integration of the backend logic with the newly created React component within `JoinSection.jsx`

## Links

- [jira](https://codedotorg.atlassian.net/secure/RapidBoard.jspa?rapidView=21&modal=detail&selectedIssue=LP-1644)

## Testing story

Unit tests added to `user_test.rb` to test functionality of new methods added to `user.rb`. Unit tests also added to `followers_controller_test.rb` to test changes to `followers_controller.rb` and `student_user_new.html.haml`

## Screenshots

**Scenario 1:** user has not attempted to join 3 sections in the past 24 hours
<img width="1014" alt="Screen Shot 2020-11-25 at 8 34 20 PM" src="https://user-images.githubusercontent.com/17502635/100297837-9b5d9e80-2f5d-11eb-89d8-a5722cdb81c8.png">


**Scenario 2:** user has already attempted to join 3 sections in the past 24 hours
<img width="966" alt="Screen Shot 2020-11-25 at 8 32 01 PM" src="https://user-images.githubusercontent.com/17502635/100297712-47eb5080-2f5d-11eb-85df-36c29f8c36dc.png">

**Scenario 3** user has already attempted to join 3 sections in the past 24 hours and tried to join another section without completing the captcha
<img width="996" alt="Screen Shot 2020-11-25 at 8 29 57 PM" src="https://user-images.githubusercontent.com/17502635/100297585-fe9b0100-2f5c-11eb-8fcc-8f643c77860b.png">


# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
