### PR TITLE
Profanity/Azure: Use CDO.shared_cache instead of Rails.cache

### DIFF
--- a/dashboard/app/controllers/concerns/azure_text_to_speech.rb
+++ b/dashboard/app/controllers/concerns/azure_text_to_speech.rb
@@ -15,7 +15,7 @@ module AzureTextToSpeech
   def self.get_token
     return nil unless allowed?
 
-    Rails.cache.fetch("azure_speech_service/token", expires_in: TOKEN_CACHE_TTL) do
+    CDO.shared_cache.fetch("azure_speech_service/token", expires_in: TOKEN_CACHE_TTL) do
       token_uri = URI.parse("https://#{region}.api.cognitive.microsoft.com/sts/v1.0/issueToken")
       token_http_request = Net::HTTP.new(token_uri.host, token_uri.port)
       token_http_request.use_ssl = true
@@ -71,7 +71,7 @@ module AzureTextToSpeech
     token = get_token
     return nil if token.nil_or_empty?
 
-    Rails.cache.fetch("azure_speech_service/voices") do
+    CDO.shared_cache.fetch("azure_speech_service/voices") do
       voice_uri = URI.parse("https://#{region}.tts.speech.microsoft.com/cognitiveservices/voices/list")
       voice_http_request = Net::HTTP.new(voice_uri.host, voice_uri.port)
       voice_http_request.use_ssl = true

--- a/dashboard/app/helpers/profanity_helper.rb
+++ b/dashboard/app/helpers/profanity_helper.rb
@@ -13,11 +13,11 @@ module ProfanityHelper
   def self.throttled_find_profanities(text, locale, id, limit, period)
     return yield(nil) if text.nil_or_empty?
     key = cache_key(text, locale)
-    return yield(Rails.cache.read(key)) if Rails.cache.exist?(key)
+    return yield(CDO.shared_cache.read(key)) if CDO.shared_cache.exist?(key)
     return if Cdo::Throttle.throttle(PROFANITY_PREFIX + id.to_s, limit, period)
 
     profanities = ProfanityFilter.find_potential_profanities(text, locale)
-    Rails.cache.write(key, profanities)
+    CDO.shared_cache.write(key, profanities)
     yield(profanities)
   end
 

--- a/dashboard/test/controllers/concerns/azure_text_to_speech_test.rb
+++ b/dashboard/test/controllers/concerns/azure_text_to_speech_test.rb
@@ -12,7 +12,7 @@ class AzureTextToSpeechTest < ActionController::TestCase
 
   teardown do
     # Some tests access and store data in the cache, so clear between tests to avoid state leakage
-    Rails.cache.clear
+    CDO.shared_cache.clear
   end
 
   test 'get_token: returns token on success' do

--- a/dashboard/test/helpers/profanity_helper_test.rb
+++ b/dashboard/test/helpers/profanity_helper_test.rb
@@ -3,13 +3,13 @@ require 'test_helper'
 class ProfanityHelperTest < ActionView::TestCase
   teardown do
     # Some tests access and store data in the cache, so clear between tests to avoid state leakage
-    Rails.cache.clear
+    CDO.shared_cache.clear
   end
 
   test 'throttled_find_profanities: yields profanities if cached' do
-    Rails.cache.expects(:exist?).returns(true)
+    CDO.shared_cache.expects(:exist?).returns(true)
     expected_profanities = ['bad']
-    Rails.cache.expects(:read).once.returns(expected_profanities)
+    CDO.shared_cache.expects(:read).once.returns(expected_profanities)
     Cdo::Throttle.expects(:throttle).never
     ProfanityFilter.expects(:find_potential_profanities).never
 
@@ -19,7 +19,7 @@ class ProfanityHelperTest < ActionView::TestCase
   end
 
   test 'throttled_find_profanities: does not yield if request is throttled' do
-    Rails.cache.expects(:read).never
+    CDO.shared_cache.expects(:read).never
     Cdo::Throttle.expects(:throttle).once.returns(true)
     ProfanityFilter.expects(:find_potential_profanities).never
 
@@ -27,7 +27,7 @@ class ProfanityHelperTest < ActionView::TestCase
   end
 
   test 'throttled_find_profanities: caches and yields profanities not cached or throttled' do
-    Rails.cache.expects(:read).never
+    CDO.shared_cache.expects(:read).never
     Cdo::Throttle.expects(:throttle).once.with("profanity/a1b2c3", 1, 1).returns(false)
     expected_profanities = ['bad']
     ProfanityFilter.expects(:find_potential_profanities).once.returns(expected_profanities)
@@ -38,7 +38,7 @@ class ProfanityHelperTest < ActionView::TestCase
   end
 
   test 'throttled_find_profanities: yields nil if text is empty' do
-    Rails.cache.expects(:read).never
+    CDO.shared_cache.expects(:read).never
 
     actual_profanities = -1
     ProfanityHelper.throttled_find_profanities('', 'en-US', 'a1b2c3', 1, 1) {|profanities| actual_profanities = profanities}


### PR DESCRIPTION
Updates `ProfanityHelper` and `AzureTextToSpeech` modules to use the `CDO.shared_cache` instead of `Rails.cache` to improve our cache hit rate. `CDO.shared_cache` uses ElastiCache and is shared across all instances, whereas `Rails.cache` is specific to each instance.

## Links

<!--
  Any relevant links to external resources; ie, specification documents, jira
  items, related PRs, honeybadger errors, etc
-->

- [STAR-1356](https://codedotorg.atlassian.net/browse/STAR-1356)

## Testing story

Updates unit tests.

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
