### PR TITLE
add opportunity standards editor to lesson edit page

### DIFF
--- a/apps/src/lib/levelbuilder/lesson-editor/LessonEditor.jsx
+++ b/apps/src/lib/levelbuilder/lesson-editor/LessonEditor.jsx
@@ -182,7 +182,7 @@ class LessonEditor extends Component {
       preparation,
       announcements
     } = this.state;
-    const {relatedLessons} = this.props;
+    const {relatedLessons, standards} = this.props;
     return (
       <div style={styles.editor}>
         <h1>Editing Lesson "{displayName}"</h1>
@@ -441,7 +441,10 @@ class LessonEditor extends Component {
               collapsed={true}
               fullwidth={true}
             >
-              <StandardsEditor standardType={'standard'} />
+              <StandardsEditor
+                standardType={'standard'}
+                standards={standards}
+              />
             </CollapsibleEditorSection>
           </div>
         )}

--- a/apps/src/lib/levelbuilder/lesson-editor/LessonEditor.jsx
+++ b/apps/src/lib/levelbuilder/lesson-editor/LessonEditor.jsx
@@ -69,6 +69,7 @@ class LessonEditor extends Component {
     programmingExpressions: PropTypes.arrayOf(programmingExpressionShape)
       .isRequired,
     standards: PropTypes.arrayOf(standardShape).isRequired,
+    opportunityStandards: PropTypes.arrayOf(standardShape).isRequired,
     initActivities: PropTypes.func.isRequired
   };
 
@@ -128,6 +129,7 @@ class LessonEditor extends Component {
           this.props.programmingExpressions
         ),
         standards: JSON.stringify(this.props.standards),
+        opportunityStandards: JSON.stringify(this.props.opportunityStandards),
         announcements: JSON.stringify(this.state.announcements),
         originalLessonData: JSON.stringify(this.state.originalLessonData)
       })
@@ -182,7 +184,7 @@ class LessonEditor extends Component {
       preparation,
       announcements
     } = this.state;
-    const {relatedLessons, standards} = this.props;
+    const {relatedLessons, standards, opportunityStandards} = this.props;
     return (
       <div style={styles.editor}>
         <h1>Editing Lesson "{displayName}"</h1>
@@ -445,6 +447,11 @@ class LessonEditor extends Component {
                 standardType={'standard'}
                 standards={standards}
               />
+              <h3>Opportunity Standards</h3>
+              <StandardsEditor
+                standardType={'opportunityStandard'}
+                standards={opportunityStandards}
+              />
             </CollapsibleEditorSection>
           </div>
         )}
@@ -471,7 +478,8 @@ export default connect(
     resources: state.resources,
     vocabularies: state.vocabularies,
     programmingExpressions: state.programmingExpressions,
-    standards: state.standards
+    standards: state.standards,
+    opportunityStandards: state.opportunityStandards
   }),
   {
     initActivities

--- a/apps/src/lib/levelbuilder/lesson-editor/LessonEditor.jsx
+++ b/apps/src/lib/levelbuilder/lesson-editor/LessonEditor.jsx
@@ -441,7 +441,7 @@ class LessonEditor extends Component {
               collapsed={true}
               fullwidth={true}
             >
-              <StandardsEditor />
+              <StandardsEditor standardType={'standard'} />
             </CollapsibleEditorSection>
           </div>
         )}

