### PR TITLE
[AiLab] protect against errors in metadata retrieval 

### DIFF
--- a/dashboard/app/controllers/api/v1/ml_models_controller.rb
+++ b/dashboard/app/controllers/api/v1/ml_models_controller.rb
@@ -32,7 +32,8 @@ class Api::V1::MlModelsController < Api::V1::JsonApiController
   # GET api/v1/ml_models/metadata/:model_id
   # Retrieve a trained ML model's metadata
   def user_ml_model_metadata
-    metadata = UserMlModel.where(user_id: current_user&.id, model_id: params[:model_id]).first.metadata
+    metadata = UserMlModel.where(user_id: current_user&.id, model_id: params[:model_id])&.first&.metadata
+    return render_404 unless metadata
     render json: JSON.parse(metadata)
   end
 


### PR DESCRIPTION
[HoneyBadger Error 1](https://app.honeybadger.io/projects/3240/faults/76470628)
[HoneyBadger Error 2](https://app.honeybadger.io/projects/3240/faults/76558037)

There were a few scenarios where `api/v1/ml_models/metadata/:model_id` could cause an errors. 

If no model was found => NoMethodError undefined method 'metadata' for NilClass 
If a model was found, but didn't have metadata => no implicit conversion of nil into String when we try to parse 

I added safe operators and a check that metadata != nil to prevent these errors from happening. 