### PR TITLE
allow tests to continue after console error

### DIFF
--- a/apps/test/util/throwOnConsole.js
+++ b/apps/test/util/throwOnConsole.js
@@ -18,15 +18,14 @@
  */
 function throwOnConsoleEverywhere(methodName) {
   let throwing = true;
-  let firstInstance = null;
   let wrappedMethod = null;
 
   return {
-    // Method that will stub console[methodName] during each test and throw after
-    // the test completes if it was called.
+    // Method that will stub console[methodName] during each test and throw if
+    // that method is called
     throwEverywhere() {
       beforeEach(function() {
-        // Stash test title so that we can include it in any errors
+        // Stash test title so that we can include it in the error
         let testTitle;
         if (this.currentTest) {
           testTitle = this.currentTest.title;
@@ -37,29 +36,22 @@ function throwOnConsoleEverywhere(methodName) {
           const prefix = throwing ? '' : '[ignoring]';
           wrappedMethod.call(console, prefix, msg);
 
-          // Store error so we can throw in after. This will ensure we hit a failure
-          // even if message was originally thrown in async code
-          if (throwing && !firstInstance) {
+          // Throw error with stack trace of call
+          if (throwing) {
             console[methodName] = wrappedMethod;
             wrappedMethod = null;
-
-            firstInstance = new Error(
+            throw new Error(
               `Call to console.${methodName} from "${testTitle}": ${msg}\n${getStack()}`
             );
           }
         };
       });
 
-      // After the test, throw an error if we called the console method.
       afterEach(function() {
         if (wrappedMethod) {
           console[methodName] = wrappedMethod;
         }
         wrappedMethod = null;
-        if (firstInstance) {
-          throw new Error(firstInstance);
-        }
-        firstInstance = null;
       });
     },
 


### PR DESCRIPTION
this is followup work from an investigation i started during the hackathon, trying to figure out if we could make test runs continue even after they encounter a failure so a single run through all the tests can identify all the failures, instead of just the first one.

it turned out that the failures causing the test runs to abort were caused by the code we use to fail tests on calls to `console.warn` and `console.error`. we were storing the first instance of such a call during the test then throwing an error about it in `afterEach`. however, throwing an error at that point causes the whole test run to abort, presumably because the error wasn't in a test, suggesting a problem higher up in the test suite.

this PR updates that code to throw the error immediately inside the test. this causes the specific test to fail, but allows subsequent tests to continue.