### PR TITLE
make staging commit schema_cache.yml when the schema changes

### DIFF
--- a/lib/rake/build.rake
+++ b/lib/rake/build.rake
@@ -52,7 +52,7 @@ namespace :build do
 
         # Update the schema cache file, except for production which always uses the cache.
         unless rack_env?(:production)
-          schema_cache_file = dashboard_dir('db/schema_cache.dump')
+          schema_cache_file = dashboard_dir('db/schema_cache.yml')
           RakeUtils.rake 'db:schema:cache:dump'
           if GitUtils.file_changed_from_git?(schema_cache_file)
             # Staging is responsible for committing the authoritative schema cache dump.


### PR DESCRIPTION
As part of the rails upgrade, schema_cache.dump has been replaced with schema_cache.yml. This PR fixes the part where staging decides which schema cache file to commit if it detects that the schema has changed. It does not address other instances of schema_cache.dump in the codebase:
![Screen Shot 2021-01-15 at 9 37 31 AM](https://user-images.githubusercontent.com/8001765/104760756-b3100280-5716-11eb-8066-e8187c00fc58.png)


## Testing story

not tested.

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
