### PR TITLE
[Google Blockly] Bump to 4.20201217.0

### DIFF
--- a/apps/package.json
+++ b/apps/package.json
@@ -220,7 +220,7 @@
   "dependencies": {
     "@code-dot-org/js-interpreter": "1.3.13",
     "@microsoft/immersive-reader-sdk": "^1.1.0",
-    "blockly": "3.20200924.2",
+    "blockly": "4.20201217.0",
     "crypto-js": "^3.1.9-1",
     "details-element-polyfill": "https://github.com/javan/details-element-polyfill",
     "filesaver.js": "0.2.0",

--- a/apps/src/blocklyAddons/cdoBlockSvg.js
+++ b/apps/src/blocklyAddons/cdoBlockSvg.js
@@ -5,16 +5,6 @@ export default class BlockSvg extends GoogleBlockly.BlockSvg {
   constructor(workspace, prototypeName, opt_id) {
     super(workspace, prototypeName, ++Blockly.uidCounter_); // Use counter instead of randomly generated IDs
 
-    /* *
-     * Workaround to make block id available on SVG in IE.
-     * I opened https://github.com/google/blockly/issues/4419 so hopefully we can remove this with the next
-     * Blockly release if they fix the issue.
-     * In the meantime, the workaround is to call svgGroup_.setAttribute(), instead of setting
-     * svgGroup_.dataset['id'] directly.
-     */
-    if (this.svgGroup_.dataset === undefined) {
-      this.svgGroup_.setAttribute('data-id', this.id);
-    }
     this.canDisconnectFromParent_ = true;
   }
 

--- a/apps/src/sites/studio/pages/googleBlocklyWrapper.js
+++ b/apps/src/sites/studio/pages/googleBlocklyWrapper.js
@@ -221,6 +221,10 @@ function initializeBlocklyWrapper(blocklyInstance) {
   // This function was a custom addition in CDO Blockly, so we need to add it here
   // so that our code generation logic still works with Google Blockly
   blocklyWrapper.Generator.blockSpaceToCode = function(name, opt_typeFilter) {
+    const generator = blocklyWrapper.getGenerator();
+    if (!generator.isInitialized) {
+      generator.init(blocklyWrapper.mainBlockSpace);
+    }
     let blocksToGenerate = blocklyWrapper.mainBlockSpace.getTopBlocks(
       true /* ordered */
     );

--- a/apps/yarn.lock
+++ b/apps/yarn.lock
@@ -3655,12 +3655,12 @@ block-stream@*:
   dependencies:
     inherits "~2.0.0"
 
-blockly@3.20200924.2:
-  version "3.20200924.2"
-  resolved "https://registry.yarnpkg.com/blockly/-/blockly-3.20200924.2.tgz#469611b42e869f9d50e4b562e5fe2ae48fab075f"
-  integrity sha512-2wiK8bj3qPuqb26U7HgD925nVmmcBwgoRmAqqoEJLCn+yWidrceQuDr/9aGCWxwLo0DEMStz10lhC3+Hqul83g==
+blockly@4.20201217.0:
+  version "4.20201217.0"
+  resolved "https://registry.yarnpkg.com/blockly/-/blockly-4.20201217.0.tgz#2031f42ff84d34a0fb35b1e69b0064466a1e0346"
+  integrity sha512-kQjP0TydnMIkH8pbJ0qpC1bhqATijCwFMi1UFP3SjULWTR44JpHC4g8c2K+ATUexg9p5/nioslQDNL8dBi3nvw==
   dependencies:
-    jsdom "^15.2.1"
+    jsdom "15.2.1"
 
 bluebird@^3.3.0:
   version "3.5.0"
@@ -9543,7 +9543,7 @@ jsbn@~0.1.0:
   version "0.1.0"
   resolved "https://registry.yarnpkg.com/jsbn/-/jsbn-0.1.0.tgz#650987da0dd74f4ebf5a11377a2aa2d273e97dfd"
 
-jsdom@^15.2.1:
+jsdom@15.2.1:
   version "15.2.1"
   resolved "https://registry.yarnpkg.com/jsdom/-/jsdom-15.2.1.tgz#d2feb1aef7183f86be521b8c6833ff5296d07ec5"
   integrity sha512-fAl1W0/7T2G5vURSyxBzrJ1LSdQn6Tr5UX/xD4PXDx/PDgwygedfW6El/KIj3xJ7FU61TTYnc/l/B7P49Eqt6g==


### PR DESCRIPTION

## Links

<!--
  Any relevant links to external resources; ie, specification documents, jira
  items, related PRs, honeybadger errors, etc
-->

- [jira](https://codedotorg.atlassian.net/browse/STAR-1377)
- [Blockly Release](https://github.com/google/blockly/releases/tag/4.20201217.0)

## Testing story
Manually tested with Flappy. I bug-bashed mostly in Chrome on my Mac, but once this PR is in, I'll schedule an informal bug bash to get more browsers/machines tested before we turn it back on for all Flappy levels.

<!--
  Does your change include appropriate tests?

  If so, please describe how the tests included in this PR are sufficient

  If not, please explain why this change does not need to be tested.
-->

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
