### PR TITLE
Javalab: Include real instructions

### DIFF
--- a/apps/src/javalab/JavalabView.jsx
+++ b/apps/src/javalab/JavalabView.jsx
@@ -14,21 +14,14 @@ import InstructionsWithWorkspace from '@cdo/apps/templates/instructions/Instruct
 const style = {
   instructionsAndPreview: {
     width: '40%',
-    display: 'block'
+    position: 'relative',
+    margin: 15
   },
   editorAndConsole: {
     width: '60%',
-    display: 'block'
-  },
-  instructions: {
-    height: '25%',
-    marginLeft: 15,
-    marginRight: 15,
-    backgroundColor: color.white,
-    color: color.black
+    position: 'relative'
   },
   preview: {
-    margin: 15,
     backgroundColor: color.light_gray,
     height: '200px'
   },
@@ -104,74 +97,65 @@ class JavalabView extends React.Component {
   renderJavalab() {
     return (
       <StudioAppWrapper>
-        <InstructionsWithWorkspace>
-          <div style={style.javalab}>
-            <div style={style.instructionsAndPreview}>
-              <div style={style.instructions}>
-                <PaneHeader hasFocus={true}>
-                  <PaneSection>Instructions</PaneSection>
-                </PaneHeader>
-                <ul>
-                  <li>Instruction 1</li>
-                  <li>Another Instruction</li>
-                </ul>
-              </div>
+        <div style={style.javalab}>
+          <div style={style.instructionsAndPreview}>
+            <InstructionsWithWorkspace>
               <div style={style.preview}>
                 <PaneHeader hasFocus={true}>
                   <PaneSection>Preview</PaneSection>
                 </PaneHeader>
               </div>
-            </div>
-            <div style={style.editorAndConsole}>
-              <JavalabEditor />
-              <div style={style.consoleAndButtons}>
-                <div style={style.buttons}>
-                  <button
-                    type="button"
-                    style={style.singleButton}
-                    onClick={() => {}}
-                  >
-                    <FontAwesome icon="stop" className="fa-2x" />
-                    <br />
-                    Stop
-                  </button>
-                  <button
-                    type="button"
-                    style={style.singleButton}
-                    onClick={this.props.onContinue}
-                  >
-                    <FontAwesome icon="check" className="fa-2x" />
-                    <br />
-                    Continue
-                  </button>
-                </div>
-                <div style={style.buttons}>
-                  <button
-                    type="button"
-                    style={style.singleButton}
-                    onClick={this.compile}
-                  >
-                    <FontAwesome icon="cubes" className="fa-2x" />
-                    <br />
-                    Compile
-                  </button>
-                  <button
-                    type="button"
-                    style={style.singleButton}
-                    onClick={this.run}
-                  >
-                    <FontAwesome icon="play" className="fa-2x" />
-                    <br />
-                    Run
-                  </button>
-                </div>
-                <div style={style.consoleStyle}>
-                  <JavalabConsole />
-                </div>
+            </InstructionsWithWorkspace>
+          </div>
+          <div style={style.editorAndConsole}>
+            <JavalabEditor />
+            <div style={style.consoleAndButtons}>
+              <div style={style.buttons}>
+                <button
+                  type="button"
+                  style={style.singleButton}
+                  onClick={() => {}}
+                >
+                  <FontAwesome icon="stop" className="fa-2x" />
+                  <br />
+                  Stop
+                </button>
+                <button
+                  type="button"
+                  style={style.singleButton}
+                  onClick={this.props.onContinue}
+                >
+                  <FontAwesome icon="check" className="fa-2x" />
+                  <br />
+                  Continue
+                </button>
+              </div>
+              <div style={style.buttons}>
+                <button
+                  type="button"
+                  style={style.singleButton}
+                  onClick={this.compile}
+                >
+                  <FontAwesome icon="cubes" className="fa-2x" />
+                  <br />
+                  Compile
+                </button>
+                <button
+                  type="button"
+                  style={style.singleButton}
+                  onClick={this.run}
+                >
+                  <FontAwesome icon="play" className="fa-2x" />
+                  <br />
+                  Run
+                </button>
+              </div>
+              <div style={style.consoleStyle}>
+                <JavalabConsole />
               </div>
             </div>
           </div>
-        </InstructionsWithWorkspace>
+        </div>
       </StudioAppWrapper>
     );
   }

--- a/apps/src/javalab/JavalabView.jsx
+++ b/apps/src/javalab/JavalabView.jsx
@@ -15,7 +15,7 @@ const style = {
   instructionsAndPreview: {
     width: '40%',
     position: 'relative',
-    margin: 15
+    marginRight: 15
   },
   editorAndConsole: {
     width: '60%',

--- a/dashboard/config/scripts/levels/New Java Lab Project.level
+++ b/dashboard/config/scripts/levels/New Java Lab Project.level
@@ -8,6 +8,7 @@
     "is_project_level": "true"
   },
   "published": true,
-  "notes": ""
+  "notes": "",
+  "long_instructions": "# Java Lab \r\n This is a new Java Lab project! Write some Java code!"
 }]]></config>
 </Javalab>


### PR DESCRIPTION
Replace our fake instructions panel with the real instructions panel that will pull instructions from the level definition. The UI now looks like this for the "New Java Lab" project (console not included in this screenshot as it has not changed):
<img width="1064" alt="Screen Shot 2021-03-16 at 4 14 31 PM" src="https://user-images.githubusercontent.com/33666587/111394201-79f10180-8677-11eb-995f-26a7c4d8a4b1.png">

Note: this PR is best viewed with whitespace changes hidden.

## Links
- jira ticket: [CSA-141](https://codedotorg.atlassian.net/browse/CSA-141)


## Testing story
Tested locally. This change was mostly moving the instructions to the correct place in JavalabView and some CSS updates.

## Deployment strategy

## Follow-up work
Allow creation of new Java Lab levels in levelbuilder.


## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
