### PR TITLE
Clean up existing foorm library config

### DIFF
--- a/dashboard/config/foorm/library/surveys/pd/ayw_inperson_1.0.json
+++ b/dashboard/config/foorm/library/surveys/pd/ayw_inperson_1.0.json
@@ -1,188 +1,187 @@
 {
- "published": true,
- "pages": [
-  {
-   "name": "page1",
-   "elements": [
+  "published": true,
+  "pages": [
     {
-     "type": "panel",
-     "name": "ayw1_panel",
-     "elements": [
-      {
-       "type": "html",
-       "name": "preamble",
-       "html": "<h2>Workshop Activities</h2>\n<p>We're interested in your feedback about how useful the activities in this workshop were for you.</p>\n\n\n<p>For each activity in this workshop, we ask that you <strong>rate how useful that activity was to you <em>personally</em></strong> in terms of your own <strong>learning, development, teaching practice</strong>, etc.</p>\n<table style=\"width: 100%; border: 1px solid black; margin-left: auto; margin-right: auto;\" cellpadding=\"1px\"><caption><span style=\"font-family: arial, helvetica, sans-serif;\"> </span></caption>\n<tbody>\n<tr>\n<td style=\"width: 17%; padding-top: 3px; text-align: center; vertical-align: top;\"><span style=\"font-size: 13.3333px; font-family: arial, helvetica, sans-serif;\"><strong>N/A</strong></span></td>\n<td style=\"width: 20.2282%; padding-top: 3px; text-align: center; vertical-align: top;\"><span style=\"font-family: arial, helvetica, sans-serif;\"><strong><span style=\"font-size: 10pt;\">1<span style=\"color: #ffffff;\">----</span>2</span></strong></span></td>\n<td style=\"width: 21.7718%; text-align: center; vertical-align: top;\"><span style=\"font-family: arial, helvetica, sans-serif;\"><strong><span style=\"font-size: 10pt;\">3<span style=\"color: #ffffff;\">----</span>4<span style=\"color: #ffffff;\">----</span>5</span></strong></span></td>\n<td style=\"width: 20%; text-align: center; vertical-align: top;\"><span style=\"font-family: arial, helvetica, sans-serif;\"><strong><span style=\"font-size: 10pt;\">6<span style=\"color: #ffffff;\">----</span>7</span></strong></span></td>\n</tr>\n<tr>\n<td style=\"width: 17%; text-align: center; vertical-align: middle;\"><span style=\"font-size: 10pt; font-family: arial, helvetica, sans-serif;\">I don't recognize this / I don't believe we did this today</span></td>\n<td style=\"width: 20.2282%; text-align: center; vertical-align: middle;\"><span style=\"font-size: 10pt; font-family: arial, helvetica, sans-serif;\">Not useful to me</span></td>\n<td style=\"width: 21.7718%; text-align: center; vertical-align: middle;\"><span style=\"font-size: 10pt; font-family: arial, helvetica, sans-serif;\">Somewhat useful to me</span></td>\n<td style=\"width: 20%; text-align: center; vertical-align: middle;\"><span style=\"font-size: 10pt; font-family: arial, helvetica, sans-serif;\">Very useful to me</span></td>\n</tr>\n</tbody>\n</table>"
-      },
-      {
-       "type": "matrix",
-       "name": "csd_ayw1_activities",
-       "visibleIf": "{workshop_course}='CS Discoveries'",
-       "title": "Please rate the usefulness of these CS Discoveries workshop activities.",
-       "columns": [
+      "elements": [
         {
-         "value": "1",
-         "text": "N/A"
-        },
-        {
-         "value": "2",
-         "text": "1"
-        },
-        {
-         "value": "3",
-         "text": "2"
-        },
-        {
-         "value": "4",
-         "text": "3"
-        },
-        {
-         "value": "5",
-         "text": "4"
-        },
-        {
-         "value": "6",
-         "text": "5"
-        },
-        {
-         "value": "7",
-         "text": "6"
-        },
-        {
-         "value": "8",
-         "text": "7"
+          "type": "panel",
+          "name": "ayw1_panel",
+          "elements": [
+            {
+              "type": "html",
+              "name": "preamble",
+              "html": "<h2>Workshop Activities</h2>\n<p>We're interested in your feedback about how useful the activities in this workshop were for you.</p>\n\n\n<p>For each activity in this workshop, we ask that you <strong>rate how useful that activity was to you <em>personally</em></strong> in terms of your own <strong>learning, development, teaching practice</strong>, etc.</p>\n<table style=\"width: 100%; border: 1px solid black; margin-left: auto; margin-right: auto;\" cellpadding=\"1px\"><caption><span style=\"font-family: arial, helvetica, sans-serif;\"> </span></caption>\n<tbody>\n<tr>\n<td style=\"width: 17%; padding-top: 3px; text-align: center; vertical-align: top;\"><span style=\"font-size: 13.3333px; font-family: arial, helvetica, sans-serif;\"><strong>N/A</strong></span></td>\n<td style=\"width: 20.2282%; padding-top: 3px; text-align: center; vertical-align: top;\"><span style=\"font-family: arial, helvetica, sans-serif;\"><strong><span style=\"font-size: 10pt;\">1<span style=\"color: #ffffff;\">----</span>2</span></strong></span></td>\n<td style=\"width: 21.7718%; text-align: center; vertical-align: top;\"><span style=\"font-family: arial, helvetica, sans-serif;\"><strong><span style=\"font-size: 10pt;\">3<span style=\"color: #ffffff;\">----</span>4<span style=\"color: #ffffff;\">----</span>5</span></strong></span></td>\n<td style=\"width: 20%; text-align: center; vertical-align: top;\"><span style=\"font-family: arial, helvetica, sans-serif;\"><strong><span style=\"font-size: 10pt;\">6<span style=\"color: #ffffff;\">----</span>7</span></strong></span></td>\n</tr>\n<tr>\n<td style=\"width: 17%; text-align: center; vertical-align: middle;\"><span style=\"font-size: 10pt; font-family: arial, helvetica, sans-serif;\">I don't recognize this / I don't believe we did this today</span></td>\n<td style=\"width: 20.2282%; text-align: center; vertical-align: middle;\"><span style=\"font-size: 10pt; font-family: arial, helvetica, sans-serif;\">Not useful to me</span></td>\n<td style=\"width: 21.7718%; text-align: center; vertical-align: middle;\"><span style=\"font-size: 10pt; font-family: arial, helvetica, sans-serif;\">Somewhat useful to me</span></td>\n<td style=\"width: 20%; text-align: center; vertical-align: middle;\"><span style=\"font-size: 10pt; font-family: arial, helvetica, sans-serif;\">Very useful to me</span></td>\n</tr>\n</tbody>\n</table>"
+            },
+            {
+              "type": "matrix",
+              "name": "csd_ayw1_activities",
+              "visibleIf": "{workshop_course}='CS Discoveries'",
+              "title": "Please rate the usefulness of these CS Discoveries workshop activities.",
+              "columns": [
+                {
+                  "value": "1",
+                  "text": "N/A"
+                },
+                {
+                  "value": "2",
+                  "text": "1"
+                },
+                {
+                  "value": "3",
+                  "text": "2"
+                },
+                {
+                  "value": "4",
+                  "text": "3"
+                },
+                {
+                  "value": "5",
+                  "text": "4"
+                },
+                {
+                  "value": "6",
+                  "text": "5"
+                },
+                {
+                  "value": "7",
+                  "text": "6"
+                },
+                {
+                  "value": "8",
+                  "text": "7"
+                }
+              ],
+              "rows": [
+                {
+                  "value": "opener",
+                  "text": "Workshop Opener"
+                },
+                {
+                  "value": "prev_on",
+                  "text": "Previously, On Unit 3"
+                },
+                {
+                  "value": "model_lesson",
+                  "text": "Model Lesson"
+                },
+                {
+                  "value": "model_lesson_reflection",
+                  "text": "Model Lesson Reflection"
+                },
+                {
+                  "value": "prob_solve_debug",
+                  "text": "Problem Solving and Debugging"
+                },
+                {
+                  "value": "curric_investigation",
+                  "text": "Curriculum Investigation"
+                },
+                {
+                  "value": "assessment",
+                  "text": "Assessment"
+                },
+                {
+                  "value": "conclusions_connections",
+                  "text": "Conclusions and Connections"
+                },
+                {
+                  "value": "counseling_scenarios",
+                  "text": "Counseling Scenarios"
+                },
+                {
+                  "value": "wrap_up",
+                  "text": "Wrap Up"
+                }
+              ]
+            },
+            {
+              "type": "matrix",
+              "name": "csp_ayw1_activities",
+              "visibleIf": "{workshop_course}='CS Principles'",
+              "title": "Please rate the usefulness of these CS Principles workshop activities.",
+              "columns": [
+                {
+                  "value": "1",
+                  "text": "N/A"
+                },
+                {
+                  "value": "2",
+                  "text": "1"
+                },
+                {
+                  "value": "3",
+                  "text": "2"
+                },
+                {
+                  "value": "4",
+                  "text": "3"
+                },
+                {
+                  "value": "5",
+                  "text": "4"
+                },
+                {
+                  "value": "6",
+                  "text": "5"
+                },
+                {
+                  "value": "7",
+                  "text": "6"
+                },
+                {
+                  "value": "8",
+                  "text": "7"
+                }
+              ],
+              "rows": [
+                {
+                  "value": "opener",
+                  "text": "Workshop Opener"
+                },
+                {
+                  "value": "intro_u4_eipm",
+                  "text": "Intro to Unit 4 and EIPM"
+                },
+                {
+                  "value": "model_variable_explore",
+                  "text": "Model Lesson - Variables Explore"
+                },
+                {
+                  "value": "model_investigate ",
+                  "text": " Model Lesson - Investigate"
+                },
+                {
+                  "value": "lesson_exploration_var_practice",
+                  "text": "Lesson Exploration - Variables Practice"
+                },
+                {
+                  "value": "lesson_exploration_var_make",
+                  "text": "Lesson Exploration - Variables Make"
+                },
+                {
+                  "value": "eipm",
+                  "text": "Zooming Out - EIPM and the \"Big Picture\""
+                },
+                {
+                  "value": "collaboration_unit4",
+                  "text": "Collaboration and Independent Work in Unit 4"
+                },
+                {
+                  "value": "wrap_up",
+                  "text": "Wrap Up"
+                }
+              ]
+            },
+            {
+              "type": "comment",
+              "name": "other_activities_ayw1",
+              "title": "If you participated in any other activities during this module, please describe them below.",
+              "cols": 40,
+              "rows": 2
+            }
+          ]
         }
-       ],
-       "rows": [
-        {
-         "value": "opener",
-         "text": "Workshop Opener"
-        },
-        {
-         "value": "prev_on",
-         "text": "Previously, On Unit 3"
-        },
-        {
-         "value": "model_lesson",
-         "text": "Model Lesson"
-        },
-        {
-         "value": "model_lesson_reflection",
-         "text": "Model Lesson Reflection"
-        },
-        {
-         "value": "prob_solve_debug",
-         "text": "Problem Solving and Debugging"
-        },
-        {
-         "value": "curric_investigation",
-         "text": "Curriculum Investigation"
-        },
-        {
-         "value": "assessment",
-         "text": "Assessment"
-        },
-        {
-         "value": "conclusions_connections",
-         "text": "Conclusions and Connections"
-        },
-        {
-         "value": "counseling_scenarios",
-         "text": "Counseling Scenarios"
-        },
-        {
-         "value": "wrap_up",
-         "text": "Wrap Up"
-        }
-       ]
-      },
-      {
-       "type": "matrix",
-       "name": "csp_ayw1_activities",
-       "visibleIf": "{workshop_course}='CS Principles'",
-       "title": "Please rate the usefulness of these CS Principles workshop activities.",
-       "columns": [
-        {
-         "value": "1",
-         "text": "N/A"
-        },
-        {
-         "value": "2",
-         "text": "1"
-        },
-        {
-         "value": "3",
-         "text": "2"
-        },
-        {
-         "value": "4",
-         "text": "3"
-        },
-        {
-         "value": "5",
-         "text": "4"
-        },
-        {
-         "value": "6",
-         "text": "5"
-        },
-        {
-         "value": "7",
-         "text": "6"
-        },
-        {
-         "value": "8",
-         "text": "7"
-        }
-       ],
-       "rows": [
-        {
-         "value": "opener",
-         "text": "Workshop Opener"
-        },
-        {
-         "value": "intro_u4_eipm",
-         "text": "Intro to Unit 4 and EIPM"
-        },
-        {
-         "value": "model_variable_explore",
-         "text": "Model Lesson - Variables Explore"
-        },
-        {
-         "value": "model_investigate ",
-         "text": " Model Lesson - Investigate"
-        },
-        {
-         "value": "lesson_exploration_var_practice",
-         "text": "Lesson Exploration - Variables Practice"
-        },
-        {
-         "value": "lesson_exploration_var_make",
-         "text": "Lesson Exploration - Variables Make"
-        },
-        {
-         "value": "eipm",
-         "text": "Zooming Out - EIPM and the \"Big Picture\""
-        },
-        {
-         "value": "collaboration_unit4",
-         "text": "Collaboration and Independent Work in Unit 4"
-        },
-        {
-         "value": "wrap_up",
-         "text": "Wrap Up"
-        }
-       ]
-      },
-      {
-       "type": "comment",
-       "name": "other_activities_ayw1",
-       "title": "If you participated in any other activities during this module, please describe them below.",
-       "cols": 40,
-       "rows": 2
-      }
-     ]
+      ]
     }
-   ]
-  }
- ]
+  ]
 }

