### PR TITLE
Match dance party songs to tiktok links

### DIFF
--- a/apps/src/code-studio/components/SendToPhone.jsx
+++ b/apps/src/code-studio/components/SendToPhone.jsx
@@ -2,6 +2,7 @@ import $ from 'jquery';
 import PropTypes from 'prop-types';
 import React from 'react';
 import trackEvent from '../../util/trackEvent';
+import {songTikTokLinks} from '../../dance/constants';
 
 // Similar UI exists in sharing.html.ejs. At some point int he future, it may
 // make sense to see if we can get rid of the stuff in the .ejs file
@@ -44,6 +45,7 @@ export default class SendToPhone extends React.Component {
     channelId: PropTypes.string,
     downloadUrl: PropTypes.string,
     appType: PropTypes.string.isRequired,
+    selectedSong: PropTypes.string,
     styles: PropTypes.shape({
       label: PropTypes.object,
       div: PropTypes.object
@@ -74,7 +76,13 @@ export default class SendToPhone extends React.Component {
   }
 
   handleSubmit = () => {
-    const {appType, channelId, isLegacyShare, downloadUrl} = this.props;
+    const {
+      appType,
+      channelId,
+      isLegacyShare,
+      downloadUrl,
+      selectedSong
+    } = this.props;
     // Do nothing if we aren't in a state where we can send.
     if (this.state.sendState !== SendState.canSubmit) {
       return;
@@ -93,6 +101,10 @@ export default class SendToPhone extends React.Component {
       params.url = downloadUrl;
     } else {
       params.channel_id = channelId;
+    }
+
+    if (selectedSong) {
+      params.song = songTikTokLinks[selectedSong].link;
     }
 
     const apiUrl = downloadUrl ? '/sms/send_download' : '/sms/send';

--- a/apps/src/code-studio/components/ShareAllowedDialog.jsx
+++ b/apps/src/code-studio/components/ShareAllowedDialog.jsx
@@ -523,6 +523,7 @@ class ShareAllowedDialog extends React.Component {
                           channelId={this.props.channelId}
                           appType={this.props.appType}
                           isLegacyShare={false}
+                          selectedSong={this.props.selectedSong}
                         />
                       </div>
                     </div>

--- a/apps/src/dance/constants.js
+++ b/apps/src/dance/constants.js
@@ -28,3 +28,168 @@ export const DancelabReservedWords = [
   'everySecondsRange',
   'everyVerseChorus'
 ];
+
+export const songTikTokLinks = {
+  introtoshamstep_47SOUL: {
+    link: 'https://vm.tiktok.com/ZMJEW69pm/'
+  },
+  isawthesign_aceofbase: {
+    link: 'https://vm.tiktok.com/ZMJEpG7QA/'
+  },
+  takeonme_aha: {
+    link: 'https://vm.tiktok.com/ZMJEpEv7x/'
+  },
+  showdaspoderosas_anitta: {
+    link: 'https://vm.tiktok.com/ZMJEsPdnp/'
+  },
+  jinglebells_hollywoodchristmas: {
+    link: 'https://vm.tiktok.com/ZMJEW69pm/'
+  },
+  notearslefttocry_arianagrande: {
+    link: 'https://vm.tiktok.com/ZMJEW69pm/'
+  },
+  wakemeup_aviciialoeblacc: {
+    link: 'https://vm.tiktok.com/ZMJEsr1NB/'
+  },
+  odetocode_brendandominicpaolini: {
+    link: 'https://vm.tiktok.com/ZMJEW69pm/'
+  },
+  dancinginthedark_brucespringsteen: {
+    link: 'https://vm.tiktok.com/ZMJEsDcLG/'
+  },
+  summer_calvinharris: {
+    link: 'https://vm.tiktok.com/ZMJEsSb21/'
+  },
+  callmemaybe_carlyraejepsen: {
+    link: 'https://vm.tiktok.com/ZMJEsw9un/'
+  },
+  levelup_ciara: {
+    link: 'https://vm.tiktok.com/ZMJEWrpyy/'
+  },
+  vivalavida_coldplay: {
+    link: 'https://vm.tiktok.com/ZMJEsw9un/'
+  },
+  sayso_dojacat: {
+    link: 'https://vm.tiktok.com/ZMJEW69pm/'
+  },
+  dontstartnow_dualipa: {
+    link: 'https://vm.tiktok.com/ZMJEW69pm/'
+  },
+  shapeofyou_edsheeran: {
+    link: 'https://vm.tiktok.com/ZMJEsG4Qu/'
+  },
+  occidentalview_francescogabbani: {
+    link: 'https://vm.tiktok.com/ZMJEW69pm/'
+  },
+  thunder_imaginedragons: {
+    link: 'https://vm.tiktok.com/ZMJEsWKV7/'
+  },
+  dernieredanse_indila: {
+    link: 'https://vm.tiktok.com/ZMJEW69pm/'
+  },
+  migente_jbalvin: {
+    link: 'https://vm.tiktok.com/ZMJEswNK6/'
+  },
+  savagelove_jasonderulo: {
+    link: 'https://vm.tiktok.com/ZMJEW69pm/'
+  },
+  sucker_jonasbrothers: {
+    link: 'https://vm.tiktok.com/ZMJEW69pm/'
+  },
+  sorry_justinbieber: {
+    link: 'https://vm.tiktok.com/ZMJEs7kD2/'
+  },
+  firework_katyperry: {
+    link: 'https://vm.tiktok.com/ZMJEGhJgg/'
+  },
+  neverreallyover_katyperry: {
+    link: 'https://vm.tiktok.com/ZMJEW69pm/'
+  },
+  somebodylikeyou_keithurban: {
+    link: 'https://vm.tiktok.com/ZMJEW69pm/'
+  },
+  ilkadimisenat_kenandogulu: {
+    link: 'https://vm.tiktok.com/ZMJEW69pm/'
+  },
+  kidzbop_ificanthaveyou_shawnmendes: {
+    link: 'https://vm.tiktok.com/ZMJEW69pm/'
+  },
+  needyounow_ladyantebellum: {
+    link: 'https://vm.tiktok.com/ZMJEW69pm/'
+  },
+  bornthisway_ladygaga: {
+    link: 'https://vm.tiktok.com/ZMJEGURGj/'
+  },
+  rainonme_ladygagaftarianagrande: {
+    link: 'https://vm.tiktok.com/ZMJEW69pm/'
+  },
+  oldtownroadremix_lilnasx: {
+    link: 'https://vm.tiktok.com/ZMJEW69pm/'
+  },
+  oldtownroadremix_lilnasx_long: {
+    link: 'https://vm.tiktok.com/ZMJEW69pm/'
+  },
+  euphoria_loreen: {
+    link: 'https://vm.tiktok.com/ZMJEW69pm/'
+  },
+  macarena_losdelrio: {
+    link: 'https://vm.tiktok.com/ZMJEW69pm/'
+  },
+  countrygirl_lukebryan: {
+    link: 'https://vm.tiktok.com/ZMJEW69pm/'
+  },
+  cantholdus_macklemore: {
+    link: 'https://vm.tiktok.com/ZMJEW69pm/'
+  },
+  getintothegroove_madonna: {
+    link: 'https://vm.tiktok.com/ZMJEW69pm/'
+  },
+  uptownfunk_brunomars: {
+    link: 'https://vm.tiktok.com/ZMJEW69pm/'
+  },
+  jerusalema_masterkg: {
+    link: 'https://vm.tiktok.com/ZMJEW69pm/'
+  },
+  canttouchthis_mchammer: {
+    link: 'https://vm.tiktok.com/ZMJEW69pm/'
+  },
+  wecantstop_mileycyrus: {
+    link: 'https://vm.tiktok.com/ZMJEW69pm/'
+  },
+  starships_nickiminaj: {
+    link: 'https://vm.tiktok.com/ZMJEW69pm/'
+  },
+  heyya_outkast: {
+    link: 'https://vm.tiktok.com/ZMJEW69pm/'
+  },
+  highhopes_panicatthedisco: {
+    link: 'https://vm.tiktok.com/ZMJEW69pm/'
+  },
+  calma_pedrocapo: {
+    link: 'https://vm.tiktok.com/ZMJEW69pm/'
+  },
+  backtoyou_selenagomez: {
+    link: 'https://vm.tiktok.com/ZMJEW69pm/'
+  },
+  ificanthaveyou_shawnmendes: {
+    link: 'https://vm.tiktok.com/ZMJEW69pm/'
+  },
+  cheapthrills_sia: {
+    link: 'https://vm.tiktok.com/ZMJEW69pm/'
+  },
+  dancemonkey_tonesandi: {
+    link: 'https://vm.tiktok.com/ZMJEW69pm/'
+  },
+  ymca_villagepeople: {
+    link: 'https://vm.tiktok.com/ZMJEW69pm/'
+  },
+  cantfeelmyface_theweeknd: {
+    link: 'https://vm.tiktok.com/ZMJEW69pm/'
+  },
+  iliketomoveit_william: {
+    link: 'https://vm.tiktok.com/ZMJEW69pm/'
+  },
+  wenospeakamericano_yolandabecool: {
+    link: 'https://vm.tiktok.com/ZMJEW69pm/'
+  }
+};

--- a/dashboard/app/controllers/sms_controller.rb
+++ b/dashboard/app/controllers/sms_controller.rb
@@ -4,14 +4,10 @@ class SmsController < ApplicationController
 
   # set up a client to talk to the Twilio REST API
   def send_to_phone
-    #if params[:song]
-    if true
-      #open_tik_tok_url = params[:song]
-      open_tik_tok_url = 'https://www.tiktok.com/music/Level-Up-6580213968705424134?lang=en&is_copy_url=1'
-      #video_url = "https://dance-api.code.org/videos/video-#{params[:channel_id]}.mp4"
-      video_url = 'https://dance-api.code.org/videos/video-h4sxJYdlWGggroG0DRR9ug.mp4'
+    if params[:song]
+      open_tik_tok_url = params[:song]
+      video_url = "https://dance-api.code.org/videos/video-#{params[:channel_id]}.mp4"
       message_body = "Here's your Dance Party video! Save this video and open in TikTok here to upload: #{open_tik_tok_url}"
-
       send_sms(message_body, params[:phone], video_url)
     elsif params[:level_source] && !params[:level_source].empty? && params[:phone] && (level_source = LevelSource.find(params[:level_source]))
       send_sms_link(level_source_url(level_source), params[:phone])


### PR DESCRIPTION
This adds a link between songs in dance party and their links to tiktok. [this sheet](https://docs.google.com/spreadsheets/d/1APWGtsENVIVAZmj_GQo2-Qo57RsXzJ71GYfGodawqbk/edit#gid=0) has all of the links we have so far and I added a placeholder song for anything that's missing.

Note: I don't have twilio set up on my localhost so I've only tested to make sure the open_tik_tok_url, video_url, and message_body are correct.

<!-- ### Background -->
<!-- ### Privacy -->
<!--
1.	Does the Project involve the collection, use or sharing of new Personal Data?

2.	Does the Project involve a new or changed use or sharing of existing Personal Data?
-->
<!-- ### Security -->
<!--
Link to Jira Task where sensitive security issues are discussed privately.
-->
<!-- ### Caching -->
<!-- ### Deployment strategy -->
<!-- ### Future work -->

## Links

<!--
  Any relevant links to external resources; ie, specification documents, jira
  items, related PRs, honeybadger errors, etc
-->

## Testing story

<!--
  Does your change include appropriate tests?

  If so, please describe how the tests included in this PR are sufficient

  If not, please explain why this change does not need to be tested.
-->

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
