### PR TITLE
Refactor Foorm parsing of Forms and Submissions

### DIFF
--- a/dashboard/app/models/foorm/form.rb
+++ b/dashboard/app/models/foorm/form.rb
@@ -315,11 +315,16 @@ class Foorm::Form < ApplicationRecord
     csv_result
   end
 
-  # For a given question_id, gets metadata about the question (eg, type, choices).
+  # For a given question_id, gets information about the question (eg, type, choices, question text).
+  # @param [String] question_id
+  # @return [Hash]
   def get_question_details(question_id)
     parsed_questions(true)[question_id]
   end
 
+  # Returns a readable version of the questions asked in a Form.
+  # @param [Boolean] should_flatten
+  # @return [Hash] Hash with two keys (:general and :facilitator), or those two hashes merged if the should_flatten parameter is true.
   def parsed_questions(should_flatten = false)
     @parsed_questions ||= Pd::Foorm::FoormParser.parse_form_questions(questions)
 

--- a/dashboard/app/models/foorm/form.rb
+++ b/dashboard/app/models/foorm/form.rb
@@ -340,7 +340,7 @@ class Foorm::Form < ApplicationRecord
       next if questions_content.nil_or_empty?
 
       questions_content.each do |question_id, question_details|
-        if question_details[:type] == 'matrix'
+        if question_details[:type] == ANSWER_MATRIX
           matrix_questions = question_details[:rows]
           matrix_questions.each do |matrix_question_id, matrix_question_text|
             matrix_key = self.class.get_matrix_question_id(question_id, matrix_question_id)

--- a/dashboard/app/models/foorm/form.rb
+++ b/dashboard/app/models/foorm/form.rb
@@ -315,9 +315,17 @@ class Foorm::Form < ApplicationRecord
     csv_result
   end
 
-  def parsed_questions
-    @parsed_questions ||= Pd::Foorm::FoormParser.parse_forms([self])
-    @parsed_questions
+  # For a given question_id, gets metadata about the question (eg, type, choices).
+  def get_question_details(question_id)
+    parsed_questions(true)[question_id]
+  end
+
+  def parsed_questions(should_flatten = false)
+    @parsed_questions ||= Pd::Foorm::FoormParser.parse_form_questions(questions)
+
+    should_flatten ?
+      @parsed_questions[:general].merge!(@parsed_questions[:facilitator]) :
+      @parsed_questions
   end
 
   # Returns a hash with keys matching what is produced by parsed_questions.
@@ -331,7 +339,7 @@ class Foorm::Form < ApplicationRecord
       questions[questions_section] = {}
       next if questions_content.nil_or_empty?
 
-      questions_content[key].each do |question_id, question_details|
+      questions_content.each do |question_id, question_details|
         if question_details[:type] == 'matrix'
           matrix_questions = question_details[:rows]
           matrix_questions.each do |matrix_question_id, matrix_question_text|

--- a/dashboard/app/models/foorm/submission.rb
+++ b/dashboard/app/models/foorm/submission.rb
@@ -53,6 +53,9 @@ class Foorm::Submission < ApplicationRecord
   # For a given question_id-answer key-value pair from a submission's answers,
   # returns a hash with either a single key-value pair (for question types other than matrix) and a human readable response to a question,
   # or a hash with multiple values (for matrix questions) with a human readable response to each sub-question.
+  # @param [String] question_id
+  # @param [String] answer the stored value representing a user's answer to a question (either a key that can be paired with a human readable answer, or the answer itself)
+  # @return [Hash] a human readable version of the answer(s) associated with a given question ID
   def get_formatted_answer(question_id, answer)
     question_details = form.get_question_details(question_id)
 

--- a/dashboard/app/models/foorm/submission.rb
+++ b/dashboard/app/models/foorm/submission.rb
@@ -20,7 +20,8 @@ class Foorm::Submission < ApplicationRecord
   #   - flattens matrix questions
   #   - returns readable answer, instead of a key representing a user's answer.
   def formatted_answers
