### PR TITLE
[Spritelab] implement moveBackward

### DIFF
--- a/apps/src/p5lab/spritelab/commands.js
+++ b/apps/src/p5lab/spritelab/commands.js
@@ -75,6 +75,10 @@ export const commands = {
     actionCommands.mirrorSprite(spriteArg, direction);
   },
 
+  moveBackward(spriteArg, distance) {
+    actionCommands.moveForward(spriteArg, -1 * distance);
+  },
+
   moveInDirection(spriteArg, distance, direction) {
     actionCommands.moveInDirection(spriteArg, distance, direction);
   },


### PR DESCRIPTION
this block exists in the library:
![image](https://user-images.githubusercontent.com/8787187/102277882-bdec3300-3edd-11eb-85ec-7ff6552d45be.png)
Looks like it was added 1/31:  https://github.com/code-dot-org/code-dot-org/blob/staging/dashboard/config/blocks/GamelabJr/gamelab_moveBackward.json

But the moveBackward function was never actually implemented..