### PR TITLE
seed standard category from the correct framework

### DIFF
--- a/dashboard/app/models/standard.rb
+++ b/dashboard/app/models/standard.rb
@@ -37,7 +37,7 @@ class Standard < ApplicationRecord
       filename = "config/standards/#{framework.shortcode}_standards.csv"
       CSV.foreach(filename, {headers: true}) do |row|
         standard = Standard.find_or_initialize_by(framework: framework, shortcode: row['standard'])
-        standard.category = StandardCategory.find_by!(shortcode: row['category'])
+        standard.category = StandardCategory.find_by!(framework: framework, shortcode: row['category'])
         standard.description = row['description']
         standard.save! if standard.changed?
       end


### PR DESCRIPTION
https://github.com/code-dot-org/code-dot-org/pull/39460 introduced a bug which was caught by an eyes test, where standard started being attached to categories from the wrong framework. for details, see: https://codedotorg.slack.com/archives/CA3KCSGTD/p1616087379011000

Because #39460 switched around how we do seeding, and was also followed by another PR containing a DB migration affecting this table, I wasn't initially sure if a revert would fix the problem. When I started investigating, this fix-forward seemed simple enough, so I am proposing that we fix forward for the reason that it's not necessarily any riskier than reverting.

## Testing story

verified locally that seeding passes. I was able to confirm the problematic behavior before seeding and the correct behavior after, as shown in the eyes diff in the slack thread.