### PR TITLE
Turn back on full school seeding

### DIFF
--- a/dashboard/app/models/school.rb
+++ b/dashboard/app/models/school.rb
@@ -124,8 +124,8 @@ class School < ApplicationRecord
       School.transaction do
         merge_from_csv(schools_tsv)
       end
-      # else
-      # School.seed_from_s3
+    else
+      School.seed_from_s3
     end
   end
 


### PR DESCRIPTION
I commented out full school seeding so that I could observe importing data to our production schools table (PRs [here](https://github.com/code-dot-org/code-dot-org/pull/38459) and [here](https://github.com/code-dot-org/code-dot-org/pull/38432)). I've finished that work, so now full school seeding is ok to turn back on. For context, we have a system (using `SeededS3Objects`) that will skip seeding of any file that has already been seeded in a given environment, so School.seed_from_s3 won't actually do anything now that all of the files have been imported.