### PR TITLE
Specify the invalid value in the error message for Resource.key

### DIFF
--- a/dashboard/app/models/resource.rb
+++ b/dashboard/app/models/resource.rb
@@ -32,7 +32,7 @@ class Resource < ApplicationRecord
 
   KEY_CHAR_RE = /[a-z0-9\-\_]/
   KEY_RE = /\A#{KEY_CHAR_RE}+\Z/
-  validates_format_of :key, with: KEY_RE, message: "must contain only lowercase alphanumeric characters, dashes, and underscores."
+  validates_format_of :key, with: KEY_RE, message: "must contain only lowercase alphanumeric characters, dashes, and underscores; got \"%{value}\"."
 
   has_and_belongs_to_many :lessons, join_table: :lessons_resources
   belongs_to :course_version


### PR DESCRIPTION
Otherwise, it's an entirely unhelpful error message when it occurs in the context of a full seed.

Matches the pattern that we currently use for Vocabulary, CourseOffering, and CourseVersion.

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
