### PR TITLE
Add vocabulary model and migrations

### DIFF
--- a/dashboard/app/models/vocabulary.rb
+++ b/dashboard/app/models/vocabulary.rb
@@ -1,0 +1,20 @@
+# == Schema Information
+#
+# Table name: vocabularies
+#
+#  id                :bigint           not null, primary key
+#  key               :string(255)      not null
+#  word              :string(255)      not null
+#  definition        :text(65535)      not null
+#  course_version_id :integer          not null
+#  created_at        :datetime         not null
+#  updated_at        :datetime         not null
+#
+# Indexes
+#
+#  index_vocabularies_on_key_and_course_version_id  (key,course_version_id) UNIQUE
+#  index_vocabularies_on_word_and_definition        (word,definition)
+#
+class Vocabulary < ApplicationRecord
+  belongs_to :course_version
+end

--- a/dashboard/db/migrate/20210105170753_create_vocabularies.rb
+++ b/dashboard/db/migrate/20210105170753_create_vocabularies.rb
@@ -1,0 +1,15 @@
+class CreateVocabularies < ActiveRecord::Migration[5.2]
+  def change
+    create_table :vocabularies do |t|
+      t.string :key, null: false
+      t.string :word, null: false
+      t.text :definition, null: false
+      t.integer :course_version_id, null: false
+
+      t.index [:word, :definition], type: :fulltext
+      t.index [:key, :course_version_id], unique: true
+
+      t.timestamps
+    end
+  end
+end

--- a/dashboard/db/schema.rb
+++ b/dashboard/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_12_16_185353) do
+ActiveRecord::Schema.define(version: 2021_01_05_170753) do
 
   create_table "activities", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci", force: :cascade do |t|
     t.integer "user_id"
@@ -1854,6 +1854,17 @@ ActiveRecord::Schema.define(version: 2020_12_16_185353) do
     t.string "download"
     t.string "locale", default: "en-US", null: false
     t.index ["key", "locale"], name: "index_videos_on_key_and_locale", unique: true
+  end
+
+  create_table "vocabularies", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci", force: :cascade do |t|
+    t.string "key", null: false
+    t.string "word", null: false
+    t.text "definition", null: false
+    t.integer "course_version_id", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["key", "course_version_id"], name: "index_vocabularies_on_key_and_course_version_id", unique: true
+    t.index ["word", "definition"], name: "index_vocabularies_on_word_and_definition", type: :fulltext
   end
 
   add_foreign_key "ap_school_codes", "schools"

--- a/dashboard/test/factories/factories.rb
+++ b/dashboard/test/factories/factories.rb
@@ -807,6 +807,13 @@ FactoryGirl.define do
     description 'fake description'
   end
 
+  factory :vocabulary do
+    association :course_version
+    key 'word'
+    word 'word'
+    definition 'definition'
+  end
+
   factory :callout do
     sequence(:element_id) {|n| "#pageElement#{n}"}
     localization_key 'drag_blocks'

--- a/dashboard/test/factories/factories.rb
+++ b/dashboard/test/factories/factories.rb
@@ -809,7 +809,7 @@ FactoryGirl.define do
 
   factory :vocabulary do
     association :course_version
-    key 'word'
+    sequence(:key) {|n| "vocab-#{n}"}
     word 'word'
     definition 'definition'
   end

--- a/dashboard/test/models/vocabulary_test.rb
+++ b/dashboard/test/models/vocabulary_test.rb
@@ -2,8 +2,7 @@ require 'test_helper'
 
 class VocabularyTest < ActiveSupport::TestCase
   test "can create vocabulary" do
-    vocab = create :vocabulary, key: 'foo', word: 'foo', definition: 'a fake word'
-    assert_equal 'foo', vocab.key
+    vocab = create :vocabulary, word: 'foo', definition: 'a fake word'
     assert_equal 'foo', vocab.word
     assert_equal 'a fake word', vocab.definition
   end

--- a/dashboard/test/models/vocabulary_test.rb
+++ b/dashboard/test/models/vocabulary_test.rb
@@ -1,0 +1,10 @@
+require 'test_helper'
+
+class VocabularyTest < ActiveSupport::TestCase
+  test "can create vocabulary" do
+    vocab = create :vocabulary, key: 'foo', word: 'foo', definition: 'a fake word'
+    assert_equal 'foo', vocab.key
+    assert_equal 'foo', vocab.word
+    assert_equal 'a fake word', vocab.definition
+  end
+end


### PR DESCRIPTION
Adds the model and migrations for the vocabulary model.

I decided to add a key as the spec calls out a likelihood that some courses will have multiple definitions per word (in the case of Common Sense). For now, my plan was to make the key equal to the word.

This PR adds the vocabulary/course version association but the lesson/vocabulary association will come in a later PR in order to limit the number of migrations per PR.

<!-- ### Background -->
<!-- ### Privacy -->
<!--
1.	Does the Project involve the collection, use or sharing of new Personal Data?

2.	Does the Project involve a new or changed use or sharing of existing Personal Data?
-->
<!-- ### Security -->
<!--
Link to Jira Task where sensitive security issues are discussed privately.
-->
<!-- ### Caching -->
<!-- ### Deployment strategy -->
<!-- ### Future work -->

## Links

<!--
  Any relevant links to external resources; ie, specification documents, jira
  items, related PRs, honeybadger errors, etc
-->

- [spec]()
- [jira]()

## Testing story

<!--
  Does your change include appropriate tests?

  If so, please describe how the tests included in this PR are sufficient

  If not, please explain why this change does not need to be tested.
-->

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
