### PR TITLE
Manually autosave if there are unsaved changes in window.onbeforeunload

### DIFF
--- a/apps/i18n/weblab/en_us.json
+++ b/apps/i18n/weblab/en_us.json
@@ -2,7 +2,6 @@
   "addCSSButton": "Add CSS",
   "addImageButton": "Add Image",
   "addHTMLButton": "Add HTML",
-  "confirmExitWithUnsavedChanges": "Do you want to exit with unsaved changes?",
   "currentProjectCapacity": "{currentMegabytes}MB of {totalMegabytes}MB used",
   "errorSavingProject": "Something didn't work while auto-saving your project. Check your internet connection and try manually saving. If this problem persists, try reloading the page to start over.",
   "refreshPreview": "Refresh and Save",

--- a/apps/src/weblab/WebLab.js
+++ b/apps/src/weblab/WebLab.js
@@ -297,14 +297,19 @@ WebLab.prototype.init = function(config) {
     document.getElementById(config.containerId)
   );
 
-  window.onbeforeunload = evt => {
-    if (project.hasOwnerChangedProject()) {
-      // Manually trigger an autosave instead of waiting for the next autosave.
-      project.autosave();
+  window.addEventListener('beforeunload', this.beforeUnload.bind(this));
+};
 
-      return weblabMsg.confirmExitWithUnsavedChanges();
-    }
-  };
+WebLab.prototype.beforeUnload = function(event) {
+  if (project.hasOwnerChangedProject()) {
+    // Manually trigger an autosave instead of waiting for the next autosave.
+    project.autosave();
+
+    event.preventDefault();
+    event.returnValue = weblabMsg.confirmExitWithUnsavedChanges();
+  } else {
+    delete event.returnValue;
+  }
 };
 
 WebLab.prototype.reportResult = function(submit, validated) {

--- a/apps/src/weblab/WebLab.js
+++ b/apps/src/weblab/WebLab.js
@@ -299,6 +299,9 @@ WebLab.prototype.init = function(config) {
 
   window.onbeforeunload = evt => {
     if (project.hasOwnerChangedProject()) {
+      // Manually trigger an autosave instead of waiting for the next autosave.
+      project.autosave();
+
       return weblabMsg.confirmExitWithUnsavedChanges();
     }
   };

--- a/apps/src/weblab/WebLab.js
+++ b/apps/src/weblab/WebLab.js
@@ -5,7 +5,6 @@ import ReactDOM from 'react-dom';
 import consoleApi from '../consoleApi';
 import WebLabView from './WebLabView';
 import {Provider} from 'react-redux';
-import weblabMsg from '@cdo/weblab/locale';
 import {initializeSubmitHelper, onSubmitComplete} from '../submitHelper';
 import dom from '../dom';
 import reducers from './reducers';
@@ -306,7 +305,7 @@ WebLab.prototype.beforeUnload = function(event) {
     project.autosave();
 
     event.preventDefault();
-    event.returnValue = weblabMsg.confirmExitWithUnsavedChanges();
+    event.returnValue = '';
   } else {
     delete event.returnValue;
   }

--- a/apps/test/unit/weblab/weblabTest.js
+++ b/apps/test/unit/weblab/weblabTest.js
@@ -5,11 +5,60 @@ import {TestResults} from '@cdo/apps/constants';
 import project from '@cdo/apps/code-studio/initApp/project';
 import {onSubmitComplete} from '@cdo/apps/submitHelper';
 
-describe('Web Lab', () => {
-  let reportStub, weblab;
-  describe('onFinish', () => {
+describe('WebLab', () => {
+  let weblab;
+
+  beforeEach(() => {
+    weblab = new WebLab();
+  });
+
+  describe('beforeUnload', () => {
+    let eventStub;
+
     beforeEach(() => {
-      weblab = new WebLab();
+      sinon.stub(project, 'autosave');
+      eventStub = {
+        preventDefault: sinon.stub(),
+        returnValue: undefined
+      };
+    });
+
+    afterEach(() => {
+      project.autosave.restore();
+    });
+
+    it('triggers an autosave if there are unsaved changes', () => {
+      sinon.stub(project, 'hasOwnerChangedProject').returns(true);
+
+      weblab.beforeUnload(eventStub);
+
+      expect(project.autosave).to.have.been.calledOnce;
+      expect(eventStub.preventDefault).to.have.been.calledOnce;
+      expect(eventStub.returnValue).to.equal(
+        'Do you want to exit with unsaved changes?'
+      );
+
+      project.hasOwnerChangedProject.restore();
+    });
+
+    it('deletes event returnValue if there are no unsaved changes', () => {
+      sinon.stub(project, 'hasOwnerChangedProject').returns(false);
+      eventStub.returnValue = 'I should be deleted!';
+
+      weblab.beforeUnload(eventStub);
+
+      expect(project.autosave).to.not.have.been.called;
+      expect(eventStub.preventDefault).to.not.have.been.calledOnce;
+      expect(eventStub.returnValue).to.be.undefined;
+
+      project.hasOwnerChangedProject.restore();
+    });
+  });
+
+  describe('onFinish', () => {
+    let reportStub;
+
+    beforeEach(() => {
       reportStub = sinon.stub(weblab, 'reportResult');
     });
 
@@ -44,8 +93,8 @@ describe('Web Lab', () => {
       submitted: true,
       onComplete: onSubmitComplete
     };
+
     beforeEach(() => {
-      weblab = new WebLab();
       sinon.stub(project, 'autosave').callsArg(0);
       reportStub = sinon.stub();
       weblab.studioApp_ = {report: reportStub};
@@ -53,7 +102,6 @@ describe('Web Lab', () => {
     });
 
     afterEach(() => {
-      weblab = new WebLab();
       project.autosave.restore();
     });
 
@@ -61,16 +109,13 @@ describe('Web Lab', () => {
       weblab.reportResult(true, true);
       expect(reportStub).to.have.been.calledWith({
         ...defaultValues,
-        ...{
-          result: true,
-          testResult: TestResults.FREE_PLAY
-        }
+        result: true,
+        testResult: TestResults.FREE_PLAY
       });
     });
 
     it('calls report with failure conditions if validated is false', () => {
-      const feedbackStub = sinon.stub();
-      weblab.studioApp_.displayFeedback = feedbackStub;
+      weblab.studioApp_.displayFeedback = sinon.stub();
       weblab.reportResult(true, false);
       expect(reportStub).to.have.been.calledWith({
         ...defaultValues,

--- a/apps/test/unit/weblab/weblabTest.js
+++ b/apps/test/unit/weblab/weblabTest.js
@@ -34,9 +34,7 @@ describe('WebLab', () => {
 
       expect(project.autosave).to.have.been.calledOnce;
       expect(eventStub.preventDefault).to.have.been.calledOnce;
-      expect(eventStub.returnValue).to.equal(
-        'Do you want to exit with unsaved changes?'
-      );
+      expect(eventStub.returnValue).to.equal('');
 
       project.hasOwnerChangedProject.restore();
     });


### PR DESCRIPTION
WebLab uses [the autosave feature in project.js](https://github.com/code-dot-org/code-dot-org/blob/staging/apps/src/code-studio/initApp/project.js#L730-L733) (caveat: this feature can be turned off on individual levels by levelbuilders). When a user tries to navigate away from a WebLab level/project, we warn them if there are any unsaved changes to their project (always happens -- cannot be turned off by levelbuilders):

![Screen Shot 2021-02-26 at 3 30 18 PM](https://user-images.githubusercontent.com/9812299/109366210-ab7c6700-7847-11eb-81a2-cfe0383f2a05.png)

Previously, a user had to either 1) wait for the next autosave, or 2) click the "Refresh and Save" button to make this alert go away when attempting to navigate to another page. Now, we trigger an autosave and the alert will go away once the autosave has completed.

I also did some refactoring to make this handler testable and align more with MDN's recommendation for handling `beforeunload` events: https://developer.mozilla.org/en-US/docs/Web/API/WindowEventHandlers/onbeforeunload

## Links

- jira ticket: [STAR-808](https://codedotorg.atlassian.net/browse/STAR-808)

## Testing story

Added unit tests.

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [x] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [x] Code is well-commented
- [x] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [x] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
