### PR TITLE
Use src instead of data-src for videos

### DIFF
--- a/apps/src/util/loadVideos.js
+++ b/apps/src/util/loadVideos.js
@@ -68,7 +68,7 @@ function setupVideos(player) {
         .append(
           '<iframe class="lazyload" ' +
             'style="position:absolute; top: 0; left: 0; width: 100%; height: 100%" ' +
-            `data-src="https://www.youtube-nocookie.com/embed/${$(this).data(
+            `src="https://www.youtube-nocookie.com/embed/${$(this).data(
               'video-code'
             )}?iv_load_policy=3&rel=0&autohide=1&showinfo=0&enablejsapi=1" ` +
             'frameborder="0" ' +


### PR DESCRIPTION
See [Slack discussion](https://codedotorg.slack.com/archives/CNZP84FJ5/p1613677251228400). It turns out our videos on our marketing pages use `data-src` for videos when we should use `src`. This is a small change to fix that.


## Testing story

manually tested

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
