### PR TITLE
Updating the admin pilot "add teacher" form to accept multiple emails

### DIFF
--- a/dashboard/app/controllers/admin_search_controller.rb
+++ b/dashboard/app/controllers/admin_search_controller.rb
@@ -84,10 +84,10 @@ class AdminSearchController < ApplicationController
   def add_to_pilot
     emails = params[:email]
     pilot_name = params[:pilot_name]
-    email_array = emails.split("\n").map(&:strip)
+    return head :bad_request unless Experiment::PILOT_EXPERIMENTS.find {|p| p[:name] == pilot_name}
+    email_array = emails.split("\n")
     email_array.each do |email|
-      email = email.gsub(/[\s,]/, "")
-      return head :bad_request unless Experiment::PILOT_EXPERIMENTS.find {|p| p[:name] == pilot_name}
+      email = email.strip.gsub(/[\s,]/, "")
       user = User.find_by_email_or_hashed_email(email)
       if !user
         flash[:alert] = "An account with the email address #{email} does not exist"

--- a/dashboard/app/controllers/admin_search_controller.rb
+++ b/dashboard/app/controllers/admin_search_controller.rb
@@ -80,11 +80,13 @@ class AdminSearchController < ApplicationController
     @emails = User.where(id: user_ids).pluck(:email)
   end
 
+  # Parses newline separated emails, ignores commas and whitespace
   def add_to_pilot
     emails = params[:email]
     pilot_name = params[:pilot_name]
-    email_array = emails.split(",").map(&:strip)
+    email_array = emails.split("\n").map(&:strip)
     email_array.each do |email|
+      email = email.gsub(/[\s,]/, "")
       return head :bad_request unless Experiment::PILOT_EXPERIMENTS.find {|p| p[:name] == pilot_name}
       user = User.find_by_email_or_hashed_email(email)
       if !user

--- a/dashboard/app/controllers/admin_search_controller.rb
+++ b/dashboard/app/controllers/admin_search_controller.rb
@@ -81,17 +81,20 @@ class AdminSearchController < ApplicationController
   end
 
   def add_to_pilot
-    email = params[:email]
+    emails = params[:email]
     pilot_name = params[:pilot_name]
-    return head :bad_request unless Experiment::PILOT_EXPERIMENTS.find {|p| p[:name] == pilot_name}
-    user = User.find_by_email_or_hashed_email(email)
-    if !user
-      flash[:alert] = "An account with the email address #{email} does not exist"
-    elsif user.student?
-      flash[:alert] = "Cannot add a student to the pilot"
-    else
-      SingleUserExperiment.find_or_create_by!(min_user_id: user.id, name: pilot_name)
-      flash[:notice] = "Successfully added #{email} to #{pilot_name}!"
+    email_array = emails.split(",").map(&:strip)
+    email_array.each do |email|
+      return head :bad_request unless Experiment::PILOT_EXPERIMENTS.find {|p| p[:name] == pilot_name}
+      user = User.find_by_email_or_hashed_email(email)
+      if !user
+        flash[:alert] = "An account with the email address #{email} does not exist"
+      elsif user.student?
+        flash[:alert] = "Cannot add a student to the pilot"
+      else
+        SingleUserExperiment.find_or_create_by!(min_user_id: user.id, name: pilot_name)
+        flash[:notice] = "Successfully added #{email} to #{pilot_name}!"
+      end
     end
     redirect_to action: 'show_pilot', pilot_name: pilot_name
   end

--- a/dashboard/app/views/admin_search/show_pilot.html.haml
+++ b/dashboard/app/views/admin_search/show_pilot.html.haml
@@ -1,9 +1,12 @@
 %h1
   = @pilot_name
-%h2 Input form below now accepts multiple emails!
-%h5 Ex: teach@school.org, teach2@school.org, teach3@school.org
+%h2 Enter a single email address, or several!
+%h5 Separate emails by line. For example:
+%h6 teach@school.org
+%h6 teach2@school.org
+%h6 teach3@school.org
 = form_tag controller: 'admin_search', action: 'add_to_pilot', method: "post" do
