### PR TITLE
[AiLab] make autogenerated design elements visible automatically

### DIFF
--- a/apps/src/applab/ai.js
+++ b/apps/src/applab/ai.js
@@ -62,7 +62,7 @@ function generateCodeDesignElements(modelId, modelData) {
       setText("${predictionId}", value);
     });
   });`;
-  designMode.onInsertEvent(predictOnClick);
+  designMode.onInsertAICode(predictOnClick);
 }
 
 export default function autogenerateML(modelId) {

--- a/apps/src/applab/designMode.js
+++ b/apps/src/applab/designMode.js
@@ -1043,6 +1043,8 @@ designMode.onInsertEvent = function(code) {
   Applab.scrollToEnd();
 };
 
+// By switchig to design mode, auto-generated design elements (see ai.js) will
+// appear without the user needing to click the "Run" button.
 designMode.onInsertAICode = function(code) {
   Applab.appendToEditor(code);
   getStore().dispatch(actions.changeInterfaceMode(ApplabInterfaceMode.DESIGN));

--- a/apps/src/applab/designMode.js
+++ b/apps/src/applab/designMode.js
@@ -1043,6 +1043,13 @@ designMode.onInsertEvent = function(code) {
   Applab.scrollToEnd();
 };
 
+designMode.onInsertAICode = function(code) {
+  Applab.appendToEditor(code);
+  getStore().dispatch(actions.changeInterfaceMode(ApplabInterfaceMode.DESIGN));
+  getStore().dispatch(actions.changeInterfaceMode(ApplabInterfaceMode.CODE));
+  Applab.scrollToEnd();
+};
+
 /**/
 designMode.serializeToLevelHtml = function() {
   var designModeViz = $('#designModeViz');


### PR DESCRIPTION
When students import a machine learning model into App Lab, the autogenerated design elements didn't display until the user hit run. With this change, it is readily apparent that design elements were created for the user because we now show them without the student needing to the run the program. 

BEFORE

https://user-images.githubusercontent.com/12300669/109999535-537ab000-7ce0-11eb-9f88-c19c8881993a.mov


AFTER 

https://user-images.githubusercontent.com/12300669/109999374-275f2f00-7ce0-11eb-9ab7-feb469abe5b9.mov

