### PR TITLE
Addresses flakey test for send lesson copy link on safari and ie

### DIFF
--- a/apps/src/templates/progress/SendLessonDialog.jsx
+++ b/apps/src/templates/progress/SendLessonDialog.jsx
@@ -70,7 +70,7 @@ class SendLessonDialog extends Component {
   onCopyLink() {
     copyToClipboard(this.props.lessonUrl);
 
-    // show "Link copied!" for 4 seconds
+    // show message "Link copied!" for 4 seconds
     this.setState({showLinkCopied: true});
     setTimeout(() => {
       this.setState({showLinkCopied: false});

--- a/apps/src/templates/progress/SendLessonDialog.jsx
+++ b/apps/src/templates/progress/SendLessonDialog.jsx
@@ -70,11 +70,11 @@ class SendLessonDialog extends Component {
   onCopyLink() {
     copyToClipboard(this.props.lessonUrl);
 
-    // show "Link copied!" for 2 seconds
+    // show "Link copied!" for 4 seconds
     this.setState({showLinkCopied: true});
     setTimeout(() => {
       this.setState({showLinkCopied: false});
-    }, 2000);
+    }, 4000);
 
     firehoseClient.putRecord(
       {


### PR DESCRIPTION
Upon investigation of the Saucelabs test history for both IE and Safari runs, the send lesson copy link is actually working as expected. So why is it failing, you might ask? The dialog that proclaims "Link Copied!" disappears too quickly for the test to catch! So, this fix increases the amount of time the message is displayed from 2 seconds to 4 seconds, ensuring that any test will have time to catch it, and any user might have a little more time to see it, too. 

Jira Ticket: https://codedotorg.atlassian.net/browse/LP-1765