### PR TITLE
Factor out the search component of ResourcesEditor to be used in future components

### DIFF
--- a/apps/src/lib/levelbuilder/lesson-editor/ResourcesEditor.jsx
+++ b/apps/src/lib/levelbuilder/lesson-editor/ResourcesEditor.jsx
@@ -167,9 +167,11 @@ class ResourcesEditor extends Component {
             <label>Select a resource to add</label>
             <SearchBox
               onSearchSelect={this.onSearchSelect}
-              courseVersionId={this.props.courseVersionId}
               searchUrl={'resourcesearch'}
               constructOptions={this.constructSearchOptions}
+              additionalQueryParams={{
+                courseVersionId: this.props.courseVersionId
+              }}
             />
           </div>
           <table style={{width: '100%'}}>

--- a/apps/src/lib/levelbuilder/lesson-editor/SearchBox.jsx
+++ b/apps/src/lib/levelbuilder/lesson-editor/SearchBox.jsx
@@ -7,9 +7,9 @@ import _ from 'lodash';
 export default class SearchBox extends Component {
   static propTypes = {
     onSearchSelect: PropTypes.func.isRequired,
-    courseVersionId: PropTypes.number,
     searchUrl: PropTypes.string.isRequired,
-    constructOptions: PropTypes.func.isRequired
+    constructOptions: PropTypes.func.isRequired,
+    additionalQueryParams: PropTypes.object
   };
 
   constructor(props) {
@@ -33,8 +33,8 @@ export default class SearchBox extends Component {
       query: encodeURIComponent(q),
       limit: searchLimit
     };
-    if (this.props.courseVersionId) {
-      params['courseVersionId'] = this.props.courseVersionId;
+    if (this.props.additionalQueryParams) {
+      Object.assign(params, this.props.additionalQueryParams);
     }
     const query_params = Object.keys(params)
       .map(key => `${key}=${params[key]}`)

--- a/apps/src/lib/levelbuilder/lesson-editor/SearchBox.jsx
+++ b/apps/src/lib/levelbuilder/lesson-editor/SearchBox.jsx
@@ -27,7 +27,7 @@ export default class SearchBox extends Component {
    * @param {function(err, result)} callback - Function called when the server
    *   returns results or a request error occurs.
    */
-  debouncedSearch = _.debounce((q, callback) => {
+  debouncedSearch = _.debounce((q, resolve, reject) => {
     const searchLimit = 7;
     const params = {
       query: encodeURIComponent(q),
@@ -54,8 +54,8 @@ export default class SearchBox extends Component {
       .then(json => {
         return this.props.constructOptions(json);
       })
-      .then(result => callback(null, result))
-      .catch(err => callback(err, null));
+      .then(resolve)
+      .catch(reject);
   }, 200);
 
   getOptions = q => {
@@ -67,13 +67,7 @@ export default class SearchBox extends Component {
     // Wrap the debounced call in a Promise so we _always_ return a promise
     // from this function, which resolves whenever results come back.
     return new Promise((resolve, reject) => {
-      this.debouncedSearch(q, (err, result) => {
-        if (err) {
-          reject(err);
-        } else {
-          resolve(result);
-        }
-      });
+      this.debouncedSearch(q, resolve, reject);
     });
   };
 

--- a/apps/src/lib/levelbuilder/lesson-editor/SearchBox.jsx
+++ b/apps/src/lib/levelbuilder/lesson-editor/SearchBox.jsx
@@ -1,0 +1,90 @@
+import PropTypes from 'prop-types';
+import React, {Component} from 'react';
+import Select from 'react-select';
+import 'react-select/dist/react-select.css';
+import _ from 'lodash';
+
+export default class SearchBox extends Component {
+  static propTypes = {
+    onSearchSelect: PropTypes.func.isRequired,
+    courseVersionId: PropTypes.number,
+    searchUrl: PropTypes.string.isRequired,
+    constructOptions: PropTypes.func.isRequired
+  };
+
+  constructor(props) {
+    super(props);
+    this.state = {
+      searchValue: ''
+    };
+  }
+
+  /**
+   * Debounced function that will request search results from the server.
+   * Because this function is debounced it is not guaranteed to execute
+   * when it is called - there may be a delay of up to 200ms.
+   * @param {string} q - Search query
+   * @param {function(err, result)} callback - Function called when the server
+   *   returns results or a request error occurs.
+   */
+  debouncedSearch = _.debounce((q, callback) => {
+    const searchLimit = 7;
+    const params = {
+      query: encodeURIComponent(q),
+      limit: searchLimit
+    };
+    if (this.props.courseVersionId) {
+      params['courseVersionId'] = this.props.courseVersionId;
+    }
+    const query_params = Object.keys(params)
+      .map(key => `${key}=${params[key]}`)
+      .join('&');
+    const searchUrl = `/${this.props.searchUrl}?${query_params}`;
+    // Note, we don't return the fetch promise chain because in a debounced
+    // function we're not guaranteed to return anything, and it's not a great
+    // interface to sometimes return undefined when there's still async work
+    // going on.
+    //
+    // We are including the X-Requested-With header to avoid getting a 403
+    // returned by Rack::Protection::JsonCsrf in some environments
+    fetch(searchUrl, {
+      headers: {'X-Requested-With': 'XMLHttpRequest'}
+    })
+      .then(response => (response.ok ? response.json() : []))
+      .then(json => {
+        return this.props.constructOptions(json);
+      })
+      .then(result => callback(null, result))
+      .catch(err => callback(err, null));
+  }, 200);
+
+  getOptions = q => {
+    // Only search if there are at least 3 characters
+    if (q.length < 3) {
+      return Promise.resolve();
+    }
+
+    // Wrap the debounced call in a Promise so we _always_ return a promise
+    // from this function, which resolves whenever results come back.
+    return new Promise((resolve, reject) => {
+      this.debouncedSearch(q, (err, result) => {
+        if (err) {
+          reject(err);
+        } else {
+          resolve(result);
+        }
+      });
+    });
+  };
+
+  render() {
+    return (
+      <Select.Async
+        loadOptions={this.getOptions}
+        value={this.state.searchValue}
+        onChange={this.props.onSearchSelect}
+        placeholder={''}
+      />
+    );
+  }
+}

--- a/apps/test/unit/lib/levelbuilder/lesson-editor/ResourceEditorTest.js
+++ b/apps/test/unit/lib/levelbuilder/lesson-editor/ResourceEditorTest.js
@@ -22,6 +22,7 @@ describe('ResourcesEditor', () => {
   it('renders default props', () => {
     const wrapper = shallow(<ResourcesEditor {...defaultProps} />);
     expect(wrapper.find('tr').length).to.equal(resourceTestData.length + 1);
+    expect(wrapper.find('SearchBox').length).to.equal(1);
   });
 
   it('can remove a resource', () => {

--- a/apps/test/unit/lib/levelbuilder/lesson-editor/SearchBoxTest.js
+++ b/apps/test/unit/lib/levelbuilder/lesson-editor/SearchBoxTest.js
@@ -12,7 +12,7 @@ describe('SearchBox', () => {
     fetch_spy = sinon.stub(window, 'fetch');
     defaultProps = {
       onSearchSelect: () => {},
-      courseVersionId: 1,
+      additionalQueryParams: {extraParam1: 1, extraParam2: 2},
       searchUrl: 'fakesearch',
       constructOptions
     };
@@ -38,7 +38,7 @@ describe('SearchBox', () => {
       .getOptions('abc')
       .then(() => {
         expect(fetch_spy).to.have.been.calledWith(
-          '/fakesearch?query=abc&limit=7&courseVersionId=1'
+          '/fakesearch?query=abc&limit=7&extraParam1=1&extraParam2=2'
         );
         expect(constructOptions).to.have.been.calledWith(
           JSON.stringify(returnData)

--- a/apps/test/unit/lib/levelbuilder/lesson-editor/SearchBoxTest.js
+++ b/apps/test/unit/lib/levelbuilder/lesson-editor/SearchBoxTest.js
@@ -1,0 +1,25 @@
+import React from 'react';
+import {shallow} from 'enzyme';
+import sinon from 'sinon';
+import {expect} from '../../../../util/reconfiguredChai';
+import SearchBox from '@cdo/apps/lib/levelbuilder/lesson-editor/SearchBox';
+
+describe('SearchBox', () => {
+  let defaultProps, onSearchSelect, constructOptions;
+
+  beforeEach(() => {
+    onSearchSelect = sinon.spy();
+    constructOptions = sinon.spy();
+    defaultProps = {
+      onSearchSelect,
+      courseVersionId: 1,
+      searchUrl: 'fakesearch',
+      constructOptions
+    };
+  });
+
+  it('renders default props', () => {
+    const wrapper = shallow(<SearchBox {...defaultProps} />);
+    expect(wrapper.find('Async').length).to.equal(1);
+  });
+});

--- a/apps/test/unit/lib/levelbuilder/lesson-editor/SearchBoxTest.js
+++ b/apps/test/unit/lib/levelbuilder/lesson-editor/SearchBoxTest.js
@@ -5,11 +5,11 @@ import {expect} from '../../../../util/reconfiguredChai';
 import SearchBox from '@cdo/apps/lib/levelbuilder/lesson-editor/SearchBox';
 
 describe('SearchBox', () => {
-  let defaultProps, constructOptions, fetch_spy;
+  let defaultProps, constructOptions, fetchSpy;
 
   beforeEach(() => {
     constructOptions = sinon.spy();
-    fetch_spy = sinon.stub(window, 'fetch');
+    fetchSpy = sinon.stub(window, 'fetch');
     defaultProps = {
       onSearchSelect: () => {},
       additionalQueryParams: {extraParam1: 1, extraParam2: 2},
@@ -19,7 +19,7 @@ describe('SearchBox', () => {
   });
 
   afterEach(() => {
-    fetch_spy.restore();
+    fetchSpy.restore();
   });
 
   it('renders default props', () => {
@@ -30,14 +30,14 @@ describe('SearchBox', () => {
   it('searches when query is 3+ letters', () => {
     const wrapper = mount(<SearchBox {...defaultProps} />);
     let returnData = [{result: 'res1'}];
-    fetch_spy.returns(
+    fetchSpy.returns(
       Promise.resolve({ok: true, json: () => JSON.stringify(returnData)})
     );
     return wrapper
       .instance()
       .getOptions('abc')
       .then(() => {
-        expect(fetch_spy).to.have.been.calledWith(
+        expect(fetchSpy).to.have.been.calledWith(
           '/fakesearch?query=abc&limit=7&extraParam1=1&extraParam2=2'
         );
         expect(constructOptions).to.have.been.calledWith(
@@ -49,14 +49,14 @@ describe('SearchBox', () => {
   it('doesnt when query is < 3 letters', () => {
     const wrapper = mount(<SearchBox {...defaultProps} />);
     let returnData = [{result: 'res1'}];
-    fetch_spy.returns(
+    fetchSpy.returns(
       Promise.resolve({ok: true, json: () => JSON.stringify(returnData)})
     );
     return wrapper
       .instance()
       .getOptions('ab')
       .then(() => {
-        expect(fetch_spy).to.not.have.been.calledWith(
+        expect(fetchSpy).to.not.have.been.calledWith(
           '/fakesearch?query=abc&limit=7&courseVersionId=1'
         );
         expect(constructOptions).to.not.have.been.calledWith(

--- a/apps/test/unit/lib/levelbuilder/lesson-editor/SearchBoxTest.js
+++ b/apps/test/unit/lib/levelbuilder/lesson-editor/SearchBoxTest.js
@@ -1,25 +1,67 @@
 import React from 'react';
-import {shallow} from 'enzyme';
+import {mount, shallow} from 'enzyme';
 import sinon from 'sinon';
 import {expect} from '../../../../util/reconfiguredChai';
 import SearchBox from '@cdo/apps/lib/levelbuilder/lesson-editor/SearchBox';
 
 describe('SearchBox', () => {
-  let defaultProps, onSearchSelect, constructOptions;
+  let defaultProps, constructOptions, fetch_spy;
 
   beforeEach(() => {
-    onSearchSelect = sinon.spy();
     constructOptions = sinon.spy();
+    fetch_spy = sinon.stub(window, 'fetch');
     defaultProps = {
-      onSearchSelect,
+      onSearchSelect: () => {},
       courseVersionId: 1,
       searchUrl: 'fakesearch',
       constructOptions
     };
   });
 
+  afterEach(() => {
+    fetch_spy.restore();
+  });
+
   it('renders default props', () => {
     const wrapper = shallow(<SearchBox {...defaultProps} />);
     expect(wrapper.find('Async').length).to.equal(1);
+  });
+
+  it('searches when query is 3+ letters', () => {
+    const wrapper = mount(<SearchBox {...defaultProps} />);
+    let returnData = [{result: 'res1'}];
+    fetch_spy.returns(
+      Promise.resolve({ok: true, json: () => JSON.stringify(returnData)})
+    );
+    return wrapper
+      .instance()
+      .getOptions('abc')
+      .then(() => {
+        expect(fetch_spy).to.have.been.calledWith(
+          '/fakesearch?query=abc&limit=7&courseVersionId=1'
+        );
+        expect(constructOptions).to.have.been.calledWith(
+          JSON.stringify(returnData)
+        );
+      });
+  });
+
+  it('doesnt when query is < 3 letters', () => {
+    const wrapper = mount(<SearchBox {...defaultProps} />);
+    let returnData = [{result: 'res1'}];
+    fetch_spy.returns(
+      Promise.resolve({ok: true, json: () => JSON.stringify(returnData)})
+    );
+    return wrapper
+      .instance()
+      .getOptions('ab')
+      .then(() => {
+        expect(fetch_spy).to.not.have.been.calledWith(
+          '/fakesearch?query=abc&limit=7&courseVersionId=1'
+        );
+        expect(constructOptions).to.not.have.been.calledWith(
+          JSON.stringify(returnData)
+        );
+      });
   });
 });


### PR DESCRIPTION
I believe we're likely to use this component for vocabulary and block docs in the future, so pulling it out now. I put any specific business logic in props, which actually ended up producing a very generalizable component.



<!-- ### Background -->
<!-- ### Privacy -->
<!--
1.	Does the Project involve the collection, use or sharing of new Personal Data?

2.	Does the Project involve a new or changed use or sharing of existing Personal Data?
-->
<!-- ### Security -->
<!--
Link to Jira Task where sensitive security issues are discussed privately.
-->
<!-- ### Caching -->
<!-- ### Deployment strategy -->
<!-- ### Future work -->

## Links

<!--
  Any relevant links to external resources; ie, specification documents, jira
  items, related PRs, honeybadger errors, etc
-->

- [spec]()
- [jira]()

## Testing story

Doing this exacerbated my guilt about the lack of test coverage around resource searching so I added a new unit test. Testing debounced promises that execute a web request is a challenge and I'm open to ways to make it better!

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