--- a/dashboard/config/foorm/library/surveys/pd/ayw_inperson_2.0.json
+++ b/dashboard/config/foorm/library/surveys/pd/ayw_inperson_2.0.json
@@ -1,192 +1,191 @@
 {
- "published": true,
- "pages": [
-  {
-   "name": "page1",
-   "elements": [
+  "published": true,
+  "pages": [
     {
-     "type": "panel",
-     "name": "ayw2_panel",
-     "elements": [
-      {
-       "type": "html",
-       "name": "preamble",
-       "html": "<h2>Workshop Activities</h2>\n<p>We're interested in your feedback about how useful the activities in this workshop were for you.</p>\n\n\n<p>For each activity in this workshop, we ask that you <strong>rate how useful that activity was to you <em>personally</em></strong> in terms of your own <strong>learning, development, teaching practice</strong>, etc.</p>\n<table style=\"width: 100%; border: 1px solid black; margin-left: auto; margin-right: auto;\" cellpadding=\"1px\"><caption><span style=\"font-family: arial, helvetica, sans-serif;\"> </span></caption>\n<tbody>\n<tr>\n<td style=\"width: 17%; padding-top: 3px; text-align: center; vertical-align: top;\"><span style=\"font-size: 13.3333px; font-family: arial, helvetica, sans-serif;\"><strong>N/A</strong></span></td>\n<td style=\"width: 20.2282%; padding-top: 3px; text-align: center; vertical-align: top;\"><span style=\"font-family: arial, helvetica, sans-serif;\"><strong><span style=\"font-size: 10pt;\">1<span style=\"color: #ffffff;\">----</span>2</span></strong></span></td>\n<td style=\"width: 21.7718%; text-align: center; vertical-align: top;\"><span style=\"font-family: arial, helvetica, sans-serif;\"><strong><span style=\"font-size: 10pt;\">3<span style=\"color: #ffffff;\">----</span>4<span style=\"color: #ffffff;\">----</span>5</span></strong></span></td>\n<td style=\"width: 20%; text-align: center; vertical-align: top;\"><span style=\"font-family: arial, helvetica, sans-serif;\"><strong><span style=\"font-size: 10pt;\">6<span style=\"color: #ffffff;\">----</span>7</span></strong></span></td>\n</tr>\n<tr>\n<td style=\"width: 17%; text-align: center; vertical-align: middle;\"><span style=\"font-size: 10pt; font-family: arial, helvetica, sans-serif;\">I don't recognize this / I don't believe we did this today</span></td>\n<td style=\"width: 20.2282%; text-align: center; vertical-align: middle;\"><span style=\"font-size: 10pt; font-family: arial, helvetica, sans-serif;\">Not useful to me</span></td>\n<td style=\"width: 21.7718%; text-align: center; vertical-align: middle;\"><span style=\"font-size: 10pt; font-family: arial, helvetica, sans-serif;\">Somewhat useful to me</span></td>\n<td style=\"width: 20%; text-align: center; vertical-align: middle;\"><span style=\"font-size: 10pt; font-family: arial, helvetica, sans-serif;\">Very useful to me</span></td>\n</tr>\n</tbody>\n</table>"
-      },
-      {
-       "type": "matrix",
-       "name": "csd_ayw2_activities",
-       "visibleIf": "{workshop_course}='CS Discoveries'",
-       "title": "Please rate the usefulness of these CS Discoveries workshop activities.",
-       "columns": [
+      "elements": [
         {
-         "value": "1",
-         "text": "N/A"
-        },
-        {
-         "value": "2",
-         "text": "1"
-        },
-        {
-         "value": "3",
-         "text": "2"
-        },
-        {
-         "value": "4",
-         "text": "3"
-        },
-        {
-         "value": "5",
-         "text": "4"
-        },
-        {
-         "value": "6",
-         "text": "5"
-        },
-        {
-         "value": "7",
-         "text": "6"
-        },
-        {
-         "value": "8",
-         "text": "7"
+          "type": "panel",
+          "name": "ayw2_panel",
+          "elements": [
+            {
+              "type": "html",
+              "name": "preamble",
+              "html": "<h2>Workshop Activities</h2>\n<p>We're interested in your feedback about how useful the activities in this workshop were for you.</p>\n\n\n<p>For each activity in this workshop, we ask that you <strong>rate how useful that activity was to you <em>personally</em></strong> in terms of your own <strong>learning, development, teaching practice</strong>, etc.</p>\n<table style=\"width: 100%; border: 1px solid black; margin-left: auto; margin-right: auto;\" cellpadding=\"1px\"><caption><span style=\"font-family: arial, helvetica, sans-serif;\"> </span></caption>\n<tbody>\n<tr>\n<td style=\"width: 17%; padding-top: 3px; text-align: center; vertical-align: top;\"><span style=\"font-size: 13.3333px; font-family: arial, helvetica, sans-serif;\"><strong>N/A</strong></span></td>\n<td style=\"width: 20.2282%; padding-top: 3px; text-align: center; vertical-align: top;\"><span style=\"font-family: arial, helvetica, sans-serif;\"><strong><span style=\"font-size: 10pt;\">1<span style=\"color: #ffffff;\">----</span>2</span></strong></span></td>\n<td style=\"width: 21.7718%; text-align: center; vertical-align: top;\"><span style=\"font-family: arial, helvetica, sans-serif;\"><strong><span style=\"font-size: 10pt;\">3<span style=\"color: #ffffff;\">----</span>4<span style=\"color: #ffffff;\">----</span>5</span></strong></span></td>\n<td style=\"width: 20%; text-align: center; vertical-align: top;\"><span style=\"font-family: arial, helvetica, sans-serif;\"><strong><span style=\"font-size: 10pt;\">6<span style=\"color: #ffffff;\">----</span>7</span></strong></span></td>\n</tr>\n<tr>\n<td style=\"width: 17%; text-align: center; vertical-align: middle;\"><span style=\"font-size: 10pt; font-family: arial, helvetica, sans-serif;\">I don't recognize this / I don't believe we did this today</span></td>\n<td style=\"width: 20.2282%; text-align: center; vertical-align: middle;\"><span style=\"font-size: 10pt; font-family: arial, helvetica, sans-serif;\">Not useful to me</span></td>\n<td style=\"width: 21.7718%; text-align: center; vertical-align: middle;\"><span style=\"font-size: 10pt; font-family: arial, helvetica, sans-serif;\">Somewhat useful to me</span></td>\n<td style=\"width: 20%; text-align: center; vertical-align: middle;\"><span style=\"font-size: 10pt; font-family: arial, helvetica, sans-serif;\">Very useful to me</span></td>\n</tr>\n</tbody>\n</table>"
+            },
+            {
+              "type": "matrix",
+              "name": "csd_ayw2_activities",
+              "visibleIf": "{workshop_course}='CS Discoveries'",
+              "title": "Please rate the usefulness of these CS Discoveries workshop activities.",
+              "columns": [
+                {
+                  "value": "1",
+                  "text": "N/A"
+                },
+                {
+                  "value": "2",
+                  "text": "1"
+                },
+                {
+                  "value": "3",
+                  "text": "2"
+                },
+                {
+                  "value": "4",
+                  "text": "3"
+                },
+                {
+                  "value": "5",
+                  "text": "4"
+                },
+                {
+                  "value": "6",
+                  "text": "5"
+                },
+                {
+                  "value": "7",
+                  "text": "6"
+                },
+                {
+                  "value": "8",
+                  "text": "7"
+                }
+              ],
+              "rows": [
+                {
+                  "value": "opener",
+                  "text": "Workshop Opener"
+                },
+                {
+                  "value": "prev_on",
+                  "text": "Previously, On Unit 4"
+                },
+                {
+                  "value": "model_lesson",
+                  "text": "Model Lesson"
+                },
+                {
+                  "value": "model_lesson_reflection",
+                  "text": "Model Lesson Reflection"
+                },
+                {
+                  "value": "group_dynamics",
+                  "text": "Group Dynamics"
+                },
+                {
+                  "value": "curric_investigation",
+                  "text": "Curriculum Investigation"
+                },
+                {
+                  "value": "unit4_conclusions_connections",
+                  "text": "Unit 4 Conclusions and Connections"
+                },
+                {
+                  "value": "unit_planning",
+                  "text": "Unit Planning"
+                },
+                {
+                  "value": "wrap_up",
+                  "text": "Wrap Up"
+                }
+              ]
+            },
+            {
+              "type": "matrix",
+              "name": "csp_ayw2_activities",
+              "visibleIf": "{workshop_course}='CS Principles'",
+              "title": "Please rate the usefulness of these CS Principles workshop activities.",
+              "columns": [
+                {
+                  "value": "1",
+                  "text": "N/A"
+                },
+                {
+                  "value": "2",
+                  "text": "1"
+                },
+                {
+                  "value": "3",
+                  "text": "2"
+                },
+                {
+                  "value": "4",
+                  "text": "3"
+                },
+                {
+                  "value": "5",
+                  "text": "4"
+                },
+                {
+                  "value": "6",
+                  "text": "5"
+                },
+                {
+                  "value": "7",
+                  "text": "6"
+                },
+                {
+                  "value": "8",
+                  "text": "7"
+                }
+              ],
+              "rows": [
+                {
+                  "value": "opener",
+                  "text": "Workshop Opener"
+                },
+                {
+                  "value": "recruiting_students_csp",
+                  "text": "Recruiting Students to CS Principles"
+                },
+                {
+                  "value": "prev_on",
+                  "text": "Previously, On CSP - Lists Explore"
+                },
+                {
+                  "value": "model_investigate",
+                  "text": " Model Lesson - Investigate"
+                },
+                {
+                  "value": "model_lesson_reflection",
+                  "text": "Model Lesson Reflection"
+                },
+                {
+                  "value": "lesson_investigation_lists_practice",
+                  "text": "Lesson Investigation - Lists Practice"
+                },
+                {
+                  "value": "lesson_investigation_lists_make",
+                  "text": "Lesson Investigation - Lists Make"
+                },
+                {
+                  "value": "lesson_investigation_traversals_investigate",
+                  "text": "Lesson Investigation - Traversals Investigate"
+                },
+                {
+                  "value": "unit5_conclusions_connections",
+                  "text": "Unit 5 Conclusions and Connections"
+                },
+                {
+                  "value": "unit6_overview",
+                  "text": "Unit 6 overview"
+                },
+                {
+                  "value": "wrap_up",
+                  "text": "Wrap Up"
+                }
+              ]
+            },
+            {
+              "type": "comment",
+              "name": "other_activities_ayw2",
+              "title": "If you participated in any other activities during this module, please describe them below.",
+              "cols": 40,
+              "rows": 2
+            }
+          ]
         }
-       ],
-       "rows": [
-        {
-         "value": "opener",
-         "text": "Workshop Opener"
-        },
-        {
-         "value": "prev_on",
-         "text": "Previously, On Unit 4"
-        },
-        {
-         "value": "model_lesson",
-         "text": "Model Lesson"
-        },
-        {
-         "value": "model_lesson_reflection",
-         "text": "Model Lesson Reflection"
-        },
-        {
-         "value": "group_dynamics",
-         "text": "Group Dynamics"
-        },
-        {
-         "value": "curric_investigation",
-         "text": "Curriculum Investigation"
-        },
-        {
-         "value": "unit4_conclusions_connections",
-         "text": "Unit 4 Conclusions and Connections"
-        },
-        {
-         "value": "unit_planning",
-         "text": "Unit Planning"
-        },
-        {
-         "value": "wrap_up",
-         "text": "Wrap Up"
-        }
-       ]
-      },
-      {
-       "type": "matrix",
-       "name": "csp_ayw2_activities",
-       "visibleIf": "{workshop_course}='CS Principles'",
-       "title": "Please rate the usefulness of these CS Principles workshop activities.",
-       "columns": [
-        {
-         "value": "1",
-         "text": "N/A"
-        },
-        {
-         "value": "2",
-         "text": "1"
-        },
-        {
-         "value": "3",
-         "text": "2"
-        },
-        {
-         "value": "4",
-         "text": "3"
-        },
-        {
-         "value": "5",
-         "text": "4"
-        },
-        {
-         "value": "6",
-         "text": "5"
-        },
-        {
-         "value": "7",
-         "text": "6"
-        },
-        {
-         "value": "8",
-         "text": "7"
-        }
-       ],
-       "rows": [
-        {
-         "value": "opener",
-         "text": "Workshop Opener"
-        },
-        {
-         "value": "recruiting_students_csp",
-         "text": "Recruiting Students to CS Principles"
-        },
-        {
-         "value": "prev_on",
-         "text": "Previously, On CSP - Lists Explore"
-        },
-        {
-         "value": "model_investigate",
-         "text": " Model Lesson - Investigate"
-        },
-        {
-         "value": "model_lesson_reflection",
-         "text": "Model Lesson Reflection"
-        },
-        {
-         "value": "lesson_investigation_lists_practice",
-         "text": "Lesson Investigation - Lists Practice"
-        },
-        {
-         "value": "lesson_investigation_lists_make",
-         "text": "Lesson Investigation - Lists Make"
-        },
-    {
-     "value": "lesson_investigation_traversals_investigate",
-     "text": "Lesson Investigation - Traversals Investigate"
-    },
-    {
-     "value": "unit5_conclusions_connections",
-     "text": "Unit 5 Conclusions and Connections"
-    },
-    {
-         "value": "unit6_overview",
-         "text": "Unit 6 overview"
-        },
-        {
-         "value": "wrap_up",
-         "text": "Wrap Up"
-        }
-       ]
-      },
-      {
-       "type": "comment",
-       "name": "other_activities_ayw2",
-       "title": "If you participated in any other activities during this module, please describe them below.",
-       "cols": 40,
-       "rows": 2
-      }
-     ]
+      ]
     }
-   ]
-  }
- ]
+  ]
 }

