### PR TITLE
Fix warning because prop wrong type

### DIFF
--- a/apps/src/lib/levelbuilder/shapes.jsx
+++ b/apps/src/lib/levelbuilder/shapes.jsx
@@ -90,7 +90,7 @@ export const levelShapeForScript = PropTypes.shape({
   videoKey: PropTypes.string,
   concepts: PropTypes.string,
   conceptDifficulty: PropTypes.string,
-  progression: PropTypes.bool,
+  progression: PropTypes.string,
   named: PropTypes.bool,
   bonus: PropTypes.bool,
   assessment: PropTypes.bool,


### PR DESCRIPTION
Fixing the type progression prop to fix the warnings on the script edit page. 

![Screen Shot 2021-01-06 at 8 32 47 PM](https://user-images.githubusercontent.com/208083/103839886-59e10880-505e-11eb-82cb-97e1edf0d4fe.png)


