### PR TITLE
Make related lessons work when version year is missing

### DIFF
--- a/apps/src/lib/levelbuilder/lesson-editor/RelatedLessons.jsx
+++ b/apps/src/lib/levelbuilder/lesson-editor/RelatedLessons.jsx
@@ -27,7 +27,8 @@ export default class RelatedLessons extends Component {
   };
 
   getRelatedLessonText(lesson) {
-    const includeYear = !lesson.scriptTitle.includes(lesson.versionYear);
+    const includeYear =
+      lesson.versionYear && !lesson.scriptTitle.includes(lesson.versionYear);
     const year = includeYear ? ` - ${lesson.versionYear}` : '';
     const type = lesson.lockable ? 'Lockable' : 'Lesson';
     return `${lesson.scriptTitle}${year} - ${type} ${lesson.relativePosition}`;

--- a/apps/src/lib/levelbuilder/shapes.jsx
+++ b/apps/src/lib/levelbuilder/shapes.jsx
@@ -122,7 +122,7 @@ export const lessonGroupShape = PropTypes.shape({
 
 export const relatedLessonShape = PropTypes.shape({
   scriptTitle: PropTypes.string.isRequired,
-  versionYear: PropTypes.string.isRequired,
+  versionYear: PropTypes.string,
   lockable: PropTypes.bool,
   relativePosition: PropTypes.number.isRequired,
   id: PropTypes.number.isRequired,

--- a/apps/test/unit/lib/levelbuilder/lesson-editor/RelatedLessonsTest.jsx
+++ b/apps/test/unit/lib/levelbuilder/lesson-editor/RelatedLessonsTest.jsx
@@ -23,6 +23,13 @@ describe('RelatedLessons', () => {
           relativePosition: 2,
           id: 456,
           editUrl: '/lessons/456/edit'
+        },
+        {
+          scriptTitle: 'Course 1',
+          lockable: null,
+          relativePosition: 4,
+          id: 789,
+          editUrl: '/lessons/789/edit'
         }
       ]
     };
@@ -35,13 +42,18 @@ describe('RelatedLessons', () => {
       'The following lessons are similar to this one.'
     );
 
-    const link1 = wrapper.find('a').first();
+    const link1 = wrapper.find('a').at(0);
     expect(link1.props().href).to.equal('/lessons/123/edit');
     expect(link1.text()).to.equal('Course A - 2017 - Lesson 3');
 
-    const link2 = wrapper.find('a').last();
+    const link2 = wrapper.find('a').at(1);
     expect(link2.props().href).to.equal('/lessons/456/edit');
     // Redundant version year is omitted
     expect(link2.text()).to.equal('Express (2019) - Lesson 2');
+
+    const link3 = wrapper.find('a').at(2);
+    expect(link3.props().href).to.equal('/lessons/789/edit');
+    // Missing version year is omitted
+    expect(link3.text()).to.equal('Course 1 - Lesson 4');
   });
 });

--- a/dashboard/app/models/lesson.rb
+++ b/dashboard/app/models/lesson.rb
@@ -571,7 +571,7 @@ class Lesson < ApplicationRecord
     related_lessons.map do |lesson|
       {
         scriptTitle: lesson.script.localized_title,
-        versionYear: lesson.script.get_course_version.version_year,
+        versionYear: lesson.script.get_course_version&.version_year,
         lockable: lesson.lockable,
         relativePosition: lesson.relative_position,
         id: lesson.id,

--- a/dashboard/test/models/lesson_test.rb
+++ b/dashboard/test/models/lesson_test.rb
@@ -351,6 +351,7 @@ class LessonTest < ActiveSupport::TestCase
   test 'find related lessons within CSF curriculum umbrella' do
     course_offering = create :course_offering
 
+    # lesson to find related lessons for
     script1 = create :script, name: 'script1', curriculum_umbrella: 'CSF', version_year: '2999'
     create :course_version, course_offering: course_offering, content_root: script1, key: '2999'
     lesson1 = create :lesson, script: script1, key: 'foo'
@@ -359,11 +360,13 @@ class LessonTest < ActiveSupport::TestCase
     create :course_version, course_offering: course_offering, content_root: script2, key: '3000'
     lesson2 = create :lesson, script: script2, key: 'foo'
 
+    # lesson with different key is excluded
     course_offering3 = create :course_offering
     script3 = create :script, name: 'script3', curriculum_umbrella: 'CSF', version_year: '2999'
     create :course_version, course_offering: course_offering3, content_root: script3, key: '2999'
     create :lesson, script: script3, key: 'bar'
 
+    # lesson in different curriculum umbrella is excluded
     course_offering4 = create :course_offering
     script4 = create :script, name: 'script4', curriculum_umbrella: 'other', version_year: '2999'
     create :course_version, course_offering: course_offering4, content_root: script4, key: '2999'
@@ -374,6 +377,10 @@ class LessonTest < ActiveSupport::TestCase
     create :course_version, course_offering: course_offering5, content_root: script5, key: '2999'
     lesson5 = create :lesson, script: script5, key: 'foo'
 
+    # lesson without course version / version year must still work properly
+    script6 = create :script, name: 'script6', curriculum_umbrella: 'CSF'
+    lesson6 = create :lesson, script: script6, key: 'foo'
+
     course_offering0 = create :course_offering
     script0 = create :script, name: 'script0', curriculum_umbrella: 'CSF', version_year: '2999'
     create :course_version, course_offering: course_offering0, content_root: script0, key: '2999'
@@ -383,15 +390,25 @@ class LessonTest < ActiveSupport::TestCase
     # of related_lessons, so that the count is not artificially reduced by
     # anything being cached from the call to related_lessons.
     summaries = nil
-    assert_queries(1) do
+    assert_queries(2) do
       summaries = lesson1.summarize_related_lessons
     end
 
     assert_queries(1) do
-      assert_equal [lesson0, lesson5, lesson2], lesson1.related_lessons
+      assert_equal [lesson6, lesson0, lesson5, lesson2], lesson1.related_lessons
     end
 
-    assert_equal 3, summaries.count
+    assert_equal 4, summaries.count
+    expected_summary = {
+      scriptTitle: "translation missing: en-US.data.script.name.script6.title",
+      versionYear: nil,
+      lockable: false,
+      relativePosition: 1,
+      id: lesson6.id,
+      editUrl: "/lessons/#{lesson6.id}/edit"
+    }
+    assert_equal expected_summary, summaries[0]
+
     expected_summary = {
       scriptTitle: "translation missing: en-US.data.script.name.script0.title",
       versionYear: "2999",
@@ -400,10 +417,10 @@ class LessonTest < ActiveSupport::TestCase
       id: lesson0.id,
       editUrl: "/lessons/#{lesson0.id}/edit"
     }
-    assert_equal expected_summary, summaries[0]
+    assert_equal expected_summary, summaries[1]
 
-    assert_equal '2999', summaries[1][:versionYear]
-    assert_equal '3000', summaries[2][:versionYear]
+    assert_equal '2999', summaries[2][:versionYear]
+    assert_equal '3000', summaries[3][:versionYear]
   end
 
   test 'find related lessons within a course offering without unit groups' do


### PR DESCRIPTION
Some lessons in CSF weren't editable because they had "related lessons" in courses like course1 or 20-hour, which did not have version years, which caused a server error. This PR fixes those lessons by handling the case where no version year is present.

Course D 2021 Lesson 3, before:

<img width="431" alt="Screen Shot 2020-12-16 at 5 38 54 PM" src="https://user-images.githubusercontent.com/8001765/102452902-0a279800-3ff0-11eb-8abf-2031ec19a159.png">

Course D 2021 Lesson 3, after:

![Screen Shot 2020-12-16 at 10 40 15 PM](https://user-images.githubusercontent.com/8001765/102452881-fd0aa900-3fef-11eb-8814-7dc30c41600a.png)

## Testing story

expanded unit test coverage, plus manual testing shown in screenshots.

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
