### PR TITLE
Temporarily prevent address filtering from blocking sharing applab libraries

### DIFF
--- a/lib/cdo/share_filtering.rb
+++ b/lib/cdo/share_filtering.rb
@@ -61,14 +61,14 @@ module ShareFiltering
     email = RegexpUtils.find_potential_email(text)
     return ShareFailure.new(FailureType::EMAIL, email) if email
 
-    street_address = Geocoder.find_potential_street_address(text)
-    return ShareFailure.new(FailureType::ADDRESS, street_address) if street_address
-
     phone_number = RegexpUtils.find_potential_phone_number(text)
     return ShareFailure.new(FailureType::PHONE, phone_number) if phone_number
 
     expletive = ProfanityFilter.find_potential_profanity(text, locale)
     return ShareFailure.new(FailureType::PROFANITY, expletive) if expletive
+
+    street_address = Geocoder.find_potential_street_address(text)
+    return ShareFailure.new(FailureType::ADDRESS, street_address) if street_address
 
     nil
   end

--- a/shared/middleware/files_api.rb
+++ b/shared/middleware/files_api.rb
@@ -341,6 +341,7 @@ class FilesApi < Sinatra::Base
     share_failure = ShareFiltering.find_failure(body, request.locale)
     # TODO(JillianK): we are temporarily ignoring address share failures because our address detection is very broken.
     # Once we have a better geocoding solution in H1, we should start filtering for addresses again.
+    # Additional context: https://codedotorg.atlassian.net/browse/STAR-1361
     return bad_request if endpoint == 'libraries' && share_failure && share_failure[:type] != "address"
 
     # Replacing a non-current version of main.json could lead to perceived data loss.

--- a/shared/middleware/files_api.rb
+++ b/shared/middleware/files_api.rb
@@ -338,7 +338,10 @@ class FilesApi < Sinatra::Base
     end
 
     # Block libraries with PII/profanity from being published.
-    return bad_request if endpoint == 'libraries' && ShareFiltering.find_failure(body, request.locale)
+    share_failure = ShareFiltering.find_failure(body, request.locale)
+    # TODO(JillianK): we are temporarily ignoring address share failures because our address detection is very broken.
+    # Once we have a better geocoding solution in H1, we should start filtering for addresses again.
+    return bad_request if endpoint == 'libraries' && share_failure && share_failure[:type] != "address"
 
     # Replacing a non-current version of main.json could lead to perceived data loss.
     # Log to firehose so that we can better troubleshoot issues in this case.


### PR DESCRIPTION
Libraries are incorrectly being flagged as containing an address, preventing them from being shared. While our old Google maps geocoder did a decent job of finding addresses in long strings of text, we've since switched to Mapbox which is giving us a lot of false positives (with zipcodes). This prevents address filtering from blocking the sharing of applab libraries and should be reverted once we have a better geocoding solution (which should happen in early H1). 

Note: I moved the geocoder check to the bottom of find_share_failure so that we catch phone number and expletive failures even if there is also a geocoder failure. 

<!-- ### Background -->
### Privacy
We've run this by Travis, Marina, and Amanda: our privacy policy is not officially holding us to looking for addresses in applab libraries (since applab is 13+).
<!-- ### Security -->
<!--
Link to Jira Task where sensitive security issues are discussed privately.
-->
<!-- ### Caching -->
<!-- ### Deployment strategy -->
<!-- ### Future work -->

## Links

- [jira](https://codedotorg.atlassian.net/browse/STAR-1361?atlOrigin=eyJpIjoiYmU5YThmMzQyOGMwNDVjNDlhZTg4ZDY4ZWYxY2JmNGIiLCJwIjoiaiJ9)

## Testing story

<!--
  Does your change include appropriate tests?

  If so, please describe how the tests included in this PR are sufficient

  If not, please explain why this change does not need to be tested.
-->

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
