### PR TITLE
DO NOT MERGE - Add levels review [ci skip]

### DIFF
--- a/apps/src/lib/levelbuilder/script-editor/scriptEditorRedux.js
+++ b/apps/src/lib/levelbuilder/script-editor/scriptEditorRedux.js
@@ -360,6 +360,9 @@ const serializeLesson = (lesson, levelKeyList) => {
   return s.join('\n');
 };
 
+// It looks like the new script editor already preserves the fields we are
+// worried about: video_key, concepts, level_concept_difficulty, skin.
+
 /**
  * Generate the ScriptDSL format.
  * NOTE: The Script Edit GUI no long includes the editing of levels

--- a/dashboard/app/controllers/levels_controller.rb
+++ b/dashboard/app/controllers/levels_controller.rb
@@ -409,6 +409,12 @@ class LevelsController < ApplicationController
       :description,
       {poems: []},
       {concept_ids: []},
+
+      # level_concept_difficulty_attributes is related to
+      # accepts_nested_attributes_for. anything included in this param would get
+      # set directly onto the level.level_concept_difficulty association. This
+      # is part of how the levelbuilder script update path writes level concept
+      # difficulties, but this wouldn't affect script seed.
       {level_concept_difficulty_attributes: [:id] + LevelConceptDifficulty::CONCEPTS},
       {soft_buttons: []},
       {contained_level_names: []},

--- a/dashboard/config/scripts/coursea-2019.script
+++ b/dashboard/config/scripts/coursea-2019.script
@@ -21,8 +21,6 @@ level 'GoingPlacesSafely-unplugged'
 lesson_group 'csf_sequencing', display_name: 'Sequencing'
 lesson 'Learn to Drag and Drop', display_name: 'Learn to Drag and Drop'
 skin 'jigsaw'
-# Im not seeing how this level_concept_difficulty is getting applied,
-# but I do see that it does end up in the database.
 level_concept_difficulty '{"sequencing":1}'
 level 'blockly:Jigsaw:1', progression: 'Practice'
 skin 'jigsaw'

--- a/dashboard/config/scripts/coursea-2019.script
+++ b/dashboard/config/scripts/coursea-2019.script
@@ -21,6 +21,8 @@ level 'GoingPlacesSafely-unplugged'
 lesson_group 'csf_sequencing', display_name: 'Sequencing'
 lesson 'Learn to Drag and Drop', display_name: 'Learn to Drag and Drop'
 skin 'jigsaw'
+# Im not seeing how this level_concept_difficulty is getting applied,
+# but I do see that it does end up in the database.
 level_concept_difficulty '{"sequencing":1}'
 level 'blockly:Jigsaw:1', progression: 'Practice'
 skin 'jigsaw'

--- a/dashboard/lib/level_loader.rb
+++ b/dashboard/lib/level_loader.rb
@@ -48,6 +48,10 @@ class LevelLoader
         changed_levels.reject!(&:encrypted?)
       end
 
+      # I see that level_concept_difficultys which live inside levels are seeded
+      # here, but I haven't found where they are seeded when they are specified
+      # in the .script file.
+
       # activerecord-import (with MySQL, anyway) doesn't save associated
       # models, so we've got to do this manually.
       changed_lcds = changed_levels.map(&:level_concept_difficulty).compact

--- a/dashboard/lib/level_loader.rb
+++ b/dashboard/lib/level_loader.rb
@@ -49,7 +49,7 @@ class LevelLoader
       end
 
       # I see that level_concept_difficultys which live inside levels are seeded
-      # here, but I haven't found where they are seeded when they are specified
+      # here, but this wouldn't affect how they are seeded when they are specified
       # in the .script file.
 
       # activerecord-import (with MySQL, anyway) doesn't save associated


### PR DESCRIPTION
Where I think this leaves us (@dmcavoy feel free to edit/update):

Fields in question: `skin`, `video_key`, `concepts`, `level_concept_difficulties`

At a minimum, for fields which appear in CSD/CSP/CSF 20-21 .script files, we need to do one of the following:

1. make sure everything is preserved in the following cases for each field:
    * save new script edit page (already preserves all 4 fields)
    * save new lesson edit page (I think this already preserves, may need to be confirmed)
    * new serialize / seed
2. Or, move the property into the levels.js file.

What I see in terms of where we are on these:
* `skin` could be moved into levels.js, or could be added to new script seed.
* `video_key` cannot be added to levels.js. needs to be added to new script seed. or could be ignored for now, because it only affects one level in CSF 2020.
* `level_concept_difficulties` I think this is used for reporting and/or used elsewhere on the server (need to confirm). If it is, then we can't move to levels.js. Next idea from @dmcavoy would be the one about trusting the rest of the seed process to set this already when earlier scripts are seeded (e.g. coursea-2019) for January Launch, then follow up to fix adding/editing for January ASAP.
* `concepts` ~same as level_concept_difficulties ?~ not in use in CSF/CSD/CSP 2020. can ignore for now. 