-  = text_field_tag :email, nil, placeholder: "Teacher's email(s)", style: 'margin-bottom: 0'
+  = text_area_tag :email, nil, width: '300px', height: '300px'
   = hidden_field_tag 'pilot_name', @pilot_name
   = submit_tag "Add", class: 'btn'
 %table

--- a/dashboard/app/views/admin_search/show_pilot.html.haml
+++ b/dashboard/app/views/admin_search/show_pilot.html.haml
@@ -1,7 +1,9 @@
 %h1
   = @pilot_name
+%h2 Input form below now accepts multiple emails!
+%h5 Ex: teach@school.org, teach2@school.org, teach3@school.org
 = form_tag controller: 'admin_search', action: 'add_to_pilot', method: "post" do
-  = text_field_tag :email, nil, placeholder: "Teacher's email", style: 'margin-bottom: 0'
+  = text_field_tag :email, nil, placeholder: "Teacher's email(s)", style: 'margin-bottom: 0'
   = hidden_field_tag 'pilot_name', @pilot_name
   = submit_tag "Add", class: 'btn'
 %table

--- a/dashboard/app/views/admin_search/show_pilot.html.haml
+++ b/dashboard/app/views/admin_search/show_pilot.html.haml
@@ -1,10 +1,9 @@
 %h1
   = @pilot_name
 %h2 Enter a single email address, or several!
-%h5 Separate emails by line. For example:
-%h6 teach@school.org
-%h6 teach2@school.org
-%h6 teach3@school.org
+%p Separate emails by line. For example:
+%p teacher@school.org<br>teacher2@school.org<br>teacher3@school.org
+%p Note: Use the lower right-hand corner to drag the box to any size.
 = form_tag controller: 'admin_search', action: 'add_to_pilot', method: "post" do
   = text_area_tag :email, nil, width: '300px', height: '300px'
   = hidden_field_tag 'pilot_name', @pilot_name
@@ -12,7 +11,7 @@
 %table
   %tr
     %th
-      %span Email
+      %span Current Pilot Participants
   - @emails.each do |email|
     %tr
       %td

--- a/dashboard/test/controllers/admin_search_controller_test.rb
+++ b/dashboard/test/controllers/admin_search_controller_test.rb
@@ -178,7 +178,7 @@ class AdminSearchControllerTest < ActionController::TestCase
     assert SingleUserExperiment.find_by(min_user_id: teacher2.id, name: pilot_name).present?
   end
 
-  test 'even if first email fails, second given will work successfully' do
+  test 'if first email fails, second given will work successfully' do
     student = create :student
     teacher = create :teacher
     pilot_name = 'csd-piloters'

--- a/dashboard/test/controllers/admin_search_controller_test.rb
+++ b/dashboard/test/controllers/admin_search_controller_test.rb
@@ -152,7 +152,7 @@ class AdminSearchControllerTest < ActionController::TestCase
     teacher = create :teacher
     teacher2 = create :teacher
     pilot_name = 'csd-piloters'
-    post :add_to_pilot, params: {email: teacher.email + "'\n'" + teacher2.email, pilot_name: pilot_name}
+    post :add_to_pilot, params: {email: teacher.email + "\n" + teacher2.email, pilot_name: pilot_name}
 
     assert SingleUserExperiment.find_by(min_user_id: teacher.id, name: pilot_name).present?
     assert SingleUserExperiment.find_by(min_user_id: teacher2.id, name: pilot_name).present?
@@ -162,7 +162,7 @@ class AdminSearchControllerTest < ActionController::TestCase
     teacher = create :teacher
     teacher2 = create :teacher
     pilot_name = 'csd-piloters'