-    question_answer_pairs = formatted_workshop_metadata
+    # First, grab associated PD-specific metadata for this submission (eg, workshop ID)
+    formatted_answers = formatted_workshop_metadata
 
     # Example of what parsed_answers looks like.
     # Note that matrix questions (eg, how_much_barrier_to_teaching_cs)
@@ -39,47 +40,46 @@ class Foorm::Submission < ApplicationRecord
     # }
     parsed_answers = JSON.parse(answers)
 
-    # Contains human readable questions, as well as answers
-    # (for non-free response questions).
-    # See FoormParser for the how this is structured.
-    general_parsed_questions = form.parsed_questions[:general][form.key]
-    facilitator_parsed_questions = form.parsed_questions[:facilitator] && form.parsed_questions[:facilitator][form.key]
-
-    parsed_questions = facilitator_parsed_questions ?
-                         general_parsed_questions.merge(facilitator_parsed_questions) :
-                         general_parsed_questions
-
+    # Then, merge in formatted versions of each answer in the submission.
     parsed_answers.each do |question_id, answer|
-      if parsed_questions.keys.include?(question_id)
-
-        question_details = parsed_questions[question_id]
-
-        case question_details[:type]
-        when 'matrix'
-          choices = question_details[:columns]
-
-          answer.each do |matrix_question_id, matrix_question_answer|
-            key = Foorm::Form.get_matrix_question_id(question_id, matrix_question_id)
-            question_answer_pairs[key] = choices[matrix_question_answer]
-          end
-        when 'scale', 'text'
-          question_answer_pairs[question_id] = answer
-        when 'singleSelect'
-          choices = question_details[:choices]
-          question_answer_pairs[question_id] = choices[answer]
-        when 'multiSelect'
-          choices = question_details[:choices]
-          question_answer_pairs[question_id] = answer.map {|selected| choices[selected]}.compact.sort.join(', ')
-        end
-      else
-        # For any questions in the submission that aren't in the form,
-        # include them in the formatted submission with as-is.
-        # Main use cases are survey config variables (eg, workshop_course).
-        question_answer_pairs[question_id] = answer
-      end
+      formatted_answers.merge! get_formatted_answer(question_id, answer)
     end
 
-    question_answer_pairs
+    formatted_answers
+  end
+
+  # For a given question_id-answer key-value pair from a submission's answers,
+  # returns a hash with either a single key-value pair (for question types other than matrix) and a human readable response to a question,
+  # or a hash with multiple values (for matrix questions) with a human readable response to each sub-question.
+  def get_formatted_answer(question_id, answer)
+    question_details = form.get_question_details(question_id)
+
+    # If question isn't in the Form, return as-is.
+    # This is expected for metadata about the submission.
+    return {question_id => answer} if question_details.nil?
+
+    case question_details[:type]
+    when 'matrix'
+      choices = question_details[:columns]
+
+      pairs = {}
+      answer.each do |matrix_question_id, matrix_question_answer|
+        key = Foorm::Form.get_matrix_question_id(question_id, matrix_question_id)
+        pairs[key] = choices[matrix_question_answer]
+      end
+      return pairs
+    when 'scale', 'text'
+      return {question_id => answer}
+    when 'singleSelect'
+      choices = question_details[:choices]
+      return {question_id => choices[answer]}
+    when 'multiSelect'
+      choices = question_details[:choices]
+      return {question_id => answer.map {|selected| choices[selected]}.compact.sort.join(', ')}
+    end
+
+    # Return blank hash if question_type not found
+    return {}
   end
 
   def formatted_workshop_metadata

--- a/dashboard/app/models/foorm/submission.rb
+++ b/dashboard/app/models/foorm/submission.rb
@@ -73,7 +73,7 @@ class Foorm::Submission < ApplicationRecord
         pairs[key] = choices[matrix_question_answer]
       end
       return pairs
-    when ANSWER_SCALE, ANSWER_TEXT
+    when ANSWER_RATING, ANSWER_TEXT
       return {question_id => answer}
     when ANSWER_SINGLE_SELECT
       choices = question_details[:choices]

