### PR TITLE
Removed resizeObserver entirely, set state in componentDidMount() instead

### DIFF
--- a/apps/src/templates/progress/GoogleClassroomShareButton.jsx
+++ b/apps/src/templates/progress/GoogleClassroomShareButton.jsx
@@ -39,14 +39,8 @@ export default class GoogleClassroomShareButton extends React.PureComponent {
     height: Button.ButtonHeight.default
   };
 
-  /*
-   * The button doesn't render immediately, so we use its resize event to
-   * detect when it's rendered and wait to display the label until then.
-   */
   constructor(props) {
     super(props);
-    this.onButtonResize = this.onButtonResize.bind(this);
-    this.resizeObserver = new ResizeObserver(this.onButtonResize);
 
     this.onShareStart = this.onShareStart.bind(this);
     this.onShareComplete = this.onShareComplete.bind(this);
@@ -67,7 +61,7 @@ export default class GoogleClassroomShareButton extends React.PureComponent {
 
   componentDidMount() {
     this.renderButton();
-    this.resizeObserver.observe(this.buttonRef);
+    this.setState({buttonRendered: true});
 
     // Use unique callback names since we're adding to the global namespace
     window[this.onShareStartName()] = this.onShareStart;
@@ -85,11 +79,6 @@ export default class GoogleClassroomShareButton extends React.PureComponent {
     if (!_.isEqual(this.props, prevProps)) {
       this.renderButton();
     }
-  }
-
-  onButtonResize() {
-    this.setState({buttonRendered: true});
-    this.resizeObserver.disconnect();
   }
 
   onShareStartName() {

--- a/apps/src/templates/progress/GoogleClassroomShareButton.jsx
+++ b/apps/src/templates/progress/GoogleClassroomShareButton.jsx
@@ -56,12 +56,12 @@ export default class GoogleClassroomShareButton extends React.PureComponent {
   buttonRef = null;
   iframeMouseOver = false;
   state = {
-    buttonRendered: false
+    buttonMounted: false
   };
 
   componentDidMount() {
     this.renderButton();
-    this.setState({buttonRendered: true});
+    this.setState({buttonMounted: true});
 
     // Use unique callback names since we're adding to the global namespace
     window[this.onShareStartName()] = this.onShareStart;
@@ -146,7 +146,7 @@ export default class GoogleClassroomShareButton extends React.PureComponent {
           onMouseOver={this.mouseOver}
           onMouseOut={this.mouseOut}
         />
-        {this.state.buttonRendered && (
+        {this.state.buttonMounted && (
           <span style={styles.label}>{i18n.shareToGoogleClassroom()}</span>
         )}
       </span>

--- a/dashboard/test/ui/features/learning_platform/send_lesson.feature
+++ b/dashboard/test/ui/features/learning_platform/send_lesson.feature
@@ -12,8 +12,6 @@ Scenario: Send lesson dialog renders properly
   Then I see no difference for "send lesson dialog"
   Then I close my eyes
 
-@no_ie
-@no_safari
 @no_mobile
 Scenario: Send lesson dialog opens and closes
   Given I am on "http://studio.code.org/s/csp3-2018"
@@ -23,8 +21,6 @@ Scenario: Send lesson dialog opens and closes
   When I click selector "button:contains(Done)"
   Then I wait until element ".modal" is not visible
 
-@no_ie
-@no_safari
 @no_mobile
 Scenario: Send lesson dialog copy link button works
   Given I am on "http://studio.code.org/s/coursec-2017"


### PR DESCRIPTION
The send to students button didn't work in IE and older versions of Chrome, Safari and Firefox because resizeObserver() is not supported in those browsers (see https://developer.mozilla.org/en-US/docs/Web/API/ResizeObserver). Its use was to more elegantly render the two buttons included in the share dialog. However, removing this function entirely did not noticeably impact the speed at which they render. Now the share buttons work again in the other browsers. 

Jira ticket:
 https://codedotorg.atlassian.net/browse/LP-1646

Testing:
Edits pull back in testing on IE and Safari. Previously, these browsers were both excluded from the send_lesson tests.

## PR Checklist:


- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
