### PR TITLE
Fix lesson navigation dropdown closing when clicking the last item

### DIFF
--- a/apps/src/templates/DropdownButton.js
+++ b/apps/src/templates/DropdownButton.js
@@ -1,9 +1,9 @@
 import React, {Component} from 'react';
-import ReactDOM from 'react-dom';
 import PropTypes from 'prop-types';
 import Radium from 'radium';
 import color from '@cdo/apps/util/color';
 import Button from '@cdo/apps/templates/Button';
+import onClickOutside from 'react-onclickoutside';
 
 const styles = {
   main: {
@@ -45,7 +45,7 @@ const styles = {
  * A button that drops down to a set of clickable links, and closes itself if
  * you click on the button, or outside of the dropdown.
  */
-class DropdownButton extends Component {
+export const DropdownButton = class DropdownButtonComponent extends Component {
   static propTypes = {
     text: PropTypes.string.isRequired,
     color: PropTypes.oneOf(Object.values(Button.ButtonColor)).isRequired,
@@ -67,25 +67,15 @@ class DropdownButton extends Component {
     dropdownOpen: false
   };
 
-  onComponentDidUnmount() {
-    document.removeEventListener('click', this.onClickDocument, false);
-  }
-
   expandDropdown = () => {
-    document.addEventListener('click', this.onClickDocument, false);
     this.setState({dropdownOpen: true});
   };
 
   collapseDropdown = () => {
-    document.removeEventListener('click', this.onClickDocument, false);
     this.setState({dropdownOpen: false});
   };
 
-  onClickDocument = event => {
-    // We're only concerned with clicks outside of ourselves
-    if (ReactDOM.findDOMNode(this).contains(event.target)) {
-      return;
-    }
+  handleClickOutside = () => {
     if (this.state.dropdownOpen) {
       this.collapseDropdown();
     }
@@ -135,7 +125,7 @@ class DropdownButton extends Component {
         />
 
         {dropdownOpen && (
-          <div style={styles.dropdown}>
+          <div style={styles.dropdown} ref={ref => (this.dropdownList = ref)}>
             {this.props.children.map((child, index) => (
               <a
                 {...child.props}
@@ -153,6 +143,6 @@ class DropdownButton extends Component {
       </div>
     );
   }
-}
+};
 
-export default Radium(DropdownButton);
+export default onClickOutside(Radium(DropdownButton));

--- a/apps/test/unit/templates/DropdownButtonTest.js
+++ b/apps/test/unit/templates/DropdownButtonTest.js
@@ -2,7 +2,7 @@ import {assert} from '../../util/deprecatedChai';
 import React from 'react';
 import {shallow} from 'enzyme';
 import sinon from 'sinon';
-import DropdownButton from '@cdo/apps/templates/DropdownButton';
+import {DropdownButton} from '@cdo/apps/templates/DropdownButton';
 import Button from '@cdo/apps/templates/Button';
 
 const clickSpy = sinon.spy();

--- a/apps/test/unit/templates/lessonOverview/LessonNavigationDropdownTest.jsx
+++ b/apps/test/unit/templates/lessonOverview/LessonNavigationDropdownTest.jsx
@@ -2,6 +2,7 @@ import React from 'react';
 import {shallow} from 'enzyme';
 import {expect} from '../../../util/reconfiguredChai';
 import LessonNavigationDropdown from '@cdo/apps/templates/lessonOverview/LessonNavigationDropdown';
+import DropdownButton from '@cdo/apps/templates/DropdownButton';
 import sinon from 'sinon';
 import * as utils from '@cdo/apps/utils';
 
@@ -52,7 +53,7 @@ describe('LessonNavigationDropdown', () => {
   it('renders dropdown for short lesson list', () => {
     lesson.unit.lessons = shortLessonList;
     const wrapper = shallow(<LessonNavigationDropdown lesson={lesson} />);
-    expect(wrapper.find('DropdownButton').length).to.equal(1);
+    expect(wrapper.find(DropdownButton).length).to.equal(1);
     expect(wrapper.find('a').length).to.equal(2);
 
     expect(wrapper.contains('1 - Lesson 1')).to.be.true;
@@ -62,7 +63,7 @@ describe('LessonNavigationDropdown', () => {
   it('renders dropdown for long lesson list', () => {
     lesson.unit.lessons = longLessonList;
     const wrapper = shallow(<LessonNavigationDropdown lesson={lesson} />);
-    expect(wrapper.find('DropdownButton').length).to.equal(1);
+    expect(wrapper.find(DropdownButton).length).to.equal(1);
     expect(wrapper.find('a').length).to.equal(12);
 
     expect(wrapper.contains('Lessons 1 to 10')).to.be.true;

--- a/apps/test/unit/templates/teacherDashboard/TeacherDashboardHeaderTest.js
+++ b/apps/test/unit/templates/teacherDashboard/TeacherDashboardHeaderTest.js
@@ -3,6 +3,7 @@ import i18n from '@cdo/locale';
 import {shallow} from 'enzyme';
 import {expect} from '../../../util/deprecatedChai';
 import {UnconnectedTeacherDashboardHeader as TeacherDashboardHeader} from '@cdo/apps/templates/teacherDashboard/TeacherDashboardHeader';
+import DropdownButton from '@cdo/apps/templates/DropdownButton';
 import FontAwesome from '@cdo/apps/templates/FontAwesome';
 
 // Note: The UnconnectedTeacherDashboadHeader assumes the sections it receives
@@ -75,7 +76,7 @@ describe('TeacherDashboardHeader', () => {
 
   it('renders dropdown button with links to sections, highlighting current section', () => {
     const wrapper = shallow(<TeacherDashboardHeader {...DEFAULT_PROPS} />);
-    let dropdownButton = wrapper.find('DropdownButton');
+    let dropdownButton = wrapper.find(DropdownButton);
     expect(dropdownButton).to.have.lengthOf(1);
 
     let dropdownLinks = dropdownButton.find('a');


### PR DESCRIPTION
I believe the root cause here is that the document on click handler runs _after_ the items in the dropdown are recalculated. If the dropdown is shorten during that recalculation, then the on click handler will register that the click was outside of the dropdown. I verified this by creating a script with 20 lessons and the bug doesn't repro.

I couldn't think of a way of fixing this using react refs so I'm going with the direct of using the `onClickOutside` library. I spun up an adhoc to test this on IE as our UI test doesn't run on IE to verify that it works.


https://user-images.githubusercontent.com/46464143/112904373-b708bb00-909d-11eb-9977-e0a5c80af81b.mov



## Links

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

<!--
- spec: []()
- jira ticket: []()
-->

## Testing story

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
