### PR TITLE
[Blockly] Fix scale and snap radius

### DIFF
--- a/apps/src/sites/studio/pages/googleBlocklyWrapper.js
+++ b/apps/src/sites/studio/pages/googleBlocklyWrapper.js
@@ -178,6 +178,9 @@ function initializeBlocklyWrapper(blocklyInstance) {
       this.blockly_.CONNECTING_SNAP_RADIUS = snapRadius;
     }
   });
+  // Google Blockly defaults to 28, but Cdo Blockly defaults to 15. Some labs set the snap radius
+  // by multiplying a scale factor, so it's important that the default value matches what it was on our fork
+  blocklyWrapper.SNAP_RADIUS = 15;
 
   blocklyWrapper.getGenerator = function() {
     return this.JavaScript;

--- a/dashboard/app/models/levels/blockly.rb
+++ b/dashboard/app/models/levels/blockly.rb
@@ -388,7 +388,7 @@ class Blockly < Level
       level_prop['editCode'] = uses_droplet?
 
       # Blockly requires these fields to be objects not strings
-      %w(map initialDirt serializedMaze goal softButtons inputOutputTable).
+      %w(map initialDirt serializedMaze goal softButtons inputOutputTable scale).
           concat(NetSim.json_object_attrs).
           concat(Craft.json_object_attrs).
           each do |x|


### PR DESCRIPTION
Originally started looking into this because the insertion markers in Basketball are really over-eager:
![Jan-29-2021 15-37-01](https://user-images.githubusercontent.com/8787187/106338132-e2129200-6247-11eb-8a41-4c9b1f45462b.gif)

That led me to realizing we need to set the default `Blockly.SNAP_RADIUS` to match what it is in Cdo Blockly. Instead of setting the `SNAP_RADIUS` directly, most of our labs set it by multiplying a scale factor like [this](https://github.com/code-dot-org/code-dot-org/blob/staging/apps/src/bounce/bounce.js#L747) 

However, that made me wonder why it wasn't a problem for Flappy. On closer look, I realized that though all the flappy levels I could find looked like they had a scale factor of 2, the scale was never actually being applied. Basically, the `scale` property wasn't being parsed correctly from the level file, so what ended up in appOptions was 
```
appOptions.level.scale
> "{"snapRadius":2}"
```
But Flappy expects it to be an object, and tries to loop over the keys [here](https://github.com/code-dot-org/code-dot-org/blob/staging/apps/src/flappy/flappy.js#L92) and ends up with this:
![image](https://user-images.githubusercontent.com/8787187/106339406-57339680-624b-11eb-9558-89ac5784acdd.png)


And the actual `snapRadius` property stayed at the default value `1`.
The fix is to make sure the scale property it's parsed into an object before being passed through to `appOptions`

Flappy Before
![image](https://user-images.githubusercontent.com/8787187/106338796-9365f780-6249-11eb-850b-9da999007120.png)
![Jan-29-2021 15-49-55](https://user-images.githubusercontent.com/8787187/106338886-cd36fe00-6249-11eb-97b6-e7bcbb14eb5b.gif)

Flappy After
![image](https://user-images.githubusercontent.com/8787187/106338784-8b0dbc80-6249-11eb-90da-f03a2090c20d.png)
![Jan-29-2021 15-50-17](https://user-images.githubusercontent.com/8787187/106338892-cf995800-6249-11eb-9ad8-1b16311afb44.gif)

Bounce Before
![image](https://user-images.githubusercontent.com/8787187/106338950-f6f02500-6249-11eb-98a9-828f8536a1d4.png)

Bounce After
![image](https://user-images.githubusercontent.com/8787187/106338961-feafc980-6249-11eb-82a3-ffd1acbf2e40.png)
![Jan-29-2021 15-52-55](https://user-images.githubusercontent.com/8787187/106338982-15eeb700-624a-11eb-8c26-da7f72c55902.gif)

This also affects a bunch of levels that are still on CdoBlockly. These are levels that have a `snapRadius` property set that has been improperly ignored. My best estimate is that there are 127 levels that fall into this category:
```
~/code-dot-org/dashboard/config $ grep '\\"snapRadius\\"' -rl . | wc -l
127
```
I don't think this is a big deal because it's a pretty small change and the current behavior is technically a bug.
[Example](https://levelbuilder-studio.code.org/levels/10946): 
Before
![Jan-29-2021 15-54-53](https://user-images.githubusercontent.com/8787187/106339318-12a7fb00-624b-11eb-833e-fef52b7fb2a1.gif)

After
![Jan-29-2021 15-57-55](https://user-images.githubusercontent.com/8787187/106339325-15a2eb80-624b-11eb-9997-30eaf98843ac.gif)


<!-- ### Background -->
<!-- ### Privacy -->
<!--
1.	Does the Project involve the collection, use or sharing of new Personal Data?

2.	Does the Project involve a new or changed use or sharing of existing Personal Data?
-->
<!-- ### Security -->
<!--
Link to Jira Task where sensitive security issues are discussed privately.
-->
<!-- ### Caching -->
<!-- ### Deployment strategy -->
<!-- ### Future work -->

## Links

<!--
  Any relevant links to external resources; ie, specification documents, jira
  items, related PRs, honeybadger errors, etc
-->
- [jira](https://codedotorg.atlassian.net/browse/STAR-1397)

## Testing story

<!--
  Does your change include appropriate tests?

  If so, please describe how the tests included in this PR are sufficient

  If not, please explain why this change does not need to be tested.
-->

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
