### PR TITLE
Updates to ManifestBuilder to support category deprecation

### DIFF
--- a/tools/scripts/ManifestBuilder.rb
+++ b/tools/scripts/ManifestBuilder.rb
@@ -13,6 +13,7 @@ DEFAULT_OUTPUT_FILE = "#{`git rev-parse --show-toplevel`.strip}/apps/src/p5lab/g
 SPRITELAB_OUTPUT_FILE = "#{`git rev-parse --show-toplevel`.strip}/apps/src/p5lab/spritelab/spriteCostumeLibrary.json".freeze
 DOWNLOAD_DESTINATION = '~/cdo-animation-library'.freeze
 SPRITE_COSTUME_LIST = SPRITE_LAB_ANIMATION_LIST
+SKIP_CATEGORIES = DEPRECATED_CATEGORIES
 
 class Hash
   # Like Enumerable::map but returns a Hash instead of an Array
@@ -286,7 +287,9 @@ The animation has been skipped.
       # This lambda runs synchronously after each entry is done processing - it's
       # used to collect up results and warnings to the original process/thread.
       if result.is_a? Hash
-        animation_metadata_by_name[name] = result
+        unless SKIP_CATEGORIES.include? result["categories"][0]
+          animation_metadata_by_name[name] = result
+        end
       else
         @warnings.push result
       end

--- a/tools/scripts/constants.rb
+++ b/tools/scripts/constants.rb
@@ -1,3 +1,5 @@
+DEPRECATED_CATEGORIES = ['characters', 'environment', 'gameplay', 'generic_items', 'obstacles']
+
 DEFAULT_SPRITES_LIST = [
   {name: 'bear', key: 'category_animals/bear'},
   {name: 'bee', key: 'category_animals/bee'},


### PR DESCRIPTION
As part of the animation library refresh, we're removing some old categories. To prevent older levels from breaking, we need to keep the animations in those categories in their original locations in S3. However, we don't want them to show up as options in the animation picker so we're removing them from the animation library manifests. This updates the ManifestBuilder script and constants to automatically ignore animations from deprecated categories.

<!-- ### Background -->
<!-- ### Privacy -->
<!--
1.	Does the Project involve the collection, use or sharing of new Personal Data?

2.	Does the Project involve a new or changed use or sharing of existing Personal Data?
-->
<!-- ### Security -->
<!--
Link to Jira Task where sensitive security issues are discussed privately.
-->
<!-- ### Caching -->
<!-- ### Deployment strategy -->
<!-- ### Future work -->

## Links

<!--
  Any relevant links to external resources; ie, specification documents, jira
  items, related PRs, honeybadger errors, etc
-->

- [jira](https://codedotorg.atlassian.net/browse/STAR-1274?atlOrigin=eyJpIjoiZjgyNTAwZjhiYjRmNDMyZmFmNjU5ZWI2MjZjZDljMTMiLCJwIjoiaiJ9)

## Testing story

<!--
  Does your change include appropriate tests?

  If so, please describe how the tests included in this PR are sufficient

  If not, please explain why this change does not need to be tested.
-->

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
