### PR TITLE
Nav accessibility

### DIFF
--- a/apps/src/hamburger/hamburger.js
+++ b/apps/src/hamburger/hamburger.js
@@ -7,19 +7,12 @@ import {
 
 export const initHamburger = function() {
   $(function() {
-    $('#hamburger-icon').click(function(e) {
-      $(this).toggleClass('active');
-      $('#hamburger #hamburger-contents').slideToggle();
-      e.preventDefault();
-    });
-
-    // allows users to toggle help menu by pressing return
-    // while tabbing through elements
-    $('#hamburger').on('keypress', function(e) {
+    $('#hamburger').on('keypress click', function(e) {
       if (
-        e.type === 'keypress' &&
-        e.which === 13 &&
-        e.target.className !== 'hamburger-expandable-item item'
+        (e.type === 'keypress' &&
+          e.which === 13 &&
+          e.target.className !== 'hamburger-expandable-item item') ||
+        e.type === 'click'
       ) {
         $(this).toggleClass('active');
         $('#hamburger #hamburger-contents').slideToggle();
@@ -66,16 +59,10 @@ export const initHamburger = function() {
       });
     });
 
-    $('#help-icon').click(function(e) {
-      $(this).toggleClass('active');
-      $('#help-button #help-contents').slideToggle();
-      e.preventDefault();
-    });
-
     // allows users to toggle help menu by pressing return
     // while tabbing through elements
-    $('#help-button').on('keypress', function(e) {
-      if (e.type === 'keypress' && e.which === 13) {
+    $('#help-button').on('keypress click', function(e) {
+      if ((e.type === 'keypress' && e.which === 13) || e.type === 'click') {
         $(this).toggleClass('active');
         $('#help-button #help-contents').slideToggle();
         e.preventDefault();

--- a/apps/src/hamburger/hamburger.js
+++ b/apps/src/hamburger/hamburger.js
@@ -7,18 +7,29 @@ import {
 
 export const initHamburger = function() {
   $(function() {
-    $('#hamburger').click(function(e) {
-      $(this).toggleClass('active');
-      $('#hamburger #hamburger-contents').slideToggle();
-      e.preventDefault();
+    $('#hamburger').on('keypress click', function(e) {
+      if (
+        (e.type === 'keypress' &&
+          e.which === 13 &&
+          e.target.className !== 'hamburger-expandable-item item') ||
+        e.type === 'click'
+      ) {
+        $(this).toggleClass('active');
+        $('#hamburger #hamburger-contents').slideToggle();
+        e.preventDefault();
+      }
     });
 
-    $(document).on('click', function(e) {
+    $(document).on('keypress click', function(e) {
       var hamburger = $('#hamburger');
 
       // If we didn't click the hamburger itself, and also nothing inside it,
       // then hide it.
-      if (!hamburger.is(e.target) && hamburger.has(e.target).length === 0) {
+      if (
+        !hamburger.is(e.target) &&
+        hamburger.has(e.target).length === 0 &&
+        e.target.className !== 'hamburger-expandable-item item'
+      ) {
         hamburger.children('#hamburger-contents').slideUp();
         $('#hamburger-icon').removeClass('active');
       }
@@ -48,10 +59,14 @@ export const initHamburger = function() {
       });
     });
 
-    $('#help-button').click(function(e) {
-      $(this).toggleClass('active');
-      $('#help-button #help-contents').slideToggle();
-      e.preventDefault();
+    // allows users to toggle help menu by pressing return
+    // while tabbing through elements
+    $('#help-button').on('keypress click', function(e) {
+      if ((e.type === 'keypress' && e.which === 13) || e.type === 'click') {
+        $(this).toggleClass('active');
+        $('#help-button #help-contents').slideToggle();
+        e.preventDefault();
+      }
     });
 
     $('#help-icon #report-bug').click(function() {

--- a/apps/src/hamburger/hamburger.js
+++ b/apps/src/hamburger/hamburger.js
@@ -7,12 +7,19 @@ import {
 
 export const initHamburger = function() {
   $(function() {
-    $('#hamburger').on('keypress click', function(e) {
+    $('#hamburger-icon').click(function(e) {
+      $(this).toggleClass('active');
+      $('#hamburger #hamburger-contents').slideToggle();
+      e.preventDefault();
+    });
+
+    // allows users to toggle help menu by pressing return
+    // while tabbing through elements
+    $('#hamburger').on('keypress', function(e) {
       if (
-        (e.type === 'keypress' &&
-          e.which === 13 &&
-          e.target.className !== 'hamburger-expandable-item item') ||
-        e.type === 'click'
+        e.type === 'keypress' &&
+        e.which === 13 &&
+        e.target.className !== 'hamburger-expandable-item item'
       ) {
         $(this).toggleClass('active');
         $('#hamburger #hamburger-contents').slideToggle();
@@ -59,10 +66,16 @@ export const initHamburger = function() {
       });
     });
 
+    $('#help-icon').click(function(e) {
+      $(this).toggleClass('active');
+      $('#help-button #help-contents').slideToggle();
+      e.preventDefault();
+    });
+
     // allows users to toggle help menu by pressing return
     // while tabbing through elements
-    $('#help-button').on('keypress click', function(e) {
-      if ((e.type === 'keypress' && e.which === 13) || e.type === 'click') {
+    $('#help-button').on('keypress', function(e) {
+      if (e.type === 'keypress' && e.which === 13) {
         $(this).toggleClass('active');
         $('#help-button #help-contents').slideToggle();
         e.preventDefault();

--- a/apps/src/hamburger/hamburger.js
+++ b/apps/src/hamburger/hamburger.js
@@ -7,29 +7,18 @@ import {
 
 export const initHamburger = function() {
   $(function() {
-    $('#hamburger').on('keypress click', function(e) {
-      if (
-        (e.type === 'keypress' &&
-          e.which === 13 &&
-          e.target.className !== 'hamburger-expandable-item item') ||
-        e.type === 'click'
-      ) {
-        $(this).toggleClass('active');
-        $('#hamburger #hamburger-contents').slideToggle();
-        e.preventDefault();
-      }
+    $('#hamburger').click(function(e) {
+      $(this).toggleClass('active');
+      $('#hamburger #hamburger-contents').slideToggle();
+      e.preventDefault();
     });
 
-    $(document).on('keypress click', function(e) {
+    $(document).on('click', function(e) {
       var hamburger = $('#hamburger');
 
       // If we didn't click the hamburger itself, and also nothing inside it,
       // then hide it.
-      if (
-        !hamburger.is(e.target) &&
-        hamburger.has(e.target).length === 0 &&
-        e.target.className !== 'hamburger-expandable-item item'
-      ) {
+      if (!hamburger.is(e.target) && hamburger.has(e.target).length === 0) {
         hamburger.children('#hamburger-contents').slideUp();
         $('#hamburger-icon').removeClass('active');
       }
@@ -59,14 +48,10 @@ export const initHamburger = function() {
       });
     });
 
-    // allows users to toggle help menu by pressing return
-    // while tabbing through elements
-    $('#help-button').on('keypress click', function(e) {
-      if ((e.type === 'keypress' && e.which === 13) || e.type === 'click') {
-        $(this).toggleClass('active');
-        $('#help-button #help-contents').slideToggle();
-        e.preventDefault();
-      }
+    $('#help-button').click(function(e) {
+      $(this).toggleClass('active');
+      $('#help-button #help-contents').slideToggle();
+      e.preventDefault();
     });
 
     $('#help-icon #report-bug').click(function() {

--- a/apps/src/hamburger/hamburger.js
+++ b/apps/src/hamburger/hamburger.js
@@ -13,12 +13,30 @@ export const initHamburger = function() {
       e.preventDefault();
     });
 
-    $(document).on('click', function(e) {
+    // allows users to toggle help menu by pressing return
+    // while tabbing through elements
+    $('#hamburger').on('keypress', function(e) {
+      if (
+        e.type === 'keypress' &&
+        e.which === 13 &&
+        e.target.className !== 'hamburger-expandable-item item'
+      ) {
+        $(this).toggleClass('active');
+        $('#hamburger #hamburger-contents').slideToggle();
+        e.preventDefault();
+      }
+    });
+
+    $(document).on('keypress click', function(e) {
       var hamburger = $('#hamburger');
 
       // If we didn't click the hamburger itself, and also nothing inside it,
       // then hide it.
-      if (!hamburger.is(e.target) && hamburger.has(e.target).length === 0) {
+      if (
+        !hamburger.is(e.target) &&
+        hamburger.has(e.target).length === 0 &&
+        e.target.className !== 'hamburger-expandable-item item'
+      ) {
         hamburger.children('#hamburger-contents').slideUp();
         $('#hamburger-icon').removeClass('active');
       }
@@ -34,15 +52,17 @@ export const initHamburger = function() {
     });
 
     $('.hamburger-expandable-item').each(function() {
-      $(this).click(function(e) {
-        $('#' + $(this).attr('id') + '-items').slideToggle();
-        $(this)
-          .find('.arrow-down')
-          .toggle();
-        $(this)
-          .find('.arrow-up')
-          .toggle();
-        e.preventDefault();
+      $(this).on('keypress click', function(e) {
+        if ((e.type === 'keypress' && e.which === 13) || e.type === 'click') {
+          $('#' + $(this).attr('id') + '-items').slideToggle();
+          $(this)
+            .find('.arrow-down')
+            .toggle();
+          $(this)
+            .find('.arrow-up')
+            .toggle();
+          e.preventDefault();
+        }
       });
     });
 
@@ -50,6 +70,16 @@ export const initHamburger = function() {
       $(this).toggleClass('active');
       $('#help-button #help-contents').slideToggle();
       e.preventDefault();
+    });
+
+    // allows users to toggle help menu by pressing return
+    // while tabbing through elements
+    $('#help-button').on('keypress', function(e) {
+      if (e.type === 'keypress' && e.which === 13) {
+        $(this).toggleClass('active');
+        $('#help-button #help-contents').slideToggle();
+        e.preventDefault();
+      }
     });
 
     $('#help-icon #report-bug').click(function() {

--- a/apps/src/hamburger/hamburger.js
+++ b/apps/src/hamburger/hamburger.js
@@ -22,6 +22,7 @@ export const initHamburger = function() {
         e.target.className !== 'hamburger-expandable-item item'
       ) {
         $(this).toggleClass('active');
+        $('#hamburger-icon').toggleClass('active');
         $('#hamburger #hamburger-contents').slideToggle();
         e.preventDefault();
       }

--- a/shared/css/hamburger.scss
+++ b/shared/css/hamburger.scss
@@ -93,6 +93,7 @@
       text-overflow: ellipsis;
       white-space: nowrap;
       overflow: hidden;
+      text-align: left;
 
       &:last-of-type {
         border-bottom: none;
@@ -224,6 +225,10 @@
 }
 
 #hamburger {
+  background-color: $teal;
+  border: none;
+  margin: 0;
+
   #hamburger-icon {
     padding: 10px 28px 16px 0;
     float: right;

--- a/shared/css/hamburger.scss
+++ b/shared/css/hamburger.scss
@@ -93,7 +93,6 @@
       text-overflow: ellipsis;
       white-space: nowrap;
       overflow: hidden;
-      text-align: left;
 
       &:last-of-type {
         border-bottom: none;
@@ -225,10 +224,6 @@
 }
 
 #hamburger {
-  background-color: $teal;
-  border: none;
-  margin: 0;
-
   #hamburger-icon {
     padding: 10px 28px 16px 0;
     float: right;

--- a/shared/css/user-menu.scss
+++ b/shared/css/user-menu.scss
@@ -80,10 +80,8 @@
 }
 
 .help_button {
-  background-color: $teal;
-  border: none;
-  margin: 0;
-  padding-bottom: 40px;
+  padding-left: 16px;
+  padding-top: 4px;
 
   &.hide-mobile {
     display: block;

--- a/shared/css/user-menu.scss
+++ b/shared/css/user-menu.scss
@@ -80,8 +80,10 @@
 }
 
 .help_button {
-  padding-left: 16px;
-  padding-top: 4px;
+  background-color: $teal;
+  border: none;
+  margin: 0;
+  padding-bottom: 40px;
 
   &.hide-mobile {
     display: block;

--- a/shared/haml/hamburger.haml
+++ b/shared/haml/hamburger.haml
@@ -2,7 +2,7 @@
   options = { level: level, script_level: script_level, language: language, user_type: user_type, loc_prefix: loc_prefix, request: request }
   contents = Hamburger.get_hamburger_contents(options)
 
-#hamburger{class: contents[:visibility], tabindex: "0", alt: "Menu"}
+#hamburger{class: contents[:visibility], tabindex: "0", 'aria-label': I18n.t('header_screen_reader_hamburger')}
   #hamburger-contents.hide-responsive-menu
     - contents[:entries].each do |entry|
       - if entry[:type] == "divider"

--- a/shared/haml/hamburger.haml
+++ b/shared/haml/hamburger.haml
@@ -2,25 +2,25 @@
   options = { level: level, script_level: script_level, language: language, user_type: user_type, loc_prefix: loc_prefix, request: request }
   contents = Hamburger.get_hamburger_contents(options)
 
-#hamburger{class: contents[:visibility]}
+#hamburger{class: contents[:visibility], tabindex: "0", alt: "Menu"}
   #hamburger-contents.hide-responsive-menu
     - contents[:entries].each do |entry|
       - if entry[:type] == "divider"
         .divider{id: entry[:id], class: entry[:class]}
       - elsif entry[:type] == "expander"
-        .hamburger-expandable-item.item{id: entry[:id]}
+        .hamburger-expandable-item.item{id: entry[:id], tabindex: "0"}
           .text= entry[:title]
           %i.arrow-down{class: "fa fa-caret-down"}
           %i.arrow-up{class: "fa fa-caret-up"}
         .hamburger-expandable-items{id: "#{entry[:id]}-items"}
           - entry[:subentries].each do |subentry|
             .item
-              %a{id: subentry[:id], href: subentry[:url]}= subentry[:title]
+              %a{id: subentry[:id], href: subentry[:url], tabindex: "0"}= subentry[:title]
       - else
         %div{class: entry[:class]}
           .item
             - target = entry[:target] ? entry[:target] : "_self"
-            %a{id: entry[:id], href: entry[:url], target: target, rel: entry[:rel]}= entry[:title]
+            %a{id: entry[:id], href: entry[:url], target: target, rel: entry[:rel], tabindex: "0"}= entry[:title]
 
   #hamburger-icon.clicktag{class: contents[:visibility]}
     %span{style: "pointer-events: none"}

--- a/shared/haml/hamburger.haml
+++ b/shared/haml/hamburger.haml
@@ -2,7 +2,7 @@
   options = { level: level, script_level: script_level, language: language, user_type: user_type, loc_prefix: loc_prefix, request: request }
   contents = Hamburger.get_hamburger_contents(options)
 
-#hamburger{class: contents[:visibility], tabindex: "0", 'aria-label': I18n.t('header_screen_reader_hamburger')}
+%button#hamburger{class: contents[:visibility], tabindex: "0", role: "navigation", 'aria-label': "Menu"}
   #hamburger-contents.hide-responsive-menu
     - contents[:entries].each do |entry|
       - if entry[:type] == "divider"

--- a/shared/haml/hamburger.haml
+++ b/shared/haml/hamburger.haml
@@ -15,12 +15,12 @@
         .hamburger-expandable-items{id: "#{entry[:id]}-items"}
           - entry[:subentries].each do |subentry|
             .item
-              %a{id: subentry[:id], href: subentry[:url], tabindex: "0"}= subentry[:title]
+              %a{id: subentry[:id], href: subentry[:url]}= subentry[:title]
       - else
         %div{class: entry[:class]}
           .item
             - target = entry[:target] ? entry[:target] : "_self"
-            %a{id: entry[:id], href: entry[:url], target: target, rel: entry[:rel], tabindex: "0"}= entry[:title]
+            %a{id: entry[:id], href: entry[:url], target: target, rel: entry[:rel]}= entry[:title]
 
   #hamburger-icon.clicktag{class: contents[:visibility]}
     %span{style: "pointer-events: none"}

--- a/shared/haml/hamburger.haml
+++ b/shared/haml/hamburger.haml
@@ -2,7 +2,7 @@
   options = { level: level, script_level: script_level, language: language, user_type: user_type, loc_prefix: loc_prefix, request: request }
   contents = Hamburger.get_hamburger_contents(options)
 
-%button#hamburger{class: contents[:visibility], tabindex: "0", role: "navigation", 'aria-label': "Menu"}
+#hamburger{class: contents[:visibility], tabindex: "0", 'aria-label': I18n.t('header_screen_reader_hamburger')}
   #hamburger-contents.hide-responsive-menu
     - contents[:entries].each do |entry|
       - if entry[:type] == "divider"

--- a/shared/haml/help_button.haml
+++ b/shared/haml/help_button.haml
@@ -5,7 +5,7 @@
 
   help_items = HelpHeader.get_help_contents(options)
 
-.help_button{class: "hide-mobile", id: "help-button", tabindex: "0", alt: "Help Menu"}
+.help_button{class: "hide-mobile", id: "help-button", tabindex: "0", 'aria-label': I18n.t('header_screen_reader_help')}
   .help_contents{style: 'display: none', id: "help-contents"}
     - help_items.each do |entry|
       %a.linktag{id: entry[:id], href: entry[:url], target: entry[:target], rel: entry[:rel], tabindex: "0"}=entry[:title]

--- a/shared/haml/help_button.haml
+++ b/shared/haml/help_button.haml
@@ -5,10 +5,10 @@
 
   help_items = HelpHeader.get_help_contents(options)
 
-.help_button{class: "hide-mobile", id: "help-button"}
+.help_button{class: "hide-mobile", id: "help-button", tabindex: "0", alt: "Help Menu"}
   .help_contents{style: 'display: none', id: "help-contents"}
     - help_items.each do |entry|
-      %a.linktag{id: entry[:id], href: entry[:url], target: entry[:target], rel: entry[:rel]}=entry[:title]
+      %a.linktag{id: entry[:id], href: entry[:url], target: entry[:target], rel: entry[:rel], tabindex: "0"}=entry[:title]
 
   %i.help_icon.clicktag{class: "fa fa-question-circle hide-mobile", id: "help-icon"}
     %span{style: "pointer-events: none"}

--- a/shared/haml/help_button.haml
+++ b/shared/haml/help_button.haml
@@ -8,7 +8,7 @@
 .help_button{class: "hide-mobile", id: "help-button", tabindex: "0", 'aria-label': I18n.t('header_screen_reader_help')}
   .help_contents{style: 'display: none', id: "help-contents"}
     - help_items.each do |entry|
-      %a.linktag{id: entry[:id], href: entry[:url], target: entry[:target], rel: entry[:rel], tabindex: "0"}=entry[:title]
+      %a.linktag{id: entry[:id], href: entry[:url], target: entry[:target], rel: entry[:rel]}=entry[:title]
 
   %i.help_icon.clicktag{class: "fa fa-question-circle hide-mobile", id: "help-icon"}
     %span{style: "pointer-events: none"}

--- a/shared/haml/help_button.haml
+++ b/shared/haml/help_button.haml
@@ -5,7 +5,7 @@
 
   help_items = HelpHeader.get_help_contents(options)
 
-%button.help_button{class: "hide-mobile", id: "help-button", tabindex: "0", 'aria-label': "Help Menu", role: "button"}
+.help_button{class: "hide-mobile", id: "help-button", tabindex: "0", 'aria-label': I18n.t('header_screen_reader_help')}
   .help_contents{style: 'display: none', id: "help-contents"}
     - help_items.each do |entry|
       %a.linktag{id: entry[:id], href: entry[:url], target: entry[:target], rel: entry[:rel], tabindex: "0"}=entry[:title]

--- a/shared/haml/help_button.haml
+++ b/shared/haml/help_button.haml
@@ -5,7 +5,7 @@
 
   help_items = HelpHeader.get_help_contents(options)
 
-.help_button{class: "hide-mobile", id: "help-button", tabindex: "0", 'aria-label': I18n.t('header_screen_reader_help')}
+%button.help_button{class: "hide-mobile", id: "help-button", tabindex: "0", 'aria-label': "Help Menu", role: "button"}
   .help_contents{style: 'display: none', id: "help-contents"}
     - help_items.each do |entry|
       %a.linktag{id: entry[:id], href: entry[:url], target: entry[:target], rel: entry[:rel], tabindex: "0"}=entry[:title]

--- a/shared/haml/user_header.haml
+++ b/shared/haml/user_header.haml
@@ -18,7 +18,7 @@
   should_show_create_menu = !level || level.try(:is_project_level)
 
 - if should_show_create_menu
-  .header_button.create_menu
+  .header_button.create_menu{tabindex: "0"}
     %span.create_button
       = I18n.t("#{loc_prefix}create")
     &nbsp;
@@ -34,7 +34,7 @@
         .project_link#view_all_projects
           = I18n.t("#{loc_prefix}view_all")
 - if current_user
-  .header_button.header_user.user_menu
+  .header_button.header_user.user_menu{tabindex: "0"}
     - if current_user.can_pair? && session_pairings.present?
       %i.fa.fa-users.pairing_icon
       %span.pairing_name= I18n.t("#{loc_prefix}team")
@@ -105,18 +105,20 @@
       $(document).off('click', hideUserOptions);
     }
     $(document).ready(function() {
-      $('.user_menu').click(function (e) {
-        if ($('.user_options').is(':hidden')) {
-          e.stopPropagation();
-          $('.user_options').slideDown();
-          $('.user_menu_arrow_down').hide();
-          $('.user_menu_arrow_up').show();
-          $(document).on('click', hideUserOptions);
-          hideCreateOptions()
-          $("#hamburger-icon").removeClass('active');
-          $("#help-icon").removeClass('active');
-          $('#hamburger #hamburger-contents').slideUp();
-          $('#help-button #help-contents').slideUp();
+      $('.user_menu').on("keypress click", function (e) {
+        if ((e.type === "keypress" && e.which === 13) || (e.type === "click")) {
+          if ($('.user_options').is(':hidden')) {
+            e.stopPropagation();
+            $('.user_options').slideDown();
+            $('.user_menu_arrow_down').hide();
+            $('.user_menu_arrow_up').show();
+            $(document).on('keypress click', hideUserOptions);
+            hideCreateOptions()
+            $("#hamburger-icon").removeClass('active');
+            $("#help-icon").removeClass('active');
+            $('#hamburger #hamburger-contents').slideUp();
+            $('#help-button #help-contents').slideUp();
+          }
         }
       });
       $('.user_options').click(function (e) {

--- a/shared/haml/user_header.haml
+++ b/shared/haml/user_header.haml
@@ -18,7 +18,7 @@
   should_show_create_menu = !level || level.try(:is_project_level)
 
 - if should_show_create_menu
-  .header_button.create_menu{tabindex: "0"}
+  .header_button.create_menu
     %span.create_button
       = I18n.t("#{loc_prefix}create")
     &nbsp;
@@ -34,7 +34,7 @@
         .project_link#view_all_projects
           = I18n.t("#{loc_prefix}view_all")
 - if current_user
-  .header_button.header_user.user_menu{tabindex: "0"}
+  %button.header_button.header_user.user_menu
     - if current_user.can_pair? && session_pairings.present?
       %i.fa.fa-users.pairing_icon
       %span.pairing_name= I18n.t("#{loc_prefix}team")
@@ -105,20 +105,18 @@
       $(document).off('click', hideUserOptions);
     }
     $(document).ready(function() {
-      $('.user_menu').on("keypress click", function (e) {
-        if ((e.type === "keypress" && e.which === 13) || (e.type === "click")) {
-          if ($('.user_options').is(':hidden')) {
-            e.stopPropagation();
-            $('.user_options').slideDown();
-            $('.user_menu_arrow_down').hide();
-            $('.user_menu_arrow_up').show();
-            $(document).on('keypress click', hideUserOptions);
-            hideCreateOptions()
-            $("#hamburger-icon").removeClass('active');
-            $("#help-icon").removeClass('active');
-            $('#hamburger #hamburger-contents').slideUp();
-            $('#help-button #help-contents').slideUp();
-          }
+      $('.user_menu').click(function (e) {
+        if ($('.user_options').is(':hidden')) {
+          e.stopPropagation();
+          $('.user_options').slideDown();
+          $('.user_menu_arrow_down').hide();
+          $('.user_menu_arrow_up').show();
+          $(document).on('keypress click', hideUserOptions);
+          hideCreateOptions()
+          $("#hamburger-icon").removeClass('active');
+          $("#help-icon").removeClass('active');
+          $('#hamburger #hamburger-contents').slideUp();
+          $('#help-button #help-contents').slideUp();
         }
       });
       $('.user_options').click(function (e) {


### PR DESCRIPTION
<!--
  Your description goes here: A summary of the change, including any relevant motivation and context.

  If relevant, include a description both of the existing behavior and of the new behavior.
-->
Adding screen reader accessibility for the user menu, help menu, and hamburger menu

- Help and Hamburger menus have translatable aria labels. Their strings have been added to the [I18n GSheet](https://docs.google.com/spreadsheets/d/1Tq7VqZALgRA0wYk0HDfEOTyRI0TM2Dir2rloXIPGCgU/edit#gid=0) as `header_screen_reader_hamburger` and `header_screen_reader_help`
- All 3 menus are now tab-accessible and can be expanded by using the return key (including the expandable items in the hamburger menu).

<!--
  Other aspects to consider. uncomment and add detail for any that seem necessary:
-->

<!-- ### Background -->
<!-- ### Privacy -->
<!--
1.	Does the Project involve the collection, use or sharing of new Personal Data?

2.	Does the Project involve a new or changed use or sharing of existing Personal Data?
-->
<!-- ### Security -->
<!--
Link to Jira Task where sensitive security issues are discussed privately.
-->
<!-- ### Caching -->
<!-- ### Deployment strategy -->
<!-- ### Future work -->

## Links

<!--
  Any relevant links to external resources; ie, specification documents, jira
  items, related PRs, honeybadger errors, etc
-->

- [spec]()
- [jira]()

## Testing story

<!--
  Does your change include appropriate tests?

  If so, please describe how the tests included in this PR are sufficient

  If not, please explain why this change does not need to be tested.
-->

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
