### PR TITLE
Fix HOC signup form when mapboxgl is undefined

### DIFF
--- a/pegasus/sites.v3/hourofcode.com/views/signup_form.haml
+++ b/pegasus/sites.v3/hourofcode.com/views/signup_form.haml
@@ -159,4 +159,4 @@
   var signupErrorMessage = "#{signup_submit_error_message}";
   var censusErrorMessage = "#{signup_submit_census_error_message}";
   var hocYear = "#{hoc_year}"
-  mapboxgl.accessToken = "#{CDO.mapbox_access_token}";
+  if (typeof mapboxgl === 'object') {mapboxgl.accessToken = "#{CDO.mapbox_access_token}";}


### PR DESCRIPTION
*Post merge update on 12/7/20:* This form was later removed entirely from the page; see PR https://github.com/code-dot-org/code-dot-org/pull/38138. The form turns out to have a hard dependency on the interactive map loaded by [this template](https://github.com/code-dot-org/code-dot-org/blob/staging-next/pegasus/sites.v3/hourofcode.com/views/hoc_events_map.haml). Historically the map and form had always lived on the same page.

====
Adds a check for `mapboxgl` before attempting to add the `accessToken` property. This fixes a live site error on HOC that is preventing guests from submitting the Organize an Hour of Code form. 

![image](https://user-images.githubusercontent.com/73763104/101394455-66b2e680-387d-11eb-840c-3b8a7cda0c71.png)


## Links

https://hourofcode.com/us
Start of slack convo
https://codedotorg.slack.com/archives/C0T0PNTM3/p1607207335319400
