### PR TITLE
Remove imported CB lesson descriptions that were copied from 2020

### DIFF
--- a/dashboard/config/locales/scripts.en.yml
+++ b/dashboard/config/locales/scripts.en.yml
@@ -18374,78 +18374,48 @@ en:
             CS Discoveries Pre-survey:
               key: CS Discoveries Pre-survey
               name: CS Discoveries Pre-survey
-              description_student: ''
-              description_teacher: ''
             Intro to Problem Solving:
               key: Intro to Problem Solving
               name: Intro to Problem Solving
-              description_student: "**Question of the Day: What can help us to work together and solve problems as a team?**\r\n\r\nThe class works in groups to design aluminum foil boats that will support as many pennies as possible.  At the end of the lesson groups reflect on their experiences with the activity and make connections to the types of problem solving they will be doing for the rest of the course. "
-              description_teacher: "**Question of the Day: What can help us to work together and solve problems as a team?**\r\n\r\nIn this lesson, students work in groups to design aluminum foil boats that will support as many pennies as possible. Groups have two rounds to work on their boats, with the goal of trying to hold more pennies than they did in round 1. The structure of the activity foreshadows different steps of the problem solving process that students will be introduced to in more detail in the following lesson. At the end of the lesson students reflect on their experiences with the activity and make connections to the types of problem solving they will be doing for the rest of the course.\r\n\r\n**Alternate versions of this lesson are also available.** \r\n\r\n* [Newspaper Table](../4/)\r\n* [Spaghetti Bridge](../5/)\r\n* [Paper Tower](../6/)"
             The Problem Solving Process:
               key: The Problem Solving Process
               name: The Problem Solving Process
-              description_student: "**Question of the Day: What are some common steps we can use to solve many different types of problems?**\r\n\r\nThis lesson introduces the formal problem solving process that the class will use over the course of the year, Define - Prepare - Try - Reflect.  The class relates these steps to the aluminum boats problem from the previous lesson, then a problem they are good at solving, then a problem they want to improve at solving. At the end of the lesson the class collects a list of generally useful strategies for each step of the process to put on posters that will be used throughout the unit and year."
-              description_teacher: "**Question of the Day: What are some common steps we can use to solve many different types of problems?**\r\n\r\nThis lesson introduces the formal problem solving process that students will use over the course of the year, Define - Prepare - Try - Reflect. The lesson begins by asking students to brainstorm all the different types of problems that they encounter in everyday life. Students are then shown the four steps of the problem solving process and work together to relate these abstract steps to their actual experiences solving problems. First students relate these steps to the aluminum boats problem from the previous lesson, then a problem they are good at solving, then a problem they want to improve at solving. At the end of the lesson the class collects a list of generally useful strategies for each step of the process to put on posters that will be used throughout the unit and year."
             Exploring Problem Solving:
               key: Exploring Problem Solving
               name: Exploring Problem Solving
-              description_student: "**Question of the Day: How can we apply the problem solving process to many different kinds of problems?**\r\n\r\nIn this lesson the class applies the problem solving process to three different problems: a word search, a seating arrangement for a birthday party, and planning a trip. The problems grow increasingly complex and poorly defined to highlight how the problem solving process is particularly helpful when tackling these types of problems."
-              description_teacher: "**Question of the Day: How can we apply the problem solving process to many different kinds of problems?**\r\n\r\nIn this lesson students apply the problem solving process to three different problems in order to better understand the value of each step. They will solve a word search, arrange seating for a birthday party, and redesign a classroom. The problems grow increasingly complex and poorly defined to highlight how the problem solving process is particularly helpful when tackling these types of problems. The lesson concludes with students reflecting on their experience with the problem solving process. They will justify the inclusion of each step and will brainstorm questions or strategies that can help them better define open-ended problems, as this is often the most critical step.\r\n\r\nThis lesson will likely take two class periods or more to complete. The first two problems may fit into a single class period but the third will need to be moved to a second day."
             What is a Computer?:
               key: What is a Computer?
               name: What is a Computer?
-              description_student: "**Question of the Day: What is a computer?**\r\n\r\nIn this lesson the class develops a preliminary definition of a computer. After brainstorming the possible definitions for a computer, the class works in groups to sort pictures into “is a computer” or “is not a computer” on poster paper and explain their motivations for choosing some of the most difficult categorizations.  The teacher then introduces a definition of the computer and allows groups to revise their posters according to the new definition."
-              description_teacher: "**Question of the Day: What is a computer?**\r\n\r\nIn this lesson students develop a preliminary definition of a computer. To begin the lesson, the class will brainstorm possible definitions for a computer and place the results of this brainstorm on the board. Next, students will work in groups to sort pictures into “is a computer” or “is not a computer” on poster paper. Groups will place their posters around the room and briefly explain their motivations for choosing some of their most difficult categorizations.  The teacher will then introduce a definition of the computer and allow students to revise their posters according to the new definition.\r\n"
             Input and Output:
               key: Input and Output
               name: Input and Output
-              description_student: "**Question of the Day: How do computers use input and output to get and give the information that they need to solve problems?**\r\n\r\n\r\nIn this lesson the class considers how computers get and give information to the user through inputs and outputs.  After first considering what information the would need to solve a \"thinking problem\" the class identifies the inputs and outputs to that process.  Afterwards, they explore a a series of apps and determine the inputs and outputs for each one."
-              description_teacher: "**Question of the Day: How do computers use input and output to get and give the information that they need to solve problems?**\r\n\r\nIn this lesson students consider how computers get and give information to the user through inputs and outputs.  Students first consider what information the would need to solve a \"thinking problem\", then use that information to produce a recommendation.  They then identify the inputs and outputs to that process.  Afterwards, students consider an app that engages in the same process and determine how that app inputs and outputs information.  Last, they consider other types of inputs and outputs that computers can use to help solve problems."
             Processing:
               key: Processing
               name: Processing
-              description_student: "**Question of the Day: What are the different ways computers can process information?**\r\n\r\nThis lesson introduces four types of processing that the class will use throughout the course.  Through a series of apps, the class explores how processing is used to turn input into output.  In the end, the class  brainstorms more types of app processing that would be useful."
-              description_teacher: "**Question of the Day: What are the different ways computers can process information?**\r\n\r\nThis lesson introduces students to four common types of processing: if/then (conditionals), finding a match (searching), counting, and comparing.  Students are first introduced to the types of processing through several sample apps.  They then investigate more apps to determine what sorts of processing each uses.  They then think of their own app and decide what types of processing it would need to work.  Finally, they brainstorm other types of processing that may be useful but were not included in the main lesson."
             Storage:
               key: Storage
               name: Storage
-              description_student: ''
-              description_teacher: ''
             Project - Propose an App:
               key: Project - Propose an App
               name: Project - Propose an App
-              description_student: "**Question of the Day:  How can the IOSP model help us to design an app that solves a problem?**\r\n\r\nTo conclude the study of the problem solving process and the input/output/store/process model of a computer, the class proposes apps designed to solve real world problems. This project is completed across multiple days and culminates in a poster presentation highlighting the features of each app. The project is designed to be completed in pairs though it can be completed individually."
-              description_teacher: "**Question of the Day:  How can the IOSP model help us to design an app that solves a problem?**\r\n\r\nTo conclude their study of the problem solving process and the input/output/store/process model of a computer, students will propose an app designed to solve a real world problem. This project will be completed across multiple days and will result in students creating a poster highlighting the features of their app that they will present to their classmates. A project guide provides step by step instructions for students and helps them organize their thoughts. The project is designed to be completed in pairs though it can be completed individually."
             Post-Project Test:
               key: Post-Project Test
               name: Post-Project Test
-              description_student: ''
-              description_teacher: ''
             Intro to Problem Solving - Newspaper Table (Alternate Lesson 1):
               key: Intro to Problem Solving - Newspaper Table (Alternate Lesson 1)
               name: Intro to Problem Solving - Newspaper Table (Alternate Lesson 1)
-              description_student: "**Question of the Day: What can help us to work together and solve problems as a team?**\r\n\r\nThe class works in groups to design newspaper tables that will support as many books as possible.  At the end of the lesson, groups reflect on their experiences with the activity and make connections to the types of problem solving they will be doing for the rest of the course. "
-              description_teacher: "**Question of the Day: What can help us to work together and solve problems as a team?**\r\n\r\n\r\nIn this lesson, students work in groups to design newspaper tables that will hold as many books as possible. Groups have two rounds to work on their tables, with the goal of trying to hold more books than they did in the first round. The structure of the activity foreshadows different steps of the problem solving process that students will be introduced to in more detail in the following lesson. At the end of the lesson students reflect on their experiences with the activity and make connections to the types of problem solving they will be doing for the rest of the course.\r\n\r\n**This is an alternate activity to [Intro to Problem Solving - Aluminum Boats](../1/)**"
             Intro to Problem Solving - Spaghetti Bridge (Alternate Lesson 1):
               key: Intro to Problem Solving - Spaghetti Bridge (Alternate Lesson 1)
               name: Intro to Problem Solving - Spaghetti Bridge (Alternate Lesson 1)
-              description_student: "**Question of the Day: What can help us to work together and solve problems as a team?**\r\n\r\nThe class works in groups to design spaghetti bridges that will support as many books as possible.  At the end of the lesson groups reflect on their experiences with the activity and make connections to the types of problem solving they will be doing for the rest of the course. "
-              description_teacher: "**Question of the Day: What can help us to work together and solve problems as a team?**\r\n\r\n\r\nIn this lesson, students work in groups to design spaghetti bridges that will support as many books as possible. Groups have two rounds to work on their bridges, with the goal of trying to hold more books than they did in Round 1. The structure of the activity foreshadows different steps of the problem solving process that students will be introduced to in more detail in the following lesson. At the end of the lesson students reflect on their experiences with the activity and make connections to the types of problem solving they will be doing for the rest of the course.\r\n\r\n**This is an alternate activity to [Intro to Problem Solving - Aluminum Boats](../1/)**"
             Intro to Problem Solving - Paper Tower (Alternate Lesson 1):
               key: Intro to Problem Solving - Paper Tower (Alternate Lesson 1)
               name: Intro to Problem Solving - Paper Tower (Alternate Lesson 1)
-              description_student: "**Question of the Day: What can help us to work together and solve problems as a team?**\r\n\r\nThe class works in groups to design paper towers that will be as tall as possible.  At the end of the lesson groups reflect on their experiences with the activity and make connections to the types of problem solving they will be doing for the rest of the course. "
-              description_teacher: "**Question of the Day: What can help us to work together and solve problems as a team?**\r\n\r\n\r\nIn this lesson, students work in groups to design paper towers that can stand as high as possible. Groups have two rounds to work on their towers, with the goal of trying to go higher than they did in Round 1. The structure of the activity foreshadows different steps of the problem solving process that students will be introduced to in more detail in the following lesson. At the end of the lesson students reflect on their experiences with the activity and make connections to the types of problem solving they will be doing for the rest of the course.\r\n\r\n**This is an alternate activity to [Intro to Problem Solving - Aluminum Boats](../1/)**"
             Exploring Problem Solving - Animals Theme (Alternate Lesson 3):
               key: Exploring Problem Solving - Animals Theme (Alternate Lesson 3)
               name: Exploring Problem Solving - Animals Theme (Alternate Lesson 3)
-              description_student: "**Question of the Day: How can we apply the problem solving process to many different kinds of problems?**\r\n\r\nIn this lesson the class applies the problem solving process to three different problems: a tangram puzzle, choosing a pet according to criteria, and planning a pet adoption event. The problems grow increasingly complex and poorly defined to highlight how the problem solving process is particularly helpful when tackling these types of problems."
-              description_teacher: "**Question of the Day: How can we apply the problem solving process to many different kinds of problems?**\r\n\r\nIn this lesson students apply the problem solving process to three different problems in order to better understand the value of each step. They will solve tangrams, choose a pet for several people, and plan a pet adoption event. The problems grow increasingly complex and poorly defined to highlight how the problem solving process is particularly helpful when tackling these types of problems. The lesson concludes with students reflecting on their experience with the problem solving process. They will justify the inclusion of each step and will brainstorm questions or strategies that can help them better define open-ended problems, as this is often the most critical step.\r\n\r\nThis lesson will likely take two class periods or more to complete. The first two problems may fit into a single class period but the third will need to be moved to a second day."
             Exploring Problem Solving - Games Theme (Alternate Lesson 3):
               key: Exploring Problem Solving - Games Theme (Alternate Lesson 3)
               name: Exploring Problem Solving - Games Theme (Alternate Lesson 3)
-              description_student: "**Question of the Day: How can we apply the problem solving process to many different kinds of problems?**\r\n\r\nIn this lesson the class applies the problem solving process to three different problems: a maze, a logic puzzle, and planning field day activity. The problems grow increasingly complex and poorly defined to highlight how the problem solving process is particularly helpful when tackling these types of problems."
-              description_teacher: "**Question of the Day: How can we apply the problem solving process to many different kinds of problems?**\r\n\r\nIn this lesson students apply the problem solving process to three different problems in order to better understand the value of each step. They will solve a maze, organizing a team to race as fast as possible, and design a game. The problems grow increasingly complex and poorly defined to highlight how the problem solving process is particularly helpful when tackling these types of problems. The lesson concludes with students reflecting on their experience with the problem solving process. They will justify the inclusion of each step and will brainstorm questions or strategies that can help them better define open-ended problems, as this is often the most critical step.\r\n\r\nThis lesson will likely take two class periods or more to complete. The first two problems may fit into a single class period but the third will need to be moved to a second day."
           lesson_groups:
             cspSurvey:
               display_name: Survey
@@ -18465,118 +18435,72 @@ en:
             Exploring Web Pages:
               key: Exploring Web Pages
               name: Exploring Web Pages
-              description_student: "**Question of the Day:  Why do people create web pages?**\r\n\r\nThis lesson covers the purposes that a web page might serve, both for the users and the creators. The class explores a handful of sample web pages how each of those pages is useful for users and how it might also serve its creators."
-              description_teacher: "**Question of the Day:  Why do people create web pages?**\r\n\r\n\r\nEvery website has a purpose, a reason someone created it and others use it. In this lesson, students will start to consider the purposes a website might serve, both for the users and the creators. Students will explore a some sample websites and discuss the purpose it serves for its creator, then they are asked to reflect on reasons that someone might want to create websites."
             Intro to HTML:
               key: Intro to HTML
               name: Intro to HTML
-              description_student: "**Question of the Day: How can we tell the computer both *what* to put on the web page, and *how* to organize it?**\r\n\r\n\r\nThis lesson introduces to HTML as a solution to the problem of how to communicate both the content and structure of a website to a computer. The lesson begins with a brief unplugged activity demonstrating the challenges of effectively communicating the structure of a web page. The class looks at an HTML page in Web Lab and discusses how HTML tags help solve this problem, then uses HTML to write the first web pages of the unit."
-              description_teacher: "**Question of the Day: How can we tell the computer both *what* to put on the web page, and *how* to organize it?**\r\n\r\nIn this lesson students are introduced HTML as a solution to the problem of how to communicate both the content and structure of a website to a computer. The lesson begins with a brief unplugged activity demonstrating the challenges of effectively communicating the structure of a web page. Students then look at an exemplar HTML page in Web Lab and discuss with their classmates how HTML tags help solve this problem. Students then write their first HTML. A wrap-up discussion helps to solidify the understanding of content vs. structure that was developed throughout the lesson."
             Headings:
               key: Headings
               name: Headings
-              description_student: "**Question of the Day: How can we work together to fix problems with our websites?**\r\n\r\n\r\nThis lesson continues the introduction to HTML tags, this time with headings.  The class practices using heading tags to create page and section titles and learns how the different heading elements are displayed by default. "
-              description_teacher: "**Question of the Day: How can we work together to fix problems with our websites?**\r\n\r\nIn this lesson, students continue to use HTML to structure text on web pages, this time in pairs and with a focus on working together and debugging problems with their sites.  Students learn how the different heading elements are displayed by default and practice using them to create page and section titles.  "
             'Mini-Project: HTML Web Page':
               key: 'Mini-Project: HTML Web Page'
               name: 'Mini-Project: HTML Web Page'
-              description_student: "**Question of the Day: How can I use HTML to express a personal value?**\r\n\r\nIn this lesson, the class creates personal web page on a topic of their choice.  The lesson starts with a review of HTML tags.  Next, the class designs web pages, identifying the tags needed to implement them, and creates the pages in Web Lab."
-              description_teacher: "**Question of the Day: How can I use HTML to express a personal value?**\r\n\r\nIn this optional mini-project, students use what they have learned to created their own personal web page on a topic of their choice.  The lesson starts with a review of the HTML that students have learned.  They then begin their project by designing a web page and identifying which tags they will use to implement it.  They then create their web pages in Web Lab and share with the class.  Optionally, after engaging in a formal feedback process, they may make final changes to their websites before reflecting on their process and turning in the site itself and their design and reflection.  This project can be completed in one day or expanded over several days, depending on the scheduling needs of the class."
             Digital Footprint:
               key: Digital Footprint
               name: Digital Footprint
-              description_student: "**Question of the Day: How can you make sure that your private information stays private?**\r\n\r\nThis lesson takes a step back from creating the personal website to talk about personal information people choose to share digitally.  The class begins by discussing what types of information they have shared on various websites, then looks at several sample social media pages to see what types of personal information could be shared intentionally or unintentionally.  Finally, the class comes up with a set of guidelines to follow when putting information online."
-              description_teacher: "**Question of the Day: How can you make sure that your private information stays private?**\r\n\r\nThis lesson takes a step back from developing web pages to help students articulate what personal information they choose to share digitally and with whom.  It also reinforces the notion that much of the information that they choose to share digitally falls largely out of their control the moment it is released.  \r\n\r\nStudents look at several social media pages to determine what sorts of information people are sharing about themselves or one another.  Last, students reflect on what guidelines they think are appropriate for posting information online.\r\n\r\nThe ultimate point of this lesson is not to scare students, but rather to experientially bring students to realizing precisely what level of control they don’t have in releasing information into the web."
             Styling Text with CSS:
               key: Styling Text with CSS
               name: Styling Text with CSS
