### PR TITLE
Prevent legacy script levels

### DIFF
--- a/dashboard/app/models/script.rb
+++ b/dashboard/app/models/script.rb
@@ -1040,7 +1040,8 @@ class Script < ApplicationRecord
 
   def prevent_legacy_script_levels_in_migrated_scripts
     if is_migrated && script_levels.reject(&:activity_section).any?
-      raise "legacy script levels are not allowed in migrated scripts"
+      lesson_names = lessons.all.select {|l| l.script_levels.reject(&:activity_section).any?}.map(&:name)
+      raise "Legacy script levels are not allowed in migrated scripts. Problem lessons: #{lesson_names.to_json}"
     end
   end
 

--- a/dashboard/app/models/script.rb
+++ b/dashboard/app/models/script.rb
@@ -1037,6 +1037,12 @@ class Script < ApplicationRecord
     end
   end
 
+  def prevent_legacy_script_levels_in_migrated_scripts
+    if is_migrated && script_levels.reject(&:activity_section).any?
+      raise "legacy script levels are not allowed in migrated scripts"
+    end
+  end
+
   # Script levels unfortunately have 3 position values:
   # 1. chapter: position within the Script
   # 2. position: position within the Lesson
@@ -1045,9 +1051,8 @@ class Script < ApplicationRecord
   # values of position and chapter on all script levels in the script.
   def fix_script_level_positions
     reload
-    if script_levels.reject(&:activity_section).any?
-      raise "cannot fix position of legacy script levels"
-    end
+    raise 'cannot fix script level positions on non-migrated scripts' unless is_migrated
+    prevent_legacy_script_levels_in_migrated_scripts
 
     chapter = 0
     lessons.each do |lesson|

--- a/dashboard/app/models/script.rb
+++ b/dashboard/app/models/script.rb
@@ -1004,6 +1004,7 @@ class Script < ApplicationRecord
       script.reload
       script.lesson_groups = temp_lgs
       script.save!
+      script.prevent_legacy_script_levels_in_migrated_scripts
 
       script.generate_plc_objects
 

--- a/dashboard/test/controllers/scripts_controller_test.rb
+++ b/dashboard/test/controllers/scripts_controller_test.rb
@@ -554,7 +554,7 @@ class ScriptsControllerTest < ActionController::TestCase
 
     script = create :script, name: 'migrated', is_migrated: true, hidden: true
     lesson_group = create :lesson_group, script: script
-    lesson = create :lesson, script: script, lesson_group: lesson_group
+    lesson = create :lesson, script: script, lesson_group: lesson_group, name: 'problem lesson'
 
     # A legacy script level is one without an activity section.
     create(
@@ -574,7 +574,7 @@ class ScriptsControllerTest < ActionController::TestCase
     }
 
     assert_response :not_acceptable
-    msg = 'Legacy script levels are not allowed in migrated scripts. Problem lessons: [\"Bogus Lesson 1\"]'
+    msg = 'Legacy script levels are not allowed in migrated scripts. Problem lessons: [\"problem lesson\"]'
     assert_includes response.body, msg
     assert script.is_migrated
     assert script.script_levels.any?

--- a/dashboard/test/controllers/scripts_controller_test.rb
+++ b/dashboard/test/controllers/scripts_controller_test.rb
@@ -532,7 +532,7 @@ class ScriptsControllerTest < ActionController::TestCase
       lesson: lesson,
       activity_section: section,
       activity_section_position: 1,
-      levels: [create(:maze)]
+      levels: [create(:applab)]
     )
 
     stub_file_writes(script.name)
@@ -561,7 +561,7 @@ class ScriptsControllerTest < ActionController::TestCase
       :script_level,
       script: script,
       lesson: lesson,
-      levels: [create(:maze)]
+      levels: [create(:applab)]
     )
 
     stub_file_writes(script.name)

--- a/dashboard/test/controllers/scripts_controller_test.rb
+++ b/dashboard/test/controllers/scripts_controller_test.rb
@@ -515,6 +515,71 @@ class ScriptsControllerTest < ActionController::TestCase
     assert_response :success
   end
 
