### PR TITLE
Survey configuration updates for Academic Year Workshop 4

### DIFF
--- a/dashboard/config/foorm/forms/surveys/pd/ayw_workshop_post_survey.0.json
+++ b/dashboard/config/foorm/forms/surveys/pd/ayw_workshop_post_survey.0.json
@@ -128,6 +128,32 @@
       ]
     },
     {
+      "name": "module7_page",
+      "title": "Module 7 Feedback",
+      "visibleIf": "{workshop_agenda}='module7' or {workshop_agenda}='module7_8'",
+      "elements": [
+        {
+          "type": "library_item",
+          "library_name": "surveys/pd/ayw_module_7",
+          "library_version": 0,
+          "name": "module_7_panel"
+        }
+      ]
+    },
+    {
+      "name": "module8_page",
+      "title": "Module 8 Feedback",
+      "visibleIf": "{workshop_agenda}='module8' or {workshop_agenda}='module7_8'",
+      "elements": [
+        {
+          "type": "library_item",
+          "library_name": "surveys/pd/ayw_module_8",
+          "library_version": 0,
+          "name": "module_8_panel"
+        }
+      ]
+    },
+    {
       "name": "ayw1_page",
       "title": "Academic Year Workshop 1 Feedback",
       "visibleIf": "{workshop_agenda}='in_person' and ({workshop_subject}='Academic Year Workshop 1' or {workshop_subject}='Academic Year Workshop 1 + 2')",
@@ -163,6 +189,19 @@
           "library_name": "surveys/pd/ayw_inperson_3",
           "library_version": 0,
           "name": "ayw3_panel"
+        }
+      ]
+    },
+    {
+      "name": "ayw4_page",
+      "title": "Academic Year Workshop 4 Feedback",
+      "visibleIf": "{workshop_agenda}='in_person' and ({workshop_subject}='Academic Year Workshop 4' or {workshop_subject}='Academic Year Workshop 3 + 4')",
+      "elements": [
+        {
+          "type": "library_item",
+          "library_name": "surveys/pd/ayw_inperson_4",
+          "library_version": 0,
+          "name": "ayw4_panel"
         }
       ]
     },

--- a/dashboard/config/foorm/library/surveys/pd/ayw_inperson_4.0.json
+++ b/dashboard/config/foorm/library/surveys/pd/ayw_inperson_4.0.json
@@ -1,7 +1,7 @@
 {
+  "published": true,
   "pages": [
     {
-      "name": "page1",
       "elements": [
         {
           "type": "panel",
@@ -87,11 +87,11 @@
                 {
                   "value": "wrap_up",
                   "text": "Wrap Up"
-                }
+                },
                 {
                   "value": "debrief",
                   "text": "Debrief"
-                },
+                }
               ]
             },
             {
@@ -172,6 +172,9 @@
               "rows": 2
             }
           ]
+        },
+        {
+          "name": "feed me"
         }
       ]
     }

