### PR TITLE
Pre-populate script cache in HomeControllerTest

### DIFF
--- a/dashboard/test/controllers/home_controller_test.rb
+++ b/dashboard/test/controllers/home_controller_test.rb
@@ -7,6 +7,10 @@ class HomeControllerTest < ActionController::TestCase
   setup do
     # stub properties so we don't try to hit pegasus db
     Properties.stubs(:get).returns nil
+
+    # ensure consistent query counts by calling Scripts.all_scripts to populate
+    # the script cache here
+    _ = Script.all_scripts
   end
 
   test "teacher without progress or assigned course/script redirected to index" do

--- a/dashboard/test/controllers/home_controller_test.rb
+++ b/dashboard/test/controllers/home_controller_test.rb
@@ -362,7 +362,7 @@ class HomeControllerTest < ActionController::TestCase
   # TODO: remove this test when workshop_organizer is deprecated
   test 'workshop organizers see dashboard links' do
     sign_in create(:workshop_organizer, :with_terms_of_service)
-    query_count = 15
+    query_count = 14
     assert_queries query_count do
       get :home
     end
@@ -371,7 +371,7 @@ class HomeControllerTest < ActionController::TestCase
 
   test 'program managers see dashboard links' do
     sign_in create(:program_manager, :with_terms_of_service)
-    query_count = 17
+    query_count = 16
     assert_queries query_count do
       get :home
     end
@@ -380,7 +380,7 @@ class HomeControllerTest < ActionController::TestCase
 
   test 'workshop admins see dashboard links' do
     sign_in create(:workshop_admin, :with_terms_of_service)
-    query_count = 14
+    query_count = 13
     assert_queries query_count do
       get :home
     end
@@ -391,8 +391,6 @@ class HomeControllerTest < ActionController::TestCase
   # it will fail if you try to run it independently
   # it is also flakey on drone, passing with different query counts (14 or 15)
   test 'facilitators see dashboard links' do
-    skip 'TODO: look into why this test is passing with different query counts on drone'
-
     facilitator = create(:facilitator, :with_terms_of_service)
     sign_in facilitator
     query_count = 14
@@ -404,7 +402,7 @@ class HomeControllerTest < ActionController::TestCase
 
   test 'teachers cannot see dashboard links' do
     sign_in create(:terms_of_service_teacher)
-    query_count = 13
+    query_count = 12
     assert_queries query_count do
       get :home
     end
@@ -413,7 +411,7 @@ class HomeControllerTest < ActionController::TestCase
 
   test 'workshop admins see application dashboard links' do
     sign_in create(:workshop_admin, :with_terms_of_service)
-    query_count = 14
+    query_count = 13
     assert_queries query_count do
       get :home
     end
@@ -424,7 +422,7 @@ class HomeControllerTest < ActionController::TestCase
   # TODO: remove this test when workshop_organizer is deprecated
   test 'workshop organizers who are regional partner program managers see application dashboard links' do
     sign_in create(:workshop_organizer, :as_regional_partner_program_manager, :with_terms_of_service)
-    query_count = 17
+    query_count = 16
     assert_queries query_count do
       get :home
     end
@@ -433,10 +431,8 @@ class HomeControllerTest < ActionController::TestCase
   end
 
   test 'program managers see application dashboard links' do
-    skip 'TODO: look into why this test is passing with different query counts on drone'
-
     sign_in create(:program_manager, :with_terms_of_service)
-    query_count = 17
+    query_count = 16
     assert_queries query_count do
       get :home
     end
@@ -447,7 +443,7 @@ class HomeControllerTest < ActionController::TestCase
   # TODO: remove this test when workshop_organizer is deprecated
   test 'workshop organizers who are not regional partner program managers do not see application dashboard links' do
     sign_in create(:workshop_organizer, :with_terms_of_service)
-    query_count = 15
+    query_count = 14
     assert_queries query_count do
       get :home
     end


### PR DESCRIPTION
<!--
  A summary of the change, including any relevant background, motivation, and context.
  If relevant, include a description, screenshots, and/or video of the existing and new behavior.
-->

The tests in HomeControllerTest are returning different query counts locally, in Drone, and in test.  One of the differences that I noticed is the all_scripts query which occurs in some environments but not others.  Trying a change to pre-cache this query to see if that makes the counts more consistent across environments.

## Links

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

<!--
- spec: []()
- jira ticket: []()
-->

## Testing story

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
