### PR TITLE
Prevent autofocus on first question when editing Foorm forms

### DIFF
--- a/apps/src/code-studio/pd/foorm/Foorm.jsx
+++ b/apps/src/code-studio/pd/foorm/Foorm.jsx
@@ -21,7 +21,8 @@ export default class Foorm extends React.Component {
     surveyData: PropTypes.object,
     submitParams: PropTypes.object,
     customCssClasses: PropTypes.object,
-    onComplete: PropTypes.func
+    onComplete: PropTypes.func,
+    editorMode: PropTypes.bool
   };
 
   static defaultProps = {
@@ -71,6 +72,13 @@ export default class Foorm extends React.Component {
     Survey.StylesManager.applyTheme('default');
 
     this.surveyModel = new Survey.Model(this.props.formQuestions);
+
+    // Prevents focus from moving from codemirror in Foorm Editor
+    // (where survey editors can edit survey configuration and see changes live)
+    // to the first question of the rendered SurveyJS Survey.
+    if (this.props.editorMode) {
+      this.surveyModel.focusFirstQuestionAutomatic = false;
+    }
   }
 
   onComplete = (survey, options) => {

--- a/apps/src/code-studio/pd/foorm/Foorm.jsx
+++ b/apps/src/code-studio/pd/foorm/Foorm.jsx
@@ -22,7 +22,7 @@ export default class Foorm extends React.Component {
     submitParams: PropTypes.object,
     customCssClasses: PropTypes.object,
     onComplete: PropTypes.func,
-    editorMode: PropTypes.bool
+    inEditorMode: PropTypes.bool
   };
 
   static defaultProps = {
@@ -76,7 +76,7 @@ export default class Foorm extends React.Component {
     // Prevents focus from moving from codemirror in Foorm Editor
     // (where survey editors can edit survey configuration and see changes live)
     // to the first question of the rendered SurveyJS Survey.
-    if (this.props.editorMode) {
+    if (this.props.inEditorMode) {
       this.surveyModel.focusFirstQuestionAutomatic = false;
     }
   }

--- a/apps/src/code-studio/pd/foorm/editor/FoormEditorPreview.jsx
+++ b/apps/src/code-studio/pd/foorm/editor/FoormEditorPreview.jsx
@@ -57,6 +57,7 @@ class FoormEditorPreview extends Component {
                 submitApi={'/none'}
                 key={`form-${this.props.formKey}`}
                 surveyData={this.props.surveyData}
+                editorMode={true}
               />
             )}
         </div>

--- a/apps/src/code-studio/pd/foorm/editor/FoormEditorPreview.jsx
+++ b/apps/src/code-studio/pd/foorm/editor/FoormEditorPreview.jsx
@@ -57,7 +57,7 @@ class FoormEditorPreview extends Component {
                 submitApi={'/none'}
                 key={`form-${this.props.formKey}`}
                 surveyData={this.props.surveyData}
-                editorMode={true}
+                inEditorMode={true}
               />
             )}
         </div>

--- a/apps/src/sites/studio/pages/foorm/forms/editor.js
+++ b/apps/src/sites/studio/pages/foorm/forms/editor.js
@@ -35,7 +35,7 @@ $(document).ready(function() {
 function populateCodeMirror() {
   const codeMirrorArea = document.getElementsByTagName('textarea')[0];
   codeMirror = initializeCodeMirror(codeMirrorArea, 'application/json', {
-    callback: onCodeMirrorChange
+    callback: _.debounce(onCodeMirrorChange, 250)
   });
 }
 


### PR DESCRIPTION
I noticed yesterday that some Foorm forms would lose focus from the editing area after 1-2 keystrokes. It appeared to happen only in forms that had a radio input on it (eg, workshop_csf_intro_post and ayw_workshop_pre_survey).

It looks like SurveyJS has [some logic to auto-focus the first question](https://surveyjs.io/Documentation/Library?id=SurveyModel#focusFirstQuestionAutomatic) in a survey once rendered. It makes sense then that surveys that just have a description on the first page were editable without issue (many of the forms currently available in the Foorm form editor). Unclear why certain surveys that have a question in them (nps_survey, for example) that wasn't a radio button worked previously.

I set it up so this auto-focus doesn't happen when rendering a form in "editor mode". I also debounced the codemirror callback, so that updates to the redux state (and subsequent rerender of the form) don't happen on each keystroke. Rendering the form on each keystroke was very slow for more complicated forms (such as the ones where this problem was observed, where the rendered form consists of many questions).

## Testing story

I tested this on several of the seeded form configurations. I didn't test on any production forms. You can visit /foorm/forms/editor on levelbuilder to repro the issue, and/or try this update locally with levelbuilder mode enabled.

## Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
