### PR TITLE
[Spritelab] UI Polish for pause button

### DIFF
--- a/apps/src/lib/tools/jsdebugger/redux.js
+++ b/apps/src/lib/tools/jsdebugger/redux.js
@@ -47,6 +47,10 @@ export function isPaused(state) {
   return state.runState.isDebuggerPaused;
 }
 
+export function isRunning(state) {
+  return state.runState.isRunning;
+}
+
 export function isEditWhileRun(state) {
   return state.runState.isEditWhileRun;
 }
@@ -92,7 +96,8 @@ export const selectors = {
   canRunNext,
   getLogOutput,
   getMaxLogLevel,
-  isOpen
+  isOpen,
+  isRunning
 };
 
 // actions

--- a/apps/src/templates/PauseButton.jsx
+++ b/apps/src/templates/PauseButton.jsx
@@ -3,14 +3,22 @@ import {connect} from 'react-redux';
 import PropTypes from 'prop-types';
 import color from '@cdo/apps/util/color';
 import {actions, selectors} from '@cdo/apps/lib/tools/jsdebugger/redux';
+import {setArrowButtonDisabled} from '@cdo/apps/templates/arrowDisplayRedux';
 
 const styles = {
   button: {
     minWidth: 0,
     padding: '10px 13px',
-    backgroundColor: color.orange,
-    borderColor: color.orange,
+    borderRadius: '100%',
     color: color.white
+  },
+  runningColor: {
+    backgroundColor: color.cyan,
+    borderColor: color.cyan
+  },
+  pausedColor: {
+    backgroundColor: color.orange,
+    borderColor: color.orange
   }
 };
 
@@ -19,8 +27,10 @@ class PauseButton extends React.Component {
     pauseHandler: PropTypes.func.isRequired,
     // from redux
     togglePause: PropTypes.func.isRequired,
+    setArrowButtonDisabled: PropTypes.func.isRequired,
     isPaused: PropTypes.bool.isRequired,
-    isAttached: PropTypes.bool.isRequired
+    isAttached: PropTypes.bool.isRequired,
+    isRunning: PropTypes.bool.isRequired
   };
 
   state = {
@@ -29,16 +39,23 @@ class PauseButton extends React.Component {
 
   togglePause = () => {
     this.props.pauseHandler(this.props.isPaused);
+    this.props.setArrowButtonDisabled(!this.props.isPaused);
     this.props.togglePause();
   };
 
   render() {
+    const buttonStyle = {
+      ...styles.button,
+      ...(this.props.isRunning && styles.runningColor),
+      ...(this.props.isPaused && styles.pausedColor)
+    };
+
     return (
       <button
         type="button"
         onClick={this.togglePause}
-        style={styles.button}
-        disabled={!this.props.isAttached}
+        style={buttonStyle}
+        disabled={!this.props.isRunning}
       >
         <i className={this.props.isPaused ? 'fa fa-play' : 'fa fa-pause'} />
       </button>
@@ -49,9 +66,11 @@ class PauseButton extends React.Component {
 export default connect(
   state => ({
     isAttached: selectors.isAttached(state),
-    isPaused: selectors.isPaused(state)
+    isPaused: selectors.isPaused(state),
+    isRunning: selectors.isRunning(state)
   }),
   {
-    togglePause: actions.togglePause
+    togglePause: actions.togglePause,
+    setArrowButtonDisabled
   }
 )(PauseButton);

--- a/apps/src/templates/PauseButton.jsx
+++ b/apps/src/templates/PauseButton.jsx
@@ -6,11 +6,22 @@ import {actions, selectors} from '@cdo/apps/lib/tools/jsdebugger/redux';
 import {setArrowButtonDisabled} from '@cdo/apps/templates/arrowDisplayRedux';
 
 const styles = {
+  icon: {
+    lineHeight: 'inherit',
+    color: color.white
+  },
+  container: {
+    width: 40,
+    height: 40,
+    lineHeight: '40px',
+    textAlign: 'center',
+    verticalAlign: 'middle',
+    display: 'inline-block'
+  },
   button: {
     minWidth: 0,
-    padding: '10px 13px',
-    borderRadius: '100%',
-    color: color.white
+    padding: 0,
+    borderRadius: '100%'
   },
   runningColor: {
     backgroundColor: color.cyan,
@@ -57,7 +68,14 @@ class PauseButton extends React.Component {
         style={buttonStyle}
         disabled={!this.props.isRunning}
       >
-        <i className={this.props.isPaused ? 'fa fa-play' : 'fa fa-pause'} />
+        <div style={styles.container}>
+          <i
+            style={styles.icon}
+            className={
+              this.props.isPaused ? 'fa fa-fw fa-play' : 'fa fa-fw fa-pause'
+            }
+          />
+        </div>
       </button>
     );
   }


### PR DESCRIPTION
No functional changes, just UI updates.
From the JIRA ticket:
- it should be grayed out before the program runs
- when paused, the (right/left/up/down) arrow buttons should be grayed out
- change the color and shape of the button to a ~green~ blue circle (to differentiate it from the arrow buttons)

Before
![Feb-01-2021 17-25-25](https://user-images.githubusercontent.com/8787187/106539473-eb536700-64b2-11eb-8f76-8a3b3e799b4d.gif)

After
![Feb-01-2021 17-25-12](https://user-images.githubusercontent.com/8787187/106539515-01612780-64b3-11eb-9261-6af4bcbef432.gif)


<!-- ### Background -->
<!-- ### Privacy -->
<!--
1.	Does the Project involve the collection, use or sharing of new Personal Data?

2.	Does the Project involve a new or changed use or sharing of existing Personal Data?
-->
<!-- ### Security -->
<!--
Link to Jira Task where sensitive security issues are discussed privately.
-->
<!-- ### Caching -->
<!-- ### Deployment strategy -->
<!-- ### Future work -->

## Links

<!--
  Any relevant links to external resources; ie, specification documents, jira
  items, related PRs, honeybadger errors, etc
-->
- [jira](https://codedotorg.atlassian.net/browse/STAR-1413)

## Testing story

<!--
  Does your change include appropriate tests?

  If so, please describe how the tests included in this PR are sufficient

  If not, please explain why this change does not need to be tested.
-->

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
