### PR TITLE
fix contained levels data loss bug

### DIFF
--- a/apps/src/containedLevels.js
+++ b/apps/src/containedLevels.js
@@ -60,7 +60,15 @@ export function postContainedLevelAttempt({
   attempts,
   onAttempt
 }) {
-  if (!hasContainedLevels || attempts !== 1) {
+  const isTeacher = getStore().getState().currentUser?.userType === 'teacher';
+  const isViewingStudent = !!new URLSearchParams(window.location.search).get(
+    'user_id'
+  );
+  if (
+    !hasContainedLevels ||
+    attempts !== 1 ||
+    (isTeacher && isViewingStudent)
+  ) {
     return;
   }
 


### PR DESCRIPTION
this addresses an urgent livesite issue causing data loss. the issue is that if a teacher presses `run` while viewing a student's work on a contained (predict) level, the student's answer gets stored into the teacher's progress. this is resolved by checking if we're a teacher viewing a student before posting a milestone for that level type.