### PR TITLE
[Spritelab] Enable Start in Animation Tab level configuration

### DIFF
--- a/apps/src/p5lab/P5Lab.js
+++ b/apps/src/p5lab/P5Lab.js
@@ -359,6 +359,10 @@ P5Lab.prototype.init = function(config) {
 
     this.studioApp_.init(config);
 
+    if (startInAnimationTab(getStore().getState())) {
+      getStore().dispatch(changeInterfaceMode(P5LabInterfaceMode.ANIMATION));
+    }
+
     var finishButton = document.getElementById('finishButton');
     if (finishButton) {
       dom.addClickTouchEvent(finishButton, () => this.onPuzzleComplete(false));
@@ -445,10 +449,6 @@ P5Lab.prototype.init = function(config) {
     librariesEnabled: !!config.level.librariesEnabled,
     validationEnabled: !!config.level.validationEnabled
   });
-
-  if (startInAnimationTab(getStore().getState())) {
-    getStore().dispatch(changeInterfaceMode(P5LabInterfaceMode.ANIMATION));
-  }
 
   // Push project-sourced animation metadata into store. Always use the
   // animations specified by the level definition for embed and contained

--- a/apps/src/p5lab/P5LabVisualizationHeader.jsx
+++ b/apps/src/p5lab/P5LabVisualizationHeader.jsx
@@ -31,13 +31,15 @@ class P5LabVisualizationHeader extends React.Component {
   };
 
   changeInterfaceMode = mode => {
-    if (!this.props.spriteLab) {
-      // Add a resize event to Gamelab (i.e. droplet) to ensure code is rendered
-      // correctly if it was in the middle of a transition from code to block mode
-      // when the interface mode was changed. Blockly already fires resize events
-      // so this is not needed for spriteLab - too many resize events seem to
-      // conflict with each other.
-      setTimeout(() => utils.fireResizeEvent(), 0);
+    // Make sure code workspace is rendered properly after switching from the Animation Tab.
+    if (mode === 'CODE') {
+      if (this.props.spriteLab) {
+        // Sprite Lab (Blockly) doesn't need a window resize event, but it does need to rerender.
+        setTimeout(() => Blockly.mainBlockSpace.render(), 0);
+      } else {
+        // Fire a window resize event to tell Game Lab (Droplet) to rerender.
+        setTimeout(() => utils.fireResizeEvent(), 0);
+      }
     }
 
     this.props.onInterfaceModeChange(mode);


### PR DESCRIPTION
First change: Don't dispatch the `changeInterfaceMode` event until after we've called `StudioApp.init`, which ensures that Blockly has been initialized properly. This fixes the following JS errors:
![image](https://user-images.githubusercontent.com/8787187/105563711-fdbfea80-5cd3-11eb-975a-9ad686d2f4ba.png)

Second change: Rerender Blockly.mainBlockSpace when switching from the costume tab to the code tab. This render only seems necessary the first time you switch from costume to code, but we don't know whether it's necessary from within the change handler, so I have it just always re-rendering. I don't think that'll hurt performance because it's just one render, and Blockly rerenders things basically any time you drag a block anyways.

Before:
initial page load:
![image](https://user-images.githubusercontent.com/8787187/105563733-1203e780-5cd4-11eb-8937-293331c719bf.png)
switch to code:
![image](https://user-images.githubusercontent.com/8787187/105563745-1defa980-5cd4-11eb-99c8-0bd46d85e4ff.png)
Then if you resize the window or the instructions/playspace panes:
![image](https://user-images.githubusercontent.com/8787187/105563781-3233a680-5cd4-11eb-98b1-fe786ea6ca47.png)


After:
initial page load:
![image](https://user-images.githubusercontent.com/8787187/105563607-97d36300-5cd3-11eb-8590-3e0f56bfcd2b.png)
switch to code:
![image](https://user-images.githubusercontent.com/8787187/105563617-a0c43480-5cd3-11eb-88d0-5ce15b0c08f4.png)

initial page load:
![image](https://user-images.githubusercontent.com/8787187/105563636-b6d1f500-5cd3-11eb-9049-77ee2f810d3f.png)
switch to code:
![image](https://user-images.githubusercontent.com/8787187/105563646-bfc2c680-5cd3-11eb-8622-5c9edb6b00ee.png)



<!-- ### Background -->
<!-- ### Privacy -->
<!--
1.	Does the Project involve the collection, use or sharing of new Personal Data?

2.	Does the Project involve a new or changed use or sharing of existing Personal Data?
-->
<!-- ### Security -->
<!--
Link to Jira Task where sensitive security issues are discussed privately.
-->
<!-- ### Caching -->
<!-- ### Deployment strategy -->
<!-- ### Future work -->

## Links

<!--
  Any relevant links to external resources; ie, specification documents, jira
  items, related PRs, honeybadger errors, etc
-->

- [jira](https://codedotorg.atlassian.net/browse/STAR-1402)

## Testing story

<!--
  Does your change include appropriate tests?

  If so, please describe how the tests included in this PR are sufficient

  If not, please explain why this change does not need to be tested.
-->

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
