### PR TITLE
Update csp 20-21 lessons that are lockable with lesson plan

### DIFF
--- a/dashboard/config/locales/scripts.en.yml
+++ b/dashboard/config/locales/scripts.en.yml
@@ -15810,7 +15810,7 @@ en:
             Project - Decision Maker App Part 3:
               name: Project - Decision Maker App Part 3
             'Lesson 15: Assessment Day':
-              name: 'Lesson 15: Assessment Day'
+              name: Assessment Day
           student_description: This unit explores how variables, conditionals, and functions allow for the design of increasingly complex apps. Learn how to program with these three new concepts through a sequence of collaborative activities. Then build your own decision maker app to share with friends and help them make a decision.
           name: csp4-2020
         csp5-2020:
@@ -15863,7 +15863,7 @@ en:
             Semester Hackathon Part 5:
               name: Semester Hackathon Part 5
             'Lesson 18: Assessment Day':
-              name: 'Lesson 18: Assessment Day'
+              name: Assessment Day
             Unit 5 STUDENT Survey:
               name: Unit 5 STUDENT Survey
             Unit 5 TEACHER Survey:
@@ -15910,7 +15910,7 @@ en:
             Variables Make Demo:
               name: Variables Make Demo
             'Lesson 11: Assessment Day':
-              name: 'Lesson 11: Assessment Day'
+              name: Assessment Day
           name: csp7-2020
           student_description: This unit introduces parameters, return, and libraries. Learn how to use these concepts to build new kinds of apps as well as libraries of code that you can share with your classmates. End the unit by designing a library of functions around any topic of your choosing.
         csd2-projects-temp:
@@ -17525,7 +17525,7 @@ en:
             Project - Digital Information Dilemmas Part 2:
               name: Project - Digital Information Dilemmas Part 2
             'Lesson 14: Assessment Day':
-              name: 'Lesson 14: Assessment Day'
+              name: Assessment Day
             CS Principles Pre-survey:
               name: CS Principles Pre-survey
           student_description: This unit explores the technical challenges and questions that arise from the need to represent digital information in computers. Learn how complex information like numbers, text, images, and sound are represented in text, how compression works, and the broader social impacts of digitizing the world's information.
@@ -17558,7 +17558,7 @@ en:
             Project - Internet Dilemmas Part 2:
               name: Project - Internet Dilemmas Part 2
             'Lesson 9: Assessment Day':
-              name: 'Lesson 9: Assessment Day'
+              name: Assessment Day
           student_description: This unit reveals how the Internet was designed to connect billions of devices and people to one another. Learn how the different protocols of the Internet work and actually build them yourself using the Internet Simulator. Then consider the impacts the Internet has had, both good and bad, on modern life.
           name: csp2-2020
         csp3-2020:
@@ -17593,7 +17593,7 @@ en:
             Project - Designing an App Part 5:
               name: Project - Designing an App Part 5
             'Lesson 11: Assessment Day':
-              name: 'Lesson 11: Assessment Day'
+              name: Assessment Day
           name: csp3-2020
           student_description: This unit is an introduction to programming and app design with a heavy focus on important skills like debugging, pair programming, and user testing. Learn how to design user interfaces and write event-driven programs in App Lab and then design a project that teaches your classmates about a topic of your choosing.
         csp6-2020:
@@ -17618,7 +17618,7 @@ en:
             Parallel and Distributed Algorithms:
               name: Parallel and Distributed Algorithms
             'Lesson 6: Assessment Day':
-              name: 'Lesson 6: Assessment Day'
+              name: Assessment Day
           student_description: This unit is a quick exploration of how computer scientists design algorithms to solve problems and how they analyze the speed of different algorithms. Learn about the concept of algorithmic efficiency through a variety of hands-on activities and learn how it's being applied in modern computing.
           name: csp6-2020
         csp8-2020:
@@ -17666,7 +17666,7 @@ en:
             Project - Tell a Data Story - Part 2:
               name: Project - Tell a Data Story - Part 2
             'Lesson 9: Assessment Day':
-              name: 'Lesson 9: Assessment Day'
+              name: Assessment Day
           student_description: 'In this unit learn how data analysis helps turn raw data into useful information about the world. Learn how to use data visualization to find patterns inside of data sets and learn how this data analysis process is being used in contexts like open data or machine learning to help make decisions or learn more about our world. In the unit project you''ll analyze a dataset of your choosing and present your findings. '
           name: csp9-2020
         csp10-2020:
@@ -17713,7 +17713,7 @@ en:
             'Project: Innovation Simulation Part 7':
               name: 'Project: Innovation Simulation Part 7'
             'Lesson 14: Unit Assessment Day':
-              name: 'Lesson 14: Unit Assessment Day'
+              name: Unit Assessment Day
           student_description: "In this unit learn how computing innovations have impacted our world in beneficial and harmful ways. Learn how data can pose a threat to our privacy and security, and the ways that encryption and other techniques are used to complete it. Throughout the unit participate in a \"school of the future\" conference in which you and a team make a proposal for how best to improve school life with computing innovations.\r\n\r\n"
           name: csp10-2020
         csp-march-virtual:

--- a/dashboard/config/routes.rb
+++ b/dashboard/config/routes.rb
@@ -271,6 +271,17 @@ Dashboard::Application.routes.draw do
     end
   end
 
+  # CSP 20-21 lockable lessons with lesson plan redirects
+  get '/s/csp1-2020/lockable/2(*all)', to: redirect(path: '/s/csp1-2020/stage/14%{all}')
+  get '/s/csp2-2020/lockable/1(*all)', to: redirect(path: '/s/csp2-2020/stage/9%{all}')
+  get '/s/csp3-2020/lockable/1(*all)', to: redirect(path: '/s/csp3-2020/stage/11%{all}')
+  get '/s/csp4-2020/lockable/1(*all)', to: redirect(path: '/s/csp4-2020/stage/15%{all}')
+  get '/s/csp5-2020/lockable/1(*all)', to: redirect(path: '/s/csp5-2020/stage/18%{all}')
+  get '/s/csp6-2020/lockable/1(*all)', to: redirect(path: '/s/csp6-2020/stage/6%{all}')
+  get '/s/csp7-2020/lockable/1(*all)', to: redirect(path: '/s/csp7-2020/stage/11%{all}')
+  get '/s/csp9-2020/lockable/1(*all)', to: redirect(path: '/s/csp9-2020/stage/9%{all}')
+  get '/s/csp10-2020/lockable/1(*all)', to: redirect(path: '/s/csp10-2020/stage/14%{all}')
+
   resources :scripts, path: '/s/' do
     # /s/xxx/reset
     get 'reset', to: 'script_levels#reset'

--- a/dashboard/config/scripts/csp1-2020.script
+++ b/dashboard/config/scripts/csp1-2020.script
@@ -93,6 +93,6 @@ lesson 'Project - Digital Information Dilemmas Part 2', display_name: 'Project -
 level 'CSP U1L14 SFLP 20-21', progression: 'Lesson Overview'
 level 'U1L14 CSP CFU digital information', progression: 'Check For Understanding', assessment: true
 
-lesson 'Lesson 14: Assessment Day', display_name: 'Lesson 14: Assessment Day', lockable: true, has_lesson_plan: false
+lesson 'Lesson 14: Assessment Day', display_name: 'Assessment Day', lockable: true, has_lesson_plan: true
 level 'CSP Unit 1 AP-Style Assessment _2020', progression: 'Unit 1 Exam', assessment: true
 

