### PR TITLE
Change date comparison on teacher feedback to fix flaky test 

### DIFF
--- a/apps/src/templates/instructions/TeacherFeedback.jsx
+++ b/apps/src/templates/instructions/TeacherFeedback.jsx
@@ -222,27 +222,16 @@ export class TeacherFeedback extends Component {
   };
 
   getFriendlyDate(feedbackSeen) {
-    const today = new Date();
-    const dateFeedbackSeen = new Date(feedbackSeen);
+    const now = moment();
+    const dateFeedbackSeen = moment(feedbackSeen);
+    const daysApart = now.diff(dateFeedbackSeen, 'days');
 
-    //javascript months begin counting at 0
-    const [todayM, todayD, todayY] = [
-      today.getMonth(),
-      today.getDate(),
-      today.getFullYear()
-    ];
-
-    const [m, d, y] = [
-      dateFeedbackSeen.getMonth(),
-      dateFeedbackSeen.getDate(),
-      dateFeedbackSeen.getFullYear()
-    ];
-    if (todayM === m && todayY === y && todayD === d) {
+    if (daysApart === 0) {
       return i18n.today();
-    } else if (todayM === m && todayY === y && todayD === d + 1) {
+    } else if (daysApart === 1) {
       return i18n.yesterday();
     } else {
-      return moment(dateFeedbackSeen).format('l');
+      return dateFeedbackSeen.format('l');
     }
   }
 

--- a/apps/test/unit/templates/instructions/TeacherFeedbackTest.jsx
+++ b/apps/test/unit/templates/instructions/TeacherFeedbackTest.jsx
@@ -129,7 +129,7 @@ describe('TeacherFeedback', () => {
       i18n.seenByStudent.restore();
     });
 
-    it.skip('displays nicely formatted date if student viewed teacher feedback', () => {
+    it('displays nicely formatted date if student viewed teacher feedback', () => {
       const today = new Date();
       const props = {
         ...TEACHER_FEEDBACK_NO_RUBRIC_PROPS,


### PR DESCRIPTION
Today, one test in `TeacherFeedbackTest.jsx` began failing in the staging build. The issue was do to a mistake on my part in PR #37107 - the date comparison logic in `getFriendlyDate` in `TeacherFeedback.jsx` failed to account for the month/year rollover. To solve the problem, I now use moment.js to subtract the dates. With the fix to `getFriendlyDate`, we can revert the changes introduced in #38053. 

## Links

- [slack discussion](https://codedotorg.slack.com/archives/CA3KCSGTD/p1606785494048500)

## Testing story

Re-ran the failing unit test to ensure it passed.

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
