### PR TITLE
Prevent saving lockable lesson if last level is not a level group and assessment

### DIFF
--- a/dashboard/app/controllers/lessons_controller.rb
+++ b/dashboard/app/controllers/lessons_controller.rb
@@ -48,6 +48,11 @@ class LessonsController < ApplicationController
       @lesson.update!(lesson_params.except(:resources, :objectives, :original_lesson_data))
       @lesson.update_activities(JSON.parse(params[:activities])) if params[:activities]
       @lesson.update_objectives(JSON.parse(params[:objectives])) if params[:objectives]
+
+      if @lesson.lockable
+        msg = "The last level in a lockable lesson must be a LevelGroup and an assessment."
+        raise msg unless @lesson.script_levels.last.assessment && @lesson.script_levels.last.level.type == 'LevelGroup'
+      end
     end
 
     if Rails.application.config.levelbuilder_mode


### PR DESCRIPTION
Prevent saving lockable lesson if last level is not a level group and assessment. Shows a warning to the editor to let them know this.

<img width="1158" alt="Screen Shot 2021-01-20 at 1 41 38 PM" src="https://user-images.githubusercontent.com/208083/105220165-5735e700-5b25-11eb-8e28-e7cb4db0f4c3.png">

## Links

<!--
  Any relevant links to external resources; ie, specification documents, jira
  items, related PRs, honeybadger errors, etc
-->

- [spec](https://docs.google.com/document/d/1sAAVnwv3rXQEK-qa8JnkNXFfZ0vjWQyzJ9Yx_pG4bdg/edit#)
- [jira](https://codedotorg.atlassian.net/browse/PLAT-715)

## Testing story

Tested it out locally.

Added new tests in lesson_controller_tests

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
