### PR TITLE
Add 'iframe' to default list of disallowed HTML tags

### DIFF
--- a/dashboard/app/helpers/levels_helper.rb
+++ b/dashboard/app/helpers/levels_helper.rb
@@ -475,7 +475,7 @@ module LevelsHelper
   end
 
   def disallowed_html_tags
-    DCDO.get('disallowed_html_tags', ['script'])
+    DCDO.get('disallowed_html_tags', ['script', 'iframe'])
   end
 
   # Options hash for Blockly

--- a/shared/middleware/files_api.rb
+++ b/shared/middleware/files_api.rb
@@ -308,6 +308,10 @@ class FilesApi < Sinatra::Base
     File.extname(filename&.downcase) == '.html'
   end
 
+  def disallowed_html_tags
+    DCDO.get('disallowed_html_tags', ['script', 'iframe'])
+  end
+
   # Determine whether or not a file is a valid HTML file.
   # Returns true if:
   #   1. It does not belong to a WebLab project.
@@ -324,7 +328,7 @@ class FilesApi < Sinatra::Base
     return true unless project[:projectType]&.downcase == 'weblab'
 
     # Nokogiri element selector tags must start with //
-    disallowed_tag_selectors = DCDO.get('disallowed_html_tags', ['script']).map {|tag| '//' + tag}
+    disallowed_tag_selectors = disallowed_html_tags.map {|tag| '//' + tag}
     Nokogiri::HTML(body).xpath(*disallowed_tag_selectors).empty?
   end
 


### PR DESCRIPTION
Follow-up to #39359. We had to re-enable iframes in WebLab because there was a curriculum level that taught the <iframe> element. That level was a BubbleChoice level, so we decided to remove the level since it isn't essential to our curriculum and there was only one.

Add 'iframe' to the default list of disallowed HTML tags, which is controlled by the `disallowed_html_tags` DCDO flag.

## Links

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

- [STAR-1473](https://codedotorg.atlassian.net/browse/STAR-1473)

## Testing story

Relies on existing unit tests.

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [x] Tests provide adequate coverage
- [x] Privacy and Security impacts have been assessed
- [x] Code is well-commented
- [x] New features are translatable or updates will not break translations
- [x] Relevant documentation has been added or updated
- [x] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [x] Follow-up work items (including potential tech debt) are tracked and linked
