### PR TITLE
Revert "Revert "Create or edit vocabulary""

### DIFF
--- a/apps/src/lib/levelbuilder/lesson-editor/AddVocabularyDialog.jsx
+++ b/apps/src/lib/levelbuilder/lesson-editor/AddVocabularyDialog.jsx
@@ -1,0 +1,163 @@
+import PropTypes from 'prop-types';
+import React, {Component} from 'react';
+import BaseDialog from '@cdo/apps/templates/BaseDialog';
+import DialogFooter from '@cdo/apps/templates/teacherDashboard/DialogFooter';
+import color from '@cdo/apps/util/color';
+import {vocabularyShape} from '@cdo/apps/lib/levelbuilder/shapes';
+import $ from 'jquery';
+
+const styles = {
+  dialog: {
+    paddingLeft: 20,
+    paddingRight: 20,
+    paddingBottom: 20,
+    fontFamily: '"Gotham 4r", sans-serif, sans-serif'
+  },
+  container: {
+    display: 'flex',
+    flexDirection: 'column'
+  },
+  inputAndLabel: {
+    display: 'flex',
+    flexDirection: 'column'
+  },
+  textInput: {
+    width: '98%'
+  },
+  submitButton: {
+    color: 'white',
+    backgroundColor: color.orange,
+    borderColor: color.orange,
+    borderRadius: 3,
+    fontSize: 12,
+    fontFamily: '"Gotham 4r", sans-serif',
+    fontWeight: 'bold',
+    paddingLeft: 20,
+    paddingRight: 20,
+    paddingTop: 5,
+    paddingBottom: 5
+  }
+};
+
+const initialState = {
+  word: '',
+  definition: '',
+  isSaving: false,
+  error: ''
+};
+
+export default class AddVocabularyDialog extends Component {
+  static propTypes = {
+    afterSave: PropTypes.func.isRequired,
+    handleClose: PropTypes.func.isRequired,
+    editingVocabulary: vocabularyShape,
+    courseVersionId: PropTypes.number.isRequired
+  };
+
+  constructor(props) {
+    super(props);
+    if (this.props.editingVocabulary) {
+      this.state = {
+        ...this.props.editingVocabulary,
+        isSaving: false,
+        error: ''
+      };
+    } else {
+      this.state = {...initialState};
+    }
+  }
+
+  handleWordChange = e => {
+    this.setState({word: e.target.value});
+  };
+
+  handleDefinitionChange = e => {
+    this.setState({definition: e.target.value});
+  };
+
+  resetState = () => {
+    this.setState(initialState);
+  };
+
+  onClose = () => {
+    this.resetState();
+    this.props.handleClose();
+  };
+
+  saveVocabulary = e => {
+    this.setState({isSaving: true});
+    const url = this.props.editingVocabulary
+      ? `/vocabularies/${this.props.editingVocabulary.id}`
+      : '/vocabularies';
+    const method = this.props.editingVocabulary ? 'PATCH' : 'POST';
+    const data = {
+      word: this.state.word,
+      definition: this.state.definition,
+      courseVersionId: this.props.courseVersionId
+    };
+    if (this.props.editingVocabulary) {
+      data['key'] = this.props.editingVocabulary.key;
+    }
+    $.ajax({
+      url: url,
+      method: method,
+      dataType: 'json',
+      contentType: 'application/json;charset=UTF-8',
+      data: JSON.stringify(data)
+    })
+      .done(data => {
+        this.props.afterSave(data);
+        this.onClose();
+      })
+      .fail(error => {
+        this.setState({isSaving: false, error: error.responseText});
+      });
+  };
+
+  render() {
+    const canSubmit =
+      !this.state.isSaving &&
+      this.state.word !== '' &&
+      this.state.definition !== '';
+    return (
+      <BaseDialog isOpen={true} handleClose={this.onClose}>
+        <h2>
+          {this.props.editingVocabulary ? 'Edit Vocabulary' : 'Add Vocabulary'}
+        </h2>
+
+        {this.state.error && <h3>{this.state.error}</h3>}
+        <label style={styles.inputAndLabel}>
+          Word
+          <input
+            type="text"
+            name="word"
+            value={this.state.word}
+            onChange={this.handleWordChange}
+            style={styles.textInput}
+          />
+        </label>
+        <label style={styles.inputAndLabel}>
+          Definition
+          <input
+            type="text"
+            name="definition"
+            value={this.state.definition}
+            onChange={this.handleDefinitionChange}
+            style={styles.textInput}
+          />
+        </label>
+        <DialogFooter rightAlign>
+          <button
+            id="submit-button"
+            type="button"
+            style={styles.submitButton}
+            onClick={this.saveVocabulary}
+            disabled={!canSubmit}
+          >
+            Close and Save
+          </button>
+        </DialogFooter>
+      </BaseDialog>
+    );
+  }
+}