--- a/dashboard/config/scripts/csp10-2020.script
+++ b/dashboard/config/scripts/csp10-2020.script
@@ -62,7 +62,7 @@ level 'CSP U10L12 SFLP 20-21', progression: 'Lesson Overview'
 lesson 'Project: Innovation Simulation Part 7', display_name: 'Project: Innovation Simulation Part 7', has_lesson_plan: true
 level 'CSP U10L13 SFLP 20-21', progression: 'Lesson Overview'
 
-lesson 'Lesson 14: Unit Assessment Day', display_name: 'Lesson 14: Unit Assessment Day', lockable: true, has_lesson_plan: false
+lesson 'Lesson 14: Unit Assessment Day', display_name: 'Unit Assessment Day', lockable: true, has_lesson_plan: true
 level 'CSP U10L14 SFLP 20-21', progression: 'Lesson Overview'
 level 'CSP 20-21 Unit 10 Assessment', progression: 'Unit 10 Exam', assessment: true
 

--- a/dashboard/config/scripts/csp2-2020.script
+++ b/dashboard/config/scripts/csp2-2020.script
@@ -50,6 +50,6 @@ level 'CSP U2L7 SFLP 20-21', progression: 'Lesson Overview'
 lesson 'Project - Internet Dilemmas Part 2', display_name: 'Project - Internet Dilemmas Part 2', has_lesson_plan: true
 level 'CSP U2L9 SFLP 20-21', progression: 'Lesson Overview'
 
-lesson 'Lesson 9: Assessment Day', display_name: 'Lesson 9: Assessment Day', lockable: true, has_lesson_plan: false
+lesson 'Lesson 9: Assessment Day', display_name: 'Assessment Day', lockable: true, has_lesson_plan: true
 level 'CSP Unit 2 MC Assessment _2020', progression: 'Unit 2 Exam', assessment: true
 

--- a/dashboard/config/scripts/csp3-2020.script
+++ b/dashboard/config/scripts/csp3-2020.script
@@ -82,6 +82,6 @@ lesson 'Project - Designing an App Part 5', display_name: 'Project - Designing a
 level 'CSP U3L10 SFLP 20-21', progression: 'Lesson Overview'
 level 'CSP U3 L10 Submit App', progression: 'Submit Your App', assessment: true
 
-lesson 'Lesson 11: Assessment Day', display_name: 'Lesson 11: Assessment Day', lockable: true, has_lesson_plan: false
+lesson 'Lesson 11: Assessment Day', display_name: 'Assessment Day', lockable: true, has_lesson_plan: true
 level 'CSP Unit 3 MC Assessment _2020', progression: 'Unit 3 Exam', assessment: true
 

--- a/dashboard/config/scripts/csp4-2020.script
+++ b/dashboard/config/scripts/csp4-2020.script
@@ -131,7 +131,7 @@ level 'CSP U4L14 SFLP 20-21', progression: 'Lesson Overview'
 level 'U4 L14 Practice PT 1', progression: 'Test Your Decision Maker App'
 level 'U4 L14 Practice PT 2', progression: 'Submit Your Decision Maker App', assessment: true
 
-lesson 'Lesson 15: Assessment Day', display_name: 'Lesson 15: Assessment Day', lockable: true, has_lesson_plan: false
+lesson 'Lesson 15: Assessment Day', display_name: 'Assessment Day', lockable: true, has_lesson_plan: true
 level 'CSP U4L15 SFLP 20-21', progression: 'Lesson Overview'
 level 'CSP 20-21 Unit 4 Assessment', progression: 'Unit 4 Exam', assessment: true
 

--- a/dashboard/config/scripts/csp5-2020.script
+++ b/dashboard/config/scripts/csp5-2020.script
@@ -130,7 +130,7 @@ lesson 'Semester Hackathon Part 5', display_name: 'Semester Hackathon Part 5', h
 level 'CSP U5L17 SFLP 20-21', progression: 'Lesson Overview'
 level 'U5 Hackathon Project Day 5', progression: 'Hackathon Project', assessment: true
 
-lesson 'Lesson 18: Assessment Day', display_name: 'Lesson 18: Assessment Day', lockable: true, has_lesson_plan: false
+lesson 'Lesson 18: Assessment Day', display_name: 'Assessment Day', lockable: true, has_lesson_plan: true
 level 'CSP U5L18 SFLP 20-21', progression: 'Lesson Overview'
 level 'CSP Unit 5 AP-Style Assessment _2020', progression: 'Unit 5 Exam', assessment: true
 

--- a/dashboard/config/scripts/csp6-2020.script
+++ b/dashboard/config/scripts/csp6-2020.script
@@ -39,7 +39,7 @@ level 'CSP U6L5 SFLP 20-21', progression: 'Lesson Overview'
 level 'U6L5 CFU Calculate Speedup', progression: 'Check For Understanding', assessment: true
 level 'U6 L05 Speedup Forever', progression: 'Check For Understanding', assessment: true
 
-lesson 'Lesson 6: Assessment Day', display_name: 'Lesson 6: Assessment Day', lockable: true, has_lesson_plan: false
+lesson 'Lesson 6: Assessment Day', display_name: 'Assessment Day', lockable: true, has_lesson_plan: true
 level 'CSP U6L6 SFLP 20-21', progression: 'Lesson Overview'
 level 'CSP Unit 6 AP-Style Assessment _2020', progression: 'Unit 6 Exam', assessment: true
 

--- a/dashboard/config/scripts/csp7-2020.script
+++ b/dashboard/config/scripts/csp7-2020.script
@@ -71,7 +71,7 @@ lesson 'Project - Make a Library Part 3', display_name: 'Project - Make a Librar
 level 'CSP U7L10 SFLP 20-21', progression: 'Lesson Overview'
 level 'U7 Libraries Project Part 3', progression: 'Build Your Library', assessment: true
 
-lesson 'Lesson 11: Assessment Day', display_name: 'Lesson 11: Assessment Day', lockable: true, has_lesson_plan: false
+lesson 'Lesson 11: Assessment Day', display_name: 'Assessment Day', lockable: true, has_lesson_plan: true
 level 'CSP U7L12 SFLP 20-21', progression: 'Lesson Overview'
 level 'CSP Unit 7 AP-Style Assessment _2020', progression: 'Unit 7 Exam', assessment: true
 

--- a/dashboard/config/scripts/csp9-2020.script
+++ b/dashboard/config/scripts/csp9-2020.script
@@ -55,7 +55,7 @@ lesson 'Project - Tell a Data Story - Part 2', display_name: 'Project - Tell a D
 level 'CSP U9L9 SFLP 20-21', progression: 'Lesson Overview'
 level 'CSP U9 Data Story Day 2', progression: 'Data Story Workspace', assessment: true
 
-lesson 'Lesson 9: Assessment Day', display_name: 'Lesson 9: Assessment Day', lockable: true, has_lesson_plan: false
+lesson 'Lesson 9: Assessment Day', display_name: 'Assessment Day', lockable: true, has_lesson_plan: true
 level 'CSP U9L10 SFLP 20-21', progression: 'Lesson Overview'
 level 'CSP Unit 9 AP-Style Assessment _2020', progression: 'Unit 9 Exam', assessment: true
 

