### PR TITLE
Fix missing user progress for standalone video bubbles on cached scripts

### DIFF
--- a/apps/src/sites/studio/pages/levels/_standalone_video.js
+++ b/apps/src/sites/studio/pages/levels/_standalone_video.js
@@ -1,3 +1,4 @@
+/* globals appOptions */
 import $ from 'jquery';
 import {registerGetResult} from '@cdo/apps/code-studio/levels/codeStudioLevels';
 import {
@@ -11,7 +12,42 @@ import ReactDom from 'react-dom';
 import SafeMarkdown from '@cdo/apps/templates/SafeMarkdown';
 import _ from 'lodash';
 
+import {getStore} from '@cdo/apps/code-studio/redux';
+import {
+  overwriteProgress,
+  useDbProgress
+} from '@cdo/apps/code-studio/progressRedux';
+var clientState = require('@cdo/apps/code-studio/clientState');
+import {TestResults} from '@cdo/apps/constants';
+
 $(document).ready(() => {
+  // Get the user's progress on this script
+  $.ajax(
+    `/api/user_progress` +
+      `/${appOptions.scriptName}` +
+      `/${appOptions.stagePosition}` +
+      `/${appOptions.levelPosition}` +
+      `/${appOptions.serverLevelId}`
+  ).done(data => {
+    // Merge progress from server (loaded via AJAX)
+    if (data.progress) {
+      const store = getStore();
+
+      // The server returned progress. This is the source of truth.
+      store.dispatch(useDbProgress());
+      clientState.clearProgress();
+
+      // Clear any existing redux state.
+      store.dispatch(
+        overwriteProgress(
+          _.mapValues(data.progress, level =>
+            level.submitted ? TestResults.SUBMITTED_RESULT : level.result
+          )
+        )
+      );
+    }
+  });
+
   registerGetResult();
 
   // make milestone post

--- a/apps/src/sites/studio/pages/levels/_standalone_video.js
+++ b/apps/src/sites/studio/pages/levels/_standalone_video.js
@@ -21,7 +21,10 @@ var clientState = require('@cdo/apps/code-studio/clientState');
 import {TestResults} from '@cdo/apps/constants';
 
 $(document).ready(() => {
-  // Get the user's progress on this script
+  // Workaround to get the logged-in user's progress on this script
+  // when we loaded a standalone video on a cached script level.
+  // Logged out user progress will be in the session storage. Non-
+  // cached script progress will just be replaced with the same data.
   $.ajax(
     `/api/user_progress` +
       `/${appOptions.scriptName}` +


### PR DESCRIPTION
Cached scripts (i.e. oceans) send no user data to the client on page load. For levels that contain a studio app, this is ok because user data is loaded as part of the app init process. However, for levels that do not contain a studio app (i.e. standalone video levels), no post-page-load call is made to the server, and the user progress is never sent to the client. This will cause progress to appear to be missing even though we have it recorded on the backend. 

Repro: As a logged in user, complete this level: https://studio.code.org/s/oceans/stage/1/puzzle/4 
When the next level loads, notice the progress is missing from level 4.

To fix this, we added an ajax request to the standalone_video level to get the logged-in user's progress.

Additional details: https://codedotorg.slack.com/archives/C0T0PNTM3/p1607144632288800?thread_ts=1607132125.259300&cid=C0T0PNTM3 

<!--
  Your description goes here: A summary of the change, including any relevant motivation and context.

  If relevant, include a description both of the existing behavior and of the new behavior.
-->

<!--
  Other aspects to consider. uncomment and add detail for any that seem necessary:
-->

<!-- ### Background -->
<!-- ### Privacy -->
<!--
1.	Does the Project involve the collection, use or sharing of new Personal Data?

2.	Does the Project involve a new or changed use or sharing of existing Personal Data?
-->
<!-- ### Security -->
<!--
Link to Jira Task where sensitive security issues are discussed privately.
-->
<!-- ### Caching -->
<!-- ### Deployment strategy -->
<!-- ### Future work -->

## Links

<!--
  Any relevant links to external resources; ie, specification documents, jira
  items, related PRs, honeybadger errors, etc
-->


## Testing story

<!--
  Does your change include appropriate tests?

  If so, please describe how the tests included in this PR are sufficient

  If not, please explain why this change does not need to be tested.
-->

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
