### PR TITLE
Partially defend against Tabnapping in Button component

### DIFF
--- a/apps/src/templates/Button.jsx
+++ b/apps/src/templates/Button.jsx
@@ -259,12 +259,20 @@ class Button extends React.Component {
       ? styles.sizes[size]
       : {...styles.sizes[size], ...styles.updated};
 
+    // Opening links in new tabs with 'target=_blank' is inherently insecure.
+    // Unfortunately, we depend on this functionality in a couple of place.
+    // Fortunately, it is possible to partially mitigate some of the insecurity
+    // of this functionality by using the `rel` tag to block some of the
+    // potential exploits. Therefore, we do so here.
+    const rel = target === '_blank' ? 'noopener noreferrer' : undefined;
+
     return (
       <Tag
         className={className}
         style={[styles.main, styles.colors[color], sizeStyle, style]}
         href={disabled ? 'javascript:void(0);' : href}
         target={target}
+        rel={rel}
         disabled={disabled}
         download={download}
         onClick={disabled ? null : onClick}

--- a/apps/test/unit/templates/ButtonTest.js
+++ b/apps/test/unit/templates/ButtonTest.js
@@ -31,6 +31,22 @@ describe('Button', () => {
     assert.strictEqual(wrapper.props().target, '_blank');
   });
 
+  it('attempts to mitigate some of the inherent insecurity when setting target=_blank', () => {
+    const wrapper = shallow(
+      <Button
+        __useDeprecatedTag
+        href="/foo/bar"
+        text="Click me"
+        target="something other than _blank"
+      />
+    );
+
+    assert.isUndefined(wrapper.props().rel);
+
+    wrapper.setProps({target: '_blank'});
+    assert.strictEqual(wrapper.props().rel, 'noopener noreferrer');
+  });
+
   it('renders a div when button has an onClick', () => {
     const onClick = sinon.spy();
     const wrapper = shallow(


### PR DESCRIPTION
The Button component supports the use of `target="_blank"` to open links in a new tab, which is an inherently insecure operation. I looked into removing this functionality, but we unfortunately use it in a couple of places. Enough that it would take more work to remove than I have time for right now, so I instead chose to add in what defenses are possible in this scenario.

## Links

- https://medium.com/sedeo/how-to-fix-target-blank-a-security-and-performance-issue-in-web-pages-2118eba1ce2f
- https://hackernoon.com/unsafe-use-of-target_blank-39413ycf

## Testing story

added a unit test

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
