### PR TITLE
Move teacher only markdown component off redux

### DIFF
--- a/apps/src/templates/instructions/TeacherOnlyMarkdown.jsx
+++ b/apps/src/templates/instructions/TeacherOnlyMarkdown.jsx
@@ -1,10 +1,9 @@
 import PropTypes from 'prop-types';
-import React from 'react';
-import {connect} from 'react-redux';
+import React, {Component} from 'react';
+
 import SafeMarkdown from '@cdo/apps/templates/SafeMarkdown';
 import color from '../../util/color';
 import i18n from '@cdo/locale';
-import {ViewType} from '@cdo/apps/code-studio/viewAsRedux';
 
 const styles = {
   container: {
@@ -27,25 +26,25 @@ const styles = {
   }
 };
 
-const TeacherOnlyMarkdown = ({content}) => {
-  if (!content) {
-    return null;
-  }
+export default class TeacherOnlyMarkdown extends Component {
+  static propTypes = {
+    content: PropTypes.string
+  };
 
-  return (
-    <div style={styles.container}>
-      <div style={styles.header}>{i18n.forTeachersOnly()}</div>
-      <div style={styles.content}>
-        <SafeMarkdown markdown={content} />
+  render() {
+    const {content} = this.props;
+
+    if (!content) {
+      return null;
+    }
+
+    return (
+      <div style={styles.container}>
+        <div style={styles.header}>{i18n.forTeachersOnly()}</div>
+        <div style={styles.content}>
+          <SafeMarkdown markdown={content} />
+        </div>
       </div>
-    </div>
-  );
-};
-TeacherOnlyMarkdown.propTypes = {
-  content: PropTypes.string
-};
-
-export default connect(state => ({
-  content:
-    state.viewAs === ViewType.Teacher ? state.instructions.teacherMarkdown : ''
-}))(TeacherOnlyMarkdown);
+    );
+  }
+}

--- a/apps/src/templates/instructions/TopInstructions.jsx
+++ b/apps/src/templates/instructions/TopInstructions.jsx
@@ -384,13 +384,15 @@ class TopInstructions extends Component {
         element = this.refs.commentTab;
         break;
       case TabType.TEACHER_ONLY:
-        element = this.refs.teacherOnlyTab;
+        element = this.teacherOnlyTab;
         break;
     }
+    console.log(element);
     const maxNeededHeight =
       $(ReactDOM.findDOMNode(element)).outerHeight(true) +
       HEADER_HEIGHT +
       RESIZER_HEIGHT;
+    console.log(maxNeededHeight);
 
     if (maxHeight !== maxNeededHeight) {
       setInstructionsMaxHeightNeeded(maxNeededHeight);
@@ -762,12 +764,15 @@ class TopInstructions extends Component {
                 <div>
                   {this.props.hasContainedLevels && (
                     <ContainedLevelAnswer
-                      ref="teacherOnlyTab"
+                      ref={tab => (this.teacherOnlyTab = tab)}
                       hidden={this.state.tabSelected !== TabType.TEACHER_ONLY}
                     />
                   )}
                   {this.state.tabSelected === TabType.TEACHER_ONLY && (
-                    <TeacherOnlyMarkdown ref="teacherOnlyTab" />
+                    <TeacherOnlyMarkdown
+                      ref={tab => (this.teacherOnlyTab = tab)}
+                      content={this.props.teacherMarkdown}
+                    />
                   )}
                 </div>
               )}

--- a/apps/src/templates/instructions/TopInstructions.jsx
+++ b/apps/src/templates/instructions/TopInstructions.jsx
@@ -333,7 +333,7 @@ class TopInstructions extends Component {
    * via a call to handleHeightResize from HeightResizer.
    */
   getItemTop = () => {
-    return this.refs.topInstructions.getBoundingClientRect().top;
+    return this.topInstructions.getBoundingClientRect().top;
   };
 
   /**
@@ -375,13 +375,13 @@ class TopInstructions extends Component {
     let element;
     switch (this.state.tabSelected) {
       case TabType.RESOURCES:
-        element = this.refs.helpTab;
+        element = this.helpTab;
         break;
       case TabType.INSTRUCTIONS:
-        element = this.refs.instructions;
+        element = this.instructions;
         break;
       case TabType.COMMENTS:
-        element = this.refs.commentTab;
+        element = this.commentTab;
         break;
       case TabType.TEACHER_ONLY:
         element = this.teacherOnlyTab;
@@ -599,7 +599,11 @@ class TopInstructions extends Component {
       this.props.hasContainedLevels && $('#containedLevelAnswer0').length > 0;
 
     return (
-      <div style={mainStyle} className="editor-column" ref="topInstructions">
+      <div
+        style={mainStyle}
+        className="editor-column"
+        ref={ref => (this.topInstructions = ref)}
+      >
         <PaneHeader
           hasFocus={false}
           teacherOnly={teacherOnly}
@@ -701,11 +705,21 @@ class TopInstructions extends Component {
             ]}
             id="scroll-container"
           >
-            <div ref="instructions">
+            <div
+              ref={ref => {
+                if (ref) {
+                  this.instructions = ref;
+                }
+              }}
+            >
               {this.props.hasContainedLevels && (
                 <div>
                   <ContainedLevel
-                    ref="instructions"
+                    ref={ref => {
+                      if (ref) {
+                        this.instructions = ref;
+                      }
+                    }}
                     hidden={this.state.tabSelected !== TabType.INSTRUCTIONS}
                   />
                 </div>
@@ -714,7 +728,11 @@ class TopInstructions extends Component {
                 isCSF &&
                 this.state.tabSelected === TabType.INSTRUCTIONS && (
                   <InstructionsCSF
-                    ref="instructions"
+                    ref={ref => {
+                      if (ref) {
+                        this.instructions = ref;
+                      }
+                    }}
                     handleClickCollapser={this.handleClickCollapser}
                     adjustMaxNeededHeight={this.adjustMaxNeededHeight}
                     isEmbedView={this.props.isEmbedView}
@@ -728,7 +746,11 @@ class TopInstructions extends Component {
                 this.state.tabSelected === TabType.INSTRUCTIONS && (
                   <div>
                     <Instructions
-                      ref="instructions"
+                      ref={ref => {
+                        if (ref) {
+                          this.instructions = ref;
+                        }
+                      }}
                       longInstructions={this.props.longInstructions}
                       onResize={this.adjustMaxNeededHeight}
                       inTopPane
@@ -738,7 +760,7 @@ class TopInstructions extends Component {
             </div>
             {this.state.tabSelected === TabType.RESOURCES && (
               <HelpTabContents
-                ref="helpTab"
+                ref={ref => (this.helpTab = ref)}
                 videoData={videoData}
                 mapReference={this.props.mapReference}
                 referenceLinks={this.props.referenceLinks}
@@ -754,7 +776,7 @@ class TopInstructions extends Component {
                   !this.state.teacherViewingStudentWork
                 }
                 rubric={this.state.rubric}
-                ref="commentTab"
+                ref={ref => (this.commentTab = ref)}
                 latestFeedback={this.state.feedbacks}
                 token={this.state.token}
               />
@@ -764,13 +786,13 @@ class TopInstructions extends Component {
                 <div>
                   {this.props.hasContainedLevels && (
                     <ContainedLevelAnswer
-                      ref={tab => (this.teacherOnlyTab = tab)}
+                      ref={ref => (this.teacherOnlyTab = ref)}
                       hidden={this.state.tabSelected !== TabType.TEACHER_ONLY}
                     />
                   )}
                   {this.state.tabSelected === TabType.TEACHER_ONLY && (
                     <TeacherOnlyMarkdown
-                      ref={tab => (this.teacherOnlyTab = tab)}
+                      ref={ref => (this.teacherOnlyTab = ref)}
                       content={this.props.teacherMarkdown}
                     />
                   )}

--- a/apps/src/templates/instructions/TopInstructions.jsx
+++ b/apps/src/templates/instructions/TopInstructions.jsx
@@ -387,12 +387,10 @@ class TopInstructions extends Component {
         element = this.teacherOnlyTab;
         break;
     }
-    console.log(element);
     const maxNeededHeight =
       $(ReactDOM.findDOMNode(element)).outerHeight(true) +
       HEADER_HEIGHT +
       RESIZER_HEIGHT;
-    console.log(maxNeededHeight);
 
     if (maxHeight !== maxNeededHeight) {
       setInstructionsMaxHeightNeeded(maxNeededHeight);


### PR DESCRIPTION
As part of the work on the level details dialog, I've been trying to pull as much of the redux store out of the instructions area. A handful of components access the redux store for one or two variables and will never update them. For these, I'd like to pass the prop down normally.

In this change, TopInstructions already reads `teacherMarkdown` from the store, so this just passes this down as a prop to `TeacherOnlyMarkdown`. Teacher markdown is a static on the page, so this should be a safe change. 

## Testing story

Manual testing, ensured this wasn't used elsewhere, relying on existing tests as no behavior should change here.

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
