### PR TITLE
add key to new objectives in lesson import

### DIFF
--- a/lib/cdo/lesson_import_helper.rb
+++ b/lib/cdo/lesson_import_helper.rb
@@ -40,7 +40,7 @@ module LessonImportHelper
       lesson.creative_commons_license = cb_lesson_data['creative_commons_license']
       lesson.assessment_opportunities = cb_lesson_data['assessment'] unless cb_lesson_data['assessment'].blank?
       lesson.objectives = cb_lesson_data['objectives'].map do |o|
-        Objective.new(description: o["name"])
+        Objective.new(key: SecureRandom.uuid, description: o["name"])
       end
       lesson.lesson_activities = create_lesson_activities(cb_lesson_data['activities'], lesson_levels, lesson)
       lesson.resources = create_lesson_resources(cb_lesson_data['resources'], course_version_id)


### PR DESCRIPTION
https://github.com/code-dot-org/code-dot-org/pull/38287 broke import. This PR fixes it.

## Testing story

Manually verified that the following command, which failed before, now succeeds:
```
bundle exec ./bin/oneoff/import_unit_details.rb -l -u coursed-2021 -v
```

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
