### PR TITLE
ProgressTableStudentList

### DIFF
--- a/apps/src/templates/sectionProgress/progressTables/ProgressTableStudentList.jsx
+++ b/apps/src/templates/sectionProgress/progressTables/ProgressTableStudentList.jsx
@@ -1,0 +1,104 @@
+import React from 'react';
+import * as Table from 'reactabular-table';
+import * as Sticky from 'reactabular-sticky';
+import * as Virtualized from 'reactabular-virtualized';
+import PropTypes from 'prop-types';
+import {sectionDataPropType} from '@cdo/apps/redux/sectionDataRedux';
+import {scriptDataPropType, scrollbarWidth} from '../sectionProgressConstants';
+import ProgressTableStudentName from './ProgressTableStudentName';
+import progressTableStyles from './progressTableStyles.scss';
+import * as progressStyles from '@cdo/apps/templates/progress/progressStyles';
+import {scriptUrlForStudent} from '@cdo/apps/templates/teacherDashboard/urlHelpers';
+
+const styles = {
+  gutter: {
+    height: scrollbarWidth
+  }
+};
+export default class ProgressTableStudentList extends React.Component {
+  static propTypes = {
+    section: sectionDataPropType.isRequired,
+    scriptData: scriptDataPropType.isRequired,
+    headers: PropTypes.arrayOf(PropTypes.string).isRequired,
+    studentTimestamps: PropTypes.object,
+    localeCode: PropTypes.string,
+    needsGutter: PropTypes.bool
+  };
+
+  constructor(props) {
+    super(props);
+    this.studentNameFormatter = this.studentNameFormatter.bind(this);
+  }
+
+  header = null;
+  body = null;
+  bodyComponent = null;
+
+  studentNameFormatter(value, {rowData}) {
+    // Account for scrollbar in content view
+    if (value === 'gutter') {
+      return <div style={styles.gutter} />;
+    }
+
+    const {section, scriptData, studentTimestamps, localeCode} = this.props;
+    const studentUrl = scriptUrlForStudent(
+      section.id,
+      scriptData.name,
+      rowData.id
+    );
+    return (
+      <ProgressTableStudentName
+        name={value}
+        studentId={rowData.id}
+        sectionId={section.id}
+        scriptId={scriptData.id}
+        lastTimestamp={studentTimestamps[rowData.id]}
+        localeCode={localeCode}
+        studentUrl={studentUrl}
+      />
+    );
+  }
+
+  render() {
+    return (
+      <Table.Provider
+        renderers={{
+          body: {
+            wrapper: Virtualized.BodyWrapper,
+            row: Virtualized.BodyRow
+          }
+        }}
+        columns={[
+          {property: 'name', cell: {formatters: [this.studentNameFormatter]}}
+        ]}
+      >
+        <Sticky.Header
+          ref={r => (this.header = r && r.getRef())}
+          tableBody={this.body}
+          headerRows={this.props.headers.map(header => [
+            {
+              header: {
+                label: header,
+                props: {style: progressStyles.studentListContent}
+              }
+            }
+          ])}
+        />
+        <Virtualized.Body
+          rows={this.props.section.students}
+          rowKey={'id'}
+          style={{
+            overflowX: this.props.needsGutter ? 'scroll' : 'hidden',
+            overflowY: 'hidden',
+            maxHeight: parseInt(progressTableStyles.MAX_BODY_HEIGHT)
+          }}
+          ref={r => {
+            this.body = r && r.getRef();
+            this.bodyComponent = r;
+          }}
+          tableHeader={this.header}
+        />
+      </Table.Provider>
+    );
+  }
+}

