### PR TITLE
Seed and serialization for script resources

### DIFF
--- a/dashboard/app/models/script.rb
+++ b/dashboard/app/models/script.rb
@@ -92,7 +92,8 @@ class Script < ApplicationRecord
           ]
         },
         :script_levels,
-        :levels
+        :levels,
+        :resources
       ]
     )
   end

--- a/dashboard/app/models/script.rb
+++ b/dashboard/app/models/script.rb
@@ -40,7 +40,8 @@ class Script < ApplicationRecord
   has_many :script_levels, through: :lessons
   has_many :levels_script_levels, through: :script_levels # needed for seeding logic
   has_many :levels, through: :script_levels
-  has_many :resources, join_table: :scripts_resources
+  has_and_belongs_to_many :resources, join_table: :scripts_resources
+  has_many :scripts_resources
   has_many :users, through: :user_scripts
   has_many :user_scripts
   has_many :hint_view_requests

--- a/dashboard/app/models/scripts_resource.rb
+++ b/dashboard/app/models/scripts_resource.rb
@@ -11,4 +11,6 @@
 #  index_scripts_resources_on_script_id_and_resource_id  (script_id,resource_id) UNIQUE
 #
 class ScriptsResource < ApplicationRecord
+  belongs_to :resource
+  belongs_to :script
 end

--- a/dashboard/app/models/scripts_resource.rb
+++ b/dashboard/app/models/scripts_resource.rb
@@ -13,4 +13,22 @@
 class ScriptsResource < ApplicationRecord
   belongs_to :resource
   belongs_to :script
+
+  # Used for seeding from JSON. Returns the full set of information needed to
+  # uniquely identify this object as well as any other objects it belongs to.
+  # If the attributes of this object alone aren't sufficient, and associated
+  # objects are needed, then data from the seeding_keys of those objects should
+  # be included as well. Ideally should correspond to a unique index for this
+  # model's table. See comments on ScriptSeed.seed_from_hash for more context.
+  #
+  # @param [ScriptSeed::SeedContext] seed_context - contains preloaded data to use when looking up associated objects
+  # @return [Hash<String, String>] all information needed to uniquely identify this object across environments.
+  def seeding_key(seed_context)
+    my_resource = seed_context.resources.select {|r| r.id == resource_id}.first
+    my_key = {'resource.key': my_resource.key}
+    script_seeding_key = seed_context.script.seeding_key(seed_context)
+
+    my_key.merge!(script_seeding_key) {|key, _, _| raise "Duplicate key when generating seeding_key: #{key}"}
+    my_key.stringify_keys
+  end
 end

--- a/dashboard/lib/services/script_seed.rb
+++ b/dashboard/lib/services/script_seed.rb
@@ -44,7 +44,7 @@ module Services
 
       activities = script.lessons.map(&:lesson_activities).flatten
       sections = activities.map(&:activity_sections).flatten
-      resources = script.lessons.map(&:resources).flatten
+      resources = script.lessons.map(&:resources).flatten.concat(script.resources).uniq
       lessons_resources = script.lessons.map(&:lessons_resources).flatten
       vocabularies = script.lessons.map(&:vocabularies).flatten
       lessons_vocabularies = script.lessons.map(&:lessons_vocabularies).flatten
@@ -735,6 +735,14 @@ module Services
     end
 
     class LessonsResourceSerializer < ActiveModel::Serializer
+      attributes :seeding_key
+
+      def seeding_key
+        object.seeding_key(@scope[:seed_context])
+      end
+    end
+
+    class ScriptsResourceSerializer < ActiveModel::Serializer
       attributes :seeding_key
 
       def seeding_key

--- a/dashboard/lib/services/script_seed.rb
+++ b/dashboard/lib/services/script_seed.rb
@@ -441,7 +441,7 @@ module Services
 
       # destroy_outdated_objects won't work on ScriptsResource objects because
       # they do not have an id field. Work around this by inefficiently deleting
