### PR TITLE
moved progress table legends outside of the progress tables

### DIFF
--- a/apps/src/templates/sectionProgress/progressTables/ProgressTableContainer.jsx
+++ b/apps/src/templates/sectionProgress/progressTables/ProgressTableContainer.jsx
@@ -37,7 +37,6 @@ class ProgressTableContainer extends React.Component {
     lessonCellFormatter: PropTypes.func.isRequired,
     extraHeaderFormatters: PropTypes.arrayOf(PropTypes.func),
     extraHeaderLabels: PropTypes.arrayOf(PropTypes.string),
-    children: PropTypes.node.isRequired,
 
     // redux
     section: sectionDataPropType.isRequired,
@@ -107,7 +106,6 @@ class ProgressTableContainer extends React.Component {
             {...this.props}
           />
         </div>
-        {this.props.children}
       </div>
     );
   }

--- a/apps/src/templates/sectionProgress/progressTables/ProgressTableDetailView.jsx
+++ b/apps/src/templates/sectionProgress/progressTables/ProgressTableDetailView.jsx
@@ -54,15 +54,16 @@ class ProgressTableDetailView extends React.Component {
 
   render() {
     return (
-      <ProgressTableContainer
-        onClickLesson={this.props.onClickLesson}
-        lessonCellFormatter={this.detailCellFormatter}
-        includeHeaderArrows={true}
-        extraHeaderFormatters={[this.levelIconHeaderFormatter]}
-        extraHeaderLabels={[i18n.levelType()]}
-      >
+      <div>
+        <ProgressTableContainer
+          onClickLesson={this.props.onClickLesson}
+          lessonCellFormatter={this.detailCellFormatter}
+          includeHeaderArrows={true}
+          extraHeaderFormatters={[this.levelIconHeaderFormatter]}
+          extraHeaderLabels={[i18n.levelType()]}
+        />
         <ProgressLegend excludeCsfColumn={!this.props.scriptData.csf} />
-      </ProgressTableContainer>
+      </div>
     );
   }
 }

--- a/apps/src/templates/sectionProgress/progressTables/ProgressTableSummaryView.jsx
+++ b/apps/src/templates/sectionProgress/progressTables/ProgressTableSummaryView.jsx
@@ -51,15 +51,16 @@ class ProgressTableSummaryView extends React.Component {
 
   render() {
     return (
-      <ProgressTableContainer
-        onClickLesson={this.props.onClickLesson}
-        columnWidths={new Array(this.props.scriptData.stages.length).fill(
-          COLUMN_WIDTH
-        )}
-        lessonCellFormatter={this.summaryCellFormatter}
-      >
+      <div>
+        <ProgressTableContainer
+          onClickLesson={this.props.onClickLesson}
+          columnWidths={new Array(this.props.scriptData.stages.length).fill(
+            COLUMN_WIDTH
+          )}
+          lessonCellFormatter={this.summaryCellFormatter}
+        />
         <SummaryViewLegend showCSFProgressBox={this.props.scriptData.csf} />
-      </ProgressTableContainer>
+      </div>
     );
   }
 }

--- a/apps/test/unit/templates/sectionProgress/progressTables/ProgressTableContainerTest.jsx
+++ b/apps/test/unit/templates/sectionProgress/progressTables/ProgressTableContainerTest.jsx
@@ -77,10 +77,4 @@ describe('ProgressTableContainer', () => {
       wrapper.find(ProgressTableStudentList).props().extraHeaderLabels
     ).to.equal(extraHeaderLabels);
   });
-
-  it('renders props.children', () => {
-    const children = <div id="child-div">This is the child</div>;
-    const wrapper = setUp({children});
-    expect(wrapper.find('#child-div')).to.have.length(1);
-  });
 });


### PR DESCRIPTION
i humbly submit this PR with my foot in my mouth.

when i consolidated table styles in #39091, more of the styling was contained in the parent `.progress-table` class, which is being applied to all children of the `ProgressTableContainer`. since the legends also render tables, this means those styles were unintentionally being applied to the legends. but as has been suggested by both @maureensturgeon and @jamescodeorg, the legends shouldn't be children of the tables anyway. this PR fixes that.