### PR TITLE
Lesson Modifications are announcements not activities

### DIFF
--- a/lib/cdo/lesson_import_helper.rb
+++ b/lib/cdo/lesson_import_helper.rb
@@ -164,9 +164,11 @@ module LessonImportHelper
     sections
   end
 
-  # Adds an announcement for virtual lesson modifications
+  # Adds an announcement for virtual lesson modifications to the lesson. Returns true if
+  # an announcement was added, false otherwise.
   def self.convert_virtual_lesson_modification_activity_to_announcement(activity_data, lesson)
     return false unless activity_data['name'] == 'Lesson Modifications'
+    # Virtual lesson modifications are in google docs, so strip out the docs link
     url_match = /.+[vV]irtual.+\((https:\/\/docs.google.com.+)\).+/.match(activity_data['content'])
     return false unless url_match
     announcement = {


### PR DESCRIPTION
Any activity imported with the title "Lesson Modifications" that contains the word virtual is turned into an announcement about virtual learning. There is [one activity in one lesson](https://curriculum.code.org/csp-20/unit8/3/) that has the title "Lesson Modifications" but isn't about virtual learning that is remaining as an activity for now.

![Screenshot 2020-12-08 at 3 22 25 PM](https://user-images.githubusercontent.com/46464143/101561114-92b39200-3979-11eb-8bae-69e085353bde.png)


<!--
  Your description goes here: A summary of the change, including any relevant motivation and context.

  If relevant, include a description both of the existing behavior and of the new behavior.
-->

<!--
  Other aspects to consider. uncomment and add detail for any that seem necessary:
-->

<!-- ### Background -->
<!-- ### Privacy -->
<!--
1.	Does the Project involve the collection, use or sharing of new Personal Data?

2.	Does the Project involve a new or changed use or sharing of existing Personal Data?
-->
<!-- ### Security -->
<!--
Link to Jira Task where sensitive security issues are discussed privately.
-->
<!-- ### Caching -->
<!-- ### Deployment strategy -->
<!-- ### Future work -->

## Links

<!--
  Any relevant links to external resources; ie, specification documents, jira
  items, related PRs, honeybadger errors, etc
-->

- [spec]()
- [jira]()

## Testing story

<!--
  Does your change include appropriate tests?

  If so, please describe how the tests included in this PR are sufficient

  If not, please explain why this change does not need to be tested.
-->

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
