### PR TITLE
Fix 'Add Image' button

### DIFF
--- a/apps/src/lib/levelbuilder/lesson-editor/ActivitySectionCardButtons.jsx
+++ b/apps/src/lib/levelbuilder/lesson-editor/ActivitySectionCardButtons.jsx
@@ -231,7 +231,7 @@ class ActivitySectionCardButtons extends Component {
                 <AddButton displayText="Slide" handler={this.handleAddSlide} />
                 <AddButton
                   displayText="Image"
-                  handler={this.handleOpenAddUploadImage}
+                  handler={this.handleOpenUploadImage}
                 />
               </span>
             )}

--- a/apps/test/unit/lib/levelbuilder/lesson-editor/ActivitySectionCardButtonsTest.jsx
+++ b/apps/test/unit/lib/levelbuilder/lesson-editor/ActivitySectionCardButtonsTest.jsx
@@ -125,4 +125,24 @@ describe('ActivitySectionCardButtons', () => {
     handler();
     expect(appendSlide).to.have.been.calledOnce;
   });
+
+  it('add image pressed', () => {
+    const wrapper = shallow(<ActivitySectionCardButtons {...defaultProps} />);
+    const button = wrapper.find('AddButton').filter({displayText: 'Image'});
+    const handler = button.prop('handler');
+
+    expect(wrapper.state().uploadImageOpen).to.equal(false);
+    handler();
+    expect(wrapper.state().uploadImageOpen).to.equal(true);
+  });
+
+  it('add code doc pressed', () => {
+    const wrapper = shallow(<ActivitySectionCardButtons {...defaultProps} />);
+    const button = wrapper.find('AddButton').filter({displayText: 'Code Doc'});
+    const handler = button.prop('handler');
+
+    expect(wrapper.state().addProgrammingExpressionOpen).to.equal(false);
+    handler();
+    expect(wrapper.state().addProgrammingExpressionOpen).to.equal(true);
+  });
 });


### PR DESCRIPTION
I broke it in https://github.com/code-dot-org/code-dot-org/pull/39576

Also add a unit test for it and also for the 'code doc' button added in that same PR

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
