### PR TITLE
Add 'ethnicity' to race interstitial subheading

### DIFF
--- a/dashboard/app/assets/stylesheets/interstitial.scss
+++ b/dashboard/app/assets/stylesheets/interstitial.scss
@@ -94,6 +94,9 @@
 #race-modal .custom-h1 {
   margin-top: 25px;
 }
+#race-modal h3 {
+  line-height: 24px;
+}
 #terms-modal .right-margin-5,
 #race-modal .right-margin-5 {
   margin-right: 5px;

--- a/dashboard/config/locales/en.yml
+++ b/dashboard/config/locales/en.yml
@@ -831,7 +831,7 @@ en:
     save: "Save"
   race_interstitial:
     title: "Optional: Help us track our progress toward improving diversity in computer science"
-    message: "Please tell us your race (check all that apply)"
+    message: "Please tell us your race or ethnicity (check all that apply)"
     races:
       white: "White"
       black: "Black or African American"


### PR DESCRIPTION
This is to account for the fact that Hispanic is considered an ethnicity.

## Testing story
Tested on localhost Firefox, IE, and Chrome
*Before*
![image](https://user-images.githubusercontent.com/2933346/103705172-6c284d00-4f5f-11eb-8c38-6fbf3e6d3707.png)
*After*
![race_interstitial_chrome](https://user-images.githubusercontent.com/2933346/103704938-076cf280-4f5f-11eb-8374-d694284cd782.png)

<!--
  Does your change include appropriate tests?

  If so, please describe how the tests included in this PR are sufficient

  If not, please explain why this change does not need to be tested.
-->

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
