### PR TITLE
Fix two lines showing on the right side of the calendar

### DIFF
--- a/apps/src/code-studio/components/progress/UnitCalendar.jsx
+++ b/apps/src/code-studio/components/progress/UnitCalendar.jsx
@@ -22,10 +22,10 @@ const styles = {
     border: '1px solid ' + color.purple,
     borderCollapse: 'collapse',
     display: 'flex',
-    minHeight: 50
+    minHeight: 50,
+    margin: 0
   },
   table: {
-    border: '1px solid ' + color.purple,
     borderCollapse: 'collapse',
     width: '100%'
   },
@@ -141,12 +141,7 @@ export default class UnitCalendar extends React.Component {
                 <td style={styles.weekColumn}>
                   {i18n.weekLabel({number: index + 1})}
                 </td>
-                <td
-                  style={{
-                    ...styles.scheduleColumn,
-                    ...{width: this.props.weekWidth}
-                  }}
-                >
+                <td style={styles.scheduleColumn}>
                   {this.renderWeek(week, index + 1)}
                 </td>
               </tr>


### PR DESCRIPTION
[Hannah reported](https://codedotorg.slack.com/archives/CNZP84FJ5/p1617050805133300) there were two lines showing on the right side of the unit calendar in each row. 

<img width="708" alt="Screen Shot 2021-03-29 at 10 26 40 PM" src="https://user-images.githubusercontent.com/208083/112924287-d8899700-90dd-11eb-880b-d74de0b8ea49.png">

<img width="758" alt="Screen Shot 2021-03-29 at 10 26 53 PM" src="https://user-images.githubusercontent.com/208083/112924306-dfb0a500-90dd-11eb-9a10-81d16b6df3ca.png">


## Links

https://codedotorg.atlassian.net/browse/PLAT-911

## Testing story

Manually tested see images.