### PR TITLE
[Draft] Provide teachers with read access to their students' version history LP-85

### DIFF
--- a/apps/src/StudioApp.js
+++ b/apps/src/StudioApp.js
@@ -678,13 +678,16 @@ StudioApp.prototype.getVersionHistoryHandler = function(config) {
       id: 'showVersionsModal'
     });
     ReactDOM.render(
-      React.createElement(VersionHistory, {
-        handleClearPuzzle: this.handleClearPuzzle.bind(this, config),
-        useFilesApi: !!config.useFilesApi
-      }),
+      <Provider store={getStore()}>
+        <div>
+          <VersionHistory
+            handleClearPuzzle={this.handleClearPuzzle.bind(this, config)}
+            useFilesApi={!!config.useFilesApi}
+          />
+        </div>
+      </Provider>,
       contentDiv
     );
-
     dialog.show();
   };
 };

--- a/apps/src/StudioApp.js
+++ b/apps/src/StudioApp.js
@@ -700,10 +700,19 @@ StudioApp.prototype.initTimeSpent = function() {
   );
 };
 
-StudioApp.prototype.initVersionHistoryUI = function(config) {
-  // Bind listener to 'Version History' button
+StudioApp.prototype.initVersionHistoryUI = function(config, hasStartedLevel) {
+  // Bind listener to 'Version History' button only if student viewing their own work
+  // or a teacher viewing student work when student already started level
   var versionsHeader = document.getElementById('versions-header');
-  if (versionsHeader) {
+  const {
+    isNotStartedLevel,
+    isReadOnlyWorkspace
+  } = getStore().getState().pageConstants;
+
+  if (
+    versionsHeader &&
+    (!isReadOnlyWorkspace || (isReadOnlyWorkspace && !isNotStartedLevel))
+  ) {
     dom.addClickTouchEvent(
       versionsHeader,
       this.getVersionHistoryHandler(config)

--- a/apps/src/code-studio/initApp/loadApp.js
+++ b/apps/src/code-studio/initApp/loadApp.js
@@ -115,7 +115,7 @@ export function setupApp(appOptions) {
       ) {
         $('#clear-puzzle-header').hide();
         // Only show Version History button if the user owns this project
-        if (project.isEditable()) {
+        if (project.isEditable() || appOptions.readonlyWorkspace) {
           $('#versions-header').show();
         }
       }

--- a/apps/src/templates/CodeWorkspace.jsx
+++ b/apps/src/templates/CodeWorkspace.jsx
@@ -197,6 +197,7 @@ class CodeWorkspace extends React.Component {
               id="versions-header"
               headerHasFocus={hasFocus}
               iconClass="fa fa-clock-o"
+              disabled={props.studentHasNotStartedLevel}
               label={i18n.showVersionsHeader()}
               isRtl={isRtl}
               isMinecraft={props.isMinecraft}

--- a/apps/src/templates/PaneHeader.jsx
+++ b/apps/src/templates/PaneHeader.jsx
@@ -80,7 +80,7 @@ const styles = {
     paddingLeft: 0
   },
   disabled: {
-    backgroundColor: color.lighter_gray,
+    opacity: 0.5,
     color: color.white,
     pointerEvents: 'none'
   }

--- a/apps/src/templates/PaneHeader.jsx
+++ b/apps/src/templates/PaneHeader.jsx
@@ -78,6 +78,11 @@ const styles = {
   headerButtonNoLabel: {
     paddingRight: 0,
     paddingLeft: 0
+  },
+  disabled: {
+    backgroundColor: color.lighter_gray,
+    color: color.white,
+    pointerEvents: 'none'
   }
 };
 
@@ -143,6 +148,7 @@ export const PaneButton = Radium(function(props) {
     ...(props.isMinecraft && styles.headerButtonMinecraft),
     ...(props.isPressed && styles.headerButtonPressed),
     ...(!props.headerHasFocus && styles.headerButtonUnfocused),
+    ...(props.disabled && styles.disabled),
     ...props.style
   };
 
@@ -158,7 +164,11 @@ export const PaneButton = Radium(function(props) {
   }
 
   return (
-    <div id={props.id} style={divStyle} onClick={props.onClick}>
+    <div
+      id={props.id}
+      style={divStyle}
+      onClick={props.disabled ? null : props.onClick}
+    >
       <span style={styles.headerButtonSpan}>
         {props.hiddenImage}
         <i className={props.iconClass} style={iconStyle} />
@@ -179,7 +189,8 @@ PaneButton.propTypes = {
   hiddenImage: PropTypes.element,
   isMinecraft: PropTypes.bool,
   id: PropTypes.string,
-  style: PropTypes.object
+  style: PropTypes.object,
+  disabled: PropTypes.bool
 };
 
 export default Radium(PaneHeader);

--- a/apps/src/templates/VersionHistory.jsx
+++ b/apps/src/templates/VersionHistory.jsx
@@ -1,19 +1,20 @@
 import PropTypes from 'prop-types';
 import React from 'react';
 import VersionRow from './VersionRow';
+import {connect} from 'react-redux';
 import {sources as sourcesApi, files as filesApi} from '../clientApi';
 import project from '@cdo/apps/code-studio/initApp/project';
 import firehoseClient from '@cdo/apps/lib/util/firehose';
 import * as utils from '../utils';
 import i18n from '@cdo/locale';
-
 /**
  * A component for viewing project version history.
  */
-export default class VersionHistory extends React.Component {
+export class VersionHistory extends React.Component {
   static propTypes = {
     handleClearPuzzle: PropTypes.func.isRequired,
-    useFilesApi: PropTypes.bool.isRequired
+    useFilesApi: PropTypes.bool.isRequired,
+    isTeacher: PropTypes.string
   };
 
   /**
@@ -51,6 +52,8 @@ export default class VersionHistory extends React.Component {
       );
     }
   }
+
+  viewedByTeacher = () => this.props.isTeacher === 'teacher';
 
   /**
    * Called after the component mounts, when the server responds with the
@@ -170,6 +173,7 @@ export default class VersionHistory extends React.Component {
               lastModified={new Date(version.lastModified)}
               isLatest={version.isLatest}
               onChoose={this.onChooseVersion.bind(this, version.versionId)}
+              isTeacher={this.viewedByTeacher()}
             />
           );
         }.bind(this)
@@ -181,21 +185,23 @@ export default class VersionHistory extends React.Component {
             <table style={{width: '100%'}}>
               <tbody>
                 {rows}
-                <tr>
-                  <td>
-                    <p>{i18n.versionHistory_initialVersion_label()}</p>
-                  </td>
-                  <td width="250" style={{textAlign: 'right'}}>
-                    <button
-                      type="button"
-                      className="btn-danger"
-                      onClick={this.onConfirmClearPuzzle}
-                      style={{float: 'right'}}
-                    >
-                      {i18n.versionHistory_clearProgress_confirm()}
-                    </button>
-                  </td>
-                </tr>
+                {!this.viewedByTeacher && (
+                  <tr>
+                    <td>
+                      <p>{i18n.versionHistory_initialVersion_label()}</p>
+                    </td>
+                    <td width="250" style={{textAlign: 'right'}}>
+                      <button
+                        type="button"
+                        className="btn-danger"
+                        onClick={this.onConfirmClearPuzzle}
+                        style={{float: 'right'}}
+                      >
+                        {i18n.versionHistory_clearProgress_confirm()}
+                      </button>
+                    </td>
+                  </tr>
+                )}
               </tbody>
             </table>
           </div>
@@ -212,3 +218,7 @@ export default class VersionHistory extends React.Component {
     );
   }
 }
+export const UnconnectedVersionHistory = VersionHistory;
+export default connect(state => ({
+  isTeacher: state.currentUser.userType
+}))(VersionHistory);

--- a/apps/src/templates/VersionHistory.jsx
+++ b/apps/src/templates/VersionHistory.jsx
@@ -14,7 +14,9 @@ export class VersionHistory extends React.Component {
   static propTypes = {
     handleClearPuzzle: PropTypes.func.isRequired,
     useFilesApi: PropTypes.bool.isRequired,
-    isTeacher: PropTypes.string
+    //Provided by Redux
+    isTeacher: PropTypes.string,
+    isReadOnlyWorkspace: PropTypes.bool
   };
 
   /**
@@ -53,7 +55,8 @@ export class VersionHistory extends React.Component {
     }
   }
 
-  viewedByTeacher = () => this.props.isTeacher === 'teacher';
+  teacherViewingStudentWork = () =>
+    this.props.isTeacher === 'teacher' && this.props.isReadOnlyWorkspace;
 
   /**
    * Called after the component mounts, when the server responds with the
@@ -173,7 +176,7 @@ export class VersionHistory extends React.Component {
               lastModified={new Date(version.lastModified)}
               isLatest={version.isLatest}
               onChoose={this.onChooseVersion.bind(this, version.versionId)}
-              isTeacher={this.viewedByTeacher()}
+              teacherViewingStudent={this.teacherViewingStudentWork()}
             />
           );
         }.bind(this)
@@ -185,7 +188,7 @@ export class VersionHistory extends React.Component {
             <table style={{width: '100%'}}>
               <tbody>
                 {rows}
-                {!this.viewedByTeacher && (
+                {!this.teacherViewingStudentWork && (
                   <tr>
                     <td>
                       <p>{i18n.versionHistory_initialVersion_label()}</p>
@@ -220,5 +223,6 @@ export class VersionHistory extends React.Component {
 }
 export const UnconnectedVersionHistory = VersionHistory;
 export default connect(state => ({
-  isTeacher: state.currentUser.userType
+  isTeacher: state.currentUser.userType,
+  isReadOnlyWorkspace: state.pageConstants.isReadOnlyWorkspace
 }))(VersionHistory);

--- a/apps/src/templates/VersionHistory.jsx
+++ b/apps/src/templates/VersionHistory.jsx
@@ -188,7 +188,7 @@ export class VersionHistory extends React.Component {
             <table style={{width: '100%'}}>
               <tbody>
                 {rows}
-                {!this.teacherViewingStudentWork && (
+                {!this.teacherViewingStudentWork() && (
                   <tr>
                     <td>
                       <p>{i18n.versionHistory_initialVersion_label()}</p>

--- a/apps/src/templates/VersionRow.jsx
+++ b/apps/src/templates/VersionRow.jsx
@@ -11,7 +11,7 @@ export default class VersionRow extends React.Component {
     lastModified: PropTypes.instanceOf(Date).isRequired,
     isLatest: PropTypes.bool,
     onChoose: PropTypes.func,
-    isTeacher: PropTypes.bool
+    teacherViewingStudent: PropTypes.bool
   };
 
   getLastModifiedTimestamp() {
@@ -36,13 +36,22 @@ export default class VersionRow extends React.Component {
         </button>
       );
     } else {
+      let searchParams;
+
+      //Need to specify user id if teacher viewing student version history
+      if (this.props.teacherViewingStudent) {
+        searchParams = location.search + '&version=';
+      } else {
+        searchParams = '?version=';
+      }
+
       button = [
         <a
           key={0}
           href={
             location.origin +
             location.pathname +
-            '?version=' +
+            searchParams +
             this.props.versionId
           }
           target="_blank"
@@ -53,7 +62,7 @@ export default class VersionRow extends React.Component {
           </button>
         </a>
       ];
-      if (!this.props.isTeacher) {
+      if (!this.props.teacherViewingStudent) {
         button.push(
           <button
             type="button"

--- a/apps/src/templates/VersionRow.jsx
+++ b/apps/src/templates/VersionRow.jsx
@@ -10,7 +10,8 @@ export default class VersionRow extends React.Component {
     versionId: PropTypes.string.isRequired,
     lastModified: PropTypes.instanceOf(Date).isRequired,
     isLatest: PropTypes.bool,
-    onChoose: PropTypes.func
+    onChoose: PropTypes.func,
+    isTeacher: PropTypes.bool
   };
 
   getLastModifiedTimestamp() {
@@ -50,16 +51,20 @@ export default class VersionRow extends React.Component {
           <button type="button" className="version-preview">
             <i className="fa fa-eye" />
           </button>
-        </a>,
-        <button
-          type="button"
-          key={1}
-          className="btn-info"
-          onClick={this.props.onChoose}
-        >
-          {msg.restoreThisVersion()}
-        </button>
+        </a>
       ];
+      if (!this.props.isTeacher) {
+        button.push(
+          <button
+            type="button"
+            key={1}
+            className="btn-info"
+            onClick={this.props.onChoose}
+          >
+            {msg.restoreThisVersion()}
+          </button>
+        );
+      }
     }
 
     return (


### PR DESCRIPTION
Currently, the version history feature is only exposed to the owner of a specific project. This PR contains the changes necessary to expose this functionality to teachers in order to provide more insight into student progress (and potentially detect plagiarism as well).

## Screenshots

Teachers can now see the version history button in the code workspace when reviewing student work. Upon clicking the version history button, they will see the following dialog:

<img width="857" alt="Screen Shot 2021-01-19 at 7 20 48 PM" src="https://user-images.githubusercontent.com/17502635/105112821-c235de00-5a91-11eb-8943-ba3a316b2812.png">

Clicking on the "eye" icon redirects the teacher to that specific version of the student's work: 
<img width="1031" alt="Screen Shot 2021-01-19 at 7 21 05 PM" src="https://user-images.githubusercontent.com/17502635/105112864-d2e65400-5a91-11eb-9794-6973152b968f.png">

We disable the version history button when teachers are viewing work from a student who has not yet started the level.

<img width="1024" alt="Screen Shot 2021-01-20 at 7 50 20 PM" src="https://user-images.githubusercontent.com/17502635/105258904-bbbe6980-5b58-11eb-80d3-6388cc6aad5d.png">

## Links

- [spec](https://docs.google.com/document/d/1h0-xW95lMqznanY9M2h5sH9V4kxEwaVwfUKbZjn_NaQ/edit)
- [jira](https://codedotorg.atlassian.net/browse/LP-85?atlOrigin=eyJpIjoiMjEzNGZmYjAzODA5NDc1NTgzOGFkN2VkMTE4MWJkZmQiLCJwIjoiaiJ9)

## Testing story

TODO

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
