### PR TITLE
[AiLab] strip whitespace and special characters in autogenerated code 

### DIFF
--- a/apps/src/applab/ai.js
+++ b/apps/src/applab/ai.js
@@ -9,12 +9,14 @@ function generateCodeDesignElements(modelId, modelData) {
   modelData.selectedFeatures.forEach(feature => {
     y = y + SPACER_PIXELS;
     var label = designMode.createElement('LABEL', x, y);
+    // Strip whitespace and special characters.
+    var alphaNumFeature = feature.replace(/\W/g, '');
     label.textContent = feature + ':';
-    label.id = 'design_' + feature + '_label';
+    label.id = 'design_' + alphaNumFeature + '_label';
     label.style.width = '300px';
     y = y + SPACER_PIXELS;
     if (Object.keys(modelData.featureNumberKey).includes(feature)) {
-      var selectId = feature + '_dropdown';
+      var selectId = alphaNumFeature + '_dropdown';
       var select = designMode.createElement('DROPDOWN', x, y);
       select.id = 'design_' + selectId;
       // App Lab automatically addss "option 1" and "option 2", remove them.
@@ -28,26 +30,26 @@ function generateCodeDesignElements(modelId, modelData) {
       y = y + SPACER_PIXELS;
     } else {
       var input = designMode.createElement('TEXT_INPUT');
-      input.id = 'design_' + feature + '_input';
+      input.id = 'design_' + alphaNumFeature + '_input';
       y = y + SPACER_PIXELS;
     }
-    var addFeature = `testValues.${feature} = getText("${selectId}");`;
+    var addFeature = `testValues.${alphaNumFeature} = getText("${selectId}");`;
     designMode.onInsertEvent(addFeature);
   });
   y = y + 2 * SPACER_PIXELS;
   var label = designMode.createElement('LABEL', x, y);
   label.textContent = modelData.labelColumn;
-  // TODO: this could be problematic if the name isn't formatted appropriately
-  label.id = 'design_' + modelData.name + '_label';
+  var alphaNumModelName = modelData.name.replace(/\W/g, '');
+  label.id = 'design_' + alphaNumModelName + '_label';
   label.style.width = '300px';
   y = y + SPACER_PIXELS;
-  var predictionId = modelData.name + '_prediction';
+  var predictionId = alphaNumModelName + '_prediction';
   var prediction = designMode.createElement('TEXT_INPUT', x, y);
   prediction.id = 'design_' + predictionId;
   y = y + 2 * SPACER_PIXELS;
   var predictButton = designMode.createElement('BUTTON', x, y);
   predictButton.textContent = 'Predict';
-  var predictButtonId = modelData.name + '_predict';
+  var predictButtonId = alphaNumModelName + '_predict';
   designMode.updateProperty(predictButton, 'id', predictButtonId);
   var predictOnClick = `onEvent("${predictButtonId}", "click", function() {
     getPrediction("${


### PR DESCRIPTION
Because were are using model names and feature names as ids for design elements and keys in objects in autogenerate code, we need to strip whitespaces and special characters to avoid errors when the App Lab code is run. 

BEFORE: 
<img width="654" alt="Screen Shot 2021-02-15 at 9 11 54 PM" src="https://user-images.githubusercontent.com/12300669/108011360-eaebbd80-6fd4-11eb-84ba-d6f4c7e7b95b.png">

AFTER: 
<img width="614" alt="Screen Shot 2021-02-15 at 9 09 08 PM" src="https://user-images.githubusercontent.com/12300669/108011362-ec1cea80-6fd4-11eb-85c7-e4c42ffd4b6d.png">

The `getPrediction` block can cope with spaces, special characters and even emojis (because the model id is actually the important part that gets used to retrieve the model details) so we'll allow those in model names for now. 