### PR TITLE
[Applab][Libraries] Catch openuri too long error and show message

### DIFF
--- a/apps/i18n/common/en_us.json
+++ b/apps/i18n/common/en_us.json
@@ -1022,6 +1022,7 @@
   "libraryPublishInvalid": "Your library must include a description and at least one function.",
   "libraryPublishFail": "There was an error publishing your library. Please check your internet connection and try again.",
   "libraryPublishTitle": "Successfully published your library: ",
+  "libraryTooLongFail": "Your library is too long. Please make it shorter and try again.",
   "librarySharedSections": "This library is assigned to the following sections:",
   "libraryUnPublishExplanation": "No one will be able to import or update your library. However, people who have already imported your library will be able to keep using it. You can re-publish your library at any time.",
   "libraryUnPublishFail": "There was an error unpublishing your library. Please check your internet connection and try again.",

--- a/apps/src/code-studio/components/libraries/LibraryPublisher.jsx
+++ b/apps/src/code-studio/components/libraries/LibraryPublisher.jsx
@@ -64,6 +64,7 @@ export const PublishState = {
   ERROR_PUBLISH: 'error_publish',
   INVALID_INPUT: 'invalid_input',
   PROFANE_INPUT: 'profane_input',
+  TOO_LONG: 'too_long',
   ERROR_UNPUBLISH: 'error_unpublish'
 };
 
@@ -165,7 +166,14 @@ export default class LibraryPublisher extends React.Component {
       libraryJson,
       error => {
         console.warn(`Error publishing library: ${error}`);
-        this.setState({publishState: PublishState.ERROR_PUBLISH});
+        if (
+          error.message ===
+          'httpStatusCode: 413; status: error; error: Request Entity Too Large'
+        ) {
+          this.setState({publishState: PublishState.TOO_LONG});
+        } else {
+          this.setState({publishState: PublishState.ERROR_PUBLISH});
+        }
       },
       data => {
         // Write to projects database
@@ -317,6 +325,9 @@ export default class LibraryPublisher extends React.Component {
         break;
       case PublishState.ERROR_PUBLISH:
         errorMessage = i18n.libraryPublishFail();
+        break;
+      case PublishState.TOO_LONG:
+        errorMessage = i18n.libraryTooLongFail();
         break;
       case PublishState.ERROR_UNPUBLISH:
         errorMessage = i18n.libraryUnPublishFail();

--- a/apps/test/unit/code-studio/components/libraries/LibraryPublisherTest.js
+++ b/apps/test/unit/code-studio/components/libraries/LibraryPublisherTest.js
@@ -265,7 +265,7 @@ describe('LibraryPublisher', () => {
 
     describe('with valid input', () => {
       it('sets error state when publish fails', async () => {
-        publishSpy.callsArg(1);
+        publishSpy.callsArgWith(1, {});
         sinon.stub(console, 'warn');
         wrapper.setState({
           libraryDescription: description,
@@ -277,6 +277,24 @@ describe('LibraryPublisher', () => {
         expect(wrapper.state().publishState).to.equal(
           PublishState.ERROR_PUBLISH
         );
+
+        console.warn.restore();
+      });
+
+      it('sets error state if library is too long', async () => {
+        publishSpy.callsArgWith(1, {
+          message:
+            'httpStatusCode: 413; status: error; error: Request Entity Too Large'
+        });
+        sinon.stub(console, 'warn');
+        wrapper.setState({
+          libraryDescription: description,
+          selectedFunctions: selectedFunctions
+        });
+
+        await wrapper.instance().validateAndPublish();
+
+        expect(wrapper.state().publishState).to.equal(PublishState.TOO_LONG);
 
         console.warn.restore();
       });

--- a/shared/middleware/files_api.rb
+++ b/shared/middleware/files_api.rb
@@ -339,7 +339,11 @@ class FilesApi < Sinatra::Base
 
     # Block libraries with PII/profanity from being published.
     if endpoint == 'libraries'
-      share_failure = ShareFiltering.find_failure(body, request.locale)
+      begin
+        share_failure = ShareFiltering.find_failure(body, request.locale)
+      rescue OpenURI::HTTPError => e
+        return file_too_large(endpoint) if e.message == "414 Request-URI Too Large"
+      end
       # TODO(JillianK): we are temporarily ignoring address share failures because our address detection is very broken.
       # Once we have a better geocoding solution in H1, we should start filtering for addresses again.
       # Additional context: https://codedotorg.atlassian.net/browse/STAR-1361


### PR DESCRIPTION
We've gotten several reports in Zendesk about libraries failing to publish.
It looks like at least some of these issues are caused by the library being too long for the profanity checker. This results in and `OpenURI::HTTPError`(which also results in a [honeybadger error](https://app.honeybadger.io/projects/3240/faults/64317192))

We need to rethink how the profanity checking happens a little more broadly (see [slack thread](https://codedotorg.slack.com/archives/CN4T89YP8/p1603476844003000) and [jira ticket](https://codedotorg.atlassian.net/browse/STAR-1325)), but for now, we can just surface a better error for the user.

![image](https://user-images.githubusercontent.com/8787187/107999525-6a10cf80-6f9c-11eb-8ffb-579f35beb224.png)



<!-- ### Background -->
<!-- ### Privacy -->
<!--
1.	Does the Project involve the collection, use or sharing of new Personal Data?

2.	Does the Project involve a new or changed use or sharing of existing Personal Data?
-->
<!-- ### Security -->
<!--
Link to Jira Task where sensitive security issues are discussed privately.
-->
<!-- ### Caching -->
<!-- ### Deployment strategy -->
<!-- ### Future work -->

## Links

<!--
  Any relevant links to external resources; ie, specification documents, jira
  items, related PRs, honeybadger errors, etc
-->

- [jira](https://codedotorg.atlassian.net/browse/STAR-1428)

## Testing story

<!--
  Does your change include appropriate tests?

  If so, please describe how the tests included in this PR are sufficient

  If not, please explain why this change does not need to be tested.
-->

# Reviewer Checklist:

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
