### PR TITLE
Revert "Revert "Level details component -- CSD/CSP instructions""

### DIFF
--- a/apps/src/templates/instructions/DialogInstructions.jsx
+++ b/apps/src/templates/instructions/DialogInstructions.jsx
@@ -42,7 +42,7 @@ class DialogInstructions extends React.Component {
         }
         imgURL={showImg ? this.props.imgURL : undefined}
         isBlockly={this.props.isBlockly}
-        collapsible={this.props.noInstructionsWhenCollapsed}
+        noInstructionsWhenCollapsed={this.props.noInstructionsWhenCollapsed}
       />
     );
   }

--- a/apps/src/templates/instructions/DialogInstructions.jsx
+++ b/apps/src/templates/instructions/DialogInstructions.jsx
@@ -17,7 +17,9 @@ class DialogInstructions extends React.Component {
     longInstructions: PropTypes.string,
     imgURL: PropTypes.string,
     imgOnly: PropTypes.bool,
-    hintsOnly: PropTypes.bool
+    hintsOnly: PropTypes.bool,
+    isBlockly: PropTypes.bool,
+    noInstructionsWhenCollapsed: PropTypes.bool
   };
 
   render() {
@@ -39,6 +41,8 @@ class DialogInstructions extends React.Component {
           showInstructions ? this.props.longInstructions : undefined
         }
         imgURL={showImg ? this.props.imgURL : undefined}
+        isBlockly={this.props.isBlockly}
+        collapsible={this.props.noInstructionsWhenCollapsed}
       />
     );
   }
@@ -53,5 +57,7 @@ export default connect(state => ({
   longInstructions: state.instructions.longInstructions,
   imgURL: state.instructionsDialog.imgUrl || state.pageConstants.aniGifURL,
   imgOnly: state.instructionsDialog.imgOnly,
-  hintsOnly: state.instructionsDialog.hintsOnly
+  hintsOnly: state.instructionsDialog.hintsOnly,
+  isBlockly: state.pageConstants.isBlockly,
+  noInstructionsWhenCollapsed: state.instructions.noInstructionsWhenCollapsed
 }))(DialogInstructions);

