### PR TITLE
parameterize number of activities and sections per lesson

### DIFF
--- a/dashboard/test/fixtures/test-serialize-seeding-json.script_json
+++ b/dashboard/test/fixtures/test-serialize-seeding-json.script_json
@@ -44,8 +44,8 @@
   ],
   "lessons": [
     {
-      "key": "test-serialize-seeding-json-lg-1-lesson-1",
-      "name": "test-serialize-seeding-json-lg-1-lesson-1",
+      "key": "test-serialize-seeding-json-lg-1-l-1",
+      "name": "test-serialize-seeding-json-lg-1-l-1",
       "absolute_position": 1,
       "lockable": false,
       "relative_position": 1,
@@ -53,14 +53,14 @@
         "overview": "overview 1 1"
       },
       "seeding_key": {
-        "lesson.key": "test-serialize-seeding-json-lg-1-lesson-1",
+        "lesson.key": "test-serialize-seeding-json-lg-1-l-1",
         "lesson_group.key": "test-serialize-seeding-json-lesson-group-1",
         "script.name": "test-serialize-seeding-json-script"
       }
     },
     {
-      "key": "test-serialize-seeding-json-lg-1-lesson-2",
-      "name": "test-serialize-seeding-json-lg-1-lesson-2",
+      "key": "test-serialize-seeding-json-lg-1-l-2",
+      "name": "test-serialize-seeding-json-lg-1-l-2",
       "absolute_position": 2,
       "lockable": false,
       "relative_position": 2,
@@ -68,14 +68,14 @@
         "overview": "overview 1 2"
       },
       "seeding_key": {
-        "lesson.key": "test-serialize-seeding-json-lg-1-lesson-2",
+        "lesson.key": "test-serialize-seeding-json-lg-1-l-2",
         "lesson_group.key": "test-serialize-seeding-json-lesson-group-1",
         "script.name": "test-serialize-seeding-json-script"
       }
     },
     {
-      "key": "test-serialize-seeding-json-lg-2-lesson-1",
-      "name": "test-serialize-seeding-json-lg-2-lesson-1",
+      "key": "test-serialize-seeding-json-lg-2-l-1",
+      "name": "test-serialize-seeding-json-lg-2-l-1",
       "absolute_position": 3,
       "lockable": false,
       "relative_position": 3,
@@ -83,14 +83,14 @@
         "overview": "overview 2 1"
       },
       "seeding_key": {
-        "lesson.key": "test-serialize-seeding-json-lg-2-lesson-1",
+        "lesson.key": "test-serialize-seeding-json-lg-2-l-1",
         "lesson_group.key": "test-serialize-seeding-json-lesson-group-2",
         "script.name": "test-serialize-seeding-json-script"
       }
     },
     {
-      "key": "test-serialize-seeding-json-lg-2-lesson-2",
-      "name": "test-serialize-seeding-json-lg-2-lesson-2",
+      "key": "test-serialize-seeding-json-lg-2-l-2",
+      "name": "test-serialize-seeding-json-lg-2-l-2",
       "absolute_position": 4,
       "lockable": false,
       "relative_position": 4,
@@ -98,7 +98,7 @@
         "overview": "overview 2 2"
       },
       "seeding_key": {
-        "lesson.key": "test-serialize-seeding-json-lg-2-lesson-2",
+        "lesson.key": "test-serialize-seeding-json-lg-2-l-2",
         "lesson_group.key": "test-serialize-seeding-json-lesson-group-2",
         "script.name": "test-serialize-seeding-json-script"
       }
