### PR TITLE
use script id to find teacher feedback script level

### DIFF
--- a/dashboard/app/controllers/teacher_feedbacks_controller.rb
+++ b/dashboard/app/controllers/teacher_feedbacks_controller.rb
@@ -21,8 +21,7 @@ class TeacherFeedbacksController < ApplicationController
     end
 
     @feedbacks_as_student_with_level_info = @feedbacks_as_student.map do |feedback|
-      script_level = feedback.level.script_levels.find {|sl| sl.script_id == feedback.script_id}
-      feedback.attributes.merge(script_level&.summary_for_feedback)
+      feedback.attributes.merge(feedback&.get_script_level&.summary_for_feedback)
     end
   end
 

--- a/dashboard/app/controllers/teacher_feedbacks_controller.rb
+++ b/dashboard/app/controllers/teacher_feedbacks_controller.rb
@@ -6,14 +6,24 @@ class TeacherFeedbacksController < ApplicationController
   # Feedback from any verified teacher who has provided feedback to the current
   # student on any level
   def index
-    @feedbacks_as_student = @teacher_feedbacks.order(created_at: :desc).includes(script_level: {lesson: :script}).select do |feedback|
+    scope = {
+      level: {
+        script_levels: {
+          lesson: :script
+        }
+      }
+    }
+    @feedbacks_as_student = @teacher_feedbacks.order(created_at: :desc).includes(scope).select do |feedback|
       UserPermission.where(
         user_id: feedback.teacher_id,
         permission: 'authorized_teacher'
       )
     end
 
-    @feedbacks_as_student_with_level_info = @feedbacks_as_student.map {|feedback| feedback.attributes.merge(feedback&.script_level&.summary_for_feedback)}
+    @feedbacks_as_student_with_level_info = @feedbacks_as_student.map do |feedback|
+      script_level = feedback.level.script_levels.find {|sl| sl.script_id == feedback.script_id}
+      feedback.attributes.merge(script_level&.summary_for_feedback)
+    end
   end
 
   def set_seen_on_feedback_page_at

--- a/dashboard/app/models/teacher_feedback.rb
+++ b/dashboard/app/models/teacher_feedback.rb
@@ -41,6 +41,12 @@ class TeacherFeedback < ApplicationRecord
     end
   end
 
+  # Finds the script level associated with this object, using script id and
+  # level id.
+  def get_script_level
+    level.script_levels.find {|sl| sl.script_id == script_id}
+  end
+
   def self.get_student_level_feedback(student_id, level_id, teacher_id)
     where(
       student_id: student_id,

--- a/dashboard/test/controllers/teacher_feedbacks_controller_test.rb
+++ b/dashboard/test/controllers/teacher_feedbacks_controller_test.rb
@@ -22,4 +22,17 @@ class TeacherFeedbacksControllerTest < ActionController::TestCase
     get :index
     assert_response :success
   end
+
+  test 'index returns many feedbacks' do
+    student = create :student
+    5.times do
+      create :teacher_feedback, student: student
+    end
+    assert_equal TeacherFeedback.all.count, 5
+    sign_in student
+    assert_queries 18 do
+      get :index
+      assert_response :success
+    end
+  end
 end

--- a/dashboard/test/controllers/teacher_feedbacks_controller_test.rb
+++ b/dashboard/test/controllers/teacher_feedbacks_controller_test.rb
@@ -13,6 +13,9 @@ class TeacherFeedbacksControllerTest < ActionController::TestCase
     sign_in student
     get :index
     assert_response :success
+
+    all_feedback_data = get_all_response_feedback_data
+    assert_equal 0, all_feedback_data.count
   end
 
   test 'index: returns success if signed in user - feedback' do
@@ -21,6 +24,10 @@ class TeacherFeedbacksControllerTest < ActionController::TestCase
     sign_in feedback.student
     get :index
     assert_response :success
+
+    all_feedback_data = get_all_response_feedback_data
+    assert_equal 1, all_feedback_data.count
+    assert_equal feedback.student.id, all_feedback_data.first['student_id']
   end
 
   test 'index returns many feedbacks' do
@@ -34,5 +41,16 @@ class TeacherFeedbacksControllerTest < ActionController::TestCase
       get :index
       assert_response :success
     end
+
+    all_feedback_data = get_all_response_feedback_data
+    assert_equal 5, all_feedback_data.count
+  end
+
+  private
+
+  def get_all_response_feedback_data
+    assert_select 'script[data-feedback]', 1
+    feedback_data = JSON.parse(css_select('script[data-feedback]').first.attribute('data-feedback').to_s)
+    feedback_data['all_feedback']
   end
 end

--- a/dashboard/test/controllers/teacher_feedbacks_controller_test.rb
+++ b/dashboard/test/controllers/teacher_feedbacks_controller_test.rb
@@ -30,7 +30,7 @@ class TeacherFeedbacksControllerTest < ActionController::TestCase
     end
     assert_equal TeacherFeedback.all.count, 5
     sign_in student
-    assert_queries 18 do
+    assert_queries 20 do
       get :index
       assert_response :success
     end


### PR DESCRIPTION
FInishes [PLAT-685]. See [migrating teacher feedback ids](https://docs.google.com/document/d/1SJVYtKSmOchUOcGnAOWU4Ph1u2utOc896EX_acbAnJM/edit#) for more context.

It turns out the only place we were using TeacherFeedback.script_level was on the studio.code.org/feedback page. This PR updates that codepath to use script id instead of script level id, and adds a bit of test coverage.

## Testing story

* Added test coverage which counts queries for multiple feedbacks on /feedback
* improved existing test cases to make sure the feedback data reached the client
* manually verified that /feedback is still working for students

## Future work

When viewing the script level page, we should show only feedback for that script. today, we show any feedback on that level in any script. This work is being tracked by learning platform (see [slack](https://codedotorg.slack.com/archives/CA3KCSGTD/p1611682250042600)).

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked


[PLAT-685]: https://codedotorg.atlassian.net/browse/PLAT-685