### PR TITLE
Reintroduce: Make level ID required for level objects in React components

### DIFF
--- a/apps/src/code-studio/components/BubbleChoice.jsx
+++ b/apps/src/code-studio/components/BubbleChoice.jsx
@@ -1,10 +1,10 @@
 import React from 'react';
-import PropTypes from 'prop-types';
 import i18n from '@cdo/locale';
 import color from '@cdo/apps/util/color';
 import {navigateToHref} from '@cdo/apps/utils';
 import SafeMarkdown from '@cdo/apps/templates/SafeMarkdown';
 import SublevelCard from './SublevelCard';
+import {levelTypeWithoutStatus} from '@cdo/apps/templates/progress/progressTypes';
 
 const MARGIN = 10;
 
@@ -29,27 +29,9 @@ const styles = {
 };
 
 export default class BubbleChoice extends React.Component {
-  static propTypes = {
-    level: PropTypes.shape({
-      display_name: PropTypes.string.isRequired,
-      description: PropTypes.string.isRequired,
-      previous_level_url: PropTypes.string,
-      redirect_url: PropTypes.string,
-      script_url: PropTypes.string,
-      sublevels: PropTypes.arrayOf(
-        PropTypes.shape({
-          id: PropTypes.number.isRequired,
-          display_name: PropTypes.string.isRequired,
-          description: PropTypes.string,
-          thumbnail_url: PropTypes.string,
-          url: PropTypes.string.isRequired,
-          position: PropTypes.number,
-          letter: PropTypes.string,
-          perfect: PropTypes.bool
-        })
-      )
-    })
-  };
+  // The bubble choice component doesn't need the status. It's
+  // only rendering the sublevel cards.
+  static propTypes = {level: levelTypeWithoutStatus};
 
   goToUrl = url => {
     navigateToHref(url + location.search);

--- a/apps/src/code-studio/components/SublevelCard.jsx
+++ b/apps/src/code-studio/components/SublevelCard.jsx
@@ -7,6 +7,7 @@ import FontAwesome from '@cdo/apps/templates/FontAwesome';
 import LessonExtrasFlagIcon from '@cdo/apps/templates/progress/LessonExtrasFlagIcon';
 import MazeThumbnail from '@cdo/apps/code-studio/components/lessonExtras/MazeThumbnail';
 import queryString from 'query-string';
+import {levelTypeWithoutStatus} from '@cdo/apps/templates/progress/progressTypes';
 
 const THUMBNAIL_IMAGE_SIZE = 200;
 const MARGIN = 10;
@@ -84,18 +85,8 @@ const styles = {
 export default class SublevelCard extends React.Component {
   static propTypes = {
     isLessonExtra: PropTypes.bool,
-    sublevel: PropTypes.shape({
-      id: PropTypes.number.isRequired,
-      display_name: PropTypes.string.isRequired,
-      description: PropTypes.string,
-      thumbnail_url: PropTypes.string,
-      url: PropTypes.string.isRequired,
-      position: PropTypes.number,
-      letter: PropTypes.string,
-      perfect: PropTypes.bool,
-      type: PropTypes.string,
-      maze_summary: PropTypes.object
-    }),
+    // sublevels generally use "perfect" instead of status
+    sublevel: levelTypeWithoutStatus,
     sectionId: PropTypes.number,
     userId: PropTypes.number
   };

--- a/apps/src/code-studio/components/header/HeaderMiddle.jsx
+++ b/apps/src/code-studio/components/header/HeaderMiddle.jsx
@@ -6,7 +6,6 @@ import ScriptName from './ScriptName';
 import LessonProgress from '../progress/LessonProgress';
 import HeaderPopup from './HeaderPopup';
 import HeaderFinish from './HeaderFinish';
-import {lessonExtrasUrl} from '@cdo/apps/code-studio/progressRedux';
 import _ from 'lodash';
 import $ from 'jquery';
 
@@ -33,9 +32,8 @@ class HeaderMiddle extends React.Component {
     appLoaded: PropTypes.bool,
     scriptNameData: PropTypes.object,
     lessonData: PropTypes.object,
-    lessonExtrasUrl: PropTypes.string,
     scriptData: PropTypes.object,
-    currentLevelId: PropTypes.string,
+    currentLevelId: PropTypes.number,
     linesOfCodeText: PropTypes.string,
     isRtl: PropTypes.bool
   };
@@ -339,9 +337,5 @@ class HeaderMiddle extends React.Component {
 export default connect(state => ({
   isRtl: state.isRtl,
   appLoadStarted: state.header.appLoadStarted,
-  appLoaded: state.header.appLoaded,
-  lessonExtrasUrl: lessonExtrasUrl(
-    state.progress,
-    state.progress.currentStageId
-  )
+  appLoaded: state.header.appLoaded
 }))(HeaderMiddle);

--- a/apps/src/code-studio/components/header/HeaderPopup.jsx
+++ b/apps/src/code-studio/components/header/HeaderPopup.jsx
@@ -26,7 +26,7 @@ export default class HeaderPopup extends Component {
   static propTypes = {
     scriptName: PropTypes.string,
     scriptData: PropTypes.object,
-    currentLevelId: PropTypes.string,
+    currentLevelId: PropTypes.number,
     linesOfCodeText: PropTypes.string,
     minimal: PropTypes.bool,
     windowHeight: PropTypes.number

--- a/apps/src/code-studio/components/progress/LessonProgress.jsx
+++ b/apps/src/code-studio/components/progress/LessonProgress.jsx
@@ -203,7 +203,11 @@ class LessonProgress extends Component {
             {lessonTrophyEnabled && <div style={styles.spacer} />}
             {levels.map((level, index) => {
               let isCurrent = level.isCurrentLevel;
-              if (isCurrent && level.kind === LevelKind.assessment) {
+              if (
+                isCurrent &&
+                level.kind === LevelKind.assessment &&
+                level.pageNumber
+              ) {
                 isCurrent = currentPageNumber === level.pageNumber;
               }
               return (

--- a/apps/src/code-studio/components/progress/SelectedStudentInfo.jsx
+++ b/apps/src/code-studio/components/progress/SelectedStudentInfo.jsx
@@ -3,6 +3,7 @@ import React from 'react';
 import i18n from '@cdo/locale';
 import {TeacherPanelProgressBubble} from '@cdo/apps/code-studio/components/progress/TeacherPanelProgressBubble';
 import Button from '@cdo/apps/templates/Button';
+import {levelType} from '@cdo/apps/templates/progress/progressTypes';
 import {LevelStatus} from '@cdo/apps/util/sharedConstants';
 import Radium from 'radium';
 import FontAwesome from '@cdo/apps/templates/FontAwesome';
@@ -47,7 +48,7 @@ export class SelectedStudentInfo extends React.Component {
   static propTypes = {
     students: PropTypes.arrayOf(studentShape).isRequired,
     selectedStudent: PropTypes.object,
-    level: PropTypes.object,
+    level: levelType,
     onSelectUser: PropTypes.func.isRequired,
     getSelectedUserId: PropTypes.func.isRequired
   };

--- a/apps/src/code-studio/components/progress/StudentTable.jsx
+++ b/apps/src/code-studio/components/progress/StudentTable.jsx
@@ -3,6 +3,7 @@ import PropTypes from 'prop-types';
 import Radium from 'radium';
 import color from '@cdo/apps/util/color';
 import i18n from '@cdo/locale';
+import {levelType} from '@cdo/apps/templates/progress/progressTypes';
 import {TeacherPanelProgressBubble} from '@cdo/apps/code-studio/components/progress/TeacherPanelProgressBubble';
 import FontAwesome from '@cdo/apps/templates/FontAwesome';
 
@@ -62,7 +63,7 @@ class StudentTable extends React.Component {
     students: PropTypes.arrayOf(studentShape).isRequired,
     onSelectUser: PropTypes.func.isRequired,
     getSelectedUserId: PropTypes.func.isRequired,
-    levels: PropTypes.array,
+    levels: PropTypes.arrayOf(levelType),
     sectionId: PropTypes.number,
     scriptName: PropTypes.string
   };

--- a/apps/src/code-studio/components/progress/TeacherPanelProgressBubble.jsx
+++ b/apps/src/code-studio/components/progress/TeacherPanelProgressBubble.jsx
@@ -1,5 +1,4 @@
 import React from 'react';
-import PropTypes from 'prop-types';
 import color from '@cdo/apps/util/color';
 import FontAwesome from '@cdo/apps/templates/FontAwesome';
 import {
@@ -8,6 +7,7 @@ import {
   levelProgressStyle
 } from '@cdo/apps/templates/progress/progressStyles';
 import {LevelStatus} from '@cdo/apps/util/sharedConstants';
+import {levelType} from '@cdo/apps/templates/progress/progressTypes';
 
 /**
  * A TeacherPanelProgressBubble represents progress for a specific level in the TeacherPanel. It can be a circle
@@ -53,7 +53,7 @@ const styles = {
 
 export class TeacherPanelProgressBubble extends React.Component {
   static propTypes = {
-    level: PropTypes.object.isRequired
+    level: levelType.isRequired
   };
 
   render() {

--- a/apps/src/code-studio/header.js
+++ b/apps/src/code-studio/header.js
@@ -56,12 +56,15 @@ const PUZZLE_PAGE_NONE = -1;
  *   }>
  * }}
  * @param {object} progressData
- * @param {string} currentLevelId
- * @param {number} puzzlePage
+ * @param {number} currentLevelId
+ * @param {number} currentPageNumber The page we are on if this is a multi-
+ *   page level
  * @param {boolean} signedIn True/false if we know the sign in state of the
  *   user, null otherwise
  * @param {boolean} stageExtrasEnabled Whether this user is in a section with
  *   stageExtras enabled for this script
+ * @param {boolean} isLessonExtras Boolean indicating we are not on a script
+ *   level and therefore are on lesson extras
  */
 header.build = function(
   scriptData,
@@ -69,10 +72,11 @@ header.build = function(
   lessonData,
   progressData,
   currentLevelId,
-  puzzlePage,
+  currentPageNumber,
   signedIn,
   stageExtrasEnabled,
   scriptNameData,
+  isLessonExtras,
   hasAppOptions
 ) {
   const store = getStore();
@@ -86,8 +90,7 @@ header.build = function(
   progressData = progressData || {};
 
   const linesOfCodeText = progressData.linesOfCodeText;
-
-  let saveAnswersBeforeNavigation = puzzlePage !== PUZZLE_PAGE_NONE;
+  let saveAnswersBeforeNavigation = currentPageNumber !== PUZZLE_PAGE_NONE;
 
   // Set up the store immediately.
   progress.generateStageProgress(
@@ -98,7 +101,9 @@ header.build = function(
     currentLevelId,
     saveAnswersBeforeNavigation,
     signedIn,
-    stageExtrasEnabled
+    stageExtrasEnabled,
+    isLessonExtras,
+    currentPageNumber
   );
 
   // Hold off on rendering HeaderMiddle.  This will allow the "app load"

--- a/apps/src/code-studio/progress.js
+++ b/apps/src/code-studio/progress.js
@@ -78,6 +78,10 @@ progress.showDisabledBubblesAlert = function() {
  *   user, null otherwise
  * @param {boolean} stageExtrasEnabled Whether this user is in a section with
  *   stageExtras enabled for this script
+ * @param {boolean} isLessonExtras Boolean indicating we are not on a script
+ *   level and therefore are on lesson extras
+ * @param {number} currentPageNumber The page we are on if this is a multi-
+ *   page level
  */
 progress.generateStageProgress = function(
   scriptData,
@@ -87,7 +91,9 @@ progress.generateStageProgress = function(
   currentLevelId,
   saveAnswersBeforeNavigation,
   signedIn,
-  stageExtrasEnabled
+  stageExtrasEnabled,
+  isLessonExtras,
+  currentPageNumber
 ) {
   const store = getStore();
 
@@ -107,7 +113,9 @@ progress.generateStageProgress = function(
     },
     currentLevelId,
     false,
-    saveAnswersBeforeNavigation
+    saveAnswersBeforeNavigation,
+    isLessonExtras,
+    currentPageNumber
   );
 
   store.dispatch(
@@ -261,13 +269,19 @@ function queryUserProgress(store, scriptData, currentLevelId) {
  * @param {boolean} isFullProgress - True if this contains progress for the entire
  *   script vs. a single stage.
  * @param {boolean} [saveAnswersBeforeNavigation]
+ * @param {boolean} [isLessonExtras] Optional boolean indicating we are not on
+ *   a script level and therefore are on lesson extras
+ * @param {number} [currentPageNumber] Optional. The page we are on if this is
+ *   a multi-page level
  */
 function initializeStoreWithProgress(
   store,
   scriptData,
   currentLevelId,
   isFullProgress,
-  saveAnswersBeforeNavigation = false
+  saveAnswersBeforeNavigation = false,
+  isLessonExtras = false,
+  currentPageNumber
 ) {
   store.dispatch(
     initProgress({
@@ -284,7 +298,9 @@ function initializeStoreWithProgress(
       scriptStudentDescription: scriptData.studentDescription,
       betaTitle: scriptData.beta_title,
       courseId: scriptData.course_id,
-      isFullProgress: isFullProgress
+      isFullProgress: isFullProgress,
+      isLessonExtras: isLessonExtras,
+      currentPageNumber: currentPageNumber
     })
   );
 

--- a/apps/src/code-studio/progressRedux.js
+++ b/apps/src/code-studio/progressRedux.js
@@ -45,6 +45,7 @@ const initialState = {
   scriptName: null,
   scriptTitle: null,
   courseId: null,
+  isLessonExtras: false,
 
   // The remaining fields do change after initialization
   // a mapping of level id to result
@@ -65,7 +66,8 @@ const initialState = {
   // possible that we can get the user progress back from the DB
   // prior to having information about the user login state.
   // TODO: Use sign in state to determine where to source user progress from
-  usingDbProgress: false
+  usingDbProgress: false,
+  currentPageNumber: 0
 };
 
 /**
@@ -94,7 +96,9 @@ export default function reducer(state = initialState, action) {
       betaTitle: action.betaTitle,
       courseId: action.courseId,
       currentStageId,
-      hasFullProgress: action.isFullProgress
+      hasFullProgress: action.isFullProgress,
+      isLessonExtras: action.isLessonExtras,
+      currentPageNumber: action.currentPageNumber
     };
   }
 
@@ -398,7 +402,9 @@ export const initProgress = ({
   scriptStudentDescription,
   betaTitle,
   courseId,
-  isFullProgress
+  isFullProgress,
+  isLessonExtras,
+  currentPageNumber
 }) => ({
   type: INIT_PROGRESS,
   currentLevelId,
@@ -414,7 +420,9 @@ export const initProgress = ({
   scriptStudentDescription,
   betaTitle,
   courseId,
-  isFullProgress
+  isFullProgress,
+  isLessonExtras,
+  currentPageNumber
 });
 
 export const clearProgress = () => ({
@@ -548,8 +556,7 @@ const peerReviewLevels = state =>
 const isCurrentLevel = (currentLevelId, level) => {
   return (
     !!currentLevelId &&
-    ((level.ids &&
-      level.ids.map(id => id.toString()).indexOf(currentLevelId) !== -1) ||
+    ((level.ids && level.ids.indexOf(currentLevelId) !== -1) ||
       level.uid === currentLevelId)
   );
 };

--- a/apps/src/templates/FinishDialog.story.jsx
+++ b/apps/src/templates/FinishDialog.story.jsx
@@ -59,7 +59,7 @@ for (let i = 0; i < 20; i++) {
 }
 
 const mockProgress = {
-  currentLevelId: '123',
+  currentLevelId: 123,
   professionalLearningCourse: false,
   saveAnswersBeforeNavigation: false,
   stages: [

--- a/apps/src/templates/lessonOverview/activities/ProgressionDetails.jsx
+++ b/apps/src/templates/lessonOverview/activities/ProgressionDetails.jsx
@@ -33,6 +33,7 @@ export default class ProgressionDetails extends Component {
         : scriptLevel.levels[0];
 
     return {
+      id: activeLevel.id,
       status: LevelStatus.not_tried,
       url: scriptLevel.url,
       name: activeLevel.name,

--- a/apps/src/templates/progress/DetailProgressTable.story.jsx
+++ b/apps/src/templates/progress/DetailProgressTable.story.jsx
@@ -18,6 +18,7 @@ const lessons = [
 const levelsByLesson = [
   [
     {
+      id: 30,
       status: LevelStatus.not_tried,
       url: '/step1/level1',
       name: 'First progression',
@@ -28,6 +29,7 @@ const levelsByLesson = [
       progression: 'Second Progression'
     })),
     {
+      id: 40,
       status: LevelStatus.not_tried,
       url: '/step3/level1',
       name: 'Last progression',

--- a/apps/src/templates/progress/LessonGroup.story.jsx
+++ b/apps/src/templates/progress/LessonGroup.story.jsx
@@ -18,6 +18,7 @@ const lessons = [
 const levelsByLesson = [
   [
     {
+      id: 20,
       status: LevelStatus.not_tried,
       url: '/step1/level1',
       name: 'First progression',
@@ -28,6 +29,7 @@ const levelsByLesson = [
       progression: 'Second Progression'
     })),
     {
+      id: 21,
       status: LevelStatus.not_tried,
       url: '/step3/level1',
       name: 'Last progression',

--- a/apps/src/templates/progress/ProgressBubble.story.jsx
+++ b/apps/src/templates/progress/ProgressBubble.story.jsx
@@ -12,6 +12,7 @@ export default storybook => {
         story: () => (
           <ProgressBubble
             level={{
+              id: 1,
               levelNumber: 3,
               status: status,
               url: '/foo/bar',
@@ -27,6 +28,7 @@ export default storybook => {
           story: () => (
             <ProgressBubble
               level={{
+                id: 1,
                 levelNumber: 3,
                 status: LevelStatus.perfect,
                 url: '/foo/bar',
@@ -42,6 +44,7 @@ export default storybook => {
           story: () => (
             <ProgressBubble
               level={{
+                id: 1,
                 levelNumber: 3,
                 status: LevelStatus.perfect,
                 url: '/foo/bar',
@@ -57,6 +60,7 @@ export default storybook => {
           story: () => (
             <ProgressBubble
               level={{
+                id: 1,
                 levelNumber: 3,
                 status: LevelStatus.perfect,
                 url: '/foo/bar',
@@ -73,6 +77,7 @@ export default storybook => {
           story: () => (
             <ProgressBubble
               level={{
+                id: 1,
                 levelNumber: 3,
                 status: LevelStatus.perfect,
                 url: '/foo/bar',
@@ -91,6 +96,7 @@ export default storybook => {
           story: () => (
             <ProgressBubble
               level={{
+                id: 1,
                 levelNumber: 3,
                 status: LevelStatus.attempted,
                 url: '/foo/bar',

--- a/apps/src/templates/progress/ProgressLegend.jsx
+++ b/apps/src/templates/progress/ProgressLegend.jsx
@@ -157,6 +157,7 @@ export default class ProgressLegend extends Component {
               <div style={styles.center}>
                 <ProgressBubble
                   level={{
+                    id: 1,
                     status: LevelStatus.not_tried,
                     isConceptLevel: true,
                     name: `${i18n.concept()}: ${i18n.notStarted()}`
@@ -169,6 +170,7 @@ export default class ProgressLegend extends Component {
               <div style={styles.center}>
                 <ProgressBubble
                   level={{
+                    id: 1,
                     status: LevelStatus.attempted,
                     isConceptLevel: true,
                     name: `${i18n.concept()}: ${i18n.inProgress()}`
@@ -182,6 +184,7 @@ export default class ProgressLegend extends Component {
               <div style={styles.center}>
                 <ProgressBubble
                   level={{
+                    id: 1,
                     status: LevelStatus.perfect,
                     isConceptLevel: true,
                     name: `${i18n.concept()}: ${i18n.completed()} (${i18n.perfect()})`
@@ -230,6 +233,7 @@ export default class ProgressLegend extends Component {
               <div style={styles.center}>
                 <ProgressBubble
                   level={{
+                    id: 1,
                     status: LevelStatus.not_tried,
                     isConceptLevel: false,
                     name: `${i18n.activity()}: ${i18n.notStarted()}`
@@ -242,6 +246,7 @@ export default class ProgressLegend extends Component {
               <div style={styles.center}>
                 <ProgressBubble
                   level={{
+                    id: 1,
                     status: LevelStatus.attempted,
                     isConceptLevel: false,
                     name: `${i18n.activity()}: ${i18n.inProgress()}`
@@ -255,6 +260,7 @@ export default class ProgressLegend extends Component {
                 <div style={styles.center}>
                   <ProgressBubble
                     level={{
+                      id: 1,
                       status: LevelStatus.passed,
                       isConceptLevel: false,
                       name: `${i18n.activity()}: ${i18n.completed()} (${i18n.tooManyBlocks()})`
@@ -268,6 +274,7 @@ export default class ProgressLegend extends Component {
               <div style={styles.center}>
                 <ProgressBubble
                   level={{
+                    id: 1,
                     status: LevelStatus.perfect,
                     isConceptLevel: false,
                     name: `${i18n.activity()}: ${i18n.completed()} (${i18n.perfect()})`
@@ -280,6 +287,7 @@ export default class ProgressLegend extends Component {
               <div style={styles.center}>
                 <ProgressBubble
                   level={{
+                    id: 1,
                     status: LevelStatus.submitted,
                     isConceptLevel: false,
                     name: `${i18n.activity()}: ${i18n.submitted()}`

--- a/apps/src/templates/progress/ProgressPill.story.jsx
+++ b/apps/src/templates/progress/ProgressPill.story.jsx
@@ -10,6 +10,7 @@ export default storybook => {
         <ProgressPill
           levels={[
             {
+              id: 1,
               url: '/level1',
               status: LevelStatus.perfect
             }
@@ -25,10 +26,12 @@ export default storybook => {
         <ProgressPill
           levels={[
             {
+              id: 1,
               url: '/level1',
               status: LevelStatus.perfect
             },
             {
+              id: 2,
               url: '/level2',
               status: LevelStatus.not_tried
             }
@@ -44,6 +47,7 @@ export default storybook => {
         <ProgressPill
           levels={[
             {
+              id: 1,
               url: '/level1',
               status: LevelStatus.perfect
             }

--- a/apps/src/templates/progress/progressHelpers.js
+++ b/apps/src/templates/progress/progressHelpers.js
@@ -170,6 +170,7 @@ export function summarizeProgressInStage(levelsWithStatus) {
  */
 export const processedLevel = level => {
   return {
+    id: level.activeId || level.id,
     url: level.url,
     name: level.name,
     progression: level.progression,
@@ -180,6 +181,8 @@ export const processedLevel = level => {
     levelNumber: level.kind === LevelKind.unplugged ? undefined : level.title,
     isConceptLevel: level.is_concept_level,
     bonus: level.bonus,
-    sublevels: level.sublevels
+    pageNumber: level.page_number,
+    sublevels:
+      level.sublevels && level.sublevels.map(level => processedLevel(level))
   };
 };

--- a/apps/src/templates/progress/progressTestHelpers.js
+++ b/apps/src/templates/progress/progressTestHelpers.js
@@ -24,8 +24,9 @@ export const fakeLesson = (
 });
 
 export const fakeLevel = overrides => {
-  const levelNumber = overrides.levelNumber;
+  const levelNumber = overrides.levelNumber || 1;
   return {
+    id: levelNumber,
     status: LevelStatus.not_tried,
     url: `/level${levelNumber}`,
     name: `Level ${levelNumber}`,

--- a/apps/src/templates/progress/progressTypes.js
+++ b/apps/src/templates/progress/progressTypes.js
@@ -1,7 +1,20 @@
 import PropTypes from 'prop-types';
 
-export const levelType = PropTypes.shape({
-  status: PropTypes.string.isRequired,
+/**
+ * @typedef {Object} Level
+ *
+ * @property {number} id
+ * @property {string} url
+ * @property {string} name
+ * @property {string} icon
+ * @property {bool} isUnplugged
+ * @property {number} levelNumber
+ * @property {bool} isCurrentLevel
+ * @property {bool} isConceptLevel
+ * @property {string} kind
+ */
+const levelWithoutStatusShape = {
+  id: PropTypes.number.isRequired,
   url: PropTypes.string,
   name: PropTypes.string,
   icon: PropTypes.string,
@@ -9,8 +22,26 @@ export const levelType = PropTypes.shape({
   levelNumber: PropTypes.number,
   isCurrentLevel: PropTypes.bool,
   isConceptLevel: PropTypes.bool,
-  kind: PropTypes.string,
-  sublevels: PropTypes.arrayOf(PropTypes.object)
+  kind: PropTypes.string
+};
+
+// Avoid recursive definition
+levelWithoutStatusShape.sublevels = PropTypes.arrayOf(
+  PropTypes.shape(levelWithoutStatusShape)
+);
+
+// In the future when the level object does not contain the status object,
+// we can export just levelType without needing levelTypeWithoutStatus.
+export const levelTypeWithoutStatus = PropTypes.shape(levelWithoutStatusShape);
+
+/**
+ * @typedef {Object} Level
+ *
+ * @property {string} status
+ */
+export const levelType = PropTypes.shape({
+  ...levelWithoutStatusShape,
+  status: PropTypes.string.isRequired
 });
 
 /**

--- a/apps/src/templates/sectionProgress/detail/StudentProgressDetailCell.jsx
+++ b/apps/src/templates/sectionProgress/detail/StudentProgressDetailCell.jsx
@@ -1,6 +1,7 @@
 import PropTypes from 'prop-types';
 import React, {Component} from 'react';
 import ProgressBubbleSet from '@cdo/apps/templates/progress/ProgressBubbleSet';
+import {levelType} from '@cdo/apps/templates/progress/progressTypes';
 
 const styles = {
   bubbles: {
@@ -16,7 +17,7 @@ export default class StudentProgressDetailCell extends Component {
     studentId: PropTypes.number.isRequired,
     stageId: PropTypes.number.isRequired,
     sectionId: PropTypes.number.isRequired,
-    levelsWithStatus: PropTypes.arrayOf(PropTypes.object),
+    levelsWithStatus: PropTypes.arrayOf(levelType),
     stageExtrasEnabled: PropTypes.bool
   };
 

--- a/apps/test/unit/code-studio/components/BubbleChoiceTest.js
+++ b/apps/test/unit/code-studio/components/BubbleChoiceTest.js
@@ -30,6 +30,7 @@ const fakeSublevels = [
 
 const DEFAULT_PROPS = {
   level: {
+    id: 123,
     display_name: 'Bubble Choice',
     description: 'Choose one or more levels!',
     sublevels: fakeSublevels,

--- a/apps/test/unit/code-studio/components/progress/LessonProgressTest.js
+++ b/apps/test/unit/code-studio/components/progress/LessonProgressTest.js
@@ -8,11 +8,12 @@ describe('LessonProgress', () => {
   const defaultProps = {
     levels: [
       {
+        id: 123,
         status: LevelStatus.not_tried
       }
     ],
     stageId: 1,
-    onLessonExtras: false
+    isLessonExtras: false
   };
 
   it('uses progress bubbles', () => {

--- a/apps/test/unit/code-studio/components/progress/SelectedStudentInfoTest.jsx
+++ b/apps/test/unit/code-studio/components/progress/SelectedStudentInfoTest.jsx
@@ -7,6 +7,7 @@ import {LevelStatus} from '@cdo/apps/util/sharedConstants';
 const defaultProps = {
   selectedStudent: {id: 1, name: 'Student 1'},
   level: {
+    id: 123,
     assessment: null,
     contained: false,
     driver: null,

--- a/apps/test/unit/code-studio/components/progress/StudentTableTest.jsx
+++ b/apps/test/unit/code-studio/components/progress/StudentTableTest.jsx
@@ -13,6 +13,7 @@ const MINIMUM_PROPS = {
 
 const levels = [
   {
+    id: 11,
     assessment: null,
     contained: false,
     driver: null,
@@ -26,6 +27,7 @@ const levels = [
     user_id: 1
   },
   {
+    id: 22,
     assessment: null,
     contained: false,
     driver: null,

--- a/apps/test/unit/code-studio/components/progress/TeacherPanelProgressBubbleTest.jsx
+++ b/apps/test/unit/code-studio/components/progress/TeacherPanelProgressBubbleTest.jsx
@@ -7,6 +7,7 @@ import {LevelKind, LevelStatus} from '@cdo/apps/util/sharedConstants';
 
 const defaultProps = {
   level: {
+    id: 123,
     assessment: null,
     contained: false,
     driver: null,

--- a/apps/test/unit/code-studio/components/progress/TeacherPanelTest.jsx
+++ b/apps/test/unit/code-studio/components/progress/TeacherPanelTest.jsx
@@ -8,6 +8,7 @@ import SectionSelector from '@cdo/apps/code-studio/components/progress/SectionSe
 import ViewAsToggle from '@cdo/apps/code-studio/components/progress/ViewAsToggle';
 import i18n from '@cdo/locale';
 import FontAwesome from '../../../../../src/templates/FontAwesome';
+import {LevelStatus} from '@cdo/apps/util/sharedConstants';
 
 const students = [{id: 1, name: 'Student 1'}, {id: 2, name: 'Student 2'}];
 
@@ -217,7 +218,13 @@ describe('TeacherPanel', () => {
               section: {
                 students: students
               },
-              section_script_levels: [{user_id: 1}]
+              section_script_levels: [
+                {
+                  id: 11,
+                  user_id: 1,
+                  status: LevelStatus.not_tried
+                }
+              ]
             }}
           />
         );
@@ -250,7 +257,13 @@ describe('TeacherPanel', () => {
               section: {
                 students: students
               },
-              section_script_levels: [{user_id: 1}]
+              section_script_levels: [
+                {
+                  id: 11,
+                  user_id: 1,
+                  status: LevelStatus.not_tried
+                }
+              ]
             }}
           />
         );
@@ -268,7 +281,13 @@ describe('TeacherPanel', () => {
               section: {
                 students: students
               },
-              section_script_levels: [{user_id: 1}]
+              section_script_levels: [
+                {
+                  id: 11,
+                  user_id: 1,
+                  status: LevelStatus.not_tried
+                }
+              ]
             }}
           />
         );

--- a/apps/test/unit/code-studio/progressReduxTest.js
+++ b/apps/test/unit/code-studio/progressReduxTest.js
@@ -60,6 +60,7 @@ const stageData = [
         ids: [323],
         activeId: 323,
         position: 2,
+        page_number: 1,
         kind: LevelKind.assessment,
         icon: null,
         title: 1,
@@ -73,6 +74,7 @@ const stageData = [
         ids: [322],
         activeId: 322,
         position: 3,
+        page_number: 2,
         kind: LevelKind.assessment,
         icon: null,
         title: 2,
@@ -164,7 +166,7 @@ const initialScriptOverviewProgress = {
 
 // The initial progress passed to the puzzle page
 const initialPuzzlePageProgress = {
-  currentLevelId: '341',
+  currentLevelId: 341,
   professionalLearningCourse: false,
   saveAnswersBeforeNavigation: false,
   lessonGroups: [],
@@ -198,7 +200,7 @@ describe('progressReduxTest', () => {
       const action = initProgress(initialPuzzlePageProgress);
       const nextState = reducer(undefined, action);
 
-      assert.equal(nextState.currentLevelId, '341');
+      assert.equal(nextState.currentLevelId, 341);
       assert.equal(nextState.professionalLearningCourse, false);
       assert.equal(nextState.saveAnswersBeforeNavigation, false);
       assert.deepEqual(
@@ -628,6 +630,7 @@ describe('progressReduxTest', () => {
       const expected = [
         [
           {
+            id: 2106,
             status: 'not_tried',
             url:
               'http://localhost-studio.code.org:3000/s/course3/stage/1/puzzle/1',
@@ -639,6 +642,7 @@ describe('progressReduxTest', () => {
             icon: null,
             isUnplugged: true,
             levelNumber: undefined,
+            pageNumber: undefined,
             isCurrentLevel: false,
             isConceptLevel: false,
             paired: undefined,
@@ -646,6 +650,7 @@ describe('progressReduxTest', () => {
             sublevels: []
           },
           {
+            id: 323,
             status: 'not_tried',
             url:
               'http://localhost-studio.code.org:3000/s/course3/stage/1/puzzle/2',
@@ -657,6 +662,7 @@ describe('progressReduxTest', () => {
             icon: null,
             isUnplugged: false,
             levelNumber: 1,
+            pageNumber: 1,
             isCurrentLevel: false,
             isConceptLevel: false,
             paired: undefined,
@@ -664,6 +670,7 @@ describe('progressReduxTest', () => {
             sublevels: []
           },
           {
+            id: 322,
             status: 'not_tried',
             url:
               'http://localhost-studio.code.org:3000/s/course3/stage/1/puzzle/3',
@@ -675,6 +682,7 @@ describe('progressReduxTest', () => {
             icon: null,
             isUnplugged: false,
             levelNumber: 2,
+            pageNumber: 2,
             isCurrentLevel: false,
             isConceptLevel: false,
             paired: undefined,
@@ -684,6 +692,7 @@ describe('progressReduxTest', () => {
         ],
         [
           {
+            id: 330,
             status: 'not_tried',
             url:
               'http://localhost-studio.code.org:3000/s/course3/stage/2/puzzle/1',
@@ -695,6 +704,7 @@ describe('progressReduxTest', () => {
             icon: null,
             isUnplugged: false,
             levelNumber: 1,
+            pageNumber: undefined,
             isCurrentLevel: false,
             isConceptLevel: false,
             paired: undefined,
@@ -702,6 +712,7 @@ describe('progressReduxTest', () => {
             sublevels: []
           },
           {
+            id: 339,
             status: 'perfect',
             url:
               'http://localhost-studio.code.org:3000/s/course3/stage/2/puzzle/2',
@@ -713,6 +724,7 @@ describe('progressReduxTest', () => {
             icon: null,
             isUnplugged: false,
             levelNumber: 2,
+            pageNumber: undefined,
             isCurrentLevel: false,
             isConceptLevel: false,
             paired: undefined,
@@ -720,6 +732,7 @@ describe('progressReduxTest', () => {
             sublevels: []
           },
           {
+            id: 341,
             status: 'attempted',
             url:
               'http://localhost-studio.code.org:3000/s/course3/stage/2/puzzle/3',
@@ -731,6 +744,7 @@ describe('progressReduxTest', () => {
             icon: null,
             isUnplugged: false,
             levelNumber: 3,
+            pageNumber: undefined,
             isCurrentLevel: false,
             isConceptLevel: false,
             paired: undefined,
@@ -797,7 +811,7 @@ describe('progressReduxTest', () => {
     it('sets isCurrentLevel to true for current level only', () => {
       const initializedState = {
         ...reducer(undefined, initProgress(initialScriptOverviewProgress)),
-        currentLevelId: stageData[0].levels[1].activeId.toString()
+        currentLevelId: stageData[0].levels[1].activeId
       };
 
       const stageId = stageData[0].id;

--- a/apps/test/unit/templates/lessonOverview/activities/ProgressionDetailsTest.jsx
+++ b/apps/test/unit/templates/lessonOverview/activities/ProgressionDetailsTest.jsx
@@ -12,7 +12,7 @@ describe('ProgressionDetails', () => {
     };
   });
 
-  it('renders default props', () => {
+  it('renders default props and ProgressLevelSet', () => {
     const wrapper = shallow(<ProgressionDetails {...defaultProps} />);
     expect(wrapper.find('ProgressLevelSet').length).to.equal(1);
   });

--- a/apps/test/unit/templates/progress/ProgressBubbleTest.js
+++ b/apps/test/unit/templates/progress/ProgressBubbleTest.js
@@ -7,6 +7,7 @@ import {LevelStatus, LevelKind} from '@cdo/apps/util/sharedConstants';
 
 const defaultProps = {
   level: {
+    id: 1,
     levelNumber: 1,
     status: LevelStatus.perfect,
     url: '/foo/bar',
@@ -297,6 +298,7 @@ describe('ProgressBubble', () => {
 
   it('renders a progress pill for unplugged lessons', () => {
     const unpluggedLevel = {
+      id: 1,
       status: LevelStatus.perfect,
       kind: LevelKind.unplugged,
       url: '/foo/bar',
@@ -315,6 +317,7 @@ describe('ProgressBubble', () => {
 
   it('does not render a progress pill for unplugged when small', () => {
     const unpluggedLevel = {
+      id: 1,
       status: LevelStatus.perfect,
       kind: LevelKind.unplugged,
       url: '/foo/bar',

--- a/apps/test/unit/templates/progress/ProgressLevelSetTest.js
+++ b/apps/test/unit/templates/progress/ProgressLevelSetTest.js
@@ -1,4 +1,4 @@
-import {assert} from '../../../util/deprecatedChai';
+import {assert} from '../../../util/reconfiguredChai';
 import React from 'react';
 import {shallow} from 'enzyme';
 import ProgressLevelSet from '@cdo/apps/templates/progress/ProgressLevelSet';

--- a/apps/test/unit/templates/progress/ProgressPillTest.js
+++ b/apps/test/unit/templates/progress/ProgressPillTest.js
@@ -6,12 +6,14 @@ import {LevelStatus, LevelKind} from '@cdo/apps/util/sharedConstants';
 import ReactTooltip from 'react-tooltip';
 
 const unpluggedLevel = {
+  id: 1,
   kind: LevelKind.unplugged,
   isUnplugged: true,
   status: LevelStatus.perfect
 };
 
 const assessmentLevel = {
+  id: 2,
   kind: LevelKind.assessment,
   isUnplugged: false,
   status: LevelStatus.perfect

--- a/dashboard/app/models/lesson.rb
+++ b/dashboard/app/models/lesson.rb
@@ -245,6 +245,7 @@ class Lesson < ApplicationRecord
         lesson_data[:levels] += extra_levels
         last_level_summary[:uid] = "#{last_level_summary[:ids].first}_0"
         last_level_summary[:url] << "/page/1"
+        last_level_summary[:page_number] = 1
       end
 
       # Don't want lesson plans for lockable levels

--- a/dashboard/app/models/levels/bubble_choice.rb
+++ b/dashboard/app/models/levels/bubble_choice.rb
@@ -77,6 +77,7 @@ class BubbleChoice < DSLDefined
   def summarize(script_level: nil, user: nil)
     user_id = user ? user.id : nil
     summary = {
+      id: id,
       display_name: display_name,
       description: description,
       name: name,
@@ -134,6 +135,10 @@ class BubbleChoice < DSLDefined
       if user_id
         level_info[:perfect] = UserLevel.find_by(level: level, user_id: user_id)&.perfect?
         level_info[:status] = level_info[:perfect] ? SharedConstants::LEVEL_STATUS.perfect : SharedConstants::LEVEL_STATUS.not_tried
+      else
+        # Pass an empty status if the user is not logged in so the ProgressBubble
+        # in the sublevel display can render correctly.
+        level_info[:status] = SharedConstants::LEVEL_STATUS.not_tried
       end
 
       summary << level_info

--- a/dashboard/app/views/layouts/_header.html.haml
+++ b/dashboard/app/views/layouts/_header.html.haml
@@ -147,7 +147,7 @@
       #{signed_in},
       #{lesson_extras_enabled || 'null'},
       #{script_name_data.to_json},
-      #{!script_level},
+      #{!script_level}
     )
     //]]>
 

--- a/dashboard/app/views/layouts/_header.html.haml
+++ b/dashboard/app/views/layouts/_header.html.haml
@@ -105,14 +105,6 @@
     # don't trust outside content in parameter :puzzle_page - should be integer, so immediately call to_i
     puzzle_page = params[:puzzle_page] ? params[:puzzle_page].to_i : ApplicationHelper::PUZZLE_PAGE_NONE
 
-    if script_level
-      uid = params[:puzzle_page] ? "#{script_level.level_id}_#{puzzle_page - 1}" : script_level.level_id.to_s
-    else
-      # A bit of an abuse of uid, we dont have a specific level id in this case, so just use a hardcoded string
-      uid = SharedConstants::LEVEL_KIND.stage_extras
-    end
-
-
     script_data = script.summarize_header
     lesson_group_data = script.lesson_groups.map(&:summarize)
     stage_data = (@stage || script_level.lesson).summarize
@@ -150,11 +142,12 @@
       #{lesson_group_data.to_json},
       #{stage_data.to_json},
       #{user_progress},
-      "#{uid}",
+      #{script_level&.level_id || -1},
       #{puzzle_page},
       #{signed_in},
       #{lesson_extras_enabled || 'null'},
-      #{script_name_data.to_json}
+      #{script_name_data.to_json},
+      #{!script_level},
     )
     //]]>
 

--- a/dashboard/test/models/levels/bubble_choice_test.rb
+++ b/dashboard/test/models/levels/bubble_choice_test.rb
@@ -95,6 +95,7 @@ DSL
   test 'summarize' do
     summary = @bubble_choice.summarize
     expected_summary = {
+      id: @bubble_choice.id,
       display_name: @bubble_choice.display_name,
       description: @bubble_choice.description,
       name: @bubble_choice.name,
@@ -136,7 +137,8 @@ DSL
         name: @sublevel1.name,
         position: 1,
         letter: 'a',
-        icon: nil
+        icon: nil,
+        status: 'not_tried'
       },
       {
         level_id: @sublevel2.id,
@@ -149,7 +151,8 @@ DSL
         name: @sublevel2.name,
         position: 2,
         letter: 'b',
-        icon: nil
+        icon: nil,
+        status: 'not_tried'
       }
     ]
 

--- a/dashboard/test/models/script_level_test.rb
+++ b/dashboard/test/models/script_level_test.rb
@@ -160,6 +160,7 @@ class ScriptLevelTest < ActiveSupport::TestCase
     script_level = create_script_level_with_ancestors({levels: [bubble_choice]})
 
     expected_summary = {
+      id: bubble_choice.id,
       contained: false,
       submitLevel: false,
       paired: nil,
@@ -237,7 +238,7 @@ class ScriptLevelTest < ActiveSupport::TestCase
     student = create :student
     script_level = create_script_level_with_ancestors({bonus: true})
 
-    summary = ScriptLevel.summarize_as_bonus_for_teacher_panel(script_level.script, script_level.id, student)
+    summary = ScriptLevel.summarize_as_bonus_for_teacher_panel(script_level.script, [script_level.id], student)
     assert_equal true, summary[:bonus]
     assert_equal LEVEL_STATUS.not_tried, summary[:status]
     assert_equal false, summary[:passed]


### PR DESCRIPTION
Reintroduces https://github.com/code-dot-org/code-dot-org/pull/38085 with fixes for failing UI tests

The tests were failing in the following two scenarios:
1. Single page assessments would not expand the "current level" bubble
https://studio.code.org/s/allthethings/stage/38/puzzle/3
![image](https://user-images.githubusercontent.com/8324574/104258464-7604f100-5434-11eb-9b50-a198ea573a25.png)

2. The progress header would not display on Internet Explorer
https://studio.code.org/s/allthethings/stage/18/puzzle/14
![image](https://user-images.githubusercontent.com/8324574/104258556-9fbe1800-5434-11eb-8859-b314f66c5919.png)


**----Documentation from https://github.com/code-dot-org/code-dot-org/pull/38085 copied here (below) for convenience.----**

This is a sub-task of the progress data refactor.

Looking up level progress by level ID is an eventual goal of the progress data refactor. This is the first step. In the past, the level id would not be included in the level object. Now, that ID is a required part of the object and is verified through prop-types. Additionally, locations where a level is used now use levelType.

### Considerations
**Multi-page assessments**
These continue to work as expected with this change:
![image](https://user-images.githubusercontent.com/8324574/100957523-7c1bbf80-34cf-11eb-9b83-8e0de203882d.png)
Example progression: http://localhost-studio.code.org:3000/s/csp5-2020/lockable/1/puzzle/2/page/1
https://studio.code.org/s/csp5-2020/lockable/1/puzzle/2/page/1 

**Sublevels**
These continue to work as expected with this change:
![image](https://user-images.githubusercontent.com/8324574/100958533-5e4f5a00-34d1-11eb-8e1f-3df621442200.png)
Example level: http://localhost-studio.code.org:3000/s/express-2020/stage/28/puzzle/2/sublevel/4
https://studio.code.org/s/express-2020/stage/28/puzzle/2/sublevel/4 

**Stage Extras**
Example Level: http://localhost-studio.code.org:3000/s/express-2020/stage/26/extras
And: http://localhost-studio.code.org:3000/s/express-2020/stage/28/extras
With these changes Stage Extras have feature parity with the current functionality in production including the following:
- The "header middle" component will always show the "stage extras" flag as green if the user is on the stage extras level and as gray if the user is not on the stage extras level.

<!-- ### Background -->
<!-- ### Privacy -->
<!--
1.	Does the Project involve the collection, use or sharing of new Personal Data?

2.	Does the Project involve a new or changed use or sharing of existing Personal Data?
-->
<!-- ### Security -->
<!--
Link to Jira Task where sensitive security issues are discussed privately.
-->
<!-- ### Caching -->
<!-- ### Deployment strategy -->
<!-- ### Future work -->

## Links

<!--
  Any relevant links to external resources; ie, specification documents, jira
  items, related PRs, honeybadger errors, etc
-->

- [investigation PR](https://github.com/code-dot-org/code-dot-org/pull/37930)
- [LP-1651](https://codedotorg.atlassian.net/browse/LP-1651)

## Testing story

<!--
  Does your change include appropriate tests?

  If so, please describe how the tests included in this PR are sufficient

  If not, please explain why this change does not need to be tested.
-->

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
