### PR TITLE
New teacher welcome email for es-MX locale

### DIFF
--- a/dashboard/app/controllers/registrations_controller.rb
+++ b/dashboard/app/controllers/registrations_controller.rb
@@ -112,7 +112,7 @@ class RegistrationsController < Devise::RegistrationsController
     end
 
     should_send_new_teacher_email = current_user && current_user.teacher?
-    TeacherMailer.new_teacher_email(current_user).deliver_now if should_send_new_teacher_email
+    TeacherMailer.new_teacher_email(current_user, request.locale).deliver_now if should_send_new_teacher_email
     should_send_parent_email = current_user && current_user.parent_email.present?
     ParentMailer.parent_email_added_to_student_account(current_user.parent_email, current_user).deliver_now if should_send_parent_email
 

--- a/dashboard/app/mailers/teacher_mailer.rb
+++ b/dashboard/app/mailers/teacher_mailer.rb
@@ -2,9 +2,18 @@ class TeacherMailer < ActionMailer::Base
   default from: 'Hadi Partovi <hadi_partovi@code.org>'
 
   # Send newly registered teachers a welcome email
-  def new_teacher_email(teacher)
+  def new_teacher_email(teacher, teacher_locale = 'en-US')
     @teacher = teacher
-    mail to: teacher.email, subject: I18n.t('teacher_mailer.new_teacher_subject')
+
+    # We currently have two flavors for the new teacher welcome email,
+    # en-US (the default) and es-MX.
+    email_locale = teacher_locale.to_s == 'es-MX' ? teacher_locale : 'en-US'
+    email_template = teacher_locale.to_s == 'es-MX' ? 'new_teacher_email_es-MX' : 'new_teacher_email'
+
+    mail to: teacher.email,
+      subject: I18n.t('teacher_mailer.new_teacher_subject', locale: email_locale),
+      template_path: 'teacher_mailer',
+      template_name: email_template
   end
 
   def delete_teacher_email(teacher, removed_students)

--- a/dashboard/app/views/teacher_mailer/new_teacher_email.html.haml
+++ b/dashboard/app/views/teacher_mailer/new_teacher_email.html.haml
@@ -76,8 +76,12 @@
 
 %p
   (1)
-  = get_random_donor_email_message.html_safe
+  - donor = get_random_donor_name_and_twitter
+  - tweet = "I just signed up to teach computer science using Code.org! Thanks #{donor[:twitter]} for supporting @codeorg."
+  %a{href: "https://twitter.com/intent/tweet?text=#{tweet}"} Tweet a message of thanks
+  to #{donor[:name]}, one of our donors.
   %br
+
   (2) If you shop at Amazon,
   %a{href: "https://code.org/donate/amazonsmile"}use Amazon Smile
   to donate proceeds to Code.org.

--- a/dashboard/app/views/teacher_mailer/new_teacher_email_es-MX.html.haml
+++ b/dashboard/app/views/teacher_mailer/new_teacher_email_es-MX.html.haml
@@ -1,0 +1,3 @@
+%p
+  Hola #{@teacher.name}!
+  (This is a placeholder template for es-MX content.)

--- a/dashboard/app/views/teacher_mailer/new_teacher_email_es-MX.html.haml
+++ b/dashboard/app/views/teacher_mailer/new_teacher_email_es-MX.html.haml
@@ -68,7 +68,7 @@
 %p
   (1)
   - donor = get_random_donor_name_and_twitter
-  - tweet = "I just signed up to teach computer science using Code.org! Thanks #{donor[:twitter]} for supporting @codeorg."
+  - tweet = "¡Acabo de registrarme para enseñar ciencias de la computación con Code.org! Gracias a #{donor[:twitter]} por apoyar a @codeorg."
   %a{href: "https://twitter.com/intent/tweet?text=#{tweet}"} Envía un mensaje de agradecimiento
   a #{donor[:name]}, uno de nuestros donantes.
   %br

--- a/dashboard/app/views/teacher_mailer/new_teacher_email_es-MX.html.haml
+++ b/dashboard/app/views/teacher_mailer/new_teacher_email_es-MX.html.haml
@@ -1,3 +1,78 @@
 %p
