### PR TITLE
Remove the is_migrated protection

### DIFF
--- a/dashboard/app/models/script.rb
+++ b/dashboard/app/models/script.rb
@@ -117,8 +117,6 @@ class Script < ApplicationRecord
       message: 'cannot start with a tilde or dot or contain slashes'
     }
 
-  validate :set_is_migrated_only_for_migrated_scripts
-
   def prevent_duplicate_levels
     reload
 
@@ -134,12 +132,6 @@ class Script < ApplicationRecord
   after_save :generate_plc_objects
 
   SCRIPT_DIRECTORY = "#{Rails.root}/config/scripts".freeze
-
-  def set_is_migrated_only_for_migrated_scripts
-    if !!is_migrated && !hidden
-      errors.add(:is_migrated, "Can't be set on a course that is visible")
-    end
-  end
 
   def prevent_course_version_change?
     lessons.any? {|l| l.resources.count > 0 || l.vocabularies.count > 0}

--- a/dashboard/test/controllers/courses_controller_test.rb
+++ b/dashboard/test/controllers/courses_controller_test.rb
@@ -19,7 +19,7 @@ class CoursesControllerTest < ActionController::TestCase
 
     @unit_group_regular = create :unit_group, name: 'non-plc-course'
 
-    @migrated_script = create :script, is_migrated: true, hidden: true
+    @migrated_script = create :script, is_migrated: true
     @unit_group_migrated = create :unit_group
     create :unit_group_unit, unit_group: @unit_group_migrated, script: @migrated_script, position: 1
 

--- a/dashboard/test/controllers/lessons_controller_test.rb
+++ b/dashboard/test/controllers/lessons_controller_test.rb
@@ -9,7 +9,7 @@ class LessonsControllerTest < ActionController::TestCase
     # stub writes so that we dont actually make updates to filesystem
     File.stubs(:write)
 
