### PR TITLE
Require "new" transactions for user upgrades

### DIFF
--- a/dashboard/app/models/user.rb
+++ b/dashboard/app/models/user.rb
@@ -922,7 +922,7 @@ class User < ApplicationRecord
     email = params.delete(:email)
     hashed_email = params.delete(:hashed_email)
     should_update_contact_info = email.present? || hashed_email.present?
-    transaction do
+    transaction(requres_new: true) do
       update_primary_contact_info!(new_email: email, new_hashed_email: hashed_email) if should_update_contact_info
       update!(params)
     end
@@ -957,7 +957,7 @@ class User < ApplicationRecord
 
     new_attributes = email_preference.nil? ? {} : email_preference
 
-    transaction do
+    transaction(requires_new: true) do
       if migrated?
         update_primary_contact_info!(new_email: email, new_hashed_email: hashed_email)
       else


### PR DESCRIPTION
It's not entirely clear why, but these transactions started failing on the upgrade to Rails 6. Adding the `require_new` argument causes them to start working again.

See https://api.rubyonrails.org/classes/ActiveRecord/Transactions/ClassMethods.html for more info

## Testing story

Relying on our (really quite thorough) existing unit tests

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
