### PR TITLE
Revert "Revert "Add Course Offering and Version keys to the Markdown Preprocessor syntaxes""

### DIFF
--- a/apps/src/lib/levelbuilder/lesson-editor/FindResourceDialog.jsx
+++ b/apps/src/lib/levelbuilder/lesson-editor/FindResourceDialog.jsx
@@ -20,7 +20,9 @@ class FindResourceDialog extends Component {
     super(props);
     this.state = {
       selectedResourceKey:
-        this.props.resources.length > 0 ? this.props.resources[0].key : ''
+        this.props.resources.length > 0
+          ? this.props.resources[0].markdownKey
+          : ''
     };
   }
 
@@ -50,7 +52,7 @@ class FindResourceDialog extends Component {
             value={this.state.selectedResourceKey}
           >
             {this.props.resources.map(resource => (
-              <option key={resource.key} value={resource.key}>
+              <option key={resource.key} value={resource.markdownKey}>
                 {this.formatResourceName(resource)}
               </option>
             ))}
@@ -58,9 +60,9 @@ class FindResourceDialog extends Component {
         </label>
         <p>
           <strong>Note:</strong> Resource Links render as raw syntax (ie,{' '}
-          <code>[r resource-key]</code>) in the markdown preview here in the
-          editor, but will render as fully-realized links in the actual lesson
-          view.
+          <code>[r resource-key/course_offering_key/course_version_key]</code>)
+          in the markdown preview here in the editor, but will render as
+          fully-realized links in the actual lesson view.
         </p>
         <DialogFooter rightAlign>
           <Button

--- a/apps/src/lib/levelbuilder/lesson-editor/FindVocabularyDialog.jsx
+++ b/apps/src/lib/levelbuilder/lesson-editor/FindVocabularyDialog.jsx
@@ -19,7 +19,9 @@ export default class FindVocabularyDialog extends Component {
     super(props);
     this.state = {
       selectedVocabularyKey:
-        this.props.vocabularies.length > 0 ? this.props.vocabularies[0].key : ''
+        this.props.vocabularies.length > 0
+          ? this.props.vocabularies[0].markdownKey
+          : ''
     };
   }
 
@@ -41,12 +43,18 @@ export default class FindVocabularyDialog extends Component {
             value={this.state.selectedVocabularyKey}
           >
             {this.props.vocabularies.map(vocabulary => (
-              <option key={vocabulary.key} value={vocabulary.key}>
+              <option key={vocabulary.key} value={vocabulary.markdownKey}>
                 {vocabulary.key}
               </option>
             ))}
           </select>
         </label>
+        <p>
+          <strong>Note:</strong> Vocabulary Definitions render as raw syntax
+          (ie, <code>[v vocab-key/course_offering_key/course_version_key]</code>
+          ) in the markdown preview here in the editor, but will render as
+          definition-enabled, underlined spans in the actual lesson view.
+        </p>
         <DialogFooter rightAlign>
           <Button
             text={'Close and Add'}

--- a/apps/src/lib/levelbuilder/shapes.jsx
+++ b/apps/src/lib/levelbuilder/shapes.jsx
@@ -75,6 +75,7 @@ export const activityShape = PropTypes.shape({
 
 export const resourceShape = PropTypes.shape({
   key: PropTypes.string.isRequired,
+  markdownKey: PropTypes.string,
   name: PropTypes.string.isRequired,
   url: PropTypes.string.isRequired,
   type: PropTypes.string,
@@ -87,6 +88,7 @@ export const resourceShape = PropTypes.shape({
 export const vocabularyShape = PropTypes.shape({
   id: PropTypes.number.isRequired,
   key: PropTypes.string.isRequired,
+  markdownKey: PropTypes.string,
   word: PropTypes.string.isRequired,
   definition: PropTypes.string.isRequired,
   commonSenseMedia: PropTypes.bool.isRequired

--- a/apps/test/unit/lib/levelbuilder/lesson-editor/FindResourceDialogTest.jsx
+++ b/apps/test/unit/lib/levelbuilder/lesson-editor/FindResourceDialogTest.jsx
@@ -29,15 +29,15 @@ describe('FindResourceDialog', () => {
     const wrapper = shallow(<FindResourceDialog {...defaultProps} />);
     const closeAndAddButton = wrapper.find('Button').first();
     closeAndAddButton.simulate('click', {preventDefault: () => {}});
-    expect(handleConfirm).to.have.been.calledWith('resource-1');
+    expect(handleConfirm).to.have.been.calledWith('resource-1/course/year');
   });
 
   it('adds resource key on confirm, dropdown change', () => {
     const wrapper = shallow(<FindResourceDialog {...defaultProps} />);
     const select = wrapper.find('select').first();
-    select.simulate('change', {target: {value: 'resource-2'}});
+    select.simulate('change', {target: {value: 'resource-2/course/year'}});
     const closeAndAddButton = wrapper.find('Button').first();
     closeAndAddButton.simulate('click', {preventDefault: () => {}});
-    expect(handleConfirm).to.have.been.calledWith('resource-2');
+    expect(handleConfirm).to.have.been.calledWith('resource-2/course/year');
   });
 });

--- a/apps/test/unit/lib/levelbuilder/lesson-editor/FindVocabularyDialogTest.js
+++ b/apps/test/unit/lib/levelbuilder/lesson-editor/FindVocabularyDialogTest.js
@@ -16,6 +16,7 @@ describe('FindVocabularyDialog', () => {
         {
           id: 1,
           key: 'key1',
+          markdownKey: 'key1/course/year',
           word: 'word1',
           definition: 'definition1',
           commonSenseMedia: true
@@ -23,6 +24,7 @@ describe('FindVocabularyDialog', () => {
         {
           id: 2,
           key: 'key2',
+          markdownKey: 'key2/course/year',
           word: 'word2',
           definition: 'definition2',
           commonSenseMedia: true
@@ -44,15 +46,15 @@ describe('FindVocabularyDialog', () => {
     const wrapper = shallow(<FindVocabularyDialog {...defaultProps} />);
     const closeAndAddButton = wrapper.find('Button').first();
     closeAndAddButton.simulate('click', {preventDefault: () => {}});
-    expect(handleConfirm).to.have.been.calledWith('key1');
+    expect(handleConfirm).to.have.been.calledWith('key1/course/year');
   });
 
   it('adds vocabulary key on confirm, dropdown change', () => {
     const wrapper = shallow(<FindVocabularyDialog {...defaultProps} />);
     const select = wrapper.find('select').first();
-    select.simulate('change', {target: {value: 'key2'}});
+    select.simulate('change', {target: {value: 'key2/course/year'}});
     const closeAndAddButton = wrapper.find('Button').first();
     closeAndAddButton.simulate('click', {preventDefault: () => {}});
-    expect(handleConfirm).to.have.been.calledWith('key2');
+    expect(handleConfirm).to.have.been.calledWith('key2/course/year');
   });
 });

--- a/apps/test/unit/lib/levelbuilder/lesson-editor/resourceTestData.js
+++ b/apps/test/unit/lib/levelbuilder/lesson-editor/resourceTestData.js
@@ -1,12 +1,14 @@
 export default [
   {
     key: 'resource-1',
+    markdownKey: 'resource-1/course/year',
     name: 'Resource 1',
     url: 'code.org/resource-1',
     type: 'Slides'
   },
   {
     key: 'resource-2',
+    markdownKey: 'resource-2/course/year',
     name: 'Resource 2',
     url: 'code.org/resource-2',
     type: 'Handout'

--- a/dashboard/app/models/resource.rb
+++ b/dashboard/app/models/resource.rb
@@ -86,6 +86,7 @@ class Resource < ApplicationRecord
     {
       id: id,
       key: key,
+      markdownKey: Services::MarkdownPreprocessor.build_resource_key(self),
       name: name,
       url: url,
       downloadUrl: download_url || '',

--- a/dashboard/app/models/vocabulary.rb
+++ b/dashboard/app/models/vocabulary.rb
@@ -62,6 +62,7 @@ class Vocabulary < ApplicationRecord
     {
       id: id,
       key: key,
+      markdownKey: Services::MarkdownPreprocessor.build_vocab_key(self),
       word: word,
       definition: definition,
       commonSenseMedia: !!common_sense_media

--- a/dashboard/config/scripts_json/csd3-2021.script_json
+++ b/dashboard/config/scripts_json/csd3-2021.script_json
@@ -2808,7 +2808,7 @@
       "key": "ccd1c562-1214-4b3a-9385-da4c1ca21955",
       "position": 4,
       "properties": {
-        "description": "If we want our blocks to draw shapes in different ways they'll need more inputs that let us tell them how to draw. The inputs or openings in our blocks have a formal name, [v parameter]s, and today we're going to be learning more about how to use them.",
+        "description": "If we want our blocks to draw shapes in different ways they'll need more inputs that let us tell them how to draw. The inputs or openings in our blocks have a formal name, [v parameter/csd/2021]s, and today we're going to be learning more about how to use them.",
         "remarks": true
       },
       "seeding_key": {

--- a/dashboard/config/scripts_json/csd6-2021.script_json
+++ b/dashboard/config/scripts_json/csd6-2021.script_json
@@ -1954,7 +1954,7 @@
       "key": "65b2eb73-b2f8-4ee7-ba1d-0d7e78e7f62a",
       "position": 1,
       "properties": {
-        "description": "**Distribute:** Pass out Circuit Playgrounds.\r\n\r\n**Transition:** Send students to Code Studio. Let them know that today they will be experimenting with some sensors that detect [v analog] signals and convert them to [v digital] values that can be used by the computer.",
+        "description": "**Distribute:** Pass out Circuit Playgrounds.\r\n\r\n**Transition:** Send students to Code Studio. Let them know that today they will be experimenting with some sensors that detect [v analog/csd/2021] signals and convert them to [v digital/csd/2021] values that can be used by the computer.",
         "name": "Analog Inputs\r"
       },
       "seeding_key": {
@@ -3038,7 +3038,7 @@
       "key": "463c4da0-d013-4378-be2d-fa41c520ea5e",
       "position": 5,
       "properties": {
-        "description": "The elements of our Circuit Playground are all made up of circuits so small that we can't even see most of them, but you can create a simple [v circuit] on your own by attaching wires to the copper pads on the edge of the board.",
+        "description": "The elements of our Circuit Playground are all made up of circuits so small that we can't even see most of them, but you can create a simple [v circuit/csd/2021] on your own by attaching wires to the copper pads on the edge of the board.",
         "remarks": true
       },
       "seeding_key": {

--- a/dashboard/config/scripts_json/csp1-2021.script_json
+++ b/dashboard/config/scripts_json/csp1-2021.script_json
@@ -140,7 +140,7 @@
         "overview": "Students will create rules for ordering patterns of circles and squares. Students generate all possible messages with three place values, then create rules that explain how they ordered each message. Emphasis is placed on creating clear rules so that, if another group were to follow the rules, they would generate the same list in the same order. Using these rules, students then try to list all possible messages with four place values. As the lesson concludes, students share their rules with classmates.",
         "student_overview": "Develop a system for creating and ordering patterns of shapes.",
         "purpose": "Eventually, students will need to understand the binary number system which uses 1's and 0's rather than circles and squares. This lesson acts as a bridge to the next lesson where binary is formally introduced and practiced. In wrestling with the challenge of describing the rules of ordering patterns of circles and squares clearly, students will be primed to see how the binary number system solves many of these problems. Students may discover a system that is equivalent to the binary number system, which is a feat worth celebrating, but it is not expected that every student uncovers the rules for binary in this lesson.",
-        "preparation": "* Have scissors ready for groups to create [r ab-cutouts] or have these pre-cut and prepared before class\r\n",
+        "preparation": "* Have scissors ready for groups to create [r ab-cutouts/csp/2021] or have these pre-cut and prepared before class\r\n",
         "creative_commons_license": "Creative Commons BY-NC-SA",
         "announcements": [
           {
@@ -169,7 +169,7 @@
         "overview": "In this lesson, students will practice representing numbers in binary (base 2), transitioning from the circle-square representations they made in the last lesson. Students will create and use a \"Flippy Do\", a manipulative which helps students convert between binary (base 2) and decimal (base 10) numbers. They will practice converting numbers and explore the concept of place value in the context of binary numbers.",
         "student_overview": "In this lesson, students will practice representing numbers in binary (base 2), transitioning from the circle-square representations they made in the last lesson. Students will create and use a \"Flippy Do\", a manipulative which helps students convert between binary (base 2) and decimal (base 10) numbers. They will practice converting numbers and explore the concept of place value in the context of binary numbers.",
         "purpose": "This lesson is designed to give students as much time as possible using the Flippy Do to get comfortable with the relationship between binary and decimal numbers and the concept of place value.",
-        "preparation": "* Scissors (many pairs)\r\n* Printed copies of [r u1_l4_flippy_do]\t\r\n* [KEY U1L4 Flippy Do Pt 1](https://studio.code.org/s/csp1-2020/stage/4/puzzle/1)",
+        "preparation": "* Scissors (many pairs)\r\n* Printed copies of [r u1_l4_flippy_do/csp/2021]\t\r\n* [KEY U1L4 Flippy Do Pt 1](https://studio.code.org/s/csp1-2020/stage/4/puzzle/1)",
         "creative_commons_license": "Creative Commons BY-NC-SA",
         "announcements": [
           {
@@ -256,7 +256,7 @@
         "overview": "Students explore how black and white images are represented.  Students use the black and white pixelation widget to represent each pixel of an image with black or white light.  They learn how to sample an analog image using small squares of uniform size (each represented with a black or white value) and reflect on the pros and cons of choosing a smaller or larger square size when sampling.",
         "student_overview": "Learn how computers represent black and white images using bits.",
         "purpose": "Throughout this unit, students gradually discover how to use bits to represent more complex data types. In this case, students work on representing images using sampling. Students quickly realize that very tiny sample squares are needed to approximate an image’s curves and small details. The smaller we make each sample, the more bits are needed. Students must also wrestle with deciding whether each square should be a 0 or 1, as many squares have both white and black in the same square. They will have more control over the representation of each bit in the next lesson.\r\n",
-        "preparation": "\r\n* Practice using the pixelation widget\r\n* Copies of [r u1l7_black_and_white_images] for each pair of students\r\n* [KEY U1L7 Black and White Images](https://studio.code.org/s/csp1-2020/stage/7/puzzle/1)",
+        "preparation": "\r\n* Practice using the pixelation widget\r\n* Copies of [r u1l7_black_and_white_images/csp/2021] for each pair of students\r\n* [KEY U1L7 Black and White Images](https://studio.code.org/s/csp1-2020/stage/7/puzzle/1)",
         "creative_commons_license": "Creative Commons BY-NC-SA",
         "announcements": [
           {
@@ -285,7 +285,7 @@
         "overview": "This is a second opportunity for students to interact with the Pixelation Widget, but this time they will work with color pixels.  Students start off learning that each pixel uses red, green, and blue lights that can be turned on or off using bits. They will create more color variants using an increasing amount of bits per pixel, and apply their learning by approximating an analog color image using the widget.",
         "student_overview": "Learn how computers represent color images using bits.",
         "purpose": "This lesson continues the story of how bits are used to represent digital images.  Much like in the last lesson, students will use the Pixelation Widget to attempt to make digital approximations of analog images, this time in color.  These images are produced using layers of abstraction, with each layer relying on the other to perform its process.\r\n\r\nStudents will begin to realize that analog color images have values that change smoothly and subtly, while digital images do not.  The number of digital colors is also limited by the number of bits per pixel, whereas analog colors are unlimited.\r\n",
-        "preparation": "\r\n* Practice using the color pixelation widget \r\n* Review slides from [r csp_unit_1_-_digital_information]\t\r\n",
+        "preparation": "\r\n* Practice using the color pixelation widget \r\n* Review slides from [r csp_unit_1_-_digital_information/csp/2021]\t\r\n",
         "creative_commons_license": "Creative Commons BY-NC-SA",
         "announcements": [
           {
@@ -343,7 +343,7 @@
         "overview": "Students are introduced to lossy compression via the Lossy Text Compression widget. They apply this concept and their prior knowledge of sampling to create their own lossy compressions of image files using the Lossy Image Widget. Students then discuss several practical scenarios where they need to decide whether to use a lossy or lossless compression algorithm. The lesson ends with a discussion of the situations where lossless compression is important and the situations where lossy compression is important.",
         "student_overview": "Learn how information is represented using fewer bits when it's OK for some of the information or details to be lost.",
         "purpose": "After exploring lossless compression in yesterday’s lesson, students are introduced to lossy compression. A theme throughout the lesson is that lossy compression can greatly reduce the file size, but it can also greatly reduce the quality and it’s important to find that balance between quality and file size. The real challenge here is finding where that line is - how much can we compress but still keep it recognizable? In the final discussion, students compare lossy compression with lossless compression to see that each has value depending on the situation - lossy is useful when file size needs to be minimized, but lossless is important when its vital to be able to reconstruct the original image. ",
-        "preparation": "* Explore each of the widgets for this lesson\r\n* Decide how you will let students share their lossy compressions with each other or the whole class\r\n* Have [r csp_unit_1_-_digital_information] ready for the discussion towards the end of the lesson\r\n",
+        "preparation": "* Explore each of the widgets for this lesson\r\n* Decide how you will let students share their lossy compressions with each other or the whole class\r\n* Have [r csp_unit_1_-_digital_information/csp/2021] ready for the discussion towards the end of the lesson\r\n",
         "creative_commons_license": "Creative Commons BY-NC-SA",
         "announcements": [
           {
@@ -372,7 +372,7 @@
         "overview": "Students are asked to reflect on who owns their creative works from this class, such as their pixel images, before reading an article describing how ownership can become complicated as analog works become digital artifacts. After reading the article, students watch several videos explaining copyright and introducing them to the Creative Commons. Students then re-read the article answering three questions about the benefits, harms, and impacts of current copyright policy. Students use their new understanding of copyright to form an opinion about current copyright policies and create a small poster justifying their opinion with a quote from the article.",
         "student_overview": "Learn about how people can own digital information and the ways they can share access to their creative digital works.",
         "purpose": "Students have been examining how digital information is created and stored, but they have not closely examined the question of who owns their digital data and what rules govern how that information can be shared. This lesson introduces the concept of copyright by presenting students with an article that challenges their current understanding of digital ownership and makes them wrestle with some of the complexities of owning and sharing digital information. It’s important for students to talk through their ideas and hear the perspectives of their peers as they try to unpack how copyright law can impact society. Ultimately, students begin to form their own opinions about copyright focusing on how these policies impact the world around us and observing who benefits and who is harmed in particular copyright situations.\r\n\r\nThis lesson is also a scaffold to the larger project that begins after this lesson which includes several tasks that are also a part of this lesson such as, annotating an article, answering questions, and forming an opinion using the article as evidence. Students may need support with these processes during this lesson so they are able to complete the following lesson independently. It is especially important that students use marking the text strategies to help them comprehend and synthesize the information from their article, because they will need to do this in the next lesson as well. \r\n",
-        "preparation": "\r\n* Print out [r fortnite-article] with highlighters ready to mark the text. If you are unable to print copies, see the Teaching Tip below.",
+        "preparation": "\r\n* Print out [r fortnite-article/csp/2021] with highlighters ready to mark the text. If you are unable to print copies, see the Teaching Tip below.",
         "creative_commons_license": "Creative Commons BY-NC-SA",
         "announcements": [
           {
@@ -1219,7 +1219,7 @@
       "key": "c59591f1-d97f-40b3-8051-f163351f5eea",
       "position": 2,
       "properties": {
-        "description": "**Do This:** Ensure you are registered on Code Studio as a \"verified\" teacher account\n\n* Anyone can create a teacher account on Code Studio, which means that we need an extra layer of authorization to allow CS Principles teachers to see assessments, answer keys, and any other collateral that students should not be able to trivially get access to. If you attended a Code.org 5-day workshop during the summer, you should already have this access.\n\n[pull-right]\n\n![](https://images.code.org/0989bbfe1f2ee63670754387f9e3b523-pre-survey-screencap.png)\n\n[/pull-right]\n\n* To check if you have access:\n\n\t1. Navigate to the [Unit 1 overview page](https://studio.code.org/s/csp1)\n\t2. Do you see the CS Principles Pre-course Survey at the top of the unit overview page?\n\t3. If not, you need to verify your teacher account. Please fill out [this form](https://docs.google.com/forms/d/e/1FAIpQLSdGGAJuaDMBVIRYnimPhAL96w6fCl4UdvhwmynGONM75TWwWw/viewform). Note that it can take 5-7 business days to become a verified teacher, so please do this step early!\n\n* If you are *not* a verified teacher account, you can still create a section for your class, but you will not be able to administer the pre-course survey on the first day.\n\n**Do This:** Create a class section on Code Studio.\n\n[pull-right]\n\n![](https://images.code.org/7faaa833d7aea4ddbd943ed1f2bd0ed0-sec-setup 1.png)\n\n\n[/pull-right]\n\n* You can either...\n\n\t* Go to the [r how_to_videos_1] for a video walkthrough of these steps and more on navigating your Code.org account.\n\n\t  Or...\n\n\t* Follow these steps to create a section:\n\n\t\t1. Navigate to the [My Dashboard](https://studio.code.org/home)\n\t\t2. Click 'New section' under 'Classroom Sections'\n\t\t3. Choose 'Email Logins' \n\t\t\t* If logged on through Google you can choose to sync to your Google Classroom.\n\t\t4. Give your section a name, and choose the most appropriate grade level of students in your class\n\t\t5. Set the course to be \"CS Principles\"\n\t\t6. Set the unit to be \"Unit 1: Digital Information\"\n\t\t7. *If you're NOT using Google Classroom:* Once the section is created, click the name of the section to show the unique \"join link\" for your section.\n",
+        "description": "**Do This:** Ensure you are registered on Code Studio as a \"verified\" teacher account\n\n* Anyone can create a teacher account on Code Studio, which means that we need an extra layer of authorization to allow CS Principles teachers to see assessments, answer keys, and any other collateral that students should not be able to trivially get access to. If you attended a Code.org 5-day workshop during the summer, you should already have this access.\n\n[pull-right]\n\n![](https://images.code.org/0989bbfe1f2ee63670754387f9e3b523-pre-survey-screencap.png)\n\n[/pull-right]\n\n* To check if you have access:\n\n\t1. Navigate to the [Unit 1 overview page](https://studio.code.org/s/csp1)\n\t2. Do you see the CS Principles Pre-course Survey at the top of the unit overview page?\n\t3. If not, you need to verify your teacher account. Please fill out [this form](https://docs.google.com/forms/d/e/1FAIpQLSdGGAJuaDMBVIRYnimPhAL96w6fCl4UdvhwmynGONM75TWwWw/viewform). Note that it can take 5-7 business days to become a verified teacher, so please do this step early!\n\n* If you are *not* a verified teacher account, you can still create a section for your class, but you will not be able to administer the pre-course survey on the first day.\n\n**Do This:** Create a class section on Code Studio.\n\n[pull-right]\n\n![](https://images.code.org/7faaa833d7aea4ddbd943ed1f2bd0ed0-sec-setup 1.png)\n\n\n[/pull-right]\n\n* You can either...\n\n\t* Go to the [r how_to_videos_1/csp/2021] for a video walkthrough of these steps and more on navigating your Code.org account.\n\n\t  Or...\n\n\t* Follow these steps to create a section:\n\n\t\t1. Navigate to the [My Dashboard](https://studio.code.org/home)\n\t\t2. Click 'New section' under 'Classroom Sections'\n\t\t3. Choose 'Email Logins' \n\t\t\t* If logged on through Google you can choose to sync to your Google Classroom.\n\t\t4. Give your section a name, and choose the most appropriate grade level of students in your class\n\t\t5. Set the course to be \"CS Principles\"\n\t\t6. Set the unit to be \"Unit 1: Digital Information\"\n\t\t7. *If you're NOT using Google Classroom:* Once the section is created, click the name of the section to show the unique \"join link\" for your section.\n",
         "name": "Before your first class\r"
       },
       "seeding_key": {
@@ -1295,7 +1295,7 @@
       "key": "64fdbe78-9bea-4ac8-9069-abe1a54dedfb",
       "position": 2,
       "properties": {
-        "description": "**Do This:** Students can find a link to the survey in Code Studio as the first item on the Unit 1 overview page. To ensure that students only take the survey at the appropriate time, it is \"locked\" and unviewable by them until you \"unlock\" the survey. The [r how-to-administer-a-locked-assessment] document provides details on how to do that when you are ready. Note that the instructions for administering an assessment and a survey are the same.    \r\n\r\n<img src=\"https://curriculum.code.org/media/uploads/presurvey.png\" style=\"width:400px\">",
+        "description": "**Do This:** Students can find a link to the survey in Code Studio as the first item on the Unit 1 overview page. To ensure that students only take the survey at the appropriate time, it is \"locked\" and unviewable by them until you \"unlock\" the survey. The [r how-to-administer-a-locked-assessment/csp/2021] document provides details on how to do that when you are ready. Note that the instructions for administering an assessment and a survey are the same.    \r\n\r\n<img src=\"https://curriculum.code.org/media/uploads/presurvey.png\" style=\"width:400px\">",
         "name": "Important! Have your students take the CSP Pre-Course Survey!\r"
       },
       "seeding_key": {
@@ -1413,7 +1413,7 @@
       "key": "203520f1-fecd-4a71-8173-6376037fdbcb",
       "position": 2,
       "properties": {
-        "description": "People seem to say that technology is all around us, that it affects everything we do.  Is that true?  Technological [v innovation] is about recognizing a problem that needs to be solved, or recognizing something needs improving and then building a tool to solve it.\r\n\r\n**As a class we’re going to see how innovative we can be.  We’re going to do something called “rapid prototyping.”**  \r\n\r\n\"Prototype\" is a fancy word that means a simple sketch of an idea or model for something new.  It’s the original drawing from which something real might be built or created.",
+        "description": "People seem to say that technology is all around us, that it affects everything we do.  Is that true?  Technological [v innovation/csp/2021] is about recognizing a problem that needs to be solved, or recognizing something needs improving and then building a tool to solve it.\r\n\r\n**As a class we’re going to see how innovative we can be.  We’re going to do something called “rapid prototyping.”**  \r\n\r\n\"Prototype\" is a fancy word that means a simple sketch of an idea or model for something new.  It’s the original drawing from which something real might be built or created.",
         "remarks": true,
         "name": "Identify impacts and prototype an innovation\r"
       },
@@ -1519,7 +1519,7 @@
       "key": "3d68b771-e2d0-4d0d-aa0f-59e59adb3489",
       "position": 3,
       "properties": {
-        "description": "[slide] **Video:** Play [r innovation-video-1-1]\n\n- The video is available for students in Code Studio as well."
+        "description": "[slide] **Video:** Play [r innovation-video-1-1/csp/2021]\n\n- The video is available for students in Code Studio as well."
       },
       "seeding_key": {
         "activity_section.key": "3d68b771-e2d0-4d0d-aa0f-59e59adb3489",
@@ -1858,7 +1858,7 @@
       "key": "0fad0c8b-5ee3-4145-b674-10aeea839f52",
       "position": 4,
       "properties": {
-        "description": "**Group:** Place students in groups of 2, making one group of 3 if necessary\r\n\r\n[slide] **Distribute:**  [r ag-ab-pattern] - one for each group. Each group also gets the [r ab-cutouts] to use during the activity.\r\n\r\n\r\n\r\n[slide] **Challenge #1:** Students again list all possible three place value patterns, but with an added focus on the order of their patterns.",
+        "description": "**Group:** Place students in groups of 2, making one group of 3 if necessary\r\n\r\n[slide] **Distribute:**  [r ag-ab-pattern/csp/2021] - one for each group. Each group also gets the [r ab-cutouts/csp/2021] to use during the activity.\r\n\r\n\r\n\r\n[slide] **Challenge #1:** Students again list all possible three place value patterns, but with an added focus on the order of their patterns.",
         "name": "Circle Square Activity (25 minutes) \r"
       },
       "seeding_key": {
@@ -2185,7 +2185,7 @@
       "key": "a71aae55-6d99-498d-a6fa-4c729901e49e",
       "position": 8,
       "properties": {
-        "description": "Now that you have started thinking about place value and overflow, we are going to work on a different problem. What happens when there aren’t enough place values to represent a number? You will explore this with a new version of the Flippy Do, the Flippy Do Pro!\n[r flippy_do_pro]",
+        "description": "Now that you have started thinking about place value and overflow, we are going to work on a different problem. What happens when there aren’t enough place values to represent a number? You will explore this with a new version of the Flippy Do, the Flippy Do Pro!\n[r flippy_do_pro/csp/2021]",
         "remarks": true,
         "name": "Flippy Do Pro"
       },
@@ -2521,7 +2521,7 @@
       "key": "e5a7cae0-b8fd-45db-85c2-78dbc598715c",
       "position": 12,
       "properties": {
-        "description": "[slide]  **Distribute:** Hand out copies of the [r ascii-reference-sheet] or project it. Quickly read the overview text at the beginning of the sheet."
+        "description": "[slide]  **Distribute:** Hand out copies of the [r ascii-reference-sheet/csp/2021] or project it. Quickly read the overview text at the beginning of the sheet."
       },
       "seeding_key": {
         "activity_section.key": "e5a7cae0-b8fd-45db-85c2-78dbc598715c",
@@ -2761,7 +2761,7 @@
       "key": "6a7f6a14-c3c7-4531-8526-59bfd13e0967",
       "position": 6,
       "properties": {
-        "description": " **Distribute:**  [r u1l7_black_and_white_images]"
+        "description": " **Distribute:**  [r u1l7_black_and_white_images/csp/2021]"
       },
       "seeding_key": {
         "activity_section.key": "6a7f6a14-c3c7-4531-8526-59bfd13e0967",
@@ -3296,7 +3296,7 @@
       "key": "79e7b1c0-5d3a-4b3d-9ab7-03848dee1997",
       "position": 10,
       "properties": {
-        "description": "[slide] **Video:** Show [r text-compression-widget-tutorial-1] (feel free to skip from 2:30-5:00 if your students are comfortable with how the widget works, but don't miss 5:00+). After the video, be sure to emphasize two things: \r\n\r\n* The widget we are using is an example of **lossless compression**\r\n* The compression percentage at the bottom of the screen is calculated by comparing the number of **bytes** in the original message and the number of **bytes** in the compressed message."
+        "description": "[slide] **Video:** Show [r text-compression-widget-tutorial-1/csp/2021] (feel free to skip from 2:30-5:00 if your students are comfortable with how the widget works, but don't miss 5:00+). After the video, be sure to emphasize two things: \r\n\r\n* The widget we are using is an example of **lossless compression**\r\n* The compression percentage at the bottom of the screen is calculated by comparing the number of **bytes** in the original message and the number of **bytes** in the compressed message."
       },
       "seeding_key": {
         "activity_section.key": "79e7b1c0-5d3a-4b3d-9ab7-03848dee1997",
@@ -3788,7 +3788,7 @@
       "key": "17e3d3b0-3bd0-4148-96dc-9d0e357fdbc8",
       "position": 1,
       "properties": {
-        "description": "[slide]  **Distribute:** [r fortnite-article].",
+        "description": "[slide]  **Distribute:** [r fortnite-article/csp/2021].",
         "tips": [
           {
             "key": "tip",
@@ -4098,7 +4098,7 @@
       "key": "4f127a1c-1c8b-48f3-a43f-5e706e32ba35",
       "position": 2,
       "properties": {
-        "description": "[slide] **Distribute:** Students pick one of the articles below.\n\n* [r the-ethics-of-computer-generated-actors]\n* [r dna-testing-kits-the-security-risks-in-digitized-dna]\n* [r athletes-dont-own-their-tattoos] \n\n[slide] **Display:** Instructions on lesson slides.\n\n* **Highlight/Underline:** Any information in this article that you want to learn more about. \n* **At The End:** Write a 10 word summary of the article. \n\n**Group:** Create groups of students who read the same article. You may need to have more than one group for a single article."
+        "description": "[slide] **Distribute:** Students pick one of the articles below.\n\n* [r the-ethics-of-computer-generated-actors/csp/2021]\n* [r dna-testing-kits-the-security-risks-in-digitized-dna/csp/2021]\n* [r athletes-dont-own-their-tattoos/csp/2021] \n\n[slide] **Display:** Instructions on lesson slides.\n\n* **Highlight/Underline:** Any information in this article that you want to learn more about. \n* **At The End:** Write a 10 word summary of the article. \n\n**Group:** Create groups of students who read the same article. You may need to have more than one group for a single article."
       },
       "seeding_key": {
         "activity_section.key": "4f127a1c-1c8b-48f3-a43f-5e706e32ba35",

--- a/dashboard/config/scripts_json/csp10-2021.script_json
+++ b/dashboard/config/scripts_json/csp10-2021.script_json
@@ -1199,7 +1199,7 @@
       "key": "888e973b-48f4-480c-8573-2654a891a669",
       "position": 3,
       "properties": {
-        "description": "[slide] **Brainstorm (10 mins):** Teams spend five minutes brainstorming computing innovations they believe would be beneficial to the Future School. Students should be considering if the innovations include programs as an important part of their function. If not, it's possible that it is not a computing innovation. Remind students to stay in their roles.   \r\n\r\n**Distribute:** [r csp_innovation_simulation_project_guide]\r\n\r\n\r\n[slide] **Step 1 - Reflect (10 mins):** Students use this time to consider the wants and needs of their characters and what types of computing innovations would and would not appeal to the character they are playing. Students write their reflection in the Project Guide.",
+        "description": "[slide] **Brainstorm (10 mins):** Teams spend five minutes brainstorming computing innovations they believe would be beneficial to the Future School. Students should be considering if the innovations include programs as an important part of their function. If not, it's possible that it is not a computing innovation. Remind students to stay in their roles.   \r\n\r\n**Distribute:** [r csp_innovation_simulation_project_guide/csp/2021]\r\n\r\n\r\n[slide] **Step 1 - Reflect (10 mins):** Students use this time to consider the wants and needs of their characters and what types of computing innovations would and would not appeal to the character they are playing. Students write their reflection in the Project Guide.",
         "name": "Innovation Simulation Project\r"
       },
       "seeding_key": {
@@ -1465,7 +1465,7 @@
       "key": "450ac09b-4189-43bb-af5b-105cd0124f99",
       "position": 4,
       "properties": {
-        "description": "**Group:** If students like they can work in pairs for today's activity when they will be reading the privacy policy. Each student, however, should be completing their own activity guide.\n\n**Distribute: ** Give each student a copy of [r data-policies-activity-guide]\n\n\n\n\n[slide] **Choose a Website and Find the Data Privacy Policy:** Have students pick a company / app to use. If students are having a hard time picking a specific website, many big technology companies have fairly robust data policy pages, like Facebook, Google, Twitter, Instagram, and so on.\n\n**What Is Their Data Policy?:** Students should spend 10-15 minutes reviewing the data policies and answering the questions there. \n\n**Share Findings:** Have groups meet with another group to share what they discovered."
+        "description": "**Group:** If students like they can work in pairs for today's activity when they will be reading the privacy policy. Each student, however, should be completing their own activity guide.\n\n**Distribute: ** Give each student a copy of [r data-policies-activity-guide/csp/2021]\n\n\n\n\n[slide] **Choose a Website and Find the Data Privacy Policy:** Have students pick a company / app to use. If students are having a hard time picking a specific website, many big technology companies have fairly robust data policy pages, like Facebook, Google, Twitter, Instagram, and so on.\n\n**What Is Their Data Policy?:** Students should spend 10-15 minutes reviewing the data policies and answering the questions there. \n\n**Share Findings:** Have groups meet with another group to share what they discovered."
       },
       "seeding_key": {
         "activity_section.key": "450ac09b-4189-43bb-af5b-105cd0124f99",
@@ -1537,7 +1537,7 @@
       "key": "c3e69cb7-9108-48b9-9758-db87f0bd38b2",
       "position": 2,
       "properties": {
-        "description": "**Distribute:** As students walk in give them copies of their [r data-policies-activity-guide] which they began filling out in the previous lesson.\n    "
+        "description": "**Distribute:** As students walk in give them copies of their [r data-policies-activity-guide/csp/2021] which they began filling out in the previous lesson.\n    "
       },
       "seeding_key": {
         "activity_section.key": "c3e69cb7-9108-48b9-9758-db87f0bd38b2",
@@ -2090,7 +2090,7 @@
       "key": "6fe9b2ee-f1c2-4ee8-9c8d-053587d45387",
       "position": 1,
       "properties": {
-        "description": "**Distribute:** Give students back [r csp_innovation_simulation_project_guide] if they don't already have them on hand.\r\n\r\n\r\n[slide] **Do This:** Instruct students to continue working on their projects following the instructions in the Activity Guide.  Students will be working on *Step 4 - One-pager* during this hour.\r\n\r\n**Circulate:** Throughout the lesson circulate and provide support to students on completing their one pagers."
+        "description": "**Distribute:** Give students back [r csp_innovation_simulation_project_guide/csp/2021] if they don't already have them on hand.\r\n\r\n\r\n[slide] **Do This:** Instruct students to continue working on their projects following the instructions in the Activity Guide.  Students will be working on *Step 4 - One-pager* during this hour.\r\n\r\n**Circulate:** Throughout the lesson circulate and provide support to students on completing their one pagers."
       },
       "seeding_key": {
         "activity_section.key": "6fe9b2ee-f1c2-4ee8-9c8d-053587d45387",

--- a/dashboard/config/scripts_json/csp3-2021.script_json
+++ b/dashboard/config/scripts_json/csp3-2021.script_json
@@ -108,7 +108,7 @@
         "overview": "This is the first in a series of lessons where students will make progress on building their own functional app. In this lesson, students brainstorm app ideas and sketch out user interfaces in preparation for the next lesson where they will return to App Lab. ",
         "student_overview": "This is the first in a series of lessons where students will make progress on building their own functional app. ",
         "purpose": "This lesson kicks off a project that students will complete throughout the unit. The framing of this project is also important for how programming is presented overall. Students are encouraged to collaboratively design their projects, choose topics of personal interest, and build an app to meet the needs of other people. All of this is important as part of framing programming as a collaborative, creative, and socially situated pursuit.",
-        "preparation": "* Read over the [r app_development_planning_guide]",
+        "preparation": "* Read over the [r app_development_planning_guide/csp/2021]",
         "creative_commons_license": "Creative Commons BY-NC-SA",
         "announcements": [
           {
@@ -995,7 +995,7 @@
       "key": "f8496c85-e709-44b6-8919-23c7d7839f51",
       "position": 7,
       "properties": {
-        "description": "[slide] **Display:** How Computers Work [r how_computers_work_-_what_makes_a_computer_a_computer]",
+        "description": "[slide] **Display:** How Computers Work [r how_computers_work_-_what_makes_a_computer_a_computer/csp/2021]",
         "name": "Input & Output"
       },
       "seeding_key": {
@@ -1258,7 +1258,7 @@
       "key": "e0e7e291-2820-4bb2-b24f-9ab9faee38af",
       "position": 2,
       "properties": {
-        "description": "[slide] **Distribute:** [r app_development_planning_guide]. Students will be using the Planning Guide for the rest of the unit. Read the Project Description together and make sure students understand the requirements. Direct students to the \"Investigate\" section. \r\n\r\n\r\n\r\n\r\n[slide] **Step 1:** Brainstorm Topic Ideas\r\n\r\n* Students have a lot of freedom in choosing their topics. If they are struggling with ideas, they could create an app for another class, for example: an overview of the periodic table for science class.  \r\n    \r\n\r\n[slide] **Group:** Organize students into pairs."
+        "description": "[slide] **Distribute:** [r app_development_planning_guide/csp/2021]. Students will be using the Planning Guide for the rest of the unit. Read the Project Description together and make sure students understand the requirements. Direct students to the \"Investigate\" section. \r\n\r\n\r\n\r\n\r\n[slide] **Step 1:** Brainstorm Topic Ideas\r\n\r\n* Students have a lot of freedom in choosing their topics. If they are struggling with ideas, they could create an app for another class, for example: an overview of the periodic table for science class.  \r\n    \r\n\r\n[slide] **Group:** Organize students into pairs."
       },
       "seeding_key": {
         "activity_section.key": "e0e7e291-2820-4bb2-b24f-9ab9faee38af",
@@ -1493,7 +1493,7 @@
       "key": "97d67aa6-8667-4f51-8d13-e412f4a4a798",
       "position": 3,
       "properties": {
-        "description": "This is a good opportunity to look over student's work in the [r app_development_planning_guide] as a formative assessment.",
+        "description": "This is a good opportunity to look over student's work in the [r app_development_planning_guide/csp/2021] as a formative assessment.",
         "name": "Assessment: Planning Guide"
       },
       "seeding_key": {
@@ -2016,7 +2016,7 @@
       "key": "f400d836-3586-44b0-94ba-53164c90b275",
       "position": 2,
       "properties": {
-        "description": "[slide] **Distribute:** Direct students back to the [r app_development_planning_guide]\r\n\r\n[slide] **Step 5:** Students fill out the chart on page 4, listing all of the Event Handlers in their programs. They should be able to determine these based on the Program Specification they designed.\r\n\r\n\r\n\r\n[slide] **Display:** Play the Pair Programming video found either in [r csp-unit-3-intro-to-app-design] or on Code Studio. Afterwards review the pair programming steps found in Code Studio."
+        "description": "[slide] **Distribute:** Direct students back to the [r app_development_planning_guide/csp/2021]\r\n\r\n[slide] **Step 5:** Students fill out the chart on page 4, listing all of the Event Handlers in their programs. They should be able to determine these based on the Program Specification they designed.\r\n\r\n\r\n\r\n[slide] **Display:** Play the Pair Programming video found either in [r csp-unit-3-intro-to-app-design/csp/2021] or on Code Studio. Afterwards review the pair programming steps found in Code Studio."
       },
       "seeding_key": {
         "activity_section.key": "f400d836-3586-44b0-94ba-53164c90b275",
@@ -2160,7 +2160,7 @@
       "key": "e84b5ead-1284-4ddc-84bb-020dd6ee80b1",
       "position": 4,
       "properties": {
-        "description": "[slide] **Distribute:** Direct students back to the [r app_development_planning_guide].\n\n[slide] **Step 6:** Groups swap apps and gather feedback. It is ok to move ahead to this section even if students are not done with their apps yet. \n\nHere's what you should observe:\n\n* Group A lets Group B test their app. \n* Group A watches Group B use the app, and writes down improvements that come to mind.\n* Group A interviews Group B asking for specific improvements Group A can make. This may be different than what Group A came up with during the observation. These improvements are written down in the Activity Guide. \n* Group A and B swap and now Group A tests Group B's app while Group B watches. \n* After this, mix up the group pairings and repeat the steps above. \n\n![](https://images.code.org/c1047cb72698ab39e2bdf1f6f1ba6613-image-1611868434888.png)",
+        "description": "[slide] **Distribute:** Direct students back to the [r app_development_planning_guide/csp/2021].\n\n[slide] **Step 6:** Groups swap apps and gather feedback. It is ok to move ahead to this section even if students are not done with their apps yet. \n\nHere's what you should observe:\n\n* Group A lets Group B test their app. \n* Group A watches Group B use the app, and writes down improvements that come to mind.\n* Group A interviews Group B asking for specific improvements Group A can make. This may be different than what Group A came up with during the observation. These improvements are written down in the Activity Guide. \n* Group A and B swap and now Group A tests Group B's app while Group B watches. \n* After this, mix up the group pairings and repeat the steps above. \n\n![](https://images.code.org/c1047cb72698ab39e2bdf1f6f1ba6613-image-1611868434888.png)",
         "name": "Testing and Feedback - 10 mins\r",
         "progression_name": "Add More Code"
       },
@@ -2226,7 +2226,7 @@
       "key": "25cd2d3b-a4c4-435f-b13b-ee1d42b18441",
       "position": 1,
       "properties": {
-        "description": "**Group:** Place students back in pairs with their project partner.\r\n\r\n[slide]  **Distribute:** Make sure students have access to the [r app_development_planning_guide]"
+        "description": "**Group:** Place students back in pairs with their project partner.\r\n\r\n[slide]  **Distribute:** Make sure students have access to the [r app_development_planning_guide/csp/2021]"
       },
       "seeding_key": {
         "activity_section.key": "25cd2d3b-a4c4-435f-b13b-ee1d42b18441",
@@ -2273,7 +2273,7 @@
       "key": "239b6d98-edc4-4a2c-b18d-ef16e4df533d",
       "position": 2,
       "properties": {
-        "description": "Use the rubric to assess student projects. The rubric can be found on the last page of the [r app_development_planning_guide].",
+        "description": "Use the rubric to assess student projects. The rubric can be found on the last page of the [r app_development_planning_guide/csp/2021].",
         "name": "Assessment: Project\r",
         "progression_name": "Submit Your App"
       },

--- a/dashboard/config/scripts_json/csp5-2021.script_json
+++ b/dashboard/config/scripts_json/csp5-2021.script_json
@@ -3198,7 +3198,7 @@
         "tips": [
           {
             "type": "teachingTip",
-            "markdown": "**Forming Groups:** You may opt to form the groups yourself, randomly place students in groups, or let students select their partners based on the dataset they want to work with. \r\n\r\n**Previewing the Written Responses:** You may opt to share the [r csp_u5_written_response] with students early just so they know what they'll be expected to write at the end of the 5-day project.\r\n\r\n"
+            "markdown": "**Forming Groups:** You may opt to form the groups yourself, randomly place students in groups, or let students select their partners based on the dataset they want to work with. \r\n\r\n**Previewing the Written Responses:** You may opt to share the [r csp_u5_written_response/csp/2021] with students early just so they know what they'll be expected to write at the end of the 5-day project.\r\n\r\n"
           }
         ],
         "name": "Hackathon Prep\r"
@@ -3527,7 +3527,7 @@
         "tips": [
           {
             "type": "teachingTip",
-            "markdown": "The Written Response portion of this project is a modified, short version of the Create Performance Task students will turn in to the College Board for the AP Exam. To have your students practice submitting this project using a similar interface to the Create Performance Task, see the [r csp-u5-hackathon-submission-on-ap-classroom] for instructions on how to set up an assessment on AP Classroom.\n"
+            "markdown": "The Written Response portion of this project is a modified, short version of the Create Performance Task students will turn in to the College Board for the AP Exam. To have your students practice submitting this project using a similar interface to the Create Performance Task, see the [r csp-u5-hackathon-submission-on-ap-classroom/csp/2021] for instructions on how to set up an assessment on AP Classroom.\n"
           }
         ],
         "name": "Written Response"

--- a/dashboard/config/scripts_json/pre-express-2021.script_json
+++ b/dashboard/config/scripts_json/pre-express-2021.script_json
@@ -100,7 +100,7 @@
       "properties": {
         "overview": "Using Scrat from the Ice Age franchise, students will develop sequential algorithms to move a squirrel character from one side of a maze to the acorn at the other side. To do this they will stack code blocks together in a linear sequence.",
         "purpose": "In this lesson, students will develop programming and debugging skills on a computer platform. The block-based format of these puzzles help students learn about sequence and concepts, without having to worry about perfecting syntax.",
-        "preparation": " - Watch the [r class-section-video]. Create a class section and make sure every student has a card with their passcode on it\r\n - Have the school IT person add a quick link for your class section to the computer desktop\r\n - Make sure each student has a [r think-spot-journal]",
+        "preparation": " - Watch the [r class-section-video/pre-express/2021]. Create a class section and make sure every student has a card with their passcode on it\r\n - Have the school IT person add a quick link for your class section to the computer desktop\r\n - Make sure each student has a [r think-spot-journal/pre-express/2021]",
         "creative_commons_license": "Creative Commons BY-NC-SA"
       },
       "seeding_key": {
@@ -157,7 +157,7 @@
       "properties": {
         "overview": "Students will apply the programming concepts that they have learned to the Harvester environment. Now, instead of just getting the character to a goal, students have to collect corn using a new block. Students will continue to develop sequential algorithm skills and start using the debugging process. ",
         "purpose": "In this lesson, students will develop debugging skills and will continue developing their programming skills.",
-        "preparation": " - Play through the puzzles to find any potential problem areas for your class\r\n - Locate or reprint supplies for Happy Maps\r\n - Make sure each student has a [r think-spot-journal]",
+        "preparation": " - Play through the puzzles to find any potential problem areas for your class\r\n - Locate or reprint supplies for Happy Maps\r\n - Make sure each student has a [r think-spot-journal/pre-express/2021]",
         "creative_commons_license": "Creative Commons BY-NC-SA"
       },
       "seeding_key": {
@@ -214,7 +214,7 @@
       "properties": {
         "overview": "Returning to loops, students learn to draw images by looping simple sequences of instructions. In the previous plugged lesson, loops were used to traverse a maze and collect treasure. Here, loops are creating patterns. At the end of this stage, students will be given the opportunity to create their own images using loops.",
         "purpose": "This lesson gives a different perspective on how loops can create things in programming. Students can also reflect on the inefficiency of programming without loops here because of how many blocks the program would require without the help of `repeat` loops.",
-        "preparation": " - Play through the puzzles to find any potential problem areas for your class.\r\n - Make sure each student has a [r think-spot-journal].",
+        "preparation": " - Play through the puzzles to find any potential problem areas for your class.\r\n - Make sure each student has a [r think-spot-journal/pre-express/2021].",
         "creative_commons_license": "Creative Commons BY-NC-SA"
       },
       "seeding_key": {
@@ -252,7 +252,7 @@
       "properties": {
         "overview": "In this online activity, students will have the opportunity to learn how to use events in Play Lab and to apply all of the coding skills they've learned to create an animated game. It's time to get creative and make a story in the Play Lab!",
         "purpose": "Students will further develop their understanding of events using Play Lab today. Events are very common in most computer programs. In this activity, students will use events to make a character move around the screen, make noises, and change backgrounds based on user-initiated events.",
-        "preparation": " - Play through the puzzles to find any potential problem areas for your class.\r\n - (Optional) Pick a couple of puzzles to do as a group with your class.\r\n - Review [r csf-lesson-recommend].\r\n - Make sure every student has a [r think-spot-journal].",
+        "preparation": " - Play through the puzzles to find any potential problem areas for your class.\r\n - (Optional) Pick a couple of puzzles to do as a group with your class.\r\n - Review [r csf-lesson-recommend/pre-express/2021].\r\n - Make sure every student has a [r think-spot-journal/pre-express/2021].",
         "creative_commons_license": "Creative Commons BY-NC-SA"
       },
       "seeding_key": {
@@ -1056,7 +1056,7 @@
           {
             "key": "tip",
             "type": "teachingTip",
-            "markdown": " - Use calm bodies in the lab\r\n - Remember not to chew gum or candy\r\n - Sanitize your hands\r\n - Sit with your partner at one computer\r\n - Make sure that the first \"driver\" can reach the mouse\r\n - When you get frustrated, don't hit or shake the computer or monitor\r\n - Follow the [r 202020] rule\r\n - How to deal with the [r wiggles] every 20-30 minutes (requires a free login on GoNoodle)\r\n - Ask your partner before you ask the teacher\r\n - Keep volume down so everyone else can hear their partners\r\n - Use your journal for keeping track of feelings and solutions\r\n\r\n"
+            "markdown": " - Use calm bodies in the lab\r\n - Remember not to chew gum or candy\r\n - Sanitize your hands\r\n - Sit with your partner at one computer\r\n - Make sure that the first \"driver\" can reach the mouse\r\n - When you get frustrated, don't hit or shake the computer or monitor\r\n - Follow the [r 202020/pre-express/2021] rule\r\n - How to deal with the [r wiggles/pre-express/2021] every 20-30 minutes (requires a free login on GoNoodle)\r\n - Ask your partner before you ask the teacher\r\n - Keep volume down so everyone else can hear their partners\r\n - Use your journal for keeping track of feelings and solutions\r\n\r\n"
           }
         ]
       },
@@ -1174,7 +1174,7 @@
       "key": "d69fc3f9-0235-4de1-90c7-13f7c8c22cc9",
       "position": 1,
       "properties": {
-        "description": "If students complete the puzzles from Stage 4 early, have them spend some time trying to come up with their own puzzles in their [r think-spot-journal]."
+        "description": "If students complete the puzzles from Stage 4 early, have them spend some time trying to come up with their own puzzles in their [r think-spot-journal/pre-express/2021]."
       },
       "seeding_key": {
         "activity_section.key": "d69fc3f9-0235-4de1-90c7-13f7c8c22cc9",
@@ -1199,7 +1199,7 @@
           {
             "key": "tip",
             "type": "teachingTip",
-            "markdown": " - Use calm bodies in the lab\r\n - Remember not to chew gum or candy\r\n - Sanitize your hands\r\n - Sit with your partner at one computer\r\n - Make sure that the first \"driver\" can reach the mouse\r\n - When you get frustrated, don't hit or shake the computer or monitor\r\n - Follow the [r 202020] rule\r\n - How to deal with the [r wiggles] every 20-30 minutes (requires a free login on GoNoodle)\r\n - Ask your partner before you ask the teacher\r\n - Keep volume down so everyone else can hear their partners\r\n - Use your journal for keeping track of feelings and solutions\r\n"
+            "markdown": " - Use calm bodies in the lab\r\n - Remember not to chew gum or candy\r\n - Sanitize your hands\r\n - Sit with your partner at one computer\r\n - Make sure that the first \"driver\" can reach the mouse\r\n - When you get frustrated, don't hit or shake the computer or monitor\r\n - Follow the [r 202020/pre-express/2021] rule\r\n - How to deal with the [r wiggles/pre-express/2021] every 20-30 minutes (requires a free login on GoNoodle)\r\n - Ask your partner before you ask the teacher\r\n - Keep volume down so everyone else can hear their partners\r\n - Use your journal for keeping track of feelings and solutions\r\n"
           }
         ]
       },
@@ -1259,7 +1259,7 @@
       "key": "20e998a3-d920-48f1-9d92-ec4102990042",
       "position": 2,
       "properties": {
-        "description": "This will teach students how to use Code.org to complete online puzzles.\r\n\r\nThis stage was designed to give students the opportunity to practice hand-eye coordination, clicking, and drag & drop skills.  Students will also play with sequence.\r\n\r\nThe vocabulary introduced in this lesson becomes relevant during this activity.  Take some time to explicitly teach how to click, double-click, drag, and drop.  It might work better for you to cover these words in the classroom environment where you can lead by example -- or it might make more sense to teach the words individually as students work on their puzzles in the lab.  You will need to decide what you believe is best for your class.\r\n\r\nWatch the [r pair-programming-vid] with your students, then assign them to pairs.  This should help students start off in the right direction.\r\n\r\nTeachers play a vital role in computer science education and supporting a collaborative and vibrant classroom environment. During online activities, the role of the teacher is primarily one of encouragement and support. Online lessons are meant to be student-centered, so teachers should avoid stepping in when students get stuck. Some ideas on how to do this are: \r\n\r\n - Utilize pair programming whenever possible during the activity.\r\n - Encourage students with questions/challenges to start by asking their partner.\r\n - Unanswered questions can be escalated to a nearby group, who might already know the solution.\r\n - Remind students to use the debugging process before you approach.\r\n - Have students describe the problem that they’re seeing. What is it supposed to do? What does it do? What does that tell you?\r\n - Remind frustrated students that frustration is a step on the path to learning, and that persistence will pay off.\r\n - If a student is still stuck after all of this, ask leading questions to get the student to spot an error on their own.",
+        "description": "This will teach students how to use Code.org to complete online puzzles.\r\n\r\nThis stage was designed to give students the opportunity to practice hand-eye coordination, clicking, and drag & drop skills.  Students will also play with sequence.\r\n\r\nThe vocabulary introduced in this lesson becomes relevant during this activity.  Take some time to explicitly teach how to click, double-click, drag, and drop.  It might work better for you to cover these words in the classroom environment where you can lead by example -- or it might make more sense to teach the words individually as students work on their puzzles in the lab.  You will need to decide what you believe is best for your class.\r\n\r\nWatch the [r pair-programming-vid/pre-express/2021] with your students, then assign them to pairs.  This should help students start off in the right direction.\r\n\r\nTeachers play a vital role in computer science education and supporting a collaborative and vibrant classroom environment. During online activities, the role of the teacher is primarily one of encouragement and support. Online lessons are meant to be student-centered, so teachers should avoid stepping in when students get stuck. Some ideas on how to do this are: \r\n\r\n - Utilize pair programming whenever possible during the activity.\r\n - Encourage students with questions/challenges to start by asking their partner.\r\n - Unanswered questions can be escalated to a nearby group, who might already know the solution.\r\n - Remind students to use the debugging process before you approach.\r\n - Have students describe the problem that they’re seeing. What is it supposed to do? What does it do? What does that tell you?\r\n - Remind frustrated students that frustration is a step on the path to learning, and that persistence will pay off.\r\n - If a student is still stuck after all of this, ask leading questions to get the student to spot an error on their own.",
         "name": "Online Puzzles\r"
       },
       "seeding_key": {
@@ -1271,7 +1271,7 @@
       "key": "51b1c494-c02c-43d8-bf3d-543f6634f474",
       "position": 1,
       "properties": {
-        "description": "Give the students a journal prompt to help them process some of the things that they encountered during the day.\r\n\r\n#### Journal Prompts:\r\n\r\n - Can you draw a sequence for getting ready to go to the computer lab?\r\n - Draw a computer lab \"Do\" and a \"Don't\"\r\n - Draw one of the [r feeling-faces-image] that shows how you felt about today's lesson in the corner of your journal page.",
+        "description": "Give the students a journal prompt to help them process some of the things that they encountered during the day.\r\n\r\n#### Journal Prompts:\r\n\r\n - Can you draw a sequence for getting ready to go to the computer lab?\r\n - Draw a computer lab \"Do\" and a \"Don't\"\r\n - Draw one of the [r feeling-faces-image/pre-express/2021] that shows how you felt about today's lesson in the corner of your journal page.",
         "name": "Journaling\r"
       },
       "seeding_key": {
@@ -1283,7 +1283,7 @@
       "key": "f810e0b8-71b7-4b54-8c8b-4205a471ca3b",
       "position": 1,
       "properties": {
-        "description": "If students complete the puzzles from this lesson early, have them spend some time trying to come up with their own puzzles in their [r think-spot-journal]."
+        "description": "If students complete the puzzles from this lesson early, have them spend some time trying to come up with their own puzzles in their [r think-spot-journal/pre-express/2021]."
       },
       "seeding_key": {
         "activity_section.key": "f810e0b8-71b7-4b54-8c8b-4205a471ca3b",
@@ -1332,7 +1332,7 @@
       "key": "05a3fac8-cfa8-4886-8e14-e93470dc60cd",
       "position": 2,
       "properties": {
-        "description": "**Circulate:** Teachers play a vital role in computer science education and supporting a collaborative and vibrant classroom environment. During online activities, the role of the teacher is primarily one of encouragement and support. Online lessons are meant to be student-centered, so teachers should avoid stepping in when students get stuck. Some ideas on how to do this are: \r\n\r\n - Utilize [r pair-programming-vid] whenever possible\r\n - Encourage students with questions/challenges to start by asking their partner\r\n - Unanswered questions can be escalated to a nearby group, who might already know the solution\r\n - Remind students to use the debugging process before you approach\r\n - Have students describe the problem that they’re seeing. What is it supposed to do? What does it do? What does that tell you?\r\n - Remind frustrated students that frustration is a step on the path to learning, and that persistence will pay off\r\n - If a student is still stuck after all of this, ask leading questions to get the student to spot an error on their own",
+        "description": "**Circulate:** Teachers play a vital role in computer science education and supporting a collaborative and vibrant classroom environment. During online activities, the role of the teacher is primarily one of encouragement and support. Online lessons are meant to be student-centered, so teachers should avoid stepping in when students get stuck. Some ideas on how to do this are: \r\n\r\n - Utilize [r pair-programming-vid/pre-express/2021] whenever possible\r\n - Encourage students with questions/challenges to start by asking their partner\r\n - Unanswered questions can be escalated to a nearby group, who might already know the solution\r\n - Remind students to use the debugging process before you approach\r\n - Have students describe the problem that they’re seeing. What is it supposed to do? What does it do? What does that tell you?\r\n - Remind frustrated students that frustration is a step on the path to learning, and that persistence will pay off\r\n - If a student is still stuck after all of this, ask leading questions to get the student to spot an error on their own",
         "name": "Online Puzzles\r"
       },
       "seeding_key": {
@@ -1344,7 +1344,7 @@
       "key": "12c1b1b7-2a91-4f58-ae14-136ea1536a67",
       "position": 1,
       "properties": {
-        "description": "Having students write about what they learned, why it’s useful, and how they feel about it can help solidify any knowledge they obtained today and build a review sheet for them to look to in the future.\r\n\r\n#### Journal Prompts:\r\n\r\n - What was today’s lesson about?\r\n - Draw one of the [r feeling-faces-image] that shows how you felt about today's lesson in the corner of your journal page.",
+        "description": "Having students write about what they learned, why it’s useful, and how they feel about it can help solidify any knowledge they obtained today and build a review sheet for them to look to in the future.\r\n\r\n#### Journal Prompts:\r\n\r\n - What was today’s lesson about?\r\n - Draw one of the [r feeling-faces-image/pre-express/2021] that shows how you felt about today's lesson in the corner of your journal page.",
         "name": "Journaling\r"
       },
       "seeding_key": {
@@ -1389,7 +1389,7 @@
       "key": "720aa090-bf1d-4934-9c4f-f8cad6b511ac",
       "position": 1,
       "properties": {
-        "description": "As we mentioned in the last lesson, we highly recommend viewing and using [r pair-programming-vid] as a class. Pair programming stimulates a discussion that can answer questions, review basic concepts, and build confidence with the subject.",
+        "description": "As we mentioned in the last lesson, we highly recommend viewing and using [r pair-programming-vid/pre-express/2021] as a class. Pair programming stimulates a discussion that can answer questions, review basic concepts, and build confidence with the subject.",
         "name": "Online Puzzles\r"
       },
       "seeding_key": {
@@ -1401,7 +1401,7 @@
       "key": "4f8c5eb5-a782-4698-a471-19808d1dbbc4",
       "position": 1,
       "properties": {
-        "description": "Having students write about what they learned, why it’s useful, and how they feel about it can help solidify any knowledge they obtained today and build a review sheet for them to look to in the future.\r\n\r\n#### Journal Prompts:\r\n\r\n - What was today’s lesson about?\r\n - Draw one of the [r feeling-faces-image] that shows how you felt about today's lesson in the corner of your journal page.\r\n - Draw a picture of BB-8 you guided through the maze today and add a list of the commands that you used.",
+        "description": "Having students write about what they learned, why it’s useful, and how they feel about it can help solidify any knowledge they obtained today and build a review sheet for them to look to in the future.\r\n\r\n#### Journal Prompts:\r\n\r\n - What was today’s lesson about?\r\n - Draw one of the [r feeling-faces-image/pre-express/2021] that shows how you felt about today's lesson in the corner of your journal page.\r\n - Draw a picture of BB-8 you guided through the maze today and add a list of the commands that you used.",
         "name": "Journaling\r"
       },
       "seeding_key": {
@@ -1463,7 +1463,7 @@
       "key": "94b18069-db8a-43d7-bbf0-8912ac563349",
       "position": 1,
       "properties": {
-        "description": "Having students write about what they learned, why it’s useful, and how they feel about it can help solidify any knowledge they obtained today and build a review sheet for them to look to in the future.\r\n\r\n#### Journal Prompts:\r\n\r\n - What was today’s lesson about?\r\n - Draw one of the [r feeling-faces-image] that shows how you felt about today's lesson in the corner of your journal page.\r\n - Draw a time you found a bug in your code.",
+        "description": "Having students write about what they learned, why it’s useful, and how they feel about it can help solidify any knowledge they obtained today and build a review sheet for them to look to in the future.\r\n\r\n#### Journal Prompts:\r\n\r\n - What was today’s lesson about?\r\n - Draw one of the [r feeling-faces-image/pre-express/2021] that shows how you felt about today's lesson in the corner of your journal page.\r\n - Draw a time you found a bug in your code.",
         "name": "Journaling\r"
       },
       "seeding_key": {
@@ -1553,7 +1553,7 @@
       "key": "9a875694-a4f4-4cd2-8bf8-31f8441d4a50",
       "position": 3,
       "properties": {
-        "description": "**Circulate:** Teachers play a vital role in computer science education and supporting a collaborative and vibrant classroom environment. During online activities, the role of the teacher is primarily one of encouragement and support. Online lessons are meant to be student-centered, so teachers should avoid stepping in when students get stuck. Some ideas on how to do this are: \r\n\r\n - Utilize [r pair-programming-vid] whenever possible\r\n - Encourage students with questions/challenges to start by asking their partner\r\n - Unanswered questions can be escalated to a nearby group, who might already know the solution\r\n - Remind students to use the debugging process before you approach\r\n - Have students describe the problem that they’re seeing. What is it supposed to do? What does it do? What does that tell you?\r\n - Remind frustrated students that frustration is a step on the path to learning, and that persistence will pay off.\r\n - If a student is still stuck after all of this, ask leading questions to get the student to spot an error on their own.",
+        "description": "**Circulate:** Teachers play a vital role in computer science education and supporting a collaborative and vibrant classroom environment. During online activities, the role of the teacher is primarily one of encouragement and support. Online lessons are meant to be student-centered, so teachers should avoid stepping in when students get stuck. Some ideas on how to do this are: \r\n\r\n - Utilize [r pair-programming-vid/pre-express/2021] whenever possible\r\n - Encourage students with questions/challenges to start by asking their partner\r\n - Unanswered questions can be escalated to a nearby group, who might already know the solution\r\n - Remind students to use the debugging process before you approach\r\n - Have students describe the problem that they’re seeing. What is it supposed to do? What does it do? What does that tell you?\r\n - Remind frustrated students that frustration is a step on the path to learning, and that persistence will pay off.\r\n - If a student is still stuck after all of this, ask leading questions to get the student to spot an error on their own.",
         "name": "Online Puzzles\r"
       },
       "seeding_key": {
@@ -1565,7 +1565,7 @@
       "key": "0366b799-b555-4aef-b6c7-741c035590aa",
       "position": 1,
       "properties": {
-        "description": "Having students write about what they learned, why it’s useful, and how they feel about it can help solidify any knowledge they obtained today and build a review sheet for them to look to in the future.\r\n\r\n#### Journal Prompts:\r\n\r\n - What was today’s lesson about?\r\n - Draw one of the [r feeling-faces-image] that shows how you felt about today's lesson in the corner of your journal page.\r\n - Draw Scrat and an acorn.\r\n - Draw yourself using a loop to do an everyday activity, like brushing your teeth.",
+        "description": "Having students write about what they learned, why it’s useful, and how they feel about it can help solidify any knowledge they obtained today and build a review sheet for them to look to in the future.\r\n\r\n#### Journal Prompts:\r\n\r\n - What was today’s lesson about?\r\n - Draw one of the [r feeling-faces-image/pre-express/2021] that shows how you felt about today's lesson in the corner of your journal page.\r\n - Draw Scrat and an acorn.\r\n - Draw yourself using a loop to do an everyday activity, like brushing your teeth.",
         "name": "Journaling\r"
       },
       "seeding_key": {
@@ -1645,7 +1645,7 @@
       "key": "6397718f-1733-47e6-8ace-820b3f9d1701",
       "position": 1,
       "properties": {
-        "description": "Having students write about what they learned, why it’s useful, and how they feel about it can help solidify any knowledge they obtained today and build a review sheet for them to look to in the future.\r\n\r\n#### Journal Prompts:\r\n\r\n - What was today’s lesson about?\r\n - Draw one of the [r feeling-faces-image] that shows how you felt about today's lesson in the corner of your journal page.\r\n - Draw a line of treasure that Laurel could collect.\r\n - Draw something that uses loops.",
+        "description": "Having students write about what they learned, why it’s useful, and how they feel about it can help solidify any knowledge they obtained today and build a review sheet for them to look to in the future.\r\n\r\n#### Journal Prompts:\r\n\r\n - What was today’s lesson about?\r\n - Draw one of the [r feeling-faces-image/pre-express/2021] that shows how you felt about today's lesson in the corner of your journal page.\r\n - Draw a line of treasure that Laurel could collect.\r\n - Draw something that uses loops.",
         "name": "Journaling\r"
       },
       "seeding_key": {
@@ -1695,7 +1695,7 @@
           {
             "key": "tip",
             "type": "teachingTip",
-            "markdown": "Remind the students to only share their work with their close friends or family. For more information watch or show the class [r common-sense-media-pause-think].\r\n"
+            "markdown": "Remind the students to only share their work with their close friends or family. For more information watch or show the class [r common-sense-media-pause-think/pre-express/2021].\r\n"
           }
         ]
       },
@@ -1719,7 +1719,7 @@
       "key": "7043a915-b252-47d3-bb01-5975d613129c",
       "position": 1,
       "properties": {
-        "description": "Having students write about what they learned, why it’s useful, and how they feel about it can help solidify any knowledge they obtained today and build a review sheet for them to look to in the future.\r\n\r\n#### Journal Prompts:\r\n\r\n - What was today’s lesson about?\r\n - Draw one of the [r feeling-faces-image] that shows how you felt about today's lesson in the corner of your journal page.\r\n - Draw some stairs. Imagine the loop needed to draw this.\r\n - Draw something else in your life that uses loops.",
+        "description": "Having students write about what they learned, why it’s useful, and how they feel about it can help solidify any knowledge they obtained today and build a review sheet for them to look to in the future.\r\n\r\n#### Journal Prompts:\r\n\r\n - What was today’s lesson about?\r\n - Draw one of the [r feeling-faces-image/pre-express/2021] that shows how you felt about today's lesson in the corner of your journal page.\r\n - Draw some stairs. Imagine the loop needed to draw this.\r\n - Draw something else in your life that uses loops.",
         "name": "Journaling\r"
       },
       "seeding_key": {
@@ -1769,7 +1769,7 @@
           {
             "key": "tip",
             "type": "teachingTip",
-            "markdown": "Remind the students to only share their work with their close friends or family. For more information watch or show the class [r common-sense-media-pause-think].\r\n"
+            "markdown": "Remind the students to only share their work with their close friends or family. For more information watch or show the class [r common-sense-media-pause-think/pre-express/2021].\r\n"
           }
         ]
       },
@@ -1793,7 +1793,7 @@
       "key": "e382cc47-35ef-4c10-80a1-4b9090d86856",
       "position": 1,
       "properties": {
-        "description": "Having students write about what they learned, why it’s useful, and how they feel about it can help solidify any knowledge they obtained today and build a review sheet for them to look to in the future.\r\n\r\n#### Journal Prompts:\r\n\r\n - What was today’s lesson about?\r\n - Draw one of the [r feeling-faces-image] that shows how you felt about today's lesson in the corner of your journal page.\r\n - Draw the patterns you made with a loop.\r\n - Draw a pattern that you would like to make with a loop.",
+        "description": "Having students write about what they learned, why it’s useful, and how they feel about it can help solidify any knowledge they obtained today and build a review sheet for them to look to in the future.\r\n\r\n#### Journal Prompts:\r\n\r\n - What was today’s lesson about?\r\n - Draw one of the [r feeling-faces-image/pre-express/2021] that shows how you felt about today's lesson in the corner of your journal page.\r\n - Draw the patterns you made with a loop.\r\n - Draw a pattern that you would like to make with a loop.",
         "name": "Journaling\r"
       },
       "seeding_key": {
@@ -1869,7 +1869,7 @@
       "key": "9336ef6c-3ac8-4703-8f8d-98e88518e5e9",
       "position": 1,
       "properties": {
-        "description": "Having students write about what they learned, why it’s useful, and how they feel about it can help solidify any knowledge they obtained today and build a review sheet for them to look to in the future.\r\n\r\n#### Journal Prompts:\r\n\r\n - What was today’s lesson about?\r\n - Draw one of the [r feeling-faces-image] that shows how you felt about today's lesson in the corner of your journal page.\r\n - Draw an event you used in your program today.\r\n - Imagine that you have a remote controlled robot. What would the remote look like? Draw a picture of what you think you could make the robot do.",
+        "description": "Having students write about what they learned, why it’s useful, and how they feel about it can help solidify any knowledge they obtained today and build a review sheet for them to look to in the future.\r\n\r\n#### Journal Prompts:\r\n\r\n - What was today’s lesson about?\r\n - Draw one of the [r feeling-faces-image/pre-express/2021] that shows how you felt about today's lesson in the corner of your journal page.\r\n - Draw an event you used in your program today.\r\n - Imagine that you have a remote controlled robot. What would the remote look like? Draw a picture of what you think you could make the robot do.",
         "name": "Journaling\r"
       },
       "seeding_key": {
@@ -1918,7 +1918,7 @@
           {
             "key": "tip",
             "type": "teachingTip",
-            "markdown": "Students will have the opportunity to share their final product with a link. This is a great opportunity to show your school community the great things your students are doing. Collect all of the links and keep them on your class website for all to see!\r\n\r\nRemind the students to only share their work with their close friends or family. For more information watch or show the class [r common-sense-media-pause-think].\r\n\r\n"
+            "markdown": "Students will have the opportunity to share their final product with a link. This is a great opportunity to show your school community the great things your students are doing. Collect all of the links and keep them on your class website for all to see!\r\n\r\nRemind the students to only share their work with their close friends or family. For more information watch or show the class [r common-sense-media-pause-think/pre-express/2021].\r\n\r\n"
           }
         ]
       },
@@ -1955,7 +1955,7 @@
       "key": "00695f27-0eaf-43ef-bbd4-bd7879fbaa1c",
       "position": 1,
       "properties": {
-        "description": "Having students write about what they learned, why it’s useful, and how they feel about it can help solidify any knowledge they obtained today and build a review sheet for them to look to in the future.\r\n\r\n#### Journal Prompts:\r\n\r\n - What was today’s lesson about?\r\n - Draw one of the [r feeling-faces-image] that shows how you felt about today's lesson in the corner of your journal page.\r\n - Draw an event you used in your program today.\r\n - Imagine that you have a remote controlled robot. What would the remote look like? Draw a picture of what you think you could make the robot do.",
+        "description": "Having students write about what they learned, why it’s useful, and how they feel about it can help solidify any knowledge they obtained today and build a review sheet for them to look to in the future.\r\n\r\n#### Journal Prompts:\r\n\r\n - What was today’s lesson about?\r\n - Draw one of the [r feeling-faces-image/pre-express/2021] that shows how you felt about today's lesson in the corner of your journal page.\r\n - Draw an event you used in your program today.\r\n - Imagine that you have a remote controlled robot. What would the remote look like? Draw a picture of what you think you could make the robot do.",
         "name": "Journaling\r"
       },
       "seeding_key": {

--- a/dashboard/lib/services/markdown_preprocessor.rb
+++ b/dashboard/lib/services/markdown_preprocessor.rb
@@ -40,6 +40,7 @@ module Services
     # Returns the key which can be used to create the reference syntax for the
     # given Vocabulary object.
     def self.build_vocab_key(vocab)
+      return unless vocab&.course_version&.course_offering.present?
       [vocab.key, vocab.course_version.course_offering.key, vocab.course_version.key].join('/')
     end
 
@@ -72,6 +73,7 @@ module Services
     # Returns the key which can be used to create the reference syntax for the
     # given Resource object.
     def self.build_resource_key(resource)
+      return unless resource&.course_version&.course_offering.present?
       [resource.key, resource.course_version.course_offering.key, resource.course_version.key].join('/')
     end
 

--- a/dashboard/lib/services/markdown_preprocessor.rb
+++ b/dashboard/lib/services/markdown_preprocessor.rb
@@ -37,8 +37,18 @@ module Services
       end
     end
 
+    # Returns the key which can be used to create the reference syntax for the
+    # given Vocabulary object.
+    def self.build_vocab_key(vocab)
+      [vocab.key, vocab.course_version.course_offering.key, vocab.course_version.key].join('/')
+    end
+
     # Returns a copy of `content` with all occurrences of Vocabulary references
-    # substituted with the equivalent HTML span
+    # substituted with the equivalent HTML span.
+    #
+    # Vocabulary references take the form of:
+    # `[v vocab_key/course_offering_key/course_version_key]`
+    # For example: `[v loops/coursea/2020]`
     def self.sub_vocab_definitions(content)
       sub_vocab_definitions!(content.dup)
     end
@@ -46,8 +56,11 @@ module Services
     # Performs the substitutions of MarkdownPreprocessor#sub_vocab_definitions
     # in place
     def self.sub_vocab_definitions!(content)
-      content.gsub!(/\[v (#{Vocabulary::KEY_CHAR_RE}+)\]/) do |match|
-        vocab = Vocabulary.find_by(key: $1)
+      vocab_def_re = build_key_re('v', [Vocabulary, CourseOffering, CourseVersion])
+      content.gsub!(vocab_def_re) do |match|
+        course_version = CourseVersion.joins(:course_offering).
+          find_by(key: $3, "course_offerings.key": $2)
+        vocab = Vocabulary.find_by(key: $1, course_version: course_version)
         if vocab.present?
           "<span class=\"vocab\" title=#{vocab.definition.inspect}>#{vocab.word}</span>"
         else
@@ -56,8 +69,18 @@ module Services
       end
     end
 
+    # Returns the key which can be used to create the reference syntax for the
+    # given Resource object.
+    def self.build_resource_key(resource)
+      [resource.key, resource.course_version.course_offering.key, resource.course_version.key].join('/')
+    end
+
     # Returns a copy of `content` with all occurrences of Resource links
     # substituted with the equivalent Markdown links
+    #
+    # Resource links take the form of:
+    # `[r resource_key/course_offering_key/course_version_key]`
+    # For example: `[r example-video/csd/2021]`
     def self.sub_resource_links(content)
       sub_resource_links!(content.dup)
     end
@@ -65,15 +88,30 @@ module Services
     # Performs the substitutions of MarkdownPreprocessor#sub_resource_links in
     # place
     def self.sub_resource_links!(content)
-      content.gsub!(/\[r (#{Resource::KEY_CHAR_RE}+)\]/) do |match|
-        # apparently "$1" is how ruby expects us to get match data in a block
-        resource = Resource.find_by(key: $1)
+      resource_link_re = build_key_re('r', [Resource, CourseOffering, CourseVersion])
+      content.gsub!(resource_link_re) do |match|
+        course_version = CourseVersion.joins(:course_offering).
+          find_by(key: $3, "course_offerings.key": $2)
+        resource = Resource.find_by(key: $1, course_version: course_version)
         if resource.present?
           "[#{resource.name}](#{resource.url})"
         else
           match
         end
       end
+    end
+
+    # Simple helper which builds out a regex from the given identifier and
+    # models. Requires that the models define a KEY_CHAR_RE which can be used
+    # to identify valid `key` values for the model.
+    #
+    # Specifically, given an identifier "foo" and models Bar and Baz, we will
+    # get a regex which matches strings of the form `[foo bar_key/baz_key]`
+    def self.build_key_re(identifier, models)
+      keys = models.map do |model|
+        "(#{model::KEY_CHAR_RE}+)"
+      end
+      return /\[#{identifier} #{keys.join('/')}\]/
     end
   end
 end

--- a/dashboard/test/lib/services/markdown_preprocessor_test.rb
+++ b/dashboard/test/lib/services/markdown_preprocessor_test.rb
@@ -2,14 +2,36 @@ require 'test_helper'
 
 class Services::MarkdownPreprocessorTest < ActiveSupport::TestCase
   setup do
-    create :resource, key: 'first-resource', name: "First Resource", url: "example.com/first"
-    create :resource, key: 'second-resource', name: "Second Resource", url: "example.com/second"
-    create :vocabulary, key: 'first_vocab', word: "First Vocabulary", definition: "The first of the vocabulary entries."
-    create :vocabulary, key: 'second_vocab', word: "Second Vocabulary", definition: "The second of the vocabulary entries."
+    course_offering = create :course_offering, key: 'test-course'
+    course_version = create :course_version,
+      course_offering: course_offering,
+      key: '1999'
+
+    @first_resource = create :resource,
+      key: 'first-resource',
+      name: "First Resource",
+      url: "example.com/first",
+      course_version: course_version
+    create :resource,
+      key: 'second-resource',
+      name: "Second Resource",
+      url: "example.com/second",
+      course_version: course_version
+
+    @first_vocabulary = create :vocabulary,
+      key: 'first_vocab',
+      word: "First Vocabulary",
+      definition: "The first of the vocabulary entries.",
+      course_version: course_version
+    create :vocabulary,
+      key: 'second_vocab',
+      word: "Second Vocabulary",
+      definition: "The second of the vocabulary entries.",
+      course_version: course_version
   end
 
   test 'process method invokes both resource and vocab substitutions' do
-    input = "A string containing both a Resource link [r first-resource] and a Vocab link [v first_vocab]"
+    input = "A string containing both a Resource link [r first-resource/test-course/1999] and a Vocab link [v first_vocab/test-course/1999]"
     result = Services::MarkdownPreprocessor.process(input)
     expected = "A string containing both a Resource link [First Resource](example.com/first) and a Vocab link <span class=\"vocab\" title=\"The first of the vocabulary entries.\">First Vocabulary</span>"
     assert_equal expected, result
@@ -17,10 +39,10 @@ class Services::MarkdownPreprocessorTest < ActiveSupport::TestCase
 
   test 'process is cached' do
     Rails.cache.clear
-    input = "[r first-resource]"
+    input = "[r first-resource/test-course/1999]"
 
     # First invocation queries the database
-    assert_queries 1 do
+    assert_queries 2 do
       Services::MarkdownPreprocessor.process(input)
     end
 
@@ -30,19 +52,19 @@ class Services::MarkdownPreprocessorTest < ActiveSupport::TestCase
     end
 
     # Each content string is cached individually
-    assert_queries 1 do
-      Services::MarkdownPreprocessor.process("[r second-resource]")
+    assert_queries 2 do
+      Services::MarkdownPreprocessor.process("[r second-resource/test-course/1999]")
     end
 
     # Clearing the cache causes us to start querying again
     Rails.cache.clear
-    assert_queries 1 do
+    assert_queries 2 do
       Services::MarkdownPreprocessor.process(input)
     end
   end
 
   test 'process caching can be modified with options' do
-    input = "[r first-resource][v first_vocab]"
+    input = "[r first-resource/test-course/1999][v first_vocab/test-course/1999]"
 
     # populate the cache
     Services::MarkdownPreprocessor.process(input)
@@ -53,20 +75,20 @@ class Services::MarkdownPreprocessorTest < ActiveSupport::TestCase
     end
 
     # verify that the cache can be skipped
-    assert_queries 2 do
+    assert_queries 3 do
       Services::MarkdownPreprocessor.process(input, cache_options: {force: true})
     end
   end
 
   test 'regular method process returns and does not modify' do
-    input = "[r first-resource]"
+    input = "[r first-resource/test-course/1999]"
     result = Services::MarkdownPreprocessor.process(input)
-    assert_equal "[r first-resource]", input
+    assert_equal "[r first-resource/test-course/1999]", input
     assert_equal "[First Resource](example.com/first)", result
   end
 
   test 'bang method process! modifies and returns' do
-    input = "[v first_vocab]"
+    input = "[v first_vocab/test-course/1999]"
     expected = "<span class=\"vocab\" title=\"The first of the vocabulary entries.\">First Vocabulary</span>"
 
     result = Services::MarkdownPreprocessor.process!(input)
@@ -75,7 +97,7 @@ class Services::MarkdownPreprocessorTest < ActiveSupport::TestCase
   end
 
   test 'sub_resource_links can substitute a basic resource link' do
-    input = "this string has a resource [r first-resource] link. And a [regular](link)"
+    input = "this string has a resource [r first-resource/test-course/1999] link. And a [regular](link)"
     expected = "this string has a resource [First Resource](example.com/first) link. And a [regular](link)"
 
     result = Services::MarkdownPreprocessor.sub_resource_links(input)
@@ -83,7 +105,7 @@ class Services::MarkdownPreprocessorTest < ActiveSupport::TestCase
   end
 
   test 'sub_resource_links can handle multiple resource links in a single string' do
-    input = "this string has [r second-resource] two resource [r first-resource] links"
+    input = "this string has [r second-resource/test-course/1999] two resource [r first-resource/test-course/1999] links"
     expected = "this string has [Second Resource](example.com/second) two resource [First Resource](example.com/first) links"
 
     result = Services::MarkdownPreprocessor.sub_resource_links(input)
@@ -96,8 +118,8 @@ class Services::MarkdownPreprocessorTest < ActiveSupport::TestCase
 
       It has:
 
-      1. A list with [r first-resource] a link
-      2. A **formatted [r second-resource] link**
+      1. A list with [r first-resource/test-course/1999] a link
+      2. A **formatted [r second-resource/test-course/1999] link**
 
       We also demonstrate that the markdown preprocessor we have doesn't
       respect markdown, and will replace stuff that actual markdown would leave
@@ -105,7 +127,7 @@ class Services::MarkdownPreprocessorTest < ActiveSupport::TestCase
 
       ```
       like code blocks
-      [r first-resource]
+      [r first-resource/test-course/1999]
       ```
     MARKDOWN
     expected = <<~MARKDOWN
@@ -131,13 +153,13 @@ class Services::MarkdownPreprocessorTest < ActiveSupport::TestCase
   end
 
   test 'sub_resource_links ignores unmatched resource keys' do
-    input = "this string has a resource [r nonexistent-resource] link. And a [regular](link)"
+    input = "this string has a resource [r nonexistent-resource/test-course/1999] link. And a [regular](link)"
     result = Services::MarkdownPreprocessor.sub_resource_links(input)
     assert_equal input, result
   end
 
   test 'sub_vocab_definitions can substitute a basic vocab definition' do
-    input = "this string has a vocab [v first_vocab] definition."
+    input = "this string has a vocab [v first_vocab/test-course/1999] definition."
     expected = "this string has a vocab <span class=\"vocab\" title=\"The first of the vocabulary entries.\">First Vocabulary</span> definition."
 
     result = Services::MarkdownPreprocessor.sub_vocab_definitions(input)
@@ -145,7 +167,7 @@ class Services::MarkdownPreprocessorTest < ActiveSupport::TestCase
   end
 
   test 'sub_vocab_definitions can handle multiple vocab definitions in a single string' do
-    input = "this string has [v second_vocab] two vocab [v first_vocab] definitions"
+    input = "this string has [v second_vocab/test-course/1999] two vocab [v first_vocab/test-course/1999] definitions"
     expected = "this string has <span class=\"vocab\" title=\"The second of the vocabulary entries.\">Second Vocabulary</span> two vocab <span class=\"vocab\" title=\"The first of the vocabulary entries.\">First Vocabulary</span> definitions"
 
     result = Services::MarkdownPreprocessor.sub_vocab_definitions(input)
@@ -158,8 +180,8 @@ class Services::MarkdownPreprocessorTest < ActiveSupport::TestCase
 
       It has:
 
-      1. A list with [v first_vocab] a definition
-      2. A **formatted [v second_vocab] definition**
+      1. A list with [v first_vocab/test-course/1999] a definition
+      2. A **formatted [v second_vocab/test-course/1999] definition**
 
       We also demonstrate that the markdown preprocessor we have doesn't
       respect markdown, and will replace stuff that actual markdown would leave
@@ -167,7 +189,7 @@ class Services::MarkdownPreprocessorTest < ActiveSupport::TestCase
 
       ```
       like code blocks
-      [v first_vocab]
+      [v first_vocab/test-course/1999]
       ```
     MARKDOWN
     expected = <<~MARKDOWN
@@ -193,8 +215,36 @@ class Services::MarkdownPreprocessorTest < ActiveSupport::TestCase
   end
 
   test 'sub_vocab_definitions ignores unmatched vocab keys' do
-    input = "this string has a vocab [v nonexistent_vocab] definition."
+    input = "this string has a vocab [v nonexistent_vocab/test-course/1999] definition."
     result = Services::MarkdownPreprocessor.sub_vocab_definitions(input)
     assert_equal input, result
+  end
+
+  test 'build_key_re' do
+    module Foo
+      KEY_CHAR_RE = /f/
+    end
+
+    basic_re = Services::MarkdownPreprocessor.build_key_re('test', [Foo])
+    # see https://stackoverflow.com/a/34026971/1810460 for an explanation of `?-mix`
+    assert_equal(/\[test ((?-mix:f)+)\]/, basic_re)
+    assert_match(basic_re, "[test ffffffff]")
+
+    module Bar
+      KEY_CHAR_RE = /b/
+    end
+
+    assert_equal(/\[test ((?-mix:f)+)\/((?-mix:b)+)\]/, Services::MarkdownPreprocessor.build_key_re('test', [Foo, Bar]))
+    assert_equal(/\[test ((?-mix:b)+)\/((?-mix:f)+)\]/, Services::MarkdownPreprocessor.build_key_re('test', [Bar, Foo]))
+  end
+
+  test 'build_vocab_key' do
+    assert_equal 'first_vocab/test-course/1999',
+      Services::MarkdownPreprocessor.build_vocab_key(@first_vocabulary)
+  end
+
+  test 'build_resource_key' do
+    assert_equal 'first-resource/test-course/1999',
+      Services::MarkdownPreprocessor.build_resource_key(@first_resource)
   end
 end


### PR DESCRIPTION
Reverts code-dot-org/code-dot-org#39515, restoring https://github.com/code-dot-org/code-dot-org/pull/39463

Not sure why these didn't get caught by drone, but the original PR broke some unit tests. Those tests have now been updated in https://github.com/code-dot-org/code-dot-org/pull/39518/commits/acea694c0a4fda4ed29aff6fc3a8b1060edd5682