### PR TITLE
Level-specific last progress timestamp

### DIFF
--- a/apps/src/templates/progress/progressHelpers.js
+++ b/apps/src/templates/progress/progressHelpers.js
@@ -286,6 +286,7 @@ export const levelProgressFromServer = serverProgress => {
     result: getLevelResult(serverProgress),
     paired: serverProgress.paired || false,
     timeSpent: serverProgress.time_spent || 0,
+    lastTimestamp: serverProgress.last_progress_at || 0,
     // `pages` is used by multi-page assessments, and its presence
     // (or absence) is how we distinguish those from single-page assessments
     pages:

--- a/apps/src/templates/progress/progressTypes.js
+++ b/apps/src/templates/progress/progressTypes.js
@@ -78,7 +78,8 @@ const studentLevelProgressShape = {
   status: PropTypes.string.isRequired,
   result: PropTypes.number.isRequired,
   paired: PropTypes.bool.isRequired,
-  timeSpent: PropTypes.number
+  timeSpent: PropTypes.number.isRequired,
+  lastTimestamp: PropTypes.number.isRequired
   /** pages: PropTypes.array */ // See below
 };
 // Avoid recursive definition

--- a/apps/src/templates/sectionProgress/sectionProgressTestHelpers.js
+++ b/apps/src/templates/sectionProgress/sectionProgressTestHelpers.js
@@ -92,28 +92,32 @@ function randomProgress() {
         status: LevelStatus.perfect,
         result: TestResults.MINIMUM_OPTIMAL_RESULT,
         paired: paired,
-        time_spent: 5
+        timeSpent: rand * paired,
+        lastTimestamp: Date.now()
       };
     case 1:
       return {
         status: LevelStatus.attempted,
         result: TestResults.LEVEL_STARTED,
         paired: paired,
-        time_spent: 3
+        timeSpent: rand * paired,
+        lastTimestamp: Date.now()
       };
     case 2:
       return {
         status: LevelStatus.passed,
         result: TestResults.TOO_MANY_BLOCKS_FAIL,
         paired: paired,
-        time_spent: 3
+        timeSpent: rand * paired,
+        lastTimestamp: Date.now()
       };
     default:
       return {
         status: LevelStatus.not_tried,
         result: TestResults.NO_TESTS_RUN,
         paired: paired,
-        time_spent: 0
+        timeSpent: rand * paired,
+        lastTimestamp: Date.now()
       };
   }
 }

--- a/apps/test/unit/templates/sectionProgress/sectionProgressLoaderTest.js
+++ b/apps/test/unit/templates/sectionProgress/sectionProgressLoaderTest.js
@@ -36,12 +36,25 @@ const serverProgressResponse = {
         status: 'locked',
         result: 1001,
         paired: false,
-        time_spent: undefined
+        time_spent: undefined,
+        last_progress_at: 12345
       },
-      '2001': {status: 'perfect', result: 30, paired: true, time_spent: 12345}
+      '2001': {
+        status: 'perfect',
+        result: 30,
+        paired: true,
+        time_spent: 12345,
+        last_progress_at: 12345
+      }
     },
     '102': {
-      '2000': {status: 'perfect', result: 100, paired: false, time_spent: 6789}
+      '2000': {
+        status: 'perfect',
+        result: 100,
+        paired: false,
+        time_spent: 6789,
+        last_progress_at: 6789
+      }
     }
   }
 };
@@ -63,9 +76,16 @@ const firstServerProgressResponse = {
         status: 'locked',
         result: 1001,
         paired: false,
-        time_spent: undefined
+        time_spent: undefined,
+        last_progress_at: 12345
       },
-      '2001': {status: 'perfect', result: 30, paired: true, time_spent: 12345}
+      '2001': {
+        status: 'perfect',
+        result: 30,
+        paired: true,
+        time_spent: 12345,
+        last_progress_at: 12345
+      }
     }
   }
 };
@@ -81,7 +101,13 @@ const secondServerProgressResponse = {
   },
   student_progress: {
     '102': {
-      '2000': {status: 'perfect', result: 100, paired: false, time_spent: 6789}
+      '2000': {
+        status: 'perfect',
+        result: 100,
+        paired: false,
+        time_spent: 6789,
+        last_progress_at: 6789
+      }
     }
   }
 };
@@ -109,14 +135,16 @@ const fullExpectedResult = {
           status: 'locked',
           result: 1001,
           paired: false,
-          timeSpent: 0
+          timeSpent: 0,
+          lastTimestamp: 12345
         },
         '2001': {
           pages: null,
           status: 'perfect',
           result: 30,
           paired: true,
-          timeSpent: 12345
+          timeSpent: 12345,
+          lastTimestamp: 12345
         }
       },
       102: {
@@ -125,7 +153,8 @@ const fullExpectedResult = {
           status: 'perfect',
           result: 100,
           paired: false,
-          timeSpent: 6789
+          timeSpent: 6789,
+          lastTimestamp: 6789
         }
       }
     }

--- a/dashboard/app/controllers/api_controller.rb
+++ b/dashboard/app/controllers/api_controller.rb
@@ -373,13 +373,7 @@ class ApiController < ApplicationController
     timestamp_by_user = progress_by_user.transform_values do |user|
       user.values.map {|level| level[:last_progress_at]}.compact.max
     end
-    # Remove last_progress_at from the return value, to keep the data sent to
-    # the client to a minimum.
-    progress_by_user.values.each do |user|
-      user.values.each do |level|
-        level.delete(:last_progress_at)
-      end
-    end
+
     [progress_by_user, timestamp_by_user]
   end
 


### PR DESCRIPTION
This is a simple update to add a `last_progress_at` timestamp to the per-level progress data returned from the server. Previously we were explicitly removing that value from the data, so all that was required was to remove the code that was doing that.