### PR TITLE
Add a CloudWatch metric to count number of Acapela API calls.

### DIFF
--- a/dashboard/app/controllers/registrations_controller.rb
+++ b/dashboard/app/controllers/registrations_controller.rb
@@ -112,7 +112,7 @@ class RegistrationsController < Devise::RegistrationsController
     end
 
     should_send_new_teacher_email = current_user && current_user.teacher?
-    TeacherMailer.new_teacher_email(current_user).deliver_now if should_send_new_teacher_email
+    TeacherMailer.new_teacher_email(current_user, request.locale).deliver_now if should_send_new_teacher_email
     should_send_parent_email = current_user && current_user.parent_email.present?
     ParentMailer.parent_email_added_to_student_account(current_user.parent_email, current_user).deliver_now if should_send_parent_email
 

--- a/dashboard/app/controllers/registrations_controller.rb
+++ b/dashboard/app/controllers/registrations_controller.rb
@@ -112,7 +112,7 @@ class RegistrationsController < Devise::RegistrationsController
     end
 
     should_send_new_teacher_email = current_user && current_user.teacher?
-    TeacherMailer.new_teacher_email(current_user, request.locale).deliver_now if should_send_new_teacher_email
+    TeacherMailer.new_teacher_email(current_user).deliver_now if should_send_new_teacher_email
     should_send_parent_email = current_user && current_user.parent_email.present?
     ParentMailer.parent_email_added_to_student_account(current_user.parent_email, current_user).deliver_now if should_send_parent_email
 

--- a/dashboard/app/mailers/teacher_mailer.rb
+++ b/dashboard/app/mailers/teacher_mailer.rb
@@ -2,9 +2,18 @@ class TeacherMailer < ActionMailer::Base
   default from: 'Hadi Partovi <hadi_partovi@code.org>'
 
   # Send newly registered teachers a welcome email
-  def new_teacher_email(teacher)
+  def new_teacher_email(teacher, teacher_locale = 'en-US')
     @teacher = teacher
-    mail to: teacher.email, subject: I18n.t('teacher_mailer.new_teacher_subject')
+
+    # We currently have two flavors for the new teacher welcome email,
+    # en-US (the default) and es-MX.
+    email_locale = teacher_locale.to_s == 'es-MX' ? teacher_locale : 'en-US'
+    email_template = teacher_locale.to_s == 'es-MX' ? 'new_teacher_email_es-MX' : 'new_teacher_email'
+
+    mail to: teacher.email,
+      subject: I18n.t('teacher_mailer.new_teacher_subject', locale: email_locale),
+      template_path: 'teacher_mailer',
+      template_name: email_template
   end
 
   def delete_teacher_email(teacher, removed_students)

--- a/dashboard/app/mailers/teacher_mailer.rb
+++ b/dashboard/app/mailers/teacher_mailer.rb
@@ -2,18 +2,9 @@ class TeacherMailer < ActionMailer::Base
   default from: 'Hadi Partovi <hadi_partovi@code.org>'
 
   # Send newly registered teachers a welcome email
-  def new_teacher_email(teacher, teacher_locale = 'en-US')
+  def new_teacher_email(teacher)
     @teacher = teacher
-
-    # We currently have two flavors for the new teacher welcome email,
-    # en-US (the default) and es-MX.
-    email_locale = teacher_locale.to_s == 'es-MX' ? teacher_locale : 'en-US'
-    email_template = teacher_locale.to_s == 'es-MX' ? 'new_teacher_email_es-MX' : 'new_teacher_email'
-
-    mail to: teacher.email,
-      subject: I18n.t('teacher_mailer.new_teacher_subject', locale: email_locale),
-      template_path: 'teacher_mailer',
-      template_name: email_template
+    mail to: teacher.email, subject: I18n.t('teacher_mailer.new_teacher_subject')
   end
 
   def delete_teacher_email(teacher, removed_students)

