### PR TITLE
Fix textToSpeechEnabled prop type on InlineFeedback

### DIFF
--- a/apps/src/templates/instructions/InlineFeedback.jsx
+++ b/apps/src/templates/instructions/InlineFeedback.jsx
@@ -14,7 +14,7 @@ class InlineFeedback extends Component {
     styles: PropTypes.object,
     isMinecraft: PropTypes.bool,
     skinId: PropTypes.string,
-    textToSpeechEnabled: PropTypes.string
+    textToSpeechEnabled: PropTypes.bool
   };
 
   /**


### PR DESCRIPTION
James noticed some console errors due to incorrect prop types. I manually verified that this change fixed those.

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
