### PR TITLE
Add unplugged property for lesson to script DSL

### DIFF
--- a/apps/src/lib/levelbuilder/script-editor/scriptEditorRedux.js
+++ b/apps/src/lib/levelbuilder/script-editor/scriptEditorRedux.js
@@ -354,6 +354,9 @@ const serializeLesson = (lesson, levelKeyList) => {
   if (lesson.visible_after) {
     t += ', visible_after: true';
   }
+  if (lesson.unplugged) {
+    t += ', unplugged: true';
+  }
   s.push(t);
   if (lesson.levels) {
     lesson.levels.forEach(level => {

--- a/apps/src/lib/levelbuilder/script-editor/scriptEditorRedux.js
+++ b/apps/src/lib/levelbuilder/script-editor/scriptEditorRedux.js
@@ -354,9 +354,6 @@ const serializeLesson = (lesson, levelKeyList) => {
   if (lesson.visible_after) {
     t += ', visible_after: true';
   }
-  if (lesson.unplugged) {
-    t += ', unplugged: true';
-  }
   s.push(t);
   if (lesson.levels) {
     lesson.levels.forEach(level => {

--- a/apps/test/unit/code-studio/scriptEditorReduxTest.js
+++ b/apps/test/unit/code-studio/scriptEditorReduxTest.js
@@ -28,6 +28,7 @@ const getInitialState = () => ({
           key: 'a',
           name: 'A',
           position: 1,
+          unplugged: true,
           levels: [],
           hasLessonPlan: true
         },
@@ -100,7 +101,7 @@ describe('scriptEditorRedux reducer tests', () => {
     // Verify that the JSON contains serialized lesson groups.
     expect(serializedLessonGroups).to.equal(
       "lesson_group 'lg-key', display_name: 'Display Name'\n" +
-        "lesson 'a', display_name: 'A', has_lesson_plan: true\n\n" +
+        "lesson 'a', display_name: 'A', has_lesson_plan: true, unplugged: true\n\n" +
         "lesson 'b', display_name: 'B', has_lesson_plan: false\n\n" +
         "lesson 'c', display_name: 'C', has_lesson_plan: true\n\n" +
         "lesson_group 'lg-key-2', display_name: 'Display Name 2'\n" +

--- a/dashboard/app/dsl/script_dsl.rb
+++ b/dashboard/app/dsl/script_dsl.rb
@@ -113,6 +113,7 @@ class ScriptDSL < BaseDSL
         name: properties[:display_name],
         lockable: properties[:lockable],
         has_lesson_plan: properties[:has_lesson_plan],
+        unplugged: properties[:unplugged],
         visible_after: determine_visible_after_time(properties[:visible_after]),
         script_levels: []
       }.compact
@@ -385,6 +386,7 @@ class ScriptDSL < BaseDSL
     t += ', lockable: true' if lesson.lockable
     t += ", has_lesson_plan: #{!!lesson.has_lesson_plan}"
     t += ", visible_after: '#{escape(lesson.visible_after)}'" if lesson.visible_after
+    t += ', unplugged: true' if lesson.unplugged
     s << t
     lesson.script_levels.each do |sl|
       type = 'level'

--- a/dashboard/app/dsl/script_dsl.rb
+++ b/dashboard/app/dsl/script_dsl.rb
@@ -113,7 +113,6 @@ class ScriptDSL < BaseDSL
         name: properties[:display_name],
         lockable: properties[:lockable],
         has_lesson_plan: properties[:has_lesson_plan],
-        unplugged: properties[:unplugged],
         visible_after: determine_visible_after_time(properties[:visible_after]),
         script_levels: []
       }.compact
@@ -386,7 +385,6 @@ class ScriptDSL < BaseDSL
     t += ', lockable: true' if lesson.lockable
     t += ", has_lesson_plan: #{!!lesson.has_lesson_plan}"
     t += ", visible_after: '#{escape(lesson.visible_after)}'" if lesson.visible_after
-    t += ', unplugged: true' if lesson.unplugged
     s << t
     lesson.script_levels.each do |sl|
       type = 'level'

--- a/dashboard/app/models/lesson.rb
+++ b/dashboard/app/models/lesson.rb
@@ -98,7 +98,6 @@ class Lesson < ApplicationRecord
         lockable: !!raw_lesson[:lockable],
         has_lesson_plan: !!raw_lesson[:has_lesson_plan],
         visible_after: raw_lesson[:visible_after],
-        unplugged: !!raw_lesson[:unplugged],
         relative_position: numbered_lesson ? (counters.numbered_lesson_count += 1) : (counters.unnumbered_lesson_count += 1)
       )
       lesson.save! if lesson.changed?

--- a/dashboard/app/models/lesson.rb
+++ b/dashboard/app/models/lesson.rb
@@ -98,6 +98,7 @@ class Lesson < ApplicationRecord
         lockable: !!raw_lesson[:lockable],
         has_lesson_plan: !!raw_lesson[:has_lesson_plan],
         visible_after: raw_lesson[:visible_after],
+        unplugged: !!raw_lesson[:unplugged],
         relative_position: numbered_lesson ? (counters.numbered_lesson_count += 1) : (counters.unnumbered_lesson_count += 1)
       )
       lesson.save! if lesson.changed?

--- a/dashboard/test/models/script_test.rb
+++ b/dashboard/test/models/script_test.rb
@@ -2743,6 +2743,20 @@ class ScriptTest < ActiveSupport::TestCase
     assert error.message.include? "for key 'index_script_levels_on_seed_key'"
   end
 
+  test 'can add unplugged for lesson' do
+    dsl = <<-SCRIPT
+      lesson_group 'lg-1', display_name: 'Lesson Group'
+      lesson 'Lesson1', display_name: 'Lesson 1', unplugged: true
+    SCRIPT
+
+    script = Script.add_script(
+      {name: 'lesson-group-test-script'},
+      ScriptDSL.parse(dsl, 'a filename')[0][:lesson_groups]
+    )
+
+    assert_equal true, script.lessons[0].unplugged
+  end
+
   test 'seeding_key' do
     script = create :script
 


### PR DESCRIPTION
Starts https://codedotorg.atlassian.net/browse/PLAT-344

Adds the unplugged property to seeding and serialization of non-migrated scripts which use DSL. Add a bunch of tests to check that seeding and serialization work in different directions.