### PR TITLE
Re-introduce and update PL banners for 2021

### DIFF
--- a/apps/.storybook/preview-head.html
+++ b/apps/.storybook/preview-head.html
@@ -1,7 +1,8 @@
-<link rel="stylesheet" media="all" href="css/application.css">
-<link rel="stylesheet" media="all" href="css/levelbuilder.css">
-<link rel="stylesheet" media="all" href="css/pd.css">
-<link rel="stylesheet" media="all" href="css/droplet/droplet.min.css">
+<link rel="stylesheet" media="all" href="css/application.css" />
+<link rel="stylesheet" media="all" href="css/levelbuilder.css" />
+<link rel="stylesheet" media="all" href="css/pd.css" />
+<link rel="stylesheet" media="all" href="css/droplet/droplet.min.css" />
+<link rel="stylesheet" media="all" href="/css/brstrap.css" />
 <script src="https://use.fontawesome.com/8c9a5ecdc4.js"></script>
 <script src="js/en_us/common_locale.js"></script>
 <script src="js/en_us/applab_locale.js"></script>

--- a/apps/package.json
+++ b/apps/package.json
@@ -29,7 +29,7 @@
     "start:craft": "DEV=1 grunt dev --app=craft --watch-notify;",
     "test-audio": "echo \"Open your browser to http://127.0.0.1:8080/test/audio/audio_test.html\" && http-server .",
     "prestorybook": "curl -o build/package/css/application.css http://localhost-studio.code.org:3000/assets/application.css || curl -o build/package/css/application.css https://code-dot-org.github.io/cdo-styleguide/css/application.css",