-    post :add_to_pilot, params: {email: teacher.email + " '\n'" + teacher2.email, pilot_name: pilot_name}
+    post :add_to_pilot, params: {email: teacher.email + " \n" + teacher2.email, pilot_name: pilot_name}
 
     assert SingleUserExperiment.find_by(min_user_id: teacher.id, name: pilot_name).present?
     assert SingleUserExperiment.find_by(min_user_id: teacher2.id, name: pilot_name).present?
@@ -172,7 +172,7 @@ class AdminSearchControllerTest < ActionController::TestCase
     teacher = create :teacher
     teacher2 = create :teacher
     pilot_name = 'csd-piloters'
-    post :add_to_pilot, params: {email: teacher.email + ",'\n'" + teacher2.email, pilot_name: pilot_name}
+    post :add_to_pilot, params: {email: teacher.email + ",\n" + teacher2.email, pilot_name: pilot_name}
 
     assert SingleUserExperiment.find_by(min_user_id: teacher.id, name: pilot_name).present?
     assert SingleUserExperiment.find_by(min_user_id: teacher2.id, name: pilot_name).present?
@@ -182,10 +182,10 @@ class AdminSearchControllerTest < ActionController::TestCase
     student = create :student
     teacher = create :teacher
     pilot_name = 'csd-piloters'
-    post :add_to_pilot, params: {email: student.email + "'\n'" + teacher.email, pilot_name: pilot_name}
+    post :add_to_pilot, params: {email: student.email + "\n" + teacher.email, pilot_name: pilot_name}
 
     refute SingleUserExperiment.find_by(min_user_id: student.id, name: pilot_name).present?
-    assert SingleUserExperiment.find_by(min_user_id: teacher5.id, name: pilot_name).present?
+    assert SingleUserExperiment.find_by(min_user_id: teacher.id, name: pilot_name).present?
   end
 
   test 'if middle user is not found, first and third still work successfully' do
@@ -193,7 +193,7 @@ class AdminSearchControllerTest < ActionController::TestCase
     teacher2 = create :teacher
     pilot_name = 'csd-piloters'
     post :add_to_pilot, params: {
-      email: teacher.email + "'\n'fake@fakey1.fake'\n'" + teacher2.email, pilot_name: pilot_name
+      email: teacher.email + "\nfake@fakey1.fake\n" + teacher2.email, pilot_name: pilot_name
     }
 
     assert SingleUserExperiment.find_by(min_user_id: teacher.id, name: pilot_name).present?
@@ -214,10 +214,10 @@ class AdminSearchControllerTest < ActionController::TestCase
     teacher11 = create :teacher
     pilot_name = 'csd-piloters'
     post :add_to_pilot, params: {
-      email: teacher.email + "'\n'" + teacher2.email + "'\n'" + teacher3.email +
-      teacher4.email + "'\n'" + teacher5.email + "'\n'" + teacher6.email +
-      teacher7.email + "'\n'" + teacher8.email + "'\n'" + teacher9.email +
-      teacher10.email + "'\n'" + teacher11.email, pilot_name: pilot_name
+      email: teacher.email + "\n" + teacher2.email + "\n" + teacher3.email + "\n" +
+      teacher4.email + "\n" + teacher5.email + "\n" + teacher6.email + "\n" +
+      teacher7.email + "\n" + teacher8.email + "\n" + teacher9.email + "\n" +
+      teacher10.email + "\n" + teacher11.email, pilot_name: pilot_name
     }
 
     assert SingleUserExperiment.find_by(min_user_id: teacher.id, name: pilot_name).present?

--- a/dashboard/test/controllers/admin_search_controller_test.rb
+++ b/dashboard/test/controllers/admin_search_controller_test.rb
@@ -148,6 +148,36 @@ class AdminSearchControllerTest < ActionController::TestCase
     assert SingleUserExperiment.find_by(min_user_id: teacher.id, name: pilot_name).present?
   end
 
