### PR TITLE
also delete .script_json file when script is destroyed via UI

### DIFF
--- a/dashboard/app/controllers/scripts_controller.rb
+++ b/dashboard/app/controllers/scripts_controller.rb
@@ -95,6 +95,8 @@ class ScriptsController < ApplicationController
     if Rails.application.config.levelbuilder_mode
       filename = "config/scripts/#{@script.name}.script"
       File.delete(filename) if File.exist?(filename)
+      filename = "config/scripts_json/#{@script.name}.script_json"
+      File.delete(filename) if File.exist?(filename)
     end
     redirect_to scripts_path, notice: I18n.t('crud.destroyed', model: Script.model_name.human)
   end


### PR DESCRIPTION
Finishes [PLAT-726]. 

## Testing story

Manually verified that clicking "delete" on localhost-studio.code.org/s/ deletes both the .script and the .script_json file.

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked


[PLAT-726]: https://codedotorg.atlassian.net/browse/PLAT-726