### PR TITLE
[Flappy] Switch Back to CDO Blockly

### DIFF
--- a/dashboard/app/helpers/levels_helper.rb
+++ b/dashboard/app/helpers/levels_helper.rb
@@ -312,7 +312,7 @@ module LevelsHelper
     use_blockly = !use_droplet && !use_netsim && !use_weblab
     use_p5 = @level.is_a?(Gamelab)
     hide_source = app_options[:hideSource]
-    use_google_blockly = @level.is_a?(Flappy) || view_options[:useGoogleBlockly]
+    use_google_blockly = view_options[:useGoogleBlockly]
     render partial: 'levels/apps_dependencies',
       locals: {
         app: app_options[:app],

--- a/dashboard/test/ui/features/star_labs/blocklayout.feature
+++ b/dashboard/test/ui/features/star_labs/blocklayout.feature
@@ -8,12 +8,12 @@ Background:
 Scenario: Auto-placing malformed start blocks
   When I've initialized the workspace with an auto-positioned flappy puzzle with extra newlines
   Then block "18" is near offset "16, 16"
-  And block "21" is near offset "16, 114"
+  And block "21" is near offset "16, 107"
 
 Scenario: Auto-placing blocks
   When I've initialized the workspace with an auto-positioned flappy puzzle
   Then block "18" is near offset "16, 16"
-  And block "21" is near offset "16, 114"
+  And block "21" is near offset "16, 107"
 
 Scenario: Auto-placing blocks with XML positioning
   Given I am on "http://studio.code.org/s/allthethings/stage/5/puzzle/4?noautoplay=true"

--- a/dashboard/test/ui/features/star_labs/flappydrag.feature
+++ b/dashboard/test/ui/features/star_labs/flappydrag.feature
@@ -8,4 +8,4 @@ Scenario: Connect two blocks from toolbox
   And I drag block "1" to block "3"
   And I drag block "1" to block "4"
   And I wait for 1 seconds
-  Then block "6" is child of block "4"
+  Then block "5" is child of block "4"


### PR DESCRIPTION
Regression on some iPad versions, reported through zendesk
[slack thread](https://codedotorg.slack.com/archives/C0T0PNTM3/p1607447397420600)