### PR TITLE
Check invalid types

### DIFF
--- a/apps/src/lib/util/audioApi.js
+++ b/apps/src/lib/util/audioApi.js
@@ -123,8 +123,23 @@ export const commands = {
    * @param {string} opts.language The language of the text to play.
    */
   async playSpeech(opts) {
-    apiValidateType(opts, 'playSpeech', 'text', opts.text, 'string');
-    apiValidateType(opts, 'playSpeech', 'gender', opts.gender, 'string');
+    const validText = apiValidateType(
+      opts,
+      'playSpeech',
+      'text',
+      opts.text,
+      'string'
+    );
+    const validGender = apiValidateType(
+      opts,
+      'playSpeech',
+      'gender',
+      opts.gender,
+      'string'
+    );
+    if (!validText || !validGender) {
+      return;
+    }
     apiValidateType(
       opts,
       'playSpeech',

--- a/dashboard/app/controllers/profanity_controller.rb
+++ b/dashboard/app/controllers/profanity_controller.rb
@@ -26,7 +26,7 @@ class ProfanityController < ApplicationController
       DCDO.get('profanity_request_limit_per_min_default', REQUEST_LIMIT_PER_MIN_DEFAULT)
     period = 60
 
-    ProfanityHelper.throttled_find_profanities(params[:text], locale, id, limit, period) do |profanities|
+    ProfanityHelper.throttled_find_profanities(params[:text]&.to_s, locale, id, limit, period) do |profanities|
       return render json: profanities
     end
 


### PR DESCRIPTION
Addresses [this Honeybadger error](https://app.honeybadger.io/projects/3240/faults/72264795), which occurs if `params[:text]` for `POST /profanity/find` isn't a string.

Also returns early from `playSpeech` if either required parameter (text and gender) is invalid.

## Links

<!--
  Any relevant links to external resources; ie, specification documents, jira
  items, related PRs, honeybadger errors, etc
-->

- [Honeybadger](https://app.honeybadger.io/projects/3240/faults/72264795)

## Testing story

Manually tested.

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
