### PR TITLE
Add break translated string

### DIFF
--- a/apps/i18n/common/en_us.json
+++ b/apps/i18n/common/en_us.json
@@ -169,6 +169,7 @@
   "bottomCenter": "bottom center",
   "bottomLeft": "bottom left",
   "bottomRight": "bottom right",
+  "break": "Break",
   "builtOnCodeStudio": "Built on Code Studio",
   "by": "By",
   "cancel": "Cancel",


### PR DESCRIPTION
This came up as part of initial investigation into adding a pause button for spritelab. The [existing i18n string](https://github.com/code-dot-org/code-dot-org/blob/staging/apps/i18n/common/en_us.json#L1273) for `pause` is `"Break"`. If/when we add a pause button for spritelab, we'll want `"pause": "Pause"` and `"break": "Break"`. Making this change will require some timing with i18n syncs, so I figure it's worth starting now. 
See context in this [slack thread](https://codedotorg.slack.com/archives/C0T0UQH0R/p1609866519017800)