### PR TITLE
Nav Bar Create Button Screen Reader Accessible

### DIFF
--- a/dashboard/app/assets/stylesheets/application.scss
+++ b/dashboard/app/assets/stylesheets/application.scss
@@ -284,6 +284,16 @@ img.video_thumbnail {
     }
   }
 
+  .create_menu {
+    box-shadow: none;
+    // button:active in this file uses !important for a styling scheme that doesn't
+    // match this button. We use !important here to override that scheme for only this
+    // specific button.
+    &:active {
+      border: 2px solid $white !important;
+    }
+  }
+
   .user_menu, .create_menu, .help_button {
     margin-top: 6px;
     .create_button, .display_name, .pairing_name {

--- a/shared/css/user-menu.scss
+++ b/shared/css/user-menu.scss
@@ -135,6 +135,9 @@
 }
 
 .create_menu {
+  &:focus {
+    outline: none;
+  }
   .create_options {
     width: max-content;
     z-index: 10000;

--- a/shared/css/user-menu.scss
+++ b/shared/css/user-menu.scss
@@ -135,9 +135,6 @@
 }
 
 .create_menu {
-  &:focus {
-    outline: none;
-  }
   .create_options {
     width: max-content;
     z-index: 10000;

--- a/shared/css/user-menu.scss
+++ b/shared/css/user-menu.scss
@@ -139,6 +139,8 @@
     width: max-content;
     z-index: 10000;
     border-bottom: 0;
+    display: flex;
+    flex-direction: column;
     a {
       font-family: 'Gotham 5r', sans-serif;
       min-width: 240px;
@@ -151,14 +153,16 @@
     img {
       height: 70px;
       width: 70px;
+      float: left;
     }
     .project_link_box {
       display: block;
     }
     .project_link {
       display: inline-block;
-      padding: 0 10px 0 4px;
-      line-height: 67px;
+      padding: 0 10px 0 8px;
+      line-height: 70px;
+      float: left;
     }
     #view_all_projects {
       height: 70px;

--- a/shared/haml/user_header.haml
+++ b/shared/haml/user_header.haml
@@ -135,13 +135,11 @@
       });
     });
 
-    function hideCreateOptions(event) {
-      if ((event.type === "keypress" && event.which === 13) || (event.type === "click")) {
-        $('.create_options').slideUp();
-        $('.create_menu_arrow_down').show();
-        $('.create_menu_arrow_up').hide();
-        $(document).off('click', hideCreateOptions);
-      }
+    function hideCreateOptions() {
+      $('.create_options').slideUp();
+      $('.create_menu_arrow_down').show();
+      $('.create_menu_arrow_up').hide();
+      $(document).off('click', hideCreateOptions);
     }
     $(document).ready(function() {
       $('.create_menu').click(function(e) {
@@ -150,12 +148,14 @@
           $('.create_options').slideDown();
           $('.create_menu_arrow_down').hide();
           $('.create_menu_arrow_up').show();
-          $(document).on('keypress click', (e) => hideCreateOptions(e));
+          $(document).on('keypress click', hideCreateOptions);
           hideUserOptions()
           $("#hamburger-icon").removeClass('active');
           $("#help-icon").removeClass('active');
           $('#hamburger #hamburger-contents').slideUp();
           $('#help-button #help-contents').slideUp();
+        } else {
+          hideCreateOptions();
         }
       });
       $('.create_options').click(function (e) {

--- a/shared/haml/user_header.haml
+++ b/shared/haml/user_header.haml
@@ -142,18 +142,20 @@
       $(document).off('click', hideCreateOptions);
     }
     $(document).ready(function() {
-      $('.create_menu').click(function (e) {
-        if ($('.create_options').is(':hidden')) {
-          e.stopPropagation();
-          $('.create_options').slideDown();
-          $('.create_menu_arrow_down').hide();
-          $('.create_menu_arrow_up').show();
-          $(document).on('click', hideCreateOptions);
-          hideUserOptions()
-          $("#hamburger-icon").removeClass('active');
-          $("#help-icon").removeClass('active');
-          $('#hamburger #hamburger-contents').slideUp();
-          $('#help-button #help-contents').slideUp();
+      $('.create_menu').on("keypress click", function(e) {
+        if ((e.type === "keypress" && e.which === 13) || (e.type === "click")) {
+          if ($('.create_options').is(':hidden')) {
+            e.stopPropagation();
+            $('.create_options').slideDown();
+            $('.create_menu_arrow_down').hide();
+            $('.create_menu_arrow_up').show();
+            $(document).on('click', hideCreateOptions);
+            hideUserOptions()
+            $("#hamburger-icon").removeClass('active');
+            $("#help-icon").removeClass('active');
+            $('#hamburger #hamburger-contents').slideUp();
+            $('#help-button #help-contents').slideUp();
+          }
         }
       });
       $('.create_options').click(function (e) {

--- a/shared/haml/user_header.haml
+++ b/shared/haml/user_header.haml
@@ -142,7 +142,7 @@
       $(document).off('click', hideCreateOptions);
     }
     $(document).ready(function() {
-      $('.create_menu').click(function(e) {
+      $('.create_menu').click(function (e) {
         if ($('.create_options').is(':hidden')) {
           e.stopPropagation();
           $('.create_options').slideDown();

--- a/shared/haml/user_header.haml
+++ b/shared/haml/user_header.haml
@@ -18,7 +18,7 @@
   should_show_create_menu = !level || level.try(:is_project_level)
 
 - if should_show_create_menu
-  .header_button.create_menu{tabindex: 0}
+  %button.header_button.create_menu{tabindex: 0}
     %span.create_button
       = I18n.t("#{loc_prefix}create")
     &nbsp;
@@ -144,8 +144,7 @@
       }
     }
     $(document).ready(function() {
-      $('.create_menu').on("keypress click", function(e) {
-        if ((e.type === "keypress" && e.which === 13) || (e.type === "click")) {
+      $('.create_menu').click( function(e) {
           if ($('.create_options').is(':hidden')) {
             e.stopPropagation();
             $('.create_options').slideDown();
@@ -158,7 +157,6 @@
             $('#hamburger #hamburger-contents').slideUp();
             $('#help-button #help-contents').slideUp();
           }
-        }
       });
       $('.create_options').click(function (e) {
         e.stopPropagation(); // Clicks inside the popup shouldn't close it

--- a/shared/haml/user_header.haml
+++ b/shared/haml/user_header.haml
@@ -135,11 +135,13 @@
       });
     });
 
-    function hideCreateOptions() {
-      $('.create_options').slideUp();
-      $('.create_menu_arrow_down').show();
-      $('.create_menu_arrow_up').hide();
-      $(document).off('click', hideCreateOptions);
+    function hideCreateOptions(event) {
+      if ((event.type === "keypress" && event.which === 13) || (event.type === "click")) {
+        $('.create_options').slideUp();
+        $('.create_menu_arrow_down').show();
+        $('.create_menu_arrow_up').hide();
+        $(document).off('click', hideCreateOptions);
+      }
     }
     $(document).ready(function() {
       $('.create_menu').on("keypress click", function(e) {
@@ -149,7 +151,7 @@
             $('.create_options').slideDown();
             $('.create_menu_arrow_down').hide();
             $('.create_menu_arrow_up').show();
-            $(document).on('click', hideCreateOptions);
+            $(document).on('keypress click', (e) => hideCreateOptions(e));
             hideUserOptions()
             $("#hamburger-icon").removeClass('active');
             $("#help-icon").removeClass('active');

--- a/shared/haml/user_header.haml
+++ b/shared/haml/user_header.haml
@@ -18,7 +18,7 @@
   should_show_create_menu = !level || level.try(:is_project_level)
 
 - if should_show_create_menu
-  %button.header_button.create_menu{tabindex: 0}
+  %button.header_button.create_menu
     %span.create_button
       = I18n.t("#{loc_prefix}create")
     &nbsp;

--- a/shared/haml/user_header.haml
+++ b/shared/haml/user_header.haml
@@ -144,19 +144,19 @@
       }
     }
     $(document).ready(function() {
-      $('.create_menu').click( function(e) {
-          if ($('.create_options').is(':hidden')) {
-            e.stopPropagation();
-            $('.create_options').slideDown();
-            $('.create_menu_arrow_down').hide();
-            $('.create_menu_arrow_up').show();
-            $(document).on('keypress click', (e) => hideCreateOptions(e));
-            hideUserOptions()
-            $("#hamburger-icon").removeClass('active');
-            $("#help-icon").removeClass('active');
-            $('#hamburger #hamburger-contents').slideUp();
-            $('#help-button #help-contents').slideUp();
-          }
+      $('.create_menu').click(function(e) {
+        if ($('.create_options').is(':hidden')) {
+          e.stopPropagation();
+          $('.create_options').slideDown();
+          $('.create_menu_arrow_down').hide();
+          $('.create_menu_arrow_up').show();
+          $(document).on('keypress click', (e) => hideCreateOptions(e));
+          hideUserOptions()
+          $("#hamburger-icon").removeClass('active');
+          $("#help-icon").removeClass('active');
+          $('#hamburger #hamburger-contents').slideUp();
+          $('#help-button #help-contents').slideUp();
+        }
       });
       $('.create_options').click(function (e) {
         e.stopPropagation(); // Clicks inside the popup shouldn't close it

--- a/shared/haml/user_header.haml
+++ b/shared/haml/user_header.haml
@@ -18,7 +18,7 @@
   should_show_create_menu = !level || level.try(:is_project_level)
 
 - if should_show_create_menu
-  .header_button.create_menu
+  .header_button.create_menu{tabindex: 0}
     %span.create_button
       = I18n.t("#{loc_prefix}create")
     &nbsp;


### PR DESCRIPTION
Accessibility work. Part of hackathon project for making nav bar screen reader accessible.

This PR: 
* adds a tab index to the "create" "button" to make it accessible via keyboard navigation.
* adds the ability to expand the "create" 'button' dropdown with an "enter" keypress.

When tested through my local screenreader this allowed me to navigate to a Dance party project through the create button via keyboard navigation and have the button and link text read to me.

I followed this document to guide these changes: https://a11y-guidelines.orange.com/en/web/components-examples/dropdown-menu/#

I tested this in a RTL language and with an extra long Lab name (in case of long translations).

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
