### PR TITLE
[Spritelab] the text output expand UI should stay expanded when plus sign is clicked

### DIFF
--- a/apps/src/p5lab/spritelab/TextConsole.jsx
+++ b/apps/src/p5lab/spritelab/TextConsole.jsx
@@ -6,7 +6,7 @@ import {Transition} from 'react-transition-group';
 const lineHeight = 20;
 const margin = 3;
 const maxHeight = lineHeight * 6;
-const AUTO_CLOSE_TIME = 4000;
+export const AUTO_CLOSE_TIME = 4000;
 
 export const styles = {
   hide: {
@@ -77,10 +77,18 @@ export default class TextConsole extends React.Component {
 
   timeout = 0;
 
+  /**
+   *@param {number} autoCloseTime - optional. If specified, time at which to close
+   * the console. If not specified, console will remain open indefinitely.
+   */
   toggleConsole(autoCloseTime) {
     this.state.open ? this.closeConsole() : this.openConsole(autoCloseTime);
   }
 
+  /**
+   *@param {number} autoCloseTime - optional. If specified, time at which to close
+   * the console. If not specified, console will remain open indefinitely.
+   */
   openConsole(autoCloseTime) {
     clearTimeout(this.timeout);
     this.setState({open: true}, () => {

--- a/apps/src/p5lab/spritelab/TextConsole.jsx
+++ b/apps/src/p5lab/spritelab/TextConsole.jsx
@@ -6,6 +6,7 @@ import {Transition} from 'react-transition-group';
 const lineHeight = 20;
 const margin = 3;
 const maxHeight = lineHeight * 6;
+const AUTO_CLOSE_TIME = 4000;
 
 export const styles = {
   hide: {
@@ -76,22 +77,20 @@ export default class TextConsole extends React.Component {
 
   timeout = 0;
 
-  toggleConsole() {
-    this.state.open ? this.closeConsole() : this.openThenClose();
+  toggleConsole(autoCloseTime) {
+    this.state.open ? this.closeConsole() : this.openConsole(autoCloseTime);
   }
 
-  openThenClose() {
+  openConsole(autoCloseTime) {
     clearTimeout(this.timeout);
-    this.openConsole();
-    this.timeout = setTimeout(() => {
-      this.closeConsole();
-    }, 4000);
-  }
-
-  openConsole() {
     this.setState({open: true}, () => {
       this.scrollToBottom();
     });
+    if (autoCloseTime) {
+      this.timeout = setTimeout(() => {
+        this.closeConsole();
+      }, autoCloseTime);
+    }
   }
 
   closeConsole() {
@@ -99,7 +98,7 @@ export default class TextConsole extends React.Component {
   }
 
   getButtonStyle() {
-    if (this.state.open || !this.props.consoleMessages.length) {
+    if (!this.props.consoleMessages.length) {
       return styles.hide;
     } else {
       return styles.expandButton;
@@ -133,7 +132,7 @@ export default class TextConsole extends React.Component {
     if (
       this.props.consoleMessages.length !== previousProp.consoleMessages.length
     ) {
-      this.openThenClose();
+      this.openConsole(AUTO_CLOSE_TIME);
     }
   }
 
@@ -143,7 +142,7 @@ export default class TextConsole extends React.Component {
         <Transition in={this.state.open} timeout={1000}>
           {state => (
             <div
-              onClick={() => this.toggleConsole()}
+              onClick={() => this.toggleConsole(AUTO_CLOSE_TIME)}
               ref={div => {
                 this.messageList = div;
               }}
@@ -159,9 +158,9 @@ export default class TextConsole extends React.Component {
         <button
           type="button"
           style={this.getButtonStyle()}
-          onClick={() => this.openThenClose()}
+          onClick={() => this.toggleConsole()}
         >
-          +
+          {this.state.open ? '-' : '+'}
         </button>
       </div>
     );

--- a/apps/test/unit/p5lab/spritelab/TextConsoleTest.js
+++ b/apps/test/unit/p5lab/spritelab/TextConsoleTest.js
@@ -1,10 +1,10 @@
 import React from 'react';
 import {expect} from '../../../util/reconfiguredChai';
-import TextConsole from '@cdo/apps/p5lab/spritelab/TextConsole';
+import TextConsole, {
+  AUTO_CLOSE_TIME
+} from '@cdo/apps/p5lab/spritelab/TextConsole';
 import {mount} from 'enzyme';
 import sinon from 'sinon';
-
-const AUTO_CLOSE_TIME = 4000;
 
 describe('Sprite Lab Text Console', () => {
   let wrapper;

--- a/apps/test/unit/p5lab/spritelab/TextConsoleTest.js
+++ b/apps/test/unit/p5lab/spritelab/TextConsoleTest.js
@@ -4,6 +4,8 @@ import TextConsole from '@cdo/apps/p5lab/spritelab/TextConsole';
 import {mount} from 'enzyme';
 import sinon from 'sinon';
 
+const AUTO_CLOSE_TIME = 4000;
+
 describe('Sprite Lab Text Console', () => {
   let wrapper;
 
@@ -15,8 +17,11 @@ describe('Sprite Lab Text Console', () => {
     expect(wrapper.state().open).to.be.false;
   });
 
-  it('and the button is hidden', () => {
-    expect(wrapper.instance().getButtonStyle().display).to.equal('none');
+  it('and the button text is +', () => {
+    const button = wrapper.findWhere(node => {
+      return node.type() === 'button' && node.text() === '+';
+    });
+    expect(button).to.have.lengthOf(1);
   });
 
   describe('after a line is added', () => {
@@ -34,13 +39,21 @@ describe('Sprite Lab Text Console', () => {
       expect(wrapper.state().open).to.be.true;
     });
 
-    it('the button remains hidden', () => {
-      expect(wrapper.instance().getButtonStyle().display).to.equal('none');
+    it('the button text is -', () => {
+      const button = wrapper.findWhere(node => {
+        return node.type() === 'button' && node.text() === '-';
+      });
+      expect(button).to.have.lengthOf(1);
     });
 
-    it('closes after 4000 ms', () => {
-      clock.tick(4000);
+    it('closes after AUTO_CLOSE_TIME ms', () => {
+      clock.tick(AUTO_CLOSE_TIME);
       expect(wrapper.state().open).to.be.false;
+
+      const button = wrapper.findWhere(node => {
+        return node.type() === 'button' && node.text() === '+';
+      });
+      expect(button).to.have.lengthOf(1);
     });
 
     describe('and the console is toggled', () => {
@@ -59,12 +72,14 @@ describe('Sprite Lab Text Console', () => {
       });
 
       it('opens when toggled again', () => {
-        wrapper.instance().toggleConsole();
+        wrapper.instance().toggleConsole(AUTO_CLOSE_TIME);
         expect(wrapper.state().open).to.be.true;
       });
 
-      it('opens when the button is clicked', () => {
-        wrapper.instance().openThenClose();
+      it('opens and stays open when the button is clicked', () => {
+        wrapper.instance().toggleConsole();
+        expect(wrapper.state().open).to.be.true;
+        clock.tick(AUTO_CLOSE_TIME * 2);
         expect(wrapper.state().open).to.be.true;
       });
     });


### PR DESCRIPTION
When you click run, it will still auto-close after 4 seconds and there's a minus button to close early if you want:
![image](https://user-images.githubusercontent.com/8787187/106499831-f3d97c80-6475-11eb-94ff-abd2bac2638f.png)

When you click on the plus, it stays open forever:
![image](https://user-images.githubusercontent.com/8787187/106499784-e02e1600-6475-11eb-9356-c510ab5f01b0.png)

Until you click -:
![image](https://user-images.githubusercontent.com/8787187/106500035-34d19100-6476-11eb-85a1-0299e5af2520.png)

<!--
  Other aspects to consider. uncomment and add detail for any that seem necessary:
-->

<!-- ### Background -->
<!-- ### Privacy -->
<!--
1.	Does the Project involve the collection, use or sharing of new Personal Data?

2.	Does the Project involve a new or changed use or sharing of existing Personal Data?
-->
<!-- ### Security -->
<!--
Link to Jira Task where sensitive security issues are discussed privately.
-->
<!-- ### Caching -->
<!-- ### Deployment strategy -->
<!-- ### Future work -->

## Links

<!--
  Any relevant links to external resources; ie, specification documents, jira
  items, related PRs, honeybadger errors, etc
-->

- [jira](https://codedotorg.atlassian.net/browse/STAR-1400)

## Testing story

<!--
  Does your change include appropriate tests?

  If so, please describe how the tests included in this PR are sufficient

  If not, please explain why this change does not need to be tested.
-->

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
