### PR TITLE
Check whether blockspace exists

### DIFF
--- a/apps/src/code-studio/initApp/loadApp.js
+++ b/apps/src/code-studio/initApp/loadApp.js
@@ -507,7 +507,7 @@ const sourceHandler = {
     return new Promise((resolve, reject) => {
       let source;
       let appOptions = getAppOptions();
-      if (window.Blockly) {
+      if (window.Blockly && Blockly.mainBlockSpace) {
         // If we're readOnly, source hasn't changed at all
         source = Blockly.mainBlockSpace.isReadOnly()
           ? currentLevelSource


### PR DESCRIPTION
https://github.com/code-dot-org/code-dot-org/pull/32484 made it so that we always load Blockly on contained levels, so checking whether `window.Blockly` exists is not sufficient for determining whether Blockly is actually being used. 

This led to null pointer errors on levels like https://studio.code.org/s/allthethings/stage/41/puzzle/7:
![image](https://user-images.githubusercontent.com/8787187/112055735-74cb0100-8b14-11eb-85a9-b3823b316e4d.png)

Instead, we should check `(window.Blockly && Blockly.mainBlockSpace)`

[slack thread](https://codedotorg.slack.com/archives/CN4T89YP8/p1616442024011000)
