### PR TITLE
Check files for invalid filenames after each dropbox sync

### DIFF
--- a/bin/cron/sync_dropbox
+++ b/bin/cron/sync_dropbox
@@ -1,5 +1,7 @@
 #!/usr/bin/env ruby
 require_relative 'only_one'
+require_relative '../../tools/hooks/hooks_utils.rb'
+
 abort 'Script already running' unless only_one_running?(__FILE__)
 
 # This syncs content changes from the shared dropbox folder to our github repo
@@ -45,15 +47,20 @@ while (Time.now - SCRIPT_START) < TOTAL_SECONDS
     # For full details, see unison's man page. Docs are also here: https://www.cis.upenn.edu/~bcpierce/unison/download/releases/stable/unison-manual.html
     command = "unison /home/ubuntu/Dropbox/Shared/#{key} /home/ubuntu/staging/pegasus/#{value} -silent -ignore \"Name .dropbox\" -auto -perms 0 -dontchmod -log -logfile /home/ubuntu/unison.log"
     stdout, stderr, _ = Open3.capture3(command)
-    next if stdout == "" && stderr == ""
-    error_message = <<~ERROR_MSG
-                      <!here> Error syncing Dropbox and staging
-                      Dropbox directory: #{key}
-                      pegasus directory: #{value}
-                      stdout: #{stdout}
-                      stderr: #{stderr}
-                    ERROR_MSG
-    logger.record error_message
+    if stdout == "" && stderr == ""
+      HooksUtils.get_unstaged_files.each do |filename|
+        raise "INVALID FILENAME: #{filename}" if HooksUtils.prohibited?(filename)
+      end
+    else
+      error_message = <<~ERROR_MSG
+                        <!here> Error syncing Dropbox and staging
+                        Dropbox directory: #{key}
+                        pegasus directory: #{value}
+                        stdout: #{stdout}
+                        stderr: #{stderr}
+                      ERROR_MSG
+      logger.record error_message
+    end
   end
   current_time = Time.now
   logger.save

--- a/tools/hooks/hooks_utils.rb
+++ b/tools/hooks/hooks_utils.rb
@@ -13,4 +13,19 @@ class HooksUtils
     Dir.chdir File.expand_path('../../../', __FILE__)
     `git diff --cached --name-only --diff-filter AMR`.split("\n").map(&:chomp).map {|x| File.expand_path("../../../#{x}", __FILE__)}
   end
+
+  # Returns whether a filename should be prohibited from a staging commit. Reasons for this:
+  #   * any file with an extension in {.mp4, .mov} (e.g., 'dashboard/dir/my_bad_file.mov')
+  #   * any file with non-lowercase letters in the extension (e.g., 'dashboard/dir/my_bad_file.PnG')
+  #   * any file with spaces in the name
+  #   * any file in /code.org/public/images/avatars with non-lowercase letters in the filename
+  # @param filename [String] A filename.
+  # @return [Boolean] Whether the filename should be prohibited in a commit.
+  def self.prohibited?(filename)
+    return true if ['.mp4', '.mov'].include? File.extname(filename)
+    return true if File.extname(filename) != File.extname(filename).downcase
+    return true if filename.include?(' ')
+    return true if filename.include?('/code.org/public/images/avatars/') && File.basename(filename).downcase != File.basename(filename)
+    false
+  end
 end

--- a/tools/hooks/hooks_utils.rb
+++ b/tools/hooks/hooks_utils.rb
@@ -24,7 +24,7 @@ class HooksUtils
   def self.prohibited?(filename)
     return true if ['.mp4', '.mov'].include? File.extname(filename)
     return true if File.extname(filename) != File.extname(filename).downcase
-    return true if filename.include?(' ')
+    return true if filename.match?(/\s/)
     return true if filename.include?('/code.org/public/images/avatars/') && File.basename(filename).downcase != File.basename(filename)
     false
   end

--- a/tools/hooks/restrict_staging_changes.rb
+++ b/tools/hooks/restrict_staging_changes.rb
@@ -2,21 +2,6 @@ require_relative 'hooks_utils.rb'
 
 REPO_DIR = File.expand_path('../../../', __FILE__).freeze
 
-# Returns whether a filename should be prohibited from a staging commit. Reasons for this:
-#   * any file with an extension in {.mp4, .mov} (e.g., 'dashboard/dir/my_bad_file.mov')
-#   * any file with non-lowercase letters in the extension (e.g., 'dashboard/dir/my_bad_file.PnG')
-#   * any file with spaces in the name
-#   * any file in /code.org/public/images/avatars with non-lowercase letters in the filename
-# @param filename [String] A filename.
-# @return [Boolean] Whether the filename should be prohibited in a commit.
-def prohibited?(filename)
-  return true if ['.mp4', '.mov'].include? File.extname(filename)
-  return true if File.extname(filename) != File.extname(filename).downcase
-  return true if filename.include?(' ')
-  return true if filename.include?('/code.org/public/images/avatars/') && File.basename(filename).downcase != File.basename(filename)
-  false
-end
-
 def main
   Dir.chdir REPO_DIR
 
@@ -24,7 +9,7 @@ def main
   exit(0) unless branch_name == 'staging'
 
   HooksUtils.get_staged_files.each do |filename|
-    raise "STAGING FILE BLOCKED: #{filename}" if prohibited?(filename)
+    raise "STAGING FILE BLOCKED: #{filename}" if HookUtils.prohibited?(filename)
   end
 end
 


### PR DESCRIPTION
This came out of a retro item about how invalid files can block the staging scoop. Now after each dropbox sync, the script checks to make sure names conform to our requirements and throws an exception if they don't (which I believe will print in #staging). Ideally, this will help us more quickly debug these files with content writers.

## Links

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

<!--
- spec: []()
- jira ticket: []()
-->

## Testing story

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
