### PR TITLE
Successfully move lesson to later lesson group in script

### DIFF
--- a/dashboard/app/models/script.rb
+++ b/dashboard/app/models/script.rb
@@ -1028,6 +1028,15 @@ class Script < ApplicationRecord
       script.prevent_duplicate_lesson_groups(raw_lesson_groups)
       Script.prevent_some_lessons_in_lesson_groups_and_some_not(raw_lesson_groups)
 
+      # More all lessons into the last lesson group so that we do not delete
+      # the lesson entries unless the lesson has been entirely removed from the
+      # script
+      last_lesson_group = script.lesson_groups.last
+      script.lessons.each do |l|
+        l.lesson_group = last_lesson_group
+        l.save!
+      end
+
       temp_lgs = LessonGroup.add_lesson_groups(raw_lesson_groups, script, new_suffix, editor_experiment)
       script.reload
       script.lesson_groups = temp_lgs

--- a/dashboard/test/models/script_test.rb
+++ b/dashboard/test/models/script_test.rb
@@ -2386,6 +2386,40 @@ class ScriptTest < ActiveSupport::TestCase
     refute_equal script.lessons[0].lesson_group.id, script.lessons[2].lesson_group.id
   end
 
+  test 'can move lesson to later lesson group in script' do
+    script = create :script, name: 'lesson-group-test-script'
+    lesson_group1 = create :lesson_group, key: 'lg-1', script: script
+    lesson1 = create :lesson, key: 'l-1', name: 'Lesson 1', lesson_group: lesson_group1
+    lesson2 = create :lesson, key: 'l-2', name: 'Lesson 2', lesson_group: lesson_group1
+    activity = create :lesson_activity, lesson: lesson2
+    activity_section = create :activity_section, lesson_activity: activity
+    level1 = create :level
+    script_level = create :script_level, script: script, lesson: lesson2, levels: [level1], activity_section: activity_section, activity_section_position: 1
+    lesson_group2 = create :lesson_group, key: 'lg-2', script: script
+    lesson3 = create :lesson, key: 'l-3', name: 'Lesson 3', lesson_group: lesson_group2
+
+    new_dsl = <<-SCRIPT
+      lesson_group '#{lesson_group1.key}', display_name: 'Lesson Group 1'
+      lesson '#{lesson1.key}', display_name: '#{lesson1.name}'
+
+      lesson_group '#{lesson_group2.key}', display_name: 'Lesson Group 2'
+      lesson '#{lesson2.key}', display_name: '#{lesson2.name}'
+      level '#{level1.name}'
+
+      lesson '#{lesson3.key}', display_name: '#{lesson3.name}'
+    SCRIPT
+
+    script = Script.add_script(
+      {name: 'lesson-group-test-script'},
+      ScriptDSL.parse(new_dsl, 'a filename')[0][:lesson_groups]
+    )
+
+    assert_equal script.lessons[1].lesson_group_id, lesson_group2.id
+    assert_equal script.lessons[1].id, lesson2.id
+    assert_equal script.script_levels[0].id, script_level.id
+    assert_equal script.script_levels[0].activity_section_id, activity_section.id
+  end
+
   test 'can add the lesson group for a lesson' do
     l = create :level
     old_dsl = <<-SCRIPT


### PR DESCRIPTION
## The Problem

We had a report from a contractor working on the new editor that moving a lesson to a different lesson group resulted in the following error:

'Legacy script levels are not allowed in migrated scripts.'

When looking into this locally I realized that this error showed up when moving a lesson in a migrated script with script_levels that are in activity sections to a later lesson group. Moving a lesson to an earlier lesson group or moving a lesson without script_levels saved fine.

This is because we call script#update which calls `update_text` which calls `add_script` which calls `add_lesson_groups`.  For each lesson group we set up the lessons, script_levels and level based on the Script DSL. We do not know about activities or activity sections in script DSL. During `add_lesson_groups` as you set up each lesson_group you delete any lessons which are no longer in use after the lesson_group is updated because of this these lines:

https://github.com/code-dot-org/code-dot-org/blob/45265cfd95bc88dc09b3bd2450d7d9b2fccf1b57/dashboard/app/models/lesson_group.rb#L90-L92

That meant when you looked for the lesson when setting up the later lesson group it moved to it no longer existed so we created a new lesson. This meant in `add_script_levels` when we it searched for a script_level based on script and lesson in these lines:

https://github.com/code-dot-org/code-dot-org/blob/45265cfd95bc88dc09b3bd2450d7d9b2fccf1b57/dashboard/app/models/script_level.rb#L111-L116

It did not find the old script level and thus made a new one which no longer had the activity section information associated with it. Thus resulting in the error.

## The Solution

To fix this for now I have added a step in `add_script` which moves all the lesson in the script to the last lesson group so they will only get deleted if they are actually removed from the script. 

## Future Work

I think we will want to look into getting migrated scripts off of script DSL on the script edit page entirely and not using the add_script path for migrated scripts replacing it with something more robust.  However I wanted to unblock contractors and I think this longer term fix requires some team conversations so thats probably something we need to discuss once Dave is back.  Tracking the follow up: https://codedotorg.atlassian.net/browse/PLAT-775

## Links

- jira ticket: [PLAT-771](https://codedotorg.atlassian.net/browse/PLAT-771)

## Testing story

I added a test that simulates the issue that was occurring and checked that it failed before the fix and passes after the fix.

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [X] Tests provide adequate coverage
- [X] Privacy and Security impacts have been assessed
- [X] Code is well-commented
- [X] New features are translatable or updates will not break translations
- [X] Relevant documentation has been added or updated
- [X] User impact is well-understood and desirable
- [X] Pull Request is labeled appropriately
- [X] Follow-up work items (including potential tech debt) are tracked and linked
