### PR TITLE
Move CDO.shared_cache_clear to setup in test_helper

### DIFF
--- a/dashboard/test/controllers/api/v1/text_to_speech_controller_test.rb
+++ b/dashboard/test/controllers/api/v1/text_to_speech_controller_test.rb
@@ -13,10 +13,6 @@ class Api::V1::TextToSpeechControllerTest < ActionController::TestCase
     @default_limit = Api::V1::TextToSpeechController::REQUEST_LIMIT_PER_MIN_DEFAULT
   end
 
-  teardown do
-    CDO.shared_cache.clear
-  end
-
   test 'azure: returns 400 if speech not received from Azure' do
     AzureTextToSpeech.expects(:throttled_get_speech).once.yields(nil)
     post :azure

--- a/dashboard/test/controllers/concerns/azure_text_to_speech_test.rb
+++ b/dashboard/test/controllers/concerns/azure_text_to_speech_test.rb
@@ -10,11 +10,6 @@ class AzureTextToSpeechTest < ActionController::TestCase
     CDO.stubs(:azure_speech_service_region).returns(@region)
   end
 
-  teardown do
-    # Some tests access and store data in the cache, so clear between tests to avoid state leakage
-    CDO.shared_cache.clear
-  end
-
   test 'get_token: returns token on success' do
     stub_request(:post, "https://#{@region}.api.cognitive.microsoft.com/sts/v1.0/issueToken").
       with(headers: {'Ocp-Apim-Subscription-Key' => @api_key}).

--- a/dashboard/test/helpers/profanity_helper_test.rb
+++ b/dashboard/test/helpers/profanity_helper_test.rb
@@ -1,11 +1,6 @@
 require 'test_helper'
 
 class ProfanityHelperTest < ActionView::TestCase
-  teardown do
-    # Some tests access and store data in the cache, so clear between tests to avoid state leakage
-    CDO.shared_cache.clear
-  end
-
   test 'throttled_find_profanities: yields profanities if cached' do
     CDO.shared_cache.expects(:exist?).returns(true)
     expected_profanities = ['bad']

--- a/dashboard/test/test_helper.rb
+++ b/dashboard/test/test_helper.rb
@@ -84,6 +84,8 @@ class ActiveSupport::TestCase
     # as in, I still need to clear the cache even though we are not 'performing' caching
     Rails.cache.clear
 
+    CDO.shared_cache.clear
+
     # clear log of 'delivered' mails
     ActionMailer::Base.deliveries.clear
 


### PR DESCRIPTION
The Azure TTS tests have been flaky because there is sometimes data left over in the cache (`CDO.shared_cache`). I attempted to handle this flakiness in #38922, but it showed up again today ([Slack](https://codedotorg.slack.com/archives/C0T0PNTM3/p1613403602380900)).

Instead of trying to handle all places where the cache might need to be cleared, this PR clears the cache before every unit test (similar to what we do for `Rails.cache`).