### PR TITLE
Unit Calendar: Script Editor Changes

### DIFF
--- a/apps/src/lib/levelbuilder/script-editor/ScriptEditor.jsx
+++ b/apps/src/lib/levelbuilder/script-editor/ScriptEditor.jsx
@@ -93,6 +93,7 @@ class ScriptEditor extends React.Component {
     hasCourse: PropTypes.bool,
     initialIsCourse: PropTypes.bool,
     initialShowCalendar: PropTypes.bool,
+    initialWeeklyInstructionalMinutes: PropTypes.number,
     isMigrated: PropTypes.bool,
 
     // from redux
@@ -117,6 +118,7 @@ class ScriptEditor extends React.Component {
       familyName: this.props.initialFamilyName,
       isCourse: this.props.initialIsCourse,
       showCalendar: this.props.initialShowCalendar,
+      weeklyInstructionalMinutes: this.props.initialWeeklyInstructionalMinutes,
       description: this.props.i18nData.description,
       studentDescription: this.props.i18nData.studentDescription,
       announcements: this.props.initialAnnouncements,
@@ -221,6 +223,8 @@ class ScriptEditor extends React.Component {
       family_name: this.state.familyName,
       is_course: this.state.isCourse,
       show_calendar: this.state.showCalendar,
+      weekly_instructional_minutes:
+        parseInt(this.state.weeklyInstructionalMinutes) || 0,
       description: this.state.description,
       student_description: this.state.studentDescription,
       announcements: JSON.stringify(this.state.announcements),
@@ -422,25 +426,6 @@ class ScriptEditor extends React.Component {
             />
             <HelpTip>
               <p>Check to enable text-to-speech for this script.</p>
-            </HelpTip>
-          </label>
-          <label>
-            Show Calendar
-            <input
-              type="checkbox"
-              checked={this.state.showCalendar}
-              style={styles.checkbox}
-              onChange={() =>
-                this.setState({showCalendar: !this.state.showCalendar})
-              }
-            />
-            <HelpTip>
-              <p>
-                Check to enable the calendar view on the Unit Overview Page. The
-                calendar displays each lesson and generally how long it will
-                take as well how many weeks the unit is expected to take in
-                general. (Actual calendar UI coming soon!)
-              </p>
             </HelpTip>
           </label>
           <label>
@@ -783,6 +768,47 @@ class ScriptEditor extends React.Component {
               }
             />
           </div>
+        </CollapsibleEditorSection>
+
+        <CollapsibleEditorSection title="Unit Calendar Settings">
+          <label>
+            Show Calendar
+            <input
+              type="checkbox"
+              checked={this.state.showCalendar}
+              style={styles.checkbox}
+              onChange={() =>
+                this.setState({showCalendar: !this.state.showCalendar})
+              }
+            />
+            <HelpTip>
+              <p>
+                Check to enable the calendar view on the Unit Overview Page. The
+                calendar displays each lesson and generally how long it will
+                take as well how many weeks the unit is expected to take in
+                general. (Actual calendar UI coming soon!)
+              </p>
+            </HelpTip>
+          </label>
+          <label>
+            Instructional Minutes Per Week
+            <HelpTip>
+              <p>
+                Number of instructional minutes to allocate to each week in the
+                calendar. Lessons will be divided across the days/weeks in the
+                calendar based on their length of time.
+              </p>
+            </HelpTip>
+            <input
+              value={this.state.weeklyInstructionalMinutes}
+              style={styles.input}
+              onChange={e =>
+                this.setState({
+                  weeklyInstructionalMinutes: e.target.value
+                })
+              }
+            />
+          </label>
         </CollapsibleEditorSection>
 
         <CollapsibleEditorSection title="Professional Learning Settings">

--- a/apps/src/lib/levelbuilder/script-editor/ScriptEditor.jsx
+++ b/apps/src/lib/levelbuilder/script-editor/ScriptEditor.jsx
@@ -238,8 +238,9 @@ class ScriptEditor extends React.Component {
       });
       return;
     } else if (
-      this.state.showCalendar &&
-      parseInt(this.state.weeklyInstructionalMinutes) <= 0
+      (this.state.showCalendar &&
+        parseInt(this.state.weeklyInstructionalMinutes) <= 0) ||
+      isNaN(parseInt(this.state.weeklyInstructionalMinutes))
     ) {
       this.setState({
         isSaving: false,

--- a/apps/src/lib/levelbuilder/script-editor/ScriptEditor.jsx
+++ b/apps/src/lib/levelbuilder/script-editor/ScriptEditor.jsx
@@ -264,9 +264,16 @@ class ScriptEditor extends React.Component {
 
     if (this.state.weeklyInstructionalMinutes) {
       dataToSave.weekly_instructional_minutes =
-        parseInt(this.state.weeklyInstructionalMinutes) || 0;
+        parseInt(this.state.weeklyInstructionalMinutes) || null;
     }
-
+    if (dataToSave.show_calendar && !dataToSave.weekly_instructional_minutes) {
+      this.setState({
+        isSaving: false,
+        error:
+          'Please provide instructional minutes per week in Unit Calendar Settings.'
+      });
+      return;
+    }
     if (this.state.hasImportedLessonDescriptions) {
       dataToSave.stage_descriptions = this.state.lessonDescriptions;
     }

--- a/apps/src/lib/levelbuilder/script-editor/ScriptEditor.jsx
+++ b/apps/src/lib/levelbuilder/script-editor/ScriptEditor.jsx
@@ -238,9 +238,9 @@ class ScriptEditor extends React.Component {
       });
       return;
     } else if (
-      (this.state.showCalendar &&
-        parseInt(this.state.weeklyInstructionalMinutes) <= 0) ||
-      isNaN(parseInt(this.state.weeklyInstructionalMinutes))
+      this.state.showCalendar &&
+      (parseInt(this.state.weeklyInstructionalMinutes) <= 0 ||
+        isNaN(parseInt(this.state.weeklyInstructionalMinutes)))
     ) {
       this.setState({
         isSaving: false,

--- a/apps/src/lib/levelbuilder/script-editor/ScriptEditor.jsx
+++ b/apps/src/lib/levelbuilder/script-editor/ScriptEditor.jsx
@@ -118,7 +118,8 @@ class ScriptEditor extends React.Component {
       familyName: this.props.initialFamilyName,
       isCourse: this.props.initialIsCourse,
       showCalendar: this.props.initialShowCalendar,
-      weeklyInstructionalMinutes: this.props.initialWeeklyInstructionalMinutes,
+      weeklyInstructionalMinutes:
+        this.props.initialWeeklyInstructionalMinutes || '',
       description: this.props.i18nData.description,
       studentDescription: this.props.i18nData.studentDescription,
       announcements: this.props.initialAnnouncements,
@@ -183,6 +184,17 @@ class ScriptEditor extends React.Component {
     this.setState({isCourse: !this.state.isCourse});
   };
 
+  handleShowCalendarChange = () => {
+    if (!this.state.showCalendar && !this.state.weeklyInstructionalMinutes) {
+      this.setState({
+        showCalendar: !this.state.showCalendar,
+        weeklyInstructionalMinutes: '225'
+      });
+    } else {
+      this.setState({showCalendar: !this.state.showCalendar});
+    }
+  };
+
   handleSave = (event, shouldCloseAfterSave) => {
     event.preventDefault();
 
@@ -218,11 +230,33 @@ class ScriptEditor extends React.Component {
       shouldCloseAfterSave = false;
     }
 
+    if (this.state.showCalendar && !this.state.weeklyInstructionalMinutes) {
+      this.setState({
+        isSaving: false,
+        error:
+          'Please provide instructional minutes per week in Unit Calendar Settings.'
+      });
+      return;
+    } else if (
+      this.state.showCalendar &&
+      parseInt(this.state.weeklyInstructionalMinutes) <= 0
+    ) {
+      this.setState({
+        isSaving: false,
+        error:
+          'Please provide a positive number of instructional minutes per week in Unit Calendar Settings.'
+      });
+      return;
+    }
+
     let dataToSave = {
       name: this.props.name,
       family_name: this.state.familyName,
       is_course: this.state.isCourse,
       show_calendar: this.state.showCalendar,
+      weekly_instructional_minutes: parseInt(
+        this.state.weeklyInstructionalMinutes
+      ),
       description: this.state.description,
       student_description: this.state.studentDescription,
       announcements: JSON.stringify(this.state.announcements),
@@ -262,18 +296,6 @@ class ScriptEditor extends React.Component {
       is_migrated: this.props.isMigrated
     };
 
-    if (this.state.weeklyInstructionalMinutes) {
-      dataToSave.weekly_instructional_minutes =
-        parseInt(this.state.weeklyInstructionalMinutes) || null;
-    }
-    if (dataToSave.show_calendar && !dataToSave.weekly_instructional_minutes) {
-      this.setState({
-        isSaving: false,
-        error:
-          'Please provide instructional minutes per week in Unit Calendar Settings.'
-      });
-      return;
-    }
     if (this.state.hasImportedLessonDescriptions) {
       dataToSave.stage_descriptions = this.state.lessonDescriptions;
     }
@@ -779,47 +801,46 @@ class ScriptEditor extends React.Component {
             />
           </div>
         </CollapsibleEditorSection>
-
-        <CollapsibleEditorSection title="Unit Calendar Settings">
-          <label>
-            Show Calendar
-            <input
-              type="checkbox"
-              checked={this.state.showCalendar}
-              style={styles.checkbox}
-              onChange={() =>
-                this.setState({showCalendar: !this.state.showCalendar})
-              }
-            />
-            <HelpTip>
-              <p>
-                Check to enable the calendar view on the Unit Overview Page. The
-                calendar displays each lesson and generally how long it will
-                take as well how many weeks the unit is expected to take in
-                general. (Actual calendar UI coming soon!)
-              </p>
-            </HelpTip>
-          </label>
-          <label>
-            Instructional Minutes Per Week
-            <HelpTip>
-              <p>
-                Number of instructional minutes to allocate to each week in the
-                calendar. Lessons will be divided across the days/weeks in the
-                calendar based on their length of time.
-              </p>
-            </HelpTip>
-            <input
-              value={this.state.weeklyInstructionalMinutes}
-              style={styles.input}
-              onChange={e =>
-                this.setState({
-                  weeklyInstructionalMinutes: e.target.value
-                })
-              }
-            />
-          </label>
-        </CollapsibleEditorSection>
+        {this.props.isMigrated && (
+          <CollapsibleEditorSection title="Unit Calendar Settings">
+            <label>
+              Show Calendar
+              <input
+                type="checkbox"
+                checked={this.state.showCalendar}
+                style={styles.checkbox}
+                onChange={this.handleShowCalendarChange}
+              />
+              <HelpTip>
+                <p>
+                  Check to enable the calendar view on the Unit Overview Page.
+                  The calendar displays each lesson and generally how long it
+                  will take as well how many weeks the unit is expected to take
+                  in general. (Actual calendar UI coming soon!)
+                </p>
+              </HelpTip>
+            </label>
+            <label>
+              Instructional Minutes Per Week
+              <HelpTip>
+                <p>
+                  Number of instructional minutes to allocate to each week in
+                  the calendar. Lessons will be divided across the days/weeks in
+                  the calendar based on their length of time.
+                </p>
+              </HelpTip>
+              <input
+                value={this.state.weeklyInstructionalMinutes}
+                style={styles.input}
+                onChange={e =>
+                  this.setState({
+                    weeklyInstructionalMinutes: e.target.value
+                  })
+                }
+              />
+            </label>
+          </CollapsibleEditorSection>
+        )}
 
         <CollapsibleEditorSection title="Professional Learning Settings">
           {this.props.isLevelbuilder && (

--- a/apps/src/lib/levelbuilder/script-editor/ScriptEditor.jsx
+++ b/apps/src/lib/levelbuilder/script-editor/ScriptEditor.jsx
@@ -223,8 +223,6 @@ class ScriptEditor extends React.Component {
       family_name: this.state.familyName,
       is_course: this.state.isCourse,
       show_calendar: this.state.showCalendar,
-      weekly_instructional_minutes:
-        parseInt(this.state.weeklyInstructionalMinutes) || 0,
       description: this.state.description,
       student_description: this.state.studentDescription,
       announcements: JSON.stringify(this.state.announcements),
@@ -263,6 +261,11 @@ class ScriptEditor extends React.Component {
       resourceTypes: this.state.teacherResources.map(resource => resource.type),
       is_migrated: this.props.isMigrated
     };
+
+    if (this.state.weeklyInstructionalMinutes) {
+      dataToSave.weekly_instructional_minutes =
+        parseInt(this.state.weeklyInstructionalMinutes) || 0;
+    }
 
     if (this.state.hasImportedLessonDescriptions) {
       dataToSave.stage_descriptions = this.state.lessonDescriptions;

--- a/apps/src/sites/studio/pages/scripts/edit.js
+++ b/apps/src/sites/studio/pages/scripts/edit.js
@@ -74,6 +74,9 @@ export default function initPage(scriptEditorData) {
         initialIsCourse={scriptData.is_course}
         hasCourse={scriptEditorData.has_course}
         initialShowCalendar={scriptData.showCalendar}
+        initialWeeklyInstructionalMinutes={
+          scriptData.weeklyInstructionalMinutes
+        }
         isMigrated={scriptData.is_migrated}
       />
     </Provider>,

--- a/apps/test/unit/lib/levelbuilder/script-editor/ScriptEditorTest.jsx
+++ b/apps/test/unit/lib/levelbuilder/script-editor/ScriptEditorTest.jsx
@@ -87,11 +87,11 @@ describe('ScriptEditor', () => {
     it('uses old script editor for non migrated script', () => {
       const wrapper = createWrapper({initialHidden: false});
 
-      expect(wrapper.find('input').length).to.equal(24);
-      expect(wrapper.find('input[type="checkbox"]').length).to.equal(11);
+      expect(wrapper.find('input').length).to.equal(22);
+      expect(wrapper.find('input[type="checkbox"]').length).to.equal(10);
       expect(wrapper.find('textarea').length).to.equal(3);
       expect(wrapper.find('select').length).to.equal(5);
-      expect(wrapper.find('CollapsibleEditorSection').length).to.equal(9);
+      expect(wrapper.find('CollapsibleEditorSection').length).to.equal(8);
       expect(wrapper.find('SaveBar').length).to.equal(1);
 
       expect(wrapper.find('UnitCard').length).to.equal(0);
@@ -281,6 +281,79 @@ describe('ScriptEditor', () => {
       expect(wrapper.find('.saveBar').find('FontAwesome').length).to.equal(0);
       expect(
         wrapper.find('.saveBar').contains('Error Saving: There was an error')
+      ).to.be.true;
+
+      server.restore();
+    });
+
+    it('shows error when showCalendar is true and weeklyInstructionalMinutes not provided', () => {
+      const wrapper = createWrapper({initialShowCalendar: true});
+      const scriptEditor = wrapper.find('ScriptEditor');
+
+      let returnData = 'There was an error';
+      let server = sinon.fakeServer.create();
+      server.respondWith('PUT', `/s/1`, [
+        404,
+        {'Content-Type': 'application/json'},
+        returnData
+      ]);
+
+      const saveBar = wrapper.find('SaveBar');
+
+      const saveAndKeepEditingButton = saveBar.find('button').at(0);
+      expect(saveAndKeepEditingButton.contains('Save and Keep Editing')).to.be
+        .true;
+      saveAndKeepEditingButton.simulate('click');
+
+      expect(scriptEditor.state().isSaving).to.equal(false);
+      expect(scriptEditor.state().error).to.equal(
+        'Please provide instructional minutes per week in Unit Calendar Settings.'
+      );
+
+      expect(
+        wrapper
+          .find('.saveBar')
+          .contains(
+            'Error Saving: Please provide instructional minutes per week in Unit Calendar Settings.'
+          )
+      ).to.be.true;
+
+      server.restore();
+    });
+
+    it('shows error when showCalendar is true and weeklyInstructionalMinutes is invalid', () => {
+      const wrapper = createWrapper({
+        initialShowCalendar: true,
+        initialWeeklyInstructionalMinutes: -100
+      });
+      const scriptEditor = wrapper.find('ScriptEditor');
+
+      let returnData = 'There was an error';
+      let server = sinon.fakeServer.create();
+      server.respondWith('PUT', `/s/1`, [
+        404,
+        {'Content-Type': 'application/json'},
+        returnData
+      ]);
+
+      const saveBar = wrapper.find('SaveBar');
+
+      const saveAndKeepEditingButton = saveBar.find('button').at(0);
+      expect(saveAndKeepEditingButton.contains('Save and Keep Editing')).to.be
+        .true;
+      saveAndKeepEditingButton.simulate('click');
+
+      expect(scriptEditor.state().isSaving).to.equal(false);
+      expect(scriptEditor.state().error).to.equal(
+        'Please provide a positive number of instructional minutes per week in Unit Calendar Settings.'
+      );
+
+      expect(
+        wrapper
+          .find('.saveBar')
+          .contains(
+            'Error Saving: Please provide a positive number of instructional minutes per week in Unit Calendar Settings.'
+          )
       ).to.be.true;
 
       server.restore();

--- a/apps/test/unit/lib/levelbuilder/script-editor/ScriptEditorTest.jsx
+++ b/apps/test/unit/lib/levelbuilder/script-editor/ScriptEditorTest.jsx
@@ -87,11 +87,11 @@ describe('ScriptEditor', () => {
     it('uses old script editor for non migrated script', () => {
       const wrapper = createWrapper({initialHidden: false});
 
-      expect(wrapper.find('input').length).to.equal(23);
+      expect(wrapper.find('input').length).to.equal(24);
       expect(wrapper.find('input[type="checkbox"]').length).to.equal(11);
       expect(wrapper.find('textarea').length).to.equal(3);
       expect(wrapper.find('select').length).to.equal(5);
-      expect(wrapper.find('CollapsibleEditorSection').length).to.equal(8);
+      expect(wrapper.find('CollapsibleEditorSection').length).to.equal(9);
       expect(wrapper.find('SaveBar').length).to.equal(1);
 
       expect(wrapper.find('UnitCard').length).to.equal(0);
@@ -101,11 +101,11 @@ describe('ScriptEditor', () => {
     it('uses new script editor for migrated script', () => {
       const wrapper = createWrapper({initialHidden: false, isMigrated: true});
 
-      expect(wrapper.find('input').length).to.equal(23);
+      expect(wrapper.find('input').length).to.equal(24);
       expect(wrapper.find('input[type="checkbox"]').length).to.equal(11);
       expect(wrapper.find('textarea').length).to.equal(4);
       expect(wrapper.find('select').length).to.equal(5);
-      expect(wrapper.find('CollapsibleEditorSection').length).to.equal(8);
+      expect(wrapper.find('CollapsibleEditorSection').length).to.equal(9);
       expect(wrapper.find('SaveBar').length).to.equal(1);
 
       expect(wrapper.find('UnitCard').length).to.equal(1);

--- a/dashboard/app/controllers/scripts_controller.rb
+++ b/dashboard/app/controllers/scripts_controller.rb
@@ -199,6 +199,7 @@ class ScriptsController < ApplicationController
       :is_stable,
       :is_course,
       :show_calendar,
+      :weekly_instructional_minutes,
       :is_migrated,
       :announcements,
       :pilot_experiment,

--- a/dashboard/app/models/script.rb
+++ b/dashboard/app/models/script.rb
@@ -1368,7 +1368,7 @@ class Script < ApplicationRecord
       background: background,
       is_migrated: is_migrated?,
       scriptPath: script_path(self),
-      showCalendar: show_calendar,
+      showCalendar: is_migrated ? show_calendar : false, #prevent calendar from showing for non-migrated scripts for now
       weeklyInstructionalMinutes: weekly_instructional_minutes
     }
 

--- a/dashboard/app/models/script.rb
+++ b/dashboard/app/models/script.rb
@@ -190,6 +190,7 @@ class Script < ApplicationRecord
     is_course
     background
     show_calendar
+    weekly_instructional_minutes
     is_migrated
   )
 
@@ -1367,7 +1368,8 @@ class Script < ApplicationRecord
       background: background,
       is_migrated: is_migrated?,
       scriptPath: script_path(self),
-      showCalendar: show_calendar
+      showCalendar: show_calendar,
+      weeklyInstructionalMinutes: weekly_instructional_minutes
     }
 
     #TODO: lessons should be summarized through lesson groups in the future
@@ -1552,6 +1554,7 @@ class Script < ApplicationRecord
       :editor_experiment,
       :curriculum_umbrella,
       :background,
+      :weekly_instructional_minutes,
     ]
     boolean_keys = [
       :has_verified_resources,

--- a/dashboard/test/models/script_test.rb
+++ b/dashboard/test/models/script_test.rb
@@ -968,12 +968,20 @@ class ScriptTest < ActiveSupport::TestCase
   test 'summarize includes show_calendar' do
     script = create(:script, name: 'calendar-script')
 
+    script.is_migrated = true
     script.show_calendar = true
     assert script.show_calendar
     summary = script.summarize
     assert summary[:showCalendar]
 
+    script.is_migrated = true
     script.show_calendar = false
+    refute script.show_calendar
+    summary = script.summarize
+    refute summary[:showCalendar]
+
+    script.is_migrated = false
+    script.show_calendar = true
     refute script.show_calendar
     summary = script.summarize
     refute summary[:showCalendar]

--- a/dashboard/test/models/script_test.rb
+++ b/dashboard/test/models/script_test.rb
@@ -982,7 +982,6 @@ class ScriptTest < ActiveSupport::TestCase
 
     script.is_migrated = false
     script.show_calendar = true
-    refute script.show_calendar
     summary = script.summarize
     refute summary[:showCalendar]
   end


### PR DESCRIPTION
Adds a section to the script editor for the unit calendar settings. Also adds weekly_instructional_minutes as a property on scripts.
<img width="1050" alt="Screen Shot 2021-02-08 at 2 52 52 PM" src="https://user-images.githubusercontent.com/17147070/107291631-5524c100-6a1d-11eb-93b6-cde4a7429101.png">
<img width="1440" alt="Screen Shot 2021-02-08 at 2 53 12 PM" src="https://user-images.githubusercontent.com/17147070/107291672-61108300-6a1d-11eb-9cef-dd7bcee37027.png">
<img width="1440" alt="Screen Shot 2021-02-08 at 2 53 28 PM" src="https://user-images.githubusercontent.com/17147070/107291694-6968be00-6a1d-11eb-8878-1318cb90ee60.png">


<!-- ### Background -->
<!-- ### Privacy -->
<!--
1.	Does the Project involve the collection, use or sharing of new Personal Data?

2.	Does the Project involve a new or changed use or sharing of existing Personal Data?
-->
<!-- ### Security -->
<!--
Link to Jira Task where sensitive security issues are discussed privately.
-->
<!-- ### Caching -->
<!-- ### Deployment strategy -->
<!-- ### Future work -->

## Links

<!--
  Any relevant links to external resources; ie, specification documents, jira
  items, related PRs, honeybadger errors, etc
-->

- [spec](https://docs.google.com/document/d/1Iu7CV37KA6jmW6jRW-gDn-6KgzcHE80amLlnR8vt9I0/edit)
- [jira](https://codedotorg.atlassian.net/browse/PLAT-243)

## Testing story

<!--
  Does your change include appropriate tests?

  If so, please describe how the tests included in this PR are sufficient

  If not, please explain why this change does not need to be tested.
-->

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
