### PR TITLE
[Spritelab] When Sprite Created Block

### DIFF
--- a/apps/i18n/spritelab/en_us.json
+++ b/apps/i18n/spritelab/en_us.json
@@ -1,6 +1,8 @@
 {
   "clicked": "clicked ",
   "clickedSprite": "clicked sprite",
+  "new": "new ",
+  "newSprite": "new sprite",
   "subject": "subject ",
   "subjectSprite": "subject sprite",
   "object": "object ",

--- a/apps/src/block_utils.js
+++ b/apps/src/block_utils.js
@@ -1112,6 +1112,14 @@ exports.createJsWrapperBlockCreator = function(
                 root.getConnections_()[1].targetBlock()
             );
             break;
+          case 'gamelab_newSpritePointer':
+            this.setBlockToShadow(
+              root =>
+                root.type === 'gamelab_whenSpriteCreated' &&
+                root.getConnections_()[1] &&
+                root.getConnections_()[1].targetBlock()
+            );
+            break;
           case 'gamelab_subjectSpritePointer':
             this.setBlockToShadow(
               root =>

--- a/apps/src/block_utils.js
+++ b/apps/src/block_utils.js
@@ -1102,34 +1102,35 @@ exports.createJsWrapperBlockCreator = function(
           this.initMiniFlyout(miniToolboxXml);
         }
 
-        // For mini-toolbox, indicate which blocks should receive the duplicate on drag
-        // behavior and indicates the sibling block to shadow the value from
-        if (this.type === 'gamelab_clickedSpritePointer') {
-          this.setParentForCopyOnDrag('gamelab_spriteClickedSet');
-          this.setBlockToShadow(
-            root =>
-              root.type === 'gamelab_spriteClicked' &&
-              root.getConnections_()[1] &&
-              root.getConnections_()[1].targetBlock()
-          );
-        }
-        if (this.type === 'gamelab_subjectSpritePointer') {
-          this.setParentForCopyOnDrag('gamelab_whenTouchingSet');
-          this.setBlockToShadow(
-            root =>
-              root.type === 'gamelab_checkTouching' &&
-              root.getConnections_()[1] &&
-              root.getConnections_()[1].targetBlock()
-          );
-        }
-        if (this.type === 'gamelab_objectSpritePointer') {
-          this.setParentForCopyOnDrag('gamelab_whenTouchingSet');
-          this.setBlockToShadow(
-            root =>
-              root.type === 'gamelab_checkTouching' &&
-              root.getConnections_()[2] &&
-              root.getConnections_()[2].targetBlock()
-          );
+        // Set block to shadow for preview field if needed
+        switch (this.type) {
+          case 'gamelab_clickedSpritePointer':
+            this.setBlockToShadow(
+              root =>
+                root.type === 'gamelab_spriteClicked' &&
+                root.getConnections_()[1] &&
+                root.getConnections_()[1].targetBlock()
+            );
+            break;
+          case 'gamelab_subjectSpritePointer':
+            this.setBlockToShadow(
+              root =>
+                root.type === 'gamelab_checkTouching' &&
+                root.getConnections_()[1] &&
+                root.getConnections_()[1].targetBlock()
+            );
+            break;
+          case 'gamelab_objectSpritePointer':
+            this.setBlockToShadow(
+              root =>
+                root.type === 'gamelab_checkTouching' &&
+                root.getConnections_()[2] &&
+                root.getConnections_()[2].targetBlock()
+            );
+            break;
+          default:
+            // Not a pointer block, so no block to shadow
+            break;
         }
 
         interpolateInputs(blockly, this, inputRows, inputTypes, inline);

--- a/apps/src/p5lab/spritelab/blocks.js
+++ b/apps/src/p5lab/spritelab/blocks.js
@@ -255,6 +255,10 @@ const customInputTypes = {
             block.shortString = spritelabMsg.clicked();
             block.longString = spritelabMsg.clickedSprite();
             break;
+          case 'gamelab_newSpritePointer':
+            block.shortString = spritelabMsg.new();
+            block.longString = spritelabMsg.newSprite();
+            break;
           case 'gamelab_subjectSpritePointer':
             block.shortString = spritelabMsg.subject();
             block.longString = spritelabMsg.subjectSprite();
@@ -281,6 +285,8 @@ const customInputTypes = {
       switch (block.type) {
         case 'gamelab_clickedSpritePointer':
           return '{id: extraArgs.clickedSprite}';
+        case 'gamelab_newSpritePointer':
+          return '{id: extraArgs.newSprite}';
         case 'gamelab_subjectSpritePointer':
           return '{id: extraArgs.subjectSprite}';
         case 'gamelab_objectSpritePointer':

--- a/apps/src/p5lab/spritelab/commands.js
+++ b/apps/src/p5lab/spritelab/commands.js
@@ -177,6 +177,10 @@ export const commands = {
     eventCommands.spriteClicked(condition, spriteArg, callback);
   },
 
+  whenSpriteCreated(spriteArg, callback) {
+    eventCommands.whenSpriteCreated(spriteArg, callback);
+  },
+
   whenPromptAnswered(variableName, callback) {
     eventCommands.whenPromptAnswered(variableName, callback);
   },

--- a/apps/src/p5lab/spritelab/commands/eventCommands.js
+++ b/apps/src/p5lab/spritelab/commands/eventCommands.js
@@ -39,6 +39,16 @@ export const commands = {
     }
   },
 
+  whenSpriteCreated(spriteArg, callback) {
+    if (spriteArg && spriteArg.costume) {
+      coreLibrary.addEvent(
+        'whenSpriteCreated',
+        {costume: spriteArg.costume},
+        callback
+      );
+    }
+  },
+
   whenPromptAnswered(variableName, callback) {
     coreLibrary.registerPromptAnswerCallback(variableName, callback);
   }

--- a/apps/src/p5lab/spritelab/commands/spriteCommands.js
+++ b/apps/src/p5lab/spritelab/commands/spriteCommands.js
@@ -72,7 +72,7 @@ export const commands = {
     sprite.getScale = function() {
       return sprite.scale / sprite.baseScale;
     };
-    let spriteArg = coreLibrary.addSprite(sprite, name);
+    let spriteArg = coreLibrary.addSprite(sprite, name, animation);
     if (animation) {
       sprite.setAnimation(animation);
       sprite.scale /= sprite.baseScale;

--- a/apps/src/p5lab/spritelab/coreLibrary.js
+++ b/apps/src/p5lab/spritelab/coreLibrary.js
@@ -3,6 +3,7 @@ var nativeSpriteMap = {};
 var inputEvents = [];
 var behaviors = [];
 var userInputEventCallbacks = {};
+var newSprites = {};
 
 export var background;
 export var title = '';
@@ -119,13 +120,19 @@ export function getSpriteIdsInUse() {
  * @param {Sprite} sprite
  * @returns {Number} A unique id to reference the sprite.
  */
-export function addSprite(sprite, name) {
+export function addSprite(sprite, name, animation) {
   nativeSpriteMap[spriteId] = sprite;
   sprite.id = spriteId;
   if (name) {
     enforceUniqueSpriteName(name);
     sprite.name = name;
   }
+  if (animation) {
+    // Add to new sprites map so we can fire a "when sprite created" event if needed
+    newSprites[animation] = newSprites[animation] || [];
+    newSprites[animation].push(sprite);
+  }
+
   spriteId++;
   return sprite.id;
 }
@@ -344,6 +351,17 @@ function whileClickEvent(inputEvent, p5Inst) {
   return callbackArgList;
 }
 
+function whenSpriteCreatedEvent(inputEvent, p5Inst) {
+  let callbackArgList = [];
+  let sprites = newSprites[inputEvent.args.costume] || [];
+  sprites.forEach(sprite => {
+    callbackArgList.push({newSprite: sprite.id});
+  });
+  // Clear newSprites
+  newSprites = {};
+  return callbackArgList;
+}
+
 /**
  * @param {Object} inputEvent
  * @param p5Inst - the running P5 instance
@@ -373,6 +391,8 @@ function getCallbackArgListForEvent(inputEvent, p5Inst) {
       return whenClickEvent(inputEvent, p5Inst);
     case 'whileclick':
       return whileClickEvent(inputEvent, p5Inst);
+    case 'whenSpriteCreated':
+      return whenSpriteCreatedEvent(inputEvent, p5Inst);
   }
 }
 

--- a/apps/src/p5lab/spritelab/coreLibrary.js
+++ b/apps/src/p5lab/spritelab/coreLibrary.js
@@ -357,8 +357,6 @@ function whenSpriteCreatedEvent(inputEvent, p5Inst) {
   sprites.forEach(sprite => {
     callbackArgList.push({newSprite: sprite.id});
   });
-  // Clear newSprites
-  newSprites = {};
   return callbackArgList;
 }
 
@@ -403,6 +401,9 @@ export function runEvents(p5Inst) {
       inputEvent.callback(args);
     });
   });
+
+  // Clear newSprites. Used for whenSpriteCreated events and should be reset every tick.
+  newSprites = {};
 }
 
 export function addBehavior(sprite, behavior) {

--- a/dashboard/config/blocks/GamelabJr/gamelab_newSpritePointer.json
+++ b/dashboard/config/blocks/GamelabJr/gamelab_newSpritePointer.json
@@ -1,0 +1,15 @@
+{
+  "category": "Events",
+  "config": {
+    "simpleValue": true,
+    "name": "newSpritePointer",
+    "blockText": "{SPRITE}",
+    "args": [
+      {
+        "name": "SPRITE",
+        "customInput": "spritePointer"
+      }
+    ],
+    "returnType": "Sprite"
+  }
+}

--- a/dashboard/config/blocks/GamelabJr/gamelab_whenSpriteCreated.json
+++ b/dashboard/config/blocks/GamelabJr/gamelab_whenSpriteCreated.json
@@ -1,0 +1,25 @@
+{
+  "category": "Events",
+  "config": {
+    "color": [
+      140,
+      1,
+      0.74
+    ],
+    "func": "whenSpriteCreated",
+    "blockText": "when {SPRITE} created",
+    "miniToolboxBlocks": [
+      "gamelab_newSpritePointer"
+    ],
+    "callbackParams": [
+      "extraArgs"
+    ],
+    "args": [
+      {
+        "name": "SPRITE",
+        "type": "Sprite"
+      }
+    ],
+    "eventBlock": true
+  }
+}


### PR DESCRIPTION
From the block request doc:

> New event triggered for each sprite (of matching costume or name) when it is created.
> Fires only when created, not when changing costumes.
> Has a mini-toolbox

![image](https://user-images.githubusercontent.com/8787187/102656392-aa80d800-4128-11eb-9c8f-d07511c2eb4d.png)
![Dec-18-2020 11-36-00](https://user-images.githubusercontent.com/8787187/102656558-e7e56580-4128-11eb-921f-50949f0a6a6c.gif)


<!--
  Other aspects to consider. uncomment and add detail for any that seem necessary:
-->

<!-- ### Background -->
<!-- ### Privacy -->
<!--
1.	Does the Project involve the collection, use or sharing of new Personal Data?

2.	Does the Project involve a new or changed use or sharing of existing Personal Data?
-->
<!-- ### Security -->
<!--
Link to Jira Task where sensitive security issues are discussed privately.
-->
<!-- ### Caching -->
<!-- ### Deployment strategy -->
<!-- ### Future work -->

## Links

<!--
  Any relevant links to external resources; ie, specification documents, jira
  items, related PRs, honeybadger errors, etc
-->
[block request doc](https://docs.google.com/document/d/1aU4N4K-_8y_iHB7Jmu88rZpgR_vfHHihdcYma-CnBKA/edit#heading=h.p55s2daartl4)

## Testing story

<!--
  Does your change include appropriate tests?

  If so, please describe how the tests included in this PR are sufficient

  If not, please explain why this change does not need to be tested.
-->

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
