### PR TITLE
Provide helpful message when teacher attempts to join own section LP-1712

### DIFF
--- a/apps/i18n/common/en_us.json
+++ b/apps/i18n/common/en_us.json
@@ -1573,6 +1573,7 @@
   "sectionSignInInfo": "Alternatively, share this section's sign in page with your students: ",
   "sectionsJoined": "Classroom Sections I've Joined",
   "sectionsTitle": "Classroom Sections",
+  "sectionsNotificationAlreadyOwned": "You are already the owner of section {sectionId}.",
   "sectionsNotificationFailure": "Couldn't join section",
   "sectionsNotificationJoinExists": "You have already joined section {sectionName}.",
   "sectionsNotificationJoinFail": "An error occurred attempting to join section {sectionId}.",

--- a/apps/src/templates/studioHomepages/JoinSectionNotifications.jsx
+++ b/apps/src/templates/studioHomepages/JoinSectionNotifications.jsx
@@ -17,6 +17,8 @@ export default function JoinSectionNotifications({action, result, name, id}) {
     return <JoinSectionFailNotification sectionId={id} />;
   } else if (action === 'join' && result === 'exists') {
     return <JoinSectionExistsNotification sectionName={name} />;
+  } else if (action === 'join' && result === 'section_owned') {
+    return <JoinSectionOwnedNotification sectionId={id} />;
   }
   return null;
 }
@@ -71,6 +73,17 @@ const JoinSectionFailNotification = ({sectionId}) => (
   />
 );
 JoinSectionFailNotification.propTypes =
+  JoinSectionNotFoundNotification.propTypes;
+
+const JoinSectionOwnedNotification = ({sectionId}) => (
+  <Notification
+    type="failure"
+    notice={i18n.sectionsNotificationFailure()}
+    details={i18n.sectionsNotificationAlreadyOwned({sectionId})}
+    dismissible={true}
+  />
+);
+JoinSectionOwnedNotification.propTypes =
   JoinSectionNotFoundNotification.propTypes;
 
 const JoinSectionExistsNotification = ({sectionName}) => (

--- a/dashboard/app/controllers/api/v1/sections_controller.rb
+++ b/dashboard/app/controllers/api/v1/sections_controller.rb
@@ -120,6 +120,13 @@ class Api::V1::SectionsController < Api::V1::JsonApiController
       return
     end
     result = @section.add_student current_user
+    # add_student returns 'failure' when id of current user is owner of @section
+    if result == 'failure'
+      render json: {
+        result: 'section_owned'
+      }, status: :bad_request
+      return
+    end
     render json: {
       sections: current_user.sections_as_student.map(&:summarize_without_students),
       result: result


### PR DESCRIPTION
This PR accounts for the fact that teachers can attempt to join their own sections from the teacher dashboard without being provided a helpful error message. Currently, when a teacher attempts to join their own section, nothing happens from a user point of view and a `TypeError` is logged in the browser console. The error is triggered [here](https://github.com/code-dot-org/code-dot-org/blob/e952410338380e2c0a0b74dad50f70df9b9b4813/apps/src/templates/studioHomepages/JoinSection.jsx#L118) as the code attempts to parse the section code served up by the backend. However, the backend only returns the current user's sections in which they are a student, so the `find()` method returns an empty array. 

The updated code will hit the `.fail()` [callback](https://github.com/code-dot-org/code-dot-org/blob/e952410338380e2c0a0b74dad50f70df9b9b4813/apps/src/templates/studioHomepages/JoinSection.jsx#L127) and use the existing `JoinSectionNotification` component to provide a useful error message to the teacher. These changes address the endpoint `/api/v1/section/<id>/join` – we already account for the possibility of a teacher joining their own section for the `/join/:section_code` endpoint [here](https://github.com/code-dot-org/code-dot-org/blob/e952410338380e2c0a0b74dad50f70df9b9b4813/dashboard/app/controllers/followers_controller.rb#L72).

### Background 

These changes arose out of a problem I uncovered while doing general work around expanding test coverage throughout the join section workflow - Jira [here](https://codedotorg.atlassian.net/browse/LP-1688?atlOrigin=eyJpIjoiNzY0NWRmN2ZmYWQwNDUzOThkNTAzMWQ5OGJmYWMxM2MiLCJwIjoiaiJ9).

## Links

- [jira](https://codedotorg.atlassian.net/browse/LP-1712?atlOrigin=eyJpIjoiNjAxNWEwYWJkZTY1NGI5NGIzY2RhYjIzY2Y1ZjAxMTMiLCJwIjoiaiJ9)

## Curent Behavior

![](https://slack-imgs.com/?c=1&o1=ro&url=http%3A%2F%2Fg.recordit.co%2FoN2zURWe9v.gif)

## New Behavior

<img width="989" alt="Screen Shot 2021-01-10 at 11 18 17 PM" src="https://user-images.githubusercontent.com/17502635/104146842-2245c980-539a-11eb-97ac-3e5c33cb23ba.png">


# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked


