### PR TITLE
Revert "Hide Google Log-in from Maker App"

### DIFF
--- a/apps/i18n/common/en_us.json
+++ b/apps/i18n/common/en_us.json
@@ -1142,7 +1142,6 @@
   "manageLinkedAccounts_microsoft": "Microsoft Account",
   "manageLinkedAccounts_notConnected": "Not Connected",
   "manageLinkedAccounts_rosteredSectionTooltip": "You cannot disconnect from this linked account because it is tied to one of your sections.",
-  "manageLinkedAccounts_makerAuthError": "This action cannot be done from the Maker App. Please return to your default browser and try again.",
   "manageStudents": "Manage Students",
   "manageStudentsNotificationFailure": "Something went wrong.",
   "manageStudentsNotificationCannotAdd": "You could not add {numStudents, plural, one {1 student} other {# students}} to your section. Please try again or refresh the page.",

--- a/apps/src/lib/ui/accounts/ManageLinkedAccounts.jsx
+++ b/apps/src/lib/ui/accounts/ManageLinkedAccounts.jsx
@@ -9,7 +9,6 @@ import BootstrapButton from './BootstrapButton';
 import {connect} from 'react-redux';
 import RailsAuthenticityToken from '../../util/RailsAuthenticityToken';
 import {OAuthProviders} from '@cdo/apps/lib/ui/accounts/constants';
-import {isCodeOrgBrowser} from '@cdo/apps/lib/kits/maker/util/browserChecks';
 
 export const ENCRYPTED = `*** ${i18n.encrypted()} ***`;
 const authOptionPropType = PropTypes.shape({
@@ -224,9 +223,6 @@ class OauthConnection extends React.Component {
       ? `/users/auth/${id}/disconnect`
       : `/users/auth/${credentialType}?action=connect`;
 
-    const buttonDisabled =
-      !!disconnectDisabledStatus ||
-      (isCodeOrgBrowser() && credentialType === OAuthProviders.google);
     return (
       <tr>
         <td style={styles.cell}>{displayName}</td>
@@ -241,21 +237,16 @@ class OauthConnection extends React.Component {
               action={oauthToggleConnectionPath}
             >
               {/* This button intentionally uses BootstrapButton to match other
-                  account page buttons.
-                  This button is disabled according to disconnectDisabledStatus or
-                  when the user is attempting this action from the Maker App for
-                  their Google Account. This action is blocked due to Google authentication
-                  security protocols.
-                  */}
+                  account page buttons */}
               <BootstrapButton
                 type="submit"
                 style={styles.button}
                 text={buttonText}
-                disabled={buttonDisabled}
+                disabled={!!disconnectDisabledStatus}
               />
               <RailsAuthenticityToken />
             </form>
-            {buttonDisabled && (
+            {disconnectDisabledStatus && (
               <ReactTooltip
                 id={tooltipId}
                 offset={styles.tooltipOffset}
@@ -263,12 +254,7 @@ class OauthConnection extends React.Component {
                 effect="solid"
               >
                 <div style={styles.tooltip}>
-                  {/* There are two causes for errors: disconnectDisabledStatus and logging in to
-                      Google from the Maker App. Display the appropriate error text.
-                    */}
-                  {disconnectDisabledStatus
-                    ? this.getDisconnectDisabledTooltip()
-                    : i18n.manageLinkedAccounts_makerAuthError()}
+                  {this.getDisconnectDisabledTooltip()}
                 </div>
               </ReactTooltip>
             )}
@@ -282,8 +268,6 @@ class OauthConnection extends React.Component {
 
 const GUTTER = 20;
 const BUTTON_WIDTH = 105;
-const BUTTON_PADDING = 8;
-const CELL_WIDTH = tableLayoutStyles.table.width / 3;
 const styles = {
   container: {
     paddingTop: GUTTER
@@ -300,7 +284,7 @@ const styles = {
     paddingLeft: GUTTER,
     paddingRight: GUTTER,
     fontWeight: 'normal',
-    width: CELL_WIDTH
+    width: tableLayoutStyles.table.width / 3
   },
   cell: {
     ...tableLayoutStyles.cell,
@@ -315,12 +299,10 @@ const styles = {
     width: BUTTON_WIDTH,
     fontFamily: '"Gotham 5r", sans-serif',
     color: color.charcoal,
-    padding: BUTTON_PADDING
+    padding: 8
   },
   tooltipOffset: {
-    left:
-      CELL_WIDTH / 2 - // This moves the tooltip to be in between the 2nd and 3rd columns of the table
-      (tableLayoutStyles.cell.padding + BUTTON_PADDING + BUTTON_WIDTH / 2) // This centers the tooltip over the button in the 3rd column
+    left: -(BUTTON_WIDTH / 2)
   },
   tooltip: {
     width: BUTTON_WIDTH * 2

--- a/dashboard/app/views/devise/shared/_oauth_links.haml
+++ b/dashboard/app/views/devise/shared/_oauth_links.haml
@@ -27,8 +27,3 @@
 :javascript
 
   $('.oauth_sign_in').click(dashboard.clientState.reset);
-  // If the makerBridge is available, we are in the Maker App, which has its
-  // own Google login button. Hiding this google-oauth button to avoid confusion.
-  if (!!window.MakerBridge) {
-    $('.with-google_oauth2').hide();
-  }


### PR DESCRIPTION
Reverts code-dot-org/code-dot-org#38233

This roll out caused confusion for teachers. We are going to revert it for now (see: https://codedotorg.slack.com/archives/C1B3PNDL7/p1611244824004500) so that we have a bit more time to make a smoother re-rollout plan.