### PR TITLE
[Spritelab] moveToward block shouldn't overshoot target

### DIFF
--- a/apps/src/p5lab/spritelab/commands/actionCommands.js
+++ b/apps/src/p5lab/spritelab/commands/actionCommands.js
@@ -152,6 +152,14 @@ export const commands = {
     let sprites = coreLibrary.getSpriteArray(spriteArg);
     sprites.forEach(sprite => {
       if (sprite && target) {
+        const distanceFromSpriteToTarget = Math.sqrt(
+          (sprite.x - target.x) ** 2 + (sprite.y - target.y) ** 2
+        );
+        if (distanceFromSpriteToTarget < distance) {
+          sprite.x = target.x;
+          sprite.y = target.y;
+          return;
+        }
         let angle = Math.atan2(target.y - sprite.y, target.x - sprite.x);
         if (!isNaN(angle)) {
           let dy = Math.sin(angle) * distance;

--- a/apps/test/unit/p5lab/spritelab/actionCommandsTest.js
+++ b/apps/test/unit/p5lab/spritelab/actionCommandsTest.js
@@ -139,19 +139,32 @@ describe('Action Commands', () => {
     expect(spriteCommands.getProp({name: spriteName}, 'y')).to.equal(400);
   });
 
-  it('moveToward', () => {
-    makeSprite({name: spriteName, location: {x: 0, y: 50}});
+  describe('moveToward', () => {
+    it('moves the sprite towards the target', () => {
+      makeSprite({name: spriteName, location: {x: 0, y: 50}});
 
-    commands.moveToward({name: spriteName}, 100, {x: 123, y: 321});
-    expect(spriteCommands.getProp({name: spriteName}, 'x')).to.be.within(
-      41.3,
-      41.4
-    );
-    let expectedY = 400 - (50 + 91.1);
-    expect(spriteCommands.getProp({name: spriteName}, 'y')).to.be.within(
-      expectedY,
-      expectedY + 0.1
-    );
+      commands.moveToward({name: spriteName}, 100, {x: 123, y: 321});
+      expect(spriteCommands.getProp({name: spriteName}, 'x')).to.be.within(
+        41.3,
+        41.4
+      );
+      let expectedY = 400 - (50 + 91.1);
+      expect(spriteCommands.getProp({name: spriteName}, 'y')).to.be.within(
+        expectedY,
+        expectedY + 0.1
+      );
+    });
+
+    it('does not overshoot the target', () => {
+      makeSprite({name: spriteName, location: {x: 100, y: 100}});
+      const target = {x: 110, y: 120};
+      commands.moveToward({name: spriteName}, 100, target);
+      expect(spriteCommands.getProp({name: spriteName}, 'x')).to.equal(110);
+      const expectedY = 400 - target.y;
+      expect(spriteCommands.getProp({name: spriteName}, 'y')).to.equal(
+        expectedY
+      );
+    });
   });
 
   describe('setProp', () => {


### PR DESCRIPTION
Request from curriculum - [example project](https://studio.code.org/projects/spritelab/eZqELo3qhKzthMKH-zU58pWD8o95diPcoWRKno_Erhs/edit)

This block shouldn't move past the target even if the distance to move is greater than the distance between the sprite and the target. Instead, it should just move directly to the target.
![image](https://user-images.githubusercontent.com/8787187/105431623-cfc2a380-5c0a-11eb-9c0e-53e8d5c3c692.png)


Before
![Jan-21-2021 17-03-45](https://user-images.githubusercontent.com/8787187/105431547-aefa4e00-5c0a-11eb-8146-cedd14046c54.gif)
After
![Jan-21-2021 17-03-51](https://user-images.githubusercontent.com/8787187/105431557-b28dd500-5c0a-11eb-846f-fa300b5351c6.gif)



<!-- ### Background -->
<!-- ### Privacy -->
<!--
1.	Does the Project involve the collection, use or sharing of new Personal Data?

2.	Does the Project involve a new or changed use or sharing of existing Personal Data?
-->
<!-- ### Security -->
<!--
Link to Jira Task where sensitive security issues are discussed privately.
-->
<!-- ### Caching -->
<!-- ### Deployment strategy -->
<!-- ### Future work -->

## Links

<!--
  Any relevant links to external resources; ie, specification documents, jira
  items, related PRs, honeybadger errors, etc
-->

## Testing story
Includes unit test

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
