### PR TITLE
i18n tracking logs human readable URL

### DIFF
--- a/lib/cdo/i18n_string_url_tracker.rb
+++ b/lib/cdo/i18n_string_url_tracker.rb
@@ -67,7 +67,9 @@ class I18nStringUrlTracker
     url = normalize_url(url)
     return unless string_key && url && source
 
-    add_to_buffer(string_key, url, source)
+    # Reverse the URL encoding on special characters so the human readable characters are logged.
+    logged_url = CGI.unescape(url)
+    add_to_buffer(string_key, logged_url, source)
   end
 
   private

--- a/lib/test/cdo/test_i18n_string_url_tracker.rb
+++ b/lib/test/cdo/test_i18n_string_url_tracker.rb
@@ -224,4 +224,17 @@ class TestI18nStringUrlTracker < Minitest::Test
     assert_equal(:i18n, @firehose_stream)
     assert_equal(test_record, @firehose_record)
   end
+
+  def test_log_given_url_with_special_symbol_should_log_the_special_symbol
+    # Normally, if a special character such as a white space is in a URL,
+    # it would be URL encoded to "%20"; however we want it to be logged as
+    # a normal whitespace in order to make the data easier to read by analysts.
+    test_record = {string_key: 'string.key', url: 'https://code.org/url%20with%20spaces', source: 'test'}
+    expected_record = {string_key: 'string.key', url: 'https://code.org/url with spaces', source: 'test'}
+    FirehoseClient.instance.expects(:put_record).once
+    I18nStringUrlTracker.instance.log(test_record[:string_key], test_record[:url], test_record[:source])
+    I18nStringUrlTracker.instance.send(:flush)
+    assert_equal(:i18n, @firehose_stream)
+    assert_equal(expected_record, @firehose_record)
+  end
 end


### PR DESCRIPTION
Currently, the I18n string tracking solution logs "http://code.org/hello%20world"
We want it to log "http://code.org/hello world".

## Links
* [JIRA](https://codedotorg.atlassian.net/browse/FND-1454)

## Testing story
* Unit test

## Deployment strategy
N/A
## Follow-up work

N/A

## Privacy

N/A

## Security

N/A

## Caching

N/A
## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [x] Tests provide adequate coverage
- [x] Privacy and Security impacts have been assessed
- [x] Code is well-commented
- [x] New features are translatable or updates will not break translations
- [x] Relevant documentation has been added or updated
- [x] User impact is well-understood and desirable
- [x] Pull Request is labeled appropriately
- [x] Follow-up work items (including potential tech debt) are tracked and linked
