### PR TITLE
Bugfix: DebugConsole jumps to bottom on every componentDidUpdate

### DIFF
--- a/apps/src/lib/tools/jsdebugger/DebugConsole.jsx
+++ b/apps/src/lib/tools/jsdebugger/DebugConsole.jsx
@@ -214,9 +214,10 @@ export default connect(
       this.props.appendLog(output);
     }
 
-    componentDidUpdate() {
-      // here
-      this._debugOutput.scrollTop = this._debugOutput.scrollHeight;
+    componentDidUpdate(prevProps) {
+      if (prevProps.logOutput.size !== this.props.logOutput.size) {
+        this._debugOutput.scrollTop = this._debugOutput.scrollHeight;
+      }
     }
 
     clearDebugInput() {

--- a/apps/src/lib/tools/jsdebugger/DebugConsole.jsx
+++ b/apps/src/lib/tools/jsdebugger/DebugConsole.jsx
@@ -267,37 +267,39 @@ export default connect(
     }
 
     displayOutputToConsole() {
-      if (this.props.logOutput.size > 0) {
-        return this.props.logOutput.map((rowValue, i) => {
-          if ('function' === typeof rowValue.toJS) {
-            rowValue = rowValue.toJS();
-          }
-          if (rowValue.input) {
-            return <div key={i}>&gt; {rowValue.input}</div>;
-          } else if (rowValue.skipInspector) {
-            return rowValue.output;
-          } else if (this.isValidOutput(rowValue)) {
-            if (rowValue.fromConsoleLog) {
-              return (
-                <Inspector
-                  theme={inspectorTheme}
-                  key={i}
-                  data={rowValue.output}
-                />
-              );
-            } else {
-              return (
-                <div key={i}>
-                  &lt;{' '}
-                  <div style={style.inspector}>
-                    <Inspector theme={inspectorTheme} data={rowValue.output} />
-                  </div>
-                </div>
-              );
-            }
-          }
-        });
+      if (this.props.logOutput.size <= 0) {
+        return;
       }
+
+      return this.props.logOutput.map((rowValue, i) => {
+        if ('function' === typeof rowValue.toJS) {
+          rowValue = rowValue.toJS();
+        }
+        if (rowValue.input) {
+          return <div key={i}>&gt; {rowValue.input}</div>;
+        } else if (rowValue.skipInspector) {
+          return rowValue.output;
+        } else if (this.isValidOutput(rowValue)) {
+          if (rowValue.fromConsoleLog) {
+            return (
+              <Inspector
+                theme={inspectorTheme}
+                key={i}
+                data={rowValue.output}
+              />
+            );
+          } else {
+            return (
+              <div key={i}>
+                &lt;{' '}
+                <div style={style.inspector}>
+                  <Inspector theme={inspectorTheme} data={rowValue.output} />
+                </div>
+              </div>
+            );
+          }
+        }
+      });
     }
 
     render() {

--- a/apps/src/lib/tools/jsdebugger/DebugConsole.jsx
+++ b/apps/src/lib/tools/jsdebugger/DebugConsole.jsx
@@ -77,6 +77,19 @@ const style = {
   }
 };
 
+// These colors come from the ace editor defaults
+const inspectorTheme = {
+  ...chromeLight,
+  OBJECT_VALUE_NULL_COLOR: 'rgb(88, 92, 246)',
+  OBJECT_VALUE_UNDEFINED_COLOR: 'rgb(88, 92, 246)',
+  OBJECT_VALUE_REGEXP_COLOR: '#1A1AA6',
+  OBJECT_VALUE_STRING_COLOR: '#1A1AA6',
+  OBJECT_VALUE_SYMBOL_COLOR: '#1A1AA6',
+  OBJECT_VALUE_NUMBER_COLOR: 'rgb(0, 0, 205)',
+  OBJECT_VALUE_BOOLEAN_COLOR: 'rgb(88, 92, 246)',
+  OBJECT_VALUE_FUNCTION_PREFIX_COLOR: 'rgb(85, 106, 242)'
+};
+
 const WATCH_COMMAND_PREFIX = '$watch ';
 const UNWATCH_COMMAND_PREFIX = '$unwatch ';
 
@@ -202,6 +215,7 @@ export default connect(
     }
 
     componentDidUpdate() {
+      // here
       this._debugOutput.scrollTop = this._debugOutput.scrollHeight;
     }
 
@@ -253,18 +267,6 @@ export default connect(
     }
 
     displayOutputToConsole() {
-      // These colors come from the ace editor defaults
-      const inspectorTheme = {
-        ...chromeLight,
-        OBJECT_VALUE_NULL_COLOR: 'rgb(88, 92, 246)',
-        OBJECT_VALUE_UNDEFINED_COLOR: 'rgb(88, 92, 246)',
-        OBJECT_VALUE_REGEXP_COLOR: '#1A1AA6',
-        OBJECT_VALUE_STRING_COLOR: '#1A1AA6',
-        OBJECT_VALUE_SYMBOL_COLOR: '#1A1AA6',
-        OBJECT_VALUE_NUMBER_COLOR: 'rgb(0, 0, 205)',
-        OBJECT_VALUE_BOOLEAN_COLOR: 'rgb(88, 92, 246)',
-        OBJECT_VALUE_FUNCTION_PREFIX_COLOR: 'rgb(85, 106, 242)'
-      };
       if (this.props.logOutput.size > 0) {
         return this.props.logOutput.map((rowValue, i) => {
           if ('function' === typeof rowValue.toJS) {

--- a/apps/src/lib/tools/jsdebugger/DebugConsole.jsx
+++ b/apps/src/lib/tools/jsdebugger/DebugConsole.jsx
@@ -215,10 +215,18 @@ export default connect(
     }
 
     componentDidUpdate(prevProps) {
-      if (prevProps.logOutput.size !== this.props.logOutput.size) {
-        this._debugOutput.scrollTop = this._debugOutput.scrollHeight;
+      const prevOutputSize = prevProps.logOutput.size;
+      if (
+        typeof prevOutputSize === 'number' &&
+        prevOutputSize !== this.props.logOutput.size
+      ) {
+        this.jumpToBottom();
       }
     }
+
+    jumpToBottom = () => {
+      this._debugOutput.scrollTop = this._debugOutput.scrollHeight;
+    };
 
     clearDebugInput() {
       // TODO: this needs to get called on ATTACH action being dispatched

--- a/apps/test/unit/lib/tools/jsdebugger/DebugConsoleTest.js
+++ b/apps/test/unit/lib/tools/jsdebugger/DebugConsoleTest.js
@@ -14,8 +14,23 @@ import {
 import {KeyCodes} from '@cdo/apps/constants';
 import JSInterpreter from '@cdo/apps/lib/tools/jsinterpreter/JSInterpreter';
 
+const newJSInterpreter = () => {
+  let interpreter = new JSInterpreter({
+    shouldRunAtMaxSpeed: () => false,
+    studioApp: {hideSource: true}
+  });
+  const code = '0;\n1;\n2;\n3;\n4;\n5;\n6;\n7;';
+  interpreter.calculateCodeInfo({code});
+  interpreter.parse({code});
+  interpreter.paused = true;
+  interpreter.nextStep = JSInterpreter.StepType.IN;
+  interpreter.executeInterpreter(true);
+
+  return interpreter;
+};
+
 describe('The DebugConsole component when the console is enabled', () => {
-  let root;
+  let root, jumpToBottomSpy;
 
   beforeEach(() => {
     stubRedux();
@@ -26,6 +41,8 @@ describe('The DebugConsole component when the console is enabled', () => {
         <DebugConsole debugConsoleDisabled={false} />
       </Provider>
     );
+    const debugConsoleInstance = root.find('DebugConsole').instance();
+    jumpToBottomSpy = sinon.spy(debugConsoleInstance, 'jumpToBottom');
   });
 
   afterEach(() => {
@@ -42,6 +59,14 @@ describe('The DebugConsole component when the console is enabled', () => {
 
   it('renders a debug input div', () => {
     expect(debugInput()).to.exist;
+  });
+
+  it('jumps to bottom on componentDidUpdate if log output has changed', () => {
+    expect(jumpToBottomSpy).not.to.have.been.called;
+    getStore().dispatch(actions.attach(newJSInterpreter()));
+    expect(jumpToBottomSpy).not.to.have.been.called;
+    getStore().dispatch(actions.appendLog({output: 1 + 1}));
+    expect(jumpToBottomSpy).to.have.been.calledOnce;
   });
 
   function typeKey(keyCode) {
@@ -136,21 +161,10 @@ describe('The DebugConsole component when the console is enabled', () => {
 
   describe('After an interpreter has been attached', () => {
     beforeEach(() => {
-      let interpreter = new JSInterpreter({
-        shouldRunAtMaxSpeed: () => false,
-        studioApp: {hideSource: true}
-      });
-      const code = '0;\n1;\n2;\n3;\n4;\n5;\n6;\n7;';
-      interpreter.calculateCodeInfo({code});
-      interpreter.parse({code});
-      interpreter.paused = true;
-      interpreter.nextStep = JSInterpreter.StepType.IN;
-      interpreter.executeInterpreter(true);
-
-      getStore().dispatch(actions.attach(interpreter));
+      getStore().dispatch(actions.attach(newJSInterpreter()));
     });
 
-    describe('When typing into the text input and pressing enter,', () => {
+    describe('when typing into the text input and pressing enter,', () => {
       beforeEach(() => submit('1+1;'));
 
       it('the text gets appended to the output', () => {
@@ -273,7 +287,7 @@ describe('The DebugConsole component when the console is enabled', () => {
       });
     });
 
-    describe('When typing bad code into the text input and pressing enter,', () => {
+    describe('when typing bad code into the text input and pressing enter,', () => {
       beforeEach(() => submit('a+b;'));
 
       it('the text gets appended to the output', () => {
@@ -346,6 +360,7 @@ describe('The DebugConsole component when the console is enabled', () => {
     });
   });
 });
+
 describe('The DebugConsole component when the debug console is disabled', () => {
   let root;
 
@@ -397,18 +412,7 @@ describe('The DebugConsole component when the debug console is disabled', () => 
 
   describe('After an interpreter has been attached', () => {
     beforeEach(() => {
-      let interpreter = new JSInterpreter({
-        shouldRunAtMaxSpeed: () => false,
-        studioApp: {hideSource: true}
-      });
-      const code = '0;\n1;\n2;\n3;\n4;\n5;\n6;\n7;';
-      interpreter.calculateCodeInfo({code});
-      interpreter.parse({code});
-      interpreter.paused = true;
-      interpreter.nextStep = JSInterpreter.StepType.IN;
-      interpreter.executeInterpreter(true);
-
-      getStore().dispatch(actions.attach(interpreter));
+      getStore().dispatch(actions.attach(newJSInterpreter()));
     });
 
     describe('When typing into the text input and pressing enter,', () => {

--- a/apps/test/unit/lib/tools/jsdebugger/DebugConsoleTest.js
+++ b/apps/test/unit/lib/tools/jsdebugger/DebugConsoleTest.js
@@ -2,7 +2,7 @@ import React from 'react';
 import sinon from 'sinon';
 import {Provider} from 'react-redux';
 import {mount} from 'enzyme';
-import {expect} from '../../../../util/deprecatedChai';
+import {expect} from '../../../../util/reconfiguredChai';
 import DebugConsole from '@cdo/apps/lib/tools/jsdebugger/DebugConsole';
 import {reducers, actions} from '@cdo/apps/lib/tools/jsdebugger/redux';
 import {


### PR DESCRIPTION
Fixes a bug where clicking anywhere in the debug console output caused it to jump to the bottom of the output. Now, it will only jump to the bottom when something new is logged to the debug console.

Also some small clean-up because I couldn't resist. I'd recommend hiding whitespace changes when looking at the diff.

## Links

- [STAR-1364](https://codedotorg.atlassian.net/browse/STAR-1364)

## Testing story

<!--
  Does your change include appropriate tests?

  If so, please describe how the tests included in this PR are sufficient

  If not, please explain why this change does not need to be tested.
-->

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
