### PR TITLE
[Circuit Playground] Reset send queue

### DIFF
--- a/apps/src/lib/kits/maker/boards/circuitPlayground/CircuitPlaygroundBoard.js
+++ b/apps/src/lib/kits/maker/boards/circuitPlayground/CircuitPlaygroundBoard.js
@@ -244,6 +244,15 @@ export default class CircuitPlaygroundBoard extends EventEmitter {
   }
 
   reset() {
+    /*
+     * Clear send queue of any pending messages.
+     * Important to do this before calling cleanupCircuitPlaygroundComponents. That function
+     * resets the state on the various board components, which requires writing to the board.
+     * So if we clear the queue after we call cleanupCircuitPlaygroundComponents, but before
+     * all of the writes complete, the board will be left in a partially-reset state.
+     */
+    this.serialPort_.queue = [];
+
     cleanupCircuitPlaygroundComponents(
       this.prewiredComponents_,
       false /* shouldDestroyComponents */
@@ -345,32 +354,31 @@ export default class CircuitPlaygroundBoard extends EventEmitter {
     });
 
     if (isNodeSerialAvailable()) {
-      const queue = [];
+      port.queue = [];
       let sendPending = false;
       const oldWrite = port.write;
 
       const trySend = buffer => {
         if (buffer) {
-          queue.push(buffer);
+          port.queue.push(buffer);
         }
 
-        if (sendPending || queue.length === 0) {
+        if (sendPending || port.queue.length === 0) {
           // Exhausted pending send buffer.
           return;
         }
-
-        if (queue.length > 512) {
+        if (port.queue.length > 512) {
           throw new Error(
             'Send queue is full! More than 512 pending messages.'
           );
         }
 
-        const toSend = queue.shift();
+        const toSend = port.queue.shift();
         sendPending = true;
         oldWrite.call(port, toSend, 'binary', function() {
           sendPending = false;
 
-          if (queue.length !== 0) {
+          if (port.queue.length !== 0) {
             trySend();
           }
         });


### PR DESCRIPTION
This is a sort of speculative fix. I think it will always be possible to fill the send queue, which I think will always break the current execution.
For example, the following will always fill the send queue. (And if we increase the size of the send queue, you would just need to similarly increase the size of the for loop).
```
onEvent("button1","click", function() {
  for (var i = 0; i < 513; i++) {
    led.toggle();
  }
  console.log('done');
});
```

With this fix at least, clicking Reset fixes the problem, so that the next time you click Run the board starts off in a good state.

If this works, I'll make a similar change in https://github.com/code-dot-org/chrome-serial-app


<!-- ### Background -->
<!-- ### Privacy -->
<!--
1.	Does the Project involve the collection, use or sharing of new Personal Data?

2.	Does the Project involve a new or changed use or sharing of existing Personal Data?
-->
<!-- ### Security -->
<!--
Link to Jira Task where sensitive security issues are discussed privately.
-->
<!-- ### Caching -->
<!-- ### Deployment strategy -->
<!-- ### Future work -->

## Links

<!--
  Any relevant links to external resources; ie, specification documents, jira
  items, related PRs, honeybadger errors, etc
-->

- [jira](https://codedotorg.atlassian.net/browse/STAR-1360)

## Testing story
Manually tested

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
