### PR TITLE
[Spritelab] Disable input when paused or not running

### DIFF
--- a/apps/src/p5lab/spritelab/SpritelabInput.jsx
+++ b/apps/src/p5lab/spritelab/SpritelabInput.jsx
@@ -3,6 +3,7 @@ import {connect} from 'react-redux';
 import React from 'react';
 import memoize from 'memoize-one';
 import * as shapes from '../shapes';
+import {selectors} from '@cdo/apps/lib/tools/jsdebugger/redux';
 import {PromptType, popPrompt} from './spritelabInputModule';
 import * as coreLibrary from './coreLibrary';
 
@@ -63,11 +64,17 @@ const styles = {
     overflow: 'hidden',
     whiteSpace: 'nowrap'
   },
-  choiceSprite: {
-    margin: '0px 8px',
+  choiceSpriteContainer: {
+    padding: 0,
+    background: 'transparent',
+    border: 'transparent'
+  },
+  choiceSpriteImage: {
+    margin: 0,
     height: 32,
     width: 32,
-    objectFit: 'contain'
+    objectFit: 'contain',
+    opacity: 1
   }
 };
 
@@ -82,7 +89,9 @@ class SpritelabInput extends React.Component {
         choices: PropTypes.arrayOf(PropTypes.string)
       })
     ).isRequired,
-    onPromptAnswer: PropTypes.func.isRequired
+    onPromptAnswer: PropTypes.func.isRequired,
+    isRunning: PropTypes.bool.isRequired,
+    isPaused: PropTypes.bool.isRequired
   };
 
   state = {
@@ -133,6 +142,7 @@ class SpritelabInput extends React.Component {
     const icon = this.state.collapsed ? 'angle-right' : 'angle-down';
     const numPrompts = this.props.inputList.length;
     const promptText = inputInfo.promptText;
+    const disabled = this.props.isPaused || !this.props.isRunning;
 
     let inputRow;
     switch (inputInfo.promptType) {
@@ -144,11 +154,13 @@ class SpritelabInput extends React.Component {
               type="text"
               onChange={event => this.setState({userInput: event.target.value})}
               value={this.state.userInput || ''}
+              disabled={disabled}
             />
             <button
               style={styles.submitButton}
               type="button"
               onClick={this.onTextSubmit}
+              disabled={disabled}
             >
               <i className="fa fa-check" />
             </button>
@@ -161,13 +173,19 @@ class SpritelabInput extends React.Component {
           <div style={styles.inputRow}>
             {choices.map((choice, index) =>
               !!spriteMap[choice] ? (
-                <img
+                <button
                   key={choice + index}
-                  style={styles.choiceSprite}
-                  src={spriteMap[choice]}
-                  value={choice}
+                  type="button"
                   onClick={this.onMultipleChoiceSubmit}
-                />
+                  disabled={disabled}
+                  style={styles.choiceSpriteContainer}
+                >
+                  <img
+                    src={spriteMap[choice]}
+                    value={choice}
+                    style={styles.choiceSpriteImage}
+                  />
+                </button>
               ) : (
                 <button
                   key={choice + index}
@@ -175,6 +193,7 @@ class SpritelabInput extends React.Component {
                   type="button"
                   value={choice}
                   onClick={this.onMultipleChoiceSubmit}
+                  disabled={disabled}
                 >
                   {choice}
                 </button>
@@ -215,7 +234,9 @@ class SpritelabInput extends React.Component {
 export default connect(
   state => ({
     animationList: state.animationList,
-    inputList: state.spritelabInputList || []
+    inputList: state.spritelabInputList || [],
+    isRunning: selectors.isRunning(state),
+    isPaused: selectors.isPaused(state)
   }),
   dispatch => ({
     onPromptAnswer: () => dispatch(popPrompt())


### PR DESCRIPTION
Small fix to disallow interacting with the input prompts when the program is not running or when it's paused
Before:
![Feb-04-2021 12-15-06](https://user-images.githubusercontent.com/8787187/106952735-5afd6800-66e6-11eb-933a-e811173bcfc7.gif)
![Feb-04-2021 12-43-13](https://user-images.githubusercontent.com/8787187/106953341-21792c80-66e7-11eb-8a86-a4a6b7d6050b.gif)

After:
![Feb-04-2021 12-16-32](https://user-images.githubusercontent.com/8787187/106952751-605ab280-66e6-11eb-801a-c369b5740a2f.gif)
![Feb-04-2021 12-47-04](https://user-images.githubusercontent.com/8787187/106953380-305fdf00-66e7-11eb-96a5-2346d4609422.gif)


<!-- ### Background -->
<!-- ### Privacy -->
<!--
1.	Does the Project involve the collection, use or sharing of new Personal Data?

2.	Does the Project involve a new or changed use or sharing of existing Personal Data?
-->
<!-- ### Security -->
<!--
Link to Jira Task where sensitive security issues are discussed privately.
-->
<!-- ### Caching -->
<!-- ### Deployment strategy -->
<!-- ### Future work -->

## Links

<!--
  Any relevant links to external resources; ie, specification documents, jira
  items, related PRs, honeybadger errors, etc
-->

- [spec]()
- [jira]()

## Testing story

<!--
  Does your change include appropriate tests?

  If so, please describe how the tests included in this PR are sufficient

  If not, please explain why this change does not need to be tested.
-->

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
