### PR TITLE
Hbergam/topic projects hackathon

### DIFF
--- a/apps/i18n/common/en_us.json
+++ b/apps/i18n/common/en_us.json
@@ -1421,6 +1421,8 @@
   "projectTypePlaylabPreReader": "Play Lab (Pre-reader)",
   "projectTypeStarwars": "Star Wars",
   "projectTypeStarwarsBlocks": "Star Wars (Blocks)",
+  "projectTypeSpecialTopic": "Special Topic",
+  "projectTypeSpecialTopicViewMore": "View more Special Topic projects",
   "projectTypeSpriteLab": "Sprite Lab",
   "projectTypeSports": "Sports",
   "projectTypeWeblab": "Web Lab",

--- a/apps/src/templates/projects/ProjectCardGrid.jsx
+++ b/apps/src/templates/projects/ProjectCardGrid.jsx
@@ -76,7 +76,7 @@ class ProjectCardGrid extends Component {
 
   render() {
     const {projectLists} = this.props;
-    const showSpecialTopic = experiments.isEnabled(experiments.special_topic);
+    const showSpecialTopic = experiments.isEnabled(experiments.SPECIAL_TOPIC);
     const numProjects = this.state.showAll
       ? NUM_PROJECTS_ON_PREVIEW
       : NUM_PROJECTS_IN_APP_VIEW;

--- a/apps/src/templates/projects/ProjectCardGrid.jsx
+++ b/apps/src/templates/projects/ProjectCardGrid.jsx
@@ -6,11 +6,10 @@ import i18n from '@cdo/locale';
 import {connect} from 'react-redux';
 import color from '../../util/color';
 import styleConstants from '../../styleConstants';
-//import experiments from '@cdo/apps/util/experiments';
+import experiments from '@cdo/apps/util/experiments';
 
 const NUM_PROJECTS_ON_PREVIEW = 4;
 const NUM_PROJECTS_IN_APP_VIEW = 12;
-//const showSpecialTopic = experiments.isEnabled(experiments.special_topic);
 
 const styles = {
   grid: {
@@ -77,6 +76,7 @@ class ProjectCardGrid extends Component {
 
   render() {
     const {projectLists} = this.props;
+    const showSpecialTopic = experiments.isEnabled(experiments.special_topic);
     const numProjects = this.state.showAll
       ? NUM_PROJECTS_ON_PREVIEW
       : NUM_PROJECTS_IN_APP_VIEW;
@@ -202,19 +202,18 @@ class ProjectCardGrid extends Component {
 
         {!this.state.showAll && (
           <div>
-            {this.state.showApp === 'special_topic' &&
-              this.showSpecialTopic && (
-                <ProjectAppTypeArea
-                  labKey="special_topic"
-                  labName={i18n.projectTypeSpecialTopic()}
-                  labViewMoreString={i18n.projectsViewAll()}
-                  projectList={projectLists.special_topic}
-                  numProjectsToShow={numProjects}
-                  galleryType={this.props.galleryType}
-                  navigateFunction={this.viewAllProjects}
-                  isDetailView={false}
-                />
-              )}
+            {this.state.showApp === 'special_topic' && showSpecialTopic && (
+              <ProjectAppTypeArea
+                labKey="special_topic"
+                labName={i18n.projectTypeSpecialTopic()}
+                labViewMoreString={i18n.projectsViewAll()}
+                projectList={projectLists.special_topic}
+                numProjectsToShow={numProjects}
+                galleryType={this.props.galleryType}
+                navigateFunction={this.viewAllProjects}
+                isDetailView={false}
+              />
+            )}
             {this.state.showApp === 'dance' && (
               <ProjectAppTypeArea
                 labKey="dance"

--- a/apps/src/templates/projects/ProjectCardGrid.jsx
+++ b/apps/src/templates/projects/ProjectCardGrid.jsx
@@ -6,9 +6,11 @@ import i18n from '@cdo/locale';
 import {connect} from 'react-redux';
 import color from '../../util/color';
 import styleConstants from '../../styleConstants';
+//import experiments from '@cdo/apps/util/experiments';
 
 const NUM_PROJECTS_ON_PREVIEW = 4;
 const NUM_PROJECTS_IN_APP_VIEW = 12;
+//const showSpecialTopic = experiments.isEnabled(experiments.special_topic);
 
 const styles = {
   grid: {
@@ -39,7 +41,8 @@ class ProjectCardGrid extends Component {
       bounce: PropTypes.arrayOf(projectPropType),
       events: PropTypes.arrayOf(projectPropType),
       k1: PropTypes.arrayOf(projectPropType),
-      dance: PropTypes.arrayOf(projectPropType)
+      dance: PropTypes.arrayOf(projectPropType),
+      special_topic: PropTypes.arrayOf(projectPropType)
     }).isRequired,
     galleryType: PropTypes.oneOf(['personal', 'public']).isRequired,
     selectedGallery: PropTypes.string.isRequired,
@@ -199,6 +202,19 @@ class ProjectCardGrid extends Component {
 
         {!this.state.showAll && (
           <div>
+            {this.state.showApp === 'special_topic' &&
+              this.showSpecialTopic && (
+                <ProjectAppTypeArea
+                  labKey="special_topic"
+                  labName={i18n.projectTypeSpecialTopic()}
+                  labViewMoreString={i18n.projectsViewAll()}
+                  projectList={projectLists.special_topic}
+                  numProjectsToShow={numProjects}
+                  galleryType={this.props.galleryType}
+                  navigateFunction={this.viewAllProjects}
+                  isDetailView={false}
+                />
+              )}
             {this.state.showApp === 'dance' && (
               <ProjectAppTypeArea
                 labKey="dance"

--- a/apps/src/templates/projects/ProjectCardGrid.jsx
+++ b/apps/src/templates/projects/ProjectCardGrid.jsx
@@ -83,6 +83,17 @@ class ProjectCardGrid extends Component {
         {this.state.showAll && (
           <div>
             <ProjectAppTypeArea
+              labKey="special_topic"
+              labName={i18n.projectTypeSpecialTopic()}
+              labViewMoreString={i18n.projectTypeSpecialTopicViewMore()}
+              projectList={projectLists.special_topic}
+              numProjectsToShow={numProjects}
+              galleryType={this.props.galleryType}
+              navigateFunction={this.onSelectApp}
+              isDetailView={false}
+              hideWithoutThumbnails={true}
+            />
+            <ProjectAppTypeArea
               labKey="dance"
               labName={i18n.projectTypeDance()}
               labViewMoreString={i18n.projectTypeDanceViewMore()}

--- a/apps/src/templates/projects/ProjectCardGrid.jsx
+++ b/apps/src/templates/projects/ProjectCardGrid.jsx
@@ -95,6 +95,7 @@ class ProjectCardGrid extends Component {
               navigateFunction={this.onSelectApp}
               isDetailView={false}
               hideWithoutThumbnails={true}
+              showSpecialTopic={true}
             />
             <ProjectAppTypeArea
               labKey="dance"

--- a/apps/src/templates/projects/ProjectCardGrid.jsx
+++ b/apps/src/templates/projects/ProjectCardGrid.jsx
@@ -85,18 +85,19 @@ class ProjectCardGrid extends Component {
       <div id="projectCardGrid" style={styles.grid}>
         {this.state.showAll && (
           <div>
-            <ProjectAppTypeArea
-              labKey="special_topic"
-              labName={i18n.projectTypeSpecialTopic()}
-              labViewMoreString={i18n.projectTypeSpecialTopicViewMore()}
-              projectList={projectLists.special_topic}
-              numProjectsToShow={numProjects}
-              galleryType={this.props.galleryType}
-              navigateFunction={this.onSelectApp}
-              isDetailView={false}
-              hideWithoutThumbnails={true}
-              showSpecialTopic={true}
-            />
+            {showSpecialTopic && (
+              <ProjectAppTypeArea
+                labKey="special_topic"
+                labName={i18n.projectTypeSpecialTopic()}
+                labViewMoreString={i18n.projectTypeSpecialTopicViewMore()}
+                projectList={projectLists.special_topic}
+                numProjectsToShow={numProjects}
+                galleryType={this.props.galleryType}
+                navigateFunction={this.onSelectApp}
+                isDetailView={false}
+                hideWithoutThumbnails={true}
+              />
+            )}
             <ProjectAppTypeArea
               labKey="dance"
               labName={i18n.projectTypeDance()}

--- a/apps/src/templates/projects/PublicGallery.jsx
+++ b/apps/src/templates/projects/PublicGallery.jsx
@@ -37,6 +37,7 @@ class PublicGallery extends Component {
 
     // Provided by Redux
     projectLists: PropTypes.shape({
+      special_topic: PropTypes.arrayOf(publishedProjectPropType),
       applab: PropTypes.arrayOf(publishedProjectPropType),
       spritelab: PropTypes.arrayOf(publishedProjectPropType),
       gamelab: PropTypes.arrayOf(publishedProjectPropType),

--- a/apps/src/templates/projects/projectsRedux.js
+++ b/apps/src/templates/projects/projectsRedux.js
@@ -168,6 +168,7 @@ function projectLists(state = initialProjectListState, action) {
 // Whether there are more projects of each type on the server which are
 // older than the ones we have on the client.
 const initialHasOlderProjects = {
+  special_topic: false,
   dance: true,
   applab: true,
   spritelab: true,

--- a/apps/src/util/experiments.js
+++ b/apps/src/util/experiments.js
@@ -33,6 +33,7 @@ experiments.TIME_SPENT = 'time-spent';
 experiments.APPLAB_ML = 'applab-ml';
 experiments.BYPASS_DIALOG_POPUP = 'bypass-dialog-popup';
 experiments.SPRITELAB_PAUSE = 'spritelabPause';
+experiments.SPECIAL_TOPIC = 'special-topic';
 
 /**
  * This was a gamified version of the finish dialog, built in 2018,

--- a/dashboard/test/ui/features/learning_platform/projects/public_project_gallery_project_validator.feature
+++ b/dashboard/test/ui/features/learning_platform/projects/public_project_gallery_project_validator.feature
@@ -81,3 +81,11 @@ Scenario: Can See App Lab/Game Lab View More Links
   And the project gallery contains 9 view more links
   And element ".ui-applab" contains text "View more App Lab projects"
   And element ".ui-gamelab" contains text "View more Game Lab projects"
+
+Scenario: Can See Special Topics and View More with Experiment enabled
+  Given I am on "http://studio.code.org/projects/public/?enableExperiments=special-topic"
+  And I wait until element "#projects-page" is visible
+  Then I wait until element ".ui-project-app-type-area" is in the DOM
+  And the project gallery contains 10 project types
+  And the project gallery contains 10 view more links
+  And element ".ui-special_topic" contains text "View more Special Topic projects"


### PR DESCRIPTION
This is for the Hackathon Special Topics project. We are creating another zone in the public projects gallery for a topic of the month, and this PR represents the work needed to create the space for it on that page. 

It's currently hidden behind an experiment flag (?enableExperiments=special-topic), so will not appear unless enabled. 

PR includes a new UI test to check that this flag operates as expected, only showing all 10 modules when enabled, and hiding otherwise. 

There are currently no old projects in the server to display, nor is there a designated first topic, so the name is currently the vague "Special Topic" until otherwise designated. 
![image](https://user-images.githubusercontent.com/37230822/106053980-4db9fb00-60a0-11eb-9ece-747159ad2423.png)