-  Hola #{@teacher.name}!
-  (This is a placeholder template for es-MX content.)
+  Hola #{@teacher.name}, y bienvenidos a Code.org! Estamos aquí para ayudarte a empezar.
+
+%h3
+  Paso 1: Elige un curso
+%p
+  En Code.org
+  %a{href: "https://studio.code.org/courses?view=teacher"} encontrarás cursos para cada grado
+  escolar, desde prelectores hasta estudiantes del último año de secundaria. Todos nuestros
+  cursos son gratuitos. ¿Buscas una actividad rápida? Intenta comenzar con una
+  %a{href: "https://hourofcode.com/"} Hora de Código.
+
+%h3
+  Paso 2: Configura la sección de tu aula
+%p
+  %a{href: "https://studio.code.org/home"} Configura una sección de aula
+  para ver el progreso de tus estudiantes, imprimir tarjetas de inicio de sesión para los
+  estudiantes, administrar las cuentas e imprimir certificados que pueden llevar a casa cuando
+  terminen el curso.
+
+%h3
+  Paso 3: Empieza a enseñar
+%p
+  ¡Prueba una de las lecciones por ti mismo! También tenemos planes de lecciones diarias que
+  puedes usar para guiar a tus estudiantes, actividades desconectadas que se pueden realizar sin
+  computadoras, y foros para conectarse con otros docentes.
+
+%a{href: "https://studio.code.org/home", style: 'width: 180px; height: 36px; border: 0; color: white; background-color: #FDC62C; font: bolder 18px Arial; display: block; text-align: center; line-height: 36px; text-decoration: none; border-radius: 5px;'}
+  Empieza aquí
+
+%h3
+  ¿Todavía tienes preguntas?
+%p
+  Consulta nuestra
+  %a{href: "https://support.code.org/hc/en-us/sections/115000120211-Getting-started-on-Code-org"} guía de introducción
+  o comunícate con
+  %a{href: "mailto:support@code.org"} support@code.org.
+
+%h3
+  ¡Únete al movimiento!
+%p
+  Síguenos
+  %a{href: "https://twitter.com/codeorg"}en Twitter,
+  %a{href: "https://www.instagram.com/codeorg"} en Instagram,
+  %a{href: "https://www.facebook.com/Code.org"} en Facebook
+  o
+  %a{href: "https://www.linkedin.com/company/code-org"} en LinkedIn.
+  Únete a un movimiento de más de 2 millones de docentes y más de 55 millones de estudiantes
+  que han utilizado Code.org alrededor de todo el mundo. Esto hace a Code.org la plataforma de
+  educación de  programación y el proveedor de planes de estudio de ciencias de la
+  computación más popular en las escuelas primaria y secundaria.
+%p
+  %a{href: "https://medium.com/@codeorg/cs-helps-students-outperform-in-school-college-and-workplace-66dd64a69536"} Seis estudios diferentes muestran
+  que: los estudiantes que estudian ciencias de la computación se desempeñan mejor en otras
+  materias, sobresalen en la resolución de problemas, y un 17% es más probable que ingrese a la
+  universidad. Gracias por todo el trabajo que haces para apoyar a los y las estudiantes en
+  construir sus futuros.
+
+%p
+  Saludos,
+%p
+  Hadi Partovi
+  %br
+  Fundador, Code.org
+
+%p
+  PD Si disfrutas de Code.org, puedes apoyarnos de manera gratuita:
+%p
+  (1)
+  - donor = get_random_donor_name_and_twitter
+  - tweet = "I just signed up to teach computer science using Code.org! Thanks #{donor[:twitter]} for supporting @codeorg."
+  %a{href: "https://twitter.com/intent/tweet?text=#{tweet}"} Envía un mensaje de agradecimiento
+  a #{donor[:name]}, uno de nuestros donantes.
+  %br
+
+  (2) Si compras en Amazon,
+  %a{href: "https://code.org/donate/amazonsmile"} usa Amazon Smile
+  y Amazon donará un porcentaje de tu compra a Code.org.

--- a/dashboard/test/controllers/registrations_controller_test.rb
+++ b/dashboard/test/controllers/registrations_controller_test.rb
@@ -356,6 +356,16 @@ class RegistrationsControllerTest < ActionController::TestCase
     refute mail.body.to_s =~ /New to teaching computer science/
   end
 
+  test 'create new teacher with es-MX locale sends localized welcome email' do
+    with_default_locale('es-MX') do
+      teacher_params = @default_params.update(user_type: 'teacher', email_preference_opt_in: 'yes')
+      post :create, params: {user: teacher_params}
+      mail = ActionMailer::Base.deliveries.first
+      assert_equal I18n.t('teacher_mailer.new_teacher_subject', locale: 'es-MX'), mail.subject
+      assert_match /Hola/, mail.body.to_s
+    end
+  end
+
   test "create new teacher with opt-in option as yes writes email preference as yes" do
     teacher_params = @default_params.update(user_type: 'teacher', email_preference_opt_in: 'yes')
     Geocoder.stubs(:search).returns([OpenStruct.new(country_code: 'CA')])

--- a/dashboard/test/mailers/previews/teacher_mailer_preview.rb
+++ b/dashboard/test/mailers/previews/teacher_mailer_preview.rb
@@ -2,6 +2,11 @@
 class TeacherMailerPreview < ActionMailer::Preview
   include FactoryGirl::Syntax::Methods
 
+  def new_teacher_email_es_mx_preview
+    teacher = build :teacher, email: 'teacher@gmail.com'
+    TeacherMailer.new_teacher_email(teacher, 'es-MX')
+  end
+
   def new_teacher_email_preview
     teacher = build :teacher, email: 'fake_email@fake.com'
     TeacherMailer.new_teacher_email(teacher)

