### PR TITLE
Include version of SMS controller used in demo

### DIFF
--- a/dashboard/app/controllers/sms_controller.rb
+++ b/dashboard/app/controllers/sms_controller.rb
@@ -4,11 +4,20 @@ class SmsController < ApplicationController
 
   # set up a client to talk to the Twilio REST API
   def send_to_phone
-    if params[:song]
-      open_tik_tok_url = params[:song]
-      video_url = "https://dance-api.code.org/videos/video-#{params[:channel_id]}.mp4"
-      message_body = "Here's your Dance Party video! Save this video and open in TikTok here to upload: #{open_tik_tok_url}"
-      send_sms(message_body, params[:phone], video_url)
+    #if params[:song]
+    if true
+      #open_tik_tok_url = params[:song]
+      open_tik_tok_url = 'https://www.tiktok.com/music/Level-Up-6580213968705424134?lang=en&is_copy_url=1'
+      #video_url = "https://dance-api.code.org/videos/video-#{params[:channel_id]}.mp4"
+      video_url = 'https://dance-api.code.org/videos/video-h4sxJYdlWGggroG0DRR9ug-demo3.mp4'
+      message_body = "Here's your Dance Party video #{video_url} ! Save this video and open TikTok here to upload: #{open_tik_tok_url}"
+
+      # We did this so that a message with
+      # a link to download your video (the first send_sms call)
+      # would get sent to your phone
+      # even if the video send failed (the second send_sms call)
+      send_sms(message_body, params[:phone])
+      send_sms("Here's your video", params[:phone], video_url)
     elsif params[:level_source] && !params[:level_source].empty? && params[:phone] && (level_source = LevelSource.find(params[:level_source]))
       send_sms_link(level_source_url(level_source), params[:phone])
     elsif params[:channel_id] && params[:phone] && ProjectsController::STANDALONE_PROJECTS.include?(params[:type])


### PR DESCRIPTION
Switch back to controller code used in our demo. Hard codes a single video to be sent that we've manually set the content-type header for in the S3 console.