### PR TITLE
Fix progress table student name overflow

### DIFF
--- a/apps/src/templates/sectionProgress/progressTables/ProgressTableContainer.jsx
+++ b/apps/src/templates/sectionProgress/progressTables/ProgressTableContainer.jsx
@@ -79,6 +79,9 @@ class ProgressTableContainer extends React.Component {
     this.contentView.header.scrollLeft = e.target.scrollLeft;
   }
 
+  // the student gutter is needed when there is a scroll bar at the bottom of the
+  // content section of the table so that the student list and content section
+  // are the same height vertically
   needsStudentGutter() {
     return (
       this.props.getTableWidth(this.props.scriptData.stages) >

--- a/apps/src/templates/sectionProgress/progressTables/progressTableStyles.scss
+++ b/apps/src/templates/sectionProgress/progressTables/progressTableStyles.scss
@@ -28,6 +28,7 @@ $content-view-width: $content-width - $student-list-width;
   .student-list {
     table {
       width: $student-list-width;
+      table-layout: fixed;
     }
     td,
     th {
@@ -37,6 +38,10 @@ $content-view-width: $content-width - $student-list-width;
     th {
       background-color: $table-header;
       color: $charcoal;
+    }
+    tr, td {
+      display: block;
+      width: 100%;
     }
   }
   .content-view {

--- a/apps/src/templates/sectionProgress/progressTables/progressTableStyles.scss
+++ b/apps/src/templates/sectionProgress/progressTables/progressTableStyles.scss
@@ -32,14 +32,13 @@ $content-view-width: $content-width - $student-list-width;
     }
     td,
     th {
-      width: $student-list-width;
       border-right: 0px;
     }
     th {
       background-color: $table-header;
       color: $charcoal;
     }
-    tr, td {
+    tr, td, th {
       display: block;
       width: 100%;
     }

--- a/apps/src/templates/sectionProgress/progressTables/progressTableStyles.scss
+++ b/apps/src/templates/sectionProgress/progressTables/progressTableStyles.scss
@@ -35,10 +35,12 @@ $content-view-width: $content-width - $student-list-width;
       border-right: 0px;
     }
     th {
+      width: $student-list-width;
       background-color: $table-header;
       color: $charcoal;
     }
-    tr, td, th {
+    tr,
+    td {
       display: block;
       width: 100%;
     }


### PR DESCRIPTION
<!--
  Your description goes here: A summary of the change, including any relevant motivation and context.

  If relevant, include a description both of the existing behavior and of the new behavior.
-->
- Update styles of progress table for overflowing student names

Before:
<img width="690" alt="Screen Shot 2021-02-12 at 5 23 38 PM" src="https://user-images.githubusercontent.com/24235215/107837697-15c8de00-6d57-11eb-983d-1e0027cd7608.png">


Now:
<img width="705" alt="Screen Shot 2021-02-12 at 5 21 29 PM" src="https://user-images.githubusercontent.com/24235215/107837643-c84c7100-6d56-11eb-975b-6864a6f188c9.png">

<!--
  Other aspects to consider. uncomment and add detail for any that seem necessary:
-->

<!-- ### Background -->
<!-- ### Privacy -->
<!--
1.	Does the Project involve the collection, use or sharing of new Personal Data?

2.	Does the Project involve a new or changed use or sharing of existing Personal Data?
-->
<!-- ### Security -->
<!--
Link to Jira Task where sensitive security issues are discussed privately.
-->
<!-- ### Caching -->
<!-- ### Deployment strategy -->
<!-- ### Future work -->

## Links

<!--
  Any relevant links to external resources; ie, specification documents, jira
  items, related PRs, honeybadger errors, etc
-->

- [spec]()
- [jira]()

## Testing story

<!--
  Does your change include appropriate tests?

  If so, please describe how the tests included in this PR are sufficient

  If not, please explain why this change does not need to be tested.
-->

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
