### PR TITLE
Explicitly specify class name for generic association

### DIFF
--- a/dashboard/app/models/pd/application/tag.rb
+++ b/dashboard/app/models/pd/application/tag.rb
@@ -16,6 +16,6 @@ module Pd::Application
   class Tag < ApplicationRecord
     self.table_name = 'pd_application_tags'
 
-    has_and_belongs_to_many :pd_applications, foreign_key: 'pd_application_tag_id', association_foreign_key: 'pd_application_id'
+    has_and_belongs_to_many :pd_applications, class_name: '::Pd::Application::ApplicationBase', foreign_key: 'pd_application_tag_id', association_foreign_key: 'pd_application_id'
   end
 end


### PR DESCRIPTION
This seems to work on Rails 5, but Rails 6 complains about it

## Testing story

N/A; this seems minor enough to not be necessary to test. Please let me know if you think otherwise!

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
