### PR TITLE
Make table styling only apply to text area of activity section and not progression

### DIFF
--- a/apps/src/templates/lessonOverview/activities/ActivitySection.jsx
+++ b/apps/src/templates/lessonOverview/activities/ActivitySection.jsx
@@ -57,7 +57,7 @@ export default class ActivitySection extends Component {
             </span>
           )}
         </h3>
-        <div>
+        <div className="activity-section-text">
           <div
             style={{
               ...styles.textAndProgression

--- a/apps/style/lessons.scss
+++ b/apps/style/lessons.scss
@@ -7,31 +7,34 @@
   }
 }
 
-table {
-  thead {
-    th {
-      border: 1px solid $light_gray;
+// We only want to apply table styling to the text areas or it will apply on the progression details
+.activity-section-text {
+  table {
+    thead {
+      th {
+        border: 1px solid $light_gray;
+      }
     }
-  }
-  tbody {
-    /**
-     * A pattern our curriculum authors often use is to include tables of
-     * slides, where in each row there's a cell with a screenshot of the slide
-     * and a cell with the description.
-     *
-     * Previously, they had been manually styling each screenshot with a
-     * border. To replicate this functionality, we say that every image which
-     * is an "only child" (ie, every image that's in a cell all by itself)
-     * should have a border. If at some point in the future this ends up
-     * styling images we _don't_ want to be styled, we could find a more
-     * precise way to implement this.
-     */
-    img:only-child {
-      border: 1px solid $black;
-    }
-    td {
-      padding: 10px;
-      border: 1px solid $light_gray;
+    tbody {
+      /**
+       * A pattern our curriculum authors often use is to include tables of
+       * slides, where in each row there's a cell with a screenshot of the slide
+       * and a cell with the description.
+       *
+       * Previously, they had been manually styling each screenshot with a
+       * border. To replicate this functionality, we say that every image which
+       * is an "only child" (ie, every image that's in a cell all by itself)
+       * should have a border. If at some point in the future this ends up
+       * styling images we _don't_ want to be styled, we could find a more
+       * precise way to implement this.
+       */
+      img:only-child {
+        border: 1px solid $black;
+      }
+      td {
+        padding: 10px;
+        border: 1px solid $light_gray;
+      }
     }
   }
 }


### PR DESCRIPTION
We got a report that the new table styles on lesson plans was showing on the progression details. See [thread](https://codedotorg.slack.com/archives/CNZP84FJ5/p1616541434068900).  This makes the styling of tables only apply to the text area of the activity section and not the progression. 

<img width="1002" alt="Screen Shot 2021-03-23 at 9 42 59 PM" src="https://user-images.githubusercontent.com/208083/112241509-bea10d80-8c20-11eb-81cb-be48529b764d.png">