### PR TITLE
Removed commented out png size test

### DIFF
--- a/apps/test/unit/code-studio/initApp/loadAppTest.js
+++ b/apps/test/unit/code-studio/initApp/loadAppTest.js
@@ -186,10 +186,6 @@ describe('loadApp.js', () => {
         expect(writtenLevelId).to.be.undefined;
         expect(name).to.equal('_share_image.png');
         expect(blob).to.have.property('type', 'image/png');
-        // const expectedPngSize = /PhantomJS/.test(window.navigator.userAgent)
-        //   ? 523181 // PhantomJS
-        //   : 38961; // ChromeHeadless
-        // expect(blob).to.have.property('size', expectedPngSize);
         done();
       });
 


### PR DESCRIPTION
It looks like we commented this out 6 months ago after the Chrome upgrade led this test to consistently fail. It was decided that the test was no longer necessary so I'm just removing the commented out code.

## Links

- jira ticket: [here](https://codedotorg.atlassian.net/browse/STAR-1249?atlOrigin=eyJpIjoiN2NjOWVlOTJjMGIzNDQ1YTkwYjUxZDc4NDZiMmIwYjIiLCJwIjoiaiJ9)
- Discussion: [slack](https://codedotorg.slack.com/archives/C0T0PNTM3/p1600189827366000?thread_ts=1599833556.302300&cid=C0T0PNTM3)
- PR that originally commented it out: [here](https://github.com/code-dot-org/code-dot-org/pull/36766)

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
