### PR TITLE
Make test not rely on order of the programming expression keys in array

### DIFF
--- a/dashboard/test/lib/programming_expression_autocomplete_test.rb
+++ b/dashboard/test/lib/programming_expression_autocomplete_test.rb
@@ -21,7 +21,8 @@ class ProgrammingExpressionAutocompleteTest < ActiveSupport::TestCase
   test "finds multiple matches" do
     matches = ProgrammingExpressionAutocomplete.get_search_matches('play', 5, nil)
     assert_equal 2, matches.length
-    assert_equal ['playSound-1', 'playSound-2'], matches.map {|m| m[:key]}
+    assert matches.map {|m| m[:key]}.include? 'playSound-1'
+    assert matches.map {|m| m[:key]}.include? 'playSound-2'
   end
 
   test "restricts matches by limit" do


### PR DESCRIPTION
DTT failed because of this test. See [thread](https://codedotorg.slack.com/archives/C03CM903Y/p1615584906423100). The order that the keys were showing up in on test is different than what I have locally. The order does not matter for this to be working correctly so I re-wrote the test to ignore order.
