### PR TITLE
Delete tip key before saving

### DIFF
--- a/apps/src/lib/levelbuilder/lesson-editor/activitiesEditorRedux.js
+++ b/apps/src/lib/levelbuilder/lesson-editor/activitiesEditorRedux.js
@@ -502,6 +502,11 @@ export const getSerializedActivities = rawActivities => {
         delete scriptLevel.position;
         delete scriptLevel.levelNumber;
       });
+
+      activitySection.tips.forEach(tip => {
+        // Key is just used in the react UI
+        delete tip.key;
+      });
     });
   });
 


### PR DESCRIPTION
https://codedotorg.atlassian.net/browse/PLAT-653

Deletes the tip key before saving since we don't need it and it changes when the lesson edit page reloads.

Should I try to generate the updated script_jsons locally from this change or let it happen when deployed?

## Testing story

Saved a lesson edit page locally and checked that it deleted the tip. Thoughts on if other tests are needed?

![Screen Shot 2021-01-05 at 4 58 17 PM](https://user-images.githubusercontent.com/208083/103704726-be756800-4f77-11eb-82e4-5d8403217489.png)

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
