### PR TITLE
DOTD script: replace deprecated slack api methods

### DIFF
--- a/lib/cdo/slack.rb
+++ b/lib/cdo/slack.rb
@@ -45,7 +45,7 @@ class Slack
 
     response = Retryable.retryable(on: [Errno::ETIMEDOUT, OpenURI::HTTPError], tries: 2) do
       open(
-        'https://slack.com/api/channels.info'\
+        'https://slack.com/api/conversations.info'\
         "?token=#{SLACK_TOKEN}"\
         "&channel=#{channel_id}"\
       )
@@ -77,7 +77,7 @@ class Slack
     channel_id = get_channel_id(channel_name)
     return false unless channel_id
 
-    response = open('https://slack.com/api/channels.setTopic'\
+    response = open('https://slack.com/api/conversations.setTopic'\
       "?token=#{SLACK_TOKEN}"\
       "&channel=#{channel_id}"\
       "&topic=#{new_topic}"
@@ -180,9 +180,9 @@ class Slack
 
   def self.join_room(name)
     response = open(
-      'https://slack.com/api/channels.join'\
+      'https://slack.com/api/conversations.join'\
       "?token=#{SLACK_TOKEN}"\
-      "&name=#{name}"\
+      "&channel=#{get_channel_id(name)}"
     )
 
     result = JSON.parse(response.read)
@@ -197,7 +197,8 @@ class Slack
   private_class_method def self.get_channel_id(channel_name)
     raise "CDO.slack_token undefined" if SLACK_TOKEN.nil?
     # Documentation at https://api.slack.com/methods/channels.list.
-    slack_api_url = "https://slack.com/api/channels.list?token=#{SLACK_TOKEN}"
+    slack_api_url = "https://slack.com/api/conversations.list"\
+      "?token=#{SLACK_TOKEN}&limit=1000&types=public_channel&exclude_archived=true"
     channels = open(slack_api_url).read
     begin
       parsed_channels = JSON.parse(channels)


### PR DESCRIPTION
[Slack's Channels API methods](https://api.slack.com/methods) have been deprecated and no longer work, so I updated the dotd script to use the recommended replacements.

## Links:

[LP-1535](https://codedotorg.atlassian.net/browse/LP-1535)

## Testing Story:

I tested each one manually.

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
