### PR TITLE
[AiLab] convert string testValues to numbers

### DIFF
--- a/apps/src/MLTrainers.js
+++ b/apps/src/MLTrainers.js
@@ -32,7 +32,10 @@ modelData = {
 */
 
 function convertTestValue(featureNumberKey, feature, value) {
-  return parseInt(featureNumberKey[feature][value]);
+  const convertedValue = Object.keys(featureNumberKey).includes(feature)
+    ? featureNumberKey[feature][value]
+    : value;
+  return parseInt(convertedValue);
 }
 
 export function predict(modelData) {

--- a/apps/src/MLTrainers.js
+++ b/apps/src/MLTrainers.js
@@ -29,11 +29,12 @@ modelData = {
     feature3: value
   }
 }
-
-  value in testData is the converted algorithm-ready number, not the string
-
-  TODO: convert string data in testValues using the featureNumberKey
 */
+
+function convertTestValue(featureNumberKey, feature, value) {
+  return parseInt(featureNumberKey[feature][value]);
+}
+
 export function predict(modelData) {
   // Determine which algorithm to use.
   if (KNNTrainers.includes(modelData.selectedTrainer)) {
@@ -41,7 +42,11 @@ export function predict(modelData) {
     const model = KNN.load(modelData.trainedModel);
     // Prepare test data.
     const testValues = modelData.selectedFeatures.map(feature =>
-      parseInt(modelData.testData[feature])
+      convertTestValue(
+        modelData.featureNumberKey,
+        feature,
+        modelData.testData[feature]
+      )
     );
     // Make a prediction.
     const rawPrediction = model.predict(testValues);


### PR DESCRIPTION
Follow up to #38664

The machine learning algorithms only work with numerical values. This change handles converting human readable string categories (such as "yes" or "no") back to numbers before passing them as test values to the algorithm. 

Example: 

```
testData = {
     "delicious": "yes"
} 

featureNumberKey = {
     "delicious" : {
          "yes" : 0, 
         "no": 1
      }
}
```

So if the feature is in the `featureNumberKey` it's categorical and we can lookup the number that goes with a particular string value. 