### PR TITLE
fix pause button spacing

### DIFF
--- a/apps/src/p5lab/P5LabVisualizationColumn.jsx
+++ b/apps/src/p5lab/P5LabVisualizationColumn.jsx
@@ -200,7 +200,10 @@ class P5LabVisualizationColumn extends React.Component {
 
         <GameButtons>
           {showPauseButton && (
-            <PauseButton pauseHandler={this.props.pauseHandler} />
+            <PauseButton
+              pauseHandler={this.props.pauseHandler}
+              marginRight={isShareView ? 10 : 0}
+            />
           )}
           <ArrowButtons />
 

--- a/apps/src/templates/PauseButton.jsx
+++ b/apps/src/templates/PauseButton.jsx
@@ -36,6 +36,7 @@ const styles = {
 class PauseButton extends React.Component {
   static propTypes = {
     pauseHandler: PropTypes.func.isRequired,
+    marginRight: PropTypes.number,
     // from redux
     togglePause: PropTypes.func.isRequired,
     setArrowButtonDisabled: PropTypes.func.isRequired,
@@ -58,7 +59,8 @@ class PauseButton extends React.Component {
     const buttonStyle = {
       ...styles.button,
       ...(this.props.isRunning && styles.runningColor),
-      ...(this.props.isPaused && styles.pausedColor)
+      ...(this.props.isPaused && styles.pausedColor),
+      ...(this.props.marginRight && {marginRight: this.props.marginRight})
     };
 
     return (

--- a/apps/style/common.scss
+++ b/apps/style/common.scss
@@ -243,6 +243,7 @@ button.arrow:disabled {
 #soft-buttons {
   display: inline-block;
   vertical-align: top;
+  margin-left: -9px;
   -webkit-touch-callout: none;
   &.soft-buttons-compact {
     margin: 0;

--- a/apps/style/common.scss
+++ b/apps/style/common.scss
@@ -243,7 +243,6 @@ button.arrow:disabled {
 #soft-buttons {
   display: inline-block;
   vertical-align: top;
-  margin-left: -9px;
   -webkit-touch-callout: none;
   &.soft-buttons-compact {
     margin: 0;


### PR DESCRIPTION
Fix the spacing on the pause button in share view.

Now:
<img width="1440" alt="Screen Shot 2021-03-29 at 2 46 53 PM" src="https://user-images.githubusercontent.com/17147070/112904507-e61f2c80-909d-11eb-9bda-da3e6da95357.png">

Previously:
<img width="1440" alt="Screen Shot 2021-03-29 at 2 49 45 PM" src="https://user-images.githubusercontent.com/17147070/112904588-03ec9180-909e-11eb-892b-c60ea7daf02a.png">

## Links
- jira ticket: [STAR-1445](https://codedotorg.atlassian.net/browse/STAR-1445?atlOrigin=eyJpIjoiMjU5MjY4Y2Y2ZTViNDIwYjg1NmRkMjc2YThjOWRlMTYiLCJwIjoiaiJ9)

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