+  test 'can add multiple teachers to pilot' do
+    teacher = create :teacher
+    teacher2 = create :teacher
+    pilot_name = 'csd-piloters'
+    post :add_to_pilot, params: {email: teacher.email + "'\n'" + teacher2.email, pilot_name: pilot_name}
+
+    assert SingleUserExperiment.find_by(min_user_id: teacher.id, name: pilot_name).present?
+    assert SingleUserExperiment.find_by(min_user_id: teacher2.id, name: pilot_name).present?
+  end
+
+  test 'can add multiple teachers to pilot with incorrect formatting' do
+    teacher3 = create :teacher
+    teacher4 = create :teacher
+    pilot_name = 'csd-piloters'
+    post :add_to_pilot, params: {email: teacher3.email + " '\n'" + teacher4.email, pilot_name: pilot_name}
+
+    assert SingleUserExperiment.find_by(min_user_id: teacher3.id, name: pilot_name).present?
+    assert SingleUserExperiment.find_by(min_user_id: teacher4.id, name: pilot_name).present?
+  end
+
+  test 'even if first email fails, second given will work successfully' do
+    student2 = create :student
+    teacher5 = create :teacher
+    pilot_name = 'csd-piloters'
+    post :add_to_pilot, params: {email: student2.email + "'\n'" + teacher5.email, pilot_name: pilot_name}
+
+    refute SingleUserExperiment.find_by(min_user_id: student.id, name: pilot_name).present?
+    assert SingleUserExperiment.find_by(min_user_id: teacher5.id, name: pilot_name).present?
+  end
+
   test 'cannot add student to pilot' do
     student = create :student
     pilot_name = 'csd-piloters'

--- a/dashboard/test/controllers/admin_search_controller_test.rb
+++ b/dashboard/test/controllers/admin_search_controller_test.rb
@@ -158,24 +158,63 @@ class AdminSearchControllerTest < ActionController::TestCase
     assert SingleUserExperiment.find_by(min_user_id: teacher2.id, name: pilot_name).present?
   end
 
-  test 'can add multiple teachers to pilot with incorrect formatting' do
-    teacher3 = create :teacher
-    teacher4 = create :teacher
+  test 'can add multiple teachers to pilot with extra spaces' do
+    teacher = create :teacher
+    teacher2 = create :teacher
     pilot_name = 'csd-piloters'
-    post :add_to_pilot, params: {email: teacher3.email + " '\n'" + teacher4.email, pilot_name: pilot_name}
+    post :add_to_pilot, params: {email: teacher.email + " '\n'" + teacher2.email, pilot_name: pilot_name}
 
-    assert SingleUserExperiment.find_by(min_user_id: teacher3.id, name: pilot_name).present?
-    assert SingleUserExperiment.find_by(min_user_id: teacher4.id, name: pilot_name).present?
+    assert SingleUserExperiment.find_by(min_user_id: teacher.id, name: pilot_name).present?
+    assert SingleUserExperiment.find_by(min_user_id: teacher2.id, name: pilot_name).present?
+  end
+
+  test 'can add multiple teachers to pilot with extra commas' do
+    teacher = create :teacher
+    teacher2 = create :teacher
+    pilot_name = 'csd-piloters'
+    post :add_to_pilot, params: {email: teacher.email + ",'\n'" + teacher2.email, pilot_name: pilot_name}
+
+    assert SingleUserExperiment.find_by(min_user_id: teacher.id, name: pilot_name).present?
+    assert SingleUserExperiment.find_by(min_user_id: teacher2.id, name: pilot_name).present?
   end
 
   test 'even if first email fails, second given will work successfully' do
-    student2 = create :student
-    teacher5 = create :teacher
+    student = create :student
+    teacher = create :teacher
     pilot_name = 'csd-piloters'
-    post :add_to_pilot, params: {email: student2.email + "'\n'" + teacher5.email, pilot_name: pilot_name}
+    post :add_to_pilot, params: {email: student.email + "'\n'" + teacher.email, pilot_name: pilot_name}
 
     refute SingleUserExperiment.find_by(min_user_id: student.id, name: pilot_name).present?
     assert SingleUserExperiment.find_by(min_user_id: teacher5.id, name: pilot_name).present?