--- a/dashboard/config/foorm/library/surveys/pd/ayw_inperson_4.0.json
+++ b/dashboard/config/foorm/library/surveys/pd/ayw_inperson_4.0.json
@@ -1,4 +1,179 @@
 {
-  "published": false,
-  "pages": [{ "elements": [{ "name": "feed me" }] }]
+  "pages": [
+    {
+      "name": "page1",
+      "elements": [
+        {
+          "type": "panel",
+          "name": "ayw4_panel",
+          "elements": [
+            {
+              "type": "html",
+              "name": "preamble",
+              "html": "<h2>Workshop Activities</h2>\n<p>We're interested in your feedback about how useful the activities in this workshop were for you.</p>\n\n\n<p>For each activity in this workshop, we ask that you <strong>rate how useful that activity was to you <em>personally</em></strong> in terms of your own <strong>learning, development, teaching practice</strong>, etc.</p>\n<table style=\"width: 100%; border: 1px solid black; margin-left: auto; margin-right: auto;\" cellpadding=\"1px\"><caption><span style=\"font-family: arial, helvetica, sans-serif;\"> </span></caption>\n<tbody>\n<tr>\n<td style=\"width: 17%; padding-top: 3px; text-align: center; vertical-align: top;\"><span style=\"font-size: 13.3333px; font-family: arial, helvetica, sans-serif;\"><strong>N/A</strong></span></td>\n<td style=\"width: 20.2282%; padding-top: 3px; text-align: center; vertical-align: top;\"><span style=\"font-family: arial, helvetica, sans-serif;\"><strong><span style=\"font-size: 10pt;\">1<span style=\"color: #ffffff;\">----</span>2</span></strong></span></td>\n<td style=\"width: 21.7718%; text-align: center; vertical-align: top;\"><span style=\"font-family: arial, helvetica, sans-serif;\"><strong><span style=\"font-size: 10pt;\">3<span style=\"color: #ffffff;\">----</span>4<span style=\"color: #ffffff;\">----</span>5</span></strong></span></td>\n<td style=\"width: 20%; text-align: center; vertical-align: top;\"><span style=\"font-family: arial, helvetica, sans-serif;\"><strong><span style=\"font-size: 10pt;\">6<span style=\"color: #ffffff;\">----</span>7</span></strong></span></td>\n</tr>\n<tr>\n<td style=\"width: 17%; text-align: center; vertical-align: middle;\"><span style=\"font-size: 10pt; font-family: arial, helvetica, sans-serif;\">I don't recognize this / I don't believe we did this today</span></td>\n<td style=\"width: 20.2282%; text-align: center; vertical-align: middle;\"><span style=\"font-size: 10pt; font-family: arial, helvetica, sans-serif;\">Not useful to me</span></td>\n<td style=\"width: 21.7718%; text-align: center; vertical-align: middle;\"><span style=\"font-size: 10pt; font-family: arial, helvetica, sans-serif;\">Somewhat useful to me</span></td>\n<td style=\"width: 20%; text-align: center; vertical-align: middle;\"><span style=\"font-size: 10pt; font-family: arial, helvetica, sans-serif;\">Very useful to me</span></td>\n</tr>\n</tbody>\n</table>"
+            },
+            {
+              "type": "matrix",
+              "name": "csd_ayw4_activities",
+              "visibleIf": "{workshop_course}='CS Discoveries'",
+              "title": "Please rate the usefulness of these CS Discoveries workshop activities.",
+              "columns": [
+                {
+                  "value": "1",
+                  "text": "N/A"
+                },
+                {
+                  "value": "2",
+                  "text": "1"
+                },
+                {
+                  "value": "3",
+                  "text": "2"
+                },
+                {
+                  "value": "4",
+                  "text": "3"
+                },
+                {
+                  "value": "5",
+                  "text": "4"
+                },
+                {
+                  "value": "6",
+                  "text": "5"
+                },
+                {
+                  "value": "7",
+                  "text": "6"
+                },
+                {
+                  "value": "8",
+                  "text": "7"
+                }
+              ],
+              "rows": [
+                {
+                  "value": "opener",
+                  "text": "Workshop Opener"
+                },
+                {
+                  "value": "equity",
+                  "text": "Equity"
+                },
+                {
+                  "value": "app_lab",
+                  "text": "App Lab"
+                },
+                {
+                  "value": "intro_circuit_playground",
+                  "text": "Intro Circuit Playground"
+                },
+                {
+                  "value": "model_lesson",
+                  "text": "Model Lesson"
+                },
+                {
+                  "value": "model_lesson_reflection",
+                  "text": "Model Lesson Reflection"
+                },
+                {
+                  "value": "curric_investigation",
+                  "text": "Curriculum Investigation"
+                },
+                {
+                  "value": "conclusions_connections",
+                  "text": "Conclusions and Connections"
+                },
+                {
+                  "value": "wrap_up",
+                  "text": "Wrap Up"
+                }
+                {
+                  "value": "debrief",
+                  "text": "Debrief"
+                },
+              ]
+            },
+            {
+              "type": "matrix",
+              "name": "csp_ayw4_activities",
+              "visibleIf": "{workshop_course}='CS Principles'",
+              "title": "Please rate the usefulness of these CS Principles workshop activities.",
+              "columns": [
+                {
+                  "value": "1",
+                  "text": "N/A"
+                },
+                {
+                  "value": "2",
+                  "text": "1"
+                },
+                {
+                  "value": "3",
+                  "text": "2"
+                },
+                {
+                  "value": "4",
+                  "text": "3"
+                },
+                {
+                  "value": "5",
+                  "text": "4"
+                },
+                {
+                  "value": "6",
+                  "text": "5"
+                },
+                {
+                  "value": "7",
+                  "text": "6"
+                },
+                {
+                  "value": "8",
+                  "text": "7"
+                }
+              ],
+              "rows": [
+                {
+                  "value": "opener",
+                  "text": "Workshop Opener"
+                },
+                {
+                  "value": "equitable_inclusive_classrooms",
+                  "text": "Equitable and Inclusive Classrooms"
+                },
+                {
+                  "value": "unit9_lesson_jigsaw",
+                  "text": "Unit 9 Lesson Jigsaw"
+                },
+                {
+                  "value": "unit10_overview",
+                  "text": "Unit 10 Overview"
+                },
+                {
+                  "value": "ap_test_prep",
+                  "text": "AP Test Prep"
+                },
+                {
+                  "value": "connect_community",
+                  "text": "Connect to the Community"
+                },
+                {
+                  "value": "wrap_up",
+                  "text": "Wrap Up"
+                }
+              ]
+            },
+            {
+              "type": "comment",
+              "name": "other_activities_ayw4",
+              "title": "If you participated in any other activities during this module, please describe them below.",
+              "cols": 40,
+              "rows": 2
+            }
+          ]
+        }
+      ]
+    }
+  ]
 }

