### PR TITLE
[Hackathon] add topic column to featured projects table

### DIFF
--- a/dashboard/app/models/featured_project.rb
+++ b/dashboard/app/models/featured_project.rb
@@ -6,10 +6,12 @@
 #  storage_app_id :integer
 #  featured_at    :datetime
 #  unfeatured_at  :datetime
+#  topic          :string(255)
 #
 # Indexes
 #
 #  index_featured_projects_on_storage_app_id  (storage_app_id) UNIQUE
+#  index_featured_projects_on_topic           (topic)
 #
 
 class FeaturedProject < ApplicationRecord

--- a/dashboard/db/migrate/20210126021131_add_topic_to_featured_projects.rb
+++ b/dashboard/db/migrate/20210126021131_add_topic_to_featured_projects.rb
@@ -1,0 +1,7 @@
+class AddTopicToFeaturedProjects < ActiveRecord::Migration[5.2]
+  def change
+    add_column :featured_projects, :topic, :string
+    add_index :featured_projects, :topic
+    execute "ALTER TABLE featured_projects CONVERT TO CHARACTER SET utf8 COLLATE utf8_unicode_ci"
+  end
+end

--- a/dashboard/db/schema.rb
+++ b/dashboard/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_01_21_195951) do
+ActiveRecord::Schema.define(version: 2021_01_26_021131) do
 
   create_table "activities", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci", force: :cascade do |t|
     t.integer "user_id"
@@ -441,7 +441,9 @@ ActiveRecord::Schema.define(version: 2021_01_21_195951) do
     t.integer "storage_app_id"
     t.datetime "featured_at"
     t.datetime "unfeatured_at"
+    t.string "topic"
     t.index ["storage_app_id"], name: "index_featured_projects_on_storage_app_id", unique: true
+    t.index ["topic"], name: "index_featured_projects_on_topic"
   end
 
   create_table "followers", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci", force: :cascade do |t|


### PR DESCRIPTION
We're adding a new "Special Topics" section to the top of the Project Gallery (see #38726). To do this, I'm adding a `topic` column to the FeaturedProjects table.  Those with Project Validator permissions will be able to add a topic to a given featured project. Then, we will pull featured projects that have that topic tag to display in the "Special Topics" section. 