+  test 'can update migrated script containing migrated script levels' do
+    sign_in @levelbuilder
+    Rails.application.config.stubs(:levelbuilder_mode).returns true
+
+    script = create :script, name: 'migrated', is_migrated: true, hidden: true
+    lesson_group = create :lesson_group, script: script
+    lesson = create :lesson, script: script, lesson_group: lesson_group
+    activity = create :lesson_activity, lesson: lesson
+    section = create :activity_section, lesson_activity: activity
+
+    # A migrated script level is one with an activity section.
+    create(
+      :script_level,
+      script: script,
+      lesson: lesson,
+      activity_section: section,
+      activity_section_position: 1,
+      levels: [create(:maze)]
+    )
+
+    stub_file_writes(script.name)
+
+    post :update, params: {
+      id: script.id,
+      script: {name: script.name},
+      is_migrated: true,
+      script_text: ScriptDSL.serialize_lesson_groups(script),
+    }
+    assert_response :success
+    assert script.is_migrated
+    assert script.script_levels.any?
+  end
+
+  test 'cannot update migrated script containing legacy script levels' do
+    sign_in @levelbuilder
+    Rails.application.config.stubs(:levelbuilder_mode).returns true
+
+    script = create :script, name: 'migrated', is_migrated: true, hidden: true
+    lesson_group = create :lesson_group, script: script
+    lesson = create :lesson, script: script, lesson_group: lesson_group
+
+    # A legacy script level is one without an activity section.
+    create(
+      :script_level,
+      script: script,
+      lesson: lesson,
+      levels: [create(:maze)]
+    )
+
+    stub_file_writes(script.name)
+
+    post :update, params: {
+      id: script.id,
+      script: {name: script.name},
+      is_migrated: true,
+      script_text: ScriptDSL.serialize_lesson_groups(script),
+    }
+
+    assert_response :not_acceptable
+    msg = 'Legacy script levels are not allowed in migrated scripts. Problem lessons: [\"Bogus Lesson 1\"]'
+    assert_includes response.body, msg
+    assert script.is_migrated
+    assert script.script_levels.any?
+  end
+
   test 'updates teacher resources' do
     sign_in @levelbuilder
     Rails.application.config.stubs(:levelbuilder_mode).returns true

--- a/dashboard/test/factories/factories.rb
+++ b/dashboard/test/factories/factories.rb
@@ -780,6 +780,9 @@ FactoryGirl.define do
 
   factory :lesson_group do
     sequence(:key) {|n| "Bogus Lesson Group #{n}"}
+    display_name do |lesson_group|
+      "#{lesson_group.key} Display Name"
+    end
     script
 
     position do |lesson_group|

--- a/dashboard/test/factories/factories.rb
+++ b/dashboard/test/factories/factories.rb
@@ -780,9 +780,7 @@ FactoryGirl.define do
 
   factory :lesson_group do
     sequence(:key) {|n| "Bogus Lesson Group #{n}"}
-    display_name do |lesson_group|
-      "#{lesson_group.key} Display Name"
-    end
+    display_name(&:key)
     script
 
     position do |lesson_group|

--- a/dashboard/test/fixtures/test-serialize-seeding-json.script_json
+++ b/dashboard/test/fixtures/test-serialize-seeding-json.script_json
@@ -22,6 +22,7 @@
       "user_facing": true,
       "position": 1,
       "properties": {
+        "display_name": "test-serialize-seeding-json-lesson-group-1",
         "description": "description 1"
       },
       "seeding_key": {

--- a/dashboard/test/models/script_test.rb
+++ b/dashboard/test/models/script_test.rb
@@ -2775,7 +2775,7 @@ class ScriptTest < ActiveSupport::TestCase
   end
 
   test 'fix script level positions' do
-    script = create :script
+    script = create :script, is_migrated: true, hidden: true
     lesson_group = create :lesson_group, script: script
 
     lesson_1 = create :lesson, script: script, lesson_group: lesson_group
@@ -2831,7 +2831,7 @@ class ScriptTest < ActiveSupport::TestCase
   end
 
   test 'cannot fix position of legacy script levels' do
-    script = create :script
+    script = create :script, is_migrated: true, hidden: true
     lesson_group = create :lesson_group, script: script
     lesson = create :lesson, script: script, lesson_group: lesson_group
 
@@ -2841,7 +2841,7 @@ class ScriptTest < ActiveSupport::TestCase
     error = assert_raises do
       script.fix_script_level_positions
     end
-    assert_includes error.message, "cannot fix position of legacy script levels"
+    assert_includes error.message, 'Legacy script levels are not allowed in migrated scripts.'
   end
 
   private


### PR DESCRIPTION
Finishes [PLAT-765]. See details in bug report.

## root cause

We check for and prevent legacy script levels in some circumstances, but not on script save. In the process of fixing Course E 2021, I noticed that all the activities and activity sections from certain lessons in Course E had disappeared, leaving their script levels behind as legacy script levels (i.e. without activity sections). I suspect this happened due to an edit on the script edit page, because this commit looks like it is adding a lesson `"Context-Settng Lesson"`, which can only be done from the script edit page:  e85c2d4d05f4eefe4c940bcdd9ec047b75e03c8b (search for coursee-2021.script_json)

The other commit which lost activities was  69e1fe71fffd83276153c708129f37fd0e9b8c24 (search for coursee-2021.script_json). It was harder to see what happened in that diff, but because the positions of the lessons are changing, it looks like another edit from the script page was involved.

Based on this, it seems like there is some way that using the script edit page can lead to losing all of the activities in a lesson, leaving the script levels behind. 

Unfortunately I was not able to reproduce the problem by editing the script page locally.

## solution

the solution is to prevent script update from introducing legacy script levels. I also added the names of the lessons containing the bad script levels to the error output, to hopefully give some more debugging info the next time this happens. Because it looks like all the activities in a lesson are disappearing, it seemed more useful to include the lesson names rather than the names of the individual levels.

## Testing story

new unit tests verify that update a script fails when it already contains legacy script levels.

Unit tests are passing locally. Drone problems are preventing me from seeing if there are still problems after my last test fix.

[PLAT-765]: https://codedotorg.atlassian.net/browse/PLAT-765