### PR TITLE
sync-all now checks origin/staging to see if the sync has been merged

### DIFF
--- a/bin/i18n/sync-all.rb
+++ b/bin/i18n/sync-all.rb
@@ -146,7 +146,7 @@ class I18nSync
     when /^i18n-sync/
       # If we're on an i18n sync branch, only return to staging if the branch
       # has been merged.
-      return unless GitUtils.current_branch_merged_into? "staging"
+      return unless GitUtils.current_branch_merged_into? "origin/staging"
     else
       # If we're on some other branch, then we're in some kind of weird state,
       # so error out.


### PR DESCRIPTION
Part of the i18n sync checks every hour to see if the i18n in&up and down&out PRs have been merged to origin/staging. The sync script is currently checking the local staging branch rather than origin/staging. This means that it never detects that the PRs have been merged. This results in the i18n-dev server getting stuck every week because it never detects that the changes have been pushed.

## Links
N/A

## Testing story
* Did not test

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy
I will manually update the i18n-dev server once this commit is pushed.

## Follow-up work
N/A

## Privacy
N/A

## Security
N/A

## Caching
N/A

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [x] Tests provide adequate coverage
- [x] Privacy and Security impacts have been assessed
- [x] Code is well-commented
- [x] New features are translatable or updates will not break translations
- [x] Relevant documentation has been added or updated
- [x] User impact is well-understood and desirable
- [x] Pull Request is labeled appropriately
- [x] Follow-up work items (including potential tech debt) are tracked and linked
