### PR TITLE
Add Cdo::Throttle module

### DIFF
--- a/lib/cdo/throttle.rb
+++ b/lib/cdo/throttle.rb
@@ -8,7 +8,7 @@ module Cdo
     # @param [String] id - Unique identifier to throttle on.
     # @param [Integer] limit - Number of requests allowed over period.
     # @param [Integer] period - Period of time in seconds.
-    # @param [Integer] throttle_for - How long id should stay throttled. Optional.
+    # @param [Integer] throttle_for - How long id should stay throttled in seconds. Optional.
     # Defaults to Cdo::Throttle.throttle_time.
     # @returns [Boolean] Whether or not the request should be throttled.
     def self.throttle(id, limit, period, throttle_for = throttle_time)

--- a/lib/cdo/throttle.rb
+++ b/lib/cdo/throttle.rb
@@ -1,0 +1,45 @@
+require 'cdo/shared_cache'
+require 'dynamic_config/dcdo'
+
+module Cdo
+  module Throttle
+    CACHE_PREFIX = "cdo_throttle/".freeze
+
+    # @param [String] id - Unique identifier to throttle on.
+    # @param [Integer] limit - Number of requests allowed over period.
+    # @param [Integer] period - Period of time in seconds.
+    # @param [Integer] throttle_for - How long id should stay throttled. Optional.
+    # Defaults to Cdo::Throttle.throttle_time.
+    # @returns [Boolean] Whether or not the request should be throttled.
+    def self.throttle(id, limit, period, throttle_for = throttle_time)
+      full_key = CACHE_PREFIX + id.to_s
+      value = CDO.shared_cache.read(full_key) || empty_value
+      now = Time.now.utc
+      value[:request_timestamps] << now
+
+      if value[:throttled_until]&.future?
+        should_throttle = true
+      else
+        value[:throttled_until] = nil
+        earliest = now - period
+        value[:request_timestamps].select! {|timestamp| timestamp >= earliest}
+        should_throttle = value[:request_timestamps].size > limit
+        value[:throttled_until] = now + throttle_for if should_throttle
+      end
+
+      CDO.shared_cache.write(full_key, value)
+      should_throttle
+    end
+
+    def self.empty_value
+      {
+        throttled_until: nil,
+        request_timestamps: []
+      }
+    end
+
+    def self.throttle_time
+      DCDO.get('throttle_time_default', 60)
+    end
+  end
+end

--- a/lib/test/cdo/test_throttle.rb
+++ b/lib/test/cdo/test_throttle.rb
@@ -1,0 +1,37 @@
+require_relative '../test_helper'
+require 'cdo/throttle'
+require 'timecop'
+
+class ThrottleTest < Minitest::Test
+  def teardown
+    CDO.shared_cache.clear
+  end
+
+  def test_throttle_with_limit_1
+    Timecop.freeze
+    refute Cdo::Throttle.throttle("my_key", 1, 2) # 1/1 reqs per 2s - not throttled
+    Timecop.travel(Time.now.utc + 1)
+    assert Cdo::Throttle.throttle("my_key", 1, 2) # 2/1 reqs per 2s - throttled
+    Timecop.travel(Time.now.utc + Cdo::Throttle.throttle_time - 1)
+    assert Cdo::Throttle.throttle("my_key", 1, 2) # still throttled
+    Timecop.travel(Time.now.utc + Cdo::Throttle.throttle_time)
+    refute Cdo::Throttle.throttle("my_key", 1, 2) # 1/1 reqs per 2s after waiting - not throttled anymore
+    Timecop.travel(Time.now.utc + 1)
+    assert Cdo::Throttle.throttle("my_key", 1, 2) # 2/1 reqs per 2s - throttled again
+  end
+
+  def test_throttle_with_limit_greater_than_1
+    Timecop.freeze
+    refute Cdo::Throttle.throttle("my_key", 2, 2) # 1/2 reqs per 2s - not throttled
+    Timecop.travel(Time.now.utc + 1)
+    refute Cdo::Throttle.throttle("my_key", 2, 2) # 2/2 reqs per 2s - not throttled
+    Timecop.travel(Time.now.utc + 0.5)
+    assert Cdo::Throttle.throttle("my_key", 2, 2) # 3/2 reqs per 2s - throttled
+    Timecop.travel(Time.now.utc + Cdo::Throttle.throttle_time)
+    refute Cdo::Throttle.throttle("my_key", 2, 2) # 1/2 reqs per 2s after waiting - not throttled anymore
+    Timecop.travel(Time.now.utc + 1)
+    refute Cdo::Throttle.throttle("my_key", 2, 2) # 2/2 reqs per 2s - not throttled
+    Timecop.travel(Time.now.utc + 0.5)
+    assert Cdo::Throttle.throttle("my_key", 2, 2) # 3/2 reqs per 2s - throttled again
+  end
+end


### PR DESCRIPTION
Adds a simple module that tracks whether or not a particular ID should be throttled.

`Cdo::Throttle.throttle` uses `CDO.shared_cache` (which uses Elasticache and is shared across all instances) to track timestamps for the given ID, then uses the provided `limit`, `period`, and `throttle_time` arguments to determine how many requests are allowed in the given timeframe, and if requests are above that threshold, how long that ID should be throttled.

Requests are also tracked while the ID is throttled, so making requests while throttled means that ID could stay throttled even after the original `throttle_time` has passed.

**Important note:** Because this module uses IDs to track usage, be sure the ID you provide is unique so it doesn't override unrelated IDs.

**Example:** `Cdo::Throttle.throttle("profanity/a1b2c3", 10, 60, 20)` -- The request tracked by ID `profanity/a1b2c3` can make 10 requests in 60 seconds before it is throttled. Once throttled, it will stay throttled for 20 seconds. 

Also see example usage in #38143.

## Links

<!--
  Any relevant links to external resources; ie, specification documents, jira
  items, related PRs, honeybadger errors, etc
-->

- first part of [STAR-1185](https://codedotorg.atlassian.net/browse/STAR-1185)

## Testing story

Adds unit tests.

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
