### PR TITLE
Pre-React upgrade unit test updates

### DIFF
--- a/apps/test/unit/SoundTest.js
+++ b/apps/test/unit/SoundTest.js
@@ -123,9 +123,9 @@ describe('Sound', () => {
     it('returns value of isPlaying_ property', () => {
       sound = new Sound({});
       sound.isPlaying_ = true;
-      expect(sound.isPlaying()).to.equal.true;
+      expect(sound.isPlaying()).to.be.true;
       sound.isPlaying_ = false;
-      expect(sound.isPlaying()).to.equal.false;
+      expect(sound.isPlaying()).to.be.false;
     });
   });
 
@@ -133,9 +133,9 @@ describe('Sound', () => {
     it('returns value of isLoaded_ property', () => {
       sound = new Sound({});
       sound.isLoaded_ = true;
-      expect(sound.isLoaded()).to.equal.true;
+      expect(sound.isLoaded()).to.be.true;
       sound.isLoaded_ = false;
-      expect(sound.isLoaded()).to.equal.false;
+      expect(sound.isLoaded()).to.be.false;
     });
   });
 
@@ -143,9 +143,9 @@ describe('Sound', () => {
     it('returns value of didLoadFail_ property', () => {
       sound = new Sound({});
       sound.didLoadFail_ = true;
-      expect(sound.didLoadFail()).to.equal.true;
+      expect(sound.didLoadFail()).to.be.true;
       sound.didLoadFail_ = false;
-      expect(sound.didLoadFail()).to.equal.false;
+      expect(sound.didLoadFail()).to.be.false;
     });
   });
 

