### PR TITLE
Restore "use script id to find teacher feedback script level"

### DIFF
--- a/dashboard/app/controllers/teacher_feedbacks_controller.rb
+++ b/dashboard/app/controllers/teacher_feedbacks_controller.rb
@@ -6,14 +6,23 @@ class TeacherFeedbacksController < ApplicationController
   # Feedback from any verified teacher who has provided feedback to the current
   # student on any level
   def index
-    @feedbacks_as_student = @teacher_feedbacks.order(created_at: :desc).includes(script_level: {lesson: :script}).select do |feedback|
+    scope = {
+      level: {
+        script_levels: {
+          lesson: :script
+        }
+      }
+    }
+    @feedbacks_as_student = @teacher_feedbacks.order(created_at: :desc).includes(scope).select do |feedback|
       UserPermission.where(
         user_id: feedback.teacher_id,
         permission: 'authorized_teacher'
       )
     end
 
-    @feedbacks_as_student_with_level_info = @feedbacks_as_student.map {|feedback| feedback.attributes.merge(feedback&.script_level&.summary_for_feedback)}
+    @feedbacks_as_student_with_level_info = @feedbacks_as_student.map do |feedback|
+      feedback.attributes.merge(feedback&.get_script_level&.summary_for_feedback)
+    end
   end
 
   def set_seen_on_feedback_page_at

--- a/dashboard/app/models/teacher_feedback.rb
+++ b/dashboard/app/models/teacher_feedback.rb
@@ -44,7 +44,17 @@ class TeacherFeedback < ApplicationRecord
   # Finds the script level associated with this object, using script id and
   # level id.
   def get_script_level
-    level.script_levels.find {|sl| sl.script_id == script_id}
+    script_level = level.script_levels.find {|sl| sl.script_id == script_id}
+    return script_level if script_level
+
+    # This will be somewhat expensive, but will only be executed for feedbacks
+    # which were are associated with a Bubble Choice sublevel.
+    bubble_choice_levels = script.levels.where(type: 'BubbleChoice').all
+    parent_level = bubble_choice_levels.find {|bc| bc.sublevels.include?(level)}
+
+    script_level = parent_level.script_levels.find {|sl| sl.script_id == script_id}
+    raise "no script level found for teacher feedback #{id}" unless script_level
+    script_level
   end
 
   def self.get_student_level_feedback(student_id, level_id, teacher_id)

--- a/dashboard/app/models/teacher_feedback.rb
+++ b/dashboard/app/models/teacher_feedback.rb
@@ -41,6 +41,12 @@ class TeacherFeedback < ApplicationRecord
     end
   end
 
