### PR TITLE
Add LessonEditorDialog React Component

### DIFF
--- a/apps/src/lib/levelbuilder/lesson-editor/AddLevelDialog.jsx
+++ b/apps/src/lib/levelbuilder/lesson-editor/AddLevelDialog.jsx
@@ -1,21 +1,19 @@
 import PropTypes from 'prop-types';
 import React, {Component} from 'react';
-import i18n from '@cdo/locale';
-import BaseDialog from '@cdo/apps/templates/BaseDialog';
-import DialogFooter from '@cdo/apps/templates/teacherDashboard/DialogFooter';
-import Button from '@cdo/apps/templates/Button';
-import LevelToken from '@cdo/apps/lib/levelbuilder/lesson-editor/LevelToken';
+
 import AddLevelDialogTop from '@cdo/apps/lib/levelbuilder/lesson-editor/AddLevelDialogTop';
+import Button from '@cdo/apps/templates/Button';
+import DialogFooter from '@cdo/apps/templates/teacherDashboard/DialogFooter';
+import LevelToken from '@cdo/apps/lib/levelbuilder/lesson-editor/LevelToken';
 import RemoveLevelDialog from '@cdo/apps/lib/levelbuilder/lesson-editor/RemoveLevelDialog';
+import i18n from '@cdo/locale';
 import {activitySectionShape} from '@cdo/apps/lib/levelbuilder/shapes';
