### PR TITLE
Fix printing certificates

### DIFF
--- a/pegasus/sites.v3/code.org/public/printcertificates.haml
+++ b/pegasus/sites.v3/code.org/public/printcertificates.haml
@@ -5,6 +5,8 @@ allow_post: true
 theme: none
 ---
 
+= inline_css("print.css")
+
 -# The correct param here is "script" but we want to support lingering usages of the
   legacy param script as well
 -if ! request.params['script'].nil? && ! request.params['script'].empty?

--- a/shared/css/print.css
+++ b/shared/css/print.css
@@ -1,0 +1,8 @@
+@media all {
+  .page-break { display: none; }
+}
+
+@media print {
+  .page-break { display: block; page-break-before: always; page-break-inside: avoid;}
+  .hide-print { display: none; }
+}


### PR DESCRIPTION
Specifically, re-hide the instructions which were accidentally un-hidden by https://github.com/code-dot-org/code-dot-org/pull/32922

Note that what we're doing here is extracting these lines from `common.css`: https://github.com/code-dot-org/code-dot-org/blob/9a18fc7e2e5edf9c400545bb0239122fc853d233/pegasus/sites.v3/code.org/public/css/common.css#L596-L603

And adding just them to the page `code.org/printcertificates`. Grepping through our codebase indicates that these styles are not used anywhere else, and so they should also be removed from `common.css`, but for the sake of minimizing potential regressions I'll be doing that in a separate PR after Hour of Code.

### Future work

1. Clean up css from common.css
2. Add an eyes test, to prevent this from happening again.

## Testing story

Tested manually on Firefox, Chrome, and IE.

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
