### PR TITLE
[AiLab] Generic ML predict block v1.0

### DIFF
--- a/apps/src/applab/api.js
+++ b/apps/src/applab/api.js
@@ -535,6 +535,10 @@ export function drawChartFromRecords(
   });
 }
 
-export function getPrediction(model, callback) {
-  return Applab.executeCmd(null, 'getPrediction', {model, callback});
+export function getPrediction(model, testValues, callback) {
+  return Applab.executeCmd(null, 'getPrediction', {
+    model,
+    testValues,
+    callback
+  });
 }

--- a/apps/src/applab/api.js
+++ b/apps/src/applab/api.js
@@ -534,3 +534,7 @@ export function drawChartFromRecords(
     callback: callback
   });
 }
+
+export function getPrediction(model, callback) {
+  return Applab.executeCmd(null, 'getPrediction', {model, callback});
+}

--- a/apps/src/applab/commands.js
+++ b/apps/src/applab/commands.js
@@ -19,6 +19,7 @@ import {
 } from '../lib/util/javascriptMode';
 import {commands as audioCommands} from '@cdo/apps/lib/util/audioApi';
 import {commands as timeoutCommands} from '@cdo/apps/lib/util/timeoutApi';
+import {commands as mlCommands} from '@cdo/apps/lib/util/mlApi';
 import * as makerCommands from '@cdo/apps/lib/kits/maker/commands';
 import {getAppOptions} from '@cdo/apps/code-studio/initApp/loadApp';
 import {AllowedWebRequestHeaders} from '@cdo/apps/util/sharedConstants';
@@ -2291,4 +2292,5 @@ function stopLoadingSpinnerFor(elementId) {
 // Include playSound, stopSound, etc.
 Object.assign(applabCommands, audioCommands);
 Object.assign(applabCommands, timeoutCommands);
+Object.assign(applabCommands, mlCommands);
 Object.assign(applabCommands, makerCommands);

--- a/apps/src/applab/dropletConfig.js
+++ b/apps/src/applab/dropletConfig.js
@@ -6,6 +6,7 @@ import consoleApi from '../consoleApi';
 import * as audioApi from '@cdo/apps/lib/util/audioApi';
 import audioApiDropletConfig from '@cdo/apps/lib/util/audioApiDropletConfig';
 import * as timeoutApi from '@cdo/apps/lib/util/timeoutApi';
+import MLApi from '@cdo/apps/lib/util/mlApi';
 import * as makerApi from '@cdo/apps/lib/kits/maker/api';
 import color from '../util/color';
 import getAssetDropdown from '../assetManagement/getAssetDropdown';
@@ -678,6 +679,16 @@ export var blocks = [
       1: ChartApi.getChartTypeDropdown
     }
   },
