### PR TITLE
Screen reader accessibility for Projects header

### DIFF
--- a/apps/src/code-studio/components/header/EditableProjectName.jsx
+++ b/apps/src/code-studio/components/header/EditableProjectName.jsx
@@ -13,10 +13,17 @@ import {
 import NameFailureDialog from '../NameFailureDialog';
 import NameFailureError from '../../NameFailureError';
 
-const styles = {
+export const styles = {
   buttonWrapper: {
     float: 'left',
     display: 'flex'
+  },
+  buttonSpacing: {
+    marginTop: 0,
+    marginBottom: 0,
+    marginLeft: 10,
+    marginRight: 0,
+    boxShadow: 'none'
   }
 };
 
@@ -29,18 +36,20 @@ class UnconnectedDisplayProjectName extends React.Component {
   render() {
     return (
       <div style={styles.buttonWrapper}>
-        <div className="project_name_wrapper header_text">
+        <div className="project_name_wrapper header_text" tabIndex={0}>
           <div className="project_name header_text">
             {this.props.projectName}
           </div>
           <ProjectUpdatedAt />
         </div>
-        <div
+        <button
+          type="button"
           className="project_edit header_button header_button_light"
+          style={styles.buttonSpacing}
           onClick={this.props.beginEdit}
         >
           {i18n.rename()}
-        </div>
+        </button>
       </div>
     );
   }
@@ -113,13 +122,15 @@ class UnconnectedEditProjectName extends React.Component {
             }}
           />
         </div>
-        <div
+        <button
+          type="button"
           className="project_save header_button header_button_light"
           onClick={this.saveNameChange}
           disabled={this.state.savingName}
+          style={styles.buttonSpacing}
         >
           {i18n.save()}
-        </div>
+        </button>
         <NameFailureDialog
           flaggedText={this.props.projectNameFailure}
           isOpen={!!this.props.projectNameFailure}

--- a/apps/src/code-studio/components/header/EditableProjectName.jsx
+++ b/apps/src/code-studio/components/header/EditableProjectName.jsx
@@ -44,7 +44,7 @@ class UnconnectedDisplayProjectName extends React.Component {
         </div>
         <button
           type="button"
-          className="project_edit header_button header_button_light"
+          className="project_edit header_button header_button_light no-mc"
           style={styles.buttonSpacing}
           onClick={this.props.beginEdit}
         >
@@ -124,7 +124,7 @@ class UnconnectedEditProjectName extends React.Component {
         </div>
         <button
           type="button"
-          className="project_save header_button header_button_light"
+          className="project_save header_button header_button_light no-mc"
           onClick={this.saveNameChange}
           disabled={this.state.savingName}
           style={styles.buttonSpacing}

--- a/apps/src/code-studio/components/header/ProjectExport.jsx
+++ b/apps/src/code-studio/components/header/ProjectExport.jsx
@@ -8,7 +8,7 @@ export default class ProjectExport extends React.Component {
     return (
       <button
         type="button"
-        className="project_share header_button header_button_light"
+        className="project_share header_button header_button_light no-mc"
         onClick={exportProject}
         style={styles.buttonSpacing}
       >

--- a/apps/src/code-studio/components/header/ProjectExport.jsx
+++ b/apps/src/code-studio/components/header/ProjectExport.jsx
@@ -1,16 +1,19 @@
 import React from 'react';
 import i18n from '@cdo/locale';
 import {exportProject} from '../../headerExport';
+import {styles} from './EditableProjectName';
 
 export default class ProjectExport extends React.Component {
   render() {
     return (
-      <div
+      <button
+        type="button"
         className="project_share header_button header_button_light"
         onClick={exportProject}
+        style={styles.buttonSpacing}
       >
         {i18n.export()}
-      </div>
+      </button>
     );
   }
 }

--- a/apps/src/code-studio/components/header/ProjectRemix.jsx
+++ b/apps/src/code-studio/components/header/ProjectRemix.jsx
@@ -42,7 +42,7 @@ class ProjectRemix extends React.Component {
   };
 
   render() {
-    let className = 'project_remix header_button';
+    let className = 'project_remix header_button no-mc';
     if (this.props.lightStyle) {
       className += ' header_button_light';
     }

--- a/apps/src/code-studio/components/header/ProjectRemix.jsx
+++ b/apps/src/code-studio/components/header/ProjectRemix.jsx
@@ -6,6 +6,7 @@ import {connect} from 'react-redux';
 import i18n from '@cdo/locale';
 import * as utils from '../../../utils';
 import {refreshProjectName} from '../../headerRedux';
+import {styles} from './EditableProjectName';
 
 class ProjectRemix extends React.Component {
   static propTypes = {
@@ -46,9 +47,14 @@ class ProjectRemix extends React.Component {
       className += ' header_button_light';
     }
     return (
-      <div className={className} onClick={this.remixProject}>
+      <button
+        type="button"
+        className={className}
+        onClick={this.remixProject}
+        style={styles.buttonSpacing}
+      >
         {i18n.remix()}
-      </div>
+      </button>
     );
   }
 }

--- a/apps/src/code-studio/components/header/ProjectShare.jsx
+++ b/apps/src/code-studio/components/header/ProjectShare.jsx
@@ -3,6 +3,7 @@
 import React from 'react';
 import i18n from '@cdo/locale';
 import {shareProject} from '../../headerShare';
+import {styles} from './EditableProjectName';
 
 export default class ProjectShare extends React.Component {
   shareProject = () => {
@@ -11,12 +12,14 @@ export default class ProjectShare extends React.Component {
 
   render() {
     return (
-      <div
+      <button
+        type="button"
         className="project_share header_button header_button_light"
         onClick={this.shareProject}
+        style={styles.buttonSpacing}
       >
         {i18n.share()}
-      </div>
+      </button>
     );
   }
 }

--- a/apps/src/code-studio/components/header/ProjectShare.jsx
+++ b/apps/src/code-studio/components/header/ProjectShare.jsx
@@ -14,7 +14,7 @@ export default class ProjectShare extends React.Component {
     return (
       <button
         type="button"
-        className="project_share header_button header_button_light"
+        className="project_share header_button header_button_light no-mc"
         onClick={this.shareProject}
         style={styles.buttonSpacing}
       >


### PR DESCRIPTION
Reverts code-dot-org/code-dot-org#38964

Reverting/Un-reverting with this PR: https://github.com/code-dot-org/code-dot-org/pull/38984 to minimize eyes changes in this space.

Added 'no-mc' so the headers buttons do not take on Minecraft styles