+  # Finds the script level associated with this object, using script id and
+  # level id.
+  def get_script_level
+    level.script_levels.find {|sl| sl.script_id == script_id}
+  end
+
   def self.get_student_level_feedback(student_id, level_id, teacher_id)
     where(
       student_id: student_id,

--- a/dashboard/test/controllers/teacher_feedbacks_controller_test.rb
+++ b/dashboard/test/controllers/teacher_feedbacks_controller_test.rb
@@ -13,6 +13,9 @@ class TeacherFeedbacksControllerTest < ActionController::TestCase
     sign_in student
     get :index
     assert_response :success
+
+    all_feedback_data = get_all_response_feedback_data
+    assert_equal 0, all_feedback_data.count
   end
 
   test 'index: returns success if signed in user - feedback' do
@@ -21,5 +24,33 @@ class TeacherFeedbacksControllerTest < ActionController::TestCase
     sign_in feedback.student
     get :index
     assert_response :success
+
+    all_feedback_data = get_all_response_feedback_data
+    assert_equal 1, all_feedback_data.count
+    assert_equal feedback.student.id, all_feedback_data.first['student_id']
+  end
+
+  test 'index returns many feedbacks' do
+    student = create :student
+    5.times do
+      create :teacher_feedback, student: student
+    end
+    assert_equal TeacherFeedback.all.count, 5
+    sign_in student
+    assert_queries 20 do
+      get :index
+      assert_response :success
+    end
+
+    all_feedback_data = get_all_response_feedback_data
+    assert_equal 5, all_feedback_data.count
+  end
+
+  private
+
+  def get_all_response_feedback_data
+    assert_select 'script[data-feedback]', 1
+    feedback_data = JSON.parse(css_select('script[data-feedback]').first.attribute('data-feedback').to_s)
+    feedback_data['all_feedback']
   end
 end

--- a/dashboard/test/models/teacher_feedback_test.rb
+++ b/dashboard/test/models/teacher_feedback_test.rb
@@ -179,4 +179,12 @@ class TeacherFeedbackTest < ActiveSupport::TestCase
       assert_equal datetime2, feedback.student_last_visited_at
     end
   end
+
+  test 'get_script_level finds level in script' do
+    script_level = create :script_level
+    script = script_level.script
+    level = script_level.levels.first
+    feedback = create :teacher_feedback, script: script, level: level
+    assert_equal script_level, feedback.get_script_level
+  end
 end

--- a/dashboard/test/models/teacher_feedback_test.rb
+++ b/dashboard/test/models/teacher_feedback_test.rb
@@ -185,7 +185,9 @@ class TeacherFeedbackTest < ActiveSupport::TestCase
     script = script_level.script
     level = script_level.levels.first
     feedback = create :teacher_feedback, script: script, level: level
-    assert_equal script_level, feedback.get_script_level
+    assert_queries(1) do
+      assert_equal script_level, feedback.get_script_level
+    end
   end
 
   test 'get_script_level finds bubble choice parent level' do
@@ -209,6 +211,8 @@ class TeacherFeedbackTest < ActiveSupport::TestCase
     other_script_level = create :script_level, script: script, lesson: lesson, levels: [create(:level)]
 
     feedback = create :teacher_feedback, script: script, level: child_level, script_level: other_script_level
-    assert_equal script_level, feedback.get_script_level
+    assert_queries(4) do
+      assert_equal script_level, feedback.get_script_level
+    end
   end
 end

--- a/dashboard/test/models/teacher_feedback_test.rb
+++ b/dashboard/test/models/teacher_feedback_test.rb
@@ -199,6 +199,12 @@ class TeacherFeedbackTest < ActiveSupport::TestCase
     script = create :script
     lesson_group = create :lesson_group, script: script
     lesson = create :lesson, lesson_group: lesson_group, script: script
+
+    # the query count grows with the number of bubble choice levels in the script.
+    create :script_level, script: script, lesson: lesson, levels: [create(:bubble_choice_level, :with_sublevels)]
+    create :script_level, script: script, lesson: lesson, levels: [create(:bubble_choice_level, :with_sublevels)]
+    create :script_level, script: script, lesson: lesson, levels: [create(:bubble_choice_level, :with_sublevels)]
+
     script_level = create :script_level, script: script, lesson: lesson, levels: [parent_level]
 
     # HACK: we have to supply a script_level, because it is still a required field.
@@ -211,7 +217,7 @@ class TeacherFeedbackTest < ActiveSupport::TestCase
     other_script_level = create :script_level, script: script, lesson: lesson, levels: [create(:level)]
 
     feedback = create :teacher_feedback, script: script, level: child_level, script_level: other_script_level
-    assert_queries(4) do
+    assert_queries(7) do
       assert_equal script_level, feedback.get_script_level
     end
   end


### PR DESCRIPTION
Reverts code-dot-org/code-dot-org#38855, restoring #38729.

#38729 caused honeybadger errors when trying to view feedback on bubble choice sublevels. the problem is that the code in that PR assumed that the teacher feedback level would have its own script level. However, this is not true in the case of bubble choice levels, where only the bubble choice (parent) level itself has a script level.

The solution here is to first do the cheaper search for the level within the script. When that fails, do a more expensive search for the level within each bubble choice level in the script.

[PLAT-685]: https://codedotorg.atlassian.net/browse/PLAT-685