### PR TITLE
[Spritelab] Fix behavior renaming

### DIFF
--- a/apps/package.json
+++ b/apps/package.json
@@ -48,7 +48,7 @@
     "@babel/preset-react": "^7.0.0",
     "@cdo/interpreted": "link:../dashboard/config/libraries",
     "@code-dot-org/artist": "0.2.1",
-    "@code-dot-org/blockly": "3.5.32",
+    "@code-dot-org/blockly": "3.5.33",
     "@code-dot-org/craft": "0.2.2",
     "@code-dot-org/dance-party": "1.0.1",
     "@code-dot-org/johnny-five": "0.11.1-cdo.2",

--- a/apps/src/p5lab/spritelab/blocks.js
+++ b/apps/src/p5lab/spritelab/blocks.js
@@ -538,9 +538,12 @@ export default {
         }
       },
 
-      renameProcedure(oldName, newName) {
+      renameProcedure(oldName, newName, userCreated) {
         if (Blockly.Names.equals(oldName, this.getTitleValue('VAR'))) {
           this.setTitleValue(newName, 'VAR');
+          if (userCreated) {
+            this.getTitle_('VAR').id = newName;
+          }
         }
       },
 

--- a/apps/yarn.lock
+++ b/apps/yarn.lock
@@ -1526,10 +1526,10 @@
   version "0.2.1"
   resolved "https://registry.yarnpkg.com/@code-dot-org/artist/-/artist-0.2.1.tgz#fcfe7ea5cfb3f19ddb6b912e70e922ba4b7ef0b1"
 
-"@code-dot-org/blockly@3.5.32":
-  version "3.5.32"
-  resolved "https://registry.yarnpkg.com/@code-dot-org/blockly/-/blockly-3.5.32.tgz#6659198e5314c2c395068dcc23b2141bd2694f9e"
-  integrity sha512-bSA7PwEVOGs+k62evHYBSKJZZYMVMjEQQapm0IWxTbAzSBb/KTfZT/TH2k/4niqmsPwgh7uBgUvMiaKh6F12Jg==
+"@code-dot-org/blockly@3.5.33":
+  version "3.5.33"
+  resolved "https://registry.yarnpkg.com/@code-dot-org/blockly/-/blockly-3.5.33.tgz#cf7cf61eeb7f4d10aebcedb1307bf35c12f3d052"
+  integrity sha512-KGFYKhGZ2UrRzqxkL0cvY85DUIPLUh1jCu9EUyfYYhEHcqICUnM52Jd3w0b8q53sMyKqktxGExI20dXG7QR6RQ==
 
 "@code-dot-org/craft@0.2.2":
   version "0.2.2"


### PR DESCRIPTION
Bumps Blockly to pull in https://github.com/code-dot-org/blockly/pull/260

`gamelab_behavior_get`: ![image](https://user-images.githubusercontent.com/8787187/104222456-2c49e580-53f7-11eb-9df2-dbdf348d9ee0.png) 
`behavior_definition`:  ![image](https://user-images.githubusercontent.com/8787187/104222692-8185f700-53f7-11eb-9ffc-b3b15bfcb651.png)

The other code change here is to update the id of the `gamelab_behavior_get` block whenever the `behavior_definition` name changes *if* the behavior is user-created.

<!-- ### Background -->
<!-- ### Privacy -->
<!--
1.	Does the Project involve the collection, use or sharing of new Personal Data?

2.	Does the Project involve a new or changed use or sharing of existing Personal Data?
-->
<!-- ### Security -->
<!--
Link to Jira Task where sensitive security issues are discussed privately.
-->
<!-- ### Caching -->
<!-- ### Deployment strategy -->
<!-- ### Future work -->

## Links

<!--
  Any relevant links to external resources; ie, specification documents, jira
  items, related PRs, honeybadger errors, etc
-->

## Testing story
No test right now, mostly because I want to get this fix out soon as it's currently broken in the tool. As @madelynkasula mentioned, though, it'd be good to add an integration test or something here so that we don't regress this again.

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
