### PR TITLE
Use RDS Proxy to connect to DB cluster

### DIFF
--- a/aws/cloudformation/bootstrap_chef_stack.sh.erb
+++ b/aws/cloudformation/bootstrap_chef_stack.sh.erb
@@ -119,6 +119,11 @@ cat <<JSON > $FIRST_BOOT
 <% end -%>
     "stack_name": "$STACK"
   },
+<% if database -%>
+  "cdo-mysql": {
+    "rds_proxy": "${DBProxy.Endpoint}"
+  },
+<% end -%>
 <% if CDO.chef_local_mode -%>
   "omnibus_updater": {
     "version": "$CHEF_VERSION"

--- a/aws/cloudformation/components/database.yml.erb
+++ b/aws/cloudformation/components/database.yml.erb
@@ -40,3 +40,32 @@
         PasswordLength: 10
         ExcludePunctuation: True
       Name: !Sub "CfnStack/${AWS::StackName}/database-secret"
+
+  DBProxy:
+    Type: AWS::RDS::DBProxy
+    Properties:
+      DBProxyName: !Ref AWS::StackName
+      EngineFamily: MYSQL
+      RoleArn: !GetAtt DBProxyRole.Arn
+      Auth: [{AuthScheme: SECRETS, SecretArn: !Ref DatabaseSecret, IAMAuth: DISABLED}]
+      VpcSubnetIds: <%=subnets.to_json%>
+      VpcSecurityGroupIds: [!ImportValue VPC-DBSecurityGroup]
+  DBProxyRole:
+    Type: AWS::IAM::Role
+    Properties:
+      <%=service_role 'rds'%>
+      Policies:
+        - PolicyName: RDSProxy
+          PolicyDocument:
+            Statement:
+              - {Effect: Allow, Action: 'secretsmanager:GetSecretValue', Resource: !Ref DatabaseSecret}
+      PermissionsBoundary: !ImportValue IAM-DevPermissions
+  DBProxyTargetGroup:
+    Type: AWS::RDS::DBProxyTargetGroup
+    DependsOn: [Aurora0, Aurora1]
+    Properties:
+      DBProxyName: !Ref DBProxy
+      DBClusterIdentifiers: [!Ref AuroraCluster]
+      TargetGroupName: default
+      ConnectionPoolConfigurationInfo:
+        ConnectionBorrowTimeout: 10

--- a/aws/cloudformation/iam.yml.erb
+++ b/aws/cloudformation/iam.yml.erb
@@ -118,13 +118,10 @@ Resources:
             Condition:
               StringNotEquals:
                 cloudformation:RoleARN: !Sub "arn:aws:iam::${AWS::AccountId}:role/admin/CloudFormationService"
-            # Read-only access to current secrets.
+          # Read-only access to secrets.
           - Effect: Allow
             Action: secretsmanager:GetSecretValue
             Resource: '*'
-            Condition:
-              StringEquals:
-                secretsmanager:VersionStage: AWSCURRENT
   # Permissions which grant the CurriculumBuilder project read-only acces to
   # the DCDO database, so select configuration variables can be shared between
   # the two projects.

--- a/cookbooks/cdo-mysql/attributes/default.rb
+++ b/cookbooks/cdo-mysql/attributes/default.rb
@@ -1,10 +1,13 @@
 default['cdo-mysql'] = {
   proxy: {
-    # Enable proxy on non-daemon app-servers by default.
+    # Enable ProxySQL on non-daemon app-servers by default.
     enabled: node['cdo-apps'] && !node['cdo-apps']['daemon'],
     port: 6033,
     reporting_port: 6034,
     admin: 'mysql2://admin:admin@127.0.0.1:6032'
-  }
+  },
+
+  # If RDS Proxy endpoint is provided it will be used instead of ProxySQL.
+  rds_proxy: nil
 }
 default['cdo-secrets'] = {}

--- a/cookbooks/cdo-mysql/recipes/default.rb
+++ b/cookbooks/cdo-mysql/recipes/default.rb
@@ -9,5 +9,12 @@ include_recipe 'cdo-mysql::client'
 writer = URI.parse(node['cdo-secrets']['db_writer'].to_s)
 include_recipe 'cdo-mysql::server' unless writer.hostname
 
-# Install proxy if enabled.
-include_recipe 'cdo-mysql::proxy' if node['cdo-mysql']['proxy']['enabled']
+# Override db_writer variable with RDS-proxy endpoint if provided.
+if (rds_proxy = node['cdo-mysql']['rds_proxy'])
+  node.override['cdo-secrets']['db_writer'] =
+    writer.dup.tap {|w| w.hostname = rds_proxy}.to_s
+
+# Otherwise install ProxySQL if enabled.
+elsif node['cdo-mysql']['proxy']['enabled']
+  include_recipe 'cdo-mysql::proxy'
+end


### PR DESCRIPTION
This PR integrates [RDS Proxy](https://aws.amazon.com/rds/proxy/) to connect to the Aurora database cluster to handle multiplexing, connection pooling and failover in place of ProxySQL.

It adds new resources to the `database` component of the CloudFormation application stack that configure an RDS Proxy instance targeting the Aurora database cluster, and adds a new Chef attribute `node.cdo-mysql.rds_proxy` specifying the endpoint of the RDS proxy. If provided, the RDS proxy is used instead of ProxySQL to override the `db_writer` application variable (which controls the MySQL database endpoint used to send write queries).