### PR TITLE
Write and show lesson descriptions

### DIFF
--- a/dashboard/app/models/lesson.rb
+++ b/dashboard/app/models/lesson.rb
@@ -229,9 +229,9 @@ class Lesson < ApplicationRecord
     lesson_summary = Rails.cache.fetch("#{cache_key}/lesson_summary/#{I18n.locale}/#{include_bonus_levels}") do
       cached_levels = include_bonus_levels ? cached_script_levels : cached_script_levels.reject(&:bonus)
 
-      description_student = I18n.t("data.script.name.#{script.name}.lessons.#{key}.description_student", default: '')
+      description_student = I18n.t('description_student', scope: [:data, :script, :name, script.name, :lessons, key], smart: true, default: '')
       description_student = render_codespan_only_markdown(description_student) unless script.is_migrated?
-      description_teacher = I18n.t("data.script.name.#{script.name}.lessons.#{key}.description_teacher", default: '')
+      description_teacher = I18n.t('description_teacher', scope: [:data, :script, :name, script.name, :lessons, key], smart: true, default: '')
       description_teacher = render_codespan_only_markdown(description_teacher) unless script.is_migrated?
 
       lesson_data = {
@@ -405,7 +405,7 @@ class Lesson < ApplicationRecord
 
   # Returns a hash representing i18n strings in scripts.en.yml which may need
   # to be updated after this object was updated. Currently, this only updates
-  # the lesson name.
+  # the lesson name and overviews.
   def i18n_hash
     {
       script.name => {

--- a/dashboard/app/models/lesson.rb
+++ b/dashboard/app/models/lesson.rb
@@ -255,7 +255,6 @@ class Lesson < ApplicationRecord
         unplugged: unplugged,
         lessonEditPath: edit_lesson_path(id: id)
       }
-      puts "data.script.name.#{script.name}.lessons.#{key}.description_student"
 
       # Use to_a here so that we get access to the cached script_levels.
       # Without it, script_levels.last goes back to the database.

--- a/dashboard/app/models/lesson.rb
+++ b/dashboard/app/models/lesson.rb
@@ -229,6 +229,11 @@ class Lesson < ApplicationRecord
     lesson_summary = Rails.cache.fetch("#{cache_key}/lesson_summary/#{I18n.locale}/#{include_bonus_levels}") do
       cached_levels = include_bonus_levels ? cached_script_levels : cached_script_levels.reject(&:bonus)
 
+      description_student = I18n.t("data.script.name.#{script.name}.lessons.#{key}.description_student", default: '')
+      description_student = render_codespan_only_markdown(description_student) unless script.is_migrated?
+      description_teacher = I18n.t("data.script.name.#{script.name}.lessons.#{key}.description_teacher", default: '')
+      description_teacher = render_codespan_only_markdown(description_teacher) unless script.is_migrated?
+
       lesson_data = {
         script_id: script.id,
         script_name: script.name,
@@ -245,11 +250,12 @@ class Lesson < ApplicationRecord
         hasLessonPlan: has_lesson_plan,
         numberedLesson: numbered_lesson?,
         levels: cached_levels.map {|sl| sl.summarize(false, for_edit: for_edit)},
-        description_student: render_codespan_only_markdown(I18n.t("data.script.name.#{script.name}.lessons.#{key}.description_student", default: '')),
-        description_teacher: render_codespan_only_markdown(I18n.t("data.script.name.#{script.name}.lessons.#{key}.description_teacher", default: '')),
+        description_student: description_student,
+        description_teacher: description_teacher,
         unplugged: unplugged,
         lessonEditPath: edit_lesson_path(id: id)
       }
+      puts "data.script.name.#{script.name}.lessons.#{key}.description_student"
 
       # Use to_a here so that we get access to the cached script_levels.
       # Without it, script_levels.last goes back to the database.
@@ -406,7 +412,9 @@ class Lesson < ApplicationRecord
       script.name => {
         'lessons' => {
           key => {
-            'name' => name
+            'name' => name,
+            'description_student' => student_overview,
+            'description_teacher' => overview
           }
         }
       }

--- a/dashboard/config/locales/scripts.en.yml
+++ b/dashboard/config/locales/scripts.en.yml
@@ -18903,48 +18903,81 @@ en:
             CS Discoveries Pre-survey:
               key: CS Discoveries Pre-survey
               name: CS Discoveries Pre-survey
+              description_student: 
+              description_teacher: 
             Intro to Problem Solving:
               key: Intro to Problem Solving
               name: Intro to Problem Solving
+              description_student: "**Question of the Day: What can help us to work together and solve problems as a team?**\r\n\r\nThe class works in groups to design aluminum foil boats that will support as many pennies as possible. At the end of the lesson, groups reflect on their experiences with the activity and make connections to the types of problem solving they will be doing for the rest of the course."
+              description_teacher: "**Question of the Day: What can help us to work together and solve problems as a team?**\r\n\r\nIn this lesson, students work in groups to design aluminum foil boats that will support as many pennies as possible. Groups have two rounds to work on their boats, with the goal of trying to hold more pennies than they did in round 1. The structure of the activity foreshadows different steps of the problem solving process that students will be introduced to in more detail in the following lesson. At the end of the lesson students reflect on their experiences with the activity and make connections to the types of problem solving they will be doing for the rest of the course.\r\n\r\n**Alternate versions of this lesson are also available.** \r\n\r\n* [Newspaper Table](../9/)\r\n* [Spaghetti Bridge](../10/)\r\n* [Paper Tower](../11/)"
             The Problem Solving Process:
               key: The Problem Solving Process
               name: The Problem Solving Process
+              description_student: "**Question of the Day: What are some common steps we can use to solve many different types of problems?**\r\n\r\nThis lesson introduces the formal problem solving process that the class will use over the course of the year: Define - Prepare - Try - Reflect. The class relates these steps to the problem from the previous lesson, then to a problem they are good at solving, then to a problem they want to improve at solving. At the end of the lesson, the class collects a list of generally useful strategies for each step of the process to put on posters that will be used throughout the unit and year."
+              description_teacher: "**Question of the Day: What are some common steps we can use to solve many different types of problems?**\r\n\r\nThis lesson introduces the formal problem solving process that students will use over the course of the year, Define - Prepare - Try - Reflect. The lesson begins by asking students to brainstorm all the different types of problems that they encounter in everyday life. Students are then shown the four steps of the problem solving process and work together to relate these abstract steps to their actual experiences solving problems. First students relate these steps to the problem activities from the previous lesson, then a problem they are good at solving, then a problem they want to improve at solving. At the end of the lesson the class collects a list of generally useful strategies for each step of the process to put on posters that will be used throughout the unit and year."
             Exploring Problem Solving:
               key: Exploring Problem Solving
               name: Exploring Problem Solving
+              description_student: "**Question of the Day: How can we apply the problem solving process to many different kinds of problems?**\r\n\r\nIn this lesson, the class applies the problem solving process to three different problems: a word search, a seating arrangement for a birthday party, and planning a trip. The problems grow increasingly complex and poorly defined to highlight how the problem solving process is particularly helpful when tackling these types of problems.\r\n"
+              description_teacher: "**Question of the Day: How can we apply the problem solving process to many different kinds of problems?**\r\n\r\nIn this lesson students apply the problem solving process to three different problems in order to better understand the value of each step. They will solve a word search, arrange seating for a birthday party, and redesign a classroom. The problems grow increasingly complex and poorly defined to highlight how the problem solving process is particularly helpful when tackling these types of problems. The lesson concludes with students reflecting on their experience with the problem solving process. They will justify the inclusion of each step and will brainstorm questions or strategies that can help them better define open-ended problems, as this is often the most critical step.\r\n\r\nThis lesson will likely take two class periods or more to complete. The first two problems may fit into a single class period but the third will need to be moved to a second day.\r\n\r\n\r\n**Alternate versions of this lesson are also available.** \r\n\r\n* [Animal Theme](../12/)\r\n* [Games Theme](../13/)"
             What is a Computer?:
               key: What is a Computer?
               name: What is a Computer?
+              description_student: "**Question of the Day: What is a computer?**\r\n\r\nIn this lesson, the class develops a preliminary definition of a computer. After brainstorming the possible definitions for a computer, the class works in groups to sort pictures into “is a computer” or “is not a computer” categories on poster paper, and explain their motivations for choosing some of the most difficult categorizations. The teacher then introduces a definition of the computer and allows groups to revise their posters according to the new definition.\r\n"
+              description_teacher: "**Question of the Day: What is a computer?**\r\n\r\nIn this lesson students develop a preliminary definition of a computer. To begin the lesson, the class will brainstorm possible definitions for a computer and place the results of this brainstorm on the board. Next, students will work in groups to sort pictures into “is a computer” or “is not a computer” on poster paper. Groups will place their posters around the room and briefly explain their motivations for choosing some of their most difficult categorizations.  The teacher will then introduce a definition of the computer and allow students to revise their posters according to the new definition.\r\n"
             Input and Output:
               key: Input and Output
               name: Input and Output
+              description_student: "**Question of the Day: How do computers use input and output to get and give the information that they need to solve problems?**\r\n\r\n\r\nIn this lesson, the class considers how computers get and give information to the user through inputs and outputs. After first considering what information they would need to solve a \"thinking problem”, the class identifies the inputs and outputs to that process. Afterwards, they explore a series of apps and determine the inputs and outputs for each one."
+              description_teacher: "**Question of the Day: How do computers use input and output to get and give the information that they need to solve problems?**\r\n\r\nIn this lesson students consider how computers get and give information to the user through inputs and outputs.  Students first consider what information they would need to solve a \"thinking problem\", then use that information to produce a recommendation.  They then identify the inputs and outputs to that process.  Afterwards, students consider an app that engages in the same process and determine how that app inputs and outputs information.  Last, they consider other types of inputs and outputs that computers can use to help solve problems."
             Processing:
               key: Processing
               name: Processing
+              description_student: "**Question of the Day: What are the different ways computers can process information?**\r\n\r\nThis lesson introduces four types of processing that the class will use throughout the course. Through a series of apps, the class explores how processing is used to turn input into output. In the end, the class brainstorms more types of app processing that would be useful.\r\n"
+              description_teacher: "**Question of the Day: What are the different ways computers can process information?**\r\n\r\nThis lesson introduces students to four common types of processing: if/then (conditionals), finding a match (searching), counting, and comparing.  Students are first introduced to the types of processing through several sample apps.  They then investigate more apps to determine what sorts of processing each uses.  They then think of their own app and decide what types of processing it would need to work.  Finally, they brainstorm other types of processing that may be useful but were not included in the main lesson."
             Storage:
               key: Storage
               name: Storage
+              description_student: "**Question of the Day: Why is storage an important part of the computing process?**\r\n\r\nThis lesson covers the last part of the chapter's model of computing: storage. The class interacts with several different apps, determining which information should be stored for later and why. The input-output-storage-processing model of computing is then presented in full, and the class reflects on how various apps use each of the components, and how the model impacts whether or not something should be considered a computer.\r\n"
+              description_teacher: |-
+                **Question of the Day: Why is storage an important part of the computing process?**
+
+                This lesson introduces the final component of the unit's model of computing: storage.  After trying out an "outfit picker" app, students discuss what information should be stored in the app versus input every time the app is run.  They then look at a series of apps and use their decisions about what should be stored to create guidelines for deciding what information to store.  They then review the four components of this chapter's model of computing: input, output, storage, and processing.  Afterwards, they have one last opportunity to revise their decisions about which items should be classified as a "computer" from earlier in the chapter.  The lesson ends with a reflection on their own app ideas and how storage could be used.
             Project - Propose an App:
               key: Project - Propose an App
               name: Project - Propose an App
+              description_student: "**Question of the Day:  How can the IOSP model help us to design an app that solves a problem?**\r\n\r\nTo conclude the study of the problem solving process and the input/output/store/process model of a computer, the class proposes apps designed to solve real world problems. This project is completed across multiple days and culminates in a poster presentation where students highlight the features of their apps. The project is designed to be completed in pairs, though it can be completed individually.\r\n"
+              description_teacher: "**Question of the Day:  How can the IOSP model help us to design an app that solves a problem?**\r\n\r\nTo conclude their study of the problem solving process and the input/output/store/process model of a computer, students will propose an app designed to solve a real world problem. This project will be completed across multiple days and will result in students creating a poster highlighting the features of their app that they will present to their classmates. A project guide provides step by step instructions for students and helps them organize their thoughts. The project is designed to be completed in pairs though it can be completed individually."
             Post-Project Test:
               key: Post-Project Test
               name: Post-Project Test
+              description_student: 
+              description_teacher: 
             Intro to Problem Solving - Newspaper Table (Alternate Lesson 1):
               key: Intro to Problem Solving - Newspaper Table (Alternate Lesson 1)
               name: Intro to Problem Solving - Newspaper Table (Alternate Lesson 1)
+              description_student: "**Question of the Day: What can help us to work together and solve problems as a team?**\r\n\r\nThe class works in groups to design newspaper tables that will support as many books as possible.  At the end of the lesson, groups reflect on their experiences with the activity and make connections to the types of problem solving they will be doing for the rest of the course. "
+              description_teacher: "**Question of the Day: What can help us to work together and solve problems as a team?**\r\n\r\n\r\nIn this lesson, students work in groups to design newspaper tables that will hold as many books as possible. Groups have two rounds to work on their tables, with the goal of trying to hold more books than they did in the first round. The structure of the activity foreshadows different steps of the problem solving process that students will be introduced to in more detail in the following lesson. At the end of the lesson students reflect on their experiences with the activity and make connections to the types of problem solving they will be doing for the rest of the course.\r\n\r\n**This is an alternate activity to [Intro to Problem Solving - Aluminum Boats](../1/)**"
             Intro to Problem Solving - Spaghetti Bridge (Alternate Lesson 1):
               key: Intro to Problem Solving - Spaghetti Bridge (Alternate Lesson 1)
               name: Intro to Problem Solving - Spaghetti Bridge (Alternate Lesson 1)
+              description_student: "**Question of the Day: What can help us to work together and solve problems as a team?**\r\n\r\nThe class works in groups to design spaghetti bridges that will support as many books as possible.  At the end of the lesson, groups reflect on their experiences with the activity and make connections to the types of problem solving they will be doing for the rest of the course. "
+              description_teacher: "**Question of the Day: What can help us to work together and solve problems as a team?**\r\n\r\n\r\nIn this lesson, students work in groups to design spaghetti bridges that will support as many books as possible. Groups have two rounds to work on their bridges, with the goal of trying to hold more books than they did in Round 1. The structure of the activity foreshadows different steps of the problem solving process that students will be introduced to in more detail in the following lesson. At the end of the lesson students reflect on their experiences with the activity and make connections to the types of problem solving they will be doing for the rest of the course.\r\n\r\n**This is an alternate activity to [Intro to Problem Solving - Aluminum Boats](../1/)**"
             Intro to Problem Solving - Paper Tower (Alternate Lesson 1):
               key: Intro to Problem Solving - Paper Tower (Alternate Lesson 1)
               name: Intro to Problem Solving - Paper Tower (Alternate Lesson 1)
+              description_student: "**Question of the Day: What can help us to work together and solve problems as a team?**\r\n\r\nThe class works in groups to design paper towers that will be as tall as possible.  At the end of the lesson groups reflect on their experiences with the activity and make connections to the types of problem solving they will be doing for the rest of the course. "
+              description_teacher: "**Question of the Day: What can help us to work together and solve problems as a team?**\r\n\r\n\r\nIn this lesson, students work in groups to design paper towers that can stand as high as possible. Groups have two rounds to work on their towers, with the goal of trying to go higher than they did in Round 1. The structure of the activity foreshadows different steps of the problem solving process that students will be introduced to in more detail in the following lesson. At the end of the lesson students reflect on their experiences with the activity and make connections to the types of problem solving they will be doing for the rest of the course.\r\n\r\n**This is an alternate activity to [Intro to Problem Solving - Aluminum Boats](../1/)**"
             Exploring Problem Solving - Animals Theme (Alternate Lesson 3):
               key: Exploring Problem Solving - Animals Theme (Alternate Lesson 3)
               name: Exploring Problem Solving - Animals Theme (Alternate Lesson 3)
+              description_student: "**Question of the Day: How can we apply the problem solving process to many different kinds of problems?**\r\n\r\nIn this lesson, the class applies the problem solving process to three different problems: a tangram puzzle, choosing a pet according to criteria, and planning a pet adoption event. The problems grow increasingly complex and poorly defined to highlight how the problem solving process is particularly helpful when tackling these types of problems."
+              description_teacher: "**Question of the Day: How can we apply the problem solving process to many different kinds of problems?**\r\n\r\nIn this lesson students apply the problem solving process to three different problems in order to better understand the value of each step. They will solve tangrams, choose a pet for several people, and plan a pet adoption event. The problems grow increasingly complex and poorly defined to highlight how the problem solving process is particularly helpful when tackling these types of problems. The lesson concludes with students reflecting on their experience with the problem solving process. They will justify the inclusion of each step and will brainstorm questions or strategies that can help them better define open-ended problems, as this is often the most critical step.\r\n\r\nThis lesson will likely take two class periods or more to complete. The first two problems may fit into a single class period but the third will need to be moved to a second day."
             Exploring Problem Solving - Games Theme (Alternate Lesson 3):
               key: Exploring Problem Solving - Games Theme (Alternate Lesson 3)
               name: Exploring Problem Solving - Games Theme (Alternate Lesson 3)
+              description_student: "**Question of the Day: How can we apply the problem solving process to many different kinds of problems?**\r\n\r\nIn this lesson, the class applies the problem solving process to three different problems: a maze, a logic puzzle, and planning field day activity. The problems grow increasingly complex and poorly defined to highlight how the problem solving process is particularly helpful when tackling these types of problems."
+              description_teacher: "**Question of the Day: How can we apply the problem solving process to many different kinds of problems?**\r\n\r\nIn this lesson students apply the problem solving process to three different problems in order to better understand the value of each step. They will solve a maze, organizing a team to race as fast as possible, and design a game. The problems grow increasingly complex and poorly defined to highlight how the problem solving process is particularly helpful when tackling these types of problems. The lesson concludes with students reflecting on their experience with the problem solving process. They will justify the inclusion of each step and will brainstorm questions or strategies that can help them better define open-ended problems, as this is often the most critical step.\r\n\r\nThis lesson will likely take two class periods or more to complete. The first two problems may fit into a single class period but the third will need to be moved to a second day."
           lesson_groups:
             cspSurvey:
               display_name: Survey
@@ -18973,72 +19006,118 @@ en:
             Exploring Web Pages:
               key: Exploring Web Pages
               name: Exploring Web Pages
+              description_student: "**Question of the Day:  Why do people create web pages?**\r\n\r\nThis lesson covers the purposes that a web page might serve, both for the users and the creators. The class explores a handful of sample web pages and describes how each of those pages is useful for users and how they might also serve their creators.\r\n"
+              description_teacher: "**Question of the Day:  Why do people create web pages?**  \r\n\r\n\r\nEvery website has a purpose, a reason someone created it and others use it. In this lesson, students will start to consider the purposes a website might serve, both for the users and the creators. Students will explore some sample websites and discuss the purpose they serve for their creators. They are then asked to reflect on reasons that someone might want to create websites."
             Intro to HTML:
               key: Intro to HTML
               name: Intro to HTML
+              description_student: "**Question of the Day: How can we tell the computer both *what* to put on the web page, and *how* to organize it?**\r\n\r\n\r\nThis lesson introduces HTML as a solution to the problem of how to communicate both the content and structure of a website to a computer. The lesson begins with a brief unplugged activity that demonstrates the challenges of effectively communicating the structure of a web page. Then, the class looks at an HTML page in Web Lab and discusses how HTML tags help solve this problem, before using HTML to write their first web pages of the unit.\r\n"
+              description_teacher: "**Question of the Day: How can we tell the computer both *what* to put on the web page, and *how* to organize it?**\r\n\r\nIn this lesson students are introduced to HTML as a solution to the problem of how to communicate both the content and structure of a website to a computer. The lesson begins with a brief unplugged activity demonstrating the challenges of effectively communicating the structure of a web page. Students then look at an exemplar HTML page in Web Lab and discuss with their classmates how HTML tags help solve this problem. Students then write their first HTML. A wrap-up discussion helps to solidify the understanding of content vs. structure that was developed throughout the lesson."
             Headings:
               key: Headings
               name: Headings
+              description_student: "**Question of the Day: How can we work together to fix problems with our websites?**\r\n\r\n\r\nThis lesson continues the introduction to HTML tags, this time with headings. The class practices using heading tags to create page and section titles and learns how the different heading elements are displayed by default."
+              description_teacher: "**Question of the Day: How can we work together to fix problems with our websites?**\r\n\r\nIn this lesson, students continue to use HTML to structure text on web pages, this time in pairs,  with a focus on working together and debugging problems with their sites.  Students learn how the different heading elements are displayed by default and practice using them to create page and section titles.  "
             'Mini-Project: HTML Web Page':
               key: 'Mini-Project: HTML Web Page'
               name: 'Mini-Project: HTML Web Page'
+              description_student: "**Question of the Day: How can I use HTML to express a personal value?**\r\n\r\nIn this lesson, the class creates personal web pages on a topic of their choice. The lesson starts with a review of HTML tags. Next, the class designs web pages, first identifying the tags needed to implement them, and then creating the pages in Web Lab.\r\n"
+              description_teacher: "**Question of the Day: How can I use HTML to express a personal value?**\r\n\r\nIn this optional mini-project, students use what they have learned to create their own personal web page on a topic of their choice.  The lesson starts with a review of the HTML that students have learned.  They then begin their project by designing a web page and identifying which tags they will use to implement it.  They then create their web pages in Web Lab and share with the class. Optionally, after engaging in a formal feedback process, they may make final changes to their websites before reflecting on their process.  This project can be completed in one day or expanded over several days, depending on the scheduling needs of the class."
             Digital Footprint:
               key: Digital Footprint
               name: Digital Footprint
+              description_student: "**Question of the Day: How can you make sure that your private information stays private?**\r\n\r\nThis lesson takes a step back from creating websites to talk about the personal information that people choose to share digitally. The class begins by discussing what types of information they have shared on various websites, then they look at several sample social media pages to see what types of personal information could be shared intentionally or unintentionally. Finally, the class comes up with a set of guidelines to follow when putting information online."
+              description_teacher: "**Question of the Day: How can you make sure that your private information stays private?**\r\n\r\nThis lesson takes a step back from students’ work developing web pages to help them articulate what personal information they choose to share digitally and with whom. It also reinforces the notion that much of the information that they choose to share digitally falls largely out of their control the moment it is released.  \r\n\r\nStudents look at several social media pages to determine what sorts of information people are sharing about themselves or one another. Last, students reflect on what guidelines they think are appropriate for posting information online.\r\n\r\nThe ultimate point of this lesson is not to scare students, but rather to experientially bring students to realize that they don’t have control over information released online."
             Styling Text with CSS:
               key: Styling Text with CSS
               name: Styling Text with CSS
+              description_student: "**Question of the Day: How can we change the style of text on a web page?**\r\n\r\n\r\nThis lesson introduces CSS as a way to style elements on the page. The class learns the basic syntax for CSS rule-sets and then explores properties that impact HTML text elements. Finally, they discuss the differences between content, structure, and style when making a personal web page."
+              description_teacher: "**Question of the Day: How can we change the style of text on a web page?**\r\n\r\nThis lesson introduces CSS as a way to style elements on the page. Students learn the basic syntax for CSS rule-sets and then explore properties that impact HTML text elements. They work on a HTML page about Guinness World Record holders, adding their own style to the provided page. "
             'Mini-Project: Your Personal Style':
               key: 'Mini-Project: Your Personal Style'
               name: 'Mini-Project: Your Personal Style'
+              description_student: "**Question of the Day: How can you express your personal style on a web page?**\r\n\r\nIn this lesson, students create their own styled web pages. The lesson starts with a review of the CSS. They then design the web page, identify which CSS properties they will need, and create their web pages in Web Lab."
+              description_teacher: "**How can you express your personal style on a web page?**\r\n\r\nIn this optional mini-project, students use what they have learned to create their own styled web page on a topic of their choice. The lesson starts with a review of the CSS that students have learned. They then begin their project by designing a web page and identifying which properties they will use to implement it. They create their web pages in Web Lab and share with the class.  After engaging in a formal feedback process, they make final changes to their websites before reflecting on their process.  This project can be completed in one day or expanded over several days, depending on the scheduling needs of the class."
             Intellectual Property:
               key: Intellectual Property
               name: Intellectual Property
+              description_student: "**Question of the Day: What kind of rules protect everyone's rights when we use each other's content?**\r\n\r\nStarting with a discussion of their personal opinions on how others should be allowed to use their work, the class explores the purpose and role of copyright for both creators and users of creative content. They then move on to an activity exploring the various Creative Commons licenses as a solution to the difficulties of dealing with copyright.\r\n"
+              description_teacher: "**Question of the Day: What kind of rules protect everyone's rights when we use each other's content?**\r\n\r\nStarting with a discussion of their personal opinions on how others should be allowed to use their work, the class explores the purpose and role of copyright for both creators and users of creative content. They then move on to an activity exploring the various Creative Commons licenses as a solution to the difficulty in dealing with copyright. "
             Using Images:
               key: Using Images
               name: Using Images
+              description_student: "**Question of the Day: How can we add images on our websites, while making sure we respect everyone's rights?**\r\n\r\nThe class starts by considering the ethical implications of using images on websites, specifically in terms of intellectual property. They then learn how to add images to their web pages using the <img> tag and how to cite the image sources appropriately."
+              description_teacher: "**Question of the Day: How can we add images on our websites, while making sure we respect everyone's rights?**\r\n\r\nStudents start the class by considering the ethical implications of using images on their websites, specifically in terms of intellectual property. They then learn how to add images to their web pages using the &lt;img&gt; tag and how to cite the image sources appropriately."
             'Websites for Expression ':
               key: 'Websites for Expression '
               name: Websites for Expression
+              description_student: "**Question of the Day: How can we use websites to express ourselves?**\r\n\r\nThis lesson introduces websites as a means of personal expression. Students first discuss the different ways that people express and share their interests and ideas, then they look at a few exemplar websites made by students from a previous course. Finally, everyone brainstorms and shares a list of topics and interests to include in a personal website, creating a resource for developing a personal website in the rest of the unit.\r\n"
+              description_teacher: "**Question of the Day: How can we use websites to express ourselves?**\r\n\r\nIn this lesson students investigate ways to use websites as a means of personal expression and develop a list of topics and interests that they would want to include on a personal website. Students begin by brainstorming different ways that people express and share their interests and ideas. Students then look at a few exemplar websites to identify ways they express ideas. Finally, students brainstorm and share a list of topics and interests they might want to include on a personal website; they will reference this list as they progress through the unit."
             Styling Elements with CSS:
               key: Styling Elements with CSS
               name: Styling Elements with CSS
+              description_student: "**Question of the Day: How can we style the images and layouts of our pages?**\r\n\r\nThis lesson continues the introduction to CSS style properties, this time focusing more on non-text elements. The class begins by investigating and modifying the new CSS styles on a Desserts of the World page. Afterwards, everyone applies this new knowledge to their personal websites.\r\n"
+              description_teacher: "**Question of the Day: How can we style the images and layouts of our pages?**\r\n\r\nThis lesson continues the introduction to CSS style properties, this time focusing more on non-text elements. Students begin this lesson by looking at a website about Desserts of the World. They investigate and modify the new CSS styles on this website, adding their own styles to the page. After working on the Desserts page, students apply their knowledge of new CSS properties to their personal websites."
             Your Web Page - Prepare:
               key: Your Web Page - Prepare
               name: Your Web Page - Prepare
+              description_student: "**Question of the Day: What do we need to do to prepare to build our web pages?**\r\n\r\nIn this lesson, students engage in the \"prepare\" stage of the problem-solving process by deciding what elements and style their web pages will have. They review the different HTML, CSS, and digital citizenship guidelines, then design and plan their pages, as well as download and document the images they will need. Afterwards, they reflect on how their plan will ensure that the website does what it is designed to do.\r\n"
+              description_teacher: "**Question of the Day: What do we need to do to prepare to build our web pages?**\r\n\r\nIn this lesson, students engage in the \"prepare\" stage of the problem-solving process, deciding what elements and style their web page will have. They begin by reviewing the different HTML, CSS, and digital citizenship guidelines they will need in building their web pages. They then describe and sketch their pages, listing the tags and styles they will use to get the layout and design that they decided on. They then move online to find and download the images they will need for their pages. Afterwards, they reflect on how their plan will ensure that the website does what it is designed to do."
             Project - Personal Web Page:
               key: Project - Personal Web Page
               name: Project - Personal Web Page
+              description_student: "**Question of the Day: What skills and practices help when we code web pages?**\r\n\r\nAfter quickly reviewing the debugging process, the class goes online to create the pages that they have planned out in previous lessons, with the project guides as a reference. Afterwards, they engage in a structured reflection and feedback process before making any final updates."
+              description_teacher: "**Question of the Day: What skills and practices help when we code web pages?**\r\n\r\nAfter quickly reviewing their debugging process, students go online to create the pages that they have planned out in previous lessons, with the project guides as a reference. Once they have finished with their pages, they complete a short reflection on the process, what they are most proud of, and what they would like feedback on. They then engage in a structured peer feedback process before making final edits to the pages. Afterwards, they reflect on the skills and practices that helped them to be successful.\r\n\r\n"
             Websites for a Purpose:
               key: Websites for a Purpose
               name: Websites for a Purpose
+              description_student: "**Question of the Day: What are the different reasons people make websites?**\r\n\r\nIn this lesson, students explore the different reasons people make websites. After brainstorming various reasons that they visit websites, they investigate sample web sites that have been created to address a particular problem and decide what different purposes those websites might serve for the creators. The class then thinks of problems they might want to solve with their own websites.\r\n"
+              description_teacher: "**Question of the Day: What are the different reasons people make websites?**\r\n\r\n\r\nIn this lesson, students explore the different reasons people make websites. They first think of different reasons that they visit websites, then investigate web sites that have been created to address a particular problem. After deciding what different purposes those websites might serve for the creators, they begin to think about the problem that they might want to solve with a web site. At the end of the lesson, students form the groups that they will be in for their chapter projects."
             Team Problem Solving:
               key: Team Problem Solving
               name: Team Problem Solving
+              description_student: "**Question of the Day: How can we work together to make a great team?**\r\n\r\nTeams work together to set group norms and brainstorm what features they would like their websites to have. The class starts by reflecting on what makes teams successful. Teams then make plans for how they will interact and achieve success in their own projects before brainstorming ideas for their website projects."
+              description_teacher: "**Question of the Day: How can we work together to make a great team?**\r\n\r\nStudents work together to set group norms and brainstorm what features they would like their websites to have. The class starts by thinking of some popular teams in different contexts, then reflects on what makes teams successful. They then get into their own teams and make a plan for how they will interact and reach success in their own projects. Afterwards, the teams begin to brainstorm ideas for their website project."
             Sources and Research:
               key: Sources and Research
               name: Sources and Research
+              description_student: "**Question of the Day: How do we find relevant and trustworthy information on the Internet?**\r\n\r\nThis lesson covers how to find relevant and trustworthy information online. After viewing and discussing a video about how search engines work, students search for information relevant to their sites, then analyze the sites for credibility to decide which are appropriate to use on their own website."
+              description_teacher: "**Question of the Day: How do we find relevant and trustworthy information on the Internet?**\r\n\r\nThis lesson encourages students to think more about how to find relevant and trustworthy information online. After viewing and discussing a video about how search engines work, students will search for information relevant to their site. They'll need to analyze the sites they find for credibility to decide which are appropriate to use on their own website."
             CSS Classes:
               key: CSS Classes
               name: CSS Classes
+              description_student: "**Question of the Day:  How can we create different styles for the same type of element?**\r\n\r\nThis lesson introduces CSS classes, which allow web developers to treat groups of elements they want styled differently than other elements of the same type. Students first investigate and modify classes on various pages, then create their own classes and use them to better control the appearance of their pages. Teams then reflect on how they could use this skill to improve their websites."
+              description_teacher: "**Question of the Day:  How can we create different styles for the same type of element?**\r\n\r\nThis lesson expands on the CSS that students have already learned by introducing classes, which allow web developers to treat groups of elements they want styled differently than other elements of the same type. Students first investigate and modify classes on various pages, then create their own classes and use them to better control the appearance of their pages.  They then reflect on how they could use this skill to improve their team websites."
             Planning a Multi-page Website:
               key: Planning a Multi-page Website
               name: Planning a Multi-Page Site
+              description_student: "**Question of the Day:  How do we plan a web page as a group?**\r\n\r\nThe class works in teams to plan out the final web sites and create a sketch of each page. They then download the media that they will need for their sites. At the end of the activity, they decide how the work will be distributed among them and report whether the entire team agreed to the plan."
+              description_teacher: "**Question of the Day:  How do we plan a web page as a group?**\r\n\r\nStudents work in teams to plan out their web sites and create a sketch of each page. They then download the media that they will need for their sites. At the end of the activity, they decide how the work will be distributed among team members and report whether the entire group agreed to the plan."
             Linking Pages:
               key: Linking Pages
               name: Linking Pages
+              description_student: "**Question of the Day: How can we combine several different web pages into one website?**\r\n\r\nThe class begins this lesson by looking online for the internet’s first web page and discussing how its use of links was what started the web. They then transition to Web Lab where they learn how to make their own links, as well as good conventions that make it easier for users to navigate on a page. Finally, they reflect on their team project and what their personal goals are for the final stretch.\r\n"
+              description_teacher: "**Question of the Day: How can we combine several different web pages into one website?**\r\n\r\nStudents begin the lesson by looking online for the first web page and discussing how its use of links was what started the web. They then transition to Web Lab where they learn how to make their own links, as well as good conventions that make it easier for users to navigate on a page.  Finally, they reflect on their group project and what their personal goals are for the final stretch."
             Project - Website for a Purpose:
               key: Project - Website for a Purpose
               name: Project - Website for a Purpose
+              description_student: "**Question of the Day: What skills and practices will help us work together to make a great website?**\r\n\r\nIn this lesson, teams are finally able to code the pages that they have been planning. Using the project guide, the team works together and individually to code all of their pages, then puts all of the work together into a single site."
+              description_teacher: "**Question of the Day: What skills and practices will help us work together to make a great website?**\r\n\r\nTeams have spent a lot of time throughout the chapter planning their websites. In this lesson they are finally able to code their pages. Using the project guide, the team works together and individually to code all of the pages, then puts all of the work together into a single site."
             Peer Review and Final Touches:
               key: Peer Review and Final Touches
               name: Peer Review and Final Touches
+              description_student: "**Question of the Day:  How can we use feedback to make our websites better?**\r\n\r\nThis lesson focuses on the value of peer feedback. The class first reflects on what they are proud of, and what they would like feedback on. They then give and get that feedback through a structured process that includes the project rubric criteria. Afterwards, everyone puts the finishing touches on their sites and reflects on the process before a final showcase.\r\n"
+              description_teacher: "**Question of the Day:  How can we use feedback to make our websites better?**\r\n\r\nThis lesson focuses on the value of peer feedback. Students first reflect on what they are proud of, and what they would like feedback on. Teams then work with peers to get that feedback through a structured process that includes the project rubric criteria. Afterwards, students decide how they would like to respond to the feedback and put the finishing touches on their sites.  After a final review of the rubric, they reflect on their process. To cap off the unit, they will share their projects and also a overview of the process they took to get to that final design.\r\n"
             Post-Project Test:
               key: Post-Project Test
               name: Post-Project Test
+              description_student: 
+              description_teacher: 
             CS Discoveries Post Course survey:
               key: CS Discoveries Post Course survey
               name: CS Discoveries Post Course survey
+              description_student: 
+              description_teacher: 
           lesson_groups:
             csd2_1v2:
               display_name: 'Chapter 1: Creating Webpages'
@@ -19068,90 +19147,148 @@ en:
             Programming for Entertainment:
               key: Programming for Entertainment
               name: Programming for Entertainment
+              description_student: "**Question of the Day: How is computer science used in entertainment?**\r\n\r\nThe class is asked to consider the \"problems\" of boredom and self expression, and to reflect on how they approach those problems in their own lives. From there, they will explore how Computer Science in general, and programming specifically, plays a role in either a specific form of entertainment or as a vehicle for self expression."
+              description_teacher: "**Question of the Day: How is computer science used in entertainment?**\r\n\r\nStudents are asked to consider the \"problems\" of boredom and self expression, and to reflect on how they approach those problems in their own lives. From there, students will explore how computer science in general, and programming specifically, plays a role in either a specific form of entertainment or as a vehicle for self expression."
             Plotting Shapes:
               key: Plotting Shapes
               name: Plotting Shapes
+              description_student: "**Question of the Day: How can we clearly communicate how to draw something on a screen?**\r\n\r\nThis lesson explores the challenges of communicating how to draw with shapes and use a tool that introduces how this problem is approached in Game Lab.The class uses a Game Lab tool to interactively place shapes on Game Lab's 400 by 400 grid. Partners then take turns instructing each other how to draw a hidden image using this tool, which accounts for many of the challenges of programming in Game Lab."
+              description_teacher: "**Question of the Day: How can we clearly communicate how to draw something on a screen?**\r\n\r\nStudents explore the challenges of communicating how to draw with shapes and use a tool that introduces how this problem is approached in Game Lab. The warm up activity quickly demonstrates the challenges of communicating position without some shared reference point. In the main activity, students explore a Game Lab tool that allows students to interactively place shapes on Game Lab's 400 by 400 grid. They then take turns instructing a partner how to draw a hidden image using this tool, accounting for many challenges students will encounter when programming in Game Lab. Students optionally create their own image to communicate before a debrief discussion.\r\n"
             Drawing in Game Lab:
               key: Drawing in Game Lab
               name: Drawing in Game Lab
+              description_student: "**Question of the Day: How can we communicate to a computer how to draw shapes on the screen?**\r\n\r\nThe class is introduced to Game Lab, the programming environment for this unit, and begins to use it to position shapes on the screen. The lesson covers the basics of sequencing and debugging, as well as a few simple commands. At the end of the lesson, students will be able to program images like the ones they made with the drawing tool in the previous lesson."
+              description_teacher: "**Question of the Day: How can we communicate to a computer how to draw shapes on the screen?**\r\n\r\nStudents are introduced to Game Lab, the programming environment for this unit, and begin to use it to position shapes on the screen. They learn the basics of sequencing and debugging, as well as a few simple commands. At the end of the lesson, students will be able to program images like the ones they made with the drawing tool in the previous lesson."
             Shapes and Parameters:
               key: Shapes and Parameters
               name: Shapes and Parameters
+              description_student: "**Question of the Day:  How can we use parameters to give the computer more specific instructions?**\r\n\r\nIn this lesson, students continue to develop a familiarity with Game Lab by manipulating the width and height of the shapes they use to draw. The lesson kicks off with a discussion that connects expanded block functionality (e.g. different sized shapes) with the need for more block inputs, or \"parameters.\" Finally, the class learns to draw with versions of ellipse() and rect() that include width and height parameters and to use the background() block.\r\n"
+              description_teacher: "**Question of the Day:  How can we use parameters to give the computer more specific instructions?**\r\n\r\nIn this lesson students continue to develop their familiarity with Game Lab by manipulating the width and height of the shapes they use to draw. The lesson kicks off with a discussion that connects expanded block functionality (e.g. different sized shapes) with the need for more block inputs, or \"parameters\". Students learn to draw with versions of `ellipse()` and `rect()` that include width and height parameters. They also learn to use the `background()` block."
             Variables:
               key: Variables
               name: Variables
+              description_student: "**Question of the Day:  How can we use variables to store information in our programs?**\r\n\r\nThis lesson introduces variables as a way to label a number in a program or save a randomly generated value. The class begins the lesson with a very basic description of the purpose of a variable and practices using the new blocks, then completes a level progression that reinforces the model of a variable as a way to label or name a number.\r\n"
+              description_teacher: "**Question of the Day:  How can we use variables to store information in our programs?**\r\n\r\nIn this lesson students learn how to use variables to label a number. Students begin the lesson with a very basic description of the purpose of a variable within the context of the storage component of the input-output-storage-processing model. Students then complete a level progression that reinforces the model of a variable as a way to label or name a number."
             Random Numbers:
               key: Random Numbers
               name: Random Numbers
+              description_student: "**Question of the Day: How can we make our programs behave differently each time they are run?**\r\n\r\nStudents are introduced to the randomNumber() block and how it can be used to create new behaviors in their programs. They then learn how to update variables during a program, and use those skills to draw randomized images."
+              description_teacher: "**Question of the Day: How can we make our programs behave differently each time they are run?**\r\n\r\nStudents are introduced to the `randomNumber()` block and how it can be used to create new behaviors in their programs. They then learn how to update variables during a program.  Combining all of these skills, students draw randomized images."
             Sprites:
               key: Sprites
               name: Sprites
+              description_student: "**Question of the Day:  How can we use sprites to help us keep track of lots of information in our programs?**\r\n\r\nIn order to create more interesting and detailed images, the class is introduced to the sprite object. The lesson starts with a discussion of the various information that programs must keep track of, then presents sprites as a way to keep track of that information. Students then learn how to assign each sprite an image, which greatly increases the complexity of what can be drawn on the screen."
+              description_teacher: "**Question of the Day:  How can we use sprites to help us keep track of lots of information in our programs?**\r\n\r\nIn order to create more interesting and detailed images, students are introduced to the sprite object. The lesson starts with a discussion of the various information that programs must keep track of, then presents sprites as a way to keep track of that information. Students then learn how to assign each sprite an image, which will greatly increase the complexity of what they can draw on the screen."
             Sprite Properties:
               key: Sprite Properties
               name: Sprite Properties
+              description_student: "**Question of the Day: How can we use sprite properties to change their appearance on the screen?**\r\n\r\nStudents extend their understanding of sprites by interacting with sprite properties. The lesson starts with a review of what a sprite is, then moves on to Game Lab for more practice with sprites, using their properties to change their appearance. The class then reflects on the connections between properties and variables.\r\n"
+              description_teacher: "**Question of the Day: How can we use sprite properties to change their appearance on the screen?**\r\n\r\nStudents extend their understanding of sprites by interacting with sprite properties.  Students start with a review of what a sprite is, then move on to Game Lab to practice more with sprites, using their properties to change their appearance. They then reflect on the connections between properties and variables."
             Text:
               key: Text
               name: Text
+              description_student: "**Question of the Day: How can we use text to improve our scenes and animations?**\r\n\r\nThis lesson introduces Game Lab's text commands, giving students more practice using the coordinate plane and parameters. At the beginning of the lesson, they are asked to caption a cartoon created in Game Lab. They then move onto Code Studio where they practice placing text on the screen and controlling other text properties, such as size.\r\n"
+              description_teacher: "**Question of the Day: How can we use text to improve our scenes and animations?**\r\n\r\nThis lesson introduces Game Lab's text commands, giving students more practice using the coordinate plane and parameters. At the beginning of the lesson, students are asked to caption a cartoon created in Game Lab. They then move onto Code Studio where they practice placing text on the screen and controlling other text properties, such as size.  Students who complete the assessment early may go on to learn more challenging blocks related to text properties. "
             'Mini-Project: Captioned Scenes':
               key: 'Mini-Project: Captioned Scenes'
               name: Mini-Project - Captioned Scenes
+              description_student: "**Question of the Day: How can we use Game Lab to express our creativity?**\r\n\r\nAfter a quick review of the code learned so far, the class is introduced to the first creative project of the unit. Using the problem solving process as a model, students define the scene that they want to create, prepare by thinking of the different code they will need, try their plan in Game Lab, then reflect on what they have created. They also have a chance to share their creations with their peers.\r\n"
+              description_teacher: "**Question of the Day: How can we use Game Lab to express our creativity?**\r\n\r\nAfter a quick review of the code they have learned so far, students are introduced to their first creative project of the unit. Using the problem-solving process as a model, students define the scene that they want to create, prepare by thinking of the different code they will need, try their plan in Game Lab, then reflect on what they have created. They also have a chance to share their creations with their peers."
             The Draw Loop:
               key: The Draw Loop
               name: The Draw Loop
+              description_student: "**Question of the Day: How can we animate our images in Game Lab?**\r\n\r\nThis lesson introduces the draw loop, one of the core programming paradigms in Game Lab. Students learn how to combine the draw loop with random numbers to manipulate some simple animations first with dots and then with sprites."
+              description_teacher: "**Question of the Day: How can we animate our images in Game Lab?**\r\n\r\nIn this lesson students are introduced to the draw loop, one of the core programming paradigms in Game Lab. To begin the lesson students look at some physical flipbooks to see that having many frames with different images creates the impression of motion. Students then watch a video explaining how the draw loop in Game Lab helps to create this same impression in their programs. Students combine the draw loop with random numbers to manipulate some simple animations with dots and then with sprites."
             Sprite Movement:
               key: Sprite Movement
               name: Sprite Movement
+              description_student: "**Question of the Day: How can we control sprite movement in Game Lab?**\r\n\r\nIn this lesson, the class learns how to control sprite movement using a construct called the counter pattern, which incrementally changes a sprite's properties. After brainstorming different ways that they could animate sprites by controlling their properties, students explore the counter pattern in Code Studio, using the counter pattern to create various types of sprite movements."
+              description_teacher: "**Question of the Day: How can we control sprite movement in Game Lab?**\r\n\r\nIn this lesson, students learn how to control sprite movement using a construct called the counter pattern, which incrementally changes a sprite's properties. Students first brainstorm different ways that they could animate sprites by controlling their properties, then explore the counter pattern in Code Studio. After examining working code, students try using the counter pattern to create various types of sprite movements."
             'Mini-Project: Animation':
               key: 'Mini-Project: Animation'
               name: Mini-Project - Animation
+              description_student: "**Question of the Day: How can we combine different programming patterns to make a complete animation?**\r\n\r\nIn this lesson, the class is asked to combine different methods from previous lessons to create an animated scene. Students first review the types of movement and animation that they have learned, and brainstorm what types of scenes might need that movement. They then begin to plan out their own animated scenes, which they create in Game Lab.\r\n"
+              description_teacher: "**Question of the Day: How can we combine different programming patterns to make a complete animation?**\r\n\r\nIn this lesson, students are asked to combine different methods that they have learned to create an animated scene. Students first review the types of movement and animation that they have learned, and brainstorm what types of scenes might need that movement. They then begin to plan out their own animated scenes, which they create in Game Lab."
             Conditionals:
               key: Conditionals
               name: Conditionals
+              description_student: "**Question of the Day:  How can programs react to changes as they are running?**\r\n\r\nThis lesson introduces students to booleans and conditionals, which allow a program to run differently depending on whether a condition is true. The class starts by playing a short game in which they respond according to whether particular conditions are met. They then move to Code Studio, where they learn how the computer evaluates boolean expressions, and how they can be used to structure a program."
+              description_teacher: "**Question of the Day:  How can programs react to changes as they are running?**\r\n\r\nThis lesson introduces booleans and conditionals, which allow a program to run differently depending on whether a condition is true. Students start by playing a short game in which they respond according to whether particular conditions are met. They then move to Code Studio, where they learn how the computer evaluates Boolean expressions, and how they can be used to structure a program."
             Keyboard Input:
               key: Keyboard Input
               name: Keyboard Input
+              description_student: "**Question of the Day: How can our programs react to user input?**\r\n\r\nFollowing the introduction to booleans and if statements in the previous lesson, students are introduced to a new block called keyDown(), which returns a boolean and can be used in conditionals statements to move sprites around the screen. By the end of this lesson they will have written programs that take keyboard input from the user to control sprites on the screen.\r\n"
+              description_teacher: "**Question of the Day: How can our programs react to user input?**\r\n\r\nFollowing the introduction to booleans and _if_ statements in the previous lesson, students are introduced to a new block called `keyDown()` which returns a boolean and can be used in conditionals statements to move sprites around the screen. By the end of this lesson, students will have written programs that take keyboard input from the user to control sprites on the screen."
             Mouse Input:
               key: Mouse Input
               name: Mouse Input
+              description_student: "**Question of the Day: What are more ways that the computer can react to user input?**\r\n\r\nThe class continues to explore ways to use conditional statements to take user input. In addition to the keyboard commands learned yesterday, they learn about several ways to take mouse input. They also expand their understanding of conditionals to include else, which allows for the computer to run a certain section of code when a condition is true, and a different section of code when it is not."
+              description_teacher: "**Question of the Day: What are more ways that the computer can react to user input?**\r\n\r\nIn this lesson students continue to explore ways to use conditional statements to take user input. In addition to the keyboard commands learned yesterday, students will learn about several ways to take mouse input. They will also expand their understanding of conditionals to include `else`, which allows for the computer to run a certain section of code when a condition is true, and a different section of code when it is not."
             Project - Interactive Card:
               key: Project - Interactive Card
               name: Project - Interactive Card
+              description_student: "**Question of the Day:  What skills and practices are important when creating an interactive program?**\r\n\r\nIn this culminating project for Chapter 1, students plan for and develop an interactive greeting card using all of the programming techniques they've learned to this point.\r\n"
+              description_teacher: "**Question of the Day:  What skills and practices are important when creating an interactive program?**\r\n\r\nIn this culminating project for Chapter 1, students plan for and develop an interactive greeting card using all of the programming techniques they've learned to this point."
             Velocity:
               key: Velocity
               name: Velocity
+              description_student: "**Question of the Day:  How can programming languages hide complicated patterns so that it is easier to program?**\r\n\r\nAfter a brief review of how the counter pattern is used to move sprites, the class is introduced to the idea of hiding those patterns in a single block, in order to help manage the complexity of programs. They then head to Code Studio to try out new blocks that set a sprite's velocity directly, and look at the various ways that they are able to code more complex behaviors in their sprites.\r\n"
+              description_teacher: "**Question of the Day:  How can programming languages hide complicated patterns so that it is easier to program?**\r\n\r\nAfter a brief review of how they used the counter pattern to move sprites in previous lessons, students are introduced to the idea of hiding those patterns in a single block.  Students then head to Code Studio to try out new blocks that set a sprite's velocity directly, and look at various ways that they are able to code more complex behaviors in their sprites.  "
             Collision Detection:
               key: Collision Detection
               name: Collision Detection
+              description_student: "**Question of the Day: How can programming help make complicated problems more simple?**\r\n\r\nIn this lesson, the class learns about collision detection on the computer. Working in pairs, they explore how a computer could use math, along with the sprite location and size properties, to detect whether two sprites are touching. They then use the isTouching() block to create different effects when sprites collide, and practice using the block to model various interactions."
+              description_teacher: "**Question of the Day: How can programming help make complicated problems more simple?**\r\n\r\nStudents learn about collision detection on the computer. Working in pairs, they explore how a computer could use sprite location and size properties and math to detect whether two sprites are touching. They then use the `isTouching()` block to create different effects when sprites collide, and practice using the block to model various interactions."
             'Mini-Project: Side Scroller':
               key: 'Mini-Project: Side Scroller'
               name: Mini-Project - Side Scroller
+              description_student: "**Question of the Day:  How can the new types of sprite movement and collision detection be used to create a game?**\r\n\r\nStudents use what they have learned about collision detection and setting velocity to create simple side scroller games. After looking at a sample side scroller game, they brainstorm what sort of side scroller they would like to make, then use a structured process to program the game in Code Studio."
+              description_teacher: "**Question of the Day:  How can the new types of sprite movement and collision detection be used to create a game?**\r\n\r\nStudents use what they have learned about collision detection and setting velocity to create a simple side scroller game. After looking at a sample side scroller game, students brainstorm what sort of side scroller they would like to make, then use a structured process to program the game in Code Studio."
             Complex Sprite Movement:
               key: Complex Sprite Movement
               name: Complex Sprite Movement
+              description_student: "**Question of the Day: How can previous blocks be combined in new patterns to make interesting movements?**\r\n\r\nThe class learns to combine the velocity properties of sprites with the counter pattern to create more complex sprite movement. After reviewing the two concepts, they explore various scenarios in which velocity is used in the counter pattern, and observe the different types of movement that result. In particular, students learn how to simulate gravity. They then reflect on how they were able to get new behaviors by combining blocks and patterns that they already knew.\r\n"
+              description_teacher: "**Question of the Day: How can previous blocks be combined in new patterns to make interesting movements?**\r\n\r\nStudents learn to combine the velocity properties of sprites with the counter pattern to create more complex sprite movement. After reviewing the two concepts, they explore various scenarios in which velocity is used in the counter pattern, and observe the different types of movement that result. In particular, students learn how to simulate gravity. They then reflect on how they were able to get new behaviors by combining blocks and patterns that they already knew."
             Collisions:
               key: Collisions
               name: Collisions
+              description_student: "**Question of the Day: How can programmers build on abstractions to create further abstractions?**\r\n\r\nIn this lesson, the class programs their sprites to interact in new ways. After a brief review of how they used the isTouching block, students brainstorm other ways that two sprites could interact. They then use isTouching to make one sprite push another across the screen before practicing with the four collision blocks (collide, displace, bounce, and bounceOff).\r\n"
+              description_teacher: "**Question of the Day: How can programmers build on abstractions to create further abstractions?**\r\n\r\nIn this lessson, students program their sprites to interact in new ways. After a brief review of how they used the `isTouching` block, students brainstorm other ways that two sprites could interact. They then use `isTouching` to make one sprite push another across the screen before practicing with the four collision blocks (`collide`, `displace`, `bounce`, and `bounceOff`)."
             'Mini-Project: Flyer Game':
               key: 'Mini-Project: Flyer Game'
               name: Mini-Project - Flyer Game
+              description_student: "**Question of the Day:  How can the new types of collisions and modeling movement be used to create a game?**\r\n\r\nStudents use what they have learned about simulating gravity and the different types of collisions to create simple flyer games. After looking at a sample flyer game, they brainstorm what sort of flyer they would like, then use a structured process to program the game in Code Studio.\r\n"
+              description_teacher: "**Question of the Day:  How can the new types of collisions and modeling movement be used to create a game?**\r\n\r\nStudents use what they have learned about simulating gravity and the different types of collisions to create simple flyer games. After looking at a sample flyer game, students brainstorm what sort of flyer games they would like, then use a structured process to program the game in Code Studio."
             Functions:
               key: Functions
               name: Functions
+              description_student: "**Question of the Day: How can programmers use functions to create their own abstractions?**\r\n\r\nThis lesson covers functions as a way for students to organize their code, make it more readable, and remove repeated blocks of code. The class learns that higher level or more abstract steps make it easier to understand and reason about steps, then begins to create functions in Game Lab.\r\n"
+              description_teacher: "**Question of the Day: How can programmers use functions to create their own abstractions?**\r\n\r\nStudents learn how to create functions to organize their code, make it more readable, and remove repeated blocks of code. Students first think about what sorts of new blocks they would like in Game Lab, and what code those blocks would contain inside. Afterwards students learn to create functions in Game Lab. They will use functions to remove long blocks of code from their draw loop and to replace repeated pieces of code with a single function."
             The Game Design Process:
               key: The Game Design Process
               name: The Game Design Process
+              description_student: "**Question of the Day:  How does having a plan help to make a large project easier?**\r\n\r\n\r\nThis lesson introduces the process that students will use to design games for the remainder of the unit. This process is centered around a project guide that asks students to define their sprites, variables, and functions before they begin programming their game. They walk through this process in a series of levels. At the end of the lesson, students have an opportunity to make improvements to the game to make it their own."
+              description_teacher: "**Question of the Day:  How does having a plan help to make a large project easier?**\r\n\r\nThis lesson introduces students to the process they will use to design games for the remainder of the unit. This process is centered around a project guide which asks students to define their sprites, variables, and functions before they begin programming their game. In this lesson students begin by playing a game on Game Lab where the code is hidden. They discuss what they think the sprites, variables, and functions would need to be to make the game. They are then given a completed project guide which shows one way to implement the game. Students are then walked through this process through a series of levels. At the end of the lesson, students have an opportunity to make improvements to the game to make it their own."
             Using the Game Design Process:
               key: Using the Game Design Process
               name: Using the Game Design Process
+              description_student: "**Question of the Day:  How can the problem solving process help programmers to manage large projects?**\r\n\r\n\r\nIn this multi-day lesson, the class uses the problem solving process from Unit 1 to create a platform jumper game. After looking at a sample game, they define what their games will look like and use a structured process to build them. Finally, the class reflects on how the games could be improved, and implements those changes.\r\n"
+              description_teacher: "**Question of the Day:  How can the problem solving process help programmers to manage large projects?**\r\n\r\nIn this multi-day lesson, students use the problem solving process from Unit 1 to create a platform jumper game. They start by looking at an example of a platform jumper, then define what their games will look like. Next, they use a structured process to plan the backgrounds, variables, sprites, and functions they will need to implement their game. After writing the code for the game, students will reflect on how the game could be improved, and implement those changes."
             Project - Design a Game:
               key: Project - Design a Game
               name: Project - Design a Game
+              description_student: "**Question of the Day: How can the five CS practices (problem solving, persistence, communication, collaboration, and creativity) help programmers to complete large projects?**\r\n\r\nStudents plan and build original games using the project guide from the previous two lessons. Working individually or in pairs, they plan, develop, and give feedback on the games. After incorporating the peer feedback, students share out their completed games.\r\n"
+              description_teacher: "**Question of the Day: How can the five CS practices (problem solving, persistence, communication, collaboration, and creativity) help programmers to complete large projects?**\r\n\r\nStudents will plan and build their own game using the project guide from the previous two lessons. Working individually or in pairs, students will first decide on the type of game they'd like to build, taking as inspiration a set of sample games. They will then complete a blank project guide where they will describe the game's behavior and scope out the variables, sprites, and functions they'll need to build. In Code Studio, a series of levels prompts them on a general sequence they can use to implement this plan. Partway through the process, students will share their projects for peer review and will incorporate feedback as they finish their game. At the end of the lesson, students will share their completed games with their classmates. This project will span multiple classes and can easily take anywhere from 3-5 class periods."
             Post-Project Test:
               key: Post-Project Test
               name: Post-Project Test
+              description_student: 
+              description_teacher: 
             CS Discoveries Post Course survey:
               key: CS Discoveries Post Course survey
               name: CS Discoveries Post Course survey
+              description_student: 
+              description_teacher: 
           lesson_groups:
             csd3_1:
               display_name: 'Chapter 1: Images and Animations'
@@ -19181,77 +19318,117 @@ en:
             Analysis of Design:
               key: Analysis of Design
               name: Analysis of Design
+              description_student: "The class explores a variety of different teapot designs to consider design choices. Building on this, students explore the relationship between users, their needs, and the design of objects they use.\r\n"
+              description_teacher: To kick off a unit devoted to group problem solving and developing products for other users, students begin by investigating the design of various teapots. Students analyze each teapot, attempting to identify how specific user needs might have informed its design. By considering these design choices, and attempting to match each teapot with a potential user, students can begin to see how taking a user-centered approach to designing products (both physical and digital) can make those products more useful and usable. To conclude the activity, students are asked to propose some changes to one of the teapots that would make it more useful or usable.
             Understanding Your User:
               key: Understanding Your User
               name: Understanding Your User
+              description_student: "Using user profiles, students explore how different users might react to a variety of products. Role playing as a different person, each member of the class will get to experience designs through someone else's eyes.\r\n"
+              description_teacher: "**Question of the Day: How can we make sure a product is meeting the needs of a user?**\r\n\r\nDesigners need to understand their users' needs in order to create useful products.  This lesson encourages students to think about how to design for another person by role-playing as someone else using a user profile and reacting as that user to a series of products.  Each student is assigned a user profile describing a person, which they then use to choose appropriate products, critique product design, and suggest improvements to design.\r\n"
             User-Centered Design Micro Activity:
               key: User-Centered Design Micro Activity
               name: User-Centered Design Micro Activity
             User Interfaces:
               key: User Interfaces
               name: User Interfaces
+              description_student: "In this lesson, students get to see how a paper prototype can be used to test and get feedback on software before writing any code. To help out a developer with their idea, the class tests and provides an app prototype made of paper.\r\n"
+              description_teacher: "**Question of the Day:** How can we test an app to make sure it meets a user's needs?\r\n \r\nFollowing the mini design project, students look towards the next phase of design - prototyping a product that attempts to address user needs. In teams, students examine a paper prototype for a chat app called \"Txt Ur Grndkdz\". Through using this paper prototype, students get a chance to see how a simple paper prototype can be used to quickly test ideas and assumptions before we ever get to the computer. After \"using\" the provided prototype students begin to identify ways to improve the next iteration.\r\n"
             Feedback and Testing:
               key: Feedback and Testing
               name: Feedback and Testing
+              description_student: Users have been testing an app, and they have lots of feedback for the developer. The class needs to sort through all of this feedback, identify the common themes and needs, and start revising the prototype to make it better meet the users' needs.
+              description_teacher: "**Question of the Day:** How can we use feedback to improve an app?\r\n\r\nIn this lesson students use feedback from \"users\" of the paper-prototyped app from the previous lesson in order to develop improvements to the user interface of that paper prototype. The lesson begins with a reflection on the fact that designers need to translate human needs with technology into changes to the user interface or experience. Students are then given a collection of feedback and requests from users of the app from the previous lesson. In groups students categorize the feedback and identify ways the needs expressed in the feedback could be met by changes to the interface of the app. Then in groups students will implement some of these changes to meet one of the needs they identified."
             Identifying User Needs:
               key: Identifying User Needs
               name: Identifying User Needs
+              description_student: Up to this point, the users that the class has considered have all been remote, and the only information from users has come through text or role playing. Now students get to rely on each other as potential users, as pairs interview each other to identify needs that could be addressed by developing an app.
+              description_teacher: "**Question of the Day:** How can user interviews help us create apps to meet the needs of a user?\r\n\r\nIn this lesson students interpret user interviews to determine the needs & interests of a user. They then speculate on the barriers these users are facing or the opportunities that are available for each user. In a group, they share these barriers & opportunities and brainstorm different apps that could be used to address these issues. By the end of the lesson, students will have decided on an app idea that addresses a barrier or opportunity for a user."
             Project - Paper Prototype:
               key: Project - Paper Prototype
               name: Project - Paper Prototype
+              description_student: "Using the interview information from the previous lesson, students come up with app ideas to address the needs of their users. To express those ideas, and test out their effectiveness, each student creates and tests paper prototypes of their own.\r\n"
+              description_teacher: "**Question of the Day:** How can I develop an app prototype for a user?\r\n\r\nBased on user interview from the previous lesson, each student comes up with an idea for an app that will address their user's problem. Students then get to create their own paper prototype of their app ideas by drawing \"screens\" on individual notecards. A project guide directs students through the process including building the paper prototype and testing it with their user to see if their assumptions about the user interfaces they created are accurate.\r\n\r\nThis is a two-day lesson, with specific timings outlined in the lesson plan below"
             Designing Apps for Good:
               key: Designing Apps for Good
               name: Designing Apps for Good
+              description_student: To kick off the app design project, the class organizes into teams and starts exploring app topics. Several examples of socially impactful apps serve as inspiration for the project.
+              description_teacher: "**Question of the Day:** What is an App for Good we want to create?\r\n \r\nThis lesson starts an app design project that lasts through the end of the unit. Students first explore a number of apps designed for social impact that have been created by other students. Students form project teams and lay out a contract for how the team will function throughout the development of their app. Finally, they brainstorm a team name, a topic for their app, and potential users.\r\n"
             Market Research:
               key: Market Research
               name: Market Research
+              description_student: In this lesson, students dive into app development by exploring existing apps that may serve similar users. In groups, they identify a handful of apps that address the same topic they are working on, and use those apps to help refine the app idea they will pursue.
+              description_teacher: In this lesson students research apps similar to the one they intend on creating to better understand the needs of their users. Students work within their teams to search the Internet for other apps, then evaluate the ones they find interesting. By the end of the lesson, each team will have a clearer idea about the type of app they want to create and further refine who their target users are. Each team will maintain a list of citations for all the apps they examined for use in their final presentation.
             Paper Prototypes:
               key: Paper Prototypes
               name: Build a Paper Prototype
+              description_student: Paper prototypes allow developers to quickly test ideas before investing a lot of time writing code. In this lesson, teams explore some example apps created in App Lab and use these examples to help inform the first paper prototypes of their apps.
+              description_teacher: Students work in their teams to create paper prototypes for the apps they’ve been developing. They begin by making a plan for each screen, then assigning different team members to work on each screen so the task can be completed in time. They can use 3x5 index cards to develop their paper prototypes, or the Paper Prototype template.
             Prototype Testing:
               key: Prototype Testing
               name: Prototype Testing
+              description_student: "In this lesson, teams test out their paper prototypes with other members of the class. As one student role plays as the computer, one narrates, and the rest observe, teams will get immediate feedback on their app designs, which will inform the next version of their app prototypes.\r\n"
+              description_teacher: "**Question of the Day:** How does our prototype work when tested by real users?\r\n\r\nThe primary purpose of developing paper prototypes is that they allow for quick testing and iteration before any code is written. This lesson is focused on giving teams a chance to test their prototypes before moving to App Lab. Teams develop a plan to test with users before running prototype tests with multiple other students in the class (and potentially outside the class). In order to test the prototype with the users, the students will have to assign roles in the testing (the “narrator”, the “computer” and the “observers”) as well as have some questions prepared for the user to answer after the test is complete."
             Digital Design:
               key: Digital Design
               name: Design Mode in App Lab
-              description_student: Having developed, tested, and gathered feedback on a paper prototype, teams now move to App Lab to build the next iteration of their apps. Using the drag-and-drop Design Mode, each team member builds out at least one page of their team's app, responding to feedback that was received in the previous round of testing.
-              description_teacher: Having collaboratively developed a paper prototype for their apps, groups now divide and conquer to begin work on an interactive digital version based on the paper prototype. Using the drag-and-drop design mode of App Lab, students individually work through a progression of skill-building levels to learn how to build digital versions of a paper prototype. From there, each group member builds out at least one page of their app in App Lab, to be later combined into a single app.
+              description_student: "Having developed, tested, and gathered feedback on a paper prototype, teams now move to App Lab to build the next iteration of their apps. Using the drag-and-drop Design Mode, each team member builds out at least one page of their team's app, responding to the feedback they received in the previous round of testing.\r\n"
+              description_teacher: "**Question of the Day:** How can we use App Lab and Design Mode to create apps?\r\n \r\nStudents are introduced to the App Lab programming environment that they will use to build their apps. Students work through a progression of skill-building levels to learn how to use the drag-and-drop design mode of App Lab. They end the lesson by making a plan to adapt one of their Paper Prototype screens into App Lab, focusing on having unique IDs for each element.\r\n"
             Linking Screens:
               key: Linking Screens
               name: Linking Prototype Screens
-              description_student: Building on the screens that the class designed in the previous lesson, teams combine screens into a single app. Simple code can then be added to make button clicks change to the appropriate screen.
-              description_teacher: In this lesson teams combine the screens that they designed in the previous lesson into a single app, which they can then link together using code. Students learn basic event driven programming by building up the model app that they started in the previous lesson. In addition to the screen that students designed yesterday, they'll learn how to create additional screens and even import screens made by others.
+              description_student: "Building on the screens that they designed in the previous lesson, teams combine screens into a single app. Simple code can then be added to make button clicks change to the appropriate screen.\r\n"
+              description_teacher: "**Question of the Day:** How can I combine screens to create a complete digital prototype?\r\n \r\nIn this lesson teams combine their digital prototype screens into a single app, which they can then link together using code. They share their project’s import URLs with each other, then import each teammate’s screen into their own app. Each student works independently to add events to their code to link the screens together, completing their digital prototype.\r\n"
             Testing the App:
               key: Testing the App
               name: Testing the App
+              description_student: "In this lesson, teams run another round of user testing with their interactive prototype. Feedback gathered from this round of testing will inform the final iteration of the app prototypes.\r\n"
+              description_teacher: "**Question of the Day:** How does our digital prototype work when tested by real users?\r\n \r\nBy the end of the previous lesson each team should have a working prototype of their app. The primary purpose of this lesson is to have the team actually test the app with other people, preferably from the target audience the app is intended for, or from different teams in the class while observers from the team will record the results. As with testing the paper prototypes, teams will start by planning for the specific scenarios before running and observing tests.\r\n"
             Improving and Iterating:
               key: Improving and Iterating
               name: Improving and Iterating
             Project - App Presentation:
               key: Project - App Presentation
               name: Project - App Presentation
+              description_student: "Each team prepares a presentation to \"pitch\" the app they've developed. This is the time students can share the struggles, triumphs, and plans for the future.\r\n"
+              description_teacher: "**Question of the Day:** How can I present the steps in our design process to people outside of our team?\r\n \r\nAt this point teams have researched a topic of personal and social importance, developed and tested both a paper prototype and a digital prototype, and iterated on the initial app to incorporate new features and bug fixes. Now is the time for them to review what they have done and pull together a coherent presentation to demonstrate their process of creation. Using the provided presentation template, teams prepare to present about their process of app development, including the problem they set out to solve, the ways in which they've incorporated feedback from testing, and their plans for the future.\r\n"
             Post-Project Test:
               key: Post-Project Test
               name: Post-Project Test
+              description_student: 
+              description_teacher: 
             CS Discoveries Post Course survey:
               key: CS Discoveries Post Course survey
               name: CS Discoveries Post Course survey
-              description_student: ''
-              description_teacher: ''
+              description_student: 
+              description_teacher: 
             User-Centered Design 1:
               name: User Centered Design   Define and Prepare
+              description_student: "In small groups, students use the design process to come up with ideas for smart clothing. From brainstorming, to identifying users, to finally proposing a design, this activity serves as the first of several opportunities in this unit for students to practice designing a solution for the needs of others.\r\n"
+              description_teacher: "**Question of the Day: How can we design for people other than ourselves?**\r\n\r\nThis is the first part of a two-day lesson where students are guided through an abbreviated version of the design process they will be seeing throughout this unit. This lesson focuses on the Define and Prepare steps of the process. Students first brainstorm a list of potential users of smart clothing. As a class, they then group these ideas into broad categories and each group will choose one category of user. Groups repeat this process to brainstorm needs or concerns of their user, eventually categorizing these needs and choosing one to focus on. In the next lesson, students will complete the Try and Reflect steps of the design process.\r\n"
             User-Centered Design 2:
               name: User Centered Design   Try and Reflect
+              description_student: 'Question of the Day: How can we design a product to meet a user''s needs?'
+              description_teacher: "**Question of the Day: How can we design a product to meet a user's needs?**\r\n \r\nThis is the second part of a two-day lesson where students are guided through an abbreviated version of the design process they will be seeing throughout this unit. Yesterday students completed the Define and Prepare steps of the design process. Today, they complete the Try and Reflect portions. Students continue their work from yesterday by designing a piece of smart clothing, using the specific needs and concerns they brainstormed to guide their decision making. Students have a chance to share their decision-making process and get feedback on how well their product addresses the user needs they selected.\r\n"
             Exploring UI Elements:
               name: Exploring UI Elements
+              description_student: Paper prototypes allow developers to quickly test ideas before investing a lot of time writing code. In this lesson, teams explore some example apps created in App Lab and use these examples to help inform the first paper prototypes of their apps.
+              description_teacher: Before starting to design apps, we need to help students scope their expectations. Because students will eventually be prototyping these apps in App Lab, they will be in better shape if their ideas align with the kinds of apps that can be made using AppLab’s tools. Today focuses on having teams look at several example apps made in AppLab and identifying the components of the user interface. They then make a plan for which features could use which components in their app.
             Build a Digital Prototype:
               name: Build a Digital Prototype
+              description_student: "Having developed, tested, and gathered feedback on a paper prototype, teams now move to App Lab to build the next iteration of their apps. Using the drag-and-drop Design Mode, each team member builds out at least one page of their team's app, responding to the feedback they received in the previous round of testing.\r\n"
+              description_teacher: "**Question of the Day:** How can I design a digital prototype from a paper prototype?\r\n\r\nHaving collaboratively developed a paper prototype for their apps, groups now divide and conquer to begin work on an interactive digital version based on the paper prototype. Using the drag-and-drop design mode of App Lab, students individually work through a progression of skill-building levels to learn how to build digital versions of a paper prototype. From there, each group member builds out at least one page of their app in App Lab, to be later combined into a single app."
             Events In AppLab:
               name: Events in AppLab
+              description_student: "Building on the screens that they designed in the previous lesson, teams combine screens into a single app. Simple code can then be added to make button clicks change to the appropriate screen.\r\n"
+              description_teacher: "**Question of the Day:** How can I use events to create an app?\r\n \r\nIn this lesson students learn how to add screens to their apps, how to import screens created by other students, and how to program events to navigate between screens. Students learn basic event driven programming by building up the model app that they started in the previous lesson. At the end of the lesson, students make a plan for how they will stay organized when importing each other’s screens in tomorrow’s lesson.\r\n"
             Bugs and Features:
               name: Bugs and Features
+              description_student: Using the feedback from the last round of testing, teams implement changes that address the needs of their users. Each team tracks and prioritizes the features they want to add and the bugs they need to fix.
+              description_teacher: "**Question of the Day:** How can we create a plan to address bugs and features in our prototype?\r\n \r\nTeams have at this point developed an app prototype that has gone through multiple iterations and rounds of user testing. With the information and guidance gained from the last round of user testing, each student has the opportunity to plan for and implement improvements to the team app. Depending on the time you have available, and student interest, you can run the cycle of testing and iteration as many times as you see fit.\r\n"
             Updating Your Prototype:
               name: Updating Your Prototype
+              description_student: Using the feedback from the last round of testing, teams implement changes that address the needs of their users. Each team tracks and prioritizes the features they want to add and the bugs they need to fix.
+              description_teacher: "**Question of the Day:** How can I track my work while we make updates to our app?\r\n \r\nTeams make a decision about how they will incorporate updates to their app, then they begin updating their app based on their post-its from yesterday’s lesson. They use a “To Do / Doing / Done” chart to organize their work and track their progress. Teams spend the majority of the class working on updating their app, with time at the end to re-combine into a single app if necessary.\r\n"
             Build a Paper Prototype:
               name: Build a Paper Prototype
           lesson_groups:
@@ -19284,58 +19461,92 @@ en:
             Representation Matters:
               key: Representation Matters
               name: Representation Matters
+              description_student: "This first lesson provides an overview of what data is and how it is used to solve problems. Groups use a data set to make a series of meal recommendations for people with various criteria. Afterward, groups compare their responses and discuss how the different representations of the meal data affected how they were able to solve the different problems.\r\n"
+              description_teacher: "**Question of the Day: How does data affect decisions we make everyday?**\r\n\r\nIn the first lesson of the data unit, students get an overview of what data is and how it is used to solve problems. Students start off with a brief discussion to come to a common understanding of data. They then split into groups and use a data set to make a series of meal recommendations for people with various criteria. Each group has the choices of meal represented in a different way (pictures, recipes, menu, nutrition) that gives an advantage for one of the recommendations. Afterwards, groups compare their responses and discuss how the different representations of the meal data affected how the students were able to solve the different problems.\r\n"
             Patterns and Representation:
               key: Patterns and Representation
               name: Patterns and Representation
+              description_student: "This lesson looks closer at what is needed to create a system of representation. Groups create systems that can represent any letter in the alphabet using only a single stack of cards. They then create messages with their systems and exchange with other groups to ensure the system worked as intended. Finally, the class discusses commonalities between working systems while recognizing that there are many possible working solutions.\r\n"
+              description_teacher: "**Question of the Day: How can we create a system for representing information?**\r\n\r\nIn this lesson students create their own system for representing information. They begin by brainstorming all the different systems they already use to represent yes-no responses. They then work in small groups to create a system that can represent any letter in the alphabet using only a single stack of cards. The cards used have one of 6 different possible drawings (6 animals, 6 colors, etc.) and so to represent the entire alphabet students will need to use patterns of multiple cards to represent each letter. Students create messages with their systems and exchange with other groups to ensure the system worked as intended. In the wrap-up discussion the class reviews any pros and cons of the different systems. They discuss commonalities between working systems and recognize that there are many possible solutions to this problem and what's important is that everyone uses the same arbitrary system to communicate.\r\n"
             ASCII and Binary Representation:
               key: ASCII and Binary Representation
               name: ASCII and Binary Representation
+              description_student: "This lesson introduces students to a formal binary system for encoding information: the ASCII system for representing letters and other characters. At the beginning of the lesson, the teacher introduces the fact that computers must represent information using either \"on\" or \"off.\" The class then learns about the ASCII system for representing text using binary symbols and practices using this system. Finally, they encode their own messages using ASCII.\r\n"
+              description_teacher: "**Question of the Day: What system do computers use to represent letters and words?**\r\n \r\nIn this lesson students learn to use their first binary system for encoding information, the ASCII system for representing letters and other characters. At the beginning of the lesson the teacher introduces the fact that computers must represent information using either \"on\" or \"off\". Then students are introduced to the ASCII system for representing text using binary symbols. Students practice using this system before encoding their own message using ASCII. At the end of the lesson a debrief conversation helps synthesize the key learning objectives of the activity."
             Representing Images:
               key: Representing Images
               name: Representing Images
+              description_student: "This lesson continues the study of binary representation systems, this time with images. The class is introduced to the concept of splitting images into squares or \"pixels,\" which can then be turned on or off individually to make an entire image. After doing a short set of challenges using the Pixelation Widget, students make connections between the system for representing images and the ASCII system for representing text that they learned about in the previous lesson.\r\n"
+              description_teacher: "**Question of the Day: What system do computers use to represent images?**\r\n\r\nIn this lesson students learn how computers represent images. To begin the lesson they consider the challenge of turning all the complexity of vision into a binary pattern. Through a series of images showing how this transformation is made students are introduced to the concept of splitting images into squares or \"pixels\" which can then be turned on or off individually to make the entire image. Students then do a short set of challenges using the Pixelation Widget in order to draw black and white images. Puzzles are designed to call out some of the challenges of representing images in this way. In the wrap up students make connections between the system for representing images and the system for representing text they learned in the previous lesson.\r\n"
             Representing Numbers:
               key: Representing Numbers
               name: Representing Numbers
+              description_student: This lesson introduces students to the binary number system. With a set of cards that represent the place values in a binary (base-2) number system, the class turns bits "on" or "off" by turning cards face up and face down, then observes the numbers that result from these different patterns. Eventually, the pattern is extended to a generic 4-bit system.
+              description_teacher: "**Question of the Day: What system do computers use to represent numbers?**\r\n\r\nIn this lesson, students learn about the binary number system.  With a set of cards that represent the place values in a binary (base-2) number system by a collection of dots, students turn bits \"on\" or \"off\" by turning cards face up and face down, then observe the numbers that result from these different patterns.  Eventually, students extend the pattern to a generic 4-bit system."
             Keeping Data Secret:
               key: Keeping Data Secret
               name: Keeping Data Secret
+              description_student: "Students have a discussion on the different levels of security they would like for personal data. Once the class has developed an understanding of the importance of privacy, they learn about the process of encrypting information by enciphering a note for a partner and deciphering the partner's note. The class concludes with a discussion about the importance of both physical and digital security.\r\n"
+              description_teacher: Students have a discussion on the different levels of security they would like for personal data.  Once the class has developed an understanding of the importance of privacy, they learn about the process of encrypting information by enciphering a note for a partner and deciphering the partner's note.  The class concludes with a discussion about the importance of both physical and digital security.
             Combining Representations:
               key: Combining Representations
               name: Combining Representations
+              description_student: "This lesson combines all three types of binary representation systems (ASCII characters, binary numbers, and images) to explore ways to encode more complex types of information in a record. After seeing a series of bits and being asked to decode them, students are introduced to the idea that understanding binary information requires an understanding of both the system that is being used, and the meaning of the information encoded.\r\n"
+              description_teacher: "**Question of the Day: How do computers tell the difference between binary codes for letters, numbers, or images?**\r\n \r\nIn this lesson, students use all three types of binary representation systems (ASCII characters, binary number, and images) to decode information in a record. After seeing a series of bits and being asked to decode them, students are introduced to the idea that in order to understand binary information, they must understand both the system that is being used and the meaning of the information encoded. They then decode a record representing a pet based on a given structure.\r\n"
             Project - Create a Representation:
               key: Project - Create a Representation
               name: Create a Representation
+              description_student: "The class designs structures to represent their perfect day using the binary representation systems they've learned in this chapter. After deciding which pieces of information the record should capture, students decide how a punch card of bytes of information will be interpreted to represent those pieces of information. Afterwards, they use the ASCII, binary number, and image formats they have learned to represent their perfect days and try to decipher what a partner's perfect day is like.\r\n"
+              description_teacher: In this lesson students design a structure to represent their perfect day using the binary representation systems they've learned in this chapter. Students will first write a short description of their perfect day and then review with a partner to identify the key pieces of information they think a computer could capture. As a class students will decide how a punch card of bytes of information will be interpreted to represent those pieces of information. Students will then use the ASCII, binary number, and image formats they have learned to represent their perfect days. Students then trade punch cards and try to decode what the other student's perfect day is like. The lesson ends with a reflection.
             Problem Solving and Data:
               key: Problem Solving and Data
               name: Problem Solving and Data
+              description_student: "This lesson covers how the problem solving process can be tailored to deal with data problems. The class is tasked with deciding what a city most needs to spend resources on. They must find and use data from the internet to support their decision.\r\n"
+              description_teacher: "**Question of the Day: How can we use data to solve problems in our community?**\r\n\r\nIn this lesson, students use the problem solving process from earlier in the course to solve a data problem. After reviewing the process, the class is presented with a decision: whether a city should build a library, pet shelter, or fire department. Students work in teams to collect information on the Internet to help them decide what should be built, then use this information to build an argument that will convince the city council of their choice. They then map what they have done to the problem solving process that they have been using throughout the course, comparing the general problem solving process to its specific application to data problems."
             Problem Solving with Big Data:
               key: Problem Solving with Big Data
               name: Problem Solving with Big Data
+              description_student: This lesson covers how data is collected and used by organizations to solve problems in the real world. Students look at three scenarios that could be solved using data and brainstorm the types of data they would want to use to solve each problem, as well as strategies they could use to collect the data. Each scenario also includes a video about a real-world service that has solved a similar problem with data.
+              description_teacher: "**Question of the Day: How is our data collected and why is it useful?**\r\n\r\nIn this lesson, students look at how data is collected and used by organizations to solve problems in the real world. Students are presented with three scenarios that could be solved using data and brainstorm the types of data they would need and how they could collect the data. Each problem is designed to reflect a real-world service that exists. After brainstorming, students watch a video about a real-world service and record notes about what data is collected by the real-world service and how it is used. At the end of the lesson, students record whether data was provided actively by a user, was recorded passively, or is collected by sensors.\r\n"
             Structuring Data:
               key: Structuring Data
               name: Structuring Data
+              description_student: "This lesson goes further into the interpretation of data, including how to clean and visualize raw data sets. The class first looks at how presenting data in different ways can help people to understand it better. After seeing how cleaning and visualization can help people make better decisions, students look at which parts of this process can be automated, and which parts need a human.\r\n"
+              description_teacher: "**Question of the Day: how can we make it easier for computers to process data?**\r\n\r\nIn this lesson, students go further into the collection and interpretation of data, including cleaning and visualizing data. Students first look at how presenting data in different ways can help people to understand it better, and they then create visualizations of their own data. Using the results of a preferred pizza topping survey, students must decide what to do with data that does not easily fit into the visualization scheme that they have chosen. Finally, students discuss which parts of this process can be automated by a computer and which need a human to make decisions."
             Making Decisions with Data:
               key: Making Decisions with Data
               name: Making Decisions with Data
+              description_student: "This lesson gives students a chance to practice the data problem solving process introduced in the last lesson. Not all questions have right answers, and in some cases the class can and should decide that they need to collect more data. The lesson concludes with a discussion about how different people could draw different conclusions from the same data, and how collecting different data might have affected the decisions they made.\r\n"
+              description_teacher: "**Question of the Day - how can patterns in data help make a decision?**\r\n\r\nIn this lesson students get practice making decisions with data based on problems designed to be familiar to middle school students. Students work in groups discussing how they would use the data presented to make a decision before the class discusses their final choices. Not all questions have right answers and in some cases students can and should decide that they should collect more data. The lesson concludes with a discussion of how different people could draw different conclusions from the same data, or how collecting different data might have affected the decisions they made.\r\n"
             Interpreting Data:
               key: Interpreting Data
               name: Interpreting Data
+              description_student: "Students begin the lesson by looking at a cake preference survey where respondents specified both a cake and an icing flavor. They discuss how knowing the relationship between cake and icing preference helps them better decide which combination to recommend. Students are then introduced to cross tabulation, which allows them to graph relationships to different preferences. They use this technique to find relationships in a preference survey, then brainstorm the different types of problems that this process could help solve.\r\n"
+              description_teacher: "**Question of the Day**: How can patterns in data help us make decisions?\r\n\r\nStudents begin the lesson by looking at a cake preference survey that allows respondents to specify both a cake and an icing flavor. They discuss how knowing the relationship between cake and icing preference helps them better decide which combination to recommend. They are then introduced to cross tabulation, which allows them to graph relationships to different preferences. They use this technique to find relationships in a preference survey, then brainstorm the different types of problems that this process could help solve.\r\n"
             Automating Data Decisions:
               key: Automating Data Decisions
               name: Automating Data Decisions
+              description_student: "In this lesson, the class looks at a simple example of how a computer could be used to complete the decision making step of the data problem solving process. Students are given the task of creating an algorithm that suggests a vacation spot. They then create rules, or an algorithm, that a computer could use to make this decision automatically. Students share their rules and what choices their rules would make with the class data. Next, they use data from their classmates to test whether their rules would make the same decision that a person would. The lesson concludes with a discussion about the benefits and drawbacks of using computers to automate the data problem solving process.\r\n"
+              description_teacher: "**Question of the Day: How can computers help us make decisions about data?**\r\n\r\nIn this lesson students look at a simple example of how a computer could be used to complete the decision making step of the data problem solving process. Students are given the task of creating an algorithm that could suggest a vacation spot. Students then create rules that a computer could use to make this decision automatically. Students share their rules and what choices their rules would make with the class data. They then use their rules on data from their classmates to test whether their rules would make the same decision that a person would. The lesson concludes with a discussion about the benefits and drawbacks of using computers to automate the data problem solving process.\r\n"
             Project - Make a Recommendation:
               key: Project - Make a Recommendation
               name: Project - Make a Recommendation
+              description_student: To conclude this unit, the class designs ways to use data to make recommendations or predictions to help solve a problem. In the first several steps, students brainstorm problems, perform simple research, and define a problem of their choosing. They then decide what kind of data they want to collect, how it could be collected, and how it could be used, before exchanging feedback and giving a final presentation.
+              description_teacher: To conclude this unit, students design a recommendation engine based on data that they collect and analyze from their classmates. After looking at an example of a recommendation app, students follow a project guide to complete this multi-day activity. In the first several steps, students choose what choice they want to help the user to make, what data they need to give the recommendation, create a survey, and collect information about their classmates' choices. They then interpret the data and use what they have learned to create the recommendation algorithm.  Last, they use their algorithms to make recommendations to a few classmates. Students perform a peer review and make any necessary updates to their projects before preparing a presentation to the class.
             Post-Project Test:
               key: Post-Project Test
               name: Post-Project Test
+              description_student: 
+              description_teacher: 
             CS Discoveries Post Course survey:
               key: CS Discoveries Post Course survey
               name: CS Discoveries Post Course survey
-              description_student: ''
-              description_teacher: ''
+              description_student: 
+              description_teacher: 
             Data and Machine Learning:
               name: Data and Machine Learning
+              description_student: 'Question of the Day: How can machines "learn"?'
+              description_teacher: "**Question of the Day: How can machines \"learn\"?**\r\n\r\nIn this lesson, students are introduced to the concepts of Artificial Intelligence and Machine Learning using the AI for Oceans widget. First students classify objects as either \"fish\" or \"not fish\" to attempt to remove trash from the ocean. Then, students will need to expand their training data set to include other sea creatures that belong in the water. In the second part of the activity, students will choose their own labels to apply to images of randomly generated fish. This training data is used for a machine learning model that should then be able to label new images on its own."
           lesson_groups:
             csd5_1:
               display_name: 'Chapter 1: Representing Information'
@@ -19366,57 +19577,93 @@ en:
             Innovations in Computing:
               key: Innovations in Computing
               name: Innovations in Computing
+              description_student: "In this lesson, students explore a wide variety of new and innovative computing platforms while expanding their understanding of what a computer can be.\r\n"
+              description_teacher: To kick off the final unit of this course, students will do some research into interesting innovations in computing. This lesson will expose students to wider variety of computing form factors (what a computer looks like) and fields that are impacted by computing. Later in this unit students will look back on the devices they encountered in this lesson as they develop their own physical computing devices.
             Designing Screens with Code:
               key: Designing Screens with Code
               name: Designing Screens with Code
+              description_student: "By reading and changing the content on the screen of an app, the class starts to build apps that only need a single screen. Even with just one screen, students can begin to see that these techniques allow for lots of user interaction and functionality.\r\n"
+              description_teacher: In Unit 4 students learned a very simple approach to app development in App Lab that required a separate screen for most interactions. To expand the kinds of apps that students can make, and to encourage them to think in new ways about how users interact with apps, we introduce the `setProperty()` block. This command can be used to set the content and properties of various UI elements, allowing students to write programs that update information on a single screen, instead of manually creating duplicate screens. In this lesson students build up simple apps that only require a single screen, the content of which is changed using `setProperty()`.
             The Circuit Playground:
               key: The Circuit Playground
               name: The Circuit Playground
+              description_student: In this lesson, students get to know the Circuit Playground, the circuit board that will be used throughout the rest of this unit. Using App Lab, they develop programs that use the Circuit Playground for output.
+              description_teacher: In this lesson students get their first opportunity to write programs that use the Circuit Playground. After first inspecting the board visually and hypothesizing possibly functionalities, students move online where they will learn to write applications that control an LED. By combining App Lab screens with the Circuit Playgrounds, students can gradually start to integrate elements of the board as an ouput device while relying on App Lab for user input.
             Input Unplugged:
               key: Input Unplugged
               name: Input Unplugged
+              description_student: "Students experience two different ways that an app can collect input from a user, while learning more about the event-driven programming model used in App Lab.\r\n"
+              description_teacher: In preparation for delving deeper into programming with App Lab, students will explore how a handful of different programs written in both Game Lab and App Lab handle taking input from the user. After comparing and contrasting the approaches they saw in the example apps, students group up to act out the two different models for input (conditionals in an infinite loop and asynchronous events) to gain a better understanding of how they work.
             Board Events:
               key: Board Events
               name: Board Events
+              description_student: "Using the hardware buttons and switch, students develop programs that use the Circuit Playground as an input.\r\n"
+              description_teacher: This lesson transitions students from consider the Circuit Playground as strictly an output device towards using it as a tool for both input and output. Starting with the hardware buttons and switch,sing the hardware buttons and switch, students learn to use `onBoardEvent()`, analogously to `onEvent()`, in order to take input from their Circuit Playgrounds.
             Getting Properties:
               key: Getting Properties
               name: Getting Properties
+              description_student: This lesson introduces students to the getProperty block, which allows them to access the properties of different elements with code. They first practice using the block to determine what the user has input in various user interface elements. Students later use getProperty and setProperty together with the counter pattern to make elements move across the screen. A new screen element, the slider, and a new event trigger, onChange, are also introduced.
+              description_teacher: This lesson introduces students to the `getProperty` block, which allows them to access the properties of different elements with code.  Students first practice using the block to determine what the user has input in various user interface elements. Students later use `getProperty` and `setProperty` together with the counter pattern to make elements move across the screen.  A new screen element, the slider, and a new event trigger, `onChange`, are also introduced.
             Analog Input:
               key: Analog Input
               name: Analog Input
+              description_student: "Students get to explore the analog inputs on the Circuit Playground, writing programs that respond to the environment through sensors.\r\n"
+              description_teacher: In this lesson, students explore how the three analog sensors (sound, light, and temperature) can be used to write programs that respond to changes in the environment. The use of these sensors marks a transition in terms of how users interact with a program. By using sensors as an input, the user of an app doesn't have to directly interact with it at all, or may interact without actually realizing they are doing so.
             The Program Design Process:
               key: The Program Design Process
               name: The Program Design Process
+              description_student: "This lesson introduces students to the process they will use to design programs of their own throughout this unit. This process is centered around a project guide that asks students to sketch out their screens, identify elements of the Circuit Playground to be used, define variables, and describe events before they begin programming (a process very similar to the Game Design Process that students used in Unit 3). Students begin by playing a tug o' war style game where the code is hidden. They  discuss what they think the board components, events, and variables would need to be to make the program. Then, they are then given a completed project guide that shows one way to implement the project, and are walked through this process in a series of levels. At the end of the lesson, students have an opportunity to make improvements to the program to make it their own.\r\n"
+              description_teacher: This lesson introduces students to the process they will use to design programs of their own throughout this unit. This process is centered around a project guide which asks students to sketch out their screens, identify elements of the Circuit Playground to be used, define variables, and describe events before they begin programming. This process is similar to the Game Design Process that we used in Unit 3. In this lesson students begin by playing a tug o' war style game where the code is hidden. They discuss what they think the board components, events, and variables would need to be to make the program. They are then given a completed project guide which shows one way to implement the project. Students are then walked through this process through a series of levels. At the end of the lesson students have an opportunity to make improvements to the program to make it their own.
             'Project: Make a Game':
               key: 'Project: Make a Game'
               name: Project - Make a Game
+              description_student: "For this project, students design and create a game that leverages the new inputs and outputs that are available to them. This project is purposefully left very open-ended to empower students to think broadly about how physical output might be useful in an app, while still giving them a chance to review the program development process and try out the new features available through the Circuit Playground.\r\n"
+              description_teacher: Students take what they've learned through chapter one, and develop an app of their own design that uses the board to output information.
             Arrays and Color LEDs:
               key: Arrays and Color LEDs
               name: Arrays and Color LEDs
+              description_student: "In this lesson, students are introduced to the ring of color LEDs, which are exposed as an array called colorLeds. Students learn how to access and control each LED in an array individually, preparing them to access multiple LEDs through iteration later in the chapter. \r\n"
+              description_teacher: An array is an ordered collection of items, usually of the same type. In this lesson, students learn ways to access either a specific or random value from a list using its index.  They then learn how to access the colorLEDs array that controls the behavior of the color LEDs on the Circuit Playground.  Students will control the color and intensity of each LED, then use what they have learned to program light patterns to create a light show on their Circuit Playground.
             Making Music:
               key: Making Music
               name: Making Music
+              description_student: "In this lesson, students will use the Circuit Playground’s buzzer feature to its full extent by producing sounds, notes, and songs. Students start with a short review of the buzzer's frequency and duration parameters, then move on to the concept of musical notes. Notes allow students to constrain themselves to frequencies that are used in Western music and provide a layer of abstraction that helps them to understand which frequencies might sound good together. Once students are able to play notes on the buzzer, they use arrays to hold and play sequences of notes, and compose simple songs.\r\n"
+              description_teacher: In this lesson students will use the buzzer to its full extent by producing sounds, notes, and songs with the buzzer. Students start with a short review of the buzzer's frequency and duration parameters, then move on to the concept of notes.  Notes allow students to constrain themselves to frequencies that are used in Western music and provide a layer of abstraction that helps them to understand which frequencies might sound good together.  Once students are able to play notes on the buzzer, they use arrays to hold and play sequences of notes, forming simple songs.
             Arrays and For Loops:
               key: Arrays and For Loops
               name: Arrays and For Loops
+              description_student: "Students learn to combine lists and for-loops in this lesson, which allows them to write code that impacts every element of a list, regardless of how long it is. The class uses this structure to write programs that process all of the elements in lists, including the list of color LEDs.\r\n"
+              description_teacher: Using a _for loop_ to iterate over all of the elements in an array is a really useful construct in most programming languages. In this lesson, students learn the basics of how a _for loop_ can be used to repeat code, and then combine it with what they've already learned about arrays to write programs that process all elements in an array. Students use for loops to go through each element in a list one at a time without having to write code for each element. Towards the end of the lesson students will apply this with the `colorLed` list on the board to create an app that changes all of the LEDs each time a button is clicked.
             Accelerometer:
               key: Accelerometer
               name: Accelerometer
+              description_student: In this lesson, students will explore the accelerometer and its capabilities. They’ll become familiar with its events and properties, as well as create multiple programs utilizing the accelerometer similar to those they’ve likely come across in real world applications.
+              description_teacher: In this lesson, students will explore the accelerometer and its capabilities. They’ll become familiar with its events and properties, as well as create multiple programs utilizing the accelerometer similar to those they’ve likely come across in real world applications.
             Functions with Parameters:
               key: Functions with Parameters
               name: Functions with Parameters
+              description_student: "This lesson starts with a quick review of parameters in the context of the App Lab blocks that students have seen recently. Students then look at examples of parameters within user-created functions in App Lab, and create and call functions with parameters to control multiple elements on a screen. Afterward, they use for loops to iterate over an array, passing each element into a function. Last, students use what they have learned to create a star catching game.\r\n"
+              description_teacher: The lesson starts with a quick review of parameters, in the context of App Lab blocks that they students have seen recently.  Students then look at examples of parameters within user-created functions in App Lab and create and call functions with parameters for themselves, using them to control multiple elements on a screen.  Afterwards, students use for loops to iterate over an array, passing each element into a function.  Last, students use what they have learned to create a star catching game.
             Circuits and Physical Prototypes:
               key: Circuits and Physical Prototypes
               name: Circuits and Physical Prototypes
+              description_student: "In this lesson, students wire simple circuits to create a physical prototype using low-cost and easily-found materials.\r\n"
+              description_teacher: In preparation for this chapter's final project, students will learn how to develop a prototype of a physical object that includes a Circuit Playground. Using a modelled project planning guide, students will learn how to wire a couple of simple circuits and to build prototypes that can communicate the intended design of a product, using cheap and easily found materials such as cardboard and duct tape.
             'Project: Prototype an Innovation':
               key: 'Project: Prototype an Innovation'
               name: Project - Prototype an Innovation
+              description_student: "This final project challenges students to develop and test a prototype for an innovative computing device that interacts with the physical world through various types of input and output, whichallow for interesting and unique user interactions. This project is an opportunity for students to showcase their technical skills, but they will also need to demonstrate collaboration, constructive peer feedback, and iterative problem solving as they encounter obstacles along the way. This project should be student-directed whenever possible, and provide an empowering and memorable conclusion to the final unit of CS Discoveries.\r\n"
+              description_teacher: 'In this final project for the course, students team to develop and test a prototype for an innovative computing device based on the Circuit Playground. Using the inputs and outputs available on the board, groups will create programs that allow for interesting and unique user interactions. '
             Post-Project Test:
               key: Post-Project Test
               name: Post-Project Test
+              description_student: 
+              description_teacher: 
             CS Discoveries Post Course survey:
               key: CS Discoveries Post Course survey
               name: CS Discoveries Post Course survey
+              description_student: 
+              description_teacher: 
           lesson_groups:
             csd6_1:
               display_name: 'Chapter 1: Programming with Hardware'
@@ -19445,48 +19692,78 @@ en:
             CS Principles Pre-survey:
               key: CS Principles Pre-survey
               name: CS Principles Pre-survey
+              description_student: 
+              description_teacher: 
             Welcome to CSP:
               key: Welcome to CSP
               name: Welcome to CSP
+              description_student: Welcome to Computer Science Principles! Groups make a “rapid” prototype of an innovative idea and share it. Students watch a brief video about computing innovations.
+              description_teacher: Welcome to Computer Science Principles! The first lesson is about getting students excited about the course and connecting their own personal interests to computer science.  Students are asked to share something they know a lot about and teach it to a small group.  Groups make a “rapid” prototype of an innovative idea and share it.  Students watch a brief video about computing innovations.  The lesson ends with students logging into the Code.org CSP course web site, and answering a brief prompt about what “computer science” means to them.
             Representing Information:
               key: Representing Information
               name: Representing Information
+              description_student: Design a device for sending information across the room using common household supplies.
+              description_teacher: Using everyday materials, students create devices for sending information to a partner. Each group then uses its device to send an answer to a question. Following this, students modify their devices to answer more complex answers, responding with one of four possible messages, then one of eight possible messages, then one of sixteen possible messages.
             Circle Square Patterns:
               key: Circle Square Patterns
               name: Circle Square Patterns
+              description_student: Develop a system for creating and ordering patterns of shapes.
+              description_teacher: Students will create rules for ordering patterns of circles and squares. Students generate all possible messages with three place values, then create rules that explain how they ordered each message. Emphasis is placed on creating clear rules so that, if another group were to follow the rules, they would generate the same list in the same order. Using these rules, students then try to list all possible messages with four place values. As the lesson concludes, students share their rules with classmates.
             Binary Numbers:
               key: Binary Numbers
               name: Binary Numbers
+              description_student: In this lesson, students will practice representing numbers in binary (base 2), transitioning from the circle-square representations they made in the last lesson. Students will create and use a "Flippy Do", a manipulative which helps students convert between binary (base 2) and decimal (base 10) numbers. They will practice converting numbers and explore the concept of place value in the context of binary numbers.
+              description_teacher: In this lesson, students will practice representing numbers in binary (base 2), transitioning from the circle-square representations they made in the last lesson. Students will create and use a "Flippy Do", a manipulative which helps students convert between binary (base 2) and decimal (base 10) numbers. They will practice converting numbers and explore the concept of place value in the context of binary numbers.
             Overflow and Rounding:
               key: Overflow and Rounding
               name: Overflow and Rounding
+              description_student: Explore the limitations or representing numbers with bits.
+              description_teacher: 'Students extend their understanding of the binary number system by exploring errors that result from overflow and rounding. They use the binary odometer widget and make a "flippy do pro" to practice binary-to-decimal number conversions which include fractional place values. '
             Representing Text:
               key: Representing Text
               name: Representing Text
+              description_student: Develop a system for representing text using bits based on what you already know about representing numbers.
+              description_teacher: In this lesson, students create a system for representing text using only numbers while communicating with each other. They are only allowed to send numbers back-and-forth, so they must create a system to translate between number and character. At the end of the main activity they briefly review the ASCII system for representing text. The wrap up discussion emphasizes how all of the concepts thus far have ‘built’ on each other and introduces the concept of abstraction to describe this progression.
             Black and White Images:
               key: Black and White Images
               name: Black and White Images
+              description_student: Learn how computers represent black and white images using bits.
+              description_teacher: Students explore how black and white images are represented.  Students use the black and white pixelation widget to represent each pixel of an image with black or white light.  They learn how to sample an analog image using small squares of uniform size (each represented with a black or white value) and reflect on the pros and cons of choosing a smaller or larger square size when sampling.
             Color Images:
               key: Color Images
               name: Color Images
+              description_student: Learn how computers represent color images using bits.
+              description_teacher: This is a second opportunity for students to interact with the Pixelation Widget, but this time they will work with color pixels.  Students start off learning that each pixel uses red, green, and blue lights that can be turned on or off using bits. They will create more color variants using an increasing amount of bits per pixel, and apply their learning by approximating an analog color image using the widget.
             Lossless Compression:
               key: Lossless Compression
               name: Lossless Compression
+              description_student: Learn how computers can decrease the number of bits used to represent a piece of information.
+              description_teacher: Students use the Text Compression Widget to experiment with compressing songs and poems and try to find their ‘personal best’ compression. A video introduces important vocabulary for the lesson and demonstrates the full features of the widget. Students pick a text they think will be ‘easy’ to compress and one they think will be ‘difficult’, paying attention to why some texts might be more compressible than others. As a wrap-up, students discuss what factors make some texts more compressible than others.
             Lossy Compression:
               key: Lossy Compression
               name: Lossy Compression
+              description_student: Learn how information is represented using fewer bits when it's OK for some of the information or details to be lost.
+              description_teacher: Students are introduced to lossy compression via the Lossy Text Compression widget. They apply this concept and their prior knowledge of sampling to create their own lossy compressions of image files using the Lossy Image Widget. Students then discuss several practical scenarios where they need to decide whether to use a lossy or lossless compression algorithm. The lesson ends with a discussion of the situations where lossless compression is important and the situations where lossy compression is important.
             Intellectual Property:
               key: Intellectual Property
               name: Intellectual Property
+              description_student: Learn about how people can own digital information and the ways they can share access to their creative digital works.
+              description_teacher: Students are asked to reflect on who owns their creative works from this class, such as their pixel images, before reading an article describing how ownership can become complicated as analog works become digital artifacts. After reading the article, students watch several videos explaining copyright and introducing them to the Creative Commons. Students then re-read the article answering three questions about the benefits, harms, and impacts of current copyright policy. Students use their new understanding of copyright to form an opinion about current copyright policies and create a small poster justifying their opinion with a quote from the article.
             Project - Digital Information Dilemmas Part 1:
               key: Project - Digital Information Dilemmas Part 1
               name: Project   Digital Information Dilemmas Part 1
+              description_student: Read about a current event or societal challenge created by the digitization of information.
+              description_teacher: In this lesson students begin tackling the question of whether digitizing information has made the world a better or worse place. To begin the lesson, students place stickies on a spectrum of "worse" to "better" to state their opinion prior to doing the activity. Students then choose an article they are interested in reading using a process the class completed collectively in the previous lesson. Students will discuss their preliminary reading and opinions after today's lesson and will have a chance to start making an artifact to present their findings.
             Project - Digital Information Dilemmas Part 2:
               key: Project - Digital Information Dilemmas Part 2
               name: Project   Digital Information Dilemmas Part 2
+              description_student: Share the results of your reading and discuss with classmates the overall impacts of the digitization of information.
+              description_teacher: In this lesson students finish designing an artifact that represents their analysis of an article on the impacts of digitizing information. Students will complete the final two quadrants of their poster in which they identify the benefits and harms highlighted in the article and then make an overall claim about whether the world has been made better or worse through the digitization of information. At the conclusion of the class students update the position of their stickies on the "better" to "worse" spectrum they designed yesterday and then discuss whether and why they changed their opinion.
             'Lesson 14: Assessment Day':
               key: 'Lesson 14: Assessment Day'
               name: Assessment Day
+              description_student: Assessment day to conclude the unit.
+              description_teacher: 'Students complete a multiple choice assessment which covers the unit topics. '
           lesson_groups:
             cspSurvey:
               display_name: Survey
@@ -19503,30 +19780,48 @@ en:
             Welcome to the Internet:
               key: Welcome to the Internet
               name: Welcome to the Internet
+              description_student: Learn how computers are connected into networks and the tradeoffs involved in building different types of networks.
+              description_teacher: 'After a short transition from representing information in Unit 1 to communicating information in Unit 2, students take time to think about their knowledge of the Internet and how it works. Following this, students are introduced to a new widget: The Internet Simulator which they will use throughout this unit to explore the inner workings of the Internet. '
             Building a Network:
               key: Building a Network
               name: Building a Network
+              description_student: Learn how computers are connected into networks and the tradeoffs involved in building different types of networks.
+              description_teacher: 'In this lesson, students are formed into groups of 5-7 and given string so they can connect themselves together to form a computer network. Students are given several specific networks to form, along with several guidelines for how to best form computer networks. Students are also forced to wrestle with conflicting guidelines in determining the ‘best’ way to connect together to form a network, and will need to justify why they chose the networks that they did. '
             The Need for Addressing:
               key: The Need for Addressing
               name: The Need for Addressing
+              description_student: Learn how computers are able to send information across a network even though the computers may not be directly connected. Investigate the protocols used on the Internet to make this possible.
+              description_teacher: Students complete a scheduling challenge three times, once unplugged, and twice on the Internet Simulator, to explore the need for addressing messages online. Students first complete a challenge where they are allowed to talk to one another to fill out a weekly schedule. They then move on to a version of the Internet Simulator where all of their messages are "broadcast" or sent to everyone in the same simulator room. This challenge forces students to develop shared rules for communicating to complete the scheduling activity a second and then third time. The wrap up helps students connect their experiences to real-life rules, or protocols, used on the Internet for addressing messages.
             Routers and Redundancy:
               key: Routers and Redundancy
               name: Routers and Redundancy
+              description_student: Learn how information is routed through the Internet and the reasons networks often will include many multiple paths between different points in the network.
+              description_teacher: Students spend most of today’s lesson in an updated Internet Simulator that lets students send messages with a dedicated To and From IP  Address. Students start by connecting to a dedicated router and sending messages only to each other. They look at the router logs to find other students on different routers, then send messages to those students. They look at the router logs again to notice that messages are being passed between routers in order to reach their destination. Students continue to send messages and view the logs one last time to notice that the messages are also taking different paths to reach the same destination. The lesson wraps-up by introducing new vocabulary and using these words to summarize today’s activity.
             Packets:
               key: Packets
               name: Packets
+              description_student: Learn how information travelling over the Internet is divided into many packets that travel separately through the network as well as the protocols that allow this process to work even when some packets are lost or delayed.
+              description_teacher: Students learn that large messages sent over the Internet are actually divided into individual packets and explore the challenges this creates. First students explore a version of the Internet Simulator that breaks messages into packets to get a sense for how it works. Students then use an activity guide that walks them through the challenges that dropped or out-of-order packets create. They then design their own protocol that addresses these challenges. At the end of the lesson students watch a video and learn and the User Datagram Protocol (UDP) and The Transmission Control Protocol (TCP), two different protocols for sending messages broken into packets.
             DNS and HTTP:
               key: DNS and HTTP
               name: HTTP and DNS
+              description_student: Learn how websites are shared on the Internet and then examine whether everyone actually has equal access to information on the World Wide Web.
+              description_teacher: "Students conclude their study of the layers of the Internet by learning about two top-level protocols, HTTP and DNS. The lesson begins with a review of the layers students have already learned, namely the physical Internet, IP, and TCP / UDP. The lesson then dives into the core of the unit which is \"What happens when I type an address into my browser?\" Students will complete two brief activities, one unplugged, and one plugged, that explore how the DNS works. Students then watch videos explaining how both DNS and HTTP work, taking notes in a provided activity guide. The lesson concludes with a review of how the different layers of the Internet work.\r\n"
             Project - Internet Dilemmas Part 1:
               key: Project - Internet Dilemmas Part 1
               name: Project   Internet Dilemmas Part 1
+              description_student: Begin forming your own answer to the question "Has the Internet made the world better or worse" by considering your own experiences and then reading articles about the impact of the Internet on the world.
+              description_teacher: 'Students begin working on a two-day project exploring a dilemma at the intersection of the Internet and society. '
             Project - Internet Dilemmas Part 2:
               key: Project - Internet Dilemmas Part 2
               name: Project   Internet Dilemmas Part 2
+              description_student: Share your conclusions on the question "Has the Internet made the world better or worse" by discussing the articles you read as well as your own experience.
+              description_teacher: Students finish working on a two-day project exploring a dilemma at the intersection of the Internet and society.
             'Lesson 9: Assessment Day':
               key: 'Lesson 9: Assessment Day'
               name: Assessment Day
+              description_student: Assessment day to conclude the unit.
+              description_teacher: Students complete a multiple choice assessment which covers the unit topics.
           lesson_groups:
             csp_unit2_2020:
               display_name: 'Unit 2: The Internet'
@@ -19541,36 +19836,58 @@ en:
             Introduction to Apps:
               key: Introduction to Apps
               name: Introduction to Apps
+              description_student: 'Welcome to the Introduction to App Development! We begin this unit by examining the basics of an app. '
+              description_teacher: Students explore and investigate what makes an app an app. They begin by looking at and discussing five different apps. Following this, students watch a video explaining the basics of how computers work. Finally students return to the apps and consider the various inputs and outputs.
             Introduction to Design Mode:
               key: Introduction to Design Mode
               name: Introduction to Design Mode
+              description_student: Learn how to create screens, buttons, images, text, and more inside of App Lab.
+              description_teacher: 'Students work through a progression of levels to build an understanding of how to use Design Mode to layout an app. The final level has students setting up the screen of an app by attempting to copy an image of an app. '
             Project - Designing an App Part 1:
               key: Project - Designing an App Part 1
               name: Project   Designing an App Part 1
+              description_student: 'This is the first in a series of lessons where students will make progress on building their own functional app. '
+              description_teacher: 'This is the first in a series of lessons where students will make progress on building their own functional app. In this lesson, students brainstorm app ideas and sketch out user interfaces in preparation for the next lesson where they will return to App Lab. '
             Project - Designing an App Part 2:
               key: Project - Designing an App Part 2
               name: Project   Designing an App Part 2
+              description_student: Students continue working on the unit projects in this lesson that is primarily designed to be work time. Students continue to follow the app development process outlined in their App Development Guide by transferring their user interfaces designs from their planning guides over to App Lab
+              description_teacher: Students continue working on the unit projects in this lesson that is primarily designed to be work time. Students continue to follow the app development process outlined in their App Development Guide by transferring their user interfaces designs from their planning guides over to App Lab
             The Need for Programming Languages:
               key: The Need for Programming Languages
               name: The Need for Programming Languages
+              description_student: 'This is the first in a series of lessons where students will make progress on building their own functional app. '
+              description_teacher: In this lesson students explore the challenges of clearly communicating instructions. They build a small arrangement of blocks (LEGO® pieces or paper cutouts) and then create text instructions a classmate could follow to construct the same arrangement. Groups then trade instructions to see if they were clear enough to allow reconstruction of the original arrangement. The wrap-up discussion is used to highlight the inherent ambiguities of human language and call out the need for the creation of a programming language which leaves no room for interpretation.
             Intro to Programming:
               key: Intro to Programming
               name: Intro to Programming
+              description_student: Get familiar with what programs are and how they run by using and modifying several working apps.
+              description_teacher: Students use and modify a series of simple apps to get familiar with a small set of programming commands. They observe the way the code runs by slowing down the code and compare programs that run all at once to those that respond to user actions like buttons clicks. At the end of the lesson students discuss what they observed and are introduced to some key vocabulary for describing the running of programs.
             Debugging:
               key: Debugging
               name: Debugging
+              description_student: Learn how to identify and fix problems in your code through the debugging process. Then practice using it with a classmate.
+              description_teacher: In this lesson students practice using the different programming concepts that they were introduced to in the last lesson. To begin, however, they are introduced to the concept of debugging and are encouraged to use and reflect on this practice throughout the lesson. At the end of the lesson students share their experiences debugging as well as an new realizations about programming.
             Project - Designing an App Part 3:
               key: Project - Designing an App Part 3
               name: Project   Designing an App Part 3
+              description_student: Start programming your app and learn how to effectively use pair programming to collaborate while writing code.
+              description_teacher: 'Student learn about Pair Programming by watching a video and then practicing it themselves while working on their project apps. At this stage, students are adding their first lines of code to their app using debugging skills from the previous lesson. '
             Project - Designing an App Part 4:
               key: Project - Designing an App Part 4
               name: Project   Designing an App Part 4
+              description_student: Continue working on your app and get feedback to make sure you're on the right track.
+              description_teacher: 'Students continue working on their apps. Halfway through class the focus of the lesson shifts to getting feedback. Students watch other groups test their apps and collect feedback that will be used to make updates.  '
             Project - Designing an App Part 5:
               key: Project - Designing an App Part 5
               name: Project   Designing an App Part 5
+              description_student: Complete your app and share it with classmates before reflecting on the overall process of designing the app.
+              description_teacher: Students complete their apps, making any final adjustments based on feedback from their peers. Students spend some time reviewing other apps that classmates made and then complete a short set of reflection prompts before submitting their projects.
             'Lesson 11: Assessment Day':
               key: 'Lesson 11: Assessment Day'
               name: Assessment Day
+              description_student: Complete your app and share it with classmates before reflecting on the overall process of designing the app.
+              description_teacher: 'Students complete the Unit Assessment and then spend the rest of class sharing their projects. '
           lesson_groups:
             csp_unit3_2020:
               display_name: 'Unit 3: Intro to App Design'
@@ -19585,48 +19902,78 @@ en:
             Variables Explore:
               key: Variables Explore
               name: Variables Explore
+              description_student: Develop a mental model for how information is stored and processed by programs.
+              description_teacher: To begin the lesson students explore sample apps similar to the ones they'll be able to build by the end of the unit. Then students complete an unplugged activity with plastic baggies and sticky notes to build a mental model of how variables are used to move and store information. The lesson ends with a synthesizing discussion and students adding key vocabulary to their journal.
             Variables Investigate:
               key: Variables Investigate
               name: Variables Investigate
+              description_student: Investigate and modify sample apps that use variables and learn common programming patterns with variables.
+              description_teacher: 'In this lesson students work with partners to investigate several versions of the "Thermostat App" to understand how variables store and update information. To begin, students examine a version of the app where the temperature displayed changes each time a button is clicked. The next two versions of the app demonstrate how variables can store strings. Students learn about the patterns they are observing, specifically "Counter Pattern with Event" and "Variables with String Concatenation Pattern". To conclude the lesson, students review and discuss the programming patterns that they will make use of in the programs they write. '
             Variables Practice:
               key: Variables Practice
               name: Variables Practice
+              description_student: Practice programming with variables through a set of programming puzzles.
+              description_teacher: In this lesson students spend most of their time practicing using the skills and processes they have learned about variables. At the conclusion of the lesson students discuss the main things they realized and still have questions about at the conclusion of this lesson.
             Variables Make:
               key: Variables Make
               name: Variables Make
+              description_student: Practice making an app that uses variables and programming patterns with variables.
+              description_teacher: Using Programming Patterns and a step-by-step approach students make their own version of a Photo Liker app. At the beginning of the lesson students are able to explore a working version of the app. They are then given the design elements of the app but begin with a blank screen. A progression of levels guides students on the high level steps they should use to develop their app but leaves it to them to decide how to write the code. At the end students submit their apps which can be assessed using a provided rubric.
             Conditionals Explore:
               key: Conditionals Explore
               name: Conditionals Explore
+              description_student: Develop a mental model for how computers make decisions.
+              description_teacher: 'Students learn the basics of conditionals through an unplugged activity using the sticky notes and plastic baggies from the Variables Explore lesson. Flowcharts are introduced as a way to understand how computers make decisions using Boolean expressions. '
             Conditionals Investigate:
               key: Conditionals Investigate
               name: Conditionals Investigate
+              description_student: Investigate and modify sample apps that use conditionals and learn common programming patterns with conditionals.
+              description_teacher: In this lesson students work with partners to investigate three versions of the "Thermostat App" to understand how boolean expressions and conditional statements allow programs to make decisions. In each guided investigation students first watch a short video on a concept, then use a working app to predict how new features work, then investigate the code to see how those features are implemented, and finally modify the code to add expanded features. To conclude the lesson, students review and discuss common programming patterns with conditionals.
             Conditionals Practice:
               key: Conditionals Practice
               name: Conditionals Practice
+              description_student: Practice programming with conditionals through a set of programming puzzles.
+              description_teacher: In this lesson students spend most of their time practicing using the skills and processes they have learned about conditionals. At the conclusion of the lesson students discuss the main things they realized and still have questions about at the conclusion of this lesson.
             Conditional Make:
               key: Conditional Make
               name: Conditionals Make
+              description_student: Practice making an app that uses conditionals and programming patterns with conditionals.
+              description_teacher: Using Programming Patterns and a step-by-step approach students make their own version of a Museum Ticket Generator app. At the beginning of the lesson students are able to explore a working version of the app. They are then given the design elements of the app but begin with a blank screen. A progression of levels guides students on the high level steps they should use to develop their app but leaves it to them to decide how to write the code. At the end students submit their apps which can be assessed using a provided rubric.
             Functions Explore / Investigate:
               key: Functions Explore / Investigate
               name: Functions Explore / Investigate
+              description_student: 'Develop a mental model for using functions to replace repeated code. Investigate and modify sample apps that use functions. '
+              description_teacher: Students begin the lesson by considering two ways to write out the lyrics of a song, one that includes a lot of repeated text and one that does not. After exploring this example students complete a series of investigate activities in which functions have been used to remove repeated code from a program. At the conclusion of the lesson students discuss the concept of a function to synthesize their learning and add definitions to their journal.
             Functions Practice:
               key: Functions Practice
               name: Functions Practice
+              description_student: Practice programming with functions through a set of programming puzzles.
+              description_teacher: In this lesson students spend most of their time practicing using the skills and processes they have learned about functions. At the conclusion of the lesson students discuss remaining questions in anticipation of their Make project in the following lesson.
             Functions Make:
               key: Functions Make
               name: Functions Make
+              description_student: Practice making an app that uses functions and programming patterns with functions.
+              description_teacher: Using Programming Patterns and a step-by-step approach students make their own version of a Quote Maker app. At the beginning of the lesson students are able to explore a working version of the app. They are then given the design elements of the app but begin with a blank screen. Students use an Activity Guide to go through the high level steps they should use to develop their app but leaves it to them to decide how to write the code. At the end students submit their apps which can be assessed using a provided rubric.
             Project - Decision Maker App Part 1:
               key: Project - Decision Maker App Part 1
               name: Project   Decision Maker App Part 1
+              description_student: Create an app from scratch that uses variables, conditionals, and functions to help a user make a decision.
+              description_teacher: Using a Project Planning Guide, students work through the stages of creating an app from scratch. This is the first day of a three-day project. This lesson is devoted to the planning phase.
             Project - Decision Maker App Part 2:
               key: Project - Decision Maker App Part 2
               name: Project   Decision Maker App Part 2
+              description_student: Create an app from scratch that uses variables, conditionals, and functions to help a user make a decision.
+              description_teacher: 'Students translate the plans they documented in Part 1 of the Practice PT to a working program in App Lab through a series of steps. '
             Project - Decision Maker App Part 3:
               key: Project - Decision Maker App Part 3
               name: Project   Decision Maker App Part 3
+              description_student: 'Create an app from scratch that uses variables, conditionals, and functions to help a user make a decision. '
+              description_teacher: 'The final lesson in the Practice PT progression is devoted to feedback and improvements to the Decision Maker App. Students work with classmates to review and update the functionality of their apps before submitting the final project. '
             'Lesson 15: Assessment Day':
               key: 'Lesson 15: Assessment Day'
               name: Assessment Day
+              description_student: Assessment day to conclude the unit.
+              description_teacher: Students complete a multiple choice assessment which covers the unit topics.
           lesson_groups:
             csp_variables:
               display_name: Variables
@@ -19647,57 +19994,93 @@ en:
             Lists Explore:
               key: Lists Explore
               name: Lists Explore
+              description_student: Develop a mental model for how computers store and access lists of information.
+              description_teacher: Students will learn the ways that lists are created, accessed, and changed through a teacher-guided activity using plastic baggies and pieces of paper. The lesson begins with a brief reflection on the value of lists. Students then complete the main activity which introduces the syntax to use lists and the ways they can be used. To wrap up students watch two short videos on lists and record the main concepts in their journals.
             Lists Investigate:
               key: Lists Investigate
               name: Lists Investigate
+              description_student: Investigate and modify sample apps that use lists learn common programming patterns with lists.
+              description_teacher: In this lesson students work with partners to investigate three different apps that use lists. Students first explore all three apps without seeing the code to notice similarities and predict how they will work. Then they explore the code itself and make additions and modifications to the apps. To conclude the lesson, students review and discuss common programming patterns with conditionals.
             Lists Practice:
               key: Lists Practice
               name: Lists Practice
+              description_student: Practice programming with lists through a set of programming puzzles.
+              description_teacher: 'Practice the basics of lists including creating lists and accessing, inserting, and removing elements from lists. '
             Lists Make:
               key: Lists Make
               name: Lists Make
+              description_student: Make an app that uses lists and programming patterns with lists.
+              description_teacher: Using Programming Patterns and a step-by-step approach students make their own version of a Reminder app. At the beginning of the lesson students are able to explore a working version of the app. They are then given the design elements of the app but begin with a blank screen. Students use an Activity Guide to go through the high level steps they should use to develop their app but leaves it to them to decide how to write the code. At the end students submit their apps which can be assessed using a provided rubric.
             Loops Explore:
               key: Loops Explore
               name: Loops Explore
+              description_student: Develop a mental model for how computers repeat instructions over and over using loops.
+              description_teacher: 'Students begin the lesson by discussing the purpose of loops before completing the unplugged activity. This activity involves moving a "robot" around a game board while practicing tracing blocks of code by hand. To conclude, the lesson is wrapped up with a vocabulary discussion and a video.  '
             Loops Investigate:
               key: Loops Investigate
               name: Loops Investigate
+              description_student: Investigate and modify sample apps that use loops and learn common programming patterns with loops.
+              description_teacher: 'Students practice using the for loop in order to repeatedly run pieces of code. The lesson begins with a quick investigation of an app that flips coins. After that code investigation students complete another investigation with an app that uses loops to update screen elements. '
             Loops Practice:
               key: Loops Practice
               name: Loops Practice
+              description_student: Practice programming with loops through a set of programming puzzles.
+              description_teacher: Students practice the basics of loops including using while loops, for loops, and updating multiple screen elements with a for loop. Along the way students develop debugging practices with loops.
             Loops Make:
               key: Loops Make
               name: Loops Make
+              description_student: Practice making an app that uses loops and programming patterns with loops.
+              description_teacher: Using Programming Patterns and a step-by-step approach students make their own version of a Lock Screen Maker app. At the beginning of the lesson students are able to explore a working version of the app. They are then given the design elements of the app but begin with minimal starting code. A progression of levels guides students on the high level steps they should use to develop their app but leaves it to them to decide how to write the code. At the end students submit their apps which can be assessed using a provided rubric.
             Traversals Explore:
               key: Traversals Explore
               name: Traversals Explore
+              description_student: Develop a mental model for how computers use loops to traverse and process lists of information.
+              description_teacher: 'The lesson begins with a quick review of lists and loops before moving into the main activity. Here students explore the concept with the Traversal Machine, a physical model of traversal using a for loop. '
             Traversals Investigate:
               key: Traversals Investigate
               name: Traversals Investigate
+              description_student: Investigate and modify sample apps that use traversals.
+              description_teacher: In this lesson students work with partners to investigate three different apps that use traversal to access items in a lists. Students first explore all three apps without seeing the code to notice similarities and predict how they will work. Then they explore the code itself and make additions and modifications to the apps. To conclude the lesson, students review and discuss common programming patterns with traversals.
             Traversals Practice:
               key: Traversals Practice
               name: Traversals Practice
+              description_student: Practice programming with list traversals through a set of programming puzzles.
+              description_teacher: Students practice traversing lists, filtering and reducing lists, and using the data import tools. Along the way students develop debugging practices with traversals.
             Traversals Make:
               key: Traversals Make
               name: Traversals Make
+              description_student: 'Practice making an app that processes a list from a data set using traversal. '
+              description_teacher: Using Programming Patterns and a step-by-step approach students make their own version of a Random Forecaster app. At the beginning of the lesson students are able to explore a working version of the app. They are then given the design elements of the app but begin with a blank screen. Students use an Activity Guide to go through the high level steps they should use to develop their app but leaves it to them to decide how to write the code. At the end students submit their apps which can be assessed using a provided rubric.
             Semester Hackathon Part 1:
               key: Semester Hackathon Part 1
               name: Project   Hackathon Part 1
+              description_student: 'This is the first day of a five-day unit project. Students begin the project by choosing a partner, determining a dataset to design the app around, and creating a paper prototype. '
+              description_teacher: 'This is the first day of a five-day unit project. Students begin the project by choosing a partner, determining a dataset to design the app around, and creating a paper prototype. '
             Semester Hackathon Part 2:
               key: Semester Hackathon Part 2
               name: Project   Hackathon Part 2
+              description_student: 'This is the second day of a five-day unit project. Students continue to plan for the project by filling out tables of information on element IDs and programming constructs before each tackling a different role in the project as a designer or a programmer. '
+              description_teacher: 'This is the second day of a five-day unit project. Students continue to plan for the project by filling out tables of information on element IDs and programming constructs before each tackling a different role in the project as a designer or a programmer. '
             Semester Hackathon Part 3:
               key: Semester Hackathon Part 3
               name: Project   Hackathon Part 3
+              description_student: 'This is the third day of a five-day unit project. Students continue to build their apps. '
+              description_teacher: 'This is the third day of a five-day unit project. Students continue to build their apps. '
             Semester Hackathon Part 4:
               key: Semester Hackathon Part 4
               name: Project   Hackathon Part 4
+              description_student: 'This is the fourth day of a five-day unit project. Students continue to build their apps. '
+              description_teacher: 'This is the fourth day of a five-day unit project. Students continue to build their apps. '
             Semester Hackathon Part 5:
               key: Semester Hackathon Part 5
               name: Project   Hackathon Part 5
+              description_student: 'This is the final day of a five-day unit project. Students complete a Written Response, individually answering prompts about the project. Students then share their apps during a gallery walk. '
+              description_teacher: 'This is the final day of a five-day unit project. Students complete a Written Response, individually answering prompts about the project. Students then share their apps during a gallery walk. '
             'Lesson 18: Assessment Day':
               key: 'Lesson 18: Assessment Day'
               name: Assessment Day
+              description_student: Assessment day to conclude the unit.
+              description_teacher: Students complete a multiple choice assessment which covers the unit topics.
           lesson_groups:
             csp_lists:
               display_name: Lists
@@ -19718,21 +20101,33 @@ en:
             Algorithms Solve Problems:
               key: Algorithms Solve Problems
               name: Algorithms Solve Problems
+              description_student: Learn how computer scientists think about problems and the way different algorithms can be designed to solve them.
+              description_teacher: Students will complete two exploratory activities that introduce the concept of a problem and an algorithm. In the first students answer a series of questions about birthdates and names of their classmates. They then discuss the similarities and differences between the problems. In the second activity students are given six different algorithms and must analyze them to determine which they think are the same or different. At the end of the lesson they are introduced to the formal definitions of a problem and an algorithm.
             Algorithm Efficiency:
               key: Algorithm Efficiency
               name: Algorithm Efficiency
+              description_student: Learn how computers describe how fast different algorithms are and the fact that different algorithms that solve the same problem may be faster than others.
+              description_teacher: 'In this lesson students follow a demonstration of Linear Search before writing their own search algorithms. Following this, students are introduced to Binary Search after which they compare graphs of the search algorithms to determine which is most efficient. '
             Unreasonable Time:
               key: Unreasonable Time
               name: Unreasonable Time
+              description_student: Explore two different types of algorithms that seem similar but take fundamentally different amounts of computing power to run.
+              description_teacher: Students investigate two different types of raffles that highlight the way seemingly small problems can quickly grow large. The first raffle asks students to hunt for pairs of tickets that add to a target value. The second raffle asks students to hunt for any group of tickets that adds to a target value. After trying out each raffle live students will try to figure out the patterns for how many total combinations need to be checked in each. At the end they discuss the difference between reasonable and unreasonable algorithms based on their experiences.
             The Limits of Algorithms:
               key: The Limits of Algorithms
               name: The Limits of Algorithms
+              description_student: Explore two different kinds of problems at the limits of what a computer is capable of solving and learn the difference in how computer scientists respond.
+              description_teacher: Students explore the limits of what algorithms are able to compute. First they use a widget that exposes students to the Traveling Salesman Problem. After recognizing this problem can only be solved using an unreasonable time algorithm the develop their own good enough solutions that run more efficiently. Later in the lesson students watch a video about undecidable problems for which no algorithm can ever be developed to solve them.
             Parallel and Distributed Algorithms:
               key: Parallel and Distributed Algorithms
               name: Parallel and Distributed Algorithms
+              description_student: Learn how algorithms are designed to run on many computers and the benefits and challenges that result.
+              description_teacher: In this lesson students explore the benefits and limitations of parallel and distributed computing. First they discuss the way human problem solving changes when additional people lend a hand. Then they run a series of demonstrations that show how simple tasks like sorting cards get faster when more people help, but there is a limitation to the efficiency gains. Later in the lesson students watch a video about distributed computing that highlights the ways distributed computing can help tackle new kinds of problems. To conclude the lesson students record new vocabulary in their journals and discuss any open questions.
             'Lesson 6: Assessment Day':
               key: 'Lesson 6: Assessment Day'
               name: Assessment Day
+              description_student: Assessment day to conclude the unit.
+              description_teacher: Students complete a multiple choice assessment which covers the unit topics.
           lesson_groups:
             csp_unit6_2020:
               display_name: 'Unit 6: Algorithms'
@@ -19747,36 +20142,58 @@ en:
             Parameters and Return Explore:
               key: Parameters and Return Explore
               name: Parameters and Return Explore
+              description_student: Develop a mental model for how functions can be generalized using parameters and return values.
+              description_teacher: 'Students work with envelopes and paper to model functions with parameters and return values. Students create their own physical function envelope for drawing a house that takes in different parameters, and then build another function to calculate and return the cost of building that house.  '
             Parameters and Return Investigate:
               key: Parameters and Return Investigate
               name: Parameters and Return Investigate
+              description_student: 'Investigate and modify sample apps that use parameters and return values. '
+              description_teacher: 'In this lesson students work with partners to investigate two different apps that use parameters and return values. Students are also introduced to the mod operator as part of one of the apps that they use. '
             Parameters and Return Practice:
               key: Parameters and Return Practice
               name: Parameters and Return Practice
+              description_student: Practice programming with parameters and return values through a set of programming puzzles.
+              description_teacher: Students practice writing programs with parameters and return values by creating and debugging functions that use them.
             Parameters and Return Make:
               key: Parameters and Return Make
               name: Parameters and Return Make
+              description_student: Make an app that uses functions with parameters and return.
+              description_teacher: Students use the knowledge and skills they've developed working with parameters and return values to develop a Rock Paper Scissors App. Unlike typical Make projects, students are given a significant portion of the starter code but are given three functions with parameters and return values that they'll need to develop themselves. At the end students submit their apps which can be assessed using a provided rubric.
             Libraries Explore:
               key: Libraries Explore
               name: Libraries Explore
+              description_student: 'Develop a mental model for how libraries work. '
+              description_teacher: 'Students learn the basics of libraries while building upon the envelope model of a function with a folder to represent a library. '
             Libraries Investigate:
               key: Libraries Investigate
               name: Libraries Investigate
+              description_student: Investigate and modify sample apps that use libraries learn how libraries help programmers simplify and reuse their code.
+              description_teacher: In this lesson students work with partners to investigate two apps that use libraries as well as the code used to make a library. Through a series of guided discussions they learn how libraries help programmers simplify and reuse their code.
             Libraries Practice:
               key: Libraries Practice
               name: Libraries Practice
+              description_student: Practice programming with libraries through a set of programming puzzles.
+              description_teacher: Students practice important skills for working with libraries, including testing and debugging libraries, and using libraries to help develop apps. After a brief introduction to these practices by the teacher, students spend the majority of their time programming in a level progression.
             Project - Make a Library Part 1:
               key: Project - Make a Library Part 1
               name: Project   Make a Library Part 1
+              description_student: The first day of a three day project where students build and test their own libraries.
+              description_teacher: In this lesson students begin a multi-day project designing a library of functions. Students will brainstorm common problems they've encountered while programming this year and begin to design functions that address those common problems.
             Project - Make a Library Part 2:
               key: Project - Make a Library Part 2
               name: Project   Make a Library Part 2
+              description_student: The second day of a three day project where students build and test their own libraries.
+              description_teacher: Students continue to develop their library of functions. Students are encouraged to begin developing tests for their functions to make sure they return values as expected. Late in the lesson students exchange their library with a classmate for feedback.
             Project - Make a Library Part 3:
               key: Project - Make a Library Part 3
               name: Project   Make a Library Part 3
+              description_student: The third day of a three day project where students build and test their own libraries.
+              description_teacher: Students complete their library project, finalizing their code and writing written responses explaining the way one of the functions in their library works.
             'Lesson 11: Assessment Day':
               key: 'Lesson 11: Assessment Day'
               name: Assessment Day
+              description_student: 'Students complete a multiple choice assessment which covers the unit topics. '
+              description_teacher: 'Students complete a multiple choice assessment which covers the unit topics. '
           lesson_groups:
             csp_parameters_return_values:
               display_name: Parameters and Return Values
@@ -19793,12 +20210,18 @@ en:
             Create PT - Review the Task:
               key: Create PT - Review the Task
               name: Create PT   Review the Task
+              description_student: This lesson contains a series of activities you can use to help students familiarize themselves with Create Performance Task, how it is scored, and some example tasks created by Code.org.
+              description_teacher: "This lesson contains a series of activities you can use to help students familiarize themselves with Create Performance Task, how it is scored, and some example tasks created by Code.org.\r\n\r\nStudents review the Submission Requirements and Scoring Guidelines for the Create PT. Subsequently they review three example scored Create PT submissions with commentary to better understand how the Submission Requirements and Scoring Guidelines are used together. In a wrap-up conversation they identify a piece of advice, a \"gotcha\", and a remaining question they have about the Create PT."
             Create PT - Make a Plan:
               key: Create PT - Make a Plan
               name: Create PT   Make a Plan
+              description_student: This lesson uses the Create PT Survival Guide as the backbone for a series of activities to ramp up to doing the actual Create PT. It contains activities to help students understand the requirements of the task, as well as activities to help them narrow down and brainstorm ideas for their actual project.
+              description_teacher: "This lesson uses the Create PT Survival Guide as the backbone for a series of activities to ramp up to doing the actual Create PT. It contains activities to help students understand the requirements of the task, as well as activities to help them narrow down and brainstorm ideas for their actual project.\r\n\r\nThe lesson concludes by providing students with resources to make a plan to complete the task staring in the next lesson."
             Create PT - Complete the Task:
               key: Create PT - Complete the Task
               name: Create PT - Complete the Task (12 hrs)
+              description_student: 'The lesson includes some final reminders and guidelines for completing the Create PT before officially starting. For a total of 12 class hours, you will work on your project with only types of teacher support allowed (essentially: Advise on process, not ideas).  You may also work with a collaborative partner in *in development of you program* - written responses must be done on your own.'
+              description_teacher: "It is finally time for students to take on the Create Performance Task. For a total of 12 class hours, students should work on their projects with only types of teacher support allowed (essentially: Advise on process, don’t influence or evaluate ideas).  Students may also work with a collaborative partner in *in development of their program* - written responses must be done on their own.\r\n\r\nThe lesson includes reminders about how you can interact with students while they are working on their projects, and suggestions about time line. The Create PT requires a minimum of 12 hours of class time.  At the end, students will submit their program code, program video, and written responses through their AP digital portfolio."
           lesson_groups: {}
           name: csp8-2021
           student_description: "In this unit prepare for, and do the AP Create Performance Task. Each lesson contains links to helpful documents and activities to help you understand the task and develop a plan for completing it.\r\n\r\n"
@@ -19811,30 +20234,48 @@ en:
             Learning From Data:
               key: Learning From Data
               name: Learning from Data
+              description_student: Explore the Google Trends tool in order to tell a "data story".
+              description_teacher: 'In this lesson students explore the Google Trends tool in order to tell a "data story" which explains both what the data shows and why that might be. Following this, students are introduced to the concept of metadata and look for the metadata of datasets on App Lab. '
             Exploring One Column:
               key: Exploring One Column
               name: Exploring One Column
+              description_student: Create a bar chart and a histogram in App Lab's Data Visualizer.
+              description_teacher: Students will practice making conclusions from charts and learn to use the Data Visualizer in App Lab to make create two different kinds of charts a bar chart, and a histogram. The lesson begins with a quick prompt to review the reasons charts are useful for looking at data. Students then practice reading a bar chart and review the kinds of questions it is and is not useful for answering. Afterwards they build different bar charts in the Data Visualizer and discuss why some are or are not useful. Afterwards they learn how to make histograms for building charts in instances where bar charts may not be useful. Students record their work on an activity guide. The lesson concludes with a brief review of what they learned.
             Filtering and Cleaning Data:
               key: Filtering and Cleaning Data
               name: Filtering and Cleaning Data
+              description_student: Clean data and use the filtering tools in the Data Visualizer to be able to analyze data.
+              description_teacher: 'In this lesson, student explore the challenges of working with a messy dataset. First students learn how to identify issues using the Data Visualizer, and then manually clean the data. Following this, students learn about the filtering tools in the Data Visualizer, and use a guided activity to answer data questions that require filtering a dataset. '
             Exploring Two Columns:
               key: Exploring Two Columns
               name: Exploring Two Columns
+              description_student: Create and analyze crosstab and scatter charts in App Lab's Data Visualizer.
+              description_teacher: Students will practice making conclusions from charts and learn to use the Data Visualizer in App Lab to make create two different kinds of charts, a cross tab, and a scatterplot. Students will practice reading each type of chart before learning to make them in the Data Visualizer. Students will track their work using a provided activity guide. The lesson concludes with a review of key takeaways.
             Big Data, Crowdsourcing, and Machine Learning:
               key: Big Data, Crowdsourcing, and Machine Learning
               name: Big, Open, and Crowdsourced Data
+              description_student: Learn how big data, open data, and crowdsourcing apply the data analysis process in real world context to solve problems that matter.
+              description_teacher: Students will complete a jigsaw of three different topics at the intersection of data, computing, and global impacts. These are topics, big data, crowdsourcing, and open data. Students will watch videos or listen to audio recordings about the different topics. Groups will each complete an activity guide about their topic before having individuals from each group share out their findings. The lesson concludes with a review of key points.
             Machine Learning and Bias:
               key: Machine Learning and Bias
               name: Machine Learning and Bias
+              description_student: In this lesson, students are introduced to the concepts of Artificial Intelligence and Machine Learning using the AI for Oceans widget. First students classify objects as either "fish" or "not fish" to attempt to remove trash from the ocean. Then, students will need to expand their training data set to include other sea creatures that belong in the water. In the second part of the activity, students will choose their own labels to apply to images of randomly generated fish. This training data is used for a machine learning model that should then be able to label new images on its own.
+              description_teacher: In this lesson, students are introduced to the concepts of Artificial Intelligence and Machine Learning using the AI for Oceans widget. First students classify objects as either "fish" or "not fish" to attempt to remove trash from the ocean. Then, students will need to expand their training data set to include other sea creatures that belong in the water. In the second part of the activity, students will choose their own labels to apply to images of randomly generated fish. This training data is used for a machine learning model that should then be able to label new images on its own.
             Project - Tell a Data Story - Part 1:
               key: Project - Tell a Data Story - Part 1
               name: Project   Tell a Data Story Part 1
+              description_student: You will create an effective visualization that you will use to tell a data story.
+              description_teacher: This is the first day of a project where students use the Data Analysis Process to tell a data story.  Students complete the first page of the Activity Guide for this project during this lesson.
             Project - Tell a Data Story - Part 2:
               key: Project - Tell a Data Story - Part 2
               name: Project   Tell a Data Story Part 2
+              description_student: Finish the task you started in the previous lesson by using the Data Analysis Process to tell a data story with the visualization you created.
+              description_teacher: This is the second day of a project where students use the Data Analysis Process to tell a data story.  Students complete the second page of the Activity Guide for this project during this lesson.
             'Lesson 9: Assessment Day':
               key: 'Lesson 9: Assessment Day'
               name: Assessment Day
+              description_student: 'Students complete a multiple choice assessment which covers the unit topics. '
+              description_teacher: 'Students complete a multiple choice assessment which covers the unit topics. '
           lesson_groups:
             csp_unit9_2020:
               display_name: 'Unit 9: Data'
@@ -19849,45 +20290,73 @@ en:
             Project - Innovation Simulation Part 1:
               key: Project - Innovation Simulation Part 1
               name: Project   Innovation Simulation Part 1
+              description_student: 'The class begins a simulation which will continue on at different points throughout the unit. In this simulation, students take on the roles of different stakeholders in school communities converging at a convention where they eventually will deliver a proposal on the best computing innovation for the Future School. In this lesson, students explore what a computing innovation is, do a brainstorm activity, reflect on their character role, and finally learn how to research an innovation. '
+              description_teacher: 'The class begins a simulation which will continue on at different points throughout the unit. In this simulation, students take on the roles of different stakeholders in school communities converging at a convention where they eventually will deliver a proposal on the best computing innovation for the Future School. In this lesson, students explore what a computing innovation is, do a brainstorm activity, reflect on their character role, and finally learn how to research an innovation. '
             Project - Innovation Simulation Part 2:
               key: Project - Innovation Simulation Part 2
               name: Project   Innovation Simulation Part 2
+              description_student: 'Today is focused on researching three different computing innovations and discussing these innovations with team members. '
+              description_teacher: 'Today is focused on researching three different computing innovations and discussing these innovations with team members. '
             Data Policies and Privacy:
               key: Data Policies and Privacy
               name: Data Policies and Privacy
+              description_student: Students learn that the apps, websites, and other computing innovations they use every day require a lot of data to run, much of which they might consider to be private or personal. In the warm up students discuss which of a list of possible information types they consider private. Then students read the data policies from a website or service they use or know about. This investigation focuses on the kinds of data that are being collected, the way it's being used, and any potential privacy concerns that arise. A brief second activity reveals that even data that may not seem private, like a birthdate or zipcode, can be combined to uniquely identify them. To conclude the lesson students prepare for a discussion in the following class about the pros and cons of sharing all this data by journaling about their current thoughts on whether the harms of giving up this privacy are outweighed by the benefits of the technology they power.
+              description_teacher: Students learn that the apps, websites, and other computing innovations they use every day require a lot of data to run, much of which they might consider to be private or personal. In the warm up students discuss which of a list of possible information types they consider private. Then students read the data policies from a website or service they use or know about. This investigation focuses on the kinds of data that are being collected, the way it's being used, and any potential privacy concerns that arise. A brief second activity reveals that even data that may not seem private, like a birthdate or zipcode, can be combined to uniquely identify them. To conclude the lesson students prepare for a discussion in the following class about the pros and cons of sharing all this data by journaling about their current thoughts on whether the harms of giving up this privacy are outweighed by the benefits of the technology they power.
             The Value of Privacy:
               key: The Value of Privacy
               name: The Value of Privacy
+              description_student: Students develop their own opinions on the privacy tradeoffs inherent in many modern computing innovations. At the beginning of the lesson students watch a video on facial recognition technology that presents the tradeoffs between convenience and privacy and asks them to determine whether they think the tradeoff is worth it. Students respond to two videos that look at different tradeoffs between privacy, security, and convenience. Students then evaluate the website or app they investigated in the previous lesson to determine if they think the benefits of the service outweigh the privacy risks. At the end of the class students discuss whether they generally think convenience outweighs privacy concerns.
+              description_teacher: Students develop their own opinions on the privacy tradeoffs inherent in many modern computing innovations. At the beginning of the lesson students watch a video on facial recognition technology that presents the tradeoffs between convenience and privacy and asks them to determine whether they think the tradeoff is worth it. Students respond to two videos that look at different tradeoffs between privacy, security, and convenience. Students then evaluate the website or app they investigated in the previous lesson to determine if they think the benefits of the service outweigh the privacy risks. At the end of the class students discuss whether they generally think convenience outweighs privacy concerns.
             Project - Innovation Simulation Part 3:
               key: Project - Innovation Simulation Part 3
               name: Project   Innovation Simulation Part 3
+              description_student: Students make further projects on their projects while also considering the unintended consequences their proposed innovations may have. First students watch a short video about the ways technology may have unintended consequences. Students then meet with their teams to review the different proposals for computing innovations that each team member is considering. Teams review the different ideas in character and help one another consider potential benefits and harms of each plan. Collectively they narrow down their proposals to a set that seem collectively most beneficial and present a coherent vision for the Future School. With whatever time is remaining students are able to work on one-pagers for the one innovation they chose.
+              description_teacher: Students make further projects on their projects while also considering the unintended consequences their proposed innovations may have. First students watch a short video about the ways technology may have unintended consequences. Students then meet with their teams to review the different proposals for computing innovations that each team member is considering. Teams review the different ideas in character and help one another consider potential benefits and harms of each plan. Collectively they narrow down their proposals to a set that seem collectively most beneficial and present a coherent vision for the Future School. With whatever time is remaining students are able to work on one-pagers for the one innovation they chose.
             Security Risks Part 1:
               key: Security Risks Part 1
               name: Security Risks Part 1
+              description_student: 'Students investigate three different common security risks (phishing, keylogging, malware) in a jigsaw activity. In groups, students create Public Service Announcement slides warning of the dangers of their assigned security risk. Then students are grouped with students who investigated other security risks and are instructed to share their slide and give a voice over. The activity ends with the class coming together to discuss the security risks as a whole. '
+              description_teacher: 'Students investigate three different common security risks (phishing, keylogging, malware) in a jigsaw activity. In groups, students create Public Service Announcement slides warning of the dangers of their assigned security risk. Then students are grouped with students who investigated other security risks and are instructed to share their slide and give a voice over. The activity ends with the class coming together to discuss the security risks as a whole. '
             Security Risks Part 2:
               key: Security Risks Part 2
               name: Security Risks Part 2
+              description_student: 'The lesson begins with a review of security risks by watching a video on Cybersecurity &amp; Crime. Following this, the class does an investigation into the Equifax breach, and what went wrong. The class ends with a Kahoot quiz to review security risks. '
+              description_teacher: 'The lesson begins with a review of security risks by watching a video on Cybersecurity & Crime. Following this, the class does an investigation into the Equifax breach, and what went wrong. The class ends with a Kahoot quiz to review security risks. '
             'Project: Innovation Simulation Part 4':
               key: 'Project: Innovation Simulation Part 4'
               name: Project   Innovation Simulation Part 4
+              description_student: Complete your one pager for your computing innovation.
+              description_teacher: This lesson is primarily a work day for students to complete their innovation 1-pagers. Students should work close to their teammates in case they want to discuss ways to make their proposals more aligned around a cohesive vision for the Future School. Otherwise students should have the entire class period to work independently.
             Protecting Data Part 1:
               key: Protecting Data Part 1
               name: Protecting Data Part 1
+              description_student: 'In this lesson students explore two different encryption widgets: The Caesar Cipher Widget and the Random Substitution Cipher. Afterwards, students watch a video that reviews these types of encryption and introduces a new concept: public key encryption. '
+              description_teacher: 'In this lesson students explore two different encryption widgets: The Caesar Cipher Widget and the Random Substitution Cipher. Afterwards, students watch a video that reviews these types of encryption and introduces a new concept: public key encryption. '
             Protecting Data Part 2:
               key: Protecting Data Part 2
               name: Protecting Data Part 2
+              description_student: 'This lesson is a guided tour of multifactor authentication and software updates that students can use to protect their data. Following these discussions, students are introduced to a stimulus question where they will apply their knowledge gained throughout the unit to answer questions about an innovations data, benefits and harms, effects, and security or privacy concerns. '
+              description_teacher: 'This lesson is a guided tour of multifactor authentication and software updates that students can use to protect their data. Following these discussions, students are introduced to a stimulus question where they will apply their knowledge gained throughout the unit to answer questions about an innovations data, benefits and harms, effects, and security or privacy concerns. '
             'Project: Innovation Simulation Part 5':
               key: 'Project: Innovation Simulation Part 5'
               name: Project   Innovation Simulation Part 5
+              description_student: 'Students meet with their groups to develop a shared artifact or presentation that presents their collective vision for the Future School. '
+              description_teacher: 'Students meet with their groups to develop a shared artifact or presentation that presents their collective vision for the Future School. '
             'Project: Innovation Simulation Part 6':
               key: 'Project: Innovation Simulation Part 6'
               name: Project   Innovation Simulation Part 6
+              description_student: Lesson Overview
+              description_teacher: Students will get feedback on their group innovation proposal from one other group. They will then have the remainder of the class to finalize their group presentation and individual proposals which will be presented and submitted in the following class
             'Project: Innovation Simulation Part 7':
               key: 'Project: Innovation Simulation Part 7'
               name: Project   Innovation Simulation Part 7
+              description_student: Lesson Overview
+              description_teacher: 'Students present the group Innovation Proposal they have been working on throughout the units. After each group does a brief presentation students do a gallery walk of their classmates'' projects, asking questions and reviewing any materials. Students then vote for the unified project and overall innovation they found most compelling. At the end of the lesson students will submit their projects for grading. '
             'Lesson 14: Unit Assessment Day':
               key: 'Lesson 14: Unit Assessment Day'
               name: Assessment Day
+              description_student: Assessment day to conclude the unit.
+              description_teacher: Students complete a multiple choice assessment which covers the unit topics.
           lesson_groups:
             csp_unit10_2020:
               display_name: 'Unit 10: Cybersecurity and Global Impacts'
@@ -19902,39 +20371,68 @@ en:
             Safety in My Online Neighborhood:
               key: Safety in My Online Neighborhood
               name: Safety in My Online Neighborhood
+              description_student: Learn how to go places safely online.
+              description_teacher: |-
+                [![common sense education](https://curriculum.code.org/static/img/common_sense_education.png)](https://creativecommons.org/)
+
+                This lesson was originally created by Common Sense Education. [Learn more.](https://www.commonsense.org/education/digital-citizenship/curriculum)
+
+                The power of the internet allows students to experience and visit places they might not be able to see in person. But, just like traveling in the real world, it's important to be safe when traveling online. On this virtual field trip, kids can practice staying safe on online adventures.
             Learn to Drag and Drop:
               key: Learn to Drag and Drop
               name: Learn to Drag and Drop
+              description_student: Click and drag to finish the puzzles.
+              description_teacher: This lesson will give students an idea of what to expect when they head to the computer lab. It begins with a brief discussion introducing them to computer lab manners, then they will progress into using a computer to complete online puzzles.
             'Programming: Happy Maps':
               key: 'Programming: Happy Maps'
               name: Happy Maps
+              description_student: Write instructions to get the Flurb to the fruit.
+              description_teacher: 'This unplugged lesson brings together teams with a simple task: get the "flurb" to the fruit. Students will practice writing precise instructions as they work to translate instructions into the symbols provided. If problems arise in the code, students should also work together to recognize bugs and build solutions.'
             Sequencing with Scrat:
               key: Sequencing with Scrat
               name: Sequencing with Scrat
+              description_student: Program Scrat to reach the acorn.
+              description_teacher: Using Scrat from the Ice Age franchise, students will develop sequential algorithms to move a squirrel character from one side of a maze to the acorn at the other side. To do this they will stack code blocks together in a linear sequence.
             Programming in Ice Age:
               key: Programming in Ice Age
               name: Programming with Scrat
+              description_student: Write programs to help Scrat reach the acorn.
+              description_teacher: Using characters from the Ice Age, students will develop sequential algorithms to move Scrat from one side of a maze to the acorn at the other side. To do this they will stack code blocks together in a linear sequence, making them move straight, turn left, or turn right.
             Programming with Rey and BB-8:
               key: Programming with Rey and BB-8
               name: Programming with Rey and BB-8
+              description_student: Help BB-8 collect the scrap metal.
+              description_teacher: In this lesson, students will use their newfound programming skills in more complicated ways to navigate a tricky course with BB-8.
             'Loops: Happy Loops':
               key: 'Loops: Happy Loops'
               name: Happy Loops
+              description_student: Help the Flurb solve bigger problems using loops.
+              description_teacher: This activity revisits Happy Maps. This time, student will be solving bigger, longer puzzles with their code, leading them to see utility in structures that let them write longer code in an easier way.
             Loops in Ice Age:
               key: Loops in Ice Age
               name: Loops with Scrat
+              description_student: Help Scrat cover more ground using loops.
+              description_teacher: Building on the concept of repeating instructions from "Happy Loops," this stage will have students using loops to get to the acorn more efficiently on Code.org.
             Loops in Collector:
               key: Loops in Collector
               name: Loops with Laurel
+              description_student: Help Laurel the adventurer collect the treasure underground.
+              description_teacher: In this lesson, students continue learning the concept of loops. In the previous lesson, students were introduced to loops by moving through a maze and picking corn. Here, loops are used to collect treasure in open cave spaces.
             Ocean Scene with Loops:
               key: Ocean Scene with Loops
               name: Ocean Scene with Loops
+              description_student: Use loops and patterns to finish the images.
+              description_teacher: Returning to loops, students learn to draw images by looping simple sequences of instructions. In the previous plugged lesson, loops were used to traverse a maze and collect treasure. Here, loops are creating patterns. At the end of this stage, students will be given the opportunity to create their own images using loops.
             'Events: The Big Event':
               key: 'Events: The Big Event'
               name: The Big Event Jr.
+              description_student: Move and shout when your teachers presses buttons on a giant remote.
+              description_teacher: Events are a great way to add variety to a pre-written algorithm. Sometimes you want your program to be able to respond to the user exactly when the user wants it to. That is what events are for.
             Events in Play Lab:
               key: Events in Play Lab
               name: On the Move with Events
+              description_student: Create your own game or story.
+              description_teacher: In this online activity, students will have the opportunity to learn how to use events in Play Lab and to apply all of the coding skills they've learned to create an animated game. It's time to get creative and make a story in the Play Lab!
           lesson_groups:
             csf_digcit:
               display_name: Digital Citizenship
@@ -19955,39 +20453,68 @@ en:
             Digital Trails:
               key: Digital Trails
               name: Digital Trails
+              description_student: 'Learn about your digital footprint and how to stay safe when visiting websites. '
+              description_teacher: |2-
+                 [![common sense education](https://curriculum.code.org/static/img/common_sense_education.png)](https://creativecommons.org/)
+
+                This lesson was originally created by Common Sense Education. [Learn more.](https://www.commonsense.org/education/digital-citizenship/curriculum)
+
+                Does what you do online always stay online? Students learn that the information they share online leaves a digital footprint or "trail." Depending on how they manage it, this trail can be big or small, and harmful or helpful. Students compare different trails and think critically about what kinds of information they want to leave behind.
             Move It, Move It:
               key: Move It, Move It
               name: Move It, Move It
+              description_student: Program your classmates to step carefully from place to place.
+              description_teacher: This lesson will work to prepare students mentally for the coding exercises that they will encounter over the length of this course.  In small teams, students will use physical activity to program their classmates to step carefully from place to place until a goal is achieved.
             Sequencing in Maze:
               key: Sequencing in Maze
               name: Sequencing with Angry Birds
+              description_student: Help Red the Angry Bird follow the path to the naughty pig.
+              description_teacher: Using characters from Angry Birds, students will develop sequential algorithms to move a bird from one side of a maze to the pig at the other side. To do this they will stack code blocks together in a linear sequence.
             Programming in Maze:
               key: Programming in Maze
               name: Programming with Angry Birds
+              description_student: Create programs to help the Angry Bird move through the maze.
+              description_teacher: Using characters from the game Angry Birds, students will develop sequential algorithms to move a bird from one side of a maze to the pig at the other side. To do this they will stack code blocks together in a linear sequence.
             Programming in Harvester:
               key: Programming in Harvester
               name: Programming with Harvester
+              description_student: Help the Harvester collect vegetables along a path.
+              description_teacher: 'Students will apply the programming concepts that they have learned to the Harvester environment. Now, instead of just getting the character to a goal, students have to collect corn using a new block. Students will continue to develop sequential algorithm skills and start using the debugging process. '
             'Loops: Getting Loopy':
               key: 'Loops: Getting Loopy'
               name: Getting Loopy
+              description_student: In this lesson, we'll have a dance party using repeat loops!
+              description_teacher: As we start to write longer and more interesting programs, our code often contains a lot of repetition. In this lesson, students will learn about how loops can be used to more easily communicate instructions that have a lot of repetition by looking at the repeated patterns of movement in a dance.
             Loops in Harvester:
               key: Loops in Harvester
               name: Loops with Harvester
+              description_student: Help the Harvester collect even more, using loops!
+              description_teacher: Building on the concept of repeating instructions from "Getting Loopy," this stage will have students using loops to pick corn more efficiently on Code.org.
             Loops in Collector:
               key: Loops in Collector
               name: Loops with Laurel
+              description_student: Program Laurel the adventurer to collect treasure in an open cave.
+              description_teacher: In this lesson, students continue learning the concept of loops. Here, Laurel the Adventurer uses loops to collect treasure in open cave spaces. A new `get treasure` block is introduced to help her on her journey.
             Loops in Artist:
               key: Loops in Artist
               name: Drawing Gardens with Loops
+              description_student: Use patterns and loops to finish the images.
+              description_teacher: Returning to loops, students learn to draw images by looping simple sequences of instructions. In the previous online lesson, loops were used to traverse a maze and collect treasure. Here, students use loops to create patterns. At the end of this stage, students will be given the opportunity to create their own images using loops.
             The Right App:
               key: The Right App
               name: The Right App
+              description_student: Sketch your own smartphone app.
+              description_teacher: 'This lesson has students recognize that computer science can help people in real life. First, students empathize with several fictional smartphone users in order to help them find the “right app” that addresses their needs. Then, students exercise empathy and creativity to sketch their own smartphone app that addresses the needs of one additional user. '
             'Events: The Big Event':
               key: 'Events: The Big Event'
               name: The Big Event Jr.
+              description_student: Move or shout when your teacher presses buttons on a giant remote.
+              description_teacher: Events are a great way to add variety to a pre-written algorithm. Sometimes you want your program to be able to respond to the user exactly when the user wants it to. That is what events are for.
             Events in Play Lab:
               key: Events in Play Lab
               name: A Royal Battle with Events
+              description_student: Use events to create a story or make an interactive game.
+              description_teacher: In this online activity, students will have the opportunity to learn how to use events in Play Lab and apply all of the coding skills that they've learned to create an animated game. It's time to get creative and make a game in Play Lab!
           lesson_groups:
             csf_digcit:
               display_name: Digital Citizenship
@@ -20010,57 +20537,96 @@ en:
             Putting a STOP to Online Meanness:
               key: Putting a STOP to Online Meanness
               name: Putting a STOP to Online Meanness
+              description_student: In this lesson, you'll learn about meanness and what to do if you encounter it online.
+              description_teacher: |2-
+                 [![common sense education](https://curriculum.code.org/static/img/common_sense_education.png)](https://creativecommons.org/)
+
+                This lesson was originally created by Common Sense Education. [Learn more.](https://www.commonsense.org/education/digital-citizenship/curriculum)
+
+                The internet is filled with all kinds of interesting people, but sometimes, some of them can be mean to each other. With this role play, help your students understand why it's often easier to be mean online than in person, and how to deal with online meanness when they see it.
             Password Power-Up:
               key: Password Power-Up
               name: Password Power-Up
             'Programming: My Robotic Friends':
               key: 'Programming: My Robotic Friends'
               name: My Robotic Friends Jr.
+              description_student: In this lesson, you'll pretend your classmates are robots and program them to build patterns of stacked cups.
+              description_teacher: Using a set of symbols in place of code, students will design algorithms to instruct a "robot" to stack cups in different patterns. Students will take turns participating as the robot, responding only to the algorithm defined by their peers. This segment teaches students the connection between symbols and actions, the difference between an algorithm and a program, and the valuable skill of debugging.
             Programming in Maze:
               key: Programming in Maze
               name: Programming with Angry Birds
+              description_student: Learn about sequences and algorithms with Angry Birds.
+              description_teacher: Using characters from the game Angry Birds, students will develop sequential algorithms to move a bird from one side of a maze to the pig at the other side. To do this they will stack code blocks together in a linear sequence, making them move straight, turn left, or turn right.
             Debugging in Maze:
               key: Debugging in Maze
               name: Debugging in Maze
+              description_student: Find problems in puzzles and practice your debugging skills.
+              description_teacher: Debugging is an essential element of learning to program. In this lesson, students will encounter puzzles that have been solved incorrectly. They will need to step through the existing code to identify errors, including incorrect loops, missing blocks, extra blocks, and blocks that are out of order.
             Programming in Collector:
               key: Programming in Collector
               name: Collecting Treasure with Laurel
+              description_student: Write algorithms to help Laurel the Adventurer collect lots of gems!
+              description_teacher: In this series of puzzles, students will continue to develop their understanding of algorithms and debugging. With a new character, Laurel the Adventurer, students will create sequential algorithms to get Laurel to pick up treasure as she walks along a path.
             Programming in Artist:
               key: Programming in Artist
               name: Creating Art with Code
+              description_student: Create beautiful images by programming the Artist.
+              description_teacher: In this lesson, students will take control of the Artist to complete drawings on the screen. This Artist stage will allow students to create images of increasing complexity using new blocks like `move forward by 100 pixels` and `turn right by 90 degrees`.
             Binary Bracelets:
               key: Binary Bracelets
               name: Binary Bracelets
+              description_student: Create your very own binary bracelet and learn how computers remember information!
+              description_teacher: Binary is extremely important in the world of computers. The majority of computers today store all sorts of information in binary form. This lesson helps demonstrate how it is possible to take something from real life and translate it into a series of ons and offs.
             'Loops: My Loopy Robotic Friends':
               key: 'Loops: My Loopy Robotic Friends'
               name: My Loopy Robotic Friends Jr.
+              description_student: In this lesson, you'll program your classmates again, but using loops you'll be able to solve bigger and more complicated problems.
+              description_teacher: Building on the initial "My Robotic Friends" activity, students tackle larger and more complicated designs. In order to program their "robots" to complete these bigger designs, students will need to identify repeated patterns in their instructions that could be replaced with a loop.
             Loops with Rey and BB-8:
               key: Loops with Rey and BB-8
               name: Loops with Rey and BB-8
+              description_student: 'Help BB-8 through mazes using loops! '
+              description_teacher: Building on the concept of repeating instructions from "Getting Loopy," this stage will have students using loops to help BB-8 traverse a maze more efficiently than before.
             Loops in Harvester:
               key: Loops in Harvester
               name: Harvesting Crops with Loops
+              description_student: Let's use loops to help the harvester collect some veggies!
+              description_teacher: Students loop new actions in order to help the harvester collect multiple veggies growing in large bunches.
             Looking Ahead:
               key: Looking Ahead
               name: Looking Ahead with Minecraft
+              description_student: Avoid the lava! Here you will start to learn about conditionals in the world of Minecraft.
+              description_teacher: This lesson was originally created for the Hour of Code, alongside the Minecraft team. Students will get the chance to practice ideas that they have learned up to this point, as well as getting a sneak peek at conditionals!
             Sticker Art with Loops:
               key: Sticker Art with Loops
               name: Sticker Art with Loops
+              description_student: In this lesson, loops make it easy to make even cooler images with Artist!
+              description_teacher: Watch student faces light up as they make their own gorgeous designs using a small number of blocks and digital stickers! This lesson builds on the understanding of loops from previous lessons and gives students a chance to be truly creative.  This activity is fantastic for producing artifacts for portfolios or parent/teacher conferences.
             'Events: The Big Event':
               key: 'Events: The Big Event'
               name: The Big Event
+              description_student: 'Play a fun game to learn about events. '
+              description_teacher: Students will soon learn that events are a great way to add flexibility to a pre-written algorithm. Sometimes you want your program to be able to respond to the user exactly when the user wants it to. Events can make your program more interesting and interactive.
             Build a Flappy Game:
               key: Build a Flappy Game
               name: Build a Flappy Game
+              description_student: Build you own Flappy Bird game however you like, then share it with your friends!
+              description_teacher: In this special stage, students get to build their own Flappy Bird game by using event handlers to detect mouse clicks and object collisions. At the end of the level, students will be able to customize their game by changing the visuals or rules.
             Events in Play Lab:
               key: Events in Play Lab
               name: Chase Game with Events
+              description_student: It's time to get creative and make a game in Play Lab!
+              description_teacher: In this online activity, students will have the opportunity to learn how to use events in Play Lab and to apply all the coding skills they've learned to create an animated game. It's time to get creative and make a game in Play Lab!
             Picturing Data:
               key: Picturing Data
               name: Picturing Data
+              description_student: Data can be used to help students understand their world and answer interesting questions. In this lesson, students will collect data from a Play Lab project and visualize it using different kinds of graphs.
+              description_teacher: Data can be used to help students understand their world and answer interesting questions. In this lesson, students will collect data from a Play Lab project and visualize it using different kinds of graphs.
             'End of Course Project: Create a Play Lab Game':
               key: 'End of Course Project: Create a Play Lab Game'
               name: End of Course Project
+              description_student: Get those hands ready for plenty of coding! It's time to start building your project.
+              description_teacher: 'This capstone lesson takes students through the process of designing, developing, and showcasing their own Play Lab projects! To ensure this process goes smoothly, we have provided a step-by-step structure for students to follow, from planning on paper to coding on our website. In addition, we offer ideas to help teachers facilitate a showcase finale! '
           lesson_groups:
             csf_digcit:
               display_name: Digital Citizenship
@@ -20087,64 +20653,116 @@ en:
             'Algorithms: Graph Paper Programming':
               key: 'Algorithms: Graph Paper Programming'
               name: Graph Paper Programming
+              description_student: In this lesson, you will program your classmate to draw pictures!
+              description_teacher: 'By "programming" one another to draw pictures, students get an opportunity to experience some of the core concepts of programming in a fun and accessible way. The class will start by having students use symbols to instruct each other to color squares on graph paper in an effort to reproduce an existing picture. If there’s time, the lesson can conclude with images that the students create themselves.  '
             Introduction to Online Puzzles:
               key: Introduction to Online Puzzles
               name: Introduction to Online Puzzles
+              description_student: This lesson will give you practice in the skills you will need for this course.
+              description_teacher: 'In this set of puzzles, students will begin with an introduction (or review depending on the experience of your class) of Code.org''s online workspace. There will be videos pointing out the basic functionality of the workspace including the `Run`, `Reset`, and `Step` buttons. Also discussed in these videos: dragging Blockly blocks, deleting Blockly blocks, and connecting Blockly blocks. Next, students will practice their _sequencing_ and _debugging_ skills in maze. From there, students will see new types of puzzles like Collector, Artist, and Harvester when they learn the very basics of _loops_.'
             Relay Programming:
               key: Relay Programming
               name: Relay Programming
+              description_student: Remember at the beginning of the course when you made drawings with code? In this lesson, you will be working with a team to do something very similar!
+              description_teacher: This activity will begin with a short lesson on debugging and persistence, then will quickly move to a race against the clock as students break into teams and work together to write a program one instruction at a time.
             Debugging in Collector:
               key: Debugging in Collector
               name: Debugging with Laurel
+              description_student: Have you ever run into problems while coding? In this lesson, you will learn about the secrets of debugging. Debugging is the process of finding and fixing problems in your code.
+              description_teacher: In this online activity, students will practice debugging in the "collector" environment. Students will get to practice reading and editing code to fix puzzles with simple algorithms, loops and nested loops.
             Events in Bounce:
               key: Events in Bounce
               name: Events in Bounce
+              description_student: Ever wish you could play video games in school? In this lesson, you will get to make your own!
+              description_teacher: In this online activity, students will learn what events are, and how computers use them in programs like video games. Students will work through puzzles making the program react to events (like arrow buttons being pressed.) At the end of the puzzle, students will have the opportunity to customize their game with different speeds and sounds.
             Build a Star Wars Game:
               key: Build a Star Wars Game
               name: Build a Star Wars Game
+              description_student: Feel the force as you build your own Star Wars game in this lesson.
+              description_teacher: In this lesson, students will practice using events to build a game that they can share online. Featuring R2-D2 and other Star Wars characters, students will be guided through events, then given space to create their own game.
             Dance Party:
               key: Dance Party
               name: Dance Party
+              description_student: Time to celebrate! In this lesson, you will program your own interactive dance party.
+              description_teacher: In this lesson, students will program their own interactive dance party. This activity requires sound as the tool was built to respond to music.
             Loops in Ice Age:
               key: Loops in Ice Age
               name: Loops in Ice Age
+              description_student: In this lesson you'll use the repeat block to help Scrat reach the acorn as efficiently as possible.
+              description_teacher: As a quick update (or introduction) to using loops, this stage will have students using the `repeat` block to get Scrat to the acorn more efficiently.
             Loops in Artist:
               key: Loops in Artist
               name: Drawing Shapes with Loops
+              description_student: In this lesson, loops make it easy to make cool images with the Artist!
+              description_teacher: This lesson builds on the understanding of loops from previous lessons and gives students a chance to be truly creative.  This activity doubles as a debugging exercise for extra problem-solving practice.
             Nested Loops in Bee:
               key: Nested Loops in Bee
               name: Nested Loops in Maze
+              description_student: Loops inside loops inside loops. What does this mean? This lesson will teach you what happens when you create a nested loop.
+              description_teacher: In this online activity, students will have the opportunity to push their understanding of loops to a whole new level. Playing with the Bee and Plants vs Zombies, students will learn how to program a loop to be inside of another loop. They will also be encouraged to figure out how little changes in either loop will affect their program when they click `Run`.
             Conditionals with Cards:
               key: Conditionals with Cards
               name: Conditionals with Cards
+              description_student: It's time to play a game where you earn points only under certain conditions!
+              description_teacher: "This lesson demonstrates how conditionals can be used to tailor a program to specific information. We don’t always have all of the information we need when writing a program. Sometimes you will want to do something different in one situation than in another, even if you don't know what situation will be true when your code runs. That is where conditionals come in. Conditionals allow a computer to make a decision, based on the information that is true any time your code is run.\r\n\r\n"
             Conditionals in Bee:
               key: Conditionals in Bee
               name: If/Else with Bee
+              description_student: 'Now that you understand conditionals, it''s time to program Bee to use them when collecting honey and nectar. '
+              description_teacher: Up until this point students have been writing code that executes exactly the same way each time it is run - reliable, but not very flexible. In this lesson, your class will begin to code with conditionals, allowing them to write code that functions differently depending on the specific conditions the program encounters.
             While Loops in Farmer:
               key: While Loops in Farmer
               name: While Loops in Farmer
+              description_student: 'Loops are so useful in coding. This lesson will teach you about a new kind of loop: while loops!'
+              description_teacher: "By the time students reach this lesson, they should already have plenty of practice using `repeat` loops, so now it's time to mix things up. \n\n_While loops_ are loops that continue to repeat commands while a condition is met. `While` loops are used when the programmer doesn't know the exact number of times commands need to be repeated, but does know what condition needs to be true in order for the loop to continue repeating. For example, students will be working to fill holes and dig dirt in Farmer. They will not know the size of the holes or the height of the mountains of dirt, but the students will know they need to keep filling the holes and digging the dirt as long as the ground is not flat."
             Until Loops in Maze:
               key: Until Loops in Maze
               name: Until Loops in Maze
+              description_student: You can do some amazing things when you use `until` loops!
+              description_teacher: In this lesson, students will learn about `until` loops. Students will build programs that have the main character repeat actions `until` they reach their desired stopping point.
             Conditionals & Loops in Harvester:
               key: Conditionals & Loops in Harvester
               name: Harvesting with Conditionals
+              description_student: It's not always clear when to use each conditional.  This lesson will help you get practice deciding what to do.
+              description_teacher: Students will practice `while` loops, `until` loops, and `if / else` statements. All of these blocks use conditionals. By practicing all three, students will learn to write complex and flexible code.
             'Unplugged: Binary':
               key: 'Unplugged: Binary'
               name: Binary Images
+              description_student: Learn how computers store pictures using a language with only two options.
+              description_teacher: Though many people think of binary as strictly zeros and ones, students will be introduced to the idea that information can be represented in a variety of binary options. This lesson takes that concept one step further as it illustrates how a computer can store even more complex information (such as images and colors) in binary, as well.
             Artist Binary:
               key: Artist Binary
               name: Binary Images with Artist
+              description_student: In this lesson, you will learn how to make images using only 0s and 1s.
+              description_teacher: This series of online lessons will have students learning to make images using on and off.
             Be A Super Digital Citizen:
               key: Be A Super Digital Citizen
               name: Be A Super Digital Citizen
+              description_student: Learn how you can be an upstander when you see cyberbullying.
+              description_teacher: |2-
+                 [![common sense education](https://curriculum.code.org/static/img/common_sense_education.png)](https://creativecommons.org/)
+
+                This lesson was originally created by Common Sense Education. [Learn more.](https://www.commonsense.org/education/digital-citizenship/curriculum)
+
+                Online tools are empowering for kids, and they also come with big responsibilities. But do kids always know what to do when they encounter cyberbullying? Show your students appropriate ways to take action and resolve conflicts, from being upstanders to helping others in need.
             End of Course Project:
               key: End of Course Project
               name: End of Course Project
+              description_student: Get those hands ready for plenty of coding! It's time to start building your project.
+              description_teacher: 'This capstone lesson takes students through the process of designing, developing, and showcasing their own projects! '
             lesson-6:
               name: Looking Ahead with Minecraft
+              description_student: Avoid the lava! Here you will start to learn about conditionals in the world of Minecraft.
+              description_teacher: This lesson was originally created for the Hour of Code, alongside the Minecraft team. Students will get the chance to practice ideas that they have learned up to this point, as well as getting a sneak peek at conditionals!
             lesson-5:
               name: Password Power-Up
+              description_student: In this lesson, you'll learn about how passwords protect your information, and how to make a good password.
+              description_teacher: |2-
+                 [![common sense education](https://curriculum.code.org/static/img/common_sense_education.png)](https://creativecommons.org/)
+
+                This lesson was originally created by [Common Sense Education](https://www.commonsense.org/education/digital-citizenship/curriculum).
+
+                Stronger, more secure online passwords are a good idea for everyone. But how can we help kids create better passwords and actually remember them? Use the tips in this lesson to help kids make passwords that are both secure and memorable.
           lesson_groups:
             csf_sequencing:
               display_name: Sequencing
@@ -20171,60 +20789,103 @@ en:
             Sequencing in the Maze:
               key: Sequencing in the Maze
               name: Sequencing in the Maze
+              description_student: In this lesson, you will learn how to write your very own programs!
+              description_teacher: "In this set of puzzles, students will begin with an introduction (or review depending on the experience of your class) of Code.org's online workspace. There will be videos pointing out the basic functionality of the workspace including the `Run`, `Reset`, and `Step` buttons. Also discussed in these videos: dragging Blockly blocks, deleting Blockly blocks, and connecting Blockly blocks. Next, students will practice their _sequencing_ and _debugging_ skills in the maze. \r\nDebugging is an essential element of learning to program. Students will encounter some puzzles that have been solved incorrectly. They will need to step through the existing code to identify errors, including incorrect loops, missing blocks, extra blocks, and blocks that are out of order."
             Programming and Loops with the Artist:
               key: Programming and Loops with the Artist
               name: Drawing with Loops
+              description_student: In this lesson, loops make it easy to make even cooler images with Artist!
+              description_teacher: Watch student faces light up as they make their own gorgeous designs using a small number of blocks and digital stickers! This lesson builds on the understanding of loops from previous lessons and gives students a chance to be truly creative.  This activity is fantastic for producing artifacts for portfolios or parent/teacher conferences.
             'Conditionals in Minecraft: Voyage Aquatic':
               key: 'Conditionals in Minecraft: Voyage Aquatic'
               name: 'Conditionals in Minecraft: Voyage Aquatic'
+              description_student: Here you will learn about conditionals in the world of Minecraft.
+              description_teacher: This lesson was originally created for the Hour of Code, alongside the Minecraft team. Students will get the chance to practice ideas that they have learned up to this point, as well as getting a sneak peek at conditionals!
             Conditionals:
               key: Conditionals
               name: Conditionals with the Farmer
+              description_student: You will get to tell the computer what to do under certain conditions in this fun and challenging series.
+              description_teacher: This lesson introduces students to `while` loops and `if / else` statements. _While loops_ are loops that continue to repeat commands as long as a condition is true. While loops are used when the programmer doesn't know the exact number of times the commands need to be repeated, but the programmer does know what condition needs to be true in order for the loop to continue looping. `If / Else` statements offer flexibility in programming by running entire sections of code only if something is true, otherwise it runs something else.
             Simon Says:
               key: Simon Says
-              name: Simon Says
+              name: Follow the Algorithm
+              description_student: Play a game and think about what commands are needed to get the right result.
+              description_teacher: 'In this lesson, students will play a game intended to get them thinking about the way commands need to be given to produce the right result. This will help them more easily carry over to Sprite Lab in the upcoming lessons. '
             Learning Sprites with Sprite Lab:
               key: Learning Sprites with Sprite Lab
               name: Swimming Fish with Sprite Lab
+              description_student: Learn how to create and edit sprites.
+              description_teacher: 'In this lesson, students will learn about the two concepts at the heart of Sprite Lab: sprites and behaviors. Sprites are characters or objects on the screen that students can move, change, and manipulate. Behaviors are actions that sprites will take continuously until they are stopped.'
             Alien Dance Party with Sprite Lab:
               key: Alien Dance Party with Sprite Lab
               name: Alien Dance Party with Sprite Lab
+              description_student: Create an interactive project that can be shared with classmates.
+              description_teacher: 'This lesson features Sprite Lab, a platform where students can create their own interactive animations and games. In addition to behaviors, today students will incorporate user input as events to create an "alien dance party".  '
             Private and Personal Information:
               key: Private and Personal Information
               name: Private and Personal Information
+              description_student: The internet is fun and exciting, but it's important to stay safe too. This lesson teaches you the difference between information that is safe to share and information that is private.
+              description_teacher: |2-
+                 [![common sense education](https://curriculum.code.org/static/img/common_sense_education.png)](https://creativecommons.org/)
+
+                This lesson was originally created by Common Sense Education. [Learn more.](https://www.commonsense.org/education/digital-citizenship/curriculum)
+
+                It's in our students' nature to share and connect with others. But sharing online comes with some risks. How can we help kids build strong, positive, and safe relationships online? Help your students learn the difference between what's personal and what's best left private.
             About Me:
               key: About Me
               name: About Me with Sprite Lab
+              description_student: By creating an interactive poster with SpriteLab, students will apply their understanding of sharing personal and private information on the web.
+              description_teacher: "By creating an interactive poster with SpriteLab, students will apply their understanding of sharing personal and private information on the web.\r\n"
             Digital Sharing:
               key: Digital Sharing
               name: Digital Sharing
+              description_student: 'In this lesson, you''ll learn about the challenges and benefits of ownership and copyright. '
+              description_teacher: Loaned to Computer Science Fundamentals by the team over at Copyright and Creativity, this lesson exists to help students understand the challenges and beneﬁts of respecting ownership and copyright, particularly in digital environments. Students should be encouraged to respect artists’ rights as an important part of being an ethical digital citizen.
             Nested Loops in Bee:
               key: Nested Loops in Bee
               name: Nested Loops in Maze
+              description_student: Loops inside loops inside loops. What does this mean? This lesson will teach you what happens when you place a loop inside another loop.
+              description_teacher: In this online activity, students will have the opportunity to push their understanding of loops to a whole new level. Playing with the Bee and Plants vs Zombies, students will learn how to program a loop to be inside of another loop. They will also be encouraged to figure out how little changes in either loop will affect their program when they click `Run`.
             Nested Loops in Artist:
               key: Nested Loops in Artist
               name: Fancy Shapes using Nested Loops
+              description_student: More nested loops! This time, you get to make some AMAZING drawing with nested loops.
+              description_teacher: Students will create intricate designs using Artist in today's set of puzzles. By continuing to practice nested loops with new goals, students will see more use of loops in general. This set of puzzles also offers a lot more potential for creativity with an opportunity for students to create their own design at the end of the stage.
             Nested Loops in Frozen:
               key: Nested Loops in Frozen
               name: Nested Loops with Frozen
+              description_student: 'Anna and Elsa have excellent ice-skating skills, but need your help to create patterns in the ice. Use nested loops to create something super COOL. '
+              description_teacher: Now that students know how to layer their loops, they can create so many beautiful things.  This lesson will take students through a series of exercises to help them create their own portfolio-ready images using Anna and Elsa's excellent ice-skating skills!
             'Functions: Songwriting':
               key: 'Functions: Songwriting'
               name: Songwriting
+              description_student: Even rockstars need programming skills. This lesson will teach you about functions using lyrics from songs.
+              description_teacher: One of the most magnificent structures in the computer science world is the function. Functions (sometimes called procedures) are mini programs that you can use over and over inside of your bigger program. This lesson will help students intuitively understand why combining chunks of code into functions can be such a helpful practice.
             Functions in Minecraft:
               key: Functions in Minecraft
               name: Functions in Minecraft
+              description_student: Can you figure out how to use functions for the most efficient code?
+              description_teacher: Students will begin to understand how functions can be helpful in this fun and interactive Minecraft adventure!
             Functions in Harvester:
               key: Functions in Harvester
               name: Functions with Harvester
+              description_student: Functions will save you lots of work as you help the farmer with her harvest!
+              description_teacher: Students have practiced creating impressive designs in Artist and navigating mazes in Bee, but today they will use functions to harvest crops in Harvester. This lesson will push students to use functions in the new ways by combining them with `while` loops and `if / else` statements.
             Functions in Artist:
               key: Functions in Artist
               name: Functions with Artist
+              description_student: Make complex drawings more easily with functions!
+              description_teacher: Students will be introduced to using functions with the Artist. Magnificent images will be created and modified. For more complicated patterns, students will learn about nesting functions by calling one function from inside another.
             Designing for Accessibility:
               key: Designing for Accessibility
               name: Designing for Accessibility
+              description_student: 'In this lesson, students will learn about accessibility and the value of empathy through brainstorming and designing accessible solutions for hypothetical apps. '
+              description_teacher: 'In this lesson, students will learn about accessibility and the value of empathy through brainstorming and designing accessible solutions for hypothetical apps. '
             End of Course Project:
               key: End of Course Project
               name: End of Course Project
+              description_student: Projects this big take time and plenty of planning. Find your inspiration, develop a plan, and unleash your creativity!
+              description_teacher: "The next four lessons provide an opportunity for students to put their coding skills to use in a capstone project. This project will help individuals gain experience with coding and produce an exemplar to share with peers and loved ones. Intended to be a multi-lesson or multi-week experience, students will spend time exploring brainstorming, learning about the design process, building, and presenting their final work. \r\n\r\nIn the explore stage, students will play with pre-built examples of projects in both Artist and Sprite Lab for inspiration. Next, students will learn about the design process and how to implement it in their own projects. They will then be given the space to create their own project in Artist, Sprite Lab, or another interface that they have become familiar with (this is likely the longest stage of the project). Finally, students will be able to present their finished work to their peers."
             lesson-4:
               name: Context-Settng Lesson
           lesson_groups:
@@ -20255,60 +20916,103 @@ en:
             Functions in Minecraft:
               key: Functions in Minecraft
               name: Functions in Minecraft
+              description_student: Can you figure out how to use functions for the most efficient code?
+              description_teacher: Students will begin to understand how functions can be helpful in this fun and interactive Minecraft adventure!
             Learning Sprites with Sprite Lab:
               key: Learning Sprites with Sprite Lab
               name: Swimming Fish with Sprite Lab
+              description_student: Learn how to create and edit sprites.
+              description_teacher: 'In this lesson, students will learn about the two concepts at the heart of Sprite Lab: sprites and behaviors. Sprites are characters or objects on the screen that students can move, change, and manipulate. Behaviors are actions that sprites will take continuously until they are stopped.'
             Events with Sprite Lab:
               key: Events with Sprite Lab
               name: Alien Dance Party with Sprite Lab
+              description_student: Create an interactive project that can be shared with classmates.
+              description_teacher: 'This lesson features Sprite Lab, a platform where students can create their own interactive animations and games. In addition to behaviors, today students will incorporate user input as events to create an "alien dance party".   '
             Loops with the Artist:
               key: Loops with the Artist
               name: Drawing with Loops
+              description_student: In this lesson, loops make it easy to make even cooler images with Artist!
+              description_teacher: Watch student faces light up as they make their own gorgeous designs using a small number of blocks and digital stickers! This lesson builds on the understanding of loops from previous lessons and gives students a chance to be truly creative.  This activity is fantastic for producing artifacts for portfolios or parent/teacher conferences.
             Nested Loops in the Maze:
               key: Nested Loops in the Maze
               name: Nested Loops in Maze
+              description_student: Loops inside loops inside loops. What does this mean? This lesson will teach you what happens when you place a loop inside another loop.
+              description_teacher: In this online activity, students will have the opportunity to push their understanding of loops to a whole new level. Playing with the Bee and Plants vs Zombies, students will learn how to program a loop to be inside of another loop. They will also be encouraged to figure out how little changes in either loop will affect their program when they click `Run`.
             The Power of Words:
               key: The Power of Words
               name: The Power of Words
+              description_student: Bullying is never okay. This lesson will teach you about what is and isn't okay to say online.
+              description_teacher: |2-
+                 [![common sense education](https://curriculum.code.org/static/img/common_sense_education.png)](https://creativecommons.org/)
+
+                This lesson was originally created by Common Sense Education. [Learn more.](https://www.commonsense.org/education/digital-citizenship/curriculum)
+
+                As kids grow, they'll naturally start to communicate more online. But some of what they see could make them feel hurt, sad, angry, or even fearful. Help your students build empathy for others and learn strategies to use when confronted with cyberbullying.
             Envelope Variables:
               key: Envelope Variables
               name: Envelope Variables
+              description_student: 'Envelopes and variables have something in common: both can hold valuable things. Here you will learn what variables are and the awesome things they can do.'
+              description_teacher: Variables are used as placeholders for values such as numbers or words. Variables allow for a lot of freedom in programming. Instead of having to type out a phrase many times or remember an obscure number, computer scientists can use variables to reference them. This lesson helps to explain what variables are and how we can use them in many different ways. The idea of variables isn't an easy concept to grasp, so we recommend allowing plenty of time for discussion at the end of the lesson.
             Variables as Constant in Artist:
               key: Variables as Constant in Artist
               name: Variables with Artist
+              description_student: Don't forget to bring creativity to class! In these puzzles you will be making fantastic drawings using variables.
+              description_teacher: In this lesson, students will explore the creation of repetitive designs using variables in the Artist environment. Students will learn how variables can be used to make code easier to write and easier to read, even when the values don't change at runtime.
             Variables that Change in Bee:
               key: Variables that Change in Bee
               name: Changing Variables with Bee
+              description_student: This bee loves variables!
+              description_teacher: 'This lesson will help illustrate how variables can make programs more powerful by allowing values to change while the code is running. '
             Variables that Change in Artist:
               key: Variables that Change in Artist
               name: Changing Variables with Artist
+              description_student: In this lesson, you'll make drawings using variables that change as the program runs.
+              description_teacher: In this lesson, students will explore the creation of repetitive designs using variables in the Artist environment. Students will learn how variables can be used to make code easier to write and easier to read. After guided puzzles, students will end in a freeplay level to show what they have learned and create their own designs.
             Simulating Experiments:
               key: Simulating Experiments
               name: Simulating Experiments
+              description_student: Run simulations on the computer and experiment by changing variables.
+              description_teacher: By running a simple simulation in Sprite Lab, students will experience how computing can be used to collect data that identify trends or patterns. After running the simulation multiple times, students will have an opportunity to make a prediction about how changing a variable in the simulation might impact the outcome, and then test that hypothesis.
             AI for Oceans:
               key: AI for Oceans
               name: AI For Oceans
+              description_student: 'Tutorial Summary: First students classify objects as either "fish" or "not fish" to attempt to remove trash from the ocean. Then, students will need to expand their training data set to include other sea creatures that belong in the water. In the second part of the activity, students will choose their own labels to apply to images of randomly generated fish. This training data is used for a machine learning model that should then be able to label new images on its own.'
+              description_teacher: "**Tutorial Summary:** First students classify objects as either \"fish\" or \"not fish\" to attempt to remove trash from the ocean. Then, students will need to expand their training data set to include other sea creatures that belong in the water. In the second part of the activity, students will choose their own labels to apply to images of randomly generated fish. This training data is used for a machine learning model that should then be able to label new images on its own.\r\n\r\n\r\n**Checking Correctness:** This tutorial will not tell students whether they completed the level correctly. It is possible to skip through the different parts of the activity quickly. Encourage students to watch the videos, read the instructions, and try different things along the way. At any time, they can share their findings with you or a classmate.\r\n"
             Internet:
               key: Internet
               name: The Internet
+              description_student: Ever wondered how information travels across the internet? It's not magic! This lesson will teach you the basics of how the internet works.
+              description_teacher: Even though many people use the internet daily, not very many know how it works. In this lesson, students will pretend to flow through the internet, all the while learning about connections, URLs, IP Addresses, and the DNS.
             For Loop Fun:
               key: For Loop Fun
               name: For Loop Fun
+              description_student: You're going to have loads of fun learning about `for` loops!
+              description_teacher: 'We know that loops allow us to do things over and over again, but now we’re going to learn how to use loops that have extra structures built right in. These new structures will allow students to create code that is more powerful and dynamic. '
             For Loops in Bee:
               key: For Loops in Bee
               name: For Loops with Bee
+              description_student: Buzz buzz. In these puzzles you will be guiding a bee to nectar and honey using `for` loops!
+              description_teacher: Featuring Bee, this lesson focuses on `for` loops and using an incrementing variable to solve more complicated puzzles. Students will begin by reviewing loops from previous lessons, then they'll walk through an introduction to `for` loops so they can more effectively solve complicated problems.
             For Loops in Artist:
               key: For Loops in Artist
               name: For Loops with Artist
+              description_student: Get ready to make your next masterpiece. Here you will be using `for` loops to make some jaw-dropping pictures.
+              description_teacher: In this lesson, students continue to practice `for` loops, but this time with Artist. Students will complete puzzles combining the ideas of variables, loops, and `for` loops to create complex designs. At the end, they will have a chance to create their own art in a freeplay level.
             Editing Behaviors:
               key: Editing Behaviors
               name: Behaviors in Sprite Lab
+              description_student: Learn to program your own sprite behaviors!
+              description_teacher: Here, students will use Sprite Lab to create their own customized behaviors.
             Virtual Pet:
               key: Virtual Pet
               name: Virtual Pet with Sprite Lab
+              description_student: In this lesson, students will create an interactive Virtual Pet that looks and behaves how they wish. Students will use Sprite Lab's "Costumes" tool to customize their pet's appearance. They will then use events, behaviors, and other concepts they have learned to give their pet a life of its own!
+              description_teacher: In this lesson, students will create an interactive Virtual Pet that looks and behaves how they wish. Students will use Sprite Lab's "Costumes" tool to customize their pet's appearance. They will then use events, behaviors, and other concepts they have learned to give their pet a life of its own!
             End of Course Project:
               key: End of Course Project
               name: End of Course Project
+              description_student: Projects this big take time and plenty of planning. Find your inspiration, develop a plan, and unleash your creativity!
+              description_teacher: "The next five lessons provide an opportunity for students to put their coding skills to use in a capstone project. This project will help individuals gain experience with coding and produce an exemplar to share with peers and loved ones. This is intended to be a multi-lesson or multi-week project where students spend time brainstorming, learning about the design process, building, and then presenting their final work. \r\n\r\nIn the \"Explore\" stage, students will play around with pre-built Artist and Sprite Lab programs for inspiration. Next, students will learn about the design process and how to implement it in their own projects. They will then be given the space to create their own project in Artist, Sprite Lab, or any other interface that you are comfortable providing. (This is likely the longest stage of the project.) Students will then revise their code after testing and peer review. Finally, students will be able to present their finished work to their classmates."
           lesson_groups:
             ramp_up:
               display_name: Ramp Up
@@ -20335,87 +21039,143 @@ en:
             Dance Party:
               key: Dance Party
               name: Dance Party
+              description_student: In this lesson, students will program their own interactive dance party. This activity requires sound as the tool was built to respond to music.
+              description_teacher: In this lesson, students will program their own interactive dance party. This activity requires sound as the tool was built to respond to music.
             Programming with Angry Birds:
               key: Programming with Angry Birds
               name: Programming with Angry Birds
+              description_student: Learn about sequences and algorithms with Angry Birds.
+              description_teacher: Using characters from the game Angry Birds, students will develop sequential algorithms to move a bird from one side of a maze to the pig at the other side. To do this they will stack code blocks together in a linear sequence, making them move straight, turn left, or turn right.
             Debugging with Scrat:
               key: Debugging with Scrat
               name: Debugging with Scrat
+              description_student: Find problems in puzzles and practice your debugging skills.
+              description_teacher: Debugging is an essential element of learning to program. In this lesson, students will encounter puzzles that have been solved incorrectly. They will need to step through the existing code to identify errors, including incorrect loops, missing blocks, extra blocks, and blocks that are out of order.
             Collecting Treasure with Laurel:
               key: Collecting Treasure with Laurel
               name: Collecting Treasure with Laurel
+              description_student: Write algorithms to help Laurel the Adventurer collect lots of gems!
+              description_teacher: In this series of puzzles, students will continue to develop their understanding of algorithms and debugging. With a new character, Laurel the Adventurer, students will create sequential algorithms to get Laurel to pick up treasure as she walks along a path.
             Creating Art with Code:
               key: Creating Art with Code
               name: Creating Art with Code
+              description_student: Create beautiful images by programming the Artist.
+              description_teacher: In this lesson, students will take control of the Artist to complete drawings on the screen. This Artist stage will allow students to create images of increasing complexity using new blocks like `move forward by 100 pixels` and `turn right by 90 degrees`.
             Loops with Rey and BB-8:
               key: Loops with Rey and BB-8
               name: Loops with Rey and BB-8
+              description_student: 'Help BB-8 through mazes using loops! '
+              description_teacher: Building on the concept of repeating instructions from "Getting Loopy," this stage will have students using loops to help BB-8 traverse a maze more efficiently than before.
             Sticker Art with Loops:
               key: Sticker Art with Loops
               name: Sticker Art with Loops
+              description_student: In this lesson, loops make it easy to make even cooler images with Artist!
+              description_teacher: Watch student faces light up as they make their own gorgeous designs using a small number of blocks and digital stickers! This lesson builds on the understanding of loops from previous lessons and gives students a chance to be truly creative.  This activity is fantastic for producing artifacts for portfolios or parent/teacher conferences.
             Nested Loops in Maze:
               key: Nested Loops in Maze
               name: Nested Loops in Maze
+              description_student: Loops inside loops inside loops. What does this mean? This lesson will teach you what happens when you create a nested loop.
+              description_teacher: In this online activity, students will have the opportunity to push their understanding of loops to a whole new level. Playing with the Bee and Plants vs Zombies, students will learn how to program a loop to be inside of another loop. They will also be encouraged to figure out how little changes in either loop will affect their program when they click `Run`.
             Snowflakes with Anna and Elsa:
               key: Snowflakes with Anna and Elsa
               name: Snowflakes with Anna and Elsa
+              description_student: 'Anna and Elsa have excellent ice-skating skills, but need your help to create patterns in the ice. Use nested loops to create something super COOL. '
+              description_teacher: Now that students know how to layer their loops, they can create so many beautiful things.  This lesson will take students through a series of exercises to help them create their own portfolio-ready images using Anna and Elsa's excellent ice-skating skills!
             'Looking Ahead with Minecraft ':
               key: 'Looking Ahead with Minecraft '
               name: Looking Ahead with Minecraft
+              description_student: Avoid the lava! Here you will learn about conditionals in the world of Minecraft.
+              description_teacher: This lesson was originally created for the Hour of Code, alongside the Minecraft team. Students will get the chance to practice ideas that they have learned up to this point, as well as getting a sneak peek at conditionals!
             If/Else with Bee:
               key: If/Else with Bee
               name: If/Else with Bee
+              description_student: 'Now that you understand conditionals, it''s time to program Bee to use them when collecting honey and nectar. '
+              description_teacher: Up until this point students have been writing code that executes exactly the same way each time it is run - reliable, but not very flexible. In this lesson, your class will begin to code with conditionals, allowing them to write code that functions differently depending on the specific conditions the program encounters.
             While Loops with the Farmer:
               key: While Loops with the Farmer
               name: While Loops with the Farmer
+              description_student: 'Loops are so useful in coding. This lesson will teach you about a new kind of loop: while loops!'
+              description_teacher: "By the time students reach this lesson, they should already have plenty of practice using `repeat` loops, so now it's time to mix things up. \r\n\r\n_While loops_ are loops that continue to repeat commands while a condition is met. `While` loops are used when the programmer doesn't know the exact number of times commands need to be repeated, but does know what condition needs to be true in order for the loop to continue repeating. For example, students will be working to fill holes and dig dirt in Farmer. They will not know the size of the holes or the height of the mountains of dirt, but the students will know they need to keep filling the holes and digging the dirt as long as the ground is not flat."
             'Conditionals in Minecraft: Voyage Aquatic':
               key: 'Conditionals in Minecraft: Voyage Aquatic'
               name: 'Conditionals in Minecraft: Voyage Aquatic'
+              description_student: Here you will learn about conditionals in the world of Minecraft.
+              description_teacher: This lesson was originally created for the Hour of Code, alongside the Minecraft team. Students will get the chance to practice ideas that they have learned up to this point, as well as getting a sneak peek at conditionals!
             Until Loops in Maze:
               key: Until Loops in Maze
               name: Until Loops in Maze
+              description_student: You can do some amazing things when you use `until` loops!
+              description_teacher: In this lesson, students will learn about `until` loops. Students will build programs that have the main character repeat actions `until` they reach their desired stopping point.
             Harvesting with Conditionals:
               key: Harvesting with Conditionals
               name: Harvesting with Conditionals
+              description_student: It's not always clear when to use each conditional.  This lesson will help you get practice deciding what to do.
+              description_teacher: Students will practice `while` loops, `until` loops, and `if / else` statements. All of these blocks use conditionals. By practicing all three, students will learn to write complex and flexible code.
             Functions in Minecraft:
               key: Functions in Minecraft
               name: Functions in Minecraft
+              description_student: Can you figure out how to use functions for the most efficient code?
+              description_teacher: Students will begin to understand how functions can be helpful in this fun and interactive Minecraft adventure!
             Functions with Harvester:
               key: Functions with Harvester
               name: Functions with Harvester
+              description_student: Functions will save you lots of work as you help the farmer with her harvest!
+              description_teacher: Students have practiced creating impressive designs in Artist and navigating mazes in Bee, but today they will use functions to harvest crops in Harvester. This lesson will push students to use functions in the new ways by combining them with `while` loops and `if / else` statements.
             Functions with Artist:
               key: Functions with Artist
               name: Functions with Artist
+              description_student: Make complex drawings more easily with functions!
+              description_teacher: Students will be introduced to using functions on Code.org. Magnificent images will be created and modified with functions in Artist. For more complicated patterns, students will learn about nesting functions by calling one function from inside another.
             Variables with Artist:
               key: Variables with Artist
               name: Variables with Artist
+              description_student: Don't forget to bring creativity to class! In these puzzles you will be making fantastic drawings using variables.
+              description_teacher: In this lesson, students will explore the creation of repetitive designs using variables in the Artist environment. Students will learn how variables can be used to make code easier to write and easier to read, even when the values don't change at runtime.
             Changing Variables with Bee:
               key: Changing Variables with Bee
               name: Changing Variables with Bee
+              description_student: This bee loves variables!
+              description_teacher: 'This lesson will help illustrate how variables can make programs more powerful by allowing values to change while the code is running. '
             Changing Variables with Artist:
               key: Changing Variables with Artist
               name: Changing Variables with Artist
+              description_student: In this lesson, you'll make drawings using variables that change as the program runs.
+              description_teacher: In this lesson, students will explore the creation of repetitive designs using variables in the Artist environment. Students will learn how variables can be used to make code easier to write and easier to read. After guided puzzles, students will end in a freeplay level to show what they have learned and create their own designs.
             For Loops with Bee:
               key: For Loops with Bee
               name: For Loops with Bee
+              description_student: Buzz buzz. In these puzzles you will be guiding a bee to nectar and honey using `for` loops!
+              description_teacher: Featuring Bee, this lesson focuses on `for` loops and using an incrementing variable to solve more complicated puzzles. Students will begin by reviewing loops from previous lessons, then they'll walk through an introduction to `for` loops so they can more effectively solve complicated problems.
             For Loops with Artist:
               key: For Loops with Artist
               name: For Loops with Artist
+              description_student: Get ready to make your next masterpiece. Here you will be using `for` loops to make some jaw-dropping pictures.
+              description_teacher: In this lesson, students continue to practice `for` loops, but this time with Artist. Students will complete puzzles combining the ideas of variables, loops, and `for` loops to create complex designs. At the end, they will have a chance to create their own art in a freeplay level.
             Swimming Fish in Sprite Lab:
               key: Swimming Fish in Sprite Lab
               name: Swimming Fish in Sprite Lab
+              description_student: Learn how to create and edit sprites.
+              description_teacher: 'In this lesson, students will learn about the two concepts at the heart of Sprite Lab: sprites and behaviors. Sprites are characters or objects on the screen that students can move, change, and manipulate. Behaviors are actions that sprites will take continuously until they are stopped.'
             Alien Dance Party:
               key: Alien Dance Party
               name: Alien Dance Party
+              description_student: Practice making games to share with your friends and family.
+              description_teacher: 'This lesson features Sprite Lab, a platform where students can create their own alien dance party with interactions between characters and user input. Students will work with events to create game controls. '
             Behaviors in Sprite Lab:
               key: Behaviors in Sprite Lab
               name: Behaviors in Sprite Lab
+              description_student: Learn to program your own sprite behaviors!
+              description_teacher: Here, students will use Sprite Lab to create their own customized behaviors.
             Virtual Pet with Sprite Lab:
               key: Virtual Pet with Sprite Lab
               name: Virtual Pet with Sprite Lab
+              description_student: In this lesson, students will create an interactive Virtual Pet that looks and behaves how they wish. Students will use Sprite Lab's "Costumes" tool to customize their pet's appearance. They will then use events, behaviors, and other concepts they have learned to give their pet a life of its own!
+              description_teacher: In this lesson, students will create an interactive Virtual Pet that looks and behaves how they wish. Students will use Sprite Lab's "Costumes" tool to customize their pet's appearance. They will then use events, behaviors, and other concepts they have learned to give their pet a life of its own!
             End of Course Project:
               key: End of Course Project
               name: End of Course Project
+              description_student: Get those hands ready for plenty of coding! It's time to start building your project.
+              description_teacher: 'This capstone lesson takes students through the process of designing, developing, and showcasing their own projects! '
           lesson_groups:
             csf_warmup:
               display_name: Warm Up
@@ -20446,36 +21206,58 @@ en:
             Learn to Drag and Drop:
               key: Learn to Drag and Drop
               name: Learn to Drag and Drop
+              description_student: 
+              description_teacher: This lesson will give students an idea of what to expect when they head to the computer lab. It begins with a brief discussion introducing them to computer lab manners, then they will progress into using a computer to complete online puzzles.
             Sequencing with Scrat:
               key: Sequencing with Scrat
               name: Sequencing with Scrat
+              description_student: 
+              description_teacher: Using Scrat from the Ice Age franchise, students will develop sequential algorithms to move a squirrel character from one side of a maze to the acorn at the other side. To do this they will stack code blocks together in a linear sequence.
             Programming in with Angry Birds:
               key: Programming in with Angry Birds
               name: Programming with Angry Birds
+              description_student: 
+              description_teacher: Using characters from the game Angry Birds, students will develop sequential algorithms to move a bird from one side of a maze to the pig at the other side. To do this they will stack code blocks together in a linear sequence.
             Programming with Rey and BB-8:
               key: Programming with Rey and BB-8
               name: Programming with Rey and BB-8
+              description_student: 
+              description_teacher: In this lesson, students will use their newfound programming skills in more complicated ways to navigate a tricky course with BB-8.
             Programming in Harvester:
               key: Programming in Harvester
               name: Programming with Harvester
+              description_student: 
+              description_teacher: 'Students will apply the programming concepts that they have learned to the Harvester environment. Now, instead of just getting the character to a goal, students have to collect corn using a new block. Students will continue to develop sequential algorithm skills and start using the debugging process. '
             Loops with Scrat:
               key: Loops with Scrat
               name: Loops with Scrat
+              description_student: 
+              description_teacher: Building on the concept of repeating instructions from "My Loopy Robotic Friends," this stage will have students using loops to get to the acorn more efficiently on Code.org.
             Loops with Laurel:
               key: Loops with Laurel
               name: Loops with Laurel
+              description_student: 
+              description_teacher: In this lesson, students continue learning the concept of loops. Here, Laurel the Adventurer uses loops to collect treasure in open cave spaces. A new `get treasure` block is introduced to help her on her journey.
             Ocean Scene with Loops:
               key: Ocean Scene with Loops
               name: Ocean Scene with Loops
+              description_student: 
+              description_teacher: Returning to loops, students learn to draw images by looping simple sequences of instructions. In the previous plugged lesson, loops were used to traverse a maze and collect treasure. Here, loops are creating patterns. At the end of this stage, students will be given the opportunity to create their own images using loops.
             Drawing Gardens with Loops:
               key: Drawing Gardens with Loops
               name: Drawing Gardens with Loops
+              description_student: 
+              description_teacher: Returning to loops, students learn to draw images by looping simple sequences of instructions. In the previous online lesson, loops were used to traverse a maze and collect treasure. Here, students use loops to create patterns. At the end of this stage, students will be given the opportunity to create their own images using loops.
             On the Move with Events:
               key: On the Move with Events
               name: On the Move with Events
+              description_student: 
+              description_teacher: In this online activity, students will have the opportunity to learn how to use events in Play Lab and to apply all of the coding skills they've learned to create an animated game. It's time to get creative and make a story in the Play Lab!
             A Royal Battle with Events:
               key: A Royal Battle with Events
               name: A Royal Battle with Events
+              description_student: 
+              description_teacher: In this online activity, students will have the opportunity to learn how to use events in Play Lab and apply all of the coding skills that they've learned to create an animated game. It's time to get creative and make a game in Play Lab!
           lesson_groups:
             csf_sequencing:
               display_name: Sequencing

--- a/dashboard/test/models/lesson_test.rb
+++ b/dashboard/test/models/lesson_test.rb
@@ -365,12 +365,16 @@ class LessonTest < ActiveSupport::TestCase
     script = create :script, name: 'dummy-script'
     lesson_group = create :lesson_group, script: script
     lesson = create :lesson, lesson_group: lesson_group, script: script, key: 'dummy-key', name: 'Dummy Name'
+    lesson.student_overview = 'student overview'
+    lesson.overview = 'teacher overview'
 
     expected_i18n = {
       'dummy-script' => {
         'lessons' => {
           'dummy-key' => {
-            'name' => 'Dummy Name'
+            'name' => 'Dummy Name',
+            'description_student' => 'student overview',
+            'description_teacher' => 'teacher overview'
           }
         }
       }


### PR DESCRIPTION
`student_description` and `teacher_description` are in `scripts.en.yml` for older courses. This adds a pathway for saving those fields in `scripts.en.yml` and then fetching them when displaying the script overview.

Teacher:
<img width="1089" alt="Screen Shot 2021-02-23 at 10 19 53 AM" src="https://user-images.githubusercontent.com/46464143/108889150-e3be4400-75c0-11eb-822e-3376431d71a7.png">

Student:
<img width="1088" alt="Screen Shot 2021-02-23 at 10 20 00 AM" src="https://user-images.githubusercontent.com/46464143/108889156-e751cb00-75c0-11eb-9e44-626ca1ec5f74.png">

I also tested saving old courses and the descriptions do not change.

Updated `scripts.en.yml` using 
```
lessons = Script.where("name like '%-2021'").select{|s| s.is_migrated?}.map(&:lessons).flatten
lessons.each {|l| Script.merge_and_write_i18n(l.i18n_hash, l.name) }
```



## Testing story

manual testing, updated unit tests


## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