-    @script = create :script, name: 'unit-1', is_migrated: true, hidden: true
+    @script = create :script, name: 'unit-1', is_migrated: true
     lesson_group = create :lesson_group, script: @script
     @lesson = create(
       :lesson,
@@ -69,7 +69,7 @@ class LessonsControllerTest < ActionController::TestCase
     @levelbuilder = create :levelbuilder
 
     @pilot_teacher = create :teacher, pilot_experiment: 'my-experiment'
-    @pilot_script = create :script, name: 'pilot-script', pilot_experiment: 'my-experiment', hidden: true, is_migrated: true, include_student_lesson_plans: true
+    @pilot_script = create :script, name: 'pilot-script', pilot_experiment: 'my-experiment', is_migrated: true, include_student_lesson_plans: true
     pilot_lesson_group = create :lesson_group, script: @pilot_script
     @pilot_lesson = create(
       :lesson,
@@ -88,7 +88,7 @@ class LessonsControllerTest < ActionController::TestCase
     @pilot_section = create :section, user: @pilot_teacher, script: @pilot_script
     @pilot_student = create(:follower, section: @pilot_section).student_user
 
-    @login_req_script = create :script, name: 'signed-in-script', hidden: true, is_migrated: true, include_student_lesson_plans: true, login_required: true
+    @login_req_script = create :script, name: 'signed-in-script', is_migrated: true, include_student_lesson_plans: true, login_required: true
     login_req_lesson_group = create :lesson_group, script: @login_req_script
     @login_req_lesson = create(
       :lesson,
@@ -200,7 +200,7 @@ class LessonsControllerTest < ActionController::TestCase
   end
 
   test 'show lesson when lesson is the only lesson in script' do
-    script = create :script, name: 'one-lesson-script', is_migrated: true, hidden: true
+    script = create :script, name: 'one-lesson-script', is_migrated: true
     lesson_group = create :lesson_group, script: script
     @solo_lesson_in_script = create(
       :lesson,
@@ -306,7 +306,7 @@ class LessonsControllerTest < ActionController::TestCase
 
   test 'can not show student lesson plan when lesson is in a script without student lesson plans' do
     sign_in @levelbuilder
-    script2 = create :script, name: 'course', is_migrated: true, include_student_lesson_plans: false, hidden: true
+    script2 = create :script, name: 'course', is_migrated: true, include_student_lesson_plans: false
     lesson_group2 = create :lesson_group, script: script2
     unmigrated_lesson = create(
       :lesson,
@@ -328,7 +328,7 @@ class LessonsControllerTest < ActionController::TestCase
 
   test 'show student lesson plan' do
     sign_in @levelbuilder
-    script2 = create :script, name: 'course', is_migrated: true, include_student_lesson_plans: true, hidden: true
+    script2 = create :script, name: 'course', is_migrated: true, include_student_lesson_plans: true
     lesson_group2 = create :lesson_group, script: script2
     unmigrated_lesson = create(
       :lesson,

--- a/dashboard/test/controllers/scripts_controller_test.rb
+++ b/dashboard/test/controllers/scripts_controller_test.rb
@@ -23,7 +23,7 @@ class ScriptsControllerTest < ActionController::TestCase
     @section_coursez_2017 = create :section, script: @coursez_2017
     @section_coursez_2017.add_student(@student_coursez_2017)
 
-    @migrated_script = create :script, is_migrated: true, hidden: true
+    @migrated_script = create :script, is_migrated: true
     @unmigrated_script = create :script
 
     Rails.application.config.stubs(:levelbuilder_mode).returns false
@@ -522,7 +522,7 @@ class ScriptsControllerTest < ActionController::TestCase
     sign_in @levelbuilder
     Rails.application.config.stubs(:levelbuilder_mode).returns true
 
-    script = create :script, name: 'migrated', is_migrated: true, hidden: true
+    script = create :script, name: 'migrated', is_migrated: true
     lesson_group = create :lesson_group, script: script
     lesson = create :lesson, script: script, lesson_group: lesson_group
     activity = create :lesson_activity, lesson: lesson
@@ -555,7 +555,7 @@ class ScriptsControllerTest < ActionController::TestCase
     sign_in @levelbuilder
     Rails.application.config.stubs(:levelbuilder_mode).returns true
 
-    script = create :script, name: 'migrated', is_migrated: true, hidden: true
+    script = create :script, name: 'migrated', is_migrated: true
     lesson_group = create :lesson_group, script: script
     lesson = create :lesson, script: script, lesson_group: lesson_group, name: 'problem lesson'
 

--- a/dashboard/test/dsl/script_dsl_test.rb
+++ b/dashboard/test/dsl/script_dsl_test.rb
@@ -871,8 +871,7 @@ level 'Level 3'
         family_name: 'family name',
         version_year: '2001',
         is_course: true,
-        is_migrated: true,
-        hidden: true
+        is_migrated: true
       }
     script_text = ScriptDSL.serialize_to_string(script)
     expected = <<~SCRIPT

--- a/dashboard/test/dsl/script_dsl_test.rb
+++ b/dashboard/test/dsl/script_dsl_test.rb
@@ -864,7 +864,7 @@ level 'Level 3'
     assert_equal expected, script_text
   end
 
-  test 'serialize is_migrated on hidden course' do
+  test 'serialize is_migrated' do
     script = create :script,
       {
         new_name: 'new name',
@@ -875,6 +875,7 @@ level 'Level 3'
       }
     script_text = ScriptDSL.serialize_to_string(script)
     expected = <<~SCRIPT
+      hidden false
       new_name 'new name'
       family_name 'family name'
       version_year '2001'

--- a/dashboard/test/fixtures/test-serialize-seeding-json.script_json
+++ b/dashboard/test/fixtures/test-serialize-seeding-json.script_json
@@ -2,7 +2,7 @@
   "script": {
     "name": "test-serialize-seeding-json-script",
     "wrapup_video_id": null,
-    "hidden": true,
+    "hidden": false,
     "login_required": false,
     "properties": {
       "curriculum_path": "my_curriculum_path",

--- a/dashboard/test/integration/lessons_test.rb
+++ b/dashboard/test/integration/lessons_test.rb
@@ -7,7 +7,7 @@ class LessonsTest < ActionDispatch::IntegrationTest
     # stub writes so that we dont actually make updates to filesystem
     File.stubs(:write)
 
-    @script = create :script, name: 'unit-1', is_migrated: true, hidden: true
+    @script = create :script, name: 'unit-1', is_migrated: true
     lesson_group = create :lesson_group, script: @script
     @lesson = create(
       :lesson,

--- a/dashboard/test/lib/services/curriculum_pdfs_test.rb
+++ b/dashboard/test/lib/services/curriculum_pdfs_test.rb
@@ -8,7 +8,7 @@ class Services::CurriculumPdfsTest < ActiveSupport::TestCase
 
   test 'wraps ScriptSeed with PDF generation logic' do
     CDO.stubs(:rack_env).returns(:staging)
-    script = create(:script, is_migrated: true, hidden: true)
+    script = create(:script, is_migrated: true)
     seed_hash = JSON.parse(Services::ScriptSeed.serialize_seeding_json(script))
 
     # Generate PDFs on first seed

--- a/dashboard/test/lib/services/script_seed_test.rb
+++ b/dashboard/test/lib/services/script_seed_test.rb
@@ -744,7 +744,7 @@ module Services
     end
 
     test 'import_script sets seeded_from from serialized_at' do
-      script = create(:script, is_migrated: true, hidden: true)
+      script = create(:script, is_migrated: true)
       assert script.seeded_from.nil?
 
       serialized = ScriptSeed::ScriptSerializer.new(script, scope: {seed_context: {}}).as_json.stringify_keys
@@ -923,7 +923,6 @@ module Services
         :script,
         name: "#{name_prefix}-script",
         curriculum_path: 'my_curriculum_path',
-        hidden: true,
         is_migrated: true
       )
 

--- a/dashboard/test/models/ability_test.rb
+++ b/dashboard/test/models/ability_test.rb
@@ -11,7 +11,7 @@ class AbilityTest < ActiveSupport::TestCase
       @login_required_script_level = create(:script_level, script: script)
     end
 
-    @login_required_migrated_script = create(:script, login_required: true, is_migrated: true, hidden: true).tap do |script|
+    @login_required_migrated_script = create(:script, login_required: true, is_migrated: true).tap do |script|
       @login_required_migrated_lesson = create(:lesson, script: script, has_lesson_plan: true)
     end
   end

--- a/dashboard/test/models/lesson_test.rb
+++ b/dashboard/test/models/lesson_test.rb
@@ -172,7 +172,7 @@ class LessonTest < ActiveSupport::TestCase
   end
 
   test 'can summarize lesson with new lesson plan link in migrated script' do
-    script = create :script, name: 'test-script', is_migrated: true, hidden: true
+    script = create :script, name: 'test-script', is_migrated: true
     lesson_group = create :lesson_group, script: script
     lesson1 = create :lesson, lesson_group: lesson_group, script: script, has_lesson_plan: true, lockable: true
     lesson2 = create :lesson, lesson_group: lesson_group, script: script, has_lesson_plan: false, lockable: true
@@ -367,7 +367,7 @@ class LessonTest < ActiveSupport::TestCase
   end
 
   test 'summarize for script edit includes bonus levels' do
-    script = create :script, is_migrated: true, hidden: true
+    script = create :script, is_migrated: true
     lesson_group = create :lesson_group, script: script
     lesson = create :lesson, lesson_group: lesson_group, script: script, name: 'Lesson 1', key: 'lesson-1', relative_position: 1, absolute_position: 1
     activity = create :lesson_activity, lesson: lesson
@@ -384,7 +384,7 @@ class LessonTest < ActiveSupport::TestCase
   end
 
   test 'summarize uses unplugged property' do
-    script = create :script, is_migrated: true, hidden: true
+    script = create :script, is_migrated: true
     lesson_group = create :lesson_group, script: script
     lesson = create :lesson, lesson_group: lesson_group, script: script, name: 'Lesson 1', key: 'lesson-1', relative_position: 1, absolute_position: 1, unplugged: true
 
@@ -393,7 +393,7 @@ class LessonTest < ActiveSupport::TestCase
   end
 
   test 'summarize_for_calendar adds durations of all activities' do
-    script = create :script, is_migrated: false, hidden: true
+    script = create :script, is_migrated: false
     lesson_group = create :lesson_group, script: script
     lesson = create :lesson, lesson_group: lesson_group, script: script, name: 'Lesson 1', key: 'lesson-1', relative_position: 1, absolute_position: 1, unplugged: true
     activity1 = create :lesson_activity, lesson: lesson, duration: 20
@@ -796,7 +796,7 @@ class LessonTest < ActiveSupport::TestCase
       "//test.code.org/curriculum/#{old_lesson.script.name}/1/Teacher.pdf"
     )
 
-    script = create :script, is_migrated: true, hidden: true
+    script = create :script, is_migrated: true
     new_lesson = create :lesson, script: script, key: 'Some Verbose Lesson Name', has_lesson_plan: true
     assert_nil(new_lesson.lesson_plan_pdf_url)
 
@@ -808,7 +808,7 @@ class LessonTest < ActiveSupport::TestCase
   end
 
   test 'student_lesson_plan_pdf_url gets url for migrated script with student lesson plans' do
-    script = create :script, is_migrated: true, hidden: true, include_student_lesson_plans: true
+    script = create :script, is_migrated: true, include_student_lesson_plans: true
     new_lesson = create :lesson, script: script, key: 'Some Verbose Lesson Name', has_lesson_plan: true
     assert_nil(new_lesson.student_lesson_plan_pdf_url)
 

--- a/dashboard/test/models/script_test.rb
+++ b/dashboard/test/models/script_test.rb
@@ -689,18 +689,6 @@ class ScriptTest < ActiveSupport::TestCase
     assert script.can_view_version?(teacher)
   end
 
-  test 'visible scripts can not be marked at is_migrated' do
-    assert_raises ActiveRecord::RecordInvalid do
-      create :script, name: 'my-visible-script', hidden: false, properties: {is_migrated: true}
-    end
-  end
-
-  test 'hidden scripts can be marked at is_migrated' do
-    script = create :script, name: 'my-hidden-script', hidden: true,  properties: {is_migrated: true}
-
-    assert script.properties["is_migrated"]
-  end
-
   test 'can_view_version? is true if script is latest stable version in student locale or in English' do
     latest_in_english = create :script, name: 'english-only-script', family_name: 'courseg', version_year: '2018', is_stable: true, supported_locales: []
     latest_in_locale = create :script, name: 'localized-script', family_name: 'courseg', version_year: '2017', is_stable: true, supported_locales: ['it-it']
@@ -2881,7 +2869,7 @@ class ScriptTest < ActiveSupport::TestCase
   end
 
   test 'fix script level positions' do
-    script = create :script, is_migrated: true, hidden: true
+    script = create :script, is_migrated: true
     lesson_group = create :lesson_group, script: script
 
     lesson_1 = create :lesson, script: script, lesson_group: lesson_group
@@ -2937,7 +2925,7 @@ class ScriptTest < ActiveSupport::TestCase
   end
 
   test 'cannot fix position of legacy script levels' do
-    script = create :script, is_migrated: true, hidden: true
+    script = create :script, is_migrated: true
     lesson_group = create :lesson_group, script: script
     lesson = create :lesson, script: script, lesson_group: lesson_group
 


### PR DESCRIPTION
Remove the is_migrated protection which does not let scripts be marked visible if migrated. 

## Links

https://codedotorg.atlassian.net/browse/PLAT-613

## Testing story

Updated all tests that are testing is_migrated scripts to no longer set hidden.