### PR TITLE
[Flappy] Switch to GoogleBlockly

### DIFF
--- a/dashboard/app/helpers/levels_helper.rb
+++ b/dashboard/app/helpers/levels_helper.rb
@@ -313,7 +313,7 @@ module LevelsHelper
     use_blockly = !use_droplet && !use_netsim && !use_weblab
     use_p5 = @level.is_a?(Gamelab)
     hide_source = app_options[:hideSource]
-    use_google_blockly = view_options[:useGoogleBlockly]
+    use_google_blockly = @level.is_a?(Flappy) || view_options[:useGoogleBlockly]
     render partial: 'levels/apps_dependencies',
       locals: {
         app: app_options[:app],

--- a/dashboard/test/ui/features/star_labs/blocklayout.feature
+++ b/dashboard/test/ui/features/star_labs/blocklayout.feature
@@ -8,12 +8,12 @@ Background:
 Scenario: Auto-placing malformed start blocks
   When I've initialized the workspace with an auto-positioned flappy puzzle with extra newlines
   Then block "18" is near offset "16, 16"
-  And block "21" is near offset "16, 107"
+  And block "21" is near offset "16, 114"
 
 Scenario: Auto-placing blocks
   When I've initialized the workspace with an auto-positioned flappy puzzle
   Then block "18" is near offset "16, 16"
-  And block "21" is near offset "16, 107"
+  And block "21" is near offset "16, 114"
 
 Scenario: Auto-placing blocks with XML positioning
   Given I am on "http://studio.code.org/s/allthethings/stage/5/puzzle/4?noautoplay=true"

--- a/dashboard/test/ui/features/star_labs/flappydrag.feature
+++ b/dashboard/test/ui/features/star_labs/flappydrag.feature
@@ -8,4 +8,4 @@ Scenario: Connect two blocks from toolbox
   And I drag block "1" to block "3"
   And I drag block "1" to block "4"
   And I wait for 1 seconds
-  Then block "5" is child of block "4"
+  Then block "6" is child of block "4"


### PR DESCRIPTION
We originally switched Flappy to GoogleBlockly on Nov 2, 2020 with https://github.com/code-dot-org/code-dot-org/pull/37605.
During HOC 2020, we discovered a regression with iPads using iOS 12. To fix this, we switched back to CdoBlockly with  code-dot-org/code-dot-org#38162.

The iOS12 issue ended up being two things:
1. The first issue was a GoogleBlockly issue- details in [this issue](https://github.com/google/blockly/issues/4510) and fixed by [this PR](https://github.com/google/blockly/pull/4517). That PR was included in [this release](https://github.com/google/blockly/releases/tag/4.20201217.0), which we pulled in [here](https://github.com/code-dot-org/code-dot-org/pull/38339).
2. The second issue turned out to be on our side. We have a polyfill for `PointerEvent`s, but Google Blockly uses the presence of `window.PointerEvent` to determine what events to listen for. More details in [this PR](https://github.com/code-dot-org/code-dot-org/pull/38522)

Now that both of these are fixed, Flappy works as expected on iPads with iOS 12. We also did some bug bashing on other devices to make sure there weren't other regressions, so I think we should be safe to flip Flappy back over to always using Google blockly.

Device/browsers tested:
google pixel3a / chrome
iphone / safari
chromebook
linux
mac / chrome, safari, firefox
iPad iOS 12 / chrome, safari
iPad iOS  14.2

