### PR TITLE
added a flag to disable large table stories by default

### DIFF
--- a/apps/src/templates/sectionProgress/progressTables/ProgressTableDetailView.story.jsx
+++ b/apps/src/templates/sectionProgress/progressTables/ProgressTableDetailView.story.jsx
@@ -1,75 +1,15 @@
-import React from 'react';
-import ProgressTableDetailView from '@cdo/apps/templates/sectionProgress/progressTables/ProgressTableDetailView';
-import {Provider} from 'react-redux';
-import {createStore, wrapTable} from '../sectionProgressTestHelpers';
+import {detailTableStories} from '@cdo/apps/templates/sectionProgress/progressTables/sectionProgressTableStoryBuilder';
 
+/**
+ * Stories for the SummaryView and DetailView are identical other than the
+ * actual component to render, so we build them using common code in
+ * `sectionProgressTableStoryBuilder`.
+ *
+ * Note: there is a flag in that file to enable additional stories that is
+ * disabled by default to prevent slowing down our test pipeline.
+ */
 export default storybook => {
-  storybook.storiesOf('SectionProgress/DetailView', module).addStoryTable([
-    {
-      name: 'Tiny section, small script',
-      story: () => {
-        const store = createStore(3, 10);
-        return wrapTable(
-          <Provider store={store}>
-            <ProgressTableDetailView />
-          </Provider>
-        );
-      }
-    },
-    {
-      name: 'Tiny section, large script',
-      story: () => {
-        const store = createStore(3, 30);
-        return wrapTable(
-          <Provider store={store}>
-            <ProgressTableDetailView />
-          </Provider>
-        );
-      }
-    },
-    {
-      name: 'Small section, small script',
-      story: () => {
-        const store = createStore(30, 10);
-        return wrapTable(
-          <Provider store={store}>
-            <ProgressTableDetailView />
-          </Provider>
-        );
-      }
-    },
-    {
-      name: 'Small section, large script',
-      story: () => {
-        const store = createStore(30, 30);
-        return wrapTable(
-          <Provider store={store}>
-            <ProgressTableDetailView />
-          </Provider>
-        );
-      }
-    },
-    {
-      name: 'Large section, small script',
-      story: () => {
-        const store = createStore(200, 10);
-        return wrapTable(
-          <Provider store={store}>
-            <ProgressTableDetailView />
-          </Provider>
-        );
-      }
-    },
-    {
-      name: 'Large section, large script',
-      story: () => {
-        const store = createStore(200, 30);
-        return wrapTable(
-          <Provider store={store}>
-            <ProgressTableDetailView />
-          </Provider>
-        );
-      }
-    }
-  ]);
+  storybook
+    .storiesOf('SectionProgress/DetailView', module)
+    .addStoryTable(detailTableStories);
 };

--- a/apps/src/templates/sectionProgress/progressTables/ProgressTableSummaryView.story.jsx
+++ b/apps/src/templates/sectionProgress/progressTables/ProgressTableSummaryView.story.jsx
@@ -1,75 +1,15 @@
-import React from 'react';
-import ProgressTableSummaryView from '@cdo/apps/templates/sectionProgress/progressTables/ProgressTableSummaryView';
-import {Provider} from 'react-redux';
-import {createStore, wrapTable} from '../sectionProgressTestHelpers';
+import {summaryTableStories} from '@cdo/apps/templates/sectionProgress/progressTables/sectionProgressTableStoryBuilder';
 
+/**
+ * Stories for the SummaryView and DetailView are identical other than the
+ * actual component to render, so we build them using common code in
+ * `sectionProgressTableStoryBuilder`.
+ *
+ * Note: there is a flag in that file to enable additional stories that is
+ * disabled by default to prevent slowing down our test pipeline.
+ */
 export default storybook => {
-  storybook.storiesOf('SectionProgress/SummaryView', module).addStoryTable([
-    {
-      name: 'Tiny section, small script',
-      story: () => {
-        const store = createStore(3, 10);
-        return wrapTable(
-          <Provider store={store}>
-            <ProgressTableSummaryView />
-          </Provider>
-        );
-      }
-    },
-    {
-      name: 'Tiny section, large script',
-      story: () => {
-        const store = createStore(3, 30);
-        return wrapTable(
-          <Provider store={store}>
-            <ProgressTableSummaryView />
-          </Provider>
-        );
-      }
-    },
-    {
-      name: 'Small section, small script',
-      story: () => {
-        const store = createStore(30, 10);
-        return wrapTable(
-          <Provider store={store}>
-            <ProgressTableSummaryView />
-          </Provider>
-        );
-      }
-    },
-    {
-      name: 'Small section, large script',
-      story: () => {
-        const store = createStore(30, 30);
-        return wrapTable(
-          <Provider store={store}>
-            <ProgressTableSummaryView />
-          </Provider>
-        );
-      }
-    },
-    {
-      name: 'Large section, small script',
-      story: () => {
-        const store = createStore(200, 10);
-        return wrapTable(
-          <Provider store={store}>
-            <ProgressTableSummaryView />
-          </Provider>
-        );
-      }
-    },
-    {
-      name: 'Large section, large script',
-      story: () => {
-        const store = createStore(200, 30);
-        return wrapTable(
-          <Provider store={store}>
-            <ProgressTableSummaryView />
-          </Provider>
-        );
-      }
-    }
-  ]);
+  storybook
+    .storiesOf('SectionProgress/SummaryView', module)
+    .addStoryTable(summaryTableStories);
 };

