### PR TITLE
Fix Account Purger's CloudWatch alarm

### DIFF
--- a/dashboard/test/lib/expired_deleted_account_purger_test.rb
+++ b/dashboard/test/lib/expired_deleted_account_purger_test.rb
@@ -225,6 +225,7 @@ class ExpiredDeletedAccountPurgerTest < ActiveSupport::TestCase
       includes_metrics(
         AccountsPurged: 2,
         AccountsQueued: 0,
+        ReviewQueueDepth: is_a(Integer),
         ManualReviewQueueDepth: is_a(Integer)
       )
     )
@@ -249,7 +250,8 @@ class ExpiredDeletedAccountPurgerTest < ActiveSupport::TestCase
       Done purging user_id #{student_c.id}
       AccountsPurged: 2
       AccountsQueued: 0
-      ManualReviewQueueDepth: #{QueuedAccountPurge.count}
+      ReviewQueueDepth: #{QueuedAccountPurge.count}
+      ManualReviewQueueDepth: #{QueuedAccountPurge.needing_manual_review.count}
       Purged 2 account(s).
       🕐 00:00:00
     LOG
@@ -295,6 +297,7 @@ class ExpiredDeletedAccountPurgerTest < ActiveSupport::TestCase
       includes_metrics(
         AccountsPurged: 1,
         AccountsQueued: 2,
+        ReviewQueueDepth: is_a(Integer),
         ManualReviewQueueDepth: is_a(Integer)
       )
     )
@@ -307,6 +310,8 @@ class ExpiredDeletedAccountPurgerTest < ActiveSupport::TestCase
     assert_includes purged, student_succeeds
     refute_includes purged, student_needs_review
 
+    review_queue_depth = QueuedAccountPurge.count
+    manual_reviews_needed = QueuedAccountPurge.needing_manual_review.count
     assert_equal <<~LOG, edap.log.string
       Starting purge_expired_deleted_accounts!
       deleted_after: #{4.days.ago}
@@ -319,10 +324,12 @@ class ExpiredDeletedAccountPurgerTest < ActiveSupport::TestCase
       Purging user_id #{student_autoretryable.id}
       AccountsPurged: 1
       AccountsQueued: 2
-      ManualReviewQueueDepth: #{QueuedAccountPurge.count}
+      ReviewQueueDepth: #{review_queue_depth}
+      ManualReviewQueueDepth: #{manual_reviews_needed}
       Purged 1 account(s).
       Queued 2 account(s) for retry or review.
-      #{QueuedAccountPurge.needing_manual_review.count} account(s) require review.
+      #{review_queue_depth} account(s) in the review queue.
+      #{manual_reviews_needed} account(s) require manual review.
       🕐 00:00:00
     LOG
   end
@@ -353,7 +360,8 @@ class ExpiredDeletedAccountPurgerTest < ActiveSupport::TestCase
       Done purging user_id #{student_c.id} (dry-run)
       AccountsPurged: 2
       AccountsQueued: 0
-      ManualReviewQueueDepth: #{QueuedAccountPurge.all.count}
+      ReviewQueueDepth: #{QueuedAccountPurge.count}
+      ManualReviewQueueDepth: #{QueuedAccountPurge.needing_manual_review.count}
       Would have purged 2 account(s).
       🕐 00:00:00
     LOG
@@ -392,7 +400,8 @@ class ExpiredDeletedAccountPurgerTest < ActiveSupport::TestCase
       Purging user_id #{student_b.id} (dry-run)
       AccountsPurged: 1
       AccountsQueued: 1
-      ManualReviewQueueDepth: #{QueuedAccountPurge.count}
+      ReviewQueueDepth: #{QueuedAccountPurge.count}
+      ManualReviewQueueDepth: #{QueuedAccountPurge.needing_manual_review.count}
       Would have purged 1 account(s).
       Would have queued 1 account(s) for retry or review.
       🕐 00:00:00
@@ -416,6 +425,7 @@ class ExpiredDeletedAccountPurgerTest < ActiveSupport::TestCase
       includes_metrics(
         AccountsPurged: 0,
         AccountsQueued: 0,
+        ReviewQueueDepth: is_a(Integer),
         ManualReviewQueueDepth: is_a(Integer),
       )
     )
@@ -436,7 +446,8 @@ class ExpiredDeletedAccountPurgerTest < ActiveSupport::TestCase
       Found 6 teachers to purge, which exceeds the configured limit of 5. Abandoning run.
       AccountsPurged: 0
       AccountsQueued: 0
-      ManualReviewQueueDepth: #{QueuedAccountPurge.all.count}
+      ReviewQueueDepth: #{QueuedAccountPurge.count}
+      ManualReviewQueueDepth: #{QueuedAccountPurge.needing_manual_review.count}
       Purged 0 account(s).
       🕐 00:00:00
     LOG