-      # all ScriptsResources using 1 query per lesson, and then re-importing all
+      # all ScriptsResources using 1 query, and then re-importing all
       # ScriptsResources in a single query. It may be possible to eliminate
       # these extra queries by adding an id column to the ScriptsResource model.
       seed_context.script.resources = []

--- a/dashboard/lib/services/script_seed.rb
+++ b/dashboard/lib/services/script_seed.rb
@@ -427,6 +427,7 @@ module Services
 
     def self.import_scripts_resources(scripts_resources_data, seed_context)
       return [] unless seed_context.script.get_course_version
+      return [] unless scripts_resources_data
 
       scripts_resources_to_import = scripts_resources_data.map do |lr_data|
         resource_id = seed_context.resources.select {|r| r.key == lr_data['seeding_key']['resource.key']}.first&.id

--- a/dashboard/lib/services/script_seed.rb
+++ b/dashboard/lib/services/script_seed.rb
@@ -20,7 +20,7 @@ module Services
     SeedContext = Struct.new(
       :script, :lesson_groups, :lessons, :lesson_activities, :activity_sections,
       :script_levels, :levels_script_levels, :levels, :resources,
-      :lessons_resources, :vocabularies, :lessons_vocabularies, :programming_environments,
+      :lessons_resources, :scripts_resources, :vocabularies, :lessons_vocabularies, :programming_environments,
       :programming_expressions, :lessons_programming_expressions, :objectives, :frameworks,
       :standards, :lessons_standards, keyword_init: true
     )
@@ -63,6 +63,7 @@ module Services
         levels: my_levels,
         resources: resources,
         lessons_resources: lessons_resources,
+        scripts_resources: script.scripts_resources,
         vocabularies: vocabularies,
         lessons_vocabularies: lessons_vocabularies,
         programming_environments: ProgrammingEnvironment.all,
@@ -85,6 +86,7 @@ module Services
         levels_script_levels: script.levels_script_levels.map {|lsl| ScriptSeed::LevelsScriptLevelSerializer.new(lsl, scope: scope).as_json},
         resources: resources.map {|r| ScriptSeed::ResourceSerializer.new(r, scope: scope).as_json},
         lessons_resources: lessons_resources.map {|lr| ScriptSeed::LessonsResourceSerializer.new(lr, scope: scope).as_json},
+        scripts_resources: script.scripts_resources.map {|sr| ScriptSeed::ScriptsResourceSerializer.new(sr, scope: scope).as_json},
         vocabularies: vocabularies.map {|v| ScriptSeed::VocabularySerializer.new(v, scope: scope).as_json},
         lessons_vocabularies: lessons_vocabularies.map {|lv| ScriptSeed::LessonsVocabularySerializer.new(lv, scope: scope).as_json},
         lessons_programming_expressions: lessons_programming_expressions.map {|lpe| ScriptSeed::LessonsProgrammingExpressionSerializer.new(lpe, scope: scope).as_json},
@@ -163,6 +165,7 @@ module Services
       levels_script_levels_data = data['levels_script_levels']
       resources_data = data['resources']
       lessons_resources_data = data['lessons_resources']
+      scripts_resources_data = data['scripts_resources']
       vocabularies_data = data['vocabularies']
       lessons_vocabularies_data = data['lessons_vocabularies']
       lessons_programming_expressions_data = data['lessons_programming_expressions']
@@ -203,6 +206,7 @@ module Services
 
         seed_context.resources = import_resources(resources_data, seed_context)
         seed_context.lessons_resources = import_lessons_resources(lessons_resources_data, seed_context)
+        seed_context.scripts_resources = import_scripts_resources(scripts_resources_data, seed_context)
         seed_context.vocabularies = import_vocabularies(vocabularies_data, seed_context)
         seed_context.lessons_vocabularies = import_lessons_vocabularies(lessons_vocabularies_data, seed_context)
         seed_context.programming_environments = ProgrammingEnvironment.all
