### PR TITLE
Fix missing remark markdown and put unpaired tips where they're defined 

### DIFF
--- a/lib/cdo/lesson_import_helper.rb
+++ b/lib/cdo/lesson_import_helper.rb
@@ -270,6 +270,12 @@ module LessonImportHelper
       activity_section.description = unindent_markdown(description).strip
     else
       activity_section = create_activity_section_with_tip(tip_link_matches[0], tip_match_map)
+      # Sometimes the activity section created won't contain everything it needs to.
+      # Check if the tip link match equals the remark markdown. If not, we should add
+      # the rest of the content.
+      if tip_link_matches[0][0].length < match[1].strip.length
+        activity_section.description += unindent_markdown(match[1].delete_prefix(tip_link_matches[0][0]))
+      end
     end
     activity_section.remarks = true
     activity_section

--- a/lib/cdo/lesson_import_helper.rb
+++ b/lib/cdo/lesson_import_helper.rb
@@ -104,8 +104,14 @@ module LessonImportHelper
     position = 1
     sorted_matches.each do |match|
       activity_section = nil
-      if match[:type] == 'skippable' || match[:type] == 'tip'
+      if match[:type] == 'skippable'
         next
+      elsif match[:type] == 'tip'
+        activity_section = ActivitySection.new
+        key = match[:match][3]&.strip || "#{match[:match][1]}-0"
+        activity_section.tips = [create_tip(key, match[:match][1] || "tip", match[:match][4])]
+        activity_section.key ||= SecureRandom.uuid
+        match[:activity_section_key] = activity_section.key
       elsif match[:type] == 'name'
         name = match[:match][1]
         next
@@ -140,17 +146,18 @@ module LessonImportHelper
     end
 
     # If there are any tips that didn't have a match, put them at the end
-    # TODO ideally, we'd put them in the spot they were written.
-    puts "Adding unpaired tips at the end" if tip_match_map.any? {|_, a| a.count > 0}
-    tip_match_map.each do |key, tip_list|
+    tip_match_map.each do |_, tip_list|
       tip_list.each do |tip|
-        match = tip[:match]
-        activity_section = ActivitySection.new
-        activity_section.position = sections.length + 1
-        activity_section.key ||= SecureRandom.uuid
-        activity_section.tips = [create_tip(key, match[1] || "tip", match[4] || "no markdown found")]
-        sections.push(activity_section)
+        if tip[:paired]
+          sections.reject! {|s| s.key == tip[:activity_section_key]}
+        end
       end
+    end
+
+    final_position = 1
+    sections.each do |section|
+      section.position = final_position
+      final_position += 1
     end
 
     sections
@@ -332,10 +339,11 @@ module LessonImportHelper
     if tip_link_match[1] == 'slide'
       return create_slide_activity_section(tip_link_match[3], tip_match_map)
     end
-    tip = tip_match_map[tip_link_match[2]]&.shift
+    tip = tip_match_map[tip_link_match[2]]&.detect {|t| !t[:paired]}
     unless tip
       return ActivitySection.new(description: tip_link_match[3].strip)
     end
+    tip[:paired] = true
     tip_match = tip[:match]
     activity_section = ActivitySection.new
 


### PR DESCRIPTION
a49f2fd fixes an issue where remarks with slide icons would lose some content. This would happen because it would find a tip link (slide is a subset of tip link) and create the corresponding activity section. However, that activity section wouldn't contain all of the content for the tip. Now we check whether the regex match found matches the content for the remark and if not, append the rest of the content.

533ca81 puts unpaired tips where they're defined. To do this, the script adds all tips as unpaired tips then removes the ones that were actually referenced. This isn't the most efficient way of doing this but it made it less likely for anything to get lost. Also, I've had enough bugs with activity section positions being wrong that it's not a bad thing to go over them and ensure they're correct.

<!-- ### Background -->
<!-- ### Privacy -->
<!--
1.	Does the Project involve the collection, use or sharing of new Personal Data?

2.	Does the Project involve a new or changed use or sharing of existing Personal Data?
-->
<!-- ### Security -->
<!--
Link to Jira Task where sensitive security issues are discussed privately.
-->
<!-- ### Caching -->
<!-- ### Deployment strategy -->
<!-- ### Future work -->

## Links

<!--
  Any relevant links to external resources; ie, specification documents, jira
  items, related PRs, honeybadger errors, etc
-->

- [spec]()
- [jira]()

## Testing story

<!--
  Does your change include appropriate tests?

  If so, please describe how the tests included in this PR are sufficient

  If not, please explain why this change does not need to be tested.
-->

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
