### PR TITLE
Add a warning to make copies of docs like on CB

### DIFF
--- a/apps/i18n/common/en_us.json
+++ b/apps/i18n/common/en_us.json
@@ -325,6 +325,7 @@
   "copied": "Copied!",
   "copy": "Copy",
   "copyId": "Copy ID",
+  "copyResourcesWarning": "**Heads Up!** Please make a copy of any documents you plan to share with students.",
   "copySectionCodeSuccess": "Link copied!",
   "copySectionCodeTooltip": "Click here to copy the link students need to join the section",
   "copyStudentsConfirm": "Yes, I want to copy student(s) to be in this current section AND the new section.",

--- a/apps/src/templates/lessonOverview/LessonOverview.jsx
+++ b/apps/src/templates/lessonOverview/LessonOverview.jsx
@@ -36,6 +36,13 @@ const styles = {
   navLink: {
     fontSize: 18,
     color: color.purple
+  },
+  copyResourceWarningArea: {
+    color: '#8a6d3b',
+    backgroundColor: '#fcf8e3',
+    border: '2px solid #f5e79e',
+    borderRadius: 4,
+    padding: '10px 10px 0px 10px'
   }
 };
 
@@ -170,6 +177,9 @@ class LessonOverview extends Component {
             {Object.keys(lesson.resources).length > 0 && (
               <div id="resource-section">
                 <h2>{i18n.links()}</h2>
+                <div style={styles.copyResourceWarningArea}>
+                  <SafeMarkdown markdown={i18n.copyResourcesWarning()} />
+                </div>
                 {lesson.resources['Teacher'] && (
                   <div>
                     <h3>{i18n.forTheTeachers()}</h3>


### PR DESCRIPTION
Completes: https://codedotorg.atlassian.net/browse/PLAT-617

CB Lesson Plans Have Something Like This:

<img width="513" alt="Screen Shot 2020-12-14 at 10 22 44 PM" src="https://user-images.githubusercontent.com/208083/102166773-e5e68280-3e5a-11eb-9a95-5804c73dc09b.png">

So we added this to the Code Studio Lesson Plans:
<img width="355" alt="Screen Shot 2020-12-14 at 10 21 32 PM" src="https://user-images.githubusercontent.com/208083/102166797-f696f880-3e5a-11eb-96d8-a93e48b36aaa.png">


