### PR TITLE
Disable the nps survey

### DIFF
--- a/dashboard/app/helpers/survey_results_helper.rb
+++ b/dashboard/app/helpers/survey_results_helper.rb
@@ -1,6 +1,6 @@
 module SurveyResultsHelper
   DIVERSITY_SURVEY_ENABLED = false
-  NPS_SURVEY_ENABLED = true
+  NPS_SURVEY_ENABLED = false
 
   def show_diversity_survey?(kind)
     return false unless current_user
@@ -19,6 +19,7 @@ module SurveyResultsHelper
   end
 
   def show_nps_survey?(kind)
+    return false unless SurveyResultsHelper::NPS_SURVEY_ENABLED
     return false unless current_user
     # Nov 2020: only display to half of teachers
     return false unless current_user.id.even?
@@ -26,8 +27,6 @@ module SurveyResultsHelper
     return false if current_user.under_13?
     return false unless country_us?
     return false unless account_existed_14_days?
-
-    return false unless SurveyResultsHelper::NPS_SURVEY_ENABLED
 
     # There is no reason not to show the survey, so show the survey.
     return true


### PR DESCRIPTION
The 2020 NPS survey had a good run. Time to turn it off.

The survey was enabled by this PR: https://github.com/code-dot-org/code-dot-org/pull/37867

Results can be found with this query:
`SELECT * FROM foorm_submissions WHERE form_name='surveys/teachers/nps_survey' AND form_version = 0;`

<!--
  Other aspects to consider. uncomment and add detail for any that seem necessary:
-->

<!-- ### Background -->
<!-- ### Privacy -->
<!--
1.	Does the Project involve the collection, use or sharing of new Personal Data?

2.	Does the Project involve a new or changed use or sharing of existing Personal Data?
-->
<!-- ### Security -->
<!--
Link to Jira Task where sensitive security issues are discussed privately.
-->
<!-- ### Caching -->
<!-- ### Deployment strategy -->
<!-- ### Future work -->

## Links

<!--
  Any relevant links to external resources; ie, specification documents, jira
  items, related PRs, honeybadger errors, etc
-->

- [LP-1655](https://codedotorg.atlassian.net/browse/LP-1655)

## Testing story

<!--
  Does your change include appropriate tests?

  If so, please describe how the tests included in this PR are sufficient

  If not, please explain why this change does not need to be tested.
-->

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
