### PR TITLE
Add dry run options to import data to schools, school districts, and school stats tables

### DIFF
--- a/dashboard/app/models/school.rb
+++ b/dashboard/app/models/school.rb
@@ -359,9 +359,9 @@ class School < ApplicationRecord
     schools
   end
 
-  def self.dry_seed_s3_object(bucket, filepath, import_options, &block)
+  def self.dry_seed_s3_object(bucket, filepath, import_options, &parse_row)
     AWS::S3.seed_from_file(bucket, filepath, true) do |filename|
-      merge_from_csv(filename, import_options, true, is_dry_run: true, &block)
+      merge_from_csv(filename, import_options, true, is_dry_run: true, &parse_row)
     ensure
       CDO.log.info "This is a dry run. No data is written to the database."
     end

--- a/dashboard/app/models/school_district.rb
+++ b/dashboard/app/models/school_district.rb
@@ -92,11 +92,11 @@ class SchoolDistrict < ApplicationRecord
     end
   end
 
-  def self.dry_seed_s3_object(bucket, filepath, import_options, &test)
+  def self.dry_seed_s3_object(bucket, filepath, import_options, &block)
     AWS::S3.seed_from_file(bucket, filepath, true) do |filename|
-      SchoolDistrict.merge_from_csv(filename, import_options, true, true, &test)
+      merge_from_csv(filename, import_options, true, true, &block)
     end
-    CDO.log.info "This is a dry run. No data is written to the database."
+    CDO.log.info "This is a dry run. No data written to the database."
   end
 
   # Loads/merges the data from a CSV into the school districts table.
@@ -128,7 +128,6 @@ class SchoolDistrict < ApplicationRecord
       end
     end
 
-    # Make prettier?
     CDO.log.info "School District seeding: done processing #{filename}.\n"\
       "#{new_districts.length} new districts added.\n"\
       "Districts added:\n"\

--- a/dashboard/app/models/school_district.rb
+++ b/dashboard/app/models/school_district.rb
@@ -129,12 +129,18 @@ class SchoolDistrict < ApplicationRecord
       end
     end
 
-    CDO.log.info "School District seeding: done processing #{filename}.\n"\
+    summary_message = "School District seeding: done processing #{filename}.\n"\
       "#{new_districts.length} new districts added.\n"\
-      "Districts added:\n"\
-      "#{new_districts.map {|district| district[:name]}.join("\n")}\n"\
       "#{updated_districts} districts updated.\n"\
       "#{unchanged_districts} districts in import with no updates.\n"
+
+    unless new_districts.empty?
+      summary_message <<
+        "Districts added:\n"\
+        "#{new_districts.map {|district| district[:name]}.join("\n")}\n"
+    end
+
+    CDO.log.info summary_message
 
     districts
   end

--- a/dashboard/app/models/school_district.rb
+++ b/dashboard/app/models/school_district.rb
@@ -92,22 +92,49 @@ class SchoolDistrict < ApplicationRecord
     end
   end
 
-  # Loads/merges the data from a CSV into the schools table.
+  def self.dry_seed_s3_object(bucket, filepath, import_options, &test)
+    AWS::S3.seed_from_file(bucket, filepath, true) do |filename|
+      SchoolDistrict.merge_from_csv(filename, import_options, true, true, &test)
+    end
+    CDO.log.info "This is a dry run. No data is written to the database."
+  end
+
+  # Loads/merges the data from a CSV into the school districts table.
   # Requires a block to parse the row.
   # @param filename [String] The CSV file name.
   # @param options [Hash] The CSV file parsing options.
   # @param write_updates [Boolean] Specify whether existing rows should be updated.  Default to true for backwards compatible with existing logic that calls this method to UPSERT school districts.
-  def self.merge_from_csv(filename, options = CSV_IMPORT_OPTIONS, write_updates = true)
-    CSV.read(filename, options).each do |row|
-      parsed = block_given? ? yield(row) : row.to_hash.symbolize_keys
-      loaded = find_by_id(parsed[:id])
-      if loaded.nil?
-        SchoolDistrict.new(parsed).save!
-      elsif write_updates
-        loaded.assign_attributes(parsed)
-        loaded.update!(parsed) if loaded.changed?
+  def self.merge_from_csv(filename, options = CSV_IMPORT_OPTIONS, write_updates = true, dry_run = false)
+    ActiveRecord::Base.transaction do
+      new_districts = []
+      updated_districts = 0
+      unchanged_districts = 0
+
+      CSV.read(filename, options).each do |row|
+        parsed = block_given? ? yield(row) : row.to_hash.symbolize_keys
+        loaded = find_by_id(parsed[:id])
+        if loaded.nil?
+          SchoolDistrict.new(parsed).save! unless dry_run
+          new_districts << parsed
+        elsif write_updates
+          loaded.assign_attributes(parsed)
+          if loaded.changed?
+            loaded.update!(parsed) unless dry_run
+            updated_districts += 1
+          else
+            unchanged_districts += 1
+          end
+        end
       end
     end
+
+    # Make prettier?
+    CDO.log.info "School District seeding: done processing #{filename}.\n"\
+      "#{new_districts.length} new districts added.\n"\
+      "Districts added:\n"\
+      "#{new_districts.map {|district| district[:name]}.join("\n")}\n"\
+      "#{updated_districts} districts updated.\n"\
+      "#{unchanged_districts} districts in import with no updates.\n"
   end
 
   # Download the data in the table to a CSV file.

