### PR TITLE
Allow video in SMS message

### DIFF
--- a/dashboard/app/controllers/sms_controller.rb
+++ b/dashboard/app/controllers/sms_controller.rb
@@ -4,7 +4,16 @@ class SmsController < ApplicationController
 
   # set up a client to talk to the Twilio REST API
   def send_to_phone
-    if params[:level_source] && !params[:level_source].empty? && params[:phone] && (level_source = LevelSource.find(params[:level_source]))
+    #if params[:song]
+    if true
+      #open_tik_tok_url = params[:song]
+      open_tik_tok_url = 'https://www.tiktok.com/music/Level-Up-6580213968705424134?lang=en&is_copy_url=1'
+      #video_url = "https://dance-api.code.org/videos/video-#{params[:channel_id]}.mp4"
+      video_url = 'https://dance-api.code.org/videos/video-h4sxJYdlWGggroG0DRR9ug.mp4'
+      message_body = "Here's your Dance Party video! Save this video and open in TikTok here to upload: #{open_tik_tok_url}"
+
+      send_sms(message_body, params[:phone], video_url)
+    elsif params[:level_source] && !params[:level_source].empty? && params[:phone] && (level_source = LevelSource.find(params[:level_source]))
       send_sms_link(level_source_url(level_source), params[:phone])
     elsif params[:channel_id] && params[:phone] && ProjectsController::STANDALONE_PROJECTS.include?(params[:type])
       url =
@@ -31,18 +40,25 @@ class SmsController < ApplicationController
     send_sms(body, phone)
   end
 
-  def send_sms(body, phone)
+  def send_sms(body, phone, media_url=nil)
     # If the Twilio WebService is unavailable or experiencing latency issues we can no-op this method to avoid
     # tie-ing up all puma worker threads waiting for the Twilio API to respond by switching a Gatekeeper flag.
     return head :ok unless Gatekeeper.allows('twilio', default: true)
 
     http_client = Twilio::HTTP::Client.new(timeout: DCDO.get('webpurify_http_read_timeout', 10))
     @client = Twilio::REST::Client.new CDO.twilio_sid, CDO.twilio_auth, nil, nil, http_client
-    @client.messages.create(
+
+    text_message_parameters = {
       messaging_service_sid: CDO.twilio_messaging_service,
       to: phone,
       body: body
+    }
+    text_message_parameters[:media_url] = media_url if media_url
+
+    @client.messages.create(
+      text_message_parameters
     )
+
     head :ok
   rescue Twilio::REST::RestError => e
     if e.message =~ /The message From\/To pair violates a blacklist rule./


### PR DESCRIPTION
Allows a text message to be sent with a video. Makes this determination by whether the params in the request include a "song" field, which I'm thinking we can include the string for the TikTok URL that we want to be opened when a Dance Party project with a given song is sent to phone?

Not super elegant logically but I think works for now.

Note that we'll have to go into S3 web console to manually change content type for any project that we want to have this feature work for.