### PR TITLE
proactively silence a few deprecation warnings added in Rails 6.0

### DIFF
--- a/dashboard/config/initializers/backtrace_silencers.rb
+++ b/dashboard/config/initializers/backtrace_silencers.rb
@@ -8,9 +8,15 @@
 
 # In addition to backtrace silencing, we also want to silence annoying deprecations:
 silenced = [
+  # Added in Rails 5.2
   /Single arity template handlers are deprecated/,
   /Dangerous query method \(method whose arguments are used as raw SQL\) called with non-attribute argument\(s\)/,
   /SourceAnnotationExtractor is deprecated! Use Rails::SourceAnnotationExtractor instead/,
+
+  # Added in Rails 6.0
+  /Uniqueness validator will no longer enforce case sensitive comparison in Rails 6.1/,
+  /The asset ".*" is not present in the asset pipeline.Falling back to an asset that may be in the public folder./,
+  /NOT conditions will no longer behave as NOR in Rails 6.1. To continue using NOR conditions, NOT each condition individually/,
 ]
 
 silenced_expr = Regexp.new(silenced.join('|'))


### PR DESCRIPTION
Doing this in advance of the actual upgrade, just so it doesn't get forgot.

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
