### PR TITLE
Reserialize scripts on vocab and resource change

### DIFF
--- a/dashboard/app/controllers/resources_controller.rb
+++ b/dashboard/app/controllers/resources_controller.rb
@@ -26,6 +26,7 @@ class ResourcesController < ApplicationController
       resource.course_version = course_version if course_version
     end
     if resource.save
+      resource.serialize_scripts
       render json: resource.summarize_for_lesson_edit
     else
       render status: 400, json: {error: resource.errors.full_message.to_json}
@@ -37,6 +38,7 @@ class ResourcesController < ApplicationController
     resource = Resource.find_by_id(resource_params[:id])
     if resource
       resource.update!(resource_params)
+      resource.serialize_scripts
       render json: resource.summarize_for_lesson_edit
     else
       render json: {status: 404, error: "Resource #{resource_params[:id]} not found"}

--- a/dashboard/app/controllers/vocabularies_controller.rb
+++ b/dashboard/app/controllers/vocabularies_controller.rb
@@ -21,6 +21,7 @@ class VocabulariesController < ApplicationController
     vocabulary.course_version = course_version
     begin
       vocabulary.save!
+      vocabulary.serialize_scripts
       render json: vocabulary.summarize_for_lesson_edit
     rescue ActiveRecord::RecordNotUnique, ActiveRecord::RecordInvalid => e
       render status: 400, json: {error: e.message.to_json}
@@ -37,6 +38,7 @@ class VocabulariesController < ApplicationController
       end
     end
     if vocabulary && vocabulary.update!(vocabulary_params.except(:lesson_ids))
+      vocabulary.serialize_scripts
       render json: vocabulary.summarize_for_lesson_edit
     else
       render json: {status: 404, error: "Vocabulary #{vocabulary_params[:id]} not found"}

--- a/dashboard/app/models/resource.rb
+++ b/dashboard/app/models/resource.rb
@@ -97,6 +97,12 @@ class Resource < ApplicationRecord
     }
   end
 
+  def serialize_scripts
+    if Rails.application.config.levelbuilder_mode
+      lessons.map(&:script).each(&:write_script_json)
+    end
+  end
+
   private
 
   def generate_key_from_name

--- a/dashboard/app/models/resource.rb
+++ b/dashboard/app/models/resource.rb
@@ -99,7 +99,7 @@ class Resource < ApplicationRecord
 
   def serialize_scripts
     if Rails.application.config.levelbuilder_mode
-      lessons.map(&:script).each(&:write_script_json)
+      lessons.map(&:script).uniq.each(&:write_script_json)
     end
   end
 

--- a/dashboard/app/models/vocabulary.rb
+++ b/dashboard/app/models/vocabulary.rb
@@ -116,6 +116,12 @@ class Vocabulary < ApplicationRecord
     new_key
   end
 
+  def serialize_scripts
+    if Rails.application.config.levelbuilder_mode
+      lessons.map(&:script).flatten.each(&:write_script_json)
+    end
+  end
+
   private
 
   def display_word

--- a/dashboard/app/models/vocabulary.rb
+++ b/dashboard/app/models/vocabulary.rb
@@ -118,7 +118,7 @@ class Vocabulary < ApplicationRecord
 
   def serialize_scripts
     if Rails.application.config.levelbuilder_mode
-      lessons.map(&:script).flatten.each(&:write_script_json)
+      lessons.map(&:script).each(&:write_script_json)
     end
   end
 

--- a/dashboard/app/models/vocabulary.rb
+++ b/dashboard/app/models/vocabulary.rb
@@ -118,7 +118,7 @@ class Vocabulary < ApplicationRecord
 
   def serialize_scripts
     if Rails.application.config.levelbuilder_mode
-      lessons.map(&:script).each(&:write_script_json)
+      lessons.map(&:script).uniq.each(&:write_script_json)
     end
   end
 

--- a/dashboard/test/controllers/resources_controller_test.rb
+++ b/dashboard/test/controllers/resources_controller_test.rb
@@ -6,6 +6,8 @@ class ResourcesControllerTest < ActionController::TestCase
   setup do
     Rails.application.config.stubs(:levelbuilder_mode).returns true
     @levelbuilder = create :levelbuilder
