### PR TITLE
Enable playSpeech functionality for script_levels

### DIFF
--- a/apps/src/AzureTextToSpeech.js
+++ b/apps/src/AzureTextToSpeech.js
@@ -94,9 +94,7 @@ export default class AzureTextToSpeech {
    * @param {string} opts.text
    * @param {string} opts.gender
    * @param {string} opts.languageCode
-   * @param {string} opts.url URL to request sound from.
-   * @param {string} opts.ssml SSML in request body.
-   * @param {string} opts.token Authentication token from Azure.
+   * @param {string} opts.authenticityToken Rails authenticity token. Optional.
    * @param {function(string)} opts.onFailure Called with an error message if the sound will not be played.
    * @returns {function} A thunk that returns a promise, which resolves to a SoundResponse. Example usage:
    * const soundPromise = createSoundPromise(options);

--- a/apps/src/code-studio/appOptions.js
+++ b/apps/src/code-studio/appOptions.js
@@ -63,6 +63,8 @@
  * @property {string} teacherMarkdown
  * @property {DialogOptions} dialog
  * @property {string} locale
+ * @property {?Object} azureSpeechServiceVoices
+ * @property {?string} authenticityToken
  */
 
 /**

--- a/apps/src/lib/util/audioApi.js
+++ b/apps/src/lib/util/audioApi.js
@@ -134,7 +134,10 @@ export const commands = {
       OPTIONAL
     );
 
-    const {azureSpeechServiceVoices: voices} = appOptions;
+    // appOptions.authenticityToken is only expected/used when using this block on a script_level.
+    // This is because script_levels remove Rails' authenticity token from the DOM for caching purposes:
+    // https://github.com/code-dot-org/code-dot-org/pull/5753
+    const {azureSpeechServiceVoices: voices, authenticityToken} = appOptions;
     let {text, gender, language} = opts;
 
     // Fall back to defaults if requested language/gender combination is not available.
@@ -154,6 +157,7 @@ export const commands = {
       text,
       gender,
       languageCode: voices[language].languageCode,
+      authenticityToken,
       onFailure: message => outputWarning(message + '\n')
     });
     azureTTS.enqueueAndPlay(promise);

--- a/apps/src/utils.js
+++ b/apps/src/utils.js
@@ -820,15 +820,22 @@ export function escapeRegExp(str) {
  * Detects profanity in a string.
  * @param {string} text
  * @param {string} locale Optional.
+ * @param {string} authenticityToken Rails authenticity token. Optional.
  * @returns {Array<string>|null} Array of profane words.
  */
-export const findProfanity = (text, locale) => {
-  return $.ajax({
+export const findProfanity = (text, locale, authenticityToken = null) => {
+  let request = {
     url: '/profanity/find',
     method: 'POST',
     contentType: 'application/json;charset=UTF-8',
     data: JSON.stringify({text, locale})
-  });
+  };
+
+  if (authenticityToken) {
+    request.headers = {'X-CSRF-Token': authenticityToken};
+  }
+
+  return $.ajax(request);
 };
 
 /**

--- a/dashboard/app/controllers/script_levels_controller.rb
+++ b/dashboard/app/controllers/script_levels_controller.rb
@@ -483,7 +483,9 @@ class ScriptLevelsController < ApplicationController
       has_i18n: @game.has_i18n?,
       is_challenge_level: @script_level.challenge,
       is_bonus_level: @script_level.bonus,
-      useGoogleBlockly: params[:blocklyVersion] == "Google"
+      useGoogleBlockly: params[:blocklyVersion] == "Google",
+      azure_speech_service_voices: azure_speech_service_options[:voices],
+      authenticity_token: form_authenticity_token
     )
     readonly_view_options if @level.channel_backed? && params[:version]
 

--- a/dashboard/app/helpers/view_options_helper.rb
+++ b/dashboard/app/helpers/view_options_helper.rb
@@ -35,9 +35,8 @@ module ViewOptionsHelper
     :responsive_content, # The container for the main page content will be responsive to small screen sizes.
     :answerdash,
     :signed_replay_log_url,
-    :azure_speech_service_token,
-    :azure_speech_service_url,
     :azure_speech_service_voices,
+    :authenticity_token,
     :useGoogleBlockly
   )
   # Sets custom options to be used by the view layer. The option hash is frozen once read.


### PR DESCRIPTION
This change allows the `playSpeech` block to be used on script_levels (e.g., `/s/:script_name/stage/:stage_num/puzzle/:puzzle_num`) by passing the available voices from Azure and the Rails authenticity token to the client.

The `script_levels_controller` explicitly removes Rails' authenticity token here:
https://github.com/code-dot-org/code-dot-org/blob/60b6ec75cb41af8b57f1cea5d5cf5a5e44766cae/dashboard/app/controllers/script_levels_controller.rb#L503-L506

...which is why the token is needed for script_levels but was not needed for projects routes. Without this token, when we make POST requests to our server (via `POST /profanity/find` and `POST /dashboardapi/v1/text_to_speech/azure`), the server will return a 422 with an "InvalidAuthenticityToken" error.

## Links

<!--
  Any relevant links to external resources; ie, specification documents, jira
  items, related PRs, honeybadger errors, etc
-->

- [STAR-1348](https://codedotorg.atlassian.net/browse/STAR-1348)

## Testing story

Relying on existing unit tests.

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