-              description_student: "**Question of the Day: How can we change the style of text on a web page?**\r\n\r\n\r\nThis lesson introduces CSS as a way to style elements on the page. The class learns the basic syntax for CSS rule-sets and then explores properties that impact HTML text elements, then discusses the differences between content, structure, and style when making a personal web page."
-              description_teacher: "**Question of the Day: How can we change the style of text on a web page?**\r\n\r\nThis lesson introduces CSS as a way to style elements on the page. Students learn the basic syntax for CSS rule-sets and then explore properties that impact HTML text elements. They work on a HTML page about Guinness World Record holders, adding their own style to the provided page. "
             'Mini-Project: Your Personal Style':
               key: 'Mini-Project: Your Personal Style'
               name: 'Mini-Project: Your Personal Style'
-              description_student: "**Question of the Day: How can you express your personal style on a web page?**\r\n\r\nIn this lesson, the class creates their own styled web pages.  The lesson starts with a review of the CSS.  The class then designs the web page, identifies which CSS properties they will need, and create their web pages in Web Lab."
-              description_teacher: "**How can we use web pages to express personal style?**\r\n\r\nIn this optional mini-project, student use what they have learned to created their own styled web page on a topic of their choice.  The lesson starts with a review of the CSS that students have learned.  They then begin their project by designing a web page and identifying which properties they will use to implement it.  They then create their web pages in Web Lab and share with the class.  After engaging in a formal feedback process, they make final changes to their websites before reflecting on their process and turning in the site itself and their design and reflection.  This project can be completed in one day or expanded over several days, depending on the scheduling needs of the class."
             Intellectual Property:
               key: Intellectual Property
               name: Intellectual Property
-              description_student: "**Question of the Day: What kind of rules protect everyone's rights when we use each other's content?**\r\n\r\nStarting with a discussion of their personal opinions on how others should be allowed to use their work, the class explores the purpose and role of copyright for both creators and users of creative content.  They then move on to an activity exploring the various Creative Commons licenses as a solution to the difficulty in dealing with copyright. "
-              description_teacher: "**Question of the Day: What kind of rules protect everyone's rights when we use each other's content?**\r\n\r\nStarting with a discussion of their personal opinions on how others should be allowed to use their work, the class explores the purpose and role of copyright for both creators and users of creative content.  They then move on to an activity exploring the various Creative Commons licenses as a solution to the difficulty in dealing with copyright. "
             Using Images:
               key: Using Images
               name: Using Images
-              description_student: ''
-              description_teacher: ''
             'Websites for Expression ':
               key: 'Websites for Expression '
               name: 'Websites for Expression '
-              description_student: "**Question of the Day: How can we use websites to express ourselves?**\r\n\r\nThis lesson introduces websites as a means of personal expression.  The class first discusses different ways that people express and share their interests and ideas, then looks at a few exemplar websites made by students from a previous course. Finally everyone brainstorms and shares a list of topics and interests to include, creating a resource for developing a personal website in the rest of the unit. "
-              description_teacher: "**Question of the Day: How can we use websites to express ourselves?**\r\n\r\nIn this lesson students investigate ways to use websites as a means of personal expression and develop a list of topics and interests that they would want to include on a personal website. To begin the lesson students brainstorm different ways that people express and share their interests and ideas. Students then look at a few exemplar websites to identify ways they are expressing their ideas. Finally students brainstorm and share a list of topics and interests they might want to include on a personal website which they can reference for ideas as they progress through the unit."
             Styling Elements with CSS:
               key: Styling Elements with CSS
               name: Styling Elements with CSS
-              description_student: "**Question of the Day: How can we style the images and layouts of our pages?**\r\n\r\nThis lesson continues the introduction to CSS style properties, this time focusing more on non-text elements. The class begins by investigating and modifying the new CSS styles on a Desserts of the World page. Afterwards, everyone applies this new knowledge to their personal websites."
-              description_teacher: "**Question of the Day: How can we style the images and layouts of our pages?**\r\n\r\nThis lesson continues the introduction to CSS style properties, this time focusing more on non-text elements. Students begin this lesson by looking at a website about Desserts of the World. They investigate and modify the new CSS styles on this website, adding their own styles to the page. After working on the Desserts page, students apply their knowledge of new CSS properties to their personal websites."
             Your Web Page - Prepare:
               key: Your Web Page - Prepare
               name: Your Web Page - Prepare
-              description_student: "**Question of the Day: What do we need to do to prepare to build our web pages?**\r\n\r\nIn this lesson, the class engages in the \"prepare\" stage of the problem solving process, deciding what elements and style their web pages will have.  They review the different HTML, CSS, and digital citizenship guidelines, then design and plan their pages, downloading and documenting the images they will need. Afterwards, they reflect on how their plan will ensure that the website does what it is designed to do."
-              description_teacher: "**Question of the Day: What do we need to do to prepare to build our web pages?**\r\n\r\nIn this lesson, students engage in the \"prepare\" stage of the problem solving process, deciding what elements and style their web page will have.  They begin by reviewing the different HTML, CSS, and digital citizenship guidelines they will need in building their web pages.  They then describe and sketch their pages, listing the tags and styles they will use to get the layout and design that they decided on.  Then then move online to find and download the images they will need for their pages.  Afterwards, they reflect on how their plan will ensure that the website does what it is designed to do."
             Project - Personal Web Page:
               key: Project - Personal Web Page
               name: Project - Personal Web Page
-              description_student: ''
-              description_teacher: ''
             Websites for a Purpose:
               key: Websites for a Purpose
               name: Websites for a Purpose
-              description_student: ''
-              description_teacher: ''
             Team Problem Solving:
               key: Team Problem Solving
               name: Team Problem Solving
-              description_student: "**Question of the Day: How can we work together to make a great team?**\r\n\r\nTeams work together to set group norms and brainstorm what features they would like their websites to have.  The class starts by reflecting on what makes teams successful. Teams then make plans for how they will interact and reach success in their own projects before brainstorming ideas for their website projects."
-              description_teacher: "**Question of the Day: How can we work together to make a great team?**\r\n\r\nStudents work together to set group norms and brainstorm what features they would like their websites to have.  The class starts by thinking of some popular teams in different contexts, then reflects on what makes teams successful.  They then get into their own teams and make a plan for how they will interact and reach success in their own projects.  Afterwards, the teams begin to brainstorm ideas for their website project."
             Sources and Research:
               key: Sources and Research
               name: Sources and Research
-              description_student: "**Question of the Day: How do we find relevant and trustworthy information on the Internet?**\r\n\r\nThis lesson covers how to find relevant and trustworthy information online. After viewing and discussing a video about how search engines work, the classes searches search for information relevant to their sites, then analyzes the sites for credibility to decide which are appropriate to use on their own website."
-              description_teacher: "**Question of the Day: How do we find relevant and trustworthy information on the Internet?**\r\n\r\nThis lesson encourages students to think more about how to find relevant and trustworthy information online. After viewing and discussing a video about how search engines work, students will search for information relevant to their site. They'll need to analyze the sites they find for credibility to decide which are appropriate to use on their own website."
             CSS Classes:
               key: CSS Classes
               name: CSS Classes
-              description_student: "**Question of the Day:  How can we create different styles for the same type of element?**\r\n\r\nThis lesson introduces CSS classes, which allow web developers to treat groups of elements they want styled differently than other elements of the same type. The class first investigates and modifies classes on various pages, then creates their own classes and uses them to better control the appearance of their pages.  Teams then reflect on how they could use this skill to improve their websites."
-              description_teacher: "**Question of the Day:  How can we create different styles for the same type of element?**\r\n\r\nThis lesson expands on the CSS that students have already learned by introducing classes, which allow web developers to treat groups of elements they want styled differently than other elements of the same type. Students first investigate and modify classes on various pages, then create their own classes and use them to better control the appearance of their pages.  They then reflect on how they could use this skill to improve their team websites."
             Planning a Multi-page Website:
               key: Planning a Multi-page Website
               name: Planning a Multi-page Website
-              description_student: "**Question of the Day:  How do we plan a web page as a group?**\r\n\r\nThe class works in teams to plan out the final web sites, including a sketch of each page.  They then download the media that they will need for their sites.  At the end of the activity, they decide how the work will be distributed among them and report whether the entire team agreed to the plan."
-              description_teacher: "**Question of the Day:  How do we plan a web page as a group?**\r\n\r\nStudents work in teams to plan out their web sites, including a sketch of each page.  They then download the media that they will need for their sites.  At the end of the activity, they decide how the work will be distributed among them and report whether the entire group agreed to the plan."
             Linking Pages:
               key: Linking Pages
               name: Linking Pages
-              description_student: ''
-              description_teacher: ''
             Project - Website for a Purpose:
               key: Project - Website for a Purpose
               name: Project - Website for a Purpose
-              description_student: "**Question of the Day: What skills and practices will help us work together to make a great website?**\r\n\r\nIn this lesson team are finally able to code the pages that they have been planning.  Using the project guide, the team works together and individually to code all of the pages, then puts all of the work together into a single site."
-              description_teacher: "**Question of the Day: What skills and practices will help us work together to make a great website?**\r\n\r\nTeams have spent a lot of time throughout the chapter planning their websites.  In this lesson they are finally able to code their pages.  Using the project guide, the team works together and individually to code all of the pages, then puts all of the work together into a single site."
             Peer Review and Final Touches:
               key: Peer Review and Final Touches
               name: Peer Review and Final Touches
-              description_student: "**Question of the Day:  How can we use feedback to make our websites better?**\r\n\r\nThis lesson focuses on the value of peer feedback.  The class first reflects on what they are proud of, and what they would like feedback on, then give and get that feedback though a structured process that includes the project rubric criteria.  Afterwards, everyone puts the finishing touches on their sites and reflects on the process before a final showcase."
-              description_teacher: "**Question of the Day:  How can we use feedback to make our websites better?**\r\n\r\nThis lesson focuses on the value of peer feedback.  Students first reflect on what they are proud of, and what they would like feedback on.  Teams then work with peers to get that feedback though a structured process that includes the project rubric criteria.  Afterwards, students decide how they would like to respond to the feedback and put the finishing touches on their sites.  After a final review of the rubric, they reflect on their process. To cap off the unit, they will share their projects and also a overview of the process they took to get to that final design.\r\n"
             Post-Project Test:
               key: Post-Project Test
               name: Post-Project Test
-              description_student: ''
-              description_teacher: ''
             CS Discoveries Post Course survey:
               key: CS Discoveries Post Course survey
               name: CS Discoveries Post Course survey
-              description_student: ''
-              description_teacher: ''
           lesson_groups:
             csd2_1v2:
               display_name: 'Chapter 1: Creating Webpages'
@@ -18594,154 +18518,90 @@ en:
             Programming for Entertainment:
               key: Programming for Entertainment
               name: Programming for Entertainment
-              description_student: "**Question of the Day: How is computer science used in entertainment?**\r\n\r\nThe class is asked to consider the \"problems\" of boredom and self expression, and to reflect on how they approach those problems in their own lives. From there, they will explore how Computer Science in general, and programming specifically, plays a role in either a specific form of entertainment or as a vehicle for self expression."
-              description_teacher: "**Question of the Day: How is computer science used in entertainment?**\r\n\r\nStudents are asked to consider the \"problems\" of boredom and self expression, and to reflect on how they approach those problems in their own lives. From there, students will explore how Computer Science in general, and programming specifically, plays a role in either a specific form of entertainment or as a vehicle for self expression."
             Plotting Shapes:
               key: Plotting Shapes
               name: Plotting Shapes
-              description_student: "**Question of the Day: How can we clearly communicate how to draw something on a screen?**\r\n\r\nThis lesson explores the challenges of communicating how to draw with shapes and use a tool that introduces how this problem is approached in Game Lab.The class uses a Game Lab tool  to interactively place shapes on Game Lab's 400 by 400 grid. Partners then take turns instructing each other how to draw a hidden image using this tool, accounting for many of the challenges of programming in Game Lab."
-              description_teacher: "**Question of the Day: How can we clearly communicate how to draw something on a screen?**\r\n\r\nStudents explore the challenges of communicating how to draw with shapes and use a tool that introduces how this problem is approached in Game Lab. The warm up activity quickly demonstrates the challenges of communicating position without some shared reference point. In the main activity students explore a Game Lab tool that allows students to interactively place shapes on Game Lab's 400 by 400 grid. They then take turns instructing a partner how to draw a hidden image using this tool, accounting for many challenges students will encounter when programming in Game Lab. Students optionally create their own image to communicate before a debrief discussion."
             Drawing in Game Lab:
               key: Drawing in Game Lab
               name: Drawing in Game Lab
-              description_student: "**Question of the Day: How can we communicate to a computer how to draw shapes on the screen?**\r\n\r\nThe class is introduced to Game Lab, the programming environment for this unit, and begins to use it to position shapes on the screen. The lesson covers the basics of sequencing and debugging, as well as a few simple commands.  At the end of the lesson, students will be able to program images like the ones they made with the drawing tool in the previous lesson."
-              description_teacher: "**Question of the Day: How can we communicate to a computer how to draw shapes on the screen?**\r\n\r\nStudents are introduced to Game Lab, the programming environment for this unit, and begin to use it to position shapes on the screen. They learn the basics of sequencing and debugging, as well as a few simple commands. At the end of the lesson, students will be able to program images like the ones they made with the drawing tool in the previous lesson."
             Shapes and Parameters:
               key: Shapes and Parameters
               name: Shapes and Parameters
-              description_student: "**Question of the Day:  How can we use parameters to give the computer more specific instructions?**\r\n\r\nIn this lesson the class continues to develop a familiarity with Game Lab by manipulating the width and height of the shapes they use to draw. The lesson kicks off with a discussion that connects expanded block functionality (e.g. different sized shapes) with the need for more block inputs, or \"parameters\". The class learns to draw with versions of `ellipse()` and `rect()` that include width and height parameters and to use the `background()` block."
-              description_teacher: "**Question of the Day:  How can we use parameters to give the computer more specific instructions?**\r\n\r\nIn this lesson students continue to develop their familiarity with Game Lab by manipulating the width and height of the shapes they use to draw. The lesson kicks off with a discussion that connects expanded block functionality (e.g. different sized shapes) with the need for more block inputs, or \"parameters\". Students learn to draw with versions of `ellipse()` and `rect()` that include width and height parameters. They also learn to use the `background()` block."
             Variables:
               key: Variables
               name: Variables
-              description_student: "**Question of the Day:  How can we use variables to store information in our programs?**\r\n\r\nThis lesson introduces variables as a way to label a number in a program or save a randomly generated value. The class begins the lesson with a very basic description of the purpose of a variable and practices using the new blocks, then completes a level progression that reinforces the model of a variable as a way to label or name a number."
-              description_teacher: |-
-                **Question of the Day:  How can we use variables to store information in our programs?**
-
-                In this lesson students learn how to use variables to label a number. Students begin the lesson with a very basic description of the purpose of a variable within the context of the storage component of the input-output-storage-processing model. Students then complete a level progression that reinforces the model of a variable as a way to label or name a number.
             Random Numbers:
               key: Random Numbers
               name: Random Numbers
-              description_student: "**Question of the Day: How can we make our programs behave differently each time they are run?** \r\n\r\nThe class is introduced to the `randomNumber()` block and how it can be used to create new behaviors in their programs.  They then learn how to update variables during a program and use those skills to draw randomized images."
-              description_teacher: "**Question of the Day: How can we make our programs behave differently each time they are run?** \r\n\r\nStudents are introduced to the `randomNumber()` block and how it can be used to create new behaviors in their programs.  They then learn how to update variables during a program.  Combining all of these skills students draw randomized images."
             Sprites:
               key: Sprites
               name: Sprites
-              description_student: ''
-              description_teacher: ''
             Sprite Properties:
               key: Sprite Properties
               name: Sprite Properties
-              description_student: "**Question of the Day: How can we use sprite properties to change their appearance on the screen?**\r\n\r\nThe class extends its understanding of sprites by interacting with sprite properties.  The lesson starts with a review of what a sprite is, then moves on to Game Lab for more practice with sprites, using their properties to change their appearance.  The class then reflects on the connections between properties and variables."
-              description_teacher: "**Question of the Day: How can we use sprite properties to change their appearance on the screen?**\r\n\r\nStudents extend their understanding of sprites by interacting with sprite properties.  Students start with a review of what a sprite is, then move on to Game Lab to practice more with sprites, using their properties to change their appearance.  They then reflect on the connections between properties and variables."
             Text:
               key: Text
               name: Text
-              description_student: "**Question of the Day: How can we use text to improve our scenes and animations?**\r\n\r\nThis lesson introduces Game Lab's text commands, giving the class more practice using the coordinate plane and parameters.  At the beginning of the lesson, the class is asked to caption a cartoon created in Game Lab.  They then move onto Code Studio where they practice placing text on the screen and controlling other text properties, such as size."
-              description_teacher: "**Question of the Day: How can we use text to improve our scenes and animations?**\r\n\r\nThis lesson introduces Game Lab's text commands, giving students more practice using the coordinate plane and parameters.  At the beginning of the lesson, students are asked to caption a cartoon created in Game Lab.  They then move onto Code Studio where they practice placing text on the screen and controlling other text properties, such as size.  Students who complete the assessment early may go on to learn more challenging blocks related to text properties. "
             'Mini-Project: Captioned Scenes':
               key: 'Mini-Project: Captioned Scenes'
               name: 'Mini-Project: Captioned Scenes'
-              description_student: "**Question of the Day: How can we use Game Lab to express our creativity?**\r\n\r\nAfter a quick review of the code learned so far, the class is introduced to the first creative project of the unit.  Using the problem solving process as a model, students define the scene that they want to create, prepare by thinking of the different code they will need, try their plan in Game Lab, then reflect on what they have created.  In the end, they also have a chance to share their creations with their peers."
-              description_teacher: "**Question of the Day: How can we use Game Lab to express our creativity?**\r\n\r\nAfter a quick review of the code they have learned so far, students are introduced to their first creative project of the unit.  Using the problem solving process as a model, students define the scene that they want to create, prepare by thinking of the different code they will need, try their plan in Game Lab, then reflect on what they have created.  In the end, they also have a chance to share their creations with their peers."
             The Draw Loop:
               key: The Draw Loop
               name: The Draw Loop
