### PR TITLE
2018-2019 school district import

### DIFF
--- a/dashboard/app/models/school_district.rb
+++ b/dashboard/app/models/school_district.rb
@@ -47,8 +47,8 @@ class SchoolDistrict < ApplicationRecord
       SchoolDistrict.transaction do
         merge_from_csv(school_districts_tsv)
       end
-    else
-      SchoolDistrict.seed_from_s3
+      #else
+      #SchoolDistrict.seed_from_s3
     end
   end
 

--- a/dashboard/app/models/school_district.rb
+++ b/dashboard/app/models/school_district.rb
@@ -26,6 +26,10 @@ class SchoolDistrict < ApplicationRecord
   #   via http://stackoverflow.com/questions/8073920/importing-csv-quoting-error-is-driving-me-nuts
   CSV_IMPORT_OPTIONS = {col_sep: "\t", headers: true, quote_char: "\x00"}.freeze
 
+  # School district statuses representing currently open districts in 2018-2019 import.
+  # Non-open statuses are 'Closed', 'Future', 'Inactive'
+  OPEN_SCHOOL_STATUSES = ['1-Open', '3-New', '8-Reopened', '5-Changed Boundary/Agency', '4-Added']
+
   # Gets the seeding file name.
   # @param stub_school_data [Boolean] True for stub file.
   def self.get_seed_filename(stub_school_data)

--- a/dashboard/app/models/school_district.rb
+++ b/dashboard/app/models/school_district.rb
@@ -103,7 +103,7 @@ class SchoolDistrict < ApplicationRecord
       import_options_1819 = {col_sep: ",", headers: true, quote_char: "\x00"}
       # Used table generator here to get columns of interest:
       # https://nces.ed.gov/ccd/elsi/tableGenerator.aspx
