### PR TITLE
Update unit tests to wrap tested component in <Provider/>

### DIFF
--- a/apps/test/unit/applab/ScreenSelectorTest.js
+++ b/apps/test/unit/applab/ScreenSelectorTest.js
@@ -1,5 +1,6 @@
-import {expect} from '../../util/deprecatedChai';
+import {expect} from '../../util/reconfiguredChai';
 import React from 'react';
+import {Provider} from 'react-redux';
 import {mount} from 'enzyme';
 import {
   getStore,
@@ -25,11 +26,12 @@ describe('The ScreenSelector component', () => {
 
   function render() {
     return mount(
-      <ScreenSelector
-        store={getStore()}
-        screenIds={['screen1', 'screen2']}
-        onCreate={() => {}}
-      />
+      <Provider store={getStore()}>
+        <ScreenSelector
+          screenIds={['screen1', 'screen2']}
+          onCreate={() => {}}
+        />
+      </Provider>
     );
   }
 

--- a/apps/test/unit/containedLevelsTest.js
+++ b/apps/test/unit/containedLevelsTest.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import ReactDOM from 'react-dom';
 import {Provider} from 'react-redux';
-import {assert} from '../util/deprecatedChai';
+import {assert} from '../util/reconfiguredChai';
 import sinon from 'sinon';
 import * as codeStudioLevels from '@cdo/apps/code-studio/levels/codeStudioLevels';
 import * as callouts from '@cdo/apps/code-studio/callouts';

--- a/apps/test/unit/containedLevelsTest.js
+++ b/apps/test/unit/containedLevelsTest.js
@@ -1,5 +1,6 @@
 import React from 'react';
 import ReactDOM from 'react-dom';
+import {Provider} from 'react-redux';
 import {assert} from '../util/deprecatedChai';
 import sinon from 'sinon';
 import * as codeStudioLevels from '@cdo/apps/code-studio/levels/codeStudioLevels';
@@ -16,7 +17,7 @@ import {
   restoreRedux
 } from '@cdo/apps/redux';
 import commonReducers from '@cdo/apps/redux/commonReducers';
-import UnconnectedGameButtons from '@cdo/apps/templates/GameButtons';
+import GameButtons from '@cdo/apps/templates/GameButtons';
 import {TestResults} from '@cdo/apps/constants';
 import $ from 'jquery';
 import {setInstructionsConstants} from '@cdo/apps/redux/instructions';
@@ -49,15 +50,16 @@ describe('getContainedLevelResultInfo', () => {
 
     gameButtons = document.createElement('div');
     ReactDOM.render(
-      React.createElement(UnconnectedGameButtons, {
-        hideRunButton: false,
-        runButtonText: 'Run',
-        playspacePhoneFrame: false,
-        nextLevelUrl: 'nextUrl',
-        showSkipButton: true,
-        showFinishButton: true,
-        store: getStore()
-      }),
+      <Provider store={getStore()}>
+        <GameButtons
+          hideRunButton={false}
+          runButtonText={'Run'}
+          playspacePhoneFrame={false}
+          nextLevelUrl={'nextUrl'}
+          showSkipButton={true}
+          showFinishButton={true}
+        />
+      </Provider>,
       gameButtons
     );
     document.body.appendChild(gameButtons);

--- a/apps/test/unit/containedLevelsTest.js
+++ b/apps/test/unit/containedLevelsTest.js
@@ -56,8 +56,8 @@ describe('getContainedLevelResultInfo', () => {
           runButtonText={'Run'}
           playspacePhoneFrame={false}
           nextLevelUrl={'nextUrl'}
-          showSkipButton={true}
-          showFinishButton={true}
+          showSkipButton
+          showFinishButton
         />
       </Provider>,
       gameButtons


### PR DESCRIPTION
Updates some unit tests that were failing in React 16.13 / Redux ~6 with the following error:
```
Error: Uncaught Invariant Violation: Passing redux store in props has been removed and does not do anything.
To use a custom Redux store for specific components,  create a custom React context with React.createContext(),
and pass the context object to React Redux's Provider and specific components like: 
<Provider context={MyContext}><ConnectedComponent context={MyContext} /></Provider>.
You may also pass a {context : MyContext} option to connect
(webpack:///node_modules/invariant/browser.js:45:0 <- test/entry-tests.js:100866)
```

The resolution I used was to wrap the tested component in a `<Provider/>`.

Also updated those tests to use reconfiguredChai as it didn't require any additional changes.