### PR TITLE
Set max_allowed_packet size in database configuration

### DIFF
--- a/dashboard/config/database.yml
+++ b/dashboard/config/database.yml
@@ -45,6 +45,9 @@ mysql_defaults: &mysql_defaults
   # There is a retry if necessary, so the total effective timeout value is two times the option value.
   write_timeout: 5
 
+  # `MYSQL_OPT_MAX_ALLOWED_PACKET`: This option sets the client-side maximum size of the buffer for client/server communication
+  max_allowed_packet: 268_435_456 # 256MB
+
   # Seamless Database Pool settings:
   # See: https://github.com/bdurand/seamless_database_pool#configuration
   master:


### PR DESCRIPTION
Increasing it from the default of 16MB to 256MB.

It's not yet clear why, but something in https://github.com/rails/rails/pull/37806 has caused `rake db:fixtures:load` to fail with a `Mysql2::Error: Commands out of sync; you can't run this command now` error. The error doesn't manifest if we either remove our largest fixture (`level_sources.yml`) or update this max packet setting.

I'm planning to dig more into why this is happening, but for now I'm simply increasing the configured limit as a short-term workaround.

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
