### PR TITLE
Revert "Temporarily prevent address filtering from blocking sharing applab libraries"

### DIFF
--- a/lib/cdo/share_filtering.rb
+++ b/lib/cdo/share_filtering.rb
@@ -61,14 +61,14 @@ module ShareFiltering
     email = RegexpUtils.find_potential_email(text)
     return ShareFailure.new(FailureType::EMAIL, email) if email
 
+    street_address = Geocoder.find_potential_street_address(text)
+    return ShareFailure.new(FailureType::ADDRESS, street_address) if street_address
+
     phone_number = RegexpUtils.find_potential_phone_number(text)
     return ShareFailure.new(FailureType::PHONE, phone_number) if phone_number
 
     expletive = ProfanityFilter.find_potential_profanity(text, locale)
     return ShareFailure.new(FailureType::PROFANITY, expletive) if expletive
-
-    street_address = Geocoder.find_potential_street_address(text)
-    return ShareFailure.new(FailureType::ADDRESS, street_address) if street_address
 
     nil
   end

--- a/shared/middleware/files_api.rb
+++ b/shared/middleware/files_api.rb
@@ -338,11 +338,7 @@ class FilesApi < Sinatra::Base
     end
 
     # Block libraries with PII/profanity from being published.
-    share_failure = ShareFiltering.find_failure(body, request.locale)
-    # TODO(JillianK): we are temporarily ignoring address share failures because our address detection is very broken.
-    # Once we have a better geocoding solution in H1, we should start filtering for addresses again.
-    # Additional context: https://codedotorg.atlassian.net/browse/STAR-1361
-    return bad_request if endpoint == 'libraries' && share_failure && share_failure[:type] != "address"
+    return bad_request if endpoint == 'libraries' && ShareFiltering.find_failure(body, request.locale)
 
     # Replacing a non-current version of main.json could lead to perceived data loss.
     # Log to firehose so that we can better troubleshoot issues in this case.


### PR DESCRIPTION
Reverts code-dot-org/code-dot-org#38240 - merged without a drone run so reverting and reopening a PR for the drone run