### PR TITLE
Serialize teacher resources for unit groups

### DIFF
--- a/dashboard/app/models/unit_group.rb
+++ b/dashboard/app/models/unit_group.rb
@@ -101,8 +101,9 @@ class UnitGroup < ApplicationRecord
       resources_imported = hash['resources'].map do |resource_data|
         resource_attrs = resource_data.except('seeding_key')
         resource_attrs['course_version_id'] = course_version.id
-        resource = Resource.find_or_create_by(key: resource_attrs['key'])
-        resource.update!(resource_attrs)
+        resource = Resource.find_or_initialize_by(key: resource_attrs['key'], course_version_id: course_version.id)
+        resource.assign_attributes(resource_attrs)
+        resource.save! if resource.changed?
         resource
       end
       unit_group.resources = resources_imported
@@ -112,7 +113,7 @@ class UnitGroup < ApplicationRecord
     unit_group
   rescue Exception => e
     # print filename for better debugging
-    new_e = Exception.new("in course: #{path}: #{e.message}")
+    new_e = Exception.new("in course: #{hash['name']}: #{e.message}")
     new_e.set_backtrace(e.backtrace)
     raise new_e
   end

--- a/dashboard/app/models/unit_group.rb
+++ b/dashboard/app/models/unit_group.rb
@@ -21,7 +21,7 @@ class UnitGroup < ApplicationRecord
   has_many :default_unit_group_units, -> {where(experiment_name: nil).order('position ASC')}, class_name: 'UnitGroupUnit', dependent: :destroy, foreign_key: 'course_id'
   has_many :default_scripts, through: :default_unit_group_units, source: :script
   has_many :alternate_unit_group_units, -> {where.not(experiment_name: nil)}, class_name: 'UnitGroupUnit', dependent: :destroy, foreign_key: 'course_id'
-  has_many :resources, join_table: :unit_groups_resources
+  has_and_belongs_to_many :resources, join_table: :unit_groups_resources
   has_one :course_version, as: :content_root
 
   after_save :write_serialization
@@ -89,9 +89,23 @@ class UnitGroup < ApplicationRecord
     unit_group = UnitGroup.find_or_create_by!(name: hash['name'])
     unit_group.update_scripts(hash['script_names'], hash['alternate_scripts'])
     unit_group.properties = hash['properties']
-    unit_group.save!
 
+    # add_course_offering creates the course version
     CourseOffering.add_course_offering(unit_group)
+    course_version = unit_group.course_version
+
+    if course_version && hash['resources']
+      resources_imported = hash['resources'].map do |resource_data|
+        resource_attrs = resource_data.except('seeding_key')
+        resource_attrs['course_version_id'] = course_version.id
+        resource = Resource.find_or_create_by(key: resource_attrs['key'])
+        resource.update!(resource_attrs)
+        resource
+      end
+      unit_group.resources = resources_imported
+    end
+
+    unit_group.save!
     unit_group
   rescue Exception => e
     # print filename for better debugging
@@ -117,7 +131,8 @@ class UnitGroup < ApplicationRecord
         name: name,
         script_names: default_unit_group_units.map(&:script).map(&:name),
         alternate_scripts: summarize_alternate_scripts,
-        properties: properties
+        properties: properties,
+        resources: resources.map {|r| Services::ScriptSeed::ResourceSerializer.new(r, scope: {}).as_json},
       }.compact
     )
   end

--- a/dashboard/app/models/unit_group.rb
+++ b/dashboard/app/models/unit_group.rb
@@ -85,7 +85,10 @@ class UnitGroup < ApplicationRecord
   def self.load_from_path(path)
     serialization = File.read(path)
     hash = JSON.parse(serialization)
+    UnitGroup.seed_from_hash(hash)
+  end
 
+  def self.seed_from_hash(hash)
     unit_group = UnitGroup.find_or_create_by!(name: hash['name'])
     unit_group.update_scripts(hash['script_names'], hash['alternate_scripts'])
     unit_group.properties = hash['properties']

--- a/dashboard/test/models/unit_group_test.rb
+++ b/dashboard/test/models/unit_group_test.rb
@@ -107,8 +107,9 @@ class UnitGroupTest < ActiveSupport::TestCase
   end
 
   test "can seed unit group and create resources from hash" do
-    course_version = create :course_version
-    unit_group = create(:unit_group, name: 'my-unit-group', is_stable: true, family_name: 'test', version_year: '2000', course_version: course_version)
+    unit_group = create(:unit_group, name: 'my-unit-group', is_stable: true, family_name: 'test', version_year: '2000')
+    CourseOffering.add_course_offering(unit_group)
+    course_version = unit_group.course_version
     create(:unit_group_unit, unit_group: unit_group, position: 1, script: create(:script, name: "script1"))
     create(:unit_group_unit, unit_group: unit_group, position: 2, script: create(:script, name: "script2"))
     create(:unit_group_unit, unit_group: unit_group, position: 3, script: create(:script, name: "script3"))
@@ -116,12 +117,78 @@ class UnitGroupTest < ActiveSupport::TestCase
 
     serialization = unit_group.serialize
     unit_group.destroy
+    course_version.destroy
 
     seeded_unit_group = UnitGroup.seed_from_hash(JSON.parse(serialization))
     assert_equal 'my-unit-group', seeded_unit_group.name
     assert_equal 3, seeded_unit_group.default_unit_group_units.length
     assert_equal 3, seeded_unit_group.default_scripts.length
     assert_equal 2, seeded_unit_group.resources.length
