### PR TITLE
Add a unique index to ProgrammingEnvironment#name

### DIFF
--- a/dashboard/app/models/programming_environment.rb
+++ b/dashboard/app/models/programming_environment.rb
@@ -8,13 +8,16 @@
 #  created_at :datetime         not null
 #  updated_at :datetime         not null
 #
+# Indexes
 #
-# @attr [String] editor_type - Type of editor one of the following: 'text-based', 'droplet', 'blockly'
+#  index_programming_environments_on_name  (name) UNIQUE
+#
 class ProgrammingEnvironment < ApplicationRecord
   include SerializedProperties
 
   has_many :programming_expressions
 
+  # @attr [String] editor_type - Type of editor one of the following: 'text-based', 'droplet', 'blockly'
   serialized_attrs %w(
     editor_type
   )

--- a/dashboard/db/migrate/20210318013815_add_unique_index_to_programming_environment_on_name.rb
+++ b/dashboard/db/migrate/20210318013815_add_unique_index_to_programming_environment_on_name.rb
@@ -1,0 +1,5 @@
+class AddUniqueIndexToProgrammingEnvironmentOnName < ActiveRecord::Migration[5.2]
+  def change
+    add_index :programming_environments, :name, unique: true
+  end
+end

--- a/dashboard/db/schema.rb
+++ b/dashboard/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_03_13_061652) do
+ActiveRecord::Schema.define(version: 2021_03_18_013815) do
 
   create_table "activities", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci", force: :cascade do |t|
     t.integer "user_id"
@@ -1272,6 +1272,7 @@ ActiveRecord::Schema.define(version: 2021_03_13_061652) do
     t.text "properties"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.index ["name"], name: "index_programming_environments_on_name", unique: true
   end
 
   create_table "programming_expressions", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci", force: :cascade do |t|


### PR DESCRIPTION
Mostly so that we can uniquely identify ProgrammingExpressions by `ProgrammingExpression#key` and `ProgrammingEnvironment#name`, but also because it's generally nice to have at least one non-id field be unique.

Currently we only have four programming environments whose names do not collide, so I'm not worried about this change being expensive to implement or introducing the danger of invalidating existing environments.

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