--- a/dashboard/app/models/foorm/submission.rb
+++ b/dashboard/app/models/foorm/submission.rb
@@ -11,6 +11,8 @@
 #
 
 class Foorm::Submission < ApplicationRecord
+  include Pd::Foorm::Constants
+
   has_one :workshop_metadata, class_name: 'Pd::WorkshopSurveyFoormSubmission', foreign_key: :foorm_submission_id
   has_one :misc_survey, foreign_key: :foorm_submission_id
 
@@ -59,7 +61,7 @@ class Foorm::Submission < ApplicationRecord
     return {question_id => answer} if question_details.nil?
 
     case question_details[:type]
-    when 'matrix'
+    when ANSWER_MATRIX
       choices = question_details[:columns]
 
       pairs = {}
@@ -68,12 +70,12 @@ class Foorm::Submission < ApplicationRecord
         pairs[key] = choices[matrix_question_answer]
       end
       return pairs
-    when 'scale', 'text'
+    when ANSWER_SCALE, ANSWER_TEXT
       return {question_id => answer}
-    when 'singleSelect'
+    when ANSWER_SINGLE_SELECT
       choices = question_details[:choices]
       return {question_id => choices[answer]}
-    when 'multiSelect'
+    when ANSWER_MULTI_SELECT
       choices = question_details[:choices]
       return {question_id => answer.map {|selected| choices[selected]}.compact.sort.join(', ')}
     end

--- a/dashboard/lib/pd/foorm/foorm_parser.rb
+++ b/dashboard/lib/pd/foorm/foorm_parser.rb
@@ -40,21 +40,31 @@ module Pd::Foorm
     def self.parse_forms(forms)
       parsed_forms = {general: {}, facilitator: {}}
       forms.each do |form|
-        parsed_form = {general: {}, facilitator: {}}
-        form_questions = JSON.parse(form.questions)
-        form_questions = ::Foorm::Form.fill_in_library_items(form_questions)
-        form_questions.deep_symbolize_keys!
-        form_questions[:pages].each do |page|
-          page[:elements].each do |question_data|
-            parsed_form.deep_merge!(parse_element(question_data, false))
-          end
-        end
-        parsed_forms[:general][get_form_key(form.name, form.version)] = parsed_form[:general]
+        parsed_form_questions = parse_form_questions(form.questions)
+
+        parsed_forms[:general][get_form_key(form.name, form.version)] = parsed_form_questions[:general]
         unless parsed_form[:facilitator].empty?
-          parsed_forms[:facilitator][get_form_key(form.name, form.version)] = parsed_form[:facilitator]
+          parsed_forms[:facilitator][get_form_key(form.name, form.version)] = parsed_form_questions[:facilitator]
         end
       end
+
       parsed_forms
+    end
+
+    # Parse single form, and return a readable version of its questions.
+    def self.parse_form_questions(form_questions)
+      form_questions_parsed_from_json = JSON.parse(form_questions)
+      parsed_form_questions = {general: {}, facilitator: {}}
+
+      filled_in_form_questions = ::Foorm::Form.fill_in_library_items(form_questions_parsed_from_json)
+      filled_in_form_questions.deep_symbolize_keys!
+      filled_in_form_questions[:pages].each do |page|
+        page[:elements].each do |question_data|
+          parsed_form_questions.deep_merge!(parse_element(question_data, false))
+        end
+      end
+
+      parsed_form_questions
     end
 
     # parse a form element

--- a/dashboard/lib/pd/foorm/foorm_parser.rb
+++ b/dashboard/lib/pd/foorm/foorm_parser.rb
@@ -51,7 +51,9 @@ module Pd::Foorm
       parsed_forms
     end
 
-    # Parse single form, and return a readable version of its questions.
+    # Parse the questions of a single form, and return a readable version.
+    # @param [String] form_questions Unparsed JSON string containing a Form's questions.
+    # @return [Hash] Hash with two keys (:general and :facilitator), containing a readable version of the questions asked in a Form.
     def self.parse_form_questions(form_questions)
       form_questions_parsed_from_json = JSON.parse(form_questions)
       parsed_form_questions = {general: {}, facilitator: {}}