@@ -106,53 +106,53 @@
   ],
   "lesson_activities": [
     {
-      "key": "test-serialize-seeding-json-lg-1-lesson-1-activity-1",
+      "key": "test-serialize-seeding-json-lg-1-l-1-a-1",
       "position": 1,
       "properties": {
         "name": "My Activity"
       },
       "seeding_key": {
-        "lesson_activity.key": "test-serialize-seeding-json-lg-1-lesson-1-activity-1",
-        "lesson.key": "test-serialize-seeding-json-lg-1-lesson-1",
+        "lesson_activity.key": "test-serialize-seeding-json-lg-1-l-1-a-1",
+        "lesson.key": "test-serialize-seeding-json-lg-1-l-1",
         "lesson_group.key": "test-serialize-seeding-json-lesson-group-1",
         "script.name": "test-serialize-seeding-json-script"
       }
     },
     {
-      "key": "test-serialize-seeding-json-lg-1-lesson-2-activity-1",
+      "key": "test-serialize-seeding-json-lg-1-l-2-a-1",
       "position": 1,
       "properties": {
         "name": "My Activity"
       },
       "seeding_key": {
-        "lesson_activity.key": "test-serialize-seeding-json-lg-1-lesson-2-activity-1",
-        "lesson.key": "test-serialize-seeding-json-lg-1-lesson-2",
+        "lesson_activity.key": "test-serialize-seeding-json-lg-1-l-2-a-1",
+        "lesson.key": "test-serialize-seeding-json-lg-1-l-2",
         "lesson_group.key": "test-serialize-seeding-json-lesson-group-1",
         "script.name": "test-serialize-seeding-json-script"
       }
     },
     {
-      "key": "test-serialize-seeding-json-lg-2-lesson-1-activity-1",
+      "key": "test-serialize-seeding-json-lg-2-l-1-a-1",
       "position": 1,
       "properties": {
         "name": "My Activity"
       },
       "seeding_key": {
-        "lesson_activity.key": "test-serialize-seeding-json-lg-2-lesson-1-activity-1",
-        "lesson.key": "test-serialize-seeding-json-lg-2-lesson-1",
+        "lesson_activity.key": "test-serialize-seeding-json-lg-2-l-1-a-1",
+        "lesson.key": "test-serialize-seeding-json-lg-2-l-1",
         "lesson_group.key": "test-serialize-seeding-json-lesson-group-2",
         "script.name": "test-serialize-seeding-json-script"
       }
     },
     {
-      "key": "test-serialize-seeding-json-lg-2-lesson-2-activity-1",
+      "key": "test-serialize-seeding-json-lg-2-l-2-a-1",
       "position": 1,
       "properties": {
         "name": "My Activity"
       },
       "seeding_key": {
-        "lesson_activity.key": "test-serialize-seeding-json-lg-2-lesson-2-activity-1",
-        "lesson.key": "test-serialize-seeding-json-lg-2-lesson-2",
+        "lesson_activity.key": "test-serialize-seeding-json-lg-2-l-2-a-1",
+        "lesson.key": "test-serialize-seeding-json-lg-2-l-2",
         "lesson_group.key": "test-serialize-seeding-json-lesson-group-2",
         "script.name": "test-serialize-seeding-json-script"
       }
@@ -160,47 +160,47 @@
   ],
   "activity_sections": [
     {
-      "key": "test-serialize-seeding-json-lg-1-lesson-1-activity-1-section-1",
+      "key": "test-serialize-seeding-json-lg-1-l-1-a-1-s-1",
       "position": 1,
       "properties": {
         "name": "My Activity Section"
       },
       "seeding_key": {
-        "activity_section.key": "test-serialize-seeding-json-lg-1-lesson-1-activity-1-section-1",
-        "lesson_activity.key": "test-serialize-seeding-json-lg-1-lesson-1-activity-1"
+        "activity_section.key": "test-serialize-seeding-json-lg-1-l-1-a-1-s-1",
+        "lesson_activity.key": "test-serialize-seeding-json-lg-1-l-1-a-1"
       }
     },
     {
-      "key": "test-serialize-seeding-json-lg-1-lesson-2-activity-1-section-1",
+      "key": "test-serialize-seeding-json-lg-1-l-2-a-1-s-1",
       "position": 1,
       "properties": {
         "name": "My Activity Section"
       },
       "seeding_key": {
-        "activity_section.key": "test-serialize-seeding-json-lg-1-lesson-2-activity-1-section-1",
-        "lesson_activity.key": "test-serialize-seeding-json-lg-1-lesson-2-activity-1"
+        "activity_section.key": "test-serialize-seeding-json-lg-1-l-2-a-1-s-1",
+        "lesson_activity.key": "test-serialize-seeding-json-lg-1-l-2-a-1"
       }
     },
     {
-      "key": "test-serialize-seeding-json-lg-2-lesson-1-activity-1-section-1",
+      "key": "test-serialize-seeding-json-lg-2-l-1-a-1-s-1",
       "position": 1,
       "properties": {
         "name": "My Activity Section"
       },
       "seeding_key": {
-        "activity_section.key": "test-serialize-seeding-json-lg-2-lesson-1-activity-1-section-1",
-        "lesson_activity.key": "test-serialize-seeding-json-lg-2-lesson-1-activity-1"
+        "activity_section.key": "test-serialize-seeding-json-lg-2-l-1-a-1-s-1",
+        "lesson_activity.key": "test-serialize-seeding-json-lg-2-l-1-a-1"
       }
     },
     {
-      "key": "test-serialize-seeding-json-lg-2-lesson-2-activity-1-section-1",
+      "key": "test-serialize-seeding-json-lg-2-l-2-a-1-s-1",
       "position": 1,
       "properties": {
         "name": "My Activity Section"
       },
       "seeding_key": {
-        "activity_section.key": "test-serialize-seeding-json-lg-2-lesson-2-activity-1-section-1",
-        "lesson_activity.key": "test-serialize-seeding-json-lg-2-lesson-2-activity-1"
+        "activity_section.key": "test-serialize-seeding-json-lg-2-l-2-a-1-s-1",
+        "lesson_activity.key": "test-serialize-seeding-json-lg-2-l-2-a-1"
       }
     }
   ],
@@ -218,10 +218,10 @@
         "script_level.level_keys": [
           "blockly:test-serialize-seeding-json_game1:1_2_1"
         ],
-        "lesson.key": "test-serialize-seeding-json-lg-1-lesson-1",
+        "lesson.key": "test-serialize-seeding-json-lg-1-l-1",
         "lesson_group.key": "test-serialize-seeding-json-lesson-group-1",
         "script.name": "test-serialize-seeding-json-script",
-        "activity_section.key": "test-serialize-seeding-json-lg-1-lesson-1-activity-1-section-1"
+        "activity_section.key": "test-serialize-seeding-json-lg-1-l-1-a-1-s-1"
       },
       "level_keys": [
         "blockly:test-serialize-seeding-json_game1:1_2_1"
@@ -241,10 +241,10 @@
         "script_level.level_keys": [
           "blockly:test-serialize-seeding-json_game2:1_2_2"
         ],
-        "lesson.key": "test-serialize-seeding-json-lg-1-lesson-1",
+        "lesson.key": "test-serialize-seeding-json-lg-1-l-1",
         "lesson_group.key": "test-serialize-seeding-json-lesson-group-1",
         "script.name": "test-serialize-seeding-json-script",
-        "activity_section.key": "test-serialize-seeding-json-lg-1-lesson-1-activity-1-section-1"
+        "activity_section.key": "test-serialize-seeding-json-lg-1-l-1-a-1-s-1"
       },
       "level_keys": [
         "blockly:test-serialize-seeding-json_game2:1_2_2"
@@ -253,7 +253,7 @@
     {
       "chapter": 3,
       "position": 1,
-      "activity_section_position": 3,
+      "activity_section_position": 1,
       "assessment": null,
       "properties": {
       },
@@ -263,10 +263,10 @@
         "script_level.level_keys": [
           "blockly:test-serialize-seeding-json_game3:1_2_3"
         ],
-        "lesson.key": "test-serialize-seeding-json-lg-1-lesson-2",
+        "lesson.key": "test-serialize-seeding-json-lg-1-l-2",
         "lesson_group.key": "test-serialize-seeding-json-lesson-group-1",
         "script.name": "test-serialize-seeding-json-script",
-        "activity_section.key": "test-serialize-seeding-json-lg-1-lesson-2-activity-1-section-1"
+        "activity_section.key": "test-serialize-seeding-json-lg-1-l-2-a-1-s-1"
       },
       "level_keys": [
         "blockly:test-serialize-seeding-json_game3:1_2_3"
@@ -275,7 +275,7 @@
     {
       "chapter": 4,
       "position": 2,
-      "activity_section_position": 4,
+      "activity_section_position": 2,
       "assessment": null,
       "properties": {
         "challenge": true
@@ -286,10 +286,10 @@
         "script_level.level_keys": [
           "blockly:test-serialize-seeding-json_game4:1_2_4"
         ],
-        "lesson.key": "test-serialize-seeding-json-lg-1-lesson-2",
+        "lesson.key": "test-serialize-seeding-json-lg-1-l-2",
         "lesson_group.key": "test-serialize-seeding-json-lesson-group-1",
         "script.name": "test-serialize-seeding-json-script",
-        "activity_section.key": "test-serialize-seeding-json-lg-1-lesson-2-activity-1-section-1"
+        "activity_section.key": "test-serialize-seeding-json-lg-1-l-2-a-1-s-1"
       },
       "level_keys": [
         "blockly:test-serialize-seeding-json_game4:1_2_4"
@@ -298,7 +298,7 @@
     {
       "chapter": 5,
       "position": 1,
-      "activity_section_position": 5,
+      "activity_section_position": 1,
       "assessment": null,
       "properties": {
       },
@@ -308,10 +308,10 @@
         "script_level.level_keys": [
           "blockly:test-serialize-seeding-json_game5:1_2_5"
         ],
-        "lesson.key": "test-serialize-seeding-json-lg-2-lesson-1",
+        "lesson.key": "test-serialize-seeding-json-lg-2-l-1",
         "lesson_group.key": "test-serialize-seeding-json-lesson-group-2",
         "script.name": "test-serialize-seeding-json-script",
-        "activity_section.key": "test-serialize-seeding-json-lg-2-lesson-1-activity-1-section-1"
+        "activity_section.key": "test-serialize-seeding-json-lg-2-l-1-a-1-s-1"
       },
       "level_keys": [
         "blockly:test-serialize-seeding-json_game5:1_2_5"
@@ -320,7 +320,7 @@
     {
       "chapter": 6,
       "position": 2,
-      "activity_section_position": 6,
+      "activity_section_position": 2,
       "assessment": null,
       "properties": {
         "challenge": true
@@ -331,10 +331,10 @@
         "script_level.level_keys": [
           "blockly:test-serialize-seeding-json_game6:1_2_6"
         ],
-        "lesson.key": "test-serialize-seeding-json-lg-2-lesson-1",
+        "lesson.key": "test-serialize-seeding-json-lg-2-l-1",
         "lesson_group.key": "test-serialize-seeding-json-lesson-group-2",
         "script.name": "test-serialize-seeding-json-script",
-        "activity_section.key": "test-serialize-seeding-json-lg-2-lesson-1-activity-1-section-1"
+        "activity_section.key": "test-serialize-seeding-json-lg-2-l-1-a-1-s-1"
       },
       "level_keys": [
         "blockly:test-serialize-seeding-json_game6:1_2_6"
@@ -343,7 +343,7 @@
     {
       "chapter": 7,
       "position": 1,
-      "activity_section_position": 7,
+      "activity_section_position": 1,
       "assessment": null,
       "properties": {
       },
@@ -353,10 +353,10 @@
         "script_level.level_keys": [
           "blockly:test-serialize-seeding-json_game7:1_2_7"
         ],
-        "lesson.key": "test-serialize-seeding-json-lg-2-lesson-2",
+        "lesson.key": "test-serialize-seeding-json-lg-2-l-2",
         "lesson_group.key": "test-serialize-seeding-json-lesson-group-2",
         "script.name": "test-serialize-seeding-json-script",
-        "activity_section.key": "test-serialize-seeding-json-lg-2-lesson-2-activity-1-section-1"
+        "activity_section.key": "test-serialize-seeding-json-lg-2-l-2-a-1-s-1"
       },
       "level_keys": [
         "blockly:test-serialize-seeding-json_game7:1_2_7"
@@ -365,7 +365,7 @@
     {
       "chapter": 8,
       "position": 2,
-      "activity_section_position": 8,
+      "activity_section_position": 2,
       "assessment": null,
       "properties": {
         "challenge": true
@@ -376,10 +376,10 @@
         "script_level.level_keys": [
           "blockly:test-serialize-seeding-json_game8:1_2_8"
         ],
-        "lesson.key": "test-serialize-seeding-json-lg-2-lesson-2",
+        "lesson.key": "test-serialize-seeding-json-lg-2-l-2",
         "lesson_group.key": "test-serialize-seeding-json-lesson-group-2",
         "script.name": "test-serialize-seeding-json-script",
-        "activity_section.key": "test-serialize-seeding-json-lg-2-lesson-2-activity-1-section-1"
+        "activity_section.key": "test-serialize-seeding-json-lg-2-l-2-a-1-s-1"
       },
       "level_keys": [
         "blockly:test-serialize-seeding-json_game8:1_2_8"
@@ -393,10 +393,10 @@
         "script_level.level_keys": [
           "blockly:test-serialize-seeding-json_game1:1_2_1"
         ],
-        "lesson.key": "test-serialize-seeding-json-lg-1-lesson-1",
+        "lesson.key": "test-serialize-seeding-json-lg-1-l-1",
         "lesson_group.key": "test-serialize-seeding-json-lesson-group-1",
         "script.name": "test-serialize-seeding-json-script",
-        "activity_section.key": "test-serialize-seeding-json-lg-1-lesson-1-activity-1-section-1"
+        "activity_section.key": "test-serialize-seeding-json-lg-1-l-1-a-1-s-1"
       }
     },
     {
@@ -405,10 +405,10 @@
         "script_level.level_keys": [
           "blockly:test-serialize-seeding-json_game2:1_2_2"
         ],
-        "lesson.key": "test-serialize-seeding-json-lg-1-lesson-1",
+        "lesson.key": "test-serialize-seeding-json-lg-1-l-1",
         "lesson_group.key": "test-serialize-seeding-json-lesson-group-1",
         "script.name": "test-serialize-seeding-json-script",
-        "activity_section.key": "test-serialize-seeding-json-lg-1-lesson-1-activity-1-section-1"
+        "activity_section.key": "test-serialize-seeding-json-lg-1-l-1-a-1-s-1"
       }
     },
     {
@@ -417,10 +417,10 @@
         "script_level.level_keys": [
           "blockly:test-serialize-seeding-json_game3:1_2_3"
         ],
-        "lesson.key": "test-serialize-seeding-json-lg-1-lesson-2",
+        "lesson.key": "test-serialize-seeding-json-lg-1-l-2",
         "lesson_group.key": "test-serialize-seeding-json-lesson-group-1",
         "script.name": "test-serialize-seeding-json-script",
-        "activity_section.key": "test-serialize-seeding-json-lg-1-lesson-2-activity-1-section-1"
+        "activity_section.key": "test-serialize-seeding-json-lg-1-l-2-a-1-s-1"
       }
     },
     {
@@ -429,10 +429,10 @@
         "script_level.level_keys": [
           "blockly:test-serialize-seeding-json_game4:1_2_4"
         ],
-        "lesson.key": "test-serialize-seeding-json-lg-1-lesson-2",
+        "lesson.key": "test-serialize-seeding-json-lg-1-l-2",
         "lesson_group.key": "test-serialize-seeding-json-lesson-group-1",
         "script.name": "test-serialize-seeding-json-script",
-        "activity_section.key": "test-serialize-seeding-json-lg-1-lesson-2-activity-1-section-1"
+        "activity_section.key": "test-serialize-seeding-json-lg-1-l-2-a-1-s-1"
       }
     },
     {
@@ -441,10 +441,10 @@
         "script_level.level_keys": [
           "blockly:test-serialize-seeding-json_game5:1_2_5"
         ],
-        "lesson.key": "test-serialize-seeding-json-lg-2-lesson-1",
+        "lesson.key": "test-serialize-seeding-json-lg-2-l-1",
         "lesson_group.key": "test-serialize-seeding-json-lesson-group-2",
         "script.name": "test-serialize-seeding-json-script",
-        "activity_section.key": "test-serialize-seeding-json-lg-2-lesson-1-activity-1-section-1"
+        "activity_section.key": "test-serialize-seeding-json-lg-2-l-1-a-1-s-1"
       }
     },
     {
@@ -453,10 +453,10 @@
         "script_level.level_keys": [
           "blockly:test-serialize-seeding-json_game6:1_2_6"
         ],
-        "lesson.key": "test-serialize-seeding-json-lg-2-lesson-1",
+        "lesson.key": "test-serialize-seeding-json-lg-2-l-1",
         "lesson_group.key": "test-serialize-seeding-json-lesson-group-2",
         "script.name": "test-serialize-seeding-json-script",
-        "activity_section.key": "test-serialize-seeding-json-lg-2-lesson-1-activity-1-section-1"
+        "activity_section.key": "test-serialize-seeding-json-lg-2-l-1-a-1-s-1"
       }
     },
     {
@@ -465,10 +465,10 @@
         "script_level.level_keys": [
           "blockly:test-serialize-seeding-json_game7:1_2_7"
         ],
-        "lesson.key": "test-serialize-seeding-json-lg-2-lesson-2",
+        "lesson.key": "test-serialize-seeding-json-lg-2-l-2",
         "lesson_group.key": "test-serialize-seeding-json-lesson-group-2",
         "script.name": "test-serialize-seeding-json-script",
-        "activity_section.key": "test-serialize-seeding-json-lg-2-lesson-2-activity-1-section-1"
+        "activity_section.key": "test-serialize-seeding-json-lg-2-l-2-a-1-s-1"
       }
     },
     {
@@ -477,10 +477,10 @@
         "script_level.level_keys": [
           "blockly:test-serialize-seeding-json_game8:1_2_8"
         ],
-        "lesson.key": "test-serialize-seeding-json-lg-2-lesson-2",
+        "lesson.key": "test-serialize-seeding-json-lg-2-l-2",
         "lesson_group.key": "test-serialize-seeding-json-lesson-group-2",
         "script.name": "test-serialize-seeding-json-script",
-        "activity_section.key": "test-serialize-seeding-json-lg-2-lesson-2-activity-1-section-1"
+        "activity_section.key": "test-serialize-seeding-json-lg-2-l-2-a-1-s-1"
       }
     }
   ],
