### PR TITLE
[AiLab] fix layout and id bugs in autogenerated continuous feature input fields

### DIFF
--- a/apps/src/applab/ai.js
+++ b/apps/src/applab/ai.js
@@ -12,14 +12,15 @@ function generateCodeDesignElements(modelId, modelData) {
     y = y + SPACER_PIXELS;
     var label = designMode.createElement('LABEL', x, y);
     var alphaNumFeature = stripSpaceAndSpecial(feature);
+    let fieldId;
     label.textContent = feature + ':';
     label.id = 'design_' + alphaNumFeature + '_label';
     label.style.width = '300px';
     y = y + SPACER_PIXELS;
     if (Object.keys(modelData.featureNumberKey).includes(feature)) {
-      var selectId = alphaNumFeature + '_dropdown';
+      fieldId = alphaNumFeature + '_dropdown';
       var select = designMode.createElement('DROPDOWN', x, y);
-      select.id = 'design_' + selectId;
+      select.id = 'design_' + fieldId;
       // App Lab automatically addss "option 1" and "option 2", remove them.
       select.options.remove(0);
       select.options.remove(0);
@@ -30,11 +31,12 @@ function generateCodeDesignElements(modelId, modelData) {
       });
       y = y + SPACER_PIXELS;
     } else {
-      var input = designMode.createElement('TEXT_INPUT');
-      input.id = 'design_' + alphaNumFeature + '_input';
+      var input = designMode.createElement('TEXT_INPUT', x, y);
+      fieldId = alphaNumFeature + '_input';
+      input.id = 'design_' + fieldId;
       y = y + SPACER_PIXELS;
     }
-    var addFeature = `testValues.${alphaNumFeature} = getText("${selectId}");`;
+    var addFeature = `testValues.${alphaNumFeature} = getText("${fieldId}");`;
     inputFields.push(addFeature);
   });
   y = y + 2 * SPACER_PIXELS;


### PR DESCRIPTION
Fixes for a couple of problems in autogenerated code and design elements for continuous features: 

1.) The `getText` code for continuous features was referencing "undefined" rather than the correct element id. To fix I assigned the element id to a variable and correctly passed that variable to the code that generates `getText`. 

2.) The generated input boxes were all stacked in the top left corner rather than aligned correctly in the layout of the screen. To fix, I needed to pass x and y coordinates to the `createElement` function for those input fields.

BEFORE: 
<img width="1170" alt="Screen Shot 2021-02-18 at 11 11 19 AM" src="https://user-images.githubusercontent.com/12300669/108389905-1f7e9580-71de-11eb-9615-63616808537a.png">

AFTER: 
<img width="1195" alt="Screen Shot 2021-02-18 at 11 26 14 AM" src="https://user-images.githubusercontent.com/12300669/108389910-21485900-71de-11eb-9fda-270e61c3da6a.png">
