### PR TITLE
Add scripts for CB Markdown compatibility testing

### DIFF
--- a/apps/script/render-markdown.js
+++ b/apps/script/render-markdown.js
@@ -1,0 +1,103 @@
+const fs = require('fs');
+const path = require('path');
+
+const Parser = require('@code-dot-org/redactable-markdown/src/redactableMarkdownParser');
+
+const remarkRehype = require('remark-rehype');
+const rehypeRaw = require('rehype-raw');
+const rehypeSanitize = require('rehype-sanitize');
+const rehypeStringify = require('rehype-stringify');
+const defaultSanitizationSchema = require('hast-util-sanitize/lib/github.json');
+
+const details = require('../src/templates/plugins/details');
+const expandableImages = require('../src/templates/plugins/expandableImages');
+const xmlAsTopLevelBlock = require('../src/templates/plugins/xmlAsTopLevelBlock');
+
+// create custom sanitization schema as per
+// https://github.com/syntax-tree/hast-util-sanitize#schema
+// to support our custom syntaxes
+const schema = Object.assign({}, defaultSanitizationSchema);
+
+// We use a _lot_ of image formatting stuff in our
+// instructions, particularly in CSP
+schema.attributes.img.push('height', 'width');
+
+// Add support for expandableImages
+schema.tagNames.push('span');
+schema.attributes.span = ['dataUrl', 'className'];
+
+// Add support for inline styles (gross)
+// TODO replace all inline styles in our curriculum content with
+// semantically-significant content
+schema.attributes['*'].push('style', 'className');
+
+// Add support for Blockly XML
+schema.clobber = [];
+const blocklyTags = [
+  'block',
+  'functional_input',
+  'mutation',
+  'next',
+  'statement',
+  'title',
+  'value',
+  'xml'
+];
+schema.tagNames = schema.tagNames.concat(blocklyTags);
+blocklyTags.forEach(tag => {
+  schema.attributes[tag] = ['block_text', 'id', 'inline', 'name', 'type'];
+});
+
+const parser = Parser.create()
+  .getParser()
+  // include custom plugins
+  .use([xmlAsTopLevelBlock, expandableImages, details])
+  // convert markdown to an HTML Abstract Syntax Tree (HAST)
+  .use(remarkRehype, {
+    // include any raw HTML in the markdown as raw HTML nodes in the HAST
+    allowDangerousHTML: true
+  })
+  // parse the raw HTML nodes in the HAST to actual HAST nodes
+  .use(rehypeRaw)
+  // sanitize the HAST
+  .use(rehypeSanitize, schema)
+  // compile to a string
+  .use(rehypeStringify);
+
+const render = function(data) {
+  if (Array.isArray(data)) {
+    // Array
+    return data.map(render);
+  } else if (typeof data === 'string' || data instanceof String) {
+    // String
+    return parser.processSync(data).contents;
+  } else if (typeof data === 'object' && data !== null) {
+    // Object
+    return Object.keys(data).reduce(function(result, key) {
+      result[key] = render(data[key]);
+      return result;
+    }, {});
+  } else {
+    throw 'cannot render unknown data type: ' + typeof data;
+  }
+};
+
+const main = function(filepaths) {
+  filepaths.forEach(function(filepath) {
+    const data = fs.readFileSync(filepath, 'utf8');
+
+    if (path.extname(filepath) !== '.json') {
+      throw 'cannot parse non-json file ' + filepath;
+    }
+
+    const rendered = render(JSON.parse(data));
+    const dest =
+      '/tmp/' + path.basename(filepath).replace('.json', '') + '.remark.json';
+
+    console.log('writing to ' + dest);
+
+    fs.writeFileSync(dest, JSON.stringify(rendered, null, 4));
+  });
+};
+
+main(process.argv.slice(2));

--- a/bin/oneoff/serialize_imported_curriculumbuilder_data.rb
+++ b/bin/oneoff/serialize_imported_curriculumbuilder_data.rb
@@ -1,0 +1,44 @@
+#!/usr/bin/env ruby
+
+require 'json'
+require_relative '../../deployment'
+require_relative '../../dashboard/config/environment'
+
+FIELDS_BY_MODEL = {
+  LessonGroup => %w(description big_questions),
+  Lesson => %w(overview student_overview purpose preparation assessment_opportunities),
+  ActivitySection => %w(description),
+  Objective => %w(description),
+
+  # possibly unnecessary:
+  Resource => %w(name type),
+  Vocabulary => %w(definition),
+}
+
+def serialize_model_data(model, fields)
+  data = {}
+  all_fields = fields.concat(%w(name)).sort.uniq
+
+  model.all.each do |object|
+    data[object.id] = all_fields.reduce({}) do |accum, field|
+      value = object.try(field)
+      accum[field] = value unless value.nil?
+      accum
+    end
+
+    if model == ActivitySection
+      data[object.id]["tips"] = object.tips.map {|t| t["markdown"]} unless object.tips.blank?
+    end
+
+    data.delete(object.id) if data[object.id].empty? || data[object.id].keys == ["name"]
+  end
+
+  File.write("/tmp/cb_markdown/#{model.name}.json", JSON.pretty_generate(data))
+end
+
+def main
+  FIELDS_BY_MODEL.each do |model, fields|
+  end
+end
+
+main


### PR DESCRIPTION
Specifically:
- One script for serializing all markdown content currently on Dashboard which was originally imported from CurriculumBuilder
- One script which will render serialized markdown content using Remark

<!--
  Your description goes here: A summary of the change, including any relevant motivation and context.

  If relevant, include a description both of the existing behavior and of the new behavior.
-->

<!--
  Other aspects to consider. uncomment and add detail for any that seem necessary:
-->

<!-- ### Background -->
<!-- ### Privacy -->
<!--
1.	Does the Project involve the collection, use or sharing of new Personal Data?

2.	Does the Project involve a new or changed use or sharing of existing Personal Data?
-->
<!-- ### Security -->
<!--
Link to Jira Task where sensitive security issues are discussed privately.
-->
<!-- ### Caching -->
<!-- ### Deployment strategy -->
<!-- ### Future work -->

## Links

<!--
  Any relevant links to external resources; ie, specification documents, jira
  items, related PRs, honeybadger errors, etc
-->

- [Matching CB Script](https://github.com/code-dot-org/curriculumbuilder/pull/336)
- [tool which can be used to find inconsistencies](https://github.com/Hamms/html-equivalency)

## Testing story

<!--
  Does your change include appropriate tests?

  If so, please describe how the tests included in this PR are sufficient

  If not, please explain why this change does not need to be tested.
-->

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
