### PR TITLE
playSpeech cleanup: Remove fallback to languageCode

### DIFF
--- a/apps/src/lib/util/audioApi.js
+++ b/apps/src/lib/util/audioApi.js
@@ -168,14 +168,10 @@ export const commands = {
     }
 
     const azureTTS = AzureTextToSpeech.getSingleton();
-    // Voices from the server used to have a "languageCode" key, which has been renamed
-    // to "locale". Voices are cached, so allow for either key for backwards compatibility.
-    // This can be removed a couple of days after this code has been deployed.
-    const locale = voices[language].locale || voices[language].languageCode;
     const promise = azureTTS.createSoundPromise({
       text,
       gender,
-      locale,
+      locale: voices[language].locale,
       authenticityToken,
       onFailure: message => outputWarning(message + '\n')
     });


### PR DESCRIPTION
Clean-up for #38498. Once the list of Azure TTS voices is no longer cached with the "languageCode" key, we can remove the fallback and only use the "locale" key.

## Links

- [STAR-1359](https://codedotorg.atlassian.net/browse/STAR-1359)

## Testing story

Existing unit tests.

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