--- a/apps/src/templates/sectionProgress/progressTables/progressTableStyles.scss
+++ b/apps/src/templates/sectionProgress/progressTables/progressTableStyles.scss
@@ -1,0 +1,66 @@
+@import 'color';
+@import 'style-constants';
+
+$row-height: 42px;
+$max-height: 680px;
+$student-list-width: 170px;
+$content-view-width: $content-width - $student-list-width;
+
+.progress-table {
+  table {
+    border: 1px solid;
+    border-color: $border-gray;
+  }
+  th {
+    background-color: $table-header;
+    border-width: 0px 1px 2px 0px;
+    border-color: $border-gray;
+    height: 100%;
+  }
+  th,
+  td {
+    padding: 0px;
+    box-sizing: border-box;
+  }
+  tr:nth-child(even) {
+    background-color: $background_gray;
+  }
+  .student-list {
+    table {
+      width: $student-list-width;
+    }
+    td,
+    th {
+      width: $student-list-width;
+      border-right: 0px;
+    }
+    th {
+      background-color: $table-header;
+      color: $charcoal;
+    }
+  }
+  .content-view {
+    thead,
+    tbody {
+      max-width: $content-view-width;
+    }
+    tr {
+      height: $row-height;
+    }
+    th,
+    td {
+      border-right: 1px solid;
+      border-color: $border-gray;
+      &:last-child {
+        border-right: 0px;
+      }
+    }
+  }
+}
+
+:export {
+  MAX_BODY_HEIGHT: $max-height / 1px;
+  STUDENT_LIST_WIDTH: $student-list-width / 1px;
+  CONTENT_VIEW_WIDTH: $content-view-width / 1px;
+  ROW_HEIGHT: $row-height / 1px;
+}

--- a/apps/test/unit/templates/sectionProgress/progressTables/ProgressTableStudentListTest.jsx
+++ b/apps/test/unit/templates/sectionProgress/progressTables/ProgressTableStudentListTest.jsx
@@ -1,0 +1,57 @@
+import React from 'react';
+import {expect} from '../../../../util/reconfiguredChai';
+import {shallow, mount} from 'enzyme';
+import ProgressTableStudentList from '@cdo/apps/templates/sectionProgress/progressTables/ProgressTableStudentList';
+import * as Sticky from 'reactabular-sticky';
+import ProgressTableStudentName from '@cdo/apps/templates/sectionProgress/progressTables/ProgressTableStudentName';
+import * as Virtualized from 'reactabular-virtualized';
+
+const TEST_STUDENT_1 = {
+  id: 1,
+  name: 'Joe'
+};
+
+const TEST_STUDENT_2 = {
+  id: 2,
+  name: 'Jamie'
+};
+
+const DEFAULT_PROPS = {
+  section: {
+    id: 1,
+    students: [TEST_STUDENT_1, TEST_STUDENT_2]
+  },
+  scriptData: {
+    id: 144,
+    name: 'csd1'
+  },
+  headers: ['Lesson'],
+  studentTimestamps: {3: 1610435096000, 4: 0},
+  localeCode: 'en-US',
+  needsGutter: false
+};
+
+describe('ProgressTableStudentList', () => {
+  it('displays a header for each header in props.headers', () => {
+    const headers = ['Lesson', 'Level Type'];
+    const props = {...DEFAULT_PROPS, headers: headers};
+    const wrapper = shallow(<ProgressTableStudentList {...props} />);
+    const stickyHeaderComponent = wrapper.find(Sticky.Header);
+    expect(stickyHeaderComponent.contains(headers[0]));
+    expect(stickyHeaderComponent.contains(headers[1]));
+  });
+
+  it('displays a ProgressTableStudentName for each student', () => {
+    const wrapper = mount(<ProgressTableStudentList {...DEFAULT_PROPS} />);
+    expect(wrapper.find(ProgressTableStudentName)).to.have.length(2);
+    expect(wrapper.contains('Joe')).to.equal(true);
+    expect(wrapper.contains('Jamie')).to.equal(true);
+  });
+
+  it('displays body with overflow scroll if needsGutter is true', () => {
+    const props = {...DEFAULT_PROPS, needsGutter: true};
+    const wrapper = mount(<ProgressTableStudentList {...props} />);
+    const virtualizedBodyComponent = wrapper.find(Virtualized.Body);
+    expect(virtualizedBodyComponent.props().style.overflowX).to.equal('scroll');
+  });
+});


### PR DESCRIPTION
this PR represents a combined effort between @cforkish and @maureensturgeon, and was extracted from the full refactor work in #38309.

this is a component used to render a fixed column of hyperlinked student names in the section progress summary and detail tables. there is no equivalent component in the legacy tables, which rendered that column directly in `VirtualizedSummaryView` and `VirtualizedDetailView`.

you can refer to [this tech spec](https://docs.google.com/document/d/1SS1DYiLObiccRrVTo3LuLSe5OFiWla2qhsIWlfMvPIo/edit#) to see how this component fits into the full table architecture.

<img width="174" alt="Screen Shot 2021-01-22 at 10 50 46 AM" src="https://user-images.githubusercontent.com/4986878/105532489-c1729700-5c9f-11eb-948e-ab46731d7d32.png">
