### PR TITLE
Script#localized_title default to name

### DIFF
--- a/dashboard/app/models/script.rb
+++ b/dashboard/app/models/script.rb
@@ -1601,7 +1601,12 @@ class Script < ApplicationRecord
   end
 
   def localized_title
-    I18n.t "data.script.name.#{name}.title"
+    I18n.t(
+      "title",
+      default: name,
+      scope: [:data, :script, :name, name],
+      smart: true
+    )
   end
 
   def title_for_display

--- a/dashboard/test/controllers/api/v1/assessments_controller_test.rb
+++ b/dashboard/test/controllers/api/v1/assessments_controller_test.rb
@@ -137,7 +137,7 @@ class Api::V1::AssessmentsControllerTest < ActionController::TestCase
         "display_name" => nil, "answers" => expected_answers, "question_text" => sub_level5.get_question_text, "question_index" => 7},
     ]
     level_response = JSON.parse(@response.body)[level1.id.to_s]
-    assert_equal "translation missing: en-US.data.script.name.#{script.name}.title", level_response["name"]
+    assert_equal script.name, level_response["name"]
     assert_equal level1.id.to_s, level_response["id"]
     assert_equal expected_questions, level_response["questions"]
   end
@@ -243,13 +243,12 @@ class Api::V1::AssessmentsControllerTest < ActionController::TestCase
 
     assert_response :success
 
