### PR TITLE
Send lesson path from server to lesson editor

### DIFF
--- a/apps/src/lib/levelbuilder/lesson-editor/LessonEditor.jsx
+++ b/apps/src/lib/levelbuilder/lesson-editor/LessonEditor.jsx
@@ -125,7 +125,7 @@ class LessonEditor extends Component {
         if (shouldCloseAfterSave) {
           if (data.hasLessonPlan) {
             navigateToHref(
-              `/lessons/${this.state.originalLessonData.id}${
+              `${this.state.originalLessonData.lessonPath}${
                 window.location.search
               }`
             );

--- a/apps/src/lib/levelbuilder/script-editor/LessonToken.jsx
+++ b/apps/src/lib/levelbuilder/script-editor/LessonToken.jsx
@@ -162,7 +162,7 @@ export default class LessonToken extends Component {
                 onClick={() => {
                   window.lessonEditorOpened = true;
                   const win = window.open(
-                    `/lessons/${this.props.lesson.id}/edit`,
+                    `${this.props.lesson.lessonEditPath}`,
                     '_blank'
                   );
                   win.focus();

--- a/apps/src/lib/levelbuilder/script-editor/scriptEditorRedux.js
+++ b/apps/src/lib/levelbuilder/script-editor/scriptEditorRedux.js
@@ -267,6 +267,7 @@ export const mapLessonGroupDataForEditor = rawLessonGroups => {
           assessment: lesson.assessment,
           unplugged: lesson.unplugged,
           hasLessonPlan: lesson.hasLessonPlan,
+          lessonEditPath: lesson.lessonEditPath,
           name: lesson.name,
           /*
            * NOTE: The Script Edit GUI no longer includes the editing of levels

--- a/apps/test/unit/lib/levelbuilder/lesson-editor/LessonEditorTest.js
+++ b/apps/test/unit/lib/levelbuilder/lesson-editor/LessonEditorTest.js
@@ -56,7 +56,8 @@ describe('LessonEditor', () => {
         announcements: [],
         assessmentOpportunities: 'Assessment Opportunities',
         courseVersionId: 1,
-        scriptPath: '/s/my-script/'
+        scriptPath: '/s/my-script/',
+        lessonPath: '/lessons/1'
       }
     };
   });

--- a/dashboard/app/models/lesson.rb
+++ b/dashboard/app/models/lesson.rb
@@ -236,7 +236,8 @@ class Lesson < ApplicationRecord
         levels: cached_levels.map {|sl| sl.summarize(false, for_edit: for_edit)},
         description_student: render_codespan_only_markdown(I18n.t("data.script.name.#{script.name}.lessons.#{key}.description_student", default: '')),
         description_teacher: render_codespan_only_markdown(I18n.t("data.script.name.#{script.name}.lessons.#{key}.description_teacher", default: '')),
-        unplugged: display_as_unplugged # TODO: Update to use unplugged property
+        unplugged: display_as_unplugged, # TODO: Update to use unplugged property
+        lessonEditPath: edit_lesson_path(id: id)
       }
 
       # Use to_a here so that we get access to the cached script_levels.
@@ -315,7 +316,8 @@ class Lesson < ApplicationRecord
       vocabularies: vocabularies.map(&:summarize_for_edit),
       objectives: objectives.map(&:summarize_for_edit),
       courseVersionId: lesson_group.script.get_course_version&.id,
-      scriptPath: script_path(script)
+      scriptPath: script_path(script),
+      lessonPath: lesson_path(id: id)
     }
   end
 


### PR DESCRIPTION
Pass lesson path down from the server instead of creating it client side. This will help when we update lesson paths soon.

