### PR TITLE
[AiLab] more spacing between autogenerated design elements

### DIFF
--- a/apps/src/applab/ai.js
+++ b/apps/src/applab/ai.js
@@ -25,9 +25,11 @@ function generateCodeDesignElements(modelId, modelData) {
         optionElement.text = option;
         select.options.add(optionElement);
       });
+      y = y + SPACER_PIXELS;
     } else {
       var input = designMode.createElement('TEXT_INPUT');
       input.id = 'design_' + feature + '_input';
+      y = y + SPACER_PIXELS;
     }
     var addFeature = `testValues.${feature} = getText("${selectId}");`;
     designMode.onInsertEvent(addFeature);


### PR DESCRIPTION
Follow up to #38664 

BEFORE: When there are multiple fields in the auto-generated test form, the elements were overlapping. 
<img width="366" alt="Screen Shot 2021-02-15 at 9 57 59 AM" src="https://user-images.githubusercontent.com/12300669/107971039-f3fe6f80-6f7f-11eb-89b3-7fb18814b563.png">


AFTER: This change just adds a little more breathing room for each element.

<img width="221" alt="Screen Shot 2021-02-15 at 11 13 05 AM" src="https://user-images.githubusercontent.com/12300669/107970877-b6014b80-6f7f-11eb-9df3-643bdee6c741.png">
