### PR TITLE
Fix display when a progression only has an unplugged lesson

### DIFF
--- a/apps/src/templates/progress/ProgressLevelSet.jsx
+++ b/apps/src/templates/progress/ProgressLevelSet.jsx
@@ -6,6 +6,7 @@ import color from '@cdo/apps/util/color';
 import {levelType} from './progressTypes';
 import {getIconForLevel} from './progressHelpers';
 import ProgressPill from './ProgressPill';
+import i18n from '@cdo/locale';
 
 const styles = {
   table: {
@@ -73,12 +74,20 @@ class ProgressLevelSet extends React.Component {
     const multiLevelStep = levels.length > 1;
     const url = multiLevelStep ? undefined : levels[0].url;
 
-    let pillText;
+    let pillText, icon;
+    let progressStyle = false;
     if (levels[0].isUnplugged || levels[levels.length - 1].isUnplugged) {
       // We explicitly don't want any text in this case
-      pillText = '';
+      if (multiLevelStep) {
+        pillText = '';
+        icon = getIconForLevel(levels[0]);
+      } else {
+        pillText = i18n.unpluggedActivity();
+        progressStyle = true;
+      }
     } else {
       pillText = levels[0].levelNumber.toString();
+      icon = getIconForLevel(levels[0]);
       if (multiLevelStep) {
         pillText += `-${levels[levels.length - 1].levelNumber}`;
       }
@@ -91,10 +100,11 @@ class ProgressLevelSet extends React.Component {
             <td style={styles.col1}>
               <ProgressPill
                 levels={levels}
-                icon={getIconForLevel(levels[0])}
+                icon={icon}
                 text={pillText}
                 disabled={disabled}
                 selectedSectionId={selectedSectionId}
+                progressStyle={progressStyle}
               />
             </td>
             <td style={styles.col2}>

--- a/apps/test/unit/templates/progress/ProgressLevelSetTest.js
+++ b/apps/test/unit/templates/progress/ProgressLevelSetTest.js
@@ -61,4 +61,21 @@ describe('ProgressLevelSet', function() {
     );
     assert.equal(wrapper.find('ProgressPill').props().text, '');
   });
+
+  it('renders a pill with unplugged text when only level is unplugged', () => {
+    const wrapper = shallow(
+      <ProgressLevelSet
+        name={undefined}
+        levels={[fakeLevel({isUnplugged: true})].map(level => ({
+          ...level,
+          name: undefined
+        }))}
+        disabled={false}
+      />
+    );
+    assert.equal(
+      wrapper.find('ProgressPill').props().text,
+      'Unplugged Activity'
+    );
+  });
 });


### PR DESCRIPTION
Resolve [PLAT-531](https://codedotorg.atlassian.net/browse/PLAT-531).

Before:
![Screen Shot 2021-02-22 at 1 35 01 PM](https://user-images.githubusercontent.com/46464143/108870563-16f6d800-75ad-11eb-81e4-45084bbda269.png)

After:
![Screen Shot 2021-02-22 at 1 35 07 PM](https://user-images.githubusercontent.com/46464143/108870595-1c542280-75ad-11eb-9f88-86120c768bd6.png)

The difference comes from [this check](https://github.com/code-dot-org/code-dot-org/blob/4703cb5a8c5e21b6bb4d0a1efb6fe9339bb43bea/apps/src/templates/progress/ProgressLessonContent.jsx#L41). In coursea-2020 the progressions with just an unplugged level did not have a progression name, but in coursea-2021 it does. There are a few ways I thought to handle this:
1. Remove the progression name from this progression. I really don't like the idea of manipulating the data object to fit this check though.
2. Remove the check on progression name. I tried that and it did fix this issue but I was a bit concerned about downstream effects.
3. Add a case for a single unplugged lesson in `ProgressLevelSet`. (This PR.)

Definitely open to ideas or other thoughts here. I think I chose the least bad option but there may be things I didn't consider.

## Links

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

<!--
- spec: []()
- jira ticket: []()
-->

## Testing story

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
