### PR TITLE
suppress firehose logging in unit tests

### DIFF
--- a/apps/src/lib/util/firehose.js
+++ b/apps/src/lib/util/firehose.js
@@ -375,12 +375,18 @@ function getSingleton() {
 }
 
 function putRecord(data, options) {
+  if (IN_UNIT_TEST) {
+    return;
+  }
   getSingleton().then(firehoseClient =>
     firehoseClient.putRecord(data, options)
   );
 }
 
 function putRecordBatch(data, options) {
+  if (IN_UNIT_TEST) {
+    return;
+  }
   getSingleton().then(firehoseClient =>
     firehoseClient.putRecordBatch(data, options)
   );


### PR DESCRIPTION
this is a simple QOL update to suppress firehose logging in unit tests to make it easier to find relevant test output in console logs.