### PR TITLE
Code.org logo alt text

### DIFF
--- a/dashboard/app/views/layouts/_header.html.haml
+++ b/dashboard/app/views/layouts/_header.html.haml
@@ -72,9 +72,9 @@
       .header_left
         .header_logo
           - if current_user
-            = link_to(image_tag('logo.svg', alt: 'Code.org Home'), '/home', {id: "logo_home_link"})
+            = link_to(image_tag('logo.svg', alt: I18n.t(:code_org_logo_alt)), '/home', {id: "logo_home_link"})
           - else
-            = link_to(image_tag('logo.svg', alt: 'Code.org Home'), CDO.code_org_url, {id: "logo_home_link"})
+            = link_to(image_tag('logo.svg', alt: I18n.t(:code_org_logo_alt)), CDO.code_org_url, {id: "logo_home_link"})
 
       .header_middle{dir: locale_dir}
         - if should_show_progress || level

--- a/dashboard/app/views/layouts/_header.html.haml
+++ b/dashboard/app/views/layouts/_header.html.haml
@@ -72,9 +72,9 @@
       .header_left
         .header_logo
           - if current_user
-            = link_to(image_tag('logo.svg'), '/home', {id: "logo_home_link"})
+            = link_to(image_tag('logo.svg', alt: 'Code.org Home'), '/home', {id: "logo_home_link"})
           - else
-            = link_to(image_tag('logo.svg'), CDO.code_org_url, {id: "logo_home_link"})
+            = link_to(image_tag('logo.svg', alt: 'Code.org Home'), CDO.code_org_url, {id: "logo_home_link"})
 
       .header_middle{dir: locale_dir}
         - if should_show_progress || level

--- a/dashboard/config/locales/en.yml
+++ b/dashboard/config/locales/en.yml
@@ -1166,3 +1166,4 @@ en:
   behaviors:
     this_sprite: "this sprite"
   unit_prefix: "Unit %{n}"
+  code_org_logo_alt: "Code.org Home"


### PR DESCRIPTION
Part of Navigation accessibility work for Jan 2021 Hackathon. Before, Code.org logo read as "Visited Link" in my local screenreader. Now it reads as "Code.org Home Visited Link" to represent what the link does. Followed these instructions for logo link best practices: https://www.w3.org/WAI/tutorials/images/functional/

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
