### PR TITLE
Hide chapter if all lessons are hidden

### DIFF
--- a/apps/src/templates/progress/LessonGroup.story.jsx
+++ b/apps/src/templates/progress/LessonGroup.story.jsx
@@ -57,15 +57,53 @@ export default storybook => {
     },
 
     {
-      name: 'LessonGroup with summary view',
+      name: 'LessonGroup in teacher summary view with one hidden lesson',
       story: () => (
-        <Provider store={createStoreWithHiddenLesson(ViewType.Teacher, null)}>
+        <Provider store={createStoreWithHiddenLesson(ViewType.Teacher, 3)}>
           <LessonGroup
             lessonGroup={{displayName: 'My Group'}}
             isPlc={false}
             isSummaryView={true}
             lessons={lessons}
             levelsByLesson={levelsByLesson}
+          />
+        </Provider>
+      )
+    },
+
+    {
+      name: 'LessonGroup with all lessons hidden teacher summary view',
+      story: () => (
+        <Provider store={createStoreWithHiddenLesson(ViewType.Teacher, 1)}>
+          <LessonGroup
+            lessonGroup={{
+              displayName: 'My Group',
+              description: 'Lesson Group Description',
+              bigQuestions: 'Why? Who? Where?'
+            }}
+            isPlc={false}
+            isSummaryView={true}
+            lessons={[lessons[0]]}
+            levelsByLesson={[levelsByLesson[0]]}
+          />
+        </Provider>
+      )
+    },
+
+    {
+      name: 'LessonGroup with all lessons hidden student summary view (empty)',
+      story: () => (
+        <Provider store={createStoreWithHiddenLesson(ViewType.Student, 1)}>
+          <LessonGroup
+            lessonGroup={{
+              displayName: 'My Group',
+              description: 'Lesson Group Description',
+              bigQuestions: 'Why? Who? Where?'
+            }}
+            isPlc={false}
+            isSummaryView={true}
+            lessons={[lessons[0]]}
+            levelsByLesson={[levelsByLesson[0]]}
           />
         </Provider>
       )

--- a/apps/test/unit/templates/progress/LessonGroupTest.jsx
+++ b/apps/test/unit/templates/progress/LessonGroupTest.jsx
@@ -2,6 +2,7 @@ import React from 'react';
 import {expect} from '../../../util/reconfiguredChai';
 import {shallow} from 'enzyme';
 import {UnconnectedLessonGroup as LessonGroup} from '@cdo/apps/templates/progress/LessonGroup';
+import {fakeLesson} from '@cdo/apps/templates/progress/progressTestHelpers';
 
 const DEFAULT_PROPS = {
   isPlc: false,
@@ -12,21 +13,9 @@ const DEFAULT_PROPS = {
     description: 'A chapter about conditionals',
     bigQuestions: 'Why is the earth round? Can pigs fly?'
   },
-  lessons: [],
-  levelsByLesson: []
-};
-
-const NO_QUESTION_OR_DESCRIPTION_PROPS = {
-  isPlc: false,
-  isSummaryView: false,
-  scriptId: 1,
-  lessonGroup: {
-    displayName: 'jazz',
-    description: null,
-    bigQuestions: null
-  },
-  lessons: [],
-  levelsByLesson: []
+  lessons: [fakeLesson('lesson1', 1)],
+  levelsByLesson: [],
+  lessonIsVisible: () => true
 };
 
 describe('LessonGroup', () => {
@@ -42,9 +31,24 @@ describe('LessonGroup', () => {
     expect(wrapper.state('lessonGroupInfoDialogOpen')).to.be.true;
   });
   it('renders without lesson group info button when there is no description or big questions', () => {
-    const wrapper = shallow(
-      <LessonGroup {...NO_QUESTION_OR_DESCRIPTION_PROPS} />
-    );
+    const props = {
+      ...DEFAULT_PROPS,
+      lessonGroup: {
+        displayName: 'jazz',
+        description: null,
+        bigQuestions: null
+      }
+    };
+    const wrapper = shallow(<LessonGroup {...props} />);
     expect(wrapper.find('FontAwesome')).to.have.lengthOf(1);
+  });
+  it('does not render if there are no visible lessons', () => {
+    const props = {
+      ...DEFAULT_PROPS,
+      isSummaryView: true,
+      lessonIsVisible: () => false
+    };
+    const wrapper = shallow(<LessonGroup {...props} />);
+    expect(wrapper.get(0)).to.be.null;
   });
 });


### PR DESCRIPTION
<!--
  Your description goes here: A summary of the change, including any relevant motivation and context.

  If relevant, include a description both of the existing behavior and of the new behavior.
-->
- Updates `LessonGroup` component to return null if the view is summary view and all lessons in the group are hidden
- Set summary view on load if teacher is viewing as a student (`/s/coursea-2020?section_id=1&viewAs=Student` when logged in as teacher)

Teacher view:
<img width="846" alt="Screen Shot 2020-12-16 at 11 13 38 AM" src="https://user-images.githubusercontent.com/24235215/102395475-082dec80-3f90-11eb-83ec-3f41a26382d5.png">


Student view:
<img width="841" alt="Screen Shot 2020-12-16 at 11 13 44 AM" src="https://user-images.githubusercontent.com/24235215/102395486-0bc17380-3f90-11eb-835c-75cba5dd7155.png">


<!--
  Other aspects to consider. uncomment and add detail for any that seem necessary:
-->

<!-- ### Background -->
<!-- ### Privacy -->
<!--
1.	Does the Project involve the collection, use or sharing of new Personal Data?

2.	Does the Project involve a new or changed use or sharing of existing Personal Data?
-->
<!-- ### Security -->
<!--
Link to Jira Task where sensitive security issues are discussed privately.
-->
<!-- ### Caching -->
<!-- ### Deployment strategy -->
<!-- ### Future work -->

## Links

<!--
  Any relevant links to external resources; ie, specification documents, jira
  items, related PRs, honeybadger errors, etc
-->
https://codedotorg.atlassian.net/browse/LP-1493

- [spec]()
- [jira]()

## Testing story

<!--
  Does your change include appropriate tests?

  If so, please describe how the tests included in this PR are sufficient

  If not, please explain why this change does not need to be tested.
-->
I have added tests for `LessonGroup` and `progressRedux` (let me know if I should add more)

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
