### PR TITLE
Undo whitespace change in `moving west` shared function

### DIFF
--- a/dashboard/config/shared_functions/GamelabJr/moving west.xml
+++ b/dashboard/config/shared_functions/GamelabJr/moving west.xml
@@ -7,17 +7,17 @@
   <title name="NAME" id="moving west">moving west</title>
   <statement name="STACK">
     <block type="gamelab_moveInDirection">
-<title name="DIRECTION">"West"</title>
-<value name="SPRITE">
-<block type="sprite_parameter_get">
-<title name="VAR">this sprite</title>
-</block>
-</value>
-<value name="DISTANCE">
-<block type="math_number">
-<title name="NUM">5</title>
-</block>
-</value>
-</block>
+      <title name="DIRECTION">"West"</title>
+      <value name="SPRITE">
+        <block type="sprite_parameter_get">
+          <title name="VAR">this sprite</title>
+        </block>
+      </value>
+      <value name="DISTANCE">
+        <block type="math_number">
+          <title name="NUM">5</title>
+        </block>
+      </value>
+    </block>
   </statement>
 </block>


### PR DESCRIPTION
Fixes indentation in the `moving west` block XML. The indentation was broken in #38507 during a manual merge conflict fix on levelbuilder, but the root cause is still unknown. To fix this issue, I ran `bundle exec rails seed:shared_blockly_functions` and committed the result.

Since each machine in our build process (staging, levelbuilder, test, production) runs this same seed step, each machine has generated this same diff. However, this only raised an error on the staging machine because it runs [`restrict_staging_changes.rb`](https://github.com/code-dot-org/code-dot-org/blob/staging/tools/hooks/restrict_staging_changes.rb), which disallows committing files with spaces in their names. (Slack threads from this issue popping up while committing content on the staging machine: [1](https://codedotorg.slack.com/archives/C0T0PNTM3/p1610485355055400), [2](https://codedotorg.slack.com/archives/C0T0PNTM3/p1610568928102400))

To try to repro how this happened, I did the following as a levelbuilder locally:
- I created a new shared function with the same blocks. Saving and seeding this block generated properly-formatted XML.
- I updated the existing `moving west` function (after fixing the XML) by adding a new block and updating the existing blocks. The resulting XML was still properly formatted.

If there are other ways that we might reproduce this issue to root cause and prevent this from happening again, let me know. But it seems that the basic functionality for shared functions is generating expected XML, so I think it's okay to fix this instance and investigate more deeply if it happens again.

## Links

- [STAR-1394](https://codedotorg.atlassian.net/browse/STAR-1394)

## Testing story

<!--
  Does your change include appropriate tests?

  If so, please describe how the tests included in this PR are sufficient

  If not, please explain why this change does not need to be tested.
-->

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