@@ -419,6 +423,30 @@ module Services
 
       LessonsResource.import! lessons_resources_to_import, on_duplicate_key_update: get_columns(LessonsResource)
       LessonsResource.joins(:lesson).where('stages.script_id' => seed_context.script.id)
+    end
+
+    def self.import_scripts_resources(scripts_resources_data, seed_context)
+      return [] unless seed_context.script.get_course_version
+
+      scripts_resources_to_import = scripts_resources_data.map do |lr_data|
+        resource_id = seed_context.resources.select {|r| r.key == lr_data['seeding_key']['resource.key']}.first&.id
+        raise 'No resource found' if resource_id.nil?
+
+        ScriptsResource.new(
+          script_id: seed_context.script.id,
+          resource_id: resource_id
+        )
+      end
+
+      # destroy_outdated_objects won't work on ScriptsResource objects because
+      # they do not have an id field. Work around this by inefficiently deleting
+      # all ScriptsResources using 1 query per lesson, and then re-importing all
+      # ScriptsResources in a single query. It may be possible to eliminate
+      # these extra queries by adding an id column to the ScriptsResource model.
+      seed_context.script.resources = []
+
+      ScriptsResource.import! scripts_resources_to_import, on_duplicate_key_update: get_columns(ScriptsResource)
+      ScriptsResource.where('script_id' => seed_context.script.id)
     end
 
     def self.import_vocabularies(vocabularies_data, seed_context)

--- a/dashboard/test/fixtures/test-serialize-seeding-json.script_json
+++ b/dashboard/test/fixtures/test-serialize-seeding-json.script_json
@@ -805,6 +805,16 @@
       "seeding_key": {
         "resource.key": "test-serialize-seeding-json-lg-1-l-2-resource-2"
       }
+    },
+    {
+      "name": "fake name",
+      "url": "fake.url",
+      "key": "test-serialize-seeding-json-script-resource-1",
+      "properties": {
+      },
+      "seeding_key": {
+        "resource.key": "test-serialize-seeding-json-script-resource-1"
+      }
     }
   ],
   "lessons_resources": [
@@ -834,7 +844,12 @@
     }
   ],
   "scripts_resources": [
-
+    {
+      "seeding_key": {
+        "resource.key": "test-serialize-seeding-json-script-resource-1",
+        "script.name": "test-serialize-seeding-json-script"
+      }
+    }
   ],
   "vocabularies": [
     {

--- a/dashboard/test/fixtures/test-serialize-seeding-json.script_json
+++ b/dashboard/test/fixtures/test-serialize-seeding-json.script_json
@@ -833,6 +833,9 @@
       }
     }
   ],
