### PR TITLE
No longer notify Honeybadger when throttling requests

### DIFF
--- a/dashboard/app/controllers/api/v1/text_to_speech_controller.rb
+++ b/dashboard/app/controllers/api/v1/text_to_speech_controller.rb
@@ -30,11 +30,6 @@ class Api::V1::TextToSpeechController < Api::V1::JsonApiController
     end
 
     # If we make it here, the request should be throttled.
-    Honeybadger.notify(
-      error_class: 'RequestThrottledWarning',
-      error_message: "Client throttled for POST #{request.path}",
-      context: {throttle_id: id, is_ip: throttle_ip, limit: limit, period: period}
-    )
     head :too_many_requests
   end
 

--- a/dashboard/app/controllers/profanity_controller.rb
+++ b/dashboard/app/controllers/profanity_controller.rb
@@ -31,11 +31,6 @@ class ProfanityController < ApplicationController
     end
 
     # If we make it here, the request should be throttled.
-    Honeybadger.notify(
-      error_class: 'RequestThrottledWarning',
-      error_message: "Client throttled for POST #{request.path}",
-      context: {throttle_id: id, is_ip: throttle_ip, limit: limit, period: period}
-    )
     head :too_many_requests
   end
 

--- a/dashboard/test/controllers/profanity_controller_test.rb
+++ b/dashboard/test/controllers/profanity_controller_test.rb
@@ -49,7 +49,6 @@ class ProfanityControllerTest < ActionController::TestCase
 
   test 'find: returns 429 if request is throttled' do
     ProfanityHelper.expects(:throttled_find_profanities).once.returns(nil)
-    Honeybadger.expects(:notify).once
     post :find, params: {text: 'hola', locale: 'es-MX'}
     assert_response :too_many_requests
   end


### PR DESCRIPTION
As of #38143 and #38148, we notify Honeybadger every time a user is throttled by `POST /profanity/find` ([Honeybadger](https://app.honeybadger.io/projects/3240/faults/72254493)) or `POST /dashboardapi/v1/text_to_speech/azure` ([Honeybadger](https://app.honeybadger.io/projects/3240/faults/73150408)). This was for monitoring purposes to make sure we aren't improperly throttling users. Since those PRs have merged, I've investigated high-volume occurrences of this error to make sure everything looks okay (e.g., the user wasn't throttled for too long and we aren't seeing huge influxes of throttling based on user IP). 

To date, all of the throttling occurrences have been expected, so I'm removing the logging as it's noisy. Users see a message that they've been throttled when this happens, so they can also reach out to support if they think they've been unnecessarily throttled.

## Links

- [`POST /profanity/find` Honeybadger](https://app.honeybadger.io/projects/3240/faults/72254493)
- [`POST /dashboardapi/v1/text_to_speech/azure` Honeybadger](https://app.honeybadger.io/projects/3240/faults/73150408)
- [STAR-1388](https://codedotorg.atlassian.net/browse/STAR-1388)

## Testing story

Updated appropriate test.
