### PR TITLE
Update sublevels to always use a level id

### DIFF
--- a/apps/src/code-studio/components/BubbleChoice.jsx
+++ b/apps/src/code-studio/components/BubbleChoice.jsx
@@ -1,10 +1,10 @@
 import React from 'react';
-import PropTypes from 'prop-types';
 import i18n from '@cdo/locale';
 import color from '@cdo/apps/util/color';
 import {navigateToHref} from '@cdo/apps/utils';
 import SafeMarkdown from '@cdo/apps/templates/SafeMarkdown';
 import SublevelCard from './SublevelCard';
+import {levelTypeWithoutStatus} from '@cdo/apps/templates/progress/progressTypes';
 
 const MARGIN = 10;
 
@@ -29,27 +29,9 @@ const styles = {
 };
 
 export default class BubbleChoice extends React.Component {
-  static propTypes = {
-    level: PropTypes.shape({
-      display_name: PropTypes.string.isRequired,
-      description: PropTypes.string.isRequired,
-      previous_level_url: PropTypes.string,
-      redirect_url: PropTypes.string,
-      script_url: PropTypes.string,
-      sublevels: PropTypes.arrayOf(
-        PropTypes.shape({
-          id: PropTypes.number.isRequired,
-          display_name: PropTypes.string.isRequired,
-          description: PropTypes.string,
-          thumbnail_url: PropTypes.string,
-          url: PropTypes.string.isRequired,
-          position: PropTypes.number,
-          letter: PropTypes.string,
-          perfect: PropTypes.bool
-        })
-      )
-    })
-  };
+  // The bubble choice component doesn't need the status. It's
+  // only rendering the sublevel cards.
+  static propTypes = {level: levelTypeWithoutStatus};
 
   goToUrl = url => {
     navigateToHref(url + location.search);

--- a/apps/src/code-studio/components/SublevelCard.jsx
+++ b/apps/src/code-studio/components/SublevelCard.jsx
@@ -7,6 +7,7 @@ import FontAwesome from '@cdo/apps/templates/FontAwesome';
 import LessonExtrasFlagIcon from '@cdo/apps/templates/progress/LessonExtrasFlagIcon';
 import MazeThumbnail from '@cdo/apps/code-studio/components/lessonExtras/MazeThumbnail';
 import queryString from 'query-string';
+import {levelType} from '@cdo/apps/templates/progress/progressTypes';
 
 const THUMBNAIL_IMAGE_SIZE = 200;
 const MARGIN = 10;
@@ -84,18 +85,7 @@ const styles = {
 export default class SublevelCard extends React.Component {
   static propTypes = {
     isLessonExtra: PropTypes.bool,
-    sublevel: PropTypes.shape({
-      id: PropTypes.number.isRequired,
-      display_name: PropTypes.string.isRequired,
-      description: PropTypes.string,
-      thumbnail_url: PropTypes.string,
-      url: PropTypes.string.isRequired,
-      position: PropTypes.number,
-      letter: PropTypes.string,
-      perfect: PropTypes.bool,
-      type: PropTypes.string,
-      maze_summary: PropTypes.object
-    }),
+    sublevel: levelType,
     sectionId: PropTypes.number,
     userId: PropTypes.number
   };

--- a/apps/src/templates/progress/progressHelpers.js
+++ b/apps/src/templates/progress/progressHelpers.js
@@ -168,9 +168,9 @@ export function summarizeProgressInStage(levelsWithStatus) {
  * The level object passed down to use via the server (and stored in stage.stages.levels)
  * contains more data than we need. This filters to the parts our views care about.
  */
-export const processedLevel = level => {
+export const processedLevel = (level, isSublevel) => {
   return {
-    id: level.activeId,
+    id: isSublevel ? level.id : level.activeId,
     url: level.url,
     name: level.name,
     progression: level.progression,
@@ -181,6 +181,8 @@ export const processedLevel = level => {
     levelNumber: level.kind === LevelKind.unplugged ? undefined : level.title,
     isConceptLevel: level.is_concept_level,
     bonus: level.bonus,
-    sublevels: level.sublevels
+    sublevels:
+      level.sublevels &&
+      level.sublevels.map(level => processedLevel(level, true))
   };
 };

--- a/apps/src/templates/progress/progressTypes.js
+++ b/apps/src/templates/progress/progressTypes.js
@@ -1,7 +1,19 @@
 import PropTypes from 'prop-types';
 
-export const levelType = PropTypes.shape({
-  status: PropTypes.string.isRequired,
+/**
+ * @typedef {Object} Level
+ *
+ * @property {number} id
+ * @property {string} url
+ * @property {string} name
+ * @property {string} icon
+ * @property {bool} isUnplugged
+ * @property {number} levelNumber
+ * @property {bool} isCurrentLevel
+ * @property {bool} isConceptLevel
+ * @property {string} kind
+ */
+const levelWithoutStatusShape = {
   id: PropTypes.number.isRequired,
   url: PropTypes.string,
   name: PropTypes.string,
@@ -10,8 +22,26 @@ export const levelType = PropTypes.shape({
   levelNumber: PropTypes.number,
   isCurrentLevel: PropTypes.bool,
   isConceptLevel: PropTypes.bool,
-  kind: PropTypes.string,
-  sublevels: PropTypes.arrayOf(PropTypes.object)
+  kind: PropTypes.string
+};
+
+// Avoid recursive definition
+levelWithoutStatusShape.sublevels = PropTypes.arrayOf(
+  PropTypes.shape(levelWithoutStatusShape)
+);
+
+// In the future when the level object does not contain the status object,
+// we can export just levelType without needing levelTypeWithoutStatus.
+export const levelTypeWithoutStatus = PropTypes.shape(levelWithoutStatusShape);
+
+/**
+ * @typedef {Object} Level
+ *
+ * @property {string} status
+ */
+export const levelType = PropTypes.shape({
+  ...levelWithoutStatusShape,
+  status: PropTypes.string.isRequired
 });
 
 /**

--- a/dashboard/app/models/levels/bubble_choice.rb
+++ b/dashboard/app/models/levels/bubble_choice.rb
@@ -77,6 +77,7 @@ class BubbleChoice < DSLDefined
   def summarize(script_level: nil, user: nil)
     user_id = user ? user.id : nil
     summary = {
+      id: id,
       display_name: display_name,
       description: description,
       name: name,
@@ -134,6 +135,10 @@ class BubbleChoice < DSLDefined
       if user_id
         level_info[:perfect] = UserLevel.find_by(level: level, user_id: user_id)&.perfect?
         level_info[:status] = level_info[:perfect] ? SharedConstants::LEVEL_STATUS.perfect : SharedConstants::LEVEL_STATUS.not_tried
+      else
+        # Pass an empty status if the user is not logged in so the ProgressBubble
+        # in the sublevel display can render correctly.
+        level_info[:status] = SharedConstants::LEVEL_STATUS.not_tried
       end
 
       summary << level_info


### PR DESCRIPTION
Follow-up to https://github.com/code-dot-org/code-dot-org/pull/38085

From that PR:
"""
This is a sub-task of the progress data refactor.

Looking up level progress by level ID is an eventual goal of the progress data refactor. This is the first step. In the past, the level id would not be included in the level object. Now, that ID is a required part of the object and is verified through prop-types. Additionally, locations where a level is used now use levelType.
"""

This PR finishes that work by enforcing the existence of level ID in bubble choice levels and sublevels. 

Note: sublevels cards don't display progress if the user is logged out. Currently, when logged out, sublevel cards will always display the "in progress" status regardless of what the user has done. With this change, sublevel cards will always display the "not started" status when logged out.

<!--
  Other aspects to consider. uncomment and add detail for any that seem necessary:
-->

<!-- ### Background -->
<!-- ### Privacy -->
<!--
1.	Does the Project involve the collection, use or sharing of new Personal Data?

2.	Does the Project involve a new or changed use or sharing of existing Personal Data?
-->
<!-- ### Security -->
<!--
Link to Jira Task where sensitive security issues are discussed privately.
-->
<!-- ### Caching -->
<!-- ### Deployment strategy -->
<!-- ### Future work -->

## Links

<!--
  Any relevant links to external resources; ie, specification documents, jira
  items, related PRs, honeybadger errors, etc
-->

- [investigation PR](https://github.com/code-dot-org/code-dot-org/pull/37930)
- [LP-1651](https://codedotorg.atlassian.net/browse/LP-1651)

## Testing story

<!--
  Does your change include appropriate tests?

  If so, please describe how the tests included in this PR are sufficient

  If not, please explain why this change does not need to be tested.
-->

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
