### PR TITLE
Revert "CSS updates for user menu button"

### DIFF
--- a/dashboard/app/assets/stylesheets/application.scss
+++ b/dashboard/app/assets/stylesheets/application.scss
@@ -284,7 +284,7 @@ img.video_thumbnail {
     }
   }
 
-  .user_menu, .create_menu {
+  .create_menu {
     box-shadow: none;
     // button:active in this file uses !important for a styling scheme that doesn't
     // match this button. We use !important here to override that scheme for only this

--- a/shared/css/user-menu.scss
+++ b/shared/css/user-menu.scss
@@ -53,8 +53,6 @@
     text-align: left;
     white-space: nowrap;
     padding: 0;
-    display: flex;
-    flex-direction: column;
 
     .display_name {
       font-family: $gotham-bold;


### PR DESCRIPTION
Reverts code-dot-org/code-dot-org#38933

Reverting because of a bug found in an Eyes test, where Minecraft styling is overriding nav bar styling