### PR TITLE
AI/ML Homepage banner: updates for actual-hoc

### DIFF
--- a/pegasus/sites.v3/code.org/views/homepage_hero.haml
+++ b/pegasus/sites.v3/code.org/views/homepage_hero.haml
@@ -42,7 +42,7 @@
       .left.col-40
         .hero-super-message
           - if hoc_mode == "actual-hoc"
-            = hoc_s(:hoc2020_ai_subheader_actual_hoc)
+            = hoc_s(:social_hoc2018_hoc_here)
           - else
             = hoc_s(:hoc2020_ai_subheader)
         .hero-message
@@ -56,8 +56,11 @@
                 %button.herohocbutton.herohocbutton-solid-white= I18n.t(entry[:text])
       .right.col-50{style: "text-align: center;"}
         .hero-bot
-          %a{href: "/ai"}
+          - if hoc_mode == "actual-hoc"
             %img{src: "/images/homepage/hoc2020_ai_bot.png"}
+          - else
+            %a{href: "/ai"}
+              %img{src: "/images/homepage/hoc2020_ai_bot.png"}
   - elsif show_single_hero == "codebytes2020"
     .hero-message-codebytes
       Join us during this year's

--- a/pegasus/sites.v3/code.org/views/homepage_hero.haml
+++ b/pegasus/sites.v3/code.org/views/homepage_hero.haml
@@ -41,7 +41,10 @@
         &nbsp;
       .left.col-40
         .hero-super-message
-          = hoc_s(:hoc2020_ai_subheader)
+          - if hoc_mode == "actual-hoc"
+            = hoc_s(:hoc2020_ai_subheader_actual_hoc)
+          - else
+            = hoc_s(:hoc2020_ai_subheader)
         .hero-message
           = hoc_s(:hoc2020_ai_header)
         .hero-description

--- a/pegasus/sites.v3/hourofcode.com/i18n/en.yml
+++ b/pegasus/sites.v3/hourofcode.com/i18n/en.yml
@@ -40,7 +40,6 @@
   social_hoc2020_global_movement: 'The Hour of Code is a global movement reaching tens of millions of students. One-hour tutorials are available in 45+ languages for all ages.'
   social_hoc2020_coming_dates: 'The Hour of Code is coming December 7-13, 2020. Computer science is foundational for every student to learn.'
   hoc2020_ai_subheader: 'The Hour of Code 2020 is coming!'
-  hoc2020_ai_subheader_actual_hoc: 'The Hour of Code 2020 is here!'
   hoc2020_ai_header: 'Explore Artificial Intelligence'
   hoc2020_ai_description: 'AI and Machine Learning are impacting our entire world. Join us to explore AI in a new video series, train AI for Oceans in 25+ languages, discuss ethics and AI, and more...'
 

--- a/pegasus/sites.v3/hourofcode.com/i18n/en.yml
+++ b/pegasus/sites.v3/hourofcode.com/i18n/en.yml
@@ -40,6 +40,7 @@
   social_hoc2020_global_movement: 'The Hour of Code is a global movement reaching tens of millions of students. One-hour tutorials are available in 45+ languages for all ages.'
   social_hoc2020_coming_dates: 'The Hour of Code is coming December 7-13, 2020. Computer science is foundational for every student to learn.'
   hoc2020_ai_subheader: 'The Hour of Code 2020 is coming!'
+  hoc2020_ai_subheader_actual_hoc: 'The Hour of Code 2020 is here!'
   hoc2020_ai_header: 'Explore Artificial Intelligence'
   hoc2020_ai_description: 'AI and Machine Learning are impacting our entire world. Join us to explore AI in a new video series, train AI for Oceans in 25+ languages, discuss ethics and AI, and more...'
 

--- a/pegasus/src/homepage.rb
+++ b/pegasus/src/homepage.rb
@@ -105,9 +105,7 @@ class Homepage
   end
 
   def self.get_actions(request)
-    code_break_takeover = promote_code_break(request)
-    code_bytes_takeover = promote_code_bytes(request)
-    hoc2020_ai_takeover = promote_hoc2020_ai(request)
+    hero_type = show_single_hero(request)
     # Show a Latin American specific video to users browsing in Spanish or
     # Portuguese to promote LATAM HOC.
     latam_language_codes = [:"es-MX", :"es-ES", :"pt-BR", :"pt-PT"]
@@ -116,7 +114,7 @@ class Homepage
       download_path = "//videos.code.org/social/latam-hour-of-code-2018.mp4"
       facebook = "https://www.facebook.com/Code.org/videos/173765420214608/"
       twitter = "Aprender las ciencias de la computación es fundamental para trabajar en el siglo XXI. Si aprendan crear la tecnología del futuro, podrán controlar sus futuros. ¿Qué vas a crear? #HoraDelCodigo #QueVasACrear https://twitter.com/codeorg/status/1047063784949460995"
-    elsif code_break_takeover
+    elsif hero_type == "codebreak2020"
       youtube_id = "27ln76y27IQ"
       download_path = ""
       facebook = "https://www.facebook.com/sharer/sharer.php?u=https%3A//www.facebook.com/Code.org/posts/2799748100121475"
@@ -129,15 +127,25 @@ class Homepage
     end
 
     hoc_mode = DCDO.get('hoc_mode', CDO.default_hoc_mode)
-    if hoc2020_ai_takeover
-      [
-        {
-          type: "hoc2020_ai_join_us",
-          text: "homepage_action_text_join_us",
-          url: "/ai"
-        }
-      ]
-    elsif code_break_takeover
+    if hero_type == "hoc2020_ai"
+      if hoc_mode == "actual-hoc"
+        [
+          {
+            type: "hoc2020_ai_join_us",
+            text: "homepage_action_text_join_us",
+            url: "/hourofcode/overview"
+          }
+        ]
+      else
+        [
+          {
+            type: "hoc2020_ai_join_us",
+            text: "homepage_action_text_join_us",
+            url: "/ai"
+          }
+        ]
+      end
+    elsif hero_type == "codebreak2020"
       [
         {
           type: "code_break_check"
@@ -146,7 +154,7 @@ class Homepage
           type: "code_break_home"
         }
       ]
-    elsif code_bytes_takeover
+    elsif hero_type == "codebytes2020"
       [
         {
           type: "cta_button_solid_yellow",


### PR DESCRIPTION
Update AI/ML homepage banner to have minor changes when hoc_mode is set to actual-hoc. The banner will update to say "The Hour of Code is here!" and the Join Us button will direct to the hour of code overview page:
<img width="1778" alt="Screen Shot 2020-11-30 at 1 55 03 PM" src="https://user-images.githubusercontent.com/33666587/100670673-12a38180-3314-11eb-883e-452b7f1a953b.png">

I also made a minor update to our button selection logic for banners based on Clare's comment on [this pr](https://github.com/code-dot-org/code-dot-org/pull/38005/files#r530018886).

## Links

- [jira](https://codedotorg.atlassian.net/browse/PLC-1062)

## Testing story
Tested locally in both actual-hoc and soon-hoc modes.

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
