### PR TITLE
Use S3 to store Drone Build logs instead of the Drone Server database

### DIFF
--- a/aws/cloudformation/drone-stack.yml
+++ b/aws/cloudformation/drone-stack.yml
@@ -257,6 +257,9 @@ Resources:
               Value: true
             # Store Drone Build logs in S3 instead of in a blob column in the logs table in the Drone Server relational database.
             -
+              Name: AWS_REGION
+              Value: !Ref AWS::Region
+            -
               Name: DRONE_S3_BUCKET
               Value: code-dot-org
             -

--- a/aws/cloudformation/drone-stack.yml
+++ b/aws/cloudformation/drone-stack.yml
@@ -192,6 +192,7 @@ Resources:
       RequiresCompatibilities:
         - EC2
       ExecutionRoleArn: !Sub "arn:aws:iam::${AWS::AccountId}:role/DroneEcsTaskExecutionRole"
+      TaskRoleArn: !Sub "arn:aws:iam::${AWS::AccountId}:role/DroneServer"
       Volumes:
         -
           Name: db-data
@@ -254,6 +255,13 @@ Resources:
             -
               Name: DRONE_SERVER_PRIVATE_MODE
               Value: true
+            # Store Drone Build logs in S3 instead of in a blob column in the logs table in the Drone Server relational database.
+            -
+              Name: DRONE_S3_BUCKET
+              Value: code-dot-org
+            -
+              Name: DRONE_S3_PREFIX
+              Value: /drone-build-logs/
 
   DroneMasterEcsService:
     Type: AWS::ECS::Service

--- a/aws/cloudformation/drone-stack.yml
+++ b/aws/cloudformation/drone-stack.yml
@@ -257,6 +257,9 @@ Resources:
               Value: true
             # Store Drone Build logs in S3 instead of in a blob column in the logs table in the Drone Server relational database.
             -
+              Name: AWS_DEFAULT_REGION
+              Value: us-east-1
+            -
               Name: AWS_REGION
               Value: us-east-1
             -

--- a/aws/cloudformation/drone-stack.yml
+++ b/aws/cloudformation/drone-stack.yml
@@ -258,7 +258,7 @@ Resources:
             # Store Drone Build logs in S3 instead of in a blob column in the logs table in the Drone Server relational database.
             -
               Name: AWS_REGION
-              Value: !Ref AWS::Region
+              Value: us-east-1
             -
               Name: DRONE_S3_BUCKET
               Value: code-dot-org


### PR DESCRIPTION
Our self-hosted Drone infrastructure stores both build configuration and build logs in a SQLite database on the file system of the EC2 Instance that hosts the Drone Server container. Configure Drone Server to store the text contents of Drone Builds in S3 instead of a [BLOB column](https://github.com/drone/drone/blob/778d0a0aff2053faffbf5b174ebf07ed71257eb5/store/shared/migrate/sqlite/ddl_gen.go#L488) in the `logs` table. This mitigates the quickly growing size of the Drone Server database file (we've had 2 outages in the last 2 years due to the database consuming all storage) and possibly resolves[ a recent issue](https://codedotorg.slack.com/archives/C0T0PNTM3/p1608159097297000?thread_ts=1608136244.251400&cid=C0T0PNTM3) where many Drone Builds with a change to the apps package are having the logs of the "Unit Tests" Drone build step abruptly cut off. 

<!-- ### Background -->
<!-- ### Privacy -->
<!--
1.	Does the Project involve the collection, use or sharing of new Personal Data?

2.	Does the Project involve a new or changed use or sharing of existing Personal Data?
-->
### Security

The `DroneServer` ECS Task Role and the Policies assigned to it were created manually in the web console and not in this CloudFormation template. They only grant read/write access to an S3 bucket that only contains Drone logs and Drone build cache files.

<!-- ### Caching -->
<!-- ### Deployment strategy -->
<!-- ### Future work -->

## Links

<!--
  Any relevant links to external resources; ie, specification documents, jira
  items, related PRs, honeybadger errors, etc
-->

- [spec]()
- [jira]()

## Testing story

<!--
  Does your change include appropriate tests?

  If so, please describe how the tests included in this PR are sufficient

  If not, please explain why this change does not need to be tested.
-->

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
