### PR TITLE
Clarify warning when making changes to UI tests

### DIFF
--- a/dashboard/test/ui/features/curriculum_platform/levelbuilder/lesson_edit_page.feature
+++ b/dashboard/test/ui/features/curriculum_platform/levelbuilder/lesson_edit_page.feature
@@ -1,7 +1,6 @@
 # We need "press keys" to type into the React form's fields, but that doesn't work on IE.
 @no_ie
 @no_mobile
-@eyes
 
 Feature: Using the Lesson Edit Page
   Scenario: Save changes using the lesson edit page

--- a/dashboard/test/ui/features/curriculum_platform/levelbuilder/lesson_edit_page.feature
+++ b/dashboard/test/ui/features/curriculum_platform/levelbuilder/lesson_edit_page.feature
@@ -1,6 +1,7 @@
 # We need "press keys" to type into the React form's fields, but that doesn't work on IE.
 @no_ie
 @no_mobile
+@eyes
 
 Feature: Using the Lesson Edit Page
   Scenario: Save changes using the lesson edit page

--- a/tools/hooks/scary_changes.rb
+++ b/tools/hooks/scary_changes.rb
@@ -49,7 +49,13 @@ class ScaryChangeDetector
 
         #{changes.join("\n")}
 
-        Please amend your commit message to include the tag [test all browsers] if you haven't already.
+        If you'd like Drone to test your changes across all browsers
+        (instead of only in Chrome, the default),
+        amend your commit message to include the tag [test all browsers] if you haven't already.
+
+        Note that (as of January 2020) Drone will not successfully run all tests across all browsers,
+        so you may need another commit without the [test all browsers] tag
+        if you'd like to see all tests (in Chrome) passing in Drone without manual inspection.
     EOS
   end
 

--- a/tools/hooks/scary_changes.rb
+++ b/tools/hooks/scary_changes.rb
@@ -53,7 +53,7 @@ class ScaryChangeDetector
         (instead of only in Chrome, the default),
         amend your commit message to include the tag [test all browsers] if you haven't already.
 
-        Note that (as of January 2020) Drone will not successfully run all tests across all browsers,
+        Note that (as of January 2021) Drone will not successfully run all tests across all browsers,
         so you may need another commit without the [test all browsers] tag
         if you'd like to see all tests (in Chrome) passing in Drone without manual inspection.
     EOS


### PR DESCRIPTION
Any change to a UI test file currently gives this warning:

![image](https://user-images.githubusercontent.com/25372625/105227459-35813380-5b16-11eb-8c21-158954fb0dfc.png)

This is a useful warning for folks well versed in our UI testing to prevent blocking a test build with changes that could have been tested in Drone, but not as great for people with less experience who are making small changes and might view this warning as a requirement for merging a PR with changes to a UI test file. 

New warning (updated to 2021 from 2020 since screenshot was taken 🤦 ) -- message is kind of verbose, if others have ideas on how to make it more concise/clear.:

![image](https://user-images.githubusercontent.com/25372625/105229506-e7216400-5b18-11eb-8c5e-a44357b762ab.png)

Currently, Drone will not pass with `[test all browsers]` specified -- there's more discussion [here about differences between our test environment and Drone](https://github.com/code-dot-org/code-dot-org/pull/34325) that might cause this problem, but looking at a couple recent failures using the `[test all browsers]` tag ([here's one](https://drone.cdn-code.org/code-dot-org/code-dot-org/2816/2/4)), I wonder if things might just time out on Drone when testing all browsers. Here's some of the log:

```
19 Jan 23:37:51 - Cleaning up the tunnel connection to maki1162.miso.saucelabs.com
--
11781 | 19 Jan 23:37:52 - Cleaning up.
11782 | 19 Jan 23:37:53 - Removing tunnel 31a3f1e9f99c4decba6f4a48d7c674bf.
11783 | 19 Jan 23:37:54 - Waiting for any active jobs using this tunnel to finish.
11784 | 19 Jan 23:37:56 - Press CTRL-C again to shut down immediately.
11785 | 19 Jan 23:37:58 - Note: if you do this, tests that are still running will fail.
11786 | 19 Jan 23:38:08 - Error when removing tunnel: couldn't connect to https://saucelabs.com/rest/v1/******/tunnels/31a3f1e9f99c4decba6f4a48d7c674bf?wait_for_jobs=1: Delete https://saucelabs.com/rest/v1/******/tunnels/31a3f1e9f99c4decba6f4a48d7c674bf?wait_for_jobs=1: dial tcp: lookup saucelabs.com on 127.0.0.11:53: read udp 127.0.0.1:32814->127.0.0.11:53: i/o timeout. Treating error as fatal, client will now exit.
11787 | 19 Jan 23:38:08 - Waiting for the connection to terminate...
11788 | 19 Jan 23:38:28 - Connection closed (0).
11789 | 19 Jan 23:38:28 - Goodbye.
11790 | [test] iPhone_hour_of_code_hoc_reset first selenium error: Failed to open TCP connection to localhost:4445 (Cannot assign requested address - connect(2) for "localhost" port 4445) (Errno::EADDRNOTAVAIL)
11791 | [test] [hour_of_code/hoc_reset] Failing Scenarios:
11792 | [hour_of_code/hoc_reset] cucumber features/hour_of_code/hoc_reset.feature:3 # Scenario: hoc/reset resets videos, callouts, level progress
11793 | [hour_of_code/hoc_reset]
11794 | [hour_of_code/hoc_reset] 1 scenario (1 failed)
11795 | [hour_of_code/hoc_reset] 13 steps (13 skipped)
11796 | [hour_of_code/hoc_reset] 2m11.912s
```