### PR TITLE
[Applab Datasets] Fix small regression with live table last updated time

### DIFF
--- a/apps/i18n/common/en_us.json
+++ b/apps/i18n/common/en_us.json
@@ -944,6 +944,7 @@
   "lastUpdatedCurrentTeacher": "Updated by you",
   "seenByStudent": "Seen by student",
   "lastUpdatedNoTime": "Last Updated:",
+  "lastUpdatedWithTime": "Last updated {time}",
   "learnMore": "Learn more",
   "leaveSection": "Leave section",
   "less": "Less",

--- a/apps/src/storage/dataBrowser/LibraryTable.jsx
+++ b/apps/src/storage/dataBrowser/LibraryTable.jsx
@@ -107,7 +107,7 @@ class LibraryTable extends React.Component {
             <div style={styles.tableDescription}>
               {datasetInfo.lastUpdated && (
                 <span style={styles.lastUpdated}>
-                  {msg.lastUpdated({
+                  {msg.lastUpdatedWithTime({
                     time: moment(datasetInfo.lastUpdated).fromNow()
                   })}
                 </span>


### PR DESCRIPTION
I noticed a small regression where live tables were not properly showing when they were last updated:
![image](https://user-images.githubusercontent.com/8787187/103576414-f1403300-4e87-11eb-9bc5-9b6a422ab088.png)

Root cause looks like https://github.com/code-dot-org/code-dot-org/pull/37107, which removed the `{time}` param from the translated string.
Solution is just to add another string so that we can show the time correctly here without affecting the teacher feedback usage

![image](https://user-images.githubusercontent.com/8787187/103576621-4714db00-4e88-11eb-9bbd-adb58ef77205.png)



<!--
  Other aspects to consider. uncomment and add detail for any that seem necessary:
-->

<!-- ### Background -->
<!-- ### Privacy -->
<!--
1.	Does the Project involve the collection, use or sharing of new Personal Data?

2.	Does the Project involve a new or changed use or sharing of existing Personal Data?
-->
<!-- ### Security -->
<!--
Link to Jira Task where sensitive security issues are discussed privately.
-->
<!-- ### Caching -->
<!-- ### Deployment strategy -->
<!-- ### Future work -->

## Links

<!--
  Any relevant links to external resources; ie, specification documents, jira
  items, related PRs, honeybadger errors, etc
-->


## Testing story

<!--
  Does your change include appropriate tests?

  If so, please describe how the tests included in this PR are sufficient

  If not, please explain why this change does not need to be tested.
-->

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
