### PR TITLE
Add image/jpg to ALLOWED_CONTENT_TYPES

### DIFF
--- a/dashboard/app/controllers/media_proxy_controller.rb
+++ b/dashboard/app/controllers/media_proxy_controller.rb
@@ -21,6 +21,8 @@ class MediaProxyController < ApplicationController
       'image/x-windows-bmp',
       'image/gif',
       'image/jpeg',
+      # image/jpg is not a valid content type but is used by some content providers, so we are supporting it.
+      'image/jpg',
       'image/png',
       'image/svg+xml',
       'audio/basic',


### PR DESCRIPTION
Add `image/jpg` to list of allowed content-type headers in our media proxy. This isn't technically a valid MIME type (`image/jpeg` is the correct type to use here), but some providers still use it, so we want to support it:

<img width="753" alt="Screen Shot 2021-03-01 at 1 12 20 PM" src="https://user-images.githubusercontent.com/9812299/109559673-cf31ee00-7a8f-11eb-8582-a98d3047333d.png">


## Links

- jira ticket: [STAR-1465](https://codedotorg.atlassian.net/browse/STAR-1465)

## Testing story

Manually tested with `https://mars.nasa.gov/mars2020-raw-images/pub/ods/surface/sol/00004/ids/edr/browse/edl/ESF_0004_0667289069_518ECM_N0010052EDLC00004_0010LUJ01_1200.jpg` (the example image in the screenshot above).