### PR TITLE
Seed foorm forms and libraries inside of a transaction

### DIFF
--- a/dashboard/app/models/foorm/form.rb
+++ b/dashboard/app/models/foorm/form.rb
@@ -57,7 +57,7 @@ class Foorm::Form < ApplicationRecord
         form.questions = questions
         form.published = published
         form.save! if form.changed?
-      rescue
+      rescue JSON::ParserError
         raise format('failed to parse %s', full_name)
       end
     end

--- a/dashboard/app/models/foorm/form.rb
+++ b/dashboard/app/models/foorm/form.rb
@@ -24,7 +24,7 @@ class Foorm::Form < ApplicationRecord
   has_many :submissions, foreign_key: [:form_name, :form_version], primary_key: [:name, :version]
   validate :validate_questions, :validate_published
 
-  after_save :write_form_to_file
+  after_commit :write_form_to_file
 
   # We have a uniqueness constraint on form name and version for this table.
   # This key format is used elsewhere in Foorm to uniquely identify a form.
@@ -33,27 +33,33 @@ class Foorm::Form < ApplicationRecord
   end
 
   def self.setup
-    Dir.glob('config/foorm/forms/**/*.json').each do |path|
-      # Given: "config/foorm/forms/surveys/pd/pre_workshop_survey.0.json"
-      # we get full_name: "surveys/pd/pre_workshop_survey"
-      #      and version: 0
-      unique_path = path.partition("config/foorm/forms/")[2]
-      filename_and_version = File.basename(unique_path, ".json")
-      filename, version = filename_and_version.split(".")
-      version = version.to_i
-      full_name = File.dirname(unique_path) + "/" + filename
+    # Seed all forms inside of a transaction, such that all forms are imported/updated successfully
+    # or none at all.
+    ActiveRecord::Base.transaction do
+      Dir.glob('config/foorm/forms/**/*.json').each do |path|
+        # Given: "config/foorm/forms/surveys/pd/pre_workshop_survey.0.json"
+        # we get full_name: "surveys/pd/pre_workshop_survey"
+        #      and version: 0
+        unique_path = path.partition("config/foorm/forms/")[2]
+        filename_and_version = File.basename(unique_path, ".json")
+        filename, version = filename_and_version.split(".")
+        version = version.to_i
+        full_name = File.dirname(unique_path) + "/" + filename
 
-      # Let's load the JSON text.
-      questions = File.read(path)
+        # Let's load the JSON text.
+        questions = File.read(path)
 
-      # if published is not provided, default to true
-      questions_parsed = JSON.parse(questions)
-      published = questions_parsed['published'].nil? ? true : questions_parsed['published']
+        # if published is not provided, default to true
+        questions_parsed = JSON.parse(questions)
+        published = questions_parsed['published'].nil? ? true : questions_parsed['published']
 
-      form = Foorm::Form.find_or_initialize_by(name: full_name, version: version)
-      form.questions = questions
-      form.published = published
-      form.save! if form.changed?
+        form = Foorm::Form.find_or_initialize_by(name: full_name, version: version)
+        form.questions = questions
+        form.published = published
+        form.save! if form.changed?
+      rescue
+        raise format('failed to parse %s', full_name)
+      end
     end
   end
 

--- a/dashboard/app/models/foorm/library.rb
+++ b/dashboard/app/models/foorm/library.rb
@@ -18,21 +18,21 @@ class Foorm::Library < ApplicationRecord
 
   has_many :library_questions, primary_key: [:name, :version], foreign_key: [:library_name, :library_version]
 
-  after_save :write_library_to_file
+  after_commit :write_library_to_file
 
   def self.setup
-    Dir.glob('config/foorm/library/**/*.json').each do |path|
-      # Given: "config/foorm/library/surveys/pd/pre_workshop_survey.0.json"
-      # we get full_name: "surveys/pd/pre_workshop_survey"
-      #      and version: 0
-      unique_path = path.partition("config/foorm/library/")[2]
-      filename_and_version = File.basename(unique_path, ".json")
-      filename, version = filename_and_version.split(".")
-      version = version.to_i
-      full_name = File.dirname(unique_path) + "/" + filename
+    ActiveRecord::Base.transaction do
+      Dir.glob('config/foorm/library/**/*.json').each do |path|
+        # Given: "config/foorm/library/surveys/pd/pre_workshop_survey.0.json"
+        # we get full_name: "surveys/pd/pre_workshop_survey"
+        #      and version: 0
+        unique_path = path.partition("config/foorm/library/")[2]
+        filename_and_version = File.basename(unique_path, ".json")
+        filename, version = filename_and_version.split(".")
+        version = version.to_i
+        full_name = File.dirname(unique_path) + "/" + filename
 
-      # Let's load the JSON text.
-      begin
+        # Let's load the JSON text.
         library = Foorm::Library.find_or_initialize_by(
           name: full_name,
           version: version

--- a/dashboard/app/models/foorm/library.rb
+++ b/dashboard/app/models/foorm/library.rb
@@ -21,6 +21,8 @@ class Foorm::Library < ApplicationRecord
   after_commit :write_library_to_file
 
   def self.setup
+    # Seed all libraries inside of a transaction, such that all libraries are imported/updated successfully
+    # or none at all.
     ActiveRecord::Base.transaction do
       Dir.glob('config/foorm/library/**/*.json').each do |path|
         # Given: "config/foorm/library/surveys/pd/pre_workshop_survey.0.json"

--- a/dashboard/app/models/foorm/library.rb
+++ b/dashboard/app/models/foorm/library.rb
@@ -60,7 +60,7 @@ class Foorm::Library < ApplicationRecord
             library_question.save! if library_question.changed?
           end
         end
-      rescue
+      rescue JSON::ParserError
         raise format('failed to parse %s', full_name)
       end
     end

--- a/dashboard/app/models/foorm/library_question.rb
+++ b/dashboard/app/models/foorm/library_question.rb
@@ -23,7 +23,7 @@ class Foorm::LibraryQuestion < ApplicationRecord
 
   validate :validate_library_question
 
-  after_save :write_to_file
+  after_commit :write_to_file
 
   def validate_library_question
     Foorm::Form.validate_element(JSON.parse(question).deep_symbolize_keys, Set.new)


### PR DESCRIPTION
Modifies our seeding process to only write updates to Foorm libraries (and library questions) and forms if all updates were executed successfully. This change is particularly relevant in the context of libraries, where a library of 10 library questions could fail on, say, the third question, then end up writing an incomplete version of the library back to the config directory based on the 2 questions that had been imported successfully.

This change puts all changes made to all libraries or forms inside one transaction, rather than a single transaction per library/form. I could be convinced to have one transaction per library/form, but not sure it makes a huge difference.

## Testing story

I tested manually that:
1. Using our existing seeding process, a library with a library question in it that was missing a required field (name) seeded an impartial version of the library, and that impartial library was also saved to our config directory.
2. With the new seeding process, a library with a library question in it that had invalid JSON seeded 0 libraries and 0 library questions, and made no changes to the config directory.
3. With the new seeding process, when all libraries are valid, all libraries are inserted as expected.
4. With our existing seeding process, when one form is invalid, other forms will be written to the database.
5. With our new seeding process, when one form is invalid, 0 forms are written to the database.

## PR Checklist:

- [x] Tests provide adequate coverage
- [x] Privacy and Security impacts have been assessed
- [x] Code is well-commented
- [x] New features are translatable or updates will not break translations
- [x] Relevant documentation has been added or updated
- [x] User impact is well-understood and desirable
- [x] Pull Request is labeled appropriately
- [x] Follow-up work items (including potential tech debt) are tracked and linked
