### PR TITLE
Minor frontend fixes to improve unit test reliability

### DIFF
--- a/apps/src/code-studio/pd/application_dashboard/detail_view_contents.jsx
+++ b/apps/src/code-studio/pd/application_dashboard/detail_view_contents.jsx
@@ -499,10 +499,11 @@ export class DetailViewContents extends React.Component {
     return (
       <Button
         title={
-          !statusIsLockable &&
-          `Can only lock if status is one of ${ApplicationFinalStatuses.join(
-            ', '
-          )}`
+          !statusIsLockable
+            ? `Can only lock if status is one of ${ApplicationFinalStatuses.join(
+                ', '
+              )}`
+            : undefined
         }
         disabled={!(this.state.editing && statusIsLockable)}
         onClick={this.handleLockClick}
@@ -670,8 +671,9 @@ export class DetailViewContents extends React.Component {
           componentClass="select"
           disabled={this.state.locked || !this.state.editing}
           title={
-            this.state.locked &&
-            'The status of this application has been locked'
+            this.state.locked
+              ? 'The status of this application has been locked'
+              : undefined
           }
           value={this.state.status}
           onChange={this.handleStatusChange}

--- a/apps/src/code-studio/pd/foorm/FoormEditor.jsx
+++ b/apps/src/code-studio/pd/foorm/FoormEditor.jsx
@@ -150,7 +150,8 @@ class FoormEditor extends React.Component {
         .fail(result => {
           this.setState({
             libraryError: true,
-            libraryErrorMessage: result.responseJSON.error
+            libraryErrorMessage:
+              (result.responseJSON && result.responseJSON.error) || 'unknown'
           });
         });
     },

--- a/apps/test/unit/code-studio/components/SortedTableSelectTest.js
+++ b/apps/test/unit/code-studio/components/SortedTableSelectTest.js
@@ -47,7 +47,6 @@ describe('SortedTableSelect', () => {
   it('areAllSelected returns false on initial render', () => {
     const wrapper = shallow(<SortedTableSelect {...DEFAULT_PROPS} />);
     expect(wrapper.instance().areAllSelected()).to.be.false;
-    expect(wrapper.state().rowsChecked).to.be.empty;
   });
 
   it('areAllSelected returns true when all rows are checked', () => {

--- a/apps/test/unit/code-studio/pd/professional_learning_landing/plcElements/EnrollmentUnitAssignmentTest.js
+++ b/apps/test/unit/code-studio/pd/professional_learning_landing/plcElements/EnrollmentUnitAssignmentTest.js
@@ -31,8 +31,7 @@ describe('Enrollment unit assignment', () => {
       />
     );
 
-    expect(enrollmentUnitAssignment.find('ModuleAssignment').length).to.be
-      .empty;
+    expect(enrollmentUnitAssignment.find('ModuleAssignment')).to.be.empty;
     expect(enrollmentUnitAssignment.find('div > div').text()).to.equal(
       'Coming soon!'
     );


### PR DESCRIPTION
In our testing of the feasibility of upgrading to react-16.13 a few unit tests failed due to the new version being stricter about catching errors. These fixes will prevent some tests from failing when we upgrade. 
The fixes are:
- instead of using && to set a title field, use ternary and assign to undefined if the expression would have evaluated to false
- only call `.empty` in unit tests on lists (was calling on a non-existent state variable and on 0 before)
- check for the existence of an object before trying to get an element out of it (this caused occasional failures already).


## Testing story
Tested these by running unit tests and verifying they still pass on our current react version, and will pass if we upgrade to > React 16.

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
