### PR TITLE
Undo hack to hide the event registration form during HOC

### DIFF
--- a/pegasus/sites.v3/hourofcode.com/views/home_signup.haml
+++ b/pegasus/sites.v3/hourofcode.com/views/home_signup.haml
@@ -4,7 +4,7 @@
 %a#hocsignupform{name: 'signup'}
 #join
   %h1#join-us-header=hoc_s(:front_join_us_button)
-  -if true #["post-hoc", false].include?(hoc_mode)
+  -if ["post-hoc", false].include?(hoc_mode)
     #signup-closed
       !=hoc_s(:signup_registration_not_required_markdown, markdown: :inline, locals: {hoc_activities_url: resolve_url('/learn'), howto_guide_url: resolve_url('/how-to')})
       =hoc_s(:signup_registration_closed)


### PR DESCRIPTION
This form broke when we turned on the static map on this page during HOC. I made a [hacky change](https://github.com/code-dot-org/code-dot-org/pull/38138/files) to hide the form, which I am undoing here. The form will be hidden as long as we are in 'post-hoc' mode, which was the behavior we had before my hacky change.

<!--
  Your description goes here: A summary of the change, including any relevant motivation and context.

  If relevant, include a description both of the existing behavior and of the new behavior.
-->

<!--
  Other aspects to consider. uncomment and add detail for any that seem necessary:
-->

<!-- ### Background -->
<!-- ### Privacy -->
<!--
1.	Does the Project involve the collection, use or sharing of new Personal Data?

2.	Does the Project involve a new or changed use or sharing of existing Personal Data?
-->
<!-- ### Security -->
<!--
Link to Jira Task where sensitive security issues are discussed privately.
-->
<!-- ### Caching -->
<!-- ### Deployment strategy -->
<!-- ### Future work -->

## Links

<!--
  Any relevant links to external resources; ie, specification documents, jira
  items, related PRs, honeybadger errors, etc
-->

- [spec]()
- [jira]()

## Testing story

<!--
  Does your change include appropriate tests?

  If so, please describe how the tests included in this PR are sufficient

  If not, please explain why this change does not need to be tested.
-->

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
