### PR TITLE
Javalab: Enable file naming

### DIFF
--- a/apps/src/javalab/JavalabEditor.jsx
+++ b/apps/src/javalab/JavalabEditor.jsx
@@ -69,6 +69,46 @@ class JavalabEditor extends React.Component {
     };
   };
 
+  displayFileRename() {
+    return (
+      <div style={style.tabs}>
+        <div style={style.tab}>
+          <input
+            type="text"
+            ariaLabel="file name"
+            value={this.props.fileName}
+            onChange={e => this.props.setFileName(e.target.value)}
+            onBlur={() => this.setState({renameFileActive: false})}
+          />
+        </div>
+        <button
+          type="button"
+          onClick={() => this.setState({renameFileActive: false})}
+          className="btn btn-default btn-sm"
+          style={style.button}
+        >
+          Save
+        </button>
+      </div>
+    );
+  }
+
+  displayFileNameAndRenameButton() {
+    return (
+      <div style={style.tabs}>
+        <div style={style.tab}>{this.props.fileName}</div>
+        <button
+          type="button"
+          onClick={() => this.setState({renameFileActive: true})}
+          className="btn btn-default btn-sm"
+          style={style.button}
+        >
+          Rename
+        </button>
+      </div>
+    );
+  }
+
   render() {
     return (
       <div style={this.props.style}>
@@ -76,39 +116,9 @@ class JavalabEditor extends React.Component {
           <PaneSection>Editor</PaneSection>
         </PaneHeader>
         <div>
-          {this.state.renameFileActive ? (
-            <div style={style.tabs}>
-              <div style={style.tab}>
-                <input
-                  type="text"
-                  ariaLabel="file name"
-                  value={this.props.fileName}
-                  onChange={e => this.props.setFileName(e.target.value)}
-                  onBlur={() => this.setState({renameFileActive: false})}
-                />
-              </div>
-              <button
-                type="button"
-                onClick={() => this.setState({renameFileActive: false})}
-                className="btn btn-default btn-sm"
-                style={style.button}
-              >
-                Save
-              </button>
-            </div>
-          ) : (
-            <div style={style.tabs}>
-              <div style={style.tab}>{this.props.fileName}</div>
-              <button
-                type="button"
-                onClick={() => this.setState({renameFileActive: true})}
-                className="btn btn-default btn-sm"
-                style={style.button}
-              >
-                Rename
-              </button>
-            </div>
-          )}
+          {this.state.renameFileActive
+            ? this.displayFileRename()
+            : this.displayFileNameAndRenameButton()}
         </div>
         <div ref={el => (this._codeMirror = el)} style={style.editor} />
       </div>

--- a/apps/src/javalab/JavalabEditor.jsx
+++ b/apps/src/javalab/JavalabEditor.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import {connect} from 'react-redux';
-import {setEditorText} from './javalabRedux';
+import {setEditorText, setFileName} from './javalabRedux';
 import PropTypes from 'prop-types';
 import PaneHeader, {PaneSection} from '@cdo/apps/templates/PaneHeader';
 import {EditorView} from '@codemirror/view';
@@ -12,6 +12,17 @@ const style = {
     width: '100%',
     height: 600,
     backgroundColor: '#282c34'
+  },
+  tabs: {
+    display: 'flex'
+  },
+  tab: {
+    backgroundColor: '#282c34',
+    textAlign: 'center',
+    padding: 10
+  },
+  button: {
+    marginLeft: 10
   }
 };
 
@@ -20,8 +31,19 @@ class JavalabEditor extends React.Component {
     style: PropTypes.object,
     // populated by redux
     editorText: PropTypes.string,
-    setEditorText: PropTypes.func
+    setEditorText: PropTypes.func,
+    fileName: PropTypes.string,
+    setFileName: PropTypes.func
   };
+
+  constructor(props) {
+    super(props);
+
+    this.state = {
+      renameFileActive: false,
+      showFileManagementPanel: false
+    };
+  }
 
   componentDidMount() {
     this.editor = new EditorView({
@@ -53,6 +75,41 @@ class JavalabEditor extends React.Component {
         <PaneHeader hasFocus={true}>
           <PaneSection>Editor</PaneSection>
         </PaneHeader>
+        <div>
+          {this.state.renameFileActive ? (
+            <div style={style.tabs}>
+              <div style={style.tab}>
+                <input
+                  type="text"
+                  ariaLabel="file name"
+                  value={this.props.fileName}
+                  onChange={e => this.props.setFileName(e.target.value)}
+                  onBlur={() => this.setState({renameFileActive: false})}
+                />
+              </div>
+              <button
+                type="button"
+                onClick={() => this.setState({renameFileActive: false})}
+                className="btn btn-default btn-sm"
+                style={style.button}
+              >
+                Save
+              </button>
+            </div>
+          ) : (
+            <div style={style.tabs}>
+              <div style={style.tab}>{this.props.fileName}</div>
+              <button
+                type="button"
+                onClick={() => this.setState({renameFileActive: true})}
+                className="btn btn-default btn-sm"
+                style={style.button}
+              >
+                Rename
+              </button>
+            </div>
+          )}
+        </div>
         <div ref={el => (this._codeMirror = el)} style={style.editor} />
       </div>
     );
@@ -61,9 +118,11 @@ class JavalabEditor extends React.Component {
 
 export default connect(
   state => ({
-    editorText: state.javalab.editorText
+    editorText: state.javalab.editorText,
+    fileName: state.javalab.fileName
   }),
   dispatch => ({
-    setEditorText: editorText => dispatch(setEditorText(editorText))
+    setEditorText: editorText => dispatch(setEditorText(editorText)),
+    setFileName: fileName => dispatch(setFileName(fileName))
   })
 )(JavalabEditor);

--- a/apps/src/javalab/javalabRedux.js
+++ b/apps/src/javalab/javalabRedux.js
@@ -1,9 +1,11 @@
 const APPEND_CONSOLE_LOG = 'javalab/APPEND_CONSOLE_LOG';
 const SET_EDITOR_TEXT = 'javalab/SET_EDITOR_TEXT';
+const SET_FILE_NAME = 'javalab/SET_FILE_NAME';
 
 const initialState = {
   consoleLogs: [],
-  editorText: ''
+  editorText: '',
+  fileName: 'Untitled File'
 };
 
 export const appendInputLog = input => ({
@@ -21,6 +23,11 @@ export const setEditorText = editorText => ({
   editorText
 });
 
+export const setFileName = fileName => ({
+  type: SET_FILE_NAME,
+  fileName
+});
+
 export default function reducer(state = initialState, action) {
   if (action.type === APPEND_CONSOLE_LOG) {
     return {
@@ -32,6 +39,12 @@ export default function reducer(state = initialState, action) {
     return {
       ...state,
       editorText: action.editorText
+    };
+  }
+  if (action.type === SET_FILE_NAME) {
+    return {
+      ...state,
+      fileName: action.fileName
     };
   }
   return state;

--- a/apps/src/javalab/javalabRedux.js
+++ b/apps/src/javalab/javalabRedux.js
@@ -5,7 +5,7 @@ const SET_FILE_NAME = 'javalab/SET_FILE_NAME';
 const initialState = {
   consoleLogs: [],
   editorText: '',
-  fileName: 'Untitled File'
+  fileName: 'MyClass.java'
 };
 
 export const appendInputLog = input => ({


### PR DESCRIPTION
Adds the concept of a file name in Javalab and allow the file to be renamed. The file will start out as "MyClass.java". Currently renaming the file will only persist for the current session--as a follow up we will persist the file and file name.

The current UI is temporary as we will need to enable creation, deletion and rename of multiple files in the future and will do the full UI in the spec then (see spec linked below). This UI just enables rename and saves the name to redux.

Current UI:
Default view:
<img width="612" alt="Screen Shot 2021-03-02 at 9 25 03 AM" src="https://user-images.githubusercontent.com/33666587/109689366-11176e80-7b3a-11eb-890f-17d31f3df7ff.png">

If rename is clicked:
<img width="617" alt="Screen Shot 2021-03-02 at 9 25 21 AM" src="https://user-images.githubusercontent.com/33666587/109689387-1674b900-7b3a-11eb-90e6-7e6652d60d09.png">


## Links

<!--
- spec: [CSA IDE Design]()
- jira ticket: [CSA-123](https://codedotorg.atlassian.net/browse/CSA-123)
-->

## Testing story
Tested locally. The editor is still in prototype mode.

## Follow-up work

- [Save editor code to S3](https://codedotorg.atlassian.net/browse/CSA-122)


## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
