### PR TITLE
Allow full seeding of school districts

### DIFF
--- a/dashboard/app/models/school_district.rb
+++ b/dashboard/app/models/school_district.rb
@@ -48,8 +48,8 @@ class SchoolDistrict < ApplicationRecord
       SchoolDistrict.transaction do
         merge_from_csv(school_districts_tsv)
       end
-      #else
-      #SchoolDistrict.seed_from_s3
+    else
+      SchoolDistrict.seed_from_s3
     end
   end
 


### PR DESCRIPTION
We fully seed school districts in production (not sure where else?) I prevented automatic seeding of a new file until I could import it manually, which I've done (see [this comment](https://github.com/code-dot-org/code-dot-org/pull/38300#issuecomment-757063626) for more details).