### PR TITLE
Fix flakiness in dashboard/ AzureTextToSpeech tests

### DIFF
--- a/dashboard/test/controllers/api/v1/text_to_speech_controller_test.rb
+++ b/dashboard/test/controllers/api/v1/text_to_speech_controller_test.rb
@@ -13,6 +13,10 @@ class Api::V1::TextToSpeechControllerTest < ActionController::TestCase
     @default_limit = Api::V1::TextToSpeechController::REQUEST_LIMIT_PER_MIN_DEFAULT
   end
 
+  teardown do
+    CDO.shared_cache.clear
+  end
+
   test 'azure: returns 400 if speech not received from Azure' do
     AzureTextToSpeech.expects(:throttled_get_speech).once.yields(nil)
     post :azure

--- a/dashboard/test/controllers/concerns/azure_text_to_speech_test.rb
+++ b/dashboard/test/controllers/concerns/azure_text_to_speech_test.rb
@@ -132,17 +132,15 @@ class AzureTextToSpeechTest < ActionController::TestCase
     assert_nil AzureTextToSpeech.get_voices
   end
 
-  # TODO: (maddie 01/21/2021) This test is flaky and blocking builds. The behavior has been verified as expected/wanted.
-  # https://codedotorg.atlassian.net/browse/STAR-1410
-  # test 'get_azure_speech_service_voices returns nil on error' do
-  #   AzureTextToSpeech.stubs(:get_token).returns(@mock_token)
-  #   Honeybadger.expects(:notify).once
-  #   stub_request(:get, "https://#{@region}.tts.speech.microsoft.com/cognitiveservices/voices/list").
-  #     with(headers: {'Authorization' => "Bearer #{@mock_token}"}).
-  #     to_raise(ArgumentError)
+  test 'get_azure_speech_service_voices returns nil on error' do
+    AzureTextToSpeech.stubs(:get_token).returns(@mock_token)
+    Honeybadger.expects(:notify).once
+    stub_request(:get, "https://#{@region}.tts.speech.microsoft.com/cognitiveservices/voices/list").
+      with(headers: {'Authorization' => "Bearer #{@mock_token}"}).
+      to_raise(ArgumentError)
 
-  #   assert_nil AzureTextToSpeech.get_voices
-  # end
+    assert_nil AzureTextToSpeech.get_voices
+  end
 
   test 'get_voice_by: returns voice name if exists for given locale + gender' do
     AzureTextToSpeech.stubs(:get_voices).returns(

--- a/dashboard/test/controllers/projects_controller_test.rb
+++ b/dashboard/test/controllers/projects_controller_test.rb
@@ -13,7 +13,7 @@ class ProjectsControllerTest < ActionController::TestCase
   setup do
     sign_in_with_request create :user
     Geocoder.stubs(:search).returns([OpenStruct.new(country_code: 'US')])
-    stub(:azure_speech_service_options).returns({})
+    AzureTextToSpeech.stubs(:get_voices).returns({})
   end
 
   self.use_transactional_test_case = true
@@ -27,7 +27,7 @@ class ProjectsControllerTest < ActionController::TestCase
   end
 
   teardown do
-    unstub(:azure_speech_service_options)
+    AzureTextToSpeech.unstub(:get_voices)
   end
 
   test "index" do

--- a/dashboard/test/controllers/projects_controller_test.rb
+++ b/dashboard/test/controllers/projects_controller_test.rb
@@ -13,6 +13,7 @@ class ProjectsControllerTest < ActionController::TestCase
   setup do
     sign_in_with_request create :user
     Geocoder.stubs(:search).returns([OpenStruct.new(country_code: 'US')])
+    stub(:azure_speech_service_options).returns({})
   end
 
   self.use_transactional_test_case = true
@@ -23,6 +24,10 @@ class ProjectsControllerTest < ActionController::TestCase
     @section = create :section
     @section.add_student @driver
     @section.add_student @navigator
+  end
+
+  teardown do
+    unstub(:azure_speech_service_options)
   end
 
   test "index" do

--- a/dashboard/test/controllers/script_levels_controller_test.rb
+++ b/dashboard/test/controllers/script_levels_controller_test.rb
@@ -58,6 +58,11 @@ class ScriptLevelsControllerTest < ActionController::TestCase
   setup do
     client_state.reset
     Gatekeeper.clear
+    stub(:azure_speech_service_options).returns({})
+  end
+
+  teardown do
+    unstub(:azure_speech_service_options)
   end
 
   test 'should show script level for twenty hour' do

--- a/dashboard/test/controllers/script_levels_controller_test.rb
+++ b/dashboard/test/controllers/script_levels_controller_test.rb
@@ -58,11 +58,11 @@ class ScriptLevelsControllerTest < ActionController::TestCase
   setup do
     client_state.reset
     Gatekeeper.clear
-    stub(:azure_speech_service_options).returns({})
+    AzureTextToSpeech.stubs(:get_voices).returns({})
   end
 
   teardown do
-    unstub(:azure_speech_service_options)
+    AzureTextToSpeech.unstub(:get_voices)
   end
 
   test 'should show script level for twenty hour' do


### PR DESCRIPTION
Fixes some flakiness in unit tests involving `AzureTextToSpeech` that was occurring because `CDO.shared_cache` sometimes had data when it shouldn't (e.g., a test expects an API call to happen if the cache doesn't already have a token, but that token wasn't cleared from a previous unit test, causing the test to fail).

## Links

<!--
  Any relevant links to external resources; ie, specification documents, jira
  items, related PRs, honeybadger errors, etc
-->

- [STAR-1410](https://codedotorg.atlassian.net/browse/STAR-1410)

## Testing story

De-flakes unit tests.

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