@@ -455,6 +466,7 @@ class ExpiredDeletedAccountPurgerTest < ActiveSupport::TestCase
       includes_metrics(
         AccountsPurged: 6,
         AccountsQueued: 0,
+        ReviewQueueDepth: is_a(Integer),
         ManualReviewQueueDepth: is_a(Integer),
       )
     )
@@ -481,7 +493,8 @@ class ExpiredDeletedAccountPurgerTest < ActiveSupport::TestCase
       Done purging user_id #{students[5].id}
       AccountsPurged: 6
       AccountsQueued: 0
-      ManualReviewQueueDepth: #{QueuedAccountPurge.all.count}
+      ReviewQueueDepth: #{QueuedAccountPurge.count}
+      ManualReviewQueueDepth: #{QueuedAccountPurge.needing_manual_review.count}
       Purged 6 account(s).
       🕐 00:00:00
     LOG
@@ -504,6 +517,7 @@ class ExpiredDeletedAccountPurgerTest < ActiveSupport::TestCase
       includes_metrics(
         AccountsPurged: 0,
         AccountsQueued: 0,
+        ReviewQueueDepth: is_a(Integer),
         ManualReviewQueueDepth: is_a(Integer),
       )
     )
@@ -524,7 +538,8 @@ class ExpiredDeletedAccountPurgerTest < ActiveSupport::TestCase
       Found 6 accounts to purge, which exceeds the configured limit of 5. Abandoning run.
       AccountsPurged: 0
       AccountsQueued: 0
-      ManualReviewQueueDepth: #{QueuedAccountPurge.all.count}
+      ReviewQueueDepth: #{QueuedAccountPurge.count}
+      ManualReviewQueueDepth: #{QueuedAccountPurge.needing_manual_review.count}
       Purged 0 account(s).
       🕐 00:00:00
     LOG


### PR DESCRIPTION
[FND-1360](https://codedotorg.atlassian.net/browse/FND-1360)
Fix Account Purger's CloudWatch alarm to use the correct value of `ManualReviewQueueDepth`.
To avoid confusion, Account Purger will start reporting both number of accounts in the review queue (`ReviewQueueDepth`) and number of accounts require manual reviews (`ManualReviewQueueDepth`). 

## Context
From 8/24/2020 up to 1/10/2021, the Account Purger's CloudWatch alarm consistently showed almost 7K accounts **needed manual reviews**, much higher than the threshold value of 30.
<img width="755" alt="Screen Shot 2021-01-17 at 10 42 27 AM" src="https://user-images.githubusercontent.com/46507039/104852585-b50dc900-58b0-11eb-8621-9a45459151e1.png">

However, the Account Purger's Slack report in #user-accounts channel showed <30 accounts required manual reviews. 
<img width="287" alt="Screen Shot 2021-01-17 at 11 12 21 AM" src="https://user-images.githubusercontent.com/46507039/104853318-df618580-58b4-11eb-9e21-7d8110b8e93d.png">

The reason was the CloudWatch alarm actually shows the **total number of accounts queued** in the `QueuedAccountPurge`. It includes accounts that we failed to purge for any reasons, including auto-retryable ones. Only a small portion of them required manual reviews. 

## Links:
* Purged Accounts [CloudWatch dashboard](https://console.aws.amazon.com/cloudwatch/home?region=us-east-1#dashboards:name=Purged-Accounts).
* Queued Account Purge [CloudWatch alarm](https://console.aws.amazon.com/cloudwatch/home?region=us-east-1#alarmsV2:alarm/Queued+Account+Purge?~(search~'account)) --> [metric](https://console.aws.amazon.com/cloudwatch/home?region=us-east-1#metricsV2:graph=~(region~'us-east-1~metrics~(~(~'DeletedAccountPurger~'ManualReviewQueueDepth~'Environment~'production~(stat~'Average)))~view~'timeSeries~stacked~false~start~'-P3M~end~'P0D~period~86400~annotations~(horizontal~(~(label~'ManualReviewQueueDepth*20*3e*3d*2030*20for*201*20datapoints*20within*201*20day~value~30)))~title~'Queued*20Account*20Purge))
* Example of an [AccountPurger message](https://codedotorg.slack.com/archives/C6B838SB0/p1610870636000400) in the #cron-daily channel.

## Testing story
* Unit test: `bundle exec rails test test/lib/expired_deleted_account_purger_test.rb`
* Test in Rails console:
  ```
  edap = ExpiredDeletedAccountPurger.new
  edap.send(:report_results)
  edap.log.string
  # Verify that the log string includes ReviewQueueDepth and ManualReviewQueueDepth
  ```

