### PR TITLE
add unique constraint to lessons_resources index

### DIFF
--- a/dashboard/db/migrate/20201209073557_add_unique_index_to_lessons_resources.rb
+++ b/dashboard/db/migrate/20201209073557_add_unique_index_to_lessons_resources.rb
@@ -1,0 +1,9 @@
+class AddUniqueIndexToLessonsResources < ActiveRecord::Migration[5.2]
+  def up
+    remove_index :lessons_resources, [:lesson_id, :resource_id]
+    add_index :lessons_resources, [:lesson_id, :resource_id], unique: true
+  end
+
+  def down
+  end
+end

--- a/dashboard/db/schema.rb
+++ b/dashboard/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_11_24_184316) do
+ActiveRecord::Schema.define(version: 2020_12_09_073557) do
 
   create_table "activities", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci", force: :cascade do |t|
     t.integer "user_id"
@@ -557,7 +557,7 @@ ActiveRecord::Schema.define(version: 2020_11_24_184316) do
   create_table "lessons_resources", id: false, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci", force: :cascade do |t|
     t.integer "lesson_id", null: false
     t.integer "resource_id", null: false
-    t.index ["lesson_id", "resource_id"], name: "index_lessons_resources_on_lesson_id_and_resource_id"
+    t.index ["lesson_id", "resource_id"], name: "index_lessons_resources_on_lesson_id_and_resource_id", unique: true
     t.index ["resource_id", "lesson_id"], name: "index_lessons_resources_on_resource_id_and_lesson_id"
   end
 


### PR DESCRIPTION
In preparation for seeding Resources, we need one of the existing indexes on the lessons_resources table to be unique. This is because the activerecord-import library relies on a unique constraint violation occurring in order for it to detect and update an existing row, rather than creating a duplicate row: https://github.com/zdennis/activerecord-import#duplicate-key-update

## Testing story

Verified in local development (wip) that this avoids duplicates when doing an `import!`.
 
# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
