### PR TITLE
Add 20MB max size to WebLab projects

### DIFF
--- a/apps/src/weblab/brambleHost.js
+++ b/apps/src/weblab/brambleHost.js
@@ -12,6 +12,9 @@ window.requirejs.config({baseUrl: BRAMBLE_BASE_URL});
 // This is needed to support jQuery binary downloads
 import '../assetManagement/download';
 
+// the max size in bytes for a bramble project -- 20 megabytes == 20971520 bytes
+const MAX_PROJECT_CAPACITY = 20971520;
+
 // the main Bramble object -- used to access file system
 let bramble_ = null;
 // the Bramble proxy object -- used to access methods on the Bramble UI frame
@@ -601,12 +604,16 @@ function load(Bramble) {
   bramble_ = Bramble;
 
   Bramble.load('#bramble', {
-    url: BRAMBLE_BASE_URL + '/index.html?disableExtensions=bramble-move-file',
+    url: BRAMBLE_BASE_URL + '/index.html',
     useLocationSearch: true,
     disableUIState: true,
+    capacity: MAX_PROJECT_CAPACITY,
     initialUIState: {
       theme: 'light-theme',
       readOnly: webLab_.getPageConstants().isReadOnlyWorkspace
+    },
+    extensions: {
+      disable: ['bramble-move-file']
     }
   });
 


### PR DESCRIPTION
When we upgraded Bramble in mid-January, there was a new feature we didn't notice before shipping that enforced a `capacity` on Bramble projects (added to upstream in [this PR](https://github.com/mozilla/brackets/pull/800)). The default capacity is 5MB, which is too small for WebLab projects, so we are increasing the capacity to 20MB as a starting point.

## Links

<!--
  Any relevant links to external resources; ie, specification documents, jira
  items, related PRs, honeybadger errors, etc
-->

- [STAR-1407](https://codedotorg.atlassian.net/browse/STAR-1407)

## Testing story

Tested manually.

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
