### PR TITLE
Temporarily turn off sorting by popularity

### DIFF
--- a/pegasus/src/database.rb
+++ b/pegasus/src/database.rb
@@ -84,7 +84,10 @@ class Tutorials
   end
 
   def self.sort_by_popularity?(site, hoc_mode)
-    ("post-hoc" == hoc_mode) || (site == 'code.org' && [false, 'pre-hoc'].include?(hoc_mode))
+    # temporarily turning off sorting by popularity so that a new popularity rank can be established
+    false
+    # after new popularity rank is established, re-enable:
+    # ("post-hoc" == hoc_mode) || (site == 'code.org' && [false, 'pre-hoc'].include?(hoc_mode))
   end
 end
 

--- a/pegasus/test/test_tutorials.rb
+++ b/pegasus/test/test_tutorials.rb
@@ -27,37 +27,47 @@ class TutorialsTest < Minitest::Test
     refute_equal Tutorials.new(:tutorials).contents('code.org').first[:image], tutorial[:image]
   end
 
-  def test_sort_by_popularity_code_org
+  # sort_by_popularity temporarily returns false while we gather new popularity ranking
+  def test_sort_by_popularity_temp
     code_org = "code.org"
 
-    assert Tutorials.sort_by_popularity?(code_org, "post-hoc")
-    assert Tutorials.sort_by_popularity?(code_org, "pre-hoc")
-    assert Tutorials.sort_by_popularity?(code_org, false)
-
-    refute Tutorials.sort_by_popularity?(code_org, "bad data")
-    refute Tutorials.sort_by_popularity?(code_org, "soon-hoc")
-    refute Tutorials.sort_by_popularity?(code_org, "actual-hoc")
+    refute Tutorials.sort_by_popularity?(code_org, "post-hoc")
+    refute Tutorials.sort_by_popularity?(code_org, "pre-hoc")
+    refute Tutorials.sort_by_popularity?(code_org, false)
   end
 
-  def test_sort_by_popularity_hour_of_code_com
-    hour_of_code = "hourofcode.com"
+  # re-enable when new popularity ranking data has been gathered:
+  # def test_sort_by_popularity_code_org
+  #   code_org = "code.org"
 
-    assert Tutorials.sort_by_popularity?(hour_of_code, "post-hoc")
+  #   assert Tutorials.sort_by_popularity?(code_org, "post-hoc")
+  #   assert Tutorials.sort_by_popularity?(code_org, "pre-hoc")
+  #   assert Tutorials.sort_by_popularity?(code_org, false)
 
-    refute Tutorials.sort_by_popularity?(hour_of_code, "pre-hoc")
-    refute Tutorials.sort_by_popularity?(hour_of_code, "actual-hoc")
-    refute Tutorials.sort_by_popularity?(hour_of_code, false)
-    refute Tutorials.sort_by_popularity?(hour_of_code, "not a value")
-  end
+  #   refute Tutorials.sort_by_popularity?(code_org, "bad data")
+  #   refute Tutorials.sort_by_popularity?(code_org, "soon-hoc")
+  #   refute Tutorials.sort_by_popularity?(code_org, "actual-hoc")
+  # end
 
-  def test_sort_by_popularity_cs_ed_week_org
-    cs_ed_week = "csedweek.org"
+  # def test_sort_by_popularity_hour_of_code_com
+  #   hour_of_code = "hourofcode.com"
 
-    assert Tutorials.sort_by_popularity?(cs_ed_week, "post-hoc")
+  #   assert Tutorials.sort_by_popularity?(hour_of_code, "post-hoc")
 
-    refute Tutorials.sort_by_popularity?(cs_ed_week, "pre-hoc")
-    refute Tutorials.sort_by_popularity?(cs_ed_week, "soon-hoc")
-    refute Tutorials.sort_by_popularity?(cs_ed_week, false)
-    refute Tutorials.sort_by_popularity?(cs_ed_week, "unexpected")
-  end
+  #   refute Tutorials.sort_by_popularity?(hour_of_code, "pre-hoc")
+  #   refute Tutorials.sort_by_popularity?(hour_of_code, "actual-hoc")
+  #   refute Tutorials.sort_by_popularity?(hour_of_code, false)
+  #   refute Tutorials.sort_by_popularity?(hour_of_code, "not a value")
+  # end
+
+  # def test_sort_by_popularity_cs_ed_week_org
+  #   cs_ed_week = "csedweek.org"
+
+  #   assert Tutorials.sort_by_popularity?(cs_ed_week, "post-hoc")
+
+  #   refute Tutorials.sort_by_popularity?(cs_ed_week, "pre-hoc")
+  #   refute Tutorials.sort_by_popularity?(cs_ed_week, "soon-hoc")
+  #   refute Tutorials.sort_by_popularity?(cs_ed_week, false)
+  #   refute Tutorials.sort_by_popularity?(cs_ed_week, "unexpected")
+  # end
 end


### PR DESCRIPTION
<!--
  Your description goes here: A summary of the change, including any relevant motivation and context.

  If relevant, include a description both of the existing behavior and of the new behavior.
-->

Previously the Activities page (https://code.org/learn) default sort was popularity, in order for us to get a new popularity ranking for activities for 2021, we need to turn off popularity sorting so that the old ranking doesn't influence the new ranking. When the new ranking has been determined these changes will be reverted.

<!--
  Other aspects to consider. uncomment and add detail for any that seem necessary:
-->

<!-- ### Background -->
<!-- ### Privacy -->
<!--
1.	Does the Project involve the collection, use or sharing of new Personal Data?

2.	Does the Project involve a new or changed use or sharing of existing Personal Data?
-->
<!-- ### Security -->
<!--
Link to Jira Task where sensitive security issues are discussed privately.
-->
https://codedotorg.atlassian.net/browse/LP-1698

<!-- ### Caching -->
<!-- ### Deployment strategy -->
<!-- ### Future work -->

## Links

<!--
  Any relevant links to external resources; ie, specification documents, jira
  items, related PRs, honeybadger errors, etc
-->

- [spec]()
- [jira]()

## Testing story

<!--
  Does your change include appropriate tests?

  If so, please describe how the tests included in this PR are sufficient

  If not, please explain why this change does not need to be tested.
-->

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
