### PR TITLE
Revert "Revert "Allow editors to move activity sections between activities""

### DIFF
--- a/apps/src/lib/levelbuilder/lesson-editor/ActivitiesEditor.jsx
+++ b/apps/src/lib/levelbuilder/lesson-editor/ActivitiesEditor.jsx
@@ -48,7 +48,8 @@ class ActivitiesEditor extends Component {
   handleAddActivity = () => {
     this.props.addActivity(
       this.props.activities.length,
-      this.generateActivityKey()
+      this.generateActivityKey(),
+      this.generateActivitySectionKey()
     );
   };
 
@@ -63,6 +64,25 @@ class ActivitiesEditor extends Component {
     }
 
     return `activity-${activityNumber}`;
+  };
+
+  generateActivitySectionKey = () => {
+    let activitySectionNumber = 1;
+
+    let activitySectionKeys = [];
+    this.props.activities.forEach(activity => {
+      activity.activitySections.forEach(section => {
+        activitySectionKeys.push(section.key);
+      });
+    });
+
+    while (
+      activitySectionKeys.includes(`activitySection-${activitySectionNumber}`)
+    ) {
+      activitySectionNumber++;
+    }
+
+    return `activitySection-${activitySectionNumber}`;
   };
 
   // To be populated with the react ref of each ActivitySectionCard element.
