### PR TITLE
Revert "Check files for invalid filenames after each dropbox sync"

### DIFF
--- a/bin/cron/sync_dropbox
+++ b/bin/cron/sync_dropbox
@@ -1,7 +1,5 @@
 #!/usr/bin/env ruby
 require_relative 'only_one'
-require_relative '../../tools/hooks/hooks_utils.rb'
-
 abort 'Script already running' unless only_one_running?(__FILE__)
 
 # This syncs content changes from the shared dropbox folder to our github repo
@@ -47,20 +45,15 @@ while (Time.now - SCRIPT_START) < TOTAL_SECONDS
     # For full details, see unison's man page. Docs are also here: https://www.cis.upenn.edu/~bcpierce/unison/download/releases/stable/unison-manual.html
     command = "unison /home/ubuntu/Dropbox/Shared/#{key} /home/ubuntu/staging/pegasus/#{value} -silent -ignore \"Name .dropbox\" -auto -perms 0 -dontchmod -log -logfile /home/ubuntu/unison.log"
     stdout, stderr, _ = Open3.capture3(command)
-    if stdout == "" && stderr == ""
-      HooksUtils.get_unstaged_files.each do |filename|
-        raise "INVALID FILENAME: #{filename}" if HooksUtils.prohibited?(filename)
-      end
-    else
-      error_message = <<~ERROR_MSG
-                        <!here> Error syncing Dropbox and staging
-                        Dropbox directory: #{key}
-                        pegasus directory: #{value}
-                        stdout: #{stdout}
-                        stderr: #{stderr}
-                      ERROR_MSG
-      logger.record error_message
-    end
+    next if stdout == "" && stderr == ""
+    error_message = <<~ERROR_MSG
+                      <!here> Error syncing Dropbox and staging
+                      Dropbox directory: #{key}
+                      pegasus directory: #{value}
+                      stdout: #{stdout}
+                      stderr: #{stderr}
+                    ERROR_MSG
+    logger.record error_message
   end
   current_time = Time.now
   logger.save

--- a/tools/hooks/hooks_utils.rb
+++ b/tools/hooks/hooks_utils.rb
@@ -13,19 +13,4 @@ class HooksUtils
     Dir.chdir File.expand_path('../../../', __FILE__)
     `git diff --cached --name-only --diff-filter AMR`.split("\n").map(&:chomp).map {|x| File.expand_path("../../../#{x}", __FILE__)}
   end
-
-  # Returns whether a filename should be prohibited from a staging commit. Reasons for this:
-  #   * any file with an extension in {.mp4, .mov} (e.g., 'dashboard/dir/my_bad_file.mov')
-  #   * any file with non-lowercase letters in the extension (e.g., 'dashboard/dir/my_bad_file.PnG')
-  #   * any file with spaces in the name
-  #   * any file in /code.org/public/images/avatars with non-lowercase letters in the filename
-  # @param filename [String] A filename.
-  # @return [Boolean] Whether the filename should be prohibited in a commit.
-  def self.prohibited?(filename)
-    return true if ['.mp4', '.mov'].include? File.extname(filename)
-    return true if File.extname(filename) != File.extname(filename).downcase
-    return true if filename.match?(/\s/)
-    return true if filename.include?('/code.org/public/images/avatars/') && File.basename(filename).downcase != File.basename(filename)
-    false
-  end
 end

--- a/tools/hooks/restrict_staging_changes.rb
+++ b/tools/hooks/restrict_staging_changes.rb
@@ -2,6 +2,21 @@ require_relative 'hooks_utils.rb'
 
 REPO_DIR = File.expand_path('../../../', __FILE__).freeze
 
+# Returns whether a filename should be prohibited from a staging commit. Reasons for this:
+#   * any file with an extension in {.mp4, .mov} (e.g., 'dashboard/dir/my_bad_file.mov')
+#   * any file with non-lowercase letters in the extension (e.g., 'dashboard/dir/my_bad_file.PnG')
+#   * any file with spaces in the name
+#   * any file in /code.org/public/images/avatars with non-lowercase letters in the filename
+# @param filename [String] A filename.
+# @return [Boolean] Whether the filename should be prohibited in a commit.
+def prohibited?(filename)
+  return true if ['.mp4', '.mov'].include? File.extname(filename)
+  return true if File.extname(filename) != File.extname(filename).downcase
+  return true if filename.include?(' ')
+  return true if filename.include?('/code.org/public/images/avatars/') && File.basename(filename).downcase != File.basename(filename)
+  false
+end
+
 def main
   Dir.chdir REPO_DIR
 
@@ -9,7 +24,7 @@ def main
   exit(0) unless branch_name == 'staging'
 
   HooksUtils.get_staged_files.each do |filename|
-    raise "STAGING FILE BLOCKED: #{filename}" if HookUtils.prohibited?(filename)
+    raise "STAGING FILE BLOCKED: #{filename}" if prohibited?(filename)
   end
 end
 


### PR DESCRIPTION
Reverts code-dot-org/code-dot-org#39496. It wasn't working and has a small bug that caused the staging scoop to fail, so reverting for now