### PR TITLE
[P5Lab] don't show pause button in gamelab

### DIFF
--- a/apps/src/p5lab/P5LabVisualizationColumn.jsx
+++ b/apps/src/p5lab/P5LabVisualizationColumn.jsx
@@ -202,7 +202,7 @@ class P5LabVisualizationColumn extends React.Component {
         </div>
 
         <GameButtons>
-          {this.spritelabPauseExperiment && (
+          {spriteLab && this.spritelabPauseExperiment && (
             <PauseButton pauseHandler={this.props.pauseHandler} />
           )}
           <ArrowButtons />


### PR DESCRIPTION
Mike noticed that the pause button is also showing in gamelab (when the experiment is enabled)
![image](https://user-images.githubusercontent.com/8787187/105064190-6cc9e480-5a31-11eb-9888-c1fb440f3e9a.png)

After:
![image](https://user-images.githubusercontent.com/8787187/105066558-c6331300-5a33-11eb-8292-430dac73c55d.png)

<!-- ### Background -->
<!-- ### Privacy -->
<!--
1.	Does the Project involve the collection, use or sharing of new Personal Data?

2.	Does the Project involve a new or changed use or sharing of existing Personal Data?
-->
<!-- ### Security -->
<!--
Link to Jira Task where sensitive security issues are discussed privately.
-->
<!-- ### Caching -->
<!-- ### Deployment strategy -->
<!-- ### Future work -->

## Links

<!--
  Any relevant links to external resources; ie, specification documents, jira
  items, related PRs, honeybadger errors, etc
-->

## Testing story

<!--
  Does your change include appropriate tests?

  If so, please describe how the tests included in this PR are sufficient

  If not, please explain why this change does not need to be tested.
-->

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
