### PR TITLE
Hide Google Log-in from Maker App

### DIFF
--- a/apps/i18n/common/en_us.json
+++ b/apps/i18n/common/en_us.json
@@ -1119,6 +1119,7 @@
   "manageLinkedAccounts_microsoft": "Microsoft Account",
   "manageLinkedAccounts_notConnected": "Not Connected",
   "manageLinkedAccounts_rosteredSectionTooltip": "You cannot disconnect from this linked account because it is tied to one of your sections.",
+  "manageLinkedAccounts_makerAuthError": "This action cannot be done from the Maker App. Please return to your default browser and try again.",
   "manageStudents": "Manage Students",
   "manageStudentsNotificationFailure": "Something went wrong.",
   "manageStudentsNotificationCannotAdd": "You could not add {numStudents, plural, one {1 student} other {# students}} to your section. Please try again or refresh the page.",

--- a/apps/src/lib/ui/accounts/ManageLinkedAccounts.jsx
+++ b/apps/src/lib/ui/accounts/ManageLinkedAccounts.jsx
@@ -282,6 +282,8 @@ class OauthConnection extends React.Component {
 
 const GUTTER = 20;
 const BUTTON_WIDTH = 105;
+const BUTTON_PADDING = 8;
+const CELL_WIDTH = tableLayoutStyles.table.width / 3;
 const styles = {
   container: {
     paddingTop: GUTTER
@@ -298,7 +300,7 @@ const styles = {
     paddingLeft: GUTTER,
     paddingRight: GUTTER,
     fontWeight: 'normal',
-    width: tableLayoutStyles.table.width / 3
+    width: CELL_WIDTH
   },
   cell: {
     ...tableLayoutStyles.cell,
@@ -313,10 +315,12 @@ const styles = {
     width: BUTTON_WIDTH,
     fontFamily: '"Gotham 5r", sans-serif',
     color: color.charcoal,
-    padding: 8
+    padding: BUTTON_PADDING
   },
   tooltipOffset: {
-    left: -(BUTTON_WIDTH / 2)
+    left:
+      CELL_WIDTH / 2 -
+      (tableLayoutStyles.cell.padding + BUTTON_PADDING + BUTTON_WIDTH / 2)
   },
   tooltip: {
     width: BUTTON_WIDTH * 2

--- a/apps/src/lib/ui/accounts/ManageLinkedAccounts.jsx
+++ b/apps/src/lib/ui/accounts/ManageLinkedAccounts.jsx
@@ -226,8 +226,7 @@ class OauthConnection extends React.Component {
 
     const buttonDisabled =
       !!disconnectDisabledStatus ||
-      (isCodeOrgBrowser() && displayName === 'Google Account');
-
+      (isCodeOrgBrowser() && credentialType === OAuthProviders.google);
     return (
       <tr>
         <td style={styles.cell}>{displayName}</td>

--- a/apps/src/lib/ui/accounts/ManageLinkedAccounts.jsx
+++ b/apps/src/lib/ui/accounts/ManageLinkedAccounts.jsx
@@ -319,8 +319,8 @@ const styles = {
   },
   tooltipOffset: {
     left:
-      CELL_WIDTH / 2 -
-      (tableLayoutStyles.cell.padding + BUTTON_PADDING + BUTTON_WIDTH / 2)
+      CELL_WIDTH / 2 - // This moves the tooltip to be in between the 2nd and 3rd columns of the table
+      (tableLayoutStyles.cell.padding + BUTTON_PADDING + BUTTON_WIDTH / 2) // This centers the tooltip over the button in the 3rd column
   },
   tooltip: {
     width: BUTTON_WIDTH * 2

--- a/apps/src/lib/ui/accounts/ManageLinkedAccounts.jsx
+++ b/apps/src/lib/ui/accounts/ManageLinkedAccounts.jsx
@@ -9,6 +9,7 @@ import BootstrapButton from './BootstrapButton';
 import {connect} from 'react-redux';
 import RailsAuthenticityToken from '../../util/RailsAuthenticityToken';
 import {OAuthProviders} from '@cdo/apps/lib/ui/accounts/constants';
+import {isCodeOrgBrowser} from '@cdo/apps/lib/kits/maker/util/browserChecks';
 
 export const ENCRYPTED = `*** ${i18n.encrypted()} ***`;
 const authOptionPropType = PropTypes.shape({
@@ -223,6 +224,10 @@ class OauthConnection extends React.Component {
       ? `/users/auth/${id}/disconnect`
       : `/users/auth/${credentialType}?action=connect`;
 
+    const buttonDisabled =
+      !!disconnectDisabledStatus ||
+      (isCodeOrgBrowser() && displayName === 'Google Account');
+
     return (
       <tr>
         <td style={styles.cell}>{displayName}</td>
@@ -237,16 +242,21 @@ class OauthConnection extends React.Component {
               action={oauthToggleConnectionPath}
             >
               {/* This button intentionally uses BootstrapButton to match other
-                  account page buttons */}
+                  account page buttons.
+                  This button is disabled according to disconnectDisabledStatus or
+                  when the user is attempting this action from the Maker App for
+                  their Google Account. This action is blocked due to Google authentication
+                  security protocols.
+                  */}
               <BootstrapButton
                 type="submit"
                 style={styles.button}
                 text={buttonText}
-                disabled={!!disconnectDisabledStatus}
+                disabled={buttonDisabled}
               />
               <RailsAuthenticityToken />
             </form>
-            {disconnectDisabledStatus && (
+            {buttonDisabled && (
               <ReactTooltip
                 id={tooltipId}
                 offset={styles.tooltipOffset}
@@ -254,7 +264,12 @@ class OauthConnection extends React.Component {
                 effect="solid"
               >
                 <div style={styles.tooltip}>
-                  {this.getDisconnectDisabledTooltip()}
+                  {/* There are two causes for errors: disconnectDisabledStatus and logging in to
+                      Google from the Maker App. Display the appropriate error text.
+                    */}
+                  {disconnectDisabledStatus
+                    ? this.getDisconnectDisabledTooltip()
+                    : i18n.manageLinkedAccounts_makerAuthError()}
                 </div>
               </ReactTooltip>
             )}

--- a/dashboard/app/views/devise/shared/_oauth_links.haml
+++ b/dashboard/app/views/devise/shared/_oauth_links.haml
@@ -27,8 +27,8 @@
 :javascript
 
   $('.oauth_sign_in').click(dashboard.clientState.reset);
-  // If the makerBridge is available, we are in the Maker App, which has it's
+  // If the makerBridge is available, we are in the Maker App, which has its
   // own Google login button. Hiding this google-oauth button to avoid confusion.
   if (!!window.MakerBridge) {
-    document.querySelector('.with-google_oauth2').style.display = 'none';
+    $('.with-google_oauth2').hide();
   }

--- a/dashboard/app/views/devise/shared/_oauth_links.haml
+++ b/dashboard/app/views/devise/shared/_oauth_links.haml
@@ -27,3 +27,8 @@
 :javascript
 
   $('.oauth_sign_in').click(dashboard.clientState.reset);
+  // If the makerBridge is available, we are in the Maker App, which has it's
+  // own Google login button. Hiding this google-oauth button to avoid confusion.
+  if (!!window.MakerBridge) {
+    document.querySelector('.with-google_oauth2').style.display = 'none';
+  }


### PR DESCRIPTION
Jira for context: https://codedotorg.atlassian.net/browse/STAR-1023
Summary - the "Continue with Google" log in button doesn't work in Maker App, so we added a button to do that at the top of the Maker Browser. Now removing the button that doesn't work to minimize confusion.

Screenshot of my Google Chrome browser on localhost and my Maker App on localhost:

![Screenshot from 2020-12-14 10-54-04](https://user-images.githubusercontent.com/2959170/102123740-27941080-3dfc-11eb-960b-853a883c0ef6.png)

I also disabled the "Connect" button in the Manage Accounts section because that uses the same path as the 'Continue with Google' button and ran into the same issue. I added a tooltip explaining that the user should try again from their default browser.

Screenshot of connect behavior on Maker App and Google Chrome:
![Screenshot from 2020-12-14 16-20-22](https://user-images.githubusercontent.com/2959170/102152652-5628e000-3e2a-11eb-92af-58165b49640a.png)

Screenshot of disconnect behavior on Maker App and Google Chrome:
![Screenshot from 2020-12-14 16-19-51](https://user-images.githubusercontent.com/2959170/102152718-76589f00-3e2a-11eb-877e-ceb634fce0ff.png)

Jillian edit: tooltip is now centered is connect behavior:
<img width="1440" alt="Screen Shot 2020-12-15 at 4 37 22 PM" src="https://user-images.githubusercontent.com/17147070/102289556-d1a29400-3ef3-11eb-8096-bd9d29d54836.png">

Jillian edit: tooltip is now centered in disconnect behavior:
<img width="1440" alt="Screen Shot 2020-12-15 at 4 32 32 PM" src="https://user-images.githubusercontent.com/17147070/102289388-622ca480-3ef3-11eb-8d54-51306a91f793.png">


# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
