### PR TITLE
[Sprite Lab] Expose event log for validation

### DIFF
--- a/apps/src/p5lab/spritelab/commands.js
+++ b/apps/src/p5lab/spritelab/commands.js
@@ -305,6 +305,10 @@ export const commands = {
     return validationCommands.getBackground();
   },
 
+  getEventLog() {
+    return validationCommands.getEventLog();
+  },
+
   getNumBehaviorsForAnimation(animation) {
     return validationCommands.getNumBehaviorsForAnimation(animation);
   },

--- a/apps/src/p5lab/spritelab/commands/validationCommands.js
+++ b/apps/src/p5lab/spritelab/commands/validationCommands.js
@@ -13,6 +13,10 @@ export const commands = {
     }
   },
 
+  getEventLog() {
+    return coreLibrary.eventLog;
+  },
+
   getNumBehaviorsForAnimation(animation) {
     return coreLibrary.getNumBehaviorsForAnimation(animation);
   },

--- a/apps/src/p5lab/spritelab/coreLibrary.js
+++ b/apps/src/p5lab/spritelab/coreLibrary.js
@@ -12,6 +12,7 @@ export var screenText = {};
 export var defaultSpriteSize = 100;
 export var printLog = [];
 export var promptVars = {};
+export var eventLog = [];
 
 export function reset() {
   spriteId = 0;
@@ -25,6 +26,7 @@ export function reset() {
   printLog = [];
   promptVars = {};
   screenText = {};
+  eventLog = [];
 }
 
 export function startPause(time) {
@@ -247,11 +249,13 @@ function atTimeEvent(inputEvent, p5Inst) {
     // the time matches the event argument)
     if (worldTime === inputEvent.args.n && previousTime !== inputEvent.args.n) {
       // Call callback with no extra args
+      eventLog.push(`atTime: ${inputEvent.args.n}`);
       return [{}];
     }
   } else if (inputEvent.args.unit === 'frames') {
     if (p5Inst.frameCount === inputEvent.args.n) {
       // Call callback with no extra args
+      eventLog.push(`atTime: ${inputEvent.args.n}`);
       return [{}];
     }
   }
@@ -281,6 +285,7 @@ function repeatForeverEvent(inputEvent, p5Inst) {
 
 function whenPressEvent(inputEvent, p5Inst) {
   if (p5Inst.keyWentDown(inputEvent.args.key)) {
+    eventLog.push(`whenPress: ${inputEvent.args.key}`);
     // Call callback with no extra args
     return [{}];
   } else {
@@ -291,6 +296,10 @@ function whenPressEvent(inputEvent, p5Inst) {
 
 function whilePressEvent(inputEvent, p5Inst) {
   if (p5Inst.keyDown(inputEvent.args.key)) {
+    // Prevent spamming the event log with repeated events
+    if (!eventLog[eventLog.length - 1]?.includes('whilePress')) {
+      eventLog.push(`whilePress: ${inputEvent.args.key}`);
+    }
     // Call callback with no extra args
     return [{}];
   } else {
@@ -331,6 +340,7 @@ function whenTouchEvent(inputEvent) {
         if (!firedOnce) {
           // Sprites are overlapping, and we haven't fired yet for this collision,
           // so we should fire the callback
+          eventLog.push(`whenTouch: ${sprite.id} ${target.id}`);
           callbackArgList.push({
             subjectSprite: sprite.id,
             objectSprite: target.id
@@ -357,6 +367,10 @@ function whileTouchEvent(inputEvent) {
   sprites.forEach(sprite => {
     targets.forEach(target => {
       if (sprite.overlap(target)) {
+        // Prevent spamming the event log with repeated events
+        if (!eventLog[eventLog.length - 1]?.includes('whileTouch')) {
+          eventLog.push(`whileTouch: ${sprite.id} ${target.id}`);
+        }
         callbackArgList.push({
           subjectSprite: sprite.id,
           objectSprite: target.id
@@ -373,6 +387,7 @@ function whenClickEvent(inputEvent, p5Inst) {
     let sprites = getSpriteArray(inputEvent.args.sprite);
     sprites.forEach(sprite => {
       if (p5Inst.mouseIsOver(sprite)) {
+        eventLog.push(`whenClick: ${sprite.id}`);
         callbackArgList.push({clickedSprite: sprite.id});
       }
     });
@@ -385,6 +400,10 @@ function whileClickEvent(inputEvent, p5Inst) {
   let sprites = getSpriteArray(inputEvent.args.sprite);
   sprites.forEach(sprite => {
     if (p5Inst.mousePressedOver(sprite)) {
+      // Prevent spamming the event log with repeated events
+      if (!eventLog[eventLog.length - 1]?.includes('whileClick')) {
+        eventLog.push(`whileClick: ${sprite.id}`);
+      }
       callbackArgList.push({clickedSprite: sprite.id});
     }
   });
@@ -395,6 +414,7 @@ function whenSpriteCreatedEvent(inputEvent, p5Inst) {
   let callbackArgList = [];
   let sprites = newSprites[inputEvent.args.costume] || [];
   sprites.forEach(sprite => {
+    eventLog.push(`spriteCreated: ${sprite.id}`);
     callbackArgList.push({newSprite: sprite.id});
   });
   return callbackArgList;


### PR DESCRIPTION
This is needed to be able to write validation code that checks for specific events.
![image](https://user-images.githubusercontent.com/8787187/113055250-3ad6ac00-915f-11eb-8203-4c3fe76bf3ca.png)

For events that continue for many frames (while touch, while click, while press), I only record the first event in a row to the log (to prevent the log from getting really big with redundant information)