### PR TITLE
Install patched ProxySQL with fix for Aurora 2.09

### DIFF
--- a/cookbooks/cdo-mysql/recipes/proxy.rb
+++ b/cookbooks/cdo-mysql/recipes/proxy.rb
@@ -1,17 +1,27 @@
 # Configure ProxySQL integration.
 
 # https://github.com/sysown/proxysql#ubuntu--debian
-apt_repository "proxysql" do
-  uri "http://repo.proxysql.com/ProxySQL/proxysql-2.0.x/#{node['lsb']['codename']}/"
-  distribution nil
-  components ['./']
-  key "https://repo.proxysql.com/ProxySQL/repo_pub_key"
-end
+# apt_repository "proxysql" do
+#   uri "http://repo.proxysql.com/ProxySQL/proxysql-2.0.x/#{node['lsb']['codename']}/"
+#   distribution nil
+#   components ['./']
+#   key "https://repo.proxysql.com/ProxySQL/repo_pub_key"
+# end
+#
+# apt_package 'proxysql' do
+#   version '2.0.7'
+#   action :upgrade
+# end
 
-apt_package 'proxysql' do
-  version '2.0.7'
-  action :upgrade
+# Use patched ProxySQL with fix for Aurora 2.09 bug.
+# See: https://github.com/sysown/proxysql/issues/3082
+proxysql_filename = 'proxysql_2.0.15-ubuntu18_amd64.deb'
+proxysql_file = "#{Chef::Config[:file_cache_path]}/#{proxysql_filename}"
+remote_file proxysql_file do
+  source "https://github.com/wjordan/proxysql/releases/download/v2.0.15-aurora_2.09_fix/#{proxysql_filename}"
+  checksum "29fe79e54bce0f532084bfd8e5a13a55f1f8530f92be8a0e7db847aefcb1762f"
 end
+dpkg_package('proxysql') {source proxysql_file}
 
 writer = URI.parse(node['cdo-secrets']['db_writer'] || 'mysql2://root@localhost/')
 writer.hostname = '127.0.0.1' if writer.hostname == 'localhost'


### PR DESCRIPTION
Update Chef cookbook with a temporary fix replacing the official repository version of `proxysql` with a custom-built package from a [github fork](https://github.com/wjordan/proxysql/tree/v2.0.15-aurora_2.09_fix), which contains a [patch](https://github.com/wjordan/proxysql/commit/0174822dbcba83d40653d0fe90061cf6f5ae26c2) to work around an Aurora engine version 2.09 bug which causes proxysql to incorrectly shun the writer instance.

Process to build the `.deb` file was to run `make ubuntu18` then upload the generated `.deb` in a GitHub release.

Testing the fix on an adhoc instance and working on verifying that the package installs and works properly with Aurora 2.09.