--- a/dashboard/app/models/concerns/text_to_speech.rb
+++ b/dashboard/app/models/concerns/text_to_speech.rb
@@ -88,13 +88,13 @@ module TextToSpeech
     VOICES[loc]
   end
 
-  def self.tts_upload_to_s3(text, filename)
+  def self.tts_upload_to_s3(text, filename, context = nil)
     return if text.blank?
     return if CDO.acapela_login.blank? || CDO.acapela_storage_app.blank? || CDO.acapela_storage_password.blank?
     return if AWS::S3.cached_exists_in_bucket?(TTS_BUCKET, filename)
 
     loc_voice = TextToSpeech.localized_voice
-    url = acapela_text_to_audio_url(text, loc_voice[:VOICE], loc_voice[:SPEED], loc_voice[:SHAPE])
+    url = acapela_text_to_audio_url(text, loc_voice[:VOICE], loc_voice[:SPEED], loc_voice[:SHAPE], context)
     return if url.nil?
     uri = URI.parse(url)
     Net::HTTP.start(uri.host) do |http|
@@ -118,9 +118,9 @@ module TextToSpeech
     TTSSafeRenderer.render(text)
   end
 
-  def tts_upload_to_s3(text)
+  def tts_upload_to_s3(text, context = nil)
     filename = tts_path(text)
-    TextToSpeech.tts_upload_to_s3(text, filename)
+    TextToSpeech.tts_upload_to_s3(text, filename, context)
   end
 
   def tts_url(text)
@@ -215,15 +215,16 @@ module TextToSpeech
   end
 
   def tts_update
-    tts_upload_to_s3(tts_short_instructions_text) if tts_should_update_short_instructions?
+    context = 'update_level'
+    tts_upload_to_s3(tts_short_instructions_text, context) if tts_should_update_short_instructions?
 
-    tts_upload_to_s3(tts_long_instructions_text) if tts_should_update_long_instructions?
+    tts_upload_to_s3(tts_long_instructions_text, context) if tts_should_update_long_instructions?
 
     if authored_hints && tts_should_update('authored_hints')
       hints = JSON.parse(authored_hints)
       hints.each do |hint|
         text = TextToSpeech.sanitize(hint["hint_markdown"])
-        tts_upload_to_s3(text)
+        tts_upload_to_s3(text, context)
         hint["tts_url"] = tts_url(text)
       end
       self.authored_hints = JSON.dump(hints)

--- a/dashboard/app/views/teacher_mailer/new_teacher_email_es-MX.html.haml
+++ b/dashboard/app/views/teacher_mailer/new_teacher_email_es-MX.html.haml
@@ -1,0 +1,3 @@
+%p
+  Hola #{@teacher.name}!
+  (This is a placeholder template for es-MX content.)

--- a/dashboard/app/views/teacher_mailer/new_teacher_email_es-MX.html.haml
+++ b/dashboard/app/views/teacher_mailer/new_teacher_email_es-MX.html.haml
@@ -1,3 +1,0 @@
-%p
-  Hola #{@teacher.name}!
-  (This is a placeholder template for es-MX content.)

--- a/dashboard/lib/acapela.rb
+++ b/dashboard/lib/acapela.rb
@@ -30,7 +30,8 @@ def acapela_text_to_audio_url(text, voice="rosie22k", speed=180, shape=100, cont
       metric_name: :AcapelaAPICall,
       dimensions: [
         {name: "Environment", value: CDO.rack_env},
-        {name: "Context", value: context}
+        {name: "Context", value: context},
+        {name: "Voice", value: voice}
       ],
       value: 1
     }

--- a/dashboard/scripts/update_tts_i18n.rb
+++ b/dashboard/scripts/update_tts_i18n.rb
@@ -24,8 +24,9 @@ def update_level_tts_i18n(level, script=nil)
   translated_text = level.tts_short_instructions_text
   english_text = TextToSpeech.sanitize(level.short_instructions || "")
 
