### PR TITLE
Move mapping of activities for editor to function for re-use after saving

### DIFF
--- a/apps/src/lib/levelbuilder/lesson-editor/activitiesEditorRedux.js
+++ b/apps/src/lib/levelbuilder/lesson-editor/activitiesEditorRedux.js
@@ -5,6 +5,7 @@ import {
   scriptLevelShape,
   tipShape
 } from '@cdo/apps/lib/levelbuilder/shapes';
+import {LevelStatus} from '@cdo/apps/util/sharedConstants';
 
 const INIT = 'activitiesEditor/INIT';
 const ADD_ACTIVITY = 'activitiesEditor/ADD_ACTIVITY';
@@ -622,6 +623,64 @@ export const getSerializedActivities = rawActivities => {
   });
 
   return JSON.stringify(activities);
+};
+
+export const mapActivityDataForEditor = rawActivities => {
+  // Rename any keys that are different on the backend.
+  rawActivities.forEach(activity => {
+    // React key which must be unique for each object in the list. React
+    // recommends against using the array index for this. We don't want to use
+    // the id column directly, because when we create new objects, we want to
+    // be able specify a react key while leaving the id field blank.
+    //
+    // This is a quirk due to the fact that we are not actually posting to the
+    // server to get a new object id at the time a new object is created in the
+    // UI. If we start doing that, then we should be able to get into a state
+    // where every object has an id, and this key field should become unneeded.
+    activity.key = activity.id + '';
+
+    activity.displayName = activity.name || '';
+    delete activity.name;
+
+    activity.duration = activity.duration || '';
+
+    activity.activitySections.forEach(activitySection => {
+      // React key
+      activitySection.key = activitySection.id + '';
+
+      activitySection.displayName = activitySection.name || '';
+      delete activitySection.name;
+
+      activitySection.text = activitySection.description || '';
+      delete activitySection.description;
+
+      activitySection.scriptLevels = activitySection.scriptLevels || [];
+      activitySection.scriptLevels.forEach(scriptLevel => {
+        scriptLevel.status = LevelStatus.not_tried;
+
+        // The position within the lesson
+        scriptLevel.levelNumber = scriptLevel.position;
+
+        // The position within the activity section
+        scriptLevel.position = scriptLevel.activitySectionPosition;
+
+        delete scriptLevel.activitySectionPosition;
+      });
+
+      activitySection.tips = activitySection.tips || [];
+
+      activitySection.tips.forEach(tip => {
+        // React key
+        tip.key = _.uniqueId();
+      });
+    });
+  });
+
+  if (rawActivities.length === 0) {
+    rawActivities.push(emptyActivity);
+  }
+
+  return rawActivities;
 };
 
 // Use PropTypes.checkPropTypes to enforce that each entry in the array of

--- a/apps/src/sites/studio/pages/lessons/edit.js
+++ b/apps/src/sites/studio/pages/lessons/edit.js
@@ -5,14 +5,12 @@ import LessonEditor from '@cdo/apps/lib/levelbuilder/lesson-editor/LessonEditor'
 import {getStore, registerReducers} from '@cdo/apps/redux';
 import reducers, {
   init,
-  emptyActivity
+  mapActivityDataForEditor
 } from '@cdo/apps/lib/levelbuilder/lesson-editor/activitiesEditorRedux';
 import resourcesEditor, {
   initResources
 } from '@cdo/apps/lib/levelbuilder/lesson-editor/resourcesEditorRedux';
 import {Provider} from 'react-redux';
-import _ from 'lodash';
-import {LevelStatus} from '@cdo/apps/util/sharedConstants';
 
 //TODO Remove once we hook up real level data
 import {levelKeyList} from '../../../../../test/unit/lib/levelbuilder/lesson-editor/activitiesTestData';
@@ -22,62 +20,8 @@ $(document).ready(function() {
   const relatedLessons = getScriptData('relatedLessons');
   const searchOptions = getScriptData('searchOptions');
 
-  const activities = lessonData.activities;
+  const activities = mapActivityDataForEditor(lessonData.activities);
   const objectives = lessonData.objectives || [];
-
-  // Rename any keys that are different on the backend.
-  activities.forEach(activity => {
-    // React key which must be unique for each object in the list. React
-    // recommends against using the array index for this. We don't want to use
-    // the id column directly, because when we create new objects, we want to
-    // be able specify a react key while leaving the id field blank.
-    //
-    // This is a quirk due to the fact that we are not actually posting to the
-    // server to get a new object id at the time a new object is created in the
-    // UI. If we start doing that, then we should be able to get into a state
-    // where every object has an id, and this key field should become unneeded.
-    activity.key = activity.id + '';
-
-    activity.displayName = activity.name || '';
-    delete activity.name;
-
-    activity.duration = activity.duration || '';
-
-    activity.activitySections.forEach(activitySection => {
-      // React key
-      activitySection.key = activitySection.id + '';
-
-      activitySection.displayName = activitySection.name || '';
-      delete activitySection.name;
-
-      activitySection.text = activitySection.description || '';
-      delete activitySection.description;
-
-      activitySection.scriptLevels = activitySection.scriptLevels || [];
-      activitySection.scriptLevels.forEach(scriptLevel => {
-        scriptLevel.status = LevelStatus.not_tried;
-
-        // The position within the lesson
-        scriptLevel.levelNumber = scriptLevel.position;
-
-        // The position within the activity section
-        scriptLevel.position = scriptLevel.activitySectionPosition;
-
-        delete scriptLevel.activitySectionPosition;
-      });
-
-      activitySection.tips = activitySection.tips || [];
-
-      activitySection.tips.forEach(tip => {
-        // React key
-        tip.key = _.uniqueId();
-      });
-    });
-  });
-
-  if (activities.length === 0) {
-    activities.push(emptyActivity);
-  }
 
   // Do the same thing for objective keys as for activity keys above.
   // React needs unique keys for all objects, but objectives don't get


### PR DESCRIPTION
Moves the set up of activities for the activities editor into a function in activitiesEditorRedux so it can be reused in other places in future PRs.
