### PR TITLE
Set view lesson plan button to link to the lesson plans on code studio for migrated scripts

### DIFF
--- a/dashboard/app/models/lesson.rb
+++ b/dashboard/app/models/lesson.rb
@@ -207,6 +207,8 @@ class Lesson < ApplicationRecord
   end
 
   def localized_lesson_plan
+    return lesson_path(id: id) if script.is_migrated
+
     if script.curriculum_path?
       path = script.curriculum_path.gsub('{LESSON}', relative_position.to_s)
 

--- a/dashboard/app/models/lesson.rb
+++ b/dashboard/app/models/lesson.rb
@@ -274,7 +274,6 @@ class Lesson < ApplicationRecord
         last_level_summary[:page_number] = 1
       end
 
-      # Don't want lesson plans for lockable levels
       if has_lesson_plan
         lesson_data[:lesson_plan_html_url] = lesson_plan_html_url
         lesson_data[:lesson_plan_pdf_url] = lesson_plan_pdf_url

--- a/dashboard/test/models/lesson_test.rb
+++ b/dashboard/test/models/lesson_test.rb
@@ -171,6 +171,24 @@ class LessonTest < ActiveSupport::TestCase
     assert_equal nil, lesson2_summary[:lesson_plan_html_url]
   end
 
+  test 'can summarize lesson with new lesson plan link in migrated script' do
+    script = create :script, name: 'test-script', is_migrated: true, hidden: true
+    lesson_group = create :lesson_group, script: script
+    lesson1 = create :lesson, lesson_group: lesson_group, script: script, has_lesson_plan: true, lockable: true
+    lesson2 = create :lesson, lesson_group: lesson_group, script: script, has_lesson_plan: false, lockable: true
+    lesson3 = create :lesson, lesson_group: lesson_group, script: script, has_lesson_plan: true, lockable: false
+    lesson4 = create :lesson, lesson_group: lesson_group, script: script, has_lesson_plan: false, lockable: false
+
+    lesson1_summary = lesson1.summarize
+    lesson2_summary = lesson2.summarize
+    lesson3_summary = lesson3.summarize
+    lesson4_summary = lesson4.summarize
+    assert_equal "/lessons/#{lesson1.id}", lesson1_summary[:lesson_plan_html_url]
+    assert_equal nil, lesson2_summary[:lesson_plan_html_url]
+    assert_equal "/lessons/#{lesson3.id}", lesson3_summary[:lesson_plan_html_url]
+    assert_equal nil, lesson4_summary[:lesson_plan_html_url]
+  end
+
   test 'can summarize lesson for lesson plan' do
     script = create :script
     lesson_group = create :lesson_group, script: script


### PR DESCRIPTION
We have moved over lesson plan content for 21-22 into scripts marked as is_migrated. We want to start showing these lesson plans when someone clicks the View Lesson Plan on the Script Overview page for migrated courses. This makes that happen!

![lesson-plan-link](https://user-images.githubusercontent.com/208083/106837544-b0932f80-6668-11eb-9575-a92db210fd73.gif)

## Links

<!--
  Any relevant links to external resources; ie, specification documents, jira
  items, related PRs, honeybadger errors, etc
-->

- [jira](https://codedotorg.atlassian.net/browse/PLAT-469)

## Testing story

Added a test to check that migrated scripts get the lesson plan url for lesson plans on Code Studio. There are old tests that check the old case of non-migrated scripts getting the old URL pattern to point to CB.