+  context = 'update_level_i18n'
   if translated_text.present? && text_translated?(translated_text, english_text)
-    level.tts_upload_to_s3(translated_text)
+    level.tts_upload_to_s3(translated_text, context)
   end
 
   # Long Instructions
@@ -35,7 +36,7 @@ def update_level_tts_i18n(level, script=nil)
     english_text = TextToSpeech.sanitize(level.long_instructions || "")
 
     if translated_text.present? && text_translated?(translated_text, english_text)
-      level.tts_upload_to_s3(translated_text)
+      level.tts_upload_to_s3(translated_text, context)
     end
   end
 
@@ -50,7 +51,7 @@ def update_level_tts_i18n(level, script=nil)
     english_text = TextToSpeech.sanitize(english_hint["hint_markdown"])
 
     if translated_text.present? && text_translated?(translated_text, english_text)
-      level.tts_upload_to_s3(translated_text)
+      level.tts_upload_to_s3(translated_text, context)
     end
   end
 end

--- a/dashboard/scripts/update_tts_i18n_static_messages.rb
+++ b/dashboard/scripts/update_tts_i18n_static_messages.rb
@@ -114,7 +114,7 @@ TextToSpeech::VOICES.each do |lang, _voice|
       # Sanitize the text after generating the filename to keep the content hash
       # consistent with original text
       text = TextToSpeech.sanitize(text)
-      TextToSpeech.tts_upload_to_s3(text, filename)
+      TextToSpeech.tts_upload_to_s3(text, filename, 'update_i18n_static_messages')
     end
   end
 end

--- a/dashboard/test/controllers/registrations_controller_test.rb
+++ b/dashboard/test/controllers/registrations_controller_test.rb
@@ -356,6 +356,16 @@ class RegistrationsControllerTest < ActionController::TestCase
     refute mail.body.to_s =~ /New to teaching computer science/
   end
 
+  test 'create new teacher with es-MX locale sends localized welcome email' do
+    with_default_locale('es-MX') do
+      teacher_params = @default_params.update(user_type: 'teacher', email_preference_opt_in: 'yes')
+      post :create, params: {user: teacher_params}
+      mail = ActionMailer::Base.deliveries.first
+      assert_equal I18n.t('teacher_mailer.new_teacher_subject', locale: 'es-MX'), mail.subject
+      assert_match /Hola/, mail.body.to_s
+    end
+  end
+
   test "create new teacher with opt-in option as yes writes email preference as yes" do
     teacher_params = @default_params.update(user_type: 'teacher', email_preference_opt_in: 'yes')
     Geocoder.stubs(:search).returns([OpenStruct.new(country_code: 'CA')])

--- a/dashboard/test/controllers/registrations_controller_test.rb
+++ b/dashboard/test/controllers/registrations_controller_test.rb
@@ -356,16 +356,6 @@ class RegistrationsControllerTest < ActionController::TestCase
     refute mail.body.to_s =~ /New to teaching computer science/
   end
 
-  test 'create new teacher with es-MX locale sends localized welcome email' do
-    with_default_locale('es-MX') do
-      teacher_params = @default_params.update(user_type: 'teacher', email_preference_opt_in: 'yes')
-      post :create, params: {user: teacher_params}
-      mail = ActionMailer::Base.deliveries.first
-      assert_equal I18n.t('teacher_mailer.new_teacher_subject', locale: 'es-MX'), mail.subject
-      assert_match /Hola/, mail.body.to_s
-    end
-  end
-
   test "create new teacher with opt-in option as yes writes email preference as yes" do
     teacher_params = @default_params.update(user_type: 'teacher', email_preference_opt_in: 'yes')
     Geocoder.stubs(:search).returns([OpenStruct.new(country_code: 'CA')])

