### PR TITLE
use strings for level ids in levelbuilder

### DIFF
--- a/apps/src/lib/levelbuilder/lesson-editor/LevelToken.jsx
+++ b/apps/src/lib/levelbuilder/lesson-editor/LevelToken.jsx
@@ -9,6 +9,7 @@ import ProgressBubble from '@cdo/apps/templates/progress/ProgressBubble';
 import LevelTokenDetails from '@cdo/apps/lib/levelbuilder/lesson-editor/LevelTokenDetails';
 import {toggleExpand} from '@cdo/apps/lib/levelbuilder/lesson-editor/activitiesEditorRedux';
 import {LevelStatus} from '@cdo/apps/util/sharedConstants';
+import _ from 'lodash';
 
 const styles = {
   levelToken: {
@@ -119,12 +120,17 @@ class LevelToken extends Component {
   };
 
   scriptLevelForProgressBubble = activeLevel => {
-    let progressBubbleLevel = activeLevel;
+    let progressBubbleLevel = _.cloneDeep(activeLevel);
 
     progressBubbleLevel['isCurrentLevel'] = false;
     progressBubbleLevel['status'] = LevelStatus.not_tried;
     progressBubbleLevel['levelNumber'] = this.props.scriptLevel.levelNumber;
     progressBubbleLevel['kind'] = this.props.scriptLevel.kind;
+
+    // TODO: (charlie) this is temporary backward compatibility with
+    // ProgressBubble, which will be updated to use strings for ids
+    // in an upcoming PR
+    progressBubbleLevel['id'] = parseInt(activeLevel.id);
 
     return progressBubbleLevel;
   };

--- a/apps/src/lib/levelbuilder/lesson-editor/LevelTokenDetails.story.jsx
+++ b/apps/src/lib/levelbuilder/lesson-editor/LevelTokenDetails.story.jsx
@@ -3,11 +3,11 @@ import {UnconnectedLevelTokenDetails as LevelTokenDetails} from '@cdo/apps/lib/l
 import {action} from '@storybook/addon-actions';
 
 const defaultLevel = {
-  id: 10,
+  id: '10',
   levels: [
     {
       name: 'Level One',
-      id: 1,
+      id: '1',
       url: 'levels/598/edit',
       icon: 'fa-desktop',
       isUnplugged: false,
@@ -19,7 +19,7 @@ const defaultLevel = {
     }
   ],
   position: 1,
-  activeId: 1,
+  activeId: '1',
   kind: 'puzzle',
   bonus: false,
   assessment: false,
@@ -28,16 +28,16 @@ const defaultLevel = {
 };
 
 const blocklyLevel = {
-  id: 11,
+  id: '11',
   position: 1,
   levels: [
     {
-      id: 4,
+      id: '4',
       name: 'blockly:Studio:playlab_1',
       url: 'levels/59800/edit'
     }
   ],
-  activeId: 4,
+  activeId: '4',
   expand: false
 };
 

--- a/apps/src/lib/levelbuilder/lesson-editor/activitiesEditorRedux.js
+++ b/apps/src/lib/levelbuilder/lesson-editor/activitiesEditorRedux.js
@@ -29,7 +29,7 @@ const MOVE_LEVEL_TO_ACTIVITY_SECTION =
 const SET_SCRIPT_LEVEL_FIELD = 'activitiesEditor/SET_SCRIPT_LEVEL_FIELD';
 const TOGGLE_EXPAND = 'activitiesEditor/TOGGLE_EXPAND';
 
-export const NEW_LEVEL_ID = -1;
+export const NEW_LEVEL_ID = '-1';
 
 // NOTE: Position for Activities, Activity Sections and Levels is 1 based.
 

--- a/apps/src/lib/levelbuilder/shapes.jsx
+++ b/apps/src/lib/levelbuilder/shapes.jsx
@@ -2,7 +2,7 @@ import PropTypes from 'prop-types';
 
 export const levelShape = PropTypes.shape({
   // id of level
-  id: PropTypes.number.isRequired,
+  id: PropTypes.string.isRequired,
   //name of level
   name: PropTypes.string.isRequired,
   //url for editing level
@@ -22,14 +22,14 @@ export const levelShape = PropTypes.shape({
 
 export const scriptLevelShape = PropTypes.shape({
   // script level id
-  id: PropTypes.number.isRequired,
+  id: PropTypes.string.isRequired,
 
   // The position of this level within the lesson in the UI.
   position: PropTypes.number.isRequired,
 
   // if only one level the id for that level
   // if multiple variants the level id for the active variant
-  activeId: PropTypes.number.isRequired,
+  activeId: PropTypes.string.isRequired,
   // all variants of this level
   levels: PropTypes.arrayOf(levelShape).isRequired,
 
@@ -83,8 +83,8 @@ export const resourceShape = PropTypes.shape({
 
 export const levelShapeForScript = PropTypes.shape({
   position: PropTypes.number,
-  activeId: PropTypes.number,
-  ids: PropTypes.arrayOf(PropTypes.number),
+  activeId: PropTypes.string,
+  ids: PropTypes.arrayOf(PropTypes.string),
   kind: PropTypes.string,
   skin: PropTypes.string,
   videoKey: PropTypes.string,

--- a/apps/src/templates/lessonOverview/activities/ProgressionDetails.jsx
+++ b/apps/src/templates/lessonOverview/activities/ProgressionDetails.jsx
@@ -33,7 +33,10 @@ export default class ProgressionDetails extends Component {
         : scriptLevel.levels[0];
 
     return {
-      id: activeLevel.id,
+      // TODO: (charlie) this is temporary backward compatibility with
+      // ProgressBubble, which will be updated to use strings for ids
+      // in an upcoming PR
+      id: parseInt(activeLevel.id),
       status: LevelStatus.not_tried,
       url: scriptLevel.url,
       name: activeLevel.name,

--- a/apps/src/templates/lessonOverview/lessonPlanShapes.jsx
+++ b/apps/src/templates/lessonOverview/lessonPlanShapes.jsx
@@ -2,7 +2,7 @@ import PropTypes from 'prop-types';
 
 export const levelShape = PropTypes.shape({
   // id of level
-  id: PropTypes.number.isRequired,
+  id: PropTypes.string.isRequired,
   //name of level
   name: PropTypes.string.isRequired,
 
@@ -20,11 +20,11 @@ export const levelShape = PropTypes.shape({
 
 export const scriptLevelShape = PropTypes.shape({
   // script level id
-  id: PropTypes.number.isRequired,
+  id: PropTypes.string.isRequired,
 
   // if only one level the id for that level
   // if multiple variants the level id for the active variant
-  activeId: PropTypes.number.isRequired,
+  activeId: PropTypes.string.isRequired,
   // all variants of this level
   levels: PropTypes.arrayOf(levelShape).isRequired,
 

--- a/apps/test/unit/lib/levelbuilder/lesson-editor/LevelTokenDetailsTest.js
+++ b/apps/test/unit/lib/levelbuilder/lesson-editor/LevelTokenDetailsTest.js
@@ -5,16 +5,16 @@ import sinon from 'sinon';
 import {UnconnectedLevelTokenDetails as LevelTokenDetails} from '@cdo/apps/lib/levelbuilder/lesson-editor/LevelTokenDetails';
 
 const defaultScriptLevel = {
-  id: 10,
+  id: '10',
   position: 1,
   levels: [
     {
       name: 'Level 1',
-      id: 2,
+      id: '2',
       url: '/fake/url/'
     }
   ],
-  activeId: 2,
+  activeId: '2',
   expand: true
 };
 

--- a/apps/test/unit/lib/levelbuilder/lesson-editor/activitiesEditorReduxTest.js
+++ b/apps/test/unit/lib/levelbuilder/lesson-editor/activitiesEditorReduxTest.js
@@ -99,7 +99,7 @@ describe('activitiesEditorRedux reducer tests', () => {
         .activities;
       assert.deepEqual(
         nextState[0].activitySections[2].scriptLevels.map(l => l.id),
-        [11, 10]
+        ['11', '10']
       );
     });
 
@@ -135,7 +135,10 @@ describe('activitiesEditorRedux reducer tests', () => {
 
       it('moves level to activitySection within the same activity', () => {
         const oldActivities = initialState.activities;
-        assert.deepEqual([[], [], [1, 2]], activeLevelIdMap(oldActivities[0]));
+        assert.deepEqual(
+          [[], [], ['1', '2']],
+          activeLevelIdMap(oldActivities[0])
+        );
 
         const activityPos = 1;
         const sectionPos = 3;
@@ -151,12 +154,18 @@ describe('activitiesEditorRedux reducer tests', () => {
             newSectionPos
           )
         ).activities;
-        assert.deepEqual([[], [2], [1]], activeLevelIdMap(newActivities[0]));
+        assert.deepEqual(
+          [[], ['2'], ['1']],
+          activeLevelIdMap(newActivities[0])
+        );
       });
 
       it('moves level to activitySection in a different activity', () => {
         const oldActivities = initialState.activities;
-        assert.deepEqual([[], [], [1, 2]], activeLevelIdMap(oldActivities[0]));
+        assert.deepEqual(
+          [[], [], ['1', '2']],
+          activeLevelIdMap(oldActivities[0])
+        );
         assert.deepEqual([[]], activeLevelIdMap(oldActivities[1]));
 
         const activityPos = 1;
@@ -174,8 +183,8 @@ describe('activitiesEditorRedux reducer tests', () => {
             newSectionPos
           )
         ).activities;
-        assert.deepEqual([[], [], [1]], activeLevelIdMap(newActivities[0]));
-        assert.deepEqual([[2]], activeLevelIdMap(newActivities[1]));
+        assert.deepEqual([[], [], ['1']], activeLevelIdMap(newActivities[0]));
+        assert.deepEqual([['2']], activeLevelIdMap(newActivities[1]));
       });
     });
 
@@ -183,11 +192,11 @@ describe('activitiesEditorRedux reducer tests', () => {
       const nextState = reducer(
         initialState,
         addLevel(1, 3, {
-          id: 12,
+          id: '12',
           levels: [
             {
               name: 'Level 4',
-              id: 4,
+              id: '4',
               url: '/levels/598/edit',
               icon: 'fa-desktop',
               isUnplugged: false,
@@ -199,7 +208,7 @@ describe('activitiesEditorRedux reducer tests', () => {
             }
           ],
           position: 4,
-          activeId: 4,
+          activeId: '4',
           kind: 'puzzle',
           bonus: false,
           assessment: false,
@@ -209,7 +218,7 @@ describe('activitiesEditorRedux reducer tests', () => {
       ).activities;
       assert.deepEqual(
         nextState[0].activitySections[2].scriptLevels.map(s => s.id),
-        [10, 11, 12]
+        ['10', '11', '12']
       );
     });
 
@@ -217,7 +226,7 @@ describe('activitiesEditorRedux reducer tests', () => {
       const nextState = reducer(initialState, removeLevel(1, 3, 1)).activities;
       assert.deepEqual(
         nextState[0].activitySections[2].scriptLevels.map(s => s.id),
-        [11]
+        ['11']
       );
     });
 

--- a/apps/test/unit/lib/levelbuilder/lesson-editor/activitiesTestData.js
+++ b/apps/test/unit/lib/levelbuilder/lesson-editor/activitiesTestData.js
@@ -43,11 +43,11 @@ export const sampleActivities = [
         text: 'This progression teaches you programming!',
         scriptLevels: [
           {
-            id: 10,
+            id: '10',
             levels: [
               {
                 name: 'Level 1',
-                id: 1,
+                id: '1',
                 url: 'levels/598/edit',
                 icon: 'fa-desktop',
                 isUnplugged: false,
@@ -60,7 +60,7 @@ export const sampleActivities = [
             ],
             position: 1,
             levelNumber: 1,
-            activeId: 1,
+            activeId: '1',
             kind: 'puzzle',
             bonus: false,
             assessment: false,
@@ -68,11 +68,11 @@ export const sampleActivities = [
             expand: false
           },
           {
-            id: 11,
+            id: '11',
             levels: [
               {
                 name: 'Level 2',
-                id: 2,
+                id: '2',
                 url: '/levels/598/edit',
                 icon: 'fa-desktop',
                 isUnplugged: false,
@@ -84,7 +84,7 @@ export const sampleActivities = [
               },
               {
                 name: 'Level 3',
-                id: 3,
+                id: '3',
                 url: '/levels/598/edit',
                 icon: 'fa-desktop',
                 isUnplugged: false,
@@ -97,7 +97,7 @@ export const sampleActivities = [
             ],
             position: 2,
             levelNumber: 2,
-            activeId: 2,
+            activeId: '2',
             kind: 'assessment',
             bonus: false,
             assessment: true,

--- a/dashboard/app/models/levels/level.rb
+++ b/dashboard/app/models/levels/level.rb
@@ -616,7 +616,7 @@ class Level < ApplicationRecord
 
   def summarize_for_edit
     {
-      id: id,
+      id: id.to_s,
       type: self.class.to_s,
       name: name,
       updated_at: updated_at.localtime.strftime("%D at %r"),

--- a/dashboard/app/models/script_level.rb
+++ b/dashboard/app/models/script_level.rb
@@ -421,6 +421,11 @@ class ScriptLevel < ApplicationRecord
       summary[:conceptDifficulty] = level.summarize_concept_difficulty
       summary[:assessment] = !!assessment
       summary[:challenge] = !!challenge
+
+      # TODO: (charlie) we will move this string conversion out of this
+      # `for_edit` block as soon as code studio updates to use strings for ids
+      summary[:ids] = summary[:ids].map(&:to_s)
+      summary[:activeId] = summary[:activeId].to_s
     end
 
     if include_prev_next
@@ -467,11 +472,11 @@ class ScriptLevel < ApplicationRecord
 
   def summarize_for_lesson_edit
     summary = summarize(for_edit: true)
-    summary[:id] = id
+    summary[:id] = id.to_s
     summary[:activitySectionPosition] = activity_section_position
     summary[:levels] = levels.map do |level|
       {
-        id: level.id,
+        id: level.id.to_s,
         name: level.name,
         url: edit_level_path(id: level.id)
       }

--- a/dashboard/test/controllers/lessons_controller_test.rb
+++ b/dashboard/test/controllers/lessons_controller_test.rb
@@ -597,7 +597,7 @@ class LessonsControllerTest < ActionController::TestCase
 
     existing_summary = existing_script_level.summarize_for_lesson_edit
     assert_equal 1, existing_summary[:activitySectionPosition]
-    assert_equal existing_survey.id, existing_summary[:activeId]
+    assert_equal existing_survey.id.to_s, existing_summary[:activeId]
     existing_summary[:assessment] = false
 
     survey_to_add = create :level_group, name: 'survey-to-add'

--- a/dashboard/test/integration/lessons_test.rb
+++ b/dashboard/test/integration/lessons_test.rb
@@ -104,11 +104,11 @@ class LessonsTest < ActionDispatch::IntegrationTest
     assert script_level_data['challenge']
     refute script_level_data['assessment']
     refute script_level_data['bonus']
-    assert_equal @level.id, script_level_data['activeId']
+    assert_equal @level.id.to_s, script_level_data['activeId']
     assert_equal 1, script_level_data['levels'].count
     level_data = script_level_data['levels'].first
     assert_equal @level.name, level_data['name']
-    assert_equal @level.id, level_data['id']
+    assert_equal @level.id.to_s, level_data['id']
   end
 
   test 'update lesson using data from edit page' do

--- a/dashboard/test/models/level_test.rb
+++ b/dashboard/test/models/level_test.rb
@@ -155,7 +155,7 @@ class LevelTest < ActiveSupport::TestCase
 
     summary = level.summarize_for_edit
 
-    assert_equal(summary[:id], level.id)
+    assert_equal(summary[:id], level.id.to_s)
     assert_equal(summary[:type], 'Maze')
     assert_equal(summary[:name], 'test_level')
     assert_equal(summary[:owner], 'Best Curriculum Writer')


### PR DESCRIPTION
this builds on #38331 to standardize all level ids to be strings in our javascript code. this PR specifically addresses level ids in levelbuilder.