### PR TITLE
Enable csf workshop attendance gsheet cron job

### DIFF
--- a/bin/cron/csf_workshop_attendance_to_gdrive
+++ b/bin/cron/csf_workshop_attendance_to_gdrive
@@ -34,8 +34,10 @@ def get_rows
     ]
   ]
 
+  subjects = [Pd::SharedWorkshopConstants::SUBJECT_CSF_101, Pd::SharedWorkshopConstants::SUBJECT_CSF_201]
+
   Pd::Workshop.
-    where(subject: Pd::SharedWorkshopConstants::SUBJECT_CSF_101).
+    where(subject: subjects).
     scheduled_end_on_or_after(EARLIEST_WORKSHOP_END_DATE).
     scheduled_start_on_or_before(LATEST_WORKSHOP_START_DATE).find_each do |workshop|
       results << [

--- a/cookbooks/cdo-apps/templates/default/crontab.erb
+++ b/cookbooks/cdo-apps/templates/default/crontab.erb
@@ -94,8 +94,7 @@
       cronjob at:'* * * * *', do:deploy_dir('bin', 'cron', 'confirm_usage')
       cronjob at:'0 */2 * * *', do:deploy_dir('bin', 'cron', 'teacher_applications_to_gdrive')
       cronjob at:'30 */2 * * *', do:deploy_dir('bin', 'cron', 'summer_workshops_to_gdrive')
-      # [Clare] Disabled so that we can do the first run manually on production-daemon, to update credentials.
-      # cronjob at:'0 12 * * *', do:deploy_dir('bin', 'cron', 'csf_workshop_attendance_to_gdrive')
+      cronjob at:'0 12 * * *', do:deploy_dir('bin', 'cron', 'csf_workshop_attendance_to_gdrive')
       cronjob at:'0 7 * * *', do:deploy_dir('bin', 'cron', 'stop_inactive_adhoc_instances')
       cronjob at:'0 10 * * *', do:deploy_dir('bin', 'cron', 'redshift_rollups')
       cronjob at:'1 7 * * 6', do:deploy_dir('bin', 'cron', 'cleanup_workshop_attendance_codes')


### PR DESCRIPTION
Follow up to https://github.com/code-dot-org/code-dot-org/pull/39120 - now that I've successfully run the script manually in production (including with the other tweak in this PR), enable this to run every day. Also adding Deep Dive workshops to the export.

<!--
  A summary of the change, including any relevant background, motivation, and context.
  If relevant, include a description, screenshots, and/or video of the existing and new behavior.
-->

## Links

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

<!--
- spec: []()
- jira ticket: []()
-->

## Testing story

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
