### PR TITLE
Improve "get level from url" failure mode

### DIFF
--- a/bin/i18n/i18n_script_utils.rb
+++ b/bin/i18n/i18n_script_utils.rb
@@ -143,14 +143,14 @@ class I18nScriptUtils
     case route_params[:action]
     when "show"
       script_level = ScriptLevelsController.get_script_level(script, route_params)
-      script_level.level
+      script_level&.level
     when "stage_extras"
       # Copied from ScriptLevelsController.stage_extras
       uri = URI.parse(url)
       uri_params = CGI.parse(uri.query)
       if uri_params.key?('id')
         script_level = Script.cache_find_script_level(uri_params['id'].first)
-        script_level.level
+        script_level&.level
       elsif uri_params.key?('level_name')
         Level.find_by_name(uri_params['level_name'].first)
       end


### PR DESCRIPTION
Specifically, when we are unable to find a ScriptLevel for a given url, make sure that we return `nil` for the level rather than failing with a `NoMethodError: undefined method 'level' for nil:NilClass` error

## Testing story

n/a

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
