### PR TITLE
Allow markdown formatting for unit descriptions on the course overview page

### DIFF
--- a/apps/src/templates/courseOverview/CourseScript.js
+++ b/apps/src/templates/courseOverview/CourseScript.js
@@ -16,6 +16,7 @@ import {
 } from '@cdo/apps/code-studio/hiddenStageRedux';
 import {sectionsForDropdown} from '@cdo/apps/templates/teacherDashboard/teacherSectionsRedux';
 import firehoseClient from '@cdo/apps/lib/util/firehose';
+import SafeMarkdown from '@cdo/apps/templates/SafeMarkdown';
 
 const styles = {
   main: {
@@ -137,7 +138,9 @@ class CourseScript extends Component {
       >
         <div style={styles.content}>
           <div style={styles.title}>{title}</div>
-          <div style={styles.description}>{description}</div>
+          <div style={styles.description}>
+            <SafeMarkdown markdown={description} />
+          </div>
           <span style={styles.flex}>
             <Button
               __useDeprecatedTag


### PR DESCRIPTION
Noticed this during the discussion about how AI/ML shows up. The edit page has a markdown preview and the markdown works on the unit page, so this is just making that behavior consistent.

Before (I added the last sentence locally):
![Screen Shot 2021-02-09 at 10 32 57 AM](https://user-images.githubusercontent.com/46464143/107410636-6b388d00-6ac2-11eb-83c3-d317e270aabb.png)

After:
![Screen Shot 2021-02-09 at 10 32 26 AM](https://user-images.githubusercontent.com/46464143/107410644-6e337d80-6ac2-11eb-8db1-dbf4c89231d2.png)

<!-- ### Background -->
<!-- ### Privacy -->
<!--
1.	Does the Project involve the collection, use or sharing of new Personal Data?

2.	Does the Project involve a new or changed use or sharing of existing Personal Data?
-->
<!-- ### Security -->
<!--
Link to Jira Task where sensitive security issues are discussed privately.
-->
<!-- ### Caching -->
<!-- ### Deployment strategy -->
<!-- ### Future work -->

## Links

<!--
  Any relevant links to external resources; ie, specification documents, jira
  items, related PRs, honeybadger errors, etc
-->

- [spec]()
- [jira]()

## Testing story

<!--
  Does your change include appropriate tests?

  If so, please describe how the tests included in this PR are sufficient

  If not, please explain why this change does not need to be tested.
-->

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