--- a/dashboard/test/mailers/previews/teacher_mailer_preview.rb
+++ b/dashboard/test/mailers/previews/teacher_mailer_preview.rb
@@ -2,6 +2,11 @@
 class TeacherMailerPreview < ActionMailer::Preview
   include FactoryGirl::Syntax::Methods
 
+  def new_teacher_email_es_mx_preview
+    teacher = build :teacher, email: 'teacher@gmail.com'
+    TeacherMailer.new_teacher_email(teacher, 'es-MX')
+  end
+
   def new_teacher_email_preview
     teacher = build :teacher, email: 'fake_email@fake.com'
     TeacherMailer.new_teacher_email(teacher)

--- a/dashboard/test/mailers/previews/teacher_mailer_preview.rb
+++ b/dashboard/test/mailers/previews/teacher_mailer_preview.rb
@@ -2,11 +2,6 @@
 class TeacherMailerPreview < ActionMailer::Preview
   include FactoryGirl::Syntax::Methods
 
-  def new_teacher_email_es_mx_preview
-    teacher = build :teacher, email: 'teacher@gmail.com'
-    TeacherMailer.new_teacher_email(teacher, 'es-MX')
-  end
-
   def new_teacher_email_preview
     teacher = build :teacher, email: 'fake_email@fake.com'
     TeacherMailer.new_teacher_email(teacher)

--- a/dashboard/test/mailers/teacher_mailer_test.rb
+++ b/dashboard/test/mailers/teacher_mailer_test.rb
@@ -1,14 +1,33 @@
 require 'test_helper'
 
 class TeacherMailerTest < ActionMailer::TestCase
-  test 'new teacher email' do
-    teacher = create :teacher, email: 'minerva@hogwarts.co.uk'
-    mail = TeacherMailer.new_teacher_email(teacher)
+  test 'new teacher email for en-US locale' do
+    # Teacher with en-US locale will get the en-US version of the welcome email.
+    teacher = build :teacher, email: 'minerva@hogwarts.co.uk'
+    mail = TeacherMailer.new_teacher_email(teacher, 'en-US')
 
-    assert_equal I18n.t('teacher_mailer.new_teacher_subject'), mail.subject
+    assert_equal I18n.t('teacher_mailer.new_teacher_subject', locale: 'en-US'), mail.subject
     assert_equal [teacher.email], mail.to
     assert_equal ['hadi_partovi@code.org'], mail.from
+    assert_match /Hello/, mail.body.encoded
     assert links_are_complete_urls?(mail)
+  end
+
+  test 'new teacher email for es-MX locale' do
+    # Teacher with es-MX locale will get the es-MX version of the welcome email.
+    teacher = build :teacher, email: 'teacher@gmail.com'
+    mail = TeacherMailer.new_teacher_email(teacher, 'es-MX')
+    assert_equal I18n.t('teacher_mailer.new_teacher_subject', locale: 'es-MX'), mail.subject
+    assert_match /Hola/, mail.body.encoded
+  end
+
+  test 'new teacher email for non en-US, non es-MX locale' do
+    # Teacher with non en-US and non es-MX locale will get the
+    # standard en-US version of the welcome email.
+    teacher = build :teacher, email: 'teacher@gmail.com'
+    mail = TeacherMailer.new_teacher_email(teacher, 'it-IT')
+    assert_equal I18n.t('teacher_mailer.new_teacher_subject', locale: 'en-US'), mail.subject
+    assert_match /Hello/, mail.body.encoded
   end
 
   test 'delete teacher email' do

--- a/dashboard/test/mailers/teacher_mailer_test.rb
+++ b/dashboard/test/mailers/teacher_mailer_test.rb
@@ -1,33 +1,14 @@
 require 'test_helper'
 
 class TeacherMailerTest < ActionMailer::TestCase