--- a/dashboard/config/scripts_json/csp1-2020.script_json
+++ b/dashboard/config/scripts_json/csp1-2020.script_json
@@ -5,11 +5,21 @@
     "hidden": false,
     "login_required": true,
     "properties": {
-      "curriculum_umbrella": "CSP",
-      "student_detail_progress_view": true,
-      "has_verified_resources": true,
-      "curriculum_path": "https://curriculum.code.org/{LOCALE}/csp-20/unit1/{LESSON}",
       "hideable_lessons": true,
+      "student_detail_progress_view": true,
+      "curriculum_path": "https://curriculum.code.org/{LOCALE}/csp-20/unit1/{LESSON}",
+      "script_announcements": [
+        {
+          "notice": "",
+          "details": "Are you teaching in a Virtual setting or Socially-Distanced classroom? Check out our forum post for information and resources. ",
+          "link": "https://forum.code.org/t/announcing-modifications-for-virtual-and-socially-distanced-classrooms/33005",
+          "type": "bullhorn",
+          "visibility": "Teacher-only"
+        }
+      ],
+      "curriculum_umbrella": "CSP",
+      "has_lesson_plan": true,
+      "is_stable": true,
       "teacher_resources": [
         [
           "lessonPlans",
@@ -19,16 +29,6 @@
           "standardMappings",
           "https://curriculum.code.org/csp-20/unit1/standards/"
         ]
-      ],
-      "is_stable": true,
-      "script_announcements": [
-        {
-          "notice": "",
-          "details": "Are you teaching in a Virtual setting or Socially-Distanced classroom? Check out our forum post for information and resources. ",
-          "link": "https://forum.code.org/t/announcing-modifications-for-virtual-and-socially-distanced-classrooms/33005",
-          "type": "bullhorn",
-          "visibility": "Teacher-only"
-        }
       ],
       "announcements": [
         {
@@ -46,7 +46,7 @@
           "visibility": "Teacher-only"
         }
       ],
-      "peer_reviews_to_complete": 0
+      "has_verified_resources": true
     },
     "new_name": null,
     "family_name": null,
