### PR TITLE
[AiLab] input fields need to be set inside the onEvent

### DIFF
--- a/apps/src/applab/ai.js
+++ b/apps/src/applab/ai.js
@@ -6,6 +6,7 @@ function generateCodeDesignElements(modelId, modelData) {
   var y = 20;
   var SPACER_PIXELS = 20;
   designMode.onInsertEvent(`var testValues = {};`);
+  var inputFields = [];
   modelData.selectedFeatures.forEach(feature => {
     y = y + SPACER_PIXELS;
     var label = designMode.createElement('LABEL', x, y);
@@ -34,7 +35,7 @@ function generateCodeDesignElements(modelId, modelData) {
       y = y + SPACER_PIXELS;
     }
     var addFeature = `testValues.${alphaNumFeature} = getText("${selectId}");`;
-    designMode.onInsertEvent(addFeature);
+    inputFields.push(addFeature);
   });
   y = y + 2 * SPACER_PIXELS;
   var label = designMode.createElement('LABEL', x, y);
@@ -52,6 +53,7 @@ function generateCodeDesignElements(modelId, modelData) {
   var predictButtonId = alphaNumModelName + '_predict';
   designMode.updateProperty(predictButton, 'id', predictButtonId);
   var predictOnClick = `onEvent("${predictButtonId}", "click", function() {
+    ${inputFields.toString()}
     getPrediction("${
       modelData.name
     }", "${modelId}", testValues, function(value) {

--- a/apps/src/applab/ai.js
+++ b/apps/src/applab/ai.js
@@ -53,7 +53,7 @@ function generateCodeDesignElements(modelId, modelData) {
   var predictButtonId = alphaNumModelName + '_predict';
   designMode.updateProperty(predictButton, 'id', predictButtonId);
   var predictOnClick = `onEvent("${predictButtonId}", "click", function() {
-    ${inputFields.toString()}
+    ${inputFields.join('\n\t\t')}
     getPrediction("${
       modelData.name
     }", "${modelId}", testValues, function(value) {


### PR DESCRIPTION
Each time the predict button is clicked, we need to grab the _current_ values from the input field to build the testValues object to pass to the machine learning model. This means we need to get those values _within_ the `onEvent` code. 

BEFORE: 
<img width="614" alt="Screen Shot 2021-02-15 at 9 09 08 PM" src="https://user-images.githubusercontent.com/12300669/108139941-1c28c400-708f-11eb-827e-21f15776c850.png">

AFTER: 
<img width="599" alt="Screen Shot 2021-02-16 at 7 38 05 PM" src="https://user-images.githubusercontent.com/12300669/108139944-1d59f100-708f-11eb-9cbf-cc1f32334d78.png">
