### PR TITLE
Adding a URL allow-list for I18n String Tracking

### DIFF
--- a/lib/cdo/i18n_string_url_tracker.rb
+++ b/lib/cdo/i18n_string_url_tracker.rb
@@ -13,6 +13,8 @@ class I18nStringUrlTracker
   # @param source [String] Context about where the string lives e.g. 'ruby', 'maze', 'turtle', etc
   def log(string_key, url, source)
     return unless DCDO.get(I18N_STRING_TRACKING_DCDO_KEY, false)
+    # Skip URLs we are not interested in.
+    return unless allowed(url)
 
     url = normalize_url(url)
     return unless string_key && url && source
@@ -26,6 +28,29 @@ class I18nStringUrlTracker
 
   private
 
+  # Determines if this URL should be tracked. We want to filter URLs so we don't waste resources recording data we are
+  # not interested in.
+  def allowed(url)
+    return false unless url
+    parsed_url = URI(url)
+
+    # Include any non-studio.code.org URLs e.g. code.org, hourofcode.com, etc
+    return true unless parsed_url.host&.match(/.*studio\.code\.org.*/)
+
+    # Allow Applab/Weblab/Gamelab/Project based URLs
+    # Example: https://studio.code.org/projects/flappy/zjiufOp0h-9GS-DywevS0d3tKJyjdbQZZqZVaiuAjiU/view
+    return true if parsed_url.path&.match(/\/projects\/.*/)
+
+    # Allow script URLs
+    # Example: https://studio.code.org/s/dance-2019/stage/1/puzzle/1
+    return true if parsed_url.path&.match(/\/s\/.*/)
+
+    # Otherwise this URL should not be recorded
+    false
+  end
+
+  # Cleans up the given URL so the data we record is consistent. It also aggregates some URLs so we limit how many
+  # unique URLs we are recording.
   def normalize_url(url)
     return unless url
 
@@ -37,23 +62,48 @@ class I18nStringUrlTracker
     # strip anchor tags
     parsed_url.fragment = nil
 
+    # default to https
+    parsed_url.scheme = 'https'
+
     # Aggregate /projects/<project_type>/<project_id> URLs because each project URL will have a unique identifier
     # converts 'https://studio.code.org/projects/flappy/zjiufOp0h-9GS-DywevS0d3tKJyjdbQZZqZVaiuAjiU/view'
-    # into 'https://studio.code.org/projects/flappy/view'
+    # into 'https://studio.code.org/projects/flappy'
     # Regex explanation:
     # (.*\/projects\/) - The first major hint this this is a project URL is '/projects/' in the URL. The parenthesis around
-    # the expression make it a "capture group". Matches a string like "https://code.org/projects/"
-    # .*?\/ - This matches the project type and the '?' is included to make the matching is non-greedy. Otherwise it would
-    # match to the end of the URL past the project type. Matches a string like "maze/"
-    # .*?\/ - This matches the unique project ID. This is the part we want to omit. Matches a string like
-    # "zjiufOp0h-9GS-DywevS0d3tKJyjdbQZZqZVaiuAjiU/"
-    # (.*) - This matches the rest of the path. The parenthesis around the expression make it a "capture group". Matches
-    # a string like "view".
-    projects_regex = /(.*\/projects\/.*?\/).*?\/(.*)/
+    # the expression make it a "capture group". Matches a string like "projects/"
+    # .*?)\/ - This matches the project type and the '?' is included to make the matching is non-greedy. Otherwise it
+    # would match to the end of the URL past the project type. Matches a string like "maze"
+    # .* - This matches the unique project ID and everything after it. This is the part we want to omit. Matches a
+    # string like "zjiufOp0h-9GS-DywevS0d3tKJyjdbQZZqZVaiuAjiU/"
+    projects_regex = /(.*\/projects\/.*?)\/.*/
     parsed_url.path&.match(projects_regex) do |m|
       # capture group m[1] is the part of the URL before the project ID.
-      # capture group m[2] is the part of the URL after the project ID.
-      parsed_url.path = m[1] + m[2]
+      parsed_url.path = m[1]
+    end
+
+    # Aggregate /s/<script>/... URLs because we want to aggregate all strings by script rather than each level. The main
+    # motivation for this is to reduce the amount of data we are logging. There is a lot string reuse between levels
+    # so we can reduce how much data we log by preemptively aggregating it. Strings which are unique to a particular
+    # level usually have the specific level ID in the string key anyways.
+    # converts 'https://studio.code.org/s/dance-2019/stage/1/puzzle/1'
+    # into 'https://studio.code.org/s/dance-2019'
+    # Regex explanation:
+    # (.*\/s\/) - The first major hint this this is a script URL is '/s/' in the URL. The parenthesis around
+    # the expression make it a "capture group". Matches a string like "/s/"
+    # .*?) - This matches the script name and year, and the '?' is included to make the matching is non-greedy.
+    # Otherwise it would match to the end of the URL past the script year. Matches a string like "dance-2019"
+    # /\.* - This matches the specific level/puzzle/stage information. This is the part we want to omit. Matches a
+    # string like '/stage/1/puzzle/1'
+    script_regex = /(.*\/s\/.*?)\/.*/
+    parsed_url.path&.match(script_regex) do |m|
+      # capture group m[1] is the match in the first '()' group in the regex
+      parsed_url.path = m[1]
+    end
+
+    # Remove trailing '/' from the URL
+    parsed_url.path&.match(/(.*)\/$/) do |m|
+      # capture group m[1] is the match in the first '()' group in the regex
+      parsed_url.path = m[1]
     end
     parsed_url.to_s
   end