+
+import LessonEditorDialog from './LessonEditorDialog';
 
 const styles = {
   dialog: {
-    paddingLeft: 20,
-    paddingRight: 20,
-    paddingBottom: 20,
     width: 970,
-    fontFamily: '"Gotham 4r", sans-serif, sans-serif',
     marginLeft: -500
   },
   dialogContent: {
@@ -70,10 +68,9 @@ export default class AddLevelDialog extends Component {
 
   render() {
     return (
-      <BaseDialog
+      <LessonEditorDialog
         isOpen={this.props.isOpen}
         handleClose={this.props.handleConfirm}
-        useUpdatedStyles
         style={styles.dialog}
       >
         <h2>Add Levels</h2>
@@ -111,7 +108,7 @@ export default class AddLevelDialog extends Component {
             className="save-add-levels-button"
           />
         </DialogFooter>
-      </BaseDialog>
+      </LessonEditorDialog>
     );
   }
 }

--- a/apps/src/lib/levelbuilder/lesson-editor/AddResourceDialog.jsx
+++ b/apps/src/lib/levelbuilder/lesson-editor/AddResourceDialog.jsx
@@ -1,19 +1,15 @@
 import PropTypes from 'prop-types';
 import React, {Component} from 'react';
-import BaseDialog from '@cdo/apps/templates/BaseDialog';
+import _ from 'lodash';
+
 import DialogFooter from '@cdo/apps/templates/teacherDashboard/DialogFooter';
 import RailsAuthenticityToken from '@cdo/apps/lib/util/RailsAuthenticityToken';
 import color from '@cdo/apps/util/color';
 import {resourceShape} from '@cdo/apps/lib/levelbuilder/shapes';
-import _ from 'lodash';
+
+import LessonEditorDialog from './LessonEditorDialog';
 
 const styles = {
-  dialog: {
-    paddingLeft: 20,
-    paddingRight: 20,
-    paddingBottom: 20,
-    fontFamily: '"Gotham 4r", sans-serif, sans-serif'
-  },
   container: {
     display: 'flex',
     flexDirection: 'column'
@@ -171,11 +167,9 @@ export default class AddResourceDialog extends Component {
 
   render() {
     return (
-      <BaseDialog
+      <LessonEditorDialog
         isOpen={this.props.isOpen}
         handleClose={this.props.handleClose}
-        useUpdatedStyles
-        style={styles.dialog}
       >
         <h2>
           {this.props.existingResource ? 'Edit Resource' : 'Add Resource'}
@@ -291,7 +285,7 @@ export default class AddResourceDialog extends Component {
             />
           </DialogFooter>
         </form>
-      </BaseDialog>
+      </LessonEditorDialog>
     );
   }
 }

--- a/apps/src/lib/levelbuilder/lesson-editor/EditTipDialog.jsx
+++ b/apps/src/lib/levelbuilder/lesson-editor/EditTipDialog.jsx
@@ -1,23 +1,19 @@
 import PropTypes from 'prop-types';
 import React, {Component} from 'react';
-import i18n from '@cdo/locale';
-import BaseDialog from '@cdo/apps/templates/BaseDialog';
-import DialogFooter from '@cdo/apps/templates/teacherDashboard/DialogFooter';
+import _ from 'lodash';
+
 import Button from '@cdo/apps/templates/Button';
+import DialogFooter from '@cdo/apps/templates/teacherDashboard/DialogFooter';
 import LessonTip, {
   tipTypes
 } from '@cdo/apps/templates/lessonOverview/activities/LessonTip';
-import _ from 'lodash';
+import i18n from '@cdo/locale';
 import {tipShape} from '@cdo/apps/lib/levelbuilder/shapes';
+
 import ConfirmDeleteButton from '../../../storage/dataBrowser/ConfirmDeleteButton';
+import LessonEditorDialog from './LessonEditorDialog';
 
 const styles = {
-  dialog: {
-    paddingLeft: 20,
-    paddingBottom: 20,
-    paddingRight: 20,
-    fontFamily: '"Gotham 4r", sans-serif, sans-serif'
-  },
   dialogContent: {
     display: 'flex',
     flexDirection: 'column'
@@ -76,11 +72,9 @@ export default class EditTipDialog extends Component {
 
   render() {
     return (
-      <BaseDialog
+      <LessonEditorDialog
         isOpen={this.props.isOpen}
         handleClose={this.handleClose}
-        useUpdatedStyles
-        style={styles.dialog}
       >
         <div style={styles.dialogContent}>
           <h2>Add Callout</h2>
@@ -123,7 +117,7 @@ export default class EditTipDialog extends Component {
             color={Button.ButtonColor.orange}
           />
         </DialogFooter>
-      </BaseDialog>
+      </LessonEditorDialog>
     );
   }
 }

--- a/apps/src/lib/levelbuilder/lesson-editor/FindResourceDialog.jsx
+++ b/apps/src/lib/levelbuilder/lesson-editor/FindResourceDialog.jsx
@@ -1,19 +1,12 @@
 import PropTypes from 'prop-types';
 import React, {Component} from 'react';
-import BaseDialog from '@cdo/apps/templates/BaseDialog';
-import DialogFooter from '@cdo/apps/templates/teacherDashboard/DialogFooter';
-import Button from '@cdo/apps/templates/Button';
 import {connect} from 'react-redux';
+
+import Button from '@cdo/apps/templates/Button';
+import DialogFooter from '@cdo/apps/templates/teacherDashboard/DialogFooter';
 import {resourceShape} from '@cdo/apps/lib/levelbuilder/shapes';
 
-const styles = {
-  dialog: {
-    paddingLeft: 20,
-    paddingRight: 20,
-    paddingBottom: 20,
-    fontFamily: '"Gotham 4r", sans-serif, sans-serif'
-  }
-};
+import LessonEditorDialog from './LessonEditorDialog';
 
 class FindResourceDialog extends Component {
   static propTypes = {
@@ -45,11 +38,9 @@ class FindResourceDialog extends Component {
 
   render() {
     return (
-      <BaseDialog
+      <LessonEditorDialog
         isOpen={this.props.isOpen}
         handleClose={this.props.handleClose}
-        useUpdatedStyles
-        style={styles.dialog}
       >
         <h2>Add Resource</h2>
         <label>
@@ -75,7 +66,7 @@ class FindResourceDialog extends Component {
             color={Button.ButtonColor.orange}
           />
         </DialogFooter>
-      </BaseDialog>
+      </LessonEditorDialog>
     );
   }
 }

--- a/apps/src/lib/levelbuilder/lesson-editor/FindVocabularyDialog.jsx
+++ b/apps/src/lib/levelbuilder/lesson-editor/FindVocabularyDialog.jsx
@@ -1,18 +1,11 @@
 import PropTypes from 'prop-types';
 import React, {Component} from 'react';
-import BaseDialog from '@cdo/apps/templates/BaseDialog';
-import DialogFooter from '@cdo/apps/templates/teacherDashboard/DialogFooter';
+
 import Button from '@cdo/apps/templates/Button';
+import DialogFooter from '@cdo/apps/templates/teacherDashboard/DialogFooter';
 import {vocabularyShape} from '@cdo/apps/lib/levelbuilder/shapes';
 
-const styles = {
-  dialog: {
-    paddingLeft: 20,
-    paddingRight: 20,
-    paddingBottom: 20,
-    fontFamily: '"Gotham 4r", sans-serif, sans-serif'
-  }
-};
+import LessonEditorDialog from './LessonEditorDialog';
 
 export default class FindVocabularyDialog extends Component {
   static propTypes = {
@@ -36,11 +29,9 @@ export default class FindVocabularyDialog extends Component {
 
   render() {
     return (
-      <BaseDialog
+      <LessonEditorDialog
         isOpen={this.props.isOpen}
         handleClose={this.props.handleClose}
-        useUpdatedStyles
-        style={styles.dialog}
       >
         <h2>Add Vocabulary</h2>
         <label>
@@ -66,7 +57,7 @@ export default class FindVocabularyDialog extends Component {
             color={Button.ButtonColor.orange}
           />
         </DialogFooter>
-      </BaseDialog>
+      </LessonEditorDialog>
     );
   }
 }

--- a/apps/src/lib/levelbuilder/lesson-editor/LessonEditorDialog.jsx
+++ b/apps/src/lib/levelbuilder/lesson-editor/LessonEditorDialog.jsx
@@ -1,0 +1,42 @@
+import PropTypes from 'prop-types';
+import React from 'react';
+
+import BaseDialog from '@cdo/apps/templates/BaseDialog';
+
+const defaultStyle = {
+  paddingLeft: 20,
+  paddingRight: 20,
+  paddingBottom: 20,
+  fontFamily: '"Gotham 4r", sans-serif, sans-serif'
+};
+
+export default class LessonEditorDialog extends React.Component {
+  static propTypes = {
+    children: PropTypes.oneOfType([
+      PropTypes.arrayOf(PropTypes.node),
+      PropTypes.node
+    ]).isRequired,
+    handleClose: PropTypes.func.isRequired,
+    isOpen: PropTypes.bool.isRequired,
+    style: PropTypes.object
+  };
+
+  render() {
+    const customStyle = this.props.style || {};
+    const style = {
+      ...defaultStyle,
+      ...customStyle
+    };
+
+    return (
+      <BaseDialog
+        handleClose={this.props.handleClose}
+        isOpen={this.props.isOpen}
+        style={style}
+        useUpdatedStyles
+      >
+        {this.props.children}
+      </BaseDialog>
+    );
+  }
+}

--- a/apps/src/lib/levelbuilder/lesson-editor/RemoveLevelDialog.jsx
+++ b/apps/src/lib/levelbuilder/lesson-editor/RemoveLevelDialog.jsx
@@ -1,6 +1,7 @@
 import React, {Component} from 'react';
 import PropTypes from 'prop-types';
 import {connect} from 'react-redux';
+
 import {removeLevel} from '@cdo/apps/lib/levelbuilder/lesson-editor/activitiesEditorRedux';
 import Dialog from '@cdo/apps/templates/Dialog';
 import {activitySectionShape} from '@cdo/apps/lib/levelbuilder/shapes';

--- a/apps/test/unit/lib/levelbuilder/lesson-editor/AddLevelDialogTest.jsx
+++ b/apps/test/unit/lib/levelbuilder/lesson-editor/AddLevelDialogTest.jsx
@@ -23,7 +23,7 @@ describe('AddLevelDialog', () => {
     const wrapper = shallow(<AddLevelDialog {...defaultProps} />);
 
     expect(wrapper.contains('Add Levels')).to.be.true;
-    expect(wrapper.find('BaseDialog').length).to.equal(1);
+    expect(wrapper.find('LessonEditorDialog').length).to.equal(1);
     expect(wrapper.find('Connect(AddLevelDialogTop)').length).to.equal(1);
     expect(wrapper.find('Connect(LevelToken)').length).to.equal(2);
     expect(wrapper.find('FontAwesome').length).to.equal(0); // no spinner

--- a/apps/test/unit/lib/levelbuilder/lesson-editor/EditTipDialogTest.jsx
+++ b/apps/test/unit/lib/levelbuilder/lesson-editor/EditTipDialogTest.jsx
@@ -27,7 +27,7 @@ describe('EditTipDialog', () => {
     expect(wrapper.find('LessonTip').length).to.equal(1);
     expect(wrapper.find('select').length).to.equal(1);
     expect(wrapper.find('textarea').length).to.equal(1);
-    expect(wrapper.find('BaseDialog').length).to.equal(1);
+    expect(wrapper.find('LessonEditorDialog').length).to.equal(1);
   });
 
   it('edit tip values', () => {

--- a/apps/test/unit/lib/levelbuilder/lesson-editor/FindResourceDialogTest.jsx
+++ b/apps/test/unit/lib/levelbuilder/lesson-editor/FindResourceDialogTest.jsx
@@ -20,7 +20,7 @@ describe('FindResourceDialog', () => {
   it('renders default props', () => {
     const wrapper = shallow(<FindResourceDialog {...defaultProps} />);
     expect(wrapper.contains('Add Resource')).to.be.true;
-    expect(wrapper.find('BaseDialog').length).to.equal(1);
+    expect(wrapper.find('LessonEditorDialog').length).to.equal(1);
     expect(wrapper.find('select').length).to.equal(1);
     expect(wrapper.find('Button').length).to.equal(1);
   });

--- a/apps/test/unit/lib/levelbuilder/lesson-editor/FindVocabularyDialogTest.js
+++ b/apps/test/unit/lib/levelbuilder/lesson-editor/FindVocabularyDialogTest.js
@@ -22,7 +22,7 @@ describe('FindVocabularyDialog', () => {
   it('renders default props', () => {
     const wrapper = shallow(<FindVocabularyDialog {...defaultProps} />);
     expect(wrapper.contains('Add Vocabulary')).to.be.true;
-    expect(wrapper.find('BaseDialog').length).to.equal(1);
+    expect(wrapper.find('LessonEditorDialog').length).to.equal(1);
     expect(wrapper.find('select').length).to.equal(1);
     expect(wrapper.find('option').length).to.equal(2);
     expect(wrapper.find('Button').length).to.equal(1);


### PR DESCRIPTION
We have a bunch of dialogs in the lesson editor that were all making identical customizations to the BaseDialog component. I extracted all that into a single LessonEditorDialog component, and updated the components to use it instead.

Also organized a few import statements.

## Testing story

Updated a number of tests which apparently care about which specific component we're using to render dialogs. Also had a conversation with Dave about rethinking our approach to testing moving forward.

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
