### PR TITLE
Fix sad bee on lessons with an external markdown level

### DIFF
--- a/dashboard/app/models/activity_section.rb
+++ b/dashboard/app/models/activity_section.rb
@@ -55,9 +55,9 @@ class ActivitySection < ApplicationRecord
     }
   end
 
-  def summarize_for_lesson_show(can_view_teacher_markdown)
+  def summarize_for_lesson_show(user, can_view_teacher_markdown)
     summary = summarize
-    summary[:scriptLevels] = script_levels.map {|sl| sl.summarize_for_lesson_show(can_view_teacher_markdown)}
+    summary[:scriptLevels] = script_levels.map {|sl| sl.summarize_for_lesson_show(user, can_view_teacher_markdown)}
     Services::MarkdownPreprocessor.process!(summary[:description])
     summary
   end

--- a/dashboard/app/models/lesson.rb
+++ b/dashboard/app/models/lesson.rb
@@ -377,7 +377,7 @@ class Lesson < ApplicationRecord
       announcements: announcements,
       purpose: Services::MarkdownPreprocessor.process(purpose || ''),
       preparation: Services::MarkdownPreprocessor.process(preparation || ''),
-      activities: lesson_activities.map {|la| la.summarize_for_lesson_show(can_view_teacher_markdown)},
+      activities: lesson_activities.map {|la| la.summarize_for_lesson_show(user, can_view_teacher_markdown)},
       resources: resources_for_lesson_plan(user&.authorized_teacher?),
       vocabularies: vocabularies.map(&:summarize_for_lesson_show),
       programmingExpressions: programming_expressions.map(&:summarize_for_lesson_show),

--- a/dashboard/app/models/lesson_activity.rb
+++ b/dashboard/app/models/lesson_activity.rb
@@ -42,9 +42,9 @@ class LessonActivity < ApplicationRecord
     }
   end
 
-  def summarize_for_lesson_show(can_view_teacher_markdown)
+  def summarize_for_lesson_show(user, can_view_teacher_markdown)
     summary = summarize
-    summary[:activitySections] = activity_sections.map {|as| as.summarize_for_lesson_show(can_view_teacher_markdown)}
+    summary[:activitySections] = activity_sections.map {|as| as.summarize_for_lesson_show(user, can_view_teacher_markdown)}
     summary
   end
 

--- a/dashboard/app/models/levels/blockly.rb
+++ b/dashboard/app/models/levels/blockly.rb
@@ -792,7 +792,7 @@ class Blockly < Level
     end
   end
 
