### PR TITLE
Fix annotation for foorm library model

### DIFF
--- a/dashboard/app/models/foorm/library.rb
+++ b/dashboard/app/models/foorm/library.rb
@@ -5,7 +5,7 @@
 #  id         :bigint           not null, primary key
 #  name       :string(255)      not null
 #  version    :integer          not null
-#  published  :boolean          default(TRUE), not null
+#  published  :boolean          not null
 #  created_at :datetime         not null
 #  updated_at :datetime         not null
 #


### PR DESCRIPTION
Missed an updated annotation in this [migration PR](https://github.com/code-dot-org/code-dot-org/pull/38681) -- the schema update was made via [staging content scoop here](https://github.com/code-dot-org/code-dot-org/commit/587f5313b48b69740434ddecea309a28dbb0daa1).