### PR TITLE
Show LessonGroup for teacher if there are no lessons

### DIFF
--- a/apps/src/templates/progress/LessonGroup.jsx
+++ b/apps/src/templates/progress/LessonGroup.jsx
@@ -14,6 +14,7 @@ import color from '@cdo/apps/util/color';
 import LessonGroupInfoDialog from '@cdo/apps/templates/progress/LessonGroupInfoDialog';
 import firehoseClient from '@cdo/apps/lib/util/firehose';
 import {lessonIsVisible} from './progressHelpers';
+import {ViewType} from '@cdo/apps/code-studio/viewAsRedux';
 
 const styles = {
   main: {
@@ -65,7 +66,8 @@ class LessonGroup extends React.Component {
 
     // redux provided
     scriptId: PropTypes.number,
-    lessonIsVisible: PropTypes.func.isRequired
+    lessonIsVisible: PropTypes.func.isRequired,
+    viewAs: PropTypes.oneOf(Object.values(ViewType)).isRequired
   };
 
   state = {
@@ -112,7 +114,8 @@ class LessonGroup extends React.Component {
       levelsByLesson,
       isSummaryView,
       isPlc,
-      lessonIsVisible
+      lessonIsVisible,
+      viewAs
     } = this.props;
 
     const TableType = isSummaryView
@@ -121,7 +124,7 @@ class LessonGroup extends React.Component {
 
     const hasVisibleLesson = lessons.some(lesson => lessonIsVisible(lesson));
 
-    if (!hasVisibleLesson) {
+    if (!hasVisibleLesson && viewAs === ViewType.Student) {
       return null;
     }
 
@@ -174,5 +177,6 @@ export const UnconnectedLessonGroup = LessonGroup;
 
 export default connect(state => ({
   scriptId: state.progress.scriptId,
-  lessonIsVisible: lesson => lessonIsVisible(lesson, state, state.viewAs)
+  lessonIsVisible: lesson => lessonIsVisible(lesson, state, state.viewAs),
+  viewAs: state.viewAs
 }))(Radium(LessonGroup));

--- a/apps/src/templates/progress/LessonGroup.story.jsx
+++ b/apps/src/templates/progress/LessonGroup.story.jsx
@@ -91,6 +91,25 @@ export default storybook => {
     },
 
     {
+      name: 'LessonGroup with no lessons teacher summary view',
+      story: () => (
+        <Provider store={createStoreWithHiddenLesson(ViewType.Teacher, 1)}>
+          <LessonGroup
+            lessonGroup={{
+              displayName: 'My Group',
+              description: 'Lesson Group Description',
+              bigQuestions: 'Why? Who? Where?'
+            }}
+            isPlc={false}
+            isSummaryView={true}
+            lessons={[]}
+            levelsByLesson={[]}
+          />
+        </Provider>
+      )
+    },
+
+    {
       name: 'LessonGroup with all lessons hidden student summary view (empty)',
       story: () => (
         <Provider store={createStoreWithHiddenLesson(ViewType.Student, 1)}>

--- a/apps/test/unit/templates/progress/LessonGroupTest.jsx
+++ b/apps/test/unit/templates/progress/LessonGroupTest.jsx
@@ -3,6 +3,7 @@ import {expect} from '../../../util/reconfiguredChai';
 import {shallow} from 'enzyme';
 import {UnconnectedLessonGroup as LessonGroup} from '@cdo/apps/templates/progress/LessonGroup';
 import {fakeLesson} from '@cdo/apps/templates/progress/progressTestHelpers';
+import {ViewType} from '@cdo/apps/code-studio/viewAsRedux';
 
 const DEFAULT_PROPS = {
   isPlc: false,
@@ -15,7 +16,8 @@ const DEFAULT_PROPS = {
   },
   lessons: [fakeLesson('lesson1', 1)],
   levelsByLesson: [],
-  lessonIsVisible: () => true
+  lessonIsVisible: () => true,
+  viewAs: ViewType.Teacher
 };
 
 describe('LessonGroup', () => {
@@ -42,13 +44,34 @@ describe('LessonGroup', () => {
     const wrapper = shallow(<LessonGroup {...props} />);
     expect(wrapper.find('FontAwesome')).to.have.lengthOf(1);
   });
-  it('does not render if there are no visible lessons', () => {
+  it('does not render in student view if there are no visible lessons', () => {
     const props = {
       ...DEFAULT_PROPS,
       isSummaryView: true,
-      lessonIsVisible: () => false
+      lessonIsVisible: () => false,
+      viewAs: ViewType.Student
     };
     const wrapper = shallow(<LessonGroup {...props} />);
     expect(wrapper.get(0)).to.be.null;
+  });
+  it('does not render in student view if there are no lessons', () => {
+    const props = {
+      ...DEFAULT_PROPS,
+      isSummaryView: true,
+      lessons: [],
+      viewAs: ViewType.Student
+    };
+    const wrapper = shallow(<LessonGroup {...props} />);
+    expect(wrapper.get(0)).to.be.null;
+  });
+  it('does render in teacher view if there are no lessons', () => {
+    const props = {
+      ...DEFAULT_PROPS,
+      isSummaryView: true,
+      lessons: [],
+      viewAs: ViewType.Teacher
+    };
+    const wrapper = shallow(<LessonGroup {...props} />);
+    expect(wrapper.get(0)).to.not.be.null;
   });
 });


### PR DESCRIPTION
<!--
  Your description goes here: A summary of the change, including any relevant motivation and context.

  If relevant, include a description both of the existing behavior and of the new behavior.
-->
(This was a bug created by the solution for https://codedotorg.atlassian.net/browse/LP-1697)
Show the LessonGroup even if there are no lessons in the teacher view.
<!--
  Other aspects to consider. uncomment and add detail for any that seem necessary:
-->
<img width="1055" alt="Screen Shot 2020-12-18 at 10 52 53 AM" src="https://user-images.githubusercontent.com/24235215/102650128-40b00080-411f-11eb-903c-57bc6772d884.png">


<!-- ### Background -->
<!-- ### Privacy -->
<!--
1.	Does the Project involve the collection, use or sharing of new Personal Data?

2.	Does the Project involve a new or changed use or sharing of existing Personal Data?
-->
<!-- ### Security -->
<!--
Link to Jira Task where sensitive security issues are discussed privately.
-->
<!-- ### Caching -->
<!-- ### Deployment strategy -->
<!-- ### Future work -->

## Links

<!--
  Any relevant links to external resources; ie, specification documents, jira
  items, related PRs, honeybadger errors, etc
-->
https://codedotorg.atlassian.net/browse/LP-1697

- [spec]()
- [jira]()

## Testing story

<!--
  Does your change include appropriate tests?

  If so, please describe how the tests included in this PR are sufficient

  If not, please explain why this change does not need to be tested.
-->
I've added 2 unit tests which check that if there are no lessons that the LessonGroup will render for the teacher and will not render for the student.

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
