### PR TITLE
Added log to redux store to log progress in oceans when the user is logged out.

### DIFF
--- a/apps/src/fish/Fish.js
+++ b/apps/src/fish/Fish.js
@@ -1,3 +1,5 @@
+/* global appOptions */
+
 import React from 'react';
 import ReactDOM from 'react-dom';
 import FishView from './FishView';
@@ -6,6 +8,7 @@ import {getStore} from '../redux';
 import {setAssetPath} from '@code-dot-org/ml-activities/dist/assetPath';
 import {TestResults} from '@cdo/apps/constants';
 import fishMsg from './locale';
+import {mergeProgress} from '@cdo/apps/code-studio/progressRedux';
 
 /**
  * On small mobile devices, when in portrait orientation, we show an overlay
@@ -96,6 +99,10 @@ Fish.prototype.init = function(config) {
 
 // Called by the fish app when it wants to go to the next level.
 Fish.prototype.onContinue = function() {
+  const store = getStore();
+  store.dispatch(
+    mergeProgress({[appOptions.serverLevelId]: TestResults.ALL_PASS})
+  );
   const onReportComplete = result => {
     this.studioApp_.onContinue();
   };


### PR DESCRIPTION
Oceans levels report a milestone only when the user clicks the "continue" button. Additionally, oceans levels shortcut all the normal "onComplete" actions that record a logged-out user's progress. Because of this, the "level complete" status was not being recorded for logged-out users. This PR adds a call to the redux store to record the user's progress. Note: The redux store handles syncing to the session storage in order to persist user progress data between page loads.

Repro (without this fix): As a logged out user, go to https://studio.code.org/s/oceans/stage/1/puzzle/2
Complete the level. When the next page loads, no progress is recorded from completing puzzle 2.

More details: https://codedotorg.slack.com/archives/C0T0PNTM3/p1607132125259300
<!--
  Your description goes here: A summary of the change, including any relevant motivation and context.

  If relevant, include a description both of the existing behavior and of the new behavior.
-->

<!--
  Other aspects to consider. uncomment and add detail for any that seem necessary:
-->

<!-- ### Background -->
<!-- ### Privacy -->
<!--
1.	Does the Project involve the collection, use or sharing of new Personal Data?

2.	Does the Project involve a new or changed use or sharing of existing Personal Data?
-->
<!-- ### Security -->
<!--
Link to Jira Task where sensitive security issues are discussed privately.
-->
<!-- ### Caching -->
<!-- ### Deployment strategy -->
<!-- ### Future work -->

## Links

<!--
  Any relevant links to external resources; ie, specification documents, jira
  items, related PRs, honeybadger errors, etc
-->

## Testing story

<!--
  Does your change include appropriate tests?

  If so, please describe how the tests included in this PR are sufficient

  If not, please explain why this change does not need to be tested.
-->

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
