### PR TITLE
wait for section dropdown navigation before checking new url

### DIFF
--- a/dashboard/test/ui/features/learning_platform/section_action_dropdown.feature
+++ b/dashboard/test/ui/features/learning_platform/section_action_dropdown.feature
@@ -12,7 +12,7 @@ Feature: Using the SectionActionDropdown
 
     When I sign in as "Teacher_Sally" and go home
     And I open the section action dropdown
-    And I press the first ".view-progress-link" element
+    And I press the first ".view-progress-link" element to load a new page
     And I wait until current URL contains "/progress"
 
   # * Check that we get redirected to the right page
@@ -20,7 +20,7 @@ Feature: Using the SectionActionDropdown
     Given I am a teacher
     And I create a new section and go home
     And I open the section action dropdown
-    And I press the first ".manage-students-link" element
+    And I press the first ".manage-students-link" element to load a new page
     And I wait until current URL contains "/manage"
 
   # * Check that we get redirected to the right page
@@ -28,7 +28,7 @@ Feature: Using the SectionActionDropdown
     Given I am a teacher
     And I create a new section and go home
     And I open the section action dropdown
-    And I press the first ".print-login-link" element
+    And I press the first ".print-login-link" element to load a new page
     And I wait until current URL contains "/login_info"
 
   # * Add a section and then opens the edit dialog.


### PR DESCRIPTION
Attempts to deflake errors like this: https://cucumber-logs.s3.amazonaws.com/test/test/Safari_learning_platform_section_action_dropdown_output.html?versionId=v6taKScXlaTF3dyuCA.pvppp5ZAYlz24

I don't recall the exact details, but this is a common pattern of flakiness. the problem is generally that you need to wait for the old page to unload before you can start waiting for updates to the new url.