### PR TITLE
Allow warnings for unit tests with React lifecycle method deprecation…

### DIFF
--- a/apps/test/unit/lib/tools/jsdebugger/JsDebuggerTest.js
+++ b/apps/test/unit/lib/tools/jsdebugger/JsDebuggerTest.js
@@ -5,7 +5,10 @@ import {mount} from 'enzyme';
 import {expect} from '../../../../util/deprecatedChai';
 import JsDebugger from '@cdo/apps/lib/tools/jsdebugger/JsDebugger';
 import {actions, reducers} from '@cdo/apps/lib/tools/jsdebugger/redux';
-import {createMouseEvent} from '../../../../util/testUtils.js';
+import {
+  allowConsoleWarnings,
+  createMouseEvent
+} from '../../../../util/testUtils.js';
 import {
   getStore,
   registerReducers,
@@ -18,6 +21,10 @@ import {sandboxDocumentBody} from '../../../../util/testUtils';
 import dom from '@cdo/apps/dom';
 
 describe('The JSDebugger component', () => {
+  // TODO: (madelynkasula) Silences componentWillUpdate deprecation warning due to React 16 upgrade.
+  // This warning should be addressed after we've upgraded React.
+  allowConsoleWarnings();
+
   let root, jsDebugger, addEventSpy, removeEventSpy, codeApp;
   const getBodyEventSpies = spyOnBodyEventMethods();
   sandboxDocumentBody();

--- a/apps/test/unit/tutorialExplorer/filterHeaderTest.jsx
+++ b/apps/test/unit/tutorialExplorer/filterHeaderTest.jsx
@@ -5,6 +5,7 @@ import {expect} from '../../util/deprecatedChai';
 import FilterHeader from '@cdo/apps/tutorialExplorer/filterHeader';
 import BackButton from '@cdo/apps/tutorialExplorer/backButton';
 import i18n from '@cdo/tutorialExplorer/locale';
+import {allowConsoleWarnings} from '../../util/testUtils';
 
 const FAKE_ON_USER_INPUT = () => {};
 const FAKE_ON_ORG_NAME = () => {};
@@ -24,6 +25,10 @@ const DEFAULT_PROPS = {
 };
 
 describe('FilterHeader', () => {
+  // TODO: (madelynkasula) Silences componentWillMount deprecation warning due to React 16 upgrade.
+  // This warning should be addressed after we've upgraded React.
+  allowConsoleWarnings();
+
   it('renders simplest mobile view', () => {
     const wrapper = mount(
       <StickyContainer>

--- a/apps/test/unit/watchers/AutocompleteSelectorTest.js
+++ b/apps/test/unit/watchers/AutocompleteSelectorTest.js
@@ -3,8 +3,13 @@ import sinon from 'sinon';
 import React from 'react';
 import {mount} from 'enzyme';
 import AutocompleteSelector from '@cdo/apps/templates/watchers/AutocompleteSelector';
+import {allowConsoleWarnings} from '../../util/testUtils';
 
 describe('AutocompleteSelector', () => {
+  // TODO: (madelynkasula) Silences componentWillReceiveProps deprecation warning due to React 16 upgrade.
+  // This warning should be addressed after we've upgraded React.
+  allowConsoleWarnings();
+
   let component, componentInstance, clicked, mousedOver, clickOutside;
 
   const FIRST_OPTION_TEXT = 'option1';


### PR DESCRIPTION
… warnings

[Spreadsheet source](https://docs.google.com/spreadsheets/d/19YjaYWRN2OW51YEYeNXdzazqYkPIRKWD1SEs6YI2CfI/edit#gid=0)

This allows console warnings for *Labs unit tests that were failing due to lifecycle method deprecations in React. We are silencing these for now and will be addressing them after successfully upgrading to React 16.