### PR TITLE
Chromebook Version 89 Serial Port Fix

### DIFF
--- a/apps/src/lib/kits/maker/boards/circuitPlayground/CircuitPlaygroundBoard.js
+++ b/apps/src/lib/kits/maker/boards/circuitPlayground/CircuitPlaygroundBoard.js
@@ -20,10 +20,9 @@ import {
   J5_CONSTANTS
 } from './PlaygroundConstants';
 import Led from './Led';
-import {isNodeSerialAvailable} from '../../portScanning';
 import PlaygroundButton from './Button';
 import {detectBoardTypeFromPort, BOARD_TYPE} from '../../util/boardUtils';
-import {serialPortType} from '../../util/browserChecks';
+import {isChromeOS, serialPortType} from '../../util/browserChecks';
 
 // Polyfill node's process.hrtime for the browser, gets used by johnny-five.
 process.hrtime = require('browser-process-hrtime');
@@ -353,7 +352,7 @@ export default class CircuitPlaygroundBoard extends EventEmitter {
       baudRate: SERIAL_BAUD
     });
 
-    if (isNodeSerialAvailable()) {
+    if (!isChromeOS()) {
       port.queue = [];
       let sendPending = false;
       const oldWrite = port.write;

--- a/apps/src/lib/kits/maker/boards/microBit/MBFirmataWrapper.js
+++ b/apps/src/lib/kits/maker/boards/microBit/MBFirmataWrapper.js
@@ -1,6 +1,6 @@
 import MBFirmataClient from '../../../../../third-party/maker/MBFirmataClient';
 import {SAMPLE_INTERVAL} from './MicroBitConstants';
-import {isNodeSerialAvailable} from '../../portScanning';
+import {isChromeOS} from '@cdo/apps/lib/kits/maker/util/browserChecks';
 
 export const ACCEL_EVENT_ID = 27;
 
@@ -29,7 +29,7 @@ export default class MicrobitFirmataWrapper extends MBFirmataClient {
   }
 
   setSerialPort(port) {
-    if (isNodeSerialAvailable()) {
+    if (!isChromeOS()) {
       return super.setSerialPort(port);
     } else {
       // Use the given port. Assume the port has been opened by the caller.

--- a/apps/src/lib/kits/maker/boards/microBit/MicroBitBoard.js
+++ b/apps/src/lib/kits/maker/boards/microBit/MicroBitBoard.js
@@ -10,8 +10,7 @@ import MBFirmataWrapper from './MBFirmataWrapper';
 import ExternalLed from './ExternalLed';
 import ExternalButton from './ExternalButton';
 import CapacitiveTouchSensor from './CapacitiveTouchSensor';
-import {serialPortType} from '../../util/browserChecks';
-import {isNodeSerialAvailable} from '../../portScanning';
+import {isChromeOS, serialPortType} from '../../util/browserChecks';
 
 /**
  * Controller interface for BBC micro:bit board using
@@ -28,7 +27,7 @@ export default class MicroBitBoard extends EventEmitter {
     /** @private {Object} Map of component controllers */
     this.prewiredComponents_ = null;
 
-    this.nodeSerialAvailable = isNodeSerialAvailable();
+    this.chromeOS = isChromeOS();
 
     let portType = serialPortType(true);
 
@@ -63,7 +62,7 @@ export default class MicroBitBoard extends EventEmitter {
     const SERIAL_BAUD = 57600;
 
     let serialPort;
-    if (this.nodeSerialAvailable) {
+    if (!this.chromeOS) {
       serialPort = new SerialPortType(portName, {baudRate: SERIAL_BAUD});
       return Promise.resolve(serialPort);
     } else {

--- a/apps/src/lib/kits/maker/portScanning.js
+++ b/apps/src/lib/kits/maker/portScanning.js
@@ -3,6 +3,7 @@
 import ChromeSerialPort from 'chrome-serialport';
 import {ConnectionFailedError} from './MakerError';
 import applabI18n from '@cdo/applab/locale';
+import {isChromeOS} from '@cdo/apps/lib/kits/maker/util/browserChecks';
 
 /**
  * @typedef {Object} SerialPortInfo
@@ -58,7 +59,7 @@ export function findPortWithViableDevice() {
  * @returns {Promise} Resolves if installed, rejects if not.
  */
 export function ensureAppInstalled() {
-  if (isNodeSerialAvailable()) {
+  if (!isChromeOS()) {
     return Promise.resolve();
   }
 
@@ -74,7 +75,7 @@ export function ensureAppInstalled() {
  */
 function listSerialDevices() {
   let SerialPortType;
-  if (isNodeSerialAvailable()) {
+  if (!isChromeOS()) {
     SerialPortType = SerialPort;
     return SerialPortType.list();
   } else {
@@ -85,14 +86,6 @@ function listSerialDevices() {
       );
     });
   }
-}
-
-/**
- * @returns {boolean} Whether node SerialPort is available on window, where it
- * is provided if we're using the Code.org Browser.
- */
-export function isNodeSerialAvailable() {
-  return typeof SerialPort === 'function';
 }
 
 /**

--- a/apps/src/lib/kits/maker/util/browserChecks.js
+++ b/apps/src/lib/kits/maker/util/browserChecks.js
@@ -1,6 +1,5 @@
 /** @file Some misc. browser check methods for maker */
 /* global SerialPort */ // Maybe provided by the Code.org Browser
-import {isNodeSerialAvailable} from '../portScanning';
 import ChromeSerialPort from 'chrome-serialport';
 
 export function gtChrome33() {
@@ -50,7 +49,7 @@ export function isLinux() {
     Parameter determines whether to return the factory of the SerialPort
  */
 export function serialPortType(getFactory = null) {
-  if (isNodeSerialAvailable()) {
+  if (!isChromeOS()) {
     return SerialPort;
   } else {
     if (getFactory) {

--- a/apps/test/unit/lib/kits/maker/boards/MakerBoardTest.js
+++ b/apps/test/unit/lib/kits/maker/boards/MakerBoardTest.js
@@ -20,7 +20,8 @@ import MicroBitBoard from '@cdo/apps/lib/kits/maker/boards/microBit/MicroBitBoar
  */
 export function itImplementsTheMakerBoardInterface(
   BoardClass,
-  boardSpecificSetup = null
+  boardSpecificSetup = null,
+  boardSpecificTeardown = null
 ) {
   describe('implements the MakerBoard interface', () => {
     let board;
@@ -30,6 +31,12 @@ export function itImplementsTheMakerBoardInterface(
       // Opportunity to stub any needed to test a board
       if (boardSpecificSetup) {
         boardSpecificSetup(board);
+      }
+    });
+
+    afterEach(() => {
+      if (boardSpecificTeardown) {
+        boardSpecificTeardown(board);
       }
     });
 

--- a/apps/test/unit/lib/kits/maker/boards/MakerBoardTest.js
+++ b/apps/test/unit/lib/kits/maker/boards/MakerBoardTest.js
@@ -28,7 +28,7 @@ export function itImplementsTheMakerBoardInterface(
 
     beforeEach(() => {
       board = new BoardClass();
-      // Opportunity to stub any needed to test a board
+      // Opportunity to stub anything needed to test a board
       if (boardSpecificSetup) {
         boardSpecificSetup(board);
       }

--- a/apps/test/unit/lib/kits/maker/boards/circuitPlayground/CircuitPlaygroundBoardTest.js
+++ b/apps/test/unit/lib/kits/maker/boards/circuitPlayground/CircuitPlaygroundBoardTest.js
@@ -23,7 +23,11 @@ process.hrtime = require('browser-process-hrtime');
 const xPins = ['A0', 'A1', 'A2', 'A3', 'A4', 'A5', 'A6', 'A7'];
 const classicPins = [12, 6, 9, 10, 3, 2, 0, 1];
 
-export function itMakesCircuitPlaygroundComponentsAvailable(BoardClient) {
+export function itMakesCircuitPlaygroundComponentsAvailable(
+  BoardClient,
+  boardSpecificSetup = null,
+  boardSpecificTeardown = null
+) {
   const CP_CONSTRUCTOR_COUNT = 13;
   const CP_COMPONENT_COUNT = 16;
   const CP_COMPONENTS = [
@@ -58,8 +62,18 @@ export function itMakesCircuitPlaygroundComponentsAvailable(BoardClient) {
         },
         addCustomMarshalObject: sinon.spy()
       };
+      // Opportunity to stub any needed to test a board
+      if (boardSpecificSetup) {
+        boardSpecificSetup(board);
+      }
 
       return board.connect();
+    });
+
+    afterEach(() => {
+      if (boardSpecificTeardown) {
+        boardSpecificTeardown(board);
+      }
     });
 
     describe('adds component constructors', () => {
@@ -267,7 +281,7 @@ export function itMakesCircuitPlaygroundComponentsAvailable(BoardClient) {
 }
 
 describe('CircuitPlaygroundBoard', () => {
-  let board, playground;
+  let board, playground, spy;
 
   beforeEach(() => {
     // We use real playground-io, but our test configuration swaps in mock-firmata
@@ -308,6 +322,7 @@ describe('CircuitPlaygroundBoard', () => {
     // Construct a board to test on
     board = new CircuitPlaygroundBoard();
     ChromeSerialPort.stub.setDeviceList(CIRCUIT_PLAYGROUND_PORTS);
+    circuitPlaygroundBoardSetup();
   });
 
   afterEach(() => {
@@ -316,16 +331,33 @@ describe('CircuitPlaygroundBoard', () => {
     CircuitPlaygroundBoard.makePlaygroundTransport.restore();
     EventEmitter.prototype.once.restore();
     ChromeSerialPort.stub.reset();
+    circuitPlaygroundBoardTeardown();
   });
 
+  function circuitPlaygroundBoardSetup() {
+    spy = sinon.stub(navigator, 'userAgent').value('CrOS');
+  }
+
+  function circuitPlaygroundBoardTeardown() {
+    spy.restore();
+  }
+
   // Test coverage for Maker Board Interface
-  itImplementsTheMakerBoardInterface(CircuitPlaygroundBoard);
+  itImplementsTheMakerBoardInterface(
+    CircuitPlaygroundBoard,
+    circuitPlaygroundBoardSetup,
+    circuitPlaygroundBoardTeardown
+  );
 
   /**
    * After installing on the interpreter, test that the components and
    * component constructors are available from the interpreter
    */
-  itMakesCircuitPlaygroundComponentsAvailable(CircuitPlaygroundBoard);
+  itMakesCircuitPlaygroundComponentsAvailable(
+    CircuitPlaygroundBoard,
+    circuitPlaygroundBoardSetup,
+    circuitPlaygroundBoardTeardown
+  );
 
   describe(`connect()`, () => {
     // Remove these lines when maker-captouch is on by default.

--- a/apps/test/unit/lib/kits/maker/boards/circuitPlayground/CircuitPlaygroundBoardTest.js
+++ b/apps/test/unit/lib/kits/maker/boards/circuitPlayground/CircuitPlaygroundBoardTest.js
@@ -62,7 +62,7 @@ export function itMakesCircuitPlaygroundComponentsAvailable(
         },
         addCustomMarshalObject: sinon.spy()
       };
-      // Opportunity to stub any needed to test a board
+      // Opportunity to stub anything needed to test a board
       if (boardSpecificSetup) {
         boardSpecificSetup(board);
       }
@@ -281,7 +281,7 @@ export function itMakesCircuitPlaygroundComponentsAvailable(
 }
 
 describe('CircuitPlaygroundBoard', () => {
-  let board, playground, spy;
+  let board, playground, userAgentSpy;
 
   beforeEach(() => {
     // We use real playground-io, but our test configuration swaps in mock-firmata
@@ -335,11 +335,12 @@ describe('CircuitPlaygroundBoard', () => {
   });
 
   function circuitPlaygroundBoardSetup() {
-    spy = sinon.stub(navigator, 'userAgent').value('CrOS');
+    // 'CrOS' represents ChromeOS
+    userAgentSpy = sinon.stub(navigator, 'userAgent').value('CrOS');
   }
 
   function circuitPlaygroundBoardTeardown() {
-    spy.restore();
+    userAgentSpy.restore();
   }
 
   // Test coverage for Maker Board Interface

--- a/apps/test/unit/lib/kits/maker/portScanningTest.js
+++ b/apps/test/unit/lib/kits/maker/portScanningTest.js
@@ -15,12 +15,19 @@ import {
   findPortWithViableDevice,
   getPreferredPort
 } from '@cdo/apps/lib/kits/maker/portScanning';
+import sinon from 'sinon';
 
 describe('maker/portScanning.js', function() {
+  let spy;
   describe(`findPortWithViableDevice()`, () => {
+    beforeEach(() => {
+      spy = sinon.stub(navigator, 'userAgent').value('CrOS');
+    });
+
     // Testing against StubChromeSerialPort.js
     afterEach(() => {
       ChromeSerialPort.stub.reset();
+      spy.restore();
     });
 
     it('resolves with a port if a viable device is found', () => {

--- a/apps/test/unit/lib/kits/maker/portScanningTest.js
+++ b/apps/test/unit/lib/kits/maker/portScanningTest.js
@@ -18,16 +18,17 @@ import {
 import sinon from 'sinon';
 
 describe('maker/portScanning.js', function() {
-  let spy;
+  let userAgentSpy;
   describe(`findPortWithViableDevice()`, () => {
     beforeEach(() => {
-      spy = sinon.stub(navigator, 'userAgent').value('CrOS');
+      // 'CrOS' represents ChromeOS
+      userAgentSpy = sinon.stub(navigator, 'userAgent').value('CrOS');
     });
 
     // Testing against StubChromeSerialPort.js
     afterEach(() => {
       ChromeSerialPort.stub.reset();
-      spy.restore();
+      userAgentSpy.restore();
     });
 
     it('resolves with a port if a viable device is found', () => {


### PR DESCRIPTION
Context:
SerialPort is how we connect from the browser to the USB. Since the SerialPort was not previously provided in the browser and we exposed it in the Maker App. Later in our code, we use whether or not the SerialPort is exposed as a way to determine whether we were in the Maker App or Chrome App. However, the latest version of Chrome (89) exposes WebSerial as a SerialPort on the browser. This is excellent news for our future work of deprecating the Chrome App! Unfortunately, it meant we could no longer use whether or not the SerialPort was exposed as a way to determine whether or not we were in the Chrome App (and subsequently do Chrome App specific things) or in the Maker App.

The Change:
We already have a function called isChromeOS, so I replaced the logic on isNodeSerialAvailable with !isChromeOS. I discussed this with Maddie to figure out if it was logically sound. We agreed it was - summary: if we are in ChromeOS, we want to behave as if nodeSerial is not available. If we are not in ChromeOS, we are either in Maker App (node serial is available) or a regular browser (doesn't work anyways).
After doing this, I realized that all of our tests for the CircuitPlaygroundBoard are set up to run as if they were on ChromeOS. So I had to stub tests to believe they are in ChromeOS to get the tests up and running. This means there is going to be future work when we deprecate the Chrome App, but I don't want to block this PR on that.

History of the Change:
Today happened to be a day that we couldn't spin up adhocs! After realizing that was off the plate, we explored using an EC2 from a Windows machine to run the code and test on the Chromebook. However, that ran into the same funkiness we had with trying to ngrok to the Chromebook (it doesn't seem to recognize when the Chrome App is installed?). In the end, after the DTP had gone out for they day, Dotd froze the deploy pipeline and allowed us to merge to staging to test. (https://github.com/code-dot-org/code-dot-org/pull/39686) But then it broke the tests so we reverted (https://github.com/code-dot-org/code-dot-org/pull/39690), commented out the tests, and re-merged (https://github.com/code-dot-org/code-dot-org/pull/39691). Then we realized there was one more test that needed to be commented out and decided to open a new PR to comment that out (https://github.com/code-dot-org/code-dot-org/pull/39692), instead of reverting/unreverting once more. Once we found out that works, I reverted the temp test fix (https://github.com/code-dot-org/code-dot-org/pull/39695) and the original revert chain (https://github.com/code-dot-org/code-dot-org/pull/39696). Then I ported all the changes to this branch. Whew!


## Links

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

<!--
- spec: []()
- jira ticket: []()
-->

## Testing story
Tested locally on Chromebook. Tested locally on Linux/MakerApp. Tested locally on Mac/MakerApp.

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
