### PR TITLE
[Sprite Lab] Add validation commands

### DIFF
--- a/apps/src/p5lab/spritelab/commands.js
+++ b/apps/src/p5lab/spritelab/commands.js
@@ -322,7 +322,19 @@ export const commands = {
     return validationCommands.getBehaviorsForSpriteId(spriteId);
   },
 
+  getPrintLog() {
+    return validationCommands.getPrintLog();
+  },
+
+  getPromptVars() {
+    return validationCommands.getPromptVars();
+  },
+
   getSpriteIdsInUse() {
     return validationCommands.getSpriteIdsInUse();
+  },
+
+  getTitle() {
+    return validationCommands.getTitle();
   }
 };

--- a/apps/src/p5lab/spritelab/commands/validationCommands.js
+++ b/apps/src/p5lab/spritelab/commands/validationCommands.js
@@ -25,7 +25,19 @@ export const commands = {
     return coreLibrary.getBehaviorsForSpriteId(spriteId);
   },
 
+  getPrintLog() {
+    return coreLibrary.printLog;
+  },
+
+  getPromptVars() {
+    return coreLibrary.promptVars;
+  },
+
   getSpriteIdsInUse() {
     return coreLibrary.getSpriteIdsInUse();
+  },
+
+  getTitle() {
+    return {title: coreLibrary.title, subtitle: coreLibrary.subtitle};
   }
 };

--- a/apps/src/p5lab/spritelab/commands/worldCommands.js
+++ b/apps/src/p5lab/spritelab/commands/worldCommands.js
@@ -22,6 +22,7 @@ export const commands = {
   },
 
   printText(text) {
+    coreLibrary.printLog.push(text);
     getStore().dispatch(addConsoleMessage({text: text}));
   },
 

--- a/apps/src/p5lab/spritelab/coreLibrary.js
+++ b/apps/src/p5lab/spritelab/coreLibrary.js
@@ -11,6 +11,8 @@ export var background;
 export var title = '';
 export var subtitle = '';
 export var defaultSpriteSize = 100;
