### PR TITLE
Fix progress table expander styling

### DIFF
--- a/apps/src/templates/sectionProgress/progressTables/ProgressTableStudentName.jsx
+++ b/apps/src/templates/sectionProgress/progressTables/ProgressTableStudentName.jsx
@@ -19,9 +19,10 @@ const styles = {
     textAlign: 'center'
   },
   collapser: {
-    paddingRight: '10px',
+    paddingRight: '8px',
     fontSize: '20px',
-    verticalAlign: 'middle'
+    verticalAlign: 'middle',
+    width: '11px'
   }
 };
 class ProgressTableStudentName extends React.PureComponent {

--- a/apps/src/templates/sectionProgress/progressTables/progressTableStyles.scss
+++ b/apps/src/templates/sectionProgress/progressTables/progressTableStyles.scss
@@ -63,7 +63,7 @@ $content-view-width: $content-width - $student-list-width;
       width: $student-list-width;
     }
     .progress-table-student-name {
-      width: $student-list-width;
+      width: $student-list-width - 4px;
     }
     .expanded-row {
       td {


### PR DESCRIPTION
<!--
  A summary of the change, including any relevant background, motivation, and context.
  If relevant, include a description, screenshots, and/or video of the existing and new behavior.
-->
Ensures student names won't overflow student name column causing scrolling. Sets width of collapser icon so it won't shift names when rotated.

![Screen Shot 2021-03-17 at 11 27 29 AM](https://user-images.githubusercontent.com/24235215/111518958-d570cd00-8713-11eb-8a07-3046ac50be91.png)

## Links

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

<!--
- spec: []()
- jira ticket: []()
-->

## Testing story

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
