### PR TITLE
[Levelbuilder] Fix JS errors on level edit page

### DIFF
--- a/apps/src/p5lab/spritelab/blocks.js
+++ b/apps/src/p5lab/spritelab/blocks.js
@@ -499,7 +499,7 @@ export default {
         // blocks, disallow editing the behavior, because renaming the behavior
         // can break things.
         if (
-          appOptions && // appOptions is not available on level edit page
+          window.appOptions && // global appOptions is not available on level edit page
           appOptions.level.toolbox &&
           !appOptions.readonlyWorkspace &&
           !Blockly.hasCategories

--- a/apps/src/sites/studio/pages/levels/editors/fields/_validation_code.js
+++ b/apps/src/sites/studio/pages/levels/editors/fields/_validation_code.js
@@ -11,7 +11,7 @@ function initPage() {
     embed.on('click', () => syncValidateWithElements(embed, widgetMode));
     widgetMode.on('click', () => syncValidateWithElements(embed, widgetMode));
   }
-  if ($('#level_validation_code')) {
+  if ($('#level_validation_code').length > 0) {
     initializeCodeMirror('level_validation_code', 'javascript');
   }
 }


### PR DESCRIPTION
Follow up to https://github.com/code-dot-org/code-dot-org/pull/37381
The issue is just that `$('#level_validation_code')` is always truthy. What we need to check is `$('#level_validation_code').length` to determine if there's actually an element.

Still works for levels with JS validation:
![image](https://user-images.githubusercontent.com/8787187/109554701-6778a480-7a89-11eb-9410-93d82ad6b081.png)

And now the callout button works as expected:
![image](https://user-images.githubusercontent.com/8787187/109554737-77908400-7a89-11eb-8518-4d1d28ad800d.png)

Also while I'm in here, fix a broken guard for `appOptions` that was also causing JS errors on the LB edit page
![image](https://user-images.githubusercontent.com/8787187/109554976-d48c3a00-7a89-11eb-9634-97f09c482e6a.png)


## Links

[slack thread](https://codedotorg.slack.com/archives/C1B3PNDL7/p1614622370041600)

## Testing story
Manually confirmed that JS errors are no longer present

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
