### PR TITLE
Set correct level numbers on Lesson Edit page after saving

### DIFF
--- a/dashboard/app/models/lesson.rb
+++ b/dashboard/app/models/lesson.rb
@@ -470,6 +470,9 @@ class Lesson < ApplicationRecord
     # this update, so just set activity_section_position as the source of truth
     # and then fix chapter and position values after.
     script.fix_script_level_positions
+    # Reload the lesson to make sure the positions information we have is all up
+    # to date
+    reload
   end
 
   def update_objectives(objectives)

--- a/dashboard/app/models/lesson.rb
+++ b/dashboard/app/models/lesson.rb
@@ -470,9 +470,6 @@ class Lesson < ApplicationRecord
     # this update, so just set activity_section_position as the source of truth
     # and then fix chapter and position values after.
     script.fix_script_level_positions
-    # Reload the lesson to make sure the positions information we have is all up
-    # to date
-    reload
   end
 
   def update_objectives(objectives)


### PR DESCRIPTION
Fixes https://codedotorg.atlassian.net/browse/PLAT-616.

When saving level numbers were changing to zero in the edit UI. this is because we were summarizing a lesson object that did not have the most up to date information after the position values were updated based on the script. Reloading fixes that and the level numbers stay correct when saving.

## Links

<!--
  Any relevant links to external resources; ie, specification documents, jira
  items, related PRs, honeybadger errors, etc
-->

- [jira](https://codedotorg.atlassian.net/browse/PLAT-616)

## Testing story

I think having a test to protect against this would be good. I'm thinking a UI test. I'm wondering if we want to ship the change so its in and follow with the UI test?

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
