### PR TITLE
Show the display name of bubble choice levels

### DIFF
--- a/apps/src/templates/progress/ProgressBubble.jsx
+++ b/apps/src/templates/progress/ProgressBubble.jsx
@@ -152,8 +152,9 @@ class ProgressBubble extends React.Component {
 
     const number = level.levelNumber;
     const url = level.url;
-    const levelName =
-      level.display_name || level.name || level.progressionDisplayName;
+    const levelName = this.props.smallBubble
+      ? level.display_name || level.name
+      : level.name || level.progressionDisplayName;
     const levelIcon = getIconForLevel(level);
 
     const disabled = this.props.disabled || levelIcon === 'lock';

--- a/apps/src/templates/progress/ProgressBubble.jsx
+++ b/apps/src/templates/progress/ProgressBubble.jsx
@@ -152,7 +152,8 @@ class ProgressBubble extends React.Component {
 
     const number = level.levelNumber;
     const url = level.url;
-    const levelName = level.name || level.progressionDisplayName;
+    const levelName =
+      level.display_name || level.name || level.progressionDisplayName;
     const levelIcon = getIconForLevel(level);
 
     const disabled = this.props.disabled || levelIcon === 'lock';


### PR DESCRIPTION
It used to show the name that we use as an identifier. This change makes the progress bubble show the display name instead.


https://user-images.githubusercontent.com/46464143/113068022-4e3f4280-9172-11eb-8cb7-b8c3975871d3.mov



## Links

<!--
  Links to relevant external resources; ie, specification documents, Jira tickets, related PRs, Honeybadger errors, etc.
-->

<!--
- spec: []()
- jira ticket: []()
-->

## Testing story

<!--
  Does your change include appropriate tests?
  If so, please describe how the tests included in this PR are sufficient.
  If not, please explain why this change does not need to be tested.
-->

<!-- Other aspects to consider. Delete any sections that are not relevant to your change. -->

## Deployment strategy

## Follow-up work

<!--
  List (ideally with Jira links) any clean-up or technical debt that will be addressed in future work.
-->

## Privacy

<!--
  1.	Does this change involve the collection, use, or sharing of new Personal Data?
  2.	Does this change involve a new or changed use or sharing of existing Personal Data?
-->

## Security

<!-- Link to Jira task(s) where sensitive security issues are discussed privately. -->

## Caching

## PR Checklist:

<!--
  The final step! Before you create your PR, double-check that everything is in order.
  Change [ ] to [X] during creation to check boxes.
-->

- [ ] Tests provide adequate coverage
- [ ] Privacy and Security impacts have been assessed
- [ ] Code is well-commented
- [ ] New features are translatable or updates will not break translations
- [ ] Relevant documentation has been added or updated
- [ ] User impact is well-understood and desirable
- [ ] Pull Request is labeled appropriately
- [ ] Follow-up work items (including potential tech debt) are tracked and linked