-    "storybook": "start-storybook -p 9001 -s build/package/,../dashboard/public,../",
+    "storybook": "start-storybook -p 9001 -s build/package/,../dashboard/public,../,../pegasus/sites.v3/code.org/public",
     "storybook:deploy": "./script/deploy-storybook.sh"
   },
   "resolutions": {

--- a/apps/src/sites/code.org/pages/public/yourschool.js
+++ b/apps/src/sites/code.org/pages/public/yourschool.js
@@ -37,6 +37,10 @@ function showYourSchool() {
         hideMap={yourschoolElement.data('parameters-hide-map')}
         prefillData={prefillData}
         currentCensusYear={yourschoolElement.data('parameters-school-year')}
+        showProfessionalLearningBanner={
+          yourschoolElement.data('parameters-locale') === 'en-US' &&
+          yourschoolElement.data('parameters-teacher-applications-active')
+        }
       />
     </Provider>,
     yourschoolElement[0]

--- a/apps/src/templates/ProfessionalLearningApplyBanner.jsx
+++ b/apps/src/templates/ProfessionalLearningApplyBanner.jsx
@@ -130,7 +130,7 @@ class ProfessionalLearningApplyBanner extends React.Component {
     } else if (this.props.nominated) {
       return 'CONGRATULATIONS! You’ve been nominated for a scholarship!';
     } else {
-      return 'SEATS OPEN - 2020 Professional Learning for Middle and High School Teachers';
+      return 'SEATS OPEN - 2021 Professional Learning for Middle and High School teachers';
     }
   }
 
@@ -179,7 +179,7 @@ class ProfessionalLearningApplyBanner extends React.Component {
               >
                 <div>
                   <button type="button" style={this.styles.button}>
-                    Join us
+                    Apply Now
                   </button>
                 </div>
               </div>
@@ -189,7 +189,7 @@ class ProfessionalLearningApplyBanner extends React.Component {
               >
                 <div>
                   <button type="button" style={this.styles.button}>
-                    Join us
+                    Apply Now
                   </button>
                 </div>
               </div>

--- a/apps/src/templates/ProfessionalLearningApplyBanner.story.jsx
+++ b/apps/src/templates/ProfessionalLearningApplyBanner.story.jsx
@@ -1,0 +1,21 @@
+import React from 'react';
+import ProfessionalLearningApplyBanner from './ProfessionalLearningApplyBanner';
+
+export default storybook => {
+  storybook
+    .storiesOf('Banners/ProfessionalLearningApplyBanner', module)
+    .addStoryTable([
+      {
+        name: 'Professional Learning Apply Banner - use sign up text',
+        story: () => <ProfessionalLearningApplyBanner useSignUpText={true} />
+      },
+      {
+        name: 'Professional Learning Apply Banner - nominated',
+        story: () => <ProfessionalLearningApplyBanner nominated={true} />
+      },
+      {
+        name: 'Professional Learning Apply Banner - seats open',
+        story: () => <ProfessionalLearningApplyBanner />
+      }
+    ]);
+};

--- a/apps/src/templates/census2017/YourSchool.jsx
+++ b/apps/src/templates/census2017/YourSchool.jsx
@@ -13,6 +13,7 @@ import {SpecialAnnouncementActionBlock} from '../studioHomepages/TwoColumnAction
 import i18n from '@cdo/locale';
 import SchoolAutocompleteDropdown from '../SchoolAutocompleteDropdown';
 import CensusMapReplacement from './CensusMapReplacement';
+import ProfessionalLearningApplyBanner from '../ProfessionalLearningApplyBanner';
 
 const styles = {
   heading: {
@@ -46,7 +47,8 @@ class YourSchool extends Component {
     alertUrl: PropTypes.string,
     prefillData: censusFormPrefillDataShape,
     hideMap: PropTypes.bool,
-    currentCensusYear: PropTypes.number
+    currentCensusYear: PropTypes.number,
+    showProfessionalLearningBanner: PropTypes.bool
   };
 
   state = {
@@ -123,6 +125,14 @@ class YourSchool extends Component {
           )}
         <h1 style={styles.heading}>{i18n.yourSchoolHeading()}</h1>
         <h3 style={styles.description}>{i18n.yourSchoolDescription()}</h3>
+        {this.props.showProfessionalLearningBanner && (
+          <ProfessionalLearningApplyBanner
+            nominated={false}
+            useSignUpText={false}
+            style={styles.banner}
+            linkSuffix={'middle-high'}
+          />
+        )}
         <YourSchoolResources />
         {!this.props.hideMap && (
           <div id="map">

--- a/apps/src/templates/census2017/YourSchool.story.js
+++ b/apps/src/templates/census2017/YourSchool.story.js
@@ -10,6 +10,13 @@ export default storybook => {
         name: 'YourSchool',
         description: `Container component for /yourschool`,
         story: () => <YourSchool hideMap={true} />
+      },
+      {
+        name: 'YourSchool - with professional learning banner',
+        description: `Container component for /yourschool - with professional learning banner`,
+        story: () => (
+          <YourSchool hideMap={true} showProfessionalLearningBanner={true} />
+        )
       }
     ]);
 };

--- a/config.yml.erb
+++ b/config.yml.erb
@@ -417,6 +417,8 @@ levelbuilder_mode:
 default_hoc_mode:   post-hoc # overridden by 'hoc_mode' DCDO param, except in :test
 default_hoc_launch: ''       # overridden by 'hoc_launch' DCDO param, except in :test
 
+default_teacher_applications_active: false # overridden by 'teacher_applications_active' DCDO param, except in :test
+
 localize_apps: false
 
 partners: []

--- a/dashboard/test/lib/announcements_invalid_data.json
+++ b/dashboard/test/lib/announcements_invalid_data.json
@@ -1,16 +1,16 @@
 {
   "pages": {
     "/home": "teacher-apps-closing-2020"
-    "/courses": "teacher-apps-open-2020"
+    "/courses": "teacher-apps-open-2021"
   },
   "banners": {
-    "teacher-apps-open-2020": {
+    "teacher-apps-open-2021": {
       "image": "https://code.org/images/professional-learning-2019-3.png",
       "title": "Sign up for Professional Learning",
       "body": "Join our hands-on workshops!",
       "buttonText": "Join us",
       "buttonUrl": "https://code.org/educate/professional-learning/middle-high",
-      "buttonId": "teacher-apps-open-2020-sign-up"
+      "buttonId": "teacher-apps-open-2021-sign-up"
     },
     "teacher-apps-closing-2020": {
       "image": "https://code.org/images/professional-learning-2019-closing-soon.png",

--- a/dashboard/test/lib/announcements_test.rb
+++ b/dashboard/test/lib/announcements_test.rb
@@ -13,7 +13,7 @@ class AnnouncementsTest < ActiveSupport::TestCase
     assert_equal("Sign up for Professional Learning", announcement[:title])
     assert_equal("Join us", announcement[:buttonText])
     assert_equal("https://code.org/educate/professional-learning/middle-high", announcement[:buttonUrl])
-    assert_equal("teacher-apps-open-2020-sign-up", announcement[:buttonId])
+    assert_equal("teacher-apps-open-2021-sign-up", announcement[:buttonId])
   end
 
   test 'gets home announcement' do

--- a/dashboard/test/lib/announcements_test_data.json
+++ b/dashboard/test/lib/announcements_test_data.json
@@ -1,17 +1,17 @@
 {
   "pages": {
     "/home": "teacher-apps-closing-2020",
-    "/courses": "teacher-apps-open-2020",
+    "/courses": "teacher-apps-open-2021",
     "/another-page": "not-a-banner"
   },
   "banners": {
-    "teacher-apps-open-2020": {
+    "teacher-apps-open-2021": {
       "image": "https://code.org/images/professional-learning-2019-3.png",
       "title": "Sign up for Professional Learning",
       "body": "Join our hands-on workshops!",
       "buttonText": "Join us",
       "buttonUrl": "https://code.org/educate/professional-learning/middle-high",
-      "buttonId": "teacher-apps-open-2020-sign-up"
+      "buttonId": "teacher-apps-open-2021-sign-up"
     },
     "teacher-apps-closing-2020": {
       "image": "https://code.org/images/professional-learning-2019-closing-soon.png",

--- a/pegasus/sites.v3/code.org/announcements.json
+++ b/pegasus/sites.v3/code.org/announcements.json
@@ -4,13 +4,13 @@
   },
 
   "banners": {
-    "teacher-apps-open-2020": {
+    "teacher-apps-open-2021": {
       "image": "/images/professional-learning-2019-3.png",
       "title": "Sign up for Professional Learning",
-      "body": "98% of teachers recommend our engaging programs from elementary school to AP computer science for high school. Join our hands-on workshops with other teachers from your area. Spaces are limited, so apply today!",
+      "body": "98% of participating teachers recommend our engaging, highly supportive program. Join our hands-on workshops with other teachers from your area. Scholarships and discounts available in most areas.",
       "buttonText": "Join us",
-      "buttonUrl": "https://code.org/educate/professional-learning/middle-high",
-      "buttonId": "teacher-apps-open-2020-sign-up"
+      "buttonUrl": "https://code.org/educate/professional-learning",
+      "buttonId": "teacher-apps-open-2021-sign-up"
     },
     "teacher-apps-closing-2020": {
       "image": "/images/professional-learning-2019-closing-soon.png",
@@ -47,7 +47,7 @@
       "buttonId": "view-project-ideas-2020-button",
       "backgroundColor": "#59b9dc"
     },
-   "soonhoc-2020": {
+    "soonhoc-2020": {
       "image": "/images/teacherdashboard1.png",
       "title": "The Hour of Code is Coming",
       "body": "Sign up your class to try one of the over 115 new activities for the Hour of Code (Dec. 7-13). This year, we’ll explore how we can harness computer science and technologies like AI to help build the society we want to live in. Sign up today!",
@@ -55,7 +55,7 @@
       "buttonUrl": "https://hourofcode.com/us#join",
       "buttonId": "2020-soonhoc"
     },
- "codebytes-2020": {
+    "codebytes-2020": {
       "image": "/images/marketing/CodeBytes_TeacherDashboard_540X289_CandyBag.png",
       "title": "CodeBytes: Live interactive mini-lessons during CSEdWeek!",
       "body": "Planning for the Hour of Code with your virtual classroom? Join us for CodeBytes, a series of 20 minute lessons that will livestream December 7-11. Episodes are designed for all grade bands and students with varying technology access.",
@@ -63,7 +63,7 @@
       "buttonUrl": "http://code.org/codebytes",
       "buttonId": "codebytes"
     },
- "ai-2020": {
+    "ai-2020": {
       "image": "/images/marketing/AI-2020-540X289.png",
       "title": "Explore Artificial Intelligence and Machine Learning",
       "body": "Join us to explore how AI impacts our entire world in a brand new video series, train AI for Oceans in 25+ languages, and hear from a panel of experts during the Ethics of AI livestream on Tuesday, December 8th.",

--- a/pegasus/sites.v3/code.org/public/alternative-classrooms.md.partial
+++ b/pegasus/sites.v3/code.org/public/alternative-classrooms.md.partial
@@ -9,6 +9,8 @@ social:
     "og:image:width": 850
     "og:image:height": 502
 ---
+{{ professional_learning_apply_banner }}
+
 # Resources for Teaching in Virtual and Socially-Distanced Classrooms
 
 <div class="col-40" style="padding-right: 20px">

--- a/pegasus/sites.v3/code.org/public/educate/curriculum/high-school.md.erb
+++ b/pegasus/sites.v3/code.org/public/educate/curriculum/high-school.md.erb
@@ -3,6 +3,7 @@ title: CS Curriculum for grades 9-12
 video_player: true
 theme: responsive
 ---
+ <%= view :professional_learning_apply_banner, :link_suffix => "middle-high", :style => {"padding-bottom" => "10px"} %>	
 
 [solid-block-header]
 

--- a/pegasus/sites.v3/code.org/public/educate/curriculum/middle-school.md.erb
+++ b/pegasus/sites.v3/code.org/public/educate/curriculum/middle-school.md.erb
@@ -12,6 +12,8 @@ Middle School
 
 Our curriculum is available at [no cost](/commitment) for anyone, anywhere to teach. You can read more about our [curriculum values here](/educate/curriculum/values).
 
+ <%= view :professional_learning_apply_banner, :link_suffix => "middle-high", :style => {"padding-top" => "22px"} %>
+
 <hr>
 
 <a name="csd"></a>

--- a/pegasus/sites.v3/code.org/public/educate/professional-learning/middle-high.md.erb
+++ b/pegasus/sites.v3/code.org/public/educate/professional-learning/middle-high.md.erb
@@ -13,6 +13,7 @@ theme: responsive
 </style>
 
 # Professional Learning for Middle and High School Teachers
+ <%= view :professional_learning_apply_banner, :link_suffix => "program-information", :style => {"padding-bottom" => "32px"} %>	
 
 <a name="scholarships"></a>
 <div class="col-50">

--- a/pegasus/sites.v3/code.org/public/yourschool.haml
+++ b/pegasus/sites.v3/code.org/public/yourschool.haml
@@ -24,6 +24,8 @@ social:
 - census_announcement['school_state'] = request.params["state"] if request.params["state"]
 - census_announcement['school_zip'] = request.params["zip"] if request.params["zip"]
 - census_announcement['school_year'] = current_census_year
+- census_announcement['locale'] = request.locale
+- census_announcement['teacher_applications_active'] = DCDO.get("teacher_applications_active", CDO.default_teacher_applications_active).to_s
 
 = inline_css 'trophy_announcement_sparkle.css'
 

--- a/pegasus/sites.v3/code.org/views/homepage_below_hero_plane_banner.haml
+++ b/pegasus/sites.v3/code.org/views/homepage_below_hero_plane_banner.haml
@@ -8,16 +8,15 @@
           .banner
             %img{src: "/images/homepage/professional-learning-2018-banner.png"}
             .text
-              Professional Learning is still on! Applications
+              Sign up for Professional Learning! Middle
               %br/
-              are open for Middle and High School teachers!
+              and High School applications now open.
         .right.col-20
           %button
             Join us
       .phone.phone-feature
         .text
-          Professional Learning is still on! Applications are open
-          for Middle and High School teachers!
+          Sign up for Professional Learning! Middle and High School applications now open.
         %button
           Join us
 

--- a/pegasus/sites.v3/code.org/views/professional_learning_apply_banner.haml
+++ b/pegasus/sites.v3/code.org/views/professional_learning_apply_banner.haml
@@ -1,10 +1,14 @@
 - use_sign_up_text ||= false
 - link_suffix ||= nil
+- style ||= nil
 - data = {}
 - data[:useSignUpText] = use_sign_up_text
 - data[:nominated] = params[:nominated]
 - data[:linkSuffix] = link_suffix
+- data[:style] = style
 
-%script{src: webpack_asset_path('js/code.org/views/professional_learning_apply_banner.js'), data: {props: data.to_json}}
+-# Professional Learning is only available in the US
+- if I18n.locale == :"en-US" && DCDO.get("teacher_applications_active", CDO.default_teacher_applications_active)
+  %script{src: webpack_asset_path('js/code.org/views/professional_learning_apply_banner.js'), data: {props: data.to_json}}
 
-#apply-banner-container
+  #apply-banner-container

--- a/pegasus/src/homepage.rb
+++ b/pegasus/src/homepage.rb
@@ -506,7 +506,7 @@ class Homepage
   end
 
   def self.show_professional_learning_banner(request)
-    false
+    request.locale == "en-US" && DCDO.get("teacher_applications_active", CDO.default_teacher_applications_active)
   end
 
   def self.show_courses_banner(request)
@@ -514,7 +514,7 @@ class Homepage
   end
 
   def self.show_special2020_banner(request)
-    true
+    false
   end
 
   def self.get_dance_stars


### PR DESCRIPTION
<!--
  Your description goes here: A summary of the change, including any relevant motivation and context.

  If relevant, include a description both of the existing behavior and of the new behavior.
-->
Requested changes: https://docs.google.com/document/d/1442P0BbGEVKC0RxN9W2cW02Og1yEQcEw4dZMbRAXvlA/edit?ts=5fda6502#

- Re-introduces professional learning apply banner, homepage below hero plane banner and teacher apps open announcement banner, with updated copy.
- Banners are hidden behind the feature flag `teacher_applications_active`
- `ProfessionalLearningApplyBanner` is added to storybook

On release day 2 things need to happen
1. Set DCDO flag `teacher_applications_active` to true
2. Add to `announcements.json` pages:
    "/home": "teacher-apps-open-2021",
    "/courses": "teacher-apps-open-2021"

### Homepage
<img width="1102" alt="Screen Shot 2021-01-06 at 10 11 49 AM" src="https://user-images.githubusercontent.com/24235215/103804898-a3523900-5007-11eb-8a0d-e355b71401d6.png">

### Logged-in teacher dashboard
<img width="1063" alt="Screen Shot 2021-01-06 at 10 13 01 AM" src="https://user-images.githubusercontent.com/24235215/103804988-cd0b6000-5007-11eb-9ebb-6623934f9f48.png">

### Teach page
<img width="1032" alt="Screen Shot 2021-01-06 at 10 13 53 AM" src="https://user-images.githubusercontent.com/24235215/103805069-eb715b80-5007-11eb-9ea8-c82eaa3c3e6a.png">

### Middle/High PL page
<img width="1054" alt="Screen Shot 2021-01-06 at 10 14 54 AM" src="https://user-images.githubusercontent.com/24235215/103805134-0774fd00-5008-11eb-9cc8-64404fef01c3.png">

### Middle school curriculum page
<img width="1018" alt="Screen Shot 2021-01-06 at 10 15 25 AM" src="https://user-images.githubusercontent.com/24235215/103805189-1a87cd00-5008-11eb-9a44-e6ddee522ae9.png">

### High school curriculum page
<img width="1041" alt="Screen Shot 2021-01-06 at 10 15 54 AM" src="https://user-images.githubusercontent.com/24235215/103805234-2b384300-5008-11eb-8149-6ce937fa8231.png">

### Your school
<img width="1026" alt="Screen Shot 2021-01-06 at 10 16 25 AM" src="https://user-images.githubusercontent.com/24235215/103805298-3db27c80-5008-11eb-8085-341858fd1e8e.png">

### Alternative classrooms
<img width="1016" alt="Screen Shot 2021-01-06 at 10 16 58 AM" src="https://user-images.githubusercontent.com/24235215/103805360-50c54c80-5008-11eb-8e3b-49f09fa021df.png">

### New banner in storybook
<img width="1405" alt="Screen Shot 2021-01-05 at 4 28 07 PM" src="https://user-images.githubusercontent.com/24235215/103831123-3c954580-5030-11eb-9f86-4a994217ab2b.png">


<!--
  Other aspects to consider. uncomment and add detail for any that seem necessary:
-->

<!-- ### Background -->
<!-- ### Privacy -->
<!--
1.	Does the Project involve the collection, use or sharing of new Personal Data?

2.	Does the Project involve a new or changed use or sharing of existing Personal Data?
-->
<!-- ### Security -->
<!--
Link to Jira Task where sensitive security issues are discussed privately.
-->
<!-- ### Caching -->
<!-- ### Deployment strategy -->
<!-- ### Future work -->

## Links

https://codedotorg.atlassian.net/browse/LP-1689
<!--
  Any relevant links to external resources; ie, specification documents, jira
  items, related PRs, honeybadger errors, etc
-->

- [spec]()
- [jira]()

## Testing story

<!--
  Does your change include appropriate tests?

  If so, please describe how the tests included in this PR are sufficient

  If not, please explain why this change does not need to be tested.
-->
I have tested all pages locally with the feature flag turned on and off, added storybook stories for `ProfessionalLearningApplyBanner`

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
