### PR TITLE
Assessment opportunities editor

### DIFF
--- a/apps/i18n/common/en_us.json
+++ b/apps/i18n/common/en_us.json
@@ -120,6 +120,7 @@
   "archivedSections": "Archived Sections",
   "assessmentAndSurvey": "Assessments / Surveys",
   "assessmentOpportunity": "Assessment Opportunity",
+  "assessmentOpportunities": "Assessment Opportunities",
   "assessmentSteps": "Steps to give assessment for",
   "assessmentSettings": "Assessment Settings",
   "assign": "Assign",

--- a/apps/src/lib/levelbuilder/lesson-editor/LessonEditor.jsx
+++ b/apps/src/lib/levelbuilder/lesson-editor/LessonEditor.jsx
@@ -48,6 +48,7 @@ class LessonEditor extends Component {
     initialDisplayName: PropTypes.string.isRequired,
     initialOverview: PropTypes.string,
     initialStudentOverview: PropTypes.string,
+    initialAssessmentOpportunities: PropTypes.string,
     initialUnplugged: PropTypes.bool,
     initialLockable: PropTypes.bool,
     initialAssessment: PropTypes.bool,
@@ -72,6 +73,7 @@ class LessonEditor extends Component {
       displayName: this.props.initialDisplayName,
       overview: this.props.initialOverview,
       studentOverview: this.props.initialStudentOverview,
+      assessmentOpportunities: this.props.initialAssessmentOpportunities,
       unplugged: this.props.initialUnplugged,
       lockable: this.props.initialLockable,
       creativeCommonsLicense: this.props.initialCreativeCommonsLicense,
@@ -101,6 +103,7 @@ class LessonEditor extends Component {
         unplugged: this.state.unplugged,
         overview: this.state.overview,
         studentOverview: this.state.studentOverview,
+        assessmentOpportunities: this.state.assessmentOpportunities,
         purpose: this.state.purpose,
         preparation: this.state.preparation,
         objectives: JSON.stringify(this.state.objectives),
@@ -110,7 +113,6 @@ class LessonEditor extends Component {
       })
     })
       .done(data => {
-        console.log(data);
         if (shouldCloseAfterSave) {
           navigateToHref(`/lessons/${this.props.id}${window.location.search}`);
         } else {
@@ -135,6 +137,7 @@ class LessonEditor extends Component {
       displayName,
       overview,
       studentOverview,
+      assessmentOpportunities,
       unplugged,
       lockable,
       creativeCommonsLicense,
@@ -279,6 +282,21 @@ class LessonEditor extends Component {
             inputRows={5}
             handleMarkdownChange={e =>
               this.setState({preparation: e.target.value})
+            }
+          />
+        </CollapsibleEditorSection>
+
+        <CollapsibleEditorSection
+          title="Assessment Opportunities"
+          collapsed={true}
+          fullWidth={true}
+        >
+          <TextareaWithMarkdownPreview
+            markdown={assessmentOpportunities}
+            label={'Assessment Opportunities'}
+            inputRows={5}
+            handleMarkdownChange={e =>
+              this.setState({assessmentOpportunities: e.target.value})
             }
           />
         </CollapsibleEditorSection>

--- a/apps/src/sites/studio/pages/lessons/edit.js
+++ b/apps/src/sites/studio/pages/lessons/edit.js
@@ -98,6 +98,9 @@ $(document).ready(function() {
         initialDisplayName={lessonData.name}
         initialOverview={lessonData.overview || ''}
         initialStudentOverview={lessonData.studentOverview || ''}
+        initialAssessmentOpportunities={
+          lessonData.assessmentOpportunities || ''
+        }
         initialUnplugged={lessonData.unplugged}
         initialLockable={lessonData.lockable}
         initialCreativeCommonsLicense={lessonData.creativeCommonsLicense}

--- a/apps/src/templates/lessonOverview/LessonOverview.jsx
+++ b/apps/src/templates/lessonOverview/LessonOverview.jsx
@@ -132,6 +132,9 @@ class LessonOverview extends Component {
             <h2>{i18n.purpose()}</h2>
             <SafeMarkdown markdown={lesson.purpose} />
 
+            <h2>{i18n.assessmentOpportunities()}</h2>
+            <SafeMarkdown markdown={lesson.assessmentOpportunities} />
+
             <h2>{i18n.agenda()}</h2>
             <LessonAgenda activities={this.props.activities} />
           </div>

--- a/apps/src/templates/lessonOverview/lessonPlanShapes.jsx
+++ b/apps/src/templates/lessonOverview/lessonPlanShapes.jsx
@@ -22,5 +22,6 @@ export const lessonShape = PropTypes.shape({
   purpose: PropTypes.string.isRequired,
   preparation: PropTypes.string.isRequired,
   resources: PropTypes.object,
-  objectives: PropTypes.arrayOf(PropTypes.object).isRequired
+  objectives: PropTypes.arrayOf(PropTypes.object).isRequired,
+  assessmentOpportunities: PropTypes.string.isRequired
 });

--- a/apps/test/unit/lib/levelbuilder/lesson-editor/LessonEditorTest.js
+++ b/apps/test/unit/lib/levelbuilder/lesson-editor/LessonEditorTest.js
@@ -47,7 +47,8 @@ describe('LessonEditor', () => {
       initialPreparation: '- One',
       initialAnnouncements: [],
       relatedLessons: [],
-      initialObjectives: []
+      initialObjectives: [],
+      initialAssessmentOpportunities: 'Assessment Opportunities'
     };
   });
 
@@ -78,11 +79,11 @@ describe('LessonEditor', () => {
       'purpose'
     ).to.be.true;
     expect(wrapper.find('Connect(ActivitiesEditor)').length).to.equal(1);
-    expect(wrapper.find('TextareaWithMarkdownPreview').length).to.equal(4);
+    expect(wrapper.find('TextareaWithMarkdownPreview').length).to.equal(5);
     expect(wrapper.find('input').length).to.equal(19);
     expect(wrapper.find('select').length).to.equal(1);
     expect(wrapper.find('AnnouncementsEditor').length).to.equal(1);
-    expect(wrapper.find('CollapsibleEditorSection').length).to.equal(7);
+    expect(wrapper.find('CollapsibleEditorSection').length).to.equal(8);
     expect(wrapper.find('ResourcesEditor').length).to.equal(1);
     expect(wrapper.find('SaveBar').length).to.equal(1);
   });

--- a/apps/test/unit/templates/lessonOverview/LessonNavigationDropdownTest.jsx
+++ b/apps/test/unit/templates/lessonOverview/LessonNavigationDropdownTest.jsx
@@ -47,7 +47,8 @@ let lesson = {
   displayName: 'Lesson 1',
   overview: 'Lesson Overview',
   purpose: 'The purpose of the lesson is for people to learn',
-  preparation: '- One'
+  preparation: '- One',
+  assessmentOpportunities: 'Assessment Opportunities'
 };
 
 describe('LessonNavigationDropdown', () => {

--- a/apps/test/unit/templates/lessonOverview/LessonOverviewTest.js
+++ b/apps/test/unit/templates/lessonOverview/LessonOverviewTest.js
@@ -42,6 +42,7 @@ describe('LessonOverview', () => {
         overview: 'Lesson Overview',
         purpose: 'The purpose of the lesson is for people to learn',
         preparation: '- One',
+        assessmentOpportunities: 'Assessment Opportunities Details',
         resources: {
           Teacher: [
             {
@@ -85,7 +86,10 @@ describe('LessonOverview', () => {
     expect(safeMarkdowns.at(1).props().markdown).to.contain(
       'The purpose of the lesson is for people to learn'
     );
-    expect(safeMarkdowns.at(2).props().markdown).to.contain('- One');
+    expect(safeMarkdowns.at(2).props().markdown).to.contain(
+      'Assessment Opportunities Details'
+    );
+    expect(safeMarkdowns.at(3).props().markdown).to.contain('- One');
 
     const inlineMarkdowns = wrapper.find('InlineMarkdown');
     expect(inlineMarkdowns.at(0).props().markdown).to.contain(

--- a/dashboard/app/controllers/lessons_controller.rb
+++ b/dashboard/app/controllers/lessons_controller.rb
@@ -60,6 +60,7 @@ class LessonsController < ApplicationController
       :name,
       :overview,
       :student_overview,
+      :assessment_opportunities,
       :assessment,
       :unplugged,
       :creative_commons_license,

--- a/dashboard/app/models/lesson.rb
+++ b/dashboard/app/models/lesson.rb
@@ -320,7 +320,8 @@ class Lesson < ApplicationRecord
       activities: lesson_activities.map(&:summarize_for_lesson_show),
       resources: resources_for_lesson_plan(user&.authorized_teacher?),
       objectives: objectives.map(&:summarize_for_lesson_show),
-      is_teacher: user&.teacher?
+      is_teacher: user&.teacher?,
+      assessmentOpportunities: assessment_opportunities
     }
   end
 

--- a/dashboard/app/models/lesson.rb
+++ b/dashboard/app/models/lesson.rb
@@ -53,6 +53,7 @@ class Lesson < ApplicationRecord
     preparation
     announcements
     visible_after
+    assessment_opportunities
   )
 
   # A lesson has an absolute position and a relative position. The difference between the two is that relative_position
@@ -290,6 +291,7 @@ class Lesson < ApplicationRecord
       name: name,
       overview: overview,
       studentOverview: student_overview,
+      assessmentOpportunities: assessment_opportunities,
       assessment: assessment,
       unplugged: unplugged,
       lockable: lockable,


### PR DESCRIPTION
Adds the Assessment Opportunities field to the LessonEditor and LessonOverview. Saves the assessment_opportunities information as a property in lesson model. 

### Editor
<img width="1185" alt="Screen Shot 2020-12-02 at 10 00 25 PM" src="https://user-images.githubusercontent.com/208083/100958175-d88bd880-34e9-11eb-9d8f-c0fdbbd44370.png">

### Lesson Plan
<img width="830" alt="Screen Shot 2020-12-02 at 10 00 05 PM" src="https://user-images.githubusercontent.com/208083/100958179-d9bd0580-34e9-11eb-8cf4-6b07c668b015.png">

## Links

<!--
  Any relevant links to external resources; ie, specification documents, jira
  items, related PRs, honeybadger errors, etc
-->

- [jira](https://codedotorg.atlassian.net/browse/PLAT-593)

## Testing story

Updated existing tests for LessonEditor and LessonOverview.
Manually checked that saving Assessment Opportunities results in it showing on the Lesson Overview and on the editor page on reload.

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
