### PR TITLE
Show more informative error message when dataset upload fail, add authenticate_user before action

### DIFF
--- a/apps/src/storage/levelbuilder/Dataset.jsx
+++ b/apps/src/storage/levelbuilder/Dataset.jsx
@@ -56,9 +56,12 @@ class Dataset extends React.Component {
         this.setState({notice: 'Upload succeeded.', isError: false});
         onComplete();
       })
-      .fail((jqXHR, textStatus) =>
-        this.setState({notice: `Upload failed: ${textStatus}`, isError: true})
-      );
+      .fail((jqXHR, textStatus) => {
+        this.setState({
+          notice: `Upload failed - ${textStatus}`,
+          isError: true
+        });
+      });
   };
 
   deleteTable = () => {

--- a/apps/src/storage/levelbuilder/Dataset.jsx
+++ b/apps/src/storage/levelbuilder/Dataset.jsx
@@ -56,7 +56,9 @@ class Dataset extends React.Component {
         this.setState({notice: 'Upload succeeded.', isError: false});
         onComplete();
       })
-      .fail(() => this.setState({notice: 'Upload failed.', isError: true}));
+      .fail((jqXHR, textStatus) =>
+        this.setState({notice: `Upload failed: ${textStatus}`, isError: true})
+      );
   };
 
   deleteTable = () => {

--- a/dashboard/app/controllers/datasets_controller.rb
+++ b/dashboard/app/controllers/datasets_controller.rb
@@ -2,6 +2,7 @@ require 'json'
 require 'uri'
 
 class DatasetsController < ApplicationController
+  before_action :authenticate_user!
   before_action :require_levelbuilder_mode
   before_action :initialize_firebase
   authorize_resource class: false


### PR DESCRIPTION
Added authenticate_user before action on dataset routes to make sure the user is logged in and changed the error message to Upload Failed - ${textStatus}. textStatus can be error, abort, parseerror, or timeout.

<img width="1440" alt="Screen Shot 2021-03-25 at 11 17 08 AM" src="https://user-images.githubusercontent.com/17147070/112524423-088f0e00-8d5d-11eb-86cf-2e338e49ad49.png">


## Links

- jira ticket: [STAR-1405](https://codedotorg.atlassian.net/browse/STAR-1405)
- slack conversation: [here](https://codedotorg.slack.com/archives/C1B3PNDL7/p1610736265021300)

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
