### PR TITLE
adding haikubot pilot to pilot list

### DIFF
--- a/dashboard/app/models/experiments/experiment.rb
+++ b/dashboard/app/models/experiments/experiment.rb
@@ -114,6 +114,11 @@ class Experiment < ApplicationRecord
       name: 'ai-unit-pilot',
       label: 'AI Unit Pilot',
       allow_joining_via_url: false
+    },
+    {
+      name: 'haikubot-pilot',
+      label: 'Haiku Bot',
+      allow_joining_via_url: true
     }
   ]
 


### PR DESCRIPTION
Adding HaikuBot Pilot for March launch. Allowing joining via URL.


This ticket: https://codedotorg.atlassian.net/browse/LP-1735