### PR TITLE
Revert docFunc changes

### DIFF
--- a/apps/src/applab/dropletConfig.js
+++ b/apps/src/applab/dropletConfig.js
@@ -362,8 +362,7 @@ export var blocks = [
     category: 'Canvas',
     paramButtons: {minArgs: 1, maxArgs: 3},
     paletteParams: ['id', 'width', 'height'],
-    params: ['"id"', DEFAULT_WIDTH, DEFAULT_HEIGHT],
-    docFunc: 'createCanvasNoAssign'
+    params: ['"id"', DEFAULT_WIDTH, DEFAULT_HEIGHT]
   },
   {
     func: 'setActiveCanvas',

--- a/apps/src/dropletUtils.js
+++ b/apps/src/dropletUtils.js
@@ -170,7 +170,7 @@ standardConfig.blocks = [
     func: 'randomNumber_min_max',
     block: 'randomNumber(1, 10)',
     category: 'Math',
-    docFunc: 'randomNumber_min_max'
+    docFunc: 'randomNumber'
   },
   {func: 'mathRound', block: 'Math.round(__)', category: 'Math'},
   {func: 'mathAbs', block: 'Math.abs(__)', category: 'Math'},

--- a/apps/src/dropletUtils.js
+++ b/apps/src/dropletUtils.js
@@ -166,6 +166,7 @@ standardConfig.blocks = [
   {func: 'notOperator', block: '!__', category: 'Math'},
   // randomNumber_max has been deprecated
   // {func: 'randomNumber_max', block: 'randomNumber(__)', category: 'Math' },
+  // Note: We use randomNumber as our base docFunc here so that we get the benefits of param descriptions
   {
     func: 'randomNumber_min_max',
     block: 'randomNumber(1, 10)',

--- a/apps/src/lib/kits/maker/dropletConfig.js
+++ b/apps/src/lib/kits/maker/dropletConfig.js
@@ -145,8 +145,7 @@ const makerBlocks = [
   {
     func: 'createLed',
     ...createLedProps,
-    type: 'either',
-    docFunc: 'createLedNoAssign'
+    type: 'either'
   },
   {
     func: 'var myLed = createLed',
@@ -158,8 +157,7 @@ const makerBlocks = [
   {
     func: 'createButton',
     ...createButtonProps,
-    type: 'either',
-    docFunc: 'createButtonNoAssign'
+    type: 'either'
   },
   {
     func: 'var myButton = createButton',
@@ -425,8 +423,7 @@ const microBitBlocks = [
   {
     func: 'createCapacitiveTouchSensor',
     ...createCapacitiveTouchSensorProps,
-    type: 'either',
-    docFunc: 'createCapacitiveTouchSensorNoAssign'
+    type: 'either'
   },
   {
     func: 'var mySensor = createCapacitiveTouchSensor',


### PR DESCRIPTION
Got a[ report](https://codedotorg.slack.com/archives/CNZP84FJ5/p1615832833022400) that the documentation for randomNumber is broken. I'm removing the changes I made to docFunc in the droplet configs while I investigate how to do this correctly.

Changes originally made here: https://github.com/code-dot-org/code-dot-org/pull/39274/files
