### PR TITLE
Create or edit vocabulary

### DIFF
--- a/apps/src/lib/levelbuilder/lesson-editor/AddVocabularyDialog.jsx
+++ b/apps/src/lib/levelbuilder/lesson-editor/AddVocabularyDialog.jsx
@@ -121,7 +121,11 @@ export default class AddVocabularyDialog extends Component {
       this.state.definition !== '';
     return (
       <BaseDialog isOpen={true} handleClose={this.onClose}>
-        {this.state.error && <h2>{this.state.error}</h2>}
+        <h2>
+          {this.props.editingVocabulary ? 'Edit Vocabulary' : 'Add Vocabulary'}
+        </h2>
+
+        {this.state.error && <h3>{this.state.error}</h3>}
         <label style={styles.inputAndLabel}>
           Word
           <input

--- a/apps/src/lib/levelbuilder/lesson-editor/AddVocabularyDialog.jsx
+++ b/apps/src/lib/levelbuilder/lesson-editor/AddVocabularyDialog.jsx
@@ -38,6 +38,13 @@ const styles = {
   }
 };
 
+const initialState = {
+  word: '',
+  definition: '',
+  isSaving: false,
+  error: ''
+};
+
 export default class AddVocabularyDialog extends Component {
   static propTypes = {
     afterSave: PropTypes.func,
@@ -48,7 +55,6 @@ export default class AddVocabularyDialog extends Component {
 
   constructor(props) {
     super(props);
-    console.log(props);
     if (this.props.editingVocabulary) {
       this.state = {
         ...this.props.editingVocabulary,
@@ -56,12 +62,7 @@ export default class AddVocabularyDialog extends Component {
         error: ''
       };
     } else {
-      this.state = {
-        word: '',
-        definition: '',
-        isSaving: false,
-        error: ''
-      };
+      this.state = {...initialState};
     }
   }
 
@@ -71,6 +72,15 @@ export default class AddVocabularyDialog extends Component {
 
   handleDefinitionChange = e => {
     this.setState({definition: e.target.value});
+  };
+
+  resetState = () => {
+    this.setState(initialState);
+  };
+
+  onClose = () => {
+    this.resetState();
+    this.props.handleClose();
   };
 
   saveVocabulary = e => {
@@ -97,7 +107,7 @@ export default class AddVocabularyDialog extends Component {
     })
       .done(data => {
         this.props.afterSave(data);
-        this.props.handleClose();
+        this.onClose();
       })
       .fail(error => {
         this.setState({isSaving: false, error: error.responseText});
@@ -105,13 +115,13 @@ export default class AddVocabularyDialog extends Component {
   };
 
   render() {
-    console.log(this.state);
     const canSubmit =
       !this.state.isSaving &&
       this.state.word !== '' &&
       this.state.definition !== '';
     return (
-      <BaseDialog isOpen={true} handleClose={this.props.handleClose}>
+      <BaseDialog isOpen={true} handleClose={this.onClose}>
+        {this.state.error && <h2>{this.state.error}</h2>}
         <label style={styles.inputAndLabel}>
           Word
           <input

--- a/apps/src/lib/levelbuilder/lesson-editor/AddVocabularyDialog.jsx
+++ b/apps/src/lib/levelbuilder/lesson-editor/AddVocabularyDialog.jsx
@@ -48,12 +48,21 @@ export default class AddVocabularyDialog extends Component {
 
   constructor(props) {
     super(props);
-    this.state = {
-      word: '',
-      definition: '',
-      isSaving: false,
-      error: ''
-    };
+    console.log(props);
+    if (this.props.editingVocabulary) {
+      this.state = {
+        ...this.props.editingVocabulary,
+        isSaving: false,
+        error: ''
+      };
+    } else {
+      this.state = {
+        word: '',
+        definition: '',
+        isSaving: false,
+        error: ''
+      };
+    }
   }
 
   handleWordChange = e => {
@@ -67,16 +76,24 @@ export default class AddVocabularyDialog extends Component {
   saveVocabulary = e => {
     e.preventDefault();
     this.setState({isSaving: true});
+    const url = this.props.editingVocabulary
+      ? `/vocabularies/${this.props.editingVocabulary.id}`
+      : '/vocabularies';
+    const method = this.props.editingVocabulary ? 'PATCH' : 'POST';
+    const data = {
+      word: this.state.word,
+      definition: this.state.definition,
+      courseVersionId: this.props.courseVersionId
+    };
+    if (this.props.editingVocabulary) {
+      data['key'] = this.props.editingVocabulary.key;
+    }
     $.ajax({
-      url: `/vocabularies`,
-      method: 'POST',
+      url: url,
+      method: method,
       dataType: 'json',
       contentType: 'application/json;charset=UTF-8',
-      data: JSON.stringify({
-        word: this.state.word,
-        definition: this.state.definition,
-        courseVersionId: this.props.courseVersionId
-      })
+      data: JSON.stringify(data)
     })
       .done(data => {
         this.props.afterSave(data);
@@ -88,6 +105,7 @@ export default class AddVocabularyDialog extends Component {
   };
 
   render() {
+    console.log(this.state);
     const canSubmit =
       !this.state.isSaving &&
       this.state.word !== '' &&
@@ -122,7 +140,7 @@ export default class AddVocabularyDialog extends Component {
             onClick={this.saveVocabulary}
             disabled={!canSubmit}
           >
-            "Close and Save"
+            Close and Save
           </button>
         </DialogFooter>
       </BaseDialog>

--- a/apps/src/lib/levelbuilder/lesson-editor/AddVocabularyDialog.jsx
+++ b/apps/src/lib/levelbuilder/lesson-editor/AddVocabularyDialog.jsx
@@ -1,0 +1,99 @@
+import PropTypes from 'prop-types';
+import React, {Component} from 'react';
+import BaseDialog from '@cdo/apps/templates/BaseDialog';
+import DialogFooter from '@cdo/apps/templates/teacherDashboard/DialogFooter';
+import color from '@cdo/apps/util/color';
+import {vocabularyShape} from '@cdo/apps/lib/levelbuilder/shapes';
+
+const styles = {
+  dialog: {
+    paddingLeft: 20,
+    paddingRight: 20,
+    paddingBottom: 20,
+    fontFamily: '"Gotham 4r", sans-serif, sans-serif'
+  },
+  container: {
+    display: 'flex',
+    flexDirection: 'column'
+  },
+  inputAndLabel: {
+    display: 'flex',
+    flexDirection: 'column'
+  },
+  textInput: {
+    width: '98%'
+  },
+  submitButton: {
+    color: 'white',
+    backgroundColor: color.orange,
+    borderColor: color.orange,
+    borderRadius: 3,
+    fontSize: 12,
+    fontFamily: '"Gotham 4r", sans-serif',
+    fontWeight: 'bold',
+    paddingLeft: 20,
+    paddingRight: 20,
+    paddingTop: 5,
+    paddingBottom: 5
+  }
+};
+
+export default class AddVocabularyDialog extends Component {
+  static propTypes = {
+    onSave: PropTypes.func,
+    handleClose: PropTypes.func,
+    editingVocabulary: vocabularyShape,
+    courseVersionId: PropTypes.number
+  };
+
+  constructor(props) {
+    super(props);
+    this.state = {
+      word: '',
+      definition: ''
+    };
+  }
+
+  handleWordChange = e => {
+    this.setState({word: e.target.value});
+  };
+
+  handleDefinitionChange = e => {
+    this.setState({definition: e.target.value});
+  };
+
+  render() {
+    return (
+      <BaseDialog isOpen={true} handleClose={this.props.handleClose}>
+        <label style={styles.inputAndLabel}>
+          Word
+          <input
+            type="text"
+            name="word"
+            value={this.state.word}
+            onChange={this.handleWordChange}
+            style={styles.textInput}
+          />
+        </label>
+        <label style={styles.inputAndLabel}>
+          Definition
+          <input
+            type="text"
+            name="definition"
+            value={this.state.definition}
+            onChange={this.handleDefinitionChange}
+            style={styles.textInput}
+          />
+        </label>
+        <DialogFooter rightAlign>
+          <input
+            id="submit-button"
+            type="submit"
+            value="Close and Save"
+            style={styles.submitButton}
+          />
+        </DialogFooter>
+      </BaseDialog>
+    );
+  }
+}

--- a/apps/src/lib/levelbuilder/lesson-editor/AddVocabularyDialog.jsx
+++ b/apps/src/lib/levelbuilder/lesson-editor/AddVocabularyDialog.jsx
@@ -4,6 +4,7 @@ import BaseDialog from '@cdo/apps/templates/BaseDialog';
 import DialogFooter from '@cdo/apps/templates/teacherDashboard/DialogFooter';
 import color from '@cdo/apps/util/color';
 import {vocabularyShape} from '@cdo/apps/lib/levelbuilder/shapes';
+import $ from 'jquery';
 
 const styles = {
   dialog: {
@@ -47,10 +48,10 @@ const initialState = {
 
 export default class AddVocabularyDialog extends Component {
   static propTypes = {
-    afterSave: PropTypes.func,
-    handleClose: PropTypes.func,
+    afterSave: PropTypes.func.isRequired,
+    handleClose: PropTypes.func.isRequired,
     editingVocabulary: vocabularyShape,
-    courseVersionId: PropTypes.number
+    courseVersionId: PropTypes.number.isRequired
   };
 
   constructor(props) {
@@ -84,7 +85,6 @@ export default class AddVocabularyDialog extends Component {
   };
 
   saveVocabulary = e => {
-    e.preventDefault();
     this.setState({isSaving: true});
     const url = this.props.editingVocabulary
       ? `/vocabularies/${this.props.editingVocabulary.id}`

--- a/apps/src/lib/levelbuilder/lesson-editor/ObjectivesEditor.jsx
+++ b/apps/src/lib/levelbuilder/lesson-editor/ObjectivesEditor.jsx
@@ -1,13 +1,13 @@
 import PropTypes from 'prop-types';
 import React, {Component} from 'react';
-import color from '@cdo/apps/util/color';
 import ObjectiveLine from './ObjectiveLine';
 
 const styles = {
   addButton: {
-    background: color.cyan,
+    background: '#eee',
+    border: '1px solid #ddd',
+    boxShadow: 'inset 0 1px 0 0 rgba(255, 255, 255, 0.8)',
     borderRadius: 3,
-    color: color.white,
     fontSize: 14,
     padding: 7,
     textAlign: 'center',
@@ -141,7 +141,8 @@ export default class ObjectivesEditor extends Component {
           style={styles.addButton}
           type="button"
         >
-          <i className="fa fa-plus" style={{marginRight: 7}} /> Objective
+          <i className="fa fa-plus" style={{marginRight: 7}} /> Create New
+          Objective
         </button>
       </div>
     );

--- a/apps/src/lib/levelbuilder/lesson-editor/ResourcesEditor.jsx
+++ b/apps/src/lib/levelbuilder/lesson-editor/ResourcesEditor.jsx
@@ -42,9 +42,10 @@ const styles = {
     lineHeight: '30px'
   },
   addButton: {
-    background: color.cyan,
+    background: '#eee',
+    border: '1px solid #ddd',
+    boxShadow: 'inset 0 1px 0 0 rgba(255, 255, 255, 0.8)',
     borderRadius: 3,
-    color: color.white,
     fontSize: 14,
     padding: 7,
     textAlign: 'center',
@@ -282,7 +283,9 @@ class ResourcesEditor extends Component {
         )}
         <div>
           <div style={styles.resourceSearch}>
-            <label>Select a resource to add</label>
+            <label>
+              <strong>Select a resource to add</strong>
+            </label>
             <SearchBox
               onSearchSelect={this.onSearchSelect}
               searchUrl={'resourcesearch'}
@@ -301,7 +304,8 @@ class ResourcesEditor extends Component {
             style={styles.addButton}
             type="button"
           >
-            <i className="fa fa-plus" style={{marginRight: 7}} /> Resource
+            <i className="fa fa-plus" style={{marginRight: 7}} /> Create New
+            Resource
           </button>
         </div>
       </div>

--- a/apps/src/lib/levelbuilder/lesson-editor/VocabulariesEditor.jsx
+++ b/apps/src/lib/levelbuilder/lesson-editor/VocabulariesEditor.jsx
@@ -165,6 +165,7 @@ class VocabulariesEditor extends Component {
           <AddVocabularyDialog
             handleClose={() => this.setState({newVocabularyDialogOpen: false})}
             courseVersionId={this.props.courseVersionId}
+            afterSave={this.props.addVocabulary}
           />
         )}
         {this.state.confirmRemovalDialogOpen && (

--- a/apps/src/lib/levelbuilder/lesson-editor/VocabulariesEditor.jsx
+++ b/apps/src/lib/levelbuilder/lesson-editor/VocabulariesEditor.jsx
@@ -202,7 +202,12 @@ class VocabulariesEditor extends Component {
       <div>
         {this.state.newVocabularyDialogOpen && (
           <AddVocabularyDialog
-            handleClose={() => this.setState({newVocabularyDialogOpen: false})}
+            handleClose={() =>
+              this.setState({
+                newVocabularyDialogOpen: false,
+                vocabularyForEdit: null
+              })
+            }
             courseVersionId={this.props.courseVersionId}
             afterSave={this.afterVocabularySave}
             editingVocabulary={this.state.vocabularyForEdit}

--- a/apps/src/lib/levelbuilder/lesson-editor/VocabulariesEditor.jsx
+++ b/apps/src/lib/levelbuilder/lesson-editor/VocabulariesEditor.jsx
@@ -40,6 +40,16 @@ const styles = {
     textAlign: 'center',
     width: '50%',
     lineHeight: '30px'
+  },
+  addButton: {
+    background: color.cyan,
+    borderRadius: 3,
+    color: color.white,
+    fontSize: 14,
+    padding: 7,
+    textAlign: 'center',
+    marginTop: 10,
+    marginLeft: 0
   }
 };
 

--- a/apps/src/lib/levelbuilder/lesson-editor/VocabulariesEditor.jsx
+++ b/apps/src/lib/levelbuilder/lesson-editor/VocabulariesEditor.jsx
@@ -23,13 +23,22 @@ const styles = {
     justifyContent: 'space-evenly',
     backgroundColor: 'white'
   },
+  edit: {
+    fontSize: 14,
+    color: 'white',
+    background: color.default_blue,
+    cursor: 'pointer',
+    textAlign: 'center',
+    width: '50%',
+    lineHeight: '30px'
+  },
   remove: {
     fontSize: 14,
     color: 'white',
     background: color.dark_red,
     cursor: 'pointer',
     textAlign: 'center',
-    width: '98%',
+    width: '50%',
     lineHeight: '30px'
   }
 };
@@ -45,9 +54,30 @@ class VocabulariesEditor extends Component {
     removeVocabulary: PropTypes.func.isRequired
   };
 
+  constructor(props) {
+    super(props);
+    this.state = {
+      confirmRemovalDialogOpen: false,
+      vocabularyForRemoval: null,
+      newVocabularyDialogOpen: false,
+      vocabularyForEdit: null
+    };
+  }
+
   actionsCellFormatter = (actions, {rowData}) => {
     return (
       <div style={styles.actionsColumn}>
+        <div
+          style={styles.edit}
+          onMouseDown={() =>
+            this.setState({
+              newVocabularyDialogOpen: true,
+              vocabularyForEdit: rowData
+            })
+          }
+        >
+          <i className="fa fa-edit" />
+        </div>
         <div
           style={styles.remove}
           className="unit-test-remove-vocabulary"
@@ -124,14 +154,13 @@ class VocabulariesEditor extends Component {
     vocabulary
   });
 
-  constructor(props) {
-    super(props);
-    this.state = {
-      confirmRemovalDialogOpen: false,
-      vocabularyForRemoval: null,
-      newVocabularyDialogOpen: false
-    };
-  }
+  afterVocabularySave = vocabulary => {
+    if (this.state.vocabularyForEdit) {
+      this.props.editVocabulary(vocabulary);
+    } else {
+      this.props.addVocabulary(vocabulary);
+    }
+  };
 
   handleAddVocabularyClick = () => {
     this.setState({newVocabularyDialogOpen: true});
@@ -165,7 +194,8 @@ class VocabulariesEditor extends Component {
           <AddVocabularyDialog
             handleClose={() => this.setState({newVocabularyDialogOpen: false})}
             courseVersionId={this.props.courseVersionId}
-            afterSave={this.props.addVocabulary}
+            afterSave={this.afterVocabularySave}
+            editingVocabulary={this.state.vocabularyForEdit}
           />
         )}
         {this.state.confirmRemovalDialogOpen && (

--- a/apps/src/lib/levelbuilder/lesson-editor/VocabulariesEditor.jsx
+++ b/apps/src/lib/levelbuilder/lesson-editor/VocabulariesEditor.jsx
@@ -4,6 +4,7 @@ import {vocabularyShape} from '@cdo/apps/lib/levelbuilder/shapes';
 import color from '@cdo/apps/util/color';
 import SearchBox from './SearchBox';
 import Dialog from '@cdo/apps/templates/Dialog';
+import AddVocabularyDialog from './AddVocabularyDialog';
 import {connect} from 'react-redux';
 import {
   addVocabulary,
@@ -125,8 +126,16 @@ class VocabulariesEditor extends Component {
 
   constructor(props) {
     super(props);
-    this.state = {confirmRemovalDialogOpen: false, vocabularyForRemoval: null};
+    this.state = {
+      confirmRemovalDialogOpen: false,
+      vocabularyForRemoval: null,
+      newVocabularyDialogOpen: false
+    };
   }
+
+  handleAddVocabularyClick = () => {
+    this.setState({newVocabularyDialogOpen: true});
+  };
 
   constructSearchOptions = json => {
     const vocabKeysAdded = this.props.vocabularies.map(vocab => vocab.key);
@@ -152,6 +161,12 @@ class VocabulariesEditor extends Component {
     const columns = this.getColumns();
     return (
       <div>
+        {this.state.newVocabularyDialogOpen && (
+          <AddVocabularyDialog
+            handleClose={() => this.setState({newVocabularyDialogOpen: false})}
+            courseVersionId={this.props.courseVersionId}
+          />
+        )}
         {this.state.confirmRemovalDialogOpen && (
           <Dialog
             body={`Are you sure you want to remove the vocabulary "${
@@ -181,6 +196,13 @@ class VocabulariesEditor extends Component {
           <Table.Header />
           <Table.Body rows={this.props.vocabularies} rowKey="key" />
         </Table.Provider>
+        <button
+          onClick={this.handleAddVocabularyClick}
+          style={styles.addButton}
+          type="button"
+        >
+          <i className="fa fa-plus" style={{marginRight: 7}} /> Vocabulary
+        </button>
       </div>
     );
   }

--- a/apps/src/lib/levelbuilder/lesson-editor/VocabulariesEditor.jsx
+++ b/apps/src/lib/levelbuilder/lesson-editor/VocabulariesEditor.jsx
@@ -42,9 +42,9 @@ const styles = {
     lineHeight: '30px'
   },
   addButton: {
-    background: color.cyan,
-    borderRadius: 3,
-    color: color.white,
+    background: '#eee',
+    border: '1px solid #ddd',
+    boxShadow: 'inset 0 1px 0 0 rgba(255, 255, 255, 0.8)',
     fontSize: 14,
     padding: 7,
     textAlign: 'center',
@@ -228,7 +228,9 @@ class VocabulariesEditor extends Component {
           />
         )}
         <div style={styles.search}>
-          Select a vocabulary word to add
+          <label>
+            <strong>Select a vocabulary word to add</strong>
+          </label>
           <SearchBox
             onSearchSelect={e => this.props.addVocabulary(e.vocabulary)}
             additionalQueryParams={{
@@ -247,7 +249,8 @@ class VocabulariesEditor extends Component {
           style={styles.addButton}
           type="button"
         >
-          <i className="fa fa-plus" style={{marginRight: 7}} /> Vocabulary
+          <i className="fa fa-plus" style={{marginRight: 7}} /> Create New
+          Vocabulary
         </button>
       </div>
     );

--- a/apps/src/lib/levelbuilder/lesson-editor/VocabulariesEditor.jsx
+++ b/apps/src/lib/levelbuilder/lesson-editor/VocabulariesEditor.jsx
@@ -8,7 +8,7 @@ import AddVocabularyDialog from './AddVocabularyDialog';
 import {connect} from 'react-redux';
 import {
   addVocabulary,
-  editVocabulary,
+  updateVocabulary,
   removeVocabulary
 } from '@cdo/apps/lib/levelbuilder/lesson-editor/vocabulariesEditorRedux';
 import * as Table from 'reactabular-table';
@@ -60,7 +60,7 @@ class VocabulariesEditor extends Component {
     // Provided by redux
     vocabularies: PropTypes.arrayOf(vocabularyShape).isRequired,
     addVocabulary: PropTypes.func.isRequired,
-    editVocabulary: PropTypes.func.isRequired,
+    updateVocabulary: PropTypes.func.isRequired,
     removeVocabulary: PropTypes.func.isRequired
   };
 
@@ -166,7 +166,7 @@ class VocabulariesEditor extends Component {
 
   afterVocabularySave = vocabulary => {
     if (this.state.vocabularyForEdit) {
-      this.props.editVocabulary(vocabulary);
+      this.props.updateVocabulary(vocabulary);
     } else {
       this.props.addVocabulary(vocabulary);
     }
@@ -262,7 +262,7 @@ export default connect(
   }),
   {
     addVocabulary,
-    editVocabulary,
+    updateVocabulary,
     removeVocabulary
   }
 )(VocabulariesEditor);

--- a/apps/src/lib/levelbuilder/lesson-editor/vocabulariesEditorRedux.js
+++ b/apps/src/lib/levelbuilder/lesson-editor/vocabulariesEditorRedux.js
@@ -17,7 +17,7 @@ export const addVocabulary = newVocabulary => ({
   newVocabulary
 });
 
-export const editVocabulary = updatedVocabulary => ({
+export const updateVocabulary = updatedVocabulary => ({
   type: EDIT_VOCABULARY,
   updatedVocabulary
 });

--- a/apps/src/lib/levelbuilder/shapes.jsx
+++ b/apps/src/lib/levelbuilder/shapes.jsx
@@ -85,6 +85,7 @@ export const resourceShape = PropTypes.shape({
 });
 
 export const vocabularyShape = PropTypes.shape({
+  id: PropTypes.number.isRequired,
   key: PropTypes.string.isRequired,
   word: PropTypes.string.isRequired,
   definition: PropTypes.string.isRequired

--- a/apps/test/unit/lib/levelbuilder/lesson-editor/AddVocabularyDialogTest.jsx
+++ b/apps/test/unit/lib/levelbuilder/lesson-editor/AddVocabularyDialogTest.jsx
@@ -1,0 +1,60 @@
+import React from 'react';
+import {shallow, mount} from 'enzyme';
+import {expect} from '../../../../util/reconfiguredChai';
+import AddVocabularyDialog from '@cdo/apps/lib/levelbuilder/lesson-editor/AddVocabularyDialog';
+import sinon from 'sinon';
+
+describe('AddVocabularyDialog', () => {
+  let defaultProps, afterSaveSpy, handleCloseSpy;
+  beforeEach(() => {
+    afterSaveSpy = sinon.spy();
+    handleCloseSpy = sinon.spy();
+    defaultProps = {
+      isOpen: true,
+      afterSave: afterSaveSpy,
+      handleClose: handleCloseSpy,
+      courseVersionId: 1
+    };
+  });
+
+  it('renders default props', () => {
+    const wrapper = shallow(<AddVocabularyDialog {...defaultProps} />);
+    expect(wrapper.contains('Add Vocabulary')).to.be.true;
+    expect(wrapper.find('input').length).to.equal(2);
+  });
+
+  it('saves if input is valid', () => {
+    const wrapper = mount(<AddVocabularyDialog {...defaultProps} />);
+    const instance = wrapper.instance();
+    instance.setState({
+      word: 'my vocabulary word',
+      definition: 'my vocabulary definition'
+    });
+    const saveVocabularySpy = sinon.stub(instance, 'saveVocabulary');
+    instance.forceUpdate();
+    wrapper.update();
+    wrapper.find('#submit-button').simulate('click');
+    expect(saveVocabularySpy.calledOnce).to.be.true;
+  });
+
+  it('renders an existing vocabulary for edit', () => {
+    const existingVocabulary = {
+      id: 200,
+      key: 'key',
+      word: 'existing vocab',
+      definition: 'existing definition'
+    };
+    const wrapper = mount(
+      <AddVocabularyDialog
+        {...defaultProps}
+        editingVocabulary={existingVocabulary}
+      />
+    );
+    expect(wrapper.find('[name="word"]').props().value).to.equal(
+      'existing vocab'
+    );
+    expect(wrapper.find('[name="definition"]').props().value).to.equal(
+      'existing definition'
+    );
+  });
+});

--- a/apps/test/unit/lib/levelbuilder/lesson-editor/VocabulariesEditorTest.js
+++ b/apps/test/unit/lib/levelbuilder/lesson-editor/VocabulariesEditorTest.js
@@ -12,8 +12,8 @@ describe('VocabulariesEditor', () => {
     removeVocabulary = sinon.spy();
     defaultProps = {
       vocabularies: [
-        {key: '1', word: 'word1', definition: 'def1'},
-        {key: '2', word: 'word2', definition: 'def2'}
+        {id: 1, key: '1', word: 'word1', definition: 'def1'},
+        {id: 2, key: '2', word: 'word2', definition: 'def2'}
       ],
       addVocabulary,
       editVocabulary,

--- a/apps/test/unit/lib/levelbuilder/lesson-editor/VocabulariesEditorTest.js
+++ b/apps/test/unit/lib/levelbuilder/lesson-editor/VocabulariesEditorTest.js
@@ -5,10 +5,10 @@ import {expect} from '../../../../util/reconfiguredChai';
 import {UnconnectedVocabulariesEditor as VocabulariesEditor} from '@cdo/apps/lib/levelbuilder/lesson-editor/VocabulariesEditor';
 
 describe('VocabulariesEditor', () => {
-  let defaultProps, addVocabulary, editVocabulary, removeVocabulary;
+  let defaultProps, addVocabulary, updateVocabulary, removeVocabulary;
   beforeEach(() => {
     addVocabulary = sinon.spy();
-    editVocabulary = sinon.spy();
+    updateVocabulary = sinon.spy();
     removeVocabulary = sinon.spy();
     defaultProps = {
       vocabularies: [
@@ -16,7 +16,7 @@ describe('VocabulariesEditor', () => {
         {id: 2, key: '2', word: 'word2', definition: 'def2'}
       ],
       addVocabulary,
-      editVocabulary,
+      updateVocabulary,
       removeVocabulary
     };
   });

--- a/apps/test/unit/lib/levelbuilder/lesson-editor/vocabulariesEditorReduxTest.js
+++ b/apps/test/unit/lib/levelbuilder/lesson-editor/vocabulariesEditorReduxTest.js
@@ -8,11 +8,13 @@ import _ from 'lodash';
 
 const getInitialState = () => [
   {
+    id: 1,
     key: 'vocabulary-1',
     word: 'vocabulary-1',
     definition: 'definition1'
   },
   {
+    id: 2,
     key: 'vocabulary-2',
     word: 'vocabulary-2',
     definition: 'definition2'
@@ -27,6 +29,7 @@ describe('vocabulariesEditorRedux reducer tests', () => {
     const nextState = vocabularyEditor(
       initialState,
       addVocabulary({
+        id: 3,
         key: 'new-word',
         word: 'new-word',
         definition: 'new-definition'

--- a/apps/test/unit/lib/levelbuilder/lesson-editor/vocabulariesEditorReduxTest.js
+++ b/apps/test/unit/lib/levelbuilder/lesson-editor/vocabulariesEditorReduxTest.js
@@ -1,7 +1,7 @@
 import {assert} from 'chai';
 import vocabularyEditor, {
   addVocabulary,
-  editVocabulary,
+  updateVocabulary,
   removeVocabulary
 } from '@cdo/apps/lib/levelbuilder/lesson-editor/vocabulariesEditorRedux';
 import _ from 'lodash';
@@ -47,7 +47,7 @@ describe('vocabulariesEditorRedux reducer tests', () => {
     editedVocabulary.word = 'new word';
     const nextState = vocabularyEditor(
       initialState,
-      editVocabulary(editedVocabulary)
+      updateVocabulary(editedVocabulary)
     );
     assert.deepEqual(nextState.map(r => r.word), ['new word', 'vocabulary-2']);
   });

--- a/dashboard/app/controllers/vocabularies_controller.rb
+++ b/dashboard/app/controllers/vocabularies_controller.rb
@@ -18,15 +18,15 @@ class VocabulariesController < ApplicationController
       definition: vocabulary_params[:definition]
     )
     vocabulary.course_version = course_version
-    if vocabulary.save
+    begin
+      vocabulary.save
       render json: vocabulary.summarize_for_lesson_edit
-    else
-      render status: 400, json: {error: vocabulary.errors.full_message.to_json}
+    rescue ActiveRecord::RecordNotUnique, ActiveRecord::RecordInvalid => e
+      render status: 400, json: {error: e.message.to_json}
     end
   end
 
   def update
-    puts vocabulary_params
     vocabulary = Vocabulary.find_by_id(vocabulary_params[:id])
     if vocabulary && vocabulary.update!(vocabulary_params)
       render json: vocabulary.summarize_for_lesson_edit

--- a/dashboard/app/controllers/vocabularies_controller.rb
+++ b/dashboard/app/controllers/vocabularies_controller.rb
@@ -1,6 +1,35 @@
 class VocabulariesController < ApplicationController
+  before_action :require_levelbuilder_mode_or_test_env, except: [:show]
+
   # GET /vocabularysearch
   def search
     render json: VocabularyAutocomplete.get_search_matches(params[:query], params[:limit], params[:courseVersionId])
+  end
+
+  # POST /vocabularies
+  def create
+    course_version = CourseVersion.find_by_id(vocabulary_params[:course_version_id])
+    unless course_version
+      render status: 400, json: {error: "course version not found"}
+      return
+    end
+    vocabulary = Vocabulary.new(
+      word: vocabulary_params[:word],
+      definition: vocabulary_params[:definition]
+    )
+    vocabulary.course_version = course_version
+    if vocabulary.save
+      render json: vocabulary.summarize_for_lesson_edit
+    else
+      render status: 400, json: {error: vocabulary.errors.full_message.to_json}
+    end
+  end
+
+  private
+
+  def vocabulary_params
+    vp = params.transform_keys(&:underscore)
+    vp = vp.permit(:word, :definition, :course_version_id)
+    vp
   end
 end

--- a/dashboard/app/controllers/vocabularies_controller.rb
+++ b/dashboard/app/controllers/vocabularies_controller.rb
@@ -26,6 +26,7 @@ class VocabulariesController < ApplicationController
     end
   end
 
+  # PUT/PATCH /vocabularies
   def update
     vocabulary = Vocabulary.find_by_id(vocabulary_params[:id])
     if vocabulary && vocabulary.update!(vocabulary_params)

--- a/dashboard/app/controllers/vocabularies_controller.rb
+++ b/dashboard/app/controllers/vocabularies_controller.rb
@@ -25,11 +25,21 @@ class VocabulariesController < ApplicationController
     end
   end
 
+  def update
+    puts vocabulary_params
+    vocabulary = Vocabulary.find_by_id(vocabulary_params[:id])
+    if vocabulary && vocabulary.update!(vocabulary_params)
+      render json: vocabulary.summarize_for_lesson_edit
+    else
+      render json: {status: 404, error: "Vocabulary #{vocabulary_params[:id]} not found"}
+    end
+  end
+
   private
 
   def vocabulary_params
     vp = params.transform_keys(&:underscore)
-    vp = vp.permit(:word, :definition, :course_version_id)
+    vp = vp.permit(:id, :key, :word, :definition, :course_version_id)
     vp
   end
 end

--- a/dashboard/app/controllers/vocabularies_controller.rb
+++ b/dashboard/app/controllers/vocabularies_controller.rb
@@ -19,7 +19,7 @@ class VocabulariesController < ApplicationController
     )
     vocabulary.course_version = course_version
     begin
-      vocabulary.save
+      vocabulary.save!
       render json: vocabulary.summarize_for_lesson_edit
     rescue ActiveRecord::RecordNotUnique, ActiveRecord::RecordInvalid => e
       render status: 400, json: {error: e.message.to_json}

--- a/dashboard/app/models/lesson.rb
+++ b/dashboard/app/models/lesson.rb
@@ -308,7 +308,7 @@ class Lesson < ApplicationRecord
       announcements: announcements,
       activities: lesson_activities.map(&:summarize_for_lesson_edit),
       resources: resources.map(&:summarize_for_lesson_edit),
-      vocabularies: vocabularies.map(&:summarize_for_edit),
+      vocabularies: vocabularies.map(&:summarize_for_lesson_edit),
       objectives: objectives.map(&:summarize_for_edit),
       courseVersionId: lesson_group.script.get_course_version&.id
     }

--- a/dashboard/app/models/vocabulary.rb
+++ b/dashboard/app/models/vocabulary.rb
@@ -44,7 +44,7 @@ class Vocabulary < ApplicationRecord
   end
 
   def summarize_for_lesson_edit
-    {key: key, word: word, definition: definition}
+    {id: id, key: key, word: word, definition: definition}
   end
 
   def generate_key

--- a/dashboard/app/models/vocabulary.rb
+++ b/dashboard/app/models/vocabulary.rb
@@ -49,7 +49,7 @@ class Vocabulary < ApplicationRecord
 
   def generate_key
     return if key
-    self.key = generate_key_from_word
+    self.key = word
   end
 
   private
@@ -60,19 +60,5 @@ class Vocabulary < ApplicationRecord
 
   def display_definition
     definition
-  end
-
-  def generate_key_from_word
-    key_prefix = word.strip.downcase.gsub(/[^a-z0-9\-\_\.]+/, '_')
-    potential_clashes = Vocabulary.where(course_version_id: course_version_id)
-    potential_clashes = potential_clashes.where("vocabularies.key like '#{key_prefix}%'").pluck(:key)
-    return key_prefix unless potential_clashes.include?(key_prefix)
-    key_suffix_num = 1
-    new_key = "#{key_prefix}_#{key_suffix_num}"
-    while potential_clashes.include?(new_key)
-      key_suffix_num += 1
-      new_key = "#{key_prefix}_#{key_suffix_num}"
-    end
-    new_key
   end
 end

--- a/dashboard/config/routes.rb
+++ b/dashboard/config/routes.rb
@@ -319,6 +319,7 @@ Dashboard::Application.routes.draw do
   resources :resources, only: [:create, :update]
   get '/resourcesearch', to: 'resources#search', defaults: {format: 'json'}
 
+  resources :vocabularies, only: [:create, :update]
   get '/vocabularysearch', to: 'vocabularies#search', defaults: {format: 'json'}
 
   get '/beta', to: redirect('/')

--- a/dashboard/test/controllers/vocabularies_controller_test.rb
+++ b/dashboard/test/controllers/vocabularies_controller_test.rb
@@ -1,0 +1,46 @@
+require 'test_helper'
+
+class VocabulariesControllerTest < ActionController::TestCase
+  include Devise::Test::ControllerHelpers
+
+  setup do
+    Rails.application.config.stubs(:levelbuilder_mode).returns true
+    @levelbuilder = create :levelbuilder
+  end
+
+  test "can create vocabulary from params" do
+    sign_in @levelbuilder
+    course_version = create :course_version
+    assert_creates(Vocabulary) do
+      post :create, params: {word: 'Algorithm', definition: 'definition of algorithm', courseVersionId: course_version.id}
+      assert_response :success
+    end
+    assert(@response.body.include?('Algorithm'))
+    assert(@response.body.include?('definition of algorithm'))
+  end
+
+  test "can update from params" do
+    sign_in @levelbuilder
+    course_version = create :course_version
+    vocabulary = create :vocabulary, word: 'word', definition: 'draft definition', course_version: course_version
+    post :update, params: {id: vocabulary.id, word: 'word', definition: 'updated definition', courseVersionId: course_version.id}
+    assert_response :success
+
+    vocabulary.reload
+    assert_equal 'updated definition', vocabulary.definition
+    assert(@response.body.include?('updated definition'))
+  end
+
+  test "creating vocabulary that already exists results in error" do
+    sign_in @levelbuilder
+    course_version = create :course_version
+    vocabulary = create :vocabulary, key: 'variable', word: 'variable', definition: 'definition', course_version: course_version
+
+    post :create, params: {word: 'variable', definition: 'different definition', courseVersionId: course_version.id}
+    assert_response :bad_request
+
+    # Check that the original vocabulary wasn't changed
+    vocabulary.reload
+    assert_equal 'definition', vocabulary.definition
+  end
+end


### PR DESCRIPTION
Finishes [PLAT-637](https://codedotorg.atlassian.net/browse/PLAT-637). Adds the ability to create or edit vocabulary from the lesson edit page.

As discussed in #38392, currently the key is set to the word itself. This effectively means that there can only be one definition per word per course version. We will need to change this logic in the model when we want to remove that restriction.

Adding a new vocabulary:
https://user-images.githubusercontent.com/46464143/105528655-1a3f3100-5c9a-11eb-9a4b-f8b28acae736.mov

Editing existing vocabulary:
https://user-images.githubusercontent.com/46464143/105528674-1f03e500-5c9a-11eb-8575-ef147faa014b.mov



<!-- ### Background -->
<!-- ### Privacy -->
<!--
1.	Does the Project involve the collection, use or sharing of new Personal Data?

2.	Does the Project involve a new or changed use or sharing of existing Personal Data?
-->
<!-- ### Security -->
<!--
Link to Jira Task where sensitive security issues are discussed privately.
-->
<!-- ### Caching -->
<!-- ### Deployment strategy -->
<!-- ### Future work -->

## Links

<!--
  Any relevant links to external resources; ie, specification documents, jira
  items, related PRs, honeybadger errors, etc
-->

- [spec]()
- [jira]()

## Testing story

<!--
  Does your change include appropriate tests?

  If so, please describe how the tests included in this PR are sufficient

  If not, please explain why this change does not need to be tested.
-->

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
