### PR TITLE
Screen reader accessibility for Projects header

### DIFF
--- a/apps/src/code-studio/components/header/EditableProjectName.jsx
+++ b/apps/src/code-studio/components/header/EditableProjectName.jsx
@@ -20,7 +20,9 @@ const styles = {
   },
   button: {
     marginTop: 0,
-    marginBottom: 0
+    marginBottom: 0,
+    marginLeft: 10,
+    marginRight: 0
   }
 };
 

--- a/apps/src/code-studio/components/header/EditableProjectName.jsx
+++ b/apps/src/code-studio/components/header/EditableProjectName.jsx
@@ -29,7 +29,7 @@ class UnconnectedDisplayProjectName extends React.Component {
   render() {
     return (
       <div style={styles.buttonWrapper}>
-        <div className="project_name_wrapper header_text">
+        <div className="project_name_wrapper header_text" tabIndex={0}>
           <div className="project_name header_text">
             {this.props.projectName}
           </div>

--- a/apps/src/code-studio/components/header/EditableProjectName.jsx
+++ b/apps/src/code-studio/components/header/EditableProjectName.jsx
@@ -17,6 +17,9 @@ const styles = {
   buttonWrapper: {
     float: 'left',
     display: 'flex'
+  },
+  button: {
+    margin: 0
   }
 };
 
@@ -35,12 +38,14 @@ class UnconnectedDisplayProjectName extends React.Component {
           </div>
           <ProjectUpdatedAt />
         </div>
-        <div
+        <button
+          type="button"
           className="project_edit header_button header_button_light"
+          style={styles.button}
           onClick={this.props.beginEdit}
         >
           {i18n.rename()}
-        </div>
+        </button>
       </div>
     );
   }

--- a/apps/src/code-studio/components/header/EditableProjectName.jsx
+++ b/apps/src/code-studio/components/header/EditableProjectName.jsx
@@ -19,7 +19,8 @@ const styles = {
     display: 'flex'
   },
   button: {
-    margin: 0
+    marginTop: 0,
+    marginBottom: 0
   }
 };
 
@@ -118,13 +119,15 @@ class UnconnectedEditProjectName extends React.Component {
             }}
           />
         </div>
-        <div
+        <button
+          type="button"
           className="project_save header_button header_button_light"
           onClick={this.saveNameChange}
           disabled={this.state.savingName}
+          style={styles.button}
         >
           {i18n.save()}
-        </div>
+        </button>
         <NameFailureDialog
           flaggedText={this.props.projectNameFailure}
           isOpen={!!this.props.projectNameFailure}

--- a/apps/src/code-studio/components/header/EditableProjectName.jsx
+++ b/apps/src/code-studio/components/header/EditableProjectName.jsx
@@ -22,7 +22,8 @@ export const styles = {
     marginTop: 0,
     marginBottom: 0,
     marginLeft: 10,
-    marginRight: 0
+    marginRight: 0,
+    boxShadow: 'none'
   }
 };
 

--- a/apps/src/code-studio/components/header/EditableProjectName.jsx
+++ b/apps/src/code-studio/components/header/EditableProjectName.jsx
@@ -13,12 +13,12 @@ import {
 import NameFailureDialog from '../NameFailureDialog';
 import NameFailureError from '../../NameFailureError';
 
-const styles = {
+export const styles = {
   buttonWrapper: {
     float: 'left',
     display: 'flex'
   },
-  button: {
+  buttonSpacing: {
     marginTop: 0,
     marginBottom: 0,
     marginLeft: 10,
@@ -44,7 +44,7 @@ class UnconnectedDisplayProjectName extends React.Component {
         <button
           type="button"
           className="project_edit header_button header_button_light"
-          style={styles.button}
+          style={styles.buttonSpacing}
           onClick={this.props.beginEdit}
         >
           {i18n.rename()}
@@ -126,7 +126,7 @@ class UnconnectedEditProjectName extends React.Component {
           className="project_save header_button header_button_light"
           onClick={this.saveNameChange}
           disabled={this.state.savingName}
-          style={styles.button}
+          style={styles.buttonSpacing}
         >
           {i18n.save()}
         </button>

--- a/apps/src/code-studio/components/header/ProjectExport.jsx
+++ b/apps/src/code-studio/components/header/ProjectExport.jsx
@@ -1,16 +1,19 @@
 import React from 'react';
 import i18n from '@cdo/locale';
 import {exportProject} from '../../headerExport';
+import {styles} from './EditableProjectName';
 
 export default class ProjectExport extends React.Component {
   render() {
     return (
-      <div
+      <button
+        type="button"
         className="project_share header_button header_button_light"
         onClick={exportProject}
+        style={styles.buttonSpacing}
       >
         {i18n.export()}
-      </div>
+      </button>
     );
   }
 }

--- a/apps/src/code-studio/components/header/ProjectRemix.jsx
+++ b/apps/src/code-studio/components/header/ProjectRemix.jsx
@@ -6,6 +6,7 @@ import {connect} from 'react-redux';
 import i18n from '@cdo/locale';
 import * as utils from '../../../utils';
 import {refreshProjectName} from '../../headerRedux';
+import {styles} from './EditableProjectName';
 
 class ProjectRemix extends React.Component {
   static propTypes = {
@@ -46,9 +47,14 @@ class ProjectRemix extends React.Component {
       className += ' header_button_light';
     }
     return (
-      <div className={className} onClick={this.remixProject}>
+      <button
+        type="button"
+        className={className}
+        onClick={this.remixProject}
+        style={styles.buttonSpacing}
+      >
         {i18n.remix()}
-      </div>
+      </button>
     );
   }
 }

--- a/apps/src/code-studio/components/header/ProjectShare.jsx
+++ b/apps/src/code-studio/components/header/ProjectShare.jsx
@@ -4,6 +4,15 @@ import React from 'react';
 import i18n from '@cdo/locale';
 import {shareProject} from '../../headerShare';
 
+const styles = {
+  button: {
+    marginTop: 0,
+    marginBottom: 0,
+    marginLeft: 10,
+    marginRight: 0
+  }
+};
+
 export default class ProjectShare extends React.Component {
   shareProject = () => {
     shareProject(dashboard.project.getShareUrl());
@@ -11,12 +20,14 @@ export default class ProjectShare extends React.Component {
 
   render() {
     return (
-      <div
+      <button
+        type="button"
         className="project_share header_button header_button_light"
         onClick={this.shareProject}
+        style={styles.button}
       >
         {i18n.share()}
-      </div>
+      </button>
     );
   }
 }

--- a/apps/src/code-studio/components/header/ProjectShare.jsx
+++ b/apps/src/code-studio/components/header/ProjectShare.jsx
@@ -3,15 +3,7 @@
 import React from 'react';
 import i18n from '@cdo/locale';
 import {shareProject} from '../../headerShare';
-
-const styles = {
-  button: {
-    marginTop: 0,
-    marginBottom: 0,
-    marginLeft: 10,
-    marginRight: 0
-  }
-};
+import {styles} from './EditableProjectName';
 
 export default class ProjectShare extends React.Component {
   shareProject = () => {
@@ -24,7 +16,7 @@ export default class ProjectShare extends React.Component {
         type="button"
         className="project_share header_button header_button_light"
         onClick={this.shareProject}
-        style={styles.button}
+        style={styles.buttonSpacing}
       >
         {i18n.share()}
       </button>


### PR DESCRIPTION
Part of the accessibility Hackathon task. I made the clickable divs be buttons, which enables the built-in accessibility features for interactive tools. I added styling to the button, so that there is no visible difference between the clickable div and the buttons. Tested locally on my screenreader.

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
