### PR TITLE
stop writing deprecated standards fields

### DIFF
--- a/dashboard/app/models/standard.rb
+++ b/dashboard/app/models/standard.rb
@@ -28,17 +28,12 @@ class Standard < ApplicationRecord
       id: id,
       shortcode: shortcode,
       category_description: category.description,
-      description: description,
-
-      # deprecated fields
-      organization: organization,
-      organization_id: organization_id,
-      concept: concept
+      description: description
     }
   end
 
   # Loads/merges the data from a CSV into the Standards table.
-  # Can be used to overwrite the description and concept of
+  # Can be used to overwrite the description and category of
   # existing Standards and to create new Standards.
   # Will not delete existing Standards.
 
@@ -67,19 +62,14 @@ class Standard < ApplicationRecord
         category: category,
         shortcode: row['organization_id'],
         description: row['description'],
-
-        # deprecated fields to stop using
-        organization: row['organization'],
-        organization_id: row['organization_id'],
-        concept: row['concept'],
       }
-      loaded = Standard.find_by({organization: parsed[:organization], organization_id: parsed[:organization_id]})
+      loaded = Standard.find_by({category: parsed[:category], shortcode: parsed[:shortcode]})
       if loaded.nil?
         begin
           Standard.new(parsed).save!
           created += 1
         rescue => error
-          puts "Error when processing #{parsed[:organization]} #{parsed[:organization_id]}: #{error.message}"
+          puts "Error when processing #{row}: #{error.message}"
         end
       else
         loaded.assign_attributes(parsed)


### PR DESCRIPTION
Continues work on [PLAT-750]. Stops writing to deprecated standards fields, now that we are no longer using them as of https://github.com/code-dot-org/code-dot-org/pull/39344 .  For more background, see [Lesson Standards design doc](https://docs.google.com/document/d/1zvdv7y8VuRz8KqT1rzqeJAmvirCvUr1jS8OWy0p9FHk/edit#).

## Testing story

Existing UI test verifies that admin standards import, standards progress tab, and standards report are still working.

Since this PR also removes additional references to the deprecated fields from the seeding logic, I also manually verified that `rake seed:standards` is working as follows:
- [x] re running `rake seed:standards` locally, where I have previously seeded standards, has no effect on DB contents. 
- [x] drone + ui tests verify that seeding from scratch is still working

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked


[PLAT-750]: https://codedotorg.atlassian.net/browse/PLAT-750