### PR TITLE
add support to expand first or all standards within a framework

### DIFF
--- a/apps/src/templates/courseRollupPages/RollupLessonEntrySection.jsx
+++ b/apps/src/templates/courseRollupPages/RollupLessonEntrySection.jsx
@@ -5,7 +5,9 @@ import i18n from '@cdo/locale';
 import InlineMarkdown from '@cdo/apps/templates/InlineMarkdown';
 import ResourceList from '@cdo/apps/templates/lessonOverview/ResourceList';
 import EnhancedSafeMarkdown from '@cdo/apps/templates/EnhancedSafeMarkdown';
-import LessonStandards from '@cdo/apps/templates/lessonOverview/LessonStandards';
+import LessonStandards, {
+  ExpandMode
+} from '@cdo/apps/templates/lessonOverview/LessonStandards';
 import StyledCodeBlock from '../lessonOverview/StyledCodeBlock';
 import {lessonShape} from './rollupShapes';
 
@@ -113,7 +115,10 @@ export default class RollupLessonEntrySection extends Component {
             !this.props.lesson.preparation && <p>{i18n.rollupNoPrep()}</p>}
           {this.props.objectToRollUp === 'Standards' &&
             this.props.lesson.standards.length > 0 && (
-              <LessonStandards standards={this.props.lesson.standards} />
+              <LessonStandards
+                standards={this.props.lesson.standards}
+                expandMode={ExpandMode.ALL}
+              />
             )}
           {this.props.objectToRollUp === 'Standards' &&
             this.props.lesson.standards.length <= 0 && (

--- a/apps/src/templates/lessonOverview/LessonOverview.jsx
+++ b/apps/src/templates/lessonOverview/LessonOverview.jsx
@@ -19,7 +19,7 @@ import {announcementShape} from '@cdo/apps/code-studio/announcementsRedux';
 import {lessonShape} from '@cdo/apps/templates/lessonOverview/lessonPlanShapes';
 import Announcements from '../../code-studio/components/progress/Announcements';
 import {linkWithQueryParams} from '@cdo/apps/utils';
-import LessonStandards from './LessonStandards';
+import LessonStandards, {ExpandMode} from './LessonStandards';
 import StyledCodeBlock from './StyledCodeBlock';
 
 const styles = {
@@ -145,7 +145,10 @@ class LessonOverview extends Component {
             {lesson.standards.length > 0 && (
               <div>
                 <h2>{i18n.standards()}</h2>
-                <LessonStandards standards={lesson.standards} />
+                <LessonStandards
+                  standards={lesson.standards}
+                  expandMode={ExpandMode.FIRST}
+                />
               </div>
             )}
             {lesson.opportunityStandards.length > 0 && (

--- a/apps/src/templates/lessonOverview/LessonStandards.jsx
+++ b/apps/src/templates/lessonOverview/LessonStandards.jsx
@@ -40,11 +40,11 @@ function getNextExpandMode(parentExpandMode, index) {
 }
 
 /**
- * @param expandType {ExpandMode} The expand mode of the component
+ * @param expandMode {ExpandMode} The expand mode of the component
  * @returns {boolean} Whether the component's details element should be expanded
  */
-function getDetailsOpen(expandType) {
-  return expandType === ExpandMode.ALL || expandType === ExpandMode.FIRST;
+function getDetailsOpen(expandMode) {
+  return expandMode === ExpandMode.ALL || expandMode === ExpandMode.FIRST;
 }
 
 export default class LessonStandards extends PureComponent {

--- a/apps/src/templates/lessonOverview/LessonStandards.jsx
+++ b/apps/src/templates/lessonOverview/LessonStandards.jsx
@@ -39,6 +39,10 @@ function getNextExpandMode(parentExpandMode, index) {
   }
 }
 
+/**
+ * @param expandType {ExpandMode} The expand mode of the component
+ * @returns {boolean} Whether the component's details element should be expanded
+ */
 function getDetailsOpen(expandType) {
   return expandType === ExpandMode.ALL || expandType === ExpandMode.FIRST;
 }

--- a/apps/src/templates/lessonOverview/LessonStandards.jsx
+++ b/apps/src/templates/lessonOverview/LessonStandards.jsx
@@ -27,7 +27,8 @@ export default class LessonStandards extends PureComponent {
   }
 }
 LessonStandards.propTypes = {
-  standards: PropTypes.arrayOf(standardShape).isRequired
+  standards: PropTypes.arrayOf(standardShape).isRequired,
+  expand: PropTypes.oneOf('first', 'all')
 };
 
 class Framework extends PureComponent {

--- a/apps/src/templates/lessonOverview/LessonStandards.jsx
+++ b/apps/src/templates/lessonOverview/LessonStandards.jsx
@@ -28,7 +28,7 @@ const expandModeShape = PropTypes.oneOf(
  * @param index {number} index of the child with respect to parent
  * @returns {ExpandMode} Expand mode of child component
  */
-function getNextExpandMode(parentExpandMode, index) {
+function getChildExpandMode(parentExpandMode, index) {
   switch (parentExpandMode) {
     case ExpandMode.ALL:
       return ExpandMode.ALL;
@@ -58,7 +58,7 @@ export default class LessonStandards extends PureComponent {
       <div>
         {Object.keys(standardsByFramework).map((frameworkName, index) => {
           const standards = standardsByFramework[frameworkName];
-          const expandMode = getNextExpandMode(this.props.expandMode, index);
+          const expandMode = getChildExpandMode(this.props.expandMode, index);
           return (
             <Framework
               name={frameworkName}
@@ -97,7 +97,7 @@ class Framework extends PureComponent {
         <ul style={{listStyleType: 'none'}}>
           {Object.keys(standardsByCategory).map((categoryShortcode, index) => {
             const standards = standardsByCategory[categoryShortcode];
-            const expandMode = getNextExpandMode(this.props.expandMode, index);
+            const expandMode = getChildExpandMode(this.props.expandMode, index);
             return (
               <CategoryClass
                 key={categoryShortcode}
@@ -139,7 +139,7 @@ class ParentCategory extends PureComponent {
             {Object.keys(standardsByCategory).map(
               (categoryShortcode, index) => {
                 const standards = standardsByCategory[categoryShortcode];
-                const expandMode = getNextExpandMode(
+                const expandMode = getChildExpandMode(
                   this.props.expandMode,
                   index
                 );

--- a/apps/src/templates/lessonOverview/LessonStandards.story.jsx
+++ b/apps/src/templates/lessonOverview/LessonStandards.story.jsx
@@ -20,6 +20,15 @@ export default storybook => {
       story: () => (
         <LessonStandards standards={cspStandards.concat(cstaStandards)} />
       )
+    },
+    {
+      name: 'expand first of many standards',
+      story: () => (
+        <LessonStandards
+          standards={cspStandards.concat(cstaStandards)}
+          expand="first"
+        />
+      )
     }
   ]);
 };

--- a/apps/src/templates/lessonOverview/LessonStandards.story.jsx
+++ b/apps/src/templates/lessonOverview/LessonStandards.story.jsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import LessonStandards from './LessonStandards';
+import LessonStandards, {ExpandMode} from './LessonStandards';
 import {
   cspStandards,
   cstaStandards
@@ -26,7 +26,16 @@ export default storybook => {
       story: () => (
         <LessonStandards
           standards={cspStandards.concat(cstaStandards)}
-          expand="first"
+          expandMode={ExpandMode.FIRST}
+        />
+      )
+    },
+    {
+      name: 'expand all of many standards',
+      story: () => (
+        <LessonStandards
+          standards={cspStandards.concat(cstaStandards)}
+          expandMode={ExpandMode.ALL}
         />
       )
     }

--- a/apps/test/unit/templates/lessonOverview/LessonStandardsTest.js
+++ b/apps/test/unit/templates/lessonOverview/LessonStandardsTest.js
@@ -44,14 +44,17 @@ describe('LessonStandards', () => {
     expect(frameworks.length).to.equal(2);
     frameworks.forEach(framework => {
       expect(isOpen(framework)).to.be.false;
-      const parentCategories = framework.find('ParentCategory');
-      parentCategories.forEach(parentCategory => {
-        expect(isOpen(parentCategory)).to.be.false;
-        const categories = parentCategory.find('Category');
-        categories.forEach(category => {
-          expect(isOpen(category)).to.be.false;
-        });
-      });
+    });
+
+    const parentCategories = wrapper.find('ParentCategory');
+    expect(parentCategories.length > 0).to.be.true;
+    parentCategories.forEach(parentCategory => {
+      expect(isOpen(parentCategory)).to.be.false;
+    });
+    const categories = wrapper.find('Category');
+    expect(categories.length > 0).to.be.true;
+    categories.forEach(category => {
+      expect(isOpen(category)).to.be.false;
     });
   });
 
@@ -84,14 +87,18 @@ describe('LessonStandards', () => {
     expect(frameworks.length).to.equal(2);
     frameworks.forEach(framework => {
       expect(isOpen(framework)).to.be.true;
-      const parentCategories = framework.find('ParentCategory');
-      parentCategories.forEach(parentCategory => {
-        expect(isOpen(parentCategory)).to.be.true;
-        const categories = parentCategory.find('Category');
-        categories.forEach(category => {
-          expect(isOpen(category)).to.be.true;
-        });
-      });
+    });
+
+    const parentCategories = wrapper.find('ParentCategory');
+    expect(parentCategories.length > 0).to.be.true;
+    parentCategories.forEach(parentCategory => {
+      expect(isOpen(parentCategory)).to.be.true;
+    });
+
+    const categories = wrapper.find('Category');
+    expect(categories.length > 0).to.be.true;
+    categories.forEach(category => {
+      expect(isOpen(category)).to.be.true;
     });
   });
 });

--- a/apps/test/unit/templates/lessonOverview/LessonStandardsTest.js
+++ b/apps/test/unit/templates/lessonOverview/LessonStandardsTest.js
@@ -40,23 +40,16 @@ describe('LessonStandards', () => {
       expect(text).to.contain(standard.description);
     });
 
-    it('renders many standards with all standards expanded', () => {
-      const standards = cspStandards.concat(cstaStandards);
-      const wrapper = mount(
-        <LessonStandards standards={standards} expandMode={ExpandMode.ALL} />
-      );
-
-      const frameworks = wrapper.find('Framework');
-      expect(frameworks.length).to.equal(2);
-      frameworks.forEach(framework => {
-        expect(isOpen(framework)).to.be.false;
-        const parentCategories = framework.find('ParentCategory');
-        parentCategories.forEach(parentCategory => {
-          expect(isOpen(parentCategory)).to.be.false;
-          const categories = parentCategory.find('Category');
-          categories.forEach(category => {
-            expect(isOpen(category)).to.be.false;
-          });
+    const frameworks = wrapper.find('Framework');
+    expect(frameworks.length).to.equal(2);
+    frameworks.forEach(framework => {
+      expect(isOpen(framework)).to.be.false;
+      const parentCategories = framework.find('ParentCategory');
+      parentCategories.forEach(parentCategory => {
+        expect(isOpen(parentCategory)).to.be.false;
+        const categories = parentCategory.find('Category');
+        categories.forEach(category => {
+          expect(isOpen(category)).to.be.false;
         });
       });
     });

--- a/apps/test/unit/templates/lessonOverview/LessonStandardsTest.js
+++ b/apps/test/unit/templates/lessonOverview/LessonStandardsTest.js
@@ -1,7 +1,9 @@
 import React from 'react';
 import {mount} from 'enzyme';
 import {expect} from '../../../util/reconfiguredChai';
-import LessonStandards from '@cdo/apps/templates/lessonOverview/LessonStandards';
+import LessonStandards, {
+  ExpandMode
+} from '@cdo/apps/templates/lessonOverview/LessonStandards';
 import {cspStandards, cstaStandards} from './sampleStandardsData';
 
 describe('LessonStandards', () => {
@@ -37,5 +39,71 @@ describe('LessonStandards', () => {
       expect(text).to.contain(standard.shortcode);
       expect(text).to.contain(standard.description);
     });
+
+    it('renders many standards with all standards expanded', () => {
+      const standards = cspStandards.concat(cstaStandards);
+      const wrapper = mount(
+        <LessonStandards standards={standards} expandMode={ExpandMode.ALL} />
+      );
+
+      const frameworks = wrapper.find('Framework');
+      expect(frameworks.length).to.equal(2);
+      frameworks.forEach(framework => {
+        expect(isOpen(framework)).to.be.false;
+        const parentCategories = framework.find('ParentCategory');
+        parentCategories.forEach(parentCategory => {
+          expect(isOpen(parentCategory)).to.be.false;
+          const categories = parentCategory.find('Category');
+          categories.forEach(category => {
+            expect(isOpen(category)).to.be.false;
+          });
+        });
+      });
+    });
+  });
+
+  it('renders many standards with first standard expanded', () => {
+    const standards = cspStandards.concat(cstaStandards);
+    const wrapper = mount(
+      <LessonStandards standards={standards} expandMode={ExpandMode.FIRST} />
+    );
+    const frameworks = wrapper.find('Framework');
+    expect(frameworks.length).to.equal(2);
+    expect(isOpen(frameworks.at(0))).to.be.true;
+    expect(isOpen(frameworks.at(1))).to.be.false;
+
+    const parentCategories = frameworks.at(0).find('ParentCategory');
+    expect(parentCategories.length).to.equal(1);
+    expect(isOpen(parentCategories.at(0))).to.be.true;
+
+    const categories = parentCategories.at(0).find('Category');
+    expect(categories.length).to.equal(2);
+    expect(isOpen(categories.at(0))).to.be.true;
+    expect(isOpen(categories.at(1))).to.be.false;
+  });
+
+  it('renders many standards with all standards expanded', () => {
+    const standards = cspStandards.concat(cstaStandards);
+    const wrapper = mount(
+      <LessonStandards standards={standards} expandMode={ExpandMode.ALL} />
+    );
+    const frameworks = wrapper.find('Framework');
+    expect(frameworks.length).to.equal(2);
+    frameworks.forEach(framework => {
+      expect(isOpen(framework)).to.be.true;
+      const parentCategories = framework.find('ParentCategory');
+      parentCategories.forEach(parentCategory => {
+        expect(isOpen(parentCategory)).to.be.true;
+        const categories = parentCategory.find('Category');
+        categories.forEach(category => {
+          expect(isOpen(category)).to.be.true;
+        });
+      });
+    });
   });
 });
+
+function isOpen(wrapper) {
+  const details = wrapper.find('details').first();
+  return details.prop('open');
+}


### PR DESCRIPTION
Finishes [PLAT-901].

adds prop to control whether just the first standard or all standards should be expanded:
![Screen Shot 2021-03-29 at 8 04 30 PM](https://user-images.githubusercontent.com/8001765/112927979-b5092100-90ca-11eb-8500-95158860d6f3.png)

expands first standard on teacher lesson plan page:
![Screen Shot 2021-03-29 at 8 04 58 PM](https://user-images.githubusercontent.com/8001765/112927990-b89ca800-90ca-11eb-8888-61b893619ed5.png)

expands all standards on course rollup pages:
![Screen Shot 2021-03-29 at 8 06 21 PM](https://user-images.githubusercontent.com/8001765/112928001-bcc8c580-90ca-11eb-98fa-7be01f178948.png)


## Testing story

New stories and unit tests for expand/collapse behavior. manually verified lesson plans and rollup pages as shown in screenshots.

[PLAT-901]: https://codedotorg.atlassian.net/browse/PLAT-901