+  "scripts_resources": [
+
+  ],
   "vocabularies": [
     {
       "key": "test_serialize_seeding_json_lg_l_vocab_",

--- a/dashboard/test/lib/services/script_seed_test.rb
+++ b/dashboard/test/lib/services/script_seed_test.rb
@@ -66,7 +66,7 @@ module Services
       # This is currently:
       #   3 misc queries - starting and stopping transaction, getting max_allowed_packet
       #   4 queries to set up course offering and course version
-      #   30 queries - two for each model, + one extra query each for Lessons,
+      #   32 queries - two for each model, + one extra query each for Lessons,
       #     LessonActivities, ActivitySections, ScriptLevels, LevelsScriptLevels,
       #     Resources, and Vocabulary.
       #     These 2-3 queries per model are to (1) delete old entries, (2) import
@@ -134,6 +134,7 @@ module Services
       json = ScriptSeed.serialize_seeding_json(script)
       script.lessons.each {|l| l.resources.destroy_all}
       script.lessons.each {|l| l.vocabularies.destroy_all}
+      script.resources.destroy_all
       script.freeze
       expected_counts = get_counts
 
@@ -756,6 +757,10 @@ module Services
         assert_resources_equal(
           s1.lessons.map(&:resources).flatten,
           s2.lessons.map(&:resources).flatten
+        )
+        assert_resources_equal(
+          s1.resources,
+          s2.resources
         )
         assert_vocabularies_equal(
           s1.lessons.map(&:vocabularies).flatten,

--- a/dashboard/test/lib/services/script_seed_test.rb
+++ b/dashboard/test/lib/services/script_seed_test.rb
@@ -28,7 +28,7 @@ module Services
 
       filename = File.join(self.class.fixture_path, 'test-serialize-seeding-json.script_json')
       # Uncomment the following line to update test-serialize-seeding-json.script_json
-      # File.write(filename, ScriptSeed.serialize_seeding_json(script))
+      #File.write(filename, ScriptSeed.serialize_seeding_json(script))
 
       expected = JSON.parse(File.read(filename))
       actual = JSON.parse(ScriptSeed.serialize_seeding_json(script))
@@ -88,7 +88,7 @@ module Services
       # this is slower for most individual Scripts, but there could be a savings when seeding multiple Scripts.
       # For now, leaving this as a potential future optimization, since it seems to be reasonably fast as is.
       # The game queries can probably be avoided with a little work, though they only apply for Blockly levels.
-      assert_queries(96) do
+      assert_queries(97) do
         ScriptSeed.seed_from_json(json)
       end
 
@@ -860,6 +860,7 @@ module Services
       num_sections_per_activity: 2,
       num_script_levels_per_section: 2,
       num_resources_per_lesson: 2,
+      num_resources_per_script: 1,
       num_vocabularies_per_lesson: 2,
       num_programming_expressions_per_lesson: 2,
       num_objectives_per_lesson: 2,
@@ -905,6 +906,11 @@ module Services
           name = "#{name_prefix}-lg-#{m + 1}-l-#{n + 1}"
           create :lesson, lesson_group: lg, script: script, name: name, key: name, overview: "overview #{m + 1} #{n + 1}", has_lesson_plan: true
         end
+      end
+
+      (1..num_resources_per_script).each do |r|
+        resource = create :resource, key: "#{script.name}-resource-#{r}", course_version: course_version
+        ScriptsResource.find_or_create_by!(resource: resource, script: script)
       end
 
       sl_num = 1

--- a/dashboard/test/lib/services/script_seed_test.rb
+++ b/dashboard/test/lib/services/script_seed_test.rb
@@ -28,7 +28,7 @@ module Services
 
       filename = File.join(self.class.fixture_path, 'test-serialize-seeding-json.script_json')
       # Uncomment the following line to update test-serialize-seeding-json.script_json
-      #File.write(filename, ScriptSeed.serialize_seeding_json(script))
+      # File.write(filename, ScriptSeed.serialize_seeding_json(script))
 
       expected = JSON.parse(File.read(filename))
       actual = JSON.parse(ScriptSeed.serialize_seeding_json(script))
@@ -88,7 +88,7 @@ module Services
       # this is slower for most individual Scripts, but there could be a savings when seeding multiple Scripts.
       # For now, leaving this as a potential future optimization, since it seems to be reasonably fast as is.
       # The game queries can probably be avoided with a little work, though they only apply for Blockly levels.
-      assert_queries(95) do
+      assert_queries(96) do
         ScriptSeed.seed_from_json(json)
       end
 


### PR DESCRIPTION
Step 2 of moving teacher resources onto the Resource model. 

Steps for this will be:
1. (#39367) Create an association between resources and unit groups/scripts so that resources can be associated with a script or unit group.
2. (This PR and #39605) Add seeding of ScriptsResource and UnitGroupsResource
3. Replace the current way to add resources to a script with a new editor using the Resources model. Move all existing resources to the resources model (at least on migrated scripts, non-migrated will likely need to wait for translations). Display resources from the resources model in the dropdown.

## Links

- jira ticket: [PLAT-509](https://codedotorg.atlassian.net/browse/PLAT-509)

## Testing story

unit tests as well as a manual test

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