+    # We don't want to write to the file system here
+    Resource.any_instance.stubs(:serialize_scripts)
   end
 
   test 'can create resource from params' do
@@ -24,6 +26,7 @@ class ResourcesControllerTest < ActionController::TestCase
 
   test 'can update resource from params' do
     sign_in @levelbuilder
+    Resource.any_instance.expects(:serialize_scripts).once
     resource = create :resource, name: 'original name', type: 'Slides'
     post :update, params: {id: resource.id, name: 'new name', type: 'Slides'}
     assert_response :success

--- a/dashboard/test/controllers/vocabularies_controller_test.rb
+++ b/dashboard/test/controllers/vocabularies_controller_test.rb
@@ -6,6 +6,8 @@ class VocabulariesControllerTest < ActionController::TestCase
   setup do
     Rails.application.config.stubs(:levelbuilder_mode).returns true
     @levelbuilder = create :levelbuilder
+    # We don't want to actually write to the file system here
+    Vocabulary.any_instance.stubs(:serialize_scripts)
   end
 
   test "can create vocabulary from params" do
@@ -35,6 +37,7 @@ class VocabulariesControllerTest < ActionController::TestCase
     sign_in @levelbuilder
     course_version = create :course_version
     lesson = create :lesson
+    Vocabulary.any_instance.expects(:serialize_scripts).once
     vocabulary = create :vocabulary, word: 'word', definition: 'draft definition', course_version: course_version
     post :update, params: {id: vocabulary.id, word: 'word', definition: 'updated definition', courseVersionId: course_version.id, lessonIds: [lesson.id].to_json}
     assert_response :success

--- a/dashboard/test/models/resource_test.rb
+++ b/dashboard/test/models/resource_test.rb
@@ -88,4 +88,23 @@ class ResourceTest < ActiveSupport::TestCase
       assert_equal expected, resource.seeding_key(seed_context)
     end
   end
+
+  test 'serialize scripts that resource is in' do
+    Rails.application.config.stubs(:levelbuilder_mode).returns true
+    @levelbuilder = create :levelbuilder
+
+    course_version = create :course_version, :with_unit_group
+    unit_group = course_version.content_root
+    script1 = create :script
+    script2 = create :script
+    script1.expects(:write_script_json).once
+    script2.expects(:write_script_json).once
+    create :unit_group_unit, unit_group: unit_group, script: script1, position: 1
+    create :unit_group_unit, unit_group: unit_group, script: script2, position: 2
+    lesson1 = create :lesson, script: script1
+    lesson2 = create :lesson, script: script2
+    resource = create :resource, course_version: course_version
+    resource.lessons = [lesson1, lesson2]
+    resource.serialize_scripts
+  end
 end

--- a/dashboard/test/models/vocabulary_test.rb
+++ b/dashboard/test/models/vocabulary_test.rb
@@ -76,4 +76,23 @@ class VocabularyTest < ActiveSupport::TestCase
     vocab.key = "abcdefghijklmnopqrstuvwxyz_"
     assert vocab.valid?
   end
+
+  test 'serialize scripts that vocabulary is in' do
+    Rails.application.config.stubs(:levelbuilder_mode).returns true
+    @levelbuilder = create :levelbuilder
+
+    course_version = create :course_version, :with_unit_group
+    unit_group = course_version.content_root
+    script1 = create :script
+    script2 = create :script
+    script1.expects(:write_script_json).once
+    script2.expects(:write_script_json).once
+    create :unit_group_unit, unit_group: unit_group, script: script1, position: 1
+    create :unit_group_unit, unit_group: unit_group, script: script2, position: 2
+    lesson1 = create :lesson, script: script1
+    lesson2 = create :lesson, script: script2
+    vocabulary = create :vocabulary, course_version: course_version
+    vocabulary.lessons = [lesson1, lesson2]
+    vocabulary.serialize_scripts
+  end
 end


### PR DESCRIPTION
[PLAT-854](https://codedotorg.atlassian.net/browse/PLAT-854). The issue with our seeding logic being by script is that scripts can share resources and vocabulary, causing changes to not always stick. We should reserialize all scripts that have the resource or vocabulary object when that object is updated.

We might need to go through the script_json files and fix any that are in a bad state. I'm not completely sure the best way of going about that so I'm going to leave it as a follow-up.

## Testing story

unit test 

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
