### PR TITLE
Update string shown for HoC levels where teachers cannot view student code

### DIFF
--- a/dashboard/app/controllers/script_levels_controller.rb
+++ b/dashboard/app/controllers/script_levels_controller.rb
@@ -373,7 +373,7 @@ class ScriptLevelsController < ApplicationController
     return if params[:user_id].blank?
 
     if current_user.nil?
-      render html: 'Teacher view is not available for this puzzle', layout: true
+      render html: I18n.t('teacher.student_code_view_diabled'), layout: true
       return
     end
 

--- a/dashboard/config/locales/en.yml
+++ b/dashboard/config/locales/en.yml
@@ -455,6 +455,7 @@ en:
       worked_with: 'Worked With'
       update_lock_settings: 'Update lock settings here.'
       clear_response: 'Clear response'
+    student_code_view_diabled: 'Student code cannot be viewed for this activity.'
   user:
     email_confirm_needed: 'Email address has not been confirmed:'
     email_confirm_needed_required: 'Your email address %{email} has not been confirmed:'

--- a/dashboard/test/controllers/script_levels_controller_test.rb
+++ b/dashboard/test/controllers/script_levels_controller_test.rb
@@ -1022,7 +1022,7 @@ class ScriptLevelsControllerTest < ActionController::TestCase
     }
 
     assert_response :success
-    assert_includes response.body, 'Teacher view is not available for this puzzle'
+    assert_includes response.body, 'Student code cannot be viewed for this activity.'
   end
 
   test 'loads applab if you are a teacher viewing your student and they have a channel id' do


### PR DESCRIPTION
Updating string shown for HoC levels where teachers cannot view student code.  Also, made the string localizable.

For more details about why we don't support viewing student code for these scripts, see [LP-121](https://codedotorg.atlassian.net/browse/LP-121).  This change improves the error message but does not fix the underlying issue.

<!--
  Your description goes here: A summary of the change, including any relevant motivation and context.

  If relevant, include a description both of the existing behavior and of the new behavior.
-->

<!--
  Other aspects to consider. uncomment and add detail for any that seem necessary:
-->

<!-- ### Background -->
<!-- ### Privacy -->
<!--
1.	Does the Project involve the collection, use or sharing of new Personal Data?

2.	Does the Project involve a new or changed use or sharing of existing Personal Data?
-->
<!-- ### Security -->
<!--
Link to Jira Task where sensitive security issues are discussed privately.
-->
<!-- ### Caching -->
<!-- ### Deployment strategy -->
<!-- ### Future work -->

## Links

<!--
  Any relevant links to external resources; ie, specification documents, jira
  items, related PRs, honeybadger errors, etc
-->

## Testing story

<!--
  Does your change include appropriate tests?

  If so, please describe how the tests included in this PR are sufficient

  If not, please explain why this change does not need to be tested.
-->

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
