### PR TITLE
Re-allow <iframe> in WebLab for curriculum

### DIFF
--- a/apps/src/weblab/WebLab.js
+++ b/apps/src/weblab/WebLab.js
@@ -24,7 +24,7 @@ import {getCurrentId} from '../code-studio/initApp/project';
 export const WEBLAB_FOOTER_HEIGHT = 30;
 
 // HTML tags that are disallowed in WebLab. These tags will be removed from users' projects.
-const DISALLOWED_HTML_TAGS = ['script', 'iframe'];
+const DISALLOWED_HTML_TAGS = ['script'];
 
 /**
  * An instantiable WebLab class


### PR DESCRIPTION
Follow-up to #39207 -- this re-enables `<iframe>` in WebLab because we found out it is used in curriculum and is blocking students ([Zendesk](https://codeorg.zendesk.com/agent/tickets/320839)).

We will have to figure out if/how we want to handle iframes, but we need to unblock users in the meantime.