### PR TITLE
migration: make objectives.key column non-null and backfill as needed

### DIFF
--- a/dashboard/app/models/lesson.rb
+++ b/dashboard/app/models/lesson.rb
@@ -476,7 +476,7 @@ class Lesson < ApplicationRecord
     return unless objectives
 
     self.objectives = objectives.map do |objective|
-      persisted_objective = objective['id'].blank? ? Objective.new : Objective.find(objective['id'])
+      persisted_objective = objective['id'].blank? ? Objective.new(key: SecureRandom.uuid) : Objective.find(objective['id'])
       persisted_objective.description = objective['description']
       persisted_objective.save!
       persisted_objective

--- a/dashboard/app/models/objective.rb
+++ b/dashboard/app/models/objective.rb
@@ -7,7 +7,7 @@
 #  lesson_id  :integer
 #  created_at :datetime         not null
 #  updated_at :datetime         not null
-#  key        :string(255)
+#  key        :string(255)      not null
 #
 # Indexes
 #

--- a/dashboard/db/migrate/20201216185353_require_objectives_key.rb
+++ b/dashboard/db/migrate/20201216185353_require_objectives_key.rb
@@ -1,0 +1,14 @@
+class RequireObjectivesKey < ActiveRecord::Migration[5.2]
+  def up
+    if [:development, :adhoc].include? rack_env
+      Objective.where(key: nil).each do |objective|
+        objective.update!(key: SecureRandom.uuid)
+      end
+    end
+    change_column :objectives, :key, :string, null: false
+  end
+
+  def down
+    change_column :objectives, :key, :string, null: true
+  end
+end

--- a/dashboard/db/schema.rb
+++ b/dashboard/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_12_14_003529) do
+ActiveRecord::Schema.define(version: 2020_12_16_185353) do
 
   create_table "activities", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci", force: :cascade do |t|
     t.integer "user_id"
@@ -657,7 +657,7 @@ ActiveRecord::Schema.define(version: 2020_12_14_003529) do
     t.integer "lesson_id"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.string "key"
+    t.string "key", null: false
     t.index ["key"], name: "index_objectives_on_key", unique: true
     t.index ["lesson_id"], name: "index_objectives_on_lesson_id"
   end

--- a/dashboard/test/factories/factories.rb
+++ b/dashboard/test/factories/factories.rb
@@ -803,6 +803,7 @@ FactoryGirl.define do
   end
 
   factory :objective do
+    sequence(:key) {|n| "objective-#{n}"}
     description 'fake description'
   end
 

--- a/dashboard/test/models/objective_test.rb
+++ b/dashboard/test/models/objective_test.rb
@@ -4,6 +4,7 @@ class ObjectiveTest < ActiveSupport::TestCase
   test "can create objective" do
     objective = Objective.new
     objective.description = 'what I will learn'
+    objective.key = 'my-key'
     objective.save!
     objective.reload
     assert_equal 'what I will learn', objective.description
@@ -12,6 +13,7 @@ class ObjectiveTest < ActiveSupport::TestCase
   test "summarize" do
     objective = Objective.new
     objective.description = 'what I will learn'
+    objective.key = 'my-key'
     objective.save!
     objective.reload
     expected_summary = {id: objective.id, description: 'what I will learn'}


### PR DESCRIPTION
Follow-up from https://github.com/code-dot-org/code-dot-org/pull/38223#discussion_r543715668 . backfills development and adhoc environment with unique keys. omits test environment because (unlike resources) there are no objectives in our test fixtures, so most people probably won't have any of these.

## Testing story

ran the migration forward, backward and forward again in my local environment. 600+ objectives were backfilled with unique keys. I also verified that there are no objectives in my local test db, or on the `test` or `levelbuilder` machines. This gives a pretty good indication that the migration will succeed in all environments.

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
