### PR TITLE
Update pre-workshop survey to include all numbered lessons

### DIFF
--- a/dashboard/app/models/pd/workshop.rb
+++ b/dashboard/app/models/pd/workshop.rb
@@ -822,15 +822,15 @@ class Pd::Workshop < ApplicationRecord
 
   # @return an array of tuples, each in the format:
   #   [unit_name, [lesson names]]
-  # Units represent the localized titles for scripts in the Course
-  # Lessons are the stage names for that script (unit) preceded by "Lesson n: "
+  # Units represent the localized titles for units in the Course
+  # Lessons are the lesson names for that unit preceded by "Lesson n: "
   def pre_survey_units_and_lessons
     return nil unless pre_survey?
     pre_survey_course.default_scripts.map do |script|
       unit_name = script.title_for_display
-      stage_names = script.lessons.where(lockable: false).pluck(:name)
-      lesson_names = stage_names.each_with_index.map do |stage_name, i|
-        "Lesson #{i + 1}: #{stage_name}"
+      lesson_names = script.lessons.where(has_lesson_plan: true).or(script.lessons.where(lockable: false)).pluck(:name)
+      lesson_names = lesson_names.each_with_index.map do |lesson_name, i|
+        "Lesson #{i + 1}: #{lesson_name}"
       end
       [unit_name, lesson_names]
     end

--- a/dashboard/test/models/pd/workshop_test.rb
+++ b/dashboard/test/models/pd/workshop_test.rb
@@ -1060,7 +1060,8 @@ class Pd::WorkshopTest < ActiveSupport::TestCase
         create :unit_group_unit, unit_group: unit_group, script: script, position: (next_position += 1)
         create :lesson_group, script: script
         I18n.stubs(:t).with("data.script.name.#{script.name}.title").returns(unit_name)
-        lesson_names.each {|lesson_name| create :lesson, script: script, name: lesson_name, key: lesson_name, lesson_group: script.lesson_groups.first}
+        lesson_names.each {|lesson_name| create :lesson, script: script, name: lesson_name, key: lesson_name, lesson_group: script.lesson_groups.first, lockable: false, has_lesson_plan: true}
+        create :lesson, script: script, name: 'non-numbered lesson', key: 'non-numbered lesson', lesson_group: script.lesson_groups.first, lockable: true, has_lesson_plan: false
       end
     end
 


### PR DESCRIPTION
We recently updated the way we determine if a lesson is numbered to be based on both if its not lockable or it has a lesson plan. This updates the filter for workshop pre-surveys so they will start including lessons that are both lockable and have a lesson plan. There are 9 lessons in CSP 20-21 that would be added. The last lesson in units 1,2,3,4,5,6,7,9,10.

PLC/Baker - I'm looking for confirmation that this will not cause problems for the survey or the data we pull from these surveys. 

## Links

<!--
  Any relevant links to external resources; ie, specification documents, jira
  items, related PRs, honeybadger errors, etc
-->

- [spec](https://docs.google.com/document/d/1sAAVnwv3rXQEK-qa8JnkNXFfZ0vjWQyzJ9Yx_pG4bdg/edit#)
- [jira](https://codedotorg.atlassian.net/browse/PLAT-708)

## Testing story

Updated test in workshop_test to check it is processing correctly
