### PR TITLE
Don't compare vocab and resource content when determining if lesson has changed

### DIFF
--- a/dashboard/app/controllers/lessons_controller.rb
+++ b/dashboard/app/controllers/lessons_controller.rb
@@ -37,10 +37,10 @@ class LessonsController < ApplicationController
     if params[:originalLessonData]
       current_lesson_data = @lesson.summarize_for_lesson_edit
       old_lesson_data = JSON.parse(params[:originalLessonData])
-      current_lesson_data[:vocabularies] = current_lesson_data[:vocabularies].map {|v| v[:id]} if current_lesson_data[:vocabularies]
-      old_lesson_data['vocabularies'] = old_lesson_data['vocabularies'].map {|v| v['id']} if old_lesson_data['vocabularies']
-      current_lesson_data[:resources] = current_lesson_data[:resources].map {|v| v[:id]} if current_lesson_data[:resources]
-      old_lesson_data['resources'] = old_lesson_data['resources'].map {|v| v['id']} if old_lesson_data['resources']
+      current_lesson_data[:vocabularies]&.map! {|v| v[:id]}
+      old_lesson_data['vocabularies']&.map! {|v| v['id']}
+      current_lesson_data[:resources]&.map! {|v| v[:id]}
+      old_lesson_data['resources']&.map! {|v| v['id']}
       if old_lesson_data.to_json != current_lesson_data.to_json
         msg = "Could not update the lesson because the contents of the lesson has changed outside of this editor. Reload the page and try saving again."
         raise msg

--- a/dashboard/app/controllers/lessons_controller.rb
+++ b/dashboard/app/controllers/lessons_controller.rb
@@ -35,9 +35,13 @@ class LessonsController < ApplicationController
   # PATCH/PUT /lessons/1
   def update
     if params[:originalLessonData]
-      current_lesson_data = JSON.generate(@lesson.summarize_for_lesson_edit)
-      old_lesson_data = params[:originalLessonData]
-      if old_lesson_data != current_lesson_data
+      current_lesson_data = @lesson.summarize_for_lesson_edit
+      old_lesson_data = JSON.parse(params[:originalLessonData])
+      current_lesson_data[:vocabularies] = current_lesson_data[:vocabularies].map {|v| v[:id]} if current_lesson_data[:vocabularies]
+      old_lesson_data['vocabularies'] = old_lesson_data['vocabularies'].map {|v| v['id']} if old_lesson_data['vocabularies']
+      current_lesson_data[:resources] = current_lesson_data[:resources].map {|v| v[:id]} if current_lesson_data[:resources]
+      old_lesson_data['resources'] = old_lesson_data['resources'].map {|v| v['id']} if old_lesson_data['resources']
+      if old_lesson_data.to_json != current_lesson_data.to_json
         msg = "Could not update the lesson because the contents of the lesson has changed outside of this editor. Reload the page and try saving again."
         raise msg
       end

--- a/dashboard/test/controllers/lessons_controller_test.rb
+++ b/dashboard/test/controllers/lessons_controller_test.rb
@@ -273,7 +273,7 @@ class LessonsControllerTest < ActionController::TestCase
       post :update, params: {
         id: lesson.id,
         lesson: {name: lesson.name},
-        originalLessonData: {"name": "Not the name"}
+        originalLessonData: JSON.generate({"name": "Not the name"})
       }
     end
 
@@ -302,6 +302,66 @@ class LessonsControllerTest < ActionController::TestCase
       id: lesson.id,
       lesson: {name: lesson.name},
       originalLessonData: JSON.generate(lesson.summarize_for_lesson_edit.except(:updatedAt))
+    }
+
+    assert_response :success
+  end
+
+  test 'can update if vocabulary content changes' do
+    sign_in @levelbuilder
+    Rails.application.config.stubs(:levelbuilder_mode).returns true
+
+    script = create :script
+    lesson_group = create :lesson_group, script: script
+    lesson = create :lesson, script: script, lesson_group: lesson_group
+    lesson_activity = create :lesson_activity, lesson: lesson
+    activity_section = create :activity_section, lesson_activity: lesson_activity
+    create(
+      :script_level,
+      script: script,
+      activity_section: activity_section,
+      activity_section_position: 1,
+      lesson: lesson,
+      levels: [create(:maze)]
+    )
+    vocabulary = create :vocabulary, definition: 'original definition', lessons: [lesson]
+    original_lesson_data = JSON.generate(lesson.summarize_for_lesson_edit.except(:updatedAt))
+    vocabulary.definition = 'updated definition'
+
+    post :update, params: {
+      id: lesson.id,
+      lesson: {name: lesson.name},
+      originalLessonData: original_lesson_data
+    }
+
+    assert_response :success
+  end
+
+  test 'can update if resource content changes' do
+    sign_in @levelbuilder
+    Rails.application.config.stubs(:levelbuilder_mode).returns true
+
+    script = create :script
+    lesson_group = create :lesson_group, script: script
+    lesson = create :lesson, script: script, lesson_group: lesson_group
+    lesson_activity = create :lesson_activity, lesson: lesson
+    activity_section = create :activity_section, lesson_activity: lesson_activity
+    create(
+      :script_level,
+      script: script,
+      activity_section: activity_section,
+      activity_section_position: 1,
+      lesson: lesson,
+      levels: [create(:maze)]
+    )
+    resource = create :resource, url: 'original.url', lessons: [lesson]
+    original_lesson_data = JSON.generate(lesson.summarize_for_lesson_edit.except(:updatedAt))
+    resource.url = 'updated.url'
+
+    post :update, params: {
+      id: lesson.id,
+      lesson: {name: lesson.name},
+      originalLessonData: original_lesson_data
     }
 
     assert_response :success


### PR DESCRIPTION
Follow up to [this comment](https://github.com/code-dot-org/code-dot-org/pull/38839#issuecomment-772121247). Vocabulary and resource content are updated via their own apis and aren't updated when a lesson is updated. Instead we should check if the set of vocab/resources associated with the lesson matches (which is updated when a lesson is updated).


<!--
  Other aspects to consider. uncomment and add detail for any that seem necessary:
-->

<!-- ### Background -->
<!-- ### Privacy -->
<!--
1.	Does the Project involve the collection, use or sharing of new Personal Data?

2.	Does the Project involve a new or changed use or sharing of existing Personal Data?
-->
<!-- ### Security -->
<!--
Link to Jira Task where sensitive security issues are discussed privately.
-->
<!-- ### Caching -->
<!-- ### Deployment strategy -->
<!-- ### Future work -->

## Links

<!--
  Any relevant links to external resources; ie, specification documents, jira
  items, related PRs, honeybadger errors, etc
-->

- [spec]()
- [jira]()

## Testing story

added unit tests

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
