### PR TITLE
Activity Sections with Levels Show in Agenda

### DIFF
--- a/apps/src/templates/lessonOverview/LessonAgenda.jsx
+++ b/apps/src/templates/lessonOverview/LessonAgenda.jsx
@@ -9,11 +9,11 @@ export default class LessonAgenda extends Component {
   };
 
   render() {
-    // Do not link to sections that are progressions and sections without a displayName
+    // Do not link to sections without a displayName
     let filteredActivitiesList = _.cloneDeep(this.props.activities);
     filteredActivitiesList.forEach(activity => {
       activity.activitySections = activity.activitySections.filter(
-        section => section.displayName !== '' && section.scriptLevels.length < 1
+        section => section.displayName !== ''
       );
     });
 

--- a/apps/test/unit/templates/lessonOverview/LessonAgendaTest.jsx
+++ b/apps/test/unit/templates/lessonOverview/LessonAgendaTest.jsx
@@ -58,7 +58,7 @@ describe('LessonAgenda', () => {
 
   it('renders default props', () => {
     const wrapper = shallow(<LessonAgenda {...defaultProps} />);
-    expect(wrapper.find('a').length).to.equal(5);
+    expect(wrapper.find('a').length).to.equal(6);
 
     expect(
       wrapper
@@ -103,6 +103,13 @@ describe('LessonAgenda', () => {
       wrapper
         .find('a')
         .at(4)
+        .props().href
+    ).to.equal('#activity-section-section-4');
+
+    expect(
+      wrapper
+        .find('a')
+        .at(5)
         .props().href
     ).to.equal('#activity-section-section-6');
   });


### PR DESCRIPTION
When we first designed activity sections if they had levels they did not have any text content so we did not want to show them in the agenda. We have since updated that so we need to show these sections in the agenda. 

Some of the activity sections from the Lesson
![Screen Shot 2021-01-05 at 5 24 56 PM](https://user-images.githubusercontent.com/208083/103706539-f205c180-4f7a-11eb-91a6-16f9d4a551d9.png)

Before:

![Screen Shot 2021-01-05 at 5 24 37 PM](https://user-images.githubusercontent.com/208083/103706514-e4e8d280-4f7a-11eb-9d95-d3d52ffd358a.png)

After:
![Screen Shot 2021-01-05 at 5 23 09 PM](https://user-images.githubusercontent.com/208083/103706428-c256b980-4f7a-11eb-8ae9-1ca1e912bef5.png)


## Links

<!--
  Any relevant links to external resources; ie, specification documents, jira
  items, related PRs, honeybadger errors, etc
-->

- [jira](https://codedotorg.atlassian.net/browse/PLAT-651)

## Testing story

updated LessonAgendaTest


# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