+  end
+
+  test 'longer list of emails works correctly' do
+    teacher = create :teacher
+    teacher2 = create :teacher
+    teacher3 = create :teacher
+    teacher4 = create :teacher
+    teacher5 = create :teacher
+    teacher6 = create :teacher
+    teacher7 = create :teacher
+    teacher8 = create :teacher
+    teacher9 = create :teacher
+    teacher10 = create :teacher
+    teacher11 = create :teacher
+    pilot_name = 'csd-piloters'
+    post :add_to_pilot, params: {
+      email: teacher.email + "'\n'" + teacher2.email + "'\n'" + teacher3.email +
+      teacher4.email + "'\n'" + teacher5.email + "'\n'" + teacher6.email +
+      teacher7.email + "'\n'" + teacher8.email + "'\n'" + teacher9.email +
+      teacher10.email + "'\n'" + teacher11.email, pilot_name: pilot_name
+    }
+
+    assert SingleUserExperiment.find_by(min_user_id: teacher.id, name: pilot_name).present?
+    assert SingleUserExperiment.find_by(min_user_id: teacher2.id, name: pilot_name).present?
+    assert SingleUserExperiment.find_by(min_user_id: teacher3.id, name: pilot_name).present?
+    assert SingleUserExperiment.find_by(min_user_id: teacher6.id, name: pilot_name).present?
+    assert SingleUserExperiment.find_by(min_user_id: teacher9.id, name: pilot_name).present?
+    assert SingleUserExperiment.find_by(min_user_id: teacher10.id, name: pilot_name).present?
+    assert SingleUserExperiment.find_by(min_user_id: teacher11.id, name: pilot_name).present?
   end
 
   test 'cannot add student to pilot' do

--- a/dashboard/test/controllers/admin_search_controller_test.rb
+++ b/dashboard/test/controllers/admin_search_controller_test.rb
@@ -188,6 +188,18 @@ class AdminSearchControllerTest < ActionController::TestCase
     assert SingleUserExperiment.find_by(min_user_id: teacher5.id, name: pilot_name).present?
   end
 
+  test 'if middle user is not found, first and third still work successfully' do
+    teacher = create :teacher
+    teacher2 = create :teacher
+    pilot_name = 'csd-piloters'
+    post :add_to_pilot, params: {
+      email: teacher.email + "'\n'fake@fakey1.fake'\n'" + teacher2.email, pilot_name: pilot_name
+    }
+
+    assert SingleUserExperiment.find_by(min_user_id: teacher.id, name: pilot_name).present?
+    assert SingleUserExperiment.find_by(min_user_id: teacher2.id, name: pilot_name).present?
+  end
+
   test 'longer list of emails works correctly' do
     teacher = create :teacher
     teacher2 = create :teacher


### PR DESCRIPTION
The current pilot "add teacher" form only allows teacher emails to be added one at a time. This update will allow for multiple emails to be entered at once (separated by newline), increasing the speed at which we can get pilots up and running. See images to illustrate:

![PilotSingleEmails](https://user-images.githubusercontent.com/37230822/109568361-aa437800-7a9b-11eb-962f-fa0b6ffca2b6.jpg)

![PilotMultEmailsEnter](https://user-images.githubusercontent.com/37230822/109729566-e98dc980-7b6c-11eb-9bb3-d0ab57ecffa6.jpg)


The alerts for the input of two correct emails and one nonexistent user: 
![PilotSuccessandFailure](https://user-images.githubusercontent.com/37230822/109733251-95d2ae80-7b73-11eb-8e6d-e694ff267152.jpg)


https://codedotorg.atlassian.net/browse/LP-1728

I've added tests to ensure multiple emails can be added, and that incorrect formatting won't be prohibitive. I've also added a test to check that if the first email is correctly rejected, the second will still go through. 