### PR TITLE
Use summarize_for_lesson_edit when returning resource/vocabulary search matches

### DIFF
--- a/dashboard/lib/resources_autocomplete.rb
+++ b/dashboard/lib/resources_autocomplete.rb
@@ -8,6 +8,6 @@ class ResourcesAutocomplete < AutocompleteHelper
     query = format_query(query)
     rows = rows.
       where("MATCH(name,url) AGAINST(? in BOOLEAN MODE)", query)
-    return rows.map(&:attributes)
+    return rows.map(&:summarize_for_lesson_edit)
   end
 end

--- a/dashboard/lib/vocabulary_autocomplete.rb
+++ b/dashboard/lib/vocabulary_autocomplete.rb
@@ -8,6 +8,6 @@ class VocabularyAutocomplete < AutocompleteHelper
     query = format_query(query)
     rows = rows.
       where("MATCH(word,definition) AGAINST(? in BOOLEAN MODE)", query)
-    return rows.map(&:attributes)
+    return rows.map(&:summarize_for_lesson_edit)
   end
 end

--- a/dashboard/test/lib/resources_autocomplete_test.rb
+++ b/dashboard/test/lib/resources_autocomplete_test.rb
@@ -13,13 +13,13 @@ class ResourcesAutocompleteTest < ActiveSupport::TestCase
   test "finds resource with matching name" do
     matches = ResourcesAutocomplete.get_search_matches('Studi', 5, @course_version_2018.id)
     assert_equal 1, matches.length
-    assert_equal 'Code Studio', matches[0]['name']
+    assert_equal 'Code Studio', matches[0][:name]
   end
 
   test "finds resource with matching url" do
     matches = ResourcesAutocomplete.get_search_matches("wikip", 5, @course_version_2018.id)
     assert_equal 1, matches.length
-    assert_equal 'wiki', matches[0]['name']
+    assert_equal 'wiki', matches[0][:name]
   end
 
   test "finds multiple matches" do
@@ -33,13 +33,12 @@ class ResourcesAutocompleteTest < ActiveSupport::TestCase
     # sure the correct ones are fetched in each case.
     matches = ResourcesAutocomplete.get_search_matches("class", 5, @course_version_2018.id)
     assert_equal 2, matches.length
-    puts matches.inspect
-    assert_equal ['resource_103', 'resource_104'], matches.map {|m| m["key"]}.sort
+    assert_equal ['resource_103', 'resource_104'], matches.map {|m| m[:key]}.sort
 
     # Check that specifying a course version id finds an associated resource
     matches = ResourcesAutocomplete.get_search_matches("class", 5, @course_version_2019.id)
     assert_equal 1, matches.length
-    assert_equal 'resource_105', matches[0]["key"]
+    assert_equal 'resource_105', matches[0][:key]
   end
 
   test "only returns up to limit matches" do

--- a/dashboard/test/lib/vocabulary_autocomplete_test.rb
+++ b/dashboard/test/lib/vocabulary_autocomplete_test.rb
@@ -13,20 +13,20 @@ class VocabularyAutocompleteTest < ActiveSupport::TestCase
   test "finds vocabulary with matching word" do
     matches = VocabularyAutocomplete.get_search_matches('programming', 5, @course_version_2018.id)
     assert_equal 1, matches.length
-    assert_equal 'Programming', matches[0]['word']
-    assert_equal 'The art of creating a program.', matches[0]['definition']
+    assert_equal 'Programming', matches[0][:word]
+    assert_equal 'The art of creating a program.', matches[0][:definition]
   end
 
   test "finds vocabulary with match definition" do
     matches = VocabularyAutocomplete.get_search_matches('fixing', 5, @course_version_2018)
     assert_equal 1, matches.length
-    assert_equal 'Debugging', matches[0]['word']
+    assert_equal 'Debugging', matches[0][:word]
   end
 
   test "finds multiple matches" do
     matches = VocabularyAutocomplete.get_search_matches('pro', 5, @course_version_2018)
     assert_equal 2, matches.length
-    assert_equal ['Debugging', 'Programming'], matches.map {|m| m['word']}
+    assert_equal ['Debugging', 'Programming'], matches.map {|m| m[:word]}
   end
 
   test "restricts matches by limit" do
@@ -39,6 +39,6 @@ class VocabularyAutocompleteTest < ActiveSupport::TestCase
     # We should only get the one we requested
     matches = VocabularyAutocomplete.get_search_matches('algorithm', 1, @course_version_2019)
     assert_equal 1, matches.length
-    assert_equal @course_version_2019.id, matches[0]['course_version_id']
+    assert_equal @course_version_2019.id, Vocabulary.find(matches[0][:id]).course_version_id
   end
 end


### PR DESCRIPTION
Completes [PLAT-736](https://codedotorg.atlassian.net/browse/PLAT-736). 

tldr: As Dani predicted, the wrong information was being passed down. It doesn't appear there was any data loss so this is mostly a cosmetic fix. We didn't get a bug report for vocabulary because it doesn't actually use properties as of right now, but I also fixed that spot.

Slightly longer version: the search was returning `{id: <id>, name: <name>, ... , properties: { type: <type>, audience: <audience> ...}}` when React was expecting a flat map. So type and audience weren't there from the client's perspective and showed up as blank.

<!-- ### Background -->
<!-- ### Privacy -->
<!--
1.	Does the Project involve the collection, use or sharing of new Personal Data?

2.	Does the Project involve a new or changed use or sharing of existing Personal Data?
-->
<!-- ### Security -->
<!--
Link to Jira Task where sensitive security issues are discussed privately.
-->
<!-- ### Caching -->
<!-- ### Deployment strategy -->
<!-- ### Future work -->

## Links

<!--
  Any relevant links to external resources; ie, specification documents, jira
  items, related PRs, honeybadger errors, etc
-->

- [spec]()
- [jira]()

## Testing story

<!--
  Does your change include appropriate tests?

  If so, please describe how the tests included in this PR are sufficient

  If not, please explain why this change does not need to be tested.
-->

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
