### PR TITLE
fix inconsistency in level key names in coursee-2021

### DIFF
--- a/dashboard/config/scripts_json/coursee-2021.script_json
+++ b/dashboard/config/scripts_json/coursee-2021.script_json
@@ -4464,14 +4464,14 @@
       "properties": {
         "progression": "Practice",
         "level_keys": [
-          "courseE_farmer_ramp12g_2021"
+          "courseE_farmer_while1_2021"
         ]
       },
       "named_level": null,
       "bonus": null,
       "seeding_key": {
         "script_level.level_keys": [
-          "courseE_farmer_ramp12g_2021"
+          "courseE_farmer_while1_2021"
         ],
         "lesson.key": "Conditionals",
         "lesson_group.key": "ramp_up",
@@ -4479,7 +4479,7 @@
         "activity_section.key": "c6d24990-be45-4b52-b095-48004fcaca4a"
       },
       "level_keys": [
-        "courseE_farmer_ramp12g_2021"
+        "courseE_farmer_while1_2021"
       ]
     },
     {
@@ -7480,7 +7480,7 @@
       "seeding_key": {
         "level.key": "courseE_farmer_while1_2021",
         "script_level.level_keys": [
-          "courseE_farmer_ramp12g_2021"
+          "courseE_farmer_while1_2021"
         ],
         "lesson.key": "Conditionals",
         "lesson_group.key": "ramp_up",


### PR DESCRIPTION
Today's levelbuilder content scoop introduced a diff which caused seeding to fail on staging. After adding some debug logging, the stack trace looked like this:

```
seeding only scripts:
config/scripts/coursee-2021.script
Error destroying 1 instances of LevelsScriptLevel: [#<LevelsScriptLevel level_id: 24767, script_level_id: 31089>]
rake aborted!
ActiveRecord::UnknownPrimaryKey: Error adding script named 'coursee-2021': Unknown primary key for table levels_script_levels in model LevelsScriptLevel.
...
/home/ubuntu/staging/dashboard/lib/services/script_seed.rb:485:in `destroy_outdated_objects'
/home/ubuntu/staging/dashboard/lib/services/script_seed.rb:337:in `import_levels_script_levels'
/home/ubuntu/staging/dashboard/lib/services/script_seed.rb:188:in `block in seed_from_hash'
...
```

By looking up the level name, I was able to narrow down the problem to this section of the diff: 0b69d62d0eaa1fd8a679719bbcbdfbea5523e68a
![Screen Shot 2021-03-08 at 2 53 17 PM](https://user-images.githubusercontent.com/8001765/110393107-d7a1a000-801e-11eb-84f5-5bb0e80bb1fd.png)

It looks like the curriculum editor was trying to replace courseE_farmer_ramp12g_2021 with courseE_farmer_while1_2021 in https://levelbuilder-studio.code.org/s/coursee-2021/lessons/3 . The problem is that the level name did not get updated in all of the places, leaving the old level name around.

## Testing story

I was able to repro the seeding failure locally. The changes in this PR fix the seeding problem. 

## Future work

I've opened [PLAT-820] to track finding a root cause and fix. 


[PLAT-820]: https://codedotorg.atlassian.net/browse/PLAT-820