### PR TITLE
[Applab] Add opencagedata for startWebRequest

### DIFF
--- a/dashboard/app/controllers/xhr_proxy_controller.rb
+++ b/dashboard/app/controllers/xhr_proxy_controller.rb
@@ -36,6 +36,7 @@ class XhrProxyController < ApplicationController
     api.foursquare.com
     api.fungenerators.com
     api.nasa.gov
+    api.opencagedata.com
     api.open-notify.org
     api.openweathermap.org
     api.pegelalarm.at


### PR DESCRIPTION
[OpenCage](https://opencagedata.com/) looks like a fairly straightforward geocoder API.
Requested via [Zendesk Ticket](https://codeorg.zendesk.com/agent/tickets/308107)