### PR TITLE
Revert "AppLab: remove debug console when in readonly workspace"

### DIFF
--- a/apps/src/applab/applab.js
+++ b/apps/src/applab/applab.js
@@ -467,12 +467,9 @@ Applab.init = function(config) {
     config.level.sliderSpeed = 1.0;
   }
 
-  var showDebugButtons =
-    !config.hideSource &&
-    !config.level.debuggerDisabled &&
-    !config.readonlyWorkspace;
+  var showDebugButtons = !config.hideSource && !config.level.debuggerDisabled;
   var breakpointsEnabled = !config.level.debuggerDisabled;
-  var showDebugConsole = !config.hideSource && !config.readonlyWorkspace;
+  var showDebugConsole = !config.hideSource;
 
   // Construct a logging observer for interpreter events
   if (!config.hideSource) {


### PR DESCRIPTION
Reverts code-dot-org/code-dot-org#37979
Reason: it's breaking grading for CSP/D. See more [here](https://codedotorg.slack.com/archives/C0T0TPL9W/p1606705480246400)