### PR TITLE
Revert "Make level ID required for level objects in React components"

### DIFF
--- a/apps/src/code-studio/components/BubbleChoice.jsx
+++ b/apps/src/code-studio/components/BubbleChoice.jsx
@@ -1,10 +1,10 @@
 import React from 'react';
+import PropTypes from 'prop-types';
 import i18n from '@cdo/locale';
 import color from '@cdo/apps/util/color';
 import {navigateToHref} from '@cdo/apps/utils';
 import SafeMarkdown from '@cdo/apps/templates/SafeMarkdown';
 import SublevelCard from './SublevelCard';
-import {levelTypeWithoutStatus} from '@cdo/apps/templates/progress/progressTypes';
 
 const MARGIN = 10;
 
@@ -29,9 +29,27 @@ const styles = {
 };
 
 export default class BubbleChoice extends React.Component {
-  // The bubble choice component doesn't need the status. It's
-  // only rendering the sublevel cards.
-  static propTypes = {level: levelTypeWithoutStatus};
+  static propTypes = {
+    level: PropTypes.shape({
+      display_name: PropTypes.string.isRequired,
+      description: PropTypes.string.isRequired,
+      previous_level_url: PropTypes.string,
+      redirect_url: PropTypes.string,
+      script_url: PropTypes.string,
+      sublevels: PropTypes.arrayOf(
+        PropTypes.shape({
+          id: PropTypes.number.isRequired,
+          display_name: PropTypes.string.isRequired,
+          description: PropTypes.string,
+          thumbnail_url: PropTypes.string,
+          url: PropTypes.string.isRequired,
+          position: PropTypes.number,
+          letter: PropTypes.string,
+          perfect: PropTypes.bool
+        })
+      )
+    })
+  };
 
   goToUrl = url => {
     navigateToHref(url + location.search);

--- a/apps/src/code-studio/components/SublevelCard.jsx
+++ b/apps/src/code-studio/components/SublevelCard.jsx
@@ -7,7 +7,6 @@ import FontAwesome from '@cdo/apps/templates/FontAwesome';
 import LessonExtrasFlagIcon from '@cdo/apps/templates/progress/LessonExtrasFlagIcon';
 import MazeThumbnail from '@cdo/apps/code-studio/components/lessonExtras/MazeThumbnail';
 import queryString from 'query-string';
-import {levelTypeWithoutStatus} from '@cdo/apps/templates/progress/progressTypes';
 
 const THUMBNAIL_IMAGE_SIZE = 200;
 const MARGIN = 10;
@@ -85,8 +84,18 @@ const styles = {
 export default class SublevelCard extends React.Component {
   static propTypes = {
     isLessonExtra: PropTypes.bool,
-    // sublevels generally use "perfect" instead of status
-    sublevel: levelTypeWithoutStatus,
+    sublevel: PropTypes.shape({
+      id: PropTypes.number.isRequired,
+      display_name: PropTypes.string.isRequired,
+      description: PropTypes.string,
+      thumbnail_url: PropTypes.string,
+      url: PropTypes.string.isRequired,
+      position: PropTypes.number,
+      letter: PropTypes.string,
+      perfect: PropTypes.bool,
+      type: PropTypes.string,
+      maze_summary: PropTypes.object
+    }),
     sectionId: PropTypes.number,
     userId: PropTypes.number
   };

--- a/apps/src/code-studio/components/header/HeaderMiddle.jsx
+++ b/apps/src/code-studio/components/header/HeaderMiddle.jsx
@@ -6,6 +6,7 @@ import ScriptName from './ScriptName';
 import LessonProgress from '../progress/LessonProgress';
 import HeaderPopup from './HeaderPopup';
 import HeaderFinish from './HeaderFinish';
+import {lessonExtrasUrl} from '@cdo/apps/code-studio/progressRedux';
 import _ from 'lodash';
 import $ from 'jquery';
 
@@ -32,8 +33,9 @@ class HeaderMiddle extends React.Component {
     appLoaded: PropTypes.bool,
     scriptNameData: PropTypes.object,
     lessonData: PropTypes.object,
+    lessonExtrasUrl: PropTypes.string,
     scriptData: PropTypes.object,
-    currentLevelId: PropTypes.number,
+    currentLevelId: PropTypes.string,
     linesOfCodeText: PropTypes.string,
     isRtl: PropTypes.bool
   };
@@ -337,5 +339,9 @@ class HeaderMiddle extends React.Component {
 export default connect(state => ({
   isRtl: state.isRtl,
   appLoadStarted: state.header.appLoadStarted,
-  appLoaded: state.header.appLoaded
+  appLoaded: state.header.appLoaded,
+  lessonExtrasUrl: lessonExtrasUrl(
+    state.progress,
+    state.progress.currentStageId
+  )
 }))(HeaderMiddle);

--- a/apps/src/code-studio/components/header/HeaderPopup.jsx
+++ b/apps/src/code-studio/components/header/HeaderPopup.jsx
@@ -26,7 +26,7 @@ export default class HeaderPopup extends Component {
   static propTypes = {
     scriptName: PropTypes.string,
     scriptData: PropTypes.object,
-    currentLevelId: PropTypes.number,
+    currentLevelId: PropTypes.string,
     linesOfCodeText: PropTypes.string,
     minimal: PropTypes.bool,
     windowHeight: PropTypes.number

--- a/apps/src/code-studio/components/progress/LessonProgress.jsx
+++ b/apps/src/code-studio/components/progress/LessonProgress.jsx
@@ -11,7 +11,6 @@ import {
 } from '@cdo/apps/code-studio/progressRedux';
 import ProgressBubble from '@cdo/apps/templates/progress/ProgressBubble';
 import {levelType} from '@cdo/apps/templates/progress/progressTypes';
-import {LevelKind} from '@cdo/apps/util/sharedConstants';
 import $ from 'jquery';
 
 const styles = {
@@ -79,11 +78,10 @@ class LessonProgress extends Component {
   static propTypes = {
     levels: PropTypes.arrayOf(levelType).isRequired,
     lessonExtrasUrl: PropTypes.string,
-    isLessonExtras: PropTypes.bool,
+    onLessonExtras: PropTypes.bool,
     lessonTrophyEnabled: PropTypes.bool,
     width: PropTypes.number,
-    setDesiredWidth: PropTypes.func,
-    currentPageNumber: PropTypes.number
+    setDesiredWidth: PropTypes.func
   };
 
   getFullWidth() {
@@ -162,12 +160,7 @@ class LessonProgress extends Component {
   }
 
   render() {
-    const {
-      currentPageNumber,
-      lessonExtrasUrl,
-      isLessonExtras,
-      lessonTrophyEnabled
-    } = this.props;
+    const {lessonExtrasUrl, onLessonExtras, lessonTrophyEnabled} = this.props;
     let levels = this.props.levels;
 
     // Only puzzle levels (non-concept levels) should count towards mastery.
@@ -201,33 +194,29 @@ class LessonProgress extends Component {
             style={styles.inner}
           >
             {lessonTrophyEnabled && <div style={styles.spacer} />}
-            {levels.map((level, index) => {
-              let isCurrent = level.isCurrentLevel;
-              if (isCurrent && level.kind === LevelKind.assessment) {
-                isCurrent = currentPageNumber === level.pageNumber;
-              }
-              return (
-                <div
-                  key={index}
-                  ref={isCurrent ? 'currentLevel' : null}
-                  style={{
-                    ...(level.isUnplugged && isCurrent && styles.pillContainer)
-                  }}
-                >
-                  <ProgressBubble
-                    level={level}
-                    disabled={false}
-                    smallBubble={!isCurrent}
-                    lessonTrophyEnabled={lessonTrophyEnabled}
-                  />
-                </div>
-              );
-            })}
+            {levels.map((level, index) => (
+              <div
+                key={index}
+                ref={level.isCurrentLevel ? 'currentLevel' : null}
+                style={{
+                  ...(level.isUnplugged &&
+                    level.isCurrentLevel &&
+                    styles.pillContainer)
+                }}
+              >
+                <ProgressBubble
+                  level={level}
+                  disabled={false}
+                  smallBubble={!level.isCurrentLevel}
+                  lessonTrophyEnabled={lessonTrophyEnabled}
+                />
+              </div>
+            ))}
             {lessonExtrasUrl && !lessonTrophyEnabled && (
-              <div ref={isLessonExtras ? 'currentLevel' : null}>
+              <div ref={onLessonExtras ? 'currentLevel' : null}>
                 <LessonExtrasProgressBubble
                   lessonExtrasUrl={lessonExtrasUrl}
-                  perfect={isLessonExtras}
+                  perfect={onLessonExtras}
                 />
               </div>
             )}
@@ -252,6 +241,5 @@ export default connect(state => ({
     state.progress,
     state.progress.currentStageId
   ),
-  isLessonExtras: state.progress.isLessonExtras,
-  currentPageNumber: state.progress.currentPageNumber
+  onLessonExtras: state.progress.currentLevelId === 'stage_extras'
 }))(LessonProgress);

--- a/apps/src/code-studio/components/progress/SelectedStudentInfo.jsx
+++ b/apps/src/code-studio/components/progress/SelectedStudentInfo.jsx
@@ -3,7 +3,6 @@ import React from 'react';
 import i18n from '@cdo/locale';
 import {TeacherPanelProgressBubble} from '@cdo/apps/code-studio/components/progress/TeacherPanelProgressBubble';
 import Button from '@cdo/apps/templates/Button';
-import {levelType} from '@cdo/apps/templates/progress/progressTypes';
 import {LevelStatus} from '@cdo/apps/util/sharedConstants';
 import Radium from 'radium';
 import FontAwesome from '@cdo/apps/templates/FontAwesome';
@@ -48,7 +47,7 @@ export class SelectedStudentInfo extends React.Component {
   static propTypes = {
     students: PropTypes.arrayOf(studentShape).isRequired,
     selectedStudent: PropTypes.object,
-    level: levelType,
+    level: PropTypes.object,
     onSelectUser: PropTypes.func.isRequired,
     getSelectedUserId: PropTypes.func.isRequired
   };

--- a/apps/src/code-studio/components/progress/StudentTable.jsx
+++ b/apps/src/code-studio/components/progress/StudentTable.jsx
@@ -3,7 +3,6 @@ import PropTypes from 'prop-types';
 import Radium from 'radium';
 import color from '@cdo/apps/util/color';
 import i18n from '@cdo/locale';
-import {levelType} from '@cdo/apps/templates/progress/progressTypes';
 import {TeacherPanelProgressBubble} from '@cdo/apps/code-studio/components/progress/TeacherPanelProgressBubble';
 import FontAwesome from '@cdo/apps/templates/FontAwesome';
 
@@ -63,7 +62,7 @@ class StudentTable extends React.Component {
     students: PropTypes.arrayOf(studentShape).isRequired,
     onSelectUser: PropTypes.func.isRequired,
     getSelectedUserId: PropTypes.func.isRequired,
-    levels: PropTypes.arrayOf(levelType),
+    levels: PropTypes.array,
     sectionId: PropTypes.number,
     scriptName: PropTypes.string
   };

--- a/apps/src/code-studio/components/progress/TeacherPanelProgressBubble.jsx
+++ b/apps/src/code-studio/components/progress/TeacherPanelProgressBubble.jsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import PropTypes from 'prop-types';
 import color from '@cdo/apps/util/color';
 import FontAwesome from '@cdo/apps/templates/FontAwesome';
 import {
@@ -7,7 +8,6 @@ import {
   levelProgressStyle
 } from '@cdo/apps/templates/progress/progressStyles';
 import {LevelStatus} from '@cdo/apps/util/sharedConstants';
-import {levelType} from '@cdo/apps/templates/progress/progressTypes';
 
 /**
  * A TeacherPanelProgressBubble represents progress for a specific level in the TeacherPanel. It can be a circle
@@ -53,7 +53,7 @@ const styles = {
 
 export class TeacherPanelProgressBubble extends React.Component {
   static propTypes = {
-    level: levelType.isRequired
+    level: PropTypes.object.isRequired
   };
 
   render() {

--- a/apps/src/code-studio/header.js
+++ b/apps/src/code-studio/header.js
@@ -56,15 +56,12 @@ const PUZZLE_PAGE_NONE = -1;
  *   }>
  * }}
  * @param {object} progressData
- * @param {number} currentLevelId
- * @param {number} currentPageNumber The page we are on if this is a multi-
- *   page level
+ * @param {string} currentLevelId
+ * @param {number} puzzlePage
  * @param {boolean} signedIn True/false if we know the sign in state of the
  *   user, null otherwise
  * @param {boolean} stageExtrasEnabled Whether this user is in a section with
  *   stageExtras enabled for this script
- * @param {boolean} isLessonExtras Boolean indicating we are not on a script
- *   level and therefore are on lesson extras
  */
 header.build = function(
   scriptData,
@@ -72,11 +69,10 @@ header.build = function(
   lessonData,
   progressData,
   currentLevelId,
-  currentPageNumber,
+  puzzlePage,
   signedIn,
   stageExtrasEnabled,
   scriptNameData,
-  isLessonExtras,
   hasAppOptions
 ) {
   const store = getStore();
@@ -90,7 +86,8 @@ header.build = function(
   progressData = progressData || {};
 
   const linesOfCodeText = progressData.linesOfCodeText;
-  let saveAnswersBeforeNavigation = currentPageNumber !== PUZZLE_PAGE_NONE;
+
+  let saveAnswersBeforeNavigation = puzzlePage !== PUZZLE_PAGE_NONE;
 
   // Set up the store immediately.
   progress.generateStageProgress(
@@ -101,9 +98,7 @@ header.build = function(
     currentLevelId,
     saveAnswersBeforeNavigation,
     signedIn,
-    stageExtrasEnabled,
-    isLessonExtras,
-    currentPageNumber
+    stageExtrasEnabled
   );
 
   // Hold off on rendering HeaderMiddle.  This will allow the "app load"

--- a/apps/src/code-studio/progress.js
+++ b/apps/src/code-studio/progress.js
@@ -78,10 +78,6 @@ progress.showDisabledBubblesAlert = function() {
  *   user, null otherwise
  * @param {boolean} stageExtrasEnabled Whether this user is in a section with
  *   stageExtras enabled for this script
- * @param {boolean} isLessonExtras Boolean indicating we are not on a script
- *   level and therefore are on lesson extras
- * @param {number} currentPageNumber The page we are on if this is a multi-
- *   page level
  */
 progress.generateStageProgress = function(
   scriptData,
@@ -91,9 +87,7 @@ progress.generateStageProgress = function(
   currentLevelId,
   saveAnswersBeforeNavigation,
   signedIn,
-  stageExtrasEnabled,
-  isLessonExtras,
-  currentPageNumber
+  stageExtrasEnabled
 ) {
   const store = getStore();
 
@@ -113,9 +107,7 @@ progress.generateStageProgress = function(
     },
     currentLevelId,
     false,
-    saveAnswersBeforeNavigation,
-    isLessonExtras,
-    currentPageNumber
+    saveAnswersBeforeNavigation
   );
 
   store.dispatch(
@@ -269,19 +261,13 @@ function queryUserProgress(store, scriptData, currentLevelId) {
  * @param {boolean} isFullProgress - True if this contains progress for the entire
  *   script vs. a single stage.
  * @param {boolean} [saveAnswersBeforeNavigation]
- * @param {boolean} [isLessonExtras] Optional boolean indicating we are not on
- *   a script level and therefore are on lesson extras
- * @param {number} [currentPageNumber] Optional. The page we are on if this is
- *   a multi-page level
  */
 function initializeStoreWithProgress(
   store,
   scriptData,
   currentLevelId,
   isFullProgress,
-  saveAnswersBeforeNavigation = false,
-  isLessonExtras = false,
-  currentPageNumber
+  saveAnswersBeforeNavigation = false
 ) {
   store.dispatch(
     initProgress({
@@ -298,9 +284,7 @@ function initializeStoreWithProgress(
       scriptStudentDescription: scriptData.studentDescription,
       betaTitle: scriptData.beta_title,
       courseId: scriptData.course_id,
-      isFullProgress: isFullProgress,
-      isLessonExtras: isLessonExtras,
-      currentPageNumber: currentPageNumber
+      isFullProgress: isFullProgress
     })
   );
 

--- a/apps/src/code-studio/progressRedux.js
+++ b/apps/src/code-studio/progressRedux.js
@@ -45,7 +45,6 @@ const initialState = {
   scriptName: null,
   scriptTitle: null,
   courseId: null,
-  isLessonExtras: false,
 
   // The remaining fields do change after initialization
   // a mapping of level id to result
@@ -66,8 +65,7 @@ const initialState = {
   // possible that we can get the user progress back from the DB
   // prior to having information about the user login state.
   // TODO: Use sign in state to determine where to source user progress from
-  usingDbProgress: false,
-  currentPageNumber: 0
+  usingDbProgress: false
 };
 
 /**
@@ -96,9 +94,7 @@ export default function reducer(state = initialState, action) {
       betaTitle: action.betaTitle,
       courseId: action.courseId,
       currentStageId,
-      hasFullProgress: action.isFullProgress,
-      isLessonExtras: action.isLessonExtras,
-      currentPageNumber: action.currentPageNumber
+      hasFullProgress: action.isFullProgress
     };
   }
 
@@ -402,9 +398,7 @@ export const initProgress = ({
   scriptStudentDescription,
   betaTitle,
   courseId,
-  isFullProgress,
-  isLessonExtras,
-  currentPageNumber
+  isFullProgress
 }) => ({
   type: INIT_PROGRESS,
   currentLevelId,
@@ -420,9 +414,7 @@ export const initProgress = ({
   scriptStudentDescription,
   betaTitle,
   courseId,
-  isFullProgress,
-  isLessonExtras,
-  currentPageNumber
+  isFullProgress
 });
 
 export const clearProgress = () => ({
@@ -556,7 +548,8 @@ const peerReviewLevels = state =>
 const isCurrentLevel = (currentLevelId, level) => {
   return (
     !!currentLevelId &&
-    ((level.ids && level.ids.indexOf(currentLevelId) !== -1) ||
+    ((level.ids &&
+      level.ids.map(id => id.toString()).indexOf(currentLevelId) !== -1) ||
       level.uid === currentLevelId)
   );
 };

--- a/apps/src/templates/FinishDialog.story.jsx
+++ b/apps/src/templates/FinishDialog.story.jsx
@@ -59,7 +59,7 @@ for (let i = 0; i < 20; i++) {
 }
 
 const mockProgress = {
-  currentLevelId: 123,
+  currentLevelId: '123',
   professionalLearningCourse: false,
   saveAnswersBeforeNavigation: false,
   stages: [

--- a/apps/src/templates/lessonOverview/activities/ProgressionDetails.jsx
+++ b/apps/src/templates/lessonOverview/activities/ProgressionDetails.jsx
@@ -33,7 +33,6 @@ export default class ProgressionDetails extends Component {
         : scriptLevel.levels[0];
 
     return {
-      id: activeLevel.id,
       status: LevelStatus.not_tried,
       url: scriptLevel.url,
       name: activeLevel.name,

--- a/apps/src/templates/progress/DetailProgressTable.story.jsx
+++ b/apps/src/templates/progress/DetailProgressTable.story.jsx
@@ -18,7 +18,6 @@ const lessons = [
 const levelsByLesson = [
   [
     {
-      id: 30,
       status: LevelStatus.not_tried,
       url: '/step1/level1',
       name: 'First progression',
@@ -29,7 +28,6 @@ const levelsByLesson = [
       progression: 'Second Progression'
     })),
     {
-      id: 40,
       status: LevelStatus.not_tried,
       url: '/step3/level1',
       name: 'Last progression',

--- a/apps/src/templates/progress/LessonGroup.story.jsx
+++ b/apps/src/templates/progress/LessonGroup.story.jsx
@@ -18,7 +18,6 @@ const lessons = [
 const levelsByLesson = [
   [
     {
-      id: 20,
       status: LevelStatus.not_tried,
       url: '/step1/level1',
       name: 'First progression',
@@ -29,7 +28,6 @@ const levelsByLesson = [
       progression: 'Second Progression'
     })),
     {
-      id: 21,
       status: LevelStatus.not_tried,
       url: '/step3/level1',
       name: 'Last progression',

--- a/apps/src/templates/progress/ProgressBubble.story.jsx
+++ b/apps/src/templates/progress/ProgressBubble.story.jsx
@@ -12,7 +12,6 @@ export default storybook => {
         story: () => (
           <ProgressBubble
             level={{
-              id: 1,
               levelNumber: 3,
               status: status,
               url: '/foo/bar',
@@ -28,7 +27,6 @@ export default storybook => {
           story: () => (
             <ProgressBubble
               level={{
-                id: 1,
                 levelNumber: 3,
                 status: LevelStatus.perfect,
                 url: '/foo/bar',
@@ -44,7 +42,6 @@ export default storybook => {
           story: () => (
             <ProgressBubble
               level={{
-                id: 1,
                 levelNumber: 3,
                 status: LevelStatus.perfect,
                 url: '/foo/bar',
@@ -60,7 +57,6 @@ export default storybook => {
           story: () => (
             <ProgressBubble
               level={{
-                id: 1,
                 levelNumber: 3,
                 status: LevelStatus.perfect,
                 url: '/foo/bar',
@@ -77,7 +73,6 @@ export default storybook => {
           story: () => (
             <ProgressBubble
               level={{
-                id: 1,
                 levelNumber: 3,
                 status: LevelStatus.perfect,
                 url: '/foo/bar',
@@ -96,7 +91,6 @@ export default storybook => {
           story: () => (
             <ProgressBubble
               level={{
-                id: 1,
                 levelNumber: 3,
                 status: LevelStatus.attempted,
                 url: '/foo/bar',

--- a/apps/src/templates/progress/ProgressLegend.jsx
+++ b/apps/src/templates/progress/ProgressLegend.jsx
@@ -157,7 +157,6 @@ export default class ProgressLegend extends Component {
               <div style={styles.center}>
                 <ProgressBubble
                   level={{
-                    id: 1,
                     status: LevelStatus.not_tried,
                     isConceptLevel: true,
                     name: `${i18n.concept()}: ${i18n.notStarted()}`
@@ -170,7 +169,6 @@ export default class ProgressLegend extends Component {
               <div style={styles.center}>
                 <ProgressBubble
                   level={{
-                    id: 1,
                     status: LevelStatus.attempted,
                     isConceptLevel: true,
                     name: `${i18n.concept()}: ${i18n.inProgress()}`
@@ -184,7 +182,6 @@ export default class ProgressLegend extends Component {
               <div style={styles.center}>
                 <ProgressBubble
                   level={{
-                    id: 1,
                     status: LevelStatus.perfect,
                     isConceptLevel: true,
                     name: `${i18n.concept()}: ${i18n.completed()} (${i18n.perfect()})`
@@ -233,7 +230,6 @@ export default class ProgressLegend extends Component {
               <div style={styles.center}>
                 <ProgressBubble
                   level={{
-                    id: 1,
                     status: LevelStatus.not_tried,
                     isConceptLevel: false,
                     name: `${i18n.activity()}: ${i18n.notStarted()}`
@@ -246,7 +242,6 @@ export default class ProgressLegend extends Component {
               <div style={styles.center}>
                 <ProgressBubble
                   level={{
-                    id: 1,
                     status: LevelStatus.attempted,
                     isConceptLevel: false,
                     name: `${i18n.activity()}: ${i18n.inProgress()}`
@@ -260,7 +255,6 @@ export default class ProgressLegend extends Component {
                 <div style={styles.center}>
                   <ProgressBubble
                     level={{
-                      id: 1,
                       status: LevelStatus.passed,
                       isConceptLevel: false,
                       name: `${i18n.activity()}: ${i18n.completed()} (${i18n.tooManyBlocks()})`
@@ -274,7 +268,6 @@ export default class ProgressLegend extends Component {
               <div style={styles.center}>
                 <ProgressBubble
                   level={{
-                    id: 1,
                     status: LevelStatus.perfect,
                     isConceptLevel: false,
                     name: `${i18n.activity()}: ${i18n.completed()} (${i18n.perfect()})`
@@ -287,7 +280,6 @@ export default class ProgressLegend extends Component {
               <div style={styles.center}>
                 <ProgressBubble
                   level={{
-                    id: 1,
                     status: LevelStatus.submitted,
                     isConceptLevel: false,
                     name: `${i18n.activity()}: ${i18n.submitted()}`

--- a/apps/src/templates/progress/ProgressPill.story.jsx
+++ b/apps/src/templates/progress/ProgressPill.story.jsx
@@ -10,7 +10,6 @@ export default storybook => {
         <ProgressPill
           levels={[
             {
-              id: 1,
               url: '/level1',
               status: LevelStatus.perfect
             }
@@ -26,12 +25,10 @@ export default storybook => {
         <ProgressPill
           levels={[
             {
-              id: 1,
               url: '/level1',
               status: LevelStatus.perfect
             },
             {
-              id: 2,
               url: '/level2',
               status: LevelStatus.not_tried
             }
@@ -47,7 +44,6 @@ export default storybook => {
         <ProgressPill
           levels={[
             {
-              id: 1,
               url: '/level1',
               status: LevelStatus.perfect
             }

--- a/apps/src/templates/progress/progressHelpers.js
+++ b/apps/src/templates/progress/progressHelpers.js
@@ -170,7 +170,6 @@ export function summarizeProgressInStage(levelsWithStatus) {
  */
 export const processedLevel = level => {
   return {
-    id: level.activeId || level.id,
     url: level.url,
     name: level.name,
     progression: level.progression,
@@ -181,8 +180,6 @@ export const processedLevel = level => {
     levelNumber: level.kind === LevelKind.unplugged ? undefined : level.title,
     isConceptLevel: level.is_concept_level,
     bonus: level.bonus,
-    pageNumber: level.page_number,
-    sublevels:
-      level.sublevels && level.sublevels.map(level => processedLevel(level))
+    sublevels: level.sublevels
   };
 };

--- a/apps/src/templates/progress/progressTestHelpers.js
+++ b/apps/src/templates/progress/progressTestHelpers.js
@@ -24,9 +24,8 @@ export const fakeLesson = (
 });
 
 export const fakeLevel = overrides => {
-  const levelNumber = overrides.levelNumber || 1;
+  const levelNumber = overrides.levelNumber;
   return {
-    id: levelNumber,
     status: LevelStatus.not_tried,
     url: `/level${levelNumber}`,
     name: `Level ${levelNumber}`,

--- a/apps/src/templates/progress/progressTypes.js
+++ b/apps/src/templates/progress/progressTypes.js
@@ -1,20 +1,7 @@
 import PropTypes from 'prop-types';
 
-/**
- * @typedef {Object} Level
- *
- * @property {number} id
- * @property {string} url
- * @property {string} name
- * @property {string} icon
- * @property {bool} isUnplugged
- * @property {number} levelNumber
- * @property {bool} isCurrentLevel
- * @property {bool} isConceptLevel
- * @property {string} kind
- */
-const levelWithoutStatusShape = {
-  id: PropTypes.number.isRequired,
+export const levelType = PropTypes.shape({
+  status: PropTypes.string.isRequired,
   url: PropTypes.string,
   name: PropTypes.string,
   icon: PropTypes.string,
@@ -22,26 +9,8 @@ const levelWithoutStatusShape = {
   levelNumber: PropTypes.number,
   isCurrentLevel: PropTypes.bool,
   isConceptLevel: PropTypes.bool,
-  kind: PropTypes.string
-};
-
-// Avoid recursive definition
-levelWithoutStatusShape.sublevels = PropTypes.arrayOf(
-  PropTypes.shape(levelWithoutStatusShape)
-);
-
-// In the future when the level object does not contain the status object,
-// we can export just levelType without needing levelTypeWithoutStatus.
-export const levelTypeWithoutStatus = PropTypes.shape(levelWithoutStatusShape);
-
-/**
- * @typedef {Object} Level
- *
- * @property {string} status
- */
-export const levelType = PropTypes.shape({
-  ...levelWithoutStatusShape,
-  status: PropTypes.string.isRequired
+  kind: PropTypes.string,
+  sublevels: PropTypes.arrayOf(PropTypes.object)
 });
 
 /**

--- a/apps/src/templates/sectionProgress/detail/StudentProgressDetailCell.jsx
+++ b/apps/src/templates/sectionProgress/detail/StudentProgressDetailCell.jsx
@@ -1,7 +1,6 @@
 import PropTypes from 'prop-types';
 import React, {Component} from 'react';
 import ProgressBubbleSet from '@cdo/apps/templates/progress/ProgressBubbleSet';
-import {levelType} from '@cdo/apps/templates/progress/progressTypes';
 
 const styles = {
   bubbles: {
@@ -17,7 +16,7 @@ export default class StudentProgressDetailCell extends Component {
     studentId: PropTypes.number.isRequired,
     stageId: PropTypes.number.isRequired,
     sectionId: PropTypes.number.isRequired,
-    levelsWithStatus: PropTypes.arrayOf(levelType),
+    levelsWithStatus: PropTypes.arrayOf(PropTypes.object),
     stageExtrasEnabled: PropTypes.bool
   };
 

--- a/apps/test/unit/code-studio/components/BubbleChoiceTest.js
+++ b/apps/test/unit/code-studio/components/BubbleChoiceTest.js
@@ -30,7 +30,6 @@ const fakeSublevels = [
 
 const DEFAULT_PROPS = {
   level: {
-    id: 123,
     display_name: 'Bubble Choice',
     description: 'Choose one or more levels!',
     sublevels: fakeSublevels,

--- a/apps/test/unit/code-studio/components/progress/LessonProgressTest.js
+++ b/apps/test/unit/code-studio/components/progress/LessonProgressTest.js
@@ -8,12 +8,11 @@ describe('LessonProgress', () => {
   const defaultProps = {
     levels: [
       {
-        id: 123,
         status: LevelStatus.not_tried
       }
     ],
     stageId: 1,
-    isLessonExtras: false
+    onLessonExtras: false
   };
 
   it('uses progress bubbles', () => {

--- a/apps/test/unit/code-studio/components/progress/SelectedStudentInfoTest.jsx
+++ b/apps/test/unit/code-studio/components/progress/SelectedStudentInfoTest.jsx
@@ -7,7 +7,6 @@ import {LevelStatus} from '@cdo/apps/util/sharedConstants';
 const defaultProps = {
   selectedStudent: {id: 1, name: 'Student 1'},
   level: {
-    id: 123,
     assessment: null,
     contained: false,
     driver: null,

--- a/apps/test/unit/code-studio/components/progress/StudentTableTest.jsx
+++ b/apps/test/unit/code-studio/components/progress/StudentTableTest.jsx
@@ -13,7 +13,6 @@ const MINIMUM_PROPS = {
 
 const levels = [
   {
-    id: 11,
     assessment: null,
     contained: false,
     driver: null,
@@ -27,7 +26,6 @@ const levels = [
     user_id: 1
   },
   {
-    id: 22,
     assessment: null,
     contained: false,
     driver: null,

--- a/apps/test/unit/code-studio/components/progress/TeacherPanelProgressBubbleTest.jsx
+++ b/apps/test/unit/code-studio/components/progress/TeacherPanelProgressBubbleTest.jsx
@@ -7,7 +7,6 @@ import {LevelKind, LevelStatus} from '@cdo/apps/util/sharedConstants';
 
 const defaultProps = {
   level: {
-    id: 123,
     assessment: null,
     contained: false,
     driver: null,

--- a/apps/test/unit/code-studio/components/progress/TeacherPanelTest.jsx
+++ b/apps/test/unit/code-studio/components/progress/TeacherPanelTest.jsx
@@ -8,7 +8,6 @@ import SectionSelector from '@cdo/apps/code-studio/components/progress/SectionSe
 import ViewAsToggle from '@cdo/apps/code-studio/components/progress/ViewAsToggle';
 import i18n from '@cdo/locale';
 import FontAwesome from '../../../../../src/templates/FontAwesome';
-import {LevelStatus} from '@cdo/apps/util/sharedConstants';
 
 const students = [{id: 1, name: 'Student 1'}, {id: 2, name: 'Student 2'}];
 
@@ -218,13 +217,7 @@ describe('TeacherPanel', () => {
               section: {
                 students: students
               },
-              section_script_levels: [
-                {
-                  id: 11,
-                  user_id: 1,
-                  status: LevelStatus.not_tried
-                }
-              ]
+              section_script_levels: [{user_id: 1}]
             }}
           />
         );
@@ -257,13 +250,7 @@ describe('TeacherPanel', () => {
               section: {
                 students: students
               },
-              section_script_levels: [
-                {
-                  id: 11,
-                  user_id: 1,
-                  status: LevelStatus.not_tried
-                }
-              ]
+              section_script_levels: [{user_id: 1}]
             }}
           />
         );
@@ -281,13 +268,7 @@ describe('TeacherPanel', () => {
               section: {
                 students: students
               },
-              section_script_levels: [
-                {
-                  id: 11,
-                  user_id: 1,
-                  status: LevelStatus.not_tried
-                }
-              ]
+              section_script_levels: [{user_id: 1}]
             }}
           />
         );

--- a/apps/test/unit/code-studio/progressReduxTest.js
+++ b/apps/test/unit/code-studio/progressReduxTest.js
@@ -60,7 +60,6 @@ const stageData = [
         ids: [323],
         activeId: 323,
         position: 2,
-        page_number: 1,
         kind: LevelKind.assessment,
         icon: null,
         title: 1,
@@ -74,7 +73,6 @@ const stageData = [
         ids: [322],
         activeId: 322,
         position: 3,
-        page_number: 2,
         kind: LevelKind.assessment,
         icon: null,
         title: 2,
@@ -166,7 +164,7 @@ const initialScriptOverviewProgress = {
 
 // The initial progress passed to the puzzle page
 const initialPuzzlePageProgress = {
-  currentLevelId: 341,
+  currentLevelId: '341',
   professionalLearningCourse: false,
   saveAnswersBeforeNavigation: false,
   lessonGroups: [],
@@ -200,7 +198,7 @@ describe('progressReduxTest', () => {
       const action = initProgress(initialPuzzlePageProgress);
       const nextState = reducer(undefined, action);
 
-      assert.equal(nextState.currentLevelId, 341);
+      assert.equal(nextState.currentLevelId, '341');
       assert.equal(nextState.professionalLearningCourse, false);
       assert.equal(nextState.saveAnswersBeforeNavigation, false);
       assert.deepEqual(
@@ -630,7 +628,6 @@ describe('progressReduxTest', () => {
       const expected = [
         [
           {
-            id: 2106,
             status: 'not_tried',
             url:
               'http://localhost-studio.code.org:3000/s/course3/stage/1/puzzle/1',
@@ -642,7 +639,6 @@ describe('progressReduxTest', () => {
             icon: null,
             isUnplugged: true,
             levelNumber: undefined,
-            pageNumber: undefined,
             isCurrentLevel: false,
             isConceptLevel: false,
             paired: undefined,
@@ -650,7 +646,6 @@ describe('progressReduxTest', () => {
             sublevels: []
           },
           {
-            id: 323,
             status: 'not_tried',
             url:
               'http://localhost-studio.code.org:3000/s/course3/stage/1/puzzle/2',
@@ -662,7 +657,6 @@ describe('progressReduxTest', () => {
             icon: null,
             isUnplugged: false,
             levelNumber: 1,
-            pageNumber: 1,
             isCurrentLevel: false,
             isConceptLevel: false,
             paired: undefined,
@@ -670,7 +664,6 @@ describe('progressReduxTest', () => {
             sublevels: []
           },
           {
-            id: 322,
             status: 'not_tried',
             url:
               'http://localhost-studio.code.org:3000/s/course3/stage/1/puzzle/3',
@@ -682,7 +675,6 @@ describe('progressReduxTest', () => {
             icon: null,
             isUnplugged: false,
             levelNumber: 2,
-            pageNumber: 2,
             isCurrentLevel: false,
             isConceptLevel: false,
             paired: undefined,
@@ -692,7 +684,6 @@ describe('progressReduxTest', () => {
         ],
         [
           {
-            id: 330,
             status: 'not_tried',
             url:
               'http://localhost-studio.code.org:3000/s/course3/stage/2/puzzle/1',
@@ -704,7 +695,6 @@ describe('progressReduxTest', () => {
             icon: null,
             isUnplugged: false,
             levelNumber: 1,
-            pageNumber: undefined,
             isCurrentLevel: false,
             isConceptLevel: false,
             paired: undefined,
@@ -712,7 +702,6 @@ describe('progressReduxTest', () => {
             sublevels: []
           },
           {
-            id: 339,
             status: 'perfect',
             url:
               'http://localhost-studio.code.org:3000/s/course3/stage/2/puzzle/2',
@@ -724,7 +713,6 @@ describe('progressReduxTest', () => {
             icon: null,
             isUnplugged: false,
             levelNumber: 2,
-            pageNumber: undefined,
             isCurrentLevel: false,
             isConceptLevel: false,
             paired: undefined,
@@ -732,7 +720,6 @@ describe('progressReduxTest', () => {
             sublevels: []
           },
           {
-            id: 341,
             status: 'attempted',
             url:
               'http://localhost-studio.code.org:3000/s/course3/stage/2/puzzle/3',
@@ -744,7 +731,6 @@ describe('progressReduxTest', () => {
             icon: null,
             isUnplugged: false,
             levelNumber: 3,
-            pageNumber: undefined,
             isCurrentLevel: false,
             isConceptLevel: false,
             paired: undefined,
@@ -811,7 +797,7 @@ describe('progressReduxTest', () => {
     it('sets isCurrentLevel to true for current level only', () => {
       const initializedState = {
         ...reducer(undefined, initProgress(initialScriptOverviewProgress)),
-        currentLevelId: stageData[0].levels[1].activeId
+        currentLevelId: stageData[0].levels[1].activeId.toString()
       };
 
       const stageId = stageData[0].id;

--- a/apps/test/unit/templates/lessonOverview/activities/ProgressionDetailsTest.jsx
+++ b/apps/test/unit/templates/lessonOverview/activities/ProgressionDetailsTest.jsx
@@ -12,7 +12,7 @@ describe('ProgressionDetails', () => {
     };
   });
 
-  it('renders default props and ProgressLevelSet', () => {
+  it('renders default props', () => {
     const wrapper = shallow(<ProgressionDetails {...defaultProps} />);
     expect(wrapper.find('ProgressLevelSet').length).to.equal(1);
   });

--- a/apps/test/unit/templates/progress/ProgressBubbleTest.js
+++ b/apps/test/unit/templates/progress/ProgressBubbleTest.js
@@ -7,7 +7,6 @@ import {LevelStatus, LevelKind} from '@cdo/apps/util/sharedConstants';
 
 const defaultProps = {
   level: {
-    id: 1,
     levelNumber: 1,
     status: LevelStatus.perfect,
     url: '/foo/bar',
@@ -298,7 +297,6 @@ describe('ProgressBubble', () => {
 
   it('renders a progress pill for unplugged lessons', () => {
     const unpluggedLevel = {
-      id: 1,
       status: LevelStatus.perfect,
       kind: LevelKind.unplugged,
       url: '/foo/bar',
@@ -317,7 +315,6 @@ describe('ProgressBubble', () => {
 
   it('does not render a progress pill for unplugged when small', () => {
     const unpluggedLevel = {
-      id: 1,
       status: LevelStatus.perfect,
       kind: LevelKind.unplugged,
       url: '/foo/bar',

--- a/apps/test/unit/templates/progress/ProgressLevelSetTest.js
+++ b/apps/test/unit/templates/progress/ProgressLevelSetTest.js
@@ -1,4 +1,4 @@
-import {assert} from '../../../util/reconfiguredChai';
+import {assert} from '../../../util/deprecatedChai';
 import React from 'react';
 import {shallow} from 'enzyme';
 import ProgressLevelSet from '@cdo/apps/templates/progress/ProgressLevelSet';

--- a/apps/test/unit/templates/progress/ProgressPillTest.js
+++ b/apps/test/unit/templates/progress/ProgressPillTest.js
@@ -6,14 +6,12 @@ import {LevelStatus, LevelKind} from '@cdo/apps/util/sharedConstants';
 import ReactTooltip from 'react-tooltip';
 
 const unpluggedLevel = {
-  id: 1,
   kind: LevelKind.unplugged,
   isUnplugged: true,
   status: LevelStatus.perfect
 };
 
 const assessmentLevel = {
-  id: 2,
   kind: LevelKind.assessment,
   isUnplugged: false,
   status: LevelStatus.perfect

--- a/dashboard/app/models/lesson.rb
+++ b/dashboard/app/models/lesson.rb
@@ -245,7 +245,6 @@ class Lesson < ApplicationRecord
         lesson_data[:levels] += extra_levels
         last_level_summary[:uid] = "#{last_level_summary[:ids].first}_0"
         last_level_summary[:url] << "/page/1"
-        last_level_summary[:page_number] = 1
       end
 
       # Don't want lesson plans for lockable levels

--- a/dashboard/app/models/levels/bubble_choice.rb
+++ b/dashboard/app/models/levels/bubble_choice.rb
@@ -77,7 +77,6 @@ class BubbleChoice < DSLDefined
   def summarize(script_level: nil, user: nil)
     user_id = user ? user.id : nil
     summary = {
-      id: id,
       display_name: display_name,
       description: description,
       name: name,
@@ -135,10 +134,6 @@ class BubbleChoice < DSLDefined
       if user_id
         level_info[:perfect] = UserLevel.find_by(level: level, user_id: user_id)&.perfect?
         level_info[:status] = level_info[:perfect] ? SharedConstants::LEVEL_STATUS.perfect : SharedConstants::LEVEL_STATUS.not_tried
-      else
-        # Pass an empty status if the user is not logged in so the ProgressBubble
-        # in the sublevel display can render correctly.
-        level_info[:status] = SharedConstants::LEVEL_STATUS.not_tried
       end
 
       summary << level_info

--- a/dashboard/app/models/script_level.rb
+++ b/dashboard/app/models/script_level.rb
@@ -490,7 +490,6 @@ class ScriptLevel < ApplicationRecord
     (1..extra_level_count).each do |page_index|
       new_level = last_level_summary.deep_dup
       new_level[:uid] = "#{level_id}_#{page_index}"
-      new_level[:page_number] = page_index + 1
       new_level[:url] << "/page/#{page_index + 1}"
       new_level[:position] = last_level_summary[:position] + page_index
       new_level[:title] = last_level_summary[:position] + page_index
@@ -523,26 +522,13 @@ class ScriptLevel < ApplicationRecord
     lesson_extra_user_level = student.user_levels.where(script: script, level: bonus_level_ids)&.first
     if lesson_extra_user_level
       {
-        id: lesson_extra_user_level.id,
         bonus: true,
         user_id: student.id,
         status: SharedConstants::LEVEL_STATUS.perfect,
         passed: true
       }.merge!(lesson_extra_user_level.attributes)
-    elsif bonus_level_ids.count == 0
-      {
-        # Some lessons have a lesson extras option without any bonus levels. In
-        # these cases, they just display previous lesson challenges. These should
-        # be displayed as "perfect." Example level: /s/express-2020/stage/28/extras
-        id: -1,
-        bonus: true,
-        user_id: student.id,
-        passed: true,
-        status: SharedConstants::LEVEL_STATUS.perfect
-      }
     else
       {
-        id: bonus_level_ids.first,
         bonus: true,
         user_id: student.id,
         passed: false,
@@ -579,7 +565,6 @@ class ScriptLevel < ApplicationRecord
     end
 
     teacher_panel_summary = {
-      id: level.id,
       contained: contained,
       submitLevel: level.properties['submittable'] == 'true',
       paired: paired,

--- a/dashboard/app/views/layouts/_header.html.haml
+++ b/dashboard/app/views/layouts/_header.html.haml
@@ -105,6 +105,14 @@
     # don't trust outside content in parameter :puzzle_page - should be integer, so immediately call to_i
     puzzle_page = params[:puzzle_page] ? params[:puzzle_page].to_i : ApplicationHelper::PUZZLE_PAGE_NONE
 
+    if script_level
+      uid = params[:puzzle_page] ? "#{script_level.level_id}_#{puzzle_page - 1}" : script_level.level_id.to_s
+    else
+      # A bit of an abuse of uid, we dont have a specific level id in this case, so just use a hardcoded string
+      uid = SharedConstants::LEVEL_KIND.stage_extras
+    end
+
+
     script_data = script.summarize_header
     lesson_group_data = script.lesson_groups.map(&:summarize)
     stage_data = (@stage || script_level.lesson).summarize
@@ -142,12 +150,11 @@
       #{lesson_group_data.to_json},
       #{stage_data.to_json},
       #{user_progress},
-      #{script_level&.level_id || -1},
+      "#{uid}",
       #{puzzle_page},
       #{signed_in},
       #{lesson_extras_enabled || 'null'},
-      #{script_name_data.to_json},
-      #{!script_level},
+      #{script_name_data.to_json}
     )
     //]]>
 

--- a/dashboard/test/models/levels/bubble_choice_test.rb
+++ b/dashboard/test/models/levels/bubble_choice_test.rb
@@ -95,7 +95,6 @@ DSL
   test 'summarize' do
     summary = @bubble_choice.summarize
     expected_summary = {
-      id: @bubble_choice.id,
       display_name: @bubble_choice.display_name,
       description: @bubble_choice.description,
       name: @bubble_choice.name,
@@ -137,8 +136,7 @@ DSL
         name: @sublevel1.name,
         position: 1,
         letter: 'a',
-        icon: nil,
-        status: 'not_tried'
+        icon: nil
       },
       {
         level_id: @sublevel2.id,
@@ -151,8 +149,7 @@ DSL
         name: @sublevel2.name,
         position: 2,
         letter: 'b',
-        icon: nil,
-        status: 'not_tried'
+        icon: nil
       }
     ]
 

--- a/dashboard/test/models/script_level_test.rb
+++ b/dashboard/test/models/script_level_test.rb
@@ -160,7 +160,6 @@ class ScriptLevelTest < ActiveSupport::TestCase
     script_level = create_script_level_with_ancestors({levels: [bubble_choice]})
 
     expected_summary = {
-      id: bubble_choice.id,
       contained: false,
       submitLevel: false,
       paired: nil,
@@ -238,7 +237,7 @@ class ScriptLevelTest < ActiveSupport::TestCase
     student = create :student
     script_level = create_script_level_with_ancestors({bonus: true})
 
-    summary = ScriptLevel.summarize_as_bonus_for_teacher_panel(script_level.script, [script_level.id], student)
+    summary = ScriptLevel.summarize_as_bonus_for_teacher_panel(script_level.script, script_level.id, student)
     assert_equal true, summary[:bonus]
     assert_equal LEVEL_STATUS.not_tried, summary[:status]
     assert_equal false, summary[:passed]


### PR DESCRIPTION
Reverts code-dot-org/code-dot-org#38085

Full details: https://codedotorg.slack.com/archives/C0T0PNTM3/p1610395456498700

The header went missing on at least some levels in IE11. 
The error appears to be related to header.build, but further investigation is needed.
![image](https://user-images.githubusercontent.com/8324574/104235458-dcc0e500-5409-11eb-8adc-34042d4f0509.png)