### PR TITLE
Bump Blockly to 3.5.34

### DIFF
--- a/apps/package.json
+++ b/apps/package.json
@@ -49,7 +49,7 @@
     "@babel/preset-react": "^7.0.0",
     "@cdo/interpreted": "link:../dashboard/config/libraries",
     "@code-dot-org/artist": "0.2.1",
-    "@code-dot-org/blockly": "3.5.33",
+    "@code-dot-org/blockly": "3.5.34",
     "@code-dot-org/craft": "0.2.2",
     "@code-dot-org/dance-party": "1.0.3",
     "@code-dot-org/johnny-five": "0.11.1-cdo.2",

--- a/apps/yarn.lock
+++ b/apps/yarn.lock
@@ -1568,10 +1568,10 @@
   version "0.2.1"
   resolved "https://registry.yarnpkg.com/@code-dot-org/artist/-/artist-0.2.1.tgz#fcfe7ea5cfb3f19ddb6b912e70e922ba4b7ef0b1"
 
-"@code-dot-org/blockly@3.5.33":
-  version "3.5.33"
-  resolved "https://registry.yarnpkg.com/@code-dot-org/blockly/-/blockly-3.5.33.tgz#cf7cf61eeb7f4d10aebcedb1307bf35c12f3d052"
-  integrity sha512-KGFYKhGZ2UrRzqxkL0cvY85DUIPLUh1jCu9EUyfYYhEHcqICUnM52Jd3w0b8q53sMyKqktxGExI20dXG7QR6RQ==
+"@code-dot-org/blockly@3.5.34":
+  version "3.5.34"
+  resolved "https://registry.yarnpkg.com/@code-dot-org/blockly/-/blockly-3.5.34.tgz#5ae60e57616928ccee70c3c8542496645607ff4e"
+  integrity sha512-/gtryo3Ax7mfifZAnvovsD9a10tto2+loETMn2FCM3HYjF+jqCehr0R3ktymHKoVuQEmUy/Bv9+uNqGeGw5W7w==
 
 "@code-dot-org/craft@0.2.2":
   version "0.2.2"


### PR DESCRIPTION
Pulls in
[Don't crop images in field image dropdowns](https://github.com/code-dot-org/blockly/pull/263)
[FND-1377 Flyout subject blocks outside display area in RTL](https://github.com/code-dot-org/blockly/pull/265)
[FND-22: added a condition for positioning inline blocks in RLT context](https://github.com/code-dot-org/blockly/pull/262)
[Refresh previews on image dropdown when animations change](https://github.com/code-dot-org/blockly/pull/268)

Required for https://github.com/code-dot-org/code-dot-org/pull/39724