### PR TITLE
Manually save intentionally-invalid test models

### DIFF
--- a/dashboard/test/controllers/regional_partners_controller_test.rb
+++ b/dashboard/test/controllers/regional_partners_controller_test.rb
@@ -125,7 +125,7 @@ class RegionalPartnersControllerTest < ActionController::TestCase
   end
 
   test 'replace mappings fails on invalid non-unique zip-code mapping' do
-    create :regional_partner_with_mappings
+    build(:regional_partner_with_mappings).save(validate: false)
     sign_in @workshop_admin
     mapping = fixture_file_upload('regional_partner_mappings.csv', 'text/csv')
     post :replace_mappings, params: {id: @regional_partner.id, regions: mapping}
@@ -138,14 +138,15 @@ class RegionalPartnersControllerTest < ActionController::TestCase
   end
 
   test 'replace mappings fails on invalid non-unique state mapping' do
-    create(:regional_partner_with_mappings, mappings: [
-             create(
-               :pd_regional_partner_mapping,
-               zip_code: nil,
-               state: 'WA'
-             )
-           ]
-    )
+    build(:regional_partner_with_mappings, mappings:
+          [
+            create(
+              :pd_regional_partner_mapping,
+              zip_code: nil,
+              state: 'WA'
+            )
+          ]
+    ).save(validate: false)
 
     sign_in @workshop_admin
     mapping = fixture_file_upload('regional_partner_mappings.csv', 'text/csv')


### PR DESCRIPTION
We've got a couple tests that are creating some intentionally-invalid models. With Rails 6, models created via FactoryBot are validated by default, so we need to be more explicit about what we're doing.

## Testing story

N/A

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
