### PR TITLE
Add publish button to Foorm editor

### DIFF
--- a/apps/src/code-studio/pd/foorm/editor/FoormSaveBar.jsx
+++ b/apps/src/code-studio/pd/foorm/editor/FoormSaveBar.jsx
@@ -91,6 +91,11 @@ const aboutToPublishWarning = (
   </div>
 );
 
+const confirmationDialogNames = {
+  save: 'save',
+  publish: 'publish'
+};
+
 class FoormSaveBar extends Component {
   static propTypes = {
     formCategories: PropTypes.array,
@@ -128,12 +133,15 @@ class FoormSaveBar extends Component {
     this.props.setSaveError(null);
     if (this.props.isFormPublished) {
       // show a warning if in published mode
-      this.setState({confirmationDialogBeingShownName: 'save'});
+      this.setState({
+        confirmationDialogBeingShownName: confirmationDialogNames.save
+      });
     } else if (this.props.formId === null || this.props.formId === undefined) {
       // if this is not an existing form, show new form save modal
       this.setState({showNewFormSave: true});
     } else {
-      this.save();
+      const saveUrl = `/foorm/forms/${this.props.formId}/update_questions`;
+      this.save(saveUrl);
     }
   };
 
@@ -141,7 +149,7 @@ class FoormSaveBar extends Component {
   handlePublish = () => {
     this.setState({
       isSaving: true,
-      confirmationDialogBeingShownName: 'publish'
+      confirmationDialogBeingShownName: confirmationDialogNames.publish
     });
     this.props.setSaveError(null);
   };
@@ -162,12 +170,12 @@ class FoormSaveBar extends Component {
     this.setState({showNewFormSave: false, isSaving: false});
   };
 
-  save = () => {
+  save = url => {
     // Dedupe AJAX request? Only diffs in URL, maybe some state changes?
     // Figure out what to do with saveError?
     // Need to update this so it doesn't automatically make survey published?
     $.ajax({
-      url: `/foorm/forms/${this.props.formId}/update_questions`,
+      url: url,
       type: 'put',
       contentType: 'application/json',
       processData: false,
@@ -382,15 +390,6 @@ class FoormSaveBar extends Component {
               <FontAwesome icon="spinner" className="fa-spin" />
             </div>
           )}
-          <button
-            className="btn btn-primary"
-            type="button"
-            style={styles.button}
-            onClick={this.handleSave}
-            disabled={this.state.isSaving || this.props.formHasError}
-          >
-            Save
-          </button>
           {!this.props.isFormPublished && (
             <button
               className="btn btn-danger"
@@ -402,19 +401,38 @@ class FoormSaveBar extends Component {
               Publish
             </button>
           )}
+          <button
+            className="btn btn-primary"
+            type="button"
+            style={styles.button}
+            onClick={this.handleSave}
+            disabled={this.state.isSaving || this.props.formHasError}
+          >
+            Save
+          </button>
         </div>
         {this.renderNewFormSaveModal()}
         <ConfirmationDialog
-          show={this.state.confirmationDialogBeingShownName === 'save'}
-          onOk={this.save}
+          show={
+            this.state.confirmationDialogBeingShownName ===
+            confirmationDialogNames.save
+          }
+          onOk={() => {
+            this.save(`/foorm/forms/${this.props.formId}/update_questions`);
+          }}
           okText={'Yes, save the form'}
           onCancel={this.handleSaveCancel}
           headerText="Save Form"
           bodyText={publishedSaveWarning}
         />
         <ConfirmationDialog
-          show={this.state.confirmationDialogBeingShownName === 'publish'}
-          onOk={this.publish}
+          show={
+            this.state.confirmationDialogBeingShownName ===
+            confirmationDialogNames.publish
+          }
+          onOk={() => {
+            this.save(`/foorm/forms/${this.props.formId}/publish`);
+          }}
           okText={'Yes, publish the form'}
           onCancel={this.handlePublishCancel}
           headerText="Publish Form"

--- a/apps/src/code-studio/pd/foorm/editor/FoormSaveBar.jsx
+++ b/apps/src/code-studio/pd/foorm/editor/FoormSaveBar.jsx
@@ -115,10 +115,8 @@ class FoormSaveBar extends Component {
     super(props);
 
     this.state = {
-      // should be able to combine these confirmation props
-      showSaveConfirmation: false,
-      showPublishConfirmation: false,
-      isSavingOrPublishing: false,
+      confirmationDialogBeingShownName: null,
+      isSaving: false,
       showNewFormSave: false,
       formName: null,
       formCategory: null
@@ -126,11 +124,11 @@ class FoormSaveBar extends Component {
   }
 
   handleSave = () => {
-    this.setState({isSavingOrPublishing: true});
+    this.setState({isSaving: true});
     this.props.setSaveError(null);
     if (this.props.isFormPublished) {
       // show a warning if in published mode
-      this.setState({showSaveConfirmation: true});
+      this.setState({confirmationDialogBeingShownName: 'save'});
     } else if (this.props.formId === null || this.props.formId === undefined) {
       // if this is not an existing form, show new form save modal
       this.setState({showNewFormSave: true});
@@ -142,26 +140,26 @@ class FoormSaveBar extends Component {
   // Could this be deduped with handleSave?
   handlePublish = () => {
     this.setState({
-      isSavingOrPublishing: true,
-      showPublishConfirmation: true
+      isSaving: true,
+      confirmationDialogBeingShownName: 'publish'
     });
     this.props.setSaveError(null);
   };
 
   // probably should dedupe these two methods (handlesavecancel and handlepublishcancel)
   handleSaveCancel = () => {
-    this.setState({showSaveConfirmation: false, isSavingOrPublishing: false});
+    this.setState({confirmationDialogBeingShownName: null, isSaving: false});
   };
 
   handlePublishCancel = () => {
     this.setState({
-      showPublishConfirmation: false,
-      isSavingOrPublishing: false
+      confirmationDialogBeingShownName: null,
+      isSaving: false
     });
   };
 
   handleNewFormSaveCancel = () => {
-    this.setState({showNewFormSave: false, isSavingOrPublishing: false});
+    this.setState({showNewFormSave: false, isSaving: false});
   };
 
   save = () => {
@@ -180,13 +178,13 @@ class FoormSaveBar extends Component {
       .done(result => {
         this.handleSaveSuccess(result);
         this.setState({
-          showSaveConfirmation: false
+          confirmationDialogBeingShownName: null
         });
       })
       .fail(result => {
         this.handleSaveError(result);
         this.setState({
-          showSaveConfirmation: false
+          confirmationDialogBeingShownName: null
         });
       });
   };
@@ -206,14 +204,14 @@ class FoormSaveBar extends Component {
         this.handleSaveSuccess(result);
 
         this.setState({
-          showPublishConfirmation: false
+          confirmationDialogBeingShownName: null
         });
       })
       .fail(result => {
         // should rename this if i'm going to use it here.
         this.handleSaveError(result);
         this.setState({
-          showPublishConfirmation: false
+          confirmationDialogBeingShownName: null
         });
       });
   };
@@ -256,7 +254,7 @@ class FoormSaveBar extends Component {
 
   handleSaveSuccess(result) {
     this.setState({
-      isSavingOrPublishing: false
+      isSaving: false
     });
     this.props.setLastSaved(Date.now());
     const updatedQuestions = JSON.parse(result.questions);
@@ -275,7 +273,7 @@ class FoormSaveBar extends Component {
 
   handleSaveError(result) {
     this.setState({
-      isSavingOrPublishing: false
+      isSaving: false
     });
     // figure out exactly what this is doing
     this.props.setSaveError(
@@ -379,7 +377,7 @@ class FoormSaveBar extends Component {
               className="saveErrorMessage"
             >{`Error Saving: ${this.props.saveError}`}</div>
           )}
-          {this.state.isSavingOrPublishing && (
+          {this.state.isSaving && (
             <div style={styles.spinner}>
               <FontAwesome icon="spinner" className="fa-spin" />
             </div>
@@ -389,9 +387,7 @@ class FoormSaveBar extends Component {
             type="button"
             style={styles.button}
             onClick={this.handleSave}
-            disabled={
-              this.state.isSavingOrPublishing || this.props.formHasError
-            }
+            disabled={this.state.isSaving || this.props.formHasError}
           >
             Save
           </button>
@@ -401,9 +397,7 @@ class FoormSaveBar extends Component {
               type="button"
               style={styles.button}
               onClick={this.handlePublish}
-              disabled={
-                this.state.isSavingOrPublishing || this.props.formHasError
-              }
+              disabled={this.state.isSaving || this.props.formHasError}
             >
               Publish
             </button>
@@ -411,7 +405,7 @@ class FoormSaveBar extends Component {
         </div>
         {this.renderNewFormSaveModal()}
         <ConfirmationDialog
-          show={this.state.showSaveConfirmation}
+          show={this.state.confirmationDialogBeingShownName === 'save'}
           onOk={this.save}
           okText={'Yes, save the form'}
           onCancel={this.handleSaveCancel}
@@ -419,7 +413,7 @@ class FoormSaveBar extends Component {
           bodyText={publishedSaveWarning}
         />
         <ConfirmationDialog
-          show={this.state.showPublishConfirmation}
+          show={this.state.confirmationDialogBeingShownName === 'publish'}
           onOk={this.publish}
           okText={'Yes, publish the form'}
           onCancel={this.handlePublishCancel}

--- a/apps/src/code-studio/pd/foorm/editor/FoormSaveBar.jsx
+++ b/apps/src/code-studio/pd/foorm/editor/FoormSaveBar.jsx
@@ -197,33 +197,6 @@ class FoormSaveBar extends Component {
       });
   };
 
-  publish = () => {
-    $.ajax({
-      url: `/foorm/forms/${this.props.formId}/publish`,
-      type: 'put',
-      contentType: 'application/json',
-      processData: false,
-      data: JSON.stringify({
-        questions: this.props.formQuestions
-      })
-    })
-      .done(result => {
-        // should rename this if i'm going to use it here.
-        this.handleSaveSuccess(result);
-
-        this.setState({
-          confirmationDialogBeingShownName: null
-        });
-      })
-      .fail(result => {
-        // should rename this if i'm going to use it here.
-        this.handleSaveError(result);
-        this.setState({
-          confirmationDialogBeingShownName: null
-        });
-      });
-  };
-
   isFormNameValid = () => {
     return this.state.formName && this.state.formName.match('^[a-z0-9_]+$');
   };

--- a/apps/src/code-studio/pd/foorm/editor/FoormSaveBar.jsx
+++ b/apps/src/code-studio/pd/foorm/editor/FoormSaveBar.jsx
@@ -145,7 +145,6 @@ class FoormSaveBar extends Component {
     }
   };
 
-  // Could this be deduped with handleSave?
   handlePublish = () => {
     this.setState({
       isSaving: true,
@@ -154,16 +153,8 @@ class FoormSaveBar extends Component {
     this.props.setSaveError(null);
   };
 
-  // probably should dedupe these two methods (handlesavecancel and handlepublishcancel)
   handleSaveCancel = () => {
     this.setState({confirmationDialogBeingShownName: null, isSaving: false});
-  };
-
-  handlePublishCancel = () => {
-    this.setState({
-      confirmationDialogBeingShownName: null,
-      isSaving: false
-    });
   };
 
   handleNewFormSaveCancel = () => {
@@ -171,7 +162,6 @@ class FoormSaveBar extends Component {
   };
 
   save = url => {
-    // Dedupe AJAX request? Only diffs in URL, maybe some state changes?
     // Figure out what to do with saveError?
     // Need to update this so it doesn't automatically make survey published?
     $.ajax({
@@ -256,7 +246,7 @@ class FoormSaveBar extends Component {
     this.setState({
       isSaving: false
     });
-    // figure out exactly what this is doing
+
     this.props.setSaveError(
       (result.responseJSON && result.responseJSON.questions) ||
         result.responseText ||
@@ -407,7 +397,7 @@ class FoormSaveBar extends Component {
             this.save(`/foorm/forms/${this.props.formId}/publish`);
           }}
           okText={'Yes, publish the form'}
-          onCancel={this.handlePublishCancel}
+          onCancel={this.handleSaveCancel}
           headerText="Publish Form"
           bodyText={aboutToPublishWarning}
         />

--- a/apps/src/code-studio/pd/foorm/editor/FoormSaveBar.jsx
+++ b/apps/src/code-studio/pd/foorm/editor/FoormSaveBar.jsx
@@ -162,8 +162,6 @@ class FoormSaveBar extends Component {
   };
 
   save = url => {
-    // Figure out what to do with saveError?
-    // Need to update this so it doesn't automatically make survey published?
     $.ajax({
       url: url,
       type: 'put',

--- a/apps/src/code-studio/pd/foorm/editor/FoormSaveBar.jsx
+++ b/apps/src/code-studio/pd/foorm/editor/FoormSaveBar.jsx
@@ -84,7 +84,10 @@ const publishedSaveWarning = (
 const aboutToPublishWarning = (
   <div>
     <span style={styles.warning}>Warning: </span>You are about to publish a new
-    survey. Once a survey is published, it may be put into active use.
+    survey. Once a survey is published, it may be put into active use.{' '}
+    <span style={styles.warning}>
+      A published survey cannot be returned to draft mode!
+    </span>
     <br />
     <br />
     Are you sure you want to publish?
@@ -128,6 +131,11 @@ class FoormSaveBar extends Component {
     };
   }
 
+  updateQuestionsUrl = () =>
+    `/foorm/forms/${this.props.formId}/update_questions`;
+
+  publishUrl = () => `/foorm/forms/${this.props.formId}/publish`;
+
   handleSave = () => {
     this.setState({isSaving: true});
     this.props.setSaveError(null);
@@ -140,8 +148,7 @@ class FoormSaveBar extends Component {
       // if this is not an existing form, show new form save modal
       this.setState({showNewFormSave: true});
     } else {
-      const saveUrl = `/foorm/forms/${this.props.formId}/update_questions`;
-      this.save(saveUrl);
+      this.save(this.updateQuestionsUrl());
     }
   };
 
@@ -379,7 +386,7 @@ class FoormSaveBar extends Component {
             confirmationDialogNames.save
           }
           onOk={() => {
-            this.save(`/foorm/forms/${this.props.formId}/update_questions`);
+            this.save(this.updateQuestionsUrl());
           }}
           okText={'Yes, save the form'}
           onCancel={this.handleSaveCancel}
@@ -392,7 +399,7 @@ class FoormSaveBar extends Component {
             confirmationDialogNames.publish
           }
           onOk={() => {
-            this.save(`/foorm/forms/${this.props.formId}/publish`);
+            this.save(this.publishUrl());
           }}
           okText={'Yes, publish the form'}
           onCancel={this.handleSaveCancel}

--- a/apps/test/unit/code-studio/pd/foorm/FoormEditorTest.js
+++ b/apps/test/unit/code-studio/pd/foorm/FoormEditorTest.js
@@ -101,7 +101,7 @@ describe('FoormEditor', () => {
     expect(saveButton.contains('Save')).to.be.true;
     saveButton.simulate('click');
 
-    // check the the spinner is showing
+    // check the spinner is showing
     expect(wrapper.find('.saveBar').find('FontAwesome').length).to.equal(1);
     expect(saveBar.state().isSaving).to.equal(true);
 
@@ -133,7 +133,7 @@ describe('FoormEditor', () => {
     expect(publishButton.contains('Publish')).to.be.true;
     publishButton.simulate('click');
 
-    // check the the spinner is showing
+    // check the spinner is showing
     expect(wrapper.find('.saveBar').find('FontAwesome').length).to.equal(1);
     expect(saveBar.state().isSaving).to.equal(true);
 
@@ -177,7 +177,7 @@ describe('FoormEditor', () => {
     expect(saveButton.contains('Save')).to.be.true;
     saveButton.simulate('click');
 
-    // check the the spinner is showing
+    // check the spinner is showing
     expect(wrapper.find('.saveBar').find('FontAwesome').length).to.equal(1);
     expect(saveBar.state().isSaving).to.equal(true);
 
@@ -213,7 +213,7 @@ describe('FoormEditor', () => {
     expect(saveButton.contains('Save')).to.be.true;
     saveButton.simulate('click');
 
-    // check the the spinner is showing
+    // check the spinner is showing
     expect(wrapper.find('.saveBar').find('FontAwesome').length).to.equal(1);
     expect(saveBar.state().isSaving).to.equal(true);
 
@@ -266,7 +266,7 @@ describe('FoormEditor', () => {
     expect(saveButton.contains('Save')).to.be.true;
     saveButton.simulate('click');
 
-    // check the the spinner is showing
+    // check the spinner is showing
     expect(wrapper.find('.saveBar').find('FontAwesome').length).to.equal(1);
     expect(saveBar.state().isSaving).to.equal(true);
 
@@ -303,7 +303,7 @@ describe('FoormEditor', () => {
     expect(saveButton.contains('Publish')).to.be.true;
     saveButton.simulate('click');
 
-    // check the the spinner is showing
+    // check the spinner is showing
     expect(wrapper.find('.saveBar').find('FontAwesome').length).to.equal(1);
     expect(saveBar.state().isSaving).to.equal(true);
 
@@ -350,7 +350,7 @@ describe('FoormEditor', () => {
     expect(saveButton.contains('Save')).to.be.true;
     saveButton.simulate('click');
 
-    // check the the spinner is showing
+    // check the spinner is showing
     expect(wrapper.find('.saveBar').find('FontAwesome').length).to.equal(1);
     expect(saveBar.state().isSaving).to.equal(true);
 
@@ -400,7 +400,7 @@ describe('FoormEditor', () => {
     expect(saveButton.contains('Save')).to.be.true;
     saveButton.simulate('click');
 
-    // check the the spinner is showing
+    // check the spinner is showing
     expect(wrapper.find('.saveBar').find('FontAwesome').length).to.equal(1);
     expect(saveBar.state().isSaving).to.equal(true);
 

--- a/apps/test/unit/code-studio/pd/foorm/FoormEditorTest.js
+++ b/apps/test/unit/code-studio/pd/foorm/FoormEditorTest.js
@@ -143,7 +143,7 @@ describe('FoormEditor', () => {
         .find('ConfirmationDialog')
         .at(1)
         .prop('show'),
-      'ConfirmationDialog is showing'
+      'Publish ConfirmationDialog is showing'
     );
 
     // simulate save click. Cannot click on button itself because it is in the modal
@@ -223,7 +223,7 @@ describe('FoormEditor', () => {
         .find('ConfirmationDialog')
         .at(0)
         .prop('show'),
-      'ConfirmationDialog is showing'
+      'Save ConfirmationDialog is showing'
     );
 
     // simulate save click. Cannot click on button itself because it is in the modal
@@ -276,7 +276,7 @@ describe('FoormEditor', () => {
         .find('ConfirmationDialog')
         .at(0)
         .prop('show'),
-      'ConfirmationDialog is showing'
+      'Save ConfirmationDialog is showing'
     );
 
     // simulate cancel click. Cannot click on button itself because it is in the modal
@@ -313,7 +313,7 @@ describe('FoormEditor', () => {
         .find('ConfirmationDialog')
         .at(1)
         .prop('show'),
-      'ConfirmationDialog is showing'
+      'Publish ConfirmationDialog is showing'
     );
 
     // simulate cancel click. Cannot click on button itself because it is in the modal

--- a/dashboard/app/controllers/foorm/forms_controller.rb
+++ b/dashboard/app/controllers/foorm/forms_controller.rb
@@ -53,7 +53,7 @@ module Foorm
     # PUT foorm/form/:id/publish
     def publish
       if @form.published
-        return render plain: "success"
+        return render json: form
       end
 
       parsed_questions = JSON.parse(@form.questions)

--- a/dashboard/app/models/foorm/form.rb
+++ b/dashboard/app/models/foorm/form.rb
@@ -45,8 +45,10 @@ class Foorm::Form < ApplicationRecord
 
       # Let's load the JSON text.
       questions = File.read(path)
+
       # if published is not provided, default to true
-      published = questions['published'].nil? ? true : questions['published']
+      questions_parsed = JSON.parse(questions)
+      published = questions_parsed['published'].nil? ? true : questions_parsed['published']
 
       form = Foorm::Form.find_or_initialize_by(name: full_name, version: version)
       form.questions = questions
@@ -62,6 +64,7 @@ class Foorm::Form < ApplicationRecord
 
   def validate_published
     parsed_questions = JSON.parse(questions)
+
     unless parsed_questions['published'].nil?
       if published != parsed_questions['published']
         errors[:questions] << 'Mismatch between published state in questions and published state in model'


### PR DESCRIPTION
Adds a button to allow "publishing" of a survey via our Foorm editor. Currently this just flips a flag in the database and isn't tied to any functionality, but in the future will be used to identify surveys that are "production ready" and can be used in actual surveys of our users.

Publish option shown on "draft" surveys:

![image](https://user-images.githubusercontent.com/25372625/104376061-41974080-54d9-11eb-8662-d0679d50e59d.png)

Warning when publishing button clicked:

![image](https://user-images.githubusercontent.com/25372625/104376094-5247b680-54d9-11eb-9063-8cb36460cb75.png)

Button disappears once survey is published:

![image](https://user-images.githubusercontent.com/25372625/104376156-71464880-54d9-11eb-9d0e-256bb0642891.png)

## Testing story

Tested manually that I can publish surveys that are currently in draft state properly, and that the "publish" button does not appear for already published surveys.

## Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