-              description_student: "**Question of the Day: How can we animate our images in Game Lab?**\r\n\r\nThis lesson introduces the draw loop, one of the core programming paradigms in Game Lab.  The class combines the draw loop with random numbers to manipulate some simple animations with dots and then with sprites. "
-              description_teacher: "**Question of the Day: How can we animate our images in Game Lab?**\r\n\r\nIn this lesson students are introduced to the draw loop, one of the core programming paradigms in Game Lab. To begin the lesson students look at some physical flipbooks to see that having many frames with different images creates the impression of motion. Students then watch a video explaining how the draw loop in Game Lab helps to create this same impression in their programs. Students combine the draw loop with random numbers to manipulate some simple animations with dots and then with sprites."
             Sprite Movement:
               key: Sprite Movement
               name: Sprite Movement
-              description_student: "**Question of the Day: How can we control sprite movement in Game Lab?**\r\n\r\nIn this lesson, the class learns how to control sprite movement using a construct called the counter pattern, which incrementally changes a sprite's properties.  After brainstorming different ways that they could animate sprites by controlling their properties, the class explores the counter pattern in Code Studio, using the counter pattern to create various types of sprite movements."
-              description_teacher: "**Question of the Day: How can we control sprite movement in Game Lab?**\r\n\r\nIn this lesson, students learn how to control sprite movement using a construct called the counter pattern, which incrementally changes a sprite's properties.  Students first brainstorm different ways that they could animate sprites by controlling their properties, then explore the counter pattern in Code Studio.  After examining working code, students try using the counter pattern to create various types of sprite movements."
             'Mini-Project: Animation':
               key: 'Mini-Project: Animation'
               name: 'Mini-Project: Animation'
-              description_student: "**Question of the Day: How can we combine different programming patterns to make a complete animation?**\r\n\r\nIn this lesson, the class is asked to combine different methods from previous lessons to create an animated scene.  They first review the types of movement and animation that they have learned, and brainstorm what types of scenes might need that movement.  They then begin to plan out their own animated scenes, which they create in Game Lab."
-              description_teacher: "**Question of the Day: How can we combine different programming patterns to make a complete animation?**\r\n\r\nIn this lesson, students are asked to combine different methods that they have learned to create an animated scene.  Students first review the types of movement and animation that they have learned, and brainstorm what types of scenes might need that movement.  They then begin to plan out their own animated scenes, which they create in Game Lab."
             Conditionals:
               key: Conditionals
               name: Conditionals
-              description_student: "**Question of the Day:  How can programs react to changes as they are running?**\r\n\r\nThis lesson introduces booleans and conditionals, which allow a program to run differently depending on whether a condition is true.  The class starts by playing a short game in which they respond according to whether particular conditions are met.  They then move to Code Studio where they learn how the computer evaluates Boolean expressions, and how they can be used to structure a program."
-              description_teacher: "**Question of the Day:  How can programs react to changes as they are running?**\r\n\r\nThis lesson introduces booleans and conditionals, which allow a program to run differently depending on whether a condition is true.  Students start by playing a short game in which they respond according to whether particular conditions are met.  They then move to Code Studio where they learn how the computer evaluates Boolean expressions, and how they can be used to structure a program."
             Keyboard Input:
               key: Keyboard Input
               name: Keyboard Input
-              description_student: "**Question of the Day: How can our programs react to user input?**\r\n\r\nFollowing the introduction to booleans and _if_ statements in the previous lesson, the class is introduced to a new block called `keyDown()` which returns a boolean and can be used in conditionals statements to move sprites around the screen. By the end of this lesson the class will have written programs that take keyboard input from the user to control sprites on the screen."
-              description_teacher: "**Question of the Day: How can our programs react to user input?**\r\n\r\nFollowing the introduction to booleans and _if_ statements in the previous lesson, students are introduced to a new block called `keyDown()` which returns a boolean and can be used in conditionals statements to move sprites around the screen. By the end of this lesson students will have written programs that take keyboard input from the user to control sprites on the screen."
             Mouse Input:
               key: Mouse Input
               name: Mouse Input
-              description_student: "**Question of the Day: What are more ways that the computer can react to user input?**\r\n\r\nThe class continues to explore ways to use conditional statements to take user input. In addition to the keyboard commands learned yesterday, they will learn about several ways to take mouse input.  They will also expand their understanding of conditional to include `else`, which allows for the computer to run a certain section of code when a condition is true, and a different section of code when it is not."
-              description_teacher: |-
-                **Question of the Day: What are more ways that the computer can react to user input?**
-
-                In this lesson students continue to explore ways to use conditional statements to take user input. In addition to the keyboard commands learned yesterday, students will learn about several ways to take mouse input.  They will also expand their understanding of conditionals to include `else`, which allows for the computer to run a certain section of code when a condition is true, and a different section of code when it is not.
             Project - Interactive Card:
               key: Project - Interactive Card
               name: Project - Interactive Card
-              description_student: "**Question of the Day:  What skills and practices are important when creating an interactive program?**\r\n\r\nIn this cumulative project for Chapter 1, the class plans for and develops an interactive greeting card using all of the programming techniques they've learned to this point."
-              description_teacher: "**Question of the Day:  What skills and practices are important when creating an interactive program?**\r\n\r\nIn this cumulative project for Chapter 1, students plan for and develop an interactive greeting card using all of the programming techniques they've learned to this point."
             Velocity:
               key: Velocity
               name: Velocity
-              description_student: "**Question of the Day:  How can programming languages hide complicated patterns so that it is easier to program?**\r\n\r\nAfter a brief review of how the counter pattern is used to move sprites, the class is introduced to the idea of hiding those patterns in a single block, in order to help manage the complexity of programs.  They then head to Code Studio to try out new blocks that set a sprite's velocity directly, and look at various ways that they are able to code more complex behaviors in their sprites.  "
-              description_teacher: "**Question of the Day:  How can programming languages hide complicated patterns so that it is easier to program?**\r\n\r\nAfter a brief review of how they used the counter pattern to move sprites in previous lessons, students are introduced to the idea of hiding those patterns in a single block.  Students then head to Code Studio to try out new blocks that set a sprite's velocity directly, and look at various ways that they are able to code more complex behaviors in their sprites.  "
             Collision Detection:
               key: Collision Detection
               name: Collision Detection
-              description_student: "**Question of the Day: How can programming help make complicated problems more simple?**\r\n\r\nThe class learns about collision detection on the computer.  Working in pairs, they explore how a computer could use sprite location and size properties and math to detect whether two sprites are touching.  They then use the `isTouching()` block to create different effects when sprites collide and practice using the block to model various interactions."
-              description_teacher: "**Question of the Day: How can programming help make complicated problems more simple?**\r\n\r\nStudents learn about collision detection on the computer.  Working in pairs, they explore how a computer could use sprite location and size properties and math to detect whether two sprites are touching.  They then use the `isTouching()` block to create different effects when sprites collide and practice using the block to model various interactions."
             'Mini-Project: Side Scroller':
               key: 'Mini-Project: Side Scroller'
               name: 'Mini-Project: Side Scroller'
-              description_student: "**Question of the Day:  How can the new types of sprite movement and collision detection be used to create a game?**\r\n\r\nThe class uses what it has learned about collision detection and setting velocity to create simple side scroller games.  After looking at a sample side scroller game, students brainstorm what sort of side scroller they would like, then use a structured process to program the game in Code Studio."
-              description_teacher: "**Question of the Day:  How can the new types of sprite movement and collision detection be used to create a game?**\r\n\r\nStudents use what they have learned about collision detection and setting velocity to create a simple side scroller game.  After looking at a sample side scroller game, students brainstorm what sort of side scroller they would like, then use a structured process to program the game in Code Studio."
             Complex Sprite Movement:
               key: Complex Sprite Movement
               name: Complex Sprite Movement
-              description_student: "**Question of the Day: How can previous blocks be combined in new patterns to make interesting movements?**\r\n\r\nThe class learns to combine the velocity properties of sprites with the counter pattern to create more complex sprite movement. After reviewing the two concepts, they explore various scenarios in which velocity is used in the counter pattern, and observe the different types of movement that result.  In particular, the class learns how to simulate gravity.  They then reflect on how they were able to get new behaviors by combining blocks and patterns that they already knew."
-              description_teacher: "**Question of the Day: How can previous blocks be combined in new patterns to make interesting movements?**\r\n\r\nStudents learn to combine the velocity properties of sprites with the counter pattern to create more complex sprite movement. After reviewing the two concepts, they explore various scenarios in which velocity is used in the counter pattern, and observe the different types of movement that result.  In particular, students learn how to simulate gravity.  They then reflect on how they were able to get new behaviors by combining blocks and patterns that they already knew."
             Collisions:
               key: Collisions
               name: Collisions
-              description_student: "**Question of the Day: How can programmers build on abstractions to create further abstractions?**\r\n\r\nIn this lesson, the class programs their sprites to interact in new ways.  After a brief review of how they used the `isTouching` block, students brainstorm other ways that two sprites could interact.  They then use `isTouching` to make one sprite push another across the screen before practicing with the four collision blocks (`collide`, `displace`, `bounce`, and `bounceOff`)."
-              description_teacher: "**Question of the Day: How can programmers build on abstractions to create further abstractions?**\r\n\r\nIn this lessson, students program their sprites to interact in new ways.  After a brief review of how they used the `isTouching` block, students brainstorm other ways that two sprites could interact.  They then use `isTouching` to make one sprite push another across the screen before practicing with the four collision blocks (`collide`, `displace`, `bounce`, and `bounceOff`)."
             'Mini-Project: Flyer Game':
               key: 'Mini-Project: Flyer Game'
               name: 'Mini-Project: Flyer Game'
-              description_student: "**Question of the Day:  How can the new types collisions and modeling movement be used to create a game?**\r\n\r\nThe class uses what it has learned about simulating gravity and the different types of collisions  to create simple flyer games.  After looking at a sample flyer game, students brainstorm what sort of flyer they would like, then use a structured process to program the game in Code Studio."
-              description_teacher: "**Question of the Day:  How can the new types of collisions and modeling movement be used to create a game?**\r\n\r\nStudents use what they have learned about simulating gravity and the different types of collisions to create simple flyer games.  After looking at a sample flyer game, students brainstorm what sort of flyer games they would like, then use a structured process to program the game in Code Studio."
             Functions:
               key: Functions
               name: Functions
-              description_student: "**Question of the Day: How can programmers use functions to create their own abstractions?**\r\n\r\nThis lesson covers functions as a way to organize their code, make it more readable, and remove repeated blocks of code. The class learns that higher level or more abstract steps make it easier to understand and reason about steps, then begins to create functions in Game Lab. "
-              description_teacher: "**Question of the Day: How can programmers use functions to create their own abstractions?**\r\n\r\nStudents learn how to create functions to organize their code, make it more readable, and remove repeated blocks of code. Students first think about what sorts of new blocks they would like in Game Lab, and what code those blocks would contain inside. Afterwards students learn to create functions in Game Lab. They will use functions to remove long blocks of code from their draw loop and to replace repeated pieces of code with a single function."
             The Game Design Process:
               key: The Game Design Process
               name: The Game Design Process
-              description_student: "**Question of the Day:  How does having a plan help to make a large project easier?**\r\n\r\n\r\nThis lesson introduces the process the class will use to design games for the remainder of the unit. This process is centered around a project guide which asks students to define their sprites, variables, and functions before they begin programming their game. The class walks through this process in a series of levels.   At the end of the lesson they have an opportunity to make improvements to the game to make it their own."
-              description_teacher: "**Question of the Day:  How does having a plan help to make a large project easier?**\r\n\r\nThis lesson introduces students to the process they will use to design games for the remainder of the unit. This process is centered around a project guide which asks students to define their sprites, variables, and functions before they begin programming their game. In this lesson students begin by playing a game on Game Lab where the code is hidden. They discuss what they think the sprites, variables, and functions would need to be to make the game. They are then given a completed project guide which shows one way to implement the game. Students are then walked through this process through a series of levels.  At the end of the lesson students have an opportunity to make improvements to the game to make it their own."
             Using the Game Design Process:
               key: Using the Game Design Process
               name: Using the Game Design Process
-              description_student: "**Question of the Day:  How can the problem solving process help programmers to manage large projects?**\r\n\r\n\r\nIn this multi-day lesson, the class uses the problem solving process from Unit 1 to create a platform jumper game.  After looking at a sample game, the class defines what their games will look like and uses a structured process to build them.  Finally, the class reflects on how the games could be improved, and implements those changes."
-              description_teacher: "**Question of the Day:  How can the problem solving process help programmers to manage large projects?**\r\n\r\nIn this multi-day lesson, students use the problem solving process from Unit 1 to create a platform jumper game.  They start by looking at an example of a platform jumper, then define what their games will look like.  Next, they use a structured process to plan the backgrounds, variables, sprites, and functions they will need to implement their game.  After writing the code for the game, students will reflect on how the game could be improved, and implement those changes."
             Project - Design a Game:
               key: Project - Design a Game
               name: Project - Design a Game
-              description_student: "**Question of the Day: How can the five CS practices (problem solving, persistence, communication, collaboration, and creativity) help programmers to complete large projects?**\r\n\r\nThe class plans and builds original games using the project guide from the previous two lessons. Working individually or in pairs, the class plans, develops, and gives feedback on the games.  After incorporating the peer feedback, the class members share out their completed games."
-              description_teacher: "**Question of the Day: How can the five CS practices (problem solving, persistence, communication, collaboration, and creativity) help programmers to complete large projects?**\r\n\r\nStudents will plan and build their own game using the project guide from the previous two lessons to guide their project. Working individually or in pairs, students will first decide on the type of game they'd like to build, taking as inspiration a set of sample games. They will then complete a blank project guide where they will describe the game's behavior and scope out the variables, sprites, and functions they'll need to build. In Code Studio, a series of levels prompts them on a general sequence they can use to implement this plan. Partway through the process, students will share their projects for peer review and will incorporate feedback as they finish their game. At the end of the lesson, students will share their completed games with their classmates. This project will span multiple classes and can easily take anywhere from 3-5 class periods."
             Post-Project Test:
               key: Post-Project Test
               name: Post-Project Test
-              description_student: ''
-              description_teacher: ''
             CS Discoveries Post Course survey:
               key: CS Discoveries Post Course survey
               name: CS Discoveries Post Course survey
-              description_student: ''
-              description_teacher: ''
           lesson_groups:
             csd3_1:
               display_name: 'Chapter 1: Images and Animations'
@@ -18759,93 +18619,57 @@ en:
             Analysis of Design:
               key: Analysis of Design
               name: Analysis of Design
-              description_student: The class explores a variety of different teapot designs to consider how design choices or made and why. Using the teapots as an example, the class will explore the relationship between users, their needs, and the design of objects they use.
-              description_teacher: To kick off a unit devoted to group problem solving and developing products for other users, students begin by investigating the design of various teapots. Students analyze each teapot, attempting to identify how specific user needs might have informed its design. By considering these design choices, and attempting to match each teapot with a potential user, students can begin to see how taking a user-centered approach to designing products (both physical and digital) can make those products more useful and usable. To conclude the activity, students are asked to propose some changes to one of the teapots that would make it more useful or usable.
             Understanding Your User:
               key: Understanding Your User
               name: Understanding Your User
-              description_student: Using user profiles, the class explores how different users might react to a variety of products. Role playing as a different person, each member of the class will get to experience designs through someone else's eyes.
-              description_teacher: "Designers need to understand their users’ needs in order to create useful products.  This lesson encourages students to think about how to design for another person by role-playing as someone else using a user profile and reacting as that user to a series of products.  Each student is assigned a user profile describing a person, which they then use to choose appropriate products, critique product design, and suggest improvements to design.\r\n"
             User-Centered Design Micro Activity:
               key: User-Centered Design Micro Activity
               name: User-Centered Design Micro Activity
-              description_student: In small groups, the class uses the design process to come up with ideas for smart clothing. From brainstorming, to identifying users, to finally proposing a design, this is the first of several opportunities in this unit to practicing designing a solution for the needs of others.
-              description_teacher: This lesson guides students through an abbreviated version of the design process they will be seeing throughout this unit. Students first brainstorm a list of potential users of smart clothing. As a class, they then group these ideas into broad categories and each group will choose one category of user. Groups repeat this process to brainstorm needs or concerns of their user, eventually categorizing these needs and choosing one to focus on. Finally, students design a piece of smart clothing, using the specific needs and concerns they brainstormed to guide their decision making. At the end of the class students quickly share their decision-making process and get feedback on how well their product addresses the user need they selected.
             User Interfaces:
               key: User Interfaces
               name: User Interfaces
-              description_student: See how a paper prototype can be used to test and get feedback on software before writing any code. To help out a developer with their idea, the class tests and provides an app prototype made of paper.
-              description_teacher: Following the mini design project, students look towards the next phase of design - prototyping a product that attempts to address user needs. In teams, students examine a paper prototype for a chat app called "Txt Ur Grndkdz". Through using this paper prototype, students get a chance to see how a simple paper prototype can be used to quickly test ideas and assumptions before we ever get to the computer. After "using" the provided prototype students begin to identify ways to improve the next iteration.
             Feedback and Testing:
               key: Feedback and Testing
               name: Feedback and Testing
-              description_student: Users have been testing an app, and they have lots of feedback for the developer. The class needs to sort through all of this feedback, identify the common themes and needs, and start revising the prototype to make it better meet the users' needs.
-              description_teacher: In this lesson students use feedback from "users" of the paper-prototyped app from the previous lesson in order to develop improvements to the user interface of that paper prototype. The lesson begins with a reflection on the fact that designers need to translate human needs with technology into changes to the user interface or experience. Students are then given a collection of feedback and requests from users of the app from the previous lesson. In groups students categorize the feedback and identify ways the needs expressed in the feedback could be met by changes to the interface of the app. Then in groups students will implement some of these changes to meet one of the needs they identified.
             Identifying User Needs:
               key: Identifying User Needs
               name: Identifying User Needs
