### PR TITLE
Fix the save buttons for level saving to bottom of screen

### DIFF
--- a/dashboard/app/views/levels/edit.html.haml
+++ b/dashboard/app/views/levels/edit.html.haml
@@ -63,18 +63,19 @@
 
   .field
     = f.hidden_field :published
-  .actions
-    = f.submit 'Save and publish your completed work', {:class => 'publishLevel', :style => "background-color: #f0c14b; margin-bottom: 10px"}
-    %p Or, save, publish, and return to:
-    %ul
-      - @level.script_levels.each do |script_level|
-        %li
-          = f.submit build_script_level_path(script_level), {:class=> 'publishLevel', :name => "redirect", :style => "font-family: monospace; margin-bottom: 10px"}
-      - BubbleChoice.parent_levels(@level.name).each do |parent_level|
-        - parent_level.script_levels.each do |script_level|
+  .actions{style: "position: fixed; bottom: 0px; width: 100%; background-color: rgb(231, 232, 234); left: 0px; z-index: 900; display: flex; justify-content: flex-end; margin: 0px; align-items: center"}
+    = f.submit 'Save and publish your completed work', {:class => 'publishLevel', :style => "background-color: #f0c14b; margin-bottom: 10px; height: 35px"}
+    %div{style: "display: flex; flex-direction: column; padding: 10px 10px 0px 10px"}
+      %p Or, save, publish, and return to:
+      %ul
+        - @level.script_levels.each do |script_level|
           %li
-            - position = parent_level.sublevel_position(@level)
-            = f.submit build_script_level_path(script_level, sublevel_position: position), {:class=> 'publishLevel', :name => "redirect", :style => "font-family: monospace; margin-bottom: 10px"}
+            = f.submit build_script_level_path(script_level), {:class=> 'publishLevel', :name => "redirect", :style => "font-family: monospace; margin-bottom: 10px"}
+        - BubbleChoice.parent_levels(@level.name).each do |parent_level|
+          - parent_level.script_levels.each do |script_level|
+            %li
+              - position = parent_level.sublevel_position(@level)
+              = f.submit build_script_level_path(script_level, sublevel_position: position), {:class=> 'publishLevel', :name => "redirect", :style => "font-family: monospace; margin-bottom: 10px"}
 
 %pre#validation-error.validation-error{style: 'background-color: yellow; display: none'}
 :javascript


### PR DESCRIPTION
Makes the save buttons for level saving live in a fixed permanent position at the bottom of the screen like we do for lesson edit. 

<img width="1218" alt="Screen Shot 2021-03-29 at 1 11 51 PM" src="https://user-images.githubusercontent.com/208083/112874130-8a01db80-9090-11eb-9aa7-2b234e570ed6.png">