### PR TITLE
Backend for vocabulary search

### DIFF
--- a/dashboard/app/controllers/vocabularies_controller.rb
+++ b/dashboard/app/controllers/vocabularies_controller.rb
@@ -1,0 +1,6 @@
+class VocabulariesController < ApplicationController
+  # GET /vocabularysearch
+  def search
+    render json: VocabularyAutocomplete.get_search_matches(params[:query], params[:limit], params[:courseVersionId])
+  end
+end

--- a/dashboard/config/routes.rb
+++ b/dashboard/config/routes.rb
@@ -319,6 +319,8 @@ Dashboard::Application.routes.draw do
   resources :resources, only: [:create, :update]
   get '/resourcesearch', to: 'resources#search', defaults: {format: 'json'}
 
+  get '/vocabularysearch', to: 'vocabularies#search', defaults: {format: 'json'}
+
   get '/beta', to: redirect('/')
 
   get '/hoc/reset', to: 'script_levels#reset', script_id: Script::HOC_NAME, as: 'hoc_reset'

--- a/dashboard/lib/vocabulary_autocomplete.rb
+++ b/dashboard/lib/vocabulary_autocomplete.rb
@@ -1,0 +1,13 @@
+class VocabularyAutocomplete < AutocompleteHelper
+  def self.get_search_matches(query, limit, course_version_id)
+    limit = format_limit(limit)
+
+    rows = Vocabulary.limit(limit)
+    rows = rows.where(course_version_id: course_version_id)
+    return [] if query.length < MIN_WORD_LENGTH
+    query = format_query(query)
+    rows = rows.
+      where("MATCH(word,definition) AGAINST(? in BOOLEAN MODE)", query)
+    return rows.map(&:attributes)
+  end
+end

--- a/dashboard/test/fixtures/vocabulary.yml
+++ b/dashboard/test/fixtures/vocabulary.yml
@@ -1,0 +1,20 @@
+vocab_1_2018:
+  key: "Algorithm"
+  word: "Algorithm"
+  definition: "A list of steps to finish a task."
+  course_version: course_version_2018
+vocab_2_2018:
+  key: "Debugging"
+  word: "Debugging"
+  definition: "Finding and fixing problems in an algorithm or program."
+  course_version: course_version_2018
+vocab_3_2018:
+  key: "Programming"
+  word: "Programming"
+  definition: "The art of creating a program."
+  course_version: course_version_2018
+vocab_1_2019:
+  key: "Algorithm"
+  word: "Algorithm"
+  definition: "A list of steps to finish a task."
+  course_version: course_version_2019

--- a/dashboard/test/lib/vocabulary_autocomplete_test.rb
+++ b/dashboard/test/lib/vocabulary_autocomplete_test.rb
@@ -1,0 +1,44 @@
+require 'test_helper'
+
+class VocabularyAutocompleteTest < ActiveSupport::TestCase
+  # We rely on fulltext indices to be used in this test.
+  # In order to get this test to work, we need to have the vocabularies created
+  # as fixtures. These are defined in test/fixtures/vocabulary.yml
+
+  setup do
+    @course_version_2018 = CourseVersion.find_by_key('2018')
+    @course_version_2019 = CourseVersion.find_by_key('2019')
+  end
+
+  test "finds vocabulary with matching word" do
+    matches = VocabularyAutocomplete.get_search_matches('programming', 5, @course_version_2018.id)
+    assert_equal 1, matches.length
+    assert_equal 'Programming', matches[0]['word']
+    assert_equal 'The art of creating a program.', matches[0]['definition']
+  end
+
+  test "finds vocabulary with match definition" do
+    matches = VocabularyAutocomplete.get_search_matches('fixing', 5, @course_version_2018)
+    assert_equal 1, matches.length
+    assert_equal 'Debugging', matches[0]['word']
+  end
+
+  test "finds multiple matches" do
+    matches = VocabularyAutocomplete.get_search_matches('pro', 5, @course_version_2018)
+    assert_equal 2, matches.length
+    assert_equal ['Debugging', 'Programming'], matches.map {|m| m['word']}
+  end
+
+  test "restricts matches by limit" do
+    matches = VocabularyAutocomplete.get_search_matches('pro', 1, @course_version_2018)
+    assert_equal 1, matches.length
+  end
+
+  test "restricts matches by course version id" do
+    # There's a definition for algorithm in two course versions
+    # We should only get the one we requested
+    matches = VocabularyAutocomplete.get_search_matches('algorithm', 1, @course_version_2019)
+    assert_equal 1, matches.length
+    assert_equal @course_version_2019.id, matches[0]['course_version_id']
+  end
+end


### PR DESCRIPTION
For vocabulary, we want to search by word and definitions. This use is very similar to what we did with resources and `VocabularyAutocomplete` is pretty similar to `ResourceAutocomplete`. As with resource autocomplete, the test data needs to be in fixtures so that is pre-loaded into the database. We already have course version fixtures so I just reused those for vocab.

If you pull this branch, a URL like http://localhost-studio.code.org:3000/vocabularysearch?limit=7&query=pro&courseVersionId=50 (courseVersionId may need to be changed) should return some results. 

<!-- ### Background -->
<!-- ### Privacy -->
<!--
1.	Does the Project involve the collection, use or sharing of new Personal Data?

2.	Does the Project involve a new or changed use or sharing of existing Personal Data?
-->
<!-- ### Security -->
<!--
Link to Jira Task where sensitive security issues are discussed privately.
-->
<!-- ### Caching -->
<!-- ### Deployment strategy -->
<!-- ### Future work -->

## Testing story

Added unit tests, some manual testing

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
