### PR TITLE
Add CdoBramble with event handlers and unit tests

### DIFF
--- a/apps/src/weblab/CdoBramble.js
+++ b/apps/src/weblab/CdoBramble.js
@@ -1,0 +1,160 @@
+import {removeDisallowedHtmlContent} from './brambleUtils';
+
+export default class CdoBramble {
+  constructor(Bramble, store, url, projectPath, disallowedHtmlTags) {
+    this.Bramble = Bramble;
+    this.store = store;
+    this.url = url;
+    this.projectPath = projectPath;
+    this.disallowedHtmlTags = disallowedHtmlTags;
+    this.brambleProxy = null;
+    this.onMountableCallbacks = [];
+    this.onReadyCallbacks = [];
+    this.onProjectChangedCallbacks = [];
+    this.recentChanges = [];
+  }
+
+  init() {
+    this.Bramble.load('#bramble', this.config());
+
+    this.Bramble.on('readyStateChange', (_, newState) => {
+      this.Bramble.MOUNTABLE === newState &&
+        this.invokeAll(this.onMountableCallbacks);
+    });
+
+    this.Bramble.once('ready', brambleProxy => {
+      this.brambleProxy = brambleProxy;
+      this.configureProxy();
+      this.invokeAll(this.onReadyCallbacks);
+    });
+  }
+
+  on(event, callback) {
+    switch (event) {
+      case 'mountable':
+        this.onMountableCallbacks.push(callback);
+        break;
+      case 'ready':
+        this.onReadyCallbacks.push(callback);
+        break;
+      case 'projectChange':
+        this.onProjectChangedCallbacks.push(callback);
+        break;
+      default:
+        console.error(`CdoBramble unknown event type '${event}'`);
+    }
+
+    return this;
+  }
+
+  config() {
+    const {
+      maxProjectCapacity,
+      pageConstants
+    } = this.store.getStore().getState();
+
+    return {
+      url: this.url,
+      useLocationSearch: true,
+      disableUIState: true,
+      capacity: maxProjectCapacity,
+      initialUIState: {
+        theme: 'light-theme',
+        readOnly: pageConstants.isReadOnlyWorkspace
+      },
+      extensions: {
+        disable: ['bramble-move-file']
+      }
+    };
+  }
+
+  configureProxy() {
+    const proxy = this.brambleProxy;
+
+    proxy.disableJavaScript(); // Prevents JS from executing.
+    proxy.on('inspectorChange', this.onInspectorChanged.bind(this));
+    proxy.on('fileChange', this.onFileChanged.bind(this));
+    proxy.on('fileDelete', this.onFileDeleted.bind(this));
+    proxy.on('fileRename', this.onFileRenamed.bind(this));
+    proxy.on('projectSizeChange', this.onProjectSizeChanged.bind(this));
+  }
+
+  onInspectorChanged({enabled}) {
+    const {getStore, actions} = this.store;
+    getStore().dispatch(actions.changeInspectorOn(enabled));
+  }
+
+  handleFileChange(path) {
+    var cleanedPath = this.cleanPath(path);
+    const hasExistingChangeForPath = this.recentChanges.some(
+      change => change.operation === 'change' && change.file === cleanedPath
+    );
+
+    // Only add 'change' operation if one isn't already queued for that file.
+    if (!hasExistingChangeForPath) {
+      this.recentChanges.push({
+        operation: 'change',
+        file: cleanedPath,
+        fileDataPath: cleanedPath
+      });
+    }
+
+    this.invokeAll(this.onProjectChangedCallbacks);
+  }
+
+  onFileChanged(path) {
+    removeDisallowedHtmlContent(
+      this.Bramble.getFileSystem(),
+      this.brambleProxy,
+      path,
+      this.disallowedHtmlTags,
+      this.handleFileChange.bind(this)
+    );
+  }
+
+  onFileDeleted(path) {
+    this.recentChanges.push({
+      operation: 'delete',
+      file: this.cleanPath(path)
+    });
+
+    this.invokeAll(this.onProjectChangedCallbacks);
+  }
+
+  onFileRenamed(oldPath, newPath) {
+    const cleanedOldPath = this.cleanPath(oldPath);
+    const cleanedNewPath = this.cleanPath(newPath);
+
+    // Update the fileDataPath for any pending 'change' operations (new or modified files).
+    this.recentChanges = this.recentChanges.map(change => {
+      if (
+        change.operation === 'change' &&
+        change.fileDataPath === cleanedOldPath
+      ) {
+        change = {...change, fileDataPath: cleanedNewPath};
+      }
+
+      return change;
+    });
+    this.recentChanges.push({
+      operation: 'rename',
+      file: cleanedOldPath,
+      newFile: cleanedNewPath
+    });
+
+    this.invokeAll(this.onProjectChangedCallbacks);
+  }
+
+  onProjectSizeChanged(bytes, _) {
+    const {getStore, actions} = this.store;
+    getStore().dispatch(actions.changeProjectSize(bytes));
+  }
+
+  cleanPath(path) {
+    return path.replace(this.projectPath, '');
+  }
+
+  invokeAll(callbacks) {
+    callbacks.forEach(callback => callback());
+  }
+}

