### PR TITLE
Restoring i18n-sync-out multi-threading

### DIFF
--- a/tools/scripts/ManifestBuilder.rb
+++ b/tools/scripts/ManifestBuilder.rb
@@ -283,10 +283,7 @@ The animation has been skipped.
 
     # Parallelize metadata construction because some objects will require an
     # extra S3 request to get version IDs or image dimensions.
-    #
-    # TODO: remove 'in_threads: 0' once the i18n-dev server RAM has been increased over 8 GB
-    # https://codedotorg.atlassian.net/browse/FND-1460
-    Parallel.map(animation_objects.keys, in_threads: 0, finish: lambda do |name, _, result|
+    Parallel.map(animation_objects.keys, finish: lambda do |name, _, result|
       # This lambda runs synchronously after each entry is done processing - it's
       # used to collect up results and warnings to the original process/thread.
       if result.is_a? Hash


### PR DESCRIPTION
Restores the multi-threading for the sync-out step of our i18n-sync. This can be re-enabled because the ec2 host running the script had its memory doubled. See the JIRA task for more details.

## Links
[JIRA](https://codedotorg.atlassian.net/browse/FND-1460)

## Testing story
none

## Deployment strategy
N/A

## Follow-up work
N/A

## Privacy
N/A

## Security
N/A

## Caching
N/A

## PR Checklist:

- [x] Tests provide adequate coverage
- [x] Privacy and Security impacts have been assessed
- [x] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [x] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
