### PR TITLE
Restore spy and await setInterval to fix test state leakage

### DIFF
--- a/apps/test/unit/lib/kits/maker/boards/microBit/CapacitiveTouchSensorTest.js
+++ b/apps/test/unit/lib/kits/maker/boards/microBit/CapacitiveTouchSensorTest.js
@@ -39,11 +39,16 @@ describe('CapacitiveTouchSensor', function() {
 
   describe('emitsEvent', () => {
     let emitSpy;
+
     beforeEach(() => {
       emitSpy = sinon.spy(sensor, 'emit');
     });
 
-    it('emits the down event when it receives a high enough reading', () => {
+    afterEach(() => {
+      emitSpy.restore();
+    });
+
+    it('emits the down event when it receives a high enough reading', async () => {
       boardClient.receivedAnalogUpdate();
 
       // Seed the channel with 'unconnected' data
@@ -53,26 +58,29 @@ describe('CapacitiveTouchSensor', function() {
       // Seed the channel with 'connected' data
       boardClient.analogChannel[testPin] = 450;
 
-      setInterval(() => {
-        expect(emitSpy).to.have.been.calledOnce;
-        expect(emitSpy).to.have.been.calledWith('down');
-      }, 50);
+      // Wait for readSensorTimer to finish
+      await new Promise(resolve => setInterval(resolve, 50));
+
+      expect(emitSpy).to.have.been.calledOnce;
+      expect(emitSpy).to.have.been.calledWith('down');
     });
 
-    it('emits the up event when it receives a low enough reading', () => {
+    it('emits the up event when it receives a low enough reading', async () => {
       boardClient.receivedAnalogUpdate();
 
       // Seed the channel with 'connected' data
       boardClient.analogChannel[testPin] = 450;
       boardClient.receivedAnalogUpdate();
+      sensor.connected = true;
 
       // Seed the channel with 'unconnected' data
       boardClient.analogChannel[testPin] = 230;
 
-      setInterval(() => {
-        expect(emitSpy).to.have.been.calledOnce;
-        expect(emitSpy).to.have.been.calledWith('up');
-      }, 50);
+      // Wait for readSensorTimer to finish
+      await new Promise(resolve => setInterval(resolve, 50));
+
+      expect(emitSpy).to.have.been.calledOnce;
+      expect(emitSpy).to.have.been.calledWith('up');
     });
   });
 });


### PR DESCRIPTION
This came up while I was investigating test failures when working on upgrading our version of React (my hackathon project). Every time I ran `apps/test/unit/lib/kits/maker/boards/microBit/`, I got these test failures:
<img width="966" alt="MicroBitBoardTest_failures" src="https://user-images.githubusercontent.com/9812299/106222899-458fb780-6195-11eb-873f-a3e49df96c87.png">

This was happening on staging as well, so it's unrelated to upgrading React (I'm not sure why these haven't shown up in any staging/test builds though). The tests don't fail if you run files individually -- only when you run the entire directory. Eventually I found that the failures in `MicroBitBoardTest.js` were due to us calling `setInterval` in `CapacitiveTouchSensorTest.js`.

Refactoring the tests to wait for `setInterval` to finish then check the assertions fixed this state leakage.