### PR TITLE
Always treat student and section ids as ints

### DIFF
--- a/apps/src/code-studio/components/progress/MiniView.jsx
+++ b/apps/src/code-studio/components/progress/MiniView.jsx
@@ -29,7 +29,7 @@ class MiniView extends React.Component {
     hasGroups: PropTypes.bool.isRequired,
     scriptName: PropTypes.string.isRequired,
     hasFullProgress: PropTypes.bool.isRequired,
-    selectedSectionId: PropTypes.string
+    selectedSectionId: PropTypes.number
   };
 
   render() {
@@ -89,5 +89,5 @@ export default connect(state => ({
   scriptName: state.progress.scriptName,
   hasFullProgress: state.progress.hasFullProgress,
   hasGroups: hasGroups(state.progress),
-  selectedSectionId: state.teacherSections.selectedSectionId.toString()
+  selectedSectionId: state.teacherSections.selectedSectionId
 }))(MiniView);

--- a/apps/src/code-studio/components/progress/MiniViewTopRow.jsx
+++ b/apps/src/code-studio/components/progress/MiniViewTopRow.jsx
@@ -54,7 +54,7 @@ export default class MiniViewTopRow extends React.Component {
     scriptName: PropTypes.string.isRequired,
     // May not have this (i.e if not logged in)
     linesOfCodeText: PropTypes.string,
-    selectedSectionId: PropTypes.string
+    selectedSectionId: PropTypes.number
   };
 
   render() {

--- a/apps/src/code-studio/components/progress/SectionSelector.jsx
+++ b/apps/src/code-studio/components/progress/SectionSelector.jsx
@@ -34,7 +34,7 @@ class SectionSelector extends React.Component {
         id: PropTypes.number.isRequired
       })
     ).isRequired,
-    selectedSectionId: PropTypes.string,
+    selectedSectionId: PropTypes.number,
     selectSection: PropTypes.func.isRequired
   };
 
