### PR TITLE
Removing three deprecated pilots

### DIFF
--- a/dashboard/app/models/experiments/experiment.rb
+++ b/dashboard/app/models/experiments/experiment.rb
@@ -51,11 +51,6 @@ class Experiment < ApplicationRecord
   # http://studio.code.org/experiments/set_single_user_experiment/<EXPERIMENT_NAME>
   PILOT_EXPERIMENTS = [
     {
-      name: 'csd-piloters',
-      label: 'CSD Pilot',
-      allow_joining_via_url: true
-    },
-    {
       name: 'csp-piloters',
       label: 'CSP Pilot',
       allow_joining_via_url: false
@@ -68,16 +63,6 @@ class Experiment < ApplicationRecord
     {
       name: '20-21-virtual-AYW-CSP',
       label: 'For facilitators in virtual academic year workshops for CSP',
-      allow_joining_via_url: true
-    },
-    {
-      name: 'csp-preview',
-      label: 'CSP Preview',
-      allow_joining_via_url: true
-    },
-    {
-      name: 'csp-2020-access',
-      label: 'CSP 2020 Access',
       allow_joining_via_url: true
     },
     {

--- a/dashboard/test/controllers/admin_search_controller_test.rb
+++ b/dashboard/test/controllers/admin_search_controller_test.rb
@@ -123,17 +123,17 @@ class AdminSearchControllerTest < ActionController::TestCase
 
   test 'non-admin cannot view list of piloters' do
     sign_in @not_admin
-    get :show_pilot, params: {pilot_name: 'csd-piloters'}
+    get :show_pilot, params: {pilot_name: 'csp-piloters'}
     assert_response :forbidden
   end
 
   test 'piloter shows up in list of piloters' do
-    create :teacher, pilot_experiment: 'csd-piloters', email: 'csd@example.com'
     create :teacher, pilot_experiment: 'csp-piloters', email: 'csp@example.com'
-    get :show_pilot, params: {pilot_name: 'csd-piloters'}
+    create :teacher, pilot_experiment: 'denny-science-piloters', email: 'cspnot@example.com'
+    get :show_pilot, params: {pilot_name: 'csp-piloters'}
     assert_response :success
     assert_select 'table tr td', 1
-    assert_select 'table tr td', 'csd@example.com'
+    assert_select 'table tr td', 'csp@example.com'
   end
 
   #
@@ -142,7 +142,7 @@ class AdminSearchControllerTest < ActionController::TestCase
 
   test 'can add teacher to pilot' do
     teacher = create :teacher
-    pilot_name = 'csd-piloters'
+    pilot_name = 'csp-piloters'
     post :add_to_pilot, params: {email: teacher.email, pilot_name: pilot_name}
 
     assert SingleUserExperiment.find_by(min_user_id: teacher.id, name: pilot_name).present?
@@ -151,7 +151,7 @@ class AdminSearchControllerTest < ActionController::TestCase
   test 'can add multiple teachers to pilot' do
     teacher = create :teacher
     teacher2 = create :teacher
-    pilot_name = 'csd-piloters'
+    pilot_name = 'csp-piloters'
     post :add_to_pilot, params: {email: teacher.email + "\n" + teacher2.email, pilot_name: pilot_name}
 
     assert SingleUserExperiment.find_by(min_user_id: teacher.id, name: pilot_name).present?
@@ -161,7 +161,7 @@ class AdminSearchControllerTest < ActionController::TestCase
   test 'can add multiple teachers to pilot with extra spaces' do
     teacher = create :teacher
     teacher2 = create :teacher
-    pilot_name = 'csd-piloters'
+    pilot_name = 'csp-piloters'
     post :add_to_pilot, params: {email: teacher.email + " \n" + teacher2.email, pilot_name: pilot_name}
 
     assert SingleUserExperiment.find_by(min_user_id: teacher.id, name: pilot_name).present?
@@ -171,7 +171,7 @@ class AdminSearchControllerTest < ActionController::TestCase
   test 'can add multiple teachers to pilot with extra commas' do
     teacher = create :teacher
     teacher2 = create :teacher
-    pilot_name = 'csd-piloters'
+    pilot_name = 'csp-piloters'
     post :add_to_pilot, params: {email: teacher.email + ",\n" + teacher2.email, pilot_name: pilot_name}
 
     assert SingleUserExperiment.find_by(min_user_id: teacher.id, name: pilot_name).present?
@@ -181,7 +181,7 @@ class AdminSearchControllerTest < ActionController::TestCase
   test 'if first email fails, second given will work successfully' do
     student = create :student
     teacher = create :teacher
-    pilot_name = 'csd-piloters'
+    pilot_name = 'csp-piloters'
     post :add_to_pilot, params: {email: student.email + "\n" + teacher.email, pilot_name: pilot_name}
 
     refute SingleUserExperiment.find_by(min_user_id: student.id, name: pilot_name).present?
@@ -191,7 +191,7 @@ class AdminSearchControllerTest < ActionController::TestCase
   test 'if middle user is not found, first and third still work successfully' do
     teacher = create :teacher
     teacher2 = create :teacher
-    pilot_name = 'csd-piloters'
+    pilot_name = 'csp-piloters'
     post :add_to_pilot, params: {
       email: teacher.email + "\nfake@fakey1.fake\n" + teacher2.email, pilot_name: pilot_name
     }
@@ -212,7 +212,7 @@ class AdminSearchControllerTest < ActionController::TestCase
     teacher9 = create :teacher
     teacher10 = create :teacher
     teacher11 = create :teacher
-    pilot_name = 'csd-piloters'
+    pilot_name = 'csp-piloters'
     post :add_to_pilot, params: {
       email: teacher.email + "\n" + teacher2.email + "\n" + teacher3.email + "\n" +
       teacher4.email + "\n" + teacher5.email + "\n" + teacher6.email + "\n" +
@@ -231,7 +231,7 @@ class AdminSearchControllerTest < ActionController::TestCase
 
   test 'cannot add student to pilot' do
     student = create :student
-    pilot_name = 'csd-piloters'
+    pilot_name = 'csp-piloters'
     post :add_to_pilot, params: {email: student.email, pilot_name: pilot_name}
 
     refute SingleUserExperiment.find_by(min_user_id: student.id, name: pilot_name).present?
@@ -239,7 +239,7 @@ class AdminSearchControllerTest < ActionController::TestCase
 
   test 'non-admin cannot add teacher to pilot' do
     teacher = create :teacher
-    pilot_name = 'csd-piloters'
+    pilot_name = 'csp-piloters'
 
     sign_in @not_admin
     post :add_to_pilot, params: {email: teacher.email, pilot_name: pilot_name}


### PR DESCRIPTION
This is a cleanup PR for the pilot experiment page. We are building out documentation for how this will be managed in the future here: https://docs.google.com/document/d/1tokG6iZ2bhvsaGw4MUF2rXbPCRsBdv1hVeew8yiHRUo/edit

These three pilots have already ended, so this is simply to pull them from the admin pilot page. Several of the tests used the CSD pilot, so those have been updated to use the CSP pilot. 

Testing: Locally, I created a section and assigned a pilot course. Upon deleting that script, the course disappeared, and I was no longer able to log in as a student from that course or create a new section based on the same pilot. So, the access for teachers is actually dependent on the availability of the script, and not its existence on experiment.rb. The scripts for these three pilots have already been removed, so this update will just affect their display on the admin page.

Future work: Create a feature where any admin user can remove a teacher from a pilot (hook up disable_single_user_experiment to a UI tool) so that we are cleaning out our databases entirely. Currently, these databases still contain information from these deprecated pilots, which this PR does not address.