@@ -122,6 +142,7 @@ class ActivitiesEditor extends Component {
           <ActivityCardAndPreview
             key={activity.key}
             activity={activity}
+            generateActivitySectionKey={this.generateActivitySectionKey}
             activitiesCount={activities.length}
             setActivitySectionRef={this.setActivitySectionRef}
             updateTargetActivitySection={this.updateTargetActivitySection}

--- a/apps/src/lib/levelbuilder/lesson-editor/ActivityCard.jsx
+++ b/apps/src/lib/levelbuilder/lesson-editor/ActivityCard.jsx
@@ -69,6 +69,7 @@ const styles = {
 class ActivityCard extends Component {
   static propTypes = {
     activity: activityShape.isRequired,
+    generateActivitySectionKey: PropTypes.func.isRequired,
     activitiesCount: PropTypes.number.isRequired,
     setActivitySectionRef: PropTypes.func.isRequired,
     updateTargetActivitySection: PropTypes.func.isRequired,
@@ -90,22 +91,8 @@ class ActivityCard extends Component {
   handleAddActivitySection = () => {
     this.props.addActivitySection(
       this.props.activity.position,
-      this.generateActivitySectionKey()
+      this.props.generateActivitySectionKey()
     );
-  };
-
-  generateActivitySectionKey = () => {
-    let activitySectionNumber = this.props.activity.activitySections.length + 1;
-    while (
-      this.props.activity.activitySections.some(
-        activitySection =>
-          activitySection.key === `activitySection-${activitySectionNumber}`
-      )
-    ) {
-      activitySectionNumber++;
-    }
-
-    return `activitySection-${activitySectionNumber}`;
   };
 
   handleMoveActivity = direction => {

--- a/apps/src/lib/levelbuilder/lesson-editor/ActivityCardAndPreview.jsx
+++ b/apps/src/lib/levelbuilder/lesson-editor/ActivityCardAndPreview.jsx
@@ -30,6 +30,7 @@ const styles = {
 export default class ActivityCardAndPreview extends Component {
   static propTypes = {
     activity: activityShape,
+    generateActivitySectionKey: PropTypes.func.isRequired,
     activitiesCount: PropTypes.number,
     setActivitySectionRef: PropTypes.func.isRequired,
     updateTargetActivitySection: PropTypes.func.isRequired,
@@ -60,6 +61,7 @@ export default class ActivityCardAndPreview extends Component {
         <div style={styles.editor}>
           <ActivityCard
             activity={activity}
+            generateActivitySectionKey={this.props.generateActivitySectionKey}
             activitiesCount={this.props.activitiesCount}
             setActivitySectionRef={this.props.setActivitySectionRef}
             updateTargetActivitySection={this.props.updateTargetActivitySection}

--- a/apps/src/lib/levelbuilder/lesson-editor/ActivitySectionCard.jsx
+++ b/apps/src/lib/levelbuilder/lesson-editor/ActivitySectionCard.jsx
@@ -291,11 +291,17 @@ class ActivitySectionCard extends Component {
   };
 
   handleMoveActivitySection = direction => {
-    if (
-      (this.props.activitySection.position !== 1 && direction === 'up') ||
-      (this.props.activitySection.position !==
+    const firstActivitySectionInLesson =
+      this.props.activitySection.position === 1 &&
+      this.props.activityPosition === 1;
+    const lastActivitySectionInLesson =
+      this.props.activitySection.position ===
         this.props.activitySectionsCount &&
-        direction === 'down')
+      this.props.activityPosition === this.props.activitiesCount;
+
+    if (
+      (!firstActivitySectionInLesson && direction === 'up') ||
+      (!lastActivitySectionInLesson && direction === 'down')
     ) {
       this.props.moveActivitySection(
         this.props.activityPosition,

--- a/apps/src/lib/levelbuilder/lesson-editor/LessonEditor.jsx
+++ b/apps/src/lib/levelbuilder/lesson-editor/LessonEditor.jsx
@@ -16,7 +16,11 @@ import {
 } from '@cdo/apps/lib/levelbuilder/shapes';
 import $ from 'jquery';
 import {connect} from 'react-redux';
-import {getSerializedActivities} from '@cdo/apps/lib/levelbuilder/lesson-editor/activitiesEditorRedux';
+import {
+  getSerializedActivities,
+  mapActivityDataForEditor,
+  initActivities
+} from '@cdo/apps/lib/levelbuilder/lesson-editor/activitiesEditorRedux';
 import {navigateToHref} from '@cdo/apps/utils';
 import SaveBar from '@cdo/apps/lib/levelbuilder/SaveBar';
 
@@ -60,7 +64,10 @@ class LessonEditor extends Component {
     initialObjectives: PropTypes.arrayOf(PropTypes.object).isRequired,
     activities: PropTypes.arrayOf(activityShape).isRequired,
     resources: PropTypes.arrayOf(resourceShape).isRequired,
-    courseVersionId: PropTypes.number
+    courseVersionId: PropTypes.number,
+
+    // from redux
+    initActivities: PropTypes.func.isRequired
   };
 
   constructor(props) {
@@ -116,7 +123,10 @@ class LessonEditor extends Component {
         if (shouldCloseAfterSave) {
           navigateToHref(`/lessons/${this.props.id}${window.location.search}`);
         } else {
-          this.setState({lastSaved: data.updated_at, isSaving: false});
+          const activities = mapActivityDataForEditor(data.activities);
+
+          this.props.initActivities(activities);
+          this.setState({lastSaved: data.updatedAt, isSaving: false});
         }
       })
       .fail(error => {
@@ -345,7 +355,12 @@ class LessonEditor extends Component {
 
 export const UnconnectedLessonEditor = LessonEditor;
 
-export default connect(state => ({
-  activities: state.activities,
-  resources: state.resources
-}))(LessonEditor);
+export default connect(
+  state => ({
+    activities: state.activities,
+    resources: state.resources
+  }),
+  {
+    initActivities
+  }
+)(LessonEditor);

--- a/apps/src/lib/levelbuilder/lesson-editor/activitiesEditorRedux.js
+++ b/apps/src/lib/levelbuilder/lesson-editor/activitiesEditorRedux.js
@@ -8,6 +8,7 @@ import {
 import {LevelStatus} from '@cdo/apps/util/sharedConstants';
 
 const INIT = 'activitiesEditor/INIT';
+const INIT_ACTIVITIES = 'activitiesEditor/INIT_ACTIVITIES';
 const ADD_ACTIVITY = 'activitiesEditor/ADD_ACTIVITY';
 const MOVE_ACTIVITY = 'activitiesEditor/MOVE_ACTIVITY';
 const REMOVE_ACTIVITY = 'activitiesEditor/REMOVE_ACTIVITY';
@@ -38,10 +39,20 @@ export const init = (activities, searchOptions) => ({
   searchOptions
 });
 
-export const addActivity = (activityPosition, activityKey) => ({
+export const initActivities = activities => ({
+  type: INIT_ACTIVITIES,
+  activities
+});
+
+export const addActivity = (
+  activityPosition,
+  activityKey,
+  activitySectionKey
+) => ({
   type: ADD_ACTIVITY,
   activityPosition,
-  activityKey
+  activityKey,
+  activitySectionKey
 });
 
 export const updateActivityField = (
@@ -244,13 +255,20 @@ function activities(state = [], action) {
 
   switch (action.type) {
     case INIT:
+    case INIT_ACTIVITIES:
       validateActivities(action.activities, action.type);
       return action.activities;
     case ADD_ACTIVITY: {
       newState.push({
         ...emptyActivity,
         key: action.activityKey,
-        position: action.activityPosition
+        position: action.activityPosition,
+        activitySections: [
+          {
+            ...emptyActivitySection,
+            key: action.activitySectionKey
+          }
+        ]
       });
       updateActivityPositions(newState);
       break;
@@ -307,7 +325,6 @@ function activities(state = [], action) {
     }
     case MOVE_ACTIVITY_SECTION: {
       const activityIndex = action.activityPosition - 1;
-
       const activitySections = newState[activityIndex].activitySections;
 
       const activitySectionIndex = action.activitySectionPosition - 1;
@@ -315,7 +332,6 @@ function activities(state = [], action) {
         action.direction === 'up'
           ? activitySectionIndex - 1
           : activitySectionIndex + 1;
-
       if (
         activitySectionSwapIndex >= 0 &&
         activitySectionSwapIndex <= activitySections.length - 1
@@ -577,7 +593,7 @@ export default {
 };
 
 export const emptyActivitySection = {
-  key: 'activity-section-1',
+  key: 'activitySection-1',
   displayName: '',
   levels: [],
   tips: [],

--- a/apps/test/unit/lib/levelbuilder/lesson-editor/ActivitiesEditorTest.jsx
+++ b/apps/test/unit/lib/levelbuilder/lesson-editor/ActivitiesEditorTest.jsx
@@ -31,6 +31,10 @@ describe('ActivitiesEditor', () => {
     const button = wrapper.find('button');
     expect(button.text()).to.include('Activity');
     button.simulate('mouseDown');
-    expect(addActivity).to.have.been.calledOnce;
+    expect(addActivity).to.have.been.calledWith(
+      1,
+      'activity-2',
+      'activitySection-1'
+    );
   });
 });

--- a/apps/test/unit/lib/levelbuilder/lesson-editor/ActivityCardAndPreviewTest.jsx
+++ b/apps/test/unit/lib/levelbuilder/lesson-editor/ActivityCardAndPreviewTest.jsx
@@ -10,12 +10,14 @@ describe('ActivityCardAndPreview', () => {
     setActivitySectionRef,
     updateTargetActivitySection,
     clearTargetActivitySection,
+    generateActivitySectionKey,
     updateActivitySectionMetrics;
   beforeEach(() => {
     setActivitySectionRef = sinon.spy();
     updateTargetActivitySection = sinon.spy();
     clearTargetActivitySection = sinon.spy();
     updateActivitySectionMetrics = sinon.spy();
+    generateActivitySectionKey = sinon.spy();
     defaultProps = {
       activity: sampleActivities[0],
       activitiesCount: 1,
@@ -23,6 +25,7 @@ describe('ActivityCardAndPreview', () => {
       updateTargetActivitySection,
       clearTargetActivitySection,
       updateActivitySectionMetrics,
+      generateActivitySectionKey,
       targetActivitySectionPos: 1,
       activitySectionMetrics: []
     };

--- a/apps/test/unit/lib/levelbuilder/lesson-editor/ActivityCardTest.jsx
+++ b/apps/test/unit/lib/levelbuilder/lesson-editor/ActivityCardTest.jsx
@@ -15,6 +15,7 @@ describe('ActivityCard', () => {
     updateTargetActivitySection,
     clearTargetActivitySection,
     handleCollapse,
+    generateActivitySectionKey,
     updateActivitySectionMetrics;
   beforeEach(() => {
     addActivitySection = sinon.spy();
@@ -26,6 +27,7 @@ describe('ActivityCard', () => {
     clearTargetActivitySection = sinon.spy();
     updateActivitySectionMetrics = sinon.spy();
     handleCollapse = sinon.spy();
+    generateActivitySectionKey = sinon.spy();
     defaultProps = {
       activity: sampleActivities[0],
       activitiesCount: 1,
@@ -37,6 +39,7 @@ describe('ActivityCard', () => {
       updateTargetActivitySection,
       clearTargetActivitySection,
       updateActivitySectionMetrics,
+      generateActivitySectionKey,
       targetActivitySectionPos: 1,
       activitySectionMetrics: [],
       handleCollapse,
@@ -61,6 +64,7 @@ describe('ActivityCard', () => {
     expect(button.text()).to.include('Activity Section');
     button.simulate('mouseDown');
     expect(addActivitySection).to.have.been.calledOnce;
+    expect(generateActivitySectionKey).to.have.been.calledOnce;
   });
 
   it('edit activity title', () => {

--- a/apps/test/unit/lib/levelbuilder/lesson-editor/ActivitySectionCardTest.jsx
+++ b/apps/test/unit/lib/levelbuilder/lesson-editor/ActivitySectionCardTest.jsx
@@ -11,11 +11,7 @@ import {
 } from '@cdo/apps/redux';
 import {Provider} from 'react-redux';
 import resourceTestData from './resourceTestData';
-import {
-  levelKeyList,
-  sampleActivities,
-  searchOptions
-} from './activitiesTestData';
+import {sampleActivities, searchOptions} from './activitiesTestData';
 import reducers, {
   init
 } from '@cdo/apps/lib/levelbuilder/lesson-editor/activitiesEditorRedux';
@@ -41,7 +37,7 @@ describe('ActivitySectionCard', () => {
     registerReducers({...reducers, resources: resourcesEditor});
 
     store = getStore();
-    store.dispatch(init(sampleActivities, levelKeyList, searchOptions));
+    store.dispatch(init(sampleActivities, searchOptions));
     store.dispatch(initResources(resourceTestData));
 
     setTargetActivitySection = sinon.spy();

--- a/apps/test/unit/lib/levelbuilder/lesson-editor/ActivitySectionCardTest.jsx
+++ b/apps/test/unit/lib/levelbuilder/lesson-editor/ActivitySectionCardTest.jsx
@@ -1,12 +1,31 @@
 import React from 'react';
-import {shallow} from 'enzyme';
+import {shallow, mount} from 'enzyme';
 import {expect} from '../../../../util/reconfiguredChai';
 import {UnconnectedActivitySectionCard as ActivitySectionCard} from '@cdo/apps/lib/levelbuilder/lesson-editor/ActivitySectionCard';
 import sinon from 'sinon';
-import {sampleActivities} from './activitiesTestData';
+import {
+  stubRedux,
+  restoreRedux,
+  getStore,
+  registerReducers
+} from '@cdo/apps/redux';
+import {Provider} from 'react-redux';
+import resourceTestData from './resourceTestData';
+import {
+  levelKeyList,
+  sampleActivities,
+  searchOptions
+} from './activitiesTestData';
+import reducers, {
+  init
+} from '@cdo/apps/lib/levelbuilder/lesson-editor/activitiesEditorRedux';
+import resourcesEditor, {
+  initResources
+} from '@cdo/apps/lib/levelbuilder/lesson-editor/resourcesEditorRedux';
 
 describe('ActivitySectionCard', () => {
   let defaultProps,
+    store,
     setTargetActivitySection,
     updateTargetActivitySection,
     clearTargetActivitySection,
@@ -18,6 +37,13 @@ describe('ActivitySectionCard', () => {
     moveLevelToActivitySection,
     addLevel;
   beforeEach(() => {
+    stubRedux();
+    registerReducers({...reducers, resources: resourcesEditor});
+
+    store = getStore();
+    store.dispatch(init(sampleActivities, levelKeyList, searchOptions));
+    store.dispatch(initResources(resourceTestData));
+
     setTargetActivitySection = sinon.spy();
     updateTargetActivitySection = sinon.spy();
     clearTargetActivitySection = sinon.spy();
@@ -48,6 +74,10 @@ describe('ActivitySectionCard', () => {
       moveLevelToActivitySection,
       addLevel
     };
+  });
+
+  afterEach(() => {
+    restoreRedux();
   });
 
   it('renders activity section without levels', () => {
@@ -128,5 +158,78 @@ describe('ActivitySectionCard', () => {
       'text',
       'My section description'
     );
+  });
+
+  it('can move activity section down to next activity', () => {
+    const wrapper = mount(
+      <Provider store={store}>
+        <ActivitySectionCard {...defaultProps} />
+      </Provider>
+    );
+
+    expect(wrapper.find('OrderControls').length).to.equal(1);
+    const orderControls = wrapper.find('OrderControls');
+    expect(orderControls.find('.fa-caret-down').length).to.equal(1);
+    const down = orderControls.find('.fa-caret-down');
+    down.simulate('mouseDown');
+
+    expect(moveActivitySection).to.have.been.calledWith(1, 1, 'down');
+  });
+
+  it('can not move activity section up if first activity section in first activity', () => {
+    const wrapper = mount(
+      <Provider store={store}>
+        <ActivitySectionCard {...defaultProps} />
+      </Provider>
+    );
+
+    expect(wrapper.find('OrderControls').length).to.equal(1);
+    const orderControls = wrapper.find('OrderControls');
+    expect(orderControls.find('.fa-caret-up').length).to.equal(1);
+    const up = orderControls.find('.fa-caret-up');
+    up.simulate('mouseDown');
+
+    expect(moveActivitySection).to.not.have.been.called;
+  });
+
+  it('can move activity section up to previous activity', () => {
+    const wrapper = mount(
+      <Provider store={store}>
+        <ActivitySectionCard
+          {...defaultProps}
+          activityPosition={2}
+          activitiesCount={2}
+        />
+      </Provider>
+    );
+
+    expect(wrapper.find('OrderControls').length).to.equal(1);
+    const orderControls = wrapper.find('OrderControls');
+    expect(orderControls.find('.fa-caret-up').length).to.equal(1);
+    const up = orderControls.find('.fa-caret-up');
+    up.simulate('mouseDown');
+
+    expect(moveActivitySection).to.have.been.calledWith(2, 1, 'up');
+  });
+
+  it('can not move activity section down if last activity section in last activity', () => {
+    const wrapper = mount(
+      <Provider store={store}>
+        <ActivitySectionCard
+          {...defaultProps}
+          activityPosition={2}
+          activitiesCount={2}
+          activitySection={sampleActivities[0].activitySections[2]}
+        />
+      </Provider>
+    );
+
+    expect(wrapper.find('OrderControls').length).to.equal(1);
+    const orderControls = wrapper.find('OrderControls');
+    expect(orderControls.find('.fa-caret-down').length).to.equal(1);
+    const down = orderControls.find('.fa-caret-down');
+    down.simulate('mouseDown');
+
+    expect(moveActivitySection).to.not.have.been.called;
   });
 });

--- a/apps/test/unit/lib/levelbuilder/lesson-editor/LessonEditorTest.js
+++ b/apps/test/unit/lib/levelbuilder/lesson-editor/LessonEditorTest.js
@@ -118,7 +118,7 @@ describe('LessonEditor', () => {
     const wrapper = createWrapper({});
     const lessonEditor = wrapper.find('LessonEditor');
 
-    let returnData = {updated_at: '2020-11-06T21:33:32.000Z'};
+    let returnData = {updatedAt: '2020-11-06T21:33:32.000Z', activities: []};
     let server = sinon.fakeServer.create();
     server.respondWith('PUT', `/lessons/1`, [
       200,
@@ -187,7 +187,7 @@ describe('LessonEditor', () => {
     const wrapper = createWrapper({});
     const lessonEditor = wrapper.find('LessonEditor');
 
-    let returnData = {updated_at: '2020-11-06T21:33:32.000Z'};
+    let returnData = {updatedAt: '2020-11-06T21:33:32.000Z', activities: []};
     let server = sinon.fakeServer.create();
     server.respondWith('PUT', `/lessons/1`, [
       200,

--- a/apps/test/unit/lib/levelbuilder/lesson-editor/activitiesEditorReduxTest.js
+++ b/apps/test/unit/lib/levelbuilder/lesson-editor/activitiesEditorReduxTest.js
@@ -262,9 +262,16 @@ describe('activitiesEditorRedux reducer tests', () => {
     });
 
     it('add activity', () => {
-      const nextState = reducer(initialState, addActivity(3, 'key')).activities;
+      const nextState = reducer(
+        initialState,
+        addActivity(3, 'activity-key', 'section-key-1')
+      ).activities;
       assert.equal(nextState[nextState.length - 1].displayName, '');
-      assert.equal(nextState[nextState.length - 1].key, 'key');
+      assert.equal(nextState[nextState.length - 1].key, 'activity-key');
+      assert.equal(
+        nextState[nextState.length - 1].activitySections[0].key,
+        'section-key-1'
+      );
     });
 
     it('update activity field', () => {

--- a/dashboard/app/controllers/lessons_controller.rb
+++ b/dashboard/app/controllers/lessons_controller.rb
@@ -39,7 +39,7 @@ class LessonsController < ApplicationController
       @lesson.update_objectives(JSON.parse(params[:objectives])) if params[:objectives]
     end
 
-    render json: @lesson
+    render json: @lesson.summarize_for_lesson_edit
   rescue ActiveRecord::RecordNotFound, ActiveRecord::RecordInvalid => e
     render(status: :not_acceptable, plain: e.message)
   end

--- a/dashboard/app/models/lesson.rb
+++ b/dashboard/app/models/lesson.rb
@@ -302,7 +302,8 @@ class Lesson < ApplicationRecord
       activities: lesson_activities.map(&:summarize_for_lesson_edit),
       resources: resources.map(&:summarize_for_lesson_edit),
       objectives: objectives.map(&:summarize_for_edit),
-      courseVersionId: lesson_group.script.course_version&.id
+      courseVersionId: lesson_group.script.course_version&.id,
+      updatedAt: updated_at
     }
   end
 

--- a/dashboard/app/models/lesson_activity.rb
+++ b/dashboard/app/models/lesson_activity.rb
@@ -79,13 +79,15 @@ class LessonActivity < ApplicationRecord
   private
 
   # Finds the ActivitySection by id, or creates a new one if id is not specified.
+  # Do not try to find the activity section if it was moved here from another
+  # activity. Create a new one,, and let the old activity section be
+  # destroyed when we update the other activity.
   # @param section [Hash] - Hash representing an ActivitySection.
   # @returns [ActivitySection]
   def fetch_activity_section(section)
     if section['id']
-      activity_section = activity_sections.find(section['id'])
+      activity_section = activity_sections.find_by(id: section['id'])
       return activity_section if activity_section
-      raise ActiveRecord::RecordNotFound.new("ActivitySection id #{section['id']} not found in LessonActivity id #{id}")
     end
 
     activity_sections.create(

--- a/dashboard/test/controllers/lessons_controller_test.rb
+++ b/dashboard/test/controllers/lessons_controller_test.rb
@@ -177,13 +177,13 @@ class LessonsControllerTest < ActionController::TestCase
   test_user_gets_response_for :update, params: -> {@update_params}, user: :teacher, response: :forbidden
   test_user_gets_response_for :update, params: -> {@update_params}, user: :levelbuilder, response: :success
 
-  test 'update lesson return updated lesson' do
+  test 'update lesson returns summary of updated lesson' do
     sign_in @levelbuilder
 
     put :update, params: @update_params
 
-    assert_equal 'new overview', JSON.parse(@response.body)['properties']['overview']
-    assert_equal 'new student overview', JSON.parse(@response.body)['properties']['student_overview']
+    assert_equal 'new overview', JSON.parse(@response.body)['overview']
+    assert_equal 'new student overview', JSON.parse(@response.body)['studentOverview']
   end
 
   test 'cannot update lesson with legacy script levels' do


### PR DESCRIPTION
Reverts code-dot-org/code-dot-org#38192 Reimplements: #38099

It looks like the timing of merging https://github.com/code-dot-org/code-dot-org/pull/38118 (removing levelKeyList) and when I ran my tests on the original version of this PR did not line up in a way where it caught that I had not removed levelKeyList in the updates to ActivitySectionCardTest. I have updated that and now the tests pass.