@@ -96,7 +96,7 @@ export const UnconnectedSectionSelector = SectionSelector;
 
 export default connect(
   state => ({
-    selectedSectionId: state.teacherSections.selectedSectionId.toString(),
+    selectedSectionId: state.teacherSections.selectedSectionId,
     sections: sectionsNameAndId(state.teacherSections)
   }),
   dispatch => ({

--- a/apps/src/code-studio/components/progress/SelectedStudentInfo.jsx
+++ b/apps/src/code-studio/components/progress/SelectedStudentInfo.jsx
@@ -3,10 +3,10 @@ import React from 'react';
 import i18n from '@cdo/locale';
 import {TeacherPanelProgressBubble} from '@cdo/apps/code-studio/components/progress/TeacherPanelProgressBubble';
 import Button from '@cdo/apps/templates/Button';
+import {studentType} from '@cdo/apps/templates/progress/progressTypes';
 import {LevelStatus} from '@cdo/apps/util/sharedConstants';
 import Radium from 'radium';
 import FontAwesome from '@cdo/apps/templates/FontAwesome';
-import {studentShape} from './StudentTable';
 
 const RadiumFontAwesome = Radium(FontAwesome);
 
@@ -45,7 +45,7 @@ const styles = {
 
 export class SelectedStudentInfo extends React.Component {
   static propTypes = {
-    students: PropTypes.arrayOf(studentShape).isRequired,
+    students: PropTypes.arrayOf(studentType).isRequired,
     selectedStudent: PropTypes.object,
     level: PropTypes.object,
     onSelectUser: PropTypes.func.isRequired,

--- a/apps/src/code-studio/components/progress/StageLockDialog.jsx
+++ b/apps/src/code-studio/components/progress/StageLockDialog.jsx
@@ -77,7 +77,7 @@ class StageLockDialog extends React.Component {
         lockStatus: PropTypes.oneOf(Object.values(LockStatus)).isRequired
       })
     ),
-    selectedSectionId: PropTypes.string.isRequired,
+    selectedSectionId: PropTypes.number,
     saving: PropTypes.bool.isRequired,
     saveDialog: PropTypes.func.isRequired
   };
@@ -151,7 +151,7 @@ class StageLockDialog extends React.Component {
     const responsiveHeight = {
       maxHeight: window.innerHeight * 0.8 - 100
     };
-    const hasSelectedSection = this.props.selectedSectionId !== '';
+    const hasSelectedSection = this.props.selectedSectionId !== null;
     const hiddenUnlessSelectedSection = hasSelectedSection ? {} : styles.hidden;
     return (
       <BaseDialog
@@ -331,7 +331,7 @@ export default connect(
     initialLockStatus: state.stageLock.lockStatus,
     isOpen: !!state.stageLock.lockDialogStageId,
     saving: state.stageLock.saving,
-    selectedSectionId: state.teacherSections.selectedSectionId.toString()
+    selectedSectionId: state.teacherSections.selectedSectionId
   }),
   dispatch => ({
     saveDialog(sectionId, lockStatus) {

--- a/apps/src/code-studio/components/progress/StageLockDialog.jsx
+++ b/apps/src/code-studio/components/progress/StageLockDialog.jsx
@@ -151,7 +151,7 @@ class StageLockDialog extends React.Component {
     const responsiveHeight = {
       maxHeight: window.innerHeight * 0.8 - 100
     };
-    const hasSelectedSection = this.props.selectedSectionId !== null;
+    const hasSelectedSection = !!this.props.selectedSectionId;
     const hiddenUnlessSelectedSection = hasSelectedSection ? {} : styles.hidden;
     return (
       <BaseDialog

--- a/apps/src/code-studio/components/progress/StudentTable.jsx
+++ b/apps/src/code-studio/components/progress/StudentTable.jsx
@@ -3,6 +3,7 @@ import PropTypes from 'prop-types';
 import Radium from 'radium';
 import color from '@cdo/apps/util/color';
 import i18n from '@cdo/locale';
+import {studentType} from '@cdo/apps/templates/progress/progressTypes';
 import {TeacherPanelProgressBubble} from '@cdo/apps/code-studio/components/progress/TeacherPanelProgressBubble';
 import FontAwesome from '@cdo/apps/templates/FontAwesome';
 
@@ -52,14 +53,9 @@ const styles = {
   }
 };
 
-export const studentShape = PropTypes.shape({
-  id: PropTypes.number.isRequired,
-  name: PropTypes.string.isRequired
-});
-
 class StudentTable extends React.Component {
   static propTypes = {
-    students: PropTypes.arrayOf(studentShape).isRequired,
+    students: PropTypes.arrayOf(studentType).isRequired,
     onSelectUser: PropTypes.func.isRequired,
     getSelectedUserId: PropTypes.func.isRequired,
     levels: PropTypes.array,

--- a/apps/src/code-studio/components/progress/TeacherPanel.jsx
+++ b/apps/src/code-studio/components/progress/TeacherPanel.jsx
@@ -9,7 +9,8 @@ import {fullyLockedStageMapping} from '../../stageLockRedux';
 import {ViewType} from '../../viewAsRedux';
 import {hasLockableStages} from '../../progressRedux';
 import {pageTypes} from '@cdo/apps/templates/teacherDashboard/teacherSectionsRedux';
-import StudentTable, {studentShape} from './StudentTable';
+import {studentType} from '@cdo/apps/templates/progress/progressTypes';
+import StudentTable from './StudentTable';
 import {teacherDashboardUrl} from '@cdo/apps/templates/teacherDashboard/urlHelpers';
 import {SelectedStudentInfo} from './SelectedStudentInfo';
 import Button from '@cdo/apps/templates/Button';
@@ -76,7 +77,7 @@ class TeacherPanel extends React.Component {
     }),
     scriptHasLockableStages: PropTypes.bool.isRequired,
     unlockedStageNames: PropTypes.arrayOf(PropTypes.string).isRequired,
-    students: PropTypes.arrayOf(studentShape)
+    students: PropTypes.arrayOf(studentType)
   };
 
   logToFirehose = (eventName, overrideData = {}) => {

--- a/apps/src/code-studio/hiddenStageRedux.js
+++ b/apps/src/code-studio/hiddenStageRedux.js
@@ -12,7 +12,7 @@ const SET_HIDDEN_STAGES = 'hiddenStage/SET_HIDDEN_STAGES';
 const UPDATE_HIDDEN_STAGE = 'hiddenStage/UPDATE_HIDDEN_STAGE';
 const UPDATE_HIDDEN_SCRIPT = 'hiddenStage/UPDATE_HIDDEN_SCRIPT';
 
-export const STUDENT_SECTION_ID = 'STUDENT';
+export const STUDENT_SECTION_ID = -2;
 
 const HiddenState = Immutable.Record({
   hiddenStagesInitialized: false,
@@ -91,7 +91,7 @@ export default function reducer(state = new HiddenState(), action) {
   if (action.type === UPDATE_HIDDEN_SCRIPT) {
     const {sectionId, scriptId, hidden} = action;
     const nextState = state.setIn(
-      ['scriptsBySection', sectionId.toString(), scriptId.toString()],
+      ['scriptsBySection', sectionId, scriptId.toString()],
       hidden
     );
     validateSectionIds(nextState);
@@ -244,8 +244,9 @@ export function initializeHiddenScripts(data) {
       data = {[STUDENT_SECTION_ID]: data};
     }
 
-    Object.keys(data).forEach(sectionId => {
-      const hiddenScriptIds = data[sectionId];
+    Object.keys(data).forEach(sectionIdString => {
+      const sectionId = parseInt(sectionIdString);
+      const hiddenScriptIds = data[sectionIdString];
       hiddenScriptIds.forEach(scriptId => {
         dispatch(updateHiddenScript(sectionId, scriptId, true));
       });
@@ -284,5 +285,5 @@ function isHiddenForSection(state, sectionId, itemId, bySectionKey) {
     sectionId = STUDENT_SECTION_ID;
   }
   const bySection = state.get(bySectionKey);
-  return !!bySection.getIn([sectionId.toString(), itemId.toString()]);
+  return !!bySection.getIn([sectionId, itemId.toString()]);
 }

--- a/apps/src/code-studio/hiddenStageRedux.js
+++ b/apps/src/code-studio/hiddenStageRedux.js
@@ -139,7 +139,6 @@ export function updateHiddenScript(sectionId, scriptId, hidden) {
  */
 export function toggleHiddenStage(scriptName, sectionId, stageId, hidden) {
   return dispatch => {
-    // update local state
     dispatch(updateHiddenStage(sectionId, stageId, hidden));
     postToggleHidden(scriptName, sectionId, stageId, hidden);
   };
@@ -159,7 +158,7 @@ export function toggleHiddenScript(scriptName, sectionId, scriptId, hidden) {
  * Post to the server to toggle the hidden state of a stage or script. stageId
  * should be null if we're hiding the script rather than a particular stage
  * @param {string} scriptName
- * @param {string} sectionId
+ * @param {number} sectionId
  * @param {string} stageId
  * @param {boolean} hidden
  */

--- a/apps/src/code-studio/hiddenStageRedux.js
+++ b/apps/src/code-studio/hiddenStageRedux.js
@@ -58,7 +58,9 @@ export default function reducer(state = new HiddenState(), action) {
     const {hiddenStagesPerSection, hideableStagesAllowed} = action;
 
     // Iterate through each section
-    const sectionIds = Object.keys(hiddenStagesPerSection);
+    const sectionIds = Object.keys(hiddenStagesPerSection).map(
+      sectionIdString => parseInt(sectionIdString)
+    );
     let nextState = state;
     sectionIds.forEach(sectionId => {
       // And iterate through each hidden stage within that section

--- a/apps/src/code-studio/progress.js
+++ b/apps/src/code-studio/progress.js
@@ -353,7 +353,7 @@ function initializeStoreWithSections(store, scriptData) {
     };
   }
   store.dispatch(setSections(sections));
-  store.dispatch(selectSection(currentSection.id.toString()));
+  store.dispatch(selectSection(currentSection.id));
 }
 
 function initializeGooglePlatformApi(store) {

--- a/apps/src/lib/ui/ParentLetter.jsx
+++ b/apps/src/lib/ui/ParentLetter.jsx
@@ -40,7 +40,7 @@ const LOGIN_TYPE_NAMES = {
  */
 class ParentLetter extends React.Component {
   static propTypes = {
-    studentId: PropTypes.string,
+    studentId: PropTypes.number,
     autoPrint: PropTypes.bool,
     // Provided by Redux
     section: PropTypes.shape({
@@ -76,9 +76,7 @@ class ParentLetter extends React.Component {
     const loginType = section.loginType;
     const student =
       students.length !== 0 && studentId
-        ? students
-            .filter(student => student.id.toString() === studentId)
-            .shift()
+        ? students.filter(student => student.id === studentId).shift()
         : null;
     const studentName = student ? student.name : 'your student';
     const secretPicturePath = student ? student.secret_picture_path : null;
@@ -152,7 +150,7 @@ export default connect(state => ({
     state.teacherSections.sections[state.teacherSections.selectedSectionId],
   students: state.sectionData.section.students,
   teacherName: state.currentUser.userName,
-  studentId: queryParams('studentId')
+  studentId: parseInt(queryParams('studentId'))
 }))(ParentLetter);
 
 const Header = ({logoUrl}) => {

--- a/apps/src/lib/ui/ParentLetter.story.jsx
+++ b/apps/src/lib/ui/ParentLetter.story.jsx
@@ -51,7 +51,7 @@ export default storybook => {
           }}
           teacherName="Minerva McGonagall"
           students={sampleStudents}
-          studentId={'101'}
+          studentId={101}
         />
       </Page>
     ));

--- a/apps/src/templates/courseOverview/CourseScript.story.js
+++ b/apps/src/templates/courseOverview/CourseScript.story.js
@@ -12,7 +12,7 @@ const unhiddenState = Immutable.fromJS({
   scriptsBySection: {}
 });
 const hiddenState = unhiddenState.setIn(
-  ['stagesBySection', sectionId.toString(), courseId.toString()],
+  ['stagesBySection', sectionId, courseId.toString()],
   true
 );
 

--- a/apps/src/templates/progress/ProgressBubble.jsx
+++ b/apps/src/templates/progress/ProgressBubble.jsx
@@ -90,11 +90,7 @@ class ProgressBubble extends React.Component {
     level: levelType.isRequired,
     disabled: PropTypes.bool.isRequired,
     smallBubble: PropTypes.bool,
-    //TODO: (ErinB) probably change to use just number during post launch clean-up.
-    selectedSectionId: PropTypes.oneOfType([
-      PropTypes.string,
-      PropTypes.number
-    ]),
+    selectedSectionId: PropTypes.number,
     selectedStudentId: PropTypes.oneOfType([
       PropTypes.string,
       PropTypes.number

--- a/apps/src/templates/progress/ProgressBubbleSet.jsx
+++ b/apps/src/templates/progress/ProgressBubbleSet.jsx
@@ -62,11 +62,7 @@ class ProgressBubbleSet extends React.Component {
     levels: PropTypes.arrayOf(levelType).isRequired,
     disabled: PropTypes.bool.isRequired,
     style: PropTypes.object,
-    //TODO: (ErinB) probably change to use just number during post launch clean-up.
-    selectedSectionId: PropTypes.oneOfType([
-      PropTypes.string,
-      PropTypes.number
-    ]),
+    selectedSectionId: PropTypes.number,
     selectedStudentId: PropTypes.oneOfType([
       PropTypes.string,
       PropTypes.number

--- a/apps/src/templates/progress/ProgressLesson.jsx
+++ b/apps/src/templates/progress/ProgressLesson.jsx
@@ -80,7 +80,7 @@ class ProgressLesson extends React.Component {
     showLockIcon: PropTypes.bool.isRequired,
     lessonIsVisible: PropTypes.func.isRequired,
     lessonLockedForSection: PropTypes.func.isRequired,
-    selectedSectionId: PropTypes.string
+    selectedSectionId: PropTypes.number
   };
 
   constructor(props) {
@@ -232,5 +232,5 @@ export default connect(state => ({
   lessonLockedForSection: lessonId =>
     lessonIsLockedForAllStudents(lessonId, state),
   lessonIsVisible: (lesson, viewAs) => lessonIsVisible(lesson, state, viewAs),
-  selectedSectionId: state.teacherSections.selectedSectionId.toString()
+  selectedSectionId: state.teacherSections.selectedSectionId
 }))(ProgressLesson);

--- a/apps/src/templates/progress/ProgressLessonContent.jsx
+++ b/apps/src/templates/progress/ProgressLessonContent.jsx
@@ -24,7 +24,7 @@ export default class ProgressLessonContent extends React.Component {
     description: PropTypes.string,
     levels: PropTypes.arrayOf(levelType).isRequired,
     disabled: PropTypes.bool.isRequired,
-    selectedSectionId: PropTypes.string
+    selectedSectionId: PropTypes.number
   };
 
   render() {

--- a/apps/src/templates/progress/ProgressLessonTeacherInfo.jsx
+++ b/apps/src/templates/progress/ProgressLessonTeacherInfo.jsx
@@ -55,7 +55,9 @@ class ProgressLessonTeacherInfo extends React.Component {
 
   onClickHiddenToggle(value) {
     const {scriptName, section, lesson, toggleHiddenStage} = this.props;
-    const sectionId = (section && section.id) || null;
+    // sectionId will always have a valid value here because the button that
+    // calls this method is only shown when we have a valid sectionId
+    const sectionId = section.id;
     toggleHiddenStage(scriptName, sectionId, lesson.id, value === 'hidden');
     firehoseClient.putRecord(
       {

--- a/apps/src/templates/progress/ProgressLessonTeacherInfo.jsx
+++ b/apps/src/templates/progress/ProgressLessonTeacherInfo.jsx
@@ -55,7 +55,7 @@ class ProgressLessonTeacherInfo extends React.Component {
 
   onClickHiddenToggle(value) {
     const {scriptName, section, lesson, toggleHiddenStage} = this.props;
-    const sectionId = (section && section.id.toString()) || '';
+    const sectionId = (section && section.id) || null;
     toggleHiddenStage(scriptName, sectionId, lesson.id, value === 'hidden');
     firehoseClient.putRecord(
       {
@@ -88,7 +88,7 @@ class ProgressLessonTeacherInfo extends React.Component {
       lessonUrl
     } = this.props;
 
-    const sectionId = (section && section.id.toString()) || '';
+    const sectionId = (section && section.id) || null;
     const showHiddenForSectionToggle =
       section && scriptAllowsHiddenStages && !hasNoSections;
     const isHidden =

--- a/apps/src/templates/progress/ProgressLessonTeacherInfo.story.jsx
+++ b/apps/src/templates/progress/ProgressLessonTeacherInfo.story.jsx
@@ -99,7 +99,7 @@ const createStore = ({preload = false, allowHidden = true} = {}) => {
     });
     store.dispatch(setSections([sections[11]]));
     store.dispatch(setSectionLockStatus(sections));
-    store.dispatch(selectSection('11'));
+    store.dispatch(selectSection(11));
   }
   return store;
 };

--- a/apps/src/templates/progress/ProgressLevelSet.jsx
+++ b/apps/src/templates/progress/ProgressLevelSet.jsx
@@ -64,7 +64,7 @@ class ProgressLevelSet extends React.Component {
     name: PropTypes.string,
     levels: PropTypes.arrayOf(levelType).isRequired,
     disabled: PropTypes.bool.isRequired,
-    selectedSectionId: PropTypes.string
+    selectedSectionId: PropTypes.number
   };
 
   render() {

--- a/apps/src/templates/progress/ProgressPill.jsx
+++ b/apps/src/templates/progress/ProgressPill.jsx
@@ -63,7 +63,7 @@ class ProgressPill extends React.Component {
     text: PropTypes.string,
     tooltip: PropTypes.element,
     disabled: PropTypes.bool,
-    selectedSectionId: PropTypes.string,
+    selectedSectionId: PropTypes.number,
     progressStyle: PropTypes.bool
   };
 

--- a/apps/src/templates/progress/StageLock.jsx
+++ b/apps/src/templates/progress/StageLock.jsx
@@ -34,7 +34,7 @@ class StageLock extends React.Component {
     lesson: lessonType.isRequired,
 
     // redux provided
-    sectionId: PropTypes.string.isRequired,
+    sectionId: PropTypes.number,
     sectionsAreLoaded: PropTypes.bool.isRequired,
     saving: PropTypes.bool.isRequired,
     openLockDialog: PropTypes.func.isRequired,
@@ -74,7 +74,7 @@ class StageLock extends React.Component {
 export const UnconnectedStageLock = StageLock;
 export default connect(
   state => ({
-    sectionId: state.teacherSections.selectedSectionId.toString(),
+    sectionId: state.teacherSections.selectedSectionId,
     sectionsAreLoaded: state.teacherSections.sectionsAreLoaded,
     saving: state.stageLock.saving
   }),

--- a/apps/src/templates/progress/progressTestHelpers.js
+++ b/apps/src/templates/progress/progressTestHelpers.js
@@ -58,7 +58,7 @@ export const createStoreWithHiddenLesson = (viewAs, lessonId) => {
     },
     viewAs: viewAs,
     teacherSections: {
-      selectedSectionId: '11'
+      selectedSectionId: 11
     },
     hiddenStage: Immutable.fromJS({
       stagesBySection: {

--- a/apps/src/templates/progress/progressTypes.js
+++ b/apps/src/templates/progress/progressTypes.js
@@ -1,5 +1,10 @@
 import PropTypes from 'prop-types';
 
+export const studentType = PropTypes.shape({
+  id: PropTypes.number.isRequired,
+  name: PropTypes.string.isRequired
+});
+
 export const levelType = PropTypes.shape({
   status: PropTypes.string.isRequired,
   url: PropTypes.string,

--- a/apps/src/templates/studioHomepages/JoinSectionNotifications.jsx
+++ b/apps/src/templates/studioHomepages/JoinSectionNotifications.jsx
@@ -4,27 +4,35 @@ import React from 'react';
 import Notification from '@cdo/apps/templates/Notification';
 import i18n from '@cdo/locale';
 
-export default function JoinSectionNotifications({action, result, name, id}) {
+export default function JoinSectionNotifications({
+  action,
+  result,
+  sectionName,
+  sectionCode
+}) {
   if (action === 'join' && result === 'success') {
-    return <JoinSectionSuccessNotification sectionName={name} />;
+    return <JoinSectionSuccessNotification sectionName={sectionName} />;
   } else if (action === 'leave' && result === 'success') {
     return (
-      <LeaveSectionSuccessNotification sectionName={name} sectionId={id} />
+      <LeaveSectionSuccessNotification
+        sectionName={sectionName}
+        sectionCode={sectionCode}
+      />
     );
   } else if (action === 'join' && result === 'section_notfound') {
-    return <JoinSectionNotFoundNotification sectionId={id} />;
+    return <JoinSectionNotFoundNotification sectionCode={sectionCode} />;
   } else if (action === 'join' && result === 'fail') {
-    return <JoinSectionFailNotification sectionId={id} />;
+    return <JoinSectionFailNotification sectionCode={sectionCode} />;
   } else if (action === 'join' && result === 'exists') {
-    return <JoinSectionExistsNotification sectionName={name} />;
+    return <JoinSectionExistsNotification sectionName={sectionName} />;
   }
   return null;
 }
 JoinSectionNotifications.propTypes = {
   action: PropTypes.string,
   result: PropTypes.string,
-  name: PropTypes.string,
-  id: PropTypes.string
+  sectionName: PropTypes.string,
+  sectionCode: PropTypes.string
 };
 
 const JoinSectionSuccessNotification = ({sectionName}) => (
@@ -39,34 +47,34 @@ JoinSectionSuccessNotification.propTypes = {
   sectionName: PropTypes.string.isRequired
 };
 
-const LeaveSectionSuccessNotification = ({sectionName, sectionId}) => (
+const LeaveSectionSuccessNotification = ({sectionName, sectionCode}) => (
   <Notification
     type="success"
     notice={i18n.sectionsNotificationSuccess()}
-    details={i18n.sectionsNotificationLeaveSuccess({sectionName, sectionId})}
+    details={i18n.sectionsNotificationLeaveSuccess({sectionName, sectionCode})}
     dismissible={true}
   />
 );
 LeaveSectionSuccessNotification.propTypes =
   JoinSectionSuccessNotification.propTypes;
 
-const JoinSectionNotFoundNotification = ({sectionId}) => (
+const JoinSectionNotFoundNotification = ({sectionCode}) => (
   <Notification
     type="failure"
     notice={i18n.sectionsNotificationFailure()}
-    details={i18n.sectionsNotificationJoinNotFound({sectionId})}
+    details={i18n.sectionsNotificationJoinNotFound({sectionCode})}
     dismissible={true}
   />
 );
 JoinSectionNotFoundNotification.propTypes = {
-  sectionId: PropTypes.string.isRequired
+  sectionCode: PropTypes.string.isRequired
 };
 
-const JoinSectionFailNotification = ({sectionId}) => (
+const JoinSectionFailNotification = ({sectionCode}) => (
   <Notification
     type="failure"
     notice={i18n.sectionsNotificationFailure()}
-    details={i18n.sectionsNotificationJoinFail({sectionId})}
+    details={i18n.sectionsNotificationJoinFail({sectionCode})}
     dismissible={true}
   />
 );

--- a/apps/src/templates/studioHomepages/JoinSectionNotifications.story.jsx
+++ b/apps/src/templates/studioHomepages/JoinSectionNotifications.story.jsx
@@ -12,7 +12,7 @@ export default storybook =>
           <JoinSectionNotifications
             action="join"
             result="success"
-            name="Ada Lovelace Homeroom"
+            sectionName="Ada Lovelace Homeroom"
           />
         )
       },
@@ -22,8 +22,8 @@ export default storybook =>
           <JoinSectionNotifications
             action="leave"
             result="success"
-            name="Ada Lovelace Homeroom"
-            id="BCDFGH"
+            sectionName="Ada Lovelace Homeroom"
+            sectionCode="BCDFGH"
           />
         )
       },
@@ -33,14 +33,18 @@ export default storybook =>
           <JoinSectionNotifications
             action="join"
             result="section_notfound"
-            id="BCDFGH"
+            sectionCode="BCDFGH"
           />
         )
       },
       {
         name: 'Join failed',
         story: () => (
-          <JoinSectionNotifications action="join" result="fail" id="BCDFGH" />
+          <JoinSectionNotifications
+            action="join"
+            result="fail"
+            sectionCode="BCDFGH"
+          />
         )
       },
       {
@@ -49,7 +53,7 @@ export default storybook =>
           <JoinSectionNotifications
             action="join"
             result="exists"
-            name="Ada Lovelace Homeroom"
+            sectionName="Ada Lovelace Homeroom"
           />
         )
       },
@@ -59,7 +63,7 @@ export default storybook =>
           <JoinSectionNotifications
             action={null}
             result={null}
-            id="Ada Lovelace Homeroom"
+            sectionName="Ada Lovelace Homeroom"
           />
         )
       }

--- a/apps/src/templates/studioHomepages/StudentSections.jsx
+++ b/apps/src/templates/studioHomepages/StudentSections.jsx
@@ -19,25 +19,25 @@ export default class StudentSections extends Component {
       sections: props.initialSections,
       action: null,
       result: null,
-      resultName: null,
-      resultId: null
+      sectionName: null,
+      sectionCode: null
     };
   }
 
   updateSections = sections => this.setState({sections});
 
-  updateSectionsResult = (action, result, name, id) => {
+  updateSectionsResult = (action, result, sectionName, sectionCode) => {
     this.setState({
       action: action,
       result: result,
-      resultName: name,
-      resultId: id
+      sectionName: sectionName,
+      sectionCode: sectionCode
     });
   };
 
   render() {
     const {isTeacher} = this.props;
-    const {sections, action, result, resultName, resultId} = this.state;
+    const {sections, action, result, sectionName, sectionCode} = this.state;
     const enrolledInASection = sections.length > 0;
     const heading = isTeacher ? i18n.sectionsJoined() : i18n.sectionsTitle();
     const description = isTeacher ? '' : i18n.enrollmentDescription();
@@ -47,8 +47,8 @@ export default class StudentSections extends Component {
         <JoinSectionNotifications
           action={action}
           result={result}
-          name={resultName}
-          id={resultId}
+          name={sectionName}
+          code={sectionCode}
         />
         {enrolledInASection && (
           <SectionsAsStudentTable

--- a/apps/src/templates/teacherDashboard/EditSectionForm.jsx
+++ b/apps/src/templates/teacherDashboard/EditSectionForm.jsx
@@ -101,7 +101,7 @@ class EditSectionForm extends Component {
     const {section, updateHiddenScript} = this.props;
 
     // Avoid incorrectly showing the hidden unit warning twice.
-    updateHiddenScript(section.id.toString(), section.scriptId, false);
+    updateHiddenScript(section.id, section.scriptId, false);
 
     this.setState({showHiddenUnitWarning: false});
     this.handleSave();

--- a/apps/src/templates/teacherDashboard/SectionLoginInfo.jsx
+++ b/apps/src/templates/teacherDashboard/SectionLoginInfo.jsx
@@ -38,12 +38,10 @@ class SectionLoginInfo extends React.Component {
 
   render() {
     const {studioUrlPrefix, section} = this.props;
-    const singleStudentId = queryParams('studentId');
+    const singleStudentId = parseInt(queryParams('studentId'));
     const autoPrint = !!singleStudentId || !!queryParams('autoPrint');
     const students = singleStudentId
-      ? this.props.students.filter(
-          student => student.id.toString() === singleStudentId
-        )
+      ? this.props.students.filter(student => student.id === singleStudentId)
       : this.props.students;
 
     return (

--- a/apps/src/templates/teacherDashboard/teacherSectionsRedux.js
+++ b/apps/src/templates/teacherDashboard/teacherSectionsRedux.js
@@ -22,8 +22,8 @@ const USER_EDITABLE_SECTION_PROPS = [
 /** @const {number} ID for a new section that has not been saved */
 const PENDING_NEW_SECTION_ID = -1;
 
-/** @const {string} Empty string used to indicate no section selected */
-export const NO_SECTION = '';
+/** @const {null} Null is used to indicate no section selected */
+export const NO_SECTION = null;
 
 /** @const {Object} Map oauth section type to relative "list rosters" URL. */
 const urlByProvider = {

--- a/apps/test/unit/code-studio/components/progress/StageLockDialogTest.jsx
+++ b/apps/test/unit/code-studio/components/progress/StageLockDialogTest.jsx
@@ -9,15 +9,17 @@ const MINIMUM_PROPS = {
   isOpen: false,
   handleClose: () => {},
   initialLockStatus: [],
-  selectedSectionId: '',
+  selectedSectionId: null,
   saving: false,
   saveDialog: () => {}
 };
 
+const fakeSectionId = 12345;
+
 describe('StageLockDialog', () => {
   it('renders with a selected section', () => {
     const wrapper = shallow(
-      <StageLockDialog {...MINIMUM_PROPS} selectedSectionId="fakeSectionId" />
+      <StageLockDialog {...MINIMUM_PROPS} selectedSectionId={fakeSectionId} />
     );
     expect(wrapper).not.to.be.null;
   });
@@ -114,13 +116,13 @@ describe('StageLockDialog', () => {
 
     it('opens a window to the section assessments page', () => {
       const wrapper = shallow(
-        <StageLockDialog {...MINIMUM_PROPS} selectedSectionId="fakeSectionId" />
+        <StageLockDialog {...MINIMUM_PROPS} selectedSectionId={fakeSectionId} />
       );
       expect(window.open).not.to.have.been.called;
 
       wrapper.instance().viewSection();
       expect(window.open).to.have.been.calledOnce.and.calledWith(
-        '/teacher_dashboard/sections/fakeSectionId/assessments'
+        `/teacher_dashboard/sections/${fakeSectionId}/assessments`
       );
     });
   });
@@ -130,7 +132,7 @@ describe('StageLockDialog', () => {
     const wrapper = shallow(
       <StageLockDialog
         {...MINIMUM_PROPS}
-        selectedSectionId="fakeSectionId"
+        selectedSectionId={fakeSectionId}
         initialLockStatus={[
           {name: 'fakeStage1', lockStatus: LockStatus.Editable},
           {name: 'fakeStage2', lockStatus: LockStatus.Editable}
@@ -142,7 +144,7 @@ describe('StageLockDialog', () => {
 
     wrapper.instance().handleSave();
     expect(saveDialog).to.have.been.calledOnce.and.calledWith(
-      'fakeSectionId',
+      fakeSectionId,
       wrapper.state().lockStatus
     );
   });

--- a/apps/test/unit/code-studio/hiddenStageReduxTest.js
+++ b/apps/test/unit/code-studio/hiddenStageReduxTest.js
@@ -78,7 +78,7 @@ describe('hiddenStageRedux', () => {
         hiddenStagesInitialized: true,
         hideableStagesAllowed: true,
         stagesBySection: {
-          STUDENT: {
+          '-2': {
             123: true,
             456: true
           }
@@ -237,18 +237,18 @@ describe('hiddenStageRedux', () => {
     describe('toggleHiddenScript', () => {
       it('updates state and makes POST', () => {
         const dispatch = sinon.spy();
-        toggleHiddenScript('somescript', '123', '45', true)(dispatch);
+        toggleHiddenScript('somescript', 123, '45', true)(dispatch);
 
         assert(
           dispatch.firstCall.calledWithExactly(
-            updateHiddenScript('123', '45', true)
+            updateHiddenScript(123, '45', true)
           )
         );
 
         assert.strictEqual(lastRequest.url, '/s/somescript/toggle_hidden');
         assert.strictEqual(
           lastRequest.requestBody,
-          JSON.stringify({section_id: '123', hidden: true})
+          JSON.stringify({section_id: 123, hidden: true})
         );
       });
     });
@@ -308,21 +308,21 @@ describe('hiddenStageRedux', () => {
 
       it('dispatches for each section/script for teachers', () => {
         const data = {
-          '123': ['1', '2'],
-          '456': ['3']
+          123: ['1', '2'],
+          456: ['3']
         };
         initializeHiddenScripts(data)(dispatch);
         assert.deepEqual(
           dispatch.getCall(0).args[0],
-          updateHiddenScript('123', '1', true)
+          updateHiddenScript(123, '1', true)
         );
         assert.deepEqual(
           dispatch.getCall(1).args[0],
-          updateHiddenScript('123', '2', true)
+          updateHiddenScript(123, '2', true)
         );
         assert.deepEqual(
           dispatch.getCall(2).args[0],
-          updateHiddenScript('456', '3', true)
+          updateHiddenScript(456, '3', true)
         );
       });
 

--- a/apps/test/unit/templates/progress/ProgressBubbleTest.js
+++ b/apps/test/unit/templates/progress/ProgressBubbleTest.js
@@ -358,7 +358,7 @@ describe('ProgressBubble', () => {
         <ProgressBubble
           {...defaultProps}
           currentLocation={fakeLocation}
-          selectedSectionId="12345"
+          selectedSectionId={12345}
         />
       );
       assert.include(wrapper.find('a').prop('href'), 'section_id=12345');
@@ -370,7 +370,7 @@ describe('ProgressBubble', () => {
         <ProgressBubble
           {...defaultProps}
           currentLocation={fakeLocation}
-          selectedSectionId="12345"
+          selectedSectionId={12345}
           selectedStudentId="207"
         />
       );
@@ -395,7 +395,7 @@ describe('ProgressBubble', () => {
         <ProgressBubble
           {...defaultProps}
           currentLocation={fakeLocation}
-          selectedSectionId="12345"
+          selectedSectionId={12345}
         />
       );
       const href = wrapper.find('a').prop('href');

--- a/apps/test/unit/templates/progress/StageLockTest.jsx
+++ b/apps/test/unit/templates/progress/StageLockTest.jsx
@@ -7,7 +7,7 @@ import StageLockDialog from '@cdo/apps/code-studio/components/progress/StageLock
 import Button from '@cdo/apps/templates/Button';
 import i18n from '@cdo/locale';
 
-const FAKE_SECTION_ID = 'fake-section-id';
+const FAKE_SECTION_ID = 42;
 const FAKE_LESSON_ID = 33;
 const DEFAULT_PROPS = {
   lesson: {


### PR DESCRIPTION
<!--
  Your description goes here: A summary of the change, including any relevant motivation and context.

  If relevant, include a description both of the existing behavior and of the new behavior.
-->
Some tech debt clean-up in preparation for a larger refactor of section progress.  The intent of this change is to always treat student and section ids as ints throughout our JS code.  Note that the underlying "maps" of student ids to student info and section ids to section info still store the ids as strings (because the maps are actually plain JS objects which only support string keys).  This should be largely transparent due to JS type coercion rules but can sometimes be visible, e.g. when asking for the keys via `Object.keys()`.

Additional supporting changes:
- Moved studentType from StudentTable into progressTypes.js
- renamed some variables in StudentSections that were section codes and not section ids.
- changed STUDENT_SECTION_ID constant in hiddenStageRedux to be an integer

<!--
  Other aspects to consider. uncomment and add detail for any that seem necessary:
-->
Tip: It's probably easiest to review the two commits separately as they are completely independent.

<!-- ### Background -->
<!-- ### Privacy -->
<!--
1.	Does the Project involve the collection, use or sharing of new Personal Data?

2.	Does the Project involve a new or changed use or sharing of existing Personal Data?
-->
<!-- ### Security -->
<!--
Link to Jira Task where sensitive security issues are discussed privately.
-->
<!-- ### Caching -->
<!-- ### Deployment strategy -->
<!-- ### Future work -->

## Links

<!--
  Any relevant links to external resources; ie, specification documents, jira
  items, related PRs, honeybadger errors, etc
-->

- [jira](https://codedotorg.atlassian.net/browse/LP-1650)

## Testing story

<!--
  Does your change include appropriate tests?

  If so, please describe how the tests included in this PR are sufficient

  If not, please explain why this change does not need to be tested.
-->

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
