### PR TITLE
Do not show the duration of activity on agenda if it is zero

### DIFF
--- a/apps/src/templates/lessonOverview/LessonAgenda.jsx
+++ b/apps/src/templates/lessonOverview/LessonAgenda.jsx
@@ -22,9 +22,16 @@ export default class LessonAgenda extends Component {
         {filteredActivitiesList.map(activity => (
           <ul key={activity.key} style={{listStyleType: 'none'}}>
             <li>
-              <a href={`#activity-${activity.key}`}>{`${
-                activity.displayName
-              } (${activity.duration} ${i18n.minutes()})`}</a>
+              {activity.duration > 0 && (
+                <a href={`#activity-${activity.key}`}>{`${
+                  activity.displayName
+                } (${activity.duration} ${i18n.minutes()})`}</a>
+              )}
+              {activity.duration === 0 && (
+                <a href={`#activity-${activity.key}`}>{`${
+                  activity.displayName
+                }`}</a>
+              )}
             </li>
             {activity.activitySections.map(section => (
               <li style={{marginLeft: 15}} key={section.key}>


### PR DESCRIPTION
Title really says it all. See examples of how it works below.

<img width="960" alt="Screen Shot 2020-12-11 at 2 36 09 PM" src="https://user-images.githubusercontent.com/208083/101950955-28daf880-3bc4-11eb-9135-902a06a6ce5a.png">
<img width="514" alt="Screen Shot 2020-12-11 at 2 35 58 PM" src="https://user-images.githubusercontent.com/208083/101950958-2a0c2580-3bc4-11eb-9605-9b2edc3a4153.png">

## Links

<!--
  Any relevant links to external resources; ie, specification documents, jira
  items, related PRs, honeybadger errors, etc
-->

- [jira](https://codedotorg.atlassian.net/browse/PLAT-533)

