### PR TITLE
[AiLab] correctly access data in testValues

### DIFF
--- a/apps/src/MLTrainers.js
+++ b/apps/src/MLTrainers.js
@@ -1,4 +1,5 @@
 import KNN from 'ml-knn';
+import {stripSpaceAndSpecial} from '@cdo/apps/aiUtils';
 
 const KNNTrainers = ['knnClassify', 'knnRegress'];
 
@@ -48,7 +49,7 @@ export function predict(modelData) {
       convertTestValue(
         modelData.featureNumberKey,
         feature,
-        modelData.testData[feature.replace(/\W/g, '')]
+        modelData.testData[stripSpaceAndSpecial(feature)]
       )
     );
     // Make a prediction.

--- a/apps/src/MLTrainers.js
+++ b/apps/src/MLTrainers.js
@@ -48,7 +48,7 @@ export function predict(modelData) {
       convertTestValue(
         modelData.featureNumberKey,
         feature,
-        modelData.testData[feature]
+        modelData.testData[feature.replace(/\W/g, '')]
       )
     );
     // Make a prediction.

--- a/apps/src/aiUtils.js
+++ b/apps/src/aiUtils.js
@@ -1,0 +1,5 @@
+// Strip whitespace and special characters. We need this to use feature name
+// strings as design element ids and object {} keys.
+export function stripSpaceAndSpecial(string) {
+  return string.replace(/\W/g, '');
+}

--- a/apps/src/applab/ai.js
+++ b/apps/src/applab/ai.js
@@ -1,5 +1,6 @@
 import $ from 'jquery';
 import designMode from './designMode';
+import {stripSpaceAndSpecial} from '@cdo/apps/aiUtils';
 
 function generateCodeDesignElements(modelId, modelData) {
   var x = 20;
@@ -9,8 +10,7 @@ function generateCodeDesignElements(modelId, modelData) {
   modelData.selectedFeatures.forEach(feature => {
     y = y + SPACER_PIXELS;
     var label = designMode.createElement('LABEL', x, y);
-    // Strip whitespace and special characters.
-    var alphaNumFeature = feature.replace(/\W/g, '');
+    var alphaNumFeature = stripSpaceAndSpecial(feature);
     label.textContent = feature + ':';
     label.id = 'design_' + alphaNumFeature + '_label';
     label.style.width = '300px';
@@ -39,7 +39,7 @@ function generateCodeDesignElements(modelId, modelData) {
   y = y + 2 * SPACER_PIXELS;
   var label = designMode.createElement('LABEL', x, y);
   label.textContent = modelData.labelColumn;
-  var alphaNumModelName = modelData.name.replace(/\W/g, '');
+  var alphaNumModelName = stripSpaceAndSpecial(modelData.name);
   label.id = 'design_' + alphaNumModelName + '_label';
   label.style.width = '300px';
   y = y + SPACER_PIXELS;


### PR DESCRIPTION
tldr: "Whipped Cream" != "WhippedCream"

We got reports from the curriculum team of a bug where the prediction in AI Lab didn't match the prediction in App Lab for the same trained model with the same test values. This initially seemed very worrisome, but was actually quite a straightforward fix. 

In #39067 we striped column names from AI Lab trained models of whitespace and special characters so they could be used as design element ids and keys in the `testValues` object. 

However, in the `predict` function we were not correctly accessing values in `testValues` to pass to the `convertTestValue` function from #39044. Therefore, certain features (particularly those with spaces, e.g. "whipped cream" and "fried chicken") were being converted to NaN, which was causing the trained model to return inaccurate predictions. 

BEFORE: 
<img width="634" alt="Screen Shot 2021-02-16 at 10 23 31 PM" src="https://user-images.githubusercontent.com/12300669/108152010-0f639a80-70a6-11eb-9883-43ba924bcfcf.png">

AFTER: 
<img width="466" alt="Screen Shot 2021-02-16 at 10 06 41 PM" src="https://user-images.githubusercontent.com/12300669/108152015-138fb800-70a6-11eb-8a45-0409dc5292ce.png">

Now, predictions are consistent across AI Lab and App Lab. 
