### PR TITLE
Increase Drone clone depth for i18n sync

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -10,7 +10,7 @@ steps:
 - name: clone
   image: docker:git
   commands:
-  - git clone --branch $DRONE_SOURCE_BRANCH  --depth 100 $DRONE_GIT_HTTP_URL .
+  - git clone --branch $DRONE_SOURCE_BRANCH  --depth 200 $DRONE_GIT_HTTP_URL .
   - git reset --hard $DRONE_COMMIT
   # Also fetch the target branch (which is staging for pull requests.) We need this for determining which tests to run based on changed files.
   - git remote set-branches --add origin $DRONE_TARGET_BRANCH
@@ -100,7 +100,7 @@ steps:
 - name: clone
   image: docker:git
   commands:
-  - git clone --branch $DRONE_SOURCE_BRANCH  --depth 100 $DRONE_GIT_HTTP_URL .
+  - git clone --branch $DRONE_SOURCE_BRANCH  --depth 200 $DRONE_GIT_HTTP_URL .
   - git reset --hard $DRONE_COMMIT
   # Also fetch the target branch (which is staging or staging-next for pull requests.) We need this for determining which tests to run based on changed files.
   - git remote set-branches --add origin $DRONE_TARGET_BRANCH
@@ -187,6 +187,6 @@ trigger:
   - pull_request
 ---
 kind: signature
-hmac: 1eb7f310b1ec6c67a0f6fa5b24ad6daab49a401ac9ed2bd908d3da4436003adc
+hmac: dc4e945db625740ff05bf17df74f5e97a40b0e336db058bf3ea7c5543e9ce9e5
 
 ...


### PR DESCRIPTION
Because of the winter break, the i18n sync feature branch [contains more than 100 commits](https://github.com/code-dot-org/code-dot-org/pull/38360/commits), causing the Drone Build to fail for this sync because [merging `staging` into the feature branch fails](http://drone.cdn-code.org/code-dot-org/code-dot-org/2372/2/2):

```
+ git clone --branch $DRONE_SOURCE_BRANCH  --depth 100 $DRONE_GIT_HTTP_URL .
2	Cloning into '.'...
3	Updating files:   9% (6342/68017)
Updating files:  10% (6802/68017)
Updating files:  11% (7482/68017)

<snip>

Updating files: 100% (68017/68017)
Updating files: 100% (68017/68017), done.
4	+ git reset --hard $DRONE_COMMIT
5	HEAD is now at 57170297 adding single quotes in i18n/dance/km_kh.json consistent with other languages
6	+ git remote set-branches --add origin $DRONE_TARGET_BRANCH
7	+ git fetch --depth 100 origin $DRONE_TARGET_BRANCH
8	From https://github.com/code-dot-org/code-dot-org
9	 * branch                  staging    -> FETCH_HEAD
10	 * [new branch]            staging    -> origin/staging
11	+ git config user.name "Drone"
12	+ git config user.email "drone-fake-user@code.org"
13	+ git merge origin/$DRONE_TARGET_BRANCH
14	fatal: refusing to merge unrelated histories
```

Increase git clone depth on the feature branch to 200.

<!-- ### Background -->
<!-- ### Privacy -->
<!--
1.	Does the Project involve the collection, use or sharing of new Personal Data?

2.	Does the Project involve a new or changed use or sharing of existing Personal Data?
-->
<!-- ### Security -->
<!--
Link to Jira Task where sensitive security issues are discussed privately.
-->
<!-- ### Caching -->
<!-- ### Deployment strategy -->
<!-- ### Future work -->

## Links

<!--
  Any relevant links to external resources; ie, specification documents, jira
  items, related PRs, honeybadger errors, etc
-->

- [spec]()
- [jira]()

## Testing story

<!--
  Does your change include appropriate tests?

  If so, please describe how the tests included in this PR are sufficient

  If not, please explain why this change does not need to be tested.
-->

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
