### PR TITLE
[Flappy] Switch to Google Blockly

### DIFF
--- a/apps/src/blocklyAddons/cdoTouch.js
+++ b/apps/src/blocklyAddons/cdoTouch.js
@@ -1,0 +1,15 @@
+export default function initializeBlocklyXml(blocklyWrapper) {
+  // Aliasing Google's setClientFromTouch() so that we can override it, but still be able
+  // to call Google's setClientFromTouch() in the override function.
+  blocklyWrapper.Touch.originalSetClientFromTouch =
+    blocklyWrapper.Touch.setClientFromTouch;
+
+  // This change is needed to make our UI tests work on iPad, iPhone, and Safari 12
+  blocklyWrapper.Touch.setClientFromTouch = function(e) {
+    // Safari doesn't support e.changedTouches
+    if (!e.changedTouches) {
+      return;
+    }
+    blocklyWrapper.Touch.originalSetClientFromTouch(e);
+  };
+}

--- a/apps/src/sites/studio/pages/googleBlocklyWrapper.js
+++ b/apps/src/sites/studio/pages/googleBlocklyWrapper.js
@@ -8,6 +8,7 @@ import CdoInput from '@cdo/apps/blocklyAddons/cdoInput';
 import CdoPathObject from '@cdo/apps/blocklyAddons/cdoPathObject';
 import CdoScrollbar from '@cdo/apps/blocklyAddons/cdoScrollbar';
 import CdoTheme from '@cdo/apps/blocklyAddons/cdoTheme';
+import initializeTouch from '@cdo/apps/blocklyAddons/cdoTouch';
 import CdoTrashcan from '@cdo/apps/blocklyAddons/cdoTrashcan';
 import CdoWorkspaceSvg from '@cdo/apps/blocklyAddons/cdoWorkspaceSvg';
 import initializeBlocklyXml from '@cdo/apps/blocklyAddons/cdoXml';
@@ -119,6 +120,7 @@ function initializeBlocklyWrapper(blocklyInstance) {
   blocklyWrapper.wrapReadOnlyProperty('useContractEditor');
   blocklyWrapper.wrapReadOnlyProperty('useModalFunctionEditor');
   blocklyWrapper.wrapReadOnlyProperty('utils');
+  blocklyWrapper.wrapReadOnlyProperty('Touch');
   blocklyWrapper.wrapReadOnlyProperty('Trashcan');
   blocklyWrapper.wrapReadOnlyProperty('Variables');
   blocklyWrapper.wrapReadOnlyProperty('weblab_locale');
@@ -270,6 +272,7 @@ function initializeBlocklyWrapper(blocklyInstance) {
   };
 
   initializeBlocklyXml(blocklyWrapper);
+  initializeTouch(blocklyWrapper);
 
   return blocklyWrapper;
 }

--- a/dashboard/app/helpers/levels_helper.rb
+++ b/dashboard/app/helpers/levels_helper.rb
@@ -313,7 +313,7 @@ module LevelsHelper
     use_blockly = !use_droplet && !use_netsim && !use_weblab
     use_p5 = @level.is_a?(Gamelab)
     hide_source = app_options[:hideSource]
-    use_google_blockly = view_options[:useGoogleBlockly]
+    use_google_blockly = @level.is_a?(Flappy) || view_options[:useGoogleBlockly]
     render partial: 'levels/apps_dependencies',
       locals: {
         app: app_options[:app],

--- a/dashboard/test/ui/features/star_labs/blocklayout.feature
+++ b/dashboard/test/ui/features/star_labs/blocklayout.feature
@@ -8,12 +8,12 @@ Background:
 Scenario: Auto-placing malformed start blocks
   When I've initialized the workspace with an auto-positioned flappy puzzle with extra newlines
   Then block "18" is near offset "16, 16"
-  And block "21" is near offset "16, 107"
+  And block "21" is near offset "16, 114"
 
 Scenario: Auto-placing blocks
   When I've initialized the workspace with an auto-positioned flappy puzzle
   Then block "18" is near offset "16, 16"
-  And block "21" is near offset "16, 107"
+  And block "21" is near offset "16, 114"
 
 Scenario: Auto-placing blocks with XML positioning
   Given I am on "http://studio.code.org/s/allthethings/stage/5/puzzle/4?noautoplay=true"

--- a/dashboard/test/ui/features/star_labs/flappydrag.feature
+++ b/dashboard/test/ui/features/star_labs/flappydrag.feature
@@ -8,4 +8,4 @@ Scenario: Connect two blocks from toolbox
   And I drag block "1" to block "3"
   And I drag block "1" to block "4"
   And I wait for 1 seconds
-  Then block "5" is child of block "4"
+  Then block "6" is child of block "4"

--- a/dashboard/vendor/assets/javascripts/jquery.simulate.js
+++ b/dashboard/vendor/assets/javascripts/jquery.simulate.js
@@ -312,7 +312,7 @@ if ('ontouchstart' in document.documentElement) {
 
 $.extend( $.simulate.prototype, {
   simulateDrag: function() {
-    if (window.Blockly && Blockly.version === 'Google') {
+    if (window.Blockly && Blockly.version === 'Google' && Blockly.utils.global['PointerEvent']) {
       touchMappings = {
         mousedown: 'pointerdown',
         mousemove: 'pointermove',


### PR DESCRIPTION
The [last attempt](https://github.com/code-dot-org/code-dot-org/pull/38586) was [reverted](https://github.com/code-dot-org/code-dot-org/pull/38599) because of two tests (`flappy.feature` and `flappydrag.feature`) failing on iPhone, iPad, and Safari.

`bd69705` and `d815e6c` are the new changes. Both just have to do with how drag events are simulated by our UI tests.

`flappydrag.feature`
![image](https://user-images.githubusercontent.com/8787187/105884002-5802c900-5fbc-11eb-8ca7-253a726fc9ac.png)

`flappy.feature`
![image](https://user-images.githubusercontent.com/8787187/105884041-6355f480-5fbc-11eb-9bd8-a295b4a4ced2.png)



<!-- ### Background -->
<!-- ### Privacy -->
<!--
1.	Does the Project involve the collection, use or sharing of new Personal Data?

2.	Does the Project involve a new or changed use or sharing of existing Personal Data?
-->
<!-- ### Security -->
<!--
Link to Jira Task where sensitive security issues are discussed privately.
-->
<!-- ### Caching -->
<!-- ### Deployment strategy -->
<!-- ### Future work -->

## Links

<!--
  Any relevant links to external resources; ie, specification documents, jira
  items, related PRs, honeybadger errors, etc
-->

- [spec]()
- [jira]()

## Testing story

<!--
  Does your change include appropriate tests?

  If so, please describe how the tests included in this PR are sufficient

  If not, please explain why this change does not need to be tested.
-->

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
