### PR TITLE
Follow-up changes to treating section ids as ints

### DIFF
--- a/apps/src/code-studio/components/progress/SectionSelector.jsx
+++ b/apps/src/code-studio/components/progress/SectionSelector.jsx
@@ -39,7 +39,9 @@ class SectionSelector extends React.Component {
   };
 
   handleSelectChange = event => {
-    const newSectionId = event.target.value;
+    const newSectionIdString = event.target.value;
+    const newSectionId =
+      newSectionIdString === '' ? NO_SECTION : parseInt(newSectionIdString);
 
     if (this.props.logToFirehose) {
       this.props.logToFirehose();
@@ -47,7 +49,7 @@ class SectionSelector extends React.Component {
 
     updateQueryParam(
       'section_id',
-      newSectionId === NO_SECTION ? undefined : newSectionId
+      newSectionId === NO_SECTION ? undefined : newSectionId.toString()
     );
     // If we have a user_id when we switch sections we should get rid of it
     updateQueryParam('user_id', undefined);
@@ -74,7 +76,7 @@ class SectionSelector extends React.Component {
           ...styles.select,
           ...style
         }}
-        value={selectedSectionId}
+        value={selectedSectionId ? selectedSectionId.toString() : ''}
         onChange={this.handleSelectChange}
       >
         {!requireSelection && (
@@ -83,7 +85,7 @@ class SectionSelector extends React.Component {
           </option>
         )}
         {sections.map(({id, name}) => (
-          <option key={id} value={id}>
+          <option key={id.toString()} value={id.toString()}>
             {name}
           </option>
         ))}

--- a/apps/src/code-studio/teacherPanelHelpers.js
+++ b/apps/src/code-studio/teacherPanelHelpers.js
@@ -79,8 +79,9 @@ export function queryLockStatus(store, scriptId, pageType) {
       if (pageType !== 'script_overview') {
         store.dispatch(setSections(teacherSections));
         const query = queryString.parse(location.search);
-        if (query.section_id) {
-          store.dispatch(selectSection(query.section_id));
+        const section_id = parseInt(query.section_id);
+        if (section_id) {
+          store.dispatch(selectSection(section_id));
         }
       }
 

--- a/apps/src/sites/studio/pages/courses/show.js
+++ b/apps/src/sites/studio/pages/courses/show.js
@@ -54,7 +54,7 @@ function showCourseOverview() {
       store.dispatch(setVerified());
     }
 
-    const sectionId = clientState.queryParams('section_id');
+    const sectionId = parseInt(clientState.queryParams('section_id'));
     if (sectionId) {
       store.dispatch(selectSection(sectionId));
     }

--- a/apps/src/templates/teacherDashboard/teacherSectionsRedux.js
+++ b/apps/src/templates/teacherDashboard/teacherSectionsRedux.js
@@ -690,7 +690,7 @@ export default function teacherSections(state = initialState, action) {
     let selectedSectionId = state.selectedSectionId;
     // If we have only one section, autoselect it
     if (Object.keys(action.sections).length === 1) {
-      selectedSectionId = action.sections[0].id.toString();
+      selectedSectionId = action.sections[0].id;
     }
 
     sections.forEach(section => {
@@ -727,10 +727,7 @@ export default function teacherSections(state = initialState, action) {
 
   if (action.type === SELECT_SECTION) {
     let sectionId = action.sectionId;
-    if (
-      sectionId !== NO_SECTION &&
-      !state.sectionIds.includes(parseInt(sectionId, 10))
-    ) {
+    if (sectionId !== NO_SECTION && !state.sectionIds.includes(sectionId)) {
       sectionId = NO_SECTION;
     }
     return {

--- a/apps/test/unit/code-studio/components/progress/SectionSelectorTest.js
+++ b/apps/test/unit/code-studio/components/progress/SectionSelectorTest.js
@@ -5,7 +5,6 @@ import {UnconnectedSectionSelector as SectionSelector} from '@cdo/apps/code-stud
 import {mount} from 'enzyme';
 import * as utils from '@cdo/apps/utils';
 import * as codeStudioUtils from '@cdo/apps/code-studio/utils';
-import {NO_SECTION} from '@cdo/apps/templates/teacherDashboard/teacherSectionsRedux';
 
 const fakeSection = {
   name: 'My Section',
@@ -83,11 +82,9 @@ describe('SectionSelector', () => {
           selectSection={() => {}}
         />
       );
-      wrapper
-        .find('select')
-        .simulate('change', {target: {value: 'testSectionId'}});
+      wrapper.find('select').simulate('change', {target: {value: '12345'}});
       expect(codeStudioUtils.updateQueryParam)
-        .to.have.been.calledTwice.and.calledWith('section_id', 'testSectionId')
+        .to.have.been.calledTwice.and.calledWith('section_id', '12345')
         .and.calledWith('user_id', undefined);
     });
 
@@ -101,7 +98,7 @@ describe('SectionSelector', () => {
           selectSection={() => {}}
         />
       );
-      wrapper.find('select').simulate('change', {target: {value: NO_SECTION}});
+      wrapper.find('select').simulate('change', {target: {value: ''}});
       expect(codeStudioUtils.updateQueryParam)
         .to.have.been.calledTwice.and.calledWith('section_id', undefined)
         .and.calledWith('user_id', undefined);
@@ -119,9 +116,7 @@ describe('SectionSelector', () => {
           reloadOnChange={true}
         />
       );
-      wrapper
-        .find('select')
-        .simulate('change', {target: {value: 'testSectionId'}});
+      wrapper.find('select').simulate('change', {target: {value: '12345'}});
       expect(utils.reload).to.have.been.calledOnce;
       expect(selectSection).not.to.have.been.called;
     });
@@ -138,12 +133,8 @@ describe('SectionSelector', () => {
           reloadOnChange={false}
         />
       );
-      wrapper
-        .find('select')
-        .simulate('change', {target: {value: 'testSectionId'}});
-      expect(selectSection).to.have.been.calledOnce.and.calledWith(
-        'testSectionId'
-      );
+      wrapper.find('select').simulate('change', {target: {value: '12345'}});
+      expect(selectSection).to.have.been.calledOnce.and.calledWith(12345);
       expect(utils.reload).not.to.have.been.called;
     });
   });

--- a/apps/test/unit/templates/teacherDashboard/teacherSectionsReduxTest.js
+++ b/apps/test/unit/templates/teacherDashboard/teacherSectionsReduxTest.js
@@ -452,10 +452,7 @@ describe('teacherSectionsRedux', () => {
     it('does set selectedSectionId if passed a single section', () => {
       const action = setSections(sections.slice(0, 1));
       const nextState = reducer(startState, action);
-      assert.strictEqual(
-        nextState.selectedSectionId,
-        sections[0].id.toString()
-      );
+      assert.strictEqual(nextState.selectedSectionId, sections[0].id);
     });
 
     it('throws rather than let us destroy data', () => {
@@ -483,7 +480,7 @@ describe('teacherSectionsRedux', () => {
   });
 
   describe('selectSection', () => {
-    const firstSectionId = sections[0].id.toString();
+    const firstSectionId = sections[0].id;
     it('can change the selected section', () => {
       const sectionState = reducer(undefined, setSections(sections));
 
@@ -507,7 +504,7 @@ describe('teacherSectionsRedux', () => {
       let sectionState = reducer(undefined, setSections(sections));
       assert.equal(sectionState.selectedSectionId, NO_SECTION);
 
-      const action = selectSection('99999');
+      const action = selectSection(99999);
       sectionState = reducer(initialState, action);
       assert.equal(sectionState.selectedSectionId, NO_SECTION);
     });


### PR DESCRIPTION
<!--
  Your description goes here: A summary of the change, including any relevant motivation and context.

  If relevant, include a description both of the existing behavior and of the new behavior.
-->
Fix some regressions from #38158.  There are some additional cases that the original PR didn't address:
- Keys and values for `<select>` and `<option>` elements must be strings and the changed event for a `<select>` returns a string.  When using a section id as the key/value of an `<option>`, convert to and from string.
- When parsing a section id from a query string, convert from string to int.

<!--
  Other aspects to consider. uncomment and add detail for any that seem necessary:
-->

<!-- ### Background -->
<!-- ### Privacy -->
<!--
1.	Does the Project involve the collection, use or sharing of new Personal Data?

2.	Does the Project involve a new or changed use or sharing of existing Personal Data?
-->
<!-- ### Security -->
<!--
Link to Jira Task where sensitive security issues are discussed privately.
-->
<!-- ### Caching -->
<!-- ### Deployment strategy -->
<!-- ### Future work -->

## Links

<!--
  Any relevant links to external resources; ie, specification documents, jira
  items, related PRs, honeybadger errors, etc
-->

## Testing story

<!--
  Does your change include appropriate tests?

  If so, please describe how the tests included in this PR are sufficient

  If not, please explain why this change does not need to be tested.
-->

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
