### PR TITLE
Move pepjs polyfill to CdoBlockly 

### DIFF
--- a/apps/src/polyfills.js
+++ b/apps/src/polyfills.js
@@ -1,7 +1,3 @@
-/**
- * "Pointer Events Polyfill" to support pointer events on Safari
- */
-import 'pepjs';
 import wickedGoodXpath from 'wgxpath';
 
 /**

--- a/apps/src/sites/studio/pages/blockly.js
+++ b/apps/src/sites/studio/pages/blockly.js
@@ -1,3 +1,15 @@
+/**
+ * "Pointer Events Polyfill" to support pointer events on Safari.
+ * This polyfill is used only for the Location Picker in Sprite Lab.
+ * Google Blockly breaks on some browsers if this polyfill is present
+ * as it uses the presence of window.PointerEvent to decide what types
+ * of touch events to listen for.
+ * Loading the polyfill here guarantees it will be present for Sprite Lab
+ * (which uses Cdo Blockly) and it will not be present for any lab loaded
+ * with Google Blockly.
+ */
+import 'pepjs';
+
 import CDOBlockly from '@code-dot-org/blockly';
 import initializeCdoBlocklyWrapper from './cdoBlocklyWrapper';
 


### PR DESCRIPTION
This polyfill was added by https://github.com/code-dot-org/code-dot-org/pull/22448. It is only used for the Location Picker, which is only used in Sprite Lab:
![Jan-12-2021 09-20-28](https://user-images.githubusercontent.com/8787187/104349209-7c887c80-54b7-11eb-8207-e9ec61258379.gif)

However, the presence of this polyfill breaks Google Blockly's touch-handling logic. They test for the presence of `window.PointerEvent` to decide which types of events to listen for. See https://github.com/google/blockly/blob/master/core/touch.js#L51

The solution here is to tie the pepjs polyfill to the Blockly loading code. That way we always load it when we are using CdoBlockly, and we never load it when we are using GoogleBlockly. Currently, Sprite Lab always uses CdoBlockly, so this ensures the polyfill will always be there for the location picker. When we eventually switch Sprite Lab over to Google Blockly, we'll probably need to make the location picker work without the polyfill, but that's a long ways off anyways.

some additional discussion in [slack thread](https://codedotorg.slack.com/archives/C0T0PNR0D/p1610410306076300)


<!--
  Other aspects to consider. uncomment and add detail for any that seem necessary:
-->

<!-- ### Background -->
<!-- ### Privacy -->
<!--
1.	Does the Project involve the collection, use or sharing of new Personal Data?

2.	Does the Project involve a new or changed use or sharing of existing Personal Data?
-->
<!-- ### Security -->
<!--
Link to Jira Task where sensitive security issues are discussed privately.
-->
<!-- ### Caching -->
<!-- ### Deployment strategy -->
<!-- ### Future work -->

## Links

<!--
  Any relevant links to external resources; ie, specification documents, jira
  items, related PRs, honeybadger errors, etc
-->


## Testing story
Manually tested a spritelab level and a flappy level on:
- Mac Chrome
- Mac Safari
- iPad with iOS 12
- Saucelabs Safari 12
- Saucelab Firefox 56

<!--
  Does your change include appropriate tests?

  If so, please describe how the tests included in this PR are sufficient

  If not, please explain why this change does not need to be tested.
-->

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