--- a/dashboard/config/foorm/library/surveys/pd/ayw_module_7.0.json
+++ b/dashboard/config/foorm/library/surveys/pd/ayw_module_7.0.json
@@ -1,8 +1,11 @@
 {
+  "published": true,
   "pages": [
     {
-      "name": "page1",
       "elements": [
+        {
+          "name": "feed me"
+        },
         {
           "type": "panel",
           "name": "module_7_panel",

--- a/dashboard/config/foorm/library/surveys/pd/ayw_module_7.0.json
+++ b/dashboard/config/foorm/library/surveys/pd/ayw_module_7.0.json
@@ -1,4 +1,156 @@
 {
-  "published": false,
-  "pages": [{ "elements": [{ "name": "feed me" }] }]
+  "pages": [
+    {
+      "name": "page1",
+      "elements": [
+        {
+          "type": "panel",
+          "name": "module_7_panel",
+          "elements": [
+            {
+              "type": "html",
+              "name": "question1",
+              "html": "<h2>How useful was Module 7?</h2>\n<p>We're interested in your feedback about how useful the activities in Module 7 were for you.</p>\n"
+            },
+            {
+              "type": "html",
+              "name": "question4",
+              "html": "<table style=\"width: 100%; border: 1px solid black; margin-left: auto; margin-right: auto;\" cellpadding=\"1px\"><caption><span style=\"font-family: arial, helvetica, sans-serif;\"> </span></caption>\n<tbody>\n<tr>\n<td style=\"width: 17%; padding-top: 3px; text-align: center; vertical-align: top;\"><span style=\"font-size: 13.3333px; font-family: arial, helvetica, sans-serif;\"><strong>N/A</strong></span></td>\n<td style=\"width: 20.2282%; padding-top: 3px; text-align: center; vertical-align: top;\"><span style=\"font-family: arial, helvetica, sans-serif;\"><strong><span style=\"font-size: 10pt;\">1<span style=\"color: #ffffff;\">----</span>2</span></strong></span></td>\n<td style=\"width: 21.7718%; text-align: center; vertical-align: top;\"><span style=\"font-family: arial, helvetica, sans-serif;\"><strong><span style=\"font-size: 10pt;\">3<span style=\"color: #ffffff;\">----</span>4<span style=\"color: #ffffff;\">----</span>5</span></strong></span></td>\n<td style=\"width: 20%; text-align: center; vertical-align: top;\"><span style=\"font-family: arial, helvetica, sans-serif;\"><strong><span style=\"font-size: 10pt;\">6<span style=\"color: #ffffff;\">----</span>7</span></strong></span></td>\n</tr>\n<tr>\n<td style=\"width: 17%; text-align: center; vertical-align: middle;\"><span style=\"font-size: 10pt; font-family: arial, helvetica, sans-serif;\">I don't recognize this / I don't believe we did this today</span></td>\n<td style=\"width: 20.2282%; text-align: center; vertical-align: middle;\"><span style=\"font-size: 10pt; font-family: arial, helvetica, sans-serif;\">Not useful to me</span></td>\n<td style=\"width: 21.7718%; text-align: center; vertical-align: middle;\"><span style=\"font-size: 10pt; font-family: arial, helvetica, sans-serif;\">Somewhat useful to me</span></td>\n<td style=\"width: 20%; text-align: center; vertical-align: middle;\"><span style=\"font-size: 10pt; font-family: arial, helvetica, sans-serif;\">Very useful to me</span></td>\n</tr>\n</tbody>\n</table>"
+            },
+            {
+              "type": "matrix",
+              "name": "csd_activities_m7",
+              "visibleIf": "{workshop_course}='CS Discoveries'",
+              "title": "Please rate the usefulness of these CS Discoveries workshop activities.",
+              "columns": [
+                {
+                  "value": "1",
+                  "text": "N/A"
+                },
+                {
+                  "value": "2",
+                  "text": "1"
+                },
+                {
+                  "value": "3",
+                  "text": "2"
+                },
+                {
+                  "value": "4",
+                  "text": "3"
+                },
+                {
+                  "value": "5",
+                  "text": "4"
+                },
+                {
+                  "value": "6",
+                  "text": "5"
+                },
+                {
+                  "value": "7",
+                  "text": "6"
+                },
+                {
+                  "value": "8",
+                  "text": "7"
+                }
+              ],
+              "rows": [
+                {
+                  "value": "welcome",
+                  "text": "Workshop"
+                },
+                {
+                  "value": "circuit_playground",
+                  "text": "Circuit Playground"
+                },
+                {
+                  "value": "lesson_investigation",
+                  "text": "Lesson Investigation"
+                },
+                {
+                  "value": "lesson_reflection",
+                  "text": "Lesson Reflection"
+                },
+                {
+                  "value": "alternatives",
+                  "text": "Alternatives"
+                },
+                {
+                  "value": "wrap_up",
+                  "text": "Wrap Up"
+                }
+              ]
+            },
+            {
+              "type": "matrix",
+              "name": "csp_activities_m7",
+              "visibleIf": "{workshop_course}='CS Principles'",
+              "title": "Please rate the usefulness of these CS Principles workshop activities.",
+              "columns": [
+                {
+                  "value": "1",
+                  "text": "N/A"
+                },
+                {
+                  "value": "2",
+                  "text": "1"
+                },
+                {
+                  "value": "3",
+                  "text": "2"
+                },
+                {
+                  "value": "4",
+                  "text": "3"
+                },
+                {
+                  "value": "5",
+                  "text": "4"
+                },
+                {
+                  "value": "6",
+                  "text": "5"
+                },
+                {
+                  "value": "7",
+                  "text": "6"
+                },
+                {
+                  "value": "8",
+                  "text": "7"
+                }
+              ],
+              "rows": [
+                {
+                  "value": "opener",
+                  "text": "Workshop Opener"
+                },
+                {
+                  "value": "context_unit10",
+                  "text": "Context for Unit 10"
+                },
+                {
+                  "value": "unit10_run_through",
+                  "text": "Unit 10 Project Run-Through"
+                },
+                {
+                  "value": "wrap_up",
+                  "text": "Wrap Up"
+                }
+              ]
+            },
+            {
+              "type": "comment",
+              "name": "other_activities_m7",
+              "title": "If you participated in any other activities during this workshop, please describe them below.",
+              "cols": 40,
+              "rows": 2
+            }
+          ]
+        }
+      ]
+    }
+  ]
 }

--- a/dashboard/config/foorm/library/surveys/pd/ayw_module_8.0.json
+++ b/dashboard/config/foorm/library/surveys/pd/ayw_module_8.0.json
@@ -1,8 +1,11 @@
 {
+  "published": true,
   "pages": [
     {
-      "name": "page1",
       "elements": [
+        {
+          "name": "feed me"
+        },
         {
           "type": "panel",
           "name": "module_8_panel",

--- a/dashboard/config/foorm/library/surveys/pd/ayw_module_8.0.json
+++ b/dashboard/config/foorm/library/surveys/pd/ayw_module_8.0.json
@@ -1,4 +1,148 @@
 {
-  "published": false,
-  "pages": [{ "elements": [{ "name": "feed me" }] }]
+  "pages": [
+    {
+      "name": "page1",
+      "elements": [
+        {
+          "type": "panel",
+          "name": "module_8_panel",
+          "elements": [
+            {
+              "type": "html",
+              "name": "question1",
+              "html": "<h2>How useful was Module 8?</h2>\n<p>We're interested in your feedback about how useful the activities in Module 8 were for you.</p>\n"
+            },
+            {
+              "type": "html",
+              "name": "question4",
+              "html": "<table style=\"width: 100%; border: 1px solid black; margin-left: auto; margin-right: auto;\" cellpadding=\"1px\"><caption><span style=\"font-family: arial, helvetica, sans-serif;\"> </span></caption>\n<tbody>\n<tr>\n<td style=\"width: 17%; padding-top: 3px; text-align: center; vertical-align: top;\"><span style=\"font-size: 13.3333px; font-family: arial, helvetica, sans-serif;\"><strong>N/A</strong></span></td>\n<td style=\"width: 20.2282%; padding-top: 3px; text-align: center; vertical-align: top;\"><span style=\"font-family: arial, helvetica, sans-serif;\"><strong><span style=\"font-size: 10pt;\">1<span style=\"color: #ffffff;\">----</span>2</span></strong></span></td>\n<td style=\"width: 21.7718%; text-align: center; vertical-align: top;\"><span style=\"font-family: arial, helvetica, sans-serif;\"><strong><span style=\"font-size: 10pt;\">3<span style=\"color: #ffffff;\">----</span>4<span style=\"color: #ffffff;\">----</span>5</span></strong></span></td>\n<td style=\"width: 20%; text-align: center; vertical-align: top;\"><span style=\"font-family: arial, helvetica, sans-serif;\"><strong><span style=\"font-size: 10pt;\">6<span style=\"color: #ffffff;\">----</span>7</span></strong></span></td>\n</tr>\n<tr>\n<td style=\"width: 17%; text-align: center; vertical-align: middle;\"><span style=\"font-size: 10pt; font-family: arial, helvetica, sans-serif;\">I don't recognize this / I don't believe we did this today</span></td>\n<td style=\"width: 20.2282%; text-align: center; vertical-align: middle;\"><span style=\"font-size: 10pt; font-family: arial, helvetica, sans-serif;\">Not useful to me</span></td>\n<td style=\"width: 21.7718%; text-align: center; vertical-align: middle;\"><span style=\"font-size: 10pt; font-family: arial, helvetica, sans-serif;\">Somewhat useful to me</span></td>\n<td style=\"width: 20%; text-align: center; vertical-align: middle;\"><span style=\"font-size: 10pt; font-family: arial, helvetica, sans-serif;\">Very useful to me</span></td>\n</tr>\n</tbody>\n</table>"
+            },
+            {
+              "type": "matrix",
+              "name": "csd_activities_m8",
+              "visibleIf": "{workshop_course}='CS Discoveries'",
+              "title": "Please rate the usefulness of these CS Discoveries workshop activities.",
+              "columns": [
+                {
+                  "value": "1",
+                  "text": "N/A"
+                },
+                {
+                  "value": "2",
+                  "text": "1"
+                },
+                {
+                  "value": "3",
+                  "text": "2"
+                },
+                {
+                  "value": "4",
+                  "text": "3"
+                },
+                {
+                  "value": "5",
+                  "text": "4"
+                },
+                {
+                  "value": "6",
+                  "text": "5"
+                },
+                {
+                  "value": "7",
+                  "text": "6"
+                },
+                {
+                  "value": "8",
+                  "text": "7"
+                }
+              ],
+              "rows": [
+                {
+                  "value": "welcome",
+                  "text": "Welcome"
+                },
+                {
+                  "value": "conclusions_connections",
+                  "text": "Conclusions and Connections"
+                },
+                {
+                  "value": "equity",
+                  "text": "Equity"
+                },
+                {
+                  "value": "wrap_up",
+                  "text": "Wrap Up"
+                }
+              ]
+            },
+            {
+              "type": "matrix",
+              "name": "csp_activities_m8",
+              "visibleIf": "{workshop_course}='CS Principles'",
+              "title": "Please rate the usefulness of these CS Principles workshop activities.",
+              "columns": [
+                {
+                  "value": "1",
+                  "text": "N/A"
+                },
+                {
+                  "value": "2",
+                  "text": "1"
+                },
+                {
+                  "value": "3",
+                  "text": "2"
+                },
+                {
+                  "value": "4",
+                  "text": "3"
+                },
+                {
+                  "value": "5",
+                  "text": "4"
+                },
+                {
+                  "value": "6",
+                  "text": "5"
+                },
+                {
+                  "value": "7",
+                  "text": "6"
+                },
+                {
+                  "value": "8",
+                  "text": "7"
+                }
+              ],
+              "rows": [
+                {
+                  "value": "opener",
+                  "text": "Workshop Opener"
+                },
+                {
+                  "value": "setting_goals_inclusive_classroom",
+                  "text": "Setting Goals for an Inclusive Classroom"
+                },
+                {
+                  "value": "connecting_community",
+                  "text": "Connecting to the Community"
+                },
+                {
+                  "value": "wrap_up",
+                  "text": "Wrap Up"
+                }
+              ]
+            },
+            {
+              "type": "comment",
+              "name": "other_activities_m8",
+              "title": "If you participated in any other activities during this workshop, please describe them below.",
+              "cols": 40,
+              "rows": 2
+            }
+          ]
+        }
+      ]
+    }
+  ]
 }


### PR DESCRIPTION
Configuration changes for post-workshop surveys for Academic Year Workshop (AYW) 4 (the fourth of four academic year workshops for teachers in our CS Principles and CS Discoveries Professional Learning programs). We intended to do this originally via our new Foorm Form/Library Editors, but there was a scheduling misunderstanding and we need to get these surveys out ASAP (there are already AYW4 workshops happening, which have post-surveys that missing the questions that are introduced in this PR).

## Testing story

I imported these new configurations via `bundle exec rake seed:foorms`, which seeded the database with these new configurations.

I then used our Foorm Editor to preview the new configurations

Module 7
![image](https://user-images.githubusercontent.com/25372625/109057254-5ea55e80-7696-11eb-9cde-208bf9f3dade.png)

Module 8
![image](https://user-images.githubusercontent.com/25372625/109057302-6c5ae400-7696-11eb-8e4a-8bc45a7575e9.png)

In Person

![image](https://user-images.githubusercontent.com/25372625/109057384-872d5880-7696-11eb-9a67-826ef3a9b248.png)

## Deployment strategy

These updates will immediately be put in use when workshop organizers conduct post-workshop surveys for their AYW4 workshops. As mentioned above, AYW4 workshops that have already happened have conducted post-workshop surveys with questions that are not specific to the content of the workshop, so those questions will continue to be asked as well.

## PR Checklist:

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
