### PR TITLE
Switch UI tests to use bear animal head animation instead of bear

### DIFF
--- a/dashboard/test/ui/features/star_labs/gamelab/export_animations.feature
+++ b/dashboard/test/ui/features/star_labs/gamelab/export_animations.feature
@@ -5,7 +5,7 @@ Feature: Game Lab Export
 Scenario: Export library animation
   Given I start a new Game Lab project
   And I switch to the animation tab
-  And I add the bear animation from the library
+  And I add the bear animal head animation from the library
   And I switch to the code tab in Game Lab
   And I press "runButton"
 

--- a/dashboard/test/ui/features/step_definitions/gamelab.rb
+++ b/dashboard/test/ui/features/step_definitions/gamelab.rb
@@ -61,9 +61,9 @@ Then /^I select the animal category of the animation library$/ do
   @browser.execute_script("$(\"img[src*='/category_animals.png']\")[1].click();")
 end
 
-Then /^I select the bear animation from the animal category$/ do
-  wait_until {@browser.execute_script("return $(\"img[src*='/category_animals/bear.png']\").length != 0;")}
-  @browser.execute_script("$(\"img[src*='/category_animals/bear.png']\")[0].click();")
+Then /^I select the bear animal head animation from the animal category$/ do
+  wait_until {@browser.execute_script("return $(\"img[src*='/category_animals/animalhead_bear.png']\").length != 0;")}
+  @browser.execute_script("$(\"img[src*='/category_animals/animalhead_bear.png']\")[0].click();")
 end
 
 Then /^I add a new, blank animation$/ do
@@ -73,11 +73,11 @@ Then /^I add a new, blank animation$/ do
   STEPS
 end
 
-Then /^I add the bear animation from the library$/ do
+Then /^I add the bear animal head animation from the library$/ do
   steps <<-STEPS
     And I open the animation picker
     And I select the animal category of the animation library
-    And I select the bear animation from the animal category
+    And I select the bear animal head animation from the animal category
   STEPS
 end
 


### PR DESCRIPTION
We updated the gamelab animation library with new animations today which moved the bear to the second page of results, causing UI tests to fail. This switches out the usage of the bear in UI tests to be the bear animal head instead.

<!-- ### Background -->
<!-- ### Privacy -->
<!--
1.	Does the Project involve the collection, use or sharing of new Personal Data?

2.	Does the Project involve a new or changed use or sharing of existing Personal Data?
-->
<!-- ### Security -->
<!--
Link to Jira Task where sensitive security issues are discussed privately.
-->
<!-- ### Caching -->
<!-- ### Deployment strategy -->
<!-- ### Future work -->

## Links

<!--
  Any relevant links to external resources; ie, specification documents, jira
  items, related PRs, honeybadger errors, etc
-->

- [slack thread](https://codedotorg.slack.com/archives/CN4T89YP8/p1609971906013100)

## Testing story

<!--
  Does your change include appropriate tests?

  If so, please describe how the tests included in this PR are sufficient

  If not, please explain why this change does not need to be tested.
-->

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
