### PR TITLE
Disable JavaScript in WebLab

### DIFF
--- a/apps/src/weblab/brambleHost.js
+++ b/apps/src/weblab/brambleHost.js
@@ -692,6 +692,7 @@ function load(Bramble) {
       }
     }
 
+    bramble.disableJavaScript(); // Prevents JS from executing.
     bramble.on('inspectorChange', handleInspectorChange);
     bramble.on('fileChange', handleFileChange);
     bramble.on('fileDelete', handleFileDelete);


### PR DESCRIPTION
Disables JavaScript using Bramble's configuration option. This prevents JavaScript from executing, **but only within WebLab**. If projects are published to codeprojects.org with JavaScript, it will continue to execute.

This is a companion change to #39207, which removes <script> tags from WebLab HTML. The two changes together will fully disable/disallow JavaScript in WebLab.

## Links

- Part of [STAR-704](https://codedotorg.atlassian.net/browse/STAR-704)

## Testing story

No test needed.