### PR TITLE
Revert "stop writing deprecated standards fields"

### DIFF
--- a/dashboard/app/models/standard.rb
+++ b/dashboard/app/models/standard.rb
@@ -28,12 +28,17 @@ class Standard < ApplicationRecord
       id: id,
       shortcode: shortcode,
       category_description: category.description,
-      description: description
+      description: description,
+
+      # deprecated fields
+      organization: organization,
+      organization_id: organization_id,
+      concept: concept
     }
   end
 
   # Loads/merges the data from a CSV into the Standards table.
-  # Can be used to overwrite the description and category of
+  # Can be used to overwrite the description and concept of
   # existing Standards and to create new Standards.
   # Will not delete existing Standards.
 
@@ -62,14 +67,19 @@ class Standard < ApplicationRecord
         category: category,
         shortcode: row['organization_id'],
         description: row['description'],
+
+        # deprecated fields to stop using
+        organization: row['organization'],
+        organization_id: row['organization_id'],
+        concept: row['concept'],
       }
-      loaded = Standard.find_by({category: parsed[:category], shortcode: parsed[:shortcode]})
+      loaded = Standard.find_by({organization: parsed[:organization], organization_id: parsed[:organization_id]})
       if loaded.nil?
         begin
           Standard.new(parsed).save!
           created += 1
         rescue => error
-          puts "Error when processing #{row}: #{error.message}"
+          puts "Error when processing #{parsed[:organization]} #{parsed[:organization_id]}: #{error.message}"
         end
       else
         loaded.assign_attributes(parsed)


### PR DESCRIPTION
Reverts code-dot-org/code-dot-org#39455 because it appears to have broken UI tests in drone: https://cucumber-logs.s3.amazonaws.com/circle/4530/Chrome_learning_platform_teacher_dashboard_progress_standards_view_output.html?versionId=lXAAnazeIuJTWBqgQ54L5U9kZeG4Ax6y
* ![Screen Shot 2021-03-12 at 9 32 44 AM](https://user-images.githubusercontent.com/8001765/110976828-411ef880-8316-11eb-99a1-aa7181db0586.png)

I'm not sure exactly why drone passed on #39455, but it could be because we cache/hash some data related to seeding: https://github.com/code-dot-org/code-dot-org/blob/5f898b64b0630f1a99c91c3e06196c57da2e0d28/.drone.yml#L172-L174

Reverting for now while I investigate.
