### PR TITLE
[Spritelab] Add haiku block for CSC Pilot

### DIFF
--- a/apps/src/p5lab/spritelab/commands.js
+++ b/apps/src/p5lab/spritelab/commands.js
@@ -1,5 +1,6 @@
 import {commands as actionCommands} from './commands/actionCommands';
 import {commands as behaviorCommands} from './commands/behaviorCommands';
+import {commands as customLessonCommands} from './commands/customLessonCommands';
 import {commands as eventCommands} from './commands/eventCommands';
 import {commands as locationCommands} from './commands/locationCommands';
 import {commands as spriteCommands} from './commands/spriteCommands';
@@ -19,24 +20,18 @@ function drawBackground() {
   }
 }
 
-function updateTitle() {
-  this.fill('black');
-  this.stroke('white');
-  this.strokeWeight(3);
-  this.textAlign(this.CENTER, this.CENTER);
-  this.textSize(50);
-  this.text(coreLibrary.title, 0, 0, 400, 200);
-  this.textSize(35);
-  this.text(coreLibrary.subtitle, 0, 200, 400, 200);
-}
-
 export const commands = {
   executeDrawLoopAndCallbacks() {
     drawBackground.apply(this);
     coreLibrary.runBehaviors();
     coreLibrary.runEvents(this);
     this.drawSprites();
-    updateTitle.apply(this);
+    if (coreLibrary.screenText.title || coreLibrary.screenText.subtitle) {
+      worldCommands.drawTitle.apply(this);
+    }
+    if (coreLibrary.screenText.haiku) {
+      customLessonCommands.drawHaiku.apply(this);
+    }
   },
 
   // Action commands
@@ -336,5 +331,24 @@ export const commands = {
 
   getTitle() {
     return validationCommands.getTitle();
+  },
+
+  // Custom Lesson Commands
+  // These are blocks that are custom built for a particular lesson
+  getHaiku() {
+    return customLessonCommands.getHaiku();
+  },
+  hideHaiku() {
+    customLessonCommands.hideHaiku();
+  },
+  printHaiku(title, author, line1, line2, line3) {
+    customLessonCommands.printHaiku.apply(this, [
+      // default to empty string for any args not provided
+      title || '',
+      author || '',
+      line1 || '',
+      line2 || '',
+      line3 || ''
+    ]);
   }
 };

--- a/apps/src/p5lab/spritelab/commands.js
+++ b/apps/src/p5lab/spritelab/commands.js
@@ -338,9 +338,11 @@ export const commands = {
   getHaiku() {
     return customLessonCommands.getHaiku();
   },
+
   hideHaiku() {
     customLessonCommands.hideHaiku();
   },
+
   printHaiku(title, author, line1, line2, line3) {
     customLessonCommands.printHaiku.apply(this, [
       // default to empty string for any args not provided

--- a/apps/src/p5lab/spritelab/commands/customLessonCommands.js
+++ b/apps/src/p5lab/spritelab/commands/customLessonCommands.js
@@ -1,0 +1,56 @@
+import * as coreLibrary from '../coreLibrary';
+
+export const commands = {
+  // Haiku lesson in content integration pilot 2021
+  drawHaiku() {
+    const haiku = coreLibrary.screenText.haiku;
+    if (!haiku) {
+      return;
+    }
+    this.textAlign(this.CENTER, this.CENTER);
+    this.stroke('white');
+    this.fill('black');
+    this.strokeWeight(2);
+    this.textFont('Courier New');
+    this.textStyle(this.BOLD);
+    const defaultSize = 25;
+
+    const scaleTextSize = (scaleMultiplier, text) => {
+      const oldTextSize = this.textSize();
+      this.textSize(defaultSize * scaleMultiplier);
+      const size = Math.min(
+        defaultSize * scaleMultiplier,
+        (defaultSize * scaleMultiplier * 370) / this.textWidth(text)
+      );
+      this.textSize(oldTextSize);
+      return size;
+    };
+
+    this.textSize(scaleTextSize(1.6, haiku.title));
+    this.text(haiku.title, 200, 75);
+
+    this.textSize(scaleTextSize(0.8, haiku.author));
+    this.text(haiku.author, 200, 115);
+
+    this.textSize(scaleTextSize(1, haiku.line1));
+    this.text(haiku.line1, 200, 175);
+    this.textSize(scaleTextSize(1, haiku.line2));
+    this.text(haiku.line2, 200, 225);
+    this.textSize(scaleTextSize(1, haiku.line3));
+    this.text(haiku.line3, 200, 275);
+  },
+
+  getHaiku() {
+    return coreLibrary.screenText.haiku;
+  },
+
+  hideHaiku() {
+    coreLibrary.screenText = {};
+  },
+
+  printHaiku(title, author, line1, line2, line3) {
+    coreLibrary.screenText = {
+      haiku: {title, author, line1, line2, line3}
+    };
+  }
+};

--- a/apps/src/p5lab/spritelab/commands/customLessonCommands.js
+++ b/apps/src/p5lab/spritelab/commands/customLessonCommands.js
@@ -1,7 +1,7 @@
 import * as coreLibrary from '../coreLibrary';
 
 export const commands = {
-  // Haiku lesson in content integration pilot 2021
+  // Haiku lesson in CS connections pilot 2021
   drawHaiku() {
     const haiku = coreLibrary.screenText.haiku;
     if (!haiku) {

--- a/apps/src/p5lab/spritelab/commands/customLessonCommands.js
+++ b/apps/src/p5lab/spritelab/commands/customLessonCommands.js
@@ -7,6 +7,8 @@ export const commands = {
     if (!haiku) {
       return;
     }
+    // Start a new drawing layer so changing things like stroke, fill, etc won't overwrite existing values
+    this.push();
     this.textAlign(this.CENTER, this.CENTER);
     this.stroke('white');
     this.fill('black');
@@ -15,14 +17,26 @@ export const commands = {
     this.textStyle(this.BOLD);
     const defaultSize = 25;
 
+    // Compute how much space the given text would take up at the specified size
+    const computeTextWidth = (text, size) => {
+      this.push();
+      this.textSize(size);
+      const width = this.textWidth(text);
+      this.pop();
+      return width;
+    };
+
+    // Computes the right size for the specified text based on the desired scale
+    // multiplier, scaled down to fit on the screen if necessary.
     const scaleTextSize = (scaleMultiplier, text) => {
-      const oldTextSize = this.textSize();
-      this.textSize(defaultSize * scaleMultiplier);
+      const desiredSize = defaultSize * scaleMultiplier;
+      // The playspace is 400x400. We should leave a slight margin on either side,
+      // so the available width for each line of text is 370.
+      const availableWidth = 370;
       const size = Math.min(
-        defaultSize * scaleMultiplier,
-        (defaultSize * scaleMultiplier * 370) / this.textWidth(text)
+        desiredSize,
+        (desiredSize * availableWidth) / computeTextWidth(text, desiredSize)
       );
-      this.textSize(oldTextSize);
       return size;
     };
 
@@ -38,6 +52,9 @@ export const commands = {
     this.text(haiku.line2, 200, 225);
     this.textSize(scaleTextSize(1, haiku.line3));
     this.text(haiku.line3, 200, 275);
+
+    // Restore the original drawing layer
+    this.pop();
   },
 
   getHaiku() {

--- a/apps/src/p5lab/spritelab/commands/validationCommands.js
+++ b/apps/src/p5lab/spritelab/commands/validationCommands.js
@@ -38,6 +38,9 @@ export const commands = {
   },
 
   getTitle() {
-    return {title: coreLibrary.title, subtitle: coreLibrary.subtitle};
+    return {
+      title: coreLibrary.screenText.title,
+      subtitle: coreLibrary.screenText.subtitle
+    };
   }
 };

--- a/apps/src/p5lab/spritelab/commands/worldCommands.js
+++ b/apps/src/p5lab/spritelab/commands/worldCommands.js
@@ -8,6 +8,17 @@ export const commands = {
     /* no-op */
   },
 
+  drawTitle() {
+    this.fill('black');
+    this.stroke('white');
+    this.strokeWeight(3);
+    this.textAlign(this.CENTER, this.CENTER);
+    this.textSize(50);
+    this.text(coreLibrary.screenText.title, 0, 0, 400, 200);
+    this.textSize(35);
+    this.text(coreLibrary.screenText.subtitle, 0, 200, 400, 200);
+  },
+
   getTime(unit) {
     if (unit === 'seconds') {
       return coreLibrary.getAdjustedWorldTime(this) || 0;
@@ -18,7 +29,7 @@ export const commands = {
   },
 
   hideTitleScreen() {
-    coreLibrary.title = coreLibrary.subtitle = '';
+    coreLibrary.screenText = {};
   },
 
   printText(text) {
@@ -61,8 +72,7 @@ export const commands = {
   },
 
   showTitleScreen(title, subtitle) {
-    coreLibrary.title = title || '';
-    coreLibrary.subtitle = subtitle || '';
+    coreLibrary.screenText = {title: title || '', subtitle: subtitle || ''};
   },
 
   textJoin(text1, text2) {

--- a/apps/src/p5lab/spritelab/coreLibrary.js
+++ b/apps/src/p5lab/spritelab/coreLibrary.js
@@ -8,8 +8,7 @@ var totalPauseTime = 0;
 var currentPauseStartTime = 0;
 
 export var background;
-export var title = '';
-export var subtitle = '';
+export var screenText = {};
 export var defaultSpriteSize = 100;
 export var printLog = [];
 export var promptVars = {};
@@ -20,12 +19,12 @@ export function reset() {
   inputEvents = [];
   behaviors = [];
   background = 'white';
-  title = subtitle = '';
   userInputEventCallbacks = {};
   defaultSpriteSize = 100;
   totalPauseTime = 0;
   printLog = [];
   promptVars = {};
+  screenText = {};
 }
 
 export function startPause(time) {

--- a/apps/test/unit/p5lab/spritelab/validationCommandsTest.js
+++ b/apps/test/unit/p5lab/spritelab/validationCommandsTest.js
@@ -5,14 +5,20 @@ import * as coreLibrary from '@cdo/apps/p5lab/spritelab/coreLibrary';
 
 describe('Validation Commands', () => {
   it('getTitle', () => {
-    expect(commands.getTitle()).to.deep.equal({title: '', subtitle: ''});
+    expect(commands.getTitle()).to.deep.equal({
+      title: undefined,
+      subtitle: undefined
+    });
     worldCommands.showTitleScreen('my title', 'my subtitle');
     expect(commands.getTitle()).to.deep.equal({
       title: 'my title',
       subtitle: 'my subtitle'
     });
     worldCommands.hideTitleScreen();
-    expect(commands.getTitle()).to.deep.equal({title: '', subtitle: ''});
+    expect(commands.getTitle()).to.deep.equal({
+      title: undefined,
+      subtitle: undefined
+    });
   });
 
   it('getPrintLog', () => {

--- a/dashboard/config/blocks/GamelabJr/gamelab_hideHaiku.json
+++ b/dashboard/config/blocks/GamelabJr/gamelab_hideHaiku.json
@@ -1,0 +1,15 @@
+{
+  "category": "World",
+  "config": {
+    "color": [
+      240,
+      0.45,
+      0.65
+    ],
+    "func": "hideHaiku",
+    "blockText": "hide haiku",
+    "args": [
+
+    ]
+  }
+}

--- a/dashboard/config/blocks/GamelabJr/gamelab_printHaiku.json
+++ b/dashboard/config/blocks/GamelabJr/gamelab_printHaiku.json
@@ -1,8 +1,13 @@
 {
   "category": "",
   "config": {
+    "color": [
+      240,
+      0.45,
+      0.65
+    ],
     "func": "printHaiku",
-    "blockText": "print haiku {BREAK} poem title {TITLE} poem author {AUTHOR} line 1 {LINE1} line 2 {LINE2} line 3 {LINE3}",
+    "blockText": "show haiku {BREAK} poem title {TITLE} poem author {AUTHOR} line 1 {LINE1} line 2 {LINE2} line 3 {LINE3}",
     "args": [
       {
         "name": "BREAK",

--- a/dashboard/config/blocks/GamelabJr/gamelab_printHaiku.json
+++ b/dashboard/config/blocks/GamelabJr/gamelab_printHaiku.json
@@ -1,0 +1,34 @@
+{
+  "category": "",
+  "config": {
+    "func": "printHaiku",
+    "blockText": "print haiku {BREAK} poem title {TITLE} poem author {AUTHOR} line 1 {LINE1} line 2 {LINE2} line 3 {LINE3}",
+    "args": [
+      {
+        "name": "BREAK",
+        "dummy": true
+      },
+      {
+        "name": "TITLE",
+        "type": "String"
+      },
+      {
+        "name": "AUTHOR",
+        "type": "String"
+      },
+      {
+        "name": "LINE1",
+        "type": "String"
+      },
+      {
+        "name": "LINE2",
+        "type": "String"
+      },
+      {
+        "name": "LINE3",
+        "type": "String"
+      }
+    ],
+    "inline": false
+  }
+}


### PR DESCRIPTION
New blocks for Amy's pilot. Modeled almost exactly after the prototype here: https://levelbuilder-studio.code.org/s/2021drafting/stage/7/puzzle/1 which used [this library](https://levelbuilder-studio.code.org/libraries/zHaikuPrototype/edit)
![image](https://user-images.githubusercontent.com/8787187/109547786-a9e9b380-7a80-11eb-8f0e-3c6a4bd1b1ce.png)
![image](https://user-images.githubusercontent.com/8787187/109547822-b53cdf00-7a80-11eb-8c3f-0dbe7e76d0a1.png)

Example:
![image](https://user-images.githubusercontent.com/8787187/109548013-f46b3000-7a80-11eb-9e5e-eab560374703.png)

As a longer term issue, we should decided how we want to handle blocks that are used in only one lesson (a scenario that is likely to be more common with CSC). But I don't think we should block this PR on that, since it's needed for the pilot starting next week.


## Testing story

Manually tested

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