--- a/apps/src/lib/levelbuilder/lesson-editor/StandardsEditor.jsx
+++ b/apps/src/lib/levelbuilder/lesson-editor/StandardsEditor.jsx
@@ -35,9 +35,9 @@ const styles = {
 class StandardsEditor extends Component {
   static propTypes = {
     standardType: PropTypes.string.isRequired,
+    standards: PropTypes.arrayOf(standardShape).isRequired,
 
     // provided by redux
-    standards: PropTypes.arrayOf(standardShape).isRequired,
     addStandard: PropTypes.func.isRequired,
     removeStandard: PropTypes.func.isRequired
   };
@@ -239,9 +239,7 @@ class StandardsEditor extends Component {
 export const UnconnectedStandardsEditor = StandardsEditor;
 
 export default connect(
-  state => ({
-    standards: state.standards
-  }),
+  state => ({}),
   {
     addStandard,
     removeStandard

--- a/apps/src/lib/levelbuilder/lesson-editor/StandardsEditor.jsx
+++ b/apps/src/lib/levelbuilder/lesson-editor/StandardsEditor.jsx
@@ -140,8 +140,7 @@ class StandardsEditor extends Component {
   };
 
   removeStandard = () => {
-    const {frameworkShortcode, shortcode} = this.state.standardToRemove;
-    this.props.removeStandard(frameworkShortcode, shortcode);
+    this.props.removeStandard('standard', this.state.standardToRemove);
     this.handleRemoveStandardDialogClose();
   };
 
@@ -170,7 +169,7 @@ class StandardsEditor extends Component {
   };
 
   onSearchSelect = option => {
-    this.props.addStandard(option.standard);
+    this.props.addStandard('standard', option.standard);
   };
 
   render() {

--- a/apps/src/lib/levelbuilder/lesson-editor/StandardsEditor.jsx
+++ b/apps/src/lib/levelbuilder/lesson-editor/StandardsEditor.jsx
@@ -34,6 +34,8 @@ const styles = {
 
 class StandardsEditor extends Component {
   static propTypes = {
+    standardType: PropTypes.string.isRequired,
+
     // provided by redux
     standards: PropTypes.arrayOf(standardShape).isRequired,
     addStandard: PropTypes.func.isRequired,
@@ -140,7 +142,10 @@ class StandardsEditor extends Component {
   };
 
   removeStandard = () => {
-    this.props.removeStandard('standard', this.state.standardToRemove);
+    this.props.removeStandard(
+      this.props.standardType,
+      this.state.standardToRemove
+    );
     this.handleRemoveStandardDialogClose();
   };
 
@@ -169,7 +174,7 @@ class StandardsEditor extends Component {
   };
 
   onSearchSelect = option => {
-    this.props.addStandard('standard', option.standard);
+    this.props.addStandard(this.props.standardType, option.standard);
   };
 
   render() {

--- a/apps/src/lib/levelbuilder/lesson-editor/standardsEditorRedux.js
+++ b/apps/src/lib/levelbuilder/lesson-editor/standardsEditorRedux.js
@@ -4,42 +4,52 @@ const INIT = 'standardsEditor/INIT';
 const ADD_STANDARD = 'standardsEditor/ADD_STANDARD';
 const REMOVE_STANDARD = 'standardsEditor/REMOVE_STANDARD';
 
-export const initStandards = standards => ({
+export const initStandards = (standardType, standards) => ({
   type: INIT,
+  standardType,
   standards
 });
 
-export const addStandard = newStandard => ({
+export const addStandard = (standardType, newStandard) => ({
   type: ADD_STANDARD,
+  standardType,
   newStandard
 });
 
-export const removeStandard = (frameworkShortcode, shortcode) => ({
+export const removeStandard = (standardType, standard) => ({
   type: REMOVE_STANDARD,
-  frameworkShortcode,
-  shortcode
+  standardType,
+  standard
 });
 
-export default function standards(state = [], action) {
-  let newState = _.cloneDeep(state);
-
-  switch (action.type) {
-    case INIT:
-      return action.standards;
-    case ADD_STANDARD: {
-      newState = newState.concat([action.newStandard]);
-      break;
+export default function createStandardsReducer(standardType) {
+  return function standards(state = [], action) {
+    // Make it possible to create two instances of this reducer which do not
+    // interfere with each other.
+    if (standardType !== action.standardType) {
+      return state;
     }
-    case REMOVE_STANDARD: {
-      const standardToRemove = newState.find(
-        standard =>
-          standard.shortcode === action.shortcode &&
-          standard.frameworkShortcode === action.frameworkShortcode
-      );
-      newState.splice(newState.indexOf(standardToRemove), 1);
-      break;
-    }
-  }
 
-  return newState;
+    let newState = _.cloneDeep(state);
+
+    switch (action.type) {
+      case INIT:
+        return action.standards;
+      case ADD_STANDARD: {
+        newState = newState.concat([action.newStandard]);
+        break;
+      }
+      case REMOVE_STANDARD: {
+        const standardToRemove = newState.find(
+          standard =>
+            standard.shortcode === action.standard.shortcode &&
+            standard.frameworkShortcode === action.standard.frameworkShortcode
+        );
+        newState.splice(newState.indexOf(standardToRemove), 1);
+        break;
+      }
+    }
+
+    return newState;
+  };
 }

--- a/apps/src/sites/studio/pages/lessons/edit.js
+++ b/apps/src/sites/studio/pages/lessons/edit.js
@@ -10,7 +10,7 @@ import reducers, {
 import resourcesEditor, {
   initResources
 } from '@cdo/apps/lib/levelbuilder/lesson-editor/resourcesEditorRedux';
-import standardsEditor, {
+import createStandardsReducer, {
   initStandards
 } from '@cdo/apps/lib/levelbuilder/lesson-editor/standardsEditorRedux';
 import vocabulariesEditor, {
@@ -37,7 +37,7 @@ $(document).ready(function() {
     resources: resourcesEditor,
     vocabularies: vocabulariesEditor,
     programmingExpressions: programmingExpressionsEditor,
-    standards: standardsEditor
+    standards: createStandardsReducer('standard')
   });
   const store = getStore();
 
@@ -49,7 +49,7 @@ $(document).ready(function() {
   store.dispatch(
     initProgrammingExpressions(lessonData.programmingExpressions || [])
   );
-  store.dispatch(initStandards(lessonData.standards || []));
+  store.dispatch(initStandards('standard', lessonData.standards || []));
 
   ReactDOM.render(
     <Provider store={store}>

--- a/apps/src/sites/studio/pages/lessons/edit.js
+++ b/apps/src/sites/studio/pages/lessons/edit.js
@@ -37,7 +37,8 @@ $(document).ready(function() {
     resources: resourcesEditor,
     vocabularies: vocabulariesEditor,
     programmingExpressions: programmingExpressionsEditor,
-    standards: createStandardsReducer('standard')
+    standards: createStandardsReducer('standard'),
+    opportunityStandards: createStandardsReducer('opportunityStandard')
   });
   const store = getStore();
 
@@ -50,6 +51,9 @@ $(document).ready(function() {
     initProgrammingExpressions(lessonData.programmingExpressions || [])
   );
   store.dispatch(initStandards('standard', lessonData.standards || []));
+  store.dispatch(
+    initStandards('opportunityStandard', lessonData.opportunityStandards || [])
+  );
 
   ReactDOM.render(
     <Provider store={store}>

--- a/apps/test/unit/lib/levelbuilder/lesson-editor/LessonEditorTest.js
+++ b/apps/test/unit/lib/levelbuilder/lesson-editor/LessonEditorTest.js
@@ -119,6 +119,7 @@ describe('LessonEditor', () => {
         .props().disabled
     ).to.equal(false);
     expect(wrapper.find('AnnouncementsEditor').length).to.equal(1);
+    expect(wrapper.find('CollapsibleEditorSection').length).to.equal(11);
     expect(wrapper.find('ResourcesEditor').length).to.equal(1);
     expect(wrapper.find('VocabulariesEditor').length).to.equal(1);
     expect(wrapper.find('ProgrammingExpressionsEditor').length).to.equal(1);

--- a/apps/test/unit/lib/levelbuilder/lesson-editor/LessonEditorTest.js
+++ b/apps/test/unit/lib/levelbuilder/lesson-editor/LessonEditorTest.js
@@ -20,7 +20,7 @@ import vocabulariesEditor, {
 import programmingExpressionsEditor, {
   initProgrammingExpressions
 } from '@cdo/apps/lib/levelbuilder/lesson-editor/programmingExpressionsEditorRedux';
-import standardsEditor, {
+import createStandardsReducer, {
   initStandards
 } from '@cdo/apps/lib/levelbuilder/lesson-editor/standardsEditorRedux';
 import {sampleActivities, searchOptions} from './activitiesTestData';
@@ -40,7 +40,8 @@ describe('LessonEditor', () => {
       resources: resourcesEditor,
       vocabularies: vocabulariesEditor,
       programmingExpressions: programmingExpressionsEditor,
-      standards: standardsEditor
+      standards: createStandardsReducer('standard'),
+      opportunityStandards: createStandardsReducer('opportunityStandard')
     });
 
     store = getStore();
@@ -105,8 +106,6 @@ describe('LessonEditor', () => {
       'purpose'
     ).to.be.true;
     expect(wrapper.find('Connect(ActivitiesEditor)').length).to.equal(1);
-    expect(wrapper.find('TextareaWithMarkdownPreview').length).to.equal(5);
-    expect(wrapper.find('input').length).to.equal(23);
     expect(
       wrapper
         .find('input')
@@ -119,13 +118,11 @@ describe('LessonEditor', () => {
         .at(2)
         .props().disabled
     ).to.equal(false);
-    expect(wrapper.find('select').length).to.equal(2);
     expect(wrapper.find('AnnouncementsEditor').length).to.equal(1);
-    expect(wrapper.find('CollapsibleEditorSection').length).to.equal(11);
     expect(wrapper.find('ResourcesEditor').length).to.equal(1);
     expect(wrapper.find('VocabulariesEditor').length).to.equal(1);
     expect(wrapper.find('ProgrammingExpressionsEditor').length).to.equal(1);
-    expect(wrapper.find('StandardsEditor').length).to.equal(1);
+    expect(wrapper.find('StandardsEditor').length).to.equal(2);
     expect(wrapper.find('SaveBar').length).to.equal(1);
   });
 

--- a/apps/test/unit/lib/levelbuilder/lesson-editor/StandardsEditorTest.js
+++ b/apps/test/unit/lib/levelbuilder/lesson-editor/StandardsEditorTest.js
@@ -29,6 +29,7 @@ describe('StandardsEditor', () => {
     addStandard = sinon.spy();
     removeStandard = sinon.spy();
     defaultProps = {
+      standardType: 'standard',
       standards: fakeStandards,
       addStandard,
       removeStandard

--- a/apps/test/unit/lib/levelbuilder/lesson-editor/standardsEditorReduxTest.js
+++ b/apps/test/unit/lib/levelbuilder/lesson-editor/standardsEditorReduxTest.js
@@ -1,5 +1,5 @@
 import {assert} from 'chai';
-import standardsEditor, {
+import createStandardsEditor, {
   addStandard,
   removeStandard
 } from '@cdo/apps/lib/levelbuilder/lesson-editor/standardsEditorRedux';
@@ -27,13 +27,16 @@ const fakeStandards = [
 const getInitialState = () => _.cloneDeep(fakeStandards);
 
 describe('standardsEditorRedux reducer', () => {
-  let initialState;
-  beforeEach(() => (initialState = getInitialState()));
+  let initialState, standardsEditor;
+  beforeEach(() => {
+    standardsEditor = createStandardsEditor('standard');
+    initialState = getInitialState();
+  });
 
   it('add standard', () => {
     const nextState = standardsEditor(
       initialState,
-      addStandard({
+      addStandard('standard', {
         frameworkShortcode: 'framework-1',
         frameworkName: 'Framework One',
         categoryShortcode: 'CS',
@@ -52,7 +55,10 @@ describe('standardsEditorRedux reducer', () => {
   it('removes standard', () => {
     const nextState = standardsEditor(
       initialState,
-      removeStandard('framework-1', 'shortcode-1')
+      removeStandard('standard', {
+        frameworkShortcode: 'framework-1',
+        shortcode: 'shortcode-1'
+      })
     );
     assert.deepEqual(nextState.map(s => s.shortcode), ['shortcode-2']);
   });

--- a/apps/test/unit/lib/levelbuilder/lesson-editor/standardsEditorReduxTest.js
+++ b/apps/test/unit/lib/levelbuilder/lesson-editor/standardsEditorReduxTest.js
@@ -27,23 +27,26 @@ const fakeStandards = [
 const getInitialState = () => _.cloneDeep(fakeStandards);
 
 describe('standardsEditorRedux reducer', () => {
-  let initialState, standardsEditor;
+  let initialState, standardsEditor, opportunityStandardsEditor, newStandard;
   beforeEach(() => {
     standardsEditor = createStandardsEditor('standard');
+    opportunityStandardsEditor = createStandardsEditor('opportunityStandard');
+    newStandard = {
+      frameworkShortcode: 'framework-1',
+      frameworkName: 'Framework One',
+      categoryShortcode: 'CS',
+      categoryDescription: 'Computing Systems',
+      shortcode: 'new-1',
+      description: 'fake description'
+    };
+
     initialState = getInitialState();
   });
 
-  it('add standard', () => {
+  it('adds standard', () => {
     const nextState = standardsEditor(
       initialState,
-      addStandard('standard', {
-        frameworkShortcode: 'framework-1',
-        frameworkName: 'Framework One',
-        categoryShortcode: 'CS',
-        categoryDescription: 'Computing Systems',
-        shortcode: 'new-1',
-        description: 'fake description'
-      })
+      addStandard('standard', newStandard)
     );
     assert.deepEqual(nextState.map(s => s.shortcode), [
       'shortcode-1',
@@ -61,5 +64,26 @@ describe('standardsEditorRedux reducer', () => {
       })
     );
     assert.deepEqual(nextState.map(s => s.shortcode), ['shortcode-2']);
+  });
+
+  it('adds opportunity standard without adding regular standard', () => {
+    let nextState = opportunityStandardsEditor(
+      initialState,
+      addStandard('opportunityStandard', newStandard)
+    );
+    assert.deepEqual(nextState.map(s => s.shortcode), [
+      'shortcode-1',
+      'shortcode-2',
+      'new-1'
+    ]);
+
+    nextState = standardsEditor(
+      initialState,
+      addStandard('opportunityStandard', newStandard)
+    );
+    assert.deepEqual(nextState.map(s => s.shortcode), [
+      'shortcode-1',
+      'shortcode-2'
+    ]);
   });
 });

--- a/dashboard/app/controllers/lessons_controller.rb
+++ b/dashboard/app/controllers/lessons_controller.rb
@@ -78,13 +78,15 @@ class LessonsController < ApplicationController
     end
 
     standards = fetch_standards(lesson_params['standards'] || [])
+    opportunity_standards = fetch_standards(lesson_params['opportunity_standards'] || [])
     programming_expressions = fetch_programming_expressions(lesson_params['programming_expressions'] || [])
     ActiveRecord::Base.transaction do
       @lesson.resources = resources.compact
       @lesson.vocabularies = vocabularies.compact
       @lesson.standards = standards.compact
+      @lesson.opportunity_standards = opportunity_standards.compact
       @lesson.programming_expressions = programming_expressions.compact
-      @lesson.update!(lesson_params.except(:resources, :vocabularies, :objectives, :standards, :programming_expressions, :original_lesson_data))
+      @lesson.update!(lesson_params.except(:resources, :vocabularies, :objectives, :standards, :opportunity_standards, :programming_expressions, :original_lesson_data))
       @lesson.update_activities(JSON.parse(params[:activities])) if params[:activities]
       @lesson.update_objectives(JSON.parse(params[:objectives])) if params[:objectives]
 
@@ -142,13 +144,19 @@ class LessonsController < ApplicationController
       :vocabularies,
       :programming_expressions,
       :objectives,
-      :standards
+      :standards,
+      :opportunity_standards
     )
     lp[:announcements] = JSON.parse(lp[:announcements]) if lp[:announcements]
     lp[:resources] = JSON.parse(lp[:resources]) if lp[:resources]
     lp[:vocabularies] = JSON.parse(lp[:vocabularies]) if lp[:vocabularies]
     lp[:programming_expressions] = JSON.parse(lp[:programming_expressions]) if lp[:programming_expressions]
     lp[:standards] = JSON.parse(lp[:standards]) if lp[:standards]
+    lp[:opportunity_standards] = JSON.parse(lp[:opportunity_standards]) if lp[:opportunity_standards]
+    # puts 'standards'
+    # puts lp[:standards].inspect
+    # puts 'opportunity_standards'
+    # puts lp[:opportunity_standards].inspect
     lp
   end
 

--- a/dashboard/app/controllers/lessons_controller.rb
+++ b/dashboard/app/controllers/lessons_controller.rb
@@ -153,10 +153,6 @@ class LessonsController < ApplicationController
     lp[:programming_expressions] = JSON.parse(lp[:programming_expressions]) if lp[:programming_expressions]
     lp[:standards] = JSON.parse(lp[:standards]) if lp[:standards]
     lp[:opportunity_standards] = JSON.parse(lp[:opportunity_standards]) if lp[:opportunity_standards]
-    # puts 'standards'
-    # puts lp[:standards].inspect
-    # puts 'opportunity_standards'
-    # puts lp[:opportunity_standards].inspect
     lp
   end
 

--- a/dashboard/app/models/lesson.rb
+++ b/dashboard/app/models/lesson.rb
@@ -365,6 +365,7 @@ class Lesson < ApplicationRecord
       programmingExpressions: programming_expressions.map(&:summarize_for_lesson_edit),
       objectives: objectives.map(&:summarize_for_edit),
       standards: standards.map(&:summarize_for_lesson_edit),
+      opportunityStandards: opportunity_standards.map(&:summarize_for_lesson_edit),
       courseVersionId: lesson_group.script.get_course_version&.id,
       scriptIsVisible: !script.hidden,
       scriptPath: script_path(script),

--- a/dashboard/test/controllers/lessons_controller_test.rb
+++ b/dashboard/test/controllers/lessons_controller_test.rb
@@ -875,6 +875,25 @@ class LessonsControllerTest < ActionController::TestCase
     refute @lesson.standards.include?(standard_to_remove)
   end
 
+  test 'update lesson removing and adding opportunity standards' do
+    standard_to_keep = create :standard
+    standard_to_add = create :standard
+    standard_to_remove = create :standard
+
+    @lesson.opportunity_standards << standard_to_keep
+    @lesson.opportunity_standards << standard_to_remove
+
+    sign_in @levelbuilder
+    new_standards_data = [standard_to_add, standard_to_keep].map(&:summarize_for_lesson_edit).to_json
+    new_update_params = @update_params.merge({opportunityStandards: new_standards_data})
+    put :update, params: new_update_params
+    @lesson.reload
+    assert_equal 2, @lesson.opportunity_standards.count
+    assert @lesson.opportunity_standards.include?(standard_to_add)
+    assert @lesson.opportunity_standards.include?(standard_to_keep)
+    refute @lesson.opportunity_standards.include?(standard_to_remove)
+  end
+
   test 'lesson is not partially updated if any data is bad' do
     resource = create :resource
 


### PR DESCRIPTION
Continues work on [PLAT-899]. Depends on #39760. In order to reuse reducer logic without duplicating its contents, I followed one of the patterns recommended in this article: https://redux.js.org/recipes/structuring-reducers/reusing-reducer-logic

![Screen Shot 2021-03-29 at 9 56 05 AM](https://user-images.githubusercontent.com/8001765/112877830-1655d380-907c-11eb-871e-78377837c21b.png)

## Testing story

added new reducer tests and lesson update tests. also manually verified that opportunity standards can be added / removed, saved, and that those changes persist after reloading the page.

[PLAT-899]: https://codedotorg.atlassian.net/browse/PLAT-899