### PR TITLE
Make duration not required for activity section on lesson plan

### DIFF
--- a/apps/src/templates/lessonOverview/lessonPlanShapes.jsx
+++ b/apps/src/templates/lessonOverview/lessonPlanShapes.jsx
@@ -50,8 +50,7 @@ export const activitySectionShape = PropTypes.shape({
   key: PropTypes.string.isRequired,
   position: PropTypes.number.isRequired,
   displayName: PropTypes.string.isRequired,
-  duration: PropTypes.oneOfType([PropTypes.number, PropTypes.oneOf([''])])
-    .isRequired,
+  duration: PropTypes.oneOfType([PropTypes.number, PropTypes.oneOf([''])]),
   remarks: PropTypes.bool,
   progressionName: PropTypes.string,
   scriptLevels: PropTypes.arrayOf(scriptLevelShape).isRequired,


### PR DESCRIPTION
These warnings were showing up on the lesson plan page because duration was required for activity section so this PR makes it not required.

<img width="548" alt="Screen Shot 2021-02-16 at 2 18 36 PM" src="https://user-images.githubusercontent.com/208083/108111061-2d0f1080-7062-11eb-8281-9d72faa2bb02.png">

