### PR TITLE
Don't assign a name to activity sections with just a tip

### DIFF
--- a/lib/cdo/lesson_import_helper.rb
+++ b/lib/cdo/lesson_import_helper.rb
@@ -138,8 +138,11 @@ module LessonImportHelper
       next unless activity_section
       activity_section.position = position
       position += 1
-      activity_section.name = name
-      name = ''
+      # If an activity section only has a tip in it, we don't want to give it a name
+      unless match[:type] == 'tip'
+        activity_section.name = name
+        name = ''
+      end
       activity_section.key ||= SecureRandom.uuid
       activity_section.lesson_activity_id = lesson_activity_id
       activity_section.save!
@@ -161,7 +164,6 @@ module LessonImportHelper
       section.save!
       final_position += 1
     end
-
     sections
   end
 


### PR DESCRIPTION
We have some activity sections that just have a tip with no markdown because there is no link to them. We shouldn't assign a name to these activity sections because:
1. If the tip does have a link to it, this activity section will be deleted.
2. If the tip does not have a link to it, ideally someone will move the tip into a different activity section and delete that one anyway.

This resolves an issue found at the bug bash that caused activity section titles to occasionally disappear.

<!-- ### Background -->
<!-- ### Privacy -->
<!--
1.	Does the Project involve the collection, use or sharing of new Personal Data?

2.	Does the Project involve a new or changed use or sharing of existing Personal Data?
-->
<!-- ### Security -->
<!--
Link to Jira Task where sensitive security issues are discussed privately.
-->
<!-- ### Caching -->
<!-- ### Deployment strategy -->
<!-- ### Future work -->

## Links

<!--
  Any relevant links to external resources; ie, specification documents, jira
  items, related PRs, honeybadger errors, etc
-->

- [spec]()
- [jira]()

## Testing story

<!--
  Does your change include appropriate tests?

  If so, please describe how the tests included in this PR are sufficient

  If not, please explain why this change does not need to be tested.
-->

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
