### PR TITLE
surface errors to ui when script update fails

### DIFF
--- a/dashboard/app/controllers/scripts_controller.rb
+++ b/dashboard/app/controllers/scripts_controller.rb
@@ -129,7 +129,7 @@ class ScriptsController < ApplicationController
       @script.reload
       render json: @script.summarize_for_script_edit
     else
-      render json: @script.errors
+      render(status: :not_acceptable, json: @script.errors)
     end
   end
 


### PR DESCRIPTION
## background

This PR addresses the following issue:
1. go to https://levelbuilder-studio.code.org/s/csp1-2021/edit
2. under "Publishing Settings", select "Visible in Teacher Dashboard"
3. press "Save and Keep Editing"

EXPECTED: fails with error explaining that migrated scripts cannot be marked visible (yet)
ACTUAL: fails silently with success message

## root cause

this validation was failing: https://github.com/code-dot-org/code-dot-org/blob/8845df652b6d8ce0cecf6e8c1718dcc759d73f1a/dashboard/app/models/script.rb#L123-L125 

an ActiveRecord::RecordInvalid error was being raised: https://github.com/code-dot-org/code-dot-org/blob/8845df652b6d8ce0cecf6e8c1718dcc759d73f1a/dashboard/app/models/script.rb#L1154

the error was being caught and added to the list of errors on the script object: https://github.com/code-dot-org/code-dot-org/blob/8845df652b6d8ce0cecf6e8c1718dcc759d73f1a/dashboard/app/models/script.rb#L1183-L1184

the errors were even being returned to the client: https://github.com/code-dot-org/code-dot-org/blob/36bf378750d3f46bfd1c44448df9fcd626c7f5b9/dashboard/app/controllers/scripts_controller.rb#L132

but, because the status code was not a 4xx, the client treated the response as a success.

## fix

The fix is just to set the right status code in the server response. The client code then takes care of displaying the error message.

#### before
![Screen Shot 2021-01-26 at 4 21 23 PM](https://user-images.githubusercontent.com/8001765/105924223-b77bcb80-5ff2-11eb-9fa2-5eef16ecca33.png)

#### after
![Screen Shot 2021-01-26 at 4 06 19 PM](https://user-images.githubusercontent.com/8001765/105924236-bb0f5280-5ff2-11eb-9988-cf0a3521bba9.png)

## Future work

in the process of debugging this, I discovered that there are nested transactions in this codepath:
* https://github.com/code-dot-org/code-dot-org/blob/def7f2c0621d08dfe5855d3e9326c88754cb8711/dashboard/app/models/script.rb#L1163-L1168
* https://github.com/code-dot-org/code-dot-org/blob/def7f2c0621d08dfe5855d3e9326c88754cb8711/dashboard/app/models/script.rb#L989-L990

and that with default options, nested transactions are bad:
* https://pragtob.wordpress.com/2017/12/12/surprises-with-nested-transactions-rollbacks-and-activerecord/
* https://api.rubyonrails.org/classes/ActiveRecord/Transactions/ClassMethods.html#module-ActiveRecord::Transactions::ClassMethods-label-Nested+transactions

Fixed in https://github.com/code-dot-org/code-dot-org/pull/38775

## Testing story

existing test coverage, plus manually verifying the result shown in the screenshots above.

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
