### PR TITLE
Disable flaky AzureTextToSpeech test

### DIFF
--- a/dashboard/test/controllers/concerns/azure_text_to_speech_test.rb
+++ b/dashboard/test/controllers/concerns/azure_text_to_speech_test.rb
@@ -88,21 +88,18 @@ class AzureTextToSpeechTest < ActionController::TestCase
     assert_requested :post, "https://#{@region}.tts.speech.microsoft.com/cognitiveservices/v1", times: 0
   end
 
-  # 02/17/2020 Disabling this test temporarily as it's blocking the build due to flakiness.
-  # TODO: (madelynkasula) Re-enable this test in https://github.com/code-dot-org/code-dot-org/pull/39108
-  #
-  # test 'throttled_get_speech: yields nil on error' do
-  #   Cdo::Throttle.expects(:throttle).once.returns(false)
-  #   AzureTextToSpeech.expects(:get_token).once.returns(@mock_token)
-  #   AzureTextToSpeech.expects(:ssml).once.returns('<speak>hi</speak>')
-  #   stub_request(:post, "https://#{@region}.tts.speech.microsoft.com/cognitiveservices/v1").
-  #     to_raise(ArgumentError)
-  #   Honeybadger.expects(:notify).once
+  test 'throttled_get_speech: yields nil on error' do
+    Cdo::Throttle.expects(:throttle).once.returns(false)
+    AzureTextToSpeech.expects(:get_token).once.returns(@mock_token)
+    AzureTextToSpeech.expects(:ssml).once.returns('<speak>hi</speak>')
+    stub_request(:post, "https://#{@region}.tts.speech.microsoft.com/cognitiveservices/v1").
+      to_raise(ArgumentError)
+    Honeybadger.expects(:notify).once
 
-  #   actual_speech = 'should-get-set-to-nil'
-  #   AzureTextToSpeech.throttled_get_speech('hi', 'female', 'en-US', '123', 1, 1) {|speech| actual_speech = speech}
-  #   assert_nil actual_speech
-  # end
+    actual_speech = 'should-get-set-to-nil'
+    AzureTextToSpeech.throttled_get_speech('hi', 'female', 'en-US', '123', 1, 1) {|speech| actual_speech = speech}
+    assert_nil actual_speech
+  end
 
   test 'get_voices: caches and returns voices array on success' do
     AzureTextToSpeech.stubs(:get_token).returns(@mock_token)
@@ -135,15 +132,18 @@ class AzureTextToSpeechTest < ActionController::TestCase
     assert_nil AzureTextToSpeech.get_voices
   end
 
-  test 'get_azure_speech_service_voices returns nil on error' do
-    AzureTextToSpeech.stubs(:get_token).returns(@mock_token)
-    Honeybadger.expects(:notify).once
-    stub_request(:get, "https://#{@region}.tts.speech.microsoft.com/cognitiveservices/voices/list").
-      with(headers: {'Authorization' => "Bearer #{@mock_token}"}).
-      to_raise(ArgumentError)
+  # 02/17/2020 Disabling this test temporarily as it's blocking the build due to flakiness.
+  # TODO: (madelynkasula) Re-enable this test in https://github.com/code-dot-org/code-dot-org/pull/39108
+  #
+  # test 'get_azure_speech_service_voices returns nil on error' do
+  #   AzureTextToSpeech.stubs(:get_token).returns(@mock_token)
+  #   Honeybadger.expects(:notify).once
+  #   stub_request(:get, "https://#{@region}.tts.speech.microsoft.com/cognitiveservices/voices/list").
+  #     with(headers: {'Authorization' => "Bearer #{@mock_token}"}).
+  #     to_raise(ArgumentError)
 
-    assert_nil AzureTextToSpeech.get_voices
-  end
+  #   assert_nil AzureTextToSpeech.get_voices
+  # end
 
   test 'get_voice_by: returns voice name if exists for given locale + gender' do
     AzureTextToSpeech.stubs(:get_voices).returns(


### PR DESCRIPTION
I disabled the wrong test in #39110 🤦🏻‍♀️ updating to disable the correct test, which will be re-enabled in #39108.