### PR TITLE
Separate out JSON parsing logic from Script seeding logic

### DIFF
--- a/dashboard/app/models/activity_section.rb
+++ b/dashboard/app/models/activity_section.rb
@@ -93,7 +93,7 @@ class ActivitySection < ApplicationRecord
   # If the attributes of this object alone aren't sufficient, and associated objects are needed, then data from
   # the seeding_keys of those objects should be included as well.
   # Ideally should correspond to a unique index for this model's table.
-  # See comments on ScriptSeed.seed_from_json for more context.
+  # See comments on ScriptSeed.seed_from_hash for more context.
   #
   # @param [ScriptSeed::SeedContext] seed_context - contains preloaded data to use when looking up associated objects
   # @return [Hash<String, String>] all information needed to uniquely identify this object across environments.

--- a/dashboard/app/models/lesson.rb
+++ b/dashboard/app/models/lesson.rb
@@ -522,7 +522,7 @@ class Lesson < ApplicationRecord
   # If the attributes of this object alone aren't sufficient, and associated objects are needed, then data from
   # the seeding_keys of those objects should be included as well.
   # Ideally should correspond to a unique index for this model's table.
-  # See comments on ScriptSeed.seed_from_json for more context.
+  # See comments on ScriptSeed.seed_from_hash for more context.
   #
   # @param [ScriptSeed::SeedContext] seed_context - contains preloaded data to use when looking up associated objects
   # @return [Hash<String, String] all information needed to uniquely identify this object across environments.

--- a/dashboard/app/models/lesson_activity.rb
+++ b/dashboard/app/models/lesson_activity.rb
@@ -83,7 +83,7 @@ class LessonActivity < ApplicationRecord
   # If the attributes of this object alone aren't sufficient, and associated objects are needed, then data from
   # the seeding_keys of those objects should be included as well.
   # Ideally should correspond to a unique index for this model's table.
-  # See comments on ScriptSeed.seed_from_json for more context.
+  # See comments on ScriptSeed.seed_from_hash for more context.
   #
   # @param [ScriptSeed::SeedContext] seed_context - contains preloaded data to use when looking up associated objects
   # @return [Hash<String, String>] all information needed to uniquely identify this object across environments.

--- a/dashboard/app/models/lesson_group.rb
+++ b/dashboard/app/models/lesson_group.rb
@@ -157,7 +157,7 @@ class LessonGroup < ApplicationRecord
   # If the attributes of this object alone aren't sufficient, and associated objects are needed, then data from
   # the seeding_keys of those objects should be included as well.
   # Ideally should correspond to a unique index for this model's table.
-  # See comments on ScriptSeed.seed_from_json for more context.
+  # See comments on ScriptSeed.seed_from_hash for more context.
   #
   # @param [ScriptSeed::SeedContext] seed_context - contains preloaded data to use when looking up associated objects
   # @return [Hash<String, String] all information needed to uniquely identify this object across environments.

--- a/dashboard/app/models/lessons_resource.rb
+++ b/dashboard/app/models/lessons_resource.rb
@@ -19,7 +19,7 @@ class LessonsResource < ApplicationRecord
   # If the attributes of this object alone aren't sufficient, and associated
   # objects are needed, then data from the seeding_keys of those objects should
   # be included as well. Ideally should correspond to a unique index for this
-  # model's table. See comments on ScriptSeed.seed_from_json for more context.
+  # model's table. See comments on ScriptSeed.seed_from_hash for more context.
   #
   # @param [ScriptSeed::SeedContext] seed_context - contains preloaded data to use when looking up associated objects
   # @return [Hash<String, String>] all information needed to uniquely identify this object across environments.

--- a/dashboard/app/models/lessons_vocabulary.rb
+++ b/dashboard/app/models/lessons_vocabulary.rb
@@ -19,7 +19,7 @@ class LessonsVocabulary < ApplicationRecord
   # If the attributes of this object alone aren't sufficient, and associated
   # objects are needed, then data from the seeding_keys of those objects should
   # be included as well. Ideally should correspond to a unique index for this
-  # model's table. See comments on ScriptSeed.seed_from_json for more context.
+  # model's table. See comments on ScriptSeed.seed_from_hash for more context.
   #
   # @param [ScriptSeed::SeedContext] seed_context - contains preloaded data to use when looking up associated objects
   # @return [Hash<String, String>] all information needed to uniquely identify this object across environments.

--- a/dashboard/app/models/levels_script_level.rb
+++ b/dashboard/app/models/levels_script_level.rb
@@ -23,7 +23,7 @@ class LevelsScriptLevel < ApplicationRecord
   # If the attributes of this object alone aren't sufficient, and associated objects are needed, then data from
   # the seeding_keys of those objects should be included as well.
   # Ideally should correspond to a unique index for this model's table.
-  # See comments on ScriptSeed.seed_from_json for more context.
+  # See comments on ScriptSeed.seed_from_hash for more context.
   #
   # @param [ScriptSeed::SeedContext] seed_context - contains preloaded data to use when looking up associated objects
   # @return [Hash<String, String] all information needed to uniquely identify this object across environments.

--- a/dashboard/app/models/resource.rb
+++ b/dashboard/app/models/resource.rb
@@ -53,7 +53,7 @@ class Resource < ApplicationRecord
   # If the attributes of this object alone aren't sufficient, and associated
   # objects are needed, then data from the seeding_keys of those objects should
   # be included as well. Ideally should correspond to a unique index for this
-  # model's table. See comments on ScriptSeed.seed_from_json for more context.
+  # model's table. See comments on ScriptSeed.seed_from_hash for more context.
   #
   # @param [ScriptSeed::SeedContext] _seed_context - contains preloaded data to use when looking up associated objects
   # @return [Hash<String, String>] all information needed to uniquely identify this object across environments.

