### PR TITLE
Improvements to editing expandable images

### DIFF
--- a/apps/src/lib/levelbuilder/TextareaWithImageUpload.jsx
+++ b/apps/src/lib/levelbuilder/TextareaWithImageUpload.jsx
@@ -47,8 +47,10 @@ export default class TextareaWithImageUpload extends React.Component {
   };
 
   handleUploadImage = (url, expandable) => {
-    let param = expandable ? 'expandable' : '';
-    let e = {target: {value: this.props.markdown + `\n\n![${param}](${url})`}};
+    const param = expandable ? 'expandable' : '';
+    const e = {
+      target: {value: this.props.markdown + `\n\n![${param}](${url})`}
+    };
     this.props.handleMarkdownChange(e);
   };
 

--- a/apps/src/lib/levelbuilder/TextareaWithImageUpload.jsx
+++ b/apps/src/lib/levelbuilder/TextareaWithImageUpload.jsx
@@ -46,8 +46,9 @@ export default class TextareaWithImageUpload extends React.Component {
     this.setState({uploadImageOpen: false});
   };
 
-  handleUploadImage = url => {
-    let e = {target: {value: this.props.markdown + `\n\n![](${url})`}};
+  handleUploadImage = (url, expandable) => {
+    let param = expandable ? 'expandable' : '';
+    let e = {target: {value: this.props.markdown + `\n\n![${param}](${url})`}};
     this.props.handleMarkdownChange(e);
   };
 

--- a/apps/src/lib/levelbuilder/TextareaWithMarkdownPreview.jsx
+++ b/apps/src/lib/levelbuilder/TextareaWithMarkdownPreview.jsx
@@ -66,7 +66,7 @@ export default class TextareaWithMarkdownPreview extends React.Component {
               <EnhancedSafeMarkdown
                 openExternalLinksInNewTab={true}
                 markdown={this.props.markdown}
-                expandableImages={true}
+                expandableImages
               />
             </div>
           </div>

--- a/apps/src/lib/levelbuilder/TextareaWithMarkdownPreview.jsx
+++ b/apps/src/lib/levelbuilder/TextareaWithMarkdownPreview.jsx
@@ -1,6 +1,6 @@
 import PropTypes from 'prop-types';
 import React from 'react';
-import SafeMarkdown from '@cdo/apps/templates/SafeMarkdown';
+import EnhancedSafeMarkdown from '@cdo/apps/templates/EnhancedSafeMarkdown';
 import color from '@cdo/apps/util/color';
 import TextareaWithImageUpload from '@cdo/apps/lib/levelbuilder/TextareaWithImageUpload';
 import HelpTip from '@cdo/apps/lib/ui/HelpTip';
@@ -63,9 +63,10 @@ export default class TextareaWithMarkdownPreview extends React.Component {
           <div style={styles.container}>
             <div style={{marginBottom: 5}}>Preview:</div>
             <div style={styles.preview}>
-              <SafeMarkdown
+              <EnhancedSafeMarkdown
                 openExternalLinksInNewTab={true}
                 markdown={this.props.markdown}
+                expandableImages={true}
               />
             </div>
           </div>

--- a/apps/src/lib/levelbuilder/lesson-editor/ActivitySectionCard.jsx
+++ b/apps/src/lib/levelbuilder/lesson-editor/ActivitySectionCard.jsx
@@ -422,7 +422,7 @@ class ActivitySectionCard extends Component {
   };
 
   handleUploadImage = (url, expandable) => {
-    let param = expandable ? 'expandable' : '';
+    const param = expandable ? 'expandable' : '';
     this.appendMarkdownSyntax(`\n\n![${param}](${url})`);
   };
 

--- a/apps/src/lib/levelbuilder/lesson-editor/ActivitySectionCard.jsx
+++ b/apps/src/lib/levelbuilder/lesson-editor/ActivitySectionCard.jsx
@@ -421,8 +421,9 @@ class ActivitySectionCard extends Component {
     );
   };
 
-  handleUploadImage = url => {
-    this.appendMarkdownSyntax(`\n\n![](${url})`);
+  handleUploadImage = (url, expandable) => {
+    let param = expandable ? 'expandable' : '';
+    this.appendMarkdownSyntax(`\n\n![${param}](${url})`);
   };
 
   render() {

--- a/apps/src/lib/levelbuilder/lesson-editor/UploadImageDialog.jsx
+++ b/apps/src/lib/levelbuilder/lesson-editor/UploadImageDialog.jsx
@@ -108,7 +108,7 @@ export default class UploadImageDialog extends React.Component {
             type="checkbox"
             checked={this.state.expandable}
             style={styles.checkbox}
-            onChange={() => this.setState({expandable: !this.state.expandable})}
+            onChange={e => this.setState({expandable: e.target.checked})}
           />
           <HelpTip>
             <p>

--- a/apps/src/lib/levelbuilder/lesson-editor/UploadImageDialog.jsx
+++ b/apps/src/lib/levelbuilder/lesson-editor/UploadImageDialog.jsx
@@ -112,8 +112,8 @@ export default class UploadImageDialog extends React.Component {
           />
           <HelpTip>
             <p>
-              Click if you want the image to be able to be enlarged in a dialog
-              over the page.
+              Check if you want the image to be able to be enlarged in a dialog
+              over the page when clicked.
             </p>
           </HelpTip>
         </label>

--- a/apps/src/lib/levelbuilder/lesson-editor/UploadImageDialog.jsx
+++ b/apps/src/lib/levelbuilder/lesson-editor/UploadImageDialog.jsx
@@ -5,6 +5,16 @@ import Button from '@cdo/apps/templates/Button';
 import i18n from '@cdo/locale';
 
 import LessonEditorDialog from './LessonEditorDialog';
+import HelpTip from '@cdo/apps/lib/ui/HelpTip';
+
+const styles = {
+  checkbox: {
+    margin: '0 0 0 7px'
+  },
+  label: {
+    margin: '10px 0'
+  }
+};
 
 export default class UploadImageDialog extends React.Component {
   static propTypes = {
@@ -15,12 +25,14 @@ export default class UploadImageDialog extends React.Component {
 
   state = {
     imgUrl: undefined,
+    expandable: false,
     error: undefined
   };
 
   resetState = () => {
     this.setState({
       imgUrl: undefined,
+      expandable: false,
       error: undefined
     });
   };
@@ -67,7 +79,7 @@ export default class UploadImageDialog extends React.Component {
 
   handleCloseAndSave = () => {
     if (this.state.imgUrl) {
-      this.props.uploadImage(this.state.imgUrl);
+      this.props.uploadImage(this.state.imgUrl, this.state.expandable);
     }
 
     this.handleClose();
@@ -89,6 +101,22 @@ export default class UploadImageDialog extends React.Component {
             <span>{this.state.error.toString()}</span>
           </div>
         )}
+
+        <label style={styles.label}>
+          Expandable
+          <input
+            type="checkbox"
+            checked={this.state.expandable}
+            style={styles.checkbox}
+            onChange={() => this.setState({expandable: !this.state.expandable})}
+          />
+          <HelpTip>
+            <p>
+              Click if you want the image to be able to be enlarged in a dialog
+              over the page.
+            </p>
+          </HelpTip>
+        </label>
 
         <hr />
 

--- a/apps/src/sites/studio/pages/lessons/edit.js
+++ b/apps/src/sites/studio/pages/lessons/edit.js
@@ -18,11 +18,6 @@ import instructionsDialog from '@cdo/apps/redux/instructionsDialog';
 import ExpandableImageDialog from '@cdo/apps/templates/lessonOverview/ExpandableImageDialog';
 
 $(document).ready(function() {
-  displayLessonEdit();
-  prepareExpandableImageDialog();
-});
-
-function displayLessonEdit() {
   const lessonData = getScriptData('lesson');
   const relatedLessons = getScriptData('relatedLessons');
   const searchOptions = getScriptData('searchOptions');
@@ -32,6 +27,7 @@ function displayLessonEdit() {
 
   registerReducers({
     ...reducers,
+    instructionsDialog: instructionsDialog,
     resources: resourcesEditor,
     vocabularies: vocabulariesEditor
   });
@@ -43,32 +39,15 @@ function displayLessonEdit() {
 
   ReactDOM.render(
     <Provider store={store}>
-      <LessonEditor
-        initialObjectives={objectives}
-        relatedLessons={relatedLessons}
-        initialLessonData={lessonData}
-      />
+      <div>
+        <LessonEditor
+          initialObjectives={objectives}
+          relatedLessons={relatedLessons}
+          initialLessonData={lessonData}
+        />
+        <ExpandableImageDialog />
+      </div>
     </Provider>,
     document.getElementById('edit-container')
   );
-}
-
-/**
- * Initialize the DOM Element and React Component which serve as containers to
- * display expandable images.
- *
- * @see @cdo/apps/src/templates/utils/expandableImages
- */
-function prepareExpandableImageDialog() {
-  registerReducers({instructionsDialog});
-
-  const container = document.createElement('div');
-  document.body.appendChild(container);
-
-  ReactDOM.render(
-    <Provider store={getStore()}>
-      <ExpandableImageDialog />
-    </Provider>,
-    container
-  );
-}
+});

--- a/apps/src/sites/studio/pages/lessons/edit.js
+++ b/apps/src/sites/studio/pages/lessons/edit.js
@@ -14,8 +14,15 @@ import vocabulariesEditor, {
   initVocabularies
 } from '@cdo/apps/lib/levelbuilder/lesson-editor/vocabulariesEditorRedux';
 import {Provider} from 'react-redux';
+import instructionsDialog from '@cdo/apps/redux/instructionsDialog';
+import ExpandableImageDialog from '@cdo/apps/templates/lessonOverview/ExpandableImageDialog';
 
 $(document).ready(function() {
+  displayLessonEdit();
+  prepareExpandableImageDialog();
+});
+
+function displayLessonEdit() {
   const lessonData = getScriptData('lesson');
   const relatedLessons = getScriptData('relatedLessons');
   const searchOptions = getScriptData('searchOptions');
@@ -44,4 +51,24 @@ $(document).ready(function() {
     </Provider>,
     document.getElementById('edit-container')
   );
-});
+}
+
+/**
+ * Initialize the DOM Element and React Component which serve as containers to
+ * display expandable images.
+ *
+ * @see @cdo/apps/src/templates/utils/expandableImages
+ */
+function prepareExpandableImageDialog() {
+  registerReducers({instructionsDialog});
+
+  const container = document.createElement('div');
+  document.body.appendChild(container);
+
+  ReactDOM.render(
+    <Provider store={getStore()}>
+      <ExpandableImageDialog />
+    </Provider>,
+    container
+  );
+}

--- a/apps/src/templates/instructions/MarkdownInstructions.jsx
+++ b/apps/src/templates/instructions/MarkdownInstructions.jsx
@@ -106,7 +106,7 @@ class MarkdownInstructions extends React.Component {
           inTopPane && canCollapse && styles.inTopPaneCanCollapse
         ]}
       >
-        <EnhancedSafeMarkdown markdown={markdown} expandableImages={true} />
+        <EnhancedSafeMarkdown markdown={markdown} expandableImages />
       </div>
     );
   }

--- a/apps/src/templates/lessonOverview/LessonOverview.jsx
+++ b/apps/src/templates/lessonOverview/LessonOverview.jsx
@@ -146,7 +146,7 @@ class LessonOverview extends Component {
                 <h2 style={styles.titleNoTopMargin}>{i18n.overview()}</h2>
                 <EnhancedSafeMarkdown
                   markdown={lesson.overview}
-                  expandableImages={true}
+                  expandableImages
                 />
               </div>
             )}
@@ -155,7 +155,7 @@ class LessonOverview extends Component {
                 <h2>{i18n.purpose()}</h2>
                 <EnhancedSafeMarkdown
                   markdown={lesson.purpose}
-                  expandableImages={true}
+                  expandableImages
                 />
               </div>
             )}
@@ -164,7 +164,7 @@ class LessonOverview extends Component {
                 <h2>{i18n.assessmentOpportunities()}</h2>
                 <EnhancedSafeMarkdown
                   markdown={lesson.assessmentOpportunities}
-                  expandableImages={true}
+                  expandableImages
                 />
               </div>
             )}
@@ -190,7 +190,7 @@ class LessonOverview extends Component {
                 <h2>{i18n.preparation()}</h2>
                 <EnhancedSafeMarkdown
                   markdown={lesson.preparation}
-                  expandableImages={true}
+                  expandableImages
                 />
               </div>
             )}

--- a/apps/src/templates/lessonOverview/LessonOverview.jsx
+++ b/apps/src/templates/lessonOverview/LessonOverview.jsx
@@ -8,6 +8,7 @@ import {connect} from 'react-redux';
 import {SignInState} from '@cdo/apps/templates/currentUserRedux';
 import {ViewType} from '@cdo/apps/code-studio/viewAsRedux';
 import SafeMarkdown from '@cdo/apps/templates/SafeMarkdown';
+import EnhancedSafeMarkdown from '@cdo/apps/templates/EnhancedSafeMarkdown';
 import InlineMarkdown from '@cdo/apps/templates/InlineMarkdown';
 import styleConstants from '@cdo/apps/styleConstants';
 import color from '@cdo/apps/util/color';
@@ -143,19 +144,28 @@ class LessonOverview extends Component {
             {lesson.overview && (
               <div>
                 <h2 style={styles.titleNoTopMargin}>{i18n.overview()}</h2>
-                <SafeMarkdown markdown={lesson.overview} />
+                <EnhancedSafeMarkdown
+                  markdown={lesson.overview}
+                  expandableImages={true}
+                />
               </div>
             )}
             {lesson.purpose && (
               <div>
                 <h2>{i18n.purpose()}</h2>
-                <SafeMarkdown markdown={lesson.purpose} />
+                <EnhancedSafeMarkdown
+                  markdown={lesson.purpose}
+                  expandableImages={true}
+                />
               </div>
             )}
             {lesson.assessmentOpportunities && (
               <div>
                 <h2>{i18n.assessmentOpportunities()}</h2>
-                <SafeMarkdown markdown={lesson.assessmentOpportunities} />
+                <EnhancedSafeMarkdown
+                  markdown={lesson.assessmentOpportunities}
+                  expandableImages={true}
+                />
               </div>
             )}
             <h2>{i18n.agenda()}</h2>
@@ -178,7 +188,10 @@ class LessonOverview extends Component {
             {lesson.preparation && (
               <div>
                 <h2>{i18n.preparation()}</h2>
-                <SafeMarkdown markdown={lesson.preparation} />
+                <EnhancedSafeMarkdown
+                  markdown={lesson.preparation}
+                  expandableImages={true}
+                />
               </div>
             )}
             {Object.keys(lesson.resources).length > 0 && (

--- a/apps/src/templates/lessonOverview/activities/ActivitySection.jsx
+++ b/apps/src/templates/lessonOverview/activities/ActivitySection.jsx
@@ -80,10 +80,7 @@ export default class ActivitySection extends Component {
                 })
               }}
             >
-              <EnhancedSafeMarkdown
-                markdown={section.text}
-                expandableImages={true}
-              />
+              <EnhancedSafeMarkdown markdown={section.text} expandableImages />
             </div>
           </div>
           <div>

--- a/apps/test/unit/lib/levelbuilder/TextareaWithMarkdownPreviewTest.jsx
+++ b/apps/test/unit/lib/levelbuilder/TextareaWithMarkdownPreviewTest.jsx
@@ -1,6 +1,6 @@
 import {expect} from '../../../util/reconfiguredChai';
 import React from 'react';
-import {mount} from 'enzyme';
+import {shallow} from 'enzyme';
 import TextareaWithMarkdownPreview from '@cdo/apps/lib/levelbuilder/TextareaWithMarkdownPreview';
 import sinon from 'sinon';
 
@@ -18,14 +18,14 @@ describe('TextareaWithMarkdownPreview', () => {
   });
 
   it('has correct markdown for preview of unit description', () => {
-    const wrapper = mount(<TextareaWithMarkdownPreview {...defaultProps} />);
+    const wrapper = shallow(<TextareaWithMarkdownPreview {...defaultProps} />);
     expect(wrapper.contains('Section Name')).to.be.true;
     expect(wrapper.find('TextareaWithImageUpload').length).to.equal(1);
     expect(wrapper.find('TextareaWithImageUpload').props().markdown).to.equal(
       '# Title \n This is the unit description with [link](https://studio.code.org/home) **Bold** *italics*'
     );
-    expect(wrapper.find('SafeMarkdown').length).to.equal(1);
-    expect(wrapper.find('SafeMarkdown').prop('markdown')).to.equal(
+    expect(wrapper.find('EnhancedSafeMarkdown').length).to.equal(1);
+    expect(wrapper.find('EnhancedSafeMarkdown').prop('markdown')).to.equal(
       '# Title \n This is the unit description with [link](https://studio.code.org/home) **Bold** *italics*'
     );
 
@@ -33,7 +33,7 @@ describe('TextareaWithMarkdownPreview', () => {
   });
 
   it('has no HelpTip if none passed in to props', () => {
-    const wrapper = mount(
+    const wrapper = shallow(
       <TextareaWithMarkdownPreview {...defaultProps} helpTip={null} />
     );
 

--- a/apps/test/unit/templates/EnhancedSafeMarkdownTest.js
+++ b/apps/test/unit/templates/EnhancedSafeMarkdownTest.js
@@ -18,7 +18,7 @@ describe('EnhancedSafeMarkdown', () => {
 
   it('wraps output in enhancements as specified', () => {
     const wrapper = shallow(
-      <EnhancedSafeMarkdown markdown="test" expandableImages={true} />
+      <EnhancedSafeMarkdown markdown="test" expandableImages />
     );
     expect(
       wrapper.equals(

--- a/apps/test/unit/templates/lessonOverview/LessonOverviewTest.js
+++ b/apps/test/unit/templates/lessonOverview/LessonOverviewTest.js
@@ -88,15 +88,17 @@ describe('LessonOverview', () => {
 
     expect(wrapper.contains('Lesson 1: Lesson 1'), 'Lesson Name').to.be.true;
 
-    const safeMarkdowns = wrapper.find('SafeMarkdown');
-    expect(safeMarkdowns.at(0).props().markdown).to.contain('Lesson Overview');
-    expect(safeMarkdowns.at(1).props().markdown).to.contain(
+    const enhancedSafeMarkdowns = wrapper.find('EnhancedSafeMarkdown');
+    expect(enhancedSafeMarkdowns.at(0).props().markdown).to.contain(
+      'Lesson Overview'
+    );
+    expect(enhancedSafeMarkdowns.at(1).props().markdown).to.contain(
       'The purpose of the lesson is for people to learn'
     );
-    expect(safeMarkdowns.at(2).props().markdown).to.contain(
+    expect(enhancedSafeMarkdowns.at(2).props().markdown).to.contain(
       'Assessment Opportunities Details'
     );
-    expect(safeMarkdowns.at(3).props().markdown).to.contain('- One');
+    expect(enhancedSafeMarkdowns.at(3).props().markdown).to.contain('- One');
 
     const inlineMarkdowns = wrapper.find('InlineMarkdown');
 


### PR DESCRIPTION
Adds a checkbox which allows an editor to say if an image is expandable so that editors don't have to memorize the syntax for expandable images in order to add an expandable image. It adds the syntax for them.
<img width="606" alt="Screen Shot 2021-03-03 at 9 20 40 PM" src="https://user-images.githubusercontent.com/208083/109901720-846ace80-7c67-11eb-87d1-cbf32641cb12.png">

Makes expandable images work in the lesson editor so you can preview them there.
<img width="1030" alt="Screen Shot 2021-03-03 at 9 29 49 PM" src="https://user-images.githubusercontent.com/208083/109901776-99476200-7c67-11eb-84f2-a8f679041360.png">


## Testing story

- Tested manually
- Updated existing tests for impacted components

## Follow-up work

Do we want to make expandable images work for the ScriptOverview or CourseOverview?

## PR Checklist:

- [X] Tests provide adequate coverage
- [X] Privacy and Security impacts have been assessed
- [X] Code is well-commented
- [X] New features are translatable or updates will not break translations
- [X] Relevant documentation has been added or updated
- [X] User impact is well-understood and desirable
- [X] Pull Request is labeled appropriately
- [X] Follow-up work items (including potential tech debt) are tracked and linked