--- a/dashboard/config/foorm/library/surveys/pd/ayw_inperson_3.0.json
+++ b/dashboard/config/foorm/library/surveys/pd/ayw_inperson_3.0.json
@@ -2,7 +2,6 @@
   "published": true,
   "pages": [
     {
-      "name": "page1",
       "elements": [
         {
           "type": "panel",

--- a/dashboard/config/foorm/library/surveys/pd/ayw_module_1.0.json
+++ b/dashboard/config/foorm/library/surveys/pd/ayw_module_1.0.json
@@ -1,149 +1,148 @@
 {
- "published": true,
- "pages": [
-  {
-   "name": "page1",
-   "elements": [
+  "published": true,
+  "pages": [
     {
-     "type": "panel",
-     "name": "module_1_panel",
-     "elements": [
-      {
-       "type": "html",
-       "name": "question1",
-       "html": "<h2>How useful was Module 1?</h2>\n\n<p>For each activity in this module, we ask that you <strong>rate how useful that activity was to you <em>personally</em></strong> in terms of your own <strong>learning, development, teaching practice</strong>, etc.</p>"
-      },
-      {
-       "type": "html",
-       "name": "question4",
-       "html": "<table style=\"width: 100%; border: 1px solid black; margin-left: auto; margin-right: auto;\" cellpadding=\"1px\"><caption><span style=\"font-family: arial, helvetica, sans-serif;\"> </span></caption>\n<tbody>\n<tr>\n<td style=\"width: 17%; padding-top: 3px; text-align: center; vertical-align: top;\"><span style=\"font-size: 13.3333px; font-family: arial, helvetica, sans-serif;\"><strong>N/A</strong></span></td>\n<td style=\"width: 20.2282%; padding-top: 3px; text-align: center; vertical-align: top;\"><span style=\"font-family: arial, helvetica, sans-serif;\"><strong><span style=\"font-size: 10pt;\">1<span style=\"color: #ffffff;\">----</span>2</span></strong></span></td>\n<td style=\"width: 21.7718%; text-align: center; vertical-align: top;\"><span style=\"font-family: arial, helvetica, sans-serif;\"><strong><span style=\"font-size: 10pt;\">3<span style=\"color: #ffffff;\">----</span>4<span style=\"color: #ffffff;\">----</span>5</span></strong></span></td>\n<td style=\"width: 20%; text-align: center; vertical-align: top;\"><span style=\"font-family: arial, helvetica, sans-serif;\"><strong><span style=\"font-size: 10pt;\">6<span style=\"color: #ffffff;\">----</span>7</span></strong></span></td>\n</tr>\n<tr>\n<td style=\"width: 17%; text-align: center; vertical-align: middle;\"><span style=\"font-size: 10pt; font-family: arial, helvetica, sans-serif;\">I don't recognize this / I don't believe we did this today</span></td>\n<td style=\"width: 20.2282%; text-align: center; vertical-align: middle;\"><span style=\"font-size: 10pt; font-family: arial, helvetica, sans-serif;\">Not useful to me</span></td>\n<td style=\"width: 21.7718%; text-align: center; vertical-align: middle;\"><span style=\"font-size: 10pt; font-family: arial, helvetica, sans-serif;\">Somewhat useful to me</span></td>\n<td style=\"width: 20%; text-align: center; vertical-align: middle;\"><span style=\"font-size: 10pt; font-family: arial, helvetica, sans-serif;\">Very useful to me</span></td>\n</tr>\n</tbody>\n</table>"
-      },
-      {
-       "type": "matrix",
-       "name": "csd_activities_m1",
-       "visibleIf": "{workshop_course}='CS Discoveries'",
-       "title": "Please rate the usefulness of these CS Discoveries workshop activities.",
-       "columns": [
+      "elements": [
         {
-         "value": "1",
-         "text": "N/A"
-        },
-        {
-         "value": "2",
-         "text": "1"
-        },
-        {
-         "value": "3",
-         "text": "2"
-        },
-        {
-         "value": "4",
-         "text": "3"
-        },
-        {
-         "value": "5",
-         "text": "4"
-        },
-        {
-         "value": "6",
-         "text": "5"
-        },
-        {
-         "value": "7",
-         "text": "6"
-        },
-        {
-         "value": "8",
-         "text": "7"
+          "type": "panel",
+          "name": "module_1_panel",
+          "elements": [
+            {
+              "type": "html",
+              "name": "question1",
+              "html": "<h2>How useful was Module 1?</h2>\n\n<p>For each activity in this module, we ask that you <strong>rate how useful that activity was to you <em>personally</em></strong> in terms of your own <strong>learning, development, teaching practice</strong>, etc.</p>"
+            },
+            {
+              "type": "html",
+              "name": "question4",
+              "html": "<table style=\"width: 100%; border: 1px solid black; margin-left: auto; margin-right: auto;\" cellpadding=\"1px\"><caption><span style=\"font-family: arial, helvetica, sans-serif;\"> </span></caption>\n<tbody>\n<tr>\n<td style=\"width: 17%; padding-top: 3px; text-align: center; vertical-align: top;\"><span style=\"font-size: 13.3333px; font-family: arial, helvetica, sans-serif;\"><strong>N/A</strong></span></td>\n<td style=\"width: 20.2282%; padding-top: 3px; text-align: center; vertical-align: top;\"><span style=\"font-family: arial, helvetica, sans-serif;\"><strong><span style=\"font-size: 10pt;\">1<span style=\"color: #ffffff;\">----</span>2</span></strong></span></td>\n<td style=\"width: 21.7718%; text-align: center; vertical-align: top;\"><span style=\"font-family: arial, helvetica, sans-serif;\"><strong><span style=\"font-size: 10pt;\">3<span style=\"color: #ffffff;\">----</span>4<span style=\"color: #ffffff;\">----</span>5</span></strong></span></td>\n<td style=\"width: 20%; text-align: center; vertical-align: top;\"><span style=\"font-family: arial, helvetica, sans-serif;\"><strong><span style=\"font-size: 10pt;\">6<span style=\"color: #ffffff;\">----</span>7</span></strong></span></td>\n</tr>\n<tr>\n<td style=\"width: 17%; text-align: center; vertical-align: middle;\"><span style=\"font-size: 10pt; font-family: arial, helvetica, sans-serif;\">I don't recognize this / I don't believe we did this today</span></td>\n<td style=\"width: 20.2282%; text-align: center; vertical-align: middle;\"><span style=\"font-size: 10pt; font-family: arial, helvetica, sans-serif;\">Not useful to me</span></td>\n<td style=\"width: 21.7718%; text-align: center; vertical-align: middle;\"><span style=\"font-size: 10pt; font-family: arial, helvetica, sans-serif;\">Somewhat useful to me</span></td>\n<td style=\"width: 20%; text-align: center; vertical-align: middle;\"><span style=\"font-size: 10pt; font-family: arial, helvetica, sans-serif;\">Very useful to me</span></td>\n</tr>\n</tbody>\n</table>"
+            },
+            {
+              "type": "matrix",
+              "name": "csd_activities_m1",
+              "visibleIf": "{workshop_course}='CS Discoveries'",
+              "title": "Please rate the usefulness of these CS Discoveries workshop activities.",
+              "columns": [
+                {
+                  "value": "1",
+                  "text": "N/A"
+                },
+                {
+                  "value": "2",
+                  "text": "1"
+                },
+                {
+                  "value": "3",
+                  "text": "2"
+                },
+                {
+                  "value": "4",
+                  "text": "3"
+                },
+                {
+                  "value": "5",
+                  "text": "4"
+                },
+                {
+                  "value": "6",
+                  "text": "5"
+                },
+                {
+                  "value": "7",
+                  "text": "6"
+                },
+                {
+                  "value": "8",
+                  "text": "7"
+                }
+              ],
+              "rows": [
+                {
+                  "value": "opener",
+                  "text": "Workshop Opener"
+                },
+                {
+                  "value": "model_lesson_U3_L7",
+                  "text": "Model Lesson: Unit 3, Lesson 7"
+                },
+                {
+                  "value": "model_lesson_reflection",
+                  "text": "Model Lesson Reflection"
+                },
+                {
+                  "value": "wrap_up",
+                  "text": "Wrap-Up"
+                }
+              ]
+            },
+            {
+              "type": "matrix",
+              "name": "csp_activities_m1",
+              "visibleIf": "{workshop_course}='CS Principles'",
+              "title": "Please rate the usefulness of these CS Principles workshop activities.",
+              "columns": [
+                {
+                  "value": "1",
+                  "text": "N/A"
+                },
+                {
+                  "value": "2",
+                  "text": "1"
+                },
+                {
+                  "value": "3",
+                  "text": "2"
+                },
+                {
+                  "value": "4",
+                  "text": "3"
+                },
+                {
+                  "value": "5",
+                  "text": "4"
+                },
+                {
+                  "value": "6",
+                  "text": "5"
+                },
+                {
+                  "value": "7",
+                  "text": "6"
+                },
+                {
+                  "value": "8",
+                  "text": "7"
+                }
+              ],
+              "rows": [
+                {
+                  "value": "opener",
+                  "text": "Workshop Opener"
+                },
+                {
+                  "value": "demo_variables_explore",
+                  "text": "Live Demo: Variables Explore"
+                },
+                {
+                  "value": "demo_variables_investigate",
+                  "text": "Live Demo: Variables Investigate"
+                },
+                {
+                  "value": "wrap_up",
+                  "text": "Wrap Up"
+                }
+              ]
+            },
+            {
+              "type": "comment",
+              "name": "other_activities_m1",
+              "title": "If you participated in any other activities during this workshop, please describe them below.",
+              "cols": 40,
+              "rows": 2
+            }
+          ]
         }
-       ],
-       "rows": [
-        {
-         "value": "opener",
-         "text": "Workshop Opener"
-        },
-        {
-         "value": "model_lesson_U3_L7",
-         "text": "Model Lesson: Unit 3, Lesson 7"
-        },
-        {
-         "value": "model_lesson_reflection",
-         "text": "Model Lesson Reflection"
-        },
-        {
-         "value": "wrap_up",
-         "text": "Wrap-Up"
-        }
-       ]
-      },
-      {
-       "type": "matrix",
-       "name": "csp_activities_m1",
-       "visibleIf": "{workshop_course}='CS Principles'",
-       "title": "Please rate the usefulness of these CS Principles workshop activities.",
-       "columns": [
-        {
-         "value": "1",
-         "text": "N/A"
-        },
-        {
-         "value": "2",
-         "text": "1"
-        },
-        {
-         "value": "3",
-         "text": "2"
-        },
-        {
-         "value": "4",
-         "text": "3"
-        },
-        {
-         "value": "5",
-         "text": "4"
-        },
-        {
-         "value": "6",
-         "text": "5"
-        },
-        {
-         "value": "7",
-         "text": "6"
-        },
-        {
-         "value": "8",
-         "text": "7"
-        }
-       ],
-       "rows": [
-        {
-         "value": "opener",
-         "text": "Workshop Opener"
-        },
-        {
-         "value": "demo_variables_explore",
-         "text": "Live Demo: Variables Explore"
-        },
-        {
-         "value": "demo_variables_investigate",
-         "text": "Live Demo: Variables Investigate"
-        },
-        {
-         "value": "wrap_up",
-         "text": "Wrap Up"
-        }
-       ]
-      },
-      {
-       "type": "comment",
-       "name": "other_activities_m1",
-       "title": "If you participated in any other activities during this workshop, please describe them below.",
-       "cols": 40,
-       "rows": 2
-      }
-     ]
+      ]
     }
-   ]
-  }
- ]
+  ]
 }

--- a/dashboard/config/foorm/library/surveys/pd/ayw_module_2.0.json
+++ b/dashboard/config/foorm/library/surveys/pd/ayw_module_2.0.json
@@ -1,153 +1,152 @@
 {
- "published": true,
- "pages": [
-  {
-   "name": "page1",
-   "elements": [
+  "published": true,
+  "pages": [
     {
-     "type": "panel",
-     "name": "module_2_panel",
-     "elements": [
-      {
-       "type": "html",
-       "name": "question1",
-       "html": "<h2>How useful was Module 2?</h2>\n<p>We're interested in your feedback about how useful the activities in Module 2 were for you.</p>\n"
-      },
-      {
-       "type": "html",
-       "name": "question4",
-       "html": "<table style=\"width: 100%; border: 1px solid black; margin-left: auto; margin-right: auto;\" cellpadding=\"1px\"><caption><span style=\"font-family: arial, helvetica, sans-serif;\"> </span></caption>\n<tbody>\n<tr>\n<td style=\"width: 17%; padding-top: 3px; text-align: center; vertical-align: top;\"><span style=\"font-size: 13.3333px; font-family: arial, helvetica, sans-serif;\"><strong>N/A</strong></span></td>\n<td style=\"width: 20.2282%; padding-top: 3px; text-align: center; vertical-align: top;\"><span style=\"font-family: arial, helvetica, sans-serif;\"><strong><span style=\"font-size: 10pt;\">1<span style=\"color: #ffffff;\">----</span>2</span></strong></span></td>\n<td style=\"width: 21.7718%; text-align: center; vertical-align: top;\"><span style=\"font-family: arial, helvetica, sans-serif;\"><strong><span style=\"font-size: 10pt;\">3<span style=\"color: #ffffff;\">----</span>4<span style=\"color: #ffffff;\">----</span>5</span></strong></span></td>\n<td style=\"width: 20%; text-align: center; vertical-align: top;\"><span style=\"font-family: arial, helvetica, sans-serif;\"><strong><span style=\"font-size: 10pt;\">6<span style=\"color: #ffffff;\">----</span>7</span></strong></span></td>\n</tr>\n<tr>\n<td style=\"width: 17%; text-align: center; vertical-align: middle;\"><span style=\"font-size: 10pt; font-family: arial, helvetica, sans-serif;\">I don't recognize this / I don't believe we did this today</span></td>\n<td style=\"width: 20.2282%; text-align: center; vertical-align: middle;\"><span style=\"font-size: 10pt; font-family: arial, helvetica, sans-serif;\">Not useful to me</span></td>\n<td style=\"width: 21.7718%; text-align: center; vertical-align: middle;\"><span style=\"font-size: 10pt; font-family: arial, helvetica, sans-serif;\">Somewhat useful to me</span></td>\n<td style=\"width: 20%; text-align: center; vertical-align: middle;\"><span style=\"font-size: 10pt; font-family: arial, helvetica, sans-serif;\">Very useful to me</span></td>\n</tr>\n</tbody>\n</table>"
-      },
-      {
-       "type": "matrix",
-       "name": "csd_activities_m2",
-       "visibleIf": "{workshop_course}='CS Discoveries'",
-       "title": "Please rate the usefulness of these CS Discoveries workshop activities.",
-       "columns": [
+      "elements": [
         {
-         "value": "1",
-         "text": "N/A"
-        },
-        {
-         "value": "2",
-         "text": "1"
-        },
-        {
-         "value": "3",
-         "text": "2"
-        },
-        {
-         "value": "4",
-         "text": "3"
-        },
-        {
-         "value": "5",
-         "text": "4"
-        },
-        {
-         "value": "6",
-         "text": "5"
-        },
-        {
-         "value": "7",
-         "text": "6"
-        },
-        {
-         "value": "8",
-         "text": "7"
+          "type": "panel",
+          "name": "module_2_panel",
+          "elements": [
+            {
+              "type": "html",
+              "name": "question1",
+              "html": "<h2>How useful was Module 2?</h2>\n<p>We're interested in your feedback about how useful the activities in Module 2 were for you.</p>\n"
+            },
+            {
+              "type": "html",
+              "name": "question4",
+              "html": "<table style=\"width: 100%; border: 1px solid black; margin-left: auto; margin-right: auto;\" cellpadding=\"1px\"><caption><span style=\"font-family: arial, helvetica, sans-serif;\"> </span></caption>\n<tbody>\n<tr>\n<td style=\"width: 17%; padding-top: 3px; text-align: center; vertical-align: top;\"><span style=\"font-size: 13.3333px; font-family: arial, helvetica, sans-serif;\"><strong>N/A</strong></span></td>\n<td style=\"width: 20.2282%; padding-top: 3px; text-align: center; vertical-align: top;\"><span style=\"font-family: arial, helvetica, sans-serif;\"><strong><span style=\"font-size: 10pt;\">1<span style=\"color: #ffffff;\">----</span>2</span></strong></span></td>\n<td style=\"width: 21.7718%; text-align: center; vertical-align: top;\"><span style=\"font-family: arial, helvetica, sans-serif;\"><strong><span style=\"font-size: 10pt;\">3<span style=\"color: #ffffff;\">----</span>4<span style=\"color: #ffffff;\">----</span>5</span></strong></span></td>\n<td style=\"width: 20%; text-align: center; vertical-align: top;\"><span style=\"font-family: arial, helvetica, sans-serif;\"><strong><span style=\"font-size: 10pt;\">6<span style=\"color: #ffffff;\">----</span>7</span></strong></span></td>\n</tr>\n<tr>\n<td style=\"width: 17%; text-align: center; vertical-align: middle;\"><span style=\"font-size: 10pt; font-family: arial, helvetica, sans-serif;\">I don't recognize this / I don't believe we did this today</span></td>\n<td style=\"width: 20.2282%; text-align: center; vertical-align: middle;\"><span style=\"font-size: 10pt; font-family: arial, helvetica, sans-serif;\">Not useful to me</span></td>\n<td style=\"width: 21.7718%; text-align: center; vertical-align: middle;\"><span style=\"font-size: 10pt; font-family: arial, helvetica, sans-serif;\">Somewhat useful to me</span></td>\n<td style=\"width: 20%; text-align: center; vertical-align: middle;\"><span style=\"font-size: 10pt; font-family: arial, helvetica, sans-serif;\">Very useful to me</span></td>\n</tr>\n</tbody>\n</table>"
+            },
+            {
+              "type": "matrix",
+              "name": "csd_activities_m2",
+              "visibleIf": "{workshop_course}='CS Discoveries'",
+              "title": "Please rate the usefulness of these CS Discoveries workshop activities.",
+              "columns": [
+                {
+                  "value": "1",
+                  "text": "N/A"
+                },
+                {
+                  "value": "2",
+                  "text": "1"
+                },
+                {
+                  "value": "3",
+                  "text": "2"
+                },
+                {
+                  "value": "4",
+                  "text": "3"
+                },
+                {
+                  "value": "5",
+                  "text": "4"
+                },
+                {
+                  "value": "6",
+                  "text": "5"
+                },
+                {
+                  "value": "7",
+                  "text": "6"
+                },
+                {
+                  "value": "8",
+                  "text": "7"
+                }
+              ],
+              "rows": [
+                {
+                  "value": "opener",
+                  "text": "Workshop Opener"
+                },
+                {
+                  "value": "curriculum_investigate",
+                  "text": "Summary of Curriculum Investigate"
+                },
+                {
+                  "value": "assessment",
+                  "text": "Assessment"
+                },
+                {
+                  "value": "counseling",
+                  "text": "Counseling Scenarios"
+                },
+                {
+                  "value": "wrap_up",
+                  "text": "Wrap Up"
+                }
+              ]
+            },
+            {
+              "type": "matrix",
+              "name": "csp_activities_m2",
+              "visibleIf": "{workshop_course}='CS Principles'",
+              "title": "Please rate the usefulness of these CS Principles workshop activities.",
+              "columns": [
+                {
+                  "value": "1",
+                  "text": "N/A"
+                },
+                {
+                  "value": "2",
+                  "text": "1"
+                },
+                {
+                  "value": "3",
+                  "text": "2"
+                },
+                {
+                  "value": "4",
+                  "text": "3"
+                },
+                {
+                  "value": "5",
+                  "text": "4"
+                },
+                {
+                  "value": "6",
+                  "text": "5"
+                },
+                {
+                  "value": "7",
+                  "text": "6"
+                },
+                {
+                  "value": "8",
+                  "text": "7"
+                }
+              ],
+              "rows": [
+                {
+                  "value": "opener",
+                  "text": "Workshop Opener"
+                },
+                {
+                  "value": "collab_and_ind_in_U4",
+                  "text": "Collaboration and Independent Work in Unit 4"
+                },
+                {
+                  "value": "eipm",
+                  "text": "Zooming Out - EIPM and the “Big Picture”"
+                },
+                {
+                  "value": "wrap_up",
+                  "text": "Wrap Up"
+                }
+              ]
+            },
+            {
+              "type": "comment",
+              "name": "other_activities_m2",
+              "title": "If you participated in any other activities during this workshop, please describe them below.",
+              "cols": 40,
+              "rows": 2
+            }
+          ]
         }
-       ],
-       "rows": [
-        {
-         "value": "opener",
-         "text": "Workshop Opener"
-        },
-        {
-         "value": "curriculum_investigate",
-         "text": "Summary of Curriculum Investigate"
-        },
-        {
-         "value": "assessment",
-         "text": "Assessment"
-        },
-        {
-         "value": "counseling",
-         "text": "Counseling Scenarios"
-        },
-        {
-         "value": "wrap_up",
-         "text": "Wrap Up"
-        }
-       ]
-      },
-      {
-       "type": "matrix",
-       "name": "csp_activities_m2",
-       "visibleIf": "{workshop_course}='CS Principles'",
-       "title": "Please rate the usefulness of these CS Principles workshop activities.",
-       "columns": [
-        {
-         "value": "1",
-         "text": "N/A"
-        },
-        {
-         "value": "2",
-         "text": "1"
-        },
-        {
-         "value": "3",
-         "text": "2"
-        },
-        {
-         "value": "4",
-         "text": "3"
-        },
-        {
-         "value": "5",
-         "text": "4"
-        },
-        {
-         "value": "6",
-         "text": "5"
-        },
-        {
-         "value": "7",
-         "text": "6"
-        },
-        {
-         "value": "8",
-         "text": "7"
-        }
-       ],
-       "rows": [
-        {
-         "value": "opener",
-         "text": "Workshop Opener"
-        },
-        {
-         "value": "collab_and_ind_in_U4",
-         "text": "Collaboration and Independent Work in Unit 4"
-        },
-        {
-         "value": "eipm",
-         "text": "Zooming Out - EIPM and the “Big Picture”"
-        },
-        {
-         "value": "wrap_up",
-         "text": "Wrap Up"
-        }
-       ]
-      },
-      {
-       "type": "comment",
-       "name": "other_activities_m2",
-       "title": "If you participated in any other activities during this workshop, please describe them below.",
-       "cols": 40,
-       "rows": 2
-      }
-     ]
+      ]
     }
-   ]
-  }
- ]
+  ]
 }

--- a/dashboard/config/foorm/library/surveys/pd/ayw_module_3.0.json
+++ b/dashboard/config/foorm/library/surveys/pd/ayw_module_3.0.json
@@ -1,149 +1,148 @@
 {
- "published": true,
- "pages": [
-  {
-   "name": "page1",
-   "elements": [
+  "published": true,
+  "pages": [
     {
-     "type": "panel",
-     "name": "module_3_panel",
-     "elements": [
-      {
-       "type": "html",
-       "name": "question1",
-       "html": "<h2>How useful was Module 3?</h2>\n<p>We're interested in your feedback about how useful the activities in Module 3 were for you.</p>\n"
-      },
-      {
-       "type": "html",
-       "name": "question4",
-       "html": "<table style=\"width: 100%; border: 1px solid black; margin-left: auto; margin-right: auto;\" cellpadding=\"1px\"><caption><span style=\"font-family: arial, helvetica, sans-serif;\"> </span></caption>\n<tbody>\n<tr>\n<td style=\"width: 17%; padding-top: 3px; text-align: center; vertical-align: top;\"><span style=\"font-size: 13.3333px; font-family: arial, helvetica, sans-serif;\"><strong>N/A</strong></span></td>\n<td style=\"width: 20.2282%; padding-top: 3px; text-align: center; vertical-align: top;\"><span style=\"font-family: arial, helvetica, sans-serif;\"><strong><span style=\"font-size: 10pt;\">1<span style=\"color: #ffffff;\">----</span>2</span></strong></span></td>\n<td style=\"width: 21.7718%; text-align: center; vertical-align: top;\"><span style=\"font-family: arial, helvetica, sans-serif;\"><strong><span style=\"font-size: 10pt;\">3<span style=\"color: #ffffff;\">----</span>4<span style=\"color: #ffffff;\">----</span>5</span></strong></span></td>\n<td style=\"width: 20%; text-align: center; vertical-align: top;\"><span style=\"font-family: arial, helvetica, sans-serif;\"><strong><span style=\"font-size: 10pt;\">6<span style=\"color: #ffffff;\">----</span>7</span></strong></span></td>\n</tr>\n<tr>\n<td style=\"width: 17%; text-align: center; vertical-align: middle;\"><span style=\"font-size: 10pt; font-family: arial, helvetica, sans-serif;\">I don't recognize this / I don't believe we did this today</span></td>\n<td style=\"width: 20.2282%; text-align: center; vertical-align: middle;\"><span style=\"font-size: 10pt; font-family: arial, helvetica, sans-serif;\">Not useful to me</span></td>\n<td style=\"width: 21.7718%; text-align: center; vertical-align: middle;\"><span style=\"font-size: 10pt; font-family: arial, helvetica, sans-serif;\">Somewhat useful to me</span></td>\n<td style=\"width: 20%; text-align: center; vertical-align: middle;\"><span style=\"font-size: 10pt; font-family: arial, helvetica, sans-serif;\">Very useful to me</span></td>\n</tr>\n</tbody>\n</table>"
-      },
-      {
-       "type": "matrix",
-       "name": "csd_activities_m3",
-       "visibleIf": "{workshop_course}='CS Discoveries'",
-       "title": "Please rate the usefulness of these CS Discoveries workshop activities.",
-       "columns": [
+      "elements": [
         {
-         "value": "1",
-         "text": "N/A"
-        },
-        {
-         "value": "2",
-         "text": "1"
-        },
-        {
-         "value": "3",
-         "text": "2"
-        },
-        {
-         "value": "4",
-         "text": "3"
-        },
-        {
-         "value": "5",
-         "text": "4"
-        },
-        {
-         "value": "6",
-         "text": "5"
-        },
-        {
-         "value": "7",
-         "text": "6"
-        },
-        {
-         "value": "8",
-         "text": "7"
+          "type": "panel",
+          "name": "module_3_panel",
+          "elements": [
+            {
+              "type": "html",
+              "name": "question1",
+              "html": "<h2>How useful was Module 3?</h2>\n<p>We're interested in your feedback about how useful the activities in Module 3 were for you.</p>\n"
+            },
+            {
+              "type": "html",
+              "name": "question4",
+              "html": "<table style=\"width: 100%; border: 1px solid black; margin-left: auto; margin-right: auto;\" cellpadding=\"1px\"><caption><span style=\"font-family: arial, helvetica, sans-serif;\"> </span></caption>\n<tbody>\n<tr>\n<td style=\"width: 17%; padding-top: 3px; text-align: center; vertical-align: top;\"><span style=\"font-size: 13.3333px; font-family: arial, helvetica, sans-serif;\"><strong>N/A</strong></span></td>\n<td style=\"width: 20.2282%; padding-top: 3px; text-align: center; vertical-align: top;\"><span style=\"font-family: arial, helvetica, sans-serif;\"><strong><span style=\"font-size: 10pt;\">1<span style=\"color: #ffffff;\">----</span>2</span></strong></span></td>\n<td style=\"width: 21.7718%; text-align: center; vertical-align: top;\"><span style=\"font-family: arial, helvetica, sans-serif;\"><strong><span style=\"font-size: 10pt;\">3<span style=\"color: #ffffff;\">----</span>4<span style=\"color: #ffffff;\">----</span>5</span></strong></span></td>\n<td style=\"width: 20%; text-align: center; vertical-align: top;\"><span style=\"font-family: arial, helvetica, sans-serif;\"><strong><span style=\"font-size: 10pt;\">6<span style=\"color: #ffffff;\">----</span>7</span></strong></span></td>\n</tr>\n<tr>\n<td style=\"width: 17%; text-align: center; vertical-align: middle;\"><span style=\"font-size: 10pt; font-family: arial, helvetica, sans-serif;\">I don't recognize this / I don't believe we did this today</span></td>\n<td style=\"width: 20.2282%; text-align: center; vertical-align: middle;\"><span style=\"font-size: 10pt; font-family: arial, helvetica, sans-serif;\">Not useful to me</span></td>\n<td style=\"width: 21.7718%; text-align: center; vertical-align: middle;\"><span style=\"font-size: 10pt; font-family: arial, helvetica, sans-serif;\">Somewhat useful to me</span></td>\n<td style=\"width: 20%; text-align: center; vertical-align: middle;\"><span style=\"font-size: 10pt; font-family: arial, helvetica, sans-serif;\">Very useful to me</span></td>\n</tr>\n</tbody>\n</table>"
+            },
+            {
+              "type": "matrix",
+              "name": "csd_activities_m3",
+              "visibleIf": "{workshop_course}='CS Discoveries'",
+              "title": "Please rate the usefulness of these CS Discoveries workshop activities.",
+              "columns": [
+                {
+                  "value": "1",
+                  "text": "N/A"
+                },
+                {
+                  "value": "2",
+                  "text": "1"
+                },
+                {
+                  "value": "3",
+                  "text": "2"
+                },
+                {
+                  "value": "4",
+                  "text": "3"
+                },
+                {
+                  "value": "5",
+                  "text": "4"
+                },
+                {
+                  "value": "6",
+                  "text": "5"
+                },
+                {
+                  "value": "7",
+                  "text": "6"
+                },
+                {
+                  "value": "8",
+                  "text": "7"
+                }
+              ],
+              "rows": [
+                {
+                  "value": "welcome",
+                  "text": "Welcome"
+                },
+                {
+                  "value": "model_lesson",
+                  "text": "Model Lesson"
+                },
+                {
+                  "value": "model_lesson_reflection",
+                  "text": "Model Lesson Reflection and Group Work"
+                },
+                {
+                  "value": "wrap_up",
+                  "text": "Wrap Up"
+                }
+              ]
+            },
+            {
+              "type": "matrix",
+              "name": "csp_activities_m3",
+              "visibleIf": "{workshop_course}='CS Principles'",
+              "title": "Please rate the usefulness of these CS Principles workshop activities.",
+              "columns": [
+                {
+                  "value": "1",
+                  "text": "N/A"
+                },
+                {
+                  "value": "2",
+                  "text": "1"
+                },
+                {
+                  "value": "3",
+                  "text": "2"
+                },
+                {
+                  "value": "4",
+                  "text": "3"
+                },
+                {
+                  "value": "5",
+                  "text": "4"
+                },
+                {
+                  "value": "6",
+                  "text": "5"
+                },
+                {
+                  "value": "7",
+                  "text": "6"
+                },
+                {
+                  "value": "8",
+                  "text": "7"
+                }
+              ],
+              "rows": [
+                {
+                  "value": "opener",
+                  "text": "Workshop Opener"
+                },
+                {
+                  "value": "model_lesson_lists_investigate",
+                  "text": "Model Lesson - Lists Investigate"
+                },
+                {
+                  "value": "model_lesson_reflection",
+                  "text": "Model Lesson Reflection”"
+                },
+                {
+                  "value": "wrap_up",
+                  "text": "Wrap Up"
+                }
+              ]
+            },
+            {
+              "type": "comment",
+              "name": "other_activities_m3",
+              "title": "If you participated in any other activities during this workshop, please describe them below.",
+              "cols": 40,
+              "rows": 2
+            }
+          ]
         }
-       ],
-       "rows": [
-        {
-         "value": "welcome",
-         "text": "Welcome"
-        },
-        {
-         "value": "model_lesson",
-         "text": "Model Lesson"
-        },
-        {
-         "value": "model_lesson_reflection",
-         "text": "Model Lesson Reflection and Group Work"
-        },
-        {
-         "value": "wrap_up",
-         "text": "Wrap Up"
-        }
-       ]
-      },
-      {
-       "type": "matrix",
-       "name": "csp_activities_m3",
-       "visibleIf": "{workshop_course}='CS Principles'",
-       "title": "Please rate the usefulness of these CS Principles workshop activities.",
-       "columns": [
-        {
-         "value": "1",
-         "text": "N/A"
-        },
-        {
-         "value": "2",
-         "text": "1"
-        },
-        {
-         "value": "3",
-         "text": "2"
-        },
-        {
-         "value": "4",
-         "text": "3"
-        },
-        {
-         "value": "5",
-         "text": "4"
-        },
-        {
-         "value": "6",
-         "text": "5"
-        },
-        {
-         "value": "7",
-         "text": "6"
-        },
-        {
-         "value": "8",
-         "text": "7"
-        }
-       ],
-       "rows": [
-        {
-         "value": "opener",
-         "text": "Workshop Opener"
-        },
-        {
-         "value": "model_lesson_lists_investigate",
-         "text": "Model Lesson - Lists Investigate"
-        },
-        {
-         "value": "model_lesson_reflection",
-         "text": "Model Lesson Reflection”"
-        },
-        {
-         "value": "wrap_up",
-         "text": "Wrap Up"
-        }
-       ]
-      },
-      {
-       "type": "comment",
-       "name": "other_activities_m3",
-       "title": "If you participated in any other activities during this workshop, please describe them below.",
-       "cols": 40,
-       "rows": 2
-      }
-     ]
+      ]
     }
-   ]
-  }
- ]
+  ]
 }

--- a/dashboard/config/foorm/library/surveys/pd/ayw_module_4.0.json
+++ b/dashboard/config/foorm/library/surveys/pd/ayw_module_4.0.json
@@ -1,153 +1,152 @@
 {
- "published": true,
- "pages": [
-  {
-   "name": "page1",
-   "elements": [
+  "published": true,
+  "pages": [
     {
-     "type": "panel",
-     "name": "module_4_panel",
-     "elements": [
-      {
-       "type": "html",
-       "name": "question1",
-       "html": "<h2>How useful was Module 4?</h2>\n<p>We're interested in your feedback about how useful the activities in Module 4 were for you.</p>\n"
-      },
-      {
-       "type": "html",
-       "name": "question4",
-       "html": "<table style=\"width: 100%; border: 1px solid black; margin-left: auto; margin-right: auto;\" cellpadding=\"1px\"><caption><span style=\"font-family: arial, helvetica, sans-serif;\"> </span></caption>\n<tbody>\n<tr>\n<td style=\"width: 17%; padding-top: 3px; text-align: center; vertical-align: top;\"><span style=\"font-size: 13.3333px; font-family: arial, helvetica, sans-serif;\"><strong>N/A</strong></span></td>\n<td style=\"width: 20.2282%; padding-top: 3px; text-align: center; vertical-align: top;\"><span style=\"font-family: arial, helvetica, sans-serif;\"><strong><span style=\"font-size: 10pt;\">1<span style=\"color: #ffffff;\">----</span>2</span></strong></span></td>\n<td style=\"width: 21.7718%; text-align: center; vertical-align: top;\"><span style=\"font-family: arial, helvetica, sans-serif;\"><strong><span style=\"font-size: 10pt;\">3<span style=\"color: #ffffff;\">----</span>4<span style=\"color: #ffffff;\">----</span>5</span></strong></span></td>\n<td style=\"width: 20%; text-align: center; vertical-align: top;\"><span style=\"font-family: arial, helvetica, sans-serif;\"><strong><span style=\"font-size: 10pt;\">6<span style=\"color: #ffffff;\">----</span>7</span></strong></span></td>\n</tr>\n<tr>\n<td style=\"width: 17%; text-align: center; vertical-align: middle;\"><span style=\"font-size: 10pt; font-family: arial, helvetica, sans-serif;\">I don't recognize this / I don't believe we did this today</span></td>\n<td style=\"width: 20.2282%; text-align: center; vertical-align: middle;\"><span style=\"font-size: 10pt; font-family: arial, helvetica, sans-serif;\">Not useful to me</span></td>\n<td style=\"width: 21.7718%; text-align: center; vertical-align: middle;\"><span style=\"font-size: 10pt; font-family: arial, helvetica, sans-serif;\">Somewhat useful to me</span></td>\n<td style=\"width: 20%; text-align: center; vertical-align: middle;\"><span style=\"font-size: 10pt; font-family: arial, helvetica, sans-serif;\">Very useful to me</span></td>\n</tr>\n</tbody>\n</table>"
-      },
-      {
-       "type": "matrix",
-       "name": "csd_activities_m4",
-       "visibleIf": "{workshop_course}='CS Discoveries'",
-       "title": "Please rate the usefulness of these CS Discoveries workshop activities.",
-       "columns": [
+      "elements": [
         {
-         "value": "1",
-         "text": "N/A"
-        },
-        {
-         "value": "2",
-         "text": "1"
-        },
-        {
-         "value": "3",
-         "text": "2"
-        },
-        {
-         "value": "4",
-         "text": "3"
-        },
-        {
-         "value": "5",
-         "text": "4"
-        },
-        {
-         "value": "6",
-         "text": "5"
-        },
-        {
-         "value": "7",
-         "text": "6"
-        },
-        {
-         "value": "8",
-         "text": "7"
+          "type": "panel",
+          "name": "module_4_panel",
+          "elements": [
+            {
+              "type": "html",
+              "name": "question1",
+              "html": "<h2>How useful was Module 4?</h2>\n<p>We're interested in your feedback about how useful the activities in Module 4 were for you.</p>\n"
+            },
+            {
+              "type": "html",
+              "name": "question4",
+              "html": "<table style=\"width: 100%; border: 1px solid black; margin-left: auto; margin-right: auto;\" cellpadding=\"1px\"><caption><span style=\"font-family: arial, helvetica, sans-serif;\"> </span></caption>\n<tbody>\n<tr>\n<td style=\"width: 17%; padding-top: 3px; text-align: center; vertical-align: top;\"><span style=\"font-size: 13.3333px; font-family: arial, helvetica, sans-serif;\"><strong>N/A</strong></span></td>\n<td style=\"width: 20.2282%; padding-top: 3px; text-align: center; vertical-align: top;\"><span style=\"font-family: arial, helvetica, sans-serif;\"><strong><span style=\"font-size: 10pt;\">1<span style=\"color: #ffffff;\">----</span>2</span></strong></span></td>\n<td style=\"width: 21.7718%; text-align: center; vertical-align: top;\"><span style=\"font-family: arial, helvetica, sans-serif;\"><strong><span style=\"font-size: 10pt;\">3<span style=\"color: #ffffff;\">----</span>4<span style=\"color: #ffffff;\">----</span>5</span></strong></span></td>\n<td style=\"width: 20%; text-align: center; vertical-align: top;\"><span style=\"font-family: arial, helvetica, sans-serif;\"><strong><span style=\"font-size: 10pt;\">6<span style=\"color: #ffffff;\">----</span>7</span></strong></span></td>\n</tr>\n<tr>\n<td style=\"width: 17%; text-align: center; vertical-align: middle;\"><span style=\"font-size: 10pt; font-family: arial, helvetica, sans-serif;\">I don't recognize this / I don't believe we did this today</span></td>\n<td style=\"width: 20.2282%; text-align: center; vertical-align: middle;\"><span style=\"font-size: 10pt; font-family: arial, helvetica, sans-serif;\">Not useful to me</span></td>\n<td style=\"width: 21.7718%; text-align: center; vertical-align: middle;\"><span style=\"font-size: 10pt; font-family: arial, helvetica, sans-serif;\">Somewhat useful to me</span></td>\n<td style=\"width: 20%; text-align: center; vertical-align: middle;\"><span style=\"font-size: 10pt; font-family: arial, helvetica, sans-serif;\">Very useful to me</span></td>\n</tr>\n</tbody>\n</table>"
+            },
+            {
+              "type": "matrix",
+              "name": "csd_activities_m4",
+              "visibleIf": "{workshop_course}='CS Discoveries'",
+              "title": "Please rate the usefulness of these CS Discoveries workshop activities.",
+              "columns": [
+                {
+                  "value": "1",
+                  "text": "N/A"
+                },
+                {
+                  "value": "2",
+                  "text": "1"
+                },
+                {
+                  "value": "3",
+                  "text": "2"
+                },
+                {
+                  "value": "4",
+                  "text": "3"
+                },
+                {
+                  "value": "5",
+                  "text": "4"
+                },
+                {
+                  "value": "6",
+                  "text": "5"
+                },
+                {
+                  "value": "7",
+                  "text": "6"
+                },
+                {
+                  "value": "8",
+                  "text": "7"
+                }
+              ],
+              "rows": [
+                {
+                  "value": "welcome",
+                  "text": "Welcome"
+                },
+                {
+                  "value": "summary_conclusions_connections",
+                  "text": "Summary of Conclusions and Connections"
+                },
+                {
+                  "value": "unit_planning",
+                  "text": "Unit Planning"
+                },
+                {
+                  "value": "wrap_up",
+                  "text": "Wrap Up"
+                }
+              ]
+            },
+            {
+              "type": "matrix",
+              "name": "csp_activities_m4",
+              "visibleIf": "{workshop_course}='CS Principles'",
+              "title": "Please rate the usefulness of these CS Principles workshop activities.",
+              "columns": [
+                {
+                  "value": "1",
+                  "text": "N/A"
+                },
+                {
+                  "value": "2",
+                  "text": "1"
+                },
+                {
+                  "value": "3",
+                  "text": "2"
+                },
+                {
+                  "value": "4",
+                  "text": "3"
+                },
+                {
+                  "value": "5",
+                  "text": "4"
+                },
+                {
+                  "value": "6",
+                  "text": "5"
+                },
+                {
+                  "value": "7",
+                  "text": "6"
+                },
+                {
+                  "value": "8",
+                  "text": "7"
+                }
+              ],
+              "rows": [
+                {
+                  "value": "opener",
+                  "text": "Workshop Opener"
+                },
+                {
+                  "value": "recruiting_students_csp_classroom",
+                  "text": "Recruiting Students to Your CSP Classroom"
+                },
+                {
+                  "value": "unit_5_conclusions_connections",
+                  "text": "Unit 5 Conclusions and Connections"
+                },
+                {
+                  "value": "unit_6_overview",
+                  "text": "Unit 6 Overview"
+                },
+                {
+                  "value": "wrap_up",
+                  "text": "Wrap Up"
+                }
+              ]
+            },
+            {
+              "type": "comment",
+              "name": "other_activities_m4",
+              "title": "If you participated in any other activities during this workshop, please describe them below.",
+              "cols": 40,
+              "rows": 2
+            }
+          ]
         }
-       ],
-       "rows": [
-        {
-         "value": "welcome",
-         "text": "Welcome"
-        },
-        {
-         "value": "summary_conclusions_connections",
-         "text": "Summary of Conclusions and Connections"
-        },
-        {
-         "value": "unit_planning",
-         "text": "Unit Planning"
-        },
-        {
-         "value": "wrap_up",
-         "text": "Wrap Up"
-        }
-       ]
-      },
-      {
-       "type": "matrix",
-       "name": "csp_activities_m4",
-       "visibleIf": "{workshop_course}='CS Principles'",
-       "title": "Please rate the usefulness of these CS Principles workshop activities.",
-       "columns": [
-        {
-         "value": "1",
-         "text": "N/A"
-        },
-        {
-         "value": "2",
-         "text": "1"
-        },
-        {
-         "value": "3",
-         "text": "2"
-        },
-        {
-         "value": "4",
-         "text": "3"
-        },
-        {
-         "value": "5",
-         "text": "4"
-        },
-        {
-         "value": "6",
-         "text": "5"
-        },
-        {
-         "value": "7",
-         "text": "6"
-        },
-        {
-         "value": "8",
-         "text": "7"
-        }
-       ],
-       "rows": [
-        {
-         "value": "opener",
-         "text": "Workshop Opener"
-        },
-        {
-         "value": "recruiting_students_csp_classroom",
-         "text": "Recruiting Students to Your CSP Classroom"
-        },
-        {
-         "value": "unit_5_conclusions_connections",
-         "text": "Unit 5 Conclusions and Connections"
-        },
-    {
-     "value":  "unit_6_overview",
-     "text":   "Unit 6 Overview"
-    },
-        {
-         "value": "wrap_up",
-         "text": "Wrap Up"
-        }
-       ]
-      },
-      {
-       "type": "comment",
-       "name": "other_activities_m4",
-       "title": "If you participated in any other activities during this workshop, please describe them below.",
-       "cols": 40,
-       "rows": 2
-      }
-     ]
+      ]
     }
-   ]
-  }
- ]
+  ]
 }

--- a/dashboard/config/foorm/library/surveys/pd/ayw_module_5.0.json
+++ b/dashboard/config/foorm/library/surveys/pd/ayw_module_5.0.json
@@ -2,7 +2,6 @@
   "published": true,
   "pages": [
     {
-      "name": "page1",
       "elements": [
         {
           "type": "panel",

--- a/dashboard/config/foorm/library/surveys/pd/ayw_module_6.0.json
+++ b/dashboard/config/foorm/library/surveys/pd/ayw_module_6.0.json
@@ -2,7 +2,6 @@
   "published": true,
   "pages": [
     {
-      "name": "page1",
       "elements": [
         {
           "type": "panel",

--- a/dashboard/config/foorm/library/surveys/pd/ayw_satisfaction_panel.0.json
+++ b/dashboard/config/foorm/library/surveys/pd/ayw_satisfaction_panel.0.json
@@ -1,89 +1,88 @@
 {
- "published": true,
- "pages": [
-  {
-   "name": "page_1",
-   "elements": [
+  "published": true,
+  "pages": [
     {
-     "type": "panel",
-     "name": "workshop_satisfaction_panel",
-     "elements": [
-      {
-       "type": "matrix",
-       "title": "How much do you agree or disagree with the following statements about the workshop overall?",
-       "name": "workshop_satisfaction",
-       "columns": [
+      "elements": [
         {
-         "value": "1",
-         "text": "Strongly Disagree"
-       },
-       {
-         "value": "2",
-         "text": "Disagree"
-       },
-       {
-         "value": "3",
-         "text": "Slightly Disagree"
-       },
-       {
-         "value": "4",
-         "text": "Neutral"
-       },
-       {
-         "value": "5",
-         "text": "Slightly Agree"
-       },
-       {
-         "value": "6",
-         "text": "Agree"
-       },
-       {
-         "value": "7",
-         "text": "Strongly Agree"
-       }
-     ],
-       "rows": [
-       {
-         "value": "love_curriculum",
-         "text": "I love teaching with this curriculum."
-       },
-       {
-         "value": "comfort_collaborating",
-         "text": "I feel comfortable collaborating with teachers in my cohort and asking for support."
-       },
-       {
-         "value": "excited_about_next_time",
-         "text": "I am excited about what we will do next time in this workshop."
-       }
-     ]
-     },
-     {
-       "type": "comment",
-       "name": "what_supported",
-       "title": "What supported your learning the most today and why?",
-        "maxLength": 4000,
-       "cols": 60,
-       "rows": 2
-     },
-     {
-       "type": "comment",
-       "name": "what_detracted",
-       "title": "What detracted from your learning today and why?",
-        "maxLength": 4000,
-       "cols": 60,
-       "rows": 2
-     },
-     {
-       "type": "comment",
-       "name": "discuss_tomorrow",
-       "title": "What is one thing you hope to discuss or learn more about the next time we meet?",
-       "maxLength": 4000,
-       "cols": 60,
-       "rows": 2
-     }
-   ]
-   }
- ]
- }
-]
+          "type": "panel",
+          "name": "workshop_satisfaction_panel",
+          "elements": [
+            {
+              "type": "matrix",
+              "title": "How much do you agree or disagree with the following statements about the workshop overall?",
+              "name": "workshop_satisfaction",
+              "columns": [
+                {
+                  "value": "1",
+                  "text": "Strongly Disagree"
+                },
+                {
+                  "value": "2",
+                  "text": "Disagree"
+                },
+                {
+                  "value": "3",
+                  "text": "Slightly Disagree"
+                },
+                {
+                  "value": "4",
+                  "text": "Neutral"
+                },
+                {
+                  "value": "5",
+                  "text": "Slightly Agree"
+                },
+                {
+                  "value": "6",
+                  "text": "Agree"
+                },
+                {
+                  "value": "7",
+                  "text": "Strongly Agree"
+                }
+              ],
+              "rows": [
+                {
+                  "value": "love_curriculum",
+                  "text": "I love teaching with this curriculum."
+                },
+                {
+                  "value": "comfort_collaborating",
+                  "text": "I feel comfortable collaborating with teachers in my cohort and asking for support."
+                },
+                {
+                  "value": "excited_about_next_time",
+                  "text": "I am excited about what we will do next time in this workshop."
+                }
+              ]
+            },
+            {
+              "type": "comment",
+              "name": "what_supported",
+              "title": "What supported your learning the most today and why?",
+              "maxLength": 4000,
+              "cols": 60,
+              "rows": 2
+            },
+            {
+              "type": "comment",
+              "name": "what_detracted",
+              "title": "What detracted from your learning today and why?",
+              "maxLength": 4000,
+              "cols": 60,
+              "rows": 2
+            },
+            {
+              "type": "comment",
+              "name": "discuss_tomorrow",
+              "title": "What is one thing you hope to discuss or learn more about the next time we meet?",
+              "maxLength": 4000,
+              "cols": 60,
+              "rows": 2
+            }
+          ]
+        }
+      ]
+    }
+  ]
 }

--- a/dashboard/config/foorm/library/surveys/pd/ayw_virtual_panel.0.json
+++ b/dashboard/config/foorm/library/surveys/pd/ayw_virtual_panel.0.json
@@ -1,121 +1,120 @@
 {
- "published": true,
- "pages": [
-  {
-   "name": "page_1",
-   "elements": [
+  "published": true,
+  "pages": [
     {
-     "type": "panel",
-     "name": "ayw_virtual_panel",
-     "elements": [
-      {
-       "type": "matrix",
-       "name": "async_activities",
-       "title": "As part of this workshop you engaged in asynchronous work (activities that weren't part of a video conference call). To what extent do you agree or disagree that the following asynchronous activities were useful for your personal learning and development?",
-       "columns": [
+      "elements": [
         {
-         "value": "1",
-         "text": "Strongly Disagree"
-        },
-        {
-         "value": "2",
-         "text": "Disagree"
-        },
-        {
-         "value": "3",
-         "text": "Slightly Disagree"
-        },
-        {
-         "value": "4",
-         "text": "Neutral"
-        },
-        {
-         "value": "5",
-         "text": "Slightly Agree"
-        },
-        {
-         "value": "6",
-         "text": "Agree"
-        },
-        {
-         "value": "7",
-         "text": "Strongly Agree"
-        }
-       ],
-       "rows": [
-        {
-         "value": "exploration_time",
-         "text": "Exploration of course materials and resources."
-        },
-        {
-         "value": "teaching_practice_reflection",
-         "text": "Reflection on your own teaching practice."
-        },
-        {
-         "value": "group_reflection",
-         "text": "The group reflection exercise."
-        }
-       ]
-      },
-      {
-       "type": "matrix",
-       "name": "logistics_virtual",
-       "title": "To what extent were the following true about participating in this virtual workshop?",
-       "columns": [
-        {
-         "value": "1",
-         "text": "Strongly Disagree"
-        },
-        {
-         "value": "2",
-         "text": "Disagree"
-        },
-        {
-         "value": "3",
-         "text": "Slightly Disagree"
-        },
-        {
-         "value": "4",
-         "text": "Neutral"
-        },
-        {
-         "value": "5",
-         "text": "Slightly Agree"
-        },
-        {
-         "value": "6",
-         "text": "Agree"
-        },
-        {
-         "value": "7",
-         "text": "Strongly Agree"
-        }
-       ],
-       "rows": [
-        {
-         "value": "clear_communication_how_virtually_attend",
-         "text": "I received clear communication about how to virtually attend the workshop."
-        },
-        {
-         "value": "tools_met_needs",
-         "text": "The virtual meeting tool(s) met my learning needs."
-        },
-        {
-         "value": "adequate_internet_tech",
-         "text": "My internet connection and technology were adequate to fully participate."
-        }
-       ]
-      },
-      {
-       "type": "comment",
-       "name": "virtual_feedback",
+          "type": "panel",
+          "name": "ayw_virtual_panel",
+          "elements": [
+            {
+              "type": "matrix",
+              "name": "async_activities",
+              "title": "As part of this workshop you engaged in asynchronous work (activities that weren't part of a video conference call). To what extent do you agree or disagree that the following asynchronous activities were useful for your personal learning and development?",
+              "columns": [
+                {
+                  "value": "1",
+                  "text": "Strongly Disagree"
+                },
+                {
+                  "value": "2",
+                  "text": "Disagree"
+                },
+                {
+                  "value": "3",
+                  "text": "Slightly Disagree"
+                },
+                {
+                  "value": "4",
+                  "text": "Neutral"
+                },
+                {
+                  "value": "5",
+                  "text": "Slightly Agree"
+                },
+                {
+                  "value": "6",
+                  "text": "Agree"
+                },
+                {
+                  "value": "7",
+                  "text": "Strongly Agree"
+                }
+              ],
+              "rows": [
+                {
+                  "value": "exploration_time",
+                  "text": "Exploration of course materials and resources."
+                },
+                {
+                  "value": "teaching_practice_reflection",
+                  "text": "Reflection on your own teaching practice."
+                },
+                {
+                  "value": "group_reflection",
+                  "text": "The group reflection exercise."
+                }
+              ]
+            },
+            {
+              "type": "matrix",
+              "name": "logistics_virtual",
+              "title": "To what extent were the following true about participating in this virtual workshop?",
+              "columns": [
+                {
+                  "value": "1",
+                  "text": "Strongly Disagree"
+                },
+                {
+                  "value": "2",
+                  "text": "Disagree"
+                },
+                {
+                  "value": "3",
+                  "text": "Slightly Disagree"
+                },
+                {
+                  "value": "4",
+                  "text": "Neutral"
+                },
+                {
+                  "value": "5",
+                  "text": "Slightly Agree"
+                },
+                {
+                  "value": "6",
+                  "text": "Agree"
+                },
+                {
+                  "value": "7",
+                  "text": "Strongly Agree"
+                }
+              ],
+              "rows": [
+                {
+                  "value": "clear_communication_how_virtually_attend",
+                  "text": "I received clear communication about how to virtually attend the workshop."
+                },
+                {
+                  "value": "tools_met_needs",
+                  "text": "The virtual meeting tool(s) met my learning needs."
+                },
+                {
+                  "value": "adequate_internet_tech",
+                  "text": "My internet connection and technology were adequate to fully participate."
+                }
+              ]
+            },
+            {
+              "type": "comment",
+              "name": "virtual_feedback",
               "maxLength": 4000,
-       "title": "Do you have feedback about the virtual meeting tool or about how logistics were run for this workshop? Please be specific and provide suggestions for improvement.",
-       "rows": 2
-      }
-     ]
+              "title": "Do you have feedback about the virtual meeting tool or about how logistics were run for this workshop? Please be specific and provide suggestions for improvement.",
+              "rows": 2
+            }
+          ]
+        }
+      ]
     }
-   ]
-  }
- ]
+  ]
 }

--- a/dashboard/config/foorm/library/surveys/pd/facilitator_panel.0.json
+++ b/dashboard/config/foorm/library/surveys/pd/facilitator_panel.0.json
@@ -1,105 +1,103 @@
 {
- "published": true,
- "title":"Standard Facilitator effectiveness panel",
- "pages": [
-  {
-   "name": "page1",
-   "elements": [
+  "published": true,
+  "pages": [
     {
-     "type": "html",
-     "name": "facilitator_heading",
-     "html": "<h2>Facilitator Feedback</h2>\n<p>Below we present the same sets of questions for each facilitator of your workshop. Please be thoughtful in your responses for each individual.</p>"
-   },
-   {
-     "type": "paneldynamic",
-     "name": "facilitators",
-     "title": "Facilitators",
-     "allowAddPanel": false,
-     "allowRemovePanel": false,
-     "templateElements": [
-      {
-       "type": "html",
-       "name": "facilitator_name_heading",
-       "html": "<p>Below, please leave feedback for <strong>{panel.facilitator_name}</strong></p>"
-     },
-     {
-       "type": "matrix",
-       "name": "facilitator_effectiveness",
-       "title": "During my workshop, {panel.facilitator_name} did the following:",
-       "columns": [
+      "elements": [
         {
-         "value": "1",
-         "text": "Strongly Disagree"
-       },
-       {
-         "value": "2",
-         "text": "Disagree"
-       },
-       {
-         "value": "3",
-         "text": "Slightly Disagree"
-       },
-       {
-         "value": "4",
-         "text": "Neutral"
-       },
-       {
-         "value": "5",
-         "text": "Slightly Agree"
-       },
-       {
-         "value": "6",
-         "text": "Agree"
-       },
-       {
-         "value": "7",
-         "text": "Strongly Agree"
-       }
-     ],
-       "rows": [
+          "type": "html",
+          "name": "facilitator_heading",
+          "html": "<h2>Facilitator Feedback</h2>\n<p>Below we present the same sets of questions for each facilitator of your workshop. Please be thoughtful in your responses for each individual.</p>"
+        },
         {
-         "value": "demonstrated_knowledge",
-         "text": "Demonstrated knowledge of the curriculum."
-       },
-       {
-         "value": "equitable_workshop_environment",
-         "text": "Built and sustained an equitable learning environment in our workshop."
-       },
-       {
-         "value": "on_track",
-         "text": "Kept the workshop and participants on track."
-       },
-       {
-         "value": "productive_discussions",
-         "text": "Supported productive workshop discussions."
-       },
-       {
-         "value": "create_equity_for_students",
-         "text": "Helped me see ways to create and support an equitable learning environment for my students."
-       },
-       {
-         "value": "healthy_relationship",
-         "text": "Demonstrated a healthy working relationship with their co-facilitator (if applicable)."
-       }
-     ]
-     },
-     {
-       "type": "comment",
-       "name": "facilitator_did_well_fr",
-       "title": "What were two things {panel.facilitator_name} did well?",
+          "type": "paneldynamic",
+          "name": "facilitators",
+          "title": "Facilitators",
+          "allowAddPanel": false,
+          "allowRemovePanel": false,
+          "templateElements": [
+            {
+              "type": "html",
+              "name": "facilitator_name_heading",
+              "html": "<p>Below, please leave feedback for <strong>{panel.facilitator_name}</strong></p>"
+            },
+            {
+              "type": "matrix",
+              "name": "facilitator_effectiveness",
+              "title": "During my workshop, {panel.facilitator_name} did the following:",
+              "columns": [
+                {
+                  "value": "1",
+                  "text": "Strongly Disagree"
+                },
+                {
+                  "value": "2",
+                  "text": "Disagree"
+                },
+                {
+                  "value": "3",
+                  "text": "Slightly Disagree"
+                },
+                {
+                  "value": "4",
+                  "text": "Neutral"
+                },
+                {
+                  "value": "5",
+                  "text": "Slightly Agree"
+                },
+                {
+                  "value": "6",
+                  "text": "Agree"
+                },
+                {
+                  "value": "7",
+                  "text": "Strongly Agree"
+                }
+              ],
+              "rows": [
+                {
+                  "value": "demonstrated_knowledge",
+                  "text": "Demonstrated knowledge of the curriculum."
+                },
+                {
+                  "value": "equitable_workshop_environment",
+                  "text": "Built and sustained an equitable learning environment in our workshop."
+                },
+                {
+                  "value": "on_track",
+                  "text": "Kept the workshop and participants on track."
+                },
+                {
+                  "value": "productive_discussions",
+                  "text": "Supported productive workshop discussions."
+                },
+                {
+                  "value": "create_equity_for_students",
+                  "text": "Helped me see ways to create and support an equitable learning environment for my students."
+                },
+                {
+                  "value": "healthy_relationship",
+                  "text": "Demonstrated a healthy working relationship with their co-facilitator (if applicable)."
+                }
+              ]
+            },
+            {
+              "type": "comment",
+              "name": "facilitator_did_well_fr",
+              "title": "What were two things {panel.facilitator_name} did well?",
               "maxLength": 4000,
-       "rows": 2
-     },
-     {
-       "type": "comment",
-       "name": "facilitator_could_improve_fr",
-       "title": "What were two things {panel.facilitator_name} could do better?",
+              "rows": 2
+            },
+            {
+              "type": "comment",
+              "name": "facilitator_could_improve_fr",
+              "title": "What were two things {panel.facilitator_name} could do better?",
               "maxLength": 4000,
-       "rows": 2
-     }
-   ]
-   }
- ]
- }
-]
+              "rows": 2
+            }
+          ]
+        }
+      ]
+    }
+  ]
 }

--- a/dashboard/config/foorm/library/surveys/pd/workshop_elements.0.json
+++ b/dashboard/config/foorm/library/surveys/pd/workshop_elements.0.json
@@ -1,9 +1,7 @@
 {
- "published": true,
-  "title": "Library of elements for surveys of PD workshops",
+  "published": true,
   "pages": [
     {
-      "name": "page1",
       "elements": [
         {
           "type": "radiogroup",
@@ -22,215 +20,214 @@
           ]
         },
         {
-         "type": "html",
-         "name": "survey_preamble_header_and_text",
-         "html": "<h2>{workshop_course} Academic Year Workshop Post-Survey</h2>\n\n<p><strong>Congratulations! You've completed a Code.org {workshop_course} Academic Year Workshop!</strong></p>\n<p>This survey asks questions about your experience today.&nbsp;</p>\n<p><strong>Privacy and Confidentiality</strong></p>\n<ul>\n<li>Your individual responses here are completely <strong>confidential.</strong></li>\n<li>Your identity will&nbsp;<strong>never</strong> be revealed publicly or used to tie any responses back to you personally.</li>\n<li>We may share <strong>de-identified</strong>, aggregate data (representing all responses) publicly.</li>\n<li>Your <strong>de-identified&nbsp;</strong>responses will be used by Code.org, our Regional Partners, and our facilitators for program improvement.</li>\n</ul>\n<p>This survey should take <strong>less than 10 minutes</strong> to complete.&nbsp;&nbsp;<strong>Your complete honesty and candor are appreciated.</strong></p>"
-       },
-       {
-         "type": "html",
-         "name": "thank_you_heading",
-         "html": "<h2>Thank you!</h2>"
-       },
-       {
-        "type": "html",
-        "name": "workshop_experience_header",
-        "html": "<h2>Your {workshop_course} Workshop Experience</h2>"
-       },
-       {
-        "type": "matrix",
-        "name": "overall_success",
-        "title": "How much do you agree or disagree with the following statements about the workshop overall?",
-        "columns": [
-         {
-          "value": "1",
-          "text": "Strongly Disagree"
-         },
-         {
-          "value": "2",
-          "text": "Disagree"
-         },
-         {
-          "value": "3",
-          "text": "Slightly Disagree"
-         },
-         {
-          "value": "4",
-          "text": "Neutral"
-         },
-         {
-          "value": "5",
-          "text": "Slightly Agree"
-         },
-         {
-          "value": "6",
-          "text": "Agree"
-         },
-         {
-          "value": "7",
-          "text": "Strongly Agree"
-         }
-        ],
-        "rows": [
-         {
-          "value": "more_prepared",
-          "text": "I feel more prepared to teach the material covered in this workshop than before I came."
-         },
-         {
-          "value": "know_where_to_get_help",
-          "text": "I know where to go if I need help preparing to teach this material."
-         },
-         {
-          "value": "suitable_for_my_level",
-          "text": "This professional development was suitable for my level of experience with teaching CS."
-         },
-         {
-          "value": "connected_to_community",
-          "text": "I feel connected to a community of computer science teachers."
-         },
-         {
-          "value": "recommend_to_others",
-          "text": "I would recommend this professional development to others."
-         },
-         {
-          "value": "absolute_best",
-          "text": "This was the absolute best professional development I have ever participated in."
-         }
-        ]
-       },
-       {
-        "type": "matrix",
-        "name": "teacher_engagement",
-        "title": "How much do you agree or disagree with the following statements about your level of engagement in the workshop?",
-        "columns": [
-         {
-          "value": "1",
-          "text": "Strongly Disagree"
-         },
-         {
-          "value": "2",
-          "text": "Disagree"
-         },
-         {
-          "value": "3",
-          "text": "Slightly Disagree"
-         },
-         {
-          "value": "4",
-          "text": "Neutral"
-         },
-         {
-          "value": "5",
-          "text": "Slightly Agree"
-         },
-         {
-          "value": "6",
-          "text": "Agree"
-         },
-         {
-          "value": "7",
-          "text": "Strongly Agree"
-         }
-        ],
-        "rows": [
-         {
-          "value": "activities_engaging",
-          "text": "I found the activities we did in this workshop interesting and engaging."
-         },
-         {
-          "value": "highly_active",
-          "text": "I was highly active and participated a lot in the workshop activities."
-         },
-         {
-          "value": "talk_about_workshop",
-          "text": "When I'm not in Code.org workshops, I frequently talk about ideas or content from the workshop with others."
-         },
-         {
-          "value": "will_use_in_classroom",
-          "text": "I am definitely planning to make use of ideas and content covered in this workshop in my classroom."
-         }
-        ]
-       },
+          "type": "comment",
+          "name": "discuss_tomorrow",
+          "title": "What is one thing you hope to discuss or learn more about the next time we meet?",
+          "cols": 60,
+          "rows": 2
+        },
         {
-     "type": "rating",
-     "name": "feel_prepared",
-     "title": "I feel more prepared to teach {workshop_course} than I did at the beginning of the day.",
-     "rateMax": 7,
-     "minRateDescription": "Strongly Disagree",
-     "maxRateDescription": "Strongly Agree"
-    },
-    {
-     "type": "rating",
-     "name": "teacher_comfort",
-     "title": "I feel comfortable collaborating with teachers in my cohort and asking for support.",
-     "rateMax": 7,
-     "minRateDescription": "Strongly Disagree",
-     "maxRateDescription": "Strongly Agree"
-    },
-    {
-     "type": "rating",
-     "name": "teacher_community",
-     "title": "I feel like I am connected to a community of teachers in my {workshop_course} workshop.",
-     "rateMax": 7,
-     "minRateDescription": "Strongly Disagree",
-     "maxRateDescription": "Strongly Agree"
-    },
-    {
-     "type": "rating",
-     "name": "excited_about_tomorrow",
-     "title": "I am excited about what we will do next time in this workshop.",
-     "rateMax": 7,
-     "minRateDescription": "Strongly Disagree",
-     "maxRateDescription": "Strongly Agree"
-    },
-    {
-     "type": "comment",
-     "name": "what_supported",
-     "title": "What supported your learning the most today and why?",
-     "cols": 60,
-     "rows": 2
-    },
-    {
-     "type": "comment",
-     "name": "what_detracted",
-     "title": "What detracted from your learning today and why?",
-     "cols": 60,
-     "rows": 2
-    },
-    {
-     "type": "comment",
-     "name": "discuss_tomorrow",
-     "title": "What is one thing you hope to discuss or learn more about the next time we meet?",
-     "cols": 60,
-     "rows": 2
-    },
-    {
-     "type": "html",
-     "name": "question2",
-     "html": "<h2>Facilitator Feedback</h2>\n<p>Please be thoughtful in your responses for each individual.</p>"
-    },
-    {
-     "type": "paneldynamic",
-     "name": "facilitators",
-     "title": "Facilitators",
-     "templateElements": [
-      {
-       "type": "comment",
-       "name": "facilitator_feedback_FR",
-       "title": "Do you have any feedback about today for {panel.facilitator_name}?",
-       "rows": 2
-      }
-     ],
-     "templateTitle": "Facilitator {panel.facilitator_position} - {panel.facilitator_name}",
-     "allowAddPanel": false,
-     "allowRemovePanel": false
-    },
-    {
-     "type": "html",
-     "name": "question1",
-     "html": "<p> Thank you for the feedback and for participating today!</p>"
-    }
-      
-     ]
+          "type": "rating",
+          "name": "excited_about_tomorrow",
+          "title": "I am excited about what we will do next time in this workshop.",
+          "rateMax": 7,
+          "minRateDescription": "Strongly Disagree",
+          "maxRateDescription": "Strongly Agree"
+        },
+        {
+          "type": "paneldynamic",
+          "name": "facilitators",
+          "title": "Facilitators",
+          "templateElements": [
+            {
+              "type": "comment",
+              "name": "facilitator_feedback_FR",
+              "title": "Do you have any feedback about today for {panel.facilitator_name}?",
+              "rows": 2
+            }
+          ],
+          "templateTitle": "Facilitator {panel.facilitator_position} - {panel.facilitator_name}",
+          "allowAddPanel": false,
+          "allowRemovePanel": false
+        },
+        {
+          "type": "rating",
+          "name": "feel_prepared",
+          "title": "I feel more prepared to teach {workshop_course} than I did at the beginning of the day.",
+          "rateMax": 7,
+          "minRateDescription": "Strongly Disagree",
+          "maxRateDescription": "Strongly Agree"
+        },
+        {
+          "type": "matrix",
+          "name": "overall_success",
+          "title": "How much do you agree or disagree with the following statements about the workshop overall?",
+          "columns": [
+            {
+              "value": "1",
+              "text": "Strongly Disagree"
+            },
+            {
+              "value": "2",
+              "text": "Disagree"
+            },
+            {
+              "value": "3",
+              "text": "Slightly Disagree"
+            },
+            {
+              "value": "4",
+              "text": "Neutral"
+            },
+            {
+              "value": "5",
+              "text": "Slightly Agree"
+            },
+            {
+              "value": "6",
+              "text": "Agree"
+            },
+            {
+              "value": "7",
+              "text": "Strongly Agree"
+            }
+          ],
+          "rows": [
+            {
+              "value": "more_prepared",
+              "text": "I feel more prepared to teach the material covered in this workshop than before I came."
+            },
+            {
+              "value": "know_where_to_get_help",
+              "text": "I know where to go if I need help preparing to teach this material."
+            },
+            {
+              "value": "suitable_for_my_level",
+              "text": "This professional development was suitable for my level of experience with teaching CS."
+            },
+            {
+              "value": "connected_to_community",
+              "text": "I feel connected to a community of computer science teachers."
+            },
+            {
+              "value": "recommend_to_others",
+              "text": "I would recommend this professional development to others."
+            },
+            {
+              "value": "absolute_best",
+              "text": "This was the absolute best professional development I have ever participated in."
+            }
+          ]
+        },
+        {
+          "type": "html",
+          "name": "question1",
+          "html": "<p> Thank you for the feedback and for participating today!</p>"
+        },
+        {
+          "type": "html",
+          "name": "question2",
+          "html": "<h2>Facilitator Feedback</h2>\n<p>Please be thoughtful in your responses for each individual.</p>"
+        },
+        {
+          "type": "html",
+          "name": "survey_preamble_header_and_text",
+          "html": "<h2>{workshop_course} Academic Year Workshop Post-Survey</h2>\n\n<p><strong>Congratulations! You've completed a Code.org {workshop_course} Academic Year Workshop!</strong></p>\n<p>This survey asks questions about your experience today.&nbsp;</p>\n<p><strong>Privacy and Confidentiality</strong></p>\n<ul>\n<li>Your individual responses here are completely <strong>confidential.</strong></li>\n<li>Your identity will&nbsp;<strong>never</strong> be revealed publicly or used to tie any responses back to you personally.</li>\n<li>We may share <strong>de-identified</strong>, aggregate data (representing all responses) publicly.</li>\n<li>Your <strong>de-identified&nbsp;</strong>responses will be used by Code.org, our Regional Partners, and our facilitators for program improvement.</li>\n</ul>\n<p>This survey should take <strong>less than 10 minutes</strong> to complete.&nbsp;&nbsp;<strong>Your complete honesty and candor are appreciated.</strong></p>"
+        },
+        {
+          "type": "rating",
+          "name": "teacher_comfort",
+          "title": "I feel comfortable collaborating with teachers in my cohort and asking for support.",
+          "rateMax": 7,
+          "minRateDescription": "Strongly Disagree",
+          "maxRateDescription": "Strongly Agree"
+        },
+        {
+          "type": "rating",
+          "name": "teacher_community",
+          "title": "I feel like I am connected to a community of teachers in my {workshop_course} workshop.",
+          "rateMax": 7,
+          "minRateDescription": "Strongly Disagree",
+          "maxRateDescription": "Strongly Agree"
+        },
+        {
+          "type": "matrix",
+          "name": "teacher_engagement",
+          "title": "How much do you agree or disagree with the following statements about your level of engagement in the workshop?",
+          "columns": [
+            {
+              "value": "1",
+              "text": "Strongly Disagree"
+            },
+            {
+              "value": "2",
+              "text": "Disagree"
+            },
+            {
+              "value": "3",
+              "text": "Slightly Disagree"
+            },
+            {
+              "value": "4",
+              "text": "Neutral"
+            },
+            {
+              "value": "5",
+              "text": "Slightly Agree"
+            },
+            {
+              "value": "6",
+              "text": "Agree"
+            },
+            {
+              "value": "7",
+              "text": "Strongly Agree"
+            }
+          ],
+          "rows": [
+            {
+              "value": "activities_engaging",
+              "text": "I found the activities we did in this workshop interesting and engaging."
+            },
+            {
+              "value": "highly_active",
+              "text": "I was highly active and participated a lot in the workshop activities."
+            },
+            {
+              "value": "talk_about_workshop",
+              "text": "When I'm not in Code.org workshops, I frequently talk about ideas or content from the workshop with others."
+            },
+            {
+              "value": "will_use_in_classroom",
+              "text": "I am definitely planning to make use of ideas and content covered in this workshop in my classroom."
+            }
+          ]
+        },
+        {
+          "type": "html",
+          "name": "thank_you_heading",
+          "html": "<h2>Thank you!</h2>"
+        },
+        {
+          "type": "comment",
+          "name": "what_detracted",
+          "title": "What detracted from your learning today and why?",
+          "cols": 60,
+          "rows": 2
+        },
+        {
+          "type": "comment",
+          "name": "what_supported",
+          "title": "What supported your learning the most today and why?",
+          "cols": 60,
+          "rows": 2
+        },
+        {
+          "type": "html",
+          "name": "workshop_experience_header",
+          "html": "<h2>Your {workshop_course} Workshop Experience</h2>"
+        }
+      ]
     }
   ]
 }


### PR DESCRIPTION
[note: rec viewing these diffs with whitespace changes ignored]

Short term fix to prevent file system changes after seeding Foorm libraries in environments where levelbuilder_mode = true. This PR introduces all of the JSON changes that were introduced when I ran `RAILS_ENV=test bundle exec rake db:reset`.

For context, a "library question" is an entity in our Foorm survey system. A library question can be reused across multiple forms, and a library is a collection of these questions. Each library is stored as its own file in our config directory. We write to file every time a change is made to library questions while our application is in "levelbuilder mode".

The problem is that after any save to a library question, [we save that library question and any other library questions to a JSON configuration file](https://github.com/code-dot-org/code-dot-org/blob/staging/dashboard/app/models/foorm/library_question.rb#L36). This is primarily for use in the levelbuilder environment, but can produce file system changes when developers have levelbuilder_mode set to true in their locals.yml.

I am not 100% sure what the appropriate longer term solution is here -- we could separate editing foorm editing as its own config setting (vs. relying on levelbuilder mode flag). I'm not sure how substantial that change would be.

[Slack conversation with more information here.](https://codedotorg.slack.com/archives/CC4U03GA0/p1615762211004400)

## Testing story

I tested that I was able to run the same command (`RAILS_ENV=test bundle exec rake db:reset`) with the versions of the files that are in this PR. I think this also gets executed as part of our Drone run, to confirm we're not introducing any bad config.

Dave also graciously confirmed that this PR fixed the issue that this PR is intended to solve (he found no diffs when seeding Foorm forms in his test DB with the application in levelbuilder mode).

## Follow-up work

As mentioned above, open to suggestions about how we might solve this going forward. New libraries and library questions will soon be introduced via our new [Foorm editor on levelbuilder](https://github.com/code-dot-org/code-dot-org/pull/39003). I _think_ in these case, we won't have these issues because writes to file should be consistent (the changes here are largely when extraneous information, such as a page name like "page 1" was included when the library was originally imported via PR).

## PR Checklist:

- [x] Tests provide adequate coverage
- [x] Privacy and Security impacts have been assessed
- [x] Code is well-commented
- [x] New features are translatable or updates will not break translations
- [x] Relevant documentation has been added or updated
- [x] User impact is well-understood and desirable
- [x] Pull Request is labeled appropriately
- [x] Follow-up work items (including potential tech debt) are tracked and linked
