### PR TITLE
[Applab] Disallow id "bubble" in design mode

### DIFF
--- a/apps/src/applab/designElements/elementUtils.js
+++ b/apps/src/applab/designElements/elementUtils.js
@@ -103,7 +103,8 @@ var ELEMENT_ID_DENYLIST = [
   'submitButton',
   'unsubmitButton',
   'turtleImage',
-  'prompt-icon'
+  'prompt-icon',
+  'bubble'
 ];
 
 var TURTLE_CANVAS_ID = 'turtleCanvas';


### PR DESCRIPTION
This came up from a [zendesk ticket]()
Basically the issue is that we hide bubbles in the share view [here](https://github.com/code-dot-org/code-dot-org/blob/staging-next/apps/style/common.scss#L1308)
But this project had an image with id `bubble`, so it was also not visible in the share view

The solution here is to just not allow app design mode elements to have the id `bubble`

<!-- ### Background -->
<!-- ### Privacy -->
<!--
1.	Does the Project involve the collection, use or sharing of new Personal Data?

2.	Does the Project involve a new or changed use or sharing of existing Personal Data?
-->
<!-- ### Security -->
<!--
Link to Jira Task where sensitive security issues are discussed privately.
-->
<!-- ### Caching -->
<!-- ### Deployment strategy -->
<!-- ### Future work -->

## Testing story

<!--
  Does your change include appropriate tests?

  If so, please describe how the tests included in this PR are sufficient

  If not, please explain why this change does not need to be tested.
-->

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
