### PR TITLE
Show vocab on lesson overview

### DIFF
--- a/apps/src/templates/lessonOverview/LessonOverview.jsx
+++ b/apps/src/templates/lessonOverview/LessonOverview.jsx
@@ -207,6 +207,20 @@ class LessonOverview extends Component {
                 )}
               </div>
             )}
+            {lesson.vocabularies.length > 0 && (
+              <div>
+                <h2 style={styles.titleNoTopMargin}>{i18n.vocabulary()}</h2>
+                <ul>
+                  {lesson.vocabularies.map(vocab => (
+                    <li key={vocab.key}>
+                      <InlineMarkdown
+                        markdown={`**${vocab.word}** - ${vocab.definition}`}
+                      />
+                    </li>
+                  ))}
+                </ul>
+              </div>
+            )}
           </div>
         </div>
 

--- a/apps/src/templates/lessonOverview/lessonPlanShapes.jsx
+++ b/apps/src/templates/lessonOverview/lessonPlanShapes.jsx
@@ -22,6 +22,7 @@ export const lessonShape = PropTypes.shape({
   purpose: PropTypes.string.isRequired,
   preparation: PropTypes.string.isRequired,
   resources: PropTypes.object,
+  vocabularies: PropTypes.arrayOf(PropTypes.object).isRequired,
   objectives: PropTypes.arrayOf(PropTypes.object).isRequired,
   assessmentOpportunities: PropTypes.string.isRequired
 });

--- a/apps/test/unit/templates/lessonOverview/LessonNavigationDropdownTest.jsx
+++ b/apps/test/unit/templates/lessonOverview/LessonNavigationDropdownTest.jsx
@@ -44,6 +44,7 @@ let lesson = {
   position: 1,
   resources: {},
   objectives: [],
+  vocabularies: [],
   displayName: 'Lesson 1',
   overview: 'Lesson Overview',
   purpose: 'The purpose of the lesson is for people to learn',

--- a/apps/test/unit/templates/lessonOverview/LessonOverviewTest.js
+++ b/apps/test/unit/templates/lessonOverview/LessonOverviewTest.js
@@ -62,7 +62,14 @@ describe('LessonOverview', () => {
             }
           ]
         },
-        objectives: [{id: 1, description: 'what students will learn'}]
+        objectives: [{id: 1, description: 'what students will learn'}],
+        vocabularies: [
+          {
+            key: 'Algorithm',
+            word: 'Algorithm',
+            definition: 'A list of steps to finish a task.'
+          }
+        ]
       },
       activities: [],
       announcements: [],
@@ -92,8 +99,14 @@ describe('LessonOverview', () => {
     expect(safeMarkdowns.at(3).props().markdown).to.contain('- One');
 
     const inlineMarkdowns = wrapper.find('InlineMarkdown');
+
+    // The first contains the objective
     expect(inlineMarkdowns.at(0).props().markdown).to.contain(
       'what students will learn'
+    );
+    // The second contains the vocabulary
+    expect(inlineMarkdowns.at(1).props().markdown).to.contain(
+      '**Algorithm** - A list of steps to finish a task.'
     );
 
     expect(wrapper.find('LessonAgenda').length).to.equal(1);

--- a/dashboard/app/models/lesson.rb
+++ b/dashboard/app/models/lesson.rb
@@ -322,6 +322,7 @@ class Lesson < ApplicationRecord
       preparation: preparation || '',
       activities: lesson_activities.map(&:summarize_for_lesson_show),
       resources: resources_for_lesson_plan(user&.authorized_teacher?),
+      vocabularies: vocabularies.map(&:summarize_for_lesson_show),
       objectives: objectives.map(&:summarize_for_lesson_show),
       is_teacher: user&.teacher?,
       assessmentOpportunities: assessment_opportunities

--- a/dashboard/app/models/vocabulary.rb
+++ b/dashboard/app/models/vocabulary.rb
@@ -18,4 +18,18 @@
 class Vocabulary < ApplicationRecord
   has_and_belongs_to_many :lessons, join_table: :lessons_vocabularies
   belongs_to :course_version
+
+  def summarize_for_lesson_show
+    {key: key, word: display_word, definition: display_definition}
+  end
+
+  private
+
+  def display_word
+    word
+  end
+
+  def display_definition
+    definition
+  end
 end


### PR DESCRIPTION
Adds a section for vocabulary on the lesson overview page.

To test this, I imported vocab using the script updates in #38486. I don't think it's a problem if this goes in before importing vocab from curriculumbuilder as the section will be hidden until any vocab is added.

![Screen Shot 2021-01-11 at 4 10 53 PM](https://user-images.githubusercontent.com/46464143/104253151-ae063700-5428-11eb-935d-7adad3f7c5b2.png)

<!-- ### Background -->
<!-- ### Privacy -->
<!--
1.	Does the Project involve the collection, use or sharing of new Personal Data?

2.	Does the Project involve a new or changed use or sharing of existing Personal Data?
-->
<!-- ### Security -->
<!--
Link to Jira Task where sensitive security issues are discussed privately.
-->
<!-- ### Caching -->
<!-- ### Deployment strategy -->
<!-- ### Future work -->

## Links

<!--
  Any relevant links to external resources; ie, specification documents, jira
  items, related PRs, honeybadger errors, etc
-->

- [spec]()
- [jira]()

## Testing story

<!--
  Does your change include appropriate tests?

  If so, please describe how the tests included in this PR are sufficient

  If not, please explain why this change does not need to be tested.
-->

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
