### PR TITLE
Add key to programming_expression

### DIFF
--- a/dashboard/app/models/programming_expression.rb
+++ b/dashboard/app/models/programming_expression.rb
@@ -9,7 +9,7 @@
 #  programming_environment_id :bigint           not null
 #  created_at                 :datetime         not null
 #  updated_at                 :datetime         not null
-#  key                        :string(255)
+#  key                        :string(255)      not null
 #
 # Indexes
 #

--- a/dashboard/app/models/programming_expression.rb
+++ b/dashboard/app/models/programming_expression.rb
@@ -9,6 +9,7 @@
 #  programming_environment_id :bigint           not null
 #  created_at                 :datetime         not null
 #  updated_at                 :datetime         not null
+#  key                        :string(255)
 #
 # Indexes
 #

--- a/dashboard/db/migrate/20210308190316_add_key_to_programming_expressions.rb
+++ b/dashboard/db/migrate/20210308190316_add_key_to_programming_expressions.rb
@@ -1,0 +1,5 @@
+class AddKeyToProgrammingExpressions < ActiveRecord::Migration[5.2]
+  def change
+    add_column :programming_expressions, :key, :string
+  end
+end

--- a/dashboard/db/migrate/20210308190316_add_key_to_programming_expressions.rb
+++ b/dashboard/db/migrate/20210308190316_add_key_to_programming_expressions.rb
@@ -1,5 +1,5 @@
 class AddKeyToProgrammingExpressions < ActiveRecord::Migration[5.2]
   def change
-    add_column :programming_expressions, :key, :string
+    add_column :programming_expressions, :key, :string, null: false
   end
 end

--- a/dashboard/db/schema.rb
+++ b/dashboard/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_02_26_215944) do
+ActiveRecord::Schema.define(version: 2021_03_08_190316) do
 
   create_table "activities", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci", force: :cascade do |t|
     t.integer "user_id"
@@ -1281,6 +1281,7 @@ ActiveRecord::Schema.define(version: 2021_02_26_215944) do
     t.bigint "programming_environment_id", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.string "key"
     t.index ["programming_environment_id"], name: "index_programming_expressions_on_programming_environment_id"
   end
 

--- a/dashboard/db/schema.rb
+++ b/dashboard/db/schema.rb
@@ -1281,7 +1281,7 @@ ActiveRecord::Schema.define(version: 2021_03_08_190316) do
     t.bigint "programming_environment_id", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.string "key"
+    t.string "key", null: false
     t.index ["programming_environment_id"], name: "index_programming_expressions_on_programming_environment_id"
   end
 

--- a/dashboard/test/factories/factories.rb
+++ b/dashboard/test/factories/factories.rb
@@ -830,7 +830,8 @@ FactoryGirl.define do
 
   factory :programming_expression do
     association :programming_environment
-    sequence(:name) {|n| "programming-expression-#{n}"}
+    sequence(:name) {|n| "programming expression #{n}"}
+    sequence(:key) {|n| "programming-expression-#{n}"}
   end
 
   factory :callout do

--- a/dashboard/test/models/programming_expression_test.rb
+++ b/dashboard/test/models/programming_expression_test.rb
@@ -4,6 +4,7 @@ class ProgrammingExpressionTest < ActiveSupport::TestCase
   test "can create programming expression" do
     programming_expression = create :programming_expression
     assert programming_expression.name
+    assert programming_expression.key
   end
 
   test "programming expression can be added to a lesson" do


### PR DESCRIPTION
Add key to programming_expression. Key is also the slug used for the block in the url. I think having both name and key will be necessary. We will want name for searching for blocks and key for urls.
