### PR TITLE
progress table layout cleanup

### DIFF
--- a/apps/src/templates/sectionProgress/progressTables/ProgressTableContainer.jsx
+++ b/apps/src/templates/sectionProgress/progressTables/ProgressTableContainer.jsx
@@ -33,8 +33,7 @@ const styles = {
 class ProgressTableContainer extends React.Component {
   static propTypes = {
     onClickLesson: PropTypes.func.isRequired,
-    getTableWidth: PropTypes.func.isRequired,
-    columnWidths: PropTypes.arrayOf(PropTypes.number).isRequired,
+    columnWidths: PropTypes.arrayOf(PropTypes.number),
     lessonCellFormatter: PropTypes.func.isRequired,
     extraHeaderFormatters: PropTypes.arrayOf(PropTypes.func),
     extraHeaderLabels: PropTypes.arrayOf(PropTypes.string),
@@ -79,17 +78,10 @@ class ProgressTableContainer extends React.Component {
     this.contentView.header.scrollLeft = e.target.scrollLeft;
   }
 
-  // the student gutter is needed when there is a scroll bar at the bottom of the
-  // content section of the table so that the student list and content section
-  // are the same height vertically
-  needsStudentGutter() {
-    return (
-      this.props.getTableWidth(this.props.scriptData.stages) >
-      parseInt(progressTableStyles.CONTENT_VIEW_WIDTH)
-    );
-  }
-
-  needsContentGutter() {
+  // When the student list is long enough to enable vertical scrolling in the
+  // table body, we need to add a "gutter" to the content view header to
+  // account for the horizontal space used by the vertical scrollbar.
+  needsContentHeaderGutter() {
     return (
       this.props.section.students.length *
         parseInt(progressTableStyles.ROW_HEIGHT) >
@@ -104,14 +96,13 @@ class ProgressTableContainer extends React.Component {
           <ProgressTableStudentList
             ref={r => (this.studentList = r)}
             headers={[i18n.lesson(), ...(this.props.extraHeaderLabels || [])]}
-            needsGutter={this.needsStudentGutter()}
             {...this.props}
           />
         </div>
         <div style={styles.contentView} className="content-view">
           <ProgressTableContentView
             ref={r => (this.contentView = r)}
-            needsGutter={this.needsContentGutter()}
+            needsGutter={this.needsContentHeaderGutter()}
             onScroll={this.onScroll}
             {...this.props}
           />

--- a/apps/src/templates/sectionProgress/progressTables/ProgressTableContentView.jsx
+++ b/apps/src/templates/sectionProgress/progressTables/ProgressTableContentView.jsx
@@ -101,6 +101,17 @@ export default class ProgressTableContentView extends React.Component {
     );
   }
 
+  /**
+   * `columnWidths` is an optional prop. When it's provided, we explicitly
+   * constrain column widths to the provided values. When it's absent, the
+   * columns will size themselves based on their content.
+   *
+   * Note: Due to the nuances of reactabular's implementation, header cells
+   * are unable to base their width on the content of body cells, nor
+   * vice versa. Consequently, for headers to properly align with their body
+   * columns when explicit column widths are not provided, the max content
+   * width of header cells must match the max content width of body cells.
+   */
   columnWidthStyle(index) {
     const {columnWidths} = this.props;
     return columnWidths

--- a/apps/src/templates/sectionProgress/progressTables/ProgressTableContentView.jsx
+++ b/apps/src/templates/sectionProgress/progressTables/ProgressTableContentView.jsx
@@ -33,7 +33,7 @@ export default class ProgressTableContentView extends React.Component {
       PropTypes.objectOf(studentLevelProgressType)
     ).isRequired,
     onClickLesson: PropTypes.func.isRequired,
-    columnWidths: PropTypes.arrayOf(PropTypes.number).isRequired,
+    columnWidths: PropTypes.arrayOf(PropTypes.number),
     lessonCellFormatter: PropTypes.func.isRequired,
     extraHeaderFormatters: PropTypes.arrayOf(PropTypes.func),
     needsGutter: PropTypes.bool.isRequired,
@@ -103,9 +103,11 @@ export default class ProgressTableContentView extends React.Component {
 
   columnWidthStyle(index) {
     const {columnWidths} = this.props;
-    return {
-      style: {minWidth: columnWidths[index], maxWidth: columnWidths[index]}
-    };
+    return columnWidths
+      ? {
+          style: {minWidth: columnWidths[index], maxWidth: columnWidths[index]}
+        }
+      : {};
   }
 
   render() {
@@ -166,7 +168,8 @@ export default class ProgressTableContentView extends React.Component {
           rowKey={'id'}
           onScroll={this.props.onScroll}
           style={{
-            overflow: 'auto',
+            overflowX: 'scroll',
+            overflowY: 'auto',
             maxHeight: parseInt(progressTableStyles.MAX_BODY_HEIGHT)
           }}
           ref={r => {

--- a/apps/src/templates/sectionProgress/progressTables/ProgressTableDetailCell.jsx
+++ b/apps/src/templates/sectionProgress/progressTables/ProgressTableDetailCell.jsx
@@ -1,6 +1,5 @@
 import PropTypes from 'prop-types';
 import React from 'react';
-import ReactDOM from 'react-dom';
 import {
   levelTypeWithoutStatus,
   studentLevelProgressType
@@ -10,9 +9,6 @@ import * as progressStyles from '@cdo/apps/templates/progress/progressStyles';
 import color from '@cdo/apps/util/color';
 import firehoseClient from '@cdo/apps/lib/util/firehose';
 import _ from 'lodash';
-import {LevelStatus} from '@cdo/apps/util/sharedConstants';
-
-const UNPLUGGED_BUBBLE_WIDTH = getUnpluggedWidth();
 
 const styles = {
   container: {
@@ -33,22 +29,6 @@ const styles = {
   }
 };
 export default class ProgressTableDetailCell extends React.Component {
-  static widthForLevels(levels) {
-    return (
-      levels.reduce((sum, level) => {
-        return (
-          sum +
-          (level.isUnplugged
-            ? UNPLUGGED_BUBBLE_WIDTH
-            : progressStyles.BUBBLE_CONTAINER_WIDTH) +
-          (level.sublevels || []).length *
-            progressStyles.LETTER_BUBBLE_CONTAINER_WIDTH
-        );
-      }, 0) +
-      2 * progressStyles.CELL_PADDING
-    );
-  }
-
   static propTypes = {
     studentId: PropTypes.number.isRequired,
     sectionId: PropTypes.number.isRequired,
@@ -157,50 +137,3 @@ export default class ProgressTableDetailCell extends React.Component {
     );
   }
 }
-
-/**
- * The width of the unplugged bubble depends on the localization of the text,
- * but our table needs to know its rendered width for determining column width,
- * so we calculate the width here by adding the element to the DOM, getting its
- * width, then removing it.
- *
- * Note: it would make more sense to put this code in the same file with the
- * ProgressTableLevelBubble component, but due to JSX compilation the class
- * symbol for the component is undefined in that file.
- */
-function getUnpluggedWidth() {
-  // Create invisible container
-  const outer = document.createElement('div');
-  outer.style.visibility = 'hidden';
-  document.body.appendChild(outer);
-
-  // Create React element
-  const unpluggedElement = React.createElement(
-    ProgressTableLevelBubble,
-    {
-      levelStatus: LevelStatus.not_tried,
-      unplugged: true,
-      disabled: false,
-      url: ''
-    },
-    null
-  );
-
-  // Render node and fetch from DOM
-  const unpluggedNode = ReactDOM.findDOMNode(
-    ReactDOM.render(unpluggedElement, outer)
-  );
-
-  // Store the width
-  const width = unpluggedNode.offsetWidth;
-
-  // Remove temporary elements from DOM
-  ReactDOM.unmountComponentAtNode(outer);
-  outer.parentNode.removeChild(outer);
-
-  return width;
-}
-
-export const unitTestExports = {
-  getUnpluggedWidth
-};

--- a/apps/src/templates/sectionProgress/progressTables/ProgressTableDetailView.jsx
+++ b/apps/src/templates/sectionProgress/progressTables/ProgressTableDetailView.jsx
@@ -32,12 +32,6 @@ class ProgressTableDetailView extends React.Component {
     this.detailCellFormatter = this.detailCellFormatter.bind(this);
   }
 
-  getTableWidth(lessons) {
-    return lessons.reduce((totalWidth, lesson) => {
-      return totalWidth + ProgressTableDetailCell.widthForLevels(lesson.levels);
-    }, 0);
-  }
-
   levelIconHeaderFormatter(_, {columnIndex}) {
     return (
       <ProgressTableLevelIcon
@@ -59,14 +53,9 @@ class ProgressTableDetailView extends React.Component {
   }
 
   render() {
-    const columnWidths = this.props.scriptData.stages.map(lesson =>
-      ProgressTableDetailCell.widthForLevels(lesson.levels)
-    );
     return (
       <ProgressTableContainer
         onClickLesson={this.props.onClickLesson}
-        getTableWidth={lessons => this.getTableWidth(lessons)}
-        columnWidths={columnWidths}
         lessonCellFormatter={this.detailCellFormatter}
         includeHeaderArrows={true}
         extraHeaderFormatters={[this.levelIconHeaderFormatter]}

--- a/apps/src/templates/sectionProgress/progressTables/ProgressTableLevelBubble.jsx
+++ b/apps/src/templates/sectionProgress/progressTables/ProgressTableLevelBubble.jsx
@@ -60,7 +60,8 @@ const styles = {
     ...progressStyles.flex,
     borderRadius: 20,
     padding: '6px 10px',
-    fontSize: 12
+    fontSize: 12,
+    whiteSpace: 'nowrap'
   }
 };
 

--- a/apps/src/templates/sectionProgress/progressTables/ProgressTableLevelIcon.jsx
+++ b/apps/src/templates/sectionProgress/progressTables/ProgressTableLevelIcon.jsx
@@ -5,6 +5,8 @@ import FontAwesome from '@cdo/apps/templates/FontAwesome';
 import color from '@cdo/apps/util/color';
 import * as progressStyles from '@cdo/apps/templates/progress/progressStyles';
 import {getIconForLevel} from '@cdo/apps/templates/progress/progressHelpers';
+import ProgressTableLevelBubble from './ProgressTableLevelBubble';
+import {LevelStatus} from '@cdo/apps/util/sharedConstants';
 
 const styles = {
   container: {
@@ -16,23 +18,47 @@ const styles = {
     textAlign: 'center',
     color: color.charcoal,
     fontSize: 20
+  },
+  unpluggedPlaceholderContainer: {
+    height: 0,
+    opacity: 0
   }
 };
 
-function LevelIcon({icon}) {
+const placeholderUnpluggedBubble = (
+  <div style={styles.unpluggedPlaceholderContainer}>
+    <div>
+      <ProgressTableLevelBubble
+        levelStatus={LevelStatus.not_tried}
+        unplugged={true}
+        disabled={true}
+        url=""
+      />
+    </div>
+  </div>
+);
+
+function LevelIcon({icon, unplugged}) {
+  // The width of our unplugged bubble depends on the localization of the text,
+  // so to allow that to be determined at render time, we don't set an explicit
+  // width for unplugged bubbles and instead render an invisible one behind the
+  // icon to determine its width.
+  const width = unplugged ? undefined : progressStyles.BUBBLE_CONTAINER_WIDTH;
   return (
     <span
       style={{
         ...styles.icon,
-        width: progressStyles.BUBBLE_CONTAINER_WIDTH
+        width: width
       }}
     >
+      {unplugged && placeholderUnpluggedBubble}
       <FontAwesome icon={icon} />
     </span>
   );
 }
 LevelIcon.propTypes = {
-  icon: PropTypes.string.isRequired
+  icon: PropTypes.string.isRequired,
+  unplugged: PropTypes.bool
 };
 
 export default class ProgressTableLevelIcon extends React.Component {
@@ -60,7 +86,10 @@ export default class ProgressTableLevelIcon extends React.Component {
             key={`${level.id}_${level.levelNumber}`}
             style={progressStyles.flexBetween}
           >
-            <LevelIcon icon={getIconForLevel(level, true)} />
+            <LevelIcon
+              icon={getIconForLevel(level, true)}
+              unplugged={level.isUnplugged}
+            />
             {level.sublevels &&
               this.renderSublevelSpace(level.sublevels.length)}
           </span>

--- a/apps/src/templates/sectionProgress/progressTables/ProgressTableStudentList.jsx
+++ b/apps/src/templates/sectionProgress/progressTables/ProgressTableStudentList.jsx
@@ -21,8 +21,7 @@ export default class ProgressTableStudentList extends React.Component {
     scriptData: scriptDataPropType.isRequired,
     headers: PropTypes.arrayOf(PropTypes.string).isRequired,
     studentTimestamps: PropTypes.object,
-    localeCode: PropTypes.string,
-    needsGutter: PropTypes.bool
+    localeCode: PropTypes.string
   };
 
   constructor(props) {
@@ -88,7 +87,7 @@ export default class ProgressTableStudentList extends React.Component {
           rows={this.props.section.students}
           rowKey={'id'}
           style={{
-            overflowX: this.props.needsGutter ? 'scroll' : 'hidden',
+            overflowX: 'scroll',
             overflowY: 'hidden',
             maxHeight: parseInt(progressTableStyles.MAX_BODY_HEIGHT)
           }}

--- a/apps/src/templates/sectionProgress/progressTables/ProgressTableSummaryView.jsx
+++ b/apps/src/templates/sectionProgress/progressTables/ProgressTableSummaryView.jsx
@@ -12,10 +12,9 @@ import {
 } from '@cdo/apps/templates/sectionProgress/sectionProgressRedux';
 import ProgressTableContainer from './ProgressTableContainer';
 import ProgressTableSummaryCell from './ProgressTableSummaryCell';
-import progressTableStyles from './progressTableStyles.scss';
 import SummaryViewLegend from '@cdo/apps/templates/sectionProgress/summary/SummaryViewLegend';
 
-const MIN_COLUMN_WIDTH = 40;
+const COLUMN_WIDTH = 40;
 
 // This component summarizes progress for all lessons in a script, for each student
 // in a section.  It combines summary-specific components such as
@@ -32,13 +31,6 @@ class ProgressTableSummaryView extends React.Component {
   constructor(props) {
     super(props);
     this.summaryCellFormatter = this.summaryCellFormatter.bind(this);
-  }
-
-  getTableWidth(lessons) {
-    return Math.max(
-      lessons.length * MIN_COLUMN_WIDTH,
-      progressTableStyles.CONTENT_VIEW_WIDTH
-    );
   }
 
   summaryCellFormatter(lesson, student, studentProgress) {
@@ -61,9 +53,8 @@ class ProgressTableSummaryView extends React.Component {
     return (
       <ProgressTableContainer
         onClickLesson={this.props.onClickLesson}
-        getTableWidth={lessons => this.getTableWidth(lessons)}
         columnWidths={new Array(this.props.scriptData.stages.length).fill(
-          MIN_COLUMN_WIDTH
+          COLUMN_WIDTH
         )}
         lessonCellFormatter={this.summaryCellFormatter}
       >

--- a/apps/src/templates/sectionProgress/progressTables/progressTableStyles.scss
+++ b/apps/src/templates/sectionProgress/progressTables/progressTableStyles.scss
@@ -1,8 +1,10 @@
 @import 'color';
 @import 'style-constants';
 
+$scrollbar-height: 15px;
 $row-height: 42px;
-$max-height: 680px;
+$max-rows: 14;
+$max-height: $max-rows * $row-height + $scrollbar-height;
 $student-list-width: 170px;
 $content-view-width: $content-width - $student-list-width;
 

--- a/apps/src/templates/sectionProgress/progressTables/progressTableStyles.scss
+++ b/apps/src/templates/sectionProgress/progressTables/progressTableStyles.scss
@@ -8,11 +8,13 @@ $content-view-width: $content-width - $student-list-width;
 
 .progress-table {
   table {
+    table-layout: fixed;
     border: 1px solid;
     border-color: $border-gray;
   }
   th {
     background-color: $table-header;
+    color: $charcoal;
     border-width: 0px 1px 2px 0px;
     border-color: $border-gray;
     height: inherit;
@@ -21,45 +23,35 @@ $content-view-width: $content-width - $student-list-width;
   td {
     padding: 0px;
     box-sizing: border-box;
-  }
-  tr:nth-child(even) {
-    background-color: $background_gray;
-  }
-  .student-list {
-    table {
-      width: $student-list-width;
-      table-layout: fixed;
-    }
-    td,
-    th {
+    border-right: 1px solid;
+    border-color: $border-gray;
+    &:last-child {
       border-right: 0px;
     }
+  }
+  tr {
+    height: $row-height;
+    &:nth-child(even) {
+      background-color: $background_gray;
+    }
+  }
+  .student-list {
+    table,
     th {
       width: $student-list-width;
-      background-color: $table-header;
-      color: $charcoal;
     }
-    tr,
-    td {
-      display: block;
-      width: 100%;
+    tbody {
+      tr,
+      td {
+        display: block;
+        width: 100%;
+      }
     }
   }
   .content-view {
     thead,
     tbody {
       max-width: $content-view-width;
-    }
-    tr {
-      height: $row-height;
-    }
-    th,
-    td {
-      border-right: 1px solid;
-      border-color: $border-gray;
-      &:last-child {
-        border-right: 0px;
-      }
     }
   }
 }

--- a/apps/src/templates/sectionProgress/sectionProgressTestHelpers.js
+++ b/apps/src/templates/sectionProgress/sectionProgressTestHelpers.js
@@ -37,7 +37,7 @@ export function createStore(numStudents, numLessons) {
     stageExtras: false
   };
   for (let i = 0; i < numStudents; i++) {
-    section.students.push({id: i, name: 'Student' + i});
+    section.students.push({id: i, name: 'Student' + i + ' Long Lastname'});
   }
   try {
     registerReducers({

--- a/apps/test/unit/templates/sectionProgress/progressTables/ProgressTableContainerTest.jsx
+++ b/apps/test/unit/templates/sectionProgress/progressTables/ProgressTableContainerTest.jsx
@@ -70,22 +70,6 @@ describe('ProgressTableContainer', () => {
       .false;
   });
 
-  it('passes needsGutter true to the ProgressTableStudentList when the width of the stages exceeds the content view width', () => {
-    // 2000px will exceed with content view width
-    const getTableWidth = () => 2000;
-    const wrapper = setUp({getTableWidth});
-    expect(wrapper.find(ProgressTableStudentList).props().needsGutter).to.be
-      .true;
-  });
-
-  it('passes needsGutter false to the ProgressTableStudentList when the width of the stages is less than the content view width', () => {
-    // 20px will be less than the content view width
-    const getTableWidth = () => 20;
-    const wrapper = setUp({getTableWidth});
-    expect(wrapper.find(ProgressTableStudentList).props().needsGutter).to.be
-      .false;
-  });
-
   it('passes extraHeaderLabels to the ProgressTableStudentList', () => {
     const extraHeaderLabels = ['extraheader'];
     const wrapper = setUp({extraHeaderLabels});

--- a/apps/test/unit/templates/sectionProgress/progressTables/ProgressTableDetailCellTest.jsx
+++ b/apps/test/unit/templates/sectionProgress/progressTables/ProgressTableDetailCellTest.jsx
@@ -1,14 +1,10 @@
 import React from 'react';
 import {expect} from '../../../../util/reconfiguredChai';
 import {shallow} from 'enzyme';
-import ProgressTableDetailCell, {
-  unitTestExports
-} from '@cdo/apps/templates/sectionProgress/progressTables/ProgressTableDetailCell';
+import ProgressTableDetailCell from '@cdo/apps/templates/sectionProgress/progressTables/ProgressTableDetailCell';
 import ProgressTableLevelBubble from '@cdo/apps/templates/sectionProgress/progressTables/ProgressTableLevelBubble';
 import sinon from 'sinon';
 import firehoseClient from '@cdo/apps/lib/util/firehose';
-import * as progressStyles from '@cdo/apps/templates/progress/progressStyles';
-import i18n from '@cdo/locale';
 import {
   fakeLevel,
   fakeProgressForLevels
@@ -93,53 +89,5 @@ describe('ProgressTableDetailCell', () => {
     );
     sublevel.simulate('click');
     expect(firehoseClient.putRecord).to.have.been.called;
-  });
-
-  it('widthForLevels returns the correct width when there are unplugged levels', () => {
-    const levels = [level_1, level_1];
-    const unpluggedWidth = unitTestExports.getUnpluggedWidth();
-    const expectedWidth = 2 * unpluggedWidth + 2 * progressStyles.CELL_PADDING;
-    expect(ProgressTableDetailCell.widthForLevels(levels)).to.equal(
-      expectedWidth
-    );
-  });
-
-  it('getUnpluggedWidth returns the width of the unplugged bubble in english', () => {
-    expect(unitTestExports.getUnpluggedWidth()).to.equal(121);
-  });
-
-  it('getUnpluggedWidth returns the width of the unplugged bubble in spanish', () => {
-    sinon.stub(i18n, 'unpluggedActivity').returns('Actividad fuera de línea');
-    expect(unitTestExports.getUnpluggedWidth()).to.equal(147);
-  });
-
-  it('widthForLevels returns the correct width when there are no unplugged levels', () => {
-    const notUnpluggedLevel = fakeLevel({
-      isUnplugged: false
-    });
-    const levels = [notUnpluggedLevel, notUnpluggedLevel];
-
-    const levelCount = 2;
-    const expectedWidth =
-      levelCount * progressStyles.BUBBLE_CONTAINER_WIDTH +
-      2 * progressStyles.CELL_PADDING;
-
-    expect(ProgressTableDetailCell.widthForLevels(levels)).to.equal(
-      expectedWidth
-    );
-  });
-
-  it('widthForLevels returns the correct width when there are sublevels', () => {
-    const levels = [level_2];
-
-    const sublevelCount = level_2.sublevels.length;
-    const expectedWidth =
-      progressStyles.BUBBLE_CONTAINER_WIDTH +
-      sublevelCount * progressStyles.LETTER_BUBBLE_CONTAINER_WIDTH +
-      2 * progressStyles.CELL_PADDING;
-
-    expect(ProgressTableDetailCell.widthForLevels(levels)).to.equal(
-      expectedWidth
-    );
   });
 });


### PR DESCRIPTION
we discovered a few non-blocking bugs in our table layout during final testing, which this PR resolves.

1) the detail view second header row was 1px shorter in the content view than in the student list, causing the whole table to be misaligned by 1px.
2) we had not accounted for level icon layout in multi-level lessons that include an unplugged level.
3) unplugged bubble widths were being calculated incorrectly in chrome, causing those bubbles to overflow their columns (more on this below).
4) we had inadvertently made the tables taller by setting their body heights to the previous height of the whole table 

## before
<img width="242" alt="Screen Shot 2021-02-17 at 10 30 02 AM" src="https://user-images.githubusercontent.com/4986878/108259955-90f31100-7116-11eb-8e12-0af12fda7e4a.png">

## after
<img width="237" alt="Screen Shot 2021-02-17 at 10 45 15 AM" src="https://user-images.githubusercontent.com/4986878/108260012-a5370e00-7116-11eb-9a85-900b308c3a70.png">

## unplugged widths
we were using a hacky method to calculate the width of a localized unplugged bubble by rendering it in the dom, measuring it, then removing it. however, i discovered right after we shipped that chrome was producing the wrong value in this calculation. after some investigation it turned out that our font wasn't fully loaded by the time the calculation was run, resulting in a smaller pixel width.

after trying a few different ways to solve this width calculation problem, i decided to revisit the underlying need for explicit widths in the first place. in short, while there were several motivating factors, the only actual _need_ was for calculating the width of the table to conditionally render a gutter at the bottom of the student list when the content view is displaying a scrollbar. it had never occurred to me before that a much simpler (though slightly less visually appealing) solution was to just have both parts of the table always show a gutter to avoid the need to know if the content view is showing a scrollbar.

making this change allowed for a lot of good code simplification. however, due to how reactabular handles sticky headers and body virtualization, our table headers are unable to automatically size themselves based on cell content in the body, which means the headers either need to know the exact width of their body columns, or they need to render something of the same size. the way i handled this before running into the scrollbar-gutters-need-table-width issue was to simply render an invisible dummy detail cell in the header to define its size. this is obviously also hacky, but imo much less so than the previous dom measurement solution. and since the unplugged bubble is the only bubble with a dynamic size, i'm only using the hack for those icons.

tl;dr -- our detail view content table is now sizing its columns based on content size rather than explicit width. in the headers, it gets that size from the ProgressTableLevelIcon. in the body, it gets _the same_ size from the ProgressTableDetailCell. summary view content table is still using explicit width constraints to avoid some off-by-one rounding errors between header and body cells that i was seeing during development.