### PR TITLE
Add ability to generate a PDF from raw HTML

### DIFF
--- a/bin/generate-pdf/generatePdf.js
+++ b/bin/generate-pdf/generatePdf.js
@@ -6,19 +6,31 @@ const puppeteer = require("puppeteer");
       alias: "u",
       describe: "URL to generate PDF from"
     })
+    .option("html", {
+      alias: "h",
+      describe: "raw HTML to generate PDF from"
+    })
     .option("outputPath", {
       alias: "o",
       describe: "path where generated PDF file should be created"
     })
-    .demandOption(
-      ["url", "outputPath"],
-      "Please provide required url and outputPath arguments"
+    .conflicts("url", "html")
+    .demandOption("outputPath", "Please provide outputPath argument")
+    .epilogue(
+      "Make sure to specify either HTML or URL as source; otherwise, you'll get a blank page."
     )
     .help().argv;
 
   const browser = await puppeteer.launch();
   const page = await browser.newPage();
-  await page.goto(argv.url, { waitUntil: "networkidle2" });
+  const pageOptions = { waitUntil: "networkidle2" };
+
+  if (argv.url) {
+    await page.goto(argv.url, pageOptions);
+  } else if (argv.html) {
+    await page.setContent(argv.html, pageOptions);
+  }
+
   await page.pdf({
     path: argv.outputPath,
     format: "Letter",


### PR DESCRIPTION
Example:

    node bin/generate-pdf -h "<h1>Hello</h1>" -o /tmp/foo.pdf

Result: [foo.pdf](https://github.com/code-dot-org/code-dot-org/files/6193050/foo.pdf)

Will be used by resource rollup PDFs (and probably by other PDFs in the new lesson plan space) to provide title pages. See https://curriculum.code.org/csd-20/unit2_resources.pdf for an example

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
