### PR TITLE
Fixes the lesson positions after a lesson edit page save

### DIFF
--- a/dashboard/app/controllers/lessons_controller.rb
+++ b/dashboard/app/controllers/lessons_controller.rb
@@ -51,6 +51,7 @@ class LessonsController < ApplicationController
     end
 
     if Rails.application.config.levelbuilder_mode
+      @lesson.script.fix_lesson_positions
       @lesson.script.reload
 
       # This endpoint will only be hit from the lesson edit page, which is only

--- a/dashboard/app/models/script.rb
+++ b/dashboard/app/models/script.rb
@@ -1059,7 +1059,7 @@ class Script < ApplicationRecord
   end
 
   # Lessons unfortunately have 2 position values:
-  # 1. absolute_position: position within the Script
+  # 1. absolute_position: position within the script (used to order lessons with in lesson groups in correct order)
   # 2. relative_position: position within the Script relative other lockable/non-lockable lessons
   # This method updates the position values for all lessons in a script after
   # a lesson is saved

--- a/dashboard/app/models/script.rb
+++ b/dashboard/app/models/script.rb
@@ -1058,6 +1058,27 @@ class Script < ApplicationRecord
     end
   end
 
+  # Lessons unfortunately have 2 position values:
+  # 1. absolute_position: position within the Script
+  # 2. relative_position: position within the Script relative other lockable/non-lockable lessons
+  # This method updates the position values for all lessons in a script after
+  # a lesson is saved
+  def fix_lesson_positions
+    reload
+
+    total_count = 1
+    lockable_count = 1
+    non_lockable_count = 1
+    lessons.each do |lesson|
+      lesson.absolute_position = total_count
+      lesson.relative_position = lesson.lockable ? lockable_count : non_lockable_count
+      lesson.save!
+
+      total_count += 1
+      lesson.lockable ? (lockable_count += 1) : (non_lockable_count += 1)
+    end
+  end
+
   # Clone this script, appending a dash and the suffix to the name of this
   # script. Also clone all the levels in the script, appending an underscore and
   # the suffix to the name of each level. Mark the new script as hidden, and

--- a/dashboard/test/controllers/lessons_controller_test.rb
+++ b/dashboard/test/controllers/lessons_controller_test.rb
@@ -16,6 +16,8 @@ class LessonsControllerTest < ActionController::TestCase
       script_id: @script.id,
       lesson_group: lesson_group,
       name: 'lesson display name',
+      absolute_position: 1,
+      relative_position: 1,
       properties: {
         overview: 'lesson overview',
         student_overview: 'student overview'
@@ -26,7 +28,9 @@ class LessonsControllerTest < ActionController::TestCase
       :lesson,
       script_id: @script.id,
       lesson_group: lesson_group,
-      name: 'second lesson'
+      name: 'second lesson',
+      absolute_position: 2,
+      relative_position: 2
     )
 
     @script_title = 'Script Display Name'
@@ -249,6 +253,26 @@ class LessonsControllerTest < ActionController::TestCase
     ].to_json
     put :update, params: @update_params
     assert_response :forbidden
+  end
+
+  test 'updates lesson positions on lesson update' do
+    sign_in @levelbuilder
+
+    assert_equal 1, @lesson.relative_position
+    assert_equal 1, @lesson.absolute_position
+    assert_equal 2, @lesson2.relative_position
+    assert_equal 2, @lesson2.absolute_position
+
+    @update_params['lockable'] = true
+
+    put :update, params: @update_params
+
+    @lesson.reload
+    @lesson2.reload
+    assert_equal 1, @lesson.relative_position
+    assert_equal 1, @lesson.absolute_position
+    assert_equal 1, @lesson2.relative_position
+    assert_equal 2, @lesson2.absolute_position
   end
 
   test 'add activity via lesson update' do


### PR DESCRIPTION
## Background
The relative position of lessons should be set based on their position within a script relative to other lockable/non-lockable lessons. When we moved the lockable setting to the lesson edit page for migrated courses relative position stopped getting updated when the lockable setting was changed. This is because the logic associated with updating relative position is part of the script saving process where the lockable setting used to live, in the script DSL.

## Solution
Adds a method to update the absolute and relative positions of all the lessons in a script after one of the lessons in that script is saved using the new lesson edit page. 

## Future Work
We are working toward a point where relative position will be based on if a lesson has a lesson plan not if its lockable but that will come later. 

## Links

<!--
  Any relevant links to external resources; ie, specification documents, jira
  items, related PRs, honeybadger errors, etc
-->

- [lockable lessons and lessons without lesson plan spec](https://docs.google.com/document/d/1sAAVnwv3rXQEK-qa8JnkNXFfZ0vjWQyzJ9Yx_pG4bdg/edit#)
- [jira](https://codedotorg.atlassian.net/browse/PLAT-470)

## Testing story

Added a test to the lesson_controller_tests to check that update updates the positions of lessons correctly.

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
