### PR TITLE
Fix leaking sublevel progress

### DIFF
--- a/dashboard/app/models/levels/bubble_choice.rb
+++ b/dashboard/app/models/levels/bubble_choice.rb
@@ -141,8 +141,16 @@ class BubbleChoice < DSLDefined
         level_url(level.id)
 
       if user_id
-        level_info[:perfect] = UserLevel.find_by(level: level, user_id: user_id)&.perfect?
-        level_info[:status] = level_info[:perfect] ? SharedConstants::LEVEL_STATUS.perfect : SharedConstants::LEVEL_STATUS.not_tried
+        level_info[:perfect] = UserLevel.find_by(
+          level: level,
+          script: script_level.try(:script),
+          user_id: user_id
+          )&.perfect?
+        level_info[:status] = if level_info[:perfect]
+                                SharedConstants::LEVEL_STATUS.perfect
+                              else
+                                SharedConstants::LEVEL_STATUS.not_tried
+                              end
       else
         # Pass an empty status if the user is not logged in so the ProgressBubble
         # in the sublevel display can render correctly.

--- a/dashboard/test/models/levels/bubble_choice_test.rb
+++ b/dashboard/test/models/levels/bubble_choice_test.rb
@@ -221,6 +221,28 @@ DSL
     assert_nil sublevel_summary.last[:perfect]
   end
 
+  test 'summarize_sublevels does not leak progress between scripts' do
+    student = create :student
+    other_script_level = create :script_level, levels: [@bubble_choice]
+    create :user_level,
+      user: student,
+      level: @sublevel1,
+      script: @script_level.script,
+      best_result: ActivityConstants::BEST_PASS_RESULT
+    create :user_level,
+      user: student,
+      level: @sublevel2,
+      script: other_script_level.script,
+      best_result: ActivityConstants::BEST_PASS_RESULT
+    sublevel_summary = @bubble_choice.summarize_sublevels(
+      script_level: @script_level,
+      user_id: student.id
+    )
+    assert_equal 2, sublevel_summary.length
+    assert sublevel_summary.first[:perfect]
+    refute sublevel_summary.last[:perfect]
+  end
+
   test 'best_result_sublevel_id returns sublevel with highest best_result for user' do
     student = create :student
     create :user_level, user: student, level: @sublevel2, best_result: 100


### PR DESCRIPTION
currently, when we display the sublevels for a bubble choice level, the sublevels will show progress if the user has progress for that level _in any script_. this PR fixes that by including the script in the query for sublevel progress in `bubble_choice.rb`.

## Links

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

jira: [LP-1792]


[LP-1792]: https://codedotorg.atlassian.net/browse/LP-1792