-  def summarize_for_lesson_show(can_view_teacher_markdown)
+  def summarize_for_lesson_show(user, can_view_teacher_markdown)
     super.merge(
       {
         longInstructions: localized_long_instructions || long_instructions,

--- a/dashboard/app/models/levels/external.rb
+++ b/dashboard/app/models/levels/external.rb
@@ -72,10 +72,10 @@ class External < DSLDefined
     %w(bounce flappy jigsaw maze studio turtle)
   end
 
-  def summarize_for_lesson_show(can_view_teacher_markdown)
+  def summarize_for_lesson_show(user, can_view_teacher_markdown)
     super.merge(
       {
-        markdown: localized_replaced_markdown
+        markdown: localized_replaced_markdown(user)
       }
     )
   end

--- a/dashboard/app/models/levels/level.rb
+++ b/dashboard/app/models/levels/level.rb
@@ -798,7 +798,7 @@ class Level < ApplicationRecord
     }
   end
 
-  def summarize_for_lesson_show(can_view_teacher_markdown)
+  def summarize_for_lesson_show(user, can_view_teacher_markdown)
     teacher_markdown_for_display = localized_teacher_markdown if can_view_teacher_markdown
     {
       name: name,
@@ -813,7 +813,7 @@ class Level < ApplicationRecord
       referenceLinks: reference_links,
       teacherMarkdown: teacher_markdown_for_display,
       videoOptions: specified_autoplay_video&.summarize(false),
-      containedLevels: contained_levels.map {|l| l.summarize_for_lesson_show(can_view_teacher_markdown)},
+      containedLevels: contained_levels.map {|l| l.summarize_for_lesson_show(user, can_view_teacher_markdown)},
       status: SharedConstants::LEVEL_STATUS.not_tried,
       thumbnailUrl: thumbnail_url
     }

--- a/dashboard/app/models/levels/match.rb
+++ b/dashboard/app/models/levels/match.rb
@@ -77,7 +77,7 @@ class Match < DSLDefined
     'fa fa-list-ul'
   end
 
-  def summarize_for_lesson_show(can_view_teacher_markdown)
+  def summarize_for_lesson_show(user, can_view_teacher_markdown)
     super.merge(
       {
         question: question

--- a/dashboard/app/models/levels/multi.rb
+++ b/dashboard/app/models/levels/multi.rb
@@ -66,7 +66,7 @@ class Multi < Match
     return question_text
   end
 
-  def summarize_for_lesson_show(can_view_teacher_markdown)
+  def summarize_for_lesson_show(user, can_view_teacher_markdown)
     super.merge(
       {
         questionText: get_question_text

--- a/dashboard/app/models/levels/standalone_video.rb
+++ b/dashboard/app/models/levels/standalone_video.rb
@@ -81,7 +81,7 @@ class StandaloneVideo < Level
     )
   end
 
-  def summarize_for_lesson_show(can_view_teacher_markdown)
+  def summarize_for_lesson_show(user, can_view_teacher_markdown)
     super.merge(
       {
         longInstructions: localized_long_instructions

--- a/dashboard/app/models/script_level.rb
+++ b/dashboard/app/models/script_level.rb
@@ -451,10 +451,10 @@ class ScriptLevel < ApplicationRecord
     summary
   end
 
-  def summarize_for_lesson_show(can_view_teacher_markdown)
+  def summarize_for_lesson_show(user, can_view_teacher_markdown)
     summary = summarize
     summary[:id] = id.to_s
-    summary[:levels] = levels.map {|l| l.summarize_for_lesson_show(can_view_teacher_markdown)}
+    summary[:levels] = levels.map {|l| l.summarize_for_lesson_show(user, can_view_teacher_markdown)}
     summary
   end
 

--- a/dashboard/test/models/activity_section_test.rb
+++ b/dashboard/test/models/activity_section_test.rb
@@ -49,7 +49,7 @@ class ActivitySectionTest < ActiveSupport::TestCase
     activity_section = create :activity_section
     Services::MarkdownPreprocessor.expects(:process!).
       with(activity_section.description)
-    activity_section.summarize_for_lesson_show(false)
+    activity_section.summarize_for_lesson_show(nil, false)
   end
 
   test 'seeding_key' do

--- a/dashboard/test/models/blockly_test.rb
+++ b/dashboard/test/models/blockly_test.rb
@@ -642,7 +642,7 @@ XML
       game_id: Game.by_name('Maze')
     )
     I18n.backend.store_translations test_locale, custom_i18n
-    summary = level.summarize_for_lesson_show(false)
+    summary = level.summarize_for_lesson_show(nil, false)
     assert_equal 'translated long instructions', summary[:longInstructions]
     assert_equal 'translated short instructions', summary[:shortInstructions]
   end


### PR DESCRIPTION
Every lesson (in a migrated script) with an external markdown level gives a sad bee on the lesson plan page. This was introduced in #39628. The stack trace is below but the fix is to pass the user into `localized_replaced_markdown`, which requires passing the user from the controller down through the stack.

Stack trace of error:
```
ArgumentError at /s/coursef-2021/lessons/5
==========================================

> wrong number of arguments (given 0, expected 1)

app/models/levels/external.rb, line 61
--------------------------------------

ruby
   56       true
   57     end
   58   
   59     # returns a version of the markdown for this level in which
   60     # USER_ID_REPLACE_STRING is replaced by the current user's id
>  61     def localized_replaced_markdown(user)
   62       user_id = user.try(:id).to_s
   63       localized_markdown = localized_property('markdown')
   64       return localized_markdown.gsub(USER_ID_REPLACE_STRING, user_id)
   65     end
   66   


App backtrace
-------------

 - app/models/levels/external.rb:61:in `localized_replaced_markdown'
 - app/models/levels/external.rb:78:in `summarize_for_lesson_show'
 - app/models/script_level.rb:457:in `block in summarize_for_lesson_show'
 - app/models/script_level.rb:457:in `map'
```

## Links

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

<!--
- spec: []()
- jira ticket: []()
-->

## Testing story

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
