### PR TITLE
prepare to start using new standards field in existing standards report

### DIFF
--- a/dashboard/app/controllers/admin_standards_controller.rb
+++ b/dashboard/app/controllers/admin_standards_controller.rb
@@ -33,10 +33,11 @@ class AdminStandardsController < ApplicationController
       updated_standards = []
 
       lesson["standards"].each do |standard|
+        framework = Framework.find_by(shortcode: standard['framework'].downcase)
         code_studio_standard = Standard.find_by(
           {
-            organization: standard["framework"],
-            organization_id: standard["shortcode"]
+            framework: framework,
+            shortcode: standard["shortcode"]
           }
         )
 

--- a/dashboard/app/models/standard.rb
+++ b/dashboard/app/models/standard.rb
@@ -26,9 +26,13 @@ class Standard < ApplicationRecord
   def summarize
     {
       id: id,
+      shortcode: shortcode,
+      category_description: category.description,
+      description: description,
+
+      # deprecated fields
       organization: organization,
       organization_id: organization_id,
-      description: description,
       concept: concept
     }
   end

--- a/dashboard/test/ui/features/learning_platform/teacher_dashboard/progress_standards_view.feature
+++ b/dashboard/test/ui/features/learning_platform/teacher_dashboard/progress_standards_view.feature
@@ -42,9 +42,10 @@ Feature: Viewing and Printing Standards Progress
     And I wait until element "#teacher-dashboard" contains text "CSTA Standards in"
     And I wait until element "#uitest-standards-view" is visible
     And I wait until element "#uitest-progress-standards-table" is visible
-    And I wait until element "#uitest-progress-standards-table" contains text "Model daily processes by creating and following algorithms (sets of step-by-step instructions) to complete tasks."
-    And I wait until element "#uitest-progress-standards-table" contains text "Available in 1 Lesson:"
-    And I wait until element "#test-how-to-standards" contains text "How to use this information"
+    And element "#uitest-progress-standards-table" contains text "1A-AP-08"
+    And element "#uitest-progress-standards-table" contains text "Model daily processes by creating and following algorithms (sets of step-by-step instructions) to complete tasks."
+    And element "#uitest-progress-standards-table" contains text "Available in 1 Lesson:"
+    And element "#test-how-to-standards" contains text "How to use this information"
 
     # Generate PDF
     And I wait until element ".uitest-standards-generate-report" is visible


### PR DESCRIPTION
Continues work on [PLAT-750]. This PR does a few "pre flight" steps in preparation for switching the existing standards report over to using the new parts of the data model. specifically:

1. Adds a tiny bit of test coverage to the existing ui tests for the standards report. This will help make sure that we do not mess up when switching to pulling the standards shortcodes from the new database column.

2. starts using new standards fields when importing lesson-standard relationships from CB

3. starts sending new fields down to the client.

 For more background, see [Lesson Standards design doc](https://docs.google.com/document/d/1zvdv7y8VuRz8KqT1rzqeJAmvirCvUr1jS8OWy0p9FHk/edit#).

## Test Coverage

* The UI test touched in this PR covers (1) importing lesson-standard relationships, (2) the Standards tab, (3) the standards report which can be generated from that tab. I also tested all 3 of these manually.
* JS unit tests provide good coverage for the standards tab

[PLAT-750]: https://codedotorg.atlassian.net/browse/PLAT-750