### PR TITLE
add key column to objectives with unique index

### DIFF
--- a/dashboard/app/models/objective.rb
+++ b/dashboard/app/models/objective.rb
@@ -7,9 +7,11 @@
 #  lesson_id  :integer
 #  created_at :datetime         not null
 #  updated_at :datetime         not null
+#  key        :string(255)
 #
 # Indexes
 #
+#  index_objectives_on_key        (key) UNIQUE
 #  index_objectives_on_lesson_id  (lesson_id)
 #
 

--- a/dashboard/db/migrate/20201214003529_add_key_to_objectives.rb
+++ b/dashboard/db/migrate/20201214003529_add_key_to_objectives.rb
@@ -1,0 +1,6 @@
+class AddKeyToObjectives < ActiveRecord::Migration[5.2]
+  def change
+    add_column :objectives, :key, :string
+    add_index :objectives, :key, unique: true
+  end
+end

--- a/dashboard/db/schema.rb
+++ b/dashboard/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_12_09_073557) do
+ActiveRecord::Schema.define(version: 2020_12_14_003529) do
 
   create_table "activities", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci", force: :cascade do |t|
     t.integer "user_id"
@@ -657,6 +657,8 @@ ActiveRecord::Schema.define(version: 2020_12_09_073557) do
     t.integer "lesson_id"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.string "key"
+    t.index ["key"], name: "index_objectives_on_key", unique: true
     t.index ["lesson_id"], name: "index_objectives_on_lesson_id"
   end
 


### PR DESCRIPTION
Starts [PLAT-614]. In order for ActiveRecord Import to work efficiently, there needs to be a unique index on the `objectives` table which can be used to find and update existing entries.


[PLAT-614]: https://codedotorg.atlassian.net/browse/PLAT-614