### PR TITLE
Fix minecraft AI for good link

### DIFF
--- a/pegasus/sites.v3/code.org/views/minecraft_2019_promo.haml
+++ b/pegasus/sites.v3/code.org/views/minecraft_2019_promo.haml
@@ -5,7 +5,7 @@
   mee_title = I18n.t(:hoc2019_mc_mee_title)
   mee_description1 = I18n.t(:hoc2019_mc_mee_description1)
   mee_description2 = I18n.t(:hoc2019_mc_mee_description2)
-  mee_link = "www.education.minecraft.net/hour-of-code-2019"
+  mee_link = "https://education.minecraft.net/hour-of-code-2019"
   mee_link_text = I18n.t(:hoc2018_mc_educators_box1_button)
 
 .tutorial-promo-container{style: "margin-top: 25px"}


### PR DESCRIPTION
<!--
  Your description goes here: A summary of the change, including any relevant motivation and context.

  If relevant, include a description both of the existing behavior and of the new behavior.
-->

<!--
  Other aspects to consider. uncomment and add detail for any that seem necessary:
-->
Issue: https://codedotorg.atlassian.net/browse/LP-1706
Previously link was going to `https://code.org/www.education.minecraft.net/hour-of-code-2019` which was causing a 404, this fix updates link to `https://education.minecraft.net/hour-of-code-2019`. Tested locally.

<!-- ### Background -->
<!-- ### Privacy -->
<!--
1.	Does the Project involve the collection, use or sharing of new Personal Data?

2.	Does the Project involve a new or changed use or sharing of existing Personal Data?
-->
<!-- ### Security -->
<!--
Link to Jira Task where sensitive security issues are discussed privately.
-->
<!-- ### Caching -->
<!-- ### Deployment strategy -->
<!-- ### Future work -->

## Links
https://codedotorg.atlassian.net/browse/LP-1706
<!--
  Any relevant links to external resources; ie, specification documents, jira
  items, related PRs, honeybadger errors, etc
-->

- [spec]()
- [jira]()

## Testing story
Tested locally at http://localhost.code.org:3000/minecraft
<!--
  Does your change include appropriate tests?

  If so, please describe how the tests included in this PR are sufficient

  If not, please explain why this change does not need to be tested.
-->

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
