### PR TITLE
Remove broken signup form from hourofcode.com, plus banner language tweak

### DIFF
--- a/apps/i18n/common/en_us.json
+++ b/apps/i18n/common/en_us.json
@@ -1717,7 +1717,7 @@
   "stringEquals": "string=?",
   "student": "Student",
   "studentAnnouncementSpecial2020Heading": "Learn computer science at home",
-  "studentAnnouncementSpecial2020Body": "Take a Code Break with us, or see resources for students, parents, and teachers - including videos, fun tutorials, and projects!",
+  "studentAnnouncementSpecial2020Body": "Tune in to a CodeBytes mini-lesson, or see resources for students, parents, and teachers - including videos, fun tutorials, and projects!",
   "studentAnnouncementSpecial2020Button": "Get started",
   "students": "Students",
   "studentFreeResponseAnswers": "Student free response answers",

--- a/pegasus/sites.v3/hourofcode.com/views/home_signup.haml
+++ b/pegasus/sites.v3/hourofcode.com/views/home_signup.haml
@@ -4,21 +4,21 @@
 %a#hocsignupform{name: 'signup'}
 #join
   %h1#join-us-header=hoc_s(:front_join_us_button)
-  -if ["post-hoc", false].include?(hoc_mode)
-    #signup-closed
-      !=hoc_s(:signup_registration_not_required_markdown, markdown: :inline, locals: {hoc_activities_url: resolve_url('/learn'), howto_guide_url: resolve_url('/how-to')})
-      =hoc_s(:signup_registration_closed)
-    =view :index_video
-  -else
-    %h1#thanks-header{style: "display:none;"}=hoc_s(:census_thanks)
-    %div
-      .row
-        .col-md-6
-          =view :signup_form
-        .col-md-6
-          %br
-          =view :index_video
-          %br
+  /-if ["post-hoc", false].include?(hoc_mode)
+  #signup-closed
+    !=hoc_s(:signup_registration_not_required_markdown, markdown: :inline, locals: {hoc_activities_url: resolve_url('/learn'), howto_guide_url: resolve_url('/how-to')})
+    =hoc_s(:signup_registration_closed)
+  =view :index_video
+  / -else
+  /   %h1#thanks-header{style: "display:none;"}=hoc_s(:census_thanks)
+  /   %div
+  /     .row
+  /       .col-md-6
+  /         =view :signup_form
+  /       .col-md-6
+  /         %br
+  /         =view :index_video
+  /         %br
 
-          -if showAnnouncements && hoc_mode != "pre-hoc"
-            =view :announcements
+  /         -if showAnnouncements && hoc_mode != "pre-hoc"
+  /           =view :announcements

--- a/pegasus/sites.v3/hourofcode.com/views/home_signup.haml
+++ b/pegasus/sites.v3/hourofcode.com/views/home_signup.haml
@@ -4,21 +4,21 @@
 %a#hocsignupform{name: 'signup'}
 #join
   %h1#join-us-header=hoc_s(:front_join_us_button)
-  /-if ["post-hoc", false].include?(hoc_mode)
-  #signup-closed
-    !=hoc_s(:signup_registration_not_required_markdown, markdown: :inline, locals: {hoc_activities_url: resolve_url('/learn'), howto_guide_url: resolve_url('/how-to')})
-    =hoc_s(:signup_registration_closed)
-  =view :index_video
-  / -else
-  /   %h1#thanks-header{style: "display:none;"}=hoc_s(:census_thanks)
-  /   %div
-  /     .row
-  /       .col-md-6
-  /         =view :signup_form
-  /       .col-md-6
-  /         %br
-  /         =view :index_video
-  /         %br
+  -if true #["post-hoc", false].include?(hoc_mode)
+    #signup-closed
+      !=hoc_s(:signup_registration_not_required_markdown, markdown: :inline, locals: {hoc_activities_url: resolve_url('/learn'), howto_guide_url: resolve_url('/how-to')})
+      =hoc_s(:signup_registration_closed)
+    =view :index_video
+  -else
+    %h1#thanks-header{style: "display:none;"}=hoc_s(:census_thanks)
+    %div
+      .row
+        .col-md-6
+          =view :signup_form
+        .col-md-6
+          %br
+          =view :index_video
+          %br
 
-  /         -if showAnnouncements && hoc_mode != "pre-hoc"
-  /           =view :announcements
+          -if showAnnouncements && hoc_mode != "pre-hoc"
+            =view :announcements


### PR DESCRIPTION
We are using a static image in place of the usual live map, which is breaking submissions to the signup form. Remove the signup form and display this page as we usually do post-hoc.

**Before:**
<img width="937" alt="Screen Shot 2020-12-05 at 10 38 35 PM" src="https://user-images.githubusercontent.com/224089/101273485-a7f6a980-374a-11eb-8c13-f4405a23d235.png">





**After:**
<img width="959" alt="Screen Shot 2020-12-05 at 10 36 40 PM" src="https://user-images.githubusercontent.com/224089/101273455-68c85880-374a-11eb-87b4-432c87653d9c.png">





Also including a small language tweak to the signed-in homepage banner for English-speaking students; the banner previously referenced "Code Break" and now references "Code Bytes".

<img width="992" alt="Screen Shot 2020-12-05 at 7 16 15 PM" src="https://user-images.githubusercontent.com/224089/101273406-0d966600-374a-11eb-89d3-a8a09cba6e98.png">


<!--
  Your description goes here: A summary of the change, including any relevant motivation and context.

  If relevant, include a description both of the existing behavior and of the new behavior.
-->

<!--
  Other aspects to consider. uncomment and add detail for any that seem necessary:
-->

<!-- ### Background -->
<!-- ### Privacy -->
<!--
1.	Does the Project involve the collection, use or sharing of new Personal Data?

2.	Does the Project involve a new or changed use or sharing of existing Personal Data?
-->
<!-- ### Security -->
<!--
Link to Jira Task where sensitive security issues are discussed privately.
-->
<!-- ### Caching -->
<!-- ### Deployment strategy -->
<!-- ### Future work -->

## Links

<!--
  Any relevant links to external resources; ie, specification documents, jira
  items, related PRs, honeybadger errors, etc
-->

- [spec]()
- [jira]()

## Testing story

<!--
  Does your change include appropriate tests?

  If so, please describe how the tests included in this PR are sufficient

  If not, please explain why this change does not need to be tested.
-->

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
