### PR TITLE
Move the lessons to a temporary lesson group so that moving lesson groups works

### DIFF
--- a/dashboard/app/models/script.rb
+++ b/dashboard/app/models/script.rb
@@ -1052,7 +1052,7 @@ class Script < ApplicationRecord
         key: 'temp-will-be-deleted',
         script: script,
         user_facing: false,
-        position: script.lesson_groups.length
+        position: script.lesson_groups.length + 1
       )
       script.lessons.each do |l|
         l.lesson_group = temp_lg

--- a/dashboard/app/models/script.rb
+++ b/dashboard/app/models/script.rb
@@ -1045,12 +1045,17 @@ class Script < ApplicationRecord
       script.prevent_duplicate_lesson_groups(raw_lesson_groups)
       Script.prevent_some_lessons_in_lesson_groups_and_some_not(raw_lesson_groups)
 
-      # More all lessons into the last lesson group so that we do not delete
+      # More all lessons into a temporary lesson group so that we do not delete
       # the lesson entries unless the lesson has been entirely removed from the
       # script
-      last_lesson_group = script.lesson_groups.last
+      temp_lg = LessonGroup.create!(
+        key: 'temp-will-be-deleted',
+        script: script,
+        user_facing: false,
+        position: script.lesson_groups.length
+      )
       script.lessons.each do |l|
-        l.lesson_group = last_lesson_group
+        l.lesson_group = temp_lg
         l.save!
       end
 

--- a/dashboard/test/models/script_test.rb
+++ b/dashboard/test/models/script_test.rb
@@ -2420,6 +2420,40 @@ class ScriptTest < ActiveSupport::TestCase
     assert_equal script.script_levels[0].activity_section_id, activity_section.id
   end
 
+  test 'can move last lesson group up' do
+    script = create :script, name: 'lesson-group-test-script'
+    lesson_group1 = create :lesson_group, key: 'lg-1', script: script
+    lesson1 = create :lesson, key: 'l-1', name: 'Lesson 1', lesson_group: lesson_group1
+    lesson2 = create :lesson, key: 'l-2', name: 'Lesson 2', lesson_group: lesson_group1
+    activity = create :lesson_activity, lesson: lesson2
+    activity_section = create :activity_section, lesson_activity: activity
+    level1 = create :level
+    script_level = create :script_level, script: script, lesson: lesson2, levels: [level1], activity_section: activity_section, activity_section_position: 1
+    lesson_group2 = create :lesson_group, key: 'lg-2', script: script
+    lesson3 = create :lesson, key: 'l-3', name: 'Lesson 3', lesson_group: lesson_group2
+
+    new_dsl = <<-SCRIPT
+      lesson_group '#{lesson_group2.key}', display_name: 'Lesson Group 2'
+      lesson '#{lesson3.key}', display_name: '#{lesson3.name}'
+
+      lesson_group '#{lesson_group1.key}', display_name: 'Lesson Group 1'
+      lesson '#{lesson1.key}', display_name: '#{lesson1.name}'
+
+      lesson '#{lesson2.key}', display_name: '#{lesson2.name}'
+      level '#{level1.name}'
+    SCRIPT
+
+    script = Script.add_script(
+        {name: 'lesson-group-test-script'},
+        ScriptDSL.parse(new_dsl, 'a filename')[0][:lesson_groups]
+    )
+
+    assert_equal script.lessons[2].lesson_group_id, lesson_group1.id
+    assert_equal script.lessons[2].id, lesson2.id
+    assert_equal script.script_levels[0].id, script_level.id
+    assert_equal script.script_levels[0].activity_section_id, activity_section.id
+  end
+
   test 'can add the lesson group for a lesson' do
     l = create :level
     old_dsl = <<-SCRIPT


### PR DESCRIPTION
We got a [report](https://codedotorg.slack.com/archives/CNZP84FJ5/p1614891567094600) that moving the last lesson group up was giving errors about legacy script levels not being allowed in a bunch of lessons.  The issue is a follow up issue to the fix in this PR: https://github.com/code-dot-org/code-dot-org/pull/39255. 

Because the fix in the previous PR moved all the lessons to the last lesson group when you moved the last lesson group up it deleted all the lessons that had not been set up in previous lesson groups and that resulted in the chain of issues listed in that previous PR. 

To fix this we add a temporary lesson group to hold all the lessons and put it at the end of the script. This temp lesson group will get deleted by these lines in `add_script` once everything else in the script has been set up.

https://github.com/code-dot-org/code-dot-org/blob/3007647ee600bbc231be97bf17b88d2bcf23f0d9/dashboard/app/models/script.rb#L1057-L1060
 
## Testing story

Added a test to make sure you could move the last lesson group in a migrated script up without lessons getting deleted.

## Follow-up work

We still want to move off of this system going forward but after our April deadline.

## PR Checklist:

- [ ] Tests provide adequate coverage
- [X] Privacy and Security impacts have been assessed
- [X] Code is well-commented
- [X] New features are translatable or updates will not break translations
- [X] Relevant documentation has been added or updated
- [X] User impact is well-understood and desirable
- [X] Pull Request is labeled appropriately
- [X] Follow-up work items (including potential tech debt) are tracked and linked