-              description_student: Up to this point the users that the class has considered have all been remote, and the only information from users has come through text or role playing. Now the class will rely on each other as potential users, and pairs will get to interview each other to identify needs that could be addressed by developing an app.
-              description_teacher: 'Up to this point students have focused on designing for users who are, to some degree, distanced from them. Whether through brainstorming, profiles, or text feedback, the connection to an end user has never been direct. This is distance is designed to help students get outside their own head when thinking about users, but in order to get information more directly from an actual user, students need to rely on their classmates. In this lesson students pair up to become users (and designers) for each other, allowing everyone to directly interview their end user and ask questions to better inform their design. Each student pair interviews each other, attempting to identify a specific need that could be addressed by an app. '
             Project - Paper Prototype:
               key: Project - Paper Prototype
               name: Project - Paper Prototype
-              description_student: Using the interview information from the previous lesson, the class comes up with app ideas to address the needs of their users. To express those ideas, and test out their effectiveness, each student creates and tests paper prototypes of their own.
-              description_teacher: Based on the peer interview from the previous lesson, each student comes up with an idea for an app that will address their user's problem. Students then get to create their own paper prototype of their app ideas by drawing "screens" on individual notecards. A project guide directs students through the process including building the app and testing it with their user to see if their assumptions about the user interfaces they created are accurate.
             Designing Apps for Good:
               key: Designing Apps for Good
               name: Designing Apps for Good
-              description_student: To kick off the app design project, the class organizes into teams and starts exploring app topics. Several example socially impactful apps serve as inspiration for the project.
-              description_teacher: To kick off the app design project that lasts through the end of the unit, students first explore a number of apps designed for social impact that have been created by other students. The class then reviews the Define, Prepare, Try, and Reflect steps of the Problem Solving process as they develop an idea for an app of their own with social impact. Finally, students will form project teams and lay out a contract for how the team will function throughout the development of their app.
             Market Research:
               key: Market Research
               name: Market Research
-              description_student: Dive into app development by exploring existing apps that may serve similar users. Each group identifies a handful of apps that address the same topic they are working on, using those apps to help refine the app idea they will pursue.
-              description_teacher: In this lesson students research apps similar to the one they intend on creating to better understand the needs of their users. Students work within their teams to search the Internet for other apps, then evaluate the ones they find interesting. By the end of the lesson, each team will have a clearer idea about the type of app they want to create and further refine who their target users are. Each team will maintain a list of citations for all the apps they examined for use in their final presentation.
             Paper Prototypes:
               key: Paper Prototypes
               name: Paper Prototypes
-              description_student: Paper prototypes allow developers to quickly test ideas before investing a lot of time writing code. In this lesson teams explore some example apps created in App Lab, using those apps to help inform the first paper prototypes of their apps.
-              description_teacher: "Before starting to design apps, we need to help students to better scope their expectations. Because students will eventually be prototyping these apps in App Lab, they will be in better shape if their ideas align with the kinds of apps that are easily prototyped in App Lab. Teams start this scoping by looking through several example apps designed to demonstrate apps that can be created with App Lab. Teams then can chose one (or more) of the apps as a basis for their own. From there, teams have some time to discuss the basic functionality of their app before using 3x5 index cards to develop paper prototypes.\r\n"
             Prototype Testing:
               key: Prototype Testing
               name: Prototype Testing
-              description_student: In this lesson teams test out their paper prototypes with other members of the class. With one student role playing the computer, one narrating, and the rest observing, teams will get immediate feedback on their app designs which will inform the next version of their app prototypes.
-              description_teacher: The primary purpose of developing paper prototypes is that they allow for quick testing and iteration before any code is written. This lesson is focused on giving teams a chance to test their prototypes before moving to App Lab. Teams develop a plan to test with users before running prototype tests with multiple other students in the class (and potentially outside the class). In order to test the prototype with the users, the students will have to assign roles in the testing (the “narrator”, the “computer” and the “observers”) as well as have some questions prepared for the user to answer after the test is complete.
             Digital Design:
               key: Digital Design
               name: Digital Design
-              description_student: Having developed, tested, and gathered feedback on a paper prototype, teams now move to App Lab to build the next iteration of their apps. Using the drag-and-drop Design Mode, each team member builds out at least one page of their team's app, responding to feedback that was received in the previous round of testing.
-              description_teacher: Having collaboratively developed a paper prototype for their apps, groups now divide and conquer to begin work on an interactive digital version based on the paper prototype. Using the drag-and-drop design mode of App Lab, students individually work through a progression of skill-building levels to learn how to build digital versions of a paper prototype. From there, each group member builds out at least one page of their app in App Lab, to be later combined into a single app.
             Linking Screens:
               key: Linking Screens
               name: Linking Screens
-              description_student: Building on the screens that the class designed in the previous lesson, teams combine screens into a single app. Simple code can then be added to make button clicks change to the appropriate screen.
-              description_teacher: In this lesson teams combine the screens that they designed in the previous lesson into a single app, which they can then link together using code. Students learn basic event driven programming by building up the model app that they started in the previous lesson. In addition to the screen that students designed yesterday, they'll learn how to create additional screens and even import screens made by others.
             Testing the App:
               key: Testing the App
               name: Testing the App
-              description_student: Teams run another round of user testing, this time with their interactive prototype. Feedback gathered from this round of testing will inform the final iteration of the app prototypes.
-              description_teacher: 'By the end of the previous lesson each team should have a minimum viable prototype of their app. The primary purpose of this lesson is to have the team actually test the app with other people, preferably from the target audience the app is intended for, or from different teams in the class while observers from the team will record the results on the worksheets they used in the planning phase. As with testing the paper prototypes, teams will start by planning for the specific scenarios before running and observing tests. '
             Improving and Iterating:
               key: Improving and Iterating
               name: Improving and Iterating
-              description_student: Using the feedback from the last round of testing, teams implement changes that address the needs of their users. Each team tracks and prioritizes the features they want to add and the bugs they need to fix.
-              description_teacher: Teams have at this point developed an app prototype that has gone through multiple iterations and rounds of user testing. With the information and guidance gained from the last round of user testing, each student has the opportunity to plan for and implement improvements to the team app. Depending on the time you have available, and student interest, you can run the cycle of testing and iteration as many times as you see fit.
             Project - App Presentation:
               key: Project - App Presentation
               name: Project - App Presentation
-              description_student: Each team prepares a presentation to "pitch" the app they've developed. This is the time to share struggles, triumphs, and plans for the future.
-              description_teacher: At this point teams have researched a topic of personal and social importance, developed and tested both a paper prototype and a digital prototype, and iterated on the initial app to incorporate new features and bug fixes. Now is the time for them to review what they have done and pull together a coherent presentation to demonstrate their process of creation. Using the provided presentation template, teams prepare to present about their process of app development, including the problem they set out to solve, the ways in which they've incorporated feedback from testing, and their plans for the future.
             Post-Project Test:
               key: Post-Project Test
               name: Post-Project Test
-              description_student: ''
-              description_teacher: ''
             CS Discoveries Post Course survey:
               key: CS Discoveries Post Course survey
               name: CS Discoveries Post Course survey
-              description_student: ''
-              description_teacher: ''
           lesson_groups:
             csd4_1:
               display_name: 'Chapter 1: User Centered Design'
@@ -18865,88 +18689,54 @@ en:
             Representation Matters:
               key: Representation Matters
               name: Representation Matters
-              description_student: This first lesson provides an overview of what data is and how it is used to solve problems.  Groups use a data set to make a series of meal recommendations for people with various criteria.   Afterwards, groups compare their responses and discuss how the different representations of the meal data affected how the students were able to solve the different problems.
-              description_teacher: In the first lesson of the data unit, students get an overview of what data is and how it is used to solve problems.  Students start off with a brief discussion to come to a common understanding of data.  They then split into groups and use a data set to make a series of meal recommendations for people with various criteria.  Each group has the choices of meal represented in a different way (pictures, recipes, menu, nutrition) that gives an advantage for one of the recommendations.  Afterwards, groups compare their responses and discuss how the different representations of the meal data affected how the students were able to solve the different problems.
             Patterns and Representation:
               key: Patterns and Representation
               name: Patterns and Representation
-              description_student: This lesson looks closer at what is needed to create a system of representation.  Groups create systems that can represent any letter in the alphabet using only a single stack of cards, then create messages with their systems and exchange with other groups to ensure the system worked as intended.   The class discusses commonalities between working systems while recognizing that there are many possible working solutions.
-              description_teacher: In this lesson students create their own system for representing information. They begin by brainstorming all the different systems they already use to represent yes-no responses. They then work in small groups to create a system that can represent any letter in the alphabet using only a single stack of cards. The cards used have one of 6 different possible drawings (6 animals, 6 colors, etc.) and so to represent the entire alphabet students will need to use patterns of multiple cards to represent each letter. Students create messages with their systems and exchange with other groups to ensure the system worked as intended. In the wrap-up discussion the class  reviews any pros and cons of the different systems. They discuss commonalities between working systems and recognize that there are many possible solutions to this problem and what's important is that everyone use the same arbitrary system to communicate.
             ASCII and Binary Representation:
               key: ASCII and Binary Representation
               name: ASCII and Binary Representation
-              description_student: This lesson introduces a formal binary system for encoding information, the ASCII system for representing letters and other characters. At the beginning of the lesson the teacher introduces the fact that computers must represent information using either "on" or "off". The class is then introduced to the ASCII system for representing text using binary symbols and practices using this system before encoding their own messages using ASCII.
-              description_teacher: In this lesson students learn to use their first binary system for encoding information, the ASCII system for representing letters and other characters. At the beginning of the lesson the teacher introduces the fact that computers must represent information using either "on" or "off". Then students are introduced to the ASCII system for representing text using binary symbols. Students practice using this system before encoding their own message using ASCII. At the end of the lesson a debrief conversation helps synthesize the key learning objectives of the activity.
             Representing Images:
               key: Representing Images
               name: Representing Images
-              description_student: This lesson continues the study of binary representation systems, this time with images. The class is introduced to the concept of splitting images into squares or "pixels" which can then be turned on or off individually to make the entire image. After doing a short set of challenges using the Pixelation Widget, the class makes connections between the system for representing images and the system for representing text they learned in the previous lesson.
-              description_teacher: In this lesson students learn how computers represent images. To begin the lesson they consider the challenge of turning all the complexity of vision into a binary pattern. Through a series of images showing how this transformation is made students are introduced to the concept of splitting images into squares or "pixels" which can then be turned on or off individually to make the entire image. Students then do a short set of challenges using the Pixelation Widget in order to draw black and white images. Puzzles are designed to call out some of the challenges of representing images in this way. In the wrap up students make connections between the system for representing images and the system for representing text they learned in the previous lesson.
             Representing Numbers:
               key: Representing Numbers
               name: Representing Numbers
-              description_student: This lesson introduces the binary number system.  With a set of cards that represent the place values in a binary (base-2) number system, the class turns bits "on" or "off" by turning cards face up and face down, then observes the numbers that result from these different patterns.  Eventually, the pattern is extended to a generic 4-bit system.
-              description_teacher: In this lesson, students learn about the binary number system.  With a set of cards that represent the place values in a binary (base-2) number system by a collection of dots, students turn bits "on" or "off" by turning cards face up and face down, then observe the numbers that result from these different patterns.  Eventually, students extend the pattern to a generic 4-bit system.
             Keeping Data Secret:
               key: Keeping Data Secret
               name: Keeping Data Secret
-              description_student: Students have a discussion on the different levels of security they would like for personal data.  Once the class has developed an understanding of the importance of privacy, they learn about the process of encrypting information by enciphering a note for a partner and deciphering the partner's note.  The class concludes with a discussion about the importance of both physical and digital security.
-              description_teacher: Students have a discussion on the different levels of security they would like for personal data.  Once the class has developed an understanding of the importance of privacy, they learn about the process of encrypting information by enciphering a note for a partner and deciphering the partner's note.  The class concludes with a discussion about the importance of both physical and digital security.
             Combining Representations:
               key: Combining Representations
               name: Combining Representations
-              description_student: This lesson combines all three types of binary representation systems (ASCII characters, binary number, and images) to allow for the encode of more complex types information in a record.  After seeing a series of bits and being asked to decode them, the class is introduced to the idea that  understanding binary information requires understanding both the system that is being used and the meaning of the information encoded.
-              description_teacher: In this lesson, students use all three types of binary representation systems (ASCII characters, binary number, and images) to decode information in a record.  After seeing a series of bits and being asked to decode them, students are introduced to the idea that in order to understand binary information, they must understand both the system that is being used and the meaning of the information encoded.  They then decode a record representing a pet based on a given structure.
             Project - Create a Representation:
               key: Project - Create a Representation
               name: Project - Create a Representation
-              description_student: The class designs structure to represent their perfect day using the binary representation systems they've learned in this chapter. After deciding which pieces of information the record should capture, the class will decide how a punch card of bytes of information will be interpreted to represent those pieces of information. Afterwards, everyone will use the ASCII, binary number, and image formats they have learned to represent their perfect days try to decipher what a partner's perfect day is like.
-              description_teacher: In this lesson students design a structure to represent their perfect day using the binary representation systems they've learned in this chapter. Students will first write a short description of their perfect day and then review with a partner to identify the key pieces of information they think a computer could capture. As a class students will decide how a punch card of bytes of information will be interpreted to represent those pieces of information. Students will then use the ASCII, binary number, and image formats they have learned to represent their perfect days. Students then trade punch cards and try to decipher what the other student's perfect day is like. The lesson ends with a reflection.
             Problem Solving and Data:
               key: Problem Solving and Data
               name: Problem Solving and Data
-              description_student: This lesson covers how the problem solving process can be tailored to deal with data problems, in particular.  The class is tasked with deciding what a city most needs to spend resources on.  They must find and use data from the Internet to support their decision.
-              description_teacher: 'In this lesson, students use the problem solving process from earlier in the course to solve a data problem.  After reviewing the process, the class is presented with a decision: whether a city should build a library, pet shelter, or fire department.  Students work in teams to collect information on the Internet to help them decide what should be built, then use this information build an argument that will convince the city council of their choice.  They then map what they have done to the problem solving process that they have been using throughout the course, comparing the general problem solving process to its specific application to data problems.'
             Problem Solving with Big Data:
               key: Problem Solving with Big Data
               name: Problem Solving with Big Data
-              description_student: This lesson covers how data is collected and used by a organizations to solve problems in the real world. The class looks at three scenarios that could be solved using data and brainstorms the types of data they would want to solve them and how they could collect the data.  Each scenario also includes a video about a real-world service that has solved a similar problem with data.
-              description_teacher: In this lesson, students look at how data is collected and used by organizations to solve problems in the real world. The lesson begins with a quick review of the data problem solving process they  explored in the last lesson. Then students are presented three scenarios that could be solved using data and brainstorm the types of data they would want to solve them and how they could collect the data. Each problem is designed to reflect a real-world service that exists. After brainstorming, students watch a video about a real-world service and record notes about what data is collected by the real-world service and how it is used. At the end of the lesson, students record whether data was provided actively by a user, was recorded passively, or is collected by sensors.
             Structuring Data:
               key: Structuring Data
               name: Structuring Data
-              description_student: This lesson goes further into the interpretation of data, including cleaning and visualizing raw data sets.  The class first looks at the how presenting data in different ways can help people to understand it better.  After seeing how cleaning and visualization can help people make better decisions, the class looks at what parts of this process can be automated, and what need a human.
-              description_teacher: In this lesson, students go further into the collection and interpretation of data, including cleaning and visualizing data.  Students first look at the how presenting data in different ways can help people to understand it better, and they then create visualizations of their own data. Using a the results of a preferred pizza topping survey, students must decide what to do with data that does not easily fit into the visualization scheme that they have chosen.  Finally, students look at which parts of this process can be automated by a computer and which need a human to make decisions.
             Making Decisions with Data:
               key: Making Decisions with Data
               name: Making Decisions with Data
-              description_student: This lesson gives the class a chance to practice the data problem solving process introduced in the last lesson.  Not all questions have right answers and in some cases the class can and should decide that they should collect more data. The lesson concludes with a discussion of how different people could draw different conclusions from the same data, or how collecting different data might have affected the decisions they made.
-              description_teacher: In this lesson students get practice making decisions with data based on some problems designed to be familiar to middle school students. Students work in groups discussing how they would use the data presented to make a decision before the class discusses their final choices. Not all questions have right answers and in some cases students can and should decide that they should collect more data. The lesson concludes with a discussion of how different people could draw different conclusions from the same data, or how collecting different data might have affected the decisions they made.
             Interpreting Data:
               key: Interpreting Data
               name: Interpreting Data
-              description_student: Students begin the lesson by looking at a cake preference survey that allows respondents to specify both a cake and an icing flavor.  They discuss how knowing the relationship between cake and icing preference helps them better decide which combination to recommend.  They are then introduced to cross tabulation, which allows them to graph relationships to different preferences.  They use this technique to find relationships in a preference survey, then brainstorm the different types of problems that this process could help solve.
-              description_teacher: Students begin the lesson by looking at a cake preference survey that allows respondents to specify both a cake and an icing flavor.  They discuss how knowing the relationship between cake and icing preference helps them better decide which combination to recommend.  They are then introduced to cross tabulation, which allows them to graph relationships to different preferences.  They use this technique to find relationships in a preference survey, then brainstorm the different types of problems that this process could help solve.
             Automating Data Decisions:
               key: Automating Data Decisions
               name: Automating Data Decisions