--- a/apps/src/templates/instructions/Instructions.jsx
+++ b/apps/src/templates/instructions/Instructions.jsx
@@ -35,7 +35,7 @@ class Instructions extends React.Component {
     inTopPane: PropTypes.bool,
     onResize: PropTypes.func,
     isBlockly: PropTypes.bool,
-    collapsible: PropTypes.bool
+    noInstructionsWhenCollapsed: PropTypes.bool
   };
 
   /**
@@ -58,7 +58,7 @@ class Instructions extends React.Component {
           onResize={this.props.onResize}
           inTopPane={this.props.inTopPane}
           isBlockly={this.props.isBlockly}
-          collapsible={this.props.collapsible}
+          noInstructionsWhenCollapsed={this.props.noInstructionsWhenCollapsed}
         />
       );
     } else {

--- a/apps/src/templates/instructions/Instructions.jsx
+++ b/apps/src/templates/instructions/Instructions.jsx
@@ -33,7 +33,9 @@ class Instructions extends React.Component {
     authoredHints: PropTypes.element,
     inputOutputTable: PropTypes.arrayOf(PropTypes.arrayOf(PropTypes.number)),
     inTopPane: PropTypes.bool,
-    onResize: PropTypes.func
+    onResize: PropTypes.func,
+    isBlockly: PropTypes.bool,
+    collapsible: PropTypes.bool
   };
 
   /**
@@ -55,6 +57,8 @@ class Instructions extends React.Component {
           markdown={this.props.longInstructions}
           onResize={this.props.onResize}
           inTopPane={this.props.inTopPane}
+          isBlockly={this.props.isBlockly}
+          collapsible={this.props.collapsible}
         />
       );
     } else {

--- a/apps/src/templates/instructions/InstructionsCSF.jsx
+++ b/apps/src/templates/instructions/InstructionsCSF.jsx
@@ -131,6 +131,7 @@ class InstructionsCSF extends React.Component {
     overlayVisible: PropTypes.bool,
     skinId: PropTypes.string,
     isMinecraft: PropTypes.bool.isRequired,
+    isBlockly: PropTypes.bool.isRequired,
     inputOutputTable: PropTypes.arrayOf(PropTypes.arrayOf(PropTypes.number)),
     noVisualization: PropTypes.bool,
     hideOverlay: PropTypes.func.isRequired,
@@ -605,6 +606,8 @@ class InstructionsCSF extends React.Component {
                 }
                 imgURL={this.props.aniGifURL}
                 inTopPane
+                isBlockly={this.props.isBlockly}
+                collapsible={true}
               />
               {this.props.shortInstructions2 && (
                 <div className="secondary-instructions">
@@ -712,6 +715,7 @@ export default connect(
       overlayVisible: state.instructions.overlayVisible,
       skinId: state.pageConstants.skinId,
       isMinecraft: !!state.pageConstants.isMinecraft,
+      isBlockly: !!state.pageConstants.isBlockly,
       aniGifURL: state.pageConstants.aniGifURL,
       inputOutputTable: state.pageConstants.inputOutputTable,
       isRtl: state.isRtl,

--- a/apps/src/templates/instructions/InstructionsCSF.jsx
+++ b/apps/src/templates/instructions/InstructionsCSF.jsx
@@ -607,7 +607,7 @@ class InstructionsCSF extends React.Component {
                 imgURL={this.props.aniGifURL}
                 inTopPane
                 isBlockly={this.props.isBlockly}
-                collapsible={true}
+                noInstructionsWhenCollapsed={false}
               />
               {this.props.shortInstructions2 && (
                 <div className="secondary-instructions">

--- a/apps/src/templates/instructions/MarkdownInstructions.jsx
+++ b/apps/src/templates/instructions/MarkdownInstructions.jsx
@@ -26,7 +26,7 @@ const styles = {
 class MarkdownInstructions extends React.Component {
   static propTypes = {
     markdown: PropTypes.string.isRequired,
-    collapsible: PropTypes.bool,
+    noInstructionsWhenCollapsed: PropTypes.bool,
     onResize: PropTypes.func,
     inTopPane: PropTypes.bool,
     isBlockly: PropTypes.bool,
@@ -34,7 +34,7 @@ class MarkdownInstructions extends React.Component {
   };
 
   static defaultProps = {
-    collapsible: false
+    noInstructionsWhenCollapsed: false
   };
 
   componentDidMount() {
@@ -95,13 +95,14 @@ class MarkdownInstructions extends React.Component {
   render() {
     const {inTopPane, markdown} = this.props;
 
+    const canCollapse = !this.props.noInstructionsWhenCollapsed;
     return (
       <div
         className="instructions-markdown"
         style={[
           styles.standard,
           inTopPane && styles.inTopPane,
-          inTopPane && this.props.collapsible && styles.inTopPaneCanCollapse
+          inTopPane && canCollapse && styles.inTopPaneCanCollapse
         ]}
       >
         <EnhancedSafeMarkdown markdown={markdown} expandableImages />

--- a/apps/src/templates/instructions/MarkdownInstructions.jsx
+++ b/apps/src/templates/instructions/MarkdownInstructions.jsx
@@ -3,7 +3,6 @@ import React from 'react';
 import ReactDOM from 'react-dom';
 import PropTypes from 'prop-types';
 import Radium from 'radium';
-import {connect} from 'react-redux';
 import {convertXmlToBlockly} from './utils';
 
 import EnhancedSafeMarkdown from '../EnhancedSafeMarkdown';
@@ -27,7 +26,7 @@ const styles = {
 class MarkdownInstructions extends React.Component {
   static propTypes = {
     markdown: PropTypes.string.isRequired,
-    noInstructionsWhenCollapsed: PropTypes.bool,
+    collapsible: PropTypes.bool,
     onResize: PropTypes.func,
     inTopPane: PropTypes.bool,
     isBlockly: PropTypes.bool,
@@ -35,7 +34,7 @@ class MarkdownInstructions extends React.Component {
   };
 
   static defaultProps = {
-    noInstructionsWhenCollapsed: false
+    collapsible: false
   };
 
   componentDidMount() {
@@ -96,14 +95,13 @@ class MarkdownInstructions extends React.Component {
   render() {
     const {inTopPane, markdown} = this.props;
 
-    const canCollapse = !this.props.noInstructionsWhenCollapsed;
     return (
       <div
         className="instructions-markdown"
         style={[
           styles.standard,
           inTopPane && styles.inTopPane,
-          inTopPane && canCollapse && styles.inTopPaneCanCollapse
+          inTopPane && this.props.collapsible && styles.inTopPaneCanCollapse
         ]}
       >
         <EnhancedSafeMarkdown markdown={markdown} expandableImages />
@@ -112,8 +110,4 @@ class MarkdownInstructions extends React.Component {
   }
 }
 
-export const StatelessMarkdownInstructions = Radium(MarkdownInstructions);
-export default connect(state => ({
-  isBlockly: state.pageConstants.isBlockly,
-  noInstructionsWhenCollapsed: state.instructions.noInstructionsWhenCollapsed
-}))(Radium(MarkdownInstructions));
+export default Radium(MarkdownInstructions);

--- a/apps/src/templates/instructions/TopInstructions.jsx
+++ b/apps/src/templates/instructions/TopInstructions.jsx
@@ -797,7 +797,9 @@ class TopInstructions extends Component {
                       onResize={this.adjustMaxNeededHeight}
                       inTopPane
                       isBlockly={this.props.isBlockly}
-                      collapsible={this.props.noInstructionsWhenCollapsed}
+                      noInstructionsWhenCollapsed={
+                        this.props.noInstructionsWhenCollapsed
+                      }
                     />
                   </div>
                 )}

--- a/apps/src/templates/instructions/TopInstructions.jsx
+++ b/apps/src/templates/instructions/TopInstructions.jsx
@@ -184,12 +184,12 @@ class TopInstructions extends Component {
     isEmbedView: PropTypes.bool.isRequired,
     hasContainedLevels: PropTypes.bool,
     height: PropTypes.number.isRequired,
-    expandedHeight: PropTypes.number.isRequired,
+    expandedHeight: PropTypes.number,
     maxHeight: PropTypes.number.isRequired,
     longInstructions: PropTypes.string,
     isCollapsed: PropTypes.bool.isRequired,
     noVisualization: PropTypes.bool.isRequired,
-    toggleInstructionsCollapsed: PropTypes.func.isRequired,
+    toggleInstructionsCollapsed: PropTypes.func,
     setInstructionsRenderedHeight: PropTypes.func.isRequired,
     setInstructionsMaxHeightNeeded: PropTypes.func.isRequired,
     documentationUrl: PropTypes.string,
@@ -206,8 +206,16 @@ class TopInstructions extends Component {
     hidden: PropTypes.bool.isRequired,
     shortInstructions: PropTypes.string,
     isMinecraft: PropTypes.bool.isRequired,
+    isBlockly: PropTypes.bool.isRequired,
     isRtl: PropTypes.bool.isRequired,
-    widgetMode: PropTypes.bool
+    widgetMode: PropTypes.bool,
+    mainStyle: PropTypes.object,
+    containerStyle: PropTypes.object,
+    resizable: PropTypes.bool
+  };
+
+  static defaultProps = {
+    resizable: true
   };
 
   constructor(props) {
@@ -554,11 +562,13 @@ class TopInstructions extends Component {
     } = this.props;
 
     const isCSF = !this.props.noInstructionsWhenCollapsed;
-    const isCSDorCSP = this.props.noInstructionsWhenCollapsed;
+    const isCSDorCSP = !isCSF;
     const widgetWidth = WIDGET_WIDTH + 'px';
 
     const mainStyle = [
-      this.props.isRtl ? styles.mainRtl : styles.main,
+      !this.props.mainStyle &&
+        (this.props.isRtl ? styles.mainRtl : styles.main),
+      this.props.mainStyle,
       {
         height: this.props.height - RESIZER_HEIGHT
       },
@@ -732,7 +742,7 @@ class TopInstructions extends Component {
               !this.props.hasContainedLevels &&
               this.state.tabSelected === TabType.INSTRUCTIONS
                 ? styles.csfBody
-                : styles.body,
+                : this.props.containerStyle || styles.body,
               this.props.isMinecraft && craftStyles.instructionsBody
             ]}
             id="scroll-container"
@@ -786,6 +796,8 @@ class TopInstructions extends Component {
                       longInstructions={this.props.longInstructions}
                       onResize={this.adjustMaxNeededHeight}
                       inTopPane
+                      isBlockly={this.props.isBlockly}
+                      collapsible={this.props.noInstructionsWhenCollapsed}
                     />
                   </div>
                 )}
@@ -831,7 +843,7 @@ class TopInstructions extends Component {
                 </div>
               )}
           </div>
-          {!this.props.isEmbedView && (
+          {!this.props.isEmbedView && this.props.resizable && (
             <HeightResizer
               resizeItemTop={this.getItemTop}
               position={this.props.height}
@@ -843,12 +855,13 @@ class TopInstructions extends Component {
     );
   }
 }
-export const UnconnectedTopInstructions = TopInstructions;
+export const UnconnectedTopInstructions = Radium(TopInstructions);
 export default connect(
   state => ({
     isEmbedView: state.pageConstants.isEmbedView,
     hasContainedLevels: state.pageConstants.hasContainedLevels,
     isMinecraft: !!state.pageConstants.isMinecraft,
+    isBlockly: !!state.pageConstants.isBlockly,
     height: state.instructions.renderedHeight,
     expandedHeight: state.instructions.expandedHeight,
     maxHeight: Math.min(

--- a/apps/src/templates/lessonOverview/activities/LevelDetailsDialog.jsx
+++ b/apps/src/templates/lessonOverview/activities/LevelDetailsDialog.jsx
@@ -3,6 +3,8 @@ import React, {Component} from 'react';
 import ReactDOM from 'react-dom';
 import BaseDialog from '@cdo/apps/templates/BaseDialog';
 import DialogFooter from '@cdo/apps/templates/teacherDashboard/DialogFooter';
+import {UnconnectedTopInstructions} from '@cdo/apps/templates/instructions/TopInstructions';
+import {ViewType} from '@cdo/apps/code-studio/viewAsRedux';
 import SafeMarkdown from '@cdo/apps/templates/SafeMarkdown';
 import {createVideoWithFallback} from '@cdo/apps/code-studio/videos';
 import $ from 'jquery';
@@ -11,10 +13,14 @@ import i18n from '@cdo/locale';
 import ProgressBubbleSet from '@cdo/apps/templates/progress/ProgressBubbleSet';
 import SublevelCard from '@cdo/apps/code-studio/components/SublevelCard';
 import _ from 'lodash';
+import styleConstants from '@cdo/apps/styleConstants';
+import {connect} from 'react-redux';
 
 const VIDEO_WIDTH = 670;
 const VIDEO_HEIGHT = 375;
 const VIDEO_MODAL_WIDTH = 700;
+const HEADER_HEIGHT = styleConstants['workspace-headers-height'];
+const MAX_LEVEL_HEIGHT = 550;
 
 const styles = {
   sublevelCards: {
@@ -23,10 +29,12 @@ const styles = {
   }
 };
 
-export default class LevelDetailsDialog extends Component {
+class LevelDetailsDialog extends Component {
   static propTypes = {
     scriptLevel: PropTypes.object.isRequired,
-    handleClose: PropTypes.func.isRequired
+    handleClose: PropTypes.func.isRequired,
+    viewAs: PropTypes.oneOf(Object.values(ViewType)).isRequired,
+    isRtl: PropTypes.bool.isRequired
   };
 
   constructor(props) {
@@ -36,7 +44,9 @@ export default class LevelDetailsDialog extends Component {
     scriptLevel.highlighted = true;
     this.state = {
       selectedLevel,
-      scriptLevel
+      scriptLevel,
+      height: MAX_LEVEL_HEIGHT,
+      maxHeight: MAX_LEVEL_HEIGHT
     };
   }
 
@@ -74,7 +84,42 @@ export default class LevelDetailsDialog extends Component {
         </div>
       );
     } else {
-      return <div>Not implemented yet</div>;
+      // TODO: calculate more of these parameters based on the level and pages
+      return (
+        <UnconnectedTopInstructions
+          hasContainedLevels={false}
+          noVisualization={true}
+          isMinecraft={false}
+          isBlockly={false}
+          isRtl={this.props.isRtl}
+          longInstructions={level.longInstructions || level.long_instructions}
+          shortInstructions={level.shortInstructions}
+          noInstructionsWhenCollapsed={true}
+          levelVideos={level.videos}
+          mapReference={level.mapReference}
+          referenceLinks={level.referenceLinks}
+          teacherMarkdown={level.teacherMarkdown}
+          viewAs={this.props.viewAs}
+          height={this.state.height}
+          maxHeight={Math.min(this.state.maxHeight, MAX_LEVEL_HEIGHT)}
+          expandedHeight={this.state.height}
+          isCollapsed={false}
+          hidden={false}
+          isEmbedView={false}
+          mainStyle={{paddingBottom: 5}}
+          containerStyle={{
+            overflowY: 'scroll',
+            height: this.state.height - HEADER_HEIGHT
+          }}
+          setInstructionsRenderedHeight={height =>
+            this.setState({height: Math.min(height, MAX_LEVEL_HEIGHT)})
+          }
+          setInstructionsMaxHeightNeeded={maxHeight =>
+            this.setState({maxHeight})
+          }
+          resizable={false}
+        />
+      );
     }
   };
 
@@ -152,33 +197,45 @@ export default class LevelDetailsDialog extends Component {
     const {scriptLevel} = this.props;
     const level = this.state.selectedLevel;
     const preview = this.getComponentContent(level);
+    const levelSpecificStyling =
+      level.type === 'StandaloneVideo'
+        ? {width: VIDEO_MODAL_WIDTH, marginLeft: -VIDEO_MODAL_WIDTH / 2}
+        : {};
     return (
       <BaseDialog
         isOpen={true}
         handleClose={this.props.handleClose}
         fullWidth={level.type !== 'StandaloneVideo'}
-        style={
-          level.type === 'StandaloneVideo'
-            ? {width: VIDEO_MODAL_WIDTH, marginLeft: -VIDEO_MODAL_WIDTH / 2}
-            : {}
-        }
+        style={{padding: 15, ...levelSpecificStyling}}
+        useUpdatedStyles
       >
         <h1>{i18n.levelPreview()}</h1>
         {this.renderBubbleChoiceBubbles()}
-        {preview}
+        <div>{preview}</div>
         <DialogFooter rightAlign>
           <Button
             onClick={this.props.handleClose}
             text={i18n.dismiss()}
             color={'gray'}
+            __useDeprecatedTag
+            style={{margin: 5}}
           />
           <Button
-            href={scriptLevel.url}
+            href={level.url || scriptLevel.url}
             text={i18n.seeFullLevel()}
             color={'orange'}
+            __useDeprecatedTag
+            style={{margin: 5}}
           />
         </DialogFooter>
       </BaseDialog>
     );
   }
 }
+
+export const UnconnectedLevelDetailsDialog = LevelDetailsDialog;
+
+export default connect(state => ({
+  viewAs: state.viewAs,
+  isRtl: state.isRtl
+}))(LevelDetailsDialog);

--- a/apps/src/templates/lessonOverview/activities/LevelDetailsDialog.story.jsx
+++ b/apps/src/templates/lessonOverview/activities/LevelDetailsDialog.story.jsx
@@ -1,10 +1,15 @@
 import React from 'react';
-import LevelDetailsDialog from './LevelDetailsDialog';
+import {UnconnectedLevelDetailsDialog as LevelDetailsDialog} from './LevelDetailsDialog';
+import {Provider} from 'react-redux';
+import {getStore} from '@cdo/apps/code-studio/redux';
+import {ViewType} from '@cdo/apps/code-studio/viewAsRedux';
 
 const defaultProps = {
   handleClose: () => {
     console.log('closed');
-  }
+  },
+  viewAs: ViewType.Teacher,
+  isRtl: false
 };
 
 const standaloneVideoScriptLevel = {
@@ -82,6 +87,30 @@ const bubbleChoiceScriptLevel = {
   ]
 };
 
+const levelWithInstructions = {
+  url: '/s/csd6-2020/stage/16/puzzle/9/page/1',
+  level: {
+    type: 'Weblab',
+    longInstructions:
+      'These are some long instructions!\n**Do this**\nSome more detailed instructions.',
+    teacherMarkdown: 'Just some markdown for teachers.',
+    mapReference: '/docs/csd-1718/html_tags/index.html',
+    videos: [
+      {
+        autoplay: true,
+        download:
+          'https://videos.code.org/levelbuilder/weblab_introtohtml-mp4.mp4',
+        enable_fallback: true,
+        key: 'csd_weblab_intro_2',
+        name: 'Intro to Web Lab - Part 2',
+        src:
+          'https://www.youtube-nocookie.com/embed/Hjl6gbg9kmk/?autoplay=1&enablejsapi=1&iv_load_policy=3&modestbranding=1&rel=0&showinfo=1&v=Hjl6gbg9kmk&wmode=transparent',
+        thumbnail: '/c/video_thumbnails/csd_weblab_intro_2.jpg'
+      }
+    ]
+  }
+};
+
 export default storybook => {
   storybook.storiesOf('LevelDetailsDialog', module).addStoryTable([
     {
@@ -118,6 +147,29 @@ export default storybook => {
           {...defaultProps}
           scriptLevel={bubbleChoiceScriptLevel}
         />
+      )
+    },
+    {
+      name: 'TopInstructions',
+      story: () => (
+        <Provider store={getStore()}>
+          <LevelDetailsDialog
+            {...defaultProps}
+            scriptLevel={levelWithInstructions}
+          />
+        </Provider>
+      )
+    },
+    {
+      name: 'TopInstructions RTL',
+      story: () => (
+        <Provider store={getStore()}>
+          <LevelDetailsDialog
+            {...defaultProps}
+            isRtl
+            scriptLevel={levelWithInstructions}
+          />
+        </Provider>
       )
     }
   ]);

--- a/apps/test/unit/instructionsComponentsTest.js
+++ b/apps/test/unit/instructionsComponentsTest.js
@@ -5,7 +5,7 @@ import {expect} from '../util/reconfiguredChai';
 import {setExternalGlobals} from '../util/testUtils';
 
 import NonMarkdownInstructions from '@cdo/apps/templates/instructions/NonMarkdownInstructions';
-import {StatelessMarkdownInstructions} from '@cdo/apps/templates/instructions/MarkdownInstructions';
+import MarkdownInstructions from '@cdo/apps/templates/instructions/MarkdownInstructions';
 
 describe('instructions components', () => {
   setExternalGlobals();
@@ -13,7 +13,7 @@ describe('instructions components', () => {
   describe('MarkdownInstructions', function() {
     it('standard case had top padding and no left margin', function() {
       const wrapper = shallow(
-        <StatelessMarkdownInstructions
+        <MarkdownInstructions
           markdown="md"
           markdownClassicMargins={false}
           inTopPane={false}
@@ -32,7 +32,7 @@ describe('instructions components', () => {
 
     it('inTopPane has no top padding', function() {
       const wrapper = shallow(
-        <StatelessMarkdownInstructions
+        <MarkdownInstructions
           markdown="md"
           inTopPane={true}
           noInstructionsWhenCollapsed={true}

--- a/apps/test/unit/templates/instructions/TopInstructionsTest.jsx
+++ b/apps/test/unit/templates/instructions/TopInstructionsTest.jsx
@@ -25,6 +25,7 @@ const DEFAULT_PROPS = {
   shortInstructions: '',
   hidden: false,
   isMinecraft: false,
+  isBlockly: false,
   isRtl: false
 };
 

--- a/apps/test/unit/templates/lessonOverview/activities/LevelDetailsDialogTest.jsx
+++ b/apps/test/unit/templates/lessonOverview/activities/LevelDetailsDialogTest.jsx
@@ -2,7 +2,8 @@ import React from 'react';
 import {shallow, mount} from 'enzyme';
 import {expect} from '../../../../util/reconfiguredChai';
 import sinon from 'sinon';
-import LevelDetailsDialog from '@cdo/apps/templates/lessonOverview/activities/LevelDetailsDialog';
+import {ViewType} from '@cdo/apps/code-studio/viewAsRedux';
+import {UnconnectedLevelDetailsDialog as LevelDetailsDialog} from '@cdo/apps/templates/lessonOverview/activities/LevelDetailsDialog';
 
 describe('LevelDetailsDialogTest', () => {
   let handleCloseSpy, defaultProps;
@@ -11,25 +12,42 @@ describe('LevelDetailsDialogTest', () => {
     handleCloseSpy = sinon.spy();
     defaultProps = {
       handleClose: handleCloseSpy,
-      scriptLevel: {
-        url: 'level.url',
-        level: {
-          type: 'External',
-          markdown: 'Some markdown'
-        }
-      }
+      viewAs: ViewType.Teacher,
+      isRtl: false
     };
   });
 
   it('calls handleClose when dismiss is clicked', () => {
-    const wrapper = shallow(<LevelDetailsDialog {...defaultProps} />);
+    const wrapper = shallow(
+      <LevelDetailsDialog
+        {...defaultProps}
+        scriptLevel={{
+          url: 'level.url',
+          level: {
+            type: 'External',
+            markdown: 'Some markdown'
+          }
+        }}
+      />
+    );
     const dismissButton = wrapper.find('Button').at(0);
     dismissButton.simulate('click');
     expect(handleCloseSpy.calledOnce).to.be.true;
   });
 
   it('links to level url', () => {
-    const wrapper = shallow(<LevelDetailsDialog {...defaultProps} />);
+    const wrapper = shallow(
+      <LevelDetailsDialog
+        {...defaultProps}
+        scriptLevel={{
+          url: 'level.url',
+          level: {
+            type: 'External',
+            markdown: 'Some markdown'
+          }
+        }}
+      />
+    );
     const levelLink = wrapper.find('Button').at(1);
     expect(levelLink.props().href).to.equal('level.url');
   });
@@ -37,7 +55,7 @@ describe('LevelDetailsDialogTest', () => {
   it('can display an external markdown level', () => {
     const wrapper = mount(
       <LevelDetailsDialog
-        handleClose={handleCloseSpy}
+        {...defaultProps}
         scriptLevel={{
           url: 'level.url',
           level: {type: 'External', markdown: 'This is some text.'}
@@ -50,7 +68,7 @@ describe('LevelDetailsDialogTest', () => {
   it('can display a LevelGroup', () => {
     const wrapper = mount(
       <LevelDetailsDialog
-        handleClose={handleCloseSpy}
+        {...defaultProps}
         scriptLevel={{
           url: 'level.url',
           level: {type: 'LevelGroup'}
@@ -72,7 +90,7 @@ describe('LevelDetailsDialogTest', () => {
     const loadVideoSpy = sinon.stub(LevelDetailsDialog.prototype, 'loadVideo');
     const wrapper = mount(
       <LevelDetailsDialog
-        handleClose={handleCloseSpy}
+        {...defaultProps}
         scriptLevel={{
           url: 'level.url',
           level: {
@@ -89,7 +107,7 @@ describe('LevelDetailsDialogTest', () => {
   it('can display a bubble choice level', () => {
     const wrapper = shallow(
       <LevelDetailsDialog
-        handleClose={handleCloseSpy}
+        {...defaultProps}
         scriptLevel={{
           id: 'scriptlevel',
           url: 'level.url',
@@ -142,10 +160,7 @@ describe('LevelDetailsDialogTest', () => {
       ]
     };
     const wrapper = shallow(
-      <LevelDetailsDialog
-        handleClose={handleCloseSpy}
-        scriptLevel={bubbleChoiceLevel}
-      />
+      <LevelDetailsDialog {...defaultProps} scriptLevel={bubbleChoiceLevel} />
     );
     wrapper
       .instance()
@@ -157,5 +172,24 @@ describe('LevelDetailsDialogTest', () => {
         .first()
         .props().markdown
     ).to.equal('Markdown1');
+  });
+
+  it('can display a CSD/CSP puzzle level', () => {
+    const wrapper = shallow(
+      <LevelDetailsDialog
+        {...defaultProps}
+        scriptLevel={{
+          id: 'scriptlevel',
+          url: 'level.url',
+          status: 'not_tried',
+          level: {
+            type: 'Weblab',
+            id: 'level',
+            longInstructions: 'long instructions'
+          }
+        }}
+      />
+    );
+    expect(wrapper.find('TopInstructions').length).to.equal(1);
   });
 });


### PR DESCRIPTION
Reverts code-dot-org/code-dot-org#39499, see 979cefaeed98f28e1454fd14f4a284af2e811987 for fixes

In my effort to make a prop be more readable by renaming `noInstructionsWhenCollapsed` to `collapsible`, I added a series of bugs where `collapsible` was negated. I switched back to using `noInstructionsWhenCollapsed` so that the negation only happens once. This was the reason behind the test failure that caused the original revert.