### PR TITLE
[AiLab] connect predict block to ML algorithm 

### DIFF
--- a/apps/src/MLTrainers.js
+++ b/apps/src/MLTrainers.js
@@ -1,4 +1,4 @@
-const KNN = require('ml-knn');
+import KNN from 'ml-knn';
 
 const KNNTrainers = ['knnClassify', 'knnRegress'];
 
@@ -42,7 +42,7 @@ export function predict(modelData) {
       feature => modelData.testData[feature]
     );
     // Make a prediction.
-    const rawPrediction = model.predict(testValues)[0];
+    const rawPrediction = model.predict(testValues);
     // Convert prediction to human readable (if needed)
     const prediction = Object.keys(modelData.featureNumberKey).includes(
       modelData.labelColumn

--- a/apps/src/applab/api.js
+++ b/apps/src/applab/api.js
@@ -535,6 +535,10 @@ export function drawChartFromRecords(
   });
 }
 
-export function getPrediction(model, callback) {
-  return Applab.executeCmd(null, 'getPrediction', {model, callback});
+export function getPrediction(model, testValues, callback) {
+  return Applab.executeCmd(null, 'getPrediction', {
+    model,
+    testValues,
+    callback
+  });
 }

--- a/apps/src/applab/api.js
+++ b/apps/src/applab/api.js
@@ -534,3 +534,7 @@ export function drawChartFromRecords(
     callback: callback
   });
 }
+
+export function getPrediction(model, callback) {
+  return Applab.executeCmd(null, 'getPrediction', {model, callback});
+}

--- a/apps/src/applab/commands.js
+++ b/apps/src/applab/commands.js
@@ -19,6 +19,7 @@ import {
 } from '../lib/util/javascriptMode';
 import {commands as audioCommands} from '@cdo/apps/lib/util/audioApi';
 import {commands as timeoutCommands} from '@cdo/apps/lib/util/timeoutApi';
+import {commands as mlCommands} from '@cdo/apps/lib/util/mlApi';
 import * as makerCommands from '@cdo/apps/lib/kits/maker/commands';
 import {getAppOptions} from '@cdo/apps/code-studio/initApp/loadApp';
 import {AllowedWebRequestHeaders} from '@cdo/apps/util/sharedConstants';
@@ -2291,4 +2292,5 @@ function stopLoadingSpinnerFor(elementId) {
 // Include playSound, stopSound, etc.
 Object.assign(applabCommands, audioCommands);
 Object.assign(applabCommands, timeoutCommands);
+Object.assign(applabCommands, mlCommands);
 Object.assign(applabCommands, makerCommands);

--- a/apps/src/applab/dropletConfig.js
+++ b/apps/src/applab/dropletConfig.js
@@ -6,6 +6,7 @@ import consoleApi from '../consoleApi';
 import * as audioApi from '@cdo/apps/lib/util/audioApi';
 import audioApiDropletConfig from '@cdo/apps/lib/util/audioApiDropletConfig';
 import * as timeoutApi from '@cdo/apps/lib/util/timeoutApi';
+import MLApi from '@cdo/apps/lib/util/mlApi';
 import * as makerApi from '@cdo/apps/lib/kits/maker/api';
 import color from '../util/color';
 import getAssetDropdown from '../assetManagement/getAssetDropdown';
@@ -678,6 +679,16 @@ export var blocks = [
       1: ChartApi.getChartTypeDropdown
     }
   },
