### PR TITLE
[Artist] Add save image button

### DIFF
--- a/apps/src/imageUtils.js
+++ b/apps/src/imageUtils.js
@@ -177,3 +177,13 @@ export async function toImageData(input) {
     throw new Error('Unable to convert input to ImageData: ' + err);
   }
 }
+
+/**
+ * @param {Blob}
+ */
+export function downloadBlobAsPng(blob) {
+  const download = document.createElement('a');
+  download.href = URL.createObjectURL(blob);
+  download.download = 'image.png';
+  download.click();
+}

--- a/apps/src/imageUtils.js
+++ b/apps/src/imageUtils.js
@@ -181,9 +181,9 @@ export async function toImageData(input) {
 /**
  * @param {Blob}
  */
-export function downloadBlobAsPng(blob) {
+export function downloadBlobAsPng(blob, filename = 'image.png') {
   const download = document.createElement('a');
   download.href = URL.createObjectURL(blob);
-  download.download = 'image.png';
+  download.download = filename;
   download.click();
 }

--- a/apps/src/storage/dataBrowser/dataVisualizer/Snapshot.jsx
+++ b/apps/src/storage/dataBrowser/dataVisualizer/Snapshot.jsx
@@ -4,7 +4,7 @@ import PropTypes from 'prop-types';
 import {connect} from 'react-redux';
 import moment from 'moment';
 import msg from '@cdo/locale';
-import {svgToDataURI} from '@cdo/apps/imageUtils';
+import * as imageUtils from '@cdo/apps/imageUtils';
 import {html2canvas} from '@cdo/apps/util/htmlToCanvasWrapper';
 import BaseDialog from '@cdo/apps/templates/BaseDialog';
 import PendingButton from '@cdo/apps/templates/PendingButton';
@@ -79,11 +79,13 @@ class Snapshot extends React.Component {
     if (!svg) {
       return;
     }
-    svgToDataURI(svg, 'image/png', {renderer: 'native'}).then(imageURI => {
-      if (this.isMounted_) {
-        this.setState({imageSrc: imageURI});
-      }
-    });
+    imageUtils
+      .svgToDataURI(svg, 'image/png', {renderer: 'native'})
+      .then(imageURI => {
+        if (this.isMounted_) {
+          this.setState({imageSrc: imageURI});
+        }
+      });
   };
 
   getPngBlob = async () => {
@@ -111,10 +113,7 @@ class Snapshot extends React.Component {
   save = async () => {
     this.setState({isSavePending: true});
     const pngBlob = await this.getPngBlob();
-    const download = document.createElement('a');
-    download.href = URL.createObjectURL(pngBlob);
-    download.download = 'image.png';
-    download.click();
+    imageUtils.downloadBlobAsPng(pngBlob);
     this.setState({isSavePending: false});
   };
 

--- a/apps/src/turtle/ArtistVisualizationColumn.jsx
+++ b/apps/src/turtle/ArtistVisualizationColumn.jsx
@@ -8,75 +8,75 @@ import ProtectedVisualizationDiv from '../templates/ProtectedVisualizationDiv';
 import SaveImageButton from './SaveImageButton';
 import msg from '@cdo/locale';
 
-var styles = {
+const styles = {
   invisible: {
     visibility: 'hidden'
   }
 };
 
-var ArtistVisualizationColumn = function(props) {
-  return (
-    <span>
-      <ProtectedVisualizationDiv />
-      <GameButtons>
-        {props.showSaveImageButton && (
-          <SaveImageButton displayCanvas={props.displayCanvas} />
-        )}
-        <div id="slider-cell">
-          <svg id="slider" version="1.1" width="150" height="50">
-            {/* Slow icon. */}
-            <clipPath id="slowClipPath">
-              <rect width="26" height="12" x="5" y="14" />
-            </clipPath>
-            <image
-              xlinkHref={props.iconPath}
-              height="42"
-              width="84"
-              x="-21"
-              y="-10"
-              clipPath="url(#slowClipPath)"
-            />
-            {/* Fast icon. */}
-            <clipPath id="fastClipPath">
-              <rect width="26" height="16" x="120" y="10" />
-            </clipPath>
-            <image
-              xlinkHref={props.iconPath}
-              height="42"
-              width="84"
-              x="120"
-              y="-11"
-              clipPath="url(#fastClipPath)"
-            />
-          </svg>
-          {
-            ' ' /* Explicitly insert whitespace so that this behaves like our ejs file*/
-          }
-          <img
-            id="spinner"
-            style={styles.invisible}
-            src="/blockly/media/turtle/loading.gif"
-            height="15"
-            width="15"
-          />{' '}
-          {props.showFinishButton && (
-            <button type="button" id="finishButton" className="share">
-              <img src="/blockly/media/1x1.gif" />
-              {msg.finish()}
-            </button>
+export default class ArtistVisualizationColumn extends React.Component {
+  static propTypes = {
+    showFinishButton: PropTypes.bool.isRequired,
+    showSaveImageButton: PropTypes.bool.isRequired,
+    displayCanvas: PropTypes.instanceOf(HTMLCanvasElement).isRequired,
+    iconPath: PropTypes.string.isRequired
+  };
+
+  render() {
+    return (
+      <span>
+        <ProtectedVisualizationDiv />
+        <GameButtons>
+          {this.props.showSaveImageButton && (
+            <SaveImageButton displayCanvas={this.props.displayCanvas} />
           )}
-        </div>
-      </GameButtons>
-      <BelowVisualization />
-    </span>
-  );
-};
-
-ArtistVisualizationColumn.propTypes = {
-  showFinishButton: PropTypes.bool.isRequired,
-  showSaveImageButton: PropTypes.bool.isRequired,
-  displayCanvas: PropTypes.instanceOf(HTMLCanvasElement).isRequired,
-  iconPath: PropTypes.string.isRequired
-};
-
-module.exports = ArtistVisualizationColumn;
+          <div id="slider-cell">
+            <svg id="slider" version="1.1" width="150" height="50">
+              {/* Slow icon. */}
+              <clipPath id="slowClipPath">
+                <rect width="26" height="12" x="5" y="14" />
+              </clipPath>
+              <image
+                xlinkHref={this.props.iconPath}
+                height="42"
+                width="84"
+                x="-21"
+                y="-10"
+                clipPath="url(#slowClipPath)"
+              />
+              {/* Fast icon. */}
+              <clipPath id="fastClipPath">
+                <rect width="26" height="16" x="120" y="10" />
+              </clipPath>
+              <image
+                xlinkHref={this.props.iconPath}
+                height="42"
+                width="84"
+                x="120"
+                y="-11"
+                clipPath="url(#fastClipPath)"
+              />
+            </svg>
+            {
+              ' ' /* Explicitly insert whitespace so that this behaves like our ejs file*/
+            }
+            <img
+              id="spinner"
+              style={styles.invisible}
+              src="/blockly/media/turtle/loading.gif"
+              height="15"
+              width="15"
+            />{' '}
+            {this.props.showFinishButton && (
+              <button type="button" id="finishButton" className="share">
+                <img src="/blockly/media/1x1.gif" />
+                {msg.finish()}
+              </button>
+            )}
+          </div>
+        </GameButtons>
+        <BelowVisualization />
+      </span>
+    );
+  }
+}

--- a/apps/src/turtle/ArtistVisualizationColumn.jsx
+++ b/apps/src/turtle/ArtistVisualizationColumn.jsx
@@ -1,9 +1,9 @@
-/* global appOptions */
 import PropTypes from 'prop-types';
 import React from 'react';
 
-var GameButtons = require('../templates/GameButtons').default;
-var BelowVisualization = require('../templates/BelowVisualization');
+import GameButtons from '@cdo/apps/templates/GameButtons';
+import BelowVisualization from '../templates/BelowVisualization';
+
 import ProtectedVisualizationDiv from '../templates/ProtectedVisualizationDiv';
 import SaveImageButton from './SaveImageButton';
 import msg from '@cdo/locale';
@@ -15,12 +15,13 @@ var styles = {
 };
 
 var ArtistVisualizationColumn = function(props) {
-  const showSaveImageButton = !!appOptions.level.enableDownloadImage;
   return (
     <span>
       <ProtectedVisualizationDiv />
       <GameButtons>
-        {showSaveImageButton && <SaveImageButton />}
+        {props.showSaveImageButton && (
+          <SaveImageButton displayCanvas={props.displayCanvas} />
+        )}
         <div id="slider-cell">
           <svg id="slider" version="1.1" width="150" height="50">
             {/* Slow icon. */}
@@ -73,6 +74,8 @@ var ArtistVisualizationColumn = function(props) {
 
 ArtistVisualizationColumn.propTypes = {
   showFinishButton: PropTypes.bool.isRequired,
+  showSaveImageButton: PropTypes.bool.isRequired,
+  displayCanvas: PropTypes.instanceOf(HTMLCanvasElement).isRequired,
   iconPath: PropTypes.string.isRequired
 };
 

--- a/apps/src/turtle/ArtistVisualizationColumn.jsx
+++ b/apps/src/turtle/ArtistVisualizationColumn.jsx
@@ -1,9 +1,11 @@
+/* global appOptions */
 import PropTypes from 'prop-types';
 import React from 'react';
 
 var GameButtons = require('../templates/GameButtons').default;
 var BelowVisualization = require('../templates/BelowVisualization');
 import ProtectedVisualizationDiv from '../templates/ProtectedVisualizationDiv';
+import SaveImageButton from './SaveImageButton';
 import msg from '@cdo/locale';
 
 var styles = {
@@ -13,10 +15,12 @@ var styles = {
 };
 
 var ArtistVisualizationColumn = function(props) {
+  const showSaveImageButton = !!appOptions.level.enableDownloadImage;
   return (
     <span>
       <ProtectedVisualizationDiv />
       <GameButtons>
+        {showSaveImageButton && <SaveImageButton />}
         <div id="slider-cell">
           <svg id="slider" version="1.1" width="150" height="50">
             {/* Slow icon. */}

--- a/apps/src/turtle/SaveImageButton.jsx
+++ b/apps/src/turtle/SaveImageButton.jsx
@@ -27,7 +27,7 @@ const styles = {
   }
 };
 
-class SaveImageButton extends React.Component {
+export default class SaveImageButton extends React.Component {
   static propTypes = {
     displayCanvas: PropTypes.instanceOf(HTMLCanvasElement).isRequired
   };
@@ -46,5 +46,3 @@ class SaveImageButton extends React.Component {
     );
   }
 }
-
-export default SaveImageButton;

--- a/apps/src/turtle/SaveImageButton.jsx
+++ b/apps/src/turtle/SaveImageButton.jsx
@@ -1,5 +1,6 @@
+import PropTypes from 'prop-types';
 import React from 'react';
-import msg from '@cdo/locale';
+import i18n from '@cdo/locale';
 import * as imageUtils from '@cdo/apps/imageUtils';
 import color from '@cdo/apps/util/color';
 
@@ -27,20 +28,20 @@ const styles = {
 };
 
 class SaveImageButton extends React.Component {
+  static propTypes = {
+    displayCanvas: PropTypes.instanceOf(HTMLCanvasElement).isRequired
+  };
+
   save = async () => {
-    const canvasEl = document.getElementById('display');
-    const blob = await imageUtils.canvasToBlob(canvasEl);
-    const download = document.createElement('a');
-    download.href = URL.createObjectURL(blob);
-    download.download = 'image.png';
-    download.click();
+    const blob = await imageUtils.canvasToBlob(this.props.displayCanvas);
+    imageUtils.downloadBlobAsPng(blob);
   };
 
   render() {
     return (
       <button type="button" style={styles.button} onClick={this.save}>
         <i style={styles.icon} className="fa fa-fw fa-camera" />
-        {msg.save()}
+        {i18n.save()}
       </button>
     );
   }

--- a/apps/src/turtle/SaveImageButton.jsx
+++ b/apps/src/turtle/SaveImageButton.jsx
@@ -1,0 +1,49 @@
+import React from 'react';
+import msg from '@cdo/locale';
+import * as imageUtils from '@cdo/apps/imageUtils';
+import color from '@cdo/apps/util/color';
+
+const styles = {
+  icon: {
+    lineHeight: 'inherit',
+    color: color.white,
+    paddingRight: 8
+  },
+  container: {
+    lineHeight: '40px',
+    textAlign: 'center',
+    verticalAlign: 'middle',
+    display: 'inline-block',
+    textSize: 'large'
+  },
+  button: {
+    padding: '0px 8px',
+    lineHeight: '40px',
+    borderRadius: 5,
+    backgroundColor: color.cyan,
+    borderColor: color.cyan,
+    color: color.white
+  }
+};
+
+class SaveImageButton extends React.Component {
+  save = async () => {
+    const canvasEl = document.getElementById('display');
+    const blob = await imageUtils.canvasToBlob(canvasEl);
+    const download = document.createElement('a');
+    download.href = URL.createObjectURL(blob);
+    download.download = 'image.png';
+    download.click();
+  };
+
+  render() {
+    return (
+      <button type="button" style={styles.button} onClick={this.save}>
+        <i style={styles.icon} className="fa fa-fw fa-camera" />
+        {msg.save()}
+      </button>
+    );
+  }
+}
+
+export default SaveImageButton;

--- a/apps/src/turtle/artist.js
+++ b/apps/src/turtle/artist.js
@@ -345,6 +345,8 @@ Artist.prototype.init = function(config) {
   var visualizationColumn = (
     <ArtistVisualizationColumn
       showFinishButton={!!config.level.freePlay && !config.level.isProjectLevel}
+      showSaveImageButton={!!config.level.enableDownloadImage}
+      displayCanvas={this.visualization.displayCanvas}
       iconPath={iconPath}
     />
   );

--- a/dashboard/app/models/levels/artist.rb
+++ b/dashboard/app/models/levels/artist.rb
@@ -38,6 +38,7 @@ class Artist < Blockly
     solution_image_url
     auto_run
     validation_enabled
+    enable_download_image
   )
 
   def xml_blocks
@@ -55,7 +56,8 @@ class Artist < Blockly
         user: params[:user],
         game: Game.custom_artist,
         level_num: 'custom',
-        validation_enabled: true
+        validation_enabled: true,
+        enable_download_image: false
       )
     )
   end

--- a/dashboard/app/views/levels/editors/fields/_artist_fields.html.haml
+++ b/dashboard/app/views/levels/editors/fields/_artist_fields.html.haml
@@ -3,6 +3,9 @@
 
 #artist.in.collapse
   .field
+    = render partial: 'levels/editors/fields/checkboxes', locals: {f: f, field_name: :enable_download_image, description: "Enable Download Image"}
+    %p If checked, there will be a button to download the final image as a PNG.
+  .field
     = f.label :slider_speed, 'Slider speed (artist only)'
     %p Number from 0.0 to 1.0 for how fast artist runs. If not set, default is 1.0
     = f.number_field :slider_speed, :step => 0.1


### PR DESCRIPTION
Button to download the artist image as a PNG
![Mar-15-2021 17-24-50](https://user-images.githubusercontent.com/8787187/111238236-ea364f00-85b3-11eb-9468-6bcd615918f1.gif)

- Configurable per level and defaults to Off. That means that there will be no user impact until curriculum decides to turn it on for levels.
- Turns out that the `show/hide artist` block already exists. It can be added to toolboxes by levelbuilders.


## Links

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

- jira ticket: [1485](https://codedotorg.atlassian.net/browse/STAR-1485)

## Testing story
Manual testing

## Follow-up work
- We might want to disable the button while the program is running. I think we can wait for pilot feedback to see if that's desired.

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
