### PR TITLE
Volunteer map: hide empty values

### DIFF
--- a/pegasus/sites.v3/code.org/public/js/volunteer-local.js
+++ b/pegasus/sites.v3/code.org/public/js/volunteer-local.js
@@ -488,6 +488,10 @@ function createMapEntryDetail(elements) {
   return div;
 }
 
+function hasContent(value) {
+  return value && value !== "null";
+}
+
 function compileHTML(index, location) {
   let html = createHTMLElement("div");
 
@@ -497,13 +501,13 @@ function compileHTML(index, location) {
     ])
   );
 
-  if (location.company_s) {
+  if (hasContent(location.company_s)) {
     html.appendChild(
       createMapEntryDetail([document.createTextNode(location.company_s)])
     );
   }
 
-  if (location.experience_s) {
+  if (hasContent(location.experience_s)) {
     html.appendChild(
       createMapEntryDetail([
         createHTMLElement("strong", null, "Experience:"),
@@ -512,7 +516,7 @@ function compileHTML(index, location) {
     );
   }
 
-  if (location.location_flexibility_ss) {
+  if (hasContent(location.location_flexibility_ss)) {
     location.location_flexibility_ss.forEach(function(field, index) {
       location.location_flexibility_ss[index] = i18n("location_" + field);
     });
@@ -527,7 +531,7 @@ function compileHTML(index, location) {
     );
   }
 
-  if (location.description_s) {
+  if (hasContent(location.description_s)) {
     html.appendChild(
       createMapEntryDetail([
         createHTMLElement("strong", null, "About me:"),
@@ -536,7 +540,7 @@ function compileHTML(index, location) {
     );
   }
 
-  if (location.linkedin_s) {
+  if (hasContent(location.linkedin_s)) {
     if (!location.linkedin_s.match(/^https?:\/\//i)) {
       location.linkedin_s = "http://" + location.linkedin_s;
     }
@@ -549,7 +553,7 @@ function compileHTML(index, location) {
     );
   }
 
-  if (location.facebook_s) {
+  if (hasContent(location.facebook_s)) {
     if (!location.facebook_s.match(/^https?:\/\//i)) {
       location.facebook_s = "http://" + location.facebook_s;
     }


### PR DESCRIPTION
The popups in the map at https://code.org/volunteer/remote have been showing "null" for fields with no value, rather than hiding them.  Poking around the server, I don't see an obvious explanation for why or when this regressed, but I do see a string `"null"` being sent back to the client in the response JSON, rather than a `null` value, hence this approach to the fix.

### before
![Screen Shot 2021-01-04 at 5 31 59 PM](https://user-images.githubusercontent.com/2205926/103507612-712cb580-4e14-11eb-8cd0-1560f2a3ec98.png)

### after
![Screen Shot 2021-01-04 at 5 32 46 PM](https://user-images.githubusercontent.com/2205926/103507617-7427a600-4e14-11eb-8adf-5a66353b6352.png)

Thanks to @tanyaparker for noticing this issue.