@@ -488,213 +488,213 @@
     {
       "name": "fake name",
       "url": "fake.url",
-      "key": "test-serialize-seeding-json-lg-1-lesson-1-resource-1",
+      "key": "test-serialize-seeding-json-lg-1-l-1-resource-1",
       "properties": {
       },
       "seeding_key": {
-        "resource.key": "test-serialize-seeding-json-lg-1-lesson-1-resource-1"
+        "resource.key": "test-serialize-seeding-json-lg-1-l-1-resource-1"
       }
     },
     {
       "name": "fake name",
       "url": "fake.url",
-      "key": "test-serialize-seeding-json-lg-1-lesson-1-resource-2",
+      "key": "test-serialize-seeding-json-lg-1-l-1-resource-2",
       "properties": {
       },
       "seeding_key": {
-        "resource.key": "test-serialize-seeding-json-lg-1-lesson-1-resource-2"
+        "resource.key": "test-serialize-seeding-json-lg-1-l-1-resource-2"
       }
     },
     {
       "name": "fake name",
       "url": "fake.url",
-      "key": "test-serialize-seeding-json-lg-1-lesson-2-resource-1",
+      "key": "test-serialize-seeding-json-lg-1-l-2-resource-1",
       "properties": {
       },
       "seeding_key": {
-        "resource.key": "test-serialize-seeding-json-lg-1-lesson-2-resource-1"
+        "resource.key": "test-serialize-seeding-json-lg-1-l-2-resource-1"
       }
     },
     {
       "name": "fake name",
       "url": "fake.url",
-      "key": "test-serialize-seeding-json-lg-1-lesson-2-resource-2",
+      "key": "test-serialize-seeding-json-lg-1-l-2-resource-2",
       "properties": {
       },
       "seeding_key": {
-        "resource.key": "test-serialize-seeding-json-lg-1-lesson-2-resource-2"
+        "resource.key": "test-serialize-seeding-json-lg-1-l-2-resource-2"
       }
     },
     {
       "name": "fake name",
       "url": "fake.url",
-      "key": "test-serialize-seeding-json-lg-2-lesson-1-resource-1",
+      "key": "test-serialize-seeding-json-lg-2-l-1-resource-1",
       "properties": {
       },
       "seeding_key": {
-        "resource.key": "test-serialize-seeding-json-lg-2-lesson-1-resource-1"
+        "resource.key": "test-serialize-seeding-json-lg-2-l-1-resource-1"
       }
     },
     {
       "name": "fake name",
       "url": "fake.url",
-      "key": "test-serialize-seeding-json-lg-2-lesson-1-resource-2",
+      "key": "test-serialize-seeding-json-lg-2-l-1-resource-2",
       "properties": {
       },
       "seeding_key": {
-        "resource.key": "test-serialize-seeding-json-lg-2-lesson-1-resource-2"
+        "resource.key": "test-serialize-seeding-json-lg-2-l-1-resource-2"
       }
     },
     {
       "name": "fake name",
       "url": "fake.url",
-      "key": "test-serialize-seeding-json-lg-2-lesson-2-resource-1",
+      "key": "test-serialize-seeding-json-lg-2-l-2-resource-1",
       "properties": {
       },
       "seeding_key": {
-        "resource.key": "test-serialize-seeding-json-lg-2-lesson-2-resource-1"
+        "resource.key": "test-serialize-seeding-json-lg-2-l-2-resource-1"
       }
     },
     {
       "name": "fake name",
       "url": "fake.url",
-      "key": "test-serialize-seeding-json-lg-2-lesson-2-resource-2",
+      "key": "test-serialize-seeding-json-lg-2-l-2-resource-2",
       "properties": {
       },
       "seeding_key": {
-        "resource.key": "test-serialize-seeding-json-lg-2-lesson-2-resource-2"
+        "resource.key": "test-serialize-seeding-json-lg-2-l-2-resource-2"
       }
     }
   ],
   "lessons_resources": [
     {
       "seeding_key": {
-        "lesson.key": "test-serialize-seeding-json-lg-1-lesson-1",
-        "resource.key": "test-serialize-seeding-json-lg-1-lesson-1-resource-1"
+        "lesson.key": "test-serialize-seeding-json-lg-1-l-1",
+        "resource.key": "test-serialize-seeding-json-lg-1-l-1-resource-1"
       }
     },
     {
       "seeding_key": {
-        "lesson.key": "test-serialize-seeding-json-lg-1-lesson-1",
-        "resource.key": "test-serialize-seeding-json-lg-1-lesson-1-resource-2"
+        "lesson.key": "test-serialize-seeding-json-lg-1-l-1",
+        "resource.key": "test-serialize-seeding-json-lg-1-l-1-resource-2"
       }
     },
     {
       "seeding_key": {
-        "lesson.key": "test-serialize-seeding-json-lg-1-lesson-2",
-        "resource.key": "test-serialize-seeding-json-lg-1-lesson-2-resource-1"
+        "lesson.key": "test-serialize-seeding-json-lg-1-l-2",
+        "resource.key": "test-serialize-seeding-json-lg-1-l-2-resource-1"
       }
     },
     {
       "seeding_key": {
-        "lesson.key": "test-serialize-seeding-json-lg-1-lesson-2",
-        "resource.key": "test-serialize-seeding-json-lg-1-lesson-2-resource-2"
+        "lesson.key": "test-serialize-seeding-json-lg-1-l-2",
+        "resource.key": "test-serialize-seeding-json-lg-1-l-2-resource-2"
       }
     },
     {
       "seeding_key": {
-        "lesson.key": "test-serialize-seeding-json-lg-2-lesson-1",
-        "resource.key": "test-serialize-seeding-json-lg-2-lesson-1-resource-1"
+        "lesson.key": "test-serialize-seeding-json-lg-2-l-1",
+        "resource.key": "test-serialize-seeding-json-lg-2-l-1-resource-1"
       }
     },
     {
       "seeding_key": {
-        "lesson.key": "test-serialize-seeding-json-lg-2-lesson-1",
-        "resource.key": "test-serialize-seeding-json-lg-2-lesson-1-resource-2"
+        "lesson.key": "test-serialize-seeding-json-lg-2-l-1",
+        "resource.key": "test-serialize-seeding-json-lg-2-l-1-resource-2"
       }
     },
     {
       "seeding_key": {
-        "lesson.key": "test-serialize-seeding-json-lg-2-lesson-2",
-        "resource.key": "test-serialize-seeding-json-lg-2-lesson-2-resource-1"
+        "lesson.key": "test-serialize-seeding-json-lg-2-l-2",
+        "resource.key": "test-serialize-seeding-json-lg-2-l-2-resource-1"
       }
     },
     {
       "seeding_key": {
-        "lesson.key": "test-serialize-seeding-json-lg-2-lesson-2",
-        "resource.key": "test-serialize-seeding-json-lg-2-lesson-2-resource-2"
+        "lesson.key": "test-serialize-seeding-json-lg-2-l-2",
+        "resource.key": "test-serialize-seeding-json-lg-2-l-2-resource-2"
       }
     }
   ],
   "objectives": [
     {
-      "key": "test-serialize-seeding-json-lg-1-lesson-1-objective-1",
+      "key": "test-serialize-seeding-json-lg-1-l-1-objective-1",
       "properties": {
         "description": "fake description"
       },
       "seeding_key": {
-        "lesson.key": "test-serialize-seeding-json-lg-1-lesson-1",
-        "objective.key": "test-serialize-seeding-json-lg-1-lesson-1-objective-1"
+        "lesson.key": "test-serialize-seeding-json-lg-1-l-1",
+        "objective.key": "test-serialize-seeding-json-lg-1-l-1-objective-1"
       }
     },
     {
-      "key": "test-serialize-seeding-json-lg-1-lesson-1-objective-2",
+      "key": "test-serialize-seeding-json-lg-1-l-1-objective-2",
       "properties": {
         "description": "fake description"
       },
       "seeding_key": {
-        "lesson.key": "test-serialize-seeding-json-lg-1-lesson-1",
-        "objective.key": "test-serialize-seeding-json-lg-1-lesson-1-objective-2"
+        "lesson.key": "test-serialize-seeding-json-lg-1-l-1",
+        "objective.key": "test-serialize-seeding-json-lg-1-l-1-objective-2"
       }
     },
     {
-      "key": "test-serialize-seeding-json-lg-1-lesson-2-objective-1",
+      "key": "test-serialize-seeding-json-lg-1-l-2-objective-1",
       "properties": {
         "description": "fake description"
       },
       "seeding_key": {
-        "lesson.key": "test-serialize-seeding-json-lg-1-lesson-2",
-        "objective.key": "test-serialize-seeding-json-lg-1-lesson-2-objective-1"
+        "lesson.key": "test-serialize-seeding-json-lg-1-l-2",
+        "objective.key": "test-serialize-seeding-json-lg-1-l-2-objective-1"
       }
     },
     {
-      "key": "test-serialize-seeding-json-lg-1-lesson-2-objective-2",
+      "key": "test-serialize-seeding-json-lg-1-l-2-objective-2",
       "properties": {
         "description": "fake description"
       },
       "seeding_key": {
-        "lesson.key": "test-serialize-seeding-json-lg-1-lesson-2",
-        "objective.key": "test-serialize-seeding-json-lg-1-lesson-2-objective-2"
+        "lesson.key": "test-serialize-seeding-json-lg-1-l-2",
+        "objective.key": "test-serialize-seeding-json-lg-1-l-2-objective-2"
       }
     },
     {
-      "key": "test-serialize-seeding-json-lg-2-lesson-1-objective-1",
+      "key": "test-serialize-seeding-json-lg-2-l-1-objective-1",
       "properties": {
         "description": "fake description"
       },
       "seeding_key": {
-        "lesson.key": "test-serialize-seeding-json-lg-2-lesson-1",
-        "objective.key": "test-serialize-seeding-json-lg-2-lesson-1-objective-1"
+        "lesson.key": "test-serialize-seeding-json-lg-2-l-1",
+        "objective.key": "test-serialize-seeding-json-lg-2-l-1-objective-1"
       }
     },
     {
-      "key": "test-serialize-seeding-json-lg-2-lesson-1-objective-2",
+      "key": "test-serialize-seeding-json-lg-2-l-1-objective-2",
       "properties": {
         "description": "fake description"
       },
       "seeding_key": {
-        "lesson.key": "test-serialize-seeding-json-lg-2-lesson-1",
-        "objective.key": "test-serialize-seeding-json-lg-2-lesson-1-objective-2"
+        "lesson.key": "test-serialize-seeding-json-lg-2-l-1",
+        "objective.key": "test-serialize-seeding-json-lg-2-l-1-objective-2"
       }
     },
     {
-      "key": "test-serialize-seeding-json-lg-2-lesson-2-objective-1",
+      "key": "test-serialize-seeding-json-lg-2-l-2-objective-1",
       "properties": {
         "description": "fake description"
       },
       "seeding_key": {
-        "lesson.key": "test-serialize-seeding-json-lg-2-lesson-2",
-        "objective.key": "test-serialize-seeding-json-lg-2-lesson-2-objective-1"
+        "lesson.key": "test-serialize-seeding-json-lg-2-l-2",
+        "objective.key": "test-serialize-seeding-json-lg-2-l-2-objective-1"
       }
     },
     {
-      "key": "test-serialize-seeding-json-lg-2-lesson-2-objective-2",
+      "key": "test-serialize-seeding-json-lg-2-l-2-objective-2",
       "properties": {
         "description": "fake description"
       },
       "seeding_key": {
-        "lesson.key": "test-serialize-seeding-json-lg-2-lesson-2",
-        "objective.key": "test-serialize-seeding-json-lg-2-lesson-2-objective-2"
+        "lesson.key": "test-serialize-seeding-json-lg-2-l-2",
+        "objective.key": "test-serialize-seeding-json-lg-2-l-2-objective-2"
       }
     }
   ]

