### PR TITLE
Manually include data from Microsoft in Hours Served metric

### DIFF
--- a/bin/cron/analyze_hoc_activity
+++ b/bin/cron/analyze_hoc_activity
@@ -49,6 +49,9 @@ def main
   # discussion of ways to resolve the problem can be found in this document:
   # https://docs.google.com/document/d/1RTTCpkDYZjqZxfVehkZRkk1HckYMvFdFGs6SEZnK1I8
   total_started += 14_861_327
+  # March 2021:
+  # Microsoft provided data about Hour of Code served through their tutorials.
+  total_started += 3_774_215
 
   today = Date.today
   day = Date.new(2014, 12, 6)


### PR DESCRIPTION
Manually add # of hours served from tutorials hosted separately by Microsoft.

## Testing story

There's not really a way to test this other than in production -- I did verify that the value I'm updating [is what is used to populate the "# of hours served" value on hourofcode.com](https://github.com/code-dot-org/code-dot-org/blob/staging/pegasus/sites.v3/hourofcode.com/public/index.haml#L128), and I'm relatively confident that the same value is used in other places we report "# of hours served" (I did [some work on this script last year](https://github.com/code-dot-org/code-dot-org/pull/33611)).

We should see a bump of 3.7 million in the number of hours served on the day this is released (in addition to however many hours of code are actually started that day, which is closer to 1 million). I looked at the most recent file in pegasus/cache on `production-daemon`, where we store daily rollups of the # of hours of code served, to get a sense of how many we're adding per day at the moment.