### PR TITLE
Enforce key format for Course Offering and Version 

### DIFF
--- a/dashboard/app/models/course_offering.rb
+++ b/dashboard/app/models/course_offering.rb
@@ -17,6 +17,12 @@
 class CourseOffering < ApplicationRecord
   has_many :course_versions
 
+  KEY_CHAR_RE = /[a-z-]/
+  KEY_RE = /\A#{KEY_CHAR_RE}+\Z/
+  validates_format_of :key,
+    with: KEY_RE,
+    message: "must contain only lowercase alphabetic characters and dashes; got \"%{value}\"."
+
   # Seeding method for creating / updating / deleting a CourseOffering and CourseVersion for the given
   # potential content root, i.e. a Script or UnitGroup.
   #

--- a/dashboard/app/models/course_offering.rb
+++ b/dashboard/app/models/course_offering.rb
@@ -17,7 +17,7 @@
 class CourseOffering < ApplicationRecord
   has_many :course_versions
 
-  KEY_CHAR_RE = /[a-z-]/
+  KEY_CHAR_RE = /[a-z\-]/
   KEY_RE = /\A#{KEY_CHAR_RE}+\Z/
   validates_format_of :key,
     with: KEY_RE,

--- a/dashboard/app/models/course_version.rb
+++ b/dashboard/app/models/course_version.rb
@@ -24,6 +24,12 @@ class CourseVersion < ApplicationRecord
   has_many :resources
   has_many :vocabularies
 
+  KEY_CHAR_RE = /\d/
+  KEY_RE = /\A#{KEY_CHAR_RE}+\Z/
+  validates_format_of :key,
+    with: KEY_RE,
+    message: "must contain only digits; got \"%{value}\"."
+
   def units
     content_root_type == 'UnitGroup' ? content_root.default_scripts : [content_root]
   end

--- a/dashboard/test/factories/factories.rb
+++ b/dashboard/test/factories/factories.rb
@@ -4,8 +4,8 @@ FactoryGirl.allow_class_lookup = false
 
 FactoryGirl.define do
   factory :course_offering do
-    sequence(:key) {|n| "bogus-course-offering-#{n}"}
-    sequence(:display_name) {|n| "bogus-course-offering-#{n}"}
+    sequence(:key, 'a') {|c| "bogus-course-offering-#{c}"}
+    sequence(:display_name, 'a') {|c| "bogus-course-offering-#{c}"}
   end
 
   factory :course_version do

--- a/dashboard/test/fixtures/test-all-properties.script
+++ b/dashboard/test/fixtures/test-all-properties.script
@@ -1,4 +1,4 @@
-family_name 'csd1'
+family_name 'csd-one'
 
 hideable_lessons true
 project_widget_visible true

--- a/dashboard/test/fixtures/test-serialize-seeding-json.script_json
+++ b/dashboard/test/fixtures/test-serialize-seeding-json.script_json
@@ -8,7 +8,7 @@
       "curriculum_path": "my_curriculum_path",
       "is_migrated": true,
       "is_course": true,
-      "version_year": "test-serialize-seeding-json-version"
+      "version_year": "1999"
     },
     "new_name": null,
     "family_name": "test-serialize-seeding-json-family",

--- a/dashboard/test/lib/services/script_seed_test.rb
+++ b/dashboard/test/lib/services/script_seed_test.rb
@@ -725,15 +725,20 @@ module Services
         is_migrated: true
       )
 
+      # Make sure that family name and version year each conform to the
+      # expected formats.
+      family_name = "#{name_prefix.gsub(/[^a-z\-]/i, '')}-family"
+      version_year = "1999"
+
       if with_unit_group
-        unit_group = create :unit_group, family_name: "#{name_prefix}-family", version_year: "#{name_prefix}-version"
+        unit_group = create :unit_group, family_name: family_name, version_year: version_year
         create :unit_group_unit, unit_group: unit_group, script: script, position: 1
         CourseOffering.add_course_offering(unit_group)
       else
         script.update!(
           is_course: true,
-          family_name: "#{name_prefix}-family",
-          version_year: "#{name_prefix}-version"
+          family_name: family_name,
+          version_year: version_year
         )
         CourseOffering.add_course_offering(script)
       end

--- a/dashboard/test/models/course_offering_test.rb
+++ b/dashboard/test/models/course_offering_test.rb
@@ -141,6 +141,13 @@ class CourseOfferingTest < ActiveSupport::TestCase
     end
   end
 
+  test "enforces key format" do
+    course_offering = build :course_offering, key: 'invalid key'
+    refute course_offering.valid?
+    course_offering.key = 'abcdefghijklmnopqrstuvwxyz-'
+    assert course_offering.valid?
+  end
+
   def course_offering_with_versions(num_versions, content_root_trait=:with_unit_group)
     create :course_offering do |offering|
       create_list :course_version, num_versions, content_root_trait, course_offering: offering

--- a/dashboard/test/models/course_version_test.rb
+++ b/dashboard/test/models/course_version_test.rb
@@ -85,4 +85,11 @@ class CourseVersionTest < ActiveSupport::TestCase
     course_version.destroy_and_destroy_parent_if_empty
     assert_nil CourseVersion.find_by(course_offering: nil, key: course_version.key)
   end
+
+  test "enforces key format" do
+    course_version = build :course_version, key: 'invalid key'
+    refute course_version.valid?
+    course_version.key = '0123456789'
+    assert course_version.valid?
+  end
 end


### PR DESCRIPTION
So we can reference these values in markdown syntax.

See the comment thread in https://github.com/code-dot-org/code-dot-org/pull/39447

Examination of our current set of values in these fields makes me feel quite comfortable that this change won't result in any validation failures for existing content:

```ruby
[development] dashboard > CourseOffering.all.pluck(:key)
=> ["coursea", "courseb", "coursec", "coursed", "coursee", "coursef", "csa", "csd", "csp", "express", "pre-express", "ui-test-versioned-script"]
[development] dashboard > CourseVersion.all.pluck(:key)
=> ["2020", "2017", "2018", "2019", "2020", "2021", "2017", "2018", "2019", "2020", "2021", "2017", "2018", "2019", "2020", "2021", "2017", "2018", "2019", "2020", "2021", "2017", "2018", "2019", "2020", "2021", "2017", "2018", "2019", "2020", "2021", "2017", "2018", "2019", "2020", "2021", "2017", "2018", "2019", "2020", "2021", "2020", "2017", "2018", "2019", "2020", "2021", "2017", "2018", "2019", "2020", "2021"]
```

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
