### PR TITLE
Java IDE: minor improvements

### DIFF
--- a/apps/Gruntfile.js
+++ b/apps/Gruntfile.js
@@ -352,7 +352,7 @@ describe('entry tests', () => {
             'build/package/css/foorm_editor.css',
             'style/code-studio/foorm_editor.scss'
           ],
-          ['build/package/css/javaIde.css', 'style/javaide/style.scss']
+          ['build/package/css/javaIde.css', 'style/javaIde/style.scss']
         ].concat(
           appsToBuild.map(function(app) {
             return [

--- a/apps/src/javaide/JavaConsole.jsx
+++ b/apps/src/javaide/JavaConsole.jsx
@@ -5,6 +5,7 @@ import {appendInputLog} from './javaIdeRedux';
 import CommandHistory from '@cdo/apps/lib/tools/jsdebugger/CommandHistory';
 import {KeyCodes} from '@cdo/apps/constants';
 import color from '@cdo/apps/util/color';
+import PaneHeader, {PaneSection} from '@cdo/apps/templates/PaneHeader';
 
 const style = {
   consoleStyle: {
@@ -12,8 +13,6 @@ const style = {
     color: color.white,
     height: '200px',
     overflowY: 'auto',
-    border: '1px solid #e7e8ea',
-    borderRadius: 15,
     padding: 5
   },
   consoleLogs: {
@@ -127,18 +126,24 @@ class JavaConsole extends React.Component {
 
   render() {
     return (
-      <div style={style.consoleStyle} ref={el => (this._consoleLogs = el)}>
-        <div style={style.consoleLogs}>{this.displayConsoleLogs()}</div>
-        <div style={style.consoleInputWrapper}>
-          <span style={style.consoleInputPrompt} onClick={this.focus}>
-            &gt;
-          </span>
-          <input
-            type="text"
-            spellCheck="false"
-            style={style.consoleInput}
-            onKeyDown={this.onInputKeyDown}
-          />
+      <div>
+        <PaneHeader hasFocus={true}>
+          <PaneSection>Console</PaneSection>
+        </PaneHeader>
+        <div style={style.consoleStyle} ref={el => (this._consoleLogs = el)}>
+          <div style={style.consoleLogs}>{this.displayConsoleLogs()}</div>
+          <div style={style.consoleInputWrapper}>
+            <span style={style.consoleInputPrompt} onClick={this.focus}>
+              &gt;
+            </span>
+            <input
+              type="text"
+              spellCheck="false"
+              style={style.consoleInput}
+              onKeyDown={this.onInputKeyDown}
+              aria-label="console input"
+            />
+          </div>
         </div>
       </div>
     );

--- a/apps/src/javaide/JavaEditor.jsx
+++ b/apps/src/javaide/JavaEditor.jsx
@@ -24,7 +24,6 @@ class JavaEditor extends React.Component {
   };
 
   onChange = newValue => {
-    console.log(newValue);
     this.props.setEditorText(newValue);
   };
 

--- a/apps/src/javaide/JavaEditor.jsx
+++ b/apps/src/javaide/JavaEditor.jsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import $ from 'jquery';
 import AceEditor from 'react-ace';
 import {connect} from 'react-redux';
 import {setEditorText} from './javaIdeRedux';
@@ -23,8 +24,17 @@ class JavaEditor extends React.Component {
   };
 
   onChange = newValue => {
+    console.log(newValue);
     this.props.setEditorText(newValue);
   };
+
+  componentDidMount() {
+    let textInput = $('.ace_text-input');
+    if (textInput) {
+      let textInputElement = textInput.first();
+      textInputElement.attr('aria-label', 'java editor panel');
+    }
+  }
 
   render() {
     return (

--- a/apps/src/javaide/JavaIdeView.jsx
+++ b/apps/src/javaide/JavaIdeView.jsx
@@ -103,7 +103,6 @@ class JavaIdeView extends React.Component {
                 type="button"
                 style={style.singleButton}
                 onClick={this.compile}
-                className="hover-pointer"
               >
                 <FontAwesome icon="cubes" className="fa-2x" />
                 <br />
@@ -113,7 +112,6 @@ class JavaIdeView extends React.Component {
                 type="button"
                 style={style.singleButton}
                 onClick={this.run}
-                className="hover-pointer"
               >
                 <FontAwesome icon="play" className="fa-2x" />
                 <br />

--- a/apps/src/sites/studio/pages/java_ide/index.js
+++ b/apps/src/sites/studio/pages/java_ide/index.js
@@ -4,7 +4,7 @@ import {Provider} from 'react-redux';
 import JavaIdeView from '@cdo/apps/javaide/JavaIdeView';
 import {getStore} from '@cdo/apps/code-studio/redux';
 import javaIde from '@cdo/apps/javaide/javaIdeRedux';
-import {registerReducers} from '@cdo/apps//redux';
+import {registerReducers} from '@cdo/apps/redux';
 
 $(document).ready(function() {
   registerReducers({javaIde});

--- a/apps/style/javaIde/style.scss
+++ b/apps/style/javaIde/style.scss
@@ -12,7 +12,3 @@ body {
 .main {
   padding: 0;
 }
-
-.hover-pointer:hover {
-  cursor: pointer;
-}


### PR DESCRIPTION
A few style/accessibility improvements to the java ide:
- add labels to the console and editor inputs
- add a header to the console
- fix gruntfile import for css file

Only visible change to the editor is the addition of the header to the console (and removal of the border that was previously around the console):
![Screen Shot 2021-02-10 at 4 23 01 PM](https://user-images.githubusercontent.com/33666587/107590130-47f20880-6bbc-11eb-801c-77f546fa9e62.png)


## Testing story
Tested locally. The Java IDE is only available for admins and levelbuilders currently.

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
