### PR TITLE
adding validation for zip codes not to be over 5 digits

### DIFF
--- a/dashboard/app/models/school_info.rb
+++ b/dashboard/app/models/school_info.rb
@@ -151,7 +151,7 @@ class SchoolInfo < ApplicationRecord
 
   def validate_zip
     if zip
-      errors.add(:zip, 'Invalid zip code') unless zip > 0 && zip < 99999
+      errors.add(:zip, 'Invalid zip code') unless zip > 0 && zip < 100_000
     end
   end
 

--- a/dashboard/app/models/school_info.rb
+++ b/dashboard/app/models/school_info.rb
@@ -151,7 +151,7 @@ class SchoolInfo < ApplicationRecord
 
   def validate_zip
     if zip
-      errors.add(:zip, 'Invalid zip code') unless zip > 0
+      errors.add(:zip, 'Invalid zip code') unless zip > 0 && zip < 99999
     end
   end
 

--- a/dashboard/test/models/school_info_test.rb
+++ b/dashboard/test/models/school_info_test.rb
@@ -347,6 +347,18 @@ class SchoolInfoTest < ActiveSupport::TestCase
     assert_equal 'Zip Invalid zip code', school_info.errors.full_messages.first
   end
 
+  test 'US charter with over 5 digit zip code fails' do
+    school_info = build :school_info_us_charter, :with_district, school_other: true, zip: 136_177_321_812, school_name: "Another School"
+    refute school_info.valid?
+    assert_equal 'Zip Invalid zip code', school_info.errors.full_messages.first
+  end
+
+  test 'US charter with negative zip code fails' do
+    school_info = build :school_info_us_charter, :with_district, school_other: true, zip: -98144, school_name: "Another School"
+    refute school_info.valid?
+    assert_equal 'Zip Invalid zip code', school_info.errors.full_messages.first
+  end
+
   # deprecated data formats (without country). The absence of the country column is the marker that
   # the record does NOT conform to the newer data format. These older records may belong to a Pd::Enrollment,
   # in which case the school name should be stored in enrollment.school, NOT in enrollment.school_info.school_name.


### PR DESCRIPTION
<!--
  A summary of the change, including any relevant background, motivation, and context.
  If relevant, include a description, screenshots, and/or video of the existing and new behavior.
-->
Adding zip code validation to make sure they don't exceed 5 digits and trigger Honeybadger errors (e.g. https://app.honeybadger.io/projects/3240/faults/40884376). Added 2 unit tests as well.
## Links

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

<!--
- spec: []()
- jira ticket: [link](https://codedotorg.atlassian.net/secure/RapidBoard.jspa?rapidView=28&modal=detail&selectedIssue=FND-1397)
-->

## Testing story
Added 2 unit tests to ensure we don't accept negative values or integers over 99999 as zip codes
<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
