### PR TITLE
replace context with provider in tests

### DIFF
--- a/apps/test/unit/templates/CertificateTest.js
+++ b/apps/test/unit/templates/CertificateTest.js
@@ -1,12 +1,23 @@
 import React from 'react';
-import {shallow} from 'enzyme';
-import {expect} from '../../util/deprecatedChai';
+import {Provider} from 'react-redux';
+import {mount} from 'enzyme';
+import {expect} from '../../util/reconfiguredChai';
 import Certificate from '@cdo/apps/templates/Certificate';
 import {combineReducers, createStore} from 'redux';
 import responsive from '@cdo/apps/code-studio/responsiveRedux';
+import isRtl from '@cdo/apps/code-studio/isRtlRedux';
+
+const store = createStore(combineReducers({responsive, isRtl}));
+
+function wrapperWithTutorial(tutorial) {
+  return mount(
+    <Provider store={store}>
+      <Certificate tutorial={tutorial} />
+    </Provider>
+  );
+}
 
 describe('Certificate', () => {
-  const store = createStore(combineReducers({responsive}));
   let storedWindowDashboard;
 
   beforeEach(() => {
@@ -21,36 +32,28 @@ describe('Certificate', () => {
   });
 
   it('renders Minecraft certificate for Minecraft Adventurer', () => {
-    const wrapper = shallow(<Certificate tutorial="mc" />, {
-      context: {store}
-    }).dive();
+    const wrapper = wrapperWithTutorial('mc');
     expect(wrapper.find('img').html()).to.include(
       'MC_Hour_Of_Code_Certificate'
     );
   });
 
   it('renders Minecraft certificate for Minecraft Designer', () => {
-    const wrapper = shallow(<Certificate tutorial="minecraft" />, {
-      context: {store}
-    }).dive();
+    const wrapper = wrapperWithTutorial('minecraft');
     expect(wrapper.find('img').html()).to.include(
       'MC_Hour_Of_Code_Certificate'
     );
   });
 
   it("renders unique certificate for Minecraft Hero's Journey", () => {
-    const wrapper = shallow(<Certificate tutorial="hero" />, {
-      context: {store}
-    }).dive();
+    const wrapper = wrapperWithTutorial('hero');
     expect(wrapper.find('img').html()).to.include(
       'MC_Hour_Of_Code_Certificate_Hero'
     );
   });
 
   it('renders unique certificate for Minecraft Voyage Aquatic', () => {
-    const wrapper = shallow(<Certificate tutorial="aquatic" />, {
-      context: {store}
-    }).dive();
+    const wrapper = wrapperWithTutorial('aquatic');
     expect(wrapper.find('img').html()).to.include(
       'MC_Hour_Of_Code_Certificate_Aquatic'
     );
@@ -58,9 +61,7 @@ describe('Certificate', () => {
 
   it('renders default certificate for all other tutorials', () => {
     ['applab-intro', 'dance', 'flappy', 'frozen'].forEach(tutorial => {
-      const wrapper = shallow(<Certificate tutorial={tutorial} />, {
-        context: {store}
-      }).dive();
+      const wrapper = wrapperWithTutorial(tutorial);
       expect(wrapper.find('img').html()).to.include('hour_of_code_certificate');
     });
   });

--- a/apps/test/unit/templates/HeaderBannerTest.js
+++ b/apps/test/unit/templates/HeaderBannerTest.js
@@ -1,6 +1,7 @@
 import React from 'react';
-import {shallow} from 'enzyme';
-import {expect} from '../../util/deprecatedChai';
+import {Provider} from 'react-redux';
+import {mount} from 'enzyme';
+import {expect} from '../../util/reconfiguredChai';
 import HeaderBanner from '@cdo/apps/templates/HeaderBanner';
 import {combineReducers, createStore} from 'redux';
 import responsive, {
@@ -9,83 +10,92 @@ import responsive, {
 } from '@cdo/apps/code-studio/responsiveRedux';
 import styleConstants from '@cdo/apps/styleConstants';
 
-describe('HeaderBanner', () => {
-  const store = createStore(combineReducers({responsive}));
-  store.dispatch(setResponsiveSize(ResponsiveSize.lg));
+const store = createStore(combineReducers({responsive}));
+store.dispatch(setResponsiveSize(ResponsiveSize.lg));
 
+function wrapperWithProps(short, subheading, description) {
+  return mount(
+    <Provider store={store}>
+      <HeaderBanner
+        headingText="Home"
+        subHeadingText={subheading}
+        description={description}
+        short={short}
+      />
+    </Provider>
+  );
+}
+
+describe('HeaderBanner', () => {
   it('renders a short HeaderBanner without a subheading or description', () => {
-    const wrapper = shallow(<HeaderBanner headingText="Home" short={true} />, {
-      context: {store}
-    });
-    expect(wrapper.dive()).to.containMatchingElement(
-      <div>
-        <div
-          style={{
-            minHeight: 140,
-            maxWidth: styleConstants['content-width']
-          }}
-        >
-          <div>
-            <div>Home</div>
+    const wrapper = wrapperWithProps(true);
+    expect(
+      wrapper.containsMatchingElement(
+        <div>
+          <div
+            style={{
+              minHeight: 140,
+              maxWidth: styleConstants['content-width']
+            }}
+          >
+            <div>
+              <div>Home</div>
+            </div>
           </div>
         </div>
-      </div>
+      )
     );
   });
 
   it('renders a short HeaderBanner with a subheading', () => {
-    const wrapper = shallow(
-      <HeaderBanner
-        headingText="Home"
-        subHeadingText="This is where you can find useful information."
-        short={true}
-      />,
-      {context: {store}}
+    const wrapper = wrapperWithProps(
+      true,
+      'This is where you can find useful information.'
     );
-    expect(wrapper.dive()).to.containMatchingElement(
-      <div>
-        <div
-          style={{
-            minHeight: 140,
-            maxWidth: styleConstants['content-width']
-          }}
-        >
-          <div>
-            <div>Home</div>
-            <div>This is where you can find useful information.</div>
+    expect(
+      wrapper.containsMatchingElement(
+        <div>
+          <div
+            style={{
+              minHeight: 140,
+              maxWidth: styleConstants['content-width']
+            }}
+          >
+            <div>
+              <div>Home</div>
+              <div>This is where you can find useful information.</div>
+            </div>
           </div>
         </div>
-      </div>
+      )
     );
   });
 
   it('renders an extended HeaderBanner with a subheading and description', () => {
-    const wrapper = shallow(
-      <HeaderBanner
-        headingText="Home"
-        subHeadingText="This is where you can find useful information."
-        description="Everything on the page is customized to you and easy to find."
-        short={false}
-      />,
-      {context: {store}}
+    const wrapper = wrapperWithProps(
+      false,
+      'This is where you can find useful information.',
+      'Everything on the page is customized to you and easy to find.'
     );
-    expect(wrapper.dive()).to.containMatchingElement(
-      <div>
-        <div
-          style={{
-            minHeight: 260,
-            maxWidth: styleConstants['content-width']
-          }}
-        >
-          <div>
-            <div>Home</div>
-            <div>This is where you can find useful information.</div>
+    expect(
+      wrapper.containsMatchingElement(
+        <div>
+          <div
+            style={{
+              minHeight: 260,
+              maxWidth: styleConstants['content-width']
+            }}
+          >
             <div>
-              Everything on the page is customized to you and easy to find.
+              <div>Home</div>
+              <div>This is where you can find useful information.</div>
+              <div>
+                Everything on the page is customized to you and easy to find.
+              </div>
             </div>
           </div>
         </div>
-      </div>
+      )
     );
   });
 });

--- a/apps/test/unit/templates/NotificationTest.js
+++ b/apps/test/unit/templates/NotificationTest.js
@@ -1,5 +1,6 @@
 import React from 'react';
-import {shallow} from 'enzyme';
+import {Provider} from 'react-redux';
+import {mount} from 'enzyme';
 import {expect} from '../../util/deprecatedChai';
 import Notification from '@cdo/apps/templates/Notification';
 import Button from '@cdo/apps/templates//Button';
@@ -59,11 +60,15 @@ const findCourse = {
   dismissible: false
 };
 
-describe('Notification', () => {
-  const store = createStore(combineReducers({isRtl}));
+const store = createStore(combineReducers({isRtl}));
 
+function wrapped(element) {
+  return mount(<Provider store={store}>{element}</Provider>);
+}
+
+describe('Notification', () => {
   it('renders an announcement notification', () => {
-    const wrapper = shallow(
+    const wrapper = wrapped(
       <Notification
         type="bullhorn"
         notice={announcement.heading}
@@ -73,36 +78,37 @@ describe('Notification', () => {
         buttonLink={announcement.link}
         newWindow={true}
         analyticId={announcement.id}
-      />,
-      {context: {store}}
-    ).dive();
-    expect(wrapper).to.containMatchingElement(
-      <div>
+      />
+    );
+    expect(
+      wrapper.containsMatchingElement(
         <div>
           <div>
-            <FontAwesome icon="bullhorn" />
-          </div>
-          <div>
             <div>
-              <div>{announcement.heading}</div>
-              <div>{announcement.description}</div>
+              <FontAwesome icon="bullhorn" />
             </div>
             <div>
-              <Button
-                __useDeprecatedTag
-                href={announcement.link}
-                text={announcement.buttonText}
-                target="_blank"
-              />
+              <div>
+                <div>{announcement.heading}</div>
+                <div>{announcement.description}</div>
+              </div>
+              <div>
+                <Button
+                  __useDeprecatedTag
+                  href={announcement.link}
+                  text={announcement.buttonText}
+                  target="_blank"
+                />
+              </div>
             </div>
           </div>
+          <div />
         </div>
-        <div />
-      </div>
+      )
     );
   });
   it('renders an announcement notification with no button because no link provided', () => {
-    const wrapper = shallow(
+    const wrapper = wrapped(
       <Notification
         type="bullhorn"
         notice={announcementNoLink.heading}
@@ -112,141 +118,146 @@ describe('Notification', () => {
         buttonLink={announcementNoLink.link}
         newWindow={true}
         analyticId={announcementNoLink.id}
-      />,
-      {context: {store}}
-    ).dive();
-    expect(wrapper).to.containMatchingElement(
-      <div>
+      />
+    );
+    expect(
+      wrapper.containsMatchingElement(
         <div>
           <div>
-            <FontAwesome icon="bullhorn" />
-          </div>
-          <div>
             <div>
-              <div>{announcementNoLink.heading}</div>
-              <div>{announcementNoLink.description}</div>
+              <FontAwesome icon="bullhorn" />
             </div>
-            <div />
+            <div>
+              <div>
+                <div>{announcementNoLink.heading}</div>
+                <div>{announcementNoLink.description}</div>
+              </div>
+              <div />
+            </div>
           </div>
+          <div />
         </div>
-        <div />
-      </div>
+      )
     );
   });
   it('renders an information notification', () => {
-    const wrapper = shallow(
+    const wrapper = wrapped(
       <Notification
         type="information"
         notice={information.notice}
         details={information.details}
         dismissible={false}
-      />,
-      {context: {store}}
-    ).dive();
-    expect(wrapper).to.containMatchingElement(
-      <div>
+      />
+    );
+    expect(
+      wrapper.containsMatchingElement(
         <div>
           <div>
-            <FontAwesome icon="info-circle" />
-          </div>
-          <div>
             <div>
-              <div>{information.notice}</div>
-              <div>{information.details}</div>
+              <FontAwesome icon="info-circle" />
             </div>
-            <div />
+            <div>
+              <div>
+                <div>{information.notice}</div>
+                <div>{information.details}</div>
+              </div>
+              <div />
+            </div>
           </div>
+          <div />
         </div>
-        <div />
-      </div>
+      )
     );
   });
   it('renders a success notification', () => {
-    const wrapper = shallow(
+    const wrapper = wrapped(
       <Notification
         type="success"
         notice={success.notice}
         details={success.details}
         dismissible={false}
-      />,
-      {context: {store}}
-    ).dive();
-    expect(wrapper).to.containMatchingElement(
-      <div>
+      />
+    );
+    expect(
+      wrapper.containsMatchingElement(
         <div>
           <div>
-            <FontAwesome icon="check-circle" />
-          </div>
-          <div>
             <div>
-              <div>{success.notice}</div>
-              <div>{success.details}</div>
+              <FontAwesome icon="check-circle" />
             </div>
-            <div />
+            <div>
+              <div>
+                <div>{success.notice}</div>
+                <div>{success.details}</div>
+              </div>
+              <div />
+            </div>
           </div>
+          <div />
         </div>
-        <div />
-      </div>
+      )
     );
   });
   it('renders a failure notification', () => {
-    const wrapper = shallow(
+    const wrapper = wrapped(
       <Notification
         type="failure"
         notice={failure.notice}
         details={failure.details}
         dismissible={false}
-      />,
-      {context: {store}}
-    ).dive();
-    expect(wrapper).to.containMatchingElement(
-      <div>
+      />
+    );
+    expect(
+      wrapper.containsMatchingElement(
         <div>
           <div>
-            <FontAwesome icon="exclamation-triangle" />
-          </div>
-          <div>
             <div>
-              <div>{failure.notice}</div>
-              <div>{failure.details}</div>
+              <FontAwesome icon="exclamation-triangle" />
             </div>
-            <div />
+            <div>
+              <div>
+                <div>{failure.notice}</div>
+                <div>{failure.details}</div>
+              </div>
+              <div />
+            </div>
           </div>
+          <div />
         </div>
-        <div />
-      </div>
+      )
     );
   });
   it('renders a warning notification', () => {
-    const wrapper = shallow(
+    const wrapper = wrapped(
       <Notification
         type="warning"
         notice={warning.notice}
         details={warning.details}
         dismissible={false}
-      />,
-      {context: {store}}
-    ).dive();
-    expect(wrapper).to.containMatchingElement(
-      <div>
+      />
+    );
+    expect(
+      wrapper.containsMatchingElement(
         <div>
           <div>
-            <FontAwesome icon="exclamation-triangle" />
-          </div>
-          <div>
             <div>
-              <div>{warning.notice}</div>
-              <div>{warning.details}</div>
+              <FontAwesome icon="exclamation-triangle" />
             </div>
-            <div />
+            <div>
+              <div>
+                <div>{warning.notice}</div>
+                <div>{warning.details}</div>
+              </div>
+              <div />
+            </div>
           </div>
+          <div />
         </div>
-        <div />
-      </div>
+      )
     );
   });
   it('renders a find a course notification', () => {
-    const wrapper = shallow(
+    const wrapper = wrapped(
       <Notification
         type="course"
         notice={findCourse.notice}
@@ -255,41 +266,41 @@ describe('Notification', () => {
         buttonText={findCourse.buttonText}
         buttonLink={findCourse.link}
         newWindow={true}
-      />,
-      {context: {store}}
-    ).dive();
-    expect(wrapper).to.containMatchingElement(
-      <div>
+      />
+    );
+    expect(
+      wrapper.containsMatchingElement(
         <div>
           <div>
             <div>
-              <div>{findCourse.notice}</div>
-              <div>{findCourse.details}</div>
-            </div>
-            <div>
-              <Button
-                __useDeprecatedTag
-                href={findCourse.link}
-                text={findCourse.buttonText}
-                target="_blank"
-              />
+              <div>
+                <div>{findCourse.notice}</div>
+                <div>{findCourse.details}</div>
+              </div>
+              <div>
+                <Button
+                  __useDeprecatedTag
+                  href={findCourse.link}
+                  text={findCourse.buttonText}
+                  target="_blank"
+                />
+              </div>
             </div>
           </div>
+          <div />
         </div>
-        <div />
-      </div>
+      )
     );
   });
   it('renders a dismissible notification', () => {
-    const wrapper = shallow(
+    const wrapper = wrapped(
       <Notification
         type="information"
         notice={information.notice}
         details={information.details}
         dismissible={true}
-      />,
-      {context: {store}}
-    ).dive();
+      />
+    );
     expect(wrapper.find('FontAwesome').length).to.equal(2);
     expect(
       wrapper

--- a/apps/test/unit/templates/StudentsBeyondHocTest.js
+++ b/apps/test/unit/templates/StudentsBeyondHocTest.js
@@ -1,49 +1,52 @@
 import React from 'react';
-import {shallow} from 'enzyme';
-import {expect} from '../../util/deprecatedChai';
+import {Provider} from 'react-redux';
+import {mount} from 'enzyme';
+import {expect} from '../../util/reconfiguredChai';
 import StudentsBeyondHoc from '@cdo/apps/templates/StudentsBeyondHoc';
 import {combineReducers, createStore} from 'redux';
 import responsive from '@cdo/apps/code-studio/responsiveRedux';
+import isRtl from '@cdo/apps/code-studio/isRtlRedux';
+
+const store = createStore(combineReducers({responsive, isRtl}));
+
+function wrapped(element) {
+  return mount(<Provider store={store}>{element}</Provider>);
+}
 
 describe('StudentsBeyondHoc', () => {
-  const store = createStore(combineReducers({responsive}));
-
   it('renders a VerticalImageResourceCardRow component', () => {
-    const wrapper = shallow(
+    const wrapper = wrapped(
       <StudentsBeyondHoc
         completedTutorialType="other"
         MCShareLink=""
         userType="signedOut"
         isEnglish={true}
-      />,
-      {context: {store}}
-    ).dive();
+      />
+    );
     expect(wrapper.find('VerticalImageResourceCardRow').exists());
   });
 
   it('renders a CourseBlocksStudentGradeBands component', () => {
-    const wrapper = shallow(
+    const wrapper = wrapped(
       <StudentsBeyondHoc
         completedTutorialType="other"
         MCShareLink="code.org/minecraft/sharelink"
         userType="signedOut"
         isEnglish={true}
-      />,
-      {context: {store}}
-    ).dive();
+      />
+    );
     expect(wrapper.find('CourseBlocksStudentGradeBands').exists());
   });
 
   it('renders a LocalClassActionBlock component', () => {
-    const wrapper = shallow(
+    const wrapper = wrapped(
       <StudentsBeyondHoc
         completedTutorialType="other"
         MCShareLink="code.org/minecraft/sharelink"
         userType="signedOut"
         isEnglish={true}
-      />,
-      {context: {store}}
-    ).dive();
+      />
+    );
     expect(wrapper.find('LocalClassActionBlock').exists());
   });
 });

--- a/apps/test/unit/templates/manageStudents/SharingControlActionsHeaderCellTest.js
+++ b/apps/test/unit/templates/manageStudents/SharingControlActionsHeaderCellTest.js
@@ -19,8 +19,8 @@ describe('SharingControlActionsHeaderCell', () => {
     const enableAllString = i18n.projectSharingEnableAll();
     const disableAllString = i18n.projectSharingDisableAll();
     const learnMoreString = i18n.learnMore();
-    expect(wrapper.find(enableAllString)).to.exist;
-    expect(wrapper.find(disableAllString)).to.exist;
-    expect(wrapper.find(learnMoreString)).to.exist;
+    expect(wrapper.find(enableAllString).exists);
+    expect(wrapper.find(disableAllString).exists);
+    expect(wrapper.find(learnMoreString).exists);
   });
 });

--- a/apps/test/unit/templates/manageStudents/SharingControlActionsHeaderCellTest.js
+++ b/apps/test/unit/templates/manageStudents/SharingControlActionsHeaderCellTest.js
@@ -1,6 +1,7 @@
 import React from 'react';
-import {shallow} from 'enzyme';
-import {expect} from '../../../util/deprecatedChai';
+import {Provider} from 'react-redux';
+import {mount} from 'enzyme';
+import {expect} from '../../../util/reconfiguredChai';
 import i18n from '@cdo/locale';
 import {combineReducers, createStore} from 'redux';
 import reducer from '@cdo/apps/templates/manageStudents/manageStudentsRedux';
@@ -10,14 +11,16 @@ describe('SharingControlActionsHeaderCell', () => {
   const store = createStore(combineReducers({manageStudents: reducer}));
 
   it('renders enable all, disable all and learn more options', () => {
-    const wrapper = shallow(<SharingControlActionsHeaderCell />, {
-      context: {store}
-    }).dive();
+    const wrapper = mount(
+      <Provider store={store}>
+        <SharingControlActionsHeaderCell />
+      </Provider>
+    );
     const enableAllString = i18n.projectSharingEnableAll();
     const disableAllString = i18n.projectSharingDisableAll();
     const learnMoreString = i18n.learnMore();
-    expect(wrapper).to.contain(enableAllString);
-    expect(wrapper).to.contain(disableAllString);
-    expect(wrapper).to.contain(learnMoreString);
+    expect(wrapper.find(enableAllString)).to.exist;
+    expect(wrapper.find(disableAllString)).to.exist;
+    expect(wrapper.find(learnMoreString)).to.exist;
   });
 });

--- a/apps/test/unit/templates/projects/ProjectCardGridTest.js
+++ b/apps/test/unit/templates/projects/ProjectCardGridTest.js
@@ -1,6 +1,7 @@
 import React from 'react';
-import {shallow} from 'enzyme';
-import {expect} from '../../../util/deprecatedChai';
+import {Provider} from 'react-redux';
+import {mount} from 'enzyme';
+import {expect} from '../../../util/reconfiguredChai';
 import ProjectCardGrid from '@cdo/apps/templates/projects/ProjectCardGrid';
 import ProjectAppTypeArea from '@cdo/apps/templates/projects/ProjectAppTypeArea.jsx';
 import {projects} from './projectsTestData';
@@ -11,48 +12,54 @@ describe('ProjectCardGrid', () => {
   const store = createStore(combineReducers({projects: reducer}));
 
   it('filters by selected app type', () => {
-    const wrapper = shallow(
-      <ProjectCardGrid projectLists={projects} galleryType="public" />,
-      {context: {store}}
-    ).dive();
+    const wrapper = mount(
+      <Provider store={store}>
+        <ProjectCardGrid projectLists={projects} galleryType="public" />
+      </Provider>
+    );
 
-    const onSelectApp = wrapper.instance().onSelectApp;
-    const viewAllProjects = wrapper.instance().viewAllProjects;
+    const component = wrapper
+      .find(ProjectCardGrid)
+      .childAt(0)
+      .instance();
 
     // Should show all project types.
-    expect(wrapper)
-      .to.have.exactly(9)
-      .descendants(ProjectAppTypeArea);
-    expect(wrapper.find(ProjectAppTypeArea).first()).to.have.props({
-      labKey: 'dance',
-      labName: 'Dance Party',
-      numProjectsToShow: 4
-    });
+    expect(wrapper.find(ProjectAppTypeArea)).to.have.lengthOf(9);
+    const props1 = wrapper
+      .find(ProjectAppTypeArea)
+      .first()
+      .props();
+    expect(props1.labKey).to.equal('dance');
+    expect(props1.labName).to.equal('Dance Party');
+    expect(props1.numProjectsToShow).to.equal(4);
 
     // Filter to only show Play Lab projects.
-    onSelectApp('playlab');
-    expect(wrapper.find(ProjectAppTypeArea).length).to.equal(1);
-    expect(wrapper.find(ProjectAppTypeArea)).to.have.props({
-      labKey: 'playlab',
-      labName: 'All Play Lab Projects',
-      numProjectsToShow: 12
-    });
+    component.onSelectApp('playlab');
+    wrapper.setProps({}); // Force a re-render
+    expect(wrapper.find(ProjectAppTypeArea)).to.have.lengthOf(1);
+    const props2 = wrapper
+      .find(ProjectAppTypeArea)
+      .first()
+      .props();
+    expect(props2.labKey).to.equal('playlab');
+    expect(props2.labName).to.equal('All Play Lab Projects');
+    expect(props2.numProjectsToShow).to.equal(12);
 
     // Show all project types.
-    viewAllProjects();
-    expect(wrapper)
-      .to.have.exactly(9)
-      .descendants(ProjectAppTypeArea);
+    component.viewAllProjects();
+    wrapper.setProps({}); // Force a re-render
+    expect(wrapper.find(ProjectAppTypeArea)).to.have.lengthOf(9);
 
     // Filter to only show Minecraft projects.
-    onSelectApp('minecraft');
-    expect(wrapper)
-      .to.have.exactly(1)
-      .descendants(ProjectAppTypeArea);
-    expect(wrapper.find(ProjectAppTypeArea)).to.have.props({
-      labKey: 'minecraft',
-      labName: 'All Minecraft Projects',
-      numProjectsToShow: 12
-    });
+    component.onSelectApp('minecraft');
+    wrapper.setProps({}); // Force a re-render
+    expect(wrapper.find(ProjectAppTypeArea)).to.have.lengthOf(1);
+    const props3 = wrapper
+      .find(ProjectAppTypeArea)
+      .first()
+      .props();
+    expect(props3.labKey).to.equal('minecraft');
+    expect(props3.labName).to.equal('All Minecraft Projects');
+    expect(props3.numProjectsToShow).to.equal(12);
   });
 });

--- a/apps/test/unit/templates/studioHomepages/CourseCardTest.js
+++ b/apps/test/unit/templates/studioHomepages/CourseCardTest.js
@@ -1,61 +1,68 @@
 import React from 'react';
-import {shallow} from 'enzyme';
-import {expect} from '../../../util/deprecatedChai';
+import {Provider} from 'react-redux';
+import {mount} from 'enzyme';
+import {expect} from '../../../util/reconfiguredChai';
 import CourseCard from '@cdo/apps/templates/studioHomepages/CourseCard';
 import FontAwesome from '@cdo/apps/templates/FontAwesome';
 import {courses} from './homepagesTestData';
 import {combineReducers, createStore} from 'redux';
 import isRtl, {setRtl} from '@cdo/apps/code-studio/isRtlRedux';
 
-describe('CourseCard', () => {
-  const store = createStore(combineReducers({isRtl}));
+const store = createStore(combineReducers({isRtl}));
 
+function wrapped(element) {
+  return mount(<Provider store={store}>{element}</Provider>);
+}
+
+describe('CourseCard', () => {
   it('renders a card-shaped link', () => {
-    const wrapper = shallow(
+    const wrapper = wrapped(
       <CourseCard
         title={courses[0].title}
         description={courses[0].description}
         link={courses[0].link}
-      />,
-      {context: {store}}
-    ).dive();
-    expect(wrapper).to.containMatchingElement(
-      <a href={courses[0].link}>
-        <img />
-        <div>{courses[0].title}</div>
-        <div>
-          {courses[0].description}
+      />
+    );
+    expect(
+      wrapper.containsMatchingElement(
+        <a href={courses[0].link}>
+          <img />
+          <div>{courses[0].title}</div>
           <div>
-            <h3>View course</h3>
-            <FontAwesome icon="chevron-right" />
+            {courses[0].description}
+            <div>
+              <h3>View course</h3>
+              <FontAwesome icon="chevron-right" />
+            </div>
           </div>
-        </div>
-      </a>
+        </a>
+      )
     );
   });
 
   it('can render in RTL mode', () => {
     store.dispatch(setRtl(true));
-    const wrapper = shallow(
+    const wrapper = wrapped(
       <CourseCard
         title={courses[0].title}
         description={courses[0].description}
         link={courses[0].link}
-      />,
-      {context: {store}}
-    ).dive();
-    expect(wrapper).to.containMatchingElement(
-      <a href={courses[0].link}>
-        <img />
-        <div>{courses[0].title}</div>
-        <div>
-          {courses[0].description}
+      />
+    );
+    expect(
+      wrapper.containsMatchingElement(
+        <a href={courses[0].link}>
+          <img />
+          <div>{courses[0].title}</div>
           <div>
-            <h3>View course</h3>
-            <FontAwesome icon="chevron-left" />
+            {courses[0].description}
+            <div>
+              <h3>View course</h3>
+              <FontAwesome icon="chevron-left" />
+            </div>
           </div>
-        </div>
-      </a>
+        </a>
+      )
     );
   });
 });

--- a/apps/test/unit/templates/studioHomepages/SectionsAsStudentTableTest.js
+++ b/apps/test/unit/templates/studioHomepages/SectionsAsStudentTableTest.js
@@ -1,92 +1,102 @@
 import React from 'react';
-import {shallow} from 'enzyme';
-import {expect} from '../../../util/deprecatedChai';
+import {Provider} from 'react-redux';
+import {mount} from 'enzyme';
+import {expect} from '../../../util/reconfiguredChai';
 import i18n from '@cdo/locale';
 import {joinedSections} from './homepagesTestData';
 import SectionsAsStudentTable from '@cdo/apps/templates/studioHomepages/SectionsAsStudentTable';
 import {combineReducers, createStore} from 'redux';
 import isRtl from '@cdo/apps/code-studio/isRtlRedux';
 
-describe('SectionsAsStudentTable', () => {
-  const store = createStore(combineReducers({isRtl}));
+const store = createStore(combineReducers({isRtl}));
 
+function wrapped(element) {
+  return mount(<Provider store={store}>{element}</Provider>);
+}
+
+describe('SectionsAsStudentTable', () => {
   it('shows column headers for students', () => {
-    const wrapper = shallow(
-      <SectionsAsStudentTable sections={joinedSections} canLeave={false} />,
-      {context: {store}}
-    ).dive();
+    const wrapper = wrapped(
+      <SectionsAsStudentTable sections={joinedSections} canLeave={false} />
+    );
     [i18n.section(), i18n.course(), i18n.teacher(), i18n.sectionCode()].forEach(
       headerText => {
-        expect(wrapper).to.containMatchingElement(
-          <td>
-            <div>{headerText}</div>
-          </td>
+        expect(
+          wrapper.containsMatchingElement(
+            <td>
+              <div>{headerText}</div>
+            </td>
+          )
         );
       }
     );
   });
 
   it('does not show a leave section button for teacher-managed student accounts', () => {
-    const wrapper = shallow(
-      <SectionsAsStudentTable sections={joinedSections} canLeave={false} />,
-      {context: {store}}
-    ).dive();
+    const wrapper = wrapped(
+      <SectionsAsStudentTable sections={joinedSections} canLeave={false} />
+    );
     expect(wrapper.find('Button').exists()).to.be.false;
   });
 
   it('shows a leave section button for students who do not have teacher-managed accounts', () => {
-    const wrapper = shallow(
-      <SectionsAsStudentTable sections={joinedSections} canLeave={true} />,
-      {context: {store}}
-    ).dive();
+    const wrapper = wrapped(
+      <SectionsAsStudentTable sections={joinedSections} canLeave={true} />
+    );
     expect(wrapper.find('Button').exists()).to.be.true;
   });
 
   it('renders a row for each joined section', () => {
-    const wrapper = shallow(
-      <SectionsAsStudentTable sections={joinedSections} canLeave={false} />,
-      {context: {store}}
-    ).dive();
+    const wrapper = wrapped(
+      <SectionsAsStudentTable sections={joinedSections} canLeave={false} />
+    );
     expect(wrapper.find('.test-row')).to.have.length(4);
-    expect(wrapper).to.containMatchingElement(<div>Current unit:</div>);
+    expect(wrapper.containsMatchingElement(<div>Current unit:</div>));
     joinedSections.forEach(section => {
-      expect(wrapper).to.containMatchingElement(
-        <td>
-          <div>{section.name}</div>
-        </td>
+      expect(
+        wrapper.containsMatchingElement(
+          <td>
+            <div>{section.name}</div>
+          </td>
+        )
       );
       if (section.currentUnitTitle) {
-        expect(wrapper).to.containMatchingElement(
-          <td>
-            <a href={section.linkToAssigned}>{section.assignedTitle}</a>
-            <div>
-              <div>Current unit:</div>
-              <a href={section.linkToCurrentUnit}>{section.currentUnitTitle}</a>
-            </div>
-          </td>
+        expect(
+          wrapper.containsMatchingElement(
+            <td>
+              <a href={section.linkToAssigned}>{section.assignedTitle}</a>
+              <div>
+                <div>Current unit:</div>
+                <a href={section.linkToCurrentUnit}>
+                  {section.currentUnitTitle}
+                </a>
+              </div>
+            </td>
+          )
         );
       } else {
-        expect(wrapper).to.containMatchingElement(
-          <td>
-            <a href={section.linkToAssigned}>{section.assignedTitle}</a>
-          </td>
+        expect(
+          wrapper.containsMatchingElement(
+            <td>
+              <a href={section.linkToAssigned}>{section.assignedTitle}</a>
+            </td>
+          )
         );
       }
-      expect(wrapper).to.containMatchingElement(<td>{section.teacherName}</td>);
+      expect(wrapper.containsMatchingElement(<td>{section.teacherName}</td>));
     });
   });
 
   it('shows section codes correctly', () => {
-    const wrapper = shallow(
-      <SectionsAsStudentTable sections={joinedSections} canLeave={false} />,
-      {context: {store}}
-    ).dive();
+    const wrapper = wrapped(
+      <SectionsAsStudentTable sections={joinedSections} canLeave={false} />
+    );
 
-    expect(wrapper).to.containMatchingElement(<td>ClassOneCode</td>);
-    expect(wrapper).to.containMatchingElement(<td>ClassTwoCode</td>);
-    expect(wrapper).to.containMatchingElement(<td>Google Classroom</td>);
-    expect(wrapper).to.not.containMatchingElement(<td>DoNotShowThis</td>);
-    expect(wrapper).to.containMatchingElement(<td>Clever</td>);
-    expect(wrapper).to.not.containMatchingElement(<td>OrThisEither</td>);
+    expect(wrapper.containsMatchingElement(<td>ClassOneCode</td>));
+    expect(wrapper.containsMatchingElement(<td>ClassTwoCode</td>));
+    expect(wrapper.containsMatchingElement(<td>Google Classroom</td>));
+    expect(wrapper.containsMatchingElement(<td>DoNotShowThis</td>)).to.be.false;
+    expect(wrapper.containsMatchingElement(<td>Clever</td>));
+    expect(wrapper.containsMatchingElement(<td>OrThisEither</td>)).to.be.false;
   });
 });

--- a/apps/test/unit/templates/studioHomepages/SetUpSectionsTest.jsx
+++ b/apps/test/unit/templates/studioHomepages/SetUpSectionsTest.jsx
@@ -1,7 +1,8 @@
 import React from 'react';
-import {shallow} from 'enzyme';
+import {Provider} from 'react-redux';
+import {shallow, mount} from 'enzyme';
 import sinon from 'sinon';
-import {expect} from '../../../util/deprecatedChai';
+import {expect} from '../../../util/reconfiguredChai';
 import Button from '@cdo/apps/templates/Button';
 import SetUpMessage from '@cdo/apps/templates/studioHomepages/SetUpMessage';
 import {UnconnectedSetUpSections as SetUpSections} from '@cdo/apps/templates/studioHomepages/SetUpSections';
@@ -15,23 +16,27 @@ describe('SetUpSections', () => {
     );
     const instance = wrapper.instance();
 
-    expect(wrapper).to.containMatchingElement(
-      <SetUpMessage
-        type="sections"
-        headingText="Set up your classroom"
-        descriptionText="Create a new classroom section to start assigning courses and seeing your student progress."
-        buttonText="Create a section"
-        onClick={instance.beginEditingNewSection}
-      />
+    expect(
+      wrapper.containsMatchingElement(
+        <SetUpMessage
+          type="sections"
+          headingText="Set up your classroom"
+          descriptionText="Create a new classroom section to start assigning courses and seeing your student progress."
+          buttonText="Create a section"
+          onClick={instance.beginEditingNewSection}
+        />
+      )
     );
   });
 
   it('calls beginEditingNewSection with no arguments when button is clicked', () => {
     const store = createStore(combineReducers({isRtl}));
     const spy = sinon.spy();
-    const wrapper = shallow(<SetUpSections beginEditingNewSection={spy} />)
-      .dive({context: {store}})
-      .dive();
+    const wrapper = mount(
+      <Provider store={store}>
+        <SetUpSections beginEditingNewSection={spy} />
+      </Provider>
+    );
     expect(spy).not.to.have.been.called;
 
     wrapper.find(Button).simulate('click', {fake: 'event'});

--- a/apps/test/unit/templates/studioHomepages/TopCourseTest.js
+++ b/apps/test/unit/templates/studioHomepages/TopCourseTest.js
@@ -1,5 +1,6 @@
 import React from 'react';
-import {shallow} from 'enzyme';
+import {Provider} from 'react-redux';
+import {mount} from 'enzyme';
 import {expect} from '../../../util/deprecatedChai';
 import i18n from '@cdo/locale';
 import TopCourse from '@cdo/apps/templates/studioHomepages/TopCourse';
@@ -12,36 +13,39 @@ describe('TopCourse', () => {
   const store = createStore(combineReducers({isRtl}));
 
   it('renders a TopCourse with 2 buttons', () => {
-    const wrapper = shallow(
-      <TopCourse
-        assignableName={topCourse.assignableName}
-        lessonName={topCourse.lessonName}
-        linkToOverview={topCourse.linkToOverview}
-        linkToLesson={topCourse.linkToLesson}
-      />,
-      {context: {store}}
-    ).dive();
-    expect(wrapper).to.containMatchingElement(
-      <div>
-        <img />
-        <div>{topCourse.assignableName}</div>
+    const wrapper = mount(
+      <Provider store={store}>
+        <TopCourse
+          assignableName={topCourse.assignableName}
+          lessonName={topCourse.lessonName}
+          linkToOverview={topCourse.linkToOverview}
+          linkToLesson={topCourse.linkToLesson}
+        />
+      </Provider>
+    );
+    expect(
+      wrapper.containsMatchingElement(
         <div>
-          <div>You are currently working on {topCourse.lessonName}.</div>
-          <div>{i18n.topCourseExplanation()}</div>
+          <img />
+          <div>{topCourse.assignableName}</div>
+          <div>
+            <div>You are currently working on {topCourse.lessonName}.</div>
+            <div>{i18n.topCourseExplanation()}</div>
+          </div>
+          <div>
+            <Button
+              __useDeprecatedTag
+              href={topCourse.linkToOverview}
+              text="View course"
+            />
+            <Button
+              __useDeprecatedTag
+              href={topCourse.linkToLesson}
+              text="Continue lesson"
+            />
+          </div>
         </div>
-        <div>
-          <Button
-            __useDeprecatedTag
-            href={topCourse.linkToOverview}
-            text="View course"
-          />
-          <Button
-            __useDeprecatedTag
-            href={topCourse.linkToLesson}
-            text="Continue lesson"
-          />
-        </div>
-      </div>
+      )
     );
   });
 });


### PR DESCRIPTION
this is preliminary groundwork for upgrading react and redux. some of our tests were using a deprecated api to pass a redux store into a component, which has been removed in the latest version of react-redux. however, since fixing those tests to work with the latest version of react-redux doesn't require any functionality we don't already have in our existing version, we are safe to update these tests before updating react-redux.

while updating those tests i also updated them to use `reconfiguredChai`, and many of the code changes in this PR are related to that change