### PR TITLE
disable standards migration breaking local development

### DIFF
--- a/dashboard/db/migrate/20210313061652_nullable_standards_fields.rb
+++ b/dashboard/db/migrate/20210313061652_nullable_standards_fields.rb
@@ -1,6 +1,10 @@
 class NullableStandardsFields < ActiveRecord::Migration[5.2]
   def change
-    change_column :standards, :organization, :string, null: true
-    change_column :standards, :organization_id, :string, null: true
+    # make sure developers who have not seeded in a while do not run this
+    # migration, because an earlier migration will already have removed this
+    # column.
+    #
+    # change_column :standards, :organization, :string, null: true
+    # change_column :standards, :organization_id, :string, null: true
   end
 end


### PR DESCRIPTION
The following migrations on the standards table were merged (and reached production) in this order (updated):
* https://github.com/code-dot-org/code-dot-org/blob/staging/dashboard/db/migrate/20210313061652_nullable_standards_fields.rb#L5
* https://github.com/code-dot-org/code-dot-org/blob/staging/dashboard/db/migrate/20210311005651_remove_fields_from_standards.rb

however, because of the order of their timestamps, developers migrating their local databases for the first time in a while are running them in the opposite order, leading to errors.

The solution is to disable the 3/13 migration since the column was already removed in the 3/11 migration.