### PR TITLE
translating spritelab behavior names and adding blockly shared functi…

### DIFF
--- a/bin/i18n/sync-in.rb
+++ b/bin/i18n/sync-in.rb
@@ -16,11 +16,11 @@ require_relative 'redact_restore_utils'
 require_relative '../../tools/scripts/ManifestBuilder'
 
 def sync_in
-  # HocSyncUtils.sync_in
-  # localize_level_content
-  # localize_project_content
-  # localize_block_content
-  # localize_animation_library
+  HocSyncUtils.sync_in
+  localize_level_content
+  localize_project_content
+  localize_block_content
+  localize_animation_library
   localize_shared_functions
   puts "Copying source files"
   I18nScriptUtils.run_bash_script "bin/i18n-codeorg/in.sh"

--- a/bin/i18n/sync-in.rb
+++ b/bin/i18n/sync-in.rb
@@ -16,11 +16,12 @@ require_relative 'redact_restore_utils'
 require_relative '../../tools/scripts/ManifestBuilder'
 
 def sync_in
-  HocSyncUtils.sync_in
-  localize_level_content
-  localize_project_content
-  localize_block_content
-  localize_animation_library
+  # HocSyncUtils.sync_in
+  # localize_level_content
+  # localize_project_content
+  # localize_block_content
+  # localize_animation_library
+  localize_shared_functions
   puts "Copying source files"
   I18nScriptUtils.run_bash_script "bin/i18n-codeorg/in.sh"
   redact_level_content
@@ -286,6 +287,19 @@ def localize_animation_library
   File.open(spritelab_animation_source_file, "w") do |file|
     animation_strings = ManifestBuilder.new({spritelab: true, silent: true}).get_animation_strings
     file.write(JSON.pretty_generate(animation_strings))
+  end
+end
+
+def localize_shared_functions
+  puts "Preparing shared functions"
+
+  shared_functions = SharedBlocklyFunction.where(level_type: 'GamelabJr').pluck(:name)
+  hash = {}
+  shared_functions.sort.each do |func|
+    hash[func] = func
+  end
+  File.open("i18n/locales/source/dashboard/shared_functions.yml", "w+") do |f|
+    f.write(I18nScriptUtils.to_crowdin_yaml({"en" => {"data" => {"shared_functions" => hash}}}))
   end
 end
 

--- a/dashboard/app/models/levels/blockly.rb
+++ b/dashboard/app/models/levels/blockly.rb
@@ -579,8 +579,6 @@ class Blockly < Level
     end
     block_xml.xpath("//block[@type=\"behavior_definition\"]").each do |behavior|
       behavior_name = behavior.at_xpath('./title[@name="NAME"]')
-      puts "from blockly.rb #{behavior_name}, #{behavior_name.content}, #{name}"
-      # puts "#{data.behavior_names.*}"
       next unless behavior_name
       localized_name = I18n.t(
         behavior_name.content,

--- a/dashboard/app/models/levels/blockly.rb
+++ b/dashboard/app/models/levels/blockly.rb
@@ -566,6 +566,30 @@ class Blockly < Level
       end
       mutation.set_attribute('name', localized_name) if localized_name
     end
+    block_xml.xpath("//block[@type=\"gamelab_behavior_get\"]").each do |behavior|
+      behavior_name = behavior.at_xpath('./title[@name="VAR"]')
+      next unless behavior_name
+      localized_name = I18n.t(
+        behavior_name.content,
+        scope: [:data, :behavior_names, name],
+        default: nil,
+        smart: true
+      )
+      behavior_name.content = localized_name if localized_name
+    end
+    block_xml.xpath("//block[@type=\"behavior_definition\"]").each do |behavior|
+      behavior_name = behavior.at_xpath('./title[@name="NAME"]')
+      puts "from blockly.rb #{behavior_name}, #{behavior_name.content}, #{name}"
+      # puts "#{data.behavior_names.*}"
+      next unless behavior_name
+      localized_name = I18n.t(
+        behavior_name.content,
+        scope: [:data, :behavior_names, name],
+        default: nil,
+        smart: true
+      )
+      behavior_name.content = localized_name if localized_name
+    end
 
     localize_behaviors(block_xml)
     return block_xml.serialize(save_with: XML_OPTIONS).strip

--- a/dashboard/app/models/shared_blockly_function.rb
+++ b/dashboard/app/models/shared_blockly_function.rb
@@ -53,7 +53,14 @@ class SharedBlocklyFunction < ApplicationRecord
           end
           xml.description description
         end
-        xml.title(name, name: 'NAME', id: name)
+        localized_name = I18n.t(
+          name,
+          scope: [:data, :shared_functions],
+          default: nil,
+          smart: true
+        )
+        localized_name ||= name
+        xml.title(localized_name, name: 'NAME', id: name)
         xml.statement(name: 'STACK') do
           xml << stack.gsub(/\n */, '')
         end

--- a/i18n/locales/source/dashboard/shared_functions.yml
+++ b/i18n/locales/source/dashboard/shared_functions.yml
@@ -1,0 +1,22 @@
+---
+en:
+  data:
+    shared_functions:
+      driving with arrow keys: driving with arrow keys
+      fluttering: fluttering
+      growing: growing
+      jittering: jittering
+      moving east: moving east
+      moving east and looping: moving east and looping
+      moving north: moving north
+      moving south: moving south
+      moving west: moving west
+      moving west and looping: moving west and looping
+      moving with arrow keys: moving with arrow keys
+      patrolling: patrolling
+      shrinking: shrinking
+      spinning left: spinning left
+      spinning right: spinning right
+      swimming left and right: swimming left and right
+      wandering: wandering
+      wobbling: wobbling


### PR DESCRIPTION
…ons to be translated

1. Re-enabling behavior name translations according to https://github.com/code-dot-org/code-dot-org/pull/33683
2. Enabling translations of shared functions in Sprite Lab

<!--
  Your description goes here: A summary of the change, including any relevant motivation and context.

  If relevant, include a description both of the existing behavior and of the new behavior.
-->

<!--
  Other aspects to consider. uncomment and add detail for any that seem necessary:
-->

<!-- ### Background -->
<!-- ### Privacy -->
<!--
1.	Does the Project involve the collection, use or sharing of new Personal Data?

2.	Does the Project involve a new or changed use or sharing of existing Personal Data?
-->
<!-- ### Security -->
<!--
Link to Jira Task where sensitive security issues are discussed privately.
-->
<!-- ### Caching -->
<!-- ### Deployment strategy -->
<!-- ### Future work -->

## Links

<!--
  Any relevant links to external resources; ie, specification documents, jira
  items, related PRs, honeybadger errors, etc
-->

- [jira](https://codedotorg.atlassian.net/secure/RapidBoard.jspa?rapidView=28&modal=detail&selectedIssue=FND-390)

## Testing story
Tested `shared_functions` manually by grabbing a couple of translations and ensuring they appeared. Verified that `behavior_name` translations are already available, so I verified translations in multiple languages
<!--
  Does your change include appropriate tests?

  If so, please describe how the tests included in this PR are sufficient

  If not, please explain why this change does not need to be tested.
-->

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
