### PR TITLE
Hbergam/signin callout UI

### DIFF
--- a/apps/i18n/common/en_us.json
+++ b/apps/i18n/common/en_us.json
@@ -1224,6 +1224,8 @@
   "notApplicable": "N/A",
   "notCompleted": "Not completed",
   "notSaved": "Not saved",
+  "notSignedInHeader": "You are not signed in",
+  "notSignedInBody": "You don't need an account to work on this lesson, but if you want to save your work, remember to sign in or create an account before you get started.",
   "notStarted": "Not started",
   "nPoints": "{numPoints, plural, one {1 point} other {# points}}",
   "numMatchCorrect": "# match correct",

--- a/apps/src/code-studio/components/header/SignInCallout.jsx
+++ b/apps/src/code-studio/components/header/SignInCallout.jsx
@@ -74,16 +74,16 @@ const styles = {
  */
 export default class SignInCallout extends React.Component {
   static propTypes = {
-    handleClose: PropTypes.func
+    handleClose: PropTypes.func.isRequired
   };
 
   constructor(props) {
     super(props);
 
-    this.getContent = this.getContent.bind(this);
+    this.renderContent = this.renderContent.bind(this);
   }
 
-  getContent() {
+  renderContent() {
     return (
       <div style={styles.contentContainer}>
         <img
@@ -107,7 +107,7 @@ export default class SignInCallout extends React.Component {
           onClick={this.props.handleClose}
         />
         <div style={styles.upTriangle} />
-        <div style={styles.content}>{this.getContent()}</div>
+        <div style={styles.content}>{this.renderContent()}</div>
       </div>
     );
   }

--- a/apps/src/code-studio/components/header/SignInCallout.jsx
+++ b/apps/src/code-studio/components/header/SignInCallout.jsx
@@ -1,0 +1,135 @@
+import React from 'react';
+import cookies from 'js-cookie';
+
+const CALLOUT_COLOR = '#454545';
+const TRIANGLE_BASE = 30;
+const TRIANGLE_HEIGHT = 15;
+const CALLOUT_Z_INDEX = 1040;
+const CALLOUT_TOP = 30;
+
+const HideSignInCallout = 'hide_signin_callout';
+
+const styles = {
+  container: {
+    // The outermost div is relatively positioned so it can be used as a positional
+    // anchor for its children (which will be absolutely positioned to avoid affecting
+    // layout).  This element must be 0-sized to avoid affecting layout.
+    position: 'relative',
+    height: 0,
+    width: 0
+  },
+  content: {
+    position: 'absolute',
+    top: CALLOUT_TOP,
+    right: -90,
+    zIndex: CALLOUT_Z_INDEX,
+    backgroundColor: CALLOUT_COLOR,
+    borderRadius: 3
+  },
+  modalBackdrop: {
+    // Most backdrop attributes come from the 'modal-backdrop' class defined by bootstrap
+    // but we need to override the opacity as the default opacity of 0.8 is too dark.
+    // Note that bootstrap defaults the z-index of the backdrop to 1040.
+    opacity: 0.5
+  },
+  upTriangle: {
+    position: 'absolute',
+    top: CALLOUT_TOP - TRIANGLE_HEIGHT,
+    left: -(TRIANGLE_HEIGHT / 2.0),
+    width: 0,
+    height: 0,
+    borderStyle: 'solid',
+    borderTopWidth: 0,
+    borderRightWidth: TRIANGLE_BASE,
+    borderBottomWidth: TRIANGLE_HEIGHT,
+    borderLeftWidth: TRIANGLE_BASE,
+    borderTopColor: 'transparent',
+    borderRightColor: 'transparent',
+    borderBottomColor: CALLOUT_COLOR,
+    borderLeftColor: 'transparent',
+    zIndex: CALLOUT_Z_INDEX
+  },
+  contentContainer: {
+    display: 'flex',
+    flexDirection: 'row',
+    padding: 20
+  },
+  imageContainer: {
+    width: 100,
+    marginRight: 20
+  },
+  textContainer: {
+    width: 400,
+    textAlign: 'left',
+    whiteSpace: 'normal'
+  },
+  textHeader: {
+    marginTop: 0
+  }
+};
+
+/*
+ * This is a callout attached to the sign-in button that's used on CSF level
+ * pages to remind the user to sign-in.  Note that the sign-in button is
+ * defined in shared/haml/user_header.haml and is not a React component.
+ * This component is injected into the page by src/code-studio/header.js.
+ */
+export default class SignInCallout extends React.Component {
+  constructor(props) {
+    super(props);
+
+    this.closeCallout = this.closeCallout.bind(this);
+    this.getContent = this.getContent.bind(this);
+
+    // Using explicit strings: only show if neither says to hide
+    this.state = {
+      showCallout: !(
+        cookies.get(HideSignInCallout) === 'true' ||
+        sessionStorage.getItem(HideSignInCallout) === 'true'
+      )
+    };
+  }
+
+  closeCallout(event) {
+    this.setState({showCallout: false});
+    cookies.set(HideSignInCallout, 'true', {expires: 1, path: '/'});
+    sessionStorage.setItem(HideSignInCallout, 'true');
+    event.preventDefault();
+  }
+
+  getContent() {
+    return (
+      <div style={styles.contentContainer}>
+        <div style={styles.imageContainer}>
+          <img src="/shared/images/user-not-signed-in.png" />
+        </div>
+        <div style={styles.textContainer}>
+          <h2 style={styles.textHeader}>You are not signed in</h2>
+          <p>
+            You don't need an account to work on this lesson, but if you want to
+            save your work, remember to sign in or create an account before you
+            get started.
+          </p>
+        </div>
+      </div>
+    );
+  }
+
+  render() {
+    if (this.state.showCallout) {
+      return (
+        <div style={styles.container}>
+          <div
+            className="modal-backdrop"
+            style={styles.modalBackdrop}
+            onClick={this.closeCallout}
+          />
+          <div style={styles.upTriangle} />
+          <div style={styles.content}>{this.getContent()}</div>
+        </div>
+      );
+    } else {
+      return <div />;
+    }
+  }
+}

--- a/apps/src/code-studio/components/header/SignInCallout.jsx
+++ b/apps/src/code-studio/components/header/SignInCallout.jsx
@@ -1,14 +1,12 @@
 import React from 'react';
-import cookies from 'js-cookie';
 import i18n from '@cdo/locale';
+import PropTypes from 'prop-types';
 
 const CALLOUT_COLOR = '#454545';
 const TRIANGLE_BASE = 30;
 const TRIANGLE_HEIGHT = 15;
 const CALLOUT_Z_INDEX = 1040;
 const CALLOUT_TOP = 30;
-
-const HideSignInCallout = 'hide_signin_callout';
 
 const styles = {
   container: {
@@ -75,26 +73,14 @@ const styles = {
  * This component is injected into the page by src/code-studio/header.js.
  */
 export default class SignInCallout extends React.Component {
+  static propTypes = {
+    handleClose: PropTypes.func
+  };
+
   constructor(props) {
     super(props);
 
-    this.closeCallout = this.closeCallout.bind(this);
     this.getContent = this.getContent.bind(this);
-
-    // Using explicit strings: only show if neither says to hide
-    this.state = {
-      showCallout: !(
-        cookies.get(HideSignInCallout) === 'true' ||
-        sessionStorage.getItem(HideSignInCallout) === 'true'
-      )
-    };
-  }
-
-  closeCallout(event) {
-    this.setState({showCallout: false});
-    cookies.set(HideSignInCallout, 'true', {expires: 1, path: '/'});
-    sessionStorage.setItem(HideSignInCallout, 'true');
-    event.preventDefault();
   }
 
   getContent() {
@@ -113,20 +99,16 @@ export default class SignInCallout extends React.Component {
   }
 
   render() {
-    if (this.state.showCallout) {
-      return (
-        <div style={styles.container}>
-          <div
-            className="modal-backdrop"
-            style={styles.modalBackdrop}
-            onClick={this.closeCallout}
-          />
-          <div style={styles.upTriangle} />
-          <div style={styles.content}>{this.getContent()}</div>
-        </div>
-      );
-    } else {
-      return <div />;
-    }
+    return (
+      <div style={styles.container}>
+        <div
+          className="modal-backdrop"
+          style={styles.modalBackdrop}
+          onClick={this.props.handleClose}
+        />
+        <div style={styles.upTriangle} />
+        <div style={styles.content}>{this.getContent()}</div>
+      </div>
+    );
   }
 }

--- a/apps/src/code-studio/components/header/SignInCallout.jsx
+++ b/apps/src/code-studio/components/header/SignInCallout.jsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import cookies from 'js-cookie';
+import i18n from '@cdo/locale';
 
 const CALLOUT_COLOR = '#454545';
 const TRIANGLE_BASE = 30;
@@ -51,7 +52,6 @@ const styles = {
   },
   contentContainer: {
     display: 'flex',
-    flexDirection: 'row',
     padding: 20
   },
   imageContainer: {
@@ -100,16 +100,13 @@ export default class SignInCallout extends React.Component {
   getContent() {
     return (
       <div style={styles.contentContainer}>
-        <div style={styles.imageContainer}>
-          <img src="/shared/images/user-not-signed-in.png" />
-        </div>
+        <img
+          style={styles.imageContainer}
+          src="/shared/images/user-not-signed-in.png"
+        />
         <div style={styles.textContainer}>
-          <h2 style={styles.textHeader}>You are not signed in</h2>
-          <p>
-            You don't need an account to work on this lesson, but if you want to
-            save your work, remember to sign in or create an account before you
-            get started.
-          </p>
+          <h2 style={styles.textHeader}>{i18n.notSignedInHeader()}</h2>
+          <p> {i18n.notSignedInBody()}</p>
         </div>
       </div>
     );

--- a/apps/src/code-studio/components/header/SignInCalloutLogic.js
+++ b/apps/src/code-studio/components/header/SignInCalloutLogic.js
@@ -1,0 +1,37 @@
+import React from 'react';
+import cookies from 'js-cookie';
+import SignInCallout from './SignInCallout';
+
+const HideSignInCallout = 'hide_signin_callout';
+
+export default class SignInCalloutLogic extends React.Component {
+  constructor(props) {
+    super(props);
+    this.closeCallout = this.closeCallout.bind(this);
+    this.state = {
+      showCallout: !(
+        cookies.get(HideSignInCallout) === 'true' ||
+        sessionStorage.getItem(HideSignInCallout) === 'true'
+      )
+    };
+  }
+
+  closeCallout(event) {
+    this.setState({showCallout: false});
+    cookies.set(HideSignInCallout, 'true', {expires: 1, path: '/'});
+    sessionStorage.setItem(HideSignInCallout, 'true');
+    event.preventDefault();
+  }
+
+  render() {
+    if (this.state.showCallout) {
+      return (
+        <div className="uitest-signincallout">
+          <SignInCallout handleClose={this.closeCallout} />
+        </div>
+      );
+    } else {
+      return <div />;
+    }
+  }
+}

--- a/apps/src/code-studio/components/header/SignInCalloutLogic.js
+++ b/apps/src/code-studio/components/header/SignInCalloutLogic.js
@@ -4,6 +4,8 @@ import SignInCallout from './SignInCallout';
 
 const HideSignInCallout = 'hide_signin_callout';
 
+// The use of both session storage and cookies is to check for 1 day
+// and 1 session, and display the callout again only once BOTH have passed.
 export default class SignInCalloutLogic extends React.Component {
   constructor(props) {
     super(props);
@@ -23,6 +25,9 @@ export default class SignInCalloutLogic extends React.Component {
     event.preventDefault();
   }
 
+  // For readibility: returning an empty div here explicitly if the callout is
+  // not supposed to be displayed. This avoids using a render statement that
+  // often returns *nothing.
   render() {
     if (this.state.showCallout) {
       return (

--- a/apps/src/code-studio/components/header/SignInCalloutWrapper.js
+++ b/apps/src/code-studio/components/header/SignInCalloutWrapper.js
@@ -11,10 +11,14 @@ export default class SignInCalloutWrapper extends React.Component {
   constructor(props) {
     super(props);
     this.closeCallout = this.closeCallout.bind(this);
-    // The use of both session storage and cookies is to check for 1 day
-    // and 1 session, and display the callout again only once BOTH have passed.
+    // Before the cookies are set, searching for them will return false, so the
+    // desired flag should logically read 'true' when set: resulting in the
+    // 'hide' name. Though this leads to a bit of a double negative in the
+    // display logic (if not hide: display), it is the clearest option for now.
     this.state = {
       hideCallout:
+        // The use of both session storage and cookies is to check for 1 day
+        // and 1 session, and display the callout again once BOTH have passed.
         cookies.get(HideSignInCallout) === 'true' ||
         sessionStorage.getItem(HideSignInCallout) === 'true'
     };

--- a/apps/src/code-studio/components/header/SignInCalloutWrapper.js
+++ b/apps/src/code-studio/components/header/SignInCalloutWrapper.js
@@ -6,20 +6,19 @@ const HideSignInCallout = 'hide_signin_callout';
 
 // The use of both session storage and cookies is to check for 1 day
 // and 1 session, and display the callout again only once BOTH have passed.
-export default class SignInCalloutLogic extends React.Component {
+export default class SignInCalloutWrapper extends React.Component {
   constructor(props) {
     super(props);
     this.closeCallout = this.closeCallout.bind(this);
     this.state = {
-      showCallout: !(
+      hideCallout:
         cookies.get(HideSignInCallout) === 'true' ||
         sessionStorage.getItem(HideSignInCallout) === 'true'
-      )
     };
   }
 
   closeCallout(event) {
-    this.setState({showCallout: false});
+    this.setState({hideCallout: true});
     cookies.set(HideSignInCallout, 'true', {expires: 1, path: '/'});
     sessionStorage.setItem(HideSignInCallout, 'true');
     event.preventDefault();
@@ -29,14 +28,14 @@ export default class SignInCalloutLogic extends React.Component {
   // not supposed to be displayed. This avoids using a render statement that
   // often returns *nothing.
   render() {
-    if (this.state.showCallout) {
+    if (this.state.hideCallout) {
+      return null;
+    } else {
       return (
         <div className="uitest-signincallout">
           <SignInCallout handleClose={this.closeCallout} />
         </div>
       );
-    } else {
-      return <div />;
     }
   }
 }

--- a/apps/src/code-studio/components/header/SignInCalloutWrapper.js
+++ b/apps/src/code-studio/components/header/SignInCalloutWrapper.js
@@ -4,12 +4,15 @@ import SignInCallout from './SignInCallout';
 
 const HideSignInCallout = 'hide_signin_callout';
 
-// The use of both session storage and cookies is to check for 1 day
-// and 1 session, and display the callout again only once BOTH have passed.
+// This class hold the display logic for the sign in callout, which prompts
+// students to log in in order to save their progress. The callout's freqency
+// is regulated here by the use of both session storage and cookies.
 export default class SignInCalloutWrapper extends React.Component {
   constructor(props) {
     super(props);
     this.closeCallout = this.closeCallout.bind(this);
+    // The use of both session storage and cookies is to check for 1 day
+    // and 1 session, and display the callout again only once BOTH have passed.
     this.state = {
       hideCallout:
         cookies.get(HideSignInCallout) === 'true' ||

--- a/apps/test/unit/code-studio/components/header/SignInCalloutTest.js
+++ b/apps/test/unit/code-studio/components/header/SignInCalloutTest.js
@@ -15,12 +15,17 @@ describe('ViewPopup', () => {
   it('hides when dismissed', () => {
     wrapper.setProps(CalloutProps); // force a re-render
     expect(wrapper.find('div.modal-backdrop').exists()).to.be.true;
-    wrapper.setProps(CookieProps); // should have now switched to false
+    wrapper.setState({showCallout: false});
     expect(wrapper.find('div.modal-backdrop').exists()).to.be.false;
   });
 
   it('hides when cookies are set', () => {
     wrapper.setProps(CookieProps);
     expect(wrapper.find('div.modal-backdrop').exists()).to.be.false;
+  });
+
+  it('displays the correct background darkness', () => {
+    wrapper.setState({showCallout: true});
+    expect(wrapper.html().includes('opacity:0.5')).to.be.true;
   });
 });

--- a/apps/test/unit/code-studio/components/header/SignInCalloutTest.js
+++ b/apps/test/unit/code-studio/components/header/SignInCalloutTest.js
@@ -1,10 +1,10 @@
 import React from 'react';
-import SignInCallout from '@cdo/apps/code-studio/components/header/SignInCallout';
+import SignInCalloutLogic from '@cdo/apps/code-studio/components/header/SignInCalloutLogic';
 import {shallow} from 'enzyme';
 import {expect} from '../../../../util/reconfiguredChai';
 import i18n from '@cdo/locale';
 
-const wrapper = shallow(<SignInCallout />);
+const wrapper = shallow(<SignInCalloutLogic />);
 
 describe('ViewPopup', () => {
   it('displays the correct background darkness', () => {
@@ -12,8 +12,11 @@ describe('ViewPopup', () => {
     expect(wrapper.html().includes('opacity:0.5')).to.be.true;
   });
 
-  it('shows the correct header and body text', () => {
+  it('shows the correct header', () => {
     expect(wrapper.html().includes(i18n.notSignedInHeader())).to.be.true;
-    expect(wrapper.html().includes(i18n.notSignedInBody())).to.be.true;
+  });
+
+  it('shows the correct image', () => {
+    expect(wrapper.html().includes('user-not-signed-in.png')).to.be.true;
   });
 });

--- a/apps/test/unit/code-studio/components/header/SignInCalloutTest.js
+++ b/apps/test/unit/code-studio/components/header/SignInCalloutTest.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import {SignInCallout as Callout} from '@cdo/apps/code-studio/components/header/SignInCallout';
 import {shallow} from 'enzyme';
-import {expect, assert} from '../../../util/reconfiguredChai';
+import {expect, assert} from '../../../../util/reconfiguredChai';
 
 const CalloutProps = {
   showCallout: true
@@ -12,15 +12,10 @@ const CookieProps = {
 const wrapper = shallow(<Callout />);
 
 describe('ViewPopup', () => {
-  it('renders a sign in reminder popup', () => {
-    assert.equal(wrapper.find('.modal-backdrop').length, 1);
-    assert.equal(wrapper.find('.modal-backdrop').at(0), 'link');
-    assert.equal(wrapper.find('.modal-backdrop').opacity, 0.5);
-  });
-
   it('hides when dismissed', () => {
     wrapper.setProps(CalloutProps); // force a re-render
     expect(wrapper.find('.modal-backdrop').exists()).to.be.true;
+    assert.equal(wrapper.find('.modal-backdrop').opacity, 0.5);
     wrapper.setProps({showCallout: false});
     expect(wrapper.find('.modal-backdrop').exists()).to.be.false;
   });

--- a/apps/test/unit/code-studio/components/header/SignInCalloutTest.js
+++ b/apps/test/unit/code-studio/components/header/SignInCalloutTest.js
@@ -1,7 +1,8 @@
 import React from 'react';
-import {assert} from '../../../util/reconfiguredChai';
 import {SignInCallout as Callout} from '@cdo/apps/code-studio/components/header/SignInCallout';
 import {shallow} from 'enzyme';
+
+var assert = require('assert');
 
 describe('ViewPopup', () => {
   it('renders a sign in reminder popup', () => {

--- a/apps/test/unit/code-studio/components/header/SignInCalloutTest.js
+++ b/apps/test/unit/code-studio/components/header/SignInCalloutTest.js
@@ -1,15 +1,32 @@
 import React from 'react';
 import {SignInCallout as Callout} from '@cdo/apps/code-studio/components/header/SignInCallout';
 import {shallow} from 'enzyme';
+import {expect, assert} from '../../../util/reconfiguredChai';
 
-var assert = require('assert');
+const CalloutProps = {
+  showCallout: true
+};
+const CookieProps = {
+  HideSignInCallout: true
+};
+const wrapper = shallow(<Callout />);
 
 describe('ViewPopup', () => {
   it('renders a sign in reminder popup', () => {
-    const wrapper = shallow(<Callout />);
-
     assert.equal(wrapper.find('.modal-backdrop').length, 1);
     assert.equal(wrapper.find('.modal-backdrop').at(0), 'link');
     assert.equal(wrapper.find('.modal-backdrop').opacity, 0.5);
+  });
+
+  it('hides when dismissed', () => {
+    wrapper.setProps(CalloutProps); // force a re-render
+    expect(wrapper.find('.modal-backdrop').exists()).to.be.true;
+    wrapper.setProps({showCallout: false});
+    expect(wrapper.find('.modal-backdrop').exists()).to.be.false;
+  });
+
+  it('hides when cookies are set', () => {
+    wrapper.setProps(CookieProps);
+    expect(wrapper.find('.modal-backdrop').exists()).to.be.false;
   });
 });

--- a/apps/test/unit/code-studio/components/header/SignInCalloutTest.js
+++ b/apps/test/unit/code-studio/components/header/SignInCalloutTest.js
@@ -1,14 +1,14 @@
 import React from 'react';
-import SignInCalloutLogic from '@cdo/apps/code-studio/components/header/SignInCalloutLogic';
+import SignInCalloutWrapper from '@cdo/apps/code-studio/components/header/SignInCalloutWrapper';
 import {shallow} from 'enzyme';
 import {expect} from '../../../../util/reconfiguredChai';
 import i18n from '@cdo/locale';
 
-const wrapper = shallow(<SignInCalloutLogic />);
+const wrapper = shallow(<SignInCalloutWrapper />);
 
 describe('ViewPopup', () => {
   it('displays the correct background darkness', () => {
-    wrapper.setState({showCallout: true});
+    wrapper.setState({hideCallout: false});
     expect(wrapper.html().includes('opacity:0.5')).to.be.true;
   });
 

--- a/apps/test/unit/code-studio/components/header/SignInCalloutTest.js
+++ b/apps/test/unit/code-studio/components/header/SignInCalloutTest.js
@@ -2,30 +2,18 @@ import React from 'react';
 import SignInCallout from '@cdo/apps/code-studio/components/header/SignInCallout';
 import {shallow} from 'enzyme';
 import {expect} from '../../../../util/reconfiguredChai';
+import i18n from '@cdo/locale';
 
-const CalloutProps = {
-  showCallout: true
-};
-const CookieProps = {
-  showCallout: false
-};
 const wrapper = shallow(<SignInCallout />);
 
 describe('ViewPopup', () => {
-  it('hides when dismissed', () => {
-    wrapper.setProps(CalloutProps); // force a re-render
-    expect(wrapper.find('div.modal-backdrop').exists()).to.be.true;
-    wrapper.setState({showCallout: false});
-    expect(wrapper.find('div.modal-backdrop').exists()).to.be.false;
-  });
-
-  it('hides when cookies are set', () => {
-    wrapper.setProps(CookieProps);
-    expect(wrapper.find('div.modal-backdrop').exists()).to.be.false;
-  });
-
   it('displays the correct background darkness', () => {
     wrapper.setState({showCallout: true});
     expect(wrapper.html().includes('opacity:0.5')).to.be.true;
+  });
+
+  it('shows the correct header and body text', () => {
+    expect(wrapper.html().includes(i18n.notSignedInHeader())).to.be.true;
+    expect(wrapper.html().includes(i18n.notSignedInBody())).to.be.true;
   });
 });

--- a/apps/test/unit/code-studio/components/header/SignInCalloutTest.js
+++ b/apps/test/unit/code-studio/components/header/SignInCalloutTest.js
@@ -1,27 +1,26 @@
 import React from 'react';
-import {SignInCallout as Callout} from '@cdo/apps/code-studio/components/header/SignInCallout';
+import SignInCallout from '@cdo/apps/code-studio/components/header/SignInCallout';
 import {shallow} from 'enzyme';
-import {expect, assert} from '../../../../util/reconfiguredChai';
+import {expect} from '../../../../util/reconfiguredChai';
 
 const CalloutProps = {
   showCallout: true
 };
 const CookieProps = {
-  HideSignInCallout: true
+  showCallout: false
 };
-const wrapper = shallow(<Callout />);
+const wrapper = shallow(<SignInCallout />);
 
 describe('ViewPopup', () => {
   it('hides when dismissed', () => {
     wrapper.setProps(CalloutProps); // force a re-render
-    expect(wrapper.find('.modal-backdrop').exists()).to.be.true;
-    assert.equal(wrapper.find('.modal-backdrop').opacity, 0.5);
-    wrapper.setProps({showCallout: false});
-    expect(wrapper.find('.modal-backdrop').exists()).to.be.false;
+    expect(wrapper.find('div.modal-backdrop').exists()).to.be.true;
+    wrapper.setProps(CookieProps); // should have now switched to false
+    expect(wrapper.find('div.modal-backdrop').exists()).to.be.false;
   });
 
   it('hides when cookies are set', () => {
     wrapper.setProps(CookieProps);
-    expect(wrapper.find('.modal-backdrop').exists()).to.be.false;
+    expect(wrapper.find('div.modal-backdrop').exists()).to.be.false;
   });
 });

--- a/apps/test/unit/code-studio/components/header/SignInCalloutTest.js
+++ b/apps/test/unit/code-studio/components/header/SignInCalloutTest.js
@@ -1,0 +1,14 @@
+import React from 'react';
+import {assert} from '../../../util/reconfiguredChai';
+import {SignInCallout as Callout} from '@cdo/apps/code-studio/components/header/SignInCallout';
+import {shallow} from 'enzyme';
+
+describe('ViewPopup', () => {
+  it('renders a sign in reminder popup', () => {
+    const wrapper = shallow(<Callout />);
+
+    assert.equal(wrapper.find('.modal-backdrop').length, 1);
+    assert.equal(wrapper.find('.modal-backdrop').at(0), 'link');
+    assert.equal(wrapper.find('.modal-backdrop').opacity, 0.5);
+  });
+});


### PR DESCRIPTION
This is the visual component for the Sign In reminder popup. 
It will appear attached to the header in code studio for CSF courses only, but this PR only represents the component without any of the attachment logic. 

The cookies and storage logic are built here, but will be tested explicitly in the next pr. 

Testing includes a test for the callout to render when its state says it should, and to be hidden otherwise. There is also a test to check that the background opacity is as-set at 0.5 instead of the default 0.8.

https://codedotorg.atlassian.net/browse/LP-1595

![image](https://user-images.githubusercontent.com/37230822/107422824-667ad580-6ad0-11eb-8812-3976e1e3196d.png)
