### PR TITLE
Put tips after the progression details

### DIFF
--- a/apps/src/templates/lessonOverview/activities/ActivitySection.jsx
+++ b/apps/src/templates/lessonOverview/activities/ActivitySection.jsx
@@ -34,6 +34,9 @@ const styles = {
     display: 'flex',
     flexDirection: 'column',
     width: '100%' // If there are tips for the activity section this is updated below
+  },
+  progression: {
+    marginBottom: 5
   }
 };
 
@@ -83,15 +86,17 @@ export default class ActivitySection extends Component {
               <EnhancedSafeMarkdown markdown={section.text} expandableImages />
             </div>
           </div>
-          <div>
-            {section.tips.map((tip, index) => {
-              return <LessonTip key={`tip-${index}`} tip={tip} />;
-            })}
-          </div>
         </div>
         {section.scriptLevels.length > 0 && (
-          <ProgressionDetails section={section} />
+          <div style={styles.progression}>
+            <ProgressionDetails section={section} />
+          </div>
         )}
+        <div className="activity-section-text">
+          {section.tips.map((tip, index) => {
+            return <LessonTip key={`tip-${index}`} tip={tip} />;
+          })}
+        </div>
       </div>
     );
   }

--- a/apps/src/templates/lessonOverview/activities/ProgressionDetails.jsx
+++ b/apps/src/templates/lessonOverview/activities/ProgressionDetails.jsx
@@ -10,7 +10,6 @@ const styles = {
     borderStyle: 'solid',
     borderColor: color.lighter_gray,
     margin: '10px, 0px',
-    width: '95%',
     backgroundColor: color.lightest_gray,
     padding: '0px 10px 10px 10px'
   },


### PR DESCRIPTION
https://codedotorg.atlassian.net/browse/PLAT-879

Tips and Progressions that were in the same activity section were showing in the wrong order (Tips above progression). This moved tips below the progressions. 

<img width="1002" alt="Screen Shot 2021-03-24 at 9 21 52 PM" src="https://user-images.githubusercontent.com/208083/112404602-05f1d180-8ce7-11eb-8bab-d27d51442619.png">