--- a/apps/test/unit/applab/redux/applabTest.js
+++ b/apps/test/unit/applab/redux/applabTest.js
@@ -94,7 +94,7 @@ describe('App Lab redux module', () => {
 
   describe('interfaceMode', () => {
     it('exposes state on the interfaceMode key', () => {
-      expect(store.getState().interfaceMode).to.be.defined;
+      expect(store.getState().interfaceMode).to.not.be.undefined;
     });
 
     describe('the initial state', () => {
@@ -147,7 +147,7 @@ describe('App Lab redux module', () => {
 
   describe('maker', () => {
     it('exposes state on the maker key', () => {
-      expect(store.getState().maker).to.be.defined;
+      expect(store.getState().maker).to.not.be.undefined;
     });
   });
 });

--- a/apps/test/unit/lib/kits/maker/boards/microBit/AccelerometerTest.js
+++ b/apps/test/unit/lib/kits/maker/boards/microBit/AccelerometerTest.js
@@ -28,7 +28,7 @@ describe('MicroBitAccelerometer', function() {
     attributes.forEach(attr => {
       desc = Object.getOwnPropertyDescriptor(accelerometer, attr);
       expect(desc.set).to.be.undefined;
-      expect(desc.get).to.be.defined;
+      expect(desc.get).to.not.be.undefined;
     });
   });
 

--- a/apps/test/unit/lib/kits/maker/boards/microBit/CapacitiveTouchSensorTest.js
+++ b/apps/test/unit/lib/kits/maker/boards/microBit/CapacitiveTouchSensorTest.js
@@ -18,7 +18,7 @@ describe('CapacitiveTouchSensor', function() {
       'isPressed'
     );
     expect(isPressedDescriptor.set).to.be.undefined;
-    expect(isPressedDescriptor.get).to.be.defined;
+    expect(isPressedDescriptor.get).to.not.be.undefined;
   });
 
   describe(`start() and stop()`, () => {

--- a/apps/test/unit/lib/kits/maker/boards/microBit/CompassTest.js
+++ b/apps/test/unit/lib/kits/maker/boards/microBit/CompassTest.js
@@ -16,7 +16,7 @@ describe('MicroBit Compass', function() {
   it(`attributes are readonly`, () => {
     let desc = Object.getOwnPropertyDescriptor(compass, 'heading');
     expect(desc.set).to.be.undefined;
-    expect(desc.get).to.be.defined;
+    expect(desc.get).to.not.be.undefined;
   });
 
   it(`magnetometer values calculated as expected and rounded to hundredth`, () => {

--- a/apps/test/unit/lib/kits/maker/boards/microBit/LightSensorTest.js
+++ b/apps/test/unit/lib/kits/maker/boards/microBit/LightSensorTest.js
@@ -20,13 +20,13 @@ describe('LightSensor', function() {
   it(`value attribute is readonly`, () => {
     let descriptor = Object.getOwnPropertyDescriptor(lightSensor, 'value');
     expect(descriptor.set).to.be.undefined;
-    expect(descriptor.get).to.be.defined;
+    expect(descriptor.get).to.not.be.undefined;
   });
 
   it(`threshold attribute can be read and set`, () => {
     let descriptor = Object.getOwnPropertyDescriptor(lightSensor, 'threshold');
-    expect(descriptor.set).to.be.defined;
-    expect(descriptor.get).to.be.defined;
+    expect(descriptor.set).to.not.be.undefined;
+    expect(descriptor.get).to.not.be.undefined;
 
     expect(lightSensor.state.threshold).to.equal(128);
     lightSensor.state.threshold = 199;

--- a/apps/test/unit/lib/kits/maker/boards/microBit/MicroBitThermometerTest.js
+++ b/apps/test/unit/lib/kits/maker/boards/microBit/MicroBitThermometerTest.js
@@ -19,7 +19,7 @@ describe('MicroBitThermometer', function() {
     attributes.forEach(attr => {
       descriptor = Object.getOwnPropertyDescriptor(thermometer, attr);
       expect(descriptor.set).to.be.undefined;
-      expect(descriptor.get).to.be.defined;
+      expect(descriptor.get).to.not.be.undefined;
     });
   });
 

--- a/apps/test/unit/lib/tools/jsdebugger/reduxTest.js
+++ b/apps/test/unit/lib/tools/jsdebugger/reduxTest.js
@@ -66,7 +66,7 @@ describe('The JSDebugger redux duck', () => {
   }
 
   it('exposes state on the jsdebugger key', () => {
-    expect(store.getState().jsdebugger).to.be.defined;
+    expect(store.getState().jsdebugger).to.not.be.undefined;
   });
 
   it('the state can be accesed via the getRoot selector', () => {

--- a/apps/test/unit/lib/tools/jsinterpreter/CustomMarshalingInterpreterTest.js
+++ b/apps/test/unit/lib/tools/jsinterpreter/CustomMarshalingInterpreterTest.js
@@ -802,9 +802,7 @@ describe('The CustomMarshalingInterpreter', () => {
       });
 
       it('will skip the inherits and trigger properties if present', () => {
-        expect(nativeFunc.inherits).to.not.be.undefined;
         value.assert(`assert(value.inherits === undefined)`);
-        expect(nativeFunc.trigger).to.not.be.undefined;
         value.assert(`assert(value.trigger === undefined)`);
       });
     });

--- a/apps/test/unit/lib/tools/jsinterpreter/CustomMarshalingInterpreterTest.js
+++ b/apps/test/unit/lib/tools/jsinterpreter/CustomMarshalingInterpreterTest.js
@@ -802,9 +802,9 @@ describe('The CustomMarshalingInterpreter', () => {
       });
 
       it('will skip the inherits and trigger properties if present', () => {
-        expect(nativeFunc.inherits).to.be.defined;
+        expect(nativeFunc.inherits).to.not.be.undefined;
         value.assert(`assert(value.inherits === undefined)`);
-        expect(nativeFunc.trigger).to.be.defined;
+        expect(nativeFunc.trigger).to.not.be.undefined;
         value.assert(`assert(value.trigger === undefined)`);
       });
     });

--- a/apps/test/unit/lib/tools/jsinterpreter/JSInterpreterTest.js
+++ b/apps/test/unit/lib/tools/jsinterpreter/JSInterpreterTest.js
@@ -952,7 +952,7 @@ myCallback("this message is coming from inside the interpreter");
           jsInterpreter.executeInterpreter(true);
         });
         it('will populate the executionError property of the interpreter', () => {
-          expect(jsInterpreter.executionError).to.be.defined;
+          expect(jsInterpreter.executionError).to.not.be.undefined;
           expect(jsInterpreter.executionError).to.equal('gotcha');
         });
         it('will call the handleError method.', () => {

--- a/apps/test/unit/p5lab/reducersTest.js
+++ b/apps/test/unit/p5lab/reducersTest.js
@@ -32,8 +32,8 @@ describe('gamelabReducer', function() {
 
   it('has expected default state', function() {
     expect(initialState.interfaceMode).to.equal(CODE);
-    expect(initialState.pageConstants).to.be.an.object;
-    expect(initialState.pageConstants.assetUrl).to.be.a.function;
+    expect(initialState.pageConstants).to.be.an('object');
+    expect(initialState.pageConstants.assetUrl).to.be.a('function');
     expect(initialState.pageConstants.isEmbedView).to.be.undefined;
     expect(initialState.pageConstants.isShareView).to.be.undefined;
     expect(initialState.textConsole).to.be.empty;


### PR DESCRIPTION
This change is in preparation for upgrading Chai (from 3.5.0 to ^4.2.0), which we'll be doing when we upgrade React. There have been several API updates in Chai, all of which work with our current version.

**Some of the errors that occur when we upgrade Chai + how I resolved them:**

1. `Error: Invalid Chai property: equal.true. See docs for proper usage of "equal".`
```javascript
// no longer works
expect(true).to.equal.true;

// updated expectation
expect(true).to.be.true;
```

2. `Error: Invalid Chai property: defined. Did you mean "undefined"?`
```javascript
const myVar = 2;

// no longer works
expect(myVar).to.be.defined;

// updated expectation
expect(myVar).to.not.be.undefined;
```

3. `Error: Invalid Chai property: (object|function|etc)`
```javascript
// no longer works
expect({}).to.be.an.object;
expect(() => {}).to.be.a.function;

// updated expectations
expect({}).to.be.an('object');
expect(() => {}).to.be.a('function');
```