### PR TITLE
Monitor dashboard transactional emails

### DIFF
--- a/dashboard/app/mailers/email_delivery_interceptor.rb
+++ b/dashboard/app/mailers/email_delivery_interceptor.rb
@@ -1,0 +1,16 @@
+require 'cdo/aws/metrics'
+
+class EmailDeliveryInterceptor
+  def self.delivering_email(message)
+    metrics = [
+      {
+        metric_name: :EmailToSend,
+        dimensions: [
+          {name: "Environment", value: CDO.rack_env}
+        ],
+        value: 1
+      }
+    ]
+    Cdo::Metrics.push 'ActionMailer', metrics
+  end
+end

--- a/dashboard/app/mailers/email_delivery_interceptor.rb
+++ b/dashboard/app/mailers/email_delivery_interceptor.rb
@@ -1,5 +1,9 @@
 require 'cdo/aws/metrics'
 
+#
+# Intercepting emails before they are handed off to the delivery agents.
+# https://guides.rubyonrails.org/action_mailer_basics.html#intercepting-and-observing-emails
+#
 class EmailDeliveryInterceptor
   def self.delivering_email(message)
     metrics = [

--- a/dashboard/app/mailers/email_delivery_observer.rb
+++ b/dashboard/app/mailers/email_delivery_observer.rb
@@ -1,0 +1,14 @@
+class EmailDeliveryObserver
+  def self.delivered_email(message)
+    metrics = [
+      {
+        metric_name: :EmailSent,
+        dimensions: [
+          {name: "Environment", value: CDO.rack_env}
+        ],
+        value: 1
+      }
+    ]
+    Cdo::Metrics.push 'ActionMailer', metrics
+  end
+end

--- a/dashboard/app/mailers/email_delivery_observer.rb
+++ b/dashboard/app/mailers/email_delivery_observer.rb
@@ -1,3 +1,9 @@
+require 'cdo/aws/metrics'
+
+#
+# Observing emails after they have been sent.
+# https://guides.rubyonrails.org/action_mailer_basics.html#intercepting-and-observing-emails
+#
 class EmailDeliveryObserver
   def self.delivered_email(message)
     metrics = [

--- a/dashboard/config/initializers/email_delivery_watchers.rb
+++ b/dashboard/config/initializers/email_delivery_watchers.rb
@@ -1,0 +1,7 @@
+require 'email_delivery_interceptor'
+require 'email_delivery_observer'
+
+if Rails.env.production?
+  ActionMailer::Base.register_interceptor EmailDeliveryInterceptor
+  ActionMailer::Base.register_observer EmailDeliveryObserver
+end

--- a/dashboard/test/mailers/email_delivery_interceptor_test.rb
+++ b/dashboard/test/mailers/email_delivery_interceptor_test.rb
@@ -18,6 +18,16 @@ class EmailDeliveryInterceptorTest < ActiveSupport::TestCase
     ]
     Cdo::Metrics.expects(:push).with('ActionMailer', expected_metric)
 
+    # Ignores other ActionMailer metrics.
+    #
+    # We use EmailDeliveryInterceptor and EmailDeliveryObserver to intercept the email delivery
+    # process. When an email is delivered, both the interceptor and observer are triggered,
+    # pushing their metrics to CloudWatch.
+    # To isolate this test to just the interceptor, we have to ignore any metrics pushed by
+    # the observer.
+    # @see Observing and Intercepting Mails https://apidock.com/rails/ActionMailer/Base
+    Cdo::Metrics.stubs(:push).with('ActionMailer', Not(equals(expected_metric)))
+
     teacher = build :teacher, email: 'teacher@gmail.com'
     TeacherMailer.new_teacher_email(teacher).deliver_now
   end

--- a/dashboard/test/mailers/email_delivery_interceptor_test.rb
+++ b/dashboard/test/mailers/email_delivery_interceptor_test.rb
@@ -1,0 +1,20 @@
+require 'test_helper'
+require 'testing/includes_metrics'
+
+class EmailDeliveryInterceptorTest < ActiveSupport::TestCase
+  test 'push a metric when an email is going to be sent' do
+    ActionMailer::Base.register_interceptor EmailDeliveryInterceptor
+
+    Cdo::Metrics.expects(:push).once.with(
+      'ActionMailer', includes_metrics(EmailToSend: 1)
+    )
+
+    # TODO: remove this unrelated expectation
+    Cdo::Metrics.expects(:push).with(
+      'ActionMailer', includes_metrics(EmailSent: 1)
+    )
+
+    teacher = build :teacher, email: 'teacher@gmail.com'
+    TeacherMailer.new_teacher_email(teacher).deliver_now
+  end
+end

--- a/dashboard/test/mailers/email_delivery_interceptor_test.rb
+++ b/dashboard/test/mailers/email_delivery_interceptor_test.rb
@@ -1,5 +1,4 @@
 require 'test_helper'
-require 'testing/includes_metrics'
 
 class EmailDeliveryInterceptorTest < ActiveSupport::TestCase
   setup do

--- a/dashboard/test/mailers/email_delivery_observer_test.rb
+++ b/dashboard/test/mailers/email_delivery_observer_test.rb
@@ -1,0 +1,24 @@
+require 'test_helper'
+require 'testing/includes_metrics'
+
+class EmailDeliveryObserverTest < ActiveSupport::TestCase
+  setup do
+    ActionMailer::Base.register_observer EmailDeliveryObserver
+  end
+
+  test 'push a metric when an email is sent' do
+    expected_metric = [
+      {
+        metric_name: :EmailSent,
+        dimensions: [
+          {name: "Environment", value: CDO.rack_env}
+        ],
+        value: 1
+      }
+    ]
+    Cdo::Metrics.expects(:push).with('ActionMailer', expected_metric)
+
+    teacher = build :teacher, email: 'teacher@gmail.com'
+    TeacherMailer.new_teacher_email(teacher).deliver_now
+  end
+end

--- a/dashboard/test/mailers/email_delivery_observer_test.rb
+++ b/dashboard/test/mailers/email_delivery_observer_test.rb
@@ -18,6 +18,16 @@ class EmailDeliveryObserverTest < ActiveSupport::TestCase
     ]
     Cdo::Metrics.expects(:push).with('ActionMailer', expected_metric)
 
