### PR TITLE
Bump Bramble to 0.1.30

### DIFF
--- a/dashboard/app/controllers/weblab_host_controller.rb
+++ b/dashboard/app/controllers/weblab_host_controller.rb
@@ -1,7 +1,7 @@
 class WeblabHostController < ApplicationController
   layout false
 
-  BRAMBLE_URL = 'https://downloads.computinginthecore.org/bramble_0.1.29'
+  BRAMBLE_URL = 'https://downloads.computinginthecore.org/bramble_0.1.30'
   BRAMBLE_LOCALHOST_URL = 'http://127.0.0.1:8000/src'
 
   def index


### PR DESCRIPTION
Update Bramble version to 0.1.30.

## Links

- [STAR-481](https://codedotorg.atlassian.net/browse/STAR-481) - [bramble/#17](https://github.com/code-dot-org/bramble/pull/17) - track allowlist instead of disallow list for filename characters
- [STAR-1474](https://codedotorg.atlassian.net/browse/STAR-1474) - [bramble/#18](https://github.com/code-dot-org/bramble/pull/18) - disable drag-and-drop file upload
- [STAR-1489](https://codedotorg.atlassian.net/browse/STAR-1489) - [bramble/#19](https://github.com/code-dot-org/bramble/pull/19) - remove 'allow' attribute from Bramble iframes