### PR TITLE
[AiLab] rename getPrediction params

### DIFF
--- a/apps/src/applab/ai.js
+++ b/apps/src/applab/ai.js
@@ -6,7 +6,7 @@ function generateCodeDesignElements(modelId, modelData) {
   var x = 20;
   var y = 20;
   var SPACER_PIXELS = 20;
-  designMode.onInsertEvent(`var testValues = {};`);
+  designMode.onInsertEvent(`var data = {};`);
   var inputFields = [];
   modelData.selectedFeatures.forEach(feature => {
     y = y + SPACER_PIXELS;
@@ -36,7 +36,7 @@ function generateCodeDesignElements(modelId, modelData) {
       input.id = 'design_' + fieldId;
       y = y + SPACER_PIXELS;
     }
-    var addFeature = `testValues.${alphaNumFeature} = getText("${fieldId}");`;
+    var addFeature = `data.${alphaNumFeature} = getText("${fieldId}");`;
     inputFields.push(addFeature);
   });
   y = y + 2 * SPACER_PIXELS;
@@ -57,9 +57,7 @@ function generateCodeDesignElements(modelId, modelData) {
   var predictOnClick = `onEvent("${predictButtonId}", "click", function() {
     ${inputFields.join('\n\t\t')}
     setText("${predictionId}", '');
-    getPrediction("${
-      modelData.name
-    }", "${modelId}", testValues, function(value) {
+    getPrediction("${modelData.name}", "${modelId}", data, function(value) {
       setText("${predictionId}", value);
     });
   });`;

--- a/apps/src/applab/ai/dropletConfig.js
+++ b/apps/src/applab/ai/dropletConfig.js
@@ -9,7 +9,7 @@ const aiBlocks = [
     func: 'getPrediction',
     parent: api,
     category: 'Data',
-    paletteParams: ['model_name', 'model_id', 'testValues', 'callback'],
-    params: ['"myModel"', '"modelId"', 'testValues', 'function (value) {\n \n}']
+    paletteParams: ['name', 'id', 'data', 'callback'],
+    params: ['"name"', '"id"', 'data', 'function (value) {\n \n}']
   }
 ];

--- a/apps/src/applab/dropletConfig.js
+++ b/apps/src/applab/dropletConfig.js
@@ -1137,8 +1137,8 @@ if (experiments.isEnabled(experiments.APPLAB_ML)) {
     func: 'getPrediction',
     parent: api,
     category: 'Data',
-    paletteParams: ['model_name', 'model_id', 'testValues', 'callback'],
-    params: ['"myModel"', '"modelId"', 'testValues', 'function (value) {\n \n}']
+    paletteParams: ['name', 'id', 'data', 'callback'],
+    params: ['"name"', '"id"', 'data', 'function (value) {\n \n}']
   });
 }
 

--- a/dashboard/config/programming_expressions/applab/getPrediction.json
+++ b/dashboard/config/programming_expressions/applab/getPrediction.json
@@ -2,15 +2,15 @@
   "func": "getPrediction",
   "category": "Data",
   "paletteParams": [
-    "model_name",
-    "model_id",
-    "testValues",
+    "name",
+    "id",
+    "data",
     "callback"
   ],
   "params": [
-    "\"myModel\"",
-    "\"modelId\"",
-    "testValues",
+    "\"name\"",
+    "\"id\"",
+    "data",
     "function (value) {\n \n}"
   ]
 }


### PR DESCRIPTION
Adjusting the parameter names for the `getPrediction` block based on Curriculum request. 

BEFORE: 
![Screen Shot 2021-03-30 at 12 33 32 PM](https://user-images.githubusercontent.com/12300669/113023966-3658c600-9154-11eb-8d0b-d4b6d3350d98.png)
![Screen Shot 2021-03-30 at 12 33 51 PM](https://user-images.githubusercontent.com/12300669/113023972-38228980-9154-11eb-95d4-d54ff84747b5.png)


AFTER: 
![Screen Shot 2021-03-30 at 12 28 53 PM](https://user-images.githubusercontent.com/12300669/113023985-3a84e380-9154-11eb-8e70-976b62a63919.png)
![Screen Shot 2021-03-30 at 12 28 39 PM](https://user-images.githubusercontent.com/12300669/113023991-3c4ea700-9154-11eb-82e6-126233bd59d6.png)

