### PR TITLE
Require CLUSTER_ID environment variable to be set for delete_cluster task

### DIFF
--- a/lib/cdo/aws/rds.rb
+++ b/lib/cdo/aws/rds.rb
@@ -78,7 +78,7 @@ module Cdo
     end
 
     def self.delete_cluster(cluster_id: nil, max_attempts: 20, delay: 60)
-      raise StandardError.new("CLUSTER_ID environment variable is required.") unless cluster_id
+      raise StandardError.new("CLUSTER_ID environment variable is required.") unless cluster_id.present?
       rds_client = Aws::RDS::Client.new
       begin
         existing_cluster = rds_client.describe_db_clusters({db_cluster_identifier: cluster_id}).db_clusters.first

--- a/lib/cdo/aws/rds.rb
+++ b/lib/cdo/aws/rds.rb
@@ -77,7 +77,8 @@ module Cdo
       CDO.log.info "Done creating database cluster - #{clone_cluster_id}"
     end
 
-    def self.delete_cluster(cluster_id, max_attempts = 20, delay = 60)
+    def self.delete_cluster(cluster_id: nil, max_attempts: 20, delay: 60)
+      raise StandardError.new("CLUSTER_ID environment variable is required.") unless cluster_id
       rds_client = Aws::RDS::Client.new
       begin
         existing_cluster = rds_client.describe_db_clusters({db_cluster_identifier: cluster_id}).db_clusters.first

--- a/lib/rake/rds.rake
+++ b/lib/rake/rds.rake
@@ -19,6 +19,9 @@ namespace :rds do
 
   desc 'Delete CLUSTER_ID'
   task :delete_cluster do
-    Cdo::RDS.delete_cluster(ENV['CLUSTER_ID'])
+    options = {
+      cluster_id: ENV['CLUSTER_ID']
+    }
+    Cdo::RDS.delete_cluster(options.compact)
   end
 end


### PR DESCRIPTION
The `rds:delete_cluster` rake task was deleting the first RDS cluster in our AWS account when the CLUSTER_ID environment variable was not set!!! Protect against missing/empty CLUSTER_ID.

<!-- ### Background -->
<!-- ### Privacy -->
<!--
1.	Does the Project involve the collection, use or sharing of new Personal Data?

2.	Does the Project involve a new or changed use or sharing of existing Personal Data?
-->
<!-- ### Security -->
<!--
Link to Jira Task where sensitive security issues are discussed privately.
-->
<!-- ### Caching -->
<!-- ### Deployment strategy -->
<!-- ### Future work -->



## Testing story

```
kilkenny:code-dot-org suresh$ bundle exec rake rds:delete_cluster
rake aborted!
StandardError: CLUSTER_ID environment variable is required.
/Users/suresh/code-dot-org/lib/cdo/aws/rds.rb:82:in `delete_cluster'
/Users/suresh/code-dot-org/lib/rake/rds.rake:25:in `block (2 levels) in <top (required)>'
/Users/suresh/.rbenv/versions/2.5.0/bin/bundle:23:in `load'
/Users/suresh/.rbenv/versions/2.5.0/bin/bundle:23:in `<main>'
Tasks: TOP => rds:delete_cluster
(See full trace by running task with --trace)


$ bundle exec rake rds:delete_cluster CLUSTER_ID=
rake aborted!
StandardError: CLUSTER_ID environment variable is required.
/Users/suresh/code-dot-org/lib/cdo/aws/rds.rb:82:in `delete_cluster'
/Users/suresh/code-dot-org/lib/rake/rds.rake:25:in `block (2 levels) in <top (required)>'
/Users/suresh/.rbenv/versions/2.5.0/bin/bundle:23:in `load'
/Users/suresh/.rbenv/versions/2.5.0/bin/bundle:23:in `<main>'
Tasks: TOP => rds:delete_cluster
(See full trace by running task with --trace)

suresh$ bundle exec rake rds:delete_cluster CLUSTER_ID=production-feedback-schema-change-test
Database Cluster production-feedback-schema-change-test has been deleted. DBCluster production-feedback-schema-change-test not found.
```

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
