### PR TITLE
Migration for foorm library model

### DIFF
--- a/dashboard/app/models/foorm/library.rb
+++ b/dashboard/app/models/foorm/library.rb
@@ -1,0 +1,17 @@
+# == Schema Information
+#
+# Table name: foorm_libraries
+#
+#  id         :bigint           not null, primary key
+#  name       :string(255)      not null
+#  version    :integer          not null
+#  published  :boolean          default(TRUE), not null
+#  created_at :datetime         not null
+#  updated_at :datetime         not null
+#
+# Indexes
+#
+#  index_foorm_libraries_on_multiple_fields  (name,version) UNIQUE
+#
+class Foorm::Library < ApplicationRecord
+end

--- a/dashboard/db/migrate/20210121195951_create_foorm_libraries.rb
+++ b/dashboard/db/migrate/20210121195951_create_foorm_libraries.rb
@@ -3,7 +3,7 @@ class CreateFoormLibraries < ActiveRecord::Migration[5.2]
     create_table :foorm_libraries do |t|
       t.string :name, null: false
       t.integer :version, null: false
-      t.boolean :published, default: true, null: false
+      t.boolean :published, null: false
 
       t.timestamps
 

--- a/dashboard/db/migrate/20210121195951_create_foorm_libraries.rb
+++ b/dashboard/db/migrate/20210121195951_create_foorm_libraries.rb
@@ -1,0 +1,13 @@
+class CreateFoormLibraries < ActiveRecord::Migration[5.2]
+  def change
+    create_table :foorm_libraries do |t|
+      t.string :name, null: false
+      t.integer :version, null: false
+      t.boolean :published, default: true, null: false
+
+      t.timestamps
+
+      t.index [:name, :version], name: "index_foorm_libraries_on_multiple_fields", unique: true
+    end
+  end
+end

--- a/dashboard/db/schema.rb
+++ b/dashboard/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_01_08_224326) do
+ActiveRecord::Schema.define(version: 2021_01_21_195951) do
 
   create_table "activities", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci", force: :cascade do |t|
     t.integer "user_id"
@@ -462,6 +462,15 @@ ActiveRecord::Schema.define(version: 2021_01_08_224326) do
     t.datetime "updated_at", null: false
     t.boolean "published", default: true, null: false
     t.index ["name", "version"], name: "index_foorm_forms_on_name_and_version", unique: true
+  end
+
+  create_table "foorm_libraries", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci", force: :cascade do |t|
+    t.string "name", null: false
+    t.integer "version", null: false
+    t.boolean "published", default: true, null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["name", "version"], name: "index_foorm_libraries_on_multiple_fields", unique: true
   end
 
   create_table "foorm_library_questions", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci", force: :cascade do |t|


### PR DESCRIPTION
Creates a `Library` model for foorm, representing a collection of `LibraryQuestions`. This entity should make it easier to reason about saving changes to library questions, which will require saving the entire library to which the question belongs. See https://github.com/code-dot-org/code-dot-org/pull/38682 for an immediate follow-up putting this to initial use.

## Testing

I executed the migration locally via `bundle exec rake db:migrate`.

## Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
