### PR TITLE
[Applab][Libraries] Catch openuri too long error

### DIFF
--- a/apps/src/code-studio/components/libraries/LibraryPublisher.jsx
+++ b/apps/src/code-studio/components/libraries/LibraryPublisher.jsx
@@ -166,10 +166,7 @@ export default class LibraryPublisher extends React.Component {
       libraryJson,
       error => {
         console.warn(`Error publishing library: ${error}`);
-        if (
-          error.message ===
-          'httpStatusCode: 413; status: error; error: Request Entity Too Large'
-        ) {
+        if (error.message.includes('httpStatusCode: 413')) {
           this.setState({publishState: PublishState.TOO_LONG});
         } else {
           this.setState({publishState: PublishState.ERROR_PUBLISH});

--- a/apps/test/unit/code-studio/components/libraries/LibraryPublisherTest.js
+++ b/apps/test/unit/code-studio/components/libraries/LibraryPublisherTest.js
@@ -265,7 +265,9 @@ describe('LibraryPublisher', () => {
 
     describe('with valid input', () => {
       it('sets error state when publish fails', async () => {
-        publishSpy.callsArgWith(1, {});
+        publishSpy.callsArgWith(1, {
+          message: ''
+        });
         sinon.stub(console, 'warn');
         wrapper.setState({
           libraryDescription: description,

--- a/apps/test/unit/code-studio/components/libraries/LibraryPublisherTest.js
+++ b/apps/test/unit/code-studio/components/libraries/LibraryPublisherTest.js
@@ -283,8 +283,7 @@ describe('LibraryPublisher', () => {
 
       it('sets error state if library is too long', async () => {
         publishSpy.callsArgWith(1, {
-          message:
-            'httpStatusCode: 413; status: error; error: Request Entity Too Large'
+          message: 'httpStatusCode: 413; status: error; error: '
         });
         sinon.stub(console, 'warn');
         wrapper.setState({


### PR DESCRIPTION
Quick follow-up to https://github.com/code-dot-org/code-dot-org/pull/39057
Turns out on non-local environments the error string looks slightly different:
Prod
![image](https://user-images.githubusercontent.com/8787187/108929405-d624b080-75f8-11eb-9fbd-8159233378d9.png)
Dev
![image](https://user-images.githubusercontent.com/8787187/108929507-0b310300-75f9-11eb-8f5d-8e92c6d3b668.png)

Updating the check to be slightly less specific so that it works on prod.