### PR TITLE
Foorm library editor update API

### DIFF
--- a/dashboard/app/controllers/api/v1/pd/foorm/library_questions_controller.rb
+++ b/dashboard/app/controllers/api/v1/pd/foorm/library_questions_controller.rb
@@ -1,0 +1,29 @@
+class Api::V1::Pd::Foorm::FormsController < ApplicationController
+  include Api::CsvDownload
+
+  # GET api/v1/pd/foorm/library_questions/:library_name
+  def get_library_questions_for_library
+    library_questions = Foorm::Form.where(library_name: params[:library_name])
+    if library_questions
+      data_to_return = [].tap do |library|
+        library_questions.each do |library_question|
+          library << {
+            id: question.id,
+            question: JSON.parse(library_question.question),
+            name: library_question.name,
+            published: question.published,
+            version: question.version
+          }
+        end
+      end
+      render json: data_to_return
+    else
+      render json: {}
+    end
+  end
+
+  # TBD
+  def validate_library_question
+    # TBD
+  end
+end

--- a/dashboard/app/controllers/api/v1/pd/foorm/library_questions_controller.rb
+++ b/dashboard/app/controllers/api/v1/pd/foorm/library_questions_controller.rb
@@ -1,6 +1,4 @@
-class Api::V1::Pd::Foorm::FormsController < ApplicationController
-  include Api::CsvDownload
-
+class Api::V1::Pd::Foorm::LibraryQuestionsController < ApplicationController
   # GET api/v1/pd/foorm/library_questions/:library_name
   def get_library_questions_for_library
     library_questions = Foorm::Form.where(library_name: params[:library_name])

--- a/dashboard/app/controllers/foorm/library_questions_controller.rb
+++ b/dashboard/app/controllers/foorm/library_questions_controller.rb
@@ -25,13 +25,9 @@ module Foorm
     def update_library
       params[:library_questions].each do |library_question|
         db_record = Foorm::LibraryQuestion.find library_question[:id]
-        db_record.assign_attributes(
-          published: library_question[:published]
-          # others
-        )
+        db_record.question = library_question[:question]
 
         # What to do if some saves are successful, and others fail?
-        library_question.question = library_question[:question]
         library_question.save
       end
     end

--- a/dashboard/app/controllers/foorm/library_questions_controller.rb
+++ b/dashboard/app/controllers/foorm/library_questions_controller.rb
@@ -5,25 +5,6 @@ module Foorm
     before_action :authenticate_user!
     authorize_resource
 
-    # PUT '/foorm/library_questions/:id'
-    def update
-      question = params[:question]
-      @library_question.question = question
-
-      @library_question.save
-    end
-
-    def update_group
-      ActiveRecord::Base.transaction do
-        params[:update].each do |library_question|
-          library_question = Foorm::LibraryQuestion.find library_question[:id]
-          library_question.question = library_question[:question]
-          library_question.save
-          # need to rollback file system changes somehow if we roll back db changes?
-        end
-      end
-    end
-
     # GET '/foorm/library_questions/editor'
     def editor
       formatted_names_and_versions = Foorm::LibraryQuestion.all.map {|library_question| {name: library_question.library_name, version: library_question.library_version}}.uniq
@@ -38,6 +19,21 @@ module Foorm
       }
 
       render 'foorm/library_questions/editor'
+    end
+
+    # PUT '/foorm/library_questions/update_library'
+    def update_library
+      params[:library_questions].each do |library_question|
+        db_record = Foorm::LibraryQuestion.find library_question[:id]
+        db_record.assign_attributes(
+          published: library_question[:published]
+          # others
+        )
+
+        # What to do if some saves are successful, and others fail?
+        library_question.question = library_question[:question]
+        library_question.save
+      end
     end
   end
 end

--- a/dashboard/app/controllers/foorm/library_questions_controller.rb
+++ b/dashboard/app/controllers/foorm/library_questions_controller.rb
@@ -13,6 +13,17 @@ module Foorm
       @library_question.save
     end
 
+    def update_group
+      ActiveRecord::Base.transaction do
+        params[:update].each do |library_question|
+          library_question = Foorm::LibraryQuestion.find library_question[:id]
+          library_question.question = library_question[:question]
+          library_question.save
+          # need to rollback file system changes somehow if we roll back db changes?
+        end
+      end
+    end
+
     # GET '/foorm/library_questions/editor'
     def editor
       formatted_names_and_versions = Foorm::LibraryQuestion.all.map {|library_question| {name: library_question.library_name, version: library_question.library_version}}.uniq

--- a/dashboard/app/controllers/foorm/library_questions_controller.rb
+++ b/dashboard/app/controllers/foorm/library_questions_controller.rb
@@ -5,6 +5,14 @@ module Foorm
     before_action :authenticate_user!
     authorize_resource
 