--- a/lib/cdo/i18n_string_url_tracker.rb
+++ b/lib/cdo/i18n_string_url_tracker.rb
@@ -28,6 +28,10 @@ class I18nStringUrlTracker
 
   private
 
+  # Paths where everything everything will after it will be aggregated.
+  # You can also add single pages which don't need aggregation as well e.g. /home
+  SIMPLE_PATHS = %w(home teacher_dashboard courses users).freeze
+
   # Determines if this URL should be tracked. We want to filter URLs so we don't waste resources recording data we are
   # not interested in.
   def allowed(url)
@@ -45,6 +49,11 @@ class I18nStringUrlTracker
     # Example: https://studio.code.org/s/dance-2019/stage/1/puzzle/1
     return true if parsed_url.path&.match(/\/s\/.*/)
 
+    # Allow URLs where the path starts with anything in SIMPLE_PATHS
+    # Example https://studio.code.org/home
+    SIMPLE_PATHS.each do |page|
+      return true if parsed_url.path&.match(/^\/#{page}.*/)
+    end
     # Otherwise this URL should not be recorded
     false
   end
@@ -105,6 +114,17 @@ class I18nStringUrlTracker
       # capture group m[1] is the match in the first '()' group in the regex
       parsed_url.path = m[1]
     end
+
+    # Simple aggregation for any paths which start with one of the given pages
+    # converts 'https://studio.code.org/teacher_dashboard/sections/3263468/login_info'
+    # int 'https://studio.code.org/teacher_dashboard'
+    SIMPLE_PATHS.each do |page|
+      parsed_url.path&.match(/^(\/#{page}).*/) do |m|
+        # capture group m[1] is the match in the first '()' group in the regex
+        parsed_url.path = m[1]
+      end
+    end
+
     parsed_url.to_s
   end
 end

--- a/lib/test/cdo/test_i18n_string_url_tracker.rb
+++ b/lib/test/cdo/test_i18n_string_url_tracker.rb
@@ -142,4 +142,35 @@ class TestI18nStringUrlTracker < Minitest::Test
     assert_equal(:i18n, @firehose_stream)
     assert_equal(expected_record, @firehose_record)
   end
+
+  def test_log_given_home_url_should_be_logged
+    test_record = {string_key: 'string.key', url: 'https://studio.code.org/home', source: 'test'}
+    I18nStringUrlTracker.instance.log(test_record[:string_key], test_record[:url], test_record[:source])
+    assert_equal(:i18n, @firehose_stream)
+    assert_equal(test_record, @firehose_record)
+  end
+
+  def test_log_given_teacher_dashboard_url_should_only_log_teacher_dashboard
+    test_record = {string_key: 'string.key', url: 'https://studio.code.org/teacher_dashboard/sections/3263468/login_info', source: 'test'}
+    expected_record = {string_key: 'string.key', url: 'https://studio.code.org/teacher_dashboard', source: 'test'}
+    I18nStringUrlTracker.instance.log(test_record[:string_key], test_record[:url], test_record[:source])
+    assert_equal(:i18n, @firehose_stream)
+    assert_equal(expected_record, @firehose_record)
+  end
+
+  def test_log_given_courses_url_should_only_log_courses
+    test_record = {string_key: 'string.key', url: 'https://studio.code.org/courses/csd-2020?section_id=3263468', source: 'test'}
+    expected_record = {string_key: 'string.key', url: 'https://studio.code.org/courses', source: 'test'}
+    I18nStringUrlTracker.instance.log(test_record[:string_key], test_record[:url], test_record[:source])
+    assert_equal(:i18n, @firehose_stream)
+    assert_equal(expected_record, @firehose_record)
+  end
+
+  def test_log_given_users_url_should_only_log_users
+    test_record = {string_key: 'string.key', url: 'https://studio.code.org/users/edit', source: 'test'}
+    expected_record = {string_key: 'string.key', url: 'https://studio.code.org/users', source: 'test'}
+    I18nStringUrlTracker.instance.log(test_record[:string_key], test_record[:url], test_record[:source])
+    assert_equal(:i18n, @firehose_stream)
+    assert_equal(expected_record, @firehose_record)
+  end
 end


### PR DESCRIPTION
When I18n String Tracking was first launched, the amount of data produced was too much. There were two main causes: high number of users generating data and too many unique URLs. This PR addresses the latter issue by adding significant aggregation and also adding an allow list of URLs so we aren't logging data for pages wer aren't interested in tracking yet.

Allow-list:
* Any non-studio URL e.g. code.org, hourofcode.com, etc
* Studio Project URLs which are used by Applab, Gamelab, etc
* Studio Script URLs such as DanceParty and Minecraft

Normalization:
* http -> https
* remove trailing `/`

Aggregation:
* Project URLs only log the project type and excludes the project's unique ID and the view of the page
```
https://studio.code.org/projects/flappy/zjiufOp0h-9GS-DywevS0d3tKJyjdbQZZqZVaiuAjiU/view
is logged as
https://studio.code.org/projects/flappy
```
* Script URLs only log the script name and year instead of each individual level
```
https://studio.code.org/s/dance-2019/stage/1/puzzle/1
is logged as
https://studio.code.org/s/dance-2019
```

## Links

- [spec](https://docs.google.com/document/d/1zbQNn83YOafVbAkxfc6MgBFPB8Em9EuBusXobaWiCbw/edit)
- [jira](https://codedotorg.atlassian.net/browse/FND-1291)

## Testing story
* Unit tests

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
