### PR TITLE
[Spritelab] Remove spritelabInput experiment

### DIFF
--- a/apps/src/p5lab/P5LabVisualizationColumn.jsx
+++ b/apps/src/p5lab/P5LabVisualizationColumn.jsx
@@ -66,9 +66,6 @@ class P5LabVisualizationColumn extends React.Component {
     this.spritelabPauseExperiment = experiments.isEnabled(
       experiments.SPRITELAB_PAUSE
     );
-    this.spritelabInputExperiment = experiments.isEnabled(
-      experiments.SPRITELAB_INPUT
-    );
   }
 
   // Cache app-space mouse coordinates, which we get from the
@@ -198,7 +195,7 @@ class P5LabVisualizationColumn extends React.Component {
             </VisualizationOverlay>
           </ProtectedVisualizationDiv>
           <TextConsole consoleMessages={this.props.consoleMessages} />
-          {this.spritelabInputExperiment && <SpritelabInput />}
+          <SpritelabInput />
         </div>
 
         <GameButtons>

--- a/apps/src/p5lab/P5LabVisualizationColumn.jsx
+++ b/apps/src/p5lab/P5LabVisualizationColumn.jsx
@@ -195,7 +195,7 @@ class P5LabVisualizationColumn extends React.Component {
             </VisualizationOverlay>
           </ProtectedVisualizationDiv>
           <TextConsole consoleMessages={this.props.consoleMessages} />
-          <SpritelabInput />
+          {spriteLab && <SpritelabInput />}
         </div>
 
         <GameButtons>

--- a/apps/src/util/experiments.js
+++ b/apps/src/util/experiments.js
@@ -29,7 +29,6 @@ experiments.TEACHER_DASHBOARD_SECTION_BUTTONS_ALTERNATE_TEXT =
   'teacher-dashboard-section-buttons-alternate-text';
 experiments.FINISH_DIALOG_METRICS = 'finish-dialog-metrics';
 experiments.I18N_TRACKING = 'i18n-tracking';
-experiments.SPRITELAB_INPUT = 'spritelabInput';
 experiments.TIME_SPENT = 'time-spent';
 experiments.APPLAB_ML = 'applab-ml';
 experiments.BYPASS_DIALOG_POPUP = 'bypass-dialog-popup';


### PR DESCRIPTION
Pull the spritelab input feature out from behind the experiment. This will be used by pilot teachers within the next few weeks.
![image](https://user-images.githubusercontent.com/8787187/104787330-149a9600-5744-11eb-85a4-91781b46c21d.png)
![image](https://user-images.githubusercontent.com/8787187/104787370-2a0fc000-5744-11eb-8a1b-854377d09162.png)
![image](https://user-images.githubusercontent.com/8787187/104787518-896dd000-5744-11eb-912e-6fb811cbbc5a.png)

![image](https://user-images.githubusercontent.com/8787187/104787337-195f4a00-5744-11eb-9e35-6126fcf69fec.png)

Relevant PRs
https://github.com/code-dot-org/code-dot-org/pull/37204
https://github.com/code-dot-org/code-dot-org/pull/38115
https://github.com/code-dot-org/code-dot-org/pull/38084

<!-- ### Background -->
<!-- ### Privacy -->
<!--
1.	Does the Project involve the collection, use or sharing of new Personal Data?

2.	Does the Project involve a new or changed use or sharing of existing Personal Data?
-->
<!-- ### Security -->
<!--
Link to Jira Task where sensitive security issues are discussed privately.
-->
<!-- ### Caching -->
<!-- ### Deployment strategy -->
<!-- ### Future work -->

## Links

<!--
  Any relevant links to external resources; ie, specification documents, jira
  items, related PRs, honeybadger errors, etc
-->

- [spec](https://docs.google.com/document/d/1pZppqxv7UoAQU8BOygErJRfbCHAzIeuDRB9yaFKY7-Q/edit)
- [jira](https://codedotorg.atlassian.net/browse/STAR-1406)

## Testing story

<!--
  Does your change include appropriate tests?

  If so, please describe how the tests included in this PR are sufficient

  If not, please explain why this change does not need to be tested.
-->

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
