### PR TITLE
add missing annotation on TeacherFeedback model

### DIFF
--- a/dashboard/app/models/teacher_feedback.rb
+++ b/dashboard/app/models/teacher_feedback.rb
@@ -20,6 +20,7 @@
 # Indexes
 #
 #  index_feedback_on_student_and_level_and_teacher_id  (student_id,level_id,teacher_id)
+#  index_teacher_feedbacks_on_teacher_id               (teacher_id)
 #
 
 class TeacherFeedback < ApplicationRecord


### PR DESCRIPTION
Follow-on to https://github.com/code-dot-org/code-dot-org/pull/37993 . This diff has been showing up when I run `rake db:migrate` since that PR was merged:

![Screen Shot 2020-12-09 at 8 53 13 AM](https://user-images.githubusercontent.com/8001765/101660428-039b8e00-39fc-11eb-8c62-3c54d3ede5ec.png)
