### PR TITLE
Update PDF pathnames

### DIFF
--- a/dashboard/lib/services/lesson_plan_pdfs.rb
+++ b/dashboard/lib/services/lesson_plan_pdfs.rb
@@ -128,18 +128,15 @@ module Services
     # lesson's script but also the current version of the script in the environment.
     #
     # Expect this to look something like this for teacher lesson plans
-    # <Pathname:csp1-2021/20210216001309/Welcome to CSP.pdf>
+    # <Pathname:csp1-2021/20210216001309/teacher-lesson-plans/Welcome to CSP.pdf>
     # and this for student lesson plans
-    # <Pathname:csp1-2021/20210216001309/student/Welcome to CSP.pdf>
+    # <Pathname:csp1-2021/20210216001309/student-lesson-plans/Welcome to CSP.pdf>
     def self.get_pathname(lesson, student_facing = false)
       return nil unless lesson&.script&.seeded_from
       version_number = Time.parse(lesson.script.seeded_from).to_s(:number)
       filename = ActiveStorage::Filename.new(lesson.key + ".pdf").sanitized
-      if student_facing
-        return Pathname.new(File.join(lesson.script.name, version_number, 'student', filename))
-      else
-        return Pathname.new(File.join(lesson.script.name, version_number, filename))
-      end
+      subdir = student_facing ? "student-lesson-plans" : "teacher-lesson-plans"
+      return Pathname.new(File.join(lesson.script.name, version_number, subdir, filename))
     end
 
     def self.get_url(lesson, student_facing=false)

--- a/dashboard/lib/tasks/lesson_plan_pdfs.rake
+++ b/dashboard/lib/tasks/lesson_plan_pdfs.rake
@@ -7,7 +7,8 @@ namespace :lesson_plan_pdfs do
 
   def get_pdfless_lessons(script)
     script.lessons.select(&:has_lesson_plan).select do |lesson|
-      !Services::LessonPlanPdfs.pdf_exists_for?(lesson)
+      !Services::LessonPlanPdfs.pdf_exists_for?(lesson) ||
+        !Services::LessonPlanPdfs.pdf_exists_for?(lesson, true)
     end
   end
 
@@ -36,6 +37,7 @@ namespace :lesson_plan_pdfs do
         get_pdfless_lessons(script).each do |lesson|
           puts "Generating missing PDF for #{lesson.key} (from #{script.name})"
           Services::LessonPlanPdfs.generate_lesson_pdf(lesson, dir)
+          Services::LessonPlanPdfs.generate_lesson_pdf(lesson, dir, true)
           any_pdf_generated = true
         end
       end
@@ -60,6 +62,7 @@ namespace :lesson_plan_pdfs do
       get_pdf_enabled_scripts.each do |script|
         script.lessons.select(&:has_lesson_plan).each do |lesson|
           Services::LessonPlanPdfs.generate_lesson_pdf(lesson, dir)
+          Services::LessonPlanPdfs.generate_lesson_pdf(lesson, dir, true)
         end
       end
       Services::LessonPlanPdfs.upload_generated_pdfs_to_s3(dir)

--- a/dashboard/test/lib/services/lesson_plan_pdfs_test.rb
+++ b/dashboard/test/lib/services/lesson_plan_pdfs_test.rb
@@ -95,6 +95,15 @@ class Services::LessonPlanPdfsTest < ActiveSupport::TestCase
     refute_equal original_pathname, new_pathname
   end
 
+  test 'pathnames are differentiated by audience' do
+    script = create(:script, name: "test-pathnames-script", seeded_from: Time.at(0))
+    lesson = create(:lesson, script: script, key: "test-pathnames-lesson")
+    assert_equal Pathname.new("test-pathnames-script/19691231160000/teacher-lesson-plans/test-pathnames-lesson.pdf"),
+      Services::LessonPlanPdfs.get_pathname(lesson)
+    assert_equal Pathname.new("test-pathnames-script/19691231160000/student-lesson-plans/test-pathnames-lesson.pdf"),
+      Services::LessonPlanPdfs.get_pathname(lesson, student_facing=true)
+  end
+
   test 'Lesson PDFs are generated into the given directory' do
     script = create(:script, seeded_from: Time.now)
     lesson = create(:lesson, script: script)