--- a/apps/src/lib/levelbuilder/lesson-editor/ObjectivesEditor.jsx
+++ b/apps/src/lib/levelbuilder/lesson-editor/ObjectivesEditor.jsx
@@ -1,13 +1,13 @@
 import PropTypes from 'prop-types';
 import React, {Component} from 'react';
-import color from '@cdo/apps/util/color';
 import ObjectiveLine from './ObjectiveLine';
 
 const styles = {
   addButton: {
-    background: color.cyan,
+    background: '#eee',
+    border: '1px solid #ddd',
+    boxShadow: 'inset 0 1px 0 0 rgba(255, 255, 255, 0.8)',
     borderRadius: 3,
-    color: color.white,
     fontSize: 14,
     padding: 7,
     textAlign: 'center',
@@ -141,7 +141,8 @@ export default class ObjectivesEditor extends Component {
           style={styles.addButton}
           type="button"
         >
-          <i className="fa fa-plus" style={{marginRight: 7}} /> Objective
+          <i className="fa fa-plus" style={{marginRight: 7}} /> Create New
+          Objective
         </button>
       </div>
     );

--- a/apps/src/lib/levelbuilder/lesson-editor/ResourcesEditor.jsx
+++ b/apps/src/lib/levelbuilder/lesson-editor/ResourcesEditor.jsx
@@ -42,9 +42,10 @@ const styles = {
     lineHeight: '30px'
   },
   addButton: {
-    background: color.cyan,
+    background: '#eee',
+    border: '1px solid #ddd',
+    boxShadow: 'inset 0 1px 0 0 rgba(255, 255, 255, 0.8)',
     borderRadius: 3,
-    color: color.white,
     fontSize: 14,
     padding: 7,
     textAlign: 'center',
@@ -282,7 +283,9 @@ class ResourcesEditor extends Component {
         )}
         <div>
           <div style={styles.resourceSearch}>
-            <label>Select a resource to add</label>
+            <label>
+              <strong>Select a resource to add</strong>
+            </label>
             <SearchBox
               onSearchSelect={this.onSearchSelect}
               searchUrl={'resourcesearch'}
@@ -301,7 +304,8 @@ class ResourcesEditor extends Component {
             style={styles.addButton}
             type="button"
           >
-            <i className="fa fa-plus" style={{marginRight: 7}} /> Resource
+            <i className="fa fa-plus" style={{marginRight: 7}} /> Create New
+            Resource
           </button>
         </div>
       </div>

--- a/apps/src/lib/levelbuilder/lesson-editor/vocabulariesEditorRedux.js
+++ b/apps/src/lib/levelbuilder/lesson-editor/vocabulariesEditorRedux.js
@@ -17,7 +17,7 @@ export const addVocabulary = newVocabulary => ({
   newVocabulary
 });
 
-export const editVocabulary = updatedVocabulary => ({
+export const updateVocabulary = updatedVocabulary => ({
   type: EDIT_VOCABULARY,
   updatedVocabulary
 });

--- a/apps/src/lib/levelbuilder/shapes.jsx
+++ b/apps/src/lib/levelbuilder/shapes.jsx
@@ -85,6 +85,7 @@ export const resourceShape = PropTypes.shape({
 });
 
 export const vocabularyShape = PropTypes.shape({
+  id: PropTypes.number.isRequired,
   key: PropTypes.string.isRequired,
   word: PropTypes.string.isRequired,
   definition: PropTypes.string.isRequired

--- a/apps/test/unit/lib/levelbuilder/lesson-editor/AddVocabularyDialogTest.jsx
+++ b/apps/test/unit/lib/levelbuilder/lesson-editor/AddVocabularyDialogTest.jsx
@@ -1,0 +1,104 @@
+import React from 'react';
+import {shallow, mount} from 'enzyme';
+import {expect} from '../../../../util/reconfiguredChai';
+import AddVocabularyDialog from '@cdo/apps/lib/levelbuilder/lesson-editor/AddVocabularyDialog';
+import sinon from 'sinon';
+
+describe('AddVocabularyDialog', () => {
+  let defaultProps, afterSaveSpy, handleCloseSpy;
+  beforeEach(() => {
+    afterSaveSpy = sinon.spy();
+    handleCloseSpy = sinon.spy();
+    defaultProps = {
+      isOpen: true,
+      afterSave: afterSaveSpy,
+      handleClose: handleCloseSpy,
+      courseVersionId: 1
+    };
+  });
+
+  it('renders default props', () => {
+    const wrapper = shallow(<AddVocabularyDialog {...defaultProps} />);
+    expect(wrapper.contains('Add Vocabulary')).to.be.true;
+    expect(wrapper.find('input').length).to.equal(2);
+  });
+
+  it('closes if save is successful', () => {
+    const wrapper = mount(<AddVocabularyDialog {...defaultProps} />);
+    const instance = wrapper.instance();
+    instance.setState({
+      word: 'my vocabulary word',
+      definition: 'my vocabulary definition'
+    });
+    instance.forceUpdate();
+    wrapper.update();
+    /*const saveVocabularySpy = sinon.stub(instance, 'saveVocabulary');
+    expect(saveVocabularySpy.calledOnce).to.be.true;*/
+    let returnData = {
+      id: 1,
+      key: 'my vocabulary word',
+      word: 'my vocabulary word',
+      definition: 'my vocabulary definition'
+    };
+    let server = sinon.fakeServer.create();
+    server.respondWith('POST', `/vocabularies`, [
+      200,
+      {'Content-Type': 'application/json'},
+      JSON.stringify(returnData)
+    ]);
+
+    wrapper.find('#submit-button').simulate('click');
+    expect(wrapper.find('AddVocabularyDialog').state().isSaving).to.be.true;
+
+    server.respond();
+    wrapper.update();
+
+    expect(handleCloseSpy.calledOnce).to.be.true;
+    expect(afterSaveSpy.calledOnce).to.be.true;
+  });
+
+  it('renders an existing vocabulary for edit', () => {
+    const existingVocabulary = {
+      id: 200,
+      key: 'key',
+      word: 'existing vocab',
+      definition: 'existing definition'
+    };
+    const wrapper = mount(
+      <AddVocabularyDialog
+        {...defaultProps}
+        editingVocabulary={existingVocabulary}
+      />
+    );
+    expect(wrapper.find('[name="word"]').props().value).to.equal(
+      'existing vocab'
+    );
+    expect(wrapper.find('[name="definition"]').props().value).to.equal(
+      'existing definition'
+    );
+  });
+
+  it('shows an error if save was unsuccessful', () => {
+    const wrapper = mount(<AddVocabularyDialog {...defaultProps} />);
+    const instance = wrapper.instance();
+    instance.setState({
+      word: 'my vocabulary word',
+      definition: 'my vocabulary definition'
+    });
+    instance.forceUpdate();
+    wrapper.update();
+
+    let returnData = 'There was an error';
+    let server = sinon.fakeServer.create();
+    server.respondWith('POST', `/vocabularies`, [
+      404,
+      {'Content-Type': 'application/json'},
+      returnData
+    ]);
+
+    wrapper.find('#submit-button').simulate('click');
+    server.respond();
+    wrapper.update();
+    expect(wrapper.find('h3').contains('There was an error'));
+  });
+});

--- a/apps/test/unit/lib/levelbuilder/lesson-editor/FindVocabularyDialogTest.js
+++ b/apps/test/unit/lib/levelbuilder/lesson-editor/FindVocabularyDialogTest.js
@@ -13,8 +13,8 @@ describe('FindVocabularyDialog', () => {
       handleConfirm,
       handleClose: sinon.spy(),
       vocabularies: [
-        {key: 'key1', word: 'word1', definition: 'definition1'},
-        {key: 'key2', word: 'word2', definition: 'definition2'}
+        {id: 1, key: 'key1', word: 'word1', definition: 'definition1'},
+        {id: 2, key: 'key2', word: 'word2', definition: 'definition2'}
       ]
     };
   });

--- a/apps/test/unit/lib/levelbuilder/lesson-editor/VocabulariesEditorTest.js
+++ b/apps/test/unit/lib/levelbuilder/lesson-editor/VocabulariesEditorTest.js
@@ -5,18 +5,18 @@ import {expect} from '../../../../util/reconfiguredChai';
 import {UnconnectedVocabulariesEditor as VocabulariesEditor} from '@cdo/apps/lib/levelbuilder/lesson-editor/VocabulariesEditor';
 
 describe('VocabulariesEditor', () => {
-  let defaultProps, addVocabulary, editVocabulary, removeVocabulary;
+  let defaultProps, addVocabulary, updateVocabulary, removeVocabulary;
   beforeEach(() => {
     addVocabulary = sinon.spy();
-    editVocabulary = sinon.spy();
+    updateVocabulary = sinon.spy();
     removeVocabulary = sinon.spy();
     defaultProps = {
       vocabularies: [
-        {key: '1', word: 'word1', definition: 'def1'},
-        {key: '2', word: 'word2', definition: 'def2'}
+        {id: 1, key: '1', word: 'word1', definition: 'def1'},
+        {id: 2, key: '2', word: 'word2', definition: 'def2'}
       ],
       addVocabulary,
-      editVocabulary,
+      updateVocabulary,
       removeVocabulary
     };
   });

--- a/apps/test/unit/lib/levelbuilder/lesson-editor/vocabulariesEditorReduxTest.js
+++ b/apps/test/unit/lib/levelbuilder/lesson-editor/vocabulariesEditorReduxTest.js
@@ -1,18 +1,20 @@
 import {assert} from 'chai';
 import vocabularyEditor, {
   addVocabulary,
-  editVocabulary,
+  updateVocabulary,
   removeVocabulary
 } from '@cdo/apps/lib/levelbuilder/lesson-editor/vocabulariesEditorRedux';
 import _ from 'lodash';
 
 const getInitialState = () => [
   {
+    id: 1,
     key: 'vocabulary-1',
     word: 'vocabulary-1',
     definition: 'definition1'
   },
   {
+    id: 2,
     key: 'vocabulary-2',
     word: 'vocabulary-2',
     definition: 'definition2'
@@ -27,6 +29,7 @@ describe('vocabulariesEditorRedux reducer tests', () => {
     const nextState = vocabularyEditor(
       initialState,
       addVocabulary({
+        id: 3,
         key: 'new-word',
         word: 'new-word',
         definition: 'new-definition'
@@ -44,7 +47,7 @@ describe('vocabulariesEditorRedux reducer tests', () => {
     editedVocabulary.word = 'new word';
     const nextState = vocabularyEditor(
       initialState,
-      editVocabulary(editedVocabulary)
+      updateVocabulary(editedVocabulary)
     );
     assert.deepEqual(nextState.map(r => r.word), ['new word', 'vocabulary-2']);
   });

--- a/dashboard/app/controllers/vocabularies_controller.rb
+++ b/dashboard/app/controllers/vocabularies_controller.rb
@@ -1,6 +1,46 @@
 class VocabulariesController < ApplicationController
+  before_action :require_levelbuilder_mode_or_test_env, except: [:show]
+
   # GET /vocabularysearch
   def search
     render json: VocabularyAutocomplete.get_search_matches(params[:query], params[:limit], params[:courseVersionId])
+  end
+
+  # POST /vocabularies
+  def create
+    course_version = CourseVersion.find_by_id(vocabulary_params[:course_version_id])
+    unless course_version
+      render status: 400, json: {error: "course version not found"}
+      return
+    end
+    vocabulary = Vocabulary.new(
+      word: vocabulary_params[:word],
+      definition: vocabulary_params[:definition]
+    )
+    vocabulary.course_version = course_version
+    begin
+      vocabulary.save!
+      render json: vocabulary.summarize_for_lesson_edit
+    rescue ActiveRecord::RecordNotUnique, ActiveRecord::RecordInvalid => e
+      render status: 400, json: {error: e.message.to_json}
+    end
+  end
+
+  # PUT/PATCH /vocabularies
+  def update
+    vocabulary = Vocabulary.find_by_id(vocabulary_params[:id])
+    if vocabulary && vocabulary.update!(vocabulary_params)
+      render json: vocabulary.summarize_for_lesson_edit
+    else
+      render json: {status: 404, error: "Vocabulary #{vocabulary_params[:id]} not found"}
+    end
+  end
+
+  private
+
+  def vocabulary_params
+    vp = params.transform_keys(&:underscore)
+    vp = vp.permit(:id, :key, :word, :definition, :course_version_id)
+    vp
   end
 end

--- a/dashboard/app/models/lesson.rb
+++ b/dashboard/app/models/lesson.rb
@@ -313,7 +313,7 @@ class Lesson < ApplicationRecord
       announcements: announcements,
       activities: lesson_activities.map(&:summarize_for_lesson_edit),
       resources: resources.map(&:summarize_for_lesson_edit),
-      vocabularies: vocabularies.map(&:summarize_for_edit),
+      vocabularies: vocabularies.map(&:summarize_for_lesson_edit),
       objectives: objectives.map(&:summarize_for_edit),
       courseVersionId: lesson_group.script.get_course_version&.id,
       scriptPath: script_path(script),

--- a/dashboard/app/models/vocabulary.rb
+++ b/dashboard/app/models/vocabulary.rb
@@ -20,6 +20,8 @@ class Vocabulary < ApplicationRecord
   has_many :lessons_vocabularies
   belongs_to :course_version
 
+  before_validation :generate_key, on: :create
+
   # Used for seeding from JSON. Returns the full set of information needed to
   # uniquely identify this object as well as any other objects it belongs to.
   # If the attributes of this object alone aren't sufficient, and associated
@@ -41,8 +43,13 @@ class Vocabulary < ApplicationRecord
     {key: key, word: display_word, definition: display_definition}
   end
 
-  def summarize_for_edit
-    {key: key, word: word, definition: definition}
+  def summarize_for_lesson_edit
+    {id: id, key: key, word: word, definition: definition}
+  end
+
+  def generate_key
+    return if key
+    self.key = word
   end
 
   private

--- a/dashboard/config/routes.rb
+++ b/dashboard/config/routes.rb
@@ -319,6 +319,7 @@ Dashboard::Application.routes.draw do
   resources :resources, only: [:create, :update]
   get '/resourcesearch', to: 'resources#search', defaults: {format: 'json'}
 
+  resources :vocabularies, only: [:create, :update]
   get '/vocabularysearch', to: 'vocabularies#search', defaults: {format: 'json'}
 
   get '/beta', to: redirect('/')

--- a/dashboard/test/controllers/vocabularies_controller_test.rb
+++ b/dashboard/test/controllers/vocabularies_controller_test.rb
@@ -1,0 +1,46 @@
+require 'test_helper'
+
+class VocabulariesControllerTest < ActionController::TestCase
+  include Devise::Test::ControllerHelpers
+
+  setup do
+    Rails.application.config.stubs(:levelbuilder_mode).returns true
+    @levelbuilder = create :levelbuilder
+  end
+
+  test "can create vocabulary from params" do
+    sign_in @levelbuilder
+    course_version = create :course_version
+    assert_creates(Vocabulary) do
+      post :create, params: {word: 'Algorithm', definition: 'definition of algorithm', courseVersionId: course_version.id}
+      assert_response :success
+    end
+    assert(@response.body.include?('Algorithm'))
+    assert(@response.body.include?('definition of algorithm'))
+  end
+
+  test "can update from params" do
+    sign_in @levelbuilder
+    course_version = create :course_version
+    vocabulary = create :vocabulary, word: 'word', definition: 'draft definition', course_version: course_version
+    post :update, params: {id: vocabulary.id, word: 'word', definition: 'updated definition', courseVersionId: course_version.id}
+    assert_response :success
+
+    vocabulary.reload
+    assert_equal 'updated definition', vocabulary.definition
+    assert(@response.body.include?('updated definition'))
+  end
+
+  test "creating vocabulary that already exists results in error" do
+    sign_in @levelbuilder
+    course_version = create :course_version
+    vocabulary = create :vocabulary, key: 'variable', word: 'variable', definition: 'definition', course_version: course_version
+
+    post :create, params: {word: 'variable', definition: 'different definition', courseVersionId: course_version.id}
+    assert_response :bad_request
+
+    # Check that the original vocabulary wasn't changed
+    vocabulary.reload
+    assert_equal 'definition', vocabulary.definition
+  end
+end


### PR DESCRIPTION
Reverts code-dot-org/code-dot-org#38780

400ecad7f478d2fa02149d3d80c054ac48b3ea22 contains the test fix.

#38694 broke test, despite the fact that Drone succeeded. This was because a test added in #38641 didn't set a required field of `vocabularyShape`. #38641 was merged before #38694 but was not pulled into #38694 before merge.