### PR TITLE
Add confirmation dialog on resource deletion

### DIFF
--- a/apps/src/lib/levelbuilder/lesson-editor/ResourcesEditor.jsx
+++ b/apps/src/lib/levelbuilder/lesson-editor/ResourcesEditor.jsx
@@ -150,7 +150,7 @@ class ResourcesEditor extends Component {
     this.props.editResource(resource);
   };
 
-  handleRemove = resource => {
+  handleRemoveResourceDialogOpen = resource => {
     this.setState({resourceToRemove: resource, confirmRemovalDialogOpen: true});
   };
 
@@ -257,7 +257,9 @@ class ResourcesEditor extends Component {
                     <div
                       style={styles.remove}
                       className="unit-test-remove-resource"
-                      onMouseDown={() => this.handleRemove(resource)}
+                      onMouseDown={() =>
+                        this.handleRemoveResourceDialogOpen(resource)
+                      }
                     >
                       <i className="fa fa-times" />
                     </div>

--- a/apps/src/lib/levelbuilder/lesson-editor/ResourcesEditor.jsx
+++ b/apps/src/lib/levelbuilder/lesson-editor/ResourcesEditor.jsx
@@ -7,6 +7,7 @@ import 'react-select/dist/react-select.css';
 import color from '@cdo/apps/util/color';
 import AddResourceDialog from './AddResourceDialog';
 import Button from '@cdo/apps/templates/Button';
+import Dialog from '@cdo/apps/templates/Dialog';
 import {connect} from 'react-redux';
 import {
   addResource,
@@ -67,7 +68,8 @@ class ResourcesEditor extends Component {
     this.state = {
       resourceInput: '',
       searchValue: '',
-      newResourceDialogOpen: false
+      newResourceDialogOpen: false,
+      confirmRemovalDialogOpen: false
     };
   }
 
@@ -148,8 +150,17 @@ class ResourcesEditor extends Component {
     this.props.editResource(resource);
   };
 
-  handleRemove = key => {
-    this.props.removeResource(key);
+  handleRemove = resource => {
+    this.setState({resourceToRemove: resource, confirmRemovalDialogOpen: true});
+  };
+
+  handleRemoveResourceDialogClose = () => {
+    this.setState({resourceToRemove: null, confirmRemovalDialogOpen: false});
+  };
+
+  removeResource = () => {
+    this.props.removeResource(this.state.resourceToRemove.key);
+    this.handleRemoveResourceDialogClose();
   };
 
   handleEdit = resource => {
@@ -179,6 +190,20 @@ class ResourcesEditor extends Component {
             handleClose={this.handleNewResourceDialogClose}
             existingResource={this.state.editingResource}
             courseVersionId={this.props.courseVersionId}
+          />
+        )}
+        {this.state.confirmRemovalDialogOpen && (
+          <Dialog
+            body={`Are you sure you want to remove resource "${
+              this.state.resourceToRemove.name
+            }" from this lesson?`}
+            cancelText="Cancel"
+            confirmText="Delete"
+            confirmType="danger"
+            isOpen={this.state.confirmRemovalDialogOpen}
+            handleClose={this.handleRemoveResourceDialogClose}
+            onCancel={this.handleRemoveResourceDialogClose}
+            onConfirm={this.removeResource}
           />
         )}
         Resources
@@ -231,7 +256,8 @@ class ResourcesEditor extends Component {
                     </div>
                     <div
                       style={styles.remove}
-                      onMouseDown={() => this.handleRemove(resource.key)}
+                      className="unit-test-remove-resource"
+                      onMouseDown={() => this.handleRemove(resource)}
                     >
                       <i className="fa fa-times" />
                     </div>

--- a/apps/test/unit/lib/levelbuilder/lesson-editor/ResourceEditorTest.js
+++ b/apps/test/unit/lib/levelbuilder/lesson-editor/ResourceEditorTest.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import {shallow} from 'enzyme';
+import {mount, shallow} from 'enzyme';
 import sinon from 'sinon';
 import {expect} from '../../../../util/reconfiguredChai';
 import {UnconnectedResourcesEditor as ResourcesEditor} from '@cdo/apps/lib/levelbuilder/lesson-editor/ResourcesEditor';
@@ -25,16 +25,33 @@ describe('ResourcesEditor', () => {
   });
 
   it('can remove a resource', () => {
-    const wrapper = shallow(<ResourcesEditor {...defaultProps} />);
+    const wrapper = mount(<ResourcesEditor {...defaultProps} />);
     const numResources = wrapper.find('tr').length;
     expect(numResources).at.least(2);
-    // Find one of thet "remove" buttons and click it
+    // Find one of the "remove" buttons and click it
     const removeResourceButton = wrapper
-      .find('.fa-times')
-      .first()
-      .parent();
+      .find('.unit-test-remove-resource')
+      .first();
     removeResourceButton.simulate('mouseDown');
+    const removeDialog = wrapper.find('Dialog');
+    const deleteButton = removeDialog.find('button').at(1);
+    deleteButton.simulate('click');
     expect(removeResource).to.have.been.calledOnce;
+  });
+
+  it('can cancel removing a resource', () => {
+    const wrapper = mount(<ResourcesEditor {...defaultProps} />);
+    const numResources = wrapper.find('tr').length;
+    expect(numResources).at.least(2);
+    // Find one of the "remove" buttons and click it
+    const removeResourceButton = wrapper
+      .find('.unit-test-remove-resource')
+      .first();
+    removeResourceButton.simulate('mouseDown');
+    const removeDialog = wrapper.find('Dialog');
+    const cancelButton = removeDialog.find('button').at(0);
+    cancelButton.simulate('click');
+    expect(removeResource).not.to.have.been.called;
   });
 
   it('can add a resource', () => {


### PR DESCRIPTION
Resolves [PLAT-574](https://codedotorg.atlassian.net/browse/PLAT-538).

Dialog:
![Screenshot 2020-12-03 at 2 03 32 PM](https://user-images.githubusercontent.com/46464143/101093953-77f3ae80-3570-11eb-9ff6-6f5b5ff1124d.png)

Cancel delete:
![resource-delete-cancel](https://user-images.githubusercontent.com/46464143/101094326-154ee280-3571-11eb-8e40-c02d688c4cda.gif)


Confirm delete:
![resource-delete-confirm](https://user-images.githubusercontent.com/46464143/101094332-18e26980-3571-11eb-8ade-625f1985bdf1.gif)


<!-- ### Background -->
<!-- ### Privacy -->
<!--
1.	Does the Project involve the collection, use or sharing of new Personal Data?

2.	Does the Project involve a new or changed use or sharing of existing Personal Data?
-->
<!-- ### Security -->
<!--
Link to Jira Task where sensitive security issues are discussed privately.
-->
<!-- ### Caching -->
<!-- ### Deployment strategy -->
<!-- ### Future work -->

## Links

<!--
  Any relevant links to external resources; ie, specification documents, jira
  items, related PRs, honeybadger errors, etc
-->

- [spec]()
- [jira]()

## Testing story

<!--
  Does your change include appropriate tests?

  If so, please describe how the tests included in this PR are sufficient

  If not, please explain why this change does not need to be tested.
-->

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
