### PR TITLE
Send teacher reminders to bug their principals if they have not approved

### DIFF
--- a/dashboard/bin/scheduled_pd_application_emails
+++ b/dashboard/bin/scheduled_pd_application_emails
@@ -7,7 +7,7 @@ require_relative '../config/environment'
 def queue_pd_reminder_emails
   # For each teacher application, queue up one reminder email if their principal
   # hasn't yet responded.
-  Pd::Application::Teacher1920Application.all.each do |teacher_application|
+  Pd::Application::Teacher2122Application.all.each do |teacher_application|
     if teacher_application.allow_sending_principal_approval_teacher_reminder_email?
       teacher_application.queue_email :principal_approval_teacher_reminder
     end


### PR DESCRIPTION
We have an [old cronjob](https://github.com/code-dot-org/code-dot-org/blob/staging/cookbooks/cdo-apps/templates/default/crontab.erb#L86) that is supposed to send reminders to teachers to remind them to bug their principals to approve their application if they have not done so already. It runs at 8 AM PST daily. In the last two application updates, we've forgotten to update this script.

For posterity (also commented well in the code), are the requirements for sending this email:

- we haven’t sent one of these reminders before
- application status is unreviewed / pending
- we’ve sent the principal an approval email before, and it was created at least 5 days ago (we check when the email was created, not sent, but presumably these things are very similar)
- principal approval required for this type of application
- we haven’t received a response from the principal yet

## Testing story

I checked that the methods used to determine eligibility to send these emails in the 19-20 version of the teacher application still exist in 21-22, and that the email previews for these emails at /rails/mailers still render with the 21-22 version of the teacher application. I also checked how many emails we'll send once this is turned on -- looks like 287/947 applications received will get this reminder once this change is made.

```
[production] dashboard > count = 0; Pd::Application::Teacher2122Application.all.each { |ta| count += 1 if ta.allow_sending_principal_approval_teacher_reminder_email?}; puts count
287
=> nil
[production] dashboard > Pd::Application::Teacher2122Application.count
=> 947
```

## PR Checklist:

- [x] Tests provide adequate coverage
- [x] Privacy and Security impacts have been assessed
- [x] Code is well-commented
- [x] New features are translatable or updates will not break translations
- [x] Relevant documentation has been added or updated
- [x] User impact is well-understood and desirable
- [x] Pull Request is labeled appropriately
- [x] Follow-up work items (including potential tech debt) are tracked and linked