+export var printLog = [];
+export var promptVars = {};
 
 export function reset() {
   spriteId = 0;
@@ -22,6 +24,8 @@ export function reset() {
   userInputEventCallbacks = {};
   defaultSpriteSize = 100;
   totalPauseTime = 0;
+  printLog = [];
+  promptVars = {};
 }
 
 export function startPause(time) {
@@ -181,6 +185,10 @@ export function deleteSprite(spriteId) {
 }
 
 export function registerPrompt(promptText, variableName, setterCallback) {
+  if (!variableName) {
+    return;
+  }
+  promptVars[variableName] = null;
   if (!userInputEventCallbacks[variableName]) {
     userInputEventCallbacks[variableName] = {
       setterCallbacks: [],
@@ -191,6 +199,9 @@ export function registerPrompt(promptText, variableName, setterCallback) {
 }
 
 export function registerPromptAnswerCallback(variableName, userCallback) {
+  if (!variableName) {
+    return;
+  }
   if (!userInputEventCallbacks[variableName]) {
     userInputEventCallbacks[variableName] = {
       setterCallbacks: [],
@@ -201,6 +212,7 @@ export function registerPromptAnswerCallback(variableName, userCallback) {
 }
 
 export function onPromptAnswer(variableName, userInput) {
+  promptVars[variableName] = userInput;
   const callbacks = userInputEventCallbacks[variableName];
   if (callbacks) {
     // Make sure to call the setter callback to set the variable

--- a/apps/src/p5lab/spritelab/coreLibrary.js
+++ b/apps/src/p5lab/spritelab/coreLibrary.js
@@ -188,7 +188,12 @@ export function registerPrompt(promptText, variableName, setterCallback) {
   if (!variableName) {
     return;
   }
-  promptVars[variableName] = null;
+  if (promptVars[variableName] === undefined) {
+    // Set explicitly to null so that we can tell that there *is* a prompt
+    // for this variable name, it just hasn't been answered yet.
+    promptVars[variableName] = null;
+  }
+
   if (!userInputEventCallbacks[variableName]) {
     userInputEventCallbacks[variableName] = {
       setterCallbacks: [],

--- a/apps/test/unit/p5lab/spritelab/validationCommandsTest.js
+++ b/apps/test/unit/p5lab/spritelab/validationCommandsTest.js
@@ -1,0 +1,53 @@
+import {expect} from '../../../util/reconfiguredChai';
+import {commands} from '@cdo/apps/p5lab/spritelab/commands/validationCommands';
+import {commands as worldCommands} from '@cdo/apps/p5lab/spritelab/commands/worldCommands';
+import * as coreLibrary from '@cdo/apps/p5lab/spritelab/coreLibrary';
+
+describe('Validation Commands', () => {
+  it('getTitle', () => {
+    expect(commands.getTitle()).to.deep.equal({title: '', subtitle: ''});
+    worldCommands.showTitleScreen('my title', 'my subtitle');
+    expect(commands.getTitle()).to.deep.equal({
+      title: 'my title',
+      subtitle: 'my subtitle'
+    });
+    worldCommands.hideTitleScreen();
+    expect(commands.getTitle()).to.deep.equal({title: '', subtitle: ''});
+  });
+
+  it('getPrintLog', () => {
+    expect(commands.getPrintLog()).to.deep.equal([]);
+    worldCommands.printText('first');
+    expect(commands.getPrintLog()).to.deep.equal(['first']);
+    worldCommands.printText('second');
+    expect(commands.getPrintLog()).to.deep.equal(['first', 'second']);
+    worldCommands.printText('third');
+    expect(commands.getPrintLog()).to.deep.equal(['first', 'second', 'third']);
+  });
+
+  it('getPromptVars', () => {
+    expect(commands.getPromptVars()).to.deep.equal({});
+    worldCommands.setPrompt('prompt text', 'myVar1', () => {});
+    worldCommands.setPrompt('prompt text', 'myVar2', () => {});
+    worldCommands.setPromptWithChoices(
+      'prompt text',
+      'myVar3',
+      ['a', 'b', 'c'],
+      () => {}
+    );
+    worldCommands.setPromptWithChoices(
+      'prompt text',
+      'myVar4',
+      [1, 2, 3],
+      () => {}
+    );
+    expect(commands.getPromptVars()).to.deep.equal({
+      myVar1: null,
+      myVar2: null,
+      myVar3: null,
+      myVar4: null
+    });
+    coreLibrary.onPromptAnswer('myVar2', 'my answer');
+    coreLibrary.onPromptAnswer('myVar3', 2);
+  });
+});


### PR DESCRIPTION
A couple simple validation commands that will make Mike's life easier :)
`getTitle`: returns the current value of the title and subtitle in the format `{title: _, subtitle: _}`
`getPrintLog`: returns an array of all the things that have been printed to the console
`getPromptVars`: returns a map of the variables for set prompt blocks. Format is variable name -> value (or `null` if the input hasn't been answered yet)

<!-- ### Background -->
<!-- ### Privacy -->
<!--
1.	Does the Project involve the collection, use or sharing of new Personal Data?

2.	Does the Project involve a new or changed use or sharing of existing Personal Data?
-->
<!-- ### Security -->
<!--
Link to Jira Task where sensitive security issues are discussed privately.
-->
<!-- ### Caching -->
<!-- ### Deployment strategy -->
<!-- ### Future work -->

## Links

<!--
  Any relevant links to external resources; ie, specification documents, jira
  items, related PRs, honeybadger errors, etc
-->


## Testing story
Unit tests

<!--
  Does your change include appropriate tests?

  If so, please describe how the tests included in this PR are sufficient

  If not, please explain why this change does not need to be tested.
-->

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