-  test 'new teacher email for en-US locale' do
-    # Teacher with en-US locale will get the en-US version of the welcome email.
-    teacher = build :teacher, email: 'minerva@hogwarts.co.uk'
-    mail = TeacherMailer.new_teacher_email(teacher, 'en-US')
+  test 'new teacher email' do
+    teacher = create :teacher, email: 'minerva@hogwarts.co.uk'
+    mail = TeacherMailer.new_teacher_email(teacher)
 
-    assert_equal I18n.t('teacher_mailer.new_teacher_subject', locale: 'en-US'), mail.subject
+    assert_equal I18n.t('teacher_mailer.new_teacher_subject'), mail.subject
     assert_equal [teacher.email], mail.to
     assert_equal ['hadi_partovi@code.org'], mail.from
-    assert_match /Hello/, mail.body.encoded
     assert links_are_complete_urls?(mail)
-  end
-
-  test 'new teacher email for es-MX locale' do
-    # Teacher with es-MX locale will get the es-MX version of the welcome email.
-    teacher = build :teacher, email: 'teacher@gmail.com'
-    mail = TeacherMailer.new_teacher_email(teacher, 'es-MX')
-    assert_equal I18n.t('teacher_mailer.new_teacher_subject', locale: 'es-MX'), mail.subject
-    assert_match /Hola/, mail.body.encoded
-  end
-
-  test 'new teacher email for non en-US, non es-MX locale' do
-    # Teacher with non en-US and non es-MX locale will get the
-    # standard en-US version of the welcome email.
-    teacher = build :teacher, email: 'teacher@gmail.com'
-    mail = TeacherMailer.new_teacher_email(teacher, 'it-IT')
-    assert_equal I18n.t('teacher_mailer.new_teacher_subject', locale: 'en-US'), mail.subject
-    assert_match /Hello/, mail.body.encoded
   end
 
   test 'delete teacher email' do

--- a/dashboard/test/scripts/update_tts_i18n_test.rb
+++ b/dashboard/test/scripts/update_tts_i18n_test.rb
@@ -16,7 +16,7 @@ class UpdateTtsI18nTest < ActiveSupport::TestCase
     }
     I18n.backend.store_translations test_locale, custom_i18n
 
-    level.expects(:tts_upload_to_s3).with("translated short instructions\n")
+    level.expects(:tts_upload_to_s3).with {|text, _| text == "translated short instructions\n"}
     I18n.locale = test_locale
     update_level_tts_i18n(level)
   end
@@ -32,7 +32,7 @@ class UpdateTtsI18nTest < ActiveSupport::TestCase
     create :multi, name: 'contained level', long_instructions: "contained level long instructions"
     level = create :maze, name: 'containing level', contained_level_names: ['contained level']
 
-    level.expects(:tts_upload_to_s3).with("contained level long instructions\n")
+    level.expects(:tts_upload_to_s3).with {|text, _| text == "contained level long instructions\n"}
     I18n.locale = test_locale
     update_level_tts_i18n(level)
   end


