### PR TITLE
make script_id required in teacher_feedbacks

### DIFF
--- a/dashboard/app/models/teacher_feedback.rb
+++ b/dashboard/app/models/teacher_feedback.rb
@@ -26,7 +26,7 @@
 
 class TeacherFeedback < ApplicationRecord
   acts_as_paranoid # use deleted_at column instead of deleting rows
-  validates_presence_of :student_id, :level_id, :teacher_id, :script_level_id, unless: :deleted?
+  validates_presence_of :student_id, :script_id, :level_id, :teacher_id, :script_level_id, unless: :deleted?
   belongs_to :student, class_name: 'User'
   has_many :student_sections, class_name: 'Section', through: :student, source: 'sections_as_student'
   belongs_to :script

--- a/dashboard/app/models/teacher_feedback.rb
+++ b/dashboard/app/models/teacher_feedback.rb
@@ -33,7 +33,7 @@ class TeacherFeedback < ApplicationRecord
   belongs_to :level
   belongs_to :script_level
   belongs_to :teacher, class_name: 'User'
-  validate :validate_script_and_script_level
+  validate :validate_script_and_script_level, on: :create
 
   def validate_script_and_script_level
     if script_level.script_id != script_id

--- a/dashboard/app/models/teacher_feedback.rb
+++ b/dashboard/app/models/teacher_feedback.rb
@@ -29,6 +29,7 @@ class TeacherFeedback < ApplicationRecord
   validates_presence_of :student_id, :level_id, :teacher_id, :script_level_id, unless: :deleted?
   belongs_to :student, class_name: 'User'
   has_many :student_sections, class_name: 'Section', through: :student, source: 'sections_as_student'
+  belongs_to :script
   belongs_to :level
   belongs_to :script_level
   belongs_to :teacher, class_name: 'User'

--- a/dashboard/app/models/teacher_feedback.rb
+++ b/dashboard/app/models/teacher_feedback.rb
@@ -16,7 +16,7 @@
 #  student_last_visited_at  :datetime
 #  script_level_id          :integer          not null
 #  seen_on_feedback_page_at :datetime
-#  script_id                :integer
+#  script_id                :integer          not null
 #
 # Indexes
 #

--- a/dashboard/app/models/teacher_feedback.rb
+++ b/dashboard/app/models/teacher_feedback.rb
@@ -33,6 +33,13 @@ class TeacherFeedback < ApplicationRecord
   belongs_to :level
   belongs_to :script_level
   belongs_to :teacher, class_name: 'User'
