### PR TITLE
Add detail data to lesson progress

### DIFF
--- a/apps/src/templates/progress/progressTestHelpers.js
+++ b/apps/src/templates/progress/progressTestHelpers.js
@@ -7,7 +7,10 @@
 
 import _ from 'lodash';
 import {LevelStatus} from '@cdo/apps/util/sharedConstants';
-import {levelProgressFromStatus} from '@cdo/apps/templates/progress/progressHelpers';
+import {
+  levelProgressFromStatus,
+  lessonProgressForSection
+} from '@cdo/apps/templates/progress/progressHelpers';
 import {createStore} from 'redux';
 import Immutable from 'immutable';
 
@@ -171,6 +174,10 @@ export const fakeProgressTableReduxInitialState = (
   if (!scriptData) {
     scriptData = fakeScriptData({stages});
   }
+  const levelProgressData = fakeStudentLevelProgress(
+    scriptData.stages[0].levels,
+    students
+  );
 
   return {
     progress: {
@@ -185,9 +192,12 @@ export const fakeProgressTableReduxInitialState = (
     sectionProgress: {
       scriptDataByScript: {[scriptData.id]: scriptData},
       studentLevelProgressByScript: {
-        [scriptData.id]: fakeStudentLevelProgress(
-          scriptData.stages[0].levels,
-          students
+        [scriptData.id]: levelProgressData
+      },
+      studentLessonProgressByScript: {
+        [scriptData.id]: lessonProgressForSection(
+          levelProgressData,
+          scriptData.stages
         )
       },
       studentLastUpdateByScript: fakeStudentLastUpdateByScript(

--- a/apps/src/templates/progress/progressTypes.js
+++ b/apps/src/templates/progress/progressTypes.js
@@ -69,7 +69,9 @@ export const levelType = PropTypes.shape({
  * @property {bool} paired
  * A boolean indicating if a student was paired on a level.
  * @property {number} timeSpent
- * An optional value indicating the time a student spent on a level.
+ * The number of seconds a student spent on a level.
+ * @property {number} lastTimestamp
+ * A timestamp of the last time a student made progress on a level.
  * @property {array} pages
  * An optional array of recursive progress objects representing progress on
  * individual pages of a multi-page assessment

--- a/apps/src/templates/progress/progressTypes.js
+++ b/apps/src/templates/progress/progressTypes.js
@@ -118,12 +118,16 @@ export const lessonType = PropTypes.shape({
  * @property {number} incompletePercent
  * @property {number} imperfectPercent
  * @property {number} completedPercent
+ * @property {number} timeSpent
+ * @property {number} lastTimestamp
  */
 export const studentLessonProgressType = PropTypes.shape({
   isStarted: PropTypes.bool.isRequired,
   incompletePercent: PropTypes.number.isRequired,
   imperfectPercent: PropTypes.number.isRequired,
-  completedPercent: PropTypes.number.isRequired
+  completedPercent: PropTypes.number.isRequired,
+  timeSpent: PropTypes.number.isRequired,
+  lastTimestamp: PropTypes.number.isRequired
 });
 
 /**

--- a/apps/src/templates/sectionProgress/SectionProgress.jsx
+++ b/apps/src/templates/sectionProgress/SectionProgress.jsx
@@ -15,7 +15,7 @@ import {
   setLessonOfInterest,
   setCurrentView
 } from './sectionProgressRedux';
-import {loadScript} from './sectionProgressLoader';
+import {loadScriptProgress} from './sectionProgressLoader';
 import {ViewType, scriptDataPropType} from './sectionProgressConstants';
 import {sectionDataPropType} from '@cdo/apps/redux/sectionDataRedux';
 import {
@@ -86,12 +86,12 @@ class SectionProgress extends Component {
   }
 
   componentDidMount() {
-    loadScript(this.props.scriptId, this.props.section.id);
+    loadScriptProgress(this.props.scriptId, this.props.section.id);
   }
 
   onChangeScript(scriptId) {
     this.props.setScriptId(scriptId);
-    loadScript(scriptId, this.props.section.id);
+    loadScriptProgress(scriptId, this.props.section.id);
 
     firehoseClient.putRecord(
       {

--- a/apps/src/templates/sectionProgress/progressTables/ProgressTableContainer.jsx
+++ b/apps/src/templates/sectionProgress/progressTables/ProgressTableContainer.jsx
@@ -3,7 +3,6 @@ import {connect} from 'react-redux';
 import PropTypes from 'prop-types';
 import i18n from '@cdo/locale';
 import {scriptDataPropType} from '../sectionProgressConstants';
-import {studentLevelProgressType} from '@cdo/apps/templates/progress/progressTypes';
 import {sectionDataPropType} from '@cdo/apps/redux/sectionDataRedux';
 import {getCurrentScriptData} from '@cdo/apps/templates/sectionProgress/sectionProgressRedux';
 import styleConstants from '@cdo/apps/styleConstants';
@@ -42,9 +41,6 @@ class ProgressTableContainer extends React.Component {
     section: sectionDataPropType.isRequired,
     scriptData: scriptDataPropType.isRequired,
     lessonOfInterest: PropTypes.number.isRequired,
-    levelProgressByStudent: PropTypes.objectOf(
-      PropTypes.objectOf(studentLevelProgressType)
-    ).isRequired,
     studentTimestamps: PropTypes.object.isRequired,
     localeCode: PropTypes.string
   };
@@ -117,10 +113,6 @@ export default connect(state => ({
   section: state.sectionData.section,
   scriptData: getCurrentScriptData(state),
   lessonOfInterest: state.sectionProgress.lessonOfInterest,
-  levelProgressByStudent:
-    state.sectionProgress.studentLevelProgressByScript[
-      state.scriptSelection.scriptId
-    ],
   studentTimestamps:
     state.sectionProgress.studentLastUpdateByScript[
       state.scriptSelection.scriptId

--- a/apps/src/templates/sectionProgress/progressTables/ProgressTableContentView.jsx
+++ b/apps/src/templates/sectionProgress/progressTables/ProgressTableContentView.jsx
@@ -3,7 +3,6 @@ import * as Table from 'reactabular-table';
 import * as Sticky from 'reactabular-sticky';
 import * as Virtualized from 'reactabular-virtualized';
 import PropTypes from 'prop-types';
-import {studentLevelProgressType} from '@cdo/apps/templates/progress/progressTypes';
 import {sectionDataPropType} from '@cdo/apps/redux/sectionDataRedux';
 import {scriptDataPropType, scrollbarWidth} from '../sectionProgressConstants';
 import {lessonIsAllAssessment} from '@cdo/apps/templates/progress/progressHelpers';
@@ -29,9 +28,6 @@ export default class ProgressTableContentView extends React.Component {
     section: sectionDataPropType.isRequired,
     scriptData: scriptDataPropType.isRequired,
     lessonOfInterest: PropTypes.number.isRequired,
-    levelProgressByStudent: PropTypes.objectOf(
-      PropTypes.objectOf(studentLevelProgressType)
-    ).isRequired,
     onClickLesson: PropTypes.func.isRequired,
     columnWidths: PropTypes.arrayOf(PropTypes.number),
     lessonCellFormatter: PropTypes.func.isRequired,
@@ -93,11 +89,9 @@ export default class ProgressTableContentView extends React.Component {
   }
 
   contentCellFormatter(_, {rowData, columnIndex}) {
-    const {scriptData, levelProgressByStudent} = this.props;
     return this.props.lessonCellFormatter(
-      scriptData.stages[columnIndex],
-      rowData,
-      levelProgressByStudent[rowData.id]
+      this.props.scriptData.stages[columnIndex],
+      rowData
     );
   }
 

--- a/apps/src/templates/sectionProgress/progressTables/ProgressTableDetailView.jsx
+++ b/apps/src/templates/sectionProgress/progressTables/ProgressTableDetailView.jsx
@@ -3,6 +3,7 @@ import {connect} from 'react-redux';
 import PropTypes from 'prop-types';
 import i18n from '@cdo/locale';
 import {scriptDataPropType} from '../sectionProgressConstants';
+import {studentLevelProgressType} from '@cdo/apps/templates/progress/progressTypes';
 import {
   getCurrentScriptData,
   setLessonOfInterest
@@ -23,6 +24,9 @@ class ProgressTableDetailView extends React.Component {
     // redux
     section: sectionDataPropType.isRequired,
     scriptData: scriptDataPropType.isRequired,
+    levelProgressByStudent: PropTypes.objectOf(
+      PropTypes.objectOf(studentLevelProgressType)
+    ).isRequired,
     onClickLesson: PropTypes.func.isRequired
   };
 
@@ -40,7 +44,8 @@ class ProgressTableDetailView extends React.Component {
     );
   }
 
-  detailCellFormatter(lesson, student, studentProgress) {
+  detailCellFormatter(lesson, student) {
+    const studentProgress = this.props.levelProgressByStudent[student.id];
     return (
       <ProgressTableDetailCell
         studentId={student.id}
@@ -70,7 +75,11 @@ class ProgressTableDetailView extends React.Component {
 export default connect(
   state => ({
     section: state.sectionData.section,
-    scriptData: getCurrentScriptData(state)
+    scriptData: getCurrentScriptData(state),
+    levelProgressByStudent:
+      state.sectionProgress.studentLevelProgressByScript[
+        state.scriptSelection.scriptId
+      ]
   }),
   dispatch => ({
     onClickLesson(lessonPosition) {

--- a/apps/src/templates/sectionProgress/progressTables/ProgressTableSummaryCell.jsx
+++ b/apps/src/templates/sectionProgress/progressTables/ProgressTableSummaryCell.jsx
@@ -89,3 +89,7 @@ export default class ProgressTableSummaryCell extends React.Component {
     );
   }
 }
+
+export const unitTestExports = {
+  BorderedBox
+};

--- a/apps/src/templates/sectionProgress/progressTables/ProgressTableSummaryCell.jsx
+++ b/apps/src/templates/sectionProgress/progressTables/ProgressTableSummaryCell.jsx
@@ -13,10 +13,26 @@ const styles = {
   }
 };
 
+function BorderedBox({borderColor, onClick, children}) {
+  const boxStyle = {
+    ...styles.container,
+    borderColor: borderColor
+  };
+  return (
+    <div style={boxStyle} onClick={onClick} className="uitest-summary-cell">
+      {children}
+    </div>
+  );
+}
+BorderedBox.propTypes = {
+  borderColor: PropTypes.string.isRequired,
+  onClick: PropTypes.func,
+  children: PropTypes.node
+};
 export default class ProgressTableSummaryCell extends React.Component {
   static propTypes = {
     studentId: PropTypes.number.isRequired,
-    studentLessonProgress: studentLessonProgressType.isRequired,
+    studentLessonProgress: studentLessonProgressType,
     isAssessmentLesson: PropTypes.bool,
     onSelectDetailView: PropTypes.func
   };
@@ -26,16 +42,26 @@ export default class ProgressTableSummaryCell extends React.Component {
   }
 
   render() {
-    const {studentLessonProgress, isAssessmentLesson} = this.props;
+    const {
+      studentLessonProgress,
+      isAssessmentLesson,
+      onSelectDetailView
+    } = this.props;
 
-    const boxStyle = {
-      ...styles.container,
-      borderColor: studentLessonProgress.isStarted
-        ? isAssessmentLesson
-          ? color.level_submitted
-          : color.level_perfect
-        : color.light_gray
-    };
+    if (!studentLessonProgress) {
+      return (
+        <BorderedBox
+          borderColor={color.light_gray}
+          onClick={onSelectDetailView}
+        />
+      );
+    }
+
+    const borderColor = studentLessonProgress.isStarted
+      ? isAssessmentLesson
+        ? color.level_submitted
+        : color.level_perfect
+      : color.light_gray;
 
     const incompleteStyle = {
       backgroundColor: color.level_not_tried,
@@ -55,15 +81,11 @@ export default class ProgressTableSummaryCell extends React.Component {
     };
 
     return (
-      <div
-        style={boxStyle}
-        onClick={this.props.onSelectDetailView}
-        className="uitest-summary-cell"
-      >
+      <BorderedBox borderColor={borderColor} onClick={onSelectDetailView}>
         <div style={incompleteStyle} />
         <div style={imperfectStyle} />
         <div style={completedStyle} />
-      </div>
+      </BorderedBox>
     );
   }
 }

--- a/apps/src/templates/sectionProgress/progressTables/ProgressTableSummaryView.jsx
+++ b/apps/src/templates/sectionProgress/progressTables/ProgressTableSummaryView.jsx
@@ -1,11 +1,9 @@
 import React from 'react';
 import {connect} from 'react-redux';
 import PropTypes from 'prop-types';
-import {
-  progressForLesson,
-  lessonIsAllAssessment
-} from '@cdo/apps/templates/progress/progressHelpers';
+import {lessonIsAllAssessment} from '@cdo/apps/templates/progress/progressHelpers';
 import {scriptDataPropType} from '../sectionProgressConstants';
+import {studentLessonProgressType} from '@cdo/apps/templates/progress/progressTypes';
 import {
   getCurrentScriptData,
   jumpToLessonDetails
@@ -25,6 +23,9 @@ class ProgressTableSummaryView extends React.Component {
   static propTypes = {
     // redux
     scriptData: scriptDataPropType.isRequired,
+    lessonProgressByStudent: PropTypes.objectOf(
+      PropTypes.objectOf(studentLessonProgressType)
+    ).isRequired,
     onClickLesson: PropTypes.func.isRequired
   };
 
@@ -33,17 +34,15 @@ class ProgressTableSummaryView extends React.Component {
     this.summaryCellFormatter = this.summaryCellFormatter.bind(this);
   }
 
-  summaryCellFormatter(lesson, student, studentProgress) {
-    const studentLessonProgress = progressForLesson(
-      studentProgress,
-      lesson.levels
-    );
-    const isAssessmentLesson = lessonIsAllAssessment(lesson.levels);
+  summaryCellFormatter(lesson, student) {
+    const studentLessonProgress = this.props.lessonProgressByStudent[
+      student.id
+    ][lesson.id];
     return (
       <ProgressTableSummaryCell
         studentId={student.id}
         studentLessonProgress={studentLessonProgress}
-        isAssessmentLesson={isAssessmentLesson}
+        isAssessmentLesson={lessonIsAllAssessment(lesson.levels)}
         onSelectDetailView={() => this.props.onClickLesson(lesson.position)}
       />
     );
@@ -67,7 +66,11 @@ class ProgressTableSummaryView extends React.Component {
 
 export default connect(
   state => ({
-    scriptData: getCurrentScriptData(state)
+    scriptData: getCurrentScriptData(state),
+    lessonProgressByStudent:
+      state.sectionProgress.studentLessonProgressByScript[
+        state.scriptSelection.scriptId
+      ]
   }),
   dispatch => ({
     onClickLesson(lessonPosition) {

--- a/apps/src/templates/sectionProgress/sectionProgressLoader.js
+++ b/apps/src/templates/sectionProgress/sectionProgressLoader.js
@@ -21,7 +21,7 @@ import _ from 'lodash';
 
 const NUM_STUDENTS_PER_PAGE = 50;
 
-export function loadScript(scriptId, sectionId) {
+export function loadScriptProgress(scriptId, sectionId) {
   const state = getStore().getState().sectionProgress;
   const sectionData = getStore().getState().sectionData.section;
 

--- a/apps/src/templates/sectionProgress/sectionProgressLoader.js
+++ b/apps/src/templates/sectionProgress/sectionProgressLoader.js
@@ -10,7 +10,7 @@ import {
 import {
   processedLevel,
   processServerSectionProgress,
-  progressForLesson
+  lessonProgressForSection
 } from '@cdo/apps/templates/progress/progressHelpers';
 import {
   fetchStandardsCoveredForScript,
@@ -96,13 +96,11 @@ export function loadScript(scriptId, sectionId) {
   requests.push(scriptRequest);
   Promise.all(requests).then(() => {
     sectionProgress.studentLessonProgressByScript = {
-      [scriptId]: {
-        ...sectionProgress.studentLessonProgressByScript,
-        ...summarizeLessonProgress(
-          sectionProgress.studentLevelProgressByScript[scriptId],
-          sectionProgress.scriptDataByScript[scriptId].stages
-        )
-      }
+      ...sectionProgress.studentLessonProgressByScript,
+      [scriptId]: lessonProgressForSection(
+        sectionProgress.studentLevelProgressByScript[scriptId],
+        sectionProgress.scriptDataByScript[scriptId].stages
+      )
     };
     getStore().dispatch(addDataByScript(sectionProgress));
     getStore().dispatch(finishLoadingProgress());
@@ -118,20 +116,6 @@ export function loadScript(scriptId, sectionId) {
 function processStudentTimestamps(timestamps) {
   const studentTimestamps = _.mapValues(timestamps, seconds => seconds * 1000);
   return studentTimestamps;
-}
-
-function summarizeLessonProgress(studentLevelProgress, lessons) {
-  const studentLessonProgress = {};
-  Object.entries(studentLevelProgress).forEach(([studentId, levelProgress]) => {
-    studentLessonProgress[studentId] = {};
-    lessons.forEach(lesson => {
-      studentLessonProgress[studentId][lesson.id] = progressForLesson(
-        levelProgress,
-        lesson.levels
-      );
-    });
-  });
-  return studentLessonProgress;
 }
 
 function postProcessDataByScript(scriptData) {

--- a/apps/src/templates/sectionProgress/sectionProgressRedux.js
+++ b/apps/src/templates/sectionProgress/sectionProgressRedux.js
@@ -37,6 +37,7 @@ const initialState = {
   currentView: ViewType.SUMMARY,
   scriptDataByScript: {},
   studentLevelProgressByScript: {},
+  studentLessonProgressByScript: {},
   studentLastUpdateByScript: {},
   lessonOfInterest: INITIAL_LESSON_OF_INTEREST,
   isLoadingProgress: false,
@@ -104,6 +105,10 @@ export default function sectionProgress(state = initialState, action) {
       studentLevelProgressByScript: {
         ...state.studentLevelProgressByScript,
         ...action.data.studentLevelProgressByScript
+      },
+      studentLessonProgressByScript: {
+        ...state.studentLessonProgressByScript,
+        ...action.data.studentLessonProgressByScript
       },
       studentLastUpdateByScript: {
         ...state.studentLastUpdateByScript,

--- a/apps/src/templates/sectionProgress/sectionProgressTestHelpers.js
+++ b/apps/src/templates/sectionProgress/sectionProgressTestHelpers.js
@@ -11,6 +11,7 @@ import scriptSelection, {
 import locales from '@cdo/apps/redux/localesRedux';
 import {LevelStatus} from '@cdo/apps/util/sharedConstants';
 import {TestResults} from '@cdo/apps/constants';
+import {lessonProgressForSection} from '@cdo/apps/templates/progress/progressHelpers';
 
 export function wrapTable(table) {
   return (
@@ -79,6 +80,9 @@ function buildSectionProgress(students, scriptData) {
   return {
     scriptDataByScript: {[scriptData.id]: scriptData},
     studentLevelProgressByScript: {[scriptData.id]: progress},
+    studentLessonProgressByScript: {
+      [scriptData.id]: lessonProgressForSection(progress, scriptData.stages)
+    },
     studentLastUpdateByScript: {[scriptData.id]: lastUpdates}
   };
 }

--- a/apps/src/templates/sectionProgress/standards/StandardsReport.jsx
+++ b/apps/src/templates/sectionProgress/standards/StandardsReport.jsx
@@ -25,7 +25,7 @@ import StandardsReportCurrentCourseInfo from './StandardsReportCurrentCourseInfo
 import StandardsReportHeader from './StandardsReportHeader';
 import color from '@cdo/apps/util/color';
 import _ from 'lodash';
-import {loadScript} from '../sectionProgressLoader';
+import {loadScriptProgress} from '../sectionProgressLoader';
 import PrintReportButton from './PrintReportButton';
 import {cstaStandardsURL} from './standardsConstants';
 import FontAwesome from '@cdo/apps/templates/FontAwesome';
@@ -83,7 +83,7 @@ class StandardsReport extends Component {
     const scriptIdFromTD =
       window.opener.teacherDashboardStoreInformation.scriptId;
     this.props.setScriptId(scriptIdFromTD);
-    loadScript(scriptIdFromTD, this.props.section.id);
+    loadScriptProgress(scriptIdFromTD, this.props.section.id);
   }
 
   getLinkToOverview() {

--- a/apps/test/unit/templates/progress/progressHelpersTest.js
+++ b/apps/test/unit/templates/progress/progressHelpersTest.js
@@ -11,7 +11,7 @@ import {
   lessonIsLockedForAllStudents,
   getIconForLevel,
   stageLocked,
-  progressForLesson,
+  lessonProgressForSection,
   isLevelAssessment,
   lessonIsAllAssessment
 } from '@cdo/apps/templates/progress/progressHelpers';
@@ -255,17 +255,33 @@ describe('progressHelpers', () => {
     });
   });
 
-  describe('progressForLesson', () => {
+  describe('lessonProgressForSection', () => {
     /**
      * Note: this function is only used by section progress tables, which have
      * been refactored to expect the `status` value to be in a sepaparate
      * `studentLevelProgressType` object rather than the `levelType` object.
      */
+    const STUDENT_ID = 11;
+    const LESSON_ID = 111;
+
+    // helper function to get lesson progress for a single student
+    const getStudentLessonProgress = (studentLevelProgress, levels) => {
+      const lesson = {id: LESSON_ID, levels: levels};
+      const sectionLevelProgress = {[STUDENT_ID]: studentLevelProgress};
+      const sectionLessonProgress = lessonProgressForSection(
+        sectionLevelProgress,
+        [lesson]
+      );
+      return sectionLessonProgress[STUDENT_ID][LESSON_ID];
+    };
 
     it('summarizes all untried levels', () => {
       const levels = fakeLevels(3);
       const studentProgress = fakeProgressForLevels(levels);
-      const studentLessonProgress = progressForLesson(studentProgress, levels);
+      const studentLessonProgress = getStudentLessonProgress(
+        studentProgress,
+        levels
+      );
       assert.deepEqual(studentLessonProgress, {
         isStarted: false,
         incompletePercent: 100,
@@ -283,7 +299,10 @@ describe('progressHelpers', () => {
       studentProgress[2].status = LevelStatus.submitted;
       studentProgress[3].status = LevelStatus.readonly;
 
-      const studentLessonProgress = progressForLesson(studentProgress, levels);
+      const studentLessonProgress = getStudentLessonProgress(
+        studentProgress,
+        levels
+      );
       assert.deepEqual(studentLessonProgress, {
         isStarted: true,
         incompletePercent: 0,
@@ -300,7 +319,10 @@ describe('progressHelpers', () => {
         levels,
         LevelStatus.attempted
       );
-      const studentLessonProgress = progressForLesson(studentProgress, levels);
+      const studentLessonProgress = getStudentLessonProgress(
+        studentProgress,
+        levels
+      );
       assert.deepEqual(studentLessonProgress, {
         isStarted: true,
         incompletePercent: 100,
@@ -322,7 +344,10 @@ describe('progressHelpers', () => {
       studentProgress[6].status = LevelStatus.locked;
       studentProgress[7].status = 'other';
 
-      const studentLessonProgress = progressForLesson(studentProgress, levels);
+      const studentLessonProgress = getStudentLessonProgress(
+        studentProgress,
+        levels
+      );
       assert.deepEqual(studentLessonProgress, {
         isStarted: true,
         incompletePercent: 50,
@@ -339,7 +364,10 @@ describe('progressHelpers', () => {
       studentProgress[1].status = LevelStatus.perfect;
       levels[0].bonus = true;
 
-      const studentLessonProgress = progressForLesson(studentProgress, levels);
+      const studentLessonProgress = getStudentLessonProgress(
+        studentProgress,
+        levels
+      );
       assert.deepEqual(studentLessonProgress, {
         isStarted: false,
         incompletePercent: 100,
@@ -352,11 +380,14 @@ describe('progressHelpers', () => {
 
     it('returns null if all levels are bonus', () => {
       const levels = fakeLevels(2);
-      const studentProgress = fakeProgressForLevels(levels);
       levels[0].bonus = true;
       levels[1].bonus = true;
+      const studentProgress = fakeProgressForLevels(levels);
 
-      const studentLessonProgress = progressForLesson(studentProgress, levels);
+      const studentLessonProgress = getStudentLessonProgress(
+        studentProgress,
+        levels
+      );
       assert.equal(studentLessonProgress, null);
     });
 
@@ -369,7 +400,10 @@ describe('progressHelpers', () => {
       studentProgress[1].timeSpent = 1;
       studentProgress[2].timeSpent = 2;
 
-      const studentLessonProgress = progressForLesson(studentProgress, levels);
+      const studentLessonProgress = getStudentLessonProgress(
+        studentProgress,
+        levels
+      );
       assert.deepEqual(studentLessonProgress, {
         isStarted: true,
         incompletePercent: 100,
@@ -389,7 +423,10 @@ describe('progressHelpers', () => {
       studentProgress[1].lastTimestamp = 2;
       studentProgress[2].lastTimestamp = 1;
 
-      const studentLessonProgress = progressForLesson(studentProgress, levels);
+      const studentLessonProgress = getStudentLessonProgress(
+        studentProgress,
+        levels
+      );
       assert.deepEqual(studentLessonProgress, {
         isStarted: true,
         incompletePercent: 100,

--- a/apps/test/unit/templates/progress/progressHelpersTest.js
+++ b/apps/test/unit/templates/progress/progressHelpersTest.js
@@ -11,7 +11,7 @@ import {
   lessonIsLockedForAllStudents,
   getIconForLevel,
   stageLocked,
-  summarizeProgressInStage,
+  progressForLesson,
   isLevelAssessment,
   lessonIsAllAssessment
 } from '@cdo/apps/templates/progress/progressHelpers';
@@ -255,7 +255,7 @@ describe('progressHelpers', () => {
     });
   });
 
-  describe('summarizeProgressInStage', () => {
+  describe('progressForLesson', () => {
     /**
      * Note: this function is only used by section progress tables, which have
      * been refactored to expect the `status` value to be in a sepaparate
@@ -265,10 +265,15 @@ describe('progressHelpers', () => {
     it('summarizes all untried levels', () => {
       const levels = fakeLevels(3);
       const studentProgress = fakeProgressForLevels(levels);
-      const summarizedStage = summarizeProgressInStage(studentProgress, levels);
-      assert.equal(summarizedStage.total, 3);
-      assert.equal(summarizedStage.incomplete, 3);
-      assert.equal(summarizedStage.completed, 0);
+      const studentLessonProgress = progressForLesson(studentProgress, levels);
+      assert.deepEqual(studentLessonProgress, {
+        isStarted: false,
+        incompletePercent: 100,
+        imperfectPercent: 0,
+        completedPercent: 0,
+        timeSpent: 0,
+        lastTimestamp: 0
+      });
     });
 
     it('summarizes all completed levels', () => {
@@ -278,11 +283,15 @@ describe('progressHelpers', () => {
       studentProgress[2].status = LevelStatus.submitted;
       studentProgress[3].status = LevelStatus.readonly;
 
-      const summarizedStage = summarizeProgressInStage(studentProgress, levels);
-      assert.equal(summarizedStage.total, 3);
-      assert.equal(summarizedStage.incomplete, 0);
-      assert.equal(summarizedStage.completed, 3);
-      assert.equal(summarizedStage.attempted, 0);
+      const studentLessonProgress = progressForLesson(studentProgress, levels);
+      assert.deepEqual(studentLessonProgress, {
+        isStarted: true,
+        incompletePercent: 0,
+        imperfectPercent: 0,
+        completedPercent: 100,
+        timeSpent: 0,
+        lastTimestamp: 0
+      });
     });
 
     it('summarizes all attempted levels', () => {
@@ -291,43 +300,104 @@ describe('progressHelpers', () => {
         levels,
         LevelStatus.attempted
       );
-      const summarizedStage = summarizeProgressInStage(studentProgress, levels);
-      assert.equal(summarizedStage.total, 2);
-      assert.equal(summarizedStage.incomplete, 2);
-      assert.equal(summarizedStage.completed, 0);
-      assert.equal(summarizedStage.attempted, 2);
+      const studentLessonProgress = progressForLesson(studentProgress, levels);
+      assert.deepEqual(studentLessonProgress, {
+        isStarted: true,
+        incompletePercent: 100,
+        imperfectPercent: 0,
+        completedPercent: 0,
+        timeSpent: 0,
+        lastTimestamp: 0
+      });
     });
 
     it('summarizes a mix of levels', () => {
-      const levels = fakeLevels(7);
+      const levels = fakeLevels(8);
       const studentProgress = fakeProgressForLevels(levels);
       studentProgress[1].status = LevelStatus.submitted;
       studentProgress[2].status = LevelStatus.perfect;
       studentProgress[3].status = LevelStatus.attempted;
       studentProgress[4].status = LevelStatus.passed;
       studentProgress[5].status = LevelStatus.free_play_complete;
-      studentProgress[6].status = 'other';
+      studentProgress[6].status = LevelStatus.locked;
+      studentProgress[7].status = 'other';
 
-      const summarizedStage = summarizeProgressInStage(studentProgress, levels);
-      assert.equal(summarizedStage.total, 7);
-      assert.equal(summarizedStage.incomplete, 3);
-      assert.equal(summarizedStage.completed, 3);
-      assert.equal(summarizedStage.imperfect, 1);
-      assert.equal(summarizedStage.attempted, 1);
+      const studentLessonProgress = progressForLesson(studentProgress, levels);
+      assert.deepEqual(studentLessonProgress, {
+        isStarted: true,
+        incompletePercent: 50,
+        imperfectPercent: 12.5,
+        completedPercent: 37.5,
+        timeSpent: 0,
+        lastTimestamp: 0
+      });
     });
 
-    it('does not summarize bonus levels', () => {
-      const levels = fakeLevels(1);
+    it('does not include bonus levels', () => {
+      const levels = fakeLevels(2);
       const studentProgress = fakeProgressForLevels(levels);
-      studentProgress[1].status = LevelStatus.submitted;
+      studentProgress[1].status = LevelStatus.perfect;
       levels[0].bonus = true;
 
-      const summarizedStage = summarizeProgressInStage(studentProgress, levels);
-      assert.equal(summarizedStage.total, 0);
-      assert.equal(summarizedStage.incomplete, 0);
-      assert.equal(summarizedStage.completed, 0);
-      assert.equal(summarizedStage.imperfect, 0);
-      assert.equal(summarizedStage.attempted, 0);
+      const studentLessonProgress = progressForLesson(studentProgress, levels);
+      assert.deepEqual(studentLessonProgress, {
+        isStarted: false,
+        incompletePercent: 100,
+        imperfectPercent: 0,
+        completedPercent: 0,
+        timeSpent: 0,
+        lastTimestamp: 0
+      });
+    });
+
+    it('returns null if all levels are bonus', () => {
+      const levels = fakeLevels(2);
+      const studentProgress = fakeProgressForLevels(levels);
+      levels[0].bonus = true;
+      levels[1].bonus = true;
+
+      const studentLessonProgress = progressForLesson(studentProgress, levels);
+      assert.equal(studentLessonProgress, null);
+    });
+
+    it('computes correct timeSpent', () => {
+      const levels = fakeLevels(2);
+      const studentProgress = fakeProgressForLevels(
+        levels,
+        LevelStatus.attempted
+      );
+      studentProgress[1].timeSpent = 1;
+      studentProgress[2].timeSpent = 2;
+
+      const studentLessonProgress = progressForLesson(studentProgress, levels);
+      assert.deepEqual(studentLessonProgress, {
+        isStarted: true,
+        incompletePercent: 100,
+        imperfectPercent: 0,
+        completedPercent: 0,
+        timeSpent: 3,
+        lastTimestamp: 0
+      });
+    });
+
+    it('computes correct lastTimestamp', () => {
+      const levels = fakeLevels(2);
+      const studentProgress = fakeProgressForLevels(
+        levels,
+        LevelStatus.attempted
+      );
+      studentProgress[1].lastTimestamp = 2;
+      studentProgress[2].lastTimestamp = 1;
+
+      const studentLessonProgress = progressForLesson(studentProgress, levels);
+      assert.deepEqual(studentLessonProgress, {
+        isStarted: true,
+        incompletePercent: 100,
+        imperfectPercent: 0,
+        completedPercent: 0,
+        timeSpent: 0,
+        lastTimestamp: 2
+      });
     });
   });
 });

--- a/apps/test/unit/templates/sectionProgress/SectionProgressTest.js
+++ b/apps/test/unit/templates/sectionProgress/SectionProgressTest.js
@@ -16,7 +16,7 @@ describe('SectionProgress', () => {
   let DEFAULT_PROPS;
 
   beforeEach(() => {
-    sinon.stub(progressLoader, 'loadScript');
+    sinon.stub(progressLoader, 'loadScriptProgress');
     DEFAULT_PROPS = {
       setLessonOfInterest: () => {},
       setCurrentView: () => {},
@@ -51,7 +51,7 @@ describe('SectionProgress', () => {
   });
 
   afterEach(() => {
-    progressLoader.loadScript.restore();
+    progressLoader.loadScriptProgress.restore();
   });
 
   it('loading data shows loading icon', () => {

--- a/apps/test/unit/templates/sectionProgress/StandardsReportTest.jsx
+++ b/apps/test/unit/templates/sectionProgress/StandardsReportTest.jsx
@@ -10,7 +10,7 @@ describe('StandardsReport', () => {
   let DEFAULT_PROPS;
 
   beforeEach(() => {
-    sinon.stub(progressLoader, 'loadScript');
+    sinon.stub(progressLoader, 'loadScriptProgress');
     DEFAULT_PROPS = {
       scriptId: 2,
       teacherName: 'Awesome Teacher',
@@ -49,7 +49,7 @@ describe('StandardsReport', () => {
 
   afterEach(() => {
     restoreOnWindow('opener');
-    progressLoader.loadScript.restore();
+    progressLoader.loadScriptProgress.restore();
   });
 
   it('report shows print buttons', () => {

--- a/apps/test/unit/templates/sectionProgress/progressTables/ProgressTableSummaryCellTest.jsx
+++ b/apps/test/unit/templates/sectionProgress/progressTables/ProgressTableSummaryCellTest.jsx
@@ -1,7 +1,9 @@
 import React from 'react';
 import {expect} from '../../../../util/reconfiguredChai';
 import {mount} from 'enzyme';
-import ProgressTableSummaryCell from '@cdo/apps/templates/sectionProgress/progressTables/ProgressTableSummaryCell';
+import ProgressTableSummaryCell, {
+  unitTestExports
+} from '@cdo/apps/templates/sectionProgress/progressTables/ProgressTableSummaryCell';
 import color from '@cdo/apps/util/color';
 import sinon from 'sinon';
 import _ from 'lodash';
@@ -22,12 +24,8 @@ const DEFAULT_PROPS = {
 
 const setUp = (overrideProps = {}) => {
   const props = _.merge(_.cloneDeep(DEFAULT_PROPS), overrideProps);
-  return (
-    mount(<ProgressTableSummaryCell {...props} />)
-      // <BorderedBox>
-      .childAt(0)
-      // styled <div>
-      .childAt(0)
+  return mount(<ProgressTableSummaryCell {...props} />).find(
+    unitTestExports.BorderedBox
   );
 };
 
@@ -38,8 +36,7 @@ const getStyle = (wrapper, styleName) => {
 describe('ProgressTableSummaryCell', () => {
   it('displays as not started when missing progress data', () => {
     const wrapper = setUp({studentLessonProgress: null});
-    const borderColor = getStyle(wrapper, 'borderColor');
-    expect(borderColor).to.equal(color.light_gray);
+    expect(wrapper.props().borderColor).to.equal(color.light_gray);
   });
 
   it('calls onSelectDetailView when clicked', () => {
@@ -52,22 +49,19 @@ describe('ProgressTableSummaryCell', () => {
   it('displays border as color.light_gray when a lesson has not been started', () => {
     const studentLessonProgress = {isStarted: false};
     const wrapper = setUp({studentLessonProgress});
-    const borderColor = getStyle(wrapper, 'borderColor');
-    expect(borderColor).to.equal(color.light_gray);
+    expect(wrapper.props().borderColor).to.equal(color.light_gray);
   });
 
   it('displays border as color.level_perfect when a lesson has been started and not isAssessmentLesson', () => {
     const studentLessonProgress = {isStarted: true};
     const wrapper = setUp({isAssessmentLesson: false, studentLessonProgress});
-    const borderColor = getStyle(wrapper, 'borderColor');
-    expect(borderColor).to.equal(color.level_perfect);
+    expect(wrapper.props().borderColor).to.equal(color.level_perfect);
   });
 
   it('displays border as color.level_submitted when a lesson has been started and is isAssessmentLesson', () => {
     const studentLessonProgress = {isStarted: true};
     const wrapper = setUp({isAssessmentLesson: true, studentLessonProgress});
-    const borderColor = getStyle(wrapper, 'borderColor');
-    expect(borderColor).to.equal(color.level_submitted);
+    expect(wrapper.props().borderColor).to.equal(color.level_submitted);
   });
 
   it('displays incomplete portion as a percent in color.level_not_tried', () => {
@@ -78,7 +72,7 @@ describe('ProgressTableSummaryCell', () => {
       incompletePercent: 75
     };
     const wrapper = setUp({studentLessonProgress});
-    const incompletePortion = wrapper.childAt(0);
+    const incompletePortion = wrapper.childAt(0).childAt(0);
 
     const backgroundColor = getStyle(incompletePortion, 'backgroundColor');
     expect(backgroundColor).to.equal(color.level_not_tried);
@@ -95,7 +89,7 @@ describe('ProgressTableSummaryCell', () => {
       incompletePercent: 50
     };
     const wrapper = setUp({studentLessonProgress});
-    const imperfectPortion = wrapper.childAt(1);
+    const imperfectPortion = wrapper.childAt(0).childAt(1);
 
     const backgroundColor = getStyle(imperfectPortion, 'backgroundColor');
     expect(backgroundColor).to.equal(color.level_passed);
@@ -112,7 +106,7 @@ describe('ProgressTableSummaryCell', () => {
       incompletePercent: 50
     };
     const wrapper = setUp({isAssessmentLesson: true, studentLessonProgress});
-    const completedPortion = wrapper.childAt(2);
+    const completedPortion = wrapper.childAt(0).childAt(2);
 
     const backgroundColor = getStyle(completedPortion, 'backgroundColor');
     expect(backgroundColor).to.equal(color.level_submitted);
@@ -129,7 +123,7 @@ describe('ProgressTableSummaryCell', () => {
       incompletePercent: 50
     };
     const wrapper = setUp({isAssessmentLesson: false, studentLessonProgress});
-    const completedPortion = wrapper.childAt(2);
+    const completedPortion = wrapper.childAt(0).childAt(2);
 
     const backgroundColor = getStyle(completedPortion, 'backgroundColor');
     expect(backgroundColor).to.equal(color.level_perfect);

--- a/apps/test/unit/templates/sectionProgress/progressTables/ProgressTableSummaryCellTest.jsx
+++ b/apps/test/unit/templates/sectionProgress/progressTables/ProgressTableSummaryCellTest.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import {expect} from '../../../../util/reconfiguredChai';
-import {shallow} from 'enzyme';
+import {mount} from 'enzyme';
 import ProgressTableSummaryCell from '@cdo/apps/templates/sectionProgress/progressTables/ProgressTableSummaryCell';
 import color from '@cdo/apps/util/color';
 import sinon from 'sinon';
@@ -12,15 +12,23 @@ const DEFAULT_PROPS = {
     isStarted: true,
     completedPercent: 100,
     imperfectPercent: 0,
-    incompletePercent: 0
+    incompletePercent: 0,
+    timeSpent: 0,
+    lastTimestamp: 0
   },
   isAssessmentLesson: false,
   onSelectDetailView: () => {}
 };
 
 const setUp = (overrideProps = {}) => {
-  const props = _.merge(DEFAULT_PROPS, overrideProps);
-  return shallow(<ProgressTableSummaryCell {...props} />);
+  const props = _.merge(_.cloneDeep(DEFAULT_PROPS), overrideProps);
+  return (
+    mount(<ProgressTableSummaryCell {...props} />)
+      // <BorderedBox>
+      .childAt(0)
+      // styled <div>
+      .childAt(0)
+  );
 };
 
 const getStyle = (wrapper, styleName) => {
@@ -28,6 +36,12 @@ const getStyle = (wrapper, styleName) => {
 };
 
 describe('ProgressTableSummaryCell', () => {
+  it('displays as not started when missing progress data', () => {
+    const wrapper = setUp({studentLessonProgress: null});
+    const borderColor = getStyle(wrapper, 'borderColor');
+    expect(borderColor).to.equal(color.light_gray);
+  });
+
   it('calls onSelectDetailView when clicked', () => {
     const onClickSpy = sinon.spy();
     const wrapper = setUp({onSelectDetailView: onClickSpy});

--- a/apps/test/unit/templates/sectionProgress/progressTables/ProgressTableSummaryViewTest.jsx
+++ b/apps/test/unit/templates/sectionProgress/progressTables/ProgressTableSummaryViewTest.jsx
@@ -24,8 +24,16 @@ import {
   fakeProgressTableReduxInitialState
 } from '@cdo/apps/templates/progress/progressTestHelpers';
 
-const LESSON_1 = fakeLessonWithLevels({position: 1, levels: fakeLevels(1)});
-const LESSON_2 = fakeLessonWithLevels({position: 2, levels: fakeLevels(2)});
+const LESSON_1 = fakeLessonWithLevels({
+  id: 1,
+  position: 1,
+  levels: fakeLevels(1)
+});
+const LESSON_2 = fakeLessonWithLevels({
+  id: 2,
+  position: 2,
+  levels: fakeLevels(2)
+});
 const STAGES = [LESSON_1, LESSON_2];
 const STUDENTS = fakeStudents(2);
 const SCRIPT_DATA = fakeScriptData({stages: STAGES});

--- a/apps/test/unit/templates/sectionProgress/sectionProgressLoaderTest.js
+++ b/apps/test/unit/templates/sectionProgress/sectionProgressLoaderTest.js
@@ -1,6 +1,6 @@
 import {expect} from '../../../util/reconfiguredChai';
 import sinon from 'sinon';
-import {loadScript} from '@cdo/apps/templates/sectionProgress/sectionProgressLoader';
+import {loadScriptProgress} from '@cdo/apps/templates/sectionProgress/sectionProgressLoader';
 import * as sectionProgress from '@cdo/apps/templates/sectionProgress/sectionProgressRedux';
 import * as progressHelpers from '@cdo/apps/templates/progress/progressHelpers';
 import * as redux from '@cdo/apps/redux';
@@ -240,7 +240,7 @@ describe('sectionProgressLoader.loadScript', () => {
         };
       }
     });
-    expect(loadScript(0)).to.be.undefined;
+    expect(loadScriptProgress(0)).to.be.undefined;
     expect(startLoadingProgressStub).to.have.not.been.called;
     expect(startRefreshingProgressStub).to.have.not.been.called;
   });
@@ -292,7 +292,7 @@ describe('sectionProgressLoader.loadScript', () => {
         })
       });
 
-      loadScript(0, 0);
+      loadScriptProgress(0, 0);
       expect(startLoadingProgressStub).to.have.not.been.called;
       expect(startRefreshingProgressStub).to.have.been.calledOnce;
       expect(addDataByScriptStub).to.have.been.calledOnce;
@@ -337,7 +337,7 @@ describe('sectionProgressLoader.loadScript', () => {
           then: sinon.stub().callsArgWith(0, secondServerProgressResponse)
         })
       });
-      loadScript(123, 0);
+      loadScriptProgress(123, 0);
       expect(addDataByScriptStub).to.have.been.calledWith(fullExpectedResult);
       progressHelpers.processedLevel.restore();
     });
@@ -371,7 +371,7 @@ describe('sectionProgressLoader.loadScript', () => {
           })
         });
 
-        loadScript(0, 0);
+        loadScriptProgress(0, 0);
         expect(startLoadingProgressStub).to.have.been.calledOnce;
         expect(startRefreshingProgressStub).to.have.not.been.called;
         expect(addDataByScriptStub).to.have.been.calledOnce;
@@ -414,7 +414,7 @@ describe('sectionProgressLoader.loadScript', () => {
             then: sinon.stub().callsArgWith(0, {})
           })
         });
-        loadScript(0, 0);
+        loadScriptProgress(0, 0);
         expect(addDataByScriptStub).to.have.been.calledWith(expectedResult);
         progressHelpers.processedLevel.restore();
       });
@@ -432,7 +432,7 @@ describe('sectionProgressLoader.loadScript', () => {
             then: sinon.stub().callsArgWith(0, serverProgressResponse)
           })
         });
-        loadScript(123, 0);
+        loadScriptProgress(123, 0);
         expect(addDataByScriptStub).to.have.been.calledWith(fullExpectedResult);
         progressHelpers.processedLevel.restore();
       });

--- a/apps/test/unit/templates/sectionProgress/sectionProgressLoaderTest.js
+++ b/apps/test/unit/templates/sectionProgress/sectionProgressLoaderTest.js
@@ -12,7 +12,7 @@ const serverScriptResponse = {
   hasStandards: false,
   id: 123,
   path: 'test/url',
-  lessons: [{levels: []}],
+  lessons: [{id: 11, levels: [{id: '2000'}, {id: '2001'}]}],
   title: 'Course B',
   version_year: '2020'
 };
@@ -25,13 +25,13 @@ const serverProgressResponse = {
     total_pages: 1
   },
   student_last_updates: {
-    '100': null,
-    '101': timeInSeconds,
-    '102': timeInSeconds + 1
+    100: null,
+    101: timeInSeconds,
+    102: timeInSeconds + 1
   },
   student_progress: {
-    '100': {},
-    '101': {
+    100: {},
+    101: {
       '2000': {
         status: 'locked',
         result: 1001,
@@ -47,7 +47,7 @@ const serverProgressResponse = {
         last_progress_at: 12345
       }
     },
-    '102': {
+    102: {
       '2000': {
         status: 'perfect',
         result: 100,
@@ -66,12 +66,12 @@ const firstServerProgressResponse = {
     total_pages: 2
   },
   student_last_updates: {
-    '100': null,
-    '101': timeInSeconds
+    100: null,
+    101: timeInSeconds
   },
   student_progress: {
-    '100': {},
-    '101': {
+    100: {},
+    101: {
       '2000': {
         status: 'locked',
         result: 1001,
@@ -97,10 +97,10 @@ const secondServerProgressResponse = {
     total_pages: 2
   },
   student_last_updates: {
-    '102': timeInSeconds + 1
+    102: timeInSeconds + 1
   },
   student_progress: {
-    '102': {
+    102: {
       '2000': {
         status: 'perfect',
         result: 100,
@@ -121,7 +121,7 @@ const fullExpectedResult = {
       hasStandards: false,
       id: 123,
       path: 'test/url',
-      stages: [{levels: []}],
+      stages: [{id: 11, levels: [{id: '2000'}, {id: '2001'}]}],
       title: 'Course B',
       version_year: '2020'
     }
@@ -153,6 +153,40 @@ const fullExpectedResult = {
           status: 'perfect',
           result: 100,
           paired: false,
+          timeSpent: 6789,
+          lastTimestamp: 6789
+        }
+      }
+    }
+  },
+  studentLessonProgressByScript: {
+    123: {
+      100: {
+        11: {
+          isStarted: false,
+          incompletePercent: 100,
+          imperfectPercent: 0,
+          completedPercent: 0,
+          timeSpent: 0,
+          lastTimestamp: 0
+        }
+      },
+      101: {
+        11: {
+          isStarted: true,
+          incompletePercent: 50,
+          imperfectPercent: 0,
+          completedPercent: 50,
+          timeSpent: 12345,
+          lastTimestamp: 12345
+        }
+      },
+      102: {
+        11: {
+          isStarted: true,
+          incompletePercent: 50,
+          imperfectPercent: 0,
+          completedPercent: 50,
           timeSpent: 6789,
           lastTimestamp: 6789
         }
@@ -272,6 +306,7 @@ describe('sectionProgressLoader.loadScript', () => {
           return {
             sectionProgress: {
               studentLevelProgressByScript: [],
+              studentLessonProgressByScript: [],
               scriptDataByScript: [],
               currentView: 0
             },
@@ -285,7 +320,7 @@ describe('sectionProgressLoader.loadScript', () => {
         dispatch: () => {}
       });
 
-      sinon.stub(progressHelpers, 'processedLevel');
+      sinon.stub(progressHelpers, 'processedLevel').returnsArg(0);
       addDataByScriptStub = sinon.spy(sectionProgress, 'addDataByScript');
       fetchStub.onCall(0).returns({
         then: sinon.stub().returns({
@@ -365,6 +400,7 @@ describe('sectionProgressLoader.loadScript', () => {
             }
           },
           studentLevelProgressByScript: {'0': {}},
+          studentLessonProgressByScript: {'0': {}},
           studentLastUpdateByScript: {'0': {}}
         };
 
@@ -384,7 +420,7 @@ describe('sectionProgressLoader.loadScript', () => {
       });
 
       it('transforms the data provided by the server', () => {
-        sinon.stub(progressHelpers, 'processedLevel');
+        sinon.stub(progressHelpers, 'processedLevel').returnsArg(0);
         addDataByScriptStub = sinon.spy(sectionProgress, 'addDataByScript');
         fetchStub.onCall(0).returns({
           then: sinon.stub().returns({


### PR DESCRIPTION
this PR updates how we calculate the "lesson progress" we display in the section progress summary view in two ways:

1. the data is now computed when we initially receive it from the server and stored in redux alongside level progress data, rather than calculating it at render time as we were doing before
2. `timeSpent` and `lastTimestamp` have been added to `studentLessonProgressType` for display in the forthcoming expanded detail rows we will be adding to the progress tables.

now that the summary table and detail table rely on different redux data, the redux connection had to be moved out of the shared `ProgressTableContainer` component into the summary and detail view components.

since level progress data is sparsely populated it made sense to do the same for lesson progress data, so `ProgressTableSummaryCell` was updated to handle missing lesson progress data.

## Links

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

- jira ticket: [LP-1744]

[LP-1744]: https://codedotorg.atlassian.net/browse/LP-1744