### PR TITLE
Make the block color for Advanced in gamelab match applab

### DIFF
--- a/apps/src/p5lab/gamelab/dropletConfig.js
+++ b/apps/src/p5lab/gamelab/dropletConfig.js
@@ -1968,7 +1968,7 @@ module.exports.categories = {
   Advanced: {
     id: 'advanced',
     color: 'blue',
-    rgb: color.droplet_blue,
+    rgb: color.droplet_bright_blue,
     blocks: []
   }
 };


### PR DESCRIPTION
The palette color for the Advanced category in Game Lab does not match the one used in App Lab. They are slightly different colors of blue. This makes them match. Since this category is not shown in the toolbox or used in the curriculum there should not be other areas where screenshots and such would need to be updated. See [thread](https://codedotorg.slack.com/archives/C1B3PNDL7/p1614718268052000) for details