-              description_student: In this lesson students look at a simple example of how a computer could be used to complete the decision making step of the data problem solving process. Students are given the task of creating an algorithm that could suggest a vacation spot.  Students then create rules, or an algorithm, that a computer could use to make this decision automatically. Students share their rules and what choices their rules would make with the class data. They then use their rules on data from their classmates to test whether their rules would make the same decision that  a person would. The lesson concludes with a discussion about the benefits and drawbacks of using computers to automate the data problem solving process.
-              description_teacher: In this lesson students look at a simple example of how a computer could be used to complete the decision making step of the data problem solving process. Students are given the task of creating an algorithm that could suggest a vacation spot.  Students then create rules, or an algorithm, that a computer could use to make this decision automatically. Students share their rules and what choices their rules would make with the class data. They then use their rules on data from their classmates to test whether their rules would make the same decision that  a person would. The lesson concludes with a discussion about the benefits and drawbacks of using computers to automate the data problem solving process.
             Project - Make a Recommendation:
               key: Project - Make a Recommendation
               name: Project - Make a Recommendation
-              description_student: ''
-              description_teacher: ''
             Post-Project Test:
               key: Post-Project Test
               name: Post-Project Test
-              description_student: ''
-              description_teacher: ''
             CS Discoveries Post Course survey:
               key: CS Discoveries Post Course survey
               name: CS Discoveries Post Course survey
-              description_student: ''
-              description_teacher: ''
           lesson_groups:
             csd5_1:
               display_name: 'Chapter 1: Representing Information'
@@ -18964,93 +18754,57 @@ en:
             Innovations in Computing:
               key: Innovations in Computing
               name: Innovations in Computing
-              description_student: ''
-              description_teacher: ''
             Designing Screens with Code:
               key: Designing Screens with Code
               name: Designing Screens with Code
-              description_student: ''
-              description_teacher: ''
             The Circuit Playground:
               key: The Circuit Playground
               name: The Circuit Playground
-              description_student: ''
-              description_teacher: ''
             Input Unplugged:
               key: Input Unplugged
               name: Input Unplugged
-              description_student: ''
-              description_teacher: ''
             Board Events:
               key: Board Events
               name: Board Events
-              description_student: ''
-              description_teacher: ''
             Getting Properties:
               key: Getting Properties
               name: Getting Properties
-              description_student: ''
-              description_teacher: ''
             Analog Input:
               key: Analog Input
               name: Analog Input
-              description_student: ''
-              description_teacher: ''
             The Program Design Process:
               key: The Program Design Process
               name: The Program Design Process
-              description_student: ''
-              description_teacher: ''
             'Project: Make a Game':
               key: 'Project: Make a Game'
               name: 'Project: Make a Game'
-              description_student: ''
-              description_teacher: ''
             Arrays and Color LEDs:
               key: Arrays and Color LEDs
               name: Arrays and Color LEDs
-              description_student: ''
-              description_teacher: ''
             Making Music:
               key: Making Music
               name: Making Music
-              description_student: ''
-              description_teacher: ''
             Arrays and For Loops:
               key: Arrays and For Loops
               name: Arrays and For Loops
-              description_student: ''
-              description_teacher: ''
             Accelerometer:
               key: Accelerometer
               name: Accelerometer
-              description_student: ''
-              description_teacher: ''
             Functions with Parameters:
               key: Functions with Parameters
               name: Functions with Parameters
-              description_student: ''
-              description_teacher: ''
             Circuits and Physical Prototypes:
               key: Circuits and Physical Prototypes
               name: Circuits and Physical Prototypes
-              description_student: ''
-              description_teacher: ''
             'Project: Prototype an Innovation':
               key: 'Project: Prototype an Innovation'
               name: 'Project: Prototype an Innovation'
-              description_student: ''
-              description_teacher: ''
             Post-Project Test:
               key: Post-Project Test
               name: Post-Project Test
-              description_student: ''
-              description_teacher: ''
             CS Discoveries Post Course survey:
               key: CS Discoveries Post Course survey
               name: CS Discoveries Post Course survey
-              description_student: ''
-              description_teacher: ''
           lesson_groups:
             csd6_1:
               display_name: 'Chapter 1: Programming with Hardware'
@@ -19068,78 +18822,48 @@ en:
             CS Principles Pre-survey:
               key: CS Principles Pre-survey
               name: CS Principles Pre-survey
-              description_student: ''
-              description_teacher: ''
             Welcome to CSP:
               key: Welcome to CSP
               name: Welcome to CSP
-              description_student: ''
-              description_teacher: ''
             Representing Information:
               key: Representing Information
               name: Representing Information
-              description_student: ''
-              description_teacher: ''
             Circle Square Patterns:
               key: Circle Square Patterns
               name: Circle Square Patterns
-              description_student: ''
-              description_teacher: ''
             Binary Numbers:
               key: Binary Numbers
               name: Binary Numbers
-              description_student: ''
-              description_teacher: ''
             Overflow and Rounding:
               key: Overflow and Rounding
               name: Overflow and Rounding
-              description_student: ''
-              description_teacher: ''
             Representing Text:
               key: Representing Text
               name: Representing Text
-              description_student: ''
-              description_teacher: ''
             Black and White Images:
               key: Black and White Images
               name: Black and White Images
-              description_student: ''
-              description_teacher: ''
             Color Images:
               key: Color Images
               name: Color Images
-              description_student: ''
-              description_teacher: ''
             Lossless Compression:
               key: Lossless Compression
               name: Lossless Compression
-              description_student: ''
-              description_teacher: ''
             Lossy Compression:
               key: Lossy Compression
               name: Lossy Compression
-              description_student: ''
-              description_teacher: ''
             Intellectual Property:
               key: Intellectual Property
               name: Intellectual Property
-              description_student: ''
-              description_teacher: ''
             Project - Digital Information Dilemmas Part 1:
               key: Project - Digital Information Dilemmas Part 1
               name: Project - Digital Information Dilemmas Part 1
-              description_student: ''
-              description_teacher: ''
             Project - Digital Information Dilemmas Part 2:
               key: Project - Digital Information Dilemmas Part 2
               name: Project - Digital Information Dilemmas Part 2
-              description_student: ''
-              description_teacher: ''
             'Lesson 14: Assessment Day':
               key: 'Lesson 14: Assessment Day'
               name: 'Lesson 14: Assessment Day'
-              description_student: ''
-              description_teacher: ''
           lesson_groups:
             cspSurvey:
               display_name: Survey
@@ -19155,48 +18879,30 @@ en:
             Welcome to the Internet:
               key: Welcome to the Internet
               name: Welcome to the Internet
-              description_student: ''
-              description_teacher: ''
             Building a Network:
               key: Building a Network
               name: Building a Network
-              description_student: ''
-              description_teacher: ''
             The Need for Addressing:
               key: The Need for Addressing
               name: The Need for Addressing
-              description_student: ''
-              description_teacher: ''
             Routers and Redundancy:
               key: Routers and Redundancy
               name: Routers and Redundancy
-              description_student: ''
-              description_teacher: ''
             Packets:
               key: Packets
               name: Packets
-              description_student: ''
-              description_teacher: ''
             DNS and HTTP:
               key: DNS and HTTP
               name: DNS and HTTP
-              description_student: ''
-              description_teacher: ''
             Project - Internet Dilemmas Part 1:
               key: Project - Internet Dilemmas Part 1
               name: Project - Internet Dilemmas Part 1
-              description_student: ''
-              description_teacher: ''
             Project - Internet Dilemmas Part 2:
               key: Project - Internet Dilemmas Part 2
               name: Project - Internet Dilemmas Part 2
-              description_student: ''
-              description_teacher: ''
             'Lesson 9: Assessment Day':
               key: 'Lesson 9: Assessment Day'
               name: 'Lesson 9: Assessment Day'
-              description_student: ''
-              description_teacher: ''
           lesson_groups:
             csp_unit2_2020:
               display_name: 'Unit 2: The Internet'
@@ -19210,58 +18916,36 @@ en:
             Introduction to Apps:
               key: Introduction to Apps
               name: Introduction to Apps
-              description_student: ''
-              description_teacher: ''
             Introduction to Design Mode:
               key: Introduction to Design Mode
               name: Introduction to Design Mode
-              description_student: ''
-              description_teacher: ''
             Project - Designing an App Part 1:
               key: Project - Designing an App Part 1
               name: Project - Designing an App Part 1
-              description_student: ''
-              description_teacher: ''
             Project - Designing an App Part 2:
               key: Project - Designing an App Part 2
               name: Project - Designing an App Part 2
-              description_student: ''
-              description_teacher: ''
             The Need for Programming Languages:
               key: The Need for Programming Languages
               name: The Need for Programming Languages
-              description_student: ''
-              description_teacher: ''
             Intro to Programming:
               key: Intro to Programming
               name: Intro to Programming
-              description_student: ''
-              description_teacher: ''
             Debugging:
               key: Debugging
               name: Debugging
-              description_student: ''
-              description_teacher: ''
             Project - Designing an App Part 3:
               key: Project - Designing an App Part 3
               name: Project - Designing an App Part 3
-              description_student: ''
-              description_teacher: ''
             Project - Designing an App Part 4:
               key: Project - Designing an App Part 4
               name: Project - Designing an App Part 4
-              description_student: ''
-              description_teacher: ''
             Project - Designing an App Part 5:
               key: Project - Designing an App Part 5
               name: Project - Designing an App Part 5
-              description_student: ''
-              description_teacher: ''
             'Lesson 11: Assessment Day':
               key: 'Lesson 11: Assessment Day'
               name: 'Lesson 11: Assessment Day'
-              description_student: ''
-              description_teacher: ''
           lesson_groups:
             csp_unit3_2020:
               display_name: 'Unit 3: Intro to App Design'
@@ -19275,78 +18959,48 @@ en:
             Variables Explore:
               key: Variables Explore
               name: Variables Explore
-              description_student: ''
-              description_teacher: ''
             Variables Investigate:
               key: Variables Investigate
               name: Variables Investigate
-              description_student: ''
-              description_teacher: ''
             Variables Practice:
               key: Variables Practice
               name: Variables Practice
-              description_student: ''
-              description_teacher: ''
             Variables Make:
               key: Variables Make
               name: Variables Make
-              description_student: ''
-              description_teacher: ''
             Conditionals Explore:
               key: Conditionals Explore
               name: Conditionals Explore
-              description_student: ''
-              description_teacher: ''
             Conditionals Investigate:
               key: Conditionals Investigate
               name: Conditionals Investigate
-              description_student: ''
-              description_teacher: ''
             Conditionals Practice:
               key: Conditionals Practice
               name: Conditionals Practice
-              description_student: ''
-              description_teacher: ''
             Conditional Make:
               key: Conditional Make
               name: Conditional Make
-              description_student: ''
-              description_teacher: ''
             Functions Explore / Investigate:
               key: Functions Explore / Investigate
               name: Functions Explore / Investigate
-              description_student: ''
-              description_teacher: ''
             Functions Practice:
               key: Functions Practice
               name: Functions Practice
-              description_student: ''
-              description_teacher: ''
             Functions Make:
               key: Functions Make
               name: Functions Make
-              description_student: ''
-              description_teacher: ''
             Project - Decision Maker App Part 1:
               key: Project - Decision Maker App Part 1
               name: Project - Decision Maker App Part 1
-              description_student: ''
-              description_teacher: ''
             Project - Decision Maker App Part 2:
               key: Project - Decision Maker App Part 2
               name: Project - Decision Maker App Part 2
-              description_student: ''
-              description_teacher: ''
             Project - Decision Maker App Part 3:
               key: Project - Decision Maker App Part 3
               name: Project - Decision Maker App Part 3
-              description_student: ''
-              description_teacher: ''
             'Lesson 15: Assessment Day':
               key: 'Lesson 15: Assessment Day'
               name: 'Lesson 15: Assessment Day'
-              description_student: ''
-              description_teacher: ''
           lesson_groups:
             csp_variables:
               display_name: Variables
@@ -19366,93 +19020,57 @@ en:
             Lists Explore:
               key: Lists Explore
               name: Lists Explore
-              description_student: ''
-              description_teacher: ''
             Lists Investigate:
               key: Lists Investigate
               name: Lists Investigate
-              description_student: ''
-              description_teacher: ''
             Lists Practice:
               key: Lists Practice
               name: Lists Practice
-              description_student: ''
-              description_teacher: ''
             Lists Make:
               key: Lists Make
               name: Lists Make
-              description_student: ''
-              description_teacher: ''
             Loops Explore:
               key: Loops Explore
               name: Loops Explore
-              description_student: ''
-              description_teacher: ''
             Loops Investigate:
               key: Loops Investigate
               name: Loops Investigate
-              description_student: ''
-              description_teacher: ''
             Loops Practice:
               key: Loops Practice
               name: Loops Practice
-              description_student: ''
-              description_teacher: ''
             Loops Make:
               key: Loops Make
               name: Loops Make
-              description_student: ''
-              description_teacher: ''
             Traversals Explore:
               key: Traversals Explore
               name: Traversals Explore
-              description_student: ''
-              description_teacher: ''
             Traversals Investigate:
               key: Traversals Investigate
               name: Traversals Investigate
-              description_student: ''
-              description_teacher: ''
             Traversals Practice:
               key: Traversals Practice
               name: Traversals Practice
-              description_student: ''
-              description_teacher: ''
             Traversals Make:
               key: Traversals Make
               name: Traversals Make
-              description_student: ''
-              description_teacher: ''
             Semester Hackathon Part 1:
               key: Semester Hackathon Part 1
               name: Semester Hackathon Part 1
-              description_student: ''
-              description_teacher: ''
             Semester Hackathon Part 2:
               key: Semester Hackathon Part 2
               name: Semester Hackathon Part 2
-              description_student: ''
-              description_teacher: ''
             Semester Hackathon Part 3:
               key: Semester Hackathon Part 3
               name: Semester Hackathon Part 3
-              description_student: ''
-              description_teacher: ''
             Semester Hackathon Part 4:
               key: Semester Hackathon Part 4
               name: Semester Hackathon Part 4
-              description_student: ''
-              description_teacher: ''
             Semester Hackathon Part 5:
               key: Semester Hackathon Part 5
               name: Semester Hackathon Part 5
-              description_student: ''
-              description_teacher: ''
             'Lesson 18: Assessment Day':
               key: 'Lesson 18: Assessment Day'
               name: 'Lesson 18: Assessment Day'
-              description_student: ''
-              description_teacher: ''
           lesson_groups:
             csp_lists:
               display_name: Lists
@@ -19472,33 +19090,21 @@ en:
             Algorithms Solve Problems:
               key: Algorithms Solve Problems
               name: Algorithms Solve Problems
-              description_student: ''
-              description_teacher: ''
             Algorithm Efficiency:
               key: Algorithm Efficiency
               name: Algorithm Efficiency
-              description_student: ''
-              description_teacher: ''
             Unreasonable Time:
               key: Unreasonable Time
               name: Unreasonable Time
-              description_student: ''
-              description_teacher: ''
             The Limits of Algorithms:
               key: The Limits of Algorithms
               name: The Limits of Algorithms
-              description_student: ''
-              description_teacher: ''
             Parallel and Distributed Algorithms:
               key: Parallel and Distributed Algorithms
               name: Parallel and Distributed Algorithms
-              description_student: ''
-              description_teacher: ''
             'Lesson 6: Assessment Day':
               key: 'Lesson 6: Assessment Day'
               name: 'Lesson 6: Assessment Day'
-              description_student: ''
-              description_teacher: ''
           lesson_groups:
             csp_unit6_2020:
               display_name: 'Unit 6: Algorithms'
@@ -19512,58 +19118,36 @@ en:
             Parameters and Return Explore:
               key: Parameters and Return Explore
               name: Parameters and Return Explore
-              description_student: ''
-              description_teacher: ''
             Parameters and Return Investigate:
               key: Parameters and Return Investigate
               name: Parameters and Return Investigate
-              description_student: ''
-              description_teacher: ''
             Parameters and Return Practice:
               key: Parameters and Return Practice
               name: Parameters and Return Practice
-              description_student: ''
-              description_teacher: ''
             Parameters and Return Make:
               key: Parameters and Return Make
               name: Parameters and Return Make
-              description_student: ''
-              description_teacher: ''
             Libraries Explore:
               key: Libraries Explore
               name: Libraries Explore
-              description_student: ''
-              description_teacher: ''
             Libraries Investigate:
               key: Libraries Investigate
               name: Libraries Investigate
-              description_student: ''
-              description_teacher: ''
             Libraries Practice:
               key: Libraries Practice
               name: Libraries Practice
-              description_student: ''
-              description_teacher: ''
             Project - Make a Library Part 1:
               key: Project - Make a Library Part 1
               name: Project - Make a Library Part 1
-              description_student: ''
-              description_teacher: ''
             Project - Make a Library Part 2:
               key: Project - Make a Library Part 2
               name: Project - Make a Library Part 2
-              description_student: ''
-              description_teacher: ''
             Project - Make a Library Part 3:
               key: Project - Make a Library Part 3
               name: Project - Make a Library Part 3
-              description_student: ''
-              description_teacher: ''
             'Lesson 11: Assessment Day':
               key: 'Lesson 11: Assessment Day'
               name: 'Lesson 11: Assessment Day'
-              description_student: ''
-              description_teacher: ''
           lesson_groups:
             csp_parameters_return_values:
               display_name: Parameters and Return Values
@@ -19579,18 +19163,12 @@ en:
             Create PT - Review the Task:
               key: Create PT - Review the Task
               name: Create PT - Review the Task
-              description_student: ''
-              description_teacher: ''
             Create PT - Make a Plan:
               key: Create PT - Make a Plan
               name: Create PT - Make a Plan
-              description_student: ''
-              description_teacher: ''
             Create PT - Complete the Task:
               key: Create PT - Complete the Task
               name: Create PT - Complete the Task
-              description_student: ''
-              description_teacher: ''
           lesson_groups: {}
           name: csp8-2021
         csp9-2021:
@@ -19602,48 +19180,30 @@ en:
             Learning From Data:
               key: Learning From Data
               name: Learning From Data
-              description_student: ''
-              description_teacher: ''
             Exploring One Column:
               key: Exploring One Column
               name: Exploring One Column
-              description_student: ''
-              description_teacher: ''
             Filtering and Cleaning Data:
               key: Filtering and Cleaning Data
               name: Filtering and Cleaning Data
