### PR TITLE
Log clicks on Announcements on script and course overview pages

### DIFF
--- a/apps/src/code-studio/announcementsRedux.js
+++ b/apps/src/code-studio/announcementsRedux.js
@@ -23,7 +23,8 @@ export const announcementShape = PropTypes.shape({
   details: PropTypes.string.isRequired,
   link: PropTypes.string.isRequired,
   type: PropTypes.oneOf(Object.values(NotificationType)).isRequired,
-  visibility: PropTypes.oneOf(Object.values(VisibilityType))
+  visibility: PropTypes.oneOf(Object.values(VisibilityType)),
+  analyticsData: PropTypes.object
 });
 
 export default function announcements(state = [], action) {

--- a/apps/src/code-studio/announcementsRedux.js
+++ b/apps/src/code-studio/announcementsRedux.js
@@ -23,8 +23,7 @@ export const announcementShape = PropTypes.shape({
   details: PropTypes.string.isRequired,
   link: PropTypes.string.isRequired,
   type: PropTypes.oneOf(Object.values(NotificationType)).isRequired,
-  visibility: PropTypes.oneOf(Object.values(VisibilityType)),
-  analyticsData: PropTypes.object
+  visibility: PropTypes.oneOf(Object.values(VisibilityType))
 });
 
 export default function announcements(state = [], action) {

--- a/apps/src/code-studio/components/progress/Announcements.jsx
+++ b/apps/src/code-studio/components/progress/Announcements.jsx
@@ -49,6 +49,7 @@ export default class Announcements extends Component {
             buttonLink={announcement.link}
             dismissible={true}
             width={this.props.width}
+            analyticsData={announcement.analyticsData}
           />
         ))}
       </div>

