### PR TITLE
Display project capacity in WebLab

### DIFF
--- a/apps/i18n/weblab/en_us.json
+++ b/apps/i18n/weblab/en_us.json
@@ -3,6 +3,7 @@
   "addImageButton": "Add Image",
   "addHTMLButton": "Add HTML",
   "confirmExitWithUnsavedChanges": "Do you want to exit with unsaved changes?",
+  "currentProjectCapacity": "{currentMegabytes}MB of {totalMegabytes}MB used",
   "errorSavingProject": "Something didn't work while auto-saving your project. Check your internet connection and try manually saving. If this problem persists, try reloading the page to start over.",
   "refreshPreview": "Refresh and Save",
   "toggleInspectorOn": "Inspector: Off",

--- a/apps/src/templates/Meter.jsx
+++ b/apps/src/templates/Meter.jsx
@@ -14,7 +14,7 @@ const styles = {
     width: 100,
     height: 10,
     borderRadius: 8,
-    backgroundColor: 'white',
+    backgroundColor: color.white,
     overflow: 'hidden'
   },
   meterValue: {

--- a/apps/src/templates/Meter.jsx
+++ b/apps/src/templates/Meter.jsx
@@ -44,9 +44,11 @@ export default class Meter extends Component {
 
     return (
       <div style={{...styles.container, ...containerStyle}}>
-        <label htmlFor={id} style={styles.label}>
-          {label}
-        </label>
+        {label && (
+          <label htmlFor={id} style={styles.label}>
+            {label}
+          </label>
+        )}
         <div id={id} style={styles.meter}>
           <div
             style={{

--- a/apps/src/templates/Meter.jsx
+++ b/apps/src/templates/Meter.jsx
@@ -1,0 +1,62 @@
+import React, {Component} from 'react';
+import PropTypes from 'prop-types';
+import color from '@cdo/apps/util/color';
+
+const styles = {
+  container: {
+    display: 'flex',
+    alignItems: 'center'
+  },
+  label: {
+    margin: '0 10px'
+  },
+  meter: {
+    width: 100,
+    height: 10,
+    borderRadius: 8,
+    backgroundColor: 'white',
+    overflow: 'hidden'
+  },
+  meterValue: {
+    height: '100%'
+  }
+};
+
+export default class Meter extends Component {
+  static propTypes = {
+    id: PropTypes.string.isRequired,
+    label: PropTypes.string,
+    value: PropTypes.number.isRequired,
+    max: PropTypes.number.isRequired,
+    containerStyle: PropTypes.object
+  };
+
+  render() {
+    const {id, label, value, max, containerStyle} = this.props;
+    const percentFull = Math.round((value / max) * 100);
+
+    let backgroundColor = color.light_teal;
+    if (percentFull >= 90) {
+      backgroundColor = color.red;
+    } else if (percentFull >= 75) {
+      backgroundColor = color.orange;
+    }
+
+    return (
+      <div style={{...styles.container, ...containerStyle}}>
+        <label htmlFor={id} style={styles.label}>
+          {label}
+        </label>
+        <div id={id} style={styles.meter}>
+          <div
+            style={{
+              ...styles.meterValue,
+              width: `${percentFull}%`,
+              backgroundColor
+            }}
+          />
+        </div>
+      </div>
+    );
+  }
+}

--- a/apps/src/templates/Meter.story.jsx
+++ b/apps/src/templates/Meter.story.jsx
@@ -1,0 +1,65 @@
+import React from 'react';
+import Meter from '@cdo/apps/templates/Meter';
+import color from '@cdo/apps/util/color';
+
+// The meter background is white, so add a background color to make
+// the meter more easily visible.
+const containerStyle = {
+  backgroundColor: color.lightest_gray,
+  padding: 10
+};
+
+export default storybook => {
+  return storybook.storiesOf('Meter', module).addStoryTable([
+    {
+      name: 'Half-full meter',
+      description: 'Displays the default meter color',
+      story: () => (
+        <Meter
+          id="meter-1"
+          label="Glass half-full:"
+          value={5}
+          max={10}
+          containerStyle={containerStyle}
+        />
+      )
+    },
+    {
+      name: '75%+ full meter',
+      description: 'Displays a warning meter color',
+      story: () => (
+        <Meter
+          id="meter-2"
+          label="Warning zone:"
+          value={8}
+          max={10}
+          containerStyle={containerStyle}
+        />
+      )
+    },
+    {
+      name: '90%+ full meter',
+      description: 'Displays a stronger warning meter color',
+      story: () => (
+        <Meter
+          id="meter-3"
+          label="Almost full!"
+          value={9}
+          max={10}
+          containerStyle={containerStyle}
+        />
+      )
+    },
+    {
+      name: 'Meter with no label',
+      story: () => (
+        <Meter
+          id="meter-4"
+          value={4}
+          max={10}
+          containerStyle={containerStyle}
+        />
+      )
+    }
+  ]);
+};

--- a/apps/src/weblab/WebLab.js
+++ b/apps/src/weblab/WebLab.js
@@ -30,6 +30,9 @@ export const WEBLAB_FOOTER_HEIGHT = 30;
 // Global singleton
 let webLab_ = null;
 
+// The max size in bytes for a WebLab project. 20 megabytes == 20971520 bytes
+const MAX_PROJECT_CAPACITY = 20971520;
+
 const WebLab = function() {
   this.skin = null;
   this.level = null;
@@ -79,6 +82,7 @@ WebLab.prototype.init = function(config) {
   this.level = config.level;
   this.suppliedFilesVersionId = queryParams('version');
   this.initialFilesVersionId = this.suppliedFilesVersionId;
+  getStore().dispatch(actions.changeMaxProjectCapacity(MAX_PROJECT_CAPACITY));
 
   this.brambleHost = null;
 
@@ -341,6 +345,14 @@ WebLab.prototype.onFinish = function(submit) {
   } else {
     this.reportResult(submit, true /* validated */);
   }
+};
+
+WebLab.prototype.getMaxProjectCapacity = function() {
+  return getStore().getState().maxProjectCapacity;
+};
+
+WebLab.prototype.setProjectSize = function(bytes) {
+  getStore().dispatch(actions.changeProjectSize(bytes));
 };
 
 WebLab.prototype.getCodeAsync = function() {

--- a/apps/src/weblab/WebLabView.jsx
+++ b/apps/src/weblab/WebLabView.jsx
@@ -14,7 +14,7 @@ import {changeShowError} from './actions';
 import BaseDialog from '@cdo/apps/templates/BaseDialog';
 import Button from '@cdo/apps/templates/Button';
 import {getStore} from '../redux';
-import color from '@cdo/apps/util/color';
+import Meter from '@cdo/apps/templates/Meter';
 
 // Coefficient for converting bytes to megabytes.
 const B_TO_MB_COEFFICIENT = 0.000000954;
@@ -58,51 +58,9 @@ class WebLabView extends React.Component {
     return Math.round(bytes * B_TO_MB_COEFFICIENT);
   };
 
-  renderProjectCapacityMeter = () => {
-    const {maxProjectCapacity, projectSize} = this.props;
-    if (maxProjectCapacity <= 0 || projectSize <= 0) {
-      return null;
-    }
-
-    const id = 'weblab-project-capacity';
-    const percentUsed = Math.round((projectSize / maxProjectCapacity) * 100);
-    const styles = {
-      container: {
-        float: 'left',
-        display: 'flex',
-        height: styleConstants['workspace-headers-height'],
-        alignItems: 'center'
-      },
-      meterContainer: {
-        width: 100,
-        height: 10,
-        borderRadius: 8,
-        backgroundColor: 'white',
-        overflow: 'hidden'
-      },
-      meter: {
-        width: `${percentUsed}%`,
-        height: '100%',
-        backgroundColor: color.light_teal
-      }
-    };
-
-    return (
-      <div style={styles.container}>
-        <label htmlFor={id} style={{margin: '0 10px'}}>
-          {weblabMsg.currentProjectCapacity({
-            currentMegabytes: this.bytesToMegabytes(projectSize),
-            totalMegabytes: this.bytesToMegabytes(maxProjectCapacity)
-          })}
-        </label>
-        <div id={id} style={styles.meterContainer}>
-          <div style={styles.meter} />
-        </div>
-      </div>
-    );
-  };
-
   render() {
+    const {maxProjectCapacity, projectSize} = this.props;
+
     let headersHeight = styleConstants['workspace-headers-height'];
     let iframeHeightOffset =
       headersHeight + (this.props.isProjectLevel ? 0 : 70);
@@ -111,6 +69,10 @@ class WebLabView extends React.Component {
       width: '100%',
       height: `calc(100% - ${iframeHeightOffset}px)`
     };
+    const projectCapacityLabel = weblabMsg.currentProjectCapacity({
+      currentMegabytes: this.bytesToMegabytes(projectSize),
+      totalMegabytes: this.bytesToMegabytes(maxProjectCapacity)
+    });
 
     return (
       <StudioAppWrapper>
@@ -175,7 +137,18 @@ class WebLabView extends React.Component {
                         isRtl={false}
                         label={msg.showVersionsHeader()}
                       />
-                      {this.renderProjectCapacityMeter()}
+                      {maxProjectCapacity > 0 && projectSize > 0 && (
+                        <Meter
+                          id="weblab-project-capacity"
+                          label={projectCapacityLabel}
+                          value={projectSize}
+                          max={maxProjectCapacity}
+                          containerStyle={{
+                            float: 'left',
+                            height: styleConstants['workspace-headers-height']
+                          }}
+                        />
+                      )}
                       <PaneButton
                         iconClass="fa fa-repeat"
                         leftJustified={false}

--- a/apps/src/weblab/WebLabView.jsx
+++ b/apps/src/weblab/WebLabView.jsx
@@ -55,7 +55,25 @@ class WebLabView extends React.Component {
   }
 
   bytesToMegabytes = bytes => {
-    return Math.round(bytes * B_TO_MB_COEFFICIENT);
+    return bytes * B_TO_MB_COEFFICIENT;
+  };
+
+  projectCapacityLabel = () => {
+    let totalMegabytes = Math.round(
+      this.bytesToMegabytes(this.props.maxProjectCapacity)
+    );
+    let currentMegabytes = this.bytesToMegabytes(this.props.projectSize);
+    // If using 75%+ capacity, display a decimal with 2 digits.
+    // Otherwise, round the capacity.
+    currentMegabytes =
+      currentMegabytes / totalMegabytes >= 0.75
+        ? currentMegabytes.toFixed(2)
+        : Math.round(currentMegabytes);
+
+    return weblabMsg.currentProjectCapacity({
+      currentMegabytes,
+      totalMegabytes
+    });
   };
 
   render() {
@@ -69,10 +87,6 @@ class WebLabView extends React.Component {
       width: '100%',
       height: `calc(100% - ${iframeHeightOffset}px)`
     };
-    const projectCapacityLabel = weblabMsg.currentProjectCapacity({
-      currentMegabytes: this.bytesToMegabytes(projectSize),
-      totalMegabytes: this.bytesToMegabytes(maxProjectCapacity)
-    });
 
     return (
       <StudioAppWrapper>
@@ -140,7 +154,7 @@ class WebLabView extends React.Component {
                       {maxProjectCapacity > 0 && projectSize > 0 && (
                         <Meter
                           id="weblab-project-capacity"
-                          label={projectCapacityLabel}
+                          label={this.projectCapacityLabel()}
                           value={projectSize}
                           max={maxProjectCapacity}
                           containerStyle={{

--- a/apps/src/weblab/WebLabView.jsx
+++ b/apps/src/weblab/WebLabView.jsx
@@ -16,8 +16,10 @@ import Button from '@cdo/apps/templates/Button';
 import {getStore} from '../redux';
 import Meter from '@cdo/apps/templates/Meter';
 
-// Coefficient for converting bytes to megabytes.
-const B_TO_MB_COEFFICIENT = 0.000000954;
+// Helper for converting bytes to megabytes.
+const bytesToMegabytes = bytes => {
+  return bytes * 0.000000954;
+};
 
 /**
  * Top-level React wrapper for WebLab
@@ -54,15 +56,11 @@ class WebLabView extends React.Component {
     getStore().dispatch(changeShowError(false));
   }
 
-  bytesToMegabytes = bytes => {
-    return bytes * B_TO_MB_COEFFICIENT;
-  };
-
   projectCapacityLabel = () => {
     let totalMegabytes = Math.round(
-      this.bytesToMegabytes(this.props.maxProjectCapacity)
+      bytesToMegabytes(this.props.maxProjectCapacity)
     );
-    let currentMegabytes = this.bytesToMegabytes(this.props.projectSize);
+    let currentMegabytes = bytesToMegabytes(this.props.projectSize);
     // If using 75%+ capacity, display a decimal with 2 digits.
     // Otherwise, round the capacity.
     currentMegabytes =

--- a/apps/src/weblab/WebLabView.jsx
+++ b/apps/src/weblab/WebLabView.jsx
@@ -14,6 +14,7 @@ import {changeShowError} from './actions';
 import BaseDialog from '@cdo/apps/templates/BaseDialog';
 import Button from '@cdo/apps/templates/Button';
 import {getStore} from '../redux';
+import color from '@cdo/apps/util/color';
 
 // Coefficient for converting bytes to megabytes.
 const B_TO_MB_COEFFICIENT = 0.000000954;
@@ -64,25 +65,39 @@ class WebLabView extends React.Component {
     }
 
     const id = 'weblab-project-capacity';
-    const sizeContainerStyles = {
-      float: 'left',
-      display: 'flex',
-      height: styleConstants['workspace-headers-height'],
-      alignItems: 'center'
-    };
     const percentUsed = Math.round((projectSize / maxProjectCapacity) * 100);
+    const styles = {
+      container: {
+        float: 'left',
+        display: 'flex',
+        height: styleConstants['workspace-headers-height'],
+        alignItems: 'center'
+      },
+      meterContainer: {
+        width: 100,
+        height: 10,
+        borderRadius: 8,
+        backgroundColor: 'white',
+        overflow: 'hidden'
+      },
+      meter: {
+        width: `${percentUsed}%`,
+        height: '100%',
+        backgroundColor: color.light_teal
+      }
+    };
 
     return (
-      <div style={sizeContainerStyles}>
+      <div style={styles.container}>
         <label htmlFor={id} style={{margin: '0 10px'}}>
           {weblabMsg.currentProjectCapacity({
             currentMegabytes: this.bytesToMegabytes(projectSize),
             totalMegabytes: this.bytesToMegabytes(maxProjectCapacity)
           })}
         </label>
-        <meter id={id} max={maxProjectCapacity} value={projectSize}>
-          ({percentUsed}%)
-        </meter>
+        <div id={id} style={styles.meterContainer}>
+          <div style={styles.meter} />
+        </div>
       </div>
     );
   };

--- a/apps/src/weblab/WebLabView.jsx
+++ b/apps/src/weblab/WebLabView.jsx
@@ -57,9 +57,37 @@ class WebLabView extends React.Component {
     return Math.round(bytes * B_TO_MB_COEFFICIENT);
   };
 
-  render() {
+  renderProjectCapacityMeter = () => {
     const {maxProjectCapacity, projectSize} = this.props;
+    if (maxProjectCapacity <= 0 || projectSize <= 0) {
+      return null;
+    }
 
+    const id = 'weblab-project-capacity';
+    const sizeContainerStyles = {
+      float: 'left',
+      display: 'flex',
+      height: styleConstants['workspace-headers-height'],
+      alignItems: 'center'
+    };
+    const percentUsed = Math.round((projectSize / maxProjectCapacity) * 100);
+
+    return (
+      <div style={sizeContainerStyles}>
+        <label htmlFor={id} style={{margin: '0 10px'}}>
+          {weblabMsg.currentProjectCapacity({
+            currentMegabytes: this.bytesToMegabytes(projectSize),
+            totalMegabytes: this.bytesToMegabytes(maxProjectCapacity)
+          })}
+        </label>
+        <meter id={id} max={maxProjectCapacity} value={projectSize}>
+          ({percentUsed}%)
+        </meter>
+      </div>
+    );
+  };
+
+  render() {
     let headersHeight = styleConstants['workspace-headers-height'];
     let iframeHeightOffset =
       headersHeight + (this.props.isProjectLevel ? 0 : 70);
@@ -67,12 +95,6 @@ class WebLabView extends React.Component {
       position: 'absolute',
       width: '100%',
       height: `calc(100% - ${iframeHeightOffset}px)`
-    };
-    const sizeContainerStyles = {
-      float: 'left',
-      display: 'flex',
-      height: headersHeight,
-      alignItems: 'center'
     };
 
     return (
@@ -138,34 +160,7 @@ class WebLabView extends React.Component {
                         isRtl={false}
                         label={msg.showVersionsHeader()}
                       />
-                      {projectSize > 0 && maxProjectCapacity > 0 && (
-                        <div style={sizeContainerStyles}>
-                          <label
-                            htmlFor="weblab-project-capacity"
-                            style={{margin: '0 10px'}}
-                          >
-                            {weblabMsg.currentProjectCapacity({
-                              currentMegabytes: this.bytesToMegabytes(
-                                projectSize
-                              ),
-                              totalMegabytes: this.bytesToMegabytes(
-                                maxProjectCapacity
-                              )
-                            })}
-                          </label>
-                          <meter
-                            id="weblab-project-capacity"
-                            max={maxProjectCapacity}
-                            value={projectSize}
-                          >
-                            (
-                            {Math.round(
-                              (projectSize / maxProjectCapacity) * 100
-                            )}
-                            %)
-                          </meter>
-                        </div>
-                      )}
+                      {this.renderProjectCapacityMeter()}
                       <PaneButton
                         iconClass="fa fa-repeat"
                         leftJustified={false}

--- a/apps/src/weblab/actions.js
+++ b/apps/src/weblab/actions.js
@@ -6,7 +6,9 @@ import * as utils from '../utils';
 export const ActionType = utils.makeEnum(
   'CHANGE_FULL_SCREEN_PREVIEW_ON',
   'CHANGE_INSPECTOR_ON',
-  'CHANGE_SHOW_ERROR'
+  'CHANGE_SHOW_ERROR',
+  'CHANGE_MAX_PROJECT_CAPACITY',
+  'CHANGE_PROJECT_SIZE'
 );
 
 /**
@@ -42,5 +44,28 @@ export function changeShowError(showError) {
   return {
     type: ActionType.CHANGE_SHOW_ERROR,
     showError
+  };
+}
+
+/**
+ * Set the maximum project size in bytes.
+ * @param {number} bytes
+ * @returns {{type: ActionType, bytes: number}}
+ */
+export function changeMaxProjectCapacity(bytes) {
+  return {
+    type: ActionType.CHANGE_MAX_PROJECT_CAPACITY,
+    bytes
+  };
+}
+
+/**
+ * Set the current project size in bytes.
+ * @param {number} bytes
+ */
+export function changeProjectSize(bytes) {
+  return {
+    type: ActionType.CHANGE_PROJECT_SIZE,
+    bytes
   };
 }

--- a/apps/src/weblab/brambleHost.js
+++ b/apps/src/weblab/brambleHost.js
@@ -698,7 +698,12 @@ function load(Bramble) {
     bramble.on('fileRename', handleFileRename);
     bramble.on('folderRename', handleFolderRename);
     bramble.on('projectSizeChange', (bytes, percentage) => {
-      webLab_.setProjectSize(bytes);
+      // When an image is uploaded, the project tree refreshes and bytes will be 0
+      // for a short time. This causes the project size meter to flash, so
+      // ignore this event if bytes === 0.
+      if (bytes !== 0) {
+        webLab_.setProjectSize(bytes);
+      }
     });
 
     brambleProxy_ = bramble;

--- a/apps/src/weblab/brambleHost.js
+++ b/apps/src/weblab/brambleHost.js
@@ -12,9 +12,6 @@ window.requirejs.config({baseUrl: BRAMBLE_BASE_URL});
 // This is needed to support jQuery binary downloads
 import '../assetManagement/download';
 
-// the max size in bytes for a bramble project -- 20 megabytes == 20971520 bytes
-const MAX_PROJECT_CAPACITY = 20971520;
-
 // the main Bramble object -- used to access file system
 let bramble_ = null;
 // the Bramble proxy object -- used to access methods on the Bramble UI frame
@@ -607,7 +604,7 @@ function load(Bramble) {
     url: BRAMBLE_BASE_URL + '/index.html',
     useLocationSearch: true,
     disableUIState: true,
-    capacity: MAX_PROJECT_CAPACITY,
+    capacity: webLab_.getMaxProjectCapacity(),
     initialUIState: {
       theme: 'light-theme',
       readOnly: webLab_.getPageConstants().isReadOnlyWorkspace
@@ -700,6 +697,9 @@ function load(Bramble) {
     bramble.on('fileDelete', handleFileDelete);
     bramble.on('fileRename', handleFileRename);
     bramble.on('folderRename', handleFolderRename);
+    bramble.on('projectSizeChange', (bytes, percentage) => {
+      webLab_.setProjectSize(bytes);
+    });
 
     brambleProxy_ = bramble;
 

--- a/apps/src/weblab/reducers.js
+++ b/apps/src/weblab/reducers.js
@@ -35,8 +35,32 @@ function showError(state, action) {
   }
 }
 
+function maxProjectCapacity(state, action) {
+  state = state || -1;
+
+  switch (action.type) {
+    case ActionType.CHANGE_MAX_PROJECT_CAPACITY:
+      return action.bytes;
+    default:
+      return state;
+  }
+}
+
+function projectSize(state, action) {
+  state = state || -1;
+
+  switch (action.type) {
+    case ActionType.CHANGE_PROJECT_SIZE:
+      return action.bytes;
+    default:
+      return state;
+  }
+}
+
 export default {
   fullScreenPreviewOn,
   inspectorOn,
-  showError
+  showError,
+  maxProjectCapacity,
+  projectSize
 };


### PR DESCRIPTION
Displays the project capacity for WebLab projects so that users know how close they are to the 20MB project size limit.

**Within the context of WebLab:**
![Screen Shot 2021-02-16 at 9 16 27 AM](https://user-images.githubusercontent.com/9812299/108247650-c6dcc900-7107-11eb-8daf-d20a000fdfac.png)

**The new `<Meter/>` component in Storybook:**
<img width="1165" alt="Screen Shot 2021-02-16 at 7 04 55 PM" src="https://user-images.githubusercontent.com/9812299/108247884-13280900-7108-11eb-95bc-2d1623fdd6db.png">


## Links

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

- jira ticket: [STAR-1407](https://codedotorg.atlassian.net/browse/STAR-1407)

## Testing story

Adds test coverage for the new `<Meter/>` component through Storybook.

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [x] Tests provide adequate coverage
- [x] Code is well-commented
- [x] New features are translatable or updates will not break translations
- [x] User impact is well-understood and desirable
