### PR TITLE
Unify lesson editor table styles

### DIFF
--- a/apps/src/lib/levelbuilder/lesson-editor/ObjectiveLine.jsx
+++ b/apps/src/lib/levelbuilder/lesson-editor/ObjectiveLine.jsx
@@ -2,6 +2,7 @@ import PropTypes from 'prop-types';
 import React from 'react';
 import onClickOutside from 'react-onclickoutside';
 import color from '@cdo/apps/util/color';
+import {lessonEditorTableStyles} from './TableConstants';
 
 const styles = {
   actionButtons: {
@@ -47,8 +48,7 @@ export default onClickOutside(
       onSave: PropTypes.func.isRequired,
       onEditCancel: PropTypes.func.isRequired,
       onEditClick: PropTypes.func.isRequired,
-      onRemove: PropTypes.func.isRequired,
-      lineStyle: PropTypes.object
+      onRemove: PropTypes.func.isRequired
     };
 
     constructor(props) {
@@ -72,8 +72,8 @@ export default onClickOutside(
 
     render() {
       return (
-        <tr style={this.props.lineStyle}>
-          <td style={{height: 30}}>
+        <tr>
+          <td style={lessonEditorTableStyles.cell}>
             {this.props.editing ? (
               <input
                 value={this.state.description}
@@ -97,7 +97,12 @@ export default onClickOutside(
             )}
           </td>
           {this.props.editing ? (
-            <td style={styles.actionButtons}>
+            <td
+              style={{
+                ...lessonEditorTableStyles.actionsCell,
+                ...styles.actionButtons
+              }}
+            >
               <div
                 style={styles.save}
                 onMouseDown={() => this.props.onSave(this.state.description)}
@@ -113,7 +118,12 @@ export default onClickOutside(
               </div>
             </td>
           ) : (
-            <td style={styles.actionButtons}>
+            <td
+              style={{
+                ...lessonEditorTableStyles.actionsCell,
+                ...styles.actionButtons
+              }}
+            >
               <div style={styles.edit} onMouseDown={this.props.onEditClick}>
                 <i className="fa fa-edit" />
               </div>

--- a/apps/src/lib/levelbuilder/lesson-editor/ObjectivesEditor.jsx
+++ b/apps/src/lib/levelbuilder/lesson-editor/ObjectivesEditor.jsx
@@ -4,9 +4,6 @@ import color from '@cdo/apps/util/color';
 import ObjectiveLine from './ObjectiveLine';
 
 const styles = {
-  oddRow: {
-    backgroundColor: color.lightest_gray
-  },
   addButton: {
     background: color.cyan,
     borderRadius: 3,
@@ -129,7 +126,6 @@ export default class ObjectivesEditor extends Component {
                 <ObjectiveLine
                   key={objective.key}
                   description={objective.description}
-                  lineStyle={index % 2 === 1 ? styles.oddRow : {}}
                   onSave={this.handleSave}
                   onEditCancel={this.handleCancel}
                   onEditClick={() => this.handleEdit(index)}

--- a/apps/src/lib/levelbuilder/lesson-editor/ResourcesEditor.jsx
+++ b/apps/src/lib/levelbuilder/lesson-editor/ResourcesEditor.jsx
@@ -19,15 +19,6 @@ const styles = {
   resourceSearch: {
     paddingBottom: 10
   },
-  resourceBox: {
-    border: '1px solid ' + color.light_gray,
-    padding: 10,
-    marginTop: 10,
-    marginBottom: 10
-  },
-  oddRow: {
-    backgroundColor: color.lightest_gray
-  },
   actionsColumn: {
     display: 'flex',
     justifyContent: 'space-evenly',
@@ -39,7 +30,8 @@ const styles = {
     background: color.dark_red,
     cursor: 'pointer',
     textAlign: 'center',
-    width: '48%'
+    width: '48%',
+    lineHeight: '30px'
   },
   edit: {
     fontSize: 14,
@@ -47,7 +39,8 @@ const styles = {
     background: color.default_blue,
     cursor: 'pointer',
     textAlign: 'center',
-    width: '48%'
+    width: '48%',
+    lineHeight: '30px'
   }
 };
 
@@ -278,8 +271,7 @@ class ResourcesEditor extends Component {
             onConfirm={this.removeResource}
           />
         )}
-        Resources
-        <div style={styles.resourceBox}>
+        <div>
           <div style={styles.resourceSearch}>
             <label>Select a resource to add</label>
             <SearchBox

--- a/apps/src/lib/levelbuilder/lesson-editor/ResourcesEditor.jsx
+++ b/apps/src/lib/levelbuilder/lesson-editor/ResourcesEditor.jsx
@@ -4,7 +4,6 @@ import {resourceShape} from '@cdo/apps/lib/levelbuilder/shapes';
 import color from '@cdo/apps/util/color';
 import AddResourceDialog from './AddResourceDialog';
 import SearchBox from './SearchBox';
-import Button from '@cdo/apps/templates/Button';
 import Dialog from '@cdo/apps/templates/Dialog';
 import {connect} from 'react-redux';
 import {
@@ -41,6 +40,16 @@ const styles = {
     textAlign: 'center',
     width: '48%',
     lineHeight: '30px'
+  },
+  addButton: {
+    background: color.cyan,
+    borderRadius: 3,
+    color: color.white,
+    fontSize: 14,
+    padding: 7,
+    textAlign: 'center',
+    marginTop: 10,
+    marginLeft: 0
   }
 };
 
@@ -287,11 +296,13 @@ class ResourcesEditor extends Component {
             <Table.Header />
             <Table.Body rows={this.props.resources} rowKey="key" />
           </Table.Provider>
-          <Button
+          <button
             onClick={this.handleAddResourceClick}
-            text={'Add New Resource'}
-            color={color.blue}
-          />
+            style={styles.addButton}
+            type="button"
+          >
+            <i className="fa fa-plus" style={{marginRight: 7}} /> Resource
+          </button>
         </div>
       </div>
     );

--- a/apps/src/lib/levelbuilder/lesson-editor/ResourcesEditor.jsx
+++ b/apps/src/lib/levelbuilder/lesson-editor/ResourcesEditor.jsx
@@ -12,6 +12,8 @@ import {
   editResource,
   removeResource
 } from '@cdo/apps/lib/levelbuilder/lesson-editor/resourcesEditorRedux';
+import * as Table from 'reactabular-table';
+import {lessonEditorTableStyles} from './TableConstants';
 
 const styles = {
   resourceSearch: {
@@ -71,6 +73,125 @@ class ResourcesEditor extends Component {
     };
   }
 
+  actionsCellFormatter = (actions, {rowData}) => {
+    return (
+      <div style={styles.actionsColumn}>
+        <div style={styles.edit} onMouseDown={() => this.handleEdit(rowData)}>
+          <i className="fa fa-edit" />
+        </div>
+        <div
+          style={styles.remove}
+          className="unit-test-remove-resource"
+          onMouseDown={() => this.handleRemoveResourceDialogOpen(rowData)}
+        >
+          <i className="fa fa-times" />
+        </div>
+      </div>
+    );
+  };
+
+  getColumns() {
+    return [
+      {
+        property: 'key',
+        header: {
+          label: 'Key',
+          props: {
+            style: {width: '23%'}
+          }
+        },
+        cell: {
+          props: {
+            style: {
+              ...lessonEditorTableStyles.cell
+            }
+          }
+        }
+      },
+      {
+        property: 'name',
+        header: {
+          label: 'Name',
+          props: {
+            style: {width: '20%'}
+          }
+        },
+        cell: {
+          props: {
+            style: {
+              ...lessonEditorTableStyles.cell
+            }
+          }
+        }
+      },
+      {
+        property: 'type',
+        header: {
+          label: 'Type',
+          props: {
+            style: {width: '10%'}
+          }
+        },
+        cell: {
+          props: {
+            style: {
+              ...lessonEditorTableStyles.cell
+            }
+          }
+        }
+      },
+      {
+        property: 'audience',
+        header: {
+          label: 'Audience',
+          props: {
+            style: {width: '7%'}
+          }
+        },
+        cell: {
+          props: {
+            style: {
+              ...lessonEditorTableStyles.cell
+            }
+          }
+        }
+      },
+      {
+        property: 'url',
+        header: {
+          label: 'URL',
+          props: {
+            style: {width: '30%'}
+          }
+        },
+        cell: {
+          props: {
+            style: {
+              ...lessonEditorTableStyles.cell
+            }
+          }
+        }
+      },
+      {
+        property: 'actions',
+        header: {
+          label: 'Actions',
+          props: {
+            style: {width: '10%'}
+          }
+        },
+        cell: {
+          formatters: [this.actionsCellFormatter],
+          props: {
+            style: {
+              ...lessonEditorTableStyles.actionsCell
+            }
+          }
+        }
+      }
+    ];
+  }
+
   onSearchSelect = e => {
     this.props.addResource(e.resource);
   };
@@ -127,6 +248,7 @@ class ResourcesEditor extends Component {
   };
 
   render() {
+    const columns = this.getColumns();
     return (
       <div>
         {this.state.newResourceDialogOpen && (
@@ -169,49 +291,10 @@ class ResourcesEditor extends Component {
               }}
             />
           </div>
-          <table style={{width: '100%'}}>
-            <thead>
-              <tr>
-                <th style={{width: '20%'}}>Key</th>
-                <th style={{width: '20%'}}>Name</th>
-                <th style={{width: '10%'}}>Type</th>
-                <th style={{width: '10%'}}>Audience</th>
-                <th style={{width: '30%'}}>URL</th>
-                <th style={{width: '10%'}}>Actions</th>
-              </tr>
-            </thead>
-            <tbody>
-              {this.props.resources.map((resource, index) => (
-                <tr
-                  key={resource.key}
-                  style={index % 2 === 1 ? styles.oddRow : {}}
-                >
-                  <td>{resource.key}</td>
-                  <td>{resource.name}</td>
-                  <td>{resource.type}</td>
-                  <td>{resource.audience}</td>
-                  <td>{resource.url}</td>
-                  <td style={styles.actionsColumn}>
-                    <div
-                      style={styles.edit}
-                      onMouseDown={() => this.handleEdit(resource)}
-                    >
-                      <i className="fa fa-edit" />
-                    </div>
-                    <div
-                      style={styles.remove}
-                      className="unit-test-remove-resource"
-                      onMouseDown={() =>
-                        this.handleRemoveResourceDialogOpen(resource)
-                      }
-                    >
-                      <i className="fa fa-times" />
-                    </div>
-                  </td>
-                </tr>
-              ))}
-            </tbody>
-          </table>
+          <Table.Provider columns={columns}>
+            <Table.Header />
+            <Table.Body rows={this.props.resources} rowKey="key" />
+          </Table.Provider>
           <Button
             onClick={this.handleAddResourceClick}
             text={'Add New Resource'}

--- a/apps/src/lib/levelbuilder/lesson-editor/ResourcesEditor.jsx
+++ b/apps/src/lib/levelbuilder/lesson-editor/ResourcesEditor.jsx
@@ -29,7 +29,7 @@ const styles = {
     background: color.dark_red,
     cursor: 'pointer',
     textAlign: 'center',
-    width: '48%',
+    width: '50%',
     lineHeight: '30px'
   },
   edit: {
@@ -38,7 +38,7 @@ const styles = {
     background: color.default_blue,
     cursor: 'pointer',
     textAlign: 'center',
-    width: '48%',
+    width: '50%',
     lineHeight: '30px'
   },
   addButton: {
@@ -86,7 +86,7 @@ class ResourcesEditor extends Component {
           className="unit-test-remove-resource"
           onMouseDown={() => this.handleRemoveResourceDialogOpen(rowData)}
         >
-          <i className="fa fa-times" />
+          <i className="fa fa-trash" />
         </div>
       </div>
     );
@@ -99,7 +99,7 @@ class ResourcesEditor extends Component {
         header: {
           label: 'Key',
           props: {
-            style: {width: '23%'}
+            style: {width: '20%'}
           }
         },
         cell: {
@@ -115,7 +115,7 @@ class ResourcesEditor extends Component {
         header: {
           label: 'Name',
           props: {
-            style: {width: '20%'}
+            style: {width: '15%'}
           }
         },
         cell: {
@@ -163,7 +163,7 @@ class ResourcesEditor extends Component {
         header: {
           label: 'URL',
           props: {
-            style: {width: '30%'}
+            style: {width: '35%'}
           }
         },
         cell: {

--- a/apps/src/lib/levelbuilder/lesson-editor/TableConstants.js
+++ b/apps/src/lib/levelbuilder/lesson-editor/TableConstants.js
@@ -1,0 +1,14 @@
+import color from '@cdo/apps/util/color';
+
+export const lessonEditorTableStyles = {
+  cell: {
+    border: '1px solid',
+    borderColor: color.border_light_gray,
+    padding: 5
+  },
+  actionsCell: {
+    border: '1px solid',
+    borderColor: color.border_light_gray,
+    padding: 0
+  }
+};

--- a/apps/src/lib/levelbuilder/lesson-editor/TableConstants.js
+++ b/apps/src/lib/levelbuilder/lesson-editor/TableConstants.js
@@ -9,6 +9,7 @@ export const lessonEditorTableStyles = {
   actionsCell: {
     border: '1px solid',
     borderColor: color.border_light_gray,
-    padding: 0
+    padding: 0,
+    height: 30
   }
 };

--- a/apps/src/lib/levelbuilder/lesson-editor/VocabulariesEditor.jsx
+++ b/apps/src/lib/levelbuilder/lesson-editor/VocabulariesEditor.jsx
@@ -14,8 +14,8 @@ import * as Table from 'reactabular-table';
 import {lessonEditorTableStyles} from './TableConstants';
 
 const styles = {
-  oddRow: {
-    backgroundColor: color.lightest_gray
+  search: {
+    paddingBottom: 10
   },
   actionsColumn: {
     display: 'flex',
@@ -175,7 +175,7 @@ class VocabulariesEditor extends Component {
             onConfirm={this.handleRemoveVocabularyConfirm}
           />
         )}
-        <div>
+        <div style={styles.search}>
           Select a vocabulary word to add
           <SearchBox
             onSearchSelect={e => this.props.addVocabulary(e.vocabulary)}

--- a/apps/src/lib/levelbuilder/lesson-editor/VocabulariesEditor.jsx
+++ b/apps/src/lib/levelbuilder/lesson-editor/VocabulariesEditor.jsx
@@ -22,23 +22,14 @@ const styles = {
     justifyContent: 'space-evenly',
     backgroundColor: 'white'
   },
-  cell: {
-    border: '1px solid',
-    borderColor: color.border_light_gray,
-    padding: 5
-  },
-  actionsCell: {
-    border: '1px solid',
-    borderColor: color.border_light_gray,
-    padding: 0
-  },
   remove: {
     fontSize: 14,
     color: 'white',
     background: color.dark_red,
     cursor: 'pointer',
     textAlign: 'center',
-    width: '98%'
+    width: '98%',
+    lineHeight: '30px'
   }
 };
 
@@ -66,7 +57,7 @@ class VocabulariesEditor extends Component {
             })
           }
         >
-          <i className="fa fa-times" />
+          <i className="fa fa-trash" />
         </div>
       </div>
     );

--- a/apps/src/lib/levelbuilder/lesson-editor/VocabulariesEditor.jsx
+++ b/apps/src/lib/levelbuilder/lesson-editor/VocabulariesEditor.jsx
@@ -10,6 +10,8 @@ import {
   editVocabulary,
   removeVocabulary
 } from '@cdo/apps/lib/levelbuilder/lesson-editor/vocabulariesEditorRedux';
+import * as Table from 'reactabular-table';
+import {lessonEditorTableStyles} from './TableConstants';
 
 const styles = {
   oddRow: {
@@ -20,7 +22,16 @@ const styles = {
     justifyContent: 'space-evenly',
     backgroundColor: 'white'
   },
-
+  cell: {
+    border: '1px solid',
+    borderColor: color.border_light_gray,
+    padding: 5
+  },
+  actionsCell: {
+    border: '1px solid',
+    borderColor: color.border_light_gray,
+    padding: 0
+  },
   remove: {
     fontSize: 14,
     color: 'white',
@@ -41,6 +52,79 @@ class VocabulariesEditor extends Component {
     editVocabulary: PropTypes.func.isRequired,
     removeVocabulary: PropTypes.func.isRequired
   };
+
+  actionsCellFormatter = (actions, {rowData}) => {
+    return (
+      <div style={styles.actionsColumn}>
+        <div
+          style={styles.remove}
+          className="unit-test-remove-vocabulary"
+          onMouseDown={() =>
+            this.setState({
+              confirmRemovalDialogOpen: true,
+              vocabularyForRemoval: rowData
+            })
+          }
+        >
+          <i className="fa fa-times" />
+        </div>
+      </div>
+    );
+  };
+
+  getColumns() {
+    return [
+      {
+        property: 'word',
+        header: {
+          label: 'Word',
+          props: {
+            style: {width: '20%'}
+          }
+        },
+        cell: {
+          props: {
+            style: {
+              ...lessonEditorTableStyles.cell
+            }
+          }
+        }
+      },
+      {
+        property: 'definition',
+        header: {
+          label: 'Definition',
+          props: {
+            style: {width: '70%'}
+          }
+        },
+        cell: {
+          props: {
+            style: {
+              ...lessonEditorTableStyles.cell
+            }
+          }
+        }
+      },
+      {
+        property: 'actions',
+        header: {
+          label: 'Actions',
+          props: {
+            style: {width: '10%'}
+          }
+        },
+        cell: {
+          formatters: [this.actionsCellFormatter],
+          props: {
+            style: {
+              ...lessonEditorTableStyles.actionsCell
+            }
+          }
+        }
+      }
+    ];
+  }
 
   constructVocabularyOption = vocabulary => ({
     value: vocabulary.key,
@@ -74,6 +158,7 @@ class VocabulariesEditor extends Component {
   };
 
   render() {
+    const columns = this.getColumns();
     return (
       <div>
         {this.state.confirmRemovalDialogOpen && (
@@ -101,42 +186,10 @@ class VocabulariesEditor extends Component {
             constructOptions={this.constructSearchOptions}
           />
         </div>
-        <div>
-          <table style={{width: '100%'}}>
-            <thead>
-              <tr>
-                <th style={{width: '20%'}}>Word</th>
-                <th style={{width: '70%'}}>Definition</th>
-                <th style={{width: '10%'}}>Actions</th>
-              </tr>
-            </thead>
-            <tbody>
-              {this.props.vocabularies.map((vocab, index) => (
-                <tr
-                  key={vocab.key}
-                  style={index % 2 === 1 ? styles.oddRow : {}}
-                >
-                  <td>{vocab.word}</td>
-                  <td>{vocab.definition}</td>
-                  <td style={styles.actionsColumn}>
-                    <div
-                      style={styles.remove}
-                      className={'unit-test-remove-vocabulary'}
-                      onMouseDown={() =>
-                        this.setState({
-                          confirmRemovalDialogOpen: true,
-                          vocabularyForRemoval: vocab
-                        })
-                      }
-                    >
-                      <i className="fa fa-times" />
-                    </div>
-                  </td>
-                </tr>
-              ))}
-            </tbody>
-          </table>
-        </div>
+        <Table.Provider columns={columns} style={{width: '100%'}}>
+          <Table.Header />
+          <Table.Body rows={this.props.vocabularies} rowKey="key" />
+        </Table.Provider>
       </div>
     );
   }

--- a/apps/test/unit/lib/levelbuilder/lesson-editor/ResourceEditorTest.js
+++ b/apps/test/unit/lib/levelbuilder/lesson-editor/ResourceEditorTest.js
@@ -20,7 +20,7 @@ describe('ResourcesEditor', () => {
   });
 
   it('renders default props', () => {
-    const wrapper = shallow(<ResourcesEditor {...defaultProps} />);
+    const wrapper = mount(<ResourcesEditor {...defaultProps} />);
     expect(wrapper.find('tr').length).to.equal(resourceTestData.length + 1);
     expect(wrapper.find('SearchBox').length).to.equal(1);
   });

--- a/apps/test/unit/lib/levelbuilder/lesson-editor/VocabulariesEditorTest.js
+++ b/apps/test/unit/lib/levelbuilder/lesson-editor/VocabulariesEditorTest.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import {mount, shallow} from 'enzyme';
+import {mount} from 'enzyme';
 import sinon from 'sinon';
 import {expect} from '../../../../util/reconfiguredChai';
 import {UnconnectedVocabulariesEditor as VocabulariesEditor} from '@cdo/apps/lib/levelbuilder/lesson-editor/VocabulariesEditor';
@@ -22,7 +22,7 @@ describe('VocabulariesEditor', () => {
   });
 
   it('renders default props', () => {
-    const wrapper = shallow(<VocabulariesEditor {...defaultProps} />);
+    const wrapper = mount(<VocabulariesEditor {...defaultProps} />);
     expect(wrapper.find('tr').length).to.equal(3);
   });
 


### PR DESCRIPTION
Despite the fact that I wrote all of them, the ResourceEditor, VocabularyEditor, and ObjectivesEditor has diverged a bit in styles. This is my attempt to unify them a bit. VocabulariesEditor is still in progress so it still has some functionality to be added -- I figured this PR would allow me to build the rest of that more consistently.

Steps:
- Moved to reactabular for ResourcesEditor and VocabulariesEditor and pulled some styles into a shared file. Because of the way ObjectivesEditor is structured to allow for clicking outside of the table, that one is still a simple table.
  - 4c1b791da4c4812fce76091d323c57fc11199c29 for the ResourcesEditor 
  - 29a04fc78d7bd738bc4521e1612109b9f7710e57 for VocabulariesEditor
  - 6b55428f433fa2660383d21a05f73c65c2c91601 for ObjectivesEditor
- Cleaned up some spacing and borders (4ebdb02266dd089fa5b41dd490910ddedb752f8f)
- Unified the remove button (cad33365300386fa68c1747d45ccf7394a270c08)
- Unified the add button (3e2939c258dbc2cf4ece982b972562286f4edd99)

Before:
<img width="1437" alt="Screen Shot 2021-01-20 at 3 49 10 PM" src="https://user-images.githubusercontent.com/46464143/105254730-0fb85680-5b37-11eb-9a8c-fae26734ce59.png">

After
<img width="1435" alt="Screen Shot 2021-01-20 at 3 47 05 PM" src="https://user-images.githubusercontent.com/46464143/105254738-134bdd80-5b37-11eb-8e30-b988edc7c679.png">





<!-- ### Background -->
<!-- ### Privacy -->
<!--
1.	Does the Project involve the collection, use or sharing of new Personal Data?

2.	Does the Project involve a new or changed use or sharing of existing Personal Data?
-->
<!-- ### Security -->
<!--
Link to Jira Task where sensitive security issues are discussed privately.
-->
<!-- ### Caching -->
<!-- ### Deployment strategy -->
<!-- ### Future work -->

## Links

<!--
  Any relevant links to external resources; ie, specification documents, jira
  items, related PRs, honeybadger errors, etc
-->

- [spec]()
- [jira]()

## Testing story

<!--
  Does your change include appropriate tests?

  If so, please describe how the tests included in this PR are sufficient

  If not, please explain why this change does not need to be tested.
-->

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
