### PR TITLE
Fix lesson activity section activity section positions

### DIFF
--- a/lib/cdo/lesson_import_helper.rb
+++ b/lib/cdo/lesson_import_helper.rb
@@ -158,6 +158,7 @@ module LessonImportHelper
     final_position = 1
     sections.each do |section|
       section.position = final_position
+      section.save!
       final_position += 1
     end
 
@@ -185,7 +186,8 @@ module LessonImportHelper
   end
 
   def self.create_lesson_activities(activities_data, levels, lesson)
-    activities = activities_data.map.with_index(1) do |a, i|
+    position = 1
+    activities = activities_data.map do |a|
       if a['name'] == 'Lesson Modifications' && convert_virtual_lesson_modification_activity_to_announcement(a, lesson)
         nil
       else
@@ -194,7 +196,8 @@ module LessonImportHelper
         lesson_activity.duration = a['duration'].split[0].to_i
         lesson_activity.lesson_id = lesson.id
         lesson_activity.key = SecureRandom.uuid
-        lesson_activity.position = i
+        lesson_activity.position = position
+        position += 1
         lesson_activity.save!
         lesson_activity.reload
         lesson_activity.activity_sections = create_activity_sections(a['content'], lesson_activity.id, levels)


### PR DESCRIPTION
- I had been setting activity positions by index, but when I moved lesson modifications to be announcements, it broke this
- For some reason the activity section positions weren't getting saved correctly. I put a save in there and they started saving correctly.

<!--
  Your description goes here: A summary of the change, including any relevant motivation and context.

  If relevant, include a description both of the existing behavior and of the new behavior.
-->

<!--
  Other aspects to consider. uncomment and add detail for any that seem necessary:
-->

<!-- ### Background -->
<!-- ### Privacy -->
<!--
1.	Does the Project involve the collection, use or sharing of new Personal Data?

2.	Does the Project involve a new or changed use or sharing of existing Personal Data?
-->
<!-- ### Security -->
<!--
Link to Jira Task where sensitive security issues are discussed privately.
-->
<!-- ### Caching -->
<!-- ### Deployment strategy -->
<!-- ### Future work -->

## Links

<!--
  Any relevant links to external resources; ie, specification documents, jira
  items, related PRs, honeybadger errors, etc
-->

- [spec]()
- [jira]()

## Testing story

<!--
  Does your change include appropriate tests?

  If so, please describe how the tests included in this PR are sufficient

  If not, please explain why this change does not need to be tested.
-->

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