+  {
+    func: 'getPrediction',
+    parent: api,
+    category: 'Data',
+    paletteParams: ['model', 'callback'],
+    params: ['"myModel"', 'function (value) {\n \n}'],
+    dropdown: {
+      0: MLApi.getModelNames
+    }
+  },
 
   {
     func: 'moveForward',
@@ -1165,6 +1176,12 @@ export const categories = {
   Goals: {
     id: 'goals',
     color: 'deeppurple',
+    blocks: []
+  },
+  ML: {
+    id: 'ML',
+    color: 'blue',
+    rgb: color.blue,
     blocks: []
   }
 };

--- a/apps/src/applab/dropletConfig.js
+++ b/apps/src/applab/dropletConfig.js
@@ -18,6 +18,7 @@ import {
 } from './setPropertyDropdown';
 import {getStore} from '../redux';
 import * as applabConstants from './constants';
+import experiments from '../util/experiments';
 
 var DEFAULT_WIDTH = applabConstants.APP_WIDTH.toString();
 var DEFAULT_HEIGHT = (
@@ -678,13 +679,6 @@ export var blocks = [
       1: ChartApi.getChartTypeDropdown
     }
   },
-  {
-    func: 'getPrediction',
-    parent: api,
-    category: 'Data',
-    paletteParams: ['model', 'testValues', 'callback'],
-    params: ['"myModel"', 'testValues', 'function (value) {\n \n}']
-  },
 
   {
     func: 'moveForward',
@@ -1137,6 +1131,16 @@ export var blocks = [
     noAutocomplete: true
   }
 ];
+
+if (experiments.isEnabled(experiments.APPLAB_ML)) {
+  blocks.push({
+    func: 'getPrediction',
+    parent: api,
+    category: 'Data',
+    paletteParams: ['model', 'testValues', 'callback'],
+    params: ['"myModel"', 'testValues', 'function (value) {\n \n}']
+  });
+}
 
 export const categories = {
   'UI controls': {

--- a/apps/src/applab/dropletConfig.js
+++ b/apps/src/applab/dropletConfig.js
@@ -6,7 +6,6 @@ import consoleApi from '../consoleApi';
 import * as audioApi from '@cdo/apps/lib/util/audioApi';
 import audioApiDropletConfig from '@cdo/apps/lib/util/audioApiDropletConfig';
 import * as timeoutApi from '@cdo/apps/lib/util/timeoutApi';
-import MLApi from '@cdo/apps/lib/util/mlApi';
 import * as makerApi from '@cdo/apps/lib/kits/maker/api';
 import color from '../util/color';
 import getAssetDropdown from '../assetManagement/getAssetDropdown';
@@ -683,11 +682,8 @@ export var blocks = [
     func: 'getPrediction',
     parent: api,
     category: 'Data',
-    paletteParams: ['model', 'callback'],
-    params: ['"myModel"', 'function (value) {\n \n}'],
-    dropdown: {
-      0: MLApi.getModelNames
-    }
+    paletteParams: ['model', 'testValues', 'callback'],
+    params: ['"myModel"', 'testValues', 'function (value) {\n \n}']
   },
 
   {
@@ -1176,12 +1172,6 @@ export const categories = {
   Goals: {
     id: 'goals',
     color: 'deeppurple',
-    blocks: []
-  },
-  ML: {
-    id: 'ML',
-    color: 'blue',
-    rgb: color.blue,
     blocks: []
   }
 };

--- a/apps/src/lib/util/mlApi.js
+++ b/apps/src/lib/util/mlApi.js
@@ -1,17 +1,6 @@
 export const commands = {
   async getPrediction(opts) {
     console.log('this is where the ML code will live!');
+    console.log('opts: ', opts);
   }
-};
-
-export default function MLApi() {}
-
-MLApi.getModelNames = function() {
-  $.ajax({
-    url: '/api/v1/ml_models/names',
-    method: 'GET'
-  }).done(function(data) {
-    const names = data.map(model => model.name);
-    return names;
-  });
 };

--- a/apps/src/lib/util/mlApi.js
+++ b/apps/src/lib/util/mlApi.js
@@ -1,0 +1,17 @@
+export const commands = {
+  async getPrediction(opts) {
+    console.log('this is where the ML code will live!');
+  }
+};
+
+export default function MLApi() {}
+
+MLApi.getModelNames = function() {
+  $.ajax({
+    url: '/api/v1/ml_models/names',
+    method: 'GET'
+  }).done(function(data) {
+    const names = data.map(model => model.name);
+    return names;
+  });
+};

--- a/apps/src/lib/util/mlApi.js
+++ b/apps/src/lib/util/mlApi.js
@@ -1,5 +1,32 @@
+/* global Promise */
+
+import {predict} from '@cdo/apps/MLTrainers';
+
 export const commands = {
   async getPrediction(opts) {
-    console.log('this is where the ML code will live!');
+    return new Promise((resolve, reject) => {
+      $.ajax({
+        url: '/api/v1/ml_models/names',
+        method: 'GET'
+      })
+        .then(data => {
+          const modelId = data.find(model => model.name === opts.model).id;
+          $.ajax({
+            url: '/api/v1/ml_models/' + modelId,
+            method: 'GET'
+          }).then(modelData => {
+            const predictParams = {
+              ...modelData,
+              testData: opts.testValues
+            };
+            const result = predict(predictParams);
+            opts.callback(result);
+          });
+          return resolve();
+        })
+        .fail((jqXhr, status) => {
+          return reject({message: 'An error occurred'});
+        });
+    });
   }
 };

--- a/apps/src/lib/util/mlApi.js
+++ b/apps/src/lib/util/mlApi.js
@@ -1,6 +1,5 @@
 export const commands = {
   async getPrediction(opts) {
     console.log('this is where the ML code will live!');
-    console.log('opts: ', opts);
   }
 };

--- a/dashboard/app/controllers/api/v1/ml_models_controller.rb
+++ b/dashboard/app/controllers/api/v1/ml_models_controller.rb
@@ -18,7 +18,7 @@ class Api::V1::MlModelsController < Api::V1::JsonApiController
     )
     upload_to_s3(model_id, params["ml_model"].to_json)
 
-    render json: "hooray!"
+    render json: {id: model_id}
   end
 
   # GET api/v1/ml_models/names

--- a/lib/cdo/shared_constants.rb
+++ b/lib/cdo/shared_constants.rb
@@ -193,6 +193,7 @@ module SharedConstants
       "getUserId": null,
       "drawChart": null,
       "drawChartFromRecords": null,
+      "getPrediction": null,
 
       // Turtle
       "moveForward": null,


### PR DESCRIPTION
Connects the general `getPrediction` App Lab block created in #38428 to the KNN machine learning algorithms set up in #38205. Using this new block I was able to get a prediction back from a previously trained and saved model and output it to the App Lab console as confirmation. 

<img width="656" alt="Screen Shot 2021-01-07 at 10 06 13 PM" src="https://user-images.githubusercontent.com/12300669/103970349-0cd06580-5136-11eb-809d-d7f3bd6dc3a0.png">
