### PR TITLE
edited onclick anywhere to dismiss

### DIFF
--- a/apps/src/code-studio/components/header/SignInCallout.jsx
+++ b/apps/src/code-studio/components/header/SignInCallout.jsx
@@ -100,11 +100,10 @@ export default class SignInCallout extends React.Component {
 
   render() {
     return (
-      <div style={styles.container}>
+      <div style={styles.container} onClick={this.props.handleClose}>
         <div
-          className="login-callout"
+          className="login-callout modal-backdrop"
           style={styles.modalBackdrop}
-          onClick={this.props.handleClose}
         />
         <div style={styles.upTriangle} />
         <div style={styles.content}>{this.renderContent()}</div>

--- a/apps/src/code-studio/components/header/SignInCallout.jsx
+++ b/apps/src/code-studio/components/header/SignInCallout.jsx
@@ -7,6 +7,7 @@ const TRIANGLE_BASE = 30;
 const TRIANGLE_HEIGHT = 15;
 const CALLOUT_Z_INDEX = 1040;
 const CALLOUT_TOP = 30;
+const HEADER_HEIGHT = 50;
 
 const styles = {
   container: {
@@ -29,7 +30,13 @@ const styles = {
     // Most backdrop attributes come from the 'modal-backdrop' class defined by bootstrap
     // but we need to override the opacity as the default opacity of 0.8 is too dark.
     // Note that bootstrap defaults the z-index of the backdrop to 1040.
-    opacity: 0.5
+    position: 'fixed',
+    opacity: 0.5,
+    zIndex: 800,
+    top: HEADER_HEIGHT,
+    right: 0,
+    bottom: 0,
+    left: 0
   },
   upTriangle: {
     position: 'absolute',


### PR DESCRIPTION
This pulls up the onclick event higher in the component, so even a click in the callout box itself will dismiss the reminder and not redirect the user to sign in.

Pairs with PR: https://github.com/code-dot-org/code-dot-org/pull/39022


- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
