### PR TITLE
remove unneeded outer transaction in script update path

### DIFF
--- a/dashboard/app/models/script.rb
+++ b/dashboard/app/models/script.rb
@@ -1163,22 +1163,20 @@ class Script < ApplicationRecord
   def update_text(script_params, script_text, metadata_i18n, general_params)
     script_name = script_params[:name]
     begin
-      transaction do
-        script_data, i18n = ScriptDSL.parse(script_text, 'input', script_name)
-        Script.add_script(
-          {
-            name: script_name,
-            hidden: general_params[:hidden].nil? ? true : general_params[:hidden], # default true
-            login_required: general_params[:login_required].nil? ? false : general_params[:login_required], # default false
-            wrapup_video: general_params[:wrapup_video],
-            family_name: general_params[:family_name].presence ? general_params[:family_name] : nil, # default nil
-            properties: Script.build_property_hash(general_params)
-          },
-          script_data[:lesson_groups]
-        )
-        if Rails.application.config.levelbuilder_mode
-          Script.merge_and_write_i18n(i18n, script_name, metadata_i18n)
-        end
+      script_data, i18n = ScriptDSL.parse(script_text, 'input', script_name)
+      Script.add_script(
+        {
+          name: script_name,
+          hidden: general_params[:hidden].nil? ? true : general_params[:hidden], # default true
+          login_required: general_params[:login_required].nil? ? false : general_params[:login_required], # default false
+          wrapup_video: general_params[:wrapup_video],
+          family_name: general_params[:family_name].presence ? general_params[:family_name] : nil, # default nil
+          properties: Script.build_property_hash(general_params)
+        },
+        script_data[:lesson_groups]
+      )
+      if Rails.application.config.levelbuilder_mode
+        Script.merge_and_write_i18n(i18n, script_name, metadata_i18n)
       end
     rescue StandardError => e
       errors.add(:base, e.to_s)


### PR DESCRIPTION
## Background

in the process of debugging https://github.com/code-dot-org/code-dot-org/pull/38742, I discovered that there are nested transactions in this codepath:
* https://github.com/code-dot-org/code-dot-org/blob/def7f2c0621d08dfe5855d3e9326c88754cb8711/dashboard/app/models/script.rb#L1163-L1168
* https://github.com/code-dot-org/code-dot-org/blob/def7f2c0621d08dfe5855d3e9326c88754cb8711/dashboard/app/models/script.rb#L989-L990

and that with default options, nested transactions are bad:
* https://pragtob.wordpress.com/2017/12/12/surprises-with-nested-transactions-rollbacks-and-activerecord/
* https://api.rubyonrails.org/classes/ActiveRecord/Transactions/ClassMethods.html#module-ActiveRecord::Transactions::ClassMethods-label-Nested+transactions

the inner transaction was added somewhat recently by "moving" it from Script.setup: https://github.com/code-dot-org/code-dot-org/commit/a59166a92430ded8e4e6c472af5e6c6435a5a9c5#diff-22769ab80ff34eaf4aadc1dc87e1b9bdad8b445cec233c9a5a1d2bcc5a7a7978R943

however, that move neglected to account for the other codepaths which hit the new location of the transaction.

## fix

because all of the database writes within the outer transaction are also within the inner transaction, this PR simply removes the outer transaction. With this fix, all codepaths which use Script.add_script use exactly one transaction.

## Testing story

Existing test coverage verifies that changes to a script can be saved: https://github.com/code-dot-org/code-dot-org/blob/b81ea9c06267238f6f64c642dd9ef3364e1b22d5/dashboard/test/ui/features/curriculum_platform/levelbuilder/script_edit_page.feature#L27

I also tested the case where bad edits are made to a script, and verified that errors are shown to the user and no updates were saved to the database.

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
