### PR TITLE
Migrated level IDs to strings

### DIFF
--- a/apps/src/code-studio/components/header/HeaderMiddle.jsx
+++ b/apps/src/code-studio/components/header/HeaderMiddle.jsx
@@ -33,7 +33,7 @@ class HeaderMiddle extends React.Component {
     scriptNameData: PropTypes.object,
     lessonData: PropTypes.object,
     scriptData: PropTypes.object,
-    currentLevelId: PropTypes.number,
+    currentLevelId: PropTypes.string,
     linesOfCodeText: PropTypes.string,
     isRtl: PropTypes.bool
   };

--- a/apps/src/code-studio/components/header/HeaderPopup.jsx
+++ b/apps/src/code-studio/components/header/HeaderPopup.jsx
@@ -26,7 +26,7 @@ export default class HeaderPopup extends Component {
   static propTypes = {
     scriptName: PropTypes.string,
     scriptData: PropTypes.object,
-    currentLevelId: PropTypes.number,
+    currentLevelId: PropTypes.string,
     linesOfCodeText: PropTypes.string,
     minimal: PropTypes.bool,
     windowHeight: PropTypes.number

--- a/apps/src/code-studio/components/lessonExtras/LessonExtras.story.jsx
+++ b/apps/src/code-studio/components/lessonExtras/LessonExtras.story.jsx
@@ -35,7 +35,7 @@ export default storybook => {
               stageNumber: 1,
               levels: [
                 {
-                  id: 23222,
+                  id: '23222',
                   display_name: 'courseB_maze_seq_challenge1',
                   url:
                     'http://studio.code.org:3000/s/coursef-2019/stage/1/extras?level_name=courseC_artist_prog_challenge1',
@@ -59,7 +59,7 @@ export default storybook => {
                   }
                 },
                 {
-                  id: 23223,
+                  id: '23223',
                   display_name: 'courseB_maze_seq_challenge1',
                   url:
                     'http://studio.code.org:3000/s/coursef-2019/stage/1/extras?level_name=courseC_artist_prog_challenge1',
@@ -88,7 +88,7 @@ export default storybook => {
               stageNumber: 2,
               levels: [
                 {
-                  id: 23224,
+                  id: '23224',
                   display_name: 'courseC_artist_prog_challenge1',
                   url:
                     'http://studio.code.org:3000/s/coursef-2019/stage/1/extras?level_name=courseC_artist_prog_challenge1',
@@ -98,7 +98,7 @@ export default storybook => {
                   perfect: false
                 },
                 {
-                  id: 23225,
+                  id: '23225',
                   display_name: 'courseC_PlayLab_events_challenge1',
                   url:
                     'http://studio.code.org:3000/s/coursef-2019/stage/1/extras?level_name=courseC_artist_prog_challenge1',
@@ -113,7 +113,7 @@ export default storybook => {
               stageNumber: 3,
               levels: [
                 {
-                  id: 23226,
+                  id: '23226',
                   display_name: 'courseC_artist_prog_challenge1',
                   url:
                     'http://studio.code.org:3000/s/coursef-2019/stage/1/extras?level_name=courseC_artist_prog_challenge1',
@@ -123,7 +123,7 @@ export default storybook => {
                   perfect: false
                 },
                 {
-                  id: 23227,
+                  id: '23227',
                   display_name: 'courseB_maze_seq_challenge2',
                   url:
                     'http://studio.code.org:3000/s/coursef-2019/stage/1/extras?level_name=courseC_artist_prog_challenge1',
@@ -147,7 +147,7 @@ export default storybook => {
                   }
                 },
                 {
-                  id: 23228,
+                  id: '23228',
                   display_name: 'courseC_PlayLab_events_challenge1',
                   url:
                     'http://studio.code.org:3000/s/coursef-2019/stage/1/extras?level_name=courseC_artist_prog_challenge1',

--- a/apps/src/code-studio/components/lessonExtras/shapes.js
+++ b/apps/src/code-studio/components/lessonExtras/shapes.js
@@ -1,7 +1,7 @@
 import PropTypes from 'prop-types';
 
 export const bonusLevel = {
-  id: PropTypes.number.isRequired,
+  id: PropTypes.string.isRequired,
   display_name: PropTypes.string.isRequired,
   description: PropTypes.string,
   thumbnail_url: PropTypes.string,

--- a/apps/src/code-studio/components/progress/LessonProgress.jsx
+++ b/apps/src/code-studio/components/progress/LessonProgress.jsx
@@ -83,9 +83,7 @@ class LessonProgress extends Component {
     lessonTrophyEnabled: PropTypes.bool,
     width: PropTypes.number,
     setDesiredWidth: PropTypes.func,
-    // currentPageNumber is intentionally a string since it gets used
-    // as a string in the URL
-    currentPageNumber: PropTypes.string
+    currentPageNumber: PropTypes.number
   };
 
   getFullWidth() {

--- a/apps/src/code-studio/components/progress/LessonProgress.jsx
+++ b/apps/src/code-studio/components/progress/LessonProgress.jsx
@@ -203,11 +203,7 @@ class LessonProgress extends Component {
             {lessonTrophyEnabled && <div style={styles.spacer} />}
             {levels.map((level, index) => {
               let isCurrent = level.isCurrentLevel;
-              if (
-                isCurrent &&
-                level.kind === LevelKind.assessment &&
-                level.pageNumber
-              ) {
+              if (isCurrent && level.kind === LevelKind.assessment) {
                 isCurrent = currentPageNumber === level.pageNumber;
               }
               return (

--- a/apps/src/code-studio/components/progress/LessonProgress.jsx
+++ b/apps/src/code-studio/components/progress/LessonProgress.jsx
@@ -83,7 +83,9 @@ class LessonProgress extends Component {
     lessonTrophyEnabled: PropTypes.bool,
     width: PropTypes.number,
     setDesiredWidth: PropTypes.func,
-    currentPageNumber: PropTypes.number
+    // currentPageNumber is intentionally a string since it gets used
+    // as a string in the URL
+    currentPageNumber: PropTypes.string
   };
 
   getFullWidth() {

--- a/apps/src/code-studio/components/progress/LessonProgress.story.jsx
+++ b/apps/src/code-studio/components/progress/LessonProgress.story.jsx
@@ -11,8 +11,8 @@ import progress, {
 import {TestResults} from '@cdo/apps/constants';
 
 const activityPuzzle = {
-  ids: [123],
-  activeId: 123,
+  ids: ['123'],
+  activeId: '123',
   position: 1,
   kind: 'puzzle',
   icon: '',
@@ -23,8 +23,8 @@ const activityPuzzle = {
 };
 
 const conceptPuzzle = {
-  ids: [5086],
-  activeId: 5086,
+  ids: ['5086'],
+  activeId: '5086',
   position: 2,
   kind: 'puzzle',
   icon: 'fa-file-text',
@@ -36,8 +36,8 @@ const conceptPuzzle = {
 };
 
 const assessment1 = {
-  ids: [2441],
-  activeId: 2441,
+  ids: ['2441'],
+  activeId: '2441',
   position: 3,
   kind: 'assessment',
   icon: 'fa-check-square-o',
@@ -48,8 +48,8 @@ const assessment1 = {
 };
 
 const assessment2 = {
-  ids: [2444],
-  activeId: 2444,
+  ids: ['2444'],
+  activeId: '2444',
   position: 4,
   kind: 'assessment',
   icon: 'fa-check-square-o',
@@ -60,8 +60,8 @@ const assessment2 = {
 };
 
 const assessment3 = {
-  ids: [2744],
-  activeId: 2744,
+  ids: ['2744'],
+  activeId: '2744',
   position: 5,
   kind: 'assessment',
   icon: 'fa-check-square-o',
@@ -72,11 +72,10 @@ const assessment3 = {
 };
 
 const unplugged = {
-  ids: [2093],
-  activeId: 2093,
+  ids: ['2093'],
+  activeId: '2093',
   is_concept_level: false,
   kind: 'unplugged',
-  // kind: 'puzzle',
   position: 1,
   title: 1,
   url: 'http://studio.code.org/s/course1/stage/1/puzzle/1'

--- a/apps/src/code-studio/components/progress/SelectedStudentInfo.jsx
+++ b/apps/src/code-studio/components/progress/SelectedStudentInfo.jsx
@@ -3,7 +3,6 @@ import React from 'react';
 import i18n from '@cdo/locale';
 import {TeacherPanelProgressBubble} from '@cdo/apps/code-studio/components/progress/TeacherPanelProgressBubble';
 import Button from '@cdo/apps/templates/Button';
-import {levelType} from '@cdo/apps/templates/progress/progressTypes';
 import {LevelStatus} from '@cdo/apps/util/sharedConstants';
 import Radium from 'radium';
 import FontAwesome from '@cdo/apps/templates/FontAwesome';
@@ -48,14 +47,18 @@ export class SelectedStudentInfo extends React.Component {
   static propTypes = {
     students: PropTypes.arrayOf(studentShape).isRequired,
     selectedStudent: PropTypes.object,
-    level: levelType,
+    // While this userLevel object does have the properties of a levelType,
+    // it is conceptually more similar to a userLevel object. For example,
+    // the id property of this object is the user_level id. To get the level
+    // id, use the level_id property.
+    userLevel: PropTypes.object,
     onSelectUser: PropTypes.func.isRequired,
     getSelectedUserId: PropTypes.func.isRequired
   };
 
   onUnsubmit = () => {
     $.ajax({
-      url: `/user_levels/${this.props.level.id}`,
+      url: `/user_levels/${this.props.userLevel.id}`,
       method: 'PUT',
       data: {
         user_level: {
@@ -73,7 +76,7 @@ export class SelectedStudentInfo extends React.Component {
 
   onClearResponse = () => {
     $.ajax({
-      url: `/user_levels/${this.props.level.id}`,
+      url: `/user_levels/${this.props.userLevel.id}`,
       method: 'DELETE'
     })
       .done(data => {
@@ -112,7 +115,7 @@ export class SelectedStudentInfo extends React.Component {
   };
 
   render() {
-    const {selectedStudent, level} = this.props;
+    const {selectedStudent, userLevel} = this.props;
 
     return (
       <div style={styles.main}>
@@ -123,40 +126,40 @@ export class SelectedStudentInfo extends React.Component {
         />
         <div style={styles.studentInfo}>
           <div style={styles.name}>{selectedStudent.name}</div>
-          {level.paired && (
+          {userLevel.paired && (
             <div>
               <div>{i18n.workedWith()}</div>
-              {level.navigator && (
-                <div key={level.navigator}>
-                  {i18n.partner({partner: level.navigator})}
+              {userLevel.navigator && (
+                <div key={userLevel.navigator}>
+                  {i18n.partner({partner: userLevel.navigator})}
                 </div>
               )}
-              {level.driver && (
-                <div key={level.driver}>
-                  {i18n.loggedIn({partner: level.driver})}
+              {userLevel.driver && (
+                <div key={userLevel.driver}>
+                  {i18n.loggedIn({partner: userLevel.driver})}
                 </div>
               )}
             </div>
           )}
           <div style={styles.bubble}>
-            <TeacherPanelProgressBubble level={level} />
+            <TeacherPanelProgressBubble userLevel={userLevel} />
           </div>
-          {!level.submitLevel && (
+          {!userLevel.submitLevel && (
             <div>
               <div style={styles.timeHeader}>{i18n.lastUpdatedNoTime()}</div>
               <div>
-                {level.status !== LevelStatus.not_tried
-                  ? new Date(level.updated_at).toLocaleString()
+                {userLevel.status !== LevelStatus.not_tried
+                  ? new Date(userLevel.updated_at).toLocaleString()
                   : i18n.notApplicable()}
               </div>
             </div>
           )}
-          {level.submitLevel && (
+          {userLevel.submitLevel && (
             <div>
               <div style={styles.timeHeader}>{i18n.submittedOn()}</div>
               <div>
-                {level.status === LevelStatus.submitted
-                  ? new Date(level.updated_at).toLocaleString()
+                {userLevel.status === LevelStatus.submitted
+                  ? new Date(userLevel.updated_at).toLocaleString()
                   : i18n.notApplicable()}
               </div>
               <Button
@@ -165,7 +168,7 @@ export class SelectedStudentInfo extends React.Component {
                 color="blue"
                 onClick={this.onUnsubmit}
                 id="unsubmit-button-uitest"
-                disabled={level.status !== LevelStatus.submitted}
+                disabled={userLevel.status !== LevelStatus.submitted}
               />
             </div>
           )}

--- a/apps/src/code-studio/components/progress/StudentTable.jsx
+++ b/apps/src/code-studio/components/progress/StudentTable.jsx
@@ -3,7 +3,6 @@ import PropTypes from 'prop-types';
 import Radium from 'radium';
 import color from '@cdo/apps/util/color';
 import i18n from '@cdo/locale';
-import {levelType} from '@cdo/apps/templates/progress/progressTypes';
 import {TeacherPanelProgressBubble} from '@cdo/apps/code-studio/components/progress/TeacherPanelProgressBubble';
 import FontAwesome from '@cdo/apps/templates/FontAwesome';
 
@@ -63,7 +62,11 @@ class StudentTable extends React.Component {
     students: PropTypes.arrayOf(studentShape).isRequired,
     onSelectUser: PropTypes.func.isRequired,
     getSelectedUserId: PropTypes.func.isRequired,
-    levels: PropTypes.arrayOf(levelType),
+    // While this userLevels object does have the properties of a levelType,
+    // it is conceptually more similar to a userLevel object. For example,
+    // the id property of this object is the user_level id. To get the level
+    // id, use the level_id property.
+    userLevels: PropTypes.arrayOf(PropTypes.object),
     sectionId: PropTypes.number,
     scriptName: PropTypes.string
   };
@@ -72,10 +75,10 @@ class StudentTable extends React.Component {
     let url;
     const queryStr = `?section_id=${this.props.sectionId}&user_id=${studentId}`;
 
-    if (this.props.levels) {
-      url = this.props.levels[0].bonus
+    if (this.props.userLevels) {
+      url = this.props.userLevels[0].bonus
         ? 'extras'
-        : this.props.levels[0].levelNumber;
+        : this.props.userLevels[0].levelNumber;
     } else {
       url = this.props.scriptName;
     }
@@ -93,7 +96,7 @@ class StudentTable extends React.Component {
   };
 
   render() {
-    const {students, onSelectUser, getSelectedUserId, levels} = this.props;
+    const {students, onSelectUser, getSelectedUserId, userLevels} = this.props;
     const selectedUserId = getSelectedUserId();
 
     return (
@@ -113,13 +116,17 @@ class StudentTable extends React.Component {
             >
               <td key={`td-${student.id}`} style={styles.td}>
                 <div style={styles.studentTableRow}>
-                  {levels && (
+                  {userLevels && (
                     <TeacherPanelProgressBubble
-                      level={levels.find(level => student.id === level.user_id)}
+                      userLevel={userLevels.find(
+                        userLevel => student.id === userLevel.user_id
+                      )}
                     />
                   )}
                   <div
-                    style={levels ? styles.nameWithBubble : styles.nameInScript}
+                    style={
+                      userLevels ? styles.nameWithBubble : styles.nameInScript
+                    }
                   >
                     {student.name}
                     <a

--- a/apps/src/code-studio/components/progress/TeacherPanel.jsx
+++ b/apps/src/code-studio/components/progress/TeacherPanel.jsx
@@ -153,7 +153,7 @@ class TeacherPanel extends React.Component {
               <SelectedStudentInfo
                 students={students}
                 selectedStudent={currentStudent}
-                level={currentStudentScriptLevel}
+                userLevel={currentStudentScriptLevel}
                 onSelectUser={id => this.onSelectUser(id, 'iterator')}
                 getSelectedUserId={this.props.getSelectedUserId}
               />
@@ -229,7 +229,7 @@ class TeacherPanel extends React.Component {
             )}
           {viewAs === ViewType.Teacher && (students || []).length > 0 && (
             <StudentTable
-              levels={currentSectionScriptLevels}
+              userLevels={currentSectionScriptLevels}
               students={students}
               onSelectUser={id => this.onSelectUser(id, 'select_specific')}
               getSelectedUserId={this.props.getSelectedUserId}

--- a/apps/src/code-studio/components/progress/TeacherPanelProgressBubble.jsx
+++ b/apps/src/code-studio/components/progress/TeacherPanelProgressBubble.jsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import PropTypes from 'prop-types';
 import color from '@cdo/apps/util/color';
 import FontAwesome from '@cdo/apps/templates/FontAwesome';
 import {
@@ -7,7 +8,6 @@ import {
   levelProgressStyle
 } from '@cdo/apps/templates/progress/progressStyles';
 import {LevelStatus} from '@cdo/apps/util/sharedConstants';
-import {levelType} from '@cdo/apps/templates/progress/progressTypes';
 
 /**
  * A TeacherPanelProgressBubble represents progress for a specific level in the TeacherPanel. It can be a circle
@@ -53,24 +53,29 @@ const styles = {
 
 export class TeacherPanelProgressBubble extends React.Component {
   static propTypes = {
-    level: levelType.isRequired
+    // While this userLevel object does have the properties of a levelType object, can
+    // either be more like a userLevel object or a level object depenting on whether the
+    // user has made progress. For example, if the user has progress recorded, the id
+    // property of this object is the user_level id. In this case, to get the level id,
+    // use the level_id property.
+    userLevel: PropTypes.object.isRequired
   };
 
   render() {
-    const {level} = this.props;
+    const {userLevel} = this.props;
 
-    if (level.assessment && level.passed) {
-      level.status = LevelStatus.completed_assessment;
+    if (userLevel.assessment && userLevel.passed) {
+      userLevel.status = LevelStatus.completed_assessment;
     }
 
-    const number = level.levelNumber;
+    const number = userLevel.levelNumber;
 
-    const hideNumber = level.paired || level.bonus;
+    const hideNumber = userLevel.paired || userLevel.bonus;
 
     const style = {
       ...styles.main,
-      ...(level.isConceptLevel && styles.diamond),
-      ...levelProgressStyle(level, false)
+      ...(userLevel.isConceptLevel && styles.diamond),
+      ...levelProgressStyle(userLevel, false)
     };
 
     // Outer div here is used to make sure our bubbles all take up equivalent
@@ -87,13 +92,13 @@ export class TeacherPanelProgressBubble extends React.Component {
         <div style={style}>
           <div
             style={{
-              fontSize: level.paired || level.bonus ? 14 : 16,
+              fontSize: userLevel.paired || userLevel.bonus ? 14 : 16,
               ...styles.contents,
-              ...(level.isConceptLevel && styles.diamondContents)
+              ...(userLevel.isConceptLevel && styles.diamondContents)
             }}
           >
-            {level.paired && <FontAwesome icon="users" />}
-            {level.bonus && <FontAwesome icon="flag-checkered" />}
+            {userLevel.paired && <FontAwesome icon="users" />}
+            {userLevel.bonus && <FontAwesome icon="flag-checkered" />}
             {!hideNumber && <span>{number}</span>}
           </div>
         </div>

--- a/apps/src/code-studio/header.js
+++ b/apps/src/code-studio/header.js
@@ -34,7 +34,7 @@ var header = {};
 /**
  * See ApplicationHelper::PUZZLE_PAGE_NONE.
  */
-const PUZZLE_PAGE_NONE = -1;
+const PUZZLE_PAGE_NONE = '-1';
 
 /**
  * @param {object} scriptData
@@ -49,16 +49,19 @@ const PUZZLE_PAGE_NONE = -1;
  *   finishLink: string,
  *   finishText: string,
  *   levels: Array.<{
- *     id: number,
+ *     id: string,
  *     position: number,
  *     title: string,
  *     kind: string
  *   }>
  * }}
  * @param {object} progressData
- * @param {number} currentLevelId
- * @param {number} currentPageNumber The page we are on if this is a multi-
- *   page level
+ * @param {string} currentLevelId The id of the level the user is currently
+ *   on. This gets used in the url and as a key in many objects. Therefore,
+ *   it is a string despite always being a numerical value
+ * @param {string} currentPageNumber The page we are on if this is a multi-
+ *   page level. This gets used in the URL and therefore is intentionally a
+ *   string despite always being a numerical value
  * @param {boolean} signedIn True/false if we know the sign in state of the
  *   user, null otherwise
  * @param {boolean} stageExtrasEnabled Whether this user is in a section with

--- a/apps/src/code-studio/header.js
+++ b/apps/src/code-studio/header.js
@@ -115,7 +115,6 @@ header.build = function(
           scriptData={scriptData}
           currentLevelId={currentLevelId}
           linesOfCodeText={linesOfCodeText}
-          hasAppOptions={hasAppOptions}
         />
       </Provider>,
       document.querySelector('.header_level')

--- a/apps/src/code-studio/header.js
+++ b/apps/src/code-studio/header.js
@@ -22,6 +22,7 @@ import {Provider} from 'react-redux';
 import progress from './progress';
 import {getStore} from '../redux';
 
+import {PUZZLE_PAGE_NONE} from '@cdo/apps/templates/progress/progressTypes';
 import HeaderMiddle from '@cdo/apps/code-studio/components/header/HeaderMiddle';
 
 /**
@@ -30,11 +31,6 @@ import HeaderMiddle from '@cdo/apps/code-studio/components/header/HeaderMiddle';
 
 // Namespace for manipulating the header DOM.
 var header = {};
-
-/**
- * See ApplicationHelper::PUZZLE_PAGE_NONE.
- */
-const PUZZLE_PAGE_NONE = '-1';
 
 /**
  * @param {object} scriptData
@@ -59,9 +55,8 @@ const PUZZLE_PAGE_NONE = '-1';
  * @param {string} currentLevelId The id of the level the user is currently
  *   on. This gets used in the url and as a key in many objects. Therefore,
  *   it is a string despite always being a numerical value
- * @param {string} currentPageNumber The page we are on if this is a multi-
- *   page level. This gets used in the URL and therefore is intentionally a
- *   string despite always being a numerical value
+ * @param {number} currentPageNumber The page we are on if this is a multi-
+ *   page level.
  * @param {boolean} signedIn True/false if we know the sign in state of the
  *   user, null otherwise
  * @param {boolean} stageExtrasEnabled Whether this user is in a section with

--- a/apps/src/code-studio/header.js
+++ b/apps/src/code-studio/header.js
@@ -76,8 +76,7 @@ header.build = function(
   signedIn,
   stageExtrasEnabled,
   scriptNameData,
-  isLessonExtras,
-  hasAppOptions
+  isLessonExtras
 ) {
   const store = getStore();
   if (progressData) {

--- a/apps/src/code-studio/progress.js
+++ b/apps/src/code-studio/progress.js
@@ -82,9 +82,8 @@ progress.showDisabledBubblesAlert = function() {
  *   stageExtras enabled for this script
  * @param {boolean} isLessonExtras Boolean indicating we are not on a script
  *   level and therefore are on lesson extras
- * @param {string} currentPageNumber The page we are on if this is a multi-
- *   page level. This is intentionally a string despite being a numerical
- *   value since it gets used in the url
+ * @param {number} currentPageNumber The page we are on if this is a multi-
+ *   page level.
  */
 progress.generateStageProgress = function(
   scriptData,
@@ -276,9 +275,8 @@ function queryUserProgress(store, scriptData, currentLevelId) {
  * @param {boolean} [saveAnswersBeforeNavigation]
  * @param {boolean} [isLessonExtras] Optional boolean indicating we are not on
  *   a script level and therefore are on lesson extras
- * @param {string} [currentPageNumber] Optional. The page we are on if this is
- *   a multi-page level. This is intentionally a string despite being a
- *   numerical value since it gets used in the url
+ * @param {number} [currentPageNumber] Optional. The page we are on if this is
+ *   a multi-page level.
  */
 function initializeStoreWithProgress(
   store,

--- a/apps/src/code-studio/progress.js
+++ b/apps/src/code-studio/progress.js
@@ -72,7 +72,9 @@ progress.showDisabledBubblesAlert = function() {
  *   we have in renderCourseProgress)
  * @param {object} stageData
  * @param {object} progressData
- * @param {string} currentLevelid
+ * @param {string} currentLevelid The id of the level the user is currently on.
+ *   This gets used in the url and as a key in many objects. Therefore, it is a
+ *   string despite always being a numerical value
  * @param {boolean} saveAnswersBeforeNavigation
  * @param {boolean} signedIn True/false if we know the sign in state of the
  *   user, null otherwise
@@ -80,8 +82,9 @@ progress.showDisabledBubblesAlert = function() {
  *   stageExtras enabled for this script
  * @param {boolean} isLessonExtras Boolean indicating we are not on a script
  *   level and therefore are on lesson extras
- * @param {number} currentPageNumber The page we are on if this is a multi-
- *   page level
+ * @param {string} currentPageNumber The page we are on if this is a multi-
+ *   page level. This is intentionally a string despite being a numerical
+ *   value since it gets used in the url
  */
 progress.generateStageProgress = function(
   scriptData,
@@ -265,14 +268,17 @@ function queryUserProgress(store, scriptData, currentLevelId) {
  * @param {boolean} [scriptData.plc]
  * @param {object[]} [scriptData.stages]
  * @param {boolean} scriptData.age_13_required
- * @param {string} currentLevelId
+ * @param {string} currentLevelId The id of the level the user is currently on.
+ *   This gets used in the url and as a key in many objects. Therefore, it is a
+ *   string despite always being a numerical value
  * @param {boolean} isFullProgress - True if this contains progress for the entire
  *   script vs. a single stage.
  * @param {boolean} [saveAnswersBeforeNavigation]
  * @param {boolean} [isLessonExtras] Optional boolean indicating we are not on
  *   a script level and therefore are on lesson extras
- * @param {number} [currentPageNumber] Optional. The page we are on if this is
- *   a multi-page level
+ * @param {string} [currentPageNumber] Optional. The page we are on if this is
+ *   a multi-page level. This is intentionally a string despite being a
+ *   numerical value since it gets used in the url
  */
 function initializeStoreWithProgress(
   store,

--- a/apps/src/code-studio/progressRedux.js
+++ b/apps/src/code-studio/progressRedux.js
@@ -67,7 +67,7 @@ const initialState = {
   // prior to having information about the user login state.
   // TODO: Use sign in state to determine where to source user progress from
   usingDbProgress: false,
-  currentPageNumber: 0
+  currentPageNumber: '0'
 };
 
 /**
@@ -555,9 +555,7 @@ const peerReviewLevels = state =>
  */
 const isCurrentLevel = (currentLevelId, level) => {
   return (
-    !!currentLevelId &&
-    ((level.ids && level.ids.indexOf(currentLevelId) !== -1) ||
-      level.uid === currentLevelId)
+    !!currentLevelId && (level.id && level.id.indexOf(currentLevelId) !== -1)
   );
 };
 
@@ -578,10 +576,11 @@ const levelWithStatus = (
       );
     }
   }
+  const normalizedLevel = processedLevel(level);
   return {
-    ...processedLevel(level),
+    ...normalizedLevel,
     status: statusForLevel(level, levelProgress),
-    isCurrentLevel: isCurrentLevel(currentLevelId, level),
+    isCurrentLevel: isCurrentLevel(currentLevelId, normalizedLevel),
     paired: levelPairing[level.activeId],
     readonlyAnswers: level.readonly_answers
   };

--- a/apps/src/code-studio/progressRedux.js
+++ b/apps/src/code-studio/progressRedux.js
@@ -8,6 +8,7 @@ import {LevelStatus, LevelKind} from '@cdo/apps/util/sharedConstants';
 import {TestResults} from '@cdo/apps/constants';
 import {ViewType, SET_VIEW_TYPE} from './viewAsRedux';
 import {processedLevel} from '@cdo/apps/templates/progress/progressHelpers';
+import {PUZZLE_PAGE_NONE} from '@cdo/apps/templates/progress/progressTypes';
 import {setVerified} from '@cdo/apps/code-studio/verifiedTeacherRedux';
 import {authorizeLockable} from './stageLockRedux';
 
@@ -67,7 +68,7 @@ const initialState = {
   // prior to having information about the user login state.
   // TODO: Use sign in state to determine where to source user progress from
   usingDbProgress: false,
-  currentPageNumber: '0'
+  currentPageNumber: PUZZLE_PAGE_NONE
 };
 
 /**

--- a/apps/src/lib/levelbuilder/lesson-editor/LevelToken.jsx
+++ b/apps/src/lib/levelbuilder/lesson-editor/LevelToken.jsx
@@ -127,11 +127,6 @@ class LevelToken extends Component {
     progressBubbleLevel['levelNumber'] = this.props.scriptLevel.levelNumber;
     progressBubbleLevel['kind'] = this.props.scriptLevel.kind;
 
-    // TODO: (charlie) this is temporary backward compatibility with
-    // ProgressBubble, which will be updated to use strings for ids
-    // in an upcoming PR
-    progressBubbleLevel['id'] = parseInt(activeLevel.id);
-
     return progressBubbleLevel;
   };
 

--- a/apps/src/sites/studio/pages/levels/_bubble_choice.js
+++ b/apps/src/sites/studio/pages/levels/_bubble_choice.js
@@ -5,7 +5,14 @@ import BubbleChoice from '@cdo/apps/code-studio/components/BubbleChoice';
 const script = document.querySelector('script[data-bubblechoice]');
 const data = JSON.parse(script.dataset.bubblechoice);
 
+let level = data.level;
+level.sublevels = data.level.sublevels.map(sublevel => {
+  sublevel.id = sublevel.id.toString();
+  return sublevel;
+});
+level.id = level.id.toString();
+
 ReactDOM.render(
-  <BubbleChoice level={data.level} />,
+  <BubbleChoice level={level} />,
   document.querySelector('#bubble-choice')
 );

--- a/apps/src/sites/studio/pages/scripts/stage_extras.js
+++ b/apps/src/sites/studio/pages/scripts/stage_extras.js
@@ -11,6 +11,14 @@ const projectTypes = JSON.parse(script.dataset.widgetTypes);
 const viewer = JSON.parse(script.dataset.viewer);
 const store = getStore();
 
+config.bonusLevels = config.bonusLevels.map(bonus => {
+  bonus.levels = bonus.levels.map(level => {
+    level.id = level.id.toString();
+    return level;
+  });
+  return bonus;
+});
+
 ReactDOM.render(
   <Provider store={store}>
     <LessonExtras

--- a/apps/src/templates/FinishDialog.story.jsx
+++ b/apps/src/templates/FinishDialog.story.jsx
@@ -45,11 +45,12 @@ const studentCode = {
 
 const levels = [];
 for (let i = 0; i < 20; i++) {
+  const id = (1818 + i).toString();
   levels.push({
-    activeId: 1818 + i,
+    activeId: id,
     freePlay: false,
     icon: null,
-    ids: [1818 + i],
+    ids: [id],
     is_concept_level: false,
     kind: 'puzzle',
     position: i + 1,

--- a/apps/src/templates/FinishDialog.story.jsx
+++ b/apps/src/templates/FinishDialog.story.jsx
@@ -59,7 +59,7 @@ for (let i = 0; i < 20; i++) {
 }
 
 const mockProgress = {
-  currentLevelId: 123,
+  currentLevelId: '123',
   professionalLearningCourse: false,
   saveAnswersBeforeNavigation: false,
   stages: [

--- a/apps/src/templates/lessonOverview/activities/ProgressionDetails.jsx
+++ b/apps/src/templates/lessonOverview/activities/ProgressionDetails.jsx
@@ -33,10 +33,7 @@ export default class ProgressionDetails extends Component {
         : scriptLevel.levels[0];
 
     return {
-      // TODO: (charlie) this is temporary backward compatibility with
-      // ProgressBubble, which will be updated to use strings for ids
-      // in an upcoming PR
-      id: parseInt(activeLevel.id),
+      id: activeLevel.id,
       status: LevelStatus.not_tried,
       url: scriptLevel.url,
       name: activeLevel.name,

--- a/apps/src/templates/progress/DetailProgressTable.story.jsx
+++ b/apps/src/templates/progress/DetailProgressTable.story.jsx
@@ -18,7 +18,7 @@ const lessons = [
 const levelsByLesson = [
   [
     {
-      id: 30,
+      id: '30',
       status: LevelStatus.not_tried,
       url: '/step1/level1',
       name: 'First progression',
@@ -29,7 +29,7 @@ const levelsByLesson = [
       progression: 'Second Progression'
     })),
     {
-      id: 40,
+      id: '40',
       status: LevelStatus.not_tried,
       url: '/step3/level1',
       name: 'Last progression',

--- a/apps/src/templates/progress/LessonGroup.story.jsx
+++ b/apps/src/templates/progress/LessonGroup.story.jsx
@@ -18,7 +18,7 @@ const lessons = [
 const levelsByLesson = [
   [
     {
-      id: 20,
+      id: '20',
       status: LevelStatus.not_tried,
       url: '/step1/level1',
       name: 'First progression',
@@ -29,7 +29,7 @@ const levelsByLesson = [
       progression: 'Second Progression'
     })),
     {
-      id: 21,
+      id: '21',
       status: LevelStatus.not_tried,
       url: '/step3/level1',
       name: 'Last progression',

--- a/apps/src/templates/progress/ProgressBubble.story.jsx
+++ b/apps/src/templates/progress/ProgressBubble.story.jsx
@@ -12,7 +12,7 @@ export default storybook => {
         story: () => (
           <ProgressBubble
             level={{
-              id: 1,
+              id: '1',
               levelNumber: 3,
               status: status,
               url: '/foo/bar',
@@ -28,7 +28,7 @@ export default storybook => {
           story: () => (
             <ProgressBubble
               level={{
-                id: 1,
+                id: '1',
                 levelNumber: 3,
                 status: LevelStatus.perfect,
                 url: '/foo/bar',
@@ -44,7 +44,7 @@ export default storybook => {
           story: () => (
             <ProgressBubble
               level={{
-                id: 1,
+                id: '1',
                 levelNumber: 3,
                 status: LevelStatus.perfect,
                 url: '/foo/bar',
@@ -60,7 +60,7 @@ export default storybook => {
           story: () => (
             <ProgressBubble
               level={{
-                id: 1,
+                id: '1',
                 levelNumber: 3,
                 status: LevelStatus.perfect,
                 url: '/foo/bar',
@@ -77,7 +77,7 @@ export default storybook => {
           story: () => (
             <ProgressBubble
               level={{
-                id: 1,
+                id: '1',
                 levelNumber: 3,
                 status: LevelStatus.perfect,
                 url: '/foo/bar',
@@ -96,7 +96,7 @@ export default storybook => {
           story: () => (
             <ProgressBubble
               level={{
-                id: 1,
+                id: '1',
                 levelNumber: 3,
                 status: LevelStatus.attempted,
                 url: '/foo/bar',

--- a/apps/src/templates/progress/ProgressLegend.jsx
+++ b/apps/src/templates/progress/ProgressLegend.jsx
@@ -157,7 +157,7 @@ export default class ProgressLegend extends Component {
               <div style={styles.center}>
                 <ProgressBubble
                   level={{
-                    id: 1,
+                    id: '1',
                     status: LevelStatus.not_tried,
                     isConceptLevel: true,
                     name: `${i18n.concept()}: ${i18n.notStarted()}`
@@ -170,7 +170,7 @@ export default class ProgressLegend extends Component {
               <div style={styles.center}>
                 <ProgressBubble
                   level={{
-                    id: 1,
+                    id: '1',
                     status: LevelStatus.attempted,
                     isConceptLevel: true,
                     name: `${i18n.concept()}: ${i18n.inProgress()}`
@@ -184,7 +184,7 @@ export default class ProgressLegend extends Component {
               <div style={styles.center}>
                 <ProgressBubble
                   level={{
-                    id: 1,
+                    id: '1',
                     status: LevelStatus.perfect,
                     isConceptLevel: true,
                     name: `${i18n.concept()}: ${i18n.completed()} (${i18n.perfect()})`
@@ -233,7 +233,7 @@ export default class ProgressLegend extends Component {
               <div style={styles.center}>
                 <ProgressBubble
                   level={{
-                    id: 1,
+                    id: '1',
                     status: LevelStatus.not_tried,
                     isConceptLevel: false,
                     name: `${i18n.activity()}: ${i18n.notStarted()}`
@@ -246,7 +246,7 @@ export default class ProgressLegend extends Component {
               <div style={styles.center}>
                 <ProgressBubble
                   level={{
-                    id: 1,
+                    id: '1',
                     status: LevelStatus.attempted,
                     isConceptLevel: false,
                     name: `${i18n.activity()}: ${i18n.inProgress()}`
@@ -260,7 +260,7 @@ export default class ProgressLegend extends Component {
                 <div style={styles.center}>
                   <ProgressBubble
                     level={{
-                      id: 1,
+                      id: '1',
                       status: LevelStatus.passed,
                       isConceptLevel: false,
                       name: `${i18n.activity()}: ${i18n.completed()} (${i18n.tooManyBlocks()})`
@@ -274,7 +274,7 @@ export default class ProgressLegend extends Component {
               <div style={styles.center}>
                 <ProgressBubble
                   level={{
-                    id: 1,
+                    id: '1',
                     status: LevelStatus.perfect,
                     isConceptLevel: false,
                     name: `${i18n.activity()}: ${i18n.completed()} (${i18n.perfect()})`
@@ -287,7 +287,7 @@ export default class ProgressLegend extends Component {
               <div style={styles.center}>
                 <ProgressBubble
                   level={{
-                    id: 1,
+                    id: '1',
                     status: LevelStatus.submitted,
                     isConceptLevel: false,
                     name: `${i18n.activity()}: ${i18n.submitted()}`

--- a/apps/src/templates/progress/ProgressLesson.story.jsx
+++ b/apps/src/templates/progress/ProgressLesson.story.jsx
@@ -60,21 +60,21 @@ export default storybook => {
           }}
           levels={[
             {
-              id: -1,
+              id: '-1',
               name: 'Link to submitted review',
               status: LevelStatus.perfect,
               url: '/peer_reviews/1',
               levelNumber: 1
             },
             {
-              id: -1,
+              id: '-1',
               name: 'Review a new submission',
               status: LevelStatus.not_tried,
               url: '/pull-review',
               levelNumber: 2
             },
             {
-              id: -1,
+              id: '-1',
               icon: 'fa-lock',
               name: 'Reviews unavailable at this time',
               status: LevelStatus.locked,
@@ -82,7 +82,7 @@ export default storybook => {
               levelNumber: 3
             },
             {
-              id: -1,
+              id: '-1',
               icon: 'fa-lock',
               name: 'Reviews unavailable at this time',
               status: LevelStatus.locked,

--- a/apps/src/templates/progress/ProgressPill.story.jsx
+++ b/apps/src/templates/progress/ProgressPill.story.jsx
@@ -10,7 +10,7 @@ export default storybook => {
         <ProgressPill
           levels={[
             {
-              id: 1,
+              id: '1',
               url: '/level1',
               status: LevelStatus.perfect
             }
@@ -26,12 +26,12 @@ export default storybook => {
         <ProgressPill
           levels={[
             {
-              id: 1,
+              id: '1',
               url: '/level1',
               status: LevelStatus.perfect
             },
             {
-              id: 2,
+              id: '2',
               url: '/level2',
               status: LevelStatus.not_tried
             }
@@ -47,7 +47,7 @@ export default storybook => {
         <ProgressPill
           levels={[
             {
-              id: 1,
+              id: '1',
               url: '/level1',
               status: LevelStatus.perfect
             }

--- a/apps/src/templates/progress/SummaryProgressTable.story.jsx
+++ b/apps/src/templates/progress/SummaryProgressTable.story.jsx
@@ -74,21 +74,21 @@ export default storybook => {
           levelsByLesson={[
             [
               {
-                id: -1,
+                id: '-1',
                 name: 'Link to submitted review',
                 status: LevelStatus.perfect,
                 url: '/peer_reviews/1',
                 levelNumber: 1
               },
               {
-                id: -1,
+                id: '-1',
                 name: 'Review a new submission',
                 status: LevelStatus.not_tried,
                 url: '/pull-review',
                 levelNumber: 2
               },
               {
-                id: -1,
+                id: '-1',
                 icon: 'fa-lock',
                 name: 'Reviews unavailable at this time',
                 status: LevelStatus.locked,

--- a/apps/src/templates/progress/progressHelpers.js
+++ b/apps/src/templates/progress/progressHelpers.js
@@ -169,8 +169,11 @@ export function summarizeProgressInStage(levelsWithStatus) {
  * contains more data than we need. This filters to the parts our views care about.
  */
 export const processedLevel = level => {
+  // id and pageNumber should be strings since they get used in object keys
+  // and urls.
+  const id = level.activeId || level.id;
   return {
-    id: level.activeId || level.id,
+    id: id.toString(),
     url: level.url,
     name: level.name,
     progression: level.progression,
@@ -181,7 +184,7 @@ export const processedLevel = level => {
     levelNumber: level.kind === LevelKind.unplugged ? undefined : level.title,
     isConceptLevel: level.is_concept_level,
     bonus: level.bonus,
-    pageNumber: level.page_number,
+    pageNumber: level.page_number && level.page_number.toString(),
     sublevels:
       level.sublevels && level.sublevels.map(level => processedLevel(level))
   };

--- a/apps/src/templates/progress/progressHelpers.js
+++ b/apps/src/templates/progress/progressHelpers.js
@@ -2,6 +2,7 @@ import {fullyLockedStageMapping} from '@cdo/apps/code-studio/stageLockRedux';
 import {ViewType} from '@cdo/apps/code-studio/viewAsRedux';
 import {isStageHiddenForSection} from '@cdo/apps/code-studio/hiddenStageRedux';
 import {LevelStatus, LevelKind} from '@cdo/apps/util/sharedConstants';
+import {PUZZLE_PAGE_NONE} from './progressTypes';
 
 /**
  * This is conceptually similar to being a selector, except that it operates on
@@ -169,11 +170,9 @@ export function summarizeProgressInStage(levelsWithStatus) {
  * contains more data than we need. This filters to the parts our views care about.
  */
 export const processedLevel = level => {
-  // id and pageNumber should be strings since they get used in object keys
-  // and urls.
-  const id = level.activeId || level.id;
   return {
-    id: id.toString(),
+    // ids should be a strings since they are used for object keys
+    id: (level.activeId || level.id).toString(),
     url: level.url,
     name: level.name,
     progression: level.progression,
@@ -184,7 +183,10 @@ export const processedLevel = level => {
     levelNumber: level.kind === LevelKind.unplugged ? undefined : level.title,
     isConceptLevel: level.is_concept_level,
     bonus: level.bonus,
-    pageNumber: level.page_number && level.page_number.toString(),
+    pageNumber:
+      typeof level.page_number !== 'undefined'
+        ? level.page_number
+        : PUZZLE_PAGE_NONE,
     sublevels:
       level.sublevels && level.sublevels.map(level => processedLevel(level))
   };

--- a/apps/src/templates/progress/progressHelpers.js
+++ b/apps/src/templates/progress/progressHelpers.js
@@ -171,8 +171,7 @@ export function summarizeProgressInStage(levelsWithStatus) {
  */
 export const processedLevel = level => {
   return {
-    // ids should be a strings since they are used for object keys
-    id: (level.activeId || level.id).toString(),
+    id: level.activeId || level.id,
     url: level.url,
     name: level.name,
     progression: level.progression,

--- a/apps/src/templates/progress/progressTestHelpers.js
+++ b/apps/src/templates/progress/progressTestHelpers.js
@@ -26,7 +26,7 @@ export const fakeLesson = (
 export const fakeLevel = overrides => {
   const levelNumber = overrides.levelNumber || 1;
   return {
-    id: levelNumber,
+    id: levelNumber.toString(),
     status: LevelStatus.not_tried,
     url: `/level${levelNumber}`,
     name: `Level ${levelNumber}`,

--- a/apps/src/templates/progress/progressTypes.js
+++ b/apps/src/templates/progress/progressTypes.js
@@ -1,6 +1,11 @@
 import PropTypes from 'prop-types';
 
 /**
+ * See ApplicationHelper::PUZZLE_PAGE_NONE.
+ */
+export const PUZZLE_PAGE_NONE = -1;
+
+/**
  * @typedef {Object} Level
  *
  * @property {string} id The id of the level. It is intentionally
@@ -14,10 +19,8 @@ import PropTypes from 'prop-types';
  * @property {bool} isCurrentLevel
  * @property {bool} isConceptLevel
  * @property {string} kind
- * @property {string} pageNumber The page number of the level if
- *   this is a multi-page level. It is intentionally a string
- *   (despite always being numerical) because it gets used as a
- *   key in JS objects and is used in the url.
+ * @property {number} pageNumber The page number of the level if
+ *   this is a multi-page level, or PUZZLE_PAGE_NONE
  */
 const levelWithoutStatusShape = {
   id: PropTypes.string.isRequired,
@@ -29,7 +32,7 @@ const levelWithoutStatusShape = {
   isCurrentLevel: PropTypes.bool,
   isConceptLevel: PropTypes.bool,
   kind: PropTypes.string,
-  pageNumber: PropTypes.string
+  pageNumber: PropTypes.number
 };
 
 // Avoid recursive definition

--- a/apps/src/templates/progress/progressTypes.js
+++ b/apps/src/templates/progress/progressTypes.js
@@ -3,7 +3,9 @@ import PropTypes from 'prop-types';
 /**
  * @typedef {Object} Level
  *
- * @property {number} id
+ * @property {string} id The id of the level. It is intentionally
+ *   a string (despite always being numerical) because it gets
+ *   used as a key in JS objects and is used in the url.
  * @property {string} url
  * @property {string} name
  * @property {string} icon
@@ -12,9 +14,13 @@ import PropTypes from 'prop-types';
  * @property {bool} isCurrentLevel
  * @property {bool} isConceptLevel
  * @property {string} kind
+ * @property {string} pageNumber The page number of the level if
+ *   this is a multi-page level. It is intentionally a string
+ *   (despite always being numerical) because it gets used as a
+ *   key in JS objects and is used in the url.
  */
 const levelWithoutStatusShape = {
-  id: PropTypes.number.isRequired,
+  id: PropTypes.string.isRequired,
   url: PropTypes.string,
   name: PropTypes.string,
   icon: PropTypes.string,
@@ -22,7 +28,8 @@ const levelWithoutStatusShape = {
   levelNumber: PropTypes.number,
   isCurrentLevel: PropTypes.bool,
   isConceptLevel: PropTypes.bool,
-  kind: PropTypes.string
+  kind: PropTypes.string,
+  pageNumber: PropTypes.string
 };
 
 // Avoid recursive definition

--- a/apps/test/unit/code-studio/components/BonusLevelsTest.jsx
+++ b/apps/test/unit/code-studio/components/BonusLevelsTest.jsx
@@ -11,7 +11,7 @@ const DEFAULT_PROPS = {
 };
 
 describe('BonusLevels', () => {
-  it('renders correct number of sublevels', () => {
+  it('renders correct number of bonus levels', () => {
     const wrapper = shallow(<BonusLevels {...DEFAULT_PROPS} />);
     assert.equal(7, wrapper.find('SublevelCard').length);
   });

--- a/apps/test/unit/code-studio/components/BubbleChoiceTest.js
+++ b/apps/test/unit/code-studio/components/BubbleChoiceTest.js
@@ -7,7 +7,7 @@ import * as utils from '@cdo/apps/utils';
 
 const fakeSublevels = [
   {
-    id: 1,
+    id: '1',
     display_name: 'Choice 1',
     thumbnail_url: 'some-fake.url/kittens.png',
     url: '/s/script/stage/1/puzzle/2/sublevel/1',
@@ -17,7 +17,7 @@ const fakeSublevels = [
     status: 'perfect'
   },
   {
-    id: 2,
+    id: '2',
     display_name: 'Choice 2',
     thumbnail_url: null,
     url: '/s/script/stage/1/puzzle/2/sublevel/2',
@@ -30,7 +30,7 @@ const fakeSublevels = [
 
 const DEFAULT_PROPS = {
   level: {
-    id: 123,
+    id: '123',
     display_name: 'Bubble Choice',
     description: 'Choose one or more levels!',
     sublevels: fakeSublevels,

--- a/apps/test/unit/code-studio/components/SublevelCardTest.js
+++ b/apps/test/unit/code-studio/components/SublevelCardTest.js
@@ -6,7 +6,7 @@ import SublevelCard from '@cdo/apps/code-studio/components/SublevelCard';
 const DEFAULT_PROPS = {
   isLessonExtra: false,
   sublevel: {
-    id: 1,
+    id: '1',
     display_name: 'Choice 1',
     description: 'Sublevel 1 is lots of fun',
     thumbnail_url: 'some-fake.url/kittens.png',
@@ -21,7 +21,7 @@ const DEFAULT_PROPS = {
 const LESSON_EXTRAS_DEFAULT_PROPS = {
   isLessonExtra: true,
   sublevel: {
-    id: 1,
+    id: '1',
     display_name: 'Choice 1',
     description: 'Sublevel 1 is lots of fun',
     thumbnail_url: 'some-fake.url/kittens.png',
@@ -32,7 +32,7 @@ const LESSON_EXTRAS_DEFAULT_PROPS = {
 };
 
 const sublevel_no_thumbnail = {
-  id: 1,
+  id: '1',
   display_name: 'Choice 1',
   description: 'Sublevel 1 is lots of fun',
   thumbnail_url: null,

--- a/apps/test/unit/code-studio/components/lessonExtrasTestHelpers.js
+++ b/apps/test/unit/code-studio/components/lessonExtrasTestHelpers.js
@@ -3,7 +3,7 @@ export const bonusLevels = [
     stageNumber: 1,
     levels: [
       {
-        id: 23222,
+        id: '23222',
         display_name: 'Bonus Level',
         description: 'A lovely description for this sublevel',
         thumbnail_url: '',
@@ -12,7 +12,7 @@ export const bonusLevels = [
         perfect: true
       },
       {
-        id: 23223,
+        id: '23223',
         display_name: '2nd Challenge',
         description: 'Sublevel 2 is lots of fun',
         thumbnail_url: 'some-fake.url/kittens.png',
@@ -26,7 +26,7 @@ export const bonusLevels = [
     stageNumber: 2,
     levels: [
       {
-        id: 23224,
+        id: '23224',
         display_name: 'Bonus Level',
         description: null,
         thumbnail_url:
@@ -36,7 +36,7 @@ export const bonusLevels = [
         perfect: true
       },
       {
-        id: 23225,
+        id: '23225',
         display_name: '2nd Challenge',
         description: null,
         thumbnail_url:
@@ -51,7 +51,7 @@ export const bonusLevels = [
     stageNumber: 3,
     levels: [
       {
-        id: 23226,
+        id: '23226',
         display_name: 'courseC_artist_prog_challenge1',
         description: null,
         thumbnail_url:
@@ -61,7 +61,7 @@ export const bonusLevels = [
         perfect: false
       },
       {
-        id: 23227,
+        id: '23227',
         display_name: 'courseB_maze_seq_challenge2',
         description: null,
         url:
@@ -70,7 +70,7 @@ export const bonusLevels = [
         perfect: true
       },
       {
-        id: 23228,
+        id: '23228',
         display_name: 'A challenge',
         description: null,
         url:

--- a/apps/test/unit/code-studio/components/progress/LessonProgressTest.js
+++ b/apps/test/unit/code-studio/components/progress/LessonProgressTest.js
@@ -8,7 +8,7 @@ describe('LessonProgress', () => {
   const defaultProps = {
     levels: [
       {
-        id: 123,
+        id: '123',
         status: LevelStatus.not_tried
       }
     ],

--- a/apps/test/unit/code-studio/components/progress/SelectedStudentInfoTest.jsx
+++ b/apps/test/unit/code-studio/components/progress/SelectedStudentInfoTest.jsx
@@ -6,8 +6,8 @@ import {LevelStatus} from '@cdo/apps/util/sharedConstants';
 
 const defaultProps = {
   selectedStudent: {id: 1, name: 'Student 1'},
-  level: {
-    id: '123',
+  userLevel: {
+    id: 123,
     assessment: null,
     contained: false,
     driver: null,
@@ -36,8 +36,8 @@ describe('SelectedStudentInfo', () => {
     const wrapper = shallow(
       <SelectedStudentInfo
         {...defaultProps}
-        level={{
-          ...defaultProps.level,
+        userLevel={{
+          ...defaultProps.userLevel,
           submitLevel: true,
           submitted: true,
           status: LevelStatus.submitted
@@ -53,8 +53,8 @@ describe('SelectedStudentInfo', () => {
     const wrapper = shallow(
       <SelectedStudentInfo
         {...defaultProps}
-        level={{
-          ...defaultProps.level,
+        userLevel={{
+          ...defaultProps.userLevel,
           contained: true,
           status: LevelStatus.perfect
         }}
@@ -68,8 +68,8 @@ describe('SelectedStudentInfo', () => {
     const wrapper = shallow(
       <SelectedStudentInfo
         {...defaultProps}
-        level={{
-          ...defaultProps.level,
+        userLevel={{
+          ...defaultProps.userLevel,
           paired: true,
           status: LevelStatus.perfect,
           navigator: 'Student 2'
@@ -86,8 +86,8 @@ describe('SelectedStudentInfo', () => {
     const wrapper = shallow(
       <SelectedStudentInfo
         {...defaultProps}
-        level={{
-          ...defaultProps.level,
+        userLevel={{
+          ...defaultProps.userLevel,
           paired: true,
           status: LevelStatus.perfect,
           driver: 'Student 2'

--- a/apps/test/unit/code-studio/components/progress/SelectedStudentInfoTest.jsx
+++ b/apps/test/unit/code-studio/components/progress/SelectedStudentInfoTest.jsx
@@ -7,7 +7,7 @@ import {LevelStatus} from '@cdo/apps/util/sharedConstants';
 const defaultProps = {
   selectedStudent: {id: 1, name: 'Student 1'},
   level: {
-    id: 123,
+    id: '123',
     assessment: null,
     contained: false,
     driver: null,

--- a/apps/test/unit/code-studio/components/progress/StudentTableTest.jsx
+++ b/apps/test/unit/code-studio/components/progress/StudentTableTest.jsx
@@ -8,12 +8,12 @@ const MINIMUM_PROPS = {
   students: [{id: 1, name: 'Student 1'}, {id: 2, name: 'Student 2'}],
   onSelectUser: () => {},
   getSelectedUserId: () => {},
-  levels: null
+  userLevels: null
 };
 
-const levels = [
+const userLevels = [
   {
-    id: '11',
+    id: 11,
     assessment: null,
     contained: false,
     driver: null,
@@ -27,7 +27,7 @@ const levels = [
     user_id: 1
   },
   {
-    id: '22',
+    id: 22,
     assessment: null,
     contained: false,
     driver: null,
@@ -45,7 +45,7 @@ const levels = [
 describe('StudentTable', () => {
   it('display bubbles when levels', () => {
     const wrapper = shallow(
-      <StudentTable {...MINIMUM_PROPS} levels={levels} />
+      <StudentTable {...MINIMUM_PROPS} userLevels={userLevels} />
     );
 
     expect(wrapper.find('TeacherPanelProgressBubble')).to.have.length(2);

--- a/apps/test/unit/code-studio/components/progress/StudentTableTest.jsx
+++ b/apps/test/unit/code-studio/components/progress/StudentTableTest.jsx
@@ -13,7 +13,7 @@ const MINIMUM_PROPS = {
 
 const levels = [
   {
-    id: 11,
+    id: '11',
     assessment: null,
     contained: false,
     driver: null,
@@ -27,7 +27,7 @@ const levels = [
     user_id: 1
   },
   {
-    id: 22,
+    id: '22',
     assessment: null,
     contained: false,
     driver: null,

--- a/apps/test/unit/code-studio/components/progress/TeacherPanelProgressBubbleTest.jsx
+++ b/apps/test/unit/code-studio/components/progress/TeacherPanelProgressBubbleTest.jsx
@@ -6,8 +6,8 @@ import color from '@cdo/apps/util/color';
 import {LevelKind, LevelStatus} from '@cdo/apps/util/sharedConstants';
 
 const defaultProps = {
-  level: {
-    id: '123',
+  userLevel: {
+    id: 123,
     assessment: null,
     contained: false,
     driver: null,
@@ -27,8 +27,8 @@ describe('StudentTable', () => {
     const wrapper = shallow(
       <TeacherPanelProgressBubble
         {...defaultProps}
-        level={{
-          ...defaultProps.level,
+        userLevel={{
+          ...defaultProps.userLevel,
           paired: true,
           driver: 'My Friend'
         }}
@@ -42,8 +42,8 @@ describe('StudentTable', () => {
     const wrapper = shallow(
       <TeacherPanelProgressBubble
         {...defaultProps}
-        level={{
-          ...defaultProps.level,
+        userLevel={{
+          ...defaultProps.userLevel,
           paired: true,
           navigator: 'My Friend'
         }}
@@ -64,8 +64,8 @@ describe('StudentTable', () => {
     const wrapper = shallow(
       <TeacherPanelProgressBubble
         {...defaultProps}
-        level={{
-          ...defaultProps.level,
+        userLevel={{
+          ...defaultProps.userLevel,
           passed: true,
           status: LevelStatus.perfect,
           assessment: false
@@ -81,8 +81,8 @@ describe('StudentTable', () => {
     const wrapper = shallow(
       <TeacherPanelProgressBubble
         {...defaultProps}
-        level={{
-          ...defaultProps.level,
+        userLevel={{
+          ...defaultProps.userLevel,
           passed: true,
           kind: LevelKind.assessment,
           status: LevelStatus.completed_assessment
@@ -98,8 +98,8 @@ describe('StudentTable', () => {
     const wrapper = shallow(
       <TeacherPanelProgressBubble
         {...defaultProps}
-        level={{
-          ...defaultProps.level,
+        userLevel={{
+          ...defaultProps.userLevel,
           status: LevelStatus.attempted
         }}
       />
@@ -113,8 +113,8 @@ describe('StudentTable', () => {
     const wrapper = shallow(
       <TeacherPanelProgressBubble
         {...defaultProps}
-        level={{
-          ...defaultProps.level,
+        userLevel={{
+          ...defaultProps.userLevel,
           passed: true,
           status: LevelStatus.passed
         }}
@@ -129,8 +129,8 @@ describe('StudentTable', () => {
     const wrapper = shallow(
       <TeacherPanelProgressBubble
         {...defaultProps}
-        level={{
-          ...defaultProps.level,
+        userLevel={{
+          ...defaultProps.userLevel,
           kind: LevelKind.assessment,
           status: LevelStatus.submitted,
           passed: true
@@ -147,8 +147,8 @@ describe('StudentTable', () => {
     const wrapper = shallow(
       <TeacherPanelProgressBubble
         {...defaultProps}
-        level={{
-          ...defaultProps.level,
+        userLevel={{
+          ...defaultProps.userLevel,
           isConceptLevel: true
         }}
       />

--- a/apps/test/unit/code-studio/components/progress/TeacherPanelProgressBubbleTest.jsx
+++ b/apps/test/unit/code-studio/components/progress/TeacherPanelProgressBubbleTest.jsx
@@ -7,7 +7,7 @@ import {LevelKind, LevelStatus} from '@cdo/apps/util/sharedConstants';
 
 const defaultProps = {
   level: {
-    id: 123,
+    id: '123',
     assessment: null,
     contained: false,
     driver: null,

--- a/apps/test/unit/code-studio/components/progress/TeacherPanelTest.jsx
+++ b/apps/test/unit/code-studio/components/progress/TeacherPanelTest.jsx
@@ -220,7 +220,7 @@ describe('TeacherPanel', () => {
               },
               section_script_levels: [
                 {
-                  id: '11',
+                  id: 11,
                   user_id: 1,
                   status: LevelStatus.not_tried
                 }
@@ -259,7 +259,7 @@ describe('TeacherPanel', () => {
               },
               section_script_levels: [
                 {
-                  id: '11',
+                  id: 11,
                   user_id: 1,
                   status: LevelStatus.not_tried
                 }
@@ -283,7 +283,7 @@ describe('TeacherPanel', () => {
               },
               section_script_levels: [
                 {
-                  id: '11',
+                  id: 11,
                   user_id: 1,
                   status: LevelStatus.not_tried
                 }

--- a/apps/test/unit/code-studio/components/progress/TeacherPanelTest.jsx
+++ b/apps/test/unit/code-studio/components/progress/TeacherPanelTest.jsx
@@ -220,7 +220,7 @@ describe('TeacherPanel', () => {
               },
               section_script_levels: [
                 {
-                  id: 11,
+                  id: '11',
                   user_id: 1,
                   status: LevelStatus.not_tried
                 }
@@ -259,7 +259,7 @@ describe('TeacherPanel', () => {
               },
               section_script_levels: [
                 {
-                  id: 11,
+                  id: '11',
                   user_id: 1,
                   status: LevelStatus.not_tried
                 }
@@ -283,7 +283,7 @@ describe('TeacherPanel', () => {
               },
               section_script_levels: [
                 {
-                  id: 11,
+                  id: '11',
                   user_id: 1,
                   status: LevelStatus.not_tried
                 }

--- a/apps/test/unit/code-studio/progressReduxTest.js
+++ b/apps/test/unit/code-studio/progressReduxTest.js
@@ -43,8 +43,8 @@ const stageData = [
     lockable: false,
     levels: [
       {
-        ids: [2106],
-        activeId: 2106,
+        ids: ['2106'],
+        activeId: '2106',
         position: 1,
         kind: LevelKind.unplugged,
         icon: null,
@@ -57,8 +57,8 @@ const stageData = [
         sublevels: []
       },
       {
-        ids: [323],
-        activeId: 323,
+        ids: ['323'],
+        activeId: '323',
         position: 2,
         page_number: 1,
         kind: LevelKind.assessment,
@@ -71,8 +71,8 @@ const stageData = [
         sublevels: []
       },
       {
-        ids: [322],
-        activeId: 322,
+        ids: ['322'],
+        activeId: '322',
         position: 3,
         page_number: 2,
         kind: LevelKind.assessment,
@@ -104,8 +104,8 @@ const stageData = [
     lockable: false,
     levels: [
       {
-        ids: [330],
-        activeId: 330,
+        ids: ['330'],
+        activeId: '330',
         position: 1,
         kind: LevelKind.puzzle,
         icon: null,
@@ -118,8 +118,8 @@ const stageData = [
         sublevels: []
       },
       {
-        ids: [339],
-        activeId: 339,
+        ids: ['339'],
+        activeId: '339',
         position: 2,
         kind: LevelKind.puzzle,
         icon: null,
@@ -131,8 +131,8 @@ const stageData = [
         sublevels: []
       },
       {
-        ids: [341],
-        activeId: 341,
+        ids: ['341'],
+        activeId: '341',
         position: 3,
         kind: LevelKind.puzzle,
         icon: null,
@@ -166,7 +166,7 @@ const initialScriptOverviewProgress = {
 
 // The initial progress passed to the puzzle page
 const initialPuzzlePageProgress = {
-  currentLevelId: 341,
+  currentLevelId: '341',
   professionalLearningCourse: false,
   saveAnswersBeforeNavigation: false,
   lessonGroups: [],
@@ -200,7 +200,7 @@ describe('progressReduxTest', () => {
       const action = initProgress(initialPuzzlePageProgress);
       const nextState = reducer(undefined, action);
 
-      assert.equal(nextState.currentLevelId, 341);
+      assert.equal(nextState.currentLevelId, '341');
       assert.equal(nextState.professionalLearningCourse, false);
       assert.equal(nextState.saveAnswersBeforeNavigation, false);
       assert.deepEqual(
@@ -240,14 +240,14 @@ describe('progressReduxTest', () => {
       // not perfect
       const state = {
         levelProgress: {
-          341: TestResults.MISSING_RECOMMENDED_BLOCK_UNFINISHED
+          '341': TestResults.MISSING_RECOMMENDED_BLOCK_UNFINISHED
         },
         stages: [
           {
             lockable: false,
             levels: [
               {
-                ids: [341],
+                ids: ['341'],
                 kind: 'puzzle',
                 status: LevelStatus.not_tried
               }
@@ -257,9 +257,9 @@ describe('progressReduxTest', () => {
       };
 
       // update progress to perfect
-      const action = mergeProgress({341: TestResults.ALL_PASS});
+      const action = mergeProgress({'341': TestResults.ALL_PASS});
       const nextState = reducer(state, action);
-      assert.equal(nextState.levelProgress[341], TestResults.ALL_PASS);
+      assert.equal(nextState.levelProgress['341'], TestResults.ALL_PASS);
     });
 
     it('cannot move progress backwards', () => {
@@ -267,14 +267,14 @@ describe('progressReduxTest', () => {
       // perfect
       const state = {
         levelProgress: {
-          339: TestResults.ALL_PASS
+          '339': TestResults.ALL_PASS
         },
         stages: [
           {
             lockable: false,
             levels: [
               {
-                ids: [341],
+                ids: ['341'],
                 kind: 'puzzle',
                 status: LevelStatus.perfect
               }
@@ -288,7 +288,7 @@ describe('progressReduxTest', () => {
         341: TestResults.MISSING_RECOMMENDED_BLOCK_UNFINISHED
       });
       const nextState = reducer(state, action);
-      assert.equal(nextState.levelProgress[339], TestResults.ALL_PASS);
+      assert.equal(nextState.levelProgress['339'], TestResults.ALL_PASS);
     });
 
     it('initially sets postMilestoneDisabled to false', () => {
@@ -400,11 +400,11 @@ describe('progressReduxTest', () => {
     describe('statusForLevel', () => {
       it('returns LevelStatus.locked for locked assessment level', () => {
         const level = {
-          ids: [5275],
+          ids: ['5275'],
           uid: '5275_0'
         };
         const levelProgress = {
-          5275: TestResults.LOCKED_RESULT
+          '5275': TestResults.LOCKED_RESULT
         };
         const status = statusForLevel(level, levelProgress);
         assert.strictEqual(status, LevelStatus.locked);
@@ -412,7 +412,7 @@ describe('progressReduxTest', () => {
 
       it('returns LevelStatus.attempted for unlocked assessment level', () => {
         const level = {
-          ids: [5275],
+          ids: ['5275'],
           uid: '5275_0'
         };
         const levelProgress = {
@@ -426,10 +426,10 @@ describe('progressReduxTest', () => {
 
       it('returns LevelStatus.perfect for completed level', () => {
         const level = {
-          ids: [123]
+          ids: ['123']
         };
         const levelProgress = {
-          123: TestResults.ALL_PASS
+          '123': TestResults.ALL_PASS
         };
         const status = statusForLevel(level, levelProgress);
         assert.strictEqual(status, LevelStatus.perfect);
@@ -437,10 +437,10 @@ describe('progressReduxTest', () => {
 
       it('returns LevelStatus.not_tried for level with no progress', () => {
         const level = {
-          ids: [123]
+          ids: ['123']
         };
         const levelProgress = {
-          999: TestResults.ALL_PASS
+          '999': TestResults.ALL_PASS
         };
         const status = statusForLevel(level, levelProgress);
         assert.strictEqual(status, LevelStatus.not_tried);
@@ -468,11 +468,11 @@ describe('progressReduxTest', () => {
       });
       it('returns LevelStatus.completed_assessment for assessment level', () => {
         const level = {
-          ids: [123],
+          ids: ['123'],
           kind: LevelKind.assessment
         };
         const levelProgress = {
-          123: TestResults.ALL_PASS
+          '123': TestResults.ALL_PASS
         };
         const status = statusForLevel(level, levelProgress);
         assert.strictEqual(status, LevelStatus.completed_assessment);
@@ -487,7 +487,7 @@ describe('progressReduxTest', () => {
       lesson_group_display_name: 'Peer Review',
       levels: [
         {
-          ids: [0],
+          ids: ['0'],
           kind: LevelKind.peer_review,
           title: '',
           url: '',
@@ -496,7 +496,7 @@ describe('progressReduxTest', () => {
           locked: true
         },
         {
-          ids: [1],
+          ids: ['1'],
           kind: LevelKind.peer_review,
           title: '',
           url: '',
@@ -539,16 +539,16 @@ describe('progressReduxTest', () => {
       // with some progress, and 1 stage of peer reviews
       const state = {
         levelProgress: {
-          341: TestResults.MISSING_RECOMMENDED_BLOCK_UNFINISHED
+          '341': TestResults.MISSING_RECOMMENDED_BLOCK_UNFINISHED
         },
         stages: [stageData[1]],
         peerReviewLessonInfo: peerReviewLessonInfo
       };
-      assert.equal(state.stages[0].levels[2].ids[0], 341);
+      assert.equal(state.stages[0].levels[2].ids[0], '341');
       state.stages[0].levels[2].status = LevelStatus.attempted;
 
       assert.deepEqual(peerReviewLessonInfo.levels[0], {
-        ids: [0],
+        ids: ['0'],
         kind: LevelKind.peer_review,
         title: '',
         url: '',
@@ -559,7 +559,7 @@ describe('progressReduxTest', () => {
 
       const action = mergePeerReviewProgress([
         {
-          id: 13,
+          id: '13',
           locked: false,
           name: 'Ready to review',
           result: TestResults.UNSUBMITTED_ATTEMPT,
@@ -584,7 +584,7 @@ describe('progressReduxTest', () => {
 
       // First assert about previous state, to make sure that we didn't mutate it
       assert.deepEqual(state.peerReviewLessonInfo.levels[0], {
-        ids: [0],
+        ids: ['0'],
         kind: LevelKind.peer_review,
         title: '',
         url: '',
@@ -596,8 +596,8 @@ describe('progressReduxTest', () => {
       // Now assert for our new state
       assert.deepEqual(nextState.peerReviewLessonInfo.levels[0], {
         // TODO: Seems strange to have both an id and ids. Can we make this better?
-        id: 13,
-        ids: [0],
+        id: '13',
+        ids: ['0'],
         // TODO: Seems strange to have an fa-lock icon even tho we're not locked.
         icon: 'fa-lock',
         locked: false,
@@ -621,16 +621,16 @@ describe('progressReduxTest', () => {
       // merge some progress so that we have statuses
       const action = mergeProgress({
         // stage 2 level 2 is pass
-        339: TestResults.ALL_PASS,
+        '339': TestResults.ALL_PASS,
         // stage 2 level 3 is incomplete
-        341: TestResults.MISSING_RECOMMENDED_BLOCK_UNFINISHED
+        '341': TestResults.MISSING_RECOMMENDED_BLOCK_UNFINISHED
       });
       const state = reducer(initializedState, action);
 
       const expected = [
         [
           {
-            id: 2106,
+            id: '2106',
             status: 'not_tried',
             url:
               'http://localhost-studio.code.org:3000/s/course3/stage/1/puzzle/1',
@@ -650,7 +650,7 @@ describe('progressReduxTest', () => {
             sublevels: []
           },
           {
-            id: 323,
+            id: '323',
             status: 'not_tried',
             url:
               'http://localhost-studio.code.org:3000/s/course3/stage/1/puzzle/2',
@@ -662,7 +662,7 @@ describe('progressReduxTest', () => {
             icon: null,
             isUnplugged: false,
             levelNumber: 1,
-            pageNumber: 1,
+            pageNumber: '1',
             isCurrentLevel: false,
             isConceptLevel: false,
             paired: undefined,
@@ -670,7 +670,7 @@ describe('progressReduxTest', () => {
             sublevels: []
           },
           {
-            id: 322,
+            id: '322',
             status: 'not_tried',
             url:
               'http://localhost-studio.code.org:3000/s/course3/stage/1/puzzle/3',
@@ -682,7 +682,7 @@ describe('progressReduxTest', () => {
             icon: null,
             isUnplugged: false,
             levelNumber: 2,
-            pageNumber: 2,
+            pageNumber: '2',
             isCurrentLevel: false,
             isConceptLevel: false,
             paired: undefined,
@@ -692,7 +692,7 @@ describe('progressReduxTest', () => {
         ],
         [
           {
-            id: 330,
+            id: '330',
             status: 'not_tried',
             url:
               'http://localhost-studio.code.org:3000/s/course3/stage/2/puzzle/1',
@@ -712,7 +712,7 @@ describe('progressReduxTest', () => {
             sublevels: []
           },
           {
-            id: 339,
+            id: '339',
             status: 'perfect',
             url:
               'http://localhost-studio.code.org:3000/s/course3/stage/2/puzzle/2',
@@ -732,7 +732,7 @@ describe('progressReduxTest', () => {
             sublevels: []
           },
           {
-            id: 341,
+            id: '341',
             status: 'attempted',
             url:
               'http://localhost-studio.code.org:3000/s/course3/stage/2/puzzle/3',
@@ -775,13 +775,13 @@ describe('progressReduxTest', () => {
               {
                 kind: LevelKind.unplugged,
                 title: 'Unplugged Activity',
-                ids: [123],
+                ids: ['123'],
                 display_as_unplugged: true
               },
               {
                 kind: LevelKind.puzzle,
                 title: 1,
-                ids: [124],
+                ids: ['124'],
                 display_as_unplugged: false
               }
             ]
@@ -1039,7 +1039,7 @@ describe('progressReduxTest', () => {
         {
           url: '',
           name: 'fake level',
-          ids: [1],
+          ids: ['1'],
           title: 1
         }
       ]
@@ -1049,7 +1049,7 @@ describe('progressReduxTest', () => {
       const state = {
         lessonGroups: [
           {
-            id: 1,
+            id: '1',
             display_name: 'Lesson Group',
             description: 'This is a lesson group',
             big_questions: ' - Why'
@@ -1092,7 +1092,7 @@ describe('progressReduxTest', () => {
 
     it('includes bonus levels in groups if includeBonusLevels is true', () => {
       const bonusLevel = {
-        ids: [2106],
+        ids: ['2106'],
         title: 1,
         bonus: true
       };
@@ -1224,7 +1224,7 @@ describe('progressReduxTest', () => {
           levels: [
             {
               icon: 'fa-lock',
-              ids: [0],
+              ids: ['0'],
               kind: LevelKind.peer_review,
               locked: true,
               name: 'Reviews Unavailable at this time',
@@ -1249,8 +1249,8 @@ describe('progressReduxTest', () => {
           levels: [
             {
               icon: 'fa-lock',
-              id: 1,
-              ids: [0],
+              id: '1',
+              ids: ['0'],
               kind: LevelKind.peer_review,
               locked: false,
               name: 'Link to submitted review',
@@ -1273,7 +1273,7 @@ describe('progressReduxTest', () => {
   });
 
   describe('isPerfect', () => {
-    const levelId = 1;
+    const levelId = '1';
 
     it('returns false if progress was not initialized', () => {
       const state = {};
@@ -1290,7 +1290,7 @@ describe('progressReduxTest', () => {
     it('returns false if the level was not perfected', () => {
       const state = {
         levelProgress: {
-          1: TestResults.MINIMUM_PASS_RESULT
+          '1': TestResults.MINIMUM_PASS_RESULT
         }
       };
       assert.isFalse(isPerfect(state, levelId));
@@ -1299,7 +1299,7 @@ describe('progressReduxTest', () => {
     it('returns true if the level was perfected', () => {
       const state = {
         levelProgress: {
-          1: TestResults.ALL_PASS
+          '1': TestResults.ALL_PASS
         }
       };
       assert.isTrue(isPerfect(state, levelId));

--- a/apps/test/unit/code-studio/progressReduxTest.js
+++ b/apps/test/unit/code-studio/progressReduxTest.js
@@ -3,6 +3,7 @@ import sinon from 'sinon';
 import {TestResults} from '@cdo/apps/constants';
 import {LevelStatus, LevelKind} from '@cdo/apps/util/sharedConstants';
 import {ViewType, setViewType} from '@cdo/apps/code-studio/viewAsRedux';
+import {PUZZLE_PAGE_NONE} from '@cdo/apps/templates/progress/progressTypes';
 import reducer, {
   initProgress,
   isPerfect,
@@ -43,8 +44,8 @@ const stageData = [
     lockable: false,
     levels: [
       {
-        ids: [2106],
-        activeId: 2106,
+        ids: ['2106'],
+        activeId: '2106',
         position: 1,
         kind: LevelKind.unplugged,
         icon: null,
@@ -57,8 +58,8 @@ const stageData = [
         sublevels: []
       },
       {
-        ids: [323],
-        activeId: 323,
+        ids: ['323'],
+        activeId: '323',
         position: 2,
         page_number: 1,
         kind: LevelKind.assessment,
@@ -71,8 +72,8 @@ const stageData = [
         sublevels: []
       },
       {
-        ids: [322],
-        activeId: 322,
+        ids: ['322'],
+        activeId: '322',
         position: 3,
         page_number: 2,
         kind: LevelKind.assessment,
@@ -104,8 +105,8 @@ const stageData = [
     lockable: false,
     levels: [
       {
-        ids: [330],
-        activeId: 330,
+        ids: ['330'],
+        activeId: '330',
         position: 1,
         kind: LevelKind.puzzle,
         icon: null,
@@ -118,8 +119,8 @@ const stageData = [
         sublevels: []
       },
       {
-        ids: [339],
-        activeId: 339,
+        ids: ['339'],
+        activeId: '339',
         position: 2,
         kind: LevelKind.puzzle,
         icon: null,
@@ -131,8 +132,8 @@ const stageData = [
         sublevels: []
       },
       {
-        ids: [341],
-        activeId: 341,
+        ids: ['341'],
+        activeId: '341',
         position: 3,
         kind: LevelKind.puzzle,
         icon: null,
@@ -642,7 +643,7 @@ describe('progressReduxTest', () => {
             icon: null,
             isUnplugged: true,
             levelNumber: undefined,
-            pageNumber: undefined,
+            pageNumber: PUZZLE_PAGE_NONE,
             isCurrentLevel: false,
             isConceptLevel: false,
             paired: undefined,
@@ -662,7 +663,7 @@ describe('progressReduxTest', () => {
             icon: null,
             isUnplugged: false,
             levelNumber: 1,
-            pageNumber: '1',
+            pageNumber: 1,
             isCurrentLevel: false,
             isConceptLevel: false,
             paired: undefined,
@@ -682,7 +683,7 @@ describe('progressReduxTest', () => {
             icon: null,
             isUnplugged: false,
             levelNumber: 2,
-            pageNumber: '2',
+            pageNumber: 2,
             isCurrentLevel: false,
             isConceptLevel: false,
             paired: undefined,
@@ -704,7 +705,7 @@ describe('progressReduxTest', () => {
             icon: null,
             isUnplugged: false,
             levelNumber: 1,
-            pageNumber: undefined,
+            pageNumber: PUZZLE_PAGE_NONE,
             isCurrentLevel: false,
             isConceptLevel: false,
             paired: undefined,
@@ -724,7 +725,7 @@ describe('progressReduxTest', () => {
             icon: null,
             isUnplugged: false,
             levelNumber: 2,
-            pageNumber: undefined,
+            pageNumber: PUZZLE_PAGE_NONE,
             isCurrentLevel: false,
             isConceptLevel: false,
             paired: undefined,
@@ -744,7 +745,7 @@ describe('progressReduxTest', () => {
             icon: null,
             isUnplugged: false,
             levelNumber: 3,
-            pageNumber: undefined,
+            pageNumber: PUZZLE_PAGE_NONE,
             isCurrentLevel: false,
             isConceptLevel: false,
             paired: undefined,

--- a/apps/test/unit/code-studio/progressReduxTest.js
+++ b/apps/test/unit/code-studio/progressReduxTest.js
@@ -43,8 +43,8 @@ const stageData = [
     lockable: false,
     levels: [
       {
-        ids: ['2106'],
-        activeId: '2106',
+        ids: [2106],
+        activeId: 2106,
         position: 1,
         kind: LevelKind.unplugged,
         icon: null,
@@ -57,8 +57,8 @@ const stageData = [
         sublevels: []
       },
       {
-        ids: ['323'],
-        activeId: '323',
+        ids: [323],
+        activeId: 323,
         position: 2,
         page_number: 1,
         kind: LevelKind.assessment,
@@ -71,8 +71,8 @@ const stageData = [
         sublevels: []
       },
       {
-        ids: ['322'],
-        activeId: '322',
+        ids: [322],
+        activeId: 322,
         position: 3,
         page_number: 2,
         kind: LevelKind.assessment,
@@ -104,8 +104,8 @@ const stageData = [
     lockable: false,
     levels: [
       {
-        ids: ['330'],
-        activeId: '330',
+        ids: [330],
+        activeId: 330,
         position: 1,
         kind: LevelKind.puzzle,
         icon: null,
@@ -118,8 +118,8 @@ const stageData = [
         sublevels: []
       },
       {
-        ids: ['339'],
-        activeId: '339',
+        ids: [339],
+        activeId: 339,
         position: 2,
         kind: LevelKind.puzzle,
         icon: null,
@@ -131,8 +131,8 @@ const stageData = [
         sublevels: []
       },
       {
-        ids: ['341'],
-        activeId: '341',
+        ids: [341],
+        activeId: 341,
         position: 3,
         kind: LevelKind.puzzle,
         icon: null,
@@ -776,12 +776,14 @@ describe('progressReduxTest', () => {
                 kind: LevelKind.unplugged,
                 title: 'Unplugged Activity',
                 ids: ['123'],
+                activeId: '123',
                 display_as_unplugged: true
               },
               {
                 kind: LevelKind.puzzle,
                 title: 1,
                 ids: ['124'],
+                activeId: '123',
                 display_as_unplugged: false
               }
             ]
@@ -1040,6 +1042,7 @@ describe('progressReduxTest', () => {
           url: '',
           name: 'fake level',
           ids: ['1'],
+          activeId: 1,
           title: 1
         }
       ]
@@ -1092,6 +1095,7 @@ describe('progressReduxTest', () => {
 
     it('includes bonus levels in groups if includeBonusLevels is true', () => {
       const bonusLevel = {
+        activeId: 2106,
         ids: ['2106'],
         title: 1,
         bonus: true

--- a/apps/test/unit/templates/progress/ProgressBubbleTest.js
+++ b/apps/test/unit/templates/progress/ProgressBubbleTest.js
@@ -7,7 +7,7 @@ import {LevelStatus, LevelKind} from '@cdo/apps/util/sharedConstants';
 
 const defaultProps = {
   level: {
-    id: 1,
+    id: '1',
     levelNumber: 1,
     status: LevelStatus.perfect,
     url: '/foo/bar',
@@ -298,7 +298,7 @@ describe('ProgressBubble', () => {
 
   it('renders a progress pill for unplugged lessons', () => {
     const unpluggedLevel = {
-      id: 1,
+      id: '1',
       status: LevelStatus.perfect,
       kind: LevelKind.unplugged,
       url: '/foo/bar',
@@ -317,7 +317,7 @@ describe('ProgressBubble', () => {
 
   it('does not render a progress pill for unplugged when small', () => {
     const unpluggedLevel = {
-      id: 1,
+      id: '1',
       status: LevelStatus.perfect,
       kind: LevelKind.unplugged,
       url: '/foo/bar',

--- a/apps/test/unit/templates/progress/ProgressPillTest.js
+++ b/apps/test/unit/templates/progress/ProgressPillTest.js
@@ -6,14 +6,14 @@ import {LevelStatus, LevelKind} from '@cdo/apps/util/sharedConstants';
 import ReactTooltip from 'react-tooltip';
 
 const unpluggedLevel = {
-  id: 1,
+  id: '1',
   kind: LevelKind.unplugged,
   isUnplugged: true,
   status: LevelStatus.perfect
 };
 
 const assessmentLevel = {
-  id: 2,
+  id: '2',
   kind: LevelKind.assessment,
   isUnplugged: false,
   status: LevelStatus.perfect

--- a/apps/test/unit/templates/sectionProgress/VirtualizedDetailViewTest.js
+++ b/apps/test/unit/templates/sectionProgress/VirtualizedDetailViewTest.js
@@ -29,13 +29,13 @@ describe('VirtualizedSummaryView', () => {
     defaultProps = {
       levelsByLesson: {
         0: {
-          0: [{id: 789, status: 'perfect'}]
+          0: [{id: '789', status: 'perfect'}]
         },
         1: {
-          0: [{id: 789, status: 'perfect'}]
+          0: [{id: '789', status: 'perfect'}]
         },
         3: {
-          0: [{id: 789, status: 'perfect'}]
+          0: [{id: '789', status: 'perfect'}]
         }
       },
       lessonOfInterest: 1,
@@ -49,7 +49,7 @@ describe('VirtualizedSummaryView', () => {
         stages: [
           {
             id: 456,
-            levels: [{id: 789}]
+            levels: [{id: '789'}]
           }
         ]
       },

--- a/dashboard/app/controllers/api/v1/assessments_controller.rb
+++ b/dashboard/app/controllers/api/v1/assessments_controller.rb
@@ -52,7 +52,7 @@ class Api::V1::AssessmentsController < Api::V1::JsonApiController
       end
 
       assessments[level_group.id] = {
-        id: level_group.id,
+        id: level_group.id.to_s,
         questions: questions,
         name: script_level.lesson.localized_title,
       }

--- a/dashboard/app/models/lesson.rb
+++ b/dashboard/app/models/lesson.rb
@@ -249,7 +249,7 @@ class Lesson < ApplicationRecord
         lesson_data[:levels] += extra_levels
         last_level_summary[:uid] = "#{last_level_summary[:ids].first}_0"
         last_level_summary[:url] << "/page/1"
-        last_level_summary[:page_number] = 1
+        last_level_summary[:page_number] = "1"
       end
 
       # Don't want lesson plans for lockable levels

--- a/dashboard/app/models/lesson.rb
+++ b/dashboard/app/models/lesson.rb
@@ -249,7 +249,7 @@ class Lesson < ApplicationRecord
         lesson_data[:levels] += extra_levels
         last_level_summary[:uid] = "#{last_level_summary[:ids].first}_0"
         last_level_summary[:url] << "/page/1"
-        last_level_summary[:page_number] = "1"
+        last_level_summary[:page_number] = 1
       end
 
       # Don't want lesson plans for lockable levels

--- a/dashboard/app/models/levels/bubble_choice.rb
+++ b/dashboard/app/models/levels/bubble_choice.rb
@@ -77,7 +77,7 @@ class BubbleChoice < DSLDefined
   def summarize(script_level: nil, user: nil)
     user_id = user ? user.id : nil
     summary = {
-      id: id,
+      id: id.to_s,
       display_name: display_name,
       description: description,
       name: name,
@@ -116,7 +116,7 @@ class BubbleChoice < DSLDefined
 
       level_info.merge!(
         {
-          id: level.id,
+          id: level.id.to_s,
           description: level.try(:bubble_choice_description),
           thumbnail_url: level.try(:thumbnail_url),
           position: index + 1,

--- a/dashboard/app/models/levels/level.rb
+++ b/dashboard/app/models/levels/level.rb
@@ -607,7 +607,7 @@ class Level < ApplicationRecord
 
   def summarize
     {
-      level_id: id,
+      level_id: id.to_s,
       type: self.class.to_s,
       name: name,
       display_name: display_name

--- a/dashboard/app/models/script_level.rb
+++ b/dashboard/app/models/script_level.rb
@@ -495,7 +495,7 @@ class ScriptLevel < ApplicationRecord
     (1..extra_level_count).each do |page_index|
       new_level = last_level_summary.deep_dup
       new_level[:uid] = "#{level_id}_#{page_index}"
-      new_level[:page_number] = (page_index + 1).to_s
+      new_level[:page_number] = page_index + 1
       new_level[:url] << "/page/#{page_index + 1}"
       new_level[:position] = last_level_summary[:position] + page_index
       new_level[:title] = last_level_summary[:position] + page_index

--- a/dashboard/app/models/script_level.rb
+++ b/dashboard/app/models/script_level.rb
@@ -495,7 +495,7 @@ class ScriptLevel < ApplicationRecord
     (1..extra_level_count).each do |page_index|
       new_level = last_level_summary.deep_dup
       new_level[:uid] = "#{level_id}_#{page_index}"
-      new_level[:page_number] = page_index + 1
+      new_level[:page_number] = (page_index + 1).to_s
       new_level[:url] << "/page/#{page_index + 1}"
       new_level[:position] = last_level_summary[:position] + page_index
       new_level[:title] = last_level_summary[:position] + page_index
@@ -599,6 +599,7 @@ class ScriptLevel < ApplicationRecord
       bonus: bonus
     }
     if user_level
+      # note: level.id gets replaced with user_level.id here
       teacher_panel_summary.merge!(user_level.attributes)
     end
 

--- a/dashboard/app/models/script_level.rb
+++ b/dashboard/app/models/script_level.rb
@@ -386,8 +386,8 @@ class ScriptLevel < ApplicationRecord
     end
 
     summary = {
-      ids: ids,
-      activeId: oldest_active_level.id,
+      ids: ids.map(&:to_s),
+      activeId: oldest_active_level.id.to_s,
       position: position,
       kind: kind,
       icon: level.icon,
@@ -421,11 +421,6 @@ class ScriptLevel < ApplicationRecord
       summary[:conceptDifficulty] = level.summarize_concept_difficulty
       summary[:assessment] = !!assessment
       summary[:challenge] = !!challenge
-
-      # TODO: (charlie) we will move this string conversion out of this
-      # `for_edit` block as soon as code studio updates to use strings for ids
-      summary[:ids] = summary[:ids].map(&:to_s)
-      summary[:activeId] = summary[:activeId].to_s
     end
 
     if include_prev_next
@@ -458,11 +453,11 @@ class ScriptLevel < ApplicationRecord
 
   def summarize_for_lesson_show
     summary = summarize
-    summary[:id] = id
+    summary[:id] = id.to_s
     summary[:levels] = levels.map do |level|
       {
         name: level.name,
-        id: level.id,
+        id: level.id.to_s,
         icon: level.icon,
         isConceptLevel: level.concept_level?
       }
@@ -472,7 +467,6 @@ class ScriptLevel < ApplicationRecord
 
   def summarize_for_lesson_edit
     summary = summarize(for_edit: true)
-    summary[:id] = id.to_s
     summary[:activitySectionPosition] = activity_section_position
     summary[:levels] = levels.map do |level|
       {
@@ -507,7 +501,7 @@ class ScriptLevel < ApplicationRecord
   def summarize_as_bonus(user_id = nil)
     perfect = user_id ? UserLevel.find_by(level: level, user_id: user_id)&.perfect? : false
     {
-      id: id,
+      id: id.to_s,
       type: level.type,
       description: level.try(:bubble_choice_description),
       display_name: level.display_name || I18n.t('lesson_extras.bonus_level'),
@@ -528,7 +522,7 @@ class ScriptLevel < ApplicationRecord
     lesson_extra_user_level = student.user_levels.where(script: script, level: bonus_level_ids)&.first
     if lesson_extra_user_level
       {
-        id: lesson_extra_user_level.id,
+        id: lesson_extra_user_level.id.to_s,
         bonus: true,
         user_id: student.id,
         status: SharedConstants::LEVEL_STATUS.perfect,
@@ -539,7 +533,7 @@ class ScriptLevel < ApplicationRecord
         # Some lessons have a lesson extras option without any bonus levels. In
         # these cases, they just display previous lesson challenges. These should
         # be displayed as "perfect." Example level: /s/express-2020/stage/28/extras
-        id: -1,
+        id: '-1',
         bonus: true,
         user_id: student.id,
         passed: true,
@@ -547,7 +541,7 @@ class ScriptLevel < ApplicationRecord
       }
     else
       {
-        id: bonus_level_ids.first,
+        id: bonus_level_ids.first.to_s,
         bonus: true,
         user_id: student.id,
         passed: false,
@@ -584,7 +578,7 @@ class ScriptLevel < ApplicationRecord
     end
 
     teacher_panel_summary = {
-      id: level.id,
+      id: level.id.to_s,
       contained: contained,
       submitLevel: level.properties['submittable'] == 'true',
       paired: paired,

--- a/dashboard/app/models/script_level.rb
+++ b/dashboard/app/models/script_level.rb
@@ -467,6 +467,7 @@ class ScriptLevel < ApplicationRecord
 
   def summarize_for_lesson_edit
     summary = summarize(for_edit: true)
+    summary[:id] = id.to_s
     summary[:activitySectionPosition] = activity_section_position
     summary[:levels] = levels.map do |level|
       {

--- a/dashboard/app/views/layouts/_header.html.haml
+++ b/dashboard/app/views/layouts/_header.html.haml
@@ -142,7 +142,7 @@
       #{stage_data.to_json},
       #{user_progress},
       "#{script_level&.level_id || -1}",
-      "#{puzzle_page}",
+      #{puzzle_page},
       #{signed_in},
       #{lesson_extras_enabled || 'null'},
       #{script_name_data.to_json},

--- a/dashboard/app/views/layouts/_header.html.haml
+++ b/dashboard/app/views/layouts/_header.html.haml
@@ -102,8 +102,7 @@
       lesson_extras_enabled = view_as.lesson_extras_enabled?(script)
     end
 
-    # don't trust outside content in parameter :puzzle_page - should be integer, so immediately call to_i
-    puzzle_page = params[:puzzle_page] ? params[:puzzle_page].to_i : ApplicationHelper::PUZZLE_PAGE_NONE
+    puzzle_page = params[:puzzle_page] ? params[:puzzle_page] : ApplicationHelper::PUZZLE_PAGE_NONE
 
     script_data = script.summarize_header
     lesson_group_data = script.lesson_groups.map(&:summarize)
@@ -142,8 +141,8 @@
       #{lesson_group_data.to_json},
       #{stage_data.to_json},
       #{user_progress},
-      #{script_level&.level_id || -1},
-      #{puzzle_page},
+      "#{script_level&.level_id || -1}",
+      "#{puzzle_page}",
       #{signed_in},
       #{lesson_extras_enabled || 'null'},
       #{script_name_data.to_json},

--- a/dashboard/test/controllers/api/v1/assessments_controller_test.rb
+++ b/dashboard/test/controllers/api/v1/assessments_controller_test.rb
@@ -119,26 +119,26 @@ class Api::V1::AssessmentsControllerTest < ActionController::TestCase
     expected_match_options = [{"text" => "one"}, {"text" => "two"}]
 
     expected_questions = [
-      {"level_id" => sub_level1.id, "type" => "TextMatch", "name" => sub_level1.name,
+      {"level_id" => sub_level1.id.to_s, "type" => "TextMatch", "name" => sub_level1.name,
         "display_name" => nil, "title" => "title", "question_text" => nil, "question_index" => 0},
-      {"level_id" => sub_level2.id, "type" => "Multi", "name" => sub_level2.name,
+      {"level_id" => sub_level2.id.to_s, "type" => "Multi", "name" => sub_level2.name,
         "display_name" => nil, "answers" => expected_answers, "question_text" => sub_level2.get_question_text, "question_index" => 1},
-      {"level_id" => sub_level3.id, "type" => "Multi", "name" => sub_level3.name,
+      {"level_id" => sub_level3.id.to_s, "type" => "Multi", "name" => sub_level3.name,
         "display_name" => nil, "answers" => expected_answers, "question_text" => sub_level3.get_question_text, "question_index" => 2},
-      {"level_id" => sub_level4.id, "type" => "Multi", "name" => sub_level4.name,
+      {"level_id" => sub_level4.id.to_s, "type" => "Multi", "name" => sub_level4.name,
         "display_name" => nil, "answers" => expected_answers, "question_text" => sub_level4.get_question_text, "question_index" => 3},
-      {"level_id" => sub_level6.id, "type" => "Match", "name" => sub_level6.name,
+      {"level_id" => sub_level6.id.to_s, "type" => "Match", "name" => sub_level6.name,
        "display_name" => nil, "answers" => expected_match_answers, "options" => expected_match_options, "question_text" => sub_level6.get_question_text, "question" => sub_level6.question, "question_index" => 4},
-      {"level_id" => sub_level7.id, "type" => "Match", "name" => sub_level7.name,
+      {"level_id" => sub_level7.id.to_s, "type" => "Match", "name" => sub_level7.name,
        "display_name" => nil, "answers" => expected_match_answers, "options" => expected_match_options, "question_text" => sub_level7.get_question_text, "question" => sub_level7.question, "question_index" => 5},
-      {"level_id" => sub_level8.id, "type" => "Match", "name" => sub_level8.name,
+      {"level_id" => sub_level8.id.to_s, "type" => "Match", "name" => sub_level8.name,
        "display_name" => nil, "answers" => expected_match_answers, "options" => expected_match_options, "question_text" => sub_level8.get_question_text, "question" => sub_level8.question, "question_index" => 6},
-      {"level_id" => sub_level5.id, "type" => "Multi", "name" => sub_level5.name,
+      {"level_id" => sub_level5.id.to_s, "type" => "Multi", "name" => sub_level5.name,
         "display_name" => nil, "answers" => expected_answers, "question_text" => sub_level5.get_question_text, "question_index" => 7},
     ]
     level_response = JSON.parse(@response.body)[level1.id.to_s]
     assert_equal "translation missing: en-US.data.script.name.#{script.name}.title", level_response["name"]
-    assert_equal level1.id, level_response["id"]
+    assert_equal level1.id.to_s, level_response["id"]
     assert_equal expected_questions, level_response["questions"]
   end
 

--- a/dashboard/test/models/lesson_test.rb
+++ b/dashboard/test/models/lesson_test.rb
@@ -82,7 +82,7 @@ class LessonTest < ActiveSupport::TestCase
 
     summary = lesson.summarize(true)
     assert_equal 1, summary[:levels].length
-    assert_equal [level.id], summary[:levels].first[:ids]
+    assert_equal [level.id.to_s], summary[:levels].first[:ids]
   end
 
   test "summary of levels for lesson plan" do
@@ -100,7 +100,7 @@ class LessonTest < ActiveSupport::TestCase
         assessment: script_level.assessment,
         progression: script_level.progression,
         path: script_level.path,
-        level_id: level.id,
+        level_id: level.id.to_s,
         type: level.class.to_s,
         name: level.name,
         display_name: level.display_name

--- a/dashboard/test/models/level_test.rb
+++ b/dashboard/test/models/level_test.rb
@@ -143,7 +143,7 @@ class LevelTest < ActiveSupport::TestCase
 
   test "summarize returns object with expected fields" do
     summary = @level.summarize
-    assert_equal(summary[:level_id], @level.id)
+    assert_equal(summary[:level_id], @level.id.to_s)
     assert_equal(summary[:type], 'Maze')
     assert_equal(summary[:name], '__bob4')
     assert_nil(summary[:display_name])

--- a/dashboard/test/models/levels/bubble_choice_test.rb
+++ b/dashboard/test/models/levels/bubble_choice_test.rb
@@ -95,7 +95,7 @@ DSL
   test 'summarize' do
     summary = @bubble_choice.summarize
     expected_summary = {
-      id: @bubble_choice.id,
+      id: @bubble_choice.id.to_s,
       display_name: @bubble_choice.display_name,
       description: @bubble_choice.description,
       name: @bubble_choice.name,
@@ -127,8 +127,8 @@ DSL
     expected_summary = [
       {
         # level_id and id are used by different features so keeping both
-        level_id: @sublevel1.id,
-        id: @sublevel1.id,
+        level_id: @sublevel1.id.to_s,
+        id: @sublevel1.id.to_s,
         display_name: @sublevel1.display_name,
         description: @sublevel1.bubble_choice_description,
         thumbnail_url: @sublevel1.thumbnail_url,
@@ -141,8 +141,8 @@ DSL
         status: 'not_tried'
       },
       {
-        level_id: @sublevel2.id,
-        id: @sublevel2.id,
+        level_id: @sublevel2.id.to_s,
+        id: @sublevel2.id.to_s,
         display_name: @sublevel2.name,
         description: @sublevel2.bubble_choice_description,
         thumbnail_url: nil,

--- a/dashboard/test/models/script_level_test.rb
+++ b/dashboard/test/models/script_level_test.rb
@@ -160,7 +160,7 @@ class ScriptLevelTest < ActiveSupport::TestCase
     script_level = create_script_level_with_ancestors({levels: [bubble_choice]})
 
     expected_summary = {
-      id: bubble_choice.id,
+      id: bubble_choice.id.to_s,
       contained: false,
       submitLevel: false,
       paired: nil,

--- a/dashboard/test/models/script_test.rb
+++ b/dashboard/test/models/script_test.rb
@@ -1124,7 +1124,7 @@ class ScriptTest < ActiveSupport::TestCase
     response = script.summarize(true, nil, true)
     assert_equal 1, response[:lessons].length
     assert_equal 1, response[:lessons].first[:levels].length
-    assert_equal [level.id], response[:lessons].first[:levels].first[:ids]
+    assert_equal [level.id.to_s], response[:lessons].first[:levels].first[:ids]
   end
 
   test 'should generate PLC objects' do


### PR DESCRIPTION
Note: This PR was a shared effort between jmkulwik and cforkish.

this is the third and final installment of work to make `id` a required string property on `level` objects in our client code. initially we decided to use numbers for the id property, and that work was completed in #38085. then after being educated about the preference for using strings for keys in javascript objects (which is the primary purpose of the id prop), we decided to update the prop to be a string. this work was divided into two parts. the first was to update all the levelbuilder code to use strings, which was completed in #38403. this PR completes the work by updating the rest of our client code to use strings.