### PR TITLE
Show duration on activity section in agenda

### DIFF
--- a/apps/src/sites/studio/pages/lessons/show.js
+++ b/apps/src/sites/studio/pages/lessons/show.js
@@ -46,6 +46,8 @@ function displayLessonOverview() {
       activitySection.displayName = activitySection.name || '';
       delete activitySection.name;
 
+      activitySection.duration = activitySection.duration || 0;
+
       activitySection.text = activitySection.description || '';
       delete activitySection.description;
 

--- a/apps/src/templates/lessonOverview/LessonAgenda.jsx
+++ b/apps/src/templates/lessonOverview/LessonAgenda.jsx
@@ -35,9 +35,16 @@ export default class LessonAgenda extends Component {
             </li>
             {activity.activitySections.map(section => (
               <li style={{marginLeft: 15}} key={section.key}>
-                <a href={`#activity-section-${section.key}`}>
-                  {section.displayName}
-                </a>
+                {section.duration > 0 && (
+                  <a href={`#section-${section.key}`}>{`${
+                    section.displayName
+                  } (${section.duration} ${i18n.minutes()})`}</a>
+                )}
+                {section.duration === 0 && (
+                  <a href={`#section-${section.key}`}>{`${
+                    section.displayName
+                  }`}</a>
+                )}
               </li>
             ))}
           </ul>

--- a/apps/test/unit/templates/lessonOverview/LessonAgendaTest.jsx
+++ b/apps/test/unit/templates/lessonOverview/LessonAgendaTest.jsx
@@ -16,15 +16,18 @@ describe('LessonAgenda', () => {
             {
               key: 'section-1',
               displayName: 'Making programs',
+              duration: 20,
               scriptLevels: []
             },
             {
               key: 'section-2',
               displayName: '',
+              duration: 0,
               scriptLevels: [{id: 10}]
             },
             {
               key: 'section-3',
+              duration: 10,
               displayName: 'Non Programming Progression',
               scriptLevels: []
             }
@@ -37,16 +40,19 @@ describe('LessonAgenda', () => {
           activitySections: [
             {
               key: 'section-4',
+              duration: 0,
               displayName: 'Section 4',
               scriptLevels: [{id: 11}]
             },
             {
               key: 'section-5',
+              duration: 0,
               displayName: '',
               scriptLevels: []
             },
             {
               key: 'section-6',
+              duration: 0,
               displayName: 'Section 6',
               scriptLevels: []
             }
@@ -56,61 +62,12 @@ describe('LessonAgenda', () => {
     };
   });
 
-  it('renders default props', () => {
+  it('Display correct information for agenda', () => {
     const wrapper = shallow(<LessonAgenda {...defaultProps} />);
-    expect(wrapper.find('a').length).to.equal(6);
 
-    expect(
-      wrapper
-        .find('a')
-        .at(0)
-        .props().href
-    ).to.equal('#activity-activity-1');
-    expect(
-      wrapper
-        .find('a')
-        .at(0)
-        .contains('Main Activity (20 minutes)')
-    ).to.be.true;
-
-    expect(
-      wrapper
-        .find('a')
-        .at(1)
-        .props().href
-    ).to.equal('#activity-section-section-1');
-    expect(
-      wrapper
-        .find('a')
-        .at(2)
-        .props().href
-    ).to.equal('#activity-section-section-3');
-
-    expect(
-      wrapper
-        .find('a')
-        .at(3)
-        .props().href
-    ).to.equal('#activity-activity-2');
-    expect(
-      wrapper
-        .find('a')
-        .at(3)
-        .contains('2nd Activity (30 minutes)')
-    ).to.be.true;
-
-    expect(
-      wrapper
-        .find('a')
-        .at(4)
-        .props().href
-    ).to.equal('#activity-section-section-4');
-
-    expect(
-      wrapper
-        .find('a')
-        .at(5)
-        .props().href
-    ).to.equal('#activity-section-section-6');
+    expect(wrapper.text()).to.include('Main Activity (20 minutes)');
+    expect(wrapper.text()).to.include('Making programs (20 minutes)');
+    expect(wrapper.text()).to.include('Non Programming Progression');
+    expect(wrapper.text()).to.include('2nd Activity (30 minutes)');
   });
 });


### PR DESCRIPTION
Show the activity section time on the agenda on the front page of the lesson.

<img width="582" alt="Screen Shot 2021-03-29 at 9 58 37 PM" src="https://user-images.githubusercontent.com/208083/112922230-1f758d80-90da-11eb-9694-66107b71424b.png">


## Links

https://codedotorg.atlassian.net/browse/PLAT-910

## Testing story

- Updated the tests to check for the right strings instead of checking for the link tags with certain content.
- Check for duration in the activity section string
