### PR TITLE
Restore `materialize_transactions` calls

### DIFF
--- a/dashboard/config/initializers/restore_materialize_transactions.rb
+++ b/dashboard/config/initializers/restore_materialize_transactions.rb
@@ -1,0 +1,19 @@
+module RestoreMaterializeTransactions
+  # These `materialize_transactions` calls were removed in
+  # https://github.com/rails/rails/commit/7d83ef4f7bd9e5766ebdb438370621a98be06a7c,
+  # but doing so prevents some of our transaction from working correctly. This
+  # module simply patches them back in.
+
+  def exec_query(sql, name = "SQL", binds = [], prepare: false)
+    materialize_transactions
+    super
+  end
+
+  def exec_delete(sql, name = nil, binds = [])
+    materialize_transactions
+    super
+  end
+  alias :exec_update :exec_delete
+end
+
+ActiveRecord::ConnectionAdapters::Mysql2Adapter.prepend RestoreMaterializeTransactions


### PR DESCRIPTION
Originally removed in https://github.com/rails/rails/commit/7d83ef4f7bd9e5766ebdb438370621a98be06a7c, the absense of these calls caused some broken functionality for us.

For example, see:

https://github.com/code-dot-org/code-dot-org/blob/ea98b47d1820685f6a946664fde9a4af79da7d86/dashboard/test/lib/account_purger_test.rb#L84-L109

Which is testing to confirm that these transactions:

https://github.com/code-dot-org/code-dot-org/blob/50393062efc80ac1adc572ced96027a59e245669/dashboard/lib/account_purger.rb#L57-L65

Get successfully rolled back if the process encounters an error. Without these `materialize_transactions` calls, the rollback wasn't happening.

To fix, this PR simply patches the calls back in to the underlying Rails methods.

## Testing story

Relying on existing unit tests

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