-      AWS::S3.seed_from_file('cdo-nces', "2018-2019/ccd/ELSI_csv_export_637423414304008909966.csv") do |filename|
+      AWS::S3.seed_from_file('cdo-nces', "2018-2019/ccd/ELSI_csv_export_6374544705259568713496.csv") do |filename|
         SchoolDistrict.merge_from_csv(filename, import_options_1819, true, new_attributes: ['last_known_school_year_open']) do |row|
           {
             id:                           row['Agency ID - NCES Assigned [District] Latest available year'].tr('"=', '').to_i,

--- a/dashboard/app/models/school_district.rb
+++ b/dashboard/app/models/school_district.rb
@@ -176,15 +176,16 @@ class SchoolDistrict < ApplicationRecord
       end
     end
 
+    future_tense_dry_run = is_dry_run ? ' to be' : ''
     summary_message = "School District seeding: done processing #{filename}.\n"\
-      "#{new_districts.length} new districts added.\n"\
-      "#{updated_districts} districts updated.\n"\
-      "#{unchanged_districts} districts unchanged (district considered changed if only update was adding new columns included in this import).\n"
+      "#{new_districts.length} new districts#{future_tense_dry_run} added.\n"\
+      "#{updated_districts} districts#{future_tense_dry_run} updated.\n"\
+      "#{unchanged_districts} districts#{future_tense_dry_run} unchanged (district considered changed if only update was adding new columns included in this import).\n"
 
     # More detailed logging in dry run mode
     if !new_districts.empty? && is_dry_run
       summary_message <<
-        "Districts added:\n"\
+        "Districts#{future_tense_dry_run} added:\n"\
         "#{new_districts.map {|district| district[:name]}.join("\n")}\n"
     end
 

--- a/dashboard/app/models/school_district.rb
+++ b/dashboard/app/models/school_district.rb
@@ -35,7 +35,7 @@ class SchoolDistrict < ApplicationRecord
   # Seeds all the data from the source file.
   # @param options [Hash] Optional map of options.
   def self.seed_all(options = {})
-    options[:stub_school_data] ||= CDO.stub_school_data
+    options[:stub_school_data] = CDO.stub_school_data unless options.key?(:stub_school_data)
 
     if options[:stub_school_data]
       # use a much smaller dataset in environments that reseed data frequently.

--- a/dashboard/app/models/school_district.rb
+++ b/dashboard/app/models/school_district.rb
@@ -52,7 +52,7 @@ class SchoolDistrict < ApplicationRecord
     SchoolDistrict.transaction do
       CDO.log.info "Seeding 2013-2014 school district data"
       AWS::S3.seed_from_file('cdo-nces', "2013-2014/ccd/ag131a_supp.txt") do |filename|
-        SchoolDistrict.merge_from_csv(filename, CSV_IMPORT_OPTIONS, false) do |row|
+        SchoolDistrict.merge_from_csv(filename) do |row|
           {
             id:    row['LEAID'].to_i,
             name:  row['NAME'].upcase,
@@ -65,7 +65,7 @@ class SchoolDistrict < ApplicationRecord
 
       CDO.log.info "Seeding 2014-2015 school district data"
       AWS::S3.seed_from_file('cdo-nces', "2014-2015/ccd/ccd_lea_029_1415_w_0216161ar.txt") do |filename|
-        SchoolDistrict.merge_from_csv(filename, CSV_IMPORT_OPTIONS, false) do |row|
+        SchoolDistrict.merge_from_csv(filename) do |row|
           {
             id:    row['LEAID'].to_i,
             name:  row['LEA_NAME'].upcase,
@@ -76,6 +76,11 @@ class SchoolDistrict < ApplicationRecord
         end
       end
 
+      # Note this iteration was never run with write_updates set to true,
+      # meaning that school districts that had updates in this iteration
+      # (but were not new) were not completed.
+      # That said, (presumably) most relevant updates were
+      # completed in the subsequent upload for 2018-2019.
       CDO.log.info "Seeding 2017-2018 school district data"
       import_options_1718 = {col_sep: ",", headers: true, quote_char: "\x00"}
       AWS::S3.seed_from_file('cdo-nces', "2017-2018/ccd/ccd_lea_029_1718_w_0a_03302018.csv") do |filename|


### PR DESCRIPTION
Import newest set of school districts from the National Center for Education Statistics, for the 2018-2019 school year.

Currently, this new file will be seeded the next time our seeing process runs (I think when we next deploy?). Last time we did this, we [commented out the seeding step for school districts](https://github.com/code-dot-org/code-dot-org/blob/staging/dashboard/app/models/school_district.rb#L48) so we could seed the file manually (in order that we could keep a close eye on what happened, but also to not slow down the deploy), but since we're separating the seeding of new school districts (about 20% of the size of schools) from schools, it might be ok just to let it run as part of the deploy.

## Testing story

I reseeded my local school districts table from scratch to 19,661 rows (19,668 rows in production -- this diff is expected per [exploration done the last time we did this](https://github.com/code-dot-org/code-dot-org/pull/25707)). Then, I dry ran the import via:

```
parse_row = proc do |row|
  {
    id:                           row['Agency ID - NCES Assigned [District] Latest available year'].tr('"=', '').to_i,
    name:                         row['Agency Name'].upcase,
    city:                         row['Location City [District] 2018-19'].to_s.upcase.presence,
    state:                        row['Location State Abbr [District] 2018-19'].strip.to_s.upcase.presence,
    zip:                          row['Location ZIP [District] 2018-19'].tr('"=', ''),
    last_known_school_year_open:  '2018-2019'
  }
end

SchoolDistrict.seed_s3_object('cdo-nces', '2018-2019/ccd/ELSI_csv_export_637423414304008909966.csv', {headers: true, encoding: 'ISO-8859-1:UTF-8', quote_char: "\x00"}, is_dry_run: true, new_attributes: ['last_known_school_year_open'], &parse_row)

School District seeding: done processing /var/folders/xp/9jb41z0n0y1fc7c_g45tgsqc0000gn/T/ELSI_csv_export_6374544705259568713496.csv.20201216-16660-b5jqqi.
1230 new districts to be added.
2079 districts to be updated.
16272 districts to be unchanged (district considered changed if only update was adding new columns included in this import).
Districts to be added:
ACADEMIA AVANCE CHARTER DISTRICT
ACADEMIA MODERNA DISTRICT
ACADEMY CHARTER SCHOOL-UNIONDALE (THE)
ACADEMY FOR ACADEMIC EXCELLENCE DISTRICT
...
```

Then, I seeded the new file for real:

```
SchoolDistrict.seed_s3_object('cdo-nces', '2018-2019/ccd/ELSI_csv_export_6374544705259568713496.csv', {headers: true, encoding: 'ISO-8859-1:UTF-8', quote_char: "\x00"}, new_attributes: ['last_known_school_year_open'], &parse_row)

School District seeding: done processing /var/folders/xp/9jb41z0n0y1fc7c_g45tgsqc0000gn/T/ELSI_csv_export_6374544705259568713496.csv.20210108-50195-1baoqog.
1230 new districts added.
2079 districts updated.
16272 districts unchanged (district considered changed if only update was adding new columns included in this import).
```

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
