### PR TITLE
Add has_lesson_plan to lesson model

### DIFF
--- a/dashboard/app/models/lesson.rb
+++ b/dashboard/app/models/lesson.rb
@@ -13,6 +13,7 @@
 #  properties        :text(65535)
 #  lesson_group_id   :integer
 #  key               :string(255)      not null
+#  has_lesson_plan   :boolean
 #
 # Indexes
 #

--- a/dashboard/db/migrate/20210108224326_add_has_lesson_plan_to_lesson.rb
+++ b/dashboard/db/migrate/20210108224326_add_has_lesson_plan_to_lesson.rb
@@ -1,0 +1,5 @@
+class AddHasLessonPlanToLesson < ActiveRecord::Migration[5.2]
+  def change
+    add_column :stages, :has_lesson_plan, :boolean
+  end
+end

--- a/dashboard/db/schema.rb
+++ b/dashboard/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_01_05_191438) do
+ActiveRecord::Schema.define(version: 2021_01_08_224326) do
 
   create_table "activities", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci", force: :cascade do |t|
     t.integer "user_id"
@@ -1527,6 +1527,7 @@ ActiveRecord::Schema.define(version: 2021_01_05_191438) do
     t.text "properties"
     t.integer "lesson_group_id"
     t.string "key", null: false
+    t.boolean "has_lesson_plan"
     t.index ["lesson_group_id", "key"], name: "index_stages_on_lesson_group_id_and_key", unique: true
     t.index ["script_id", "key"], name: "index_stages_on_script_id_and_key", unique: true
   end


### PR DESCRIPTION
This is the start of work on lockable lessons and lesson without lesson plan improvements.

This adds the `has_lesson_plan` field to the lesson(stage) model. We need to add this right now because currently we rely on `lockable` to tell us both if something is lockable and if it has a lesson plan. The connection being if something is lockable it does not have a lesson plan. However we already have lessons that are lockable and have a lesson plan (last lesson in each unit of CSP 20-21).

## Future Work

- Setting this field to the correct value for each existing lesson
- Using this field to determine things like the view lesson plan button or the url to access a lesson

More coming on this plan as we sort out the details but I feel solid on the fact that we need this field.

## Links

<!--
  Any relevant links to external resources; ie, specification documents, jira
  items, related PRs, honeybadger errors, etc
-->

- [Jira](https://codedotorg.atlassian.net/browse/PLAT-577)
- [Planning Ideas Doc](https://docs.google.com/document/d/1sAAVnwv3rXQEK-qa8JnkNXFfZ0vjWQyzJ9Yx_pG4bdg/edit)

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