--- a/dashboard/lib/pd/foorm/foorm_parser.rb
+++ b/dashboard/lib/pd/foorm/foorm_parser.rb
@@ -43,7 +43,7 @@ module Pd::Foorm
         parsed_form_questions = parse_form_questions(form.questions)
 
         parsed_forms[:general][get_form_key(form.name, form.version)] = parsed_form_questions[:general]
-        unless parsed_form[:facilitator].empty?
+        unless parsed_form_questions[:facilitator].empty?
           parsed_forms[:facilitator][get_form_key(form.name, form.version)] = parsed_form_questions[:facilitator]
         end
       end


### PR DESCRIPTION
An attempt to disentangle some of the parsing code that we use to process Foorm Forms and Submissions. No new functionality is introduced in this PR, only a rejiggering of existing code.

Some history -- `FoormParser.parse_forms` was written to take an array of Forms, and process them into a format like this, where the questions for each Form processed are listed under the top-level keys `general` and `facilitator`:

```
#   {
#     general: {
#       <form-name>.<form-version>: {
#         <question_name>: {
#           title: "sample title",
#           type: "text/singleSelect/multiSelect/matrix/scale",
#           # for singleSelect/multiSelect/scale
#           choices: {
#             choice_1_name: "choice 1 value",
#             ...
#           },
#           # if has other choice
#           other_text: "Other choice text",
#           # for matrix
#           rows: {
#             row_1_name: "row 1 value",
#             ...
#           },
#           columns: {
#             column_1_name: "column 1 value",
#             ...
#           }
#         }
#       }
#     },
#     facilitator: {
#       <form-name>.<form-version>: {same format as general}
#     }
#   }
```

Last year, not knowing that much about Foorm, I [jury rigged this parse_forms method to get a formatted version of an individual Form's questions](https://github.com/code-dot-org/code-dot-org/blob/staging/dashboard/app/models/foorm/form.rb#L318). That implementation is confusing, among other pieces of the code that is used to process Foorm submissions into CSVs currently -- I've taken a few steps in this PR to hopefully make this code less spaghetti-ish.

The changes introduced here are:
- (modified) `Submission.instance.formatted_answers`: take out [Form parsing code that isn't really related to the submission](https://github.com/code-dot-org/code-dot-org/blob/staging/dashboard/app/models/foorm/submission.rb#L45-L55), and moves it into the two Form instance methods below.
- (modified) `Form.instance.parsed_questions`: uses a cleaned up implementation of FoormParser.parse_form_questions (described below). Also optionally "flattens" the parsed_questions to no longer have the top-level "general" and "facilitator" keys, which is used in a Submission's `formatted_answers`.
- (new) `Form.instance.get_question_details(question_id)`: standalone method that allows getting information about a specific question (also used in Submission's `formatted_answers`, and is helpful from a mental model perspective of being able to think about a specific answered question in a Submission, vs. the Submission as a whole).

I also try to isolate core logic/clean up naming in a couple of methods:
- (new)` Submission.instance.get_formatted_answer(question_id, answer)`: takes core function of `Submission.instance.formatted_answers` and isolates the logic that processes a single key-value pair in a Submission's `answers`.
- (new) `FoormParser.parse_form_questions(form_questions)`: takes the core function of `FoormParser.parse_forms` (ie, parsing the Form's `questions` attribute), and isolates it, such that it can be used more directly by `Form.instance.parsed_questions`.

## Testing story

We have existing testing that covers the top-level methods for processing Forms and Submissions (`submissions_to_csv` and `formatted_answers`, respectively) that exercise these new code paths. I am curious though what best practice might be around testing these helper methods directly, though.

## PR Checklist:

- [x] Tests provide adequate coverage
- [x] Privacy and Security impacts have been assessed
- [x] Code is well-commented
- [x] New features are translatable or updates will not break translations
- [x] Relevant documentation has been added or updated
- [x] User impact is well-understood and desirable
- [x] Pull Request is labeled appropriately
- [x] Follow-up work items (including potential tech debt) are tracked and linked