+    # Ignores other ActionMailer metrics.
+    #
+    # We use EmailDeliveryInterceptor and EmailDeliveryObserver to intercept the email delivery
+    # process. When an email is delivered, both the interceptor and observer are triggered,
+    # pushing their metrics to CloudWatch.
+    # To isolate this test to just the observer, we have to ignore any metrics pushed by
+    # the interceptor.
+    # @see Observing and Intercepting Mails https://apidock.com/rails/ActionMailer/Base
+    Cdo::Metrics.stubs(:push).with('ActionMailer', Not(equals(expected_metric)))
+
     teacher = build :teacher, email: 'teacher@gmail.com'
     TeacherMailer.new_teacher_email(teacher).deliver_now
   end

--- a/dashboard/test/mailers/email_delivery_observer_test.rb
+++ b/dashboard/test/mailers/email_delivery_observer_test.rb
@@ -1,5 +1,4 @@
 require 'test_helper'
-require 'testing/includes_metrics'
 
 class EmailDeliveryObserverTest < ActiveSupport::TestCase
   setup do


### PR DESCRIPTION
[FND-1465](https://codedotorg.atlassian.net/browse/FND-1465)
Creating the first version of transactional email monitoring system using ActionMailer interceptor and observer.

The interceptor is called before emails are handed-off to the delivery agents. The observer is called after emails have been sent. They emit `EmailToSend` and `EmailSent` events to CloudWatch.

[ActionMailer-Emails dashboard](https://console.aws.amazon.com/cloudwatch/home?region=us-east-1#dashboards:name=ActionMailer-Emails) on CloudWatch.
<img width="445" alt="Screen Shot 2021-03-25 at 7 21 49 PM" src="https://user-images.githubusercontent.com/46507039/112568324-81af5500-8d9f-11eb-8921-43db6af30b30.png">
(`EmailNotSent` = `EmailToSend` - `EmailSent`)

## Links
- https://guides.rubyonrails.org/action_mailer_basics.html#intercepting-and-observing-emails
- https://apidock.com/rails/ActionMailer/Base


## Testing story
- Unit tests
  - bundle exec rails test test/mailers/email_delivery_interceptor_test.rb
  - bundle exec rails test test/mailers/email_delivery_observer_test.rb

- Manual tests on local machine
  - Turn on MailCatcher
    - Set `use_mailcatcher: true` in `locals.yml`.
    - Start the service by running `mailcatcher --ip=0.0.0.0`
    - Open http://0.0.0.0:1080/
  - Send an email from a Rails console
      ```
      include FactoryGirl::Syntax::Methods
      teacher = build :teacher, email: 'ha@hi.hello'
      TeacherMailer.new_teacher_email(teacher).deliver_now
      ```
  - Verify that MailCatcher catches that email (i.e. we don't break a core feature). 
  - Verify that `EmailToSend` and `EmailSent` metrics are sent to CloudWatch.
  - Clean up
    - Kill MailCatcher `kill -9 $(lsof -t -i :1025)`
    - Reset `use_mailcatcher` in `locals.yml`.

## Follow-up work
- [ ] Create an alarm when too many emails are not sent. [Test alarm, only notify ha@code.org](https://console.aws.amazon.com/cloudwatch/home?region=us-east-1#alarmsV2:alarm/test-email-not-sent-too-high?).
- [ ] Create a metric aggregator to reduce the number of events sent to CloudWatch.
- [ ] Collect more email information in the interceptor and observer such as email subject and email template.

## PR Checklist:
- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
