### PR TITLE
Add annotation for new topic column in FeaturedProject model

### DIFF
--- a/dashboard/app/models/featured_project.rb
+++ b/dashboard/app/models/featured_project.rb
@@ -6,10 +6,12 @@
 #  storage_app_id :integer
 #  featured_at    :datetime
 #  unfeatured_at  :datetime
+#  topic          :string(255)
 #
 # Indexes
 #
 #  index_featured_projects_on_storage_app_id  (storage_app_id) UNIQUE
+#  index_featured_projects_on_topic           (topic)
 #
 
 class FeaturedProject < ApplicationRecord


### PR DESCRIPTION
A new `topic` column was added to the `FeaturedProject` model in #38727, but the annotation was accidentally overridden in  #38762 as they were happening simultaneously. This just adds the annotation back by running `bundle exec rails db:migrate` locally.