### PR TITLE
Disable Join Section button when no section code is inputted

### DIFF
--- a/apps/src/templates/studioHomepages/JoinSection.jsx
+++ b/apps/src/templates/studioHomepages/JoinSection.jsx
@@ -166,6 +166,7 @@ export default class JoinSection extends React.Component {
             __useDeprecatedTag
             onClick={this.joinSection}
             color={Button.ButtonColor.gray}
+            disabled={this.state.sectionCode.length === 0}
             text={i18n.joinSection()}
             style={styles.button}
           />

--- a/apps/test/unit/templates/studioHomepages/JoinSectionTest.jsx
+++ b/apps/test/unit/templates/studioHomepages/JoinSectionTest.jsx
@@ -20,7 +20,7 @@ describe('JoinSection', () => {
     server.restore();
   });
 
-  it('renders with a dashbed border when not enrolled in a section', () => {
+  it('renders with a dashed border when not enrolled in a section', () => {
     const wrapper = shallow(
       <JoinSection {...DEFAULT_PROPS} enrolledInASection={false} />
     );
@@ -32,6 +32,13 @@ describe('JoinSection', () => {
       <JoinSection {...DEFAULT_PROPS} enrolledInASection={true} />
     );
     expect(wrapper.prop('style')).to.include({borderStyle: 'solid'});
+  });
+
+  it('renders with disabled button when input is empty', () => {
+    const wrapper = shallow(<JoinSection {...DEFAULT_PROPS} />);
+    expect(wrapper.find('Button').prop('disabled')).to.be.true;
+    wrapper.find('input').simulate('change', {target: {value: 'ABCDEF'}});
+    expect(wrapper.find('Button').prop('disabled')).to.be.false;
   });
 
   it('updates state when typing', () => {


### PR DESCRIPTION
This small fix disables the "Join Section" button in the `JoinSection` component when the user has not yet inputted any text. Currently, the user can click "Join Section" without inputting any text, resulting in a `POST` request to `/api/v1/sections//join`. On the user's side, they do get a helpful error message, but the error message is printed awkwardly as the undefined section code is represented by just a blank space. To prevent the user from making these requests in the first place, we will disable the button until the user types. The validation of the section code itself is still left to the `POST` request and the subsequent response.

## Previous Behavior

`POST` Request:
<img width="426" alt="Screen Shot 2021-01-03 at 8 23 03 PM" src="https://user-images.githubusercontent.com/17502635/103593921-2a4ac880-4ec5-11eb-9cb0-1cec186f3d25.png">

Error Message With Blank Space:
<img width="969" alt="Screen Shot 2021-01-03 at 8 22 53 PM" src="https://user-images.githubusercontent.com/17502635/103593937-35055d80-4ec5-11eb-8b53-4e5c6e949633.png">

## New Behavior
<img alt='demo' src='http://g.recordit.co/KCAcvMNgPN.gif'>

## Testing story

Added unit test to confirm prop passed to `Button` component reflects the state of the input in `JoinSection`

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
