### PR TITLE
[Spritelab] Implement new UI for user input block

### DIFF
--- a/apps/src/p5lab/P5LabVisualizationColumn.jsx
+++ b/apps/src/p5lab/P5LabVisualizationColumn.jsx
@@ -165,29 +165,32 @@ class P5LabVisualizationColumn extends React.Component {
 
     return (
       <div style={{position: 'relative'}}>
-        <ProtectedVisualizationDiv>
-          <Pointable
-            id="divGameLab"
-            style={divGameLabStyle}
-            tabIndex="1"
-            onPointerMove={this.pickerPointerMove}
-            onPointerUp={this.pickerPointerUp}
-            elementRef={el => (this.divGameLab = el)}
-          />
-          <VisualizationOverlay
-            width={APP_WIDTH}
-            height={APP_HEIGHT}
-            onMouseMove={this.onMouseMove}
-          >
-            <GridOverlay show={this.props.showGrid} showWhileRunning={true} />
-            <CrosshairOverlay flip={spriteLab} />
-            <TooltipOverlay providers={[coordinatesProvider(spriteLab)]} />
-          </VisualizationOverlay>
-        </ProtectedVisualizationDiv>
-        <TextConsole consoleMessages={this.props.consoleMessages} />
-        {experiments.isEnabled(experiments.SPRITELAB_INPUT) && (
-          <SpritelabInput />
-        )}
+        <div style={{position: 'relative'}}>
+          <ProtectedVisualizationDiv>
+            <Pointable
+              id="divGameLab"
+              style={divGameLabStyle}
+              tabIndex="1"
+              onPointerMove={this.pickerPointerMove}
+              onPointerUp={this.pickerPointerUp}
+              elementRef={el => (this.divGameLab = el)}
+            />
+            <VisualizationOverlay
+              width={APP_WIDTH}
+              height={APP_HEIGHT}
+              onMouseMove={this.onMouseMove}
+            >
+              <GridOverlay show={this.props.showGrid} showWhileRunning={true} />
+              <CrosshairOverlay flip={spriteLab} />
+              <TooltipOverlay providers={[coordinatesProvider(spriteLab)]} />
+            </VisualizationOverlay>
+          </ProtectedVisualizationDiv>
+          <TextConsole consoleMessages={this.props.consoleMessages} />
+          {experiments.isEnabled(experiments.SPRITELAB_INPUT) && (
+            <SpritelabInput />
+          )}
+        </div>
+
         <GameButtons>
           <ArrowButtons />
 

--- a/apps/src/p5lab/spritelab/SpritelabInput.jsx
+++ b/apps/src/p5lab/spritelab/SpritelabInput.jsx
@@ -9,7 +9,7 @@ const styles = {
     background: 'rgba(34, 42, 51, 0.85)',
     textAlign: 'center',
     position: 'absolute',
-    top: 336, // TODO: Update when playspace resizes
+    bottom: 0,
     width: '100%'
   },
   prompt: {

--- a/apps/src/p5lab/spritelab/SpritelabInput.jsx
+++ b/apps/src/p5lab/spritelab/SpritelabInput.jsx
@@ -91,12 +91,14 @@ class SpritelabInput extends React.Component {
     return (
       <div id="spritelabInputArea" style={styles.container}>
         <div style={styles.prompt}>
-          <span style={styles.circle} className="fa-stack">
-            <i className="fa fa-circle fa-stack-2x" />
-            <strong className="fa-stack-1x" style={styles.number}>
-              {numPrompts}
-            </strong>
-          </span>
+          {numPrompts > 1 && (
+            <span style={styles.circle} className="fa-stack">
+              <i className="fa fa-circle fa-stack-2x" />
+              <strong className="fa-stack-1x" style={styles.number}>
+                {numPrompts}
+              </strong>
+            </span>
+          )}
           <div style={styles.promptText}>{promptText}</div>
           <a onClick={this.toggleCollapsed}>
             <span style={styles.icon} className="fa-stack">

--- a/apps/src/p5lab/spritelab/SpritelabInput.jsx
+++ b/apps/src/p5lab/spritelab/SpritelabInput.jsx
@@ -20,7 +20,7 @@ const styles = {
     lineHeight: '2em',
     verticalAlign: 'middle',
     display: 'inline-block',
-    maxWidth: 'calc(100% - 60px)',
+    maxWidth: 'calc(100% - 100px)',
     textOverflow: 'ellipsis',
     overflow: 'hidden',
     whiteSpace: 'nowrap'
@@ -39,6 +39,17 @@ const styles = {
   submitButton: {
     padding: 4,
     margin: '2px 5px'
+  },
+  circle: {
+    position: 'absolute',
+    left: 10,
+    paddingRight: 8,
+    paddingTop: 6,
+    fontSize: 11
+  },
+  number: {
+    color: 'rgb(34, 42, 51)',
+    fontSize: 9
   }
 };
 
@@ -80,18 +91,18 @@ class SpritelabInput extends React.Component {
     return (
       <div id="spritelabInputArea" style={styles.container}>
         <div style={styles.prompt}>
-          <span className="fa-stack">
+          <span style={styles.circle} className="fa-stack">
             <i className="fa fa-circle fa-stack-2x" />
-            <strong className="fa-stack-1x" style={{color: '#222A33'}}>
+            <strong className="fa-stack-1x" style={styles.number}>
               {numPrompts}
             </strong>
           </span>
+          <div style={styles.promptText}>{promptText}</div>
           <a onClick={this.toggleCollapsed}>
             <span style={styles.icon} className="fa-stack">
               <i className={`fa fa-${icon} fa-stack-2x`} />
             </span>
           </a>
-          <div style={styles.promptText}>{promptText}</div>
         </div>
         {!this.state.collapsed && (
           <div style={styles.inputRow}>
@@ -104,7 +115,7 @@ class SpritelabInput extends React.Component {
             <button
               style={styles.submitButton}
               type="button"
-              onClick={() => this.userInputSubmit()}
+              onClick={this.userInputSubmit}
             >
               <i className="fa fa-check" />
             </button>

--- a/apps/src/p5lab/spritelab/SpritelabInput.jsx
+++ b/apps/src/p5lab/spritelab/SpritelabInput.jsx
@@ -19,7 +19,11 @@ const styles = {
   promptText: {
     lineHeight: '2em',
     verticalAlign: 'middle',
-    display: 'inline-block'
+    display: 'inline-block',
+    maxWidth: 'calc(100% - 60px)',
+    textOverflow: 'ellipsis',
+    overflow: 'hidden',
+    whiteSpace: 'nowrap'
   },
   icon: {
     color: 'white'

--- a/apps/src/p5lab/spritelab/SpritelabInput.jsx
+++ b/apps/src/p5lab/spritelab/SpritelabInput.jsx
@@ -4,6 +4,40 @@ import React from 'react';
 import {popPrompt} from './spritelabInputModule';
 import * as coreLibrary from './coreLibrary';
 
+const styles = {
+  container: {
+    background: 'rgba(34, 42, 51, 0.85)',
+    textAlign: 'center',
+    position: 'absolute',
+    top: 336, // TODO: Update when playspace resizes
+    width: '100%'
+  },
+  prompt: {
+    color: 'white',
+    fontSize: 15
+  },
+  promptText: {
+    lineHeight: '2em',
+    verticalAlign: 'middle',
+    display: 'inline-block'
+  },
+  icon: {
+    color: 'white'
+  },
+  inputRow: {
+    padding: 0
+  },
+  inputArea: {
+    width: 'calc(100% - 80px)',
+    marginBottom: 2,
+    marginTop: 2
+  },
+  submitButton: {
+    padding: 4,
+    margin: '2px 5px'
+  }
+};
+
 class SpritelabInput extends React.Component {
   static propTypes = {
     inputList: PropTypes.array.isRequired,
@@ -11,7 +45,8 @@ class SpritelabInput extends React.Component {
   };
 
   state = {
-    userInput: ''
+    userInput: '',
+    collapsed: false
   };
 
   userInputSubmit() {
@@ -25,26 +60,52 @@ class SpritelabInput extends React.Component {
     this.setState({userInput: ''});
   }
 
+  toggleCollapsed = () =>
+    this.setState({
+      collapsed: !this.state.collapsed
+    });
+
   render() {
+    const icon = this.state.collapsed ? 'angle-right' : 'angle-down';
+    const numPrompts = this.props.inputList.length;
     const promptText =
       this.props.inputList[0] && this.props.inputList[0].promptText;
     if (!promptText) {
       return null;
     }
     return (
-      <div id="spritelabInputArea">
-        <div>{`Prompt: ${promptText}`}</div>
-        <div>
-          Answer:
-          <input
-            type="text"
-            onChange={event => this.setState({userInput: event.target.value})}
-            value={this.state.userInput || ''}
-          />
-          <button type="button" onClick={() => this.userInputSubmit()}>
-            <i className="fa fa-check" />
-          </button>
+      <div id="spritelabInputArea" style={styles.container}>
+        <div style={styles.prompt}>
+          <span className="fa-stack">
+            <i className="fa fa-circle fa-stack-2x" />
+            <strong className="fa-stack-1x" style={{color: '#222A33'}}>
+              {numPrompts}
+            </strong>
+          </span>
+          <a onClick={this.toggleCollapsed}>
+            <span style={styles.icon} className="fa-stack">
+              <i className={`fa fa-${icon} fa-stack-2x`} />
+            </span>
+          </a>
+          <div style={styles.promptText}>{promptText}</div>
         </div>
+        {!this.state.collapsed && (
+          <div style={styles.inputRow}>
+            <input
+              style={styles.inputArea}
+              type="text"
+              onChange={event => this.setState({userInput: event.target.value})}
+              value={this.state.userInput || ''}
+            />
+            <button
+              style={styles.submitButton}
+              type="button"
+              onClick={() => this.userInputSubmit()}
+            >
+              <i className="fa fa-check" />
+            </button>
+          </div>
+        )}
       </div>
     );
   }


### PR DESCRIPTION
Probably easier to review with [whitespace ignored](https://github.com/code-dot-org/code-dot-org/pull/38084/files?diff=unified&w=1)
No change to the user input functionality in sprite lab, just a new UI. The number indicates how many input prompts are in the queue. The input area overlays the spritelab playspace, aligned to the bottom and fitting the width of the playspace. The prompt text is truncated with ellipsis if needed to make sure the prompt fits on one line.
Before:
![image](https://user-images.githubusercontent.com/8787187/100917854-8ff20200-348c-11eb-8577-b502e4a1a1cf.png)

After:
![Dec-02-2020 10-48-56](https://user-images.githubusercontent.com/8787187/100917864-941e1f80-348c-11eb-899f-5d2ac9a69e54.gif)


<!-- ### Background -->
<!-- ### Privacy -->
<!--
1.	Does the Project involve the collection, use or sharing of new Personal Data?

2.	Does the Project involve a new or changed use or sharing of existing Personal Data?
-->
<!-- ### Security -->
<!--
Link to Jira Task where sensitive security issues are discussed privately.
-->
<!-- ### Caching -->
<!-- ### Deployment strategy -->
<!-- ### Future work -->

## Links

<!--
  Any relevant links to external resources; ie, specification documents, jira
  items, related PRs, honeybadger errors, etc
-->

- [spec](https://docs.google.com/document/d/1pZppqxv7UoAQU8BOygErJRfbCHAzIeuDRB9yaFKY7-Q/edit#)
- [jira](https://codedotorg.atlassian.net/browse/STAR-1130)

## Testing story

<!--
  Does your change include appropriate tests?

  If so, please describe how the tests included in this PR are sufficient

  If not, please explain why this change does not need to be tested.
-->

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