--- a/dashboard/test/lib/services/script_seed_test.rb
+++ b/dashboard/test/lib/services/script_seed_test.rb
@@ -592,7 +592,9 @@ module Services
       name_prefix=nil,
       num_lesson_groups=2,
       num_lessons_per_group=2,
-      num_script_levels_per_lesson=2,
+      num_activities_per_lesson=1,
+      num_sections_per_activity=1,
+      num_script_levels_per_section=2,
       num_resources_per_lesson=2,
       num_objectives_per_lesson=2,
       with_unit_group: false
@@ -628,30 +630,32 @@ module Services
 
       script.lesson_groups.each_with_index do |lg, m|
         num_lessons_per_group.times do |n|
-          name = "#{name_prefix}-lg-#{m + 1}-lesson-#{n + 1}"
+          name = "#{name_prefix}-lg-#{m + 1}-l-#{n + 1}"
           create :lesson, lesson_group: lg, script: script, name: name, key: name, overview: "overview #{m + 1} #{n + 1}"
         end
       end
 
-      i = 1
+      sl_num = 1
       script.lessons.each do |lesson|
-        # For now, just create one LessonActivity and ActivitySection per Lesson.
-        activity = lesson.lesson_activities.create(
-          name: 'My Activity',
-          position: 1,
-          key: "#{lesson.name}-activity-1"
-        )
-        section = activity.activity_sections.create(
-          name: 'My Activity Section',
-          position: 1,
-          key: "#{activity.key}-section-1"
-        )
-
-        num_script_levels_per_lesson.times do
-          game = create :game, name: "#{name_prefix}_game#{i}"
-          level = create :level, name: "#{name_prefix}_blockly_#{i}", level_num: "1_2_#{i}", game: game
-          create :script_level, activity_section: section, activity_section_position: i, lesson: lesson, script: script, levels: [level], challenge: i.even?
-          i += 1
+        (1..num_activities_per_lesson).each do |activity_pos|
+          activity = lesson.lesson_activities.create(
+            name: 'My Activity',
+            position: activity_pos,
+            key: "#{lesson.name}-a-#{activity_pos}"
+          )
+          (1..num_sections_per_activity).each do |section_pos|
+            section = activity.activity_sections.create(
+              name: 'My Activity Section',
+              position: section_pos,
+              key: "#{activity.key}-s-#{section_pos}"
+            )
+            (1..num_script_levels_per_section).each do |sl_pos|
+              game = create :game, name: "#{name_prefix}_game#{sl_num}"
+              level = create :level, name: "#{name_prefix}_blockly_#{sl_num}", level_num: "1_2_#{sl_num}", game: game
+              create :script_level, activity_section: section, activity_section_position: sl_pos, lesson: lesson, script: script, levels: [level], challenge: sl_num.even?
+              sl_num += 1
+            end
+          end
         end
 
         next unless course_version

