### PR TITLE
AiLab: Show Help & Tips option in level editor

### DIFF
--- a/dashboard/app/models/levels/level.rb
+++ b/dashboard/app/models/levels/level.rb
@@ -739,6 +739,11 @@ class Level < ApplicationRecord
     false
   end
 
+  def show_help_and_tips_in_level_editor?
+    (uses_droplet? || is_a?(Blockly) || is_a?(Weblab) || is_a?(Ailab)) &&
+    !(is_a?(NetSim) || is_a?(GamelabJr) || is_a?(Dancelab) || is_a?(BubbleChoice))
+  end
+
   def localized_teacher_markdown
     if should_localize?
       I18n.t(

--- a/dashboard/app/views/levels/editors/fields/_help_and_tips.html.haml
+++ b/dashboard/app/views/levels/editors/fields/_help_and_tips.html.haml
@@ -1,22 +1,20 @@
--# Deprecated for Sprite Lab and Dance
-- if !(@level.is_a?(GamelabJr) || @level.is_a?(Dancelab) || @level.is_a?(BubbleChoice))
-  %h1.control-legend{data: {toggle: "collapse", target: "#help_and_tips"}}
-    Help and Tips
-  #help_and_tips.in.collapse
+%h1.control-legend{data: {toggle: "collapse", target: "#help_and_tips"}}
+  Help and Tips
+#help_and_tips.in.collapse
 
-    = f.label :map_reference, 'Map Reference'
-    %li If there is a key resource you want to reference in the instructions, add the link here. It will show up under the 'Help & Tips' tab.
-    %li This should be a string representing the URL on studio.code.org/docs you want to embed, i.e. '/docs/csd/maker_leds/index.html'.
+  = f.label :map_reference, 'Map Reference'
+  %li If there is a key resource you want to reference in the instructions, add the link here. It will show up under the 'Help & Tips' tab.
+  %li This should be a string representing the URL on studio.code.org/docs you want to embed, i.e. '/docs/csd/maker_leds/index.html'.
 
-    = f.text_field :map_reference, placeholder: 'Map Reference'
+  = f.text_field :map_reference, placeholder: 'Map Reference'
 
-    .field
-      = f.label :reference_link, 'Reference Links'
-      %li Add links to pages on Curriculum Builder below. They will show up in the 'Help & Tips' tab below any videos and the map reference.
-      %li These should be strings representing the URL on [docs|curriculum].code.org you want to embed, i.e. '/docs/csd/maker_leds/index.html' or '/curriculum/path/to/file'.
-      %li Put each link on a new line
+  .field
+    = f.label :reference_link, 'Reference Links'
+    %li Add links to pages on Curriculum Builder below. They will show up in the 'Help & Tips' tab below any videos and the map reference.
+    %li These should be strings representing the URL on [docs|curriculum].code.org you want to embed, i.e. '/docs/csd/maker_leds/index.html' or '/curriculum/path/to/file'.
+    %li Put each link on a new line
 
-      .row
-        .span8
-          - @level.reference_links = [''] unless @level.reference_links.try(:present?)
-          = text_area_tag 'level[reference_links]', @level.reference_links.join("\r\n"), rows: 6, class: "input-block-level", placeholder: 'Additional Reference Link'
+    .row
+      .span8
+        - @level.reference_links = [''] unless @level.reference_links.try(:present?)
+        = text_area_tag 'level[reference_links]', @level.reference_links.join("\r\n"), rows: 6, class: "input-block-level", placeholder: 'Additional Reference Link'

--- a/dashboard/app/views/levels/editors/fields/_instructions_area.html.haml
+++ b/dashboard/app/views/levels/editors/fields/_instructions_area.html.haml
@@ -3,6 +3,6 @@
 
 #instructions_area.in.collapse
   = render partial: 'levels/editors/fields/instructions', locals: {f: f} unless @level.is_a?(DSLDefined) || @level.is_a?(Unplugged)
-  = render partial: 'levels/editors/fields/help_and_tips', locals: {f: f} if ((@level.uses_droplet?) || @level.is_a?(Blockly) || @level.is_a?(Weblab)) && !@level.is_a?(NetSim)
+  = render partial: 'levels/editors/fields/help_and_tips', locals: {f: f} if @level.show_help_and_tips_in_level_editor?
   = render partial: 'levels/editors/fields/mini_rubric', locals: {f: f} if (@level.uses_droplet?) || @level.is_a?(Weblab)
   = render partial: 'levels/editors/fields/authored_hints', locals: {f: f} if !(@level.uses_droplet?) && @level.is_a?(Blockly) && !@level.is_a?(NetSim)


### PR DESCRIPTION
Also consolidate the logic for showing this option in general, and hoist it into the model.
