### PR TITLE
Add playSpeech block to gamelab

### DIFF
--- a/apps/src/p5lab/gamelab/dropletConfig.js
+++ b/apps/src/p5lab/gamelab/dropletConfig.js
@@ -55,6 +55,7 @@ module.exports.blocks = [
   //  {func: 'height', category: 'World', type: 'readonlyproperty', noAutocomplete: true },
   {...audioApiDropletConfig.playSound, category: 'World'},
   {...audioApiDropletConfig.stopSound, category: 'World'},
+  {...audioApiDropletConfig.playSpeech, category: 'World'},
   {
     func: 'keyIsPressed',
     category: 'World',

--- a/lib/cdo/shared_constants.rb
+++ b/lib/cdo/shared_constants.rb
@@ -388,6 +388,7 @@ module SharedConstants
       "drawSprites": null,
       "playSound": null,
       "stopSound": null,
+      "playSpeech": null,
       "keyDown": null,
       "keyWentDown": null,
       "keyWentUp": null,


### PR DESCRIPTION
Adds the `playSpeech` block to Gamelab. 

I wanted to wait until #38202 was merged because that bug will manifest most in Gamelab, and we were focused on deploying this block for Applab before the end of the year. This block was deployed for Applab in #38186.

## Links

<!--
  Any relevant links to external resources; ie, specification documents, jira
  items, related PRs, honeybadger errors, etc
-->

- [spec]()
- [jira]()

## Testing story

<!--
  Does your change include appropriate tests?

  If so, please describe how the tests included in this PR are sufficient

  If not, please explain why this change does not need to be tested.
-->

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
