### PR TITLE
[AiLab] adjust ml_model metadata route & handle if model id not found 

### DIFF
--- a/apps/src/code-studio/components/ModelCard.jsx
+++ b/apps/src/code-studio/components/ModelCard.jsx
@@ -47,7 +47,7 @@ export default class ModelCard extends React.Component {
     if (this.props.modelId) {
       this.setState({isImportPending: true});
       $.ajax({
-        url: '/api/v1/ml_models/metadata/' + this.props.modelId,
+        url: '/api/v1/ml_models/' + this.props.modelId + '/metadata',
         method: 'GET',
         dataType: 'json'
       })

--- a/dashboard/app/controllers/api/v1/ml_models_controller.rb
+++ b/dashboard/app/controllers/api/v1/ml_models_controller.rb
@@ -45,6 +45,7 @@ class Api::V1::MlModelsController < Api::V1::JsonApiController
   # Retrieve a trained ML model from S3
   def get_trained_model
     model = download_from_s3(params[:model_id])
+    return render_404 unless model
     render json: model
   end
 

--- a/dashboard/config/routes.rb
+++ b/dashboard/config/routes.rb
@@ -717,8 +717,8 @@ Dashboard::Application.routes.draw do
 
       post 'ml_models/save', to: 'ml_models#save'
       get 'ml_models/names', to: 'ml_models#user_ml_model_names'
-      get 'ml_models/metadata/:model_id', to: 'ml_models#user_ml_model_metadata'
       get 'ml_models/:model_id', to: 'ml_models#get_trained_model'
+      get 'ml_models/:model_id/metadata', to: 'ml_models#user_ml_model_metadata'
 
       resources :teacher_feedbacks, only: [:index, :create] do
         collection do


### PR DESCRIPTION
[HoneyBadger Error ](https://app.honeybadger.io/projects/3240/faults/77429517)

Previously, if the model id was unspecified when trying to fetch metadata, we hit a route like: https://studio.code.org/api/v1/ml_models/metadata, which throws the error `AWS::S3::NoSuchKey: No such key `metadata'` This happens because when we try to download the model with id `metadata` from S3, that model doesn't exist.  

![Screen Shot 2021-03-08 at 4 38 35 PM](https://user-images.githubusercontent.com/12300669/110387799-24da3d80-8030-11eb-98dd-a8450a75835f.png)

Instead, if there's a missing or malformed model id, we now more appropriately throw a 404 not found error in the controller. 

Additionally, I modified the route to fetch metadata to be more consistent with Rails convention: `model/<:id>/action` 