### PR TITLE
Fix path to shared_cache in filesystem

### DIFF
--- a/lib/cdo/shared_cache.rb
+++ b/lib/cdo/shared_cache.rb
@@ -35,7 +35,7 @@ module Cdo
     # Use memcached if available, with FileStore as fallback.
     def self.cache
       @@cache ||= begin
-        memcached || ActiveSupport::Cache::FileStore.new(dashboard_dir('tmp', 'cache'))
+        memcached || ActiveSupport::Cache::FileStore.new(dashboard_dir('tmp', 'cache', 'shared'))
       end
     end
   end


### PR DESCRIPTION
When `shared_cache.clear` is called all files in the path are recursively removed, which deletes other cached files in this folder that we may not want to delete as well. The shared cache should be its own subfolder in this directory.

This fixes a bug indirectly triggered by #38142, which uses the shared cache and calls `CDO.shared_cache.clear` in a unit-test teardown hook.

### Testing

Manually ran `lib/test/cdo/test_throttle.rb` and confirmed that all files in the `dashboard/tmp/cache` folder were deleted before this change, and that they persist after this change.