### PR TITLE
[AiLab] string changes in ModelManagerDialog

### DIFF
--- a/apps/i18n/common/en_us.json
+++ b/apps/i18n/common/en_us.json
@@ -1137,7 +1137,7 @@
   "makerViewProjectsDesc": "Go to your project list to view all of your existing projects and continue working on them.",
   "makerViewProjectsTitle": "View your project list",
   "makeYourOwnFlappy": "Make Your Own Flappy Game",
-  "manageAIModels": "Manage AI Models",
+  "manageAIModels": "Manage A.I. Models",
   "manageAssets": "Manage Assets",
   "manageLibraries": "Manage Libraries",
   "manageLinkedAccounts": "Manage Linked Accounts",

--- a/apps/i18n/common/en_us.json
+++ b/apps/i18n/common/en_us.json
@@ -1137,7 +1137,7 @@
   "makerViewProjectsDesc": "Go to your project list to view all of your existing projects and continue working on them.",
   "makerViewProjectsTitle": "View your project list",
   "makeYourOwnFlappy": "Make Your Own Flappy Game",
-  "manageAIModels": "Manage A.I. Models",
+  "manageAIModels": "Manage AI Models",
   "manageAssets": "Manage Assets",
   "manageLibraries": "Manage Libraries",
   "manageLinkedAccounts": "Manage Linked Accounts",

--- a/apps/i18n/common/en_us.json
+++ b/apps/i18n/common/en_us.json
@@ -52,6 +52,7 @@
   "advancedShare": "Show advanced options",
   "age": "Age",
   "agenda": "Agenda",
+  "aiTrainedModels": "AI Trained Models",
   "all": "All",
   "allHandouts": "All Handouts",
   "allowEditing": "Allow editing",

--- a/apps/src/code-studio/components/ModelManagerDialog.jsx
+++ b/apps/src/code-studio/components/ModelManagerDialog.jsx
@@ -81,7 +81,7 @@ export default class ModelManagerDialog extends React.Component {
           handleClose={this.closeModelManager}
           useUpdatedStyles
         >
-          <h2>A.I Trained Models</h2>
+          <h2>A.I. Trained Models</h2>
           <div style={styles.left}>
             <select
               name="model"

--- a/apps/src/code-studio/components/ModelManagerDialog.jsx
+++ b/apps/src/code-studio/components/ModelManagerDialog.jsx
@@ -81,7 +81,7 @@ export default class ModelManagerDialog extends React.Component {
           handleClose={this.closeModelManager}
           useUpdatedStyles
         >
-          <h2>A.I. Trained Models</h2>
+          <h2>AI Trained Models</h2>
           <div style={styles.left}>
             <select
               name="model"


### PR DESCRIPTION
Changed "A.I" to "AI" for consistency. 

Model manager dialog before: 
![model_manager_before](https://user-images.githubusercontent.com/40412372/111854087-c38d5680-88da-11eb-8bd8-216fa793db99.png)

Model manager dialog after: 
![Screen Shot 2021-03-22 at 11 27 15 AM](https://user-images.githubusercontent.com/40412372/112040699-c23e7280-8b02-11eb-848c-4dd1a88baf7f.png)