--- a/dashboard/test/mailers/teacher_mailer_test.rb
+++ b/dashboard/test/mailers/teacher_mailer_test.rb
@@ -1,14 +1,33 @@
 require 'test_helper'
 
 class TeacherMailerTest < ActionMailer::TestCase
-  test 'new teacher email' do
-    teacher = create :teacher, email: 'minerva@hogwarts.co.uk'
-    mail = TeacherMailer.new_teacher_email(teacher)
+  test 'new teacher email for en-US locale' do
+    # Teacher with en-US locale will get the en-US version of the welcome email.
+    teacher = build :teacher, email: 'minerva@hogwarts.co.uk'
+    mail = TeacherMailer.new_teacher_email(teacher, 'en-US')
 
-    assert_equal I18n.t('teacher_mailer.new_teacher_subject'), mail.subject
+    assert_equal I18n.t('teacher_mailer.new_teacher_subject', locale: 'en-US'), mail.subject
     assert_equal [teacher.email], mail.to
     assert_equal ['hadi_partovi@code.org'], mail.from
+    assert_match /Hello/, mail.body.encoded
     assert links_are_complete_urls?(mail)
+  end
+
+  test 'new teacher email for es-MX locale' do
+    # Teacher with es-MX locale will get the es-MX version of the welcome email.
+    teacher = build :teacher, email: 'teacher@gmail.com'
+    mail = TeacherMailer.new_teacher_email(teacher, 'es-MX')
+    assert_equal I18n.t('teacher_mailer.new_teacher_subject', locale: 'es-MX'), mail.subject
+    assert_match /Hola/, mail.body.encoded
+  end
+
+  test 'new teacher email for non en-US, non es-MX locale' do
+    # Teacher with non en-US and non es-MX locale will get the
+    # standard en-US version of the welcome email.
+    teacher = build :teacher, email: 'teacher@gmail.com'
+    mail = TeacherMailer.new_teacher_email(teacher, 'it-IT')
+    assert_equal I18n.t('teacher_mailer.new_teacher_subject', locale: 'en-US'), mail.subject
+    assert_match /Hello/, mail.body.encoded
   end
 
   test 'delete teacher email' do


### PR DESCRIPTION
[FND-1456](https://codedotorg.atlassian.net/browse/FND-1456) 
Create a localized [welcome email for teachers](https://docs.google.com/document/d/1kRl3fBvL9U9KaWkq9iab3-zPTZ1BiXTinppNPPvoCOs/edit?ts=6053984b&pli=1) with es-MX locale. All other new teachers still receive the standard welcome email in English.

Result:
  <img width="717" alt="Screen Shot 2021-03-18 at 11 18 50 AM" src="https://user-images.githubusercontent.com/46507039/111676777-c0f80780-87db-11eb-9e99-6e0b7de57d33.png">


## Testing story
### Unit tests and integration test
  - `bundle exec rails test test/controllers/registrations_controller_test.rb`
  - `bundle exec rails test test/mailers/teacher_mailer_test.rb`

###  Email previews
Check 2 versions of the teacher email at http://localhost-studio.code.org:3000/rails/mailers/teacher_mailer/

### Manually test the new-teacher sign-up scenario on local machine
- Set the default locale  to "es-MX" https://github.com/code-dot-org/code-dot-org/blob/aafe2062b90f48a12a17e236c63f2164235557c5/lib/cdo/rack/request.rb#L27
- Enable `mailcatcher` 
  - Set `use_mailcatcher: true` in `locals.yml`. (See [Email brownbag doc](https://docs.google.com/document/d/1aKY6HSWfQtpXXXtFH6APXFJ9OSlJpTxoVcM-rElgivA/edit?pli=1#) for more details about our email system.)
  - Start `mailcatcher`: `mailcatcher --ip=0.0.0.0`
  - Open `mailcatcher` inbox at http://0.0.0.0:1080/
  - After done, kill `mailcatcher` by running: `kill -9 $(lsof -t -i :1025)` and reset `use_mailcatcher` value in `locals.yml`.
- Sign up as a new teacher at http://localhost-studio.code.org:3000/users/sign_up
- Verify that a welcome email using es-MX is in the `mailcatcher` inbox.
    <img width="603" alt="Screen Shot 2021-03-10 at 1 36 32 PM" src="https://user-images.githubusercontent.com/46507039/110701224-bfa85880-81a5-11eb-992a-e03a689fe555.png">


## To-do before merging. (Don't merge before a monitoring system is in place.)
- [x] Add real content to the `new_teacher_email_es-MX.html.haml` file.
- [x] Update Twitter tweet in Spanish.
- [ ] Create a monitoring system for transactional email. [FND-1465](https://codedotorg.atlassian.net/browse/FND-1465)

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [x] Tests provide adequate coverage
- [x] Privacy and Security impacts have been assessed
- [x] Code is well-commented
- [x] New features are translatable or updates will not break translations
- [x] Relevant documentation has been added or updated
- [x] User impact is well-understood and desirable
- [x] Pull Request is labeled appropriately
- [x] Follow-up work items (including potential tech debt) are tracked and linked