-              description_student: ''
-              description_teacher: ''
             Exploring Two Columns:
               key: Exploring Two Columns
               name: Exploring Two Columns
-              description_student: ''
-              description_teacher: ''
             Big Data, Crowdsourcing, and Machine Learning:
               key: Big Data, Crowdsourcing, and Machine Learning
               name: Big Data, Crowdsourcing, and Machine Learning
-              description_student: ''
-              description_teacher: ''
             Machine Learning and Bias:
               key: Machine Learning and Bias
               name: Machine Learning and Bias
-              description_student: ''
-              description_teacher: ''
             Project - Tell a Data Story - Part 1:
               key: Project - Tell a Data Story - Part 1
               name: Project - Tell a Data Story - Part 1
-              description_student: ''
-              description_teacher: ''
             Project - Tell a Data Story - Part 2:
               key: Project - Tell a Data Story - Part 2
               name: Project - Tell a Data Story - Part 2
-              description_student: ''
-              description_teacher: ''
             'Lesson 9: Assessment Day':
               key: 'Lesson 9: Assessment Day'
               name: 'Lesson 9: Assessment Day'
-              description_student: ''
-              description_teacher: ''
           lesson_groups:
             csp_unit9_2020:
               display_name: 'Unit 9: Data'
@@ -19657,73 +19217,45 @@ en:
             Project - Innovation Simulation Part 1:
               key: Project - Innovation Simulation Part 1
               name: Project - Innovation Simulation Part 1
-              description_student: ''
-              description_teacher: ''
             Project - Innovation Simulation Part 2:
               key: Project - Innovation Simulation Part 2
               name: Project - Innovation Simulation Part 2
-              description_student: ''
-              description_teacher: ''
             Data Policies and Privacy:
               key: Data Policies and Privacy
               name: Data Policies and Privacy
-              description_student: ''
-              description_teacher: ''
             The Value of Privacy:
               key: The Value of Privacy
               name: The Value of Privacy
-              description_student: ''
-              description_teacher: ''
             Project - Innovation Simulation Part 3:
               key: Project - Innovation Simulation Part 3
               name: Project - Innovation Simulation Part 3
-              description_student: ''
-              description_teacher: ''
             Security Risks Part 1:
               key: Security Risks Part 1
               name: Security Risks Part 1
-              description_student: ''
-              description_teacher: ''
             Security Risks Part 2:
               key: Security Risks Part 2
               name: Security Risks Part 2
-              description_student: ''
-              description_teacher: ''
             'Project: Innovation Simulation Part 4':
               key: 'Project: Innovation Simulation Part 4'
               name: 'Project: Innovation Simulation Part 4'
-              description_student: ''
-              description_teacher: ''
             Protecting Data Part 1:
               key: Protecting Data Part 1
               name: Protecting Data Part 1
-              description_student: ''
-              description_teacher: ''
             Protecting Data Part 2:
               key: Protecting Data Part 2
               name: Protecting Data Part 2
-              description_student: ''
-              description_teacher: ''
             'Project: Innovation Simulation Part 5':
               key: 'Project: Innovation Simulation Part 5'
               name: 'Project: Innovation Simulation Part 5'
-              description_student: ''
-              description_teacher: ''
             'Project: Innovation Simulation Part 6':
               key: 'Project: Innovation Simulation Part 6'
               name: 'Project: Innovation Simulation Part 6'
-              description_student: ''
-              description_teacher: ''
             'Project: Innovation Simulation Part 7':
               key: 'Project: Innovation Simulation Part 7'
               name: 'Project: Innovation Simulation Part 7'
-              description_student: ''
-              description_teacher: ''
             'Lesson 14: Unit Assessment Day':
               key: 'Lesson 14: Unit Assessment Day'
               name: 'Lesson 14: Unit Assessment Day'
-              description_student: ''
-              description_teacher: ''
           lesson_groups:
             csp_unit10_2020:
               display_name: 'Unit 10: Cybersecurity and Global Impacts'
@@ -19737,68 +19269,39 @@ en:
             Safety in My Online Neighborhood:
               key: Safety in My Online Neighborhood
               name: Safety in My Online Neighborhood
