### PR TITLE
isolate bubbleDialog code

### DIFF
--- a/apps/src/StudioApp.js
+++ b/apps/src/StudioApp.js
@@ -1665,7 +1665,7 @@ StudioApp.prototype.displayFeedback = function(options) {
     );
   }
 
-  if (experiments.isEnabled('bubbleDialog')) {
+  if (experiments.isEnabled(experiments.BUBBLE_DIALOG)) {
     // Track whether this experiment is in use. If not, delete this and similar
     // sections of code. If it is, create a non-experiment flag.
     trackEvent(
@@ -2068,7 +2068,12 @@ StudioApp.prototype.setConfigValues_ = function(config) {
 
   this.appMsg = config.appMsg;
   this.IDEAL_BLOCK_NUM = config.level.ideal || Infinity;
-  getStore().dispatch(setBlockLimit(this.IDEAL_BLOCK_NUM));
+  if (experiments.isEnabled(experiments.BUBBLE_DIALOG)) {
+    // This seems to break levels that start in the animation/costume tab.
+    // If this feature comes out from behind the experiment, make sure not to
+    // regress those levels.
+    getStore().dispatch(setBlockLimit(this.IDEAL_BLOCK_NUM));
+  }
   this.MIN_WORKSPACE_HEIGHT = config.level.minWorkspaceHeight || 800;
   this.requiredBlocks_ = config.level.requiredBlocks || [];
   this.recommendedBlocks_ = config.level.recommendedBlocks || [];

--- a/apps/src/maze/results/collector.js
+++ b/apps/src/maze/results/collector.js
@@ -164,7 +164,7 @@ export default class CollectorHandler extends ResultsHandler {
         });
       case true:
         // Remove this case when we turn the bubble dialog on for everyone
-        if (!experiments.isEnabled('bubbleDialog')) {
+        if (!experiments.isEnabled(experiments.BUBBLE_DIALOG)) {
           return mazeMsg.collectorCollectedEverything({
             count: this.getPotentialMaxCollected()
           });

--- a/apps/src/p5lab/AnimationPicker/AnimationPreview.jsx
+++ b/apps/src/p5lab/AnimationPicker/AnimationPreview.jsx
@@ -95,7 +95,7 @@ export default class AnimationPreview extends React.Component {
       ? nextAnimation.sourceSize
       : {x: 1, y: 1};
     this.setState({
-      framesPerRow: Math.floor(sourceSize.x / nextAnimation.frameSize.x),
+      framesPerRow: Math.floor(sourceSize.x / nextAnimation.frameSize.x) || 1,
       scaledSourceSize: scaleVector2(sourceSize, scale),
       scaledFrameSize: scaledFrameSize,
       extraTopMargin: Math.ceil((innerHeight - scaledFrameSize.y) / 2),

--- a/apps/src/util/experiments.js
+++ b/apps/src/util/experiments.js
@@ -36,6 +36,13 @@ experiments.BYPASS_DIALOG_POPUP = 'bypass-dialog-popup';
 experiments.SPRITELAB_PAUSE = 'spritelabPause';
 
 /**
+ * This was a gamified version of the finish dialog, built in 2018,
+ * but never fully shipped.
+ * See github.com/code-dot-org/code-dot-org/pull/19557
+ */
+experiments.BUBBLE_DIALOG = 'bubbleDialog';
+
+/**
  * Get our query string. Provided as a method so that tests can mock this.
  */
 experiments.getQueryString_ = function() {


### PR DESCRIPTION
The "start in animation tab" feature for Gamelab levels is currently broken, and most likely has been since December 2017. 
I didn't track all the way to the bottom of the issue, but it stems from the `dispatch` call in `setConfigValues_`. Turns out, this is code for an unfinished project to implement a new finish dialog. Since this code is supposed to be behind the experiment, the solution is just to move the `dispatch` call also behind an experiment check. I also added some comments since it's very hard to tell from the code alone that the Finish Dialog isn't actually used anywhere.

Before:
![image](https://user-images.githubusercontent.com/8787187/105423073-b82eef00-5bf9-11eb-9969-764b2ade3e61.png)

After:
![image](https://user-images.githubusercontent.com/8787187/105423346-3390a080-5bfa-11eb-8163-c11466912703.png)


Relevant PRs:
[Start in Animation Tab](https://github.com/code-dot-org/code-dot-org/pull/11037) (Oct 2016)
[New Finish Dialog](https://github.com/code-dot-org/code-dot-org/pull/19557) (Dec 2017)

Follow up work
- figure out what to do with the finish dialog in general
- enable start in animation tab for spritelab levels.