### PR TITLE
[Spritelab] Add level configuration to hide pause button and remove experiment

### DIFF
--- a/apps/src/p5lab/P5Lab.js
+++ b/apps/src/p5lab/P5Lab.js
@@ -495,6 +495,7 @@ P5Lab.prototype.init = function(config) {
             showFinishButton={finishButtonFirstLine && showFinishButton}
             onMount={onMount}
             pauseHandler={this.onPause}
+            hidePauseButton={!!this.level.hidePauseButton}
           />
         </Provider>,
         document.getElementById(config.containerId)

--- a/apps/src/p5lab/P5Lab.js
+++ b/apps/src/p5lab/P5Lab.js
@@ -395,7 +395,7 @@ P5Lab.prototype.init = function(config) {
     (!config.hideSource &&
       !config.level.debuggerDisabled &&
       !config.level.iframeEmbedAppAndCode);
-  var showPauseButton = experiments.isEnabled(experiments.SPRITELAB_PAUSE);
+  var showPauseButton = this.isSpritelab && !config.level.hidePauseButton;
   var showDebugConsole = config.level.editCode && !config.hideSource;
   this.debuggerEnabled =
     showDebugButtons || showPauseButton || showDebugConsole;

--- a/apps/src/p5lab/P5LabView.jsx
+++ b/apps/src/p5lab/P5LabView.jsx
@@ -27,6 +27,8 @@ class P5LabView extends React.Component {
     // Provided manually
     showFinishButton: PropTypes.bool.isRequired,
     onMount: PropTypes.func.isRequired,
+    pauseHandler: PropTypes.func.isRequired,
+    hidePauseButton: PropTypes.bool.isRequired,
     // Provided by Redux
     interfaceMode: PropTypes.oneOf([
       P5LabInterfaceMode.CODE,
@@ -40,8 +42,7 @@ class P5LabView extends React.Component {
     isIframeEmbed: PropTypes.bool.isRequired,
     isRunning: PropTypes.bool.isRequired,
     spriteLab: PropTypes.bool.isRequired,
-    isBackground: PropTypes.bool,
-    pauseHandler: PropTypes.func.isRequired
+    isBackground: PropTypes.bool
   };
 
   state = {
@@ -114,6 +115,7 @@ class P5LabView extends React.Component {
           <P5LabVisualizationColumn
             finishButton={showFinishButton}
             pauseHandler={this.props.pauseHandler}
+            hidePauseButton={this.props.hidePauseButton}
           />
           {this.getChannelId() && (
             <AnimationPicker

--- a/apps/src/p5lab/P5LabVisualizationColumn.jsx
+++ b/apps/src/p5lab/P5LabVisualizationColumn.jsx
@@ -7,7 +7,6 @@ import GameButtons from '@cdo/apps/templates/GameButtons';
 import ArrowButtons from '@cdo/apps/templates/ArrowButtons';
 import PauseButton from '@cdo/apps/templates/PauseButton';
 import BelowVisualization from '@cdo/apps/templates/BelowVisualization';
-import experiments from '@cdo/apps/util/experiments';
 import {APP_HEIGHT, APP_WIDTH} from './constants';
 import {GAMELAB_DPAD_CONTAINER_ID} from './gamelab/constants';
 import CompletionButton from '@cdo/apps/templates/CompletionButton';
@@ -66,9 +65,6 @@ class P5LabVisualizationColumn extends React.Component {
 
   constructor(props) {
     super(props);
-    this.spritelabPauseExperiment = experiments.isEnabled(
-      experiments.SPRITELAB_PAUSE
-    );
   }
 
   // Cache app-space mouse coordinates, which we get from the
@@ -174,10 +170,7 @@ class P5LabVisualizationColumn extends React.Component {
       divGameLabStyle.zIndex = MODAL_Z_INDEX;
     }
     const isSpritelab = this.props.spriteLab;
-    const showPauseButton =
-      isSpritelab &&
-      this.spritelabPauseExperiment &&
-      !this.props.hidePauseButton;
+    const showPauseButton = isSpritelab && !this.props.hidePauseButton;
 
     return (
       <div style={{position: 'relative'}}>

--- a/apps/src/p5lab/P5LabVisualizationColumn.jsx
+++ b/apps/src/p5lab/P5LabVisualizationColumn.jsx
@@ -46,6 +46,10 @@ const styles = {
 class P5LabVisualizationColumn extends React.Component {
   static propTypes = {
     finishButton: PropTypes.bool.isRequired,
+    pauseHandler: PropTypes.func.isRequired,
+    hidePauseButton: PropTypes.bool.isRequired,
+
+    // From redux
     isResponsive: PropTypes.bool.isRequired,
     isShareView: PropTypes.bool.isRequired,
     isProjectLevel: PropTypes.bool.isRequired,
@@ -57,8 +61,7 @@ class P5LabVisualizationColumn extends React.Component {
     cancelPicker: PropTypes.func.isRequired,
     selectPicker: PropTypes.func.isRequired,
     updatePicker: PropTypes.func.isRequired,
-    consoleMessages: PropTypes.array.isRequired,
-    pauseHandler: PropTypes.func.isRequired
+    consoleMessages: PropTypes.array.isRequired
   };
 
   constructor(props) {
@@ -170,7 +173,11 @@ class P5LabVisualizationColumn extends React.Component {
     if (this.props.pickingLocation) {
       divGameLabStyle.zIndex = MODAL_Z_INDEX;
     }
-    const spriteLab = this.props.spriteLab;
+    const isSpritelab = this.props.spriteLab;
+    const showPauseButton =
+      isSpritelab &&
+      this.spritelabPauseExperiment &&
+      !this.props.hidePauseButton;
 
     return (
       <div style={{position: 'relative'}}>
@@ -190,25 +197,25 @@ class P5LabVisualizationColumn extends React.Component {
               onMouseMove={this.onMouseMove}
             >
               <GridOverlay show={this.props.showGrid} showWhileRunning={true} />
-              <CrosshairOverlay flip={spriteLab} />
-              <TooltipOverlay providers={[coordinatesProvider(spriteLab)]} />
+              <CrosshairOverlay flip={isSpritelab} />
+              <TooltipOverlay providers={[coordinatesProvider(isSpritelab)]} />
             </VisualizationOverlay>
           </ProtectedVisualizationDiv>
           <TextConsole consoleMessages={this.props.consoleMessages} />
-          {spriteLab && <SpritelabInput />}
+          {isSpritelab && <SpritelabInput />}
         </div>
 
         <GameButtons>
-          {spriteLab && this.spritelabPauseExperiment && (
+          {showPauseButton && (
             <PauseButton pauseHandler={this.props.pauseHandler} />
           )}
           <ArrowButtons />
 
           <CompletionButton />
 
-          {!spriteLab && !isShareView && this.renderGridCheckbox()}
+          {!isSpritelab && !isShareView && this.renderGridCheckbox()}
         </GameButtons>
-        {!spriteLab && this.renderAppSpaceCoordinates()}
+        {!isSpritelab && this.renderAppSpaceCoordinates()}
         <ProtectedStatefulDiv
           id={GAMELAB_DPAD_CONTAINER_ID}
           className={classNames({responsive: isResponsive})}

--- a/apps/src/util/experiments.js
+++ b/apps/src/util/experiments.js
@@ -32,7 +32,6 @@ experiments.I18N_TRACKING = 'i18n-tracking';
 experiments.TIME_SPENT = 'time-spent';
 experiments.APPLAB_ML = 'applab-ml';
 experiments.BYPASS_DIALOG_POPUP = 'bypass-dialog-popup';
-experiments.SPRITELAB_PAUSE = 'spritelabPause';
 experiments.SPECIAL_TOPIC = 'special-topic';
 
 /**

--- a/dashboard/app/models/levels/gamelab_jr.rb
+++ b/dashboard/app/models/levels/gamelab_jr.rb
@@ -31,6 +31,7 @@ class GamelabJr < Gamelab
     use_default_sprites
     block_pools
     mini_toolbox
+    hide_pause_button
   )
 
   def shared_blocks
@@ -57,7 +58,8 @@ class GamelabJr < Gamelab
           hide_custom_blocks: true,
           all_animations_single_frame: true,
           use_modal_function_editor: true,
-          mini_toolbox: false
+          mini_toolbox: false,
+          hide_pause_button: false
         }
       )
     )

--- a/dashboard/app/views/levels/editors/fields/_control_buttons.html.haml
+++ b/dashboard/app/views/levels/editors/fields/_control_buttons.html.haml
@@ -10,3 +10,8 @@
     %a.select_none{href: '#'} none
     (shift-click or cmd-click to select multiple). Arrow buttons to display below the game canvas.
   = f.collection_select :soft_buttons, soft_button_options, :value, :name, {selected: @level.soft_buttons}, {multiple: true}
+
+  - if @level.is_a?(GamelabJr)
+    .field
+      = render partial: 'levels/editors/fields/checkboxes', locals: {f: f, field_name: :hide_pause_button, description: "Don't show Pause Button"}
+


### PR DESCRIPTION
Checkbox on the level edit page that lets levelbuilders hide the pause button on a level if desired.
![image](https://user-images.githubusercontent.com/8787187/107259167-88e9f180-69f1-11eb-932b-6e651d7c9962.png)
![image](https://user-images.githubusercontent.com/8787187/107259284-ab7c0a80-69f1-11eb-9cdf-8869d7ef5a9e.png)

This PR also removes the experiment flag, so the pause button will be visible on all Sprite Lab levels unless `hidePauseButton` is set to `true`.

<!-- ### Background -->
<!-- ### Privacy -->
<!--
1.	Does the Project involve the collection, use or sharing of new Personal Data?

2.	Does the Project involve a new or changed use or sharing of existing Personal Data?
-->
<!-- ### Security -->
<!--
Link to Jira Task where sensitive security issues are discussed privately.
-->
<!-- ### Caching -->
<!-- ### Deployment strategy -->
<!-- ### Future work -->

## Links

<!--
  Any relevant links to external resources; ie, specification documents, jira
  items, related PRs, honeybadger errors, etc
-->

- [jira](https://codedotorg.atlassian.net/browse/STAR-1420)

## Testing story

<!--
  Does your change include appropriate tests?

  If so, please describe how the tests included in this PR are sufficient

  If not, please explain why this change does not need to be tested.
-->

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
