### PR TITLE
Hide resources editor if no course version is supplied

### DIFF
--- a/apps/src/lib/levelbuilder/lesson-editor/LessonEditor.jsx
+++ b/apps/src/lib/levelbuilder/lesson-editor/LessonEditor.jsx
@@ -301,13 +301,15 @@ class LessonEditor extends Component {
           />
         </CollapsibleEditorSection>
 
-        <CollapsibleEditorSection
-          title="Resources"
-          collapsed={true}
-          fullWidth={true}
-        >
-          <ResourcesEditor courseVersionId={this.props.courseVersionId} />
-        </CollapsibleEditorSection>
+        {this.props.courseVersionId && (
+          <CollapsibleEditorSection
+            title="Resources"
+            collapsed={true}
+            fullWidth={true}
+          >
+            <ResourcesEditor courseVersionId={this.props.courseVersionId} />
+          </CollapsibleEditorSection>
+        )}
 
         <CollapsibleEditorSection
           title="Objectives"

--- a/apps/src/lib/levelbuilder/lesson-editor/LessonEditor.jsx
+++ b/apps/src/lib/levelbuilder/lesson-editor/LessonEditor.jsx
@@ -301,15 +301,19 @@ class LessonEditor extends Component {
           />
         </CollapsibleEditorSection>
 
-        {this.props.courseVersionId && (
-          <CollapsibleEditorSection
-            title="Resources"
-            collapsed={true}
-            fullWidth={true}
-          >
+        <CollapsibleEditorSection
+          title="Resources"
+          collapsed={true}
+          fullWidth={true}
+        >
+          {this.props.courseVersionId ? (
             <ResourcesEditor courseVersionId={this.props.courseVersionId} />
-          </CollapsibleEditorSection>
-        )}
+          ) : (
+            <h4>
+              Resources cannot be added if a script is not in a course version.
+            </h4>
+          )}
+        </CollapsibleEditorSection>
 
         <CollapsibleEditorSection
           title="Objectives"

--- a/apps/src/lib/levelbuilder/lesson-editor/LessonEditor.jsx
+++ b/apps/src/lib/levelbuilder/lesson-editor/LessonEditor.jsx
@@ -310,7 +310,9 @@ class LessonEditor extends Component {
             <ResourcesEditor courseVersionId={this.props.courseVersionId} />
           ) : (
             <h4>
-              Resources cannot be added if a script is not in a course version.
+              A unit must be in a course version, i.e. a unit must belong to a
+              course or have 'Is a Standalone Course' checked, in order to add
+              resources.
             </h4>
           )}
         </CollapsibleEditorSection>

--- a/apps/test/unit/lib/levelbuilder/lesson-editor/LessonEditorTest.js
+++ b/apps/test/unit/lib/levelbuilder/lesson-editor/LessonEditorTest.js
@@ -48,7 +48,8 @@ describe('LessonEditor', () => {
       initialAnnouncements: [],
       relatedLessons: [],
       initialObjectives: [],
-      initialAssessmentOpportunities: 'Assessment Opportunities'
+      initialAssessmentOpportunities: 'Assessment Opportunities',
+      courseVersionId: 1
     };
   });
 


### PR DESCRIPTION
First and simplest step for [PLAT-505](https://codedotorg.atlassian.net/browse/PLAT-505): hide the resource editor if no course version is provided.

<!-- ### Background -->
<!-- ### Privacy -->
<!--
1.	Does the Project involve the collection, use or sharing of new Personal Data?

2.	Does the Project involve a new or changed use or sharing of existing Personal Data?
-->
<!-- ### Security -->
<!--
Link to Jira Task where sensitive security issues are discussed privately.
-->
<!-- ### Caching -->
<!-- ### Deployment strategy -->
<!-- ### Future work -->

## Links

<!--
  Any relevant links to external resources; ie, specification documents, jira
  items, related PRs, honeybadger errors, etc
-->

- [spec]()
- [jira]()

## Testing story

<!--
  Does your change include appropriate tests?

  If so, please describe how the tests included in this PR are sufficient

  If not, please explain why this change does not need to be tested.
-->

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
