### PR TITLE
Refactor progress loading and saving for signed-out users

### DIFF
--- a/apps/src/StudioApp.js
+++ b/apps/src/StudioApp.js
@@ -64,7 +64,6 @@ import {setIsRunning, setIsEditWhileRun, setStepSpeed} from './redux/runState';
 import {isEditWhileRun} from './lib/tools/jsdebugger/redux';
 import {setPageConstants} from './redux/pageConstants';
 import {setVisualizationScale} from './redux/layout';
-import {mergeProgress} from './code-studio/progressRedux';
 import {createLibraryClosure} from '@cdo/apps/code-studio/components/libraries/libraryParser';
 import {
   setAchievements,
@@ -1655,16 +1654,6 @@ StudioApp.prototype.displayFeedback = function(options) {
     options.feedbackType = TestResults.EDIT_BLOCKS;
   }
 
-  // Write updated progress to Redux.
-  const store = getStore();
-  if (this.config) {
-    // Some apps (Weblab, Oceans) don't have a config. Skip this step
-    // for those.
-    store.dispatch(
-      mergeProgress({[this.config.serverLevelId]: options.feedbackType})
-    );
-  }
-
   if (experiments.isEnabled(experiments.BUBBLE_DIALOG)) {
     // Track whether this experiment is in use. If not, delete this and similar
     // sections of code. If it is, create a non-experiment flag.
@@ -1686,6 +1675,7 @@ StudioApp.prototype.displayFeedback = function(options) {
     const hasNewFinishDialog = newFinishDialogApps[this.config.app];
 
     if (hasNewFinishDialog && !this.hasContainedLevels) {
+      const store = getStore();
       const generatedCodeProperties = this.feedback_.getGeneratedCodeProperties(
         this.config.appStrings
       );

--- a/apps/src/code-studio/clientState.js
+++ b/apps/src/code-studio/clientState.js
@@ -39,6 +39,15 @@ clientState.reset = function() {
 };
 
 /**
+ * Clear progress-related values from session storage.
+ */
+clientState.clearProgress = function() {
+  sessionStorage.removeItem('progress');
+  sessionStorage.removeItem('lines');
+  removeItemsWithPrefix(sessionStorage, 'source_');
+};
+
+/**
  * Returns the client-cached copy of the level source for the given script
  * level, if it's newer than the given timestamp.
  * @param {string} scriptName
@@ -250,4 +259,17 @@ function hasSeenVisualElement(visualElementType, visualElementId) {
  */
 function createKey(scriptName, levelId, prefix) {
   return (prefix ? prefix + '_' : '') + scriptName + '_' + levelId;
+}
+
+/**
+ * Removes all items from the given sessionStorage object that start with the
+ * given prefix.
+ *
+ * @param {Storage} sessionStorage
+ * @param {string} prefix
+ */
+function removeItemsWithPrefix(sessionStorage, prefix) {
+  Object.keys(sessionStorage)
+    .filter(key => key.startsWith(prefix))
+    .forEach(key => sessionStorage.removeItem(key));
 }

--- a/apps/src/code-studio/clientState.js
+++ b/apps/src/code-studio/clientState.js
@@ -3,7 +3,8 @@
  *       combination of cookies and HTML5 web storage.
  */
 import {trySetSessionStorage} from '../utils';
-import {getStore} from './redux';
+import {mergeActivityResult} from './activityUtils';
+
 // Note: sessionStorage is not shared between tabs.
 var sessionStorage = window.sessionStorage;
 
@@ -35,11 +36,6 @@ clientState.reset = function() {
   try {
     sessionStorage.clear();
   } catch (e) {}
-};
-
-clientState.clearProgress = function() {
-  sessionStorage.removeItem('progress');
-  sessionStorage.removeItem('lines');
 };
 
 /**
@@ -93,48 +89,58 @@ clientState.writeSourceForLevel = function(
 
 /**
  * Tracks the lines of code written after the user clicks run if their
- * solution is successful. Skips if the user is logged in.
+ * solution is successful.
  * @param {boolean} result - Whether the user's solution is successful
  * @param {number} lines - Number of lines of code user wrote in this solution
  */
 clientState.trackLines = function(result, lines) {
-  if (
-    result &&
-    isFinite(lines) &&
-    !getStore().getState().progress.usingDbProgress
-  ) {
+  if (result && isFinite(lines)) {
     addLines(lines);
   }
 };
 
 /**
- * Write down user progress for an entire script.
+ * Merges the given testResult for the given level into the progress
+ * data stored in session storage.
  * @param {string} scriptName
- * @param {Object<String, number>} progress
+ * @param {number} levelId
+ * @param {TestResults} testResult
  */
-clientState.batchTrackProgress = function(scriptName, progress) {
-  var data = {};
-  var keys = Object.keys(progress);
-  for (let i = 0; i < keys.length; i++) {
-    let level = keys[i];
-    if (
-      progress[level] &&
-      progress[level] <= clientState.MAXIMUM_CACHABLE_RESULT
-    ) {
-      data[level] = progress[level];
-    }
+clientState.trackProgress = function(scriptName, levelId, testResult) {
+  // testResult values > 1000 are for server use only and should not be stored
+  // locally
+  if (!testResult || testResult > clientState.MAXIMUM_CACHABLE_RESULT) {
+    return;
   }
 
-  var progressMap = clientState.allLevelsProgress();
-  progressMap[scriptName] = data;
-  trySetSessionStorage('progress', JSON.stringify(progressMap));
+  const progressData = levelProgressByScript();
+  if (!progressData[scriptName]) {
+    progressData[scriptName] = {};
+  }
+  const savedResult = progressData[scriptName][levelId] || 0;
+  const mergedResult = mergeActivityResult(savedResult, testResult);
+
+  if (mergedResult !== savedResult) {
+    progressData[scriptName][levelId] = mergedResult;
+    trySetSessionStorage('progress', JSON.stringify(progressData));
+  }
 };
 
 /**
- * Returns a map from (string) level id to progress value.
- * @return {Object<String, number>}
+ * Returns the level progress map for the given script.
+ * @param {string} scriptName The script name
+ * @returns {Object<number, number>} map from levelId -> testResult
  */
-clientState.allLevelsProgress = function() {
+clientState.levelProgress = function(scriptName) {
+  var progressMap = levelProgressByScript();
+  return progressMap[scriptName] || {};
+};
+
+/**
+ * Returns a map from script name to level progress map
+ * @return {Object<String, Object>}
+ */
+function levelProgressByScript() {
   var progressJson = sessionStorage.getItem('progress');
   try {
     return progressJson ? JSON.parse(progressJson) : {};
@@ -142,7 +148,7 @@ clientState.allLevelsProgress = function() {
     // Recover from malformed data.
     return {};
   }
-};
+}
 
 /**
  * Returns the number of lines completed from the cookie.

--- a/apps/src/code-studio/header.js
+++ b/apps/src/code-studio/header.js
@@ -116,7 +116,7 @@ header.build = function(
     );
     // Only render sign in callout if the course is CSF and the user is
     // not signed in
-    if (scriptData.is_csf && !signedIn) {
+    if (scriptData.is_csf && signedIn === false) {
       ReactDOM.render(
         <SignInCalloutWrapper />,
         document.querySelector('.signin_callout_wrapper')

--- a/apps/src/code-studio/header.js
+++ b/apps/src/code-studio/header.js
@@ -12,8 +12,6 @@ import {
   refreshProjectName,
   setShowTryAgainDialog
 } from './headerRedux';
-import {useDbProgress} from './progressRedux';
-import clientState from './clientState';
 
 import React from 'react';
 import ReactDOM from 'react-dom';
@@ -77,11 +75,6 @@ header.build = function(
   scriptNameData,
   isLessonExtras
 ) {
-  const store = getStore();
-  if (progressData) {
-    store.dispatch(useDbProgress());
-    clientState.clearProgress();
-  }
   scriptData = scriptData || {};
   lessonGroupData = lessonGroupData || {};
   lessonData = lessonData || {};
@@ -107,6 +100,7 @@ header.build = function(
   // Hold off on rendering HeaderMiddle.  This will allow the "app load"
   // to potentially begin before we first render HeaderMiddle, giving HeaderMiddle
   // the opportunity to wait until the app is loaded before rendering.
+  const store = getStore();
   $(document).ready(function() {
     ReactDOM.render(
       <Provider store={store}>

--- a/apps/src/code-studio/header.js
+++ b/apps/src/code-studio/header.js
@@ -83,7 +83,8 @@ header.build = function(
   const linesOfCodeText = progressData.linesOfCodeText;
   let saveAnswersBeforeNavigation = currentPageNumber !== PUZZLE_PAGE_NONE;
 
-  // Set up the store immediately.
+  // Set up the store immediately. Note that some progress values are populated
+  // asynchronously.
   progress.generateStageProgress(
     scriptData,
     lessonGroupData,

--- a/apps/src/code-studio/initApp/loadApp.js
+++ b/apps/src/code-studio/initApp/loadApp.js
@@ -308,8 +308,8 @@ function loadAppAsync(appOptions) {
         appOptions.disableSocialShare = data.disableSocialShare;
 
         // We do not need to process data.progress here because labs do not use
-        // the the level progress data directly. (The progress bubbles in the
-        // header of the level pages are rendered by header.build in header.js.)
+        // the level progress data directly. (The progress bubbles in the header
+        // of the level pages are rendered by header.build in header.js.)
 
         if (data.lastAttempt) {
           appOptions.level.lastAttempt = data.lastAttempt.source;

--- a/apps/src/code-studio/initApp/loadApp.js
+++ b/apps/src/code-studio/initApp/loadApp.js
@@ -2,10 +2,7 @@
 import $ from 'jquery';
 import React from 'react';
 import ReactDOM from 'react-dom';
-import {TestResults} from '@cdo/apps/constants';
 import {getStore} from '../redux';
-import {overwriteProgress, useDbProgress} from '../progressRedux';
-import {SignInState} from '@cdo/apps/templates/currentUserRedux';
 import {setVerified} from '@cdo/apps/code-studio/verifiedTeacherRedux';
 import {
   setAppLoadStarted,
@@ -25,51 +22,13 @@ var createCallouts = require('@cdo/apps/code-studio/callouts').default;
 var reporting = require('@cdo/apps/code-studio/reporting');
 var LegacyDialog = require('@cdo/apps/code-studio/LegacyDialog');
 var showVideoDialog = require('@cdo/apps/code-studio/videos').showVideoDialog;
-import {
-  lockContainedLevelAnswers,
-  getContainedLevelId
-} from '@cdo/apps/code-studio/levels/codeStudioLevels';
+import {lockContainedLevelAnswers} from '@cdo/apps/code-studio/levels/codeStudioLevels';
 import queryString from 'query-string';
 import * as imageUtils from '@cdo/apps/imageUtils';
 import trackEvent from '../../util/trackEvent';
 import msg from '@cdo/locale';
-import _ from 'lodash';
-
-// Max milliseconds to wait for last attempt data from the server
-var LAST_ATTEMPT_TIMEOUT = 5000;
 
 const SHARE_IMAGE_NAME = '_share_image.png';
-
-/**
- * When we have a publicly cacheable script, the server does not send down the
- * user's levelProgress, and instead we get it asynchronously. This method adds
- * that progress to our redux store, and then also updates the clientState (i.e.
- * sessionStorage)
- * Note: A better approach to backing up progress in sessionStorage would likely
- * be to attach a listener to our redux store, and then update clientState whenever
- * levelProgress changes in the store.
- * @param {string} scriptName
- * @param {Object<number, TestResult>} serverProgress Mapping from levelId to TestResult
- */
-function mergeProgressData(scriptName, serverProgress) {
-  if (!serverProgress) {
-    return;
-  }
-  const store = getStore();
-
-  // The server returned progress. This is the source of truth.
-  store.dispatch(useDbProgress());
-  clientState.clearProgress();
-
-  // Clear any existing redux state.
-  store.dispatch(
-    overwriteProgress(
-      _.mapValues(serverProgress, level =>
-        level.submitted ? TestResults.SUBMITTED_RESULT : level.result
-      )
-    )
-  );
-}
 
 /**
  * Legacy Blockly initialization that was moved here from _blockly.html.haml.
@@ -82,8 +41,6 @@ export function setupApp(appOptions) {
     throw new Error('Assume existence of window.dashboard');
   }
   timing.startTiming('Puzzle', window.script_path, '');
-
-  var lastSavedProgram;
 
   if (appOptions.hasContainedLevels) {
     if (appOptions.readonlyWorkspace) {
@@ -140,28 +97,8 @@ export function setupApp(appOptions) {
         // already stored in the channels API.)
         delete report.program;
         delete report.image;
-      } else if (
-        report.testResult !== TestResults.SKIPPED &&
-        report.program !== undefined
-      ) {
-        // Only locally cache non-channel-backed levels. Use a client-generated
-        // timestamp initially (it will be updated with a timestamp from the server
-        // if we get a response.
-        lastSavedProgram = decodeURIComponent(report.program);
-
-        // If the program is the result for a contained level, store it with
-        // the contained level id
-        const levelId =
-          appOptions.hasContainedLevels && !appOptions.level.edit_blocks
-            ? getContainedLevelId()
-            : appOptions.serverProjectLevelId || appOptions.serverLevelId;
-        clientState.writeSourceForLevel(
-          appOptions.scriptName,
-          levelId,
-          +new Date(),
-          lastSavedProgram
-        );
       }
+
       // Our report will already have the correct callback and program
       // in the contained level case, unless we're editing blocks.
       if (appOptions.level.edit_blocks || !appOptions.hasContainedLevels) {
@@ -181,17 +118,6 @@ export function setupApp(appOptions) {
         timing.stopTiming('Puzzle', window.script_path, '');
       }
       reporting.sendReport(report);
-    },
-    onComplete: function(/*LiveMilestoneResponse*/ response) {
-      if (!appOptions.channel && !appOptions.hasContainedLevels) {
-        // Update the cache timestamp with the (more accurate) value from the server.
-        clientState.writeSourceForLevel(
-          appOptions.scriptName,
-          appOptions.serverProjectLevelId || appOptions.serverLevelId,
-          response.timestamp,
-          lastSavedProgram
-        );
-      }
     },
     onResetPressed: function() {
       reporting.cancelReport();
@@ -366,22 +292,6 @@ function loadAppAsync(appOptions) {
   }
 
   return new Promise((resolve, reject) => {
-    let lastAttemptLoaded = false;
-
-    const loadLastAttemptFromSessionStorage = () => {
-      if (!lastAttemptLoaded) {
-        lastAttemptLoaded = true;
-
-        // Load the locally-cached last attempt (if one exists)
-        appOptions.level.lastAttempt = clientState.sourceForLevel(
-          appOptions.scriptName,
-          appOptions.serverProjectLevelId || appOptions.serverLevelId
-        );
-
-        resolve(appOptions);
-      }
-    };
-
     if (appOptions.publicCaching) {
       // Disable social share by default on publicly-cached pages, because we don't know
       // if the user is underage until we get data back from /api/user_progress/ and we
@@ -389,49 +299,24 @@ function loadAppAsync(appOptions) {
       appOptions.disableSocialShare = true;
     }
 
-    $.ajax(
-      `/api/user_progress` +
-        `/${appOptions.scriptName}` +
-        `/${appOptions.stagePosition}` +
-        `/${appOptions.levelPosition}` +
-        `/${appOptions.serverLevelId}`
-    )
-      .done(data => {
-        appOptions.disableSocialShare = data.disableSocialShare;
+    if (appOptions.userId) {
+      // User is signed in, send request to server to get user progress
+      $.ajax(
+        `/api/user_progress` +
+          `/${appOptions.scriptName}` +
+          `/${appOptions.stagePosition}` +
+          `/${appOptions.levelPosition}` +
+          `/${appOptions.serverLevelId}`
+      )
+        .done(data => {
+          appOptions.disableSocialShare = data.disableSocialShare;
 
-        // Merge progress from server (loaded via AJAX)
-        mergeProgressData(appOptions.scriptName, data.progress);
+          // We do not need to process data.progress here because labs do not use
+          // the the level progress data directly. (The progress bubbles in the
+          // header of the level pages are rendered by header.build in header.js.)
 
-        if (!lastAttemptLoaded) {
           if (data.lastAttempt) {
-            lastAttemptLoaded = true;
-
-            var timestamp = data.lastAttempt.timestamp;
-            var source = data.lastAttempt.source;
-
-            var cachedProgram = clientState.sourceForLevel(
-              appOptions.scriptName,
-              appOptions.serverLevelId,
-              timestamp
-            );
-            if (cachedProgram !== undefined) {
-              // Client version is newer
-              appOptions.level.lastAttempt = cachedProgram;
-            } else if (source && source.length) {
-              // Sever version is newer
-              appOptions.level.lastAttempt = source;
-
-              // Write down the lastAttempt from server in sessionStorage
-              clientState.writeSourceForLevel(
-                appOptions.scriptName,
-                appOptions.serverLevelId,
-                timestamp,
-                source
-              );
-            }
-            resolve(appOptions);
-          } else {
-            loadLastAttemptFromSessionStorage();
+            appOptions.level.lastAttempt = data.lastAttempt.source;
           }
 
           if (data.pairingDriver) {
@@ -439,28 +324,29 @@ function loadAppAsync(appOptions) {
             appOptions.level.pairingAttempt = data.pairingAttempt;
             appOptions.level.pairingChannelId = data.pairingChannelId;
           }
-        }
 
-        const store = getStore();
+          if (data.isVerifiedTeacher) {
+            getStore().dispatch(setVerified());
+          }
 
-        // Note: We aren't guaranteed that currentUser.signInState will have been set at this point.
-        // It gets set on document.ready. However, it is highly unlikely that the server will return
-        // a response before document.ready is triggered. So far, this hasn't caused problems, so not
-        // worrying about this for now.
-        const signInState = store.getState().currentUser.signInState;
-        if (signInState === SignInState.SignedIn) {
+          // Check to see if we need to show disabled bubbles alert
           progress.showDisabledBubblesAlert();
-        }
-        if (data.isVerifiedTeacher) {
-          store.dispatch(setVerified());
-        }
-      })
-      .fail(loadLastAttemptFromSessionStorage);
 
-    // Use this instead of a timeout on the AJAX request because we still want
-    // the header progress data even if the last attempt data takes too long.
-    // The progress dots can fade in at any time without impacting the user.
-    setTimeout(loadLastAttemptFromSessionStorage, LAST_ATTEMPT_TIMEOUT);
+          resolve(appOptions);
+        })
+        .fail(() => {
+          // TODO: Show an error to the user here? (LP-1815)
+          resolve(appOptions);
+        });
+    } else {
+      // User is not signed in, load last attempt from session storage.
+      appOptions.level.lastAttempt = clientState.sourceForLevel(
+        appOptions.scriptName,
+        appOptions.serverProjectLevelId || appOptions.serverLevelId
+      );
+
+      resolve(appOptions);
+    }
   });
 }
 

--- a/apps/src/code-studio/levels/postOnLoad.js
+++ b/apps/src/code-studio/levels/postOnLoad.js
@@ -11,8 +11,6 @@ import {
   getLastServerResponse
 } from '@cdo/apps/code-studio/reporting';
 import {TestResults} from '@cdo/apps/constants';
-import {getStore} from '@cdo/apps/redux';
-import {mergeProgress} from '@cdo/apps/code-studio/progressRedux';
 
 /**
  * Make our milestone post with some simple configuration. Note, this assumes
@@ -51,15 +49,6 @@ export function postMilestoneForPageLoad() {
  * In practice, these will be identical.
  */
 export function onContinue() {
-  // Record the progress in redux - this will ensure progress is mirrored in the
-  // session storage if the user is logged out. When the user is logged in, this
-  // is a no-op as the redux store will be cleared when the page navigation
-  // happens. Logged-in progress is stored by the milestone in postMilestoneForPageLoad.
-  const store = getStore();
-  store.dispatch(
-    mergeProgress({[appOptions.serverLevelId]: TestResults.ALL_PASS})
-  );
-
   const lastServerResponse = getLastServerResponse();
   let url = lastServerResponse && lastServerResponse.nextRedirect;
   if (!url) {

--- a/apps/src/code-studio/progressRedux.js
+++ b/apps/src/code-studio/progressRedux.js
@@ -31,7 +31,6 @@ const SET_STUDENT_DEFAULTS_SUMMARY_VIEW =
 const SET_CURRENT_STAGE_ID = 'progress/SET_CURRENT_STAGE_ID';
 const SET_SCRIPT_COMPLETED = 'progress/SET_SCRIPT_COMPLETED';
 const SET_STAGE_EXTRAS_ENABLED = 'progress/SET_STAGE_EXTRAS_ENABLED';
-const USE_DB_PROGRESS = 'progress/USE_DB_PROGRESS';
 const OVERWRITE_PROGRESS = 'progress/OVERWRITE_PROGRESS';
 
 const PEER_REVIEW_ID = -1;
@@ -66,11 +65,6 @@ const initialState = {
   isSummaryView: true,
   hasFullProgress: false,
   stageExtrasEnabled: false,
-  // Note: usingDbProgress === "user is logged in". However, it is
-  // possible that we can get the user progress back from the DB
-  // prior to having information about the user login state.
-  // TODO: Use sign in state to determine where to source user progress from
-  usingDbProgress: false,
   currentPageNumber: PUZZLE_PAGE_NONE
 };
 
@@ -103,13 +97,6 @@ export default function reducer(state = initialState, action) {
       hasFullProgress: action.isFullProgress,
       isLessonExtras: action.isLessonExtras,
       currentPageNumber: action.currentPageNumber
-    };
-  }
-
-  if (action.type === USE_DB_PROGRESS) {
-    return {
-      ...state,
-      usingDbProgress: true
     };
   }
 
@@ -413,10 +400,6 @@ export const initProgress = ({
 
 export const clearProgress = () => ({
   type: CLEAR_PROGRESS
-});
-
-export const useDbProgress = () => ({
-  type: USE_DB_PROGRESS
 });
 
 export const mergeProgress = levelProgress => ({

--- a/apps/src/code-studio/progressRedux.js
+++ b/apps/src/code-studio/progressRedux.js
@@ -31,6 +31,7 @@ const SET_STUDENT_DEFAULTS_SUMMARY_VIEW =
 const SET_CURRENT_STAGE_ID = 'progress/SET_CURRENT_STAGE_ID';
 const SET_SCRIPT_COMPLETED = 'progress/SET_SCRIPT_COMPLETED';
 const SET_STAGE_EXTRAS_ENABLED = 'progress/SET_STAGE_EXTRAS_ENABLED';
+const USE_DB_PROGRESS = 'progress/USE_DB_PROGRESS';
 const OVERWRITE_PROGRESS = 'progress/OVERWRITE_PROGRESS';
 
 const PEER_REVIEW_ID = -1;
@@ -65,6 +66,11 @@ const initialState = {
   isSummaryView: true,
   hasFullProgress: false,
   stageExtrasEnabled: false,
+  // Note: usingDbProgress === "user is logged in". However, it is
+  // possible that we can get the user progress back from the DB
+  // prior to having information about the user login state.
+  // TODO: Use sign in state to determine where to source user progress from
+  usingDbProgress: false,
   currentPageNumber: PUZZLE_PAGE_NONE
 };
 
@@ -97,6 +103,13 @@ export default function reducer(state = initialState, action) {
       hasFullProgress: action.isFullProgress,
       isLessonExtras: action.isLessonExtras,
       currentPageNumber: action.currentPageNumber
+    };
+  }
+
+  if (action.type === USE_DB_PROGRESS) {
+    return {
+      ...state,
+      usingDbProgress: true
     };
   }
 
@@ -400,6 +413,10 @@ export const initProgress = ({
 
 export const clearProgress = () => ({
   type: CLEAR_PROGRESS
+});
+
+export const useDbProgress = () => ({
+  type: USE_DB_PROGRESS
 });
 
 export const mergeProgress = levelProgress => ({

--- a/apps/src/code-studio/reporting.js
+++ b/apps/src/code-studio/reporting.js
@@ -254,11 +254,10 @@ reporting.sendReport = function(report) {
     mergeProgress({[appOptions.serverLevelId]: report.testResult})
   );
 
-  // If the user is not signed in, save progress information to session storage.
-  // (Note: For users that are not signed in, we still send a milestone report
-  // to the server so we can get information from the response, but the progress
-  // report that is sent is not saved by the server.)
-  if (!appOptions.userId) {
+  // If progress is not being saved in the database, save it locally.
+  // (Note: Either way, we still send a milestone report to the server so we can
+  // get information from the response.)
+  if (!store.getState().progress.usingDbProgress) {
     saveReportLocally(report);
   }
 

--- a/apps/src/code-studio/reporting.js
+++ b/apps/src/code-studio/reporting.js
@@ -4,6 +4,9 @@ import $ from 'jquery';
 import _ from 'lodash';
 import {TestResults} from '@cdo/apps/constants';
 import {PostMilestoneMode} from '@cdo/apps/util/sharedConstants';
+import {getContainedLevelId} from '@cdo/apps/code-studio/levels/codeStudioLevels';
+import {getStore} from '@cdo/apps/redux';
+import {mergeProgress} from '@cdo/apps/code-studio/progressRedux';
 var clientState = require('./clientState');
 
 var lastAjaxRequest;
@@ -213,6 +216,8 @@ function validateReport(report) {
 
 /**
  * Notify the progression system of level attempt or completion.
+ * All labs/activities should call this function to report progress, typically
+ * when the "Run" or "Submit" button is clicked.
  *
  * Provides a response to a callback, which can provide a video to play
  * and next/previous level URLs.
@@ -243,6 +248,20 @@ reporting.sendReport = function(report) {
 
   validateReport(report);
 
+  // Update Redux
+  const store = getStore();
+  store.dispatch(
+    mergeProgress({[appOptions.serverLevelId]: report.testResult})
+  );
+
+  // If the user is not signed in, save progress information to session storage.
+  // (Note: For users that are not signed in, we still send a milestone report
+  // to the server so we can get information from the response, but the progress
+  // report that is sent is not saved by the server.)
+  if (!appOptions.userId) {
+    saveReportLocally(report);
+  }
+
   // jQuery can do this implicitly, but when url-encoding it, jQuery calls a method that
   // shows the result dialog immediately
   var queryItems = [];
@@ -251,7 +270,6 @@ reporting.sendReport = function(report) {
     queryItems.push(key + '=' + report[key]);
   }
   const queryString = queryItems.join('&');
-  clientState.trackLines(report.result, report.lines);
 
   // Post milestone iff the server tells us.
   // Check a second switch if we passed the last level of the script.
@@ -335,6 +353,37 @@ reporting.sendReport = function(report) {
     }, 1000);
   }
 };
+
+/**
+ * Save information in milestone report to session storage.
+ * @param report
+ */
+function saveReportLocally(report) {
+  clientState.trackLines(report.result, report.lines);
+  clientState.trackProgress(
+    appOptions.scriptName,
+    appOptions.serverLevelId,
+    report.testResult
+  );
+
+  if (report.program && report.testResult !== TestResults.SKIPPED) {
+    const program = decodeURIComponent(report.program);
+
+    // If the program is the result for a contained level, store it with
+    // the contained level id
+    const levelId =
+      appOptions.hasContainedLevels && !appOptions.level.edit_blocks
+        ? getContainedLevelId()
+        : appOptions.serverProjectLevelId || appOptions.serverLevelId;
+
+    clientState.writeSourceForLevel(
+      appOptions.scriptName,
+      levelId,
+      +new Date(),
+      program
+    );
+  }
+}
 
 reporting.cancelReport = function() {
   if (lastAjaxRequest) {

--- a/apps/src/sites/studio/pages/levels/_standalone_video.js
+++ b/apps/src/sites/studio/pages/levels/_standalone_video.js
@@ -1,4 +1,3 @@
-/* globals appOptions */
 import $ from 'jquery';
 import {registerGetResult} from '@cdo/apps/code-studio/levels/codeStudioLevels';
 import {
@@ -12,45 +11,7 @@ import ReactDom from 'react-dom';
 import SafeMarkdown from '@cdo/apps/templates/SafeMarkdown';
 import _ from 'lodash';
 
-import {getStore} from '@cdo/apps/code-studio/redux';
-import {
-  overwriteProgress,
-  useDbProgress
-} from '@cdo/apps/code-studio/progressRedux';
-var clientState = require('@cdo/apps/code-studio/clientState');
-import {TestResults} from '@cdo/apps/constants';
-
 $(document).ready(() => {
-  // Workaround to get the logged-in user's progress on this script
-  // when we loaded a standalone video on a cached script level.
-  // Logged out user progress will be in the session storage. Non-
-  // cached script progress will just be replaced with the same data.
-  $.ajax(
-    `/api/user_progress` +
-      `/${appOptions.scriptName}` +
-      `/${appOptions.stagePosition}` +
-      `/${appOptions.levelPosition}` +
-      `/${appOptions.serverLevelId}`
-  ).done(data => {
-    // Merge progress from server (loaded via AJAX)
-    if (data.progress) {
-      const store = getStore();
-
-      // The server returned progress. This is the source of truth.
-      store.dispatch(useDbProgress());
-      clientState.clearProgress();
-
-      // Clear any existing redux state.
-      store.dispatch(
-        overwriteProgress(
-          _.mapValues(data.progress, level =>
-            level.submitted ? TestResults.SUBMITTED_RESULT : level.result
-          )
-        )
-      );
-    }
-  });
-
   registerGetResult();
 
   // make milestone post

--- a/apps/test/unit/code-studio/clientStateTest.js
+++ b/apps/test/unit/code-studio/clientStateTest.js
@@ -3,8 +3,6 @@
 var assert = require('assert');
 var state = require('@cdo/apps/code-studio/clientState');
 var chai = require('chai');
-import sinon from 'sinon';
-import * as redux from '@cdo/apps/redux';
 
 chai.should();
 
@@ -78,17 +76,6 @@ describe('clientState#trackLines', function() {
 
     state.trackLines(true, -10);
     state.lines().should.equal(10);
-  });
-
-  it('does not track line counts when the DB is managing tracking', function() {
-    sinon.stub(redux, 'getStore').returns({
-      getState: () => {
-        return {progress: {usingDbProgress: true}};
-      }
-    });
-    state.trackLines(true, 10);
-    state.lines().should.equal(0);
-    redux.getStore.restore();
   });
 
   it('Does not record line counts when level progress does not have a line count', function() {

--- a/apps/test/unit/code-studio/initApp/loadAppTest.js
+++ b/apps/test/unit/code-studio/initApp/loadAppTest.js
@@ -29,17 +29,13 @@ describe('loadApp.js', () => {
         readLevelId = levelId;
         return OLD_CODE;
       });
-    sinon.stub($, 'ajax').callsFake(() => {
-      return {
-        done() {
-          return {
-            fail(callback) {
-              callback();
-            }
-          };
+    sinon.stub($, 'ajax').callsFake(() => ({
+      done: successCallback => ({
+        fail: failureCallback => {
+          successCallback({signedIn: false});
         }
-      };
-    });
+      })
+    }));
   });
   beforeEach(() => {
     writtenLevelId = undefined;

--- a/apps/test/unit/code-studio/initApp/loadAppTest.js
+++ b/apps/test/unit/code-studio/initApp/loadAppTest.js
@@ -60,36 +60,6 @@ describe('loadApp.js', () => {
     window.appOptions = oldAppOptions;
   });
 
-  it('stores attempts for logged-out users against the server level id', () => {
-    setupApp(appOptions);
-    appOptions.onAttempt({program: 'program'});
-
-    expect(writtenLevelId).to.equal(SERVER_LEVEL_ID);
-  });
-
-  it('stores attempts for logged-out users against the server project level id for template backed level', () => {
-    appOptions.serverProjectLevelId = SERVER_PROJECT_LEVEL_ID;
-    setupApp(appOptions);
-    appOptions.onAttempt({program: 'program'});
-
-    expect(writtenLevelId).to.equal(SERVER_PROJECT_LEVEL_ID);
-  });
-
-  it('stores completed attempts for logged-out users against the server level id', () => {
-    setupApp(appOptions);
-    appOptions.onComplete({});
-
-    expect(writtenLevelId).to.equal(SERVER_LEVEL_ID);
-  });
-
-  it('stores completed attempts for logged-out users against the server project level for template backed level', () => {
-    appOptions.serverProjectLevelId = SERVER_PROJECT_LEVEL_ID;
-    setupApp(appOptions);
-    appOptions.onComplete({});
-
-    expect(writtenLevelId).to.equal(SERVER_PROJECT_LEVEL_ID);
-  });
-
   it('loads attempt stored under server level id', done => {
     const appOptionsData = document.createElement('script');
     appOptionsData.setAttribute('data-appoptions', JSON.stringify(appOptions));

--- a/dashboard/app/controllers/api_controller.rb
+++ b/dashboard/app/controllers/api_controller.rb
@@ -399,9 +399,14 @@ class ApiController < ApplicationController
       script = Script.get_from_cache(params[:script])
       user = params[:user_id].present? ? User.find(params[:user_id]) : current_user
       teacher_viewing_student = current_user.students.include?(user)
-      render json: summarize_user_progress(script, user).merge({teacherViewingStudent: teacher_viewing_student})
+      render json: summarize_user_progress(script, user).merge(
+        {
+          signedIn: true,
+          teacherViewingStudent: teacher_viewing_student,
+        }
+      )
     else
-      render json: {}
+      render json: {signedIn: false}
     end
   end
 
@@ -414,6 +419,7 @@ class ApiController < ApplicationController
   # but not completed.)
   def user_progress_for_stage
     response = user_summary(current_user)
+    response[:signedIn] = !current_user.nil?
 
     script = Script.get_from_cache(params[:script])
     stage = script.lessons[params[:stage_position].to_i - 1]

--- a/dashboard/test/controllers/api_controller_test.rb
+++ b/dashboard/test/controllers/api_controller_test.rb
@@ -850,7 +850,7 @@ class ApiControllerTest < ActionController::TestCase
     }
     assert_response :success
     body = JSON.parse(response.body)
-    assert_equal({}, body)
+    assert_equal({signedIn: false}, body)
     assert_equal(
       [
         {

--- a/dashboard/test/controllers/api_controller_test.rb
+++ b/dashboard/test/controllers/api_controller_test.rb
@@ -792,6 +792,7 @@ class ApiControllerTest < ActionController::TestCase
     result = {"status" => "perfect", "result" => 100}
     assert_response :success
     body = JSON.parse(response.body)
+    assert_equal true, body['signedIn']
     assert_nil body['disableSocialShare']
     assert_equal result, body['progress'][level.id.to_s]
     assert_equal 'level source', body['lastAttempt']['source']
@@ -850,7 +851,7 @@ class ApiControllerTest < ActionController::TestCase
     }
     assert_response :success
     body = JSON.parse(response.body)
-    assert_equal({signedIn: false}, body)
+    assert_equal false, body['signedIn']
     assert_equal(
       [
         {

--- a/dashboard/test/ui/features/learning_platform/progress.feature
+++ b/dashboard/test/ui/features/learning_platform/progress.feature
@@ -1,0 +1,39 @@
+Feature: Level Progress
+
+  Scenario: Progress is saved for signed-in student
+    Given I am a student
+
+    When I complete the level on "http://studio.code.org/s/allthethings/stage/2/puzzle/1"
+    Then I verify progress in the header of the current page is "perfect" for level 1
+    And I verify progress in the header of the current page is "not_tried" for level 2
+
+    When I am on "http://studio.code.org/s/allthethings/stage/2/puzzle/2"
+    And I wait for the page to fully load
+    And I wait for 2 seconds
+    Then I verify progress in the header of the current page is "perfect" for level 1
+    And I verify progress in the header of the current page is "not_tried" for level 2
+
+    When I am on "http://studio.code.org/s/allthethings"
+    And I wait until element "td:contains(Maze)" is visible
+    And I wait for 2 seconds
+    Then I verify progress for stage 2 level 1 is "perfect"
+    And I verify progress for stage 2 level 2 is "not_tried"
+
+  Scenario: Progress is saved for signed-out student
+    Given I am not signed in
+
+    When I complete the level on "http://studio.code.org/s/allthethings/stage/2/puzzle/1"
+    Then I verify progress in the header of the current page is "perfect" for level 1
+    And I verify progress in the header of the current page is "not_tried" for level 2
+
+    When I am on "http://studio.code.org/s/allthethings/stage/2/puzzle/2"
+    And I wait for the page to fully load
+    And I wait for 2 seconds
+    Then I verify progress in the header of the current page is "perfect" for level 1
+    And I verify progress in the header of the current page is "not_tried" for level 2
+
+    When I am on "http://studio.code.org/s/allthethings"
+    And I wait until element "td:contains(Maze)" is visible
+    And I wait for 2 seconds
+    Then I verify progress for stage 2 level 1 is "perfect"
+    And I verify progress for stage 2 level 2 is "not_tried"


### PR DESCRIPTION
<!--
  A summary of the change, including any relevant background, motivation, and context.
  If relevant, include a description, screenshots, and/or video of the existing and new behavior.
-->

The goal of this PR is to consolidate and (hopefully) simplify how we load and save progress for the level page and fix several bugs in the process.  We are specifically focused on the following aspects of progress:
- The TestResult of each level.  This is reflected in the progress bubbles at the top of the level page.
- The student's source code/answer, often referred to as `lastAttempt` in the code.

**Loading Progress**

How level progress is loaded depends on several factors:
- **What type of level it is.**  In particular, a bunch of the logic was in loadApp.js which is specific to lab-based projects.
- **Whether the user is signed in or not.**  Progress for signed-in users is stored in the database and progress for signed-out users is stored in the browser's session storage.
- **Whether the level is a [cached HoC level](https://github.com/code-dot-org/code-dot-org/blob/b0272a6ef85ed7d788469a51e402ffbd39a9b4de/cookbooks/cdo-varnish/libraries/http_cache.rb#L27-L49).**  For regular, non-cached levels, progress is embedded in the html page.  For cached levels, progress is requested from the server asynchronously.

For more details, see [this comment](https://codedotorg.atlassian.net/browse/LP-1810?focusedCommentId=18142) in the Jira ticket.

This PR attempts to unify the codepath for all the cases above, collecting code from several locations and consolidating it in progress.generateStageProgress().  After trying several approaches, I decided to (1) process all cases asynchronously, (2) continue using the progress embedded in the html page when it is available, and (3) request the data from the server when it is not available.  (I considered (and tried!) making all cases load progress asynchronously from the server but this was riskier than I was comfortable with.)

**Saving Progress**

Prior to this change, there were two very different code paths for saving progress to the server and for saving progress locally:
- Progress was saved to the server via reporting.sendReport() which sent a milestone request to the server.
- Progress was saved locally via a listener that listened for changes to the redux store.

I've unified these code paths as follows:
- All level types report progress by calling reporting.sendReport() which does the following:
    - Update redux
    - Saves the report locally if appropriate
    - Sends a milestone report to the server.  The report is always sent; the server decides whether to save it to the database depending on if the user is logged in.


## Links

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

[LP-1564](https://codedotorg.atlassian.net/browse/LP-1564)
[LP-1810](https://codedotorg.atlassian.net/browse/LP-1810)
[LP-1822](https://codedotorg.atlassian.net/browse/LP-1822)

## Testing story

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

There were existing UI tests for verifying level progress for cached (HoC) levels in hour_of_code.feature and hour_of_code_signed_in.feature.  I've added new UI tests for verify level progress for regular uncached levels.

I'm deferring unit tests for the js code because the code is currently structured in a way that makes unit testing difficult and I'm anticipating larger, structural changes to this code in the near future.

The team has also done a bug bash.

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
