### PR TITLE
Add 2021 courses to script constants and categories

### DIFF
--- a/dashboard/config/locales/scripts.en.yml
+++ b/dashboard/config/locales/scripts.en.yml
@@ -8,17 +8,20 @@ en:
         csd_2018_category_name: CS Discoveries ('18-'19)
         csd_2019_category_name: CS Discoveries ('19-'20)
         csd_2020_category_name: CS Discoveries ('20-'21)
+        csd_2021_category_name: CS Discoveries ('21-'22)
         csd_pilot_category_name: CS Discoveries Pilot
         csf_category_name: CS Fundamentals
         csf_2018_category_name: CS Fundamentals ('18-'19)
         csf_2019_category_name: CS Fundamentals ('19-'20)
         csf_2020_category_name: CS Fundamentals ('20-'21)
+        csf_2021_category_name: CS Fundamentals ('21-'22)
         csf_international_category_name: CS Fundamentals International
         csf2_draft_category_name: 'Under Development: Courses A - F'
         csp_category_name: CS Principles ('15-'16)
         csp_2018_category_name: CS Principles ('18-'19)
         csp_2019_category_name: CS Principles ('19-'20)
         csp_2020_category_name: CS Principles ('20-'21)
+        csp_2021_category_name: CS Principles ('21-'22)
         cspexams_category_name: CS Principles Practice Test
         csp17_category_name: CS Principles ('17-'18)
         full_course_category_name: Full Courses

--- a/lib/cdo/script_constants.rb
+++ b/lib/cdo/script_constants.rb
@@ -59,6 +59,16 @@ module ScriptConstants
       EXPRESS_2020_NAME = 'express-2020'.freeze,
       PRE_READER_EXPRESS_2020_NAME = 'pre-express-2020'.freeze,
     ],
+    csf_2021: [
+      COURSEA_2021_NAME = 'coursea-2021'.freeze,
+      COURSEB_2021_NAME = 'courseb-2021'.freeze,
+      COURSEC_2021_NAME = 'coursec-2021'.freeze,
+      COURSED_2021_NAME = 'coursed-2021'.freeze,
+      COURSEE_2021_NAME = 'coursee-2021'.freeze,
+      COURSEF_2021_NAME = 'coursef-2021'.freeze,
+      EXPRESS_2021_NAME = 'express-2021'.freeze,
+      PRE_READER_EXPRESS_2021_NAME = 'pre-express-2021'.freeze,
+    ],
     hoc: [
       # Note that now multiple scripts can be an 'hour of code' script.
       # If adding a script here,
@@ -119,6 +129,14 @@ module ScriptConstants
       CSD2_PILOT_NAME = 'csd2-pilot'.freeze,
       CSD3_PILOT_NAME = 'csd3-pilot'.freeze,
     ],
+    csd_2021: [
+      CSD1_2021_NAME = 'csd1-2021'.freeze,
+      CSD2_2021_NAME = 'csd2-2021'.freeze,
+      CSD3_2021_NAME = 'csd3-2021'.freeze,
+      CSD4_2021_NAME = 'csd4-2021'.freeze,
+      CSD5_2021_NAME = 'csd5-2021'.freeze,
+      CSD6_2021_NAME = 'csd6-2021'.freeze,
+    ],
     csd_2020: [
       CSD1_2020_NAME = 'csd1-2020'.freeze,
       CSD2_2020_NAME = 'csd2-2020'.freeze,
@@ -152,6 +170,18 @@ module ScriptConstants
       CSD5_NAME = 'csd5-2017'.freeze,
       CSD6_NAME = 'csd6-2017'.freeze,
     ],
+    csp_2021: [
+      CSP1_2021_NAME = 'csp1-2021'.freeze,
+      CSP2_2021_NAME = 'csp2-2021'.freeze,
+      CSP3_2021_NAME = 'csp3-2021'.freeze,
+      CSP4_2021_NAME = 'csp4-2021'.freeze,
+      CSP5_2021_NAME = 'csp5-2021'.freeze,
+      CSP6_2021_NAME = 'csp6-2021'.freeze,
+      CSP7_2021_NAME = 'csp7-2021'.freeze,
+      CSP8_2021_NAME = 'csp8-2021'.freeze,
+      CSP9_2021_NAME = 'csp9-2021'.freeze,
+      CSP10_2021_NAME = 'csp10-2021'.freeze,
+    ].freeze,
     csp_2020: [
       CSP1_2020_NAME = 'csp1-2020'.freeze,
       CSP2_2020_NAME = 'csp2-2020'.freeze,

--- a/lib/test/test_script_constants.rb
+++ b/lib/test/test_script_constants.rb
@@ -62,8 +62,8 @@ class ScriptConstantsTest < Minitest::Test
   end
 
   def test_category_priority
-    assert_equal 5, ScriptConstants.category_priority(:csf_international)
-    assert_equal 7, ScriptConstants.category_priority(:research_studies)
+    assert_equal 6, ScriptConstants.category_priority(:csf_international)
+    assert_equal 8, ScriptConstants.category_priority(:research_studies)
   end
 
   def test_assignable_info


### PR DESCRIPTION
Each year part of shipping curriculum is adding updates to script constants for the upcoming years course.  This sets up CSF, CSD and CSP. When CSD adds the AI/ML unit we will need to add something here for that as well.

In addition we have to add category names to scripts.en.yml. This is done here as well.

https://codedotorg.atlassian.net/browse/PLAT-596
https://codedotorg.atlassian.net/browse/PLAT-601