### PR TITLE
Add some basic rake tasks for Lesson Plan PDF generation

### DIFF
--- a/dashboard/lib/services/lesson_plan_pdfs.rb
+++ b/dashboard/lib/services/lesson_plan_pdfs.rb
@@ -4,7 +4,9 @@ require 'pdf/conversion'
 
 module Services
   # Contains all code related to the generation, storage, and
-  # retrieval of Lesson Plan PDFs
+  # retrieval of Lesson Plan PDFs.
+  #
+  # Also see lesson_plan_pdfs.rake for some associated logic
   module LessonPlanPdfs
     DEBUG = false
     S3_BUCKET = "cdo-lesson-plans#{'-dev' if DEBUG}".freeze
@@ -133,6 +135,11 @@ module Services
       return nil unless pathname.present?
 
       File.join(get_base_url, pathname)
+    end
+
+    def self.pdf_exists_for?(lesson)
+      pathname = get_pathname(lesson)
+      AWS::S3.cached_exists_in_bucket?(S3_BUCKET, pathname.to_s)
     end
 
     def self.generate_lesson_pdf(lesson, directory="/tmp/")

--- a/dashboard/lib/tasks/lesson_plan_pdfs.rake
+++ b/dashboard/lib/tasks/lesson_plan_pdfs.rake
@@ -1,0 +1,51 @@
+namespace :lesson_plan_pdfs do
+  def get_pdf_enabled_scripts
+    Script.all.select do |script|
+      script.is_migrated && script.seeded_from.present?
+    end
+  end
+
+  def get_pdfless_lessons(script)
+    script.lessons.select(&:has_lesson_plan).select do |lesson|
+      !Services::LessonPlanPdfs.pdf_exists_for?(lesson)
+    end
+  end
+
+  desc 'Identify all content for which we expect to have a generated PDF, but don\'t.'
+  task identify_missing_pdfs: :environment do
+    any_missing_pdfs_found = false
+    get_pdf_enabled_scripts.each do |script|
+      pdfless_lessons = get_pdfless_lessons(script)
+      next if pdfless_lessons.empty?
+
+      any_missing_pdfs_found = true
+      puts "Script #{script.name.inspect} is missing PDFs for:"
+      pdfless_lessons.each do |lesson|
+        puts "  #{lesson.name.inspect} (#{lesson.key})"
+      end
+    end
+
+    puts "No missing PDFs found" unless any_missing_pdfs_found
+  end
+
+  desc 'Generate any PDFs that we would expect to have been generated automatically but for whatever reason haven\'t been.'
+  task generate_missing_pdfs: :environment do
+    Dir.mktmpdir("pdf_generation") do |dir|
+      any_pdf_generated = false
+      get_pdf_enabled_scripts.each do |script|
+        get_pdfless_lessons(script).each do |lesson|
+          puts "Generating missing PDF for #{lesson.key} (from #{script.name})"
+          Services::LessonPlanPdfs.generate_lesson_pdf(lesson, dir)
+          any_pdf_generated = true
+        end
+      end
+
+      if any_pdf_generated
+        puts "Generated all missing PDFs, uploading results to S3"
+        Services::LessonPlanPdfs.upload_generated_pdfs_to_s3(dir)
+      else
+        puts "No missing PDFs found to generate"
+      end
+    end
+  end
+end

--- a/dashboard/lib/tasks/lesson_plan_pdfs.rake
+++ b/dashboard/lib/tasks/lesson_plan_pdfs.rake
@@ -48,4 +48,23 @@ namespace :lesson_plan_pdfs do
       end
     end
   end
+
+  task generate_all_pdfs: :environment do
+    puts "About to (re)generate all PDFs for all scripts."
+    puts "As of Feb 2021, we expect this operation to take about half an hour. We expect it to take longer the more content we've added since that date."
+    puts "Are you sure you want to proceed? (y/N)"
+    input = STDIN.gets.strip.downcase
+    next unless input == 'y'
+
+    Dir.mktmpdir("pdf_generation") do |dir|
+      get_pdf_enabled_scripts.each do |script|
+        script.lessons.select(&:has_lesson_plan).each do |lesson|
+          Services::LessonPlanPdfs.generate_lesson_pdf(lesson, dir)
+        end
+      end
+      Services::LessonPlanPdfs.upload_generated_pdfs_to_s3(dir)
+    end
+
+    puts "Generated all PDFs"
+  end
 end


### PR DESCRIPTION
Follow-up to https://github.com/code-dot-org/code-dot-org/pull/39011

Specifically:

1. `identify_missing_pdfs` will check all content for which we expect to have PDFs and verify that there is actually a file on S3
2. `generate_missing_pdfs` will manually generate any missing PDFs
3. `generate_all_pdfs` will manually (re)generate all PDFs

## Testing story

Manually verified that these work; we don't currently have any plans to use these scripts in any official capacity, so I wasn't planning on adding more formal tests.

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