-              description_student: Learn how to go places safely online.
-              description_teacher: |-
-                ![](https://curriculum.code.org/media/uploads/CommonSenseEducationShort400px.png){: style="padding:10px 0"}
-
-                This lesson was originally created by [Common Sense Education](https://www.commonsense.org/education/digital-citizenship/curriculum).
-
-                The power of the internet allows students to experience and visit places they might not be able to see in person. But, just like traveling in the real world, it's important to be safe when traveling online. On this virtual field trip, kids can practice staying safe on online adventures.
             Learn to Drag and Drop:
               key: Learn to Drag and Drop
               name: Learn to Drag and Drop
-              description_student: Click and drag to finish the puzzles.
-              description_teacher: This lesson will give students an idea of what to expect when they head to the computer lab. It begins with a brief discussion introducing them to computer lab manners, then they will progress into using a computer to complete online puzzles.
             'Programming: Happy Maps':
               key: 'Programming: Happy Maps'
               name: Happy Maps
-              description_student: Write instructions to get the Flurb to the fruit.
-              description_teacher: 'This unplugged lesson brings together teams with a simple task: get the "flurb" to the fruit. Students will practice writing precise instructions as they work to translate instructions into the symbols provided. If problems arise in the code, students should also work together to recognize bugs and build solutions.'
             Sequencing with Scrat:
               key: Sequencing with Scrat
               name: Sequencing with Scrat
-              description_student: Program Scrat to reach the acorn.
-              description_teacher: Using Scrat from the Ice Age franchise, students will develop sequential algorithms to move a squirrel character from one side of a maze to the acorn at the other side. To do this they will stack code blocks together in a linear sequence.
             Programming in Ice Age:
               key: Programming in Ice Age
               name: Programming with Scrat
-              description_student: Write programs to help Scrat reach the acorn.
-              description_teacher: Using characters from the Ice Age, students will develop sequential algorithms to move Scrat from one side of a maze to the acorn at the other side. To do this they will stack code blocks together in a linear sequence, making them move straight, turn left, or turn right.
             Programming with Rey and BB-8:
               key: Programming with Rey and BB-8
               name: Programming with Rey and BB-8
-              description_student: Help BB-8 collect the scrap metal.
-              description_teacher: In this lesson, students will use their newfound programming skills in more complicated ways to navigate a tricky course with BB-8.
             'Loops: Happy Loops':
               key: 'Loops: Happy Loops'
               name: Happy Loops
-              description_student: Help the Flurb solve bigger problems using loops.
-              description_teacher: This activity revisits Happy Maps. This time, student will be solving bigger, longer puzzles with their code, leading them to see utility in structures that let them write longer code in an easier way.
             Loops in Ice Age:
               key: Loops in Ice Age
               name: Loops with Scrat
-              description_student: Help Scrat cover more ground using loops.
-              description_teacher: Building on the concept of repeating instructions from "Happy Loops," this stage will have students using loops to get to the acorn more efficiently on Code.org.
             Loops in Collector:
               key: Loops in Collector
               name: Loops with Laurel
-              description_student: Help Laurel the adventurer collect the treasure underground.
-              description_teacher: In this lesson, students continue learning the concept of loops. In the previous lesson, students were introduced to loops by moving through a maze and picking corn. Here, loops are used to collect treasure in open cave spaces.
             Ocean Scene with Loops:
               key: Ocean Scene with Loops
               name: Ocean Scene with Loops
-              description_student: Use loops and patterns to finish the images.
-              description_teacher: Returning to loops, students learn to draw images by looping simple sequences of instructions. In the previous plugged lesson, loops were used to traverse a maze and collect treasure. Here, loops are creating patterns. At the end of this stage, students will be given the opportunity to create their own images using loops.
             'Events: The Big Event':
               key: 'Events: The Big Event'
               name: The Big Event Jr.
-              description_student: Move and shout when your teachers presses buttons on a giant remote.
-              description_teacher: Events are a great way to add variety to a pre-written algorithm. Sometimes you want your program to be able to respond to the user exactly when the user wants it to. That is what events are for.
             Events in Play Lab:
               key: Events in Play Lab
               name: On the Move with Events
-              description_student: Create your own game or story.
-              description_teacher: In this online activity, students will have the opportunity to learn how to use events in Play Lab and to apply all of the coding skills they've learned to create an animated game. It's time to get creative and make a story in the Play Lab!
           lesson_groups:
             csf_digcit:
               display_name: Digital Citizenship
@@ -19818,68 +19321,39 @@ en:
             Digital Trails:
               key: Digital Trails
               name: Digital Trails
-              description_student: 'Learn about your digital footprint and how to stay safe when visiting websites. '
-              description_teacher: |-
-                ![](https://curriculum.code.org/media/uploads/CommonSenseEducationShort400px.png){: style="padding:10px 0"}
-
-                This lesson was originally created by [Common Sense Education](https://www.commonsense.org/education/digital-citizenship/curriculum).
-
-                Does what you do online always stay online? Students learn that the information they share online leaves a digital footprint or "trail." Depending on how they manage it, this trail can be big or small, and harmful or helpful. Students compare different trails and think critically about what kinds of information they want to leave behind.
             Move It, Move It:
               key: Move It, Move It
               name: Move It, Move It
-              description_student: Program your classmates to step carefully from place to place.
-              description_teacher: This lesson will work to prepare students mentally for the coding exercises that they will encounter over the length of this course.  In small teams, students will use physical activity to program their classmates to step carefully from place to place until a goal is achieved.
             Sequencing in Maze:
               key: Sequencing in Maze
               name: Sequencing with Angry Birds
-              description_student: Help Red the Angry Bird follow the path to the naughty pig.
-              description_teacher: Using characters from Angry Birds, students will develop sequential algorithms to move a bird from one side of a maze to the pig at the other side. To do this they will stack code blocks together in a linear sequence.
             Programming in Maze:
               key: Programming in Maze
               name: Programming with Angry Birds
-              description_student: Create programs to help the Angry Bird move through the maze.
-              description_teacher: Using characters from the game Angry Birds, students will develop sequential algorithms to move a bird from one side of a maze to the pig at the other side. To do this they will stack code blocks together in a linear sequence.
             Programming in Harvester:
               key: Programming in Harvester
               name: Programming with Harvester
-              description_student: Help the Harvester collect vegetables along a path.
-              description_teacher: 'Students will apply the programming concepts that they have learned to the Harvester environment. Now, instead of just getting the character to a goal, students have to collect corn using a new block. Students will continue to develop sequential algorithm skills and start using the debugging process. '
             'Loops: Getting Loopy':
               key: 'Loops: Getting Loopy'
               name: Getting Loopy
-              description_student: In this lesson, we'll have a dance party using repeat loops!
-              description_teacher: As we start to write longer and more interesting programs, our code often contains a lot of repetition. In this lesson, students will learn about how loops can be used to more easily communicate instructions that have a lot of repetition by looking at the repeated patterns of movement in a dance.
             Loops in Harvester:
               key: Loops in Harvester
               name: Loops with Harvester
-              description_student: Help the Harvester collect even more, using loops!
-              description_teacher: Building on the concept of repeating instructions from "Getting Loopy," this stage will have students using loops to pick corn more efficiently on Code.org.
             Loops in Collector:
               key: Loops in Collector
               name: Loops with Laurel
-              description_student: Program Laurel the adventurer to collect treasure in an open cave.
-              description_teacher: In this lesson, students continue learning the concept of loops. Here, Laurel the Adventurer uses loops to collect treasure in open cave spaces. A new `get treasure` block is introduced to help her on her journey.
             Loops in Artist:
               key: Loops in Artist
               name: Drawing Gardens with Loops
-              description_student: Use patterns and loops to finish the images.
-              description_teacher: Returning to loops, students learn to draw images by looping simple sequences of instructions. In the previous online lesson, loops were used to traverse a maze and collect treasure. Here, students use loops to create patterns. At the end of this stage, students will be given the opportunity to create their own images using loops.
             The Right App:
               key: The Right App
               name: The Right App
-              description_student: Sketch your own smartphone app.
-              description_teacher: 'This lesson has students recognize that computer science can help people in real life. First, students empathize with several fictional smartphone users in order to help them find the “right app” that addresses their needs. Then, students exercise empathy and creativity to sketch their own smartphone app that addresses the needs of one additional user. '
             'Events: The Big Event':
               key: 'Events: The Big Event'
               name: The Big Event Jr.
-              description_student: Move or shout when your teacher presses buttons on a giant remote.
-              description_teacher: Events are a great way to add variety to a pre-written algorithm. Sometimes you want your program to be able to respond to the user exactly when the user wants it to. That is what events are for.
             Events in Play Lab:
               key: Events in Play Lab
               name: A Royal Battle with Events
-              description_student: Use events to create a story or make an interactive game.
-              description_teacher: In this online activity, students will have the opportunity to learn how to use events in Play Lab and apply all of the coding skills that they've learned to create an animated game. It's time to get creative and make a game in Play Lab!
           lesson_groups:
             csf_digcit:
               display_name: Digital Citizenship
@@ -19901,103 +19375,57 @@ en:
             Putting a STOP to Online Meanness:
               key: Putting a STOP to Online Meanness
               name: Putting a STOP to Online Meanness
-              description_student: In this lesson, you'll learn about meanness and what to do if you encounter it online.
-              description_teacher: |-
-                <img alt="" src="https://curriculum.code.org/media/uploads/CommonSenseEducationShort400px.png" style="padding: 10px 0;">
-
-                This lesson was originally created by [Common Sense Education](https://www.commonsense.org/education/digital-citizenship/curriculum).
-
-                The internet is filled with all kinds of interesting people, but sometimes, some of them can be mean to each other. With this role play, help your students understand why it's often easier to be mean online than in person, and how to deal with online meanness when they see it.
             Password Power-Up:
               key: Password Power-Up
               name: Password Power-Up
-              description_student: In this lesson, you'll learn about how passwords protect your information, and how to make a good password.
-              description_teacher: |-
-                <img alt="" src="https://curriculum.code.org/media/uploads/CommonSenseEducationShort400px.png" style="padding: 10px 0;">
-
-                This lesson was originally created by [Common Sense Education](https://www.commonsense.org/education/digital-citizenship/curriculum).
-
-                Stronger, more secure online passwords are a good idea for everyone. But how can we help kids create better passwords and actually remember them? Use the tips in this lesson to help kids make passwords that are both secure and memorable.
             'Programming: My Robotic Friends':
               key: 'Programming: My Robotic Friends'
               name: My Robotic Friends Jr.
-              description_student: In this lesson, you'll pretend your classmates are robots and program them to build patterns of stacked cups.
-              description_teacher: Using a set of symbols in place of code, students will design algorithms to instruct a "robot" to stack cups in different patterns. Students will take turns participating as the robot, responding only to the algorithm defined by their peers. This segment teaches students the connection between symbols and actions, the difference between an algorithm and a program, and the valuable skill of debugging.
             Programming in Maze:
               key: Programming in Maze
               name: Programming with Angry Birds
-              description_student: Learn about sequences and algorithms with Angry Birds.
-              description_teacher: Using characters from the game Angry Birds, students will develop sequential algorithms to move a bird from one side of a maze to the pig at the other side. To do this they will stack code blocks together in a linear sequence, making them move straight, turn left, or turn right.
             Debugging in Maze:
               key: Debugging in Maze
               name: Debugging in Maze
-              description_student: Find problems in puzzles and practice your debugging skills.
-              description_teacher: Debugging is an essential element of learning to program. In this lesson, students will encounter puzzles that have been solved incorrectly. They will need to step through the existing code to identify errors, including incorrect loops, missing blocks, extra blocks, and blocks that are out of order.
             Programming in Collector:
               key: Programming in Collector
               name: Collecting Treasure with Laurel
-              description_student: Write algorithms to help Laurel the Adventurer collect lots of gems!
-              description_teacher: In this series of puzzles, students will continue to develop their understanding of algorithms and debugging. With a new character, Laurel the Adventurer, students will create sequential algorithms to get Laurel to pick up treasure as she walks along a path.
             Programming in Artist:
               key: Programming in Artist
               name: Creating Art with Code
-              description_student: Create beautiful images by programming the Artist.
-              description_teacher: In this lesson, students will take control of the Artist to complete drawings on the screen. This Artist stage will allow students to create images of increasing complexity using new blocks like `move forward by 100 pixels` and `turn right by 90 degrees`.
             Binary Bracelets:
               key: Binary Bracelets
               name: Binary Bracelets
-              description_student: Create your very own binary bracelet and learn how computers remember information!
-              description_teacher: Binary is extremely important in the world of computers. The majority of computers today store all sorts of information in binary form. This lesson helps demonstrate how it is possible to take something from real life and translate it into a series of ons and offs.
             'Loops: My Loopy Robotic Friends':
               key: 'Loops: My Loopy Robotic Friends'
               name: My Loopy Robotic Friends Jr.
-              description_student: In this lesson, you'll program your classmates again, but using loops you'll be able to solve bigger and more complicated problems.
-              description_teacher: Building on the initial "My Robotic Friends" activity, students tackle larger and more complicated designs. In order to program their "robots" to complete these bigger designs, students will need to identify repeated patterns in their instructions that could be replaced with a loop.
             Loops with Rey and BB-8:
               key: Loops with Rey and BB-8
               name: Loops with Rey and BB-8
-              description_student: 'Help BB-8 through mazes using loops! '
-              description_teacher: Building on the concept of repeating instructions from "Getting Loopy," this stage will have students using loops to help BB-8 traverse a maze more efficiently than before.
             Loops in Harvester:
               key: Loops in Harvester
               name: Harvesting Crops with Loops
-              description_student: Let's use loops to help the harvester collect some veggies!
-              description_teacher: "In the preceding stage, students used loops to create fantastic drawings. Now they're going to loop new actions in order to help the harvester collect multiple veggies growing in large bunches.\r\n"
             Looking Ahead:
               key: Looking Ahead
               name: Looking Ahead with Minecraft
-              description_student: Avoid the lava! Here you will start to learn about conditionals in the world of Minecraft.
-              description_teacher: This lesson was originally created for the Hour of Code, alongside the Minecraft team. Students will get the chance to practice ideas that they have learned up to this point, as well as getting a sneak peek at conditionals!
             Sticker Art with Loops:
               key: Sticker Art with Loops
               name: Sticker Art with Loops
-              description_student: In this lesson, loops make it easy to make even cooler images with Artist!
-              description_teacher: Watch student faces light up as they make their own gorgeous designs using a small number of blocks and digital stickers! This lesson builds on the understanding of loops from previous lessons and gives students a chance to be truly creative.  This activity is fantastic for producing artifacts for portfolios or parent/teacher conferences.
             'Events: The Big Event':
               key: 'Events: The Big Event'
               name: The Big Event
-              description_student: 'Play a fun game to learn about events. '
-              description_teacher: Students will soon learn that events are a great way to add flexibility to a pre-written algorithm. Sometimes you want your program to be able to respond to the user exactly when the user wants it to. Events can make your program more interesting and interactive.
             Build a Flappy Game:
               key: Build a Flappy Game
               name: Build a Flappy Game
-              description_student: Build you own Flappy Bird game however you like, then share it with your friends!
-              description_teacher: In this special stage, students get to build their own Flappy Bird game by using event handlers to detect mouse clicks and object collisions. At the end of the level, students will be able to customize their game by changing the visuals or rules.
             Events in Play Lab:
               key: Events in Play Lab
               name: Chase Game with Events
-              description_student: It's time to get creative and make a game in Play Lab!
-              description_teacher: In this online activity, students will have the opportunity to learn how to use events in Play Lab and to apply all the coding skills they've learned to create an animated game. It's time to get creative and make a game in Play Lab!
             Picturing Data:
               key: Picturing Data
               name: Picturing Data
-              description_student: Data can be used to help students understand their world and answer interesting questions. In this lesson, students will collect data from a Play Lab project and visualize it using different kinds of graphs.
-              description_teacher: Data can be used to help students understand their world and answer interesting questions. In this lesson, students will collect data from a Play Lab project and visualize it using different kinds of graphs.
             'End of Course Project: Create a Play Lab Game':
               key: 'End of Course Project: Create a Play Lab Game'
               name: End of Course Project
-              description_student: Get those hands ready for plenty of coding! It's time to start building your project.
-              description_teacher: 'This capstone lesson takes students through the process of designing, developing, and showcasing their own Play Lab projects! To ensure this process goes smoothly, we have provided a step-by-step structure for students to follow, from planning on paper to coding on our website. In addition, we offer ideas to help teachers facilitate a showcase finale! '
           lesson_groups:
             csf_digcit:
               display_name: Digital Citizenship
@@ -20023,103 +19451,60 @@ en:
             'Algorithms: Graph Paper Programming':
               key: 'Algorithms: Graph Paper Programming'
               name: Graph Paper Programming
-              description_student: In this lesson, you will program your classmate to draw pictures!
-              description_teacher: 'By "programming" one another to draw pictures, students get an opportunity to experience some of the core concepts of programming in a fun and accessible way. The class will start by having students use symbols to instruct each other to color squares on graph paper in an effort to reproduce an existing picture. If there’s time, the lesson can conclude with images that the students create themselves.  '
             Introduction to Online Puzzles:
               key: Introduction to Online Puzzles
               name: Introduction to Online Puzzles
-              description_student: This lesson will give you practice in the skills you will need for this course.
-              description_teacher: 'In this set of puzzles, students will begin with an introduction (or review depending on the experience of your class) of Code.org''s online workspace. There will be videos pointing out the basic functionality of the workspace including the `Run`, `Reset`, and `Step` buttons. Also discussed in these videos: dragging Blockly blocks, deleting Blockly blocks, and connecting Blockly blocks. Next, students will practice their _sequencing_ and _debugging_ skills in maze. From there, students will see new types of puzzles like Collector, Artist, and Harvester when they learn the very basics of _loops_.'
             Relay Programming:
               key: Relay Programming
               name: Relay Programming
-              description_student: Remember at the beginning of the course when you made drawings with code? In this lesson, you will be working with a team to do something very similar!
-              description_teacher: This activity will begin with a short lesson on debugging and persistence, then will quickly move to a race against the clock as students break into teams and work together to write a program one instruction at a time.
             Debugging in Collector:
               key: Debugging in Collector
               name: Debugging with Laurel
-              description_student: Have you ever run into problems while coding? In this lesson, you will learn about the secrets of debugging. Debugging is the process of finding and fixing problems in your code.
-              description_teacher: In this online activity, students will practice debugging in the "collector" environment. Students will get to practice reading and editing code to fix puzzles with simple algorithms, loops and nested loops.
             Events in Bounce:
               key: Events in Bounce
               name: Events in Bounce
-              description_student: Ever wish you could play video games in school? In this lesson, you will get to make your own!
-              description_teacher: In this online activity, students will learn what events are, and how computers use them in programs like video games. Students will work through puzzles making the program react to events (like arrow buttons being pressed.) At the end of the puzzle, students will have the opportunity to customize their game with different speeds and sounds.
             Build a Star Wars Game:
               key: Build a Star Wars Game
               name: Build a Star Wars Game
-              description_student: Feel the force as you build your own Star Wars game in this lesson.
-              description_teacher: In this lesson, students will practice using events to build a game that they can share online. Featuring R2-D2 and other Star Wars characters, students will be guided through events, then given space to create their own game.
             Dance Party:
               key: Dance Party
               name: Dance Party
-              description_student: Time to celebrate! In this lesson, you will program your own interactive dance party.
-              description_teacher: In this lesson, students will program their own interactive dance party. This activity requires sound as the tool was built to respond to music.
             Loops in Ice Age:
               key: Loops in Ice Age
               name: Loops in Ice Age
-              description_student: In this lesson you'll use the repeat block to help Scrat reach the acorn as efficiently as possible.
-              description_teacher: As a quick update (or introduction) to using loops, this stage will have students using the `repeat` block to get Scrat to the acorn more efficiently.
             Loops in Artist:
               key: Loops in Artist
               name: Drawing Shapes with Loops
-              description_student: In this lesson, loops make it easy to make cool images with the Artist!
-              description_teacher: This lesson builds on the understanding of loops from previous lessons and gives students a chance to be truly creative.  This activity doubles as a debugging exercise for extra problem-solving practice.
             Nested Loops in Bee:
               key: Nested Loops in Bee
               name: Nested Loops in Maze
-              description_student: Loops inside loops inside loops. What does this mean? This lesson will teach you what happens when you create a nested loop.
-              description_teacher: In this online activity, students will have the opportunity to push their understanding of loops to a whole new level. Playing with the Bee and Plants vs Zombies, students will learn how to program a loop to be inside of another loop. They will also be encouraged to figure out how little changes in either loop will affect their program when they click `Run`.
             Conditionals with Cards:
               key: Conditionals with Cards
               name: Conditionals with Cards
-              description_student: It's time to play a game where you earn points only under certain conditions!
-              description_teacher: "This lesson demonstrates how conditionals can be used to tailor a program to specific information. We don’t always have all of the information we need when writing a program. Sometimes you will want to do something different in one situation than in another, even if you don't know what situation will be true when your code runs. That is where conditionals come in. Conditionals allow a computer to make a decision, based on the information that is true any time your code is run.\r\n\r\n"
             Conditionals in Bee:
               key: Conditionals in Bee
               name: If/Else with Bee
-              description_student: 'Now that you understand conditionals, it''s time to program Bee to use them when collecting honey and nectar. '
-              description_teacher: Up until this point students have been writing code that executes exactly the same way each time it is run - reliable, but not very flexible. In this lesson, your class will begin to code with conditionals, allowing them to write code that functions differently depending on the specific conditions the program encounters.
             While Loops in Farmer:
               key: While Loops in Farmer
               name: While Loops in Farmer
-              description_student: 'Loops are so useful in coding. This lesson will teach you about a new kind of loop: while loops!'
-              description_teacher: "By the time students reach this lesson, they should already have plenty of practice using `repeat` loops, so now it's time to mix things up. \r\n\r\n_While loops_ are loops that continue to repeat commands while a condition is met. `While` loops are used when the programmer doesn't know the exact number of times commands need to be repeated, but does know what condition needs to be true in order for the loop to continue repeating. For example, students will be working to fill holes and dig dirt in Farmer. They will not know the size of the holes or the height of the mountains of dirt, but the students will know they need to keep filling the holes and digging the dirt as long as the ground is not flat."
             Until Loops in Maze:
               key: Until Loops in Maze
               name: Until Loops in Maze
-              description_student: You can do some amazing things when you use `until` loops!
-              description_teacher: In this lesson, students will learn about `until` loops. Students will build programs that have the main character repeat actions `until` they reach their desired stopping point.
             Conditionals & Loops in Harvester:
               key: Conditionals & Loops in Harvester
               name: Harvesting with Conditionals
-              description_student: It's not always clear when to use each conditional.  This lesson will help you get practice deciding what to do.
-              description_teacher: Students will practice `while` loops, `until` loops, and `if / else` statements. All of these blocks use conditionals. By practicing all three, students will learn to write complex and flexible code.
             'Unplugged: Binary':
               key: 'Unplugged: Binary'
               name: Binary Images
-              description_student: Learn how computers store pictures using a language with only two options.
-              description_teacher: Though many people think of binary as strictly zeros and ones, students will be introduced to the idea that information can be represented in a variety of binary options. This lesson takes that concept one step further as it illustrates how a computer can store even more complex information (such as images and colors) in binary, as well.
             Artist Binary:
               key: Artist Binary
               name: Binary Images with Artist
-              description_student: In this lesson, you will learn how to make images using only 0s and 1s.
-              description_teacher: This series of online lessons will have students learning to make images using on and off.
             Be A Super Digital Citizen:
               key: Be A Super Digital Citizen
               name: Be A Super Digital Citizen
-              description_student: Learn how you can be an upstander when you see cyberbullying.
-              description_teacher: |-
-                ![](https://curriculum.code.org/media/uploads/CommonSenseEducationShort400px.png){: style="padding:10px 0"}
-
-                This lesson was originally created by [Common Sense Education](https://www.commonsense.org/education/digital-citizenship/curriculum).
-
-                Online tools are empowering for kids, and they also come with big responsibilities. But do kids always know what to do when they encounter cyberbullying? Show your students appropriate ways to take action and resolve conflicts, from being upstanders to helping others in need.
             End of Course Project:
               key: End of Course Project
               name: End of Course Project
-              description_student: Get those hands ready for plenty of coding! It's time to start building your project.
-              description_teacher: 'This capstone lesson takes students through the process of designing, developing, and showcasing their own projects! '
           lesson_groups:
             csf_sequencing:
               display_name: Sequencing
@@ -20145,103 +19530,60 @@ en:
             Sequencing in the Maze:
               key: Sequencing in the Maze
               name: Sequencing in the Maze
-              description_student: In this lesson, you will learn how to write your very own programs!
-              description_teacher: "In this set of puzzles, students will begin with an introduction (or review depending on the experience of your class) of Code.org's online workspace. There will be videos pointing out the basic functionality of the workspace including the `Run`, `Reset`, and `Step` buttons. Also discussed in these videos: dragging Blockly blocks, deleting Blockly blocks, and connecting Blockly blocks. Next, students will practice their _sequencing_ and _debugging_ skills in the maze. \r\nDebugging is an essential element of learning to program. Students will encounter some puzzles that have been solved incorrectly. They will need to step through the existing code to identify errors, including incorrect loops, missing blocks, extra blocks, and blocks that are out of order."
             Programming and Loops with the Artist:
               key: Programming and Loops with the Artist
               name: Drawing with Loops
-              description_student: In this lesson, loops make it easy to make even cooler images with Artist!
-              description_teacher: Watch student faces light up as they make their own gorgeous designs using a small number of blocks and digital stickers! This lesson builds on the understanding of loops from previous lessons and gives students a chance to be truly creative.  This activity is fantastic for producing artifacts for portfolios or parent/teacher conferences.
             'Conditionals in Minecraft: Voyage Aquatic':
               key: 'Conditionals in Minecraft: Voyage Aquatic'
               name: 'Conditionals in Minecraft: Voyage Aquatic'
-              description_student: Here you will learn about conditionals in the world of Minecraft.
-              description_teacher: This lesson was originally created for the Hour of Code, alongside the Minecraft team. Students will get the chance to practice ideas that they have learned up to this point, as well as getting a sneak peek at conditionals!
             Conditionals:
               key: Conditionals
               name: Conditionals with the Farmer
-              description_student: You will get to tell the computer what to do under certain conditions in this fun and challenging series.
-              description_teacher: This lesson introduces students to `while` loops and `if / else` statements. _While loops_ are loops that continue to repeat commands as long as a condition is true. While loops are used when the programmer doesn't know the exact number of times the commands need to be repeated, but the programmer does know what condition needs to be true in order for the loop to continue looping. `If / Else` statements offer flexibility in programming by running entire sections of code only if something is true, otherwise it runs something else.
             Simon Says:
               key: Simon Says
               name: Simon Says
-              description_student: Play a game and think about what commands are needed to get the right result.
-              description_teacher: 'In this lesson, students will play a game intended to get them thinking about the way commands need to be given to produce the right result. This will help them more easily carry over to Sprite Lab in the upcoming lessons. '
             Learning Sprites with Sprite Lab:
               key: Learning Sprites with Sprite Lab
               name: Swimming Fish with Sprite Lab
-              description_student: Learn how to create and edit sprites.
-              description_teacher: 'In this lesson, students will learn about the two concepts at the heart of Sprite Lab: sprites and behaviors. Sprites are characters or objects on the screen that students can move, change, and manipulate. Behaviors are actions that sprites will take continuously until they are stopped.'
             Alien Dance Party with Sprite Lab:
               key: Alien Dance Party with Sprite Lab
               name: Alien Dance Party with Sprite Lab
-              description_student: Create an interactive project that can be shared with classmates.
-              description_teacher: 'This lesson features Sprite Lab, a platform where students can create their own interactive animations and games. In addition to behaviors, today students will incorporate user input as events to create an "alien dance party".  '
             Private and Personal Information:
               key: Private and Personal Information
               name: Private and Personal Information
-              description_student: The internet is fun and exciting, but it's important to stay safe too. This lesson teaches you the difference between information that is safe to share and information that is private.
-              description_teacher: |-
-                ![](https://curriculum.code.org/media/uploads/CommonSenseEducationShort400px.png){: style="padding:10px 0"}
-
-                This lesson was originally created by [Common Sense Education](https://www.commonsense.org/education/digital-citizenship/curriculum).
-
-                It's in our students' nature to share and connect with others. But sharing online comes with some risks. How can we help kids build strong, positive, and safe relationships online? Help your students learn the difference between what's personal and what's best left private.
             About Me:
               key: About Me
               name: About Me with Sprite Lab
-              description_student: By creating an interactive poster with SpriteLab, students will apply their understanding of sharing personal and private information on the web.
-              description_teacher: "By creating an interactive poster with SpriteLab, students will apply their understanding of sharing personal and private information on the web.\r\n"
             Digital Sharing:
               key: Digital Sharing
               name: Digital Sharing
-              description_student: 'In this lesson, you''ll learn about the challenges and benefits of ownership and copyright. '
-              description_teacher: Loaned to Computer Science Fundamentals by the team over at Copyright and Creativity, this lesson exists to help students understand the challenges and beneﬁts of respecting ownership and copyright, particularly in digital environments. Students should be encouraged to respect artists’ rights as an important part of being an ethical digital citizen.
             Nested Loops in Bee:
               key: Nested Loops in Bee
               name: Nested Loops in Maze
-              description_student: Loops inside loops inside loops. What does this mean? This lesson will teach you what happens when you place a loop inside another loop.
-              description_teacher: In this online activity, students will have the opportunity to push their understanding of loops to a whole new level. Playing with the Bee and Plants vs Zombies, students will learn how to program a loop to be inside of another loop. They will also be encouraged to figure out how little changes in either loop will affect their program when they click `Run`.
             Nested Loops in Artist:
               key: Nested Loops in Artist
               name: Fancy Shapes using Nested Loops
-              description_student: More nested loops! This time, you get to make some AMAZING drawing with nested loops.
-              description_teacher: Students will create intricate designs using Artist in today's set of puzzles. By continuing to practice nested loops with new goals, students will see more uses of loops in general. This set of puzzles also offers a lot more potential for creativity with an opportunity for students to create their own design at the end of the stage.
             Nested Loops in Frozen:
               key: Nested Loops in Frozen
               name: Nested Loops with Frozen
-              description_student: 'Anna and Elsa have excellent ice-skating skills, but need your help to create patterns in the ice. Use nested loops to create something super COOL. '
-              description_teacher: Now that students know how to layer their loops, they can create so many beautiful things.  This lesson will take students through a series of exercises to help them create their own portfolio-ready images using Anna and Elsa's excellent ice-skating skills!
             'Functions: Songwriting':
               key: 'Functions: Songwriting'
               name: Songwriting
-              description_student: Even rockstars need programming skills. This lesson will teach you about functions using lyrics from songs.
-              description_teacher: One of the most magnificent structures in the computer science world is the function. Functions (sometimes called procedures) are mini programs that you can use over and over inside of your bigger program. This lesson will help students intuitively understand why combining chunks of code into functions can be such a helpful practice.
             Functions in Minecraft:
               key: Functions in Minecraft
               name: Functions in Minecraft
-              description_student: Can you figure out how to use functions for the most efficient code?
-              description_teacher: Students will begin to understand how functions can be helpful in this fun and interactive Minecraft adventure!
             Functions in Harvester:
               key: Functions in Harvester
               name: Functions with Harvester
-              description_student: Functions will save you lots of work as you help the farmer with her harvest!
-              description_teacher: Students have practiced creating impressive designs in Artist and navigating mazes in Bee, but today they will use functions to harvest crops in Harvester. This lesson will push students to use functions in the new ways by combining them with `while` loops and `if / else` statements.
             Functions in Artist:
               key: Functions in Artist
               name: Functions with Artist
-              description_student: Make complex drawings more easily with functions!
-              description_teacher: Students will be introduced to using functions with the Artist. Magnificent images will be created and modified. For more complicated patterns, students will learn about nesting functions by calling one function from inside another.
             Designing for Accessibility:
               key: Designing for Accessibility
               name: Designing for Accessibility
-              description_student: 'In this lesson, students will learn about accessibility and the value of empathy through brainstorming and designing accessible solutions for hypothetical apps. '
-              description_teacher: 'In this lesson, students will learn about accessibility and the value of empathy through brainstorming and designing accessible solutions for hypothetical apps. '
             End of Course Project:
               key: End of Course Project
               name: End of Course Project
-              description_student: Projects this big take time and plenty of planning. Find your inspiration, develop a plan, and unleash your creativity!
-              description_teacher: "The next four lessons provide an opportunity for students to put their coding skills to use in a capstone project. This project will help individuals gain experience with coding and produce an exemplar to share with peers and loved ones. Intended to be a multi-lesson or multi-week experience, students will spend time exploring brainstorming, learning about the design process, building, and presenting their final work. \r\n\r\nIn the explore stage, students will play with pre-built examples of projects in both Artist and Sprite Lab for inspiration. Next, students will learn about the design process and how to implement it in their own projects. They will then be given the space to create their own project in Artist, Sprite Lab, or another interface that they have become familiar with (this is likely the longest stage of the project). Finally, students will be able to present their finished work to their peers."
           lesson_groups:
             ramp_up:
               display_name: Ramp-Up
@@ -20267,103 +19609,60 @@ en:
             Functions in Minecraft:
               key: Functions in Minecraft
               name: Functions in Minecraft
-              description_student: Can you figure out how to use functions for the most efficient code?
-              description_teacher: Students will begin to understand how functions can be helpful in this fun and interactive Minecraft adventure!
             Learning Sprites with Sprite Lab:
               key: Learning Sprites with Sprite Lab
               name: Swimming Fish with Sprite Lab
-              description_student: Learn how to create and edit sprites.
-              description_teacher: 'In this lesson, students will learn about the two concepts at the heart of Sprite Lab: sprites and behaviors. Sprites are characters or objects on the screen that students can move, change, and manipulate. Behaviors are actions that sprites will take continuously until they are stopped.'
             Events with Sprite Lab:
               key: Events with Sprite Lab
               name: Alien Dance Party with Sprite Lab
-              description_student: Create an interactive project that can be shared with classmates.
-              description_teacher: 'This lesson features Sprite Lab, a platform where students can create their own interactive animations and games. In addition to behaviors, today students will incorporate user input as events to create an "alien dance party".   '
             Loops with the Artist:
               key: Loops with the Artist
               name: Drawing with Loops
-              description_student: In this lesson, loops make it easy to make even cooler images with Artist!
-              description_teacher: Watch student faces light up as they make their own gorgeous designs using a small number of blocks and digital stickers! This lesson builds on the understanding of loops from previous lessons and gives students a chance to be truly creative.  This activity is fantastic for producing artifacts for portfolios or parent/teacher conferences.
             Nested Loops in the Maze:
               key: Nested Loops in the Maze
               name: Nested Loops in Maze
-              description_student: Loops inside loops inside loops. What does this mean? This lesson will teach you what happens when you place a loop inside another loop.
-              description_teacher: In this online activity, students will have the opportunity to push their understanding of loops to a whole new level. Playing with the Bee and Plants vs Zombies, students will learn how to program a loop to be inside of another loop. They will also be encouraged to figure out how little changes in either loop will affect their program when they click `Run`.
             The Power of Words:
               key: The Power of Words
               name: The Power of Words
-              description_student: Bullying is never okay. This lesson will teach you about what is and isn't okay to say online.
-              description_teacher: |-
-                ![](https://curriculum.code.org/media/uploads/CommonSenseEducationShort400px.png){: style="padding:10px 0"}
-
-                This lesson was originally created by [Common Sense Education](https://www.commonsense.org/education/digital-citizenship/curriculum).
-
-                As kids grow, they'll naturally start to communicate more online. But some of what they see could make them feel hurt, sad, angry, or even fearful. Help your students build empathy for others and learn strategies to use when confronted with cyberbullying.
             Envelope Variables:
               key: Envelope Variables
               name: Envelope Variables
-              description_student: 'Envelopes and variables have something in common: both can hold valuable things. Here you will learn what variables are and the awesome things they can do.'
-              description_teacher: Variables are used as placeholders for values such as numbers or words. Variables allow for a lot of freedom in programming. Instead of having to type out a phrase many times or remember an obscure number, computer scientists can use variables to reference them. This lesson helps to explain what variables are and how we can use them in many different ways. The idea of variables isn't an easy concept to grasp, so we recommend allowing plenty of time for discussion at the end of the lesson.
             Variables as Constant in Artist:
               key: Variables as Constant in Artist
               name: Variables with Artist
-              description_student: Don't forget to bring creativity to class! In these puzzles you will be making fantastic drawings using variables.
-              description_teacher: In this lesson, students will explore the creation of repetitive designs using variables in the Artist environment. Students will learn how variables can be used to make code easier to write and easier to read, even when the values don't change at runtime.
             Variables that Change in Bee:
               key: Variables that Change in Bee
               name: Changing Variables with Bee
-              description_student: This bee loves variables!
-              description_teacher: 'This lesson will help illustrate how variables can make programs more powerful by allowing values to change while the code is running. '
             Variables that Change in Artist:
               key: Variables that Change in Artist
               name: Changing Variables with Artist
-              description_student: In this lesson, you'll make drawings using variables that change as the program runs.
-              description_teacher: In this lesson, students will explore the creation of repetitive designs using variables in the Artist environment. Students will learn how variables can be used to make code easier to write and easier to read. After guided puzzles, students will end in a freeplay level to show what they have learned and create their own designs.
             Simulating Experiments:
               key: Simulating Experiments
               name: Simulating Experiments
-              description_student: Run simulations on the computer and experiment by changing variables.
-              description_teacher: By running a simple simulation in Sprite Lab, students will experience how computing can be used to collect data that identify trends or patterns. After running the simulation multiple times, students will have an opportunity to make a prediction about how changing a variable in the simulation might impact the outcome, and then test that hypothesis.
             AI for Oceans:
               key: AI for Oceans
               name: AI for Oceans
-              description_student: 'Tutorial Summary: First students classify objects as either "fish" or "not fish" to attempt to remove trash from the ocean. Then, students will need to expand their training data set to include other sea creatures that belong in the water. In the second part of the activity, students will choose their own labels to apply to images of randomly generated fish. This training data is used for a machine learning model that should then be able to label new images on its own.'
-              description_teacher: "**Tutorial Summary:** First students classify objects as either \"fish\" or \"not fish\" to attempt to remove trash from the ocean. Then, students will need to expand their training data set to include other sea creatures that belong in the water. In the second part of the activity, students will choose their own labels to apply to images of randomly generated fish. This training data is used for a machine learning model that should then be able to label new images on its own.\r\n\r\n\r\n**Checking Correctness:** This tutorial will not tell students whether they completed the level correctly. It is possible to skip through the different parts of the activity quickly. Encourage students to watch the videos, read the instructions, and try different things along the way. At any time, they can share their findings with you or a classmate.\r\n"
             Internet:
               key: Internet
               name: The Internet
-              description_student: Ever wondered how information travels across the internet? It's not magic! This lesson will teach you the basics of how the internet works.
-              description_teacher: Even though many people use the internet daily, not very many know how it works. In this lesson, students will pretend to flow through the internet, all the while learning about connections, URLs, IP Addresses, and the DNS.
             For Loop Fun:
               key: For Loop Fun
               name: For Loop Fun
-              description_student: You're going to have loads of fun learning about `for` loops!
-              description_teacher: 'We know that loops allow us to do things over and over again, but now we’re going to learn how to use loops that have extra structures built right in. These new structures will allow students to create code that is more powerful and dynamic. '
             For Loops in Bee:
               key: For Loops in Bee
               name: For Loops with Bee
-              description_student: Buzz buzz. In these puzzles you will be guiding a bee to nectar and honey using `for` loops!
-              description_teacher: Featuring Bee, this lesson focuses on `for` loops and using an incrementing variable to solve more complicated puzzles. Students will begin by reviewing loops from previous lessons, then they'll walk through an introduction to `for` loops so they can more effectively solve complicated problems.
             For Loops in Artist:
               key: For Loops in Artist
               name: For Loops with Artist
-              description_student: Get ready to make your next masterpiece. Here you will be using `for` loops to make some jaw-dropping pictures.
-              description_teacher: In this lesson, students continue to practice `for` loops, but this time with Artist. Students will complete puzzles combining the ideas of variables, loops, and `for` loops to create complex designs. At the end, they will have a chance to create their own art in a freeplay level.
             Editing Behaviors:
               key: Editing Behaviors
               name: Behaviors in Sprite Lab
-              description_student: Learn to program your own sprite behaviors!
-              description_teacher: Here, students will use Sprite Lab to create their own customized behaviors.
             Virtual Pet:
               key: Virtual Pet
               name: Virtual Pet with Sprite Lab
-              description_student: In this lesson, students will create an interactive Virtual Pet that looks and behaves how they wish. Students will use Sprite Lab's "Costumes" tool to customize their pet's appearance. They will then use events, behaviors, and other concepts they have learned to give their pet a life of its own!
-              description_teacher: In this lesson, students will create an interactive Virtual Pet that looks and behaves how they wish. Students will use Sprite Lab's "Costumes" tool to customize their pet's appearance. They will then use events, behaviors, and other concepts they have learned to give their pet a life of its own!
             End of Course Project:
               key: End of Course Project
               name: End of Course Project
-              description_student: Projects this big take time and plenty of planning. Find your inspiration, develop a plan, and unleash your creativity!
-              description_teacher: "The next five lessons provide an opportunity for students to put their coding skills to use in a capstone project. This project will help individuals gain experience with coding and produce an exemplar to share with peers and loved ones. This is intended to be a multi-lesson or multi-week project where students spend time brainstorming, learning about the design process, building, and then presenting their final work. \r\n\r\nIn the \"Explore\" stage, students will play around with pre-built Artist and Sprite Lab programs for inspiration. Next, students will learn about the design process and how to implement it in their own projects. They will then be given the space to create their own project in Artist, Sprite Lab, or any other interface that you are comfortable providing. (This is likely the longest stage of the project.) Students will then revise their code after testing and peer review. Finally, students will be able to present their finished work to their classmates."
           lesson_groups:
             ramp_up:
               display_name: Ramp-Up
@@ -20389,143 +19688,87 @@ en:
             Dance Party:
               key: Dance Party
               name: Dance Party
-              description_student: ''
-              description_teacher: ''
             Programming with Angry Birds:
               key: Programming with Angry Birds
               name: Programming with Angry Birds
-              description_student: ''
-              description_teacher: ''
             Debugging with Scrat:
               key: Debugging with Scrat
               name: Debugging with Scrat
-              description_student: ''
-              description_teacher: ''
             Collecting Treasure with Laurel:
               key: Collecting Treasure with Laurel
               name: Collecting Treasure with Laurel
-              description_student: ''
-              description_teacher: ''
             Creating Art with Code:
               key: Creating Art with Code
               name: Creating Art with Code
-              description_student: ''
-              description_teacher: ''
             Loops with Rey and BB-8:
               key: Loops with Rey and BB-8
               name: Loops with Rey and BB-8
-              description_student: ''
-              description_teacher: ''
             Sticker Art with Loops:
               key: Sticker Art with Loops
               name: Sticker Art with Loops
-              description_student: ''
-              description_teacher: ''
             Nested Loops in Maze:
               key: Nested Loops in Maze
               name: Nested Loops in Maze
-              description_student: ''
-              description_teacher: ''
             Snowflakes with Anna and Elsa:
               key: Snowflakes with Anna and Elsa
               name: Snowflakes with Anna and Elsa
-              description_student: ''
-              description_teacher: ''
             'Looking Ahead with Minecraft ':
               key: 'Looking Ahead with Minecraft '
               name: 'Looking Ahead with Minecraft '
-              description_student: ''
-              description_teacher: ''
             If/Else with Bee:
               key: If/Else with Bee
               name: If/Else with Bee
-              description_student: ''
-              description_teacher: ''
             While Loops with the Farmer:
               key: While Loops with the Farmer
               name: While Loops with the Farmer
-              description_student: ''
-              description_teacher: ''
             'Conditionals in Minecraft: Voyage Aquatic':
               key: 'Conditionals in Minecraft: Voyage Aquatic'
               name: 'Conditionals in Minecraft: Voyage Aquatic'
-              description_student: ''
-              description_teacher: ''
             Until Loops in Maze:
               key: Until Loops in Maze
               name: Until Loops in Maze
-              description_student: ''
-              description_teacher: ''
             Harvesting with Conditionals:
               key: Harvesting with Conditionals
               name: Harvesting with Conditionals
-              description_student: ''
-              description_teacher: ''
             Functions in Minecraft:
               key: Functions in Minecraft
               name: Functions in Minecraft
-              description_student: ''
-              description_teacher: ''
             Functions with Harvester:
               key: Functions with Harvester
               name: Functions with Harvester
-              description_student: ''
-              description_teacher: ''
             Functions with Artist:
               key: Functions with Artist
               name: Functions with Artist
-              description_student: ''
-              description_teacher: ''
             Variables with Artist:
               key: Variables with Artist
               name: Variables with Artist
-              description_student: ''
-              description_teacher: ''
             Changing Variables with Bee:
               key: Changing Variables with Bee
               name: Changing Variables with Bee
-              description_student: ''
-              description_teacher: ''
             Changing Variables with Artist:
               key: Changing Variables with Artist
               name: Changing Variables with Artist
-              description_student: ''
-              description_teacher: ''
             For Loops with Bee:
               key: For Loops with Bee
               name: For Loops with Bee
-              description_student: ''
-              description_teacher: ''
             For Loops with Artist:
               key: For Loops with Artist
               name: For Loops with Artist
-              description_student: ''
-              description_teacher: ''
             Swimming Fish in Sprite Lab:
               key: Swimming Fish in Sprite Lab
               name: Swimming Fish in Sprite Lab
-              description_student: ''
-              description_teacher: ''
             Alien Dance Party:
               key: Alien Dance Party
               name: Alien Dance Party
-              description_student: ''
-              description_teacher: ''
             Behaviors in Sprite Lab:
               key: Behaviors in Sprite Lab
               name: Behaviors in Sprite Lab
-              description_student: ''
-              description_teacher: ''
             Virtual Pet with Sprite Lab:
               key: Virtual Pet with Sprite Lab
               name: Virtual Pet with Sprite Lab
-              description_student: ''
-              description_teacher: ''
             End of Course Project:
               key: End of Course Project
               name: End of Course Project
-              description_student: ''
-              description_teacher: ''
           lesson_groups:
             csf_warmup:
               display_name: Warm-Up
@@ -20555,58 +19798,36 @@ en:
             Learn to Drag and Drop:
               key: Learn to Drag and Drop
               name: Learn to Drag and Drop
-              description_student: ''
-              description_teacher: This lesson will give students an idea of what to expect when they head to the computer lab. It begins with a brief discussion introducing them to computer lab manners, then they will progress into using a computer to complete online puzzles.
             Sequencing with Scrat:
               key: Sequencing with Scrat
               name: Sequencing with Scrat
-              description_student: ''
-              description_teacher: Using Scrat from the Ice Age franchise, students will develop sequential algorithms to move a squirrel character from one side of a maze to the acorn at the other side. To do this they will stack code blocks together in a linear sequence.
             Programming in with Angry Birds:
               key: Programming in with Angry Birds
               name: Programming in with Angry Birds
-              description_student: ''
-              description_teacher: ''
             Programming with Rey and BB-8:
               key: Programming with Rey and BB-8
               name: Programming with Rey and BB-8
-              description_student: ''
-              description_teacher: In this lesson, students will use their newfound programming skills in more complicated ways to navigate a tricky course with BB-8.
             Programming in Harvester:
               key: Programming in Harvester
               name: Programming in Harvester
-              description_student: ''
-              description_teacher: 'Students will apply the programming concepts that they have learned to the Harvester environment. Now, instead of just getting the character to a goal, students have to collect corn using a new block. Students will continue to develop sequential algorithm skills and start using the debugging process. '
             Loops with Scrat:
               key: Loops with Scrat
               name: Loops with Scrat
-              description_student: ''
-              description_teacher: ''
             Loops with Laurel:
               key: Loops with Laurel
               name: Loops with Laurel
-              description_student: ''
-              description_teacher: ''
             Ocean Scene with Loops:
               key: Ocean Scene with Loops
               name: Ocean Scene with Loops
-              description_student: ''
-              description_teacher: Returning to loops, students learn to draw images by looping simple sequences of instructions. In the previous plugged lesson, loops were used to traverse a maze and collect treasure. Here, loops are creating patterns. At the end of this stage, students will be given the opportunity to create their own images using loops.
             Drawing Gardens with Loops:
               key: Drawing Gardens with Loops
               name: Drawing Gardens with Loops
-              description_student: ''
-              description_teacher: ''
             On the Move with Events:
               key: On the Move with Events
               name: On the Move with Events
-              description_student: ''
-              description_teacher: ''
             A Royal Battle with Events:
               key: A Royal Battle with Events
               name: A Royal Battle with Events
-              description_student: ''
-              description_teacher: ''
           lesson_groups:
             csf_sequencing:
               display_name: Sequencing


### PR DESCRIPTION
Finished https://codedotorg.atlassian.net/browse/PLAT-570

Removes `description_teacher` and `description_student` from scripts.en.yml for the 2021 scripts which were copied from 2020. These fields are the imported curriculum builder descriptions which is a feature we will be deprecating for the new scripts and setting up differently. In an effort to not keep around data which is not being used I wanted to remove these (Ideal I would have just not copied these fields but that didn't happen).