### PR TITLE
WebLab disallow script and iframe tags

### DIFF
--- a/apps/src/weblab/WebLab.js
+++ b/apps/src/weblab/WebLab.js
@@ -23,6 +23,13 @@ import {getCurrentId} from '../code-studio/initApp/project';
 
 export const WEBLAB_FOOTER_HEIGHT = 30;
 
+// HTML tags that are disallowed in WebLab. These tags will be removed from users' projects.
+const DISALLOWED_HTML_TAGS = 'script|iframe';
+export const DISALLOWED_ELEMENTS_REGEX = new RegExp(
+  `<(${DISALLOWED_HTML_TAGS})[\\s\\S]*\\/(${DISALLOWED_HTML_TAGS})*>`,
+  'gi'
+);
+
 /**
  * An instantiable WebLab class
  */
@@ -82,6 +89,7 @@ WebLab.prototype.init = function(config) {
   this.level = config.level;
   this.suppliedFilesVersionId = queryParams('version');
   this.initialFilesVersionId = this.suppliedFilesVersionId;
+  this.disallowedElementsRegex = DISALLOWED_ELEMENTS_REGEX;
   getStore().dispatch(actions.changeMaxProjectCapacity(MAX_PROJECT_CAPACITY));
 
   this.brambleHost = null;

--- a/apps/src/weblab/WebLab.js
+++ b/apps/src/weblab/WebLab.js
@@ -24,12 +24,7 @@ import {getCurrentId} from '../code-studio/initApp/project';
 export const WEBLAB_FOOTER_HEIGHT = 30;
 
 // HTML tags that are disallowed in WebLab. These tags will be removed from users' projects.
-// The RegExp below will match on single and multiline elements, as well as self-closing tags.
-const DISALLOWED_HTML_TAGS = 'script|iframe';
-export const DISALLOWED_ELEMENTS_REGEX = new RegExp(
-  `<(${DISALLOWED_HTML_TAGS})[\\s\\S]*\\/(${DISALLOWED_HTML_TAGS})*>`,
-  'gi'
-);
+const DISALLOWED_HTML_TAGS = ['script', 'iframe'];
 
 /**
  * An instantiable WebLab class
@@ -90,7 +85,7 @@ WebLab.prototype.init = function(config) {
   this.level = config.level;
   this.suppliedFilesVersionId = queryParams('version');
   this.initialFilesVersionId = this.suppliedFilesVersionId;
-  this.disallowedElementsRegex = DISALLOWED_ELEMENTS_REGEX;
+  this.disallowedHtmlTags = DISALLOWED_HTML_TAGS;
   getStore().dispatch(actions.changeMaxProjectCapacity(MAX_PROJECT_CAPACITY));
 
   this.brambleHost = null;

--- a/apps/src/weblab/WebLab.js
+++ b/apps/src/weblab/WebLab.js
@@ -24,6 +24,7 @@ import {getCurrentId} from '../code-studio/initApp/project';
 export const WEBLAB_FOOTER_HEIGHT = 30;
 
 // HTML tags that are disallowed in WebLab. These tags will be removed from users' projects.
+// The RegExp below will match on single and multiline elements, as well as self-closing tags.
 const DISALLOWED_HTML_TAGS = 'script|iframe';
 export const DISALLOWED_ELEMENTS_REGEX = new RegExp(
   `<(${DISALLOWED_HTML_TAGS})[\\s\\S]*\\/(${DISALLOWED_HTML_TAGS})*>`,

--- a/apps/src/weblab/brambleHost.js
+++ b/apps/src/weblab/brambleHost.js
@@ -656,7 +656,7 @@ function load(Bramble) {
         bramble_.getFileSystem(),
         brambleProxy_,
         path,
-        webLab_.disallowedElementsRegex,
+        webLab_.disallowedHtmlTags,
         handleFileChange
       );
     }

--- a/apps/src/weblab/brambleHost.js
+++ b/apps/src/weblab/brambleHost.js
@@ -568,7 +568,7 @@ function syncFiles(callback) {
  * Remove disallowed elements from the HTML file at the given path. The editor is set to readOnly
  * while overwriting the file if any disallowed elements are found.
  */
-function handleDisallowedElements(path, callback) {
+function handleDisallowedElements(fileSystem, brambleProxy, path, callback) {
   function wrappedCallback() {
     if (callback) {
       callback(path);
@@ -580,17 +580,16 @@ function handleDisallowedElements(path, callback) {
     return;
   }
 
-  const fs = bramble_.getFileSystem();
-  fs.readFile(path, 'utf8', function(error, data) {
+  fileSystem.readFile(path, 'utf8', function(error, data) {
     if (error || !data.match(DISALLOWED_ELEMENTS_REGEX)) {
       wrappedCallback();
       return;
     }
 
-    brambleProxy_.enableReadonly();
+    brambleProxy.enableReadonly();
     data = data.replace(DISALLOWED_ELEMENTS_REGEX, '');
-    fs.writeFile(path, Buffer.from(data), function(error) {
-      brambleProxy_.disableReadonly();
+    fileSystem.writeFile(path, Buffer.from(data), function(error) {
+      brambleProxy.disableReadonly();
       wrappedCallback();
     });
   });
@@ -691,7 +690,12 @@ function load(Bramble) {
     }
 
     function validateFileAndHandleChange(path) {
-      handleDisallowedElements(path, handleFileChange);
+      handleDisallowedElements(
+        bramble_.getFileSystem(),
+        brambleProxy_,
+        path,
+        handleFileChange
+      );
     }
 
     function handleFileDelete(path) {

--- a/apps/src/weblab/brambleHost.js
+++ b/apps/src/weblab/brambleHost.js
@@ -11,7 +11,7 @@ window.requirejs.config({baseUrl: BRAMBLE_BASE_URL});
 
 // This is needed to support jQuery binary downloads
 import '../assetManagement/download';
-import {removeDisallowedHtmlContent} from './brambleUtils';
+import {createHtmlDocument, removeDisallowedHtmlContent} from './brambleUtils';
 
 // the main Bramble object -- used to access file system
 let bramble_ = null;
@@ -416,8 +416,7 @@ function addFileHTML() {
     {
       basenamePrefix: 'new',
       ext: 'html',
-      contents:
-        '<!DOCTYPE html>\n<html>\n  <head>\n    \n  </head>\n  <body>\n    \n  </body>\n</html>'
+      contents: createHtmlDocument()
     },
     err => {
       if (err) {

--- a/apps/src/weblab/brambleHost.js
+++ b/apps/src/weblab/brambleHost.js
@@ -584,7 +584,7 @@ function handleDisallowedElements(path, callback) {
 
     brambleProxy_.enableReadonly();
     data = data.replace(disallowedElementsRegex, '');
-    fs.writeFile(path, new Buffer(data), function(error) {
+    fs.writeFile(path, Buffer.from(data), function(error) {
       brambleProxy_.disableReadonly();
       wrappedCallback();
     });

--- a/apps/src/weblab/brambleUtils.js
+++ b/apps/src/weblab/brambleUtils.js
@@ -33,10 +33,10 @@ function removeDisallowedHtmlContent(
       return;
     }
 
-    brambleProxy.enableReadonly();
+    brambleProxy.enableReadOnly();
     data = data.replace(regex, '');
     fileSystem.writeFile(path, Buffer.from(data), function(error) {
-      brambleProxy.disableReadonly();
+      brambleProxy.disableReadOnly();
       wrappedCallback();
     });
   });

--- a/apps/src/weblab/brambleUtils.js
+++ b/apps/src/weblab/brambleUtils.js
@@ -1,0 +1,47 @@
+/**
+ * Remove disallowed content from the HTML at the given path. The editor will be set as readOnly
+ * while this method overwrites the HTML file. Use this method carefully as it does overwrite
+ * file contents.
+ *
+ * @param {Object} fileSystem - The current file system. This method requires `readFile` and `writeFile` methods.
+ * @param {Object} brambleProxy - Communicate with Bramble. This method requires `enableReadonly` and `disableReadonly` methods.
+ * @param {string} path - Path to the HTML file.
+ * @param {RegExp} regex - Used to match on and remove disallowed content.
+ * @param {func} callback - Will be called with the given path. Optional.
+ */
+function removeDisallowedHtmlContent(
+  fileSystem,
+  brambleProxy,
+  path,
+  regex,
+  callback
+) {
+  function wrappedCallback() {
+    if (callback) {
+      callback(path);
+    }
+  }
+
+  if (!path.endsWith('.html')) {
+    wrappedCallback();
+    return;
+  }
+
+  fileSystem.readFile(path, 'utf8', function(error, data) {
+    if (error || !data.match(regex)) {
+      wrappedCallback();
+      return;
+    }
+
+    brambleProxy.enableReadonly();
+    data = data.replace(regex, '');
+    fileSystem.writeFile(path, Buffer.from(data), function(error) {
+      brambleProxy.disableReadonly();
+      wrappedCallback();
+    });
+  });
+}
+
+export default {
+  removeDisallowedHtmlContent
+};

--- a/apps/src/weblab/brambleUtils.js
+++ b/apps/src/weblab/brambleUtils.js
@@ -6,14 +6,14 @@
  * @param {Object} fileSystem - The current file system. This method requires `readFile` and `writeFile` methods.
  * @param {Object} brambleProxy - Communicate with Bramble. This method requires `enableReadonly` and `disableReadonly` methods.
  * @param {string} path - Path to the HTML file.
- * @param {RegExp} regex - Used to match on and remove disallowed content.
+ * @param {Array<string>} disallowedTags - HTML tags that should be removed.
  * @param {func} callback - Will be called with the given path. Optional.
  */
 function removeDisallowedHtmlContent(
   fileSystem,
   brambleProxy,
   path,
-  regex,
+  disallowedTags,
   callback
 ) {
   function wrappedCallback() {
@@ -28,13 +28,35 @@ function removeDisallowedHtmlContent(
   }
 
   fileSystem.readFile(path, 'utf8', function(error, data) {
-    if (error || !data.match(regex)) {
+    if (error) {
+      wrappedCallback();
+      return;
+    }
+
+    const dom = new DOMParser().parseFromString(data, 'text/xml');
+    // An invalid DOM returns an error document rather than throwing an error:
+    // https://developer.mozilla.org/en-US/docs/Web/API/DOMParser#examples
+    if (dom.documentElement.innerHTML.includes('parsererror')) {
+      wrappedCallback();
+      return;
+    }
+
+    const nodes = dom.querySelectorAll(disallowedTags.join(', '));
+    if (nodes.length <= 0) {
       wrappedCallback();
       return;
     }
 
     brambleProxy.enableReadOnly();
-    data = data.replace(regex, '');
+    for (var i = 0; i < nodes.length; i++) {
+      nodes[i].parentElement.removeChild(nodes[i]);
+    }
+    // We prefer <!DOCTYPE html>\n<html>, but serializeToString returns
+    // <!DOCTYPE html><html>. Manually add newline to keep formatting consistent.
+    data = new XMLSerializer()
+      .serializeToString(dom)
+      .replace('<!DOCTYPE html>', '<!DOCTYPE html>\n');
+
     fileSystem.writeFile(path, Buffer.from(data), function(error) {
       brambleProxy.disableReadOnly();
       wrappedCallback();

--- a/apps/test/unit/weblab/brambleUtilsTest.js
+++ b/apps/test/unit/weblab/brambleUtilsTest.js
@@ -14,15 +14,17 @@ const invalidHtmlFile = `<!DOCTYPE html>
   <body>
     <script src="index.js">
     </script>
-    <a href="/some.url">I will be deleted!</a>
+    Content outside diallowed tag <a href="/some.url">I will be deleted!</a>
     <div>divs are allowed</div>
   </body>
 </html>`;
 const fixedInvalidHtmlFile = `<!DOCTYPE html>
 <html>
+  <head>
+
+  </head>
   <body>
-    
-    
+    Content outside diallowed tag 
     <div>divs are allowed</div>
   </body>
 </html>`;

--- a/apps/test/unit/weblab/brambleUtilsTest.js
+++ b/apps/test/unit/weblab/brambleUtilsTest.js
@@ -1,0 +1,128 @@
+import {expect} from '../../util/reconfiguredChai';
+import sinon from 'sinon';
+import {removeDisallowedHtmlContent} from '@cdo/apps/weblab/brambleUtils';
+
+// This regex is meant to mimic the way we disallow certain HTML tags in WebLab.js.
+const REGEX = new RegExp(`<(script|a)[\\s\\S]*\\/(script|a)*>`, 'gi');
+
+describe('removeDisallowedHtmlContent', () => {
+  let fileSystemStub, brambleProxyStub, callbackSpy;
+
+  beforeEach(() => {
+    fileSystemStub = {
+      readFile: sinon.spy(),
+      writeFile: sinon.spy()
+    };
+    brambleProxyStub = {
+      enableReadonly: sinon.spy()
+    };
+    callbackSpy = sinon.spy();
+  });
+
+  it('no-ops if path does not point to an HTML file', () => {
+    removeDisallowedHtmlContent(
+      fileSystemStub,
+      brambleProxyStub,
+      '/style.css',
+      REGEX,
+      callbackSpy
+    );
+
+    expect(fileSystemStub.readFile).to.not.have.been.called;
+    expect(fileSystemStub.writeFile).to.not.have.been.called;
+    expect(brambleProxyStub.enableReadonly).to.not.have.been.called;
+    expect(callbackSpy).to.have.been.calledOnceWith('/style.css');
+  });
+
+  it('no-ops if reading file errored', () => {
+    fileSystemStub.readFile = sinon
+      .stub()
+      .callsFake((path, encoding, callback) => {
+        callback(new Error('uh oh!'), null);
+      });
+
+    removeDisallowedHtmlContent(
+      fileSystemStub,
+      brambleProxyStub,
+      '/index.html',
+      REGEX,
+      callbackSpy
+    );
+
+    expect(fileSystemStub.readFile).to.have.been.calledOnce;
+    expect(fileSystemStub.writeFile).to.not.have.been.called;
+    expect(brambleProxyStub.enableReadonly).to.not.have.been.called;
+    expect(callbackSpy).to.have.been.calledOnceWith('/index.html');
+  });
+
+  it('no-ops if file contents do not contain disallowed content', () => {
+    fileSystemStub.readFile = sinon
+      .stub()
+      .callsFake((path, encoding, callback) => {
+        const fileData = `<!DOCTYPE html>
+        <html>
+          <body>
+            <p>Important paragraph.</p>
+          </body>
+        </html>
+        `;
+        callback(null, fileData);
+      });
+
+    removeDisallowedHtmlContent(
+      fileSystemStub,
+      brambleProxyStub,
+      '/index.html',
+      REGEX,
+      callbackSpy
+    );
+
+    expect(fileSystemStub.readFile).to.have.been.calledOnce;
+    expect(fileSystemStub.writeFile).to.not.have.been.called;
+    expect(brambleProxyStub.enableReadonly).to.not.have.been.called;
+    expect(callbackSpy).to.have.been.calledOnceWith('/index.html');
+  });
+
+  it('writes the file without disallowed content', () => {
+    // Based on REGEX, both <script> and <a> tags should be removed from the template below.
+    const invalidFileData = `<!DOCTYPE html>
+    <html>
+      <body>
+        <script src="index.js">
+        </script>
+        <a href="/some.url">I will be deleted!</a>
+        <div>divs are allowed</div>
+      </body>
+    </html>
+    `;
+    const expectedFileData = `<!DOCTYPE html>
+    <html>
+      <body>
+        
+        <div>divs are allowed</div>
+      </body>
+    </html>
+    `;
+    fileSystemStub.readFile = sinon
+      .stub()
+      .callsFake((path, encoding, callback) => {
+        callback(null, invalidFileData);
+      });
+
+    removeDisallowedHtmlContent(
+      fileSystemStub,
+      brambleProxyStub,
+      '/index.html',
+      REGEX,
+      callbackSpy
+    );
+
+    expect(fileSystemStub.readFile).to.have.been.calledOnce;
+    expect(brambleProxyStub.enableReadonly).to.have.been.calledOnce;
+    expect(fileSystemStub.writeFile).to.have.been.calledOnce;
+    const actualFileData = fileSystemStub.writeFile
+      .getCall(0)
+      .args[1].toString();
+    expect(actualFileData).to.equal(expectedFileData);
+  });
+});

--- a/apps/test/unit/weblab/weblabTest.js
+++ b/apps/test/unit/weblab/weblabTest.js
@@ -5,9 +5,8 @@ import {TestResults} from '@cdo/apps/constants';
 import project from '@cdo/apps/code-studio/initApp/project';
 import {onSubmitComplete} from '@cdo/apps/submitHelper';
 
-describe('WebLab', () => {
+describe('Web Lab', () => {
   let reportStub, weblab;
-
   describe('onFinish', () => {
     beforeEach(() => {
       weblab = new WebLab();

--- a/apps/test/unit/weblab/weblabTest.js
+++ b/apps/test/unit/weblab/weblabTest.js
@@ -1,6 +1,6 @@
 import sinon from 'sinon';
 import {expect} from '../../util/reconfiguredChai';
-import WebLab, {DISALLOWED_ELEMENTS_REGEX} from '@cdo/apps/weblab/WebLab';
+import WebLab from '@cdo/apps/weblab/WebLab';
 import {TestResults} from '@cdo/apps/constants';
 import project from '@cdo/apps/code-studio/initApp/project';
 import {onSubmitComplete} from '@cdo/apps/submitHelper';
@@ -33,59 +33,6 @@ describe('WebLab', () => {
       };
       weblab.onFinish(false);
       expect(reportStub).to.have.been.calledWith(false, false);
-    });
-  });
-
-  describe('DISALLOWED_ELEMENTS_REGEX', () => {
-    it('matches on script tags', () => {
-      let test;
-
-      // single line tag
-      test = '<script src="index.js"></script>';
-      expect(test.match(DISALLOWED_ELEMENTS_REGEX)).to.deep.equal([test]);
-      test = '<script src="index.js">some content</script>';
-      expect(test.match(DISALLOWED_ELEMENTS_REGEX)).to.deep.equal([test]);
-
-      // multiline tag
-      test = `<script async src="file.js">
-      </script>`;
-      expect(test.match(DISALLOWED_ELEMENTS_REGEX)).to.deep.equal([test]);
-
-      // mixed with allowed tags
-      const match = '<script src="index.js"></script>';
-      test = `<body>
-        <a href="/some.url"></a>
-        ${match}
-        <div></div>
-      </body>
-      `;
-      expect(test.match(DISALLOWED_ELEMENTS_REGEX)).to.deep.equal([match]);
-    });
-
-    // <script> and <iframe> tags should work the same, so some expectations
-    // aren't reiterated below for brevity.
-    it('matches on iframe tags', () => {
-      let test;
-
-      // single line tag
-      test = '<iframe src="/weblab"></iframe>';
-      expect(test.match(DISALLOWED_ELEMENTS_REGEX)).to.deep.equal([test]);
-
-      // self-closing tag
-      test = '<iframe async src="/weblab"/>';
-      expect(test.match(DISALLOWED_ELEMENTS_REGEX)).to.deep.equal([test]);
-      test = '<iframe async src="/weblab" />';
-      expect(test.match(DISALLOWED_ELEMENTS_REGEX)).to.deep.equal([test]);
-
-      // mixed with allowed tags
-      const match = '<iframe src="/weblab"></iframe>';
-      test = `<body>
-        <a href="/some.url"></a>
-        ${match}
-        <div></div>
-      </body>
-      `;
-      expect(test.match(DISALLOWED_ELEMENTS_REGEX)).to.deep.equal([match]);
     });
   });
 

--- a/apps/test/unit/weblab/weblabTest.js
+++ b/apps/test/unit/weblab/weblabTest.js
@@ -1,12 +1,13 @@
 import sinon from 'sinon';
 import {expect} from '../../util/reconfiguredChai';
-import WebLab from '@cdo/apps/weblab/WebLab';
+import WebLab, {DISALLOWED_ELEMENTS_REGEX} from '@cdo/apps/weblab/WebLab';
 import {TestResults} from '@cdo/apps/constants';
 import project from '@cdo/apps/code-studio/initApp/project';
 import {onSubmitComplete} from '@cdo/apps/submitHelper';
 
-describe('Web Lab', () => {
+describe('WebLab', () => {
   let reportStub, weblab;
+
   describe('onFinish', () => {
     beforeEach(() => {
       weblab = new WebLab();
@@ -32,6 +33,59 @@ describe('Web Lab', () => {
       };
       weblab.onFinish(false);
       expect(reportStub).to.have.been.calledWith(false, false);
+    });
+  });
+
+  describe('DISALLOWED_ELEMENTS_REGEX', () => {
+    it('matches on script tags', () => {
+      let test;
+
+      // single line tag
+      test = '<script src="index.js"></script>';
+      expect(test.match(DISALLOWED_ELEMENTS_REGEX)).to.deep.equal([test]);
+      test = '<script src="index.js">some content</script>';
+      expect(test.match(DISALLOWED_ELEMENTS_REGEX)).to.deep.equal([test]);
+
+      // multiline tag
+      test = `<script async src="file.js">
+      </script>`;
+      expect(test.match(DISALLOWED_ELEMENTS_REGEX)).to.deep.equal([test]);
+
+      // mixed with allowed tags
+      const match = '<script src="index.js"></script>';
+      test = `<body>
+        <a href="/some.url"></a>
+        ${match}
+        <div></div>
+      </body>
+      `;
+      expect(test.match(DISALLOWED_ELEMENTS_REGEX)).to.deep.equal([match]);
+    });
+
+    // <script> and <iframe> tags should work the same, so some expectations
+    // aren't reiterated below for brevity.
+    it('matches on iframe tags', () => {
+      let test;
+
+      // single line tag
+      test = '<iframe src="/weblab"></iframe>';
+      expect(test.match(DISALLOWED_ELEMENTS_REGEX)).to.deep.equal([test]);
+
+      // self-closing tag
+      test = '<iframe async src="/weblab"/>';
+      expect(test.match(DISALLOWED_ELEMENTS_REGEX)).to.deep.equal([test]);
+      test = '<iframe async src="/weblab" />';
+      expect(test.match(DISALLOWED_ELEMENTS_REGEX)).to.deep.equal([test]);
+
+      // mixed with allowed tags
+      const match = '<iframe src="/weblab"></iframe>';
+      test = `<body>
+        <a href="/some.url"></a>
+        ${match}
+        <div></div>
+      </body>
+      `;
+      expect(test.match(DISALLOWED_ELEMENTS_REGEX)).to.deep.equal([match]);
     });
   });
 

--- a/dashboard/app/controllers/weblab_host_controller.rb
+++ b/dashboard/app/controllers/weblab_host_controller.rb
@@ -1,7 +1,7 @@
 class WeblabHostController < ApplicationController
   layout false
 
-  BRAMBLE_URL = 'https://downloads.computinginthecore.org/bramble_0.1.27'
+  BRAMBLE_URL = 'https://downloads.computinginthecore.org/bramble_0.1.28'
   BRAMBLE_LOCALHOST_URL = 'http://127.0.0.1:8000/src'
 
   def index


### PR DESCRIPTION
~Important note: This change relies on a change in Bramble ([PR](https://github.com/code-dot-org/bramble/pull/14)). That PR needs to be merged and a new version of Bramble must be published and consumed here before this PR can be merged.~ (This is done!)

Disallows `<script>` and `<iframe>` tags in WebLab as they pose a security threat and are unnecessary for users (our curriculum does not teach JavaScript in CSD, which is the only place WebLab is used). Neither CodeMirror nor Bramble allow specific HTML tags to be disallowed, so we are removing the tags in Code Studio.

When a user changes an HTML file, we read the file to determine if it contains any disallowed elements. If it does, we enable readOnly mode (to prevent incoming changes from the user), re-write the file to Bramble without the disallowed content, and disable readOnly mode.

[A video displaying what it looks like when these tags are removed.](https://drive.google.com/file/d/1iWX3SOQGfe-cfMGOYaut29KkNiWBgAas/view) Google Drive compressed the video a lot, so let me know if the video quality is too poor.

## Links

- Part of [STAR-704](https://codedotorg.atlassian.net/browse/STAR-704)
- [Companion change in Bramble](https://github.com/code-dot-org/bramble/pull/14) to allow us to set readOnly mode.

## Testing story

Added unit tests. I introduced a new file, `brambleUtils.js`, because `brambleHost.js` is untestable. Follow-up work has been logged to refactor `brambleHost.js`.

## Follow-up work

- [STAR-1147](https://codedotorg.atlassian.net/browse/STAR-1447) - Refactor and unit test brambleHost.js.

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [x] Tests provide adequate coverage
- [x] Privacy and Security impacts have been assessed
- [x] Code is well-commented
- [x] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [x] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [x] Follow-up work items (including potential tech debt) are tracked and linked
