### PR TITLE
preserve level_keys property when script_json is saved

### DIFF
--- a/dashboard/app/models/script_level.rb
+++ b/dashboard/app/models/script_level.rb
@@ -128,6 +128,14 @@ class ScriptLevel < ApplicationRecord
       seed_key_data = script_level.seeding_key(seed_context, false)
       script_level_attributes[:seed_key] = HashingUtils.ruby_hash_to_md5_hash(seed_key_data)
 
+      # Preserve the level_keys property. If we detected an existing script
+      # level earlier, then the level keys have not changed and it is safe to
+      # use the existing level_keys. Otherwise these will be regenerated.
+      # These are not strictly needed, because level_keys are only used during
+      # seeding. However, this eliminates the problem where level_keys disappear
+      # from .script_json files after a script is saved.
+      properties[:level_keys] = script_level.get_level_keys(seed_context, true)
+
       script_level.assign_attributes(script_level_attributes)
       # We must assign properties separately since otherwise, a missing property won't correctly overwrite the current value
       script_level.properties = properties


### PR DESCRIPTION
This fixes an undesired change to .script_json whenever a script is saved. The following diffs show the change in output when saving a freshly seeded script:

before:
![Screen Shot 2021-01-07 at 6 01 57 AM](https://user-images.githubusercontent.com/8001765/103901410-f8488a80-50ad-11eb-9c6d-1d76645eee27.png)

after:
![Screen Shot 2021-01-07 at 6 14 13 AM](https://user-images.githubusercontent.com/8001765/103902610-9ee15b00-50af-11eb-868c-cd410b2868aa.png)

## Future work

The other changes shown in the "after" diff will be handled as follows:
* peer_reviews_to_complete should be fixed to not be set to 0, otherwise it could mess up this logic: https://github.com/code-dot-org/code-dot-org/blob/bfb2c7346c9e517cb8985e15378a1942b8a19e10/dashboard/app/controllers/peer_reviews_controller.rb#L18 I'll tackle this in the next PR. This is tracked in [PLAT-658]
* the other diffs show the values of bonus and assessment changing from false to null. These get set to false by the import script and by saving the lesson edit page in `update_script_levels` here: https://github.com/code-dot-org/code-dot-org/blob/9ffc3ebef3fcf12172231ed0bccbf91b7eae7d5d/dashboard/app/models/activity_section.rb#L76-L77 these get set to null by saving the script edit page in `add_script_levels` here: https://github.com/code-dot-org/code-dot-org/blob/c87bb46a55b282a94c584fc247c85968b3baa54e/dashboard/app/models/script_level.rb#L107-L108 because add_script_levels also gets called during legacy script seed, and we don't want to risk losing script levels / teacher feedbacks on live scripts, I am going to propose that we change `update_script_levels` to match legacy script behavior and use `nil` when these values are not present. In the future, once [PLAT-460] is done and migrated scripts no longer depend on the legacy script seed path, we could consider changing these back to `false`.

## Testing story

Manual verification shown in the diffs above.

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked


[PLAT-658]: https://codedotorg.atlassian.net/browse/PLAT-658

[PLAT-460]: https://codedotorg.atlassian.net/browse/PLAT-460