### PR TITLE
Reverting only portion of changes that affected backend lock and subm…

### DIFF
--- a/dashboard/app/models/user_level.rb
+++ b/dashboard/app/models/user_level.rb
@@ -36,6 +36,8 @@ class UserLevel < ApplicationRecord
   after_save :after_submit, if: :submitted_or_resubmitted?
   before_save :before_unsubmit, if: ->(ul) {ul.submitted_changed? from: true, to: false}
 
+  validate :readonly_requires_submitted
+
   # TODO(asher): Consider making these scopes and the methods below more consistent, in tense and in
   # word choice.
   scope :attempted, -> {where.not(best_result: nil)}
@@ -45,6 +47,12 @@ class UserLevel < ApplicationRecord
   def self.by_stage(stage)
     levels = stage.script_levels.map(&:level_ids).flatten
     where(script: stage.script, level: levels)
+  end
+
+  def readonly_requires_submitted
+    if readonly_answers? && !submitted?
+      errors.add(:readonly_answers, 'readonly_answers only valid on submitted UserLevel')
+    end
   end
 
   def attempted?
@@ -159,6 +167,7 @@ class UserLevel < ApplicationRecord
     return if !user_level.persisted? && locked
 
     user_level.assign_attributes(
+      submitted: locked || readonly_answers,
       readonly_answers: !locked && readonly_answers,
       unlocked_at: locked ? nil : Time.now,
       # level_group, which is the only levels that we lock, always sets best_result to 100 when complete

--- a/dashboard/test/controllers/api_controller_test.rb
+++ b/dashboard/test/controllers/api_controller_test.rb
@@ -383,7 +383,7 @@ class ApiControllerTest < ActionController::TestCase
 
     post :update_lockable_state, params: {updates: updates}
     user_level = UserLevel.find_by(user_level_data)
-    assert_equal false, user_level.submitted?
+    assert_equal true, user_level.submitted?
     assert_equal true, user_level.readonly_answers?
     assert_not_nil user_level.unlocked_at
 
@@ -436,7 +436,7 @@ class ApiControllerTest < ActionController::TestCase
 
       post :update_lockable_state, params: {updates: updates}
       user_level = UserLevel.find_by(user_level_data)
-      assert_equal false, user_level.submitted?
+      assert_equal true, user_level.submitted?
       assert_equal false, user_level.readonly_answers?
       assert_nil user_level.unlocked_at
       # update_lockable_state does not modify updated_at
@@ -456,7 +456,7 @@ class ApiControllerTest < ActionController::TestCase
 
       post :update_lockable_state, params: {updates: updates}
       user_level = UserLevel.find_by(user_level_data)
-      assert_equal false, user_level.submitted?
+      assert_equal true, user_level.submitted?
       assert_equal true, user_level.readonly_answers?
       assert_not_nil user_level.unlocked_at
       assert_equal expected_updated_at, user_level.updated_at
@@ -494,7 +494,7 @@ class ApiControllerTest < ActionController::TestCase
 
       post :update_lockable_state, params: {updates: updates}
       user_level = UserLevel.find_by(user_level_data)
-      assert_equal true, user_level.submitted?
+      assert_equal false, user_level.submitted?
       assert_equal false, user_level.readonly_answers?
       assert_not_nil user_level.unlocked_at
       assert_equal expected_updated_at, user_level.updated_at


### PR DESCRIPTION
…it logic

This is a partial revert to restore the lock and submit logic back to their status prior to PR38532 on 1/20. This maintains the UI updates included, but reverts any user_level.rb changes (and associated tests) so we can investigate the bug it introduced. In short: it prevented teachers from locking/unlocking assessments. 