### PR TITLE
Re-implement seeding programming expression with programming environment

### DIFF
--- a/dashboard/app/models/lessons_programming_expression.rb
+++ b/dashboard/app/models/lessons_programming_expression.rb
@@ -26,8 +26,10 @@ class LessonsProgrammingExpression < ApplicationRecord
   def seeding_key(seed_context)
     my_lesson = seed_context.lessons.select {|l| l.id == lesson_id}.first
     my_programming_expression = seed_context.programming_expressions.select {|pe| pe.id == programming_expression_id}.first
+    my_programming_environment = seed_context.programming_environments.select {|pe| pe.id == my_programming_expression.programming_environment_id}.first
     {
       'lesson.key' => my_lesson.key,
+      'programming_environment.name' => my_programming_environment.name,
       'programming_expression.key' => my_programming_expression.key
     }.stringify_keys
   end

--- a/dashboard/app/models/programming_environment.rb
+++ b/dashboard/app/models/programming_environment.rb
@@ -15,6 +15,8 @@
 class ProgrammingEnvironment < ApplicationRecord
   include SerializedProperties
 
+  validates_uniqueness_of :name
+
   has_many :programming_expressions
 
   # @attr [String] editor_type - Type of editor one of the following: 'text-based', 'droplet', 'blockly'

--- a/dashboard/config/scripts_json/allthemigratedthings.script_json
+++ b/dashboard/config/scripts_json/allthemigratedthings.script_json
@@ -417,6 +417,7 @@
     {
       "seeding_key": {
         "lesson.key": "lesson-1",
+        "programming_environment.name": "gamelab",
         "programming_expression.key": "playSound"
       }
     }

--- a/dashboard/config/scripts_json/csd1-2021.script_json
+++ b/dashboard/config/scripts_json/csd1-2021.script_json
@@ -25,7 +25,7 @@
     },
     "new_name": null,
     "family_name": null,
-    "serialized_at": "2021-03-15 12:46:13 UTC",
+    "serialized_at": "2021-03-18 21:58:25 UTC",
     "seeding_key": {
       "script.name": "csd1-2021"
     }
@@ -5010,10 +5010,10 @@
       "activity_section_position": 1,
       "assessment": null,
       "properties": {
-        "progression": "Video: Problem Solving Process",
         "level_keys": [
           "CSD Problem Solving Process Video_2021"
-        ]
+        ],
+        "progression": "Video: Problem Solving Process"
       },
       "named_level": null,
       "bonus": null,
@@ -5036,10 +5036,10 @@
       "activity_section_position": 1,
       "assessment": null,
       "properties": {
-        "progression": "Video: What Makes a Computer, a Computer?",
         "level_keys": [
           "CSD What Makes a Computer a Computer Video_2021"
-        ]
+        ],
+        "progression": "Video: What Makes a Computer, a Computer?"
       },
       "named_level": null,
       "bonus": null,
@@ -5062,10 +5062,10 @@
       "activity_section_position": 1,
       "assessment": null,
       "properties": {
-        "progression": "App: Pet Chooser",
         "level_keys": [
           "CSD U1 IO Pet Chooser_2021"
-        ]
+        ],
+        "progression": "App: Pet Chooser"
       },
       "named_level": null,
       "bonus": null,
@@ -5088,10 +5088,10 @@
       "activity_section_position": 1,
       "assessment": null,
       "properties": {
-        "progression": "App: Story Creator",
         "level_keys": [
           "CSD U1 IO Story_2021"
-        ]
+        ],
+        "progression": "App: Story Creator"
       },
       "named_level": null,
       "bonus": null,
@@ -5114,10 +5114,10 @@
       "activity_section_position": 1,
       "assessment": null,
       "properties": {
-        "progression": "App: Improved Pet Chooser",
         "level_keys": [
           "CSD U1 IO Pet Chooser 2_2021"
-        ]
+        ],
+        "progression": "App: Improved Pet Chooser"
       },
       "named_level": null,
       "bonus": null,
@@ -5140,10 +5140,10 @@
       "activity_section_position": 1,
       "assessment": null,
       "properties": {
-        "progression": "App: Is It Your Birthday?",
         "level_keys": [
           "CSD U1 processing bday_2021"
-        ]
+        ],
+        "progression": "App: Is It Your Birthday?"
       },
       "named_level": null,
       "bonus": null,
@@ -5166,10 +5166,10 @@
       "activity_section_position": 1,
       "assessment": null,
       "properties": {
-        "progression": "App: National Park Quiz",
         "level_keys": [
           "CSD U1 processing npark_2021"
-        ]
+        ],
+        "progression": "App: National Park Quiz"
       },
       "named_level": null,
       "bonus": null,
@@ -5192,10 +5192,10 @@
       "activity_section_position": 1,
       "assessment": null,
       "properties": {
-        "progression": "App: How Many Countries...",
         "level_keys": [
           "CSD U1 processing countries_2021"
-        ]
+        ],
+        "progression": "App: How Many Countries..."
       },
       "named_level": null,
       "bonus": null,
@@ -5218,10 +5218,10 @@
       "activity_section_position": 1,
       "assessment": null,
       "properties": {
-        "progression": "App: My Famous Birthday",
         "level_keys": [
           "CSD U1 processing writers_2021"
-        ]
+        ],
+        "progression": "App: My Famous Birthday"
       },
       "named_level": null,
       "bonus": null,
@@ -5244,10 +5244,10 @@
       "activity_section_position": 1,
       "assessment": null,
       "properties": {
-        "progression": "App: Stamp Notebook",
         "level_keys": [
           "CSD U1 processing notebook_2021"
-        ]
+        ],
+        "progression": "App: Stamp Notebook"
       },
       "named_level": null,
       "bonus": null,
@@ -5270,10 +5270,10 @@
       "activity_section_position": 1,
       "assessment": null,
       "properties": {
-        "progression": "App: The Fastest Finger",
         "level_keys": [
           "CSD U1 processing fastest_2021"
-        ]
+        ],
+        "progression": "App: The Fastest Finger"
       },
       "named_level": null,
       "bonus": null,
@@ -5296,10 +5296,10 @@
       "activity_section_position": 1,
       "assessment": null,
       "properties": {
-        "progression": "App: Guess the Number",
         "level_keys": [
           "CSD U1 processing guess_2021"
-        ]
+        ],
+        "progression": "App: Guess the Number"
       },
       "named_level": null,
       "bonus": null,
@@ -5322,10 +5322,10 @@
       "activity_section_position": 1,
       "assessment": null,
       "properties": {
-        "progression": "App: Where Should I Live?",
         "level_keys": [
           "CSD U1 processing live_2021"
-        ]
+        ],
+        "progression": "App: Where Should I Live?"
       },
       "named_level": null,
       "bonus": null,
@@ -5348,10 +5348,10 @@
       "activity_section_position": 1,
       "assessment": null,
       "properties": {
-        "progression": "App: Outfit Picker",
         "level_keys": [
           "CSD U1 storage outfit_2021"
-        ]
+        ],
+        "progression": "App: Outfit Picker"
       },
       "named_level": null,
       "bonus": null,
@@ -5374,10 +5374,10 @@
       "activity_section_position": 1,
       "assessment": null,
       "properties": {
-        "progression": "App: Friend Finder",
         "level_keys": [
           "CSD U1 storage friends_2021"
-        ]
+        ],
+        "progression": "App: Friend Finder"
       },
       "named_level": null,
       "bonus": null,
@@ -5400,10 +5400,10 @@
       "activity_section_position": 1,
       "assessment": null,
       "properties": {
-        "progression": "App: Kids Movie Recommender",
         "level_keys": [
           "CSD U1 storage movies_2021"
-        ]
+        ],
+        "progression": "App: Kids Movie Recommender"
       },
       "named_level": null,
       "bonus": null,
@@ -5426,10 +5426,10 @@
       "activity_section_position": 1,
       "assessment": null,
       "properties": {
-        "progression": "Video: IOSP Model",
         "level_keys": [
           "CSD U1 storage video_2021"
-        ]
+        ],
+        "progression": "Video: IOSP Model"
       },
       "named_level": null,
       "bonus": null,
@@ -5452,10 +5452,10 @@
       "activity_section_position": 1,
       "assessment": true,
       "properties": {
-        "progression": "Reflection",
         "level_keys": [
           "csd-pulse-check-survey-1-levelgroup U1Ch2_2021"
-        ]
+        ],
+        "progression": "Reflection"
       },
       "named_level": null,
       "bonus": null,
@@ -7142,5 +7142,8 @@
         "objective.key": "1e8b24b5-f8b6-46a6-b0b1-aba1633a02f0"
       }
     }
+  ],
+  "lessons_standards": [
+
   ]
 }

--- a/dashboard/config/scripts_json/csd1-2021.script_json
+++ b/dashboard/config/scripts_json/csd1-2021.script_json
@@ -25,7 +25,7 @@
     },
     "new_name": null,
     "family_name": null,
-    "serialized_at": "2021-03-18 21:58:25 UTC",
+    "serialized_at": "2021-03-15 12:46:13 UTC",
     "seeding_key": {
       "script.name": "csd1-2021"
     }
@@ -5010,10 +5010,10 @@
       "activity_section_position": 1,
       "assessment": null,
       "properties": {
+        "progression": "Video: Problem Solving Process",
         "level_keys": [
           "CSD Problem Solving Process Video_2021"
-        ],
-        "progression": "Video: Problem Solving Process"
+        ]
       },
       "named_level": null,
       "bonus": null,
@@ -5036,10 +5036,10 @@
       "activity_section_position": 1,
       "assessment": null,
       "properties": {
+        "progression": "Video: What Makes a Computer, a Computer?",
         "level_keys": [
           "CSD What Makes a Computer a Computer Video_2021"
-        ],
-        "progression": "Video: What Makes a Computer, a Computer?"
+        ]
       },
       "named_level": null,
       "bonus": null,
@@ -5062,10 +5062,10 @@
       "activity_section_position": 1,
       "assessment": null,
       "properties": {
+        "progression": "App: Pet Chooser",
         "level_keys": [
           "CSD U1 IO Pet Chooser_2021"
-        ],
-        "progression": "App: Pet Chooser"
+        ]
       },
       "named_level": null,
       "bonus": null,
@@ -5088,10 +5088,10 @@
       "activity_section_position": 1,
       "assessment": null,
       "properties": {
+        "progression": "App: Story Creator",
         "level_keys": [
           "CSD U1 IO Story_2021"
-        ],
-        "progression": "App: Story Creator"
+        ]
       },
       "named_level": null,
       "bonus": null,
@@ -5114,10 +5114,10 @@
       "activity_section_position": 1,
       "assessment": null,
       "properties": {
+        "progression": "App: Improved Pet Chooser",
         "level_keys": [
           "CSD U1 IO Pet Chooser 2_2021"
-        ],
-        "progression": "App: Improved Pet Chooser"
+        ]
       },
       "named_level": null,
       "bonus": null,
@@ -5140,10 +5140,10 @@
       "activity_section_position": 1,
       "assessment": null,
       "properties": {
+        "progression": "App: Is It Your Birthday?",
         "level_keys": [
           "CSD U1 processing bday_2021"
-        ],
-        "progression": "App: Is It Your Birthday?"
+        ]
       },
       "named_level": null,
       "bonus": null,
@@ -5166,10 +5166,10 @@
       "activity_section_position": 1,
       "assessment": null,
       "properties": {
+        "progression": "App: National Park Quiz",
         "level_keys": [
           "CSD U1 processing npark_2021"
-        ],
-        "progression": "App: National Park Quiz"
+        ]
       },
       "named_level": null,
       "bonus": null,
@@ -5192,10 +5192,10 @@
       "activity_section_position": 1,
       "assessment": null,
       "properties": {
+        "progression": "App: How Many Countries...",
         "level_keys": [
           "CSD U1 processing countries_2021"
-        ],
-        "progression": "App: How Many Countries..."
+        ]
       },
       "named_level": null,
       "bonus": null,
@@ -5218,10 +5218,10 @@
       "activity_section_position": 1,
       "assessment": null,
       "properties": {
+        "progression": "App: My Famous Birthday",
         "level_keys": [
           "CSD U1 processing writers_2021"
-        ],
-        "progression": "App: My Famous Birthday"
+        ]
       },
       "named_level": null,
       "bonus": null,
@@ -5244,10 +5244,10 @@
       "activity_section_position": 1,
       "assessment": null,
       "properties": {
+        "progression": "App: Stamp Notebook",
         "level_keys": [
           "CSD U1 processing notebook_2021"
-        ],
-        "progression": "App: Stamp Notebook"
+        ]
       },
       "named_level": null,
       "bonus": null,
@@ -5270,10 +5270,10 @@
       "activity_section_position": 1,
       "assessment": null,
       "properties": {
+        "progression": "App: The Fastest Finger",
         "level_keys": [
           "CSD U1 processing fastest_2021"
-        ],
-        "progression": "App: The Fastest Finger"
+        ]
       },
       "named_level": null,
       "bonus": null,
@@ -5296,10 +5296,10 @@
       "activity_section_position": 1,
       "assessment": null,
       "properties": {
+        "progression": "App: Guess the Number",
         "level_keys": [
           "CSD U1 processing guess_2021"
-        ],
-        "progression": "App: Guess the Number"
+        ]
       },
       "named_level": null,
       "bonus": null,
@@ -5322,10 +5322,10 @@
       "activity_section_position": 1,
       "assessment": null,
       "properties": {
+        "progression": "App: Where Should I Live?",
         "level_keys": [
           "CSD U1 processing live_2021"
-        ],
-        "progression": "App: Where Should I Live?"
+        ]
       },
       "named_level": null,
       "bonus": null,
@@ -5348,10 +5348,10 @@
       "activity_section_position": 1,
       "assessment": null,
       "properties": {
+        "progression": "App: Outfit Picker",
         "level_keys": [
           "CSD U1 storage outfit_2021"
-        ],
-        "progression": "App: Outfit Picker"
+        ]
       },
       "named_level": null,
       "bonus": null,
@@ -5374,10 +5374,10 @@
       "activity_section_position": 1,
       "assessment": null,
       "properties": {
+        "progression": "App: Friend Finder",
         "level_keys": [
           "CSD U1 storage friends_2021"
-        ],
-        "progression": "App: Friend Finder"
+        ]
       },
       "named_level": null,
       "bonus": null,
@@ -5400,10 +5400,10 @@
       "activity_section_position": 1,
       "assessment": null,
       "properties": {
+        "progression": "App: Kids Movie Recommender",
         "level_keys": [
           "CSD U1 storage movies_2021"
-        ],
-        "progression": "App: Kids Movie Recommender"
+        ]
       },
       "named_level": null,
       "bonus": null,
@@ -5426,10 +5426,10 @@
       "activity_section_position": 1,
       "assessment": null,
       "properties": {
+        "progression": "Video: IOSP Model",
         "level_keys": [
           "CSD U1 storage video_2021"
-        ],
-        "progression": "Video: IOSP Model"
+        ]
       },
       "named_level": null,
       "bonus": null,
@@ -5452,10 +5452,10 @@
       "activity_section_position": 1,
       "assessment": true,
       "properties": {
+        "progression": "Reflection",
         "level_keys": [
           "csd-pulse-check-survey-1-levelgroup U1Ch2_2021"
-        ],
-        "progression": "Reflection"
+        ]
       },
       "named_level": null,
       "bonus": null,
@@ -7142,8 +7142,5 @@
         "objective.key": "1e8b24b5-f8b6-46a6-b0b1-aba1633a02f0"
       }
     }
-  ],
-  "lessons_standards": [
-
   ]
 }

--- a/dashboard/config/scripts_json/csd2-2021.script_json
+++ b/dashboard/config/scripts_json/csd2-2021.script_json
@@ -24,7 +24,7 @@
     },
     "new_name": null,
     "family_name": null,
-    "serialized_at": "2021-03-15 12:47:19 UTC",
+    "serialized_at": "2021-03-18 21:55:01 UTC",
     "seeding_key": {
       "script.name": "csd2-2021"
     }
@@ -5901,10 +5901,10 @@
       "activity_section_position": 1,
       "assessment": null,
       "properties": {
-        "progression": "Sample Personal Web Pages",
         "level_keys": [
           "CSD Web Sample Pages_2021"
-        ]
+        ],
+        "progression": "Sample Personal Web Pages"
       },
       "named_level": null,
       "bonus": null,
@@ -5927,10 +5927,10 @@
       "activity_section_position": 1,
       "assessment": null,
       "properties": {
-        "progression": "Experiment with Web Lab",
         "level_keys": [
           "CSDU2 - Type Anything_2021"
-        ]
+        ],
+        "progression": "Experiment with Web Lab"
       },
       "named_level": null,
       "bonus": null,
@@ -5953,10 +5953,10 @@
       "activity_section_position": 1,
       "assessment": null,
       "properties": {
-        "progression": "Video: Intro to Web Lab - Part 1",
         "level_keys": [
           "Intro to Web Lab - Part 1_2021"
-        ]
+        ],
+        "progression": "Video: Intro to Web Lab - Part 1"
       },
       "named_level": null,
       "bonus": null,
@@ -5979,10 +5979,10 @@
       "activity_section_position": 1,
       "assessment": null,
       "properties": {
-        "progression": "Explore HTML",
         "level_keys": [
           "CSD U2 Inspector Warm Up_2021"
-        ]
+        ],
+        "progression": "Explore HTML"
       },
       "named_level": null,
       "bonus": null,
@@ -6005,10 +6005,10 @@
       "activity_section_position": 1,
       "assessment": null,
       "properties": {
-        "progression": "Video: Intro to Web Lab - Part 2",
         "level_keys": [
           "Intro to Web Lab - Part 2_2021"
-        ]
+        ],
+        "progression": "Video: Intro to Web Lab - Part 2"
       },
       "named_level": null,
       "bonus": null,
@@ -6031,10 +6031,10 @@
       "activity_section_position": 1,
       "assessment": null,
       "properties": {
-        "progression": "Practice",
         "level_keys": [
           "CSD U2 HTML Adding Paragraphs_2021"
-        ]
+        ],
+        "progression": "Practice"
       },
       "named_level": null,
       "bonus": null,
@@ -6057,10 +6057,10 @@
       "activity_section_position": 1,
       "assessment": true,
       "properties": {
-        "progression": "Assessment",
         "level_keys": [
           "CSD U2 HTML Adding Paragraphs pt 2_2021"
-        ]
+        ],
+        "progression": "Assessment"
       },
       "named_level": null,
       "bonus": null,
@@ -6083,10 +6083,10 @@
       "activity_section_position": 1,
       "assessment": null,
       "properties": {
-        "progression": "Challenge",
         "level_keys": [
           "CSD U2 HTML Debug Paragraphs_2021"
-        ]
+        ],
+        "progression": "Challenge"
       },
       "named_level": null,
       "bonus": null,
@@ -6109,10 +6109,10 @@
       "activity_section_position": 1,
       "assessment": false,
       "properties": {
-        "progression": "Video: Pair Programming",
         "level_keys": [
           "CSD U2 Pair Programming Video_2021"
-        ]
+        ],
+        "progression": "Video: Pair Programming"
       },
       "named_level": null,
       "bonus": null,
@@ -6135,10 +6135,10 @@
       "activity_section_position": 1,
       "assessment": false,
       "properties": {
-        "progression": "Skill Building",
         "level_keys": [
           "CSD U2 Heading debug_2021"
-        ]
+        ],
+        "progression": "Skill Building"
       },
       "named_level": null,
       "bonus": null,
@@ -6161,10 +6161,10 @@
       "activity_section_position": 2,
       "assessment": false,
       "properties": {
-        "progression": "Skill Building",
         "level_keys": [
           "CSD U2 Heading Demo_2021"
-        ]
+        ],
+        "progression": "Skill Building"
       },
       "named_level": null,
       "bonus": null,
@@ -6187,10 +6187,10 @@
       "activity_section_position": 3,
       "assessment": false,
       "properties": {
-        "progression": "Skill Building",
         "level_keys": [
           "CSD U2 Heading Sizes_2021"
-        ]
+        ],
+        "progression": "Skill Building"
       },
       "named_level": null,
       "bonus": null,
@@ -6213,10 +6213,10 @@
       "activity_section_position": 1,
       "assessment": true,
       "properties": {
-        "progression": "Quick Check",
         "level_keys": [
           "CSD Header Size MC_2018_2019_pilot_2021"
-        ]
+        ],
+        "progression": "Quick Check"
       },
       "named_level": null,
       "bonus": null,
@@ -6239,10 +6239,10 @@
       "activity_section_position": 1,
       "assessment": false,
       "properties": {
-        "progression": "Video: Debugging",
         "level_keys": [
           "CSD Web Debugging_2021"
-        ]
+        ],
+        "progression": "Video: Debugging"
       },
       "named_level": null,
       "bonus": null,
@@ -6265,10 +6265,10 @@
       "activity_section_position": 1,
       "assessment": false,
       "properties": {
-        "progression": "Practice",
         "level_keys": [
           "CSD Web Headings practice_2021"
-        ]
+        ],
+        "progression": "Practice"
       },
       "named_level": null,
       "bonus": null,
@@ -6291,10 +6291,10 @@
       "activity_section_position": 1,
       "assessment": true,
       "properties": {
-        "progression": "Assessment",
         "level_keys": [
           "CSD U2 Heading Test_2021"
-        ]
+        ],
+        "progression": "Assessment"
       },
       "named_level": null,
       "bonus": null,
@@ -6317,10 +6317,10 @@
       "activity_section_position": 1,
       "assessment": false,
       "properties": {
-        "progression": "Challenges",
         "level_keys": [
           "CSD Web Headings challenge_2021"
-        ]
+        ],
+        "progression": "Challenges"
       },
       "named_level": null,
       "bonus": null,
@@ -6343,10 +6343,10 @@
       "activity_section_position": 1,
       "assessment": null,
       "properties": {
-        "progression": "Review: HTML",
         "level_keys": [
           "CSD HTML project Review_2021"
-        ]
+        ],
+        "progression": "Review: HTML"
       },
       "named_level": null,
       "bonus": null,
@@ -6369,10 +6369,10 @@
       "activity_section_position": 1,
       "assessment": null,
       "properties": {
-        "progression": "Challenge: Lists",
         "level_keys": [
           "CSD HTML project Lists_2021"
-        ]
+        ],
+        "progression": "Challenge: Lists"
       },
       "named_level": null,
       "bonus": null,
@@ -6395,10 +6395,10 @@
       "activity_section_position": 1,
       "assessment": null,
       "properties": {
-        "progression": "Code Your Page",
         "level_keys": [
           "CSD web HTML project HTML_2021"
-        ]
+        ],
+        "progression": "Code Your Page"
       },
       "named_level": null,
       "bonus": null,
@@ -6421,10 +6421,10 @@
       "activity_section_position": 1,
       "assessment": null,
       "properties": {
-        "progression": "Review Your Page",
         "level_keys": [
           "CSD web HTML project check_2021"
-        ]
+        ],
+        "progression": "Review Your Page"
       },
       "named_level": null,
       "bonus": null,
@@ -6447,10 +6447,10 @@
       "activity_section_position": 1,
       "assessment": null,
       "properties": {
-        "progression": "Social Sleuth",
         "level_keys": [
           "Social Sleuth_2018_2019_pilot_2021"
-        ]
+        ],
+        "progression": "Social Sleuth"
       },
       "named_level": null,
       "bonus": null,
@@ -6473,10 +6473,10 @@
       "activity_section_position": 1,
       "assessment": null,
       "properties": {
-        "progression": "Sample Website",
         "level_keys": [
           "CSD U2 Sample CSS text_2021"
-        ]
+        ],
+        "progression": "Sample Website"
       },
       "named_level": null,
       "bonus": null,
@@ -6499,10 +6499,10 @@
       "activity_section_position": 1,
       "assessment": null,
       "properties": {
-        "progression": "Exploration",
         "level_keys": [
           "CSD U2 CSS explore CSS_2021"
-        ]
+        ],
+        "progression": "Exploration"
       },
       "named_level": null,
       "bonus": null,
@@ -6525,10 +6525,10 @@
       "activity_section_position": 1,
       "assessment": null,
       "properties": {
-        "progression": "Video: Intro to CSS - Part 1",
         "level_keys": [
           "Video: Intro to CSS_2021"
-        ]
+        ],
+        "progression": "Video: Intro to CSS - Part 1"
       },
       "named_level": null,
       "bonus": null,
@@ -6551,10 +6551,10 @@
       "activity_section_position": 1,
       "assessment": null,
       "properties": {
-        "progression": "Skill Building",
         "level_keys": [
           "CSD U2 text style h1_2021"
-        ]
+        ],
+        "progression": "Skill Building"
       },
       "named_level": null,
       "bonus": null,
@@ -6577,10 +6577,10 @@
       "activity_section_position": 2,
       "assessment": null,
       "properties": {
-        "progression": "Skill Building",
         "level_keys": [
           "CSD U2 text style h3_2021"
-        ]
+        ],
+        "progression": "Skill Building"
       },
       "named_level": null,
       "bonus": null,
@@ -6603,10 +6603,10 @@
       "activity_section_position": 3,
       "assessment": null,
       "properties": {
-        "progression": "Skill Building",
         "level_keys": [
           "CSD U2 text style size_2021"
-        ]
+        ],
+        "progression": "Skill Building"
       },
       "named_level": null,
       "bonus": null,
@@ -6629,10 +6629,10 @@
       "activity_section_position": 1,
       "assessment": null,
       "properties": {
-        "progression": "Video: Intro to CSS - Part 2",
         "level_keys": [
           "Video: Intro to CSS Part 2_2021"
-        ]
+        ],
+        "progression": "Video: Intro to CSS - Part 2"
       },
       "named_level": null,
       "bonus": null,
@@ -6655,10 +6655,10 @@
       "activity_section_position": 1,
       "assessment": null,
       "properties": {
-        "progression": "Skill Building",
         "level_keys": [
           "CSD U2 add file_2021"
-        ]
+        ],
+        "progression": "Skill Building"
       },
       "named_level": null,
       "bonus": null,
@@ -6681,10 +6681,10 @@
       "activity_section_position": 1,
       "assessment": null,
       "properties": {
-        "progression": "Practice",
         "level_keys": [
           "CSD U2 CSS practice_pilot_2021"
-        ]
+        ],
+        "progression": "Practice"
       },
       "named_level": null,
       "bonus": null,
@@ -6707,10 +6707,10 @@
       "activity_section_position": 1,
       "assessment": true,
       "properties": {
-        "progression": "Assessment",
         "level_keys": [
           "CSD Web CSS Assessment_2021"
-        ]
+        ],
+        "progression": "Assessment"
       },
       "named_level": null,
       "bonus": null,
@@ -6733,10 +6733,10 @@
       "activity_section_position": 1,
       "assessment": null,
       "properties": {
-        "progression": "Challenges",
         "level_keys": [
           "CSD U2 CSS challenge_pilot_2021"
-        ]
+        ],
+        "progression": "Challenges"
       },
       "named_level": null,
       "bonus": null,
@@ -6759,10 +6759,10 @@
       "activity_section_position": 1,
       "assessment": null,
       "properties": {
-        "progression": "Review: CSS",
         "level_keys": [
           "CSD CSS project Review_2021"
-        ]
+        ],
+        "progression": "Review: CSS"
       },
       "named_level": null,
       "bonus": null,
@@ -6785,10 +6785,10 @@
       "activity_section_position": 1,
       "assessment": null,
       "properties": {
-        "progression": "Challenge: RGB Colors",
         "level_keys": [
           "CSD CSS project RGB_2021"
-        ]
+        ],
+        "progression": "Challenge: RGB Colors"
       },
       "named_level": null,
       "bonus": null,
@@ -6811,10 +6811,10 @@
       "activity_section_position": 1,
       "assessment": null,
       "properties": {
-        "progression": "Add Content and Structure to Your Page",
         "level_keys": [
           "CSD web CSS project HTML_2021"
-        ]
+        ],
+        "progression": "Add Content and Structure to Your Page"
       },
       "named_level": null,
       "bonus": null,
@@ -6837,10 +6837,10 @@
       "activity_section_position": 1,
       "assessment": null,
       "properties": {
-        "progression": "Add Style to Your Page",
         "level_keys": [
           "CSD web CSS project CSS_2021"
-        ]
+        ],
+        "progression": "Add Style to Your Page"
       },
       "named_level": null,
       "bonus": null,
@@ -6863,10 +6863,10 @@
       "activity_section_position": 1,
       "assessment": null,
       "properties": {
-        "progression": "Review Your Page",
         "level_keys": [
           "CSD web CSS project check_2021"
-        ]
+        ],
+        "progression": "Review Your Page"
       },
       "named_level": null,
       "bonus": null,
@@ -6889,10 +6889,10 @@
       "activity_section_position": 1,
       "assessment": null,
       "properties": {
-        "progression": "Skill Building",
         "level_keys": [
           "CSD U2 Image Tag 1_2021"
-        ]
+        ],
+        "progression": "Skill Building"
       },
       "named_level": null,
       "bonus": null,
@@ -6915,10 +6915,10 @@
       "activity_section_position": 2,
       "assessment": null,
       "properties": {
-        "progression": "Skill Building",
         "level_keys": [
           "CSD U2 Image Credit_2021"
-        ]
+        ],
+        "progression": "Skill Building"
       },
       "named_level": null,
       "bonus": null,
@@ -6941,10 +6941,10 @@
       "activity_section_position": 3,
       "assessment": null,
       "properties": {
-        "progression": "Skill Building",
         "level_keys": [
           "CSD U2 Image Tag Debug_2021"
-        ]
+        ],
+        "progression": "Skill Building"
       },
       "named_level": null,
       "bonus": null,
@@ -6967,10 +6967,10 @@
       "activity_section_position": 4,
       "assessment": null,
       "properties": {
-        "progression": "Skill Building",
         "level_keys": [
           "CSD U2 Image choose name_2021"
-        ]
+        ],
+        "progression": "Skill Building"
       },
       "named_level": null,
       "bonus": null,
@@ -6993,10 +6993,10 @@
       "activity_section_position": 5,
       "assessment": null,
       "properties": {
-        "progression": "Skill Building",
         "level_keys": [
           "CSD U2 Image Tag 2_2021"
-        ]
+        ],
+        "progression": "Skill Building"
       },
       "named_level": null,
       "bonus": null,
@@ -7019,10 +7019,10 @@
       "activity_section_position": 1,
       "assessment": null,
       "properties": {
-        "progression": "Practice",
         "level_keys": [
           "CSD U2 Image practice_pilot_2021"
-        ]
+        ],
+        "progression": "Practice"
       },
       "named_level": null,
       "bonus": null,
@@ -7045,10 +7045,10 @@
       "activity_section_position": 1,
       "assessment": true,
       "properties": {
-        "progression": "Assessment",
         "level_keys": [
           "CSD U2 Image assessment_2021"
-        ]
+        ],
+        "progression": "Assessment"
       },
       "named_level": null,
       "bonus": null,
@@ -7071,10 +7071,10 @@
       "activity_section_position": 1,
       "assessment": null,
       "properties": {
-        "progression": "Challenges",
         "level_keys": [
           "CSD U2 Image challenge_pilot_2021"
-        ]
+        ],
+        "progression": "Challenges"
       },
       "named_level": null,
       "bonus": null,
@@ -7097,10 +7097,10 @@
       "activity_section_position": 1,
       "assessment": null,
       "properties": {
-        "progression": "Sample Personal Websites",
         "level_keys": [
           "CSD U2 Expression Exemplars_2018_2019_pilot_2021"
-        ]
+        ],
+        "progression": "Sample Personal Websites"
       },
       "named_level": null,
       "bonus": null,
@@ -7123,10 +7123,10 @@
       "activity_section_position": 1,
       "assessment": null,
       "properties": {
-        "progression": "Sample Website",
         "level_keys": [
           "CSD U2 Sample CSS layout_2021"
-        ]
+        ],
+        "progression": "Sample Website"
       },
       "named_level": null,
       "bonus": null,
@@ -7149,10 +7149,10 @@
       "activity_section_position": 1,
       "assessment": null,
       "properties": {
-        "progression": "Exploration",
         "level_keys": [
           "CSD U2 layout style sample_2021"
-        ]
+        ],
+        "progression": "Exploration"
       },
       "named_level": null,
       "bonus": null,
@@ -7175,10 +7175,10 @@
       "activity_section_position": 1,
       "assessment": null,
       "properties": {
-        "progression": "Skill Building",
         "level_keys": [
           "CSD U2 layout style bgcolor_2021"
-        ]
+        ],
+        "progression": "Skill Building"
       },
       "named_level": null,
       "bonus": null,
@@ -7201,10 +7201,10 @@
       "activity_section_position": 2,
       "assessment": null,
       "properties": {
-        "progression": "Skill Building",
         "level_keys": [
           "CSD U2 layout style body_2021"
-        ]
+        ],
+        "progression": "Skill Building"
       },
       "named_level": null,
       "bonus": null,
@@ -7227,10 +7227,10 @@
       "activity_section_position": 3,
       "assessment": null,
       "properties": {
-        "progression": "Skill Building",
         "level_keys": [
           "CSD U2 layout style float_2021"
-        ]
+        ],
+        "progression": "Skill Building"
       },
       "named_level": null,
       "bonus": null,
@@ -7253,10 +7253,10 @@
       "activity_section_position": 4,
       "assessment": null,
       "properties": {
-        "progression": "Skill Building",
         "level_keys": [
           "CSD U2 layout style width_2021"
-        ]
+        ],
+        "progression": "Skill Building"
       },
       "named_level": null,
       "bonus": null,
@@ -7279,10 +7279,10 @@
       "activity_section_position": 1,
       "assessment": null,
       "properties": {
-        "progression": "Practice",
         "level_keys": [
           "CSD U2 layout style practice_pilot_2021"
-        ]
+        ],
+        "progression": "Practice"
       },
       "named_level": null,
       "bonus": null,
@@ -7305,10 +7305,10 @@
       "activity_section_position": 1,
       "assessment": true,
       "properties": {
-        "progression": "Assessment",
         "level_keys": [
           "CSD U2 add style_2021"
-        ]
+        ],
+        "progression": "Assessment"
       },
       "named_level": null,
       "bonus": null,
@@ -7331,10 +7331,10 @@
       "activity_section_position": 1,
       "assessment": null,
       "properties": {
-        "progression": "Challenges",
         "level_keys": [
           "CSD U2 layout style challenge_pilot_2021"
-        ]
+        ],
+        "progression": "Challenges"
       },
       "named_level": null,
       "bonus": null,
@@ -7357,10 +7357,10 @@
       "activity_section_position": 1,
       "assessment": null,
       "properties": {
-        "progression": "Project Guide",
         "level_keys": [
           "CSD U2 project guide_2018_2019_pilot_2021"
-        ]
+        ],
+        "progression": "Project Guide"
       },
       "named_level": null,
       "bonus": null,
@@ -7383,10 +7383,10 @@
       "activity_section_position": 1,
       "assessment": null,
       "properties": {
-        "progression": "Website Project",
         "level_keys": [
           "CSD U2 upload images_2021"
-        ]
+        ],
+        "progression": "Website Project"
       },
       "named_level": null,
       "bonus": null,
@@ -7409,10 +7409,10 @@
       "activity_section_position": 2,
       "assessment": null,
       "properties": {
-        "progression": "Website Project",
         "level_keys": [
           "CSD U2 add content_2021"
-        ]
+        ],
+        "progression": "Website Project"
       },
       "named_level": null,
       "bonus": null,
@@ -7435,10 +7435,10 @@
       "activity_section_position": 3,
       "assessment": null,
       "properties": {
-        "progression": "Website Project",
         "level_keys": [
           "CSD U2 CSS_2021"
-        ]
+        ],
+        "progression": "Website Project"
       },
       "named_level": null,
       "bonus": null,
@@ -7461,10 +7461,10 @@
       "activity_section_position": 4,
       "assessment": null,
       "properties": {
-        "progression": "Website Project",
         "level_keys": [
           "CSD U2 project review_2021"
-        ]
+        ],
+        "progression": "Website Project"
       },
       "named_level": null,
       "bonus": null,
@@ -7487,10 +7487,10 @@
       "activity_section_position": 1,
       "assessment": null,
       "properties": {
-        "progression": "Video: Publishing Your Website",
         "level_keys": [
           "CSD U2 publish video_2021"
-        ]
+        ],
+        "progression": "Video: Publishing Your Website"
       },
       "named_level": null,
       "bonus": null,
@@ -7513,10 +7513,10 @@
       "activity_section_position": 1,
       "assessment": null,
       "properties": {
-        "progression": "Publishing Your Website",
         "level_keys": [
           "CSD U2 project share_2021"
-        ]
+        ],
+        "progression": "Publishing Your Website"
       },
       "named_level": null,
       "bonus": null,
@@ -7539,10 +7539,10 @@
       "activity_section_position": 1,
       "assessment": true,
       "properties": {
-        "progression": "Reflection",
         "level_keys": [
           "csd-pulse-check-survey-1-levelgroup U2Ch1_2018_2019_pilot_2021"
-        ]
+        ],
+        "progression": "Reflection"
       },
       "named_level": null,
       "bonus": null,
@@ -7565,10 +7565,10 @@
       "activity_section_position": 1,
       "assessment": null,
       "properties": {
-        "progression": "Top Websites",
         "level_keys": [
           "CSD U2 Top Websites_2018_2019_pilot_2021"
-        ]
+        ],
+        "progression": "Top Websites"
       },
       "named_level": null,
       "bonus": null,
@@ -7591,10 +7591,10 @@
       "activity_section_position": 1,
       "assessment": null,
       "properties": {
-        "progression": "Video: Teamwork",
         "level_keys": [
           "csd web teamwork video_2021"
-        ]
+        ],
+        "progression": "Video: Teamwork"
       },
       "named_level": null,
       "bonus": null,
@@ -7617,10 +7617,10 @@
       "activity_section_position": 1,
       "assessment": null,
       "properties": {
-        "progression": "Video: Managing Disagreement",
         "level_keys": [
           "csd web disagreement video_2021"
-        ]
+        ],
+        "progression": "Video: Managing Disagreement"
       },
       "named_level": null,
       "bonus": null,
@@ -7643,10 +7643,10 @@
       "activity_section_position": 1,
       "assessment": null,
       "properties": {
-        "progression": "Sample Web Page",
         "level_keys": [
           "CSD U2 Sample classes_2021"
-        ]
+        ],
+        "progression": "Sample Web Page"
       },
       "named_level": null,
       "bonus": null,
@@ -7669,10 +7669,10 @@
       "activity_section_position": 1,
       "assessment": null,
       "properties": {
-        "progression": "Exploration",
         "level_keys": [
           "CSD U2 classes waterfalls_2021"
-        ]
+        ],
+        "progression": "Exploration"
       },
       "named_level": null,
       "bonus": null,
@@ -7695,10 +7695,10 @@
       "activity_section_position": 1,
       "assessment": null,
       "properties": {
-        "progression": "Skill Building",
         "level_keys": [
           "CSD U2 classes humors_2021"
-        ]
+        ],
+        "progression": "Skill Building"
       },
       "named_level": null,
       "bonus": null,
@@ -7721,10 +7721,10 @@
       "activity_section_position": 1,
       "assessment": null,
       "properties": {
-        "progression": "Practice",
         "level_keys": [
           "CSD web classes practice_2021"
-        ]
+        ],
+        "progression": "Practice"
       },
       "named_level": null,
       "bonus": null,
@@ -7747,10 +7747,10 @@
       "activity_section_position": 1,
       "assessment": true,
       "properties": {
-        "progression": "Assessment",
         "level_keys": [
           "CSD U2 classes haikus_2021"
-        ]
+        ],
+        "progression": "Assessment"
       },
       "named_level": null,
       "bonus": null,
@@ -7773,10 +7773,10 @@
       "activity_section_position": 1,
       "assessment": null,
       "properties": {
-        "progression": "Challenges",
         "level_keys": [
           "CSD web classes challenge_2021"
-        ]
+        ],
+        "progression": "Challenges"
       },
       "named_level": null,
       "bonus": null,
@@ -7799,10 +7799,10 @@
       "activity_section_position": 1,
       "assessment": null,
       "properties": {
-        "progression": "Upload Your Images",
         "level_keys": [
           "CSD web upload images multi_2021"
-        ]
+        ],
+        "progression": "Upload Your Images"
       },
       "named_level": null,
       "bonus": null,
@@ -7825,10 +7825,10 @@
       "activity_section_position": 1,
       "assessment": null,
       "properties": {
-        "progression": "Exploration",
         "level_keys": [
           "CSD U2 link demo_2021"
-        ]
+        ],
+        "progression": "Exploration"
       },
       "named_level": null,
       "bonus": null,
@@ -7851,10 +7851,10 @@
       "activity_section_position": 1,
       "assessment": null,
       "properties": {
-        "progression": "Skill Building",
         "level_keys": [
           "CSD U2 making links_2021"
-        ]
+        ],
+        "progression": "Skill Building"
       },
       "named_level": null,
       "bonus": null,
@@ -7877,10 +7877,10 @@
       "activity_section_position": 2,
       "assessment": null,
       "properties": {
-        "progression": "Skill Building",
         "level_keys": [
           "CSD U2 naming links_2021"
-        ]
+        ],
+        "progression": "Skill Building"
       },
       "named_level": null,
       "bonus": null,
@@ -7903,10 +7903,10 @@
       "activity_section_position": 3,
       "assessment": null,
       "properties": {
-        "progression": "Skill Building",
         "level_keys": [
           "CSD U2 naming pages_2021"
-        ]
+        ],
+        "progression": "Skill Building"
       },
       "named_level": null,
       "bonus": null,
@@ -7929,10 +7929,10 @@
       "activity_section_position": 1,
       "assessment": null,
       "properties": {
-        "progression": "Practice",
         "level_keys": [
           "CSD U2 nav bar_2021"
-        ]
+        ],
+        "progression": "Practice"
       },
       "named_level": null,
       "bonus": null,
@@ -7955,10 +7955,10 @@
       "activity_section_position": 1,
       "assessment": true,
       "properties": {
-        "progression": "Adding Pages",
         "level_keys": [
           "CSD U2 adding pages_2021"
-        ]
+        ],
+        "progression": "Adding Pages"
       },
       "named_level": null,
       "bonus": null,
@@ -7981,10 +7981,10 @@
       "activity_section_position": 1,
       "assessment": null,
       "properties": {
-        "progression": "Challenges",
         "level_keys": [
           "CSD U2 links challenge_2021"
-        ]
+        ],
+        "progression": "Challenges"
       },
       "named_level": null,
       "bonus": null,
@@ -8007,10 +8007,10 @@
       "activity_section_position": 1,
       "assessment": null,
       "properties": {
-        "progression": "Your Team Project",
         "level_keys": [
           "CSD web create pages project_2021"
-        ]
+        ],
+        "progression": "Your Team Project"
       },
       "named_level": null,
       "bonus": null,
@@ -8033,10 +8033,10 @@
       "activity_section_position": 1,
       "assessment": null,
       "properties": {
-        "progression": "Add Content and HTML",
         "level_keys": [
           "CSD web add html_2021"
-        ]
+        ],
+        "progression": "Add Content and HTML"
       },
       "named_level": null,
       "bonus": null,
@@ -8059,10 +8059,10 @@
       "activity_section_position": 1,
       "assessment": null,
       "properties": {
-        "progression": "Share Your Pages",
         "level_keys": [
           "CSD web share html_2021"
-        ]
+        ],
+        "progression": "Share Your Pages"
       },
       "named_level": null,
       "bonus": null,
@@ -8085,10 +8085,10 @@
       "activity_section_position": 1,
       "assessment": null,
       "properties": {
-        "progression": "Add Style",
         "level_keys": [
           "CSD web add CSS_2021"
-        ]
+        ],
+        "progression": "Add Style"
       },
       "named_level": null,
       "bonus": null,
@@ -8111,10 +8111,10 @@
       "activity_section_position": 1,
       "assessment": null,
       "properties": {
-        "progression": "Share Your Stylesheets",
         "level_keys": [
           "CSD web share CSS_2021"
-        ]
+        ],
+        "progression": "Share Your Stylesheets"
       },
       "named_level": null,
       "bonus": null,
@@ -8137,10 +8137,10 @@
       "activity_section_position": 1,
       "assessment": null,
       "properties": {
-        "progression": "Check Your Work",
         "level_keys": [
           "CSD web check_2021"
-        ]
+        ],
+        "progression": "Check Your Work"
       },
       "named_level": null,
       "bonus": null,
@@ -8163,10 +8163,10 @@
       "activity_section_position": 1,
       "assessment": null,
       "properties": {
-        "progression": "Final Website",
         "level_keys": [
           "CSD Web incorporate feedback_2021"
-        ]
+        ],
+        "progression": "Final Website"
       },
       "named_level": null,
       "bonus": null,
@@ -8189,10 +8189,10 @@
       "activity_section_position": 1,
       "assessment": true,
       "properties": {
-        "progression": "Reflection",
         "level_keys": [
           "csd-pulse-check-survey-1-levelgroup U2Ch2_2018_2019_pilot_2021"
-        ]
+        ],
+        "progression": "Reflection"
       },
       "named_level": null,
       "bonus": null,
@@ -10970,132 +10970,154 @@
     {
       "seeding_key": {
         "lesson.key": "Intro to HTML",
-        "programming_expression.key": "html"
-      }
-    },
-    {
-      "seeding_key": {
-        "lesson.key": "Intro to HTML",
-        "programming_expression.key": "doctype"
-      }
-    },
-    {
-      "seeding_key": {
-        "lesson.key": "Intro to HTML",
-        "programming_expression.key": "body"
-      }
-    },
-    {
-      "seeding_key": {
-        "lesson.key": "Intro to HTML",
+        "programming_environment.name": "weblab",
         "programming_expression.key": "head"
       }
     },
     {
       "seeding_key": {
         "lesson.key": "Intro to HTML",
+        "programming_environment.name": "weblab",
+        "programming_expression.key": "doctype"
+      }
+    },
+    {
+      "seeding_key": {
+        "lesson.key": "Intro to HTML",
+        "programming_environment.name": "weblab",
         "programming_expression.key": "P"
       }
     },
     {
       "seeding_key": {
+        "lesson.key": "Intro to HTML",
+        "programming_environment.name": "weblab",
+        "programming_expression.key": "body"
+      }
+    },
+    {
+      "seeding_key": {
+        "lesson.key": "Intro to HTML",
+        "programming_environment.name": "weblab",
+        "programming_expression.key": "html"
+      }
+    },
+    {
+      "seeding_key": {
         "lesson.key": "Headings",
+        "programming_environment.name": "weblab",
         "programming_expression.key": "h"
       }
     },
     {
       "seeding_key": {
         "lesson.key": "Styling Text with CSS",
-        "programming_expression.key": "font-family"
-      }
-    },
-    {
-      "seeding_key": {
-        "lesson.key": "Styling Text with CSS",
-        "programming_expression.key": "font-size"
-      }
-    },
-    {
-      "seeding_key": {
-        "lesson.key": "Styling Text with CSS",
+        "programming_environment.name": "weblab",
         "programming_expression.key": "color"
       }
     },
     {
       "seeding_key": {
         "lesson.key": "Styling Text with CSS",
-        "programming_expression.key": "Text-Dec"
+        "programming_environment.name": "weblab",
+        "programming_expression.key": "font-size"
       }
     },
     {
       "seeding_key": {
         "lesson.key": "Styling Text with CSS",
+        "programming_environment.name": "weblab",
+        "programming_expression.key": "font-family"
+      }
+    },
+    {
+      "seeding_key": {
+        "lesson.key": "Styling Text with CSS",
+        "programming_environment.name": "weblab",
         "programming_expression.key": "text-align"
       }
     },
     {
       "seeding_key": {
+        "lesson.key": "Styling Text with CSS",
+        "programming_environment.name": "weblab",
+        "programming_expression.key": "Text-Dec"
+      }
+    },
+    {
+      "seeding_key": {
         "lesson.key": "Using Images",
+        "programming_environment.name": "weblab",
         "programming_expression.key": "img"
       }
     },
     {
       "seeding_key": {
         "lesson.key": "Styling Elements with CSS",
-        "programming_expression.key": "border-width"
-      }
-    },
-    {
-      "seeding_key": {
-        "lesson.key": "Styling Elements with CSS",
-        "programming_expression.key": "background-color"
-      }
-    },
-    {
-      "seeding_key": {
-        "lesson.key": "Styling Elements with CSS",
-        "programming_expression.key": "margin"
-      }
-    },
-    {
-      "seeding_key": {
-        "lesson.key": "Styling Elements with CSS",
-        "programming_expression.key": "float"
-      }
-    },
-    {
-      "seeding_key": {
-        "lesson.key": "Styling Elements with CSS",
-        "programming_expression.key": "height"
-      }
-    },
-    {
-      "seeding_key": {
-        "lesson.key": "Styling Elements with CSS",
+        "programming_environment.name": "weblab",
         "programming_expression.key": "width"
       }
     },
     {
       "seeding_key": {
         "lesson.key": "Styling Elements with CSS",
-        "programming_expression.key": "border-color"
+        "programming_environment.name": "weblab",
+        "programming_expression.key": "height"
       }
     },
     {
       "seeding_key": {
         "lesson.key": "Styling Elements with CSS",
+        "programming_environment.name": "weblab",
+        "programming_expression.key": "margin"
+      }
+    },
+    {
+      "seeding_key": {
+        "lesson.key": "Styling Elements with CSS",
+        "programming_environment.name": "weblab",
+        "programming_expression.key": "border-radius"
+      }
+    },
+    {
+      "seeding_key": {
+        "lesson.key": "Styling Elements with CSS",
+        "programming_environment.name": "weblab",
+        "programming_expression.key": "background-color"
+      }
+    },
+    {
+      "seeding_key": {
+        "lesson.key": "Styling Elements with CSS",
+        "programming_environment.name": "weblab",
+        "programming_expression.key": "float"
+      }
+    },
+    {
+      "seeding_key": {
+        "lesson.key": "Styling Elements with CSS",
+        "programming_environment.name": "weblab",
         "programming_expression.key": "border-style"
       }
     },
     {
       "seeding_key": {
         "lesson.key": "Styling Elements with CSS",
-        "programming_expression.key": "border-radius"
+        "programming_environment.name": "weblab",
+        "programming_expression.key": "border-color"
+      }
+    },
+    {
+      "seeding_key": {
+        "lesson.key": "Styling Elements with CSS",
+        "programming_environment.name": "weblab",
+        "programming_expression.key": "border-width"
       }
     },
     {
       "seeding_key": {
         "lesson.key": "Linking Pages",
+        "programming_environment.name": "weblab",
         "programming_expression.key": "A"
       }
     }
@@ -11451,5 +11473,8 @@
         "objective.key": "c2b66c71-919f-4bbb-bdc4-9fbb244e4991"
       }
     }
+  ],
+  "lessons_standards": [
+
   ]
 }

--- a/dashboard/config/scripts_json/csd2-2021.script_json
+++ b/dashboard/config/scripts_json/csd2-2021.script_json
@@ -24,7 +24,7 @@
     },
     "new_name": null,
     "family_name": null,
-    "serialized_at": "2021-03-18 21:55:01 UTC",
+    "serialized_at": "2021-03-15 12:47:19 UTC",
     "seeding_key": {
       "script.name": "csd2-2021"
     }
@@ -5901,10 +5901,10 @@
       "activity_section_position": 1,
       "assessment": null,
       "properties": {
+        "progression": "Sample Personal Web Pages",
         "level_keys": [
           "CSD Web Sample Pages_2021"
-        ],
-        "progression": "Sample Personal Web Pages"
+        ]
       },
       "named_level": null,
       "bonus": null,
@@ -5927,10 +5927,10 @@
       "activity_section_position": 1,
       "assessment": null,
       "properties": {
+        "progression": "Experiment with Web Lab",
         "level_keys": [
           "CSDU2 - Type Anything_2021"
-        ],
-        "progression": "Experiment with Web Lab"
+        ]
       },
       "named_level": null,
       "bonus": null,
@@ -5953,10 +5953,10 @@
       "activity_section_position": 1,
       "assessment": null,
       "properties": {
+        "progression": "Video: Intro to Web Lab - Part 1",
         "level_keys": [
           "Intro to Web Lab - Part 1_2021"
-        ],
-        "progression": "Video: Intro to Web Lab - Part 1"
+        ]
       },
       "named_level": null,
       "bonus": null,
@@ -5979,10 +5979,10 @@
       "activity_section_position": 1,
       "assessment": null,
       "properties": {
+        "progression": "Explore HTML",
         "level_keys": [
           "CSD U2 Inspector Warm Up_2021"
-        ],
-        "progression": "Explore HTML"
+        ]
       },
       "named_level": null,
       "bonus": null,
@@ -6005,10 +6005,10 @@
       "activity_section_position": 1,
       "assessment": null,
       "properties": {
+        "progression": "Video: Intro to Web Lab - Part 2",
         "level_keys": [
           "Intro to Web Lab - Part 2_2021"
-        ],
-        "progression": "Video: Intro to Web Lab - Part 2"
+        ]
       },
       "named_level": null,
       "bonus": null,
@@ -6031,10 +6031,10 @@
       "activity_section_position": 1,
       "assessment": null,
       "properties": {
+        "progression": "Practice",
         "level_keys": [
           "CSD U2 HTML Adding Paragraphs_2021"
-        ],
-        "progression": "Practice"
+        ]
       },
       "named_level": null,
       "bonus": null,
@@ -6057,10 +6057,10 @@
       "activity_section_position": 1,
       "assessment": true,
       "properties": {
+        "progression": "Assessment",
         "level_keys": [
           "CSD U2 HTML Adding Paragraphs pt 2_2021"
-        ],
-        "progression": "Assessment"
+        ]
       },
       "named_level": null,
       "bonus": null,
@@ -6083,10 +6083,10 @@
       "activity_section_position": 1,
       "assessment": null,
       "properties": {
+        "progression": "Challenge",
         "level_keys": [
           "CSD U2 HTML Debug Paragraphs_2021"
-        ],
-        "progression": "Challenge"
+        ]
       },
       "named_level": null,
       "bonus": null,
@@ -6109,10 +6109,10 @@
       "activity_section_position": 1,
       "assessment": false,
       "properties": {
+        "progression": "Video: Pair Programming",
         "level_keys": [
           "CSD U2 Pair Programming Video_2021"
-        ],
-        "progression": "Video: Pair Programming"
+        ]
       },
       "named_level": null,
       "bonus": null,
@@ -6135,10 +6135,10 @@
       "activity_section_position": 1,
       "assessment": false,
       "properties": {
+        "progression": "Skill Building",
         "level_keys": [
           "CSD U2 Heading debug_2021"
-        ],
-        "progression": "Skill Building"
+        ]
       },
       "named_level": null,
       "bonus": null,
@@ -6161,10 +6161,10 @@
       "activity_section_position": 2,
       "assessment": false,
       "properties": {
+        "progression": "Skill Building",
         "level_keys": [
           "CSD U2 Heading Demo_2021"
-        ],
-        "progression": "Skill Building"
+        ]
       },
       "named_level": null,
       "bonus": null,
@@ -6187,10 +6187,10 @@
       "activity_section_position": 3,
       "assessment": false,
       "properties": {
+        "progression": "Skill Building",
         "level_keys": [
           "CSD U2 Heading Sizes_2021"
-        ],
-        "progression": "Skill Building"
+        ]
       },
       "named_level": null,
       "bonus": null,
@@ -6213,10 +6213,10 @@
       "activity_section_position": 1,
       "assessment": true,
       "properties": {
+        "progression": "Quick Check",
         "level_keys": [
           "CSD Header Size MC_2018_2019_pilot_2021"
-        ],
-        "progression": "Quick Check"
+        ]
       },
       "named_level": null,
       "bonus": null,
@@ -6239,10 +6239,10 @@
       "activity_section_position": 1,
       "assessment": false,
       "properties": {
+        "progression": "Video: Debugging",
         "level_keys": [
           "CSD Web Debugging_2021"
-        ],
-        "progression": "Video: Debugging"
+        ]
       },
       "named_level": null,
       "bonus": null,
@@ -6265,10 +6265,10 @@
       "activity_section_position": 1,
       "assessment": false,
       "properties": {
+        "progression": "Practice",
         "level_keys": [
           "CSD Web Headings practice_2021"
-        ],
-        "progression": "Practice"
+        ]
       },
       "named_level": null,
       "bonus": null,
@@ -6291,10 +6291,10 @@
       "activity_section_position": 1,
       "assessment": true,
       "properties": {
+        "progression": "Assessment",
         "level_keys": [
           "CSD U2 Heading Test_2021"
-        ],
-        "progression": "Assessment"
+        ]
       },
       "named_level": null,
       "bonus": null,
@@ -6317,10 +6317,10 @@
       "activity_section_position": 1,
       "assessment": false,
       "properties": {
+        "progression": "Challenges",
         "level_keys": [
           "CSD Web Headings challenge_2021"
-        ],
-        "progression": "Challenges"
+        ]
       },
       "named_level": null,
       "bonus": null,
@@ -6343,10 +6343,10 @@
       "activity_section_position": 1,
       "assessment": null,
       "properties": {
+        "progression": "Review: HTML",
         "level_keys": [
           "CSD HTML project Review_2021"
-        ],
-        "progression": "Review: HTML"
+        ]
       },
       "named_level": null,
       "bonus": null,
@@ -6369,10 +6369,10 @@
       "activity_section_position": 1,
       "assessment": null,
       "properties": {
+        "progression": "Challenge: Lists",
         "level_keys": [
           "CSD HTML project Lists_2021"
-        ],
-        "progression": "Challenge: Lists"
+        ]
       },
       "named_level": null,
       "bonus": null,
@@ -6395,10 +6395,10 @@
       "activity_section_position": 1,
       "assessment": null,
       "properties": {
+        "progression": "Code Your Page",
         "level_keys": [
           "CSD web HTML project HTML_2021"
-        ],
-        "progression": "Code Your Page"
+        ]
       },
       "named_level": null,
       "bonus": null,
@@ -6421,10 +6421,10 @@
       "activity_section_position": 1,
       "assessment": null,
       "properties": {
+        "progression": "Review Your Page",
         "level_keys": [
           "CSD web HTML project check_2021"
-        ],
-        "progression": "Review Your Page"
+        ]
       },
       "named_level": null,
       "bonus": null,
@@ -6447,10 +6447,10 @@
       "activity_section_position": 1,
       "assessment": null,
       "properties": {
+        "progression": "Social Sleuth",
         "level_keys": [
           "Social Sleuth_2018_2019_pilot_2021"
-        ],
-        "progression": "Social Sleuth"
+        ]
       },
       "named_level": null,
       "bonus": null,
@@ -6473,10 +6473,10 @@
       "activity_section_position": 1,
       "assessment": null,
       "properties": {
+        "progression": "Sample Website",
         "level_keys": [
           "CSD U2 Sample CSS text_2021"
-        ],
-        "progression": "Sample Website"
+        ]
       },
       "named_level": null,
       "bonus": null,
@@ -6499,10 +6499,10 @@
       "activity_section_position": 1,
       "assessment": null,
       "properties": {
+        "progression": "Exploration",
         "level_keys": [
           "CSD U2 CSS explore CSS_2021"
-        ],
-        "progression": "Exploration"
+        ]
       },
       "named_level": null,
       "bonus": null,
@@ -6525,10 +6525,10 @@
       "activity_section_position": 1,
       "assessment": null,
       "properties": {
+        "progression": "Video: Intro to CSS - Part 1",
         "level_keys": [
           "Video: Intro to CSS_2021"
-        ],
-        "progression": "Video: Intro to CSS - Part 1"
+        ]
       },
       "named_level": null,
       "bonus": null,
@@ -6551,10 +6551,10 @@
       "activity_section_position": 1,
       "assessment": null,
       "properties": {
+        "progression": "Skill Building",
         "level_keys": [
           "CSD U2 text style h1_2021"
-        ],
-        "progression": "Skill Building"
+        ]
       },
       "named_level": null,
       "bonus": null,
@@ -6577,10 +6577,10 @@
       "activity_section_position": 2,
       "assessment": null,
       "properties": {
+        "progression": "Skill Building",
         "level_keys": [
           "CSD U2 text style h3_2021"
-        ],
-        "progression": "Skill Building"
+        ]
       },
       "named_level": null,
       "bonus": null,
@@ -6603,10 +6603,10 @@
       "activity_section_position": 3,
       "assessment": null,
       "properties": {
+        "progression": "Skill Building",
         "level_keys": [
           "CSD U2 text style size_2021"
-        ],
-        "progression": "Skill Building"
+        ]
       },
       "named_level": null,
       "bonus": null,
@@ -6629,10 +6629,10 @@
       "activity_section_position": 1,
       "assessment": null,
       "properties": {
+        "progression": "Video: Intro to CSS - Part 2",
         "level_keys": [
           "Video: Intro to CSS Part 2_2021"
-        ],
-        "progression": "Video: Intro to CSS - Part 2"
+        ]
       },
       "named_level": null,
       "bonus": null,
@@ -6655,10 +6655,10 @@
       "activity_section_position": 1,
       "assessment": null,
       "properties": {
+        "progression": "Skill Building",
         "level_keys": [
           "CSD U2 add file_2021"
-        ],
-        "progression": "Skill Building"
+        ]
       },
       "named_level": null,
       "bonus": null,
@@ -6681,10 +6681,10 @@
       "activity_section_position": 1,
       "assessment": null,
       "properties": {
+        "progression": "Practice",
         "level_keys": [
           "CSD U2 CSS practice_pilot_2021"
-        ],
-        "progression": "Practice"
+        ]
       },
       "named_level": null,
       "bonus": null,
@@ -6707,10 +6707,10 @@
       "activity_section_position": 1,
       "assessment": true,
       "properties": {
+        "progression": "Assessment",
         "level_keys": [
           "CSD Web CSS Assessment_2021"
-        ],
-        "progression": "Assessment"
+        ]
       },
       "named_level": null,
       "bonus": null,
@@ -6733,10 +6733,10 @@
       "activity_section_position": 1,
       "assessment": null,
       "properties": {
+        "progression": "Challenges",
         "level_keys": [
           "CSD U2 CSS challenge_pilot_2021"
-        ],
-        "progression": "Challenges"
+        ]
       },
       "named_level": null,
       "bonus": null,
@@ -6759,10 +6759,10 @@
       "activity_section_position": 1,
       "assessment": null,
       "properties": {
+        "progression": "Review: CSS",
         "level_keys": [
           "CSD CSS project Review_2021"
-        ],
-        "progression": "Review: CSS"
+        ]
       },
       "named_level": null,
       "bonus": null,
@@ -6785,10 +6785,10 @@
       "activity_section_position": 1,
       "assessment": null,
       "properties": {
+        "progression": "Challenge: RGB Colors",
         "level_keys": [
           "CSD CSS project RGB_2021"
-        ],
-        "progression": "Challenge: RGB Colors"
+        ]
       },
       "named_level": null,
       "bonus": null,
@@ -6811,10 +6811,10 @@
       "activity_section_position": 1,
       "assessment": null,
       "properties": {
+        "progression": "Add Content and Structure to Your Page",
         "level_keys": [
           "CSD web CSS project HTML_2021"
-        ],
-        "progression": "Add Content and Structure to Your Page"
+        ]
       },
       "named_level": null,
       "bonus": null,
@@ -6837,10 +6837,10 @@
       "activity_section_position": 1,
       "assessment": null,
       "properties": {
+        "progression": "Add Style to Your Page",
         "level_keys": [
           "CSD web CSS project CSS_2021"
-        ],
-        "progression": "Add Style to Your Page"
+        ]
       },
       "named_level": null,
       "bonus": null,
@@ -6863,10 +6863,10 @@
       "activity_section_position": 1,
       "assessment": null,
       "properties": {
+        "progression": "Review Your Page",
         "level_keys": [
           "CSD web CSS project check_2021"
-        ],
-        "progression": "Review Your Page"
+        ]
       },
       "named_level": null,
       "bonus": null,
@@ -6889,10 +6889,10 @@
       "activity_section_position": 1,
       "assessment": null,
       "properties": {
+        "progression": "Skill Building",
         "level_keys": [
           "CSD U2 Image Tag 1_2021"
-        ],
-        "progression": "Skill Building"
+        ]
       },
       "named_level": null,
       "bonus": null,
@@ -6915,10 +6915,10 @@
       "activity_section_position": 2,
       "assessment": null,
       "properties": {
+        "progression": "Skill Building",
         "level_keys": [
           "CSD U2 Image Credit_2021"
-        ],
-        "progression": "Skill Building"
+        ]
       },
       "named_level": null,
       "bonus": null,
@@ -6941,10 +6941,10 @@
       "activity_section_position": 3,
       "assessment": null,
       "properties": {
+        "progression": "Skill Building",
         "level_keys": [
           "CSD U2 Image Tag Debug_2021"
-        ],
-        "progression": "Skill Building"
+        ]
       },
       "named_level": null,
       "bonus": null,
@@ -6967,10 +6967,10 @@
       "activity_section_position": 4,
       "assessment": null,
       "properties": {
+        "progression": "Skill Building",
         "level_keys": [
           "CSD U2 Image choose name_2021"
-        ],
-        "progression": "Skill Building"
+        ]
       },
       "named_level": null,
       "bonus": null,
@@ -6993,10 +6993,10 @@
       "activity_section_position": 5,
       "assessment": null,
       "properties": {
+        "progression": "Skill Building",
         "level_keys": [
           "CSD U2 Image Tag 2_2021"
-        ],
-        "progression": "Skill Building"
+        ]
       },
       "named_level": null,
       "bonus": null,
@@ -7019,10 +7019,10 @@
       "activity_section_position": 1,
       "assessment": null,
       "properties": {
+        "progression": "Practice",
         "level_keys": [
           "CSD U2 Image practice_pilot_2021"
-        ],
-        "progression": "Practice"
+        ]
       },
       "named_level": null,
       "bonus": null,
@@ -7045,10 +7045,10 @@
       "activity_section_position": 1,
       "assessment": true,
       "properties": {
+        "progression": "Assessment",
         "level_keys": [
           "CSD U2 Image assessment_2021"
-        ],
-        "progression": "Assessment"
+        ]
       },
       "named_level": null,
       "bonus": null,
@@ -7071,10 +7071,10 @@
       "activity_section_position": 1,
       "assessment": null,
       "properties": {
+        "progression": "Challenges",
         "level_keys": [
           "CSD U2 Image challenge_pilot_2021"
-        ],
-        "progression": "Challenges"
+        ]
       },
       "named_level": null,
       "bonus": null,
@@ -7097,10 +7097,10 @@
       "activity_section_position": 1,
       "assessment": null,
       "properties": {
+        "progression": "Sample Personal Websites",
         "level_keys": [
           "CSD U2 Expression Exemplars_2018_2019_pilot_2021"
-        ],
-        "progression": "Sample Personal Websites"
+        ]
       },
       "named_level": null,
       "bonus": null,
@@ -7123,10 +7123,10 @@
       "activity_section_position": 1,
       "assessment": null,
       "properties": {
+        "progression": "Sample Website",
         "level_keys": [
           "CSD U2 Sample CSS layout_2021"
-        ],
-        "progression": "Sample Website"
+        ]
       },
       "named_level": null,
       "bonus": null,
@@ -7149,10 +7149,10 @@
       "activity_section_position": 1,
       "assessment": null,
       "properties": {
+        "progression": "Exploration",
         "level_keys": [
           "CSD U2 layout style sample_2021"
-        ],
-        "progression": "Exploration"
+        ]
       },
       "named_level": null,
       "bonus": null,
@@ -7175,10 +7175,10 @@
       "activity_section_position": 1,
       "assessment": null,
       "properties": {
+        "progression": "Skill Building",
         "level_keys": [
           "CSD U2 layout style bgcolor_2021"
-        ],
-        "progression": "Skill Building"
+        ]
       },
       "named_level": null,
       "bonus": null,
@@ -7201,10 +7201,10 @@
       "activity_section_position": 2,
       "assessment": null,
       "properties": {
+        "progression": "Skill Building",
         "level_keys": [
           "CSD U2 layout style body_2021"
-        ],
-        "progression": "Skill Building"
+        ]
       },
       "named_level": null,
       "bonus": null,
@@ -7227,10 +7227,10 @@
       "activity_section_position": 3,
       "assessment": null,
       "properties": {
+        "progression": "Skill Building",
         "level_keys": [
           "CSD U2 layout style float_2021"
-        ],
-        "progression": "Skill Building"
+        ]
       },
       "named_level": null,
       "bonus": null,
@@ -7253,10 +7253,10 @@
       "activity_section_position": 4,
       "assessment": null,
       "properties": {
+        "progression": "Skill Building",
         "level_keys": [
           "CSD U2 layout style width_2021"
-        ],
-        "progression": "Skill Building"
+        ]
       },
       "named_level": null,
       "bonus": null,
@@ -7279,10 +7279,10 @@
       "activity_section_position": 1,
       "assessment": null,
       "properties": {
+        "progression": "Practice",
         "level_keys": [
           "CSD U2 layout style practice_pilot_2021"
-        ],
-        "progression": "Practice"
+        ]
       },
       "named_level": null,
       "bonus": null,
@@ -7305,10 +7305,10 @@
       "activity_section_position": 1,
       "assessment": true,
       "properties": {
+        "progression": "Assessment",
         "level_keys": [
           "CSD U2 add style_2021"
-        ],
-        "progression": "Assessment"
+        ]
       },
       "named_level": null,
       "bonus": null,
@@ -7331,10 +7331,10 @@
       "activity_section_position": 1,
       "assessment": null,
       "properties": {
+        "progression": "Challenges",
         "level_keys": [
           "CSD U2 layout style challenge_pilot_2021"
-        ],
-        "progression": "Challenges"
+        ]
       },
       "named_level": null,
       "bonus": null,
@@ -7357,10 +7357,10 @@
       "activity_section_position": 1,
       "assessment": null,
       "properties": {
+        "progression": "Project Guide",
         "level_keys": [
           "CSD U2 project guide_2018_2019_pilot_2021"
-        ],
-        "progression": "Project Guide"
+        ]
       },
       "named_level": null,
       "bonus": null,
@@ -7383,10 +7383,10 @@
       "activity_section_position": 1,
       "assessment": null,
       "properties": {
+        "progression": "Website Project",
         "level_keys": [
           "CSD U2 upload images_2021"
-        ],
-        "progression": "Website Project"
+        ]
       },
       "named_level": null,
       "bonus": null,
@@ -7409,10 +7409,10 @@
       "activity_section_position": 2,
       "assessment": null,
       "properties": {
+        "progression": "Website Project",
         "level_keys": [
           "CSD U2 add content_2021"
-        ],
-        "progression": "Website Project"
+        ]
       },
       "named_level": null,
       "bonus": null,
@@ -7435,10 +7435,10 @@
       "activity_section_position": 3,
       "assessment": null,
       "properties": {
+        "progression": "Website Project",
         "level_keys": [
           "CSD U2 CSS_2021"
-        ],
-        "progression": "Website Project"
+        ]
       },
       "named_level": null,
       "bonus": null,
@@ -7461,10 +7461,10 @@
       "activity_section_position": 4,
       "assessment": null,
       "properties": {
+        "progression": "Website Project",
         "level_keys": [
           "CSD U2 project review_2021"
-        ],
-        "progression": "Website Project"
+        ]
       },
       "named_level": null,
       "bonus": null,
@@ -7487,10 +7487,10 @@
       "activity_section_position": 1,
       "assessment": null,
       "properties": {
+        "progression": "Video: Publishing Your Website",
         "level_keys": [
           "CSD U2 publish video_2021"
-        ],
-        "progression": "Video: Publishing Your Website"
+        ]
       },
       "named_level": null,
       "bonus": null,
@@ -7513,10 +7513,10 @@
       "activity_section_position": 1,
       "assessment": null,
       "properties": {
+        "progression": "Publishing Your Website",
         "level_keys": [
           "CSD U2 project share_2021"
-        ],
-        "progression": "Publishing Your Website"
+        ]
       },
       "named_level": null,
       "bonus": null,
@@ -7539,10 +7539,10 @@
       "activity_section_position": 1,
       "assessment": true,
       "properties": {
+        "progression": "Reflection",
         "level_keys": [
           "csd-pulse-check-survey-1-levelgroup U2Ch1_2018_2019_pilot_2021"
-        ],
-        "progression": "Reflection"
+        ]
       },
       "named_level": null,
       "bonus": null,
@@ -7565,10 +7565,10 @@
       "activity_section_position": 1,
       "assessment": null,
       "properties": {
+        "progression": "Top Websites",
         "level_keys": [
           "CSD U2 Top Websites_2018_2019_pilot_2021"
-        ],
-        "progression": "Top Websites"
+        ]
       },
       "named_level": null,
       "bonus": null,
@@ -7591,10 +7591,10 @@
       "activity_section_position": 1,
       "assessment": null,
       "properties": {
+        "progression": "Video: Teamwork",
         "level_keys": [
           "csd web teamwork video_2021"
-        ],
-        "progression": "Video: Teamwork"
+        ]
       },
       "named_level": null,
       "bonus": null,
@@ -7617,10 +7617,10 @@
       "activity_section_position": 1,
       "assessment": null,
       "properties": {
+        "progression": "Video: Managing Disagreement",
         "level_keys": [
           "csd web disagreement video_2021"
-        ],
-        "progression": "Video: Managing Disagreement"
+        ]
       },
       "named_level": null,
       "bonus": null,
@@ -7643,10 +7643,10 @@
       "activity_section_position": 1,
       "assessment": null,
       "properties": {
+        "progression": "Sample Web Page",
         "level_keys": [
           "CSD U2 Sample classes_2021"
-        ],
-        "progression": "Sample Web Page"
+        ]
       },
       "named_level": null,
       "bonus": null,
@@ -7669,10 +7669,10 @@
       "activity_section_position": 1,
       "assessment": null,
       "properties": {
+        "progression": "Exploration",
         "level_keys": [
           "CSD U2 classes waterfalls_2021"
-        ],
-        "progression": "Exploration"
+        ]
       },
       "named_level": null,
       "bonus": null,
@@ -7695,10 +7695,10 @@
       "activity_section_position": 1,
       "assessment": null,
       "properties": {
+        "progression": "Skill Building",
         "level_keys": [
           "CSD U2 classes humors_2021"
-        ],
-        "progression": "Skill Building"
+        ]
       },
       "named_level": null,
       "bonus": null,
@@ -7721,10 +7721,10 @@
       "activity_section_position": 1,
       "assessment": null,
       "properties": {
+        "progression": "Practice",
         "level_keys": [
           "CSD web classes practice_2021"
-        ],
-        "progression": "Practice"
+        ]
       },
       "named_level": null,
       "bonus": null,
@@ -7747,10 +7747,10 @@
       "activity_section_position": 1,
       "assessment": true,
       "properties": {
+        "progression": "Assessment",
         "level_keys": [
           "CSD U2 classes haikus_2021"
-        ],
-        "progression": "Assessment"
+        ]
       },
       "named_level": null,
       "bonus": null,
@@ -7773,10 +7773,10 @@
       "activity_section_position": 1,
       "assessment": null,
       "properties": {
+        "progression": "Challenges",
         "level_keys": [
           "CSD web classes challenge_2021"
-        ],
-        "progression": "Challenges"
+        ]
       },
       "named_level": null,
       "bonus": null,
@@ -7799,10 +7799,10 @@
       "activity_section_position": 1,
       "assessment": null,
       "properties": {
+        "progression": "Upload Your Images",
         "level_keys": [
           "CSD web upload images multi_2021"
-        ],
-        "progression": "Upload Your Images"
+        ]
       },
       "named_level": null,
       "bonus": null,
@@ -7825,10 +7825,10 @@
       "activity_section_position": 1,
       "assessment": null,
       "properties": {
+        "progression": "Exploration",
         "level_keys": [
           "CSD U2 link demo_2021"
-        ],
-        "progression": "Exploration"
+        ]
       },
       "named_level": null,
       "bonus": null,
@@ -7851,10 +7851,10 @@
       "activity_section_position": 1,
       "assessment": null,
       "properties": {
+        "progression": "Skill Building",
         "level_keys": [
           "CSD U2 making links_2021"
-        ],
-        "progression": "Skill Building"
+        ]
       },
       "named_level": null,
       "bonus": null,
@@ -7877,10 +7877,10 @@
       "activity_section_position": 2,
       "assessment": null,
       "properties": {
+        "progression": "Skill Building",
         "level_keys": [
           "CSD U2 naming links_2021"
-        ],
-        "progression": "Skill Building"
+        ]
       },
       "named_level": null,
       "bonus": null,
@@ -7903,10 +7903,10 @@
       "activity_section_position": 3,
       "assessment": null,
       "properties": {
+        "progression": "Skill Building",
         "level_keys": [
           "CSD U2 naming pages_2021"
-        ],
-        "progression": "Skill Building"
+        ]
       },
       "named_level": null,
       "bonus": null,
@@ -7929,10 +7929,10 @@
       "activity_section_position": 1,
       "assessment": null,
       "properties": {
+        "progression": "Practice",
         "level_keys": [
           "CSD U2 nav bar_2021"
-        ],
-        "progression": "Practice"
+        ]
       },
       "named_level": null,
       "bonus": null,
@@ -7955,10 +7955,10 @@
       "activity_section_position": 1,
       "assessment": true,
       "properties": {
+        "progression": "Adding Pages",
         "level_keys": [
           "CSD U2 adding pages_2021"
-        ],
-        "progression": "Adding Pages"
+        ]
       },
       "named_level": null,
       "bonus": null,
@@ -7981,10 +7981,10 @@
       "activity_section_position": 1,
       "assessment": null,
       "properties": {
+        "progression": "Challenges",
         "level_keys": [
           "CSD U2 links challenge_2021"
-        ],
-        "progression": "Challenges"
+        ]
       },
       "named_level": null,
       "bonus": null,
@@ -8007,10 +8007,10 @@
       "activity_section_position": 1,
       "assessment": null,
       "properties": {
+        "progression": "Your Team Project",
         "level_keys": [
           "CSD web create pages project_2021"
-        ],
-        "progression": "Your Team Project"
+        ]
       },
       "named_level": null,
       "bonus": null,
@@ -8033,10 +8033,10 @@
       "activity_section_position": 1,
       "assessment": null,
       "properties": {
+        "progression": "Add Content and HTML",
         "level_keys": [
           "CSD web add html_2021"
-        ],
-        "progression": "Add Content and HTML"
+        ]
       },
       "named_level": null,
       "bonus": null,
@@ -8059,10 +8059,10 @@
       "activity_section_position": 1,
       "assessment": null,
       "properties": {
+        "progression": "Share Your Pages",
         "level_keys": [
           "CSD web share html_2021"
-        ],
-        "progression": "Share Your Pages"
+        ]
       },
       "named_level": null,
       "bonus": null,
@@ -8085,10 +8085,10 @@
       "activity_section_position": 1,
       "assessment": null,
       "properties": {
+        "progression": "Add Style",
         "level_keys": [
           "CSD web add CSS_2021"
-        ],
-        "progression": "Add Style"
+        ]
       },
       "named_level": null,
       "bonus": null,
@@ -8111,10 +8111,10 @@
       "activity_section_position": 1,
       "assessment": null,
       "properties": {
+        "progression": "Share Your Stylesheets",
         "level_keys": [
           "CSD web share CSS_2021"
-        ],
-        "progression": "Share Your Stylesheets"
+        ]
       },
       "named_level": null,
       "bonus": null,
@@ -8137,10 +8137,10 @@
       "activity_section_position": 1,
       "assessment": null,
       "properties": {
+        "progression": "Check Your Work",
         "level_keys": [
           "CSD web check_2021"
-        ],
-        "progression": "Check Your Work"
+        ]
       },
       "named_level": null,
       "bonus": null,
@@ -8163,10 +8163,10 @@
       "activity_section_position": 1,
       "assessment": null,
       "properties": {
+        "progression": "Final Website",
         "level_keys": [
           "CSD Web incorporate feedback_2021"
-        ],
-        "progression": "Final Website"
+        ]
       },
       "named_level": null,
       "bonus": null,
@@ -8189,10 +8189,10 @@
       "activity_section_position": 1,
       "assessment": true,
       "properties": {
+        "progression": "Reflection",
         "level_keys": [
           "csd-pulse-check-survey-1-levelgroup U2Ch2_2018_2019_pilot_2021"
-        ],
-        "progression": "Reflection"
+        ]
       },
       "named_level": null,
       "bonus": null,
@@ -11473,8 +11473,5 @@
         "objective.key": "c2b66c71-919f-4bbb-bdc4-9fbb244e4991"
       }
     }
-  ],
-  "lessons_standards": [
-
   ]
 }

--- a/dashboard/config/scripts_json/csd3-2021.script_json
+++ b/dashboard/config/scripts_json/csd3-2021.script_json
@@ -25,7 +25,7 @@
     },
     "new_name": null,
     "family_name": null,
-    "serialized_at": "2021-03-15 12:48:46 UTC",
+    "serialized_at": "2021-03-18 21:59:34 UTC",
     "seeding_key": {
       "script.name": "csd3-2021"
     }
@@ -17682,276 +17682,322 @@
     {
       "seeding_key": {
         "lesson.key": "Drawing in Game Lab",
+        "programming_environment.name": "gamelab",
         "programming_expression.key": "rect"
       }
     },
     {
       "seeding_key": {
         "lesson.key": "Drawing in Game Lab",
+        "programming_environment.name": "gamelab",
         "programming_expression.key": "ellipse"
       }
     },
     {
       "seeding_key": {
         "lesson.key": "Drawing in Game Lab",
+        "programming_environment.name": "gamelab",
         "programming_expression.key": "fill"
       }
     },
     {
       "seeding_key": {
         "lesson.key": "Shapes and Parameters",
-        "programming_expression.key": "rect"
-      }
-    },
-    {
-      "seeding_key": {
-        "lesson.key": "Shapes and Parameters",
+        "programming_environment.name": "gamelab",
         "programming_expression.key": "background"
       }
     },
     {
       "seeding_key": {
         "lesson.key": "Shapes and Parameters",
+        "programming_environment.name": "gamelab",
+        "programming_expression.key": "rect"
+      }
+    },
+    {
+      "seeding_key": {
+        "lesson.key": "Shapes and Parameters",
+        "programming_environment.name": "gamelab",
         "programming_expression.key": "ellipse"
       }
     },
     {
       "seeding_key": {
         "lesson.key": "Variables",
-        "programming_expression.key": "declareNoAssign_x"
-      }
-    },
-    {
-      "seeding_key": {
-        "lesson.key": "Variables",
+        "programming_environment.name": "gamelab",
         "programming_expression.key": "declareAssign_x"
       }
     },
     {
       "seeding_key": {
+        "lesson.key": "Variables",
+        "programming_environment.name": "gamelab",
+        "programming_expression.key": "declareNoAssign_x"
+      }
+    },
+    {
+      "seeding_key": {
         "lesson.key": "Random Numbers",
+        "programming_environment.name": "gamelab",
         "programming_expression.key": "randomNumber"
       }
     },
     {
       "seeding_key": {
         "lesson.key": "Sprites",
-        "programming_expression.key": "createSprite"
-      }
-    },
-    {
-      "seeding_key": {
-        "lesson.key": "Sprites",
+        "programming_environment.name": "gamelab",
         "programming_expression.key": "drawSprites"
       }
     },
     {
       "seeding_key": {
-        "lesson.key": "Sprite Properties",
-        "programming_expression.key": "rotation"
+        "lesson.key": "Sprites",
+        "programming_environment.name": "gamelab",
+        "programming_expression.key": "createSprite"
       }
     },
     {
       "seeding_key": {
         "lesson.key": "Sprite Properties",
-        "programming_expression.key": "y"
-      }
-    },
-    {
-      "seeding_key": {
-        "lesson.key": "Sprite Properties",
+        "programming_environment.name": "gamelab",
         "programming_expression.key": "scale"
       }
     },
     {
       "seeding_key": {
         "lesson.key": "Sprite Properties",
+        "programming_environment.name": "gamelab",
         "programming_expression.key": "x"
       }
     },
     {
       "seeding_key": {
-        "lesson.key": "The Draw Loop",
-        "programming_expression.key": "World.frameRate"
+        "lesson.key": "Sprite Properties",
+        "programming_environment.name": "gamelab",
+        "programming_expression.key": "y"
+      }
+    },
+    {
+      "seeding_key": {
+        "lesson.key": "Sprite Properties",
+        "programming_environment.name": "gamelab",
+        "programming_expression.key": "rotation"
       }
     },
     {
       "seeding_key": {
         "lesson.key": "The Draw Loop",
+        "programming_environment.name": "gamelab",
         "programming_expression.key": "draw"
       }
     },
     {
       "seeding_key": {
-        "lesson.key": "Conditionals",
-        "programming_expression.key": "equalityOperator"
+        "lesson.key": "The Draw Loop",
+        "programming_environment.name": "gamelab",
+        "programming_expression.key": "World.frameRate"
       }
     },
     {
       "seeding_key": {
         "lesson.key": "Conditionals",
-        "programming_expression.key": "greaterThanOrEqualOperator"
+        "programming_environment.name": "gamelab",
+        "programming_expression.key": "lessThanOrEqualOperator"
       }
     },
     {
       "seeding_key": {
         "lesson.key": "Conditionals",
+        "programming_environment.name": "gamelab",
         "programming_expression.key": "greaterThanOperator"
       }
     },
     {
       "seeding_key": {
         "lesson.key": "Conditionals",
-        "programming_expression.key": "ifBlock"
+        "programming_environment.name": "gamelab",
+        "programming_expression.key": "greaterThanOrEqualOperator"
       }
     },
     {
       "seeding_key": {
         "lesson.key": "Conditionals",
-        "programming_expression.key": "lessThanOperator"
+        "programming_environment.name": "gamelab",
+        "programming_expression.key": "equalityOperator"
       }
     },
     {
       "seeding_key": {
         "lesson.key": "Conditionals",
+        "programming_environment.name": "gamelab",
         "programming_expression.key": "inequalityOperator"
       }
     },
     {
       "seeding_key": {
         "lesson.key": "Conditionals",
-        "programming_expression.key": "lessThanOrEqualOperator"
+        "programming_environment.name": "gamelab",
+        "programming_expression.key": "lessThanOperator"
+      }
+    },
+    {
+      "seeding_key": {
+        "lesson.key": "Conditionals",
+        "programming_environment.name": "gamelab",
+        "programming_expression.key": "ifBlock"
       }
     },
     {
       "seeding_key": {
         "lesson.key": "Keyboard Input",
+        "programming_environment.name": "gamelab",
         "programming_expression.key": "keyDown"
       }
     },
     {
       "seeding_key": {
         "lesson.key": "Mouse Input",
+        "programming_environment.name": "gamelab",
         "programming_expression.key": "keyWentUp"
       }
     },
     {
       "seeding_key": {
         "lesson.key": "Mouse Input",
+        "programming_environment.name": "gamelab",
         "programming_expression.key": "visible"
       }
     },
     {
       "seeding_key": {
         "lesson.key": "Mouse Input",
-        "programming_expression.key": "keyWentDown"
-      }
-    },
-    {
-      "seeding_key": {
-        "lesson.key": "Mouse Input",
-        "programming_expression.key": "mouseWentDown"
-      }
-    },
-    {
-      "seeding_key": {
-        "lesson.key": "Mouse Input",
-        "programming_expression.key": "mouseDown"
-      }
-    },
-    {
-      "seeding_key": {
-        "lesson.key": "Mouse Input",
-        "programming_expression.key": "ifElseBlock"
-      }
-    },
-    {
-      "seeding_key": {
-        "lesson.key": "Mouse Input",
+        "programming_environment.name": "gamelab",
         "programming_expression.key": "mouseDidMove"
       }
     },
     {
       "seeding_key": {
         "lesson.key": "Mouse Input",
+        "programming_environment.name": "gamelab",
+        "programming_expression.key": "ifElseBlock"
+      }
+    },
+    {
+      "seeding_key": {
+        "lesson.key": "Mouse Input",
+        "programming_environment.name": "gamelab",
         "programming_expression.key": "mouseWentUp"
       }
     },
     {
       "seeding_key": {
+        "lesson.key": "Mouse Input",
+        "programming_environment.name": "gamelab",
+        "programming_expression.key": "mouseWentDown"
+      }
+    },
+    {
+      "seeding_key": {
+        "lesson.key": "Mouse Input",
+        "programming_environment.name": "gamelab",
+        "programming_expression.key": "mouseDown"
+      }
+    },
+    {
+      "seeding_key": {
+        "lesson.key": "Mouse Input",
+        "programming_environment.name": "gamelab",
+        "programming_expression.key": "keyWentDown"
+      }
+    },
+    {
+      "seeding_key": {
         "lesson.key": "Velocity",
+        "programming_environment.name": "gamelab",
+        "programming_expression.key": "rotationSpeed"
+      }
+    },
+    {
+      "seeding_key": {
+        "lesson.key": "Velocity",
+        "programming_environment.name": "gamelab",
         "programming_expression.key": "velocityY"
       }
     },
     {
       "seeding_key": {
         "lesson.key": "Velocity",
+        "programming_environment.name": "gamelab",
         "programming_expression.key": "velocityX"
       }
     },
     {
       "seeding_key": {
-        "lesson.key": "Velocity",
-        "programming_expression.key": "rotationSpeed"
-      }
-    },
-    {
-      "seeding_key": {
         "lesson.key": "Collision Detection",
+        "programming_environment.name": "gamelab",
         "programming_expression.key": "debug"
       }
     },
     {
       "seeding_key": {
         "lesson.key": "Collision Detection",
+        "programming_environment.name": "gamelab",
         "programming_expression.key": "isTouching"
       }
     },
     {
       "seeding_key": {
         "lesson.key": "Collisions",
-        "programming_expression.key": "setCollider"
-      }
-    },
-    {
-      "seeding_key": {
-        "lesson.key": "Collisions",
-        "programming_expression.key": "bounceOff"
-      }
-    },
-    {
-      "seeding_key": {
-        "lesson.key": "Collisions",
+        "programming_environment.name": "gamelab",
         "programming_expression.key": "displace"
       }
     },
     {
       "seeding_key": {
         "lesson.key": "Collisions",
+        "programming_environment.name": "gamelab",
+        "programming_expression.key": "collide"
+      }
+    },
+    {
+      "seeding_key": {
+        "lesson.key": "Collisions",
+        "programming_environment.name": "gamelab",
         "programming_expression.key": "bounciness"
       }
     },
     {
       "seeding_key": {
         "lesson.key": "Collisions",
-        "programming_expression.key": "bounce"
+        "programming_environment.name": "gamelab",
+        "programming_expression.key": "setCollider"
       }
     },
     {
       "seeding_key": {
         "lesson.key": "Collisions",
-        "programming_expression.key": "collide"
+        "programming_environment.name": "gamelab",
+        "programming_expression.key": "bounceOff"
+      }
+    },
+    {
+      "seeding_key": {
+        "lesson.key": "Collisions",
+        "programming_environment.name": "gamelab",
+        "programming_expression.key": "bounce"
       }
     },
     {
       "seeding_key": {
         "lesson.key": "Functions",
+        "programming_environment.name": "gamelab",
         "programming_expression.key": "functionParams_none"
       }
     },
     {
       "seeding_key": {
         "lesson.key": "Functions",
+        "programming_environment.name": "gamelab",
         "programming_expression.key": "callMyFunction"
       }
     }
@@ -18397,5 +18443,8 @@
         "objective.key": "7f488fda-a480-4f40-814d-6a2810780b38"
       }
     }
+  ],
+  "lessons_standards": [
+
   ]
 }

--- a/dashboard/config/scripts_json/csd3-2021.script_json
+++ b/dashboard/config/scripts_json/csd3-2021.script_json
@@ -25,7 +25,7 @@
     },
     "new_name": null,
     "family_name": null,
-    "serialized_at": "2021-03-18 21:59:34 UTC",
+    "serialized_at": "2021-03-15 12:48:46 UTC",
     "seeding_key": {
       "script.name": "csd3-2021"
     }
@@ -18443,8 +18443,5 @@
         "objective.key": "7f488fda-a480-4f40-814d-6a2810780b38"
       }
     }
-  ],
-  "lessons_standards": [
-
   ]
 }

--- a/dashboard/config/scripts_json/csd4-2021.script_json
+++ b/dashboard/config/scripts_json/csd4-2021.script_json
@@ -25,7 +25,7 @@
     },
     "new_name": null,
     "family_name": null,
-    "serialized_at": "2021-03-18 22:00:19 UTC",
+    "serialized_at": "2021-03-15 12:49:31 UTC",
     "seeding_key": {
       "script.name": "csd4-2021"
     }
@@ -5957,10 +5957,10 @@
       "activity_section_position": 1,
       "assessment": true,
       "properties": {
+        "progression": "Reflection",
         "level_keys": [
           "csd-pulse-check-survey-1-levelgroup U4Ch1_2021"
-        ],
-        "progression": "Reflection"
+        ]
       },
       "named_level": null,
       "bonus": null,
@@ -5983,10 +5983,10 @@
       "activity_section_position": 1,
       "assessment": null,
       "properties": {
+        "progression": "Demo Apps",
         "level_keys": [
           "Example App Types_2021"
-        ],
-        "progression": "Demo Apps"
+        ]
       },
       "named_level": null,
       "bonus": null,
@@ -6009,10 +6009,10 @@
       "activity_section_position": 2,
       "assessment": null,
       "properties": {
+        "progression": "Demo Apps",
         "level_keys": [
           "CSDU4 Quiz App Demo_2021"
-        ],
-        "progression": "Demo Apps"
+        ]
       },
       "named_level": null,
       "bonus": null,
@@ -6035,10 +6035,10 @@
       "activity_section_position": 3,
       "assessment": null,
       "properties": {
+        "progression": "Demo Apps",
         "level_keys": [
           "CSDU4 Decision App Demo_2021"
-        ],
-        "progression": "Demo Apps"
+        ]
       },
       "named_level": null,
       "bonus": null,
@@ -6061,10 +6061,10 @@
       "activity_section_position": 4,
       "assessment": null,
       "properties": {
+        "progression": "Demo Apps",
         "level_keys": [
           "CSDU4 List App Demo_2021"
-        ],
-        "progression": "Demo Apps"
+        ]
       },
       "named_level": null,
       "bonus": null,
@@ -6087,10 +6087,10 @@
       "activity_section_position": 5,
       "assessment": null,
       "properties": {
+        "progression": "Demo Apps",
         "level_keys": [
           "CSDU4 Crowdsource App Demo_2021"
-        ],
-        "progression": "Demo Apps"
+        ]
       },
       "named_level": null,
       "bonus": null,
@@ -6113,10 +6113,10 @@
       "activity_section_position": 1,
       "assessment": null,
       "properties": {
+        "progression": "Build a Screen",
         "level_keys": [
           "CSDU4 Design Mode Video_2021"
-        ],
-        "progression": "Build a Screen"
+        ]
       },
       "named_level": null,
       "bonus": null,
@@ -6139,10 +6139,10 @@
       "activity_section_position": 2,
       "assessment": null,
       "properties": {
+        "progression": "Build a Screen",
         "level_keys": [
           "U4 Model Design 1_2021"
-        ],
-        "progression": "Build a Screen"
+        ]
       },
       "named_level": null,
       "bonus": null,
@@ -6165,10 +6165,10 @@
       "activity_section_position": 3,
       "assessment": null,
       "properties": {
+        "progression": "Build a Screen",
         "level_keys": [
           "U4 Model Design 2_2021"
-        ],
-        "progression": "Build a Screen"
+        ]
       },
       "named_level": null,
       "bonus": null,
@@ -6191,10 +6191,10 @@
       "activity_section_position": 4,
       "assessment": null,
       "properties": {
+        "progression": "Build a Screen",
         "level_keys": [
           "U4 Model Design 3_2021"
-        ],
-        "progression": "Build a Screen"
+        ]
       },
       "named_level": null,
       "bonus": null,
@@ -6217,10 +6217,10 @@
       "activity_section_position": 5,
       "assessment": null,
       "properties": {
+        "progression": "Build a Screen",
         "level_keys": [
           "U4 Model Design 4_2021"
-        ],
-        "progression": "Build a Screen"
+        ]
       },
       "named_level": null,
       "bonus": null,
@@ -6243,10 +6243,10 @@
       "activity_section_position": 1,
       "assessment": null,
       "properties": {
+        "progression": "Finish a Screen",
         "level_keys": [
           "U4 Model Design 5_2021"
-        ],
-        "progression": "Finish a Screen"
+        ]
       },
       "named_level": null,
       "bonus": null,
@@ -6269,10 +6269,10 @@
       "activity_section_position": 2,
       "assessment": null,
       "properties": {
+        "progression": "Finish a Screen",
         "level_keys": [
           "U4 Model Design 6_2021"
-        ],
-        "progression": "Finish a Screen"
+        ]
       },
       "named_level": null,
       "bonus": null,
@@ -6295,10 +6295,10 @@
       "activity_section_position": 3,
       "assessment": true,
       "properties": {
+        "progression": "Finish a Screen",
         "level_keys": [
           "U4 Model Design 7_2021"
-        ],
-        "progression": "Finish a Screen"
+        ]
       },
       "named_level": null,
       "bonus": null,
@@ -6321,10 +6321,10 @@
       "activity_section_position": 1,
       "assessment": null,
       "properties": {
+        "progression": "App Project: Screen Design",
         "level_keys": [
           "Design a Screen for your App_2021"
-        ],
-        "progression": "App Project: Screen Design"
+        ]
       },
       "named_level": null,
       "bonus": null,
@@ -6347,10 +6347,10 @@
       "activity_section_position": 2,
       "assessment": true,
       "properties": {
+        "progression": "App Project: Screen Design",
         "level_keys": [
           "CSD U4 - Design Mode Project_2021"
-        ],
-        "progression": "App Project: Screen Design"
+        ]
       },
       "named_level": null,
       "bonus": null,
@@ -6373,10 +6373,10 @@
       "activity_section_position": 1,
       "assessment": null,
       "properties": {
+        "progression": "Adding Screens",
         "level_keys": [
           "U4 Model Program 1_2021"
-        ],
-        "progression": "Adding Screens"
+        ]
       },
       "named_level": null,
       "bonus": null,
@@ -6399,10 +6399,10 @@
       "activity_section_position": 2,
       "assessment": null,
       "properties": {
+        "progression": "Adding Screens",
         "level_keys": [
           "U4 Model Program 1.5_2021"
-        ],
-        "progression": "Adding Screens"
+        ]
       },
       "named_level": null,
       "bonus": null,
@@ -6425,10 +6425,10 @@
       "activity_section_position": 3,
       "assessment": null,
       "properties": {
+        "progression": "Adding Screens",
         "level_keys": [
           "U4 Model Program 2_2021"
-        ],
-        "progression": "Adding Screens"
+        ]
       },
       "named_level": null,
       "bonus": null,
@@ -6451,10 +6451,10 @@
       "activity_section_position": 4,
       "assessment": null,
       "properties": {
+        "progression": "Adding Screens",
         "level_keys": [
           "U4 Model Program 2.5_2021"
-        ],
-        "progression": "Adding Screens"
+        ]
       },
       "named_level": null,
       "bonus": null,
@@ -6477,10 +6477,10 @@
       "activity_section_position": 1,
       "assessment": null,
       "properties": {
+        "progression": "Events and Linking Screens",
         "level_keys": [
           "U4 Model Program 3_2021"
-        ],
-        "progression": "Events and Linking Screens"
+        ]
       },
       "named_level": null,
       "bonus": null,
@@ -6503,10 +6503,10 @@
       "activity_section_position": 2,
       "assessment": null,
       "properties": {
+        "progression": "Events and Linking Screens",
         "level_keys": [
           "U4 Model Program 4_2021"
-        ],
-        "progression": "Events and Linking Screens"
+        ]
       },
       "named_level": null,
       "bonus": null,
@@ -6529,10 +6529,10 @@
       "activity_section_position": 3,
       "assessment": true,
       "properties": {
+        "progression": "Events and Linking Screens",
         "level_keys": [
           "U4 Model Program 5_2021"
-        ],
-        "progression": "Events and Linking Screens"
+        ]
       },
       "named_level": null,
       "bonus": null,
@@ -6555,10 +6555,10 @@
       "activity_section_position": 1,
       "assessment": null,
       "properties": {
+        "progression": "Combining Projects",
         "level_keys": [
           "CSDU4 Project Import_2021"
-        ],
-        "progression": "Combining Projects"
+        ]
       },
       "named_level": null,
       "bonus": null,
@@ -6581,10 +6581,10 @@
       "activity_section_position": 2,
       "assessment": true,
       "properties": {
+        "progression": "Combining Projects",
         "level_keys": [
           "CSDU4 Project Events_2021"
-        ],
-        "progression": "Combining Projects"
+        ]
       },
       "named_level": null,
       "bonus": null,
@@ -6632,10 +6632,10 @@
       "activity_section_position": 1,
       "assessment": true,
       "properties": {
+        "progression": "Reflection",
         "level_keys": [
           "csd-pulse-check-survey-1-levelgroup U4Ch2_2021"
-        ],
-        "progression": "Reflection"
+        ]
       },
       "named_level": null,
       "bonus": null,
@@ -8883,8 +8883,5 @@
         "objective.key": "3f8b9c32-15fb-4b26-9360-9cb6fdfe7ed3"
       }
     }
-  ],
-  "lessons_standards": [
-
   ]
 }

--- a/dashboard/config/scripts_json/csd4-2021.script_json
+++ b/dashboard/config/scripts_json/csd4-2021.script_json
@@ -25,7 +25,7 @@
     },
     "new_name": null,
     "family_name": null,
-    "serialized_at": "2021-03-15 12:49:31 UTC",
+    "serialized_at": "2021-03-18 22:00:19 UTC",
     "seeding_key": {
       "script.name": "csd4-2021"
     }
@@ -5957,10 +5957,10 @@
       "activity_section_position": 1,
       "assessment": true,
       "properties": {
-        "progression": "Reflection",
         "level_keys": [
           "csd-pulse-check-survey-1-levelgroup U4Ch1_2021"
-        ]
+        ],
+        "progression": "Reflection"
       },
       "named_level": null,
       "bonus": null,
@@ -5983,10 +5983,10 @@
       "activity_section_position": 1,
       "assessment": null,
       "properties": {
-        "progression": "Demo Apps",
         "level_keys": [
           "Example App Types_2021"
-        ]
+        ],
+        "progression": "Demo Apps"
       },
       "named_level": null,
       "bonus": null,
@@ -6009,10 +6009,10 @@
       "activity_section_position": 2,
       "assessment": null,
       "properties": {
-        "progression": "Demo Apps",
         "level_keys": [
           "CSDU4 Quiz App Demo_2021"
-        ]
+        ],
+        "progression": "Demo Apps"
       },
       "named_level": null,
       "bonus": null,
@@ -6035,10 +6035,10 @@
       "activity_section_position": 3,
       "assessment": null,
       "properties": {
-        "progression": "Demo Apps",
         "level_keys": [
           "CSDU4 Decision App Demo_2021"
-        ]
+        ],
+        "progression": "Demo Apps"
       },
       "named_level": null,
       "bonus": null,
@@ -6061,10 +6061,10 @@
       "activity_section_position": 4,
       "assessment": null,
       "properties": {
-        "progression": "Demo Apps",
         "level_keys": [
           "CSDU4 List App Demo_2021"
-        ]
+        ],
+        "progression": "Demo Apps"
       },
       "named_level": null,
       "bonus": null,
@@ -6087,10 +6087,10 @@
       "activity_section_position": 5,
       "assessment": null,
       "properties": {
-        "progression": "Demo Apps",
         "level_keys": [
           "CSDU4 Crowdsource App Demo_2021"
-        ]
+        ],
+        "progression": "Demo Apps"
       },
       "named_level": null,
       "bonus": null,
@@ -6113,10 +6113,10 @@
       "activity_section_position": 1,
       "assessment": null,
       "properties": {
-        "progression": "Build a Screen",
         "level_keys": [
           "CSDU4 Design Mode Video_2021"
-        ]
+        ],
+        "progression": "Build a Screen"
       },
       "named_level": null,
       "bonus": null,
@@ -6139,10 +6139,10 @@
       "activity_section_position": 2,
       "assessment": null,
       "properties": {
-        "progression": "Build a Screen",
         "level_keys": [
           "U4 Model Design 1_2021"
-        ]
+        ],
+        "progression": "Build a Screen"
       },
       "named_level": null,
       "bonus": null,
@@ -6165,10 +6165,10 @@
       "activity_section_position": 3,
       "assessment": null,
       "properties": {
-        "progression": "Build a Screen",
         "level_keys": [
           "U4 Model Design 2_2021"
-        ]
+        ],
+        "progression": "Build a Screen"
       },
       "named_level": null,
       "bonus": null,
@@ -6191,10 +6191,10 @@
       "activity_section_position": 4,
       "assessment": null,
       "properties": {
-        "progression": "Build a Screen",
         "level_keys": [
           "U4 Model Design 3_2021"
-        ]
+        ],
+        "progression": "Build a Screen"
       },
       "named_level": null,
       "bonus": null,
@@ -6217,10 +6217,10 @@
       "activity_section_position": 5,
       "assessment": null,
       "properties": {
-        "progression": "Build a Screen",
         "level_keys": [
           "U4 Model Design 4_2021"
-        ]
+        ],
+        "progression": "Build a Screen"
       },
       "named_level": null,
       "bonus": null,
@@ -6243,10 +6243,10 @@
       "activity_section_position": 1,
       "assessment": null,
       "properties": {
-        "progression": "Finish a Screen",
         "level_keys": [
           "U4 Model Design 5_2021"
-        ]
+        ],
+        "progression": "Finish a Screen"
       },
       "named_level": null,
       "bonus": null,
@@ -6269,10 +6269,10 @@
       "activity_section_position": 2,
       "assessment": null,
       "properties": {
-        "progression": "Finish a Screen",
         "level_keys": [
           "U4 Model Design 6_2021"
-        ]
+        ],
+        "progression": "Finish a Screen"
       },
       "named_level": null,
       "bonus": null,
@@ -6295,10 +6295,10 @@
       "activity_section_position": 3,
       "assessment": true,
       "properties": {
-        "progression": "Finish a Screen",
         "level_keys": [
           "U4 Model Design 7_2021"
-        ]
+        ],
+        "progression": "Finish a Screen"
       },
       "named_level": null,
       "bonus": null,
@@ -6321,10 +6321,10 @@
       "activity_section_position": 1,
       "assessment": null,
       "properties": {
-        "progression": "App Project: Screen Design",
         "level_keys": [
           "Design a Screen for your App_2021"
-        ]
+        ],
+        "progression": "App Project: Screen Design"
       },
       "named_level": null,
       "bonus": null,
@@ -6347,10 +6347,10 @@
       "activity_section_position": 2,
       "assessment": true,
       "properties": {
-        "progression": "App Project: Screen Design",
         "level_keys": [
           "CSD U4 - Design Mode Project_2021"
-        ]
+        ],
+        "progression": "App Project: Screen Design"
       },
       "named_level": null,
       "bonus": null,
@@ -6373,10 +6373,10 @@
       "activity_section_position": 1,
       "assessment": null,
       "properties": {
-        "progression": "Adding Screens",
         "level_keys": [
           "U4 Model Program 1_2021"
-        ]
+        ],
+        "progression": "Adding Screens"
       },
       "named_level": null,
       "bonus": null,
@@ -6399,10 +6399,10 @@
       "activity_section_position": 2,
       "assessment": null,
       "properties": {
-        "progression": "Adding Screens",
         "level_keys": [
           "U4 Model Program 1.5_2021"
-        ]
+        ],
+        "progression": "Adding Screens"
       },
       "named_level": null,
       "bonus": null,
@@ -6425,10 +6425,10 @@
       "activity_section_position": 3,
       "assessment": null,
       "properties": {
-        "progression": "Adding Screens",
         "level_keys": [
           "U4 Model Program 2_2021"
-        ]
+        ],
+        "progression": "Adding Screens"
       },
       "named_level": null,
       "bonus": null,
@@ -6451,10 +6451,10 @@
       "activity_section_position": 4,
       "assessment": null,
       "properties": {
-        "progression": "Adding Screens",
         "level_keys": [
           "U4 Model Program 2.5_2021"
-        ]
+        ],
+        "progression": "Adding Screens"
       },
       "named_level": null,
       "bonus": null,
@@ -6477,10 +6477,10 @@
       "activity_section_position": 1,
       "assessment": null,
       "properties": {
-        "progression": "Events and Linking Screens",
         "level_keys": [
           "U4 Model Program 3_2021"
-        ]
+        ],
+        "progression": "Events and Linking Screens"
       },
       "named_level": null,
       "bonus": null,
@@ -6503,10 +6503,10 @@
       "activity_section_position": 2,
       "assessment": null,
       "properties": {
-        "progression": "Events and Linking Screens",
         "level_keys": [
           "U4 Model Program 4_2021"
-        ]
+        ],
+        "progression": "Events and Linking Screens"
       },
       "named_level": null,
       "bonus": null,
@@ -6529,10 +6529,10 @@
       "activity_section_position": 3,
       "assessment": true,
       "properties": {
-        "progression": "Events and Linking Screens",
         "level_keys": [
           "U4 Model Program 5_2021"
-        ]
+        ],
+        "progression": "Events and Linking Screens"
       },
       "named_level": null,
       "bonus": null,
@@ -6555,10 +6555,10 @@
       "activity_section_position": 1,
       "assessment": null,
       "properties": {
-        "progression": "Combining Projects",
         "level_keys": [
           "CSDU4 Project Import_2021"
-        ]
+        ],
+        "progression": "Combining Projects"
       },
       "named_level": null,
       "bonus": null,
@@ -6581,10 +6581,10 @@
       "activity_section_position": 2,
       "assessment": true,
       "properties": {
-        "progression": "Combining Projects",
         "level_keys": [
           "CSDU4 Project Events_2021"
-        ]
+        ],
+        "progression": "Combining Projects"
       },
       "named_level": null,
       "bonus": null,
@@ -6632,10 +6632,10 @@
       "activity_section_position": 1,
       "assessment": true,
       "properties": {
-        "progression": "Reflection",
         "level_keys": [
           "csd-pulse-check-survey-1-levelgroup U4Ch2_2021"
-        ]
+        ],
+        "progression": "Reflection"
       },
       "named_level": null,
       "bonus": null,
@@ -8493,18 +8493,21 @@
     {
       "seeding_key": {
         "lesson.key": "Events In AppLab",
+        "programming_environment.name": "applab",
         "programming_expression.key": "console.log"
       }
     },
     {
       "seeding_key": {
         "lesson.key": "Events In AppLab",
+        "programming_environment.name": "applab",
         "programming_expression.key": "onEvent"
       }
     },
     {
       "seeding_key": {
         "lesson.key": "Events In AppLab",
+        "programming_environment.name": "applab",
         "programming_expression.key": "setScreen"
       }
     }
@@ -8880,5 +8883,8 @@
         "objective.key": "3f8b9c32-15fb-4b26-9360-9cb6fdfe7ed3"
       }
     }
+  ],
+  "lessons_standards": [
+
   ]
 }

--- a/dashboard/config/scripts_json/csd5-2021.script_json
+++ b/dashboard/config/scripts_json/csd5-2021.script_json
@@ -25,7 +25,7 @@
     },
     "new_name": null,
     "family_name": null,
-    "serialized_at": "2021-03-15 12:50:13 UTC",
+    "serialized_at": "2021-03-18 22:01:56 UTC",
     "seeding_key": {
       "script.name": "csd5-2021"
     }
@@ -5114,10 +5114,10 @@
       "activity_section_position": 1,
       "assessment": null,
       "properties": {
-        "progression": "Representing Images",
         "level_keys": [
           "CSD U5 black white images pixelation_2021"
-        ]
+        ],
+        "progression": "Representing Images"
       },
       "named_level": null,
       "bonus": null,
@@ -5140,10 +5140,10 @@
       "activity_section_position": 2,
       "assessment": null,
       "properties": {
-        "progression": "Representing Images",
         "level_keys": [
           "CSD U5 black white images pixelation 2_2021"
-        ]
+        ],
+        "progression": "Representing Images"
       },
       "named_level": null,
       "bonus": null,
@@ -5166,10 +5166,10 @@
       "activity_section_position": 3,
       "assessment": null,
       "properties": {
-        "progression": "Representing Images",
         "level_keys": [
           "CSD U5 black white images pixelation 3_2021"
-        ]
+        ],
+        "progression": "Representing Images"
       },
       "named_level": null,
       "bonus": null,
@@ -5192,10 +5192,10 @@
       "activity_section_position": 4,
       "assessment": null,
       "properties": {
-        "progression": "Representing Images",
         "level_keys": [
           "CSD U5 black white images pixelation 4_2021"
-        ]
+        ],
+        "progression": "Representing Images"
       },
       "named_level": null,
       "bonus": null,
@@ -5218,10 +5218,10 @@
       "activity_section_position": 5,
       "assessment": null,
       "properties": {
-        "progression": "Representing Images",
         "level_keys": [
           "CSD U5 black white images pixelation 5_2021"
-        ]
+        ],
+        "progression": "Representing Images"
       },
       "named_level": null,
       "bonus": null,
@@ -5244,10 +5244,10 @@
       "activity_section_position": 1,
       "assessment": null,
       "properties": {
-        "progression": "Binary Numbers",
         "level_keys": [
           "CSD U5 binary 1_2021"
-        ]
+        ],
+        "progression": "Binary Numbers"
       },
       "named_level": null,
       "bonus": null,
@@ -5270,10 +5270,10 @@
       "activity_section_position": 2,
       "assessment": null,
       "properties": {
-        "progression": "Binary Numbers",
         "level_keys": [
           "CSD U5 binary 2_2021"
-        ]
+        ],
+        "progression": "Binary Numbers"
       },
       "named_level": null,
       "bonus": null,
@@ -5296,10 +5296,10 @@
       "activity_section_position": 3,
       "assessment": null,
       "properties": {
-        "progression": "Binary Numbers",
         "level_keys": [
           "CSD U5 binary 4-new_2021"
-        ]
+        ],
+        "progression": "Binary Numbers"
       },
       "named_level": null,
       "bonus": null,
@@ -5322,10 +5322,10 @@
       "activity_section_position": 4,
       "assessment": null,
       "properties": {
-        "progression": "Binary Numbers",
         "level_keys": [
           "CSD U5 binary 5-new_2021"
-        ]
+        ],
+        "progression": "Binary Numbers"
       },
       "named_level": null,
       "bonus": null,
@@ -5348,10 +5348,10 @@
       "activity_section_position": 5,
       "assessment": null,
       "properties": {
-        "progression": "Binary Numbers",
         "level_keys": [
           "CSD U5 binary 6-new_2021"
-        ]
+        ],
+        "progression": "Binary Numbers"
       },
       "named_level": null,
       "bonus": null,
@@ -5374,10 +5374,10 @@
       "activity_section_position": 6,
       "assessment": null,
       "properties": {
-        "progression": "Binary Numbers",
         "level_keys": [
           "CSD U5 binary 7-new_2021"
-        ]
+        ],
+        "progression": "Binary Numbers"
       },
       "named_level": null,
       "bonus": null,
@@ -5400,10 +5400,10 @@
       "activity_section_position": 1,
       "assessment": null,
       "properties": {
-        "progression": "Binary and Data",
         "level_keys": [
           "CSD U5 binary video_2021"
-        ]
+        ],
+        "progression": "Binary and Data"
       },
       "named_level": null,
       "bonus": null,
@@ -5426,10 +5426,10 @@
       "activity_section_position": 1,
       "assessment": null,
       "properties": {
-        "progression": "Combining Representations",
         "level_keys": [
           "CSD U3 combining rep_2021"
-        ]
+        ],
+        "progression": "Combining Representations"
       },
       "named_level": null,
       "bonus": null,
@@ -5452,10 +5452,10 @@
       "activity_section_position": 2,
       "assessment": null,
       "properties": {
-        "progression": "Combining Representations",
         "level_keys": [
           "CSD U5 student record_2021"
-        ]
+        ],
+        "progression": "Combining Representations"
       },
       "named_level": null,
       "bonus": null,
@@ -5478,10 +5478,10 @@
       "activity_section_position": 1,
       "assessment": null,
       "properties": {
-        "progression": "Keeping Data Secret",
         "level_keys": [
           "CSD U5 Encryption 2_2021"
-        ]
+        ],
+        "progression": "Keeping Data Secret"
       },
       "named_level": null,
       "bonus": null,
@@ -5504,10 +5504,10 @@
       "activity_section_position": 2,
       "assessment": null,
       "properties": {
-        "progression": "Keeping Data Secret",
         "level_keys": [
           "CSD U5 Encryption 1_2021"
-        ]
+        ],
+        "progression": "Keeping Data Secret"
       },
       "named_level": null,
       "bonus": null,
@@ -5530,10 +5530,10 @@
       "activity_section_position": 1,
       "assessment": true,
       "properties": {
-        "progression": "Reflection",
         "level_keys": [
           "csd-pulse-check-survey-1-levelgroup U5Ch1_2021"
-        ]
+        ],
+        "progression": "Reflection"
       },
       "named_level": null,
       "bonus": null,
@@ -5556,10 +5556,10 @@
       "activity_section_position": 1,
       "assessment": null,
       "properties": {
-        "progression": "Data Visualization",
         "level_keys": [
           "CSD U5 data visualization_2021"
-        ]
+        ],
+        "progression": "Data Visualization"
       },
       "named_level": null,
       "bonus": null,
@@ -5582,10 +5582,10 @@
       "activity_section_position": 2,
       "assessment": null,
       "properties": {
-        "progression": "Data Visualization",
         "level_keys": [
           "CSD U5 Pizza_2021"
-        ]
+        ],
+        "progression": "Data Visualization"
       },
       "named_level": null,
       "bonus": null,
@@ -5608,10 +5608,10 @@
       "activity_section_position": 3,
       "assessment": null,
       "properties": {
-        "progression": "Data Visualization",
         "level_keys": [
           "CSD U5 Pizza 2_2021"
-        ]
+        ],
+        "progression": "Data Visualization"
       },
       "named_level": null,
       "bonus": null,
@@ -5634,10 +5634,10 @@
       "activity_section_position": 1,
       "assessment": null,
       "properties": {
-        "progression": "Cake Survey",
         "level_keys": [
           "CSD U5 crosstab warmup_2021"
-        ]
+        ],
+        "progression": "Cake Survey"
       },
       "named_level": null,
       "bonus": null,
@@ -5660,10 +5660,10 @@
       "activity_section_position": 1,
       "assessment": null,
       "properties": {
-        "progression": "Problem Solving",
         "level_keys": [
           "CSD U5 Netflix Data Video_2021"
-        ]
+        ],
+        "progression": "Problem Solving"
       },
       "named_level": null,
       "bonus": null,
@@ -5686,10 +5686,10 @@
       "activity_section_position": 2,
       "assessment": null,
       "properties": {
-        "progression": "Problem Solving",
         "level_keys": [
           "CSD U5 Waze Data Video_2021"
-        ]
+        ],
+        "progression": "Problem Solving"
       },
       "named_level": null,
       "bonus": null,
@@ -5712,10 +5712,10 @@
       "activity_section_position": 3,
       "assessment": null,
       "properties": {
-        "progression": "Problem Solving",
         "level_keys": [
           "CSD U5 Amazon Data Video_2021"
-        ]
+        ],
+        "progression": "Problem Solving"
       },
       "named_level": null,
       "bonus": null,
@@ -5738,10 +5738,10 @@
       "activity_section_position": 1,
       "assessment": null,
       "properties": {
-        "progression": "Sample App",
         "level_keys": [
           "csd u5 recommender sample_2021"
-        ]
+        ],
+        "progression": "Sample App"
       },
       "named_level": null,
       "bonus": null,
@@ -5764,10 +5764,10 @@
       "activity_section_position": 1,
       "assessment": true,
       "properties": {
-        "progression": "Reflection",
         "level_keys": [
           "csd-pulse-check-survey-1-levelgroup U5Ch2_2021"
-        ]
+        ],
+        "progression": "Reflection"
       },
       "named_level": null,
       "bonus": null,
@@ -7856,5 +7856,8 @@
         "objective.key": "b0342e84-056b-46d6-ac84-1d976155c38d"
       }
     }
+  ],
+  "lessons_standards": [
+
   ]
 }

--- a/dashboard/config/scripts_json/csd5-2021.script_json
+++ b/dashboard/config/scripts_json/csd5-2021.script_json
@@ -25,7 +25,7 @@
     },
     "new_name": null,
     "family_name": null,
-    "serialized_at": "2021-03-18 22:01:56 UTC",
+    "serialized_at": "2021-03-15 12:50:13 UTC",
     "seeding_key": {
       "script.name": "csd5-2021"
     }
@@ -5114,10 +5114,10 @@
       "activity_section_position": 1,
       "assessment": null,
       "properties": {
+        "progression": "Representing Images",
         "level_keys": [
           "CSD U5 black white images pixelation_2021"
-        ],
-        "progression": "Representing Images"
+        ]
       },
       "named_level": null,
       "bonus": null,
@@ -5140,10 +5140,10 @@
       "activity_section_position": 2,
       "assessment": null,
       "properties": {
+        "progression": "Representing Images",
         "level_keys": [
           "CSD U5 black white images pixelation 2_2021"
-        ],
-        "progression": "Representing Images"
+        ]
       },
       "named_level": null,
       "bonus": null,
@@ -5166,10 +5166,10 @@
       "activity_section_position": 3,
       "assessment": null,
       "properties": {
+        "progression": "Representing Images",
         "level_keys": [
           "CSD U5 black white images pixelation 3_2021"
-        ],
-        "progression": "Representing Images"
+        ]
       },
       "named_level": null,
       "bonus": null,
@@ -5192,10 +5192,10 @@
       "activity_section_position": 4,
       "assessment": null,
       "properties": {
+        "progression": "Representing Images",
         "level_keys": [
           "CSD U5 black white images pixelation 4_2021"
-        ],
-        "progression": "Representing Images"
+        ]
       },
       "named_level": null,
       "bonus": null,
@@ -5218,10 +5218,10 @@
       "activity_section_position": 5,
       "assessment": null,
       "properties": {
+        "progression": "Representing Images",
         "level_keys": [
           "CSD U5 black white images pixelation 5_2021"
-        ],
-        "progression": "Representing Images"
+        ]
       },
       "named_level": null,
       "bonus": null,
@@ -5244,10 +5244,10 @@
       "activity_section_position": 1,
       "assessment": null,
       "properties": {
+        "progression": "Binary Numbers",
         "level_keys": [
           "CSD U5 binary 1_2021"
-        ],
-        "progression": "Binary Numbers"
+        ]
       },
       "named_level": null,
       "bonus": null,
@@ -5270,10 +5270,10 @@
       "activity_section_position": 2,
       "assessment": null,
       "properties": {
+        "progression": "Binary Numbers",
         "level_keys": [
           "CSD U5 binary 2_2021"
-        ],
-        "progression": "Binary Numbers"
+        ]
       },
       "named_level": null,
       "bonus": null,
@@ -5296,10 +5296,10 @@
       "activity_section_position": 3,
       "assessment": null,
       "properties": {
+        "progression": "Binary Numbers",
         "level_keys": [
           "CSD U5 binary 4-new_2021"
-        ],
-        "progression": "Binary Numbers"
+        ]
       },
       "named_level": null,
       "bonus": null,
@@ -5322,10 +5322,10 @@
       "activity_section_position": 4,
       "assessment": null,
       "properties": {
+        "progression": "Binary Numbers",
         "level_keys": [
           "CSD U5 binary 5-new_2021"
-        ],
-        "progression": "Binary Numbers"
+        ]
       },
       "named_level": null,
       "bonus": null,
@@ -5348,10 +5348,10 @@
       "activity_section_position": 5,
       "assessment": null,
       "properties": {
+        "progression": "Binary Numbers",
         "level_keys": [
           "CSD U5 binary 6-new_2021"
-        ],
-        "progression": "Binary Numbers"
+        ]
       },
       "named_level": null,
       "bonus": null,
@@ -5374,10 +5374,10 @@
       "activity_section_position": 6,
       "assessment": null,
       "properties": {
+        "progression": "Binary Numbers",
         "level_keys": [
           "CSD U5 binary 7-new_2021"
-        ],
-        "progression": "Binary Numbers"
+        ]
       },
       "named_level": null,
       "bonus": null,
@@ -5400,10 +5400,10 @@
       "activity_section_position": 1,
       "assessment": null,
       "properties": {
+        "progression": "Binary and Data",
         "level_keys": [
           "CSD U5 binary video_2021"
-        ],
-        "progression": "Binary and Data"
+        ]
       },
       "named_level": null,
       "bonus": null,
@@ -5426,10 +5426,10 @@
       "activity_section_position": 1,
       "assessment": null,
       "properties": {
+        "progression": "Combining Representations",
         "level_keys": [
           "CSD U3 combining rep_2021"
-        ],
-        "progression": "Combining Representations"
+        ]
       },
       "named_level": null,
       "bonus": null,
@@ -5452,10 +5452,10 @@
       "activity_section_position": 2,
       "assessment": null,
       "properties": {
+        "progression": "Combining Representations",
         "level_keys": [
           "CSD U5 student record_2021"
-        ],
-        "progression": "Combining Representations"
+        ]
       },
       "named_level": null,
       "bonus": null,
@@ -5478,10 +5478,10 @@
       "activity_section_position": 1,
       "assessment": null,
       "properties": {
+        "progression": "Keeping Data Secret",
         "level_keys": [
           "CSD U5 Encryption 2_2021"
-        ],
-        "progression": "Keeping Data Secret"
+        ]
       },
       "named_level": null,
       "bonus": null,
@@ -5504,10 +5504,10 @@
       "activity_section_position": 2,
       "assessment": null,
       "properties": {
+        "progression": "Keeping Data Secret",
         "level_keys": [
           "CSD U5 Encryption 1_2021"
-        ],
-        "progression": "Keeping Data Secret"
+        ]
       },
       "named_level": null,
       "bonus": null,
@@ -5530,10 +5530,10 @@
       "activity_section_position": 1,
       "assessment": true,
       "properties": {
+        "progression": "Reflection",
         "level_keys": [
           "csd-pulse-check-survey-1-levelgroup U5Ch1_2021"
-        ],
-        "progression": "Reflection"
+        ]
       },
       "named_level": null,
       "bonus": null,
@@ -5556,10 +5556,10 @@
       "activity_section_position": 1,
       "assessment": null,
       "properties": {
+        "progression": "Data Visualization",
         "level_keys": [
           "CSD U5 data visualization_2021"
-        ],
-        "progression": "Data Visualization"
+        ]
       },
       "named_level": null,
       "bonus": null,
@@ -5582,10 +5582,10 @@
       "activity_section_position": 2,
       "assessment": null,
       "properties": {
+        "progression": "Data Visualization",
         "level_keys": [
           "CSD U5 Pizza_2021"
-        ],
-        "progression": "Data Visualization"
+        ]
       },
       "named_level": null,
       "bonus": null,
@@ -5608,10 +5608,10 @@
       "activity_section_position": 3,
       "assessment": null,
       "properties": {
+        "progression": "Data Visualization",
         "level_keys": [
           "CSD U5 Pizza 2_2021"
-        ],
-        "progression": "Data Visualization"
+        ]
       },
       "named_level": null,
       "bonus": null,
@@ -5634,10 +5634,10 @@
       "activity_section_position": 1,
       "assessment": null,
       "properties": {
+        "progression": "Cake Survey",
         "level_keys": [
           "CSD U5 crosstab warmup_2021"
-        ],
-        "progression": "Cake Survey"
+        ]
       },
       "named_level": null,
       "bonus": null,
@@ -5660,10 +5660,10 @@
       "activity_section_position": 1,
       "assessment": null,
       "properties": {
+        "progression": "Problem Solving",
         "level_keys": [
           "CSD U5 Netflix Data Video_2021"
-        ],
-        "progression": "Problem Solving"
+        ]
       },
       "named_level": null,
       "bonus": null,
@@ -5686,10 +5686,10 @@
       "activity_section_position": 2,
       "assessment": null,
       "properties": {
+        "progression": "Problem Solving",
         "level_keys": [
           "CSD U5 Waze Data Video_2021"
-        ],
-        "progression": "Problem Solving"
+        ]
       },
       "named_level": null,
       "bonus": null,
@@ -5712,10 +5712,10 @@
       "activity_section_position": 3,
       "assessment": null,
       "properties": {
+        "progression": "Problem Solving",
         "level_keys": [
           "CSD U5 Amazon Data Video_2021"
-        ],
-        "progression": "Problem Solving"
+        ]
       },
       "named_level": null,
       "bonus": null,
@@ -5738,10 +5738,10 @@
       "activity_section_position": 1,
       "assessment": null,
       "properties": {
+        "progression": "Sample App",
         "level_keys": [
           "csd u5 recommender sample_2021"
-        ],
-        "progression": "Sample App"
+        ]
       },
       "named_level": null,
       "bonus": null,
@@ -5764,10 +5764,10 @@
       "activity_section_position": 1,
       "assessment": true,
       "properties": {
+        "progression": "Reflection",
         "level_keys": [
           "csd-pulse-check-survey-1-levelgroup U5Ch2_2021"
-        ],
-        "progression": "Reflection"
+        ]
       },
       "named_level": null,
       "bonus": null,
@@ -7856,8 +7856,5 @@
         "objective.key": "b0342e84-056b-46d6-ac84-1d976155c38d"
       }
     }
-  ],
-  "lessons_standards": [
-
   ]
 }

--- a/dashboard/config/scripts_json/csd6-2021.script_json
+++ b/dashboard/config/scripts_json/csd6-2021.script_json
@@ -10460,7 +10460,7 @@
       }
     }
   ],
-  g"lessons_programming_expressions": [
+  "lessons_programming_expressions": [
     {
       "seeding_key": {
         "lesson.key": "Designing Screens with Code",

--- a/dashboard/config/scripts_json/csd6-2021.script_json
+++ b/dashboard/config/scripts_json/csd6-2021.script_json
@@ -31,7 +31,7 @@
     },
     "new_name": null,
     "family_name": "csd6",
-    "serialized_at": "2021-03-18 22:02:51 UTC",
+    "serialized_at": "2021-03-15 12:51:02 UTC",
     "seeding_key": {
       "script.name": "csd6-2021"
     }
@@ -3459,10 +3459,10 @@
       "activity_section_position": 1,
       "assessment": null,
       "properties": {
+        "progression": "Innovation Research",
         "level_keys": [
           "CSDU6 Innovation_2021"
-        ],
-        "progression": "Innovation Research"
+        ]
       },
       "named_level": null,
       "bonus": null,
@@ -3485,10 +3485,10 @@
       "activity_section_position": 1,
       "assessment": null,
       "properties": {
+        "progression": "Setting Properties",
         "level_keys": [
           "CSD U6 setProperty predict app_2021"
-        ],
-        "progression": "Setting Properties"
+        ]
       },
       "named_level": null,
       "bonus": null,
@@ -3511,10 +3511,10 @@
       "activity_section_position": 2,
       "assessment": null,
       "properties": {
+        "progression": "Setting Properties",
         "level_keys": [
           "CSD U6 setProperty Text_2021"
-        ],
-        "progression": "Setting Properties"
+        ]
       },
       "named_level": null,
       "bonus": null,
@@ -3537,10 +3537,10 @@
       "activity_section_position": 3,
       "assessment": true,
       "properties": {
+        "progression": "Setting Properties",
         "level_keys": [
           "CSD U6 setProperty xy_2021"
-        ],
-        "progression": "Setting Properties"
+        ]
       },
       "named_level": null,
       "bonus": null,
@@ -3563,10 +3563,10 @@
       "activity_section_position": 1,
       "assessment": null,
       "properties": {
+        "progression": "Events and Properties",
         "level_keys": [
           "CSD U6 setProperty xy click_2021"
-        ],
-        "progression": "Events and Properties"
+        ]
       },
       "named_level": null,
       "bonus": null,
@@ -3589,10 +3589,10 @@
       "activity_section_position": 2,
       "assessment": null,
       "properties": {
+        "progression": "Events and Properties",
         "level_keys": [
           "CSD U6 setProperty xy random_2021"
-        ],
-        "progression": "Events and Properties"
+        ]
       },
       "named_level": null,
       "bonus": null,
@@ -3615,10 +3615,10 @@
       "activity_section_position": 3,
       "assessment": null,
       "properties": {
+        "progression": "Events and Properties",
         "level_keys": [
           "CSD U6 setProperty hidden_2021"
-        ],
-        "progression": "Events and Properties"
+        ]
       },
       "named_level": null,
       "bonus": null,
@@ -3641,10 +3641,10 @@
       "activity_section_position": 4,
       "assessment": true,
       "properties": {
+        "progression": "Events and Properties",
         "level_keys": [
           "CSD U6 setProperty hidden 2_2021"
-        ],
-        "progression": "Events and Properties"
+        ]
       },
       "named_level": null,
       "bonus": null,
@@ -3667,10 +3667,10 @@
       "activity_section_position": 1,
       "assessment": null,
       "properties": {
+        "progression": "Emotion Machine Example",
         "level_keys": [
           "CSD U6 emotion machine example_2021"
-        ],
-        "progression": "Emotion Machine Example"
+        ]
       },
       "named_level": null,
       "bonus": null,
@@ -3693,10 +3693,10 @@
       "activity_section_position": 1,
       "assessment": null,
       "properties": {
+        "progression": "Building an App",
         "level_keys": [
           "CSD U6 emotion machine 1_2021"
-        ],
-        "progression": "Building an App"
+        ]
       },
       "named_level": null,
       "bonus": null,
@@ -3719,10 +3719,10 @@
       "activity_section_position": 2,
       "assessment": null,
       "properties": {
+        "progression": "Building an App",
         "level_keys": [
           "CSD U6 emotion machine 2_2021"
-        ],
-        "progression": "Building an App"
+        ]
       },
       "named_level": null,
       "bonus": null,
@@ -3745,10 +3745,10 @@
       "activity_section_position": 3,
       "assessment": null,
       "properties": {
+        "progression": "Building an App",
         "level_keys": [
           "CSD U6 emotion machine 3_2021"
-        ],
-        "progression": "Building an App"
+        ]
       },
       "named_level": null,
       "bonus": null,
@@ -3771,10 +3771,10 @@
       "activity_section_position": 4,
       "assessment": true,
       "properties": {
+        "progression": "Building an App",
         "level_keys": [
           "CSD U6 emotion machine 4_2021"
-        ],
-        "progression": "Building an App"
+        ]
       },
       "named_level": null,
       "bonus": null,
@@ -3797,10 +3797,10 @@
       "activity_section_position": 1,
       "assessment": null,
       "properties": {
+        "progression": "Hardware and Software",
         "level_keys": [
           "CSD U6 hardware software video_2021"
-        ],
-        "progression": "Hardware and Software"
+        ]
       },
       "named_level": null,
       "bonus": null,
@@ -3823,10 +3823,10 @@
       "activity_section_position": 1,
       "assessment": null,
       "properties": {
+        "progression": "Using the LED",
         "level_keys": [
           "CSDU6 Circuit Playground Test_2021"
-        ],
-        "progression": "Using the LED"
+        ]
       },
       "named_level": null,
       "bonus": null,
@@ -3849,10 +3849,10 @@
       "activity_section_position": 2,
       "assessment": null,
       "properties": {
+        "progression": "Using the LED",
         "level_keys": [
           "CSD U6 test LED_2021"
-        ],
-        "progression": "Using the LED"
+        ]
       },
       "named_level": null,
       "bonus": null,
@@ -3875,10 +3875,10 @@
       "activity_section_position": 3,
       "assessment": null,
       "properties": {
+        "progression": "Using the LED",
         "level_keys": [
           "CSD U6 predict LED button_2021"
-        ],
-        "progression": "Using the LED"
+        ]
       },
       "named_level": null,
       "bonus": null,
@@ -3901,10 +3901,10 @@
       "activity_section_position": 4,
       "assessment": null,
       "properties": {
+        "progression": "Using the LED",
         "level_keys": [
           "CSD U6 add LED button_2021"
-        ],
-        "progression": "Using the LED"
+        ]
       },
       "named_level": null,
       "bonus": null,
@@ -3927,10 +3927,10 @@
       "activity_section_position": 5,
       "assessment": null,
       "properties": {
+        "progression": "Using the LED",
         "level_keys": [
           "CSD U6 LED toggle_2021"
-        ],
-        "progression": "Using the LED"
+        ]
       },
       "named_level": null,
       "bonus": null,
@@ -3953,10 +3953,10 @@
       "activity_section_position": 6,
       "assessment": true,
       "properties": {
+        "progression": "Using the LED",
         "level_keys": [
           "CSD U6 LED all_2021"
-        ],
-        "progression": "Using the LED"
+        ]
       },
       "named_level": null,
       "bonus": null,
@@ -3979,10 +3979,10 @@
       "activity_section_position": 1,
       "assessment": null,
       "properties": {
+        "progression": "LED Apps",
         "level_keys": [
           "CSD U6 LED create intro_2021"
-        ],
-        "progression": "LED Apps"
+        ]
       },
       "named_level": null,
       "bonus": null,
@@ -4005,10 +4005,10 @@
       "activity_section_position": 2,
       "assessment": null,
       "properties": {
+        "progression": "LED Apps",
         "level_keys": [
           "CSD U6 light show_2021"
-        ],
-        "progression": "LED Apps"
+        ]
       },
       "named_level": null,
       "bonus": null,
@@ -4031,10 +4031,10 @@
       "activity_section_position": 3,
       "assessment": null,
       "properties": {
+        "progression": "LED Apps",
         "level_keys": [
           "CSD U6 Catch the Mouse_2021"
-        ],
-        "progression": "LED Apps"
+        ]
       },
       "named_level": null,
       "bonus": null,
@@ -4057,10 +4057,10 @@
       "activity_section_position": 4,
       "assessment": null,
       "properties": {
+        "progression": "LED Apps",
         "level_keys": [
           "CSD U6 create LED app_2021"
-        ],
-        "progression": "LED Apps"
+        ]
       },
       "named_level": null,
       "bonus": null,
@@ -4083,10 +4083,10 @@
       "activity_section_position": 5,
       "assessment": true,
       "properties": {
+        "progression": "LED Apps",
         "level_keys": [
           "CSD U6 create LED app 2_2021"
-        ],
-        "progression": "LED Apps"
+        ]
       },
       "named_level": null,
       "bonus": null,
@@ -4109,10 +4109,10 @@
       "activity_section_position": 1,
       "assessment": null,
       "properties": {
+        "progression": "Input Examples",
         "level_keys": [
           "CSDU6 GameLab Input 1_2021"
-        ],
-        "progression": "Input Examples"
+        ]
       },
       "named_level": null,
       "bonus": null,
@@ -4135,10 +4135,10 @@
       "activity_section_position": 2,
       "assessment": null,
       "properties": {
+        "progression": "Input Examples",
         "level_keys": [
           "CSDU6 AppLab Input 1_2021"
-        ],
-        "progression": "Input Examples"
+        ]
       },
       "named_level": null,
       "bonus": null,
@@ -4161,10 +4161,10 @@
       "activity_section_position": 1,
       "assessment": null,
       "properties": {
+        "progression": "Board Events",
         "level_keys": [
           "CSDU6 - button LED prediction_2021"
-        ],
-        "progression": "Board Events"
+        ]
       },
       "named_level": null,
       "bonus": null,
@@ -4187,10 +4187,10 @@
       "activity_section_position": 2,
       "assessment": null,
       "properties": {
+        "progression": "Board Events",
         "level_keys": [
           "CSDU6 - LED buttonL_2021"
-        ],
-        "progression": "Board Events"
+        ]
       },
       "named_level": null,
       "bonus": null,
@@ -4213,10 +4213,10 @@
       "activity_section_position": 3,
       "assessment": true,
       "properties": {
+        "progression": "Board Events",
         "level_keys": [
           "CSDU6 - LED toggle buttonL up_2021"
-        ],
-        "progression": "Board Events"
+        ]
       },
       "named_level": null,
       "bonus": null,
@@ -4239,10 +4239,10 @@
       "activity_section_position": 1,
       "assessment": null,
       "properties": {
+        "progression": "Using the Switch",
         "level_keys": [
           "CSDU6 - lightswitch toggleswitch_2021"
-        ],
-        "progression": "Using the Switch"
+        ]
       },
       "named_level": null,
       "bonus": null,
@@ -4265,10 +4265,10 @@
       "activity_section_position": 2,
       "assessment": null,
       "properties": {
+        "progression": "Using the Switch",
         "level_keys": [
           "CSDU6 - toggle state LED prediction_2021"
-        ],
-        "progression": "Using the Switch"
+        ]
       },
       "named_level": null,
       "bonus": null,
@@ -4291,10 +4291,10 @@
       "activity_section_position": 3,
       "assessment": null,
       "properties": {
+        "progression": "Using the Switch",
         "level_keys": [
           "CSDU6 - toggleswitch state setProp_2021"
-        ],
-        "progression": "Using the Switch"
+        ]
       },
       "named_level": null,
       "bonus": null,
@@ -4317,10 +4317,10 @@
       "activity_section_position": 1,
       "assessment": null,
       "properties": {
+        "progression": "The Buzzer",
         "level_keys": [
           "CSDU6 - buzzer intro_2021"
-        ],
-        "progression": "The Buzzer"
+        ]
       },
       "named_level": null,
       "bonus": null,
@@ -4343,10 +4343,10 @@
       "activity_section_position": 2,
       "assessment": null,
       "properties": {
+        "progression": "The Buzzer",
         "level_keys": [
           "CSDU6 - buzzer duration_2021"
-        ],
-        "progression": "The Buzzer"
+        ]
       },
       "named_level": null,
       "bonus": null,
@@ -4369,10 +4369,10 @@
       "activity_section_position": 3,
       "assessment": null,
       "properties": {
+        "progression": "The Buzzer",
         "level_keys": [
           "CSDU6 - buzzer duration buttons_2021"
-        ],
-        "progression": "The Buzzer"
+        ]
       },
       "named_level": null,
       "bonus": null,
@@ -4395,10 +4395,10 @@
       "activity_section_position": 1,
       "assessment": null,
       "properties": {
+        "progression": "Extra Challenge: Sound Board",
         "level_keys": [
           "CSDU6 - board event challenge_2021"
-        ],
-        "progression": "Extra Challenge: Sound Board"
+        ]
       },
       "named_level": null,
       "bonus": true,
@@ -4421,10 +4421,10 @@
       "activity_section_position": 1,
       "assessment": null,
       "properties": {
+        "progression": "Getting Properties",
         "level_keys": [
           "CSD U6 getProperty Demo_2021"
-        ],
-        "progression": "Getting Properties"
+        ]
       },
       "named_level": null,
       "bonus": null,
@@ -4447,10 +4447,10 @@
       "activity_section_position": 2,
       "assessment": null,
       "properties": {
+        "progression": "Getting Properties",
         "level_keys": [
           "CSD U6 getProperty input_2021"
-        ],
-        "progression": "Getting Properties"
+        ]
       },
       "named_level": null,
       "bonus": null,
@@ -4473,10 +4473,10 @@
       "activity_section_position": 3,
       "assessment": null,
       "properties": {
+        "progression": "Getting Properties",
         "level_keys": [
           "CSD U6 getProperty dropdown_2021"
-        ],
-        "progression": "Getting Properties"
+        ]
       },
       "named_level": null,
       "bonus": null,
@@ -4499,10 +4499,10 @@
       "activity_section_position": 4,
       "assessment": null,
       "properties": {
+        "progression": "Getting Properties",
         "level_keys": [
           "CSD U6 getProperty board predict_2021"
-        ],
-        "progression": "Getting Properties"
+        ]
       },
       "named_level": null,
       "bonus": null,
@@ -4525,10 +4525,10 @@
       "activity_section_position": 5,
       "assessment": true,
       "properties": {
+        "progression": "Getting Properties",
         "level_keys": [
           "CSD U6 getProperty buzzer_2021"
-        ],
-        "progression": "Getting Properties"
+        ]
       },
       "named_level": null,
       "bonus": null,
@@ -4551,10 +4551,10 @@
       "activity_section_position": 1,
       "assessment": null,
       "properties": {
+        "progression": "Sliders",
         "level_keys": [
           "CSD U6 slider intro_2021"
-        ],
-        "progression": "Sliders"
+        ]
       },
       "named_level": null,
       "bonus": null,
@@ -4577,10 +4577,10 @@
       "activity_section_position": 2,
       "assessment": null,
       "properties": {
+        "progression": "Sliders",
         "level_keys": [
           "CSD U6 frequency_2021"
-        ],
-        "progression": "Sliders"
+        ]
       },
       "named_level": null,
       "bonus": null,
@@ -4603,10 +4603,10 @@
       "activity_section_position": 3,
       "assessment": null,
       "properties": {
+        "progression": "Sliders",
         "level_keys": [
           "CSD U6 interval_2021"
-        ],
-        "progression": "Sliders"
+        ]
       },
       "named_level": null,
       "bonus": null,
@@ -4629,10 +4629,10 @@
       "activity_section_position": 1,
       "assessment": null,
       "properties": {
+        "progression": "Change",
         "level_keys": [
           "CSD U6 change_2021"
-        ],
-        "progression": "Change"
+        ]
       },
       "named_level": null,
       "bonus": null,
@@ -4655,10 +4655,10 @@
       "activity_section_position": 2,
       "assessment": null,
       "properties": {
+        "progression": "Change",
         "level_keys": [
           "CSD U6 get toggle_2021"
-        ],
-        "progression": "Change"
+        ]
       },
       "named_level": null,
       "bonus": null,
@@ -4681,10 +4681,10 @@
       "activity_section_position": 3,
       "assessment": null,
       "properties": {
+        "progression": "Change",
         "level_keys": [
           "CSD U6 getters debug_2021"
-        ],
-        "progression": "Change"
+        ]
       },
       "named_level": null,
       "bonus": null,
@@ -4707,10 +4707,10 @@
       "activity_section_position": 1,
       "assessment": null,
       "properties": {
+        "progression": "Motorcycle",
         "level_keys": [
           "CSD U6 move motorcycle_2021"
-        ],
-        "progression": "Motorcycle"
+        ]
       },
       "named_level": null,
       "bonus": null,
@@ -4733,10 +4733,10 @@
       "activity_section_position": 2,
       "assessment": null,
       "properties": {
+        "progression": "Motorcycle",
         "level_keys": [
           "CSD U6 design motorcycle_2021"
-        ],
-        "progression": "Motorcycle"
+        ]
       },
       "named_level": null,
       "bonus": null,
@@ -4759,10 +4759,10 @@
       "activity_section_position": 1,
       "assessment": null,
       "properties": {
+        "progression": "Extra Challenge",
         "level_keys": [
           "CSD U6 challenge motorcycle_2021"
-        ],
-        "progression": "Extra Challenge"
+        ]
       },
       "named_level": null,
       "bonus": true,
@@ -4785,10 +4785,10 @@
       "activity_section_position": 1,
       "assessment": null,
       "properties": {
+        "progression": "Sensor Experiment",
         "level_keys": [
           "CSD U6 sensor experiment embedded_2021"
-        ],
-        "progression": "Sensor Experiment"
+        ]
       },
       "named_level": null,
       "bonus": null,
@@ -4811,10 +4811,10 @@
       "activity_section_position": 1,
       "assessment": null,
       "properties": {
+        "progression": "Reading Sensors",
         "level_keys": [
           "CSD U6 analog sound_2021"
-        ],
-        "progression": "Reading Sensors"
+        ]
       },
       "named_level": null,
       "bonus": null,
@@ -4837,10 +4837,10 @@
       "activity_section_position": 2,
       "assessment": null,
       "properties": {
+        "progression": "Reading Sensors",
         "level_keys": [
           "CSD U6 analog light_2021"
-        ],
-        "progression": "Reading Sensors"
+        ]
       },
       "named_level": null,
       "bonus": null,
@@ -4863,10 +4863,10 @@
       "activity_section_position": 3,
       "assessment": null,
       "properties": {
+        "progression": "Reading Sensors",
         "level_keys": [
           "CSD U6 analog temp_2021"
-        ],
-        "progression": "Reading Sensors"
+        ]
       },
       "named_level": null,
       "bonus": null,
@@ -4889,10 +4889,10 @@
       "activity_section_position": 1,
       "assessment": null,
       "properties": {
+        "progression": "Sensor Events",
         "level_keys": [
           "CSD U6 analog predict_2021"
-        ],
-        "progression": "Sensor Events"
+        ]
       },
       "named_level": null,
       "bonus": null,
@@ -4915,10 +4915,10 @@
       "activity_section_position": 2,
       "assessment": null,
       "properties": {
+        "progression": "Sensor Events",
         "level_keys": [
           "CSD U6 analog data_2021"
-        ],
-        "progression": "Sensor Events"
+        ]
       },
       "named_level": null,
       "bonus": null,
@@ -4941,10 +4941,10 @@
       "activity_section_position": 3,
       "assessment": null,
       "properties": {
+        "progression": "Sensor Events",
         "level_keys": [
           "CSD U6 analog change_2021"
-        ],
-        "progression": "Sensor Events"
+        ]
       },
       "named_level": null,
       "bonus": null,
@@ -4967,10 +4967,10 @@
       "activity_section_position": 4,
       "assessment": null,
       "properties": {
+        "progression": "Sensor Events",
         "level_keys": [
           "CSD U6 analog threshold_2021"
-        ],
-        "progression": "Sensor Events"
+        ]
       },
       "named_level": null,
       "bonus": null,
@@ -4993,10 +4993,10 @@
       "activity_section_position": 1,
       "assessment": null,
       "properties": {
+        "progression": "Sensors to Colors",
         "level_keys": [
           "CSD U6 analog rbg 1_2021"
-        ],
-        "progression": "Sensors to Colors"
+        ]
       },
       "named_level": null,
       "bonus": null,
@@ -5019,10 +5019,10 @@
       "activity_section_position": 2,
       "assessment": null,
       "properties": {
+        "progression": "Sensors to Colors",
         "level_keys": [
           "CSD U6 analog rbg 2_2021"
-        ],
-        "progression": "Sensors to Colors"
+        ]
       },
       "named_level": null,
       "bonus": null,
@@ -5045,10 +5045,10 @@
       "activity_section_position": 3,
       "assessment": true,
       "properties": {
+        "progression": "Sensors to Colors",
         "level_keys": [
           "CSD U6 analog rgb 3_2021"
-        ],
-        "progression": "Sensors to Colors"
+        ]
       },
       "named_level": null,
       "bonus": null,
@@ -5071,10 +5071,10 @@
       "activity_section_position": 1,
       "assessment": null,
       "properties": {
+        "progression": "Extra Challenge",
         "level_keys": [
           "CSD U6 analog challenge_2021"
-        ],
-        "progression": "Extra Challenge"
+        ]
       },
       "named_level": null,
       "bonus": true,
@@ -5097,10 +5097,10 @@
       "activity_section_position": 1,
       "assessment": null,
       "properties": {
+        "progression": "Sample Program",
         "level_keys": [
           "CSD U6 emoji race demo_2021"
-        ],
-        "progression": "Sample Program"
+        ]
       },
       "named_level": null,
       "bonus": null,
@@ -5123,10 +5123,10 @@
       "activity_section_position": 1,
       "assessment": null,
       "properties": {
+        "progression": "Plan Your Project",
         "level_keys": [
           "CSD U6 tugowar stop_2021"
-        ],
-        "progression": "Plan Your Project"
+        ]
       },
       "named_level": null,
       "bonus": null,
@@ -5149,10 +5149,10 @@
       "activity_section_position": 1,
       "assessment": null,
       "properties": {
+        "progression": "Screen Design",
         "level_keys": [
           "CSD U6 tugowar design 1_2021"
-        ],
-        "progression": "Screen Design"
+        ]
       },
       "named_level": null,
       "bonus": null,
@@ -5175,10 +5175,10 @@
       "activity_section_position": 2,
       "assessment": null,
       "properties": {
+        "progression": "Screen Design",
         "level_keys": [
           "CSD U6 tugowar design 1.5_2021"
-        ],
-        "progression": "Screen Design"
+        ]
       },
       "named_level": null,
       "bonus": null,
@@ -5201,10 +5201,10 @@
       "activity_section_position": 3,
       "assessment": null,
       "properties": {
+        "progression": "Screen Design",
         "level_keys": [
           "CSD U6 tugowar design 2_2021"
-        ],
-        "progression": "Screen Design"
+        ]
       },
       "named_level": null,
       "bonus": null,
@@ -5227,10 +5227,10 @@
       "activity_section_position": 1,
       "assessment": null,
       "properties": {
+        "progression": "Finishing Functions",
         "level_keys": [
           "CSD U6 tugowar variables 1_2021"
-        ],
-        "progression": "Finishing Functions"
+        ]
       },
       "named_level": null,
       "bonus": null,
@@ -5253,10 +5253,10 @@
       "activity_section_position": 2,
       "assessment": null,
       "properties": {
+        "progression": "Finishing Functions",
         "level_keys": [
           "CSD U6 tugowar variables 2_2021"
-        ],
-        "progression": "Finishing Functions"
+        ]
       },
       "named_level": null,
       "bonus": null,
@@ -5279,10 +5279,10 @@
       "activity_section_position": 3,
       "assessment": null,
       "properties": {
+        "progression": "Finishing Functions",
         "level_keys": [
           "CSD U6 tugowar variables 3_2021"
-        ],
-        "progression": "Finishing Functions"
+        ]
       },
       "named_level": null,
       "bonus": null,
@@ -5305,10 +5305,10 @@
       "activity_section_position": 1,
       "assessment": null,
       "properties": {
+        "progression": "Checking for a Winner",
         "level_keys": [
           "CSD U6 tugowar conditional_2021"
-        ],
-        "progression": "Checking for a Winner"
+        ]
       },
       "named_level": null,
       "bonus": null,
@@ -5331,10 +5331,10 @@
       "activity_section_position": 2,
       "assessment": null,
       "properties": {
+        "progression": "Checking for a Winner",
         "level_keys": [
           "CSD U6 tugowar setScreen_2021"
-        ],
-        "progression": "Checking for a Winner"
+        ]
       },
       "named_level": null,
       "bonus": null,
@@ -5357,10 +5357,10 @@
       "activity_section_position": 3,
       "assessment": null,
       "properties": {
+        "progression": "Checking for a Winner",
         "level_keys": [
           "CSD U6 tugowar setProperty_2021"
-        ],
-        "progression": "Checking for a Winner"
+        ]
       },
       "named_level": null,
       "bonus": null,
@@ -5383,10 +5383,10 @@
       "activity_section_position": 4,
       "assessment": true,
       "properties": {
+        "progression": "Checking for a Winner",
         "level_keys": [
           "CSD U6 tugowar buzzer_2021"
-        ],
-        "progression": "Checking for a Winner"
+        ]
       },
       "named_level": null,
       "bonus": null,
@@ -5409,10 +5409,10 @@
       "activity_section_position": 1,
       "assessment": null,
       "properties": {
+        "progression": "Make it Your Own",
         "level_keys": [
           "CSD U6 tugowar final_2021"
-        ],
-        "progression": "Make it Your Own"
+        ]
       },
       "named_level": null,
       "bonus": null,
@@ -5435,10 +5435,10 @@
       "activity_section_position": 1,
       "assessment": null,
       "properties": {
+        "progression": "Demo - Bug Grab",
         "level_keys": [
           "CSD U6 tugowar demo_2021"
-        ],
-        "progression": "Demo - Bug Grab"
+        ]
       },
       "named_level": null,
       "bonus": null,
@@ -5461,10 +5461,10 @@
       "activity_section_position": 1,
       "assessment": null,
       "properties": {
+        "progression": "Plan Your Project",
         "level_keys": [
           "CSD U6 game project stop_2021"
-        ],
-        "progression": "Plan Your Project"
+        ]
       },
       "named_level": null,
       "bonus": null,
@@ -5487,10 +5487,10 @@
       "activity_section_position": 1,
       "assessment": null,
       "properties": {
+        "progression": "Screen Design",
         "level_keys": [
           "CSD U6 game project screens_2021"
-        ],
-        "progression": "Screen Design"
+        ]
       },
       "named_level": null,
       "bonus": null,
@@ -5513,10 +5513,10 @@
       "activity_section_position": 1,
       "assessment": null,
       "properties": {
+        "progression": "Events",
         "level_keys": [
           "CSD U6 game project screen links_2021"
-        ],
-        "progression": "Events"
+        ]
       },
       "named_level": null,
       "bonus": null,
@@ -5539,10 +5539,10 @@
       "activity_section_position": 2,
       "assessment": null,
       "properties": {
+        "progression": "Events",
         "level_keys": [
           "CSD U6 game project board events_2021"
-        ],
-        "progression": "Events"
+        ]
       },
       "named_level": null,
       "bonus": null,
@@ -5565,10 +5565,10 @@
       "activity_section_position": 1,
       "assessment": null,
       "properties": {
+        "progression": "Functions",
         "level_keys": [
           "CSD U6 game project functions define_2021"
-        ],
-        "progression": "Functions"
+        ]
       },
       "named_level": null,
       "bonus": null,
@@ -5591,10 +5591,10 @@
       "activity_section_position": 2,
       "assessment": null,
       "properties": {
+        "progression": "Functions",
         "level_keys": [
           "CSD U6 game project functions call_2021"
-        ],
-        "progression": "Functions"
+        ]
       },
       "named_level": null,
       "bonus": null,
@@ -5617,10 +5617,10 @@
       "activity_section_position": 1,
       "assessment": null,
       "properties": {
+        "progression": "Finishing Touches",
         "level_keys": [
           "CSD U6 game project finish_2021"
-        ],
-        "progression": "Finishing Touches"
+        ]
       },
       "named_level": null,
       "bonus": null,
@@ -5643,10 +5643,10 @@
       "activity_section_position": 1,
       "assessment": true,
       "properties": {
+        "progression": "Reflection",
         "level_keys": [
           "csd-pulse-check-survey-1-levelgroup U6Ch1_2021"
-        ],
-        "progression": "Reflection"
+        ]
       },
       "named_level": null,
       "bonus": null,
@@ -5669,10 +5669,10 @@
       "activity_section_position": 1,
       "assessment": null,
       "properties": {
+        "progression": "Video: Introduction to Arrays",
         "level_keys": [
           "CSD U6 arrays video_2021"
-        ],
-        "progression": "Video: Introduction to Arrays"
+        ]
       },
       "named_level": null,
       "bonus": null,
@@ -5695,10 +5695,10 @@
       "activity_section_position": 1,
       "assessment": null,
       "properties": {
+        "progression": "Introduction to Arrays",
         "level_keys": [
           "CSD U6 arrays select predict_2021"
-        ],
-        "progression": "Introduction to Arrays"
+        ]
       },
       "named_level": null,
       "bonus": null,
@@ -5721,10 +5721,10 @@
       "activity_section_position": 2,
       "assessment": null,
       "properties": {
+        "progression": "Introduction to Arrays",
         "level_keys": [
           "CSDU6 arrays select rainbow_2021"
-        ],
-        "progression": "Introduction to Arrays"
+        ]
       },
       "named_level": null,
       "bonus": null,
@@ -5747,10 +5747,10 @@
       "activity_section_position": 3,
       "assessment": null,
       "properties": {
+        "progression": "Introduction to Arrays",
         "level_keys": [
           "CSDU6 array select days_2021"
-        ],
-        "progression": "Introduction to Arrays"
+        ]
       },
       "named_level": null,
       "bonus": null,
@@ -5773,10 +5773,10 @@
       "activity_section_position": 4,
       "assessment": null,
       "properties": {
+        "progression": "Introduction to Arrays",
         "level_keys": [
           "CSDU6 arrays select random_2021"
-        ],
-        "progression": "Introduction to Arrays"
+        ]
       },
       "named_level": null,
       "bonus": null,
@@ -5799,10 +5799,10 @@
       "activity_section_position": 5,
       "assessment": true,
       "properties": {
+        "progression": "Introduction to Arrays",
         "level_keys": [
           "CSDU6 arrays select variable_2021"
-        ],
-        "progression": "Introduction to Arrays"
+        ]
       },
       "named_level": null,
       "bonus": null,
@@ -5825,10 +5825,10 @@
       "activity_section_position": 1,
       "assessment": true,
       "properties": {
+        "progression": "Using Arrays",
         "level_keys": [
           "CSD U6 array multi_2021"
-        ],
-        "progression": "Using Arrays"
+        ]
       },
       "named_level": null,
       "bonus": null,
@@ -5851,10 +5851,10 @@
       "activity_section_position": 1,
       "assessment": null,
       "properties": {
+        "progression": "Color LEDs",
         "level_keys": [
           "CSD U6 colorLeds predict_2021"
-        ],
-        "progression": "Color LEDs"
+        ]
       },
       "named_level": null,
       "bonus": null,
@@ -5877,10 +5877,10 @@
       "activity_section_position": 2,
       "assessment": null,
       "properties": {
+        "progression": "Color LEDs",
         "level_keys": [
           "CSD U6 colorLED on_2021"
-        ],
-        "progression": "Color LEDs"
+        ]
       },
       "named_level": null,
       "bonus": null,
@@ -5903,10 +5903,10 @@
       "activity_section_position": 3,
       "assessment": null,
       "properties": {
+        "progression": "Color LEDs",
         "level_keys": [
           "CSD U6 LEDs color_2021"
-        ],
-        "progression": "Color LEDs"
+        ]
       },
       "named_level": null,
       "bonus": null,
@@ -5929,10 +5929,10 @@
       "activity_section_position": 4,
       "assessment": null,
       "properties": {
+        "progression": "Color LEDs",
         "level_keys": [
           "CSD U6 colorLeds debug_2021"
-        ],
-        "progression": "Color LEDs"
+        ]
       },
       "named_level": null,
       "bonus": null,
@@ -5955,10 +5955,10 @@
       "activity_section_position": 5,
       "assessment": null,
       "properties": {
+        "progression": "Color LEDs",
         "level_keys": [
           "CSD U6 colorLeds intensity_2021"
-        ],
-        "progression": "Color LEDs"
+        ]
       },
       "named_level": null,
       "bonus": null,
@@ -5981,10 +5981,10 @@
       "activity_section_position": 1,
       "assessment": null,
       "properties": {
+        "progression": "Light Show",
         "level_keys": [
           "CSD U6 colorLeds light pattern_2021"
-        ],
-        "progression": "Light Show"
+        ]
       },
       "named_level": null,
       "bonus": null,
@@ -6007,10 +6007,10 @@
       "activity_section_position": 2,
       "assessment": true,
       "properties": {
+        "progression": "Light Show",
         "level_keys": [
           "CSD U6 light pattern off_2021"
-        ],
-        "progression": "Light Show"
+        ]
       },
       "named_level": null,
       "bonus": null,
@@ -6033,10 +6033,10 @@
       "activity_section_position": 1,
       "assessment": null,
       "properties": {
+        "progression": "Challenge Levels",
         "level_keys": [
           "CSD U6 light pattern challenge_2021"
-        ],
-        "progression": "Challenge Levels"
+        ]
       },
       "named_level": null,
       "bonus": true,
@@ -6059,10 +6059,10 @@
       "activity_section_position": 1,
       "assessment": null,
       "properties": {
+        "progression": "Playing Notes",
         "level_keys": [
           "CSDU6 circuit playground piano_2021"
-        ],
-        "progression": "Playing Notes"
+        ]
       },
       "named_level": null,
       "bonus": null,
@@ -6085,10 +6085,10 @@
       "activity_section_position": 2,
       "assessment": null,
       "properties": {
+        "progression": "Playing Notes",
         "level_keys": [
           "CSDU6 frequency modification_2021"
-        ],
-        "progression": "Playing Notes"
+        ]
       },
       "named_level": null,
       "bonus": null,
@@ -6111,10 +6111,10 @@
       "activity_section_position": 3,
       "assessment": null,
       "properties": {
+        "progression": "Playing Notes",
         "level_keys": [
           "CSDU6 frequency creation_2021"
-        ],
-        "progression": "Playing Notes"
+        ]
       },
       "named_level": null,
       "bonus": null,
@@ -6137,10 +6137,10 @@
       "activity_section_position": 4,
       "assessment": null,
       "properties": {
+        "progression": "Playing Notes",
         "level_keys": [
           "CSDU6 piano with notes_2021"
-        ],
-        "progression": "Playing Notes"
+        ]
       },
       "named_level": null,
       "bonus": null,
@@ -6163,10 +6163,10 @@
       "activity_section_position": 1,
       "assessment": null,
       "properties": {
+        "progression": "Musical Arrays",
         "level_keys": [
           "CSD U6 array piano_2021"
-        ],
-        "progression": "Musical Arrays"
+        ]
       },
       "named_level": null,
       "bonus": null,
@@ -6189,10 +6189,10 @@
       "activity_section_position": 2,
       "assessment": null,
       "properties": {
+        "progression": "Musical Arrays",
         "level_keys": [
           "CSD U6 random array notes_2021"
-        ],
-        "progression": "Musical Arrays"
+        ]
       },
       "named_level": null,
       "bonus": null,
@@ -6215,10 +6215,10 @@
       "activity_section_position": 3,
       "assessment": true,
       "properties": {
+        "progression": "Musical Arrays",
         "level_keys": [
           "CSDU6 making new arrays_2021"
-        ],
-        "progression": "Musical Arrays"
+        ]
       },
       "named_level": null,
       "bonus": null,
@@ -6241,10 +6241,10 @@
       "activity_section_position": 1,
       "assessment": null,
       "properties": {
+        "progression": "Making Songs",
         "level_keys": [
           "CSDU6 play predict code_2021"
-        ],
-        "progression": "Making Songs"
+        ]
       },
       "named_level": null,
       "bonus": null,
@@ -6267,10 +6267,10 @@
       "activity_section_position": 2,
       "assessment": null,
       "properties": {
+        "progression": "Making Songs",
         "level_keys": [
           "CSDU6 play songs_2021"
-        ],
-        "progression": "Making Songs"
+        ]
       },
       "named_level": null,
       "bonus": null,
@@ -6293,10 +6293,10 @@
       "activity_section_position": 3,
       "assessment": null,
       "properties": {
+        "progression": "Making Songs",
         "level_keys": [
           "CSDU6 play null notes_2021"
-        ],
-        "progression": "Making Songs"
+        ]
       },
       "named_level": null,
       "bonus": null,
@@ -6319,10 +6319,10 @@
       "activity_section_position": 4,
       "assessment": true,
       "properties": {
+        "progression": "Making Songs",
         "level_keys": [
           "CDU U6 Playground Sound Board_2021"
-        ],
-        "progression": "Making Songs"
+        ]
       },
       "named_level": null,
       "bonus": null,
@@ -6345,10 +6345,10 @@
       "activity_section_position": 1,
       "assessment": null,
       "properties": {
+        "progression": "Extra",
         "level_keys": [
           "CSDU6 buzzer 2d arrays_2021"
-        ],
-        "progression": "Extra"
+        ]
       },
       "named_level": null,
       "bonus": true,
@@ -6371,10 +6371,10 @@
       "activity_section_position": 2,
       "assessment": null,
       "properties": {
+        "progression": "Extra",
         "level_keys": [
           "CSDU6 buzzer.stop_2021"
-        ],
-        "progression": "Extra"
+        ]
       },
       "named_level": null,
       "bonus": true,
@@ -6397,10 +6397,10 @@
       "activity_section_position": 1,
       "assessment": null,
       "properties": {
+        "progression": "Programs that Repeat",
         "level_keys": [
           "CSD U6 for loop click predict_2021"
-        ],
-        "progression": "Programs that Repeat"
+        ]
       },
       "named_level": null,
       "bonus": null,
@@ -6423,10 +6423,10 @@
       "activity_section_position": 2,
       "assessment": null,
       "properties": {
+        "progression": "Programs that Repeat",
         "level_keys": [
           "CSD U6 for loop click exit_2021"
-        ],
-        "progression": "Programs that Repeat"
+        ]
       },
       "named_level": null,
       "bonus": null,
@@ -6449,10 +6449,10 @@
       "activity_section_position": 1,
       "assessment": null,
       "properties": {
+        "progression": "Video: For Loops",
         "level_keys": [
           "CSD: For Loop_2021"
-        ],
-        "progression": "Video: For Loops"
+        ]
       },
       "named_level": null,
       "bonus": null,
@@ -6475,10 +6475,10 @@
       "activity_section_position": 1,
       "assessment": null,
       "properties": {
+        "progression": "For Loops",
         "level_keys": [
           "CSDU6 - for loop - predict print_2021"
-        ],
-        "progression": "For Loops"
+        ]
       },
       "named_level": null,
       "bonus": null,
@@ -6501,10 +6501,10 @@
       "activity_section_position": 2,
       "assessment": null,
       "properties": {
+        "progression": "For Loops",
         "level_keys": [
           "CSD U6 for loop button array_2021"
-        ],
-        "progression": "For Loops"
+        ]
       },
       "named_level": null,
       "bonus": null,
@@ -6527,10 +6527,10 @@
       "activity_section_position": 3,
       "assessment": null,
       "properties": {
+        "progression": "For Loops",
         "level_keys": [
           "CSD U6 for loop list.length_2021"
-        ],
-        "progression": "For Loops"
+        ]
       },
       "named_level": null,
       "bonus": null,
@@ -6553,10 +6553,10 @@
       "activity_section_position": 4,
       "assessment": null,
       "properties": {
+        "progression": "For Loops",
         "level_keys": [
           "CSD U6 for loop images_2021"
-        ],
-        "progression": "For Loops"
+        ]
       },
       "named_level": null,
       "bonus": null,
@@ -6579,10 +6579,10 @@
       "activity_section_position": 5,
       "assessment": null,
       "properties": {
+        "progression": "For Loops",
         "level_keys": [
           "CSD U6 for loop map_2021"
-        ],
-        "progression": "For Loops"
+        ]
       },
       "named_level": null,
       "bonus": null,
@@ -6605,10 +6605,10 @@
       "activity_section_position": 1,
       "assessment": null,
       "properties": {
+        "progression": "For Loops and Color LEDs",
         "level_keys": [
           "CSD U6 for loop led on_2021"
-        ],
-        "progression": "For Loops and Color LEDs"
+        ]
       },
       "named_level": null,
       "bonus": null,
@@ -6631,10 +6631,10 @@
       "activity_section_position": 2,
       "assessment": null,
       "properties": {
+        "progression": "For Loops and Color LEDs",
         "level_keys": [
           "CSD U6 for loop led off_2021"
-        ],
-        "progression": "For Loops and Color LEDs"
+        ]
       },
       "named_level": null,
       "bonus": null,
@@ -6657,10 +6657,10 @@
       "activity_section_position": 3,
       "assessment": null,
       "properties": {
+        "progression": "For Loops and Color LEDs",
         "level_keys": [
           "CSD U6 for loop led color_2021"
-        ],
-        "progression": "For Loops and Color LEDs"
+        ]
       },
       "named_level": null,
       "bonus": null,
@@ -6683,10 +6683,10 @@
       "activity_section_position": 4,
       "assessment": true,
       "properties": {
+        "progression": "For Loops and Color LEDs",
         "level_keys": [
           "CSD U6 for loop led personalize_2021"
-        ],
-        "progression": "For Loops and Color LEDs"
+        ]
       },
       "named_level": null,
       "bonus": null,
@@ -6709,10 +6709,10 @@
       "activity_section_position": 1,
       "assessment": null,
       "properties": {
+        "progression": "Orientation",
         "level_keys": [
           "CSD U6 Airplane predict_2021"
-        ],
-        "progression": "Orientation"
+        ]
       },
       "named_level": null,
       "bonus": null,
@@ -6735,10 +6735,10 @@
       "activity_section_position": 2,
       "assessment": null,
       "properties": {
+        "progression": "Orientation",
         "level_keys": [
           "CSD U6 investigate orientation_2021"
-        ],
-        "progression": "Orientation"
+        ]
       },
       "named_level": null,
       "bonus": null,
@@ -6761,10 +6761,10 @@
       "activity_section_position": 3,
       "assessment": null,
       "properties": {
+        "progression": "Orientation",
         "level_keys": [
           "CSD U6 directional leds pitch_2021"
-        ],
-        "progression": "Orientation"
+        ]
       },
       "named_level": null,
       "bonus": null,
@@ -6787,10 +6787,10 @@
       "activity_section_position": 4,
       "assessment": null,
       "properties": {
+        "progression": "Orientation",
         "level_keys": [
           "CSD U6 directional LEDs roll_2021"
-        ],
-        "progression": "Orientation"
+        ]
       },
       "named_level": null,
       "bonus": null,
@@ -6813,10 +6813,10 @@
       "activity_section_position": 1,
       "assessment": null,
       "properties": {
+        "progression": "Accelerometer Events",
         "level_keys": [
           "CSD U6 stillness game predict code_2021"
-        ],
-        "progression": "Accelerometer Events"
+        ]
       },
       "named_level": null,
       "bonus": null,
@@ -6839,10 +6839,10 @@
       "activity_section_position": 2,
       "assessment": null,
       "properties": {
+        "progression": "Accelerometer Events",
         "level_keys": [
           "CSD U6 Pedometer_2021"
-        ],
-        "progression": "Accelerometer Events"
+        ]
       },
       "named_level": null,
       "bonus": null,
@@ -6865,10 +6865,10 @@
       "activity_section_position": 3,
       "assessment": true,
       "properties": {
+        "progression": "Accelerometer Events",
         "level_keys": [
           "CSD U6 goalie_2021"
-        ],
-        "progression": "Accelerometer Events"
+        ]
       },
       "named_level": null,
       "bonus": null,
@@ -6891,10 +6891,10 @@
       "activity_section_position": 4,
       "assessment": null,
       "properties": {
+        "progression": "Accelerometer Events",
         "level_keys": [
           "CSD U6 Driver pt1_2021"
-        ],
-        "progression": "Accelerometer Events"
+        ]
       },
       "named_level": null,
       "bonus": null,
@@ -6917,10 +6917,10 @@
       "activity_section_position": 5,
       "assessment": null,
       "properties": {
+        "progression": "Accelerometer Events",
         "level_keys": [
           "CSD U6 Driver pt 2_2021"
-        ],
-        "progression": "Accelerometer Events"
+        ]
       },
       "named_level": null,
       "bonus": null,
@@ -6943,10 +6943,10 @@
       "activity_section_position": 1,
       "assessment": null,
       "properties": {
+        "progression": "Functions with Parameters",
         "level_keys": [
           "CSD U6 params predict_2021"
-        ],
-        "progression": "Functions with Parameters"
+        ]
       },
       "named_level": null,
       "bonus": null,
@@ -6969,10 +6969,10 @@
       "activity_section_position": 2,
       "assessment": null,
       "properties": {
+        "progression": "Functions with Parameters",
         "level_keys": [
           "CSD U6 functions paramters video_2021"
-        ],
-        "progression": "Functions with Parameters"
+        ]
       },
       "named_level": null,
       "bonus": null,
@@ -6995,10 +6995,10 @@
       "activity_section_position": 3,
       "assessment": null,
       "properties": {
+        "progression": "Functions with Parameters",
         "level_keys": [
           "CSD U6 params modify clouds_2021"
-        ],
-        "progression": "Functions with Parameters"
+        ]
       },
       "named_level": null,
       "bonus": null,
@@ -7021,10 +7021,10 @@
       "activity_section_position": 4,
       "assessment": null,
       "properties": {
+        "progression": "Functions with Parameters",
         "level_keys": [
           "CSD U6 params modify planes_2021"
-        ],
-        "progression": "Functions with Parameters"
+        ]
       },
       "named_level": null,
       "bonus": null,
@@ -7047,10 +7047,10 @@
       "activity_section_position": 5,
       "assessment": null,
       "properties": {
+        "progression": "Functions with Parameters",
         "level_keys": [
           "CSD U6 params create colors_2021"
-        ],
-        "progression": "Functions with Parameters"
+        ]
       },
       "named_level": null,
       "bonus": null,
@@ -7073,10 +7073,10 @@
       "activity_section_position": 1,
       "assessment": null,
       "properties": {
+        "progression": "Iteration and Parameters",
         "level_keys": [
           "CSD U6 iter predict bubbles_2021"
-        ],
-        "progression": "Iteration and Parameters"
+        ]
       },
       "named_level": null,
       "bonus": null,
@@ -7099,10 +7099,10 @@
       "activity_section_position": 2,
       "assessment": null,
       "properties": {
+        "progression": "Iteration and Parameters",
         "level_keys": [
           "CSD U6 iter modify bugs_2021"
-        ],
-        "progression": "Iteration and Parameters"
+        ]
       },
       "named_level": null,
       "bonus": null,
@@ -7125,10 +7125,10 @@
       "activity_section_position": 3,
       "assessment": null,
       "properties": {
+        "progression": "Iteration and Parameters",
         "level_keys": [
           "CSD U6 iter create notes_2021"
-        ],
-        "progression": "Iteration and Parameters"
+        ]
       },
       "named_level": null,
       "bonus": null,
@@ -7151,10 +7151,10 @@
       "activity_section_position": 1,
       "assessment": null,
       "properties": {
+        "progression": "Star Chaser",
         "level_keys": [
           "CSD U6 params starchaser intro_2021"
-        ],
-        "progression": "Star Chaser"
+        ]
       },
       "named_level": null,
       "bonus": null,
@@ -7177,10 +7177,10 @@
       "activity_section_position": 2,
       "assessment": null,
       "properties": {
+        "progression": "Star Chaser",
         "level_keys": [
           "CSD U6 params starchaser 1_2021"
-        ],
-        "progression": "Star Chaser"
+        ]
       },
       "named_level": null,
       "bonus": null,
@@ -7203,10 +7203,10 @@
       "activity_section_position": 3,
       "assessment": null,
       "properties": {
+        "progression": "Star Chaser",
         "level_keys": [
           "CSD U6 params starchaser 2_2021"
-        ],
-        "progression": "Star Chaser"
+        ]
       },
       "named_level": null,
       "bonus": null,
@@ -7229,10 +7229,10 @@
       "activity_section_position": 4,
       "assessment": null,
       "properties": {
+        "progression": "Star Chaser",
         "level_keys": [
           "CSD U6 params starchaser 3_2021"
-        ],
-        "progression": "Star Chaser"
+        ]
       },
       "named_level": null,
       "bonus": null,
@@ -7255,10 +7255,10 @@
       "activity_section_position": 5,
       "assessment": null,
       "properties": {
+        "progression": "Star Chaser",
         "level_keys": [
           "CSD U6 params starchaser 4_2021"
-        ],
-        "progression": "Star Chaser"
+        ]
       },
       "named_level": null,
       "bonus": null,
@@ -7281,10 +7281,10 @@
       "activity_section_position": 6,
       "assessment": true,
       "properties": {
+        "progression": "Star Chaser",
         "level_keys": [
           "CSD U6 params starchaser 5_2021"
-        ],
-        "progression": "Star Chaser"
+        ]
       },
       "named_level": null,
       "bonus": null,
@@ -7307,10 +7307,10 @@
       "activity_section_position": 7,
       "assessment": null,
       "properties": {
+        "progression": "Star Chaser",
         "level_keys": [
           "CSD U6 params starchaser challenge 1_2021"
-        ],
-        "progression": "Star Chaser"
+        ]
       },
       "named_level": null,
       "bonus": true,
@@ -7333,10 +7333,10 @@
       "activity_section_position": 8,
       "assessment": null,
       "properties": {
+        "progression": "Star Chaser",
         "level_keys": [
           "CSD U6 params starchaser challenge 2_2021"
-        ],
-        "progression": "Star Chaser"
+        ]
       },
       "named_level": null,
       "bonus": true,
@@ -7359,10 +7359,10 @@
       "activity_section_position": 1,
       "assessment": null,
       "properties": {
+        "progression": "Circuits and Logic",
         "level_keys": [
           "CSD U6 circuit logic video_2021"
-        ],
-        "progression": "Circuits and Logic"
+        ]
       },
       "named_level": null,
       "bonus": null,
@@ -7385,10 +7385,10 @@
       "activity_section_position": 1,
       "assessment": null,
       "properties": {
+        "progression": "Simple Circuits",
         "level_keys": [
           "CSD U6 circuit predict_2021"
-        ],
-        "progression": "Simple Circuits"
+        ]
       },
       "named_level": null,
       "bonus": null,
@@ -7411,10 +7411,10 @@
       "activity_section_position": 2,
       "assessment": null,
       "properties": {
+        "progression": "Simple Circuits",
         "level_keys": [
           "CSD U6 circuit pinMode_2021"
-        ],
-        "progression": "Simple Circuits"
+        ]
       },
       "named_level": null,
       "bonus": null,
@@ -7437,10 +7437,10 @@
       "activity_section_position": 3,
       "assessment": null,
       "properties": {
+        "progression": "Simple Circuits",
         "level_keys": [
           "CSD U6 circuit createLed_2021"
-        ],
-        "progression": "Simple Circuits"
+        ]
       },
       "named_level": null,
       "bonus": null,
@@ -7463,10 +7463,10 @@
       "activity_section_position": 4,
       "assessment": null,
       "properties": {
+        "progression": "Simple Circuits",
         "level_keys": [
           "CSD U6 circuit multi led_2021"
-        ],
-        "progression": "Simple Circuits"
+        ]
       },
       "named_level": null,
       "bonus": null,
@@ -7489,10 +7489,10 @@
       "activity_section_position": 1,
       "assessment": null,
       "properties": {
+        "progression": "Smart Bike - Blinkers",
         "level_keys": [
           "CSD U6 circuit smart bike blinkers_2021"
-        ],
-        "progression": "Smart Bike - Blinkers"
+        ]
       },
       "named_level": null,
       "bonus": null,
@@ -7515,10 +7515,10 @@
       "activity_section_position": 2,
       "assessment": true,
       "properties": {
+        "progression": "Smart Bike - Blinkers",
         "level_keys": [
           "CSD U6 circuit smart bike blinker buttons_2021"
-        ],
-        "progression": "Smart Bike - Blinkers"
+        ]
       },
       "named_level": null,
       "bonus": null,
@@ -7541,10 +7541,10 @@
       "activity_section_position": 3,
       "assessment": null,
       "properties": {
+        "progression": "Smart Bike - Blinkers",
         "level_keys": [
           "CSD U6 circuit smart bike blinker build_2021"
-        ],
-        "progression": "Smart Bike - Blinkers"
+        ]
       },
       "named_level": null,
       "bonus": null,
@@ -7567,10 +7567,10 @@
       "activity_section_position": 1,
       "assessment": null,
       "properties": {
+        "progression": "Button Circuits",
         "level_keys": [
           "CSD U6 circuit createButton_2021"
-        ],
-        "progression": "Button Circuits"
+        ]
       },
       "named_level": null,
       "bonus": null,
@@ -7593,10 +7593,10 @@
       "activity_section_position": 1,
       "assessment": null,
       "properties": {
+        "progression": "Finish the Prototype",
         "level_keys": [
           "CSD U6 circuit smart bike buzzer_2021"
-        ],
-        "progression": "Finish the Prototype"
+        ]
       },
       "named_level": null,
       "bonus": null,
@@ -7619,10 +7619,10 @@
       "activity_section_position": 2,
       "assessment": null,
       "properties": {
+        "progression": "Finish the Prototype",
         "level_keys": [
           "CSD U6 circuit smart bike light_2021"
-        ],
-        "progression": "Finish the Prototype"
+        ]
       },
       "named_level": null,
       "bonus": null,
@@ -7645,10 +7645,10 @@
       "activity_section_position": 3,
       "assessment": true,
       "properties": {
+        "progression": "Finish the Prototype",
         "level_keys": [
           "CSD U6 circuit smart bike final_2021"
-        ],
-        "progression": "Finish the Prototype"
+        ]
       },
       "named_level": null,
       "bonus": null,
@@ -7671,10 +7671,10 @@
       "activity_section_position": 1,
       "assessment": null,
       "properties": {
+        "progression": "Design Your Prototype",
         "level_keys": [
           "CSD U6 final intro_2021"
-        ],
-        "progression": "Design Your Prototype"
+        ]
       },
       "named_level": null,
       "bonus": null,
@@ -7697,10 +7697,10 @@
       "activity_section_position": 1,
       "assessment": null,
       "properties": {
+        "progression": "User Interface",
         "level_keys": [
           "CSDU6 - final project 1_2021"
-        ],
-        "progression": "User Interface"
+        ]
       },
       "named_level": null,
       "bonus": null,
@@ -7723,10 +7723,10 @@
       "activity_section_position": 2,
       "assessment": null,
       "properties": {
+        "progression": "User Interface",
         "level_keys": [
           "CSDU6 - final project 2_2021"
-        ],
-        "progression": "User Interface"
+        ]
       },
       "named_level": null,
       "bonus": null,
@@ -7749,10 +7749,10 @@
       "activity_section_position": 1,
       "assessment": null,
       "properties": {
+        "progression": "Board Input and Output",
         "level_keys": [
           "CSDU6 - final project 3_2021"
-        ],
-        "progression": "Board Input and Output"
+        ]
       },
       "named_level": null,
       "bonus": null,
@@ -7775,10 +7775,10 @@
       "activity_section_position": 2,
       "assessment": null,
       "properties": {
+        "progression": "Board Input and Output",
         "level_keys": [
           "CSDU6 - final project 5_2021"
-        ],
-        "progression": "Board Input and Output"
+        ]
       },
       "named_level": null,
       "bonus": null,
@@ -7801,10 +7801,10 @@
       "activity_section_position": 1,
       "assessment": null,
       "properties": {
+        "progression": "Finishing Touches",
         "level_keys": [
           "CSDU6 - final project 4_2021"
-        ],
-        "progression": "Finishing Touches"
+        ]
       },
       "named_level": null,
       "bonus": null,
@@ -7827,10 +7827,10 @@
       "activity_section_position": 2,
       "assessment": null,
       "properties": {
+        "progression": "Finishing Touches",
         "level_keys": [
           "CSDU6 - final project 6_2021"
-        ],
-        "progression": "Finishing Touches"
+        ]
       },
       "named_level": null,
       "bonus": null,
@@ -7853,10 +7853,10 @@
       "activity_section_position": 1,
       "assessment": true,
       "properties": {
+        "progression": "Reflection",
         "level_keys": [
           "csd-pulse-check-survey-1-levelgroup U6Ch2_2021"
-        ],
-        "progression": "Reflection"
+        ]
       },
       "named_level": null,
       "bonus": null,
@@ -10460,7 +10460,7 @@
       }
     }
   ],
-  "lessons_programming_expressions": [
+"lessons_programming_expressions": [
     {
       "seeding_key": {
         "lesson.key": "Designing Screens with Code",
@@ -11112,8 +11112,5 @@
         "objective.key": "5ae2739b-3776-43ba-973f-50fa22302e32"
       }
     }
-  ],
-  "lessons_standards": [
-
   ]
 }

--- a/dashboard/config/scripts_json/csd6-2021.script_json
+++ b/dashboard/config/scripts_json/csd6-2021.script_json
@@ -31,7 +31,7 @@
     },
     "new_name": null,
     "family_name": "csd6",
-    "serialized_at": "2021-03-15 12:51:02 UTC",
+    "serialized_at": "2021-03-18 22:02:51 UTC",
     "seeding_key": {
       "script.name": "csd6-2021"
     }
@@ -3459,10 +3459,10 @@
       "activity_section_position": 1,
       "assessment": null,
       "properties": {
-        "progression": "Innovation Research",
         "level_keys": [
           "CSDU6 Innovation_2021"
-        ]
+        ],
+        "progression": "Innovation Research"
       },
       "named_level": null,
       "bonus": null,
@@ -3485,10 +3485,10 @@
       "activity_section_position": 1,
       "assessment": null,
       "properties": {
-        "progression": "Setting Properties",
         "level_keys": [
           "CSD U6 setProperty predict app_2021"
-        ]
+        ],
+        "progression": "Setting Properties"
       },
       "named_level": null,
       "bonus": null,
@@ -3511,10 +3511,10 @@
       "activity_section_position": 2,
       "assessment": null,
       "properties": {
-        "progression": "Setting Properties",
         "level_keys": [
           "CSD U6 setProperty Text_2021"
-        ]
+        ],
+        "progression": "Setting Properties"
       },
       "named_level": null,
       "bonus": null,
@@ -3537,10 +3537,10 @@
       "activity_section_position": 3,
       "assessment": true,
       "properties": {
-        "progression": "Setting Properties",
         "level_keys": [
           "CSD U6 setProperty xy_2021"
-        ]
+        ],
+        "progression": "Setting Properties"
       },
       "named_level": null,
       "bonus": null,
@@ -3563,10 +3563,10 @@
       "activity_section_position": 1,
       "assessment": null,
       "properties": {
-        "progression": "Events and Properties",
         "level_keys": [
           "CSD U6 setProperty xy click_2021"
-        ]
+        ],
+        "progression": "Events and Properties"
       },
       "named_level": null,
       "bonus": null,
@@ -3589,10 +3589,10 @@
       "activity_section_position": 2,
       "assessment": null,
       "properties": {
-        "progression": "Events and Properties",
         "level_keys": [
           "CSD U6 setProperty xy random_2021"
-        ]
+        ],
+        "progression": "Events and Properties"
       },
       "named_level": null,
       "bonus": null,
@@ -3615,10 +3615,10 @@
       "activity_section_position": 3,
       "assessment": null,
       "properties": {
-        "progression": "Events and Properties",
         "level_keys": [
           "CSD U6 setProperty hidden_2021"
-        ]
+        ],
+        "progression": "Events and Properties"
       },
       "named_level": null,
       "bonus": null,
@@ -3641,10 +3641,10 @@
       "activity_section_position": 4,
       "assessment": true,
       "properties": {
-        "progression": "Events and Properties",
         "level_keys": [
           "CSD U6 setProperty hidden 2_2021"
-        ]
+        ],
+        "progression": "Events and Properties"
       },
       "named_level": null,
       "bonus": null,
@@ -3667,10 +3667,10 @@
       "activity_section_position": 1,
       "assessment": null,
       "properties": {
-        "progression": "Emotion Machine Example",
         "level_keys": [
           "CSD U6 emotion machine example_2021"
-        ]
+        ],
+        "progression": "Emotion Machine Example"
       },
       "named_level": null,
       "bonus": null,
@@ -3693,10 +3693,10 @@
       "activity_section_position": 1,
       "assessment": null,
       "properties": {
-        "progression": "Building an App",
         "level_keys": [
           "CSD U6 emotion machine 1_2021"
-        ]
+        ],
+        "progression": "Building an App"
       },
       "named_level": null,
       "bonus": null,
@@ -3719,10 +3719,10 @@
       "activity_section_position": 2,
       "assessment": null,
       "properties": {
-        "progression": "Building an App",
         "level_keys": [
           "CSD U6 emotion machine 2_2021"
-        ]
+        ],
+        "progression": "Building an App"
       },
       "named_level": null,
       "bonus": null,
@@ -3745,10 +3745,10 @@
       "activity_section_position": 3,
       "assessment": null,
       "properties": {
-        "progression": "Building an App",
         "level_keys": [
           "CSD U6 emotion machine 3_2021"
-        ]
+        ],
+        "progression": "Building an App"
       },
       "named_level": null,
       "bonus": null,
@@ -3771,10 +3771,10 @@
       "activity_section_position": 4,
       "assessment": true,
       "properties": {
-        "progression": "Building an App",
         "level_keys": [
           "CSD U6 emotion machine 4_2021"
-        ]
+        ],
+        "progression": "Building an App"
       },
       "named_level": null,
       "bonus": null,
@@ -3797,10 +3797,10 @@
       "activity_section_position": 1,
       "assessment": null,
       "properties": {
-        "progression": "Hardware and Software",
         "level_keys": [
           "CSD U6 hardware software video_2021"
-        ]
+        ],
+        "progression": "Hardware and Software"
       },
       "named_level": null,
       "bonus": null,
@@ -3823,10 +3823,10 @@
       "activity_section_position": 1,
       "assessment": null,
       "properties": {
-        "progression": "Using the LED",
         "level_keys": [
           "CSDU6 Circuit Playground Test_2021"
-        ]
+        ],
+        "progression": "Using the LED"
       },
       "named_level": null,
       "bonus": null,
@@ -3849,10 +3849,10 @@
       "activity_section_position": 2,
       "assessment": null,
       "properties": {
-        "progression": "Using the LED",
         "level_keys": [
           "CSD U6 test LED_2021"
-        ]
+        ],
+        "progression": "Using the LED"
       },
       "named_level": null,
       "bonus": null,
@@ -3875,10 +3875,10 @@
       "activity_section_position": 3,
       "assessment": null,
       "properties": {
-        "progression": "Using the LED",
         "level_keys": [
           "CSD U6 predict LED button_2021"
-        ]
+        ],
+        "progression": "Using the LED"
       },
       "named_level": null,
       "bonus": null,
@@ -3901,10 +3901,10 @@
       "activity_section_position": 4,
       "assessment": null,
       "properties": {
-        "progression": "Using the LED",
         "level_keys": [
           "CSD U6 add LED button_2021"
-        ]
+        ],
+        "progression": "Using the LED"
       },
       "named_level": null,
       "bonus": null,
@@ -3927,10 +3927,10 @@
       "activity_section_position": 5,
       "assessment": null,
       "properties": {
-        "progression": "Using the LED",
         "level_keys": [
           "CSD U6 LED toggle_2021"
-        ]
+        ],
+        "progression": "Using the LED"
       },
       "named_level": null,
       "bonus": null,
@@ -3953,10 +3953,10 @@
       "activity_section_position": 6,
       "assessment": true,
       "properties": {
-        "progression": "Using the LED",
         "level_keys": [
           "CSD U6 LED all_2021"
-        ]
+        ],
+        "progression": "Using the LED"
       },
       "named_level": null,
       "bonus": null,
@@ -3979,10 +3979,10 @@
       "activity_section_position": 1,
       "assessment": null,
       "properties": {
-        "progression": "LED Apps",
         "level_keys": [
           "CSD U6 LED create intro_2021"
-        ]
+        ],
+        "progression": "LED Apps"
       },
       "named_level": null,
       "bonus": null,
@@ -4005,10 +4005,10 @@
       "activity_section_position": 2,
       "assessment": null,
       "properties": {
-        "progression": "LED Apps",
         "level_keys": [
           "CSD U6 light show_2021"
-        ]
+        ],
+        "progression": "LED Apps"
       },
       "named_level": null,
       "bonus": null,
@@ -4031,10 +4031,10 @@
       "activity_section_position": 3,
       "assessment": null,
       "properties": {
-        "progression": "LED Apps",
         "level_keys": [
           "CSD U6 Catch the Mouse_2021"
-        ]
+        ],
+        "progression": "LED Apps"
       },
       "named_level": null,
       "bonus": null,
@@ -4057,10 +4057,10 @@
       "activity_section_position": 4,
       "assessment": null,
       "properties": {
-        "progression": "LED Apps",
         "level_keys": [
           "CSD U6 create LED app_2021"
-        ]
+        ],
+        "progression": "LED Apps"
       },
       "named_level": null,
       "bonus": null,
@@ -4083,10 +4083,10 @@
       "activity_section_position": 5,
       "assessment": true,
       "properties": {
-        "progression": "LED Apps",
         "level_keys": [
           "CSD U6 create LED app 2_2021"
-        ]
+        ],
+        "progression": "LED Apps"
       },
       "named_level": null,
       "bonus": null,
@@ -4109,10 +4109,10 @@
       "activity_section_position": 1,
       "assessment": null,
       "properties": {
-        "progression": "Input Examples",
         "level_keys": [
           "CSDU6 GameLab Input 1_2021"
-        ]
+        ],
+        "progression": "Input Examples"
       },
       "named_level": null,
       "bonus": null,
@@ -4135,10 +4135,10 @@
       "activity_section_position": 2,
       "assessment": null,
       "properties": {
-        "progression": "Input Examples",
         "level_keys": [
           "CSDU6 AppLab Input 1_2021"
-        ]
+        ],
+        "progression": "Input Examples"
       },
       "named_level": null,
       "bonus": null,
@@ -4161,10 +4161,10 @@
       "activity_section_position": 1,
       "assessment": null,
       "properties": {
-        "progression": "Board Events",
         "level_keys": [
           "CSDU6 - button LED prediction_2021"
-        ]
+        ],
+        "progression": "Board Events"
       },
       "named_level": null,
       "bonus": null,
@@ -4187,10 +4187,10 @@
       "activity_section_position": 2,
       "assessment": null,
       "properties": {
-        "progression": "Board Events",
         "level_keys": [
           "CSDU6 - LED buttonL_2021"
-        ]
+        ],
+        "progression": "Board Events"
       },
       "named_level": null,
       "bonus": null,
@@ -4213,10 +4213,10 @@
       "activity_section_position": 3,
       "assessment": true,
       "properties": {
-        "progression": "Board Events",
         "level_keys": [
           "CSDU6 - LED toggle buttonL up_2021"
-        ]
+        ],
+        "progression": "Board Events"
       },
       "named_level": null,
       "bonus": null,
@@ -4239,10 +4239,10 @@
       "activity_section_position": 1,
       "assessment": null,
       "properties": {
-        "progression": "Using the Switch",
         "level_keys": [
           "CSDU6 - lightswitch toggleswitch_2021"
-        ]
+        ],
+        "progression": "Using the Switch"
       },
       "named_level": null,
       "bonus": null,
@@ -4265,10 +4265,10 @@
       "activity_section_position": 2,
       "assessment": null,
       "properties": {
-        "progression": "Using the Switch",
         "level_keys": [
           "CSDU6 - toggle state LED prediction_2021"
-        ]
+        ],
+        "progression": "Using the Switch"
       },
       "named_level": null,
       "bonus": null,
@@ -4291,10 +4291,10 @@
       "activity_section_position": 3,
       "assessment": null,
       "properties": {
-        "progression": "Using the Switch",
         "level_keys": [
           "CSDU6 - toggleswitch state setProp_2021"
-        ]
+        ],
+        "progression": "Using the Switch"
       },
       "named_level": null,
       "bonus": null,
@@ -4317,10 +4317,10 @@
       "activity_section_position": 1,
       "assessment": null,
       "properties": {
-        "progression": "The Buzzer",
         "level_keys": [
           "CSDU6 - buzzer intro_2021"
-        ]
+        ],
+        "progression": "The Buzzer"
       },
       "named_level": null,
       "bonus": null,
@@ -4343,10 +4343,10 @@
       "activity_section_position": 2,
       "assessment": null,
       "properties": {
-        "progression": "The Buzzer",
         "level_keys": [
           "CSDU6 - buzzer duration_2021"
-        ]
+        ],
+        "progression": "The Buzzer"
       },
       "named_level": null,
       "bonus": null,
@@ -4369,10 +4369,10 @@
       "activity_section_position": 3,
       "assessment": null,
       "properties": {
-        "progression": "The Buzzer",
         "level_keys": [
           "CSDU6 - buzzer duration buttons_2021"
-        ]
+        ],
+        "progression": "The Buzzer"
       },
       "named_level": null,
       "bonus": null,
@@ -4395,10 +4395,10 @@
       "activity_section_position": 1,
       "assessment": null,
       "properties": {
-        "progression": "Extra Challenge: Sound Board",
         "level_keys": [
           "CSDU6 - board event challenge_2021"
-        ]
+        ],
+        "progression": "Extra Challenge: Sound Board"
       },
       "named_level": null,
       "bonus": true,
@@ -4421,10 +4421,10 @@
       "activity_section_position": 1,
       "assessment": null,
       "properties": {
-        "progression": "Getting Properties",
         "level_keys": [
           "CSD U6 getProperty Demo_2021"
-        ]
+        ],
+        "progression": "Getting Properties"
       },
       "named_level": null,
       "bonus": null,
@@ -4447,10 +4447,10 @@
       "activity_section_position": 2,
       "assessment": null,
       "properties": {
-        "progression": "Getting Properties",
         "level_keys": [
           "CSD U6 getProperty input_2021"
-        ]
+        ],
+        "progression": "Getting Properties"
       },
       "named_level": null,
       "bonus": null,
@@ -4473,10 +4473,10 @@
       "activity_section_position": 3,
       "assessment": null,
       "properties": {
-        "progression": "Getting Properties",
         "level_keys": [
           "CSD U6 getProperty dropdown_2021"
-        ]
+        ],
+        "progression": "Getting Properties"
       },
       "named_level": null,
       "bonus": null,
@@ -4499,10 +4499,10 @@
       "activity_section_position": 4,
       "assessment": null,
       "properties": {
-        "progression": "Getting Properties",
         "level_keys": [
           "CSD U6 getProperty board predict_2021"
-        ]
+        ],
+        "progression": "Getting Properties"
       },
       "named_level": null,
       "bonus": null,
@@ -4525,10 +4525,10 @@
       "activity_section_position": 5,
       "assessment": true,
       "properties": {
-        "progression": "Getting Properties",
         "level_keys": [
           "CSD U6 getProperty buzzer_2021"
-        ]
+        ],
+        "progression": "Getting Properties"
       },
       "named_level": null,
       "bonus": null,
@@ -4551,10 +4551,10 @@
       "activity_section_position": 1,
       "assessment": null,
       "properties": {
-        "progression": "Sliders",
         "level_keys": [
           "CSD U6 slider intro_2021"
-        ]
+        ],
+        "progression": "Sliders"
       },
       "named_level": null,
       "bonus": null,
@@ -4577,10 +4577,10 @@
       "activity_section_position": 2,
       "assessment": null,
       "properties": {
-        "progression": "Sliders",
         "level_keys": [
           "CSD U6 frequency_2021"
-        ]
+        ],
+        "progression": "Sliders"
       },
       "named_level": null,
       "bonus": null,
@@ -4603,10 +4603,10 @@
       "activity_section_position": 3,
       "assessment": null,
       "properties": {
-        "progression": "Sliders",
         "level_keys": [
           "CSD U6 interval_2021"
-        ]
+        ],
+        "progression": "Sliders"
       },
       "named_level": null,
       "bonus": null,
@@ -4629,10 +4629,10 @@
       "activity_section_position": 1,
       "assessment": null,
       "properties": {
-        "progression": "Change",
         "level_keys": [
           "CSD U6 change_2021"
-        ]
+        ],
+        "progression": "Change"
       },
       "named_level": null,
       "bonus": null,
@@ -4655,10 +4655,10 @@
       "activity_section_position": 2,
       "assessment": null,
       "properties": {
-        "progression": "Change",
         "level_keys": [
           "CSD U6 get toggle_2021"
-        ]
+        ],
+        "progression": "Change"
       },
       "named_level": null,
       "bonus": null,
@@ -4681,10 +4681,10 @@
       "activity_section_position": 3,
       "assessment": null,
       "properties": {
-        "progression": "Change",
         "level_keys": [
           "CSD U6 getters debug_2021"
-        ]
+        ],
+        "progression": "Change"
       },
       "named_level": null,
       "bonus": null,
@@ -4707,10 +4707,10 @@
       "activity_section_position": 1,
       "assessment": null,
       "properties": {
-        "progression": "Motorcycle",
         "level_keys": [
           "CSD U6 move motorcycle_2021"
-        ]
+        ],
+        "progression": "Motorcycle"
       },
       "named_level": null,
       "bonus": null,
@@ -4733,10 +4733,10 @@
       "activity_section_position": 2,
       "assessment": null,
       "properties": {
-        "progression": "Motorcycle",
         "level_keys": [
           "CSD U6 design motorcycle_2021"
-        ]
+        ],
+        "progression": "Motorcycle"
       },
       "named_level": null,
       "bonus": null,
@@ -4759,10 +4759,10 @@
       "activity_section_position": 1,
       "assessment": null,
       "properties": {
-        "progression": "Extra Challenge",
         "level_keys": [
           "CSD U6 challenge motorcycle_2021"
-        ]
+        ],
+        "progression": "Extra Challenge"
       },
       "named_level": null,
       "bonus": true,
@@ -4785,10 +4785,10 @@
       "activity_section_position": 1,
       "assessment": null,
       "properties": {
-        "progression": "Sensor Experiment",
         "level_keys": [
           "CSD U6 sensor experiment embedded_2021"
-        ]
+        ],
+        "progression": "Sensor Experiment"
       },
       "named_level": null,
       "bonus": null,
@@ -4811,10 +4811,10 @@
       "activity_section_position": 1,
       "assessment": null,
       "properties": {
-        "progression": "Reading Sensors",
         "level_keys": [
           "CSD U6 analog sound_2021"
-        ]
+        ],
+        "progression": "Reading Sensors"
       },
       "named_level": null,
       "bonus": null,
@@ -4837,10 +4837,10 @@
       "activity_section_position": 2,
       "assessment": null,
       "properties": {
-        "progression": "Reading Sensors",
         "level_keys": [
           "CSD U6 analog light_2021"
-        ]
+        ],
+        "progression": "Reading Sensors"
       },
       "named_level": null,
       "bonus": null,
@@ -4863,10 +4863,10 @@
       "activity_section_position": 3,
       "assessment": null,
       "properties": {
-        "progression": "Reading Sensors",
         "level_keys": [
           "CSD U6 analog temp_2021"
-        ]
+        ],
+        "progression": "Reading Sensors"
       },
       "named_level": null,
       "bonus": null,
@@ -4889,10 +4889,10 @@
       "activity_section_position": 1,
       "assessment": null,
       "properties": {
-        "progression": "Sensor Events",
         "level_keys": [
           "CSD U6 analog predict_2021"
-        ]
+        ],
+        "progression": "Sensor Events"
       },
       "named_level": null,
       "bonus": null,
@@ -4915,10 +4915,10 @@
       "activity_section_position": 2,
       "assessment": null,
       "properties": {
-        "progression": "Sensor Events",
         "level_keys": [
           "CSD U6 analog data_2021"
-        ]
+        ],
+        "progression": "Sensor Events"
       },
       "named_level": null,
       "bonus": null,
@@ -4941,10 +4941,10 @@
       "activity_section_position": 3,
       "assessment": null,
       "properties": {
-        "progression": "Sensor Events",
         "level_keys": [
           "CSD U6 analog change_2021"
-        ]
+        ],
+        "progression": "Sensor Events"
       },
       "named_level": null,
       "bonus": null,
@@ -4967,10 +4967,10 @@
       "activity_section_position": 4,
       "assessment": null,
       "properties": {
-        "progression": "Sensor Events",
         "level_keys": [
           "CSD U6 analog threshold_2021"
-        ]
+        ],
+        "progression": "Sensor Events"
       },
       "named_level": null,
       "bonus": null,
@@ -4993,10 +4993,10 @@
       "activity_section_position": 1,
       "assessment": null,
       "properties": {
-        "progression": "Sensors to Colors",
         "level_keys": [
           "CSD U6 analog rbg 1_2021"
-        ]
+        ],
+        "progression": "Sensors to Colors"
       },
       "named_level": null,
       "bonus": null,
@@ -5019,10 +5019,10 @@
       "activity_section_position": 2,
       "assessment": null,
       "properties": {
-        "progression": "Sensors to Colors",
         "level_keys": [
           "CSD U6 analog rbg 2_2021"
-        ]
+        ],
+        "progression": "Sensors to Colors"
       },
       "named_level": null,
       "bonus": null,
@@ -5045,10 +5045,10 @@
       "activity_section_position": 3,
       "assessment": true,
       "properties": {
-        "progression": "Sensors to Colors",
         "level_keys": [
           "CSD U6 analog rgb 3_2021"
-        ]
+        ],
+        "progression": "Sensors to Colors"
       },
       "named_level": null,
       "bonus": null,
@@ -5071,10 +5071,10 @@
       "activity_section_position": 1,
       "assessment": null,
       "properties": {
-        "progression": "Extra Challenge",
         "level_keys": [
           "CSD U6 analog challenge_2021"
-        ]
+        ],
+        "progression": "Extra Challenge"
       },
       "named_level": null,
       "bonus": true,
@@ -5097,10 +5097,10 @@
       "activity_section_position": 1,
       "assessment": null,
       "properties": {
-        "progression": "Sample Program",
         "level_keys": [
           "CSD U6 emoji race demo_2021"
-        ]
+        ],
+        "progression": "Sample Program"
       },
       "named_level": null,
       "bonus": null,
@@ -5123,10 +5123,10 @@
       "activity_section_position": 1,
       "assessment": null,
       "properties": {
-        "progression": "Plan Your Project",
         "level_keys": [
           "CSD U6 tugowar stop_2021"
-        ]
+        ],
+        "progression": "Plan Your Project"
       },
       "named_level": null,
       "bonus": null,
@@ -5149,10 +5149,10 @@
       "activity_section_position": 1,
       "assessment": null,
       "properties": {
-        "progression": "Screen Design",
         "level_keys": [
           "CSD U6 tugowar design 1_2021"
-        ]
+        ],
+        "progression": "Screen Design"
       },
       "named_level": null,
       "bonus": null,
@@ -5175,10 +5175,10 @@
       "activity_section_position": 2,
       "assessment": null,
       "properties": {
-        "progression": "Screen Design",
         "level_keys": [
           "CSD U6 tugowar design 1.5_2021"
-        ]
+        ],
+        "progression": "Screen Design"
       },
       "named_level": null,
       "bonus": null,
@@ -5201,10 +5201,10 @@
       "activity_section_position": 3,
       "assessment": null,
       "properties": {
-        "progression": "Screen Design",
         "level_keys": [
           "CSD U6 tugowar design 2_2021"
-        ]
+        ],
+        "progression": "Screen Design"
       },
       "named_level": null,
       "bonus": null,
@@ -5227,10 +5227,10 @@
       "activity_section_position": 1,
       "assessment": null,
       "properties": {
-        "progression": "Finishing Functions",
         "level_keys": [
           "CSD U6 tugowar variables 1_2021"
-        ]
+        ],
+        "progression": "Finishing Functions"
       },
       "named_level": null,
       "bonus": null,
@@ -5253,10 +5253,10 @@
       "activity_section_position": 2,
       "assessment": null,
       "properties": {
-        "progression": "Finishing Functions",
         "level_keys": [
           "CSD U6 tugowar variables 2_2021"
-        ]
+        ],
+        "progression": "Finishing Functions"
       },
       "named_level": null,
       "bonus": null,
@@ -5279,10 +5279,10 @@
       "activity_section_position": 3,
       "assessment": null,
       "properties": {
-        "progression": "Finishing Functions",
         "level_keys": [
           "CSD U6 tugowar variables 3_2021"
-        ]
+        ],
+        "progression": "Finishing Functions"
       },
       "named_level": null,
       "bonus": null,
@@ -5305,10 +5305,10 @@
       "activity_section_position": 1,
       "assessment": null,
       "properties": {
-        "progression": "Checking for a Winner",
         "level_keys": [
           "CSD U6 tugowar conditional_2021"
-        ]
+        ],
+        "progression": "Checking for a Winner"
       },
       "named_level": null,
       "bonus": null,
@@ -5331,10 +5331,10 @@
       "activity_section_position": 2,
       "assessment": null,
       "properties": {
-        "progression": "Checking for a Winner",
         "level_keys": [
           "CSD U6 tugowar setScreen_2021"
-        ]
+        ],
+        "progression": "Checking for a Winner"
       },
       "named_level": null,
       "bonus": null,
@@ -5357,10 +5357,10 @@
       "activity_section_position": 3,
       "assessment": null,
       "properties": {
-        "progression": "Checking for a Winner",
         "level_keys": [
           "CSD U6 tugowar setProperty_2021"
-        ]
+        ],
+        "progression": "Checking for a Winner"
       },
       "named_level": null,
       "bonus": null,
@@ -5383,10 +5383,10 @@
       "activity_section_position": 4,
       "assessment": true,
       "properties": {
-        "progression": "Checking for a Winner",
         "level_keys": [
           "CSD U6 tugowar buzzer_2021"
-        ]
+        ],
+        "progression": "Checking for a Winner"
       },
       "named_level": null,
       "bonus": null,
@@ -5409,10 +5409,10 @@
       "activity_section_position": 1,
       "assessment": null,
       "properties": {
-        "progression": "Make it Your Own",
         "level_keys": [
           "CSD U6 tugowar final_2021"
-        ]
+        ],
+        "progression": "Make it Your Own"
       },
       "named_level": null,
       "bonus": null,
@@ -5435,10 +5435,10 @@
       "activity_section_position": 1,
       "assessment": null,
       "properties": {
-        "progression": "Demo - Bug Grab",
         "level_keys": [
           "CSD U6 tugowar demo_2021"
-        ]
+        ],
+        "progression": "Demo - Bug Grab"
       },
       "named_level": null,
       "bonus": null,
@@ -5461,10 +5461,10 @@
       "activity_section_position": 1,
       "assessment": null,
       "properties": {
-        "progression": "Plan Your Project",
         "level_keys": [
           "CSD U6 game project stop_2021"
-        ]
+        ],
+        "progression": "Plan Your Project"
       },
       "named_level": null,
       "bonus": null,
@@ -5487,10 +5487,10 @@
       "activity_section_position": 1,
       "assessment": null,
       "properties": {
-        "progression": "Screen Design",
         "level_keys": [
           "CSD U6 game project screens_2021"
-        ]
+        ],
+        "progression": "Screen Design"
       },
       "named_level": null,
       "bonus": null,
@@ -5513,10 +5513,10 @@
       "activity_section_position": 1,
       "assessment": null,
       "properties": {
-        "progression": "Events",
         "level_keys": [
           "CSD U6 game project screen links_2021"
-        ]
+        ],
+        "progression": "Events"
       },
       "named_level": null,
       "bonus": null,
@@ -5539,10 +5539,10 @@
       "activity_section_position": 2,
       "assessment": null,
       "properties": {
-        "progression": "Events",
         "level_keys": [
           "CSD U6 game project board events_2021"
-        ]
+        ],
+        "progression": "Events"
       },
       "named_level": null,
       "bonus": null,
@@ -5565,10 +5565,10 @@
       "activity_section_position": 1,
       "assessment": null,
       "properties": {
-        "progression": "Functions",
         "level_keys": [
           "CSD U6 game project functions define_2021"
-        ]
+        ],
+        "progression": "Functions"
       },
       "named_level": null,
       "bonus": null,
@@ -5591,10 +5591,10 @@
       "activity_section_position": 2,
       "assessment": null,
       "properties": {
-        "progression": "Functions",
         "level_keys": [
           "CSD U6 game project functions call_2021"
-        ]
+        ],
+        "progression": "Functions"
       },
       "named_level": null,
       "bonus": null,
@@ -5617,10 +5617,10 @@
       "activity_section_position": 1,
       "assessment": null,
       "properties": {
-        "progression": "Finishing Touches",
         "level_keys": [
           "CSD U6 game project finish_2021"
-        ]
+        ],
+        "progression": "Finishing Touches"
       },
       "named_level": null,
       "bonus": null,
@@ -5643,10 +5643,10 @@
       "activity_section_position": 1,
       "assessment": true,
       "properties": {
-        "progression": "Reflection",
         "level_keys": [
           "csd-pulse-check-survey-1-levelgroup U6Ch1_2021"
-        ]
+        ],
+        "progression": "Reflection"
       },
       "named_level": null,
       "bonus": null,
@@ -5669,10 +5669,10 @@
       "activity_section_position": 1,
       "assessment": null,
       "properties": {
-        "progression": "Video: Introduction to Arrays",
         "level_keys": [
           "CSD U6 arrays video_2021"
-        ]
+        ],
+        "progression": "Video: Introduction to Arrays"
       },
       "named_level": null,
       "bonus": null,
@@ -5695,10 +5695,10 @@
       "activity_section_position": 1,
       "assessment": null,
       "properties": {
-        "progression": "Introduction to Arrays",
         "level_keys": [
           "CSD U6 arrays select predict_2021"
-        ]
+        ],
+        "progression": "Introduction to Arrays"
       },
       "named_level": null,
       "bonus": null,
@@ -5721,10 +5721,10 @@
       "activity_section_position": 2,
       "assessment": null,
       "properties": {
-        "progression": "Introduction to Arrays",
         "level_keys": [
           "CSDU6 arrays select rainbow_2021"
-        ]
+        ],
+        "progression": "Introduction to Arrays"
       },
       "named_level": null,
       "bonus": null,
@@ -5747,10 +5747,10 @@
       "activity_section_position": 3,
       "assessment": null,
       "properties": {
-        "progression": "Introduction to Arrays",
         "level_keys": [
           "CSDU6 array select days_2021"
-        ]
+        ],
+        "progression": "Introduction to Arrays"
       },
       "named_level": null,
       "bonus": null,
@@ -5773,10 +5773,10 @@
       "activity_section_position": 4,
       "assessment": null,
       "properties": {
-        "progression": "Introduction to Arrays",
         "level_keys": [
           "CSDU6 arrays select random_2021"
-        ]
+        ],
+        "progression": "Introduction to Arrays"
       },
       "named_level": null,
       "bonus": null,
@@ -5799,10 +5799,10 @@
       "activity_section_position": 5,
       "assessment": true,
       "properties": {
-        "progression": "Introduction to Arrays",
         "level_keys": [
           "CSDU6 arrays select variable_2021"
-        ]
+        ],
+        "progression": "Introduction to Arrays"
       },
       "named_level": null,
       "bonus": null,
@@ -5825,10 +5825,10 @@
       "activity_section_position": 1,
       "assessment": true,
       "properties": {
-        "progression": "Using Arrays",
         "level_keys": [
           "CSD U6 array multi_2021"
-        ]
+        ],
+        "progression": "Using Arrays"
       },
       "named_level": null,
       "bonus": null,
@@ -5851,10 +5851,10 @@
       "activity_section_position": 1,
       "assessment": null,
       "properties": {
-        "progression": "Color LEDs",
         "level_keys": [
           "CSD U6 colorLeds predict_2021"
-        ]
+        ],
+        "progression": "Color LEDs"
       },
       "named_level": null,
       "bonus": null,
@@ -5877,10 +5877,10 @@
       "activity_section_position": 2,
       "assessment": null,
       "properties": {
-        "progression": "Color LEDs",
         "level_keys": [
           "CSD U6 colorLED on_2021"
-        ]
+        ],
+        "progression": "Color LEDs"
       },
       "named_level": null,
       "bonus": null,
@@ -5903,10 +5903,10 @@
       "activity_section_position": 3,
       "assessment": null,
       "properties": {
-        "progression": "Color LEDs",
         "level_keys": [
           "CSD U6 LEDs color_2021"
-        ]
+        ],
+        "progression": "Color LEDs"
       },
       "named_level": null,
       "bonus": null,
@@ -5929,10 +5929,10 @@
       "activity_section_position": 4,
       "assessment": null,
       "properties": {
-        "progression": "Color LEDs",
         "level_keys": [
           "CSD U6 colorLeds debug_2021"
-        ]
+        ],
+        "progression": "Color LEDs"
       },
       "named_level": null,
       "bonus": null,
@@ -5955,10 +5955,10 @@
       "activity_section_position": 5,
       "assessment": null,
       "properties": {
-        "progression": "Color LEDs",
         "level_keys": [
           "CSD U6 colorLeds intensity_2021"
-        ]
+        ],
+        "progression": "Color LEDs"
       },
       "named_level": null,
       "bonus": null,
@@ -5981,10 +5981,10 @@
       "activity_section_position": 1,
       "assessment": null,
       "properties": {
-        "progression": "Light Show",
         "level_keys": [
           "CSD U6 colorLeds light pattern_2021"
-        ]
+        ],
+        "progression": "Light Show"
       },
       "named_level": null,
       "bonus": null,
@@ -6007,10 +6007,10 @@
       "activity_section_position": 2,
       "assessment": true,
       "properties": {
-        "progression": "Light Show",
         "level_keys": [
           "CSD U6 light pattern off_2021"
-        ]
+        ],
+        "progression": "Light Show"
       },
       "named_level": null,
       "bonus": null,
@@ -6033,10 +6033,10 @@
       "activity_section_position": 1,
       "assessment": null,
       "properties": {
-        "progression": "Challenge Levels",
         "level_keys": [
           "CSD U6 light pattern challenge_2021"
-        ]
+        ],
+        "progression": "Challenge Levels"
       },
       "named_level": null,
       "bonus": true,
@@ -6059,10 +6059,10 @@
       "activity_section_position": 1,
       "assessment": null,
       "properties": {
-        "progression": "Playing Notes",
         "level_keys": [
           "CSDU6 circuit playground piano_2021"
-        ]
+        ],
+        "progression": "Playing Notes"
       },
       "named_level": null,
       "bonus": null,
@@ -6085,10 +6085,10 @@
       "activity_section_position": 2,
       "assessment": null,
       "properties": {
-        "progression": "Playing Notes",
         "level_keys": [
           "CSDU6 frequency modification_2021"
-        ]
+        ],
+        "progression": "Playing Notes"
       },
       "named_level": null,
       "bonus": null,
@@ -6111,10 +6111,10 @@
       "activity_section_position": 3,
       "assessment": null,
       "properties": {
-        "progression": "Playing Notes",
         "level_keys": [
           "CSDU6 frequency creation_2021"
-        ]
+        ],
+        "progression": "Playing Notes"
       },
       "named_level": null,
       "bonus": null,
@@ -6137,10 +6137,10 @@
       "activity_section_position": 4,
       "assessment": null,
       "properties": {
-        "progression": "Playing Notes",
         "level_keys": [
           "CSDU6 piano with notes_2021"
-        ]
+        ],
+        "progression": "Playing Notes"
       },
       "named_level": null,
       "bonus": null,
@@ -6163,10 +6163,10 @@
       "activity_section_position": 1,
       "assessment": null,
       "properties": {
-        "progression": "Musical Arrays",
         "level_keys": [
           "CSD U6 array piano_2021"
-        ]
+        ],
+        "progression": "Musical Arrays"
       },
       "named_level": null,
       "bonus": null,
@@ -6189,10 +6189,10 @@
       "activity_section_position": 2,
       "assessment": null,
       "properties": {
-        "progression": "Musical Arrays",
         "level_keys": [
           "CSD U6 random array notes_2021"
-        ]
+        ],
+        "progression": "Musical Arrays"
       },
       "named_level": null,
       "bonus": null,
@@ -6215,10 +6215,10 @@
       "activity_section_position": 3,
       "assessment": true,
       "properties": {
-        "progression": "Musical Arrays",
         "level_keys": [
           "CSDU6 making new arrays_2021"
-        ]
+        ],
+        "progression": "Musical Arrays"
       },
       "named_level": null,
       "bonus": null,
@@ -6241,10 +6241,10 @@
       "activity_section_position": 1,
       "assessment": null,
       "properties": {
-        "progression": "Making Songs",
         "level_keys": [
           "CSDU6 play predict code_2021"
-        ]
+        ],
+        "progression": "Making Songs"
       },
       "named_level": null,
       "bonus": null,
@@ -6267,10 +6267,10 @@
       "activity_section_position": 2,
       "assessment": null,
       "properties": {
-        "progression": "Making Songs",
         "level_keys": [
           "CSDU6 play songs_2021"
-        ]
+        ],
+        "progression": "Making Songs"
       },
       "named_level": null,
       "bonus": null,
@@ -6293,10 +6293,10 @@
       "activity_section_position": 3,
       "assessment": null,
       "properties": {
-        "progression": "Making Songs",
         "level_keys": [
           "CSDU6 play null notes_2021"
-        ]
+        ],
+        "progression": "Making Songs"
       },
       "named_level": null,
       "bonus": null,
@@ -6319,10 +6319,10 @@
       "activity_section_position": 4,
       "assessment": true,
       "properties": {
-        "progression": "Making Songs",
         "level_keys": [
           "CDU U6 Playground Sound Board_2021"
-        ]
+        ],
+        "progression": "Making Songs"
       },
       "named_level": null,
       "bonus": null,
@@ -6345,10 +6345,10 @@
       "activity_section_position": 1,
       "assessment": null,
       "properties": {
-        "progression": "Extra",
         "level_keys": [
           "CSDU6 buzzer 2d arrays_2021"
-        ]
+        ],
+        "progression": "Extra"
       },
       "named_level": null,
       "bonus": true,
@@ -6371,10 +6371,10 @@
       "activity_section_position": 2,
       "assessment": null,
       "properties": {
-        "progression": "Extra",
         "level_keys": [
           "CSDU6 buzzer.stop_2021"
-        ]
+        ],
+        "progression": "Extra"
       },
       "named_level": null,
       "bonus": true,
@@ -6397,10 +6397,10 @@
       "activity_section_position": 1,
       "assessment": null,
       "properties": {
-        "progression": "Programs that Repeat",
         "level_keys": [
           "CSD U6 for loop click predict_2021"
-        ]
+        ],
+        "progression": "Programs that Repeat"
       },
       "named_level": null,
       "bonus": null,
@@ -6423,10 +6423,10 @@
       "activity_section_position": 2,
       "assessment": null,
       "properties": {
-        "progression": "Programs that Repeat",
         "level_keys": [
           "CSD U6 for loop click exit_2021"
-        ]
+        ],
+        "progression": "Programs that Repeat"
       },
       "named_level": null,
       "bonus": null,
@@ -6449,10 +6449,10 @@
       "activity_section_position": 1,
       "assessment": null,
       "properties": {
-        "progression": "Video: For Loops",
         "level_keys": [
           "CSD: For Loop_2021"
-        ]
+        ],
+        "progression": "Video: For Loops"
       },
       "named_level": null,
       "bonus": null,
@@ -6475,10 +6475,10 @@
       "activity_section_position": 1,
       "assessment": null,
       "properties": {
-        "progression": "For Loops",
         "level_keys": [
           "CSDU6 - for loop - predict print_2021"
-        ]
+        ],
+        "progression": "For Loops"
       },
       "named_level": null,
       "bonus": null,
@@ -6501,10 +6501,10 @@
       "activity_section_position": 2,
       "assessment": null,
       "properties": {
-        "progression": "For Loops",
         "level_keys": [
           "CSD U6 for loop button array_2021"
-        ]
+        ],
+        "progression": "For Loops"
       },
       "named_level": null,
       "bonus": null,
@@ -6527,10 +6527,10 @@
       "activity_section_position": 3,
       "assessment": null,
       "properties": {
-        "progression": "For Loops",
         "level_keys": [
           "CSD U6 for loop list.length_2021"
-        ]
+        ],
+        "progression": "For Loops"
       },
       "named_level": null,
       "bonus": null,
@@ -6553,10 +6553,10 @@
       "activity_section_position": 4,
       "assessment": null,
       "properties": {
-        "progression": "For Loops",
         "level_keys": [
           "CSD U6 for loop images_2021"
-        ]
+        ],
+        "progression": "For Loops"
       },
       "named_level": null,
       "bonus": null,
@@ -6579,10 +6579,10 @@
       "activity_section_position": 5,
       "assessment": null,
       "properties": {
-        "progression": "For Loops",
         "level_keys": [
           "CSD U6 for loop map_2021"
-        ]
+        ],
+        "progression": "For Loops"
       },
       "named_level": null,
       "bonus": null,
@@ -6605,10 +6605,10 @@
       "activity_section_position": 1,
       "assessment": null,
       "properties": {
-        "progression": "For Loops and Color LEDs",
         "level_keys": [
           "CSD U6 for loop led on_2021"
-        ]
+        ],
+        "progression": "For Loops and Color LEDs"
       },
       "named_level": null,
       "bonus": null,
@@ -6631,10 +6631,10 @@
       "activity_section_position": 2,
       "assessment": null,
       "properties": {
-        "progression": "For Loops and Color LEDs",
         "level_keys": [
           "CSD U6 for loop led off_2021"
-        ]
+        ],
+        "progression": "For Loops and Color LEDs"
       },
       "named_level": null,
       "bonus": null,
@@ -6657,10 +6657,10 @@
       "activity_section_position": 3,
       "assessment": null,
       "properties": {
-        "progression": "For Loops and Color LEDs",
         "level_keys": [
           "CSD U6 for loop led color_2021"
-        ]
+        ],
+        "progression": "For Loops and Color LEDs"
       },
       "named_level": null,
       "bonus": null,
@@ -6683,10 +6683,10 @@
       "activity_section_position": 4,
       "assessment": true,
       "properties": {
-        "progression": "For Loops and Color LEDs",
         "level_keys": [
           "CSD U6 for loop led personalize_2021"
-        ]
+        ],
+        "progression": "For Loops and Color LEDs"
       },
       "named_level": null,
       "bonus": null,
@@ -6709,10 +6709,10 @@
       "activity_section_position": 1,
       "assessment": null,
       "properties": {
-        "progression": "Orientation",
         "level_keys": [
           "CSD U6 Airplane predict_2021"
-        ]
+        ],
+        "progression": "Orientation"
       },
       "named_level": null,
       "bonus": null,
@@ -6735,10 +6735,10 @@
       "activity_section_position": 2,
       "assessment": null,
       "properties": {
-        "progression": "Orientation",
         "level_keys": [
           "CSD U6 investigate orientation_2021"
-        ]
+        ],
+        "progression": "Orientation"
       },
       "named_level": null,
       "bonus": null,
@@ -6761,10 +6761,10 @@
       "activity_section_position": 3,
       "assessment": null,
       "properties": {
-        "progression": "Orientation",
         "level_keys": [
           "CSD U6 directional leds pitch_2021"
-        ]
+        ],
+        "progression": "Orientation"
       },
       "named_level": null,
       "bonus": null,
@@ -6787,10 +6787,10 @@
       "activity_section_position": 4,
       "assessment": null,
       "properties": {
-        "progression": "Orientation",
         "level_keys": [
           "CSD U6 directional LEDs roll_2021"
-        ]
+        ],
+        "progression": "Orientation"
       },
       "named_level": null,
       "bonus": null,
@@ -6813,10 +6813,10 @@
       "activity_section_position": 1,
       "assessment": null,
       "properties": {
-        "progression": "Accelerometer Events",
         "level_keys": [
           "CSD U6 stillness game predict code_2021"
-        ]
+        ],
+        "progression": "Accelerometer Events"
       },
       "named_level": null,
       "bonus": null,
@@ -6839,10 +6839,10 @@
       "activity_section_position": 2,
       "assessment": null,
       "properties": {
-        "progression": "Accelerometer Events",
         "level_keys": [
           "CSD U6 Pedometer_2021"
-        ]
+        ],
+        "progression": "Accelerometer Events"
       },
       "named_level": null,
       "bonus": null,
@@ -6865,10 +6865,10 @@
       "activity_section_position": 3,
       "assessment": true,
       "properties": {
-        "progression": "Accelerometer Events",
         "level_keys": [
           "CSD U6 goalie_2021"
-        ]
+        ],
+        "progression": "Accelerometer Events"
       },
       "named_level": null,
       "bonus": null,
@@ -6891,10 +6891,10 @@
       "activity_section_position": 4,
       "assessment": null,
       "properties": {
-        "progression": "Accelerometer Events",
         "level_keys": [
           "CSD U6 Driver pt1_2021"
-        ]
+        ],
+        "progression": "Accelerometer Events"
       },
       "named_level": null,
       "bonus": null,
@@ -6917,10 +6917,10 @@
       "activity_section_position": 5,
       "assessment": null,
       "properties": {
-        "progression": "Accelerometer Events",
         "level_keys": [
           "CSD U6 Driver pt 2_2021"
-        ]
+        ],
+        "progression": "Accelerometer Events"
       },
       "named_level": null,
       "bonus": null,
@@ -6943,10 +6943,10 @@
       "activity_section_position": 1,
       "assessment": null,
       "properties": {
-        "progression": "Functions with Parameters",
         "level_keys": [
           "CSD U6 params predict_2021"
-        ]
+        ],
+        "progression": "Functions with Parameters"
       },
       "named_level": null,
       "bonus": null,
@@ -6969,10 +6969,10 @@
       "activity_section_position": 2,
       "assessment": null,
       "properties": {
-        "progression": "Functions with Parameters",
         "level_keys": [
           "CSD U6 functions paramters video_2021"
-        ]
+        ],
+        "progression": "Functions with Parameters"
       },
       "named_level": null,
       "bonus": null,
@@ -6995,10 +6995,10 @@
       "activity_section_position": 3,
       "assessment": null,
       "properties": {
-        "progression": "Functions with Parameters",
         "level_keys": [
           "CSD U6 params modify clouds_2021"
-        ]
+        ],
+        "progression": "Functions with Parameters"
       },
       "named_level": null,
       "bonus": null,
@@ -7021,10 +7021,10 @@
       "activity_section_position": 4,
       "assessment": null,
       "properties": {
-        "progression": "Functions with Parameters",
         "level_keys": [
           "CSD U6 params modify planes_2021"
-        ]
+        ],
+        "progression": "Functions with Parameters"
       },
       "named_level": null,
       "bonus": null,
@@ -7047,10 +7047,10 @@
       "activity_section_position": 5,
       "assessment": null,
       "properties": {
-        "progression": "Functions with Parameters",
         "level_keys": [
           "CSD U6 params create colors_2021"
-        ]
+        ],
+        "progression": "Functions with Parameters"
       },
       "named_level": null,
       "bonus": null,
@@ -7073,10 +7073,10 @@
       "activity_section_position": 1,
       "assessment": null,
       "properties": {
-        "progression": "Iteration and Parameters",
         "level_keys": [
           "CSD U6 iter predict bubbles_2021"
-        ]
+        ],
+        "progression": "Iteration and Parameters"
       },
       "named_level": null,
       "bonus": null,
@@ -7099,10 +7099,10 @@
       "activity_section_position": 2,
       "assessment": null,
       "properties": {
-        "progression": "Iteration and Parameters",
         "level_keys": [
           "CSD U6 iter modify bugs_2021"
-        ]
+        ],
+        "progression": "Iteration and Parameters"
       },
       "named_level": null,
       "bonus": null,
@@ -7125,10 +7125,10 @@
       "activity_section_position": 3,
       "assessment": null,
       "properties": {
-        "progression": "Iteration and Parameters",
         "level_keys": [
           "CSD U6 iter create notes_2021"
-        ]
+        ],
+        "progression": "Iteration and Parameters"
       },
       "named_level": null,
       "bonus": null,
@@ -7151,10 +7151,10 @@
       "activity_section_position": 1,
       "assessment": null,
       "properties": {
-        "progression": "Star Chaser",
         "level_keys": [
           "CSD U6 params starchaser intro_2021"
-        ]
+        ],
+        "progression": "Star Chaser"
       },
       "named_level": null,
       "bonus": null,
@@ -7177,10 +7177,10 @@
       "activity_section_position": 2,
       "assessment": null,
       "properties": {
-        "progression": "Star Chaser",
         "level_keys": [
           "CSD U6 params starchaser 1_2021"
-        ]
+        ],
+        "progression": "Star Chaser"
       },
       "named_level": null,
       "bonus": null,
@@ -7203,10 +7203,10 @@
       "activity_section_position": 3,
       "assessment": null,
       "properties": {
-        "progression": "Star Chaser",
         "level_keys": [
           "CSD U6 params starchaser 2_2021"
-        ]
+        ],
+        "progression": "Star Chaser"
       },
       "named_level": null,
       "bonus": null,
@@ -7229,10 +7229,10 @@
       "activity_section_position": 4,
       "assessment": null,
       "properties": {
-        "progression": "Star Chaser",
         "level_keys": [
           "CSD U6 params starchaser 3_2021"
-        ]
+        ],
+        "progression": "Star Chaser"
       },
       "named_level": null,
       "bonus": null,
@@ -7255,10 +7255,10 @@
       "activity_section_position": 5,
       "assessment": null,
       "properties": {
-        "progression": "Star Chaser",
         "level_keys": [
           "CSD U6 params starchaser 4_2021"
-        ]
+        ],
+        "progression": "Star Chaser"
       },
       "named_level": null,
       "bonus": null,
@@ -7281,10 +7281,10 @@
       "activity_section_position": 6,
       "assessment": true,
       "properties": {
-        "progression": "Star Chaser",
         "level_keys": [
           "CSD U6 params starchaser 5_2021"
-        ]
+        ],
+        "progression": "Star Chaser"
       },
       "named_level": null,
       "bonus": null,
@@ -7307,10 +7307,10 @@
       "activity_section_position": 7,
       "assessment": null,
       "properties": {
-        "progression": "Star Chaser",
         "level_keys": [
           "CSD U6 params starchaser challenge 1_2021"
-        ]
+        ],
+        "progression": "Star Chaser"
       },
       "named_level": null,
       "bonus": true,
@@ -7333,10 +7333,10 @@
       "activity_section_position": 8,
       "assessment": null,
       "properties": {
-        "progression": "Star Chaser",
         "level_keys": [
           "CSD U6 params starchaser challenge 2_2021"
-        ]
+        ],
+        "progression": "Star Chaser"
       },
       "named_level": null,
       "bonus": true,
@@ -7359,10 +7359,10 @@
       "activity_section_position": 1,
       "assessment": null,
       "properties": {
-        "progression": "Circuits and Logic",
         "level_keys": [
           "CSD U6 circuit logic video_2021"
-        ]
+        ],
+        "progression": "Circuits and Logic"
       },
       "named_level": null,
       "bonus": null,
@@ -7385,10 +7385,10 @@
       "activity_section_position": 1,
       "assessment": null,
       "properties": {
-        "progression": "Simple Circuits",
         "level_keys": [
           "CSD U6 circuit predict_2021"
-        ]
+        ],
+        "progression": "Simple Circuits"
       },
       "named_level": null,
       "bonus": null,
@@ -7411,10 +7411,10 @@
       "activity_section_position": 2,
       "assessment": null,
       "properties": {
-        "progression": "Simple Circuits",
         "level_keys": [
           "CSD U6 circuit pinMode_2021"
-        ]
+        ],
+        "progression": "Simple Circuits"
       },
       "named_level": null,
       "bonus": null,
@@ -7437,10 +7437,10 @@
       "activity_section_position": 3,
       "assessment": null,
       "properties": {
-        "progression": "Simple Circuits",
         "level_keys": [
           "CSD U6 circuit createLed_2021"
-        ]
+        ],
+        "progression": "Simple Circuits"
       },
       "named_level": null,
       "bonus": null,
@@ -7463,10 +7463,10 @@
       "activity_section_position": 4,
       "assessment": null,
       "properties": {
-        "progression": "Simple Circuits",
         "level_keys": [
           "CSD U6 circuit multi led_2021"
-        ]
+        ],
+        "progression": "Simple Circuits"
       },
       "named_level": null,
       "bonus": null,
@@ -7489,10 +7489,10 @@
       "activity_section_position": 1,
       "assessment": null,
       "properties": {
-        "progression": "Smart Bike - Blinkers",
         "level_keys": [
           "CSD U6 circuit smart bike blinkers_2021"
-        ]
+        ],
+        "progression": "Smart Bike - Blinkers"
       },
       "named_level": null,
       "bonus": null,
@@ -7515,10 +7515,10 @@
       "activity_section_position": 2,
       "assessment": true,
       "properties": {
-        "progression": "Smart Bike - Blinkers",
         "level_keys": [
           "CSD U6 circuit smart bike blinker buttons_2021"
-        ]
+        ],
+        "progression": "Smart Bike - Blinkers"
       },
       "named_level": null,
       "bonus": null,
@@ -7541,10 +7541,10 @@
       "activity_section_position": 3,
       "assessment": null,
       "properties": {
-        "progression": "Smart Bike - Blinkers",
         "level_keys": [
           "CSD U6 circuit smart bike blinker build_2021"
-        ]
+        ],
+        "progression": "Smart Bike - Blinkers"
       },
       "named_level": null,
       "bonus": null,
@@ -7567,10 +7567,10 @@
       "activity_section_position": 1,
       "assessment": null,
       "properties": {
-        "progression": "Button Circuits",
         "level_keys": [
           "CSD U6 circuit createButton_2021"
-        ]
+        ],
+        "progression": "Button Circuits"
       },
       "named_level": null,
       "bonus": null,
@@ -7593,10 +7593,10 @@
       "activity_section_position": 1,
       "assessment": null,
       "properties": {
-        "progression": "Finish the Prototype",
         "level_keys": [
           "CSD U6 circuit smart bike buzzer_2021"
-        ]
+        ],
+        "progression": "Finish the Prototype"
       },
       "named_level": null,
       "bonus": null,
@@ -7619,10 +7619,10 @@
       "activity_section_position": 2,
       "assessment": null,
       "properties": {
-        "progression": "Finish the Prototype",
         "level_keys": [
           "CSD U6 circuit smart bike light_2021"
-        ]
+        ],
+        "progression": "Finish the Prototype"
       },
       "named_level": null,
       "bonus": null,
@@ -7645,10 +7645,10 @@
       "activity_section_position": 3,
       "assessment": true,
       "properties": {
-        "progression": "Finish the Prototype",
         "level_keys": [
           "CSD U6 circuit smart bike final_2021"
-        ]
+        ],
+        "progression": "Finish the Prototype"
       },
       "named_level": null,
       "bonus": null,
@@ -7671,10 +7671,10 @@
       "activity_section_position": 1,
       "assessment": null,
       "properties": {
-        "progression": "Design Your Prototype",
         "level_keys": [
           "CSD U6 final intro_2021"
-        ]
+        ],
+        "progression": "Design Your Prototype"
       },
       "named_level": null,
       "bonus": null,
@@ -7697,10 +7697,10 @@
       "activity_section_position": 1,
       "assessment": null,
       "properties": {
-        "progression": "User Interface",
         "level_keys": [
           "CSDU6 - final project 1_2021"
-        ]
+        ],
+        "progression": "User Interface"
       },
       "named_level": null,
       "bonus": null,
@@ -7723,10 +7723,10 @@
       "activity_section_position": 2,
       "assessment": null,
       "properties": {
-        "progression": "User Interface",
         "level_keys": [
           "CSDU6 - final project 2_2021"
-        ]
+        ],
+        "progression": "User Interface"
       },
       "named_level": null,
       "bonus": null,
@@ -7749,10 +7749,10 @@
       "activity_section_position": 1,
       "assessment": null,
       "properties": {
-        "progression": "Board Input and Output",
         "level_keys": [
           "CSDU6 - final project 3_2021"
-        ]
+        ],
+        "progression": "Board Input and Output"
       },
       "named_level": null,
       "bonus": null,
@@ -7775,10 +7775,10 @@
       "activity_section_position": 2,
       "assessment": null,
       "properties": {
-        "progression": "Board Input and Output",
         "level_keys": [
           "CSDU6 - final project 5_2021"
-        ]
+        ],
+        "progression": "Board Input and Output"
       },
       "named_level": null,
       "bonus": null,
@@ -7801,10 +7801,10 @@
       "activity_section_position": 1,
       "assessment": null,
       "properties": {
-        "progression": "Finishing Touches",
         "level_keys": [
           "CSDU6 - final project 4_2021"
-        ]
+        ],
+        "progression": "Finishing Touches"
       },
       "named_level": null,
       "bonus": null,
@@ -7827,10 +7827,10 @@
       "activity_section_position": 2,
       "assessment": null,
       "properties": {
-        "progression": "Finishing Touches",
         "level_keys": [
           "CSDU6 - final project 6_2021"
-        ]
+        ],
+        "progression": "Finishing Touches"
       },
       "named_level": null,
       "bonus": null,
@@ -7853,10 +7853,10 @@
       "activity_section_position": 1,
       "assessment": true,
       "properties": {
-        "progression": "Reflection",
         "level_keys": [
           "csd-pulse-check-survey-1-levelgroup U6Ch2_2021"
-        ]
+        ],
+        "progression": "Reflection"
       },
       "named_level": null,
       "bonus": null,
@@ -10464,223 +10464,260 @@
     {
       "seeding_key": {
         "lesson.key": "Designing Screens with Code",
+        "programming_environment.name": "applab",
         "programming_expression.key": "setProperty"
       }
     },
     {
       "seeding_key": {
         "lesson.key": "The Circuit Playground",
-        "programming_expression.key": "led.off"
-      }
-    },
-    {
-      "seeding_key": {
-        "lesson.key": "The Circuit Playground",
-        "programming_expression.key": "led.on"
-      }
-    },
-    {
-      "seeding_key": {
-        "lesson.key": "The Circuit Playground",
+        "programming_environment.name": "applab",
         "programming_expression.key": "led.blink"
       }
     },
     {
       "seeding_key": {
         "lesson.key": "The Circuit Playground",
-        "programming_expression.key": "led.toggle"
+        "programming_environment.name": "applab",
+        "programming_expression.key": "led.on"
       }
     },
     {
       "seeding_key": {
         "lesson.key": "The Circuit Playground",
+        "programming_environment.name": "applab",
+        "programming_expression.key": "led.off"
+      }
+    },
+    {
+      "seeding_key": {
+        "lesson.key": "The Circuit Playground",
+        "programming_environment.name": "applab",
         "programming_expression.key": "led.pulse"
       }
     },
     {
       "seeding_key": {
-        "lesson.key": "Board Events",
-        "programming_expression.key": "isPressed"
+        "lesson.key": "The Circuit Playground",
+        "programming_environment.name": "applab",
+        "programming_expression.key": "led.toggle"
       }
     },
     {
       "seeding_key": {
         "lesson.key": "Board Events",
-        "programming_expression.key": "toggleSwitch.isOpen"
-      }
-    },
-    {
-      "seeding_key": {
-        "lesson.key": "Board Events",
+        "programming_environment.name": "applab",
         "programming_expression.key": "toggleSwitch"
       }
     },
     {
       "seeding_key": {
         "lesson.key": "Board Events",
-        "programming_expression.key": "buttons"
+        "programming_environment.name": "applab",
+        "programming_expression.key": "toggleSwitch.isOpen"
       }
     },
     {
       "seeding_key": {
         "lesson.key": "Board Events",
+        "programming_environment.name": "applab",
         "programming_expression.key": "onBoardEvent"
       }
     },
     {
       "seeding_key": {
+        "lesson.key": "Board Events",
+        "programming_environment.name": "applab",
+        "programming_expression.key": "isPressed"
+      }
+    },
+    {
+      "seeding_key": {
+        "lesson.key": "Board Events",
+        "programming_environment.name": "applab",
+        "programming_expression.key": "buttons"
+      }
+    },
+    {
+      "seeding_key": {
         "lesson.key": "Getting Properties",
+        "programming_environment.name": "applab",
         "programming_expression.key": "getProperty"
       }
     },
     {
       "seeding_key": {
         "lesson.key": "Analog Input",
-        "programming_expression.key": "soundSensor"
-      }
-    },
-    {
-      "seeding_key": {
-        "lesson.key": "Analog Input",
+        "programming_environment.name": "applab",
         "programming_expression.key": "tempSensor"
       }
     },
     {
       "seeding_key": {
         "lesson.key": "Analog Input",
-        "programming_expression.key": "lightSensor"
+        "programming_environment.name": "applab",
+        "programming_expression.key": "soundSensor"
       }
     },
     {
       "seeding_key": {
         "lesson.key": "Analog Input",
+        "programming_environment.name": "applab",
+        "programming_expression.key": "soundSensor.value"
+      }
+    },
+    {
+      "seeding_key": {
+        "lesson.key": "Analog Input",
+        "programming_environment.name": "applab",
         "programming_expression.key": "soundSensor.setScale"
       }
     },
     {
       "seeding_key": {
         "lesson.key": "Analog Input",
-        "programming_expression.key": "soundSensor.value"
+        "programming_environment.name": "applab",
+        "programming_expression.key": "lightSensor"
       }
     },
     {
       "seeding_key": {
         "lesson.key": "Arrays and Color LEDs",
-        "programming_expression.key": "on"
-      }
-    },
-    {
-      "seeding_key": {
-        "lesson.key": "Arrays and Color LEDs",
-        "programming_expression.key": "accessListItem"
-      }
-    },
-    {
-      "seeding_key": {
-        "lesson.key": "Arrays and Color LEDs",
-        "programming_expression.key": "blink"
-      }
-    },
-    {
-      "seeding_key": {
-        "lesson.key": "Arrays and Color LEDs",
-        "programming_expression.key": "color"
-      }
-    },
-    {
-      "seeding_key": {
-        "lesson.key": "Arrays and Color LEDs",
+        "programming_environment.name": "applab",
         "programming_expression.key": "colorLeds"
       }
     },
     {
       "seeding_key": {
         "lesson.key": "Arrays and Color LEDs",
+        "programming_environment.name": "applab",
+        "programming_expression.key": "color"
+      }
+    },
+    {
+      "seeding_key": {
+        "lesson.key": "Arrays and Color LEDs",
+        "programming_environment.name": "applab",
+        "programming_expression.key": "accessListItem"
+      }
+    },
+    {
+      "seeding_key": {
+        "lesson.key": "Arrays and Color LEDs",
+        "programming_environment.name": "applab",
         "programming_expression.key": "intensity"
       }
     },
     {
       "seeding_key": {
-        "lesson.key": "Making Music",
-        "programming_expression.key": "declareAssign_list_abd"
+        "lesson.key": "Arrays and Color LEDs",
+        "programming_environment.name": "applab",
+        "programming_expression.key": "on"
+      }
+    },
+    {
+      "seeding_key": {
+        "lesson.key": "Arrays and Color LEDs",
+        "programming_environment.name": "applab",
+        "programming_expression.key": "blink"
       }
     },
     {
       "seeding_key": {
         "lesson.key": "Making Music",
-        "programming_expression.key": "listLength"
-      }
-    },
-    {
-      "seeding_key": {
-        "lesson.key": "Making Music",
+        "programming_environment.name": "applab",
         "programming_expression.key": "buzzer.note"
       }
     },
     {
       "seeding_key": {
         "lesson.key": "Making Music",
+        "programming_environment.name": "applab",
+        "programming_expression.key": "listLength"
+      }
+    },
+    {
+      "seeding_key": {
+        "lesson.key": "Making Music",
+        "programming_environment.name": "applab",
+        "programming_expression.key": "declareAssign_list_abd"
+      }
+    },
+    {
+      "seeding_key": {
+        "lesson.key": "Making Music",
+        "programming_environment.name": "applab",
         "programming_expression.key": "buzzerplaynotes"
       }
     },
     {
       "seeding_key": {
         "lesson.key": "Arrays and For Loops",
-        "programming_expression.key": "functionParams_n"
-      }
-    },
-    {
-      "seeding_key": {
-        "lesson.key": "Arrays and For Loops",
+        "programming_environment.name": "applab",
         "programming_expression.key": "forLoop_i_0_4"
       }
     },
     {
       "seeding_key": {
         "lesson.key": "Arrays and For Loops",
+        "programming_environment.name": "applab",
         "programming_expression.key": "callMyFunction_n"
       }
     },
     {
       "seeding_key": {
+        "lesson.key": "Arrays and For Loops",
+        "programming_environment.name": "applab",
+        "programming_expression.key": "functionParams_n"
+      }
+    },
+    {
+      "seeding_key": {
         "lesson.key": "Accelerometer",
+        "programming_environment.name": "applab",
         "programming_expression.key": "accelerometer.getOrientation"
       }
     },
     {
       "seeding_key": {
         "lesson.key": "Functions with Parameters",
-        "programming_expression.key": "functionParams_n"
-      }
-    },
-    {
-      "seeding_key": {
-        "lesson.key": "Functions with Parameters",
+        "programming_environment.name": "applab",
         "programming_expression.key": "callMyFunction_n"
       }
     },
     {
       "seeding_key": {
-        "lesson.key": "Circuits and Physical Prototypes",
-        "programming_expression.key": "digitalWrite"
+        "lesson.key": "Functions with Parameters",
+        "programming_environment.name": "applab",
+        "programming_expression.key": "functionParams_n"
       }
     },
     {
       "seeding_key": {
         "lesson.key": "Circuits and Physical Prototypes",
+        "programming_environment.name": "applab",
         "programming_expression.key": "createLed"
       }
     },
     {
       "seeding_key": {
         "lesson.key": "Circuits and Physical Prototypes",
+        "programming_environment.name": "applab",
         "programming_expression.key": "createButton"
       }
     },
     {
       "seeding_key": {
         "lesson.key": "Circuits and Physical Prototypes",
+        "programming_environment.name": "applab",
         "programming_expression.key": "pinMode"
+      }
+    },
+    {
+      "seeding_key": {
+        "lesson.key": "Circuits and Physical Prototypes",
+        "programming_environment.name": "applab",
+        "programming_expression.key": "digitalWrite"
       }
     }
   ],
@@ -11075,5 +11112,8 @@
         "objective.key": "5ae2739b-3776-43ba-973f-50fa22302e32"
       }
     }
+  ],
+  "lessons_standards": [
+
   ]
 }

--- a/dashboard/config/scripts_json/csd6-2021.script_json
+++ b/dashboard/config/scripts_json/csd6-2021.script_json
@@ -10460,7 +10460,7 @@
       }
     }
   ],
-"lessons_programming_expressions": [
+  g"lessons_programming_expressions": [
     {
       "seeding_key": {
         "lesson.key": "Designing Screens with Code",

--- a/dashboard/config/scripts_json/csp1-2021.script_json
+++ b/dashboard/config/scripts_json/csp1-2021.script_json
@@ -24,7 +24,7 @@
     },
     "new_name": null,
     "family_name": null,
-    "serialized_at": "2021-03-15 12:51:48 UTC",
+    "serialized_at": "2021-03-18 22:04:10 UTC",
     "seeding_key": {
       "script.name": "csp1-2021"
     }
@@ -6095,6 +6095,19 @@
   ],
   "resources": [
     {
+      "name": "Computer Science is Changing Everything",
+      "url": "https://youtu.be/1x54GqfL3UY",
+      "key": "innovation-video-1-1",
+      "properties": {
+        "type": "Video",
+        "audience": "Student",
+        "download_url": "https://videos.code.org/2015/csp/cs_is_changing_everything.mp4"
+      },
+      "seeding_key": {
+        "resource.key": "innovation-video-1-1"
+      }
+    },
+    {
       "name": "Code Studio Teacher Dashboard Video Tutorial",
       "url": "https://www.youtube.com/watch?v=ebQY8fb2OV4&feature=youtu.be",
       "key": "code-studio-teacher-dashboard-video-tutorial",
@@ -6116,19 +6129,6 @@
       },
       "seeding_key": {
         "resource.key": "personal-innovations-1"
-      }
-    },
-    {
-      "name": "Computer Science is Changing Everything",
-      "url": "https://youtu.be/1x54GqfL3UY",
-      "key": "innovation-video-1-1",
-      "properties": {
-        "type": "Video",
-        "audience": "Student",
-        "download_url": "https://videos.code.org/2015/csp/cs_is_changing_everything.mp4"
-      },
-      "seeding_key": {
-        "resource.key": "innovation-video-1-1"
       }
     },
     {
@@ -6541,6 +6541,12 @@
     {
       "seeding_key": {
         "lesson.key": "Welcome to CSP",
+        "resource.key": "innovation-video-1-1"
+      }
+    },
+    {
+      "seeding_key": {
+        "lesson.key": "Welcome to CSP",
         "resource.key": "code-studio-teacher-dashboard-video-tutorial"
       }
     },
@@ -6548,12 +6554,6 @@
       "seeding_key": {
         "lesson.key": "Welcome to CSP",
         "resource.key": "personal-innovations-1"
-      }
-    },
-    {
-      "seeding_key": {
-        "lesson.key": "Welcome to CSP",
-        "resource.key": "innovation-video-1-1"
       }
     },
     {
@@ -7055,5 +7055,8 @@
         "objective.key": "0682a50c-8324-42b4-91e8-6e75176fd3b0"
       }
     }
+  ],
+  "lessons_standards": [
+
   ]
 }

--- a/dashboard/config/scripts_json/csp1-2021.script_json
+++ b/dashboard/config/scripts_json/csp1-2021.script_json
@@ -24,7 +24,7 @@
     },
     "new_name": null,
     "family_name": null,
-    "serialized_at": "2021-03-18 22:04:10 UTC",
+    "serialized_at": "2021-03-15 12:51:48 UTC",
     "seeding_key": {
       "script.name": "csp1-2021"
     }
@@ -6095,19 +6095,6 @@
   ],
   "resources": [
     {
-      "name": "Computer Science is Changing Everything",
-      "url": "https://youtu.be/1x54GqfL3UY",
-      "key": "innovation-video-1-1",
-      "properties": {
-        "type": "Video",
-        "audience": "Student",
-        "download_url": "https://videos.code.org/2015/csp/cs_is_changing_everything.mp4"
-      },
-      "seeding_key": {
-        "resource.key": "innovation-video-1-1"
-      }
-    },
-    {
       "name": "Code Studio Teacher Dashboard Video Tutorial",
       "url": "https://www.youtube.com/watch?v=ebQY8fb2OV4&feature=youtu.be",
       "key": "code-studio-teacher-dashboard-video-tutorial",
@@ -6129,6 +6116,19 @@
       },
       "seeding_key": {
         "resource.key": "personal-innovations-1"
+      }
+    },
+    {
+      "name": "Computer Science is Changing Everything",
+      "url": "https://youtu.be/1x54GqfL3UY",
+      "key": "innovation-video-1-1",
+      "properties": {
+        "type": "Video",
+        "audience": "Student",
+        "download_url": "https://videos.code.org/2015/csp/cs_is_changing_everything.mp4"
+      },
+      "seeding_key": {
+        "resource.key": "innovation-video-1-1"
       }
     },
     {
@@ -6541,12 +6541,6 @@
     {
       "seeding_key": {
         "lesson.key": "Welcome to CSP",
-        "resource.key": "innovation-video-1-1"
-      }
-    },
-    {
-      "seeding_key": {
-        "lesson.key": "Welcome to CSP",
         "resource.key": "code-studio-teacher-dashboard-video-tutorial"
       }
     },
@@ -6554,6 +6548,12 @@
       "seeding_key": {
         "lesson.key": "Welcome to CSP",
         "resource.key": "personal-innovations-1"
+      }
+    },
+    {
+      "seeding_key": {
+        "lesson.key": "Welcome to CSP",
+        "resource.key": "innovation-video-1-1"
       }
     },
     {
@@ -7055,8 +7055,5 @@
         "objective.key": "0682a50c-8324-42b4-91e8-6e75176fd3b0"
       }
     }
-  ],
-  "lessons_standards": [
-
   ]
 }

--- a/dashboard/config/scripts_json/csp10-2021.script_json
+++ b/dashboard/config/scripts_json/csp10-2021.script_json
@@ -19,7 +19,7 @@
     },
     "new_name": null,
     "family_name": null,
-    "serialized_at": "2021-03-18 22:11:10 UTC",
+    "serialized_at": "2021-03-15 12:59:03 UTC",
     "seeding_key": {
       "script.name": "csp10-2021"
     }
@@ -2869,10 +2869,10 @@
       "activity_section_position": 1,
       "assessment": null,
       "properties": {
+        "progression": "Keylogging",
         "level_keys": [
           "CSP 20-21 Keylogging_2021"
-        ],
-        "progression": "Keylogging"
+        ]
       },
       "named_level": null,
       "bonus": null,
@@ -2920,10 +2920,10 @@
       "activity_section_position": 1,
       "assessment": null,
       "properties": {
+        "progression": "Malware",
         "level_keys": [
           "CSP 20-21 Rogue Access Points_2021"
-        ],
-        "progression": "Malware"
+        ]
       },
       "named_level": null,
       "bonus": null,
@@ -2998,10 +2998,10 @@
       "activity_section_position": 1,
       "assessment": null,
       "properties": {
+        "progression": "Encryption Widgets",
         "level_keys": [
           "Crack a Caesar Cipher_2021"
-        ],
-        "progression": "Encryption Widgets"
+        ]
       },
       "named_level": null,
       "bonus": null,
@@ -3024,10 +3024,10 @@
       "activity_section_position": 2,
       "assessment": null,
       "properties": {
+        "progression": "Encryption Widgets",
         "level_keys": [
           "Crack Random Substitution_2021"
-        ],
-        "progression": "Encryption Widgets"
+        ]
       },
       "named_level": null,
       "bonus": null,
@@ -3102,10 +3102,10 @@
       "activity_section_position": 1,
       "assessment": true,
       "properties": {
+        "progression": "Unit 10 Exam",
         "level_keys": [
           "CSP 20-21 Unit 10 Assessment_2021"
-        ],
-        "progression": "Unit 10 Exam"
+        ]
       },
       "named_level": null,
       "bonus": null,
@@ -4242,8 +4242,5 @@
         "objective.key": "a89f82c6-f7e9-493d-8b85-5a06e5ae7029"
       }
     }
-  ],
-  "lessons_standards": [
-
   ]
 }

--- a/dashboard/config/scripts_json/csp10-2021.script_json
+++ b/dashboard/config/scripts_json/csp10-2021.script_json
@@ -19,7 +19,7 @@
     },
     "new_name": null,
     "family_name": null,
-    "serialized_at": "2021-03-15 12:59:03 UTC",
+    "serialized_at": "2021-03-18 22:11:10 UTC",
     "seeding_key": {
       "script.name": "csp10-2021"
     }
@@ -2869,10 +2869,10 @@
       "activity_section_position": 1,
       "assessment": null,
       "properties": {
-        "progression": "Keylogging",
         "level_keys": [
           "CSP 20-21 Keylogging_2021"
-        ]
+        ],
+        "progression": "Keylogging"
       },
       "named_level": null,
       "bonus": null,
@@ -2920,10 +2920,10 @@
       "activity_section_position": 1,
       "assessment": null,
       "properties": {
-        "progression": "Malware",
         "level_keys": [
           "CSP 20-21 Rogue Access Points_2021"
-        ]
+        ],
+        "progression": "Malware"
       },
       "named_level": null,
       "bonus": null,
@@ -2998,10 +2998,10 @@
       "activity_section_position": 1,
       "assessment": null,
       "properties": {
-        "progression": "Encryption Widgets",
         "level_keys": [
           "Crack a Caesar Cipher_2021"
-        ]
+        ],
+        "progression": "Encryption Widgets"
       },
       "named_level": null,
       "bonus": null,
@@ -3024,10 +3024,10 @@
       "activity_section_position": 2,
       "assessment": null,
       "properties": {
-        "progression": "Encryption Widgets",
         "level_keys": [
           "Crack Random Substitution_2021"
-        ]
+        ],
+        "progression": "Encryption Widgets"
       },
       "named_level": null,
       "bonus": null,
@@ -3102,10 +3102,10 @@
       "activity_section_position": 1,
       "assessment": true,
       "properties": {
-        "progression": "Unit 10 Exam",
         "level_keys": [
           "CSP 20-21 Unit 10 Assessment_2021"
-        ]
+        ],
+        "progression": "Unit 10 Exam"
       },
       "named_level": null,
       "bonus": null,
@@ -4242,5 +4242,8 @@
         "objective.key": "a89f82c6-f7e9-493d-8b85-5a06e5ae7029"
       }
     }
+  ],
+  "lessons_standards": [
+
   ]
 }

--- a/dashboard/config/scripts_json/csp2-2021.script_json
+++ b/dashboard/config/scripts_json/csp2-2021.script_json
@@ -19,7 +19,7 @@
     },
     "new_name": null,
     "family_name": null,
-    "serialized_at": "2021-03-18 22:05:11 UTC",
+    "serialized_at": "2021-03-15 12:52:35 UTC",
     "seeding_key": {
       "script.name": "csp2-2021"
     }
@@ -2399,10 +2399,10 @@
       "activity_section_position": 1,
       "assessment": null,
       "properties": {
+        "progression": "Internet Simulator",
         "level_keys": [
           "CSP U2L1 Internet Simulator: Sending Text_2021"
-        ],
-        "progression": "Internet Simulator"
+        ]
       },
       "named_level": null,
       "bonus": null,
@@ -2425,10 +2425,10 @@
       "activity_section_position": 1,
       "assessment": true,
       "properties": {
+        "progression": "Check For Understanding",
         "level_keys": [
           "U2L1 CFU how use internet_2021"
-        ],
-        "progression": "Check For Understanding"
+        ]
       },
       "named_level": null,
       "bonus": null,
@@ -2451,10 +2451,10 @@
       "activity_section_position": 1,
       "assessment": true,
       "properties": {
+        "progression": "Check For Understanding",
         "level_keys": [
           "U2L1 CFU paths_2021"
-        ],
-        "progression": "Check For Understanding"
+        ]
       },
       "named_level": null,
       "bonus": null,
@@ -2477,10 +2477,10 @@
       "activity_section_position": 1,
       "assessment": null,
       "properties": {
+        "progression": "Internet Simulator",
         "level_keys": [
           "U2L2 CSP Internet Simulator Broadcast_2021"
-        ],
-        "progression": "Internet Simulator"
+        ]
       },
       "named_level": null,
       "bonus": null,
@@ -2503,10 +2503,10 @@
       "activity_section_position": 1,
       "assessment": true,
       "properties": {
+        "progression": "Check For Understanding",
         "level_keys": [
           "U2L2 CSP CFU IP Addresses_2021"
-        ],
-        "progression": "Check For Understanding"
+        ]
       },
       "named_level": null,
       "bonus": null,
@@ -2529,10 +2529,10 @@
       "activity_section_position": 2,
       "assessment": true,
       "properties": {
+        "progression": "Check For Understanding",
         "level_keys": [
           "U2L2 CSP CFU IP works_2021"
-        ],
-        "progression": "Check For Understanding"
+        ]
       },
       "named_level": null,
       "bonus": null,
@@ -2555,10 +2555,10 @@
       "activity_section_position": 1,
       "assessment": null,
       "properties": {
+        "progression": "Internet Simulator",
         "level_keys": [
           "U1L3 CSP Internet Simulator Routers_2021"
-        ],
-        "progression": "Internet Simulator"
+        ]
       },
       "named_level": null,
       "bonus": null,
@@ -2581,10 +2581,10 @@
       "activity_section_position": 1,
       "assessment": true,
       "properties": {
+        "progression": "Check For Understanding",
         "level_keys": [
           "U2L3 CSP CFU Routers_2021"
-        ],
-        "progression": "Check For Understanding"
+        ]
       },
       "named_level": null,
       "bonus": null,
@@ -2607,10 +2607,10 @@
       "activity_section_position": 2,
       "assessment": true,
       "properties": {
+        "progression": "Check For Understanding",
         "level_keys": [
           "U2L3 CSP CFU Redundancy_2021"
-        ],
-        "progression": "Check For Understanding"
+        ]
       },
       "named_level": null,
       "bonus": null,
@@ -2633,10 +2633,10 @@
       "activity_section_position": 1,
       "assessment": null,
       "properties": {
+        "progression": "Internet Simulator",
         "level_keys": [
           "U1L4 CSP Internet Simulator Packets 2_2021"
-        ],
-        "progression": "Internet Simulator"
+        ]
       },
       "named_level": null,
       "bonus": null,
@@ -2659,10 +2659,10 @@
       "activity_section_position": 1,
       "assessment": true,
       "properties": {
+        "progression": "Check For Understanding",
         "level_keys": [
           "U2L4 Multiple Choice packets_2021"
-        ],
-        "progression": "Check For Understanding"
+        ]
       },
       "named_level": null,
       "bonus": null,
@@ -2685,10 +2685,10 @@
       "activity_section_position": 2,
       "assessment": true,
       "properties": {
+        "progression": "Check For Understanding",
         "level_keys": [
           "U2L4 CSP CFU terms_2021"
-        ],
-        "progression": "Check For Understanding"
+        ]
       },
       "named_level": null,
       "bonus": null,
@@ -2711,10 +2711,10 @@
       "activity_section_position": 1,
       "assessment": null,
       "properties": {
+        "progression": "Internet Simulator",
         "level_keys": [
           "U1L5 CSP Internet Simulator DNS_2021"
-        ],
-        "progression": "Internet Simulator"
+        ]
       },
       "named_level": null,
       "bonus": null,
@@ -2737,10 +2737,10 @@
       "activity_section_position": 1,
       "assessment": true,
       "properties": {
+        "progression": "Check For Understanding",
         "level_keys": [
           "U2L4 CSP CFU scale_2021"
-        ],
-        "progression": "Check For Understanding"
+        ]
       },
       "named_level": null,
       "bonus": null,
@@ -2763,10 +2763,10 @@
       "activity_section_position": 2,
       "assessment": true,
       "properties": {
+        "progression": "Check For Understanding",
         "level_keys": [
           "U2L5 CSP CFU subgroups_2021"
-        ],
-        "progression": "Check For Understanding"
+        ]
       },
       "named_level": null,
       "bonus": null,
@@ -2789,10 +2789,10 @@
       "activity_section_position": 1,
       "assessment": true,
       "properties": {
+        "progression": "Unit 2 Exam",
         "level_keys": [
           "CSP Unit 2 MC Assessment _2021"
-        ],
-        "progression": "Unit 2 Exam"
+        ]
       },
       "named_level": null,
       "bonus": null,
@@ -3586,8 +3586,5 @@
         "objective.key": "fd64f96c-7a32-4465-9bcf-d8a7f2398195"
       }
     }
-  ],
-  "lessons_standards": [
-
   ]
 }

--- a/dashboard/config/scripts_json/csp2-2021.script_json
+++ b/dashboard/config/scripts_json/csp2-2021.script_json
@@ -19,7 +19,7 @@
     },
     "new_name": null,
     "family_name": null,
-    "serialized_at": "2021-03-15 12:52:35 UTC",
+    "serialized_at": "2021-03-18 22:05:11 UTC",
     "seeding_key": {
       "script.name": "csp2-2021"
     }
@@ -2399,10 +2399,10 @@
       "activity_section_position": 1,
       "assessment": null,
       "properties": {
-        "progression": "Internet Simulator",
         "level_keys": [
           "CSP U2L1 Internet Simulator: Sending Text_2021"
-        ]
+        ],
+        "progression": "Internet Simulator"
       },
       "named_level": null,
       "bonus": null,
@@ -2425,10 +2425,10 @@
       "activity_section_position": 1,
       "assessment": true,
       "properties": {
-        "progression": "Check For Understanding",
         "level_keys": [
           "U2L1 CFU how use internet_2021"
-        ]
+        ],
+        "progression": "Check For Understanding"
       },
       "named_level": null,
       "bonus": null,
@@ -2451,10 +2451,10 @@
       "activity_section_position": 1,
       "assessment": true,
       "properties": {
-        "progression": "Check For Understanding",
         "level_keys": [
           "U2L1 CFU paths_2021"
-        ]
+        ],
+        "progression": "Check For Understanding"
       },
       "named_level": null,
       "bonus": null,
@@ -2477,10 +2477,10 @@
       "activity_section_position": 1,
       "assessment": null,
       "properties": {
-        "progression": "Internet Simulator",
         "level_keys": [
           "U2L2 CSP Internet Simulator Broadcast_2021"
-        ]
+        ],
+        "progression": "Internet Simulator"
       },
       "named_level": null,
       "bonus": null,
@@ -2503,10 +2503,10 @@
       "activity_section_position": 1,
       "assessment": true,
       "properties": {
-        "progression": "Check For Understanding",
         "level_keys": [
           "U2L2 CSP CFU IP Addresses_2021"
-        ]
+        ],
+        "progression": "Check For Understanding"
       },
       "named_level": null,
       "bonus": null,
@@ -2529,10 +2529,10 @@
       "activity_section_position": 2,
       "assessment": true,
       "properties": {
-        "progression": "Check For Understanding",
         "level_keys": [
           "U2L2 CSP CFU IP works_2021"
-        ]
+        ],
+        "progression": "Check For Understanding"
       },
       "named_level": null,
       "bonus": null,
@@ -2555,10 +2555,10 @@
       "activity_section_position": 1,
       "assessment": null,
       "properties": {
-        "progression": "Internet Simulator",
         "level_keys": [
           "U1L3 CSP Internet Simulator Routers_2021"
-        ]
+        ],
+        "progression": "Internet Simulator"
       },
       "named_level": null,
       "bonus": null,
@@ -2581,10 +2581,10 @@
       "activity_section_position": 1,
       "assessment": true,
       "properties": {
-        "progression": "Check For Understanding",
         "level_keys": [
           "U2L3 CSP CFU Routers_2021"
-        ]
+        ],
+        "progression": "Check For Understanding"
       },
       "named_level": null,
       "bonus": null,
@@ -2607,10 +2607,10 @@
       "activity_section_position": 2,
       "assessment": true,
       "properties": {
-        "progression": "Check For Understanding",
         "level_keys": [
           "U2L3 CSP CFU Redundancy_2021"
-        ]
+        ],
+        "progression": "Check For Understanding"
       },
       "named_level": null,
       "bonus": null,
@@ -2633,10 +2633,10 @@
       "activity_section_position": 1,
       "assessment": null,
       "properties": {
-        "progression": "Internet Simulator",
         "level_keys": [
           "U1L4 CSP Internet Simulator Packets 2_2021"
-        ]
+        ],
+        "progression": "Internet Simulator"
       },
       "named_level": null,
       "bonus": null,
@@ -2659,10 +2659,10 @@
       "activity_section_position": 1,
       "assessment": true,
       "properties": {
-        "progression": "Check For Understanding",
         "level_keys": [
           "U2L4 Multiple Choice packets_2021"
-        ]
+        ],
+        "progression": "Check For Understanding"
       },
       "named_level": null,
       "bonus": null,
@@ -2685,10 +2685,10 @@
       "activity_section_position": 2,
       "assessment": true,
       "properties": {
-        "progression": "Check For Understanding",
         "level_keys": [
           "U2L4 CSP CFU terms_2021"
-        ]
+        ],
+        "progression": "Check For Understanding"
       },
       "named_level": null,
       "bonus": null,
@@ -2711,10 +2711,10 @@
       "activity_section_position": 1,
       "assessment": null,
       "properties": {
-        "progression": "Internet Simulator",
         "level_keys": [
           "U1L5 CSP Internet Simulator DNS_2021"
-        ]
+        ],
+        "progression": "Internet Simulator"
       },
       "named_level": null,
       "bonus": null,
@@ -2737,10 +2737,10 @@
       "activity_section_position": 1,
       "assessment": true,
       "properties": {
-        "progression": "Check For Understanding",
         "level_keys": [
           "U2L4 CSP CFU scale_2021"
-        ]
+        ],
+        "progression": "Check For Understanding"
       },
       "named_level": null,
       "bonus": null,
@@ -2763,10 +2763,10 @@
       "activity_section_position": 2,
       "assessment": true,
       "properties": {
-        "progression": "Check For Understanding",
         "level_keys": [
           "U2L5 CSP CFU subgroups_2021"
-        ]
+        ],
+        "progression": "Check For Understanding"
       },
       "named_level": null,
       "bonus": null,
@@ -2789,10 +2789,10 @@
       "activity_section_position": 1,
       "assessment": true,
       "properties": {
-        "progression": "Unit 2 Exam",
         "level_keys": [
           "CSP Unit 2 MC Assessment _2021"
-        ]
+        ],
+        "progression": "Unit 2 Exam"
       },
       "named_level": null,
       "bonus": null,
@@ -3586,5 +3586,8 @@
         "objective.key": "fd64f96c-7a32-4465-9bcf-d8a7f2398195"
       }
     }
+  ],
+  "lessons_standards": [
+
   ]
 }

--- a/dashboard/config/scripts_json/csp3-2021.script_json
+++ b/dashboard/config/scripts_json/csp3-2021.script_json
@@ -19,7 +19,7 @@
     },
     "new_name": null,
     "family_name": null,
-    "serialized_at": "2021-03-15 12:53:19 UTC",
+    "serialized_at": "2021-03-18 22:05:59 UTC",
     "seeding_key": {
       "script.name": "csp3-2021"
     }
@@ -2372,10 +2372,10 @@
       "activity_section_position": 1,
       "assessment": null,
       "properties": {
-        "progression": "App Exploration",
         "level_keys": [
           "CSP U3 Water Conservation Sample App_2021"
-        ]
+        ],
+        "progression": "App Exploration"
       },
       "named_level": null,
       "bonus": null,
@@ -2398,10 +2398,10 @@
       "activity_section_position": 2,
       "assessment": null,
       "properties": {
-        "progression": "App Exploration",
         "level_keys": [
           "CSP U3 Bird Quiz App_2021"
-        ]
+        ],
+        "progression": "App Exploration"
       },
       "named_level": null,
       "bonus": null,
@@ -2424,10 +2424,10 @@
       "activity_section_position": 3,
       "assessment": null,
       "properties": {
-        "progression": "App Exploration",
         "level_keys": [
           "CSP U3 Hamilton Township App_2021"
-        ]
+        ],
+        "progression": "App Exploration"
       },
       "named_level": null,
       "bonus": null,
@@ -2450,10 +2450,10 @@
       "activity_section_position": 4,
       "assessment": null,
       "properties": {
-        "progression": "App Exploration",
         "level_keys": [
           "CSP U3 Four Square App_2021"
-        ]
+        ],
+        "progression": "App Exploration"
       },
       "named_level": null,
       "bonus": null,
@@ -2476,10 +2476,10 @@
       "activity_section_position": 5,
       "assessment": null,
       "properties": {
-        "progression": "App Exploration",
         "level_keys": [
           "CSP U3 Monarch Butterfly App_2021"
-        ]
+        ],
+        "progression": "App Exploration"
       },
       "named_level": null,
       "bonus": null,
@@ -2502,10 +2502,10 @@
       "activity_section_position": 1,
       "assessment": null,
       "properties": {
-        "progression": "How Computers Work",
         "level_keys": [
           "How Computers Work part 1 CSP_2021"
-        ]
+        ],
+        "progression": "How Computers Work"
       },
       "named_level": null,
       "bonus": null,
@@ -2528,10 +2528,10 @@
       "activity_section_position": 1,
       "assessment": null,
       "properties": {
-        "progression": "App Investigation",
         "level_keys": [
           "CSP U3 Water Conservation Sample App Investigate_2021"
-        ]
+        ],
+        "progression": "App Investigation"
       },
       "named_level": null,
       "bonus": null,
@@ -2554,10 +2554,10 @@
       "activity_section_position": 2,
       "assessment": null,
       "properties": {
-        "progression": "App Investigation",
         "level_keys": [
           "CSP U3 Bird Quiz App Investigation_2021"
-        ]
+        ],
+        "progression": "App Investigation"
       },
       "named_level": null,
       "bonus": null,
@@ -2580,10 +2580,10 @@
       "activity_section_position": 3,
       "assessment": null,
       "properties": {
-        "progression": "App Investigation",
         "level_keys": [
           "CSP U3 Hamilton Township App Investigation_2021"
-        ]
+        ],
+        "progression": "App Investigation"
       },
       "named_level": null,
       "bonus": null,
@@ -2606,10 +2606,10 @@
       "activity_section_position": 4,
       "assessment": null,
       "properties": {
-        "progression": "App Investigation",
         "level_keys": [
           "CSP U3 Four Square App Investigation_2021"
-        ]
+        ],
+        "progression": "App Investigation"
       },
       "named_level": null,
       "bonus": null,
@@ -2632,10 +2632,10 @@
       "activity_section_position": 5,
       "assessment": null,
       "properties": {
-        "progression": "App Investigation",
         "level_keys": [
           "CSP U3 Monarch Butterfly App Investigation_2021"
-        ]
+        ],
+        "progression": "App Investigation"
       },
       "named_level": null,
       "bonus": null,
@@ -2658,10 +2658,10 @@
       "activity_section_position": 1,
       "assessment": true,
       "properties": {
-        "progression": "Check For Understanding",
         "level_keys": [
           "CSP U3 L1 Input Output Matching_2021"
-        ]
+        ],
+        "progression": "Check For Understanding"
       },
       "named_level": null,
       "bonus": null,
@@ -2684,10 +2684,10 @@
       "activity_section_position": 1,
       "assessment": null,
       "properties": {
-        "progression": "Design Mode Exploration",
         "level_keys": [
           "CSP U3 Hamilton Township Design Mode_2021"
-        ]
+        ],
+        "progression": "Design Mode Exploration"
       },
       "named_level": null,
       "bonus": null,
@@ -2710,10 +2710,10 @@
       "activity_section_position": 2,
       "assessment": null,
       "properties": {
-        "progression": "Design Mode Exploration",
         "level_keys": [
           "CSP U3 L2 Design Mode Themes_2021"
-        ]
+        ],
+        "progression": "Design Mode Exploration"
       },
       "named_level": null,
       "bonus": null,
@@ -2736,10 +2736,10 @@
       "activity_section_position": 3,
       "assessment": null,
       "properties": {
-        "progression": "Design Mode Exploration",
         "level_keys": [
           "CSP U3 L2 Design Mode Colors_2021"
-        ]
+        ],
+        "progression": "Design Mode Exploration"
       },
       "named_level": null,
       "bonus": null,
@@ -2762,10 +2762,10 @@
       "activity_section_position": 4,
       "assessment": null,
       "properties": {
-        "progression": "Design Mode Exploration",
         "level_keys": [
           "CSP U3 L2 Design Mode Images_2021"
-        ]
+        ],
+        "progression": "Design Mode Exploration"
       },
       "named_level": null,
       "bonus": null,
@@ -2788,10 +2788,10 @@
       "activity_section_position": 5,
       "assessment": null,
       "properties": {
-        "progression": "Design Mode Exploration",
         "level_keys": [
           "CSP U3 L2 Design Mode Icons_2021"
-        ]
+        ],
+        "progression": "Design Mode Exploration"
       },
       "named_level": null,
       "bonus": null,
@@ -2814,10 +2814,10 @@
       "activity_section_position": 6,
       "assessment": null,
       "properties": {
-        "progression": "Design Mode Exploration",
         "level_keys": [
           "CSP U3 L2 Design Mode ids_2021"
-        ]
+        ],
+        "progression": "Design Mode Exploration"
       },
       "named_level": null,
       "bonus": null,
@@ -2840,10 +2840,10 @@
       "activity_section_position": 1,
       "assessment": null,
       "properties": {
-        "progression": "Copy an App",
         "level_keys": [
           "CSP U3 L2 Copy an App_2021"
-        ]
+        ],
+        "progression": "Copy an App"
       },
       "named_level": null,
       "bonus": null,
@@ -2866,10 +2866,10 @@
       "activity_section_position": 1,
       "assessment": true,
       "properties": {
-        "progression": "Check For Understanding",
         "level_keys": [
           "U3L2 CSP CFU ID names_2021"
-        ]
+        ],
+        "progression": "Check For Understanding"
       },
       "named_level": null,
       "bonus": null,
@@ -2892,10 +2892,10 @@
       "activity_section_position": 1,
       "assessment": null,
       "properties": {
-        "progression": "Sample Prototype",
         "level_keys": [
           "CSP U3 Bird Quiz Storyboard_2021"
-        ]
+        ],
+        "progression": "Sample Prototype"
       },
       "named_level": null,
       "bonus": null,
@@ -2918,10 +2918,10 @@
       "activity_section_position": 1,
       "assessment": null,
       "properties": {
-        "progression": "Build Your Screens",
         "level_keys": [
           "CSP U3 L4 Design Screens_2021"
-        ]
+        ],
+        "progression": "Build Your Screens"
       },
       "named_level": null,
       "bonus": null,
@@ -2944,10 +2944,10 @@
       "activity_section_position": 1,
       "assessment": true,
       "properties": {
-        "progression": "Check For Understanding",
         "level_keys": [
           "U3L5 CSP CFU natural language_2021"
-        ]
+        ],
+        "progression": "Check For Understanding"
       },
       "named_level": null,
       "bonus": null,
@@ -2970,10 +2970,10 @@
       "activity_section_position": 1,
       "assessment": null,
       "properties": {
-        "progression": "Code Investigation",
         "level_keys": [
           "U3 Program Investigate Sequential 1_2021"
-        ]
+        ],
+        "progression": "Code Investigation"
       },
       "named_level": null,
       "bonus": null,
@@ -2996,10 +2996,10 @@
       "activity_section_position": 2,
       "assessment": null,
       "properties": {
-        "progression": "Code Investigation",
         "level_keys": [
           "U3 Program Investigate Sequential 2_2021"
-        ]
+        ],
+        "progression": "Code Investigation"
       },
       "named_level": null,
       "bonus": null,
@@ -3022,10 +3022,10 @@
       "activity_section_position": 3,
       "assessment": null,
       "properties": {
-        "progression": "Code Investigation",
         "level_keys": [
           "U3 Program Investigate Event-Driven 1_2021"
-        ]
+        ],
+        "progression": "Code Investigation"
       },
       "named_level": null,
       "bonus": null,
@@ -3048,10 +3048,10 @@
       "activity_section_position": 4,
       "assessment": null,
       "properties": {
-        "progression": "Code Investigation",
         "level_keys": [
           "U3 Program Investigate Event-Driven 2_2021"
-        ]
+        ],
+        "progression": "Code Investigation"
       },
       "named_level": null,
       "bonus": null,
@@ -3074,10 +3074,10 @@
       "activity_section_position": 5,
       "assessment": null,
       "properties": {
-        "progression": "Code Investigation",
         "level_keys": [
           "U3 Program Investigate Event-Driven 3_2021"
-        ]
+        ],
+        "progression": "Code Investigation"
       },
       "named_level": null,
       "bonus": null,
@@ -3100,10 +3100,10 @@
       "activity_section_position": 1,
       "assessment": true,
       "properties": {
-        "progression": "Check for Understanding",
         "level_keys": [
           "U3L6 CSP CFU Sequential vs Event Driven_2021"
-        ]
+        ],
+        "progression": "Check for Understanding"
       },
       "named_level": null,
       "bonus": null,
@@ -3126,10 +3126,10 @@
       "activity_section_position": 1,
       "assessment": null,
       "properties": {
-        "progression": "Debugging",
         "level_keys": [
           "U3 Program Practice Pt 1_2021"
-        ]
+        ],
+        "progression": "Debugging"
       },
       "named_level": null,
       "bonus": null,
@@ -3152,10 +3152,10 @@
       "activity_section_position": 2,
       "assessment": null,
       "properties": {
-        "progression": "Debugging",
         "level_keys": [
           "U3 Program Practice Pt 2_2021"
-        ]
+        ],
+        "progression": "Debugging"
       },
       "named_level": null,
       "bonus": null,
@@ -3178,10 +3178,10 @@
       "activity_section_position": 3,
       "assessment": null,
       "properties": {
-        "progression": "Debugging",
         "level_keys": [
           "U3 Program Practice Pt 3_2021"
-        ]
+        ],
+        "progression": "Debugging"
       },
       "named_level": null,
       "bonus": null,
@@ -3204,10 +3204,10 @@
       "activity_section_position": 4,
       "assessment": null,
       "properties": {
-        "progression": "Debugging",
         "level_keys": [
           "U3 Program Practice Pt 4_2021"
-        ]
+        ],
+        "progression": "Debugging"
       },
       "named_level": null,
       "bonus": null,
@@ -3230,10 +3230,10 @@
       "activity_section_position": 5,
       "assessment": null,
       "properties": {
-        "progression": "Debugging",
         "level_keys": [
           "U3 Program Practice Pt 5_2021"
-        ]
+        ],
+        "progression": "Debugging"
       },
       "named_level": null,
       "bonus": null,
@@ -3256,10 +3256,10 @@
       "activity_section_position": 6,
       "assessment": null,
       "properties": {
-        "progression": "Debugging",
         "level_keys": [
           "U3 Program Practice Pt 6_2021"
-        ]
+        ],
+        "progression": "Debugging"
       },
       "named_level": null,
       "bonus": null,
@@ -3282,10 +3282,10 @@
       "activity_section_position": 7,
       "assessment": null,
       "properties": {
-        "progression": "Debugging",
         "level_keys": [
           "U3 Program Practice Pt 8_2021"
-        ]
+        ],
+        "progression": "Debugging"
       },
       "named_level": null,
       "bonus": null,
@@ -3308,10 +3308,10 @@
       "activity_section_position": 1,
       "assessment": true,
       "properties": {
-        "progression": "Check for Understanding",
         "level_keys": [
           "U3L7 CSP CFU What was confusing_2021"
-        ]
+        ],
+        "progression": "Check for Understanding"
       },
       "named_level": null,
       "bonus": null,
@@ -3334,10 +3334,10 @@
       "activity_section_position": 1,
       "assessment": null,
       "properties": {
-        "progression": "Pair Programming",
         "level_keys": [
           "U3 L08 Pair Programming Video_2021"
-        ]
+        ],
+        "progression": "Pair Programming"
       },
       "named_level": null,
       "bonus": null,
@@ -3360,10 +3360,10 @@
       "activity_section_position": 1,
       "assessment": null,
       "properties": {
-        "progression": "Add Code",
         "level_keys": [
           "CSP U3 L4 Add Code_2021"
-        ]
+        ],
+        "progression": "Add Code"
       },
       "named_level": null,
       "bonus": null,
@@ -3386,10 +3386,10 @@
       "activity_section_position": 1,
       "assessment": null,
       "properties": {
-        "progression": "Add More Code",
         "level_keys": [
           "CSP U3 L9 Add More Code_2021"
-        ]
+        ],
+        "progression": "Add More Code"
       },
       "named_level": null,
       "bonus": null,
@@ -3412,10 +3412,10 @@
       "activity_section_position": 1,
       "assessment": true,
       "properties": {
-        "progression": "Submit your app",
         "level_keys": [
           "CSP U3 L10 Submit App_2021"
-        ]
+        ],
+        "progression": "Submit your app"
       },
       "named_level": null,
       "bonus": null,
@@ -3438,10 +3438,10 @@
       "activity_section_position": 1,
       "assessment": true,
       "properties": {
-        "progression": "Unit 3 Exam",
         "level_keys": [
           "CSP Unit 3 MC Assessment _2021"
-        ]
+        ],
+        "progression": "Unit 3 Exam"
       },
       "named_level": null,
       "bonus": null,
@@ -4549,5 +4549,8 @@
         "objective.key": "802cfd1b-a6af-429b-b188-bcb1e7b854e3"
       }
     }
+  ],
+  "lessons_standards": [
+
   ]
 }

--- a/dashboard/config/scripts_json/csp3-2021.script_json
+++ b/dashboard/config/scripts_json/csp3-2021.script_json
@@ -19,7 +19,7 @@
     },
     "new_name": null,
     "family_name": null,
-    "serialized_at": "2021-03-18 22:05:59 UTC",
+    "serialized_at": "2021-03-15 12:53:19 UTC",
     "seeding_key": {
       "script.name": "csp3-2021"
     }
@@ -2372,10 +2372,10 @@
       "activity_section_position": 1,
       "assessment": null,
       "properties": {
+        "progression": "App Exploration",
         "level_keys": [
           "CSP U3 Water Conservation Sample App_2021"
-        ],
-        "progression": "App Exploration"
+        ]
       },
       "named_level": null,
       "bonus": null,
@@ -2398,10 +2398,10 @@
       "activity_section_position": 2,
       "assessment": null,
       "properties": {
+        "progression": "App Exploration",
         "level_keys": [
           "CSP U3 Bird Quiz App_2021"
-        ],
-        "progression": "App Exploration"
+        ]
       },
       "named_level": null,
       "bonus": null,
@@ -2424,10 +2424,10 @@
       "activity_section_position": 3,
       "assessment": null,
       "properties": {
+        "progression": "App Exploration",
         "level_keys": [
           "CSP U3 Hamilton Township App_2021"
-        ],
-        "progression": "App Exploration"
+        ]
       },
       "named_level": null,
       "bonus": null,
@@ -2450,10 +2450,10 @@
       "activity_section_position": 4,
       "assessment": null,
       "properties": {
+        "progression": "App Exploration",
         "level_keys": [
           "CSP U3 Four Square App_2021"
-        ],
-        "progression": "App Exploration"
+        ]
       },
       "named_level": null,
       "bonus": null,
@@ -2476,10 +2476,10 @@
       "activity_section_position": 5,
       "assessment": null,
       "properties": {
+        "progression": "App Exploration",
         "level_keys": [
           "CSP U3 Monarch Butterfly App_2021"
-        ],
-        "progression": "App Exploration"
+        ]
       },
       "named_level": null,
       "bonus": null,
@@ -2502,10 +2502,10 @@
       "activity_section_position": 1,
       "assessment": null,
       "properties": {
+        "progression": "How Computers Work",
         "level_keys": [
           "How Computers Work part 1 CSP_2021"
-        ],
-        "progression": "How Computers Work"
+        ]
       },
       "named_level": null,
       "bonus": null,
@@ -2528,10 +2528,10 @@
       "activity_section_position": 1,
       "assessment": null,
       "properties": {
+        "progression": "App Investigation",
         "level_keys": [
           "CSP U3 Water Conservation Sample App Investigate_2021"
-        ],
-        "progression": "App Investigation"
+        ]
       },
       "named_level": null,
       "bonus": null,
@@ -2554,10 +2554,10 @@
       "activity_section_position": 2,
       "assessment": null,
       "properties": {
+        "progression": "App Investigation",
         "level_keys": [
           "CSP U3 Bird Quiz App Investigation_2021"
-        ],
-        "progression": "App Investigation"
+        ]
       },
       "named_level": null,
       "bonus": null,
@@ -2580,10 +2580,10 @@
       "activity_section_position": 3,
       "assessment": null,
       "properties": {
+        "progression": "App Investigation",
         "level_keys": [
           "CSP U3 Hamilton Township App Investigation_2021"
-        ],
-        "progression": "App Investigation"
+        ]
       },
       "named_level": null,
       "bonus": null,
@@ -2606,10 +2606,10 @@
       "activity_section_position": 4,
       "assessment": null,
       "properties": {
+        "progression": "App Investigation",
         "level_keys": [
           "CSP U3 Four Square App Investigation_2021"
-        ],
-        "progression": "App Investigation"
+        ]
       },
       "named_level": null,
       "bonus": null,
@@ -2632,10 +2632,10 @@
       "activity_section_position": 5,
       "assessment": null,
       "properties": {
+        "progression": "App Investigation",
         "level_keys": [
           "CSP U3 Monarch Butterfly App Investigation_2021"
-        ],
-        "progression": "App Investigation"
+        ]
       },
       "named_level": null,
       "bonus": null,
@@ -2658,10 +2658,10 @@
       "activity_section_position": 1,
       "assessment": true,
       "properties": {
+        "progression": "Check For Understanding",
         "level_keys": [
           "CSP U3 L1 Input Output Matching_2021"
-        ],
-        "progression": "Check For Understanding"
+        ]
       },
       "named_level": null,
       "bonus": null,
@@ -2684,10 +2684,10 @@
       "activity_section_position": 1,
       "assessment": null,
       "properties": {
+        "progression": "Design Mode Exploration",
         "level_keys": [
           "CSP U3 Hamilton Township Design Mode_2021"
-        ],
-        "progression": "Design Mode Exploration"
+        ]
       },
       "named_level": null,
       "bonus": null,
@@ -2710,10 +2710,10 @@
       "activity_section_position": 2,
       "assessment": null,
       "properties": {
+        "progression": "Design Mode Exploration",
         "level_keys": [
           "CSP U3 L2 Design Mode Themes_2021"
-        ],
-        "progression": "Design Mode Exploration"
+        ]
       },
       "named_level": null,
       "bonus": null,
@@ -2736,10 +2736,10 @@
       "activity_section_position": 3,
       "assessment": null,
       "properties": {
+        "progression": "Design Mode Exploration",
         "level_keys": [
           "CSP U3 L2 Design Mode Colors_2021"
-        ],
-        "progression": "Design Mode Exploration"
+        ]
       },
       "named_level": null,
       "bonus": null,
@@ -2762,10 +2762,10 @@
       "activity_section_position": 4,
       "assessment": null,
       "properties": {
+        "progression": "Design Mode Exploration",
         "level_keys": [
           "CSP U3 L2 Design Mode Images_2021"
-        ],
-        "progression": "Design Mode Exploration"
+        ]
       },
       "named_level": null,
       "bonus": null,
@@ -2788,10 +2788,10 @@
       "activity_section_position": 5,
       "assessment": null,
       "properties": {
+        "progression": "Design Mode Exploration",
         "level_keys": [
           "CSP U3 L2 Design Mode Icons_2021"
-        ],
-        "progression": "Design Mode Exploration"
+        ]
       },
       "named_level": null,
       "bonus": null,
@@ -2814,10 +2814,10 @@
       "activity_section_position": 6,
       "assessment": null,
       "properties": {
+        "progression": "Design Mode Exploration",
         "level_keys": [
           "CSP U3 L2 Design Mode ids_2021"
-        ],
-        "progression": "Design Mode Exploration"
+        ]
       },
       "named_level": null,
       "bonus": null,
@@ -2840,10 +2840,10 @@
       "activity_section_position": 1,
       "assessment": null,
       "properties": {
+        "progression": "Copy an App",
         "level_keys": [
           "CSP U3 L2 Copy an App_2021"
-        ],
-        "progression": "Copy an App"
+        ]
       },
       "named_level": null,
       "bonus": null,
@@ -2866,10 +2866,10 @@
       "activity_section_position": 1,
       "assessment": true,
       "properties": {
+        "progression": "Check For Understanding",
         "level_keys": [
           "U3L2 CSP CFU ID names_2021"
-        ],
-        "progression": "Check For Understanding"
+        ]
       },
       "named_level": null,
       "bonus": null,
@@ -2892,10 +2892,10 @@
       "activity_section_position": 1,
       "assessment": null,
       "properties": {
+        "progression": "Sample Prototype",
         "level_keys": [
           "CSP U3 Bird Quiz Storyboard_2021"
-        ],
-        "progression": "Sample Prototype"
+        ]
       },
       "named_level": null,
       "bonus": null,
@@ -2918,10 +2918,10 @@
       "activity_section_position": 1,
       "assessment": null,
       "properties": {
+        "progression": "Build Your Screens",
         "level_keys": [
           "CSP U3 L4 Design Screens_2021"
-        ],
-        "progression": "Build Your Screens"
+        ]
       },
       "named_level": null,
       "bonus": null,
@@ -2944,10 +2944,10 @@
       "activity_section_position": 1,
       "assessment": true,
       "properties": {
+        "progression": "Check For Understanding",
         "level_keys": [
           "U3L5 CSP CFU natural language_2021"
-        ],
-        "progression": "Check For Understanding"
+        ]
       },
       "named_level": null,
       "bonus": null,
@@ -2970,10 +2970,10 @@
       "activity_section_position": 1,
       "assessment": null,
       "properties": {
+        "progression": "Code Investigation",
         "level_keys": [
           "U3 Program Investigate Sequential 1_2021"
-        ],
-        "progression": "Code Investigation"
+        ]
       },
       "named_level": null,
       "bonus": null,
@@ -2996,10 +2996,10 @@
       "activity_section_position": 2,
       "assessment": null,
       "properties": {
+        "progression": "Code Investigation",
         "level_keys": [
           "U3 Program Investigate Sequential 2_2021"
-        ],
-        "progression": "Code Investigation"
+        ]
       },
       "named_level": null,
       "bonus": null,
@@ -3022,10 +3022,10 @@
       "activity_section_position": 3,
       "assessment": null,
       "properties": {
+        "progression": "Code Investigation",
         "level_keys": [
           "U3 Program Investigate Event-Driven 1_2021"
-        ],
-        "progression": "Code Investigation"
+        ]
       },
       "named_level": null,
       "bonus": null,
@@ -3048,10 +3048,10 @@
       "activity_section_position": 4,
       "assessment": null,
       "properties": {
+        "progression": "Code Investigation",
         "level_keys": [
           "U3 Program Investigate Event-Driven 2_2021"
-        ],
-        "progression": "Code Investigation"
+        ]
       },
       "named_level": null,
       "bonus": null,
@@ -3074,10 +3074,10 @@
       "activity_section_position": 5,
       "assessment": null,
       "properties": {
+        "progression": "Code Investigation",
         "level_keys": [
           "U3 Program Investigate Event-Driven 3_2021"
-        ],
-        "progression": "Code Investigation"
+        ]
       },
       "named_level": null,
       "bonus": null,
@@ -3100,10 +3100,10 @@
       "activity_section_position": 1,
       "assessment": true,
       "properties": {
+        "progression": "Check for Understanding",
         "level_keys": [
           "U3L6 CSP CFU Sequential vs Event Driven_2021"
-        ],
-        "progression": "Check for Understanding"
+        ]
       },
       "named_level": null,
       "bonus": null,
@@ -3126,10 +3126,10 @@
       "activity_section_position": 1,
       "assessment": null,
       "properties": {
+        "progression": "Debugging",
         "level_keys": [
           "U3 Program Practice Pt 1_2021"
-        ],
-        "progression": "Debugging"
+        ]
       },
       "named_level": null,
       "bonus": null,
@@ -3152,10 +3152,10 @@
       "activity_section_position": 2,
       "assessment": null,
       "properties": {
+        "progression": "Debugging",
         "level_keys": [
           "U3 Program Practice Pt 2_2021"
-        ],
-        "progression": "Debugging"
+        ]
       },
       "named_level": null,
       "bonus": null,
@@ -3178,10 +3178,10 @@
       "activity_section_position": 3,
       "assessment": null,
       "properties": {
+        "progression": "Debugging",
         "level_keys": [
           "U3 Program Practice Pt 3_2021"
-        ],
-        "progression": "Debugging"
+        ]
       },
       "named_level": null,
       "bonus": null,
@@ -3204,10 +3204,10 @@
       "activity_section_position": 4,
       "assessment": null,
       "properties": {
+        "progression": "Debugging",
         "level_keys": [
           "U3 Program Practice Pt 4_2021"
-        ],
-        "progression": "Debugging"
+        ]
       },
       "named_level": null,
       "bonus": null,
@@ -3230,10 +3230,10 @@
       "activity_section_position": 5,
       "assessment": null,
       "properties": {
+        "progression": "Debugging",
         "level_keys": [
           "U3 Program Practice Pt 5_2021"
-        ],
-        "progression": "Debugging"
+        ]
       },
       "named_level": null,
       "bonus": null,
@@ -3256,10 +3256,10 @@
       "activity_section_position": 6,
       "assessment": null,
       "properties": {
+        "progression": "Debugging",
         "level_keys": [
           "U3 Program Practice Pt 6_2021"
-        ],
-        "progression": "Debugging"
+        ]
       },
       "named_level": null,
       "bonus": null,
@@ -3282,10 +3282,10 @@
       "activity_section_position": 7,
       "assessment": null,
       "properties": {
+        "progression": "Debugging",
         "level_keys": [
           "U3 Program Practice Pt 8_2021"
-        ],
-        "progression": "Debugging"
+        ]
       },
       "named_level": null,
       "bonus": null,
@@ -3308,10 +3308,10 @@
       "activity_section_position": 1,
       "assessment": true,
       "properties": {
+        "progression": "Check for Understanding",
         "level_keys": [
           "U3L7 CSP CFU What was confusing_2021"
-        ],
-        "progression": "Check for Understanding"
+        ]
       },
       "named_level": null,
       "bonus": null,
@@ -3334,10 +3334,10 @@
       "activity_section_position": 1,
       "assessment": null,
       "properties": {
+        "progression": "Pair Programming",
         "level_keys": [
           "U3 L08 Pair Programming Video_2021"
-        ],
-        "progression": "Pair Programming"
+        ]
       },
       "named_level": null,
       "bonus": null,
@@ -3360,10 +3360,10 @@
       "activity_section_position": 1,
       "assessment": null,
       "properties": {
+        "progression": "Add Code",
         "level_keys": [
           "CSP U3 L4 Add Code_2021"
-        ],
-        "progression": "Add Code"
+        ]
       },
       "named_level": null,
       "bonus": null,
@@ -3386,10 +3386,10 @@
       "activity_section_position": 1,
       "assessment": null,
       "properties": {
+        "progression": "Add More Code",
         "level_keys": [
           "CSP U3 L9 Add More Code_2021"
-        ],
-        "progression": "Add More Code"
+        ]
       },
       "named_level": null,
       "bonus": null,
@@ -3412,10 +3412,10 @@
       "activity_section_position": 1,
       "assessment": true,
       "properties": {
+        "progression": "Submit your app",
         "level_keys": [
           "CSP U3 L10 Submit App_2021"
-        ],
-        "progression": "Submit your app"
+        ]
       },
       "named_level": null,
       "bonus": null,
@@ -3438,10 +3438,10 @@
       "activity_section_position": 1,
       "assessment": true,
       "properties": {
+        "progression": "Unit 3 Exam",
         "level_keys": [
           "CSP Unit 3 MC Assessment _2021"
-        ],
-        "progression": "Unit 3 Exam"
+        ]
       },
       "named_level": null,
       "bonus": null,
@@ -4549,8 +4549,5 @@
         "objective.key": "802cfd1b-a6af-429b-b188-bcb1e7b854e3"
       }
     }
-  ],
-  "lessons_standards": [
-
   ]
 }

--- a/dashboard/config/scripts_json/csp4-2021.script_json
+++ b/dashboard/config/scripts_json/csp4-2021.script_json
@@ -19,7 +19,7 @@
     },
     "new_name": null,
     "family_name": null,
-    "serialized_at": "2021-03-18 18:21:23 UTC",
+    "serialized_at": "2021-03-18 22:06:39 UTC",
     "seeding_key": {
       "script.name": "csp4-2021"
     }
@@ -3610,10 +3610,10 @@
       "activity_section_position": 1,
       "assessment": false,
       "properties": {
-        "progression": "Sample Apps",
         "level_keys": [
           "CSP U4 My Pet Rock Example App_2021"
-        ]
+        ],
+        "progression": "Sample Apps"
       },
       "named_level": null,
       "bonus": null,
@@ -3636,10 +3636,10 @@
       "activity_section_position": 2,
       "assessment": false,
       "properties": {
-        "progression": "Sample Apps",
         "level_keys": [
           "U4 L01 Poetry App_2021"
-        ]
+        ],
+        "progression": "Sample Apps"
       },
       "named_level": null,
       "bonus": null,
@@ -3662,10 +3662,10 @@
       "activity_section_position": 3,
       "assessment": false,
       "properties": {
-        "progression": "Sample Apps",
         "level_keys": [
           "U4 L01 Thermostat App_2021"
-        ]
+        ],
+        "progression": "Sample Apps"
       },
       "named_level": null,
       "bonus": null,
@@ -3688,10 +3688,10 @@
       "activity_section_position": 1,
       "assessment": true,
       "properties": {
-        "progression": "Check For Understanding",
         "level_keys": [
           "U1 L02 CYU MC_2021"
-        ]
+        ],
+        "progression": "Check For Understanding"
       },
       "named_level": null,
       "bonus": null,
@@ -3714,10 +3714,10 @@
       "activity_section_position": 1,
       "assessment": null,
       "properties": {
-        "progression": "Investigation #1: Thermostat App v.1 (Levels 1 - 2) - 10 mins",
         "level_keys": [
           "U4 L02 Thermostat App v1_2021"
-        ]
+        ],
+        "progression": "Investigation #1: Thermostat App v.1 (Levels 1 - 2) - 10 mins"
       },
       "named_level": null,
       "bonus": null,
@@ -3740,10 +3740,10 @@
       "activity_section_position": 2,
       "assessment": null,
       "properties": {
-        "progression": "Investigation #1: Thermostat App v.1 (Levels 1 - 2) - 10 mins",
         "level_keys": [
           "U4 L02 Thermostat App v1 Code_2021"
-        ]
+        ],
+        "progression": "Investigation #1: Thermostat App v.1 (Levels 1 - 2) - 10 mins"
       },
       "named_level": null,
       "bonus": null,
@@ -3766,10 +3766,10 @@
       "activity_section_position": 1,
       "assessment": null,
       "properties": {
-        "progression": "Investigation #2: Thermostat App v.2 (Level 3) - 10 mins",
         "level_keys": [
           "U4 L02 Thermostat App v2_2021"
-        ]
+        ],
+        "progression": "Investigation #2: Thermostat App v.2 (Level 3) - 10 mins"
       },
       "named_level": null,
       "bonus": null,
@@ -3792,10 +3792,10 @@
       "activity_section_position": 1,
       "assessment": null,
       "properties": {
-        "progression": "Investigation #3: Thermostat App v.3 (Levels 4 - 5) - 8 mins",
         "level_keys": [
           "U4 L02 Thermostat App v3_2021"
-        ]
+        ],
+        "progression": "Investigation #3: Thermostat App v.3 (Levels 4 - 5) - 8 mins"
       },
       "named_level": null,
       "bonus": null,
@@ -3818,10 +3818,10 @@
       "activity_section_position": 2,
       "assessment": null,
       "properties": {
-        "progression": "Investigation #3: Thermostat App v.3 (Levels 4 - 5) - 8 mins",
         "level_keys": [
           "U4 L02 Thermostat App v3 pt2_2021"
-        ]
+        ],
+        "progression": "Investigation #3: Thermostat App v.3 (Levels 4 - 5) - 8 mins"
       },
       "named_level": null,
       "bonus": null,
@@ -3844,10 +3844,10 @@
       "activity_section_position": 1,
       "assessment": true,
       "properties": {
-        "progression": "Assessment: Check For Understanding\r",
         "level_keys": [
           "U4 L02 CYU Exit Ticket_2021"
-        ]
+        ],
+        "progression": "Assessment: Check For Understanding\r"
       },
       "named_level": null,
       "bonus": null,
@@ -3870,10 +3870,10 @@
       "activity_section_position": 1,
       "assessment": null,
       "properties": {
-        "progression": "Assigning Numbers and Strings",
         "level_keys": [
           "U4 L03 Variables numbers practice 1_2021"
-        ]
+        ],
+        "progression": "Assigning Numbers and Strings"
       },
       "named_level": null,
       "bonus": null,
@@ -3896,10 +3896,10 @@
       "activity_section_position": 2,
       "assessment": null,
       "properties": {
-        "progression": "Assigning Numbers and Strings",
         "level_keys": [
           "U4 L03 Variables numbers practice 4_2021"
-        ]
+        ],
+        "progression": "Assigning Numbers and Strings"
       },
       "named_level": null,
       "bonus": null,
@@ -3922,10 +3922,10 @@
       "activity_section_position": 1,
       "assessment": null,
       "properties": {
-        "progression": "Variables and Operators",
         "level_keys": [
           "U4 L03 Variables operator practice 1_2021"
-        ]
+        ],
+        "progression": "Variables and Operators"
       },
       "named_level": null,
       "bonus": null,
@@ -3948,10 +3948,10 @@
       "activity_section_position": 2,
       "assessment": null,
       "properties": {
-        "progression": "Variables and Operators",
         "level_keys": [
           "U4 L03 Variables operator practice 3_2021"
-        ]
+        ],
+        "progression": "Variables and Operators"
       },
       "named_level": null,
       "bonus": null,
@@ -3974,10 +3974,10 @@
       "activity_section_position": 3,
       "assessment": null,
       "properties": {
-        "progression": "Variables and Operators",
         "level_keys": [
           "U4 L03 Variables operator practice 2_2021"
-        ]
+        ],
+        "progression": "Variables and Operators"
       },
       "named_level": null,
       "bonus": null,
@@ -4000,10 +4000,10 @@
       "activity_section_position": 4,
       "assessment": null,
       "properties": {
-        "progression": "Variables and Operators",
         "level_keys": [
           "U4 L03 Variables operator practice 5_2021"
-        ]
+        ],
+        "progression": "Variables and Operators"
       },
       "named_level": null,
       "bonus": null,
@@ -4026,10 +4026,10 @@
       "activity_section_position": 5,
       "assessment": null,
       "properties": {
-        "progression": "Variables and Operators",
         "level_keys": [
           "U4 L03 Variables operator practice 6_2021"
-        ]
+        ],
+        "progression": "Variables and Operators"
       },
       "named_level": null,
       "bonus": null,
@@ -4052,10 +4052,10 @@
       "activity_section_position": 1,
       "assessment": null,
       "properties": {
-        "progression": "Debugging Scope Issues",
         "level_keys": [
           "U4 L03 Variable Scope: Local vs. Global_2021"
-        ]
+        ],
+        "progression": "Debugging Scope Issues"
       },
       "named_level": null,
       "bonus": null,
@@ -4078,10 +4078,10 @@
       "activity_section_position": 2,
       "assessment": null,
       "properties": {
-        "progression": "Debugging Scope Issues",
         "level_keys": [
           "U4 L03 Scope Issue_2021"
-        ]
+        ],
+        "progression": "Debugging Scope Issues"
       },
       "named_level": null,
       "bonus": null,
@@ -4104,10 +4104,10 @@
       "activity_section_position": 1,
       "assessment": null,
       "properties": {
-        "progression": "Putting it Together",
         "level_keys": [
           "U4 L03 Variables operator practice 4_2021"
-        ]
+        ],
+        "progression": "Putting it Together"
       },
       "named_level": null,
       "bonus": null,
@@ -4130,10 +4130,10 @@
       "activity_section_position": 1,
       "assessment": true,
       "properties": {
-        "progression": "Assessment: Check For Understanding: AP Practice\r",
         "level_keys": [
           "U4L3 CFU Variables Psuedocode_2021"
-        ]
+        ],
+        "progression": "Assessment: Check For Understanding: AP Practice\r"
       },
       "named_level": null,
       "bonus": null,
@@ -4156,10 +4156,10 @@
       "activity_section_position": 2,
       "assessment": true,
       "properties": {
-        "progression": "Assessment: Check For Understanding: AP Practice\r",
         "level_keys": [
           "U4L3 CFU Variables Randomness Psuedocode_2021"
-        ]
+        ],
+        "progression": "Assessment: Check For Understanding: AP Practice\r"
       },
       "named_level": null,
       "bonus": null,
@@ -4182,10 +4182,10 @@
       "activity_section_position": 1,
       "assessment": null,
       "properties": {
-        "progression": "Try the Photo Liker app",
         "level_keys": [
           "U4 L04 Variables Make Project_2021"
-        ]
+        ],
+        "progression": "Try the Photo Liker app"
       },
       "named_level": null,
       "bonus": null,
@@ -4208,10 +4208,10 @@
       "activity_section_position": 1,
       "assessment": true,
       "properties": {
-        "progression": "Make the Photo Liker app",
         "level_keys": [
           "U4 L04 Variables Make Project Submit_2021"
-        ]
+        ],
+        "progression": "Make the Photo Liker app"
       },
       "named_level": null,
       "bonus": null,
@@ -4234,10 +4234,10 @@
       "activity_section_position": 1,
       "assessment": null,
       "properties": {
-        "progression": "Conditionals: Boolean Expressions",
         "level_keys": [
           "U4 L06 Introduction to Conditionals: Boolean Expressions_2021"
-        ]
+        ],
+        "progression": "Conditionals: Boolean Expressions"
       },
       "named_level": null,
       "bonus": null,
@@ -4260,10 +4260,10 @@
       "activity_section_position": 1,
       "assessment": true,
       "properties": {
-        "progression": "Assessment: Check For Understanding\r",
         "level_keys": [
           "U4 L05 CYU Exit Ticket_2021"
-        ]
+        ],
+        "progression": "Assessment: Check For Understanding\r"
       },
       "named_level": null,
       "bonus": null,
@@ -4286,10 +4286,10 @@
       "activity_section_position": 1,
       "assessment": null,
       "properties": {
-        "progression": "If-Statements",
         "level_keys": [
           "U4 L06 Lemon Hunter App v1 Code_2021"
-        ]
+        ],
+        "progression": "If-Statements"
       },
       "named_level": null,
       "bonus": null,
@@ -4312,10 +4312,10 @@
       "activity_section_position": 2,
       "assessment": null,
       "properties": {
-        "progression": "If-Statements",
         "level_keys": [
           "U4L06 Introduction to Conditionals: if Statements_2021"
-        ]
+        ],
+        "progression": "If-Statements"
       },
       "named_level": null,
       "bonus": null,
@@ -4338,10 +4338,10 @@
       "activity_section_position": 1,
       "assessment": null,
       "properties": {
-        "progression": "If-Else Statements",
         "level_keys": [
           "U4L06 Introduction to Conditionals: if-else Statements_2021"
-        ]
+        ],
+        "progression": "If-Else Statements"
       },
       "named_level": null,
       "bonus": null,
@@ -4364,10 +4364,10 @@
       "activity_section_position": 2,
       "assessment": null,
       "properties": {
-        "progression": "If-Else Statements",
         "level_keys": [
           "U4L06 Introduction to Conditionals: if-else-if Statements_2021"
-        ]
+        ],
+        "progression": "If-Else Statements"
       },
       "named_level": null,
       "bonus": null,
@@ -4390,10 +4390,10 @@
       "activity_section_position": 3,
       "assessment": null,
       "properties": {
-        "progression": "If-Else Statements",
         "level_keys": [
           "U4 L06 Lemon Hunter App v2 Code_2021"
-        ]
+        ],
+        "progression": "If-Else Statements"
       },
       "named_level": null,
       "bonus": null,
@@ -4416,10 +4416,10 @@
       "activity_section_position": 1,
       "assessment": null,
       "properties": {
-        "progression": "Logical Operators: AND OR",
         "level_keys": [
           "U4L06 Introduction to Conditionals: Compound Boolean Expressions_2021"
-        ]
+        ],
+        "progression": "Logical Operators: AND OR"
       },
       "named_level": null,
       "bonus": null,
@@ -4442,10 +4442,10 @@
       "activity_section_position": 2,
       "assessment": null,
       "properties": {
-        "progression": "Logical Operators: AND OR",
         "level_keys": [
           "U4 L06 Lemon Hunter App v3 Code_2021"
-        ]
+        ],
+        "progression": "Logical Operators: AND OR"
       },
       "named_level": null,
       "bonus": null,
@@ -4468,10 +4468,10 @@
       "activity_section_position": 1,
       "assessment": true,
       "properties": {
-        "progression": "Patterns: If-else-if",
         "level_keys": [
           "U4 L06 CYU Exit Ticket_2021"
-        ]
+        ],
+        "progression": "Patterns: If-else-if"
       },
       "named_level": null,
       "bonus": null,
@@ -4494,10 +4494,10 @@
       "activity_section_position": 1,
       "assessment": null,
       "properties": {
-        "progression": "Check Your Understanding",
         "level_keys": [
           "Checking Multiple Conditions with If-elseif_2021"
-        ]
+        ],
+        "progression": "Check Your Understanding"
       },
       "named_level": null,
       "bonus": null,
@@ -4520,10 +4520,10 @@
       "activity_section_position": 1,
       "assessment": null,
       "properties": {
-        "progression": "Boolean expressions",
         "level_keys": [
           "U4 L07 Conditionals Practice 1_2021"
-        ]
+        ],
+        "progression": "Boolean expressions"
       },
       "named_level": null,
       "bonus": null,
@@ -4546,10 +4546,10 @@
       "activity_section_position": 2,
       "assessment": null,
       "properties": {
-        "progression": "Boolean expressions",
         "level_keys": [
           "U4 L07 Conditionals Practice 2_2021"
-        ]
+        ],
+        "progression": "Boolean expressions"
       },
       "named_level": null,
       "bonus": null,
@@ -4572,10 +4572,10 @@
       "activity_section_position": 3,
       "assessment": null,
       "properties": {
-        "progression": "Boolean expressions",
         "level_keys": [
           "U4 L07 Conditionals Practice 3_2021"
-        ]
+        ],
+        "progression": "Boolean expressions"
       },
       "named_level": null,
       "bonus": null,
@@ -4598,10 +4598,10 @@
       "activity_section_position": 1,
       "assessment": null,
       "properties": {
-        "progression": "If-Statements",
         "level_keys": [
           "U4 L07 Conditionals Practice 10_2021"
-        ]
+        ],
+        "progression": "If-Statements"
       },
       "named_level": null,
       "bonus": null,
@@ -4624,10 +4624,10 @@
       "activity_section_position": 2,
       "assessment": null,
       "properties": {
-        "progression": "If-Statements",
         "level_keys": [
           "U4 L07 Conditionals Practice 4_2021"
-        ]
+        ],
+        "progression": "If-Statements"
       },
       "named_level": null,
       "bonus": null,
@@ -4650,10 +4650,10 @@
       "activity_section_position": 3,
       "assessment": null,
       "properties": {
-        "progression": "If-Statements",
         "level_keys": [
           "U4 L07 Conditionals Practice 5_2021"
-        ]
+        ],
+        "progression": "If-Statements"
       },
       "named_level": null,
       "bonus": null,
@@ -4676,10 +4676,10 @@
       "activity_section_position": 4,
       "assessment": null,
       "properties": {
-        "progression": "If-Statements",
         "level_keys": [
           "U4 L07 Conditionals Practice 6_2021"
-        ]
+        ],
+        "progression": "If-Statements"
       },
       "named_level": null,
       "bonus": null,
@@ -4702,10 +4702,10 @@
       "activity_section_position": 5,
       "assessment": null,
       "properties": {
-        "progression": "If-Statements",
         "level_keys": [
           "U4 L07 Conditionals Practice equivalent expressions_2021"
-        ]
+        ],
+        "progression": "If-Statements"
       },
       "named_level": null,
       "bonus": null,
@@ -4728,10 +4728,10 @@
       "activity_section_position": 1,
       "assessment": null,
       "properties": {
-        "progression": "Logical Operators",
         "level_keys": [
           "U4 L07 Conditionals Practice 7_2021"
-        ]
+        ],
+        "progression": "Logical Operators"
       },
       "named_level": null,
       "bonus": null,
@@ -4754,10 +4754,10 @@
       "activity_section_position": 2,
       "assessment": null,
       "properties": {
-        "progression": "Logical Operators",
         "level_keys": [
           "U4 L07 Conditionals Practice 8_2021"
-        ]
+        ],
+        "progression": "Logical Operators"
       },
       "named_level": null,
       "bonus": null,
@@ -4780,10 +4780,10 @@
       "activity_section_position": 1,
       "assessment": true,
       "properties": {
-        "progression": "Check For Understanding: AP Practice",
         "level_keys": [
           "U4L10 CFU Conditionals Psuedocode_2021"
-        ]
+        ],
+        "progression": "Check For Understanding: AP Practice"
       },
       "named_level": null,
       "bonus": null,
@@ -4806,10 +4806,10 @@
       "activity_section_position": 2,
       "assessment": true,
       "properties": {
-        "progression": "Check For Understanding: AP Practice",
         "level_keys": [
           "U4L10 CFU Conditionals Psuedocode 2_2021"
-        ]
+        ],
+        "progression": "Check For Understanding: AP Practice"
       },
       "named_level": null,
       "bonus": null,
@@ -4832,10 +4832,10 @@
       "activity_section_position": 1,
       "assessment": null,
       "properties": {
-        "progression": "Try to the Museum Ticket Generator App",
         "level_keys": [
           "U4 L08 Conditionals Make Project Sample_2021"
-        ]
+        ],
+        "progression": "Try to the Museum Ticket Generator App"
       },
       "named_level": null,
       "bonus": null,
@@ -4858,10 +4858,10 @@
       "activity_section_position": 1,
       "assessment": true,
       "properties": {
-        "progression": "Make the Museum Ticket Generator App",
         "level_keys": [
           "U4L08 Museum Ticket Generator_2021"
-        ]
+        ],
+        "progression": "Make the Museum Ticket Generator App"
       },
       "named_level": null,
       "bonus": null,
@@ -4884,10 +4884,10 @@
       "activity_section_position": 1,
       "assessment": null,
       "properties": {
-        "progression": "Explore Functions",
         "level_keys": [
           "U4 L09 Functions Song_2021"
-        ]
+        ],
+        "progression": "Explore Functions"
       },
       "named_level": null,
       "bonus": null,
@@ -4910,10 +4910,10 @@
       "activity_section_position": 1,
       "assessment": null,
       "properties": {
-        "progression": "Declaring and Calling Functions",
         "level_keys": [
           "U4L09 Intro to Functions Video_2021"
-        ]
+        ],
+        "progression": "Declaring and Calling Functions"
       },
       "named_level": null,
       "bonus": null,
@@ -4936,10 +4936,10 @@
       "activity_section_position": 2,
       "assessment": null,
       "properties": {
-        "progression": "Declaring and Calling Functions",
         "level_keys": [
           "U4 L09 Score Clicker Investigate_2021"
-        ]
+        ],
+        "progression": "Declaring and Calling Functions"
       },
       "named_level": null,
       "bonus": null,
@@ -4962,10 +4962,10 @@
       "activity_section_position": 3,
       "assessment": null,
       "properties": {
-        "progression": "Declaring and Calling Functions",
         "level_keys": [
           "U4 L09 Thermostat App v7_2021"
-        ]
+        ],
+        "progression": "Declaring and Calling Functions"
       },
       "named_level": null,
       "bonus": null,
@@ -4988,10 +4988,10 @@
       "activity_section_position": 1,
       "assessment": null,
       "properties": {
-        "progression": "Update Screen Pattern",
         "level_keys": [
           "updateScreen Pattern_2021"
-        ]
+        ],
+        "progression": "Update Screen Pattern"
       },
       "named_level": null,
       "bonus": null,
@@ -5014,10 +5014,10 @@
       "activity_section_position": 1,
       "assessment": true,
       "properties": {
-        "progression": "Check Your Understanding",
         "level_keys": [
           "CSP U4 L09 CFU Exit Ticket_2021"
-        ]
+        ],
+        "progression": "Check Your Understanding"
       },
       "named_level": null,
       "bonus": null,
@@ -5040,10 +5040,10 @@
       "activity_section_position": 1,
       "assessment": null,
       "properties": {
-        "progression": "Declare and Call Functions",
         "level_keys": [
           "U4 L10 Functions Practice Calling Functions 1_2021"
-        ]
+        ],
+        "progression": "Declare and Call Functions"
       },
       "named_level": null,
       "bonus": null,
@@ -5066,10 +5066,10 @@
       "activity_section_position": 2,
       "assessment": null,
       "properties": {
-        "progression": "Declare and Call Functions",
         "level_keys": [
           "U4 L10 Functions Practice 1_2021"
-        ]
+        ],
+        "progression": "Declare and Call Functions"
       },
       "named_level": null,
       "bonus": null,
@@ -5092,10 +5092,10 @@
       "activity_section_position": 3,
       "assessment": null,
       "properties": {
-        "progression": "Declare and Call Functions",
         "level_keys": [
           "U4 L10 Functions Practice 2_2021"
-        ]
+        ],
+        "progression": "Declare and Call Functions"
       },
       "named_level": null,
       "bonus": null,
@@ -5118,10 +5118,10 @@
       "activity_section_position": 4,
       "assessment": null,
       "properties": {
-        "progression": "Declare and Call Functions",
         "level_keys": [
           "U4 L10 Functions Practice 3_2021"
-        ]
+        ],
+        "progression": "Declare and Call Functions"
       },
       "named_level": null,
       "bonus": null,
@@ -5144,10 +5144,10 @@
       "activity_section_position": 5,
       "assessment": null,
       "properties": {
-        "progression": "Declare and Call Functions",
         "level_keys": [
           "U4 L10 Functions Build Practice 2_2021"
-        ]
+        ],
+        "progression": "Declare and Call Functions"
       },
       "named_level": null,
       "bonus": null,
@@ -5170,10 +5170,10 @@
       "activity_section_position": 1,
       "assessment": null,
       "properties": {
-        "progression": "Function Scope",
         "level_keys": [
           "Debugging Variable Scope and Functions_2021"
-        ]
+        ],
+        "progression": "Function Scope"
       },
       "named_level": null,
       "bonus": null,
@@ -5196,10 +5196,10 @@
       "activity_section_position": 2,
       "assessment": null,
       "properties": {
-        "progression": "Function Scope",
         "level_keys": [
           "U4 L10 Functions Scope Practice 1 v2_2021"
-        ]
+        ],
+        "progression": "Function Scope"
       },
       "named_level": null,
       "bonus": null,
@@ -5222,10 +5222,10 @@
       "activity_section_position": 1,
       "assessment": null,
       "properties": {
-        "progression": "When to Declare Functions",
         "level_keys": [
           "When to Make Functions Map_2021"
-        ]
+        ],
+        "progression": "When to Declare Functions"
       },
       "named_level": null,
       "bonus": null,
@@ -5248,10 +5248,10 @@
       "activity_section_position": 2,
       "assessment": null,
       "properties": {
-        "progression": "When to Declare Functions",
         "level_keys": [
           "U4 L10 Making Functions Practice_2021"
-        ]
+        ],
+        "progression": "When to Declare Functions"
       },
       "named_level": null,
       "bonus": null,
@@ -5274,10 +5274,10 @@
       "activity_section_position": 1,
       "assessment": true,
       "properties": {
-        "progression": "Check For Understanding: AP Practice",
         "level_keys": [
           "U4L10 CFU Functions Psuedocode_2021"
-        ]
+        ],
+        "progression": "Check For Understanding: AP Practice"
       },
       "named_level": null,
       "bonus": null,
@@ -5300,10 +5300,10 @@
       "activity_section_position": 1,
       "assessment": null,
       "properties": {
-        "progression": "Quote Maker App",
         "level_keys": [
           "U4 L11 Functions Make 1 2020_2021"
-        ]
+        ],
+        "progression": "Quote Maker App"
       },
       "named_level": null,
       "bonus": null,
@@ -5326,10 +5326,10 @@
       "activity_section_position": 1,
       "assessment": true,
       "properties": {
-        "progression": "Make the Quote Maker App",
         "level_keys": [
           "U4 L11 Functions Make 2020_2021"
-        ]
+        ],
+        "progression": "Make the Quote Maker App"
       },
       "named_level": null,
       "bonus": null,
@@ -5352,10 +5352,10 @@
       "activity_section_position": 1,
       "assessment": null,
       "properties": {
-        "progression": "Sample Apps",
         "level_keys": [
           "U4 L12 Practice PT 1_2021"
-        ]
+        ],
+        "progression": "Sample Apps"
       },
       "named_level": null,
       "bonus": null,
@@ -5378,10 +5378,10 @@
       "activity_section_position": 2,
       "assessment": null,
       "properties": {
-        "progression": "Sample Apps",
         "level_keys": [
           "U4 L12 Practice PT 2_2021"
-        ]
+        ],
+        "progression": "Sample Apps"
       },
       "named_level": null,
       "bonus": null,
@@ -5404,10 +5404,10 @@
       "activity_section_position": 1,
       "assessment": null,
       "properties": {
-        "progression": "Create the Screens",
         "level_keys": [
           "U4 L13 Practice PT 1_2021"
-        ]
+        ],
+        "progression": "Create the Screens"
       },
       "named_level": null,
       "bonus": null,
@@ -5430,10 +5430,10 @@
       "activity_section_position": 1,
       "assessment": null,
       "properties": {
-        "progression": "Create the Variables",
         "level_keys": [
           "U4 L13 Practice PT 2_2021"
-        ]
+        ],
+        "progression": "Create the Variables"
       },
       "named_level": null,
       "bonus": null,
@@ -5456,10 +5456,10 @@
       "activity_section_position": 1,
       "assessment": null,
       "properties": {
-        "progression": "Create the Function",
         "level_keys": [
           "U4 L13 Practice PT 3_2021"
-        ]
+        ],
+        "progression": "Create the Function"
       },
       "named_level": null,
       "bonus": null,
@@ -5482,10 +5482,10 @@
       "activity_section_position": 1,
       "assessment": null,
       "properties": {
-        "progression": "Add onEvents",
         "level_keys": [
           "U4 L13 Practice PT 4_2021"
-        ]
+        ],
+        "progression": "Add onEvents"
       },
       "named_level": null,
       "bonus": null,
@@ -5508,10 +5508,10 @@
       "activity_section_position": 1,
       "assessment": null,
       "properties": {
-        "progression": "Test Your Decision Maker App",
         "level_keys": [
           "U4 L14 Practice PT 1_2021"
-        ]
+        ],
+        "progression": "Test Your Decision Maker App"
       },
       "named_level": null,
       "bonus": null,
@@ -5534,10 +5534,10 @@
       "activity_section_position": 1,
       "assessment": true,
       "properties": {
-        "progression": "Submit Your Decision Maker App",
         "level_keys": [
           "U4 L14 Practice PT 2_2021"
-        ]
+        ],
+        "progression": "Submit Your Decision Maker App"
       },
       "named_level": null,
       "bonus": null,
@@ -5560,10 +5560,10 @@
       "activity_section_position": 1,
       "assessment": true,
       "properties": {
-        "progression": "Unit 4 Exam",
         "level_keys": [
           "CSP 20-21 Unit 4 Assessment_2021"
-        ]
+        ],
+        "progression": "Unit 4 Exam"
       },
       "named_level": null,
       "bonus": null,

--- a/dashboard/config/scripts_json/csp4-2021.script_json
+++ b/dashboard/config/scripts_json/csp4-2021.script_json
@@ -19,7 +19,7 @@
     },
     "new_name": null,
     "family_name": null,
-    "serialized_at": "2021-03-18 22:06:39 UTC",
+    "serialized_at": "2021-03-18 18:21:23 UTC",
     "seeding_key": {
       "script.name": "csp4-2021"
     }
@@ -3610,10 +3610,10 @@
       "activity_section_position": 1,
       "assessment": false,
       "properties": {
+        "progression": "Sample Apps",
         "level_keys": [
           "CSP U4 My Pet Rock Example App_2021"
-        ],
-        "progression": "Sample Apps"
+        ]
       },
       "named_level": null,
       "bonus": null,
@@ -3636,10 +3636,10 @@
       "activity_section_position": 2,
       "assessment": false,
       "properties": {
+        "progression": "Sample Apps",
         "level_keys": [
           "U4 L01 Poetry App_2021"
-        ],
-        "progression": "Sample Apps"
+        ]
       },
       "named_level": null,
       "bonus": null,
@@ -3662,10 +3662,10 @@
       "activity_section_position": 3,
       "assessment": false,
       "properties": {
+        "progression": "Sample Apps",
         "level_keys": [
           "U4 L01 Thermostat App_2021"
-        ],
-        "progression": "Sample Apps"
+        ]
       },
       "named_level": null,
       "bonus": null,
@@ -3688,10 +3688,10 @@
       "activity_section_position": 1,
       "assessment": true,
       "properties": {
+        "progression": "Check For Understanding",
         "level_keys": [
           "U1 L02 CYU MC_2021"
-        ],
-        "progression": "Check For Understanding"
+        ]
       },
       "named_level": null,
       "bonus": null,
@@ -3714,10 +3714,10 @@
       "activity_section_position": 1,
       "assessment": null,
       "properties": {
+        "progression": "Investigation #1: Thermostat App v.1 (Levels 1 - 2) - 10 mins",
         "level_keys": [
           "U4 L02 Thermostat App v1_2021"
-        ],
-        "progression": "Investigation #1: Thermostat App v.1 (Levels 1 - 2) - 10 mins"
+        ]
       },
       "named_level": null,
       "bonus": null,
@@ -3740,10 +3740,10 @@
       "activity_section_position": 2,
       "assessment": null,
       "properties": {
+        "progression": "Investigation #1: Thermostat App v.1 (Levels 1 - 2) - 10 mins",
         "level_keys": [
           "U4 L02 Thermostat App v1 Code_2021"
-        ],
-        "progression": "Investigation #1: Thermostat App v.1 (Levels 1 - 2) - 10 mins"
+        ]
       },
       "named_level": null,
       "bonus": null,
@@ -3766,10 +3766,10 @@
       "activity_section_position": 1,
       "assessment": null,
       "properties": {
+        "progression": "Investigation #2: Thermostat App v.2 (Level 3) - 10 mins",
         "level_keys": [
           "U4 L02 Thermostat App v2_2021"
-        ],
-        "progression": "Investigation #2: Thermostat App v.2 (Level 3) - 10 mins"
+        ]
       },
       "named_level": null,
       "bonus": null,
@@ -3792,10 +3792,10 @@
       "activity_section_position": 1,
       "assessment": null,
       "properties": {
+        "progression": "Investigation #3: Thermostat App v.3 (Levels 4 - 5) - 8 mins",
         "level_keys": [
           "U4 L02 Thermostat App v3_2021"
-        ],
-        "progression": "Investigation #3: Thermostat App v.3 (Levels 4 - 5) - 8 mins"
+        ]
       },
       "named_level": null,
       "bonus": null,
@@ -3818,10 +3818,10 @@
       "activity_section_position": 2,
       "assessment": null,
       "properties": {
+        "progression": "Investigation #3: Thermostat App v.3 (Levels 4 - 5) - 8 mins",
         "level_keys": [
           "U4 L02 Thermostat App v3 pt2_2021"
-        ],
-        "progression": "Investigation #3: Thermostat App v.3 (Levels 4 - 5) - 8 mins"
+        ]
       },
       "named_level": null,
       "bonus": null,
@@ -3844,10 +3844,10 @@
       "activity_section_position": 1,
       "assessment": true,
       "properties": {
+        "progression": "Assessment: Check For Understanding\r",
         "level_keys": [
           "U4 L02 CYU Exit Ticket_2021"
-        ],
-        "progression": "Assessment: Check For Understanding\r"
+        ]
       },
       "named_level": null,
       "bonus": null,
@@ -3870,10 +3870,10 @@
       "activity_section_position": 1,
       "assessment": null,
       "properties": {
+        "progression": "Assigning Numbers and Strings",
         "level_keys": [
           "U4 L03 Variables numbers practice 1_2021"
-        ],
-        "progression": "Assigning Numbers and Strings"
+        ]
       },
       "named_level": null,
       "bonus": null,
@@ -3896,10 +3896,10 @@
       "activity_section_position": 2,
       "assessment": null,
       "properties": {
+        "progression": "Assigning Numbers and Strings",
         "level_keys": [
           "U4 L03 Variables numbers practice 4_2021"
-        ],
-        "progression": "Assigning Numbers and Strings"
+        ]
       },
       "named_level": null,
       "bonus": null,
@@ -3922,10 +3922,10 @@
       "activity_section_position": 1,
       "assessment": null,
       "properties": {
+        "progression": "Variables and Operators",
         "level_keys": [
           "U4 L03 Variables operator practice 1_2021"
-        ],
-        "progression": "Variables and Operators"
+        ]
       },
       "named_level": null,
       "bonus": null,
@@ -3948,10 +3948,10 @@
       "activity_section_position": 2,
       "assessment": null,
       "properties": {
+        "progression": "Variables and Operators",
         "level_keys": [
           "U4 L03 Variables operator practice 3_2021"
-        ],
-        "progression": "Variables and Operators"
+        ]
       },
       "named_level": null,
       "bonus": null,
@@ -3974,10 +3974,10 @@
       "activity_section_position": 3,
       "assessment": null,
       "properties": {
+        "progression": "Variables and Operators",
         "level_keys": [
           "U4 L03 Variables operator practice 2_2021"
-        ],
-        "progression": "Variables and Operators"
+        ]
       },
       "named_level": null,
       "bonus": null,
@@ -4000,10 +4000,10 @@
       "activity_section_position": 4,
       "assessment": null,
       "properties": {
+        "progression": "Variables and Operators",
         "level_keys": [
           "U4 L03 Variables operator practice 5_2021"
-        ],
-        "progression": "Variables and Operators"
+        ]
       },
       "named_level": null,
       "bonus": null,
@@ -4026,10 +4026,10 @@
       "activity_section_position": 5,
       "assessment": null,
       "properties": {
+        "progression": "Variables and Operators",
         "level_keys": [
           "U4 L03 Variables operator practice 6_2021"
-        ],
-        "progression": "Variables and Operators"
+        ]
       },
       "named_level": null,
       "bonus": null,
@@ -4052,10 +4052,10 @@
       "activity_section_position": 1,
       "assessment": null,
       "properties": {
+        "progression": "Debugging Scope Issues",
         "level_keys": [
           "U4 L03 Variable Scope: Local vs. Global_2021"
-        ],
-        "progression": "Debugging Scope Issues"
+        ]
       },
       "named_level": null,
       "bonus": null,
@@ -4078,10 +4078,10 @@
       "activity_section_position": 2,
       "assessment": null,
       "properties": {
+        "progression": "Debugging Scope Issues",
         "level_keys": [
           "U4 L03 Scope Issue_2021"
-        ],
-        "progression": "Debugging Scope Issues"
+        ]
       },
       "named_level": null,
       "bonus": null,
@@ -4104,10 +4104,10 @@
       "activity_section_position": 1,
       "assessment": null,
       "properties": {
+        "progression": "Putting it Together",
         "level_keys": [
           "U4 L03 Variables operator practice 4_2021"
-        ],
-        "progression": "Putting it Together"
+        ]
       },
       "named_level": null,
       "bonus": null,
@@ -4130,10 +4130,10 @@
       "activity_section_position": 1,
       "assessment": true,
       "properties": {
+        "progression": "Assessment: Check For Understanding: AP Practice\r",
         "level_keys": [
           "U4L3 CFU Variables Psuedocode_2021"
-        ],
-        "progression": "Assessment: Check For Understanding: AP Practice\r"
+        ]
       },
       "named_level": null,
       "bonus": null,
@@ -4156,10 +4156,10 @@
       "activity_section_position": 2,
       "assessment": true,
       "properties": {
+        "progression": "Assessment: Check For Understanding: AP Practice\r",
         "level_keys": [
           "U4L3 CFU Variables Randomness Psuedocode_2021"
-        ],
-        "progression": "Assessment: Check For Understanding: AP Practice\r"
+        ]
       },
       "named_level": null,
       "bonus": null,
@@ -4182,10 +4182,10 @@
       "activity_section_position": 1,
       "assessment": null,
       "properties": {
+        "progression": "Try the Photo Liker app",
         "level_keys": [
           "U4 L04 Variables Make Project_2021"
-        ],
-        "progression": "Try the Photo Liker app"
+        ]
       },
       "named_level": null,
       "bonus": null,
@@ -4208,10 +4208,10 @@
       "activity_section_position": 1,
       "assessment": true,
       "properties": {
+        "progression": "Make the Photo Liker app",
         "level_keys": [
           "U4 L04 Variables Make Project Submit_2021"
-        ],
-        "progression": "Make the Photo Liker app"
+        ]
       },
       "named_level": null,
       "bonus": null,
@@ -4234,10 +4234,10 @@
       "activity_section_position": 1,
       "assessment": null,
       "properties": {
+        "progression": "Conditionals: Boolean Expressions",
         "level_keys": [
           "U4 L06 Introduction to Conditionals: Boolean Expressions_2021"
-        ],
-        "progression": "Conditionals: Boolean Expressions"
+        ]
       },
       "named_level": null,
       "bonus": null,
@@ -4260,10 +4260,10 @@
       "activity_section_position": 1,
       "assessment": true,
       "properties": {
+        "progression": "Assessment: Check For Understanding\r",
         "level_keys": [
           "U4 L05 CYU Exit Ticket_2021"
-        ],
-        "progression": "Assessment: Check For Understanding\r"
+        ]
       },
       "named_level": null,
       "bonus": null,
@@ -4286,10 +4286,10 @@
       "activity_section_position": 1,
       "assessment": null,
       "properties": {
+        "progression": "If-Statements",
         "level_keys": [
           "U4 L06 Lemon Hunter App v1 Code_2021"
-        ],
-        "progression": "If-Statements"
+        ]
       },
       "named_level": null,
       "bonus": null,
@@ -4312,10 +4312,10 @@
       "activity_section_position": 2,
       "assessment": null,
       "properties": {
+        "progression": "If-Statements",
         "level_keys": [
           "U4L06 Introduction to Conditionals: if Statements_2021"
-        ],
-        "progression": "If-Statements"
+        ]
       },
       "named_level": null,
       "bonus": null,
@@ -4338,10 +4338,10 @@
       "activity_section_position": 1,
       "assessment": null,
       "properties": {
+        "progression": "If-Else Statements",
         "level_keys": [
           "U4L06 Introduction to Conditionals: if-else Statements_2021"
-        ],
-        "progression": "If-Else Statements"
+        ]
       },
       "named_level": null,
       "bonus": null,
@@ -4364,10 +4364,10 @@
       "activity_section_position": 2,
       "assessment": null,
       "properties": {
+        "progression": "If-Else Statements",
         "level_keys": [
           "U4L06 Introduction to Conditionals: if-else-if Statements_2021"
-        ],
-        "progression": "If-Else Statements"
+        ]
       },
       "named_level": null,
       "bonus": null,
@@ -4390,10 +4390,10 @@
       "activity_section_position": 3,
       "assessment": null,
       "properties": {
+        "progression": "If-Else Statements",
         "level_keys": [
           "U4 L06 Lemon Hunter App v2 Code_2021"
-        ],
-        "progression": "If-Else Statements"
+        ]
       },
       "named_level": null,
       "bonus": null,
@@ -4416,10 +4416,10 @@
       "activity_section_position": 1,
       "assessment": null,
       "properties": {
+        "progression": "Logical Operators: AND OR",
         "level_keys": [
           "U4L06 Introduction to Conditionals: Compound Boolean Expressions_2021"
-        ],
-        "progression": "Logical Operators: AND OR"
+        ]
       },
       "named_level": null,
       "bonus": null,
@@ -4442,10 +4442,10 @@
       "activity_section_position": 2,
       "assessment": null,
       "properties": {
+        "progression": "Logical Operators: AND OR",
         "level_keys": [
           "U4 L06 Lemon Hunter App v3 Code_2021"
-        ],
-        "progression": "Logical Operators: AND OR"
+        ]
       },
       "named_level": null,
       "bonus": null,
@@ -4468,10 +4468,10 @@
       "activity_section_position": 1,
       "assessment": true,
       "properties": {
+        "progression": "Patterns: If-else-if",
         "level_keys": [
           "U4 L06 CYU Exit Ticket_2021"
-        ],
-        "progression": "Patterns: If-else-if"
+        ]
       },
       "named_level": null,
       "bonus": null,
@@ -4494,10 +4494,10 @@
       "activity_section_position": 1,
       "assessment": null,
       "properties": {
+        "progression": "Check Your Understanding",
         "level_keys": [
           "Checking Multiple Conditions with If-elseif_2021"
-        ],
-        "progression": "Check Your Understanding"
+        ]
       },
       "named_level": null,
       "bonus": null,
@@ -4520,10 +4520,10 @@
       "activity_section_position": 1,
       "assessment": null,
       "properties": {
+        "progression": "Boolean expressions",
         "level_keys": [
           "U4 L07 Conditionals Practice 1_2021"
-        ],
-        "progression": "Boolean expressions"
+        ]
       },
       "named_level": null,
       "bonus": null,
@@ -4546,10 +4546,10 @@
       "activity_section_position": 2,
       "assessment": null,
       "properties": {
+        "progression": "Boolean expressions",
         "level_keys": [
           "U4 L07 Conditionals Practice 2_2021"
-        ],
-        "progression": "Boolean expressions"
+        ]
       },
       "named_level": null,
       "bonus": null,
@@ -4572,10 +4572,10 @@
       "activity_section_position": 3,
       "assessment": null,
       "properties": {
+        "progression": "Boolean expressions",
         "level_keys": [
           "U4 L07 Conditionals Practice 3_2021"
-        ],
-        "progression": "Boolean expressions"
+        ]
       },
       "named_level": null,
       "bonus": null,
@@ -4598,10 +4598,10 @@
       "activity_section_position": 1,
       "assessment": null,
       "properties": {
+        "progression": "If-Statements",
         "level_keys": [
           "U4 L07 Conditionals Practice 10_2021"
-        ],
-        "progression": "If-Statements"
+        ]
       },
       "named_level": null,
       "bonus": null,
@@ -4624,10 +4624,10 @@
       "activity_section_position": 2,
       "assessment": null,
       "properties": {
+        "progression": "If-Statements",
         "level_keys": [
           "U4 L07 Conditionals Practice 4_2021"
-        ],
-        "progression": "If-Statements"
+        ]
       },
       "named_level": null,
       "bonus": null,
@@ -4650,10 +4650,10 @@
       "activity_section_position": 3,
       "assessment": null,
       "properties": {
+        "progression": "If-Statements",
         "level_keys": [
           "U4 L07 Conditionals Practice 5_2021"
-        ],
-        "progression": "If-Statements"
+        ]
       },
       "named_level": null,
       "bonus": null,
@@ -4676,10 +4676,10 @@
       "activity_section_position": 4,
       "assessment": null,
       "properties": {
+        "progression": "If-Statements",
         "level_keys": [
           "U4 L07 Conditionals Practice 6_2021"
-        ],
-        "progression": "If-Statements"
+        ]
       },
       "named_level": null,
       "bonus": null,
@@ -4702,10 +4702,10 @@
       "activity_section_position": 5,
       "assessment": null,
       "properties": {
+        "progression": "If-Statements",
         "level_keys": [
           "U4 L07 Conditionals Practice equivalent expressions_2021"
-        ],
-        "progression": "If-Statements"
+        ]
       },
       "named_level": null,
       "bonus": null,
@@ -4728,10 +4728,10 @@
       "activity_section_position": 1,
       "assessment": null,
       "properties": {
+        "progression": "Logical Operators",
         "level_keys": [
           "U4 L07 Conditionals Practice 7_2021"
-        ],
-        "progression": "Logical Operators"
+        ]
       },
       "named_level": null,
       "bonus": null,
@@ -4754,10 +4754,10 @@
       "activity_section_position": 2,
       "assessment": null,
       "properties": {
+        "progression": "Logical Operators",
         "level_keys": [
           "U4 L07 Conditionals Practice 8_2021"
-        ],
-        "progression": "Logical Operators"
+        ]
       },
       "named_level": null,
       "bonus": null,
@@ -4780,10 +4780,10 @@
       "activity_section_position": 1,
       "assessment": true,
       "properties": {
+        "progression": "Check For Understanding: AP Practice",
         "level_keys": [
           "U4L10 CFU Conditionals Psuedocode_2021"
-        ],
-        "progression": "Check For Understanding: AP Practice"
+        ]
       },
       "named_level": null,
       "bonus": null,
@@ -4806,10 +4806,10 @@
       "activity_section_position": 2,
       "assessment": true,
       "properties": {
+        "progression": "Check For Understanding: AP Practice",
         "level_keys": [
           "U4L10 CFU Conditionals Psuedocode 2_2021"
-        ],
-        "progression": "Check For Understanding: AP Practice"
+        ]
       },
       "named_level": null,
       "bonus": null,
@@ -4832,10 +4832,10 @@
       "activity_section_position": 1,
       "assessment": null,
       "properties": {
+        "progression": "Try to the Museum Ticket Generator App",
         "level_keys": [
           "U4 L08 Conditionals Make Project Sample_2021"
-        ],
-        "progression": "Try to the Museum Ticket Generator App"
+        ]
       },
       "named_level": null,
       "bonus": null,
@@ -4858,10 +4858,10 @@
       "activity_section_position": 1,
       "assessment": true,
       "properties": {
+        "progression": "Make the Museum Ticket Generator App",
         "level_keys": [
           "U4L08 Museum Ticket Generator_2021"
-        ],
-        "progression": "Make the Museum Ticket Generator App"
+        ]
       },
       "named_level": null,
       "bonus": null,
@@ -4884,10 +4884,10 @@
       "activity_section_position": 1,
       "assessment": null,
       "properties": {
+        "progression": "Explore Functions",
         "level_keys": [
           "U4 L09 Functions Song_2021"
-        ],
-        "progression": "Explore Functions"
+        ]
       },
       "named_level": null,
       "bonus": null,
@@ -4910,10 +4910,10 @@
       "activity_section_position": 1,
       "assessment": null,
       "properties": {
+        "progression": "Declaring and Calling Functions",
         "level_keys": [
           "U4L09 Intro to Functions Video_2021"
-        ],
-        "progression": "Declaring and Calling Functions"
+        ]
       },
       "named_level": null,
       "bonus": null,
@@ -4936,10 +4936,10 @@
       "activity_section_position": 2,
       "assessment": null,
       "properties": {
+        "progression": "Declaring and Calling Functions",
         "level_keys": [
           "U4 L09 Score Clicker Investigate_2021"
-        ],
-        "progression": "Declaring and Calling Functions"
+        ]
       },
       "named_level": null,
       "bonus": null,
@@ -4962,10 +4962,10 @@
       "activity_section_position": 3,
       "assessment": null,
       "properties": {
+        "progression": "Declaring and Calling Functions",
         "level_keys": [
           "U4 L09 Thermostat App v7_2021"
-        ],
-        "progression": "Declaring and Calling Functions"
+        ]
       },
       "named_level": null,
       "bonus": null,
@@ -4988,10 +4988,10 @@
       "activity_section_position": 1,
       "assessment": null,
       "properties": {
+        "progression": "Update Screen Pattern",
         "level_keys": [
           "updateScreen Pattern_2021"
-        ],
-        "progression": "Update Screen Pattern"
+        ]
       },
       "named_level": null,
       "bonus": null,
@@ -5014,10 +5014,10 @@
       "activity_section_position": 1,
       "assessment": true,
       "properties": {
+        "progression": "Check Your Understanding",
         "level_keys": [
           "CSP U4 L09 CFU Exit Ticket_2021"
-        ],
-        "progression": "Check Your Understanding"
+        ]
       },
       "named_level": null,
       "bonus": null,
@@ -5040,10 +5040,10 @@
       "activity_section_position": 1,
       "assessment": null,
       "properties": {
+        "progression": "Declare and Call Functions",
         "level_keys": [
           "U4 L10 Functions Practice Calling Functions 1_2021"
-        ],
-        "progression": "Declare and Call Functions"
+        ]
       },
       "named_level": null,
       "bonus": null,
@@ -5066,10 +5066,10 @@
       "activity_section_position": 2,
       "assessment": null,
       "properties": {
+        "progression": "Declare and Call Functions",
         "level_keys": [
           "U4 L10 Functions Practice 1_2021"
-        ],
-        "progression": "Declare and Call Functions"
+        ]
       },
       "named_level": null,
       "bonus": null,
@@ -5092,10 +5092,10 @@
       "activity_section_position": 3,
       "assessment": null,
       "properties": {
+        "progression": "Declare and Call Functions",
         "level_keys": [
           "U4 L10 Functions Practice 2_2021"
-        ],
-        "progression": "Declare and Call Functions"
+        ]
       },
       "named_level": null,
       "bonus": null,
@@ -5118,10 +5118,10 @@
       "activity_section_position": 4,
       "assessment": null,
       "properties": {
+        "progression": "Declare and Call Functions",
         "level_keys": [
           "U4 L10 Functions Practice 3_2021"
-        ],
-        "progression": "Declare and Call Functions"
+        ]
       },
       "named_level": null,
       "bonus": null,
@@ -5144,10 +5144,10 @@
       "activity_section_position": 5,
       "assessment": null,
       "properties": {
+        "progression": "Declare and Call Functions",
         "level_keys": [
           "U4 L10 Functions Build Practice 2_2021"
-        ],
-        "progression": "Declare and Call Functions"
+        ]
       },
       "named_level": null,
       "bonus": null,
@@ -5170,10 +5170,10 @@
       "activity_section_position": 1,
       "assessment": null,
       "properties": {
+        "progression": "Function Scope",
         "level_keys": [
           "Debugging Variable Scope and Functions_2021"
-        ],
-        "progression": "Function Scope"
+        ]
       },
       "named_level": null,
       "bonus": null,
@@ -5196,10 +5196,10 @@
       "activity_section_position": 2,
       "assessment": null,
       "properties": {
+        "progression": "Function Scope",
         "level_keys": [
           "U4 L10 Functions Scope Practice 1 v2_2021"
-        ],
-        "progression": "Function Scope"
+        ]
       },
       "named_level": null,
       "bonus": null,
@@ -5222,10 +5222,10 @@
       "activity_section_position": 1,
       "assessment": null,
       "properties": {
+        "progression": "When to Declare Functions",
         "level_keys": [
           "When to Make Functions Map_2021"
-        ],
-        "progression": "When to Declare Functions"
+        ]
       },
       "named_level": null,
       "bonus": null,
@@ -5248,10 +5248,10 @@
       "activity_section_position": 2,
       "assessment": null,
       "properties": {
+        "progression": "When to Declare Functions",
         "level_keys": [
           "U4 L10 Making Functions Practice_2021"
-        ],
-        "progression": "When to Declare Functions"
+        ]
       },
       "named_level": null,
       "bonus": null,
@@ -5274,10 +5274,10 @@
       "activity_section_position": 1,
       "assessment": true,
       "properties": {
+        "progression": "Check For Understanding: AP Practice",
         "level_keys": [
           "U4L10 CFU Functions Psuedocode_2021"
-        ],
-        "progression": "Check For Understanding: AP Practice"
+        ]
       },
       "named_level": null,
       "bonus": null,
@@ -5300,10 +5300,10 @@
       "activity_section_position": 1,
       "assessment": null,
       "properties": {
+        "progression": "Quote Maker App",
         "level_keys": [
           "U4 L11 Functions Make 1 2020_2021"
-        ],
-        "progression": "Quote Maker App"
+        ]
       },
       "named_level": null,
       "bonus": null,
@@ -5326,10 +5326,10 @@
       "activity_section_position": 1,
       "assessment": true,
       "properties": {
+        "progression": "Make the Quote Maker App",
         "level_keys": [
           "U4 L11 Functions Make 2020_2021"
-        ],
-        "progression": "Make the Quote Maker App"
+        ]
       },
       "named_level": null,
       "bonus": null,
@@ -5352,10 +5352,10 @@
       "activity_section_position": 1,
       "assessment": null,
       "properties": {
+        "progression": "Sample Apps",
         "level_keys": [
           "U4 L12 Practice PT 1_2021"
-        ],
-        "progression": "Sample Apps"
+        ]
       },
       "named_level": null,
       "bonus": null,
@@ -5378,10 +5378,10 @@
       "activity_section_position": 2,
       "assessment": null,
       "properties": {
+        "progression": "Sample Apps",
         "level_keys": [
           "U4 L12 Practice PT 2_2021"
-        ],
-        "progression": "Sample Apps"
+        ]
       },
       "named_level": null,
       "bonus": null,
@@ -5404,10 +5404,10 @@
       "activity_section_position": 1,
       "assessment": null,
       "properties": {
+        "progression": "Create the Screens",
         "level_keys": [
           "U4 L13 Practice PT 1_2021"
-        ],
-        "progression": "Create the Screens"
+        ]
       },
       "named_level": null,
       "bonus": null,
@@ -5430,10 +5430,10 @@
       "activity_section_position": 1,
       "assessment": null,
       "properties": {
+        "progression": "Create the Variables",
         "level_keys": [
           "U4 L13 Practice PT 2_2021"
-        ],
-        "progression": "Create the Variables"
+        ]
       },
       "named_level": null,
       "bonus": null,
@@ -5456,10 +5456,10 @@
       "activity_section_position": 1,
       "assessment": null,
       "properties": {
+        "progression": "Create the Function",
         "level_keys": [
           "U4 L13 Practice PT 3_2021"
-        ],
-        "progression": "Create the Function"
+        ]
       },
       "named_level": null,
       "bonus": null,
@@ -5482,10 +5482,10 @@
       "activity_section_position": 1,
       "assessment": null,
       "properties": {
+        "progression": "Add onEvents",
         "level_keys": [
           "U4 L13 Practice PT 4_2021"
-        ],
-        "progression": "Add onEvents"
+        ]
       },
       "named_level": null,
       "bonus": null,
@@ -5508,10 +5508,10 @@
       "activity_section_position": 1,
       "assessment": null,
       "properties": {
+        "progression": "Test Your Decision Maker App",
         "level_keys": [
           "U4 L14 Practice PT 1_2021"
-        ],
-        "progression": "Test Your Decision Maker App"
+        ]
       },
       "named_level": null,
       "bonus": null,
@@ -5534,10 +5534,10 @@
       "activity_section_position": 1,
       "assessment": true,
       "properties": {
+        "progression": "Submit Your Decision Maker App",
         "level_keys": [
           "U4 L14 Practice PT 2_2021"
-        ],
-        "progression": "Submit Your Decision Maker App"
+        ]
       },
       "named_level": null,
       "bonus": null,
@@ -5560,10 +5560,10 @@
       "activity_section_position": 1,
       "assessment": true,
       "properties": {
+        "progression": "Unit 4 Exam",
         "level_keys": [
           "CSP 20-21 Unit 4 Assessment_2021"
-        ],
-        "progression": "Unit 4 Exam"
+        ]
       },
       "named_level": null,
       "bonus": null,

--- a/dashboard/config/scripts_json/csp5-2021.script_json
+++ b/dashboard/config/scripts_json/csp5-2021.script_json
@@ -19,7 +19,7 @@
     },
     "new_name": null,
     "family_name": null,
-    "serialized_at": "2021-03-18 22:07:19 UTC",
+    "serialized_at": "2021-03-15 12:54:57 UTC",
     "seeding_key": {
       "script.name": "csp5-2021"
     }
@@ -3672,10 +3672,10 @@
       "activity_section_position": 1,
       "assessment": null,
       "properties": {
+        "progression": "Introduction to Lists",
         "level_keys": [
           "U5 L01 Introduction to Lists_2021"
-        ],
-        "progression": "Introduction to Lists"
+        ]
       },
       "named_level": null,
       "bonus": null,
@@ -3698,10 +3698,10 @@
       "activity_section_position": 2,
       "assessment": null,
       "properties": {
+        "progression": "Introduction to Lists",
         "level_keys": [
           "Introduction to Lists - Part 2_2021"
-        ],
-        "progression": "Introduction to Lists"
+        ]
       },
       "named_level": null,
       "bonus": null,
@@ -3724,10 +3724,10 @@
       "activity_section_position": 1,
       "assessment": true,
       "properties": {
+        "progression": "Check For Understanding",
         "level_keys": [
           "csp-20-21-u5-assess-lists_2021"
-        ],
-        "progression": "Check For Understanding"
+        ]
       },
       "named_level": null,
       "bonus": null,
@@ -3750,10 +3750,10 @@
       "activity_section_position": 1,
       "assessment": null,
       "properties": {
+        "progression": "Accessing Lists",
         "level_keys": [
           "Introduction to Lists - Part 4_2021"
-        ],
-        "progression": "Accessing Lists"
+        ]
       },
       "named_level": null,
       "bonus": null,
@@ -3776,10 +3776,10 @@
       "activity_section_position": 2,
       "assessment": null,
       "properties": {
+        "progression": "Accessing Lists",
         "level_keys": [
           "U5 Lists Investigate Outfitly Code_2021"
-        ],
-        "progression": "Accessing Lists"
+        ]
       },
       "named_level": null,
       "bonus": null,
@@ -3802,10 +3802,10 @@
       "activity_section_position": 3,
       "assessment": null,
       "properties": {
+        "progression": "Accessing Lists",
         "level_keys": [
           "U5 Lists Investigate Bandly Code_2021"
-        ],
-        "progression": "Accessing Lists"
+        ]
       },
       "named_level": null,
       "bonus": null,
@@ -3828,10 +3828,10 @@
       "activity_section_position": 1,
       "assessment": null,
       "properties": {
+        "progression": "Changing Lists",
         "level_keys": [
           "Introduction to Lists - Part 3_2021"
-        ],
-        "progression": "Changing Lists"
+        ]
       },
       "named_level": null,
       "bonus": null,
@@ -3854,10 +3854,10 @@
       "activity_section_position": 2,
       "assessment": null,
       "properties": {
+        "progression": "Changing Lists",
         "level_keys": [
           "U5 Lists Investigate Partnersly Code_2021"
-        ],
-        "progression": "Changing Lists"
+        ]
       },
       "named_level": null,
       "bonus": null,
@@ -3880,10 +3880,10 @@
       "activity_section_position": 1,
       "assessment": null,
       "properties": {
+        "progression": "List Patterns",
         "level_keys": [
           "Random List Access Pattern_2021"
-        ],
-        "progression": "List Patterns"
+        ]
       },
       "named_level": null,
       "bonus": null,
@@ -3906,10 +3906,10 @@
       "activity_section_position": 2,
       "assessment": null,
       "properties": {
+        "progression": "List Patterns",
         "level_keys": [
           "List Scrolling Pattern_2021"
-        ],
-        "progression": "List Patterns"
+        ]
       },
       "named_level": null,
       "bonus": null,
@@ -3932,10 +3932,10 @@
       "activity_section_position": 1,
       "assessment": null,
       "properties": {
+        "progression": "Setting up Lists",
         "level_keys": [
           "U5 L03 Lists Practice 1_2021"
-        ],
-        "progression": "Setting up Lists"
+        ]
       },
       "named_level": null,
       "bonus": null,
@@ -3958,10 +3958,10 @@
       "activity_section_position": 2,
       "assessment": null,
       "properties": {
+        "progression": "Setting up Lists",
         "level_keys": [
           "U5 L03 Lists Practice 2_2021"
-        ],
-        "progression": "Setting up Lists"
+        ]
       },
       "named_level": null,
       "bonus": null,
@@ -3984,10 +3984,10 @@
       "activity_section_position": 1,
       "assessment": null,
       "properties": {
+        "progression": "Accessing Elements in a List",
         "level_keys": [
           "U5 L03 Lists Practice 3.75_2021"
-        ],
-        "progression": "Accessing Elements in a List"
+        ]
       },
       "named_level": null,
       "bonus": null,
@@ -4010,10 +4010,10 @@
       "activity_section_position": 2,
       "assessment": null,
       "properties": {
+        "progression": "Accessing Elements in a List",
         "level_keys": [
           "U5 L03 Lists Practice 3.5_2021"
-        ],
-        "progression": "Accessing Elements in a List"
+        ]
       },
       "named_level": null,
       "bonus": null,
@@ -4036,10 +4036,10 @@
       "activity_section_position": 3,
       "assessment": null,
       "properties": {
+        "progression": "Accessing Elements in a List",
         "level_keys": [
           "U5 L03 Lists Practice 10_2021"
-        ],
-        "progression": "Accessing Elements in a List"
+        ]
       },
       "named_level": null,
       "bonus": null,
@@ -4062,10 +4062,10 @@
       "activity_section_position": 1,
       "assessment": null,
       "properties": {
+        "progression": "Strings and Indexes",
         "level_keys": [
           "U5 L03 Lists Practice Strings 2_2021"
-        ],
-        "progression": "Strings and Indexes"
+        ]
       },
       "named_level": null,
       "bonus": null,
@@ -4088,10 +4088,10 @@
       "activity_section_position": 2,
       "assessment": null,
       "properties": {
+        "progression": "Strings and Indexes",
         "level_keys": [
           "U5 L03 Lists Practice Strings 3_2021"
-        ],
-        "progression": "Strings and Indexes"
+        ]
       },
       "named_level": null,
       "bonus": null,
@@ -4114,10 +4114,10 @@
       "activity_section_position": 1,
       "assessment": null,
       "properties": {
+        "progression": "List Operations",
         "level_keys": [
           "U5 L03 Lists Practice 4_2021"
-        ],
-        "progression": "List Operations"
+        ]
       },
       "named_level": null,
       "bonus": null,
@@ -4140,10 +4140,10 @@
       "activity_section_position": 2,
       "assessment": null,
       "properties": {
+        "progression": "List Operations",
         "level_keys": [
           "U5 L03 Lists Practice 5_2021"
-        ],
-        "progression": "List Operations"
+        ]
       },
       "named_level": null,
       "bonus": null,
@@ -4166,10 +4166,10 @@
       "activity_section_position": 3,
       "assessment": null,
       "properties": {
+        "progression": "List Operations",
         "level_keys": [
           "U5 L03 Lists Practice 9_2021"
-        ],
-        "progression": "List Operations"
+        ]
       },
       "named_level": null,
       "bonus": null,
@@ -4192,10 +4192,10 @@
       "activity_section_position": 4,
       "assessment": null,
       "properties": {
+        "progression": "List Operations",
         "level_keys": [
           "U5 L03 Lists Practice 6_2021"
-        ],
-        "progression": "List Operations"
+        ]
       },
       "named_level": null,
       "bonus": null,
@@ -4218,10 +4218,10 @@
       "activity_section_position": 1,
       "assessment": true,
       "properties": {
+        "progression": "Check For Understanding: AP Practice",
         "level_keys": [
           "U5L3 CFU Lists Psuedocode_2021"
-        ],
-        "progression": "Check For Understanding: AP Practice"
+        ]
       },
       "named_level": null,
       "bonus": null,
@@ -4244,10 +4244,10 @@
       "activity_section_position": 2,
       "assessment": true,
       "properties": {
+        "progression": "Check For Understanding: AP Practice",
         "level_keys": [
           "U5L3 CFU Lists Psuedocode 2_2021"
-        ],
-        "progression": "Check For Understanding: AP Practice"
+        ]
       },
       "named_level": null,
       "bonus": null,
@@ -4270,10 +4270,10 @@
       "activity_section_position": 1,
       "assessment": null,
       "properties": {
+        "progression": "Try the Reminders App",
         "level_keys": [
           "U5 Lists Make Project Sample App 2020_2021"
-        ],
-        "progression": "Try the Reminders App"
+        ]
       },
       "named_level": null,
       "bonus": null,
@@ -4296,10 +4296,10 @@
       "activity_section_position": 1,
       "assessment": true,
       "properties": {
+        "progression": "Make the Reminders App",
         "level_keys": [
           "U5 Lists Make Project 2020_2021"
-        ],
-        "progression": "Make the Reminders App"
+        ]
       },
       "named_level": null,
       "bonus": null,
@@ -4322,10 +4322,10 @@
       "activity_section_position": 1,
       "assessment": null,
       "properties": {
+        "progression": "Introduction to Loops",
         "level_keys": [
           "csp_applab_loops_2021"
-        ],
-        "progression": "Introduction to Loops"
+        ]
       },
       "named_level": null,
       "bonus": null,
@@ -4348,10 +4348,10 @@
       "activity_section_position": 1,
       "assessment": true,
       "properties": {
+        "progression": "Check For Understanding",
         "level_keys": [
           "U3L5 CSP CFU Looping_2021"
-        ],
-        "progression": "Check For Understanding"
+        ]
       },
       "named_level": null,
       "bonus": null,
@@ -4374,10 +4374,10 @@
       "activity_section_position": 1,
       "assessment": null,
       "properties": {
+        "progression": "Coin Flipper App",
         "level_keys": [
           "U5 Loops Investigate Coin Flipper Predict_2021"
-        ],
-        "progression": "Coin Flipper App"
+        ]
       },
       "named_level": null,
       "bonus": null,
@@ -4400,10 +4400,10 @@
       "activity_section_position": 2,
       "assessment": null,
       "properties": {
+        "progression": "Coin Flipper App",
         "level_keys": [
           "U5 Loops Investigate Coin Flipper_2021"
-        ],
-        "progression": "Coin Flipper App"
+        ]
       },
       "named_level": null,
       "bonus": null,
@@ -4426,10 +4426,10 @@
       "activity_section_position": 1,
       "assessment": null,
       "properties": {
+        "progression": "Font Tester App",
         "level_keys": [
           "U5 Loops Investigate Font Tester_2021"
-        ],
-        "progression": "Font Tester App"
+        ]
       },
       "named_level": null,
       "bonus": null,
@@ -4452,10 +4452,10 @@
       "activity_section_position": 1,
       "assessment": true,
       "properties": {
+        "progression": "Check For Understanding",
         "level_keys": [
           "U3L6 CSP CFU Element Looping_2021"
-        ],
-        "progression": "Check For Understanding"
+        ]
       },
       "named_level": null,
       "bonus": null,
@@ -4478,10 +4478,10 @@
       "activity_section_position": 1,
       "assessment": null,
       "properties": {
+        "progression": "While Loop Practice",
         "level_keys": [
           "U5 Loops Practice Part 1_2021"
-        ],
-        "progression": "While Loop Practice"
+        ]
       },
       "named_level": null,
       "bonus": null,
@@ -4504,10 +4504,10 @@
       "activity_section_position": 2,
       "assessment": null,
       "properties": {
+        "progression": "While Loop Practice",
         "level_keys": [
           "U5 Loops Practice Part 2_2021"
-        ],
-        "progression": "While Loop Practice"
+        ]
       },
       "named_level": null,
       "bonus": null,
@@ -4530,10 +4530,10 @@
       "activity_section_position": 3,
       "assessment": null,
       "properties": {
+        "progression": "While Loop Practice",
         "level_keys": [
           "U5 Loops Practice Part 3_2021"
-        ],
-        "progression": "While Loop Practice"
+        ]
       },
       "named_level": null,
       "bonus": null,
@@ -4556,10 +4556,10 @@
       "activity_section_position": 1,
       "assessment": null,
       "properties": {
+        "progression": "For Loop Practice",
         "level_keys": [
           "U5 Loops Practice Part 4_2021"
-        ],
-        "progression": "For Loop Practice"
+        ]
       },
       "named_level": null,
       "bonus": null,
@@ -4582,10 +4582,10 @@
       "activity_section_position": 2,
       "assessment": null,
       "properties": {
+        "progression": "For Loop Practice",
         "level_keys": [
           "U5 Loops Practice Part 5_2021"
-        ],
-        "progression": "For Loop Practice"
+        ]
       },
       "named_level": null,
       "bonus": null,
@@ -4608,10 +4608,10 @@
       "activity_section_position": 3,
       "assessment": null,
       "properties": {
+        "progression": "For Loop Practice",
         "level_keys": [
           "U5 Loops Practice Part 6_2021"
-        ],
-        "progression": "For Loop Practice"
+        ]
       },
       "named_level": null,
       "bonus": null,
@@ -4634,10 +4634,10 @@
       "activity_section_position": 1,
       "assessment": null,
       "properties": {
+        "progression": "Loops and Screen Elements",
         "level_keys": [
           "U5 Loops Practice Sentence Randomizer_2021"
-        ],
-        "progression": "Loops and Screen Elements"
+        ]
       },
       "named_level": null,
       "bonus": null,
@@ -4660,10 +4660,10 @@
       "activity_section_position": 2,
       "assessment": null,
       "properties": {
+        "progression": "Loops and Screen Elements",
         "level_keys": [
           "U5 Loops Practice Dice Roller_2021"
-        ],
-        "progression": "Loops and Screen Elements"
+        ]
       },
       "named_level": null,
       "bonus": null,
@@ -4686,10 +4686,10 @@
       "activity_section_position": 1,
       "assessment": true,
       "properties": {
+        "progression": "Check For Understanding: AP Practice",
         "level_keys": [
           "U5L7 CFU Loops Psuedocode_2021"
-        ],
-        "progression": "Check For Understanding: AP Practice"
+        ]
       },
       "named_level": null,
       "bonus": null,
@@ -4712,10 +4712,10 @@
       "activity_section_position": 2,
       "assessment": true,
       "properties": {
+        "progression": "Check For Understanding: AP Practice",
         "level_keys": [
           "U5L7 CFU Loops Psuedocode 2_2021"
-        ],
-        "progression": "Check For Understanding: AP Practice"
+        ]
       },
       "named_level": null,
       "bonus": null,
@@ -4738,10 +4738,10 @@
       "activity_section_position": 1,
       "assessment": null,
       "properties": {
+        "progression": "Try the Lock Screen Maker",
         "level_keys": [
           "U5 Loops Make Wallpaper App Example 2020_2021"
-        ],
-        "progression": "Try the Lock Screen Maker"
+        ]
       },
       "named_level": null,
       "bonus": null,
@@ -4764,10 +4764,10 @@
       "activity_section_position": 1,
       "assessment": true,
       "properties": {
+        "progression": "Make the Lock Screen Maker",
         "level_keys": [
           "U5 Loops Make Wallpaper App 2020_2021"
-        ],
-        "progression": "Make the Lock Screen Maker"
+        ]
       },
       "named_level": null,
       "bonus": null,
@@ -4790,10 +4790,10 @@
       "activity_section_position": 1,
       "assessment": null,
       "properties": {
+        "progression": "Introduction to Traversal",
         "level_keys": [
           "Processing Lists with Loops_2021"
-        ],
-        "progression": "Introduction to Traversal"
+        ]
       },
       "named_level": null,
       "bonus": null,
@@ -4816,10 +4816,10 @@
       "activity_section_position": 1,
       "assessment": true,
       "properties": {
+        "progression": "Assessment: Check For Understanding\r",
         "level_keys": [
           "U5 L09 Traversals Exit Ticket_2021"
-        ],
-        "progression": "Assessment: Check For Understanding\r"
+        ]
       },
       "named_level": null,
       "bonus": null,
@@ -4842,10 +4842,10 @@
       "activity_section_position": 1,
       "assessment": null,
       "properties": {
+        "progression": "Mile Tracker Investigation",
         "level_keys": [
           "U5 Traversals Investigate Mile Tracker Modify_2021"
-        ],
-        "progression": "Mile Tracker Investigation"
+        ]
       },
       "named_level": null,
       "bonus": null,
@@ -4868,10 +4868,10 @@
       "activity_section_position": 1,
       "assessment": null,
       "properties": {
+        "progression": "Data Tab Investigation",
         "level_keys": [
           "CSP U5L10 Traversals Investigate_2021"
-        ],
-        "progression": "Data Tab Investigation"
+        ]
       },
       "named_level": null,
       "bonus": null,
@@ -4894,10 +4894,10 @@
       "activity_section_position": 1,
       "assessment": null,
       "properties": {
+        "progression": "Random Dog Picker Investigation",
         "level_keys": [
           "U5 Traversals Investigate Dog Finder Modify_2021"
-        ],
-        "progression": "Random Dog Picker Investigation"
+        ]
       },
       "named_level": null,
       "bonus": null,
@@ -4920,10 +4920,10 @@
       "activity_section_position": 1,
       "assessment": null,
       "properties": {
+        "progression": "Traversal Patterns",
         "level_keys": [
           "List Filter Pattern_2021"
-        ],
-        "progression": "Traversal Patterns"
+        ]
       },
       "named_level": null,
       "bonus": null,
@@ -4946,10 +4946,10 @@
       "activity_section_position": 2,
       "assessment": null,
       "properties": {
+        "progression": "Traversal Patterns",
         "level_keys": [
           "List Reduce Pattern_2021"
-        ],
-        "progression": "Traversal Patterns"
+        ]
       },
       "named_level": null,
       "bonus": null,
@@ -4972,10 +4972,10 @@
       "activity_section_position": 1,
       "assessment": true,
       "properties": {
+        "progression": "Check For Understanding",
         "level_keys": [
           "CSP U5L10 CFU Traversals_2021"
-        ],
-        "progression": "Check For Understanding"
+        ]
       },
       "named_level": null,
       "bonus": null,
@@ -4998,10 +4998,10 @@
       "activity_section_position": 1,
       "assessment": null,
       "properties": {
+        "progression": "Traversal Practice",
         "level_keys": [
           "U5 Traversals Practice Part 3_2021"
-        ],
-        "progression": "Traversal Practice"
+        ]
       },
       "named_level": null,
       "bonus": null,
@@ -5024,10 +5024,10 @@
       "activity_section_position": 2,
       "assessment": null,
       "properties": {
+        "progression": "Traversal Practice",
         "level_keys": [
           "U5 Traversals Practice Part 2_2021"
-        ],
-        "progression": "Traversal Practice"
+        ]
       },
       "named_level": null,
       "bonus": null,
@@ -5050,10 +5050,10 @@
       "activity_section_position": 3,
       "assessment": null,
       "properties": {
+        "progression": "Traversal Practice",
         "level_keys": [
           "U5 Traversals Practice Part 1_2021"
-        ],
-        "progression": "Traversal Practice"
+        ]
       },
       "named_level": null,
       "bonus": null,
@@ -5076,10 +5076,10 @@
       "activity_section_position": 1,
       "assessment": null,
       "properties": {
+        "progression": "Reduce and Filter Practice",
         "level_keys": [
           "U5 Traversals Practice Part 4_2021"
-        ],
-        "progression": "Reduce and Filter Practice"
+        ]
       },
       "named_level": null,
       "bonus": null,
@@ -5102,10 +5102,10 @@
       "activity_section_position": 2,
       "assessment": null,
       "properties": {
+        "progression": "Reduce and Filter Practice",
         "level_keys": [
           "U5 Traversals Practice Part 5_2021"
-        ],
-        "progression": "Reduce and Filter Practice"
+        ]
       },
       "named_level": null,
       "bonus": null,
@@ -5128,10 +5128,10 @@
       "activity_section_position": 3,
       "assessment": null,
       "properties": {
+        "progression": "Reduce and Filter Practice",
         "level_keys": [
           "U5 Traversals Practice Part 6_2021"
-        ],
-        "progression": "Reduce and Filter Practice"
+        ]
       },
       "named_level": null,
       "bonus": null,
@@ -5154,10 +5154,10 @@
       "activity_section_position": 1,
       "assessment": null,
       "properties": {
+        "progression": "App Practice",
         "level_keys": [
           "U5 Traversals Practice Part 7_2021"
-        ],
-        "progression": "App Practice"
+        ]
       },
       "named_level": null,
       "bonus": null,
@@ -5180,10 +5180,10 @@
       "activity_section_position": 1,
       "assessment": true,
       "properties": {
+        "progression": "Check For Understanding: AP Practice",
         "level_keys": [
           "U5L11 CFU For Each Psuedocode_2021"
-        ],
-        "progression": "Check For Understanding: AP Practice"
+        ]
       },
       "named_level": null,
       "bonus": null,
@@ -5206,10 +5206,10 @@
       "activity_section_position": 1,
       "assessment": null,
       "properties": {
+        "progression": "Try the Random Forecaster App",
         "level_keys": [
           "U5 Traversals Make Project Sample App 2020_2021"
-        ],
-        "progression": "Try the Random Forecaster App"
+        ]
       },
       "named_level": null,
       "bonus": null,
@@ -5232,10 +5232,10 @@
       "activity_section_position": 1,
       "assessment": true,
       "properties": {
+        "progression": "Make the Random Forecaster App",
         "level_keys": [
           "U5 Traversals Make Project 2020_2021"
-        ],
-        "progression": "Make the Random Forecaster App"
+        ]
       },
       "named_level": null,
       "bonus": null,
@@ -5258,10 +5258,10 @@
       "activity_section_position": 1,
       "assessment": null,
       "properties": {
+        "progression": "Hackathon Project",
         "level_keys": [
           "U5 Hackathon Project Day 2_2021"
-        ],
-        "progression": "Hackathon Project"
+        ]
       },
       "named_level": null,
       "bonus": null,
@@ -5284,10 +5284,10 @@
       "activity_section_position": 1,
       "assessment": null,
       "properties": {
+        "progression": "Hackathon Project",
         "level_keys": [
           "U5 Hackathon Project Day 3_2021"
-        ],
-        "progression": "Hackathon Project"
+        ]
       },
       "named_level": null,
       "bonus": null,
@@ -5310,10 +5310,10 @@
       "activity_section_position": 1,
       "assessment": null,
       "properties": {
+        "progression": "Hackathon Project",
         "level_keys": [
           "U5 Hackathon Project Day 4_2021"
-        ],
-        "progression": "Hackathon Project"
+        ]
       },
       "named_level": null,
       "bonus": null,
@@ -5336,10 +5336,10 @@
       "activity_section_position": 1,
       "assessment": true,
       "properties": {
+        "progression": "Hackathon Project",
         "level_keys": [
           "U5 Hackathon Project Day 5_2021"
-        ],
-        "progression": "Hackathon Project"
+        ]
       },
       "named_level": null,
       "bonus": null,
@@ -5362,10 +5362,10 @@
       "activity_section_position": 1,
       "assessment": true,
       "properties": {
+        "progression": "Unit 5 Exam",
         "level_keys": [
           "CSP Unit 5 AP-Style Assessment _2021"
-        ],
-        "progression": "Unit 5 Exam"
+        ]
       },
       "named_level": null,
       "bonus": null,
@@ -7230,8 +7230,5 @@
         "objective.key": "6af46814-d6eb-4253-befb-d901de9ac632"
       }
     }
-  ],
-  "lessons_standards": [
-
   ]
 }

--- a/dashboard/config/scripts_json/csp5-2021.script_json
+++ b/dashboard/config/scripts_json/csp5-2021.script_json
@@ -19,7 +19,7 @@
     },
     "new_name": null,
     "family_name": null,
-    "serialized_at": "2021-03-15 12:54:57 UTC",
+    "serialized_at": "2021-03-18 22:07:19 UTC",
     "seeding_key": {
       "script.name": "csp5-2021"
     }
@@ -3672,10 +3672,10 @@
       "activity_section_position": 1,
       "assessment": null,
       "properties": {
-        "progression": "Introduction to Lists",
         "level_keys": [
           "U5 L01 Introduction to Lists_2021"
-        ]
+        ],
+        "progression": "Introduction to Lists"
       },
       "named_level": null,
       "bonus": null,
@@ -3698,10 +3698,10 @@
       "activity_section_position": 2,
       "assessment": null,
       "properties": {
-        "progression": "Introduction to Lists",
         "level_keys": [
           "Introduction to Lists - Part 2_2021"
-        ]
+        ],
+        "progression": "Introduction to Lists"
       },
       "named_level": null,
       "bonus": null,
@@ -3724,10 +3724,10 @@
       "activity_section_position": 1,
       "assessment": true,
       "properties": {
-        "progression": "Check For Understanding",
         "level_keys": [
           "csp-20-21-u5-assess-lists_2021"
-        ]
+        ],
+        "progression": "Check For Understanding"
       },
       "named_level": null,
       "bonus": null,
@@ -3750,10 +3750,10 @@
       "activity_section_position": 1,
       "assessment": null,
       "properties": {
-        "progression": "Accessing Lists",
         "level_keys": [
           "Introduction to Lists - Part 4_2021"
-        ]
+        ],
+        "progression": "Accessing Lists"
       },
       "named_level": null,
       "bonus": null,
@@ -3776,10 +3776,10 @@
       "activity_section_position": 2,
       "assessment": null,
       "properties": {
-        "progression": "Accessing Lists",
         "level_keys": [
           "U5 Lists Investigate Outfitly Code_2021"
-        ]
+        ],
+        "progression": "Accessing Lists"
       },
       "named_level": null,
       "bonus": null,
@@ -3802,10 +3802,10 @@
       "activity_section_position": 3,
       "assessment": null,
       "properties": {
-        "progression": "Accessing Lists",
         "level_keys": [
           "U5 Lists Investigate Bandly Code_2021"
-        ]
+        ],
+        "progression": "Accessing Lists"
       },
       "named_level": null,
       "bonus": null,
@@ -3828,10 +3828,10 @@
       "activity_section_position": 1,
       "assessment": null,
       "properties": {
-        "progression": "Changing Lists",
         "level_keys": [
           "Introduction to Lists - Part 3_2021"
-        ]
+        ],
+        "progression": "Changing Lists"
       },
       "named_level": null,
       "bonus": null,
@@ -3854,10 +3854,10 @@
       "activity_section_position": 2,
       "assessment": null,
       "properties": {
-        "progression": "Changing Lists",
         "level_keys": [
           "U5 Lists Investigate Partnersly Code_2021"
-        ]
+        ],
+        "progression": "Changing Lists"
       },
       "named_level": null,
       "bonus": null,
@@ -3880,10 +3880,10 @@
       "activity_section_position": 1,
       "assessment": null,
       "properties": {
-        "progression": "List Patterns",
         "level_keys": [
           "Random List Access Pattern_2021"
-        ]
+        ],
+        "progression": "List Patterns"
       },
       "named_level": null,
       "bonus": null,
@@ -3906,10 +3906,10 @@
       "activity_section_position": 2,
       "assessment": null,
       "properties": {
-        "progression": "List Patterns",
         "level_keys": [
           "List Scrolling Pattern_2021"
-        ]
+        ],
+        "progression": "List Patterns"
       },
       "named_level": null,
       "bonus": null,
@@ -3932,10 +3932,10 @@
       "activity_section_position": 1,
       "assessment": null,
       "properties": {
-        "progression": "Setting up Lists",
         "level_keys": [
           "U5 L03 Lists Practice 1_2021"
-        ]
+        ],
+        "progression": "Setting up Lists"
       },
       "named_level": null,
       "bonus": null,
@@ -3958,10 +3958,10 @@
       "activity_section_position": 2,
       "assessment": null,
       "properties": {
-        "progression": "Setting up Lists",
         "level_keys": [
           "U5 L03 Lists Practice 2_2021"
-        ]
+        ],
+        "progression": "Setting up Lists"
       },
       "named_level": null,
       "bonus": null,
@@ -3984,10 +3984,10 @@
       "activity_section_position": 1,
       "assessment": null,
       "properties": {
-        "progression": "Accessing Elements in a List",
         "level_keys": [
           "U5 L03 Lists Practice 3.75_2021"
-        ]
+        ],
+        "progression": "Accessing Elements in a List"
       },
       "named_level": null,
       "bonus": null,
@@ -4010,10 +4010,10 @@
       "activity_section_position": 2,
       "assessment": null,
       "properties": {
-        "progression": "Accessing Elements in a List",
         "level_keys": [
           "U5 L03 Lists Practice 3.5_2021"
-        ]
+        ],
+        "progression": "Accessing Elements in a List"
       },
       "named_level": null,
       "bonus": null,
@@ -4036,10 +4036,10 @@
       "activity_section_position": 3,
       "assessment": null,
       "properties": {
-        "progression": "Accessing Elements in a List",
         "level_keys": [
           "U5 L03 Lists Practice 10_2021"
-        ]
+        ],
+        "progression": "Accessing Elements in a List"
       },
       "named_level": null,
       "bonus": null,
@@ -4062,10 +4062,10 @@
       "activity_section_position": 1,
       "assessment": null,
       "properties": {
-        "progression": "Strings and Indexes",
         "level_keys": [
           "U5 L03 Lists Practice Strings 2_2021"
-        ]
+        ],
+        "progression": "Strings and Indexes"
       },
       "named_level": null,
       "bonus": null,
@@ -4088,10 +4088,10 @@
       "activity_section_position": 2,
       "assessment": null,
       "properties": {
-        "progression": "Strings and Indexes",
         "level_keys": [
           "U5 L03 Lists Practice Strings 3_2021"
-        ]
+        ],
+        "progression": "Strings and Indexes"
       },
       "named_level": null,
       "bonus": null,
@@ -4114,10 +4114,10 @@
       "activity_section_position": 1,
       "assessment": null,
       "properties": {
-        "progression": "List Operations",
         "level_keys": [
           "U5 L03 Lists Practice 4_2021"
-        ]
+        ],
+        "progression": "List Operations"
       },
       "named_level": null,
       "bonus": null,
@@ -4140,10 +4140,10 @@
       "activity_section_position": 2,
       "assessment": null,
       "properties": {
-        "progression": "List Operations",
         "level_keys": [
           "U5 L03 Lists Practice 5_2021"
-        ]
+        ],
+        "progression": "List Operations"
       },
       "named_level": null,
       "bonus": null,
@@ -4166,10 +4166,10 @@
       "activity_section_position": 3,
       "assessment": null,
       "properties": {
-        "progression": "List Operations",
         "level_keys": [
           "U5 L03 Lists Practice 9_2021"
-        ]
+        ],
+        "progression": "List Operations"
       },
       "named_level": null,
       "bonus": null,
@@ -4192,10 +4192,10 @@
       "activity_section_position": 4,
       "assessment": null,
       "properties": {
-        "progression": "List Operations",
         "level_keys": [
           "U5 L03 Lists Practice 6_2021"
-        ]
+        ],
+        "progression": "List Operations"
       },
       "named_level": null,
       "bonus": null,
@@ -4218,10 +4218,10 @@
       "activity_section_position": 1,
       "assessment": true,
       "properties": {
-        "progression": "Check For Understanding: AP Practice",
         "level_keys": [
           "U5L3 CFU Lists Psuedocode_2021"
-        ]
+        ],
+        "progression": "Check For Understanding: AP Practice"
       },
       "named_level": null,
       "bonus": null,
@@ -4244,10 +4244,10 @@
       "activity_section_position": 2,
       "assessment": true,
       "properties": {
-        "progression": "Check For Understanding: AP Practice",
         "level_keys": [
           "U5L3 CFU Lists Psuedocode 2_2021"
-        ]
+        ],
+        "progression": "Check For Understanding: AP Practice"
       },
       "named_level": null,
       "bonus": null,
@@ -4270,10 +4270,10 @@
       "activity_section_position": 1,
       "assessment": null,
       "properties": {
-        "progression": "Try the Reminders App",
         "level_keys": [
           "U5 Lists Make Project Sample App 2020_2021"
-        ]
+        ],
+        "progression": "Try the Reminders App"
       },
       "named_level": null,
       "bonus": null,
@@ -4296,10 +4296,10 @@
       "activity_section_position": 1,
       "assessment": true,
       "properties": {
-        "progression": "Make the Reminders App",
         "level_keys": [
           "U5 Lists Make Project 2020_2021"
-        ]
+        ],
+        "progression": "Make the Reminders App"
       },
       "named_level": null,
       "bonus": null,
@@ -4322,10 +4322,10 @@
       "activity_section_position": 1,
       "assessment": null,
       "properties": {
-        "progression": "Introduction to Loops",
         "level_keys": [
           "csp_applab_loops_2021"
-        ]
+        ],
+        "progression": "Introduction to Loops"
       },
       "named_level": null,
       "bonus": null,
@@ -4348,10 +4348,10 @@
       "activity_section_position": 1,
       "assessment": true,
       "properties": {
-        "progression": "Check For Understanding",
         "level_keys": [
           "U3L5 CSP CFU Looping_2021"
-        ]
+        ],
+        "progression": "Check For Understanding"
       },
       "named_level": null,
       "bonus": null,
@@ -4374,10 +4374,10 @@
       "activity_section_position": 1,
       "assessment": null,
       "properties": {
-        "progression": "Coin Flipper App",
         "level_keys": [
           "U5 Loops Investigate Coin Flipper Predict_2021"
-        ]
+        ],
+        "progression": "Coin Flipper App"
       },
       "named_level": null,
       "bonus": null,
@@ -4400,10 +4400,10 @@
       "activity_section_position": 2,
       "assessment": null,
       "properties": {
-        "progression": "Coin Flipper App",
         "level_keys": [
           "U5 Loops Investigate Coin Flipper_2021"
-        ]
+        ],
+        "progression": "Coin Flipper App"
       },
       "named_level": null,
       "bonus": null,
@@ -4426,10 +4426,10 @@
       "activity_section_position": 1,
       "assessment": null,
       "properties": {
-        "progression": "Font Tester App",
         "level_keys": [
           "U5 Loops Investigate Font Tester_2021"
-        ]
+        ],
+        "progression": "Font Tester App"
       },
       "named_level": null,
       "bonus": null,
@@ -4452,10 +4452,10 @@
       "activity_section_position": 1,
       "assessment": true,
       "properties": {
-        "progression": "Check For Understanding",
         "level_keys": [
           "U3L6 CSP CFU Element Looping_2021"
-        ]
+        ],
+        "progression": "Check For Understanding"
       },
       "named_level": null,
       "bonus": null,
@@ -4478,10 +4478,10 @@
       "activity_section_position": 1,
       "assessment": null,
       "properties": {
-        "progression": "While Loop Practice",
         "level_keys": [
           "U5 Loops Practice Part 1_2021"
-        ]
+        ],
+        "progression": "While Loop Practice"
       },
       "named_level": null,
       "bonus": null,
@@ -4504,10 +4504,10 @@
       "activity_section_position": 2,
       "assessment": null,
       "properties": {
-        "progression": "While Loop Practice",
         "level_keys": [
           "U5 Loops Practice Part 2_2021"
-        ]
+        ],
+        "progression": "While Loop Practice"
       },
       "named_level": null,
       "bonus": null,
@@ -4530,10 +4530,10 @@
       "activity_section_position": 3,
       "assessment": null,
       "properties": {
-        "progression": "While Loop Practice",
         "level_keys": [
           "U5 Loops Practice Part 3_2021"
-        ]
+        ],
+        "progression": "While Loop Practice"
       },
       "named_level": null,
       "bonus": null,
@@ -4556,10 +4556,10 @@
       "activity_section_position": 1,
       "assessment": null,
       "properties": {
-        "progression": "For Loop Practice",
         "level_keys": [
           "U5 Loops Practice Part 4_2021"
-        ]
+        ],
+        "progression": "For Loop Practice"
       },
       "named_level": null,
       "bonus": null,
@@ -4582,10 +4582,10 @@
       "activity_section_position": 2,
       "assessment": null,
       "properties": {
-        "progression": "For Loop Practice",
         "level_keys": [
           "U5 Loops Practice Part 5_2021"
-        ]
+        ],
+        "progression": "For Loop Practice"
       },
       "named_level": null,
       "bonus": null,
@@ -4608,10 +4608,10 @@
       "activity_section_position": 3,
       "assessment": null,
       "properties": {
-        "progression": "For Loop Practice",
         "level_keys": [
           "U5 Loops Practice Part 6_2021"
-        ]
+        ],
+        "progression": "For Loop Practice"
       },
       "named_level": null,
       "bonus": null,
@@ -4634,10 +4634,10 @@
       "activity_section_position": 1,
       "assessment": null,
       "properties": {
-        "progression": "Loops and Screen Elements",
         "level_keys": [
           "U5 Loops Practice Sentence Randomizer_2021"
-        ]
+        ],
+        "progression": "Loops and Screen Elements"
       },
       "named_level": null,
       "bonus": null,
@@ -4660,10 +4660,10 @@
       "activity_section_position": 2,
       "assessment": null,
       "properties": {
-        "progression": "Loops and Screen Elements",
         "level_keys": [
           "U5 Loops Practice Dice Roller_2021"
-        ]
+        ],
+        "progression": "Loops and Screen Elements"
       },
       "named_level": null,
       "bonus": null,
@@ -4686,10 +4686,10 @@
       "activity_section_position": 1,
       "assessment": true,
       "properties": {
-        "progression": "Check For Understanding: AP Practice",
         "level_keys": [
           "U5L7 CFU Loops Psuedocode_2021"
-        ]
+        ],
+        "progression": "Check For Understanding: AP Practice"
       },
       "named_level": null,
       "bonus": null,
@@ -4712,10 +4712,10 @@
       "activity_section_position": 2,
       "assessment": true,
       "properties": {
-        "progression": "Check For Understanding: AP Practice",
         "level_keys": [
           "U5L7 CFU Loops Psuedocode 2_2021"
-        ]
+        ],
+        "progression": "Check For Understanding: AP Practice"
       },
       "named_level": null,
       "bonus": null,
@@ -4738,10 +4738,10 @@
       "activity_section_position": 1,
       "assessment": null,
       "properties": {
-        "progression": "Try the Lock Screen Maker",
         "level_keys": [
           "U5 Loops Make Wallpaper App Example 2020_2021"
-        ]
+        ],
+        "progression": "Try the Lock Screen Maker"
       },
       "named_level": null,
       "bonus": null,
@@ -4764,10 +4764,10 @@
       "activity_section_position": 1,
       "assessment": true,
       "properties": {
-        "progression": "Make the Lock Screen Maker",
         "level_keys": [
           "U5 Loops Make Wallpaper App 2020_2021"
-        ]
+        ],
+        "progression": "Make the Lock Screen Maker"
       },
       "named_level": null,
       "bonus": null,
@@ -4790,10 +4790,10 @@
       "activity_section_position": 1,
       "assessment": null,
       "properties": {
-        "progression": "Introduction to Traversal",
         "level_keys": [
           "Processing Lists with Loops_2021"
-        ]
+        ],
+        "progression": "Introduction to Traversal"
       },
       "named_level": null,
       "bonus": null,
@@ -4816,10 +4816,10 @@
       "activity_section_position": 1,
       "assessment": true,
       "properties": {
-        "progression": "Assessment: Check For Understanding\r",
         "level_keys": [
           "U5 L09 Traversals Exit Ticket_2021"
-        ]
+        ],
+        "progression": "Assessment: Check For Understanding\r"
       },
       "named_level": null,
       "bonus": null,
@@ -4842,10 +4842,10 @@
       "activity_section_position": 1,
       "assessment": null,
       "properties": {
-        "progression": "Mile Tracker Investigation",
         "level_keys": [
           "U5 Traversals Investigate Mile Tracker Modify_2021"
-        ]
+        ],
+        "progression": "Mile Tracker Investigation"
       },
       "named_level": null,
       "bonus": null,
@@ -4868,10 +4868,10 @@
       "activity_section_position": 1,
       "assessment": null,
       "properties": {
-        "progression": "Data Tab Investigation",
         "level_keys": [
           "CSP U5L10 Traversals Investigate_2021"
-        ]
+        ],
+        "progression": "Data Tab Investigation"
       },
       "named_level": null,
       "bonus": null,
@@ -4894,10 +4894,10 @@
       "activity_section_position": 1,
       "assessment": null,
       "properties": {
-        "progression": "Random Dog Picker Investigation",
         "level_keys": [
           "U5 Traversals Investigate Dog Finder Modify_2021"
-        ]
+        ],
+        "progression": "Random Dog Picker Investigation"
       },
       "named_level": null,
       "bonus": null,
@@ -4920,10 +4920,10 @@
       "activity_section_position": 1,
       "assessment": null,
       "properties": {
-        "progression": "Traversal Patterns",
         "level_keys": [
           "List Filter Pattern_2021"
-        ]
+        ],
+        "progression": "Traversal Patterns"
       },
       "named_level": null,
       "bonus": null,
@@ -4946,10 +4946,10 @@
       "activity_section_position": 2,
       "assessment": null,
       "properties": {
-        "progression": "Traversal Patterns",
         "level_keys": [
           "List Reduce Pattern_2021"
-        ]
+        ],
+        "progression": "Traversal Patterns"
       },
       "named_level": null,
       "bonus": null,
@@ -4972,10 +4972,10 @@
       "activity_section_position": 1,
       "assessment": true,
       "properties": {
-        "progression": "Check For Understanding",
         "level_keys": [
           "CSP U5L10 CFU Traversals_2021"
-        ]
+        ],
+        "progression": "Check For Understanding"
       },
       "named_level": null,
       "bonus": null,
@@ -4998,10 +4998,10 @@
       "activity_section_position": 1,
       "assessment": null,
       "properties": {
-        "progression": "Traversal Practice",
         "level_keys": [
           "U5 Traversals Practice Part 3_2021"
-        ]
+        ],
+        "progression": "Traversal Practice"
       },
       "named_level": null,
       "bonus": null,
@@ -5024,10 +5024,10 @@
       "activity_section_position": 2,
       "assessment": null,
       "properties": {
-        "progression": "Traversal Practice",
         "level_keys": [
           "U5 Traversals Practice Part 2_2021"
-        ]
+        ],
+        "progression": "Traversal Practice"
       },
       "named_level": null,
       "bonus": null,
@@ -5050,10 +5050,10 @@
       "activity_section_position": 3,
       "assessment": null,
       "properties": {
-        "progression": "Traversal Practice",
         "level_keys": [
           "U5 Traversals Practice Part 1_2021"
-        ]
+        ],
+        "progression": "Traversal Practice"
       },
       "named_level": null,
       "bonus": null,
@@ -5076,10 +5076,10 @@
       "activity_section_position": 1,
       "assessment": null,
       "properties": {
-        "progression": "Reduce and Filter Practice",
         "level_keys": [
           "U5 Traversals Practice Part 4_2021"
-        ]
+        ],
+        "progression": "Reduce and Filter Practice"
       },
       "named_level": null,
       "bonus": null,
@@ -5102,10 +5102,10 @@
       "activity_section_position": 2,
       "assessment": null,
       "properties": {
-        "progression": "Reduce and Filter Practice",
         "level_keys": [
           "U5 Traversals Practice Part 5_2021"
-        ]
+        ],
+        "progression": "Reduce and Filter Practice"
       },
       "named_level": null,
       "bonus": null,
@@ -5128,10 +5128,10 @@
       "activity_section_position": 3,
       "assessment": null,
       "properties": {
-        "progression": "Reduce and Filter Practice",
         "level_keys": [
           "U5 Traversals Practice Part 6_2021"
-        ]
+        ],
+        "progression": "Reduce and Filter Practice"
       },
       "named_level": null,
       "bonus": null,
@@ -5154,10 +5154,10 @@
       "activity_section_position": 1,
       "assessment": null,
       "properties": {
-        "progression": "App Practice",
         "level_keys": [
           "U5 Traversals Practice Part 7_2021"
-        ]
+        ],
+        "progression": "App Practice"
       },
       "named_level": null,
       "bonus": null,
@@ -5180,10 +5180,10 @@
       "activity_section_position": 1,
       "assessment": true,
       "properties": {
-        "progression": "Check For Understanding: AP Practice",
         "level_keys": [
           "U5L11 CFU For Each Psuedocode_2021"
-        ]
+        ],
+        "progression": "Check For Understanding: AP Practice"
       },
       "named_level": null,
       "bonus": null,
@@ -5206,10 +5206,10 @@
       "activity_section_position": 1,
       "assessment": null,
       "properties": {
-        "progression": "Try the Random Forecaster App",
         "level_keys": [
           "U5 Traversals Make Project Sample App 2020_2021"
-        ]
+        ],
+        "progression": "Try the Random Forecaster App"
       },
       "named_level": null,
       "bonus": null,
@@ -5232,10 +5232,10 @@
       "activity_section_position": 1,
       "assessment": true,
       "properties": {
-        "progression": "Make the Random Forecaster App",
         "level_keys": [
           "U5 Traversals Make Project 2020_2021"
-        ]
+        ],
+        "progression": "Make the Random Forecaster App"
       },
       "named_level": null,
       "bonus": null,
@@ -5258,10 +5258,10 @@
       "activity_section_position": 1,
       "assessment": null,
       "properties": {
-        "progression": "Hackathon Project",
         "level_keys": [
           "U5 Hackathon Project Day 2_2021"
-        ]
+        ],
+        "progression": "Hackathon Project"
       },
       "named_level": null,
       "bonus": null,
@@ -5284,10 +5284,10 @@
       "activity_section_position": 1,
       "assessment": null,
       "properties": {
-        "progression": "Hackathon Project",
         "level_keys": [
           "U5 Hackathon Project Day 3_2021"
-        ]
+        ],
+        "progression": "Hackathon Project"
       },
       "named_level": null,
       "bonus": null,
@@ -5310,10 +5310,10 @@
       "activity_section_position": 1,
       "assessment": null,
       "properties": {
-        "progression": "Hackathon Project",
         "level_keys": [
           "U5 Hackathon Project Day 4_2021"
-        ]
+        ],
+        "progression": "Hackathon Project"
       },
       "named_level": null,
       "bonus": null,
@@ -5336,10 +5336,10 @@
       "activity_section_position": 1,
       "assessment": true,
       "properties": {
-        "progression": "Hackathon Project",
         "level_keys": [
           "U5 Hackathon Project Day 5_2021"
-        ]
+        ],
+        "progression": "Hackathon Project"
       },
       "named_level": null,
       "bonus": null,
@@ -5362,10 +5362,10 @@
       "activity_section_position": 1,
       "assessment": true,
       "properties": {
-        "progression": "Unit 5 Exam",
         "level_keys": [
           "CSP Unit 5 AP-Style Assessment _2021"
-        ]
+        ],
+        "progression": "Unit 5 Exam"
       },
       "named_level": null,
       "bonus": null,
@@ -7230,5 +7230,8 @@
         "objective.key": "6af46814-d6eb-4253-befb-d901de9ac632"
       }
     }
+  ],
+  "lessons_standards": [
+
   ]
 }

--- a/dashboard/config/scripts_json/csp6-2021.script_json
+++ b/dashboard/config/scripts_json/csp6-2021.script_json
@@ -19,7 +19,7 @@
     },
     "new_name": null,
     "family_name": null,
-    "serialized_at": "2021-03-15 12:55:47 UTC",
+    "serialized_at": "2021-03-18 22:08:09 UTC",
     "seeding_key": {
       "script.name": "csp6-2021"
     }
@@ -1782,10 +1782,10 @@
       "activity_section_position": 1,
       "assessment": true,
       "properties": {
-        "progression": "Check For Understanding",
         "level_keys": [
           "U6 L01 Algorithms vs Problems_2021"
-        ]
+        ],
+        "progression": "Check For Understanding"
       },
       "named_level": null,
       "bonus": null,
@@ -1808,10 +1808,10 @@
       "activity_section_position": 1,
       "assessment": null,
       "properties": {
-        "progression": "Widget: Ticket Generator",
         "level_keys": [
           "CSP U6L2 Ticket Generator_2021"
-        ]
+        ],
+        "progression": "Widget: Ticket Generator"
       },
       "named_level": null,
       "bonus": null,
@@ -1834,10 +1834,10 @@
       "activity_section_position": 1,
       "assessment": true,
       "properties": {
-        "progression": "Check For Understanding",
         "level_keys": [
           "U6L2 CFU Binary Search Steps_2021"
-        ]
+        ],
+        "progression": "Check For Understanding"
       },
       "named_level": null,
       "bonus": null,
@@ -1860,10 +1860,10 @@
       "activity_section_position": 2,
       "assessment": true,
       "properties": {
-        "progression": "Check For Understanding",
         "level_keys": [
           "U6L2 CFU Efficiency and Algorithms_2021"
-        ]
+        ],
+        "progression": "Check For Understanding"
       },
       "named_level": null,
       "bonus": null,
@@ -1886,10 +1886,10 @@
       "activity_section_position": 1,
       "assessment": true,
       "properties": {
-        "progression": "Check For Understanding",
         "level_keys": [
           "U6L3 CFU Reasonable vs Unreasonable_2021"
-        ]
+        ],
+        "progression": "Check For Understanding"
       },
       "named_level": null,
       "bonus": null,
@@ -1912,10 +1912,10 @@
       "activity_section_position": 2,
       "assessment": true,
       "properties": {
-        "progression": "Check For Understanding",
         "level_keys": [
           "U6 L03 Evaluate Reasonable or Not_2021"
-        ]
+        ],
+        "progression": "Check For Understanding"
       },
       "named_level": null,
       "bonus": null,
@@ -1938,10 +1938,10 @@
       "activity_section_position": 1,
       "assessment": null,
       "properties": {
-        "progression": "Widget: Traveling Salesman",
         "level_keys": [
           "CSP U6L4 Traveling Salesman_2021"
-        ]
+        ],
+        "progression": "Widget: Traveling Salesman"
       },
       "named_level": null,
       "bonus": null,
@@ -1964,10 +1964,10 @@
       "activity_section_position": 1,
       "assessment": null,
       "properties": {
-        "progression": "Widget: Traveling Salesman - Random Nodes",
         "level_keys": [
           "CSP U6L4 Random Traveling Salesman_2021"
-        ]
+        ],
+        "progression": "Widget: Traveling Salesman - Random Nodes"
       },
       "named_level": null,
       "bonus": null,
@@ -1990,10 +1990,10 @@
       "activity_section_position": 1,
       "assessment": true,
       "properties": {
-        "progression": "Check For Understanding",
         "level_keys": [
           "U6L4 CFU Reason for Heuristics_2021"
-        ]
+        ],
+        "progression": "Check For Understanding"
       },
       "named_level": null,
       "bonus": null,
@@ -2016,10 +2016,10 @@
       "activity_section_position": 2,
       "assessment": true,
       "properties": {
-        "progression": "Check For Understanding",
         "level_keys": [
           "U6 L04 Unreasonable vs Undecidable_2021"
-        ]
+        ],
+        "progression": "Check For Understanding"
       },
       "named_level": null,
       "bonus": null,
@@ -2042,10 +2042,10 @@
       "activity_section_position": 1,
       "assessment": true,
       "properties": {
-        "progression": "Check For Understanding",
         "level_keys": [
           "U6L5 CFU Calculate Speedup_2021"
-        ]
+        ],
+        "progression": "Check For Understanding"
       },
       "named_level": null,
       "bonus": null,
@@ -2068,10 +2068,10 @@
       "activity_section_position": 2,
       "assessment": true,
       "properties": {
-        "progression": "Check For Understanding",
         "level_keys": [
           "U6 L05 Speedup Forever_2021"
-        ]
+        ],
+        "progression": "Check For Understanding"
       },
       "named_level": null,
       "bonus": null,
@@ -2094,10 +2094,10 @@
       "activity_section_position": 1,
       "assessment": true,
       "properties": {
-        "progression": "Unit 6 Exam",
         "level_keys": [
           "CSP Unit 6 AP-Style Assessment _2021"
-        ]
+        ],
+        "progression": "Unit 6 Exam"
       },
       "named_level": null,
       "bonus": null,
@@ -2564,5 +2564,8 @@
         "objective.key": "f7f9b5d1-2c17-4b12-a466-ac644a2c3376"
       }
     }
+  ],
+  "lessons_standards": [
+
   ]
 }

--- a/dashboard/config/scripts_json/csp6-2021.script_json
+++ b/dashboard/config/scripts_json/csp6-2021.script_json
@@ -19,7 +19,7 @@
     },
     "new_name": null,
     "family_name": null,
-    "serialized_at": "2021-03-18 22:08:09 UTC",
+    "serialized_at": "2021-03-15 12:55:47 UTC",
     "seeding_key": {
       "script.name": "csp6-2021"
     }
@@ -1782,10 +1782,10 @@
       "activity_section_position": 1,
       "assessment": true,
       "properties": {
+        "progression": "Check For Understanding",
         "level_keys": [
           "U6 L01 Algorithms vs Problems_2021"
-        ],
-        "progression": "Check For Understanding"
+        ]
       },
       "named_level": null,
       "bonus": null,
@@ -1808,10 +1808,10 @@
       "activity_section_position": 1,
       "assessment": null,
       "properties": {
+        "progression": "Widget: Ticket Generator",
         "level_keys": [
           "CSP U6L2 Ticket Generator_2021"
-        ],
-        "progression": "Widget: Ticket Generator"
+        ]
       },
       "named_level": null,
       "bonus": null,
@@ -1834,10 +1834,10 @@
       "activity_section_position": 1,
       "assessment": true,
       "properties": {
+        "progression": "Check For Understanding",
         "level_keys": [
           "U6L2 CFU Binary Search Steps_2021"
-        ],
-        "progression": "Check For Understanding"
+        ]
       },
       "named_level": null,
       "bonus": null,
@@ -1860,10 +1860,10 @@
       "activity_section_position": 2,
       "assessment": true,
       "properties": {
+        "progression": "Check For Understanding",
         "level_keys": [
           "U6L2 CFU Efficiency and Algorithms_2021"
-        ],
-        "progression": "Check For Understanding"
+        ]
       },
       "named_level": null,
       "bonus": null,
@@ -1886,10 +1886,10 @@
       "activity_section_position": 1,
       "assessment": true,
       "properties": {
+        "progression": "Check For Understanding",
         "level_keys": [
           "U6L3 CFU Reasonable vs Unreasonable_2021"
-        ],
-        "progression": "Check For Understanding"
+        ]
       },
       "named_level": null,
       "bonus": null,
@@ -1912,10 +1912,10 @@
       "activity_section_position": 2,
       "assessment": true,
       "properties": {
+        "progression": "Check For Understanding",
         "level_keys": [
           "U6 L03 Evaluate Reasonable or Not_2021"
-        ],
-        "progression": "Check For Understanding"
+        ]
       },
       "named_level": null,
       "bonus": null,
@@ -1938,10 +1938,10 @@
       "activity_section_position": 1,
       "assessment": null,
       "properties": {
+        "progression": "Widget: Traveling Salesman",
         "level_keys": [
           "CSP U6L4 Traveling Salesman_2021"
-        ],
-        "progression": "Widget: Traveling Salesman"
+        ]
       },
       "named_level": null,
       "bonus": null,
@@ -1964,10 +1964,10 @@
       "activity_section_position": 1,
       "assessment": null,
       "properties": {
+        "progression": "Widget: Traveling Salesman - Random Nodes",
         "level_keys": [
           "CSP U6L4 Random Traveling Salesman_2021"
-        ],
-        "progression": "Widget: Traveling Salesman - Random Nodes"
+        ]
       },
       "named_level": null,
       "bonus": null,
@@ -1990,10 +1990,10 @@
       "activity_section_position": 1,
       "assessment": true,
       "properties": {
+        "progression": "Check For Understanding",
         "level_keys": [
           "U6L4 CFU Reason for Heuristics_2021"
-        ],
-        "progression": "Check For Understanding"
+        ]
       },
       "named_level": null,
       "bonus": null,
@@ -2016,10 +2016,10 @@
       "activity_section_position": 2,
       "assessment": true,
       "properties": {
+        "progression": "Check For Understanding",
         "level_keys": [
           "U6 L04 Unreasonable vs Undecidable_2021"
-        ],
-        "progression": "Check For Understanding"
+        ]
       },
       "named_level": null,
       "bonus": null,
@@ -2042,10 +2042,10 @@
       "activity_section_position": 1,
       "assessment": true,
       "properties": {
+        "progression": "Check For Understanding",
         "level_keys": [
           "U6L5 CFU Calculate Speedup_2021"
-        ],
-        "progression": "Check For Understanding"
+        ]
       },
       "named_level": null,
       "bonus": null,
@@ -2068,10 +2068,10 @@
       "activity_section_position": 2,
       "assessment": true,
       "properties": {
+        "progression": "Check For Understanding",
         "level_keys": [
           "U6 L05 Speedup Forever_2021"
-        ],
-        "progression": "Check For Understanding"
+        ]
       },
       "named_level": null,
       "bonus": null,
@@ -2094,10 +2094,10 @@
       "activity_section_position": 1,
       "assessment": true,
       "properties": {
+        "progression": "Unit 6 Exam",
         "level_keys": [
           "CSP Unit 6 AP-Style Assessment _2021"
-        ],
-        "progression": "Unit 6 Exam"
+        ]
       },
       "named_level": null,
       "bonus": null,
@@ -2564,8 +2564,5 @@
         "objective.key": "f7f9b5d1-2c17-4b12-a466-ac644a2c3376"
       }
     }
-  ],
-  "lessons_standards": [
-
   ]
 }

--- a/dashboard/config/scripts_json/csp7-2021.script_json
+++ b/dashboard/config/scripts_json/csp7-2021.script_json
@@ -19,7 +19,7 @@
     },
     "new_name": null,
     "family_name": null,
-    "serialized_at": "2021-03-18 22:08:48 UTC",
+    "serialized_at": "2021-03-15 12:56:45 UTC",
     "seeding_key": {
       "script.name": "csp7-2021"
     }
@@ -2425,10 +2425,10 @@
       "activity_section_position": 1,
       "assessment": null,
       "properties": {
+        "progression": "App Investigation",
         "level_keys": [
           "U7 Param Return Investigate Rock_2021"
-        ],
-        "progression": "App Investigation"
+        ]
       },
       "named_level": null,
       "bonus": null,
@@ -2451,10 +2451,10 @@
       "activity_section_position": 2,
       "assessment": null,
       "properties": {
+        "progression": "App Investigation",
         "level_keys": [
           "U7 Param Investigate Poetry App_2021"
-        ],
-        "progression": "App Investigation"
+        ]
       },
       "named_level": null,
       "bonus": null,
@@ -2503,10 +2503,10 @@
       "activity_section_position": 1,
       "assessment": null,
       "properties": {
+        "progression": "console.log Practice",
         "level_keys": [
           "U7 Param Return Practice Part 1_2021"
-        ],
-        "progression": "console.log Practice"
+        ]
       },
       "named_level": null,
       "bonus": null,
@@ -2529,10 +2529,10 @@
       "activity_section_position": 2,
       "assessment": null,
       "properties": {
+        "progression": "console.log Practice",
         "level_keys": [
           "U7 Param Return Practice Part 2_2021"
-        ],
-        "progression": "console.log Practice"
+        ]
       },
       "named_level": null,
       "bonus": null,
@@ -2555,10 +2555,10 @@
       "activity_section_position": 3,
       "assessment": null,
       "properties": {
+        "progression": "console.log Practice",
         "level_keys": [
           "U7 Param Return Practice Part 4_2021"
-        ],
-        "progression": "console.log Practice"
+        ]
       },
       "named_level": null,
       "bonus": null,
@@ -2581,10 +2581,10 @@
       "activity_section_position": 4,
       "assessment": null,
       "properties": {
+        "progression": "console.log Practice",
         "level_keys": [
           "U7 Param Return Practice Part 3_2021"
-        ],
-        "progression": "console.log Practice"
+        ]
       },
       "named_level": null,
       "bonus": null,
@@ -2607,10 +2607,10 @@
       "activity_section_position": 5,
       "assessment": null,
       "properties": {
+        "progression": "console.log Practice",
         "level_keys": [
           "U7 Param Return Practice Part 5_2021"
-        ],
-        "progression": "console.log Practice"
+        ]
       },
       "named_level": null,
       "bonus": null,
@@ -2633,10 +2633,10 @@
       "activity_section_position": 1,
       "assessment": null,
       "properties": {
+        "progression": "App Practice",
         "level_keys": [
           "U7 Param Investigate Calculator App_2021"
-        ],
-        "progression": "App Practice"
+        ]
       },
       "named_level": null,
       "bonus": null,
@@ -2659,10 +2659,10 @@
       "activity_section_position": 2,
       "assessment": null,
       "properties": {
+        "progression": "App Practice",
         "level_keys": [
           "U7 Param Practice App 2_2021"
-        ],
-        "progression": "App Practice"
+        ]
       },
       "named_level": null,
       "bonus": null,
@@ -2685,10 +2685,10 @@
       "activity_section_position": 1,
       "assessment": null,
       "properties": {
+        "progression": "MOD Practice",
         "level_keys": [
           "U7 Param Return Practice MOD_2021"
-        ],
-        "progression": "MOD Practice"
+        ]
       },
       "named_level": null,
       "bonus": null,
@@ -2737,10 +2737,10 @@
       "activity_section_position": 1,
       "assessment": null,
       "properties": {
+        "progression": "Try the Rock Paper Scissors App",
         "level_keys": [
           "U7 Param Return Make RPS App_2021"
-        ],
-        "progression": "Try the Rock Paper Scissors App"
+        ]
       },
       "named_level": null,
       "bonus": null,
@@ -2763,10 +2763,10 @@
       "activity_section_position": 1,
       "assessment": true,
       "properties": {
+        "progression": "Make the Rock Paper Scissors App",
         "level_keys": [
           "U7 Param Return Make RPS App Project_2021"
-        ],
-        "progression": "Make the Rock Paper Scissors App"
+        ]
       },
       "named_level": null,
       "bonus": null,
@@ -2815,10 +2815,10 @@
       "activity_section_position": 1,
       "assessment": null,
       "properties": {
+        "progression": "States App",
         "level_keys": [
           "U7L6 States App Investigation_2021"
-        ],
-        "progression": "States App"
+        ]
       },
       "named_level": null,
       "bonus": null,
@@ -2841,10 +2841,10 @@
       "activity_section_position": 1,
       "assessment": null,
       "properties": {
+        "progression": "Pigify App",
         "level_keys": [
           "U7L6 Pigify App Investigation_2021"
-        ],
-        "progression": "Pigify App"
+        ]
       },
       "named_level": null,
       "bonus": null,
@@ -2893,10 +2893,10 @@
       "activity_section_position": 1,
       "assessment": null,
       "properties": {
+        "progression": "Using Libraries",
         "level_keys": [
           "U7 Libraries Practice 3_2021"
-        ],
-        "progression": "Using Libraries"
+        ]
       },
       "named_level": null,
       "bonus": null,
@@ -2919,10 +2919,10 @@
       "activity_section_position": 2,
       "assessment": null,
       "properties": {
+        "progression": "Using Libraries",
         "level_keys": [
           "U7 Libraries Practice 5_2021"
-        ],
-        "progression": "Using Libraries"
+        ]
       },
       "named_level": null,
       "bonus": null,
@@ -2945,10 +2945,10 @@
       "activity_section_position": 1,
       "assessment": null,
       "properties": {
+        "progression": "Testing Libraries",
         "level_keys": [
           "U7 Libraries Practice 2_2021"
-        ],
-        "progression": "Testing Libraries"
+        ]
       },
       "named_level": null,
       "bonus": null,
@@ -2971,10 +2971,10 @@
       "activity_section_position": 2,
       "assessment": null,
       "properties": {
+        "progression": "Testing Libraries",
         "level_keys": [
           "U7 Libraries Practice 1_2021"
-        ],
-        "progression": "Testing Libraries"
+        ]
       },
       "named_level": null,
       "bonus": null,
@@ -2997,10 +2997,10 @@
       "activity_section_position": 3,
       "assessment": null,
       "properties": {
+        "progression": "Testing Libraries",
         "level_keys": [
           "U7 Libraries Practice 4_2021"
-        ],
-        "progression": "Testing Libraries"
+        ]
       },
       "named_level": null,
       "bonus": null,
@@ -3049,10 +3049,10 @@
       "activity_section_position": 1,
       "assessment": null,
       "properties": {
+        "progression": "Build Your Library",
         "level_keys": [
           "U7 Libraries Project Part 1_2021"
-        ],
-        "progression": "Build Your Library"
+        ]
       },
       "named_level": null,
       "bonus": null,
@@ -3075,10 +3075,10 @@
       "activity_section_position": 1,
       "assessment": null,
       "properties": {
+        "progression": "Build Your Library",
         "level_keys": [
           "U7 Libraries Project Part 2_2021"
-        ],
-        "progression": "Build Your Library"
+        ]
       },
       "named_level": null,
       "bonus": null,
@@ -3101,10 +3101,10 @@
       "activity_section_position": 1,
       "assessment": null,
       "properties": {
+        "progression": "Test a Classmate's Library",
         "level_keys": [
           "U7 Libraries Project Test a Library_2021"
-        ],
-        "progression": "Test a Classmate's Library"
+        ]
       },
       "named_level": null,
       "bonus": null,
@@ -3127,10 +3127,10 @@
       "activity_section_position": 1,
       "assessment": true,
       "properties": {
+        "progression": "Build Your Library",
         "level_keys": [
           "U7 Libraries Project Part 3_2021"
-        ],
-        "progression": "Build Your Library"
+        ]
       },
       "named_level": null,
       "bonus": null,
@@ -4112,8 +4112,5 @@
         "objective.key": "efa4b437-61f3-4a0f-a7cf-6e1f3056af68"
       }
     }
-  ],
-  "lessons_standards": [
-
   ]
 }

--- a/dashboard/config/scripts_json/csp7-2021.script_json
+++ b/dashboard/config/scripts_json/csp7-2021.script_json
@@ -19,7 +19,7 @@
     },
     "new_name": null,
     "family_name": null,
-    "serialized_at": "2021-03-15 12:56:45 UTC",
+    "serialized_at": "2021-03-18 22:08:48 UTC",
     "seeding_key": {
       "script.name": "csp7-2021"
     }
@@ -2425,10 +2425,10 @@
       "activity_section_position": 1,
       "assessment": null,
       "properties": {
-        "progression": "App Investigation",
         "level_keys": [
           "U7 Param Return Investigate Rock_2021"
-        ]
+        ],
+        "progression": "App Investigation"
       },
       "named_level": null,
       "bonus": null,
@@ -2451,10 +2451,10 @@
       "activity_section_position": 2,
       "assessment": null,
       "properties": {
-        "progression": "App Investigation",
         "level_keys": [
           "U7 Param Investigate Poetry App_2021"
-        ]
+        ],
+        "progression": "App Investigation"
       },
       "named_level": null,
       "bonus": null,
@@ -2503,10 +2503,10 @@
       "activity_section_position": 1,
       "assessment": null,
       "properties": {
-        "progression": "console.log Practice",
         "level_keys": [
           "U7 Param Return Practice Part 1_2021"
-        ]
+        ],
+        "progression": "console.log Practice"
       },
       "named_level": null,
       "bonus": null,
@@ -2529,10 +2529,10 @@
       "activity_section_position": 2,
       "assessment": null,
       "properties": {
-        "progression": "console.log Practice",
         "level_keys": [
           "U7 Param Return Practice Part 2_2021"
-        ]
+        ],
+        "progression": "console.log Practice"
       },
       "named_level": null,
       "bonus": null,
@@ -2555,10 +2555,10 @@
       "activity_section_position": 3,
       "assessment": null,
       "properties": {
-        "progression": "console.log Practice",
         "level_keys": [
           "U7 Param Return Practice Part 4_2021"
-        ]
+        ],
+        "progression": "console.log Practice"
       },
       "named_level": null,
       "bonus": null,
@@ -2581,10 +2581,10 @@
       "activity_section_position": 4,
       "assessment": null,
       "properties": {
-        "progression": "console.log Practice",
         "level_keys": [
           "U7 Param Return Practice Part 3_2021"
-        ]
+        ],
+        "progression": "console.log Practice"
       },
       "named_level": null,
       "bonus": null,
@@ -2607,10 +2607,10 @@
       "activity_section_position": 5,
       "assessment": null,
       "properties": {
-        "progression": "console.log Practice",
         "level_keys": [
           "U7 Param Return Practice Part 5_2021"
-        ]
+        ],
+        "progression": "console.log Practice"
       },
       "named_level": null,
       "bonus": null,
@@ -2633,10 +2633,10 @@
       "activity_section_position": 1,
       "assessment": null,
       "properties": {
-        "progression": "App Practice",
         "level_keys": [
           "U7 Param Investigate Calculator App_2021"
-        ]
+        ],
+        "progression": "App Practice"
       },
       "named_level": null,
       "bonus": null,
@@ -2659,10 +2659,10 @@
       "activity_section_position": 2,
       "assessment": null,
       "properties": {
-        "progression": "App Practice",
         "level_keys": [
           "U7 Param Practice App 2_2021"
-        ]
+        ],
+        "progression": "App Practice"
       },
       "named_level": null,
       "bonus": null,
@@ -2685,10 +2685,10 @@
       "activity_section_position": 1,
       "assessment": null,
       "properties": {
-        "progression": "MOD Practice",
         "level_keys": [
           "U7 Param Return Practice MOD_2021"
-        ]
+        ],
+        "progression": "MOD Practice"
       },
       "named_level": null,
       "bonus": null,
@@ -2737,10 +2737,10 @@
       "activity_section_position": 1,
       "assessment": null,
       "properties": {
-        "progression": "Try the Rock Paper Scissors App",
         "level_keys": [
           "U7 Param Return Make RPS App_2021"
-        ]
+        ],
+        "progression": "Try the Rock Paper Scissors App"
       },
       "named_level": null,
       "bonus": null,
@@ -2763,10 +2763,10 @@
       "activity_section_position": 1,
       "assessment": true,
       "properties": {
-        "progression": "Make the Rock Paper Scissors App",
         "level_keys": [
           "U7 Param Return Make RPS App Project_2021"
-        ]
+        ],
+        "progression": "Make the Rock Paper Scissors App"
       },
       "named_level": null,
       "bonus": null,
@@ -2815,10 +2815,10 @@
       "activity_section_position": 1,
       "assessment": null,
       "properties": {
-        "progression": "States App",
         "level_keys": [
           "U7L6 States App Investigation_2021"
-        ]
+        ],
+        "progression": "States App"
       },
       "named_level": null,
       "bonus": null,
@@ -2841,10 +2841,10 @@
       "activity_section_position": 1,
       "assessment": null,
       "properties": {
-        "progression": "Pigify App",
         "level_keys": [
           "U7L6 Pigify App Investigation_2021"
-        ]
+        ],
+        "progression": "Pigify App"
       },
       "named_level": null,
       "bonus": null,
@@ -2893,10 +2893,10 @@
       "activity_section_position": 1,
       "assessment": null,
       "properties": {
-        "progression": "Using Libraries",
         "level_keys": [
           "U7 Libraries Practice 3_2021"
-        ]
+        ],
+        "progression": "Using Libraries"
       },
       "named_level": null,
       "bonus": null,
@@ -2919,10 +2919,10 @@
       "activity_section_position": 2,
       "assessment": null,
       "properties": {
-        "progression": "Using Libraries",
         "level_keys": [
           "U7 Libraries Practice 5_2021"
-        ]
+        ],
+        "progression": "Using Libraries"
       },
       "named_level": null,
       "bonus": null,
@@ -2945,10 +2945,10 @@
       "activity_section_position": 1,
       "assessment": null,
       "properties": {
-        "progression": "Testing Libraries",
         "level_keys": [
           "U7 Libraries Practice 2_2021"
-        ]
+        ],
+        "progression": "Testing Libraries"
       },
       "named_level": null,
       "bonus": null,
@@ -2971,10 +2971,10 @@
       "activity_section_position": 2,
       "assessment": null,
       "properties": {
-        "progression": "Testing Libraries",
         "level_keys": [
           "U7 Libraries Practice 1_2021"
-        ]
+        ],
+        "progression": "Testing Libraries"
       },
       "named_level": null,
       "bonus": null,
@@ -2997,10 +2997,10 @@
       "activity_section_position": 3,
       "assessment": null,
       "properties": {
-        "progression": "Testing Libraries",
         "level_keys": [
           "U7 Libraries Practice 4_2021"
-        ]
+        ],
+        "progression": "Testing Libraries"
       },
       "named_level": null,
       "bonus": null,
@@ -3049,10 +3049,10 @@
       "activity_section_position": 1,
       "assessment": null,
       "properties": {
-        "progression": "Build Your Library",
         "level_keys": [
           "U7 Libraries Project Part 1_2021"
-        ]
+        ],
+        "progression": "Build Your Library"
       },
       "named_level": null,
       "bonus": null,
@@ -3075,10 +3075,10 @@
       "activity_section_position": 1,
       "assessment": null,
       "properties": {
-        "progression": "Build Your Library",
         "level_keys": [
           "U7 Libraries Project Part 2_2021"
-        ]
+        ],
+        "progression": "Build Your Library"
       },
       "named_level": null,
       "bonus": null,
@@ -3101,10 +3101,10 @@
       "activity_section_position": 1,
       "assessment": null,
       "properties": {
-        "progression": "Test a Classmate's Library",
         "level_keys": [
           "U7 Libraries Project Test a Library_2021"
-        ]
+        ],
+        "progression": "Test a Classmate's Library"
       },
       "named_level": null,
       "bonus": null,
@@ -3127,10 +3127,10 @@
       "activity_section_position": 1,
       "assessment": true,
       "properties": {
-        "progression": "Build Your Library",
         "level_keys": [
           "U7 Libraries Project Part 3_2021"
-        ]
+        ],
+        "progression": "Build Your Library"
       },
       "named_level": null,
       "bonus": null,
@@ -4112,5 +4112,8 @@
         "objective.key": "efa4b437-61f3-4a0f-a7cf-6e1f3056af68"
       }
     }
+  ],
+  "lessons_standards": [
+
   ]
 }

--- a/dashboard/config/scripts_json/csp8-2021.script_json
+++ b/dashboard/config/scripts_json/csp8-2021.script_json
@@ -19,7 +19,7 @@
     },
     "new_name": null,
     "family_name": null,
-    "serialized_at": "2021-03-18 22:09:38 UTC",
+    "serialized_at": "2021-03-15 12:57:32 UTC",
     "seeding_key": {
       "script.name": "csp8-2021"
     }
@@ -802,10 +802,10 @@
       "activity_section_position": 1,
       "assessment": null,
       "properties": {
+        "progression": "Tech Setup and Tools for Create PT",
         "level_keys": [
           "csp-pt-tech-setup-and-tools_2021"
-        ],
-        "progression": "Tech Setup and Tools for Create PT"
+        ]
       },
       "named_level": null,
       "bonus": null,
@@ -828,10 +828,10 @@
       "activity_section_position": 1,
       "assessment": null,
       "properties": {
+        "progression": "Create PT Coding Workspace",
         "level_keys": [
           "Create PT Workspace 2020_2021"
-        ],
-        "progression": "Create PT Coding Workspace"
+        ]
       },
       "named_level": null,
       "bonus": null,
@@ -1357,8 +1357,5 @@
         "objective.key": "f31a2fd3-f77b-46e7-93ad-37aeaf2a156a"
       }
     }
-  ],
-  "lessons_standards": [
-
   ]
 }

--- a/dashboard/config/scripts_json/csp8-2021.script_json
+++ b/dashboard/config/scripts_json/csp8-2021.script_json
@@ -19,7 +19,7 @@
     },
     "new_name": null,
     "family_name": null,
-    "serialized_at": "2021-03-15 12:57:32 UTC",
+    "serialized_at": "2021-03-18 22:09:38 UTC",
     "seeding_key": {
       "script.name": "csp8-2021"
     }
@@ -802,10 +802,10 @@
       "activity_section_position": 1,
       "assessment": null,
       "properties": {
-        "progression": "Tech Setup and Tools for Create PT",
         "level_keys": [
           "csp-pt-tech-setup-and-tools_2021"
-        ]
+        ],
+        "progression": "Tech Setup and Tools for Create PT"
       },
       "named_level": null,
       "bonus": null,
@@ -828,10 +828,10 @@
       "activity_section_position": 1,
       "assessment": null,
       "properties": {
-        "progression": "Create PT Coding Workspace",
         "level_keys": [
           "Create PT Workspace 2020_2021"
-        ]
+        ],
+        "progression": "Create PT Coding Workspace"
       },
       "named_level": null,
       "bonus": null,
@@ -1357,5 +1357,8 @@
         "objective.key": "f31a2fd3-f77b-46e7-93ad-37aeaf2a156a"
       }
     }
+  ],
+  "lessons_standards": [
+
   ]
 }

--- a/dashboard/config/scripts_json/csp9-2021.script_json
+++ b/dashboard/config/scripts_json/csp9-2021.script_json
@@ -19,7 +19,7 @@
     },
     "new_name": null,
     "family_name": null,
-    "serialized_at": "2021-03-15 12:58:16 UTC",
+    "serialized_at": "2021-03-18 22:10:21 UTC",
     "seeding_key": {
       "script.name": "csp9-2021"
     }
@@ -1968,10 +1968,10 @@
       "activity_section_position": 1,
       "assessment": null,
       "properties": {
-        "progression": "Exploring Metadata",
         "level_keys": [
           "CSP U9L1 Metadata_2021"
-        ]
+        ],
+        "progression": "Exploring Metadata"
       },
       "named_level": null,
       "bonus": null,
@@ -2020,10 +2020,10 @@
       "activity_section_position": 1,
       "assessment": null,
       "properties": {
-        "progression": "Making Bar Charts and Histograms",
         "level_keys": [
           "CSP U9L2 Making Bar Charts and Histograms_2021"
-        ]
+        ],
+        "progression": "Making Bar Charts and Histograms"
       },
       "named_level": null,
       "bonus": null,
@@ -2072,10 +2072,10 @@
       "activity_section_position": 1,
       "assessment": null,
       "properties": {
-        "progression": "Cleaning Data",
         "level_keys": [
           "CSP U9L3 Data Cleaning_2021"
-        ]
+        ],
+        "progression": "Cleaning Data"
       },
       "named_level": null,
       "bonus": null,
@@ -2149,10 +2149,10 @@
       "activity_section_position": 1,
       "assessment": null,
       "properties": {
-        "progression": "Crosstab and Scatter Charts",
         "level_keys": [
           "CSP U9L4 Making Crosstabs and Scatter Plots_2021"
-        ]
+        ],
+        "progression": "Crosstab and Scatter Charts"
       },
       "named_level": null,
       "bonus": null,
@@ -2175,10 +2175,10 @@
       "activity_section_position": 1,
       "assessment": null,
       "properties": {
-        "progression": "What Type of Chart?",
         "level_keys": [
           "Which Type of Chart_2021"
-        ]
+        ],
+        "progression": "What Type of Chart?"
       },
       "named_level": null,
       "bonus": null,
@@ -2227,10 +2227,10 @@
       "activity_section_position": 1,
       "assessment": null,
       "properties": {
-        "progression": "AI for Oceans - Machine Learning",
         "level_keys": [
           "Oceans_Video_Machine_Learning_2021"
-        ]
+        ],
+        "progression": "AI for Oceans - Machine Learning"
       },
       "named_level": null,
       "bonus": null,
@@ -2253,10 +2253,10 @@
       "activity_section_position": 2,
       "assessment": null,
       "properties": {
-        "progression": "AI for Oceans - Machine Learning",
         "level_keys": [
           "Oceans_FishVTrash_2021"
-        ]
+        ],
+        "progression": "AI for Oceans - Machine Learning"
       },
       "named_level": null,
       "bonus": null,
@@ -2279,10 +2279,10 @@
       "activity_section_position": 3,
       "assessment": null,
       "properties": {
-        "progression": "AI for Oceans - Machine Learning",
         "level_keys": [
           "Oceans_CreaturesVTrashDemo_2021"
-        ]
+        ],
+        "progression": "AI for Oceans - Machine Learning"
       },
       "named_level": null,
       "bonus": null,
@@ -2305,10 +2305,10 @@
       "activity_section_position": 4,
       "assessment": null,
       "properties": {
-        "progression": "AI for Oceans - Machine Learning",
         "level_keys": [
           "Oceans_CreaturesVTrash_2021"
-        ]
+        ],
+        "progression": "AI for Oceans - Machine Learning"
       },
       "named_level": null,
       "bonus": null,
@@ -2331,10 +2331,10 @@
       "activity_section_position": 5,
       "assessment": null,
       "properties": {
-        "progression": "AI for Oceans - Machine Learning",
         "level_keys": [
           "Oceans_Video_Training_Data_2021"
-        ]
+        ],
+        "progression": "AI for Oceans - Machine Learning"
       },
       "named_level": null,
       "bonus": null,
@@ -2357,10 +2357,10 @@
       "activity_section_position": 6,
       "assessment": null,
       "properties": {
-        "progression": "AI for Oceans - Machine Learning",
         "level_keys": [
           "Oceans_Short_2021"
-        ]
+        ],
+        "progression": "AI for Oceans - Machine Learning"
       },
       "named_level": null,
       "bonus": null,
@@ -2383,10 +2383,10 @@
       "activity_section_position": 7,
       "assessment": null,
       "properties": {
-        "progression": "AI for Oceans - Machine Learning",
         "level_keys": [
           "Oceans_Long_2021"
-        ]
+        ],
+        "progression": "AI for Oceans - Machine Learning"
       },
       "named_level": null,
       "bonus": null,
@@ -2435,10 +2435,10 @@
       "activity_section_position": 1,
       "assessment": null,
       "properties": {
-        "progression": "Data Story Workspace",
         "level_keys": [
           "CSP U9 Data Story Day 1_2021"
-        ]
+        ],
+        "progression": "Data Story Workspace"
       },
       "named_level": null,
       "bonus": null,
@@ -2461,10 +2461,10 @@
       "activity_section_position": 1,
       "assessment": true,
       "properties": {
-        "progression": "Data Story Workspace",
         "level_keys": [
           "CSP U9 Data Story Day 2_2021"
-        ]
+        ],
+        "progression": "Data Story Workspace"
       },
       "named_level": null,
       "bonus": null,
@@ -3310,5 +3310,8 @@
         "objective.key": "923cb922-4718-43ed-a135-f3bd078fd3db"
       }
     }
+  ],
+  "lessons_standards": [
+
   ]
 }

--- a/dashboard/config/scripts_json/csp9-2021.script_json
+++ b/dashboard/config/scripts_json/csp9-2021.script_json
@@ -19,7 +19,7 @@
     },
     "new_name": null,
     "family_name": null,
-    "serialized_at": "2021-03-18 22:10:21 UTC",
+    "serialized_at": "2021-03-15 12:58:16 UTC",
     "seeding_key": {
       "script.name": "csp9-2021"
     }
@@ -1968,10 +1968,10 @@
       "activity_section_position": 1,
       "assessment": null,
       "properties": {
+        "progression": "Exploring Metadata",
         "level_keys": [
           "CSP U9L1 Metadata_2021"
-        ],
-        "progression": "Exploring Metadata"
+        ]
       },
       "named_level": null,
       "bonus": null,
@@ -2020,10 +2020,10 @@
       "activity_section_position": 1,
       "assessment": null,
       "properties": {
+        "progression": "Making Bar Charts and Histograms",
         "level_keys": [
           "CSP U9L2 Making Bar Charts and Histograms_2021"
-        ],
-        "progression": "Making Bar Charts and Histograms"
+        ]
       },
       "named_level": null,
       "bonus": null,
@@ -2072,10 +2072,10 @@
       "activity_section_position": 1,
       "assessment": null,
       "properties": {
+        "progression": "Cleaning Data",
         "level_keys": [
           "CSP U9L3 Data Cleaning_2021"
-        ],
-        "progression": "Cleaning Data"
+        ]
       },
       "named_level": null,
       "bonus": null,
@@ -2149,10 +2149,10 @@
       "activity_section_position": 1,
       "assessment": null,
       "properties": {
+        "progression": "Crosstab and Scatter Charts",
         "level_keys": [
           "CSP U9L4 Making Crosstabs and Scatter Plots_2021"
-        ],
-        "progression": "Crosstab and Scatter Charts"
+        ]
       },
       "named_level": null,
       "bonus": null,
@@ -2175,10 +2175,10 @@
       "activity_section_position": 1,
       "assessment": null,
       "properties": {
+        "progression": "What Type of Chart?",
         "level_keys": [
           "Which Type of Chart_2021"
-        ],
-        "progression": "What Type of Chart?"
+        ]
       },
       "named_level": null,
       "bonus": null,
@@ -2227,10 +2227,10 @@
       "activity_section_position": 1,
       "assessment": null,
       "properties": {
+        "progression": "AI for Oceans - Machine Learning",
         "level_keys": [
           "Oceans_Video_Machine_Learning_2021"
-        ],
-        "progression": "AI for Oceans - Machine Learning"
+        ]
       },
       "named_level": null,
       "bonus": null,
@@ -2253,10 +2253,10 @@
       "activity_section_position": 2,
       "assessment": null,
       "properties": {
+        "progression": "AI for Oceans - Machine Learning",
         "level_keys": [
           "Oceans_FishVTrash_2021"
-        ],
-        "progression": "AI for Oceans - Machine Learning"
+        ]
       },
       "named_level": null,
       "bonus": null,
@@ -2279,10 +2279,10 @@
       "activity_section_position": 3,
       "assessment": null,
       "properties": {
+        "progression": "AI for Oceans - Machine Learning",
         "level_keys": [
           "Oceans_CreaturesVTrashDemo_2021"
-        ],
-        "progression": "AI for Oceans - Machine Learning"
+        ]
       },
       "named_level": null,
       "bonus": null,
@@ -2305,10 +2305,10 @@
       "activity_section_position": 4,
       "assessment": null,
       "properties": {
+        "progression": "AI for Oceans - Machine Learning",
         "level_keys": [
           "Oceans_CreaturesVTrash_2021"
-        ],
-        "progression": "AI for Oceans - Machine Learning"
+        ]
       },
       "named_level": null,
       "bonus": null,
@@ -2331,10 +2331,10 @@
       "activity_section_position": 5,
       "assessment": null,
       "properties": {
+        "progression": "AI for Oceans - Machine Learning",
         "level_keys": [
           "Oceans_Video_Training_Data_2021"
-        ],
-        "progression": "AI for Oceans - Machine Learning"
+        ]
       },
       "named_level": null,
       "bonus": null,
@@ -2357,10 +2357,10 @@
       "activity_section_position": 6,
       "assessment": null,
       "properties": {
+        "progression": "AI for Oceans - Machine Learning",
         "level_keys": [
           "Oceans_Short_2021"
-        ],
-        "progression": "AI for Oceans - Machine Learning"
+        ]
       },
       "named_level": null,
       "bonus": null,
@@ -2383,10 +2383,10 @@
       "activity_section_position": 7,
       "assessment": null,
       "properties": {
+        "progression": "AI for Oceans - Machine Learning",
         "level_keys": [
           "Oceans_Long_2021"
-        ],
-        "progression": "AI for Oceans - Machine Learning"
+        ]
       },
       "named_level": null,
       "bonus": null,
@@ -2435,10 +2435,10 @@
       "activity_section_position": 1,
       "assessment": null,
       "properties": {
+        "progression": "Data Story Workspace",
         "level_keys": [
           "CSP U9 Data Story Day 1_2021"
-        ],
-        "progression": "Data Story Workspace"
+        ]
       },
       "named_level": null,
       "bonus": null,
@@ -2461,10 +2461,10 @@
       "activity_section_position": 1,
       "assessment": true,
       "properties": {
+        "progression": "Data Story Workspace",
         "level_keys": [
           "CSP U9 Data Story Day 2_2021"
-        ],
-        "progression": "Data Story Workspace"
+        ]
       },
       "named_level": null,
       "bonus": null,
@@ -3310,8 +3310,5 @@
         "objective.key": "923cb922-4718-43ed-a135-f3bd078fd3db"
       }
     }
-  ],
-  "lessons_standards": [
-
   ]
 }

--- a/dashboard/lib/services/script_seed.rb
+++ b/dashboard/lib/services/script_seed.rb
@@ -20,9 +20,9 @@ module Services
     SeedContext = Struct.new(
       :script, :lesson_groups, :lessons, :lesson_activities, :activity_sections,
       :script_levels, :levels_script_levels, :levels, :resources,
-      :lessons_resources, :vocabularies, :lessons_vocabularies, :programming_expressions,
-      :lessons_programming_expressions, :objectives, :frameworks, :standards,
-      :lessons_standards, keyword_init: true
+      :lessons_resources, :vocabularies, :lessons_vocabularies, :programming_environments,
+      :programming_expressions, :lessons_programming_expressions, :objectives, :frameworks,
+      :standards, :lessons_standards, keyword_init: true
     )
 
     # Produces a JSON representation of the given Script and all objects under it in its "tree", in a format specifically
@@ -65,6 +65,7 @@ module Services
         lessons_resources: lessons_resources,
         vocabularies: vocabularies,
         lessons_vocabularies: lessons_vocabularies,
+        programming_environments: ProgrammingEnvironment.all,
         programming_expressions: ProgrammingExpression.all,
         lessons_programming_expressions: lessons_programming_expressions,
         objectives: objectives,
@@ -204,6 +205,7 @@ module Services
         seed_context.lessons_resources = import_lessons_resources(lessons_resources_data, seed_context)
         seed_context.vocabularies = import_vocabularies(vocabularies_data, seed_context)
         seed_context.lessons_vocabularies = import_lessons_vocabularies(lessons_vocabularies_data, seed_context)
+        seed_context.programming_environments = ProgrammingEnvironment.all
         seed_context.programming_expressions = ProgrammingExpression.all
         seed_context.lessons_programming_expressions = import_lessons_programming_expressions(lessons_programming_expressions_data, seed_context)
         seed_context.objectives = import_objectives(objectives_data, seed_context)
@@ -490,8 +492,11 @@ module Services
         lesson_id = seed_context.lessons.select {|l| l.key == lpe_data['seeding_key']['lesson.key']}.first&.id
         raise 'No lesson found' if lesson_id.nil?
 
-        programming_expression_id = seed_context.programming_expressions.select {|pe| pe.key == lpe_data['seeding_key']['programming_expression.key']}.first&.id
-        raise 'No programming expression found' if programming_expression_id.nil?
+        programming_environment_id = seed_context.programming_environments.select {|pe| pe.name == lpe_data['seeding_key']['programming_environment.name']}.first&.id
+        programming_expression_id = seed_context.programming_expressions.select do |pe|
+          pe.programming_environment_id == programming_environment_id && pe.key == lpe_data['seeding_key']['programming_expression.key']
+        end.first&.id
+        raise "No programming expression with key #{lpe_data['seeding_key']['programming_expression.key']} found" if programming_expression_id.nil?
 
         LessonsProgrammingExpression.new(
           lesson_id: lesson_id,

--- a/dashboard/test/fixtures/test-serialize-seeding-json.script_json
+++ b/dashboard/test/fixtures/test-serialize-seeding-json.script_json
@@ -905,24 +905,28 @@
     {
       "seeding_key": {
         "lesson.key": "test-serialize-seeding-json-lg-1-l-1",
+        "programming_environment.name": "new-lab",
         "programming_expression.key": "test-serialize-seeding-json-lg-1-l-1-programming-expression-1"
       }
     },
     {
       "seeding_key": {
         "lesson.key": "test-serialize-seeding-json-lg-1-l-1",
+        "programming_environment.name": "new-lab",
         "programming_expression.key": "test-serialize-seeding-json-lg-1-l-1-programming-expression-2"
       }
     },
     {
       "seeding_key": {
         "lesson.key": "test-serialize-seeding-json-lg-1-l-2",
+        "programming_environment.name": "new-lab",
         "programming_expression.key": "test-serialize-seeding-json-lg-1-l-2-programming-expression-1"
       }
     },
     {
       "seeding_key": {
         "lesson.key": "test-serialize-seeding-json-lg-1-l-2",
+        "programming_environment.name": "new-lab",
         "programming_expression.key": "test-serialize-seeding-json-lg-1-l-2-programming-expression-2"
       }
     }

--- a/dashboard/test/models/lessons_programming_expression_test.rb
+++ b/dashboard/test/models/lessons_programming_expression_test.rb
@@ -21,6 +21,7 @@ class LessonsProgrammingExpressionTest < ActiveSupport::TestCase
       script: script,
       lesson_groups: script.lesson_groups.to_a,
       lessons: script.lessons.to_a,
+      programming_environments: [programming_expression.programming_environment],
       programming_expressions: [programming_expression]
     )
     lessons_programming_expression = lesson.lessons_programming_expressions.first
@@ -29,6 +30,7 @@ class LessonsProgrammingExpressionTest < ActiveSupport::TestCase
     assert_queries(0) do
       expected = {
         'lesson.key' => lesson.key,
+        'programming_environment.name' => programming_expression.programming_environment.name,
         'programming_expression.key' => programming_expression.key
       }
       assert_equal expected, lessons_programming_expression.seeding_key(seed_context)


### PR DESCRIPTION
Re-implements the work in https://github.com/code-dot-org/code-dot-org/pull/39561. It would not let me just revert so I had to re-implement by hand.

The issue was that the exist lesson_proramming_expressions in the script json files did not include programming_environment so seeding those was failing.  I have re-imported everything and included the changes to script_json files in this PR.

## Links

- jira ticket: [PLAT-848](https://codedotorg.atlassian.net/browse/PLAT-848)

## Testing story

- Ran bundle exec rake build locally to make sure there were no issue.

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [x] Tests provide adequate coverage
- [x] Privacy and Security impacts have been assessed
- [x] Code is well-commented
- [x] New features are translatable or updates will not break translations
- [x] Relevant documentation has been added or updated
- [x] User impact is well-understood and desirable
- [x] Pull Request is labeled appropriately
- [x] Follow-up work items (including potential tech debt) are tracked and linked