--- a/apps/src/code-studio/components/progress/Announcements.jsx
+++ b/apps/src/code-studio/components/progress/Announcements.jsx
@@ -12,7 +12,8 @@ export default class Announcements extends Component {
   static propTypes = {
     announcements: PropTypes.arrayOf(announcementShape).isRequired,
     width: PropTypes.oneOfType([PropTypes.number, PropTypes.string]),
-    viewAs: PropTypes.oneOf(Object.values(ViewType)).isRequired
+    viewAs: PropTypes.oneOf(Object.values(ViewType)).isRequired,
+    firehoseAnalyticsData: PropTypes.object
   };
 
   /*
@@ -49,7 +50,7 @@ export default class Announcements extends Component {
             buttonLink={announcement.link}
             dismissible={true}
             width={this.props.width}
-            analyticsData={announcement.analyticsData}
+            firehoseAnalyticsData={this.props.firehoseAnalyticsData}
           />
         ))}
       </div>

--- a/apps/src/code-studio/components/progress/ScriptOverviewHeader.jsx
+++ b/apps/src/code-studio/components/progress/ScriptOverviewHeader.jsx
@@ -119,6 +119,18 @@ class ScriptOverviewHeader extends Component {
     });
   };
 
+  getAnnouncementsWithAnalyticsData() {
+    return this.props.announcements.map(announcement => {
+      return {
+        ...announcement,
+        analyticsData: {
+          script_id: this.props.scriptId,
+          user_id: this.props.userId
+        }
+      };
+    });
+  }
+
   render() {
     const {
       plcHeaderProps,
@@ -175,7 +187,7 @@ class ScriptOverviewHeader extends Component {
         )}
         {isSignedIn && (
           <Announcements
-            announcements={this.props.announcements}
+            announcements={this.getAnnouncementsWithAnalyticsData()}
             width={SCRIPT_OVERVIEW_WIDTH}
             viewAs={viewAs}
           />

--- a/apps/src/code-studio/components/progress/ScriptOverviewHeader.jsx
+++ b/apps/src/code-studio/components/progress/ScriptOverviewHeader.jsx
@@ -119,21 +119,10 @@ class ScriptOverviewHeader extends Component {
     });
   };
 
-  getAnnouncementsWithAnalyticsData() {
-    return this.props.announcements.map(announcement => {
-      return {
-        ...announcement,
-        analyticsData: {
-          script_id: this.props.scriptId,
-          user_id: this.props.userId
-        }
-      };
-    });
-  }
-
   render() {
     const {
       plcHeaderProps,
+      scriptId,
       scriptName,
       scriptTitle,
       scriptDescription,
@@ -187,9 +176,13 @@ class ScriptOverviewHeader extends Component {
         )}
         {isSignedIn && (
           <Announcements
-            announcements={this.getAnnouncementsWithAnalyticsData()}
+            announcements={this.props.announcements}
             width={SCRIPT_OVERVIEW_WIDTH}
             viewAs={viewAs}
+            firehoseAnalyticsData={{
+              script_id: scriptId,
+              user_id: userId
+            }}
           />
         )}
         {userId && <StudentFeedbackNotification studentId={userId} />}

--- a/apps/src/templates/Notification.jsx
+++ b/apps/src/templates/Notification.jsx
@@ -146,9 +146,9 @@ class Notification extends Component {
     dismissible: PropTypes.bool.isRequired,
     onDismiss: PropTypes.func,
     newWindow: PropTypes.bool,
-    // analyticId and firehoseAnalyticsData are only used when a primary button is provided.
+    // googleAnalyticsId and firehoseAnalyticsData are only used when a primary button is provided.
     // It's not used by the array of buttons.
-    analyticId: PropTypes.string,
+    googleAnalyticsId: PropTypes.string,
     firehoseAnalyticsData: PropTypes.object,
     responsiveSize: PropTypes.oneOf(['lg', 'md', 'sm', 'xs']),
     isRtl: PropTypes.bool.isRequired,
@@ -187,11 +187,11 @@ class Notification extends Component {
   };
 
   onAnnouncementClick() {
-    const {firehoseAnalyticsData, analyticId} = this.props;
+    const {firehoseAnalyticsData, googleAnalyticsId} = this.props;
 
     // Log to Google Analytics
-    if (analyticId) {
-      trackEvent('teacher_announcement', 'click', analyticId);
+    if (googleAnalyticsId) {
+      trackEvent('teacher_announcement', 'click', googleAnalyticsId);
     }
 
     // Log to Firehose

--- a/apps/src/templates/Notification.jsx
+++ b/apps/src/templates/Notification.jsx
@@ -146,10 +146,10 @@ class Notification extends Component {
     dismissible: PropTypes.bool.isRequired,
     onDismiss: PropTypes.func,
     newWindow: PropTypes.bool,
-    // analyticId and analyticsData are only used when a primary button is provided.
+    // analyticId and firehoseAnalyticsData are only used when a primary button is provided.
     // It's not used by the array of buttons.
     analyticId: PropTypes.string,
-    analyticsData: PropTypes.object,
+    firehoseAnalyticsData: PropTypes.object,
     responsiveSize: PropTypes.oneOf(['lg', 'md', 'sm', 'xs']),
     isRtl: PropTypes.bool.isRequired,
     onButtonClick: PropTypes.func,
@@ -187,7 +187,7 @@ class Notification extends Component {
   };
 
   onAnnouncementClick() {
-    const {analyticsData, analyticId} = this.props;
+    const {firehoseAnalyticsData, analyticId} = this.props;
 
     // Log to Google Analytics
     if (analyticId) {
@@ -195,15 +195,16 @@ class Notification extends Component {
     }
 
     // Log to Firehose
-    if (analyticsData) {
+    if (firehoseAnalyticsData) {
       let record = {};
 
       // Our firehose logging system has standalone fields for commonly used metadata (eg, user_id).
-      // Here, we separate out those fields from any other analytics data provided in the analyticsData prop.
+      // Here, we separate out those fields from any other analytics data provided in the firehoseAnalyticsData prop.
       // We include these properties in the data_json object as well, in case that is easier for our product team to use.
       ['user_id', 'script_id'].forEach(firehoseMetadataKey => {
-        if (firehoseMetadataKey in analyticsData) {
-          record[firehoseMetadataKey] = analyticsData[firehoseMetadataKey];
+        if (firehoseMetadataKey in firehoseAnalyticsData) {
+          record[firehoseMetadataKey] =
+            firehoseAnalyticsData[firehoseMetadataKey];
         }
       });
 
@@ -212,7 +213,7 @@ class Notification extends Component {
         study: 'notification_engagement',
         event: 'notification_click',
         data_json: JSON.stringify({
-          ...analyticsData,
+          ...firehoseAnalyticsData,
           notice: this.props.notice,
           details: this.props.details,
           buttonLink: this.props.buttonLink

--- a/apps/src/templates/Notification.story.jsx
+++ b/apps/src/templates/Notification.story.jsx
@@ -42,6 +42,12 @@ const announcement = {
   dismissible: false
 };
 
+const announcementWithAnalyticsData = {
+  ...announcement,
+  analyticId: 'sample_announcement',
+  analyticsData: {user_id: 1, important_data_point: 2}
+};
+
 export default storybook => {
   return storybook
     .storiesOf('Notification', module)
@@ -152,11 +158,10 @@ export default storybook => {
         story: () => (
           <Notification
             type="bullhorn"
-            {...announcement}
+            {...announcementWithAnalyticsData}
             buttonText="Learn more"
             buttonLink="/"
             newWindow={true}
-            analyticId="sample_announcement"
           />
         )
       },

--- a/apps/src/templates/Notification.story.jsx
+++ b/apps/src/templates/Notification.story.jsx
@@ -42,10 +42,9 @@ const announcement = {
   dismissible: false
 };
 
-const announcementWithAnalyticsData = {
-  ...announcement,
-  analyticId: 'sample_announcement',
-  analyticsData: {user_id: 1, important_data_point: 2}
+const firehoseAnalyticsData = {
+  user_id: 1,
+  important_data_point: 2
 };
 
 export default storybook => {
@@ -158,10 +157,11 @@ export default storybook => {
         story: () => (
           <Notification
             type="bullhorn"
-            {...announcementWithAnalyticsData}
+            {...announcement}
             buttonText="Learn more"
             buttonLink="/"
             newWindow={true}
+            firehoseAnalyticsData={firehoseAnalyticsData}
           />
         )
       },

--- a/apps/src/templates/Notification.story.jsx
+++ b/apps/src/templates/Notification.story.jsx
@@ -162,6 +162,7 @@ export default storybook => {
             buttonLink="/"
             newWindow={true}
             firehoseAnalyticsData={firehoseAnalyticsData}
+            googleAnalyticsId="sample_announcement"
           />
         )
       },

--- a/apps/src/templates/courseOverview/CourseOverview.js
+++ b/apps/src/templates/courseOverview/CourseOverview.js
@@ -138,18 +138,6 @@ class CourseOverview extends Component {
     });
   };
 
-  getAnnouncementsWithAnalyticsData() {
-    return this.props.announcements.map(announcement => {
-      return {
-        ...announcement,
-        analyticsData: {
-          unit_group_id: this.props.id,
-          user_id: this.props.userId
-        }
-      };
-    });
-  }
-
   render() {
     const {
       name,
@@ -224,9 +212,13 @@ class CourseOverview extends Component {
         )}
         {isSignedIn && (
           <Announcements
-            announcements={this.getAnnouncementsWithAnalyticsData()}
+            announcements={this.props.announcements}
             width={styleConstants['content-width']}
             viewAs={viewAs}
+            firehoseAnalyticsId={{
+              user_id: userId,
+              unit_group_id: id
+            }}
           />
         )}
         <div style={styles.titleWrapper}>

--- a/apps/src/templates/courseOverview/CourseOverview.js
+++ b/apps/src/templates/courseOverview/CourseOverview.js
@@ -138,6 +138,18 @@ class CourseOverview extends Component {
     });
   };
 
+  getAnnouncementsWithAnalyticsData() {
+    return this.props.announcements.map(announcement => {
+      return {
+        ...announcement,
+        analyticsData: {
+          unit_group_id: this.props.id,
+          user_id: this.props.userId
+        }
+      };
+    });
+  }
+
   render() {
     const {
       name,
@@ -212,7 +224,7 @@ class CourseOverview extends Component {
         )}
         {isSignedIn && (
           <Announcements
-            announcements={this.props.announcements}
+            announcements={this.getAnnouncementsWithAnalyticsData()}
             width={styleConstants['content-width']}
             viewAs={viewAs}
           />

--- a/apps/src/templates/feedback/StudentFeedbackNotification.jsx
+++ b/apps/src/templates/feedback/StudentFeedbackNotification.jsx
@@ -45,7 +45,7 @@ export default class StudentFeedbackNotification extends Component {
             buttonText={i18n.feedbackNotificationButton()}
             buttonLink="/feedback"
             dismissible={false}
-            analyticId="student-feedback"
+            googleAnalyticsId="student-feedback"
           />
         )}
       </div>

--- a/apps/src/templates/studioHomepages/TeacherHomepage.jsx
+++ b/apps/src/templates/studioHomepages/TeacherHomepage.jsx
@@ -219,7 +219,7 @@ export class UnconnectedTeacherHomepage extends Component {
                 buttonText={announcement.buttonText}
                 buttonLink={announcement.link}
                 newWindow={true}
-                analyticId={announcement.id}
+                googleAnalyticsId={announcement.id}
               />
               <div style={styles.clear} />
             </div>

--- a/apps/test/unit/code-studio/components/progress/AnnouncementsTest.jsx
+++ b/apps/test/unit/code-studio/components/progress/AnnouncementsTest.jsx
@@ -3,11 +3,13 @@ import {assert} from '../../../../util/reconfiguredChai';
 import {shallow} from 'enzyme';
 import {ViewType} from '@cdo/apps/code-studio/viewAsRedux';
 import Announcements from '@cdo/apps/code-studio/components/progress/Announcements';
+import Notification from '@cdo/apps/templates/Notification';
 import {
   fakeStudentAnnouncement,
   fakeTeacherAndStudentAnnouncement,
   fakeTeacherAnnouncement,
-  fakeOldTeacherAnnouncement
+  fakeOldTeacherAnnouncement,
+  fakeTeacherAnnouncementWithAnalyticsData
 } from './FakeAnnouncementsTestData';
 
 const defaultProps = {
@@ -19,7 +21,7 @@ const defaultProps = {
 describe('Announcements', () => {
   it('does not show Notifications if no announcements', () => {
     const wrapper = shallow(<Announcements {...defaultProps} />);
-    assert.equal(wrapper.find('Connect(Notification)').length, 0);
+    assert.equal(wrapper.find(Notification).length, 0);
   });
 
   it('displays old teacher announcement for teacher', () => {
@@ -29,7 +31,7 @@ describe('Announcements', () => {
         announcements={[fakeOldTeacherAnnouncement]}
       />
     );
-    assert.equal(wrapper.find('Connect(Notification)').length, 1);
+    assert.equal(wrapper.find(Notification).length, 1);
   });
 
   it('does not display old teacher announcement for student', () => {
@@ -40,7 +42,7 @@ describe('Announcements', () => {
         viewAs={ViewType.Student}
       />
     );
-    assert.equal(wrapper.find('Connect(Notification)').length, 0);
+    assert.equal(wrapper.find(Notification).length, 0);
   });
 
   it('displays new teacher announcement for teacher', () => {
@@ -50,7 +52,7 @@ describe('Announcements', () => {
         announcements={[fakeTeacherAnnouncement]}
       />
     );
-    assert.equal(wrapper.find('Connect(Notification)').length, 1);
+    assert.equal(wrapper.find(Notification).length, 1);
   });
 
   it('has only teacher announcements', () => {
@@ -64,7 +66,7 @@ describe('Announcements', () => {
         ]}
       />
     );
-    assert.equal(wrapper.find('Connect(Notification)').length, 2);
+    assert.equal(wrapper.find(Notification).length, 2);
   });
 
   it('has student announcement if necessary', () => {
@@ -75,7 +77,7 @@ describe('Announcements', () => {
         announcements={[fakeStudentAnnouncement]}
       />
     );
-    assert.equal(wrapper.find('Connect(Notification)').length, 1);
+    assert.equal(wrapper.find(Notification).length, 1);
   });
 
   it('has all student announcements but no teacher announcements if necessary', () => {
@@ -91,6 +93,16 @@ describe('Announcements', () => {
       />,
       {disableLifecycleMethods: true}
     );
-    assert.equal(wrapper.find('Connect(Notification)').length, 2);
+    assert.equal(wrapper.find(Notification).length, 2);
+  });
+
+  it('displays teacher announcement with analytics data', () => {
+    const wrapper = shallow(
+      <Announcements
+        {...defaultProps}
+        announcements={[fakeTeacherAnnouncementWithAnalyticsData]}
+      />
+    );
+    assert.equal(wrapper.find(Notification).length, 1);
   });
 });

--- a/apps/test/unit/code-studio/components/progress/AnnouncementsTest.jsx
+++ b/apps/test/unit/code-studio/components/progress/AnnouncementsTest.jsx
@@ -8,14 +8,18 @@ import {
   fakeStudentAnnouncement,
   fakeTeacherAndStudentAnnouncement,
   fakeTeacherAnnouncement,
-  fakeOldTeacherAnnouncement,
-  fakeTeacherAnnouncementWithAnalyticsData
+  fakeOldTeacherAnnouncement
 } from './FakeAnnouncementsTestData';
 
 const defaultProps = {
   announcements: [],
   viewAs: ViewType.Teacher,
   width: 1000
+};
+
+const firehoseAnalyticsData = {
+  user_id: 1,
+  script_id: 2
 };
 
 describe('Announcements', () => {
@@ -100,7 +104,8 @@ describe('Announcements', () => {
     const wrapper = shallow(
       <Announcements
         {...defaultProps}
-        announcements={[fakeTeacherAnnouncementWithAnalyticsData]}
+        firehoseAnalyticsData={firehoseAnalyticsData}
+        announcements={[fakeTeacherAnnouncement]}
       />
     );
     assert.equal(wrapper.find(Notification).length, 1);

--- a/apps/test/unit/code-studio/components/progress/FakeAnnouncementsTestData.jsx
+++ b/apps/test/unit/code-studio/components/progress/FakeAnnouncementsTestData.jsx
@@ -8,6 +8,7 @@ export const fakeTeacherAnnouncement = {
   type: NotificationType.information,
   visibility: VisibilityType.teacher
 };
+
 export const fakeStudentAnnouncement = {
   notice: 'Notice - Student',
   details: 'Students are the best',
@@ -15,6 +16,7 @@ export const fakeStudentAnnouncement = {
   type: NotificationType.information,
   visibility: VisibilityType.student
 };
+
 export const fakeTeacherAndStudentAnnouncement = {
   notice: 'Notice - Teacher And Student',
   details: 'More detail here',
@@ -22,9 +24,18 @@ export const fakeTeacherAndStudentAnnouncement = {
   type: NotificationType.information,
   visibility: VisibilityType.teacherAndStudent
 };
+
 export const fakeOldTeacherAnnouncement = {
   notice: 'Notice - Teacher',
   details: 'Teachers are the best',
   link: '/foo/bar/teacher',
   type: NotificationType.information
+};
+
+export const fakeTeacherAnnouncementWithAnalyticsData = {
+  ...fakeTeacherAnnouncement,
+  analyticsData: {
+    user_id: 1,
+    script_id: 2
+  }
 };

--- a/apps/test/unit/code-studio/components/progress/FakeAnnouncementsTestData.jsx
+++ b/apps/test/unit/code-studio/components/progress/FakeAnnouncementsTestData.jsx
@@ -31,11 +31,3 @@ export const fakeOldTeacherAnnouncement = {
   link: '/foo/bar/teacher',
   type: NotificationType.information
 };
-
-export const fakeTeacherAnnouncementWithAnalyticsData = {
-  ...fakeTeacherAnnouncement,
-  analyticsData: {
-    user_id: 1,
-    script_id: 2
-  }
-};

--- a/apps/test/unit/templates/NotificationTest.js
+++ b/apps/test/unit/templates/NotificationTest.js
@@ -14,7 +14,11 @@ const announcement = {
   description:
     "Go Beyond an Hour of Code and explore computer science concepts with your students every week. Code.org offers curriculum, lesson plans, high quality professional learning programs, and tons of great tools for all grade levels - and it's free. No experience required - find the next step that's right for your classroom.",
   link:
-    'http://teacherblog.code.org/post/160703303174/coming-soon-access-your-top-resources-with-the'
+    'http://teacherblog.code.org/post/160703303174/coming-soon-access-your-top-resources-with-the',
+  analyticsData: {
+    user_id: 1,
+    important_data_point: 2
+  }
 };
 
 const announcementNoLink = {
@@ -77,7 +81,7 @@ describe('Notification', () => {
         buttonText={announcement.buttonText}
         buttonLink={announcement.link}
         newWindow={true}
-        analyticId={announcement.id}
+        analyticsData={announcement.analyticsData}
       />
     );
     expect(
@@ -117,7 +121,6 @@ describe('Notification', () => {
         buttonText={announcementNoLink.buttonText}
         buttonLink={announcementNoLink.link}
         newWindow={true}
-        analyticId={announcementNoLink.id}
       />
     );
     expect(

--- a/apps/test/unit/templates/NotificationTest.js
+++ b/apps/test/unit/templates/NotificationTest.js
@@ -14,11 +14,7 @@ const announcement = {
   description:
     "Go Beyond an Hour of Code and explore computer science concepts with your students every week. Code.org offers curriculum, lesson plans, high quality professional learning programs, and tons of great tools for all grade levels - and it's free. No experience required - find the next step that's right for your classroom.",
   link:
-    'http://teacherblog.code.org/post/160703303174/coming-soon-access-your-top-resources-with-the',
-  analyticsData: {
-    user_id: 1,
-    important_data_point: 2
-  }
+    'http://teacherblog.code.org/post/160703303174/coming-soon-access-your-top-resources-with-the'
 };
 
 const announcementNoLink = {
@@ -64,6 +60,11 @@ const findCourse = {
   dismissible: false
 };
 
+const firehoseAnalyticsData = {
+  user_id: 1,
+  important_data_point: 2
+};
+
 const store = createStore(combineReducers({isRtl}));
 
 function wrapped(element) {
@@ -81,7 +82,7 @@ describe('Notification', () => {
         buttonText={announcement.buttonText}
         buttonLink={announcement.link}
         newWindow={true}
-        analyticsData={announcement.analyticsData}
+        firehoseAnalyticsData={firehoseAnalyticsData}
       />
     );
     expect(


### PR DESCRIPTION
Logs to Firehose any time a user clicks on a button on an announcement on script and course overview pages.

A couple notes:
- ~~"injects" analytics data to be logged to Firehose into announcements data in the script and course overview components. Alternative was to use a version of the Notification component that is connected to the redux store, but I thought it was cleaner this way.~~
- analytics data from the course and script overview pages are currently the same for each Notification, so we use a single prop when creating the `Announcements` component instead of injecting the analytics data into each Announcement.
- A nice to have for this item was to add GA logging as well, which I did not do. We have some [existing functionality](https://github.com/code-dot-org/code-dot-org/blob/staging/apps/src/templates/Notification.jsx#L188) on `Notification` components to allow logging to GA, but it involves providing an analyticId, which I didn't see a clean way providing an ID for each announcement.

Note for anyone reading that I didn't realize for a while while working on this: logging of script ID and user ID are [actually built into our Firehose client](https://github.com/code-dot-org/code-dot-org/blob/staging/apps/src/lib/util/firehose.js#L171), but only on pages where we have access to `pageConstants`, which is not the case on these pages (I think `pageConstants` is available when you're working on a level? Not 100% sure).

## Links

- jira ticket: [LP-1576](https://codedotorg.atlassian.net/browse/LP-1576)

## Testing story

I tested this manually on /s/csp1-2020, which has an announcement. I also added/modified tests to the Notification and Announcement test files to confirm at least that components that have these new props are able to render.

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [x] Tests provide adequate coverage
- [x] Privacy and Security impacts have been assessed
- [x] Code is well-commented
- [x] New features are translatable or updates will not break translations
- [x] Relevant documentation has been added or updated
- [x] User impact is well-understood and desirable
- [x] Pull Request is labeled appropriately
- [x] Follow-up work items (including potential tech debt) are tracked and linked
