### PR TITLE
Hide preparation, overview, purpose, and assessment opportunities sections on lesson plans if empty

### DIFF
--- a/apps/src/templates/lessonOverview/LessonOverview.jsx
+++ b/apps/src/templates/lessonOverview/LessonOverview.jsx
@@ -152,8 +152,12 @@ class LessonOverview extends Component {
                 </ul>
               </div>
             )}
-            <h2>{i18n.preparation()}</h2>
-            <SafeMarkdown markdown={lesson.preparation} />
+            {lesson.preparation && (
+              <div>
+                <h2>{i18n.preparation()}</h2>
+                <SafeMarkdown markdown={lesson.preparation} />
+              </div>
+            )}
             {Object.keys(lesson.resources).length > 0 && (
               <div id="resource-section">
                 <h2>{i18n.links()}</h2>

--- a/apps/src/templates/lessonOverview/LessonOverview.jsx
+++ b/apps/src/templates/lessonOverview/LessonOverview.jsx
@@ -126,15 +126,24 @@ class LessonOverview extends Component {
 
         <div style={styles.frontPage}>
           <div style={styles.left}>
-            <h2>{i18n.overview()}</h2>
-            <SafeMarkdown markdown={lesson.overview} />
-
-            <h2>{i18n.purpose()}</h2>
-            <SafeMarkdown markdown={lesson.purpose} />
-
-            <h2>{i18n.assessmentOpportunities()}</h2>
-            <SafeMarkdown markdown={lesson.assessmentOpportunities} />
-
+            {lesson.overview && (
+              <div>
+                <h2>{i18n.overview()}</h2>
+                <SafeMarkdown markdown={lesson.overview} />
+              </div>
+            )}
+            {lesson.purpose && (
+              <div>
+                <h2>{i18n.purpose()}</h2>
+                <SafeMarkdown markdown={lesson.purpose} />
+              </div>
+            )}
+            {lesson.assessmentOpportunities && (
+              <div>
+                <h2>{i18n.assessmentOpportunities()}</h2>
+                <SafeMarkdown markdown={lesson.assessmentOpportunities} />
+              </div>
+            )}
             <h2>{i18n.agenda()}</h2>
             <LessonAgenda activities={this.props.activities} />
           </div>


### PR DESCRIPTION
Title should be self-explanatory. I've been noticing this when I've been comparing CB to studio on the import and it's a quick fix. 😄 

<!-- ### Background -->
<!-- ### Privacy -->
<!--
1.	Does the Project involve the collection, use or sharing of new Personal Data?

2.	Does the Project involve a new or changed use or sharing of existing Personal Data?
-->
<!-- ### Security -->
<!--
Link to Jira Task where sensitive security issues are discussed privately.
-->
<!-- ### Caching -->
<!-- ### Deployment strategy -->
<!-- ### Future work -->

## Links

<!--
  Any relevant links to external resources; ie, specification documents, jira
  items, related PRs, honeybadger errors, etc
-->

- [spec]()
- [jira]()

## Testing story

<!--
  Does your change include appropriate tests?

  If so, please describe how the tests included in this PR are sufficient

  If not, please explain why this change does not need to be tested.
-->

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