+  end
+
+  test "can seed unit group and only update resources from course version" do
+    unit_group = create(:unit_group, name: 'my-unit-group', is_stable: true, family_name: 'test', version_year: '2000')
+    CourseOffering.add_course_offering(unit_group)
+    create(:unit_group_unit, unit_group: unit_group, position: 1, script: create(:script, name: "script1"))
+    create(:unit_group_unit, unit_group: unit_group, position: 2, script: create(:script, name: "script2"))
+    create(:unit_group_unit, unit_group: unit_group, position: 3, script: create(:script, name: "script3"))
+    resource = create(:resource, course_version: create(:course_version))
+    resource_in_script = create(:resource, course_version: unit_group.course_version)
+    unit_group.resources = [resource_in_script]
+
+    serialization = unit_group.serialize
+
+    hash = JSON.parse(serialization)
+    hash['resources'][0]['name'] = 'updated name'
+    seeded_unit_group = UnitGroup.seed_from_hash(hash)
+    resource.reload
+    resource_in_script.reload
+    assert_equal 1, seeded_unit_group.resources.length
+    assert_equal 'updated name', seeded_unit_group.resources[0].name
+    assert_equal 'updated name', resource_in_script.name
+    refute_equal 'updated name', resource.name
+  end
+
+  test "can seed unit group and remove resources from hash" do
+    unit_group = create(:unit_group, name: 'my-unit-group', is_stable: true, family_name: 'test', version_year: '2000')
+    CourseOffering.add_course_offering(unit_group)
+    course_version = unit_group.course_version
+    create(:unit_group_unit, unit_group: unit_group, position: 1, script: create(:script, name: "script1"))
+    create(:unit_group_unit, unit_group: unit_group, position: 2, script: create(:script, name: "script2"))
+    create(:unit_group_unit, unit_group: unit_group, position: 3, script: create(:script, name: "script3"))
+    unit_group.resources = [create(:resource, course_version: course_version), create(:resource, course_version: course_version)]
+
+    serialization = unit_group.serialize
+    unit_group.destroy
+    course_version.destroy
+
+    hash = JSON.parse(serialization)
+    hash.delete('resources')
+    seeded_unit_group = UnitGroup.seed_from_hash(hash)
+    assert_equal 'my-unit-group', seeded_unit_group.name
+    assert_equal 3, seeded_unit_group.default_unit_group_units.length
+    assert_equal 3, seeded_unit_group.default_scripts.length
+    assert_equal 0, seeded_unit_group.resources.length
+  end
+
+  test "can seed unit group and update resources from hash" do
+    unit_group = create(:unit_group, name: 'my-unit-group', is_stable: true, family_name: 'test', version_year: '2000')
+    CourseOffering.add_course_offering(unit_group)
+    create(:unit_group_unit, unit_group: unit_group, position: 1, script: create(:script, name: "script1"))
+    create(:unit_group_unit, unit_group: unit_group, position: 2, script: create(:script, name: "script2"))
+    create(:unit_group_unit, unit_group: unit_group, position: 3, script: create(:script, name: "script3"))
+    resource = create(:resource, course_version: unit_group.course_version)
+    unit_group.resources = [resource]
+
+    serialization = unit_group.serialize
+
+    hash = JSON.parse(serialization)
+    hash['resources'][0]['name'] = 'updated name'
+    seeded_unit_group = UnitGroup.seed_from_hash(hash)
+    resource.reload
+    assert_equal 1, seeded_unit_group.resources.length
+    assert_equal 'updated name', seeded_unit_group.resources[0].name
+    assert_equal 'updated name', resource.name
   end
 
   test "stable?: true if unit_group has plc_course" do

--- a/dashboard/test/models/unit_group_test.rb
+++ b/dashboard/test/models/unit_group_test.rb
@@ -91,7 +91,7 @@ class UnitGroupTest < ActiveSupport::TestCase
     assert_equal 2, obj['resources'].length
   end
 
-  test "should load_from_path" do
+  test "can seed unit group from hash" do
     unit_group = create(:unit_group, name: 'my-unit-group', is_stable: true)
     create(:unit_group_unit, unit_group: unit_group, position: 1, script: create(:script, name: "script1"))
     create(:unit_group_unit, unit_group: unit_group, position: 2, script: create(:script, name: "script2"))
@@ -106,7 +106,7 @@ class UnitGroupTest < ActiveSupport::TestCase
     assert_equal 3, seeded_unit_group.default_scripts.length
   end
 
-  test "should load_from_path and create resources" do
+  test "can seed unit group and create resources from hash" do
     course_version = create :course_version
     unit_group = create(:unit_group, name: 'my-unit-group', is_stable: true, family_name: 'test', version_year: '2000', course_version: course_version)
     create(:unit_group_unit, unit_group: unit_group, position: 1, script: create(:script, name: "script1"))


### PR DESCRIPTION
Step 2 of moving teacher resources onto the Resource model. 

Steps for this will be:
1. (#39367) Create an association between resources and unit groups/scripts so that resources can be associated with a script or unit group.
2. (This PR and #39617) Add seeding of ScriptsResource and UnitGroupsResource
3. Replace the current way to add resources to a script with a new editor using the Resources model. Move all existing resources to the resources model (at least on migrated scripts, non-migrated will likely need to wait for translations). Display resources from the resources model in the dropdown.

## Links

- jira ticket: [PLAT-509](https://codedotorg.atlassian.net/browse/PLAT-509)

## Testing story

unit tests as well as a manual test

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