+    # PUT '/foorm/library_questions/:id'
+    def update
+      question = params[:question]
+      @library_question.question = question
+
+      @library_question.save
+    end
+
     # GET '/foorm/library_questions/editor'
     def editor
       formatted_names_and_versions = Foorm::LibraryQuestion.all.map {|library_question| {name: library_question.library_name, version: library_question.library_version}}.uniq

--- a/dashboard/app/models/foorm/form.rb
+++ b/dashboard/app/models/foorm/form.rb
@@ -149,6 +149,7 @@ class Foorm::Form < ApplicationRecord
 
   # Checks that the element name is not in element_names and the choices/rows/columns are unique and all have
   # value/text parameters. If any of the above are not true, will raise an InvalidFoormConfigurationError.
+  # Note that this method is also used to validate library_questions.
   def self.validate_element(element_data, element_names)
     return unless PANEL_TYPES.include?(element_data[:type]) || QUESTION_TYPES.include?(element_data[:type])
     unless element_data[:name]

--- a/dashboard/config/routes.rb
+++ b/dashboard/config/routes.rb
@@ -778,8 +778,11 @@ Dashboard::Application.routes.draw do
       get :editor, on: :collection
     end
 
-    resources :library_questions, only: [:update] do
-      get :editor, on: :collection
+    resources :library_questions, only: [] do
+      collection do
+        get :editor
+        put :update_library
+      end
     end
   end
 end

--- a/dashboard/config/routes.rb
+++ b/dashboard/config/routes.rb
@@ -778,7 +778,7 @@ Dashboard::Application.routes.draw do
       get :editor, on: :collection
     end
 
-    resources :library_questions, only: [] do
+    resources :library_questions, only: [:update] do
       get :editor, on: :collection
     end
   end

--- a/dashboard/test/factories/foorm_factories.rb
+++ b/dashboard/test/factories/foorm_factories.rb
@@ -1135,4 +1135,17 @@ FactoryGirl.define do
     ]
   }'
   end
+
+  factory :foorm_library_question, class: 'Foorm::LibraryQuestion' do
+    sequence(:library_name) {|n| "LibraryName#{n}"}
+    library_version 0
+    sequence(:question_name) {|n| "LibraryQuestionName#{n}"}
+    sequence(:question) do |n|
+      "{
+        \"type\": \"comment\",
+        \"name\": \"what_supported#{n}\",
+        \"title\": \"What supported your learning the most today and why?\"
+      }"
+    end
+  end
 end

--- a/dashboard/test/models/foorm/library_question_test.rb
+++ b/dashboard/test/models/foorm/library_question_test.rb
@@ -1,0 +1,52 @@
+require 'test_helper'
+
+class Foorm::LibraryQuestionTest < ActiveSupport::TestCase
+  test 'other_questions_in_library returns other questions in library with multiple questions' do
+    library_questions = create_list(:foorm_library_question, 3, library_name: "LibraryName#{SecureRandom.hex}")
+
+    assert_equal 2,
+      library_questions.first.other_questions_in_library.count
+  end
+
+  test 'other_questions_in_library returns empty array in library with one question' do
+    library_question = create :foorm_library_question
+
+    assert_empty library_question.other_questions_in_library
+  end
+
+  test 'library_formatted_as_json returns expected hash for library with multiple questions' do
+    library_questions = create_list(:foorm_library_question, 3, library_name: "LibraryName#{SecureRandom.hex}")
+
+    expected = {
+      'published' => true,
+      'pages' => [
+        {
+          'elements' => [
+            JSON.parse(library_questions.first.question),
+            JSON.parse(library_questions.second.question),
+            JSON.parse(library_questions.third.question)
+          ]
+        }
+      ]
+    }
+
+    assert_equal expected, library_questions.first.library_formatted
+  end
+
+  test 'library_formatted_as_json returns expected hash for library with one question' do
+    library_question = create :foorm_library_question
+
+    expected = {
+      'published' => true,
+      'pages' => [
+        {
+          'elements' => [
+            JSON.parse(library_question.question)
+          ]
+        }
+      ]
+    }
+
+    assert_equal expected, library_question.library_formatted
+  end
+end


### PR DESCRIPTION
Rough strokes for Foorm library editor API.

Struggling with how to deal with editing of a single library question, and write that change to a file (we store foorm config in our repo, in addition to in our database). Each row in our DB represents a library question, but a set of related questions (a "library", grouped by the `library_name` field ) are stored in a single file (a "library").

How can we edit multiple questions, but rollback changes if one of them fails, while also keeping consistent with the config files, and being able to send something sensible back to the front end?