@@ -293,11 +293,11 @@
     },
     {
       "key": "Lesson 14: Assessment Day",
-      "name": "Lesson 14: Assessment Day",
+      "name": "Assessment Day",
       "absolute_position": 15,
       "lockable": true,
-      "has_lesson_plan": false,
-      "relative_position": 2,
+      "has_lesson_plan": true,
+      "relative_position": 14,
       "properties": {
       },
       "seeding_key": {

--- a/dashboard/config/scripts_json/csp1-2020.script_json
+++ b/dashboard/config/scripts_json/csp1-2020.script_json
@@ -5,21 +5,11 @@
     "hidden": false,
     "login_required": true,
     "properties": {
-      "hideable_lessons": true,
-      "student_detail_progress_view": true,
-      "curriculum_path": "https://curriculum.code.org/{LOCALE}/csp-20/unit1/{LESSON}",
-      "script_announcements": [
-        {
-          "notice": "",
-          "details": "Are you teaching in a Virtual setting or Socially-Distanced classroom? Check out our forum post for information and resources. ",
-          "link": "https://forum.code.org/t/announcing-modifications-for-virtual-and-socially-distanced-classrooms/33005",
-          "type": "bullhorn",
-          "visibility": "Teacher-only"
-        }
-      ],
       "curriculum_umbrella": "CSP",
-      "has_lesson_plan": true,
-      "is_stable": true,
+      "student_detail_progress_view": true,
+      "has_verified_resources": true,
+      "curriculum_path": "https://curriculum.code.org/{LOCALE}/csp-20/unit1/{LESSON}",
+      "hideable_lessons": true,
       "teacher_resources": [
         [
           "lessonPlans",
@@ -29,6 +19,16 @@
           "standardMappings",
           "https://curriculum.code.org/csp-20/unit1/standards/"
         ]
+      ],
+      "is_stable": true,
+      "script_announcements": [
+        {
+          "notice": "",
+          "details": "Are you teaching in a Virtual setting or Socially-Distanced classroom? Check out our forum post for information and resources. ",
+          "link": "https://forum.code.org/t/announcing-modifications-for-virtual-and-socially-distanced-classrooms/33005",
+          "type": "bullhorn",
+          "visibility": "Teacher-only"
+        }
       ],
       "announcements": [
         {
@@ -46,7 +46,7 @@
           "visibility": "Teacher-only"
         }
       ],
-      "has_verified_resources": true
+      "peer_reviews_to_complete": 0
     },
     "new_name": null,
     "family_name": null,

--- a/dashboard/config/scripts_json/csp10-2020.script_json
+++ b/dashboard/config/scripts_json/csp10-2020.script_json
@@ -5,22 +5,12 @@
     "hidden": false,
     "login_required": true,
     "properties": {
-      "hideable_lessons": true,
-      "student_detail_progress_view": true,
-      "curriculum_path": "https://curriculum.code.org/{LOCALE}/csp-20/unit10/{LESSON}",
-      "script_announcements": [
-        {
-          "notice": "",
-          "details": "Are you teaching in a Virtual setting or Socially-Distanced classroom? Check out our forum post for information and resources. ",
-          "link": "https://forum.code.org/t/announcing-modifications-for-virtual-and-socially-distanced-classrooms/33005",
-          "type": "bullhorn",
-          "visibility": "Teacher-only"
-        }
-      ],
       "curriculum_umbrella": "CSP",
-      "has_lesson_plan": true,
-      "is_stable": true,
+      "student_detail_progress_view": true,
+      "has_verified_resources": true,
+      "curriculum_path": "https://curriculum.code.org/{LOCALE}/csp-20/unit10/{LESSON}",
       "project_sharing": true,
+      "hideable_lessons": true,
       "teacher_resources": [
         [
           "lessonPlans",
@@ -30,6 +20,16 @@
           "standardMappings",
           "https://curriculum.code.org/csp-20/unit10/standards/"
         ]
+      ],
+      "is_stable": true,
+      "script_announcements": [
+        {
+          "notice": "",
+          "details": "Are you teaching in a Virtual setting or Socially-Distanced classroom? Check out our forum post for information and resources. ",
+          "link": "https://forum.code.org/t/announcing-modifications-for-virtual-and-socially-distanced-classrooms/33005",
+          "type": "bullhorn",
+          "visibility": "Teacher-only"
+        }
       ],
       "announcements": [
         {
@@ -47,7 +47,7 @@
           "visibility": "Teacher-only"
         }
       ],
-      "has_verified_resources": true
+      "peer_reviews_to_complete": 0
     },
     "new_name": null,
     "family_name": null,

--- a/dashboard/config/scripts_json/csp10-2020.script_json
+++ b/dashboard/config/scripts_json/csp10-2020.script_json
@@ -5,12 +5,22 @@
     "hidden": false,
     "login_required": true,
     "properties": {
-      "curriculum_umbrella": "CSP",
-      "student_detail_progress_view": true,
-      "has_verified_resources": true,
-      "curriculum_path": "https://curriculum.code.org/{LOCALE}/csp-20/unit10/{LESSON}",
-      "project_sharing": true,
       "hideable_lessons": true,
+      "student_detail_progress_view": true,
+      "curriculum_path": "https://curriculum.code.org/{LOCALE}/csp-20/unit10/{LESSON}",
+      "script_announcements": [
+        {
+          "notice": "",
+          "details": "Are you teaching in a Virtual setting or Socially-Distanced classroom? Check out our forum post for information and resources. ",
+          "link": "https://forum.code.org/t/announcing-modifications-for-virtual-and-socially-distanced-classrooms/33005",
+          "type": "bullhorn",
+          "visibility": "Teacher-only"
+        }
+      ],
+      "curriculum_umbrella": "CSP",
+      "has_lesson_plan": true,
+      "is_stable": true,
+      "project_sharing": true,
       "teacher_resources": [
         [
           "lessonPlans",
@@ -20,16 +30,6 @@
           "standardMappings",
           "https://curriculum.code.org/csp-20/unit10/standards/"
         ]
-      ],
-      "is_stable": true,
-      "script_announcements": [
-        {
-          "notice": "",
-          "details": "Are you teaching in a Virtual setting or Socially-Distanced classroom? Check out our forum post for information and resources. ",
-          "link": "https://forum.code.org/t/announcing-modifications-for-virtual-and-socially-distanced-classrooms/33005",
-          "type": "bullhorn",
-          "visibility": "Teacher-only"
-        }
       ],
       "announcements": [
         {
@@ -47,7 +47,7 @@
           "visibility": "Teacher-only"
         }
       ],
-      "peer_reviews_to_complete": 0
+      "has_verified_resources": true
     },
     "new_name": null,
     "family_name": null,
@@ -267,11 +267,11 @@
     },
     {
       "key": "Lesson 14: Unit Assessment Day",
-      "name": "Lesson 14: Unit Assessment Day",
+      "name": "Unit Assessment Day",
       "absolute_position": 14,
       "lockable": true,
-      "has_lesson_plan": false,
-      "relative_position": 1,
+      "has_lesson_plan": true,
+      "relative_position": 14,
       "properties": {
       },
       "seeding_key": {

--- a/dashboard/config/scripts_json/csp2-2020.script_json
+++ b/dashboard/config/scripts_json/csp2-2020.script_json
@@ -5,12 +5,22 @@
     "hidden": false,
     "login_required": true,
     "properties": {
-      "curriculum_umbrella": "CSP",
-      "student_detail_progress_view": true,
-      "has_verified_resources": true,
-      "curriculum_path": "https://curriculum.code.org/{LOCALE}/csp-20/unit2/{LESSON}",
-      "project_sharing": true,
       "hideable_lessons": true,
+      "student_detail_progress_view": true,
+      "curriculum_path": "https://curriculum.code.org/{LOCALE}/csp-20/unit2/{LESSON}",
+      "script_announcements": [
+        {
+          "notice": "",
+          "details": "Are you teaching in a Virtual setting or Socially-Distanced classroom? Check out our forum post for information and resources. ",
+          "link": "https://forum.code.org/t/announcing-modifications-for-virtual-and-socially-distanced-classrooms/33005",
+          "type": "bullhorn",
+          "visibility": "Teacher-only"
+        }
+      ],
+      "curriculum_umbrella": "CSP",
+      "has_lesson_plan": true,
+      "is_stable": true,
+      "project_sharing": true,
       "teacher_resources": [
         [
           "lessonPlans",
@@ -20,16 +30,6 @@
           "standardMappings",
           "https://curriculum.code.org/csp-20/unit2/standards/"
         ]
-      ],
-      "is_stable": true,
-      "script_announcements": [
-        {
-          "notice": "",
-          "details": "Are you teaching in a Virtual setting or Socially-Distanced classroom? Check out our forum post for information and resources. ",
-          "link": "https://forum.code.org/t/announcing-modifications-for-virtual-and-socially-distanced-classrooms/33005",
-          "type": "bullhorn",
-          "visibility": "Teacher-only"
-        }
       ],
       "announcements": [
         {
@@ -47,7 +47,7 @@
           "visibility": "Teacher-only"
         }
       ],
-      "peer_reviews_to_complete": 0
+      "has_verified_resources": true
     },
     "new_name": null,
     "family_name": null,
@@ -192,11 +192,11 @@
     },
     {
       "key": "Lesson 9: Assessment Day",
-      "name": "Lesson 9: Assessment Day",
+      "name": "Assessment Day",
       "absolute_position": 9,
       "lockable": true,
-      "has_lesson_plan": false,
-      "relative_position": 1,
+      "has_lesson_plan": true,
+      "relative_position": 9,
       "properties": {
       },
       "seeding_key": {

--- a/dashboard/config/scripts_json/csp2-2020.script_json
+++ b/dashboard/config/scripts_json/csp2-2020.script_json
@@ -5,22 +5,12 @@
     "hidden": false,
     "login_required": true,
     "properties": {
-      "hideable_lessons": true,
-      "student_detail_progress_view": true,
-      "curriculum_path": "https://curriculum.code.org/{LOCALE}/csp-20/unit2/{LESSON}",
-      "script_announcements": [
-        {
-          "notice": "",
-          "details": "Are you teaching in a Virtual setting or Socially-Distanced classroom? Check out our forum post for information and resources. ",
-          "link": "https://forum.code.org/t/announcing-modifications-for-virtual-and-socially-distanced-classrooms/33005",
-          "type": "bullhorn",
-          "visibility": "Teacher-only"
-        }
-      ],
       "curriculum_umbrella": "CSP",
-      "has_lesson_plan": true,
-      "is_stable": true,
+      "student_detail_progress_view": true,
+      "has_verified_resources": true,
+      "curriculum_path": "https://curriculum.code.org/{LOCALE}/csp-20/unit2/{LESSON}",
       "project_sharing": true,
+      "hideable_lessons": true,
       "teacher_resources": [
         [
           "lessonPlans",
@@ -30,6 +20,16 @@
           "standardMappings",
           "https://curriculum.code.org/csp-20/unit2/standards/"
         ]
+      ],
+      "is_stable": true,
+      "script_announcements": [
+        {
+          "notice": "",
+          "details": "Are you teaching in a Virtual setting or Socially-Distanced classroom? Check out our forum post for information and resources. ",
+          "link": "https://forum.code.org/t/announcing-modifications-for-virtual-and-socially-distanced-classrooms/33005",
+          "type": "bullhorn",
+          "visibility": "Teacher-only"
+        }
       ],
       "announcements": [
         {
@@ -47,7 +47,7 @@
           "visibility": "Teacher-only"
         }
       ],
-      "has_verified_resources": true
+      "peer_reviews_to_complete": 0
     },
     "new_name": null,
     "family_name": null,

--- a/dashboard/config/scripts_json/csp3-2020.script_json
+++ b/dashboard/config/scripts_json/csp3-2020.script_json
@@ -5,23 +5,9 @@
     "hidden": false,
     "login_required": true,
     "properties": {
-      "curriculum_umbrella": "CSP",
-      "student_detail_progress_view": true,
-      "has_verified_resources": true,
-      "curriculum_path": "https://curriculum.code.org/{LOCALE}/csp-20/unit3/{LESSON}",
-      "project_sharing": true,
       "hideable_lessons": true,
-      "teacher_resources": [
-        [
-          "lessonPlans",
-          "https://curriculum.code.org/csp-20/unit3/"
-        ],
-        [
-          "standardMappings",
-          "https://curriculum.code.org/csp-20/unit3/standards/"
-        ]
-      ],
-      "is_stable": true,
+      "student_detail_progress_view": true,
+      "curriculum_path": "https://curriculum.code.org/{LOCALE}/csp-20/unit3/{LESSON}",
       "script_announcements": [
         {
           "notice": "",
@@ -31,12 +17,26 @@
           "visibility": "Teacher-only"
         },
         {
-          "notice": "Looking for the Lesson Activities?",
-          "details": "Teachers, some lessons in this unit contain activities that are not located on Code Studio. Make sure to read the Lesson Plans and check out the unit slides. ",
-          "link": "https://curriculum.code.org/csp-20/unit3/",
+          "notice": "Student",
+          "details": "Student",
+          "link": "",
           "type": "information",
-          "visibility": "Teacher-only"
+          "visibility": "Student-only"
         }
+      ],
+      "curriculum_umbrella": "CSP",
+      "has_lesson_plan": true,
+      "is_stable": true,
+      "project_sharing": true,
+      "teacher_resources": [
+        [
+          "lessonPlans",
+          "https://curriculum.code.org/csp-20/unit3/"
+        ],
+        [
+          "standardMappings",
+          "https://curriculum.code.org/csp-20/unit3/standards/"
+        ]
       ],
       "announcements": [
         {
@@ -61,7 +61,7 @@
           "visibility": "Teacher-only"
         }
       ],
-      "peer_reviews_to_complete": 0
+      "has_verified_resources": true
     },
     "new_name": null,
     "family_name": null,
@@ -236,11 +236,11 @@
     },
     {
       "key": "Lesson 11: Assessment Day",
-      "name": "Lesson 11: Assessment Day",
+      "name": "Assessment Day",
       "absolute_position": 11,
       "lockable": true,
-      "has_lesson_plan": false,
-      "relative_position": 1,
+      "has_lesson_plan": true,
+      "relative_position": 11,
       "properties": {
       },
       "seeding_key": {

--- a/dashboard/config/scripts_json/csp3-2020.script_json
+++ b/dashboard/config/scripts_json/csp3-2020.script_json
@@ -5,29 +5,12 @@
     "hidden": false,
     "login_required": true,
     "properties": {
-      "hideable_lessons": true,
-      "student_detail_progress_view": true,
-      "curriculum_path": "https://curriculum.code.org/{LOCALE}/csp-20/unit3/{LESSON}",
-      "script_announcements": [
-        {
-          "notice": "",
-          "details": "Are you teaching in a Virtual setting or Socially-Distanced classroom? Check out our forum post for information and resources. ",
-          "link": "https://forum.code.org/t/announcing-modifications-for-virtual-and-socially-distanced-classrooms/33005",
-          "type": "bullhorn",
-          "visibility": "Teacher-only"
-        },
-        {
-          "notice": "Student",
-          "details": "Student",
-          "link": "",
-          "type": "information",
-          "visibility": "Student-only"
-        }
-      ],
       "curriculum_umbrella": "CSP",
-      "has_lesson_plan": true,
-      "is_stable": true,
+      "student_detail_progress_view": true,
+      "has_verified_resources": true,
+      "curriculum_path": "https://curriculum.code.org/{LOCALE}/csp-20/unit3/{LESSON}",
       "project_sharing": true,
+      "hideable_lessons": true,
       "teacher_resources": [
         [
           "lessonPlans",
@@ -37,6 +20,23 @@
           "standardMappings",
           "https://curriculum.code.org/csp-20/unit3/standards/"
         ]
+      ],
+      "is_stable": true,
+      "script_announcements": [
+        {
+          "notice": "",
+          "details": "Are you teaching in a Virtual setting or Socially-Distanced classroom? Check out our forum post for information and resources. ",
+          "link": "https://forum.code.org/t/announcing-modifications-for-virtual-and-socially-distanced-classrooms/33005",
+          "type": "bullhorn",
+          "visibility": "Teacher-only"
+        },
+        {
+          "notice": "Looking for the Lesson Activities?",
+          "details": "Teachers, some lessons in this unit contain activities that are not located on Code Studio. Make sure to read the Lesson Plans and check out the unit slides. ",
+          "link": "https://curriculum.code.org/csp-20/unit3/",
+          "type": "information",
+          "visibility": "Teacher-only"
+        }
       ],
       "announcements": [
         {
@@ -61,7 +61,7 @@
           "visibility": "Teacher-only"
         }
       ],
-      "has_verified_resources": true
+      "peer_reviews_to_complete": 0
     },
     "new_name": null,
     "family_name": null,

--- a/dashboard/config/scripts_json/csp4-2020.script_json
+++ b/dashboard/config/scripts_json/csp4-2020.script_json
@@ -5,12 +5,22 @@
     "hidden": false,
     "login_required": true,
     "properties": {
-      "student_detail_progress_view": true,
-      "has_verified_resources": true,
-      "curriculum_path": "https://curriculum.code.org/{LOCALE}/csp-20/unit4/{LESSON}",
-      "curriculum_umbrella": "CSP",
-      "project_sharing": true,
       "hideable_lessons": true,
+      "student_detail_progress_view": true,
+      "curriculum_path": "https://curriculum.code.org/{LOCALE}/csp-20/unit4/{LESSON}",
+      "script_announcements": [
+        {
+          "notice": "",
+          "details": "Are you teaching in a Virtual setting or Socially-Distanced classroom? Check out our forum post for information and resources. ",
+          "link": "https://forum.code.org/t/announcing-modifications-for-virtual-and-socially-distanced-classrooms/33005",
+          "type": "bullhorn",
+          "visibility": "Teacher-only"
+        }
+      ],
+      "curriculum_umbrella": "CSP",
+      "has_lesson_plan": true,
+      "is_stable": true,
+      "project_sharing": true,
       "teacher_resources": [
         [
           "lessonPlans",
@@ -20,23 +30,6 @@
           "standardMappings",
           "https://curriculum.code.org/csp-20/unit4/standards/"
         ]
-      ],
-      "is_stable": true,
-      "script_announcements": [
-        {
-          "notice": "",
-          "details": "Are you teaching in a Virtual setting or Socially-Distanced classroom? Check out our forum post for information and resources. ",
-          "link": "https://forum.code.org/t/announcing-modifications-for-virtual-and-socially-distanced-classrooms/33005",
-          "type": "bullhorn",
-          "visibility": "Teacher-only"
-        },
-        {
-          "notice": "EIPM Lessons",
-          "details": "In this unit, we beginning following our new programming model called EIPM. Check out this helpful video series to learn all about it! ",
-          "link": "https://www.youtube.com/playlist?list=PLzdnOPI1iJNeqEl6MN7c2KyM3gdBSo8t3",
-          "type": "information",
-          "visibility": "Teacher-only"
-        }
       ],
       "announcements": [
         {
@@ -61,7 +54,7 @@
           "visibility": "Teacher-only"
         }
       ],
-      "peer_reviews_to_complete": 0
+      "has_verified_resources": true
     },
     "new_name": null,
     "family_name": null,
@@ -332,11 +325,11 @@
     },
     {
       "key": "Lesson 15: Assessment Day",
-      "name": "Lesson 15: Assessment Day",
+      "name": "Assessment Day",
       "absolute_position": 15,
       "lockable": true,
-      "has_lesson_plan": false,
-      "relative_position": 1,
+      "has_lesson_plan": true,
+      "relative_position": 15,
       "properties": {
       },
       "seeding_key": {

--- a/dashboard/config/scripts_json/csp4-2020.script_json
+++ b/dashboard/config/scripts_json/csp4-2020.script_json
@@ -5,22 +5,12 @@
     "hidden": false,
     "login_required": true,
     "properties": {
-      "hideable_lessons": true,
       "student_detail_progress_view": true,
+      "has_verified_resources": true,
       "curriculum_path": "https://curriculum.code.org/{LOCALE}/csp-20/unit4/{LESSON}",
-      "script_announcements": [
-        {
-          "notice": "",
-          "details": "Are you teaching in a Virtual setting or Socially-Distanced classroom? Check out our forum post for information and resources. ",
-          "link": "https://forum.code.org/t/announcing-modifications-for-virtual-and-socially-distanced-classrooms/33005",
-          "type": "bullhorn",
-          "visibility": "Teacher-only"
-        }
-      ],
       "curriculum_umbrella": "CSP",
-      "has_lesson_plan": true,
-      "is_stable": true,
       "project_sharing": true,
+      "hideable_lessons": true,
       "teacher_resources": [
         [
           "lessonPlans",
@@ -30,6 +20,23 @@
           "standardMappings",
           "https://curriculum.code.org/csp-20/unit4/standards/"
         ]
+      ],
+      "is_stable": true,
+      "script_announcements": [
+        {
+          "notice": "",
+          "details": "Are you teaching in a Virtual setting or Socially-Distanced classroom? Check out our forum post for information and resources. ",
+          "link": "https://forum.code.org/t/announcing-modifications-for-virtual-and-socially-distanced-classrooms/33005",
+          "type": "bullhorn",
+          "visibility": "Teacher-only"
+        },
+        {
+          "notice": "EIPM Lessons",
+          "details": "In this unit, we beginning following our new programming model called EIPM. Check out this helpful video series to learn all about it! ",
+          "link": "https://www.youtube.com/playlist?list=PLzdnOPI1iJNeqEl6MN7c2KyM3gdBSo8t3",
+          "type": "information",
+          "visibility": "Teacher-only"
+        }
       ],
       "announcements": [
         {
@@ -54,7 +61,7 @@
           "visibility": "Teacher-only"
         }
       ],
-      "has_verified_resources": true
+      "peer_reviews_to_complete": 0
     },
     "new_name": null,
     "family_name": null,

--- a/dashboard/config/scripts_json/csp5-2020.script_json
+++ b/dashboard/config/scripts_json/csp5-2020.script_json
@@ -5,12 +5,22 @@
     "hidden": false,
     "login_required": true,
     "properties": {
-      "student_detail_progress_view": true,
-      "has_verified_resources": true,
-      "curriculum_path": "https://curriculum.code.org/{LOCALE}/csp-20/unit5/{LESSON}",
-      "curriculum_umbrella": "CSP",
-      "project_sharing": true,
       "hideable_lessons": true,
+      "student_detail_progress_view": true,
+      "curriculum_path": "https://curriculum.code.org/{LOCALE}/csp-20/unit5/{LESSON}",
+      "script_announcements": [
+        {
+          "notice": "",
+          "details": "Are you teaching in a Virtual setting or Socially-Distanced classroom? Check out our forum post for information and resources. ",
+          "link": "https://forum.code.org/t/announcing-modifications-for-virtual-and-socially-distanced-classrooms/33005",
+          "type": "bullhorn",
+          "visibility": "Teacher-only"
+        }
+      ],
+      "curriculum_umbrella": "CSP",
+      "has_lesson_plan": true,
+      "is_stable": true,
+      "project_sharing": true,
       "teacher_resources": [
         [
           "lessonPlans",
@@ -20,16 +30,6 @@
           "standardMappings",
           "https://curriculum.code.org/csp-20/unit5/standards/"
         ]
-      ],
-      "is_stable": true,
-      "script_announcements": [
-        {
-          "notice": "",
-          "details": "Are you teaching in a Virtual setting or Socially-Distanced classroom? Check out our forum post for information and resources. ",
-          "link": "https://forum.code.org/t/announcing-modifications-for-virtual-and-socially-distanced-classrooms/33005",
-          "type": "bullhorn",
-          "visibility": "Teacher-only"
-        }
       ],
       "announcements": [
         {
@@ -47,7 +47,7 @@
           "visibility": "Teacher-only"
         }
       ],
-      "peer_reviews_to_complete": 0
+      "has_verified_resources": true
     },
     "new_name": null,
     "family_name": null,
@@ -363,11 +363,11 @@
     },
     {
       "key": "Lesson 18: Assessment Day",
-      "name": "Lesson 18: Assessment Day",
+      "name": "Assessment Day",
       "absolute_position": 18,
       "lockable": true,
-      "has_lesson_plan": false,
-      "relative_position": 1,
+      "has_lesson_plan": true,
+      "relative_position": 18,
       "properties": {
       },
       "seeding_key": {

--- a/dashboard/config/scripts_json/csp5-2020.script_json
+++ b/dashboard/config/scripts_json/csp5-2020.script_json
@@ -5,22 +5,12 @@
     "hidden": false,
     "login_required": true,
     "properties": {
-      "hideable_lessons": true,
       "student_detail_progress_view": true,
+      "has_verified_resources": true,
       "curriculum_path": "https://curriculum.code.org/{LOCALE}/csp-20/unit5/{LESSON}",
-      "script_announcements": [
-        {
-          "notice": "",
-          "details": "Are you teaching in a Virtual setting or Socially-Distanced classroom? Check out our forum post for information and resources. ",
-          "link": "https://forum.code.org/t/announcing-modifications-for-virtual-and-socially-distanced-classrooms/33005",
-          "type": "bullhorn",
-          "visibility": "Teacher-only"
-        }
-      ],
       "curriculum_umbrella": "CSP",
-      "has_lesson_plan": true,
-      "is_stable": true,
       "project_sharing": true,
+      "hideable_lessons": true,
       "teacher_resources": [
         [
           "lessonPlans",
@@ -30,6 +20,16 @@
           "standardMappings",
           "https://curriculum.code.org/csp-20/unit5/standards/"
         ]
+      ],
+      "is_stable": true,
+      "script_announcements": [
+        {
+          "notice": "",
+          "details": "Are you teaching in a Virtual setting or Socially-Distanced classroom? Check out our forum post for information and resources. ",
+          "link": "https://forum.code.org/t/announcing-modifications-for-virtual-and-socially-distanced-classrooms/33005",
+          "type": "bullhorn",
+          "visibility": "Teacher-only"
+        }
       ],
       "announcements": [
         {
@@ -47,7 +47,7 @@
           "visibility": "Teacher-only"
         }
       ],
-      "has_verified_resources": true
+      "peer_reviews_to_complete": 0
     },
     "new_name": null,
     "family_name": null,

--- a/dashboard/config/scripts_json/csp6-2020.script_json
+++ b/dashboard/config/scripts_json/csp6-2020.script_json
@@ -5,12 +5,22 @@
     "hidden": false,
     "login_required": true,
     "properties": {
-      "curriculum_umbrella": "CSP",
-      "student_detail_progress_view": true,
-      "has_verified_resources": true,
-      "curriculum_path": "https://curriculum.code.org/{LOCALE}/csp-20/unit6/{LESSON}",
-      "project_sharing": true,
       "hideable_lessons": true,
+      "student_detail_progress_view": true,
+      "curriculum_path": "https://curriculum.code.org/{LOCALE}/csp-20/unit6/{LESSON}",
+      "script_announcements": [
+        {
+          "notice": "",
+          "details": "Are you teaching in a Virtual setting or Socially-Distanced classroom? Check out our forum post for information and resources. ",
+          "link": "https://forum.code.org/t/announcing-modifications-for-virtual-and-socially-distanced-classrooms/33005",
+          "type": "bullhorn",
+          "visibility": "Teacher-only"
+        }
+      ],
+      "curriculum_umbrella": "CSP",
+      "has_lesson_plan": true,
+      "is_stable": true,
+      "project_sharing": true,
       "teacher_resources": [
         [
           "lessonPlans",
@@ -20,16 +30,6 @@
           "standardMappings",
           "https://curriculum.code.org/csp-20/unit6/standards/"
         ]
-      ],
-      "is_stable": true,
-      "script_announcements": [
-        {
-          "notice": "",
-          "details": "Are you teaching in a Virtual setting or Socially-Distanced classroom? Check out our forum post for information and resources. ",
-          "link": "https://forum.code.org/t/announcing-modifications-for-virtual-and-socially-distanced-classrooms/33005",
-          "type": "bullhorn",
-          "visibility": "Teacher-only"
-        }
       ],
       "announcements": [
         {
@@ -47,7 +47,7 @@
           "visibility": "Teacher-only"
         }
       ],
-      "peer_reviews_to_complete": 0
+      "has_verified_resources": true
     },
     "new_name": null,
     "family_name": null,
@@ -147,11 +147,11 @@
     },
     {
       "key": "Lesson 6: Assessment Day",
-      "name": "Lesson 6: Assessment Day",
+      "name": "Assessment Day",
       "absolute_position": 6,
       "lockable": true,
-      "has_lesson_plan": false,
-      "relative_position": 1,
+      "has_lesson_plan": true,
+      "relative_position": 6,
       "properties": {
       },
       "seeding_key": {

--- a/dashboard/config/scripts_json/csp6-2020.script_json
+++ b/dashboard/config/scripts_json/csp6-2020.script_json
@@ -5,22 +5,12 @@
     "hidden": false,
     "login_required": true,
     "properties": {
-      "hideable_lessons": true,
-      "student_detail_progress_view": true,
-      "curriculum_path": "https://curriculum.code.org/{LOCALE}/csp-20/unit6/{LESSON}",
-      "script_announcements": [
-        {
-          "notice": "",
-          "details": "Are you teaching in a Virtual setting or Socially-Distanced classroom? Check out our forum post for information and resources. ",
-          "link": "https://forum.code.org/t/announcing-modifications-for-virtual-and-socially-distanced-classrooms/33005",
-          "type": "bullhorn",
-          "visibility": "Teacher-only"
-        }
-      ],
       "curriculum_umbrella": "CSP",
-      "has_lesson_plan": true,
-      "is_stable": true,
+      "student_detail_progress_view": true,
+      "has_verified_resources": true,
+      "curriculum_path": "https://curriculum.code.org/{LOCALE}/csp-20/unit6/{LESSON}",
       "project_sharing": true,
+      "hideable_lessons": true,
       "teacher_resources": [
         [
           "lessonPlans",
@@ -30,6 +20,16 @@
           "standardMappings",
           "https://curriculum.code.org/csp-20/unit6/standards/"
         ]
+      ],
+      "is_stable": true,
+      "script_announcements": [
+        {
+          "notice": "",
+          "details": "Are you teaching in a Virtual setting or Socially-Distanced classroom? Check out our forum post for information and resources. ",
+          "link": "https://forum.code.org/t/announcing-modifications-for-virtual-and-socially-distanced-classrooms/33005",
+          "type": "bullhorn",
+          "visibility": "Teacher-only"
+        }
       ],
       "announcements": [
         {
@@ -47,7 +47,7 @@
           "visibility": "Teacher-only"
         }
       ],
-      "has_verified_resources": true
+      "peer_reviews_to_complete": 0
     },
     "new_name": null,
     "family_name": null,

--- a/dashboard/config/scripts_json/csp7-2020.script_json
+++ b/dashboard/config/scripts_json/csp7-2020.script_json
@@ -5,12 +5,22 @@
     "hidden": false,
     "login_required": true,
     "properties": {
-      "curriculum_umbrella": "CSP",
-      "student_detail_progress_view": true,
-      "has_verified_resources": true,
-      "curriculum_path": "https://curriculum.code.org/{LOCALE}/csp-20/unit7/{LESSON}",
-      "project_sharing": true,
       "hideable_lessons": true,
+      "student_detail_progress_view": true,
+      "curriculum_path": "https://curriculum.code.org/{LOCALE}/csp-20/unit7/{LESSON}",
+      "script_announcements": [
+        {
+          "notice": "",
+          "details": "Are you teaching in a Virtual setting or Socially-Distanced classroom? Check out our forum post for information and resources. ",
+          "link": "https://forum.code.org/t/announcing-modifications-for-virtual-and-socially-distanced-classrooms/33005",
+          "type": "bullhorn",
+          "visibility": "Teacher-only"
+        }
+      ],
+      "curriculum_umbrella": "CSP",
+      "has_lesson_plan": true,
+      "is_stable": true,
+      "project_sharing": true,
       "teacher_resources": [
         [
           "lessonPlans",
@@ -20,16 +30,6 @@
           "standardMappings",
           "https://curriculum.code.org/csp-20/unit7/standards/"
         ]
-      ],
-      "is_stable": true,
-      "script_announcements": [
-        {
-          "notice": "",
-          "details": "Are you teaching in a Virtual setting or Socially-Distanced classroom? Check out our forum post for information and resources. ",
-          "link": "https://forum.code.org/t/announcing-modifications-for-virtual-and-socially-distanced-classrooms/33005",
-          "type": "bullhorn",
-          "visibility": "Teacher-only"
-        }
       ],
       "announcements": [
         {
@@ -47,7 +47,7 @@
           "visibility": "Teacher-only"
         }
       ],
-      "peer_reviews_to_complete": 0
+      "has_verified_resources": true
     },
     "new_name": null,
     "family_name": null,
@@ -234,11 +234,11 @@
     },
     {
       "key": "Lesson 11: Assessment Day",
-      "name": "Lesson 11: Assessment Day",
+      "name": "Assessment Day",
       "absolute_position": 11,
       "lockable": true,
-      "has_lesson_plan": false,
-      "relative_position": 1,
+      "has_lesson_plan": true,
+      "relative_position": 11,
       "properties": {
       },
       "seeding_key": {

--- a/dashboard/config/scripts_json/csp7-2020.script_json
+++ b/dashboard/config/scripts_json/csp7-2020.script_json
@@ -5,22 +5,12 @@
     "hidden": false,
     "login_required": true,
     "properties": {
-      "hideable_lessons": true,
-      "student_detail_progress_view": true,
-      "curriculum_path": "https://curriculum.code.org/{LOCALE}/csp-20/unit7/{LESSON}",
-      "script_announcements": [
-        {
-          "notice": "",
-          "details": "Are you teaching in a Virtual setting or Socially-Distanced classroom? Check out our forum post for information and resources. ",
-          "link": "https://forum.code.org/t/announcing-modifications-for-virtual-and-socially-distanced-classrooms/33005",
-          "type": "bullhorn",
-          "visibility": "Teacher-only"
-        }
-      ],
       "curriculum_umbrella": "CSP",
-      "has_lesson_plan": true,
-      "is_stable": true,
+      "student_detail_progress_view": true,
+      "has_verified_resources": true,
+      "curriculum_path": "https://curriculum.code.org/{LOCALE}/csp-20/unit7/{LESSON}",
       "project_sharing": true,
+      "hideable_lessons": true,
       "teacher_resources": [
         [
           "lessonPlans",
@@ -30,6 +20,16 @@
           "standardMappings",
           "https://curriculum.code.org/csp-20/unit7/standards/"
         ]
+      ],
+      "is_stable": true,
+      "script_announcements": [
+        {
+          "notice": "",
+          "details": "Are you teaching in a Virtual setting or Socially-Distanced classroom? Check out our forum post for information and resources. ",
+          "link": "https://forum.code.org/t/announcing-modifications-for-virtual-and-socially-distanced-classrooms/33005",
+          "type": "bullhorn",
+          "visibility": "Teacher-only"
+        }
       ],
       "announcements": [
         {
@@ -47,7 +47,7 @@
           "visibility": "Teacher-only"
         }
       ],
-      "has_verified_resources": true
+      "peer_reviews_to_complete": 0
     },
     "new_name": null,
     "family_name": null,

--- a/dashboard/config/scripts_json/csp9-2020.script_json
+++ b/dashboard/config/scripts_json/csp9-2020.script_json
@@ -5,12 +5,22 @@
     "hidden": false,
     "login_required": true,
     "properties": {
-      "curriculum_umbrella": "CSP",
-      "student_detail_progress_view": true,
-      "has_verified_resources": true,
-      "curriculum_path": "https://curriculum.code.org/{LOCALE}/csp-20/unit9/{LESSON}",
-      "project_sharing": true,
       "hideable_lessons": true,
+      "student_detail_progress_view": true,
+      "curriculum_path": "https://curriculum.code.org/{LOCALE}/csp-20/unit9/{LESSON}",
+      "script_announcements": [
+        {
+          "notice": "",
+          "details": "Are you teaching in a Virtual setting or Socially-Distanced classroom? Check out our forum post for information and resources. ",
+          "link": "https://forum.code.org/t/announcing-modifications-for-virtual-and-socially-distanced-classrooms/33005",
+          "type": "bullhorn",
+          "visibility": "Teacher-only"
+        }
+      ],
+      "curriculum_umbrella": "CSP",
+      "has_lesson_plan": true,
+      "is_stable": true,
+      "project_sharing": true,
       "teacher_resources": [
         [
           "lessonPlans",
@@ -20,16 +30,6 @@
           "standardMappings",
           "https://curriculum.code.org/csp-20/unit9/standards/"
         ]
-      ],
-      "is_stable": true,
-      "script_announcements": [
-        {
-          "notice": "",
-          "details": "Are you teaching in a Virtual setting or Socially-Distanced classroom? Check out our forum post for information and resources. ",
-          "link": "https://forum.code.org/t/announcing-modifications-for-virtual-and-socially-distanced-classrooms/33005",
-          "type": "bullhorn",
-          "visibility": "Teacher-only"
-        }
       ],
       "announcements": [
         {
@@ -47,7 +47,7 @@
           "visibility": "Teacher-only"
         }
       ],
-      "peer_reviews_to_complete": 0
+      "has_verified_resources": true
     },
     "new_name": null,
     "family_name": null,
@@ -192,11 +192,11 @@
     },
     {
       "key": "Lesson 9: Assessment Day",
-      "name": "Lesson 9: Assessment Day",
+      "name": "Assessment Day",
       "absolute_position": 9,
       "lockable": true,
-      "has_lesson_plan": false,
-      "relative_position": 1,
+      "has_lesson_plan": true,
+      "relative_position": 9,
       "properties": {
       },
       "seeding_key": {

--- a/dashboard/config/scripts_json/csp9-2020.script_json
+++ b/dashboard/config/scripts_json/csp9-2020.script_json
@@ -5,22 +5,12 @@
     "hidden": false,
     "login_required": true,
     "properties": {
-      "hideable_lessons": true,
-      "student_detail_progress_view": true,
-      "curriculum_path": "https://curriculum.code.org/{LOCALE}/csp-20/unit9/{LESSON}",
-      "script_announcements": [
-        {
-          "notice": "",
-          "details": "Are you teaching in a Virtual setting or Socially-Distanced classroom? Check out our forum post for information and resources. ",
-          "link": "https://forum.code.org/t/announcing-modifications-for-virtual-and-socially-distanced-classrooms/33005",
-          "type": "bullhorn",
-          "visibility": "Teacher-only"
-        }
-      ],
       "curriculum_umbrella": "CSP",
-      "has_lesson_plan": true,
-      "is_stable": true,
+      "student_detail_progress_view": true,
+      "has_verified_resources": true,
+      "curriculum_path": "https://curriculum.code.org/{LOCALE}/csp-20/unit9/{LESSON}",
       "project_sharing": true,
+      "hideable_lessons": true,
       "teacher_resources": [
         [
           "lessonPlans",
@@ -30,6 +20,16 @@
           "standardMappings",
           "https://curriculum.code.org/csp-20/unit9/standards/"
         ]
+      ],
+      "is_stable": true,
+      "script_announcements": [
+        {
+          "notice": "",
+          "details": "Are you teaching in a Virtual setting or Socially-Distanced classroom? Check out our forum post for information and resources. ",
+          "link": "https://forum.code.org/t/announcing-modifications-for-virtual-and-socially-distanced-classrooms/33005",
+          "type": "bullhorn",
+          "visibility": "Teacher-only"
+        }
       ],
       "announcements": [
         {
@@ -47,7 +47,7 @@
           "visibility": "Teacher-only"
         }
       ],
-      "has_verified_resources": true
+      "peer_reviews_to_complete": 0
     },
     "new_name": null,
     "family_name": null,


### PR DESCRIPTION
The final step in the lockable journey!

After all the hard work to separate has_lesson_plan and lockable this is where we finally get to see it pay off in a current course!

This PR updates the 9 lessons in CSP 20-21 which are lockable and have lesson plans to set has_lesson_plan to true. Previously these lessons did not show the View Lesson Plan button on the script overview page but now they will!

<img width="918" alt="Screen Shot 2021-02-02 at 9 23 13 PM" src="https://user-images.githubusercontent.com/208083/106688820-dd7a1080-659c-11eb-870e-0f84baee4318.png">

Also because of the past updates with the update of has_lesson_plan to true for these lesson the URL will update to `/stage/...` instead of `/lockable/...`.  This PR creates redirects for the old URLs in case teachers had them saved somewhere they will get sent to the right place.  I checked all these routes in my local environment.

## Links

<!--
  Any relevant links to external resources; ie, specification documents, jira
  items, related PRs, honeybadger errors, etc
-->

- [spec](https://docs.google.com/document/d/1sAAVnwv3rXQEK-qa8JnkNXFfZ0vjWQyzJ9Yx_pG4bdg/edit#heading=h.my8ycsh5b29w)
- [jira](https://codedotorg.atlassian.net/browse/PLAT-735)

## Testing story

- Checked each re-direct by hand locally
- Manually spot checked the script overview page for each updated script
- Checked that the numbers updated correctly for each script in the progress view of teacher dashboard
- Manually checked that locking and unlocking for a student still worked with the URL redirects

