### PR TITLE
[AiLab] Display min/max values for continuous features

### DIFF
--- a/apps/src/applab/ai.js
+++ b/apps/src/applab/ai.js
@@ -17,6 +17,7 @@ function generateCodeDesignElements(modelId, modelData) {
     label.style.width = '300px';
     y = y + SPACER_PIXELS;
     if (Object.keys(modelData.featureNumberKey).includes(feature)) {
+      // create dropdown menu for each categorical feature
       label.textContent = feature + ':';
       fieldId = alphaNumFeature + '_dropdown';
       var select = designMode.createElement('DROPDOWN', x, y);
@@ -31,10 +32,13 @@ function generateCodeDesignElements(modelId, modelData) {
       });
       y = y + SPACER_PIXELS;
     } else {
+      // create text input field for each continuous feature
       label.textContent = feature;
       var labelMinMax = designMode.createElement('LABEL', x, y);
+      // return a string of min and max values rounded to two decimal places
       var min = modelData.extremumsByColumn[feature].min.toFixed(2);
       var max = modelData.extremumsByColumn[feature].max.toFixed(2);
+      // unary plus operator returns a number and truncates trailing zeroes
       labelMinMax.textContent = `(min: ${+min}, max: ${+max}):`;
       labelMinMax.style.width = '300px';
       y = y + SPACER_PIXELS;
@@ -47,6 +51,7 @@ function generateCodeDesignElements(modelId, modelData) {
     inputFields.push(addFeature);
   });
   y = y + 2 * SPACER_PIXELS;
+  // predicted feature
   var label = designMode.createElement('LABEL', x, y);
   label.textContent = modelData.labelColumn;
   var alphaNumModelName = stripSpaceAndSpecial(modelData.name);
