### PR TITLE
Define test data association after persisting

### DIFF
--- a/dashboard/test/models/vocabulary_test.rb
+++ b/dashboard/test/models/vocabulary_test.rb
@@ -9,7 +9,11 @@ class VocabularyTest < ActiveSupport::TestCase
 
   test "vocabulary can be added to a lesson" do
     lesson = create :lesson
-    vocab = create :vocabulary, key: 'foo', word: 'foo', definition: 'a fake word', lessons: [lesson]
+    vocab = create :vocabulary, key: 'foo', word: 'foo', definition: 'a fake word'
+    # Associate vocab with lesson after save; otherwise, Lesson will complain
+    # about missing vocabulary_id
+    vocab.lessons = [lesson]
+
     assert_equal 1, vocab.lessons.length
     assert_equal 1, lesson.vocabularies.length
   end


### PR DESCRIPTION
I'm not entirely sure why, but on Rails 6 we get `ActiveRecord::NotNullViolation: Mysql2::Error: Field 'vocabulary_id' doesn't have a default value` when trying to create the model and association simultaneously.

## Testing story

N/A

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
