### PR TITLE
Add a 'download' property to Button

### DIFF
--- a/apps/src/templates/Button.jsx
+++ b/apps/src/templates/Button.jsx
@@ -197,6 +197,7 @@ class Button extends React.Component {
     target: PropTypes.string,
     style: PropTypes.object,
     disabled: PropTypes.bool,
+    download: PropTypes.oneOfType([PropTypes.bool, PropTypes.string]),
     onClick: PropTypes.func,
     id: PropTypes.string,
     tabIndex: PropTypes.oneOfType([PropTypes.number, PropTypes.string]),
@@ -226,6 +227,7 @@ class Button extends React.Component {
       style,
       onClick,
       disabled,
+      download,
       id,
       tabIndex,
       isPending,
@@ -245,6 +247,14 @@ class Button extends React.Component {
       Tag = href ? 'a' : 'div';
     }
 
+    if (download && Tag !== 'a') {
+      // <button> and <div> elements do not support the download attribute, so
+      // don't let this component attempt to do that.
+      throw new Error(
+        'Attempted to use the download attribute with a non-anchor tag'
+      );
+    }
+
     const sizeStyle = __useDeprecatedTag
       ? styles.sizes[size]
       : {...styles.sizes[size], ...styles.updated};
@@ -256,6 +266,7 @@ class Button extends React.Component {
         href={disabled ? 'javascript:void(0);' : href}
         target={target}
         disabled={disabled}
+        download={download}
         onClick={disabled ? null : onClick}
         onKeyDown={this.onKeyDown}
         tabIndex={tabIndex}

--- a/apps/test/unit/templates/ButtonTest.js
+++ b/apps/test/unit/templates/ButtonTest.js
@@ -174,24 +174,30 @@ describe('Button', () => {
     assert.equal(icon.props().icon, 'lock');
   });
 
-  it('supports the download attribute, but only for anchors', () => {
-    let wrapper = shallow(
+  it('supports the download property/attribute', () => {
+    // The download attribute can be used with or without a value (see
+    // https://developer.mozilla.org/en-US/docs/Web/HTML/Element/a#attr-download),
+    // so make sure to test both.
+    const wrapper = shallow(
       <Button __useDeprecatedTag download href="/foo/bar" text="Click me" />
     );
     assert.equal(wrapper.find('a').prop('download'), true);
-
-    wrapper = shallow(
-      <Button
-        __useDeprecatedTag
-        download="baz"
-        href="/foo/bar"
-        text="Click me"
-      />
-    );
+    wrapper.setProps({download: 'baz'});
     assert.equal(wrapper.find('a').prop('download'), 'baz');
+  });
+
+  it('does not support the download property/attribute for non-anchor tags', () => {
+    // <button> and <div> elements do not have a download attribute, so we
+    // proactively prevent our component from attempting to use the download
+    // property when the underlying element would be one of them.
+    assert.throws(() => {
+      // button case
+      shallow(<Button download text="Click me" />);
+    });
 
     assert.throws(() => {
-      shallow(<Button download href="/foo/bar" text="Click me" />);
+      // div case
+      shallow(<Button __useDeprecatedTag download text="Click me" />);
     });
   });
 });

--- a/apps/test/unit/templates/ButtonTest.js
+++ b/apps/test/unit/templates/ButtonTest.js
@@ -173,4 +173,25 @@ describe('Button', () => {
     assert(icon);
     assert.equal(icon.props().icon, 'lock');
   });
+
+  it('supports the download attribute, but only for anchors', () => {
+    let wrapper = shallow(
+      <Button __useDeprecatedTag download href="/foo/bar" text="Click me" />
+    );
+    assert.equal(wrapper.find('a').prop('download'), true);
+
+    wrapper = shallow(
+      <Button
+        __useDeprecatedTag
+        download="baz"
+        href="/foo/bar"
+        text="Click me"
+      />
+    );
+    assert.equal(wrapper.find('a').prop('download'), 'baz');
+
+    assert.throws(() => {
+      shallow(<Button download href="/foo/bar" text="Click me" />);
+    });
+  });
 });


### PR DESCRIPTION
And restrict it to only work when the component is rendering an anchor.

Intended for use with [Lesson Plan PDFs](https://github.com/code-dot-org/code-dot-org/pull/39011)

See https://developer.mozilla.org/en-US/docs/Web/HTML/Element/a#attr-download

## Testing story

Added a basic unit test

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