--- a/dashboard/app/models/script.rb
+++ b/dashboard/app/models/script.rb
@@ -1793,7 +1793,7 @@ class Script < ApplicationRecord
   # If the attributes of this object alone aren't sufficient, and associated objects are needed, then data from
   # the seeding_keys of those objects should be included as well.
   # Ideally should correspond to a unique index for this model's table.
-  # See comments on ScriptSeed.seed_from_json for more context.
+  # See comments on ScriptSeed.seed_from_hash for more context.
   #
   # @param [ScriptSeed::SeedContext] seed_context - contains preloaded data to use when looking up associated objects
   # @return [Hash<String, String>] all information needed to uniquely identify this object across environments.

--- a/dashboard/app/models/script_level.rb
+++ b/dashboard/app/models/script_level.rb
@@ -641,7 +641,7 @@ class ScriptLevel < ApplicationRecord
   # If the attributes of this object alone aren't sufficient, and associated objects are needed, then data from
   # the seeding_keys of those objects should be included as well.
   # Ideally should correspond to a unique index for this model's table.
-  # See comments on ScriptSeed.seed_from_json for more context.
+  # See comments on ScriptSeed.seed_from_hash for more context.
   #
   # @param [ScriptSeed::SeedContext] seed_context - contains preloaded data to use when looking up associated objects
   # @param [boolean] use_existing_level_keys - If true, use existing information in the level_keys property if available

--- a/dashboard/app/models/vocabulary.rb
+++ b/dashboard/app/models/vocabulary.rb
@@ -27,7 +27,7 @@ class Vocabulary < ApplicationRecord
   # If the attributes of this object alone aren't sufficient, and associated
   # objects are needed, then data from the seeding_keys of those objects should
   # be included as well. Ideally should correspond to a unique index for this
-  # model's table. See comments on ScriptSeed.seed_from_json for more context.
+  # model's table. See comments on ScriptSeed.seed_from_hash for more context.
   #
   # @param [ScriptSeed::SeedContext] _seed_context - contains preloaded data to use when looking up associated objects
   # @return [Hash<String, String>] all information needed to uniquely identify this object across environments.

--- a/dashboard/lib/services/script_seed.rb
+++ b/dashboard/lib/services/script_seed.rb
@@ -89,7 +89,15 @@ module Services
       seed_from_json(File.read(file_or_path))
     end
 
-    # Creates / updates the objects in the database described by the input JSON.
+    # Convenience wrapper around seed_from_hash. Parses the given content as a json string and then seeds using it.
+    #
+    # @param [String] json_string
+    # @return [Script] the Script created/updated from seeding
+    def self.seed_from_json(json_string)
+      seed_from_hash(JSON.parse(json_string))
+    end
+
+    # Creates / updates the objects in the database described by the input hash.
     #
     # This method is responsible for Script objects and everything "under" them logically in the curriculum data
     # hierarchy. Currently (9/23/2020), this looks like:
@@ -129,26 +137,24 @@ module Services
     #
     # - We try to achieve both simplicity and performance.
     #
-    # @param [String] json_string - The input JSON to seed from.
+    # @param [Hash] data - The input data to seed from.
     # @return [Script] the Script created/updated from seeding
-    def self.seed_from_json(json_string)
+    def self.seed_from_hash(data)
+      script_data = data['script']
+      lesson_groups_data = data['lesson_groups']
+      lessons_data = data['lessons']
+      lesson_activities_data = data['lesson_activities']
+      activity_sections_data = data['activity_sections']
+      script_levels_data = data['script_levels']
+      levels_script_levels_data = data['levels_script_levels']
+      resources_data = data['resources']
+      lessons_resources_data = data['lessons_resources']
+      vocabularies_data = data['vocabularies']
+      lessons_vocabularies_data = data['lessons_vocabularies']
+      objectives_data = data['objectives']
+      seed_context = SeedContext.new
+
       Script.transaction do
-        data = JSON.parse(json_string)
-
-        script_data = data['script']
-        lesson_groups_data = data['lesson_groups']
-        lessons_data = data['lessons']
-        lesson_activities_data = data['lesson_activities']
-        activity_sections_data = data['activity_sections']
-        script_levels_data = data['script_levels']
-        levels_script_levels_data = data['levels_script_levels']
-        resources_data = data['resources']
-        lessons_resources_data = data['lessons_resources']
-        vocabularies_data = data['vocabularies']
-        lessons_vocabularies_data = data['lessons_vocabularies']
-        objectives_data = data['objectives']
-        seed_context = SeedContext.new
-
         # The order of the following import steps is important. If B belongs_to
         # A, then B holds an id field referring to A, and therefore A must be
         # imported before B. For example, LessonsResource belongs to both
@@ -160,9 +166,7 @@ module Services
         # Course version must be set before resources and vocabulary are imported. If the
         # script is in a unit group, we must wait and let the next seed step set
         # the course version on the unit group before resources and vocabulary can be imported.
-        if seed_context.script.is_course
-          CourseOffering.add_course_offering(seed_context.script)
-        end
+        CourseOffering.add_course_offering(seed_context.script) if seed_context.script.is_course
 
         seed_context.lesson_groups = import_lesson_groups(lesson_groups_data, seed_context)
         seed_context.lessons = import_lessons(lessons_data, seed_context)


### PR DESCRIPTION
Also be a bit more specific about exactly which operations we wrap in a transaction

## Testing story

I considered updating some (possibly all) of the places in https://github.com/code-dot-org/code-dot-org/blob/staging/dashboard/test/lib/services/script_seed_test.rb that are currently calling `seed_from_json` to instead call `seed_from_hash`, but it doesn't seem necessary. I'd be happy to do so if anyone thinks otherwise.

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
