### PR TITLE
Specify that TestCase transaction should not be lazy

### DIFF
--- a/dashboard/test/testing/transactional_test_case.rb
+++ b/dashboard/test/testing/transactional_test_case.rb
@@ -28,7 +28,7 @@ module ActiveSupport
           if use_transactional_test_case?
             @test_case_connections = enlist_transaction_connections
             @test_case_connections.each do |connection|
-              connection.begin_transaction joinable: false, lock_thread: true
+              connection.begin_transaction joinable: false, _lazy: false, lock_thread: true
               connection.pool.lock_thread = true
             end
           end


### PR DESCRIPTION
According to https://github.com/rails/rails/pull/35082, Rails transactions were at some point made lazy, which started causing problems for test transactions.

When trying to upgrade to Rail 6, we saw similar problems with our custom implementation of transactions for test _cases_ rather than just individual tests. Mirroring the fixes in the linked PR in our own implementation seems to resolve those problems.

## Testing story

N/A

## Links

- [PR that originally implemented lazy transactions](https://github.com/rails/rails/pull/32647)

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
