### PR TITLE
Add teacher markdown to level details dialog and fix some csf levels

### DIFF
--- a/apps/src/templates/lessonOverview/activities/LevelDetailsDialog.jsx
+++ b/apps/src/templates/lessonOverview/activities/LevelDetailsDialog.jsx
@@ -12,6 +12,7 @@ import Button from '@cdo/apps/templates/Button';
 import i18n from '@cdo/locale';
 import ProgressBubbleSet from '@cdo/apps/templates/progress/ProgressBubbleSet';
 import SublevelCard from '@cdo/apps/code-studio/components/SublevelCard';
+import TeacherOnlyMarkdown from '@cdo/apps/templates/instructions/TeacherOnlyMarkdown';
 import _ from 'lodash';
 import styleConstants from '@cdo/apps/styleConstants';
 import {connect} from 'react-redux';
@@ -26,6 +27,10 @@ const styles = {
   sublevelCards: {
     display: 'flex',
     flexWrap: 'wrap'
+  },
+  scrollContainer: {
+    maxHeight: '60vh',
+    overflow: 'auto'
   }
 };
 
@@ -50,12 +55,31 @@ class LevelDetailsDialog extends Component {
     };
   }
 
+  getTeacherOnlyMarkdownComponent = level => {
+    if (level.teacherMarkdown) {
+      return <TeacherOnlyMarkdown content={level.teacherMarkdown} />;
+    } else {
+      return null;
+    }
+  };
+
   getComponentContent = level => {
     if (level.type === 'External') {
-      return <SafeMarkdown markdown={level.markdown} />;
+      return (
+        <div style={styles.scrollContainer}>
+          <SafeMarkdown markdown={level.markdown} />
+          {level.videoOptions && (
+            <div
+              id={'level-details-dialog-video'}
+              ref={ref => (this.video = ref)}
+            />
+          )}
+          {this.getTeacherOnlyMarkdownComponent(level)}
+        </div>
+      );
     } else if (level.type === 'StandaloneVideo') {
       return (
-        <div>
+        <div style={styles.scrollContainer}>
           {level.longInstructions && (
             <SafeMarkdown markdown={level.longInstructions} />
           )}
@@ -63,6 +87,7 @@ class LevelDetailsDialog extends Component {
             id={'level-details-dialog-video'}
             ref={ref => (this.video = ref)}
           />
+          {this.getTeacherOnlyMarkdownComponent(level)}
         </div>
       );
     } else if (level.type === 'LevelGroup') {
@@ -83,14 +108,15 @@ class LevelDetailsDialog extends Component {
       );
     } else if (level.type === 'Match' || level.type === 'Multi') {
       return (
-        <div>
+        <div style={styles.scrollContainer}>
           {level.question && <SafeMarkdown markdown={level.question} />}
           {level.questionText && <SafeMarkdown markdown={level.questionText} />}
+          {this.getTeacherOnlyMarkdownComponent(level)}
         </div>
       );
     } else if (level.type === 'BubbleChoice') {
       return (
-        <div style={styles.sublevelCards}>
+        <div style={{...styles.scrollContainer, ...styles.sublevelCards}}>
           {this.props.scriptLevel.sublevels.map(sublevel => (
             <SublevelCard
               isLessonExtra={false}
@@ -113,7 +139,11 @@ class LevelDetailsDialog extends Component {
           isMinecraft={false}
           isBlockly={false}
           isRtl={this.props.isRtl}
-          longInstructions={level.longInstructions || level.long_instructions}
+          longInstructions={
+            level.longInstructions ||
+            level.long_instructions ||
+            level.shortInstructions
+          }
           shortInstructions={level.shortInstructions}
           noInstructionsWhenCollapsed={true}
           levelVideos={level.videos}
@@ -129,7 +159,7 @@ class LevelDetailsDialog extends Component {
           isEmbedView={false}
           mainStyle={{paddingBottom: 5}}
           containerStyle={{
-            overflowY: 'scroll',
+            overflowY: 'auto',
             height: this.state.height - HEADER_HEIGHT
           }}
           setInstructionsRenderedHeight={height =>
@@ -228,15 +258,17 @@ class LevelDetailsDialog extends Component {
     const {scriptLevel} = this.props;
     const level = this.state.selectedLevel;
     const preview = this.getComponentContent(level);
-    const levelSpecificStyling =
-      level.type === 'StandaloneVideo'
-        ? {width: VIDEO_MODAL_WIDTH, marginLeft: -VIDEO_MODAL_WIDTH / 2}
-        : {};
+    const hasVideo =
+      level.type === 'StandaloneVideo' ||
+      (level.type === 'External' && !!level.videoOptions);
+    const levelSpecificStyling = hasVideo
+      ? {width: VIDEO_MODAL_WIDTH, marginLeft: -VIDEO_MODAL_WIDTH / 2}
+      : {};
     return (
       <BaseDialog
         isOpen={true}
         handleClose={this.props.handleClose}
-        fullWidth={level.type !== 'StandaloneVideo'}
+        fullWidth={!hasVideo}
         style={{...levelSpecificStyling}}
       >
         <h1>{i18n.levelPreview()}</h1>

--- a/apps/test/unit/templates/lessonOverview/activities/LevelDetailsDialogTest.jsx
+++ b/apps/test/unit/templates/lessonOverview/activities/LevelDetailsDialogTest.jsx
@@ -6,7 +6,7 @@ import {ViewType} from '@cdo/apps/code-studio/viewAsRedux';
 import {UnconnectedLevelDetailsDialog as LevelDetailsDialog} from '@cdo/apps/templates/lessonOverview/activities/LevelDetailsDialog';
 
 describe('LevelDetailsDialogTest', () => {
-  let handleCloseSpy, defaultProps;
+  let handleCloseSpy, loadVideoSpy, defaultProps;
 
   beforeEach(() => {
     handleCloseSpy = sinon.spy();
@@ -15,6 +15,11 @@ describe('LevelDetailsDialogTest', () => {
       viewAs: ViewType.Teacher,
       isRtl: false
     };
+    loadVideoSpy = sinon.stub(LevelDetailsDialog.prototype, 'loadVideo');
+  });
+
+  afterEach(() => {
+    loadVideoSpy.restore();
   });
 
   it('calls handleClose when dismiss is clicked', () => {
@@ -65,6 +70,32 @@ describe('LevelDetailsDialogTest', () => {
     expect(wrapper.contains('This is some text.')).to.be.true;
   });
 
+  it('can display the video and teacher markdown for an external markdown level', () => {
+    const wrapper = mount(
+      <LevelDetailsDialog
+        {...defaultProps}
+        scriptLevel={{
+          url: 'level.url',
+          level: {
+            type: 'External',
+            markdown: 'This is some text.',
+            teacherMarkdown: 'This is some teacher only text.',
+            videoOptions: {url: 'video.url'}
+          }
+        }}
+      />
+    );
+    expect(loadVideoSpy.calledOnce).to.be.true;
+    expect(wrapper.contains('This is some text.')).to.be.true;
+    expect(wrapper.find('TeacherOnlyMarkdown').length).to.equal(1);
+    expect(
+      wrapper
+        .find('TeacherOnlyMarkdown')
+        .first()
+        .props().content
+    ).to.equal('This is some teacher only text.');
+  });
+
   it('can display a LevelGroup', () => {
     const wrapper = shallow(
       <LevelDetailsDialog
@@ -98,7 +129,6 @@ describe('LevelDetailsDialogTest', () => {
   });
 
   it('tries to load a video on a standalone video level', () => {
-    const loadVideoSpy = sinon.stub(LevelDetailsDialog.prototype, 'loadVideo');
     const wrapper = mount(
       <LevelDetailsDialog
         {...defaultProps}
@@ -113,6 +143,31 @@ describe('LevelDetailsDialogTest', () => {
     );
     expect(loadVideoSpy.calledOnce).to.be.true;
     expect(wrapper.contains('Some things to think about.')).to.be.true;
+  });
+
+  it('can display teacher markdown on a standalone video level', () => {
+    const wrapper = mount(
+      <LevelDetailsDialog
+        {...defaultProps}
+        scriptLevel={{
+          url: 'level.url',
+          level: {
+            type: 'StandaloneVideo',
+            longInstructions: 'Some things to think about.',
+            teacherMarkdown: 'Some things to teach about.'
+          }
+        }}
+      />
+    );
+    expect(loadVideoSpy.calledOnce).to.be.true;
+    expect(wrapper.contains('Some things to think about.')).to.be.true;
+    expect(wrapper.find('TeacherOnlyMarkdown').length).to.equal(1);
+    expect(
+      wrapper
+        .find('TeacherOnlyMarkdown')
+        .first()
+        .props().content
+    ).to.equal('Some things to teach about.');
   });
 
   it('can display a bubble choice level', () => {
@@ -243,7 +298,8 @@ describe('LevelDetailsDialogTest', () => {
               id: 'level',
               question:
                 'Look at the code below and predict how the headings will be displayed.',
-              questionText: 'Eggs, Bacon, Waffles'
+              questionText: 'Eggs, Bacon, Waffles',
+              teacherMarkdown: 'This is a multiple choice level.'
             }
           }}
         />
@@ -263,5 +319,12 @@ describe('LevelDetailsDialogTest', () => {
           .at(1)
           .props().markdown
       ).equal('Eggs, Bacon, Waffles');
+      expect(wrapper.find('TeacherOnlyMarkdown').length).to.equal(1);
+      expect(
+        wrapper
+          .find('TeacherOnlyMarkdown')
+          .first()
+          .props().content
+      ).to.equal('This is a multiple choice level.');
     };
 });


### PR DESCRIPTION
This PR does some polish on the level details dialog, particularly:
- Adds teacher markdown to standalone video levels, external markdown levels, and match/multi levels. This required some styling for scrolling as the preview would get too long.
- If an external markdown level has a video, we show the video
- CSF levels with only short instructions weren't working so I added a workaround for that. Ideally, I would do more improvements to CSF levels but this fixes a bug where the dialog wouldn't show up at all

Teacher markdown on a multi level and a standalone video, respectively:
![Screen Shot 2021-03-29 at 11 50 41 AM](https://user-images.githubusercontent.com/46464143/112885831-0e029600-9086-11eb-9822-d0641098e44c.png)

![Screen Shot 2021-03-29 at 11 51 14 AM](https://user-images.githubusercontent.com/46464143/112885851-135fe080-9086-11eb-9e35-3a98bbd24a4a.png)

External markdown level with video:
![Screen Shot 2021-03-29 at 11 59 11 AM](https://user-images.githubusercontent.com/46464143/112885984-368a9000-9086-11eb-84e4-9ef6c0878c60.png)


## Testing story

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
