### PR TITLE
Update bramble to 0.1.29

### DIFF
--- a/dashboard/app/controllers/weblab_host_controller.rb
+++ b/dashboard/app/controllers/weblab_host_controller.rb
@@ -1,7 +1,7 @@
 class WeblabHostController < ApplicationController
   layout false
 
-  BRAMBLE_URL = 'https://downloads.computinginthecore.org/bramble_0.1.28'
+  BRAMBLE_URL = 'https://downloads.computinginthecore.org/bramble_0.1.29'
   BRAMBLE_LOCALHOST_URL = 'http://127.0.0.1:8000/src'
 
   def index


### PR DESCRIPTION
Updates Code Studio's version of Bramble to 0.1.29, which contains a change that fixes the commit our filer submodule points to ([this PR](https://github.com/code-dot-org/bramble/pull/16)).

## Links
- [STAR-1468](https://codedotorg.atlassian.net/browse/STAR-1468)