### PR TITLE
backfill teacher feedbacks with level appearing in exactly one stable script

### DIFF
--- a/bin/oneoff/backfill_data/backfill_script_ids_in_teacher_feedbacks.rb
+++ b/bin/oneoff/backfill_data/backfill_script_ids_in_teacher_feedbacks.rb
@@ -21,7 +21,7 @@ require_relative '../../../dashboard/config/environment'
 $stdout.sync = true
 
 def feedbacks_without_script_id
-  TeacherFeedback.where(script_id: nil)
+  TeacherFeedback.with_deleted.where(script_id: nil)
 end
 
 def puts_count

--- a/bin/oneoff/backfill_data/backfill_script_ids_in_teacher_feedbacks_2.rb
+++ b/bin/oneoff/backfill_data/backfill_script_ids_in_teacher_feedbacks_2.rb
@@ -21,7 +21,7 @@ require_relative '../../../dashboard/config/environment'
 $stdout.sync = true
 
 def feedbacks_without_script_id
-  TeacherFeedback.where(script_id: nil)
+  TeacherFeedback.with_deleted.where(script_id: nil)
 end
 
 def puts_count

--- a/bin/oneoff/backfill_data/backfill_script_ids_in_teacher_feedbacks_2.rb
+++ b/bin/oneoff/backfill_data/backfill_script_ids_in_teacher_feedbacks_2.rb
@@ -1,0 +1,56 @@
+#!/usr/bin/env ruby
+# Backfill existing TeacherFeedbacks to set script_id based on script_level_id.
+
+require 'optparse'
+
+$options = {actually_update: false}
+OptionParser.new do |opts|
+  opts.banner = "Usage: #{File.basename(__FILE__)} [options]"
+  opts.on('-u', '--actually-update', 'Actually perform the update.') do
+    $options[:actually_update] = true
+  end
+  opts.on('-h', '--help', 'Add -u to perform the update.') do
+    puts opts
+    exit
+  end
+end.parse!
+puts "Called with options: #{$options}"
+
+require_relative '../../../dashboard/config/environment'
+
+$stdout.sync = true
+
+def feedbacks_without_script_id
+  TeacherFeedback.where(script_id: nil)
+end
+
+def puts_count
+  puts "There are #{feedbacks_without_script_id.count} feedbacks without a script_id"
+end
+
+def update_script_ids
+  puts "starting backfilling script_ids"
+  feedbacks_without_script_id.find_in_batches(batch_size: 1000) do |batch|
+    print '.'
+    ActiveRecord::Base.transaction do
+      batch.each do |teacher_feedback|
+        level = teacher_feedback.level
+        # if the level appears in only one stable script, set its script id to
+        # point to that script.
+        stable_scripts = level.script_levels.map(&:script).select(&:is_stable)
+        if stable_scripts.count == 1
+          script = stable_scripts.first
+          teacher_feedback.update!(script_id: script.id)
+        end
+      rescue => e
+        puts "Error updating teacher feedback id #{teacher_feedback.id}: #{e}"
+      end
+      raise ActiveRecord::Rollback unless $options[:actually_update]
+    end
+  end
+  puts "finished backfilling script_ids!"
+end
+
+puts_count
+update_script_ids
+puts_count


### PR DESCRIPTION
continues on [PLAT-684]. https://github.com/code-dot-org/code-dot-org/pull/38567 backfilled all but 321 teacher feedbacks out of more than 2 million. This PR should backfill 204 of these remaining feedbacks.

### root cause

The 321 feedbacks failed to backfill because their script_level_id did not point to a valid script level object. Possible reasons for this include:
1. the script has been deleted
2. the level has been removed from a script
3. any of these attributes of the script level (including their position within the script) changed: dashboard/app/models/script_level.rb#L101-L109 

Investigation showed that in one example, a level was added to csd3-2020.script on 2020-06-18: https://github.com/code-dot-org/code-dot-org/commit/cabb2fddcda2ccc1dec3576c9b5de7526c5f5fb8#diff-11e9fd3f6a46a2d40de152ee7b5d5072fd554a5525b2409be7998313f4ed4d11 this caused script level attributes of levels after that point in the script to change, causing those script levels to be destroyed and re-created with a different id. The created_at dates of the 321 teacher feedbacks and the script levels in that script corroborate this theory.

### proposed fix

For all 321 problematic teacher feedbacks, the level they point to exists in either 0 or 1 stable script. 204 of them exist in exactly 1 stable script and the rest do not appear in any stable script.

```
[production] dashboard > feedbacks = TeacherFeedback.where(script_id: nil)
[production] dashboard > feedbacks.count
=> 321

[production] dashboard > levels = feedbacks.map(&:level).uniq
[production] dashboard > feedback_scripts = levels.map {|l| l.script_levels.map(&:script).select(&:is_stable).map(&:name).first}.compact.sort.uniq
=> ["csd3-2020", "csp1-2020", "csp4-2020", "csp5-2020"]

[production] dashboard > feedbacks.select {|fb| feedback_scripts.include?(fb.level.script_levels.map(&:script).select(&:is_stable).map(&:name).first)}.count
=> 204
```

This PR fixes these feedbacks by assigning their script_id to point to the one stable script containing its level.

### future work

if this backfill succeeds in fixing all teacher feedbacks on levels in stable scripts, my plan is to remove the ~120 remaining feedbacks as follows:
```
TeacherFeedback.where(script_id: nil).count # safety check, should be < 120
TeacherFeedback.where(script_id: nil).destroy_all
```

## Testing story

Manually verified locally by creating a teacher feedback, then modifying the script so that the script level attributes change. I also verified that nothing happens for feedbacks whose level is not in any stable script.

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked


[PLAT-684]: https://codedotorg.atlassian.net/browse/PLAT-684