--- a/apps/src/weblab/WebLab.js
+++ b/apps/src/weblab/WebLab.js
@@ -615,4 +615,12 @@ WebLab.prototype.PageAction = makeEnum(
   logToCloud.PageAction.BrambleFilesystemResetFailed
 );
 
+WebLab.prototype.redux = function() {
+  return {
+    getStore,
+    reducers,
+    actions
+  };
+};
+
 export default WebLab;

--- a/apps/test/unit/weblab/CdoBrambleTest.js
+++ b/apps/test/unit/weblab/CdoBrambleTest.js
@@ -1,0 +1,124 @@
+import sinon from 'sinon';
+import {expect} from '../../util/reconfiguredChai';
+import CdoBramble from '@cdo/apps/weblab/CdoBramble';
+
+describe('CdoBramble', () => {
+  const brambleUrl = 'https://bramble.org/index.html';
+  const projectPath = '/project/123/';
+  let cdoBramble, storeState;
+
+  beforeEach(() => {
+    storeState = {
+      maxProjectCapacity: 1000,
+      pageConstants: {isReadOnlyWorkspace: false}
+    };
+    const mockStore = {
+      getStore: () => ({
+        getState: () => storeState
+      })
+    };
+
+    cdoBramble = new CdoBramble({}, mockStore, brambleUrl, projectPath, []);
+  });
+
+  describe('config', () => {
+    it('sets dynamic values from state', () => {
+      const actualConfig = cdoBramble.config();
+      expect(actualConfig.url).to.equal(brambleUrl);
+      expect(actualConfig.capacity).to.equal(storeState.maxProjectCapacity);
+      expect(actualConfig.initialUIState.readOnly).to.equal(
+        storeState.pageConstants.isReadOnlyWorkspace
+      );
+    });
+  });
+
+  describe('handleFileChange', () => {
+    const filename = 'index.html';
+    let fileChange;
+
+    beforeEach(() => {
+      fileChange = {
+        operation: 'change',
+        file: filename,
+        fileDataPath: filename
+      };
+    });
+
+    it('adds a change operation for the file', () => {
+      expect(cdoBramble.recentChanges.length).to.equal(0);
+      cdoBramble.handleFileChange(projectPath + filename);
+      expect(cdoBramble.recentChanges).to.deep.equal([fileChange]);
+    });
+
+    it('does not add a change operation if one already exists for the file', () => {
+      cdoBramble.recentChanges = [{...fileChange}];
+      cdoBramble.handleFileChange(projectPath + filename);
+      expect(cdoBramble.recentChanges).to.deep.equal([fileChange]);
+    });
+
+    it('invokes onProjectChangedCallbacks', () => {
+      const callbackSpy1 = sinon.stub();
+      const callbackSpy2 = sinon.stub();
+      cdoBramble.onProjectChangedCallbacks = [callbackSpy1, callbackSpy2];
+      cdoBramble.handleFileChange('index.html');
+      expect(callbackSpy1).to.have.been.calledOnce;
+      expect(callbackSpy2).to.have.been.calledOnce;
+    });
+  });
+
+  describe('onFileDeleted', () => {
+    it('adds a delete operation for the file', () => {
+      expect(cdoBramble.recentChanges.length).to.equal(0);
+      cdoBramble.onFileDeleted(projectPath + 'index.html');
+      expect(cdoBramble.recentChanges).to.deep.equal([
+        {operation: 'delete', file: 'index.html'}
+      ]);
+    });
+
+    it('invokes onProjectChangedCallbacks', () => {
+      const callbackSpy1 = sinon.stub();
+      const callbackSpy2 = sinon.stub();
+      cdoBramble.onProjectChangedCallbacks = [callbackSpy1, callbackSpy2];
+      cdoBramble.onFileDeleted('index.html');
+      expect(callbackSpy1).to.have.been.calledOnce;
+      expect(callbackSpy2).to.have.been.calledOnce;
+    });
+  });
+
+  describe('onFileRenamed', () => {
+    const oldPath = 'old.html';
+    const newPath = 'new.html';
+
+    it('updates fileDataPath for recent change if one exists', () => {
+      cdoBramble.recentChanges = [
+        {operation: 'change', fileDataPath: 'other.html'},
+        {operation: 'change', fileDataPath: oldPath},
+        {operation: 'delete', fileDataPath: 'style.css'}
+      ];
+      cdoBramble.onFileRenamed(oldPath, newPath);
+      expect(cdoBramble.recentChanges).to.deep.equal([
+        {operation: 'change', fileDataPath: 'other.html'},
+        {operation: 'change', fileDataPath: newPath},
+        {operation: 'delete', fileDataPath: 'style.css'},
+        {operation: 'rename', file: oldPath, newFile: newPath}
+      ]);
+    });
+
+    it('adds a rename operation for the file', () => {
+      expect(cdoBramble.recentChanges.length).to.equal(0);
+      cdoBramble.onFileRenamed(oldPath, newPath);
+      expect(cdoBramble.recentChanges).to.deep.equal([
+        {operation: 'rename', file: oldPath, newFile: newPath}
+      ]);
+    });
+
+    it('invokes onProjectChangedCallbacks', () => {
+      const callbackSpy1 = sinon.stub();
+      const callbackSpy2 = sinon.stub();
+      cdoBramble.onProjectChangedCallbacks = [callbackSpy1, callbackSpy2];
+      cdoBramble.onFileRenamed(oldPath, newPath);
+      expect(callbackSpy1).to.have.been.calledOnce;
+      expect(callbackSpy2).to.have.been.calledOnce;
+    });
+  });
+});


