### PR TITLE
Improve Remove Warning for Activity and Activity Section

### DIFF
--- a/apps/src/lib/levelbuilder/lesson-editor/ActivityCard.jsx
+++ b/apps/src/lib/levelbuilder/lesson-editor/ActivityCard.jsx
@@ -183,7 +183,7 @@ class ActivityCard extends Component {
             </label>
           </div>
           <OrderControls
-            name={activity.key || '(none)'}
+            name={activity.displayName || 'Unnamed Activity'}
             move={this.handleMoveActivity}
             remove={this.handleRemoveActivity}
           />

--- a/apps/src/lib/levelbuilder/lesson-editor/ActivitySectionCard.jsx
+++ b/apps/src/lib/levelbuilder/lesson-editor/ActivitySectionCard.jsx
@@ -414,7 +414,7 @@ class ActivitySectionCard extends Component {
             <OrderControls
               name={
                 this.props.activitySection.displayName ||
-                this.props.activitySection.key
+                'Unnamed Activity Section'
               }
               move={this.handleMoveActivitySection}
               remove={this.handleRemoveActivitySection}


### PR DESCRIPTION
Updates the delete warning on activity and activity section to use the displayName instead of the key and if no displayName is provided it was say 'Unnamed Activity' or 'Unnamed Activity Section'. See pictures below.

### Activity Section
<img width="492" alt="Screen Shot 2020-12-02 at 10 11 39 PM" src="https://user-images.githubusercontent.com/208083/100959034-6f0cc980-34eb-11eb-8627-494f04d93b71.png">
<img width="515" alt="Screen Shot 2020-12-02 at 10 11 32 PM" src="https://user-images.githubusercontent.com/208083/100959037-6fa56000-34eb-11eb-924c-3d770ccb8beb.png">

### Activity
<img width="499" alt="Screen Shot 2020-12-02 at 10 11 20 PM" src="https://user-images.githubusercontent.com/208083/100959038-6fa56000-34eb-11eb-8bdb-b46888a4302a.png">
<img width="519" alt="Screen Shot 2020-12-02 at 10 11 11 PM" src="https://user-images.githubusercontent.com/208083/100959039-703df680-34eb-11eb-8e9c-d1d3a93e2445.png">

## Links

<!--
  Any relevant links to external resources; ie, specification documents, jira
  items, related PRs, honeybadger errors, etc
-->

- [jira](https://codedotorg.atlassian.net/browse/PLAT-541)

## Testing story

Tested it locally (see pictures)

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
