### PR TITLE
[AiLab] clear previous prediction before a new one is displayed

### DIFF
--- a/apps/src/applab/ai.js
+++ b/apps/src/applab/ai.js
@@ -56,6 +56,7 @@ function generateCodeDesignElements(modelId, modelData) {
   designMode.updateProperty(predictButton, 'id', predictButtonId);
   var predictOnClick = `onEvent("${predictButtonId}", "click", function() {
     ${inputFields.join('\n\t\t')}
+    setText("${predictionId}", '');
     getPrediction("${
       modelData.name
     }", "${modelId}", testValues, function(value) {


### PR DESCRIPTION
There was no visual cue that a new prediction was being made. This made students think the 'Predict' button wasn't working. Now, the previous prediction is cleared before the new one is displayed.

Before



https://user-images.githubusercontent.com/40412372/111680481-81cbb580-87df-11eb-97e1-ad8cd903c173.mov

After

https://user-images.githubusercontent.com/40412372/111680519-8a23f080-87df-11eb-8750-f8b67e1ca7b7.mov