--- a/dashboard/test/lib/services/lesson_plan_pdfs_test.rb
+++ b/dashboard/test/lib/services/lesson_plan_pdfs_test.rb
@@ -98,9 +98,9 @@ class Services::LessonPlanPdfsTest < ActiveSupport::TestCase
   test 'pathnames are differentiated by audience' do
     script = create(:script, name: "test-pathnames-script", seeded_from: Time.at(0))
     lesson = create(:lesson, script: script, key: "test-pathnames-lesson")
-    assert_equal Pathname.new("test-pathnames-script/19691231160000/teacher-lesson-plans/test-pathnames-lesson.pdf"),
+    assert_equal Pathname.new("test-pathnames-script/19700101000000/teacher-lesson-plans/test-pathnames-lesson.pdf"),
       Services::LessonPlanPdfs.get_pathname(lesson)
-    assert_equal Pathname.new("test-pathnames-script/19691231160000/student-lesson-plans/test-pathnames-lesson.pdf"),
+    assert_equal Pathname.new("test-pathnames-script/19700101000000/student-lesson-plans/test-pathnames-lesson.pdf"),
       Services::LessonPlanPdfs.get_pathname(lesson, true)
   end
 

--- a/dashboard/test/lib/services/lesson_plan_pdfs_test.rb
+++ b/dashboard/test/lib/services/lesson_plan_pdfs_test.rb
@@ -101,7 +101,7 @@ class Services::LessonPlanPdfsTest < ActiveSupport::TestCase
     assert_equal Pathname.new("test-pathnames-script/19691231160000/teacher-lesson-plans/test-pathnames-lesson.pdf"),
       Services::LessonPlanPdfs.get_pathname(lesson)
     assert_equal Pathname.new("test-pathnames-script/19691231160000/student-lesson-plans/test-pathnames-lesson.pdf"),
-      Services::LessonPlanPdfs.get_pathname(lesson, student_facing=true)
+      Services::LessonPlanPdfs.get_pathname(lesson, true)
   end
 
   test 'Lesson PDFs are generated into the given directory' do

--- a/dashboard/test/models/lesson_test.rb
+++ b/dashboard/test/models/lesson_test.rb
@@ -803,7 +803,7 @@ class LessonTest < ActiveSupport::TestCase
     script.seeded_from = Time.now.to_s
     assert_equal(
       new_lesson.lesson_plan_pdf_url,
-      "https://lesson-plans.code.org/#{script.name}/#{Time.parse(script.seeded_from).to_s(:number)}/Some Verbose Lesson Name.pdf"
+      "https://lesson-plans.code.org/#{script.name}/#{Time.parse(script.seeded_from).to_s(:number)}/teacher-lesson-plans/Some Verbose Lesson Name.pdf"
     )
   end
 
@@ -815,7 +815,7 @@ class LessonTest < ActiveSupport::TestCase
     script.seeded_from = Time.now.to_s
     assert_equal(
       new_lesson.student_lesson_plan_pdf_url,
-      "https://lesson-plans.code.org/#{script.name}/#{Time.parse(script.seeded_from).to_s(:number)}/student/Some Verbose Lesson Name.pdf"
+      "https://lesson-plans.code.org/#{script.name}/#{Time.parse(script.seeded_from).to_s(:number)}/student-lesson-plans/Some Verbose Lesson Name.pdf"
     )
   end
 


### PR DESCRIPTION
In preparation for adding several more types of PDFs, we move teacher lesson plans to their own subdirectory and update the name of the student lesson plans subdirectory to match.

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
