### PR TITLE
Add an Acapela metric without dimension

### DIFF
--- a/dashboard/lib/acapela.rb
+++ b/dashboard/lib/acapela.rb
@@ -25,7 +25,26 @@ def acapela_text_to_audio_url(text, voice="rosie22k", speed=180, shape=100, cont
   request = VAAS_HASH.merge(params)
   response = Net::HTTP.post_form(URI.parse(VAAS_URL), request)
 
+  # CloudWatch dashboard to monitor Acapela-TTS-Service
+  # https://console.aws.amazon.com/cloudwatch/home?region=us-east-1#dashboards:name=Acapela-TTS-Service
   metrics = [
+    # The first metric has no dimension. It simply counts the total number
+    # of Acapela API calls across all scenarios.
+    {
+      metric_name: :AcapelaAPICallTotal,
+      value: 1
+    },
+    # The second metric is more granular. It counts the number of Acapela API
+    # calls in a unique combination of environment, context and voice.
+    # CloudWatch treats each unique combination of dimensions as a separate metric,
+    # even if the metrics have the same metric name. So later, we have to use
+    # Search expression and Metric math to aggregate those metrics.
+    #
+    # @see the following links for more details
+    # https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/cloudwatch_concepts.html#Metric
+    # https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/cloudwatch_concepts.html#Dimension
+    # https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/using-search-expressions.html
+    # https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/using-metric-math.html
     {
       metric_name: :AcapelaAPICall,
       dimensions: [


### PR DESCRIPTION
[FND-1464](https://codedotorg.atlassian.net/browse/FND-1464) 
Adding a simple metric, `AcapelaAPICallTotal`, without dimension to count the total number of Acapela API calls across all scenarios. The new metric will be used to create an Acapela alarm in the [Acapela-TTS-Service dashboard](https://console.aws.amazon.com/cloudwatch/home?region=us-east-1#dashboards:name=Acapela-TTS-Service).

A test alarm using the `AcapelaAPICallTotal` metric: [test-acapela-api-calls-too-high](https://console.aws.amazon.com/cloudwatch/home?region=us-east-1#alarmsV2:alarm/test-acapela-api-calls-too-high?)

## Background
In https://github.com/code-dot-org/code-dot-org/pull/39396, we added the `AcapelaAPICall` metric with 3 dimensions (context, environment, and voice) to count the number of requests to Acapela in different scenarios. 

We want to create a CloudWatch alarm when the total number of Acapela requests, regardless of scenarios, exceeds a threshold. 

To calculate the total number of Acapela requests, we first use [search expression](https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/using-search-expressions.html) to find all matching metrics. (A metric is an [unique combination](https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/cloudwatch_concepts.html#Dimension) of its namespace, metric name, dimension name and dimension value). Then, we use [metric math](https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/using-metric-math.html) to sum up values from those individual metrics.
* `e1` expression is a search expression.
* `e2` expression is a simple `SUM` of values from `e1`.
  ```json
  "metrics": [
      [ { "expression": "SEARCH('{TTS,Context,Environment,Voice} AcapelaAPICall ', 'SampleCount', 86400)", "id": "e1", "period": 300, "region": "us-east-1", "label": "Total calls" } ],
      [ { "expression": "SUM(e1)", "label": "Total Calls", "id": "e2", "region": "us-east-1", "visible": false } ]
  ],
  ```

Turns out, CloudWatch doesn't support creating an alarm for a complex calculation using both metric math and search expression like that. 

The solution is to create a very simple metric across all scenarios and create an alarm based on it.

## Links
- [Slack discussion](https://codedotorg.slack.com/archives/C03CK49G9/p1616089895020000) about CloudWatch alarm with #infrastructure.

## Testing story
Sent the new metric from a development environment. Verified that it got to CloudWatch and could create an alarm for it.
