### PR TITLE
refactor sectionProgressRedux

### DIFF
--- a/apps/src/code-studio/activityUtils.js
+++ b/apps/src/code-studio/activityUtils.js
@@ -11,7 +11,7 @@ import {LevelStatus} from '@cdo/apps/util/sharedConstants';
  * @return {string}
  */
 export const activityCssClass = result => {
-  if (!result) {
+  if (!result || result === TestResults.NO_TESTS_RUN) {
     return LevelStatus.not_tried;
   }
   if (result === TestResults.REVIEW_ACCEPTED_RESULT) {

--- a/apps/src/code-studio/activityUtils.js
+++ b/apps/src/code-studio/activityUtils.js
@@ -42,6 +42,40 @@ export const activityCssClass = result => {
 };
 
 /**
+ * Inverse of the above function.
+ * Given a status string, returns a result value.
+ * @param {string} status
+ * @return {number}
+ */
+export const resultFromStatus = status => {
+  if (status === LevelStatus.review_accepted) {
+    return TestResults.REVIEW_ACCEPTED_RESULT;
+  }
+  if (status === LevelStatus.review_rejected) {
+    return TestResults.REVIEW_REJECTED_RESULT;
+  }
+  if (status === LevelStatus.submitted) {
+    return TestResults.SUBMITTED_RESULT;
+  }
+  if (status === LevelStatus.locked) {
+    return TestResults.LOCKED_RESULT;
+  }
+  if (status === LevelStatus.readonly) {
+    return TestResults.READONLY_SUBMISSION_RESULT;
+  }
+  if (status === LevelStatus.free_play_complete) {
+    return TestResults.FREE_PLAY;
+  }
+  if (status === LevelStatus.perfect) {
+    return TestResults.ALL_PASS;
+  }
+  if (status === LevelStatus.passed) {
+    return TestResults.MINIMUM_PASS_RESULT;
+  }
+  return TestResults.NO_TESTS_RUN;
+};
+
+/**
  * Returns the "best" of the two results, as defined in apps/src/constants.js.
  * Note that there are negative results that count as an attempt, so we can't
  * just take the maximum.

--- a/apps/src/code-studio/progress.js
+++ b/apps/src/code-studio/progress.js
@@ -122,7 +122,7 @@ progress.generateStageProgress = function(
 
   store.dispatch(
     mergeProgress(
-      _.mapValues(progressData.levels, level =>
+      _.mapValues(progressData.progress, level =>
         level.submitted ? TestResults.SUBMITTED_RESULT : level.result
       )
     )

--- a/apps/src/code-studio/progressRedux.js
+++ b/apps/src/code-studio/progressRedux.js
@@ -358,8 +358,8 @@ const userProgressFromServer = (state, dispatch, userId = null) => {
     }
 
     // Merge progress from server
-    if (data.levels) {
-      const levelProgress = _.mapValues(data.levels, getLevelResult);
+    if (data.progress) {
+      const levelProgress = _.mapValues(data.progress, getLevelResult);
       dispatch(mergeProgress(levelProgress));
 
       if (data.peerReviewsPerformed) {

--- a/apps/src/code-studio/progressRedux.js
+++ b/apps/src/code-studio/progressRedux.js
@@ -7,7 +7,10 @@ import {mergeActivityResult, activityCssClass} from './activityUtils';
 import {LevelStatus, LevelKind} from '@cdo/apps/util/sharedConstants';
 import {TestResults} from '@cdo/apps/constants';
 import {ViewType, SET_VIEW_TYPE} from './viewAsRedux';
-import {processedLevel} from '@cdo/apps/templates/progress/progressHelpers';
+import {
+  processedLevel,
+  getLevelResult
+} from '@cdo/apps/templates/progress/progressHelpers';
 import {PUZZLE_PAGE_NONE} from '@cdo/apps/templates/progress/progressTypes';
 import {setVerified} from '@cdo/apps/code-studio/verifiedTeacherRedux';
 import {authorizeLockable} from './stageLockRedux';
@@ -277,25 +280,6 @@ function bestResultLevelId(levelIds, progressData) {
   });
   return bestId;
 }
-
-/**
- * Given a level that we get from the server using either /api/user_progress or
- * /dashboardapi/section_level_progress, extracts the result, appropriately
- * discerning a locked/submitted result for certain levels.
- */
-export const getLevelResult = level => {
-  if (level.status === LevelStatus.locked) {
-    return TestResults.LOCKED_RESULT;
-  }
-  if (level.readonly_answers) {
-    return TestResults.READONLY_SUBMISSION_RESULT;
-  }
-  if (level.submitted) {
-    return TestResults.SUBMITTED_RESULT;
-  }
-
-  return level.result;
-};
 
 /**
  * Does some processing of our passed in lesson, namely

--- a/apps/src/redux/sectionDataRedux.js
+++ b/apps/src/redux/sectionDataRedux.js
@@ -35,7 +35,7 @@ export const SET_SECTION = 'sectionData/SET_SECTION';
 export const setSection = section => {
   // Sort section.students by name.
   const sortedStudents = section.students.sort((a, b) =>
-    a.name.localeCompare(b.name)
+    a.name.localeCompare(b.name, undefined, {numeric: true})
   );
 
   // Filter data to match sectionDataPropType

--- a/apps/src/templates/progress/progressHelpers.js
+++ b/apps/src/templates/progress/progressHelpers.js
@@ -285,6 +285,8 @@ export const levelProgressFromServer = serverProgress => {
     result: getLevelResult(serverProgress),
     paired: serverProgress.paired || false,
     timeSpent: serverProgress.time_spent || 0,
+    // `pages` is used by multi-page assessments, and its presence
+    // (or absence) is how we distinguish those from single-page assessments
     pages:
       serverProgress.pages_completed &&
       serverProgress.pages_completed.length > 1

--- a/apps/src/templates/progress/progressHelpers.js
+++ b/apps/src/templates/progress/progressHelpers.js
@@ -177,48 +177,54 @@ export function progressForLesson(studentLevelProgress, levels) {
 
 /**
  * Summarizes stage progress data.
- * @param {[]} levelsWithStatus An array of objects each representing
- * students progress in a level
+ * @param {{id:studentLevelProgressType}} studentProgress An object keyed by
+ * level id containing objects representing the student's progress in that level
+ * @param {levelType[]} levels An array of the levels in a stage
  * @returns {object} An object with a total count of levels in each of the
  * following buckets: total, completed, imperfect, incomplete, attempted.
  */
-export function summarizeProgressInStage(levelsWithStatus) {
+export function summarizeProgressInStage(studentProgress, levels) {
   // Filter any bonus levels as they do not count toward progress.
-  levelsWithStatus = levelsWithStatus.filter(level => !level.bonus);
+  const filteredLevels = levels.filter(level => !level.bonus);
 
   // Get counts of statuses
   let statusCounts = {
-    total: levelsWithStatus.length,
+    total: 0,
     completed: 0,
     imperfect: 0,
     incomplete: 0,
     attempted: 0
   };
-  for (let i = 0; i < levelsWithStatus.length; i++) {
-    const status = levelsWithStatus[i].status;
-    switch (status) {
+
+  filteredLevels.forEach(level => {
+    const levelProgress = studentProgress[level.id];
+    if (!levelProgress) {
+      return;
+    }
+    statusCounts.total++;
+    switch (levelProgress.status) {
       case LevelStatus.perfect:
       case LevelStatus.submitted:
       case LevelStatus.free_play_complete:
       case LevelStatus.completed_assessment:
       case LevelStatus.readonly:
-        statusCounts.completed = statusCounts.completed + 1;
+        statusCounts.completed++;
         break;
       case LevelStatus.not_tried:
-        statusCounts.incomplete = statusCounts.incomplete + 1;
+        statusCounts.incomplete++;
         break;
       case LevelStatus.attempted:
-        statusCounts.incomplete = statusCounts.incomplete + 1;
-        statusCounts.attempted = statusCounts.attempted + 1;
+        statusCounts.incomplete++;
+        statusCounts.attempted++;
         break;
       case LevelStatus.passed:
-        statusCounts.imperfect = statusCounts.imperfect + 1;
+        statusCounts.imperfect++;
         break;
       // All others are assumed to be not tried
       default:
-        statusCounts.incomplete = statusCounts.incomplete + 1;
+        statusCounts.incomplete++;
     }
-  }
+  });
   return statusCounts;
 }
 

--- a/apps/src/templates/progress/progressHelpers.js
+++ b/apps/src/templates/progress/progressHelpers.js
@@ -258,7 +258,7 @@ export const processedLevel = level => {
   };
 };
 
-const getLevelResult = serverProgress => {
+export const getLevelResult = serverProgress => {
   if (serverProgress.status === LevelStatus.locked) {
     return TestResults.LOCKED_RESULT;
   }

--- a/apps/src/templates/progress/progressHelpers.js
+++ b/apps/src/templates/progress/progressHelpers.js
@@ -4,7 +4,10 @@ import {isStageHiddenForSection} from '@cdo/apps/code-studio/hiddenStageRedux';
 import {LevelStatus, LevelKind} from '@cdo/apps/util/sharedConstants';
 import {PUZZLE_PAGE_NONE} from './progressTypes';
 import {TestResults} from '@cdo/apps/constants';
-import {activityCssClass} from '@cdo/apps/code-studio/activityUtils';
+import {
+  activityCssClass,
+  resultFromStatus
+} from '@cdo/apps/code-studio/activityUtils';
 import _ from 'lodash';
 
 /**
@@ -260,7 +263,7 @@ const getLevelResult = serverProgress => {
     return TestResults.SUBMITTED_RESULT;
   }
 
-  return serverProgress.result || TestResults.NO_TESTS_RUN;
+  return serverProgress.result || resultFromStatus(serverProgress.status);
 };
 
 /**

--- a/apps/src/templates/progress/progressTypes.js
+++ b/apps/src/templates/progress/progressTypes.js
@@ -54,6 +54,37 @@ export const levelType = PropTypes.shape({
   ...levelWithoutStatusShape,
   status: PropTypes.string.isRequired
 });
+/**
+ * @typedef {Object} StudentLevelProgress
+ *
+ * @property {string} status
+ * A string enum representing student progress status on a level.
+ * See src/util/sharedConstants.LevelStatus.
+ * @property {number} result
+ * A numerical enum of the TestResult a student received for a level.
+ * See src/constants.TestResult.
+ * See src/code-studio/activityUtils.activityCssClass for a mapping to status.
+ * @property {bool} paired
+ * A boolean indicating if a student was paired on a level.
+ * @property {number} timeSpent
+ * An optional value indicating the time a student spent on a level.
+ * @property {array} pages
+ * Array of StudentLevelProgress objects representing progress on individual
+ * pages of a multi-page assessment
+ */
+const studentLevelProgressShape = {
+  status: PropTypes.string.isRequired,
+  result: PropTypes.number.isRequired,
+  paired: PropTypes.bool.isRequired,
+  timeSpent: PropTypes.number
+};
+// Avoid recursive definition
+studentLevelProgressShape.pages = PropTypes.arrayOf(
+  PropTypes.shape(studentLevelProgressShape)
+);
+export const studentLevelProgressType = PropTypes.shape(
+  studentLevelProgressShape
+);
 
 /**
  * @typedef {Object} Lesson

--- a/apps/src/templates/progress/progressTypes.js
+++ b/apps/src/templates/progress/progressTypes.js
@@ -55,6 +55,7 @@ export const levelType = PropTypes.shape({
   ...levelWithoutStatusShape,
   status: PropTypes.string.isRequired
 });
+
 /**
  * @typedef {Object} StudentLevelProgress
  *
@@ -108,53 +109,6 @@ export const lessonType = PropTypes.shape({
 });
 
 /**
- * @typedef {Object} LessonGroup
- *
- * @property {string} displayName
- * @property {number} id
- * @property {array} bigQuestion
- * @property {string} description
- */
-export const lessonGroupType = PropTypes.shape({
-  id: PropTypes.number,
-  displayName: PropTypes.string,
-  bigQuestions: PropTypes.string,
-  description: PropTypes.string
-});
-
-/**
- * @typedef {Object} StudentLevelProgress
- *
- * @property {string} status
- * A string enum representing student progress status on a level.
- * See src/util/sharedConstants.LevelStatus.
- * @property {number} result
- * A numerical enum of the TestResult a student received for a level.
- * See src/constants.TestResult.
- * See src/code-studio/activityUtils.activityCssClass for a mapping to status.
- * @property {bool} paired
- * A boolean indicating if a student was paired on a level.
- * @property {number} timeSpent
- * An optional value indicating the time a student spent on a level.
- * @property {array} pages
- * Array of StudentLevelProgress objects representing progress on individual
- * pages of a multi-page assessment
- */
-const studentLevelProgressShape = {
-  status: PropTypes.string.isRequired,
-  result: PropTypes.number.isRequired,
-  paired: PropTypes.bool.isRequired,
-  timeSpent: PropTypes.number
-};
-// Avoid recursive definition
-studentLevelProgressShape.pages = PropTypes.arrayOf(
-  PropTypes.shape(studentLevelProgressShape)
-);
-export const studentLevelProgressType = PropTypes.shape(
-  studentLevelProgressShape
-);
-
-/**
  * @typedef {Object} StudentLessonProgress
  *
  * @property {bool} isStarted
@@ -167,4 +121,19 @@ export const studentLessonProgressType = PropTypes.shape({
   incompletePercent: PropTypes.number.isRequired,
   imperfectPercent: PropTypes.number.isRequired,
   completedPercent: PropTypes.number.isRequired
+});
+
+/**
+ * @typedef {Object} LessonGroup
+ *
+ * @property {string} displayName
+ * @property {number} id
+ * @property {array} bigQuestion
+ * @property {string} description
+ */
+export const lessonGroupType = PropTypes.shape({
+  id: PropTypes.number,
+  displayName: PropTypes.string,
+  bigQuestions: PropTypes.string,
+  description: PropTypes.string
 });

--- a/apps/src/templates/progress/progressTypes.js
+++ b/apps/src/templates/progress/progressTypes.js
@@ -21,6 +21,7 @@ export const PUZZLE_PAGE_NONE = -1;
  * @property {string} kind
  * @property {number} pageNumber The page number of the level if
  *   this is a multi-page level, or PUZZLE_PAGE_NONE
+ * @property {array} sublevels An optional array of recursive sublevel objects
  */
 const levelWithoutStatusShape = {
   id: PropTypes.string.isRequired,
@@ -34,8 +35,8 @@ const levelWithoutStatusShape = {
   isConceptLevel: PropTypes.bool,
   kind: PropTypes.string,
   pageNumber: PropTypes.number
+  /** sublevels: PropTypes.array */ // See below
 };
-
 // Avoid recursive definition
 levelWithoutStatusShape.sublevels = PropTypes.arrayOf(
   PropTypes.shape(levelWithoutStatusShape)
@@ -69,14 +70,15 @@ export const levelType = PropTypes.shape({
  * @property {number} timeSpent
  * An optional value indicating the time a student spent on a level.
  * @property {array} pages
- * Array of StudentLevelProgress objects representing progress on individual
- * pages of a multi-page assessment
+ * An optional array of recursive progress objects representing progress on
+ * individual pages of a multi-page assessment
  */
 const studentLevelProgressShape = {
   status: PropTypes.string.isRequired,
   result: PropTypes.number.isRequired,
   paired: PropTypes.bool.isRequired,
   timeSpent: PropTypes.number
+  /** pages: PropTypes.array */ // See below
 };
 // Avoid recursive definition
 studentLevelProgressShape.pages = PropTypes.arrayOf(

--- a/apps/src/templates/sectionProgress/SectionProgress.jsx
+++ b/apps/src/templates/sectionProgress/SectionProgress.jsx
@@ -12,7 +12,6 @@ import {connect} from 'react-redux';
 import i18n from '@cdo/locale';
 import {h3Style} from '../../lib/ui/Headings';
 import {
-  getCurrentProgress,
   getCurrentScriptData,
   setLessonOfInterest,
   setCurrentView
@@ -282,11 +281,10 @@ export default connect(
     validScripts: state.scriptSelection.validScripts,
     currentView: state.sectionProgress.currentView,
     scriptData: getCurrentScriptData(state),
-    studentLevelProgress: getCurrentProgress(state),
     isLoadingProgress: state.sectionProgress.isLoadingProgress,
     showStandardsIntroDialog: !state.currentUser.hasSeenStandardsReportInfo,
     studentTimestamps:
-      state.sectionProgress.studentTimestampsByScript[
+      state.sectionProgress.studentLastUpdateByScript[
         state.scriptSelection.scriptId
       ],
     localeCode: state.locales.localeCode

--- a/apps/src/templates/sectionProgress/detail/VirtualizedDetailView.jsx
+++ b/apps/src/templates/sectionProgress/detail/VirtualizedDetailView.jsx
@@ -1,5 +1,6 @@
 import PropTypes from 'prop-types';
 import React, {Component} from 'react';
+import _ from 'lodash';
 import {connect} from 'react-redux';
 import {MultiGrid} from 'react-virtualized';
 import StudentProgressDetailCell from '@cdo/apps/templates/sectionProgress/detail/StudentProgressDetailCell';
@@ -11,6 +12,7 @@ import {
 } from '@cdo/apps/templates/sectionProgress/sectionProgressRedux';
 import {scriptDataPropType} from '../sectionProgressConstants';
 import {sectionDataPropType} from '@cdo/apps/redux/sectionDataRedux';
+import {studentLevelProgressType} from '@cdo/apps/templates/progress/progressTypes';
 import {getIconForLevel} from '@cdo/apps/templates/progress/progressHelpers';
 import color from '../../../util/color';
 import {
@@ -71,25 +73,33 @@ class VirtualizedDetailView extends Component {
   static propTypes = {
     section: sectionDataPropType.isRequired,
     scriptData: scriptDataPropType.isRequired,
+    levelProgressByStudent: PropTypes.objectOf(
+      PropTypes.objectOf(studentLevelProgressType)
+    ).isRequired,
     lessonOfInterest: PropTypes.number.isRequired,
     setLessonOfInterest: PropTypes.func.isRequired,
     columnWidths: PropTypes.arrayOf(PropTypes.number).isRequired,
-    levelsByLesson: PropTypes.object,
     onScroll: PropTypes.func,
-    stageExtrasEnabled: PropTypes.bool
+    scriptName: PropTypes.string,
+    scriptId: PropTypes.number
   };
 
   constructor(props) {
     super(props);
-    this.state = {
-      fixedColumnCount: 1,
-      fixedRowCount: 2,
-      scrollToColumn: 0,
-      scrollToRow: 0
-    };
-    this.detailView = null;
     this.setDetailViewRef = this.setDetailViewRef.bind(this);
+    this.onClickLevel = this.onClickLevel.bind(this);
+    this.cellRenderer = this.cellRenderer.bind(this);
+    this.studentCellRenderer = this.studentCellRenderer.bind(this);
+    this.getColumnWidth = this.getColumnWidth.bind(this);
   }
+
+  state = {
+    fixedColumnCount: 1,
+    fixedRowCount: 2,
+    scrollToColumn: 0,
+    scrollToRow: 0
+  };
+  detailView = null;
 
   componentWillReceiveProps(nextProps) {
     // When we replace the script, re-compute the column widths
@@ -100,7 +110,12 @@ class VirtualizedDetailView extends Component {
   }
 
   componentDidUpdate(prevProps) {
-    if (this.props.levelsByLesson !== prevProps.levelsByLesson) {
+    if (
+      !_.isEqual(
+        this.props.levelProgressByStudent,
+        prevProps.levelProgressByStudent
+      )
+    ) {
       this.detailView.forceUpdateGrids();
     }
   }
@@ -109,11 +124,11 @@ class VirtualizedDetailView extends Component {
     this.detailView = ref;
   }
 
-  onClickLevel = lessonOfInterest => {
+  onClickLevel(lessonOfInterest) {
     this.props.setLessonOfInterest(lessonOfInterest);
-  };
+  }
 
-  cellRenderer = ({columnIndex, key, rowIndex, style}) => {
+  cellRenderer({columnIndex, key, rowIndex, style}) {
     const {scriptData, columnWidths} = this.props;
     // Subtract 2 to account for the 2 header rows.
     // We don't want leave off the first 2 students.
@@ -220,10 +235,35 @@ class VirtualizedDetailView extends Component {
         )}
       </div>
     );
-  };
+  }
 
-  studentCellRenderer = (studentStartIndex, stageIdIndex, key, style) => {
-    const {section, levelsByLesson, stageExtrasEnabled} = this.props;
+  studentCellRenderer(studentStartIndex, stageIdIndex, key, style) {
+    const {section, levelProgressByStudent, scriptData} = this.props;
+    const student = section.students[studentStartIndex];
+    let child;
+    if (stageIdIndex < 0) {
+      child = (
+        <SectionProgressNameCell
+          name={student.name}
+          studentId={student.id}
+          sectionId={section.id}
+          scriptName={scriptData.name}
+          scriptId={scriptData.id}
+        />
+      );
+    } else {
+      const stageLevels = scriptData.stages[stageIdIndex].levels;
+      child = (
+        <StudentProgressDetailCell
+          studentId={student.id}
+          sectionId={section.id}
+          stageId={stageIdIndex}
+          stageExtrasEnabled={section.stageExtras}
+          levels={stageLevels}
+          studentProgress={levelProgressByStudent[student.id] || {}}
+        />
+      );
+    }
 
     // Alternate background colour of each row
     if (studentStartIndex % 2 === 1) {
@@ -233,33 +273,16 @@ class VirtualizedDetailView extends Component {
       };
     }
 
-    const student = section.students[studentStartIndex];
-
     return (
       <div className={progressStyles.Cell} key={key} style={style}>
-        {stageIdIndex < 0 && (
-          <SectionProgressNameCell
-            name={student.name}
-            studentId={student.id}
-            sectionId={section.id}
-          />
-        )}
-        {stageIdIndex >= 0 && (
-          <StudentProgressDetailCell
-            studentId={student.id}
-            sectionId={section.id}
-            stageId={stageIdIndex}
-            stageExtrasEnabled={stageExtrasEnabled}
-            levelsWithStatus={levelsByLesson[student.id][stageIdIndex]}
-          />
-        )}
+        {child}
       </div>
     );
-  };
+  }
 
-  getColumnWidth = ({index}) => {
+  getColumnWidth({index}) {
     return this.props.columnWidths[index] || 0;
-  };
+  }
 
   render() {
     const {section, scriptData, lessonOfInterest, onScroll} = this.props;
@@ -303,8 +326,8 @@ export default connect(
   state => ({
     columnWidths: getColumnWidthsForDetailView(state),
     lessonOfInterest: state.sectionProgress.lessonOfInterest,
-    levelsByLesson:
-      state.sectionProgress.levelsByLessonByScript[
+    levelProgressByStudent:
+      state.sectionProgress.studentLevelProgressByScript[
         state.scriptSelection.scriptId
       ]
   }),

--- a/apps/src/templates/sectionProgress/sectionProgressConstants.js
+++ b/apps/src/templates/sectionProgress/sectionProgressConstants.js
@@ -18,7 +18,8 @@ export const scriptDataPropType = PropTypes.shape({
     })
   ),
   family_name: PropTypes.string,
-  version_year: PropTypes.string
+  version_year: PropTypes.string,
+  name: PropTypes.string
 });
 
 // Types of views of the progress tab

--- a/apps/src/templates/sectionProgress/sectionProgressLoader.js
+++ b/apps/src/templates/sectionProgress/sectionProgressLoader.js
@@ -7,15 +7,14 @@ import {
   startRefreshingProgress,
   finishRefreshingProgress
 } from './sectionProgressRedux';
-import {processedLevel} from '@cdo/apps/templates/progress/progressHelpers';
+import {
+  processedLevel,
+  processServerSectionProgress
+} from '@cdo/apps/templates/progress/progressHelpers';
 import {
   fetchStandardsCoveredForScript,
   fetchStudentLevelScores
 } from '@cdo/apps/templates/sectionProgress/standards/sectionStandardsProgressRedux';
-import {
-  levelsByLesson,
-  getLevelResult
-} from '@cdo/apps/code-studio/progressRedux';
 import {getStore} from '@cdo/apps/redux';
 import _ from 'lodash';
 
@@ -42,11 +41,9 @@ export function loadScript(scriptId, sectionId) {
   }
 
   let sectionProgress = {
+    scriptDataByScript: {},
     studentLevelProgressByScript: {},
-    studentTimestampsByScript: {},
-    studentLevelTimeSpentByScript: {},
-    studentLevelPairingByScript: {},
-    scriptDataByScript: {}
+    studentLastUpdateByScript: {}
   };
 
   // Get the script data
@@ -55,23 +52,10 @@ export function loadScript(scriptId, sectionId) {
   })
     .then(response => response.json())
     .then(scriptData => {
-      // Filter to match scriptDataPropType
-      const filteredScriptData = {
-        id: scriptData.id,
-        csf: scriptData.csf,
-        hasStandards: scriptData.hasStandards,
-        title: scriptData.title,
-        path: scriptData.path,
-        stages: scriptData.lessons,
-        family_name: scriptData.family_name,
-        version_year: scriptData.version_year
+      sectionProgress.scriptDataByScript = {
+        [scriptId]: postProcessDataByScript(scriptData)
       };
-      sectionProgress.scriptDataByScript = {[scriptId]: filteredScriptData};
 
-      if (scriptData.hasStandards) {
-        getStore().dispatch(fetchStandardsCoveredForScript(scriptId));
-        getStore().dispatch(fetchStudentLevelScores(scriptId, sectionId));
-      }
       if (
         state.currentView === ViewType.STANDARDS &&
         !scriptData.hasStandards
@@ -94,28 +78,13 @@ export function loadScript(scriptId, sectionId) {
         sectionProgress.studentLevelProgressByScript = {
           [scriptId]: {
             ...sectionProgress.studentLevelProgressByScript[scriptId],
-            ...getInfoByStudentByLevel(data.students, getLevelResult)
+            ...processServerSectionProgress(data.student_progress)
           }
         };
-
-        sectionProgress.studentTimestampsByScript = {
+        sectionProgress.studentLastUpdateByScript = {
           [scriptId]: {
-            ...sectionProgress.studentTimestampsByScript[scriptId],
-            ...processStudentTimestamps(data.student_timestamps)
-          }
-        };
-
-        sectionProgress.studentLevelTimeSpentByScript = {
-          [scriptId]: {
-            ...sectionProgress.studentLevelTimeSpentByScript[scriptId],
-            ...getInfoByStudentByLevel(data.students, level => level.time_spent)
-          }
-        };
-
-        sectionProgress.studentLevelPairingByScript = {
-          [scriptId]: {
-            ...sectionProgress.studentLevelPairingByScript[scriptId],
-            ...processStudentPairing(data.students)
+            ...sectionProgress.studentLastUpdateByScript[scriptId],
+            ...processStudentTimestamps(data.student_last_updates)
           }
         };
       });
@@ -124,16 +93,14 @@ export function loadScript(scriptId, sectionId) {
   // Combine and transform the data
   requests.push(scriptRequest);
   Promise.all(requests).then(() => {
-    sectionProgress.levelsByLessonByScript = postProcessLevelsByLesson(
-      scriptId,
-      sectionProgress
-    );
-    sectionProgress.scriptDataByScript[scriptId] = postProcessDataByScript(
-      sectionProgress.scriptDataByScript[scriptId]
-    );
     getStore().dispatch(addDataByScript(sectionProgress));
     getStore().dispatch(finishLoadingProgress());
     getStore().dispatch(finishRefreshingProgress());
+
+    if (sectionProgress.scriptDataByScript[scriptId].hasStandards) {
+      getStore().dispatch(fetchStandardsCoveredForScript(scriptId));
+      getStore().dispatch(fetchStudentLevelScores(scriptId, sectionId));
+    }
   });
 }
 
@@ -142,63 +109,29 @@ function processStudentTimestamps(timestamps) {
   return studentTimestamps;
 }
 
-function processStudentPairing(students) {
-  const studentPairing = getStudentPairing(students);
-  const isValid = Object.keys(studentPairing).every(userId =>
-    Object.keys(studentPairing[userId]).every(
-      levelId => typeof studentPairing[userId][levelId] === 'boolean'
-    )
-  );
-  if (!isValid) {
-    throw new Error('Input is invalid');
-  }
-  return studentPairing;
-}
-
 function postProcessDataByScript(scriptData) {
-  if (!scriptData.stages) {
-    return scriptData;
+  // Filter to match scriptDataPropType
+  const filteredScriptData = {
+    id: scriptData.id,
+    csf: scriptData.csf,
+    hasStandards: scriptData.hasStandards,
+    title: scriptData.title,
+    path: scriptData.path,
+    stages: scriptData.lessons,
+    family_name: scriptData.family_name,
+    version_year: scriptData.version_year,
+    name: scriptData.name
+  };
+  if (!filteredScriptData.stages) {
+    return filteredScriptData;
   }
   return {
-    ...scriptData,
-    stages: scriptData.stages.map(stage => {
+    ...filteredScriptData,
+    stages: filteredScriptData.stages.map(stage => {
       return {
         ...stage,
         levels: stage.levels.map(level => processedLevel(level))
       };
     })
   };
-}
-
-function postProcessLevelsByLesson(scriptId, progress) {
-  const studentLevelProgress =
-    progress.studentLevelProgressByScript[scriptId] || {};
-  const studentTimeSpent =
-    progress.studentLevelTimeSpentByScript[scriptId] || {};
-  const pairing = progress.studentLevelPairingByScript[scriptId];
-  const scriptData = progress.scriptDataByScript[scriptId];
-  let levelsByLessonByStudent = {};
-  for (const studentId of Object.keys(studentLevelProgress)) {
-    levelsByLessonByStudent[studentId] = levelsByLesson({
-      stages: scriptData.stages,
-      levelProgress: studentLevelProgress[studentId],
-      levelTimeSpent: studentTimeSpent[studentId],
-      levelPairing: pairing[studentId],
-      currentLevelId: null
-    });
-  }
-  return {[scriptId]: levelsByLessonByStudent};
-}
-
-function getStudentPairing(dataByStudent) {
-  return getInfoByStudentByLevel(
-    dataByStudent,
-    levelData => !!levelData.paired
-  );
-}
-
-function getInfoByStudentByLevel(dataByStudent, infoFromLevelData) {
-  return _.mapValues(dataByStudent, studentData =>
-    _.mapValues(studentData, infoFromLevelData)
-  );
 }

--- a/apps/src/templates/sectionProgress/sectionProgressRedux.js
+++ b/apps/src/templates/sectionProgress/sectionProgressRedux.js
@@ -45,10 +45,7 @@ const initialState = {
   currentView: ViewType.SUMMARY,
   scriptDataByScript: {},
   studentLevelProgressByScript: {},
-  studentLevelPairingByScript: {},
-  studentTimestampsByScript: {},
-  studentLevelTimeSpentByScript: {},
-  levelsByLessonByScript: {},
+  studentLastUpdateByScript: {},
   lessonOfInterest: INITIAL_LESSON_OF_INTEREST,
   isLoadingProgress: false,
   isRefreshingProgress: false
@@ -112,25 +109,13 @@ export default function sectionProgress(state = initialState, action) {
         ...state.scriptDataByScript,
         ...action.data.scriptDataByScript
       },
-      levelsByLessonByScript: {
-        ...state.levelsByLessonByScript,
-        ...action.data.levelsByLessonByScript
-      },
       studentLevelProgressByScript: {
         ...state.studentLevelProgressByScript,
         ...action.data.studentLevelProgressByScript
       },
-      studentLevelPairingByScript: {
-        ...state.studentLevelPairingByScript,
-        ...action.data.studentLevelPairingByScript
-      },
-      studentTimestampsByScript: {
-        ...state.studentTimestampsByScript,
-        ...action.data.studentTimestampsByScript
-      },
-      studentLevelTimeSpentByScript: {
-        ...state.studentLevelTimeSpentByScript,
-        ...action.data.studentLevelTimeSpentByScript
+      studentLastUpdateByScript: {
+        ...state.studentLastUpdateByScript,
+        ...action.data.studentLastUpdateByScript
       }
     };
   }
@@ -163,17 +148,6 @@ export const jumpToLessonDetails = lessonOfInterest => {
 // Selector functions
 
 /**
- * Retrieves the progress for the section in the selected script
- * @returns {number} keys are student ids, values are
- * objects of {levelIds: LevelStatus}
- */
-export const getCurrentProgress = state => {
-  return state.sectionProgress.studentLevelProgressByScript[
-    state.scriptSelection.scriptId
-  ];
-};
-
-/**
  * Retrieves the script data for the section in the selected script
  * @returns {scriptDataPropType} object containing metadata about the script structure
  */
@@ -181,23 +155,6 @@ export const getCurrentScriptData = state => {
   return state.sectionProgress.scriptDataByScript[
     state.scriptSelection.scriptId
   ];
-};
-
-/**
- * Retrieves the combined script and progress data for the current scriptId for the entire section.
- */
-export const getLevelsByLesson = state => {
-  return state.sectionProgress.levelsByLessonByScript[
-    state.scriptSelection.scriptId
-  ];
-};
-
-/**
- * Retrieves the combined script and progress data for student for the stage.
- * This represents the data for a single cell.
- */
-export const getLevels = (state, studentId, stageId) => {
-  return getLevelsByLesson(state)[studentId][stageId];
 };
 
 /**

--- a/apps/src/templates/sectionProgress/standards/sectionStandardsProgressRedux.js
+++ b/apps/src/templates/sectionProgress/standards/sectionStandardsProgressRedux.js
@@ -305,19 +305,20 @@ export function getPluggedLessonCompletionStatus(state, lesson) {
     const numberStudentsInSection =
       state.teacherSections.sections[state.teacherSections.selectedSectionId]
         .studentCount;
-    const levelResultsByStudent =
+    const levelProgressByScript =
       state.sectionProgress.studentLevelProgressByScript[scriptId];
 
-    const studentIds = Object.keys(levelResultsByStudent);
-    const levelIds = _.map(lesson.levels, 'activeId');
+    const studentIds = Object.keys(levelProgressByScript);
+    const levelIds = _.map(lesson.levels, 'id');
     let numStudentsCompletedLesson = 0;
     let numStudentsInProgressLesson = 0;
     studentIds.forEach(studentId => {
       let numLevelsInLessonCompletedByStudent = 0;
       levelIds.forEach(levelId => {
+        const levelProgress = levelProgressByScript[studentId][levelId];
         if (
-          levelResultsByStudent[studentId][levelId] >=
-          TestResults.MINIMUM_PASS_RESULT
+          levelProgress &&
+          levelProgress.result >= TestResults.MINIMUM_PASS_RESULT
         ) {
           numLevelsInLessonCompletedByStudent++;
         }

--- a/apps/src/templates/sectionProgress/standards/sectionStandardsProgressRedux.js
+++ b/apps/src/templates/sectionProgress/standards/sectionStandardsProgressRedux.js
@@ -316,7 +316,6 @@ export function getPluggedLessonCompletionStatus(state, lesson) {
       let numLevelsInLessonCompletedByStudent = 0;
       levelIds.forEach(levelId => {
         const levelProgress = levelProgressByScript[studentId][levelId];
-        // console.log('progress', studentId, levelId, levelProgress);
         if (
           levelProgress &&
           levelProgress.result >= TestResults.MINIMUM_PASS_RESULT
@@ -353,7 +352,6 @@ export function fetchStandardsCoveredForScript(scriptId) {
       dataType: 'json',
       url: `/dashboardapi/script_standards/${scriptId}`
     }).then(data => {
-      console.log('standards data', scriptId, data);
       const standardsData = data;
       dispatch(setStandardsData(standardsData));
     });
@@ -375,7 +373,6 @@ export function fetchStudentLevelScores(scriptId, sectionId) {
       return fetch(url, {credentials: 'include'})
         .then(response => response.json())
         .then(data => {
-          console.log('scores data', data);
           const scoresData = data;
           unpluggedLessonIds.forEach(lessonId =>
             dispatch(setStudentLevelScores(scriptId, lessonId, scoresData))

--- a/apps/src/templates/sectionProgress/standards/sectionStandardsProgressRedux.js
+++ b/apps/src/templates/sectionProgress/standards/sectionStandardsProgressRedux.js
@@ -316,6 +316,7 @@ export function getPluggedLessonCompletionStatus(state, lesson) {
       let numLevelsInLessonCompletedByStudent = 0;
       levelIds.forEach(levelId => {
         const levelProgress = levelProgressByScript[studentId][levelId];
+        // console.log('progress', studentId, levelId, levelProgress);
         if (
           levelProgress &&
           levelProgress.result >= TestResults.MINIMUM_PASS_RESULT
@@ -352,6 +353,7 @@ export function fetchStandardsCoveredForScript(scriptId) {
       dataType: 'json',
       url: `/dashboardapi/script_standards/${scriptId}`
     }).then(data => {
+      console.log('standards data', scriptId, data);
       const standardsData = data;
       dispatch(setStandardsData(standardsData));
     });
@@ -373,6 +375,7 @@ export function fetchStudentLevelScores(scriptId, sectionId) {
       return fetch(url, {credentials: 'include'})
         .then(response => response.json())
         .then(data => {
+          console.log('scores data', data);
           const scoresData = data;
           unpluggedLessonIds.forEach(lessonId =>
             dispatch(setStudentLevelScores(scriptId, lessonId, scoresData))

--- a/apps/src/templates/sectionProgress/standards/standardsTestHelpers.js
+++ b/apps/src/templates/sectionProgress/standards/standardsTestHelpers.js
@@ -1,4 +1,5 @@
 import {TeacherScores} from '@cdo/apps/templates/sectionProgress/standards/standardsConstants';
+import {levelProgressFromResult} from '@cdo/apps/templates/progress/progressHelpers';
 
 export const unpluggedLessonList = [
   {
@@ -154,7 +155,7 @@ const scriptDataByScript = {
         title: 'Lesson 2: Learn to Drag and Drop',
         lesson_group_display_name: 'Sequencing',
         lockable: false,
-        levels: [{activeId: 10001}, {activeId: 10002}, {activeId: 10003}],
+        levels: [{id: '10001'}, {id: '10002'}, {id: '10003'}],
         description_student: 'Click and drag to finish the puzzles.',
         description_teacher:
           'This lesson will give students an idea of what to expect when they head to the computer lab. It begins with a brief discussion introducing them to computer lab manners, then they will progress into using a computer to complete online puzzles.',
@@ -194,25 +195,27 @@ const scriptDataByScript = {
 
 export const pluggedLesson = scriptDataByScript[scriptId].stages[1];
 
+const progress20 = levelProgressFromResult(20);
+
 const sectionCompletedLesson = {
   92: {
     100001: {
-      10001: 20,
-      10002: 20,
-      10003: 20
+      10001: progress20,
+      10002: progress20,
+      10003: progress20
     },
     100002: {
-      10001: 20,
-      10002: 20,
-      10003: 20
+      10001: progress20,
+      10002: progress20,
+      10003: progress20
     },
     100003: {
-      10001: 20,
-      10002: 20
+      10001: progress20,
+      10002: progress20
     },
     100004: {
-      10001: 20,
-      10002: 20
+      10001: progress20,
+      10002: progress20
     }
   }
 };
@@ -220,14 +223,14 @@ const sectionCompletedLesson = {
 const sectionPartialCompletedLesson = {
   92: {
     100001: {
-      10001: 20,
-      10002: 20,
-      10003: 20
+      10001: progress20,
+      10002: progress20,
+      10003: progress20
     },
     100002: {
-      10001: 20,
-      10002: 20,
-      10003: 20
+      10001: progress20,
+      10002: progress20,
+      10003: progress20
     }
   }
 };

--- a/apps/src/templates/sectionProgress/summary/StudentProgressSummaryCell.jsx
+++ b/apps/src/templates/sectionProgress/summary/StudentProgressSummaryCell.jsx
@@ -1,9 +1,5 @@
 import React, {Component} from 'react';
 import ProgressBox from '@cdo/apps/templates/sectionProgress/ProgressBox';
-import {
-  summarizeProgressInStage,
-  lessonIsAllAssessment
-} from '@cdo/apps/templates/progress/progressHelpers';
 import PropTypes from 'prop-types';
 import Radium from 'radium';
 
@@ -12,21 +8,27 @@ import Radium from 'radium';
 class StudentProgressSummaryCell extends Component {
   static propTypes = {
     studentId: PropTypes.number.isRequired,
+    statusCounts: PropTypes.object.isRequired,
+    assessmentStage: PropTypes.bool.isRequired,
     style: PropTypes.object,
-    levelsWithStatus: PropTypes.arrayOf(PropTypes.object),
     onSelectDetailView: PropTypes.func
   };
 
   render() {
     const totalPixels = 20;
-    const statusCounts = summarizeProgressInStage(this.props.levelsWithStatus);
-    const assessmentStage = lessonIsAllAssessment(this.props.levelsWithStatus);
-    const perfectPixels = Math.floor(
-      (statusCounts.completed / statusCounts.total) * totalPixels
-    );
-    const imperfectPixels = Math.floor(
-      (statusCounts.imperfect / statusCounts.total) * totalPixels
-    );
+    const {statusCounts, assessmentStage} = this.props;
+    const perfectPixels =
+      (statusCounts.total &&
+        Math.floor(
+          (statusCounts.completed / statusCounts.total) * totalPixels
+        )) ||
+      0;
+    const imperfectPixels =
+      (statusCounts.total &&
+        Math.floor(
+          (statusCounts.imperfect / statusCounts.total) * totalPixels
+        )) ||
+      0;
     const incompletePixels = totalPixels - perfectPixels - imperfectPixels;
     const started =
       statusCounts.attempted > 0 ||

--- a/apps/src/templates/sectionProgress/summary/VirtualizedSummaryView.jsx
+++ b/apps/src/templates/sectionProgress/summary/VirtualizedSummaryView.jsx
@@ -8,7 +8,7 @@ import {jumpToLessonDetails} from '@cdo/apps/templates/sectionProgress/sectionPr
 import {scriptDataPropType} from '../sectionProgressConstants';
 import {
   summarizeProgressInStage,
-  stageIsAllAssessment
+  lessonIsAllAssessment
 } from '@cdo/apps/templates/progress/progressHelpers';
 import {sectionDataPropType} from '@cdo/apps/redux/sectionDataRedux';
 import StudentProgressSummaryCell from './StudentProgressSummaryCell';
@@ -127,7 +127,7 @@ class VirtualizedSummaryView extends Component {
         levelProgressByStudent[student.id],
         stageLevels
       );
-      const assessmentStage = stageIsAllAssessment(stageLevels);
+      const assessmentStage = lessonIsAllAssessment(stageLevels);
       child = (
         <StudentProgressSummaryCell
           studentId={student.id}

--- a/apps/test/unit/code-studio/progressReduxTest.js
+++ b/apps/test/unit/code-studio/progressReduxTest.js
@@ -4,6 +4,7 @@ import {TestResults} from '@cdo/apps/constants';
 import {LevelStatus, LevelKind} from '@cdo/apps/util/sharedConstants';
 import {ViewType, setViewType} from '@cdo/apps/code-studio/viewAsRedux';
 import {PUZZLE_PAGE_NONE} from '@cdo/apps/templates/progress/progressTypes';
+import {getLevelResult} from '@cdo/apps/templates/progress/progressHelpers';
 import reducer, {
   initProgress,
   isPerfect,
@@ -24,7 +25,6 @@ import reducer, {
   setCurrentStageId,
   lessonExtrasUrl,
   setStageExtrasEnabled,
-  getLevelResult,
   __testonly__
 } from '@cdo/apps/code-studio/progressRedux';
 

--- a/apps/test/unit/code-studio/progressReduxTest.js
+++ b/apps/test/unit/code-studio/progressReduxTest.js
@@ -1454,7 +1454,7 @@ describe('progressReduxTest', () => {
         focusAreaStageIds: [1, 2],
         lockableAuthorized: true,
         completed: true,
-        levels: {},
+        progress: {},
         peerReviewsPerformed: true,
         current_stage: 1
       };

--- a/apps/test/unit/templates/sectionProgress/VirtualizedDetailViewTest.js
+++ b/apps/test/unit/templates/sectionProgress/VirtualizedDetailViewTest.js
@@ -15,9 +15,9 @@ import {
 import {Provider} from 'react-redux';
 
 const studentData = [
-  {id: '1', name: 'studentb'},
-  {id: '3', name: 'studentc'},
-  {id: '0', name: 'studenta'}
+  {id: 1, name: 'studentb'},
+  {id: 3, name: 'studentc'},
+  {id: 0, name: 'studenta'}
 ];
 
 describe('VirtualizedSummaryView', () => {
@@ -28,21 +28,21 @@ describe('VirtualizedSummaryView', () => {
     registerReducers({sectionProgress, scriptSelection, currentUser});
     defaultProps = {
       levelProgressByStudent: {
-        '0': {
+        0: {
           '789': {
             status: 'perfect',
             result: 1,
             paired: false
           }
         },
-        '1': {
+        1: {
           '789': {
             status: 'perfect',
             result: 1,
             paired: false
           }
         },
-        '3': {
+        3: {
           '789': {
             status: 'perfect',
             result: 1,
@@ -52,7 +52,7 @@ describe('VirtualizedSummaryView', () => {
       },
       lessonOfInterest: 1,
       section: {
-        id: '1',
+        id: 1,
         script: {id: 123},
         students: studentData
       },

--- a/apps/test/unit/templates/sectionProgress/VirtualizedDetailViewTest.js
+++ b/apps/test/unit/templates/sectionProgress/VirtualizedDetailViewTest.js
@@ -15,9 +15,9 @@ import {
 import {Provider} from 'react-redux';
 
 const studentData = [
-  {id: 1, name: 'studentb'},
-  {id: 3, name: 'studentc'},
-  {id: 0, name: 'studenta'}
+  {id: '1', name: 'studentb'},
+  {id: '3', name: 'studentc'},
+  {id: '0', name: 'studenta'}
 ];
 
 describe('VirtualizedSummaryView', () => {
@@ -27,20 +27,32 @@ describe('VirtualizedSummaryView', () => {
     stubRedux();
     registerReducers({sectionProgress, scriptSelection, currentUser});
     defaultProps = {
-      levelsByLesson: {
-        0: {
-          0: [{id: '789', status: 'perfect'}]
+      levelProgressByStudent: {
+        '0': {
+          '789': {
+            status: 'perfect',
+            result: 1,
+            paired: false
+          }
         },
-        1: {
-          0: [{id: '789', status: 'perfect'}]
+        '1': {
+          '789': {
+            status: 'perfect',
+            result: 1,
+            paired: false
+          }
         },
-        3: {
-          0: [{id: '789', status: 'perfect'}]
+        '3': {
+          '789': {
+            status: 'perfect',
+            result: 1,
+            paired: false
+          }
         }
       },
       lessonOfInterest: 1,
       section: {
-        id: 1,
+        id: '1',
         script: {id: 123},
         students: studentData
       },
@@ -96,7 +108,7 @@ describe('VirtualizedSummaryView', () => {
       <UnconnectedVirtualizedDetailView {...defaultProps} />
     );
     wrapper.instance().detailView = {forceUpdateGrids: forceUpdateGridsSpy};
-    wrapper.setProps({levelsByLesson: {}});
+    wrapper.setProps({levelProgressByStudent: {}});
     expect(forceUpdateGridsSpy).to.have.been.calledOnce;
   });
 });

--- a/apps/test/unit/templates/sectionProgress/VirtualizedSummaryViewTest.js
+++ b/apps/test/unit/templates/sectionProgress/VirtualizedSummaryViewTest.js
@@ -17,9 +17,9 @@ import {LevelStatus} from '@cdo/apps/util/sharedConstants';
 import {levelProgressWithStatus} from '@cdo/apps/templates/progress/progressHelpers';
 
 const studentData = [
-  {id: '1', name: 'studentb'},
-  {id: '3', name: 'studentc'},
-  {id: '0', name: 'studenta'}
+  {id: 1, name: 'studentb'},
+  {id: 3, name: 'studentc'},
+  {id: 0, name: 'studenta'}
 ];
 
 describe('VirtualizedSummaryView', () => {
@@ -30,24 +30,24 @@ describe('VirtualizedSummaryView', () => {
     registerReducers({sectionProgress, scriptSelection, currentUser});
     defaultProps = {
       levelProgressByStudent: {
-        '0': {
+        0: {
           '789': levelProgressWithStatus(LevelStatus.perfect)
         },
-        '1': {
+        1: {
           '789': levelProgressWithStatus(LevelStatus.perfect)
         },
-        '3': {
+        3: {
           '789': levelProgressWithStatus(LevelStatus.perfect)
         }
       },
       lessonOfInterest: 1,
       section: {
-        id: '1',
+        id: 1,
         script: {id: '123'},
         students: studentData
       },
       scriptData: {
-        id: '123',
+        id: 123,
         stages: [
           {
             id: '456',

--- a/apps/test/unit/templates/sectionProgress/VirtualizedSummaryViewTest.js
+++ b/apps/test/unit/templates/sectionProgress/VirtualizedSummaryViewTest.js
@@ -14,7 +14,7 @@ import {
 } from '@cdo/apps/redux';
 import {Provider} from 'react-redux';
 import {LevelStatus} from '@cdo/apps/util/sharedConstants';
-import {levelProgressWithStatus} from '@cdo/apps/templates/progress/progressHelpers';
+import {levelProgressFromStatus} from '@cdo/apps/templates/progress/progressHelpers';
 
 const studentData = [
   {id: 1, name: 'studentb'},
@@ -31,13 +31,13 @@ describe('VirtualizedSummaryView', () => {
     defaultProps = {
       levelProgressByStudent: {
         0: {
-          '789': levelProgressWithStatus(LevelStatus.perfect)
+          '789': levelProgressFromStatus(LevelStatus.perfect)
         },
         1: {
-          '789': levelProgressWithStatus(LevelStatus.perfect)
+          '789': levelProgressFromStatus(LevelStatus.perfect)
         },
         3: {
-          '789': levelProgressWithStatus(LevelStatus.perfect)
+          '789': levelProgressFromStatus(LevelStatus.perfect)
         }
       },
       lessonOfInterest: 1,

--- a/apps/test/unit/templates/sectionProgress/VirtualizedSummaryViewTest.js
+++ b/apps/test/unit/templates/sectionProgress/VirtualizedSummaryViewTest.js
@@ -13,11 +13,13 @@ import {
   restoreRedux
 } from '@cdo/apps/redux';
 import {Provider} from 'react-redux';
+import {LevelStatus} from '@cdo/apps/util/sharedConstants';
+import {levelProgressWithStatus} from '@cdo/apps/templates/progress/progressHelpers';
 
 const studentData = [
-  {id: 1, name: 'studentb'},
-  {id: 3, name: 'studentc'},
-  {id: 0, name: 'studenta'}
+  {id: '1', name: 'studentb'},
+  {id: '3', name: 'studentc'},
+  {id: '0', name: 'studenta'}
 ];
 
 describe('VirtualizedSummaryView', () => {
@@ -27,34 +29,34 @@ describe('VirtualizedSummaryView', () => {
     stubRedux();
     registerReducers({sectionProgress, scriptSelection, currentUser});
     defaultProps = {
-      levelsByLesson: {
-        0: {
-          0: [{id: 789, status: 'perfect'}]
+      levelProgressByStudent: {
+        '0': {
+          '789': levelProgressWithStatus(LevelStatus.perfect)
         },
-        1: {
-          0: [{id: 789, status: 'perfect'}]
+        '1': {
+          '789': levelProgressWithStatus(LevelStatus.perfect)
         },
-        3: {
-          0: [{id: 789, status: 'perfect'}]
+        '3': {
+          '789': levelProgressWithStatus(LevelStatus.perfect)
         }
       },
       lessonOfInterest: 1,
       section: {
-        id: 1,
-        script: {id: 123},
+        id: '1',
+        script: {id: '123'},
         students: studentData
       },
       scriptData: {
-        id: 123,
+        id: '123',
         stages: [
           {
-            id: 456,
+            id: '456',
             position: 1,
             relative_position: 2,
             lockable: true,
             hasLessonPlan: false,
             numberedLesson: false,
-            levels: [{id: 789}]
+            levels: [{id: '789'}]
           }
         ]
       },
@@ -94,13 +96,13 @@ describe('VirtualizedSummaryView', () => {
     expect(wrapper.find('StudentProgressSummaryCell')).to.have.length(3);
   });
 
-  it('updates the grid when the levels change', () => {
+  it('updates the grid when progress changes', () => {
     const forceUpdateGridsSpy = sinon.spy();
     const wrapper = shallow(
       <UnconnectedVirtualizedSummaryView {...defaultProps} />
     );
     wrapper.instance().summaryView = {forceUpdateGrids: forceUpdateGridsSpy};
-    wrapper.setProps({levelsByLesson: {}});
+    wrapper.setProps({levelProgressByStudent: {}});
     expect(forceUpdateGridsSpy).to.have.been.calledOnce;
   });
 });

--- a/apps/test/unit/templates/sectionProgress/sectionProgressLoaderTest.js
+++ b/apps/test/unit/templates/sectionProgress/sectionProgressLoaderTest.js
@@ -88,12 +88,12 @@ const secondServerProgressResponse = {
 
 const fullExpectedResult = {
   scriptDataByScript: {
-    '123': {
+    123: {
       csf: true,
       family_name: 'courseb',
       name: 'courseb-2020',
       hasStandards: false,
-      id: '123',
+      id: 123,
       path: 'test/url',
       stages: [{levels: []}],
       title: 'Course B',
@@ -101,9 +101,9 @@ const fullExpectedResult = {
     }
   },
   studentLevelProgressByScript: {
-    '123': {
-      '100': {},
-      '101': {
+    123: {
+      100: {},
+      101: {
         '2000': {
           pages: null,
           status: 'locked',
@@ -119,7 +119,7 @@ const fullExpectedResult = {
           timeSpent: 12345
         }
       },
-      '102': {
+      102: {
         '2000': {
           pages: null,
           status: 'perfect',
@@ -131,7 +131,7 @@ const fullExpectedResult = {
     }
   },
   studentLastUpdateByScript: {
-    '123': {
+    123: {
       '100': 0,
       '101': timeInSeconds * 1000,
       '102': (timeInSeconds + 1) * 1000
@@ -177,7 +177,7 @@ describe('sectionProgressLoader.loadScript', () => {
         };
       }
     });
-    expect(loadScript('0')).to.be.undefined;
+    expect(loadScript(0)).to.be.undefined;
     expect(startLoadingProgressStub).to.have.not.been.called;
     expect(startRefreshingProgressStub).to.have.not.been.called;
   });
@@ -229,7 +229,7 @@ describe('sectionProgressLoader.loadScript', () => {
         })
       });
 
-      loadScript('0', '0');
+      loadScript(0, 0);
       expect(startLoadingProgressStub).to.have.not.been.called;
       expect(startRefreshingProgressStub).to.have.been.calledOnce;
       expect(addDataByScriptStub).to.have.been.calledOnce;
@@ -273,7 +273,7 @@ describe('sectionProgressLoader.loadScript', () => {
           then: sinon.stub().callsArgWith(0, secondServerProgressResponse)
         })
       });
-      loadScript('123', '0');
+      loadScript(123, 0);
       expect(addDataByScriptStub).to.have.been.calledWith(fullExpectedResult);
       progressHelpers.processedLevel.restore();
     });
@@ -307,7 +307,7 @@ describe('sectionProgressLoader.loadScript', () => {
           })
         });
 
-        loadScript('0', '0');
+        loadScript(0, 0);
         expect(startLoadingProgressStub).to.have.been.calledOnce;
         expect(startRefreshingProgressStub).to.have.not.been.called;
         expect(addDataByScriptStub).to.have.been.calledOnce;
@@ -349,7 +349,7 @@ describe('sectionProgressLoader.loadScript', () => {
             then: sinon.stub().callsArgWith(0, {})
           })
         });
-        loadScript('0', '0');
+        loadScript(0, 0);
         expect(addDataByScriptStub).to.have.been.calledWith(expectedResult);
         progressHelpers.processedLevel.restore();
       });
@@ -367,7 +367,7 @@ describe('sectionProgressLoader.loadScript', () => {
             then: sinon.stub().callsArgWith(0, serverProgressResponse)
           })
         });
-        loadScript('123', '0');
+        loadScript(123, 0);
         expect(addDataByScriptStub).to.have.been.calledWith(fullExpectedResult);
         progressHelpers.processedLevel.restore();
       });

--- a/apps/test/unit/templates/sectionProgress/sectionProgressReduxTest.js
+++ b/apps/test/unit/templates/sectionProgress/sectionProgressReduxTest.js
@@ -5,7 +5,6 @@ import sectionProgress, {
   setLessonOfInterest,
   startLoadingProgress,
   finishLoadingProgress,
-  getCurrentProgress,
   getCurrentScriptData,
   startRefreshingProgress,
   finishRefreshingProgress
@@ -85,8 +84,7 @@ describe('sectionProgressRedux', () => {
       const nextState = sectionProgress(initialState, action);
       assert.deepEqual(nextState.scriptDataByScript, {});
       assert.deepEqual(nextState.studentLevelProgressByScript, {});
-      assert.deepEqual(nextState.levelsByLessonByScript, {});
-      assert.deepEqual(nextState.studentTimestampsByScript, {});
+      assert.deepEqual(nextState.studentLastUpdateByScript, {});
     });
   });
 
@@ -157,23 +155,6 @@ describe('sectionProgressRedux', () => {
       const action = setLessonOfInterest(lessonOfInterest);
       const nextState = sectionProgress(initialState, action);
       assert.deepEqual(nextState.lessonOfInterest, lessonOfInterest);
-    });
-  });
-
-  describe('getCurrentProgress', () => {
-    it('gets the progress for the current script', () => {
-      const stateWithProgress = {
-        scriptSelection: {scriptId: 123},
-        sectionProgress: {
-          studentLevelProgressByScript: {
-            123: 'fake progress 1',
-            456: 'fake progress 2'
-          }
-        }
-      };
-      expect(getCurrentProgress(stateWithProgress)).to.deep.equal(
-        'fake progress 1'
-      );
     });
   });
 

--- a/dashboard/app/controllers/api_controller.rb
+++ b/dashboard/app/controllers/api_controller.rb
@@ -332,8 +332,8 @@ class ApiController < ApplicationController
 
     # Get the level progress for each student
     render json: {
-      students: student_progress,
-      student_timestamps: student_timestamps,
+      student_progress: student_progress,
+      student_last_updates: student_timestamps,
       pagination: {
         total_pages: paged_students.total_pages,
         page: page,

--- a/dashboard/app/controllers/api_controller.rb
+++ b/dashboard/app/controllers/api_controller.rb
@@ -431,7 +431,7 @@ class ApiController < ApplicationController
       level_source = user_level.try(:level_source).try(:data)
 
       # Temporarily return the full set of progress so we can overwrite what the sessionStorage changed
-      response[:progress] = summarize_user_progress(script, current_user)[:levels]
+      response[:progress] = summarize_user_progress(script, current_user)[:progress]
 
       if user_level
         response[:lastAttempt] = {

--- a/dashboard/app/helpers/users_helper.rb
+++ b/dashboard/app/helpers/users_helper.rb
@@ -307,7 +307,7 @@ module UsersHelper
     summary = summarize_user_progress(script, user)
     levels = script.script_levels.map(&:level)
     completed = levels.count do |l|
-      sum = summary[:levels][l.id]; sum && %w(perfect passed).include?(sum[:status])
+      sum = summary[:progress][l.id]; sum && %w(perfect passed).include?(sum[:status])
     end
     (100.0 * completed / levels.count).round(2)
   end

--- a/dashboard/test/controllers/api_controller_test.rb
+++ b/dashboard/test/controllers/api_controller_test.rb
@@ -837,19 +837,19 @@ class ApiControllerTest < ActionController::TestCase
     get :section_level_progress, params: {section_id: @section.id, page: 1, per: 2}
     assert_response :success
     data = JSON.parse(@response.body)
-    assert_equal 2, data['students'].keys.length
+    assert_equal 2, data['student_progress'].keys.length
     assert_equal 3, data['pagination']['total_pages']
 
     get :section_level_progress, params: {section_id: @section.id, page: 2, per: 2}
     assert_response :success
     data = JSON.parse(@response.body)
-    assert_equal 2, data['students'].keys.length
+    assert_equal 2, data['student_progress'].keys.length
 
     # third page has only one student (of 5 total)
     get :section_level_progress, params: {section_id: @section.id, page: 3, per: 2}
     assert_response :success
     data = JSON.parse(@response.body)
-    assert_equal 1, data['students'].keys.length
+    assert_equal 1, data['student_progress'].keys.length
 
     # if we request 1 per page, page 6 should still work (because page 5 gave
     # us a full page of data), but page 7 should fail
@@ -874,22 +874,22 @@ class ApiControllerTest < ActionController::TestCase
     get :section_level_progress, params: {section_id: @section.id, script_id: script.id, page: 1, per: 2}
     assert_response :success
     data = JSON.parse(@response.body)
-    assert_equal 2, data['students'].keys.length
-    assert_equal 2, data['student_timestamps'].keys.length
+    assert_equal 2, data['student_progress'].keys.length
+    assert_equal 2, data['student_last_updates'].keys.length
     assert_equal 3, data['pagination']['total_pages']
 
     get :section_level_progress, params: {section_id: @section.id, script_id: script.id, page: 2, per: 2}
     assert_response :success
     data = JSON.parse(@response.body)
-    assert_equal 2, data['students'].keys.length
-    assert_equal 2, data['student_timestamps'].keys.length
+    assert_equal 2, data['student_progress'].keys.length
+    assert_equal 2, data['student_last_updates'].keys.length
 
     # third page has only one student (of 5 total)
     get :section_level_progress, params: {section_id: @section.id, script_id: script.id, page: 3, per: 2}
     assert_response :success
     data = JSON.parse(@response.body)
-    assert_equal 1, data['students'].keys.length
-    assert_equal 1, data['student_timestamps'].keys.length
+    assert_equal 1, data['student_progress'].keys.length
+    assert_equal 1, data['student_last_updates'].keys.length
   end
 
   test "should get paired icons for paired user levels" do

--- a/dashboard/test/controllers/api_controller_test.rb
+++ b/dashboard/test/controllers/api_controller_test.rb
@@ -592,9 +592,9 @@ class ApiControllerTest < ActionController::TestCase
     body = JSON.parse(response.body)
     assert_equal 2, body['linesOfCode']
     script_level = script.script_levels[1]
-    level_id = script_level.level.id
-    assert_equal 'perfect', body['levels'][level_id.to_s]['status']
-    assert_equal 100, body['levels'][level_id.to_s]['result']
+    level_id = script_level.level.id.to_s
+    assert_equal 'perfect', body['progress'][level_id]['status']
+    assert_equal 100, body['progress'][level_id]['result']
   end
 
   test "should get user progress for lesson" do

--- a/dashboard/test/helpers/users_helper_test.rb
+++ b/dashboard/test/helpers/users_helper_test.rb
@@ -15,7 +15,7 @@ class UsersHelperTest < ActionView::TestCase
         linesOfCode: 42,
         linesOfCodeText: 'Total lines of code: 42',
         lockableAuthorized: false,
-        levels: {},
+        progress: {},
         # second stage because first is unplugged
         current_stage: script.lessons[1].id,
         completed: false,
@@ -32,7 +32,7 @@ class UsersHelperTest < ActionView::TestCase
         linesOfCode: 42,
         linesOfCodeText: 'Total lines of code: 42',
         lockableAuthorized: false,
-        levels: {
+        progress: {
           ul1.level_id => {status: LEVEL_STATUS.perfect, result: ActivityConstants::BEST_PASS_RESULT},
           ul3.level_id => {status: LEVEL_STATUS.passed, result: 20}
         },
@@ -106,7 +106,7 @@ class UsersHelperTest < ActionView::TestCase
         linesOfCode: 42,
         linesOfCodeText: 'Total lines of code: 42',
         lockableAuthorized: false,
-        levels: {
+        progress: {
           ul.level_id => {
             status: LEVEL_STATUS.perfect,
             result: ActivityConstants::BEST_PASS_RESULT,
@@ -141,7 +141,7 @@ class UsersHelperTest < ActionView::TestCase
       linesOfCode: 150,
       linesOfCodeText: 'Total lines of code: 150',
       lockableAuthorized: false,
-      levels: {
+      progress: {
         # BubbleChoice levels return status/result using the sublevel with the highest best_result.
         level.id => {
           status: LEVEL_STATUS.perfect,
@@ -182,7 +182,7 @@ class UsersHelperTest < ActionView::TestCase
     assert UserLevel.find_by(user: user, level: level).nil?
     assert_equal(
       {level.id => {status: LEVEL_STATUS.locked}},
-      summarize_user_progress(script, user)[:levels]
+      summarize_user_progress(script, user)[:progress]
     )
 
     # Now "unlock" it by creating a non-submitted UserLevel
@@ -287,7 +287,7 @@ class UsersHelperTest < ActionView::TestCase
 
     # No user level exists, no progress
     assert UserLevel.find_by(user: user, level: level).nil?
-    assert_equal({}, summarize_user_progress(script, user)[:levels])
+    assert_equal({}, summarize_user_progress(script, user)[:progress])
 
     # now create a non-submitted user level
     user_level = create :user_level, user: user, best_result: ActivityConstants::UNSUBMITTED_RESULT, level: level, script: script, unlocked_at: nil, readonly_answers: nil, submitted: false

--- a/dashboard/test/helpers/users_helper_test.rb
+++ b/dashboard/test/helpers/users_helper_test.rb
@@ -187,7 +187,7 @@ class UsersHelperTest < ActionView::TestCase
 
     # Now "unlock" it by creating a non-submitted UserLevel
     user_level = create :user_level, user: user, best_result: nil, level: level, script: script, unlocked_at: Time.now, readonly_answers: false, submitted: false
-    assert_equal({}, summarize_user_progress(script, user)[:levels], 'No level progress since we dont have a result')
+    assert_equal({}, summarize_user_progress(script, user)[:progress], 'No level progress since we dont have a result')
 
     # put in in "view answers" mode
     user_level.delete
@@ -198,7 +198,7 @@ class UsersHelperTest < ActionView::TestCase
         "#{level.id}_0" => {submitted: true, readonly_answers: true},
         "#{level.id}_1" => {submitted: true, readonly_answers: true}
       },
-      summarize_user_progress(script, user)[:levels], 'level shows as locked again'
+      summarize_user_progress(script, user)[:progress], 'level shows as locked again'
     )
 
     # now submit it (the student ui will display this as locked)
@@ -216,7 +216,7 @@ class UsersHelperTest < ActionView::TestCase
         "#{level.id}_0" => {submitted: true},
         "#{level.id}_1" => {submitted: true}
       },
-      summarize_user_progress(script, user)[:levels],
+      summarize_user_progress(script, user)[:progress],
       'level shows as locked again'
     )
 
@@ -230,7 +230,7 @@ class UsersHelperTest < ActionView::TestCase
         "#{level.id}_0" => {},
         "#{level.id}_1" => {}
       },
-      summarize_user_progress(script, user)[:levels],
+      summarize_user_progress(script, user)[:progress],
       'level still shows as locked'
     )
 
@@ -243,7 +243,7 @@ class UsersHelperTest < ActionView::TestCase
         "#{level.id}_0" => {},
         "#{level.id}_1" => {}
       },
-      summarize_user_progress(script, user)[:levels],
+      summarize_user_progress(script, user)[:progress],
       'level shows attempted now'
     )
 
@@ -263,7 +263,7 @@ class UsersHelperTest < ActionView::TestCase
         "#{level.id}_0" => {submitted: true, readonly_answers: true},
         "#{level.id}_1" => {submitted: true, readonly_answers: true}
       },
-      summarize_user_progress(script, user)[:levels],
+      summarize_user_progress(script, user)[:progress],
       'level shows as submitted'
     )
   end
@@ -297,7 +297,7 @@ class UsersHelperTest < ActionView::TestCase
         "#{level.id}_0" => {},
         "#{level.id}_1" => {}
       },
-      summarize_user_progress(script, user)[:levels]
+      summarize_user_progress(script, user)[:progress]
     )
 
     # now create a submitted user level
@@ -309,7 +309,7 @@ class UsersHelperTest < ActionView::TestCase
         "#{level.id}_0" => {submitted: true},
         "#{level.id}_1" => {submitted: true}
       },
-      summarize_user_progress(script, user)[:levels]
+      summarize_user_progress(script, user)[:progress]
     )
   end
 

--- a/dashboard/test/ui/features/learning_platform/level_types/bubble_choice.feature
+++ b/dashboard/test/ui/features/learning_platform/level_types/bubble_choice.feature
@@ -28,7 +28,7 @@ Feature: BubbleChoice
     And I wait until element ".teacher-panel" is visible
     When I click selector ".teacher-panel table td:contains(Alice)" once I see it
     And I wait until element "td:contains(Bubble Choice)" is visible
-    And I wait for 2 seconds
+    And I wait for 4 seconds
     Then I verify progress for stage 40 level 1 is "perfect"
 
     # View progress from BubbleChoice activity page
@@ -38,5 +38,5 @@ Feature: BubbleChoice
     Then I verify progress for the sublevel with selector ".uitest-bubble-choice:eq(0) .uitest-ProgressBubble:first .uitest-bubble" is "not_tried"
     When I click selector ".teacher-panel table td:contains(Alice)" once I see it
     And I wait until element ".uitest-bubble-choice:eq(0)" is visible
-    And I wait for 2 seconds
+    And I wait for 4 seconds
     Then I verify progress for the sublevel with selector ".uitest-bubble-choice:eq(0) .uitest-ProgressBubble:first .uitest-bubble" is "perfect"

--- a/dashboard/test/ui/features/learning_platform/level_types/level_group_multi_page_dots.feature
+++ b/dashboard/test/ui/features/learning_platform/level_types/level_group_multi_page_dots.feature
@@ -8,7 +8,7 @@ Background:
   And I wait to see ".nextPageButton"
   And element ".nextPageButton" is visible
 
-Scenario: Submit three pages as... 1. some, 2. none, 3. all questions answered.
+Scenario: Submit three pages as... 1. all, 2. none, 3. some questions answered.
   When element ".level-group-content:nth(0) .multi-question" contains text "Which arrow gets"
 
   # Enter answers to all three multis on the first page.
@@ -45,8 +45,9 @@ Scenario: Submit three pages as... 1. some, 2. none, 3. all questions answered.
 
   Then I reload the page
   And I wait to see ".react_stage"
+  And I wait until jQuery Ajax requests are finished
 
-  # Verify the three dots in the header are 1. some, 2. none, 3. all questions answered.
+  # Verify the three dots in the header are 1. all, 2. none, 3. some questions answered.
   And I verify progress in the header of the current page is "perfect_assessment" for level 2
   And I verify progress in the header of the current page is "not_tried" for level 3
   And I verify progress in the header of the current page is "attempted_assessment" for level 4
@@ -71,6 +72,7 @@ Scenario: Submit three pages as... 1. some, 2. none, 3. all questions answered.
   And I press "#ok-button" using jQuery to load a new page
   And I am on "http://studio.code.org/s/allthethings/stage/23/puzzle/1?noautoplay=true"
   And I wait to see ".react_stage"
+  And I wait until jQuery Ajax requests are finished
 
   # Verify the three dots in the header all reflect the submission.
   And I verify progress in the header of the current page is "perfect_assessment" for level 2


### PR DESCRIPTION
this is a revival of the PR that started this whole refactor project #37246 and was extracted from the completed section progress table refactor #38309.

The purpose of this refactor is the separate student-specific progress data from general level/lesson/lessonGroup data. The motivation was that with very large sections, merging all the progress data with level data was resulting in _a lot_ of data bloat (see below). And since progress data comes from a separate api endpoint than script data, it seemed like a logical division.

## sectionProgressRedux
`/dashboardapi/section_level_progress/` returns an object with two top-level properties: 
```
serverData = {
  student_progress: {
    studentId: {
      levelId: {
        status: string,
        result: number,
        paired: bool
      }
    }
  }
  student_last_updates: {
    studentId: number (timestamp)
  }
}
```

`studentTimestampsByScript` has been renamed to `studentLastUpdateByScript`, but otherwise how we are storing `serverData.student_last_updates` remains unchanged.

for the rest of the progress data, here is how the data structure has changed:

BEFORE
with 250 students, `sectionProgressRedux` store was 109,343 lines and 3.9 MB
```
// redux properties
scriptDataByScript: {},
studentLevelProgressByScript: {},
studentLevelPairingByScript: {},
studentTimestampsByScript: {},
studentLevelTimeSpentByScript: {},
levelsByLessonByScript: {}

// status string was merged with general level data from scriptDataByScript[scriptId] into a full level object 
// that included the student-specific status string. this merge was the cause of massive data bloat.
serverData.student_progress[studentId][levelId].status -> levelsByLessonByScript[scriptId][studentId][stageIndex][levelIndex].status

// pairing data, time spent, and results were stored in their own structures
serverData.student_progress[studentId][levelId].paired -> studentLevelPairingByScript[scriptId][studentId][levelId]
serverData.student_progress[studentId][levelId].time_spent -> studentLevelTimeSpentByScript[scriptId][studentId][levelId]
serverData.student_progress[studentId][levelId].result -> studentLevelProgressByScript[scriptId][studentId][levelId]
```

AFTER
with 250 students, `sectionProgressRedux` store is 12,889 lines and 412 KB
```
// redux properties
scriptDataByScript: {},
studentLevelProgressByScript: {},
studentLastUpdateByScript: {}

// progress data is minimally post-processed to convert snake_case to camelCase and fill in missing properties,
// but otherwise the structure from the server is preserved
serverData.student_progress -> studentLevelProgressByScript[scriptId]
{[status], [result], [paired], [time_spent]} -> {status, result, paired, timeSpent}
```