### PR TITLE
disable student lesson plan ui test on iProducts

### DIFF
--- a/dashboard/test/ui/features/learning_platform/student_lesson_plan.feature
+++ b/dashboard/test/ui/features/learning_platform/student_lesson_plan.feature
@@ -1,4 +1,5 @@
 @no_ie
+@no_mobile
 Feature: Student Lesson Plan
 
   Scenario: Viewing Student Lesson Plan


### PR DESCRIPTION
Follow-on to https://github.com/code-dot-org/code-dot-org/pull/39371 to fix a failing UI test. Because this is an unlaunched feature, the plan is to disable the test in this browser and then follow up with a fix before launch.