### PR TITLE
Update redirect rules for pl pages

### DIFF
--- a/aws/s3/cdo-curriculum/redirection_rules.rb
+++ b/aws/s3/cdo-curriculum/redirection_rules.rb
@@ -74,6 +74,16 @@ routing_rules = [
   },
   {
     condition: {
+      key_prefix_equals: "plcsf-current/"
+    },
+    redirect: {
+      host_name: HOST_NAME,
+      replace_key_prefix_with: "plcsf-20/",
+      http_redirect_code: "302"
+    }
+  },
+  {
+    condition: {
       key_prefix_equals: "plcsd/"
     },
     redirect: {
@@ -84,7 +94,27 @@ routing_rules = [
   },
   {
     condition: {
+      key_prefix_equals: "plcsd-current/"
+    },
+    redirect: {
+      host_name: HOST_NAME,
+      replace_key_prefix_with: "plcsd-20/",
+      http_redirect_code: "302"
+    }
+  },
+  {
+    condition: {
       key_prefix_equals: "plcsp/"
+    },
+    redirect: {
+      host_name: HOST_NAME,
+      replace_key_prefix_with: "plcsp-20/",
+      http_redirect_code: "302"
+    }
+  },
+  {
+    condition: {
+      key_prefix_equals: "plcsp-current/"
     },
     redirect: {
       host_name: HOST_NAME,


### PR DESCRIPTION
The old course version warning on curriculum builder uses `/<canonical-slug>-current/` as the way to redirect users to the right current course. Canonical slug is set on the curriculum edit page. We have existing redirects for csp-current, csd-current, and csf-current but not the pl pages. This created redirect rules for plcsp-current, plcsd-current, plcsf-current.

![Screen Shot 2021-01-14 at 4 47 09 PM](https://user-images.githubusercontent.com/208083/104653138-27e82b80-5688-11eb-9e2e-c485995b6677.png)

