### PR TITLE
US only param in zip-state geocoding

### DIFF
--- a/dashboard/app/models/regional_partner.rb
+++ b/dashboard/app/models/regional_partner.rb
@@ -194,7 +194,7 @@ class RegionalPartner < ApplicationRecord
             # Geocoder can raise a number of errors including SocketError, with a common base of StandardError
             # See https://github.com/alexreisner/geocoder#error-handling
             Retryable.retryable(on: StandardError) do
-              state = Geocoder.search(zip_code).select {|result| result&.country_code&.downcase == "us"}&.first&.state_code
+              state = Geocoder.search(zip_code, params: {country: 'us'})&.first&.state_code
             end
           end
         rescue StandardError => e


### PR DESCRIPTION
We use a ZIP-state mapping to allow teachers to find their regional partner [on this page](https://code.org/educate/professional-learning/middle-high), and have noted issues with zip codes not being found. This change supplies a US-only param to our geocoder (Mapbox). Mapbox's geocoding API returns the top X results (5 by default, max 10), so applying a filter after the fact misses US results that were not in the top X results. By applying this search param, non-US results are filtered out before being returned.

## Testing story

Here's an example of the old approach:
```
[development] dashboard > Geocoder.search('43002').select {|result| result&.country_code&.downcase == "us"}&.first&.state_code
=> nil
```

Tested locally with zips known to be failing (first 4), as well as a couple that aren't thought to have issues:

```
[development] dashboard > Geocoder.search('43002', params: {country: 'us'})&.first&.state_code
=> "OH"
[development] dashboard > Geocoder.search('43001', params: {country: 'us'})&.first&.state_code
=> "OH"
[development] dashboard > Geocoder.search('25540', params: {country: 'us'})&.first&.state_code
=> "WV"
[development] dashboard > Geocoder.search('25770', params: {country: 'us'})&.first&.state_code
=> "WV"
[development] dashboard > Geocoder.search('20910', params: {country: 'us'})&.first&.state_code
=> "MD"
[development] dashboard > Geocoder.search('98105', params: {country: 'us'})&.first&.state_code
=> "WA"
```

## Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
