### PR TITLE
Fixing i18n-dev return-to-staging to confirm 'Yes'

### DIFF
--- a/experimental/i18n-dev.crontab
+++ b/experimental/i18n-dev.crontab
@@ -44,4 +44,4 @@ HOME=/home/ubuntu
 
 # Periodically check to see if the I18n Sync PRs have been merged and attempt
 # to return to staging.
-0 */1 * * * cd /home/ubuntu/code-dot-org && git fetch && (bundle exec ./bin/i18n/sync-all.rb -c return-to-staging | ./bin/i18n/slack_log) 2>&1 | ./bin/i18n/slack_error
+0 */1 * * * cd /home/ubuntu/code-dot-org && git fetch && (bundle exec ./bin/i18n/sync-all.rb -y -c return-to-staging | ./bin/i18n/slack_log) 2>&1 | ./bin/i18n/slack_error


### PR DESCRIPTION
When switching to the staging branch, the user is prompted with a "Yes/No" confirmation dialog. Since this is an automated process, there is no human around to type "yes". We need to use the `-y` flag to default to "Yes" for all dialogs.

## Testing
I manually ran the new command on the i18n-dev server and confirmed the switch to the staging branch.

### Before
![image](https://user-images.githubusercontent.com/1372238/110045283-5efec300-7d42-11eb-86a5-faadd2ce1e72.png)

### After
![image](https://user-images.githubusercontent.com/1372238/110045298-64f4a400-7d42-11eb-94e7-e1fb04838f83.png)