--- a/dashboard/app/models/school_stats_by_year.rb
+++ b/dashboard/app/models/school_stats_by_year.rb
@@ -75,7 +75,6 @@ class SchoolStatsByYear < ApplicationRecord
         end
       end
 
-      # Make prettier?
       CDO.log.info "School Stats By Years seeding: done processing #{filename}.\n"\
         "#{new_school_stats} school stats added.\n"\
         "#{updated_school_stats} school stats updated.\n"\

--- a/dashboard/test/factories/factories.rb
+++ b/dashboard/test/factories/factories.rb
@@ -1126,7 +1126,7 @@ FactoryGirl.define do
 
   factory :school_common, class: School do
     # school ids are not auto-assigned, so we have to assign one here
-    id {((School.maximum(:id) || 0).next).to_s}
+    id {SecureRandom.hex(6)}
     address_line1 "123 Sample St"
     address_line2 "attn: Main Office"
     city "Seattle"

--- a/dashboard/test/factories/factories.rb
+++ b/dashboard/test/factories/factories.rb
@@ -1126,7 +1126,7 @@ FactoryGirl.define do
 
   factory :school_common, class: School do
     # school ids are not auto-assigned, so we have to assign one here
-    id {(School.maximum(:id).next).to_s}
+    id {((School.maximum(:id) || 0).next).to_s}
     address_line1 "123 Sample St"
     address_line2 "attn: Main Office"
     city "Seattle"

--- a/dashboard/test/models/school_test.rb
+++ b/dashboard/test/models/school_test.rb
@@ -41,7 +41,7 @@ class SchoolTest < ActiveSupport::TestCase
     School.merge_from_csv(School.get_seed_filename(true))
 
     # Arbitrary change that should result in an update to each row.
-    block = proc do |row|
+    parse_row = proc do |row|
       {
         id: row['id'],
         state_school_id: row['state_school_id'],
@@ -52,7 +52,7 @@ class SchoolTest < ActiveSupport::TestCase
     School.any_instance.expects(:save!).never
     School.any_instance.expects(:update!).never
 
-    School.merge_from_csv(School.get_seed_filename(true), is_dry_run: true, &block)
+    School.merge_from_csv(School.get_seed_filename(true), is_dry_run: true, &parse_row)
   end
 
   test 'null state_school_id is valid' do

--- a/dashboard/test/models/school_test.rb
+++ b/dashboard/test/models/school_test.rb
@@ -3,6 +3,11 @@ require 'test_helper'
 class SchoolTest < ActiveSupport::TestCase
   include ActiveSupport::Testing::Stream
 
+  # merge_from_csv dry run tests require a clean schools table.
+  setup_all do
+    School.delete_all
+  end
+
   test "schools initialized from tsv" do
     # Populate school districts, since schools depends on them as a foreign key.
     SchoolDistrict.seed_all(stub_school_data: true, force: true)
@@ -20,6 +25,34 @@ class SchoolTest < ActiveSupport::TestCase
         school_type: 'public',
       }
     )
+  end
+
+  test 'merge_from_csv in dry run mode with blank table makes no database writes' do
+    # Populate school districts, since schools depends on them as a foreign key.
+    SchoolDistrict.seed_all(stub_school_data: true, force: true)
+
+    School.merge_from_csv(School.get_seed_filename(true), is_dry_run: true)
+    assert_equal 0, School.count
+  end
+
+  test 'merge_from_csv in dry run mode with existing rows makes no database writes' do
+    # Populate school districts, since schools depends on them as a foreign key.
+    SchoolDistrict.seed_all(stub_school_data: true, force: true)
+    School.merge_from_csv(School.get_seed_filename(true))
+
+    # Arbitrary change that should result in an update to each row.
+    block = proc do |row|
+      {
+        id: row['id'],
+        state_school_id: row['state_school_id'],
+        name: row['name'] + 'test'
+      }
+    end
+
+    School.any_instance.expects(:save!).never
+    School.any_instance.expects(:update!).never
+
+    School.merge_from_csv(School.get_seed_filename(true), is_dry_run: true, &block)
   end
 
   test 'null state_school_id is valid' do

--- a/dashboard/test/models/school_test.rb
+++ b/dashboard/test/models/school_test.rb
@@ -3,6 +3,8 @@ require 'test_helper'
 class SchoolTest < ActiveSupport::TestCase
   include ActiveSupport::Testing::Stream
 
+  self.use_transactional_test_case = true
+
   # merge_from_csv dry run tests require a clean schools table.
   setup_all do
     School.delete_all


### PR DESCRIPTION
Allows a dry run of importing an S3 object (ie, a CSV that has already been uploaded to S3) via `dry_seed_s3_object`, or an arbitrary CSV (via `merge_from_csv`).

Most detail provided for `schools` import, as this is the most important to get right (since it powers our sign up flow for teachers). 

## Future work

Immediate follow up is to use this code to import 2018-2019 schools, school districts, and school stats. I'll use these new dry run options to put more detail in that PR in the changes that would occur as a result of the import.

## Testing story

I've done manual testing of these changes locally, and added new unit tests to cover the schools import at least.

## Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
