### PR TITLE
[Hackathon] add topic column to featured projects UI table

### DIFF
--- a/apps/src/templates/projects/FeaturedProjectsTable.jsx
+++ b/apps/src/templates/projects/FeaturedProjectsTable.jsx
@@ -176,6 +176,10 @@ const typeFormatter = type => {
   return FEATURED_PROJECT_TYPE_MAP[type];
 };
 
+const topicFormatter = topic => {
+  return topic;
+};
+
 class FeaturedProjectsTable extends React.Component {
   static propTypes = {
     projectList: PropTypes.arrayOf(featuredProjectDataPropType).isRequired,
@@ -266,6 +270,23 @@ class FeaturedProjectsTable extends React.Component {
         },
         cell: {
           formatters: [typeFormatter],
+          props: {
+            style: {
+              ...styles.cellType,
+              ...tableLayoutStyles.cell
+            }
+          }
+        }
+      },
+      {
+        property: 'topic',
+        header: {
+          label: 'Topic',
+          props: {style: tableLayoutStyles.headerCell},
+          transforms: [sortable]
+        },
+        cell: {
+          formatters: [topicFormatter],
           props: {
             style: {
               ...styles.cellType,

--- a/apps/src/templates/projects/projectConstants.js
+++ b/apps/src/templates/projects/projectConstants.js
@@ -25,6 +25,7 @@ export const featuredProjectDataPropType = PropTypes.shape({
   projectName: PropTypes.string.isRequired,
   channel: PropTypes.string.isRequired,
   type: PropTypes.string.isRequired,
+  topic: PropTypes.string,
   publishedAt: PropTypes.string,
   thumbnailUrl: PropTypes.string,
   featuredAt: PropTypes.string.isRequired,

--- a/dashboard/app/controllers/projects_controller.rb
+++ b/dashboard/app/controllers/projects_controller.rb
@@ -164,7 +164,8 @@ class ProjectsController < ApplicationController
       :storage_apps__project_type___project_type,
       :storage_apps__published_at___published_at,
       :featured_projects__featured_at___featured_at,
-      :featured_projects__unfeatured_at___unfeatured_at
+      :featured_projects__unfeatured_at___unfeatured_at,
+      :featured_projects__topic___topic
     ]
   end
 
@@ -185,6 +186,7 @@ class ProjectsController < ApplicationController
         projectName: project_details_value['name'],
         channel: channel,
         type: project_details[:project_type],
+        topic: project_details[:topic],
         publishedAt: project_details[:published_at],
         thumbnailUrl: project_details_value['thumbnailUrl'],
         featuredAt: project_details[:featured_at],


### PR DESCRIPTION
Follow up to #38727 

This exposes the value in the new topics database field for Featured Projects in the Featured Projects table UI.
 
<img width="911" alt="Screen Shot 2021-01-26 at 12 24 51 PM" src="https://user-images.githubusercontent.com/12300669/105881701-d1a5b180-5fd2-11eb-903e-fa6779275967.png">

Next up we'll add the functionality for project validators to set a project's topic. 