+  {
+    func: 'getPrediction',
+    parent: api,
+    category: 'Data',
+    paletteParams: ['model', 'callback'],
+    params: ['"myModel"', 'function (value) {\n \n}'],
+    dropdown: {
+      0: MLApi.getModelNames
+    }
+  },
 
   {
     func: 'moveForward',
@@ -1165,6 +1176,12 @@ export const categories = {
   Goals: {
     id: 'goals',
     color: 'deeppurple',
+    blocks: []
+  },
+  ML: {
+    id: 'ML',
+    color: 'blue',
+    rgb: color.blue,
     blocks: []
   }
 };

--- a/apps/src/applab/dropletConfig.js
+++ b/apps/src/applab/dropletConfig.js
@@ -18,6 +18,7 @@ import {
 } from './setPropertyDropdown';
 import {getStore} from '../redux';
 import * as applabConstants from './constants';
+import experiments from '../util/experiments';
 
 var DEFAULT_WIDTH = applabConstants.APP_WIDTH.toString();
 var DEFAULT_HEIGHT = (
@@ -678,13 +679,6 @@ export var blocks = [
       1: ChartApi.getChartTypeDropdown
     }
   },
-  {
-    func: 'getPrediction',
-    parent: api,
-    category: 'Data',
-    paletteParams: ['model', 'testValues', 'callback'],
-    params: ['"myModel"', 'testValues', 'function (value) {\n \n}']
-  },
 
   {
     func: 'moveForward',
@@ -1137,6 +1131,16 @@ export var blocks = [
     noAutocomplete: true
   }
 ];
+
+if (experiments.isEnabled(experiments.APPLAB_ML)) {
+  blocks.push({
+    func: 'getPrediction',
+    parent: api,
+    category: 'Data',
+    paletteParams: ['model', 'testValues', 'callback'],
+    params: ['"myModel"', 'testValues', 'function (value) {\n \n}']
+  });
+}
 
 export const categories = {
   'UI controls': {

--- a/apps/src/applab/dropletConfig.js
+++ b/apps/src/applab/dropletConfig.js
@@ -6,7 +6,6 @@ import consoleApi from '../consoleApi';
 import * as audioApi from '@cdo/apps/lib/util/audioApi';
 import audioApiDropletConfig from '@cdo/apps/lib/util/audioApiDropletConfig';
 import * as timeoutApi from '@cdo/apps/lib/util/timeoutApi';
-import MLApi from '@cdo/apps/lib/util/mlApi';
 import * as makerApi from '@cdo/apps/lib/kits/maker/api';
 import color from '../util/color';
 import getAssetDropdown from '../assetManagement/getAssetDropdown';
@@ -683,11 +682,8 @@ export var blocks = [
     func: 'getPrediction',
     parent: api,
     category: 'Data',
-    paletteParams: ['model', 'callback'],
-    params: ['"myModel"', 'function (value) {\n \n}'],
-    dropdown: {
-      0: MLApi.getModelNames
-    }
+    paletteParams: ['model', 'testValues', 'callback'],
+    params: ['"myModel"', 'testValues', 'function (value) {\n \n}']
   },
 
   {
@@ -1176,12 +1172,6 @@ export const categories = {
   Goals: {
     id: 'goals',
     color: 'deeppurple',
-    blocks: []
-  },
-  ML: {
-    id: 'ML',
-    color: 'blue',
-    rgb: color.blue,
     blocks: []
   }
 };

--- a/apps/src/lib/util/mlApi.js
+++ b/apps/src/lib/util/mlApi.js
@@ -1,17 +1,6 @@
 export const commands = {
   async getPrediction(opts) {
     console.log('this is where the ML code will live!');
+    console.log('opts: ', opts);
   }
-};
-
-export default function MLApi() {}
-
-MLApi.getModelNames = function() {
-  $.ajax({
-    url: '/api/v1/ml_models/names',
-    method: 'GET'
-  }).done(function(data) {
-    const names = data.map(model => model.name);
-    return names;
-  });
 };

--- a/apps/src/lib/util/mlApi.js
+++ b/apps/src/lib/util/mlApi.js
@@ -1,0 +1,17 @@
+export const commands = {
+  async getPrediction(opts) {
+    console.log('this is where the ML code will live!');
+  }
+};
+
+export default function MLApi() {}
+
+MLApi.getModelNames = function() {
+  $.ajax({
+    url: '/api/v1/ml_models/names',
+    method: 'GET'
+  }).done(function(data) {
+    const names = data.map(model => model.name);
+    return names;
+  });
+};

--- a/apps/src/lib/util/mlApi.js
+++ b/apps/src/lib/util/mlApi.js
@@ -1,6 +1,5 @@
 export const commands = {
   async getPrediction(opts) {
     console.log('this is where the ML code will live!');
-    console.log('opts: ', opts);
   }
 };

--- a/lib/cdo/shared_constants.rb
+++ b/lib/cdo/shared_constants.rb
@@ -193,6 +193,7 @@ module SharedConstants
       "getUserId": null,
       "drawChart": null,
       "drawChartFromRecords": null,
+      "getPrediction": null,
 
       // Turtle
       "moveForward": null,


### PR DESCRIPTION
Hidden behind the `?enableExperiments=applab-ml` experiment param this is the first iteration of a generic `getPrediction` block. The `getPrediction` block accepts a model name, testValues object and callback function as parameters. 

<img width="558" alt="Screen Shot 2021-01-07 at 3 22 36 PM" src="https://user-images.githubusercontent.com/12300669/103941524-f8bc4200-50fc-11eb-8044-71b64e34bb7c.png">

Further revisions will be based on the outcome of discussions based on this [doc](https://docs.google.com/document/d/1sEZ9RZsyMZMV1gcblpbcDJOcS9E3QK7mOB4qowc0qGE/edit?ts=5ff6616b). In the meantime, the next step is to add in the code that will fetch the trained model, call to the ML libraries and return a prediction in `mlApi.js`.