### PR DESCRIPTION
[FND-1418](https://codedotorg.atlassian.net/browse/FND-1418)
Create a CloudWatch metric and an alarm to monitor number of API calls to the [Acapela voice-as-a-service](http://www.acapela-vaas.com/) (a paid service we use to generate text-to-speech audio files).

**Update 3/17/21**
Final dashboard: [Acapela-TTS-Service dashboard](https://console.aws.amazon.com/cloudwatch/home?region=us-east-1#dashboards:name=Acapela-TTS-Service)
<img width="1185" alt="Screen Shot 2021-03-17 at 5 31 56 PM" src="https://user-images.githubusercontent.com/46507039/111555952-b50e3600-8746-11eb-91a2-1ed0b028a38f.png">


## Context
We bought 84k voice credits from Acapela in July 2016. By 2/2021, we had used 121k credits and owed Acapela money for the overconsumption. The reason was we had a spike in 2020 with almost 70k credits used, more than all the previous years combined.

<img width="727" alt="Screen Shot 2021-03-09 at 10 08 47 AM" src="https://user-images.githubusercontent.com/46507039/110517424-b1800c80-80bf-11eb-9e2d-309a4c1a3493.png">

Diving deeper into the stats, the spikes came mostly from just 5 days in early May 2020 (5/1, 5/4, 5/5, 5/7 and 5/11).

<img width="693" alt="202005" src="https://user-images.githubusercontent.com/46507039/110517930-57cc1200-80c0-11eb-93c8-0f8db359c6d4.png">

The following is the best explanation I got so far.
- There was a change in how we check if TTS audio files already exist in S3 during that time. (If an audio file already exists in S3, don't call Acapela to regenerate it.) The change was merged on 4/27/2020 https://github.com/code-dot-org/code-dot-org/pull/34355. 
- It was then reverted on 5/11/2020 https://github.com/code-dot-org/code-dot-org/pull/34745 because the TTS part of the i18n script [got stuck](https://codedotorg.slack.com/archives/CFTFD6BPV/p1589219340177900). 
- It was fixed on 5/18/2020 https://github.com/code-dot-org/code-dot-org/pull/34787. After that we haven't seen another huge spike in consumption.


## Solution
Since we didn't know about those spikes for almost a year, a solution is to add a monitoring system to notify us when there is a spike. The easiest choice is to use CloudWatch metric and alarm.

## Links
- Slack threads
  - 2/26/21: https://codedotorg.slack.com/archives/C0T0PNTM3/p1614365136133200
  - 2/12/21: https://codedotorg.slack.com/archives/C0T0PNTM3/p1613169018349700


## Testing story
- Run existing unit tests
  - `bundle exec rails test test/models/concerns/text_to_speech_test.rb`
  - `bundle exec rails test test/scripts/update_tts_i18n_test.rb`

- Manually test 3 scenarios in which we generate TTS files. Then verify that metric data get to Cloudwatch dashboard.
  - Scenario 1: A level is updated
    ```ruby
    # Pre-requisite: turn off the checks in tts_upload_to_s3 https://github.com/code-dot-org/code-dot-org/blob/f970daeba23a8630f5d470fe18349753befeabc2/dashboard/app/models/concerns/text_to_speech.rb#L93-L94
    include FactoryGirl::Syntax::Methods
    level = create :level, name: 'level 1', type: 'Blockly', long_instructions: "test long instructions", published: true
    level.long_instructions = 'updated long instructions'
    p level.tts_should_update_long_instructions?
    level.save  # this will trigger re-generating TTS file
    ```
  - Scenario 2: Run `dashboard/scripts/update_tts_i18n.rb`
    ```ruby
    # Pre-requisite: turn of the checks in tts_upload_to_s3 https://github.com/code-dot-org/code-dot-org/blob/f970daeba23a8630f5d470fe18349753befeabc2/dashboard/app/models/concerns/text_to_speech.rb#L93-L94
    load './scripts/update_tts_i18n.rb'; 
    
    # run a single test
    I18n.locale = :'es-ES'
    level = Level.find(10240)
    script = Script.find(107)
    update_level_tts_i18n(level, script)

    # run the entire update_tts_i18n.rb script
    main
    ```
  - Scenario 3: Run `dashboard/scripts/update_tts_i18n_static_messages.rb`


## Follow-up work
- [x] Create metrics for production and levelbuilder environment after code is deployed and metric data is sent to CloudWatch. [FND-1464](https://codedotorg.atlassian.net/browse/FND-1464). [Acapela-TTS-Service dashboard](https://console.aws.amazon.com/cloudwatch/home?region=us-east-1#dashboards:name=Acapela-TTS-Service)
- [x] Create alarms for the production and levelbuilder metrics above. See https://github.com/code-dot-org/code-dot-org/pull/39623
- [ ] Consider other options if need to
  - Honeybadger notification
  - Throttling?  (Side effect: a level's TTS could be out-of-sync with its texts)

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
