### PR TITLE
added default for courses_show_csa flag in CDO.

### DIFF
--- a/config.yml.erb
+++ b/config.yml.erb
@@ -419,6 +419,8 @@ default_hoc_launch: ''       # overridden by 'hoc_launch' DCDO param, except in 
 
 default_teacher_applications_active: false # overridden by 'teacher_applications_active' DCDO param, except in :test
 
+default_courses_show_csa: true # overridden by 'courses_show_csa' DCDO param, except in :test
+
 localize_apps: false
 
 partners: []

--- a/pegasus/sites.v3/code.org/public/educate/curriculum/high-school.md.erb
+++ b/pegasus/sites.v3/code.org/public/educate/curriculum/high-school.md.erb
@@ -28,7 +28,7 @@ For high schools, we offer two years computer science courses for beginners: Com
 <br>
 <hr>
 
-<%@show_csa = DCDO.get('courses_show_csa', false)%>
+<%@show_csa = DCDO.get('courses_show_csa', CDO.default_courses_show_csa)%>
 <% if @show_csa %>
 # Computer Science A (coming in 2022)
 <%=view :csa_information %>

--- a/pegasus/sites.v3/code.org/public/educate/professional-learning/middle-high.md.erb
+++ b/pegasus/sites.v3/code.org/public/educate/professional-learning/middle-high.md.erb
@@ -132,7 +132,7 @@ The program supports teachers with diverse teaching backgrounds as they prepare 
 
 <div style="clear: both;"></div>
 
-<%@show_csa = DCDO.get('courses_show_csa', false)%>
+<%@show_csa = DCDO.get('courses_show_csa', CDO.default_courses_show_csa)%>
 <% if @show_csa %>
   <p><strong>Coming in 2022</strong>: Computer Science A! In Computer Science A, students learn object-oriented programming using Java. Students take on the role of software engineers, and practice skills that are used in the field.</p> 
   <a href="/educate/csa" target="_blank"><button>Learn more</button></a>

--- a/pegasus/sites.v3/code.org/public/student/middle-high.haml
+++ b/pegasus/sites.v3/code.org/public/student/middle-high.haml
@@ -62,7 +62,7 @@ To see what's available in your language, visit our
 = view :csp_information
 %br/
 %br/
-- @show_csa = DCDO.get('courses_show_csa', false)
+- @show_csa = DCDO.get('courses_show_csa', CDO.default_courses_show_csa)
 - if @show_csa
   %h2 Computer Science A (coming in 2022)
   %br/

--- a/shared/haml/course_explorer_table.haml
+++ b/shared/haml/course_explorer_table.haml
@@ -44,7 +44,7 @@
     }
 
 :ruby
-  show_csa = DCDO.get("courses_show_csa", false)
+  show_csa = DCDO.get("courses_show_csa", CDO.default_courses_show_csa)
   courses = []
   csa_offset = show_csa ? 1 : 0
 


### PR DESCRIPTION
this PR adds a default value for the "courses_show_csa" DCDO flag to CDO. in my initial implementation i didn't understand why this was needed for controlling the flag in test.

note: the pegasus files have also been updated in dropbox to prevent any clobbering.