### PR TITLE
Adding lifecycle logging for i18n sync scripts

### DIFF
--- a/bin/i18n/sync-all.rb
+++ b/bin/i18n/sync-all.rb
@@ -152,8 +152,10 @@ class I18nSync
       # so error out.
       raise "Tried to return to staging branch from unknown branch #{GitUtils.current_branch.inspect}"
     end
-
     `git checkout staging` if should_i "switch to staging branch"
+  rescue => e
+    puts "return_to_staging_branch failed from the error: #{e}"
+    raise e
   end
 end
 

--- a/bin/i18n/sync-down.rb
+++ b/bin/i18n/sync-down.rb
@@ -18,8 +18,7 @@ end
 
 def sync_down
   I18nScriptUtils.with_synchronous_stdout do
-    puts "Beginning sync down"
-
+    puts "Sync down starting"
     logger = Logger.new(STDOUT)
     logger.level = Logger::INFO
 
@@ -53,7 +52,10 @@ def sync_down
       puts "Files downloaded in #{elapsed}"
     end
 
-    puts "Sync down complete"
+    puts "Sync down completed successfully"
+  rescue => e
+    puts "Sync down failed from the error: #{e}"
+    raise e
   end
 end
 

--- a/bin/i18n/sync-in.rb
+++ b/bin/i18n/sync-in.rb
@@ -16,6 +16,7 @@ require_relative 'redact_restore_utils'
 require_relative '../../tools/scripts/ManifestBuilder'
 
 def sync_in
+  puts "Sync in starting"
   HocSyncUtils.sync_in
   localize_level_content
   localize_project_content
@@ -27,6 +28,10 @@ def sync_in
   redact_level_content
   redact_block_content
   localize_markdown_content
+  puts "Sync in completed successfully"
+rescue => e
+  puts "Sync in failed from the error: #{e}"
+  raise e
 end
 
 def get_i18n_strings(level)

--- a/bin/i18n/sync-out.rb
+++ b/bin/i18n/sync-out.rb
@@ -21,6 +21,7 @@ require_relative 'hoc_sync_utils'
 require_relative '../../tools/scripts/ManifestBuilder'
 
 def sync_out(upload_manifests=false)
+  puts "Sync out starting"
   rename_from_crowdin_name_to_locale
   restore_redacted_files
   distribute_translations(upload_manifests)
@@ -32,6 +33,10 @@ def sync_out(upload_manifests=false)
   I18nScriptUtils.with_synchronous_stdout do
     I18nScriptUtils.run_standalone_script "dashboard/scripts/update_tts_i18n.rb"
   end
+  puts "Sync out completed successfully"
+rescue => e
+  puts "Sync out failed from the error: #{e}"
+  raise e
 end
 
 # Return true iff the specified file in the specified locale had changes

--- a/bin/i18n/sync-up.rb
+++ b/bin/i18n/sync-up.rb
@@ -9,8 +9,7 @@ require_relative 'i18n_script_utils'
 
 def sync_up
   I18nScriptUtils.with_synchronous_stdout do
-    puts "Beginning sync up"
-
+    puts "Sync up starting"
     CROWDIN_PROJECTS.each do |name, options|
       puts "Uploading source strings to #{name} project"
       command = "crowdin --config #{options[:config_file]} --identity #{options[:identity_file]} upload sources"
@@ -27,7 +26,10 @@ def sync_up
       end
     end
 
-    puts "Sync up complete"
+    puts "Sync up completed successfully"
+  rescue => e
+    puts "Sync up failed from the error: #{e}"
+    raise e
   end
 end
 


### PR DESCRIPTION
Adding some extra logging for the i18n sync to make it clearer what the error was and when the different stages of the sync start/end.
* Added `rescue` block for logging any exceptions which are thrown and stop the scripts.
* Added "starting" and "completed" logs for the sync in/up/down/out scripts so we can see in the logs when each phase starts and stops.

## Testing story
* Manually tested.

