### PR TITLE
Increase Autoscaler capacity check frequency

### DIFF
--- a/aws/cloudformation/drone-stack.yml
+++ b/aws/cloudformation/drone-stack.yml
@@ -12,6 +12,11 @@ Parameters:
   ServiceSubnetIds:
     Type: List<AWS::EC2::Subnet::Id>
     Description: Comma separated list of existing VPC Subnet Ids where ECS EC2 Instances hosting Drone Service & Drone Autoscaler Service containers will be provisioned.
+  AutoscalerCapacityCheckInterval:
+    Type: String
+    # https://autoscale.drone.io/reference/drone-interval/
+    Description: The interval at which the Autoscaler capacity check algorithm is run to determine whether to provision new or terminate existing Drone Runner EC2 Instances.
+    Default: 1m
   WorkerPoolMinimum:
     Type: Number
     Description: Minimum number of physical servers that the autoscaler must keep alive.
@@ -326,6 +331,9 @@ Resources:
             -
               Name: DRONE_SERVER_TOKEN
               Value: '{{resolve:secretsmanager:drone/shared:SecretString:DRONE_SERVER_TOKEN}}'
+            -
+              Name: DRONE_INTERVAL
+              Value: !Ref AutoscalerCapacityCheckInterval
             -
               Name: DRONE_POOL_MIN
               Value: !Ref WorkerPoolMinimum


### PR DESCRIPTION
Despite [what the documentation says](https://autoscale.drone.io/reference/drone-interval/), logs on our Drone Autoscaler service indicate it is only carrying out a capacity check every 5 minutes to determine whether to provision additional Drone Runner EC2 Instances or to terminate unused Instances. Increase the frequency (lower the interval) to 1 minute to improve how quickly Drone Runner servers are provisioned to run new builds.

## Links

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

<!--
- spec: []()
- jira ticket: []()
-->

## Testing story

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