-    # Stage translation missing because we don't actually generate i18n files in tests.
     expected_response = {
       @student_1.id.to_s => {
         "student_name" => @student_1.name,
         "responses_by_assessment" => {
           level1.id.to_s => {
-            "stage" => "translation missing: en-US.data.script.name.#{script.name}.title",
+            "stage" => script.name,
             "puzzle" => 1,
             "question" => "Long assessment 1",
             "url" => "http://test.host/s/#{script.name}/stage/1/puzzle/1?section_id=#{@section.id}&user_id=#{@student_1.id}",
@@ -328,13 +327,12 @@ class Api::V1::AssessmentsControllerTest < ActionController::TestCase
 
     assert_response :success
 
-    # Stage translation missing because we don't actually generate i18n files in tests.
     expected_response = {
       @student_1.id.to_s => {
         "student_name" => @student_1.name,
           "responses_by_assessment" => {
             level1.id.to_s => {
-              "stage" => "translation missing: en-US.data.script.name.#{script.name}.title",
+              "stage" => script.name,
               "puzzle" => 1,
               "question" => "Long assessment 1",
               "url" => "http://test.host/s/#{script.name}/stage/1/puzzle/1?section_id=#{@section.id}&user_id=#{@student_1.id}",
@@ -539,10 +537,9 @@ class Api::V1::AssessmentsControllerTest < ActionController::TestCase
     }
     assert_response :success
 
-    # All these are translation missing because we don't actually generate i18n files in tests
     expected_response = {
       level1.id.to_s => {
-        "stage_name" => "translation missing: en-US.data.script.name.#{script.name}.title",
+        "stage_name" => script.name,
         "levelgroup_results" => [
           {
             "type" => "text_match",
@@ -680,7 +677,7 @@ class Api::V1::AssessmentsControllerTest < ActionController::TestCase
 
     expected_response = {
       level1.id.to_s => {
-        "stage_name" => "translation missing: en-US.data.script.name.#{script.name}.title",
+        "stage_name" => script.name,
         "levelgroup_results" => []
       }
     }

--- a/dashboard/test/models/lesson_test.rb
+++ b/dashboard/test/models/lesson_test.rb
@@ -635,7 +635,7 @@ class LessonTest < ActiveSupport::TestCase
 
     assert_equal 4, summaries.count
     expected_summary = {
-      scriptTitle: "translation missing: en-US.data.script.name.script6.title",
+      scriptTitle: "script6",
       versionYear: nil,
       lockable: false,
       relativePosition: 1,
@@ -645,7 +645,7 @@ class LessonTest < ActiveSupport::TestCase
     assert_equal expected_summary, summaries[0]
 
     expected_summary = {
-      scriptTitle: "translation missing: en-US.data.script.name.script0.title",
+      scriptTitle: "script0",
       versionYear: "2999",
       lockable: false,
       relativePosition: 1,
@@ -695,7 +695,7 @@ class LessonTest < ActiveSupport::TestCase
 
     assert_equal 2, summaries.count
     expected_summary = {
-      scriptTitle: "translation missing: en-US.data.script.name.script4.title",
+      scriptTitle: "script4",
       versionYear: "2999",
       lockable: false,
       relativePosition: 1,
@@ -759,7 +759,7 @@ class LessonTest < ActiveSupport::TestCase
 
     assert_equal 3, summaries.count
     expected_summary = {
-      scriptTitle: "translation missing: en-US.data.script.name.script4.title",
+      scriptTitle: "script4",
       versionYear: "2999",
       lockable: false,
       relativePosition: 1,

--- a/dashboard/test/models/pd/workshop_test.rb
+++ b/dashboard/test/models/pd/workshop_test.rb
@@ -1063,18 +1063,18 @@ class Pd::WorkshopTest < ActiveSupport::TestCase
       end
     end
 
-    add_unit.call 'unit-1', ['Unit 1 - Lesson 1', 'Unit 1 - Lesson 2']
-    add_unit.call 'unit-2', ['Unit 2 - Lesson 1', 'Unit 2 - Lesson 2']
-    add_unit.call 'unit-3', ['Unit 3 - Lesson 1']
+    add_unit.call 'pre-survey-unit-1', ['Unit 1 - Lesson 1', 'Unit 1 - Lesson 2']
+    add_unit.call 'pre-survey-unit-2', ['Unit 2 - Lesson 1', 'Unit 2 - Lesson 2']
+    add_unit.call 'pre-survey-unit-3', ['Unit 3 - Lesson 1']
 
     workshop = build :workshop
     workshop.expects(:pre_survey?).returns(true).twice
     workshop.stubs(:pre_survey_course_name).returns('pd-workshop-pre-survey-test')
 
     expected = [
-      ['unit-1', ['Lesson 1: Unit 1 - Lesson 1', 'Lesson 2: Unit 1 - Lesson 2']],
-      ['unit-2', ['Lesson 1: Unit 2 - Lesson 1', 'Lesson 2: Unit 2 - Lesson 2']],
-      ['unit-3', ['Lesson 1: Unit 3 - Lesson 1']]
+      ['pre-survey-unit-1', ['Lesson 1: Unit 1 - Lesson 1', 'Lesson 2: Unit 1 - Lesson 2']],
+      ['pre-survey-unit-2', ['Lesson 1: Unit 2 - Lesson 1', 'Lesson 2: Unit 2 - Lesson 2']],
+      ['pre-survey-unit-3', ['Lesson 1: Unit 3 - Lesson 1']]
     ]
     assert_equal expected, workshop.pre_survey_units_and_lessons
   end

--- a/dashboard/test/models/pd/workshop_test.rb
+++ b/dashboard/test/models/pd/workshop_test.rb
@@ -1056,26 +1056,25 @@ class Pd::WorkshopTest < ActiveSupport::TestCase
     unit_group = create :unit_group, name: 'pd-workshop-pre-survey-test'
     next_position = 1
     add_unit = ->(unit_name, lesson_names) do
-      create(:script).tap do |script|
+      create(:script, name: unit_name).tap do |script|
         create :unit_group_unit, unit_group: unit_group, script: script, position: (next_position += 1)
         create :lesson_group, script: script
-        I18n.stubs(:t).with("data.script.name.#{script.name}.title").returns(unit_name)
         lesson_names.each {|lesson_name| create :lesson, script: script, name: lesson_name, key: lesson_name, lesson_group: script.lesson_groups.first}
       end
     end
 
-    add_unit.call 'Unit 1', ['Unit 1 - Lesson 1', 'Unit 1 - Lesson 2']
-    add_unit.call 'Unit 2', ['Unit 2 - Lesson 1', 'Unit 2 - Lesson 2']
-    add_unit.call 'Unit 3', ['Unit 3 - Lesson 1']
+    add_unit.call 'unit-1', ['Unit 1 - Lesson 1', 'Unit 1 - Lesson 2']
+    add_unit.call 'unit-2', ['Unit 2 - Lesson 1', 'Unit 2 - Lesson 2']
+    add_unit.call 'unit-3', ['Unit 3 - Lesson 1']
 
     workshop = build :workshop
     workshop.expects(:pre_survey?).returns(true).twice
     workshop.stubs(:pre_survey_course_name).returns('pd-workshop-pre-survey-test')
 
     expected = [
-      ['Unit 1', ['Lesson 1: Unit 1 - Lesson 1', 'Lesson 2: Unit 1 - Lesson 2']],
-      ['Unit 2', ['Lesson 1: Unit 2 - Lesson 1', 'Lesson 2: Unit 2 - Lesson 2']],
-      ['Unit 3', ['Lesson 1: Unit 3 - Lesson 1']]
+      ['unit-1', ['Lesson 1: Unit 1 - Lesson 1', 'Lesson 2: Unit 1 - Lesson 2']],
+      ['unit-2', ['Lesson 1: Unit 2 - Lesson 1', 'Lesson 2: Unit 2 - Lesson 2']],
+      ['unit-3', ['Lesson 1: Unit 3 - Lesson 1']]
     ]
     assert_equal expected, workshop.pre_survey_units_and_lessons
   end

--- a/dashboard/test/models/script_test.rb
+++ b/dashboard/test/models/script_test.rb
@@ -2950,6 +2950,11 @@ class ScriptTest < ActiveSupport::TestCase
     assert_includes error.message, 'Legacy script levels are not allowed in migrated scripts.'
   end
 
+  test 'localized_title defaults to name' do
+    script = create :script, name: "test-localized-title-default"
+    assert_equal "test-localized-title-default", script.localized_title
+  end
+
   private
 
   def has_hidden_script?(scripts)


### PR DESCRIPTION
Rather than the ugly "no translation found" string.

Will make tests for https://github.com/code-dot-org/code-dot-org/pull/39682 cleaner, since we won't need to add i18n in our mocks to get the pdf filenames to work.

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
