### PR TITLE
Updated pdftk-java to more recent version.

### DIFF
--- a/cookbooks/cdo-apps/recipes/default.rb
+++ b/cookbooks/cdo-apps/recipes/default.rb
@@ -25,11 +25,11 @@ apt_package %w(
 )
 
 # Used by lesson plan generator.
-pdftk_file = 'pdftk-java_3.0.2-2_all.deb'
+pdftk_file = 'pdftk-java_3.1.1-1_all.deb'
 pdftk_local_file = "#{Chef::Config[:file_cache_path]}/#{pdftk_file}"
 remote_file pdftk_local_file do
   source "https://mirrors.kernel.org/ubuntu/pool/universe/p/pdftk-java/#{pdftk_file}"
-  checksum "92af8960406698d2e1c4f1f0c10b397e9391729c9c63070d2c3ed472850f16a9"
+  checksum "8a28ba8b100bc0b6e9f3e91c090a9b8a83a5f8a337a91150cbaadad8accb4901"
 end
 # Dependencies of pdftk-java.
 apt_package %w(


### PR DESCRIPTION
The version of pdftk-java that we were using was out of support by the code mirror we were using. This was causing adhoc environments to fail their build step as this package could not be downloaded. This PR updates it to a more recent version.

Code mirror: https://mirrors.edge.kernel.org/ubuntu/pool/universe/p/pdftk-java/

<!--
  Other aspects to consider. uncomment and add detail for any that seem necessary:
-->

<!-- ### Background -->
<!-- ### Privacy -->
<!--
1.	Does the Project involve the collection, use or sharing of new Personal Data?

2.	Does the Project involve a new or changed use or sharing of existing Personal Data?
-->
<!-- ### Security -->
<!--
Link to Jira Task where sensitive security issues are discussed privately.
-->
<!-- ### Caching -->
<!-- ### Deployment strategy -->
<!-- ### Future work -->

## Links

<!--
  Any relevant links to external resources; ie, specification documents, jira
  items, related PRs, honeybadger errors, etc
-->

## Testing story

I ran the pdf collate script, which uses pdftk-java, and the pdfs were correctly generated.

<!--
  Does your change include appropriate tests?

  If so, please describe how the tests included in this PR are sufficient

  If not, please explain why this change does not need to be tested.
-->

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
