### PR TITLE
Stronger disabling of debug console in applab readonly mode

### DIFF
--- a/apps/src/lib/tools/jsdebugger/DebugConsole.jsx
+++ b/apps/src/lib/tools/jsdebugger/DebugConsole.jsx
@@ -151,6 +151,9 @@ export default connect(
       const input = e.target.value;
       if (e.keyCode === KeyCodes.ENTER) {
         e.preventDefault();
+        if (this.props.debugConsoleDisabled) {
+          return;
+        }
         this.props.commandHistory.push(input);
         e.target.value = '';
         this.appendLog({input: input});

--- a/apps/test/unit/lib/tools/jsdebugger/DebugConsoleTest.js
+++ b/apps/test/unit/lib/tools/jsdebugger/DebugConsoleTest.js
@@ -412,9 +412,13 @@ describe('The DebugConsole component when the debug console is disabled', () => 
     });
 
     describe('When typing into the text input and pressing enter,', () => {
-      beforeEach(() => submit('console.log("test")'));
-
-      it('the text does not get appended to the output', () => {
+      it('the text does not get appended to the output if the html is unaltered', () => {
+        submit('console.log("test")');
+        expect(debugOutput().text()).not.to.contain('test');
+      });
+      it('the text does not get appended to the output if the html is changed to enable the input', () => {
+        debugInput().instance().disabled = false;
+        submit('console.log("test")');
         expect(debugOutput().text()).not.to.contain('test');
       });
     });


### PR DESCRIPTION
We need to disable the debug console in applab readonly mode because otherwise you can use setKeyValue to add data to a user's app. We tried removing the console entirely but there are some levels that rely on console output so we had to add it back. Then we tried keeping the console but disabling the text input but a user pointed out that you could use browser dev tools to re enable the text input. This adds another layer to disabled text input by preventing the input from being submitted when the app is in readonly mode.

Steps to reproduce the flow that this is blocking:
1. Open an applab project in readonly mode and run the app
2. Open the debug console
3. Use browser dev tools to inspect element on the input in the debug console and remove the "disabled" prop
4. Try to type in the debug console input. You're able to type but with this change, pressing enter to submit/execute your input does nothing

<!-- ### Background -->
<!-- ### Privacy -->
<!--
1.	Does the Project involve the collection, use or sharing of new Personal Data?

2.	Does the Project involve a new or changed use or sharing of existing Personal Data?
-->
<!-- ### Security -->
<!--
Link to Jira Task where sensitive security issues are discussed privately.
-->
<!-- ### Caching -->
<!-- ### Deployment strategy -->
<!-- ### Future work -->

## Links

<!--
  Any relevant links to external resources; ie, specification documents, jira
  items, related PRs, honeybadger errors, etc
-->

- [jira](https://codedotorg.atlassian.net/browse/STAR-1316)

## Testing story

<!--
  Does your change include appropriate tests?

  If so, please describe how the tests included in this PR are sufficient

  If not, please explain why this change does not need to be tested.
-->

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