@@ -54,9 +59,11 @@ function generateCodeDesignElements(modelId, modelData) {
   label.style.width = '300px';
   y = y + SPACER_PIXELS;
   var predictionId = alphaNumModelName + '_prediction';
+  // text input field to display prediction
   var prediction = designMode.createElement('TEXT_INPUT', x, y);
   prediction.id = 'design_' + predictionId;
   y = y + 2 * SPACER_PIXELS;
+  // predict button
   var predictButton = designMode.createElement('BUTTON', x, y);
   predictButton.textContent = 'Predict';
   var predictButtonId = alphaNumModelName + '_predict';

--- a/apps/src/applab/ai.js
+++ b/apps/src/applab/ai.js
@@ -31,13 +31,13 @@ function generateCodeDesignElements(modelId, modelData) {
       });
       y = y + SPACER_PIXELS;
     } else {
+      label.textContent = feature;
       var labelMinMax = designMode.createElement('LABEL', x, y);
       var min = modelData.extremumsByColumn[feature].min.toFixed(2);
       var max = modelData.extremumsByColumn[feature].max.toFixed(2);
       labelMinMax.textContent = `(min: ${+min}, max: ${+max}):`;
       labelMinMax.style.width = '300px';
       y = y + SPACER_PIXELS;
-      label.textContent = feature;
       var input = designMode.createElement('TEXT_INPUT', x, y);
       fieldId = alphaNumFeature + '_input';
       input.id = 'design_' + fieldId;

--- a/apps/src/applab/ai.js
+++ b/apps/src/applab/ai.js
@@ -32,9 +32,9 @@ function generateCodeDesignElements(modelId, modelData) {
       y = y + SPACER_PIXELS;
     } else {
       var labelMinMax = designMode.createElement('LABEL', x, y);
-      var min = +modelData.rangesByColumn[feature].min.toFixed(2);
-      var max = +modelData.rangesByColumn[feature].max.toFixed(2);
-      labelMinMax.textContent = `(min: ${min}, max: ${max}):`;
+      var min = modelData.extremumsByColumn[feature].min.toFixed(2);
+      var max = modelData.extremumsByColumn[feature].max.toFixed(2);
+      labelMinMax.textContent = `(min: ${+min}, max: ${+max}):`;
       labelMinMax.style.width = '300px';
       y = y + SPACER_PIXELS;
       label.textContent = feature;

--- a/apps/src/applab/ai.js
+++ b/apps/src/applab/ai.js
@@ -13,11 +13,11 @@ function generateCodeDesignElements(modelId, modelData) {
     var label = designMode.createElement('LABEL', x, y);
     var alphaNumFeature = stripSpaceAndSpecial(feature);
     let fieldId;
-    label.textContent = feature + ':';
     label.id = 'design_' + alphaNumFeature + '_label';
     label.style.width = '300px';
     y = y + SPACER_PIXELS;
     if (Object.keys(modelData.featureNumberKey).includes(feature)) {
+      label.textContent = feature + ':';
       fieldId = alphaNumFeature + '_dropdown';
       var select = designMode.createElement('DROPDOWN', x, y);
       select.id = 'design_' + fieldId;
@@ -31,6 +31,11 @@ function generateCodeDesignElements(modelId, modelData) {
       });
       y = y + SPACER_PIXELS;
     } else {
+      label.textContent = feature;
+      label.minMaxContent = `
+      (min: ${+modelData.rangesByColumn[feature].min.toFixed(
+        2
+      )} max: ${+modelData.rangesByColumn[feature].max.toFixed(2)}):`;
       var input = designMode.createElement('TEXT_INPUT', x, y);
       fieldId = alphaNumFeature + '_input';
       input.id = 'design_' + fieldId;

--- a/apps/src/applab/ai.js
+++ b/apps/src/applab/ai.js
@@ -21,7 +21,7 @@ function generateCodeDesignElements(modelId, modelData) {
       fieldId = alphaNumFeature + '_dropdown';
       var select = designMode.createElement('DROPDOWN', x, y);
       select.id = 'design_' + fieldId;
-      // App Lab automatically addss "option 1" and "option 2", remove them.
+      // App Lab automatically adds "option 1" and "option 2", remove them.
       select.options.remove(0);
       select.options.remove(0);
       Object.keys(modelData.featureNumberKey[feature]).forEach(option => {
@@ -31,11 +31,13 @@ function generateCodeDesignElements(modelId, modelData) {
       });
       y = y + SPACER_PIXELS;
     } else {
+      var labelMinMax = designMode.createElement('LABEL', x, y);
+      var min = +modelData.rangesByColumn[feature].min.toFixed(2);
+      var max = +modelData.rangesByColumn[feature].max.toFixed(2);
+      labelMinMax.textContent = `(min: ${min}, max: ${max}):`;
+      labelMinMax.style.width = '300px';
+      y = y + SPACER_PIXELS;
       label.textContent = feature;
-      label.minMaxContent = `
-      (min: ${+modelData.rangesByColumn[feature].min.toFixed(
-        2
-      )} max: ${+modelData.rangesByColumn[feature].max.toFixed(2)}):`;
       var input = designMode.createElement('TEXT_INPUT', x, y);
       fieldId = alphaNumFeature + '_input';
       input.id = 'design_' + fieldId;


### PR DESCRIPTION
This change provides context for continuous features by displaying the min/max values to users. 

Before: 
![before1](https://user-images.githubusercontent.com/40412372/112701028-baf1ce80-8e4c-11eb-9e1b-671c6861870b.png)

After: 
![after1](https://user-images.githubusercontent.com/40412372/112701049-c7762700-8e4c-11eb-91ff-84cd46eb4354.png)

During manual testing, the min/max information for features with longer names was truncated. This PR also fixes this hidden overflow issue. 

Before: 
![before2](https://user-images.githubusercontent.com/40412372/112701212-45d2c900-8e4d-11eb-8f85-8b3500f605e6.png)

After (final): 
![after2](https://user-images.githubusercontent.com/40412372/112701239-55521200-8e4d-11eb-8c7d-5a3e417c777f.png)



 
Related PR: https://github.com/code-dot-org/ml-playground/pull/126