--- a/apps/src/templates/sectionProgress/progressTables/sectionProgressTableStoryBuilder.jsx
+++ b/apps/src/templates/sectionProgress/progressTables/sectionProgressTableStoryBuilder.jsx
@@ -1,0 +1,79 @@
+import React from 'react';
+import ProgressTableDetailView from '@cdo/apps/templates/sectionProgress/progressTables/ProgressTableDetailView';
+import ProgressTableSummaryView from '@cdo/apps/templates/sectionProgress/progressTables/ProgressTableSummaryView';
+import {Provider} from 'react-redux';
+import {createStore, wrapTable} from '../sectionProgressTestHelpers';
+
+/**
+ * The variety of stories here can be useful during development, but add
+ * unnecessary work to our unit tests and have proven to be potentially flaky
+ * due to timeout while processing so much data. Set this value to `true` to
+ * enable all the stories.
+ */
+const INCLUDE_LARGE_STORIES = true;
+
+function buildSmallStories(component) {
+  return [
+    {
+      name: 'Tiny section, small script',
+      story: () => {
+        const store = createStore(3, 10);
+        return wrapTable(<Provider store={store}>{component}</Provider>);
+      }
+    },
+    {
+      name: 'Tiny section, large script',
+      story: () => {
+        const store = createStore(3, 30);
+        return wrapTable(<Provider store={store}>{component}</Provider>);
+      }
+    }
+  ];
+}
+
+function buildLargeStories(component) {
+  return [
+    {
+      name: 'Small section, small script',
+      story: () => {
+        const store = createStore(30, 10);
+        return wrapTable(<Provider store={store}>{component}</Provider>);
+      }
+    },
+    {
+      name: 'Small section, large script',
+      story: () => {
+        const store = createStore(30, 30);
+        return wrapTable(<Provider store={store}>{component}</Provider>);
+      }
+    },
+    {
+      name: 'Large section, small script',
+      story: () => {
+        const store = createStore(200, 10);
+        return wrapTable(<Provider store={store}>{component}</Provider>);
+      }
+    },
+    {
+      name: 'Large section, large script',
+      story: () => {
+        const store = createStore(200, 30);
+        return wrapTable(<Provider store={store}>{component}</Provider>);
+      }
+    }
+  ];
+}
+
+export let summaryTableStories = buildSmallStories(
+  <ProgressTableSummaryView />
+);
+export let detailTableStories = buildSmallStories(<ProgressTableDetailView />);
+
+if (INCLUDE_LARGE_STORIES) {
+  summaryTableStories = summaryTableStories.concat(
+    buildLargeStories(<ProgressTableSummaryView />)
+  );
+  detailTableStories = detailTableStories.concat(
+    buildLargeStories(<ProgressTableDetailView />)
+  );
+}

--- a/apps/src/templates/sectionProgress/progressTables/sectionProgressTableStoryBuilder.jsx
+++ b/apps/src/templates/sectionProgress/progressTables/sectionProgressTableStoryBuilder.jsx
@@ -10,7 +10,7 @@ import {createStore, wrapTable} from '../sectionProgressTestHelpers';
  * due to timeout while processing so much data. Set this value to `true` to
  * enable all the stories.
  */
-const INCLUDE_LARGE_STORIES = true;
+const INCLUDE_LARGE_STORIES = false;
 
 function buildSmallStories(component) {
   return [


### PR DESCRIPTION
a DTS today failed the "render storybooks" unit test due to a timeout in a large table story. since all stories are rendered during that test in every build, i have added a flag that disables all but the two smallest stories for section progress tables by default, since the small ones are enough for unit testing purposes.

rather than add that flag to two separate, largely-duplicated story files, i consolidated it into a common "story builder" used by both tables.