### PR TITLE
delete peer_reviews_to_complete unless greater than zero

### DIFF
--- a/dashboard/app/controllers/scripts_controller.rb
+++ b/dashboard/app/controllers/scripts_controller.rb
@@ -212,7 +212,7 @@ class ScriptsController < ApplicationController
       project_widget_types: [],
       supported_locales: [],
     ).to_h
-    h[:peer_reviews_to_complete] = h[:peer_reviews_to_complete].to_i
+    h[:peer_reviews_to_complete] = h[:peer_reviews_to_complete].to_i > 0 ? h[:peer_reviews_to_complete].to_i : nil
     h[:hidden] = !h[:visible_to_teachers]
     h[:announcements] = JSON.parse(h[:announcements]) if h[:announcements]
     h.delete(:visible_to_teachers)

--- a/dashboard/test/controllers/scripts_controller_test.rb
+++ b/dashboard/test/controllers/scripts_controller_test.rb
@@ -708,9 +708,7 @@ class ScriptsControllerTest < ActionController::TestCase
     assert_response :success
     script.reload
 
-    # peer_reviews_to_complete gets converted to an int by general_params in scripts_controller, so it becomes 0
-    expected = {"peer_reviews_to_complete" => 0}
-    assert_equal expected, script.properties
+    assert_equal({}, script.properties)
   end
 
   test 'add lesson to script' do


### PR DESCRIPTION
Finishes [PLAT-658]. It appears that the new script editing system, which is being used for 2021 scripts but not 2020 scripts, leads to this value getting set to `0` instead of `nil` when a script is edited:
![Screen Shot 2021-02-12 at 3 37 28 PM](https://user-images.githubusercontent.com/8001765/107833743-18bcd200-6d49-11eb-93ac-70754a7f8665.png)

Without this fix, saving any changes to a non-PLC script could make certain PLC code mistake it for a PLC script: https://github.com/code-dot-org/code-dot-org/blob/bfb2c7346c9e517cb8985e15378a1942b8a19e10/dashboard/app/controllers/peer_reviews_controller.rb#L18

### before

when saving a non-PLC script without making changes, the following diff appears:
<img width="1022" alt="Screen Shot 2021-01-14 at 9 18 01 PM" src="https://user-images.githubusercontent.com/8001765/104684972-f040aa00-56ae-11eb-88f0-ef04dc734331.png">

### after

no diff appears on those lines.

## Testing story

manually tested saving courseb-2021 with and without this code change. Also updated existing unit test coverage for this codepath.

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked


[PLAT-658]: https://codedotorg.atlassian.net/browse/PLAT-658