### PR TITLE
Guard against empty text arg in playSpeech

### DIFF
--- a/apps/src/lib/util/audioApi.js
+++ b/apps/src/lib/util/audioApi.js
@@ -137,7 +137,7 @@ export const commands = {
       opts.gender,
       'string'
     );
-    if (!validText || !validGender) {
+    if (!validText || opts.text.length === 0 || !validGender) {
       return;
     }
     apiValidateType(

--- a/dashboard/app/helpers/profanity_helper.rb
+++ b/dashboard/app/helpers/profanity_helper.rb
@@ -11,7 +11,7 @@ module ProfanityHelper
   # @param [Integer] limit - Number of requests allowed over period.
   # @param [Integer] period - Period of time in seconds.
   def self.throttled_find_profanities(text, locale, id, limit, period)
-    return nil if text.nil_or_empty?
+    return yield(nil) if text.nil_or_empty?
     key = cache_key(text, locale)
     return yield(Rails.cache.read(key)) if Rails.cache.exist?(key)
     return if Cdo::Throttle.throttle(PROFANITY_PREFIX + id.to_s, limit, period)

--- a/dashboard/test/controllers/profanity_controller_test.rb
+++ b/dashboard/test/controllers/profanity_controller_test.rb
@@ -41,6 +41,12 @@ class ProfanityControllerTest < ActionController::TestCase
     assert_equal @expected_profanities.to_json, @response.body
   end
 
+  test 'find: returns null if params[:text] is empty' do
+    post :find, params: {text: ""}
+    assert_response :success
+    assert_equal "null", @response.body
+  end
+
   test 'find: returns 429 if request is throttled' do
     ProfanityHelper.expects(:throttled_find_profanities).once.returns(nil)
     Honeybadger.expects(:notify).once

--- a/dashboard/test/helpers/profanity_helper_test.rb
+++ b/dashboard/test/helpers/profanity_helper_test.rb
@@ -36,4 +36,12 @@ class ProfanityHelperTest < ActionView::TestCase
     ProfanityHelper.throttled_find_profanities('bad words', 'en-US', 'a1b2c3', 1, 1) {|profanities| actual_profanities = profanities}
     assert_equal expected_profanities, actual_profanities
   end
+
+  test 'throttled_find_profanities: yields nil if text is empty' do
+    Rails.cache.expects(:read).never
+
+    actual_profanities = -1
+    ProfanityHelper.throttled_find_profanities('', 'en-US', 'a1b2c3', 1, 1) {|profanities| actual_profanities = profanities}
+    assert_nil actual_profanities
+  end
 end


### PR DESCRIPTION
Fixes a bug caught by [this Honeybadger error](https://app.honeybadger.io/projects/3240/faults/72254493/d0505d28-503a-11eb-921e-9e12c46d6766?page=0&q=occurred%3A%22%5B2021-01-06+8%3A10+UTC-8+TO+2021-01-06+8%3A20+UTC-8%5D%22%E2%80%81) (links to a specific, relevant instance of the error -- this error, in general, is expected).

When a user called playSpeech with no text (`playSpeech('', 'female', 'English')`), they were immediately being "throttled" (they saw the "you've been throttled" warning, but weren't actually throttled by our servers) because `ProfanityHelper.throttled_find_profanities` was _returning_ nil instead of _yielding_ nil in that case. Fixing that fixes the bug, but I also added an extra no-op to the block so that we don't even try to execute if the text arg is empty.

## Links

<!--
  Any relevant links to external resources; ie, specification documents, jira
  items, related PRs, honeybadger errors, etc
-->

- [Honeybadger error instance](https://app.honeybadger.io/projects/3240/faults/72254493/d0505d28-503a-11eb-921e-9e12c46d6766?page=0&q=occurred%3A%22%5B2021-01-06+8%3A10+UTC-8+TO+2021-01-06+8%3A20+UTC-8%5D%22%E2%80%81)
- [Slack discussion](https://codedotorg.slack.com/archives/C0T0PNTM3/p1609961883396200)

## Testing story

Adds unit tests.

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
