### PR TITLE
Update assert_queries to exclude SCHEMA and EXPLAIN queries

### DIFF
--- a/dashboard/test/controllers/home_controller_test.rb
+++ b/dashboard/test/controllers/home_controller_test.rb
@@ -391,9 +391,6 @@ class HomeControllerTest < ActionController::TestCase
     assert_select 'h1', count: 1, text: 'Workshop Dashboard'
   end
 
-  # this test only passes when run as part of the whole test suite
-  # it will fail if you try to run it independently
-  # it is also flakey on drone, passing with different query counts (14 or 15)
   test 'facilitators see dashboard links' do
     facilitator = create(:facilitator, :with_terms_of_service)
     sign_in facilitator

--- a/dashboard/test/testing/capture_queries.rb
+++ b/dashboard/test/testing/capture_queries.rb
@@ -61,7 +61,11 @@ module CaptureQueries
       next if ignore_filters.any? {|filter| backtrace.any? {|line| line =~ filter}}
       next unless capture_filters.all? {|filter| backtrace.any? {|line| line =~ filter}}
 
-      queries << "#{QueryLogger.log(duration, payload)}\n#{backtrace.join("\n")}"
+      query_log = QueryLogger.log(duration, payload)
+
+      # Note: the QueryLogger sql method will not return logged queries if they are SCHEMA
+      # or EXPLAIN queries, we also don't want to include these in our captured queries
+      queries << "#{query_log}\n#{backtrace.join("\n")}" unless query_log.empty?
     end
     ActiveRecord::Base.cache do
       ActiveSupport::Notifications.subscribed(query, "sql.active_record", &block)


### PR DESCRIPTION
<!--
  A summary of the change, including any relevant background, motivation, and context.
  If relevant, include a description, screenshots, and/or video of the existing and new behavior.
-->
Background:
`assert_queries` is used to count the number of queries executed during a test. There was a test (specifically `home_controller_test.rb` `facilitators see dashboard links`) which consistently failed locally (14 queries expected and 17 counted) but did not fail on the test environment when the whole test suite was run. 

It turns out the extra queries made locally were `SCHEMA` queries, these aren't made on test because the schema is cached. We leverage the ActiveRecord LogSubscriber to log the queries, this logger has it's own logic to filter out logs which are for queries of type schema or explain (https://github.com/rails/rails/blob/main/activerecord/lib/active_record/log_subscriber.rb#L5). So we can leverage this filtering and exclude queries from our counts that are being filtered by our logger.

## Links

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

<!--
- spec: []()
- jira ticket: []()
-->

## Testing story

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->
I ran the test that was failing locally, and it passed.
<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
