### PR TITLE
[Applab] Add SI and thedogapi to startWebRequest allow list

### DIFF
--- a/dashboard/app/controllers/xhr_proxy_controller.rb
+++ b/dashboard/app/controllers/xhr_proxy_controller.rb
@@ -42,6 +42,7 @@ class XhrProxyController < ApplicationController
     api.pegelalarm.at
     api.randomuser.me
     api.rebrandly.com
+    api.si.edu
     api.spacexdata.com
     api.spotify.com
     api.themoviedb.org
@@ -51,7 +52,6 @@ class XhrProxyController < ApplicationController
     api.zippopotam.us
     atlas.media.mit.edu
     bible-api.com
-    thecatapi.com
     code.org
     compete.hsctf.com
     covidtracking.com
@@ -94,6 +94,8 @@ class XhrProxyController < ApplicationController
     spreadsheets.google.com
     stats.minecraftservers.org
     swapi.co
+    thecatapi.com
+    thedogapi.com
     theunitedstates.io
     transitchicago.com
     translate.yandex.net


### PR DESCRIPTION
Requested via zendesk.
https://www.si.edu/openaccess (Smithsonian)
https://thedogapi.com/ (Dog pictures. We already allow thecatapi)
