### PR TITLE
[AiLab] code to get a prediction from a saved KNN ML model 

### DIFF
--- a/apps/package.json
+++ b/apps/package.json
@@ -228,6 +228,7 @@
     "jszip": "3.0.0",
     "memoize-one": "^5.1.1",
     "microsoft-cognitiveservices-speech-sdk": "^1.12.0",
+    "ml-knn": "^3.0.0",
     "node-sass": "^4.13.0",
     "object-fit-images": "^3.2.3",
     "pa11y-ci": "^2.3.0",

--- a/apps/src/MLTrainers.js
+++ b/apps/src/MLTrainers.js
@@ -1,0 +1,44 @@
+const KNN = require('ml-knn');
+
+const KNNTrainers = ['knnClassify', 'knnRegress'];
+
+/* NEED: testData, selectedFeatures, featureNumberKey, selectedTrainer, labelColumn and trainedModel
+
+testData = {
+  feature1: value,
+  feature2: value,
+  feature3: value
+}
+where value is the converted number, not the string
+*/
+
+function getKeyByValue(object, value) {
+  return Object.keys(object).find(key => object[key] === value);
+}
+
+export function predict(modelData) {
+  // Determine which algorithm to use.
+  if (KNNTrainers.includes(modelData.selectedTrainer)) {
+    // Re-instantiate the trained model.
+    const model = KNN.load(modelData.trainedModel);
+    // Prepare test data.
+    const testValues = modelData.selectedFeatures.map(
+      feature => modelData.testData[feature]
+    );
+
+    // Make a prediction.
+    const rawPrediction = model.predict(testValues)[0];
+    // Convert prediction to human readable (if needed)
+    const prediction = Object.keys(modelData.featureNumberKey).includes(
+      modelData.labelColumn
+    )
+      ? getKeyByValue(
+          modelData.featureNumberKey[modelData.labelColumn],
+          rawPrediction
+        )
+      : parseFloat(rawPrediction);
+    return prediction;
+  } else {
+    return 'Error: unknown trainer';
+  }
+}

--- a/apps/src/MLTrainers.js
+++ b/apps/src/MLTrainers.js
@@ -2,20 +2,36 @@ const KNN = require('ml-knn');
 
 const KNNTrainers = ['knnClassify', 'knnRegress'];
 
-/* NEED: testData, selectedFeatures, featureNumberKey, selectedTrainer, labelColumn and trainedModel
-
-testData = {
-  feature1: value,
-  feature2: value,
-  feature3: value
-}
-where value is the converted number, not the string
-*/
-
 function getKeyByValue(object, value) {
   return Object.keys(object).find(key => object[key] === value);
 }
 
+/*
+
+modelData = {
+  selectedTrainer: "selectedTrainer",
+  trainedModel: <JSON blob of trained model>,
+  featureNumberKey: {
+    feature1: {
+      value1: convertedValue1,
+      value2: convertedValue2
+    },
+    feature2: {
+      value1: convertedValue1,
+      value2: convertedValue2
+    }
+  },
+  labelColumn: "labelColumn",
+  selectedFeatures: ["feature1", "feature2"],
+  testData: {
+    feature1: value,
+    feature2: value,
+    feature3: value
+  }
+}
+
+  value in testData is the converted algorithm-ready number, not the string
+*/
 export function predict(modelData) {
   // Determine which algorithm to use.
   if (KNNTrainers.includes(modelData.selectedTrainer)) {
@@ -25,7 +41,6 @@ export function predict(modelData) {
     const testValues = modelData.selectedFeatures.map(
       feature => modelData.testData[feature]
     );
-
     // Make a prediction.
     const rawPrediction = model.predict(testValues)[0];
     // Convert prediction to human readable (if needed)

--- a/apps/yarn.lock
+++ b/apps/yarn.lock
@@ -10941,6 +10941,13 @@ ml-kernel@^2.2.0:
     ml-kernel-sigmoid "^1.0.0"
     ml-matrix "^5.0.0"
 
+ml-knn@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/ml-knn/-/ml-knn-3.0.0.tgz#98eb350919f15d4a719312cfdcf7b62693201ad5"
+  integrity sha512-w7Jig4vW09OYMurlIRRJj8yL2O/835QJpxup+yW7QVYXSjixmanPtPQL+weiTYbaB/wWX8JilB+Wllk4mxvP5w==
+  dependencies:
+    ml-distance-euclidean "^2.0.0"
+
 ml-matrix@^5.0.0:
   version "5.3.0"
   resolved "https://registry.yarnpkg.com/ml-matrix/-/ml-matrix-5.3.0.tgz#2154902a3380f6a0874ab9a2539a09e873e8db92"


### PR DESCRIPTION
When a user clicks "Predict" on a Predict Panel element in App Lab, we need to use the test data from the input fields of the Predict Panel and the selected pre-trained model to get a prediction.  This PR sets up the `predict` function for KNN algorithms (regression and classification use the same [library](https://github.com/mljs/knn)). 