### PR TITLE
reverting the user and create menus back to clickable divs, but givin…

### DIFF
--- a/dashboard/app/assets/stylesheets/application.scss
+++ b/dashboard/app/assets/stylesheets/application.scss
@@ -283,25 +283,6 @@ img.video_thumbnail {
       background-color: $orange;
     }
   }
-  .user_menu, .create_menu {
-    box-shadow: none;
-    // button:active in this file uses !important for a styling scheme that doesn't
-    // match this button. We use !important here to override that scheme for only this
-    // specific button.
-    &:active {
-      border: 2px solid $white !important;
-    }
-  }
-
-  .create_menu {
-    box-shadow: none;
-    // button:active in this file uses !important for a styling scheme that doesn't
-    // match this button. We use !important here to override that scheme for only this
-    // specific button.
-    &:active {
-      border: 2px solid $white !important;
-    }
-  }
 
   .user_menu, .create_menu, .help_button {
     margin-top: 6px;

--- a/shared/css/user-menu.scss
+++ b/shared/css/user-menu.scss
@@ -139,8 +139,6 @@
     width: max-content;
     z-index: 10000;
     border-bottom: 0;
-    display: flex;
-    flex-direction: column;
     a {
       font-family: 'Gotham 5r', sans-serif;
       min-width: 240px;
@@ -153,16 +151,14 @@
     img {
       height: 70px;
       width: 70px;
-      float: left;
     }
     .project_link_box {
       display: block;
     }
     .project_link {
       display: inline-block;
-      padding: 0 10px 0 8px;
-      line-height: 70px;
-      float: left;
+      padding: 0 10px 0 4px;
+      line-height: 67px;
     }
     #view_all_projects {
       height: 70px;

--- a/shared/haml/user_header.haml
+++ b/shared/haml/user_header.haml
@@ -18,7 +18,7 @@
   should_show_create_menu = !level || level.try(:is_project_level)
 
 - if should_show_create_menu
-  %button.header_button.create_menu.no-mc
+  .header_button.create_menu{tabindex: 0, role: "button"}
     %span.create_button
       = I18n.t("#{loc_prefix}create")
     &nbsp;
@@ -34,7 +34,7 @@
         .project_link#view_all_projects
           = I18n.t("#{loc_prefix}view_all")
 - if current_user
-  %button.header_button.header_user.user_menu.no-mc
+  .header_button.header_user.user_menu{tabindex: 0, role: "button"}
     - if current_user.can_pair? && session_pairings.present?
       %i.fa.fa-users.pairing_icon
       %span.pairing_name= I18n.t("#{loc_prefix}team")
@@ -105,18 +105,20 @@
       $(document).off('click', hideUserOptions);
     }
     $(document).ready(function() {
-      $('.user_menu').click(function (e) {
-        if ($('.user_options').is(':hidden')) {
-          e.stopPropagation();
-          $('.user_options').slideDown();
-          $('.user_menu_arrow_down').hide();
-          $('.user_menu_arrow_up').show();
-          $(document).on('keypress click', hideUserOptions);
-          hideCreateOptions()
-          $("#hamburger-icon").removeClass('active');
-          $("#help-icon").removeClass('active');
-          $('#hamburger #hamburger-contents').slideUp();
-          $('#help-button #help-contents').slideUp();
+      $('.user_menu').on('keypress click', function (e) {
+        if ((e.type === 'keypress' && e.which === 13) || e.type === 'click') {
+          if ($('.user_options').is(':hidden')) {
+            e.stopPropagation();
+            $('.user_options').slideDown();
+            $('.user_menu_arrow_down').hide();
+            $('.user_menu_arrow_up').show();
+            $(document).on('keypress click', hideUserOptions);
+            hideCreateOptions()
+            $("#hamburger-icon").removeClass('active');
+            $("#help-icon").removeClass('active');
+            $('#hamburger #hamburger-contents').slideUp();
+            $('#help-button #help-contents').slideUp();
+          }
         }
       });
       $('.user_options').click(function (e) {
@@ -142,20 +144,20 @@
       $(document).off('click', hideCreateOptions);
     }
     $(document).ready(function() {
-      $('.create_menu').click(function (e) {
-        if ($('.create_options').is(':hidden')) {
-          e.stopPropagation();
-          $('.create_options').slideDown();
-          $('.create_menu_arrow_down').hide();
-          $('.create_menu_arrow_up').show();
-          $(document).on('keypress click', hideCreateOptions);
-          hideUserOptions()
-          $("#hamburger-icon").removeClass('active');
-          $("#help-icon").removeClass('active');
-          $('#hamburger #hamburger-contents').slideUp();
-          $('#help-button #help-contents').slideUp();
-        } else {
-          hideCreateOptions();
+      $('.create_menu').on('keypress click', function (e) {
+        if ((e.type === 'keypress' && e.which === 13) || e.type === 'click') {
+          if ($('.create_options').is(':hidden')) {
+            e.stopPropagation();
+            $('.create_options').slideDown();
+            $('.create_menu_arrow_down').hide();
+            $('.create_menu_arrow_up').show();
+            $(document).on('keypress click', hideCreateOptions);
+            hideUserOptions()
+            $("#hamburger-icon").removeClass('active');
+            $("#help-icon").removeClass('active');
+            $('#hamburger #hamburger-contents').slideUp();
+            $('#help-button #help-contents').slideUp();
+          }
         }
       });
       $('.create_options').click(function (e) {


### PR DESCRIPTION
…g them button roles in the interim

After finding that changing the User and Create menus in our nav bar to buttons breaks mouse/click access in IE, we are restoring these menus as `divs`, but adding a `button` role for better screen reader access

CC @davidsbailey @hannahbergam 

<!--
  A summary of the change, including any relevant background, motivation, and context.
  If relevant, include a description, screenshots, and/or video of the existing and new behavior.
-->

## Links

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

<!--
- spec: []()
- jira ticket: []()
-->

## Testing story

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
