### PR TITLE
Investigate chromebook

### DIFF
--- a/apps/src/lib/kits/maker/boards/circuitPlayground/CircuitPlaygroundBoard.js
+++ b/apps/src/lib/kits/maker/boards/circuitPlayground/CircuitPlaygroundBoard.js
@@ -20,10 +20,9 @@ import {
   J5_CONSTANTS
 } from './PlaygroundConstants';
 import Led from './Led';
-import {isNodeSerialAvailable} from '../../portScanning';
 import PlaygroundButton from './Button';
 import {detectBoardTypeFromPort, BOARD_TYPE} from '../../util/boardUtils';
-import {serialPortType} from '../../util/browserChecks';
+import {isChromeOS, serialPortType} from '../../util/browserChecks';
 
 // Polyfill node's process.hrtime for the browser, gets used by johnny-five.
 process.hrtime = require('browser-process-hrtime');
@@ -353,7 +352,7 @@ export default class CircuitPlaygroundBoard extends EventEmitter {
       baudRate: SERIAL_BAUD
     });
 
-    if (isNodeSerialAvailable()) {
+    if (!isChromeOS()) {
       port.queue = [];
       let sendPending = false;
       const oldWrite = port.write;

--- a/apps/src/lib/kits/maker/boards/microBit/MBFirmataWrapper.js
+++ b/apps/src/lib/kits/maker/boards/microBit/MBFirmataWrapper.js
@@ -1,6 +1,6 @@
 import MBFirmataClient from '../../../../../third-party/maker/MBFirmataClient';
 import {SAMPLE_INTERVAL} from './MicroBitConstants';
-import {isNodeSerialAvailable} from '../../portScanning';
+import {isChromeOS} from '@cdo/apps/lib/kits/maker/util/browserChecks';
 
 export const ACCEL_EVENT_ID = 27;
 
@@ -29,7 +29,7 @@ export default class MicrobitFirmataWrapper extends MBFirmataClient {
   }
 
   setSerialPort(port) {
-    if (isNodeSerialAvailable()) {
+    if (!isChromeOS()) {
       return super.setSerialPort(port);
     } else {
       // Use the given port. Assume the port has been opened by the caller.

--- a/apps/src/lib/kits/maker/boards/microBit/MicroBitBoard.js
+++ b/apps/src/lib/kits/maker/boards/microBit/MicroBitBoard.js
@@ -10,8 +10,7 @@ import MBFirmataWrapper from './MBFirmataWrapper';
 import ExternalLed from './ExternalLed';
 import ExternalButton from './ExternalButton';
 import CapacitiveTouchSensor from './CapacitiveTouchSensor';
-import {serialPortType} from '../../util/browserChecks';
-import {isNodeSerialAvailable} from '../../portScanning';
+import {isChromeOS, serialPortType} from '../../util/browserChecks';
 
 /**
  * Controller interface for BBC micro:bit board using
@@ -28,7 +27,7 @@ export default class MicroBitBoard extends EventEmitter {
     /** @private {Object} Map of component controllers */
     this.prewiredComponents_ = null;
 
-    this.nodeSerialAvailable = isNodeSerialAvailable();
+    this.chromeOS = isChromeOS();
 
     let portType = serialPortType(true);
 
@@ -63,7 +62,7 @@ export default class MicroBitBoard extends EventEmitter {
     const SERIAL_BAUD = 57600;
 
     let serialPort;
-    if (this.nodeSerialAvailable) {
+    if (!this.chromeOS) {
       serialPort = new SerialPortType(portName, {baudRate: SERIAL_BAUD});
       return Promise.resolve(serialPort);
     } else {

--- a/apps/src/lib/kits/maker/portScanning.js
+++ b/apps/src/lib/kits/maker/portScanning.js
@@ -79,6 +79,8 @@ function listSerialDevices() {
     return SerialPortType.list();
   } else {
     SerialPortType = ChromeSerialPort;
+    console.log(ChromeSerialPort);
+    console.log(SerialPortType);
     return new Promise((resolve, reject) => {
       SerialPortType.list((error, list) =>
         error ? reject(error) : resolve(list)

--- a/apps/src/lib/kits/maker/portScanning.js
+++ b/apps/src/lib/kits/maker/portScanning.js
@@ -3,6 +3,7 @@
 import ChromeSerialPort from 'chrome-serialport';
 import {ConnectionFailedError} from './MakerError';
 import applabI18n from '@cdo/applab/locale';
+import {isChromeOS} from '@cdo/apps/lib/kits/maker/util/browserChecks';
 
 /**
  * @typedef {Object} SerialPortInfo
@@ -58,7 +59,7 @@ export function findPortWithViableDevice() {
  * @returns {Promise} Resolves if installed, rejects if not.
  */
 export function ensureAppInstalled() {
-  if (isNodeSerialAvailable()) {
+  if (!isChromeOS()) {
     return Promise.resolve();
   }
 
@@ -74,7 +75,7 @@ export function ensureAppInstalled() {
  */
 function listSerialDevices() {
   let SerialPortType;
-  if (isNodeSerialAvailable()) {
+  if (!isChromeOS()) {
     SerialPortType = SerialPort;
     return SerialPortType.list();
   } else {
@@ -87,14 +88,6 @@ function listSerialDevices() {
       );
     });
   }
-}
-
-/**
- * @returns {boolean} Whether node SerialPort is available on window, where it
- * is provided if we're using the Code.org Browser.
- */
-export function isNodeSerialAvailable() {
-  return typeof SerialPort === 'function';
 }
 
 /**

--- a/apps/src/lib/kits/maker/util/browserChecks.js
+++ b/apps/src/lib/kits/maker/util/browserChecks.js
@@ -1,6 +1,5 @@
 /** @file Some misc. browser check methods for maker */
 /* global SerialPort */ // Maybe provided by the Code.org Browser
-import {isNodeSerialAvailable} from '../portScanning';
 import ChromeSerialPort from 'chrome-serialport';
 
 export function gtChrome33() {
@@ -50,7 +49,7 @@ export function isLinux() {
     Parameter determines whether to return the factory of the SerialPort
  */
 export function serialPortType(getFactory = null) {
-  if (isNodeSerialAvailable()) {
+  if (!isChromeOS()) {
     return SerialPort;
   } else {
     if (getFactory) {


### PR DESCRIPTION
Chrome 89 Release turned on the WebSerial interface under "SerialPort". We had previously been using the presence or absence of serialPort to determine whether we were using the Chrome App or the Maker App. Since SerialPort is now available in both, the code was executing as if we were always in the Maker App and not in the Chrome App. I have replaced the logic of "isNodeSerialAvailable" with "!isChromeOS". If we are in ChromeOS, we want to behave as if nodeSerial is not available. If we are not in ChromeOS, we are either in Maker App (node serial is available) or a regular browser (doesn't work anyways).

Note: Console.logs are left in while testing on Jessie's machine and should be removed before merging.

Additional context on the outcome of this PR: https://github.com/code-dot-org/code-dot-org/pull/39703

## Links

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

<!--
- spec: []()
- jira ticket: []()
-->

## Testing story
Tested on Chromebook and MakerApp via Jessie's EC2 instance.

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