### PR DESCRIPTION
First PR for moving code out of brambleHost.js to organize and make it unit testable. This PR covers the `load` function (click the preview link to see all lines more easily):
https://github.com/code-dot-org/code-dot-org/blob/14945e95e06241349861214e9b8cca48be1015e0/apps/src/weblab/brambleHost.js#L600-L725

This functionality has not been changed -- any changes should be for organization/clarity only.

The ultimate goal is for all functionality to live in WebLab and CdoBramble, and brambleHost will just instantiate and configure CdoBramble. Current usage in brambleHost would look like this:

```javascript
const cdoBramble = new CdoBramble(
    Bramble,
    webLab_.redux(),
    BRAMBLE_BASE_URL + '/index.html',
    projectPath,
    webLab_.disallowedHtmlTags
);
cdoBramble
    .on('mountable', onBrambleMountableCallback_)
    .on('ready', onBrambleReadyCallback_)
    .on('projectChange', onProjectChangedCallback_)
    .init();
```

## Links

- [STAR-1447](https://codedotorg.atlassian.net/browse/STAR-1447)

## Testing story

Adds unit tests.

## Follow-up work

As part of this same ticket, I will:
- Move all functionality from brambleHost.js to CdoBramble.js with unit tests
- Refactor brambleHost.js to instantiate CdoBramble and connect it to WebLab
- Add comments/documentation to CdoBramble (it'll be easier to do all at once at the end of this process)