### PR TITLE
validate seed key consistency for levels_script_levels

### DIFF
--- a/dashboard/app/models/levels_script_level.rb
+++ b/dashboard/app/models/levels_script_level.rb
@@ -38,6 +38,10 @@ class LevelsScriptLevel < ApplicationRecord
     script_level_seeding_key = my_script_level.seeding_key(seed_context)
 
     my_key.merge!(script_level_seeding_key) {|key, _, _| raise "Duplicate key when generating seeding_key: #{key}"}
-    my_key.stringify_keys
+    my_key = my_key.stringify_keys
+    unless my_key['script_level.level_keys'].include?(my_key['level.key'])
+      raise "invalid levels_script_levels seeding key. level.key not contained in script_level.level_keys: #{my_key}"
+    end
+    my_key
   end
 end

--- a/dashboard/lib/services/script_seed.rb
+++ b/dashboard/lib/services/script_seed.rb
@@ -322,6 +322,9 @@ module Services
 
       levels_script_levels_to_import = levels_script_levels_data.map do |lsl_data|
         seeding_key = lsl_data['seeding_key']['level.key']
+        unless lsl_data['seeding_key']['script_level.level_keys'].include?(seeding_key)
+          raise "level.key not found in script_level.level_keys for #{lsl_data}"
+        end
         level = levels_by_seeding_key[seeding_key]
         unless level
           # TODO: we may want to get rid of this query since we make it for each new LevelsScriptLevel.

--- a/dashboard/test/models/script_test.rb
+++ b/dashboard/test/models/script_test.rb
@@ -264,7 +264,8 @@ class ScriptTest < ActiveSupport::TestCase
 
     # test that LessonActivity, ActivitySection and Objective can be seeded
     # from .script_json when is_migrated is specified in the .script file.
-    create :maze, name: 'test_maze_level'
+    # use 'custom' level num to make level key match level name.
+    create :maze, name: 'test_maze_level', level_num: 'custom'
     script_file = File.join(self.class.fixture_path, 'config', 'scripts', 'test-migrated-models.script')
     Script.setup([script_file])
 


### PR DESCRIPTION
FInishes [PLAT-820]. I couldn't get a repro, so I added a check to raise during serialization before bogus data is written to script_json. This should prevent us from getting into a bad state, since it will cause the save transaction to fail. If we hit this problem again, then this error will provide immediate feedback to the editor, which we can hopefully use to help get a repro.

Because bad data could also be introduced during seeding, I added a check there too.

## Testing story

* Existing test coverage on serialization / seed logic
* manually verified that `rake seed:all` works
* manually verified that I can add/update/reorder/remove levels from a lesson

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked


[PLAT-820]: https://codedotorg.atlassian.net/browse/PLAT-820