--- a/dashboard/test/lib/services/script_seed_test.rb
+++ b/dashboard/test/lib/services/script_seed_test.rb
@@ -20,7 +20,7 @@ module Services
     # When adding a new model that is serialized, update this test to include the model, generate new json,
     # save it to test-serialize-seeding-json.script_json, and eyeball the changes to see that they look right.
     test 'serialize_seeding_json' do
-      script = create_script_tree('test-serialize-seeding-json')
+      script = create_script_tree(name_prefix: 'test-serialize-seeding-json')
 
       filename = File.join(self.class.fixture_path, 'test-serialize-seeding-json.script_json')
       # Uncomment the following line to update test-serialize-seeding-json.script_json
@@ -589,14 +589,14 @@ module Services
     end
 
     def create_script_tree(
-      name_prefix=nil,
-      num_lesson_groups=2,
-      num_lessons_per_group=2,
-      num_activities_per_lesson=1,
-      num_sections_per_activity=1,
-      num_script_levels_per_section=2,
-      num_resources_per_lesson=2,
-      num_objectives_per_lesson=2,
+      name_prefix: nil,
+      num_lesson_groups: 2,
+      num_lessons_per_group: 2,
+      num_activities_per_lesson: 1,
+      num_sections_per_activity: 1,
+      num_script_levels_per_section: 2,
+      num_resources_per_lesson: 2,
+      num_objectives_per_lesson: 2,
       with_unit_group: false
     )
       name_prefix ||= SecureRandom.uuid


### PR DESCRIPTION
Starts [PLAT-609]. Makes it possible to have multiple lesson_activities per lesson or multiple activity_sections per lesson activity. This is a pure refactor -- no new test coverage is added. The defaults remains at 1, because increasing them to 2 make tests take much longer. In the next PR, I'll figure out how to test the cases where n=2 without making test time get too long.

## Testing story

Updates existing test coverage

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked


[PLAT-609]: https://codedotorg.atlassian.net/browse/PLAT-609