### PR TITLE
skip notifying dotd of build failure on adhoc

### DIFF
--- a/aws/ci_build
+++ b/aws/ci_build
@@ -178,7 +178,7 @@ def main
     else
       message = "<b>#{projects}</b> failed to build!" + time_message + log_link
       ChatClient.log message, color: 'red'
-      ChatClient.log "<@#{DevelopersTopic.dotd}> build failure", color: 'red'
+      ChatClient.log "<@#{DevelopersTopic.dotd}> build failure", color: 'red' unless rack_env?(:adhoc)
 
       ChatClient.message 'server operations', message, color: 'red', notify: 1
       ChatClient.message 'server operations', commit_url, color: 'gray', message_format: 'text'


### PR DESCRIPTION
after following the instructions in [How to Provision an adhoc Environment](https://docs.google.com/document/d/1nWeQEmEQF1B2l93JTQPyeRpLEFzCzY5NdgJ8kgprcDk/edit#heading=h.4q118j4ft9yy) to configure a slack channel, the Developer of the Day is notified when there is an adhoc build failure. This PR disables the build failure warning for the DOTD in the adhoc environment.

## Testing story

manually verified on an adhoc

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
