### PR TITLE
decomposed level bubbles

### DIFF
--- a/apps/src/templates/sectionProgress/progressTables/ProgressTableLevelBubble.jsx
+++ b/apps/src/templates/sectionProgress/progressTables/ProgressTableLevelBubble.jsx
@@ -224,13 +224,11 @@ class ProgressTableLevelBubble extends React.PureComponent {
 
 export default Radium(ProgressTableLevelBubble);
 
-export const subComps = IN_UNIT_TEST
-  ? {
-      UnpluggedBubble,
-      SmallCircle,
-      LargeCircle,
-      LargeDiamond,
-      Content,
-      LinkWrapper
-    }
-  : {};
+export const unitTestExports = {
+  UnpluggedBubble,
+  SmallCircle,
+  LargeCircle,
+  LargeDiamond,
+  Content,
+  LinkWrapper
+};

--- a/apps/src/templates/sectionProgress/progressTables/ProgressTableLevelBubble.jsx
+++ b/apps/src/templates/sectionProgress/progressTables/ProgressTableLevelBubble.jsx
@@ -101,7 +101,7 @@ function largeContentStyle(props) {
   };
 }
 
-export function UnpluggedBubble(props) {
+function UnpluggedBubble(props) {
   return (
     <div
       style={{
@@ -115,7 +115,7 @@ export function UnpluggedBubble(props) {
   );
 }
 
-export function SmallCircle(props) {
+function SmallCircle(props) {
   return (
     <div>
       <div style={{...mainStyle(props), ...styles.smallCircle}}>
@@ -137,7 +137,7 @@ LargeBubble.propTypes = {
   concept: PropTypes.bool
 };
 
-export function LargeCircle(props) {
+function LargeCircle(props) {
   return (
     <div style={{...largeStyle(props), ...styles.largeCircle}}>
       <div style={largeContentStyle(props)}>
@@ -147,7 +147,7 @@ export function LargeCircle(props) {
   );
 }
 
-export function LargeDiamond(props) {
+function LargeDiamond(props) {
   return (
     <div style={{...largeStyle(props), ...styles.largeDiamond}}>
       <div style={{...largeContentStyle(props), ...styles.diamondContents}}>
@@ -157,7 +157,7 @@ export function LargeDiamond(props) {
   );
 }
 
-export function Content(props) {
+function Content(props) {
   const {levelStatus, unplugged, bonus, paired, title} = props;
   const locked = levelStatus === LevelStatus.locked;
   return unplugged ? (
@@ -180,7 +180,7 @@ Content.propTypes = {
   title: PropTypes.string
 };
 
-export function LinkWrapper(props) {
+function LinkWrapper(props) {
   return (
     <a href={props.url} style={progressStyles.link}>
       {props.children}
@@ -223,3 +223,14 @@ class ProgressTableLevelBubble extends React.PureComponent {
 }
 
 export default Radium(ProgressTableLevelBubble);
+
+export const subComps = IN_UNIT_TEST
+  ? {
+      UnpluggedBubble,
+      SmallCircle,
+      LargeCircle,
+      LargeDiamond,
+      Content,
+      LinkWrapper
+    }
+  : {};

--- a/apps/src/templates/sectionProgress/progressTables/ProgressTableLevelBubble.story.jsx
+++ b/apps/src/templates/sectionProgress/progressTables/ProgressTableLevelBubble.story.jsx
@@ -14,7 +14,8 @@ const assessmentStatuses = [
   LevelStatus.not_tried,
   LevelStatus.attempted,
   LevelStatus.submitted,
-  LevelStatus.completed_assessment
+  LevelStatus.completed_assessment,
+  LevelStatus.perfect
 ];
 
 const wrapperStyle = {

--- a/apps/test/unit/templates/sectionProgress/ProgressTableLevelBubbleTest.jsx
+++ b/apps/test/unit/templates/sectionProgress/ProgressTableLevelBubbleTest.jsx
@@ -2,7 +2,7 @@ import {expect} from '../../../util/reconfiguredChai';
 import React from 'react';
 import {shallow, mount} from 'enzyme';
 import ProgressTableLevelBubble, {
-  subComps
+  unitTestExports
 } from '@cdo/apps/templates/sectionProgress/progressTables/ProgressTableLevelBubble';
 import color from '@cdo/apps/util/color';
 import FontAwesome from '@cdo/apps/templates/FontAwesome';
@@ -63,8 +63,8 @@ function bubbleContainerStyleForStatus(status, propOverrides = {}) {
     />
   );
   const bubbleType = propOverrides.concept
-    ? subComps.LargeDiamond
-    : subComps.LargeCircle;
+    ? unitTestExports.LargeDiamond
+    : unitTestExports.LargeCircle;
   return wrapper
     .find(bubbleType)
     .at(0)
@@ -75,46 +75,46 @@ function bubbleContainerStyleForStatus(status, propOverrides = {}) {
 describe('ProgressTableLevelBubble', () => {
   it('renders a link when enabled', () => {
     const wrapper = shallow(<ProgressTableLevelBubble {...defaultProps} />);
-    expect(wrapper.find(subComps.LinkWrapper)).to.have.lengthOf(1);
+    expect(wrapper.find(unitTestExports.LinkWrapper)).to.have.lengthOf(1);
   });
 
   it('does not render a link when disabled', () => {
     const wrapper = shallow(
       <ProgressTableLevelBubble {...defaultProps} disabled={true} />
     );
-    expect(wrapper.find(subComps.LinkWrapper)).to.have.lengthOf(0);
+    expect(wrapper.find(unitTestExports.LinkWrapper)).to.have.lengthOf(0);
   });
 
   it('shows correct text in unplugged bubble', () => {
     const wrapper = mount(
       <ProgressTableLevelBubble {...defaultProps} unplugged={true} />
     );
-    expect(wrapper.find(subComps.UnpluggedBubble)).to.have.lengthOf(1);
-    expect(wrapper.find(subComps.Content).text()).to.equal(
+    expect(wrapper.find(unitTestExports.UnpluggedBubble)).to.have.lengthOf(1);
+    expect(wrapper.find(unitTestExports.Content).text()).to.equal(
       i18n.unpluggedActivity()
     );
   });
 
   it('shows title in normal bubble', () => {
     const wrapper = mount(<ProgressTableLevelBubble {...defaultProps} />);
-    expect(wrapper.find(subComps.LargeCircle)).to.have.lengthOf(1);
-    expect(wrapper.find(subComps.Content).text()).to.equal(TITLE);
+    expect(wrapper.find(unitTestExports.LargeCircle)).to.have.lengthOf(1);
+    expect(wrapper.find(unitTestExports.Content).text()).to.equal(TITLE);
   });
 
   it('shows title in concept bubble', () => {
     const wrapper = mount(
       <ProgressTableLevelBubble {...defaultProps} concept={true} />
     );
-    expect(wrapper.find(subComps.LargeDiamond)).to.have.lengthOf(1);
-    expect(wrapper.find(subComps.Content).text()).to.equal(TITLE);
+    expect(wrapper.find(unitTestExports.LargeDiamond)).to.have.lengthOf(1);
+    expect(wrapper.find(unitTestExports.Content).text()).to.equal(TITLE);
   });
 
   it('shows title in small bubble', () => {
     const wrapper = mount(
       <ProgressTableLevelBubble {...defaultProps} smallBubble={true} />
     );
-    expect(wrapper.find(subComps.SmallCircle)).to.have.lengthOf(1);
-    expect(wrapper.find(subComps.Content).text()).to.equal(TITLE);
+    expect(wrapper.find(unitTestExports.SmallCircle)).to.have.lengthOf(1);
+    expect(wrapper.find(unitTestExports.Content).text()).to.equal(TITLE);
   });
 
   it('shows correct icon when locked', () => {

--- a/apps/test/unit/templates/sectionProgress/ProgressTableLevelBubbleTest.jsx
+++ b/apps/test/unit/templates/sectionProgress/ProgressTableLevelBubbleTest.jsx
@@ -1,7 +1,9 @@
 import {expect} from '../../../util/reconfiguredChai';
 import React from 'react';
 import {shallow, mount} from 'enzyme';
-import ProgressTableLevelBubble, * as bubbles from '@cdo/apps/templates/sectionProgress/progressTables/ProgressTableLevelBubble';
+import ProgressTableLevelBubble, {
+  subComps
+} from '@cdo/apps/templates/sectionProgress/progressTables/ProgressTableLevelBubble';
 import color from '@cdo/apps/util/color';
 import FontAwesome from '@cdo/apps/templates/FontAwesome';
 import {LevelStatus, LevelKind} from '@cdo/apps/util/sharedConstants';
@@ -50,10 +52,7 @@ const assessmentBackgrounds = {
 
 /**
  * Helper function to retrieve the style object of a rendered bubble with the
- * provided status. We use a "bonus" bubble to make it easy to find the
- * FontAwesome content node. The content is in a positioning container, and the
- * parent of that container is the actual "bubble" node with stylized border
- * and background, so we want the style of the content's grandparent.
+ * provided status and prpos.
  */
 function bubbleContainerStyleForStatus(status, propOverrides = {}) {
   const wrapper = mount(
@@ -64,8 +63,8 @@ function bubbleContainerStyleForStatus(status, propOverrides = {}) {
     />
   );
   const bubbleType = propOverrides.concept
-    ? bubbles.LargeDiamond
-    : bubbles.LargeCircle;
+    ? subComps.LargeDiamond
+    : subComps.LargeCircle;
   return wrapper
     .find(bubbleType)
     .at(0)
@@ -76,46 +75,46 @@ function bubbleContainerStyleForStatus(status, propOverrides = {}) {
 describe('ProgressTableLevelBubble', () => {
   it('renders a link when enabled', () => {
     const wrapper = shallow(<ProgressTableLevelBubble {...defaultProps} />);
-    expect(wrapper.find(bubbles.LinkWrapper)).to.have.lengthOf(1);
+    expect(wrapper.find(subComps.LinkWrapper)).to.have.lengthOf(1);
   });
 
   it('does not render a link when disabled', () => {
     const wrapper = shallow(
       <ProgressTableLevelBubble {...defaultProps} disabled={true} />
     );
-    expect(wrapper.find(bubbles.LinkWrapper)).to.have.lengthOf(0);
+    expect(wrapper.find(subComps.LinkWrapper)).to.have.lengthOf(0);
   });
 
   it('shows correct text in unplugged bubble', () => {
     const wrapper = mount(
       <ProgressTableLevelBubble {...defaultProps} unplugged={true} />
     );
-    expect(wrapper.find(bubbles.UnpluggedBubble)).to.have.lengthOf(1);
-    expect(wrapper.find(bubbles.Content).text()).to.equal(
+    expect(wrapper.find(subComps.UnpluggedBubble)).to.have.lengthOf(1);
+    expect(wrapper.find(subComps.Content).text()).to.equal(
       i18n.unpluggedActivity()
     );
   });
 
   it('shows title in normal bubble', () => {
     const wrapper = mount(<ProgressTableLevelBubble {...defaultProps} />);
-    expect(wrapper.find(bubbles.LargeCircle)).to.have.lengthOf(1);
-    expect(wrapper.find(bubbles.Content).text()).to.equal(TITLE);
+    expect(wrapper.find(subComps.LargeCircle)).to.have.lengthOf(1);
+    expect(wrapper.find(subComps.Content).text()).to.equal(TITLE);
   });
 
   it('shows title in concept bubble', () => {
     const wrapper = mount(
       <ProgressTableLevelBubble {...defaultProps} concept={true} />
     );
-    expect(wrapper.find(bubbles.LargeDiamond)).to.have.lengthOf(1);
-    expect(wrapper.find(bubbles.Content).text()).to.equal(TITLE);
+    expect(wrapper.find(subComps.LargeDiamond)).to.have.lengthOf(1);
+    expect(wrapper.find(subComps.Content).text()).to.equal(TITLE);
   });
 
   it('shows title in small bubble', () => {
     const wrapper = mount(
       <ProgressTableLevelBubble {...defaultProps} smallBubble={true} />
     );
-    expect(wrapper.find(bubbles.SmallCircle)).to.have.lengthOf(1);
-    expect(wrapper.find(bubbles.Content).text()).to.equal(TITLE);
+    expect(wrapper.find(subComps.SmallCircle)).to.have.lengthOf(1);
+    expect(wrapper.find(subComps.Content).text()).to.equal(TITLE);
   });
 
   it('shows correct icon when locked', () => {
@@ -164,20 +163,34 @@ describe('ProgressTableLevelBubble', () => {
     expect(style.transform).to.equal('rotate(45deg)');
   });
 
-  it('shows correct border/background colors for status - not assessment', () => {
-    Object.keys(borderColors).forEach(status => {
+  Object.keys(borderColors).forEach(status => {
+    it(`shows correct border color for status ${status} - not assessment`, () => {
       const style = bubbleContainerStyleForStatus(status);
       expect(style.borderColor).to.equal(borderColors[status]);
+    });
+  });
+
+  Object.keys(backgroundColors).forEach(status => {
+    it(`shows correct background color for status ${status} - not assessment`, () => {
+      const style = bubbleContainerStyleForStatus(status);
       expect(style.backgroundColor).to.equal(backgroundColors[status]);
     });
   });
 
-  it('shows correct border/background colors for status - assessment', () => {
-    Object.keys(assessmentBorders).forEach(status => {
+  Object.keys(assessmentBorders).forEach(status => {
+    it(`shows correct border color for status ${status} - assessment`, () => {
       const style = bubbleContainerStyleForStatus(status, {
         levelKind: LevelKind.assessment
       });
       expect(style.borderColor).to.equal(assessmentBorders[status]);
+    });
+  });
+
+  Object.keys(assessmentBackgrounds).forEach(status => {
+    it(`shows correct background color for status ${status} - assessment`, () => {
+      const style = bubbleContainerStyleForStatus(status, {
+        levelKind: LevelKind.assessment
+      });
       expect(style.backgroundColor).to.equal(assessmentBackgrounds[status]);
     });
   });


### PR DESCRIPTION
this is a proposal for a decomposed design pattern for components. the initial motivation was to make it easy to find and select "subcomponent pieces" of the main component in unit tests. however, upon further reflection, i think the decomposition itself is a design improvement in its own right, because it makes it easier to see what will get rendered by different code paths, and will hopefully encourage more code reuse.

i went with a convention of using function components for all the subcomponents as a way to enforce the idea that subcomponents are "pieces" of a component -- i.e. if it would need to be a class component, it should probably be its own component in its own file. that said, i didn't realize that our linter would enforce proptypes on function components. given that, it might look cleaner to use class components. but i kind of like this distinction of components=classes, subcomponents=functions.

i would like to point out that the code didn't actually change much with this update -- it mostly just moved out of the component class and into the module. most of the subcomponents i created were already in their own methods anyway, so it mostly just mean turning those methods into function components. decomposing rendering into multiple methods on component classes is already a very common design pattern in our codebase, so this change mostly amounts to a tighter encapsulation of that decomposition.

ProgressTableLevelBubble is an extreme example of this pattern because it has so many subcomponents for all the different bubble configurations. most components would probably only have a few subcomponents at most. for a simpler example, see `LessonArrow` in [this PR](https://github.com/code-dot-org/code-dot-org/pull/38565/files).

would love to get others' thoughts on this. i like it, but i can see how it might not be for everyone! :)

questions:
1) do you think it improves the tests at all?
2) do you think it makes the component code easier or harder to read (or neither)?