### PR TITLE
Temporarily disabled tests that started failing on chrome

### DIFF
--- a/dashboard/test/ui/features/learning_platform/projects/prevent_report_abuse_spam.feature
+++ b/dashboard/test/ui/features/learning_platform/projects/prevent_report_abuse_spam.feature
@@ -62,7 +62,7 @@ Scenario: Report Abuse link hidden if the user already reported Game Lab project
   And element ".ui-test-how-it-works" is visible
   And element ".ui-test-report-abuse" is not visible
 
-@no_ie
+@no_ie @no_chrome
 Scenario: Abuse reports block a project for other viewers
   Given I create a student named "Creator"
   And I make a "applab" project named "Regular Project"
@@ -93,7 +93,7 @@ Scenario: Abuse reports block a project for other viewers
   And I navigate to the last shared URL
   And I wait until element ".exclamation-abuse" is visible
 
-@no_ie
+@no_ie @no_chrome
 Scenario: Projects made by project validators are protected from abuse reports
   Given I create a teacher named "Project Validator"
   And I give user "Project Validator" project validator permission


### PR DESCRIPTION
This test was likely failing due to a chrome update. No code changes caused this failure. It was blocking a bug fix during HOC 2020 and was disabled on Chrome only. Details: https://codedotorg.slack.com/archives/C0T0PNTM3/p1607151244301000

<!--
  Other aspects to consider. uncomment and add detail for any that seem necessary:
-->

<!-- ### Background -->
<!-- ### Privacy -->
<!--
1.	Does the Project involve the collection, use or sharing of new Personal Data?

2.	Does the Project involve a new or changed use or sharing of existing Personal Data?
-->
<!-- ### Security -->
<!--
Link to Jira Task where sensitive security issues are discussed privately.
-->
<!-- ### Caching -->
<!-- ### Deployment strategy -->
<!-- ### Future work -->

## Links

<!--
  Any relevant links to external resources; ie, specification documents, jira
  items, related PRs, honeybadger errors, etc
-->


## Testing story

<!--
  Does your change include appropriate tests?

  If so, please describe how the tests included in this PR are sufficient

  If not, please explain why this change does not need to be tested.
-->

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
