### PR TITLE
Enable Autoscale Rolling Batch size to be set via CloudFormation Parameter

### DIFF
--- a/aws/cloudformation/cloud_formation_stack.yml.erb
+++ b/aws/cloudformation/cloud_formation_stack.yml.erb
@@ -17,6 +17,9 @@ Parameters:
 <% if frontends -%>
   DaemonInstanceType:
     Type: String
+  AutoscaleRollingBatchSize:
+    Type: Number
+    Default: 20
 <% end -%>
 <% if options.console -%>
   ConsoleInstanceType:

--- a/aws/cloudformation/components/ami.yml.erb
+++ b/aws/cloudformation/components/ami.yml.erb
@@ -122,7 +122,7 @@ frontend_device_name ||= '/dev/sda1'
         MinSuccessfulInstancesPercent: 80
     UpdatePolicy:
       AutoScalingRollingUpdate:
-        MaxBatchSize: 20
+        MaxBatchSize: !Ref AutoscaleRollingBatchSize
         MinInstancesInService: !GetAtt [ASGCount, DesiredCapacity]
         MinSuccessfulInstancesPercent: 80
         PauseTime: <%=frontend_timeout%>


### PR DESCRIPTION
We currently have our Autoscale rolling batch size set to 20 (20 instances are cycled into the Autoscale Group at a time during a deployment). Change this to use a CloudFormation Parameter, so we can use different size batches. Twenty was an appropriate size when we provisioned >100 web application server EC2 Instances for Hour of Code and each batch took 5-10 minutes to start up. We now need fewer instances (~25) and thanks to Fast Snapshot Restore instance launch takes 2-3 minutes, so a smaller batch size can be used. This lowers the size of our Capacity Reservations for Hour of Code, since we don't need to reserve as many instances for the rolling batch.

<!-- ### Background -->
<!-- ### Privacy -->
<!--
1.	Does the Project involve the collection, use or sharing of new Personal Data?

2.	Does the Project involve a new or changed use or sharing of existing Personal Data?
-->
<!-- ### Security -->
<!--
Link to Jira Task where sensitive security issues are discussed privately.
-->
<!-- ### Caching -->
<!-- ### Deployment strategy -->
<!-- ### Future work -->

## Links

<!--
  Any relevant links to external resources; ie, specification documents, jira
  items, related PRs, honeybadger errors, etc
-->

- [spec]()
- [jira]()

## Testing story

<!--
  Does your change include appropriate tests?

  If so, please describe how the tests included in this PR are sufficient

  If not, please explain why this change does not need to be tested.
-->

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
