### PR TITLE
include output of rake seed:default in build log during deploys

### DIFF
--- a/lib/rake/build.rake
+++ b/lib/rake/build.rake
@@ -78,7 +78,7 @@ namespace :build do
         else
           ChatClient.log 'Seeding <b>dashboard</b>...'
           ChatClient.log 'consider setting "skip_seed_all" in locals.yml if this is taking too long' if rack_env?(:development)
-          RakeUtils.rake 'seed:default', (rack_env?(:test) ? '--trace' : nil)
+          RakeUtils.rake_stream_output 'seed:default', (rack_env?(:test) ? '--trace' : nil)
         end
 
         # Commit dsls.en.yml changes on staging


### PR DESCRIPTION
When seeding fails, developers often have to rerun the seeding command to see what went wrong, because no useful output is included in the build log. This PR fixes that by including the output in the build log.

## Testing story

Drone won't really cover this change, however drone already uses something similar to stream output when it runs its own seed command: https://github.com/code-dot-org/code-dot-org/blob/441d979dd949e33a1a77ea876fa24291d6fdb7ce/lib/rake/circle.rake#L170