+  validate :validate_script_and_script_level
+
+  def validate_script_and_script_level
+    if script_level.script_id != script_id
+      errors.add(:script_id, 'script_id does not match script_level.script_id')
+    end
+  end
 
   def self.get_student_level_feedback(student_id, level_id, teacher_id)
     where(

--- a/dashboard/db/migrate/20210113224752_backfill_script_id_in_teacher_feedbacks.rb
+++ b/dashboard/db/migrate/20210113224752_backfill_script_id_in_teacher_feedbacks.rb
@@ -1,0 +1,25 @@
+class BackfillScriptIdInTeacherFeedbacks < ActiveRecord::Migration[5.2]
+  def up
+    # In production, this migration will already have been done via
+    # bin/oneoff/backfill_data/backfill_script_ids_in_teacher_feedbacks.rb,
+    # because this operation may take longer there to update 2M rows then we
+    # want to spend in the middle of a deploy to production.
+    #
+    # The purpose of this part of the migration is to fix any other environments,
+    # such as staging, test, and local development.
+    unless Rails.env.production?
+      # Do not batch, because we do not expect many of these to exist in
+      # non-production environments.
+      TeacherFeedback.where(script_id: nil).find_each do |teacher_feedback|
+        script_id = teacher_feedback.script_level.script_id
+        teacher_feedback.update!(script_id: script_id)
+      end
+    end
+
+    change_column :teacher_feedbacks, :script_id, :integer, null: false
+  end
+
+  def down
+    change_column :teacher_feedbacks, :script_id, :integer, null: true
+  end
+end

--- a/dashboard/db/migrate/20210113224752_backfill_script_id_in_teacher_feedbacks.rb
+++ b/dashboard/db/migrate/20210113224752_backfill_script_id_in_teacher_feedbacks.rb
@@ -10,7 +10,7 @@ class BackfillScriptIdInTeacherFeedbacks < ActiveRecord::Migration[5.2]
     unless Rails.env.production?
       # Do not batch, because we do not expect many of these to exist in
       # non-production environments.
-      TeacherFeedback.where(script_id: nil).find_each do |teacher_feedback|
+      TeacherFeedback.with_deleted.where(script_id: nil).find_each do |teacher_feedback|
         script_id = teacher_feedback.script_level.script_id
         teacher_feedback.update!(script_id: script_id)
       end

--- a/dashboard/db/schema.rb
+++ b/dashboard/db/schema.rb
@@ -1620,7 +1620,7 @@ ActiveRecord::Schema.define(version: 2021_01_21_195951) do
     t.datetime "student_last_visited_at"
     t.integer "script_level_id", null: false
     t.datetime "seen_on_feedback_page_at"
-    t.integer "script_id"
+    t.integer "script_id", null: false
     t.index ["student_id", "level_id", "teacher_id"], name: "index_feedback_on_student_and_level_and_teacher_id"
     t.index ["teacher_id"], name: "index_teacher_feedbacks_on_teacher_id"
   end

--- a/dashboard/test/controllers/api/v1/teacher_feedbacks_controller_test.rb
+++ b/dashboard/test/controllers/api/v1/teacher_feedbacks_controller_test.rb
@@ -19,10 +19,11 @@ class Api::V1::TeacherFeedbacksControllerTest < ActionDispatch::IntegrationTest
     @section.add_student(@student)
     @level = create :level
     @script_level = create :script_level
+    @script = @script_level.script
   end
 
   test 'can be created' do
-    teacher_sign_in_and_give_feedback(@teacher, @student, @level, @script_level, COMMENT1, PERFORMANCE1)
+    teacher_sign_in_and_give_feedback(@teacher, @student, @script, @level, @script_level, COMMENT1, PERFORMANCE1)
     teacher_feedback = TeacherFeedback.last
 
     assert_equal @student.id, teacher_feedback.student_id
@@ -38,7 +39,7 @@ class Api::V1::TeacherFeedbacksControllerTest < ActionDispatch::IntegrationTest
   end
 
   test 'can be retrieved by teacher' do
-    teacher_sign_in_and_give_feedback(@teacher, @student, @level, @script_level, COMMENT1, PERFORMANCE1)
+    teacher_sign_in_and_give_feedback(@teacher, @student, @script, @level, @script_level, COMMENT1, PERFORMANCE1)
     get "#{API}/get_feedback_from_teacher", params: {student_id: @student.id, level_id: @level.id, teacher_id: @teacher.id}
 
     assert_equal COMMENT1, parsed_response['comment']
@@ -49,8 +50,8 @@ class Api::V1::TeacherFeedbacksControllerTest < ActionDispatch::IntegrationTest
     student2 = create :student
     @section.add_student(student2)
 
-    teacher_sign_in_and_give_feedback(@teacher, @student, @level, @script_level, COMMENT1, PERFORMANCE1)
-    teacher_sign_in_and_give_feedback(@teacher, student2, @level, @script_level, COMMENT2, PERFORMANCE2)
+    teacher_sign_in_and_give_feedback(@teacher, @student, @script, @level, @script_level, COMMENT1, PERFORMANCE1)
+    teacher_sign_in_and_give_feedback(@teacher, student2, @script, @level, @script_level, COMMENT2, PERFORMANCE2)
     get "#{API}/get_feedback_from_teacher", params: {student_id: @student.id, level_id: @level.id, teacher_id: @teacher.id}
 
     assert_response :success
@@ -64,10 +65,10 @@ class Api::V1::TeacherFeedbacksControllerTest < ActionDispatch::IntegrationTest
     section2 = create :section, user: teacher2
     section2.add_student(@student)
 
-    teacher_sign_in_and_give_feedback(@teacher, @student, @level, @script_level, COMMENT1, PERFORMANCE1)
+    teacher_sign_in_and_give_feedback(@teacher, @student, @script, @level, @script_level, COMMENT1, PERFORMANCE1)
     sign_out @teacher
 
-    teacher_sign_in_and_give_feedback(teacher2, @student, @level, @script_level, COMMENT2, PERFORMANCE2)
+    teacher_sign_in_and_give_feedback(teacher2, @student, @script, @level, @script_level, COMMENT2, PERFORMANCE2)
     sign_out teacher2
 
     sign_in @teacher
@@ -86,9 +87,9 @@ class Api::V1::TeacherFeedbacksControllerTest < ActionDispatch::IntegrationTest
     level3 = create :level
     script_level3 = create :script_level
 
-    teacher_sign_in_and_give_feedback(@teacher, @student, @level, @script_level, COMMENT1, PERFORMANCE1)
-    teacher_sign_in_and_give_feedback(@teacher, @student, level2, script_level2, COMMENT2, PERFORMANCE2)
-    teacher_sign_in_and_give_feedback(@teacher, @student, level3, script_level3, COMMENT3, PERFORMANCE3)
+    teacher_sign_in_and_give_feedback(@teacher, @student, @script, @level, @script_level, COMMENT1, PERFORMANCE1)
+    teacher_sign_in_and_give_feedback(@teacher, @student, @script, level2, script_level2, COMMENT2, PERFORMANCE2)
+    teacher_sign_in_and_give_feedback(@teacher, @student, @script, level3, script_level3, COMMENT3, PERFORMANCE3)
     get "#{API}/get_feedback_from_teacher", params: {student_id: @student.id, level_id: level2.id, teacher_id: @teacher.id}
 
     assert_equal COMMENT2, parsed_response['comment']
@@ -96,9 +97,9 @@ class Api::V1::TeacherFeedbacksControllerTest < ActionDispatch::IntegrationTest
   end
 
   test 'retrieves the most recent feedback from a teacher' do
-    teacher_sign_in_and_give_feedback(@teacher, @student, @level, @script_level, COMMENT1, PERFORMANCE1)
-    teacher_sign_in_and_give_feedback(@teacher, @student, @level, @script_level, COMMENT2, PERFORMANCE2)
-    teacher_sign_in_and_give_feedback(@teacher, @student, @level, @script_level, COMMENT3, PERFORMANCE3)
+    teacher_sign_in_and_give_feedback(@teacher, @student, @script, @level, @script_level, COMMENT1, PERFORMANCE1)
+    teacher_sign_in_and_give_feedback(@teacher, @student, @script, @level, @script_level, COMMENT2, PERFORMANCE2)
+    teacher_sign_in_and_give_feedback(@teacher, @student, @script, @level, @script_level, COMMENT3, PERFORMANCE3)
     get "#{API}/get_feedback_from_teacher", params: {student_id: @student.id, level_id: @level.id, teacher_id: @teacher.id}
 
     assert_equal COMMENT3, parsed_response['comment']
@@ -106,21 +107,21 @@ class Api::V1::TeacherFeedbacksControllerTest < ActionDispatch::IntegrationTest
   end
 
   test 'bad request when student_id not provided - get_feedback_from_teacher' do
-    teacher_sign_in_and_give_feedback(@teacher, @student, @level, @script_level, COMMENT1, PERFORMANCE1)
+    teacher_sign_in_and_give_feedback(@teacher, @student, @script, @level, @script_level, COMMENT1, PERFORMANCE1)
     get "#{API}/get_feedback_from_teacher", params: {level_id: @level.id, teacher_id: @teacher.id}
 
     assert_response :bad_request
   end
 
   test 'bad request when level_id not provided - get_feedback_from_teacher' do
-    teacher_sign_in_and_give_feedback(@teacher, @student, @level, @script_level, COMMENT1, PERFORMANCE1)
+    teacher_sign_in_and_give_feedback(@teacher, @student, @script, @level, @script_level, COMMENT1, PERFORMANCE1)
     get "#{API}/get_feedback_from_teacher", params: {student_id: @student.id, teacher_id: @teacher.id}
 
     assert_response :bad_request
   end
 
   test 'bad request when teacher_id not provided - get_feedback_from_teacher' do
-    teacher_sign_in_and_give_feedback(@teacher, @student, @level, @script_level, COMMENT1, PERFORMANCE1)
+    teacher_sign_in_and_give_feedback(@teacher, @student, @script, @level, @script_level, COMMENT1, PERFORMANCE1)
     get "#{API}/get_feedback_from_teacher", params: {student_id: @student.id, level_id: @level.id}
 
     assert_response :bad_request
@@ -142,14 +143,14 @@ class Api::V1::TeacherFeedbacksControllerTest < ActionDispatch::IntegrationTest
 
   test 'count is accurate when feedback is available' do
     sign_in @student
-    teacher_sign_in_and_give_feedback(@teacher, @student, @level, @script_level, COMMENT1, PERFORMANCE1)
+    teacher_sign_in_and_give_feedback(@teacher, @student, @script, @level, @script_level, COMMENT1, PERFORMANCE1)
     sign_out @teacher
 
     sign_in @student
     get "#{API}/count"
     assert_equal "1", response.body
 
-    teacher_sign_in_and_give_feedback(@teacher, @student, @level, @script_level, COMMENT2, PERFORMANCE2)
+    teacher_sign_in_and_give_feedback(@teacher, @student, @script, @level, @script_level, COMMENT2, PERFORMANCE2)
     sign_out @teacher
 
     sign_in @student
@@ -160,7 +161,7 @@ class Api::V1::TeacherFeedbacksControllerTest < ActionDispatch::IntegrationTest
 
   test 'count does not include already seen feedback' do
     sign_in @student
-    teacher_sign_in_and_give_feedback(@teacher, @student, @level, @script_level, COMMENT1, PERFORMANCE1)
+    teacher_sign_in_and_give_feedback(@teacher, @student, @script, @level, @script_level, COMMENT1, PERFORMANCE1)
     sign_out @teacher
 
     sign_in @student
@@ -178,7 +179,7 @@ class Api::V1::TeacherFeedbacksControllerTest < ActionDispatch::IntegrationTest
   end
 
   test 'count does not include feedback from a not authorized teacher' do
-    teacher_sign_in_and_give_feedback(@not_authorized_teacher, @student, @level, @script_level, COMMENT1, PERFORMANCE1)
+    teacher_sign_in_and_give_feedback(@not_authorized_teacher, @student, @script, @level, @script_level, COMMENT1, PERFORMANCE1)
     sign_out @not_authorized_teacher
 
     sign_in @student
@@ -188,22 +189,22 @@ class Api::V1::TeacherFeedbacksControllerTest < ActionDispatch::IntegrationTest
   end
 
   test 'bad request when student_id not provided - get_feedbacks' do
-    teacher_sign_in_and_give_feedback(@teacher, @student, @level, @script_level, COMMENT1, PERFORMANCE1)
+    teacher_sign_in_and_give_feedback(@teacher, @student, @script, @level, @script_level, COMMENT1, PERFORMANCE1)
     get "#{API}/get_feedbacks", params: {level_id: @level.id}
 
     assert_response :bad_request
   end
 
   test 'bad request when level_id not provided - get_feedbacks' do
-    teacher_sign_in_and_give_feedback(@teacher, @student, @level, @script_level, COMMENT1, PERFORMANCE1)
+    teacher_sign_in_and_give_feedback(@teacher, @student, @script, @level, @script_level, COMMENT1, PERFORMANCE1)
     get "#{API}/get_feedbacks", params: {student_id: @student.id}
 
     assert_response :bad_request
   end
 
   test 'student can retrieve feedback for a level - two comments, one teacher' do
-    teacher_sign_in_and_give_feedback(@teacher, @student, @level, @script_level, COMMENT1, PERFORMANCE1)
-    teacher_sign_in_and_give_feedback(@teacher, @student, @level, @script_level, COMMENT2, PERFORMANCE2)
+    teacher_sign_in_and_give_feedback(@teacher, @student, @script, @level, @script_level, COMMENT1, PERFORMANCE1)
+    teacher_sign_in_and_give_feedback(@teacher, @student, @script, @level, @script_level, COMMENT2, PERFORMANCE2)
     sign_out @teacher
 
     sign_in @student
@@ -219,11 +220,11 @@ class Api::V1::TeacherFeedbacksControllerTest < ActionDispatch::IntegrationTest
     section2 = create :section, user: teacher2
     section2.add_student(@student)
 
-    teacher_sign_in_and_give_feedback(@teacher, @student, @level, @script_level, COMMENT1, PERFORMANCE1)
+    teacher_sign_in_and_give_feedback(@teacher, @student, @script, @level, @script_level, COMMENT1, PERFORMANCE1)
     sign_out @teacher
-    teacher_sign_in_and_give_feedback(teacher2, @student, @level, @script_level, COMMENT2, PERFORMANCE2)
+    teacher_sign_in_and_give_feedback(teacher2, @student, @script, @level, @script_level, COMMENT2, PERFORMANCE2)
     sign_out teacher2
-    teacher_sign_in_and_give_feedback(@teacher, @student, @level, @script_level, COMMENT3, PERFORMANCE3)
+    teacher_sign_in_and_give_feedback(@teacher, @student, @script, @level, @script_level, COMMENT3, PERFORMANCE3)
     sign_out @teacher
 
     sign_in @student
@@ -239,9 +240,10 @@ class Api::V1::TeacherFeedbacksControllerTest < ActionDispatch::IntegrationTest
   test 'student can retrieve feedback for a level - two levels, one comment per level, one teacher' do
     level2 = create :level
     script_level2 = create :script_level
+    script2 = script_level2.script
 
-    teacher_sign_in_and_give_feedback(@teacher, @student, @level, @script_level, COMMENT1, PERFORMANCE1)
-    teacher_sign_in_and_give_feedback(@teacher, @student, level2, script_level2, COMMENT2, PERFORMANCE2)
+    teacher_sign_in_and_give_feedback(@teacher, @student, @script, @level, @script_level, COMMENT1, PERFORMANCE1)
+    teacher_sign_in_and_give_feedback(@teacher, @student, script2, level2, script_level2, COMMENT2, PERFORMANCE2)
     sign_out @teacher
 
     sign_in @student
@@ -264,7 +266,7 @@ class Api::V1::TeacherFeedbacksControllerTest < ActionDispatch::IntegrationTest
     @section1 = create :section, user: @teacher1
     @section1.add_student(@student)
 
-    teacher_sign_in_and_give_feedback(@teacher1, @student, @level, @script_level, COMMENT1, PERFORMANCE1)
+    teacher_sign_in_and_give_feedback(@teacher1, @student, @script, @level, @script_level, COMMENT1, PERFORMANCE1)
     sign_in @student
     get "#{API}/get_feedbacks", params: {student_id: @student.id, level_id: @level.id}
 
@@ -297,10 +299,11 @@ class Api::V1::TeacherFeedbacksControllerTest < ActionDispatch::IntegrationTest
 
   # Sign in as teacher and leave feedback for student on level.
   # Assert that the feedback request was successful
-  def teacher_sign_in_and_give_feedback(teacher, student, level, script_level, comment, performance)
+  def teacher_sign_in_and_give_feedback(teacher, student, script, level, script_level, comment, performance)
     sign_in teacher
     params = {
       student_id: student.id,
+      script_id: script.id,
       level_id:  level.id,
       script_level_id: script_level.id,
       comment: comment,

--- a/dashboard/test/controllers/api/v1/teacher_feedbacks_controller_test.rb
+++ b/dashboard/test/controllers/api/v1/teacher_feedbacks_controller_test.rb
@@ -84,12 +84,14 @@ class Api::V1::TeacherFeedbacksControllerTest < ActionDispatch::IntegrationTest
   test 'retrieves comment on requested level when teacher has given student feedback on multiple levels' do
     level2 = create :level
     script_level2 = create :script_level
+    script2 = script_level2.script
     level3 = create :level
     script_level3 = create :script_level
+    script3 = script_level3.script
 
     teacher_sign_in_and_give_feedback(@teacher, @student, @script, @level, @script_level, COMMENT1, PERFORMANCE1)
-    teacher_sign_in_and_give_feedback(@teacher, @student, @script, level2, script_level2, COMMENT2, PERFORMANCE2)
-    teacher_sign_in_and_give_feedback(@teacher, @student, @script, level3, script_level3, COMMENT3, PERFORMANCE3)
+    teacher_sign_in_and_give_feedback(@teacher, @student, script2, level2, script_level2, COMMENT2, PERFORMANCE2)
+    teacher_sign_in_and_give_feedback(@teacher, @student, script3, level3, script_level3, COMMENT3, PERFORMANCE3)
     get "#{API}/get_feedback_from_teacher", params: {student_id: @student.id, level_id: level2.id, teacher_id: @teacher.id}
 
     assert_equal COMMENT2, parsed_response['comment']

--- a/dashboard/test/factories/factories.rb
+++ b/dashboard/test/factories/factories.rb
@@ -1308,6 +1308,7 @@ FactoryGirl.define do
     association :teacher
     association :level
     association :script_level
+    association :script
   end
 
   factory :teacher_score do

--- a/dashboard/test/factories/factories.rb
+++ b/dashboard/test/factories/factories.rb
@@ -1307,8 +1307,11 @@ FactoryGirl.define do
     association :student
     association :teacher
     association :level
-    association :script_level
     association :script
+
+    script_level do |tf|
+      create :script_level, script: tf.script, levels: [tf.level]
+    end
   end
 
   factory :teacher_score do


### PR DESCRIPTION
Finishes [PLAT-684]. See [migrating teacher feedback ids](https://docs.google.com/document/d/1SJVYtKSmOchUOcGnAOWU4Ph1u2utOc896EX_acbAnJM/edit#) for more context.

Previous PRs:
* #38553 makes sure the script_id field is always set when creating new TeacherFeedback objects
* #38567 contains a backfill script which will be run in production before this migration is shipped

This PR contains a migration which does the following:
1. backfills data in non-production environments
2. marks the script_id column as non-null
3. adds validations to ensure script_id is present and equal to script_level.script_id
4. fixes unit tests to meet new constraints

## Testing story

Ran the migration forward and backward locally, which succeeds even when some TeacherFeedbacks have no script_id.

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked


[PLAT-684]: https://codedotorg.atlassian.net/browse/PLAT-684