### PR TITLE
More level details polish

### DIFF
--- a/apps/src/templates/lessonOverview/activities/LevelDetailsDialog.jsx
+++ b/apps/src/templates/lessonOverview/activities/LevelDetailsDialog.jsx
@@ -283,6 +283,7 @@ class LevelDetailsDialog extends Component {
           />
           <Button
             href={level.url || scriptLevel.url}
+            target={'_blank'}
             text={i18n.seeFullLevel()}
             color={'orange'}
             __useDeprecatedTag

--- a/apps/src/templates/lessonOverview/activities/ProgressionDetails.jsx
+++ b/apps/src/templates/lessonOverview/activities/ProgressionDetails.jsx
@@ -1,17 +1,12 @@
 import PropTypes from 'prop-types';
 import React, {Component} from 'react';
 import ProgressLevelSet from '@cdo/apps/templates/progress/ProgressLevelSet';
-import color from '@cdo/apps/util/color';
 import {LevelStatus} from '@cdo/apps/util/sharedConstants';
 import LevelDetailsDialog from './LevelDetailsDialog';
 
 const styles = {
   progressionBox: {
-    borderWidth: 2,
-    borderStyle: 'solid',
-    borderColor: color.lighter_gray,
     margin: '10px, 0px',
-    backgroundColor: color.lightest_gray,
     padding: '0px 10px 10px 10px'
   },
   description: {

--- a/apps/src/templates/progress/ProgressPill.jsx
+++ b/apps/src/templates/progress/ProgressPill.jsx
@@ -94,7 +94,7 @@ class ProgressPill extends React.Component {
 
     let style = {
       ...styles.levelPill,
-      ...(url && hoverStyle),
+      ...((url || onClick) && hoverStyle),
       ...(!multiLevelStep &&
         levelProgressStyle(levels[0].status, levels[0].kind, false))
     };


### PR DESCRIPTION
- Link to level opens in new tab ([jira](https://codedotorg.atlassian.net/browse/PLAT-920))
- Remove border and background from progression ([jira](https://codedotorg.atlassian.net/browse/PLAT-893))
- Single level progressions have the orange background on hover ([part of jira task](https://codedotorg.atlassian.net/browse/PLAT-918))

![Screen Shot 2021-03-30 at 2 39 30 PM](https://user-images.githubusercontent.com/46464143/113060628-c2bfb480-9165-11eb-8a9b-6cfe141fc9cd.png)


## Links

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

<!--
- spec: []()
- jira ticket: []()
-->

## Testing story

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
